### PR TITLE
Fix compilation errors in icn-types crate

### DIFF
--- a/crates/icn-types/Cargo.toml
+++ b/crates/icn-types/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.9"
 chrono = "0.4"
 tokio = { version = "1", features = ["full"] }

--- a/crates/icn-types/src/lib.rs
+++ b/crates/icn-types/src/lib.rs
@@ -2,6 +2,7 @@ use std::time::SystemTime;
 use sha2::{Sha256, Digest};
 use serde::{Serialize, Deserialize};
 use chrono::{DateTime, Utc};
+use serde_derive::{Serialize, Deserialize};
 
 /// Represents a block in the blockchain
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Enable the `derive` feature for the `serde` crate and import the `serde_derive` crate.

* Modify `crates/icn-types/Cargo.toml` to enable the `derive` feature for the `serde` crate.
* Import the `serde_derive` crate in `crates/icn-types/src/lib.rs` to bring the `Serialize` and `Deserialize` derive macros into scope.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/InterCooperative-Network/ICN/pull/23?shareId=8a086c9b-a381-4c64-8f60-1de445f388d5).