### PR TITLE
feat(security,sdk): Add trust penalty wiring and SDK delegation support

### DIFF
--- a/icn/crates/icn-core/src/supervisor/init_trust.rs
+++ b/icn/crates/icn-core/src/supervisor/init_trust.rs
@@ -175,4 +175,174 @@ mod tests {
         // Either None or Isolated is acceptable for unknown peers
         assert!(result.is_none() || result == Some(TrustClass::Isolated));
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_misbehavior_updates_trust_graph() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = Config {
+            data_dir: temp_dir.path().to_path_buf(),
+            ..Default::default()
+        };
+        let keypair = icn_identity::KeyPair::generate().unwrap();
+        let own_did = keypair.did().clone();
+
+        let services = init_trust_services(&config, own_did.clone()).await.unwrap();
+
+        // Create a peer DID
+        let peer_keypair = icn_identity::KeyPair::generate().unwrap();
+        let peer_did = peer_keypair.did().clone();
+
+        // Record a violation against the peer
+        {
+            let mut detector = services.misbehavior_detector.write().await;
+            let violation = icn_security::Violation::InvalidSignature {
+                message_hash: [0u8; 32],
+            };
+            detector.record_violation(&peer_did, violation, vec![]);
+        }
+
+        // Give the callback time to complete
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Verify the trust graph was updated
+        let graph = services.trust_graph.read().await;
+        let trust_score = graph.compute_trust_score(&peer_did).unwrap_or(0.0);
+
+        // Score should be reduced from the violation (0.75 after one InvalidSignature)
+        // The callback maps this to trust score, so it should be 0.75
+        assert!(
+            trust_score >= 0.5 && trust_score <= 1.0,
+            "Trust score should be moderate after violation: got {}",
+            trust_score
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_severe_misbehavior_causes_quarantine() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = Config {
+            data_dir: temp_dir.path().to_path_buf(),
+            ..Default::default()
+        };
+        let keypair = icn_identity::KeyPair::generate().unwrap();
+        let own_did = keypair.did().clone();
+
+        let services = init_trust_services(&config, own_did).await.unwrap();
+
+        let peer_keypair = icn_identity::KeyPair::generate().unwrap();
+        let peer_did = peer_keypair.did().clone();
+
+        // Record multiple violations to trigger quarantine/ban
+        {
+            let mut detector = services.misbehavior_detector.write().await;
+
+            // Record enough violations to drop reputation below quarantine threshold
+            // InvalidSignature has severity 5, penalty = 0.25 per violation
+            // After 3 violations: 1.0 - 0.75 = 0.25 (quarantined)
+            // After 4+ violations: 0.0 (banned, as score <= ban_threshold of 0.0)
+            for _ in 0..10 {
+                let violation = icn_security::Violation::InvalidSignature {
+                    message_hash: [0u8; 32],
+                };
+                detector.record_violation(&peer_did, violation, vec![]);
+            }
+        }
+
+        // Verify peer is quarantined OR banned (severe misbehavior escalates to ban)
+        let detector = services.misbehavior_detector.read().await;
+        assert!(
+            detector.is_quarantined(&peer_did) || detector.is_banned(&peer_did),
+            "Peer should be quarantined or banned after many violations"
+        );
+
+        // Trust should be very low
+        let graph = services.trust_graph.read().await;
+        let trust_score = graph.compute_trust_score(&peer_did).unwrap_or(0.0);
+        assert!(
+            trust_score < 0.3,
+            "Trust score should be very low when quarantined/banned: got {}",
+            trust_score
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_quarantine_release_restores_trust() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = Config {
+            data_dir: temp_dir.path().to_path_buf(),
+            ..Default::default()
+        };
+        let keypair = icn_identity::KeyPair::generate().unwrap();
+        let own_did = keypair.did().clone();
+
+        let services = init_trust_services(&config, own_did).await.unwrap();
+
+        let peer_keypair = icn_identity::KeyPair::generate().unwrap();
+        let peer_did = peer_keypair.did().clone();
+
+        // Quarantine the peer using InvalidSignature (severity 5, penalty 0.25)
+        // After 3 violations: 1.0 - 0.75 = 0.25 (quarantined but not banned)
+        {
+            let mut detector = services.misbehavior_detector.write().await;
+            for _ in 0..3 {
+                let violation = icn_security::Violation::InvalidSignature {
+                    message_hash: [0u8; 32],
+                };
+                detector.record_violation(&peer_did, violation, vec![]);
+            }
+        }
+
+        // Verify quarantined (not banned yet)
+        {
+            let detector = services.misbehavior_detector.read().await;
+            assert!(
+                detector.is_quarantined(&peer_did),
+                "Peer should be quarantined after 3 InvalidSignature violations"
+            );
+            assert!(
+                !detector.is_banned(&peer_did),
+                "Peer should NOT be banned yet"
+            );
+        }
+
+        // Get trust score before release
+        let trust_before = {
+            let graph = services.trust_graph.read().await;
+            graph.compute_trust_score(&peer_did).unwrap_or(0.0)
+        };
+
+        // Force release from quarantine
+        {
+            let mut detector = services.misbehavior_detector.write().await;
+            detector.force_release_from_quarantine(&peer_did);
+        }
+
+        // Give callback time to complete
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Verify no longer quarantined
+        {
+            let detector = services.misbehavior_detector.read().await;
+            assert!(
+                !detector.is_quarantined(&peer_did),
+                "Peer should no longer be quarantined after force release"
+            );
+        }
+
+        // Trust should improve after release
+        let graph = services.trust_graph.read().await;
+        let trust_after = graph.compute_trust_score(&peer_did).unwrap_or(0.0);
+        assert!(
+            trust_after > trust_before,
+            "Trust should improve after quarantine release: before={}, after={}",
+            trust_before,
+            trust_after
+        );
+        // Trust should be at least moderate after reset to 0.6 reputation
+        assert!(
+            trust_after >= 0.3,
+            "Trust should be at least moderate after release: got {}",
+            trust_after
+        );
+    }
 }

--- a/icn/crates/icn-core/src/supervisor/init_trust.rs
+++ b/icn/crates/icn-core/src/supervisor/init_trust.rs
@@ -238,8 +238,8 @@ mod tests {
 
             // Record enough violations to drop reputation below quarantine threshold
             // InvalidSignature has severity 5, penalty = 0.25 per violation
-            // After 3 violations: 1.0 - 0.75 = 0.25 (quarantined)
-            // After 4+ violations: 0.0 (banned, as score <= ban_threshold of 0.0)
+            // After 3 violations: 1.0 - (3 × 0.25) = 0.25 (quarantined)
+            // After 4+ violations: 1.0 - (4 × 0.25) = 0.0 (banned, as score <= ban_threshold of 0.0)
             for _ in 0..10 {
                 let violation = icn_security::Violation::InvalidSignature {
                     message_hash: [0u8; 32],
@@ -281,7 +281,7 @@ mod tests {
         let peer_did = peer_keypair.did().clone();
 
         // Quarantine the peer using InvalidSignature (severity 5, penalty 0.25)
-        // After 3 violations: 1.0 - 0.75 = 0.25 (quarantined but not banned)
+        // After 3 violations: 1.0 - (3 * 0.25) = 0.25 (quarantined but not banned)
         {
             let mut detector = services.misbehavior_detector.write().await;
             for _ in 0..3 {

--- a/icn/crates/icn-core/src/supervisor/init_trust.rs
+++ b/icn/crates/icn-core/src/supervisor/init_trust.rs
@@ -211,9 +211,8 @@ mod tests {
         // Score should be reduced from the violation (0.75 after one InvalidSignature)
         // The callback maps this to trust score, so it should be 0.75
         assert!(
-            trust_score >= 0.5 && trust_score <= 1.0,
-            "Trust score should be moderate after violation: got {}",
-            trust_score
+            (0.5..=1.0).contains(&trust_score),
+            "Trust score should be moderate after violation: got {trust_score}"
         );
     }
 
@@ -260,8 +259,7 @@ mod tests {
         let trust_score = graph.compute_trust_score(&peer_did).unwrap_or(0.0);
         assert!(
             trust_score < 0.3,
-            "Trust score should be very low when quarantined/banned: got {}",
-            trust_score
+            "Trust score should be very low when quarantined/banned: got {trust_score}"
         );
     }
 
@@ -334,15 +332,12 @@ mod tests {
         let trust_after = graph.compute_trust_score(&peer_did).unwrap_or(0.0);
         assert!(
             trust_after > trust_before,
-            "Trust should improve after quarantine release: before={}, after={}",
-            trust_before,
-            trust_after
+            "Trust should improve after quarantine release: before={trust_before}, after={trust_after}"
         );
         // Trust should be at least moderate after reset to 0.6 reputation
         assert!(
             trust_after >= 0.3,
-            "Trust should be at least moderate after release: got {}",
-            trust_after
+            "Trust should be at least moderate after release: got {trust_after}"
         );
     }
 }

--- a/icn/crates/icn-net/src/encryption.rs
+++ b/icn/crates/icn-net/src/encryption.rs
@@ -35,13 +35,19 @@
 //! - Applies a safety gap (+10,000) on restart to handle any unsaved sequences
 //! - Provides per-(sender, recipient) sequence isolation
 //!
+//! **IMPORTANT**: Call `load_and_apply_safety_gap()` during node startup,
+//! AFTER the store is initialized but BEFORE sending any encrypted messages.
+//! This ensures the safety gap is applied exactly once per restart.
+//!
 //! **Usage**:
 //! ```rust,ignore
 //! use icn_net::{OutgoingSequenceTracker, EncryptedEnvelope};
 //!
+//! // During node startup (once per restart)
 //! let tracker = OutgoingSequenceTracker::new(store)?;
-//! tracker.load_and_apply_safety_gap().await?;
+//! tracker.load_and_apply_safety_gap().await?; // Apply safety gap
 //!
+//! // When sending encrypted messages
 //! let seq = tracker.next_sequence(&my_did, &recipient_did).await?;
 //! let envelope = EncryptedEnvelope::encrypt(&my_did, &recipient_did, seq, ...)?;
 //! ```

--- a/icn/crates/icn-net/src/encryption.rs
+++ b/icn/crates/icn-net/src/encryption.rs
@@ -26,21 +26,31 @@
 //!
 //! ## Security Considerations
 //!
-//! ### Nonce Reuse Risk (Sequence Persistence)
+//! ### Nonce Uniqueness (Sequence Persistence)
 //!
-//! **KNOWN LIMITATION**: Sequence counters are NOT persisted across restarts.
+//! Nonces are derived from: `SHA256(sequence || from_did || to_did)`.
+//! To prevent nonce reuse across restarts, use [`OutgoingSequenceTracker`] which:
 //!
-//! Nonces are derived from: `BLAKE2b(sequence || from_did || to_did)`.
-//! If a node restarts and reuses sequence numbers, nonces could repeat,
-//! completely breaking ChaCha20-Poly1305 security (keystream reuse).
+//! - Persists sequence numbers to disk via [`icn_store::Store`]
+//! - Applies a safety gap (+10,000) on restart to handle any unsaved sequences
+//! - Provides per-(sender, recipient) sequence isolation
 //!
-//! **Mitigations**:
+//! **Usage**:
+//! ```rust,ignore
+//! use icn_net::{OutgoingSequenceTracker, EncryptedEnvelope};
+//!
+//! let tracker = OutgoingSequenceTracker::new(store)?;
+//! tracker.load_and_apply_safety_gap().await?;
+//!
+//! let seq = tracker.next_sequence(&my_did, &recipient_did).await?;
+//! let envelope = EncryptedEnvelope::encrypt(&my_did, &recipient_did, seq, ...)?;
+//! ```
+//!
+//! **Additional Protections**:
 //! - TLS provides independent transport-layer encryption
 //! - SignedEnvelope has separate replay protection
-//! - Restarts are infrequent in production
-//! - Sequence numbers typically have large gaps
 //!
-//! **Future Work**: Persist per-recipient sequence counters to disk.
+//! [`OutgoingSequenceTracker`]: crate::sequence_tracker::OutgoingSequenceTracker
 //!
 //! ## Limitations
 //!

--- a/icn/crates/icn-net/src/encryption.rs
+++ b/icn/crates/icn-net/src/encryption.rs
@@ -58,6 +58,13 @@
 //!
 //! [`OutgoingSequenceTracker`]: crate::sequence_tracker::OutgoingSequenceTracker
 //!
+//! ## TODO: Integration
+//!
+//! The `OutgoingSequenceTracker` is currently standalone. Future work:
+//! - Wire into `NetworkActor` for automatic sequence management
+//! - Add periodic cleanup task for stale entries
+//! - Add metrics for cache size monitoring
+//!
 //! ## Limitations
 //!
 //! - No Perfect Forward Secrecy (static keys, add in Phase 11)

--- a/icn/crates/icn-net/src/handlers/handshake.rs
+++ b/icn/crates/icn-net/src/handlers/handshake.rs
@@ -183,3 +183,177 @@ impl ConnectionContext {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::replay_guard::ReplayGuard;
+    use crate::topology::{NeighborLimitsConfig, NeighborSets, TopologyConfig};
+    use crate::{RateLimitConfig, RateLimiter, SessionManager};
+    use icn_identity::{IdentityBundle, KeyPair};
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    fn create_test_context_with_topology() -> (ConnectionContext, Arc<RwLock<NeighborSets>>) {
+        let keypair = KeyPair::generate().unwrap();
+        let identity_bundle = IdentityBundle::from_keypair(keypair.clone()).unwrap();
+        let own_did = keypair.did().clone();
+
+        let forward_count = Arc::new(AtomicUsize::new(0));
+        let forward_count_clone = Arc::clone(&forward_count);
+
+        let handler: crate::IncomingMessageHandler = Arc::new(move |_msg| {
+            forward_count_clone.fetch_add(1, Ordering::SeqCst);
+        });
+
+        let rate_limiter = Arc::new(RateLimiter::new(RateLimitConfig::default()));
+        let replay_guard = Arc::new(RwLock::new(ReplayGuard::new(300, 3600)));
+        let session_manager = Arc::new(RwLock::new(SessionManager::new()));
+        let peer_connections = Arc::new(RwLock::new(HashMap::new()));
+
+        let topology_config = TopologyConfig {
+            region: "us-west".to_string(),
+            cluster_id: "cluster-1".to_string(),
+            role: NodeRole::Edge,
+            neighbor_limits: NeighborLimitsConfig::default(),
+            fanout: Default::default(),
+        };
+
+        let own_topology = TopologyInfo {
+            region: "us-west".to_string(),
+            cluster_id: "cluster-1".to_string(),
+            role: NodeRole::Edge,
+        };
+
+        let neighbor_sets = Arc::new(RwLock::new(NeighborSets::new(own_topology)));
+
+        let ctx = ConnectionContext {
+            handler,
+            rate_limiter,
+            replay_guard,
+            neighbor_sets: Some(neighbor_sets.clone()),
+            topology_config: Some(topology_config),
+            trust_graph: None,
+            session_manager,
+            peer_connections,
+            blob_registry: None,
+            misbehavior_detector: None,
+            identity_bundle,
+            own_did,
+        };
+
+        (ctx, neighbor_sets)
+    }
+
+    fn create_test_context_no_topology() -> ConnectionContext {
+        let keypair = KeyPair::generate().unwrap();
+        let identity_bundle = IdentityBundle::from_keypair(keypair.clone()).unwrap();
+        let own_did = keypair.did().clone();
+
+        let handler: crate::IncomingMessageHandler = Arc::new(move |_msg| {});
+
+        let rate_limiter = Arc::new(RateLimiter::new(RateLimitConfig::default()));
+        let replay_guard = Arc::new(RwLock::new(ReplayGuard::new(300, 3600)));
+        let session_manager = Arc::new(RwLock::new(SessionManager::new()));
+        let peer_connections = Arc::new(RwLock::new(HashMap::new()));
+
+        ConnectionContext {
+            handler,
+            rate_limiter,
+            replay_guard,
+            neighbor_sets: None,
+            topology_config: None,
+            trust_graph: None,
+            session_manager,
+            peer_connections,
+            blob_registry: None,
+            misbehavior_detector: None,
+            identity_bundle,
+            own_did,
+        }
+    }
+
+    #[test]
+    fn test_handle_handshake_ack() {
+        // Simple test - just ensures it doesn't panic
+        let ctx = create_test_context_no_topology();
+        let peer = KeyPair::generate().unwrap();
+        ctx.handle_handshake_ack(&peer.did());
+        // If we get here without panic, test passes
+    }
+
+    #[tokio::test]
+    async fn test_handle_pong_records_rtt() {
+        let (ctx, neighbor_sets) = create_test_context_with_topology();
+        let peer = KeyPair::generate().unwrap();
+        let peer_did = peer.did().clone();
+
+        // Add the peer to neighbor sets first
+        {
+            let mut sets = neighbor_sets.write().await;
+            sets.add_neighbor(
+                PeerId(peer_did.clone()),
+                TopologyInfo {
+                    region: "us-west".to_string(),
+                    cluster_id: "cluster-1".to_string(),
+                    role: NodeRole::Edge,
+                },
+                None,
+                0.5,
+                &NeighborLimitsConfig::default(),
+            );
+        }
+
+        // Simulate a ping sent 50ms ago
+        let ping_sent_at = icn_time::current_timestamp_millis() - 50;
+        let pong_sent_at = ping_sent_at + 25; // Pong sent 25ms after ping received
+
+        ctx.handle_pong(&peer_did, ping_sent_at, pong_sent_at).await;
+
+        // Verify RTT was recorded (should be approximately 50ms)
+        let sets = neighbor_sets.read().await;
+        let rtt = sets.get_rtt(&PeerId(peer_did.clone()));
+        assert!(rtt.is_some());
+        // RTT should be close to 50ms (with some timing variance)
+        let rtt = rtt.unwrap();
+        assert!(
+            rtt >= 40 && rtt <= 100,
+            "RTT {} was not in expected range",
+            rtt
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_pong_without_topology() {
+        // Should not panic even without topology enabled
+        let ctx = create_test_context_no_topology();
+        let peer = KeyPair::generate().unwrap();
+
+        let ping_sent_at = icn_time::current_timestamp_millis() - 50;
+        let pong_sent_at = ping_sent_at + 25;
+
+        ctx.handle_pong(&peer.did(), ping_sent_at, pong_sent_at)
+            .await;
+        // Test passes if no panic
+    }
+
+    #[tokio::test]
+    async fn test_handle_pong_unknown_peer() {
+        let (ctx, neighbor_sets) = create_test_context_with_topology();
+        let peer = KeyPair::generate().unwrap();
+
+        // Don't add peer to neighbor sets - should still not panic
+        let ping_sent_at = icn_time::current_timestamp_millis() - 50;
+        let pong_sent_at = ping_sent_at + 25;
+
+        ctx.handle_pong(&peer.did(), ping_sent_at, pong_sent_at)
+            .await;
+
+        // RTT should not be recorded for unknown peer
+        let sets = neighbor_sets.read().await;
+        let rtt = sets.get_rtt(&PeerId(peer.did().clone()));
+        assert!(rtt.is_none());
+    }
+}

--- a/icn/crates/icn-net/src/handlers/handshake.rs
+++ b/icn/crates/icn-net/src/handlers/handshake.rs
@@ -280,7 +280,7 @@ mod tests {
         // Simple test - just ensures it doesn't panic
         let ctx = create_test_context_no_topology();
         let peer = KeyPair::generate().unwrap();
-        ctx.handle_handshake_ack(&peer.did());
+        ctx.handle_handshake_ack(peer.did());
         // If we get here without panic, test passes
     }
 
@@ -319,9 +319,8 @@ mod tests {
         // RTT should be close to 50ms (with some timing variance)
         let rtt = rtt.unwrap();
         assert!(
-            rtt >= 40 && rtt <= 100,
-            "RTT {} was not in expected range",
-            rtt
+            (40..=100).contains(&rtt),
+            "RTT {rtt} was not in expected range"
         );
     }
 
@@ -334,7 +333,7 @@ mod tests {
         let ping_sent_at = icn_time::current_timestamp_millis() - 50;
         let pong_sent_at = ping_sent_at + 25;
 
-        ctx.handle_pong(&peer.did(), ping_sent_at, pong_sent_at)
+        ctx.handle_pong(peer.did(), ping_sent_at, pong_sent_at)
             .await;
         // Test passes if no panic
     }
@@ -348,7 +347,7 @@ mod tests {
         let ping_sent_at = icn_time::current_timestamp_millis() - 50;
         let pong_sent_at = ping_sent_at + 25;
 
-        ctx.handle_pong(&peer.did(), ping_sent_at, pong_sent_at)
+        ctx.handle_pong(peer.did(), ping_sent_at, pong_sent_at)
             .await;
 
         // RTT should not be recorded for unknown peer

--- a/icn/crates/icn-net/src/handlers/signed.rs
+++ b/icn/crates/icn-net/src/handlers/signed.rs
@@ -89,3 +89,256 @@ fn compute_message_hash(envelope: &SignedEnvelope) -> Vec<u8> {
     hasher.update(envelope.from.as_str().as_bytes());
     hasher.finalize().to_vec()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::PayloadType;
+    use crate::protocol::MessagePayload;
+    use crate::replay_guard::ReplayGuard;
+    use crate::{RateLimitConfig, RateLimiter, SessionManager};
+    use icn_identity::{IdentityBundle, KeyPair};
+    use icn_security::{MisbehaviorDetector, MisbehaviorThresholds};
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    /// Create a minimal ConnectionContext for testing
+    fn create_test_context(
+        misbehavior_detector: Option<Arc<RwLock<MisbehaviorDetector>>>,
+    ) -> (ConnectionContext, Arc<AtomicUsize>) {
+        let keypair = KeyPair::generate().unwrap();
+        let identity_bundle = IdentityBundle::from_keypair(keypair.clone()).unwrap();
+        let own_did = keypair.did().clone();
+
+        // Counter for forwarded messages
+        let forward_count = Arc::new(AtomicUsize::new(0));
+        let forward_count_clone = Arc::clone(&forward_count);
+
+        let handler: crate::IncomingMessageHandler = Arc::new(move |_msg| {
+            forward_count_clone.fetch_add(1, Ordering::SeqCst);
+        });
+
+        let rate_limiter = Arc::new(RateLimiter::new(RateLimitConfig::default()));
+        let replay_guard = Arc::new(RwLock::new(ReplayGuard::new(300, 3600)));
+        let session_manager = Arc::new(RwLock::new(SessionManager::new()));
+        let peer_connections = Arc::new(RwLock::new(HashMap::new()));
+
+        let ctx = ConnectionContext {
+            handler,
+            rate_limiter,
+            replay_guard,
+            neighbor_sets: None,
+            topology_config: None,
+            trust_graph: None,
+            session_manager,
+            peer_connections,
+            blob_registry: None,
+            misbehavior_detector,
+            identity_bundle,
+            own_did,
+        };
+
+        (ctx, forward_count)
+    }
+
+    fn create_signed_envelope(keypair: &KeyPair, sequence: u64) -> SignedEnvelope {
+        SignedEnvelope::new(
+            keypair.did(),
+            keypair,
+            sequence,
+            PayloadType::Gossip,
+            b"test payload".to_vec(),
+        )
+        .unwrap()
+    }
+
+    fn create_network_message(envelope: &SignedEnvelope) -> NetworkMessage {
+        NetworkMessage {
+            version: 1,
+            from: envelope.from.clone(),
+            to: None,
+            trace_context: None,
+            payload: MessagePayload::Signed(envelope.clone()),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_valid_signature_forwarded() {
+        let (ctx, forward_count) = create_test_context(None);
+        let sender = KeyPair::generate().unwrap();
+        let envelope = create_signed_envelope(&sender, 1);
+        let message = create_network_message(&envelope);
+
+        ctx.handle_signed(message, &envelope).await;
+
+        // Message should be forwarded
+        assert_eq!(forward_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_invalid_signature_rejected() {
+        let detector = Arc::new(RwLock::new(MisbehaviorDetector::new(
+            MisbehaviorThresholds::default(),
+        )));
+        let (ctx, forward_count) = create_test_context(Some(detector.clone()));
+
+        let sender = KeyPair::generate().unwrap();
+        let mut envelope = create_signed_envelope(&sender, 1);
+
+        // Tamper with the signature
+        envelope.signature[0] ^= 0xFF;
+
+        let message = create_network_message(&envelope);
+        ctx.handle_signed(message, &envelope).await;
+
+        // Message should NOT be forwarded
+        assert_eq!(forward_count.load(Ordering::SeqCst), 0);
+
+        // Should record an InvalidSignature violation
+        let detector_guard = detector.read().await;
+        let violations = detector_guard.get_violations(&sender.did());
+        assert!(!violations.is_empty());
+        assert!(matches!(
+            violations[0].violation,
+            icn_security::Violation::InvalidSignature { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_replay_attack_rejected() {
+        let detector = Arc::new(RwLock::new(MisbehaviorDetector::new(
+            MisbehaviorThresholds::default(),
+        )));
+        let (ctx, forward_count) = create_test_context(Some(detector.clone()));
+
+        let sender = KeyPair::generate().unwrap();
+        let envelope = create_signed_envelope(&sender, 1);
+        let message = create_network_message(&envelope);
+
+        // First message should be forwarded
+        ctx.handle_signed(message.clone(), &envelope).await;
+        assert_eq!(forward_count.load(Ordering::SeqCst), 1);
+
+        // Replay should be rejected
+        ctx.handle_signed(message.clone(), &envelope).await;
+        assert_eq!(forward_count.load(Ordering::SeqCst), 1); // Still 1
+
+        // Should record a ReplayAttack violation
+        let detector_guard = detector.read().await;
+        let violations = detector_guard.get_violations(&sender.did());
+        assert!(!violations.is_empty());
+        assert!(matches!(
+            violations[0].violation,
+            icn_security::Violation::ReplayAttack { sequence: 1, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_sequential_messages_forwarded() {
+        let (ctx, forward_count) = create_test_context(None);
+        let sender = KeyPair::generate().unwrap();
+
+        // Send messages with sequential sequence numbers
+        for seq in 1..=5 {
+            let envelope = create_signed_envelope(&sender, seq);
+            let message = create_network_message(&envelope);
+            ctx.handle_signed(message, &envelope).await;
+        }
+
+        // All 5 messages should be forwarded
+        assert_eq!(forward_count.load(Ordering::SeqCst), 5);
+    }
+
+    #[tokio::test]
+    async fn test_out_of_order_messages_forwarded() {
+        let (ctx, forward_count) = create_test_context(None);
+        let sender = KeyPair::generate().unwrap();
+
+        // Send messages out of order: 3, 1, 2
+        for seq in [3, 1, 2] {
+            let envelope = create_signed_envelope(&sender, seq);
+            let message = create_network_message(&envelope);
+            ctx.handle_signed(message, &envelope).await;
+        }
+
+        // All 3 messages should be forwarded (out of order is OK)
+        assert_eq!(forward_count.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn test_multiple_senders_independent() {
+        let (ctx, forward_count) = create_test_context(None);
+
+        let alice = KeyPair::generate().unwrap();
+        let bob = KeyPair::generate().unwrap();
+
+        // Both can send sequence 1
+        let envelope_alice = create_signed_envelope(&alice, 1);
+        let envelope_bob = create_signed_envelope(&bob, 1);
+
+        ctx.handle_signed(create_network_message(&envelope_alice), &envelope_alice)
+            .await;
+        ctx.handle_signed(create_network_message(&envelope_bob), &envelope_bob)
+            .await;
+
+        // Both should be forwarded
+        assert_eq!(forward_count.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn test_no_detector_no_crash_on_invalid() {
+        // Test that invalid messages are handled gracefully without detector
+        let (ctx, forward_count) = create_test_context(None); // No detector
+
+        let sender = KeyPair::generate().unwrap();
+        let mut envelope = create_signed_envelope(&sender, 1);
+
+        // Tamper with signature
+        envelope.signature[0] ^= 0xFF;
+
+        let message = create_network_message(&envelope);
+
+        // Should not panic, just not forward
+        ctx.handle_signed(message, &envelope).await;
+        assert_eq!(forward_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn test_compute_message_hash_deterministic() {
+        let sender = KeyPair::generate().unwrap();
+        let envelope = create_signed_envelope(&sender, 42);
+
+        let hash1 = compute_message_hash(&envelope);
+        let hash2 = compute_message_hash(&envelope);
+
+        assert_eq!(hash1, hash2);
+        assert_eq!(hash1.len(), 32); // SHA-256 output
+    }
+
+    #[test]
+    fn test_compute_message_hash_unique_per_sequence() {
+        let sender = KeyPair::generate().unwrap();
+        let envelope1 = create_signed_envelope(&sender, 1);
+        let envelope2 = create_signed_envelope(&sender, 2);
+
+        let hash1 = compute_message_hash(&envelope1);
+        let hash2 = compute_message_hash(&envelope2);
+
+        assert_ne!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_compute_message_hash_unique_per_sender() {
+        let sender1 = KeyPair::generate().unwrap();
+        let sender2 = KeyPair::generate().unwrap();
+        let envelope1 = create_signed_envelope(&sender1, 1);
+        let envelope2 = create_signed_envelope(&sender2, 1);
+
+        let hash1 = compute_message_hash(&envelope1);
+        let hash2 = compute_message_hash(&envelope2);
+
+        assert_ne!(hash1, hash2);
+    }
+}

--- a/icn/crates/icn-net/src/handlers/signed.rs
+++ b/icn/crates/icn-net/src/handlers/signed.rs
@@ -198,7 +198,7 @@ mod tests {
 
         // Should record an InvalidSignature violation
         let detector_guard = detector.read().await;
-        let violations = detector_guard.get_violations(&sender.did());
+        let violations = detector_guard.get_violations(sender.did());
         assert!(!violations.is_empty());
         assert!(matches!(
             violations[0].violation,
@@ -227,7 +227,7 @@ mod tests {
 
         // Should record a ReplayAttack violation
         let detector_guard = detector.read().await;
-        let violations = detector_guard.get_violations(&sender.did());
+        let violations = detector_guard.get_violations(sender.did());
         assert!(!violations.is_empty());
         assert!(matches!(
             violations[0].violation,

--- a/icn/crates/icn-net/src/lib.rs
+++ b/icn/crates/icn-net/src/lib.rs
@@ -20,6 +20,7 @@ mod handlers;
 pub mod protocol;
 pub mod rate_limit;
 pub mod replay_guard;
+pub mod sequence_tracker;
 pub mod session;
 pub mod stun;
 pub mod tls;
@@ -43,6 +44,7 @@ pub use protocol::{
 };
 pub use rate_limit::{RateLimitConfig, RateLimiter, TrustGatedRateLimitConfig};
 pub use replay_guard::ReplayGuard;
+pub use sequence_tracker::OutgoingSequenceTracker;
 pub use session::SessionManager;
 pub use stun::StunClient;
 pub use topology::{

--- a/icn/crates/icn-net/src/sequence_tracker.rs
+++ b/icn/crates/icn-net/src/sequence_tracker.rs
@@ -1,0 +1,477 @@
+//! Persistent outgoing sequence number tracking for encryption nonces.
+//!
+//! This module solves a critical security vulnerability: without persistence,
+//! sequence counters used for ChaCha20-Poly1305 nonce derivation would reset
+//! on node restart, potentially reusing nonces and breaking encryption security.
+//!
+//! # Architecture
+//!
+//! ```text
+//! OutgoingSequenceTracker
+//!   ├── In-memory cache (HashMap<(sender, recipient), sequence>)
+//!   ├── Persistent store (Sled via icn-store)
+//!   └── Safety gap on restart (+10000)
+//! ```
+//!
+//! # Security Properties
+//!
+//! - **Nonce uniqueness**: Monotonically increasing sequences guarantee unique nonces
+//! - **Restart safety**: Safety gap prevents nonce reuse even if last save was delayed
+//! - **Per-recipient isolation**: Separate sequence spaces per sender-recipient pair
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use icn_net::OutgoingSequenceTracker;
+//! use icn_store::SledStore;
+//!
+//! let store = SledStore::open("/path/to/data")?;
+//! let tracker = OutgoingSequenceTracker::new(Arc::new(store))?;
+//!
+//! // Get next sequence for encryption
+//! let seq = tracker.next_sequence(&my_did, &recipient_did).await?;
+//!
+//! // Use in EncryptedEnvelope
+//! let envelope = EncryptedEnvelope::encrypt(&my_did, &recipient_did, seq, ...)?;
+//! ```
+
+use anyhow::{Context, Result};
+use icn_identity::Did;
+use icn_store::Store;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Safety gap added to all sequences on startup.
+///
+/// This ensures that even if persistence was delayed or crashed before saving,
+/// we won't reuse any nonces. 10,000 provides ample safety margin:
+/// - At 1000 msg/sec, covers 10 seconds of unsynced messages
+/// - At 100 msg/sec, covers 100 seconds
+/// - In practice, sequences are persisted immediately after increment
+const RESTART_SAFETY_GAP: u64 = 10_000;
+
+/// Key prefix for sequence storage.
+const SEQUENCE_PREFIX: &[u8] = b"outgoing_seq:";
+
+/// Persistent entry for a single sender-recipient sequence.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SequenceEntry {
+    /// Last used sequence number
+    sequence: u64,
+    /// Timestamp of last update (for debugging/audit)
+    updated_at_ms: u64,
+}
+
+/// Persistent outgoing sequence number tracker for encryption nonces.
+///
+/// Tracks and persists sequence numbers per (sender, recipient) pair to ensure
+/// nonce uniqueness for ChaCha20-Poly1305 encryption even across restarts.
+pub struct OutgoingSequenceTracker {
+    /// In-memory cache of sequences
+    cache: RwLock<HashMap<(Did, Did), u64>>,
+    /// Persistent storage backend
+    store: Arc<dyn Store>,
+    /// Whether we've applied the restart safety gap
+    restart_gap_applied: RwLock<bool>,
+}
+
+impl OutgoingSequenceTracker {
+    /// Create a new sequence tracker with the given storage backend.
+    ///
+    /// On creation, loads all existing sequences from storage and applies
+    /// a safety gap to prevent nonce reuse after restart.
+    pub fn new(store: Arc<dyn Store>) -> Result<Self> {
+        let tracker = Self {
+            cache: RwLock::new(HashMap::new()),
+            store,
+            restart_gap_applied: RwLock::new(false),
+        };
+
+        Ok(tracker)
+    }
+
+    /// Create a sequence tracker for testing (no persistence).
+    #[cfg(test)]
+    pub fn in_memory() -> Self {
+        Self {
+            cache: RwLock::new(HashMap::new()),
+            store: Arc::new(icn_store::SledStore::temporary().unwrap()),
+            restart_gap_applied: RwLock::new(true), // No gap needed for tests
+        }
+    }
+
+    /// Load sequences from persistent storage and apply restart safety gap.
+    ///
+    /// This should be called during node startup, after the store is ready.
+    /// It loads all persisted sequences and adds RESTART_SAFETY_GAP to each.
+    pub async fn load_and_apply_safety_gap(&self) -> Result<usize> {
+        let mut applied = self.restart_gap_applied.write().await;
+        if *applied {
+            return Ok(0);
+        }
+
+        let entries = self
+            .store
+            .scan(SEQUENCE_PREFIX)
+            .context("Failed to scan sequence entries from store")?;
+
+        let mut cache = self.cache.write().await;
+        let mut count = 0;
+
+        for (key, value) in entries {
+            if let Some((sender, recipient)) = Self::parse_key(&key) {
+                if let Ok(entry) = serde_json::from_slice::<SequenceEntry>(&value) {
+                    // Apply safety gap
+                    let safe_sequence = entry.sequence.saturating_add(RESTART_SAFETY_GAP);
+                    cache.insert((sender.clone(), recipient.clone()), safe_sequence);
+
+                    // Persist the new safe sequence
+                    self.persist_sequence_inner(&sender, &recipient, safe_sequence)?;
+
+                    tracing::debug!(
+                        sender = %sender,
+                        recipient = %recipient,
+                        old_seq = entry.sequence,
+                        new_seq = safe_sequence,
+                        "Applied restart safety gap to sequence"
+                    );
+
+                    count += 1;
+                }
+            }
+        }
+
+        *applied = true;
+
+        tracing::info!(
+            loaded_sequences = count,
+            safety_gap = RESTART_SAFETY_GAP,
+            "Loaded outgoing sequences with restart safety gap"
+        );
+
+        Ok(count)
+    }
+
+    /// Get the next sequence number for a sender-recipient pair.
+    ///
+    /// Automatically increments and persists the sequence.
+    /// Thread-safe and guaranteed to return unique, monotonically increasing values.
+    pub async fn next_sequence(&self, sender: &Did, recipient: &Did) -> Result<u64> {
+        // Ensure safety gap has been applied on first access
+        {
+            let applied = self.restart_gap_applied.read().await;
+            if !*applied {
+                drop(applied);
+                self.load_and_apply_safety_gap().await?;
+            }
+        }
+
+        let key = (sender.clone(), recipient.clone());
+
+        let mut cache = self.cache.write().await;
+        let next_seq = cache.get(&key).map(|s| s + 1).unwrap_or(1);
+
+        // Update cache
+        cache.insert(key, next_seq);
+
+        // Persist immediately (critical for nonce safety)
+        drop(cache); // Release lock before IO
+        self.persist_sequence(sender, recipient, next_seq).await?;
+
+        Ok(next_seq)
+    }
+
+    /// Get the current sequence number without incrementing (for inspection).
+    pub async fn current_sequence(&self, sender: &Did, recipient: &Did) -> Option<u64> {
+        let cache = self.cache.read().await;
+        cache.get(&(sender.clone(), recipient.clone())).copied()
+    }
+
+    /// Persist a sequence to storage.
+    async fn persist_sequence(&self, sender: &Did, recipient: &Did, sequence: u64) -> Result<()> {
+        self.persist_sequence_inner(sender, recipient, sequence)
+    }
+
+    fn persist_sequence_inner(&self, sender: &Did, recipient: &Did, sequence: u64) -> Result<()> {
+        let key = Self::make_key(sender, recipient);
+        let entry = SequenceEntry {
+            sequence,
+            updated_at_ms: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0),
+        };
+
+        let value = serde_json::to_vec(&entry).context("Failed to serialize sequence entry")?;
+
+        self.store
+            .put(&key, &value)
+            .context("Failed to persist sequence")?;
+
+        Ok(())
+    }
+
+    /// Separator between sender and recipient DIDs in storage key.
+    /// Using a sequence that won't appear in DIDs (which contain colons).
+    const DID_SEPARATOR: &'static [u8] = b"||";
+
+    /// Generate storage key for a sender-recipient pair.
+    fn make_key(sender: &Did, recipient: &Did) -> Vec<u8> {
+        let mut key = Vec::with_capacity(SEQUENCE_PREFIX.len() + 200);
+        key.extend_from_slice(SEQUENCE_PREFIX);
+        key.extend_from_slice(sender.as_str().as_bytes());
+        key.extend_from_slice(Self::DID_SEPARATOR);
+        key.extend_from_slice(recipient.as_str().as_bytes());
+        key
+    }
+
+    /// Parse storage key back to sender-recipient pair.
+    fn parse_key(key: &[u8]) -> Option<(Did, Did)> {
+        if !key.starts_with(SEQUENCE_PREFIX) {
+            return None;
+        }
+
+        let rest = &key[SEQUENCE_PREFIX.len()..];
+        let rest_str = std::str::from_utf8(rest).ok()?;
+
+        // Split on "||" separator
+        let parts: Vec<&str> = rest_str.splitn(2, "||").collect();
+        if parts.len() != 2 {
+            return None;
+        }
+
+        let sender = Did::from_str(parts[0]).ok()?;
+        let recipient = Did::from_str(parts[1]).ok()?;
+
+        Some((sender, recipient))
+    }
+
+    /// Get number of tracked sender-recipient pairs.
+    pub async fn pair_count(&self) -> usize {
+        self.cache.read().await.len()
+    }
+
+    /// Clear all sequences (for testing only).
+    #[cfg(test)]
+    pub async fn clear(&self) {
+        self.cache.write().await.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use icn_identity::KeyPair;
+
+    /// Generate a new DID from a fresh keypair
+    fn generate_did() -> Did {
+        KeyPair::generate().unwrap().did().clone()
+    }
+
+    #[tokio::test]
+    async fn test_next_sequence_increments() {
+        let tracker = OutgoingSequenceTracker::in_memory();
+
+        let alice = generate_did();
+        let bob = generate_did();
+
+        // First sequence should be 1
+        let seq1 = tracker.next_sequence(&alice, &bob).await.unwrap();
+        assert_eq!(seq1, 1);
+
+        // Second should be 2
+        let seq2 = tracker.next_sequence(&alice, &bob).await.unwrap();
+        assert_eq!(seq2, 2);
+
+        // Third should be 3
+        let seq3 = tracker.next_sequence(&alice, &bob).await.unwrap();
+        assert_eq!(seq3, 3);
+    }
+
+    #[tokio::test]
+    async fn test_separate_recipient_sequences() {
+        let tracker = OutgoingSequenceTracker::in_memory();
+
+        let alice = generate_did();
+        let bob = generate_did();
+        let charlie = generate_did();
+
+        // Alice -> Bob starts at 1
+        let seq1 = tracker.next_sequence(&alice, &bob).await.unwrap();
+        assert_eq!(seq1, 1);
+
+        // Alice -> Charlie also starts at 1 (independent)
+        let seq2 = tracker.next_sequence(&alice, &charlie).await.unwrap();
+        assert_eq!(seq2, 1);
+
+        // Alice -> Bob increments independently
+        let seq3 = tracker.next_sequence(&alice, &bob).await.unwrap();
+        assert_eq!(seq3, 2);
+
+        // Alice -> Charlie still increments independently
+        let seq4 = tracker.next_sequence(&alice, &charlie).await.unwrap();
+        assert_eq!(seq4, 2);
+    }
+
+    #[tokio::test]
+    async fn test_separate_sender_sequences() {
+        let tracker = OutgoingSequenceTracker::in_memory();
+
+        let alice = generate_did();
+        let bob = generate_did();
+        let charlie = generate_did();
+
+        // Alice -> Charlie
+        let seq1 = tracker.next_sequence(&alice, &charlie).await.unwrap();
+        assert_eq!(seq1, 1);
+
+        // Bob -> Charlie (different sender, same recipient)
+        let seq2 = tracker.next_sequence(&bob, &charlie).await.unwrap();
+        assert_eq!(seq2, 1);
+    }
+
+    #[tokio::test]
+    async fn test_current_sequence() {
+        let tracker = OutgoingSequenceTracker::in_memory();
+
+        let alice = generate_did();
+        let bob = generate_did();
+
+        // No sequence yet
+        assert_eq!(tracker.current_sequence(&alice, &bob).await, None);
+
+        // Get first sequence
+        tracker.next_sequence(&alice, &bob).await.unwrap();
+
+        // Now should be 1
+        assert_eq!(tracker.current_sequence(&alice, &bob).await, Some(1));
+
+        // Get another
+        tracker.next_sequence(&alice, &bob).await.unwrap();
+
+        // Now should be 2
+        assert_eq!(tracker.current_sequence(&alice, &bob).await, Some(2));
+    }
+
+    #[tokio::test]
+    async fn test_persistence_and_safety_gap() {
+        let store = Arc::new(icn_store::SledStore::temporary().unwrap());
+
+        let alice = generate_did();
+        let bob = generate_did();
+
+        // Create tracker and get some sequences
+        {
+            let tracker = OutgoingSequenceTracker::new(store.clone()).unwrap();
+
+            // First load applies safety gap (to nothing)
+            tracker.load_and_apply_safety_gap().await.unwrap();
+
+            // Get sequences 1, 2, 3
+            for expected in 1..=3 {
+                let seq = tracker.next_sequence(&alice, &bob).await.unwrap();
+                assert_eq!(seq, expected);
+            }
+        }
+
+        // Create new tracker (simulating restart)
+        {
+            let tracker = OutgoingSequenceTracker::new(store.clone()).unwrap();
+
+            // Load should apply safety gap
+            let loaded = tracker.load_and_apply_safety_gap().await.unwrap();
+            assert_eq!(loaded, 1); // One pair loaded
+
+            // Current sequence should be 3 + RESTART_SAFETY_GAP
+            let current = tracker.current_sequence(&alice, &bob).await.unwrap();
+            assert_eq!(current, 3 + RESTART_SAFETY_GAP);
+
+            // Next sequence should be 3 + RESTART_SAFETY_GAP + 1
+            let next = tracker.next_sequence(&alice, &bob).await.unwrap();
+            assert_eq!(next, 3 + RESTART_SAFETY_GAP + 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_make_and_parse_key() {
+        let alice = generate_did();
+        let bob = generate_did();
+
+        let key = OutgoingSequenceTracker::make_key(&alice, &bob);
+        let (parsed_sender, parsed_recipient) = OutgoingSequenceTracker::parse_key(&key).unwrap();
+
+        assert_eq!(parsed_sender.as_str(), alice.as_str());
+        assert_eq!(parsed_recipient.as_str(), bob.as_str());
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_access() {
+        use std::sync::Arc;
+
+        let tracker = Arc::new(OutgoingSequenceTracker::in_memory());
+
+        let alice = generate_did();
+        let bob = generate_did();
+
+        // Spawn 10 concurrent tasks, each getting 10 sequences
+        let mut handles = vec![];
+
+        for _ in 0..10 {
+            let tracker = Arc::clone(&tracker);
+            let alice = alice.clone();
+            let bob = bob.clone();
+
+            handles.push(tokio::spawn(async move {
+                let mut seqs = vec![];
+                for _ in 0..10 {
+                    seqs.push(tracker.next_sequence(&alice, &bob).await.unwrap());
+                }
+                seqs
+            }));
+        }
+
+        // Collect all sequences
+        let mut all_seqs = vec![];
+        for handle in handles {
+            all_seqs.extend(handle.await.unwrap());
+        }
+
+        // Should have 100 unique sequences
+        assert_eq!(all_seqs.len(), 100);
+
+        // All should be unique
+        all_seqs.sort();
+        all_seqs.dedup();
+        assert_eq!(all_seqs.len(), 100);
+
+        // Should be 1..=100
+        assert_eq!(all_seqs[0], 1);
+        assert_eq!(all_seqs[99], 100);
+    }
+
+    #[tokio::test]
+    async fn test_pair_count() {
+        let tracker = OutgoingSequenceTracker::in_memory();
+
+        let alice = generate_did();
+        let bob = generate_did();
+        let charlie = generate_did();
+
+        assert_eq!(tracker.pair_count().await, 0);
+
+        tracker.next_sequence(&alice, &bob).await.unwrap();
+        assert_eq!(tracker.pair_count().await, 1);
+
+        tracker.next_sequence(&alice, &charlie).await.unwrap();
+        assert_eq!(tracker.pair_count().await, 2);
+
+        tracker.next_sequence(&bob, &charlie).await.unwrap();
+        assert_eq!(tracker.pair_count().await, 3);
+
+        // Same pair doesn't increase count
+        tracker.next_sequence(&alice, &bob).await.unwrap();
+        assert_eq!(tracker.pair_count().await, 3);
+    }
+}

--- a/icn/crates/icn-net/src/sequence_tracker.rs
+++ b/icn/crates/icn-net/src/sequence_tracker.rs
@@ -214,7 +214,8 @@ impl OutgoingSequenceTracker {
     }
 
     /// Separator between sender and recipient DIDs in storage key.
-    /// Using a sequence that won't appear in DIDs (which contain colons).
+    /// Chosen because `||` is unlikely to appear in the base58-encoded public keys used in DIDs,
+    /// even though DIDs themselves contain colons.
     const DID_SEPARATOR: &'static [u8] = b"||";
 
     /// Generate storage key for a sender-recipient pair.

--- a/icn/crates/icn-net/src/sequence_tracker.rs
+++ b/icn/crates/icn-net/src/sequence_tracker.rs
@@ -254,6 +254,79 @@ impl OutgoingSequenceTracker {
         self.cache.read().await.len()
     }
 
+    /// Cleanup stale entries from cache and persistent storage.
+    ///
+    /// Removes entries that haven't been used within the retention period.
+    /// Should be called periodically (e.g., hourly) to prevent unbounded memory growth.
+    ///
+    /// # Arguments
+    /// * `retention_secs` - Remove entries older than this many seconds
+    ///
+    /// # Returns
+    /// Number of entries removed
+    pub async fn cleanup_stale_entries(&self, retention_secs: u64) -> Result<usize> {
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+
+        let cutoff_ms = now_ms.saturating_sub(retention_secs * 1000);
+
+        let entries = self
+            .store
+            .scan(SEQUENCE_PREFIX)
+            .context("Failed to scan sequence entries")?;
+
+        let mut removed = 0;
+        let mut cache = self.cache.write().await;
+
+        for (key, value) in entries {
+            if let Ok(entry) = serde_json::from_slice::<SequenceEntry>(&value) {
+                if entry.updated_at_ms < cutoff_ms {
+                    // Remove from storage
+                    if self.store.delete(&key).is_ok() {
+                        // Remove from cache if we can parse the key
+                        if let Some((sender, recipient)) = Self::parse_key(&key) {
+                            cache.remove(&(sender, recipient));
+                        }
+                        removed += 1;
+                    }
+                }
+            }
+        }
+
+        if removed > 0 {
+            tracing::info!(
+                removed_entries = removed,
+                retention_secs = retention_secs,
+                "Cleaned up stale sequence tracker entries"
+            );
+        }
+
+        Ok(removed)
+    }
+
+    /// Check if safety gap has been applied.
+    ///
+    /// Returns true if `load_and_apply_safety_gap()` has been called.
+    /// Useful for startup validation.
+    pub async fn is_initialized(&self) -> bool {
+        *self.restart_gap_applied.read().await
+    }
+
+    /// Require that safety gap has been explicitly applied.
+    ///
+    /// Returns error if `load_and_apply_safety_gap()` hasn't been called.
+    /// Use this in strict mode when you want to enforce explicit initialization.
+    pub async fn require_initialized(&self) -> Result<()> {
+        if !*self.restart_gap_applied.read().await {
+            anyhow::bail!(
+                "Sequence tracker not initialized. Call load_and_apply_safety_gap() during startup."
+            )
+        }
+        Ok(())
+    }
+
     /// Clear all sequences (for testing only).
     #[cfg(test)]
     pub async fn clear(&self) {
@@ -474,5 +547,84 @@ mod tests {
         // Same pair doesn't increase count
         tracker.next_sequence(&alice, &bob).await.unwrap();
         assert_eq!(tracker.pair_count().await, 3);
+    }
+
+    #[tokio::test]
+    async fn test_is_initialized() {
+        let store = Arc::new(icn_store::SledStore::temporary().unwrap());
+        let tracker = OutgoingSequenceTracker::new(store).unwrap();
+
+        // Not initialized yet
+        assert!(!tracker.is_initialized().await);
+
+        // Apply safety gap
+        tracker.load_and_apply_safety_gap().await.unwrap();
+
+        // Now initialized
+        assert!(tracker.is_initialized().await);
+    }
+
+    #[tokio::test]
+    async fn test_require_initialized_error() {
+        let store = Arc::new(icn_store::SledStore::temporary().unwrap());
+        let tracker = OutgoingSequenceTracker::new(store).unwrap();
+
+        // Should error before initialization
+        let result = tracker.require_initialized().await;
+        assert!(result.is_err());
+
+        // Apply safety gap
+        tracker.load_and_apply_safety_gap().await.unwrap();
+
+        // Should succeed after initialization
+        let result = tracker.require_initialized().await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_auto_initialization_on_next_sequence() {
+        let store = Arc::new(icn_store::SledStore::temporary().unwrap());
+        let tracker = OutgoingSequenceTracker::new(store).unwrap();
+
+        let alice = generate_did();
+        let bob = generate_did();
+
+        // Not initialized
+        assert!(!tracker.is_initialized().await);
+
+        // next_sequence auto-initializes
+        let seq = tracker.next_sequence(&alice, &bob).await.unwrap();
+        assert_eq!(seq, 1);
+
+        // Now initialized
+        assert!(tracker.is_initialized().await);
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_stale_entries() {
+        let store = Arc::new(icn_store::SledStore::temporary().unwrap());
+        let tracker = OutgoingSequenceTracker::new(store).unwrap();
+        tracker.load_and_apply_safety_gap().await.unwrap();
+
+        let alice = generate_did();
+        let bob = generate_did();
+        let charlie = generate_did();
+
+        // Create some entries
+        tracker.next_sequence(&alice, &bob).await.unwrap();
+        tracker.next_sequence(&alice, &charlie).await.unwrap();
+
+        assert_eq!(tracker.pair_count().await, 2);
+
+        // Cleanup with 0 retention - should remove nothing (entries are fresh)
+        // Actually with 0 retention, entries created "now" shouldn't be removed
+        // because their timestamp is >= cutoff
+        let removed = tracker.cleanup_stale_entries(0).await.unwrap();
+        assert_eq!(removed, 0);
+
+        // Cleanup with very long retention - should remove nothing
+        let removed = tracker.cleanup_stale_entries(86400).await.unwrap();
+        assert_eq!(removed, 0);
+        assert_eq!(tracker.pair_count().await, 2);
     }
 }

--- a/icn/crates/icn-net/src/sequence_tracker.rs
+++ b/icn/crates/icn-net/src/sequence_tracker.rs
@@ -264,6 +264,10 @@ impl OutgoingSequenceTracker {
     ///
     /// # Returns
     /// Number of entries removed
+    ///
+    /// # Safety
+    /// Uses double-check pattern to avoid TOCTOU race conditions: entries are
+    /// verified as still stale after acquiring the write lock before deletion.
     pub async fn cleanup_stale_entries(&self, retention_secs: u64) -> Result<usize> {
         let now_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -272,20 +276,36 @@ impl OutgoingSequenceTracker {
 
         let cutoff_ms = now_ms.saturating_sub(retention_secs * 1000);
 
+        // First pass: collect candidate keys (without holding cache lock)
         let entries = self
             .store
             .scan(SEQUENCE_PREFIX)
             .context("Failed to scan sequence entries")?;
 
-        let mut removed = 0;
-        let mut cache = self.cache.write().await;
-
+        let mut candidate_keys: Vec<Vec<u8>> = Vec::new();
         for (key, value) in entries {
             if let Ok(entry) = serde_json::from_slice::<SequenceEntry>(&value) {
                 if entry.updated_at_ms < cutoff_ms {
-                    // Remove from storage
-                    if self.store.delete(&key).is_ok() {
-                        // Remove from cache if we can parse the key
+                    candidate_keys.push(key);
+                }
+            }
+        }
+
+        if candidate_keys.is_empty() {
+            return Ok(0);
+        }
+
+        // Second pass: re-check and delete under lock (TOCTOU protection)
+        let mut removed = 0;
+        let mut cache = self.cache.write().await;
+
+        for key in candidate_keys {
+            // Re-read entry from store to check if it's still stale
+            // (could have been updated between scan and now)
+            if let Ok(Some(fresh_value)) = self.store.get(&key) {
+                if let Ok(fresh_entry) = serde_json::from_slice::<SequenceEntry>(&fresh_value) {
+                    // Only delete if STILL stale after re-check AND delete succeeds
+                    if fresh_entry.updated_at_ms < cutoff_ms && self.store.delete(&key).is_ok() {
                         if let Some((sender, recipient)) = Self::parse_key(&key) {
                             cache.remove(&(sender, recipient));
                         }

--- a/icn/crates/icn-security/src/misbehavior.rs
+++ b/icn/crates/icn-security/src/misbehavior.rs
@@ -425,12 +425,20 @@ impl MisbehaviorDetector {
     ///
     /// Should be called periodically to restore baseline trust for rehabilitated peers.
     /// Returns the list of DIDs that were released from quarantine.
+    ///
+    /// # Reputation Decay
+    ///
+    /// This method applies reputation decay to ALL tracked peers, not just quarantined ones.
+    /// This is intentional: good actors' scores should also recover towards 1.0 over time,
+    /// and the decay rate provides a "healing" mechanism for the entire trust system.
+    /// Without universal decay, a single past violation would permanently lower a peer's score.
     pub fn check_quarantine_releases(&mut self) -> Vec<Did> {
         let mut released = Vec::new();
         let now = SystemTime::now();
 
-        // Apply reputation decay based on time since last update
-        // This prevents re-applying decay on every call
+        // Apply reputation decay to ALL reputation scores.
+        // This is intentional - it allows good actors to recover reputation over time
+        // and prevents permanent penalties for minor past violations.
         for (_did, score) in self.reputation_scores.iter_mut() {
             if let Ok(elapsed) = now.duration_since(score.updated_at) {
                 let hours = elapsed.as_secs() as f64 / 3600.0;

--- a/icn/crates/icn-security/src/misbehavior.rs
+++ b/icn/crates/icn-security/src/misbehavior.rs
@@ -427,13 +427,17 @@ impl MisbehaviorDetector {
     /// Returns the list of DIDs that were released from quarantine.
     pub fn check_quarantine_releases(&mut self) -> Vec<Did> {
         let mut released = Vec::new();
+        let now = SystemTime::now();
 
-        // Apply reputation decay first to update scores
+        // Apply reputation decay based on time since last update
+        // This prevents re-applying decay on every call
         for (_did, score) in self.reputation_scores.iter_mut() {
-            if let Some(last) = score.last_violation {
-                if let Ok(elapsed) = SystemTime::now().duration_since(last) {
-                    let hours = elapsed.as_secs() as f64 / 3600.0;
-                    score.score = (score.score + self.thresholds.decay_rate * hours).min(1.0);
+            if let Ok(elapsed) = now.duration_since(score.updated_at) {
+                let hours = elapsed.as_secs() as f64 / 3600.0;
+                if hours > 0.0 {
+                    let decay_amount = self.thresholds.decay_rate * hours;
+                    score.score = (score.score + decay_amount).min(1.0);
+                    score.updated_at = now; // Critical: update timestamp to prevent re-decay
                 }
             }
         }
@@ -456,6 +460,9 @@ impl MisbehaviorDetector {
         if !released.is_empty() {
             info!("Released {} peers from quarantine", released.len());
         }
+
+        // Periodic cleanup of old violations
+        self.cleanup_old_violations();
 
         released
     }
@@ -482,10 +489,19 @@ impl MisbehaviorDetector {
 
     /// Manually force release from quarantine (administrative action).
     ///
-    /// This bypasses reputation checks and resets to baseline trust.
+    /// This bypasses reputation checks and provides a full "administrative pardon":
+    /// - Removes from quarantine
+    /// - Resets reputation to baseline (0.6)
+    /// - Clears violation history
+    ///
+    /// **AUDIT**: This is a privileged operation that should be logged and monitored.
     pub fn force_release_from_quarantine(&mut self, did: &Did) {
         if self.quarantined.remove(did).is_some() {
-            warn!("Administratively released {} from quarantine", did);
+            // High-priority audit log for administrative override
+            warn!(
+                "AUDIT: Administrative quarantine release for {} - this is a privileged operation",
+                did
+            );
             metrics::quarantined_dec();
 
             // Reset reputation to baseline
@@ -493,7 +509,11 @@ impl MisbehaviorDetector {
                 score.score = Self::BASELINE_REPUTATION_SCORE;
                 score.total_violations = 0;
                 score.severity_points = 0;
+                score.updated_at = SystemTime::now();
             }
+
+            // Clear violation history for true administrative pardon
+            self.violations.remove(did);
 
             // Update trust graph if callback is set
             if let Some(ref callback) = self.trust_penalty_callback {

--- a/icn/crates/icn-security/src/misbehavior.rs
+++ b/icn/crates/icn-security/src/misbehavior.rs
@@ -303,23 +303,28 @@ impl MisbehaviorDetector {
         // Add to violation history
         self.violations.entry(did.clone()).or_default().push(record);
 
-        // Update reputation score
-        let score = self.reputation_scores.entry(did.clone()).or_default();
+        // Update reputation score and capture thresholds for later checks
+        let (is_auto_ban, should_ban, should_quarantine) = {
+            let score = self.reputation_scores.entry(did.clone()).or_default();
+            score.apply_penalty(&violation, self.thresholds.decay_rate);
 
-        score.apply_penalty(&violation, self.thresholds.decay_rate);
+            (
+                violation.is_auto_ban(),
+                score.is_banned(self.thresholds.ban_threshold),
+                score.is_quarantined(self.thresholds.quarantine_threshold),
+            )
+        };
 
         // Emit metrics
         metrics::violations_inc(&did.to_string(), &violation.description());
 
-        // Update trust graph if callback is set (Phase 18)
-        if let Some(ref callback) = self.trust_penalty_callback {
-            callback(did, score.score);
-        }
+        // Update trust graph if callback is set (Phase 18, with panic safety)
+        self.invoke_trust_callback(did);
 
         // Check for auto-quarantine/ban
-        if violation.is_auto_ban() || score.is_banned(self.thresholds.ban_threshold) {
+        if is_auto_ban || should_ban {
             self.ban_peer(did);
-        } else if score.is_quarantined(self.thresholds.quarantine_threshold) {
+        } else if should_quarantine {
             self.quarantine_peer(did);
         }
 
@@ -483,10 +488,36 @@ impl MisbehaviorDetector {
             info!("Released {} from quarantine (reputation recovered)", did);
             metrics::quarantined_dec();
 
-            // Update trust graph if callback is set
-            if let Some(ref callback) = self.trust_penalty_callback {
-                if let Some(score) = self.reputation_scores.get(did) {
-                    callback(did, score.score);
+            // Update trust graph if callback is set (with panic safety)
+            self.invoke_trust_callback(did);
+
+            // Cleanup old violations to prevent unbounded growth
+            self.cleanup_old_violations();
+        }
+    }
+
+    /// Safely invoke the trust penalty callback with panic protection.
+    ///
+    /// If the callback panics, the error is logged but does not propagate.
+    /// This prevents callback failures from crashing the detector.
+    fn invoke_trust_callback(&self, did: &Did) {
+        if let Some(ref callback) = self.trust_penalty_callback {
+            if let Some(score) = self.reputation_scores.get(did) {
+                let did_clone = did.clone();
+                let score_value = score.score;
+                let callback_clone = callback.clone();
+
+                // Catch panics from callback to prevent detector crash
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+                    callback_clone(&did_clone, score_value);
+                }));
+
+                if let Err(e) = result {
+                    warn!(
+                        "Trust penalty callback panicked for {}: {:?}",
+                        did,
+                        e.downcast_ref::<&str>().unwrap_or(&"unknown panic")
+                    );
                 }
             }
         }
@@ -512,23 +543,23 @@ impl MisbehaviorDetector {
             );
             metrics::quarantined_dec();
 
-            // Reset reputation to baseline
+            // Reset reputation to baseline (full pardon)
             if let Some(score) = self.reputation_scores.get_mut(did) {
                 score.score = Self::BASELINE_REPUTATION_SCORE;
                 score.total_violations = 0;
                 score.severity_points = 0;
+                score.last_violation = None; // Clear violation history for clean slate
                 score.updated_at = SystemTime::now();
             }
 
             // Clear violation history for true administrative pardon
             self.violations.remove(did);
 
-            // Update trust graph if callback is set
-            if let Some(ref callback) = self.trust_penalty_callback {
-                if let Some(score) = self.reputation_scores.get(did) {
-                    callback(did, score.score);
-                }
-            }
+            // Update trust graph if callback is set (with panic safety)
+            self.invoke_trust_callback(did);
+
+            // Cleanup old violations from other DIDs
+            self.cleanup_old_violations();
         }
     }
 

--- a/icn/crates/icn-security/src/misbehavior.rs
+++ b/icn/crates/icn-security/src/misbehavior.rs
@@ -446,7 +446,10 @@ impl MisbehaviorDetector {
         // and prevents permanent penalties for minor past violations.
         for (_did, score) in self.reputation_scores.iter_mut() {
             if let Ok(elapsed) = now.duration_since(score.updated_at) {
-                let hours = elapsed.as_secs() as f64 / 3600.0;
+                // Cap decay hours to 720 (30 days) to prevent floating point precision issues
+                // when nodes are offline for extended periods
+                const MAX_DECAY_HOURS: f64 = 720.0;
+                let hours = (elapsed.as_secs() as f64 / 3600.0).min(MAX_DECAY_HOURS);
                 if hours > 0.0 {
                     let decay_amount = self.thresholds.decay_rate * hours;
                     score.score = (score.score + decay_amount).min(1.0);

--- a/icn/crates/icn-security/src/misbehavior.rs
+++ b/icn/crates/icn-security/src/misbehavior.rs
@@ -477,6 +477,9 @@ impl MisbehaviorDetector {
         }
     }
 
+    /// Baseline reputation score for administrative release (0.6 = moderate trust)
+    const BASELINE_REPUTATION_SCORE: f64 = 0.6;
+
     /// Manually force release from quarantine (administrative action).
     ///
     /// This bypasses reputation checks and resets to baseline trust.
@@ -487,14 +490,16 @@ impl MisbehaviorDetector {
 
             // Reset reputation to baseline
             if let Some(score) = self.reputation_scores.get_mut(did) {
-                score.score = 0.6; // Baseline trust
+                score.score = Self::BASELINE_REPUTATION_SCORE;
                 score.total_violations = 0;
                 score.severity_points = 0;
             }
 
             // Update trust graph if callback is set
             if let Some(ref callback) = self.trust_penalty_callback {
-                callback(did, 0.6);
+                if let Some(score) = self.reputation_scores.get(did) {
+                    callback(did, score.score);
+                }
             }
         }
     }
@@ -707,9 +712,9 @@ mod tests {
 
         assert!(detector.is_quarantined(&did), "DID should be quarantined");
 
-        // Manually set reputation above release threshold (quarantine_threshold + 0.1)
+        // Manually set reputation just above release threshold (quarantine_threshold + 0.1)
         if let Some(score) = detector.reputation_scores.get_mut(&did) {
-            score.score = 0.65; // Above 0.5 + 0.1 = 0.6 release threshold
+            score.score = 0.61; // Slightly above 0.5 + 0.1 = 0.6 release threshold
         }
 
         let released = detector.check_quarantine_releases();
@@ -812,8 +817,7 @@ mod tests {
         // Starting from 1.0, new score = 1.0 - 0.25 = 0.75
         assert!(
             (score - 0.75).abs() < 0.01,
-            "Score should be approximately 0.75, got {}",
-            score
+            "Score should be approximately 0.75, got {score}"
         );
     }
 

--- a/icn/crates/icn-security/src/misbehavior.rs
+++ b/icn/crates/icn-security/src/misbehavior.rs
@@ -421,6 +421,84 @@ impl MisbehaviorDetector {
         self.violations.retain(|_, v| !v.is_empty());
     }
 
+    /// Check and release peers whose reputation has recovered above quarantine threshold.
+    ///
+    /// Should be called periodically to restore baseline trust for rehabilitated peers.
+    /// Returns the list of DIDs that were released from quarantine.
+    pub fn check_quarantine_releases(&mut self) -> Vec<Did> {
+        let mut released = Vec::new();
+
+        // Apply reputation decay first to update scores
+        for (_did, score) in self.reputation_scores.iter_mut() {
+            if let Some(last) = score.last_violation {
+                if let Ok(elapsed) = SystemTime::now().duration_since(last) {
+                    let hours = elapsed.as_secs() as f64 / 3600.0;
+                    score.score = (score.score + self.thresholds.decay_rate * hours).min(1.0);
+                }
+            }
+        }
+
+        // Check for quarantine release
+        let quarantine_threshold = self.thresholds.quarantine_threshold;
+        let release_threshold = quarantine_threshold + 0.1; // Must exceed threshold by 0.1
+
+        let dids_to_check: Vec<Did> = self.quarantined.keys().cloned().collect();
+
+        for did in dids_to_check {
+            if let Some(score) = self.reputation_scores.get(&did) {
+                if score.score >= release_threshold {
+                    self.release_from_quarantine(&did);
+                    released.push(did);
+                }
+            }
+        }
+
+        if !released.is_empty() {
+            info!("Released {} peers from quarantine", released.len());
+        }
+
+        released
+    }
+
+    /// Release a peer from quarantine, restoring baseline trust.
+    ///
+    /// This should only be called when a peer's reputation has sufficiently recovered.
+    pub fn release_from_quarantine(&mut self, did: &Did) {
+        if self.quarantined.remove(did).is_some() {
+            info!("Released {} from quarantine (reputation recovered)", did);
+            metrics::quarantined_dec();
+
+            // Update trust graph if callback is set
+            if let Some(ref callback) = self.trust_penalty_callback {
+                if let Some(score) = self.reputation_scores.get(did) {
+                    callback(did, score.score);
+                }
+            }
+        }
+    }
+
+    /// Manually force release from quarantine (administrative action).
+    ///
+    /// This bypasses reputation checks and resets to baseline trust.
+    pub fn force_release_from_quarantine(&mut self, did: &Did) {
+        if self.quarantined.remove(did).is_some() {
+            warn!("Administratively released {} from quarantine", did);
+            metrics::quarantined_dec();
+
+            // Reset reputation to baseline
+            if let Some(score) = self.reputation_scores.get_mut(did) {
+                score.score = 0.6; // Baseline trust
+                score.total_violations = 0;
+                score.severity_points = 0;
+            }
+
+            // Update trust graph if callback is set
+            if let Some(ref callback) = self.trust_penalty_callback {
+                callback(did, 0.6);
+            }
+        }
+    }
+
     /// Get statistics for monitoring
     pub fn get_stats(&self) -> MisbehaviorStats {
         MisbehaviorStats {
@@ -610,5 +688,179 @@ mod tests {
         assert_eq!(stats.total_tracked_dids, 2);
         assert_eq!(stats.total_violations, 2);
         assert_eq!(stats.banned_count, 1); // did2 auto-banned
+    }
+
+    #[test]
+    fn test_quarantine_release_with_high_score() {
+        let mut detector = MisbehaviorDetector::new(MisbehaviorThresholds::default());
+        let did = test_did();
+
+        // First quarantine the peer via rate limiting
+        for _ in 0..15 {
+            let violation = Violation::ExcessiveResourceUse {
+                metric: "test".to_string(),
+                observed: 10,
+                limit: 5,
+            };
+            detector.record_violation(&did, violation, vec![]);
+        }
+
+        assert!(detector.is_quarantined(&did), "DID should be quarantined");
+
+        // Manually set reputation above release threshold (quarantine_threshold + 0.1)
+        if let Some(score) = detector.reputation_scores.get_mut(&did) {
+            score.score = 0.65; // Above 0.5 + 0.1 = 0.6 release threshold
+        }
+
+        let released = detector.check_quarantine_releases();
+        assert!(released.contains(&did), "DID should be released");
+        assert!(
+            !detector.is_quarantined(&did),
+            "DID should no longer be quarantined"
+        );
+    }
+
+    #[test]
+    fn test_force_release_from_quarantine() {
+        let mut detector = MisbehaviorDetector::new(MisbehaviorThresholds::default());
+        let did = test_did();
+
+        // Quarantine the peer
+        for _ in 0..15 {
+            let violation = Violation::ExcessiveResourceUse {
+                metric: "test".to_string(),
+                observed: 10,
+                limit: 5,
+            };
+            detector.record_violation(&did, violation, vec![]);
+        }
+
+        assert!(detector.is_quarantined(&did), "DID should be quarantined");
+
+        // Force release
+        detector.force_release_from_quarantine(&did);
+
+        assert!(
+            !detector.is_quarantined(&did),
+            "DID should no longer be quarantined"
+        );
+
+        // Reputation should be reset to baseline
+        let rep = detector.get_reputation(&did).unwrap().score;
+        assert!(
+            (rep - 0.6).abs() < 0.01,
+            "Reputation should be reset to 0.6 baseline"
+        );
+    }
+
+    #[test]
+    fn test_trust_penalty_callback_called() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_count_clone = call_count.clone();
+
+        let mut detector = MisbehaviorDetector::new(MisbehaviorThresholds::default());
+
+        // Set up callback
+        let callback: TrustPenaltyCallback = Arc::new(move |_did, _score| {
+            call_count_clone.fetch_add(1, Ordering::SeqCst);
+        });
+        detector.set_trust_penalty_callback(callback);
+
+        let did = test_did();
+        let violation = Violation::ExcessiveResourceUse {
+            metric: "test".to_string(),
+            observed: 10,
+            limit: 5,
+        };
+
+        detector.record_violation(&did, violation, vec![]);
+
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "Trust penalty callback should be called once"
+        );
+    }
+
+    #[test]
+    fn test_trust_penalty_callback_receives_correct_score() {
+        use std::sync::{Arc, Mutex};
+
+        let received_score = Arc::new(Mutex::new(None));
+        let received_score_clone = received_score.clone();
+
+        let mut detector = MisbehaviorDetector::new(MisbehaviorThresholds::default());
+
+        // Set up callback to capture score
+        let callback: TrustPenaltyCallback = Arc::new(move |_did, score| {
+            *received_score_clone.lock().unwrap() = Some(score);
+        });
+        detector.set_trust_penalty_callback(callback);
+
+        let did = test_did();
+        let violation = Violation::InvalidSignature {
+            message_hash: [0u8; 32],
+        };
+
+        detector.record_violation(&did, violation, vec![]);
+
+        let score = received_score.lock().unwrap().expect("Score should be set");
+        // InvalidSignature has severity 5, penalty = 5 * 0.05 = 0.25
+        // Starting from 1.0, new score = 1.0 - 0.25 = 0.75
+        assert!(
+            (score - 0.75).abs() < 0.01,
+            "Score should be approximately 0.75, got {}",
+            score
+        );
+    }
+
+    #[test]
+    fn test_release_from_quarantine_calls_callback() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_count_clone = call_count.clone();
+
+        let mut detector = MisbehaviorDetector::new(MisbehaviorThresholds::default());
+
+        let callback: TrustPenaltyCallback = Arc::new(move |_did, _score| {
+            call_count_clone.fetch_add(1, Ordering::SeqCst);
+        });
+        detector.set_trust_penalty_callback(callback);
+
+        let did = test_did();
+
+        // Quarantine via violations
+        for _ in 0..15 {
+            detector.record_violation(
+                &did,
+                Violation::ExcessiveResourceUse {
+                    metric: "test".to_string(),
+                    observed: 10,
+                    limit: 5,
+                },
+                vec![],
+            );
+        }
+
+        // Reset call count after initial violations
+        call_count.store(0, Ordering::SeqCst);
+
+        // Set reputation high enough for release
+        if let Some(score) = detector.reputation_scores.get_mut(&did) {
+            score.score = 0.65;
+        }
+
+        detector.release_from_quarantine(&did);
+
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "Callback should be called on quarantine release"
+        );
     }
 }

--- a/sdk/typescript/src/index.test.ts
+++ b/sdk/typescript/src/index.test.ts
@@ -1083,9 +1083,10 @@ describe('governance operations - additional', () => {
 });
 
 describe('vote delegation', () => {
-  // Use valid-looking DIDs (key portion must be at least 10 chars)
-  const validBobDid = 'did:icn:zBobKey123456789';
-  const validCharlieDid = 'did:icn:zCharlieKey12345';
+  // Use valid-looking DIDs (key portion must be at least 10 chars and use base58btc encoding)
+  // Base58btc starts with 'z' prefix, followed by valid base58 chars
+  const validBobDid = 'did:icn:zBobKeyABCDEFGHJ';
+  const validCharlieDid = 'did:icn:zCharlieKeyNPQRS';
 
   it('should create a blanket delegation', async () => {
     const mockResponse = {
@@ -1313,7 +1314,7 @@ describe('vote delegation', () => {
     it('should reject invalid scope format', async () => {
       await expect(
         client.createDelegation({
-          delegate: 'did:icn:validkey123456',
+          delegate: 'did:icn:zValidKeyABCDEF',
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           scope: 'invalid-scope' as any, // Bypass type check for runtime validation test
         })
@@ -1323,7 +1324,7 @@ describe('vote delegation', () => {
     it('should reject empty scope ID', async () => {
       await expect(
         client.createDelegation({
-          delegate: 'did:icn:validkey123456',
+          delegate: 'did:icn:zValidKeyABCDEF',
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           scope: 'domain:' as any, // Bypass type check for runtime validation test
         })
@@ -1333,7 +1334,7 @@ describe('vote delegation', () => {
     it('should reject past expiration', async () => {
       await expect(
         client.createDelegation({
-          delegate: 'did:icn:validkey123456',
+          delegate: 'did:icn:zValidKeyABCDEF',
           scope: 'blanket',
           expires_at: 1700000000, // Past timestamp (Nov 2023)
         })
@@ -1341,13 +1342,15 @@ describe('vote delegation', () => {
     });
 
     it('should accept valid blanket delegation', async () => {
+      // Valid base58btc DID (starts with 'z')
+      const validDid = 'did:icn:zValidKeyABCDEF';
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 201,
         json: async () => ({
           id: 'del-1',
-          delegator: 'did:icn:alice',
-          delegate: 'did:icn:validkey123456',
+          delegator: 'did:icn:alice123456789',
+          delegate: validDid,
           scope: 'blanket',
           is_active: true,
         }),
@@ -1355,20 +1358,21 @@ describe('vote delegation', () => {
 
       await expect(
         client.createDelegation({
-          delegate: 'did:icn:validkey123456',
+          delegate: validDid,
           scope: 'blanket',
         })
       ).resolves.toBeDefined();
     });
 
     it('should accept valid domain-scoped delegation', async () => {
+      const validDid = 'did:icn:zValidKeyABCDEF';
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 201,
         json: async () => ({
           id: 'del-2',
-          delegator: 'did:icn:alice',
-          delegate: 'did:icn:validkey123456',
+          delegator: 'did:icn:alice123456789',
+          delegate: validDid,
           scope: 'domain:test-domain',
           is_active: true,
         }),
@@ -1376,20 +1380,21 @@ describe('vote delegation', () => {
 
       await expect(
         client.createDelegation({
-          delegate: 'did:icn:validkey123456',
+          delegate: validDid,
           scope: 'domain:test-domain',
         })
       ).resolves.toBeDefined();
     });
 
     it('should accept valid proposal-scoped delegation', async () => {
+      const validDid = 'did:icn:zValidKeyABCDEF';
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 201,
         json: async () => ({
           id: 'del-3',
-          delegator: 'did:icn:alice',
-          delegate: 'did:icn:validkey123456',
+          delegator: 'did:icn:alice123456789',
+          delegate: validDid,
           scope: 'proposal:prop-123',
           is_active: true,
         }),
@@ -1397,7 +1402,7 @@ describe('vote delegation', () => {
 
       await expect(
         client.createDelegation({
-          delegate: 'did:icn:validkey123456',
+          delegate: validDid,
           scope: 'proposal:prop-123',
         })
       ).resolves.toBeDefined();

--- a/sdk/typescript/src/index.test.ts
+++ b/sdk/typescript/src/index.test.ts
@@ -1082,6 +1082,198 @@ describe('governance operations - additional', () => {
   });
 });
 
+describe('vote delegation', () => {
+  it('should create a blanket delegation', async () => {
+    const mockResponse = {
+      id: 'del-123',
+      delegator: 'did:icn:alice',
+      delegate: 'did:icn:bob',
+      scope: 'blanket',
+      created_at: 1700000000,
+      is_active: true,
+    };
+
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => mockResponse,
+    });
+
+    const client = new ICNClient({
+      baseUrl: 'http://localhost:8080',
+      token: 'test-token',
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    const result = await client.createDelegation({
+      delegate: 'did:icn:bob',
+      scope: 'blanket',
+    });
+
+    expect(result.id).toBe('del-123');
+    expect(result.scope).toBe('blanket');
+    expect(result.is_active).toBe(true);
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:8080/v1/gov/delegations');
+    expect(options.method).toBe('POST');
+
+    const body = JSON.parse(options.body);
+    expect(body.delegate).toBe('did:icn:bob');
+    expect(body.scope).toBe('blanket');
+  });
+
+  it('should create a domain-scoped delegation with expiry', async () => {
+    const mockResponse = {
+      id: 'del-456',
+      delegator: 'did:icn:alice',
+      delegate: 'did:icn:charlie',
+      scope: 'domain:my-domain',
+      created_at: 1700000000,
+      expires_at: 1700086400,
+      is_active: true,
+    };
+
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => mockResponse,
+    });
+
+    const client = new ICNClient({
+      baseUrl: 'http://localhost:8080',
+      token: 'test-token',
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    const result = await client.createDelegation({
+      delegate: 'did:icn:charlie',
+      scope: 'domain:my-domain',
+      expires_at: 1700086400,
+    });
+
+    expect(result.scope).toBe('domain:my-domain');
+    expect(result.expires_at).toBe(1700086400);
+  });
+
+  it('should list delegations (active only by default)', async () => {
+    const mockResponse = {
+      given: [
+        {
+          id: 'del-1',
+          delegator: 'did:icn:alice',
+          delegate: 'did:icn:bob',
+          scope: 'blanket',
+          created_at: 1700000000,
+          is_active: true,
+        },
+      ],
+      received: [
+        {
+          id: 'del-2',
+          delegator: 'did:icn:charlie',
+          delegate: 'did:icn:alice',
+          scope: 'domain:test',
+          created_at: 1700000000,
+          is_active: true,
+        },
+      ],
+    };
+
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockResponse,
+    });
+
+    const client = new ICNClient({
+      baseUrl: 'http://localhost:8080',
+      token: 'test-token',
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    const result = await client.listDelegations();
+
+    expect(result.given).toHaveLength(1);
+    expect(result.received).toHaveLength(1);
+    expect(result.given[0].id).toBe('del-1');
+    expect(result.received[0].scope).toBe('domain:test');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:8080/v1/gov/delegations');
+  });
+
+  it('should list delegations including revoked', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ given: [], received: [] }),
+    });
+
+    const client = new ICNClient({
+      baseUrl: 'http://localhost:8080',
+      token: 'test-token',
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    await client.listDelegations(true);
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:8080/v1/gov/delegations?include_revoked=true');
+  });
+
+  it('should get a specific delegation', async () => {
+    const mockResponse = {
+      id: 'del-123',
+      delegator: 'did:icn:alice',
+      delegate: 'did:icn:bob',
+      scope: 'proposal:prop-1',
+      created_at: 1700000000,
+      is_active: true,
+    };
+
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockResponse,
+    });
+
+    const client = new ICNClient({
+      baseUrl: 'http://localhost:8080',
+      token: 'test-token',
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    const result = await client.getDelegation('del-123');
+
+    expect(result.id).toBe('del-123');
+    expect(result.scope).toBe('proposal:prop-1');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:8080/v1/gov/delegations/del-123');
+  });
+
+  it('should revoke a delegation', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: async () => null,
+    });
+
+    const client = new ICNClient({
+      baseUrl: 'http://localhost:8080',
+      token: 'test-token',
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    await client.revokeDelegation('del-123');
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:8080/v1/gov/delegations/del-123');
+    expect(options.method).toBe('DELETE');
+  });
+});
+
 describe('compute task submission - CCL', () => {
   it('should submit CCL task with code', async () => {
     const mockResponse = {

--- a/sdk/typescript/src/index.test.ts
+++ b/sdk/typescript/src/index.test.ts
@@ -1083,11 +1083,15 @@ describe('governance operations - additional', () => {
 });
 
 describe('vote delegation', () => {
+  // Use valid-looking DIDs (key portion must be at least 10 chars)
+  const validBobDid = 'did:icn:zBobKey123456789';
+  const validCharlieDid = 'did:icn:zCharlieKey12345';
+
   it('should create a blanket delegation', async () => {
     const mockResponse = {
       id: 'del-123',
-      delegator: 'did:icn:alice',
-      delegate: 'did:icn:bob',
+      delegator: 'did:icn:alice123456',
+      delegate: validBobDid,
       scope: 'blanket',
       created_at: 1700000000,
       is_active: true,
@@ -1106,7 +1110,7 @@ describe('vote delegation', () => {
     });
 
     const result = await client.createDelegation({
-      delegate: 'did:icn:bob',
+      delegate: validBobDid,
       scope: 'blanket',
     });
 
@@ -1119,18 +1123,21 @@ describe('vote delegation', () => {
     expect(options.method).toBe('POST');
 
     const body = JSON.parse(options.body);
-    expect(body.delegate).toBe('did:icn:bob');
+    expect(body.delegate).toBe(validBobDid);
     expect(body.scope).toBe('blanket');
   });
 
   it('should create a domain-scoped delegation with expiry', async () => {
+    // Use a future timestamp (2030-01-01 00:00:00 UTC)
+    const futureExpiry = 1893456000;
+
     const mockResponse = {
       id: 'del-456',
-      delegator: 'did:icn:alice',
-      delegate: 'did:icn:charlie',
+      delegator: 'did:icn:alice123456',
+      delegate: validCharlieDid,
       scope: 'domain:my-domain',
       created_at: 1700000000,
-      expires_at: 1700086400,
+      expires_at: futureExpiry,
       is_active: true,
     };
 
@@ -1147,13 +1154,13 @@ describe('vote delegation', () => {
     });
 
     const result = await client.createDelegation({
-      delegate: 'did:icn:charlie',
+      delegate: validCharlieDid,
       scope: 'domain:my-domain',
-      expires_at: 1700086400,
+      expires_at: futureExpiry,
     });
 
     expect(result.scope).toBe('domain:my-domain');
-    expect(result.expires_at).toBe(1700086400);
+    expect(result.expires_at).toBe(futureExpiry);
   });
 
   it('should list delegations (active only by default)', async () => {
@@ -1271,6 +1278,130 @@ describe('vote delegation', () => {
     const [url, options] = mockFetch.mock.calls[0];
     expect(url).toBe('http://localhost:8080/v1/gov/delegations/del-123');
     expect(options.method).toBe('DELETE');
+  });
+
+  describe('input validation', () => {
+    let client: ICNClient;
+    const mockFetch = jest.fn();
+
+    beforeEach(() => {
+      client = new ICNClient({
+        baseUrl: 'http://localhost:8080',
+        token: 'test-token',
+        fetch: mockFetch as unknown as typeof fetch,
+      });
+    });
+
+    it('should reject invalid delegate DID', async () => {
+      await expect(
+        client.createDelegation({
+          delegate: 'not-a-valid-did',
+          scope: 'blanket',
+        })
+      ).rejects.toThrow('must be a valid DID');
+    });
+
+    it('should reject empty delegate', async () => {
+      await expect(
+        client.createDelegation({
+          delegate: '',
+          scope: 'blanket',
+        })
+      ).rejects.toThrow('delegate is required');
+    });
+
+    it('should reject invalid scope format', async () => {
+      await expect(
+        client.createDelegation({
+          delegate: 'did:icn:validkey123456',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          scope: 'invalid-scope' as any, // Bypass type check for runtime validation test
+        })
+      ).rejects.toThrow("scope must be 'blanket'");
+    });
+
+    it('should reject empty scope ID', async () => {
+      await expect(
+        client.createDelegation({
+          delegate: 'did:icn:validkey123456',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          scope: 'domain:' as any, // Bypass type check for runtime validation test
+        })
+      ).rejects.toThrow('scope ID cannot be empty');
+    });
+
+    it('should reject past expiration', async () => {
+      await expect(
+        client.createDelegation({
+          delegate: 'did:icn:validkey123456',
+          scope: 'blanket',
+          expires_at: 1700000000, // Past timestamp (Nov 2023)
+        })
+      ).rejects.toThrow('expires_at must be in the future');
+    });
+
+    it('should accept valid blanket delegation', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({
+          id: 'del-1',
+          delegator: 'did:icn:alice',
+          delegate: 'did:icn:validkey123456',
+          scope: 'blanket',
+          is_active: true,
+        }),
+      });
+
+      await expect(
+        client.createDelegation({
+          delegate: 'did:icn:validkey123456',
+          scope: 'blanket',
+        })
+      ).resolves.toBeDefined();
+    });
+
+    it('should accept valid domain-scoped delegation', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({
+          id: 'del-2',
+          delegator: 'did:icn:alice',
+          delegate: 'did:icn:validkey123456',
+          scope: 'domain:test-domain',
+          is_active: true,
+        }),
+      });
+
+      await expect(
+        client.createDelegation({
+          delegate: 'did:icn:validkey123456',
+          scope: 'domain:test-domain',
+        })
+      ).resolves.toBeDefined();
+    });
+
+    it('should accept valid proposal-scoped delegation', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({
+          id: 'del-3',
+          delegator: 'did:icn:alice',
+          delegate: 'did:icn:validkey123456',
+          scope: 'proposal:prop-123',
+          is_active: true,
+        }),
+      });
+
+      await expect(
+        client.createDelegation({
+          delegate: 'did:icn:validkey123456',
+          scope: 'proposal:prop-123',
+        })
+      ).resolves.toBeDefined();
+    });
   });
 });
 

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -651,7 +651,7 @@ export class ICNClient {
    * await client.createDelegation({
    *   delegate: 'did:icn:delegate123',
    *   scope: 'domain:my-governance-domain',
-   *   expires_at: Date.now() / 1000 + 86400, // Expires in 24 hours
+   *   expires_at: Math.floor(Date.now() / 1000) + 86400, // Expires in 24 hours
    * });
    *
    * // Proposal-scoped delegation - delegate can only vote on specific proposal

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -122,6 +122,103 @@ const DEFAULT_RETRY: Required<RetryOptions> = {
   retryableStatuses: [408, 429, 500, 502, 503, 504],
 };
 
+// ===========================================================================
+// Input Validation Helpers
+// ===========================================================================
+
+/**
+ * Validate a DID (Decentralized Identifier) format.
+ *
+ * ICN DIDs follow the pattern: did:icn:<multibase-encoded-public-key>
+ * where the key portion is base58btc encoded (starts with 'z').
+ *
+ * @throws ICNError if the DID format is invalid
+ */
+function validateDid(did: string, fieldName = 'DID'): void {
+  if (!did || typeof did !== 'string') {
+    throw new ICNError(`${fieldName} is required`, 400, 'INVALID_DID');
+  }
+
+  // Basic format check: did:method:identifier
+  const parts = did.split(':');
+  if (parts.length < 3 || parts[0] !== 'did') {
+    throw new ICNError(`${fieldName} must be a valid DID (did:method:identifier)`, 400, 'INVALID_DID');
+  }
+
+  // ICN-specific validation
+  if (parts[1] === 'icn') {
+    const key = parts.slice(2).join(':'); // Handle edge case of colons in key
+    if (!key || key.length < 10) {
+      throw new ICNError(`${fieldName} has invalid key portion`, 400, 'INVALID_DID');
+    }
+  }
+}
+
+/**
+ * Validate delegation scope format.
+ *
+ * Valid formats:
+ * - undefined or 'blanket' - blanket delegation
+ * - 'domain:<domain-id>' - domain-scoped delegation
+ * - 'proposal:<proposal-id>' - proposal-scoped delegation
+ *
+ * @throws ICNError if the scope format is invalid
+ */
+function validateDelegationScope(scope: string | undefined): void {
+  if (scope === undefined || scope === 'blanket') {
+    return; // Valid blanket delegation
+  }
+
+  if (typeof scope !== 'string') {
+    throw new ICNError('scope must be a string', 400, 'INVALID_SCOPE');
+  }
+
+  const validPrefixes = ['domain:', 'proposal:'];
+  const hasValidPrefix = validPrefixes.some(prefix => scope.startsWith(prefix));
+
+  if (!hasValidPrefix) {
+    throw new ICNError(
+      `scope must be 'blanket', 'domain:<id>', or 'proposal:<id>' (got: ${scope})`,
+      400,
+      'INVALID_SCOPE'
+    );
+  }
+
+  // Validate that the ID portion is non-empty
+  const colonIndex = scope.indexOf(':');
+  const id = scope.slice(colonIndex + 1);
+  if (!id || id.length === 0) {
+    throw new ICNError('scope ID cannot be empty', 400, 'INVALID_SCOPE');
+  }
+}
+
+/**
+ * Validate expiration timestamp.
+ *
+ * @throws ICNError if the expiration is in the past or too far in the future
+ */
+function validateExpiration(expiresAt: number | undefined): void {
+  if (expiresAt === undefined) {
+    return; // Optional field
+  }
+
+  if (typeof expiresAt !== 'number' || !Number.isInteger(expiresAt)) {
+    throw new ICNError('expires_at must be an integer timestamp', 400, 'INVALID_EXPIRATION');
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+
+  if (expiresAt <= now) {
+    throw new ICNError('expires_at must be in the future', 400, 'INVALID_EXPIRATION');
+  }
+
+  // Max 10 years in the future
+  const maxExpiry = now + (10 * 365 * 24 * 60 * 60);
+  if (expiresAt > maxExpiry) {
+    throw new ICNError('expires_at cannot be more than 10 years in the future', 400, 'INVALID_EXPIRATION');
+  }
+}
+
 /**
  * ICN Gateway API Client
  */
@@ -662,6 +759,11 @@ export class ICNClient {
    * ```
    */
   async createDelegation(req: CreateDelegationRequest): Promise<DelegationResponse> {
+    // Client-side validation
+    validateDid(req.delegate, 'delegate');
+    validateDelegationScope(req.scope);
+    validateExpiration(req.expires_at);
+
     return this.post<DelegationResponse>('/gov/delegations', req);
   }
 

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -132,6 +132,9 @@ const DEFAULT_RETRY: Required<RetryOptions> = {
  * ICN DIDs follow the pattern: did:icn:<multibase-encoded-public-key>
  * where the key portion is base58btc encoded (starts with 'z').
  *
+ * Accepts both ICN DIDs (strict 3-part format) and other DID methods
+ * (for interoperability with external systems).
+ *
  * @throws ICNError if the DID format is invalid
  */
 function validateDid(did: string, fieldName = 'DID'): void {
@@ -145,13 +148,28 @@ function validateDid(did: string, fieldName = 'DID'): void {
     throw new ICNError(`${fieldName} must be a valid DID (did:method:identifier)`, 400, 'INVALID_DID');
   }
 
-  // ICN-specific validation
-  if (parts[1] === 'icn') {
-    const key = parts.slice(2).join(':'); // Handle edge case of colons in key
+  const method = parts[1];
+
+  // ICN-specific validation (strict 3-part format)
+  if (method === 'icn') {
+    // ICN DIDs must be exactly: did:icn:<key>
+    if (parts.length !== 3) {
+      throw new ICNError(`${fieldName} must be exactly did:icn:<key> format`, 400, 'INVALID_DID');
+    }
+
+    const key = parts[2];
+    // Key portion should be base58btc encoded (typically 43-44 chars for Ed25519)
     if (!key || key.length < 10) {
       throw new ICNError(`${fieldName} has invalid key portion`, 400, 'INVALID_DID');
     }
+
+    // Multibase prefix check (base58btc starts with 'z')
+    if (!key.startsWith('z') && !/^[1-9A-HJ-NP-Za-km-z]+$/.test(key)) {
+      // Allow both multibase format and raw base58 for backwards compatibility
+      throw new ICNError(`${fieldName} has invalid key encoding`, 400, 'INVALID_DID');
+    }
   }
+  // Other DID methods (did:key, did:web, etc.) - allow more parts
 }
 
 /**

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -163,9 +163,11 @@ function validateDid(did: string, fieldName = 'DID'): void {
       throw new ICNError(`${fieldName} has invalid key portion`, 400, 'INVALID_DID');
     }
 
-    // Multibase prefix check (base58btc starts with 'z')
+    // Multibase prefix check: ICN DIDs use base58btc encoding (multibase prefix 'z').
+    // For backwards compatibility with legacy DIDs, we also accept raw base58 without
+    // the 'z' prefix. Base58 charset excludes 0, O, I, l to avoid ambiguity.
+    // New DIDs should use multibase format: did:icn:z<base58btc-key>
     if (!key.startsWith('z') && !/^[1-9A-HJ-NP-Za-km-z]+$/.test(key)) {
-      // Allow both multibase format and raw base58 for backwards compatibility
       throw new ICNError(`${fieldName} has invalid key encoding`, 400, 'INVALID_DID');
     }
   }

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -104,6 +104,10 @@ import {
   ListDevicesResponse,
   RevokeDeviceRequest,
   RevokeDeviceResponse,
+  // Vote delegation types
+  CreateDelegationRequest,
+  DelegationResponse,
+  DelegationListResponse,
 } from './types';
 
 export * from './types';
@@ -624,6 +628,86 @@ export class ICNClient {
    */
   async getVotes(proposalId: string): Promise<VoteTally> {
     return this.get<VoteTally>(`/gov/proposals/${proposalId}/votes`);
+  }
+
+  // ===========================================================================
+  // Vote Delegation
+  // ===========================================================================
+
+  /**
+   * Create a vote delegation
+   *
+   * Allows the authenticated user to delegate their voting power to another DID.
+   *
+   * @example
+   * ```typescript
+   * // Blanket delegation - delegate can vote on all proposals
+   * await client.createDelegation({
+   *   delegate: 'did:icn:delegate123',
+   *   scope: 'blanket',
+   * });
+   *
+   * // Domain-scoped delegation - delegate can only vote in specific domain
+   * await client.createDelegation({
+   *   delegate: 'did:icn:delegate123',
+   *   scope: 'domain:my-governance-domain',
+   *   expires_at: Date.now() / 1000 + 86400, // Expires in 24 hours
+   * });
+   *
+   * // Proposal-scoped delegation - delegate can only vote on specific proposal
+   * await client.createDelegation({
+   *   delegate: 'did:icn:delegate123',
+   *   scope: 'proposal:prop-123',
+   * });
+   * ```
+   */
+  async createDelegation(req: CreateDelegationRequest): Promise<DelegationResponse> {
+    return this.post<DelegationResponse>('/gov/delegations', req);
+  }
+
+  /**
+   * List delegations for the authenticated user
+   *
+   * Returns both delegations given by and received by the user.
+   *
+   * @param includeRevoked - Whether to include revoked delegations (default: false)
+   * @example
+   * ```typescript
+   * // Get active delegations only
+   * const { given, received } = await client.listDelegations();
+   * console.log('Delegations given:', given.length);
+   * console.log('Delegations received:', received.length);
+   *
+   * // Include revoked delegations
+   * const all = await client.listDelegations(true);
+   * ```
+   */
+  async listDelegations(includeRevoked = false): Promise<DelegationListResponse> {
+    const query = includeRevoked ? '?include_revoked=true' : '';
+    return this.get<DelegationListResponse>(`/gov/delegations${query}`);
+  }
+
+  /**
+   * Get a specific delegation by ID
+   *
+   * Only the delegator or delegate can view a delegation (for privacy).
+   */
+  async getDelegation(delegationId: string): Promise<DelegationResponse> {
+    return this.get<DelegationResponse>(`/gov/delegations/${encodeURIComponent(delegationId)}`);
+  }
+
+  /**
+   * Revoke a delegation
+   *
+   * Only the delegator can revoke their delegation.
+   *
+   * @example
+   * ```typescript
+   * await client.revokeDelegation('delegation-123');
+   * ```
+   */
+  async revokeDelegation(delegationId: string): Promise<void> {
+    return this.delete<void>(`/gov/delegations/${encodeURIComponent(delegationId)}`);
   }
 
   // ===========================================================================

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -237,6 +237,62 @@ export interface ProposalOutcome {
 }
 
 // ============================================================================
+// Vote Delegation
+// ============================================================================
+
+/**
+ * Scope of a vote delegation.
+ * - "blanket": Delegate can vote on behalf of delegator for all proposals
+ * - "domain:<id>": Delegate can only vote in the specified governance domain
+ * - "proposal:<id>": Delegate can only vote on the specified proposal
+ */
+export type DelegationScope = 'blanket' | `domain:${string}` | `proposal:${string}`;
+
+/**
+ * Request to create a new vote delegation
+ */
+export interface CreateDelegationRequest {
+  /** DID of the delegate (who receives voting power) */
+  delegate: string;
+  /** Scope of delegation */
+  scope: DelegationScope;
+  /** Optional expiry timestamp (Unix seconds) */
+  expires_at?: number;
+}
+
+/**
+ * Response containing delegation details
+ */
+export interface DelegationResponse {
+  /** Unique delegation ID */
+  id: string;
+  /** DID of the delegator (who gave up voting power) */
+  delegator: string;
+  /** DID of the delegate (who received voting power) */
+  delegate: string;
+  /** Scope of delegation */
+  scope: string;
+  /** Creation timestamp (Unix seconds) */
+  created_at: number;
+  /** Optional expiry timestamp (Unix seconds) */
+  expires_at?: number;
+  /** Revocation timestamp (Unix seconds), if revoked */
+  revoked_at?: number;
+  /** Whether the delegation is currently active */
+  is_active: boolean;
+}
+
+/**
+ * Response containing delegations given and received by a user
+ */
+export interface DelegationListResponse {
+  /** Delegations given by the caller */
+  given: DelegationResponse[];
+  /** Delegations received by the caller */
+  received: DelegationResponse[];
+}
+
+// ============================================================================
 // Compute
 // ============================================================================
 


### PR DESCRIPTION
## Summary

This PR implements two key features:

### 1. Trust Penalty Application (Issue #316)
Wires misbehavior detection to trust graph penalties with quarantine release mechanisms:

- **`check_quarantine_releases()`** - Periodic check for reputation recovery above threshold
- **`release_from_quarantine()`** - Normal release with trust callback invocation  
- **`force_release_from_quarantine()`** - Administrative release with reputation reset to 0.6 baseline

Also includes:
- Persistent sequence counter (`OutgoingSequenceTracker`) for ChaCha20-Poly1305 nonce safety
- 14 new unit tests for icn-net handlers (signature verification, replay detection, RTT measurement)
- 5 integration tests for trust penalty flow

### 2. TypeScript SDK Vote Delegation
Adds vote delegation support to the governance module:

- **Types**: `DelegationScope`, `CreateDelegationRequest`, `DelegationResponse`, `DelegationListResponse`
- **Methods**: `createDelegation()`, `listDelegations()`, `getDelegation()`, `revokeDelegation()`
- 6 new unit tests for delegation functionality

## Changes

| File | Changes |
|------|---------|
| `icn-security/src/misbehavior.rs` | Add quarantine release methods |
| `icn-net/src/sequence_tracker.rs` | New persistent sequence tracker |
| `icn-net/src/handlers/signed.rs` | Add 10 unit tests |
| `icn-net/src/handlers/handshake.rs` | Add 4 unit tests |
| `icn-core/src/supervisor/init_trust.rs` | Add 5 integration tests |
| `sdk/typescript/src/types.ts` | Add delegation types |
| `sdk/typescript/src/index.ts` | Add delegation methods |
| `sdk/typescript/src/index.test.ts` | Add 6 delegation tests |

## Test Plan

- [x] All Rust tests pass (`cargo test`)
- [x] All TypeScript SDK tests pass (`npm test` - 86 tests)
- [x] Clippy clean
- [x] Format check passes

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)