### PR TITLE
feat(sdk): add identity resolution and device management methods

### DIFF
--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -8967,7 +8967,7 @@ fn handle_api_command(cmd: ApiCommands) -> Result<()> {
                 "json" => doc
                     .to_json()
                     .context("Failed to serialize OpenAPI spec to JSON")?,
-                "yaml" | _ => doc
+                _ => doc
                     .to_yaml()
                     .context("Failed to serialize OpenAPI spec to YAML")?,
             };

--- a/icn/crates/icn-ccl/tests/contract_integration.rs
+++ b/icn/crates/icn-ccl/tests/contract_integration.rs
@@ -1,11 +1,7 @@
 //! CCL Contract Integration Tests
 //!
 //! These tests validate the full contract lifecycle:
-#![allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::cloned_ref_to_slice_refs
-)]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 //! 1. Contract creation and validation
 //! 2. Contract deployment to registry
 //! 3. Contract execution with rule invocation

--- a/icn/crates/icn-core/tests/fork_resolution_integration.rs
+++ b/icn/crates/icn-core/tests/fork_resolution_integration.rs
@@ -10,12 +10,7 @@
 //! - Fork resolution on partition heal
 //! - Balance invariant (sum=0) verification
 
-#![allow(
-    dead_code,
-    unused_imports,
-    unused_variables,
-    clippy::cloned_ref_to_slice_refs
-)]
+#![allow(dead_code, unused_imports, unused_variables)]
 
 use anyhow::Result;
 use icn_identity::{Did, KeyPair};

--- a/icn/crates/icn-core/tests/fork_resolution_integration.rs
+++ b/icn/crates/icn-core/tests/fork_resolution_integration.rs
@@ -242,7 +242,7 @@ async fn test_fork_resolution_maintains_ledger_invariants() -> Result<()> {
     info!("Genesis entry created: {:?}", hex::encode(genesis_hash.0));
 
     // Verify genesis balance invariant
-    verify_balance_invariant(&[genesis.clone()])?;
+    verify_balance_invariant(std::slice::from_ref(&genesis))?;
 
     // Simulate partition: Partition A (nodes 0,1) and Partition B (nodes 2,3)
 
@@ -591,8 +591,8 @@ async fn test_multicurrency_fork_invariants() -> Result<()> {
         .build()?;
 
     // Both entries together should maintain invariant
-    verify_balance_invariant(&[entry_hours.clone()])?;
-    verify_balance_invariant(&[entry_usd.clone()])?;
+    verify_balance_invariant(std::slice::from_ref(&entry_hours))?;
+    verify_balance_invariant(std::slice::from_ref(&entry_usd))?;
 
     // Even if both are accepted (no actual fork - different currencies)
     verify_balance_invariant(&[entry_hours, entry_usd])?;

--- a/icn/crates/icn-gateway/src/api/budgets.rs
+++ b/icn/crates/icn-gateway/src/api/budgets.rs
@@ -6,8 +6,8 @@ use actix_web::{delete, get, post, put, web, HttpRequest, HttpResponse};
 use icn_identity::Did;
 pub use icn_store::budgets::{Budget, BudgetPeriod, BudgetStatus, BudgetStore};
 use serde::Deserialize;
-use utoipa::ToSchema;
 use std::collections::HashMap;
+use utoipa::ToSchema;
 
 use crate::error::{GatewayError, Result};
 use crate::middleware::{get_claims, require_scope};

--- a/icn/crates/icn-gateway/src/api/commons/anchor.rs
+++ b/icn/crates/icn-gateway/src/api/commons/anchor.rs
@@ -7,9 +7,9 @@
 
 use actix_web::{get, post, put, web, HttpRequest, HttpResponse};
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 use std::sync::Arc;
 use tracing::warn;
+use utoipa::ToSchema;
 
 use crate::commons_mgr::CommonsManager;
 use crate::error::{GatewayError, Result};

--- a/icn/crates/icn-gateway/src/api/commons/mod.rs
+++ b/icn/crates/icn-gateway/src/api/commons/mod.rs
@@ -9,8 +9,8 @@ pub mod anchor;
 
 use actix_web::{delete, get, post, put, web, HttpRequest, HttpResponse};
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 use std::sync::Arc;
+use utoipa::ToSchema;
 
 use crate::commons_mgr::CommonsManager;
 use crate::error::{GatewayError, Result};

--- a/icn/crates/icn-gateway/src/api/constitutional/appeals_ui.rs
+++ b/icn/crates/icn-gateway/src/api/constitutional/appeals_ui.rs
@@ -6,8 +6,8 @@ use actix_web::{get, post, web, HttpRequest, HttpResponse};
 use icn_governance::{Appeal, AppealId, AppealStatus};
 use icn_identity::Did;
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 use std::sync::Arc;
+use utoipa::ToSchema;
 
 use crate::commons_mgr::CommonsManager;
 use crate::error::{GatewayError, Result};

--- a/icn/crates/icn-gateway/src/api/constitutional/mod.rs
+++ b/icn/crates/icn-gateway/src/api/constitutional/mod.rs
@@ -40,8 +40,8 @@ pub mod voting;
 
 use actix_web::{get, post, web, HttpRequest, HttpResponse};
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 use std::sync::Arc;
+use utoipa::ToSchema;
 
 use crate::commons_mgr::CommonsManager;
 use crate::error::{GatewayError, Result};

--- a/icn/crates/icn-gateway/src/api/constitutional/voting.rs
+++ b/icn/crates/icn-gateway/src/api/constitutional/voting.rs
@@ -6,8 +6,8 @@
 
 use actix_web::{get, post, web, HttpRequest, HttpResponse};
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 use std::sync::Arc;
+use utoipa::ToSchema;
 
 use crate::commons_mgr::CommonsManager;
 use crate::error::{GatewayError, Result};

--- a/icn/crates/icn-gateway/src/api/escrow.rs
+++ b/icn/crates/icn-gateway/src/api/escrow.rs
@@ -6,10 +6,10 @@ use actix_web::{get, post, web, HttpRequest, HttpResponse};
 use icn_identity::Did;
 pub use icn_store::escrow::{Escrow, EscrowCondition, EscrowStatus, EscrowStore};
 use serde::Deserialize;
-use utoipa::ToSchema;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::{info, warn};
+use utoipa::ToSchema;
 
 use crate::error::{GatewayError, Result};
 use crate::ledger_mgr::LedgerManager;

--- a/icn/crates/icn-gateway/src/api/federation.rs
+++ b/icn/crates/icn-gateway/src/api/federation.rs
@@ -4,8 +4,8 @@
 
 use actix_web::{get, post, web, HttpRequest, HttpResponse};
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 use std::sync::Arc;
+use utoipa::ToSchema;
 
 use crate::error::{GatewayError, Result};
 use crate::federation_mgr::FederationManager;

--- a/icn/crates/icn-gateway/src/api/identity.rs
+++ b/icn/crates/icn-gateway/src/api/identity.rs
@@ -5,8 +5,8 @@
 
 use actix_web::{get, web, HttpResponse};
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 use std::sync::Arc;
+use utoipa::ToSchema;
 
 use crate::error::{GatewayError, Result};
 use crate::federation_mgr::FederationManager;

--- a/icn/crates/icn-gateway/src/api/members.rs
+++ b/icn/crates/icn-gateway/src/api/members.rs
@@ -2,8 +2,8 @@
 
 use actix_web::{get, web, HttpRequest, HttpResponse};
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 use std::sync::Arc;
+use utoipa::ToSchema;
 
 use crate::commons_mgr::CommonsManager;
 use crate::coop::{CoopManager, MemberRole};

--- a/icn/crates/icn-gateway/src/api/recurring_payments.rs
+++ b/icn/crates/icn-gateway/src/api/recurring_payments.rs
@@ -8,10 +8,10 @@ pub use icn_store::recurring_payments::{
     PaymentFrequency, RecurringPayment, RecurringPaymentStore, RecurringStatus,
 };
 use serde::Deserialize;
-use utoipa::ToSchema;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
+use utoipa::ToSchema;
 
 use crate::error::{GatewayError, Result};
 use crate::ledger_mgr::LedgerManager;

--- a/icn/crates/icn-gateway/src/api/sdis/anchor.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/anchor.rs
@@ -13,8 +13,8 @@
 
 use actix_web::{get, post, web, HttpResponse};
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 use std::sync::Arc;
+use utoipa::ToSchema;
 use uuid::Uuid;
 
 use super::enrollment::{AnchorDto, EnrollmentPathwayDto, KeyBundleDto};

--- a/icn/crates/icn-gateway/src/api/sdis/enrollment.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/enrollment.rs
@@ -13,8 +13,8 @@
 
 use actix_web::{get, post, web, HttpResponse};
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 use std::sync::Arc;
+use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::error::{GatewayError, Result};

--- a/icn/crates/icn-gateway/src/api/sdis/ephemeral.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/ephemeral.rs
@@ -13,9 +13,9 @@ use icn_identity::KeyBundle;
 use icn_zkp::ProofType;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 use std::time::Duration;
 use thiserror::Error;
+use utoipa::ToSchema;
 
 /// Epoch for relative timestamps (2024-01-01 00:00:00 UTC)
 pub const EPOCH_2024: u64 = 1704067200;

--- a/icn/crates/icn-gateway/src/api/sdis/mod.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/mod.rs
@@ -46,8 +46,8 @@ pub mod verify;
 
 use actix_web::{get, post, web, HttpResponse};
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 use std::sync::Arc;
+use utoipa::ToSchema;
 
 use crate::error::{GatewayError, Result};
 pub use ephemeral::{Channel, EphemeralBinding, EphemeralProof, VerifyResult};

--- a/icn/crates/icn-gateway/src/api/sdis/recovery.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/recovery.rs
@@ -13,8 +13,8 @@
 
 use actix_web::{get, post, web, HttpResponse};
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 use std::sync::Arc;
+use utoipa::ToSchema;
 use uuid::Uuid;
 
 use super::enrollment::KeyBundleDto;

--- a/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
@@ -11,9 +11,9 @@ use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use icn_identity::commons::{JurisdictionId, MembershipCapability};
 use icn_identity::Did;
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::auth::AuthManager;

--- a/icn/crates/icn-gateway/src/api/trust.rs
+++ b/icn/crates/icn-gateway/src/api/trust.rs
@@ -2,8 +2,8 @@
 
 use actix_web::{get, post, web, HttpResponse};
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 use std::sync::Arc;
+use utoipa::ToSchema;
 
 use crate::error::{GatewayError, Result};
 use crate::events::{EventBroadcaster, GatewayEvent};

--- a/icn/crates/icn-gateway/src/openapi.rs
+++ b/icn/crates/icn-gateway/src/openapi.rs
@@ -7,40 +7,42 @@ use utoipa::OpenApi;
 // Re-export models for schema registration
 use crate::models::{
     AccountDeltaResponse, AddMemberRequest, BalanceResponse, CastVoteRequest, ChallengeRequest,
-    ChallengeResponse, ComponentHealth, CreateCoopRequest, CreateDomainRequest, CreateInviteRequest,
-    CreatePaymentRequest, CreateProposalRequest, CreateSessionRequest, CreateSessionResponse,
-    HealthResponse, InviteInfo, InviteListResponse, InviteResponse, JoinRequest, JoinResponse,
-    OpenProposalRequest, PaginationInfo, ProposalPayloadRequest, SessionQrData, SessionStatusResponse,
-    TokenResponse, TransactionHistoryEntry, TransactionHistoryResponse, UpdateRoleRequest,
-    UpdateSettingsRequest, VerifyRequest, VoteChoiceResponse,
+    ChallengeResponse, ComponentHealth, CreateCoopRequest, CreateDomainRequest,
+    CreateInviteRequest, CreatePaymentRequest, CreateProposalRequest, CreateSessionRequest,
+    CreateSessionResponse, HealthResponse, InviteInfo, InviteListResponse, InviteResponse,
+    JoinRequest, JoinResponse, OpenProposalRequest, PaginationInfo, ProposalPayloadRequest,
+    SessionQrData, SessionStatusResponse, TokenResponse, TransactionHistoryEntry,
+    TransactionHistoryResponse, UpdateRoleRequest, UpdateSettingsRequest, VerifyRequest,
+    VoteChoiceResponse,
 };
 
 // API module types
-use crate::api::membership::{
-    ApplyMembershipRequest, MembershipActionRequest, CapabilityRequest, RoleRequest,
-    BanMemberRequest, RevokeMembershipRequest, MemberResponse,
-};
 use crate::api::charter::{
-    CharterSummaryResponse, CharterDetailResponse, FounderResponse, CreateCharterRequest,
-    SignCharterRequest, UpdateCharterStatusRequest, FounderDetailResponse, FoundersResponse,
-    TimelineEvent, TimelineResponse,
-};
-use crate::api::steward::{
-    StewardSummaryResponse, StewardDetailResponse, RegisterStewardRequest, UpdateStatusRequest,
-    ExtendTermRequest, BondOperationRequest,
-};
-use crate::api::governance_dashboard::{
-    GovernanceDashboard, AmendmentsBreakdown, AppealsBreakdown, ActivityEvent,
+    CharterDetailResponse, CharterSummaryResponse, CreateCharterRequest, FounderDetailResponse,
+    FounderResponse, FoundersResponse, SignCharterRequest, TimelineEvent, TimelineResponse,
+    UpdateCharterStatusRequest,
 };
 use crate::api::devices::{
-    ApiRegisterDeviceRequest, ApiRevokeDeviceRequest, ApiRegisterDeviceResponse, ApiListDevicesResponse,
+    ApiListDevicesResponse, ApiRegisterDeviceRequest, ApiRegisterDeviceResponse,
+    ApiRevokeDeviceRequest,
+};
+use crate::api::governance_dashboard::{
+    ActivityEvent, AmendmentsBreakdown, AppealsBreakdown, GovernanceDashboard,
+};
+use crate::api::membership::{
+    ApplyMembershipRequest, BanMemberRequest, CapabilityRequest, MemberResponse,
+    MembershipActionRequest, RevokeMembershipRequest, RoleRequest,
 };
 use crate::api::notifications::{
+    ListNotificationsResponse, MarkReadResponse, NotificationCountResponse,
     RegisterDeviceRequest as NotifRegisterDeviceRequest, RegisterDeviceResponse,
-    ListNotificationsResponse, NotificationCountResponse, MarkReadResponse,
+};
+use crate::api::steward::{
+    BondOperationRequest, ExtendTermRequest, RegisterStewardRequest, StewardDetailResponse,
+    StewardSummaryResponse, UpdateStatusRequest,
 };
 use crate::identity_mgr::DeviceInfo;
-use icn_store::notifications::{Platform, InAppNotification};
+use icn_store::notifications::{InAppNotification, Platform};
 
 /// OpenAPI documentation for ICN Gateway
 #[derive(OpenApi)]

--- a/icn/crates/icn-gateway/src/rate_limit.rs
+++ b/icn/crates/icn-gateway/src/rate_limit.rs
@@ -639,8 +639,7 @@ impl VelocityLimiter {
             );
             gateway::velocity_limit_exceeded_inc();
             return Err(GatewayError::RateLimitExceeded(format!(
-                "Transaction velocity limit exceeded: {} transactions/hour (limit: {})",
-                current_count, limit
+                "Transaction velocity limit exceeded: {current_count} transactions/hour (limit: {limit})"
             )));
         }
 

--- a/icn/crates/icn-gateway/src/rate_limit.rs
+++ b/icn/crates/icn-gateway/src/rate_limit.rs
@@ -528,10 +528,10 @@ pub struct VelocityLimitConfig {
 impl Default for VelocityLimitConfig {
     fn default() -> Self {
         Self {
-            isolated_limit: 10,    // Very conservative for unknown users
-            known_limit: 50,       // Moderate for known users
-            partner_limit: 100,    // Higher for trusted partners
-            federated_limit: 200,  // Highest for federated nodes
+            isolated_limit: 10,                // Very conservative for unknown users
+            known_limit: 50,                   // Moderate for known users
+            partner_limit: 100,                // Higher for trusted partners
+            federated_limit: 200,              // Highest for federated nodes
             window: Duration::from_secs(3600), // 1 hour window
         }
     }

--- a/icn/crates/icn-gossip/src/gossip.rs
+++ b/icn/crates/icn-gossip/src/gossip.rs
@@ -46,7 +46,7 @@ fn topics_per_peer_limit(trust_class: Option<TrustClass>) -> usize {
     match trust_class {
         Some(TrustClass::Federated) => MAX_TOPICS_PER_PEER_BASE * 4, // 400 topics
         Some(TrustClass::Partner) => MAX_TOPICS_PER_PEER_BASE * 2,   // 200 topics
-        Some(TrustClass::Known) => MAX_TOPICS_PER_PEER_BASE,          // 100 topics
+        Some(TrustClass::Known) => MAX_TOPICS_PER_PEER_BASE,         // 100 topics
         Some(TrustClass::Isolated) | None => MAX_TOPICS_PER_PEER_BASE / 2, // 50 topics
     }
 }
@@ -2008,7 +2008,10 @@ mod tests {
         assert_eq!(subs.len(), 50, "Should have 50 subscriptions");
 
         // 51st subscription should fail
-        gossip.create_topic(Topic::new("test:topic_50".to_string(), AccessControl::Public));
+        gossip.create_topic(Topic::new(
+            "test:topic_50".to_string(),
+            AccessControl::Public,
+        ));
         let result = gossip.subscribe("test:topic_50", peer.clone());
         assert!(result.is_err(), "51st subscription should fail");
         assert!(
@@ -2052,7 +2055,11 @@ mod tests {
 
         // Verify peer has 100 subscriptions (well under 400 limit)
         let subs = gossip.get_subscriptions(&peer);
-        assert_eq!(subs.len(), 100, "Federated peer should have 100 subscriptions");
+        assert_eq!(
+            subs.len(),
+            100,
+            "Federated peer should have 100 subscriptions"
+        );
     }
 
     #[test]

--- a/icn/crates/icn-gossip/src/handlers/pull.rs
+++ b/icn/crates/icn-gossip/src/handlers/pull.rs
@@ -6,7 +6,9 @@
 
 use crate::bloom::BloomFilter;
 use crate::gossip::GossipActor;
-use crate::types::{BloomFilterData, ContentHash, GossipEntry, GossipMessage, SyncCursor, TrustResourceLimits};
+use crate::types::{
+    BloomFilterData, ContentHash, GossipEntry, GossipMessage, SyncCursor, TrustResourceLimits,
+};
 use crate::vector_clock::VectorClock;
 use anyhow::Result;
 use icn_identity::Did;
@@ -176,9 +178,15 @@ impl GossipActor {
         // Validate cursor if provided
         if let Some(ref c) = cursor {
             if c.is_expired() {
-                warn!("Received expired cursor for topic {}, ignoring cursor", topic);
+                warn!(
+                    "Received expired cursor for topic {}, ignoring cursor",
+                    topic
+                );
             } else if c.topic != topic {
-                warn!("Cursor topic mismatch: {} vs {}, ignoring cursor", c.topic, topic);
+                warn!(
+                    "Cursor topic mismatch: {} vs {}, ignoring cursor",
+                    c.topic, topic
+                );
             }
         }
 
@@ -194,7 +202,9 @@ impl GossipActor {
         // Sort entries deterministically for pagination (by timestamp, then hash)
         let mut sorted_entries: Vec<_> = topic_entries.values().cloned().collect();
         sorted_entries.sort_by(|a, b| {
-            a.timestamp.cmp(&b.timestamp).then_with(|| a.hash.cmp(&b.hash))
+            a.timestamp
+                .cmp(&b.timestamp)
+                .then_with(|| a.hash.cmp(&b.hash))
         });
 
         // Find starting position from cursor
@@ -246,9 +256,9 @@ impl GossipActor {
         // Determine if there are more entries and create cursor
         let has_more = last_entry_index + 1 < sorted_entries.len() && !response_entries.is_empty();
         let next_cursor = if has_more {
-            sorted_entries.get(last_entry_index).map(|e| {
-                SyncCursor::new(last_entry_index as u64, e.hash, topic.clone())
-            })
+            sorted_entries
+                .get(last_entry_index)
+                .map(|e| SyncCursor::new(last_entry_index as u64, e.hash, topic.clone()))
         } else {
             None
         };

--- a/icn/crates/icn-gossip/src/lib.rs
+++ b/icn/crates/icn-gossip/src/lib.rs
@@ -63,7 +63,7 @@ pub use partition::{
 pub use scalability::{CompressedVectorClock, ShardStats, ShardedTopic, TopicShard, VarInt};
 pub use sync::{Backoff, PeerSyncManager, PeerSyncState};
 pub use types::{
-    AccessControl, ContentHash, GossipEntry, GossipMessage, Scope, Subscription, SyncCursor,
-    Topic, TrustResourceLimits,
+    AccessControl, ContentHash, GossipEntry, GossipMessage, Scope, Subscription, SyncCursor, Topic,
+    TrustResourceLimits,
 };
 pub use vector_clock::VectorClock;

--- a/icn/crates/icn-identity/src/commons_store.rs
+++ b/icn/crates/icn-identity/src/commons_store.rs
@@ -644,8 +644,11 @@ mod tests {
         store.store(&holder1).unwrap();
 
         // Create and suspend another holder
-        let mut holder2 =
-            CommonsHolderRecord::new([2u8; 32], TEST_DID_2.parse().expect("valid DID"), POPLevel::Strong);
+        let mut holder2 = CommonsHolderRecord::new(
+            [2u8; 32],
+            TEST_DID_2.parse().expect("valid DID"),
+            POPLevel::Strong,
+        );
         holder2.suspend("test".to_string(), 9999999999);
         store.store(&holder2).unwrap();
 
@@ -764,8 +767,11 @@ mod tests {
 
         store.store(&create_test_holder()).unwrap();
 
-        let holder2 =
-            CommonsHolderRecord::new([2u8; 32], TEST_DID_2.parse().expect("valid DID"), POPLevel::Strong);
+        let holder2 = CommonsHolderRecord::new(
+            [2u8; 32],
+            TEST_DID_2.parse().expect("valid DID"),
+            POPLevel::Strong,
+        );
         store.store(&holder2).unwrap();
 
         assert_eq!(store.count().unwrap(), 2);

--- a/icn/crates/icn-identity/src/personhood.rs
+++ b/icn/crates/icn-identity/src/personhood.rs
@@ -376,6 +376,8 @@ impl PersonhoodAnchor {
         let now = icn_time::current_timestamp_secs();
 
         // Create a genesis attestation using well-known genesis issuer
+        // SAFETY: GENESIS_ISSUER_DID is a compile-time constant that is always valid
+        #[allow(clippy::expect_used)]
         let genesis_issuer: Did = Self::GENESIS_ISSUER_DID
             .parse()
             .expect("Genesis issuer DID is valid");

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -2045,11 +2045,7 @@ impl Ledger {
                     );
                     icn_obs::metrics::ledger::entries_rejected_credit_limit_inc();
                     anyhow::bail!(
-                        "Account {} would exceed credit limit for {}: new balance {} < -{}",
-                        account,
-                        currency,
-                        new_balance,
-                        calculated_limit
+                        "Account {account} would exceed credit limit for {currency}: new balance {new_balance} < -{calculated_limit}"
                     );
                 }
             }

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -151,10 +151,10 @@ impl Ledger {
             trust_graph: None,
             min_trust_for_entry: DEFAULT_MIN_TRUST_FOR_ENTRY,
             journal_version,
-            event_emitter: None,           // Set via set_event_emitter()
-            domain_id: None,               // Set via set_domain_id()
-            validation_hook: None,         // Set via set_validation_hook()
-            credit_policy_manager: None,   // Set via set_credit_policy_manager()
+            event_emitter: None,         // Set via set_event_emitter()
+            domain_id: None,             // Set via set_domain_id()
+            validation_hook: None,       // Set via set_validation_hook()
+            credit_policy_manager: None, // Set via set_credit_policy_manager()
         };
 
         // Load cached balances from storage
@@ -2025,9 +2025,9 @@ impl Ledger {
                 let base_policy = &policy_manager.credit_policy;
 
                 // Calculate: baseline + trust_bonus + history_bonus
-                let trust_bonus =
-                    (base_policy.baseline as f64 * trust_score * base_policy.trust_multiplier)
-                        as i64;
+                let trust_bonus = (base_policy.baseline as f64
+                    * trust_score
+                    * base_policy.trust_multiplier) as i64;
                 let history_bonus = (cleared_volume as f64 * base_policy.history_bonus_rate) as i64;
                 let calculated_limit = base_policy.baseline + trust_bonus + history_bonus;
 

--- a/icn/crates/icn-net/src/protocol.rs
+++ b/icn/crates/icn-net/src/protocol.rs
@@ -401,8 +401,8 @@ impl NetworkMessage {
 
         // Only compress if enabled, above threshold, and would reduce size
         if enable_compression && raw_bytes.len() >= COMPRESSION_THRESHOLD {
-            let compressed = zstd::encode_all(raw_bytes.as_slice(), 3)
-                .context("Failed to compress message")?;
+            let compressed =
+                zstd::encode_all(raw_bytes.as_slice(), 3).context("Failed to compress message")?;
 
             // Only use compression if it actually reduces size
             if compressed.len() < raw_bytes.len() {
@@ -602,7 +602,9 @@ pub async fn read_message(recv: &mut quinn::RecvStream) -> Result<(NetworkMessag
 /// Helper for reading length-prefixed messages with compression support
 /// Use this for peers that support MESSAGE_COMPRESSION capability.
 /// Returns the message and the number of bytes read (including 4-byte length prefix)
-pub async fn read_message_compressed(recv: &mut quinn::RecvStream) -> Result<(NetworkMessage, usize)> {
+pub async fn read_message_compressed(
+    recv: &mut quinn::RecvStream,
+) -> Result<(NetworkMessage, usize)> {
     // Read 4-byte length prefix (big-endian)
     let mut len_buf = [0u8; 4];
     recv.read_exact(&mut len_buf)
@@ -1010,8 +1012,14 @@ mod tests {
 
     #[test]
     fn test_compression_format_conversion() {
-        assert_eq!(CompressionFormat::try_from(0).unwrap(), CompressionFormat::None);
-        assert_eq!(CompressionFormat::try_from(1).unwrap(), CompressionFormat::Zstd);
+        assert_eq!(
+            CompressionFormat::try_from(0).unwrap(),
+            CompressionFormat::None
+        );
+        assert_eq!(
+            CompressionFormat::try_from(1).unwrap(),
+            CompressionFormat::Zstd
+        );
         assert!(CompressionFormat::try_from(2).is_err());
         assert!(CompressionFormat::try_from(255).is_err());
     }

--- a/icn/crates/icn-net/src/protocol.rs
+++ b/icn/crates/icn-net/src/protocol.rs
@@ -41,7 +41,7 @@ impl TryFrom<u8> for CompressionFormat {
         match value {
             0 => Ok(CompressionFormat::None),
             1 => Ok(CompressionFormat::Zstd),
-            _ => anyhow::bail!("Unknown compression format: {}", value),
+            _ => anyhow::bail!("Unknown compression format: {value}"),
         }
     }
 }

--- a/sdk/typescript/src/index.test.ts
+++ b/sdk/typescript/src/index.test.ts
@@ -1730,3 +1730,285 @@ describe('amendment voting', () => {
     expect(url).toBe('http://localhost:8080/v1/constitutional/amendments/abc123def456/my-vote');
   });
 });
+
+describe('identity resolution', () => {
+  it('should resolve a DID without attestations', async () => {
+    const mockResponse = {
+      did: 'did:icn:abc123',
+      valid: true,
+      coop_id: 'my-coop',
+      has_attestations: false,
+    };
+
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockResponse,
+    });
+
+    const client = new ICNClient({
+      baseUrl: 'http://localhost:8080',
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    const result = await client.resolveDid('did:icn:abc123');
+
+    expect(result.valid).toBe(true);
+    expect(result.did).toBe('did:icn:abc123');
+    expect(result.coop_id).toBe('my-coop');
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:8080/v1/identity/resolve/did%3Aicn%3Aabc123');
+    expect(options.headers['Authorization']).toBeUndefined(); // Public endpoint
+  });
+
+  it('should resolve a DID with attestations included', async () => {
+    const mockResponse = {
+      did: 'did:icn:abc123',
+      valid: true,
+      coop_id: 'my-coop',
+      has_attestations: true,
+      attestation_count: 3,
+    };
+
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockResponse,
+    });
+
+    const client = new ICNClient({
+      baseUrl: 'http://localhost:8080',
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    const result = await client.resolveDid('did:icn:abc123', true);
+
+    expect(result.has_attestations).toBe(true);
+    expect(result.attestation_count).toBe(3);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:8080/v1/identity/resolve/did%3Aicn%3Aabc123?include_attestations=true');
+  });
+
+  it('should check identity service health', async () => {
+    const mockResponse = {
+      status: 'ok',
+      service: 'identity',
+    };
+
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockResponse,
+    });
+
+    const client = new ICNClient({
+      baseUrl: 'http://localhost:8080',
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    const result = await client.identityHealth();
+
+    expect(result.status).toBe('ok');
+    expect(result.service).toBe('identity');
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:8080/v1/identity/health');
+    expect(options.headers['Authorization']).toBeUndefined(); // Public endpoint
+  });
+});
+
+describe('device management', () => {
+  it('should register a new device', async () => {
+    const mockResponse = {
+      device: {
+        id: 'phone-2',
+        label: 'My iPhone',
+        key_type: 'Ed25519',
+        capabilities: ['sign', 'encrypt'],
+        added_at: 1700000000,
+        revoked: false,
+      },
+      message: 'Device registered successfully',
+    };
+
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => mockResponse,
+    });
+
+    const client = new ICNClient({
+      baseUrl: 'http://localhost:8080',
+      token: 'test-token',
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    const result = await client.registerDevice('did:icn:alice', {
+      device_id: 'phone-2',
+      label: 'My iPhone',
+      public_key: 'deadbeef...',
+      capabilities: ['sign', 'encrypt'],
+      signing_device_id: 'device-1',
+      signature: 'cafebabe...',
+    });
+
+    expect(result.device.id).toBe('phone-2');
+    expect(result.device.capabilities).toContain('sign');
+    expect(result.message).toBe('Device registered successfully');
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:8080/v1/devices/did%3Aicn%3Aalice');
+    expect(options.method).toBe('POST');
+    expect(options.headers['Authorization']).toBe('Bearer test-token');
+    const body = JSON.parse(options.body);
+    expect(body.device_id).toBe('phone-2');
+    expect(body.signing_device_id).toBe('device-1');
+  });
+
+  it('should list all devices for a DID', async () => {
+    const mockResponse = {
+      devices: [
+        {
+          id: 'device-1',
+          label: 'Primary Device',
+          key_type: 'Ed25519',
+          capabilities: ['sign', 'add_device', 'revoke_device'],
+          added_at: 1699000000,
+          revoked: false,
+        },
+        {
+          id: 'phone-1',
+          label: 'Mobile Phone',
+          key_type: 'Ed25519',
+          capabilities: ['sign'],
+          added_at: 1700000000,
+          revoked: false,
+        },
+      ],
+      total: 2,
+    };
+
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockResponse,
+    });
+
+    const client = new ICNClient({
+      baseUrl: 'http://localhost:8080',
+      token: 'test-token',
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    const result = await client.listDevices('did:icn:alice');
+
+    expect(result.total).toBe(2);
+    expect(result.devices).toHaveLength(2);
+    expect(result.devices[0].id).toBe('device-1');
+    expect(result.devices[1].id).toBe('phone-1');
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:8080/v1/devices/did%3Aicn%3Aalice');
+  });
+
+  it('should get a specific device by ID', async () => {
+    const mockResponse = {
+      id: 'phone-1',
+      label: 'Mobile Phone',
+      key_type: 'Ed25519',
+      capabilities: ['sign', 'encrypt'],
+      added_at: 1700000000,
+      revoked: false,
+    };
+
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockResponse,
+    });
+
+    const client = new ICNClient({
+      baseUrl: 'http://localhost:8080',
+      token: 'test-token',
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    const result = await client.getDevice('did:icn:alice', 'phone-1');
+
+    expect(result.id).toBe('phone-1');
+    expect(result.capabilities).toContain('sign');
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:8080/v1/devices/did%3Aicn%3Aalice/phone-1');
+  });
+
+  it('should revoke a device', async () => {
+    const mockResponse = {
+      message: 'Device revoked successfully',
+      device_id: 'phone-old',
+    };
+
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockResponse,
+    });
+
+    const client = new ICNClient({
+      baseUrl: 'http://localhost:8080',
+      token: 'test-token',
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    const result = await client.revokeDevice('did:icn:alice', 'phone-old', {
+      signing_device_id: 'device-1',
+      signature: 'cafebabe...',
+    });
+
+    expect(result.message).toBe('Device revoked successfully');
+    expect(result.device_id).toBe('phone-old');
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:8080/v1/devices/did%3Aicn%3Aalice/phone-old');
+    expect(options.method).toBe('DELETE');
+    const body = JSON.parse(options.body);
+    expect(body.signing_device_id).toBe('device-1');
+    expect(body.signature).toBe('cafebabe...');
+  });
+
+  it('should handle device registration with encryption key', async () => {
+    const mockResponse = {
+      device: {
+        id: 'phone-3',
+        label: 'Encrypted Device',
+        key_type: 'Ed25519',
+        capabilities: ['sign', 'encrypt'],
+        added_at: 1700000000,
+        revoked: false,
+      },
+      message: 'Device registered successfully',
+    };
+
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => mockResponse,
+    });
+
+    const client = new ICNClient({
+      baseUrl: 'http://localhost:8080',
+      token: 'test-token',
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    const result = await client.registerDevice('did:icn:alice', {
+      device_id: 'phone-3',
+      label: 'Encrypted Device',
+      public_key: 'deadbeef...',
+      encryption_public_key: 'cafebabe...',
+      capabilities: ['sign', 'encrypt'],
+      signing_device_id: 'device-1',
+      signature: 'signature...',
+    });
+
+    expect(result.device.id).toBe('phone-3');
+    const [, options] = mockFetch.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.encryption_public_key).toBe('cafebabe...');
+  });
+});

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -95,6 +95,15 @@ import {
   AddEvidenceRequest,
   AddResponseRequest,
   ResolveAppealRequest,
+  // Identity and device types
+  DidResolutionResponse,
+  IdentityHealthResponse,
+  DeviceInfo,
+  RegisterDeviceRequest,
+  RegisterDeviceResponse,
+  ListDevicesResponse,
+  RevokeDeviceRequest,
+  RevokeDeviceResponse,
 } from './types';
 
 export * from './types';
@@ -332,8 +341,8 @@ export class ICNClient {
     return this.request<T>('PUT', path, body, requireAuth);
   }
 
-  private delete<T>(path: string, requireAuth = true): Promise<T> {
-    return this.request<T>('DELETE', path, undefined, requireAuth);
+  private delete<T>(path: string, body?: unknown, requireAuth = true): Promise<T> {
+    return this.request<T>('DELETE', path, body, requireAuth);
   }
 
   // ===========================================================================
@@ -1212,6 +1221,142 @@ export class ICNClient {
    */
   async withdrawAppeal(appealId: string, reason?: string): Promise<Appeal> {
     return this.post<Appeal>(`/constitutional/appeals/${appealId}/withdraw`, { reason });
+  }
+
+  // ===========================================================================
+  // Identity Resolution
+  // ===========================================================================
+
+  /**
+   * Resolve a DID and check if it's valid
+   *
+   * This is a PUBLIC endpoint that allows verification of DIDs.
+   *
+   * @param did - The DID to resolve
+   * @param includeAttestations - Whether to include attestation details
+   * @returns DID resolution response with validity and attestation info
+   *
+   * @example
+   * ```typescript
+   * const result = await client.resolveDid('did:icn:abc123');
+   * if (result.valid) {
+   *   console.log('DID is valid, belongs to coop:', result.coop_id);
+   * }
+   * ```
+   */
+  async resolveDid(did: string, includeAttestations?: boolean): Promise<DidResolutionResponse> {
+    const query = includeAttestations ? '?include_attestations=true' : '';
+    return this.get<DidResolutionResponse>(`/identity/resolve/${encodeURIComponent(did)}${query}`, false);
+  }
+
+  /**
+   * Check identity service health
+   *
+   * @returns Health status of the identity service
+   */
+  async identityHealth(): Promise<IdentityHealthResponse> {
+    return this.get<IdentityHealthResponse>('/identity/health', false);
+  }
+
+  // ===========================================================================
+  // Device Management
+  // ===========================================================================
+
+  /**
+   * Register a new device for a DID
+   *
+   * Adds a new device to the authenticated user's DID document.
+   * The request must be signed by an existing device with AddDevice capability.
+   *
+   * @param did - The DID to register the device for (must match authenticated user)
+   * @param req - Device registration request
+   * @returns The registered device info
+   *
+   * @example
+   * ```typescript
+   * const result = await client.registerDevice('did:icn:alice', {
+   *   device_id: 'phone-2',
+   *   label: 'My iPhone',
+   *   public_key: '...hex-encoded Ed25519 public key...',
+   *   capabilities: ['sign', 'encrypt'],
+   *   signing_device_id: 'device-1',
+   *   signature: '...hex-encoded signature...',
+   * });
+   * console.log('Registered device:', result.device.id);
+   * ```
+   */
+  async registerDevice(did: string, req: RegisterDeviceRequest): Promise<RegisterDeviceResponse> {
+    return this.post<RegisterDeviceResponse>(`/devices/${encodeURIComponent(did)}`, req);
+  }
+
+  /**
+   * List all devices for a DID
+   *
+   * Returns all devices registered for the authenticated user's DID.
+   *
+   * @param did - The DID to list devices for (must match authenticated user)
+   * @returns List of devices with total count
+   *
+   * @example
+   * ```typescript
+   * const result = await client.listDevices('did:icn:alice');
+   * console.log(`${result.total} devices registered`);
+   * for (const device of result.devices) {
+   *   console.log(`- ${device.id}: ${device.label} (revoked: ${device.revoked})`);
+   * }
+   * ```
+   */
+  async listDevices(did: string): Promise<ListDevicesResponse> {
+    return this.get<ListDevicesResponse>(`/devices/${encodeURIComponent(did)}`);
+  }
+
+  /**
+   * Get a specific device by ID
+   *
+   * @param did - The DID the device belongs to (must match authenticated user)
+   * @param deviceId - The device ID to retrieve
+   * @returns Device information
+   *
+   * @example
+   * ```typescript
+   * const device = await client.getDevice('did:icn:alice', 'phone-1');
+   * console.log(`Device ${device.id} has capabilities:`, device.capabilities);
+   * ```
+   */
+  async getDevice(did: string, deviceId: string): Promise<DeviceInfo> {
+    return this.get<DeviceInfo>(`/devices/${encodeURIComponent(did)}/${encodeURIComponent(deviceId)}`);
+  }
+
+  /**
+   * Revoke a device
+   *
+   * Revokes a device from the authenticated user's DID document.
+   * The request must be signed by a device with RevokeDevice capability.
+   * Cannot revoke the last device with management capabilities.
+   *
+   * @param did - The DID the device belongs to (must match authenticated user)
+   * @param deviceId - The device ID to revoke
+   * @param req - Revocation request with signing device and signature
+   * @returns Revocation response
+   *
+   * @example
+   * ```typescript
+   * const result = await client.revokeDevice('did:icn:alice', 'phone-old', {
+   *   signing_device_id: 'device-1',
+   *   signature: '...hex-encoded signature...',
+   * });
+   * console.log('Revoked device:', result.device_id);
+   * ```
+   */
+  async revokeDevice(
+    did: string,
+    deviceId: string,
+    req: RevokeDeviceRequest
+  ): Promise<RevokeDeviceResponse> {
+    return this.delete<RevokeDeviceResponse>(
+      `/devices/${encodeURIComponent(did)}/${encodeURIComponent(deviceId)}`,
+      req
+    );
   }
 
   // ===========================================================================

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1245,8 +1245,15 @@ export class ICNClient {
    * ```
    */
   async resolveDid(did: string, includeAttestations?: boolean): Promise<DidResolutionResponse> {
-    const query = includeAttestations ? '?include_attestations=true' : '';
-    return this.get<DidResolutionResponse>(`/identity/resolve/${encodeURIComponent(did)}${query}`, false);
+    const params = new URLSearchParams();
+    if (includeAttestations) {
+      params.set('include_attestations', 'true');
+    }
+    const query = params.toString();
+    return this.get<DidResolutionResponse>(
+      `/identity/resolve/${encodeURIComponent(did)}${query ? `?${query}` : ''}`,
+      false
+    );
   }
 
   /**

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -862,3 +862,106 @@ export interface AppealListResponse {
   appeals: Appeal[];
   count: number;
 }
+
+// ============================================================================
+// Identity Resolution
+// ============================================================================
+
+/** Response from DID resolution */
+export interface DidResolutionResponse {
+  /** The resolved DID string */
+  did: string;
+  /** Whether the DID is valid and parseable */
+  valid: boolean;
+  /** The cooperative ID this DID belongs to (if known) */
+  coop_id?: string;
+  /** Whether the DID has attestations in this cooperative */
+  has_attestations: boolean;
+  /** Number of valid attestations (if include_attestations was requested) */
+  attestation_count?: number;
+}
+
+/** Identity service health check response */
+export interface IdentityHealthResponse {
+  status: string;
+  service: string;
+}
+
+// ============================================================================
+// Device Management
+// ============================================================================
+
+/** Device capability types */
+export type DeviceCapability =
+  | 'sign'
+  | 'add_device'
+  | 'revoke_device'
+  | 'rotate_key'
+  | 'recover'
+  | 'encrypt';
+
+/** Device information */
+export interface DeviceInfo {
+  /** Unique device identifier */
+  id: string;
+  /** Human-readable label */
+  label: string;
+  /** Key type (e.g., "Ed25519") */
+  key_type: string;
+  /** Capabilities granted to this device */
+  capabilities: string[];
+  /** Timestamp when device was added */
+  added_at: number;
+  /** Whether the device has been revoked */
+  revoked: boolean;
+}
+
+/** Request to register a new device */
+export interface RegisterDeviceRequest {
+  /** Unique device identifier (e.g., "phone-1", "laptop-work") */
+  device_id: string;
+  /** Human-readable label */
+  label: string;
+  /** Ed25519 public key (hex-encoded) */
+  public_key: string;
+  /** Optional X25519 encryption public key (hex-encoded) */
+  encryption_public_key?: string;
+  /** Capabilities to grant: "sign", "add_device", "revoke_device", "rotate_key", "encrypt" */
+  capabilities: string[];
+  /** Device ID of the device signing this request (must have AddDevice capability) */
+  signing_device_id: string;
+  /** Hex-encoded signature of the registration request */
+  signature: string;
+}
+
+/** Response from device registration */
+export interface RegisterDeviceResponse {
+  /** The registered device info */
+  device: DeviceInfo;
+  /** Success message */
+  message: string;
+}
+
+/** Response from listing devices */
+export interface ListDevicesResponse {
+  /** List of devices */
+  devices: DeviceInfo[];
+  /** Total count */
+  total: number;
+}
+
+/** Request to revoke a device */
+export interface RevokeDeviceRequest {
+  /** Device ID of the device signing this request (must have RevokeDevice capability) */
+  signing_device_id: string;
+  /** Hex-encoded signature */
+  signature: string;
+}
+
+/** Response from device revocation */
+export interface RevokeDeviceResponse {
+  /** Success message */
+  message: string;
+  /** The revoked device ID */
+  device_id: string;
+}


### PR DESCRIPTION
## Summary

Adds TypeScript SDK support for identity resolution and device management operations, enabling mobile apps to:
- Resolve and verify DIDs across cooperatives
- Register, list, and revoke devices for multi-device support

## Changes

### New Methods
| Method | Description |
|--------|-------------|
| `resolveDid(did, includeAttestations?)` | Public DID resolution |
| `identityHealth()` | Identity service health check |
| `registerDevice(did, req)` | Register a new device |
| `listDevices(did)` | List all devices for a DID |
| `getDevice(did, deviceId)` | Get a specific device |
| `revokeDevice(did, deviceId, req)` | Revoke a device |

### New Types
- `DidResolutionResponse`, `IdentityHealthResponse`
- `DeviceInfo`, `DeviceCapability`
- `RegisterDeviceRequest`, `RegisterDeviceResponse`
- `ListDevicesResponse`, `RevokeDeviceRequest`, `RevokeDeviceResponse`

## Test plan

- [x] Added 8 new unit tests covering all identity and device methods
- [x] All 80 SDK tests pass
- [x] Types correctly match backend API contracts

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)