### PR TITLE
feat(gateway): Add entity audit retention policy

### DIFF
--- a/icn/crates/icn-core/src/config.rs
+++ b/icn/crates/icn-core/src/config.rs
@@ -372,6 +372,62 @@ impl Default for RateLimitingConfig {
     }
 }
 
+// Audit retention default value functions
+fn default_retention_days() -> u64 {
+    365
+}
+fn default_max_records_per_entity() -> usize {
+    10000
+}
+fn default_prune_interval_secs() -> u64 {
+    3600
+}
+fn default_prune_batch_size() -> usize {
+    1000
+}
+
+/// Audit retention configuration for entity audit records
+///
+/// Controls how long audit records are kept and how pruning is performed.
+/// This prevents unbounded storage growth in high-activity cooperatives.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditRetentionConfig {
+    /// Maximum age of audit records in days (default: 365)
+    /// Records older than this are eligible for pruning
+    #[serde(default = "default_retention_days")]
+    pub retention_days: u64,
+
+    /// Maximum number of audit records per entity (default: 10000)
+    /// Oldest records beyond this limit are eligible for pruning
+    #[serde(default = "default_max_records_per_entity")]
+    pub max_records_per_entity: usize,
+
+    /// Interval between automatic pruning runs in seconds (default: 3600 = 1 hour)
+    #[serde(default = "default_prune_interval_secs")]
+    pub prune_interval_secs: u64,
+
+    /// Enable automatic background pruning (default: true)
+    #[serde(default = "default_true")]
+    pub auto_prune_enabled: bool,
+
+    /// Batch size for pruning operations (default: 1000)
+    /// Larger batches are more efficient but may cause longer lock times
+    #[serde(default = "default_prune_batch_size")]
+    pub prune_batch_size: usize,
+}
+
+impl Default for AuditRetentionConfig {
+    fn default() -> Self {
+        Self {
+            retention_days: default_retention_days(),
+            max_records_per_entity: default_max_records_per_entity(),
+            prune_interval_secs: default_prune_interval_secs(),
+            auto_prune_enabled: true,
+            prune_batch_size: default_prune_batch_size(),
+        }
+    }
+}
+
 /// Gateway API configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GatewayConfig {
@@ -395,6 +451,10 @@ pub struct GatewayConfig {
     /// If empty, gateway will fail to start
     #[serde(default)]
     pub jwt_secret: String,
+
+    /// Audit retention policy configuration
+    #[serde(default)]
+    pub audit_retention: AuditRetentionConfig,
 }
 
 /// Federation configuration for cross-network connectivity
@@ -642,6 +702,7 @@ impl Default for GatewayConfig {
             token_expiry_hours: default_token_expiry_hours(),
             challenge_ttl_minutes: default_challenge_ttl_minutes(),
             jwt_secret: String::new(),
+            audit_retention: AuditRetentionConfig::default(),
         }
     }
 }

--- a/icn/crates/icn-core/src/supervisor/background_tasks.rs
+++ b/icn/crates/icn-core/src/supervisor/background_tasks.rs
@@ -474,6 +474,111 @@ async fn apply_pending_change(
     ParameterApplyResult::Applied
 }
 
+/// Configuration for entity audit pruning task
+pub struct AuditPruneConfig {
+    /// Interval between pruning runs
+    pub prune_interval: Duration,
+    /// Maximum age of audit records in days
+    pub retention_days: u64,
+    /// Maximum records to keep per entity
+    pub max_records_per_entity: usize,
+    /// Batch size for pruning operations
+    pub batch_size: usize,
+}
+
+impl Default for AuditPruneConfig {
+    fn default() -> Self {
+        Self {
+            prune_interval: Duration::from_secs(3600), // 1 hour
+            retention_days: 365,
+            max_records_per_entity: 10000,
+            batch_size: 1000,
+        }
+    }
+}
+
+impl From<&crate::config::AuditRetentionConfig> for AuditPruneConfig {
+    fn from(config: &crate::config::AuditRetentionConfig) -> Self {
+        Self {
+            prune_interval: Duration::from_secs(config.prune_interval_secs),
+            retention_days: config.retention_days,
+            max_records_per_entity: config.max_records_per_entity,
+            batch_size: config.prune_batch_size,
+        }
+    }
+}
+
+/// Spawn the entity audit pruning background task
+///
+/// This task periodically prunes old audit records based on the retention policy.
+/// It runs at the configured interval and removes records that:
+/// 1. Exceed the maximum age (retention_days)
+/// 2. Exceed the maximum count per entity (max_records_per_entity)
+///
+/// # Parameters
+/// - `config`: Pruning configuration
+/// - `audit_manager`: The entity audit manager
+/// - `shutdown_rx`: Shutdown signal receiver
+pub fn spawn_audit_prune_task(
+    config: AuditPruneConfig,
+    audit_manager: Arc<icn_gateway::EntityAuditManager>,
+    mut shutdown_rx: BroadcastReceiver<()>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        info!(
+            retention_days = config.retention_days,
+            max_records = config.max_records_per_entity,
+            interval_secs = config.prune_interval.as_secs(),
+            "Audit prune task started"
+        );
+
+        let mut interval = tokio::time::interval(config.prune_interval);
+
+        // Skip first tick to avoid immediate pruning on startup
+        interval.tick().await;
+
+        loop {
+            select! {
+                _ = interval.tick() => {
+                    debug!("Running scheduled audit pruning");
+
+                    match audit_manager.prune_audit_records(
+                        config.retention_days,
+                        config.max_records_per_entity,
+                        config.batch_size,
+                    ) {
+                        Ok(stats) => {
+                            if stats.records_pruned > 0 {
+                                info!(
+                                    records_pruned = stats.records_pruned,
+                                    entities_processed = stats.entities_processed,
+                                    duration_ms = stats.duration_ms,
+                                    "Audit pruning completed"
+                                );
+                            } else {
+                                debug!("Audit pruning completed - no records to prune");
+                            }
+
+                            // Log any non-fatal errors
+                            for error in &stats.errors {
+                                warn!("Audit prune error: {}", error);
+                            }
+                        }
+                        Err(e) => {
+                            warn!("Audit pruning failed: {}", e);
+                            icn_obs::metrics::gateway::entity_audit_prune_failed_inc();
+                        }
+                    }
+                }
+                _ = shutdown_rx.recv() => {
+                    info!("Audit prune task shutting down");
+                    break;
+                }
+            }
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -495,5 +600,14 @@ mod tests {
     fn test_parameter_scheduler_config_default() {
         let config = ParameterSchedulerConfig::default();
         assert_eq!(config.check_interval, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn test_audit_prune_config_default() {
+        let config = AuditPruneConfig::default();
+        assert_eq!(config.prune_interval, Duration::from_secs(3600));
+        assert_eq!(config.retention_days, 365);
+        assert_eq!(config.max_records_per_entity, 10000);
+        assert_eq!(config.batch_size, 1000);
     }
 }

--- a/icn/crates/icn-gateway/src/api/entity.rs
+++ b/icn/crates/icn-gateway/src/api/entity.rs
@@ -946,6 +946,45 @@ pub struct AuditQueryParams {
     pub offset: Option<usize>,
 }
 
+// ============================================================================
+// Admin API Types (Audit Retention)
+// ============================================================================
+
+/// Request to prune audit records
+#[derive(Debug, Deserialize)]
+pub struct PruneAuditRequest {
+    /// Specific entity to prune (optional - prunes all if not set)
+    pub entity_id: Option<String>,
+    /// Override retention days (optional - uses system default if not set)
+    pub retention_days: Option<u64>,
+    /// Override max records per entity (optional)
+    pub max_records: Option<usize>,
+}
+
+/// Response from prune operation
+#[derive(Debug, Serialize)]
+pub struct PruneAuditResponse {
+    /// Number of records scanned
+    pub records_scanned: usize,
+    /// Number of records pruned
+    pub records_pruned: usize,
+    /// Number of entities processed
+    pub entities_processed: usize,
+    /// Duration of operation in milliseconds
+    pub duration_ms: u64,
+    /// Any errors encountered (non-fatal)
+    pub errors: Vec<String>,
+}
+
+/// Response from audit stats endpoint
+#[derive(Debug, Serialize)]
+pub struct AuditStatsResponse {
+    /// Total number of audit records
+    pub total_records: usize,
+    /// Number of entities with audit trails
+    pub entities_with_audits: usize,
+}
+
 /// GET /entities/:id/audit - Get entity audit trail
 ///
 /// Requires the caller to either:
@@ -1012,9 +1051,149 @@ pub async fn get_entity_audit(
     Ok(HttpResponse::Ok().json(trail))
 }
 
+// ============================================================================
+// Admin Endpoints (Audit Retention)
+// ============================================================================
+
+/// POST /entities/audit/prune - Manually prune audit records (admin only)
+///
+/// Requires "admin" or "entity:audit" scope.
+/// Can prune all entities or a specific entity. Supports overriding
+/// retention policy parameters.
+#[post("/audit/prune")]
+pub async fn prune_audit(
+    req: HttpRequest,
+    audit_mgr: web::Data<Arc<EntityAuditManager>>,
+    body: web::Json<PruneAuditRequest>,
+) -> Result<HttpResponse> {
+    // Require admin scope
+    let claims = get_claims(&req)
+        .ok_or_else(|| GatewayError::AuthenticationFailed("No claims found".to_string()))?;
+
+    let has_admin_scope = claims
+        .scopes
+        .iter()
+        .any(|s| s == "admin" || s == "entity:audit");
+
+    if !has_admin_scope {
+        return Err(GatewayError::Forbidden(
+            "Admin scope required to prune audit records".to_string(),
+        ));
+    }
+
+    // Default retention policy values
+    let retention_days = body.retention_days.unwrap_or(365);
+    let max_records = body.max_records.unwrap_or(10000);
+    let batch_size = 1000; // Fixed batch size for manual prune
+
+    let start = std::time::Instant::now();
+
+    let stats = if let Some(ref entity_id_str) = body.entity_id {
+        // Prune specific entity
+        let entity_id: EntityId = entity_id_str
+            .parse()
+            .map_err(|e| GatewayError::BadRequest(format!("Invalid entity ID: {e}")))?;
+
+        info!(
+            entity_id = %entity_id,
+            retention_days = retention_days,
+            max_records = max_records,
+            "Admin pruning audit records for specific entity"
+        );
+
+        audit_mgr
+            .prune_entity(&entity_id, Some(retention_days), Some(max_records))
+            .map_err(|e| {
+                GatewayError::InternalError(format!("Failed to prune audit records: {e}"))
+            })?
+    } else {
+        // Prune all entities
+        info!(
+            retention_days = retention_days,
+            max_records = max_records,
+            "Admin pruning audit records for all entities"
+        );
+
+        audit_mgr
+            .prune_audit_records(retention_days, max_records, batch_size)
+            .map_err(|e| {
+                GatewayError::InternalError(format!("Failed to prune audit records: {e}"))
+            })?
+    };
+
+    let duration_ms = start.elapsed().as_millis() as u64;
+
+    // Record metrics
+    gateway_metrics::entity_audit_pruned_inc(stats.records_pruned);
+    gateway_metrics::entity_audit_prune_duration(start.elapsed().as_secs_f64());
+
+    let response = PruneAuditResponse {
+        records_scanned: stats.records_scanned,
+        records_pruned: stats.records_pruned,
+        entities_processed: stats.entities_processed,
+        duration_ms,
+        errors: stats.errors,
+    };
+
+    info!(
+        records_scanned = stats.records_scanned,
+        records_pruned = stats.records_pruned,
+        entities_processed = stats.entities_processed,
+        duration_ms = duration_ms,
+        "Admin prune completed"
+    );
+
+    Ok(HttpResponse::Ok().json(response))
+}
+
+/// GET /entities/audit/stats - Get audit storage statistics (admin only)
+///
+/// Requires "admin" or "entity:audit" scope.
+/// Returns total record count and number of entities with audit trails.
+#[get("/audit/stats")]
+pub async fn audit_stats(
+    req: HttpRequest,
+    audit_mgr: web::Data<Arc<EntityAuditManager>>,
+) -> Result<HttpResponse> {
+    // Require admin scope
+    let claims = get_claims(&req)
+        .ok_or_else(|| GatewayError::AuthenticationFailed("No claims found".to_string()))?;
+
+    let has_admin_scope = claims
+        .scopes
+        .iter()
+        .any(|s| s == "admin" || s == "entity:audit");
+
+    if !has_admin_scope {
+        return Err(GatewayError::Forbidden(
+            "Admin scope required to view audit statistics".to_string(),
+        ));
+    }
+
+    let total_records = audit_mgr
+        .count_audit_records()
+        .map_err(|e| GatewayError::InternalError(format!("Failed to count audit records: {e}")))?;
+
+    let entities_with_audits = audit_mgr
+        .get_entities_with_audits()
+        .map_err(|e| GatewayError::InternalError(format!("Failed to get entities: {e}")))?
+        .len();
+
+    let response = AuditStatsResponse {
+        total_records,
+        entities_with_audits,
+    };
+
+    Ok(HttpResponse::Ok().json(response))
+}
+
 /// Configure entity routes
 pub fn configure(cfg: &mut web::ServiceConfig) {
-    cfg.service(register_entity)
+    // Order matters: /audit/* routes must come before /{id}/* routes
+    // to avoid treating "audit" as an entity ID
+    cfg.service(prune_audit)
+        .service(audit_stats)
+        .service(register_entity)
         .service(get_entity)
         .service(update_entity)
         .service(delete_entity)

--- a/icn/crates/icn-gateway/src/entity_audit.rs
+++ b/icn/crates/icn-gateway/src/entity_audit.rs
@@ -324,6 +324,244 @@ impl EntityAuditManager {
         self.store.put(key.as_bytes(), &value)?;
         Ok(())
     }
+
+    /// Prune audit records based on retention policy
+    ///
+    /// This method scans all entity audit records and removes those that:
+    /// 1. Exceed the maximum age (retention_days)
+    /// 2. Exceed the maximum count per entity (max_records_per_entity)
+    ///
+    /// Records are pruned in order from oldest to newest.
+    ///
+    /// # Arguments
+    /// * `retention_days` - Maximum age of records in days
+    /// * `max_records_per_entity` - Maximum records to keep per entity
+    /// * `batch_size` - Maximum records to process per entity per call
+    ///
+    /// # Returns
+    /// Statistics about the pruning operation
+    pub fn prune_audit_records(
+        &self,
+        retention_days: u64,
+        max_records_per_entity: usize,
+        batch_size: usize,
+    ) -> Result<PruneStats> {
+        let start = std::time::Instant::now();
+        let mut stats = PruneStats {
+            records_scanned: 0,
+            records_pruned: 0,
+            entities_processed: 0,
+            duration_ms: 0,
+            errors: Vec::new(),
+        };
+
+        // Calculate cutoff timestamp (seconds)
+        let now_secs = icn_time::current_timestamp_millis() / 1000;
+        let cutoff_secs = now_secs.saturating_sub(retention_days * 24 * 60 * 60);
+
+        // Get all unique entity IDs with audit records
+        let entity_ids = self.get_entities_with_audits()?;
+
+        for entity_id in entity_ids {
+            stats.entities_processed += 1;
+
+            match self.prune_entity_audits(
+                &entity_id,
+                cutoff_secs,
+                max_records_per_entity,
+                batch_size,
+            ) {
+                Ok((scanned, pruned)) => {
+                    stats.records_scanned += scanned;
+                    stats.records_pruned += pruned;
+                }
+                Err(e) => {
+                    stats.errors.push(format!("{entity_id}: {e}"));
+                }
+            }
+        }
+
+        stats.duration_ms = start.elapsed().as_millis() as u64;
+
+        // Record metrics
+        gateway_metrics::entity_audit_pruned_inc(stats.records_pruned);
+        gateway_metrics::entity_audit_prune_duration(stats.duration_ms as f64 / 1000.0);
+
+        info!(
+            records_pruned = stats.records_pruned,
+            entities_processed = stats.entities_processed,
+            duration_ms = stats.duration_ms,
+            "Audit pruning completed"
+        );
+
+        Ok(stats)
+    }
+
+    /// Prune audit records for a specific entity
+    ///
+    /// # Arguments
+    /// * `entity_id` - Entity to prune records for
+    /// * `retention_days` - Optional max age override (None = no age limit)
+    /// * `max_records` - Optional max count override (None = no count limit)
+    ///
+    /// # Returns
+    /// Statistics about the pruning operation
+    pub fn prune_entity(
+        &self,
+        entity_id: &EntityId,
+        retention_days: Option<u64>,
+        max_records: Option<usize>,
+    ) -> Result<PruneStats> {
+        let start = std::time::Instant::now();
+
+        let now_secs = icn_time::current_timestamp_millis() / 1000;
+        let cutoff_secs = retention_days
+            .map(|days| now_secs.saturating_sub(days * 24 * 60 * 60))
+            .unwrap_or(0);
+
+        let max = max_records.unwrap_or(usize::MAX);
+
+        let (scanned, pruned) =
+            self.prune_entity_audits(entity_id, cutoff_secs, max, usize::MAX)?;
+
+        let stats = PruneStats {
+            records_scanned: scanned,
+            records_pruned: pruned,
+            entities_processed: 1,
+            duration_ms: start.elapsed().as_millis() as u64,
+            errors: Vec::new(),
+        };
+
+        // Record metrics
+        gateway_metrics::entity_audit_pruned_inc(stats.records_pruned);
+
+        Ok(stats)
+    }
+
+    /// Count total audit records across all entities
+    pub fn count_audit_records(&self) -> Result<usize> {
+        self.store.scan_count(ENTITY_AUDIT_PREFIX.as_bytes())
+    }
+
+    /// Prune audit records for a single entity
+    ///
+    /// Returns (records_scanned, records_pruned)
+    fn prune_entity_audits(
+        &self,
+        entity_id: &EntityId,
+        cutoff_secs: u64,
+        max_records: usize,
+        batch_size: usize,
+    ) -> Result<(usize, usize)> {
+        let prefix = format!("{ENTITY_AUDIT_PREFIX}{entity_id}:");
+
+        // Scan all records for this entity (forward order = oldest first)
+        let all_pairs = self.store.scan(prefix.as_bytes())?;
+        let total_count = all_pairs.len();
+
+        // Calculate how many to prune based on count limit
+        let excess_count = total_count.saturating_sub(max_records);
+
+        let mut scanned = 0;
+        let mut pruned = 0;
+
+        for (key, value) in all_pairs.into_iter().take(batch_size) {
+            scanned += 1;
+
+            // Check if record should be pruned
+            let should_prune = if scanned <= excess_count {
+                // Prune excess records (oldest first since keys are timestamp-ordered)
+                true
+            } else if cutoff_secs > 0 {
+                // Check age-based pruning
+                if let Ok(record) = serde_json::from_slice::<EntityAuditRecord>(&value) {
+                    record.performed_at < cutoff_secs
+                } else {
+                    // Corrupted record - prune it
+                    gateway_metrics::entity_audit_corruption_inc();
+                    true
+                }
+            } else {
+                false
+            };
+
+            if should_prune {
+                self.store.delete(&key)?;
+                pruned += 1;
+            }
+        }
+
+        Ok((scanned, pruned))
+    }
+
+    /// Get list of entity IDs that have audit records
+    pub fn get_entities_with_audits(&self) -> Result<Vec<EntityId>> {
+        let mut entities = std::collections::HashSet::new();
+
+        // Scan all audit keys to extract unique entity IDs
+        // Key format: gateway:entity:audit:{entity_id}:{timestamp}:{audit_id}
+        let pairs = self.store.scan(ENTITY_AUDIT_PREFIX.as_bytes())?;
+
+        for (key, _) in pairs {
+            let key_str = String::from_utf8_lossy(&key);
+            if let Some(rest) = key_str.strip_prefix(ENTITY_AUDIT_PREFIX) {
+                // rest = "{entity_id}:{timestamp}:{audit_id}"
+                // entity_id format: "entity:icn:cooperative:name" or similar
+                // We need to find where the entity_id ends (before the millisecond timestamp)
+                // The timestamp is a large number, so we look for the pattern
+                if let Some(entity_id_str) = Self::extract_entity_id_from_key(rest) {
+                    if let Ok(entity_id) = entity_id_str.parse() {
+                        entities.insert(entity_id);
+                    }
+                }
+            }
+        }
+
+        Ok(entities.into_iter().collect())
+    }
+
+    /// Extract entity ID from the rest of the key after prefix
+    ///
+    /// Key rest format: "{entity_id}:{millis_timestamp}:{audit_id}"
+    /// Entity ID format: "entity:icn:{type}:{name}" (contains colons)
+    /// We find the timestamp by looking for the millisecond number pattern
+    fn extract_entity_id_from_key(rest: &str) -> Option<String> {
+        // Split by colon and work backwards to find the timestamp
+        // The timestamp is a 13-digit number (milliseconds since epoch)
+        let parts: Vec<&str> = rest.split(':').collect();
+
+        // Minimum: entity:icn:type:name:timestamp:audit-id = 6 parts
+        if parts.len() < 6 {
+            return None;
+        }
+
+        // Find the timestamp part (should be at position -2 from end, before audit-id)
+        // audit-id format: "audit-{secs}-{uuid}"
+        // So we look for a part that is purely numeric and ~13 digits (millis timestamp)
+        for i in 3..parts.len().saturating_sub(1) {
+            if parts[i].chars().all(|c| c.is_ascii_digit()) && parts[i].len() >= 13 {
+                // Found the timestamp - entity_id is everything before this
+                return Some(parts[..i].join(":"));
+            }
+        }
+
+        None
+    }
+}
+
+/// Statistics from a pruning operation
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PruneStats {
+    /// Total records scanned
+    pub records_scanned: usize,
+    /// Records pruned (deleted)
+    pub records_pruned: usize,
+    /// Entities processed
+    pub entities_processed: usize,
+    /// Duration in milliseconds
+    pub duration_ms: u64,
+    /// Errors encountered (non-fatal)
+    pub errors: Vec<String>,
 }
 
 #[cfg(test)]
@@ -519,5 +757,306 @@ mod tests {
             trail.records[1].performed_at >= trail.records[2].performed_at,
             "Timestamps should be descending"
         );
+    }
+
+    #[test]
+    fn test_count_audit_records() {
+        let (mgr, _temp) = create_test_manager();
+
+        let entity1 = EntityId::cooperative("coop-1").expect("valid coop id");
+        let entity2 = EntityId::cooperative("coop-2").expect("valid coop id");
+        let performer_keypair = KeyPair::generate().expect("keypair");
+        let performer = EntityId::from_did(performer_keypair.did());
+
+        // Start with 0 records
+        assert_eq!(mgr.count_audit_records().unwrap(), 0);
+
+        // Add 3 records to entity1
+        for i in 0..3 {
+            mgr.record_audit(
+                &entity1,
+                EntityOperation::Updated {
+                    changed_fields: vec![format!("field{}", i)],
+                },
+                &performer,
+                None,
+                None,
+            )
+            .expect("Failed to record audit");
+        }
+
+        assert_eq!(mgr.count_audit_records().unwrap(), 3);
+
+        // Add 2 records to entity2
+        for i in 0..2 {
+            mgr.record_audit(
+                &entity2,
+                EntityOperation::Updated {
+                    changed_fields: vec![format!("field{}", i)],
+                },
+                &performer,
+                None,
+                None,
+            )
+            .expect("Failed to record audit");
+        }
+
+        assert_eq!(mgr.count_audit_records().unwrap(), 5);
+    }
+
+    #[test]
+    fn test_get_entities_with_audits() {
+        let (mgr, _temp) = create_test_manager();
+
+        let entity1 = EntityId::cooperative("coop-1").expect("valid coop id");
+        let entity2 = EntityId::cooperative("coop-2").expect("valid coop id");
+        let performer_keypair = KeyPair::generate().expect("keypair");
+        let performer = EntityId::from_did(performer_keypair.did());
+
+        // Start with 0 entities
+        assert_eq!(mgr.get_entities_with_audits().unwrap().len(), 0);
+
+        // Add record to entity1
+        mgr.record_audit(
+            &entity1,
+            EntityOperation::Registered {
+                entity_type: "cooperative".to_string(),
+                name: "Coop 1".to_string(),
+            },
+            &performer,
+            None,
+            None,
+        )
+        .expect("Failed to record audit");
+
+        let entities = mgr.get_entities_with_audits().unwrap();
+        assert_eq!(entities.len(), 1);
+        assert!(entities.contains(&entity1));
+
+        // Add record to entity2
+        mgr.record_audit(
+            &entity2,
+            EntityOperation::Registered {
+                entity_type: "cooperative".to_string(),
+                name: "Coop 2".to_string(),
+            },
+            &performer,
+            None,
+            None,
+        )
+        .expect("Failed to record audit");
+
+        let entities = mgr.get_entities_with_audits().unwrap();
+        assert_eq!(entities.len(), 2);
+        assert!(entities.contains(&entity1));
+        assert!(entities.contains(&entity2));
+    }
+
+    #[test]
+    fn test_prune_by_count() {
+        let (mgr, _temp) = create_test_manager();
+
+        let entity_id = EntityId::cooperative("test-coop").expect("valid coop id");
+        let performer_keypair = KeyPair::generate().expect("keypair");
+        let performer = EntityId::from_did(performer_keypair.did());
+
+        // Create 10 records
+        for i in 0..10 {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            mgr.record_audit(
+                &entity_id,
+                EntityOperation::Updated {
+                    changed_fields: vec![format!("field{}", i)],
+                },
+                &performer,
+                None,
+                None,
+            )
+            .expect("Failed to record audit");
+        }
+
+        assert_eq!(mgr.count_audit_records().unwrap(), 10);
+
+        // Prune to max 5 records (long retention to avoid age-based pruning)
+        let stats = mgr
+            .prune_audit_records(
+                365 * 10, // 10 years retention - won't trigger age-based prune
+                5,        // max 5 records per entity
+                100,      // batch size
+            )
+            .expect("Failed to prune");
+
+        assert_eq!(stats.records_scanned, 10);
+        assert_eq!(stats.records_pruned, 5); // Oldest 5 pruned
+        assert_eq!(stats.entities_processed, 1);
+
+        // Verify 5 records remain
+        assert_eq!(mgr.count_audit_records().unwrap(), 5);
+
+        // Verify we kept the 5 most recent (newest) records
+        let trail = mgr.get_audit_trail(&entity_id, 10, 0).unwrap();
+        assert_eq!(trail.total, 5);
+    }
+
+    #[test]
+    fn test_prune_specific_entity() {
+        let (mgr, _temp) = create_test_manager();
+
+        let entity1 = EntityId::cooperative("coop-1").expect("valid coop id");
+        let entity2 = EntityId::cooperative("coop-2").expect("valid coop id");
+        let performer_keypair = KeyPair::generate().expect("keypair");
+        let performer = EntityId::from_did(performer_keypair.did());
+
+        // Create 10 records each for 2 entities
+        for entity in [&entity1, &entity2] {
+            for i in 0..10 {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+                mgr.record_audit(
+                    entity,
+                    EntityOperation::Updated {
+                        changed_fields: vec![format!("field{}", i)],
+                    },
+                    &performer,
+                    None,
+                    None,
+                )
+                .expect("Failed to record audit");
+            }
+        }
+
+        assert_eq!(mgr.count_audit_records().unwrap(), 20);
+
+        // Prune only entity1 to max 3 records
+        let stats = mgr
+            .prune_entity(
+                &entity1,
+                Some(365 * 10), // Long retention
+                Some(3),        // max 3 records
+            )
+            .expect("Failed to prune");
+
+        assert_eq!(stats.records_scanned, 10); // Only scanned entity1
+        assert_eq!(stats.records_pruned, 7); // Pruned 7 records from entity1
+        assert_eq!(stats.entities_processed, 1);
+
+        // Verify entity1 has 3 records
+        let trail1 = mgr.get_audit_trail(&entity1, 20, 0).unwrap();
+        assert_eq!(trail1.total, 3);
+
+        // Verify entity2 still has 10 records (unaffected)
+        let trail2 = mgr.get_audit_trail(&entity2, 20, 0).unwrap();
+        assert_eq!(trail2.total, 10);
+    }
+
+    #[test]
+    fn test_prune_all_entities() {
+        let (mgr, _temp) = create_test_manager();
+
+        let entity1 = EntityId::cooperative("coop-1").expect("valid coop id");
+        let entity2 = EntityId::cooperative("coop-2").expect("valid coop id");
+        let performer_keypair = KeyPair::generate().expect("keypair");
+        let performer = EntityId::from_did(performer_keypair.did());
+
+        // Create 10 records each for 2 entities
+        for entity in [&entity1, &entity2] {
+            for i in 0..10 {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+                mgr.record_audit(
+                    entity,
+                    EntityOperation::Updated {
+                        changed_fields: vec![format!("field{}", i)],
+                    },
+                    &performer,
+                    None,
+                    None,
+                )
+                .expect("Failed to record audit");
+            }
+        }
+
+        assert_eq!(mgr.count_audit_records().unwrap(), 20);
+
+        // Prune all entities to max 5 records each
+        let stats = mgr
+            .prune_audit_records(
+                365 * 10, // Long retention
+                5,        // max 5 records per entity
+                100,
+            )
+            .expect("Failed to prune");
+
+        assert_eq!(stats.records_scanned, 20); // Scanned all
+        assert_eq!(stats.records_pruned, 10); // 5 pruned from each entity
+        assert_eq!(stats.entities_processed, 2);
+
+        // Verify both entities have 5 records
+        let trail1 = mgr.get_audit_trail(&entity1, 20, 0).unwrap();
+        assert_eq!(trail1.total, 5);
+
+        let trail2 = mgr.get_audit_trail(&entity2, 20, 0).unwrap();
+        assert_eq!(trail2.total, 5);
+    }
+
+    #[test]
+    fn test_prune_no_op_when_under_limit() {
+        let (mgr, _temp) = create_test_manager();
+
+        let entity_id = EntityId::cooperative("test-coop").expect("valid coop id");
+        let performer_keypair = KeyPair::generate().expect("keypair");
+        let performer = EntityId::from_did(performer_keypair.did());
+
+        // Create 3 records
+        for i in 0..3 {
+            mgr.record_audit(
+                &entity_id,
+                EntityOperation::Updated {
+                    changed_fields: vec![format!("field{}", i)],
+                },
+                &performer,
+                None,
+                None,
+            )
+            .expect("Failed to record audit");
+        }
+
+        // Prune with limit of 10 (higher than actual count)
+        let stats = mgr
+            .prune_audit_records(365 * 10, 10, 100)
+            .expect("Failed to prune");
+
+        assert_eq!(stats.records_scanned, 3);
+        assert_eq!(stats.records_pruned, 0); // Nothing pruned
+        assert_eq!(stats.entities_processed, 1);
+
+        // All 3 records still exist
+        assert_eq!(mgr.count_audit_records().unwrap(), 3);
+    }
+
+    #[test]
+    fn test_extract_entity_id_from_key() {
+        // Test cooperative entity ID extraction
+        let key = "entity:icn:cooperative:test-coop:1703500000000:audit-1703500000-abc123";
+        assert_eq!(
+            EntityAuditManager::extract_entity_id_from_key(key),
+            Some("entity:icn:cooperative:test-coop".to_string())
+        );
+
+        // Test federation entity ID extraction
+        let key = "entity:icn:federation:test-fed:1703500000000:audit-1703500000-xyz789";
+        assert_eq!(
+            EntityAuditManager::extract_entity_id_from_key(key),
+            Some("entity:icn:federation:test-fed".to_string())
+        );
+
+        // Test DID-based entity ID (individual)
+        let key = "entity:icn:individual:5FyKAM:1703500000000:audit-1703500000-def456";
+        assert_eq!(
+            EntityAuditManager::extract_entity_id_from_key(key),
+            Some("entity:icn:individual:5FyKAM".to_string())
+        );
+
+        // Test invalid key (too few parts)
+        let key = "entity:icn:invalid:123";
+        assert_eq!(EntityAuditManager::extract_entity_id_from_key(key), None);
     }
 }

--- a/icn/crates/icn-gateway/src/lib.rs
+++ b/icn/crates/icn-gateway/src/lib.rs
@@ -64,6 +64,7 @@ pub use commons_store::SledCommonsStore;
 pub use commons_store::{CommonsStore, CommonsStoreBackend, InMemoryCommonsStore};
 pub use community_mgr::CommunityManager;
 pub use compute_events::{create_forwarding_callback, forward_compute_event};
+pub use entity_audit::{EntityAuditManager, PruneStats};
 pub use entity_mgr::EntityHandle;
 pub use error::{GatewayError, Result};
 pub use events::{BalanceChangeDetail, EventBroadcaster, GatewayEvent, SequencedEvent};

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -40,6 +40,33 @@ use crate::trust_mgr::{TrustGraphHandle, TrustManager};
 use icn_compute::ComputeHandle;
 use icn_store::SledStore;
 
+/// Configuration for audit record pruning
+#[derive(Debug, Clone)]
+pub struct AuditPruneConfig {
+    /// Maximum age of audit records in days
+    pub retention_days: u64,
+    /// Maximum records per entity
+    pub max_records_per_entity: usize,
+    /// Interval between prune runs in seconds
+    pub prune_interval_secs: u64,
+    /// Batch size for pruning
+    pub batch_size: usize,
+    /// Whether auto-pruning is enabled
+    pub enabled: bool,
+}
+
+impl Default for AuditPruneConfig {
+    fn default() -> Self {
+        Self {
+            retention_days: 365,
+            max_records_per_entity: 10000,
+            prune_interval_secs: 3600,
+            batch_size: 1000,
+            enabled: true,
+        }
+    }
+}
+
 /// Gateway server configuration
 pub struct GatewayServer {
     bind_addr: SocketAddr,
@@ -66,6 +93,8 @@ pub struct GatewayServer {
     community_handle: Option<icn_community::CommunityHandle>,
     /// Optional handle to daemon's StewardActor (for SDIS ceremonies)
     steward_handle: Option<icn_steward::StewardHandle>,
+    /// Audit pruning configuration
+    audit_prune_config: Option<AuditPruneConfig>,
 }
 
 impl GatewayServer {
@@ -88,6 +117,7 @@ impl GatewayServer {
             entity_handle: None,
             community_handle: None,
             steward_handle: None,
+            audit_prune_config: None,
         }
     }
 
@@ -114,6 +144,7 @@ impl GatewayServer {
             entity_handle: None,
             community_handle: None,
             steward_handle: None,
+            audit_prune_config: None,
         }
     }
 
@@ -141,7 +172,14 @@ impl GatewayServer {
             entity_handle: None,
             community_handle: None,
             steward_handle: None,
+            audit_prune_config: None,
         }
+    }
+
+    /// Set audit pruning configuration
+    pub fn with_audit_prune_config(mut self, config: AuditPruneConfig) -> Self {
+        self.audit_prune_config = Some(config);
+        self
     }
 
     /// Set custom security configuration
@@ -581,6 +619,66 @@ impl GatewayServer {
                     }
                 }
             });
+        }
+
+        // Spawn audit record pruning background task if configured
+        if let Some(ref prune_config) = self.audit_prune_config {
+            if prune_config.enabled {
+                let entity_audit_manager_clone = entity_audit_manager.clone();
+                let retention_days = prune_config.retention_days;
+                let max_records = prune_config.max_records_per_entity;
+                let batch_size = prune_config.batch_size;
+                let prune_interval = Duration::from_secs(prune_config.prune_interval_secs);
+                let mut shutdown_signal = shutdown_tx.subscribe();
+
+                tokio::spawn(async move {
+                    let mut interval = tokio::time::interval(prune_interval);
+                    info!(
+                        "Audit prune task started: retention_days={}, max_records={}, interval={}s",
+                        retention_days,
+                        max_records,
+                        prune_interval.as_secs()
+                    );
+
+                    loop {
+                        tokio::select! {
+                            _ = interval.tick() => {
+                                let start = std::time::Instant::now();
+                                match entity_audit_manager_clone.prune_audit_records(
+                                    retention_days,
+                                    max_records,
+                                    batch_size,
+                                ) {
+                                    Ok(stats) => {
+                                        let duration = start.elapsed().as_secs_f64();
+                                        if stats.records_pruned > 0 {
+                                            info!(
+                                                "Audit prune completed: scanned={}, pruned={}, entities={}, duration={:.2}s",
+                                                stats.records_scanned,
+                                                stats.records_pruned,
+                                                stats.entities_processed,
+                                                duration
+                                            );
+                                        }
+                                        // Record metrics
+                                        icn_obs::metrics::gateway::entity_audit_pruned_inc(stats.records_pruned);
+                                        icn_obs::metrics::gateway::entity_audit_prune_duration(duration);
+                                    }
+                                    Err(e) => {
+                                        warn!("Audit prune failed: {}", e);
+                                        icn_obs::metrics::gateway::entity_audit_prune_failed_inc();
+                                    }
+                                }
+                            }
+                            _ = shutdown_signal.recv() => {
+                                info!("Audit prune task received shutdown signal");
+                                break;
+                            }
+                        }
+                    }
+                });
+                info!("Audit record pruning task started");
+            }
         }
 
         // Clone security config for the move closure

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -927,6 +927,18 @@ pub fn init_descriptions() {
         "icn_gateway_entity_audit_corruption_total",
         "Total number of corrupted audit records detected during reads"
     );
+    describe_counter!(
+        "icn_gateway_entity_audit_records_pruned_total",
+        "Total number of entity audit records pruned by retention policy"
+    );
+    describe_histogram!(
+        "icn_gateway_entity_audit_prune_duration_seconds",
+        "Duration of entity audit pruning operations in seconds"
+    );
+    describe_counter!(
+        "icn_gateway_entity_audit_prune_failures_total",
+        "Total number of failed audit prune operations"
+    );
 
     // RPC metrics
     describe_counter!(
@@ -2813,6 +2825,27 @@ pub mod gateway {
     /// indicating potential data corruption requiring investigation.
     pub fn entity_audit_corruption_inc() {
         counter!("icn_gateway_entity_audit_corruption_total").increment(1);
+    }
+
+    /// Increment audit records pruned counter
+    ///
+    /// Tracks the total number of audit records removed by the retention policy.
+    pub fn entity_audit_pruned_inc(count: usize) {
+        counter!("icn_gateway_entity_audit_records_pruned_total").increment(count as u64);
+    }
+
+    /// Record audit pruning duration in seconds
+    ///
+    /// Tracks how long pruning operations take for performance monitoring.
+    pub fn entity_audit_prune_duration(duration_secs: f64) {
+        histogram!("icn_gateway_entity_audit_prune_duration_seconds").record(duration_secs);
+    }
+
+    /// Increment audit prune failure counter
+    ///
+    /// Tracks cases where the pruning operation failed.
+    pub fn entity_audit_prune_failed_inc() {
+        counter!("icn_gateway_entity_audit_prune_failures_total").increment(1);
     }
 }
 


### PR DESCRIPTION
## Summary

Implements a configurable retention policy for entity audit records (from PR #305), preventing unbounded storage growth in high-activity cooperatives.

**Key Features:**
- Configurable retention via `AuditRetentionConfig` (retention_days, max_records_per_entity)
- Background pruning task with graceful shutdown
- Admin API endpoints for manual pruning and statistics
- Prometheus metrics for monitoring

## Changes

### Configuration (`icn-core/src/config.rs`)
- Added `AuditRetentionConfig` struct with defaults:
  - `retention_days: 365`
  - `max_records_per_entity: 10000`
  - `prune_interval_secs: 3600`
  - `auto_prune_enabled: true`
  - `prune_batch_size: 1000`

### Pruning Methods (`icn-gateway/src/entity_audit.rs`)
- `prune_audit_records()` - Prune all entities based on retention policy
- `prune_entity()` - Prune specific entity (for admin API)
- `count_audit_records()` - Count total audit records
- `get_entities_with_audits()` - List entities with audit trails
- `PruneStats` struct with operation statistics

### Admin API (`icn-gateway/src/api/entity.rs`)
- `POST /entities/audit/prune` - Manual prune (requires admin/entity:audit scope)
- `GET /entities/audit/stats` - Audit storage statistics

### Background Task (`icn-gateway/src/server.rs`)
- Spawns prune task when `auto_prune_enabled` is true
- Follows established cleanup task pattern with shutdown signal handling

### Metrics (`icn-obs/src/metrics_legacy.rs`)
- `entity_audit_pruned_total` - Counter of pruned records
- `entity_audit_prune_duration_seconds` - Histogram of prune duration
- `entity_audit_prune_failures_total` - Counter of failed prune operations

## Dependencies

- Depends on PR #305 (Entity Audit Logging)

## Test Plan

- [x] Unit tests for pruning by count (test_prune_by_count)
- [x] Unit tests for specific entity pruning (test_prune_specific_entity)
- [x] Unit tests for all-entity pruning (test_prune_all_entities)
- [x] Unit tests for no-op when under limit
- [x] Unit tests for entity ID extraction from key
- [x] All existing tests still pass
- [x] Clippy passes with no warnings

## Closes

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)