### PR TITLE
fix(compute): document executor error safety (#217)

### DIFF
--- a/icn/crates/icn-compute/src/executor.rs
+++ b/icn/crates/icn-compute/src/executor.rs
@@ -190,6 +190,8 @@ impl LocalExecutor {
         let signing_key_bytes: [u8; 32] = signing_key
             .try_into()
             .map_err(|_| ComputeError::InvalidSignature("Invalid signing key length".into()))?;
+        // SAFETY: SigningKey::from_bytes is infallible for any 32-byte array.
+        // Length is already validated by try_into() above.
         let ed25519_key = ed25519_dalek::SigningKey::from_bytes(&signing_key_bytes);
 
         let mut result = ComputeResult {


### PR DESCRIPTION
## Summary

After thorough investigation, the executor code is **already panic-safe**. This PR adds documentation explaining why `SigningKey::from_bytes` is infallible for validated 32-byte arrays.

## Investigation Findings

| Location | Type | Status |
|----------|------|--------|
| `executor.rs:186` | `.unwrap_or(Duration::ZERO)` | ✅ Safe - has fallback |
| `executor.rs:193` | `SigningKey::from_bytes()` | ✅ Safe - infallible for 32-byte arrays |
| `executor.rs:435,459,476` | `.unwrap()` in tests | ✅ Acceptable in test code |
| `wasm_executor.rs:257,267` | `.expect()` in Default | ✅ Intentional - has SAFETY comment |

### Issue's Original Concerns (NOT FOUND in current code)
- ❌ Checkpoint store `.expect()` - not present
- ❌ Resource measurement `.unwrap()` - not present  
- ❌ Policy parsing `.unwrap()` - not present

### Metrics Coverage Verified
- `ExecutionOutcome::Failed` → `tasks_failed_inc(reason)` ✅
- `ExecutionOutcome::OutOfFuel` → `tasks_out_of_fuel_inc()` ✅
- `ExecutionOutcome::Timeout` → `tasks_timeout_inc()` ✅

## Changes

- Add SAFETY comment to `SigningKey::from_bytes` explaining infallibility

Closes #217

## Test plan

- [x] Build succeeds: `cargo build -p icn-compute`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)