### PR TITLE
feat(gateway): Complete Sprint 2 Gateway Polish

### DIFF
--- a/icn/crates/icn-core/src/governance/actor.rs
+++ b/icn/crates/icn-core/src/governance/actor.rs
@@ -199,6 +199,16 @@ impl GovernanceHandle {
     pub async fn revoke_delegation(&self, id: &DelegationId, revoked_at: Timestamp) -> Result<()> {
         self.inner.write().await.revoke_delegation(id, revoked_at)
     }
+
+    /// Get vote tally for a proposal
+    pub async fn get_vote_tally(&self, proposal_id: &ProposalId) -> Result<VoteTally> {
+        self.inner.read().await.get_vote_tally(proposal_id)
+    }
+
+    /// Get list of voter DIDs for a proposal
+    pub async fn get_voter_dids(&self, proposal_id: &ProposalId) -> Result<Vec<Did>> {
+        self.inner.read().await.get_voter_dids(proposal_id)
+    }
 }
 
 /// Implement GovernanceOps trait to allow RPC integration without circular dependencies
@@ -319,6 +329,16 @@ impl icn_governance::GovernanceOps for GovernanceHandle {
 
     async fn revoke_delegation(&self, id: &DelegationId, revoked_at: Timestamp) -> Result<()> {
         Self::revoke_delegation(self, id, revoked_at).await
+    }
+
+    // Vote tracking operations
+
+    async fn get_vote_tally(&self, proposal_id: &ProposalId) -> Result<VoteTally> {
+        Self::get_vote_tally(self, proposal_id).await
+    }
+
+    async fn get_voter_dids(&self, proposal_id: &ProposalId) -> Result<Vec<Did>> {
+        Self::get_voter_dids(self, proposal_id).await
     }
 }
 
@@ -928,6 +948,18 @@ impl GovernanceActor {
         rows.into_iter()
             .map(|(_k, v)| Ok(serde_json::from_slice::<Vote>(&v)?))
             .collect()
+    }
+
+    /// Get vote tally for a proposal
+    fn get_vote_tally(&self, proposal_id: &ProposalId) -> Result<VoteTally> {
+        let votes = self.load_votes(proposal_id)?;
+        Ok(VoteTally::from(votes))
+    }
+
+    /// Get list of voter DIDs for a proposal
+    fn get_voter_dids(&self, proposal_id: &ProposalId) -> Result<Vec<Did>> {
+        let votes = self.load_votes(proposal_id)?;
+        Ok(votes.into_iter().map(|v| v.voter).collect())
     }
 
     /// Maximum depth for transitive delegations

--- a/icn/crates/icn-core/src/supervisor/mod.rs
+++ b/icn/crates/icn-core/src/supervisor/mod.rs
@@ -129,6 +129,9 @@ impl Supervisor {
         // Treasury handle for gateway integration
         let treasury_handle_for_gateway: Option<icn_gateway::TreasuryHandle>;
 
+        // Ledger handle for gateway balance queries
+        let ledger_handle_for_gateway: Option<icn_gateway::LedgerHandle>;
+
         // Governance event subscription handles - MUST persist for daemon lifetime
         // Stored at function scope to prevent premature Drop (which would unsubscribe)
         let governance_event_subscription: Option<crate::events::SubscriptionHandle>;
@@ -833,6 +836,9 @@ impl Supervisor {
             // Store treasury handle for gateway integration
             treasury_handle_for_gateway = Some(treasury_manager_handle.clone());
 
+            // Store ledger handle for gateway balance queries
+            ledger_handle_for_gateway = Some(ledger_handle.clone());
+
             // Subscribe to governance events for ledger execution
             // CRITICAL: Must store handle to keep subscription alive for daemon lifetime
             governance_event_subscription = Some({
@@ -1076,13 +1082,14 @@ impl Supervisor {
 
             info!("Metrics update task spawned (system metrics only)");
 
-            // No event broadcaster or compute/trust/governance/treasury handles without identity
+            // No event broadcaster or compute/trust/governance/treasury/ledger handles without identity
             event_broadcaster = None;
             compute_handle_for_gateway = None;
             coop_handle_for_gateway = None;
             trust_graph_handle_for_gateway = None;
             governance_handle_for_gateway = None;
             treasury_handle_for_gateway = None;
+            ledger_handle_for_gateway = None;
 
             (None, None, None)
         };
@@ -1155,6 +1162,11 @@ impl Supervisor {
                         // Connect treasury handle if available
                         if let Some(handle) = treasury_handle_for_gateway {
                             gateway_server = gateway_server.with_treasury_handle(handle);
+                        }
+
+                        // Connect ledger handle for balance queries
+                        if let Some(handle) = ledger_handle_for_gateway {
+                            gateway_server = gateway_server.with_ledger_handle(handle);
                         }
 
                         if let Err(e) = gateway_server.run().await {

--- a/icn/crates/icn-gateway/src/api/ledger.rs
+++ b/icn/crates/icn-gateway/src/api/ledger.rs
@@ -12,6 +12,7 @@ use crate::models::{
     AccountDeltaResponse, BalanceResponse, CreatePaymentRequest, TransactionHistoryEntry,
 };
 use crate::rate_limit::VelocityLimiter;
+use crate::trust_mgr::TrustManager;
 use crate::validation;
 use icn_obs::metrics::gateway;
 
@@ -52,6 +53,7 @@ pub async fn create_payment(
     ledger_mgr: web::Data<Arc<LedgerManager>>,
     budget_store: web::Data<BudgetStore>,
     velocity_limiter: web::Data<VelocityLimiter>,
+    trust_mgr: web::Data<Arc<TrustManager>>,
     notification_service: web::Data<Arc<crate::notifications::NotificationService>>,
     event_broadcaster: web::Data<Arc<crate::events::EventBroadcaster>>,
     coop_id: web::Path<String>,
@@ -107,9 +109,8 @@ pub async fn create_payment(
     }
 
     // Check transaction velocity limit (Issue #164)
-    // For now, use 0.5 as default trust score (Known+ trust level)
-    // TODO: Look up actual trust score from trust graph when available
-    let trust_score = 0.5;
+    // Look up trust score from trust graph for rate limiting
+    let trust_score = trust_mgr.compute_trust_score_for_velocity(&from).await;
     velocity_limiter.check_and_record(&req.from, trust_score)?;
 
     let hash = ledger_mgr.create_payment(&coop_id, &from, &to, req.amount, req.currency.clone())?;
@@ -373,6 +374,7 @@ mod tests {
     use super::*;
     use crate::auth::TokenClaims;
     use crate::events::EventBroadcaster;
+    use crate::trust_mgr::TrustManager;
     use actix_web::{test, App, HttpMessage};
     use icn_identity::IdentityBundle;
 
@@ -382,6 +384,7 @@ mod tests {
         let db = sled::Config::new().temporary(true).open().unwrap();
         let budget_store = BudgetStore::new(db);
         let velocity_limiter = VelocityLimiter::default();
+        let trust_mgr = Arc::new(TrustManager::new());
         // Use temporary store for tests
         let store = Arc::new(crate::notifications::NotificationStore::new(
             sled::Config::new().temporary(true).open().unwrap(),
@@ -397,6 +400,7 @@ mod tests {
                 .app_data(web::Data::new(ledger_mgr.clone()))
                 .app_data(web::Data::new(budget_store.clone()))
                 .app_data(web::Data::new(velocity_limiter.clone()))
+                .app_data(web::Data::new(trust_mgr.clone()))
                 .app_data(web::Data::new(notification_service.clone()))
                 .app_data(web::Data::new(event_broadcaster.clone()))
                 .service(
@@ -538,6 +542,7 @@ mod tests {
         let db = sled::Config::new().temporary(true).open().unwrap();
         let budget_store = BudgetStore::new(db);
         let velocity_limiter = VelocityLimiter::default();
+        let trust_mgr = Arc::new(TrustManager::new());
         // Use temporary store for tests
         let store = Arc::new(crate::notifications::NotificationStore::new(
             sled::Config::new().temporary(true).open().unwrap(),
@@ -552,6 +557,7 @@ mod tests {
                 .app_data(web::Data::new(ledger_mgr.clone()))
                 .app_data(web::Data::new(budget_store.clone()))
                 .app_data(web::Data::new(velocity_limiter.clone()))
+                .app_data(web::Data::new(trust_mgr.clone()))
                 .app_data(web::Data::new(notification_service.clone()))
                 .app_data(web::Data::new(event_broadcaster.clone()))
                 .service(
@@ -611,6 +617,7 @@ mod tests {
         let db = sled::Config::new().temporary(true).open().unwrap();
         let budget_store = BudgetStore::new(db);
         let velocity_limiter = VelocityLimiter::default();
+        let trust_mgr = Arc::new(TrustManager::new());
         // Use temporary store for tests
         let store = Arc::new(crate::notifications::NotificationStore::new(
             sled::Config::new().temporary(true).open().unwrap(),
@@ -627,6 +634,7 @@ mod tests {
                 .app_data(web::Data::new(ledger_mgr.clone()))
                 .app_data(web::Data::new(budget_store.clone()))
                 .app_data(web::Data::new(velocity_limiter.clone()))
+                .app_data(web::Data::new(trust_mgr.clone()))
                 .app_data(web::Data::new(notification_service.clone()))
                 .app_data(web::Data::new(event_broadcaster.clone()))
                 .service(web::scope("/ledger").service(create_payment)),
@@ -666,6 +674,7 @@ mod tests {
         let db = sled::Config::new().temporary(true).open().unwrap();
         let budget_store = BudgetStore::new(db);
         let velocity_limiter = VelocityLimiter::default();
+        let trust_mgr = Arc::new(TrustManager::new());
         // Use temporary store for tests
         let store = Arc::new(crate::notifications::NotificationStore::new(
             sled::Config::new().temporary(true).open().unwrap(),
@@ -692,6 +701,7 @@ mod tests {
                 .app_data(web::Data::new(ledger_mgr.clone()))
                 .app_data(web::Data::new(budget_store.clone()))
                 .app_data(web::Data::new(velocity_limiter.clone()))
+                .app_data(web::Data::new(trust_mgr.clone()))
                 .app_data(web::Data::new(notification_service.clone()))
                 .app_data(web::Data::new(event_broadcaster.clone()))
                 .service(
@@ -761,6 +771,7 @@ mod tests {
         let db = sled::Config::new().temporary(true).open().unwrap();
         let budget_store = BudgetStore::new(db);
         let velocity_limiter = VelocityLimiter::default();
+        let trust_mgr = Arc::new(TrustManager::new());
         // Use temporary store for tests
         let store = Arc::new(crate::notifications::NotificationStore::new(
             sled::Config::new().temporary(true).open().unwrap(),
@@ -775,6 +786,7 @@ mod tests {
                 .app_data(web::Data::new(ledger_mgr.clone()))
                 .app_data(web::Data::new(budget_store.clone()))
                 .app_data(web::Data::new(velocity_limiter.clone()))
+                .app_data(web::Data::new(trust_mgr.clone()))
                 .app_data(web::Data::new(notification_service.clone()))
                 .app_data(web::Data::new(event_broadcaster.clone()))
                 .service(web::scope("/ledger").service(create_payment)),

--- a/icn/crates/icn-gateway/src/api/treasury.rs
+++ b/icn/crates/icn-gateway/src/api/treasury.rs
@@ -23,16 +23,26 @@ use crate::middleware::{require_coop_access, require_scope};
 use crate::treasury_mgr::GatewayTreasuryManager;
 
 // ============================================================================
-// Constants
+// Configurable Limits
 // ============================================================================
 
 /// Default pagination limit for audit trail queries
-/// TODO: Make configurable via gateway config or environment variable
-const DEFAULT_AUDIT_LIMIT: usize = 20;
+/// Can be overridden via ICN_AUDIT_DEFAULT_LIMIT environment variable
+fn default_audit_limit() -> usize {
+    std::env::var("ICN_AUDIT_DEFAULT_LIMIT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(20)
+}
 
 /// Maximum pagination limit for audit trail queries
-/// TODO: Make configurable via gateway config or environment variable
-const MAX_AUDIT_LIMIT: usize = 100;
+/// Can be overridden via ICN_AUDIT_MAX_LIMIT environment variable
+fn max_audit_limit() -> usize {
+    std::env::var("ICN_AUDIT_MAX_LIMIT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(100)
+}
 
 // ============================================================================
 // Request/Response Types
@@ -596,8 +606,8 @@ pub async fn get_audit_trail(
     let limit: usize = query
         .get("limit")
         .and_then(|s| s.parse().ok())
-        .unwrap_or(DEFAULT_AUDIT_LIMIT)
-        .min(MAX_AUDIT_LIMIT);
+        .unwrap_or_else(default_audit_limit)
+        .min(max_audit_limit());
 
     let offset: usize = query
         .get("offset")

--- a/icn/crates/icn-gateway/src/api/treasury.rs
+++ b/icn/crates/icn-gateway/src/api/treasury.rs
@@ -10,12 +10,14 @@
 //! spending thresholds, budget creation) must go through the governance
 //! proposal system.
 
-use actix_web::{get, post, web, HttpRequest, HttpResponse};
+use actix_web::{get, post, web, HttpMessage, HttpRequest, HttpResponse};
+use icn_identity::Did;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::info;
 
+use crate::auth::TokenClaims;
 use crate::error::{GatewayError, Result};
 use crate::middleware::{require_coop_access, require_scope};
 use crate::treasury_mgr::GatewayTreasuryManager;
@@ -663,6 +665,7 @@ pub async fn deposit_to_treasury(
     req: HttpRequest,
     path: web::Path<String>,
     body: web::Json<DepositRequest>,
+    treasury_mgr: web::Data<Arc<GatewayTreasuryManager>>,
 ) -> Result<HttpResponse> {
     require_scope(&req, "treasury:write")?;
 
@@ -682,25 +685,74 @@ pub async fn deposit_to_treasury(
         ));
     }
 
+    // Get depositor DID from auth token
+    let claims = req
+        .extensions()
+        .get::<TokenClaims>()
+        .cloned()
+        .ok_or_else(|| {
+            GatewayError::AuthenticationFailed("Missing authentication claims".to_string())
+        })?;
+
+    let depositor_did: Did = claims.sub.parse().map_err(|e| {
+        GatewayError::InternalError(format!("Invalid depositor DID in claims: {e}"))
+    })?;
+
+    // Get the treasury for this cooperative
+    let treasury = treasury_mgr
+        .get_treasury_by_coop(&coop_id)
+        .await
+        .map_err(|e| GatewayError::InternalError(e.to_string()))?
+        .ok_or_else(|| {
+            GatewayError::NotFound(format!("Treasury not found for cooperative: {coop_id}"))
+        })?;
+
     info!(
         coop_id = %coop_id,
+        depositor = %depositor_did,
+        treasury = %treasury.treasury_did,
         amount = body.amount,
         currency = %body.currency,
         "Treasury deposit requested"
     );
 
-    // TODO: Wire to ledger to create deposit entry
-    // Deposits don't require approval - they add to treasury
+    // Check if ledger is wired for deposits
+    if !treasury_mgr.is_ledger_wired() {
+        return Err(GatewayError::ServiceUnavailable(
+            "Treasury deposits require daemon integration. \
+             Start icnd with full identity to enable deposits."
+                .to_string(),
+        ));
+    }
+
+    // Create the deposit entry
+    let entry_hash = treasury_mgr
+        .create_deposit(
+            &treasury.treasury_did,
+            &depositor_did,
+            body.amount,
+            body.currency.clone(),
+            body.memo.clone(),
+        )
+        .await
+        .map_err(|e| GatewayError::InternalError(e.to_string()))?;
+
+    info!(
+        coop_id = %coop_id,
+        entry_hash = %entry_hash,
+        "Treasury deposit completed"
+    );
 
     let response = serde_json::json!({
-        "status": "pending",
-        "message": "Treasury deposit processing",
+        "status": "completed",
+        "message": "Treasury deposit successful",
         "coop_id": coop_id,
         "amount": body.amount,
-        "currency": body.currency
+        "currency": body.currency,
+        "entry_hash": entry_hash.to_string()
     });
 
-    Ok(HttpResponse::Accepted().json(response))
+    Ok(HttpResponse::Ok().json(response))
 }
 
 // ============================================================================

--- a/icn/crates/icn-gateway/src/api/treasury.rs
+++ b/icn/crates/icn-gateway/src/api/treasury.rs
@@ -26,22 +26,50 @@ use crate::treasury_mgr::GatewayTreasuryManager;
 // Configurable Limits
 // ============================================================================
 
+/// Minimum allowed value for limits (prevents invalid zero limits)
+const MIN_LIMIT: usize = 1;
+
+/// Default fallback values (used when env vars are not set)
+const DEFAULT_AUDIT_LIMIT_FALLBACK: usize = 20;
+const MAX_AUDIT_LIMIT_FALLBACK: usize = 100;
+
 /// Default pagination limit for audit trail queries
 /// Can be overridden via ICN_AUDIT_DEFAULT_LIMIT environment variable
+///
+/// Validation:
+/// - Must be >= MIN_LIMIT (1)
+/// - Must be <= max_audit_limit()
+/// - Invalid values fall back to DEFAULT_AUDIT_LIMIT_FALLBACK
 fn default_audit_limit() -> usize {
-    std::env::var("ICN_AUDIT_DEFAULT_LIMIT")
+    let max = max_audit_limit_raw();
+    let raw = std::env::var("ICN_AUDIT_DEFAULT_LIMIT")
         .ok()
         .and_then(|v| v.parse().ok())
-        .unwrap_or(20)
+        .unwrap_or(DEFAULT_AUDIT_LIMIT_FALLBACK);
+
+    // Clamp to valid range: [MIN_LIMIT, max]
+    raw.max(MIN_LIMIT).min(max)
 }
 
 /// Maximum pagination limit for audit trail queries
 /// Can be overridden via ICN_AUDIT_MAX_LIMIT environment variable
+///
+/// Validation:
+/// - Must be >= MIN_LIMIT (1)
+/// - Invalid values fall back to MAX_AUDIT_LIMIT_FALLBACK
 fn max_audit_limit() -> usize {
-    std::env::var("ICN_AUDIT_MAX_LIMIT")
+    max_audit_limit_raw()
+}
+
+/// Internal: get raw max limit without clamping default
+fn max_audit_limit_raw() -> usize {
+    let raw = std::env::var("ICN_AUDIT_MAX_LIMIT")
         .ok()
         .and_then(|v| v.parse().ok())
-        .unwrap_or(100)
+        .unwrap_or(MAX_AUDIT_LIMIT_FALLBACK);
+
+    // Ensure at least MIN_LIMIT
+    raw.max(MIN_LIMIT)
 }
 
 // ============================================================================

--- a/icn/crates/icn-gateway/src/api/treasury.rs
+++ b/icn/crates/icn-gateway/src/api/treasury.rs
@@ -269,14 +269,18 @@ pub async fn get_treasury_status(
         .filter(|b| matches!(b.status, icn_ledger::BudgetStatus::Active))
         .count();
 
-    // TODO: Get actual balance from ledger via LedgerActor
-    // For now, omit balance field (None is skipped in serialization)
+    // Query actual balance from ledger (returns None if ledger not wired)
+    let balance = treasury_mgr
+        .get_treasury_balance(&treasury.treasury_did, &treasury.currency)
+        .await
+        .map_err(|e| GatewayError::InternalError(e.to_string()))?;
+
     let response = TreasuryStatusResponse {
         treasury_did: treasury.treasury_did.to_string(),
         coop_id: treasury.coop_id,
         currency: treasury.currency,
         is_active: treasury.is_active,
-        balance: None,
+        balance,
         active_budget_count,
         spending_rule_count: rules.len(),
     };
@@ -306,19 +310,33 @@ pub async fn get_treasury_balance(
         .await
         .map_err(|e| GatewayError::InternalError(e.to_string()))?;
 
-    let Some(_treasury) = treasury else {
+    let Some(treasury) = treasury else {
         return Err(GatewayError::NotFound(format!(
             "Treasury not configured for cooperative '{coop_id}'"
         )));
     };
 
-    // Balance lookup requires ledger integration which is not yet implemented.
-    // Return 503 Service Unavailable instead of fake/empty data.
-    // TODO: Wire LedgerActor to get actual balances once ledger integration is complete.
-    Err(GatewayError::ServiceUnavailable(
-        "Treasury balance lookup not yet implemented. Use budget endpoints for allocated amounts."
-            .to_string(),
-    ))
+    // Check if ledger is wired for balance queries
+    if !treasury_mgr.is_ledger_wired() {
+        return Err(GatewayError::ServiceUnavailable(
+            "Treasury balance lookup requires daemon integration. \
+             Start icnd with full identity to enable balance queries."
+                .to_string(),
+        ));
+    }
+
+    // Query all balances from ledger
+    let balances = treasury_mgr
+        .get_all_treasury_balances(&treasury.treasury_did)
+        .await
+        .map_err(|e| GatewayError::InternalError(e.to_string()))?;
+
+    let response = TreasuryBalanceResponse {
+        treasury_did: treasury.treasury_did.to_string(),
+        balances,
+    };
+
+    Ok(HttpResponse::Ok().json(response))
 }
 
 /// GET /treasury/{coop_id}/budgets - List budgets

--- a/icn/crates/icn-gateway/src/governance_mgr.rs
+++ b/icn/crates/icn-gateway/src/governance_mgr.rs
@@ -404,18 +404,10 @@ impl GovernanceManager {
     }
 
     /// Get vote tally for a proposal
-    ///
-    /// Note: Returns error in actor-backed mode (not exposed via GovernanceOps).
-    /// TODO(#273): Add get_vote_tally to GovernanceOps trait.
     pub async fn get_vote_tally(&self, proposal_id: &ProposalId) -> Result<VoteTally> {
-        if self.governance_handle.is_some() {
-            // Actor-backed mode: vote tally not exposed via GovernanceOps
-            // Return explicit error rather than silent empty data
-            anyhow::bail!(
-                "Vote tally not available in actor-backed mode for proposal '{}'. \
-                 Use proposal state to get final outcome, or add get_vote_tally to GovernanceOps trait.",
-                proposal_id.0
-            );
+        if let Some(ref handle) = self.governance_handle {
+            // Actor-backed mode: delegate to GovernanceActor via GovernanceOps
+            return handle.get_vote_tally(proposal_id).await;
         }
 
         // Standalone mode: in-memory storage
@@ -428,18 +420,10 @@ impl GovernanceManager {
     }
 
     /// Get list of voter DIDs for a proposal (for notifications)
-    ///
-    /// Note: Returns error in actor-backed mode (not exposed via GovernanceOps).
-    /// TODO(#273): Add get_voter_dids to GovernanceOps trait.
     pub async fn get_voter_dids(&self, proposal_id: &ProposalId) -> Result<Vec<Did>> {
-        if self.governance_handle.is_some() {
-            // Actor-backed mode: voter DIDs not exposed via GovernanceOps
-            // Return explicit error rather than silent empty data
-            anyhow::bail!(
-                "Voter list not available in actor-backed mode for proposal '{}'. \
-                 Add get_voter_dids to GovernanceOps trait to expose this data.",
-                proposal_id.0
-            );
+        if let Some(ref handle) = self.governance_handle {
+            // Actor-backed mode: delegate to GovernanceActor via GovernanceOps
+            return handle.get_voter_dids(proposal_id).await;
         }
 
         // Standalone mode: in-memory storage

--- a/icn/crates/icn-gateway/src/lib.rs
+++ b/icn/crates/icn-gateway/src/lib.rs
@@ -76,4 +76,4 @@ pub use rate_limit::{
     RateLimiter, VelocityLimitConfig, VelocityLimiter,
 };
 pub use server::GatewayServer;
-pub use treasury_mgr::{GatewayTreasuryManager, TreasuryHandle};
+pub use treasury_mgr::{GatewayTreasuryManager, LedgerHandle, TreasuryHandle};

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -31,7 +31,7 @@ use crate::notification_triggers::{GovernanceNotificationTrigger, LedgerNotifica
 use crate::notifications::NotificationService;
 use crate::rate_limit::{IpRateLimiter, RateLimitConfig, RateLimiter};
 use crate::security::{configure_cors, SecurityConfig, SecurityHeaders};
-use crate::treasury_mgr::{GatewayTreasuryManager, TreasuryHandle};
+use crate::treasury_mgr::{GatewayTreasuryManager, LedgerHandle, TreasuryHandle};
 use crate::trust_mgr::{TrustGraphHandle, TrustManager};
 use icn_compute::ComputeHandle;
 
@@ -53,6 +53,8 @@ pub struct GatewayServer {
     contract_registry_handle: Option<icn_ccl::ContractRegistryHandle>,
     /// Optional handle to daemon's TreasuryManager (for treasury operations)
     treasury_handle: Option<TreasuryHandle>,
+    /// Optional handle to daemon's Ledger (for balance queries)
+    ledger_handle: Option<LedgerHandle>,
 }
 
 impl GatewayServer {
@@ -71,6 +73,7 @@ impl GatewayServer {
             governance_handle: None,
             contract_registry_handle: None,
             treasury_handle: None,
+            ledger_handle: None,
         }
     }
 
@@ -93,6 +96,7 @@ impl GatewayServer {
             governance_handle: None,
             contract_registry_handle: None,
             treasury_handle: None,
+            ledger_handle: None,
         }
     }
 
@@ -116,6 +120,7 @@ impl GatewayServer {
             governance_handle: None,
             contract_registry_handle: None,
             treasury_handle: None,
+            ledger_handle: None,
         }
     }
 
@@ -173,6 +178,15 @@ impl GatewayServer {
     /// TreasuryManager, enabling treasury operations with governance integration.
     pub fn with_treasury_handle(mut self, handle: TreasuryHandle) -> Self {
         self.treasury_handle = Some(handle);
+        self
+    }
+
+    /// Set ledger handle for balance queries
+    ///
+    /// When set, treasury balance endpoints query actual ledger balances
+    /// instead of returning placeholders.
+    pub fn with_ledger_handle(mut self, handle: LedgerHandle) -> Self {
+        self.ledger_handle = Some(handle);
         self
     }
 
@@ -260,14 +274,22 @@ impl GatewayServer {
         let commons_manager = Arc::new(CommonsManager::new());
 
         // Create treasury manager (uses handle if available, otherwise in-memory)
-        let treasury_manager: Arc<GatewayTreasuryManager> =
-            if let Some(handle) = self.treasury_handle {
-                info!("Treasury manager connected to daemon (using TreasuryManager handle)");
-                Arc::new(GatewayTreasuryManager::with_handle(handle))
+        let treasury_manager: Arc<GatewayTreasuryManager> = if let Some(handle) =
+            self.treasury_handle
+        {
+            let mut mgr = GatewayTreasuryManager::with_handle(handle);
+            // Wire ledger handle for balance queries
+            if let Some(ledger_handle) = self.ledger_handle.clone() {
+                mgr.set_ledger_handle(ledger_handle);
+                info!("Treasury manager connected to daemon (TreasuryManager + Ledger handles)");
             } else {
-                info!("Treasury manager running standalone (in-memory only)");
-                Arc::new(GatewayTreasuryManager::new())
-            };
+                info!("Treasury manager connected to daemon (TreasuryManager handle only)");
+            }
+            Arc::new(mgr)
+        } else {
+            info!("Treasury manager running standalone (in-memory only)");
+            Arc::new(GatewayTreasuryManager::new())
+        };
 
         // Create SDIS state for identity verification
         let sdis_state = Arc::new(crate::api::sdis::SdisState::new());

--- a/icn/crates/icn-gateway/src/treasury_mgr.rs
+++ b/icn/crates/icn-gateway/src/treasury_mgr.rs
@@ -351,6 +351,81 @@ impl GatewayTreasuryManager {
         }
         Ok(HashMap::new()) // Ledger not wired
     }
+
+    // ============================================================================
+    // Ledger Write Operations
+    // ============================================================================
+
+    /// Create a deposit entry in the ledger
+    ///
+    /// Creates a journal entry that credits the treasury and debits the depositor.
+    /// Returns the entry hash on success.
+    ///
+    /// Requires both ledger_handle and treasury_handle to be wired.
+    pub async fn create_deposit(
+        &self,
+        treasury_did: &Did,
+        from_did: &Did,
+        amount: i64,
+        currency: String,
+        memo: Option<String>,
+    ) -> Result<icn_ledger::ContentHash> {
+        let ledger_handle = self
+            .ledger_handle
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Ledger not wired - deposits require daemon mode"))?;
+
+        // Build the journal entry: debit from depositor, credit to treasury
+        let mut entry = icn_ledger::entry::JournalEntryBuilder::new(from_did.clone())
+            .debit(from_did.clone(), currency.clone(), amount)
+            .credit(treasury_did.clone(), currency.clone(), amount)
+            .build()?;
+
+        // Compute the hash
+        let hash = entry.compute_hash()?;
+
+        // Append to ledger
+        {
+            let mut ledger = ledger_handle.write().await;
+            ledger.append_entry(entry)?;
+        }
+
+        // Record audit trail if treasury handle is available
+        if self.treasury_handle.is_some() {
+            // Get the new balance for audit
+            let new_balance = self
+                .get_treasury_balance(treasury_did, &currency)
+                .await?
+                .unwrap_or(0);
+
+            let operation = TreasuryOperation::Deposit {
+                from: from_did.clone(),
+                amount,
+                currency,
+                memo,
+            };
+
+            self.record_audit(
+                treasury_did,
+                operation,
+                from_did.clone(),
+                new_balance,
+                None, // No proposal for deposits
+                Some(hash.clone()),
+            )
+            .await?;
+        }
+
+        debug!(
+            treasury = %treasury_did,
+            from = %from_did,
+            amount = amount,
+            hash = %hash,
+            "Created treasury deposit entry"
+        );
+
+        Ok(hash)
+    }
 }
 
 impl Default for GatewayTreasuryManager {

--- a/icn/crates/icn-gateway/src/treasury_mgr.rs
+++ b/icn/crates/icn-gateway/src/treasury_mgr.rs
@@ -358,10 +358,18 @@ impl GatewayTreasuryManager {
 
     /// Create a deposit entry in the ledger
     ///
-    /// Creates a journal entry that credits the treasury and debits the depositor.
+    /// Creates a journal entry that transfers value from the depositor to the treasury.
+    /// In ICN's mutual credit accounting:
+    /// - The depositor is credited (balance decreases = giving funds)
+    /// - The treasury is debited (balance increases = receiving funds)
+    ///
+    /// The balance is captured atomically with the ledger update to ensure
+    /// the audit trail reflects the correct post-deposit balance.
+    ///
     /// Returns the entry hash on success.
     ///
-    /// Requires both ledger_handle and treasury_handle to be wired.
+    /// Requires ledger_handle to be wired. Treasury handle is optional but
+    /// required for audit trail recording.
     pub async fn create_deposit(
         &self,
         treasury_did: &Did,
@@ -375,29 +383,29 @@ impl GatewayTreasuryManager {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Ledger not wired - deposits require daemon mode"))?;
 
-        // Build the journal entry: debit from depositor, credit to treasury
+        // Build the journal entry: credit depositor (giving funds), debit treasury (receiving funds)
+        // In ICN's mutual credit accounting:
+        // - Credit = balance decreases (giving value)
+        // - Debit = balance increases (receiving value)
         let mut entry = icn_ledger::entry::JournalEntryBuilder::new(from_did.clone())
-            .debit(from_did.clone(), currency.clone(), amount)
-            .credit(treasury_did.clone(), currency.clone(), amount)
+            .credit(from_did.clone(), currency.clone(), amount) // Depositor gives funds
+            .debit(treasury_did.clone(), currency.clone(), amount) // Treasury receives funds
             .build()?;
 
         // Compute the hash
         let hash = entry.compute_hash()?;
 
-        // Append to ledger
-        {
+        // Append to ledger and get new balance atomically to avoid race conditions.
+        // We must capture the balance while holding the lock to ensure consistency
+        // between the ledger state and the audit trail.
+        let new_balance = {
             let mut ledger = ledger_handle.write().await;
             ledger.append_entry(entry)?;
-        }
+            ledger.get_balance(treasury_did, &currency)
+        };
 
         // Record audit trail if treasury handle is available
         if self.treasury_handle.is_some() {
-            // Get the new balance for audit
-            let new_balance = self
-                .get_treasury_balance(treasury_did, &currency)
-                .await?
-                .unwrap_or(0);
-
             let operation = TreasuryOperation::Deposit {
                 from: from_did.clone(),
                 amount,

--- a/icn/crates/icn-gateway/src/treasury_mgr.rs
+++ b/icn/crates/icn-gateway/src/treasury_mgr.rs
@@ -18,9 +18,10 @@
 use anyhow::Result;
 use icn_identity::Did;
 use icn_ledger::{
-    ApprovalType, PaginatedAuditTrail, SpendingRule, Treasury, TreasuryAuditRecord, TreasuryBudget,
-    TreasuryManager as LedgerTreasuryManager, TreasuryOperation,
+    ApprovalType, Ledger, PaginatedAuditTrail, SpendingRule, Treasury, TreasuryAuditRecord,
+    TreasuryBudget, TreasuryManager as LedgerTreasuryManager, TreasuryOperation,
 };
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::debug;
@@ -30,16 +31,26 @@ use tracing::debug;
 /// This wraps the daemon's TreasuryManager for gateway integration.
 pub type TreasuryHandle = Arc<RwLock<LedgerTreasuryManager>>;
 
+/// Handle type for ledger balance queries
+///
+/// This wraps the daemon's Ledger for balance lookups.
+pub type LedgerHandle = Arc<RwLock<Ledger>>;
+
 /// Treasury manager for gateway API
 ///
 /// Supports two modes:
 /// - **Standalone mode** (`new()`): In-memory storage, for testing only
 /// - **Actor-backed mode** (`with_handle()`): Delegates to daemon's TreasuryManager
+///
+/// When a `LedgerHandle` is set (via `set_ledger_handle`), balance queries
+/// return actual ledger balances instead of placeholders.
 pub struct GatewayTreasuryManager {
     /// In-memory TreasuryManager - used in standalone mode
     standalone: Option<LedgerTreasuryManager>,
     /// Optional handle to daemon's TreasuryManager (actor-backed mode)
     treasury_handle: Option<TreasuryHandle>,
+    /// Optional handle to daemon's Ledger (for balance queries)
+    ledger_handle: Option<LedgerHandle>,
 }
 
 impl GatewayTreasuryManager {
@@ -52,6 +63,7 @@ impl GatewayTreasuryManager {
         GatewayTreasuryManager {
             standalone: Some(LedgerTreasuryManager::new()),
             treasury_handle: None,
+            ledger_handle: None,
         }
     }
 
@@ -67,12 +79,27 @@ impl GatewayTreasuryManager {
         GatewayTreasuryManager {
             standalone: None,
             treasury_handle: Some(handle),
+            ledger_handle: None,
         }
+    }
+
+    /// Set ledger handle for balance queries
+    ///
+    /// When set, balance queries return actual ledger balances.
+    /// When not set, balance endpoints return None or 503.
+    pub fn set_ledger_handle(&mut self, handle: LedgerHandle) {
+        debug!("GatewayTreasuryManager wired to daemon Ledger for balance queries");
+        self.ledger_handle = Some(handle);
     }
 
     /// Check if running in actor-backed mode
     pub fn is_actor_backed(&self) -> bool {
         self.treasury_handle.is_some()
+    }
+
+    /// Check if ledger is wired for balance queries
+    pub fn is_ledger_wired(&self) -> bool {
+        self.ledger_handle.is_some()
     }
 
     // ============================================================================
@@ -288,6 +315,41 @@ impl GatewayTreasuryManager {
         }
 
         anyhow::bail!("Audit recording not supported in standalone mode")
+    }
+
+    // ============================================================================
+    // Ledger Balance Queries
+    // ============================================================================
+
+    /// Get balance for a treasury account from ledger
+    ///
+    /// Returns the balance for a specific currency, or None if ledger not wired.
+    pub async fn get_treasury_balance(
+        &self,
+        treasury_did: &Did,
+        currency: &str,
+    ) -> Result<Option<i64>> {
+        if let Some(ref ledger_handle) = self.ledger_handle {
+            let ledger = ledger_handle.read().await;
+            let balance = ledger.get_balance(treasury_did, currency);
+            return Ok(Some(balance));
+        }
+        Ok(None) // Ledger not wired
+    }
+
+    /// Get all balances for a treasury account
+    ///
+    /// Returns a map of currency -> balance, or empty if ledger not wired.
+    pub async fn get_all_treasury_balances(
+        &self,
+        treasury_did: &Did,
+    ) -> Result<HashMap<String, i64>> {
+        if let Some(ref ledger_handle) = self.ledger_handle {
+            let ledger = ledger_handle.read().await;
+            let account_balances = ledger.get_account_balances(treasury_did);
+            return Ok(account_balances.balances);
+        }
+        Ok(HashMap::new()) // Ledger not wired
     }
 }
 

--- a/icn/crates/icn-gateway/src/trust_mgr.rs
+++ b/icn/crates/icn-gateway/src/trust_mgr.rs
@@ -20,6 +20,27 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::debug;
 
+// ============================================================================
+// Trust Score Constants
+// ============================================================================
+
+/// Default trust score returned when trust cannot be computed.
+///
+/// This corresponds to the "Known" trust level in ICN's trust classification:
+/// - Isolated: < 0.1 (10 msg/sec rate limit)
+/// - Known: 0.1-0.4 (50 msg/sec rate limit)
+/// - Partner: 0.4-0.7 (100 msg/sec rate limit)
+/// - Federated: > 0.7 (200 msg/sec rate limit)
+///
+/// A score of 0.5 represents the middle of the "Known+" range, providing
+/// moderate rate limits while not granting excessive privileges to unknown peers.
+///
+/// This default is used when:
+/// 1. The TrustGraph returns an error during score computation
+/// 2. Running in standalone mode without a configured perspective DID
+/// 3. The target DID has no trust edges (neither direct nor transitive)
+pub const DEFAULT_TRUST_SCORE: f64 = 0.5;
+
 /// Trust edge for API responses
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TrustEdgeResponse {
@@ -254,19 +275,38 @@ impl TrustManager {
     /// This computes the trust score from the node's perspective to the given DID.
     /// Used for rate limiting based on trust level.
     ///
-    /// Returns the trust score, or 0.5 (Known level) if unable to compute.
+    /// # Trust-Based Rate Limiting
+    ///
+    /// The returned score maps to velocity limits as follows:
+    /// - Isolated (< 0.1): 10 msg/sec - Unknown/untrusted peers
+    /// - Known (0.1-0.4): 50 msg/sec - Recognized but not endorsed
+    /// - Partner (0.4-0.7): 100 msg/sec - Trusted collaborators
+    /// - Federated (> 0.7): 200 msg/sec - Highly trusted federation members
+    ///
+    /// # Default Behavior
+    ///
+    /// Returns [`DEFAULT_TRUST_SCORE`] (0.5) when trust cannot be computed:
+    /// - TrustGraph lookup fails or returns None
+    /// - Running in standalone mode without a configured perspective DID
+    /// - Target has no trust edges in the graph
+    ///
+    /// The 0.5 default places unknown targets at the Partner threshold,
+    /// which is intentionally permissive to avoid blocking legitimate traffic
+    /// from new participants while still providing some rate protection.
     pub async fn compute_trust_score_for_velocity(&self, target: &Did) -> f64 {
         if let Some(ref handle) = self.trust_graph {
             // Actor-backed mode: delegate to TrustGraph
             let graph = handle.read().await;
-            graph.compute_trust_score(target).unwrap_or(0.5)
+            graph
+                .compute_trust_score(target)
+                .unwrap_or(DEFAULT_TRUST_SCORE)
         } else {
             // Standalone mode: use own_did if set, otherwise return default
             if let Some(ref own_did) = self.own_did {
                 self.compute_trust_score_local(own_did, target)
             } else {
-                // No perspective set, return Known level default
-                0.5
+                // No perspective set - see DEFAULT_TRUST_SCORE documentation
+                DEFAULT_TRUST_SCORE
             }
         }
     }

--- a/icn/crates/icn-gateway/src/trust_mgr.rs
+++ b/icn/crates/icn-gateway/src/trust_mgr.rs
@@ -249,6 +249,28 @@ impl TrustManager {
         }
     }
 
+    /// Compute trust score for velocity limiting (async version)
+    ///
+    /// This computes the trust score from the node's perspective to the given DID.
+    /// Used for rate limiting based on trust level.
+    ///
+    /// Returns the trust score, or 0.5 (Known level) if unable to compute.
+    pub async fn compute_trust_score_for_velocity(&self, target: &Did) -> f64 {
+        if let Some(ref handle) = self.trust_graph {
+            // Actor-backed mode: delegate to TrustGraph
+            let graph = handle.read().await;
+            graph.compute_trust_score(target).unwrap_or(0.5)
+        } else {
+            // Standalone mode: use own_did if set, otherwise return default
+            if let Some(ref own_did) = self.own_did {
+                self.compute_trust_score_local(own_did, target)
+            } else {
+                // No perspective set, return Known level default
+                0.5
+            }
+        }
+    }
+
     /// Compute trust score using local (in-memory or fallback) algorithm
     fn compute_trust_score_local(&self, from: &Did, to: &Did) -> f64 {
         // Direct trust

--- a/icn/crates/icn-governance/src/handle.rs
+++ b/icn/crates/icn-governance/src/handle.rs
@@ -6,7 +6,7 @@ use icn_identity::Did;
 
 use crate::{
     Delegation, DelegationId, GovernanceDomain, GovernanceDomainId, GovernanceParams,
-    MembershipConfig, Proposal, ProposalId, ProposalPayload, Timestamp, VoteChoice,
+    MembershipConfig, Proposal, ProposalId, ProposalPayload, Timestamp, VoteChoice, VoteTally,
 };
 
 /// Trait for governance operations exposed to RPC layer
@@ -84,4 +84,17 @@ pub trait GovernanceOps: Send + Sync {
 
     /// Revoke a delegation
     async fn revoke_delegation(&self, id: &DelegationId, revoked_at: Timestamp) -> Result<()>;
+
+    // Vote tracking operations
+
+    /// Get the vote tally for a proposal
+    ///
+    /// Returns the current vote counts (for, against, abstain) for a proposal.
+    async fn get_vote_tally(&self, proposal_id: &ProposalId) -> Result<VoteTally>;
+
+    /// Get the list of DIDs who voted on a proposal
+    ///
+    /// Returns all DIDs that have cast votes on the proposal.
+    /// Useful for notifications and audit purposes.
+    async fn get_voter_dids(&self, proposal_id: &ProposalId) -> Result<Vec<Did>>;
 }


### PR DESCRIPTION
## Summary

Sprint 2 Gateway Polish - completes remaining gateway integration TODOs to achieve full daemon wiring.

### Changes

- **Treasury Balance Wiring**: Wire `LedgerHandle` through gateway for real balance lookups
  - Add `LedgerHandle` type and balance query methods to `GatewayTreasuryManager`
  - Wire handle from Supervisor to Gateway
  - Treasury status and balance endpoints now return actual ledger data

- **Treasury Deposit Wiring**: Wire deposit endpoint to create ledger entries
  - Add `create_deposit()` method that creates journal entries
  - Records audit trail for deposits
  - Returns 503 if ledger not wired (standalone mode)

- **GovernanceOps Expansion** (#273): Add vote tracking to trait
  - Add `get_vote_tally()` to GovernanceOps
  - Add `get_voter_dids()` to GovernanceOps
  - Update GatewayGovernanceManager to use trait methods in actor-backed mode

- **Trust Score Wiring**: Wire trust graph lookup for velocity limiting
  - Add `compute_trust_score_for_velocity()` async method
  - Update payment endpoint to use actual trust scores

- **Configurable Audit Limits**: Make pagination configurable
  - Replace hardcoded constants with environment-configurable functions
  - `ICN_AUDIT_DEFAULT_LIMIT` and `ICN_AUDIT_MAX_LIMIT` env vars

## Test plan

- [x] `cargo test -p icn-gateway --lib` - All 276 tests pass
- [x] `cargo test -p icn-core --lib` - All tests pass
- [x] `cargo test -p icn-governance` - All tests pass
- [x] `cargo clippy` - No warnings
- [x] `cargo fmt --check` - Passes

## Deferred Tasks

The following tasks from the Sprint 2 plan are deferred to a follow-up:

- Task 3.2: TrustGraph incoming edge index (requires changes to icn-trust crate)
- Task 4.2: Native cursor-based pagination (more complex implementation)

🤖 Generated with [Claude Code](https://claude.ai/code)