### PR TITLE
feat(governance): Add deliberation infrastructure for proposal discussions

### DIFF
--- a/icn/crates/icn-gateway/src/api/governance.rs
+++ b/icn/crates/icn-gateway/src/api/governance.rs
@@ -2,7 +2,7 @@
 //!
 //! RESTful API for managing governance domains, proposals, and votes.
 
-use actix_web::{delete, get, post, web, HttpRequest, HttpResponse};
+use actix_web::{delete, get, post, put, web, HttpRequest, HttpResponse};
 use std::sync::Arc;
 
 use crate::error::Result;
@@ -1169,6 +1169,489 @@ fn parse_delegation_scope(scope: &str) -> Result<DelegationScope> {
     )))
 }
 
+// ============================================================================
+// Deliberation Endpoints
+// ============================================================================
+
+/// POST /gov/proposals/{id}/deliberation/start - Start deliberation period
+#[post("/proposals/{id}/deliberation/start")]
+pub async fn start_deliberation(
+    http_req: HttpRequest,
+    gov_mgr: web::Data<Arc<GovernanceManager>>,
+    id: web::Path<String>,
+    req: web::Json<StartDeliberationRequest>,
+) -> Result<HttpResponse> {
+    // Check authorization
+    require_scope(&http_req, "gov:write")?;
+
+    // Extract authenticated DID from JWT claims
+    let claims = get_claims(&http_req).ok_or_else(|| {
+        crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
+    })?;
+
+    let caller_did: Did = claims.sub.parse().map_err(|e| {
+        crate::error::GatewayError::BadRequest(format!("Invalid DID in token: {e}"))
+    })?;
+
+    let proposal_id = ProposalId(id.into_inner());
+
+    // Get the proposal to verify authorization
+    let proposal = gov_mgr.get_proposal(&proposal_id).await?.ok_or_else(|| {
+        crate::error::GatewayError::NotFound(format!("Proposal not found: {}", proposal_id.0))
+    })?;
+
+    // Only the proposer can start deliberation
+    if proposal.proposer != caller_did {
+        return Err(crate::error::GatewayError::AuthorizationFailed(
+            "Only the proposer can start deliberation".to_string(),
+        ));
+    }
+
+    // Use the provided period or get default from domain config
+    let period = req.deliberation_period_seconds.unwrap_or(7 * 24 * 60 * 60); // Default: 7 days
+
+    gov_mgr.start_deliberation(&proposal_id, period).await?;
+
+    // Get updated proposal
+    let updated_proposal = gov_mgr.get_proposal(&proposal_id).await?.ok_or_else(|| {
+        crate::error::GatewayError::InternalError("Proposal disappeared after update".to_string())
+    })?;
+
+    Ok(HttpResponse::Ok().json(updated_proposal))
+}
+
+/// POST /gov/proposals/{id}/deliberation/end - End deliberation and open voting
+#[post("/proposals/{id}/deliberation/end")]
+pub async fn end_deliberation(
+    http_req: HttpRequest,
+    gov_mgr: web::Data<Arc<GovernanceManager>>,
+    id: web::Path<String>,
+    req: web::Json<EndDeliberationRequest>,
+) -> Result<HttpResponse> {
+    // Check authorization
+    require_scope(&http_req, "gov:write")?;
+
+    // Extract authenticated DID from JWT claims
+    let claims = get_claims(&http_req).ok_or_else(|| {
+        crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
+    })?;
+
+    let caller_did: Did = claims.sub.parse().map_err(|e| {
+        crate::error::GatewayError::BadRequest(format!("Invalid DID in token: {e}"))
+    })?;
+
+    let proposal_id = ProposalId(id.into_inner());
+
+    // Get the proposal to verify authorization
+    let proposal = gov_mgr.get_proposal(&proposal_id).await?.ok_or_else(|| {
+        crate::error::GatewayError::NotFound(format!("Proposal not found: {}", proposal_id.0))
+    })?;
+
+    // Only the proposer can end deliberation
+    if proposal.proposer != caller_did {
+        return Err(crate::error::GatewayError::AuthorizationFailed(
+            "Only the proposer can end deliberation".to_string(),
+        ));
+    }
+
+    let voting_period = req.voting_period_seconds.unwrap_or(7 * 24 * 60 * 60); // Default: 7 days
+
+    gov_mgr
+        .end_deliberation_and_open(&proposal_id, voting_period)
+        .await?;
+
+    // Get updated proposal
+    let updated_proposal = gov_mgr.get_proposal(&proposal_id).await?.ok_or_else(|| {
+        crate::error::GatewayError::InternalError("Proposal disappeared after update".to_string())
+    })?;
+
+    Ok(HttpResponse::Ok().json(updated_proposal))
+}
+
+// ============================================================================
+// Discussion Endpoints
+// ============================================================================
+
+/// POST /gov/proposals/{id}/comments - Add a comment to a proposal
+#[post("/proposals/{id}/comments")]
+pub async fn add_comment(
+    http_req: HttpRequest,
+    gov_mgr: web::Data<Arc<GovernanceManager>>,
+    id: web::Path<String>,
+    req: web::Json<AddCommentRequest>,
+) -> Result<HttpResponse> {
+    // Check authorization
+    require_scope(&http_req, "gov:write")?;
+
+    // Extract authenticated DID from JWT claims
+    let claims = get_claims(&http_req).ok_or_else(|| {
+        crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
+    })?;
+
+    let author: Did = claims.sub.parse().map_err(|e| {
+        crate::error::GatewayError::BadRequest(format!("Invalid DID in token: {e}"))
+    })?;
+
+    let proposal_id = ProposalId(id.into_inner());
+
+    // Validate content
+    if req.content.trim().is_empty() {
+        return Err(crate::error::GatewayError::BadRequest(
+            "Comment content cannot be empty".to_string(),
+        ));
+    }
+
+    if req.content.len() > 10000 {
+        return Err(crate::error::GatewayError::BadRequest(
+            "Comment content exceeds maximum length of 10000 characters".to_string(),
+        ));
+    }
+
+    // Create the comment
+    let mut comment =
+        icn_governance::Comment::new(proposal_id.clone(), author, req.content.clone());
+
+    // Set parent if this is a reply
+    if let Some(parent_id) = &req.parent_id {
+        comment.parent_id = Some(icn_governance::CommentId(parent_id.clone()));
+    }
+
+    let comment_id = gov_mgr.add_comment(comment.clone()).await?;
+
+    Ok(HttpResponse::Created().json(CommentResponse {
+        id: comment_id.0,
+        proposal_id: comment.proposal_id.0,
+        author: comment.author.to_string(),
+        content: comment.content,
+        parent_id: comment.parent_id.map(|p| p.0),
+        created_at: comment.created_at,
+        updated_at: comment.updated_at,
+        reactions: std::collections::HashMap::new(),
+        is_edited: comment.is_edited,
+        is_deleted: comment.is_deleted,
+    }))
+}
+
+/// GET /gov/proposals/{id}/comments - List comments on a proposal
+#[get("/proposals/{id}/comments")]
+pub async fn list_comments(
+    http_req: HttpRequest,
+    gov_mgr: web::Data<Arc<GovernanceManager>>,
+    id: web::Path<String>,
+    query: web::Query<ListCommentsQuery>,
+) -> Result<HttpResponse> {
+    // Check authorization (read access)
+    require_scope(&http_req, "gov:read")?;
+
+    let proposal_id = ProposalId(id.into_inner());
+
+    let limit = query.limit.unwrap_or(50).min(100);
+    let offset = query.offset.unwrap_or(0);
+
+    let comments = gov_mgr.list_comments(&proposal_id, limit, offset).await?;
+    let total = gov_mgr.count_comments(&proposal_id).await?;
+
+    let responses: Vec<CommentResponse> = comments
+        .into_iter()
+        .map(|c| CommentResponse {
+            id: c.id.0,
+            proposal_id: c.proposal_id.0,
+            author: c.author.to_string(),
+            content: c.content,
+            parent_id: c.parent_id.map(|p| p.0),
+            created_at: c.created_at,
+            updated_at: c.updated_at,
+            reactions: c.reactions.into_iter().map(|(k, v)| (k, v.len())).collect(),
+            is_edited: c.is_edited,
+            is_deleted: c.is_deleted,
+        })
+        .collect();
+
+    Ok(HttpResponse::Ok().json(ListCommentsResponse {
+        comments: responses,
+        total,
+        limit,
+        offset,
+    }))
+}
+
+/// GET /gov/proposals/{id}/discussion - Get full discussion with metadata
+#[get("/proposals/{id}/discussion")]
+pub async fn get_discussion(
+    http_req: HttpRequest,
+    gov_mgr: web::Data<Arc<GovernanceManager>>,
+    id: web::Path<String>,
+) -> Result<HttpResponse> {
+    // Check authorization (read access)
+    require_scope(&http_req, "gov:read")?;
+
+    let proposal_id = ProposalId(id.into_inner());
+
+    let discussion = gov_mgr.get_discussion(&proposal_id).await?;
+
+    match discussion {
+        Some(d) => {
+            let comments: Vec<CommentResponse> = d
+                .comments
+                .into_iter()
+                .map(|c| CommentResponse {
+                    id: c.id.0,
+                    proposal_id: c.proposal_id.0,
+                    author: c.author.to_string(),
+                    content: c.content,
+                    parent_id: c.parent_id.map(|p| p.0),
+                    created_at: c.created_at,
+                    updated_at: c.updated_at,
+                    reactions: c.reactions.into_iter().map(|(k, v)| (k, v.len())).collect(),
+                    is_edited: c.is_edited,
+                    is_deleted: c.is_deleted,
+                })
+                .collect();
+
+            Ok(HttpResponse::Ok().json(DiscussionResponse {
+                proposal_id: d.proposal_id.0,
+                comments,
+                participant_count: d.participant_count,
+                last_activity_at: d.last_activity_at,
+            }))
+        }
+        None => Ok(HttpResponse::Ok().json(DiscussionResponse {
+            proposal_id: proposal_id.0,
+            comments: vec![],
+            participant_count: 0,
+            last_activity_at: 0,
+        })),
+    }
+}
+
+/// PUT /gov/comments/{id} - Edit a comment
+#[put("/comments/{id}")]
+pub async fn edit_comment(
+    http_req: HttpRequest,
+    gov_mgr: web::Data<Arc<GovernanceManager>>,
+    id: web::Path<String>,
+    req: web::Json<EditCommentRequest>,
+) -> Result<HttpResponse> {
+    // Check authorization
+    require_scope(&http_req, "gov:write")?;
+
+    // Extract authenticated DID from JWT claims
+    let claims = get_claims(&http_req).ok_or_else(|| {
+        crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
+    })?;
+
+    let editor: Did = claims.sub.parse().map_err(|e| {
+        crate::error::GatewayError::BadRequest(format!("Invalid DID in token: {e}"))
+    })?;
+
+    let comment_id = icn_governance::CommentId(id.into_inner());
+
+    // Validate content
+    if req.content.trim().is_empty() {
+        return Err(crate::error::GatewayError::BadRequest(
+            "Comment content cannot be empty".to_string(),
+        ));
+    }
+
+    gov_mgr
+        .edit_comment(&comment_id, req.content.clone(), &editor)
+        .await?;
+
+    // Get updated comment
+    let updated = gov_mgr.get_comment(&comment_id).await?.ok_or_else(|| {
+        crate::error::GatewayError::NotFound("Comment not found after update".to_string())
+    })?;
+
+    Ok(HttpResponse::Ok().json(CommentResponse {
+        id: updated.id.0,
+        proposal_id: updated.proposal_id.0,
+        author: updated.author.to_string(),
+        content: updated.content,
+        parent_id: updated.parent_id.map(|p| p.0),
+        created_at: updated.created_at,
+        updated_at: updated.updated_at,
+        reactions: updated
+            .reactions
+            .into_iter()
+            .map(|(k, v)| (k, v.len()))
+            .collect(),
+        is_edited: updated.is_edited,
+        is_deleted: updated.is_deleted,
+    }))
+}
+
+/// DELETE /gov/comments/{id} - Delete a comment
+#[delete("/comments/{id}")]
+pub async fn delete_comment(
+    http_req: HttpRequest,
+    gov_mgr: web::Data<Arc<GovernanceManager>>,
+    id: web::Path<String>,
+) -> Result<HttpResponse> {
+    // Check authorization
+    require_scope(&http_req, "gov:write")?;
+
+    // Extract authenticated DID from JWT claims
+    let claims = get_claims(&http_req).ok_or_else(|| {
+        crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
+    })?;
+
+    let deleter: Did = claims.sub.parse().map_err(|e| {
+        crate::error::GatewayError::BadRequest(format!("Invalid DID in token: {e}"))
+    })?;
+
+    let comment_id = icn_governance::CommentId(id.into_inner());
+
+    gov_mgr.delete_comment(&comment_id, &deleter).await?;
+
+    Ok(HttpResponse::NoContent().finish())
+}
+
+/// POST /gov/comments/{id}/reactions - Add a reaction to a comment
+#[post("/comments/{id}/reactions")]
+pub async fn add_reaction(
+    http_req: HttpRequest,
+    gov_mgr: web::Data<Arc<GovernanceManager>>,
+    id: web::Path<String>,
+    req: web::Json<AddReactionRequest>,
+) -> Result<HttpResponse> {
+    // Check authorization
+    require_scope(&http_req, "gov:write")?;
+
+    // Extract authenticated DID from JWT claims
+    let claims = get_claims(&http_req).ok_or_else(|| {
+        crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
+    })?;
+
+    let reactor: Did = claims.sub.parse().map_err(|e| {
+        crate::error::GatewayError::BadRequest(format!("Invalid DID in token: {e}"))
+    })?;
+
+    let comment_id = icn_governance::CommentId(id.into_inner());
+
+    // Validate emoji
+    if req.emoji.is_empty() || req.emoji.chars().count() > 10 {
+        return Err(crate::error::GatewayError::BadRequest(
+            "Invalid emoji: must be 1-10 characters".to_string(),
+        ));
+    }
+
+    gov_mgr
+        .add_reaction(&comment_id, &reactor, &req.emoji)
+        .await?;
+
+    Ok(HttpResponse::Created().finish())
+}
+
+/// DELETE /gov/comments/{id}/reactions/{emoji} - Remove a reaction from a comment
+#[delete("/comments/{id}/reactions/{emoji}")]
+pub async fn remove_reaction(
+    http_req: HttpRequest,
+    gov_mgr: web::Data<Arc<GovernanceManager>>,
+    path: web::Path<(String, String)>,
+) -> Result<HttpResponse> {
+    // Check authorization
+    require_scope(&http_req, "gov:write")?;
+
+    // Extract authenticated DID from JWT claims
+    let claims = get_claims(&http_req).ok_or_else(|| {
+        crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
+    })?;
+
+    let reactor: Did = claims.sub.parse().map_err(|e| {
+        crate::error::GatewayError::BadRequest(format!("Invalid DID in token: {e}"))
+    })?;
+
+    let (comment_id_str, emoji) = path.into_inner();
+    let comment_id = icn_governance::CommentId(comment_id_str);
+
+    gov_mgr
+        .remove_reaction(&comment_id, &reactor, &emoji)
+        .await?;
+
+    Ok(HttpResponse::NoContent().finish())
+}
+
+// ============================================================================
+// Request/Response Types for Deliberation & Discussion
+// ============================================================================
+
+/// Request to start deliberation
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct StartDeliberationRequest {
+    /// Duration in seconds (optional, defaults to domain config or 7 days)
+    pub deliberation_period_seconds: Option<u64>,
+}
+
+/// Request to end deliberation
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct EndDeliberationRequest {
+    /// Voting period in seconds (optional, defaults to domain config or 7 days)
+    pub voting_period_seconds: Option<u64>,
+}
+
+/// Request to add a comment
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct AddCommentRequest {
+    /// Comment content
+    pub content: String,
+    /// Parent comment ID (if this is a reply)
+    pub parent_id: Option<String>,
+}
+
+/// Request to edit a comment
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct EditCommentRequest {
+    /// New content
+    pub content: String,
+}
+
+/// Request to add a reaction
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct AddReactionRequest {
+    /// Emoji reaction
+    pub emoji: String,
+}
+
+/// Query parameters for listing comments
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct ListCommentsQuery {
+    pub limit: Option<usize>,
+    pub offset: Option<usize>,
+}
+
+/// Response for a single comment
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct CommentResponse {
+    pub id: String,
+    pub proposal_id: String,
+    pub author: String,
+    pub content: String,
+    pub parent_id: Option<String>,
+    pub created_at: u64,
+    pub updated_at: u64,
+    pub reactions: std::collections::HashMap<String, usize>,
+    pub is_edited: bool,
+    pub is_deleted: bool,
+}
+
+/// Response for listing comments
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ListCommentsResponse {
+    pub comments: Vec<CommentResponse>,
+    pub total: usize,
+    pub limit: usize,
+    pub offset: usize,
+}
+
+/// Response for a discussion
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DiscussionResponse {
+    pub proposal_id: String,
+    pub comments: Vec<CommentResponse>,
+    pub participant_count: usize,
+    pub last_activity_at: u64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1754,11 +2237,11 @@ mod tests {
                 domain_id.clone(),
                 "Test Coop".to_string(),
                 "cooperative".to_string(),
-                GovernanceParams {
-                    quorum_percentage: 80, // Need 4 out of 5 members to vote
-                    approval_threshold_percentage: 66,
-                    voting_period_seconds: 86400,
-                },
+                GovernanceParams::new(
+                    80,    // quorum_percentage - Need 4 out of 5 members to vote
+                    66,    // approval_threshold_percentage
+                    86400, // voting_period_seconds
+                ),
                 MembershipConfig {
                     source: MembershipSource::StaticList(vec![
                         alice.did().clone(),

--- a/icn/crates/icn-gateway/src/email_client.rs
+++ b/icn/crates/icn-gateway/src/email_client.rs
@@ -367,6 +367,13 @@ impl EmailTemplates {
             NotificationType::BalanceChange => self.balance_template(title, body, data),
             NotificationType::SecurityAlert => self.security_alert_template(title, body, data),
             NotificationType::System => self.system_template(title, body, data),
+            NotificationType::DeliberationStarted => self.deliberation_template(title, body, data),
+            NotificationType::DeliberationEnding => {
+                self.deliberation_ending_template(title, body, data)
+            }
+            NotificationType::CommentAdded => self.comment_template(title, body, data),
+            NotificationType::CommentReply => self.comment_template(title, body, data),
+            NotificationType::CommentReaction => self.comment_template(title, body, data),
         };
 
         EmailMessage::new(to, subject, text_body).with_html(html_body)
@@ -687,6 +694,115 @@ impl EmailTemplates {
         let subject = format!("[{}] {}", self.coop_name, title);
         let text = body.to_string();
         let html = self.simple_notification_html(title, body, "");
+
+        (subject, text, html)
+    }
+
+    fn deliberation_template(
+        &self,
+        title: &str,
+        body: &str,
+        data: Option<&serde_json::Value>,
+    ) -> (String, String, String) {
+        let proposal_id = data
+            .and_then(|d| d.get("proposal_id"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+
+        let subject = format!("[{}] Deliberation Started: {}", self.coop_name, title);
+        let text = format!(
+            "{}\n\nJoin the discussion at: {}/governance/proposals/{}\n",
+            body, self.base_url, proposal_id
+        );
+        let html = format!(
+            r#"<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+    <h2 style="color: #1e40af;">📣 Deliberation Started</h2>
+    <p>{}</p>
+    <a href="{}/governance/proposals/{}" style="display: inline-block; background: #1e40af; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; margin: 20px 0;">Join the Discussion</a>
+    <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
+    <p style="color: #666; font-size: 12px;">{}</p>
+</body>
+</html>"#,
+            body, self.base_url, proposal_id, self.coop_name
+        );
+
+        (subject, text, html)
+    }
+
+    fn deliberation_ending_template(
+        &self,
+        _title: &str,
+        body: &str,
+        data: Option<&serde_json::Value>,
+    ) -> (String, String, String) {
+        let proposal_id = data
+            .and_then(|d| d.get("proposal_id"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        let hours_remaining = data
+            .and_then(|d| d.get("hours_remaining"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+
+        let subject = format!("[{}] ⏰ Deliberation Ending Soon", self.coop_name);
+        let text = format!(
+            "{}\n\nOnly {} hours left! Join the discussion at: {}/governance/proposals/{}\n",
+            body, hours_remaining, self.base_url, proposal_id
+        );
+        let html = format!(
+            r#"<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+    <div style="background: #fef3c7; border: 2px solid #f59e0b; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
+        <h2 style="color: #d97706; margin-top: 0;">⏰ Deliberation Ending Soon</h2>
+        <p style="color: #92400e;">{}</p>
+        <p style="font-weight: bold;">Only {} hours remaining!</p>
+    </div>
+    <a href="{}/governance/proposals/{}" style="display: inline-block; background: #f59e0b; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; margin: 20px 0;">Join the Discussion</a>
+    <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
+    <p style="color: #666; font-size: 12px;">{}</p>
+</body>
+</html>"#,
+            body, hours_remaining, self.base_url, proposal_id, self.coop_name
+        );
+
+        (subject, text, html)
+    }
+
+    fn comment_template(
+        &self,
+        title: &str,
+        body: &str,
+        data: Option<&serde_json::Value>,
+    ) -> (String, String, String) {
+        let proposal_id = data
+            .and_then(|d| d.get("proposal_id"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+
+        let subject = format!("[{}] {}", self.coop_name, title);
+        let text = format!(
+            "{}\n\nView the discussion at: {}/governance/proposals/{}\n",
+            body, self.base_url, proposal_id
+        );
+        let html = format!(
+            r#"<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+    <h2 style="color: #1e40af;">{}</h2>
+    <p>{}</p>
+    <a href="{}/governance/proposals/{}" style="display: inline-block; background: #1e40af; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; margin: 20px 0;">View Discussion</a>
+    <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
+    <p style="color: #666; font-size: 12px;">{}</p>
+</body>
+</html>"#,
+            title, body, self.base_url, proposal_id, self.coop_name
+        );
 
         (subject, text, html)
     }

--- a/icn/crates/icn-gateway/src/governance_mgr.rs
+++ b/icn/crates/icn-gateway/src/governance_mgr.rs
@@ -17,10 +17,11 @@
 
 use anyhow::Result;
 use icn_governance::{
-    Delegation, DelegationId, DelegationScope, GovernanceConfig, GovernanceDomain,
-    GovernanceDomainId, GovernanceOps, GovernanceParams, GovernanceProfileId, MembershipConfig,
-    MembershipSource, Proposal, ProposalId, ProposalPayload, ProposalState, Timestamp, Vote,
-    VoteChoice, VoteTally, DEFAULT_MAX_DELEGATION_DEPTH,
+    Comment, CommentId, Delegation, DelegationId, DelegationScope, Discussion, DiscussionStore,
+    GovernanceConfig, GovernanceDomain, GovernanceDomainId, GovernanceOps, GovernanceParams,
+    GovernanceProfileId, InMemoryDiscussionStore, MembershipConfig, MembershipSource, Proposal,
+    ProposalId, ProposalPayload, ProposalState, Timestamp, Vote, VoteChoice, VoteTally,
+    DEFAULT_MAX_DELEGATION_DEPTH,
 };
 use icn_identity::Did;
 use std::collections::{HashMap, HashSet};
@@ -51,6 +52,8 @@ pub struct GovernanceManager {
     votes: RwLock<HashMap<ProposalId, Vec<Vote>>>,
     /// In-memory storage for delegations (standalone mode only)
     delegations: RwLock<HashMap<DelegationId, Delegation>>,
+    /// In-memory storage for discussions (standalone mode only)
+    discussions: RwLock<InMemoryDiscussionStore>,
     /// Optional handle to daemon's GovernanceActor (actor-backed mode)
     governance_handle: Option<GovernanceHandle>,
 }
@@ -67,6 +70,7 @@ impl GovernanceManager {
             proposals: RwLock::new(HashMap::new()),
             votes: RwLock::new(HashMap::new()),
             delegations: RwLock::new(HashMap::new()),
+            discussions: RwLock::new(InMemoryDiscussionStore::new()),
             governance_handle: None,
         }
     }
@@ -90,6 +94,7 @@ impl GovernanceManager {
             proposals: RwLock::new(HashMap::new()),
             votes: RwLock::new(HashMap::new()),
             delegations: RwLock::new(HashMap::new()),
+            discussions: RwLock::new(InMemoryDiscussionStore::new()),
             governance_handle: Some(handle),
         }
     }
@@ -731,6 +736,215 @@ impl GovernanceManager {
                 id.0
             )
         }
+    }
+
+    // ============================================================================
+    // Deliberation Methods
+    // ============================================================================
+
+    /// Start deliberation period for a proposal
+    ///
+    /// Transitions the proposal from Draft to Deliberation state.
+    /// The deliberation period allows structured discussion before voting.
+    pub async fn start_deliberation(
+        &self,
+        proposal_id: &ProposalId,
+        deliberation_period_seconds: u64,
+    ) -> Result<()> {
+        // TODO: When actor-backed mode supports deliberation, delegate here
+        // For now, standalone mode only
+
+        let mut proposals = self.proposals.write().map_err(|e| {
+            anyhow::anyhow!("Proposals storage lock poisoned (concurrent panic?): {e}")
+        })?;
+
+        let proposal = proposals
+            .get_mut(proposal_id)
+            .ok_or_else(|| anyhow::anyhow!("Proposal '{}' not found", proposal_id.0))?;
+
+        proposal.start_deliberation(deliberation_period_seconds)?;
+        Ok(())
+    }
+
+    /// End deliberation and open for voting
+    ///
+    /// Transitions the proposal from Deliberation to Open state.
+    pub async fn end_deliberation_and_open(
+        &self,
+        proposal_id: &ProposalId,
+        voting_period_seconds: u64,
+    ) -> Result<()> {
+        // TODO: When actor-backed mode supports deliberation, delegate here
+        // For now, standalone mode only
+
+        let mut proposals = self.proposals.write().map_err(|e| {
+            anyhow::anyhow!("Proposals storage lock poisoned (concurrent panic?): {e}")
+        })?;
+
+        let proposal = proposals
+            .get_mut(proposal_id)
+            .ok_or_else(|| anyhow::anyhow!("Proposal '{}' not found", proposal_id.0))?;
+
+        proposal.end_deliberation_and_open(voting_period_seconds)?;
+        Ok(())
+    }
+
+    // ============================================================================
+    // Discussion Methods
+    // ============================================================================
+
+    /// Add a comment to a proposal's discussion
+    pub async fn add_comment(&self, comment: Comment) -> Result<CommentId> {
+        // Validate proposal exists and allows comments
+        {
+            let proposals = self
+                .proposals
+                .read()
+                .map_err(|e| anyhow::anyhow!("Proposals storage lock poisoned: {e}"))?;
+
+            let proposal = proposals
+                .get(&comment.proposal_id)
+                .ok_or_else(|| anyhow::anyhow!("Proposal '{}' not found", comment.proposal_id.0))?;
+
+            if !proposal.state.allows_comments() {
+                anyhow::bail!(
+                    "Cannot add comment: proposal '{}' is not open for discussion (state: {:?})",
+                    comment.proposal_id.0,
+                    proposal.state
+                );
+            }
+        }
+
+        let mut discussions = self
+            .discussions
+            .write()
+            .map_err(|e| anyhow::anyhow!("Discussions storage lock poisoned: {e}"))?;
+
+        discussions
+            .add_comment(comment)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+
+    /// Get a comment by ID
+    pub async fn get_comment(&self, comment_id: &CommentId) -> Result<Option<Comment>> {
+        let discussions = self
+            .discussions
+            .read()
+            .map_err(|e| anyhow::anyhow!("Discussions storage lock poisoned: {e}"))?;
+
+        Ok(discussions.get_comment(comment_id).cloned())
+    }
+
+    /// Edit a comment
+    pub async fn edit_comment(
+        &self,
+        comment_id: &CommentId,
+        new_content: String,
+        editor: &Did,
+    ) -> Result<()> {
+        let mut discussions = self
+            .discussions
+            .write()
+            .map_err(|e| anyhow::anyhow!("Discussions storage lock poisoned: {e}"))?;
+
+        discussions
+            .edit_comment(comment_id, new_content, editor)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+
+    /// Delete a comment (soft delete)
+    pub async fn delete_comment(&self, comment_id: &CommentId, deleter: &Did) -> Result<()> {
+        let mut discussions = self
+            .discussions
+            .write()
+            .map_err(|e| anyhow::anyhow!("Discussions storage lock poisoned: {e}"))?;
+
+        discussions
+            .delete_comment(comment_id, deleter)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+
+    /// Add a reaction to a comment
+    pub async fn add_reaction(
+        &self,
+        comment_id: &CommentId,
+        reactor: &Did,
+        emoji: &str,
+    ) -> Result<()> {
+        let mut discussions = self
+            .discussions
+            .write()
+            .map_err(|e| anyhow::anyhow!("Discussions storage lock poisoned: {e}"))?;
+
+        discussions
+            .add_reaction(comment_id, reactor, emoji)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+
+    /// Remove a reaction from a comment
+    pub async fn remove_reaction(
+        &self,
+        comment_id: &CommentId,
+        reactor: &Did,
+        emoji: &str,
+    ) -> Result<()> {
+        let mut discussions = self
+            .discussions
+            .write()
+            .map_err(|e| anyhow::anyhow!("Discussions storage lock poisoned: {e}"))?;
+
+        discussions
+            .remove_reaction(comment_id, reactor, emoji)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+
+    /// Get the full discussion for a proposal
+    pub async fn get_discussion(&self, proposal_id: &ProposalId) -> Result<Option<Discussion>> {
+        let discussions = self
+            .discussions
+            .read()
+            .map_err(|e| anyhow::anyhow!("Discussions storage lock poisoned: {e}"))?;
+
+        Ok(discussions.get_discussion(proposal_id))
+    }
+
+    /// List comments for a proposal with pagination
+    pub async fn list_comments(
+        &self,
+        proposal_id: &ProposalId,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Vec<Comment>> {
+        let discussions = self
+            .discussions
+            .read()
+            .map_err(|e| anyhow::anyhow!("Discussions storage lock poisoned: {e}"))?;
+
+        Ok(discussions
+            .list_comments(proposal_id, limit, offset)
+            .into_iter()
+            .cloned()
+            .collect())
+    }
+
+    /// Get comment count for a proposal
+    pub async fn count_comments(&self, proposal_id: &ProposalId) -> Result<usize> {
+        let discussions = self
+            .discussions
+            .read()
+            .map_err(|e| anyhow::anyhow!("Discussions storage lock poisoned: {e}"))?;
+
+        Ok(discussions.count_comments(proposal_id))
+    }
+
+    /// Get participants in a proposal's discussion
+    pub async fn get_discussion_participants(&self, proposal_id: &ProposalId) -> Result<Vec<Did>> {
+        let discussions = self
+            .discussions
+            .read()
+            .map_err(|e| anyhow::anyhow!("Discussions storage lock poisoned: {e}"))?;
+
+        Ok(discussions.get_participants(proposal_id))
     }
 }
 

--- a/icn/crates/icn-gateway/src/notification_queue.rs
+++ b/icn/crates/icn-gateway/src/notification_queue.rs
@@ -129,6 +129,16 @@ pub enum NotificationType {
     SecurityAlert,
     /// General system notification
     System,
+    /// Deliberation started on a proposal
+    DeliberationStarted,
+    /// Deliberation ending soon reminder
+    DeliberationEnding,
+    /// Comment added to proposal discussion
+    CommentAdded,
+    /// Reply to your comment
+    CommentReply,
+    /// Reaction to your comment
+    CommentReaction,
 }
 
 impl QueuedNotification {

--- a/icn/crates/icn-gateway/src/notification_triggers.rs
+++ b/icn/crates/icn-gateway/src/notification_triggers.rs
@@ -307,6 +307,162 @@ impl GovernanceNotificationTrigger {
         }));
         self.queue.queue(notif).await
     }
+
+    /// Queue notification when deliberation starts on a proposal
+    pub async fn on_deliberation_started(
+        &self,
+        recipient: &str,
+        coop_id: &str,
+        proposal_id: &str,
+        proposal_title: &str,
+        ends_at: u64,
+    ) -> Result<String, String> {
+        let days_remaining = (ends_at.saturating_sub(current_timestamp())) / 86400;
+        let body = format!(
+            "📣 New proposal open for discussion: \"{proposal_title}\"\nDeliberation ends in {days_remaining} days. Join the conversation!"
+        );
+
+        let notif = QueuedNotification::new(
+            recipient,
+            coop_id,
+            "Deliberation Started",
+            body,
+            NotificationType::DeliberationStarted,
+        )
+        .with_data(serde_json::json!({
+            "type": "deliberation_started",
+            "proposal_id": proposal_id,
+            "proposal_title": proposal_title,
+            "ends_at": ends_at,
+        }));
+        self.queue.queue(notif).await
+    }
+
+    /// Queue notification when deliberation is ending soon
+    pub async fn on_deliberation_ending_soon(
+        &self,
+        recipient: &str,
+        coop_id: &str,
+        proposal_id: &str,
+        proposal_title: &str,
+        hours_remaining: u64,
+    ) -> Result<String, String> {
+        let body = format!(
+            "⏰ Deliberation ending soon: \"{proposal_title}\"\nOnly {hours_remaining} hours left to comment before voting begins."
+        );
+
+        let notif = QueuedNotification::new(
+            recipient,
+            coop_id,
+            "Deliberation Ending Soon",
+            body,
+            NotificationType::DeliberationEnding,
+        )
+        .with_data(serde_json::json!({
+            "type": "deliberation_ending",
+            "proposal_id": proposal_id,
+            "proposal_title": proposal_title,
+            "hours_remaining": hours_remaining,
+        }));
+        self.queue.queue(notif).await
+    }
+
+    /// Queue notification when a comment is added to a proposal
+    pub async fn on_comment_added(
+        &self,
+        recipient: &str,
+        coop_id: &str,
+        proposal_id: &str,
+        comment_id: &str,
+        commenter: &str,
+    ) -> Result<String, String> {
+        let body = format!(
+            "{} commented on a proposal you're following",
+            truncate_did(commenter)
+        );
+
+        let notif = QueuedNotification::new(
+            recipient,
+            coop_id,
+            "New Comment",
+            body,
+            NotificationType::CommentAdded,
+        )
+        .with_data(serde_json::json!({
+            "type": "comment_added",
+            "proposal_id": proposal_id,
+            "comment_id": comment_id,
+            "commenter": commenter,
+        }));
+        self.queue.queue(notif).await
+    }
+
+    /// Queue notification when someone replies to your comment
+    pub async fn on_comment_reply(
+        &self,
+        recipient: &str,
+        coop_id: &str,
+        proposal_id: &str,
+        comment_id: &str,
+        parent_comment_id: &str,
+        replier: &str,
+    ) -> Result<String, String> {
+        let body = format!("{} replied to your comment", truncate_did(replier));
+
+        let notif = QueuedNotification::new(
+            recipient,
+            coop_id,
+            "New Reply",
+            body,
+            NotificationType::CommentReply,
+        )
+        .with_data(serde_json::json!({
+            "type": "comment_reply",
+            "proposal_id": proposal_id,
+            "comment_id": comment_id,
+            "parent_comment_id": parent_comment_id,
+            "replier": replier,
+        }));
+        self.queue.queue(notif).await
+    }
+
+    /// Queue notification when someone reacts to your comment
+    pub async fn on_comment_reaction(
+        &self,
+        recipient: &str,
+        coop_id: &str,
+        proposal_id: &str,
+        comment_id: &str,
+        reactor: &str,
+        emoji: &str,
+    ) -> Result<String, String> {
+        let body = format!(
+            "{} reacted {} to your comment",
+            truncate_did(reactor),
+            emoji
+        );
+
+        let notif = QueuedNotification::new(
+            recipient,
+            coop_id,
+            "New Reaction",
+            body,
+            NotificationType::CommentReaction,
+        )
+        .with_data(serde_json::json!({
+            "type": "comment_reaction",
+            "proposal_id": proposal_id,
+            "comment_id": comment_id,
+            "reactor": reactor,
+            "emoji": emoji,
+        }));
+        self.queue.queue(notif).await
+    }
+}
+
+/// Get current timestamp in seconds
+fn current_timestamp() -> u64 {
+    icn_time::current_timestamp_secs()
 }
 
 /// Truncate DID for display

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -893,6 +893,17 @@ impl GatewayServer {
                                 .service(api::governance::list_delegations)
                                 .service(api::governance::get_delegation)
                                 .service(api::governance::revoke_delegation)
+                                // Deliberation endpoints
+                                .service(api::governance::start_deliberation)
+                                .service(api::governance::end_deliberation)
+                                // Discussion endpoints
+                                .service(api::governance::add_comment)
+                                .service(api::governance::list_comments)
+                                .service(api::governance::get_discussion)
+                                .service(api::governance::edit_comment)
+                                .service(api::governance::delete_comment)
+                                .service(api::governance::add_reaction)
+                                .service(api::governance::remove_reaction)
                                 // Apply auth first, then rate limiting (wrapping order: last runs first)
                                 .wrap(middleware::from_fn(
                                     crate::rate_limit::rate_limit_middleware,

--- a/icn/crates/icn-governance/src/config.rs
+++ b/icn/crates/icn-governance/src/config.rs
@@ -56,16 +56,14 @@ impl GovernanceConfig {
     /// - Membership: Trust threshold 0.3 (known peers)
     /// - Quorum: 50% of eligible voters
     /// - Approval: Simple majority (>50%)
+    /// - Deliberation: 7 days required
+    /// - Voting: 7 days
     /// - Emergency: 67% quorum, 75% approval for freeze/veto, 80% for rollback
     pub fn cooperative_default() -> Self {
         Self {
             profile: GovernanceProfileId::builtin("cooperative_default"),
             membership: MembershipConfig::trust_threshold(0.3),
-            params: GovernanceParams {
-                quorum_percentage: 50,
-                approval_threshold_percentage: 50,
-                voting_period_seconds: 7 * 24 * 60 * 60, // 7 days
-            },
+            params: GovernanceParams::default(),
             emergency: EmergencyThresholds::default(),
         }
     }
@@ -271,7 +269,7 @@ impl EmergencyThresholds {
     }
 }
 
-/// Governance parameters (quorum, thresholds, voting period)
+/// Governance parameters (quorum, thresholds, voting period, deliberation)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GovernanceParams {
     /// Minimum percentage of eligible voters that must vote (0-100)
@@ -282,10 +280,45 @@ pub struct GovernanceParams {
 
     /// How long voting is open (in seconds)
     pub voting_period_seconds: u64,
+
+    /// Default deliberation period before voting (in seconds)
+    /// Default: 604800 (7 days)
+    pub deliberation_period_seconds: u64,
+
+    /// Whether deliberation is required before voting
+    /// When true, proposals must go through Draft → Deliberation → Open
+    /// When false, proposals can skip directly to Open (Draft → Open)
+    /// Default: true
+    pub require_deliberation: bool,
+
+    /// Minimum deliberation period (in seconds)
+    /// Cannot set deliberation shorter than this
+    /// Default: 86400 (1 day)
+    pub min_deliberation_seconds: u64,
+
+    /// Maximum deliberation period (in seconds)
+    /// Cannot set deliberation longer than this
+    /// Default: 2592000 (30 days)
+    pub max_deliberation_seconds: u64,
+}
+
+impl Default for GovernanceParams {
+    fn default() -> Self {
+        Self {
+            quorum_percentage: 50,
+            approval_threshold_percentage: 50,
+            voting_period_seconds: 7 * 24 * 60 * 60, // 7 days
+            deliberation_period_seconds: 7 * 24 * 60 * 60, // 7 days
+            require_deliberation: true,
+            min_deliberation_seconds: 24 * 60 * 60, // 1 day
+            max_deliberation_seconds: 30 * 24 * 60 * 60, // 30 days
+        }
+    }
 }
 
 impl GovernanceParams {
-    /// Create new governance parameters
+    /// Create new governance parameters with basic settings
+    /// Uses default deliberation settings
     pub fn new(
         quorum_percentage: u8,
         approval_threshold_percentage: u8,
@@ -295,7 +328,45 @@ impl GovernanceParams {
             quorum_percentage,
             approval_threshold_percentage,
             voting_period_seconds,
+            ..Default::default()
         }
+    }
+
+    /// Create governance parameters with custom deliberation settings
+    pub fn with_deliberation(
+        quorum_percentage: u8,
+        approval_threshold_percentage: u8,
+        voting_period_seconds: u64,
+        deliberation_period_seconds: u64,
+        require_deliberation: bool,
+    ) -> Self {
+        Self {
+            quorum_percentage,
+            approval_threshold_percentage,
+            voting_period_seconds,
+            deliberation_period_seconds,
+            require_deliberation,
+            ..Default::default()
+        }
+    }
+
+    /// Set deliberation requirement
+    pub fn set_require_deliberation(mut self, require: bool) -> Self {
+        self.require_deliberation = require;
+        self
+    }
+
+    /// Set deliberation period
+    pub fn set_deliberation_period(mut self, seconds: u64) -> Self {
+        self.deliberation_period_seconds = seconds;
+        self
+    }
+
+    /// Set minimum and maximum deliberation bounds
+    pub fn set_deliberation_bounds(mut self, min_seconds: u64, max_seconds: u64) -> Self {
+        self.min_deliberation_seconds = min_seconds;
+        self.max_deliberation_seconds = max_seconds;
+        self
     }
 
     /// Validate parameters are in valid ranges
@@ -308,6 +379,52 @@ impl GovernanceParams {
         }
         if self.voting_period_seconds == 0 {
             anyhow::bail!("Voting period must be greater than 0");
+        }
+
+        // Deliberation validation
+        if self.require_deliberation && self.deliberation_period_seconds == 0 {
+            anyhow::bail!("Deliberation period must be greater than 0 when required");
+        }
+        if self.deliberation_period_seconds < self.min_deliberation_seconds {
+            anyhow::bail!(
+                "Deliberation period ({}) is less than minimum ({})",
+                self.deliberation_period_seconds,
+                self.min_deliberation_seconds
+            );
+        }
+        if self.deliberation_period_seconds > self.max_deliberation_seconds {
+            anyhow::bail!(
+                "Deliberation period ({}) exceeds maximum ({})",
+                self.deliberation_period_seconds,
+                self.max_deliberation_seconds
+            );
+        }
+        if self.min_deliberation_seconds > self.max_deliberation_seconds {
+            anyhow::bail!(
+                "Minimum deliberation ({}) exceeds maximum ({})",
+                self.min_deliberation_seconds,
+                self.max_deliberation_seconds
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Validate a specific deliberation duration against bounds
+    pub fn validate_deliberation_duration(&self, duration_seconds: u64) -> anyhow::Result<()> {
+        if duration_seconds < self.min_deliberation_seconds {
+            anyhow::bail!(
+                "Deliberation duration ({} seconds) is less than minimum ({} seconds)",
+                duration_seconds,
+                self.min_deliberation_seconds
+            );
+        }
+        if duration_seconds > self.max_deliberation_seconds {
+            anyhow::bail!(
+                "Deliberation duration ({} seconds) exceeds maximum ({} seconds)",
+                duration_seconds,
+                self.max_deliberation_seconds
+            );
         }
         Ok(())
     }
@@ -325,6 +442,12 @@ mod tests {
         assert_eq!(config.params.quorum_percentage, 50);
         assert_eq!(config.params.approval_threshold_percentage, 50);
         assert_eq!(config.params.voting_period_seconds, 7 * 24 * 60 * 60);
+
+        // Deliberation parameters should be default
+        assert_eq!(config.params.deliberation_period_seconds, 7 * 24 * 60 * 60);
+        assert!(config.params.require_deliberation);
+        assert_eq!(config.params.min_deliberation_seconds, 24 * 60 * 60);
+        assert_eq!(config.params.max_deliberation_seconds, 30 * 24 * 60 * 60);
 
         // Emergency thresholds should be default
         assert_eq!(config.emergency.freeze_quorum_percentage, 67);
@@ -346,6 +469,77 @@ mod tests {
 
         let invalid_period = GovernanceParams::new(50, 50, 0);
         assert!(invalid_period.validate().is_err());
+    }
+
+    #[test]
+    fn test_deliberation_validation() {
+        // Valid default params
+        let valid = GovernanceParams::default();
+        assert!(valid.validate().is_ok());
+
+        // Deliberation period below minimum
+        let mut invalid = GovernanceParams::default();
+        invalid.deliberation_period_seconds = 3600; // 1 hour, below 1 day minimum
+        assert!(invalid.validate().is_err());
+
+        // Deliberation period above maximum
+        let mut invalid = GovernanceParams::default();
+        invalid.deliberation_period_seconds = 60 * 24 * 60 * 60; // 60 days, above 30 day max
+        assert!(invalid.validate().is_err());
+
+        // Min > max is invalid
+        let mut invalid = GovernanceParams::default();
+        invalid.min_deliberation_seconds = 10 * 24 * 60 * 60;
+        invalid.max_deliberation_seconds = 5 * 24 * 60 * 60;
+        assert!(invalid.validate().is_err());
+
+        // Zero deliberation with require_deliberation = true
+        let mut invalid = GovernanceParams::default();
+        invalid.deliberation_period_seconds = 0;
+        invalid.min_deliberation_seconds = 0;
+        assert!(invalid.validate().is_err());
+
+        // Zero deliberation with require_deliberation = false is fine
+        let mut valid = GovernanceParams::default();
+        valid.require_deliberation = false;
+        valid.deliberation_period_seconds = 0;
+        valid.min_deliberation_seconds = 0;
+        assert!(valid.validate().is_ok());
+    }
+
+    #[test]
+    fn test_params_with_deliberation() {
+        let params = GovernanceParams::with_deliberation(
+            60,    // quorum
+            51,    // approval
+            3600,  // voting period
+            86400, // deliberation period (1 day)
+            true,  // require deliberation
+        );
+
+        assert_eq!(params.quorum_percentage, 60);
+        assert_eq!(params.approval_threshold_percentage, 51);
+        assert_eq!(params.voting_period_seconds, 3600);
+        assert_eq!(params.deliberation_period_seconds, 86400);
+        assert!(params.require_deliberation);
+    }
+
+    #[test]
+    fn test_validate_deliberation_duration() {
+        let params = GovernanceParams::default();
+
+        // Valid duration within bounds
+        assert!(params
+            .validate_deliberation_duration(7 * 24 * 60 * 60)
+            .is_ok());
+
+        // Below minimum
+        assert!(params.validate_deliberation_duration(3600).is_err());
+
+        // Above maximum
+        assert!(params
+            .validate_deliberation_duration(60 * 24 * 60 * 60)
+            .is_err());
     }
 
     #[test]

--- a/icn/crates/icn-governance/src/config.rs
+++ b/icn/crates/icn-governance/src/config.rs
@@ -478,32 +478,42 @@ mod tests {
         assert!(valid.validate().is_ok());
 
         // Deliberation period below minimum
-        let mut invalid = GovernanceParams::default();
-        invalid.deliberation_period_seconds = 3600; // 1 hour, below 1 day minimum
+        let invalid = GovernanceParams {
+            deliberation_period_seconds: 3600, // 1 hour, below 1 day minimum
+            ..Default::default()
+        };
         assert!(invalid.validate().is_err());
 
         // Deliberation period above maximum
-        let mut invalid = GovernanceParams::default();
-        invalid.deliberation_period_seconds = 60 * 24 * 60 * 60; // 60 days, above 30 day max
+        let invalid = GovernanceParams {
+            deliberation_period_seconds: 60 * 24 * 60 * 60, // 60 days, above 30 day max
+            ..Default::default()
+        };
         assert!(invalid.validate().is_err());
 
         // Min > max is invalid
-        let mut invalid = GovernanceParams::default();
-        invalid.min_deliberation_seconds = 10 * 24 * 60 * 60;
-        invalid.max_deliberation_seconds = 5 * 24 * 60 * 60;
+        let invalid = GovernanceParams {
+            min_deliberation_seconds: 10 * 24 * 60 * 60,
+            max_deliberation_seconds: 5 * 24 * 60 * 60,
+            ..Default::default()
+        };
         assert!(invalid.validate().is_err());
 
         // Zero deliberation with require_deliberation = true
-        let mut invalid = GovernanceParams::default();
-        invalid.deliberation_period_seconds = 0;
-        invalid.min_deliberation_seconds = 0;
+        let invalid = GovernanceParams {
+            deliberation_period_seconds: 0,
+            min_deliberation_seconds: 0,
+            ..Default::default()
+        };
         assert!(invalid.validate().is_err());
 
         // Zero deliberation with require_deliberation = false is fine
-        let mut valid = GovernanceParams::default();
-        valid.require_deliberation = false;
-        valid.deliberation_period_seconds = 0;
-        valid.min_deliberation_seconds = 0;
+        let valid = GovernanceParams {
+            require_deliberation: false,
+            deliberation_period_seconds: 0,
+            min_deliberation_seconds: 0,
+            ..Default::default()
+        };
         assert!(valid.validate().is_ok());
     }
 

--- a/icn/crates/icn-governance/src/discussion.rs
+++ b/icn/crates/icn-governance/src/discussion.rs
@@ -662,7 +662,7 @@ mod tests {
 
         for i in 0..10 {
             let comment =
-                Comment::new(proposal_id.clone(), alice.clone(), format!("Comment {}", i));
+                Comment::new(proposal_id.clone(), alice.clone(), format!("Comment {i}"));
             store.add_comment(comment).unwrap();
         }
 

--- a/icn/crates/icn-governance/src/discussion.rs
+++ b/icn/crates/icn-governance/src/discussion.rs
@@ -661,8 +661,7 @@ mod tests {
         let alice = test_did("alice");
 
         for i in 0..10 {
-            let comment =
-                Comment::new(proposal_id.clone(), alice.clone(), format!("Comment {i}"));
+            let comment = Comment::new(proposal_id.clone(), alice.clone(), format!("Comment {i}"));
             store.add_comment(comment).unwrap();
         }
 

--- a/icn/crates/icn-governance/src/discussion.rs
+++ b/icn/crates/icn-governance/src/discussion.rs
@@ -1,0 +1,736 @@
+//! Discussion and comment infrastructure for proposal deliberation
+//!
+//! This module provides the foundation for structured discussions during
+//! the deliberation phase of governance proposals. Members can comment,
+//! reply in threads, and react to comments.
+
+use crate::proposal::ProposalId;
+use icn_identity::Did;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+
+/// Unique identifier for a comment
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CommentId(pub String);
+
+impl CommentId {
+    pub fn new() -> Self {
+        Self(uuid::Uuid::new_v4().to_string())
+    }
+
+    pub fn from_string(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+}
+
+impl Default for CommentId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for CommentId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A comment on a proposal during deliberation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Comment {
+    /// Unique identifier for this comment
+    pub id: CommentId,
+    /// The proposal this comment belongs to
+    pub proposal_id: ProposalId,
+    /// Author's DID
+    pub author: Did,
+    /// Comment content (markdown supported)
+    pub content: String,
+    /// Parent comment ID for threaded replies
+    pub parent_id: Option<CommentId>,
+    /// When the comment was created
+    pub created_at: u64,
+    /// When the comment was last updated
+    pub updated_at: u64,
+    /// Reactions (emoji -> list of reactors)
+    pub reactions: HashMap<String, Vec<Did>>,
+    /// Whether the comment has been edited
+    pub is_edited: bool,
+    /// Whether the comment has been soft-deleted
+    pub is_deleted: bool,
+}
+
+impl Comment {
+    /// Create a new top-level comment
+    pub fn new(proposal_id: ProposalId, author: Did, content: String) -> Self {
+        let now = current_timestamp();
+        Self {
+            id: CommentId::new(),
+            proposal_id,
+            author,
+            content,
+            parent_id: None,
+            created_at: now,
+            updated_at: now,
+            reactions: HashMap::new(),
+            is_edited: false,
+            is_deleted: false,
+        }
+    }
+
+    /// Create a reply to an existing comment
+    pub fn reply(parent: &Comment, author: Did, content: String) -> Self {
+        let mut comment = Self::new(parent.proposal_id.clone(), author, content);
+        comment.parent_id = Some(parent.id.clone());
+        comment
+    }
+
+    /// Check if this comment is a reply to another comment
+    pub fn is_reply(&self) -> bool {
+        self.parent_id.is_some()
+    }
+
+    /// Get the total reaction count
+    pub fn reaction_count(&self) -> usize {
+        self.reactions.values().map(|v| v.len()).sum()
+    }
+
+    /// Check if a user has reacted with a specific emoji
+    pub fn has_reacted(&self, user: &Did, emoji: &str) -> bool {
+        self.reactions
+            .get(emoji)
+            .map(|reactors| reactors.contains(user))
+            .unwrap_or(false)
+    }
+}
+
+/// Discussion thread on a proposal
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Discussion {
+    /// The proposal being discussed
+    pub proposal_id: ProposalId,
+    /// All comments in chronological order
+    pub comments: Vec<Comment>,
+    /// Number of unique participants
+    pub participant_count: usize,
+    /// Timestamp of last activity
+    pub last_activity_at: u64,
+}
+
+impl Discussion {
+    /// Create a new empty discussion
+    pub fn new(proposal_id: ProposalId) -> Self {
+        Self {
+            proposal_id,
+            comments: Vec::new(),
+            participant_count: 0,
+            last_activity_at: current_timestamp(),
+        }
+    }
+
+    /// Get top-level comments (not replies)
+    pub fn top_level_comments(&self) -> Vec<&Comment> {
+        self.comments
+            .iter()
+            .filter(|c| c.parent_id.is_none() && !c.is_deleted)
+            .collect()
+    }
+
+    /// Get replies to a specific comment
+    pub fn replies_to(&self, comment_id: &CommentId) -> Vec<&Comment> {
+        self.comments
+            .iter()
+            .filter(|c| c.parent_id.as_ref() == Some(comment_id) && !c.is_deleted)
+            .collect()
+    }
+}
+
+/// Error type for discussion operations
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum DiscussionError {
+    #[error("Comment not found: {0}")]
+    CommentNotFound(String),
+
+    #[error("Discussion not found for proposal: {0}")]
+    DiscussionNotFound(String),
+
+    #[error("Not authorized: {0}")]
+    NotAuthorized(String),
+
+    #[error("Invalid operation: {0}")]
+    InvalidOperation(String),
+
+    #[error("Storage error: {0}")]
+    StorageError(String),
+}
+
+/// Trait for discussion storage backends
+pub trait DiscussionStore: Send + Sync {
+    /// Add a new comment
+    fn add_comment(&mut self, comment: Comment) -> Result<CommentId, DiscussionError>;
+
+    /// Get a comment by ID
+    fn get_comment(&self, id: &CommentId) -> Option<&Comment>;
+
+    /// Get a mutable reference to a comment
+    fn get_comment_mut(&mut self, id: &CommentId) -> Option<&mut Comment>;
+
+    /// Edit a comment's content
+    fn edit_comment(
+        &mut self,
+        id: &CommentId,
+        new_content: String,
+        editor: &Did,
+    ) -> Result<(), DiscussionError>;
+
+    /// Soft-delete a comment
+    fn delete_comment(&mut self, id: &CommentId, deleter: &Did) -> Result<(), DiscussionError>;
+
+    /// Add a reaction to a comment
+    fn add_reaction(
+        &mut self,
+        comment_id: &CommentId,
+        reactor: &Did,
+        emoji: &str,
+    ) -> Result<(), DiscussionError>;
+
+    /// Remove a reaction from a comment
+    fn remove_reaction(
+        &mut self,
+        comment_id: &CommentId,
+        reactor: &Did,
+        emoji: &str,
+    ) -> Result<(), DiscussionError>;
+
+    /// Get the full discussion for a proposal
+    fn get_discussion(&self, proposal_id: &ProposalId) -> Option<Discussion>;
+
+    /// List comments for a proposal with pagination
+    fn list_comments(&self, proposal_id: &ProposalId, limit: usize, offset: usize)
+        -> Vec<&Comment>;
+
+    /// Count comments for a proposal
+    fn count_comments(&self, proposal_id: &ProposalId) -> usize;
+
+    /// Get unique participant DIDs for a proposal discussion
+    fn get_participants(&self, proposal_id: &ProposalId) -> Vec<Did>;
+}
+
+/// In-memory implementation of DiscussionStore for testing
+#[derive(Debug, Default)]
+pub struct InMemoryDiscussionStore {
+    comments: HashMap<CommentId, Comment>,
+    by_proposal: HashMap<ProposalId, Vec<CommentId>>,
+}
+
+impl InMemoryDiscussionStore {
+    pub fn new() -> Self {
+        Self {
+            comments: HashMap::new(),
+            by_proposal: HashMap::new(),
+        }
+    }
+}
+
+impl DiscussionStore for InMemoryDiscussionStore {
+    fn add_comment(&mut self, comment: Comment) -> Result<CommentId, DiscussionError> {
+        let id = comment.id.clone();
+        let proposal_id = comment.proposal_id.clone();
+
+        // Validate parent exists if this is a reply
+        if let Some(ref parent_id) = comment.parent_id {
+            if !self.comments.contains_key(parent_id) {
+                return Err(DiscussionError::CommentNotFound(format!(
+                    "Parent comment {parent_id} not found"
+                )));
+            }
+        }
+
+        self.comments.insert(id.clone(), comment);
+        self.by_proposal
+            .entry(proposal_id)
+            .or_default()
+            .push(id.clone());
+
+        Ok(id)
+    }
+
+    fn get_comment(&self, id: &CommentId) -> Option<&Comment> {
+        self.comments.get(id)
+    }
+
+    fn get_comment_mut(&mut self, id: &CommentId) -> Option<&mut Comment> {
+        self.comments.get_mut(id)
+    }
+
+    fn edit_comment(
+        &mut self,
+        id: &CommentId,
+        new_content: String,
+        editor: &Did,
+    ) -> Result<(), DiscussionError> {
+        let comment = self
+            .comments
+            .get_mut(id)
+            .ok_or_else(|| DiscussionError::CommentNotFound(id.0.clone()))?;
+
+        if &comment.author != editor {
+            return Err(DiscussionError::NotAuthorized(
+                "Only the author can edit a comment".to_string(),
+            ));
+        }
+
+        if comment.is_deleted {
+            return Err(DiscussionError::InvalidOperation(
+                "Cannot edit a deleted comment".to_string(),
+            ));
+        }
+
+        comment.content = new_content;
+        comment.updated_at = current_timestamp();
+        comment.is_edited = true;
+
+        Ok(())
+    }
+
+    fn delete_comment(&mut self, id: &CommentId, deleter: &Did) -> Result<(), DiscussionError> {
+        let comment = self
+            .comments
+            .get_mut(id)
+            .ok_or_else(|| DiscussionError::CommentNotFound(id.0.clone()))?;
+
+        if &comment.author != deleter {
+            return Err(DiscussionError::NotAuthorized(
+                "Only the author can delete a comment".to_string(),
+            ));
+        }
+
+        comment.is_deleted = true;
+        comment.content = "[deleted]".to_string();
+        comment.updated_at = current_timestamp();
+
+        Ok(())
+    }
+
+    fn add_reaction(
+        &mut self,
+        comment_id: &CommentId,
+        reactor: &Did,
+        emoji: &str,
+    ) -> Result<(), DiscussionError> {
+        let comment = self
+            .comments
+            .get_mut(comment_id)
+            .ok_or_else(|| DiscussionError::CommentNotFound(comment_id.0.clone()))?;
+
+        if comment.is_deleted {
+            return Err(DiscussionError::InvalidOperation(
+                "Cannot react to a deleted comment".to_string(),
+            ));
+        }
+
+        let reactors = comment.reactions.entry(emoji.to_string()).or_default();
+
+        // Don't add duplicate reactions
+        if !reactors.contains(reactor) {
+            reactors.push(reactor.clone());
+        }
+
+        Ok(())
+    }
+
+    fn remove_reaction(
+        &mut self,
+        comment_id: &CommentId,
+        reactor: &Did,
+        emoji: &str,
+    ) -> Result<(), DiscussionError> {
+        let comment = self
+            .comments
+            .get_mut(comment_id)
+            .ok_or_else(|| DiscussionError::CommentNotFound(comment_id.0.clone()))?;
+
+        if let Some(reactors) = comment.reactions.get_mut(emoji) {
+            reactors.retain(|r| r != reactor);
+            if reactors.is_empty() {
+                comment.reactions.remove(emoji);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn get_discussion(&self, proposal_id: &ProposalId) -> Option<Discussion> {
+        let comment_ids = self.by_proposal.get(proposal_id)?;
+
+        let comments: Vec<Comment> = comment_ids
+            .iter()
+            .filter_map(|id| self.comments.get(id).cloned())
+            .collect();
+
+        if comments.is_empty() {
+            return None;
+        }
+
+        // Calculate participants and last_activity before moving comments
+        let participants: HashSet<Did> = comments
+            .iter()
+            .filter(|c| !c.is_deleted)
+            .map(|c| c.author.clone())
+            .collect();
+
+        let last_activity = comments
+            .iter()
+            .filter(|c| !c.is_deleted)
+            .map(|c| c.updated_at)
+            .max()
+            .unwrap_or(0);
+
+        let participant_count = participants.len();
+
+        Some(Discussion {
+            proposal_id: proposal_id.clone(),
+            comments,
+            participant_count,
+            last_activity_at: last_activity,
+        })
+    }
+
+    fn list_comments(
+        &self,
+        proposal_id: &ProposalId,
+        limit: usize,
+        offset: usize,
+    ) -> Vec<&Comment> {
+        self.by_proposal
+            .get(proposal_id)
+            .map(|ids| {
+                ids.iter()
+                    .filter_map(|id| self.comments.get(id))
+                    .filter(|c| !c.is_deleted)
+                    .skip(offset)
+                    .take(limit)
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn count_comments(&self, proposal_id: &ProposalId) -> usize {
+        self.by_proposal
+            .get(proposal_id)
+            .map(|ids| {
+                ids.iter()
+                    .filter_map(|id| self.comments.get(id))
+                    .filter(|c| !c.is_deleted)
+                    .count()
+            })
+            .unwrap_or(0)
+    }
+
+    fn get_participants(&self, proposal_id: &ProposalId) -> Vec<Did> {
+        self.by_proposal
+            .get(proposal_id)
+            .map(|ids| {
+                let participants: HashSet<_> = ids
+                    .iter()
+                    .filter_map(|id| self.comments.get(id))
+                    .filter(|c| !c.is_deleted)
+                    .map(|c| c.author.clone())
+                    .collect();
+                participants.into_iter().collect()
+            })
+            .unwrap_or_default()
+    }
+}
+
+fn current_timestamp() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_did(name: &str) -> Did {
+        // Create deterministic DIDs for testing based on name
+        let mut bytes = [0u8; 32];
+        let name_bytes = name.as_bytes();
+        for (i, &b) in name_bytes.iter().enumerate() {
+            if i < 32 {
+                bytes[i] = b;
+            }
+        }
+        Did::from_anchor_id(&bytes)
+    }
+
+    fn test_proposal_id() -> ProposalId {
+        ProposalId("test-proposal-1".to_string())
+    }
+
+    #[test]
+    fn test_create_comment() {
+        let proposal_id = test_proposal_id();
+        let author = test_did("alice");
+        let comment = Comment::new(
+            proposal_id.clone(),
+            author.clone(),
+            "Great idea!".to_string(),
+        );
+
+        assert_eq!(comment.proposal_id, proposal_id);
+        assert_eq!(comment.author, author);
+        assert_eq!(comment.content, "Great idea!");
+        assert!(comment.parent_id.is_none());
+        assert!(!comment.is_edited);
+        assert!(!comment.is_deleted);
+    }
+
+    #[test]
+    fn test_create_reply() {
+        let proposal_id = test_proposal_id();
+        let alice = test_did("alice");
+        let bob = test_did("bob");
+
+        let parent = Comment::new(proposal_id.clone(), alice, "What do you think?".to_string());
+        let reply = Comment::reply(&parent, bob, "I agree!".to_string());
+
+        assert_eq!(reply.parent_id, Some(parent.id.clone()));
+        assert!(reply.is_reply());
+    }
+
+    #[test]
+    fn test_add_and_retrieve_comment() {
+        let mut store = InMemoryDiscussionStore::new();
+        let proposal_id = test_proposal_id();
+        let author = test_did("alice");
+
+        let comment = Comment::new(
+            proposal_id.clone(),
+            author.clone(),
+            "Test comment".to_string(),
+        );
+        let id = store.add_comment(comment).unwrap();
+
+        let retrieved = store.get_comment(&id).unwrap();
+        assert_eq!(retrieved.content, "Test comment");
+        assert_eq!(retrieved.author, author);
+    }
+
+    #[test]
+    fn test_threaded_replies() {
+        let mut store = InMemoryDiscussionStore::new();
+        let proposal_id = test_proposal_id();
+        let alice = test_did("alice");
+        let bob = test_did("bob");
+
+        let parent = Comment::new(proposal_id.clone(), alice, "Parent comment".to_string());
+        let parent_id = store.add_comment(parent.clone()).unwrap();
+
+        let reply = Comment::reply(
+            store.get_comment(&parent_id).unwrap(),
+            bob,
+            "Reply comment".to_string(),
+        );
+        let reply_id = store.add_comment(reply).unwrap();
+
+        let retrieved_reply = store.get_comment(&reply_id).unwrap();
+        assert_eq!(retrieved_reply.parent_id, Some(parent_id));
+    }
+
+    #[test]
+    fn test_edit_comment() {
+        let mut store = InMemoryDiscussionStore::new();
+        let proposal_id = test_proposal_id();
+        let alice = test_did("alice");
+
+        let comment = Comment::new(proposal_id.clone(), alice.clone(), "Original".to_string());
+        let id = store.add_comment(comment).unwrap();
+
+        store
+            .edit_comment(&id, "Edited".to_string(), &alice)
+            .unwrap();
+
+        let retrieved = store.get_comment(&id).unwrap();
+        assert_eq!(retrieved.content, "Edited");
+        assert!(retrieved.is_edited);
+    }
+
+    #[test]
+    fn test_edit_comment_not_author() {
+        let mut store = InMemoryDiscussionStore::new();
+        let proposal_id = test_proposal_id();
+        let alice = test_did("alice");
+        let bob = test_did("bob");
+
+        let comment = Comment::new(proposal_id.clone(), alice, "Original".to_string());
+        let id = store.add_comment(comment).unwrap();
+
+        let result = store.edit_comment(&id, "Hacked!".to_string(), &bob);
+        assert!(matches!(result, Err(DiscussionError::NotAuthorized(_))));
+    }
+
+    #[test]
+    fn test_delete_comment() {
+        let mut store = InMemoryDiscussionStore::new();
+        let proposal_id = test_proposal_id();
+        let alice = test_did("alice");
+
+        let comment = Comment::new(proposal_id.clone(), alice.clone(), "To delete".to_string());
+        let id = store.add_comment(comment).unwrap();
+
+        store.delete_comment(&id, &alice).unwrap();
+
+        let retrieved = store.get_comment(&id).unwrap();
+        assert!(retrieved.is_deleted);
+        assert_eq!(retrieved.content, "[deleted]");
+    }
+
+    #[test]
+    fn test_reactions() {
+        let mut store = InMemoryDiscussionStore::new();
+        let proposal_id = test_proposal_id();
+        let alice = test_did("alice");
+        let bob = test_did("bob");
+
+        let comment = Comment::new(
+            proposal_id.clone(),
+            alice.clone(),
+            "React to me!".to_string(),
+        );
+        let id = store.add_comment(comment).unwrap();
+
+        store.add_reaction(&id, &bob, "thumbsup").unwrap();
+        store.add_reaction(&id, &alice, "thumbsup").unwrap();
+        store.add_reaction(&id, &bob, "heart").unwrap();
+
+        let retrieved = store.get_comment(&id).unwrap();
+        assert_eq!(retrieved.reactions.get("thumbsup").unwrap().len(), 2);
+        assert_eq!(retrieved.reactions.get("heart").unwrap().len(), 1);
+        assert!(retrieved.has_reacted(&bob, "thumbsup"));
+        assert!(!retrieved.has_reacted(&bob, "smile"));
+    }
+
+    #[test]
+    fn test_remove_reaction() {
+        let mut store = InMemoryDiscussionStore::new();
+        let proposal_id = test_proposal_id();
+        let alice = test_did("alice");
+        let bob = test_did("bob");
+
+        let comment = Comment::new(
+            proposal_id.clone(),
+            alice.clone(),
+            "React to me!".to_string(),
+        );
+        let id = store.add_comment(comment).unwrap();
+
+        store.add_reaction(&id, &bob, "thumbsup").unwrap();
+        store.remove_reaction(&id, &bob, "thumbsup").unwrap();
+
+        let retrieved = store.get_comment(&id).unwrap();
+        assert!(!retrieved.reactions.contains_key("thumbsup"));
+    }
+
+    #[test]
+    fn test_get_discussion() {
+        let mut store = InMemoryDiscussionStore::new();
+        let proposal_id = test_proposal_id();
+        let alice = test_did("alice");
+        let bob = test_did("bob");
+
+        let comment1 = Comment::new(proposal_id.clone(), alice.clone(), "First".to_string());
+        let comment2 = Comment::new(proposal_id.clone(), bob.clone(), "Second".to_string());
+        let comment3 = Comment::new(proposal_id.clone(), alice.clone(), "Third".to_string());
+
+        store.add_comment(comment1).unwrap();
+        store.add_comment(comment2).unwrap();
+        store.add_comment(comment3).unwrap();
+
+        let discussion = store.get_discussion(&proposal_id).unwrap();
+        assert_eq!(discussion.comments.len(), 3);
+        assert_eq!(discussion.participant_count, 2); // alice and bob
+    }
+
+    #[test]
+    fn test_list_comments_pagination() {
+        let mut store = InMemoryDiscussionStore::new();
+        let proposal_id = test_proposal_id();
+        let alice = test_did("alice");
+
+        for i in 0..10 {
+            let comment =
+                Comment::new(proposal_id.clone(), alice.clone(), format!("Comment {}", i));
+            store.add_comment(comment).unwrap();
+        }
+
+        let page1 = store.list_comments(&proposal_id, 3, 0);
+        assert_eq!(page1.len(), 3);
+
+        let page2 = store.list_comments(&proposal_id, 3, 3);
+        assert_eq!(page2.len(), 3);
+
+        let page_last = store.list_comments(&proposal_id, 3, 9);
+        assert_eq!(page_last.len(), 1);
+    }
+
+    #[test]
+    fn test_count_comments_excludes_deleted() {
+        let mut store = InMemoryDiscussionStore::new();
+        let proposal_id = test_proposal_id();
+        let alice = test_did("alice");
+
+        let comment1 = Comment::new(proposal_id.clone(), alice.clone(), "Keep".to_string());
+        let comment2 = Comment::new(proposal_id.clone(), alice.clone(), "Delete".to_string());
+
+        store.add_comment(comment1).unwrap();
+        let id2 = store.add_comment(comment2).unwrap();
+
+        store.delete_comment(&id2, &alice).unwrap();
+
+        assert_eq!(store.count_comments(&proposal_id), 1);
+    }
+
+    #[test]
+    fn test_get_participants() {
+        let mut store = InMemoryDiscussionStore::new();
+        let proposal_id = test_proposal_id();
+        let alice = test_did("alice");
+        let bob = test_did("bob");
+        let charlie = test_did("charlie");
+
+        store
+            .add_comment(Comment::new(
+                proposal_id.clone(),
+                alice.clone(),
+                "Alice 1".to_string(),
+            ))
+            .unwrap();
+        store
+            .add_comment(Comment::new(
+                proposal_id.clone(),
+                bob.clone(),
+                "Bob 1".to_string(),
+            ))
+            .unwrap();
+        store
+            .add_comment(Comment::new(
+                proposal_id.clone(),
+                alice.clone(),
+                "Alice 2".to_string(),
+            ))
+            .unwrap();
+        store
+            .add_comment(Comment::new(
+                proposal_id.clone(),
+                charlie.clone(),
+                "Charlie 1".to_string(),
+            ))
+            .unwrap();
+
+        let participants = store.get_participants(&proposal_id);
+        assert_eq!(participants.len(), 3);
+    }
+}

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -39,6 +39,8 @@ pub mod charter_store;
 pub mod config;
 #[allow(missing_docs)]
 pub mod delegation;
+#[allow(missing_docs)]
+pub mod discussion;
 pub mod domain;
 #[allow(missing_docs)]
 pub mod error;
@@ -89,6 +91,9 @@ pub use config::{EmergencyThresholds, GovernanceConfig, GovernanceParams};
 pub use delegation::{
     Delegation, DelegationError, DelegationId, DelegationManager, DelegationScope,
     DEFAULT_MAX_DELEGATION_DEPTH,
+};
+pub use discussion::{
+    Comment, CommentId, Discussion, DiscussionError, DiscussionStore, InMemoryDiscussionStore,
 };
 pub use domain::{GovernanceDomain, GovernanceDomainId};
 pub use error::{GovernanceError, Result};

--- a/icn/crates/icn-governance/src/message.rs
+++ b/icn/crates/icn-governance/src/message.rs
@@ -1,6 +1,8 @@
 //! Governance gossip messages for distributed coordination
 
-use crate::{Delegation, DelegationId, GovernanceDomain, Proposal, ProposalId, Timestamp, Vote};
+use crate::{
+    CommentId, Delegation, DelegationId, GovernanceDomain, Proposal, ProposalId, Timestamp, Vote,
+};
 use icn_identity::Did;
 use serde::{Deserialize, Serialize};
 
@@ -93,6 +95,106 @@ pub enum GovernanceMessage {
         /// When it was revoked
         revoked_at: Timestamp,
     },
+
+    // === Deliberation Messages ===
+    /// A proposal has entered the deliberation phase
+    DeliberationStarted {
+        /// Proposal ID
+        proposal_id: ProposalId,
+
+        /// When deliberation started
+        started_at: Timestamp,
+
+        /// When deliberation ends
+        ends_at: Timestamp,
+    },
+
+    /// Deliberation has ended and voting has opened
+    DeliberationEnded {
+        /// Proposal ID
+        proposal_id: ProposalId,
+
+        /// When deliberation ended
+        ended_at: Timestamp,
+
+        /// Number of comments during deliberation
+        comment_count: usize,
+
+        /// Number of unique participants in the discussion
+        participant_count: usize,
+    },
+
+    /// A comment was added to a proposal
+    CommentCreated {
+        /// Proposal ID
+        proposal_id: ProposalId,
+
+        /// Comment ID
+        comment_id: CommentId,
+
+        /// Who wrote the comment
+        author: Did,
+
+        /// Parent comment ID (if this is a reply)
+        parent_id: Option<CommentId>,
+
+        /// When the comment was created
+        created_at: Timestamp,
+    },
+
+    /// A comment was edited
+    CommentEdited {
+        /// Proposal ID
+        proposal_id: ProposalId,
+
+        /// Comment ID
+        comment_id: CommentId,
+
+        /// When the comment was edited
+        edited_at: Timestamp,
+    },
+
+    /// A comment was deleted
+    CommentDeleted {
+        /// Proposal ID
+        proposal_id: ProposalId,
+
+        /// Comment ID
+        comment_id: CommentId,
+
+        /// When the comment was deleted
+        deleted_at: Timestamp,
+    },
+
+    /// A reaction was added to a comment
+    ReactionAdded {
+        /// Proposal ID
+        proposal_id: ProposalId,
+
+        /// Comment ID
+        comment_id: CommentId,
+
+        /// Who reacted
+        reactor: Did,
+
+        /// The emoji reaction
+        emoji: String,
+    },
+
+    /// A reaction was removed from a comment
+    ReactionRemoved {
+        /// Proposal ID
+        proposal_id: ProposalId,
+
+        /// Comment ID
+        comment_id: CommentId,
+
+        /// Who removed their reaction
+        reactor: Did,
+
+        /// The emoji reaction that was removed
+        emoji: String,
+    },
 }
 
 /// Outcome of a closed proposal
@@ -180,6 +282,107 @@ impl GovernanceMessage {
         }
     }
 
+    /// Create a DeliberationStarted message
+    pub fn deliberation_started(
+        proposal_id: ProposalId,
+        started_at: Timestamp,
+        ends_at: Timestamp,
+    ) -> Self {
+        Self::DeliberationStarted {
+            proposal_id,
+            started_at,
+            ends_at,
+        }
+    }
+
+    /// Create a DeliberationEnded message
+    pub fn deliberation_ended(
+        proposal_id: ProposalId,
+        ended_at: Timestamp,
+        comment_count: usize,
+        participant_count: usize,
+    ) -> Self {
+        Self::DeliberationEnded {
+            proposal_id,
+            ended_at,
+            comment_count,
+            participant_count,
+        }
+    }
+
+    /// Create a CommentCreated message
+    pub fn comment_created(
+        proposal_id: ProposalId,
+        comment_id: CommentId,
+        author: Did,
+        parent_id: Option<CommentId>,
+        created_at: Timestamp,
+    ) -> Self {
+        Self::CommentCreated {
+            proposal_id,
+            comment_id,
+            author,
+            parent_id,
+            created_at,
+        }
+    }
+
+    /// Create a CommentEdited message
+    pub fn comment_edited(
+        proposal_id: ProposalId,
+        comment_id: CommentId,
+        edited_at: Timestamp,
+    ) -> Self {
+        Self::CommentEdited {
+            proposal_id,
+            comment_id,
+            edited_at,
+        }
+    }
+
+    /// Create a CommentDeleted message
+    pub fn comment_deleted(
+        proposal_id: ProposalId,
+        comment_id: CommentId,
+        deleted_at: Timestamp,
+    ) -> Self {
+        Self::CommentDeleted {
+            proposal_id,
+            comment_id,
+            deleted_at,
+        }
+    }
+
+    /// Create a ReactionAdded message
+    pub fn reaction_added(
+        proposal_id: ProposalId,
+        comment_id: CommentId,
+        reactor: Did,
+        emoji: String,
+    ) -> Self {
+        Self::ReactionAdded {
+            proposal_id,
+            comment_id,
+            reactor,
+            emoji,
+        }
+    }
+
+    /// Create a ReactionRemoved message
+    pub fn reaction_removed(
+        proposal_id: ProposalId,
+        comment_id: CommentId,
+        reactor: Did,
+        emoji: String,
+    ) -> Self {
+        Self::ReactionRemoved {
+            proposal_id,
+            comment_id,
+            reactor,
+            emoji,
+        }
+    }
+
     /// Get a short description of this message type for logging
     pub fn message_type(&self) -> &'static str {
         match self {
@@ -192,6 +395,13 @@ impl GovernanceMessage {
             Self::ProposalCancelled { .. } => "ProposalCancelled",
             Self::DelegationCreated { .. } => "DelegationCreated",
             Self::DelegationRevoked { .. } => "DelegationRevoked",
+            Self::DeliberationStarted { .. } => "DeliberationStarted",
+            Self::DeliberationEnded { .. } => "DeliberationEnded",
+            Self::CommentCreated { .. } => "CommentCreated",
+            Self::CommentEdited { .. } => "CommentEdited",
+            Self::CommentDeleted { .. } => "CommentDeleted",
+            Self::ReactionAdded { .. } => "ReactionAdded",
+            Self::ReactionRemoved { .. } => "ReactionRemoved",
         }
     }
 

--- a/icn/crates/icn-governance/src/proposal.rs
+++ b/icn/crates/icn-governance/src/proposal.rs
@@ -637,7 +637,7 @@ impl Proposal {
                 if now < *ends_at {
                     anyhow::bail!(
                         "Deliberation period not yet ended ({} seconds remaining)",
-                        ends_at - now
+                        ends_at.saturating_sub(now)
                     );
                 }
             }
@@ -942,7 +942,7 @@ mod tests {
             },
         );
 
-        // Cannot force close from Draft (must be Open)
+        // Cannot force close from Draft (must be Deliberation or Open)
         assert!(proposal
             .force_close(crate::ProposalOutcome::Accepted, "Emergency".to_string())
             .is_err());

--- a/icn/crates/icn-governance/src/proposal.rs
+++ b/icn/crates/icn-governance/src/proposal.rs
@@ -31,8 +31,20 @@ impl std::fmt::Display for ProposalId {
 /// State of a proposal in its lifecycle
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ProposalState {
-    /// Draft proposal, not yet open for voting
+    /// Draft proposal, not yet open for discussion or voting
     Draft,
+
+    /// Open for deliberation (discussion before voting)
+    ///
+    /// During deliberation, members can comment, discuss, and refine the proposal.
+    /// No voting occurs during this phase. When deliberation ends, the proposal
+    /// transitions to Open for voting.
+    Deliberation {
+        /// When deliberation started
+        started_at: Timestamp,
+        /// When deliberation ends (and voting can begin)
+        ends_at: Timestamp,
+    },
 
     /// Open for voting
     Open {
@@ -86,9 +98,27 @@ pub enum ProposalState {
 }
 
 impl ProposalState {
+    /// Check if proposal is in draft state
+    pub fn is_draft(&self) -> bool {
+        matches!(self, ProposalState::Draft)
+    }
+
+    /// Check if proposal is in deliberation phase
+    pub fn is_deliberating(&self) -> bool {
+        matches!(self, ProposalState::Deliberation { .. })
+    }
+
     /// Check if proposal is open for voting
     pub fn is_open(&self) -> bool {
         matches!(self, ProposalState::Open { .. })
+    }
+
+    /// Check if proposal allows comments (deliberation or open for voting)
+    pub fn allows_comments(&self) -> bool {
+        matches!(
+            self,
+            ProposalState::Deliberation { .. } | ProposalState::Open { .. }
+        )
     }
 
     /// Check if proposal is closed (any terminal state)
@@ -104,11 +134,27 @@ impl ProposalState {
         )
     }
 
+    /// Get the timestamp when deliberation ends (if deliberating)
+    pub fn deliberation_ends_at(&self) -> Option<Timestamp> {
+        match self {
+            ProposalState::Deliberation { ends_at, .. } => Some(*ends_at),
+            _ => None,
+        }
+    }
+
     /// Get the timestamp when voting closes (if open)
     pub fn closes_at(&self) -> Option<Timestamp> {
         match self {
             ProposalState::Open { closes_at, .. } => Some(*closes_at),
             _ => None,
+        }
+    }
+
+    /// Check if deliberation period has ended (for transition to voting)
+    pub fn can_end_deliberation(&self, current_time: Timestamp) -> bool {
+        match self {
+            ProposalState::Deliberation { ends_at, .. } => current_time >= *ends_at,
+            _ => false,
         }
     }
 }
@@ -554,7 +600,88 @@ impl Proposal {
         }
     }
 
-    /// Open the proposal for voting
+    /// Start deliberation period for the proposal
+    ///
+    /// Transitions: Draft → Deliberation
+    ///
+    /// During deliberation, members can comment and discuss the proposal.
+    /// Voting is not yet open. Call `end_deliberation_and_open()` to
+    /// transition to voting when the deliberation period ends.
+    pub fn start_deliberation(&mut self, deliberation_period_seconds: u64) -> anyhow::Result<()> {
+        if !matches!(self.state, ProposalState::Draft) {
+            anyhow::bail!("Can only start deliberation from Draft state");
+        }
+
+        let now = icn_time::current_timestamp_secs();
+
+        self.state = ProposalState::Deliberation {
+            started_at: now,
+            ends_at: now + deliberation_period_seconds,
+        };
+        self.updated_at = now;
+
+        Ok(())
+    }
+
+    /// End deliberation and open for voting
+    ///
+    /// Transitions: Deliberation → Open
+    ///
+    /// Can only be called after the deliberation period has ended.
+    /// For early transition (before deliberation ends), use `force_end_deliberation()`.
+    pub fn end_deliberation_and_open(&mut self, voting_period_seconds: u64) -> anyhow::Result<()> {
+        let now = icn_time::current_timestamp_secs();
+
+        match &self.state {
+            ProposalState::Deliberation { ends_at, .. } => {
+                if now < *ends_at {
+                    anyhow::bail!(
+                        "Deliberation period not yet ended ({} seconds remaining)",
+                        ends_at - now
+                    );
+                }
+            }
+            _ => {
+                anyhow::bail!("Can only end deliberation from Deliberation state");
+            }
+        }
+
+        self.state = ProposalState::Open {
+            opened_at: now,
+            closes_at: now + voting_period_seconds,
+        };
+        self.updated_at = now;
+
+        Ok(())
+    }
+
+    /// Force end deliberation early and open for voting
+    ///
+    /// This is an administrative action that bypasses the deliberation timer.
+    /// Use with caution - deliberation exists to ensure adequate discussion.
+    pub fn force_end_deliberation(&mut self, voting_period_seconds: u64) -> anyhow::Result<()> {
+        if !matches!(self.state, ProposalState::Deliberation { .. }) {
+            anyhow::bail!("Can only force end deliberation from Deliberation state");
+        }
+
+        let now = icn_time::current_timestamp_secs();
+
+        self.state = ProposalState::Open {
+            opened_at: now,
+            closes_at: now + voting_period_seconds,
+        };
+        self.updated_at = now;
+
+        Ok(())
+    }
+
+    /// Open the proposal for voting directly (skip deliberation)
+    ///
+    /// Transitions: Draft → Open
+    ///
+    /// Use this when deliberation is not required (e.g., emergency proposals).
+    /// For normal proposals, prefer `start_deliberation()` followed by
+    /// `end_deliberation_and_open()`.
     pub fn open(&mut self, voting_period_seconds: u64) -> anyhow::Result<()> {
         if !matches!(self.state, ProposalState::Draft) {
             anyhow::bail!("Can only open proposals in Draft state");
@@ -588,6 +715,9 @@ impl Proposal {
     }
 
     /// Cancel the proposal
+    ///
+    /// Can cancel from Draft, Deliberation, or Open states.
+    /// Cannot cancel already closed proposals.
     pub fn cancel(&mut self) -> anyhow::Result<()> {
         if self.state.is_closed() {
             anyhow::bail!("Cannot cancel a closed proposal");
@@ -603,7 +733,7 @@ impl Proposal {
 
     /// Veto the proposal (emergency governance action)
     ///
-    /// Can be applied to proposals in Draft or Open state.
+    /// Can be applied to proposals in Draft, Deliberation, or Open state.
     /// Vetoed proposals cannot be reopened or executed.
     pub fn veto(&mut self, reason: String) -> anyhow::Result<()> {
         if self.state.is_closed() {
@@ -623,15 +753,15 @@ impl Proposal {
 
     /// Force close the proposal with a specified outcome
     ///
-    /// Can be applied to proposals in Open state only.
-    /// Used for emergency situations where normal voting cannot proceed.
+    /// Can be applied to proposals in Deliberation or Open state.
+    /// Used for emergency situations where normal process cannot proceed.
     pub fn force_close(
         &mut self,
         outcome: super::ProposalOutcome,
         reason: String,
     ) -> anyhow::Result<()> {
-        if !self.state.is_open() {
-            anyhow::bail!("Can only force close proposals in Open state");
+        if !self.state.is_open() && !self.state.is_deliberating() {
+            anyhow::bail!("Can only force close proposals in Deliberation or Open state");
         }
 
         let now = icn_time::current_timestamp_secs();

--- a/icn/crates/icn-rpc/src/handler/governance.rs
+++ b/icn/crates/icn-rpc/src/handler/governance.rs
@@ -124,6 +124,15 @@ pub async fn handle_governance_proposal_list(id: u64, state: &Arc<RpcServer>) ->
                 .map(|p| {
                     let (state_str, opened_at, closes_at, closed_at) = match &p.state {
                         ProposalState::Draft => ("draft".to_string(), None, None, None),
+                        ProposalState::Deliberation {
+                            started_at,
+                            ends_at,
+                        } => (
+                            "deliberation".to_string(),
+                            Some(*started_at),
+                            Some(*ends_at),
+                            None,
+                        ),
                         ProposalState::Open {
                             opened_at,
                             closes_at,
@@ -204,6 +213,15 @@ pub async fn handle_governance_proposal_get(
         Ok(Some(p)) => {
             let (state_str, opened_at, closes_at, closed_at) = match &p.state {
                 ProposalState::Draft => ("draft".to_string(), None, None, None),
+                ProposalState::Deliberation {
+                    started_at,
+                    ends_at,
+                } => (
+                    "deliberation".to_string(),
+                    Some(*started_at),
+                    Some(*ends_at),
+                    None,
+                ),
                 ProposalState::Open {
                     opened_at,
                     closes_at,
@@ -297,11 +315,11 @@ pub async fn handle_governance_domain_create(
         },
     };
 
-    let params_config = icn_governance::GovernanceParams {
-        quorum_percentage: request.params.quorum_percentage,
-        approval_threshold_percentage: request.params.approval_threshold_percentage,
-        voting_period_seconds: request.params.voting_period_seconds,
-    };
+    let params_config = icn_governance::GovernanceParams::new(
+        request.params.quorum_percentage,
+        request.params.approval_threshold_percentage,
+        request.params.voting_period_seconds,
+    );
 
     let domain_id = icn_governance::GovernanceDomainId(request.domain_id);
 


### PR DESCRIPTION
## Summary

Implements Phase 1 of the Programmable Democratic Governance plan, adding structured deliberation before voting on proposals.

### New Features
- **Deliberation State**: Proposals can now enter a `Deliberation` phase between `Draft` and `Open` states
- **Discussion System**: Full comment infrastructure with threaded replies and emoji reactions
- **API Endpoints**: 9 new endpoints for managing deliberation and comments
- **Notifications**: Email and push notifications for deliberation events

### Changes

**icn-governance:**
- Add `Deliberation { started_at, ends_at }` variant to `ProposalState`
- Add `start_deliberation()` and `end_deliberation_and_open()` methods to `Proposal`
- Create `discussion.rs` with `Comment`, `Discussion`, `DiscussionStore` types
- Add deliberation params to `GovernanceParams` config
- Add gossip messages: `DeliberationStarted`, `DeliberationEnded`, `CommentCreated`, etc.

**icn-gateway:**
- Add discussion storage and methods to `GovernanceManager`
- Add REST API endpoints:
  - `POST /gov/proposals/{id}/deliberation/start`
  - `POST /gov/proposals/{id}/deliberation/end`
  - `POST /gov/proposals/{id}/comments`
  - `GET /gov/proposals/{id}/comments`
  - `GET /gov/proposals/{id}/discussion`
  - `PUT /gov/comments/{id}`
  - `DELETE /gov/comments/{id}`
  - `POST /gov/comments/{id}/reactions`
  - `DELETE /gov/comments/{id}/reactions/{emoji}`
- Add notification triggers and email templates

**icn-rpc:**
- Handle `Deliberation` state in governance handler

## Test plan

- [x] All governance tests pass (33 tests)
- [x] All gateway tests pass (19+ tests)
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)