### PR TITLE
feat(entity): Add unified CooperativeEntity model (Phase 19 prep)

### DIFF
--- a/docs/dev-journal/COOPERATIVE_ENTITY_SPEC.md
+++ b/docs/dev-journal/COOPERATIVE_ENTITY_SPEC.md
@@ -89,7 +89,7 @@ impl EntityId {
 ```
 
 **Slug Validation Rules**:
-- 3-64 characters
+- 4-64 characters (minimum 4 to avoid namespace collisions)
 - Lowercase letters, numbers, hyphens only
 - Must start with a letter
 - No consecutive hyphens

--- a/docs/dev-journal/COOPERATIVE_ENTITY_SPEC.md
+++ b/docs/dev-journal/COOPERATIVE_ENTITY_SPEC.md
@@ -1,16 +1,41 @@
 # CooperativeEntity Type Specification
 
 ---
-**Status**: DRAFT
+**Status**: IMPLEMENTED
 **Created**: 2025-12-24
 **Updated**: 2025-12-24
 **Phase**: 19 - Cooperative Entity Foundation
 **Authors**: fahertym, Claude Code
-**Decision Makers**: TBD (pending review)
+**Crate**: `icn-entity` (32 tests passing)
 
 ---
 
 **Related**: [COOPERATIVE_MIDDLE_LAYER_GAP_ANALYSIS.md](COOPERATIVE_MIDDLE_LAYER_GAP_ANALYSIS.md)
+
+## Implementation Status
+
+| Component | Status | File |
+|-----------|--------|------|
+| EntityId | Complete | `entity.rs` |
+| EntityType | Complete | `entity.rs` |
+| CooperativeEntity | Complete | `entity.rs` |
+| EntityStatus | Complete | `entity.rs` |
+| AccountId | Complete | `entity.rs` |
+| Membership | Complete | `membership.rs` |
+| MembershipRole | Complete | `membership.rs` |
+| MembershipCapability | Complete | `membership.rs` |
+| MembershipStatus | Complete | `membership.rs` |
+| EntityRegistry trait | Complete | `registry.rs` |
+| InMemoryRegistry | Complete | `registry.rs` |
+| EntityRegistryHandle | Complete | `registry.rs` |
+| LifecycleEvent | Complete | `lifecycle.rs` |
+| EntityLifecycle trait | Complete | `lifecycle.rs` |
+
+**Note**: The implementation uses a simplified model compared to the original spec below. Key differences:
+- EntityId format: `entity:icn:<type>:<identifier>` (vs `entity:<type>:<namespace>:<local_id>`)
+- Three entity types: Individual, Cooperative, Federation (vs Person, WorkingGroup, Cooperative, Federation, Commons)
+- No EntityAnchor yet (deferred to full SDIS integration)
+- No GovernanceConfig/EconomicConfig/TrustConfig embedded (linked via domain_id instead)
 
 ## Overview
 
@@ -28,45 +53,48 @@ This document specifies the `CooperativeEntity` type - a unified recursive model
 
 ## Core Types
 
-### EntityId
+### EntityId (Implemented)
 
 A universally unique identifier for any cooperative entity.
 
 ```rust
 /// Unique identifier for a cooperative entity
-/// Format: "entity:{type}:{namespace}:{local_id}"
+/// Format: "entity:icn:{type}:{identifier}"
 /// Examples:
-///   - "entity:person:icn:did:icn:z123..."
-///   - "entity:coop:food-network:sunshine-coop"
-///   - "entity:federation:regional:pacific-northwest"
-///   - "entity:commons:global:icn-protocol"
+///   - "entity:icn:individual:z5TrA8Qk..." (wraps DID public key)
+///   - "entity:icn:cooperative:food-coop-2024"
+///   - "entity:icn:federation:midwest-fed"
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct EntityId(String);
 
 impl EntityId {
-    pub fn person(did: &Did) -> Self {
-        Self(format!("entity:person:icn:{did}"))
-    }
+    /// Create from an existing DID (for individuals)
+    pub fn from_did(did: &Did) -> Self;
 
-    pub fn coop(namespace: &str, local_id: &str) -> Self {
-        Self(format!("entity:coop:{namespace}:{local_id}"))
-    }
+    /// Create a cooperative entity ID from slug
+    pub fn cooperative(slug: &str) -> Result<Self>;
 
-    pub fn federation(namespace: &str, local_id: &str) -> Self {
-        Self(format!("entity:federation:{namespace}:{local_id}"))
-    }
+    /// Create a federation entity ID from slug
+    pub fn federation(slug: &str) -> Result<Self>;
 
-    pub fn commons(local_id: &str) -> Self {
-        Self(format!("entity:commons:global:{local_id}"))
-    }
+    /// Get entity type from the ID
+    pub fn entity_type(&self) -> EntityType;
 
-    pub fn entity_type(&self) -> EntityType {
-        // Parse from string
-    }
+    /// Convert back to DID (only for individuals)
+    pub fn to_did(&self) -> Option<Did>;
+
+    /// Get the raw identifier portion
+    pub fn identifier(&self) -> &str;
 }
 ```
 
-### EntityType
+**Slug Validation Rules**:
+- 3-64 characters
+- Lowercase letters, numbers, hyphens only
+- Must start with a letter
+- No consecutive hyphens
+
+### EntityType (Implemented)
 
 The level in the cooperative hierarchy.
 
@@ -74,48 +102,23 @@ The level in the cooperative hierarchy.
 /// The type/level of a cooperative entity
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EntityType {
-    /// Individual person with SDIS anchor
-    Person,
+    /// Individual backed by a DID
+    Individual,
 
-    /// Working group within a cooperative
-    WorkingGroup,
-
-    /// A cooperative organization
+    /// Cooperative organization
     Cooperative,
 
     /// Federation of cooperatives
     Federation,
 
-    /// Meta-federation or global commons (e.g., ICN Protocol itself)
-    Commons,
-}
-
-impl EntityType {
-    /// Returns the parent type in the hierarchy
-    pub fn parent_type(&self) -> Option<EntityType> {
-        match self {
-            EntityType::Person => Some(EntityType::Cooperative),
-            EntityType::WorkingGroup => Some(EntityType::Cooperative),
-            EntityType::Cooperative => Some(EntityType::Federation),
-            EntityType::Federation => Some(EntityType::Commons),
-            EntityType::Commons => None,
-        }
-    }
-
-    /// Returns child types that can be members
-    pub fn allowed_member_types(&self) -> Vec<EntityType> {
-        match self {
-            EntityType::Person => vec![],
-            EntityType::WorkingGroup => vec![EntityType::Person],
-            EntityType::Cooperative => vec![EntityType::Person, EntityType::WorkingGroup],
-            EntityType::Federation => vec![EntityType::Cooperative],
-            EntityType::Commons => vec![EntityType::Federation],
-        }
-    }
+    /// Unknown type (parsing fallback)
+    Unknown,
 }
 ```
 
-### CooperativeEntity
+**Design Decision**: The implementation uses three core types (Individual, Cooperative, Federation) rather than the five originally proposed. WorkingGroup can be modeled as a Cooperative with a parent_id, and Commons can be modeled as a top-level Federation.
+
+### CooperativeEntity (Implemented)
 
 The core entity type representing any participant at any level.
 
@@ -132,155 +135,128 @@ pub struct CooperativeEntity {
     /// Type/level in the hierarchy
     pub entity_type: EntityType,
 
-    /// Cryptographic identity anchor
-    pub anchor: EntityAnchor,
+    /// Entity lifecycle state
+    pub status: EntityStatus,
 
     /// Parent entity (if any)
     pub parent_id: Option<EntityId>,
 
-    /// Entity lifecycle state
-    pub state: EntityState,
+    /// Link to governance domain (if governance enabled)
+    pub governance_domain_id: Option<String>,
 
-    /// Governance configuration
-    pub governance: GovernanceConfig,
+    /// Link to treasury account (if treasury enabled)
+    pub treasury_account: Option<AccountReference>,
 
-    /// Economic configuration
-    pub economics: EconomicConfig,
+    /// Creation timestamp (Unix seconds)
+    pub created_at: u64,
 
-    /// Trust configuration
-    pub trust: TrustConfig,
+    /// Last modification timestamp (Unix seconds)
+    pub updated_at: u64,
 
-    /// Creation timestamp
-    pub created_at: Timestamp,
+    /// Human-readable description
+    pub description: Option<String>,
 
-    /// Last modification timestamp
-    pub updated_at: Timestamp,
+    /// Arbitrary key-value metadata
+    pub metadata: HashMap<String, String>,
+}
 
-    /// Metadata (tags, descriptions, external links)
-    pub metadata: EntityMetadata,
+impl CooperativeEntity {
+    /// Create an individual entity from a DID
+    pub fn individual(did: &Did, name: &str) -> Self;
+
+    /// Create a cooperative entity (builder pattern)
+    pub fn cooperative(slug: &str, name: &str) -> Result<Self>;
+
+    /// Create a federation entity (builder pattern)
+    pub fn federation(slug: &str, name: &str) -> Result<Self>;
+
+    /// Builder methods
+    pub fn with_description(self, description: &str) -> Self;
+    pub fn with_governance_domain(self, domain_id: &str) -> Self;
+    pub fn with_metadata(self, key: &str, value: &str) -> Self;
 }
 ```
 
-### EntityAnchor
+**Design Decision**: Governance/Economic/Trust configurations are linked via IDs rather than embedded. This reduces coupling and allows the entity crate to remain lightweight.
 
-The cryptographic anchor for entity identity.
+### EntityAnchor (Deferred)
 
-```rust
-/// Cryptographic anchor for entity identity
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum EntityAnchor {
-    /// Individual anchor (SDIS personal identity)
-    Personal {
-        /// The person's DID
-        did: Did,
-        /// VUI commitment for uniqueness
-        vui_commitment: [u8; 32],
-        /// Creation ceremony proof
-        ceremony_proof: Option<CeremonyProof>,
-    },
+The cryptographic anchor for entity identity. **Not yet implemented** - deferred to full SDIS integration in Phase 22.
 
-    /// Cooperative anchor (threshold-derived from member signatures)
-    Cooperative {
-        /// Derived DID for the cooperative
-        did: Did,
-        /// Threshold (k of n) for signing
-        threshold: Threshold,
-        /// Current key holders (member DIDs with signing authority)
-        key_holders: Vec<Did>,
-        /// Creation ceremony proof
-        ceremony_proof: CeremonyProof,
-    },
+The original design proposed:
+- `Personal`: Individual anchor with VUI commitment and ceremony proof
+- `Cooperative`: Threshold-derived anchor from member signatures
+- `Federation`: Anchor derived from member cooperatives
+- `Genesis`: For the ICN Protocol Commons
 
-    /// Federation anchor (derived from member cooperatives)
-    Federation {
-        /// Derived DID for the federation
-        did: Did,
-        /// Member coops that contribute to anchor
-        anchor_members: Vec<EntityId>,
-        /// Threshold for federation-level signing
-        threshold: Threshold,
-    },
+**Current Implementation**: Individuals link to DIDs via `EntityId::from_did()`. Cooperatives and federations have no cryptographic anchor yet - they are identified by their EntityId slug. Multi-party signing will be added when threshold signatures are implemented.
 
-    /// Genesis anchor (for ICN Protocol Commons)
-    Genesis {
-        /// The genesis DID
-        did: Did,
-        /// Genesis block hash
-        genesis_hash: [u8; 32],
-    },
-}
-
-/// Threshold configuration for multi-party anchors
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Threshold {
-    /// Required signatures
-    pub k: u32,
-    /// Total signers
-    pub n: u32,
-}
-```
-
-### EntityState
+### EntityStatus (Implemented)
 
 The lifecycle state of an entity.
 
 ```rust
-/// Entity lifecycle state
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum EntityState {
-    /// Entity is being formed (not yet operational)
-    Forming {
-        /// Required steps to become active
-        pending_steps: Vec<FormationStep>,
-    },
+/// Entity lifecycle status
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum EntityStatus {
+    /// Entity is being formed (pre-charter ratification)
+    #[default]
+    Forming,
 
     /// Entity is active and operational
     Active,
 
-    /// Entity is suspended (governance action)
+    /// Entity is suspended (frozen)
     Suspended {
         reason: String,
-        suspended_at: Timestamp,
-        suspended_by: EntityId,
+        suspended_at: u64,
     },
 
-    /// Entity is being dissolved
+    /// Entity is in the process of dissolving
     Dissolving {
-        reason: String,
-        dissolution_started_at: Timestamp,
-        assets_transferred_to: Option<EntityId>,
+        started_at: u64,
     },
 
-    /// Entity is dissolved (historical record only)
+    /// Entity has been dissolved
     Dissolved {
-        dissolved_at: Timestamp,
-        final_state_hash: [u8; 32],
+        dissolved_at: u64,
+    },
+
+    /// Entity has merged into another entity
+    Merged {
+        into: EntityId,
+        merged_at: u64,
+    },
+
+    /// Entity has split into multiple entities
+    Split {
+        into: Vec<EntityId>,
+        split_at: u64,
     },
 }
 
-/// Steps required during entity formation
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum FormationStep {
-    /// Minimum number of founding members
-    MinimumMembers { required: u32, current: u32 },
+impl EntityStatus {
+    /// Check if entity is operational
+    pub fn is_operational(&self) -> bool;
 
-    /// Charter ratification
-    CharterRatification { ratified: bool },
-
-    /// Initial treasury funding
-    TreasuryFunding { minimum: i64, current: i64, currency: String },
-
-    /// Anchor ceremony completion
-    AnchorCeremony { completed: bool },
-
-    /// Parent entity approval (if applicable)
-    ParentApproval { approved: bool },
+    /// Check if entity lifecycle has ended
+    pub fn is_terminated(&self) -> bool;
 }
 ```
 
+**Valid State Transitions**:
+| From | To |
+|------|-----|
+| Forming | Active |
+| Active | Suspended, Dissolving, Merged, Split |
+| Suspended | Active, Dissolving |
+| Dissolving | Dissolved, Merged, Split |
+
+**Design Decision**: FormationStep tracking is deferred. The `Forming` state is simple for now; detailed formation requirements can be tracked externally or added later.
+
 ---
 
-## Membership Model
+## Membership Model (Implemented)
 
 ### Membership
 
@@ -290,440 +266,338 @@ Represents the relationship between an entity and its parent.
 /// Membership of an entity within another entity
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Membership {
-    /// The member entity
+    /// The member entity (individual OR cooperative)
     pub member_id: EntityId,
 
     /// The containing entity (parent)
     pub parent_id: EntityId,
 
-    /// Type of membership
-    pub membership_type: MembershipType,
+    /// Role within the parent entity
+    pub role: MembershipRole,
 
-    /// Roles assigned to this member
-    pub roles: Vec<Role>,
+    /// Current membership status
+    pub status: MembershipStatus,
 
-    /// Membership state
-    pub state: MembershipState,
+    /// When membership was created (Unix timestamp)
+    pub joined_at: u64,
 
-    /// When membership was established
-    pub joined_at: Timestamp,
+    /// When membership was last updated
+    pub updated_at: u64,
 
-    /// Sponsor who vouched for this member (if applicable)
-    pub sponsored_by: Option<EntityId>,
+    /// Voting shares (for weighted voting, 0 = no vote)
+    pub shares: u64,
 
-    /// Contribution credits (for credit limit calculations)
-    pub contribution_score: u64,
+    /// Capabilities granted by this membership
+    pub capabilities: Vec<MembershipCapability>,
+
+    /// Optional notes
+    pub notes: Option<String>,
 }
 
-/// Type of membership
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum MembershipType {
-    /// Full voting member
-    Full,
+impl Membership {
+    /// Create a new pending membership
+    pub fn new(member_id: EntityId, parent_id: EntityId, role: MembershipRole) -> Self;
 
-    /// Probationary member (limited voting, time-limited)
-    Probationary { expires_at: Timestamp },
+    /// Create an active membership (bypass pending state)
+    pub fn active(member_id: EntityId, parent_id: EntityId, role: MembershipRole) -> Self;
 
-    /// Associate member (no voting, economic participation only)
-    Associate,
+    /// Check if member can vote
+    pub fn can_vote(&self) -> bool;  // requires: active + shares > 0 + Vote capability
 
-    /// Observer (read-only access)
-    Observer,
-}
-
-/// Membership lifecycle state
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum MembershipState {
-    /// Application pending approval
-    Pending { application_id: String },
-
-    /// Active member
-    Active,
-
-    /// Suspended (can be reactivated)
-    Suspended { reason: String, until: Option<Timestamp> },
-
-    /// Voluntarily withdrawn
-    Withdrawn { at: Timestamp },
-
-    /// Expelled (cannot rejoin without appeal)
-    Expelled { at: Timestamp, reason: String },
-}
-
-/// Role within an entity
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Role {
-    pub name: String,
-    pub permissions: Vec<Permission>,
-    pub granted_at: Timestamp,
-    pub expires_at: Option<Timestamp>,
-}
-
-/// Permissions a role can grant
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum Permission {
-    /// Can vote on proposals
-    Vote,
-    /// Can create proposals
-    Propose,
-    /// Can approve new members
-    ApproveMembership,
-    /// Can sign on behalf of entity
-    Sign,
-    /// Can manage treasury
-    Treasury,
-    /// Can manage governance parameters
-    Governance,
-    /// Full administrative access
-    Admin,
+    /// Check if member can create proposals
+    pub fn can_propose(&self) -> bool;
 }
 ```
 
----
-
-## Governance Configuration
+### MembershipRole
 
 ```rust
-/// Governance configuration for an entity
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct GovernanceConfig {
-    /// Governance domain ID (links to icn-governance)
-    pub domain_id: GovernanceDomainId,
+pub enum MembershipRole {
+    // Individual Roles (for people)
+    Founder,             // All capabilities
+    Member,              // Vote, Propose
+    Worker,              // Vote, Propose
+    Consumer,            // Vote, Propose
+    Producer,            // Vote, Propose
+    BoardMember,         // Vote, Propose, Treasury, Invite
+    Officer { title: String },  // Vote, Propose, Treasury
 
-    /// Voting mechanism
-    pub voting: VotingConfig,
+    // Entity Roles (for organizations)
+    FederatedMember,     // Vote, Propose, Sign
+    AssociateMember,     // Propose
+    ObserverMember,      // None
+    ProvisionalMember,   // Propose
 
-    /// Quorum requirements
-    pub quorum: QuorumConfig,
-
-    /// Proposal types allowed at this level
-    pub allowed_proposal_types: Vec<ProposalType>,
-
-    /// Constraints from parent entity
-    pub parent_constraints: Vec<Constraint>,
-}
-
-/// Voting configuration
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct VotingConfig {
-    /// How votes are weighted
-    pub weight_model: VoteWeightModel,
-
-    /// Delegation allowed?
-    pub delegation_enabled: bool,
-
-    /// Maximum delegation depth
-    pub max_delegation_depth: u32,
-}
-
-/// Vote weighting models
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum VoteWeightModel {
-    /// One member, one vote
-    EqualWeight,
-
-    /// Weighted by contribution score
-    ContributionWeighted { cap: Option<f64> },
-
-    /// Quadratic voting
-    Quadratic { credits_per_period: u64 },
-
-    /// Conviction voting (time-weighted)
-    Conviction { decay_rate: f64 },
-}
-
-/// Quorum requirements
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct QuorumConfig {
-    /// Minimum participation rate (0.0 - 1.0)
-    pub participation_threshold: f64,
-
-    /// Approval threshold for passing (0.0 - 1.0)
-    pub approval_threshold: f64,
-
-    /// Different thresholds per proposal type
-    pub type_overrides: HashMap<ProposalType, (f64, f64)>,
+    // Custom
+    Custom { name: String },  // Vote, Propose
 }
 ```
 
----
-
-## Economic Configuration
+### MembershipStatus
 
 ```rust
-/// Economic configuration for an entity
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct EconomicConfig {
-    /// Entity's treasury (if applicable)
-    pub treasury: Option<TreasuryConfig>,
-
-    /// Credit policy for members
-    pub credit_policy: CreditPolicyConfig,
-
-    /// Currencies supported
-    pub currencies: Vec<CurrencyConfig>,
-
-    /// Inter-entity agreements
-    pub agreements: Vec<InterEntityAgreement>,
-}
-
-/// Treasury configuration
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct TreasuryConfig {
-    /// Treasury DID (for ledger accounts)
-    pub treasury_did: Did,
-
-    /// Spending approval thresholds
-    pub spending_thresholds: Vec<SpendingThreshold>,
-
-    /// Budget allocation method
-    pub budget_method: BudgetMethod,
-}
-
-/// Credit policy for entity members
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CreditPolicyConfig {
-    /// Base credit limit for new members
-    pub base_limit: i64,
-
-    /// Trust-based bonus multiplier (0.0 - 1.0 trust score)
-    pub trust_multiplier: f64,
-
-    /// Contribution-based bonus
-    pub contribution_bonus_rate: f64,
-
-    /// Ramp period for new members (seconds)
-    pub ramp_period_seconds: u64,
-
-    /// Anti-extraction ratio (max debit/credit ratio)
-    pub max_debit_credit_ratio: f64,
-}
-
-/// Agreement between entities
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct InterEntityAgreement {
-    /// Agreement ID
-    pub id: String,
-
-    /// Parties to the agreement
-    pub parties: Vec<EntityId>,
-
-    /// Agreement type
-    pub agreement_type: AgreementType,
-
-    /// Terms
-    pub terms: AgreementTerms,
-
-    /// State
-    pub state: AgreementState,
-}
-
-/// Types of inter-entity agreements
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum AgreementType {
-    /// Mutual credit line between entities
-    CreditLine,
-
-    /// Clearing/settlement agreement
-    Clearing,
-
-    /// Group purchasing participation
-    GroupPurchasing,
-
-    /// Federation membership
-    FederationMembership,
-
-    /// Service provision
-    ServiceAgreement,
+pub enum MembershipStatus {
+    Pending,    // Application pending
+    Active,     // In good standing
+    Suspended,  // Temporarily frozen
+    Inactive,   // Not participating
+    Resigned,   // Voluntarily left
+    Removed,    // Governance removal
+    Expelled,   // Serious violation
 }
 ```
 
----
-
-## Trust Configuration
+### MembershipCapability
 
 ```rust
-/// Trust configuration for an entity
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct TrustConfig {
-    /// Trust policies for different relationship types
-    pub policies: Vec<TrustPolicy>,
-
-    /// Minimum trust for various operations
-    pub thresholds: TrustThresholds,
-
-    /// Trust decay settings
-    pub decay: TrustDecay,
-}
-
-/// Trust thresholds for operations
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct TrustThresholds {
-    /// Minimum trust to join (sponsor trust)
-    pub join: f64,
-
-    /// Minimum trust to transact
-    pub transact: f64,
-
-    /// Minimum trust to vote
-    pub vote: f64,
-
-    /// Minimum trust to propose
-    pub propose: f64,
-
-    /// Minimum trust to sign on behalf of entity
-    pub sign: f64,
+pub enum MembershipCapability {
+    Vote,               // Can vote on proposals
+    Propose,            // Can create proposals
+    TreasuryAccess,     // Can perform treasury operations
+    Invite,             // Can invite new members
+    ManageSubEntities,  // Can manage child entities
+    Sign,               // Can sign on behalf of entity
+    Configure,          // Can modify entity settings
+    ViewSensitive,      // Can view confidential info
+    Custom(String),     // User-defined capability
 }
 ```
 
+**Key Insight**: Capabilities are explicit, not derived from roles. Each role has default capabilities, but they can be overridden with `membership.with_capabilities()`.
+
 ---
 
-## Entity Registry
+## Configuration (Linked, Not Embedded)
+
+The original spec proposed embedding GovernanceConfig, EconomicConfig, and TrustConfig directly in CooperativeEntity. The implementation uses **linked references** instead:
+
+```rust
+pub struct CooperativeEntity {
+    // ...
+    pub governance_domain_id: Option<String>,  // Links to icn-governance
+    pub treasury_account: Option<AccountReference>,  // Links to icn-ledger
+    // Trust is implicit via the entity's DIDs in the trust graph
+}
+```
+
+**Benefits**:
+- Reduced coupling between crates
+- Configuration lives in its natural home (governance in icn-governance, treasury in icn-ledger)
+- Entity crate stays lightweight
+- Easier to evolve configurations independently
+
+**Deferred to Phase 19+ Integration**:
+- GovernanceConfig (voting models, quorum, constraints)
+- EconomicConfig (credit policy, inter-entity agreements)
+- TrustConfig (entity-level trust thresholds)
+
+See the original spec sections below for the envisioned designs.
+
+---
+
+## Entity Registry (Implemented)
 
 The entity registry maintains the global state of all entities.
 
 ```rust
 /// Entity registry for storing and querying entities
 pub trait EntityRegistry: Send + Sync {
-    /// Create a new entity
-    async fn create(&self, entity: CooperativeEntity) -> Result<EntityId>;
+    // Entity CRUD
+    fn register(&mut self, entity: CooperativeEntity) -> Result<()>;
+    fn get(&self, id: &EntityId) -> Result<Option<CooperativeEntity>>;
+    fn update(&mut self, entity: CooperativeEntity) -> Result<()>;
+    fn delete(&mut self, id: &EntityId) -> Result<()>;
 
-    /// Get entity by ID
-    async fn get(&self, id: &EntityId) -> Result<Option<CooperativeEntity>>;
+    // Queries
+    fn list_by_type(&self, entity_type: EntityType) -> Result<Vec<EntityId>>;
+    fn list_children(&self, parent_id: &EntityId) -> Result<Vec<EntityId>>;
 
-    /// Update an entity
-    async fn update(&self, entity: CooperativeEntity) -> Result<()>;
-
-    /// List members of an entity
-    async fn list_members(&self, parent_id: &EntityId) -> Result<Vec<Membership>>;
-
-    /// Get membership of an entity within a parent
-    async fn get_membership(&self, member_id: &EntityId, parent_id: &EntityId)
+    // Membership operations
+    fn add_membership(&mut self, membership: Membership) -> Result<()>;
+    fn remove_membership(&mut self, member_id: &EntityId, parent_id: &EntityId) -> Result<()>;
+    fn get_membership(&self, member_id: &EntityId, parent_id: &EntityId)
         -> Result<Option<Membership>>;
-
-    /// Add a member to an entity
-    async fn add_member(&self, membership: Membership) -> Result<()>;
-
-    /// Update membership
-    async fn update_membership(&self, membership: Membership) -> Result<()>;
-
-    /// List all entities at a given level
-    async fn list_by_type(&self, entity_type: EntityType) -> Result<Vec<CooperativeEntity>>;
-
-    /// Get the entity hierarchy (ancestors)
-    async fn get_ancestors(&self, id: &EntityId) -> Result<Vec<CooperativeEntity>>;
-
-    /// Get all descendants of an entity
-    async fn get_descendants(&self, id: &EntityId) -> Result<Vec<CooperativeEntity>>;
+    fn get_members(&self, parent_id: &EntityId) -> Result<Vec<Membership>>;
+    fn get_memberships(&self, member_id: &EntityId) -> Result<Vec<Membership>>;
 }
 ```
+
+### EntityRegistryHandle
+
+Thread-safe async wrapper for concurrent access:
+
+```rust
+pub struct EntityRegistryHandle {
+    inner: Arc<RwLock<InMemoryRegistry>>,
+}
+
+impl EntityRegistryHandle {
+    pub fn new() -> Self;
+
+    // Async versions of all trait methods
+    pub async fn register(&self, entity: CooperativeEntity) -> Result<()>;
+    pub async fn get(&self, id: &EntityId) -> Result<Option<CooperativeEntity>>;
+    // ... etc
+}
+```
+
+### InMemoryRegistry
+
+Reference implementation for testing and development:
+
+```rust
+pub struct InMemoryRegistry {
+    entities: HashMap<String, CooperativeEntity>,
+    memberships: Vec<Membership>,
+}
+```
+
+**Constraints Enforced**:
+- Duplicate entity IDs rejected
+- Cannot update non-existent entities
+- Cannot delete entities with active memberships
+- Both member and parent must exist to add membership
 
 ---
 
-## Entity Lifecycle Operations
+## Entity Lifecycle (Implemented)
 
-### Formation
+### LifecycleEvent
+
+Events that mark entity state transitions:
 
 ```rust
-/// Entity formation ceremony
-pub struct FormationCeremony {
-    /// The entity being formed
-    pub entity: CooperativeEntity,
-
-    /// Founding members
-    pub founders: Vec<(EntityId, Role)>,
-
-    /// Initial charter (ratified by founders)
-    pub charter: Charter,
-
-    /// Cryptographic proofs from the ceremony
-    pub ceremony_proofs: Vec<CeremonyProof>,
-}
-
-/// Charter defining entity rules
-pub struct Charter {
-    /// Mission statement
-    pub mission: String,
-
-    /// Governance rules
-    pub governance_rules: Vec<CharterRule>,
-
-    /// Economic rules
-    pub economic_rules: Vec<CharterRule>,
-
-    /// Amendment process
-    pub amendment_threshold: f64,
-
-    /// Hash of the charter content
-    pub content_hash: [u8; 32],
-
-    /// Signatures from ratifying members
-    pub ratifications: Vec<(EntityId, Signature)>,
+pub enum LifecycleEvent {
+    Created {
+        entity_id: EntityId,
+        created_by: EntityId,
+        timestamp: u64,
+    },
+    Activated {
+        entity_id: EntityId,
+        charter_hash: String,
+        activated_by: EntityId,
+        timestamp: u64,
+    },
+    Suspended {
+        entity_id: EntityId,
+        reason: String,
+        suspended_by: EntityId,
+        timestamp: u64,
+    },
+    Reactivated {
+        entity_id: EntityId,
+        reactivated_by: EntityId,
+        timestamp: u64,
+    },
+    DissolutionStarted {
+        entity_id: EntityId,
+        started_by: EntityId,
+        timestamp: u64,
+    },
+    Dissolved {
+        entity_id: EntityId,
+        timestamp: u64,
+    },
+    Merged {
+        source_id: EntityId,
+        target_id: EntityId,
+        merged_by: EntityId,
+        timestamp: u64,
+    },
+    Split {
+        source_id: EntityId,
+        new_entity_ids: Vec<EntityId>,
+        split_by: EntityId,
+        timestamp: u64,
+    },
 }
 ```
 
-### Dissolution
+### EntityLifecycle Trait
 
 ```rust
-/// Entity dissolution process
-pub struct DissolutionProcess {
-    /// Entity being dissolved
-    pub entity_id: EntityId,
+pub trait EntityLifecycle {
+    fn create(&mut self, entity: CooperativeEntity, created_by: &EntityId)
+        -> Result<LifecycleEvent>;
 
-    /// Reason for dissolution
-    pub reason: String,
+    fn activate(&mut self, entity_id: &EntityId, charter_hash: String, by: &EntityId)
+        -> Result<LifecycleEvent>;
 
-    /// How assets will be distributed
-    pub asset_distribution: AssetDistribution,
+    fn suspend(&mut self, entity_id: &EntityId, reason: String, by: &EntityId)
+        -> Result<LifecycleEvent>;
 
-    /// Required approvals
-    pub required_approvals: Vec<EntityId>,
+    fn reactivate(&mut self, entity_id: &EntityId, by: &EntityId)
+        -> Result<LifecycleEvent>;
 
-    /// Current approval status
-    pub approvals: Vec<(EntityId, Timestamp, Signature)>,
+    fn begin_dissolution(&mut self, entity_id: &EntityId, by: &EntityId)
+        -> Result<LifecycleEvent>;
 
-    /// Cooling-off period end
-    pub cooling_off_ends_at: Timestamp,
-}
+    fn dissolve(&mut self, entity_id: &EntityId)
+        -> Result<LifecycleEvent>;
 
-/// How to distribute assets on dissolution
-pub enum AssetDistribution {
-    /// Transfer all to parent entity
-    ToParent,
+    fn merge(&mut self, source_id: &EntityId, target_id: &EntityId, by: &EntityId)
+        -> Result<LifecycleEvent>;
 
-    /// Distribute proportionally to members
-    ToMembers { by_contribution: bool },
-
-    /// Transfer to specific entity
-    ToEntity(EntityId),
-
-    /// Contribute to commons
-    ToCommons,
+    fn split(&mut self, source_id: &EntityId, new_entities: Vec<CooperativeEntity>, by: &EntityId)
+        -> Result<Vec<LifecycleEvent>>;
 }
 ```
+
+### State Transition Validation
+
+```rust
+pub fn validate_transition(from: &EntityStatus, to: &EntityStatus) -> Result<()>;
+```
+
+**Note**: FormationCeremony, Charter, and DissolutionProcess are deferred to full Phase 19 integration. The current implementation provides the event types and trait interface.
 
 ---
 
 ## Migration Strategy
 
-### Phase 1: Type Introduction
-1. Create `icn-entity` crate with core types
-2. No breaking changes - new types exist alongside old
+### AccountId - The Bridge Type
 
-### Phase 2: Subsystem Integration
-1. Update `icn-governance` to accept EntityId where it currently uses Did
-2. Update `icn-ledger` to support EntityId accounts
-3. Update `icn-trust` to support entity-to-entity trust
+The `AccountId` enum provides backward compatibility:
 
-### Phase 3: Migration Tools
-1. Create `Did` → `EntityId` mapping
-2. Build migration scripts for existing data
+```rust
+pub enum AccountId {
+    Did(Did),           // Legacy DID-based accounts
+    Entity(EntityId),   // New entity-based accounts
+}
+
+impl AccountId {
+    pub fn as_did(&self) -> Option<&Did>;
+    pub fn as_entity(&self) -> Option<&EntityId>;
+}
+```
+
+This allows gradual migration - existing code uses `AccountId::Did`, new code can use `AccountId::Entity`.
+
+### Phase 1: Type Introduction (Current - Sprint 3)
+1. ✅ Create `icn-entity` crate with core types
+2. ✅ Implement EntityId, CooperativeEntity, Membership
+3. ✅ Implement EntityRegistry trait
+4. ✅ Implement LifecycleEvent and EntityLifecycle trait
+5. No breaking changes - new types exist alongside old
+
+### Phase 2: Subsystem Integration (Phase 19)
+1. Add `AccountId` to ledger types (replace `account_id: Did`)
+2. Add `entity_id` field to governance domains
+3. Update treasury to use `EntityId` for cooperative accounts
+4. Add entity registry actor to runtime
+
+### Phase 3: Full Integration (Phase 19+)
+1. Update icn-governance to accept EntityId
+2. Update icn-ledger to support entity-level accounts
+3. Update icn-trust to support entity-to-entity edges
+4. Add gateway entity endpoints
+
+### Phase 4: Migration & Cleanup (Future)
+1. Create `Did` → `EntityId` mapping for existing data
+2. Build migration scripts
 3. Dual-write during transition period
-
-### Phase 4: Deprecation
-1. Mark old APIs as deprecated
-2. Update gateway to use new types
-3. Remove deprecated types after migration complete
+4. Deprecate DID-only APIs
 
 ---
 
@@ -747,32 +621,65 @@ pub enum AssetDistribution {
 ## Open Questions
 
 1. **Anchor Rotation**: How do cooperative anchors rotate when membership changes?
+   - *Deferred to Phase 22 SDIS integration*
+
 2. **Cross-Federation Trust**: How does trust propagate across federation boundaries?
+   - *Will require entity-level edges in trust graph*
+
 3. **Conflict Resolution**: When parent and child entity rules conflict, which wins?
+   - *Proposed: Subsidiarity principle - local unless explicitly delegated up*
+
 4. **Privacy**: Which entity information should be public vs. member-only?
+   - *Current: All public. Future: Add visibility field*
+
+5. **Multi-Federation Membership**: Can a cooperative belong to multiple federations?
+   - *Current implementation: Yes. Question: Scope capabilities per-federation?*
+
+6. **Entity Recovery**: What happens if an entity loses all authorized members?
+   - *Not yet addressed*
 
 ---
 
-## Next Steps
+## Next Steps (Updated)
 
-1. [ ] Review spec with stakeholders
-2. [ ] Create `icn-entity` crate with core types
-3. [ ] Implement EntityRegistry trait
-4. [ ] Write migration plan for existing data
-5. [ ] Update gateway API spec for entity endpoints
+1. ✅ Review spec with stakeholders
+2. ✅ Create `icn-entity` crate with core types
+3. ✅ Implement EntityRegistry trait
+4. ✅ Implement LifecycleEvent and EntityLifecycle trait
+5. [ ] **Phase 19**: Integrate with icn-ledger (AccountId)
+6. [ ] **Phase 19**: Integrate with icn-governance (entity domains)
+7. [ ] **Phase 19**: Add entity actor to runtime
+8. [ ] **Phase 19**: Add gateway entity endpoints
+9. [ ] Write migration plan for existing data
 
 ---
 
-## Appendix: Type Summary
+## Appendix: Implemented Type Summary
 
-| Type | Purpose | Key Fields |
-|------|---------|------------|
-| `EntityId` | Unique identifier | Type, namespace, local_id |
-| `EntityType` | Hierarchy level | Person, Coop, Federation, Commons |
-| `CooperativeEntity` | Core entity | anchor, governance, economics, trust |
-| `EntityAnchor` | Cryptographic root | DID, threshold, ceremony proof |
-| `EntityState` | Lifecycle | Forming, Active, Suspended, Dissolved |
-| `Membership` | Parent-child relation | member_id, parent_id, roles, state |
-| `GovernanceConfig` | Voting rules | domain, quorum, constraints |
-| `EconomicConfig` | Financial rules | treasury, credit policy, agreements |
-| `TrustConfig` | Trust rules | thresholds, decay, policies |
+| Type | Purpose | File |
+|------|---------|------|
+| `EntityId` | Unique identifier (`entity:icn:<type>:<id>`) | `entity.rs` |
+| `EntityType` | Individual, Cooperative, Federation | `entity.rs` |
+| `CooperativeEntity` | Core entity record | `entity.rs` |
+| `EntityStatus` | Lifecycle state (Forming → Active → ...) | `entity.rs` |
+| `AccountId` | DID or EntityId (migration bridge) | `entity.rs` |
+| `AccountReference` | Link to ledger account | `entity.rs` |
+| `Membership` | Entity-to-parent relationship | `membership.rs` |
+| `MembershipRole` | Founder, Worker, FederatedMember, etc. | `membership.rs` |
+| `MembershipStatus` | Pending, Active, Suspended, etc. | `membership.rs` |
+| `MembershipCapability` | Vote, Propose, Treasury, etc. | `membership.rs` |
+| `EntityRegistry` | Storage trait | `registry.rs` |
+| `InMemoryRegistry` | Reference implementation | `registry.rs` |
+| `EntityRegistryHandle` | Async wrapper | `registry.rs` |
+| `LifecycleEvent` | State transition events | `lifecycle.rs` |
+| `EntityLifecycle` | Lifecycle operations trait | `lifecycle.rs` |
+| `EntityError` | Error type | `error.rs` |
+
+---
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| 2025-12-24 | Initial implementation complete (Sprint 3) |
+| 2025-12-24 | Updated spec to reflect actual implementation |

--- a/docs/dev-journal/COOPERATIVE_ENTITY_SPEC.md
+++ b/docs/dev-journal/COOPERATIVE_ENTITY_SPEC.md
@@ -485,9 +485,9 @@ pub enum LifecycleEvent {
         suspended_by: EntityId,
         timestamp: u64,
     },
-    Reactivated {
+    Resumed {
         entity_id: EntityId,
-        reactivated_by: EntityId,
+        resumed_by: EntityId,
         timestamp: u64,
     },
     DissolutionStarted {
@@ -502,13 +502,13 @@ pub enum LifecycleEvent {
     Merged {
         source_id: EntityId,
         target_id: EntityId,
-        merged_by: EntityId,
+        merger_proposal_id: Option<String>,
         timestamp: u64,
     },
     Split {
         source_id: EntityId,
         new_entity_ids: Vec<EntityId>,
-        split_by: EntityId,
+        split_proposal_id: Option<String>,
         timestamp: u64,
     },
 }
@@ -527,7 +527,7 @@ pub trait EntityLifecycle {
     fn suspend(&mut self, entity_id: &EntityId, reason: String, by: &EntityId)
         -> Result<LifecycleEvent>;
 
-    fn reactivate(&mut self, entity_id: &EntityId, by: &EntityId)
+    fn resume(&mut self, entity_id: &EntityId, by: &EntityId)
         -> Result<LifecycleEvent>;
 
     fn begin_dissolution(&mut self, entity_id: &EntityId, by: &EntityId)

--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -2910,6 +2910,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "icn-entity"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "icn-identity",
+ "icn-time",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "icn-federation"
 version = "0.1.0"
 dependencies = [

--- a/icn/Cargo.toml
+++ b/icn/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "crates/icn-crypto-pq",
     "crates/icn-steward",
     "crates/icn-zkp", "crates/icn-cooperative", "crates/icn-community", "crates/icn-coop",
+    "crates/icn-entity",
 ]
 
 [workspace.package]

--- a/icn/crates/icn-entity/Cargo.toml
+++ b/icn/crates/icn-entity/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "icn-entity"
+version.workspace = true
+edition.workspace = true
+description = "Unified cooperative entity model for ICN"
+license.workspace = true
+repository.workspace = true
+
+[features]
+default = []
+
+[dependencies]
+icn-identity = { path = "../icn-identity" }
+icn-time = { path = "../icn-time" }
+serde.workspace = true
+serde_json = "1.0"
+anyhow.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+tokio.workspace = true
+
+[dev-dependencies]
+
+[lints]
+workspace = true

--- a/icn/crates/icn-entity/src/entity.rs
+++ b/icn/crates/icn-entity/src/entity.rs
@@ -68,24 +68,55 @@ impl EntityId {
     }
 
     /// Validate a slug for use in EntityId
+    ///
+    /// Rules:
+    /// - 3-64 characters
+    /// - Lowercase letters, numbers, hyphens only
+    /// - Must start with a letter
+    /// - No consecutive hyphens
     fn validate_slug(slug: &str) -> Result<()> {
-        if slug.is_empty() {
-            return Err(EntityError::InvalidFormat("Slug cannot be empty".into()));
-        }
-        if slug.len() > 128 {
+        if slug.len() < 3 {
             return Err(EntityError::InvalidFormat(
-                "Slug cannot exceed 128 characters".into(),
+                "Slug must be at least 3 characters".into(),
             ));
         }
-        // Allow alphanumeric, hyphens, and underscores
-        if !slug
-            .chars()
-            .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
-        {
+        if slug.len() > 64 {
             return Err(EntityError::InvalidFormat(
-                "Slug can only contain alphanumeric characters, hyphens, and underscores".into(),
+                "Slug cannot exceed 64 characters".into(),
             ));
         }
+
+        let mut chars = slug.chars().peekable();
+
+        // Must start with a lowercase letter
+        match chars.next() {
+            Some(c) if c.is_ascii_lowercase() => {}
+            _ => {
+                return Err(EntityError::InvalidFormat(
+                    "Slug must start with a lowercase letter".into(),
+                ));
+            }
+        }
+
+        // Check remaining characters
+        let mut prev_hyphen = false;
+        for c in chars {
+            if c == '-' {
+                if prev_hyphen {
+                    return Err(EntityError::InvalidFormat(
+                        "Slug cannot contain consecutive hyphens".into(),
+                    ));
+                }
+                prev_hyphen = true;
+            } else if c.is_ascii_lowercase() || c.is_ascii_digit() {
+                prev_hyphen = false;
+            } else {
+                return Err(EntityError::InvalidFormat(
+                    "Slug can only contain lowercase letters, numbers, and hyphens".into(),
+                ));
+            }
+        }
+
         Ok(())
     }
 
@@ -288,6 +319,22 @@ impl EntityStatus {
     }
 }
 
+impl std::fmt::Display for EntityStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EntityStatus::Forming => write!(f, "Forming"),
+            EntityStatus::Active => write!(f, "Active"),
+            EntityStatus::Suspended { reason, .. } => write!(f, "Suspended: {reason}"),
+            EntityStatus::Dissolving { .. } => write!(f, "Dissolving"),
+            EntityStatus::Dissolved { .. } => write!(f, "Dissolved"),
+            EntityStatus::Merged { into, .. } => write!(f, "Merged into {}", into.identifier()),
+            EntityStatus::Split { into, .. } => {
+                write!(f, "Split into {} entities", into.len())
+            }
+        }
+    }
+}
+
 // ============================================================================
 // AccountReference
 // ============================================================================
@@ -421,31 +468,44 @@ impl CooperativeEntity {
         })
     }
 
+    // ========================================================================
+    // Builder methods
+    //
+    // Note: Builder methods are for initial construction and do NOT update
+    // the `updated_at` timestamp. When modifying an existing entity, use
+    // `EntityRegistry::update()` which should update the timestamp.
+    // ========================================================================
+
     /// Set the parent entity
+    #[must_use]
     pub fn with_parent(mut self, parent_id: EntityId) -> Self {
         self.parent_id = Some(parent_id);
         self
     }
 
     /// Set the governance domain
+    #[must_use]
     pub fn with_governance_domain(mut self, domain_id: impl Into<String>) -> Self {
         self.governance_domain_id = Some(domain_id.into());
         self
     }
 
     /// Set the treasury account
+    #[must_use]
     pub fn with_treasury(mut self, account: AccountReference) -> Self {
         self.treasury_account = Some(account);
         self
     }
 
     /// Set the description
+    #[must_use]
     pub fn with_description(mut self, description: impl Into<String>) -> Self {
         self.description = Some(description.into());
         self
     }
 
     /// Add metadata
+    #[must_use]
     pub fn with_metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.metadata.insert(key.into(), value.into());
         self
@@ -591,12 +651,29 @@ mod tests {
 
     #[test]
     fn test_entity_id_slug_validation() {
-        // Valid slugs
+        // Valid slugs (lowercase, 3-64 chars, start with letter)
         assert!(EntityId::cooperative("valid-slug").is_ok());
-        assert!(EntityId::cooperative("valid_slug").is_ok());
-        assert!(EntityId::cooperative("ValidSlug123").is_ok());
+        assert!(EntityId::cooperative("abc").is_ok());
+        assert!(EntityId::cooperative("test123").is_ok());
+        assert!(EntityId::cooperative("food-coop-2024").is_ok());
 
-        // Invalid slugs
+        // Invalid: too short
+        assert!(EntityId::cooperative("ab").is_err());
+
+        // Invalid: doesn't start with letter
+        assert!(EntityId::cooperative("123-coop").is_err());
+        assert!(EntityId::cooperative("-test").is_err());
+
+        // Invalid: uppercase
+        assert!(EntityId::cooperative("ValidSlug").is_err());
+
+        // Invalid: underscores not allowed
+        assert!(EntityId::cooperative("valid_slug").is_err());
+
+        // Invalid: consecutive hyphens
+        assert!(EntityId::cooperative("test--coop").is_err());
+
+        // Invalid: empty or spaces
         assert!(EntityId::cooperative("").is_err());
         assert!(EntityId::cooperative("invalid slug").is_err());
         assert!(EntityId::cooperative("invalid/slug").is_err());

--- a/icn/crates/icn-entity/src/entity.rs
+++ b/icn/crates/icn-entity/src/entity.rs
@@ -1,0 +1,648 @@
+//! Core entity types for the ICN unified cooperative model
+//!
+//! This module defines the foundational types for representing entities at all scales:
+//! - Individuals (backed by DIDs)
+//! - Cooperatives (worker, consumer, multi-stakeholder)
+//! - Federations (cooperatives of cooperatives)
+//!
+//! The key insight is that membership is recursive: a cooperative's members
+//! can themselves be cooperatives.
+
+use crate::error::{EntityError, Result};
+use icn_identity::Did;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fmt;
+use std::str::FromStr;
+
+// ============================================================================
+// EntityId
+// ============================================================================
+
+/// Unique identifier for any entity (individual, cooperative, or federation)
+///
+/// EntityId is designed to be compatible with DIDs:
+/// - For individuals: wraps their DID directly
+/// - For cooperatives: derived from cooperative creation ceremony
+/// - For federations: derived from federation charter
+///
+/// # Format
+///
+/// `entity:icn:<type>:<identifier>`
+///
+/// # Examples
+///
+/// - `entity:icn:individual:z5TrA8...` (wraps DID)
+/// - `entity:icn:cooperative:food-coop-2024`
+/// - `entity:icn:federation:midwest-fed`
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct EntityId(String);
+
+impl EntityId {
+    /// Create an EntityId from an individual's DID
+    ///
+    /// This wraps the DID in the entity format, allowing individuals
+    /// to participate in the entity system while maintaining their
+    /// cryptographic identity.
+    pub fn from_did(did: &Did) -> Self {
+        let did_str = did.as_str();
+        let identifier = did_str.strip_prefix("did:icn:").unwrap_or(did_str);
+        EntityId(format!("entity:icn:individual:{identifier}"))
+    }
+
+    /// Create an EntityId for a cooperative
+    ///
+    /// The slug should be a URL-safe identifier for the cooperative.
+    /// It will be validated for allowed characters.
+    pub fn cooperative(slug: &str) -> Result<Self> {
+        Self::validate_slug(slug)?;
+        Ok(EntityId(format!("entity:icn:cooperative:{slug}")))
+    }
+
+    /// Create an EntityId for a federation
+    ///
+    /// The slug should be a URL-safe identifier for the federation.
+    pub fn federation(slug: &str) -> Result<Self> {
+        Self::validate_slug(slug)?;
+        Ok(EntityId(format!("entity:icn:federation:{slug}")))
+    }
+
+    /// Validate a slug for use in EntityId
+    fn validate_slug(slug: &str) -> Result<()> {
+        if slug.is_empty() {
+            return Err(EntityError::InvalidFormat("Slug cannot be empty".into()));
+        }
+        if slug.len() > 128 {
+            return Err(EntityError::InvalidFormat(
+                "Slug cannot exceed 128 characters".into(),
+            ));
+        }
+        // Allow alphanumeric, hyphens, and underscores
+        if !slug
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+        {
+            return Err(EntityError::InvalidFormat(
+                "Slug can only contain alphanumeric characters, hyphens, and underscores".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Get the entity type from this ID
+    pub fn entity_type(&self) -> EntityType {
+        if self.0.contains(":individual:") {
+            EntityType::Individual
+        } else if self.0.contains(":cooperative:") {
+            EntityType::Cooperative
+        } else if self.0.contains(":federation:") {
+            EntityType::Federation
+        } else {
+            EntityType::Unknown
+        }
+    }
+
+    /// Try to extract the underlying DID (only works for individuals)
+    ///
+    /// Returns `Some(Did)` if this entity represents an individual,
+    /// `None` for cooperatives and federations.
+    pub fn to_did(&self) -> Option<Did> {
+        if self.entity_type() == EntityType::Individual {
+            let identifier = self.0.strip_prefix("entity:icn:individual:")?;
+            Did::from_str(&format!("did:icn:{identifier}")).ok()
+        } else {
+            None
+        }
+    }
+
+    /// Get the raw identifier portion (after the type prefix)
+    pub fn identifier(&self) -> &str {
+        self.0.split(':').next_back().unwrap_or(&self.0)
+    }
+
+    /// Get the full entity ID string
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Check if this entity represents an individual
+    pub fn is_individual(&self) -> bool {
+        self.entity_type() == EntityType::Individual
+    }
+
+    /// Check if this entity represents a cooperative
+    pub fn is_cooperative(&self) -> bool {
+        self.entity_type() == EntityType::Cooperative
+    }
+
+    /// Check if this entity represents a federation
+    pub fn is_federation(&self) -> bool {
+        self.entity_type() == EntityType::Federation
+    }
+
+    /// Check if this entity represents an organization (cooperative or federation)
+    pub fn is_organization(&self) -> bool {
+        matches!(
+            self.entity_type(),
+            EntityType::Cooperative | EntityType::Federation
+        )
+    }
+}
+
+impl FromStr for EntityId {
+    type Err = EntityError;
+
+    fn from_str(s: &str) -> Result<Self> {
+        if !s.starts_with("entity:icn:") {
+            return Err(EntityError::InvalidFormat(
+                "EntityId must start with 'entity:icn:'".into(),
+            ));
+        }
+
+        let parts: Vec<&str> = s.split(':').collect();
+        if parts.len() != 4 {
+            return Err(EntityError::InvalidFormat(
+                "EntityId must have format 'entity:icn:<type>:<identifier>'".into(),
+            ));
+        }
+
+        let type_part = parts[2];
+        if !["individual", "cooperative", "federation"].contains(&type_part) {
+            return Err(EntityError::InvalidFormat(format!(
+                "Unknown entity type: {type_part}"
+            )));
+        }
+
+        Ok(EntityId(s.to_string()))
+    }
+}
+
+impl fmt::Display for EntityId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+// ============================================================================
+// EntityType
+// ============================================================================
+
+/// Entity types supported by ICN
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EntityType {
+    /// An individual person (backed by DID/SDIS anchor)
+    Individual,
+
+    /// A cooperative (worker, consumer, producer, multi-stakeholder, etc.)
+    Cooperative,
+
+    /// A federation of cooperatives
+    Federation,
+
+    /// Unknown/unrecognized type
+    Unknown,
+}
+
+impl fmt::Display for EntityType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            EntityType::Individual => write!(f, "individual"),
+            EntityType::Cooperative => write!(f, "cooperative"),
+            EntityType::Federation => write!(f, "federation"),
+            EntityType::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
+// ============================================================================
+// EntityStatus
+// ============================================================================
+
+/// Entity lifecycle status
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EntityStatus {
+    /// Entity is being formed (pre-charter ratification)
+    #[default]
+    Forming,
+
+    /// Entity is active and operational
+    Active,
+
+    /// Entity is suspended (frozen)
+    Suspended {
+        /// Reason for suspension
+        reason: String,
+        /// When suspended (Unix timestamp)
+        suspended_at: u64,
+    },
+
+    /// Entity is in the process of dissolving
+    Dissolving {
+        /// When dissolution started
+        started_at: u64,
+    },
+
+    /// Entity has been dissolved
+    Dissolved {
+        /// When dissolved
+        dissolved_at: u64,
+    },
+
+    /// Entity has merged into another entity
+    Merged {
+        /// The entity this was merged into
+        into: EntityId,
+        /// When merged
+        merged_at: u64,
+    },
+
+    /// Entity has split into multiple entities
+    Split {
+        /// The entities created from this split
+        into: Vec<EntityId>,
+        /// When split
+        split_at: u64,
+    },
+}
+
+impl EntityStatus {
+    /// Check if entity is operational (can perform normal operations)
+    pub fn is_operational(&self) -> bool {
+        matches!(self, EntityStatus::Active)
+    }
+
+    /// Check if entity lifecycle has ended
+    pub fn is_terminated(&self) -> bool {
+        matches!(
+            self,
+            EntityStatus::Dissolved { .. }
+                | EntityStatus::Merged { .. }
+                | EntityStatus::Split { .. }
+        )
+    }
+}
+
+// ============================================================================
+// AccountReference
+// ============================================================================
+
+/// Reference to an account in the ledger
+///
+/// This links an entity to its treasury/ledger account.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccountReference {
+    /// The account identifier (can be EntityId string or legacy Did string)
+    pub account_id: String,
+
+    /// Primary currency managed by this account
+    pub currency: String,
+}
+
+impl AccountReference {
+    /// Create a new account reference
+    pub fn new(account_id: impl Into<String>, currency: impl Into<String>) -> Self {
+        AccountReference {
+            account_id: account_id.into(),
+            currency: currency.into(),
+        }
+    }
+}
+
+// ============================================================================
+// CooperativeEntity
+// ============================================================================
+
+/// A cooperative entity that works at all scales
+///
+/// This is the unified model that can represent:
+/// - Individuals (with DID binding)
+/// - Cooperatives of various types
+/// - Federations of cooperatives
+///
+/// The recursive membership model allows entities to contain other entities
+/// as members, enabling arbitrary organizational hierarchies.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CooperativeEntity {
+    /// Unique entity identifier
+    pub id: EntityId,
+
+    /// Human-readable name
+    pub name: String,
+
+    /// Entity type (individual, cooperative, federation)
+    pub entity_type: EntityType,
+
+    /// Lifecycle status
+    pub status: EntityStatus,
+
+    /// Parent entity (for hierarchical membership)
+    /// None for top-level entities or individuals not in any organization
+    pub parent_id: Option<EntityId>,
+
+    /// Governance domain ID (links to icn-governance)
+    /// Individuals typically don't have governance domains
+    pub governance_domain_id: Option<String>,
+
+    /// Treasury account (links to icn-ledger)
+    /// Individuals may not have treasury; coops always do
+    pub treasury_account: Option<AccountReference>,
+
+    /// When the entity was created (Unix timestamp)
+    pub created_at: u64,
+
+    /// When the entity was last updated (Unix timestamp)
+    pub updated_at: u64,
+
+    /// Optional description
+    pub description: Option<String>,
+
+    /// Arbitrary metadata for extensibility
+    pub metadata: HashMap<String, String>,
+}
+
+impl CooperativeEntity {
+    /// Create a new entity for an individual
+    pub fn individual(did: &Did, name: impl Into<String>) -> Self {
+        let now = icn_time::current_timestamp_secs();
+        CooperativeEntity {
+            id: EntityId::from_did(did),
+            name: name.into(),
+            entity_type: EntityType::Individual,
+            status: EntityStatus::Active, // Individuals are active immediately
+            parent_id: None,
+            governance_domain_id: None,
+            treasury_account: None,
+            created_at: now,
+            updated_at: now,
+            description: None,
+            metadata: HashMap::new(),
+        }
+    }
+
+    /// Create a new cooperative entity
+    pub fn cooperative(slug: &str, name: impl Into<String>) -> Result<Self> {
+        let now = icn_time::current_timestamp_secs();
+        Ok(CooperativeEntity {
+            id: EntityId::cooperative(slug)?,
+            name: name.into(),
+            entity_type: EntityType::Cooperative,
+            status: EntityStatus::Forming,
+            parent_id: None,
+            governance_domain_id: None,
+            treasury_account: None,
+            created_at: now,
+            updated_at: now,
+            description: None,
+            metadata: HashMap::new(),
+        })
+    }
+
+    /// Create a new federation entity
+    pub fn federation(slug: &str, name: impl Into<String>) -> Result<Self> {
+        let now = icn_time::current_timestamp_secs();
+        Ok(CooperativeEntity {
+            id: EntityId::federation(slug)?,
+            name: name.into(),
+            entity_type: EntityType::Federation,
+            status: EntityStatus::Forming,
+            parent_id: None,
+            governance_domain_id: None,
+            treasury_account: None,
+            created_at: now,
+            updated_at: now,
+            description: None,
+            metadata: HashMap::new(),
+        })
+    }
+
+    /// Set the parent entity
+    pub fn with_parent(mut self, parent_id: EntityId) -> Self {
+        self.parent_id = Some(parent_id);
+        self
+    }
+
+    /// Set the governance domain
+    pub fn with_governance_domain(mut self, domain_id: impl Into<String>) -> Self {
+        self.governance_domain_id = Some(domain_id.into());
+        self
+    }
+
+    /// Set the treasury account
+    pub fn with_treasury(mut self, account: AccountReference) -> Self {
+        self.treasury_account = Some(account);
+        self
+    }
+
+    /// Set the description
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Add metadata
+    pub fn with_metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.metadata.insert(key.into(), value.into());
+        self
+    }
+
+    /// Check if entity can be activated
+    pub fn can_activate(&self) -> bool {
+        matches!(self.status, EntityStatus::Forming)
+    }
+
+    /// Check if entity can be suspended
+    pub fn can_suspend(&self) -> bool {
+        matches!(self.status, EntityStatus::Active)
+    }
+
+    /// Check if entity can be dissolved
+    pub fn can_dissolve(&self) -> bool {
+        matches!(
+            self.status,
+            EntityStatus::Active | EntityStatus::Suspended { .. }
+        )
+    }
+}
+
+// ============================================================================
+// AccountId (Backward Compatibility)
+// ============================================================================
+
+/// Account identifier that works with both legacy DIDs and new EntityIds
+///
+/// This type provides backward compatibility during the migration from
+/// DID-based account identification to EntityId-based identification.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum AccountId {
+    /// Legacy DID-based account (individual)
+    Did(Did),
+
+    /// New EntityId-based account (individual, cooperative, or federation)
+    Entity(EntityId),
+}
+
+impl AccountId {
+    /// Get string representation
+    pub fn as_str(&self) -> String {
+        match self {
+            AccountId::Did(did) => did.to_string(),
+            AccountId::Entity(id) => id.to_string(),
+        }
+    }
+
+    /// Check if this is an individual account
+    pub fn is_individual(&self) -> bool {
+        match self {
+            AccountId::Did(_) => true,
+            AccountId::Entity(id) => id.is_individual(),
+        }
+    }
+}
+
+impl From<Did> for AccountId {
+    fn from(did: Did) -> Self {
+        AccountId::Did(did)
+    }
+}
+
+impl From<EntityId> for AccountId {
+    fn from(id: EntityId) -> Self {
+        AccountId::Entity(id)
+    }
+}
+
+impl fmt::Display for AccountId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use icn_identity::KeyPair;
+
+    #[test]
+    fn test_entity_id_from_did() {
+        let keypair = KeyPair::generate().unwrap();
+        let did = keypair.did().clone();
+        let entity_id = EntityId::from_did(&did);
+
+        assert!(entity_id.is_individual());
+        assert!(!entity_id.is_cooperative());
+        assert!(!entity_id.is_federation());
+        assert_eq!(entity_id.entity_type(), EntityType::Individual);
+
+        // Should be able to convert back to DID
+        let recovered_did = entity_id.to_did().unwrap();
+        assert_eq!(recovered_did, did);
+    }
+
+    #[test]
+    fn test_entity_id_cooperative() {
+        let entity_id = EntityId::cooperative("food-coop-2024").unwrap();
+
+        assert!(!entity_id.is_individual());
+        assert!(entity_id.is_cooperative());
+        assert!(!entity_id.is_federation());
+        assert!(entity_id.is_organization());
+        assert_eq!(entity_id.entity_type(), EntityType::Cooperative);
+        assert_eq!(entity_id.identifier(), "food-coop-2024");
+
+        // Should not be able to convert to DID
+        assert!(entity_id.to_did().is_none());
+    }
+
+    #[test]
+    fn test_entity_id_federation() {
+        let entity_id = EntityId::federation("midwest-fed").unwrap();
+
+        assert!(entity_id.is_federation());
+        assert!(entity_id.is_organization());
+        assert_eq!(entity_id.entity_type(), EntityType::Federation);
+    }
+
+    #[test]
+    fn test_entity_id_parse() {
+        let id_str = "entity:icn:cooperative:test-coop";
+        let entity_id: EntityId = id_str.parse().unwrap();
+        assert_eq!(entity_id.as_str(), id_str);
+        assert!(entity_id.is_cooperative());
+    }
+
+    #[test]
+    fn test_entity_id_invalid_format() {
+        assert!(EntityId::from_str("invalid").is_err());
+        assert!(EntityId::from_str("entity:other:cooperative:test").is_err());
+        assert!(EntityId::from_str("entity:icn:unknown:test").is_err());
+    }
+
+    #[test]
+    fn test_entity_id_slug_validation() {
+        // Valid slugs
+        assert!(EntityId::cooperative("valid-slug").is_ok());
+        assert!(EntityId::cooperative("valid_slug").is_ok());
+        assert!(EntityId::cooperative("ValidSlug123").is_ok());
+
+        // Invalid slugs
+        assert!(EntityId::cooperative("").is_err());
+        assert!(EntityId::cooperative("invalid slug").is_err());
+        assert!(EntityId::cooperative("invalid/slug").is_err());
+    }
+
+    #[test]
+    fn test_cooperative_entity_creation() {
+        let entity = CooperativeEntity::cooperative("test-coop", "Test Cooperative").unwrap();
+
+        assert_eq!(entity.name, "Test Cooperative");
+        assert!(entity.id.is_cooperative());
+        assert!(matches!(entity.status, EntityStatus::Forming));
+        assert!(entity.can_activate());
+    }
+
+    #[test]
+    fn test_individual_entity_creation() {
+        let keypair = KeyPair::generate().unwrap();
+        let did = keypair.did().clone();
+        let entity = CooperativeEntity::individual(&did, "Alice");
+
+        assert_eq!(entity.name, "Alice");
+        assert!(entity.id.is_individual());
+        assert!(matches!(entity.status, EntityStatus::Active));
+    }
+
+    #[test]
+    fn test_entity_serialization() {
+        let entity = CooperativeEntity::cooperative("test", "Test").unwrap();
+        let json = serde_json::to_string(&entity).unwrap();
+        let parsed: CooperativeEntity = serde_json::from_str(&json).unwrap();
+        assert_eq!(entity.id, parsed.id);
+        assert_eq!(entity.name, parsed.name);
+    }
+
+    #[test]
+    fn test_account_id_from_did() {
+        let keypair = KeyPair::generate().unwrap();
+        let did = keypair.did().clone();
+        let account_id: AccountId = did.clone().into();
+
+        assert!(account_id.is_individual());
+        assert!(matches!(account_id, AccountId::Did(_)));
+    }
+
+    #[test]
+    fn test_account_id_from_entity() {
+        let entity_id = EntityId::cooperative("test").unwrap();
+        let account_id: AccountId = entity_id.into();
+
+        assert!(!account_id.is_individual());
+        assert!(matches!(account_id, AccountId::Entity(_)));
+    }
+}

--- a/icn/crates/icn-entity/src/entity.rs
+++ b/icn/crates/icn-entity/src/entity.rs
@@ -90,15 +90,19 @@ impl EntityId {
     }
 
     /// Get the entity type from this ID
+    ///
+    /// Parses the format `entity:icn:<type>:<identifier>` and extracts the type.
     pub fn entity_type(&self) -> EntityType {
-        if self.0.contains(":individual:") {
-            EntityType::Individual
-        } else if self.0.contains(":cooperative:") {
-            EntityType::Cooperative
-        } else if self.0.contains(":federation:") {
-            EntityType::Federation
-        } else {
-            EntityType::Unknown
+        // Expected format: entity:icn:<type>:<identifier>
+        let mut parts = self.0.split(':');
+        // Skip "entity" and "icn"
+        let _ = parts.next();
+        let _ = parts.next();
+        match parts.next() {
+            Some("individual") => EntityType::Individual,
+            Some("cooperative") => EntityType::Cooperative,
+            Some("federation") => EntityType::Federation,
+            _ => EntityType::Unknown,
         }
     }
 
@@ -525,6 +529,7 @@ impl fmt::Display for AccountId {
 // ============================================================================
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use icn_identity::KeyPair;

--- a/icn/crates/icn-entity/src/entity.rs
+++ b/icn/crates/icn-entity/src/entity.rs
@@ -70,14 +70,14 @@ impl EntityId {
     /// Validate a slug for use in EntityId
     ///
     /// Rules:
-    /// - 3-64 characters
+    /// - 4-64 characters (minimum 4 to avoid namespace collisions)
     /// - Lowercase letters, numbers, hyphens only
     /// - Must start with a letter
     /// - No consecutive hyphens
     fn validate_slug(slug: &str) -> Result<()> {
-        if slug.len() < 3 {
+        if slug.len() < 4 {
             return Err(EntityError::InvalidFormat(
-                "Slug must be at least 3 characters".into(),
+                "Slug must be at least 4 characters".into(),
             ));
         }
         if slug.len() > 64 {
@@ -202,10 +202,27 @@ impl FromStr for EntityId {
         }
 
         let type_part = parts[2];
-        if !["individual", "cooperative", "federation"].contains(&type_part) {
-            return Err(EntityError::InvalidFormat(format!(
-                "Unknown entity type: {type_part}"
-            )));
+        let identifier = parts[3];
+
+        match type_part {
+            "individual" => {
+                // Individual identifiers are base58-encoded public keys
+                // Just verify it's non-empty
+                if identifier.is_empty() {
+                    return Err(EntityError::InvalidFormat(
+                        "Individual identifier cannot be empty".into(),
+                    ));
+                }
+            }
+            "cooperative" | "federation" => {
+                // Cooperative/federation identifiers must be valid slugs
+                Self::validate_slug(identifier)?;
+            }
+            _ => {
+                return Err(EntityError::InvalidFormat(format!(
+                    "Unknown entity type: {type_part}"
+                )));
+            }
         }
 
         Ok(EntityId(s.to_string()))
@@ -650,14 +667,32 @@ mod tests {
     }
 
     #[test]
+    fn test_entity_id_fromstr_validates_slug() {
+        // Valid FromStr parsing
+        assert!(EntityId::from_str("entity:icn:cooperative:valid-slug").is_ok());
+        assert!(EntityId::from_str("entity:icn:federation:test-fed").is_ok());
+        assert!(EntityId::from_str("entity:icn:individual:z5TrA8Qk").is_ok());
+
+        // Invalid: cooperative/federation slugs must pass validation
+        assert!(EntityId::from_str("entity:icn:cooperative:ab").is_err()); // too short
+        assert!(EntityId::from_str("entity:icn:cooperative:abc").is_err()); // too short (< 4)
+        assert!(EntityId::from_str("entity:icn:federation:123").is_err()); // doesn't start with letter
+        assert!(EntityId::from_str("entity:icn:cooperative:Test").is_err()); // uppercase
+
+        // Individual identifiers just need to be non-empty
+        assert!(EntityId::from_str("entity:icn:individual:").is_err()); // empty
+    }
+
+    #[test]
     fn test_entity_id_slug_validation() {
-        // Valid slugs (lowercase, 3-64 chars, start with letter)
+        // Valid slugs (lowercase, 4-64 chars, start with letter)
         assert!(EntityId::cooperative("valid-slug").is_ok());
-        assert!(EntityId::cooperative("abc").is_ok());
+        assert!(EntityId::cooperative("abcd").is_ok());
         assert!(EntityId::cooperative("test123").is_ok());
         assert!(EntityId::cooperative("food-coop-2024").is_ok());
 
-        // Invalid: too short
+        // Invalid: too short (minimum 4 chars)
+        assert!(EntityId::cooperative("abc").is_err());
         assert!(EntityId::cooperative("ab").is_err());
 
         // Invalid: doesn't start with letter

--- a/icn/crates/icn-entity/src/error.rs
+++ b/icn/crates/icn-entity/src/error.rs
@@ -1,0 +1,49 @@
+//! Error types for the entity module
+
+use thiserror::Error;
+
+/// Errors that can occur in entity operations
+#[derive(Error, Debug)]
+pub enum EntityError {
+    /// Invalid entity ID format
+    #[error("Invalid entity ID format: {0}")]
+    InvalidFormat(String),
+
+    /// Entity not found
+    #[error("Entity not found: {0}")]
+    NotFound(String),
+
+    /// Entity already exists
+    #[error("Entity already exists: {0}")]
+    AlreadyExists(String),
+
+    /// Invalid entity type
+    #[error("Invalid entity type: {0}")]
+    InvalidType(String),
+
+    /// Invalid state transition
+    #[error("Invalid state transition from {from:?} to {to:?}")]
+    InvalidStateTransition {
+        from: crate::EntityStatus,
+        to: crate::EntityStatus,
+    },
+
+    /// Membership error
+    #[error("Membership error: {0}")]
+    MembershipError(String),
+
+    /// Registry error
+    #[error("Registry error: {0}")]
+    RegistryError(String),
+
+    /// Serialization error
+    #[error("Serialization error: {0}")]
+    SerializationError(#[from] serde_json::Error),
+
+    /// Internal error
+    #[error("Internal error: {0}")]
+    Internal(#[from] anyhow::Error),
+}
+
+/// Result type for entity operations
+pub type Result<T> = std::result::Result<T, EntityError>;

--- a/icn/crates/icn-entity/src/lib.rs
+++ b/icn/crates/icn-entity/src/lib.rs
@@ -1,0 +1,85 @@
+//! ICN Entity - Unified Cooperative Entity Model
+//!
+//! This crate provides a recursive entity abstraction that works at all scales:
+//! - **Individuals** (backed by DIDs)
+//! - **Cooperatives** (worker, consumer, producer, multi-stakeholder)
+//! - **Federations** (cooperatives of cooperatives)
+//!
+//! # Overview
+//!
+//! The key insight is that membership is recursive: a cooperative's members
+//! can themselves be cooperatives. This enables arbitrary organizational
+//! hierarchies while maintaining a simple, unified model.
+//!
+//! # EntityId Format
+//!
+//! Entity IDs follow the format `entity:icn:<type>:<identifier>`:
+//!
+//! - `entity:icn:individual:z5TrA8...` - Individual (wraps DID)
+//! - `entity:icn:cooperative:food-coop-2024` - Cooperative
+//! - `entity:icn:federation:midwest-fed` - Federation
+//!
+//! # DID Interoperability
+//!
+//! EntityIds are designed to be compatible with DIDs:
+//! - For individuals: `EntityId::from_did(did)` wraps the DID
+//! - For organizations: EntityIds are independent (no keypair)
+//! - `EntityId::to_did()` returns `Some(Did)` for individuals, `None` for orgs
+//!
+//! # Backward Compatibility
+//!
+//! The [`AccountId`] enum provides backward compatibility during migration:
+//!
+//! ```ignore
+//! enum AccountId {
+//!     Did(Did),        // Legacy DID-based accounts
+//!     Entity(EntityId), // New entity-based accounts
+//! }
+//! ```
+//!
+//! # Example
+//!
+//! ```
+//! use icn_entity::{CooperativeEntity, EntityId, Membership, MembershipRole};
+//! use icn_identity::KeyPair;
+//!
+//! // Create a cooperative
+//! let coop = CooperativeEntity::cooperative("food-coop", "Community Food Coop")
+//!     .unwrap()
+//!     .with_description("A worker-owned grocery store");
+//!
+//! // Create an individual member
+//! let keypair = KeyPair::generate().unwrap();
+//! let member = CooperativeEntity::individual(keypair.did(), "Alice");
+//!
+//! // Create membership
+//! let membership = Membership::active(
+//!     member.id.clone(),
+//!     coop.id.clone(),
+//!     MembershipRole::Worker,
+//! );
+//!
+//! assert!(membership.can_vote());
+//! assert!(membership.can_propose());
+//! ```
+//!
+//! # Modules
+//!
+//! - [`entity`] - Core types: `EntityId`, `EntityType`, `CooperativeEntity`
+//! - [`membership`] - Membership types: `Membership`, `MembershipRole`
+//! - [`registry`] - Registry trait and in-memory implementation
+//! - [`lifecycle`] - Lifecycle events and state transitions
+//! - [`error`] - Error types
+
+pub mod entity;
+pub mod error;
+pub mod lifecycle;
+pub mod membership;
+pub mod registry;
+
+// Re-export main types at crate root
+pub use entity::{AccountId, AccountReference, CooperativeEntity, EntityId, EntityStatus, EntityType};
+pub use error::{EntityError, Result};
+pub use lifecycle::{EntityLifecycle, LifecycleEvent};
+pub use membership::{Membership, MembershipCapability, MembershipRole, MembershipStatus};
+pub use registry::{EntityRegistry, EntityRegistryHandle, InMemoryRegistry};

--- a/icn/crates/icn-entity/src/lib.rs
+++ b/icn/crates/icn-entity/src/lib.rs
@@ -78,7 +78,9 @@ pub mod membership;
 pub mod registry;
 
 // Re-export main types at crate root
-pub use entity::{AccountId, AccountReference, CooperativeEntity, EntityId, EntityStatus, EntityType};
+pub use entity::{
+    AccountId, AccountReference, CooperativeEntity, EntityId, EntityStatus, EntityType,
+};
 pub use error::{EntityError, Result};
 pub use lifecycle::{EntityLifecycle, LifecycleEvent};
 pub use membership::{Membership, MembershipCapability, MembershipRole, MembershipStatus};

--- a/icn/crates/icn-entity/src/lifecycle.rs
+++ b/icn/crates/icn-entity/src/lifecycle.rs
@@ -1,0 +1,394 @@
+//! Entity lifecycle management
+//!
+//! This module defines the lifecycle events and state transitions for entities.
+//! Entities go through various states from formation to dissolution.
+
+use crate::entity::{CooperativeEntity, EntityId, EntityStatus};
+use crate::error::{EntityError, Result};
+use serde::{Deserialize, Serialize};
+
+// ============================================================================
+// LifecycleEvent
+// ============================================================================
+
+/// Events that occur during an entity's lifecycle
+///
+/// These events are recorded for audit trails and can trigger
+/// notifications or governance actions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum LifecycleEvent {
+    /// Entity was created
+    Created {
+        entity_id: EntityId,
+        created_by: EntityId,
+        timestamp: u64,
+    },
+
+    /// Entity was activated (charter ratified, ready for operation)
+    Activated {
+        entity_id: EntityId,
+        charter_hash: String,
+        activated_by: EntityId,
+        timestamp: u64,
+    },
+
+    /// Entity was suspended
+    Suspended {
+        entity_id: EntityId,
+        reason: String,
+        suspended_by: EntityId,
+        timestamp: u64,
+    },
+
+    /// Entity was resumed from suspension
+    Resumed {
+        entity_id: EntityId,
+        resumed_by: EntityId,
+        timestamp: u64,
+    },
+
+    /// Entity dissolution process started
+    DissolutionStarted {
+        entity_id: EntityId,
+        initiator: EntityId,
+        reason: String,
+        timestamp: u64,
+    },
+
+    /// Entity was fully dissolved
+    Dissolved {
+        entity_id: EntityId,
+        timestamp: u64,
+    },
+
+    /// Entity merged into another
+    Merged {
+        source_id: EntityId,
+        target_id: EntityId,
+        merger_proposal_id: Option<String>,
+        timestamp: u64,
+    },
+
+    /// Entity split into multiple entities
+    Split {
+        source_id: EntityId,
+        new_entity_ids: Vec<EntityId>,
+        split_proposal_id: Option<String>,
+        timestamp: u64,
+    },
+
+    /// Entity metadata was updated
+    Updated {
+        entity_id: EntityId,
+        updated_by: EntityId,
+        changes: Vec<String>, // List of fields that changed
+        timestamp: u64,
+    },
+}
+
+impl LifecycleEvent {
+    /// Get the entity ID this event relates to
+    pub fn entity_id(&self) -> &EntityId {
+        match self {
+            LifecycleEvent::Created { entity_id, .. } => entity_id,
+            LifecycleEvent::Activated { entity_id, .. } => entity_id,
+            LifecycleEvent::Suspended { entity_id, .. } => entity_id,
+            LifecycleEvent::Resumed { entity_id, .. } => entity_id,
+            LifecycleEvent::DissolutionStarted { entity_id, .. } => entity_id,
+            LifecycleEvent::Dissolved { entity_id, .. } => entity_id,
+            LifecycleEvent::Merged { source_id, .. } => source_id,
+            LifecycleEvent::Split { source_id, .. } => source_id,
+            LifecycleEvent::Updated { entity_id, .. } => entity_id,
+        }
+    }
+
+    /// Get the timestamp of this event
+    pub fn timestamp(&self) -> u64 {
+        match self {
+            LifecycleEvent::Created { timestamp, .. } => *timestamp,
+            LifecycleEvent::Activated { timestamp, .. } => *timestamp,
+            LifecycleEvent::Suspended { timestamp, .. } => *timestamp,
+            LifecycleEvent::Resumed { timestamp, .. } => *timestamp,
+            LifecycleEvent::DissolutionStarted { timestamp, .. } => *timestamp,
+            LifecycleEvent::Dissolved { timestamp, .. } => *timestamp,
+            LifecycleEvent::Merged { timestamp, .. } => *timestamp,
+            LifecycleEvent::Split { timestamp, .. } => *timestamp,
+            LifecycleEvent::Updated { timestamp, .. } => *timestamp,
+        }
+    }
+
+    /// Get a human-readable description of this event
+    pub fn description(&self) -> String {
+        match self {
+            LifecycleEvent::Created { entity_id, .. } => {
+                format!("Entity {} was created", entity_id.identifier())
+            }
+            LifecycleEvent::Activated { entity_id, .. } => {
+                format!("Entity {} was activated", entity_id.identifier())
+            }
+            LifecycleEvent::Suspended { entity_id, reason, .. } => {
+                format!("Entity {} was suspended: {}", entity_id.identifier(), reason)
+            }
+            LifecycleEvent::Resumed { entity_id, .. } => {
+                format!("Entity {} was resumed", entity_id.identifier())
+            }
+            LifecycleEvent::DissolutionStarted { entity_id, reason, .. } => {
+                format!(
+                    "Entity {} dissolution started: {}",
+                    entity_id.identifier(),
+                    reason
+                )
+            }
+            LifecycleEvent::Dissolved { entity_id, .. } => {
+                format!("Entity {} was dissolved", entity_id.identifier())
+            }
+            LifecycleEvent::Merged {
+                source_id,
+                target_id,
+                ..
+            } => {
+                format!(
+                    "Entity {} merged into {}",
+                    source_id.identifier(),
+                    target_id.identifier()
+                )
+            }
+            LifecycleEvent::Split {
+                source_id,
+                new_entity_ids,
+                ..
+            } => {
+                let new_ids: Vec<_> = new_entity_ids.iter().map(|e| e.identifier()).collect();
+                format!(
+                    "Entity {} split into {:?}",
+                    source_id.identifier(),
+                    new_ids
+                )
+            }
+            LifecycleEvent::Updated { entity_id, changes, .. } => {
+                format!(
+                    "Entity {} updated: {:?}",
+                    entity_id.identifier(),
+                    changes
+                )
+            }
+        }
+    }
+}
+
+// ============================================================================
+// EntityLifecycle Trait
+// ============================================================================
+
+/// Trait for entity lifecycle management
+///
+/// Implementations of this trait handle state transitions and
+/// generate appropriate lifecycle events.
+pub trait EntityLifecycle {
+    /// Create a new entity
+    ///
+    /// The entity starts in `Forming` status.
+    fn create(
+        &mut self,
+        entity: CooperativeEntity,
+        created_by: &EntityId,
+    ) -> Result<LifecycleEvent>;
+
+    /// Activate an entity after charter ratification
+    ///
+    /// Transitions from `Forming` to `Active`.
+    fn activate(
+        &mut self,
+        entity_id: &EntityId,
+        charter_hash: String,
+        activated_by: &EntityId,
+    ) -> Result<LifecycleEvent>;
+
+    /// Suspend an entity
+    ///
+    /// Transitions from `Active` to `Suspended`.
+    fn suspend(
+        &mut self,
+        entity_id: &EntityId,
+        reason: String,
+        suspended_by: &EntityId,
+    ) -> Result<LifecycleEvent>;
+
+    /// Resume a suspended entity
+    ///
+    /// Transitions from `Suspended` to `Active`.
+    fn resume(&mut self, entity_id: &EntityId, resumed_by: &EntityId) -> Result<LifecycleEvent>;
+
+    /// Start entity dissolution
+    ///
+    /// Transitions to `Dissolving`.
+    fn start_dissolution(
+        &mut self,
+        entity_id: &EntityId,
+        initiator: &EntityId,
+        reason: String,
+    ) -> Result<LifecycleEvent>;
+
+    /// Complete entity dissolution
+    ///
+    /// Transitions from `Dissolving` to `Dissolved`.
+    fn complete_dissolution(&mut self, entity_id: &EntityId) -> Result<LifecycleEvent>;
+
+    /// Merge source entity into target entity
+    ///
+    /// The source entity transitions to `Merged`.
+    fn merge(
+        &mut self,
+        source_id: &EntityId,
+        target_id: &EntityId,
+        proposal_id: Option<String>,
+    ) -> Result<LifecycleEvent>;
+
+    /// Split an entity into multiple new entities
+    ///
+    /// The source entity transitions to `Split`.
+    fn split(
+        &mut self,
+        source_id: &EntityId,
+        new_entities: Vec<CooperativeEntity>,
+        proposal_id: Option<String>,
+    ) -> Result<Vec<LifecycleEvent>>;
+}
+
+// ============================================================================
+// State Transition Validation
+// ============================================================================
+
+/// Validate a state transition
+pub fn validate_transition(from: &EntityStatus, to: &EntityStatus) -> Result<()> {
+    let valid = match (from, to) {
+        // From Forming
+        (EntityStatus::Forming, EntityStatus::Active) => true,
+        (EntityStatus::Forming, EntityStatus::Dissolved { .. }) => true, // Abandoned
+
+        // From Active
+        (EntityStatus::Active, EntityStatus::Suspended { .. }) => true,
+        (EntityStatus::Active, EntityStatus::Dissolving { .. }) => true,
+        (EntityStatus::Active, EntityStatus::Merged { .. }) => true,
+        (EntityStatus::Active, EntityStatus::Split { .. }) => true,
+
+        // From Suspended
+        (EntityStatus::Suspended { .. }, EntityStatus::Active) => true, // Resume
+        (EntityStatus::Suspended { .. }, EntityStatus::Dissolving { .. }) => true,
+
+        // From Dissolving
+        (EntityStatus::Dissolving { .. }, EntityStatus::Dissolved { .. }) => true,
+        (EntityStatus::Dissolving { .. }, EntityStatus::Active) => true, // Cancellation
+
+        // All other transitions are invalid
+        _ => false,
+    };
+
+    if valid {
+        Ok(())
+    } else {
+        Err(EntityError::InvalidStateTransition {
+            from: from.clone(),
+            to: to.clone(),
+        })
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_transitions() {
+        // Forming -> Active
+        assert!(validate_transition(&EntityStatus::Forming, &EntityStatus::Active).is_ok());
+
+        // Active -> Suspended
+        assert!(validate_transition(
+            &EntityStatus::Active,
+            &EntityStatus::Suspended {
+                reason: "test".into(),
+                suspended_at: 0
+            }
+        )
+        .is_ok());
+
+        // Suspended -> Active (resume)
+        assert!(validate_transition(
+            &EntityStatus::Suspended {
+                reason: "test".into(),
+                suspended_at: 0
+            },
+            &EntityStatus::Active
+        )
+        .is_ok());
+
+        // Active -> Dissolving
+        assert!(validate_transition(
+            &EntityStatus::Active,
+            &EntityStatus::Dissolving { started_at: 0 }
+        )
+        .is_ok());
+
+        // Dissolving -> Dissolved
+        assert!(validate_transition(
+            &EntityStatus::Dissolving { started_at: 0 },
+            &EntityStatus::Dissolved { dissolved_at: 0 }
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_invalid_transitions() {
+        // Dissolved -> Active (can't resurrect)
+        assert!(validate_transition(
+            &EntityStatus::Dissolved { dissolved_at: 0 },
+            &EntityStatus::Active
+        )
+        .is_err());
+
+        // Forming -> Suspended (must activate first)
+        assert!(validate_transition(
+            &EntityStatus::Forming,
+            &EntityStatus::Suspended {
+                reason: "test".into(),
+                suspended_at: 0
+            }
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_lifecycle_event_serialization() {
+        let event = LifecycleEvent::Created {
+            entity_id: EntityId::cooperative("test").unwrap(),
+            created_by: EntityId::cooperative("creator").unwrap(),
+            timestamp: 1234567890,
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: LifecycleEvent = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(event.timestamp(), parsed.timestamp());
+    }
+
+    #[test]
+    fn test_lifecycle_event_description() {
+        let event = LifecycleEvent::Merged {
+            source_id: EntityId::cooperative("source").unwrap(),
+            target_id: EntityId::cooperative("target").unwrap(),
+            merger_proposal_id: Some("prop-123".into()),
+            timestamp: 0,
+        };
+
+        let desc = event.description();
+        assert!(desc.contains("merged"));
+        assert!(desc.contains("source"));
+        assert!(desc.contains("target"));
+    }
+}

--- a/icn/crates/icn-entity/src/lifecycle.rs
+++ b/icn/crates/icn-entity/src/lifecycle.rs
@@ -391,4 +391,180 @@ mod tests {
         assert!(desc.contains("source"));
         assert!(desc.contains("target"));
     }
+
+    #[test]
+    fn test_all_valid_state_transitions() {
+        // Test all valid transitions from the state machine
+
+        // Forming -> Active (charter ratification)
+        assert!(validate_transition(&EntityStatus::Forming, &EntityStatus::Active).is_ok());
+
+        // Forming -> Dissolved (abandoned)
+        assert!(validate_transition(
+            &EntityStatus::Forming,
+            &EntityStatus::Dissolved { dissolved_at: 0 }
+        )
+        .is_ok());
+
+        // Active -> Suspended
+        assert!(validate_transition(
+            &EntityStatus::Active,
+            &EntityStatus::Suspended {
+                reason: "test".into(),
+                suspended_at: 0
+            }
+        )
+        .is_ok());
+
+        // Active -> Dissolving
+        assert!(validate_transition(
+            &EntityStatus::Active,
+            &EntityStatus::Dissolving { started_at: 0 }
+        )
+        .is_ok());
+
+        // Active -> Merged
+        assert!(validate_transition(
+            &EntityStatus::Active,
+            &EntityStatus::Merged {
+                into: EntityId::cooperative("target").unwrap(),
+                merged_at: 0
+            }
+        )
+        .is_ok());
+
+        // Active -> Split
+        assert!(validate_transition(
+            &EntityStatus::Active,
+            &EntityStatus::Split {
+                into: vec![
+                    EntityId::cooperative("new1").unwrap(),
+                    EntityId::cooperative("new2").unwrap()
+                ],
+                split_at: 0
+            }
+        )
+        .is_ok());
+
+        // Suspended -> Active (resume)
+        assert!(validate_transition(
+            &EntityStatus::Suspended {
+                reason: "test".into(),
+                suspended_at: 0
+            },
+            &EntityStatus::Active
+        )
+        .is_ok());
+
+        // Suspended -> Dissolving
+        assert!(validate_transition(
+            &EntityStatus::Suspended {
+                reason: "test".into(),
+                suspended_at: 0
+            },
+            &EntityStatus::Dissolving { started_at: 0 }
+        )
+        .is_ok());
+
+        // Dissolving -> Dissolved
+        assert!(validate_transition(
+            &EntityStatus::Dissolving { started_at: 0 },
+            &EntityStatus::Dissolved { dissolved_at: 0 }
+        )
+        .is_ok());
+
+        // Dissolving -> Active (cancellation)
+        assert!(validate_transition(
+            &EntityStatus::Dissolving { started_at: 0 },
+            &EntityStatus::Active
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_terminal_states_cannot_transition() {
+        let terminal_states = [
+            EntityStatus::Dissolved { dissolved_at: 0 },
+            EntityStatus::Merged {
+                into: EntityId::cooperative("target").unwrap(),
+                merged_at: 0,
+            },
+            EntityStatus::Split {
+                into: vec![EntityId::cooperative("new1").unwrap()],
+                split_at: 0,
+            },
+        ];
+
+        for terminal in &terminal_states {
+            // Cannot transition to Active
+            assert!(
+                validate_transition(terminal, &EntityStatus::Active).is_err(),
+                "Terminal state {:?} should not transition to Active",
+                terminal
+            );
+
+            // Cannot transition to any other state
+            assert!(
+                validate_transition(
+                    terminal,
+                    &EntityStatus::Suspended {
+                        reason: "test".into(),
+                        suspended_at: 0
+                    }
+                )
+                .is_err(),
+                "Terminal state {:?} should not transition to Suspended",
+                terminal
+            );
+        }
+    }
+
+    #[test]
+    fn test_lifecycle_event_entity_id_extraction() {
+        let coop_id = EntityId::cooperative("test-coop").unwrap();
+
+        let events = vec![
+            LifecycleEvent::Created {
+                entity_id: coop_id.clone(),
+                created_by: EntityId::cooperative("creator").unwrap(),
+                timestamp: 0,
+            },
+            LifecycleEvent::Activated {
+                entity_id: coop_id.clone(),
+                charter_hash: "abc123".into(),
+                activated_by: EntityId::cooperative("activator").unwrap(),
+                timestamp: 0,
+            },
+            LifecycleEvent::Suspended {
+                entity_id: coop_id.clone(),
+                reason: "testing".into(),
+                suspended_by: EntityId::cooperative("suspender").unwrap(),
+                timestamp: 0,
+            },
+            LifecycleEvent::Resumed {
+                entity_id: coop_id.clone(),
+                resumed_by: EntityId::cooperative("resumer").unwrap(),
+                timestamp: 0,
+            },
+            LifecycleEvent::DissolutionStarted {
+                entity_id: coop_id.clone(),
+                initiator: EntityId::cooperative("initiator").unwrap(),
+                reason: "closing".into(),
+                timestamp: 0,
+            },
+            LifecycleEvent::Dissolved {
+                entity_id: coop_id.clone(),
+                timestamp: 0,
+            },
+        ];
+
+        for event in events {
+            assert_eq!(
+                event.entity_id(),
+                &coop_id,
+                "entity_id() should return correct ID for {:?}",
+                event
+            );
+        }
+    }
 }

--- a/icn/crates/icn-entity/src/lifecycle.rs
+++ b/icn/crates/icn-entity/src/lifecycle.rs
@@ -57,10 +57,7 @@ pub enum LifecycleEvent {
     },
 
     /// Entity was fully dissolved
-    Dissolved {
-        entity_id: EntityId,
-        timestamp: u64,
-    },
+    Dissolved { entity_id: EntityId, timestamp: u64 },
 
     /// Entity merged into another
     Merged {
@@ -127,13 +124,21 @@ impl LifecycleEvent {
             LifecycleEvent::Activated { entity_id, .. } => {
                 format!("Entity {} was activated", entity_id.identifier())
             }
-            LifecycleEvent::Suspended { entity_id, reason, .. } => {
-                format!("Entity {} was suspended: {}", entity_id.identifier(), reason)
+            LifecycleEvent::Suspended {
+                entity_id, reason, ..
+            } => {
+                format!(
+                    "Entity {} was suspended: {}",
+                    entity_id.identifier(),
+                    reason
+                )
             }
             LifecycleEvent::Resumed { entity_id, .. } => {
                 format!("Entity {} was resumed", entity_id.identifier())
             }
-            LifecycleEvent::DissolutionStarted { entity_id, reason, .. } => {
+            LifecycleEvent::DissolutionStarted {
+                entity_id, reason, ..
+            } => {
                 format!(
                     "Entity {} dissolution started: {}",
                     entity_id.identifier(),
@@ -160,18 +165,12 @@ impl LifecycleEvent {
                 ..
             } => {
                 let new_ids: Vec<_> = new_entity_ids.iter().map(|e| e.identifier()).collect();
-                format!(
-                    "Entity {} split into {:?}",
-                    source_id.identifier(),
-                    new_ids
-                )
+                format!("Entity {} split into {:?}", source_id.identifier(), new_ids)
             }
-            LifecycleEvent::Updated { entity_id, changes, .. } => {
-                format!(
-                    "Entity {} updated: {:?}",
-                    entity_id.identifier(),
-                    changes
-                )
+            LifecycleEvent::Updated {
+                entity_id, changes, ..
+            } => {
+                format!("Entity {} updated: {:?}", entity_id.identifier(), changes)
             }
         }
     }
@@ -300,6 +299,7 @@ pub fn validate_transition(from: &EntityStatus, to: &EntityStatus) -> Result<()>
 // ============================================================================
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/icn/crates/icn-entity/src/membership.rs
+++ b/icn/crates/icn-entity/src/membership.rs
@@ -54,15 +54,16 @@ impl Membership {
     /// Create a new pending membership
     pub fn new(member_id: EntityId, parent_id: EntityId, role: MembershipRole) -> Self {
         let now = icn_time::current_timestamp_secs();
+        let capabilities = role.default_capabilities();
         Membership {
             member_id,
             parent_id,
-            role: role.clone(),
+            role,
             status: MembershipStatus::Pending,
             joined_at: now,
             updated_at: now,
             shares: 1, // Default to 1 share (one member, one vote)
-            capabilities: role.default_capabilities(),
+            capabilities,
             notes: None,
         }
     }
@@ -110,9 +111,7 @@ impl Membership {
 
     /// Check if member can vote
     pub fn can_vote(&self) -> bool {
-        self.is_active()
-            && self.shares > 0
-            && self.has_capability(&MembershipCapability::Vote)
+        self.is_active() && self.shares > 0 && self.has_capability(&MembershipCapability::Vote)
     }
 
     /// Check if member can create proposals
@@ -216,10 +215,9 @@ impl MembershipRole {
             MembershipRole::Worker
             | MembershipRole::Consumer
             | MembershipRole::Producer
-            | MembershipRole::Member => vec![
-                MembershipCapability::Vote,
-                MembershipCapability::Propose,
-            ],
+            | MembershipRole::Member => {
+                vec![MembershipCapability::Vote, MembershipCapability::Propose]
+            }
 
             // Federated members get full voting rights
             MembershipRole::FederatedMember => vec![
@@ -229,23 +227,18 @@ impl MembershipRole {
             ],
 
             // Associate members may have limited rights
-            MembershipRole::AssociateMember => vec![
-                MembershipCapability::Propose,
-            ],
+            MembershipRole::AssociateMember => vec![MembershipCapability::Propose],
 
             // Observers have no default capabilities
             MembershipRole::ObserverMember => vec![],
 
             // Provisional members have limited rights
-            MembershipRole::ProvisionalMember => vec![
-                MembershipCapability::Propose,
-            ],
+            MembershipRole::ProvisionalMember => vec![MembershipCapability::Propose],
 
             // Custom roles start with basic member rights
-            MembershipRole::Custom { .. } => vec![
-                MembershipCapability::Vote,
-                MembershipCapability::Propose,
-            ],
+            MembershipRole::Custom { .. } => {
+                vec![MembershipCapability::Vote, MembershipCapability::Propose]
+            }
         }
     }
 
@@ -334,9 +327,7 @@ impl MembershipStatus {
     pub fn is_terminated(&self) -> bool {
         matches!(
             self,
-            MembershipStatus::Resigned
-                | MembershipStatus::Removed
-                | MembershipStatus::Expelled
+            MembershipStatus::Resigned | MembershipStatus::Removed | MembershipStatus::Expelled
         )
     }
 }
@@ -414,6 +405,7 @@ impl fmt::Display for MembershipCapability {
 // ============================================================================
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use icn_identity::KeyPair;
@@ -470,7 +462,8 @@ mod tests {
         let member_coop = EntityId::cooperative("member-coop").unwrap();
         let federation = EntityId::federation("fed").unwrap();
 
-        let membership = Membership::active(member_coop, federation, MembershipRole::ObserverMember);
+        let membership =
+            Membership::active(member_coop, federation, MembershipRole::ObserverMember);
 
         // Observers have no shares by default but we gave them 1
         // They don't have Vote capability
@@ -511,10 +504,9 @@ mod tests {
         let member = create_test_individual();
         let coop = create_test_coop();
 
-        let no_shares = Membership::active(member.clone(), coop.clone(), MembershipRole::Member)
-            .with_shares(0);
-        let with_shares = Membership::active(member, coop, MembershipRole::Member)
-            .with_shares(10);
+        let no_shares =
+            Membership::active(member.clone(), coop.clone(), MembershipRole::Member).with_shares(0);
+        let with_shares = Membership::active(member, coop, MembershipRole::Member).with_shares(10);
 
         assert!(!no_shares.can_vote()); // 0 shares = no vote
         assert!(with_shares.can_vote());
@@ -539,7 +531,10 @@ mod tests {
         assert_eq!(MembershipRole::Founder.to_string(), "Founder");
         assert_eq!(MembershipRole::Worker.to_string(), "Worker");
         assert_eq!(
-            MembershipRole::Officer { title: "President".into() }.to_string(),
+            MembershipRole::Officer {
+                title: "President".into()
+            }
+            .to_string(),
             "Officer (President)"
         );
     }

--- a/icn/crates/icn-entity/src/membership.rs
+++ b/icn/crates/icn-entity/src/membership.rs
@@ -1,0 +1,546 @@
+//! Membership types for the ICN entity model
+//!
+//! This module defines the membership relationship between entities.
+//! The key insight is that membership is recursive: a cooperative's members
+//! can be individuals OR other cooperatives.
+
+use crate::entity::EntityId;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+// ============================================================================
+// Membership
+// ============================================================================
+
+/// A membership record linking an entity to its parent entity
+///
+/// This is the key to recursive composition: members can be individuals
+/// (backed by DIDs) OR other cooperatives, enabling:
+/// - Worker cooperatives with individual members
+/// - Federations with cooperative members
+/// - Multi-stakeholder cooperatives with mixed membership
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Membership {
+    /// The entity being granted membership (individual or organization)
+    pub member_id: EntityId,
+
+    /// The entity granting membership (cooperative or federation)
+    pub parent_id: EntityId,
+
+    /// Role within the parent entity
+    pub role: MembershipRole,
+
+    /// Current membership status
+    pub status: MembershipStatus,
+
+    /// When membership was created (Unix timestamp)
+    pub joined_at: u64,
+
+    /// When membership was last updated (Unix timestamp)
+    pub updated_at: u64,
+
+    /// Voting shares (for weighted voting systems)
+    /// 0 means no voting rights (e.g., observer status)
+    pub shares: u64,
+
+    /// Capabilities granted by this membership
+    pub capabilities: Vec<MembershipCapability>,
+
+    /// Optional notes about this membership
+    pub notes: Option<String>,
+}
+
+impl Membership {
+    /// Create a new pending membership
+    pub fn new(member_id: EntityId, parent_id: EntityId, role: MembershipRole) -> Self {
+        let now = icn_time::current_timestamp_secs();
+        Membership {
+            member_id,
+            parent_id,
+            role: role.clone(),
+            status: MembershipStatus::Pending,
+            joined_at: now,
+            updated_at: now,
+            shares: 1, // Default to 1 share (one member, one vote)
+            capabilities: role.default_capabilities(),
+            notes: None,
+        }
+    }
+
+    /// Create an active membership (bypass pending state)
+    pub fn active(member_id: EntityId, parent_id: EntityId, role: MembershipRole) -> Self {
+        let mut m = Self::new(member_id, parent_id, role);
+        m.status = MembershipStatus::Active;
+        m
+    }
+
+    /// Set the number of voting shares
+    pub fn with_shares(mut self, shares: u64) -> Self {
+        self.shares = shares;
+        self
+    }
+
+    /// Set custom capabilities (overrides role defaults)
+    pub fn with_capabilities(mut self, capabilities: Vec<MembershipCapability>) -> Self {
+        self.capabilities = capabilities;
+        self
+    }
+
+    /// Add a capability
+    pub fn add_capability(&mut self, capability: MembershipCapability) {
+        if !self.capabilities.contains(&capability) {
+            self.capabilities.push(capability);
+        }
+    }
+
+    /// Remove a capability
+    pub fn remove_capability(&mut self, capability: &MembershipCapability) {
+        self.capabilities.retain(|c| c != capability);
+    }
+
+    /// Check if member has a specific capability
+    pub fn has_capability(&self, capability: &MembershipCapability) -> bool {
+        self.capabilities.contains(capability)
+    }
+
+    /// Check if membership is active
+    pub fn is_active(&self) -> bool {
+        matches!(self.status, MembershipStatus::Active)
+    }
+
+    /// Check if member can vote
+    pub fn can_vote(&self) -> bool {
+        self.is_active()
+            && self.shares > 0
+            && self.has_capability(&MembershipCapability::Vote)
+    }
+
+    /// Check if member can create proposals
+    pub fn can_propose(&self) -> bool {
+        self.is_active() && self.has_capability(&MembershipCapability::Propose)
+    }
+
+    /// Set notes
+    pub fn with_notes(mut self, notes: impl Into<String>) -> Self {
+        self.notes = Some(notes.into());
+        self
+    }
+}
+
+// ============================================================================
+// MembershipRole
+// ============================================================================
+
+/// Role a member has within an entity
+///
+/// Roles determine default capabilities and governance weight.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MembershipRole {
+    // ========================================
+    // Individual Roles (for individual members)
+    // ========================================
+    /// Founding member who established the cooperative
+    Founder,
+
+    /// Regular member with standard rights
+    Member,
+
+    /// Worker-owner in a worker cooperative
+    Worker,
+
+    /// Consumer member in a consumer cooperative
+    Consumer,
+
+    /// Producer member in a producer cooperative
+    Producer,
+
+    /// Elected board member
+    BoardMember,
+
+    /// Officer (president, secretary, treasurer, etc.)
+    Officer { title: String },
+
+    // ========================================
+    // Entity Roles (when member is itself an entity)
+    // ========================================
+    /// Full voting member of a federation
+    FederatedMember,
+
+    /// Associate member (may have limited voting rights)
+    AssociateMember,
+
+    /// Observer status (no voting rights, can attend meetings)
+    ObserverMember,
+
+    /// Provisional member (probationary period)
+    ProvisionalMember,
+
+    // ========================================
+    // Custom role
+    // ========================================
+    /// Custom role defined by the cooperative
+    Custom { name: String },
+}
+
+impl MembershipRole {
+    /// Get default capabilities for this role
+    pub fn default_capabilities(&self) -> Vec<MembershipCapability> {
+        match self {
+            // Founders get all capabilities
+            MembershipRole::Founder => vec![
+                MembershipCapability::Vote,
+                MembershipCapability::Propose,
+                MembershipCapability::TreasuryAccess,
+                MembershipCapability::Invite,
+                MembershipCapability::ManageSubEntities,
+                MembershipCapability::Sign,
+            ],
+
+            // Board members get most capabilities
+            MembershipRole::BoardMember => vec![
+                MembershipCapability::Vote,
+                MembershipCapability::Propose,
+                MembershipCapability::TreasuryAccess,
+                MembershipCapability::Invite,
+            ],
+
+            // Officers get capabilities based on their role
+            MembershipRole::Officer { .. } => vec![
+                MembershipCapability::Vote,
+                MembershipCapability::Propose,
+                MembershipCapability::TreasuryAccess,
+            ],
+
+            // Regular members (worker, consumer, producer, member)
+            MembershipRole::Worker
+            | MembershipRole::Consumer
+            | MembershipRole::Producer
+            | MembershipRole::Member => vec![
+                MembershipCapability::Vote,
+                MembershipCapability::Propose,
+            ],
+
+            // Federated members get full voting rights
+            MembershipRole::FederatedMember => vec![
+                MembershipCapability::Vote,
+                MembershipCapability::Propose,
+                MembershipCapability::Sign,
+            ],
+
+            // Associate members may have limited rights
+            MembershipRole::AssociateMember => vec![
+                MembershipCapability::Propose,
+            ],
+
+            // Observers have no default capabilities
+            MembershipRole::ObserverMember => vec![],
+
+            // Provisional members have limited rights
+            MembershipRole::ProvisionalMember => vec![
+                MembershipCapability::Propose,
+            ],
+
+            // Custom roles start with basic member rights
+            MembershipRole::Custom { .. } => vec![
+                MembershipCapability::Vote,
+                MembershipCapability::Propose,
+            ],
+        }
+    }
+
+    /// Check if this is an individual role
+    pub fn is_individual_role(&self) -> bool {
+        matches!(
+            self,
+            MembershipRole::Founder
+                | MembershipRole::Member
+                | MembershipRole::Worker
+                | MembershipRole::Consumer
+                | MembershipRole::Producer
+                | MembershipRole::BoardMember
+                | MembershipRole::Officer { .. }
+        )
+    }
+
+    /// Check if this is an entity/organizational role
+    pub fn is_entity_role(&self) -> bool {
+        matches!(
+            self,
+            MembershipRole::FederatedMember
+                | MembershipRole::AssociateMember
+                | MembershipRole::ObserverMember
+                | MembershipRole::ProvisionalMember
+        )
+    }
+}
+
+impl fmt::Display for MembershipRole {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MembershipRole::Founder => write!(f, "Founder"),
+            MembershipRole::Member => write!(f, "Member"),
+            MembershipRole::Worker => write!(f, "Worker"),
+            MembershipRole::Consumer => write!(f, "Consumer"),
+            MembershipRole::Producer => write!(f, "Producer"),
+            MembershipRole::BoardMember => write!(f, "Board Member"),
+            MembershipRole::Officer { title } => write!(f, "Officer ({title})"),
+            MembershipRole::FederatedMember => write!(f, "Federated Member"),
+            MembershipRole::AssociateMember => write!(f, "Associate Member"),
+            MembershipRole::ObserverMember => write!(f, "Observer"),
+            MembershipRole::ProvisionalMember => write!(f, "Provisional Member"),
+            MembershipRole::Custom { name } => write!(f, "{name}"),
+        }
+    }
+}
+
+// ============================================================================
+// MembershipStatus
+// ============================================================================
+
+/// Membership status
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MembershipStatus {
+    /// Membership application pending approval
+    Pending,
+
+    /// Active member in good standing
+    Active,
+
+    /// Membership temporarily suspended
+    Suspended,
+
+    /// Inactive member (not participating but not removed)
+    Inactive,
+
+    /// Member has voluntarily left
+    Resigned,
+
+    /// Member was removed by governance action
+    Removed,
+
+    /// Member was expelled (serious violation)
+    Expelled,
+}
+
+impl MembershipStatus {
+    /// Check if member is in good standing
+    pub fn is_good_standing(&self) -> bool {
+        matches!(self, MembershipStatus::Active)
+    }
+
+    /// Check if membership has ended
+    pub fn is_terminated(&self) -> bool {
+        matches!(
+            self,
+            MembershipStatus::Resigned
+                | MembershipStatus::Removed
+                | MembershipStatus::Expelled
+        )
+    }
+}
+
+impl fmt::Display for MembershipStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MembershipStatus::Pending => write!(f, "Pending"),
+            MembershipStatus::Active => write!(f, "Active"),
+            MembershipStatus::Suspended => write!(f, "Suspended"),
+            MembershipStatus::Inactive => write!(f, "Inactive"),
+            MembershipStatus::Resigned => write!(f, "Resigned"),
+            MembershipStatus::Removed => write!(f, "Removed"),
+            MembershipStatus::Expelled => write!(f, "Expelled"),
+        }
+    }
+}
+
+// ============================================================================
+// MembershipCapability
+// ============================================================================
+
+/// Capabilities that can be granted through membership
+///
+/// These define what actions a member can take within the entity.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MembershipCapability {
+    /// Can vote on proposals
+    Vote,
+
+    /// Can create proposals
+    Propose,
+
+    /// Can access treasury operations
+    TreasuryAccess,
+
+    /// Can invite new members
+    Invite,
+
+    /// Can manage sub-entities (for federations)
+    ManageSubEntities,
+
+    /// Can sign on behalf of entity
+    Sign,
+
+    /// Can modify entity settings
+    Configure,
+
+    /// Can view sensitive information
+    ViewSensitive,
+
+    /// Custom capability
+    Custom(String),
+}
+
+impl fmt::Display for MembershipCapability {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MembershipCapability::Vote => write!(f, "vote"),
+            MembershipCapability::Propose => write!(f, "propose"),
+            MembershipCapability::TreasuryAccess => write!(f, "treasury_access"),
+            MembershipCapability::Invite => write!(f, "invite"),
+            MembershipCapability::ManageSubEntities => write!(f, "manage_sub_entities"),
+            MembershipCapability::Sign => write!(f, "sign"),
+            MembershipCapability::Configure => write!(f, "configure"),
+            MembershipCapability::ViewSensitive => write!(f, "view_sensitive"),
+            MembershipCapability::Custom(name) => write!(f, "custom:{name}"),
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use icn_identity::KeyPair;
+
+    fn create_test_individual() -> EntityId {
+        let keypair = KeyPair::generate().unwrap();
+        EntityId::from_did(keypair.did())
+    }
+
+    fn create_test_coop() -> EntityId {
+        EntityId::cooperative("test-coop").unwrap()
+    }
+
+    #[test]
+    fn test_membership_creation() {
+        let member = create_test_individual();
+        let coop = create_test_coop();
+
+        let membership = Membership::new(member.clone(), coop.clone(), MembershipRole::Worker);
+
+        assert_eq!(membership.member_id, member);
+        assert_eq!(membership.parent_id, coop);
+        assert!(matches!(membership.status, MembershipStatus::Pending));
+        assert_eq!(membership.shares, 1);
+    }
+
+    #[test]
+    fn test_membership_active() {
+        let member = create_test_individual();
+        let coop = create_test_coop();
+
+        let membership = Membership::active(member, coop, MembershipRole::Worker);
+
+        assert!(membership.is_active());
+        assert!(membership.can_vote());
+        assert!(membership.can_propose());
+    }
+
+    #[test]
+    fn test_founder_capabilities() {
+        let member = create_test_individual();
+        let coop = create_test_coop();
+
+        let membership = Membership::active(member, coop, MembershipRole::Founder);
+
+        assert!(membership.has_capability(&MembershipCapability::Vote));
+        assert!(membership.has_capability(&MembershipCapability::TreasuryAccess));
+        assert!(membership.has_capability(&MembershipCapability::Invite));
+        assert!(membership.has_capability(&MembershipCapability::Sign));
+    }
+
+    #[test]
+    fn test_observer_no_vote() {
+        let member_coop = EntityId::cooperative("member-coop").unwrap();
+        let federation = EntityId::federation("fed").unwrap();
+
+        let membership = Membership::active(member_coop, federation, MembershipRole::ObserverMember);
+
+        // Observers have no shares by default but we gave them 1
+        // They don't have Vote capability
+        assert!(!membership.has_capability(&MembershipCapability::Vote));
+        assert!(!membership.can_vote());
+    }
+
+    #[test]
+    fn test_federated_membership() {
+        let member_coop = EntityId::cooperative("member-coop").unwrap();
+        let federation = EntityId::federation("midwest-fed").unwrap();
+
+        let membership = Membership::active(
+            member_coop.clone(),
+            federation.clone(),
+            MembershipRole::FederatedMember,
+        );
+
+        assert!(membership.is_active());
+        assert!(membership.can_vote());
+        assert!(membership.has_capability(&MembershipCapability::Sign));
+    }
+
+    #[test]
+    fn test_custom_capabilities() {
+        let member = create_test_individual();
+        let coop = create_test_coop();
+
+        let membership = Membership::active(member, coop, MembershipRole::Member)
+            .with_capabilities(vec![MembershipCapability::Vote]);
+
+        assert!(membership.has_capability(&MembershipCapability::Vote));
+        assert!(!membership.has_capability(&MembershipCapability::Propose));
+    }
+
+    #[test]
+    fn test_shares_affect_voting() {
+        let member = create_test_individual();
+        let coop = create_test_coop();
+
+        let no_shares = Membership::active(member.clone(), coop.clone(), MembershipRole::Member)
+            .with_shares(0);
+        let with_shares = Membership::active(member, coop, MembershipRole::Member)
+            .with_shares(10);
+
+        assert!(!no_shares.can_vote()); // 0 shares = no vote
+        assert!(with_shares.can_vote());
+        assert_eq!(with_shares.shares, 10);
+    }
+
+    #[test]
+    fn test_membership_serialization() {
+        let member = create_test_individual();
+        let coop = create_test_coop();
+        let membership = Membership::active(member, coop, MembershipRole::Worker);
+
+        let json = serde_json::to_string(&membership).unwrap();
+        let parsed: Membership = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(membership.member_id, parsed.member_id);
+        assert_eq!(membership.role, parsed.role);
+    }
+
+    #[test]
+    fn test_role_display() {
+        assert_eq!(MembershipRole::Founder.to_string(), "Founder");
+        assert_eq!(MembershipRole::Worker.to_string(), "Worker");
+        assert_eq!(
+            MembershipRole::Officer { title: "President".into() }.to_string(),
+            "Officer (President)"
+        );
+    }
+}

--- a/icn/crates/icn-entity/src/membership.rs
+++ b/icn/crates/icn-entity/src/membership.rs
@@ -460,7 +460,7 @@ mod tests {
     #[test]
     fn test_observer_no_vote() {
         let member_coop = EntityId::cooperative("member-coop").unwrap();
-        let federation = EntityId::federation("fed").unwrap();
+        let federation = EntityId::federation("test-fed").unwrap();
 
         let membership =
             Membership::active(member_coop, federation, MembershipRole::ObserverMember);

--- a/icn/crates/icn-entity/src/membership.rs
+++ b/icn/crates/icn-entity/src/membership.rs
@@ -88,15 +88,24 @@ impl Membership {
     }
 
     /// Add a capability
+    ///
+    /// Updates `updated_at` timestamp for audit trail accuracy.
     pub fn add_capability(&mut self, capability: MembershipCapability) {
         if !self.capabilities.contains(&capability) {
             self.capabilities.push(capability);
+            self.updated_at = icn_time::current_timestamp_secs();
         }
     }
 
     /// Remove a capability
+    ///
+    /// Updates `updated_at` timestamp for audit trail accuracy.
     pub fn remove_capability(&mut self, capability: &MembershipCapability) {
+        let before_len = self.capabilities.len();
         self.capabilities.retain(|c| c != capability);
+        if self.capabilities.len() != before_len {
+            self.updated_at = icn_time::current_timestamp_secs();
+        }
     }
 
     /// Check if member has a specific capability
@@ -536,6 +545,49 @@ mod tests {
             }
             .to_string(),
             "Officer (President)"
+        );
+    }
+
+    #[test]
+    fn test_capability_modification_updates_timestamp() {
+        let member = create_test_individual();
+        let coop = create_test_coop();
+        let mut membership = Membership::active(member, coop, MembershipRole::Member);
+        let original_updated_at = membership.updated_at;
+
+        // Wait a tiny bit to ensure timestamp changes
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        // Add a capability - should update timestamp
+        membership.add_capability(MembershipCapability::TreasuryAccess);
+        assert!(
+            membership.updated_at >= original_updated_at,
+            "updated_at should be updated on add_capability()"
+        );
+
+        let after_add = membership.updated_at;
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        // Remove a capability - should update timestamp
+        membership.remove_capability(&MembershipCapability::TreasuryAccess);
+        assert!(
+            membership.updated_at >= after_add,
+            "updated_at should be updated on remove_capability()"
+        );
+
+        // Adding duplicate should not update timestamp
+        let before_noop = membership.updated_at;
+        membership.add_capability(MembershipCapability::Vote); // Already has Vote
+        assert_eq!(
+            membership.updated_at, before_noop,
+            "updated_at should not change when adding duplicate capability"
+        );
+
+        // Removing non-existent should not update timestamp
+        membership.remove_capability(&MembershipCapability::TreasuryAccess); // Already removed
+        assert_eq!(
+            membership.updated_at, before_noop,
+            "updated_at should not change when removing non-existent capability"
         );
     }
 }

--- a/icn/crates/icn-entity/src/membership.rs
+++ b/icn/crates/icn-entity/src/membership.rs
@@ -465,8 +465,8 @@ mod tests {
         let membership =
             Membership::active(member_coop, federation, MembershipRole::ObserverMember);
 
-        // Observers have no shares by default but we gave them 1
-        // They don't have Vote capability
+        // Observers receive the default 1 share like other members,
+        // but their role does not include the Vote capability, so can_vote() is false
         assert!(!membership.has_capability(&MembershipCapability::Vote));
         assert!(!membership.can_vote());
     }

--- a/icn/crates/icn-entity/src/registry.rs
+++ b/icn/crates/icn-entity/src/registry.rs
@@ -605,7 +605,7 @@ mod tests {
         // Register some entities
         for i in 0..10 {
             let entity =
-                CooperativeEntity::cooperative(&format!("coop-{i:03}"), &format!("Coop {i}"))
+                CooperativeEntity::cooperative(&format!("coop-{i:03}"), format!("Coop {i}"))
                     .unwrap();
             handle.register(entity).await.unwrap();
         }
@@ -640,7 +640,7 @@ mod tests {
             let h = Arc::clone(&handle);
             tasks.push(tokio::spawn(async move {
                 let entity =
-                    CooperativeEntity::cooperative(&format!("coop-{i:03}"), &format!("Coop {i}"))
+                    CooperativeEntity::cooperative(&format!("coop-{i:03}"), format!("Coop {i}"))
                         .unwrap();
                 h.register(entity).await
             }));

--- a/icn/crates/icn-entity/src/registry.rs
+++ b/icn/crates/icn-entity/src/registry.rs
@@ -212,14 +212,37 @@ impl EntityRegistry for InMemoryRegistry {
         let parent_str = membership.parent_id.as_str();
 
         // Verify both entities exist
-        if !self.entities.contains_key(member_str) {
+        let member_entity = self.entities.get(member_str).ok_or_else(|| {
+            EntityError::MembershipError(format!("Member entity not found: {member_str}"))
+        })?;
+        let parent_entity = self.entities.get(parent_str).ok_or_else(|| {
+            EntityError::MembershipError(format!("Parent entity not found: {parent_str}"))
+        })?;
+
+        // Validate entity type relationships:
+        // - Individuals can join Cooperatives or Federations
+        // - Cooperatives can join Federations
+        // - Federations can join Federations (recursive)
+        // - Nothing can join an Individual
+        let valid_relationship = match (&parent_entity.entity_type, &member_entity.entity_type) {
+            // Cooperatives accept individuals
+            (EntityType::Cooperative, EntityType::Individual) => true,
+            // Federations accept individuals, cooperatives, and other federations
+            (EntityType::Federation, EntityType::Individual) => true,
+            (EntityType::Federation, EntityType::Cooperative) => true,
+            (EntityType::Federation, EntityType::Federation) => true,
+            // Individuals cannot have members
+            (EntityType::Individual, _) => false,
+            // Unknown types - reject for safety
+            (EntityType::Unknown, _) | (_, EntityType::Unknown) => false,
+            // Other combinations are invalid
+            _ => false,
+        };
+
+        if !valid_relationship {
             return Err(EntityError::MembershipError(format!(
-                "Member entity not found: {member_str}"
-            )));
-        }
-        if !self.entities.contains_key(parent_str) {
-            return Err(EntityError::MembershipError(format!(
-                "Parent entity not found: {parent_str}"
+                "Invalid membership: {:?} cannot be a member of {:?}",
+                member_entity.entity_type, parent_entity.entity_type
             )));
         }
 
@@ -502,6 +525,58 @@ mod tests {
         // Try to delete coop with active member
         let result = registry.delete(&coop_id);
         assert!(matches!(result, Err(EntityError::RegistryError(_))));
+    }
+
+    #[test]
+    fn test_invalid_membership_relationships() {
+        let mut registry = InMemoryRegistry::new();
+
+        // Create entities
+        let individual = create_test_individual();
+        let individual_id = individual.id.clone();
+        registry.register(individual).unwrap();
+
+        let coop = create_test_coop();
+        let coop_id = coop.id.clone();
+        registry.register(coop).unwrap();
+
+        let fed = CooperativeEntity::federation("test-fed", "Test Federation").unwrap();
+        let fed_id = fed.id.clone();
+        registry.register(fed).unwrap();
+
+        // Valid: Individual joins Cooperative
+        let membership = Membership::active(
+            individual_id.clone(),
+            coop_id.clone(),
+            MembershipRole::Worker,
+        );
+        assert!(registry.add_membership(membership).is_ok());
+
+        // Valid: Cooperative joins Federation
+        let membership = Membership::active(
+            coop_id.clone(),
+            fed_id.clone(),
+            MembershipRole::FederatedMember,
+        );
+        assert!(registry.add_membership(membership).is_ok());
+
+        // Invalid: Cooperative cannot be member of Individual
+        let individual2 = create_test_individual();
+        let individual2_id = individual2.id.clone();
+        registry.register(individual2).unwrap();
+
+        let invalid = Membership::active(coop_id.clone(), individual2_id, MembershipRole::Member);
+        let result = registry.add_membership(invalid);
+        assert!(matches!(result, Err(EntityError::MembershipError(_))));
+
+        // Invalid: Federation cannot be member of Cooperative
+        let fed2 = CooperativeEntity::federation("test-fed-2", "Test Federation 2").unwrap();
+        let fed2_id = fed2.id.clone();
+        registry.register(fed2).unwrap();
+
+        let invalid = Membership::active(fed2_id, coop_id, MembershipRole::FederatedMember);
+        let result = registry.add_membership(invalid);
+        assert!(matches!(result, Err(EntityError::MembershipError(_))));
     }
 
     #[tokio::test]

--- a/icn/crates/icn-entity/src/registry.rs
+++ b/icn/crates/icn-entity/src/registry.rs
@@ -135,11 +135,13 @@ impl EntityRegistry for InMemoryRegistry {
         Ok(self.entities.get(id.as_str()).cloned())
     }
 
-    fn update(&mut self, entity: CooperativeEntity) -> Result<()> {
+    fn update(&mut self, mut entity: CooperativeEntity) -> Result<()> {
         let id = entity.id.as_str().to_string();
         if !self.entities.contains_key(&id) {
             return Err(EntityError::NotFound(id));
         }
+        // Auto-update the updated_at timestamp for audit trail accuracy
+        entity.updated_at = icn_time::current_timestamp_secs();
         self.entities.insert(id, entity);
         Ok(())
     }
@@ -591,5 +593,90 @@ mod tests {
 
         assert!(handle.exists(&id).await.unwrap());
         assert_eq!(handle.count().await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_handle_concurrent_reads() {
+        use std::sync::Arc;
+
+        let registry = InMemoryRegistry::new();
+        let handle = Arc::new(registry.into_handle());
+
+        // Register some entities
+        for i in 0..10 {
+            let entity =
+                CooperativeEntity::cooperative(&format!("coop-{i:03}"), &format!("Coop {i}"))
+                    .unwrap();
+            handle.register(entity).await.unwrap();
+        }
+
+        // Spawn multiple concurrent read tasks
+        let mut tasks = Vec::new();
+        for _ in 0..10 {
+            let h = Arc::clone(&handle);
+            tasks.push(tokio::spawn(async move {
+                // Each task reads all entities
+                h.count().await.unwrap()
+            }));
+        }
+
+        // All tasks should succeed and see the same count
+        for task in tasks {
+            let count = task.await.unwrap();
+            assert_eq!(count, 10);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_concurrent_writes() {
+        use std::sync::Arc;
+
+        let registry = InMemoryRegistry::new();
+        let handle = Arc::new(registry.into_handle());
+
+        // Spawn multiple concurrent write tasks
+        let mut tasks = Vec::new();
+        for i in 0..10 {
+            let h = Arc::clone(&handle);
+            tasks.push(tokio::spawn(async move {
+                let entity =
+                    CooperativeEntity::cooperative(&format!("coop-{i:03}"), &format!("Coop {i}"))
+                        .unwrap();
+                h.register(entity).await
+            }));
+        }
+
+        // All tasks should succeed
+        for task in tasks {
+            task.await.unwrap().unwrap();
+        }
+
+        // Should have all 10 entities
+        assert_eq!(handle.count().await.unwrap(), 10);
+    }
+
+    #[test]
+    fn test_update_auto_updates_timestamp() {
+        let mut registry = InMemoryRegistry::new();
+        let entity = create_test_coop();
+        let id = entity.id.clone();
+        let original_updated_at = entity.updated_at;
+
+        registry.register(entity.clone()).unwrap();
+
+        // Wait a tiny bit to ensure timestamp changes
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        // Update the entity
+        let mut updated_entity = entity.clone();
+        updated_entity.name = "Updated Name".to_string();
+        registry.update(updated_entity).unwrap();
+
+        // Verify updated_at was auto-updated
+        let retrieved = registry.get(&id).unwrap().unwrap();
+        assert!(
+            retrieved.updated_at >= original_updated_at,
+            "updated_at should be updated on registry.update()"
+        );
     }
 }

--- a/icn/crates/icn-entity/src/registry.rs
+++ b/icn/crates/icn-entity/src/registry.rs
@@ -70,8 +70,11 @@ pub trait EntityRegistry: Send + Sync {
     fn add_membership(&mut self, membership: Membership) -> Result<()>;
 
     /// Get a specific membership
-    fn get_membership(&self, member_id: &EntityId, parent_id: &EntityId)
-        -> Result<Option<Membership>>;
+    fn get_membership(
+        &self,
+        member_id: &EntityId,
+        parent_id: &EntityId,
+    ) -> Result<Option<Membership>>;
 
     /// Get all memberships for an entity (where it's a member)
     fn get_memberships_of(&self, member_id: &EntityId) -> Result<Vec<Membership>>;
@@ -144,11 +147,8 @@ impl EntityRegistry for InMemoryRegistry {
     fn delete(&mut self, id: &EntityId) -> Result<()> {
         let id_str = id.as_str().to_string();
 
-        // Check if entity has members
-        let has_members = self
-            .memberships
-            .keys()
-            .any(|(_, parent)| parent == &id_str);
+        // Check if entity has members (is a parent)
+        let has_members = self.memberships.keys().any(|(_, parent)| parent == &id_str);
         if has_members {
             return Err(EntityError::RegistryError(
                 "Cannot delete entity with active members".into(),
@@ -158,6 +158,10 @@ impl EntityRegistry for InMemoryRegistry {
         if self.entities.remove(&id_str).is_none() {
             return Err(EntityError::NotFound(id_str));
         }
+
+        // Remove any memberships where this entity is a member
+        self.memberships.retain(|(member, _), _| member != &id_str);
+
         Ok(())
     }
 
@@ -193,7 +197,10 @@ impl EntityRegistry for InMemoryRegistry {
     }
 
     fn get_parent(&self, entity_id: &EntityId) -> Result<Option<EntityId>> {
-        Ok(self.entities.get(entity_id.as_str()).and_then(|e| e.parent_id.clone()))
+        Ok(self
+            .entities
+            .get(entity_id.as_str())
+            .and_then(|e| e.parent_id.clone()))
     }
 
     fn count(&self) -> Result<usize> {
@@ -201,10 +208,22 @@ impl EntityRegistry for InMemoryRegistry {
     }
 
     fn add_membership(&mut self, membership: Membership) -> Result<()> {
-        let key = (
-            membership.member_id.as_str().to_string(),
-            membership.parent_id.as_str().to_string(),
-        );
+        let member_str = membership.member_id.as_str();
+        let parent_str = membership.parent_id.as_str();
+
+        // Verify both entities exist
+        if !self.entities.contains_key(member_str) {
+            return Err(EntityError::MembershipError(format!(
+                "Member entity not found: {member_str}"
+            )));
+        }
+        if !self.entities.contains_key(parent_str) {
+            return Err(EntityError::MembershipError(format!(
+                "Parent entity not found: {parent_str}"
+            )));
+        }
+
+        let key = (member_str.to_string(), parent_str.to_string());
 
         // Check membership doesn't already exist
         if self.memberships.contains_key(&key) {
@@ -213,7 +232,6 @@ impl EntityRegistry for InMemoryRegistry {
             ));
         }
 
-        // Optionally verify entities exist (skip for flexibility in testing)
         self.memberships.insert(key, membership);
         Ok(())
     }
@@ -257,9 +275,7 @@ impl EntityRegistry for InMemoryRegistry {
         );
 
         if !self.memberships.contains_key(&key) {
-            return Err(EntityError::MembershipError(
-                "Membership not found".into(),
-            ));
+            return Err(EntityError::MembershipError("Membership not found".into()));
         }
 
         self.memberships.insert(key, membership);
@@ -273,9 +289,7 @@ impl EntityRegistry for InMemoryRegistry {
         );
 
         if self.memberships.remove(&key).is_none() {
-            return Err(EntityError::MembershipError(
-                "Membership not found".into(),
-            ));
+            return Err(EntityError::MembershipError("Membership not found".into()));
         }
         Ok(())
     }
@@ -358,6 +372,7 @@ impl EntityRegistryHandle {
 // ============================================================================
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::membership::MembershipRole;

--- a/icn/crates/icn-entity/src/registry.rs
+++ b/icn/crates/icn-entity/src/registry.rs
@@ -1,0 +1,505 @@
+//! Entity registry trait and in-memory implementation
+//!
+//! The registry provides storage and lookup for entities and memberships.
+//! This module defines the trait interface and a simple in-memory implementation
+//! for testing.
+
+use crate::entity::{CooperativeEntity, EntityId, EntityType};
+use crate::error::{EntityError, Result};
+use crate::membership::Membership;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+// ============================================================================
+// EntityRegistry Trait
+// ============================================================================
+
+/// Registry for entity storage and lookup
+///
+/// This trait defines the interface for entity persistence.
+/// Implementations can be:
+/// - In-memory (for testing)
+/// - Persistent (sled-backed, for production)
+/// - Actor-backed (delegating to an actor system)
+pub trait EntityRegistry: Send + Sync {
+    // ========================================
+    // Entity Operations
+    // ========================================
+
+    /// Register a new entity
+    ///
+    /// Returns error if entity with same ID already exists.
+    fn register(&mut self, entity: CooperativeEntity) -> Result<()>;
+
+    /// Get an entity by ID
+    fn get(&self, id: &EntityId) -> Result<Option<CooperativeEntity>>;
+
+    /// Update an existing entity
+    ///
+    /// Returns error if entity does not exist.
+    fn update(&mut self, entity: CooperativeEntity) -> Result<()>;
+
+    /// Delete an entity
+    ///
+    /// Returns error if entity has active members.
+    fn delete(&mut self, id: &EntityId) -> Result<()>;
+
+    /// Check if entity exists
+    fn exists(&self, id: &EntityId) -> Result<bool>;
+
+    /// List all entities of a given type
+    fn list_by_type(&self, entity_type: EntityType) -> Result<Vec<EntityId>>;
+
+    /// List child entities (direct members that are themselves entities)
+    fn list_children(&self, parent_id: &EntityId) -> Result<Vec<EntityId>>;
+
+    /// Get the parent entity (if any)
+    fn get_parent(&self, entity_id: &EntityId) -> Result<Option<EntityId>>;
+
+    /// Count total entities
+    fn count(&self) -> Result<usize>;
+
+    // ========================================
+    // Membership Operations
+    // ========================================
+
+    /// Add a membership record
+    ///
+    /// Returns error if membership already exists or entities don't exist.
+    fn add_membership(&mut self, membership: Membership) -> Result<()>;
+
+    /// Get a specific membership
+    fn get_membership(&self, member_id: &EntityId, parent_id: &EntityId)
+        -> Result<Option<Membership>>;
+
+    /// Get all memberships for an entity (where it's a member)
+    fn get_memberships_of(&self, member_id: &EntityId) -> Result<Vec<Membership>>;
+
+    /// Get all members of an entity
+    fn get_members(&self, parent_id: &EntityId) -> Result<Vec<Membership>>;
+
+    /// Update membership status/role
+    fn update_membership(&mut self, membership: Membership) -> Result<()>;
+
+    /// Remove membership
+    fn remove_membership(&mut self, member_id: &EntityId, parent_id: &EntityId) -> Result<()>;
+
+    /// Count members of an entity
+    fn member_count(&self, parent_id: &EntityId) -> Result<usize>;
+}
+
+// ============================================================================
+// InMemoryRegistry
+// ============================================================================
+
+/// In-memory implementation of EntityRegistry for testing
+///
+/// This implementation stores all data in memory and is not persistent.
+/// Use this for unit tests and development only.
+#[derive(Debug, Default)]
+pub struct InMemoryRegistry {
+    /// Entity storage: EntityId -> CooperativeEntity
+    entities: HashMap<String, CooperativeEntity>,
+
+    /// Membership storage: (member_id, parent_id) -> Membership
+    memberships: HashMap<(String, String), Membership>,
+}
+
+impl InMemoryRegistry {
+    /// Create a new empty registry
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Get a handle for async access
+    pub fn into_handle(self) -> EntityRegistryHandle {
+        EntityRegistryHandle::new(self)
+    }
+}
+
+impl EntityRegistry for InMemoryRegistry {
+    fn register(&mut self, entity: CooperativeEntity) -> Result<()> {
+        let id = entity.id.as_str().to_string();
+        if self.entities.contains_key(&id) {
+            return Err(EntityError::AlreadyExists(id));
+        }
+        self.entities.insert(id, entity);
+        Ok(())
+    }
+
+    fn get(&self, id: &EntityId) -> Result<Option<CooperativeEntity>> {
+        Ok(self.entities.get(id.as_str()).cloned())
+    }
+
+    fn update(&mut self, entity: CooperativeEntity) -> Result<()> {
+        let id = entity.id.as_str().to_string();
+        if !self.entities.contains_key(&id) {
+            return Err(EntityError::NotFound(id));
+        }
+        self.entities.insert(id, entity);
+        Ok(())
+    }
+
+    fn delete(&mut self, id: &EntityId) -> Result<()> {
+        let id_str = id.as_str().to_string();
+
+        // Check if entity has members
+        let has_members = self
+            .memberships
+            .keys()
+            .any(|(_, parent)| parent == &id_str);
+        if has_members {
+            return Err(EntityError::RegistryError(
+                "Cannot delete entity with active members".into(),
+            ));
+        }
+
+        if self.entities.remove(&id_str).is_none() {
+            return Err(EntityError::NotFound(id_str));
+        }
+        Ok(())
+    }
+
+    fn exists(&self, id: &EntityId) -> Result<bool> {
+        Ok(self.entities.contains_key(id.as_str()))
+    }
+
+    fn list_by_type(&self, entity_type: EntityType) -> Result<Vec<EntityId>> {
+        Ok(self
+            .entities
+            .values()
+            .filter(|e| e.entity_type == entity_type)
+            .map(|e| e.id.clone())
+            .collect())
+    }
+
+    fn list_children(&self, parent_id: &EntityId) -> Result<Vec<EntityId>> {
+        let parent_str = parent_id.as_str();
+        Ok(self
+            .memberships
+            .iter()
+            .filter(|((_, parent), _)| parent == parent_str)
+            .filter_map(|((member, _), _)| {
+                self.entities.get(member).and_then(|e| {
+                    if e.id.is_organization() {
+                        Some(e.id.clone())
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect())
+    }
+
+    fn get_parent(&self, entity_id: &EntityId) -> Result<Option<EntityId>> {
+        Ok(self.entities.get(entity_id.as_str()).and_then(|e| e.parent_id.clone()))
+    }
+
+    fn count(&self) -> Result<usize> {
+        Ok(self.entities.len())
+    }
+
+    fn add_membership(&mut self, membership: Membership) -> Result<()> {
+        let key = (
+            membership.member_id.as_str().to_string(),
+            membership.parent_id.as_str().to_string(),
+        );
+
+        // Check membership doesn't already exist
+        if self.memberships.contains_key(&key) {
+            return Err(EntityError::MembershipError(
+                "Membership already exists".into(),
+            ));
+        }
+
+        // Optionally verify entities exist (skip for flexibility in testing)
+        self.memberships.insert(key, membership);
+        Ok(())
+    }
+
+    fn get_membership(
+        &self,
+        member_id: &EntityId,
+        parent_id: &EntityId,
+    ) -> Result<Option<Membership>> {
+        let key = (
+            member_id.as_str().to_string(),
+            parent_id.as_str().to_string(),
+        );
+        Ok(self.memberships.get(&key).cloned())
+    }
+
+    fn get_memberships_of(&self, member_id: &EntityId) -> Result<Vec<Membership>> {
+        let member_str = member_id.as_str();
+        Ok(self
+            .memberships
+            .iter()
+            .filter(|((member, _), _)| member == member_str)
+            .map(|(_, m)| m.clone())
+            .collect())
+    }
+
+    fn get_members(&self, parent_id: &EntityId) -> Result<Vec<Membership>> {
+        let parent_str = parent_id.as_str();
+        Ok(self
+            .memberships
+            .iter()
+            .filter(|((_, parent), _)| parent == parent_str)
+            .map(|(_, m)| m.clone())
+            .collect())
+    }
+
+    fn update_membership(&mut self, membership: Membership) -> Result<()> {
+        let key = (
+            membership.member_id.as_str().to_string(),
+            membership.parent_id.as_str().to_string(),
+        );
+
+        if !self.memberships.contains_key(&key) {
+            return Err(EntityError::MembershipError(
+                "Membership not found".into(),
+            ));
+        }
+
+        self.memberships.insert(key, membership);
+        Ok(())
+    }
+
+    fn remove_membership(&mut self, member_id: &EntityId, parent_id: &EntityId) -> Result<()> {
+        let key = (
+            member_id.as_str().to_string(),
+            parent_id.as_str().to_string(),
+        );
+
+        if self.memberships.remove(&key).is_none() {
+            return Err(EntityError::MembershipError(
+                "Membership not found".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn member_count(&self, parent_id: &EntityId) -> Result<usize> {
+        let parent_str = parent_id.as_str();
+        Ok(self
+            .memberships
+            .keys()
+            .filter(|(_, parent)| parent == parent_str)
+            .count())
+    }
+}
+
+// ============================================================================
+// EntityRegistryHandle
+// ============================================================================
+
+/// Handle for async access to an entity registry
+///
+/// Wraps a registry in an Arc<RwLock> for thread-safe async access.
+#[derive(Clone)]
+pub struct EntityRegistryHandle {
+    inner: Arc<RwLock<InMemoryRegistry>>,
+}
+
+impl EntityRegistryHandle {
+    /// Create a new handle wrapping a registry
+    pub fn new(registry: InMemoryRegistry) -> Self {
+        EntityRegistryHandle {
+            inner: Arc::new(RwLock::new(registry)),
+        }
+    }
+
+    /// Register a new entity
+    pub async fn register(&self, entity: CooperativeEntity) -> Result<()> {
+        let mut registry = self.inner.write().await;
+        registry.register(entity)
+    }
+
+    /// Get an entity by ID
+    pub async fn get(&self, id: &EntityId) -> Result<Option<CooperativeEntity>> {
+        let registry = self.inner.read().await;
+        registry.get(id)
+    }
+
+    /// Update an existing entity
+    pub async fn update(&self, entity: CooperativeEntity) -> Result<()> {
+        let mut registry = self.inner.write().await;
+        registry.update(entity)
+    }
+
+    /// Check if entity exists
+    pub async fn exists(&self, id: &EntityId) -> Result<bool> {
+        let registry = self.inner.read().await;
+        registry.exists(id)
+    }
+
+    /// Get all members of an entity
+    pub async fn get_members(&self, parent_id: &EntityId) -> Result<Vec<Membership>> {
+        let registry = self.inner.read().await;
+        registry.get_members(parent_id)
+    }
+
+    /// Add a membership
+    pub async fn add_membership(&self, membership: Membership) -> Result<()> {
+        let mut registry = self.inner.write().await;
+        registry.add_membership(membership)
+    }
+
+    /// Get count of entities
+    pub async fn count(&self) -> Result<usize> {
+        let registry = self.inner.read().await;
+        registry.count()
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::membership::MembershipRole;
+    use icn_identity::KeyPair;
+
+    fn create_test_individual() -> CooperativeEntity {
+        let keypair = KeyPair::generate().unwrap();
+        CooperativeEntity::individual(keypair.did(), "Alice")
+    }
+
+    fn create_test_coop() -> CooperativeEntity {
+        CooperativeEntity::cooperative("test-coop", "Test Cooperative").unwrap()
+    }
+
+    #[test]
+    fn test_register_and_get() {
+        let mut registry = InMemoryRegistry::new();
+        let entity = create_test_coop();
+        let id = entity.id.clone();
+
+        registry.register(entity.clone()).unwrap();
+
+        let retrieved = registry.get(&id).unwrap().unwrap();
+        assert_eq!(retrieved.name, entity.name);
+    }
+
+    #[test]
+    fn test_duplicate_register_fails() {
+        let mut registry = InMemoryRegistry::new();
+        let entity = create_test_coop();
+
+        registry.register(entity.clone()).unwrap();
+        let result = registry.register(entity);
+
+        assert!(matches!(result, Err(EntityError::AlreadyExists(_))));
+    }
+
+    #[test]
+    fn test_update() {
+        let mut registry = InMemoryRegistry::new();
+        let mut entity = create_test_coop();
+        let id = entity.id.clone();
+
+        registry.register(entity.clone()).unwrap();
+
+        entity.name = "Updated Name".to_string();
+        registry.update(entity).unwrap();
+
+        let retrieved = registry.get(&id).unwrap().unwrap();
+        assert_eq!(retrieved.name, "Updated Name");
+    }
+
+    #[test]
+    fn test_update_nonexistent_fails() {
+        let mut registry = InMemoryRegistry::new();
+        let entity = create_test_coop();
+
+        let result = registry.update(entity);
+        assert!(matches!(result, Err(EntityError::NotFound(_))));
+    }
+
+    #[test]
+    fn test_list_by_type() {
+        let mut registry = InMemoryRegistry::new();
+
+        let coop = create_test_coop();
+        let individual = create_test_individual();
+
+        registry.register(coop).unwrap();
+        registry.register(individual).unwrap();
+
+        let coops = registry.list_by_type(EntityType::Cooperative).unwrap();
+        let individuals = registry.list_by_type(EntityType::Individual).unwrap();
+
+        assert_eq!(coops.len(), 1);
+        assert_eq!(individuals.len(), 1);
+    }
+
+    #[test]
+    fn test_membership() {
+        let mut registry = InMemoryRegistry::new();
+
+        let coop = create_test_coop();
+        let coop_id = coop.id.clone();
+        registry.register(coop).unwrap();
+
+        let individual = create_test_individual();
+        let individual_id = individual.id.clone();
+        registry.register(individual).unwrap();
+
+        let membership = Membership::active(
+            individual_id.clone(),
+            coop_id.clone(),
+            MembershipRole::Worker,
+        );
+        registry.add_membership(membership).unwrap();
+
+        // Check member count
+        assert_eq!(registry.member_count(&coop_id).unwrap(), 1);
+
+        // Get members
+        let members = registry.get_members(&coop_id).unwrap();
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0].member_id, individual_id);
+
+        // Get memberships of individual
+        let memberships = registry.get_memberships_of(&individual_id).unwrap();
+        assert_eq!(memberships.len(), 1);
+        assert_eq!(memberships[0].parent_id, coop_id);
+    }
+
+    #[test]
+    fn test_delete_with_members_fails() {
+        let mut registry = InMemoryRegistry::new();
+
+        let coop = create_test_coop();
+        let coop_id = coop.id.clone();
+        registry.register(coop).unwrap();
+
+        let individual = create_test_individual();
+        let individual_id = individual.id.clone();
+        registry.register(individual).unwrap();
+
+        let membership = Membership::active(individual_id, coop_id.clone(), MembershipRole::Worker);
+        registry.add_membership(membership).unwrap();
+
+        // Try to delete coop with active member
+        let result = registry.delete(&coop_id);
+        assert!(matches!(result, Err(EntityError::RegistryError(_))));
+    }
+
+    #[tokio::test]
+    async fn test_handle_async_operations() {
+        let registry = InMemoryRegistry::new();
+        let handle = registry.into_handle();
+
+        let entity = create_test_coop();
+        let id = entity.id.clone();
+
+        handle.register(entity).await.unwrap();
+
+        assert!(handle.exists(&id).await.unwrap());
+        assert_eq!(handle.count().await.unwrap(), 1);
+    }
+}


### PR DESCRIPTION
## Summary

Introduces the `icn-entity` crate with a recursive entity abstraction for all organizational structures in ICN. This is Phase 19 prep work - type definitions only, no integration yet.

### Key Components

- **EntityId**: Format `entity:icn:<type>:<identifier>` with DID interop
- **CooperativeEntity**: Core entity record with lifecycle status
- **Membership**: Recursive membership model (individuals OR cooperatives as members)
- **EntityRegistry**: Storage trait with InMemoryRegistry implementation
- **LifecycleEvent**: State transition events with audit trail

### Design Decisions

| Decision | Choice |
|----------|--------|
| EntityId format | `entity:icn:<type>:<id>` for type-level distinction |
| DID interop | `from_did()`/`to_did()` for individuals |
| Capabilities | Explicit (not derived from roles) |
| Config embedding | Linked via IDs, not embedded |

### Files Changed

| File | Description |
|------|-------------|
| `icn/crates/icn-entity/src/entity.rs` | EntityId, EntityType, CooperativeEntity, EntityStatus, AccountId |
| `icn/crates/icn-entity/src/membership.rs` | Membership, MembershipRole, MembershipCapability, MembershipStatus |
| `icn/crates/icn-entity/src/registry.rs` | EntityRegistry trait, InMemoryRegistry, EntityRegistryHandle |
| `icn/crates/icn-entity/src/lifecycle.rs` | LifecycleEvent, EntityLifecycle trait |
| `icn/crates/icn-entity/src/error.rs` | EntityError |
| `docs/dev-journal/COOPERATIVE_ENTITY_SPEC.md` | Updated spec to reflect implementation |

## Test plan

- [x] 32 unit tests passing
- [x] clippy clean
- [x] EntityId round-trips through serialization
- [x] EntityId::from_did() / to_did() works correctly
- [x] Membership capability checks work

```bash
cargo test -p icn-entity
cargo clippy -p icn-entity -- -D warnings
```

## What's Next (Phase 19)

1. Integrate with icn-ledger (AccountId)
2. Integrate with icn-governance (entity domains)
3. Add entity actor to runtime
4. Add gateway entity endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)