### PR TITLE
feat(ccl): add ContractRegistryActor for gossip-synced contract storage (#200)

### DIFF
--- a/icn/crates/icn-ccl/src/lib.rs
+++ b/icn/crates/icn-ccl/src/lib.rs
@@ -52,6 +52,7 @@ pub mod disputes;
 pub mod interpreter;
 pub mod messages;
 pub mod registry;
+pub mod registry_actor;
 pub mod runtime;
 pub mod types;
 
@@ -73,6 +74,11 @@ pub use messages::{
 };
 pub use registry::{
     compute_hash, ContentHash, ContractMetadata, ContractRegistry, RegistryError, RegistryStats,
+};
+pub use registry_actor::{
+    ContractRegistryActor, ContractRegistryHandle, ContractRegistryMessage, ContractSummary,
+    DeploymentMetadata, Visibility, TOPIC_CONTRACTS, TOPIC_CONTRACTS_DEPLOY,
+    TOPIC_CONTRACTS_REVOKE,
 };
 pub use runtime::{ContractInfo, ContractRuntime};
 pub use types::{

--- a/icn/crates/icn-ccl/src/lib.rs
+++ b/icn/crates/icn-ccl/src/lib.rs
@@ -74,11 +74,11 @@ pub use messages::{
 };
 pub use registry::{
     compute_hash, ContentHash, ContractMetadata, ContractRegistry, RegistryError, RegistryStats,
+    Visibility,
 };
 pub use registry_actor::{
     ContractRegistryActor, ContractRegistryHandle, ContractRegistryMessage, ContractSummary,
-    DeploymentMetadata, Visibility, TOPIC_CONTRACTS, TOPIC_CONTRACTS_DEPLOY,
-    TOPIC_CONTRACTS_REVOKE,
+    DeploymentMetadata, TOPIC_CONTRACTS, TOPIC_CONTRACTS_DEPLOY, TOPIC_CONTRACTS_REVOKE,
 };
 pub use runtime::{ContractInfo, ContractRuntime};
 pub use types::{

--- a/icn/crates/icn-ccl/src/registry.rs
+++ b/icn/crates/icn-ccl/src/registry.rs
@@ -48,6 +48,18 @@ pub enum RegistryError {
 
 pub type Result<T> = std::result::Result<T, RegistryError>;
 
+/// Contract visibility level
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum Visibility {
+    /// Only visible to owner
+    #[default]
+    Private,
+    /// Visible to cooperative members
+    Coop(String),
+    /// Publicly visible (may require governance approval)
+    Public,
+}
+
 /// Contract metadata stored alongside the contract
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContractMetadata {
@@ -69,6 +81,8 @@ pub struct ContractMetadata {
     pub currency: Option<String>,
     /// Rule names for discovery
     pub rules: Vec<String>,
+    /// Visibility level
+    pub visibility: Visibility,
 }
 
 impl ContractMetadata {
@@ -91,12 +105,19 @@ impl ContractMetadata {
                 .collect(),
             currency: contract.currency.clone(),
             rules: contract.rules.iter().map(|r| r.name.clone()).collect(),
+            visibility: Visibility::default(),
         })
     }
 
     /// Set description
     pub fn with_description(mut self, description: impl Into<String>) -> Self {
         self.description = Some(description.into());
+        self
+    }
+
+    /// Set visibility
+    pub fn with_visibility(mut self, visibility: Visibility) -> Self {
+        self.visibility = visibility;
         self
     }
 }
@@ -160,6 +181,18 @@ impl ContractRegistry {
         owner: &str,
         version: Option<u32>,
     ) -> Result<ContentHash> {
+        self.deploy_with_visibility(contract, owner, version, Visibility::default())
+            .await
+    }
+
+    /// Deploy a contract with explicit visibility
+    pub async fn deploy_with_visibility(
+        &self,
+        contract: Contract,
+        owner: &str,
+        version: Option<u32>,
+        visibility: Visibility,
+    ) -> Result<ContentHash> {
         // Validate contract
         contract
             .validate()
@@ -189,8 +222,9 @@ impl ContractRegistry {
             }
         };
 
-        // Create metadata
-        let metadata = ContractMetadata::from_contract(&contract, owner, version)?;
+        // Create metadata with visibility
+        let metadata =
+            ContractMetadata::from_contract(&contract, owner, version)?.with_visibility(visibility);
 
         // Persist to store if available
         if let Some(store) = &self.store {

--- a/icn/crates/icn-ccl/src/registry_actor/command.rs
+++ b/icn/crates/icn-ccl/src/registry_actor/command.rs
@@ -1,0 +1,125 @@
+//! Command types for the Contract Registry Actor
+//!
+//! Defines the message protocol used to communicate with the actor.
+
+use crate::ast::Contract;
+use crate::registry::{ContentHash, ContractMetadata, RegistryError, RegistryStats};
+use tokio::sync::oneshot;
+
+use super::types::{
+    ApprovalStatus, ContractFilter, ContractRegistryMessage, ContractSummary, DeploymentMetadata,
+};
+
+/// Commands sent to the ContractRegistryActor
+pub(crate) enum ContractRegistryCommand {
+    /// Register a new contract
+    Register {
+        contract: Contract,
+        metadata: DeploymentMetadata,
+        resp: oneshot::Sender<Result<ContentHash, RegistryError>>,
+    },
+
+    /// Get a contract by hash
+    Get {
+        hash: ContentHash,
+        resp: oneshot::Sender<Option<Contract>>,
+    },
+
+    /// Get contract metadata by hash
+    GetMetadata {
+        hash: ContentHash,
+        resp: oneshot::Sender<Option<ContractMetadata>>,
+    },
+
+    /// List contracts matching a filter
+    List {
+        filter: ContractFilter,
+        resp: oneshot::Sender<Vec<ContractSummary>>,
+    },
+
+    /// Resolve contract by name and optional version
+    Resolve {
+        name: String,
+        version: Option<u32>,
+        resp: oneshot::Sender<Option<ContentHash>>,
+    },
+
+    /// Revoke a contract (owner only)
+    Revoke {
+        hash: ContentHash,
+        requester: String,
+        reason: String,
+        resp: oneshot::Sender<Result<(), RegistryError>>,
+    },
+
+    /// Handle incoming gossip message
+    GossipMessage(ContractRegistryMessage),
+
+    /// Check governance approval status for a contract
+    CheckApproval {
+        hash: ContentHash,
+        resp: oneshot::Sender<ApprovalStatus>,
+    },
+
+    /// Get registry statistics
+    Stats {
+        resp: oneshot::Sender<RegistryStats>,
+    },
+
+    /// Check if a contract exists
+    Exists {
+        hash: ContentHash,
+        resp: oneshot::Sender<bool>,
+    },
+
+    /// Get all contract hashes (for anti-entropy digest)
+    GetAllHashes {
+        resp: oneshot::Sender<Vec<ContentHash>>,
+    },
+}
+
+impl std::fmt::Debug for ContractRegistryCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Register { metadata, .. } => f
+                .debug_struct("Register")
+                .field("owner", &metadata.owner)
+                .finish(),
+            Self::Get { hash, .. } => f
+                .debug_struct("Get")
+                .field("hash", &hex::encode(hash))
+                .finish(),
+            Self::GetMetadata { hash, .. } => f
+                .debug_struct("GetMetadata")
+                .field("hash", &hex::encode(hash))
+                .finish(),
+            Self::List { filter, .. } => f.debug_struct("List").field("filter", filter).finish(),
+            Self::Resolve { name, version, .. } => f
+                .debug_struct("Resolve")
+                .field("name", name)
+                .field("version", version)
+                .finish(),
+            Self::Revoke {
+                hash, requester, ..
+            } => f
+                .debug_struct("Revoke")
+                .field("hash", &hex::encode(hash))
+                .field("requester", requester)
+                .finish(),
+            Self::GossipMessage(msg) => f
+                .debug_struct("GossipMessage")
+                .field("type", &msg.message_type())
+                .finish(),
+            Self::CheckApproval { hash, .. } => f
+                .debug_struct("CheckApproval")
+                .field("hash", &hex::encode(hash))
+                .finish(),
+            Self::Stats { .. } => f.debug_struct("Stats").finish(),
+            Self::Exists { hash, .. } => f
+                .debug_struct("Exists")
+                .field("hash", &hex::encode(hash))
+                .finish(),
+            Self::GetAllHashes { .. } => f.debug_struct("GetAllHashes").finish(),
+        }
+    }
+}

--- a/icn/crates/icn-ccl/src/registry_actor/handle.rs
+++ b/icn/crates/icn-ccl/src/registry_actor/handle.rs
@@ -152,10 +152,7 @@ impl ContractRegistryHandle {
     /// Handle an incoming gossip message
     ///
     /// Called by the supervisor when a message arrives on contract registry topics.
-    pub async fn handle_gossip(
-        &self,
-        msg: ContractRegistryMessage,
-    ) -> Result<(), ActorError> {
+    pub async fn handle_gossip(&self, msg: ContractRegistryMessage) -> Result<(), ActorError> {
         self.tx
             .send(ContractRegistryCommand::GossipMessage(msg))
             .await

--- a/icn/crates/icn-ccl/src/registry_actor/handle.rs
+++ b/icn/crates/icn-ccl/src/registry_actor/handle.rs
@@ -1,0 +1,218 @@
+//! Handle for interacting with the Contract Registry Actor
+//!
+//! Provides a cloneable, async API for contract registry operations.
+
+use crate::ast::Contract;
+use crate::registry::{ContentHash, ContractMetadata, RegistryStats};
+use tokio::sync::{mpsc, oneshot};
+
+use super::command::ContractRegistryCommand;
+use super::types::{
+    ActorError, ApprovalStatus, ContractFilter, ContractRegistryMessage, ContractSummary,
+    DeploymentMetadata,
+};
+
+/// Handle for interacting with the ContractRegistryActor
+///
+/// This handle is cloneable and can be shared across tasks.
+#[derive(Clone)]
+pub struct ContractRegistryHandle {
+    pub(crate) tx: mpsc::Sender<ContractRegistryCommand>,
+}
+
+impl ContractRegistryHandle {
+    /// Create a new handle with the given sender
+    pub(crate) fn new(tx: mpsc::Sender<ContractRegistryCommand>) -> Self {
+        Self { tx }
+    }
+
+    /// Register a new contract in the registry
+    ///
+    /// # Arguments
+    /// * `contract` - The CCL contract to register
+    /// * `metadata` - Deployment metadata (owner, visibility, etc.)
+    ///
+    /// # Returns
+    /// The content hash of the registered contract
+    pub async fn register_contract(
+        &self,
+        contract: Contract,
+        metadata: DeploymentMetadata,
+    ) -> Result<ContentHash, ActorError> {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.tx
+            .send(ContractRegistryCommand::Register {
+                contract,
+                metadata,
+                resp: resp_tx,
+            })
+            .await
+            .map_err(|_| ActorError::ChannelClosed)?;
+        resp_rx
+            .await
+            .map_err(|_| ActorError::NoResponse)?
+            .map_err(ActorError::Registry)
+    }
+
+    /// Get a contract by its content hash
+    ///
+    /// This is the primary method used by ComputeActor to resolve CclRef.
+    pub async fn get_contract(&self, hash: &ContentHash) -> Result<Option<Contract>, ActorError> {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.tx
+            .send(ContractRegistryCommand::Get {
+                hash: *hash,
+                resp: resp_tx,
+            })
+            .await
+            .map_err(|_| ActorError::ChannelClosed)?;
+        resp_rx.await.map_err(|_| ActorError::NoResponse)
+    }
+
+    /// Get contract metadata by hash
+    pub async fn get_metadata(
+        &self,
+        hash: &ContentHash,
+    ) -> Result<Option<ContractMetadata>, ActorError> {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.tx
+            .send(ContractRegistryCommand::GetMetadata {
+                hash: *hash,
+                resp: resp_tx,
+            })
+            .await
+            .map_err(|_| ActorError::ChannelClosed)?;
+        resp_rx.await.map_err(|_| ActorError::NoResponse)
+    }
+
+    /// List contracts matching a filter
+    pub async fn list_contracts(
+        &self,
+        filter: ContractFilter,
+    ) -> Result<Vec<ContractSummary>, ActorError> {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.tx
+            .send(ContractRegistryCommand::List {
+                filter,
+                resp: resp_tx,
+            })
+            .await
+            .map_err(|_| ActorError::ChannelClosed)?;
+        resp_rx.await.map_err(|_| ActorError::NoResponse)
+    }
+
+    /// Resolve a contract by name and optional version
+    ///
+    /// If version is None, returns the latest version.
+    pub async fn resolve(
+        &self,
+        name: &str,
+        version: Option<u32>,
+    ) -> Result<Option<ContentHash>, ActorError> {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.tx
+            .send(ContractRegistryCommand::Resolve {
+                name: name.to_string(),
+                version,
+                resp: resp_tx,
+            })
+            .await
+            .map_err(|_| ActorError::ChannelClosed)?;
+        resp_rx.await.map_err(|_| ActorError::NoResponse)
+    }
+
+    /// Revoke a contract (owner only)
+    ///
+    /// # Arguments
+    /// * `hash` - Content hash of the contract to revoke
+    /// * `requester` - DID of the requester (must be owner)
+    /// * `reason` - Reason for revocation
+    pub async fn revoke_contract(
+        &self,
+        hash: &ContentHash,
+        requester: &str,
+        reason: String,
+    ) -> Result<(), ActorError> {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.tx
+            .send(ContractRegistryCommand::Revoke {
+                hash: *hash,
+                requester: requester.to_string(),
+                reason,
+                resp: resp_tx,
+            })
+            .await
+            .map_err(|_| ActorError::ChannelClosed)?;
+        resp_rx
+            .await
+            .map_err(|_| ActorError::NoResponse)?
+            .map_err(ActorError::Registry)
+    }
+
+    /// Handle an incoming gossip message
+    ///
+    /// Called by the supervisor when a message arrives on contract registry topics.
+    pub async fn handle_gossip(
+        &self,
+        msg: ContractRegistryMessage,
+    ) -> Result<(), ActorError> {
+        self.tx
+            .send(ContractRegistryCommand::GossipMessage(msg))
+            .await
+            .map_err(|_| ActorError::ChannelClosed)
+    }
+
+    /// Check governance approval status for a contract
+    pub async fn check_approval(&self, hash: &ContentHash) -> Result<ApprovalStatus, ActorError> {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.tx
+            .send(ContractRegistryCommand::CheckApproval {
+                hash: *hash,
+                resp: resp_tx,
+            })
+            .await
+            .map_err(|_| ActorError::ChannelClosed)?;
+        resp_rx.await.map_err(|_| ActorError::NoResponse)
+    }
+
+    /// Get registry statistics
+    pub async fn stats(&self) -> Result<RegistryStats, ActorError> {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.tx
+            .send(ContractRegistryCommand::Stats { resp: resp_tx })
+            .await
+            .map_err(|_| ActorError::ChannelClosed)?;
+        resp_rx.await.map_err(|_| ActorError::NoResponse)
+    }
+
+    /// Check if a contract exists in the registry
+    pub async fn exists(&self, hash: &ContentHash) -> Result<bool, ActorError> {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.tx
+            .send(ContractRegistryCommand::Exists {
+                hash: *hash,
+                resp: resp_tx,
+            })
+            .await
+            .map_err(|_| ActorError::ChannelClosed)?;
+        resp_rx.await.map_err(|_| ActorError::NoResponse)
+    }
+
+    /// Get all contract hashes (for anti-entropy)
+    pub async fn get_all_hashes(&self) -> Result<Vec<ContentHash>, ActorError> {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.tx
+            .send(ContractRegistryCommand::GetAllHashes { resp: resp_tx })
+            .await
+            .map_err(|_| ActorError::ChannelClosed)?;
+        resp_rx.await.map_err(|_| ActorError::NoResponse)
+    }
+}
+
+impl std::fmt::Debug for ContractRegistryHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ContractRegistryHandle")
+            .field("channel_open", &!self.tx.is_closed())
+            .finish()
+    }
+}

--- a/icn/crates/icn-ccl/src/registry_actor/mod.rs
+++ b/icn/crates/icn-ccl/src/registry_actor/mod.rs
@@ -189,10 +189,15 @@ impl ContractRegistryActor {
             .validate()
             .map_err(|e| RegistryError::InvalidContract(e.to_string()))?;
 
-        // Deploy to registry
+        // Deploy to registry with visibility
         let hash = self
             .registry
-            .deploy(contract.clone(), &metadata.owner, metadata.version)
+            .deploy_with_visibility(
+                contract.clone(),
+                &metadata.owner,
+                metadata.version,
+                metadata.visibility.clone(),
+            )
             .await?;
 
         // Get the created metadata for gossip
@@ -249,6 +254,12 @@ impl ContractRegistryActor {
                 // Filter by name prefix
                 if let Some(ref prefix) = filter.name_prefix {
                     if !meta.name.starts_with(prefix) {
+                        return false;
+                    }
+                }
+                // Filter by visibility
+                if let Some(ref visibility) = filter.visibility {
+                    if &meta.visibility != visibility {
                         return false;
                     }
                 }

--- a/icn/crates/icn-ccl/src/registry_actor/mod.rs
+++ b/icn/crates/icn-ccl/src/registry_actor/mod.rs
@@ -1,0 +1,694 @@
+//! Contract Registry Actor
+//!
+//! Provides an actor-based interface around the [`ContractRegistry`] with
+//! gossip-based synchronization for distributed contract management.
+//!
+//! ## Features
+//!
+//! - **Contract Registration**: Deploy contracts with metadata and versioning
+//! - **Gossip Sync**: Automatically synchronize contracts across nodes
+//! - **Visibility Control**: Private, cooperative-scoped, or public contracts
+//! - **Anti-Entropy**: Request missing contracts from peers
+//!
+//! ## Example
+//!
+//! ```ignore
+//! use icn_ccl::registry_actor::{ContractRegistryActor, DeploymentMetadata};
+//! use icn_ccl::ContractRegistry;
+//! use std::sync::Arc;
+//!
+//! let registry = Arc::new(ContractRegistry::new());
+//! let actor = ContractRegistryActor::new("did:icn:node1".into(), registry);
+//! let handle = actor.spawn();
+//!
+//! // Register a contract
+//! let hash = handle.register_contract(contract, DeploymentMetadata::new("did:icn:alice")).await?;
+//!
+//! // Get a contract by hash
+//! let contract = handle.get_contract(&hash).await?;
+//! ```
+
+mod command;
+mod handle;
+pub mod types;
+
+pub use handle::ContractRegistryHandle;
+pub use types::*;
+
+use crate::ast::Contract;
+use crate::registry::{ContentHash, ContractRegistry, RegistryError};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{mpsc, RwLock};
+use tracing::{debug, info, warn};
+
+use command::ContractRegistryCommand;
+
+/// Actor managing contract registry with gossip synchronization
+pub struct ContractRegistryActor {
+    /// This node's DID
+    own_did: String,
+
+    /// The underlying contract registry
+    registry: Arc<ContractRegistry>,
+
+    /// Callback for sending gossip messages
+    send_callback: Option<SendCallback>,
+
+    /// Callback for emitting registry events
+    event_callback: Option<EventCallback>,
+
+    /// Pending governance approvals (hash -> proposal_id)
+    pending_approvals: Arc<RwLock<HashMap<ContentHash, String>>>,
+
+    /// Revoked contracts (tracked in memory, persisted via metadata)
+    revoked_contracts: Arc<RwLock<HashMap<ContentHash, String>>>,
+}
+
+impl ContractRegistryActor {
+    /// Create a new ContractRegistryActor
+    ///
+    /// # Arguments
+    /// * `own_did` - This node's DID for gossip identification
+    /// * `registry` - The underlying contract registry to wrap
+    pub fn new(own_did: String, registry: Arc<ContractRegistry>) -> Self {
+        Self {
+            own_did,
+            registry,
+            send_callback: None,
+            event_callback: None,
+            pending_approvals: Arc::new(RwLock::new(HashMap::new())),
+            revoked_contracts: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Set the callback for sending gossip messages
+    pub fn set_send_callback(&mut self, cb: SendCallback) {
+        self.send_callback = Some(cb);
+    }
+
+    /// Set the callback for emitting registry events
+    pub fn set_event_callback(&mut self, cb: EventCallback) {
+        self.event_callback = Some(cb);
+    }
+
+    /// Spawn the actor and return a handle for interacting with it
+    ///
+    /// The actor runs in a background Tokio task until the handle is dropped.
+    pub fn spawn(self) -> ContractRegistryHandle {
+        let (tx, rx) = mpsc::channel::<ContractRegistryCommand>(256);
+        let did = self.own_did.clone();
+
+        tokio::spawn(self.run(rx));
+
+        info!(did = %did, "Contract registry actor spawned");
+        ContractRegistryHandle::new(tx)
+    }
+
+    /// Main actor loop
+    async fn run(self, mut rx: mpsc::Receiver<ContractRegistryCommand>) {
+        while let Some(cmd) = rx.recv().await {
+            debug!(?cmd, "Processing command");
+            self.handle_command(cmd).await;
+        }
+        info!("Contract registry actor stopped");
+    }
+
+    /// Handle a single command
+    async fn handle_command(&self, cmd: ContractRegistryCommand) {
+        match cmd {
+            ContractRegistryCommand::Register {
+                contract,
+                metadata,
+                resp,
+            } => {
+                let result = self.handle_register(contract, metadata).await;
+                let _ = resp.send(result);
+            }
+            ContractRegistryCommand::Get { hash, resp } => {
+                let result = self.registry.get(&hash).await.ok().flatten();
+                let _ = resp.send(result);
+            }
+            ContractRegistryCommand::GetMetadata { hash, resp } => {
+                let result = self.registry.get_metadata(&hash).await.ok().flatten();
+                let _ = resp.send(result);
+            }
+            ContractRegistryCommand::List { filter, resp } => {
+                let result = self.handle_list(filter).await;
+                let _ = resp.send(result);
+            }
+            ContractRegistryCommand::Resolve { name, version, resp } => {
+                let result = self.registry.resolve(&name, version).await.ok().flatten();
+                let _ = resp.send(result);
+            }
+            ContractRegistryCommand::Revoke {
+                hash,
+                requester,
+                reason,
+                resp,
+            } => {
+                let result = self.handle_revoke(&hash, &requester, reason).await;
+                let _ = resp.send(result);
+            }
+            ContractRegistryCommand::GossipMessage(msg) => {
+                if let Err(e) = self.handle_gossip_message(msg).await {
+                    warn!("Error handling gossip message: {}", e);
+                }
+            }
+            ContractRegistryCommand::CheckApproval { hash, resp } => {
+                let status = self.check_approval_status(&hash).await;
+                let _ = resp.send(status);
+            }
+            ContractRegistryCommand::Stats { resp } => {
+                let stats = self.registry.stats().await;
+                let _ = resp.send(stats);
+            }
+            ContractRegistryCommand::Exists { hash, resp } => {
+                let exists = self.registry.exists(&hash).await;
+                let _ = resp.send(exists);
+            }
+            ContractRegistryCommand::GetAllHashes { resp } => {
+                let hashes = self.get_all_hashes().await;
+                let _ = resp.send(hashes);
+            }
+        }
+    }
+
+    /// Handle contract registration
+    async fn handle_register(
+        &self,
+        contract: Contract,
+        metadata: DeploymentMetadata,
+    ) -> Result<ContentHash, RegistryError> {
+        // Validate contract first
+        contract
+            .validate()
+            .map_err(|e| RegistryError::InvalidContract(e.to_string()))?;
+
+        // Deploy to registry
+        let hash = self
+            .registry
+            .deploy(contract.clone(), &metadata.owner, metadata.version)
+            .await?;
+
+        // Get the created metadata for gossip
+        let contract_metadata = self.registry.get_metadata(&hash).await?.ok_or_else(|| {
+            RegistryError::StorageError("Metadata not found after deploy".to_string())
+        })?;
+
+        // Broadcast to gossip
+        if let Some(ref send_cb) = self.send_callback {
+            let msg = ContractRegistryMessage::Deployed {
+                hash,
+                contract: contract.clone(),
+                metadata: contract_metadata,
+            };
+            send_cb(msg);
+        }
+
+        // Emit event
+        if let Some(ref event_cb) = self.event_callback {
+            event_cb(ContractRegistryEvent::Deployed {
+                hash,
+                name: contract.name.clone(),
+            });
+        }
+
+        info!(
+            hash = %hex::encode(hash),
+            name = %contract.name,
+            owner = %metadata.owner,
+            "Contract registered via actor"
+        );
+
+        Ok(hash)
+    }
+
+    /// Handle contract listing with filter
+    async fn handle_list(&self, filter: ContractFilter) -> Vec<ContractSummary> {
+        let all_metadata = match self.registry.list_all().await {
+            Ok(m) => m,
+            Err(_) => return vec![],
+        };
+
+        let revoked = self.revoked_contracts.read().await;
+
+        let mut results: Vec<ContractSummary> = all_metadata
+            .iter()
+            .filter(|meta| {
+                // Filter by owner
+                if let Some(ref owner) = filter.owner {
+                    if &meta.owner != owner {
+                        return false;
+                    }
+                }
+                // Filter by name prefix
+                if let Some(ref prefix) = filter.name_prefix {
+                    if !meta.name.starts_with(prefix) {
+                        return false;
+                    }
+                }
+                true
+            })
+            .map(|meta| {
+                let mut summary = ContractSummary::from(meta);
+                summary.revoked = revoked.contains_key(&meta.code_hash);
+                summary
+            })
+            .collect();
+
+        // Apply limit
+        if let Some(limit) = filter.limit {
+            results.truncate(limit);
+        }
+
+        results
+    }
+
+    /// Handle contract revocation
+    async fn handle_revoke(
+        &self,
+        hash: &ContentHash,
+        requester: &str,
+        reason: String,
+    ) -> Result<(), RegistryError> {
+        // Get metadata to check ownership
+        let metadata = self
+            .registry
+            .get_metadata(hash)
+            .await?
+            .ok_or_else(|| RegistryError::NotFound(hex::encode(hash)))?;
+
+        // Verify requester is owner
+        if metadata.owner != requester {
+            return Err(RegistryError::AuthorizationError(format!(
+                "Only owner {} can revoke contract",
+                metadata.owner
+            )));
+        }
+
+        // Mark as revoked
+        {
+            let mut revoked = self.revoked_contracts.write().await;
+            revoked.insert(*hash, reason.clone());
+        }
+
+        // Broadcast revocation
+        if let Some(ref send_cb) = self.send_callback {
+            let msg = ContractRegistryMessage::Revoked {
+                hash: *hash,
+                owner: requester.to_string(),
+                reason: reason.clone(),
+                revoked_at: icn_time::current_timestamp_millis(),
+            };
+            send_cb(msg);
+        }
+
+        // Emit event
+        if let Some(ref event_cb) = self.event_callback {
+            event_cb(ContractRegistryEvent::Revoked {
+                hash: *hash,
+                reason: reason.clone(),
+            });
+        }
+
+        info!(
+            hash = %hex::encode(hash),
+            owner = %requester,
+            reason = %reason,
+            "Contract revoked"
+        );
+
+        Ok(())
+    }
+
+    /// Handle incoming gossip message
+    async fn handle_gossip_message(&self, msg: ContractRegistryMessage) -> Result<(), String> {
+        match msg {
+            ContractRegistryMessage::Deployed {
+                hash,
+                contract,
+                metadata,
+            } => {
+                // Check if we already have this contract
+                if self.registry.exists(&hash).await {
+                    debug!(hash = %hex::encode(hash), "Contract already exists, skipping");
+                    return Ok(());
+                }
+
+                // Validate and deploy locally
+                if let Err(e) = contract.validate() {
+                    warn!(hash = %hex::encode(hash), error = %e, "Invalid contract from gossip");
+                    return Err(format!("Invalid contract: {e}"));
+                }
+
+                match self
+                    .registry
+                    .deploy(contract.clone(), &metadata.owner, Some(metadata.version))
+                    .await
+                {
+                    Ok(_) => {
+                        info!(
+                            hash = %hex::encode(hash),
+                            name = %contract.name,
+                            "Contract synced from gossip"
+                        );
+
+                        // Emit event
+                        if let Some(ref event_cb) = self.event_callback {
+                            event_cb(ContractRegistryEvent::SyncedFromPeer {
+                                hash,
+                                peer: metadata.owner.clone(),
+                            });
+                        }
+                    }
+                    Err(RegistryError::AlreadyExists(_)) => {
+                        // Race condition, contract was added by another path
+                        debug!(hash = %hex::encode(hash), "Contract already exists (race)");
+                    }
+                    Err(e) => {
+                        warn!(hash = %hex::encode(hash), error = %e, "Failed to deploy contract from gossip");
+                        return Err(format!("Deploy failed: {e}"));
+                    }
+                }
+            }
+
+            ContractRegistryMessage::Revoked {
+                hash,
+                owner,
+                reason,
+                ..
+            } => {
+                // Verify the revocation is from the owner
+                if let Ok(Some(metadata)) = self.registry.get_metadata(&hash).await {
+                    if metadata.owner == owner {
+                        let mut revoked = self.revoked_contracts.write().await;
+                        revoked.insert(hash, reason.clone());
+                        info!(hash = %hex::encode(hash), "Contract revocation synced from gossip");
+                    } else {
+                        warn!(
+                            hash = %hex::encode(hash),
+                            claimed_owner = %owner,
+                            actual_owner = %metadata.owner,
+                            "Invalid revocation: owner mismatch"
+                        );
+                    }
+                }
+            }
+
+            ContractRegistryMessage::Request { hash, requester } => {
+                // Respond with contract if we have it
+                if let (Ok(contract), Ok(metadata)) = (
+                    self.registry.get(&hash).await,
+                    self.registry.get_metadata(&hash).await,
+                ) {
+                    if let Some(ref send_cb) = self.send_callback {
+                        let msg = ContractRegistryMessage::Response {
+                            hash,
+                            contract,
+                            metadata,
+                        };
+                        send_cb(msg);
+                        debug!(
+                            hash = %hex::encode(hash),
+                            requester = %requester,
+                            "Sent contract response"
+                        );
+                    }
+                }
+            }
+
+            ContractRegistryMessage::Response {
+                hash,
+                contract,
+                metadata,
+            } => {
+                // Store the contract if we don't have it
+                if let (Some(contract), Some(metadata)) = (contract, metadata) {
+                    if !self.registry.exists(&hash).await {
+                        if let Err(e) = self
+                            .registry
+                            .deploy(contract.clone(), &metadata.owner, Some(metadata.version))
+                            .await
+                        {
+                            if !matches!(e, RegistryError::AlreadyExists(_)) {
+                                warn!(hash = %hex::encode(hash), error = %e, "Failed to store contract response");
+                            }
+                        } else {
+                            info!(hash = %hex::encode(hash), "Stored contract from response");
+                        }
+                    }
+                }
+            }
+
+            ContractRegistryMessage::Digest { hashes, sender } => {
+                // Find contracts we don't have and request them
+                for hash in hashes {
+                    if !self.registry.exists(&hash).await {
+                        if let Some(ref send_cb) = self.send_callback {
+                            let msg = ContractRegistryMessage::Request {
+                                hash,
+                                requester: self.own_did.clone(),
+                            };
+                            send_cb(msg);
+                            debug!(
+                                hash = %hex::encode(hash),
+                                from = %sender,
+                                "Requesting missing contract"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Check approval status for a contract
+    async fn check_approval_status(&self, hash: &ContentHash) -> ApprovalStatus {
+        let pending = self.pending_approvals.read().await;
+        if let Some(proposal_id) = pending.get(hash) {
+            ApprovalStatus::Pending {
+                proposal_id: proposal_id.clone(),
+            }
+        } else {
+            ApprovalStatus::NotRequired
+        }
+    }
+
+    /// Get all contract hashes for anti-entropy
+    async fn get_all_hashes(&self) -> Vec<ContentHash> {
+        match self.registry.list_all().await {
+            Ok(metadata) => metadata.iter().map(|m| m.code_hash).collect(),
+            Err(_) => vec![],
+        }
+    }
+
+    /// Send a digest of all contracts to peers (for anti-entropy)
+    pub async fn broadcast_digest(&self) {
+        if let Some(ref send_cb) = self.send_callback {
+            let hashes = self.get_all_hashes().await;
+            if !hashes.is_empty() {
+                let msg = ContractRegistryMessage::Digest {
+                    hashes,
+                    sender: self.own_did.clone(),
+                };
+                send_cb(msg);
+                debug!("Broadcast contract digest");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Expr, Rule, Stmt, Value};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn create_test_contract(name: &str) -> Contract {
+        Contract::new(name.to_string())
+            .add_participant(icn_identity::KeyPair::generate().unwrap().did().clone())
+            .add_rule(Rule::new("test_rule".to_string()).add_stmt(Stmt::Return {
+                value: Expr::Literal(Value::String("ok".to_string())),
+            }))
+    }
+
+    #[tokio::test]
+    async fn test_actor_register_and_get() {
+        let registry = Arc::new(ContractRegistry::new());
+        let actor = ContractRegistryActor::new("did:icn:test".into(), registry);
+        let handle = actor.spawn();
+
+        let contract = create_test_contract("TestContract");
+        let metadata = DeploymentMetadata::new("did:icn:alice");
+
+        // Register
+        let hash = handle
+            .register_contract(contract.clone(), metadata)
+            .await
+            .unwrap();
+
+        // Get
+        let retrieved = handle.get_contract(&hash).await.unwrap().unwrap();
+        assert_eq!(retrieved.name, "TestContract");
+
+        // Get metadata
+        let meta = handle.get_metadata(&hash).await.unwrap().unwrap();
+        assert_eq!(meta.owner, "did:icn:alice");
+        assert_eq!(meta.version, 1);
+    }
+
+    #[tokio::test]
+    async fn test_actor_list_with_filter() {
+        let registry = Arc::new(ContractRegistry::new());
+        let actor = ContractRegistryActor::new("did:icn:test".into(), registry);
+        let handle = actor.spawn();
+
+        // Register contracts from different owners
+        handle
+            .register_contract(
+                create_test_contract("AliceContract"),
+                DeploymentMetadata::new("did:icn:alice"),
+            )
+            .await
+            .unwrap();
+
+        handle
+            .register_contract(
+                create_test_contract("BobContract"),
+                DeploymentMetadata::new("did:icn:bob"),
+            )
+            .await
+            .unwrap();
+
+        // List all
+        let all = handle.list_contracts(ContractFilter::new()).await.unwrap();
+        assert_eq!(all.len(), 2);
+
+        // Filter by owner
+        let alice_only = handle
+            .list_contracts(ContractFilter::new().with_owner("did:icn:alice"))
+            .await
+            .unwrap();
+        assert_eq!(alice_only.len(), 1);
+        assert_eq!(alice_only[0].name, "AliceContract");
+    }
+
+    #[tokio::test]
+    async fn test_actor_revoke() {
+        let registry = Arc::new(ContractRegistry::new());
+        let actor = ContractRegistryActor::new("did:icn:test".into(), registry);
+        let handle = actor.spawn();
+
+        let contract = create_test_contract("RevocableContract");
+        let hash = handle
+            .register_contract(contract, DeploymentMetadata::new("did:icn:alice"))
+            .await
+            .unwrap();
+
+        // Owner can revoke
+        handle
+            .revoke_contract(&hash, "did:icn:alice", "No longer needed".into())
+            .await
+            .unwrap();
+
+        // Contract is marked as revoked in list
+        let list = handle.list_contracts(ContractFilter::new()).await.unwrap();
+        assert!(list[0].revoked);
+    }
+
+    #[tokio::test]
+    async fn test_actor_revoke_non_owner_fails() {
+        let registry = Arc::new(ContractRegistry::new());
+        let actor = ContractRegistryActor::new("did:icn:test".into(), registry);
+        let handle = actor.spawn();
+
+        let contract = create_test_contract("OwnerOnlyContract");
+        let hash = handle
+            .register_contract(contract, DeploymentMetadata::new("did:icn:alice"))
+            .await
+            .unwrap();
+
+        // Non-owner cannot revoke
+        let result = handle
+            .revoke_contract(&hash, "did:icn:bob", "Trying to revoke".into())
+            .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_actor_resolve() {
+        let registry = Arc::new(ContractRegistry::new());
+        let actor = ContractRegistryActor::new("did:icn:test".into(), registry);
+        let handle = actor.spawn();
+
+        let contract = create_test_contract("NamedContract");
+        let hash = handle
+            .register_contract(contract, DeploymentMetadata::new("did:icn:alice"))
+            .await
+            .unwrap();
+
+        // Resolve by name
+        let resolved = handle.resolve("NamedContract", None).await.unwrap().unwrap();
+        assert_eq!(resolved, hash);
+
+        // Non-existent name
+        let not_found = handle.resolve("DoesNotExist", None).await.unwrap();
+        assert!(not_found.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_actor_event_callback() {
+        let registry = Arc::new(ContractRegistry::new());
+        let mut actor = ContractRegistryActor::new("did:icn:test".into(), registry);
+
+        let event_count = Arc::new(AtomicUsize::new(0));
+        let count_clone = event_count.clone();
+
+        actor.set_event_callback(Arc::new(move |_event| {
+            count_clone.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        let handle = actor.spawn();
+
+        // Register should emit event
+        let contract = create_test_contract("EventContract");
+        handle
+            .register_contract(contract, DeploymentMetadata::new("did:icn:alice"))
+            .await
+            .unwrap();
+
+        // Give time for event processing
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        assert!(event_count.load(Ordering::SeqCst) >= 1);
+    }
+
+    #[tokio::test]
+    async fn test_actor_stats() {
+        let registry = Arc::new(ContractRegistry::new());
+        let actor = ContractRegistryActor::new("did:icn:test".into(), registry);
+        let handle = actor.spawn();
+
+        // Initial stats
+        let stats = handle.stats().await.unwrap();
+        assert_eq!(stats.total_contracts, 0);
+
+        // Register a contract
+        handle
+            .register_contract(
+                create_test_contract("StatsContract"),
+                DeploymentMetadata::new("did:icn:alice"),
+            )
+            .await
+            .unwrap();
+
+        // Updated stats
+        let stats = handle.stats().await.unwrap();
+        assert_eq!(stats.total_contracts, 1);
+        assert_eq!(stats.unique_owners, 1);
+    }
+}

--- a/icn/crates/icn-ccl/src/registry_actor/mod.rs
+++ b/icn/crates/icn-ccl/src/registry_actor/mod.rs
@@ -137,7 +137,11 @@ impl ContractRegistryActor {
                 let result = self.handle_list(filter).await;
                 let _ = resp.send(result);
             }
-            ContractRegistryCommand::Resolve { name, version, resp } => {
+            ContractRegistryCommand::Resolve {
+                name,
+                version,
+                resp,
+            } => {
                 let result = self.registry.resolve(&name, version).await.ok().flatten();
                 let _ = resp.send(result);
             }
@@ -632,7 +636,11 @@ mod tests {
             .unwrap();
 
         // Resolve by name
-        let resolved = handle.resolve("NamedContract", None).await.unwrap().unwrap();
+        let resolved = handle
+            .resolve("NamedContract", None)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(resolved, hash);
 
         // Non-existent name

--- a/icn/crates/icn-ccl/src/registry_actor/types.rs
+++ b/icn/crates/icn-ccl/src/registry_actor/types.rs
@@ -1,0 +1,312 @@
+//! Types for the Contract Registry Actor
+//!
+//! Defines gossip messages, deployment metadata, filters, and events.
+
+use crate::ast::Contract;
+use crate::registry::{ContentHash, ContractMetadata};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// Gossip topic for contract registry sync
+pub const TOPIC_CONTRACTS: &str = "icn:contracts";
+
+/// Gossip topic for contract deployment announcements
+pub const TOPIC_CONTRACTS_DEPLOY: &str = "icn:contracts:deploy";
+
+/// Gossip topic for contract revocation announcements
+pub const TOPIC_CONTRACTS_REVOKE: &str = "icn:contracts:revoke";
+
+/// Messages sent via gossip for contract registry synchronization
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ContractRegistryMessage {
+    /// A new contract has been deployed
+    Deployed {
+        hash: ContentHash,
+        contract: Contract,
+        metadata: ContractMetadata,
+    },
+
+    /// A contract has been revoked by its owner
+    Revoked {
+        hash: ContentHash,
+        owner: String,
+        reason: String,
+        revoked_at: u64,
+    },
+
+    /// Request for a specific contract (anti-entropy)
+    Request {
+        hash: ContentHash,
+        requester: String,
+    },
+
+    /// Response with contract data
+    Response {
+        hash: ContentHash,
+        contract: Option<Contract>,
+        metadata: Option<ContractMetadata>,
+    },
+
+    /// Digest of available contracts (for anti-entropy)
+    Digest { hashes: Vec<ContentHash>, sender: String },
+}
+
+impl ContractRegistryMessage {
+    /// Serialize message to bytes
+    pub fn to_bytes(&self) -> Result<Vec<u8>, bincode::error::EncodeError> {
+        bincode::serde::encode_to_vec(self, bincode::config::legacy())
+    }
+
+    /// Deserialize message from bytes
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, bincode::error::DecodeError> {
+        bincode::serde::decode_from_slice(bytes, bincode::config::legacy()).map(|(msg, _)| msg)
+    }
+
+    /// Get the message type name for logging
+    pub fn message_type(&self) -> &'static str {
+        match self {
+            Self::Deployed { .. } => "Deployed",
+            Self::Revoked { .. } => "Revoked",
+            Self::Request { .. } => "Request",
+            Self::Response { .. } => "Response",
+            Self::Digest { .. } => "Digest",
+        }
+    }
+}
+
+/// Deployment metadata provided by the deployer
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeploymentMetadata {
+    /// Owner/deployer DID
+    pub owner: String,
+    /// Version (None for auto-increment)
+    pub version: Option<u32>,
+    /// Visibility level
+    pub visibility: Visibility,
+    /// Optional description
+    pub description: Option<String>,
+}
+
+impl DeploymentMetadata {
+    /// Create new deployment metadata
+    pub fn new(owner: impl Into<String>) -> Self {
+        Self {
+            owner: owner.into(),
+            version: None,
+            visibility: Visibility::default(),
+            description: None,
+        }
+    }
+
+    /// Set visibility
+    pub fn with_visibility(mut self, visibility: Visibility) -> Self {
+        self.visibility = visibility;
+        self
+    }
+
+    /// Set version
+    pub fn with_version(mut self, version: u32) -> Self {
+        self.version = Some(version);
+        self
+    }
+
+    /// Set description
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+}
+
+/// Contract visibility level
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum Visibility {
+    /// Only visible to owner
+    #[default]
+    Private,
+    /// Visible to cooperative members
+    Coop(String),
+    /// Publicly visible (may require governance approval)
+    Public,
+}
+
+/// Filter for listing contracts
+#[derive(Debug, Clone, Default)]
+pub struct ContractFilter {
+    /// Filter by owner DID
+    pub owner: Option<String>,
+    /// Filter by name prefix
+    pub name_prefix: Option<String>,
+    /// Filter by visibility
+    pub visibility: Option<Visibility>,
+    /// Maximum number of results
+    pub limit: Option<usize>,
+}
+
+impl ContractFilter {
+    /// Create a new empty filter
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Filter by owner
+    pub fn with_owner(mut self, owner: impl Into<String>) -> Self {
+        self.owner = Some(owner.into());
+        self
+    }
+
+    /// Filter by name prefix
+    pub fn with_name_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.name_prefix = Some(prefix.into());
+        self
+    }
+
+    /// Filter by visibility
+    pub fn with_visibility(mut self, visibility: Visibility) -> Self {
+        self.visibility = Some(visibility);
+        self
+    }
+
+    /// Limit results
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+}
+
+/// Summary of a contract for listing
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContractSummary {
+    /// Content hash
+    pub hash: ContentHash,
+    /// Contract name
+    pub name: String,
+    /// Owner DID
+    pub owner: String,
+    /// Version number
+    pub version: u32,
+    /// Deployment timestamp
+    pub deployed_at: u64,
+    /// Rule names
+    pub rules: Vec<String>,
+    /// Whether the contract is revoked
+    pub revoked: bool,
+}
+
+impl From<&ContractMetadata> for ContractSummary {
+    fn from(meta: &ContractMetadata) -> Self {
+        Self {
+            hash: meta.code_hash,
+            name: meta.name.clone(),
+            owner: meta.owner.clone(),
+            version: meta.version,
+            deployed_at: meta.deployed_at,
+            rules: meta.rules.clone(),
+            revoked: false,
+        }
+    }
+}
+
+/// Events emitted by the registry actor
+#[derive(Debug, Clone)]
+pub enum ContractRegistryEvent {
+    /// Contract was deployed
+    Deployed { hash: ContentHash, name: String },
+    /// Contract was revoked
+    Revoked { hash: ContentHash, reason: String },
+    /// Governance approval is required for a public contract
+    GovernanceApprovalRequired {
+        hash: ContentHash,
+        proposal_id: String,
+    },
+    /// Governance approved the contract
+    GovernanceApproved { hash: ContentHash },
+    /// Governance rejected the contract
+    GovernanceRejected { hash: ContentHash },
+    /// Contract was synced from a peer
+    SyncedFromPeer { hash: ContentHash, peer: String },
+}
+
+/// Approval status for contracts requiring governance
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub enum ApprovalStatus {
+    /// Approval not required (private/coop contracts)
+    #[default]
+    NotRequired,
+    /// Pending governance approval
+    Pending { proposal_id: String },
+    /// Approved by governance
+    Approved,
+    /// Rejected by governance
+    Rejected,
+}
+
+/// Callback type for sending gossip messages
+pub type SendCallback = Arc<dyn Fn(ContractRegistryMessage) + Send + Sync>;
+
+/// Callback type for emitting registry events
+pub type EventCallback = Arc<dyn Fn(ContractRegistryEvent) + Send + Sync>;
+
+/// Actor error type
+#[derive(Debug, thiserror::Error)]
+pub enum ActorError {
+    #[error("Actor channel closed")]
+    ChannelClosed,
+
+    #[error("No response from actor")]
+    NoResponse,
+
+    #[error("Registry error: {0}")]
+    Registry(#[from] crate::registry::RegistryError),
+
+    #[error("Internal error: {0}")]
+    Internal(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deployment_metadata_builder() {
+        let meta = DeploymentMetadata::new("did:icn:alice")
+            .with_visibility(Visibility::Public)
+            .with_version(2)
+            .with_description("Test contract");
+
+        assert_eq!(meta.owner, "did:icn:alice");
+        assert_eq!(meta.visibility, Visibility::Public);
+        assert_eq!(meta.version, Some(2));
+        assert_eq!(meta.description, Some("Test contract".to_string()));
+    }
+
+    #[test]
+    fn test_contract_filter_builder() {
+        let filter = ContractFilter::new()
+            .with_owner("did:icn:bob")
+            .with_name_prefix("Time")
+            .with_limit(10);
+
+        assert_eq!(filter.owner, Some("did:icn:bob".to_string()));
+        assert_eq!(filter.name_prefix, Some("Time".to_string()));
+        assert_eq!(filter.limit, Some(10));
+    }
+
+    #[test]
+    fn test_message_serialization() {
+        let msg = ContractRegistryMessage::Request {
+            hash: [1u8; 32],
+            requester: "did:icn:alice".to_string(),
+        };
+
+        let bytes = msg.to_bytes().expect("serialize");
+        let decoded = ContractRegistryMessage::from_bytes(&bytes).expect("deserialize");
+
+        match decoded {
+            ContractRegistryMessage::Request { hash, requester } => {
+                assert_eq!(hash, [1u8; 32]);
+                assert_eq!(requester, "did:icn:alice");
+            }
+            _ => panic!("Wrong message type"),
+        }
+    }
+}

--- a/icn/crates/icn-ccl/src/registry_actor/types.rs
+++ b/icn/crates/icn-ccl/src/registry_actor/types.rs
@@ -48,7 +48,10 @@ pub enum ContractRegistryMessage {
     },
 
     /// Digest of available contracts (for anti-entropy)
-    Digest { hashes: Vec<ContentHash>, sender: String },
+    Digest {
+        hashes: Vec<ContentHash>,
+        sender: String,
+    },
 }
 
 impl ContractRegistryMessage {

--- a/icn/crates/icn-ccl/src/registry_actor/types.rs
+++ b/icn/crates/icn-ccl/src/registry_actor/types.rs
@@ -3,7 +3,7 @@
 //! Defines gossip messages, deployment metadata, filters, and events.
 
 use crate::ast::Contract;
-use crate::registry::{ContentHash, ContractMetadata};
+use crate::registry::{ContentHash, ContractMetadata, Visibility};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -118,18 +118,6 @@ impl DeploymentMetadata {
         self.description = Some(description.into());
         self
     }
-}
-
-/// Contract visibility level
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub enum Visibility {
-    /// Only visible to owner
-    #[default]
-    Private,
-    /// Visible to cooperative members
-    Coop(String),
-    /// Publicly visible (may require governance approval)
-    Public,
 }
 
 /// Filter for listing contracts

--- a/icn/crates/icn-compute/src/actor/lifecycle.rs
+++ b/icn/crates/icn-compute/src/actor/lifecycle.rs
@@ -342,25 +342,30 @@ impl ComputeActor {
         }
 
         // Check if we have required capabilities
-        if !self.executor.can_execute(&task) {
-            tracing::debug!(
-                task_id = %task.id,
-                "Skipping task: missing required capabilities"
-            );
-            return Ok(()); // Can't execute this task
+        {
+            let executor = self.executor.read().await;
+            if !executor.can_execute(&task) {
+                tracing::debug!(
+                    task_id = %task.id,
+                    "Skipping task: missing required capabilities"
+                );
+                return Ok(()); // Can't execute this task
+            }
         }
 
         // Store task
         let _hash = self.task_manager.lock().await.submit(task.clone())?;
 
         // Find highest-priority pending task we can execute
-        let mgr = self.task_manager.lock().await;
-        let pending = mgr.pending_by_priority();
-        let highest_priority_task = pending
-            .into_iter()
-            .find(|(_, t)| self.executor.can_execute(t))
-            .map(|(h, _)| h);
-        drop(mgr);
+        let highest_priority_task = {
+            let mgr = self.task_manager.lock().await;
+            let pending = mgr.pending_by_priority();
+            let executor = self.executor.read().await;
+            pending
+                .into_iter()
+                .find(|(_, t)| executor.can_execute(t))
+                .map(|(h, _)| h)
+        };
 
         // Claim highest-priority task if available
         let (hash, claimed_task) = if let Some(h) = highest_priority_task {
@@ -444,9 +449,10 @@ impl ComputeActor {
 
         // Execute
         let start = std::time::Instant::now();
-        let result = self
-            .executor
-            .execute_task(&claimed_task, &self.own_did, &self.signing_key)?;
+        let result = {
+            let executor = self.executor.read().await;
+            executor.execute_task(&claimed_task, &self.own_did, &self.signing_key)?
+        };
         let duration = start.elapsed().as_secs_f64();
 
         // Record metrics

--- a/icn/crates/icn-compute/src/actor/mod.rs
+++ b/icn/crates/icn-compute/src/actor/mod.rs
@@ -162,22 +162,23 @@ impl ComputeActor {
     pub fn set_contract_registry(&mut self, registry: icn_ccl::ContractRegistryHandle) {
         // Create a resolver callback that synchronously fetches contracts from the registry
         let registry_clone = registry.clone();
-        let resolver: crate::executor::ContractResolverCallback = Arc::new(move |hash: [u8; 32]| {
-            let registry = registry_clone.clone();
-            // Use block_in_place to safely call async from sync context
-            tokio::task::block_in_place(|| {
-                tokio::runtime::Handle::current().block_on(async {
-                    match registry.get_contract(&hash).await {
-                        Ok(Some(contract)) => Some(contract),
-                        Ok(None) => None,
-                        Err(e) => {
-                            tracing::warn!("Failed to get contract from registry: {}", e);
-                            None
+        let resolver: crate::executor::ContractResolverCallback =
+            Arc::new(move |hash: [u8; 32]| {
+                let registry = registry_clone.clone();
+                // Use block_in_place to safely call async from sync context
+                tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(async {
+                        match registry.get_contract(&hash).await {
+                            Ok(Some(contract)) => Some(contract),
+                            Ok(None) => None,
+                            Err(e) => {
+                                tracing::warn!("Failed to get contract from registry: {}", e);
+                                None
+                            }
                         }
-                    }
+                    })
                 })
-            })
-        });
+            });
 
         // Set the resolver on the executor
         // Note: This requires exclusive access before spawning

--- a/icn/crates/icn-compute/src/actor/mod.rs
+++ b/icn/crates/icn-compute/src/actor/mod.rs
@@ -24,7 +24,7 @@ use types::{ExecutorInfo, ResultConsensus};
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, Mutex, RwLock};
 
 use crate::checkpoint_store::CheckpointStore;
 use crate::error::ComputeError;
@@ -40,7 +40,7 @@ pub struct ComputeActor {
     /// Task manager
     task_manager: Arc<Mutex<TaskManager>>,
     /// Local executor
-    executor: Arc<LocalExecutor>,
+    executor: Arc<RwLock<LocalExecutor>>,
     /// Callback to send gossip messages
     send_callback: Option<SendCallback>,
     /// Callback to lookup trust scores
@@ -76,6 +76,8 @@ pub struct ComputeActor {
     locality_callback: Option<LocalityCallback>,
     /// Node's own region identifier (e.g., "us-west", "eu-central")
     own_region: Option<String>,
+    /// Contract registry handle for CclRef resolution
+    contract_registry: Option<icn_ccl::ContractRegistryHandle>,
 }
 
 impl ComputeActor {
@@ -84,7 +86,7 @@ impl ComputeActor {
         Self {
             own_did,
             task_manager: Arc::new(Mutex::new(TaskManager::default())),
-            executor: Arc::new(LocalExecutor::new()),
+            executor: Arc::new(RwLock::new(LocalExecutor::new())),
             send_callback: None,
             trust_callback,
             payment_callback: None,
@@ -102,6 +104,7 @@ impl ComputeActor {
             misbehavior_detector: None, // Set via set_misbehavior_detector()
             locality_callback: None,    // Phase 16C M5: Set via set_locality_callback()
             own_region: None,           // Set via set_region() or from config
+            contract_registry: None,    // Set via set_contract_registry()
         }
     }
 
@@ -150,6 +153,41 @@ impl ComputeActor {
     /// Region identifiers should follow a consistent naming scheme (e.g., "us-west", "eu-central").
     pub fn set_region(&mut self, region: String) {
         self.own_region = Some(region);
+    }
+
+    /// Set the contract registry handle for CclRef resolution
+    ///
+    /// When set, CclRef task codes can be resolved to their contract definitions
+    /// from the contract registry before execution.
+    pub fn set_contract_registry(&mut self, registry: icn_ccl::ContractRegistryHandle) {
+        // Create a resolver callback that synchronously fetches contracts from the registry
+        let registry_clone = registry.clone();
+        let resolver: crate::executor::ContractResolverCallback = Arc::new(move |hash: [u8; 32]| {
+            let registry = registry_clone.clone();
+            // Use block_in_place to safely call async from sync context
+            tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(async {
+                    match registry.get_contract(&hash).await {
+                        Ok(Some(contract)) => Some(contract),
+                        Ok(None) => None,
+                        Err(e) => {
+                            tracing::warn!("Failed to get contract from registry: {}", e);
+                            None
+                        }
+                    }
+                })
+            })
+        });
+
+        // Set the resolver on the executor
+        // Note: This requires exclusive access before spawning
+        if let Some(executor) = Arc::get_mut(&mut self.executor) {
+            executor.get_mut().set_contract_resolver(resolver);
+        } else {
+            tracing::warn!("Cannot set contract resolver: executor already shared");
+        }
+
+        self.contract_registry = Some(registry);
     }
 
     /// Set maximum concurrent tasks this executor will claim

--- a/icn/crates/icn-compute/src/actor/mod.rs
+++ b/icn/crates/icn-compute/src/actor/mod.rs
@@ -184,11 +184,11 @@ impl ComputeActor {
         // Note: This requires exclusive access before spawning
         if let Some(executor) = Arc::get_mut(&mut self.executor) {
             executor.get_mut().set_contract_resolver(resolver);
+            // Only record the registry if we successfully configured the resolver
+            self.contract_registry = Some(registry);
         } else {
             tracing::warn!("Cannot set contract resolver: executor already shared");
         }
-
-        self.contract_registry = Some(registry);
     }
 
     /// Set maximum concurrent tasks this executor will claim

--- a/icn/crates/icn-compute/src/executor.rs
+++ b/icn/crates/icn-compute/src/executor.rs
@@ -96,12 +96,11 @@ impl LocalExecutor {
         }
 
         // Parse caller DID
-        let caller_did: icn_identity::Did = match serde_json::from_value(
-            serde_json::Value::String(ctx.executor_did.clone()),
-        ) {
-            Ok(d) => d,
-            Err(e) => return ExecutionOutcome::Failed(format!("Invalid caller DID: {e}")),
-        };
+        let caller_did: icn_identity::Did =
+            match serde_json::from_value(serde_json::Value::String(ctx.executor_did.clone())) {
+                Ok(d) => d,
+                Err(e) => return ExecutionOutcome::Failed(format!("Invalid caller DID: {e}")),
+            };
 
         // Create execution context for CCL
         let timestamp = icn_time::current_timestamp_secs();
@@ -132,8 +131,7 @@ impl LocalExecutor {
                 ctx.fuel_remaining = ctx.fuel_remaining.saturating_sub(result.fuel_consumed);
 
                 // Serialize result
-                let output =
-                    serde_json::to_vec(&result.value).unwrap_or_else(|_| b"null".to_vec());
+                let output = serde_json::to_vec(&result.value).unwrap_or_else(|_| b"null".to_vec());
                 ExecutionOutcome::Success(output)
             }
             Err(e) => {

--- a/icn/crates/icn-compute/src/executor.rs
+++ b/icn/crates/icn-compute/src/executor.rs
@@ -1,9 +1,15 @@
 //! Task execution engine.
 
+use std::sync::Arc;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use crate::error::ComputeError;
 use crate::types::{ComputeResult, ComputeTask, ExecutionOutcome, ExecutorCapability, TaskCode};
+
+/// Callback type for resolving contract references from the registry
+/// Takes a contract hash and returns the contract if found
+pub type ContractResolverCallback =
+    Arc<dyn Fn([u8; 32]) -> Option<icn_ccl::Contract> + Send + Sync>;
 
 /// Execution context provided to the executor
 pub struct ExecutionContext {
@@ -47,6 +53,8 @@ pub trait Executor: Send + Sync {
 /// Local CCL executor (placeholder - will integrate with icn-ccl)
 pub struct LocalExecutor {
     capabilities: Vec<ExecutorCapability>,
+    /// Optional contract resolver for CclRef resolution
+    contract_resolver: Option<ContractResolverCallback>,
 }
 
 impl LocalExecutor {
@@ -54,6 +62,88 @@ impl LocalExecutor {
     pub fn new() -> Self {
         Self {
             capabilities: vec![ExecutorCapability::Ccl],
+            contract_resolver: None,
+        }
+    }
+
+    /// Set the contract resolver callback for CclRef resolution
+    pub fn set_contract_resolver(&mut self, resolver: ContractResolverCallback) {
+        self.contract_resolver = Some(resolver);
+    }
+
+    /// Execute a CCL contract with a specific rule
+    ///
+    /// This helper handles the common CCL execution logic for both inline contracts
+    /// and contract references resolved from the registry.
+    fn execute_ccl_inline(
+        &self,
+        contract: &icn_ccl::Contract,
+        rule_name: &str,
+        task: &ComputeTask,
+        ctx: &mut ExecutionContext,
+    ) -> ExecutionOutcome {
+        // Validate contract structure
+        if let Err(e) = contract.validate() {
+            return ExecutionOutcome::Failed(format!("Contract validation failed: {e}"));
+        }
+
+        // Use the specified rule name
+        let rule = rule_name.to_string();
+
+        // Check that the rule exists
+        if contract.get_rule(&rule).is_none() {
+            return ExecutionOutcome::Failed(format!("Rule '{}' not found in contract", rule));
+        }
+
+        // Parse caller DID
+        let caller_did: icn_identity::Did = match serde_json::from_value(
+            serde_json::Value::String(ctx.executor_did.clone()),
+        ) {
+            Ok(d) => d,
+            Err(e) => return ExecutionOutcome::Failed(format!("Invalid caller DID: {e}")),
+        };
+
+        // Create execution context for CCL
+        let timestamp = icn_time::current_timestamp_secs();
+
+        let ccl_context = icn_ccl::ExecutionContext {
+            caller: caller_did.clone(),
+            timestamp,
+            fuel: ctx.fuel_remaining,
+            capabilities: vec![],
+            participants: vec![caller_did],
+        };
+
+        // Create contract state
+        let state = icn_ccl::ContractState::default();
+
+        // Parse inputs as arguments
+        let args: std::collections::HashMap<String, icn_ccl::Value> = if task.inputs.is_empty() {
+            std::collections::HashMap::new()
+        } else {
+            serde_json::from_slice(&task.inputs).unwrap_or_default()
+        };
+
+        // Execute via interpreter
+        let interpreter = icn_ccl::Interpreter::new(contract.clone(), state, ccl_context);
+        match interpreter.execute_rule(&rule, args) {
+            Ok(result) => {
+                // Update fuel consumed
+                ctx.fuel_remaining = ctx.fuel_remaining.saturating_sub(result.fuel_consumed);
+
+                // Serialize result
+                let output =
+                    serde_json::to_vec(&result.value).unwrap_or_else(|_| b"null".to_vec());
+                ExecutionOutcome::Success(output)
+            }
+            Err(e) => {
+                let err_str = e.to_string();
+                if err_str.contains("fuel") || err_str.contains("Fuel") {
+                    ExecutionOutcome::OutOfFuel
+                } else {
+                    ExecutionOutcome::Failed(err_str)
+                }
+            }
         }
     }
 
@@ -204,18 +294,45 @@ impl Executor for LocalExecutor {
                 }
             }
             TaskCode::CclRef { hash, rule } => {
-                // CclRef requires a contract registry to be set up
-                // The registry lookup should be handled at a higher level (ComputeActor)
-                // which resolves CclRef to Ccl before calling the executor
+                // CclRef requires a contract registry to resolve the hash
                 let hash_hex = hex::encode(hash);
-                tracing::warn!(
-                    hash = %hash_hex,
-                    rule = %rule,
-                    "CclRef requires contract registry (not yet integrated)"
-                );
-                ExecutionOutcome::Failed(format!(
-                    "Contract reference {hash_hex} not resolved. Registry integration pending."
-                ))
+
+                match &self.contract_resolver {
+                    Some(resolver) => {
+                        // Resolve the contract from the registry
+                        match resolver(*hash) {
+                            Some(contract) => {
+                                // Execute the resolved contract
+                                tracing::debug!(
+                                    hash = %hash_hex,
+                                    rule = %rule,
+                                    "Resolved CclRef, executing contract"
+                                );
+                                self.execute_ccl_inline(&contract, rule, task, ctx)
+                            }
+                            None => {
+                                tracing::warn!(
+                                    hash = %hash_hex,
+                                    rule = %rule,
+                                    "Contract not found in registry"
+                                );
+                                ExecutionOutcome::Failed(format!(
+                                    "Contract {hash_hex} not found in registry"
+                                ))
+                            }
+                        }
+                    }
+                    None => {
+                        tracing::warn!(
+                            hash = %hash_hex,
+                            rule = %rule,
+                            "CclRef requires contract registry (not configured)"
+                        );
+                        ExecutionOutcome::Failed(format!(
+                            "Contract registry not configured. Cannot resolve {hash_hex}."
+                        ))
+                    }
+                }
             }
             TaskCode::WasmRef(_) | TaskCode::WasmInline(_) => {
                 ExecutionOutcome::Failed("WASM not yet supported".into())

--- a/icn/crates/icn-compute/src/lib.rs
+++ b/icn/crates/icn-compute/src/lib.rs
@@ -61,7 +61,7 @@ pub use dispute::{
     DisputeStatus, Evidence, EvidenceType, VerificationMode,
 };
 pub use error::ComputeError;
-pub use executor::{ExecutionContext, Executor, LocalExecutor};
+pub use executor::{ContractResolverCallback, ExecutionContext, Executor, LocalExecutor};
 pub use migration_manager::{ActorMigrationManager, MigrationSender};
 pub use migration_policy::{
     DefaultMigrationPolicy, ExecutorInfo, LocalityFirstPolicy, MigrationPolicy, NetworkState,

--- a/icn/crates/icn-core/src/supervisor/init_compute.rs
+++ b/icn/crates/icn-core/src/supervisor/init_compute.rs
@@ -38,6 +38,8 @@ pub struct ComputeDeps {
     pub identity_bundle: icn_identity::IdentityBundle,
     /// Store path for dispute storage
     pub store_path: std::path::PathBuf,
+    /// Contract registry for CclRef resolution (optional)
+    pub contract_registry: Option<icn_ccl::ContractRegistryHandle>,
 }
 
 /// Services returned from compute initialization
@@ -371,6 +373,12 @@ pub async fn init_compute_services(deps: ComputeDeps) -> anyhow::Result<ComputeS
         let locality_callback = create_locality_callback(neighbor_sets.clone());
         compute_actor.set_locality_callback(locality_callback);
         info!("Locality callback set for compute placement");
+    }
+
+    // Set contract registry for CclRef resolution
+    if let Some(ref registry) = deps.contract_registry {
+        compute_actor.set_contract_registry(registry.clone());
+        info!("Contract registry set for CclRef resolution");
     }
 
     // Spawn the compute actor

--- a/icn/crates/icn-core/src/supervisor/init_contract_registry.rs
+++ b/icn/crates/icn-core/src/supervisor/init_contract_registry.rs
@@ -1,0 +1,155 @@
+//! Contract Registry actor initialization
+//!
+//! This module extracts the contract registry actor setup from the supervisor,
+//! providing a cleaner separation of concerns for contract management services.
+
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::info;
+
+use icn_ccl::{
+    ContractRegistry, ContractRegistryActor, ContractRegistryHandle, ContractRegistryMessage,
+    TOPIC_CONTRACTS, TOPIC_CONTRACTS_DEPLOY, TOPIC_CONTRACTS_REVOKE,
+};
+use icn_identity::Did;
+use icn_store::SledStore;
+
+use crate::config::Config;
+
+/// Type alias for the gossip handle
+pub type GossipHandle = Arc<RwLock<icn_gossip::GossipActor>>;
+
+/// Dependencies required for contract registry initialization
+pub struct ContractRegistryDeps {
+    /// Handle to the gossip actor for message synchronization
+    pub gossip_handle: GossipHandle,
+    /// Shutdown signal receiver
+    pub shutdown_rx: tokio::sync::broadcast::Receiver<()>,
+}
+
+/// Services returned from contract registry initialization
+pub struct ContractRegistryServices {
+    /// Handle to the contract registry actor
+    pub registry_handle: ContractRegistryHandle,
+    /// Contract registry store (for potential direct access)
+    pub registry_store: Arc<dyn icn_store::Store>,
+}
+
+/// Initialize contract registry services
+///
+/// Creates:
+/// - ContractRegistryActor for contract storage and gossip sync
+/// - Persistent storage at store_path/contract_registry
+/// - Gossip topic subscriptions for contract sync
+pub async fn init_contract_registry_services(
+    config: &Config,
+    did: Did,
+    deps: ContractRegistryDeps,
+) -> anyhow::Result<ContractRegistryServices> {
+    // Create contract registry topics before spawning actor
+    {
+        let mut gossip = deps.gossip_handle.write().await;
+
+        // Main contracts topic for queries/responses
+        gossip.create_topic(icn_gossip::Topic::new(
+            TOPIC_CONTRACTS.to_string(),
+            icn_gossip::AccessControl::Public,
+        ));
+
+        // Deployment announcements topic
+        gossip.create_topic(icn_gossip::Topic::new(
+            TOPIC_CONTRACTS_DEPLOY.to_string(),
+            icn_gossip::AccessControl::Public,
+        ));
+
+        // Revocation announcements topic
+        gossip.create_topic(icn_gossip::Topic::new(
+            TOPIC_CONTRACTS_REVOKE.to_string(),
+            icn_gossip::AccessControl::Public,
+        ));
+    }
+
+    // Open persistent store for contract registry
+    let registry_store_path = config.store_path().join("contract_registry");
+    let registry_store: Arc<dyn icn_store::Store> =
+        Arc::new(SledStore::open(&registry_store_path)?);
+
+    // Create the contract registry with persistent storage
+    let contract_registry = Arc::new(ContractRegistry::with_store(registry_store.clone()));
+
+    // Create send callback for gossip messages
+    let gossip_for_send = deps.gossip_handle.clone();
+    let send_callback = Arc::new(move |msg: ContractRegistryMessage| {
+        let gossip = gossip_for_send.clone();
+        let topic = match &msg {
+            ContractRegistryMessage::Deployed { .. } => TOPIC_CONTRACTS_DEPLOY,
+            ContractRegistryMessage::Revoked { .. } => TOPIC_CONTRACTS_REVOKE,
+            _ => TOPIC_CONTRACTS,
+        };
+
+        tokio::spawn(async move {
+            let bytes = match msg.to_bytes() {
+                Ok(b) => b,
+                Err(e) => {
+                    tracing::warn!("Failed to serialize contract registry message: {}", e);
+                    return;
+                }
+            };
+
+            let mut gossip = gossip.write().await;
+            if let Err(e) = gossip.publish(topic, bytes) {
+                tracing::warn!("Failed to publish contract registry message: {}", e);
+            }
+        });
+    });
+
+    // Create the actor with the contract registry
+    let mut actor = ContractRegistryActor::new(did.to_string(), contract_registry);
+    actor.set_send_callback(send_callback);
+
+    // Spawn the actor
+    let registry_handle = actor.spawn();
+
+    info!(
+        "✓ Contract registry actor spawned at {}",
+        registry_store_path.display()
+    );
+    icn_obs::metrics::supervisor::actor_spawned_inc("contract_registry");
+
+    // Subscribe to contract registry topics
+    {
+        let mut gossip = deps.gossip_handle.write().await;
+
+        // Subscribe to all contract topics
+        if let Err(e) = gossip.subscribe(TOPIC_CONTRACTS, did.clone()) {
+            tracing::warn!("Failed to subscribe to {}: {}", TOPIC_CONTRACTS, e);
+        }
+
+        if let Err(e) = gossip.subscribe(TOPIC_CONTRACTS_DEPLOY, did.clone()) {
+            tracing::warn!("Failed to subscribe to {}: {}", TOPIC_CONTRACTS_DEPLOY, e);
+        }
+
+        if let Err(e) = gossip.subscribe(TOPIC_CONTRACTS_REVOKE, did.clone()) {
+            tracing::warn!("Failed to subscribe to {}: {}", TOPIC_CONTRACTS_REVOKE, e);
+        }
+
+        info!("✓ Subscribed to contract registry gossip topics");
+    }
+
+    Ok(ContractRegistryServices {
+        registry_handle,
+        registry_store,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_contract_registry_deps_struct() {
+        // Verify ContractRegistryDeps fields are accessible
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<GossipHandle>();
+    }
+}

--- a/icn/crates/icn-core/src/supervisor/init_contract_registry.rs
+++ b/icn/crates/icn-core/src/supervisor/init_contract_registry.rs
@@ -23,8 +23,6 @@ pub type GossipHandle = Arc<RwLock<icn_gossip::GossipActor>>;
 pub struct ContractRegistryDeps {
     /// Handle to the gossip actor for message synchronization
     pub gossip_handle: GossipHandle,
-    /// Shutdown signal receiver
-    pub shutdown_rx: tokio::sync::broadcast::Receiver<()>,
 }
 
 /// Services returned from contract registry initialization

--- a/icn/crates/icn-core/src/supervisor/init_notifications.rs
+++ b/icn/crates/icn-core/src/supervisor/init_notifications.rs
@@ -26,6 +26,7 @@ pub type ProfileCache = Arc<RwLock<HashMap<Did, crate::node::NodeProfile>>>;
 pub type CandidateCache = Arc<icn_net::CandidateCache>;
 pub type FederationGossipHandle = Arc<icn_federation::FederationGossipHandler>;
 pub type AttestationRateLimiterHandle = Arc<crate::trust_propagation::AttestationRateLimiter>;
+pub type ContractRegistryHolder = Arc<RwLock<Option<icn_ccl::ContractRegistryHandle>>>;
 
 /// Dependencies required for notification callback handlers
 #[derive(Clone)]
@@ -62,6 +63,8 @@ pub struct NotificationDeps {
     pub federation_handler: Option<FederationGossipHandle>,
     /// Rate limiter for trust attestations
     pub attestation_rate_limiter: AttestationRateLimiterHandle,
+    /// Contract registry handle holder for gossip sync (filled after actor spawns)
+    pub contract_registry: ContractRegistryHolder,
 }
 
 /// Handle trust attestation entries
@@ -109,6 +112,23 @@ pub async fn handle_contract_deployment(entry_data: Vec<u8>, contract_actor: Con
         Err(e) => {
             warn!("Failed to deserialize contract deployment message: {}", e);
             icn_obs::metrics::contract::deployments_rejected_inc("deserialization_error");
+        }
+    }
+}
+
+/// Handle contract registry gossip messages (icn:contracts* topics)
+pub async fn handle_contract_registry_message(
+    entry_data: Vec<u8>,
+    registry_handle: icn_ccl::ContractRegistryHandle,
+) {
+    match icn_ccl::ContractRegistryMessage::from_bytes(&entry_data) {
+        Ok(msg) => {
+            if let Err(e) = registry_handle.handle_gossip(msg).await {
+                warn!("Failed to handle contract registry message: {}", e);
+            }
+        }
+        Err(e) => {
+            warn!("Failed to deserialize contract registry message: {}", e);
         }
     }
 }
@@ -783,6 +803,18 @@ pub fn create_notification_callback(
                         handle_federation_message(&topic, data, handler).await;
                     });
                 }
+            }
+        } else if topic == icn_ccl::TOPIC_CONTRACTS
+            || topic == icn_ccl::TOPIC_CONTRACTS_DEPLOY
+            || topic == icn_ccl::TOPIC_CONTRACTS_REVOKE
+        {
+            let registry_holder = deps.contract_registry.clone();
+            if let Some(data) = entry_data {
+                tokio::spawn(async move {
+                    if let Some(registry) = registry_holder.read().await.as_ref() {
+                        handle_contract_registry_message(data, registry.clone()).await;
+                    }
+                });
             }
         }
     })

--- a/icn/crates/icn-core/src/supervisor/mod.rs
+++ b/icn/crates/icn-core/src/supervisor/mod.rs
@@ -341,6 +341,11 @@ impl Supervisor {
                 tokio::sync::RwLock<Option<icn_steward::StewardHandle>>,
             > = Arc::new(tokio::sync::RwLock::new(None));
 
+            // Create contract registry handle holder (will be filled after ContractRegistryActor is spawned)
+            let contract_registry_holder: Arc<
+                tokio::sync::RwLock<Option<icn_ccl::ContractRegistryHandle>>,
+            > = Arc::new(tokio::sync::RwLock::new(None));
+
             // Keep a reference to federation registry for RPC server (declared here to be in scope for later use)
             let federation_registry_for_rpc: Option<Arc<icn_federation::CooperativeRegistry>>;
 
@@ -561,6 +566,7 @@ impl Supervisor {
                         coop_store: coop_store_for_notifications,
                         federation_handler: federation_handler_for_notifications,
                         attestation_rate_limiter,
+                        contract_registry: contract_registry_holder.clone(),
                     },
                 );
 
@@ -854,16 +860,21 @@ impl Supervisor {
             info!("✓ Governance event handlers registered");
 
             // Initialize contract registry services
-            let contract_registry_services = init_contract_registry::init_contract_registry_services(
-                &self.config,
-                did.clone(),
-                init_contract_registry::ContractRegistryDeps {
-                    gossip_handle: gossip_handle.clone(),
-                    shutdown_rx: self.shutdown_tx.subscribe(),
-                },
-            )
-            .await?;
+            let contract_registry_services =
+                init_contract_registry::init_contract_registry_services(
+                    &self.config,
+                    did.clone(),
+                    init_contract_registry::ContractRegistryDeps {
+                        gossip_handle: gossip_handle.clone(),
+                        shutdown_rx: self.shutdown_tx.subscribe(),
+                    },
+                )
+                .await?;
             let contract_registry_handle = contract_registry_services.registry_handle;
+
+            // Fill the contract registry holder for notification routing
+            *contract_registry_holder.write().await = Some(contract_registry_handle.clone());
+            info!("✓ Contract registry handle available for gossip routing");
 
             // Initialize compute actor using extracted module
             let compute_services = init_compute::init_compute_services(init_compute::ComputeDeps {

--- a/icn/crates/icn-core/src/supervisor/mod.rs
+++ b/icn/crates/icn-core/src/supervisor/mod.rs
@@ -3,6 +3,7 @@
 pub mod background_tasks;
 pub mod governance_handlers;
 pub mod init_compute;
+pub mod init_contract_registry;
 pub mod init_coop;
 pub mod init_gossip;
 pub mod init_governance;
@@ -852,6 +853,18 @@ impl Supervisor {
 
             info!("✓ Governance event handlers registered");
 
+            // Initialize contract registry services
+            let contract_registry_services = init_contract_registry::init_contract_registry_services(
+                &self.config,
+                did.clone(),
+                init_contract_registry::ContractRegistryDeps {
+                    gossip_handle: gossip_handle.clone(),
+                    shutdown_rx: self.shutdown_tx.subscribe(),
+                },
+            )
+            .await?;
+            let contract_registry_handle = contract_registry_services.registry_handle;
+
             // Initialize compute actor using extracted module
             let compute_services = init_compute::init_compute_services(init_compute::ComputeDeps {
                 trust_graph: trust_graph_handle.clone(),
@@ -864,6 +877,7 @@ impl Supervisor {
                 misbehavior_detector: misbehavior_detector.clone(),
                 identity_bundle: identity_bundle.clone(),
                 store_path: self.config.store_path(),
+                contract_registry: Some(contract_registry_handle.clone()),
             })
             .await?;
 

--- a/icn/crates/icn-core/src/supervisor/mod.rs
+++ b/icn/crates/icn-core/src/supervisor/mod.rs
@@ -866,7 +866,6 @@ impl Supervisor {
                     did.clone(),
                     init_contract_registry::ContractRegistryDeps {
                         gossip_handle: gossip_handle.clone(),
-                        shutdown_rx: self.shutdown_tx.subscribe(),
                     },
                 )
                 .await?;


### PR DESCRIPTION
## Summary

Implements Issue #200: Create a ContractRegistryActor that wraps the existing ContractRegistry with:
- Gossip-based synchronization across nodes
- Supervisor integration for lifecycle management  
- ComputeActor integration for CclRef resolution

## Changes

### registry_actor module (icn-ccl)
- `ContractRegistryActor` with spawn(), message loop, and command handlers
- `ContractRegistryHandle` with async API methods (register, get, list, resolve, revoke)
- `ContractRegistryMessage` enum for gossip sync (Deploy, Revoke, Request, Response, Digest)
- `DeploymentMetadata`, `Visibility`, `ContractFilter` types
- Gossip topics: `icn:contracts`, `icn:contracts:deploy`, `icn:contracts:revoke`

### ComputeActor integration (icn-compute)
- Add `contract_registry` field and `set_contract_registry()` setter
- Add `ContractResolverCallback` type for CclRef resolution
- Update `LocalExecutor` with contract resolver callback
- Implement `execute_ccl_inline` helper for CclRef execution
- Change executor field to `Arc<RwLock<LocalExecutor>>` for mutation after creation

### Supervisor integration (icn-core)
- Add `init_contract_registry.rs` initialization module
- Wire `ContractRegistryActor` into supervisor after governance init
- Pass registry handle to ComputeActor via `ComputeDeps`
- Add `contract_registry` field to `ComputeDeps` struct

## Test plan
- [x] All 84 icn-ccl tests pass
- [x] All 148 icn-compute unit tests pass  
- [x] All 17 icn-compute integration tests pass
- [x] icn-core builds and tests pass
- [x] Full workspace builds successfully
- [ ] Manual testing with contract deployment via gateway API

## Architecture

```
┌─────────────────┐     ┌──────────────────────┐     ┌────────────────┐
│  Gateway API    │────▶│ ContractRegistryActor│────▶│ ContractRegistry│
│  POST /contracts│     │  (gossip sync)        │     │  (storage)      │
└─────────────────┘     └──────────────────────┘     └────────────────┘
                               │
                               ▼
                        ┌──────────────────┐
                        │   ComputeActor   │
                        │ (CclRef resolve) │
                        └──────────────────┘
```

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)