### PR TITLE
feat(contracts): add contract management bundle (#201, #202, #203)

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -2916,6 +2916,7 @@ dependencies = [
  "ed25519-dalek",
  "futures-util",
  "hex",
+ "icn-ccl",
  "icn-community",
  "icn-compute",
  "icn-coop",

--- a/icn/crates/icn-ccl/src/lib.rs
+++ b/icn/crates/icn-ccl/src/lib.rs
@@ -79,8 +79,9 @@ pub use registry::{
     Visibility,
 };
 pub use registry_actor::{
-    ContractRegistryActor, ContractRegistryHandle, ContractRegistryMessage, ContractSummary,
-    DeploymentMetadata, TOPIC_CONTRACTS, TOPIC_CONTRACTS_DEPLOY, TOPIC_CONTRACTS_REVOKE,
+    ContractRegistryActor, ContractRegistryHandle, ContractRegistryMessage, ContractStatus,
+    ContractSummary, DeploymentMetadata, TOPIC_CONTRACTS, TOPIC_CONTRACTS_DEPLOY,
+    TOPIC_CONTRACTS_REVOKE,
 };
 pub use runtime::{ContractInfo, ContractRuntime};
 pub use types::{

--- a/icn/crates/icn-ccl/src/registry_actor/command.rs
+++ b/icn/crates/icn-ccl/src/registry_actor/command.rs
@@ -7,7 +7,8 @@ use crate::registry::{ContentHash, ContractMetadata, RegistryError, RegistryStat
 use tokio::sync::oneshot;
 
 use super::types::{
-    ApprovalStatus, ContractFilter, ContractRegistryMessage, ContractSummary, DeploymentMetadata,
+    ApprovalStatus, ContractFilter, ContractRegistryMessage, ContractStatus, ContractSummary,
+    DeploymentMetadata,
 };
 
 /// Commands sent to the ContractRegistryActor
@@ -50,6 +51,27 @@ pub(crate) enum ContractRegistryCommand {
         requester: String,
         reason: String,
         resp: oneshot::Sender<Result<(), RegistryError>>,
+    },
+
+    /// Deprecate a contract with optional successor (owner only)
+    Deprecate {
+        hash: ContentHash,
+        requester: String,
+        successor: Option<ContentHash>,
+        reason: String,
+        resp: oneshot::Sender<Result<(), RegistryError>>,
+    },
+
+    /// Get contract lifecycle status
+    GetStatus {
+        hash: ContentHash,
+        resp: oneshot::Sender<Option<ContractStatus>>,
+    },
+
+    /// Get version history for a contract by name
+    GetVersionHistory {
+        name: String,
+        resp: oneshot::Sender<Vec<(u32, ContentHash)>>,
     },
 
     /// Handle incoming gossip message
@@ -105,6 +127,25 @@ impl std::fmt::Debug for ContractRegistryCommand {
                 .debug_struct("Revoke")
                 .field("hash", &hex::encode(hash))
                 .field("requester", requester)
+                .finish(),
+            Self::Deprecate {
+                hash,
+                requester,
+                successor,
+                ..
+            } => f
+                .debug_struct("Deprecate")
+                .field("hash", &hex::encode(hash))
+                .field("requester", requester)
+                .field("successor", &successor.map(hex::encode))
+                .finish(),
+            Self::GetStatus { hash, .. } => f
+                .debug_struct("GetStatus")
+                .field("hash", &hex::encode(hash))
+                .finish(),
+            Self::GetVersionHistory { name, .. } => f
+                .debug_struct("GetVersionHistory")
+                .field("name", name)
                 .finish(),
             Self::GossipMessage(msg) => f
                 .debug_struct("GossipMessage")

--- a/icn/crates/icn-ccl/src/registry_actor/handle.rs
+++ b/icn/crates/icn-ccl/src/registry_actor/handle.rs
@@ -8,8 +8,8 @@ use tokio::sync::{mpsc, oneshot};
 
 use super::command::ContractRegistryCommand;
 use super::types::{
-    ActorError, ApprovalStatus, ContractFilter, ContractRegistryMessage, ContractSummary,
-    DeploymentMetadata,
+    ActorError, ApprovalStatus, ContractFilter, ContractRegistryMessage, ContractStatus,
+    ContractSummary, DeploymentMetadata,
 };
 
 /// Handle for interacting with the ContractRegistryActor
@@ -147,6 +147,71 @@ impl ContractRegistryHandle {
             .await
             .map_err(|_| ActorError::NoResponse)?
             .map_err(ActorError::Registry)
+    }
+
+    /// Deprecate a contract with optional successor (owner only)
+    ///
+    /// # Arguments
+    /// * `hash` - Content hash of the contract to deprecate
+    /// * `requester` - DID of the requester (must be owner)
+    /// * `successor` - Optional hash of the replacement contract
+    /// * `reason` - Reason for deprecation
+    pub async fn deprecate_contract(
+        &self,
+        hash: &ContentHash,
+        requester: &str,
+        successor: Option<ContentHash>,
+        reason: String,
+    ) -> Result<(), ActorError> {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.tx
+            .send(ContractRegistryCommand::Deprecate {
+                hash: *hash,
+                requester: requester.to_string(),
+                successor,
+                reason,
+                resp: resp_tx,
+            })
+            .await
+            .map_err(|_| ActorError::ChannelClosed)?;
+        resp_rx
+            .await
+            .map_err(|_| ActorError::NoResponse)?
+            .map_err(ActorError::Registry)
+    }
+
+    /// Get the lifecycle status of a contract
+    pub async fn get_status(
+        &self,
+        hash: &ContentHash,
+    ) -> Result<Option<ContractStatus>, ActorError> {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.tx
+            .send(ContractRegistryCommand::GetStatus {
+                hash: *hash,
+                resp: resp_tx,
+            })
+            .await
+            .map_err(|_| ActorError::ChannelClosed)?;
+        resp_rx.await.map_err(|_| ActorError::NoResponse)
+    }
+
+    /// Get version history for a contract by name
+    ///
+    /// Returns a list of (version, hash) pairs for all versions of the contract.
+    pub async fn get_version_history(
+        &self,
+        name: &str,
+    ) -> Result<Vec<(u32, ContentHash)>, ActorError> {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.tx
+            .send(ContractRegistryCommand::GetVersionHistory {
+                name: name.to_string(),
+                resp: resp_tx,
+            })
+            .await
+            .map_err(|_| ActorError::ChannelClosed)?;
+        resp_rx.await.map_err(|_| ActorError::NoResponse)
     }
 
     /// Handle an incoming gossip message

--- a/icn/crates/icn-ccl/src/registry_actor/mod.rs
+++ b/icn/crates/icn-ccl/src/registry_actor/mod.rs
@@ -61,8 +61,8 @@ pub struct ContractRegistryActor {
     /// Pending governance approvals (hash -> proposal_id)
     pending_approvals: Arc<RwLock<HashMap<ContentHash, String>>>,
 
-    /// Revoked contracts (tracked in memory, persisted via metadata)
-    revoked_contracts: Arc<RwLock<HashMap<ContentHash, String>>>,
+    /// Contract status tracking (Active, Deprecated, Revoked)
+    contract_status: Arc<RwLock<HashMap<ContentHash, ContractStatus>>>,
 }
 
 impl ContractRegistryActor {
@@ -78,7 +78,7 @@ impl ContractRegistryActor {
             send_callback: None,
             event_callback: None,
             pending_approvals: Arc::new(RwLock::new(HashMap::new())),
-            revoked_contracts: Arc::new(RwLock::new(HashMap::new())),
+            contract_status: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -153,6 +153,26 @@ impl ContractRegistryActor {
             } => {
                 let result = self.handle_revoke(&hash, &requester, reason).await;
                 let _ = resp.send(result);
+            }
+            ContractRegistryCommand::Deprecate {
+                hash,
+                requester,
+                successor,
+                reason,
+                resp,
+            } => {
+                let result = self
+                    .handle_deprecate(&hash, &requester, successor, reason)
+                    .await;
+                let _ = resp.send(result);
+            }
+            ContractRegistryCommand::GetStatus { hash, resp } => {
+                let status = self.get_status(&hash).await;
+                let _ = resp.send(status);
+            }
+            ContractRegistryCommand::GetVersionHistory { name, resp } => {
+                let versions = self.registry.get_versions(&name).await.unwrap_or_default();
+                let _ = resp.send(versions);
             }
             ContractRegistryCommand::GossipMessage(msg) => {
                 if let Err(e) = self.handle_gossip_message(msg).await {
@@ -240,7 +260,7 @@ impl ContractRegistryActor {
             Err(_) => return vec![],
         };
 
-        let revoked = self.revoked_contracts.read().await;
+        let statuses = self.contract_status.read().await;
 
         let mut results: Vec<ContractSummary> = all_metadata
             .iter()
@@ -267,7 +287,10 @@ impl ContractRegistryActor {
             })
             .map(|meta| {
                 let mut summary = ContractSummary::from(meta);
-                summary.revoked = revoked.contains_key(&meta.code_hash);
+                if let Some(status) = statuses.get(&meta.code_hash) {
+                    summary.status = status.clone();
+                    summary.revoked = status.is_revoked();
+                }
                 summary
             })
             .collect();
@@ -302,10 +325,18 @@ impl ContractRegistryActor {
             )));
         }
 
+        let revoked_at = icn_time::current_timestamp_millis();
+
         // Mark as revoked
         {
-            let mut revoked = self.revoked_contracts.write().await;
-            revoked.insert(*hash, reason.clone());
+            let mut statuses = self.contract_status.write().await;
+            statuses.insert(
+                *hash,
+                ContractStatus::Revoked {
+                    reason: reason.clone(),
+                    revoked_at,
+                },
+            );
         }
 
         // Broadcast revocation
@@ -314,7 +345,7 @@ impl ContractRegistryActor {
                 hash: *hash,
                 owner: requester.to_string(),
                 reason: reason.clone(),
-                revoked_at: icn_time::current_timestamp_millis(),
+                revoked_at,
             };
             send_cb(msg);
         }
@@ -335,6 +366,102 @@ impl ContractRegistryActor {
         );
 
         Ok(())
+    }
+
+    /// Handle contract deprecation
+    async fn handle_deprecate(
+        &self,
+        hash: &ContentHash,
+        requester: &str,
+        successor: Option<ContentHash>,
+        reason: String,
+    ) -> Result<(), RegistryError> {
+        // Get metadata to check ownership
+        let metadata = self
+            .registry
+            .get_metadata(hash)
+            .await?
+            .ok_or_else(|| RegistryError::NotFound(hex::encode(hash)))?;
+
+        // Verify requester is owner
+        if metadata.owner != requester {
+            return Err(RegistryError::AuthorizationError(format!(
+                "Only owner {} can deprecate contract",
+                metadata.owner
+            )));
+        }
+
+        // Verify successor exists if specified
+        if let Some(ref succ) = successor {
+            if !self.registry.exists(succ).await {
+                return Err(RegistryError::NotFound(format!(
+                    "Successor contract {} not found",
+                    hex::encode(succ)
+                )));
+            }
+        }
+
+        let deprecated_at = icn_time::current_timestamp_millis();
+
+        // Mark as deprecated
+        {
+            let mut statuses = self.contract_status.write().await;
+            statuses.insert(
+                *hash,
+                ContractStatus::Deprecated {
+                    successor,
+                    reason: reason.clone(),
+                    deprecated_at,
+                },
+            );
+        }
+
+        // Broadcast deprecation
+        if let Some(ref send_cb) = self.send_callback {
+            let msg = ContractRegistryMessage::Deprecated {
+                hash: *hash,
+                owner: requester.to_string(),
+                successor,
+                reason: reason.clone(),
+                deprecated_at,
+            };
+            send_cb(msg);
+        }
+
+        // Emit event
+        if let Some(ref event_cb) = self.event_callback {
+            event_cb(ContractRegistryEvent::Deprecated {
+                hash: *hash,
+                successor,
+                reason: reason.clone(),
+            });
+        }
+
+        info!(
+            hash = %hex::encode(hash),
+            owner = %requester,
+            successor = ?successor.map(hex::encode),
+            reason = %reason,
+            "Contract deprecated"
+        );
+
+        Ok(())
+    }
+
+    /// Get status for a contract
+    async fn get_status(&self, hash: &ContentHash) -> Option<ContractStatus> {
+        // First check if contract exists
+        if !self.registry.exists(hash).await {
+            return None;
+        }
+
+        let statuses = self.contract_status.read().await;
+        Some(
+            statuses
+                .get(hash)
+                .cloned()
+                .unwrap_or(ContractStatus::Active),
+        )
     }
 
     /// Handle incoming gossip message
@@ -392,13 +519,19 @@ impl ContractRegistryActor {
                 hash,
                 owner,
                 reason,
-                ..
+                revoked_at,
             } => {
                 // Verify the revocation is from the owner
                 if let Ok(Some(metadata)) = self.registry.get_metadata(&hash).await {
                     if metadata.owner == owner {
-                        let mut revoked = self.revoked_contracts.write().await;
-                        revoked.insert(hash, reason.clone());
+                        let mut statuses = self.contract_status.write().await;
+                        statuses.insert(
+                            hash,
+                            ContractStatus::Revoked {
+                                reason: reason.clone(),
+                                revoked_at,
+                            },
+                        );
                         info!(hash = %hex::encode(hash), "Contract revocation synced from gossip");
                     } else {
                         warn!(
@@ -406,6 +539,37 @@ impl ContractRegistryActor {
                             claimed_owner = %owner,
                             actual_owner = %metadata.owner,
                             "Invalid revocation: owner mismatch"
+                        );
+                    }
+                }
+            }
+
+            ContractRegistryMessage::Deprecated {
+                hash,
+                owner,
+                successor,
+                reason,
+                deprecated_at,
+            } => {
+                // Verify the deprecation is from the owner
+                if let Ok(Some(metadata)) = self.registry.get_metadata(&hash).await {
+                    if metadata.owner == owner {
+                        let mut statuses = self.contract_status.write().await;
+                        statuses.insert(
+                            hash,
+                            ContractStatus::Deprecated {
+                                successor,
+                                reason: reason.clone(),
+                                deprecated_at,
+                            },
+                        );
+                        info!(hash = %hex::encode(hash), "Contract deprecation synced from gossip");
+                    } else {
+                        warn!(
+                            hash = %hex::encode(hash),
+                            claimed_owner = %owner,
+                            actual_owner = %metadata.owner,
+                            "Invalid deprecation: owner mismatch"
                         );
                     }
                 }

--- a/icn/crates/icn-ccl/src/registry_actor/types.rs
+++ b/icn/crates/icn-ccl/src/registry_actor/types.rs
@@ -34,6 +34,15 @@ pub enum ContractRegistryMessage {
         revoked_at: u64,
     },
 
+    /// A contract has been deprecated
+    Deprecated {
+        hash: ContentHash,
+        owner: String,
+        successor: Option<ContentHash>,
+        reason: String,
+        deprecated_at: u64,
+    },
+
     /// Request for a specific contract (anti-entropy)
     Request {
         hash: ContentHash,
@@ -70,6 +79,7 @@ impl ContractRegistryMessage {
         match self {
             Self::Deployed { .. } => "Deployed",
             Self::Revoked { .. } => "Revoked",
+            Self::Deprecated { .. } => "Deprecated",
             Self::Request { .. } => "Request",
             Self::Response { .. } => "Response",
             Self::Digest { .. } => "Digest",
@@ -164,6 +174,55 @@ impl ContractFilter {
     }
 }
 
+/// Contract lifecycle status
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub enum ContractStatus {
+    /// Contract is active and can be executed
+    #[default]
+    Active,
+    /// Contract is deprecated, with optional successor
+    Deprecated {
+        /// Hash of the replacement contract (if any)
+        successor: Option<ContentHash>,
+        /// Reason for deprecation
+        reason: String,
+        /// When the contract was deprecated (Unix millis)
+        deprecated_at: u64,
+    },
+    /// Contract has been revoked and cannot be executed
+    Revoked {
+        /// Reason for revocation
+        reason: String,
+        /// When the contract was revoked (Unix millis)
+        revoked_at: u64,
+    },
+}
+
+impl ContractStatus {
+    /// Check if the contract is active
+    pub fn is_active(&self) -> bool {
+        matches!(self, Self::Active)
+    }
+
+    /// Check if the contract is deprecated
+    pub fn is_deprecated(&self) -> bool {
+        matches!(self, Self::Deprecated { .. })
+    }
+
+    /// Check if the contract is revoked
+    pub fn is_revoked(&self) -> bool {
+        matches!(self, Self::Revoked { .. })
+    }
+
+    /// Get the successor hash if deprecated
+    pub fn successor(&self) -> Option<ContentHash> {
+        match self {
+            Self::Deprecated { successor, .. } => *successor,
+            _ => None,
+        }
+    }
+}
+
 /// Summary of a contract for listing
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContractSummary {
@@ -181,6 +240,8 @@ pub struct ContractSummary {
     pub rules: Vec<String>,
     /// Whether the contract is revoked
     pub revoked: bool,
+    /// Contract lifecycle status
+    pub status: ContractStatus,
 }
 
 impl From<&ContractMetadata> for ContractSummary {
@@ -193,6 +254,7 @@ impl From<&ContractMetadata> for ContractSummary {
             deployed_at: meta.deployed_at,
             rules: meta.rules.clone(),
             revoked: false,
+            status: ContractStatus::Active,
         }
     }
 }
@@ -202,6 +264,12 @@ impl From<&ContractMetadata> for ContractSummary {
 pub enum ContractRegistryEvent {
     /// Contract was deployed
     Deployed { hash: ContentHash, name: String },
+    /// Contract was deprecated
+    Deprecated {
+        hash: ContentHash,
+        successor: Option<ContentHash>,
+        reason: String,
+    },
     /// Contract was revoked
     Revoked { hash: ContentHash, reason: String },
     /// Governance approval is required for a public contract

--- a/icn/crates/icn-compute/src/wasm_executor.rs
+++ b/icn/crates/icn-compute/src/wasm_executor.rs
@@ -33,6 +33,11 @@ impl WasmState {
     }
 }
 
+/// Callback type for resolving contract references from the registry
+/// Takes a contract hash and returns the contract if found
+pub type ContractResolverCallback =
+    Arc<dyn Fn([u8; 32]) -> Option<icn_ccl::Contract> + Send + Sync>;
+
 /// WASM executor using Wasmtime
 pub struct WasmExecutor {
     capabilities: Vec<ExecutorCapability>,
@@ -42,6 +47,8 @@ pub struct WasmExecutor {
     max_memory: usize,
     /// Optional WASM registry for WasmRef resolution
     registry: Option<Arc<WasmRegistry>>,
+    /// Optional contract resolver for CclRef resolution
+    contract_resolver: Option<ContractResolverCallback>,
 }
 
 impl WasmExecutor {
@@ -56,6 +63,7 @@ impl WasmExecutor {
             engine,
             max_memory: 64 * 1024 * 1024, // 64MB default
             registry: None,
+            contract_resolver: None,
         })
     }
 
@@ -66,6 +74,7 @@ impl WasmExecutor {
             capabilities: vec![ExecutorCapability::Ccl],
             max_memory: 64 * 1024 * 1024,
             registry: None,
+            contract_resolver: None,
         })
     }
 
@@ -89,6 +98,22 @@ impl WasmExecutor {
     /// Get the WASM registry if set
     pub fn registry(&self) -> Option<&Arc<WasmRegistry>> {
         self.registry.as_ref()
+    }
+
+    /// Set the contract resolver callback for CclRef resolution (builder pattern)
+    pub fn with_contract_resolver(mut self, resolver: ContractResolverCallback) -> Self {
+        self.contract_resolver = Some(resolver);
+        self
+    }
+
+    /// Set the contract resolver callback for CclRef resolution (mutable reference version)
+    pub fn set_contract_resolver(&mut self, resolver: ContractResolverCallback) {
+        self.contract_resolver = Some(resolver);
+    }
+
+    /// Get the contract resolver if set
+    pub fn contract_resolver(&self) -> Option<&ContractResolverCallback> {
+        self.contract_resolver.as_ref()
     }
 
     /// Execute a WASM module
@@ -342,14 +367,112 @@ impl Executor for WasmExecutor {
             TaskCode::CclRef { hash, rule } => {
                 // CclRef requires a contract registry to be set up
                 let hash_hex = hex::encode(hash);
-                tracing::warn!(
-                    hash = %hash_hex,
-                    rule = %rule,
-                    "CclRef requires contract registry (not yet integrated)"
-                );
-                ExecutionOutcome::Failed(format!(
-                    "Contract reference {hash_hex} not resolved. Registry integration pending."
-                ))
+
+                match &self.contract_resolver {
+                    Some(resolver) => {
+                        // Resolve the contract from the registry
+                        match resolver(*hash) {
+                            Some(contract) => {
+                                tracing::debug!(
+                                    hash = %hash_hex,
+                                    rule = %rule,
+                                    "Resolved CclRef, executing contract"
+                                );
+
+                                // Validate contract structure
+                                if let Err(e) = contract.validate() {
+                                    return ExecutionOutcome::Failed(format!(
+                                        "Contract validation failed: {e}"
+                                    ));
+                                }
+
+                                // Check that the rule exists
+                                if contract.get_rule(rule).is_none() {
+                                    return ExecutionOutcome::Failed(format!(
+                                        "Rule '{rule}' not found in contract"
+                                    ));
+                                }
+
+                                // Parse caller DID
+                                let caller_did: icn_identity::Did = match serde_json::from_value(
+                                    serde_json::Value::String(ctx.executor_did.clone()),
+                                ) {
+                                    Ok(d) => d,
+                                    Err(e) => {
+                                        return ExecutionOutcome::Failed(format!(
+                                            "Invalid caller DID: {e}"
+                                        ))
+                                    }
+                                };
+
+                                let timestamp = std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .unwrap_or_else(|e| {
+                                        tracing::warn!("System clock before UNIX epoch: {:?}", e);
+                                        std::time::Duration::ZERO
+                                    })
+                                    .as_secs();
+
+                                let ccl_context = icn_ccl::ExecutionContext {
+                                    caller: caller_did.clone(),
+                                    timestamp,
+                                    fuel: ctx.fuel_remaining,
+                                    fuel_limit: ctx.fuel_remaining,
+                                    capabilities: vec![],
+                                    participants: vec![caller_did],
+                                };
+
+                                let state = icn_ccl::ContractState::default();
+                                let args: std::collections::HashMap<String, icn_ccl::Value> =
+                                    if task.inputs.is_empty() {
+                                        std::collections::HashMap::new()
+                                    } else {
+                                        serde_json::from_slice(&task.inputs).unwrap_or_default()
+                                    };
+
+                                let interpreter =
+                                    icn_ccl::Interpreter::new(contract, state, ccl_context);
+                                match interpreter.execute_rule(rule, args) {
+                                    Ok(result) => {
+                                        ctx.fuel_remaining =
+                                            ctx.fuel_remaining.saturating_sub(result.fuel_consumed);
+                                        let output = serde_json::to_vec(&result.value)
+                                            .unwrap_or_else(|_| b"null".to_vec());
+                                        ExecutionOutcome::Success(output)
+                                    }
+                                    Err(e) => {
+                                        let err_str = e.to_string();
+                                        if err_str.contains("fuel") || err_str.contains("Fuel") {
+                                            ExecutionOutcome::OutOfFuel
+                                        } else {
+                                            ExecutionOutcome::Failed(err_str)
+                                        }
+                                    }
+                                }
+                            }
+                            None => {
+                                tracing::warn!(
+                                    hash = %hash_hex,
+                                    rule = %rule,
+                                    "Contract not found in registry"
+                                );
+                                ExecutionOutcome::Failed(format!(
+                                    "Contract {hash_hex} not found in registry"
+                                ))
+                            }
+                        }
+                    }
+                    None => {
+                        tracing::warn!(
+                            hash = %hash_hex,
+                            rule = %rule,
+                            "CclRef requires contract registry (not configured)"
+                        );
+                        ExecutionOutcome::Failed(format!(
+                            "Contract registry not configured. Cannot resolve {hash_hex}."
+                        ))
+                    }
+                }
             }
             TaskCode::WasmInline(bytes) => self.execute_wasm(bytes, &task.inputs, ctx),
             TaskCode::WasmRef(hash) => {
@@ -824,6 +947,236 @@ mod tests {
                 );
             }
             other => panic!("Expected function error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_cclref_without_resolver() {
+        let executor = WasmExecutor::new().unwrap();
+        let task = ComputeTask {
+            id: "cclref-test".into(),
+            submitter: TEST_ALICE_DID.into(),
+            coop_id: None,
+            code: TaskCode::CclRef {
+                hash: [0xCC; 32],
+                rule: "run".into(),
+            },
+            inputs: vec![],
+            fuel_limit: FuelLimit(10_000),
+            required_capabilities: vec![ExecutorCapability::Ccl],
+            priority: crate::types::TaskPriority::Normal,
+            created_at: 1000,
+            deadline: None,
+            payment_rate: None,
+            payment_currency: None,
+            resource_profile: None,
+            actor_mode: None,
+            placement_constraints: None,
+        };
+
+        let mut ctx = ExecutionContext {
+            executor_did: TEST_ALICE_DID.into(),
+            fuel_remaining: 10_000,
+        };
+
+        let result = executor.execute(&task, &mut ctx);
+        match result {
+            ExecutionOutcome::Failed(msg) => {
+                assert!(
+                    msg.contains("registry not configured"),
+                    "Expected 'registry not configured', got: {msg}"
+                );
+            }
+            other => panic!("Expected 'registry not configured' error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_cclref_not_found() {
+        // Create a resolver that always returns None
+        let resolver: ContractResolverCallback = Arc::new(|_hash| None);
+        let executor = WasmExecutor::new()
+            .unwrap()
+            .with_contract_resolver(resolver);
+
+        let task = ComputeTask {
+            id: "cclref-missing".into(),
+            submitter: TEST_ALICE_DID.into(),
+            coop_id: None,
+            code: TaskCode::CclRef {
+                hash: [0xDD; 32],
+                rule: "run".into(),
+            },
+            inputs: vec![],
+            fuel_limit: FuelLimit(10_000),
+            required_capabilities: vec![ExecutorCapability::Ccl],
+            priority: crate::types::TaskPriority::Normal,
+            created_at: 1000,
+            deadline: None,
+            payment_rate: None,
+            payment_currency: None,
+            resource_profile: None,
+            actor_mode: None,
+            placement_constraints: None,
+        };
+
+        let mut ctx = ExecutionContext {
+            executor_did: TEST_ALICE_DID.into(),
+            fuel_remaining: 10_000,
+        };
+
+        let result = executor.execute(&task, &mut ctx);
+        match result {
+            ExecutionOutcome::Failed(msg) => {
+                assert!(
+                    msg.contains("not found"),
+                    "Expected 'not found', got: {msg}"
+                );
+            }
+            other => panic!("Expected 'not found' error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_cclref_with_resolver() {
+        // Create a test contract
+        let contract_json = format!(
+            r#"{{
+            "name": "TestContract",
+            "participants": ["{TEST_ALICE_DID}"],
+            "currency": null,
+            "state_vars": [],
+            "rules": [{{
+                "name": "compute",
+                "params": [],
+                "requires": [],
+                "body": [{{ "Return": {{ "value": {{ "Literal": {{ "Int": 100 }} }} }} }}]
+            }}],
+            "triggers": []
+        }}"#
+        );
+
+        let contract: icn_ccl::Contract =
+            serde_json::from_str(&contract_json).expect("parse contract");
+        let expected_hash = [0xEE; 32];
+
+        // Create a resolver that returns our contract for the expected hash
+        let resolver: ContractResolverCallback = Arc::new(move |hash| {
+            if hash == expected_hash {
+                Some(contract.clone())
+            } else {
+                None
+            }
+        });
+
+        let executor = WasmExecutor::new()
+            .unwrap()
+            .with_contract_resolver(resolver);
+
+        let task = ComputeTask {
+            id: "cclref-valid".into(),
+            submitter: TEST_ALICE_DID.into(),
+            coop_id: None,
+            code: TaskCode::CclRef {
+                hash: expected_hash,
+                rule: "compute".into(),
+            },
+            inputs: vec![],
+            fuel_limit: FuelLimit(10_000),
+            required_capabilities: vec![ExecutorCapability::Ccl],
+            priority: crate::types::TaskPriority::Normal,
+            created_at: 1000,
+            deadline: None,
+            payment_rate: None,
+            payment_currency: None,
+            resource_profile: None,
+            actor_mode: None,
+            placement_constraints: None,
+        };
+
+        let mut ctx = ExecutionContext {
+            executor_did: TEST_ALICE_DID.into(),
+            fuel_remaining: 10_000,
+        };
+
+        let result = executor.execute(&task, &mut ctx);
+        assert!(
+            matches!(result, ExecutionOutcome::Success(_)),
+            "Expected success, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_cclref_rule_not_found() {
+        // Create a test contract with a "run" rule
+        let contract_json = format!(
+            r#"{{
+            "name": "TestContract",
+            "participants": ["{TEST_ALICE_DID}"],
+            "currency": null,
+            "state_vars": [],
+            "rules": [{{
+                "name": "run",
+                "params": [],
+                "requires": [],
+                "body": [{{ "Return": {{ "value": {{ "Literal": {{ "Int": 1 }} }} }} }}]
+            }}],
+            "triggers": []
+        }}"#
+        );
+
+        let contract: icn_ccl::Contract =
+            serde_json::from_str(&contract_json).expect("parse contract");
+        let expected_hash = [0xFF; 32];
+
+        let resolver: ContractResolverCallback = Arc::new(move |hash| {
+            if hash == expected_hash {
+                Some(contract.clone())
+            } else {
+                None
+            }
+        });
+
+        let executor = WasmExecutor::new()
+            .unwrap()
+            .with_contract_resolver(resolver);
+
+        // Try to execute a rule that doesn't exist
+        let task = ComputeTask {
+            id: "cclref-bad-rule".into(),
+            submitter: TEST_ALICE_DID.into(),
+            coop_id: None,
+            code: TaskCode::CclRef {
+                hash: expected_hash,
+                rule: "nonexistent_rule".into(),
+            },
+            inputs: vec![],
+            fuel_limit: FuelLimit(10_000),
+            required_capabilities: vec![ExecutorCapability::Ccl],
+            priority: crate::types::TaskPriority::Normal,
+            created_at: 1000,
+            deadline: None,
+            payment_rate: None,
+            payment_currency: None,
+            resource_profile: None,
+            actor_mode: None,
+            placement_constraints: None,
+        };
+
+        let mut ctx = ExecutionContext {
+            executor_did: TEST_ALICE_DID.into(),
+            fuel_remaining: 10_000,
+        };
+
+        let result = executor.execute(&task, &mut ctx);
+        match result {
+            ExecutionOutcome::Failed(msg) => {
+                assert!(
+                    msg.contains("not found") && msg.contains("nonexistent_rule"),
+                    "Expected rule not found error, got: {msg}"
+                );
+            }
+            other => panic!("Expected rule not found error, got: {other:?}"),
         }
     }
 }

--- a/icn/crates/icn-gateway/Cargo.toml
+++ b/icn/crates/icn-gateway/Cargo.toml
@@ -69,6 +69,7 @@ icn-governance = { path = "../icn-governance" }
 icn-compute = { path = "../icn-compute" }
 icn-federation = { path = "../icn-federation" }
 icn-trust = { path = "../icn-trust" }
+icn-ccl = { path = "../icn-ccl" }
 icn-zkp = { path = "../icn-zkp" }
 icn-steward = { path = "../icn-steward" }
 icn-crypto-pq = { path = "../icn-crypto-pq" }

--- a/icn/crates/icn-gateway/src/api/contracts.rs
+++ b/icn/crates/icn-gateway/src/api/contracts.rs
@@ -1,0 +1,701 @@
+//! Contract Management API endpoints
+//!
+//! RESTful API for deploying, managing, and querying CCL contracts.
+
+use actix_web::{delete, get, post, web, HttpRequest, HttpResponse};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use utoipa::ToSchema;
+
+use crate::error::{GatewayError, Result};
+use crate::middleware::{get_claims, require_scope};
+
+// Re-export types from icn_ccl for contract operations
+use icn_ccl::{
+    Contract, ContractMetadata, ContractRegistryHandle, ContractStatus, ContractSummary,
+    DeploymentMetadata, Visibility,
+};
+
+/// Helper to get the contract registry or return 503 Service Unavailable
+fn get_registry(
+    registry: &web::Data<Option<Arc<ContractRegistryHandle>>>,
+) -> Result<Arc<ContractRegistryHandle>> {
+    registry.as_ref().as_ref().cloned().ok_or_else(|| {
+        GatewayError::ServiceUnavailable(
+            "Contract registry not configured. Contracts API requires daemon integration."
+                .to_string(),
+        )
+    })
+}
+
+// ============================================================================
+// Request/Response DTOs
+// ============================================================================
+
+/// Request to deploy a new contract
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct DeployContractRequest {
+    /// CCL contract source (JSON format)
+    pub source: String,
+    /// Visibility: "private", "coop", or "public"
+    #[serde(default = "default_visibility")]
+    pub visibility: String,
+    /// Coop ID (required if visibility is "coop")
+    #[serde(default)]
+    pub coop_id: Option<String>,
+    /// Optional description
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+fn default_visibility() -> String {
+    "private".to_string()
+}
+
+/// Response from deploying a contract
+#[derive(Debug, Serialize, ToSchema)]
+pub struct DeployContractResponse {
+    /// Content hash of the deployed contract (hex)
+    pub hash: String,
+    /// Contract name
+    pub name: String,
+    /// Version number
+    pub version: u32,
+}
+
+/// Query parameters for listing contracts
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ListContractsQuery {
+    /// Filter by visibility: "private", "coop", "public"
+    #[serde(default)]
+    pub visibility: Option<String>,
+    /// Filter by owner DID
+    #[serde(default)]
+    pub owner: Option<String>,
+    /// Filter by name prefix
+    #[serde(default)]
+    pub name_prefix: Option<String>,
+    /// Maximum number of results (default: 50)
+    #[serde(default = "default_limit")]
+    pub limit: usize,
+}
+
+fn default_limit() -> usize {
+    50
+}
+
+/// Contract summary for list responses
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ContractListItem {
+    /// Content hash (hex)
+    pub hash: String,
+    /// Contract name
+    pub name: String,
+    /// Owner DID
+    pub owner: String,
+    /// Version number
+    pub version: u32,
+    /// Deployment timestamp (Unix seconds)
+    pub deployed_at: u64,
+    /// Rule names in the contract
+    pub rules: Vec<String>,
+    /// Whether the contract is revoked
+    pub revoked: bool,
+}
+
+impl From<ContractSummary> for ContractListItem {
+    fn from(summary: ContractSummary) -> Self {
+        Self {
+            hash: hex::encode(summary.hash),
+            name: summary.name,
+            owner: summary.owner,
+            version: summary.version,
+            deployed_at: summary.deployed_at,
+            rules: summary.rules,
+            revoked: summary.revoked,
+        }
+    }
+}
+
+/// Response for get contract by hash
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ContractDetailResponse {
+    /// Content hash (hex)
+    pub hash: String,
+    /// Full contract source (JSON)
+    pub source: String,
+    /// Contract metadata
+    pub metadata: ContractMetadataResponse,
+}
+
+/// Contract metadata response
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ContractMetadataResponse {
+    /// Contract name
+    pub name: String,
+    /// Owner DID
+    pub owner: String,
+    /// Version number
+    pub version: u32,
+    /// Deployment timestamp
+    pub deployed_at: u64,
+    /// Rule names
+    pub rules: Vec<String>,
+    /// Visibility level
+    pub visibility: String,
+    /// Optional description
+    pub description: Option<String>,
+}
+
+impl From<ContractMetadata> for ContractMetadataResponse {
+    fn from(meta: ContractMetadata) -> Self {
+        let visibility = match &meta.visibility {
+            Visibility::Private => "private".to_string(),
+            Visibility::Coop(id) => format!("coop:{id}"),
+            Visibility::Public => "public".to_string(),
+        };
+
+        Self {
+            name: meta.name,
+            owner: meta.owner,
+            version: meta.version,
+            deployed_at: meta.deployed_at,
+            rules: meta.rules,
+            visibility,
+            description: meta.description,
+        }
+    }
+}
+
+/// Request to revoke a contract
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct RevokeContractRequest {
+    /// Reason for revocation
+    pub reason: String,
+}
+
+/// Response from revoking a contract
+#[derive(Debug, Serialize, ToSchema)]
+pub struct RevokeContractResponse {
+    /// Contract hash that was revoked
+    pub hash: String,
+    /// Status
+    pub status: String,
+    /// Reason for revocation
+    pub reason: String,
+}
+
+/// Request to deprecate a contract
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct DeprecateContractRequest {
+    /// Reason for deprecation
+    pub reason: String,
+    /// Hash of the successor contract (optional)
+    #[serde(default)]
+    pub successor: Option<String>,
+}
+
+/// Response from deprecating a contract
+#[derive(Debug, Serialize, ToSchema)]
+pub struct DeprecateContractResponse {
+    /// Contract hash that was deprecated
+    pub hash: String,
+    /// Status
+    pub status: String,
+    /// Successor hash (if specified)
+    pub successor: Option<String>,
+    /// Reason for deprecation
+    pub reason: String,
+}
+
+/// Contract status response
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ContractStatusResponse {
+    /// Contract hash
+    pub hash: String,
+    /// Status type: "active", "deprecated", or "revoked"
+    pub status: String,
+    /// Successor hash for deprecated contracts
+    pub successor: Option<String>,
+    /// Reason for deprecation/revocation
+    pub reason: Option<String>,
+    /// When the status changed (Unix millis)
+    pub changed_at: Option<u64>,
+}
+
+impl From<(String, ContractStatus)> for ContractStatusResponse {
+    fn from((hash, status): (String, ContractStatus)) -> Self {
+        match status {
+            ContractStatus::Active => Self {
+                hash,
+                status: "active".to_string(),
+                successor: None,
+                reason: None,
+                changed_at: None,
+            },
+            ContractStatus::Deprecated {
+                successor,
+                reason,
+                deprecated_at,
+            } => Self {
+                hash,
+                status: "deprecated".to_string(),
+                successor: successor.map(hex::encode),
+                reason: Some(reason),
+                changed_at: Some(deprecated_at),
+            },
+            ContractStatus::Revoked { reason, revoked_at } => Self {
+                hash,
+                status: "revoked".to_string(),
+                successor: None,
+                reason: Some(reason),
+                changed_at: Some(revoked_at),
+            },
+        }
+    }
+}
+
+/// Version history item
+#[derive(Debug, Serialize, ToSchema)]
+pub struct VersionHistoryItem {
+    /// Version number
+    pub version: u32,
+    /// Contract hash (hex)
+    pub hash: String,
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Parse visibility string to Visibility enum
+fn parse_visibility(s: &str, coop_id: Option<&str>) -> Result<Visibility> {
+    match s.to_lowercase().as_str() {
+        "private" => Ok(Visibility::Private),
+        "coop" => {
+            let coop = coop_id.ok_or_else(|| {
+                GatewayError::BadRequest("coop_id is required for coop visibility".to_string())
+            })?;
+            Ok(Visibility::Coop(coop.to_string()))
+        }
+        "public" => Ok(Visibility::Public),
+        _ => Err(GatewayError::BadRequest(format!(
+            "Invalid visibility '{s}'. Must be 'private', 'coop', or 'public'"
+        ))),
+    }
+}
+
+/// Parse hex hash string to 32-byte array
+fn parse_hash(hash_hex: &str) -> Result<[u8; 32]> {
+    let bytes = hex::decode(hash_hex)
+        .map_err(|_| GatewayError::BadRequest("Invalid hex hash".to_string()))?;
+
+    if bytes.len() != 32 {
+        return Err(GatewayError::BadRequest(
+            "Hash must be 32 bytes (64 hex chars)".to_string(),
+        ));
+    }
+
+    let mut hash = [0u8; 32];
+    hash.copy_from_slice(&bytes);
+    Ok(hash)
+}
+
+// ============================================================================
+// Endpoints
+// ============================================================================
+
+/// POST /contracts - Deploy a new contract
+///
+/// Requires `contracts:write` scope.
+#[post("")]
+pub async fn deploy_contract(
+    http_req: HttpRequest,
+    registry_opt: web::Data<Option<Arc<ContractRegistryHandle>>>,
+    req: web::Json<DeployContractRequest>,
+) -> Result<HttpResponse> {
+    // Get the registry or return 503
+    let registry = get_registry(&registry_opt)?;
+
+    // Require contracts:write scope
+    require_scope(&http_req, "contracts:write")?;
+
+    // Get deployer DID from JWT
+    let claims = get_claims(&http_req)
+        .ok_or_else(|| GatewayError::AuthenticationFailed("No claims found".to_string()))?;
+    let owner_did = claims.sub.clone();
+
+    // Parse the contract source
+    let contract: Contract = serde_json::from_str(&req.source)
+        .map_err(|e| GatewayError::BadRequest(format!("Invalid contract JSON: {e}")))?;
+
+    // Validate contract structure
+    contract
+        .validate()
+        .map_err(|e| GatewayError::BadRequest(format!("Contract validation failed: {e}")))?;
+
+    // Parse visibility
+    let visibility = parse_visibility(&req.visibility, req.coop_id.as_deref())?;
+
+    // Create deployment metadata
+    let mut metadata = DeploymentMetadata::new(owner_did).with_visibility(visibility);
+
+    if let Some(ref desc) = req.description {
+        metadata = metadata.with_description(desc.clone());
+    }
+
+    // Register the contract
+    let hash = registry
+        .register_contract(contract.clone(), metadata)
+        .await
+        .map_err(|e| GatewayError::InternalError(format!("Failed to register contract: {e}")))?;
+
+    // Get the version from metadata
+    let version = registry
+        .get_metadata(&hash)
+        .await
+        .map_err(|e| GatewayError::InternalError(format!("Failed to get metadata: {e}")))?
+        .map(|m| m.version)
+        .unwrap_or(1);
+
+    Ok(HttpResponse::Created().json(DeployContractResponse {
+        hash: hex::encode(hash),
+        name: contract.name,
+        version,
+    }))
+}
+
+/// GET /contracts - List contracts
+///
+/// Requires `contracts:read` scope.
+#[get("")]
+pub async fn list_contracts(
+    http_req: HttpRequest,
+    registry_opt: web::Data<Option<Arc<ContractRegistryHandle>>>,
+    query: web::Query<ListContractsQuery>,
+) -> Result<HttpResponse> {
+    // Get the registry or return 503
+    let registry = get_registry(&registry_opt)?;
+
+    // Require contracts:read scope
+    require_scope(&http_req, "contracts:read")?;
+
+    // Build filter
+    let mut filter = icn_ccl::registry_actor::types::ContractFilter::new();
+
+    if let Some(ref owner) = query.owner {
+        filter = filter.with_owner(owner.clone());
+    }
+
+    if let Some(ref prefix) = query.name_prefix {
+        filter = filter.with_name_prefix(prefix.clone());
+    }
+
+    if let Some(ref vis) = query.visibility {
+        let visibility = parse_visibility(vis, None)?;
+        filter = filter.with_visibility(visibility);
+    }
+
+    filter = filter.with_limit(query.limit);
+
+    // List contracts
+    let summaries = registry
+        .list_contracts(filter)
+        .await
+        .map_err(|e| GatewayError::InternalError(format!("Failed to list contracts: {e}")))?;
+
+    let items: Vec<ContractListItem> = summaries.into_iter().map(ContractListItem::from).collect();
+
+    Ok(HttpResponse::Ok().json(items))
+}
+
+/// GET /contracts/{hash} - Get contract by hash
+///
+/// Requires `contracts:read` scope.
+#[get("/{hash}")]
+pub async fn get_contract(
+    http_req: HttpRequest,
+    registry_opt: web::Data<Option<Arc<ContractRegistryHandle>>>,
+    path: web::Path<String>,
+) -> Result<HttpResponse> {
+    // Get the registry or return 503
+    let registry = get_registry(&registry_opt)?;
+
+    // Require contracts:read scope
+    require_scope(&http_req, "contracts:read")?;
+
+    let hash_hex = path.into_inner();
+    let hash = parse_hash(&hash_hex)?;
+
+    // Get contract
+    let contract = registry
+        .get_contract(&hash)
+        .await
+        .map_err(|e| GatewayError::InternalError(format!("Failed to get contract: {e}")))?
+        .ok_or_else(|| GatewayError::NotFound(format!("Contract {hash_hex} not found")))?;
+
+    // Get metadata
+    let metadata = registry
+        .get_metadata(&hash)
+        .await
+        .map_err(|e| GatewayError::InternalError(format!("Failed to get metadata: {e}")))?
+        .ok_or_else(|| GatewayError::NotFound(format!("Contract {hash_hex} not found")))?;
+
+    // Serialize contract back to JSON
+    let source = serde_json::to_string_pretty(&contract)
+        .map_err(|e| GatewayError::InternalError(format!("Failed to serialize contract: {e}")))?;
+
+    Ok(HttpResponse::Ok().json(ContractDetailResponse {
+        hash: hash_hex,
+        source,
+        metadata: ContractMetadataResponse::from(metadata),
+    }))
+}
+
+/// DELETE /contracts/{hash} - Revoke a contract
+///
+/// Requires `contracts:write` scope. Only the contract owner can revoke.
+#[delete("/{hash}")]
+pub async fn revoke_contract(
+    http_req: HttpRequest,
+    registry_opt: web::Data<Option<Arc<ContractRegistryHandle>>>,
+    path: web::Path<String>,
+    req: web::Json<RevokeContractRequest>,
+) -> Result<HttpResponse> {
+    // Get the registry or return 503
+    let registry = get_registry(&registry_opt)?;
+
+    // Require contracts:write scope
+    require_scope(&http_req, "contracts:write")?;
+
+    // Get requester DID from JWT
+    let claims = get_claims(&http_req)
+        .ok_or_else(|| GatewayError::AuthenticationFailed("No claims found".to_string()))?;
+    let requester_did = claims.sub.clone();
+
+    let hash_hex = path.into_inner();
+    let hash = parse_hash(&hash_hex)?;
+
+    // Revoke the contract
+    registry
+        .revoke_contract(&hash, &requester_did, req.reason.clone())
+        .await
+        .map_err(|e| {
+            // Check if it's an authorization error
+            let err_str = e.to_string();
+            if err_str.contains("not authorized") || err_str.contains("not the owner") {
+                GatewayError::Forbidden("Only the contract owner can revoke".to_string())
+            } else if err_str.contains("not found") {
+                GatewayError::NotFound(format!("Contract {hash_hex} not found"))
+            } else {
+                GatewayError::InternalError(format!("Failed to revoke contract: {e}"))
+            }
+        })?;
+
+    Ok(HttpResponse::Ok().json(RevokeContractResponse {
+        hash: hash_hex,
+        status: "revoked".to_string(),
+        reason: req.reason.clone(),
+    }))
+}
+
+/// GET /contracts/{hash}/metadata - Get contract metadata only
+///
+/// Requires `contracts:read` scope.
+#[get("/{hash}/metadata")]
+pub async fn get_contract_metadata(
+    http_req: HttpRequest,
+    registry_opt: web::Data<Option<Arc<ContractRegistryHandle>>>,
+    path: web::Path<String>,
+) -> Result<HttpResponse> {
+    // Get the registry or return 503
+    let registry = get_registry(&registry_opt)?;
+
+    // Require contracts:read scope
+    require_scope(&http_req, "contracts:read")?;
+
+    let hash_hex = path.into_inner();
+    let hash = parse_hash(&hash_hex)?;
+
+    // Get metadata
+    let metadata = registry
+        .get_metadata(&hash)
+        .await
+        .map_err(|e| GatewayError::InternalError(format!("Failed to get metadata: {e}")))?
+        .ok_or_else(|| GatewayError::NotFound(format!("Contract {hash_hex} not found")))?;
+
+    Ok(HttpResponse::Ok().json(ContractMetadataResponse::from(metadata)))
+}
+
+/// POST /contracts/{hash}/deprecate - Deprecate a contract
+///
+/// Requires `contracts:write` scope. Only the contract owner can deprecate.
+#[post("/{hash}/deprecate")]
+pub async fn deprecate_contract(
+    http_req: HttpRequest,
+    registry_opt: web::Data<Option<Arc<ContractRegistryHandle>>>,
+    path: web::Path<String>,
+    req: web::Json<DeprecateContractRequest>,
+) -> Result<HttpResponse> {
+    // Get the registry or return 503
+    let registry = get_registry(&registry_opt)?;
+
+    // Require contracts:write scope
+    require_scope(&http_req, "contracts:write")?;
+
+    // Get requester DID from JWT
+    let claims = get_claims(&http_req)
+        .ok_or_else(|| GatewayError::AuthenticationFailed("No claims found".to_string()))?;
+    let requester_did = claims.sub.clone();
+
+    let hash_hex = path.into_inner();
+    let hash = parse_hash(&hash_hex)?;
+
+    // Parse successor hash if provided
+    let successor = match &req.successor {
+        Some(s) => Some(parse_hash(s)?),
+        None => None,
+    };
+
+    // Deprecate the contract
+    registry
+        .deprecate_contract(&hash, &requester_did, successor, req.reason.clone())
+        .await
+        .map_err(|e| {
+            let err_str = e.to_string();
+            if err_str.contains("not authorized") || err_str.contains("Only owner") {
+                GatewayError::Forbidden("Only the contract owner can deprecate".to_string())
+            } else if err_str.contains("not found") {
+                GatewayError::NotFound(format!("Contract {hash_hex} not found"))
+            } else {
+                GatewayError::InternalError(format!("Failed to deprecate contract: {e}"))
+            }
+        })?;
+
+    Ok(HttpResponse::Ok().json(DeprecateContractResponse {
+        hash: hash_hex,
+        status: "deprecated".to_string(),
+        successor: req.successor.clone(),
+        reason: req.reason.clone(),
+    }))
+}
+
+/// GET /contracts/{hash}/status - Get contract lifecycle status
+///
+/// Requires `contracts:read` scope.
+#[get("/{hash}/status")]
+pub async fn get_contract_status(
+    http_req: HttpRequest,
+    registry_opt: web::Data<Option<Arc<ContractRegistryHandle>>>,
+    path: web::Path<String>,
+) -> Result<HttpResponse> {
+    // Get the registry or return 503
+    let registry = get_registry(&registry_opt)?;
+
+    // Require contracts:read scope
+    require_scope(&http_req, "contracts:read")?;
+
+    let hash_hex = path.into_inner();
+    let hash = parse_hash(&hash_hex)?;
+
+    // Get status
+    let status = registry
+        .get_status(&hash)
+        .await
+        .map_err(|e| GatewayError::InternalError(format!("Failed to get status: {e}")))?
+        .ok_or_else(|| GatewayError::NotFound(format!("Contract {hash_hex} not found")))?;
+
+    Ok(HttpResponse::Ok().json(ContractStatusResponse::from((hash_hex, status))))
+}
+
+/// GET /contracts/name/{name}/versions - Get version history for a contract
+///
+/// Requires `contracts:read` scope.
+#[get("/name/{name}/versions")]
+pub async fn get_version_history(
+    http_req: HttpRequest,
+    registry_opt: web::Data<Option<Arc<ContractRegistryHandle>>>,
+    path: web::Path<String>,
+) -> Result<HttpResponse> {
+    // Get the registry or return 503
+    let registry = get_registry(&registry_opt)?;
+
+    // Require contracts:read scope
+    require_scope(&http_req, "contracts:read")?;
+
+    let name = path.into_inner();
+
+    // Get version history
+    let versions = registry
+        .get_version_history(&name)
+        .await
+        .map_err(|e| GatewayError::InternalError(format!("Failed to get version history: {e}")))?;
+
+    if versions.is_empty() {
+        return Err(GatewayError::NotFound(format!(
+            "No contracts found with name '{name}'"
+        )));
+    }
+
+    let items: Vec<VersionHistoryItem> = versions
+        .into_iter()
+        .map(|(version, hash)| VersionHistoryItem {
+            version,
+            hash: hex::encode(hash),
+        })
+        .collect();
+
+    Ok(HttpResponse::Ok().json(items))
+}
+
+/// Configure contract routes
+pub fn configure(cfg: &mut web::ServiceConfig) {
+    cfg.service(deploy_contract)
+        .service(list_contracts)
+        .service(get_contract)
+        .service(revoke_contract)
+        .service(deprecate_contract)
+        .service(get_contract_status)
+        .service(get_contract_metadata)
+        .service(get_version_history);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_visibility() {
+        assert!(matches!(
+            parse_visibility("private", None).unwrap(),
+            Visibility::Private
+        ));
+        assert!(matches!(
+            parse_visibility("public", None).unwrap(),
+            Visibility::Public
+        ));
+        assert!(matches!(
+            parse_visibility("coop", Some("coop-123")).unwrap(),
+            Visibility::Coop(_)
+        ));
+
+        // Error case: coop without coop_id
+        assert!(parse_visibility("coop", None).is_err());
+
+        // Error case: invalid visibility
+        assert!(parse_visibility("invalid", None).is_err());
+    }
+
+    #[test]
+    fn test_parse_hash() {
+        let valid_hex = "a".repeat(64);
+        let hash = parse_hash(&valid_hex).unwrap();
+        assert_eq!(hash, [0xaa; 32]);
+
+        // Error case: too short
+        assert!(parse_hash("abcd").is_err());
+
+        // Error case: invalid hex
+        assert!(parse_hash("gg".repeat(32).as_str()).is_err());
+    }
+}

--- a/icn/crates/icn-gateway/src/api/contracts.rs
+++ b/icn/crates/icn-gateway/src/api/contracts.rs
@@ -101,10 +101,17 @@ pub struct ContractListItem {
     pub rules: Vec<String>,
     /// Whether the contract is revoked
     pub revoked: bool,
+    /// Contract lifecycle status: "active", "deprecated", or "revoked"
+    pub status: String,
 }
 
 impl From<ContractSummary> for ContractListItem {
     fn from(summary: ContractSummary) -> Self {
+        let status = match &summary.status {
+            ContractStatus::Active => "active".to_string(),
+            ContractStatus::Deprecated { .. } => "deprecated".to_string(),
+            ContractStatus::Revoked { .. } => "revoked".to_string(),
+        };
         Self {
             hash: hex::encode(summary.hash),
             name: summary.name,
@@ -113,6 +120,7 @@ impl From<ContractSummary> for ContractListItem {
             deployed_at: summary.deployed_at,
             rules: summary.rules,
             revoked: summary.revoked,
+            status,
         }
     }
 }

--- a/icn/crates/icn-gateway/src/api/mod.rs
+++ b/icn/crates/icn-gateway/src/api/mod.rs
@@ -6,6 +6,7 @@ pub mod charter;
 pub mod commons;
 pub mod compute;
 pub mod constitutional;
+pub mod contracts;
 pub mod coops;
 pub mod devices;
 pub mod escrow;

--- a/icn/crates/icn-gateway/src/error.rs
+++ b/icn/crates/icn-gateway/src/error.rs
@@ -32,6 +32,9 @@ pub enum GatewayError {
     #[error("Internal server error: {0}")]
     InternalError(String),
 
+    #[error("Service unavailable: {0}")]
+    ServiceUnavailable(String),
+
     #[error("ICN substrate error: {0}")]
     SubstrateError(#[from] anyhow::Error),
 
@@ -50,6 +53,7 @@ impl ResponseError for GatewayError {
             GatewayError::RateLimitExceeded(_) => StatusCode::TOO_MANY_REQUESTS,
             GatewayError::BudgetExceeded(_) => StatusCode::FORBIDDEN,
             GatewayError::InternalError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            GatewayError::ServiceUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
             GatewayError::SubstrateError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             GatewayError::IoError(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
@@ -67,6 +71,7 @@ impl ResponseError for GatewayError {
             GatewayError::BadRequest(msg) => msg.clone(),
             GatewayError::RateLimitExceeded(msg) => format!("Rate limit exceeded for DID: {msg}"),
             GatewayError::BudgetExceeded(msg) => msg.clone(),
+            GatewayError::ServiceUnavailable(msg) => msg.clone(),
 
             // Internal errors - sanitize to prevent information leakage
             // Log the full error for debugging but return generic message to client

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -48,6 +48,8 @@ pub struct GatewayServer {
     trust_graph_handle: Option<TrustGraphHandle>,
     /// Optional handle to daemon's GovernanceActor (for actor-backed mode)
     governance_handle: Option<GovernanceHandle>,
+    /// Optional handle to daemon's ContractRegistryActor (for contract management)
+    contract_registry_handle: Option<icn_ccl::ContractRegistryHandle>,
 }
 
 impl GatewayServer {
@@ -64,6 +66,7 @@ impl GatewayServer {
             coop_handle: None,
             trust_graph_handle: None,
             governance_handle: None,
+            contract_registry_handle: None,
         }
     }
 
@@ -84,6 +87,7 @@ impl GatewayServer {
             coop_handle: None,
             trust_graph_handle: None,
             governance_handle: None,
+            contract_registry_handle: None,
         }
     }
 
@@ -105,6 +109,7 @@ impl GatewayServer {
             coop_handle: None,
             trust_graph_handle: None,
             governance_handle: None,
+            contract_registry_handle: None,
         }
     }
 
@@ -141,6 +146,18 @@ impl GatewayServer {
     /// GovernanceActor, ensuring persistence and gossip synchronization.
     pub fn with_governance_handle(mut self, handle: GovernanceHandle) -> Self {
         self.governance_handle = Some(handle);
+        self
+    }
+
+    /// Set contract registry handle for daemon integration
+    ///
+    /// When set, the contracts API will delegate all operations to the daemon's
+    /// ContractRegistryActor, enabling contract management with gossip sync.
+    pub fn with_contract_registry_handle(
+        mut self,
+        handle: icn_ccl::ContractRegistryHandle,
+    ) -> Self {
+        self.contract_registry_handle = Some(handle);
         self
     }
 
@@ -213,6 +230,17 @@ impl GatewayServer {
             info!("Compute manager running standalone (no daemon connection)");
             Arc::new(ComputeManager::new())
         };
+
+        // Create contract registry handle for contract management API
+        let contract_registry: Option<Arc<icn_ccl::ContractRegistryHandle>> =
+            if let Some(handle) = self.contract_registry_handle {
+                info!("Contract registry connected to daemon (using ContractRegistryActor)");
+                Some(Arc::new(handle))
+            } else {
+                info!("Contract registry not configured (contracts API disabled)");
+                None
+            };
+
         let federation_manager = Arc::new(FederationManager::new());
         let commons_manager = Arc::new(CommonsManager::new());
 
@@ -459,6 +487,8 @@ impl GatewayServer {
                 .app_data(web::Data::new(budget_store.clone()))
                 .app_data(web::Data::new(rate_limiter.clone()))
                 .app_data(web::Data::new(ip_rate_limiter.clone()))
+                // Contract registry (optional - for contract management API)
+                .app_data(web::Data::new(contract_registry.clone()))
                 // JSON payload size limit (256KB - we're not handling file uploads)
                 .app_data(web::JsonConfig::default().limit(262_144))
                 // Middleware (order: last wrapped runs first for REQUEST, first runs last for RESPONSE)
@@ -611,6 +641,16 @@ impl GatewayServer {
                             web::scope("/compute")
                                 .service(api::compute::submit_task)
                                 .service(api::compute::get_status)
+                                .wrap(middleware::from_fn(
+                                    crate::rate_limit::rate_limit_middleware,
+                                ))
+                                .wrap(auth.clone()),
+                        )
+                        // Protected contracts endpoints (auth + rate limiting)
+                        // Only available when ContractRegistryActor is configured
+                        .service(
+                            web::scope("/contracts")
+                                .configure(api::contracts::configure)
                                 .wrap(middleware::from_fn(
                                     crate::rate_limit::rate_limit_middleware,
                                 ))


### PR DESCRIPTION
## Summary

This PR implements the contract management bundle, enabling:
- CclRef resolution in WasmExecutor (#201)
- REST API for contract CRUD operations (#202)
- Contract lifecycle management with deprecation support (#203)

Closes #201, closes #202, closes #203.

## Changes

### Phase 1: Wire WasmExecutor to Contract Registry (#201)
- Add `ContractResolverCallback` type to WasmExecutor
- Add `with_contract_resolver()` and `set_contract_resolver()` methods
- Update CclRef handling to resolve and execute contracts via callback
- Add unit tests for CclRef resolution scenarios

### Phase 2: Contract Management API (#202)
- Add `contracts` module to gateway API
- Implement endpoints:
  - `POST /contracts` - Deploy new contract
  - `GET /contracts` - List contracts with filters
  - `GET /contracts/{hash}` - Get contract by hash
  - `DELETE /contracts/{hash}` - Revoke contract
  - `GET /contracts/{hash}/metadata` - Get contract metadata
- Add `ServiceUnavailable` error variant for 503 responses
- Wire ContractRegistryHandle to gateway server

### Phase 3: Contract Lifecycle (#203)
- Add `ContractStatus` enum (Active, Deprecated, Revoked)
- Add deprecation with successor pointer support
- Add gossip message for deprecation sync
- Add handle methods: `deprecate_contract()`, `get_status()`, `get_version_history()`
- Add API endpoints:
  - `POST /contracts/{hash}/deprecate` - Deprecate contract
  - `GET /contracts/{hash}/status` - Get lifecycle status
  - `GET /contracts/name/{name}/versions` - Get version history

## Test plan
- [x] All icn-ccl tests pass (87 tests)
- [x] All icn-compute tests pass
- [x] All icn-gateway tests pass
- [x] cargo clippy passes with -D warnings
- [x] cargo fmt passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)