### PR TITLE
fix(web): Fix pilot-ui Jest tests

### DIFF
--- a/web/pilot-ui/package.json
+++ b/web/pilot-ui/package.json
@@ -34,7 +34,7 @@
       "app.js",
       "!tests/**"
     ],
-    "coverageThresholds": {
+    "coverageThreshold": {
       "global": {
         "branches": 70,
         "functions": 70,

--- a/web/pilot-ui/tests/setup.js
+++ b/web/pilot-ui/tests/setup.js
@@ -3,7 +3,7 @@
  * Configures global test environment and utilities
  */
 
-import '@testing-library/jest-dom';
+require('@testing-library/jest-dom');
 
 // Mock localStorage
 const localStorageMock = {

--- a/web/pilot-ui/tests/utils.test.js
+++ b/web/pilot-ui/tests/utils.test.js
@@ -40,14 +40,16 @@ describe('Utility Functions', () => {
     };
 
     test('should format Unix timestamp to date string', () => {
-      const timestamp = 1704067200; // Jan 1, 2024
+      const timestamp = 1704067200; // Jan 1, 2024 UTC
       const result = formatDate(timestamp);
-      expect(result).toMatch(/1\/1\/2024|2024-01-01/); // Different locales
+      // Allow for timezone differences - could be Dec 31 or Jan 1 depending on local TZ
+      expect(result).toMatch(/12\/31\/2023|1\/1\/2024|2023-12-31|2024-01-01/);
     });
 
     test('should handle zero timestamp', () => {
       const result = formatDate(0);
-      expect(result).toMatch(/1\/1\/1970|1970-01-01/);
+      // Allow for timezone differences
+      expect(result).toMatch(/12\/31\/1969|1\/1\/1970|1969-12-31|1970-01-01/);
     });
   });
 
@@ -59,7 +61,8 @@ describe('Utility Functions', () => {
     test('should format Unix timestamp to datetime string', () => {
       const timestamp = 1704067200;
       const result = formatDateTime(timestamp);
-      expect(result).toContain('2024');
+      // Allow for timezone differences - could be Dec 31, 2023 or Jan 1, 2024
+      expect(result).toMatch(/2023|2024/);
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix `coverageThresholds` typo to `coverageThreshold` in package.json (Jest warning)
- Convert ES module `import` to CommonJS `require` in setup.js (Jest compatibility)
- Make date format tests timezone-agnostic to handle different CI environments

## Changes
The pilot-ui tests were failing due to:
1. Jest configuration typo causing a warning
2. ES module syntax not supported in Jest's CommonJS mode
3. Date format tests assuming UTC but running in local timezone

## Test plan
- [x] All 32 pilot-ui unit tests now pass locally
- [x] Tests are timezone-agnostic (work in any timezone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)