### PR TITLE
Fix syntax error in icn-p2p crate

### DIFF
--- a/crates/icn-p2p/src/lib.rs
+++ b/crates/icn-p2p/src/lib.rs
@@ -2,4 +2,5 @@ pub mod websocket;
 pub mod protocol;
 pub mod networking;
 
-use icn-types::Transaction;
+use icn_types::Transaction;
+


### PR DESCRIPTION
Fix the syntax error in `crates/icn-p2p/src/lib.rs`.

* Correct the `use` statement from `use icn-types::Transaction;` to `use icn_types::Transaction;` to resolve the compilation error.
* Add a blank line after the corrected `use` statement for better readability.

