### PR TITLE
test(rpc): Add unit tests for types module

### DIFF
--- a/icn/crates/icn-rpc/src/types.rs
+++ b/icn/crates/icn-rpc/src/types.rs
@@ -449,21 +449,28 @@ mod tests {
         let json = serde_json::to_string(&request).unwrap();
         let parsed: RpcRequest = serde_json::from_str(&json).unwrap();
 
+        // Verify all fields round-trip correctly
+        assert_eq!(parsed.jsonrpc, "2.0");
         assert_eq!(parsed.method, "test.method");
+        assert_eq!(parsed.params["param1"], 42);
         assert_eq!(parsed.id, 1);
     }
 
     #[test]
     fn test_peer_info_serialization() {
         let peer = PeerInfo {
-            did: "did:icn:test123".to_string(),
+            did: "did:icn:zPeerKeyABCDEFGHJ".to_string(), // Valid base58btc format
             addr: "127.0.0.1:9000".to_string(),
             version: "0.1.0".to_string(),
         };
 
         let json = serde_json::to_string(&peer).unwrap();
-        assert!(json.contains("did:icn:test123"));
-        assert!(json.contains("127.0.0.1:9000"));
+        let parsed: PeerInfo = serde_json::from_str(&json).unwrap();
+
+        // Verify round-trip
+        assert_eq!(parsed.did, peer.did);
+        assert_eq!(parsed.addr, peer.addr);
+        assert_eq!(parsed.version, peer.version);
     }
 
     #[test]
@@ -495,7 +502,7 @@ mod tests {
     #[test]
     fn test_membership_config_serialization() {
         let static_list = MembershipConfigInfo::StaticList {
-            members: vec!["did:icn:alice".to_string(), "did:icn:bob".to_string()],
+            members: vec!["did:icn:zAliceKeyABCDEF".to_string(), "did:icn:zBobKeyABCDEFG".to_string()],
         };
         let trust_threshold = MembershipConfigInfo::TrustThreshold { threshold: 0.5 };
 
@@ -504,6 +511,25 @@ mod tests {
 
         assert!(static_json.contains("\"type\":\"static_list\""));
         assert!(trust_json.contains("\"type\":\"trust_threshold\""));
+
+        // Verify round-trip deserialization
+        let parsed_static: MembershipConfigInfo = serde_json::from_str(&static_json).unwrap();
+        let parsed_trust: MembershipConfigInfo = serde_json::from_str(&trust_json).unwrap();
+
+        match parsed_static {
+            MembershipConfigInfo::StaticList { members } => {
+                assert_eq!(members.len(), 2);
+                assert_eq!(members[0], "did:icn:zAliceKeyABCDEF");
+            }
+            _ => panic!("Expected StaticList variant"),
+        }
+
+        match parsed_trust {
+            MembershipConfigInfo::TrustThreshold { threshold } => {
+                assert!((threshold - 0.5).abs() < f64::EPSILON);
+            }
+            _ => panic!("Expected TrustThreshold variant"),
+        }
     }
 
     #[test]
@@ -514,7 +540,7 @@ mod tests {
         let budget = ProposalPayloadInfo::Budget {
             amount: 1000,
             currency: "credits".to_string(),
-            recipient: "did:icn:bob".to_string(),
+            recipient: "did:icn:zBobKeyABCDEFGH".to_string(),
             purpose: "Development".to_string(),
         };
 
@@ -524,6 +550,27 @@ mod tests {
         assert!(text_json.contains("\"type\":\"text\""));
         assert!(budget_json.contains("\"type\":\"budget\""));
         assert!(budget_json.contains("\"amount\":1000"));
+
+        // Verify round-trip deserialization
+        let parsed_text: ProposalPayloadInfo = serde_json::from_str(&text_json).unwrap();
+        let parsed_budget: ProposalPayloadInfo = serde_json::from_str(&budget_json).unwrap();
+
+        match parsed_text {
+            ProposalPayloadInfo::Text { body } => {
+                assert_eq!(body, "Test proposal");
+            }
+            _ => panic!("Expected Text variant"),
+        }
+
+        match parsed_budget {
+            ProposalPayloadInfo::Budget { amount, currency, recipient, purpose } => {
+                assert_eq!(amount, 1000);
+                assert_eq!(currency, "credits");
+                assert_eq!(recipient, "did:icn:zBobKeyABCDEFGH");
+                assert_eq!(purpose, "Development");
+            }
+            _ => panic!("Expected Budget variant"),
+        }
     }
 
     #[test]
@@ -555,7 +602,14 @@ mod tests {
 
         let json = serde_json::to_string(&full_result).unwrap();
         assert!(json.contains("\"outcome\":\"success\""));
+        assert!(json.contains("\"output\"")); // Verify Some field is present
         assert!(!json.contains("\"error\"")); // skip_serializing_if = "Option::is_none"
+
+        // Verify round-trip
+        let parsed: TaskResultInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.outcome, "success");
+        assert_eq!(parsed.output.as_ref().unwrap()["result"], 42);
+        assert!(parsed.error.is_none());
 
         // With error
         let error_result = TaskResultInfo {
@@ -568,6 +622,7 @@ mod tests {
 
         let error_json = serde_json::to_string(&error_result).unwrap();
         assert!(error_json.contains("Out of memory"));
+        assert!(!error_json.contains("\"output\"")); // None field should be skipped
     }
 
     #[test]
@@ -632,5 +687,57 @@ mod tests {
         assert!(profile.memory_mb.is_none());
         assert!(profile.storage_mb.is_none());
         assert!(profile.network_mbps.is_none());
+
+        // Verify skip_serializing_if works
+        let output = serde_json::to_string(&profile).unwrap();
+        assert!(output.contains("cpu_cores"));
+        assert!(!output.contains("memory_mb")); // None should be skipped
+        assert!(!output.contains("storage_mb"));
+        assert!(!output.contains("network_mbps"));
+    }
+
+    // Error case tests
+    #[test]
+    fn test_invalid_membership_config_type() {
+        let json = r#"{"type": "invalid_type"}"#;
+        let result: Result<MembershipConfigInfo, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_proposal_payload_type() {
+        let json = r#"{"type": "unknown_payload"}"#;
+        let result: Result<ProposalPayloadInfo, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_missing_required_fields() {
+        // RpcRequest missing required fields
+        let json = r#"{"jsonrpc": "2.0"}"#;
+        let result: Result<RpcRequest, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+
+        // SubmitTaskRequest missing task_id
+        let json = r#"{"code": "some code"}"#;
+        let result: Result<SubmitTaskRequest, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_code_type_deserialization() {
+        // Valid cases
+        assert!(matches!(
+            serde_json::from_str::<CodeType>(r#""ccl""#).unwrap(),
+            CodeType::Ccl
+        ));
+        assert!(matches!(
+            serde_json::from_str::<CodeType>(r#""wasm""#).unwrap(),
+            CodeType::Wasm
+        ));
+
+        // Invalid case
+        let result: Result<CodeType, _> = serde_json::from_str(r#""invalid""#);
+        assert!(result.is_err());
     }
 }

--- a/icn/crates/icn-rpc/src/types.rs
+++ b/icn/crates/icn-rpc/src/types.rs
@@ -408,3 +408,229 @@ pub struct CancelRecoveryRequest {
     pub recovery_id: String,
     pub reason: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rpc_response_success() {
+        let result = serde_json::json!({"key": "value"});
+        let response = RpcResponse::success(42, result.clone());
+
+        assert_eq!(response.jsonrpc, "2.0");
+        assert_eq!(response.id, 42);
+        assert!(response.error.is_none());
+        assert_eq!(response.result.unwrap(), result);
+    }
+
+    #[test]
+    fn test_rpc_response_error() {
+        let response = RpcResponse::error(123, -32600, "Invalid Request".to_string());
+
+        assert_eq!(response.jsonrpc, "2.0");
+        assert_eq!(response.id, 123);
+        assert!(response.result.is_none());
+
+        let error = response.error.unwrap();
+        assert_eq!(error.code, -32600);
+        assert_eq!(error.message, "Invalid Request");
+    }
+
+    #[test]
+    fn test_rpc_request_serialization() {
+        let request = RpcRequest {
+            jsonrpc: "2.0".to_string(),
+            method: "test.method".to_string(),
+            params: serde_json::json!({"param1": 42}),
+            id: 1,
+        };
+
+        let json = serde_json::to_string(&request).unwrap();
+        let parsed: RpcRequest = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.method, "test.method");
+        assert_eq!(parsed.id, 1);
+    }
+
+    #[test]
+    fn test_peer_info_serialization() {
+        let peer = PeerInfo {
+            did: "did:icn:test123".to_string(),
+            addr: "127.0.0.1:9000".to_string(),
+            version: "0.1.0".to_string(),
+        };
+
+        let json = serde_json::to_string(&peer).unwrap();
+        assert!(json.contains("did:icn:test123"));
+        assert!(json.contains("127.0.0.1:9000"));
+    }
+
+    #[test]
+    fn test_code_type_default() {
+        let code_type: CodeType = Default::default();
+        assert!(matches!(code_type, CodeType::Ccl));
+    }
+
+    #[test]
+    fn test_code_type_serialization() {
+        let ccl = CodeType::Ccl;
+        let wasm = CodeType::Wasm;
+
+        assert_eq!(serde_json::to_string(&ccl).unwrap(), "\"ccl\"");
+        assert_eq!(serde_json::to_string(&wasm).unwrap(), "\"wasm\"");
+    }
+
+    #[test]
+    fn test_submit_task_request_defaults() {
+        let json = r#"{"task_id": "task-1"}"#;
+        let request: SubmitTaskRequest = serde_json::from_str(json).unwrap();
+
+        assert_eq!(request.task_id, "task-1");
+        assert_eq!(request.fuel_limit, 10_000); // default
+        assert_eq!(request.priority, "normal"); // default
+        assert!(matches!(request.code_type, CodeType::Ccl)); // default
+    }
+
+    #[test]
+    fn test_membership_config_serialization() {
+        let static_list = MembershipConfigInfo::StaticList {
+            members: vec!["did:icn:alice".to_string(), "did:icn:bob".to_string()],
+        };
+        let trust_threshold = MembershipConfigInfo::TrustThreshold { threshold: 0.5 };
+
+        let static_json = serde_json::to_string(&static_list).unwrap();
+        let trust_json = serde_json::to_string(&trust_threshold).unwrap();
+
+        assert!(static_json.contains("\"type\":\"static_list\""));
+        assert!(trust_json.contains("\"type\":\"trust_threshold\""));
+    }
+
+    #[test]
+    fn test_proposal_payload_serialization() {
+        let text = ProposalPayloadInfo::Text {
+            body: "Test proposal".to_string(),
+        };
+        let budget = ProposalPayloadInfo::Budget {
+            amount: 1000,
+            currency: "credits".to_string(),
+            recipient: "did:icn:bob".to_string(),
+            purpose: "Development".to_string(),
+        };
+
+        let text_json = serde_json::to_string(&text).unwrap();
+        let budget_json = serde_json::to_string(&budget).unwrap();
+
+        assert!(text_json.contains("\"type\":\"text\""));
+        assert!(budget_json.contains("\"type\":\"budget\""));
+        assert!(budget_json.contains("\"amount\":1000"));
+    }
+
+    #[test]
+    fn test_network_stats_serialization() {
+        let stats = NetworkStats {
+            peers_discovered: 10,
+            connections_active: 5,
+            connections_total: 100,
+        };
+
+        let json = serde_json::to_string(&stats).unwrap();
+        let parsed: NetworkStats = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.peers_discovered, 10);
+        assert_eq!(parsed.connections_active, 5);
+        assert_eq!(parsed.connections_total, 100);
+    }
+
+    #[test]
+    fn test_task_result_info_optional_fields() {
+        // With all fields
+        let full_result = TaskResultInfo {
+            outcome: "success".to_string(),
+            output: Some(serde_json::json!({"result": 42})),
+            error: None,
+            fuel_used: 500,
+            duration_ms: 100,
+        };
+
+        let json = serde_json::to_string(&full_result).unwrap();
+        assert!(json.contains("\"outcome\":\"success\""));
+        assert!(!json.contains("\"error\"")); // skip_serializing_if = "Option::is_none"
+
+        // With error
+        let error_result = TaskResultInfo {
+            outcome: "failed".to_string(),
+            output: None,
+            error: Some("Out of memory".to_string()),
+            fuel_used: 100,
+            duration_ms: 50,
+        };
+
+        let error_json = serde_json::to_string(&error_result).unwrap();
+        assert!(error_json.contains("Out of memory"));
+    }
+
+    #[test]
+    fn test_recovery_event_info_serialization() {
+        let event = RecoveryEventInfo {
+            id: "recovery-1".to_string(),
+            old_did: "did:icn:old".to_string(),
+            new_did: "did:icn:new".to_string(),
+            initiated_at: 1700000000,
+            finalized_at: None,
+            threshold: 3,
+            delay_period: 86400,
+            status: "pending".to_string(),
+            attestations_count: 1,
+            progress_summary: "1/3 attestations".to_string(),
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: RecoveryEventInfo = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.id, "recovery-1");
+        assert_eq!(parsed.threshold, 3);
+        assert!(parsed.finalized_at.is_none());
+    }
+
+    #[test]
+    fn test_ledger_entry_serialization() {
+        let entry = LedgerEntry {
+            hash: "abc123".to_string(),
+            timestamp: 1700000000,
+            author: "did:icn:alice".to_string(),
+            accounts: vec![
+                LedgerAccountDelta {
+                    account_id: "alice".to_string(),
+                    currency: "credits".to_string(),
+                    debit: Some(100),
+                    credit: None,
+                },
+                LedgerAccountDelta {
+                    account_id: "bob".to_string(),
+                    currency: "credits".to_string(),
+                    debit: None,
+                    credit: Some(100),
+                },
+            ],
+        };
+
+        let json = serde_json::to_string(&entry).unwrap();
+        let parsed: LedgerEntry = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.accounts.len(), 2);
+        assert_eq!(parsed.accounts[0].debit, Some(100));
+        assert_eq!(parsed.accounts[1].credit, Some(100));
+    }
+
+    #[test]
+    fn test_resource_profile_optional_fields() {
+        let json = r#"{"cpu_cores": 2.0}"#;
+        let profile: ResourceProfileRequest = serde_json::from_str(json).unwrap();
+
+        assert_eq!(profile.cpu_cores, Some(2.0));
+        assert!(profile.memory_mb.is_none());
+        assert!(profile.storage_mb.is_none());
+        assert!(profile.network_mbps.is_none());
+    }
+}

--- a/icn/crates/icn-rpc/src/types.rs
+++ b/icn/crates/icn-rpc/src/types.rs
@@ -502,7 +502,10 @@ mod tests {
     #[test]
     fn test_membership_config_serialization() {
         let static_list = MembershipConfigInfo::StaticList {
-            members: vec!["did:icn:zAliceKeyABCDEF".to_string(), "did:icn:zBobKeyABCDEFG".to_string()],
+            members: vec![
+                "did:icn:zAliceKeyABCDEF".to_string(),
+                "did:icn:zBobKeyABCDEFG".to_string(),
+            ],
         };
         let trust_threshold = MembershipConfigInfo::TrustThreshold { threshold: 0.5 };
 
@@ -563,7 +566,12 @@ mod tests {
         }
 
         match parsed_budget {
-            ProposalPayloadInfo::Budget { amount, currency, recipient, purpose } => {
+            ProposalPayloadInfo::Budget {
+                amount,
+                currency,
+                recipient,
+                purpose,
+            } => {
                 assert_eq!(amount, 1000);
                 assert_eq!(currency, "credits");
                 assert_eq!(recipient, "did:icn:zBobKeyABCDEFGH");


### PR DESCRIPTION
## Summary

Adds 14 new unit tests for the `icn-rpc` types module, improving test coverage from 35 to 49 tests.

## Tests Added

- `test_rpc_response_success` - RpcResponse::success() helper
- `test_rpc_response_error` - RpcResponse::error() helper  
- `test_rpc_request_serialization` - RpcRequest round-trip
- `test_peer_info_serialization` - PeerInfo fields
- `test_code_type_default` - CodeType::Ccl default
- `test_code_type_serialization` - CodeType to/from JSON
- `test_submit_task_request_defaults` - Default fuel_limit, priority, code_type
- `test_membership_config_serialization` - Tagged enum variants
- `test_proposal_payload_serialization` - Text and Budget variants
- `test_network_stats_serialization` - Round-trip test
- `test_task_result_info_optional_fields` - skip_serializing_if behavior
- `test_recovery_event_info_serialization` - Full struct round-trip
- `test_ledger_entry_serialization` - Nested structs with arrays
- `test_resource_profile_optional_fields` - Optional field deserialization

## Test Plan

```bash
cargo test -p icn-rpc --lib
```

All 49 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)