### PR TITLE
feat(governance): Milestone 2 - Delegation cycle detection improvements

### DIFF
--- a/icn/crates/icn-core/src/governance/actor.rs
+++ b/icn/crates/icn-core/src/governance/actor.rs
@@ -1320,6 +1320,10 @@ impl GovernanceActor {
     }
 
     /// Check if two delegation scopes overlap (for cycle detection)
+    ///
+    /// For Domain/Proposal combinations, we look up the proposal to get its domain
+    /// and check for precise overlap. Falls back to conservative (assume overlap)
+    /// if proposal lookup fails.
     fn scopes_overlap(
         &self,
         a: &icn_governance::DelegationScope,
@@ -1330,9 +1334,15 @@ impl GovernanceActor {
         match (a, b) {
             (DelegationScope::Blanket, _) | (_, DelegationScope::Blanket) => true,
             (DelegationScope::Domain(d1), DelegationScope::Domain(d2)) => d1 == d2,
-            // Conservative: assume overlap for Domain/Proposal combinations
-            (DelegationScope::Domain(_), DelegationScope::Proposal(_))
-            | (DelegationScope::Proposal(_), DelegationScope::Domain(_)) => true,
+            (DelegationScope::Domain(d), DelegationScope::Proposal(p))
+            | (DelegationScope::Proposal(p), DelegationScope::Domain(d)) => {
+                // Look up proposal to get its domain for precise overlap checking
+                match self.load_proposal(p) {
+                    Ok(Some(proposal)) => &proposal.domain_id == d,
+                    // Conservative fallback: assume overlap if proposal not found or error
+                    Ok(None) | Err(_) => true,
+                }
+            }
             (DelegationScope::Proposal(p1), DelegationScope::Proposal(p2)) => p1 == p2,
         }
     }

--- a/icn/crates/icn-gateway/src/governance_mgr.rs
+++ b/icn/crates/icn-gateway/src/governance_mgr.rs
@@ -646,7 +646,7 @@ impl GovernanceManager {
         let max_depth = DEFAULT_MAX_DELEGATION_DEPTH;
         if incoming_depth >= max_depth {
             anyhow::bail!(
-                "Maximum delegation depth ({max_depth}) exceeded. The delegation chain is too long.",
+                "Maximum delegation depth exceeded: computed depth {incoming_depth} >= max {max_depth}. The delegation chain is too long.",
             );
         }
 

--- a/icn/crates/icn-gateway/src/governance_mgr.rs
+++ b/icn/crates/icn-gateway/src/governance_mgr.rs
@@ -789,9 +789,17 @@ fn find_delegation_cycle(
     // Use inclusive range to detect cycles at the depth boundary
     // With MAX_DELEGATION_DEPTH=3: 0..=3 checks 4 positions (delegate + 3 hops)
     for _ in 0..=DEFAULT_MAX_DELEGATION_DEPTH {
+        // Only report a cycle if it leads back to the original delegator.
+        // If we encounter a node visited earlier in THIS walk but it's not
+        // the delegator, that's an existing cycle in the graph (e.g., B→C→B)
+        // which shouldn't block the new delegation A→B.
         if visited.contains(&current) {
-            // Found a cycle - current is already in our path
-            return Some(path);
+            if current == *delegator {
+                // True cycle back to origin delegator
+                return Some(path);
+            }
+            // Existing cycle in graph, but doesn't affect this delegation
+            return None;
         }
         visited.insert(current.clone());
 
@@ -836,6 +844,16 @@ fn compute_incoming_depth(
     compute_incoming_depth_recursive(delegate, scope, delegations, proposals, now, &mut visited)
 }
 
+/// Recursive helper for computing incoming delegation depth.
+///
+/// The visited set is shared across all recursive branches to:
+/// 1. Prevent infinite loops on cyclic delegation graphs
+/// 2. Avoid redundant computation when multiple paths lead to the same node
+///
+/// For diamond patterns (A→C, B→C, D→A, D→B), sharing the visited set means
+/// we only compute C's depth once. This is safe because depth is the maximum
+/// chain length, and once we've computed a node's contribution, we don't need
+/// to recompute it from a different path.
 fn compute_incoming_depth_recursive(
     delegate: &Did,
     scope: &DelegationScope,
@@ -844,13 +862,15 @@ fn compute_incoming_depth_recursive(
     now: Timestamp,
     visited: &mut HashSet<Did>,
 ) -> usize {
-    // Prevent infinite recursion
+    // Prevent infinite recursion on cyclic graphs
     if visited.contains(delegate) {
         return 0;
     }
     visited.insert(delegate.clone());
 
-    // Safety limit
+    // Safety limit: MAX_DELEGATION_DEPTH + 10 provides margin for edge cases
+    // like diamond patterns where we may visit more unique nodes than the
+    // strict chain depth. This is a defensive guard, not the primary limit.
     if visited.len() > DEFAULT_MAX_DELEGATION_DEPTH + 10 {
         return 0;
     }

--- a/icn/crates/icn-gateway/src/governance_mgr.rs
+++ b/icn/crates/icn-gateway/src/governance_mgr.rs
@@ -786,7 +786,9 @@ fn find_delegation_cycle(
     visited.insert(delegator.clone());
     let mut current = delegate.clone();
 
-    for _ in 0..DEFAULT_MAX_DELEGATION_DEPTH {
+    // Use inclusive range to detect cycles at the depth boundary
+    // With MAX_DELEGATION_DEPTH=3: 0..=3 checks 4 positions (delegate + 3 hops)
+    for _ in 0..=DEFAULT_MAX_DELEGATION_DEPTH {
         if visited.contains(&current) {
             // Found a cycle - current is already in our path
             return Some(path);

--- a/icn/crates/icn-gateway/src/governance_mgr.rs
+++ b/icn/crates/icn-gateway/src/governance_mgr.rs
@@ -17,12 +17,13 @@
 
 use anyhow::Result;
 use icn_governance::{
-    Delegation, DelegationId, GovernanceConfig, GovernanceDomain, GovernanceDomainId,
-    GovernanceOps, GovernanceParams, GovernanceProfileId, MembershipConfig, MembershipSource,
-    Proposal, ProposalId, ProposalPayload, ProposalState, Timestamp, Vote, VoteChoice, VoteTally,
+    Delegation, DelegationId, DelegationScope, GovernanceConfig, GovernanceDomain,
+    GovernanceDomainId, GovernanceOps, GovernanceParams, GovernanceProfileId, MembershipConfig,
+    MembershipSource, Proposal, ProposalId, ProposalPayload, ProposalState, Timestamp, Vote,
+    VoteChoice, VoteTally, DEFAULT_MAX_DELEGATION_DEPTH,
 };
 use icn_identity::Did;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 use tracing::debug;
 
@@ -608,18 +609,33 @@ impl GovernanceManager {
             );
         }
 
-        // Simple cycle check: would this create a direct cycle?
-        // (Full transitive cycle detection would require building a DelegationManager)
-        let would_cycle = delegations.values().any(|d| {
-            d.delegator == delegation.delegate
-                && d.delegate == delegation.delegator
-                && d.is_active(now)
-        });
-        if would_cycle {
+        // Full transitive cycle detection: walk the delegation chain from delegate
+        // and check if it eventually leads back to delegator (A→B→C→A detection)
+        let cycle_path = find_delegation_cycle(
+            &delegation.delegator,
+            &delegation.delegate,
+            &delegation.scope,
+            &delegations,
+            now,
+        );
+        if let Some(path) = cycle_path {
+            let path_str = path
+                .iter()
+                .map(|did| did.to_string())
+                .collect::<Vec<_>>()
+                .join(" → ");
             anyhow::bail!(
-                "Delegation would create a cycle: {} <-> {}. The delegate already delegates to this delegator.",
-                delegation.delegator,
-                delegation.delegate
+                "Delegation would create a cycle: {path_str}. Remove an existing delegation to break the cycle.",
+            );
+        }
+
+        // Check max delegation depth: count how many hops lead TO the delegator
+        let incoming_depth =
+            compute_incoming_depth(&delegation.delegator, &delegation.scope, &delegations, now);
+        let max_depth = DEFAULT_MAX_DELEGATION_DEPTH;
+        if incoming_depth >= max_depth {
+            anyhow::bail!(
+                "Maximum delegation depth ({max_depth}) exceeded. The delegation chain is too long.",
             );
         }
 
@@ -710,6 +726,121 @@ impl Default for GovernanceManager {
     }
 }
 
+// ============================================================================
+// Delegation Cycle Detection Helpers
+// ============================================================================
+
+/// Check if two delegation scopes overlap (for cycle detection)
+///
+/// Returns true if delegations with these scopes could conflict.
+/// Conservative: assumes overlap when uncertain to prevent potential cycles.
+fn scopes_overlap(a: &DelegationScope, b: &DelegationScope) -> bool {
+    match (a, b) {
+        (DelegationScope::Blanket, _) | (_, DelegationScope::Blanket) => true,
+        (DelegationScope::Domain(d1), DelegationScope::Domain(d2)) => d1 == d2,
+        // Conservative: assume domain/proposal overlap since we can't verify membership
+        (DelegationScope::Domain(_), DelegationScope::Proposal(_))
+        | (DelegationScope::Proposal(_), DelegationScope::Domain(_)) => true,
+        (DelegationScope::Proposal(p1), DelegationScope::Proposal(p2)) => p1 == p2,
+    }
+}
+
+/// Find a delegation cycle if adding delegator→delegate would create one
+///
+/// Returns Some(cycle_path) if a cycle would be created, None otherwise.
+/// The path includes the full cycle from delegator back to delegator.
+fn find_delegation_cycle(
+    delegator: &Did,
+    delegate: &Did,
+    scope: &DelegationScope,
+    delegations: &HashMap<DelegationId, Delegation>,
+    now: Timestamp,
+) -> Option<Vec<Did>> {
+    let mut path = vec![delegator.clone(), delegate.clone()];
+    let mut visited = HashSet::new();
+    visited.insert(delegator.clone());
+    let mut current = delegate.clone();
+
+    for _ in 0..DEFAULT_MAX_DELEGATION_DEPTH {
+        if visited.contains(&current) {
+            // Found a cycle - current is already in our path
+            return Some(path);
+        }
+        visited.insert(current.clone());
+
+        // Find any active delegation from current that matches scope
+        let next = delegations
+            .values()
+            .find(|d| d.delegator == current && d.is_active(now) && scopes_overlap(&d.scope, scope))
+            .map(|d| d.delegate.clone());
+
+        match next {
+            Some(d) => {
+                if d == *delegator {
+                    // Completes the cycle back to delegator
+                    path.push(d);
+                    return Some(path);
+                }
+                path.push(d.clone());
+                current = d;
+            }
+            None => return None, // No more delegations, no cycle
+        }
+    }
+
+    None
+}
+
+/// Compute incoming delegation chain depth (how many hops lead TO this delegate)
+///
+/// For example, if Alice→Bob→Charlie, then Charlie has incoming depth 2.
+fn compute_incoming_depth(
+    delegate: &Did,
+    scope: &DelegationScope,
+    delegations: &HashMap<DelegationId, Delegation>,
+    now: Timestamp,
+) -> usize {
+    let mut visited = HashSet::new();
+    compute_incoming_depth_recursive(delegate, scope, delegations, now, &mut visited)
+}
+
+fn compute_incoming_depth_recursive(
+    delegate: &Did,
+    scope: &DelegationScope,
+    delegations: &HashMap<DelegationId, Delegation>,
+    now: Timestamp,
+    visited: &mut HashSet<Did>,
+) -> usize {
+    // Prevent infinite recursion
+    if visited.contains(delegate) {
+        return 0;
+    }
+    visited.insert(delegate.clone());
+
+    // Safety limit
+    if visited.len() > DEFAULT_MAX_DELEGATION_DEPTH + 10 {
+        return 0;
+    }
+
+    // Find all delegators who have delegated to this delegate with overlapping scope
+    let delegators: Vec<Did> = delegations
+        .values()
+        .filter(|d| d.delegate == *delegate && d.is_active(now) && scopes_overlap(&d.scope, scope))
+        .map(|d| d.delegator.clone())
+        .collect();
+
+    if delegators.is_empty() {
+        return 0;
+    }
+
+    // Recursively find the maximum depth
+    delegators
+        .into_iter()
+        .map(|d| 1 + compute_incoming_depth_recursive(&d, scope, delegations, now, visited))
+        .max()
+        .unwrap_or(0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -765,5 +896,146 @@ mod tests {
         let domain = mgr.get_domain(&domain_id).await.unwrap().unwrap();
         assert_eq!(domain.config.profile.0, "contract:did:icn:abc123");
         assert!(domain.config.profile.is_contract());
+    }
+
+    // ============================================================================
+    // Delegation Cycle Detection Tests
+    // ============================================================================
+
+    fn test_did(seed: u8) -> Did {
+        Did::from_anchor_id(&[seed; 32])
+    }
+
+    #[tokio::test]
+    async fn test_delegation_direct_cycle_rejected() {
+        let mgr = GovernanceManager::new();
+        let alice = test_did(1);
+        let bob = test_did(2);
+
+        // Alice -> Bob (allowed)
+        let d1 = Delegation::new(alice.clone(), bob.clone(), DelegationScope::Blanket);
+        mgr.create_delegation(d1).await.unwrap();
+
+        // Bob -> Alice (should fail - direct cycle)
+        let d2 = Delegation::new(bob.clone(), alice.clone(), DelegationScope::Blanket);
+        let result = mgr.create_delegation(d2).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cycle"));
+    }
+
+    #[tokio::test]
+    async fn test_delegation_transitive_cycle_rejected() {
+        let mgr = GovernanceManager::new();
+        let alice = test_did(1);
+        let bob = test_did(2);
+        let charlie = test_did(3);
+
+        // Alice -> Bob (allowed)
+        let d1 = Delegation::new(alice.clone(), bob.clone(), DelegationScope::Blanket);
+        mgr.create_delegation(d1).await.unwrap();
+
+        // Bob -> Charlie (allowed)
+        let d2 = Delegation::new(bob.clone(), charlie.clone(), DelegationScope::Blanket);
+        mgr.create_delegation(d2).await.unwrap();
+
+        // Charlie -> Alice (should fail - transitive cycle A->B->C->A)
+        let d3 = Delegation::new(charlie.clone(), alice.clone(), DelegationScope::Blanket);
+        let result = mgr.create_delegation(d3).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cycle"));
+    }
+
+    #[tokio::test]
+    async fn test_delegation_max_depth_enforced() {
+        let mgr = GovernanceManager::new();
+        let alice = test_did(1);
+        let bob = test_did(2);
+        let charlie = test_did(3);
+        let dave = test_did(4);
+        let eve = test_did(5);
+
+        // Create a chain: Alice -> Bob -> Charlie -> Dave (depth 3)
+        mgr.create_delegation(Delegation::new(
+            alice.clone(),
+            bob.clone(),
+            DelegationScope::Blanket,
+        ))
+        .await
+        .unwrap();
+
+        mgr.create_delegation(Delegation::new(
+            bob.clone(),
+            charlie.clone(),
+            DelegationScope::Blanket,
+        ))
+        .await
+        .unwrap();
+
+        mgr.create_delegation(Delegation::new(
+            charlie.clone(),
+            dave.clone(),
+            DelegationScope::Blanket,
+        ))
+        .await
+        .unwrap();
+
+        // Dave -> Eve would exceed max depth (default is 3)
+        let result = mgr
+            .create_delegation(Delegation::new(
+                dave.clone(),
+                eve.clone(),
+                DelegationScope::Blanket,
+            ))
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("depth"));
+    }
+
+    #[tokio::test]
+    async fn test_delegation_different_scopes_no_cycle() {
+        let mgr = GovernanceManager::new();
+        let alice = test_did(1);
+        let bob = test_did(2);
+        let domain1 = GovernanceDomainId::new("domain1");
+        let domain2 = GovernanceDomainId::new("domain2");
+
+        // Alice -> Bob for domain1 (allowed)
+        let d1 = Delegation::new(
+            alice.clone(),
+            bob.clone(),
+            DelegationScope::Domain(domain1.clone()),
+        );
+        mgr.create_delegation(d1).await.unwrap();
+
+        // Bob -> Alice for domain2 (allowed - different domain, no cycle)
+        let d2 = Delegation::new(
+            bob.clone(),
+            alice.clone(),
+            DelegationScope::Domain(domain2.clone()),
+        );
+        let result = mgr.create_delegation(d2).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_delegation_blanket_causes_cycle_with_domain() {
+        let mgr = GovernanceManager::new();
+        let alice = test_did(1);
+        let bob = test_did(2);
+        let domain = GovernanceDomainId::new("test");
+
+        // Alice -> Bob (blanket)
+        let d1 = Delegation::new(alice.clone(), bob.clone(), DelegationScope::Blanket);
+        mgr.create_delegation(d1).await.unwrap();
+
+        // Bob -> Alice for domain (should fail - blanket overlaps with all domains)
+        let d2 = Delegation::new(
+            bob.clone(),
+            alice.clone(),
+            DelegationScope::Domain(domain.clone()),
+        );
+        let result = mgr.create_delegation(d2).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cycle"));
     }
 }

--- a/icn/crates/icn-gateway/src/governance_mgr.rs
+++ b/icn/crates/icn-gateway/src/governance_mgr.rs
@@ -589,6 +589,11 @@ impl GovernanceManager {
             anyhow::anyhow!("Delegations storage lock poisoned (concurrent panic?): {e}")
         })?;
 
+        // Get proposals for precise scope overlap checking
+        let proposals = self.proposals.read().map_err(|e| {
+            anyhow::anyhow!("Proposals storage lock poisoned (concurrent panic?): {e}")
+        })?;
+
         // Check for duplicate delegation ID
         if delegations.contains_key(&delegation.id) {
             anyhow::bail!(
@@ -616,6 +621,7 @@ impl GovernanceManager {
             &delegation.delegate,
             &delegation.scope,
             &delegations,
+            &proposals,
             now,
         );
         if let Some(path) = cycle_path {
@@ -630,14 +636,22 @@ impl GovernanceManager {
         }
 
         // Check max delegation depth: count how many hops lead TO the delegator
-        let incoming_depth =
-            compute_incoming_depth(&delegation.delegator, &delegation.scope, &delegations, now);
+        let incoming_depth = compute_incoming_depth(
+            &delegation.delegator,
+            &delegation.scope,
+            &delegations,
+            &proposals,
+            now,
+        );
         let max_depth = DEFAULT_MAX_DELEGATION_DEPTH;
         if incoming_depth >= max_depth {
             anyhow::bail!(
                 "Maximum delegation depth ({max_depth}) exceeded. The delegation chain is too long.",
             );
         }
+
+        // Release proposals lock before inserting
+        drop(proposals);
 
         delegations.insert(delegation.id.clone(), delegation);
         Ok(())
@@ -733,14 +747,24 @@ impl Default for GovernanceManager {
 /// Check if two delegation scopes overlap (for cycle detection)
 ///
 /// Returns true if delegations with these scopes could conflict.
-/// Conservative: assumes overlap when uncertain to prevent potential cycles.
-fn scopes_overlap(a: &DelegationScope, b: &DelegationScope) -> bool {
+/// Uses proposal domain lookup for precise Domain/Proposal overlap checking.
+fn scopes_overlap(
+    a: &DelegationScope,
+    b: &DelegationScope,
+    proposals: &HashMap<ProposalId, Proposal>,
+) -> bool {
     match (a, b) {
         (DelegationScope::Blanket, _) | (_, DelegationScope::Blanket) => true,
         (DelegationScope::Domain(d1), DelegationScope::Domain(d2)) => d1 == d2,
-        // Conservative: assume domain/proposal overlap since we can't verify membership
-        (DelegationScope::Domain(_), DelegationScope::Proposal(_))
-        | (DelegationScope::Proposal(_), DelegationScope::Domain(_)) => true,
+        (DelegationScope::Domain(d), DelegationScope::Proposal(p))
+        | (DelegationScope::Proposal(p), DelegationScope::Domain(d)) => {
+            // Use proposal lookup for precise domain checking
+            match proposals.get(p) {
+                Some(proposal) => &proposal.domain_id == d,
+                // Conservative fallback: assume overlap if proposal not found
+                None => true,
+            }
+        }
         (DelegationScope::Proposal(p1), DelegationScope::Proposal(p2)) => p1 == p2,
     }
 }
@@ -754,6 +778,7 @@ fn find_delegation_cycle(
     delegate: &Did,
     scope: &DelegationScope,
     delegations: &HashMap<DelegationId, Delegation>,
+    proposals: &HashMap<ProposalId, Proposal>,
     now: Timestamp,
 ) -> Option<Vec<Did>> {
     let mut path = vec![delegator.clone(), delegate.clone()];
@@ -771,7 +796,11 @@ fn find_delegation_cycle(
         // Find any active delegation from current that matches scope
         let next = delegations
             .values()
-            .find(|d| d.delegator == current && d.is_active(now) && scopes_overlap(&d.scope, scope))
+            .find(|d| {
+                d.delegator == current
+                    && d.is_active(now)
+                    && scopes_overlap(&d.scope, scope, proposals)
+            })
             .map(|d| d.delegate.clone());
 
         match next {
@@ -798,16 +827,18 @@ fn compute_incoming_depth(
     delegate: &Did,
     scope: &DelegationScope,
     delegations: &HashMap<DelegationId, Delegation>,
+    proposals: &HashMap<ProposalId, Proposal>,
     now: Timestamp,
 ) -> usize {
     let mut visited = HashSet::new();
-    compute_incoming_depth_recursive(delegate, scope, delegations, now, &mut visited)
+    compute_incoming_depth_recursive(delegate, scope, delegations, proposals, now, &mut visited)
 }
 
 fn compute_incoming_depth_recursive(
     delegate: &Did,
     scope: &DelegationScope,
     delegations: &HashMap<DelegationId, Delegation>,
+    proposals: &HashMap<ProposalId, Proposal>,
     now: Timestamp,
     visited: &mut HashSet<Did>,
 ) -> usize {
@@ -825,7 +856,11 @@ fn compute_incoming_depth_recursive(
     // Find all delegators who have delegated to this delegate with overlapping scope
     let delegators: Vec<Did> = delegations
         .values()
-        .filter(|d| d.delegate == *delegate && d.is_active(now) && scopes_overlap(&d.scope, scope))
+        .filter(|d| {
+            d.delegate == *delegate
+                && d.is_active(now)
+                && scopes_overlap(&d.scope, scope, proposals)
+        })
         .map(|d| d.delegator.clone())
         .collect();
 
@@ -836,7 +871,9 @@ fn compute_incoming_depth_recursive(
     // Recursively find the maximum depth
     delegators
         .into_iter()
-        .map(|d| 1 + compute_incoming_depth_recursive(&d, scope, delegations, now, visited))
+        .map(|d| {
+            1 + compute_incoming_depth_recursive(&d, scope, delegations, proposals, now, visited)
+        })
         .max()
         .unwrap_or(0)
 }
@@ -1035,6 +1072,126 @@ mod tests {
             DelegationScope::Domain(domain.clone()),
         );
         let result = mgr.create_delegation(d2).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cycle"));
+    }
+
+    #[tokio::test]
+    async fn test_precise_scope_overlap_no_cycle_different_domains() {
+        let mgr = GovernanceManager::new();
+        let alice = test_did(1);
+        let bob = test_did(2);
+
+        let domain_a = GovernanceDomainId::new("domain-a");
+        let domain_b = GovernanceDomainId::new("domain-b");
+        let membership = MembershipConfig {
+            source: MembershipSource::StaticList(vec![alice.clone(), bob.clone()]),
+        };
+        let params = GovernanceParams::new(50, 50, 86400);
+
+        // Create domain B
+        mgr.create_domain(
+            domain_b.clone(),
+            "Domain B".to_string(),
+            "cooperative_default".to_string(),
+            params.clone(),
+            membership.clone(),
+        )
+        .await
+        .unwrap();
+
+        // Create a proposal in domain B
+        let proposal_id = ProposalId::generate();
+        mgr.create_proposal(
+            proposal_id.clone(),
+            domain_b.clone(),
+            alice.clone(),
+            "Test Proposal".to_string(),
+            "Description".to_string(),
+            ProposalPayload::Text {
+                body: "test".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Alice delegates domain A to Bob
+        mgr.create_delegation(Delegation::new(
+            alice.clone(),
+            bob.clone(),
+            DelegationScope::Domain(domain_a.clone()),
+        ))
+        .await
+        .unwrap();
+
+        // Bob delegates proposal (in domain B) to Alice
+        // This should SUCCEED because domain A != domain B (no cycle with precise checking)
+        let result = mgr
+            .create_delegation(Delegation::new(
+                bob.clone(),
+                alice.clone(),
+                DelegationScope::Proposal(proposal_id),
+            ))
+            .await;
+        assert!(result.is_ok(), "Expected no cycle but got: {result:?}");
+    }
+
+    #[tokio::test]
+    async fn test_precise_scope_overlap_cycle_same_domain() {
+        let mgr = GovernanceManager::new();
+        let alice = test_did(1);
+        let bob = test_did(2);
+
+        let domain_a = GovernanceDomainId::new("domain-a");
+        let membership = MembershipConfig {
+            source: MembershipSource::StaticList(vec![alice.clone(), bob.clone()]),
+        };
+        let params = GovernanceParams::new(50, 50, 86400);
+
+        // Create domain A
+        mgr.create_domain(
+            domain_a.clone(),
+            "Domain A".to_string(),
+            "cooperative_default".to_string(),
+            params.clone(),
+            membership.clone(),
+        )
+        .await
+        .unwrap();
+
+        // Create a proposal in domain A
+        let proposal_id = ProposalId::generate();
+        mgr.create_proposal(
+            proposal_id.clone(),
+            domain_a.clone(),
+            alice.clone(),
+            "Test Proposal".to_string(),
+            "Description".to_string(),
+            ProposalPayload::Text {
+                body: "test".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Alice delegates domain A to Bob
+        mgr.create_delegation(Delegation::new(
+            alice.clone(),
+            bob.clone(),
+            DelegationScope::Domain(domain_a.clone()),
+        ))
+        .await
+        .unwrap();
+
+        // Bob delegates proposal (in domain A) to Alice
+        // This should FAIL because proposal is in domain A (cycle detected)
+        let result = mgr
+            .create_delegation(Delegation::new(
+                bob.clone(),
+                alice.clone(),
+                DelegationScope::Proposal(proposal_id),
+            ))
+            .await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("cycle"));
     }

--- a/icn/crates/icn-governance/src/delegation.rs
+++ b/icn/crates/icn-governance/src/delegation.rs
@@ -234,6 +234,9 @@ pub struct DelegationManager {
 
     /// Maximum allowed delegation depth
     max_depth: usize,
+
+    /// Proposal to domain mapping for precise scope overlap checking
+    proposal_domains: HashMap<ProposalId, GovernanceDomainId>,
 }
 
 impl DelegationManager {
@@ -244,6 +247,7 @@ impl DelegationManager {
             delegations_from: HashMap::new(),
             delegations_to: HashMap::new(),
             max_depth: DEFAULT_MAX_DELEGATION_DEPTH,
+            proposal_domains: HashMap::new(),
         }
     }
 
@@ -251,6 +255,24 @@ impl DelegationManager {
     pub fn with_max_depth(mut self, max_depth: usize) -> Self {
         self.max_depth = max_depth;
         self
+    }
+
+    /// Register a proposal's domain for precise scope overlap checking
+    ///
+    /// Call this when a proposal is created to enable accurate domain/proposal
+    /// scope overlap detection during delegation cycle checking.
+    pub fn register_proposal(&mut self, proposal_id: ProposalId, domain_id: GovernanceDomainId) {
+        self.proposal_domains.insert(proposal_id, domain_id);
+    }
+
+    /// Unregister a proposal (e.g., when proposal is finalized)
+    pub fn unregister_proposal(&mut self, proposal_id: &ProposalId) {
+        self.proposal_domains.remove(proposal_id);
+    }
+
+    /// Get the domain for a proposal, if registered
+    pub fn get_proposal_domain(&self, proposal_id: &ProposalId) -> Option<&GovernanceDomainId> {
+        self.proposal_domains.get(proposal_id)
     }
 
     /// Add a new delegation
@@ -543,24 +565,27 @@ impl DelegationManager {
     /// Check if two scopes overlap (for cycle detection)
     ///
     /// This function is used to determine if two delegations could conflict.
-    /// It is conservative: when uncertain, it assumes overlap to prevent potential cycles.
+    /// Uses registered proposal domains for precise overlap checking when available.
     ///
-    /// # Known Limitation
+    /// # Behavior
     ///
-    /// Domain and Proposal scopes are assumed to overlap because we don't have
-    /// access to proposal metadata to verify domain membership. This could cause
-    /// false positive cycle detection in edge cases (e.g., Alice delegates domain A
-    /// to Bob, Bob delegates proposal in domain B to Alice - flagged as cycle but isn't).
-    /// This conservative approach ensures safety at the cost of some flexibility.
+    /// - Blanket scope overlaps with all scopes
+    /// - Domain scopes overlap only if they match
+    /// - Proposal scopes overlap only if they match
+    /// - Domain + Proposal: uses registered domain mapping for precise check,
+    ///   falls back to conservative (assume overlap) if proposal not registered
     fn scopes_overlap(&self, a: &DelegationScope, b: &DelegationScope) -> bool {
         match (a, b) {
             (DelegationScope::Blanket, _) | (_, DelegationScope::Blanket) => true,
             (DelegationScope::Domain(d1), DelegationScope::Domain(d2)) => d1 == d2,
             (DelegationScope::Domain(d), DelegationScope::Proposal(p))
             | (DelegationScope::Proposal(p), DelegationScope::Domain(d)) => {
-                // Conservative: assume overlap since we can't verify domain membership
-                let _ = (d, p);
-                true
+                // Use registered domain mapping for precise check
+                match self.proposal_domains.get(p) {
+                    Some(proposal_domain) => proposal_domain == d,
+                    // Conservative fallback: assume overlap if proposal not registered
+                    None => true,
+                }
             }
             (DelegationScope::Proposal(p1), DelegationScope::Proposal(p2)) => p1 == p2,
         }
@@ -911,5 +936,103 @@ mod tests {
         assert!(manager
             .get_delegate(&alice, &DelegationScope::Blanket)
             .is_none());
+    }
+
+    #[test]
+    fn test_precise_domain_proposal_no_overlap() {
+        let mut manager = DelegationManager::new();
+        let alice = test_did(1);
+        let bob = test_did(2);
+
+        let domain_a = GovernanceDomainId::new("domain-a");
+        let domain_b = GovernanceDomainId::new("domain-b");
+        let proposal_in_b = ProposalId::new("proposal-in-domain-b");
+
+        // Register that the proposal is in domain B
+        manager.register_proposal(proposal_in_b.clone(), domain_b.clone());
+
+        // Alice delegates domain A to Bob
+        manager
+            .add_delegation(Delegation::new(
+                alice.clone(),
+                bob.clone(),
+                DelegationScope::Domain(domain_a.clone()),
+            ))
+            .unwrap();
+
+        // Bob delegates proposal (in domain B) to Alice
+        // This should succeed because domain A != domain B (no cycle)
+        let result = manager.add_delegation(Delegation::new(
+            bob.clone(),
+            alice.clone(),
+            DelegationScope::Proposal(proposal_in_b.clone()),
+        ));
+
+        assert!(result.is_ok(), "Expected no cycle but got: {:?}", result);
+    }
+
+    #[test]
+    fn test_precise_domain_proposal_with_overlap() {
+        let mut manager = DelegationManager::new();
+        let alice = test_did(1);
+        let bob = test_did(2);
+
+        let domain_a = GovernanceDomainId::new("domain-a");
+        let proposal_in_a = ProposalId::new("proposal-in-domain-a");
+
+        // Register that the proposal is in domain A
+        manager.register_proposal(proposal_in_a.clone(), domain_a.clone());
+
+        // Alice delegates domain A to Bob
+        manager
+            .add_delegation(Delegation::new(
+                alice.clone(),
+                bob.clone(),
+                DelegationScope::Domain(domain_a.clone()),
+            ))
+            .unwrap();
+
+        // Bob delegates proposal (in domain A) to Alice
+        // This should fail because domain A == proposal's domain (cycle detected)
+        let result = manager.add_delegation(Delegation::new(
+            bob.clone(),
+            alice.clone(),
+            DelegationScope::Proposal(proposal_in_a.clone()),
+        ));
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cycle"));
+    }
+
+    #[test]
+    fn test_unregistered_proposal_conservative_fallback() {
+        let mut manager = DelegationManager::new();
+        let alice = test_did(1);
+        let bob = test_did(2);
+
+        let domain_a = GovernanceDomainId::new("domain-a");
+        let unknown_proposal = ProposalId::new("unknown-proposal");
+
+        // Don't register the proposal - should fall back to conservative behavior
+
+        // Alice delegates domain A to Bob
+        manager
+            .add_delegation(Delegation::new(
+                alice.clone(),
+                bob.clone(),
+                DelegationScope::Domain(domain_a.clone()),
+            ))
+            .unwrap();
+
+        // Bob delegates unknown proposal to Alice
+        // Should fail (conservative: assume overlap when unknown)
+        let result = manager.add_delegation(Delegation::new(
+            bob.clone(),
+            alice.clone(),
+            DelegationScope::Proposal(unknown_proposal.clone()),
+        ));
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cycle"));
     }
 }


### PR DESCRIPTION
## Summary

Improves delegation cycle detection with full transitive checking and precise domain/proposal scope overlap detection.

## Changes

### Issue #262 - Transitive Cycle Detection
- Added `find_delegation_cycle()` helper for A→B→C→A detection
- Added `compute_incoming_depth()` for max delegation depth enforcement (default: 3 hops)
- Added `scopes_overlap()` for scope-aware conflict detection
- Added comprehensive tests for cycle detection edge cases

### Issue #261 - Precise Scope Overlap
- Added `proposal_domains` map to `DelegationManager` for tracking proposal domains
- Added `register_proposal()`, `unregister_proposal()`, `get_proposal_domain()` methods
- Updated `scopes_overlap()` to use registered domains for precise checking
- Falls back to conservative behavior if proposal not registered

## Also Verified (Already Implemented)

- **#272**: GovernanceOps methods `get_vote_tally()` and `get_voter_dids()` - already present
- **#273**: Proposal status transition validation - high-priority items already done

## Remaining Work

- **#282**: Delayed execution for protocol changes - Complex feature requiring background tasks and new storage, deferred to separate PR

## Test Plan

- [x] All 5 delegation tests pass in icn-gateway
- [x] All 3 precise scope overlap tests pass in icn-governance  
- [x] Cargo clippy passes with no warnings
- [x] Cargo fmt applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)