### PR TITLE
fix(gateway): Add atomic get_or_create for entity auto-registration

### DIFF
--- a/icn/crates/icn-gateway/src/api/entity.rs
+++ b/icn/crates/icn-gateway/src/api/entity.rs
@@ -30,7 +30,7 @@ use icn_identity::Did;
 use icn_obs::metrics::gateway as gateway_metrics;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 use crate::entity_audit::{EntityAuditManager, EntityOperation};
 use crate::entity_mgr::EntityManager;
@@ -288,13 +288,13 @@ pub async fn register_entity(
 
     // Ensure the creator's individual entity exists (auto-register if not)
     // This allows users to create cooperatives without first explicitly registering themselves
-    if entity_mgr.get(&creator_id)?.is_none() {
-        let individual_entity = CooperativeEntity::individual(&creator_did, &claims.sub);
-        entity_mgr.register(individual_entity).map_err(|e| {
+    // Uses atomic ensure_entity_exists to prevent race conditions with concurrent requests
+    let individual_entity = CooperativeEntity::individual(&creator_did, &claims.sub);
+    entity_mgr
+        .ensure_entity_exists(individual_entity)
+        .map_err(|e| {
             GatewayError::InternalError(format!("Failed to auto-register individual entity: {e}"))
         })?;
-        debug!(creator_id = %creator_id, "Auto-registered individual entity for creator");
-    }
 
     // Validate identifier
     if body.identifier.trim().is_empty() {
@@ -827,16 +827,16 @@ pub async fn add_membership(
             .map_err(|e| GatewayError::BadRequest(format!("Invalid DID: {e}")))?;
 
         // Auto-register the individual entity if it doesn't exist
+        // Uses atomic ensure_entity_exists to prevent race conditions with concurrent requests
         let entity_id = EntityId::from_did(&did);
-        if entity_mgr.get(&entity_id)?.is_none() {
-            let individual_entity = CooperativeEntity::individual(&did, &body.member_id);
-            entity_mgr.register(individual_entity).map_err(|e| {
+        let individual_entity = CooperativeEntity::individual(&did, &body.member_id);
+        entity_mgr
+            .ensure_entity_exists(individual_entity)
+            .map_err(|e| {
                 GatewayError::InternalError(format!(
                     "Failed to auto-register individual entity: {e}"
                 ))
             })?;
-            debug!(member_id = %entity_id, "Auto-registered individual entity for new member");
-        }
 
         entity_id
     } else {

--- a/icn/crates/icn-gateway/src/api/entity.rs
+++ b/icn/crates/icn-gateway/src/api/entity.rs
@@ -289,8 +289,9 @@ pub async fn register_entity(
     // Ensure the creator's individual entity exists (auto-register if not)
     // This allows users to create cooperatives without first explicitly registering themselves
     // Uses atomic ensure_entity_exists to prevent race conditions with concurrent requests
+    // Return value (was_created: bool) intentionally unused - we only care that entity exists
     let individual_entity = CooperativeEntity::individual(&creator_did, &claims.sub);
-    entity_mgr
+    let _ = entity_mgr
         .ensure_entity_exists(individual_entity)
         .map_err(|e| {
             GatewayError::InternalError(format!("Failed to auto-register individual entity: {e}"))
@@ -828,9 +829,10 @@ pub async fn add_membership(
 
         // Auto-register the individual entity if it doesn't exist
         // Uses atomic ensure_entity_exists to prevent race conditions with concurrent requests
+        // Return value (was_created: bool) intentionally unused - we only care that entity exists
         let entity_id = EntityId::from_did(&did);
         let individual_entity = CooperativeEntity::individual(&did, &body.member_id);
-        entity_mgr
+        let _ = entity_mgr
             .ensure_entity_exists(individual_entity)
             .map_err(|e| {
                 GatewayError::InternalError(format!(

--- a/icn/crates/icn-gateway/src/entity_mgr.rs
+++ b/icn/crates/icn-gateway/src/entity_mgr.rs
@@ -7,7 +7,8 @@
 
 use anyhow::Result;
 use icn_entity::{
-    CooperativeEntity, EntityId, EntityRegistry, EntityType, InMemoryRegistry, Membership,
+    CooperativeEntity, EntityError, EntityId, EntityRegistry, EntityType, InMemoryRegistry,
+    Membership,
 };
 use std::sync::{Arc, RwLock};
 use tracing::debug;
@@ -94,9 +95,10 @@ impl EntityManager {
             }
             Err(e) => {
                 // Check if this is an "already exists" error (from concurrent registration)
-                // EntityError::AlreadyExists gets converted to anyhow error with this message format
-                let err_msg = e.to_string();
-                if err_msg.contains("already exists") || err_msg.contains("AlreadyExists") {
+                // Use proper error downcasting instead of string matching for robustness
+                if e.downcast_ref::<EntityError>()
+                    .is_some_and(|entity_err| matches!(entity_err, EntityError::AlreadyExists(_)))
+                {
                     debug!(entity_id = %entity_id, "Entity already exists (concurrent registration)");
                     Ok(false) // Entity already existed
                 } else {
@@ -346,5 +348,88 @@ mod tests {
 
         // Now removal should succeed
         mgr.remove(&coop_id).unwrap();
+    }
+
+    #[test]
+    fn test_ensure_entity_exists_creates_new() {
+        let mgr = EntityManager::new();
+        let keypair = KeyPair::generate().unwrap();
+        let entity = CooperativeEntity::individual(keypair.did(), "Test User");
+        let entity_id = entity.id.clone();
+
+        // First call should create the entity
+        let was_created = mgr.ensure_entity_exists(entity).unwrap();
+        assert!(was_created, "Entity should be newly created");
+
+        // Verify entity exists
+        let retrieved = mgr.get(&entity_id).unwrap();
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap().name, "Test User");
+    }
+
+    #[test]
+    fn test_ensure_entity_exists_handles_existing() {
+        let mgr = EntityManager::new();
+        let keypair = KeyPair::generate().unwrap();
+        let entity = CooperativeEntity::individual(keypair.did(), "Test User");
+        let entity_id = entity.id.clone();
+
+        // Register entity directly first
+        mgr.register(entity.clone()).unwrap();
+
+        // ensure_entity_exists should return Ok(false) for existing entity
+        let entity_copy = CooperativeEntity::individual(keypair.did(), "Test User");
+        let was_created = mgr.ensure_entity_exists(entity_copy).unwrap();
+        assert!(!was_created, "Entity already existed, should return false");
+
+        // Entity should still be there
+        let retrieved = mgr.get(&entity_id).unwrap();
+        assert!(retrieved.is_some());
+    }
+
+    #[test]
+    fn test_ensure_entity_exists_concurrent_simulation() {
+        // This test simulates what happens when ensure_entity_exists is called
+        // for an entity that was just registered by another thread.
+        // We can't easily test true concurrency in unit tests, but we can verify
+        // that the "already exists" path works correctly.
+        use std::sync::Arc;
+        use std::thread;
+
+        let mgr = Arc::new(EntityManager::new());
+        let keypair = KeyPair::generate().unwrap();
+        let did = keypair.did().clone();
+
+        // Spawn multiple threads that all try to ensure the same entity exists
+        let handles: Vec<_> = (0..5)
+            .map(|i| {
+                let mgr = Arc::clone(&mgr);
+                let did = did.clone();
+                thread::spawn(move || {
+                    let entity = CooperativeEntity::individual(&did, format!("User {i}"));
+                    mgr.ensure_entity_exists(entity)
+                })
+            })
+            .collect();
+
+        // All threads should succeed (either creating or finding existing)
+        let results: Vec<bool> = handles
+            .into_iter()
+            .map(|h| h.join().unwrap().unwrap())
+            .collect();
+
+        // Exactly one should have created the entity
+        let created_count = results.iter().filter(|&&was_created| was_created).count();
+        assert_eq!(
+            created_count, 1,
+            "Exactly one thread should create the entity"
+        );
+
+        // The rest should have found it existing
+        let existing_count = results.iter().filter(|&&was_created| !was_created).count();
+        assert_eq!(
+            existing_count, 4,
+            "Other threads should find entity existing"
+        );
     }
 }

--- a/icn/crates/icn-gateway/src/entity_mgr.rs
+++ b/icn/crates/icn-gateway/src/entity_mgr.rs
@@ -76,6 +76,36 @@ impl EntityManager {
         anyhow::bail!("Entity manager not initialized")
     }
 
+    /// Ensure an entity exists, registering it atomically if not
+    ///
+    /// This method uses a try-insert pattern to avoid race conditions:
+    /// - If the entity doesn't exist, it's registered
+    /// - If the entity already exists (including from a concurrent registration), returns Ok(())
+    /// - Only propagates errors for actual failures (not "already exists")
+    ///
+    /// This is primarily used for auto-registering individual entities when users
+    /// perform operations that require their entity to exist.
+    pub fn ensure_entity_exists(&self, entity: CooperativeEntity) -> Result<bool> {
+        let entity_id = entity.id.clone();
+        match self.register(entity) {
+            Ok(()) => {
+                debug!(entity_id = %entity_id, "Auto-registered entity");
+                Ok(true) // Entity was newly created
+            }
+            Err(e) => {
+                // Check if this is an "already exists" error (from concurrent registration)
+                // EntityError::AlreadyExists gets converted to anyhow error with this message format
+                let err_msg = e.to_string();
+                if err_msg.contains("already exists") || err_msg.contains("AlreadyExists") {
+                    debug!(entity_id = %entity_id, "Entity already exists (concurrent registration)");
+                    Ok(false) // Entity already existed
+                } else {
+                    Err(e)
+                }
+            }
+        }
+    }
+
     /// Get an entity by ID
     pub fn get(&self, id: &EntityId) -> Result<Option<CooperativeEntity>> {
         if let Some(ref handle) = self.entity_handle {


### PR DESCRIPTION
## Summary

Fixes race condition in entity auto-registration by replacing check-then-create pattern with atomic try-insert pattern.

## Problem

The entity auto-registration in `register_entity` and `add_membership` used a non-atomic check-then-create pattern:

```rust
if entity_mgr.get(&creator_id)?.is_none() {  // Check
    entity_mgr.register(individual_entity)... // Create
}
```

If two concurrent requests tried to create the same individual entity, one could fail with a duplicate registration error.

## Solution

Added `ensure_entity_exists()` method to `EntityManager` that uses a try-insert pattern:
- Attempts to register the entity
- If registration succeeds → entity was newly created
- If "already exists" error → entity was created by concurrent request (OK)
- Other errors → propagate as failures

## Changes

- **`entity_mgr.rs`**: Add `ensure_entity_exists()` method with atomic semantics
- **`api/entity.rs`**: Update `register_entity` and `add_membership` to use new method
- Remove unused `debug` import

## Test Plan

- [x] All 324 gateway unit tests pass
- [x] All 30 entity integration tests pass
- [x] Clippy clean

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)