### PR TITLE
feat(governance): Implement delayed execution for protocol changes

### DIFF
--- a/icn/crates/icn-core/src/governance/actor.rs
+++ b/icn/crates/icn-core/src/governance/actor.rs
@@ -419,7 +419,9 @@ impl icn_governance::GovernanceOps for GovernanceHandle {
 
                 // Optional: max delay limit (1 year = 365 * 24 * 60 * 60 = 31536000 seconds)
                 const MAX_DELAY_SECONDS: u64 = 31536000;
-                if effective_at > now + MAX_DELAY_SECONDS {
+                // Use checked arithmetic to prevent overflow if now is close to u64::MAX
+                let max_allowed = now.checked_add(MAX_DELAY_SECONDS).unwrap_or(u64::MAX);
+                if effective_at > max_allowed {
                     bail!(
                         "Cannot create ProtocolChange proposal: effective_at is too far in the future (max: 1 year)"
                     );

--- a/icn/crates/icn-core/src/governance/actor.rs
+++ b/icn/crates/icn-core/src/governance/actor.rs
@@ -293,6 +293,32 @@ impl GovernanceHandle {
         }
     }
 
+    /// Schedule a pending parameter change for delayed execution
+    ///
+    /// Used when a ProtocolChange proposal has `effective_at` set.
+    /// The change will be applied by the background scheduler when the time comes.
+    pub fn schedule_pending_change(
+        &self,
+        change: icn_governance::PendingParameterChange,
+    ) -> Result<()> {
+        match &self.protocol_params {
+            Some(store) => {
+                store.add_pending_change(change)?;
+                icn_obs::metrics::protocol::pending_parameter_changes_scheduled_inc();
+                Ok(())
+            }
+            None => bail!("Protocol parameter store not configured"),
+        }
+    }
+
+    /// Get the current count of active pending parameter changes
+    pub fn count_pending_changes(&self) -> Result<usize> {
+        match &self.protocol_params {
+            Some(store) => store.count_pending_changes(),
+            None => Ok(0),
+        }
+    }
+
     /// Check if an entity exists (for scope validation at execution time)
     ///
     /// Returns true if the entity registry is not configured (allowing scoped params
@@ -380,12 +406,24 @@ impl icn_governance::GovernanceOps for GovernanceHandle {
                 );
             };
 
-            // Reject proposals with effective_at set (delayed execution not yet implemented)
-            if proposal.effective_at.is_some() {
-                bail!(
-                    "Cannot create ProtocolChange proposal: delayed execution (effective_at) is not yet implemented. \
-                     Remove effective_at to apply changes immediately upon approval."
-                );
+            // Validate effective_at if set (delayed execution)
+            if let Some(effective_at) = proposal.effective_at {
+                let now = icn_time::current_timestamp_secs();
+
+                // effective_at must be in the future
+                if effective_at <= now {
+                    bail!(
+                        "Cannot create ProtocolChange proposal: effective_at ({effective_at}) must be in the future (current time: {now})"
+                    );
+                }
+
+                // Optional: max delay limit (1 year = 365 * 24 * 60 * 60 = 31536000 seconds)
+                const MAX_DELAY_SECONDS: u64 = 31536000;
+                if effective_at > now + MAX_DELAY_SECONDS {
+                    bail!(
+                        "Cannot create ProtocolChange proposal: effective_at is too far in the future (max: 1 year)"
+                    );
+                }
             }
 
             // Check if the parameter exists

--- a/icn/crates/icn-core/src/governance/actor.rs
+++ b/icn/crates/icn-core/src/governance/actor.rs
@@ -418,9 +418,14 @@ impl icn_governance::GovernanceOps for GovernanceHandle {
                 }
 
                 // Optional: max delay limit (1 year = 365 * 24 * 60 * 60 = 31536000 seconds)
-                const MAX_DELAY_SECONDS: u64 = 31536000;
-                // Use checked arithmetic to prevent overflow if now is close to u64::MAX
-                let max_allowed = now.checked_add(MAX_DELAY_SECONDS).unwrap_or(u64::MAX);
+                const MAX_DELAY_SECONDS: u64 = 31_536_000;
+                // Use checked arithmetic to prevent overflow if now is close to u64::MAX.
+                // If overflow occurs, reject the proposal rather than allowing arbitrary future dates.
+                let max_allowed = now.checked_add(MAX_DELAY_SECONDS).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Cannot create ProtocolChange proposal: timestamp overflow when calculating max allowed effective_at"
+                    )
+                })?;
                 if effective_at > max_allowed {
                     bail!(
                         "Cannot create ProtocolChange proposal: effective_at is too far in the future (max: 1 year)"

--- a/icn/crates/icn-core/src/supervisor/background_tasks.rs
+++ b/icn/crates/icn-core/src/supervisor/background_tasks.rs
@@ -334,16 +334,19 @@ async fn process_due_changes(
 
     for change in due_changes {
         // If we've already processed a change for this parameter in this batch,
-        // this older change should be superseded
+        // this later change should be superseded (since get_changes_due_before returns
+        // changes ordered by effective_at ascending, earlier changes are processed first)
         if processed_params.contains(&change.parameter_id) {
             let mut updated = change.clone();
-            updated.mark_superseded("Superseded by earlier change in batch");
+            updated.mark_superseded("Superseded by change with earlier effective time");
             if let Err(e) = store.update_pending_change(updated) {
                 warn!(
                     pending_change_id = %change.id,
                     error = %e,
                     "Failed to mark pending change as superseded"
                 );
+            } else {
+                icn_obs::metrics::protocol::pending_parameter_changes_superseded_inc();
             }
             continue;
         }
@@ -379,6 +382,11 @@ async fn process_due_changes(
         }
     }
 
+    // Update the active pending changes gauge
+    if let Ok(active_count) = store.count_pending_changes() {
+        icn_obs::metrics::protocol::pending_parameter_changes_active_set(active_count as u64);
+    }
+
     Ok(())
 }
 
@@ -394,7 +402,9 @@ async fn apply_pending_change(
             // Parameter no longer exists, mark as cancelled
             let mut updated = change.clone();
             updated.mark_cancelled("Parameter no longer exists");
-            let _ = store.update_pending_change(updated);
+            if store.update_pending_change(updated).is_ok() {
+                icn_obs::metrics::protocol::pending_parameter_changes_cancelled_inc();
+            }
             return ParameterApplyResult::Skipped {
                 reason: "Parameter no longer exists".to_string(),
             };
@@ -406,27 +416,8 @@ async fn apply_pending_change(
         }
     };
 
-    // Check for existing pending changes for the same parameter that are older
-    // and should be superseded
-    if let Ok(pending_for_param) = store.list_pending_changes_for_parameter(&change.parameter_id) {
-        for other in pending_for_param {
-            if other.id != change.id
-                && other.status == icn_governance::PendingChangeStatus::Pending
-                && other.effective_at <= change.effective_at
-            {
-                // Supersede the older change
-                let mut superseded = other.clone();
-                superseded.mark_superseded(&change.id);
-                if let Err(e) = store.update_pending_change(superseded) {
-                    debug!(
-                        superseded_id = %other.id,
-                        error = %e,
-                        "Failed to mark older change as superseded"
-                    );
-                }
-            }
-        }
-    }
+    // Note: Superseding of later changes for the same parameter is handled
+    // in process_due_changes() at the batch level, not here.
 
     // Create updated parameter with new value
     let mut updated_param = current_param.clone();

--- a/icn/crates/icn-core/src/supervisor/background_tasks.rs
+++ b/icn/crates/icn-core/src/supervisor/background_tasks.rs
@@ -245,6 +245,221 @@ pub mod steward {
     }
 }
 
+/// Configuration for parameter scheduler task
+pub struct ParameterSchedulerConfig {
+    /// Interval between checking for due parameter changes
+    pub check_interval: Duration,
+}
+
+impl Default for ParameterSchedulerConfig {
+    fn default() -> Self {
+        Self {
+            check_interval: Duration::from_secs(10), // Check every 10 seconds
+        }
+    }
+}
+
+/// Result of applying a single pending parameter change
+pub enum ParameterApplyResult {
+    /// Change was successfully applied
+    Applied,
+    /// Change was skipped (e.g., parameter no longer exists)
+    Skipped { reason: String },
+    /// Change application failed
+    Failed { error: String },
+}
+
+/// Spawn the parameter scheduler background task
+///
+/// This task periodically checks for pending protocol parameter changes
+/// that are due and applies them. This enables delayed execution of
+/// governance-approved parameter changes.
+///
+/// # Parameters
+/// - `config`: Scheduler configuration
+/// - `parameter_store`: The parameter store (must support pending changes)
+/// - `shutdown_rx`: Shutdown signal receiver
+///
+/// # Behavior
+/// - Checks for due changes every `check_interval`
+/// - Applies changes in chronological order (earliest first)
+/// - Handles conflicts by superseding older pending changes for the same parameter
+/// - Logs all actions for audit trail
+pub fn spawn_parameter_scheduler_task(
+    config: ParameterSchedulerConfig,
+    parameter_store: Arc<dyn icn_governance::ProtocolParameterStore>,
+    mut shutdown_rx: BroadcastReceiver<()>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        info!("Parameter scheduler task started");
+
+        let mut interval = tokio::time::interval(config.check_interval);
+
+        loop {
+            select! {
+                _ = interval.tick() => {
+                    if let Err(e) = process_due_changes(&parameter_store).await {
+                        warn!("Error processing due parameter changes: {}", e);
+                    }
+                }
+                _ = shutdown_rx.recv() => {
+                    info!("Parameter scheduler task shutting down");
+                    break;
+                }
+            }
+        }
+    })
+}
+
+/// Process all pending parameter changes that are due
+async fn process_due_changes(
+    store: &Arc<dyn icn_governance::ProtocolParameterStore>,
+) -> anyhow::Result<()> {
+    let now = icn_time::current_timestamp_secs();
+
+    // Get all changes that are due
+    let due_changes = store.get_changes_due_before(now)?;
+
+    if due_changes.is_empty() {
+        return Ok(());
+    }
+
+    debug!(
+        due_count = due_changes.len(),
+        "Processing due parameter changes"
+    );
+
+    // Track which parameters we've processed to handle superseding
+    let mut processed_params: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    for change in due_changes {
+        // If we've already processed a change for this parameter in this batch,
+        // this older change should be superseded
+        if processed_params.contains(&change.parameter_id) {
+            let mut updated = change.clone();
+            updated.mark_superseded("Superseded by earlier change in batch");
+            if let Err(e) = store.update_pending_change(updated) {
+                warn!(
+                    pending_change_id = %change.id,
+                    error = %e,
+                    "Failed to mark pending change as superseded"
+                );
+            }
+            continue;
+        }
+
+        // Apply the change
+        match apply_pending_change(store, &change).await {
+            ParameterApplyResult::Applied => {
+                info!(
+                    pending_change_id = %change.id,
+                    parameter_id = %change.parameter_id,
+                    proposal_id = %change.proposal_id,
+                    "Applied delayed parameter change"
+                );
+                icn_obs::metrics::protocol::pending_parameter_changes_applied_inc();
+                processed_params.insert(change.parameter_id.clone());
+            }
+            ParameterApplyResult::Skipped { reason } => {
+                warn!(
+                    pending_change_id = %change.id,
+                    parameter_id = %change.parameter_id,
+                    reason = %reason,
+                    "Skipped pending parameter change"
+                );
+            }
+            ParameterApplyResult::Failed { error } => {
+                warn!(
+                    pending_change_id = %change.id,
+                    parameter_id = %change.parameter_id,
+                    error = %error,
+                    "Failed to apply pending parameter change"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Apply a single pending parameter change
+async fn apply_pending_change(
+    store: &Arc<dyn icn_governance::ProtocolParameterStore>,
+    change: &icn_governance::PendingParameterChange,
+) -> ParameterApplyResult {
+    // Get the current parameter
+    let current_param = match store.get(&change.parameter_id) {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            // Parameter no longer exists, mark as cancelled
+            let mut updated = change.clone();
+            updated.mark_cancelled("Parameter no longer exists");
+            let _ = store.update_pending_change(updated);
+            return ParameterApplyResult::Skipped {
+                reason: "Parameter no longer exists".to_string(),
+            };
+        }
+        Err(e) => {
+            return ParameterApplyResult::Failed {
+                error: format!("Failed to get parameter: {e}"),
+            };
+        }
+    };
+
+    // Check for existing pending changes for the same parameter that are older
+    // and should be superseded
+    if let Ok(pending_for_param) = store.list_pending_changes_for_parameter(&change.parameter_id) {
+        for other in pending_for_param {
+            if other.id != change.id
+                && other.status == icn_governance::PendingChangeStatus::Pending
+                && other.effective_at <= change.effective_at
+            {
+                // Supersede the older change
+                let mut superseded = other.clone();
+                superseded.mark_superseded(&change.id);
+                if let Err(e) = store.update_pending_change(superseded) {
+                    debug!(
+                        superseded_id = %other.id,
+                        error = %e,
+                        "Failed to mark older change as superseded"
+                    );
+                }
+            }
+        }
+    }
+
+    // Create updated parameter with new value
+    let mut updated_param = current_param.clone();
+    updated_param.value = change.new_value.clone();
+    updated_param.updated_at = icn_time::current_timestamp_secs();
+    updated_param.updated_by = Some(change.proposal_id.clone());
+
+    // Apply the parameter change
+    if let Err(e) = store.set(
+        updated_param,
+        Some(change.proposal_id.clone()),
+        Some(format!("delayed execution of {}", change.proposal_id)),
+    ) {
+        return ParameterApplyResult::Failed {
+            error: format!("Failed to set parameter: {e}"),
+        };
+    }
+
+    // Mark the pending change as applied
+    let mut applied_change = change.clone();
+    applied_change.mark_applied();
+    if let Err(e) = store.update_pending_change(applied_change) {
+        // Log but don't fail - the parameter was successfully updated
+        warn!(
+            pending_change_id = %change.id,
+            error = %e,
+            "Failed to mark pending change as applied"
+        );
+    }
+
+    ParameterApplyResult::Applied
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -260,5 +475,11 @@ mod tests {
         let config = MetricsUpdateConfig::default();
         assert_eq!(config.update_interval, Duration::from_secs(10));
         assert_eq!(config.active_actor_count, 7);
+    }
+
+    #[test]
+    fn test_parameter_scheduler_config_default() {
+        let config = ParameterSchedulerConfig::default();
+        assert_eq!(config.check_interval, Duration::from_secs(10));
     }
 }

--- a/icn/crates/icn-core/src/supervisor/background_tasks.rs
+++ b/icn/crates/icn-core/src/supervisor/background_tasks.rs
@@ -351,6 +351,11 @@ async fn process_due_changes(
             continue;
         }
 
+        // Mark this parameter as processed BEFORE attempting to apply.
+        // This ensures that if apply_pending_change() fails, any subsequent changes
+        // for the same parameter are still marked as superseded (not attempted).
+        processed_params.insert(change.parameter_id.clone());
+
         // Apply the change
         match apply_pending_change(store, &change).await {
             ParameterApplyResult::Applied => {
@@ -361,7 +366,6 @@ async fn process_due_changes(
                     "Applied delayed parameter change"
                 );
                 icn_obs::metrics::protocol::pending_parameter_changes_applied_inc();
-                processed_params.insert(change.parameter_id.clone());
             }
             ParameterApplyResult::Skipped { reason } => {
                 warn!(
@@ -415,6 +419,25 @@ async fn apply_pending_change(
             };
         }
     };
+
+    // Validate scope consistency: the pending change's scope must match the parameter's scope.
+    // This prevents a cooperative-scoped pending change from modifying a global parameter.
+    if current_param.scope != change.scope {
+        let mut updated = change.clone();
+        updated.mark_cancelled(format!(
+            "Scope mismatch: pending change has scope {:?} but parameter has scope {:?}",
+            change.scope, current_param.scope
+        ));
+        if store.update_pending_change(updated).is_ok() {
+            icn_obs::metrics::protocol::pending_parameter_changes_cancelled_inc();
+        }
+        return ParameterApplyResult::Skipped {
+            reason: format!(
+                "Scope mismatch: expected {:?}, found {:?}",
+                change.scope, current_param.scope
+            ),
+        };
+    }
 
     // Note: Superseding of later changes for the same parameter is handled
     // in process_due_changes() at the batch level, not here.

--- a/icn/crates/icn-core/src/supervisor/governance_handlers.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_handlers.rs
@@ -2387,6 +2387,14 @@ impl GovernanceEventHandler {
         proposal_id: ProposalId,
         proposal: icn_governance::ProtocolChangeProposal,
     ) {
+        let proposal_id_str = proposal_id.0.clone();
+
+        // Check if this is a delayed execution
+        if let Some(effective_at) = proposal.effective_at {
+            self.handle_delayed_protocol_change(proposal_id, proposal, effective_at);
+            return;
+        }
+
         info!(
             "⚙️  Protocol change proposal {} accepted: {} -> {:?}",
             proposal_id.0, proposal.parameter_id, proposal.new_value
@@ -2396,7 +2404,6 @@ impl GovernanceEventHandler {
         let param_result = self
             .gov_handle
             .get_protocol_parameter(&proposal.parameter_id);
-        let proposal_id_str = proposal_id.0.clone();
         match param_result {
             Ok(Some(mut param)) => {
                 // Capture old value for audit event (serialize to string for logging)
@@ -2526,6 +2533,67 @@ impl GovernanceEventHandler {
         }
 
         icn_obs::metrics::governance::proposals_executed_inc("protocol_change");
+    }
+
+    /// Handle a protocol parameter change with delayed execution
+    fn handle_delayed_protocol_change(
+        &self,
+        proposal_id: ProposalId,
+        proposal: icn_governance::ProtocolChangeProposal,
+        effective_at: u64,
+    ) {
+        let proposal_id_str = proposal_id.0.clone();
+
+        // Calculate delay for logging
+        let now = icn_time::current_timestamp_secs();
+        let delay_secs = effective_at.saturating_sub(now);
+        let delay_human = if delay_secs < 3600 {
+            format!("{} minutes", delay_secs / 60)
+        } else if delay_secs < 86400 {
+            format!("{} hours", delay_secs / 3600)
+        } else {
+            format!("{} days", delay_secs / 86400)
+        };
+
+        info!(
+            "⏰ Protocol change proposal {} scheduled for delayed execution: {} -> {:?} (effective in {})",
+            proposal_id.0, proposal.parameter_id, proposal.new_value, delay_human
+        );
+
+        // Determine the scope for the pending change
+        let scope = proposal
+            .scope
+            .clone()
+            .unwrap_or(icn_governance::ParameterScope::Global);
+
+        // Create the pending change
+        let pending_change = icn_governance::PendingParameterChange::new(
+            icn_governance::PendingParameterChange::generate_id(&proposal.parameter_id),
+            &proposal.parameter_id,
+            proposal.new_value.clone(),
+            effective_at,
+            scope,
+            &proposal_id_str,
+            &proposal.rationale,
+        );
+
+        // Store the pending change
+        if let Err(e) = self.gov_handle.schedule_pending_change(pending_change) {
+            let error_msg = format!(
+                "Failed to schedule delayed parameter change for '{}': {}",
+                proposal.parameter_id, e
+            );
+            warn!("{} (proposal {})", error_msg, proposal_id_str);
+            self.emit_execution_failure(&proposal_id, "protocol_change", &error_msg);
+            return;
+        }
+
+        info!(
+            "✓ Protocol parameter change {} scheduled (effective_at: {})",
+            proposal.parameter_id, effective_at
+        );
+
+        icn_obs::metrics::governance::proposals_executed_inc("protocol_change_scheduled");
     }
 }
 

--- a/icn/crates/icn-core/src/supervisor/mod.rs
+++ b/icn/crates/icn-core/src/supervisor/mod.rs
@@ -857,6 +857,7 @@ impl Supervisor {
             let _version_tracker = governance_services.version_tracker;
             let dead_letter_queue = governance_services.dead_letter_queue;
             let gov_store = governance_services.governance_store;
+            let protocol_parameter_store = governance_services.protocol_parameter_store;
 
             // Store governance handle for gateway integration
             governance_handle_for_gateway = Some(Arc::new(governance_handle.clone()));
@@ -1061,6 +1062,15 @@ impl Supervisor {
             );
 
             info!("Metrics update task spawned");
+
+            // Spawn parameter scheduler task for delayed execution (Phase 20)
+            let _parameter_scheduler_handle = background_tasks::spawn_parameter_scheduler_task(
+                background_tasks::ParameterSchedulerConfig::default(),
+                protocol_parameter_store,
+                self.shutdown_tx.subscribe(),
+            );
+
+            info!("Parameter scheduler task spawned (interval: 10 seconds)");
 
             // Activate node profile now that all actors are initialized (Phase 17)
             {

--- a/icn/crates/icn-gateway/src/governance_mgr.rs
+++ b/icn/crates/icn-gateway/src/governance_mgr.rs
@@ -589,11 +589,6 @@ impl GovernanceManager {
             anyhow::anyhow!("Delegations storage lock poisoned (concurrent panic?): {e}")
         })?;
 
-        // Get proposals for precise scope overlap checking
-        let proposals = self.proposals.read().map_err(|e| {
-            anyhow::anyhow!("Proposals storage lock poisoned (concurrent panic?): {e}")
-        })?;
-
         // Check for duplicate delegation ID
         if delegations.contains_key(&delegation.id) {
             anyhow::bail!(
@@ -621,7 +616,6 @@ impl GovernanceManager {
             &delegation.delegate,
             &delegation.scope,
             &delegations,
-            &proposals,
             now,
         );
         if let Some(path) = cycle_path {
@@ -636,22 +630,14 @@ impl GovernanceManager {
         }
 
         // Check max delegation depth: count how many hops lead TO the delegator
-        let incoming_depth = compute_incoming_depth(
-            &delegation.delegator,
-            &delegation.scope,
-            &delegations,
-            &proposals,
-            now,
-        );
+        let incoming_depth =
+            compute_incoming_depth(&delegation.delegator, &delegation.scope, &delegations, now);
         let max_depth = DEFAULT_MAX_DELEGATION_DEPTH;
         if incoming_depth >= max_depth {
             anyhow::bail!(
-                "Maximum delegation depth exceeded: computed depth {incoming_depth} >= max {max_depth}. The delegation chain is too long.",
+                "Maximum delegation depth ({max_depth}) exceeded. The delegation chain is too long.",
             );
         }
-
-        // Release proposals lock before inserting
-        drop(proposals);
 
         delegations.insert(delegation.id.clone(), delegation);
         Ok(())
@@ -747,24 +733,14 @@ impl Default for GovernanceManager {
 /// Check if two delegation scopes overlap (for cycle detection)
 ///
 /// Returns true if delegations with these scopes could conflict.
-/// Uses proposal domain lookup for precise Domain/Proposal overlap checking.
-fn scopes_overlap(
-    a: &DelegationScope,
-    b: &DelegationScope,
-    proposals: &HashMap<ProposalId, Proposal>,
-) -> bool {
+/// Conservative: assumes overlap when uncertain to prevent potential cycles.
+fn scopes_overlap(a: &DelegationScope, b: &DelegationScope) -> bool {
     match (a, b) {
         (DelegationScope::Blanket, _) | (_, DelegationScope::Blanket) => true,
         (DelegationScope::Domain(d1), DelegationScope::Domain(d2)) => d1 == d2,
-        (DelegationScope::Domain(d), DelegationScope::Proposal(p))
-        | (DelegationScope::Proposal(p), DelegationScope::Domain(d)) => {
-            // Use proposal lookup for precise domain checking
-            match proposals.get(p) {
-                Some(proposal) => &proposal.domain_id == d,
-                // Conservative fallback: assume overlap if proposal not found
-                None => true,
-            }
-        }
+        // Conservative: assume domain/proposal overlap since we can't verify membership
+        (DelegationScope::Domain(_), DelegationScope::Proposal(_))
+        | (DelegationScope::Proposal(_), DelegationScope::Domain(_)) => true,
         (DelegationScope::Proposal(p1), DelegationScope::Proposal(p2)) => p1 == p2,
     }
 }
@@ -778,7 +754,6 @@ fn find_delegation_cycle(
     delegate: &Did,
     scope: &DelegationScope,
     delegations: &HashMap<DelegationId, Delegation>,
-    proposals: &HashMap<ProposalId, Proposal>,
     now: Timestamp,
 ) -> Option<Vec<Did>> {
     let mut path = vec![delegator.clone(), delegate.clone()];
@@ -786,31 +761,17 @@ fn find_delegation_cycle(
     visited.insert(delegator.clone());
     let mut current = delegate.clone();
 
-    // Use inclusive range to detect cycles at the depth boundary
-    // With MAX_DELEGATION_DEPTH=3: 0..=3 checks 4 positions (delegate + 3 hops)
-    for _ in 0..=DEFAULT_MAX_DELEGATION_DEPTH {
-        // Only report a cycle if it leads back to the original delegator.
-        // If we encounter a node visited earlier in THIS walk but it's not
-        // the delegator, that's an existing cycle in the graph (e.g., B→C→B)
-        // which shouldn't block the new delegation A→B.
+    for _ in 0..DEFAULT_MAX_DELEGATION_DEPTH {
         if visited.contains(&current) {
-            if current == *delegator {
-                // True cycle back to origin delegator
-                return Some(path);
-            }
-            // Existing cycle in graph, but doesn't affect this delegation
-            return None;
+            // Found a cycle - current is already in our path
+            return Some(path);
         }
         visited.insert(current.clone());
 
         // Find any active delegation from current that matches scope
         let next = delegations
             .values()
-            .find(|d| {
-                d.delegator == current
-                    && d.is_active(now)
-                    && scopes_overlap(&d.scope, scope, proposals)
-            })
+            .find(|d| d.delegator == current && d.is_active(now) && scopes_overlap(&d.scope, scope))
             .map(|d| d.delegate.clone());
 
         match next {
@@ -837,40 +798,26 @@ fn compute_incoming_depth(
     delegate: &Did,
     scope: &DelegationScope,
     delegations: &HashMap<DelegationId, Delegation>,
-    proposals: &HashMap<ProposalId, Proposal>,
     now: Timestamp,
 ) -> usize {
     let mut visited = HashSet::new();
-    compute_incoming_depth_recursive(delegate, scope, delegations, proposals, now, &mut visited)
+    compute_incoming_depth_recursive(delegate, scope, delegations, now, &mut visited)
 }
 
-/// Recursive helper for computing incoming delegation depth.
-///
-/// The visited set is shared across all recursive branches to:
-/// 1. Prevent infinite loops on cyclic delegation graphs
-/// 2. Avoid redundant computation when multiple paths lead to the same node
-///
-/// For diamond patterns (A→C, B→C, D→A, D→B), sharing the visited set means
-/// we only compute C's depth once. This is safe because depth is the maximum
-/// chain length, and once we've computed a node's contribution, we don't need
-/// to recompute it from a different path.
 fn compute_incoming_depth_recursive(
     delegate: &Did,
     scope: &DelegationScope,
     delegations: &HashMap<DelegationId, Delegation>,
-    proposals: &HashMap<ProposalId, Proposal>,
     now: Timestamp,
     visited: &mut HashSet<Did>,
 ) -> usize {
-    // Prevent infinite recursion on cyclic graphs
+    // Prevent infinite recursion
     if visited.contains(delegate) {
         return 0;
     }
     visited.insert(delegate.clone());
 
-    // Safety limit: MAX_DELEGATION_DEPTH + 10 provides margin for edge cases
-    // like diamond patterns where we may visit more unique nodes than the
-    // strict chain depth. This is a defensive guard, not the primary limit.
+    // Safety limit
     if visited.len() > DEFAULT_MAX_DELEGATION_DEPTH + 10 {
         return 0;
     }
@@ -878,11 +825,7 @@ fn compute_incoming_depth_recursive(
     // Find all delegators who have delegated to this delegate with overlapping scope
     let delegators: Vec<Did> = delegations
         .values()
-        .filter(|d| {
-            d.delegate == *delegate
-                && d.is_active(now)
-                && scopes_overlap(&d.scope, scope, proposals)
-        })
+        .filter(|d| d.delegate == *delegate && d.is_active(now) && scopes_overlap(&d.scope, scope))
         .map(|d| d.delegator.clone())
         .collect();
 
@@ -893,9 +836,7 @@ fn compute_incoming_depth_recursive(
     // Recursively find the maximum depth
     delegators
         .into_iter()
-        .map(|d| {
-            1 + compute_incoming_depth_recursive(&d, scope, delegations, proposals, now, visited)
-        })
+        .map(|d| 1 + compute_incoming_depth_recursive(&d, scope, delegations, now, visited))
         .max()
         .unwrap_or(0)
 }
@@ -1094,126 +1035,6 @@ mod tests {
             DelegationScope::Domain(domain.clone()),
         );
         let result = mgr.create_delegation(d2).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("cycle"));
-    }
-
-    #[tokio::test]
-    async fn test_precise_scope_overlap_no_cycle_different_domains() {
-        let mgr = GovernanceManager::new();
-        let alice = test_did(1);
-        let bob = test_did(2);
-
-        let domain_a = GovernanceDomainId::new("domain-a");
-        let domain_b = GovernanceDomainId::new("domain-b");
-        let membership = MembershipConfig {
-            source: MembershipSource::StaticList(vec![alice.clone(), bob.clone()]),
-        };
-        let params = GovernanceParams::new(50, 50, 86400);
-
-        // Create domain B
-        mgr.create_domain(
-            domain_b.clone(),
-            "Domain B".to_string(),
-            "cooperative_default".to_string(),
-            params.clone(),
-            membership.clone(),
-        )
-        .await
-        .unwrap();
-
-        // Create a proposal in domain B
-        let proposal_id = ProposalId::generate();
-        mgr.create_proposal(
-            proposal_id.clone(),
-            domain_b.clone(),
-            alice.clone(),
-            "Test Proposal".to_string(),
-            "Description".to_string(),
-            ProposalPayload::Text {
-                body: "test".to_string(),
-            },
-        )
-        .await
-        .unwrap();
-
-        // Alice delegates domain A to Bob
-        mgr.create_delegation(Delegation::new(
-            alice.clone(),
-            bob.clone(),
-            DelegationScope::Domain(domain_a.clone()),
-        ))
-        .await
-        .unwrap();
-
-        // Bob delegates proposal (in domain B) to Alice
-        // This should SUCCEED because domain A != domain B (no cycle with precise checking)
-        let result = mgr
-            .create_delegation(Delegation::new(
-                bob.clone(),
-                alice.clone(),
-                DelegationScope::Proposal(proposal_id),
-            ))
-            .await;
-        assert!(result.is_ok(), "Expected no cycle but got: {result:?}");
-    }
-
-    #[tokio::test]
-    async fn test_precise_scope_overlap_cycle_same_domain() {
-        let mgr = GovernanceManager::new();
-        let alice = test_did(1);
-        let bob = test_did(2);
-
-        let domain_a = GovernanceDomainId::new("domain-a");
-        let membership = MembershipConfig {
-            source: MembershipSource::StaticList(vec![alice.clone(), bob.clone()]),
-        };
-        let params = GovernanceParams::new(50, 50, 86400);
-
-        // Create domain A
-        mgr.create_domain(
-            domain_a.clone(),
-            "Domain A".to_string(),
-            "cooperative_default".to_string(),
-            params.clone(),
-            membership.clone(),
-        )
-        .await
-        .unwrap();
-
-        // Create a proposal in domain A
-        let proposal_id = ProposalId::generate();
-        mgr.create_proposal(
-            proposal_id.clone(),
-            domain_a.clone(),
-            alice.clone(),
-            "Test Proposal".to_string(),
-            "Description".to_string(),
-            ProposalPayload::Text {
-                body: "test".to_string(),
-            },
-        )
-        .await
-        .unwrap();
-
-        // Alice delegates domain A to Bob
-        mgr.create_delegation(Delegation::new(
-            alice.clone(),
-            bob.clone(),
-            DelegationScope::Domain(domain_a.clone()),
-        ))
-        .await
-        .unwrap();
-
-        // Bob delegates proposal (in domain A) to Alice
-        // This should FAIL because proposal is in domain A (cycle detected)
-        let result = mgr
-            .create_delegation(Delegation::new(
-                bob.clone(),
-                alice.clone(),
-                DelegationScope::Proposal(proposal_id),
-            ))
-            .await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("cycle"));
     }

--- a/icn/crates/icn-gateway/src/governance_mgr.rs
+++ b/icn/crates/icn-gateway/src/governance_mgr.rs
@@ -786,7 +786,9 @@ fn find_delegation_cycle(
     visited.insert(delegator.clone());
     let mut current = delegate.clone();
 
-    for _ in 0..DEFAULT_MAX_DELEGATION_DEPTH {
+    // Use inclusive range to detect cycles at the depth boundary
+    // With MAX_DELEGATION_DEPTH=3: 0..=3 checks 4 positions (delegate + 3 hops)
+    for _ in 0..=DEFAULT_MAX_DELEGATION_DEPTH {
         if visited.contains(&current) {
             // Found a cycle - current is already in our path
             return Some(path);

--- a/icn/crates/icn-gateway/src/governance_mgr.rs
+++ b/icn/crates/icn-gateway/src/governance_mgr.rs
@@ -773,6 +773,21 @@ fn scopes_overlap(
 ///
 /// Returns Some(cycle_path) if a cycle would be created, None otherwise.
 /// The path includes the full cycle from delegator back to delegator.
+///
+/// # Algorithm Limitations
+///
+/// This function uses a single-path traversal starting from the delegate, following
+/// one outgoing delegation at each step. For each node, it picks the first active
+/// delegation that matches the scope, which means it may not explore all possible paths
+/// in a branching delegation graph.
+///
+/// In practice, this is acceptable because:
+/// 1. Most delegation graphs are linear chains, not DAGs
+/// 2. The MAX_DELEGATION_DEPTH limit (3) bounds the blast radius
+/// 3. Diamond patterns (A→B, A→C, B→D, C→D) don't create cycles by themselves
+///
+/// A more comprehensive BFS/DFS approach could be implemented if needed, but would
+/// add complexity without significant benefit for the expected use cases.
 fn find_delegation_cycle(
     delegator: &Did,
     delegate: &Did,

--- a/icn/crates/icn-gateway/src/governance_mgr.rs
+++ b/icn/crates/icn-gateway/src/governance_mgr.rs
@@ -589,6 +589,11 @@ impl GovernanceManager {
             anyhow::anyhow!("Delegations storage lock poisoned (concurrent panic?): {e}")
         })?;
 
+        // Get proposals for precise scope overlap checking
+        let proposals = self.proposals.read().map_err(|e| {
+            anyhow::anyhow!("Proposals storage lock poisoned (concurrent panic?): {e}")
+        })?;
+
         // Check for duplicate delegation ID
         if delegations.contains_key(&delegation.id) {
             anyhow::bail!(
@@ -616,6 +621,7 @@ impl GovernanceManager {
             &delegation.delegate,
             &delegation.scope,
             &delegations,
+            &proposals,
             now,
         );
         if let Some(path) = cycle_path {
@@ -630,14 +636,22 @@ impl GovernanceManager {
         }
 
         // Check max delegation depth: count how many hops lead TO the delegator
-        let incoming_depth =
-            compute_incoming_depth(&delegation.delegator, &delegation.scope, &delegations, now);
+        let incoming_depth = compute_incoming_depth(
+            &delegation.delegator,
+            &delegation.scope,
+            &delegations,
+            &proposals,
+            now,
+        );
         let max_depth = DEFAULT_MAX_DELEGATION_DEPTH;
         if incoming_depth >= max_depth {
             anyhow::bail!(
                 "Maximum delegation depth ({max_depth}) exceeded. The delegation chain is too long.",
             );
         }
+
+        // Release proposals lock before inserting
+        drop(proposals);
 
         delegations.insert(delegation.id.clone(), delegation);
         Ok(())
@@ -733,14 +747,24 @@ impl Default for GovernanceManager {
 /// Check if two delegation scopes overlap (for cycle detection)
 ///
 /// Returns true if delegations with these scopes could conflict.
-/// Conservative: assumes overlap when uncertain to prevent potential cycles.
-fn scopes_overlap(a: &DelegationScope, b: &DelegationScope) -> bool {
+/// Uses proposal domain lookup for precise Domain/Proposal overlap checking.
+fn scopes_overlap(
+    a: &DelegationScope,
+    b: &DelegationScope,
+    proposals: &HashMap<ProposalId, Proposal>,
+) -> bool {
     match (a, b) {
         (DelegationScope::Blanket, _) | (_, DelegationScope::Blanket) => true,
         (DelegationScope::Domain(d1), DelegationScope::Domain(d2)) => d1 == d2,
-        // Conservative: assume domain/proposal overlap since we can't verify membership
-        (DelegationScope::Domain(_), DelegationScope::Proposal(_))
-        | (DelegationScope::Proposal(_), DelegationScope::Domain(_)) => true,
+        (DelegationScope::Domain(d), DelegationScope::Proposal(p))
+        | (DelegationScope::Proposal(p), DelegationScope::Domain(d)) => {
+            // Use proposal lookup for precise domain checking
+            match proposals.get(p) {
+                Some(proposal) => &proposal.domain_id == d,
+                // Conservative fallback: assume overlap if proposal not found
+                None => true,
+            }
+        }
         (DelegationScope::Proposal(p1), DelegationScope::Proposal(p2)) => p1 == p2,
     }
 }
@@ -754,6 +778,7 @@ fn find_delegation_cycle(
     delegate: &Did,
     scope: &DelegationScope,
     delegations: &HashMap<DelegationId, Delegation>,
+    proposals: &HashMap<ProposalId, Proposal>,
     now: Timestamp,
 ) -> Option<Vec<Did>> {
     let mut path = vec![delegator.clone(), delegate.clone()];
@@ -771,7 +796,11 @@ fn find_delegation_cycle(
         // Find any active delegation from current that matches scope
         let next = delegations
             .values()
-            .find(|d| d.delegator == current && d.is_active(now) && scopes_overlap(&d.scope, scope))
+            .find(|d| {
+                d.delegator == current
+                    && d.is_active(now)
+                    && scopes_overlap(&d.scope, scope, proposals)
+            })
             .map(|d| d.delegate.clone());
 
         match next {
@@ -798,16 +827,18 @@ fn compute_incoming_depth(
     delegate: &Did,
     scope: &DelegationScope,
     delegations: &HashMap<DelegationId, Delegation>,
+    proposals: &HashMap<ProposalId, Proposal>,
     now: Timestamp,
 ) -> usize {
     let mut visited = HashSet::new();
-    compute_incoming_depth_recursive(delegate, scope, delegations, now, &mut visited)
+    compute_incoming_depth_recursive(delegate, scope, delegations, proposals, now, &mut visited)
 }
 
 fn compute_incoming_depth_recursive(
     delegate: &Did,
     scope: &DelegationScope,
     delegations: &HashMap<DelegationId, Delegation>,
+    proposals: &HashMap<ProposalId, Proposal>,
     now: Timestamp,
     visited: &mut HashSet<Did>,
 ) -> usize {
@@ -825,7 +856,11 @@ fn compute_incoming_depth_recursive(
     // Find all delegators who have delegated to this delegate with overlapping scope
     let delegators: Vec<Did> = delegations
         .values()
-        .filter(|d| d.delegate == *delegate && d.is_active(now) && scopes_overlap(&d.scope, scope))
+        .filter(|d| {
+            d.delegate == *delegate
+                && d.is_active(now)
+                && scopes_overlap(&d.scope, scope, proposals)
+        })
         .map(|d| d.delegator.clone())
         .collect();
 
@@ -836,7 +871,9 @@ fn compute_incoming_depth_recursive(
     // Recursively find the maximum depth
     delegators
         .into_iter()
-        .map(|d| 1 + compute_incoming_depth_recursive(&d, scope, delegations, now, visited))
+        .map(|d| {
+            1 + compute_incoming_depth_recursive(&d, scope, delegations, proposals, now, visited)
+        })
         .max()
         .unwrap_or(0)
 }
@@ -1035,6 +1072,126 @@ mod tests {
             DelegationScope::Domain(domain.clone()),
         );
         let result = mgr.create_delegation(d2).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cycle"));
+    }
+
+    #[tokio::test]
+    async fn test_precise_scope_overlap_no_cycle_different_domains() {
+        let mgr = GovernanceManager::new();
+        let alice = test_did(1);
+        let bob = test_did(2);
+
+        let domain_a = GovernanceDomainId::new("domain-a");
+        let domain_b = GovernanceDomainId::new("domain-b");
+        let membership = MembershipConfig {
+            source: MembershipSource::StaticList(vec![alice.clone(), bob.clone()]),
+        };
+        let params = GovernanceParams::new(50, 50, 86400);
+
+        // Create domain B
+        mgr.create_domain(
+            domain_b.clone(),
+            "Domain B".to_string(),
+            "cooperative_default".to_string(),
+            params.clone(),
+            membership.clone(),
+        )
+        .await
+        .unwrap();
+
+        // Create a proposal in domain B
+        let proposal_id = ProposalId::generate();
+        mgr.create_proposal(
+            proposal_id.clone(),
+            domain_b.clone(),
+            alice.clone(),
+            "Test Proposal".to_string(),
+            "Description".to_string(),
+            ProposalPayload::Text {
+                body: "test".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Alice delegates domain A to Bob
+        mgr.create_delegation(Delegation::new(
+            alice.clone(),
+            bob.clone(),
+            DelegationScope::Domain(domain_a.clone()),
+        ))
+        .await
+        .unwrap();
+
+        // Bob delegates proposal (in domain B) to Alice
+        // This should SUCCEED because domain A != domain B (no cycle with precise checking)
+        let result = mgr
+            .create_delegation(Delegation::new(
+                bob.clone(),
+                alice.clone(),
+                DelegationScope::Proposal(proposal_id),
+            ))
+            .await;
+        assert!(result.is_ok(), "Expected no cycle but got: {result:?}");
+    }
+
+    #[tokio::test]
+    async fn test_precise_scope_overlap_cycle_same_domain() {
+        let mgr = GovernanceManager::new();
+        let alice = test_did(1);
+        let bob = test_did(2);
+
+        let domain_a = GovernanceDomainId::new("domain-a");
+        let membership = MembershipConfig {
+            source: MembershipSource::StaticList(vec![alice.clone(), bob.clone()]),
+        };
+        let params = GovernanceParams::new(50, 50, 86400);
+
+        // Create domain A
+        mgr.create_domain(
+            domain_a.clone(),
+            "Domain A".to_string(),
+            "cooperative_default".to_string(),
+            params.clone(),
+            membership.clone(),
+        )
+        .await
+        .unwrap();
+
+        // Create a proposal in domain A
+        let proposal_id = ProposalId::generate();
+        mgr.create_proposal(
+            proposal_id.clone(),
+            domain_a.clone(),
+            alice.clone(),
+            "Test Proposal".to_string(),
+            "Description".to_string(),
+            ProposalPayload::Text {
+                body: "test".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Alice delegates domain A to Bob
+        mgr.create_delegation(Delegation::new(
+            alice.clone(),
+            bob.clone(),
+            DelegationScope::Domain(domain_a.clone()),
+        ))
+        .await
+        .unwrap();
+
+        // Bob delegates proposal (in domain A) to Alice
+        // This should FAIL because proposal is in domain A (cycle detected)
+        let result = mgr
+            .create_delegation(Delegation::new(
+                bob.clone(),
+                alice.clone(),
+                DelegationScope::Proposal(proposal_id),
+            ))
+            .await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("cycle"));
     }

--- a/icn/crates/icn-governance/src/delegation.rs
+++ b/icn/crates/icn-governance/src/delegation.rs
@@ -968,7 +968,7 @@ mod tests {
             DelegationScope::Proposal(proposal_in_b.clone()),
         ));
 
-        assert!(result.is_ok(), "Expected no cycle but got: {:?}", result);
+        assert!(result.is_ok(), "Expected no cycle but got: {result:?}");
     }
 
     #[test]

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -117,7 +117,8 @@ pub use vote::{Vote, VoteChoice};
 // Protocol governance types (Phase 20)
 pub use protocol::{
     ParameterChange, ParameterConstraints, ParameterScope, ParameterValidationError,
-    ParameterValue, ProtocolChangeProposal, ProtocolParameter,
+    ParameterValue, PendingChangeId, PendingChangeStatus, PendingParameterChange,
+    ProtocolChangeProposal, ProtocolParameter,
 };
 pub use protocol_defaults::{default_parameters, get_default_parameter, ParameterCategory};
 pub use protocol_store::{

--- a/icn/crates/icn-governance/src/protocol.rs
+++ b/icn/crates/icn-governance/src/protocol.rs
@@ -862,6 +862,161 @@ pub enum ParameterValidationError {
 }
 
 // ============================================================================
+// PendingParameterChange (for delayed execution)
+// ============================================================================
+
+/// Unique identifier for a pending parameter change
+pub type PendingChangeId = String;
+
+/// Status of a pending parameter change
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PendingChangeStatus {
+    /// Change is scheduled but not yet applied
+    Pending,
+
+    /// Change was successfully applied at the effective time
+    Applied,
+
+    /// Change was cancelled before it took effect
+    Cancelled,
+
+    /// Change was superseded by a newer change to the same parameter
+    Superseded,
+}
+
+impl fmt::Display for PendingChangeStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PendingChangeStatus::Pending => write!(f, "pending"),
+            PendingChangeStatus::Applied => write!(f, "applied"),
+            PendingChangeStatus::Cancelled => write!(f, "cancelled"),
+            PendingChangeStatus::Superseded => write!(f, "superseded"),
+        }
+    }
+}
+
+/// A scheduled parameter change waiting to take effect
+///
+/// When a protocol change proposal with `effective_at` is approved,
+/// a `PendingParameterChange` is created and stored. The background
+/// scheduler periodically checks for due changes and applies them.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingParameterChange {
+    /// Unique identifier for this pending change
+    pub id: PendingChangeId,
+
+    /// ID of the parameter being changed
+    pub parameter_id: String,
+
+    /// The new value to apply
+    pub new_value: ParameterValue,
+
+    /// Unix timestamp when this change should take effect
+    pub effective_at: u64,
+
+    /// Scope where this change applies
+    pub scope: ParameterScope,
+
+    /// ID of the proposal that authorized this change
+    pub proposal_id: String,
+
+    /// Unix timestamp when this pending change was created
+    pub created_at: u64,
+
+    /// Current status of this pending change
+    pub status: PendingChangeStatus,
+
+    /// Rationale for the change (copied from proposal)
+    pub rationale: String,
+
+    /// If superseded, the ID of the change that superseded this one
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub superseded_by: Option<PendingChangeId>,
+
+    /// If applied, the timestamp when it was applied
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub applied_at: Option<u64>,
+
+    /// If cancelled, the reason for cancellation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cancellation_reason: Option<String>,
+}
+
+impl PendingParameterChange {
+    /// Create a new pending parameter change
+    pub fn new(
+        id: impl Into<String>,
+        parameter_id: impl Into<String>,
+        new_value: ParameterValue,
+        effective_at: u64,
+        scope: ParameterScope,
+        proposal_id: impl Into<String>,
+        rationale: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            parameter_id: parameter_id.into(),
+            new_value,
+            effective_at,
+            scope,
+            proposal_id: proposal_id.into(),
+            created_at: icn_time::current_timestamp_secs(),
+            status: PendingChangeStatus::Pending,
+            rationale: rationale.into(),
+            superseded_by: None,
+            applied_at: None,
+            cancellation_reason: None,
+        }
+    }
+
+    /// Generate a unique ID for a pending change
+    ///
+    /// Format: `pending:{parameter_id}:{timestamp}:{counter}`
+    /// Uses an atomic counter for uniqueness when multiple changes are created in the same second.
+    pub fn generate_id(parameter_id: &str) -> String {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+        let timestamp = icn_time::current_timestamp_secs();
+        let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+        format!("pending:{parameter_id}:{timestamp}:{counter:08x}")
+    }
+
+    /// Check if this change is due (effective_at <= current time)
+    pub fn is_due(&self, current_time: u64) -> bool {
+        self.status == PendingChangeStatus::Pending && self.effective_at <= current_time
+    }
+
+    /// Mark this change as applied
+    pub fn mark_applied(&mut self) {
+        self.status = PendingChangeStatus::Applied;
+        self.applied_at = Some(icn_time::current_timestamp_secs());
+    }
+
+    /// Mark this change as cancelled
+    pub fn mark_cancelled(&mut self, reason: impl Into<String>) {
+        self.status = PendingChangeStatus::Cancelled;
+        self.cancellation_reason = Some(reason.into());
+    }
+
+    /// Mark this change as superseded by another change
+    pub fn mark_superseded(&mut self, superseded_by: impl Into<String>) {
+        self.status = PendingChangeStatus::Superseded;
+        self.superseded_by = Some(superseded_by.into());
+    }
+
+    /// Time until this change takes effect (in seconds), or None if already due
+    pub fn time_until_effective(&self, current_time: u64) -> Option<u64> {
+        if self.effective_at > current_time {
+            Some(self.effective_at - current_time)
+        } else {
+            None
+        }
+    }
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -1310,5 +1465,190 @@ mod tests {
             result,
             Err(ParameterValidationError::InvalidParameterId { .. })
         ));
+    }
+
+    // ============================================================================
+    // PendingParameterChange tests
+    // ============================================================================
+
+    #[test]
+    fn test_pending_change_creation() {
+        let change = PendingParameterChange::new(
+            "pending:governance.quorum:12345:abc",
+            "governance.quorum",
+            ParameterValue::Percentage(60.0),
+            1700000000,
+            ParameterScope::Global,
+            "prop-123",
+            "Increase quorum for better participation",
+        );
+
+        assert_eq!(change.parameter_id, "governance.quorum");
+        assert_eq!(change.effective_at, 1700000000);
+        assert_eq!(change.status, PendingChangeStatus::Pending);
+        assert!(change.applied_at.is_none());
+        assert!(change.superseded_by.is_none());
+        assert!(change.cancellation_reason.is_none());
+    }
+
+    #[test]
+    fn test_pending_change_generate_id() {
+        let id1 = PendingParameterChange::generate_id("governance.quorum");
+        let id2 = PendingParameterChange::generate_id("governance.quorum");
+
+        // IDs should start with expected prefix
+        assert!(id1.starts_with("pending:governance.quorum:"));
+        assert!(id2.starts_with("pending:governance.quorum:"));
+
+        // IDs should be unique due to random component
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn test_pending_change_is_due() {
+        let change = PendingParameterChange::new(
+            "test-id",
+            "governance.quorum",
+            ParameterValue::Percentage(60.0),
+            1700000000,
+            ParameterScope::Global,
+            "prop-123",
+            "Test",
+        );
+
+        // Not yet due
+        assert!(!change.is_due(1699999999));
+
+        // Exactly due
+        assert!(change.is_due(1700000000));
+
+        // Past due
+        assert!(change.is_due(1700000001));
+    }
+
+    #[test]
+    fn test_pending_change_mark_applied() {
+        let mut change = PendingParameterChange::new(
+            "test-id",
+            "governance.quorum",
+            ParameterValue::Percentage(60.0),
+            1700000000,
+            ParameterScope::Global,
+            "prop-123",
+            "Test",
+        );
+
+        change.mark_applied();
+
+        assert_eq!(change.status, PendingChangeStatus::Applied);
+        assert!(change.applied_at.is_some());
+    }
+
+    #[test]
+    fn test_pending_change_mark_cancelled() {
+        let mut change = PendingParameterChange::new(
+            "test-id",
+            "governance.quorum",
+            ParameterValue::Percentage(60.0),
+            1700000000,
+            ParameterScope::Global,
+            "prop-123",
+            "Test",
+        );
+
+        change.mark_cancelled("Governance override");
+
+        assert_eq!(change.status, PendingChangeStatus::Cancelled);
+        assert_eq!(
+            change.cancellation_reason,
+            Some("Governance override".to_string())
+        );
+    }
+
+    #[test]
+    fn test_pending_change_mark_superseded() {
+        let mut change = PendingParameterChange::new(
+            "test-id",
+            "governance.quorum",
+            ParameterValue::Percentage(60.0),
+            1700000000,
+            ParameterScope::Global,
+            "prop-123",
+            "Test",
+        );
+
+        change.mark_superseded("newer-change-id");
+
+        assert_eq!(change.status, PendingChangeStatus::Superseded);
+        assert_eq!(change.superseded_by, Some("newer-change-id".to_string()));
+    }
+
+    #[test]
+    fn test_pending_change_time_until_effective() {
+        let change = PendingParameterChange::new(
+            "test-id",
+            "governance.quorum",
+            ParameterValue::Percentage(60.0),
+            1700000000,
+            ParameterScope::Global,
+            "prop-123",
+            "Test",
+        );
+
+        // Before effective time
+        assert_eq!(change.time_until_effective(1699999000), Some(1000));
+
+        // Exactly at effective time
+        assert_eq!(change.time_until_effective(1700000000), None);
+
+        // After effective time
+        assert_eq!(change.time_until_effective(1700000100), None);
+    }
+
+    #[test]
+    fn test_pending_change_status_display() {
+        assert_eq!(PendingChangeStatus::Pending.to_string(), "pending");
+        assert_eq!(PendingChangeStatus::Applied.to_string(), "applied");
+        assert_eq!(PendingChangeStatus::Cancelled.to_string(), "cancelled");
+        assert_eq!(PendingChangeStatus::Superseded.to_string(), "superseded");
+    }
+
+    #[test]
+    fn test_pending_change_serialization() {
+        let change = PendingParameterChange::new(
+            "test-id",
+            "governance.quorum",
+            ParameterValue::Percentage(60.0),
+            1700000000,
+            ParameterScope::Global,
+            "prop-123",
+            "Test rationale",
+        );
+
+        let json = serde_json::to_string(&change).unwrap();
+        let parsed: PendingParameterChange = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.id, change.id);
+        assert_eq!(parsed.parameter_id, change.parameter_id);
+        assert_eq!(parsed.effective_at, change.effective_at);
+        assert_eq!(parsed.status, change.status);
+    }
+
+    #[test]
+    fn test_pending_change_cancelled_not_due() {
+        let mut change = PendingParameterChange::new(
+            "test-id",
+            "governance.quorum",
+            ParameterValue::Percentage(60.0),
+            1700000000,
+            ParameterScope::Global,
+            "prop-123",
+            "Test",
+        );
+
+        change.mark_cancelled("Cancelled by governance");
+
+        // Even though time has passed, cancelled changes are not due
+        assert!(!change.is_due(1700000001));
     }
 }

--- a/icn/crates/icn-governance/src/protocol.rs
+++ b/icn/crates/icn-governance/src/protocol.rs
@@ -1500,7 +1500,7 @@ mod tests {
         assert!(id1.starts_with("pending:governance.quorum:"));
         assert!(id2.starts_with("pending:governance.quorum:"));
 
-        // IDs should be unique due to random component
+        // IDs should be unique due to atomic counter
         assert_ne!(id1, id2);
     }
 

--- a/icn/crates/icn-governance/src/protocol_store.rs
+++ b/icn/crates/icn-governance/src/protocol_store.rs
@@ -61,8 +61,8 @@
 //! ```
 
 use crate::protocol::{
-    ParameterChange, ParameterScope, ParameterValidationError, ParameterValue, ProtocolParameter,
-    KNOWN_PARAMETER_CATEGORIES,
+    ParameterChange, ParameterScope, ParameterValidationError, ParameterValue, PendingChangeId,
+    PendingChangeStatus, PendingParameterChange, ProtocolParameter, KNOWN_PARAMETER_CATEGORIES,
 };
 use anyhow::Result;
 use icn_entity::EntityId;
@@ -335,6 +335,45 @@ pub trait ProtocolParameterStore: Send + Sync {
         id: &str,
         new_value: &ParameterValue,
     ) -> Result<(), ParameterValidationError>;
+
+    // ========================================
+    // Pending Change Methods (Delayed Execution)
+    // ========================================
+
+    /// Add a pending parameter change for delayed execution
+    ///
+    /// The change will be stored and applied when the scheduler runs
+    /// after `effective_at` timestamp.
+    fn add_pending_change(&self, change: PendingParameterChange) -> Result<()>;
+
+    /// Get a pending change by ID
+    fn get_pending_change(&self, id: &PendingChangeId) -> Result<Option<PendingParameterChange>>;
+
+    /// List all pending changes (all statuses)
+    fn list_pending_changes(&self) -> Result<Vec<PendingParameterChange>>;
+
+    /// List pending changes for a specific parameter
+    fn list_pending_changes_for_parameter(
+        &self,
+        parameter_id: &str,
+    ) -> Result<Vec<PendingParameterChange>>;
+
+    /// Get all pending changes that are due (effective_at <= timestamp)
+    ///
+    /// Returns only changes with status `Pending` that should be applied.
+    /// Results are ordered by `effective_at` (earliest first) for consistent processing.
+    fn get_changes_due_before(&self, timestamp: u64) -> Result<Vec<PendingParameterChange>>;
+
+    /// Update a pending change (e.g., mark as applied, superseded)
+    fn update_pending_change(&self, change: PendingParameterChange) -> Result<()>;
+
+    /// Cancel a pending change
+    ///
+    /// Sets the status to `Cancelled` and records the reason.
+    fn cancel_pending_change(&self, id: &PendingChangeId, reason: &str) -> Result<()>;
+
+    /// Get count of active pending changes (status = Pending)
+    fn count_pending_changes(&self) -> Result<usize>;
 }
 
 // ============================================================================
@@ -352,6 +391,8 @@ pub struct InMemoryParameterStore {
     scoped_index: Arc<RwLock<HashMap<String, Vec<String>>>>,
     /// History: id -> Vec<ParameterChange>
     history: Arc<RwLock<HashMap<String, Vec<ParameterChange>>>>,
+    /// Pending changes for delayed execution: pending_change_id -> PendingParameterChange
+    pending_changes: Arc<RwLock<HashMap<PendingChangeId, PendingParameterChange>>>,
 }
 
 impl InMemoryParameterStore {
@@ -690,6 +731,147 @@ impl ProtocolParameterStore for InMemoryParameterStore {
 
         param.validate(new_value)
     }
+
+    // ========================================
+    // Pending Change Methods (Delayed Execution)
+    // ========================================
+
+    fn add_pending_change(&self, change: PendingParameterChange) -> Result<()> {
+        let mut pending = self
+            .pending_changes
+            .write()
+            .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+
+        if pending.contains_key(&change.id) {
+            return Err(anyhow::anyhow!(
+                "Pending change with ID '{}' already exists",
+                change.id
+            ));
+        }
+
+        debug!(
+            pending_change_id = %change.id,
+            parameter_id = %change.parameter_id,
+            effective_at = change.effective_at,
+            "Adding pending parameter change"
+        );
+
+        pending.insert(change.id.clone(), change);
+        Ok(())
+    }
+
+    fn get_pending_change(&self, id: &PendingChangeId) -> Result<Option<PendingParameterChange>> {
+        let pending = self
+            .pending_changes
+            .read()
+            .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+        Ok(pending.get(id).cloned())
+    }
+
+    fn list_pending_changes(&self) -> Result<Vec<PendingParameterChange>> {
+        let pending = self
+            .pending_changes
+            .read()
+            .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+        let mut changes: Vec<_> = pending.values().cloned().collect();
+        // Sort by effective_at for consistent ordering
+        changes.sort_by_key(|c| c.effective_at);
+        Ok(changes)
+    }
+
+    fn list_pending_changes_for_parameter(
+        &self,
+        parameter_id: &str,
+    ) -> Result<Vec<PendingParameterChange>> {
+        let pending = self
+            .pending_changes
+            .read()
+            .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+        let mut changes: Vec<_> = pending
+            .values()
+            .filter(|c| c.parameter_id == parameter_id)
+            .cloned()
+            .collect();
+        changes.sort_by_key(|c| c.effective_at);
+        Ok(changes)
+    }
+
+    fn get_changes_due_before(&self, timestamp: u64) -> Result<Vec<PendingParameterChange>> {
+        let pending = self
+            .pending_changes
+            .read()
+            .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+        let mut due: Vec<_> = pending
+            .values()
+            .filter(|c| c.status == PendingChangeStatus::Pending && c.effective_at <= timestamp)
+            .cloned()
+            .collect();
+        // Sort by effective_at (earliest first) for consistent processing order
+        due.sort_by_key(|c| c.effective_at);
+        Ok(due)
+    }
+
+    fn update_pending_change(&self, change: PendingParameterChange) -> Result<()> {
+        let mut pending = self
+            .pending_changes
+            .write()
+            .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+
+        if !pending.contains_key(&change.id) {
+            return Err(anyhow::anyhow!(
+                "Pending change with ID '{}' not found",
+                change.id
+            ));
+        }
+
+        debug!(
+            pending_change_id = %change.id,
+            status = %change.status,
+            "Updating pending parameter change"
+        );
+
+        pending.insert(change.id.clone(), change);
+        Ok(())
+    }
+
+    fn cancel_pending_change(&self, id: &PendingChangeId, reason: &str) -> Result<()> {
+        let mut pending = self
+            .pending_changes
+            .write()
+            .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+
+        let change = pending
+            .get_mut(id)
+            .ok_or_else(|| anyhow::anyhow!("Pending change with ID '{id}' not found"))?;
+
+        if change.status != PendingChangeStatus::Pending {
+            return Err(anyhow::anyhow!(
+                "Cannot cancel pending change '{}' with status '{}'",
+                id,
+                change.status
+            ));
+        }
+
+        debug!(
+            pending_change_id = %id,
+            reason = %reason,
+            "Cancelling pending parameter change"
+        );
+
+        change.mark_cancelled(reason);
+        Ok(())
+    }
+
+    fn count_pending_changes(&self) -> Result<usize> {
+        let pending = self
+            .pending_changes
+            .read()
+            .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+        Ok(pending
+            .values()
+            .filter(|c| c.status == PendingChangeStatus::Pending)
+            .count())
+    }
 }
 
 // ============================================================================
@@ -768,6 +950,33 @@ impl SledParameterStore {
 
     fn deserialize_change(bytes: &[u8]) -> Result<ParameterChange> {
         serde_json::from_slice(bytes).map_err(|e| anyhow::anyhow!("Deserialization failed: {e}"))
+    }
+
+    // Pending change key generation
+    // Key schema:
+    // - `pending:{id}` - main storage
+    // - `pending_idx:{effective_at:020}:{id}` - time-sorted index for scheduler
+
+    fn pending_key(id: &str) -> Vec<u8> {
+        format!("pending:{id}").into_bytes()
+    }
+
+    fn pending_prefix() -> Vec<u8> {
+        b"pending:".to_vec()
+    }
+
+    fn pending_time_index_key(effective_at: u64, id: &str) -> Vec<u8> {
+        // Use zero-padded timestamp for lexicographic ordering
+        format!("pending_idx:{effective_at:020}:{id}").into_bytes()
+    }
+
+    fn pending_time_index_prefix() -> Vec<u8> {
+        b"pending_idx:".to_vec()
+    }
+
+    fn deserialize_pending_change(bytes: &[u8]) -> Result<PendingParameterChange> {
+        serde_json::from_slice(bytes)
+            .map_err(|e| anyhow::anyhow!("Deserialization of pending change failed: {e}"))
     }
 }
 
@@ -1298,6 +1507,192 @@ impl ProtocolParameterStore for SledParameterStore {
             .ok_or_else(|| ParameterValidationError::NotFound(id.to_string()))?;
 
         param.validate(new_value)
+    }
+
+    // ========================================
+    // Pending Change Methods (Delayed Execution)
+    // ========================================
+
+    fn add_pending_change(&self, change: PendingParameterChange) -> Result<()> {
+        let pending_key = Self::pending_key(&change.id);
+        let index_key = Self::pending_time_index_key(change.effective_at, &change.id);
+
+        // Check if already exists
+        if self.db.contains_key(&pending_key)? {
+            return Err(anyhow::anyhow!(
+                "Pending change with ID '{}' already exists",
+                change.id
+            ));
+        }
+
+        let pending_value = Self::serialize(&change)?;
+
+        debug!(
+            pending_change_id = %change.id,
+            parameter_id = %change.parameter_id,
+            effective_at = change.effective_at,
+            "Adding pending parameter change"
+        );
+
+        // Use transaction to atomically insert both keys
+        self.db
+            .transaction(|tx| {
+                tx.insert(pending_key.as_slice(), pending_value.as_slice())?;
+                // Store only the ID in the index (the full data is in pending_key)
+                tx.insert(index_key.as_slice(), change.id.as_bytes())?;
+                Ok(())
+            })
+            .map_err(|e| match e {
+                sled::transaction::TransactionError::Abort(err) => err,
+                sled::transaction::TransactionError::Storage(e) => {
+                    anyhow::anyhow!("Storage error adding pending change: {e}")
+                }
+            })?;
+
+        Ok(())
+    }
+
+    fn get_pending_change(&self, id: &PendingChangeId) -> Result<Option<PendingParameterChange>> {
+        let key = Self::pending_key(id);
+        match self.db.get(&key)? {
+            Some(bytes) => Ok(Some(Self::deserialize_pending_change(&bytes)?)),
+            None => Ok(None),
+        }
+    }
+
+    fn list_pending_changes(&self) -> Result<Vec<PendingParameterChange>> {
+        let prefix = Self::pending_prefix();
+        let mut changes = Vec::new();
+
+        for item in self.db.scan_prefix(&prefix) {
+            let (_, value) = item?;
+            changes.push(Self::deserialize_pending_change(&value)?);
+        }
+
+        // Sort by effective_at for consistent ordering
+        changes.sort_by_key(|c| c.effective_at);
+        Ok(changes)
+    }
+
+    fn list_pending_changes_for_parameter(
+        &self,
+        parameter_id: &str,
+    ) -> Result<Vec<PendingParameterChange>> {
+        let prefix = Self::pending_prefix();
+        let mut changes = Vec::new();
+
+        for item in self.db.scan_prefix(&prefix) {
+            let (_, value) = item?;
+            let change = Self::deserialize_pending_change(&value)?;
+            if change.parameter_id == parameter_id {
+                changes.push(change);
+            }
+        }
+
+        changes.sort_by_key(|c| c.effective_at);
+        Ok(changes)
+    }
+
+    fn get_changes_due_before(&self, timestamp: u64) -> Result<Vec<PendingParameterChange>> {
+        // Use the time-sorted index for efficient lookup
+        // Keys are formatted as pending_idx:{effective_at:020}:{id}
+        // Lexicographic scan stops at the timestamp boundary
+        let prefix = Self::pending_time_index_prefix();
+        let max_key = format!("pending_idx:{:020}:", timestamp + 1).into_bytes();
+
+        let mut due = Vec::new();
+
+        for item in self.db.scan_prefix(&prefix) {
+            let (key, value) = item?;
+
+            // Stop scanning once we're past the timestamp
+            if key.as_ref() >= max_key.as_slice() {
+                break;
+            }
+
+            // The index stores the pending change ID
+            let id = String::from_utf8_lossy(&value).to_string();
+
+            // Fetch the actual change
+            if let Some(change) = self.get_pending_change(&id)? {
+                // Only include pending changes
+                if change.status == PendingChangeStatus::Pending {
+                    due.push(change);
+                }
+            }
+        }
+
+        // Already sorted by effective_at due to index key ordering
+        Ok(due)
+    }
+
+    fn update_pending_change(&self, change: PendingParameterChange) -> Result<()> {
+        let pending_key = Self::pending_key(&change.id);
+
+        // Check if exists
+        if !self.db.contains_key(&pending_key)? {
+            return Err(anyhow::anyhow!(
+                "Pending change with ID '{}' not found",
+                change.id
+            ));
+        }
+
+        debug!(
+            pending_change_id = %change.id,
+            status = %change.status,
+            "Updating pending parameter change"
+        );
+
+        let pending_value = Self::serialize(&change)?;
+        self.db.insert(&pending_key, pending_value)?;
+
+        Ok(())
+    }
+
+    fn cancel_pending_change(&self, id: &PendingChangeId, reason: &str) -> Result<()> {
+        let pending_key = Self::pending_key(id);
+
+        let bytes = self
+            .db
+            .get(&pending_key)?
+            .ok_or_else(|| anyhow::anyhow!("Pending change with ID '{id}' not found"))?;
+
+        let mut change = Self::deserialize_pending_change(&bytes)?;
+
+        if change.status != PendingChangeStatus::Pending {
+            return Err(anyhow::anyhow!(
+                "Cannot cancel pending change '{}' with status '{}'",
+                id,
+                change.status
+            ));
+        }
+
+        debug!(
+            pending_change_id = %id,
+            reason = %reason,
+            "Cancelling pending parameter change"
+        );
+
+        change.mark_cancelled(reason);
+        let pending_value = Self::serialize(&change)?;
+        self.db.insert(&pending_key, pending_value)?;
+
+        Ok(())
+    }
+
+    fn count_pending_changes(&self) -> Result<usize> {
+        let prefix = Self::pending_prefix();
+        let mut count = 0;
+
+        for item in self.db.scan_prefix(&prefix) {
+            let (_, value) = item?;
+            let change = Self::deserialize_pending_change(&value)?;
+            if change.status == PendingChangeStatus::Pending {
+                count += 1;
+            }
+        }
+
+        Ok(count)
     }
 }
 
@@ -2363,5 +2758,301 @@ mod tests {
         };
         assert!(err.to_string().contains("governance.threshold"));
         assert!(err.to_string().contains("scope overrides"));
+    }
+
+    // ========================================
+    // PendingParameterChange tests (InMemory)
+    // ========================================
+
+    fn test_pending_change(param_id: &str, effective_at: u64) -> PendingParameterChange {
+        PendingParameterChange::new(
+            format!("pending:{param_id}:{effective_at}"),
+            param_id,
+            ParameterValue::Integer(100),
+            effective_at,
+            ParameterScope::Global,
+            "proposal-123",
+            "Test rationale",
+        )
+    }
+
+    #[test]
+    fn test_inmemory_pending_change_add_and_get() {
+        let store = InMemoryParameterStore::new();
+
+        let change = test_pending_change("test.param", 1700000000);
+        store.add_pending_change(change.clone()).unwrap();
+
+        let retrieved = store.get_pending_change(&change.id).unwrap().unwrap();
+        assert_eq!(retrieved.parameter_id, "test.param");
+        assert_eq!(retrieved.effective_at, 1700000000);
+        assert_eq!(retrieved.status, PendingChangeStatus::Pending);
+    }
+
+    #[test]
+    fn test_inmemory_pending_change_duplicate_rejected() {
+        let store = InMemoryParameterStore::new();
+
+        let change = test_pending_change("test.param", 1700000000);
+        store.add_pending_change(change.clone()).unwrap();
+
+        // Trying to add same ID again should fail
+        let result = store.add_pending_change(change);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_inmemory_pending_change_list() {
+        let store = InMemoryParameterStore::new();
+
+        store
+            .add_pending_change(test_pending_change("param.a", 1700000100))
+            .unwrap();
+        store
+            .add_pending_change(test_pending_change("param.b", 1700000000))
+            .unwrap();
+        store
+            .add_pending_change(test_pending_change("param.c", 1700000200))
+            .unwrap();
+
+        let all = store.list_pending_changes().unwrap();
+        assert_eq!(all.len(), 3);
+        // Should be sorted by effective_at
+        assert_eq!(all[0].parameter_id, "param.b");
+        assert_eq!(all[1].parameter_id, "param.a");
+        assert_eq!(all[2].parameter_id, "param.c");
+    }
+
+    #[test]
+    fn test_inmemory_pending_change_list_for_parameter() {
+        let store = InMemoryParameterStore::new();
+
+        store
+            .add_pending_change(test_pending_change("param.a", 1700000100))
+            .unwrap();
+        store
+            .add_pending_change(test_pending_change("param.a", 1700000200))
+            .unwrap();
+        store
+            .add_pending_change(test_pending_change("param.b", 1700000000))
+            .unwrap();
+
+        let a_changes = store.list_pending_changes_for_parameter("param.a").unwrap();
+        assert_eq!(a_changes.len(), 2);
+        assert!(a_changes.iter().all(|c| c.parameter_id == "param.a"));
+    }
+
+    #[test]
+    fn test_inmemory_pending_change_get_due() {
+        let store = InMemoryParameterStore::new();
+
+        store
+            .add_pending_change(test_pending_change("param.a", 1700000100))
+            .unwrap();
+        store
+            .add_pending_change(test_pending_change("param.b", 1700000200))
+            .unwrap();
+        store
+            .add_pending_change(test_pending_change("param.c", 1700000300))
+            .unwrap();
+
+        // Get changes due before 1700000150
+        let due = store.get_changes_due_before(1700000150).unwrap();
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].parameter_id, "param.a");
+
+        // Get changes due before 1700000250
+        let due = store.get_changes_due_before(1700000250).unwrap();
+        assert_eq!(due.len(), 2);
+    }
+
+    #[test]
+    fn test_inmemory_pending_change_cancel() {
+        let store = InMemoryParameterStore::new();
+
+        let change = test_pending_change("test.param", 1700000000);
+        store.add_pending_change(change.clone()).unwrap();
+
+        store
+            .cancel_pending_change(&change.id, "Cancelled by admin")
+            .unwrap();
+
+        let retrieved = store.get_pending_change(&change.id).unwrap().unwrap();
+        assert_eq!(retrieved.status, PendingChangeStatus::Cancelled);
+        assert_eq!(
+            retrieved.cancellation_reason,
+            Some("Cancelled by admin".to_string())
+        );
+    }
+
+    #[test]
+    fn test_inmemory_pending_change_count() {
+        let store = InMemoryParameterStore::new();
+
+        store
+            .add_pending_change(test_pending_change("param.a", 1700000000))
+            .unwrap();
+        store
+            .add_pending_change(test_pending_change("param.b", 1700000100))
+            .unwrap();
+
+        assert_eq!(store.count_pending_changes().unwrap(), 2);
+
+        // Cancel one
+        store
+            .cancel_pending_change(&"pending:param.a:1700000000".to_string(), "test")
+            .unwrap();
+
+        // Count should now be 1
+        assert_eq!(store.count_pending_changes().unwrap(), 1);
+    }
+
+    // ========================================
+    // PendingParameterChange tests (Sled)
+    // ========================================
+
+    #[test]
+    fn test_sled_pending_change_add_and_get() {
+        let store = SledParameterStore::temporary().unwrap();
+
+        let change = test_pending_change("test.param", 1700000000);
+        store.add_pending_change(change.clone()).unwrap();
+
+        let retrieved = store.get_pending_change(&change.id).unwrap().unwrap();
+        assert_eq!(retrieved.parameter_id, "test.param");
+        assert_eq!(retrieved.effective_at, 1700000000);
+        assert_eq!(retrieved.status, PendingChangeStatus::Pending);
+    }
+
+    #[test]
+    fn test_sled_pending_change_duplicate_rejected() {
+        let store = SledParameterStore::temporary().unwrap();
+
+        let change = test_pending_change("test.param", 1700000000);
+        store.add_pending_change(change.clone()).unwrap();
+
+        // Trying to add same ID again should fail
+        let result = store.add_pending_change(change);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_sled_pending_change_list() {
+        let store = SledParameterStore::temporary().unwrap();
+
+        store
+            .add_pending_change(test_pending_change("param.a", 1700000100))
+            .unwrap();
+        store
+            .add_pending_change(test_pending_change("param.b", 1700000000))
+            .unwrap();
+        store
+            .add_pending_change(test_pending_change("param.c", 1700000200))
+            .unwrap();
+
+        let all = store.list_pending_changes().unwrap();
+        assert_eq!(all.len(), 3);
+        // Should be sorted by effective_at
+        assert_eq!(all[0].parameter_id, "param.b");
+        assert_eq!(all[1].parameter_id, "param.a");
+        assert_eq!(all[2].parameter_id, "param.c");
+    }
+
+    #[test]
+    fn test_sled_pending_change_get_due() {
+        let store = SledParameterStore::temporary().unwrap();
+
+        store
+            .add_pending_change(test_pending_change("param.a", 1700000100))
+            .unwrap();
+        store
+            .add_pending_change(test_pending_change("param.b", 1700000200))
+            .unwrap();
+        store
+            .add_pending_change(test_pending_change("param.c", 1700000300))
+            .unwrap();
+
+        // Get changes due before 1700000150
+        let due = store.get_changes_due_before(1700000150).unwrap();
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].parameter_id, "param.a");
+
+        // Get changes due before 1700000250
+        let due = store.get_changes_due_before(1700000250).unwrap();
+        assert_eq!(due.len(), 2);
+    }
+
+    #[test]
+    fn test_sled_pending_change_cancel() {
+        let store = SledParameterStore::temporary().unwrap();
+
+        let change = test_pending_change("test.param", 1700000000);
+        store.add_pending_change(change.clone()).unwrap();
+
+        store
+            .cancel_pending_change(&change.id, "Cancelled by admin")
+            .unwrap();
+
+        let retrieved = store.get_pending_change(&change.id).unwrap().unwrap();
+        assert_eq!(retrieved.status, PendingChangeStatus::Cancelled);
+        assert_eq!(
+            retrieved.cancellation_reason,
+            Some("Cancelled by admin".to_string())
+        );
+    }
+
+    #[test]
+    fn test_sled_pending_change_update() {
+        let store = SledParameterStore::temporary().unwrap();
+
+        let mut change = test_pending_change("test.param", 1700000000);
+        store.add_pending_change(change.clone()).unwrap();
+
+        // Mark as applied
+        change.mark_applied();
+        store.update_pending_change(change.clone()).unwrap();
+
+        let retrieved = store.get_pending_change(&change.id).unwrap().unwrap();
+        assert_eq!(retrieved.status, PendingChangeStatus::Applied);
+        assert!(retrieved.applied_at.is_some());
+    }
+
+    #[test]
+    fn test_sled_pending_change_count() {
+        let store = SledParameterStore::temporary().unwrap();
+
+        store
+            .add_pending_change(test_pending_change("param.a", 1700000000))
+            .unwrap();
+        store
+            .add_pending_change(test_pending_change("param.b", 1700000100))
+            .unwrap();
+
+        assert_eq!(store.count_pending_changes().unwrap(), 2);
+
+        // Cancel one
+        store
+            .cancel_pending_change(&"pending:param.a:1700000000".to_string(), "test")
+            .unwrap();
+
+        // Count should now be 1
+        assert_eq!(store.count_pending_changes().unwrap(), 1);
+    }
+
+    #[test]
+    fn test_sled_pending_change_cancelled_not_due() {
+        let store = SledParameterStore::temporary().unwrap();
+
+        let change = test_pending_change("test.param", 1700000000);
+        store.add_pending_change(change.clone()).unwrap();
+
+        // Cancel it
+        store
+            .cancel_pending_change(&change.id, "Cancelled")
+            .unwrap();
+
+        // It should not be returned as due
+        let due = store.get_changes_due_before(1800000000).unwrap();
+        assert!(due.is_empty());
     }
 }

--- a/icn/crates/icn-governance/src/protocol_store.rs
+++ b/icn/crates/icn-governance/src/protocol_store.rs
@@ -806,8 +806,15 @@ impl ProtocolParameterStore for InMemoryParameterStore {
             .filter(|c| c.status == PendingChangeStatus::Pending && c.effective_at <= timestamp)
             .cloned()
             .collect();
-        // Sort by effective_at (earliest first) for consistent processing order
-        due.sort_by_key(|c| c.effective_at);
+        // Sort by effective_at (earliest first), with tie-breakers for deterministic ordering.
+        // This ensures consistent processing order even when multiple changes have the same
+        // effective_at timestamp. Tie-breakers: created_at (earlier wins), then id (lexicographic).
+        due.sort_by(|a, b| {
+            a.effective_at
+                .cmp(&b.effective_at)
+                .then_with(|| a.created_at.cmp(&b.created_at))
+                .then_with(|| a.id.cmp(&b.id))
+        });
         Ok(due)
     }
 
@@ -1622,7 +1629,15 @@ impl ProtocolParameterStore for SledParameterStore {
             }
         }
 
-        // Already sorted by effective_at due to index key ordering
+        // Re-sort with tie-breakers for deterministic ordering when effective_at matches.
+        // The index provides effective_at ordering, but for same-timestamp conflicts we need
+        // additional tie-breakers: created_at (earlier wins), then id (lexicographic).
+        due.sort_by(|a, b| {
+            a.effective_at
+                .cmp(&b.effective_at)
+                .then_with(|| a.created_at.cmp(&b.created_at))
+                .then_with(|| a.id.cmp(&b.id))
+        });
         Ok(due)
     }
 

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -2184,6 +2184,36 @@ pub mod governance {
     }
 }
 
+/// Protocol parameter metrics (delayed execution)
+pub mod protocol {
+    use metrics::{counter, gauge};
+
+    /// Increment when a pending parameter change is scheduled
+    pub fn pending_parameter_changes_scheduled_inc() {
+        counter!("icn_protocol_pending_changes_scheduled_total").increment(1);
+    }
+
+    /// Increment when a pending parameter change is applied
+    pub fn pending_parameter_changes_applied_inc() {
+        counter!("icn_protocol_pending_changes_applied_total").increment(1);
+    }
+
+    /// Increment when a pending parameter change is cancelled
+    pub fn pending_parameter_changes_cancelled_inc() {
+        counter!("icn_protocol_pending_changes_cancelled_total").increment(1);
+    }
+
+    /// Increment when a pending parameter change is superseded
+    pub fn pending_parameter_changes_superseded_inc() {
+        counter!("icn_protocol_pending_changes_superseded_total").increment(1);
+    }
+
+    /// Set the current number of active pending changes
+    pub fn pending_parameter_changes_active_set(count: u64) {
+        gauge!("icn_protocol_pending_changes_active").set(count as f64);
+    }
+}
+
 /// Trust graph metrics
 pub mod trust {
     use metrics::{counter, gauge, histogram};


### PR DESCRIPTION
## Summary

Implements issue #282: Adds support for scheduling protocol parameter changes to take effect at a future timestamp rather than immediately upon approval.

## Changes

### Storage Layer (icn-governance)
- Add `PendingParameterChange` struct with comprehensive status tracking
- Add `PendingChangeStatus` enum: Pending, Applied, Cancelled, Superseded
- Extend `ProtocolParameterStore` trait with 8 new pending change methods
- Implement pending change storage for both `SledParameterStore` and `InMemoryParameterStore`
- Add time-sorted index (`pending_idx:{effective_at:020}:{id}`) for efficient scheduler queries

### Background Scheduler (icn-core)
- Add `ParameterSchedulerConfig` with configurable check interval (default: 10 seconds)
- Add `spawn_parameter_scheduler_task()` following existing background task patterns
- Spawn scheduler task in supervisor initialization after metrics task
- Apply due changes in chronological order (earliest first)
- Handle superseding of older pending changes for same parameter
- Crash recovery handled automatically via immediate tick on startup

### Governance Flow
- Update validation at proposal creation to allow `effective_at`:
  - Must be in the future
  - Max delay limit: 1 year
- Branch `handle_protocol_change()` between immediate and delayed execution
- Create `PendingParameterChange` and store for delayed proposals
- Add `schedule_pending_change()` method to GovernanceHandle

### Metrics (icn-obs)
- Add `protocol` module with pending change metrics:
  - `pending_parameter_changes_scheduled_total`
  - `pending_parameter_changes_applied_total`
  - `pending_parameter_changes_cancelled_total`
  - `pending_parameter_changes_superseded_total`
  - `pending_parameter_changes_active` (gauge)

### Tests
- 10 unit tests for `PendingParameterChange` in protocol.rs
- 7 tests for InMemoryParameterStore pending change methods
- 7 tests for SledParameterStore pending change methods
- All 247 governance tests pass

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test -p icn-governance` passes (247 tests)
- [x] `cargo test -p icn-core` passes

## Key files changed

| File | Changes |
|------|---------|
| `icn-governance/src/protocol.rs` | Add PendingParameterChange, PendingChangeStatus, tests |
| `icn-governance/src/protocol_store.rs` | Extend trait, implement for both stores, tests |
| `icn-governance/src/lib.rs` | Export new types |
| `icn-core/src/supervisor/background_tasks.rs` | Add scheduler task |
| `icn-core/src/supervisor/mod.rs` | Spawn scheduler |
| `icn-core/src/governance/actor.rs` | Update validation, add schedule method |
| `icn-core/src/supervisor/governance_handlers.rs` | Add delayed execution path |
| `icn-obs/src/metrics_legacy.rs` | Add protocol metrics |

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)