### PR TITLE
docs: Update ROADMAP test count to 929+

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,14 +7,14 @@
 
 ---
 
-**Status**: **PILOT-READY** ✅ - Phase 18 Complete (Pre-Pilot Hardening), Phase 17 ✅ (Storage Replication), Phase 16 ✅ (Scheduler Evolution), Phase 15 ✅ (Compute), Phase 14 ✅ (Gateway), **Federation Layer ✅**, Phases 11-12 ✅, Tracks B1-B3 ✅, Pilot Tooling ✅ - All 800+ Tests Passing
+**Status**: **PILOT-READY** ✅ - Phase 18 Complete (Pre-Pilot Hardening), Phase 17 ✅ (Storage Replication), Phase 16 ✅ (Scheduler Evolution), Phase 15 ✅ (Compute), Phase 14 ✅ (Gateway), **Federation Layer ✅**, Phases 11-12 ✅, Tracks B1-B3 ✅, Pilot Tooling ✅ - All 929+ Tests Passing
 **Next**: Track C1 Pilot Community Selection → Track C2 Pilot MVP → 3-month Pilot Deployment
 
 ## Executive Summary
 
 **Substrate Status**: **PILOT-READY** ✅ - All critical infrastructure complete (Phases 1-18).
 
-**Completed Infrastructure** (800+ tests passing):
+**Completed Infrastructure** (929+ tests passing):
 - Three-layer security (transport/message/application encryption)
 - Multi-device identity with key rotation
 - Economic safety rails (dynamic credit limits, disputes, quotas)
@@ -1824,7 +1824,7 @@ These features are **NOT on the roadmap** until pilot communities demonstrate ne
 - **Network partition healing with conflict resolution** (Phase 18)
 - **Storage quotas with priority-based eviction** (Phase 18)
 
-**All tests passing** ✅ (760+ tests across all crates)
+**All tests passing** ✅ (929+ tests across all crates)
 
 ### What We've Completed (Pre-Pilot Critical) ✅
 


### PR DESCRIPTION
## Summary
Fix inconsistency between README (929+ tests) and ROADMAP (800+ tests) as noted by Copilot in PR #14.

## Changes
- Update test count from 800+ to 929+ in three locations in ROADMAP.md
- Current test count verified by running `cargo test --workspace` (929 passed)

## Context
Copilot code review flagged this inconsistency during PR #14 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)