### PR TITLE
Move federation logic to a separate crate

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "backend"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+tokio = { version = "1.30", features = ["full"] }
+warp = "0.3"
+serde = { version = "1.0", features = ["derive"] }
+sqlx = { version = "0.7", features = ["postgres", "runtime-tokio"] }
+icn-federation = { path = "../crates/icn-federation" }

--- a/backend/src/api/federation.rs
+++ b/backend/src/api/federation.rs
@@ -2,7 +2,7 @@ use warp::Filter;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use crate::services::federation_service::{FederationService, FederationOperation};
+use icn_federation::{FederationService, FederationOperation};
 
 #[derive(Debug, Deserialize, Serialize)]
 struct InitiateFederationRequest {


### PR DESCRIPTION
Move federation logic to a separate crate.

* **backend/src/api/federation.rs**
  - Replace the import of `FederationService` and `FederationOperation` from `crate::services::federation_service` with `icn_federation`.
* **backend/Cargo.toml**
  - Add a new `Cargo.toml` file for the backend crate with necessary dependencies, including `icn-federation`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/InterCooperative-Network/ICN/pull/84?shareId=0cf39d4c-efe6-40ae-9d36-0f3711548f64).