### PR TITLE
fix(k8s): Run icnd container as non-root user

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -94,15 +94,27 @@ spec:
           limits:
             cpu: "1"
             memory: 2Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         volumeMounts:
         - name: config
           mountPath: /etc/icn
           readOnly: true
         - name: data
           mountPath: /data
+        - name: tmp
+          mountPath: /tmp
       securityContext:
-        runAsUser: 0
-        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: config
         configMap:
@@ -110,4 +122,6 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: icn-data
+      - name: tmp
+        emptyDir: {}
 


### PR DESCRIPTION
## Summary

Addresses security concern by configuring the icnd deployment to run as non-root with restricted permissions.

## Changes

**Pod-level securityContext:**
- `runAsNonRoot: true` with UID/GID 1000
- `fsGroup: 1000` for PVC access
- `RuntimeDefault` seccomp profile

**Container-level securityContext:**
- `allowPrivilegeEscalation: false`
- `readOnlyRootFilesystem: true`
- All capabilities dropped

**Volume additions:**
- `/tmp` emptyDir volume for write access with read-only root FS

## Test plan

- [ ] Deploy to K3s cluster and verify pod starts successfully
- [ ] Check pod runs as UID 1000 (`kubectl exec icn-daemon-xxx -- id`)
- [ ] Verify health checks pass
- [ ] Confirm application functions correctly

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)