### PR TITLE
fix(gateway): add rate limiter error metrics (#216)

### DIFF
--- a/icn/crates/icn-gateway/src/rate_limit.rs
+++ b/icn/crates/icn-gateway/src/rate_limit.rs
@@ -400,7 +400,7 @@ impl IpRateLimiter {
                 "IP rate limit exceeded for: {} (available: {:.2}, needed: {:.2})",
                 ip, available, self.config.cost_per_request
             );
-            gateway::ip_rate_limit_exceeded_inc(ip);
+            gateway::ip_rate_limit_exceeded_inc();
             Err(GatewayError::RateLimitExceeded(format!("IP: {ip}")))
         }
     }

--- a/icn/crates/icn-gateway/src/rate_limit.rs
+++ b/icn/crates/icn-gateway/src/rate_limit.rs
@@ -400,6 +400,7 @@ impl IpRateLimiter {
                 "IP rate limit exceeded for: {} (available: {:.2}, needed: {:.2})",
                 ip, available, self.config.cost_per_request
             );
+            gateway::ip_rate_limit_exceeded_inc(ip);
             Err(GatewayError::RateLimitExceeded(format!("IP: {ip}")))
         }
     }

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -2480,10 +2480,11 @@ pub mod gateway {
     }
 
     /// Increment counter when IP-based rate limit is exceeded
-    pub fn ip_rate_limit_exceeded_inc(ip: &str) {
-        counter!("icn_gateway_ip_rate_limit_exceeded_total",
-                 "ip" => ip.to_string())
-        .increment(1);
+    ///
+    /// Note: IP address is intentionally not included as a label to avoid
+    /// unbounded metric cardinality from public internet traffic.
+    pub fn ip_rate_limit_exceeded_inc() {
+        counter!("icn_gateway_ip_rate_limit_exceeded_total").increment(1);
     }
 
     pub fn authorization_failures_inc(required_scope: &str) {

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -770,6 +770,14 @@ pub fn init_descriptions() {
         "Total number of requests rejected due to rate limiting"
     );
     describe_counter!(
+        "icn_gateway_velocity_limit_exceeded_total",
+        "Total number of transactions rejected due to velocity limiting"
+    );
+    describe_counter!(
+        "icn_gateway_ip_rate_limit_exceeded_total",
+        "Total number of requests rejected due to IP-based rate limiting"
+    );
+    describe_counter!(
         "icn_gateway_authorization_failures_total",
         "Total number of authorization failures by required scope"
     );
@@ -2469,6 +2477,13 @@ pub mod gateway {
     /// Increment counter when transaction velocity limit is exceeded (Issue #164)
     pub fn velocity_limit_exceeded_inc() {
         counter!("icn_gateway_velocity_limit_exceeded_total").increment(1);
+    }
+
+    /// Increment counter when IP-based rate limit is exceeded
+    pub fn ip_rate_limit_exceeded_inc(ip: &str) {
+        counter!("icn_gateway_ip_rate_limit_exceeded_total",
+                 "ip" => ip.to_string())
+        .increment(1);
     }
 
     pub fn authorization_failures_inc(required_scope: &str) {


### PR DESCRIPTION
## Summary

- Add missing `describe_counter!` for `velocity_limit_exceeded_total` metric
- Add `describe_counter!` for new `ip_rate_limit_exceeded_total` metric
- Add `ip_rate_limit_exceeded_inc()` function with `ip` label
- Wire IP metric increment in `IpRateLimiter::check_rate_limit`

All rate limit error paths now have corresponding metrics for monitoring:
| Metric | Labels | Location |
|--------|--------|----------|
| `icn_gateway_rate_limit_exceeded_total` | `did` | RateLimiter, CategoryRateLimiter |
| `icn_gateway_velocity_limit_exceeded_total` | none | VelocityLimiter |
| `icn_gateway_ip_rate_limit_exceeded_total` | `ip` | IpRateLimiter (**NEW**) |

Closes #216

## Test plan

- [x] Build succeeds: `cargo build -p icn-obs -p icn-gateway`
- [x] Tests pass: `cargo test -p icn-gateway rate_limit`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)