### PR TITLE
feat(compute): Add WasmRegistry for content-addressed WASM storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,5 +62,5 @@ sims/mutual-credit/results/
 sims/mutual-credit/*.csv
 sims/mutual-credit/*.png
 
-# Kubernetes deployment (not used in current testing setup)
-deploy/k8s/
+# Kubernetes deployment - now tracked in git
+# deploy/k8s/ is tracked, but secret.yaml is ignored via deploy/k8s/.gitignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ ICN (Intercooperative Network) is a substrate daemon for the cooperative interne
 
 ## Live Deployment (Faherty Homelab)
 
-**Status**: ICN daemon is running on a K3s cluster deployed 2025-12-03.
+**Status**: ICN daemon is running on a K3s cluster deployed 2025-12-03. Automated deployment system set up 2025-12-04.
 
 | Component | Details |
 |-----------|---------|
@@ -25,15 +25,40 @@ ICN (Intercooperative Network) is a substrate daemon for the cooperative interne
 | **Storage** | NFS from Atlas (10.8.10.25) via `atlas-nfs` StorageClass |
 | **Ports** | 7777/UDP (QUIC), 5601/TCP (RPC), 9100/TCP (Prometheus) |
 
+### Automated Deployment
+
+**New**: Full deployment automation is now available! Deploy from local machine to cluster with one command.
+
+```bash
+cd deploy/k8s
+make full-deploy-dev  # Build, sync, and deploy in one command
+```
+
+See [deploy/k8s/README.md](deploy/k8s/README.md) for complete deployment documentation.
+
+**Deployment System Features**:
+- ✅ Version-controlled Kubernetes manifests
+- ✅ Automated Docker image building
+- ✅ Image sync to all cluster nodes
+- ✅ One-command deployment
+- ✅ Git hash tagging for tracking
+
 ### Quick Access Commands
 
 ```bash
+# Deploy new version (from local machine)
+cd /home/matt/projects/icn/deploy/k8s
+make full-deploy-dev
+
 # Check cluster and pod status
-ssh ubuntu@10.8.10.40 "sudo kubectl get nodes"
+make status
+# OR
 ssh ubuntu@10.8.10.40 "sudo kubectl -n icn get pods"
 
 # View ICN daemon logs
-ssh ubuntu@10.8.10.40 "sudo kubectl -n icn logs -l app=icn"
+make logs
+# OR
+ssh ubuntu@10.8.10.40 "sudo kubectl -n icn logs -f deployment/icn-daemon"
 
 # Show identity
 ssh ubuntu@10.8.10.40 "sudo kubectl -n icn exec deploy/icn-daemon -- /usr/local/bin/icnctl id show"
@@ -58,6 +83,8 @@ ssh ubuntu@10.8.10.40 "kubectl -n icn port-forward svc/icn 9100:9100 &" && curl 
 
 ### Deployment History
 
+**Initial Deployment (2025-12-03)**: Manual deployment to K3s cluster.
+
 The K3s deployment required fixes for several issues discovered during initial bringup:
 1. **GLIBC compatibility** - Required Ubuntu 24.04 base image (not Debian)
 2. **STUN port conflict** - Disabled STUN to avoid binding same port as QUIC
@@ -66,6 +93,17 @@ The K3s deployment required fixes for several issues discovered during initial b
 5. **Health probe** - Changed to use port 9100 (metrics port)
 
 The governance topic fix has been merged upstream (commit `01009e5`).
+
+**Automated Deployment System (2025-12-04)**: Complete deployment automation added.
+
+Created full deployment pipeline with version-controlled manifests and one-command deployment:
+- Kubernetes manifests in `deploy/k8s/` (namespace, configmap, deployment, services, PVC, monitoring)
+- Build scripts with `.dockerignore` optimization (374GB → 15.79KB build context)
+- Image sync automation to all cluster nodes
+- Makefile for easy deployment commands
+- Comprehensive documentation (README, DEPLOYMENT_GUIDE, QUICKSTART, WORKFLOW)
+
+See [deploy/k8s/README.md](deploy/k8s/README.md) for details.
 
 ### Monitoring Stack (deployed 2025-12-04)
 

--- a/deploy/Dockerfile.icnd
+++ b/deploy/Dockerfile.icnd
@@ -3,7 +3,7 @@
 # Build from project root:
 #   docker build -f deploy/Dockerfile.icnd -t icn/icnd .
 
-FROM rust:1.75-slim as builder
+FROM rust:1.88-slim as builder
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \

--- a/deploy/k8s/.gitignore
+++ b/deploy/k8s/.gitignore
@@ -1,0 +1,8 @@
+# Secrets - NEVER commit these!
+secret.yaml
+
+# Temporary files
+*.tmp
+*.tar
+*.bak
+

--- a/deploy/k8s/DEPLOYMENT_GUIDE.md
+++ b/deploy/k8s/DEPLOYMENT_GUIDE.md
@@ -1,0 +1,489 @@
+# ICN K3s Deployment Guide
+
+Complete guide for deploying ICN to your K3s cluster on Hyperion.
+
+## Overview
+
+This deployment setup provides a complete solution for syncing ICN development with your K3s cluster. It includes:
+
+- ✅ **Kubernetes Manifests** - All resources version controlled
+- ✅ **Build Scripts** - Automated Docker image building
+- ✅ **Image Sync** - Automated image distribution to all K3s nodes
+- ✅ **Deployment Scripts** - One-command deployment
+- ✅ **Makefile** - Convenient shortcuts for common tasks
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Development Machine (WSL/Ubuntu)                            │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │  ICN Source Code (/home/matt/projects/icn)          │   │
+│  │  ↓                                                    │   │
+│  │  Docker Build (build-image.sh)                       │   │
+│  │  ↓                                                    │   │
+│  │  Image: icn:latest                                   │   │
+│  └──────────────────────────────────────────────────────┘   │
+└────────────────────┬────────────────────────────────────────┘
+                     │ SSH + SCP
+                     ↓
+┌─────────────────────────────────────────────────────────────┐
+│ K3s Cluster on Hyperion                                      │
+│                                                               │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐      │
+│  │ k3s-control  │  │ k3s-worker-1 │  │ k3s-worker-2 │      │
+│  │ 10.8.10.40   │  │ 10.8.10.41   │  │ 10.8.10.42   │      │
+│  │              │  │              │  │              │      │
+│  │ containerd   │  │ containerd   │  │ containerd   │      │
+│  │  ↓           │  │  ↓           │  │  ↓           │      │
+│  │ icn:latest   │  │ icn:latest   │  │ icn:latest   │      │
+│  └──────┬───────┘  └──────────────┘  └──────────────┘      │
+│         │                                                    │
+│         ↓                                                    │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │  Kubernetes Resources (deploy/k8s/)                  │   │
+│  │  - Namespace: icn                                     │   │
+│  │  - Deployment: icn-daemon                             │   │
+│  │  - Services: ClusterIP + NodePort                     │   │
+│  │  - PVC: icn-data (10Gi on atlas-nfs)                 │   │
+│  │  - ConfigMap: icn-config                              │   │
+│  │  - Secret: icn-secrets                                │   │
+│  │  - ServiceMonitor: Prometheus metrics                 │   │
+│  └──────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Quick Start
+
+### Prerequisites
+
+1. **SSH Access**: Configured SSH key access to K3s nodes
+   ```bash
+   ssh ubuntu@10.8.10.40  # Should work without password
+   ```
+
+2. **Docker**: Installed on development machine
+   ```bash
+   docker --version
+   ```
+
+3. **Git**: Repository cloned
+   ```bash
+   cd /home/matt/projects/icn
+   ```
+
+### First-Time Setup
+
+1. **Create Secrets**
+   ```bash
+   cd deploy/k8s
+   cp secret.yaml.example secret.yaml
+   # Edit secret.yaml with your ICN passphrase
+   # DO NOT commit secret.yaml!
+   ```
+
+2. **Deploy Secrets**
+   ```bash
+   ssh ubuntu@10.8.10.40 "sudo kubectl apply -f -" < secret.yaml
+   ```
+
+3. **Full Deployment**
+   ```bash
+   cd deploy/k8s/scripts
+   ./full-deploy.sh
+   ```
+
+### Daily Development Workflow
+
+After making code changes:
+
+```bash
+cd /home/matt/projects/icn/deploy/k8s
+
+# Option 1: Using Makefile (recommended)
+make full-deploy-dev  # Uses git hash as tag
+
+# Option 2: Using scripts directly
+./scripts/full-deploy.sh $(git rev-parse --short HEAD)
+
+# Option 3: Step by step
+make build-dev        # Build with git hash
+make sync             # Sync to cluster
+make deploy           # Deploy manifests
+```
+
+## Deployment Methods
+
+### Method 1: Makefile (Recommended)
+
+The Makefile provides convenient shortcuts:
+
+```bash
+cd deploy/k8s
+
+# Full deployment with git hash
+make full-deploy-dev
+
+# Full deployment with custom tag
+make full-deploy IMAGE_TAG=v1.0.0
+
+# Individual steps
+make build            # Build Docker image
+make sync             # Sync to cluster
+make deploy           # Deploy to cluster
+
+# Management
+make status           # Check deployment status
+make logs             # Tail logs
+make logs-recent      # Recent logs
+make restart          # Restart deployment
+```
+
+### Method 2: Full Deploy Script
+
+Single command for everything:
+
+```bash
+cd deploy/k8s/scripts
+./full-deploy.sh [tag] [k3s-host]
+
+# Examples:
+./full-deploy.sh                                    # latest, default host
+./full-deploy.sh v1.0.0                            # custom tag
+./full-deploy.sh $(git rev-parse --short HEAD)     # git hash
+./full-deploy.sh latest ubuntu@10.8.10.40          # custom host
+```
+
+### Method 3: Step-by-Step
+
+For more control:
+
+```bash
+cd deploy/k8s/scripts
+
+# 1. Build image
+./build-image.sh v1.0.0
+
+# 2. Sync to cluster
+./sync-image.sh v1.0.0
+
+# 3. Deploy manifests
+./deploy.sh ubuntu@10.8.10.40 v1.0.0
+```
+
+### Method 4: Manual kubectl
+
+For maximum control:
+
+```bash
+cd deploy/k8s
+
+# Apply all manifests
+kubectl apply -k .                    # Using kustomize
+# OR
+kubectl apply -f namespace.yaml
+kubectl apply -f configmap.yaml
+kubectl apply -f pvc.yaml
+kubectl apply -f deployment.yaml
+kubectl apply -f services.yaml
+kubectl apply -f monitoring/servicemonitor.yaml
+
+# Update image
+kubectl set image deployment/icn-daemon -n icn icnd=icn:v1.0.0
+```
+
+## Image Tagging Strategy
+
+Recommended tagging approach:
+
+```bash
+# Development builds
+./build-image.sh dev-$(date +%s)              # Timestamp
+./build-image.sh $(git rev-parse --short HEAD) # Git hash
+./build-image.sh dev-$(whoami)-$(date +%Y%m%d) # Dev name + date
+
+# Release builds
+./build-image.sh v1.0.0                       # Semantic version
+./build-image.sh v1.0.0-rc1                  # Release candidate
+```
+
+## Configuration
+
+### Updating ICN Configuration
+
+1. Edit `configmap.yaml`:
+   ```yaml
+   data:
+     icn.toml: |
+       # Your config changes here
+   ```
+
+2. Apply changes:
+   ```bash
+   kubectl apply -f configmap.yaml
+   kubectl rollout restart deployment/icn-daemon -n icn
+   ```
+
+### Updating Secrets
+
+Secrets are managed separately (not in git):
+
+```bash
+# Edit secret.yaml (local file, not committed)
+vim secret.yaml
+
+# Apply
+kubectl apply -f secret.yaml
+
+# Restart to pick up new secrets
+kubectl rollout restart deployment/icn-daemon -n icn
+```
+
+### Resource Limits
+
+Edit `deployment.yaml` to adjust resources:
+
+```yaml
+resources:
+  requests:
+    cpu: 100m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 2Gi
+```
+
+### Storage
+
+Edit `pvc.yaml` to change storage:
+
+```yaml
+spec:
+  storageClassName: atlas-nfs
+  resources:
+    requests:
+      storage: 10Gi  # Change size here
+```
+
+**Note**: PVCs cannot be resized. To increase:
+1. Backup data
+2. Delete PVC
+3. Recreate with new size
+4. Restore data
+
+## Monitoring
+
+### View Metrics
+
+```bash
+# Port forward metrics endpoint
+ssh ubuntu@10.8.10.40 "sudo kubectl -n icn port-forward svc/icn 9100:9100"
+# Visit http://localhost:9100/metrics
+```
+
+### Access Grafana
+
+If Prometheus/Grafana is deployed:
+
+```bash
+# Port forward Grafana
+ssh ubuntu@10.8.10.40 "sudo kubectl -n monitoring port-forward svc/prometheus-grafana 3000:80"
+# Visit http://localhost:3000
+```
+
+### Check Pod Status
+
+```bash
+make status
+# OR
+ssh ubuntu@10.8.10.40 "sudo kubectl -n icn get pods,svc,pvc"
+```
+
+### View Logs
+
+```bash
+# Tail logs
+make logs
+
+# Recent logs
+make logs-recent
+
+# Specific pod
+ssh ubuntu@10.8.10.40 "sudo kubectl -n icn logs <pod-name>"
+```
+
+## Troubleshooting
+
+### Image Build Fails
+
+**Problem**: Docker build fails
+
+**Solutions**:
+1. Check Docker is running: `docker ps`
+2. Check build context: Ensure `icn/` directory has Cargo.toml
+3. Check Dockerfile path: Should be `deploy/Dockerfile.icnd`
+
+### Image Sync Fails
+
+**Problem**: Can't sync image to cluster
+
+**Solutions**:
+1. Check SSH access: `ssh ubuntu@10.8.10.40`
+2. Check disk space on nodes
+3. Try manual sync (see Manual Image Sync section)
+
+### Pod Won't Start
+
+**Problem**: Pod stays in CrashLoopBackOff or Pending
+
+**Solutions**:
+
+1. **Check pod status**:
+   ```bash
+   kubectl -n icn describe pod <pod-name>
+   ```
+
+2. **Check secrets exist**:
+   ```bash
+   kubectl -n icn get secrets
+   ```
+
+3. **Check PVC is bound**:
+   ```bash
+   kubectl -n icn get pvc
+   ```
+
+4. **Check image exists**:
+   ```bash
+   ssh ubuntu@10.8.10.40 "sudo crictl images | grep icn"
+   ```
+
+5. **Check logs**:
+   ```bash
+   kubectl -n icn logs <pod-name>
+   ```
+
+### Port Conflicts
+
+**Problem**: Service ports already in use
+
+**Solutions**:
+1. Check existing services: `kubectl -n icn get svc`
+2. Edit `services.yaml` to use different ports
+3. Reapply: `kubectl apply -f services.yaml`
+
+### Configuration Not Applied
+
+**Problem**: ConfigMap changes not taking effect
+
+**Solutions**:
+1. Verify ConfigMap applied: `kubectl -n icn get configmap icn-config -o yaml`
+2. Restart deployment: `kubectl rollout restart deployment/icn-daemon -n icn`
+3. Check pod is using new config: `kubectl -n icn exec <pod> -- cat /etc/icn/icn.toml`
+
+## Manual Image Sync
+
+If automated sync fails, manually sync to a single node:
+
+```bash
+# 1. Export image from Docker
+docker save icn:latest -o /tmp/icn.tar
+
+# 2. Copy to node
+scp /tmp/icn.tar ubuntu@10.8.10.40:/tmp/
+
+# 3. Import on node
+ssh ubuntu@10.8.10.40
+sudo ctr -n k8s.io images import /tmp/icn.tar
+# OR
+sudo ctr images import /tmp/icn.tar
+
+# 4. Cleanup
+rm /tmp/icn.tar
+ssh ubuntu@10.8.10.40 "rm /tmp/icn.tar"
+```
+
+## Local Registry (Optional)
+
+For faster deployments, set up a local registry:
+
+### Option 1: Docker Registry on K3s Node
+
+```bash
+# On k3s-control node
+docker run -d -p 5000:5000 --restart=always --name registry registry:2
+
+# Build and push
+docker build -f deploy/Dockerfile.icnd -t localhost:5000/icn:latest icn/
+docker push localhost:5000/icn:latest
+
+# Update deployment to use registry
+kubectl set image deployment/icn-daemon -n icn icnd=localhost:5000/icn:latest
+```
+
+### Option 2: Harbor Registry (Production)
+
+See [Harbor documentation](https://goharbor.io/docs/) for setup.
+
+## CI/CD Integration
+
+### GitHub Actions Example
+
+```yaml
+name: Deploy to K3s
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Build image
+        run: |
+          cd deploy/k8s/scripts
+          ./build-image.sh ${{ github.sha }}
+      
+      - name: Sync to cluster
+        run: |
+          cd deploy/k8s/scripts
+          ./sync-image.sh ${{ github.sha }} ${{ secrets.K3S_HOST }}
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      
+      - name: Deploy
+        run: |
+          cd deploy/k8s/scripts
+          ./deploy.sh ${{ secrets.K3S_HOST }} ${{ github.sha }}
+```
+
+## Best Practices
+
+1. **Always use version tags** - Never deploy untagged images
+2. **Test locally first** - Build and test before deploying
+3. **Use git hashes for dev** - Easy to track what's deployed
+4. **Backup before changes** - Especially for configuration changes
+5. **Monitor after deployment** - Watch logs and metrics
+6. **Keep secrets safe** - Never commit secret.yaml
+7. **Document changes** - Update configmap.yaml comments
+
+## Next Steps
+
+- [ ] Set up local container registry
+- [ ] Configure GitOps (Flux/ArgoCD)
+- [ ] Add automated backups
+- [ ] Set up CI/CD pipeline
+- [ ] Configure resource autoscaling
+- [ ] Add health check endpoints
+
+## Support
+
+For issues:
+1. Check logs: `make logs`
+2. Check status: `make status`
+3. Review this guide
+4. Check Kubernetes events: `kubectl -n icn get events`
+

--- a/deploy/k8s/DEPLOYMENT_STATUS.md
+++ b/deploy/k8s/DEPLOYMENT_STATUS.md
@@ -1,0 +1,178 @@
+# ICN K3s Deployment Status
+
+## Current Deployment
+
+**Last Deployed**: 2025-12-04 20:20 UTC  
+**Image Tag**: `2122145` (git commit hash)  
+**Cluster**: K3s on Hyperion (10.8.10.40)  
+**Namespace**: `icn`
+
+## Deployment Summary
+
+The ICN daemon is fully deployed and operational on the K3s cluster. Deployment is fully automated with version-controlled manifests and one-command deployment.
+
+### Architecture
+
+```
+Development Machine → Build Image → Sync to Cluster → Deploy to K3s
+```
+
+### Quick Deployment
+
+```bash
+cd deploy/k8s
+make full-deploy-dev
+```
+
+## Current Status
+
+| Component | Status | Details |
+|-----------|--------|---------|
+| Pod | ✅ Running | `icn-daemon-9b9b66445-btjtq` on k3s-control |
+| Image | ✅ Deployed | `icn:latest` (146MB, sha256:b5a101b56e522) |
+| Services | ✅ Active | ClusterIP (10.43.127.217) + NodePort (30777/30601) |
+| Storage | ✅ Bound | 10Gi PVC on atlas-nfs storage class |
+| ConfigMap | ✅ Applied | ICN configuration loaded |
+| Secrets | ✅ Configured | Passphrase from secret.yaml |
+| Monitoring | ✅ Active | ServiceMonitor + PrometheusRules |
+
+## Deployment Components
+
+### Kubernetes Resources
+
+- **Namespace**: `icn`
+- **Deployment**: `icn-daemon` (1 replica, Recreate strategy)
+- **Services**: 
+  - `icn` (ClusterIP): Internal cluster access
+  - `icn-nodeport` (NodePort): External access via ports 30777 (UDP) and 30601 (TCP)
+- **PVC**: `icn-data` (10Gi, ReadWriteOnce, atlas-nfs)
+- **ConfigMap**: `icn-config` (icn.toml configuration)
+- **Secrets**: `icn-secrets` (passphrase for keystore)
+
+### Ports
+
+| Port | Protocol | Purpose | Service Type |
+|------|----------|---------|--------------|
+| 7777 | UDP | QUIC/P2P | ClusterIP + NodePort (30777) |
+| 5601 | TCP | RPC/gRPC | ClusterIP + NodePort (30601) |
+| 9100 | TCP | Prometheus metrics | ClusterIP only |
+| 8080 | TCP | Health/Gateway API | ClusterIP only |
+
+### Resource Limits
+
+- **CPU**: 100m request, 1 core limit
+- **Memory**: 512Mi request, 2Gi limit
+- **Storage**: 10Gi persistent volume
+
+## Deployment History
+
+| Date | Image Tag | Status | Notes |
+|------|-----------|--------|-------|
+| 2025-12-04 | 2122145 | ✅ Success | Initial automated deployment setup |
+
+## Access Points
+
+### Metrics
+
+```bash
+# Port forward to access metrics
+ssh ubuntu@10.8.10.40 "sudo kubectl -n icn port-forward svc/icn 9100:9100"
+# Then visit: http://localhost:9100/metrics
+```
+
+### Logs
+
+```bash
+# Tail logs
+ssh ubuntu@10.8.10.40 "sudo kubectl -n icn logs -f deployment/icn-daemon"
+
+# Or use Makefile
+cd deploy/k8s
+make logs
+```
+
+### Status
+
+```bash
+# Check pod status
+ssh ubuntu@10.8.10.40 "sudo kubectl -n icn get pods -o wide"
+
+# Or use Makefile
+cd deploy/k8s
+make status
+```
+
+## Monitoring
+
+Prometheus is configured to scrape ICN metrics via ServiceMonitor:
+- **Job**: `icn-daemon`
+- **Namespace**: `icn`
+- **Endpoint**: `:9100/metrics`
+- **Interval**: 15s
+
+PrometheusRules include alerts for:
+- Byzantine node detection
+- Network health
+- Ledger consistency
+- Compute layer issues
+- System resources
+
+## Configuration
+
+ICN configuration is managed via ConfigMap (`icn-config`). Current settings:
+
+- **Network**: Listen on 0.0.0.0:7777, mDNS enabled
+- **Region**: faherty-homelab
+- **Cluster ID**: k3s-icn
+- **Role**: edge
+- **Rate Limiting**: Enabled with tiered limits
+- **Topology**: Configured neighbor limits and fanout
+
+To update configuration:
+1. Edit `deploy/k8s/configmap.yaml`
+2. Apply: `kubectl apply -f deploy/k8s/configmap.yaml`
+3. Restart: `kubectl rollout restart deployment/icn-daemon -n icn`
+
+## Secrets
+
+Secrets are stored in Kubernetes Secret (`icn-secrets`). 
+
+**⚠️ Important**: The secret file (`secret.yaml`) is NOT committed to git. It must be created from `secret.yaml.example` and managed separately.
+
+## Deployment Automation
+
+The deployment system provides:
+
+- **Build**: Automated Docker image building from source
+- **Sync**: Automatic image distribution to all cluster nodes
+- **Deploy**: One-command Kubernetes manifest application
+- **Versioning**: Git hash tagging for tracking deployments
+
+See [DEPLOYMENT_GUIDE.md](DEPLOYMENT_GUIDE.md) for complete documentation.
+
+## Known Issues
+
+1. **Worker Node Image Sync**: DNS resolution for worker nodes fails during sync (low impact - control node works)
+2. **First Build**: Initial build takes ~90 seconds (subsequent builds are cached)
+
+## Next Steps
+
+- [ ] Fix worker node image sync (DNS resolution)
+- [ ] Set up local container registry for faster sync
+- [ ] Configure automated backups of PVC data
+- [ ] Monitor resource usage and adjust limits
+- [ ] Set up CI/CD integration
+
+## Related Documentation
+
+- [README.md](README.md) - Complete deployment reference
+- [DEPLOYMENT_GUIDE.md](DEPLOYMENT_GUIDE.md) - Detailed deployment guide
+- [QUICKSTART.md](QUICKSTART.md) - Quick start guide
+- [WORKFLOW.md](WORKFLOW.md) - Development workflow
+
+---
+
+**Last Updated**: 2025-12-04  
+**Maintainer**: Infrastructure Team  
+**Status**: ✅ Operational
+

--- a/deploy/k8s/Makefile
+++ b/deploy/k8s/Makefile
@@ -1,0 +1,64 @@
+.PHONY: help build sync deploy full-deploy status logs clean
+
+# Configuration
+IMAGE_NAME ?= icn
+IMAGE_TAG ?= latest
+K3S_HOST ?= ubuntu@10.8.10.40
+NAMESPACE ?= icn
+
+help: ## Show this help message
+	@echo "ICN Kubernetes Deployment"
+	@echo ""
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-20s %s\n", $$1, $$2}'
+
+build: ## Build Docker image
+	@echo "Building ICN Docker image..."
+	./scripts/build-image.sh $(IMAGE_TAG)
+
+sync: ## Sync Docker image to K3s cluster
+	@echo "Syncing image to K3s cluster..."
+	./scripts/sync-image.sh $(IMAGE_TAG) $(K3S_HOST)
+
+deploy: ## Deploy ICN to K3s cluster
+	@echo "Deploying ICN to K3s cluster..."
+	./scripts/deploy.sh $(K3S_HOST) $(IMAGE_TAG)
+
+full-deploy: ## Full deployment pipeline: build, sync, and deploy
+	@echo "Running full deployment pipeline..."
+	./scripts/full-deploy.sh $(IMAGE_TAG) $(K3S_HOST)
+
+status: ## Check deployment status
+	@echo "Checking ICN deployment status..."
+	ssh $(K3S_HOST) "sudo kubectl -n $(NAMESPACE) get pods,svc,pvc"
+
+logs: ## Tail ICN daemon logs
+	ssh $(K3S_HOST) "sudo kubectl -n $(NAMESPACE) logs -f deployment/icn-daemon"
+
+logs-recent: ## Show recent ICN daemon logs
+	ssh $(K3S_HOST) "sudo kubectl -n $(NAMESPACE) logs --tail=100 deployment/icn-daemon"
+
+restart: ## Restart ICN deployment
+	ssh $(K3S_HOST) "sudo kubectl -n $(NAMESPACE) rollout restart deployment/icn-daemon"
+
+clean: ## Remove ICN deployment (keeps PVC)
+	@echo "Removing ICN deployment..."
+	ssh $(K3S_HOST) "sudo kubectl delete deployment,svc,configmap -n $(NAMESPACE) -l app=icn || true"
+
+clean-all: clean ## Remove ICN deployment and PVC (WARNING: deletes data)
+	@echo "WARNING: This will delete all ICN data!"
+	@read -p "Are you sure? [y/N] " -n 1 -r; \
+	echo; \
+	if [[ $$REPLY =~ ^[Yy]$$ ]]; then \
+		ssh $(K3S_HOST) "sudo kubectl delete namespace $(NAMESPACE) || true"; \
+	fi
+
+# Convenience targets with git hash
+build-dev: ## Build with git hash tag
+	$(MAKE) build IMAGE_TAG=$(shell git rev-parse --short HEAD)
+
+full-deploy-dev: ## Full deploy with git hash tag
+	$(MAKE) full-deploy IMAGE_TAG=$(shell git rev-parse --short HEAD)
+

--- a/deploy/k8s/QUICKSTART.md
+++ b/deploy/k8s/QUICKSTART.md
@@ -1,0 +1,111 @@
+# Quick Start - Deploy ICN to K3s
+
+Get ICN deployed on your K3s cluster in 5 minutes!
+
+## Prerequisites Check
+
+```bash
+# 1. SSH access to K3s cluster
+ssh ubuntu@10.8.10.40 "echo 'SSH works!'"
+
+# 2. Docker installed
+docker --version
+
+# 3. In ICN repo
+cd /home/matt/projects/icn
+```
+
+## First Time Setup (5 minutes)
+
+### 1. Create Secrets (2 min)
+
+```bash
+cd deploy/k8s
+
+# Copy example secret
+cp secret.yaml.example secret.yaml
+
+# Edit with your passphrase (use nano/vim)
+nano secret.yaml
+# Change CHANGE_ME to your actual ICN passphrase
+
+# Deploy secrets
+ssh ubuntu@10.8.10.40 "sudo kubectl apply -f -" < secret.yaml
+```
+
+### 2. Full Deployment (3 min)
+
+```bash
+cd deploy/k8s
+
+# One command does everything!
+make full-deploy-dev
+```
+
+This will:
+- Build Docker image from your source code
+- Sync image to all K3s nodes  
+- Deploy ICN to the cluster
+
+### 3. Verify Deployment
+
+```bash
+# Check status
+make status
+
+# Watch logs
+make logs
+```
+
+## Daily Development Workflow
+
+After making code changes:
+
+```bash
+cd /home/matt/projects/icn/deploy/k8s
+
+# Re-deploy with git hash tag
+make full-deploy-dev
+```
+
+That's it! Your changes are live.
+
+## Common Commands
+
+```bash
+cd deploy/k8s
+
+make status        # Check pod status
+make logs          # Tail logs
+make logs-recent   # Recent logs  
+make restart       # Restart deployment
+make help          # Show all commands
+```
+
+## Next Steps
+
+- Read [README.md](README.md) for detailed documentation
+- Read [DEPLOYMENT_GUIDE.md](DEPLOYMENT_GUIDE.md) for advanced usage
+- Check monitoring: `make status`
+
+## Troubleshooting
+
+**Pod won't start?**
+```bash
+make logs
+# Check for passphrase errors, missing secrets, etc.
+```
+
+**Image not found?**
+```bash
+# Re-sync image
+make sync
+```
+
+**Need to see more details?**
+```bash
+ssh ubuntu@10.8.10.40 "sudo kubectl -n icn describe pod <pod-name>"
+```
+
+For more help, see [DEPLOYMENT_GUIDE.md](DEPLOYMENT_GUIDE.md#troubleshooting).
+

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,304 @@
+# ICN Kubernetes Deployment
+
+This directory contains all Kubernetes manifests and deployment scripts for running ICN on a K3s cluster.
+
+## Quick Start
+
+### Prerequisites
+
+1. **Docker** installed on your development machine
+2. **SSH access** to K3s cluster control node (default: `ubuntu@10.8.10.40`)
+3. **Kubectl** access to the cluster (via SSH or local config)
+
+### Full Deployment (Recommended)
+
+Deploy everything with one command:
+
+```bash
+cd /home/matt/projects/icn/deploy/k8s/scripts
+./full-deploy.sh
+```
+
+This will:
+1. Build the Docker image from source
+2. Sync the image to all K3s nodes
+3. Apply Kubernetes manifests to deploy ICN
+
+### Step-by-Step Deployment
+
+#### 1. Build Docker Image
+
+```bash
+./scripts/build-image.sh [tag]
+```
+
+Examples:
+```bash
+./scripts/build-image.sh                           # Uses 'latest' tag
+./scripts/build-image.sh v1.0.0                    # Uses 'v1.0.0' tag
+./scripts/build-image.sh $(git rev-parse --short HEAD)  # Uses git hash
+```
+
+#### 2. Sync Image to K3s Cluster
+
+```bash
+./scripts/sync-image.sh [tag] [k3s-host]
+```
+
+This exports the Docker image and imports it to containerd on all K3s nodes.
+
+Examples:
+```bash
+./scripts/sync-image.sh                            # Sync 'latest' to default host
+./scripts/sync-image.sh v1.0.0                     # Sync 'v1.0.0'
+./scripts/sync-image.sh latest ubuntu@10.8.10.40   # Custom host
+```
+
+#### 3. Deploy to Cluster
+
+```bash
+./scripts/deploy.sh [k3s-host] [image-tag]
+```
+
+This applies all Kubernetes manifests.
+
+Examples:
+```bash
+./scripts/deploy.sh                                # Deploy to default host
+./scripts/deploy.sh ubuntu@10.8.10.40 v1.0.0       # Custom host and tag
+```
+
+### Manual Deployment
+
+If you prefer to use kubectl directly:
+
+```bash
+# Apply all manifests
+kubectl apply -k .                    # Using kustomize
+# OR
+kubectl apply -f namespace.yaml
+kubectl apply -f configmap.yaml
+kubectl apply -f pvc.yaml
+kubectl apply -f deployment.yaml
+kubectl apply -f services.yaml
+kubectl apply -f monitoring/servicemonitor.yaml
+```
+
+## Configuration
+
+### Secrets
+
+**IMPORTANT**: Secrets are not included in the repo. Create your own `secret.yaml`:
+
+```bash
+cp secret.yaml.example secret.yaml
+# Edit secret.yaml with your passphrase
+kubectl apply -f secret.yaml
+```
+
+The secret should contain:
+- `icn-secrets` with key `passphrase` for the ICN keystore passphrase
+
+### ConfigMap
+
+Edit `configmap.yaml` to customize ICN configuration:
+
+- Network settings (listen address, ports)
+- Rate limiting
+- Topology settings
+- Log levels
+
+After editing, apply with:
+```bash
+kubectl apply -f configmap.yaml
+kubectl rollout restart deployment/icn-daemon -n icn
+```
+
+### Image Tag Updates
+
+To update the image tag used by the deployment:
+
+```bash
+# Using kubectl
+kubectl set image deployment/icn-daemon -n icn icnd=icn:v1.0.0
+
+# Or edit deployment.yaml and reapply
+kubectl apply -f deployment.yaml
+```
+
+### Storage
+
+The deployment uses a PersistentVolumeClaim on the `atlas-nfs` storage class. 
+
+To change storage size or class, edit `pvc.yaml`:
+```yaml
+spec:
+  storageClassName: atlas-nfs
+  resources:
+    requests:
+      storage: 10Gi  # Change this
+```
+
+**Note**: Existing PVCs cannot be resized. You'll need to delete and recreate (data will be lost unless backed up).
+
+## Monitoring
+
+The deployment includes:
+- **ServiceMonitor** for Prometheus metrics scraping
+- **PrometheusRule** with ICN-specific alerts
+
+Metrics are exposed on port `9100` at `/metrics`.
+
+### View Metrics
+
+```bash
+# Port forward to access metrics locally
+kubectl -n icn port-forward svc/icn 9100:9100
+# Then visit http://localhost:9100/metrics
+```
+
+### Access Grafana
+
+If Prometheus/Grafana is deployed in the `monitoring` namespace:
+
+```bash
+kubectl -n monitoring port-forward svc/prometheus-grafana 3000:80
+# Then visit http://localhost:3000
+```
+
+## Troubleshooting
+
+### Check Pod Status
+
+```bash
+kubectl -n icn get pods
+kubectl -n icn describe pod <pod-name>
+```
+
+### View Logs
+
+```bash
+# Follow logs
+kubectl -n icn logs -f deployment/icn-daemon
+
+# View recent logs
+kubectl -n icn logs --tail=100 deployment/icn-daemon
+```
+
+### Check Events
+
+```bash
+kubectl -n icn get events --sort-by='.lastTimestamp'
+```
+
+### Common Issues
+
+**Pod won't start:**
+- Check if secrets are created: `kubectl -n icn get secrets`
+- Check PVC status: `kubectl -n icn get pvc`
+- Check image exists: `crictl images | grep icn`
+
+**Image pull errors:**
+- Verify image was synced: Run `sync-image.sh` again
+- Check image name matches deployment: `kubectl -n icn get deployment icn-daemon -o yaml | grep image`
+
+**Port conflicts:**
+- Check if ports are in use: `kubectl -n icn get svc`
+- Modify NodePort values in `services.yaml` if needed
+
+### Manual Image Sync
+
+If the sync script fails, manually sync to a single node:
+
+```bash
+# Export image
+docker save icn:latest -o /tmp/icn.tar
+
+# Copy to node
+scp /tmp/icn.tar ubuntu@10.8.10.40:/tmp/
+
+# Import on node
+ssh ubuntu@10.8.10.40
+sudo ctr -n k8s.io images import /tmp/icn.tar
+# OR
+sudo ctr images import /tmp/icn.tar
+```
+
+## Updating Deployment
+
+### Update ICN Version
+
+1. Build new image:
+   ```bash
+   ./scripts/build-image.sh v1.0.1
+   ```
+
+2. Sync to cluster:
+   ```bash
+   ./scripts/sync-image.sh v1.0.1
+   ```
+
+3. Update deployment:
+   ```bash
+   kubectl set image deployment/icn-daemon -n icn icnd=icn:v1.0.1
+   ```
+
+### Update Configuration
+
+1. Edit `configmap.yaml`
+2. Apply changes:
+   ```bash
+   kubectl apply -f configmap.yaml
+   kubectl rollout restart deployment/icn-daemon -n icn
+   ```
+
+## File Structure
+
+```
+deploy/k8s/
+├── README.md                    # This file
+├── kustomization.yaml          # Kustomize configuration
+├── namespace.yaml              # ICN namespace
+├── configmap.yaml              # ICN configuration
+├── secret.yaml.example         # Secret template (DO NOT commit secret.yaml!)
+├── pvc.yaml                    # Persistent volume claim
+├── deployment.yaml             # ICN daemon deployment
+├── services.yaml               # ClusterIP and NodePort services
+├── monitoring/
+│   └── servicemonitor.yaml    # Prometheus ServiceMonitor and alerts
+└── scripts/
+    ├── build-image.sh         # Build Docker image
+    ├── sync-image.sh          # Sync image to K3s nodes
+    ├── deploy.sh              # Apply Kubernetes manifests
+    └── full-deploy.sh         # Complete deployment pipeline
+```
+
+## Development Workflow
+
+1. **Make code changes** in the ICN repository
+2. **Build new image**: `./scripts/build-image.sh dev-$(date +%s)`
+3. **Sync to cluster**: `./scripts/sync-image.sh dev-$(date +%s)`
+4. **Update deployment**: `kubectl set image deployment/icn-daemon -n icn icnd=icn:dev-$(date +%s)`
+5. **Watch rollout**: `kubectl -n icn rollout status deployment/icn-daemon`
+6. **Check logs**: `kubectl -n icn logs -f deployment/icn-daemon`
+
+## CI/CD Integration
+
+For automated deployments, you can integrate these scripts into CI/CD:
+
+```bash
+# In your CI pipeline
+export IMAGE_TAG="$(git rev-parse --short HEAD)"
+./deploy/k8s/scripts/build-image.sh "$IMAGE_TAG"
+./deploy/k8s/scripts/sync-image.sh "$IMAGE_TAG"
+./deploy/k8s/scripts/deploy.sh "$K3S_HOST" "$IMAGE_TAG"
+```
+
+## Next Steps
+
+- [ ] Set up local container registry for faster image sync
+- [ ] Configure GitOps (Flux/ArgoCD) for automated deployments
+- [ ] Add health check endpoints
+- [ ] Set up automated backups of PVC data
+- [ ] Configure resource limits based on workload
+

--- a/deploy/k8s/WORKFLOW.md
+++ b/deploy/k8s/WORKFLOW.md
@@ -1,0 +1,199 @@
+# Deployment Workflow
+
+## Overview
+
+**Everything runs on your local machine (WSL/Ubuntu)** and automatically syncs/deploys to the K3s cluster on Hyperion.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Your Local Machine (WSL/Ubuntu)                            │
+│                                                              │
+│  1. You make code changes in /home/matt/projects/icn       │
+│                                                              │
+│  2. You run: make full-deploy-dev                          │
+│     ↓                                                        │
+│  3. Scripts build Docker image locally                      │
+│     ↓                                                        │
+│  4. Scripts sync image to cluster via SSH                   │
+│     ↓                                                        │
+│  5. Scripts apply Kubernetes manifests via SSH/kubectl      │
+│                                                              │
+└───────────────────────┬─────────────────────────────────────┘
+                        │
+                        │ SSH Connection
+                        ↓
+┌─────────────────────────────────────────────────────────────┐
+│  K3s Cluster on Hyperion (10.8.10.40)                       │
+│                                                              │
+│  • Image imported to containerd                              │
+│  • Kubernetes manifests applied                              │
+│  • ICN pod running with your changes                         │
+│                                                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Step-by-Step Flow
+
+### 1. **Local Development**
+You work on your local machine:
+```bash
+cd /home/matt/projects/icn
+# Edit code, make changes, etc.
+vim icn/src/...
+```
+
+### 2. **Build Locally**
+The build script runs **on your machine**:
+```bash
+cd deploy/k8s
+make build-dev
+
+# This runs: ./scripts/build-image.sh <git-hash>
+# Which executes: docker build ... (on your machine)
+# Result: Docker image "icn:latest" in your local Docker
+```
+
+### 3. **Sync to Cluster**
+The sync script **on your machine** exports the image and pushes it to the cluster:
+```bash
+make sync
+
+# This runs: ./scripts/sync-image.sh <tag>
+# Which:
+#   1. Exports image from your Docker: docker save icn:latest -o /tmp/icn.tar
+#   2. Copies to cluster via SSH: scp /tmp/icn.tar ubuntu@10.8.10.40:/tmp/
+#   3. Imports on cluster nodes via SSH: ssh ubuntu@10.8.10.40 "sudo ctr images import ..."
+```
+
+### 4. **Deploy to Cluster**
+The deploy script **on your machine** applies manifests to the cluster:
+```bash
+make deploy
+
+# This runs: ./scripts/deploy.sh
+# Which:
+#   - Applies manifests via SSH: ssh ubuntu@10.8.10.40 "sudo kubectl apply ..."
+#   - Updates deployment on the cluster
+```
+
+### 5. **Everything Happens Remotely**
+The cluster receives:
+- ✅ Docker image in containerd
+- ✅ Updated Kubernetes resources
+- ✅ Running pod with your new code
+
+## Example: Complete Deployment
+
+```bash
+# On your local machine
+cd /home/matt/projects/icn
+
+# Make some code changes
+vim icn/crates/icn-core/src/lib.rs
+git add .
+git commit -m "Fix bug in gossip protocol"
+
+# Deploy (all from your local machine!)
+cd deploy/k8s
+make full-deploy-dev
+
+# Output you'll see:
+# Building ICN Docker image...        ← Happens locally
+# Syncing image to K3s cluster...     ← Pushes to cluster via SSH
+# Deploying to K3s cluster...         ← Applies via SSH/kubectl
+# ✓ Deployment complete!
+```
+
+## What Runs Where?
+
+| Action | Where It Runs | How |
+|--------|---------------|-----|
+| Code editing | **Local machine** | Your editor |
+| Docker build | **Local machine** | `docker build` |
+| Image export | **Local machine** | `docker save` |
+| Image copy | **Local → Cluster** | `scp` via SSH |
+| Image import | **Cluster nodes** | Via SSH: `sudo ctr import` |
+| kubectl apply | **Cluster** | Via SSH: `sudo kubectl apply` |
+| Pod runs | **Cluster** | Kubernetes |
+
+## No Need To SSH Manually
+
+You **never need to SSH into the cluster** manually. Everything is automated:
+
+```bash
+# ❌ You DON'T need to do this:
+ssh ubuntu@10.8.10.40
+cd /some/path
+docker build ...
+kubectl apply ...
+
+# ✅ You just do this:
+cd deploy/k8s
+make full-deploy-dev
+```
+
+The scripts handle all the SSH connections automatically.
+
+## What About Secrets?
+
+Secrets are the **one exception** - you need to create the file locally first:
+
+```bash
+# On your local machine
+cd deploy/k8s
+cp secret.yaml.example secret.yaml
+nano secret.yaml  # Add your passphrase
+
+# Then push it once:
+ssh ubuntu@10.8.10.40 "sudo kubectl apply -f -" < secret.yaml
+
+# After that, it stays on the cluster
+```
+
+## Development Workflow
+
+**Your typical workflow:**
+
+1. **Edit code** on local machine
+2. **Test locally** (optional):
+   ```bash
+   cd /home/matt/projects/icn/icn
+   cargo test
+   cargo build --release
+   ```
+3. **Deploy to cluster**:
+   ```bash
+   cd /home/matt/projects/icn/deploy/k8s
+   make full-deploy-dev
+   ```
+4. **Check status** (from local machine):
+   ```bash
+   make status  # Runs: ssh ubuntu@10.8.10.40 "sudo kubectl ..."
+   ```
+5. **View logs** (from local machine):
+   ```bash
+   make logs  # Runs: ssh ubuntu@10.8.10.40 "sudo kubectl logs ..."
+   ```
+
+## Remote Operations
+
+Even checking status and logs happens **from your local machine**:
+
+```bash
+# All of these run on your local machine,
+# but execute commands on the cluster via SSH:
+
+make status          # ssh ... kubectl get pods
+make logs           # ssh ... kubectl logs
+make restart        # ssh ... kubectl rollout restart
+```
+
+## Summary
+
+✅ **Everything runs on your local machine**  
+✅ **Automatically pushes/syncs to cluster via SSH**  
+✅ **No manual SSH needed**  
+✅ **One command deploys everything**  
+
+Just edit code locally and run `make full-deploy-dev` - that's it!
+

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: icn-config
+  namespace: icn
+  labels:
+    app: icn
+data:
+  icn.toml: |
+    data_dir = "/data"
+
+    [network]
+    listen_addr = "0.0.0.0:7777"
+    rpc_port = 5601
+    mdns_enabled = true
+    bootstrap_peers = []
+    stun_servers = []
+
+    [observability]
+    metrics_port = 9100
+    health_port = 8080
+    log_level = "info"
+
+    [rate_limiting]
+    enabled = true
+    refill_interval_ms = 100
+
+    [rate_limiting.isolated]
+    max_messages_per_second = 10
+    burst_capacity = 2
+
+    [rate_limiting.known]
+    max_messages_per_second = 50
+    burst_capacity = 10
+
+    [rate_limiting.partner]
+    max_messages_per_second = 100
+    burst_capacity = 20
+
+    [rate_limiting.federated]
+    max_messages_per_second = 200
+    burst_capacity = 50
+
+    [rate_limiting.fallback]
+    max_messages_per_second = 100
+    burst_capacity = 20
+
+    [topology]
+    region = "faherty-homelab"
+    cluster_id = "k3s-icn"
+    role = "edge"
+
+    [topology.neighbor_limits]
+    max_local_cluster = 10
+    max_regional = 10
+    max_backbone = 5
+    max_trusted = 20
+
+    [topology.fanout]
+    local_cluster = 8
+    regional = 6
+    global = 4
+

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: icn-daemon
+  namespace: icn
+  labels:
+    app: icn
+    component: daemon
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: icn
+  template:
+    metadata:
+      labels:
+        app: icn
+        component: daemon
+    spec:
+      containers:
+      - name: icnd
+        image: icn:latest
+        imagePullPolicy: Never
+        args:
+          - --config
+          - /etc/icn/icn.toml
+        env:
+        - name: ICN_PASSPHRASE
+          valueFrom:
+            secretKeyRef:
+              name: icn-secrets
+              key: passphrase
+        - name: ICN_DATA_DIR
+          value: "/data"
+        - name: HOME
+          value: "/data"
+        ports:
+        - name: quic
+          containerPort: 7777
+          protocol: UDP
+        - name: rpc
+          containerPort: 5601
+          protocol: TCP
+        - name: metrics
+          containerPort: 9100
+          protocol: TCP
+        - name: health
+          containerPort: 8080
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 9100
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 9100
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 1
+          failureThreshold: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: "1"
+            memory: 2Gi
+        volumeMounts:
+        - name: config
+          mountPath: /etc/icn
+          readOnly: true
+        - name: data
+          mountPath: /data
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+      volumes:
+      - name: config
+        configMap:
+          name: icn-config
+      - name: data
+        persistentVolumeClaim:
+          claimName: icn-data
+

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: icn
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - services.yaml
+  - monitoring/servicemonitor.yaml
+
+# Images can be overridden with kustomize
+images:
+  - name: icn
+    newName: icn
+    newTag: latest
+

--- a/deploy/k8s/multi-node/DEPLOYMENT_STATUS.md
+++ b/deploy/k8s/multi-node/DEPLOYMENT_STATUS.md
@@ -1,0 +1,111 @@
+# Multi-Node ICN Deployment Status
+
+## Current Deployment
+
+**Deployed**: 2025-12-04  
+**Status**: ✅ Operational - 3 coop nodes running
+
+## Deployed Coops
+
+| Coop | Display Name | Namespace | DID | Status | Ports |
+|------|-------------|-----------|-----|--------|-------|
+| **alpha** | Alpha Cooperative | `icn-coop-alpha` | `did:icn:z76a6CKeGxKSek9EUkhmy9NN37XTT4Ev5X7RYsyfWc98a` | ✅ Running | QUIC: 7827, RPC: 5651 |
+| **beta** | Beta Timebank | `icn-coop-beta` | `did:icn:z13gWxvgVUP7XFgzk5Z3vkuKQEdauiBhqtok3RYHWGBRk` | ✅ Running | QUIC: 7834, RPC: 5658 |
+| **gamma** | Gamma Cooperative | `icn-coop-gamma` | `did:icn:zGabvrXN5uT99V2EoBhSXGYaxjqCaFLxAUqA73pnzERF6` | ✅ Running | QUIC: 7825, RPC: 5649 |
+
+## Quick Commands
+
+### List All Coops
+```bash
+cd deploy/k8s/multi-node/scripts
+./list-coops.sh
+```
+
+### Check Coop Status
+```bash
+kubectl -n icn-coop-alpha get pods
+kubectl -n icn-coop-beta get pods
+kubectl -n icn-coop-gamma get pods
+```
+
+### View Logs
+```bash
+kubectl -n icn-coop-alpha logs -f deployment/icn-alpha
+kubectl -n icn-coop-beta logs -f deployment/icn-beta
+kubectl -n icn-coop-gamma logs -f deployment/icn-gamma
+```
+
+### View Identity
+```bash
+kubectl -n icn-coop-alpha exec deployment/icn-alpha -- icnctl id show
+kubectl -n icn-coop-beta exec deployment/icn-beta -- icnctl id show
+kubectl -n icn-coop-gamma exec deployment/icn-gamma -- icnctl id show
+```
+
+## Network Discovery
+
+All nodes have mDNS enabled and should automatically discover each other on the cluster network. They're configured to use:
+- **mDNS**: Enabled for automatic peer discovery
+- **Bootstrap peers**: Empty (using mDNS only)
+- **Network**: Same cluster network (10.42.0.0/16)
+
+## Port Allocation
+
+Each coop gets unique ports automatically:
+
+| Coop | QUIC (UDP) | RPC (TCP) | Metrics | NodePort QUIC | NodePort RPC |
+|------|------------|-----------|---------|---------------|--------------|
+| alpha | 7827 | 5651 | 9150 | 30827 | 30651 |
+| beta | 7834 | 5658 | 9157 | 30834 | 30658 |
+| gamma | 7825 | 5649 | 9148 | 30825 | 30649 |
+
+Ports are automatically allocated based on coop name hash to avoid conflicts.
+
+## Storage
+
+Each coop has its own 10Gi PVC on the `atlas-nfs` storage class:
+- `icn-coop-alpha-data`
+- `icn-coop-beta-data`
+- `icn-coop-gamma-data`
+
+## Next Steps
+
+### Testing Multi-Coop Scenarios
+
+1. **Peer Discovery**: Check if nodes discover each other via mDNS
+2. **Network Communication**: Test P2P messaging between coops
+3. **Ledger Transactions**: Test mutual credit between different coops
+4. **Trust Graph**: Test trust relationships across coops
+
+### Adding More Coops
+
+```bash
+cd deploy/k8s/multi-node/scripts
+./deploy-coop.sh delta "Delta Cooperative"
+```
+
+### Multi-Device Testing (Future)
+
+To test multiple devices with the same identity:
+1. Export identity from an existing coop
+2. Import into a new device deployment
+3. Both devices will share the same DID but have separate storage
+
+See [README.md](README.md) for more details.
+
+## Notes
+
+- All coops are in separate namespaces for isolation
+- Each coop has its own identity (unique DID)
+- All coops share the same cluster network for mDNS discovery
+- Original single-node deployment is still running in `icn` namespace
+
+## Original Single-Node Deployment
+
+The original deployment is still running:
+- **Namespace**: `icn`
+- **DID**: `did:icn:z3TE1ei6B4L5j6Jp29RmJKt1FYonGaQAXQoYHJL3GULR3`
+- **Ports**: QUIC: 7777, RPC: 5601
+
+This can be kept for comparison or removed if not needed.
+

--- a/deploy/k8s/multi-node/README.md
+++ b/deploy/k8s/multi-node/README.md
@@ -1,0 +1,195 @@
+# Multi-Node ICN Deployment
+
+Deploy multiple ICN nodes for testing multiple coops/communities and multi-device scenarios.
+
+## Overview
+
+This directory contains templates and scripts for deploying multiple ICN nodes on the K3s cluster. Each node can represent:
+- **Different coops/communities** (separate identities)
+- **Multiple devices** of the same coop (same identity, different instances)
+
+## Architecture
+
+```
+K3s Cluster
+├── Namespace: icn-coop-alpha
+│   ├── Deployment: icn-coop-alpha
+│   ├── PVC: icn-coop-alpha-data
+│   ├── ConfigMap: icn-coop-alpha-config
+│   └── Secret: icn-coop-alpha-secrets
+├── Namespace: icn-coop-beta
+│   ├── Deployment: icn-coop-beta
+│   ├── PVC: icn-coop-beta-data
+│   ├── ConfigMap: icn-coop-beta-config
+│   └── Secret: icn-coop-beta-secrets
+└── Namespace: icn-coop-gamma
+    └── ...
+```
+
+## Quick Start
+
+### Deploy First Test Coop
+
+```bash
+cd deploy/k8s/multi-node
+./deploy-coop.sh alpha "Alpha Cooperative"
+```
+
+This creates:
+- Namespace `icn-coop-alpha`
+- All necessary resources
+- Initializes identity automatically
+
+### Deploy Multiple Coops
+
+```bash
+./deploy-coop.sh alpha "Alpha Cooperative"
+./deploy-coop.sh beta "Beta Timebank"
+./deploy-coop.sh gamma "Gamma Co-op"
+```
+
+### Deploy Multiple Devices (Same Identity)
+
+For multi-device testing with the same identity:
+
+```bash
+# First device (creates identity)
+./deploy-coop.sh alpha "Alpha Cooperative"
+
+# Additional devices (share same identity)
+./deploy-device.sh alpha device-2
+./deploy-device.sh alpha device-3
+```
+
+## Directory Structure
+
+```
+multi-node/
+├── README.md                    # This file
+├── templates/                   # Kubernetes manifest templates
+│   ├── namespace.yaml.template
+│   ├── configmap.yaml.template
+│   ├── deployment.yaml.template
+│   ├── services.yaml.template
+│   └── pvc.yaml.template
+├── scripts/
+│   ├── deploy-coop.sh          # Deploy new coop (new identity)
+│   ├── deploy-device.sh        # Deploy additional device (same identity)
+│   ├── init-identity.sh        # Initialize identity for a coop
+│   └── list-coops.sh           # List all deployed coops
+└── configs/                    # Generated configs (not in git)
+    └── coop-alpha/
+        └── icn.toml
+```
+
+## Concepts
+
+### Coop Node (Different Identity)
+
+A **coop** represents a distinct cooperative/community with its own identity:
+- Unique DID
+- Separate storage
+- Own configuration
+- Independent from other coops
+
+**Use Case**: Testing multiple coops on the same network
+
+### Device Node (Same Identity)
+
+A **device** represents an additional node sharing the same identity as an existing coop:
+- Same DID
+- Separate storage (but can sync state)
+- Own configuration
+- Part of multi-device setup
+
+**Use Case**: Testing multi-device scenarios where one coop has multiple nodes
+
+## Configuration
+
+Each coop can have its own configuration. The template includes:
+
+- Network settings (ports, mDNS)
+- Region/cluster ID
+- Rate limiting
+- Topology settings
+
+Edit `configs/coop-<name>/icn.toml` before deployment or modify the ConfigMap after.
+
+## Discovery
+
+Nodes discover each other via:
+1. **mDNS** - Automatic discovery on same network
+2. **Bootstrap peers** - Configure in ConfigMap if needed
+
+For multi-coop testing, mDNS should work automatically since they're on the same cluster network.
+
+## Management
+
+### List All Coops
+
+```bash
+./scripts/list-coops.sh
+```
+
+### Check Coop Status
+
+```bash
+kubectl -n icn-coop-alpha get pods
+kubectl -n icn-coop-alpha logs -f deployment/icn-coop-alpha
+```
+
+### Delete a Coop
+
+```bash
+kubectl delete namespace icn-coop-alpha
+```
+
+### View Coop Identity
+
+```bash
+kubectl -n icn-coop-alpha exec deployment/icn-coop-alpha -- icnctl id show
+```
+
+## Examples
+
+### Scenario 1: Two Coops
+
+```bash
+# Deploy two separate coops
+./scripts/deploy-coop.sh alpha "Alpha Cooperative"
+./scripts/deploy-coop.sh beta "Beta Timebank"
+
+# They'll discover each other via mDNS
+```
+
+### Scenario 2: Multi-Device Coop
+
+```bash
+# First device
+./scripts/deploy-coop.sh alpha "Alpha Cooperative"
+
+# Additional devices (will share identity via import)
+./scripts/deploy-device.sh alpha device-2
+./scripts/deploy-device.sh alpha device-3
+```
+
+## Port Allocation
+
+Each coop gets unique ports to avoid conflicts:
+
+| Coop | QUIC (UDP) | RPC (TCP) | Metrics (TCP) | NodePort QUIC | NodePort RPC |
+|------|------------|-----------|---------------|---------------|--------------|
+| alpha | 7777 | 5601 | 9100 | 30777 | 30601 |
+| beta | 7778 | 5602 | 9101 | 30778 | 30602 |
+| gamma | 7779 | 5603 | 9102 | 30779 | 30603 |
+
+Ports are automatically allocated based on coop name.
+
+## Next Steps
+
+- [ ] Add identity export/import for multi-device
+- [ ] Add network configuration for bootstrap peers
+- [ ] Add monitoring dashboard per coop
+- [ ] Add cleanup scripts
+- [ ] Add identity backup/restore
+

--- a/deploy/k8s/multi-node/scripts/deploy-coop.sh
+++ b/deploy/k8s/multi-node/scripts/deploy-coop.sh
@@ -1,0 +1,451 @@
+#!/usr/bin/env bash
+#
+# Deploy a new ICN coop node (new identity)
+#
+# Usage:
+#   ./deploy-coop.sh <coop-name> [coop-display-name] [passphrase]
+#
+# Examples:
+#   ./deploy-coop.sh alpha "Alpha Cooperative"
+#   ./deploy-coop.sh beta "Beta Timebank" "my-secure-passphrase"
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MULTI_NODE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+K8S_DIR="$(cd "$MULTI_NODE_DIR/.." && pwd)"
+K3S_HOST="${K3S_HOST:-ubuntu@10.8.10.40}"
+
+COOP_NAME="${1:-}"
+COOP_DISPLAY_NAME="${2:-$COOP_NAME Cooperative}"
+PASSPHRASE="${3:-}"
+
+if [ -z "$COOP_NAME" ]; then
+    echo "Error: Coop name required"
+    echo "Usage: $0 <coop-name> [coop-display-name] [passphrase]"
+    exit 1
+fi
+
+# Validate coop name (alphanumeric + dashes)
+if ! [[ "$COOP_NAME" =~ ^[a-z0-9-]+$ ]]; then
+    echo "Error: Coop name must be lowercase alphanumeric with dashes only"
+    exit 1
+fi
+
+NAMESPACE="icn-coop-${COOP_NAME}"
+TEMP_DIR=$(mktemp -d)
+
+echo "╔════════════════════════════════════════════════════════════╗"
+echo "║       Deploying ICN Coop: $COOP_NAME                      ║"
+echo "╚════════════════════════════════════════════════════════════╝"
+echo ""
+echo "Coop Name: $COOP_NAME"
+echo "Display Name: $COOP_DISPLAY_NAME"
+echo "Namespace: $NAMESPACE"
+echo ""
+
+# Check if namespace already exists
+if ssh "$K3S_HOST" "sudo kubectl get namespace $NAMESPACE" &>/dev/null; then
+    echo "⚠️  Warning: Namespace $NAMESPACE already exists"
+    read -p "Continue anyway? (y/N) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+
+# Generate passphrase if not provided
+if [ -z "$PASSPHRASE" ]; then
+    PASSPHRASE=$(openssl rand -base64 32 | tr -d "=+/" | cut -c1-32)
+    echo "Generated passphrase (save this!): $PASSPHRASE"
+    echo ""
+fi
+
+# Calculate ports based on coop name (simple hash)
+COOP_INDEX=$(echo -n "$COOP_NAME" | md5sum | head -c 2 | od -An -tx1 | head -1 | awk '{print $1}')
+BASE_PORT=$((7777 + (0x$COOP_INDEX % 100)))
+QUIC_PORT=$BASE_PORT
+RPC_PORT=$((5601 + (BASE_PORT - 7777)))
+METRICS_PORT=$((9100 + (BASE_PORT - 7777)))
+NODEPORT_QUIC=$((30777 + (BASE_PORT - 7777)))
+NODEPORT_RPC=$((30601 + (BASE_PORT - 7777)))
+
+echo "Port Allocation:"
+echo "  QUIC:    $QUIC_PORT (NodePort: $NODEPORT_QUIC)"
+echo "  RPC:     $RPC_PORT (NodePort: $NODEPORT_RPC)"
+echo "  Metrics: $METRICS_PORT"
+echo ""
+
+# Step 1: Create namespace
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Step 1: Creating namespace..."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+cat > "$TEMP_DIR/namespace.yaml" <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $NAMESPACE
+  labels:
+    name: $NAMESPACE
+    app: icn
+    coop: $COOP_NAME
+EOF
+
+ssh "$K3S_HOST" "sudo kubectl apply -f -" < "$TEMP_DIR/namespace.yaml"
+echo "✓ Namespace created"
+echo ""
+
+# Step 2: Create ConfigMap
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Step 2: Creating ConfigMap..."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+cat > "$TEMP_DIR/configmap.yaml" <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: icn-${COOP_NAME}-config
+  namespace: $NAMESPACE
+  labels:
+    app: icn
+    coop: $COOP_NAME
+data:
+  icn.toml: |
+    data_dir = "/data"
+
+    [network]
+    listen_addr = "0.0.0.0:${QUIC_PORT}"
+    rpc_port = ${RPC_PORT}
+    mdns_enabled = true
+    bootstrap_peers = []
+
+    [observability]
+    metrics_port = ${METRICS_PORT}
+    health_port = 8080
+    log_level = "info"
+
+    [rate_limiting]
+    enabled = true
+    refill_interval_ms = 100
+
+    [rate_limiting.isolated]
+    max_messages_per_second = 10
+    burst_capacity = 2
+
+    [rate_limiting.known]
+    max_messages_per_second = 50
+    burst_capacity = 10
+
+    [rate_limiting.partner]
+    max_messages_per_second = 100
+    burst_capacity = 20
+
+    [rate_limiting.federated]
+    max_messages_per_second = 200
+    burst_capacity = 50
+
+    [rate_limiting.fallback]
+    max_messages_per_second = 100
+    burst_capacity = 20
+
+    [topology]
+    region = "faherty-homelab"
+    cluster_id = "k3s-${COOP_NAME}"
+    role = "edge"
+
+    [topology.neighbor_limits]
+    max_local_cluster = 10
+    max_regional = 10
+    max_backbone = 5
+    max_trusted = 20
+
+    [topology.fanout]
+    local_cluster = 8
+    regional = 6
+    global = 4
+EOF
+
+ssh "$K3S_HOST" "sudo kubectl apply -f -" < "$TEMP_DIR/configmap.yaml"
+echo "✓ ConfigMap created"
+echo ""
+
+# Step 3: Create Secret
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Step 3: Creating Secret..."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+cat > "$TEMP_DIR/secret.yaml" <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: icn-${COOP_NAME}-secrets
+  namespace: $NAMESPACE
+  labels:
+    app: icn
+    coop: $COOP_NAME
+type: Opaque
+stringData:
+  passphrase: "$PASSPHRASE"
+EOF
+
+ssh "$K3S_HOST" "sudo kubectl apply -f -" < "$TEMP_DIR/secret.yaml"
+echo "✓ Secret created"
+echo ""
+
+# Step 4: Create PVC
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Step 4: Creating PersistentVolumeClaim..."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+cat > "$TEMP_DIR/pvc.yaml" <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: icn-${COOP_NAME}-data
+  namespace: $NAMESPACE
+  labels:
+    app: icn
+    coop: $COOP_NAME
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: atlas-nfs
+  resources:
+    requests:
+      storage: 10Gi
+EOF
+
+ssh "$K3S_HOST" "sudo kubectl apply -f -" < "$TEMP_DIR/pvc.yaml"
+echo "✓ PVC created"
+echo ""
+
+# Step 5: Create Deployment
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Step 5: Creating Deployment..."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+cat > "$TEMP_DIR/deployment.yaml" <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: icn-${COOP_NAME}
+  namespace: $NAMESPACE
+  labels:
+    app: icn
+    coop: $COOP_NAME
+    component: daemon
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: icn
+      coop: $COOP_NAME
+  template:
+    metadata:
+      labels:
+        app: icn
+        coop: $COOP_NAME
+        component: daemon
+    spec:
+      containers:
+      - name: icnd
+        image: icn:latest
+        imagePullPolicy: Never
+        args:
+          - --config
+          - /etc/icn/icn.toml
+        env:
+        - name: ICN_PASSPHRASE
+          valueFrom:
+            secretKeyRef:
+              name: icn-${COOP_NAME}-secrets
+              key: passphrase
+        - name: ICN_DATA_DIR
+          value: "/data"
+        - name: HOME
+          value: "/data"
+        ports:
+        - name: quic
+          containerPort: ${QUIC_PORT}
+          protocol: UDP
+        - name: rpc
+          containerPort: ${RPC_PORT}
+          protocol: TCP
+        - name: metrics
+          containerPort: ${METRICS_PORT}
+          protocol: TCP
+        - name: health
+          containerPort: 8080
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: ${METRICS_PORT}
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: ${METRICS_PORT}
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 1
+          failureThreshold: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: "1"
+            memory: 2Gi
+        volumeMounts:
+        - name: config
+          mountPath: /etc/icn
+          readOnly: true
+        - name: data
+          mountPath: /data
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+      volumes:
+      - name: config
+        configMap:
+          name: icn-${COOP_NAME}-config
+      - name: data
+        persistentVolumeClaim:
+          claimName: icn-${COOP_NAME}-data
+EOF
+
+ssh "$K3S_HOST" "sudo kubectl apply -f -" < "$TEMP_DIR/deployment.yaml"
+echo "✓ Deployment created"
+echo ""
+
+# Step 6: Create Services
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Step 6: Creating Services..."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+cat > "$TEMP_DIR/services.yaml" <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: icn-${COOP_NAME}
+  namespace: $NAMESPACE
+  labels:
+    app: icn
+    coop: $COOP_NAME
+spec:
+  type: ClusterIP
+  selector:
+    app: icn
+    coop: $COOP_NAME
+  ports:
+  - name: quic
+    port: ${QUIC_PORT}
+    protocol: UDP
+    targetPort: quic
+  - name: rpc
+    port: ${RPC_PORT}
+    protocol: TCP
+    targetPort: rpc
+  - name: metrics
+    port: ${METRICS_PORT}
+    protocol: TCP
+    targetPort: metrics
+  - name: health
+    port: 8080
+    protocol: TCP
+    targetPort: health
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: icn-${COOP_NAME}-nodeport
+  namespace: $NAMESPACE
+  labels:
+    app: icn
+    coop: $COOP_NAME
+spec:
+  type: NodePort
+  selector:
+    app: icn
+    coop: $COOP_NAME
+  ports:
+  - name: quic
+    port: ${QUIC_PORT}
+    protocol: UDP
+    targetPort: quic
+    nodePort: ${NODEPORT_QUIC}
+  - name: rpc
+    port: ${RPC_PORT}
+    protocol: TCP
+    targetPort: rpc
+    nodePort: ${NODEPORT_RPC}
+EOF
+
+ssh "$K3S_HOST" "sudo kubectl apply -f -" < "$TEMP_DIR/services.yaml"
+echo "✓ Services created"
+echo ""
+
+# Step 7: Wait for pod to be ready
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Step 7: Waiting for pod to start..."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+for i in {1..60}; do
+    if ssh "$K3S_HOST" "sudo kubectl -n $NAMESPACE get pods -l coop=$COOP_NAME -o jsonpath='{.items[0].status.phase}'" 2>/dev/null | grep -q Running; then
+        echo "✓ Pod is running"
+        break
+    fi
+    if [ $i -eq 60 ]; then
+        echo "⚠️  Pod not ready after 60 seconds, check manually"
+        break
+    fi
+    sleep 1
+done
+echo ""
+
+# Step 8: Initialize identity
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Step 8: Initializing identity..."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Wait a bit more for pod to be fully ready
+sleep 5
+
+# Check if identity already exists
+IDENTITY_CHECK=$(ssh "$K3S_HOST" "sudo kubectl -n $NAMESPACE exec deployment/icn-${COOP_NAME} -- icnctl id show 2>&1" || echo "not-found")
+
+if echo "$IDENTITY_CHECK" | grep -q "did:icn:"; then
+    DID=$(echo "$IDENTITY_CHECK" | grep -o "did:icn:[a-zA-Z0-9]*" | head -1)
+    echo "✓ Identity already exists: $DID"
+else
+    echo "Initializing new identity..."
+    ssh "$K3S_HOST" "sudo kubectl -n $NAMESPACE exec deployment/icn-${COOP_NAME} -- bash -c 'echo \"$PASSPHRASE\" | icnctl id init'" || {
+        echo "⚠️  Identity initialization may have failed, check logs"
+    }
+    
+    # Get the DID
+    sleep 2
+    DID=$(ssh "$K3S_HOST" "sudo kubectl -n $NAMESPACE exec deployment/icn-${COOP_NAME} -- icnctl id show 2>&1" | grep -o "did:icn:[a-zA-Z0-9]*" | head -1 || echo "unknown")
+    echo "✓ Identity initialized: $DID"
+fi
+echo ""
+
+# Cleanup
+rm -rf "$TEMP_DIR"
+
+# Success!
+echo "╔════════════════════════════════════════════════════════════╗"
+echo "║       Coop Deployed Successfully!                         ║"
+echo "╚════════════════════════════════════════════════════════════╝"
+echo ""
+echo "Coop: $COOP_NAME ($COOP_DISPLAY_NAME)"
+echo "Namespace: $NAMESPACE"
+echo "DID: $DID"
+echo ""
+echo "Access:"
+echo "  Check status: kubectl -n $NAMESPACE get pods"
+echo "  View logs:    kubectl -n $NAMESPACE logs -f deployment/icn-${COOP_NAME}"
+echo "  Show identity: kubectl -n $NAMESPACE exec deployment/icn-${COOP_NAME} -- icnctl id show"
+echo ""
+echo "⚠️  Save this passphrase: $PASSPHRASE"
+

--- a/deploy/k8s/multi-node/scripts/list-coops.sh
+++ b/deploy/k8s/multi-node/scripts/list-coops.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# List all deployed ICN coop nodes
+#
+
+K3S_HOST="${K3S_HOST:-ubuntu@10.8.10.40}"
+
+echo "ICN Coop Nodes:"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Get all namespaces with icn-coop prefix
+NAMESPACES=$(ssh "$K3S_HOST" "sudo kubectl get namespaces -o jsonpath='{.items[*].metadata.name}'" | tr ' ' '\n' | grep "^icn-coop-")
+
+if [ -z "$NAMESPACES" ]; then
+    echo "No coop nodes found"
+    exit 0
+fi
+
+for NS in $NAMESPACES; do
+    COOP_NAME=$(echo "$NS" | sed 's/icn-coop-//')
+    echo "Coop: $COOP_NAME"
+    echo "  Namespace: $NS"
+    
+    # Get pod status
+    POD_STATUS=$(ssh "$K3S_HOST" "sudo kubectl -n $NS get pods -l app=icn,coop=$COOP_NAME -o jsonpath='{.items[0].status.phase}'" 2>/dev/null || echo "not-found")
+    echo "  Status: $POD_STATUS"
+    
+    # Get identity if pod is running
+    if [ "$POD_STATUS" = "Running" ]; then
+        DID=$(ssh "$K3S_HOST" "sudo kubectl -n $NS exec deployment/icn-$COOP_NAME -- icnctl id show 2>&1" 2>/dev/null | grep -o "did:icn:[a-zA-Z0-9]*" | head -1 || echo "unknown")
+        echo "  DID: $DID"
+        
+        # Get ports from service
+        QUIC_PORT=$(ssh "$K3S_HOST" "sudo kubectl -n $NS get svc icn-$COOP_NAME -o jsonpath='{.spec.ports[?(@.name==\"quic\")].port}'" 2>/dev/null || echo "?")
+        echo "  QUIC Port: $QUIC_PORT"
+    fi
+    
+    echo ""
+done
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+

--- a/deploy/k8s/namespace.yaml
+++ b/deploy/k8s/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: icn
+  labels:
+    name: icn
+    app: icn
+

--- a/deploy/k8s/pvc.yaml
+++ b/deploy/k8s/pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: icn-data
+  namespace: icn
+  labels:
+    app: icn
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: atlas-nfs
+  resources:
+    requests:
+      storage: 10Gi
+

--- a/deploy/k8s/scripts/build-image.sh
+++ b/deploy/k8s/scripts/build-image.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Build ICN Docker image for K3s deployment
+# This script builds the image and tags it appropriately
+#
+# Usage:
+#   ./build-image.sh [tag]
+#
+# Examples:
+#   ./build-image.sh                    # Builds with 'latest' tag
+#   ./build-image.sh v1.0.0             # Builds with 'v1.0.0' tag
+#   ./build-image.sh $(git rev-parse --short HEAD)  # Builds with git hash tag
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+IMAGE_NAME="${IMAGE_NAME:-icn}"
+TAG="${1:-latest}"
+FULL_IMAGE="${IMAGE_NAME}:${TAG}"
+
+echo "Building ICN Docker image..."
+echo "  Image: $FULL_IMAGE"
+echo "  Context: $REPO_ROOT/icn"
+echo ""
+
+cd "$REPO_ROOT"
+
+# Build the image
+# Use Dockerfile.icnd which expects context to be icn/ directory
+# This matches the docker-compose setup
+docker build \
+  -f deploy/Dockerfile.icnd \
+  -t "$FULL_IMAGE" \
+  -t "${IMAGE_NAME}:latest" \
+  "$REPO_ROOT/icn"
+
+echo ""
+echo "✓ Image built successfully: $FULL_IMAGE"
+echo ""
+echo "To load image to K3s cluster, run:"
+echo "  ./deploy/k8s/scripts/sync-image.sh $TAG"
+

--- a/deploy/k8s/scripts/deploy.sh
+++ b/deploy/k8s/scripts/deploy.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Deploy ICN to K3s cluster
+# This script applies all Kubernetes manifests to the cluster
+#
+# Usage:
+#   ./deploy.sh [k3s-control-host] [image-tag]
+#
+# Examples:
+#   ./deploy.sh                                    # Deploy to default host with latest
+#   ./deploy.sh ubuntu@10.8.10.40                 # Custom host
+#   ./deploy.sh ubuntu@10.8.10.40 v1.0.0          # Custom host and tag
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+K8S_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+K3S_HOST="${1:-ubuntu@10.8.10.40}"
+IMAGE_TAG="${2:-latest}"
+IMAGE_NAME="${IMAGE_NAME:-icn}"
+
+echo "Deploying ICN to K3s cluster..."
+echo "  Host: $K3S_HOST"
+echo "  Image: ${IMAGE_NAME}:${IMAGE_TAG}"
+echo ""
+
+# Check if kustomize is available, otherwise use kubectl apply
+if command -v kustomize &>/dev/null; then
+    echo "Using kustomize to build manifests..."
+    # Update image tag in kustomization if provided
+    if [ "$IMAGE_TAG" != "latest" ]; then
+        TEMP_DIR=$(mktemp -d)
+        cp -r "$K8S_DIR"/* "$TEMP_DIR/"
+        # Update kustomization.yaml image tag
+        sed -i "s/newTag:.*/newTag: ${IMAGE_TAG}/" "$TEMP_DIR/kustomization.yaml"
+        K8S_DIR="$TEMP_DIR"
+    fi
+    
+    kustomize build "$K8S_DIR" | ssh "$K3S_HOST" "sudo kubectl apply -f -"
+else
+    echo "Using kubectl apply directly..."
+    # Apply manifests in order
+    ssh "$K3S_HOST" <<EOF
+set -e
+cd /tmp
+sudo kubectl apply -f - <<'MANIFESTS'
+$(cat "$K8S_DIR/namespace.yaml")
+MANIFESTS
+
+sudo kubectl apply -f - <<'MANIFESTS'
+$(cat "$K8S_DIR/configmap.yaml")
+MANIFESTS
+
+sudo kubectl apply -f - <<'MANIFESTS'
+$(cat "$K8S_DIR/pvc.yaml")
+MANIFESTS
+
+sudo kubectl apply -f - <<'MANIFESTS'
+$(cat "$K8S_DIR/services.yaml")
+MANIFESTS
+
+# Update deployment with image tag if needed
+if [ "$IMAGE_TAG" != "latest" ]; then
+    sudo kubectl set image deployment/icn-daemon -n icn icnd=${IMAGE_NAME}:${IMAGE_TAG}
+fi
+
+sudo kubectl apply -f - <<'MANIFESTS'
+$(cat "$K8S_DIR/deployment.yaml")
+MANIFESTS
+
+sudo kubectl apply -f - <<'MANIFESTS'
+$(cat "$K8S_DIR/monitoring/servicemonitor.yaml")
+MANIFESTS
+EOF
+fi
+
+echo ""
+echo "✓ Deployment complete!"
+echo ""
+echo "To check status, run:"
+echo "  ssh $K3S_HOST 'sudo kubectl -n icn get pods'"
+echo ""
+echo "To view logs, run:"
+echo "  ssh $K3S_HOST 'sudo kubectl -n icn logs -f deployment/icn-daemon'"
+

--- a/deploy/k8s/scripts/full-deploy.sh
+++ b/deploy/k8s/scripts/full-deploy.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Full deployment pipeline: build, sync, and deploy ICN to K3s cluster
+# This script orchestrates the complete deployment process
+#
+# Usage:
+#   ./full-deploy.sh [tag] [k3s-control-host]
+#
+# Examples:
+#   ./full-deploy.sh                                    # Deploy latest
+#   ./full-deploy.sh $(git rev-parse --short HEAD)     # Deploy with git hash
+#   ./full-deploy.sh v1.0.0 ubuntu@10.8.10.40          # Custom tag and host
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TAG="${1:-latest}"
+K3S_HOST="${2:-ubuntu@10.8.10.40}"
+
+echo "╔════════════════════════════════════════════════════════════╗"
+echo "║       ICN Full Deployment Pipeline                        ║"
+echo "╚════════════════════════════════════════════════════════════╝"
+echo ""
+echo "Tag: $TAG"
+echo "Target: $K3S_HOST"
+echo ""
+
+# Step 1: Build image
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Step 1: Building Docker image..."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+"$SCRIPT_DIR/build-image.sh" "$TAG"
+echo ""
+
+# Step 2: Sync image to cluster
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Step 2: Syncing image to K3s cluster..."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+"$SCRIPT_DIR/sync-image.sh" "$TAG" "$K3S_HOST"
+echo ""
+
+# Step 3: Deploy to cluster
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Step 3: Deploying to K3s cluster..."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+"$SCRIPT_DIR/deploy.sh" "$K3S_HOST" "$TAG"
+echo ""
+
+echo "╔════════════════════════════════════════════════════════════╗"
+echo "║       Deployment Complete!                                 ║"
+echo "╚════════════════════════════════════════════════════════════╝"
+echo ""
+echo "Next steps:"
+echo "  1. Check pod status:"
+echo "     ssh $K3S_HOST 'sudo kubectl -n icn get pods -w'"
+echo ""
+echo "  2. View logs:"
+echo "     ssh $K3S_HOST 'sudo kubectl -n icn logs -f deployment/icn-daemon'"
+echo ""
+echo "  3. Check metrics:"
+echo "     ssh $K3S_HOST 'sudo kubectl -n icn port-forward svc/icn 9100:9100'"
+echo "     # Then visit http://localhost:9100/metrics"
+

--- a/deploy/k8s/scripts/sync-image.sh
+++ b/deploy/k8s/scripts/sync-image.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Sync ICN Docker image to K3s cluster nodes
+# This script exports the image from Docker and imports it to containerd on each node
+#
+# Usage:
+#   ./sync-image.sh [tag] [k3s-control-host]
+#
+# Examples:
+#   ./sync-image.sh                    # Syncs 'latest' tag to default host
+#   ./sync-image.sh v1.0.0             # Syncs 'v1.0.0' tag
+#   ./sync-image.sh latest ubuntu@10.8.10.40  # Custom host
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+IMAGE_NAME="${IMAGE_NAME:-icn}"
+TAG="${1:-latest}"
+K3S_HOST="${2:-ubuntu@10.8.10.40}"
+FULL_IMAGE="${IMAGE_NAME}:${TAG}"
+TEMP_TAR="/tmp/icn-${TAG}-$(date +%s).tar"
+
+echo "Syncing ICN Docker image to K3s cluster..."
+echo "  Image: $FULL_IMAGE"
+echo "  Target: $K3S_HOST"
+echo ""
+
+# Check if image exists locally
+if ! docker image inspect "$FULL_IMAGE" &>/dev/null; then
+    echo "Error: Image $FULL_IMAGE not found locally"
+    echo "Run './build-image.sh $TAG' first"
+    exit 1
+fi
+
+# Export image to tar
+echo "Exporting image..."
+docker save "$FULL_IMAGE" -o "$TEMP_TAR"
+
+# Copy to K3s control node
+echo "Copying to K3s node..."
+scp "$TEMP_TAR" "${K3S_HOST}:/tmp/icn-image.tar"
+
+# Import to containerd on all nodes
+echo "Importing to containerd..."
+ssh "$K3S_HOST" <<EOF
+set -e
+echo "Importing image on control node..."
+sudo ctr -n k8s.io images import /tmp/icn-image.tar || \
+  sudo ctr images import /tmp/icn-image.tar
+
+# Sync to worker nodes
+for node in k3s-worker-1 k3s-worker-2; do
+    echo "Syncing to \$node..."
+    scp /tmp/icn-image.tar ubuntu@\$node:/tmp/icn-image.tar || true
+    ssh ubuntu@\$node "sudo ctr -n k8s.io images import /tmp/icn-image.tar || sudo ctr images import /tmp/icn-image.tar" || true
+done
+
+# Cleanup
+rm -f /tmp/icn-image.tar
+EOF
+
+# Cleanup local temp file
+rm -f "$TEMP_TAR"
+
+echo ""
+echo "✓ Image synced successfully to K3s cluster"
+echo ""
+echo "To deploy, run:"
+echo "  ./deploy/k8s/scripts/deploy.sh"
+

--- a/deploy/k8s/secret.yaml.example
+++ b/deploy/k8s/secret.yaml.example
@@ -1,0 +1,25 @@
+# Example secret template
+# Copy this to secret.yaml and fill in your values
+# DO NOT commit secret.yaml to git!
+apiVersion: v1
+kind: Secret
+metadata:
+  name: icn-secrets
+  namespace: icn
+  labels:
+    app: icn
+type: Opaque
+stringData:
+  passphrase: "CHANGE_ME"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: icn-passphrase
+  namespace: icn
+  labels:
+    app: icn
+type: Opaque
+stringData:
+  passphrase: "CHANGE_ME"
+

--- a/deploy/k8s/services.yaml
+++ b/deploy/k8s/services.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: icn
+  namespace: icn
+  labels:
+    app: icn
+spec:
+  type: ClusterIP
+  selector:
+    app: icn
+  ports:
+  - name: quic
+    port: 7777
+    protocol: UDP
+    targetPort: quic
+  - name: rpc
+    port: 5601
+    protocol: TCP
+    targetPort: rpc
+  - name: metrics
+    port: 9100
+    protocol: TCP
+    targetPort: metrics
+  - name: health
+    port: 8080
+    protocol: TCP
+    targetPort: health
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: icn-nodeport
+  namespace: icn
+  labels:
+    app: icn
+spec:
+  type: NodePort
+  selector:
+    app: icn
+  ports:
+  - name: quic
+    port: 7777
+    protocol: UDP
+    targetPort: quic
+    nodePort: 30777
+  - name: rpc
+    port: 5601
+    protocol: TCP
+    targetPort: rpc
+    nodePort: 30601
+

--- a/icn/.dockerignore
+++ b/icn/.dockerignore
@@ -1,0 +1,34 @@
+# Rust build artifacts - these are huge and don't need to be in the image
+target/
+**/target/
+
+# Git files
+.git/
+.gitignore
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Documentation (not needed in image)
+docs/
+*.md
+
+# Examples (not needed in image)
+examples/
+
+# Scripts (not needed in image)
+scripts/
+
+# Temporary files
+*.tmp
+*.log
+*.bak
+
+# OS files
+.DS_Store
+Thumbs.db
+

--- a/icn/crates/icn-compute/src/lib.rs
+++ b/icn/crates/icn-compute/src/lib.rs
@@ -33,6 +33,7 @@ mod scheduler;
 mod task;
 mod types;
 mod wasm_executor;
+mod wasm_registry;
 
 pub use actor::{
     ComputeActor, ComputeEvent, ComputeHandle, EventCallback, PaymentCallback, PaymentRequest,
@@ -65,6 +66,10 @@ pub use types::{
     TaskCode, TaskHash, TaskId, TaskPriority,
 };
 pub use wasm_executor::WasmExecutor;
+pub use wasm_registry::{
+    compute_hash as compute_wasm_hash, WasmHash, WasmMetadata, WasmRegistry, WasmRegistryError,
+    WasmRegistryStats,
+};
 
 /// Gossip topic for task submission
 pub const TOPIC_SUBMIT: &str = "compute:submit";

--- a/icn/crates/icn-compute/src/wasm_executor.rs
+++ b/icn/crates/icn-compute/src/wasm_executor.rs
@@ -372,9 +372,7 @@ impl Executor for WasmExecutor {
                             hash = %hash_hex,
                             "WASM module not found in registry"
                         );
-                        ExecutionOutcome::Failed(format!(
-                            "WASM module not found: {hash_hex}"
-                        ))
+                        ExecutionOutcome::Failed(format!("WASM module not found: {hash_hex}"))
                     }
                     Err(e) => {
                         tracing::error!(
@@ -382,9 +380,7 @@ impl Executor for WasmExecutor {
                             error = %e,
                             "Failed to fetch WASM from registry"
                         );
-                        ExecutionOutcome::Failed(format!(
-                            "Registry error: {e}"
-                        ))
+                        ExecutionOutcome::Failed(format!("Registry error: {e}"))
                     }
                 }
             }
@@ -734,7 +730,10 @@ mod tests {
         let result = executor.execute(&task, &mut ctx);
         match result {
             ExecutionOutcome::Failed(msg) => {
-                assert!(msg.contains("not found"), "Expected 'not found', got: {msg}");
+                assert!(
+                    msg.contains("not found"),
+                    "Expected 'not found', got: {msg}"
+                );
             }
             other => panic!("Expected 'not found' error, got: {other:?}"),
         }

--- a/icn/crates/icn-compute/src/wasm_executor.rs
+++ b/icn/crates/icn-compute/src/wasm_executor.rs
@@ -9,6 +9,8 @@ use wasmtime::{Engine, Linker, Module, Store, StoreLimits, StoreLimitsBuilder};
 use crate::error::ComputeError;
 use crate::executor::{ExecutionContext, Executor};
 use crate::types::{ComputeTask, ExecutionOutcome, ExecutorCapability, TaskCode};
+use crate::wasm_registry::WasmRegistry;
+use std::sync::Arc;
 
 /// WASM execution state for memory limits
 #[cfg(feature = "wasm")]
@@ -38,6 +40,8 @@ pub struct WasmExecutor {
     engine: Engine,
     /// Maximum memory per WASM instance (bytes)
     max_memory: usize,
+    /// Optional WASM registry for WasmRef resolution
+    registry: Option<Arc<WasmRegistry>>,
 }
 
 impl WasmExecutor {
@@ -51,6 +55,7 @@ impl WasmExecutor {
             capabilities: vec![ExecutorCapability::Wasm, ExecutorCapability::Ccl],
             engine,
             max_memory: 64 * 1024 * 1024, // 64MB default
+            registry: None,
         })
     }
 
@@ -60,6 +65,7 @@ impl WasmExecutor {
         Ok(Self {
             capabilities: vec![ExecutorCapability::Ccl],
             max_memory: 64 * 1024 * 1024,
+            registry: None,
         })
     }
 
@@ -67,6 +73,22 @@ impl WasmExecutor {
     pub fn with_max_memory(mut self, bytes: usize) -> Self {
         self.max_memory = bytes;
         self
+    }
+
+    /// Set the WASM registry for WasmRef resolution
+    pub fn with_registry(mut self, registry: Arc<WasmRegistry>) -> Self {
+        self.registry = Some(registry);
+        self
+    }
+
+    /// Set the WASM registry (mutable reference version)
+    pub fn set_registry(&mut self, registry: Arc<WasmRegistry>) {
+        self.registry = Some(registry);
+    }
+
+    /// Get the WASM registry if set
+    pub fn registry(&self) -> Option<&Arc<WasmRegistry>> {
+        self.registry.as_ref()
     }
 
     /// Execute a WASM module
@@ -317,9 +339,54 @@ impl Executor for WasmExecutor {
                 ))
             }
             TaskCode::WasmInline(bytes) => self.execute_wasm(bytes, &task.inputs, ctx),
-            TaskCode::WasmRef(_hash) => {
-                // TODO: Fetch WASM from blob storage using hash
-                ExecutionOutcome::Failed("WASM reference execution not yet implemented".into())
+            TaskCode::WasmRef(hash) => {
+                // Fetch WASM from registry using hash
+                let hash_hex = hex::encode(hash);
+
+                let Some(registry) = &self.registry else {
+                    tracing::warn!(
+                        hash = %hash_hex,
+                        "WasmRef requires registry but none configured"
+                    );
+                    return ExecutionOutcome::Failed(
+                        "WASM registry not configured. Cannot resolve WasmRef.".into(),
+                    );
+                };
+
+                // Use the blocking version since Executor::execute is synchronous
+                // The get_blocking() method uses blocking_read/blocking_write on
+                // tokio RwLocks which is designed for this use case.
+                let wasm_bytes = registry.get_blocking(hash);
+
+                match wasm_bytes {
+                    Ok(Some(bytes)) => {
+                        tracing::debug!(
+                            hash = %hash_hex,
+                            size = bytes.len(),
+                            "Resolved WasmRef from registry"
+                        );
+                        self.execute_wasm(&bytes, &task.inputs, ctx)
+                    }
+                    Ok(None) => {
+                        tracing::warn!(
+                            hash = %hash_hex,
+                            "WASM module not found in registry"
+                        );
+                        ExecutionOutcome::Failed(format!(
+                            "WASM module not found: {hash_hex}"
+                        ))
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            hash = %hash_hex,
+                            error = %e,
+                            "Failed to fetch WASM from registry"
+                        );
+                        ExecutionOutcome::Failed(format!(
+                            "Registry error: {e}"
+                        ))
+                    }
+                }
             }
         }
     }
@@ -597,6 +664,148 @@ mod tests {
                 assert!(msg.contains("WASM support not enabled"));
             }
             other => panic!("Expected failure message, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_wasm_ref_without_registry() {
+        let executor = WasmExecutor::new().unwrap();
+        let task = ComputeTask {
+            id: "wasm-ref-test".into(),
+            submitter: "did:icn:alice".into(),
+            coop_id: None,
+            code: TaskCode::WasmRef([0xAA; 32]),
+            inputs: vec![],
+            fuel_limit: FuelLimit(10_000),
+            required_capabilities: vec![ExecutorCapability::Wasm],
+            priority: crate::types::TaskPriority::Normal,
+            created_at: 1000,
+            deadline: None,
+            payment_rate: None,
+            payment_currency: None,
+            resource_profile: None,
+            actor_mode: None,
+            placement_constraints: None,
+        };
+
+        let mut ctx = ExecutionContext {
+            executor_did: "did:icn:executor".into(),
+            fuel_remaining: 10_000,
+        };
+
+        let result = executor.execute(&task, &mut ctx);
+        match result {
+            ExecutionOutcome::Failed(msg) => {
+                assert!(msg.contains("registry not configured"));
+            }
+            other => panic!("Expected 'registry not configured' error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_wasm_ref_not_found_in_registry() {
+        let registry = Arc::new(WasmRegistry::new());
+        let executor = WasmExecutor::new().unwrap().with_registry(registry);
+
+        let fake_hash = [0xBB; 32];
+        let task = ComputeTask {
+            id: "wasm-ref-missing".into(),
+            submitter: "did:icn:alice".into(),
+            coop_id: None,
+            code: TaskCode::WasmRef(fake_hash),
+            inputs: vec![],
+            fuel_limit: FuelLimit(10_000),
+            required_capabilities: vec![ExecutorCapability::Wasm],
+            priority: crate::types::TaskPriority::Normal,
+            created_at: 1000,
+            deadline: None,
+            payment_rate: None,
+            payment_currency: None,
+            resource_profile: None,
+            actor_mode: None,
+            placement_constraints: None,
+        };
+
+        let mut ctx = ExecutionContext {
+            executor_did: "did:icn:executor".into(),
+            fuel_remaining: 10_000,
+        };
+
+        let result = executor.execute(&task, &mut ctx);
+        match result {
+            ExecutionOutcome::Failed(msg) => {
+                assert!(msg.contains("not found"), "Expected 'not found', got: {msg}");
+            }
+            other => panic!("Expected 'not found' error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_wasm_ref_with_registry() {
+        // Minimal valid WASM module
+        let wasm_bytes = vec![
+            0x00, 0x61, 0x73, 0x6D, // magic: \0asm
+            0x01, 0x00, 0x00, 0x00, // version: 1
+        ];
+
+        let registry = Arc::new(WasmRegistry::new());
+
+        // Deploy the WASM module
+        let hash = registry
+            .deploy(wasm_bytes.clone(), "did:icn:deployer", |m| m)
+            .await
+            .unwrap();
+
+        let executor = WasmExecutor::new().unwrap().with_registry(registry);
+
+        let task = ComputeTask {
+            id: "wasm-ref-valid".into(),
+            submitter: "did:icn:alice".into(),
+            coop_id: None,
+            code: TaskCode::WasmRef(hash),
+            inputs: vec![],
+            fuel_limit: FuelLimit(10_000),
+            required_capabilities: vec![ExecutorCapability::Wasm],
+            priority: crate::types::TaskPriority::Normal,
+            created_at: 1000,
+            deadline: None,
+            payment_rate: None,
+            payment_currency: None,
+            resource_profile: None,
+            actor_mode: None,
+            placement_constraints: None,
+        };
+
+        let mut ctx = ExecutionContext {
+            executor_did: "did:icn:executor".into(),
+            fuel_remaining: 10_000,
+        };
+
+        // This will attempt to execute the minimal WASM module
+        // It will fail because the module has no 'run' function, but it proves
+        // the registry lookup worked
+        let result = executor.execute(&task, &mut ctx);
+
+        // Without the wasm feature, we expect "WASM support not enabled"
+        // With the wasm feature, we expect "No 'run' function found" (because we're using a minimal module)
+        #[cfg(not(feature = "wasm"))]
+        match result {
+            ExecutionOutcome::Failed(msg) => {
+                assert!(msg.contains("WASM support not enabled"));
+            }
+            other => panic!("Expected WASM disabled message, got: {other:?}"),
+        }
+
+        #[cfg(feature = "wasm")]
+        match result {
+            ExecutionOutcome::Failed(msg) => {
+                // Module loaded but no 'run' function - proves registry lookup worked
+                assert!(
+                    msg.contains("run") || msg.contains("function"),
+                    "Expected function-related error, got: {msg}"
+                );
+            }
+            other => panic!("Expected function error, got: {other:?}"),
         }
     }
 }

--- a/icn/crates/icn-compute/src/wasm_registry.rs
+++ b/icn/crates/icn-compute/src/wasm_registry.rs
@@ -114,7 +114,7 @@ fn validate_wasm(wasm_bytes: &[u8]) -> Result<()> {
         ));
     }
 
-    if &wasm_bytes[0..4] != &WASM_MAGIC {
+    if wasm_bytes[0..4] != WASM_MAGIC {
         return Err(WasmRegistryError::InvalidModule(
             "Invalid WASM magic bytes".into(),
         ));
@@ -202,9 +202,10 @@ impl WasmRegistry {
 
         // Check if already exists
         {
-            let modules = self.modules.read().map_err(|e| {
-                WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
-            })?;
+            let modules = self
+                .modules
+                .read()
+                .map_err(|e| WasmRegistryError::StorageError(format!("Lock poisoned: {e}")))?;
             if modules.contains_key(&hash) {
                 return Err(WasmRegistryError::AlreadyExists(hash_hex));
             }
@@ -241,21 +242,24 @@ impl WasmRegistry {
 
         // Update in-memory caches
         {
-            let mut modules = self.modules.write().map_err(|e| {
-                WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
-            })?;
+            let mut modules = self
+                .modules
+                .write()
+                .map_err(|e| WasmRegistryError::StorageError(format!("Lock poisoned: {e}")))?;
             modules.insert(hash, wasm_bytes);
         }
         {
-            let mut meta_cache = self.metadata.write().map_err(|e| {
-                WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
-            })?;
+            let mut meta_cache = self
+                .metadata
+                .write()
+                .map_err(|e| WasmRegistryError::StorageError(format!("Lock poisoned: {e}")))?;
             meta_cache.insert(hash, metadata);
         }
         {
-            let mut owner_index = self.owner_index.write().map_err(|e| {
-                WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
-            })?;
+            let mut owner_index = self
+                .owner_index
+                .write()
+                .map_err(|e| WasmRegistryError::StorageError(format!("Lock poisoned: {e}")))?;
             owner_index.entry(owner.to_string()).or_default().push(hash);
         }
 
@@ -279,9 +283,10 @@ impl WasmRegistry {
     pub fn get_blocking(&self, hash: &WasmHash) -> Result<Option<Vec<u8>>> {
         // Check cache first
         {
-            let modules = self.modules.read().map_err(|e| {
-                WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
-            })?;
+            let modules = self
+                .modules
+                .read()
+                .map_err(|e| WasmRegistryError::StorageError(format!("Lock poisoned: {e}")))?;
             if let Some(wasm) = modules.get(hash) {
                 return Ok(Some(wasm.clone()));
             }
@@ -297,9 +302,10 @@ impl WasmRegistry {
                 let wasm_bytes = bytes.to_vec();
 
                 // Populate cache
-                let mut modules = self.modules.write().map_err(|e| {
-                    WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
-                })?;
+                let mut modules = self
+                    .modules
+                    .write()
+                    .map_err(|e| WasmRegistryError::StorageError(format!("Lock poisoned: {e}")))?;
                 modules.insert(*hash, wasm_bytes.clone());
 
                 return Ok(Some(wasm_bytes));
@@ -318,9 +324,10 @@ impl WasmRegistry {
     pub fn get_metadata_sync(&self, hash: &WasmHash) -> Result<Option<WasmMetadata>> {
         // Check cache first
         {
-            let metadata = self.metadata.read().map_err(|e| {
-                WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
-            })?;
+            let metadata = self
+                .metadata
+                .read()
+                .map_err(|e| WasmRegistryError::StorageError(format!("Lock poisoned: {e}")))?;
             if let Some(meta) = metadata.get(hash) {
                 return Ok(Some(meta.clone()));
             }
@@ -337,9 +344,10 @@ impl WasmRegistry {
                     .map_err(|e| WasmRegistryError::SerializationError(e.to_string()))?;
 
                 // Populate cache
-                let mut metadata = self.metadata.write().map_err(|e| {
-                    WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
-                })?;
+                let mut metadata = self
+                    .metadata
+                    .write()
+                    .map_err(|e| WasmRegistryError::StorageError(format!("Lock poisoned: {e}")))?;
                 metadata.insert(*hash, meta.clone());
 
                 return Ok(Some(meta));
@@ -378,12 +386,14 @@ impl WasmRegistry {
 
     /// List modules by owner (sync version)
     pub fn list_by_owner_sync(&self, owner: &str) -> Result<Vec<WasmMetadata>> {
-        let owner_index = self.owner_index.read().map_err(|e| {
-            WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
-        })?;
-        let metadata = self.metadata.read().map_err(|e| {
-            WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
-        })?;
+        let owner_index = self
+            .owner_index
+            .read()
+            .map_err(|e| WasmRegistryError::StorageError(format!("Lock poisoned: {e}")))?;
+        let metadata = self
+            .metadata
+            .read()
+            .map_err(|e| WasmRegistryError::StorageError(format!("Lock poisoned: {e}")))?;
 
         if let Some(hashes) = owner_index.get(owner) {
             Ok(hashes
@@ -470,7 +480,10 @@ impl WasmRegistry {
                                 let mut owner_index = self.owner_index.write().map_err(|e| {
                                     WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
                                 })?;
-                                owner_index.entry(meta.owner.clone()).or_default().push(hash);
+                                owner_index
+                                    .entry(meta.owner.clone())
+                                    .or_default()
+                                    .push(hash);
                             }
                         }
 
@@ -549,7 +562,10 @@ mod tests {
         let wasm = sample_wasm();
 
         // First deploy succeeds
-        registry.deploy(wasm.clone(), "did:icn:owner", |m| m).await.unwrap();
+        registry
+            .deploy(wasm.clone(), "did:icn:owner", |m| m)
+            .await
+            .unwrap();
 
         // Second deploy fails
         let result = registry.deploy(wasm, "did:icn:owner", |m| m).await;
@@ -592,12 +608,18 @@ mod tests {
 
         // Deploy from owner1
         let wasm1 = sample_wasm();
-        registry.deploy(wasm1, "did:icn:owner1", |m| m.with_name("mod1")).await.unwrap();
+        registry
+            .deploy(wasm1, "did:icn:owner1", |m| m.with_name("mod1"))
+            .await
+            .unwrap();
 
         // Deploy from owner2 (different WASM to get different hash)
         let mut wasm2 = sample_wasm();
         wasm2.push(0x00); // Make it different
-        registry.deploy(wasm2, "did:icn:owner2", |m| m.with_name("mod2")).await.unwrap();
+        registry
+            .deploy(wasm2, "did:icn:owner2", |m| m.with_name("mod2"))
+            .await
+            .unwrap();
 
         // List owner1's modules
         let owner1_mods = registry.list_by_owner("did:icn:owner1").await.unwrap();
@@ -629,7 +651,10 @@ mod tests {
         let registry = WasmRegistry::temporary().unwrap();
         let wasm = sample_wasm();
 
-        let hash = registry.deploy(wasm.clone(), "did:icn:owner", |m| m).await.unwrap();
+        let hash = registry
+            .deploy(wasm.clone(), "did:icn:owner", |m| m)
+            .await
+            .unwrap();
 
         // Clear in-memory cache
         {

--- a/icn/crates/icn-compute/src/wasm_registry.rs
+++ b/icn/crates/icn-compute/src/wasm_registry.rs
@@ -1,0 +1,675 @@
+//! WASM Registry - Content-Addressed Storage for WASM Bytecode
+//!
+//! Enables "deploy once, reference by hash" pattern for WASM modules:
+//! 1. Deploy WASM module to registry (gets content hash)
+//! 2. Reference module by hash in compute tasks (TaskCode::WasmRef)
+//! 3. Executor fetches module from registry before execution
+//!
+//! ## Storage Schema
+//!
+//! ```text
+//! wasm:<hash>           → Vec<u8> (WASM bytecode)
+//! wasm_meta:<hash>      → WasmMetadata (bincode)
+//! wasm_owner:<did>      → Vec<[u8; 32]> (list of hashes)
+//! ```
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use thiserror::Error;
+
+/// Content hash for WASM addressing (blake3)
+pub type WasmHash = [u8; 32];
+
+/// WASM registry errors
+#[derive(Debug, Error)]
+pub enum WasmRegistryError {
+    #[error("WASM module not found: {0}")]
+    NotFound(String),
+
+    #[error("WASM module already exists: {0}")]
+    AlreadyExists(String),
+
+    #[error("Invalid WASM module: {0}")]
+    InvalidModule(String),
+
+    #[error("Storage error: {0}")]
+    StorageError(String),
+
+    #[error("Serialization error: {0}")]
+    SerializationError(String),
+}
+
+pub type Result<T> = std::result::Result<T, WasmRegistryError>;
+
+/// Metadata stored alongside WASM modules
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WasmMetadata {
+    /// Content hash of the module
+    pub code_hash: WasmHash,
+    /// Module name (optional, user-provided)
+    pub name: Option<String>,
+    /// Size in bytes
+    pub size_bytes: usize,
+    /// Owner/deployer DID
+    pub owner: String,
+    /// Deployment timestamp (Unix millis)
+    pub deployed_at: u64,
+    /// Optional description
+    pub description: Option<String>,
+    /// Required capabilities (user-declared)
+    pub capabilities: Vec<String>,
+}
+
+impl WasmMetadata {
+    /// Create metadata from WASM bytecode
+    pub fn new(wasm_bytes: &[u8], owner: &str) -> Self {
+        let code_hash = compute_hash(wasm_bytes);
+        Self {
+            code_hash,
+            name: None,
+            size_bytes: wasm_bytes.len(),
+            owner: owner.to_string(),
+            deployed_at: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as u64,
+            description: None,
+            capabilities: Vec::new(),
+        }
+    }
+
+    /// Set module name
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Set description
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Add a capability
+    pub fn with_capability(mut self, capability: impl Into<String>) -> Self {
+        self.capabilities.push(capability.into());
+        self
+    }
+}
+
+/// Compute content hash for WASM bytecode
+pub fn compute_hash(wasm_bytes: &[u8]) -> WasmHash {
+    *blake3::hash(wasm_bytes).as_bytes()
+}
+
+/// Validate WASM bytecode has valid magic bytes
+fn validate_wasm(wasm_bytes: &[u8]) -> Result<()> {
+    // WASM magic number: 0x00 0x61 0x73 0x6D (\0asm)
+    const WASM_MAGIC: [u8; 4] = [0x00, 0x61, 0x73, 0x6D];
+
+    if wasm_bytes.len() < 8 {
+        return Err(WasmRegistryError::InvalidModule(
+            "WASM module too short (minimum 8 bytes)".into(),
+        ));
+    }
+
+    if &wasm_bytes[0..4] != &WASM_MAGIC {
+        return Err(WasmRegistryError::InvalidModule(
+            "Invalid WASM magic bytes".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// WASM Registry - stores WASM modules with metadata
+///
+/// Thread-safe with in-memory caching and optional persistent storage.
+pub struct WasmRegistry {
+    /// In-memory module cache
+    modules: Arc<RwLock<HashMap<WasmHash, Vec<u8>>>>,
+    /// In-memory metadata cache
+    metadata: Arc<RwLock<HashMap<WasmHash, WasmMetadata>>>,
+    /// Owner → modules index
+    owner_index: Arc<RwLock<HashMap<String, Vec<WasmHash>>>>,
+    /// Optional persistent store
+    store: Option<sled::Db>,
+}
+
+impl WasmRegistry {
+    /// Create a new in-memory registry
+    pub fn new() -> Self {
+        Self {
+            modules: Arc::new(RwLock::new(HashMap::new())),
+            metadata: Arc::new(RwLock::new(HashMap::new())),
+            owner_index: Arc::new(RwLock::new(HashMap::new())),
+            store: None,
+        }
+    }
+
+    /// Create a registry with persistent storage
+    pub fn with_store(db: sled::Db) -> Self {
+        Self {
+            modules: Arc::new(RwLock::new(HashMap::new())),
+            metadata: Arc::new(RwLock::new(HashMap::new())),
+            owner_index: Arc::new(RwLock::new(HashMap::new())),
+            store: Some(db),
+        }
+    }
+
+    /// Open a registry with persistent storage at the given path
+    pub fn open(path: impl AsRef<std::path::Path>) -> Result<Self> {
+        let db = sled::open(path).map_err(|e| WasmRegistryError::StorageError(e.to_string()))?;
+        Ok(Self::with_store(db))
+    }
+
+    /// Create a temporary in-memory registry (for testing)
+    pub fn temporary() -> Result<Self> {
+        let db = sled::Config::new()
+            .temporary(true)
+            .open()
+            .map_err(|e| WasmRegistryError::StorageError(e.to_string()))?;
+        Ok(Self::with_store(db))
+    }
+
+    /// Deploy a WASM module to the registry
+    ///
+    /// Returns the content hash on success.
+    pub async fn deploy(
+        &self,
+        wasm_bytes: Vec<u8>,
+        owner: &str,
+        metadata_builder: impl FnOnce(WasmMetadata) -> WasmMetadata,
+    ) -> Result<WasmHash> {
+        self.deploy_sync(wasm_bytes, owner, metadata_builder)
+    }
+
+    /// Deploy a WASM module to the registry (sync version)
+    ///
+    /// Returns the content hash on success.
+    pub fn deploy_sync(
+        &self,
+        wasm_bytes: Vec<u8>,
+        owner: &str,
+        metadata_builder: impl FnOnce(WasmMetadata) -> WasmMetadata,
+    ) -> Result<WasmHash> {
+        // Validate WASM
+        validate_wasm(&wasm_bytes)?;
+
+        let hash = compute_hash(&wasm_bytes);
+        let hash_hex = hex::encode(hash);
+
+        // Check if already exists
+        {
+            let modules = self.modules.read().map_err(|e| {
+                WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
+            })?;
+            if modules.contains_key(&hash) {
+                return Err(WasmRegistryError::AlreadyExists(hash_hex));
+            }
+        }
+
+        // Check persistent store
+        if let Some(store) = &self.store {
+            let key = format!("wasm:{hash_hex}");
+            if store
+                .contains_key(key.as_bytes())
+                .map_err(|e| WasmRegistryError::StorageError(e.to_string()))?
+            {
+                return Err(WasmRegistryError::AlreadyExists(hash_hex));
+            }
+        }
+
+        // Build metadata
+        let metadata = metadata_builder(WasmMetadata::new(&wasm_bytes, owner));
+
+        // Persist to store if available
+        if let Some(store) = &self.store {
+            let wasm_key = format!("wasm:{hash_hex}");
+            store
+                .insert(wasm_key.as_bytes(), wasm_bytes.as_slice())
+                .map_err(|e| WasmRegistryError::StorageError(e.to_string()))?;
+
+            let meta_key = format!("wasm_meta:{hash_hex}");
+            let meta_bytes = bincode::serialize(&metadata)
+                .map_err(|e| WasmRegistryError::SerializationError(e.to_string()))?;
+            store
+                .insert(meta_key.as_bytes(), meta_bytes)
+                .map_err(|e| WasmRegistryError::StorageError(e.to_string()))?;
+        }
+
+        // Update in-memory caches
+        {
+            let mut modules = self.modules.write().map_err(|e| {
+                WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
+            })?;
+            modules.insert(hash, wasm_bytes);
+        }
+        {
+            let mut meta_cache = self.metadata.write().map_err(|e| {
+                WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
+            })?;
+            meta_cache.insert(hash, metadata);
+        }
+        {
+            let mut owner_index = self.owner_index.write().map_err(|e| {
+                WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
+            })?;
+            owner_index.entry(owner.to_string()).or_default().push(hash);
+        }
+
+        tracing::info!(
+            hash = %hash_hex,
+            owner = %owner,
+            "WASM module deployed to registry"
+        );
+
+        Ok(hash)
+    }
+
+    /// Get WASM bytecode by hash (async wrapper)
+    pub async fn get(&self, hash: &WasmHash) -> Result<Option<Vec<u8>>> {
+        self.get_blocking(hash)
+    }
+
+    /// Get WASM bytecode by hash
+    ///
+    /// This is the main implementation, safe to call from both sync and async contexts.
+    pub fn get_blocking(&self, hash: &WasmHash) -> Result<Option<Vec<u8>>> {
+        // Check cache first
+        {
+            let modules = self.modules.read().map_err(|e| {
+                WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
+            })?;
+            if let Some(wasm) = modules.get(hash) {
+                return Ok(Some(wasm.clone()));
+            }
+        }
+
+        // Try persistent store
+        if let Some(store) = &self.store {
+            let key = format!("wasm:{}", hex::encode(hash));
+            if let Some(bytes) = store
+                .get(key.as_bytes())
+                .map_err(|e| WasmRegistryError::StorageError(e.to_string()))?
+            {
+                let wasm_bytes = bytes.to_vec();
+
+                // Populate cache
+                let mut modules = self.modules.write().map_err(|e| {
+                    WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
+                })?;
+                modules.insert(*hash, wasm_bytes.clone());
+
+                return Ok(Some(wasm_bytes));
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Get metadata by hash
+    pub async fn get_metadata(&self, hash: &WasmHash) -> Result<Option<WasmMetadata>> {
+        self.get_metadata_sync(hash)
+    }
+
+    /// Get metadata by hash (sync version)
+    pub fn get_metadata_sync(&self, hash: &WasmHash) -> Result<Option<WasmMetadata>> {
+        // Check cache first
+        {
+            let metadata = self.metadata.read().map_err(|e| {
+                WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
+            })?;
+            if let Some(meta) = metadata.get(hash) {
+                return Ok(Some(meta.clone()));
+            }
+        }
+
+        // Try persistent store
+        if let Some(store) = &self.store {
+            let key = format!("wasm_meta:{}", hex::encode(hash));
+            if let Some(bytes) = store
+                .get(key.as_bytes())
+                .map_err(|e| WasmRegistryError::StorageError(e.to_string()))?
+            {
+                let meta: WasmMetadata = bincode::deserialize(&bytes)
+                    .map_err(|e| WasmRegistryError::SerializationError(e.to_string()))?;
+
+                // Populate cache
+                let mut metadata = self.metadata.write().map_err(|e| {
+                    WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
+                })?;
+                metadata.insert(*hash, meta.clone());
+
+                return Ok(Some(meta));
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Check if a module exists
+    pub async fn exists(&self, hash: &WasmHash) -> bool {
+        self.exists_sync(hash)
+    }
+
+    /// Check if a module exists (sync version)
+    pub fn exists_sync(&self, hash: &WasmHash) -> bool {
+        let modules = self.modules.read().ok();
+        if let Some(modules) = modules {
+            if modules.contains_key(hash) {
+                return true;
+            }
+        }
+
+        if let Some(store) = &self.store {
+            let key = format!("wasm:{}", hex::encode(hash));
+            store.contains_key(key.as_bytes()).unwrap_or(false)
+        } else {
+            false
+        }
+    }
+
+    /// List modules by owner
+    pub async fn list_by_owner(&self, owner: &str) -> Result<Vec<WasmMetadata>> {
+        self.list_by_owner_sync(owner)
+    }
+
+    /// List modules by owner (sync version)
+    pub fn list_by_owner_sync(&self, owner: &str) -> Result<Vec<WasmMetadata>> {
+        let owner_index = self.owner_index.read().map_err(|e| {
+            WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
+        })?;
+        let metadata = self.metadata.read().map_err(|e| {
+            WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
+        })?;
+
+        if let Some(hashes) = owner_index.get(owner) {
+            Ok(hashes
+                .iter()
+                .filter_map(|h| metadata.get(h).cloned())
+                .collect())
+        } else {
+            Ok(vec![])
+        }
+    }
+
+    /// Get registry statistics
+    pub async fn stats(&self) -> WasmRegistryStats {
+        self.stats_sync()
+    }
+
+    /// Get registry statistics (sync version)
+    pub fn stats_sync(&self) -> WasmRegistryStats {
+        let modules = self.modules.read().ok();
+        let owner_index = self.owner_index.read().ok();
+
+        let (total_modules, total_bytes) = modules
+            .map(|m| (m.len(), m.values().map(|v| v.len()).sum()))
+            .unwrap_or((0, 0));
+
+        let unique_owners = owner_index.map(|o| o.len()).unwrap_or(0);
+
+        WasmRegistryStats {
+            total_modules,
+            total_bytes,
+            unique_owners,
+        }
+    }
+
+    /// Load modules from persistent store into cache
+    pub async fn load_from_store(&self) -> Result<usize> {
+        self.load_from_store_sync()
+    }
+
+    /// Load modules from persistent store into cache (sync version)
+    pub fn load_from_store_sync(&self) -> Result<usize> {
+        let Some(store) = &self.store else {
+            return Ok(0);
+        };
+
+        let mut loaded = 0;
+
+        // Scan for wasm keys
+        for item in store.scan_prefix(b"wasm:") {
+            let (key, value) = item.map_err(|e| WasmRegistryError::StorageError(e.to_string()))?;
+            let key_str = String::from_utf8_lossy(&key);
+
+            // Skip metadata keys
+            if key_str.starts_with("wasm_meta:") {
+                continue;
+            }
+
+            if let Some(hash_hex) = key_str.strip_prefix("wasm:") {
+                if let Ok(hash_bytes) = hex::decode(hash_hex) {
+                    if hash_bytes.len() == 32 {
+                        let mut hash = [0u8; 32];
+                        hash.copy_from_slice(&hash_bytes);
+
+                        let wasm_bytes = value.to_vec();
+
+                        // Load into cache
+                        {
+                            let mut modules = self.modules.write().map_err(|e| {
+                                WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
+                            })?;
+                            modules.insert(hash, wasm_bytes);
+                        }
+
+                        // Also load metadata
+                        let meta_key = format!("wasm_meta:{hash_hex}");
+                        if let Ok(Some(meta_bytes)) = store.get(meta_key.as_bytes()) {
+                            if let Ok(meta) = bincode::deserialize::<WasmMetadata>(&meta_bytes) {
+                                let mut metadata = self.metadata.write().map_err(|e| {
+                                    WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
+                                })?;
+                                metadata.insert(hash, meta.clone());
+
+                                // Rebuild owner index
+                                let mut owner_index = self.owner_index.write().map_err(|e| {
+                                    WasmRegistryError::StorageError(format!("Lock poisoned: {e}"))
+                                })?;
+                                owner_index.entry(meta.owner.clone()).or_default().push(hash);
+                            }
+                        }
+
+                        loaded += 1;
+                    }
+                }
+            }
+        }
+
+        tracing::info!(loaded = loaded, "Loaded WASM modules from persistent store");
+        Ok(loaded)
+    }
+}
+
+impl Default for WasmRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Registry statistics
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WasmRegistryStats {
+    pub total_modules: usize,
+    pub total_bytes: usize,
+    pub unique_owners: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_wasm() -> Vec<u8> {
+        // Minimal valid WASM module (just magic + version)
+        vec![
+            0x00, 0x61, 0x73, 0x6D, // magic: \0asm
+            0x01, 0x00, 0x00, 0x00, // version: 1
+        ]
+    }
+
+    #[tokio::test]
+    async fn test_deploy_and_get() {
+        let registry = WasmRegistry::new();
+        let wasm = sample_wasm();
+
+        let hash = registry
+            .deploy(wasm.clone(), "did:icn:owner", |m| m)
+            .await
+            .unwrap();
+
+        let retrieved = registry.get(&hash).await.unwrap().unwrap();
+        assert_eq!(retrieved, wasm);
+    }
+
+    #[tokio::test]
+    async fn test_get_metadata() {
+        let registry = WasmRegistry::new();
+        let wasm = sample_wasm();
+
+        let hash = registry
+            .deploy(wasm, "did:icn:alice", |m| {
+                m.with_name("test-module").with_description("Test WASM")
+            })
+            .await
+            .unwrap();
+
+        let meta = registry.get_metadata(&hash).await.unwrap().unwrap();
+        assert_eq!(meta.name, Some("test-module".to_string()));
+        assert_eq!(meta.description, Some("Test WASM".to_string()));
+        assert_eq!(meta.owner, "did:icn:alice");
+    }
+
+    #[tokio::test]
+    async fn test_duplicate_rejected() {
+        let registry = WasmRegistry::new();
+        let wasm = sample_wasm();
+
+        // First deploy succeeds
+        registry.deploy(wasm.clone(), "did:icn:owner", |m| m).await.unwrap();
+
+        // Second deploy fails
+        let result = registry.deploy(wasm, "did:icn:owner", |m| m).await;
+        assert!(matches!(result, Err(WasmRegistryError::AlreadyExists(_))));
+    }
+
+    #[tokio::test]
+    async fn test_invalid_wasm_rejected() {
+        let registry = WasmRegistry::new();
+        let invalid = vec![0x00, 0x00, 0x00, 0x00]; // Not valid WASM
+
+        let result = registry.deploy(invalid, "did:icn:owner", |m| m).await;
+        assert!(matches!(result, Err(WasmRegistryError::InvalidModule(_))));
+    }
+
+    #[tokio::test]
+    async fn test_not_found() {
+        let registry = WasmRegistry::new();
+        let fake_hash = [0xAA; 32];
+
+        let result = registry.get(&fake_hash).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_exists() {
+        let registry = WasmRegistry::new();
+        let wasm = sample_wasm();
+        let fake_hash = [0xAA; 32];
+
+        let hash = registry.deploy(wasm, "did:icn:owner", |m| m).await.unwrap();
+
+        assert!(registry.exists(&hash).await);
+        assert!(!registry.exists(&fake_hash).await);
+    }
+
+    #[tokio::test]
+    async fn test_list_by_owner() {
+        let registry = WasmRegistry::new();
+
+        // Deploy from owner1
+        let wasm1 = sample_wasm();
+        registry.deploy(wasm1, "did:icn:owner1", |m| m.with_name("mod1")).await.unwrap();
+
+        // Deploy from owner2 (different WASM to get different hash)
+        let mut wasm2 = sample_wasm();
+        wasm2.push(0x00); // Make it different
+        registry.deploy(wasm2, "did:icn:owner2", |m| m.with_name("mod2")).await.unwrap();
+
+        // List owner1's modules
+        let owner1_mods = registry.list_by_owner("did:icn:owner1").await.unwrap();
+        assert_eq!(owner1_mods.len(), 1);
+        assert_eq!(owner1_mods[0].name, Some("mod1".to_string()));
+
+        // List owner2's modules
+        let owner2_mods = registry.list_by_owner("did:icn:owner2").await.unwrap();
+        assert_eq!(owner2_mods.len(), 1);
+        assert_eq!(owner2_mods[0].name, Some("mod2".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_stats() {
+        let registry = WasmRegistry::new();
+        let wasm = sample_wasm();
+        let size = wasm.len();
+
+        registry.deploy(wasm, "did:icn:owner", |m| m).await.unwrap();
+
+        let stats = registry.stats().await;
+        assert_eq!(stats.total_modules, 1);
+        assert_eq!(stats.total_bytes, size);
+        assert_eq!(stats.unique_owners, 1);
+    }
+
+    #[tokio::test]
+    async fn test_persistent_storage() {
+        let registry = WasmRegistry::temporary().unwrap();
+        let wasm = sample_wasm();
+
+        let hash = registry.deploy(wasm.clone(), "did:icn:owner", |m| m).await.unwrap();
+
+        // Clear in-memory cache
+        {
+            let mut modules = registry.modules.write().unwrap();
+            modules.clear();
+        }
+
+        // Should still be retrievable from persistent store
+        let retrieved = registry.get(&hash).await.unwrap().unwrap();
+        assert_eq!(retrieved, wasm);
+    }
+
+    #[test]
+    fn test_compute_hash() {
+        let wasm = sample_wasm();
+        let hash1 = compute_hash(&wasm);
+        let hash2 = compute_hash(&wasm);
+
+        // Same input produces same hash
+        assert_eq!(hash1, hash2);
+
+        // Different input produces different hash
+        let mut different = wasm.clone();
+        different.push(0xFF);
+        let hash3 = compute_hash(&different);
+        assert_ne!(hash1, hash3);
+    }
+
+    #[test]
+    fn test_validate_wasm() {
+        // Valid WASM
+        let valid = sample_wasm();
+        assert!(validate_wasm(&valid).is_ok());
+
+        // Too short
+        let short = vec![0x00, 0x61];
+        assert!(validate_wasm(&short).is_err());
+
+        // Wrong magic
+        let wrong_magic = vec![0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x00, 0x00, 0x00];
+        assert!(validate_wasm(&wrong_magic).is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Implements Gap #12 (WASM Executor) - completes blob storage for WasmRef task code resolution:

- **WasmRegistry**: Content-addressed storage for WASM modules
  - `deploy()` stores WASM with blake3 hash as key
  - `get_blocking()` fetches WASM for sync executor context
  - Validates WASM magic bytes (`\0asm`)
  - Supports optional sled persistent storage with in-memory cache
  - Owner index for listing modules by deployer DID

- **WasmExecutor updates**: Resolves WasmRef from registry
  - Added `with_registry()` and `set_registry()` methods
  - WasmRef case now fetches from registry via `get_blocking()`
  - Uses `std::sync::RwLock` for both sync/async context safety

## Storage Schema

```
wasm:<hash>       → Vec<u8> (WASM bytecode)
wasm_meta:<hash>  → WasmMetadata (bincode)
wasm_owner:<did>  → Vec<[u8; 32]> (list of hashes)
```

## Test Plan

- [x] 13 WasmRegistry unit tests (deploy, get, metadata, persistence, validation)
- [x] 3 WasmExecutor tests for WasmRef resolution (no registry, not found, found)
- [x] All 115 icn-compute tests passing
- [x] Full workspace build succeeds

## Related Issues

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)