### PR TITLE
fix(oracle): Address code review follow-up items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added - Exchange Rate Oracle (2025-12-30)
+
+**Multi-Currency Support for Cooperative Economies** (PR #364):
+- Exchange rate oracle with multi-source aggregation using median consensus
+- Automatic inverse rate calculation when direct pair unavailable
+- TTL-based caching (1h) with staleness detection (24h threshold)
+- Rate audit trail for governance transparency
+
+**Rate Sources**:
+- `ManualRateSource` (priority 10): Cooperative-defined rates via governance
+- `FederationRateSource` (priority 20): Rates from bilateral clearing agreements
+- Median consensus with 15% outlier detection prevents manipulation
+
+**Gateway API** (`/v1/oracle/`):
+- `GET /rate/{from}/{to}` - Get exchange rate (with inverse fallback)
+- `POST /convert` - Convert amount between currencies
+- `GET /sources` - List available rate sources
+- `POST /rate` - Set manual rate (requires `oracle:write` scope)
+
+**TypeScript SDK**:
+- `getExchangeRate()`, `convertAmount()`, `listRateSources()`, `setManualRate()`
+- Full type definitions for all oracle operations
+
+**Metrics**:
+- `oracle_rate_queries_total`, `oracle_conversions_total`, `oracle_stale_rates_total`
+- Cache hit/miss tracking, outlier filtering counts
+
 ### Added - New Member Credit Limit Ramping (2025-12-25)
 
 **Member-Since Tracking for Economic Safety** (PR #293):

--- a/icn/crates/icn-ledger/src/oracle/sources/federation.rs
+++ b/icn/crates/icn-ledger/src/oracle/sources/federation.rs
@@ -68,7 +68,22 @@ impl FederationRateSource {
     }
 
     /// Add or update a single rate
-    pub async fn set_rate(&self, from: &str, to: &str, rate: f64, agreement_id: &str) {
+    ///
+    /// Returns an error if the rate is invalid (NaN, infinity, zero, or negative).
+    pub async fn set_rate(
+        &self,
+        from: &str,
+        to: &str,
+        rate: f64,
+        agreement_id: &str,
+    ) -> OracleResult<()> {
+        // Validate rate
+        if rate <= 0.0 || !rate.is_finite() {
+            return Err(OracleError::InvalidRate(format!(
+                "Rate must be a positive finite number, got: {rate}"
+            )));
+        }
+
         let mut rates = self.rates.write().await;
         let key = format!("{from}:{to}");
         rates.insert(
@@ -79,6 +94,7 @@ impl FederationRateSource {
                 timestamp: crate::current_timestamp_secs(),
             },
         );
+        Ok(())
     }
 
     /// Remove a rate
@@ -171,7 +187,10 @@ mod tests {
         let source = FederationRateSource::new();
 
         // Set a rate
-        source.set_rate("hours", "USD", 25.0, "agreement-1").await;
+        source
+            .set_rate("hours", "USD", 25.0, "agreement-1")
+            .await
+            .expect("should set rate");
 
         // Get it back
         let pair = CurrencyPair::new("hours", "USD");
@@ -224,7 +243,10 @@ mod tests {
         let source = FederationRateSource::new();
 
         // Set and remove
-        source.set_rate("hours", "USD", 25.0, "agreement-1").await;
+        source
+            .set_rate("hours", "USD", 25.0, "agreement-1")
+            .await
+            .expect("should set rate");
         assert!(source.supports_pair(&CurrencyPair::new("hours", "USD")));
 
         source.remove_rate("hours", "USD").await;
@@ -245,5 +267,30 @@ mod tests {
         let source = FederationRateSource::new();
         assert_eq!(source.priority(), 20);
         assert_eq!(source.source_id(), "federation");
+    }
+
+    #[tokio::test]
+    async fn test_invalid_rate() {
+        let source = FederationRateSource::new();
+
+        // Negative rate
+        let result = source.set_rate("hours", "USD", -25.0, "agreement-1").await;
+        assert!(matches!(result, Err(OracleError::InvalidRate(_))));
+
+        // Zero rate
+        let result = source.set_rate("hours", "USD", 0.0, "agreement-1").await;
+        assert!(matches!(result, Err(OracleError::InvalidRate(_))));
+
+        // NaN rate
+        let result = source
+            .set_rate("hours", "USD", f64::NAN, "agreement-1")
+            .await;
+        assert!(matches!(result, Err(OracleError::InvalidRate(_))));
+
+        // Infinity rate
+        let result = source
+            .set_rate("hours", "USD", f64::INFINITY, "agreement-1")
+            .await;
+        assert!(matches!(result, Err(OracleError::InvalidRate(_))));
     }
 }

--- a/icn/crates/icn-ledger/src/oracle/types.rs
+++ b/icn/crates/icn-ledger/src/oracle/types.rs
@@ -120,19 +120,29 @@ impl ExchangeRate {
     /// Convert an amount from source to target currency
     ///
     /// Returns `None` if the conversion would overflow i64 bounds.
+    /// Uses a 1% safety margin to account for floating-point precision issues.
     pub fn convert(&self, amount: i64) -> Option<i64> {
         let result = (amount as f64) * self.rate;
-        // Check for overflow before casting
-        if result > i64::MAX as f64 || result < i64::MIN as f64 {
+        // Check for non-finite results (NaN, infinity)
+        if !result.is_finite() {
+            return None;
+        }
+        // Use 99% of i64 bounds as safety margin for floating-point precision
+        const SAFETY_MARGIN: f64 = 0.99;
+        let max_safe = i64::MAX as f64 * SAFETY_MARGIN;
+        let min_safe = i64::MIN as f64 * SAFETY_MARGIN;
+        if result > max_safe || result < min_safe {
             return None;
         }
         Some(result.round() as i64)
     }
 
     /// Convert an amount, saturating at i64 bounds on overflow
+    ///
+    /// Returns i64::MAX or i64::MIN for values that overflow or are non-finite.
     pub fn convert_saturating(&self, amount: i64) -> i64 {
         let result = (amount as f64) * self.rate;
-        if result > i64::MAX as f64 {
+        if !result.is_finite() || result > i64::MAX as f64 {
             i64::MAX
         } else if result < i64::MIN as f64 {
             i64::MIN

--- a/icn/crates/icn-ledger/src/oracle/types.rs
+++ b/icn/crates/icn-ledger/src/oracle/types.rs
@@ -318,6 +318,46 @@ mod tests {
     }
 
     #[test]
+    fn test_exchange_rate_convert_safety_margin() {
+        // Test that values between 99% and 100% of i64 bounds return None
+        // due to the safety margin for floating-point precision
+        let rate = ExchangeRate {
+            pair: CurrencyPair::new("hours", "USD"),
+            rate: 1.0,
+            observations: vec![],
+            aggregated_at: 0,
+            ttl_secs: 3600,
+            is_stale: false,
+        };
+
+        // Value at exactly i64::MAX should return None (beyond 99% margin)
+        assert_eq!(rate.convert(i64::MAX), None);
+
+        // Value at 98% of i64::MAX should succeed (within 99% margin)
+        let safe_amount = (i64::MAX as f64 * 0.98) as i64;
+        assert!(rate.convert(safe_amount).is_some());
+
+        // Test negative overflow with safety margin
+        assert_eq!(rate.convert(i64::MIN), None);
+
+        // Value at 98% of i64::MIN should succeed
+        let safe_negative = (i64::MIN as f64 * 0.98) as i64;
+        assert!(rate.convert(safe_negative).is_some());
+
+        // Test with rate = 2.0 and i64::MIN (negative overflow)
+        let rate2 = ExchangeRate {
+            pair: CurrencyPair::new("hours", "USD"),
+            rate: 2.0,
+            observations: vec![],
+            aggregated_at: 0,
+            ttl_secs: 3600,
+            is_stale: false,
+        };
+        assert_eq!(rate2.convert(i64::MIN), None);
+        assert_eq!(rate2.convert_saturating(i64::MIN), i64::MIN);
+    }
+
+    #[test]
     fn test_exchange_rate_inverse() {
         let rate = ExchangeRate {
             pair: CurrencyPair::new("hours", "USD"),


### PR DESCRIPTION
## Summary

Addresses remaining code review feedback from PR #364 (Exchange Rate Oracle):

1. **CHANGELOG entry**: Added comprehensive entry documenting oracle feature
2. **FederationRateSource validation**: `set_rate()` now validates for NaN, infinity, negative, and zero rates (returns `OracleResult`)
3. **Overflow safety**: `convert()` uses 1% safety margin to account for floating-point precision issues near i64 bounds

## Changes

- `CHANGELOG.md`: Added Exchange Rate Oracle section
- `federation.rs`: Added rate validation to `set_rate()` + new test
- `types.rs`: Added safety margin and non-finite checks to `convert()` and `convert_saturating()`

## Test plan

- [x] 31 oracle tests pass (added test_invalid_rate for federation)
- [x] Clippy clean
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)