### PR TITLE
test(icn-time): Add comprehensive integration tests

### DIFF
--- a/icn/crates/icn-federation/tests/federation_integration.rs
+++ b/icn/crates/icn-federation/tests/federation_integration.rs
@@ -8,12 +8,12 @@
 //! 5. Federation gossip protocol
 
 use ed25519_dalek::SigningKey;
+use icn_federation::types::{CooperativeInfo, CurrencyInfo, Vouch};
 use icn_federation::{
     AttestationStore, BilateralClearingAgreement, ClearingManager, CooperativeRegistry,
     EvidenceSummary, FederatedDidResolver, FederatedTrustAttestation, FederationPolicy,
     SettlementInterval, TrustContext,
 };
-use icn_federation::types::{CooperativeInfo, CurrencyInfo, Vouch};
 use icn_identity::{Did, KeyPair};
 use icn_store::{SledStore, Store};
 use rand::rngs::OsRng;
@@ -119,19 +119,31 @@ fn test_find_coops_by_capability_and_currency() {
     let registry = CooperativeRegistry::new(store, own_info).unwrap();
 
     // Register coops with different capabilities
-    let compute_coop = create_coop_info("compute-coop", "Compute Cooperative", FederationPolicy::Open)
-        .with_capability("compute")
-        .with_capability("storage");
+    let compute_coop = create_coop_info(
+        "compute-coop",
+        "Compute Cooperative",
+        FederationPolicy::Open,
+    )
+    .with_capability("compute")
+    .with_capability("storage");
 
-    let clearing_coop = create_coop_info("clearing-coop", "Clearing Cooperative", FederationPolicy::Open)
-        .with_capability("clearing")
-        .with_currency(CurrencyInfo::new("hours", "Hours", 2));
+    let clearing_coop = create_coop_info(
+        "clearing-coop",
+        "Clearing Cooperative",
+        FederationPolicy::Open,
+    )
+    .with_capability("clearing")
+    .with_currency(CurrencyInfo::new("hours", "Hours", 2));
 
-    let full_coop = create_coop_info("full-coop", "Full Service Cooperative", FederationPolicy::Open)
-        .with_capability("compute")
-        .with_capability("clearing")
-        .with_currency(CurrencyInfo::new("hours", "Hours", 2))
-        .with_currency(CurrencyInfo::new("credits", "Credits", 2));
+    let full_coop = create_coop_info(
+        "full-coop",
+        "Full Service Cooperative",
+        FederationPolicy::Open,
+    )
+    .with_capability("compute")
+    .with_capability("clearing")
+    .with_currency(CurrencyInfo::new("hours", "Hours", 2))
+    .with_currency(CurrencyInfo::new("credits", "Credits", 2));
 
     registry.register(compute_coop).unwrap();
     registry.register(clearing_coop).unwrap();
@@ -194,9 +206,13 @@ fn test_attestation_signing_and_verification() {
         TrustContext::Economic,
         30 * 24 * 60 * 60, // 30 days expiry
     )
-    .with_evidence(EvidenceSummary::new("transactions", "Total successful transactions").with_count(150))
+    .with_evidence(
+        EvidenceSummary::new("transactions", "Total successful transactions").with_count(150),
+    )
     .with_evidence(EvidenceSummary::new("disputes", "Open disputes").with_count(0))
-    .with_evidence(EvidenceSummary::new("membership_days", "Days as active member").with_count(365));
+    .with_evidence(
+        EvidenceSummary::new("membership_days", "Days as active member").with_count(365),
+    );
 
     // Sign the attestation
     attestation.sign(&signing_key).unwrap();
@@ -235,7 +251,9 @@ fn test_attestation_store_operations() {
     attestation.sign(&signing_key).unwrap();
 
     // Store attestation
-    attestation_store.store_attestation(attestation.clone()).unwrap();
+    attestation_store
+        .store_attestation(attestation.clone())
+        .unwrap();
 
     // Retrieve by member
     let retrieved = attestation_store.get_attestations_for(&member_did).unwrap();
@@ -243,7 +261,9 @@ fn test_attestation_store_operations() {
     assert_eq!(retrieved[0].trust_score, 0.9);
 
     // Retrieve by source cooperative
-    let by_coop = attestation_store.get_attestations_from("food-coop").unwrap();
+    let by_coop = attestation_store
+        .get_attestations_from("food-coop")
+        .unwrap();
     assert_eq!(by_coop.len(), 1);
 
     // Store another attestation for same member from different coop
@@ -255,7 +275,9 @@ fn test_attestation_store_operations() {
         TrustContext::Economic,
         30 * 24 * 60 * 60,
     );
-    attestation2.sign(&SigningKey::generate(&mut OsRng)).unwrap();
+    attestation2
+        .sign(&SigningKey::generate(&mut OsRng))
+        .unwrap();
     attestation_store.store_attestation(attestation2).unwrap();
 
     // Member should now have 2 attestations
@@ -303,7 +325,7 @@ fn test_clearing_agreement_creation_and_rates() {
         coop_b_did.clone(),
     )
     .with_rate("hours", "credits", 10.0) // 1 hour = 10 credits
-    .with_rate("credits", "hours", 0.1)   // 10 credits = 1 hour
+    .with_rate("credits", "hours", 0.1) // 10 credits = 1 hour
     .with_interval(SettlementInterval::Weekly)
     .with_max_imbalance(5000);
 
@@ -361,7 +383,10 @@ fn test_clearing_manager_agreement_lifecycle() {
 fn test_settlement_interval_durations() {
     assert_eq!(SettlementInterval::Daily.seconds(), Some(24 * 60 * 60));
     assert_eq!(SettlementInterval::Weekly.seconds(), Some(7 * 24 * 60 * 60));
-    assert_eq!(SettlementInterval::Monthly.seconds(), Some(30 * 24 * 60 * 60));
+    assert_eq!(
+        SettlementInterval::Monthly.seconds(),
+        Some(30 * 24 * 60 * 60)
+    );
     assert_eq!(SettlementInterval::Manual.seconds(), None);
 }
 
@@ -374,8 +399,12 @@ async fn test_federated_did_resolution_workflow() {
     let registry = Arc::new(CooperativeRegistry::new(store, own_info).unwrap());
 
     // Register a partner cooperative with gateway
-    let partner = create_coop_info("partner-coop", "Partner Cooperative", FederationPolicy::Open)
-        .with_gateway("https://partner.example.com:8080".to_string());
+    let partner = create_coop_info(
+        "partner-coop",
+        "Partner Cooperative",
+        FederationPolicy::Open,
+    )
+    .with_gateway("https://partner.example.com:8080".to_string());
     registry.register(partner).unwrap();
 
     let mut resolver = FederatedDidResolver::new(registry);
@@ -397,13 +426,15 @@ async fn test_federated_did_resolution_workflow() {
 
     // Resolve partner coop's federated DID
     let partner_did = test_did();
-    let partner_federated = FederatedDidResolver::construct_federated_did(&partner_did, "partner-coop");
+    let partner_federated =
+        FederatedDidResolver::construct_federated_did(&partner_did, "partner-coop");
     let partner_result = resolver.resolve(&partner_federated).await.unwrap();
     assert_eq!(partner_result.coop_id, Some("partner-coop".to_string()));
     assert!(partner_result.resolved_via.is_some()); // Resolved via gateway
 
     // Unknown coop should fail
-    let unknown_federated = FederatedDidResolver::construct_federated_did(&test_did(), "unknown-coop");
+    let unknown_federated =
+        FederatedDidResolver::construct_federated_did(&test_did(), "unknown-coop");
     let unknown_result = resolver.resolve(&unknown_federated).await;
     assert!(unknown_result.is_err());
 }
@@ -466,7 +497,8 @@ async fn test_full_federation_onboarding_workflow() {
     // 1. Create federation anchor
     let anchor_store = create_test_store();
     let anchor_info = create_coop_info("anchor", "Anchor Coop", FederationPolicy::Open);
-    let anchor_registry = Arc::new(CooperativeRegistry::new(anchor_store.clone(), anchor_info).unwrap());
+    let anchor_registry =
+        Arc::new(CooperativeRegistry::new(anchor_store.clone(), anchor_info).unwrap());
 
     // 2. New coop applies to join
     let new_coop_did = test_did();
@@ -487,14 +519,18 @@ async fn test_full_federation_onboarding_workflow() {
         TrustContext::General,
         90 * 24 * 60 * 60, // 90 days
     )
-    .with_evidence(EvidenceSummary::new("verification", "Identity verified through documentation"));
+    .with_evidence(EvidenceSummary::new(
+        "verification",
+        "Identity verified through documentation",
+    ));
     attestation.sign(&anchor_key).unwrap();
 
     let attestation_store = AttestationStore::new(anchor_store.clone());
     attestation_store.store_attestation(attestation).unwrap();
 
     // 4. Setup clearing agreement
-    let clearing_manager = ClearingManager::new(anchor_store.clone(), "anchor".to_string()).unwrap();
+    let clearing_manager =
+        ClearingManager::new(anchor_store.clone(), "anchor".to_string()).unwrap();
     let agreement = BilateralClearingAgreement::new(
         "anchor-new-clearing".to_string(),
         "anchor".to_string(),
@@ -530,8 +566,10 @@ fn test_vouch_chain_federation() {
     // Scenario: Cooperative C joins via vouches from A and B (who are already federated)
 
     let store = create_test_store();
-    let own_info = create_coop_info("federation-hub", "Federation Hub",
-        FederationPolicy::Vouched { min_vouches: 2 }
+    let own_info = create_coop_info(
+        "federation-hub",
+        "Federation Hub",
+        FederationPolicy::Vouched { min_vouches: 2 },
     );
     let registry = CooperativeRegistry::new(store, own_info).unwrap();
 
@@ -653,7 +691,9 @@ fn test_attestation_removal() {
     assert_eq!(retrieved.len(), 1);
 
     // Remove attestation
-    attestation_store.remove_attestation(&member_did, "food-coop").unwrap();
+    attestation_store
+        .remove_attestation(&member_did, "food-coop")
+        .unwrap();
 
     // Verify it's gone
     let after_removal = attestation_store.get_attestations_for(&member_did).unwrap();
@@ -700,12 +740,18 @@ fn test_registry_update_last_seen() {
     let registry = CooperativeRegistry::new(store, own_info).unwrap();
 
     // Register a partner
-    let partner = create_coop_info("partner-coop", "Partner Cooperative", FederationPolicy::Open);
+    let partner = create_coop_info(
+        "partner-coop",
+        "Partner Cooperative",
+        FederationPolicy::Open,
+    );
     registry.register(partner).unwrap();
 
     // Update last_seen
     let new_timestamp = 9999999999u64;
-    registry.update_last_seen("partner-coop", new_timestamp).unwrap();
+    registry
+        .update_last_seen("partner-coop", new_timestamp)
+        .unwrap();
 
     // Verify update
     let retrieved = registry.get("partner-coop").unwrap().unwrap();
@@ -751,7 +797,9 @@ fn test_valid_attestations_filter() {
     assert_eq!(all.len(), 2);
 
     // Get valid attestations only - should be 1
-    let valid = attestation_store.get_valid_attestations_for(&member_did).unwrap();
+    let valid = attestation_store
+        .get_valid_attestations_for(&member_did)
+        .unwrap();
     assert_eq!(valid.len(), 1);
     assert_eq!(valid[0].source_coop_id, "food-coop");
 }

--- a/icn/crates/icn-time/tests/time_integration.rs
+++ b/icn/crates/icn-time/tests/time_integration.rs
@@ -1,0 +1,489 @@
+//! Time Sync Integration Tests
+//!
+//! Tests for the icn-time crate covering clock synchronization,
+//! timestamp validation, and freshness checking.
+
+use icn_time::{ClockSync, RoughTimeServer, TimeError, MAX_CLOCK_SKEW};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+/// Helper to get current unix timestamp in milliseconds
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+}
+
+// =============================================================================
+// ClockSync Lifecycle Tests
+// =============================================================================
+
+#[test]
+fn test_clock_sync_default_creation() {
+    let clock = ClockSync::new();
+
+    // Should start unsynchronized
+    assert!(clock.last_sync.is_none());
+    assert_eq!(clock.offset_millis, 0);
+    assert_eq!(clock.max_clock_skew, MAX_CLOCK_SKEW);
+}
+
+#[test]
+fn test_clock_sync_with_custom_servers() {
+    let servers = vec![
+        RoughTimeServer {
+            addr: "roughtime.cloudflare.com:2002".to_string(),
+            public_key: None,
+        },
+        RoughTimeServer {
+            addr: "roughtime.google.com:2002".to_string(),
+            public_key: None,
+        },
+    ];
+
+    let clock = ClockSync::with_servers(servers, Duration::from_secs(600));
+
+    assert!(clock.last_sync.is_none());
+    assert_eq!(clock.max_clock_skew, Duration::from_secs(600));
+}
+
+#[test]
+fn test_clock_sync_with_empty_servers() {
+    let servers: Vec<RoughTimeServer> = vec![];
+    let clock = ClockSync::with_servers(servers, MAX_CLOCK_SKEW);
+
+    assert!(clock.last_sync.is_none());
+}
+
+#[test]
+fn test_clock_sync_default_servers() {
+    let servers = ClockSync::default_servers();
+
+    // Should have at least 3 servers (MIN_SERVERS requirement)
+    assert!(servers.len() >= 3);
+
+    // Each server should have a valid address
+    for server in &servers {
+        assert!(!server.addr.is_empty());
+        assert!(server.addr.contains(':'));
+    }
+}
+
+// =============================================================================
+// RoughTimeServer Tests
+// =============================================================================
+
+#[test]
+fn test_rough_time_server_creation() {
+    let server = RoughTimeServer {
+        addr: "roughtime.example.com:2002".to_string(),
+        public_key: None,
+    };
+
+    assert_eq!(server.addr, "roughtime.example.com:2002");
+    assert!(server.public_key.is_none());
+}
+
+#[test]
+fn test_rough_time_server_with_public_key() {
+    let server = RoughTimeServer {
+        addr: "roughtime.example.com:2002".to_string(),
+        public_key: Some("abcdef123456".to_string()),
+    };
+
+    assert_eq!(server.addr, "roughtime.example.com:2002");
+    assert_eq!(server.public_key, Some("abcdef123456".to_string()));
+}
+
+#[test]
+fn test_rough_time_server_clone() {
+    let server = RoughTimeServer {
+        addr: "roughtime.example.com:2002".to_string(),
+        public_key: None,
+    };
+
+    let cloned = server.clone();
+    assert_eq!(cloned.addr, server.addr);
+}
+
+// =============================================================================
+// Timestamp Validation Tests (without sync)
+// =============================================================================
+
+#[test]
+fn test_validate_timestamp_not_synchronized() {
+    let clock = ClockSync::new();
+    let timestamp = now_millis();
+
+    let result = clock.validate_timestamp(timestamp);
+    assert!(result.is_err());
+
+    match result {
+        Err(TimeError::NotSynchronized) => {} // Expected
+        other => panic!("Expected NotSynchronized error, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_network_time_not_synchronized() {
+    let clock = ClockSync::new();
+
+    let result = clock.network_time();
+    assert!(result.is_err());
+
+    match result {
+        Err(TimeError::NotSynchronized) => {} // Expected
+        other => panic!("Expected NotSynchronized error, got {:?}", other),
+    }
+}
+
+// =============================================================================
+// Freshness Tests
+// =============================================================================
+
+#[test]
+fn test_is_fresh_not_synchronized() {
+    let clock = ClockSync::new();
+
+    // Not synchronized should not be fresh
+    assert!(!clock.is_fresh());
+}
+
+#[test]
+fn test_is_fresh_after_sync() {
+    let mut clock = ClockSync::new();
+
+    // Simulate sync
+    clock.last_sync = Some(Instant::now());
+
+    // Should be fresh immediately after sync
+    assert!(clock.is_fresh());
+}
+
+// =============================================================================
+// Manual Sync State Tests (simulating synchronized state)
+// =============================================================================
+
+#[test]
+fn test_manual_sync_state() {
+    let mut clock = ClockSync::new();
+
+    // Manually set sync state for testing
+    clock.offset_millis = 0;
+    clock.uncertainty = Duration::from_millis(100);
+    clock.last_sync = Some(Instant::now());
+
+    assert!(clock.last_sync.is_some());
+    assert_eq!(clock.offset_millis, 0);
+    assert_eq!(clock.uncertainty, Duration::from_millis(100));
+}
+
+#[test]
+fn test_validate_timestamp_within_skew() {
+    let mut clock = ClockSync::new();
+    clock.max_clock_skew = Duration::from_secs(300); // 5 minutes
+    clock.offset_millis = 0;
+    clock.uncertainty = Duration::from_millis(100);
+    clock.last_sync = Some(Instant::now());
+
+    let timestamp = now_millis();
+    let result = clock.validate_timestamp(timestamp);
+
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_validate_timestamp_too_old() {
+    let mut clock = ClockSync::new();
+    clock.max_clock_skew = Duration::from_secs(300); // 5 minutes
+    clock.offset_millis = 0;
+    clock.uncertainty = Duration::from_millis(100);
+    clock.last_sync = Some(Instant::now());
+
+    // Timestamp from 10 minutes ago (beyond 5 min skew)
+    let old_timestamp = now_millis() - 600_000;
+    let result = clock.validate_timestamp(old_timestamp);
+
+    assert!(result.is_err());
+    match result {
+        Err(TimeError::TimestampOutOfRange(..)) => {} // Expected
+        other => panic!("Expected TimestampOutOfRange error, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_validate_timestamp_in_future() {
+    let mut clock = ClockSync::new();
+    clock.max_clock_skew = Duration::from_secs(300); // 5 minutes
+    clock.offset_millis = 0;
+    clock.uncertainty = Duration::from_millis(100);
+    clock.last_sync = Some(Instant::now());
+
+    // Timestamp 10 minutes in the future (beyond 5 min skew)
+    let future_timestamp = now_millis() + 600_000;
+    let result = clock.validate_timestamp(future_timestamp);
+
+    assert!(result.is_err());
+    match result {
+        Err(TimeError::TimestampOutOfRange(..)) => {} // Expected
+        other => panic!("Expected TimestampOutOfRange error, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_validate_timestamp_at_skew_boundary() {
+    let mut clock = ClockSync::new();
+    clock.max_clock_skew = Duration::from_secs(300); // 5 minutes
+    clock.offset_millis = 0;
+    clock.uncertainty = Duration::from_millis(100);
+    clock.last_sync = Some(Instant::now());
+
+    // Timestamp exactly at the skew boundary (should be valid)
+    let boundary_timestamp = now_millis() - 299_000; // 4:59 ago
+    let result = clock.validate_timestamp(boundary_timestamp);
+
+    assert!(result.is_ok());
+}
+
+// =============================================================================
+// Network Time Tests
+// =============================================================================
+
+#[test]
+fn test_network_time_synchronized() {
+    let mut clock = ClockSync::new();
+    clock.offset_millis = 0;
+    clock.uncertainty = Duration::from_millis(100);
+    clock.last_sync = Some(Instant::now());
+
+    let result = clock.network_time();
+    assert!(result.is_ok());
+
+    let network_time = result.unwrap();
+    let local_time = now_millis();
+
+    // Should be close to current time (within a few milliseconds)
+    let diff = if network_time > local_time {
+        network_time - local_time
+    } else {
+        local_time - network_time
+    };
+    assert!(
+        diff < 1000,
+        "Network time should be within 1 second of local time"
+    );
+}
+
+#[test]
+fn test_network_time_with_positive_offset() {
+    let mut clock = ClockSync::new();
+    clock.offset_millis = 1000; // +1 second offset (local ahead)
+    clock.uncertainty = Duration::from_millis(100);
+    clock.last_sync = Some(Instant::now());
+
+    let result = clock.network_time();
+    assert!(result.is_ok());
+
+    let network_time = result.unwrap();
+    let local_time = now_millis();
+
+    // Network time should be behind local time by ~1 second
+    // network = local - offset = local - 1000
+    assert!(
+        local_time > network_time,
+        "With positive offset, network time should be behind local time"
+    );
+}
+
+#[test]
+fn test_network_time_with_negative_offset() {
+    let mut clock = ClockSync::new();
+    clock.offset_millis = -1000; // -1 second offset (local behind)
+    clock.uncertainty = Duration::from_millis(100);
+    clock.last_sync = Some(Instant::now());
+
+    let result = clock.network_time();
+    assert!(result.is_ok());
+
+    let network_time = result.unwrap();
+    let local_time = now_millis();
+
+    // Network time should be ahead of local time by ~1 second
+    // network = local - (-1000) = local + 1000
+    assert!(
+        network_time > local_time,
+        "With negative offset, network time should be ahead of local time"
+    );
+}
+
+// =============================================================================
+// Clock Offset and Uncertainty Tests
+// =============================================================================
+
+#[test]
+fn test_offset_positive_local_ahead() {
+    let mut clock = ClockSync::new();
+
+    // Positive offset means local clock is ahead
+    clock.offset_millis = 500;
+    clock.last_sync = Some(Instant::now());
+
+    // Verify the offset interpretation
+    // network_time = local_time - offset
+    let local_time = 10000i64;
+    let expected_network = local_time - clock.offset_millis;
+    assert_eq!(expected_network, 9500);
+}
+
+#[test]
+fn test_offset_negative_local_behind() {
+    let mut clock = ClockSync::new();
+
+    // Negative offset means local clock is behind
+    clock.offset_millis = -500;
+    clock.last_sync = Some(Instant::now());
+
+    // Verify the offset interpretation
+    // network_time = local_time - offset = local_time - (-500) = local_time + 500
+    let local_time = 10000i64;
+    let expected_network = local_time - clock.offset_millis;
+    assert_eq!(expected_network, 10500);
+}
+
+#[test]
+fn test_uncertainty_initialization() {
+    let clock = ClockSync::new();
+
+    // Initial uncertainty should be 10 seconds
+    assert_eq!(clock.uncertainty, Duration::from_secs(10));
+}
+
+// =============================================================================
+// Edge Cases
+// =============================================================================
+
+#[test]
+fn test_timestamp_zero() {
+    let mut clock = ClockSync::new();
+    clock.max_clock_skew = Duration::from_secs(300);
+    clock.offset_millis = 0;
+    clock.uncertainty = Duration::from_millis(100);
+    clock.last_sync = Some(Instant::now());
+
+    // Timestamp of 0 (Unix epoch) should be way too old
+    let result = clock.validate_timestamp(0);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_very_large_offset() {
+    let mut clock = ClockSync::new();
+    clock.offset_millis = i64::MAX / 2;
+    clock.last_sync = Some(Instant::now());
+
+    // Should handle large offsets without panic
+    let result = clock.network_time();
+    // May return 0 due to .max(0) protection
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_multiple_offset_updates() {
+    let mut clock = ClockSync::new();
+
+    // First sync
+    clock.offset_millis = 100;
+    clock.last_sync = Some(Instant::now());
+    assert_eq!(clock.offset_millis, 100);
+
+    // Second sync with different values
+    clock.offset_millis = 200;
+    clock.uncertainty = Duration::from_millis(30);
+    assert_eq!(clock.offset_millis, 200);
+    assert_eq!(clock.uncertainty, Duration::from_millis(30));
+}
+
+#[test]
+fn test_max_clock_skew_configuration() {
+    let servers = ClockSync::default_servers();
+
+    // Test with tight skew
+    let tight_clock = ClockSync::with_servers(servers.clone(), Duration::from_secs(60));
+    assert_eq!(tight_clock.max_clock_skew, Duration::from_secs(60));
+
+    // Test with loose skew
+    let loose_clock = ClockSync::with_servers(servers, Duration::from_secs(3600));
+    assert_eq!(loose_clock.max_clock_skew, Duration::from_secs(3600));
+}
+
+#[test]
+fn test_default_impl() {
+    // ClockSync implements Default via Default trait
+    let clock: ClockSync = Default::default();
+
+    assert!(clock.last_sync.is_none());
+    assert_eq!(clock.offset_millis, 0);
+    assert_eq!(clock.max_clock_skew, MAX_CLOCK_SKEW);
+}
+
+// =============================================================================
+// Async Sync Tests (marked as ignored - requires network)
+// =============================================================================
+
+#[tokio::test]
+#[ignore = "Requires network access to Rough Time servers"]
+async fn test_real_sync_with_servers() {
+    let mut clock = ClockSync::new();
+
+    let result = clock.sync().await;
+
+    // This may fail if servers are unreachable
+    if result.is_ok() {
+        assert!(clock.last_sync.is_some());
+        assert!(clock.is_fresh());
+        // Offset should be reasonable (within 1 hour = 3,600,000 ms)
+        assert!(clock.offset_millis.abs() < 3_600_000);
+    }
+}
+
+#[tokio::test]
+#[ignore = "Requires network access to Rough Time servers"]
+async fn test_real_sync_insufficient_servers() {
+    // Single unreachable server should fail
+    let servers = vec![RoughTimeServer {
+        addr: "invalid.server.example.com:2002".to_string(),
+        public_key: None,
+    }];
+    let mut clock = ClockSync::with_servers(servers, MAX_CLOCK_SKEW);
+
+    let result = clock.sync().await;
+
+    assert!(result.is_err());
+    assert!(clock.last_sync.is_none());
+}
+
+// =============================================================================
+// Error Type Tests
+// =============================================================================
+
+#[test]
+fn test_time_error_not_synchronized() {
+    let err = TimeError::NotSynchronized;
+    let msg = format!("{}", err);
+    assert!(msg.contains("not synchronized") || msg.contains("NotSynchronized"));
+}
+
+#[test]
+fn test_time_error_insufficient_responses() {
+    let err = TimeError::InsufficientResponses(2, 3);
+    let msg = format!("{}", err);
+    assert!(msg.contains("2") && msg.contains("3"));
+}
+
+#[test]
+fn test_time_error_timestamp_out_of_range() {
+    let err = TimeError::TimestampOutOfRange(500_000, 300_000);
+    let msg = format!("{}", err);
+    // Should contain the skew values
+    assert!(!msg.is_empty());
+}

--- a/icn/crates/icn-time/tests/time_integration.rs
+++ b/icn/crates/icn-time/tests/time_integration.rs
@@ -263,11 +263,7 @@ fn test_network_time_synchronized() {
     let local_time = now_millis();
 
     // Should be close to current time (within a few milliseconds)
-    let diff = if network_time > local_time {
-        network_time - local_time
-    } else {
-        local_time - network_time
-    };
+    let diff = network_time.abs_diff(local_time);
     assert!(
         diff < 1000,
         "Network time should be within 1 second of local time"


### PR DESCRIPTION
## Summary
- Add 32 comprehensive integration tests for the icn-time crate
- Tests cover ClockSync lifecycle, timestamp validation, network time calculation, and error handling
- 30 tests run locally, 2 network-dependent tests ignored

## Related Issues
Closes #33 (Gap #8: Time sync integration tests)

## Type of Change
- [x] Tests (adding or improving tests)

## Testing Checklist
- [x] Tests pass locally: `cargo test -p icn-time --test time_integration`
- [x] Clippy passes with no warnings
- [x] Code formatted with `cargo fmt`

## Test Coverage
| Category | Tests |
|----------|-------|
| ClockSync lifecycle | 4 |
| RoughTimeServer | 3 |
| Timestamp validation | 6 |
| Network time | 4 |
| Offset calculation | 3 |
| Freshness | 2 |
| Edge cases | 5 |
| Error types | 3 |
| Network (ignored) | 2 |
| **Total** | **32** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)