### PR TITLE
Add in-memory caching for reputation queries

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -92,11 +92,13 @@ async fn main() -> Result<(), AppError> {
     let runtime_manager = RuntimeManager::new();
     let telemetry_manager = TelemetryManager::new(PrometheusMetrics, Logger, TracingSystem);
     let identity_manager = IdentityManager::new();
+    let reputation_cache = ReputationCache::new(config.reputation_cache_max_size);
     let reputation_manager = ReputationManager::new(
         config.governance_decay_rate,
         config.resource_sharing_decay_rate,
         config.technical_contributions_decay_rate,
         config.decay_exemptions.clone(),
+        reputation_cache,
     );
 
     let notification_manager = NotificationManager::new(config.notification_email.clone(), config.notification_sms.clone());

--- a/backend/src/reputation.rs
+++ b/backend/src/reputation.rs
@@ -1,13 +1,54 @@
-pub struct ReputationManager;
+use dashmap::DashMap;
+
+pub struct ReputationCache {
+    cache: DashMap<String, i32>,
+    max_size: usize,
+}
+
+impl ReputationCache {
+    fn new(max_size: usize) -> Self {
+        Self {
+            cache: DashMap::new(),
+            max_size,
+        }
+    }
+
+    fn get(&self, did: &str) -> Option<i32> {
+        self.cache.get(did).map(|v| *v)
+    }
+
+    fn set(&self, did: &str, score: i32) {
+        if self.cache.len() >= self.max_size {
+            // Implement a simple eviction policy (e.g., remove a random entry)
+            if let Some(key) = self.cache.iter().next().map(|entry| entry.key().clone()) {
+                self.cache.remove(&key);
+            }
+        }
+        self.cache.insert(did.to_string(), score);
+    }
+}
+
+pub struct ReputationManager {
+    cache: ReputationCache,
+}
 
 impl ReputationManager {
-    pub fn new() -> Self {
-        ReputationManager
+    pub fn new(max_cache_size: usize) -> Self {
+        ReputationManager {
+            cache: ReputationCache::new(max_cache_size),
+        }
     }
 
     pub async fn get_reputation(&self, did: &str, category: &str) -> Result<i64, String> {
+        if let Some(score) = self.cache.get(did) {
+            return Ok(score as i64);
+        }
+
         // Logic to retrieve reputation for a given DID and category
-        Ok(100) // Placeholder value
+        let score = 100; // Placeholder value
+
+        self.cache.set(did, score);
+        Ok(score)
     }
 
     pub async fn is_eligible(&self, did: &str, min_reputation: i64, category: &str) -> Result<bool, String> {

--- a/backend/src/services/reputation_service.rs
+++ b/backend/src/services/reputation_service.rs
@@ -1,17 +1,54 @@
 use crate::database::db::Database;
 use crate::models::Reputation;
 use std::sync::Arc;
+use dashmap::DashMap;
+
+pub struct ReputationCache {
+    cache: DashMap<String, i32>,
+    max_size: usize,
+}
+
+impl ReputationCache {
+    fn new(max_size: usize) -> Self {
+        Self {
+            cache: DashMap::new(),
+            max_size,
+        }
+    }
+
+    fn get(&self, did: &str) -> Option<i32> {
+        self.cache.get(did).map(|v| *v)
+    }
+
+    fn set(&self, did: &str, score: i32) {
+        if self.cache.len() >= self.max_size {
+            // Implement a simple eviction policy (e.g., remove a random entry)
+            if let Some(key) = self.cache.iter().next().map(|entry| entry.key().clone()) {
+                self.cache.remove(&key);
+            }
+        }
+        self.cache.insert(did.to_string(), score);
+    }
+}
 
 pub struct ReputationService {
     db: Arc<Database>,
+    cache: ReputationCache,
 }
 
 impl ReputationService {
-    pub fn new(db: Arc<Database>) -> Self {
-        Self { db }
+    pub fn new(db: Arc<Database>, max_cache_size: usize) -> Self {
+        Self {
+            db,
+            cache: ReputationCache::new(max_cache_size),
+        }
     }
 
     pub async fn get_reputation(&self, did: &str, category: &str) -> Result<i64, sqlx::Error> {
+        if let Some(score) = self.cache.get(did) {
+            return Ok(score as i64);
+        }
+
         let reputation = sqlx::query_as!(
             Reputation,
             r#"
@@ -23,6 +60,7 @@ impl ReputationService {
         .fetch_one(&*self.db.pool)
         .await?;
 
+        self.cache.set(did, reputation.score as i32);
         Ok(reputation.score)
     }
 
@@ -39,6 +77,24 @@ impl ReputationService {
         )
         .execute(&*self.db.pool)
         .await?;
+
+        // Update the cache after adjusting the reputation
+        if let Some(mut score) = self.cache.get(did) {
+            score += adjustment as i32;
+            self.cache.set(did, score);
+        } else {
+            let reputation = sqlx::query_as!(
+                Reputation,
+                r#"
+                SELECT score FROM reputations WHERE did = $1 AND category = $2
+                "#,
+                did,
+                category
+            )
+            .fetch_one(&*self.db.pool)
+            .await?;
+            self.cache.set(did, reputation.score as i32);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Add in-memory caching for reputation queries using DashMap.

* **backend/src/reputation.rs**
  - Import `DashMap` from the `dashmap` crate.
  - Add `ReputationCache` struct with `DashMap` field and methods `new`, `get`, and `set`.
  - Integrate `ReputationCache` into `ReputationManager`.
  - Modify `get_reputation` to use the cache before querying the database.

* **backend/src/services/reputation_service.rs**
  - Import `DashMap` from the `dashmap` crate.
  - Add `ReputationCache` struct with `DashMap` field and methods `new`, `get`, and `set`.
  - Integrate `ReputationCache` into `ReputationService`.
  - Modify `get_reputation` to use the cache before querying the database.
  - Update the cache after adjusting the reputation.

* **backend/src/main.rs**
  - Initialize a `ReputationCache` instance.
  - Pass the `ReputationCache` instance to `ReputationManager`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/InterCooperative-Network/ICN/pull/86?shareId=8dc09854-b7e5-42d8-83fc-e345dba2e006).