### PR TITLE
feat(sdk): Add typed error classes to TypeScript SDK

### DIFF
--- a/sdk/typescript/src/index.test.ts
+++ b/sdk/typescript/src/index.test.ts
@@ -2,7 +2,26 @@
  * ICN TypeScript SDK Tests
  */
 
-import { ICNClient, ICNError, ICNSubscription } from './index';
+import {
+  ICNClient,
+  ICNError,
+  ICNSubscription,
+  ErrorCode,
+  AuthenticationError,
+  TokenExpiredError,
+  InvalidCredentialsError,
+  AuthorizationError,
+  InsufficientPermissionsError,
+  ValidationError,
+  NotFoundError,
+  ConflictError,
+  RateLimitError,
+  NetworkError,
+  TimeoutError,
+  ConnectionError,
+  ServerError,
+  createErrorFromResponse,
+} from './index';
 
 describe('ICNClient', () => {
   describe('constructor', () => {
@@ -2338,5 +2357,254 @@ describe('device management', () => {
     const [, options] = mockFetch.mock.calls[0];
     const body = JSON.parse(options.body);
     expect(body.encryption_public_key).toBe('cafebabe...');
+  });
+});
+
+// ============================================================================
+// Error Classes Tests
+// ============================================================================
+
+describe('Error Classes', () => {
+  describe('ICNError', () => {
+    it('should create error with all properties', () => {
+      const error = new ICNError('Test error', 500, 'TEST_CODE', { foo: 'bar' });
+      expect(error.message).toBe('Test error');
+      expect(error.statusCode).toBe(500);
+      expect(error.code).toBe('TEST_CODE');
+      expect(error.details).toEqual({ foo: 'bar' });
+      expect(error.name).toBe('ICNError');
+    });
+
+    it('should be retryable for 5xx errors', () => {
+      expect(new ICNError('error', 500).isRetryable()).toBe(true);
+      expect(new ICNError('error', 502).isRetryable()).toBe(true);
+      expect(new ICNError('error', 503).isRetryable()).toBe(true);
+    });
+
+    it('should be retryable for timeout and rate limit', () => {
+      expect(new ICNError('error', 408).isRetryable()).toBe(true);
+      expect(new ICNError('error', 429).isRetryable()).toBe(true);
+    });
+
+    it('should not be retryable for client errors', () => {
+      expect(new ICNError('error', 400).isRetryable()).toBe(false);
+      expect(new ICNError('error', 401).isRetryable()).toBe(false);
+      expect(new ICNError('error', 403).isRetryable()).toBe(false);
+      expect(new ICNError('error', 404).isRetryable()).toBe(false);
+    });
+  });
+
+  describe('AuthenticationError', () => {
+    it('should have correct status code', () => {
+      const error = new AuthenticationError('Auth failed');
+      expect(error.statusCode).toBe(401);
+      expect(error.name).toBe('AuthenticationError');
+      expect(error instanceof ICNError).toBe(true);
+    });
+  });
+
+  describe('TokenExpiredError', () => {
+    it('should have default message', () => {
+      const error = new TokenExpiredError();
+      expect(error.message).toBe('Token has expired');
+      expect(error.code).toBe(ErrorCode.TOKEN_EXPIRED);
+      expect(error instanceof AuthenticationError).toBe(true);
+    });
+  });
+
+  describe('InvalidCredentialsError', () => {
+    it('should have default message', () => {
+      const error = new InvalidCredentialsError();
+      expect(error.message).toBe('Invalid credentials');
+      expect(error.code).toBe(ErrorCode.INVALID_CREDENTIALS);
+    });
+  });
+
+  describe('AuthorizationError', () => {
+    it('should have correct status code', () => {
+      const error = new AuthorizationError('Forbidden');
+      expect(error.statusCode).toBe(403);
+      expect(error.name).toBe('AuthorizationError');
+    });
+  });
+
+  describe('InsufficientPermissionsError', () => {
+    it('should store required permissions', () => {
+      const error = new InsufficientPermissionsError('Need perms', ['read', 'write']);
+      expect(error.requiredPermissions).toEqual(['read', 'write']);
+      expect(error.code).toBe(ErrorCode.INSUFFICIENT_PERMISSIONS);
+    });
+  });
+
+  describe('ValidationError', () => {
+    it('should store field errors', () => {
+      const error = new ValidationError('Validation failed', {
+        email: ['Invalid format'],
+        name: ['Required', 'Too short'],
+      });
+      expect(error.fields.email).toEqual(['Invalid format']);
+      expect(error.fields.name).toEqual(['Required', 'Too short']);
+    });
+
+    it('should get field errors', () => {
+      const error = new ValidationError('Validation failed', {
+        email: ['Invalid format'],
+      });
+      expect(error.getFieldErrors('email')).toEqual(['Invalid format']);
+      expect(error.getFieldErrors('unknown')).toEqual([]);
+    });
+
+    it('should check if field has errors', () => {
+      const error = new ValidationError('Validation failed', {
+        email: ['Invalid format'],
+      });
+      expect(error.hasFieldError('email')).toBe(true);
+      expect(error.hasFieldError('unknown')).toBe(false);
+    });
+  });
+
+  describe('NotFoundError', () => {
+    it('should store resource info', () => {
+      const error = new NotFoundError('User not found', 'user', 'user-123');
+      expect(error.statusCode).toBe(404);
+      expect(error.resourceType).toBe('user');
+      expect(error.resourceId).toBe('user-123');
+    });
+  });
+
+  describe('ConflictError', () => {
+    it('should have correct status code', () => {
+      const error = new ConflictError('Already exists');
+      expect(error.statusCode).toBe(409);
+      expect(error.code).toBe(ErrorCode.CONFLICT);
+    });
+  });
+
+  describe('RateLimitError', () => {
+    it('should store rate limit info', () => {
+      const error = new RateLimitError('Too many requests', 60, 100, 0);
+      expect(error.statusCode).toBe(429);
+      expect(error.retryAfter).toBe(60);
+      expect(error.limit).toBe(100);
+      expect(error.remaining).toBe(0);
+    });
+
+    it('should always be retryable', () => {
+      const error = new RateLimitError();
+      expect(error.isRetryable()).toBe(true);
+    });
+  });
+
+  describe('NetworkError', () => {
+    it('should have status code 0 by default', () => {
+      const error = new NetworkError('Network failed');
+      expect(error.statusCode).toBe(0);
+      expect(error.isRetryable()).toBe(true);
+    });
+  });
+
+  describe('TimeoutError', () => {
+    it('should have status code 408', () => {
+      const error = new TimeoutError('Timeout', 5000);
+      expect(error.statusCode).toBe(408);
+      expect(error.timeoutMs).toBe(5000);
+      expect(error instanceof NetworkError).toBe(true);
+    });
+  });
+
+  describe('ConnectionError', () => {
+    it('should have correct code', () => {
+      const error = new ConnectionError();
+      expect(error.code).toBe(ErrorCode.CONNECTION_FAILED);
+      expect(error instanceof NetworkError).toBe(true);
+    });
+  });
+
+  describe('ServerError', () => {
+    it('should accept custom status code', () => {
+      const error = new ServerError('Bad Gateway', 502);
+      expect(error.statusCode).toBe(502);
+      expect(error.isRetryable()).toBe(true);
+    });
+  });
+});
+
+describe('createErrorFromResponse', () => {
+  it('should create AuthenticationError for 401', () => {
+    const error = createErrorFromResponse(401, 'Unauthorized');
+    expect(error).toBeInstanceOf(AuthenticationError);
+    expect(error.statusCode).toBe(401);
+  });
+
+  it('should create TokenExpiredError for 401 with TOKEN_EXPIRED code', () => {
+    const error = createErrorFromResponse(401, 'Token expired', ErrorCode.TOKEN_EXPIRED);
+    expect(error).toBeInstanceOf(TokenExpiredError);
+  });
+
+  it('should create AuthorizationError for 403', () => {
+    const error = createErrorFromResponse(403, 'Forbidden');
+    expect(error).toBeInstanceOf(AuthorizationError);
+  });
+
+  it('should create InsufficientPermissionsError with permissions', () => {
+    const error = createErrorFromResponse(
+      403,
+      'Need permissions',
+      ErrorCode.INSUFFICIENT_PERMISSIONS,
+      { required_permissions: ['admin'] }
+    );
+    expect(error).toBeInstanceOf(InsufficientPermissionsError);
+    expect((error as InsufficientPermissionsError).requiredPermissions).toEqual(['admin']);
+  });
+
+  it('should create NotFoundError for 404', () => {
+    const error = createErrorFromResponse(404, 'Not found', undefined, {
+      resource_type: 'user',
+      resource_id: '123',
+    });
+    expect(error).toBeInstanceOf(NotFoundError);
+    expect((error as NotFoundError).resourceType).toBe('user');
+    expect((error as NotFoundError).resourceId).toBe('123');
+  });
+
+  it('should create TimeoutError for 408', () => {
+    const error = createErrorFromResponse(408, 'Timeout');
+    expect(error).toBeInstanceOf(TimeoutError);
+  });
+
+  it('should create ConflictError for 409', () => {
+    const error = createErrorFromResponse(409, 'Conflict');
+    expect(error).toBeInstanceOf(ConflictError);
+  });
+
+  it('should create RateLimitError for 429', () => {
+    const error = createErrorFromResponse(429, 'Too many requests', undefined, {
+      retry_after: 30,
+      limit: 100,
+      remaining: 0,
+    });
+    expect(error).toBeInstanceOf(RateLimitError);
+    expect((error as RateLimitError).retryAfter).toBe(30);
+    expect((error as RateLimitError).limit).toBe(100);
+  });
+
+  it('should create ServerError for 5xx', () => {
+    const error = createErrorFromResponse(500, 'Internal error');
+    expect(error).toBeInstanceOf(ServerError);
+    expect(error.isRetryable()).toBe(true);
+  });
+
+  it('should create ValidationError for 400 with VALIDATION_FAILED', () => {
+    const error = createErrorFromResponse(400, 'Validation failed', ErrorCode.VALIDATION_FAILED, {
+      fields: { email: ['Invalid format'] },
+    });
+    expect(error).toBeInstanceOf(ValidationError);
+    expect((error as ValidationError).fields.email).toEqual(['Invalid format']);
+  });
+
+  it('should create generic ICNError for unknown status', () => {
+    const error = createErrorFromResponse(418, "I'm a teapot");
+    expect(error).toBeInstanceOf(ICNError);
+    expect(error.statusCode).toBe(418);
   });
 });

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -37,6 +37,11 @@ declare const WebSocket: {
 import {
   ICNClientOptions,
   ICNError,
+  ErrorCode,
+  createErrorFromResponse,
+  AuthenticationError,
+  TimeoutError,
+  NetworkError,
   ChallengeResponse,
   VerifyResponse,
   Cooperative,
@@ -411,7 +416,7 @@ export class ICNClient {
 
     if (requireAuth) {
       if (!this.token) {
-        throw new ICNError('Authentication required', 401);
+        throw new AuthenticationError('Authentication required', ErrorCode.AUTHENTICATION_REQUIRED);
       }
       headers['Authorization'] = `Bearer ${this.token}`;
     }
@@ -431,9 +436,9 @@ export class ICNClient {
 
       if (!response.ok) {
         const errorBody = await response.json().catch(() => ({})) as { error?: string; code?: string; details?: unknown };
-        throw new ICNError(
-          errorBody.error || response.statusText,
+        throw createErrorFromResponse(
           response.status,
+          errorBody.error || response.statusText,
           errorBody.code,
           errorBody.details
         );
@@ -450,9 +455,9 @@ export class ICNClient {
         throw error;
       }
       if ((error as Error).name === 'AbortError') {
-        throw new ICNError('Request timeout', 408);
+        throw new TimeoutError('Request timeout', this.timeout);
       }
-      throw new ICNError((error as Error).message, 0);
+      throw new NetworkError((error as Error).message, ErrorCode.NETWORK_ERROR);
     }
   }
 
@@ -956,7 +961,7 @@ export class ICNClient {
       }
       await new Promise((resolve) => setTimeout(resolve, intervalMs));
     }
-    throw new ICNError('Task polling timeout', 408);
+    throw new TimeoutError('Task polling timeout');
   }
 
   /**

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -461,6 +461,48 @@ export interface ApiError {
   details?: unknown;
 }
 
+/**
+ * Error codes for ICN API errors
+ */
+export enum ErrorCode {
+  // Authentication errors
+  TOKEN_EXPIRED = 'TOKEN_EXPIRED',
+  INVALID_CREDENTIALS = 'INVALID_CREDENTIALS',
+  INVALID_TOKEN = 'INVALID_TOKEN',
+  AUTHENTICATION_REQUIRED = 'AUTHENTICATION_REQUIRED',
+
+  // Authorization errors
+  INSUFFICIENT_PERMISSIONS = 'INSUFFICIENT_PERMISSIONS',
+  FORBIDDEN = 'FORBIDDEN',
+
+  // Validation errors
+  VALIDATION_FAILED = 'VALIDATION_FAILED',
+  INVALID_DID = 'INVALID_DID',
+  INVALID_SCOPE = 'INVALID_SCOPE',
+  INVALID_EXPIRATION = 'INVALID_EXPIRATION',
+  INVALID_REQUEST = 'INVALID_REQUEST',
+
+  // Resource errors
+  NOT_FOUND = 'NOT_FOUND',
+  ALREADY_EXISTS = 'ALREADY_EXISTS',
+  CONFLICT = 'CONFLICT',
+
+  // Rate limiting
+  RATE_LIMITED = 'RATE_LIMITED',
+
+  // Network errors
+  NETWORK_ERROR = 'NETWORK_ERROR',
+  TIMEOUT = 'TIMEOUT',
+  CONNECTION_FAILED = 'CONNECTION_FAILED',
+
+  // Server errors
+  INTERNAL_ERROR = 'INTERNAL_ERROR',
+  SERVICE_UNAVAILABLE = 'SERVICE_UNAVAILABLE',
+}
+
+/**
+ * Base error class for all ICN SDK errors
+ */
 export class ICNError extends Error {
   public readonly statusCode: number;
   public readonly code?: string;
@@ -472,6 +514,294 @@ export class ICNError extends Error {
     this.statusCode = statusCode;
     this.code = code;
     this.details = details;
+  }
+
+  /**
+   * Check if this error is retryable
+   */
+  isRetryable(): boolean {
+    return (
+      this.statusCode >= 500 ||
+      this.statusCode === 408 ||
+      this.statusCode === 429 ||
+      this.code === ErrorCode.TIMEOUT ||
+      this.code === ErrorCode.CONNECTION_FAILED
+    );
+  }
+}
+
+// ============================================================================
+// Authentication Errors (401)
+// ============================================================================
+
+/**
+ * Authentication error - credentials invalid or missing
+ */
+export class AuthenticationError extends ICNError {
+  constructor(message: string, code?: string, details?: unknown) {
+    super(message, 401, code || ErrorCode.AUTHENTICATION_REQUIRED, details);
+    this.name = 'AuthenticationError';
+  }
+}
+
+/**
+ * Token has expired and needs to be refreshed
+ */
+export class TokenExpiredError extends AuthenticationError {
+  constructor(message = 'Token has expired', details?: unknown) {
+    super(message, ErrorCode.TOKEN_EXPIRED, details);
+    this.name = 'TokenExpiredError';
+  }
+}
+
+/**
+ * Invalid credentials provided
+ */
+export class InvalidCredentialsError extends AuthenticationError {
+  constructor(message = 'Invalid credentials', details?: unknown) {
+    super(message, ErrorCode.INVALID_CREDENTIALS, details);
+    this.name = 'InvalidCredentialsError';
+  }
+}
+
+// ============================================================================
+// Authorization Errors (403)
+// ============================================================================
+
+/**
+ * Authorization error - insufficient permissions
+ */
+export class AuthorizationError extends ICNError {
+  constructor(message: string, code?: string, details?: unknown) {
+    super(message, 403, code || ErrorCode.FORBIDDEN, details);
+    this.name = 'AuthorizationError';
+  }
+}
+
+/**
+ * User lacks required permissions for the operation
+ */
+export class InsufficientPermissionsError extends AuthorizationError {
+  public readonly requiredPermissions?: string[];
+
+  constructor(message = 'Insufficient permissions', requiredPermissions?: string[], details?: unknown) {
+    super(message, ErrorCode.INSUFFICIENT_PERMISSIONS, details);
+    this.name = 'InsufficientPermissionsError';
+    this.requiredPermissions = requiredPermissions;
+  }
+}
+
+// ============================================================================
+// Validation Errors (400)
+// ============================================================================
+
+/**
+ * Validation error with field-level details
+ */
+export class ValidationError extends ICNError {
+  public readonly fields: Record<string, string[]>;
+
+  constructor(message: string, fields: Record<string, string[]> = {}, details?: unknown) {
+    super(message, 400, ErrorCode.VALIDATION_FAILED, details);
+    this.name = 'ValidationError';
+    this.fields = fields;
+  }
+
+  /**
+   * Get all error messages for a specific field
+   */
+  getFieldErrors(field: string): string[] {
+    return this.fields[field] || [];
+  }
+
+  /**
+   * Check if a specific field has errors
+   */
+  hasFieldError(field: string): boolean {
+    return field in this.fields && this.fields[field].length > 0;
+  }
+}
+
+// ============================================================================
+// Resource Errors (404, 409)
+// ============================================================================
+
+/**
+ * Resource not found
+ */
+export class NotFoundError extends ICNError {
+  public readonly resourceType?: string;
+  public readonly resourceId?: string;
+
+  constructor(message: string, resourceType?: string, resourceId?: string, details?: unknown) {
+    super(message, 404, ErrorCode.NOT_FOUND, details);
+    this.name = 'NotFoundError';
+    this.resourceType = resourceType;
+    this.resourceId = resourceId;
+  }
+}
+
+/**
+ * Resource already exists (conflict)
+ */
+export class ConflictError extends ICNError {
+  constructor(message: string, code?: string, details?: unknown) {
+    super(message, 409, code || ErrorCode.CONFLICT, details);
+    this.name = 'ConflictError';
+  }
+}
+
+// ============================================================================
+// Rate Limiting Errors (429)
+// ============================================================================
+
+/**
+ * Rate limit exceeded
+ */
+export class RateLimitError extends ICNError {
+  public readonly retryAfter?: number;
+  public readonly limit?: number;
+  public readonly remaining?: number;
+
+  constructor(
+    message = 'Rate limit exceeded',
+    retryAfter?: number,
+    limit?: number,
+    remaining?: number,
+    details?: unknown
+  ) {
+    super(message, 429, ErrorCode.RATE_LIMITED, details);
+    this.name = 'RateLimitError';
+    this.retryAfter = retryAfter;
+    this.limit = limit;
+    this.remaining = remaining;
+  }
+
+  isRetryable(): boolean {
+    return true;
+  }
+}
+
+// ============================================================================
+// Network Errors (0, 408)
+// ============================================================================
+
+/**
+ * Network-level error
+ */
+export class NetworkError extends ICNError {
+  constructor(message: string, code?: string, details?: unknown) {
+    super(message, 0, code || ErrorCode.NETWORK_ERROR, details);
+    this.name = 'NetworkError';
+  }
+
+  isRetryable(): boolean {
+    return true;
+  }
+}
+
+/**
+ * Request timeout
+ */
+export class TimeoutError extends NetworkError {
+  public readonly timeoutMs?: number;
+
+  constructor(message = 'Request timeout', timeoutMs?: number, details?: unknown) {
+    super(message, ErrorCode.TIMEOUT, details);
+    this.name = 'TimeoutError';
+    this.timeoutMs = timeoutMs;
+    // Override status code for timeout
+    (this as { statusCode: number }).statusCode = 408;
+  }
+}
+
+/**
+ * Connection failed
+ */
+export class ConnectionError extends NetworkError {
+  constructor(message = 'Connection failed', details?: unknown) {
+    super(message, ErrorCode.CONNECTION_FAILED, details);
+    this.name = 'ConnectionError';
+  }
+}
+
+// ============================================================================
+// Server Errors (500+)
+// ============================================================================
+
+/**
+ * Internal server error
+ */
+export class ServerError extends ICNError {
+  constructor(message: string, statusCode = 500, code?: string, details?: unknown) {
+    super(message, statusCode, code || ErrorCode.INTERNAL_ERROR, details);
+    this.name = 'ServerError';
+  }
+
+  isRetryable(): boolean {
+    return true;
+  }
+}
+
+// ============================================================================
+// Error Factory
+// ============================================================================
+
+/**
+ * Create a typed error from an API response
+ */
+export function createErrorFromResponse(
+  statusCode: number,
+  message: string,
+  code?: string,
+  details?: unknown
+): ICNError {
+  switch (statusCode) {
+    case 400:
+      if (code === ErrorCode.VALIDATION_FAILED) {
+        const fields = (details as { fields?: Record<string, string[]> })?.fields || {};
+        return new ValidationError(message, fields, details);
+      }
+      return new ICNError(message, statusCode, code, details);
+
+    case 401:
+      if (code === ErrorCode.TOKEN_EXPIRED) {
+        return new TokenExpiredError(message, details);
+      }
+      if (code === ErrorCode.INVALID_CREDENTIALS) {
+        return new InvalidCredentialsError(message, details);
+      }
+      return new AuthenticationError(message, code, details);
+
+    case 403:
+      if (code === ErrorCode.INSUFFICIENT_PERMISSIONS) {
+        const permissions = (details as { required_permissions?: string[] })?.required_permissions;
+        return new InsufficientPermissionsError(message, permissions, details);
+      }
+      return new AuthorizationError(message, code, details);
+
+    case 404:
+      const resourceType = (details as { resource_type?: string })?.resource_type;
+      const resourceId = (details as { resource_id?: string })?.resource_id;
+      return new NotFoundError(message, resourceType, resourceId, details);
+
+    case 408:
+      return new TimeoutError(message, undefined, details);
+
+    case 409:
+      return new ConflictError(message, code, details);
+
+    case 429:
+      const retryAfter = (details as { retry_after?: number })?.retry_after;
+      const limit = (details as { limit?: number })?.limit;
+      const remaining = (details as { remaining?: number })?.remaining;
+      return new RateLimitError(message, retryAfter, limit, remaining, details);
+
+    default:
+      if (statusCode >= 500) {
+        return new ServerError(message, statusCode, code, details);
+      }
+      return new ICNError(message, statusCode, code, details);
   }
 }
 

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -690,8 +690,8 @@ export class RateLimitError extends ICNError {
  * Network-level error
  */
 export class NetworkError extends ICNError {
-  constructor(message: string, code?: string, details?: unknown) {
-    super(message, 0, code || ErrorCode.NETWORK_ERROR, details);
+  constructor(message: string, code?: string, details?: unknown, statusCode = 0) {
+    super(message, statusCode, code || ErrorCode.NETWORK_ERROR, details);
     this.name = 'NetworkError';
   }
 
@@ -707,11 +707,9 @@ export class TimeoutError extends NetworkError {
   public readonly timeoutMs?: number;
 
   constructor(message = 'Request timeout', timeoutMs?: number, details?: unknown) {
-    super(message, ErrorCode.TIMEOUT, details);
+    super(message, ErrorCode.TIMEOUT, details, 408);
     this.name = 'TimeoutError';
     this.timeoutMs = timeoutMs;
-    // Override status code for timeout
-    (this as { statusCode: number }).statusCode = 408;
   }
 }
 


### PR DESCRIPTION
## Summary

Implements comprehensive error class hierarchy for better developer experience and programmatic error handling.

## Error Classes Added

| Error Class | Status Code | Use Case |
|-------------|-------------|----------|
| `AuthenticationError` | 401 | Auth failures |
| `TokenExpiredError` | 401 | Token needs refresh |
| `InvalidCredentialsError` | 401 | Wrong credentials |
| `AuthorizationError` | 403 | Permission denied |
| `InsufficientPermissionsError` | 403 | Missing permissions |
| `ValidationError` | 400 | Input validation |
| `NotFoundError` | 404 | Resource not found |
| `ConflictError` | 409 | Already exists |
| `RateLimitError` | 429 | Rate limited |
| `NetworkError` | 0 | Network issues |
| `TimeoutError` | 408 | Request timeout |
| `ConnectionError` | 0 | Connection failed |
| `ServerError` | 5xx | Server errors |

## Features

- `ErrorCode` enum for programmatic handling
- `isRetryable()` method on all errors
- `createErrorFromResponse()` factory function
- `ValidationError.getFieldErrors(field)` helper
- `RateLimitError` exposes `retryAfter`, `limit`, `remaining`

## Usage Example

```typescript
try {
  await client.getBalance(coopId, did);
} catch (error) {
  if (error instanceof TokenExpiredError) {
    await refreshToken();
  } else if (error instanceof RateLimitError) {
    await sleep(error.retryAfter * 1000);
  } else if (error instanceof ValidationError) {
    console.log(error.getFieldErrors('amount'));
  }
}
```

## Test Plan

- [x] All 94 existing SDK tests pass
- [x] TypeScript builds successfully
- [ ] CI passes

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)