### PR TITLE
feat(ledger): Add cross-currency payment support

### DIFF
--- a/icn/crates/icn-gateway/src/api/ledger.rs
+++ b/icn/crates/icn-gateway/src/api/ledger.rs
@@ -9,7 +9,8 @@ use crate::error::{GatewayError, Result};
 use crate::ledger_mgr::LedgerManager;
 use crate::middleware::{get_claims, require_coop_access, require_scope};
 use crate::models::{
-    AccountDeltaResponse, BalanceResponse, CreatePaymentRequest, TransactionHistoryEntry,
+    AccountDeltaResponse, BalanceResponse, CreateCrossPaymentRequest, CreatePaymentRequest,
+    CrossPaymentQuoteRequest, TransactionHistoryEntry,
 };
 use crate::rate_limit::VelocityLimiter;
 use crate::trust_mgr::TrustManager;
@@ -367,6 +368,146 @@ pub async fn get_history(
     };
 
     Ok(HttpResponse::Ok().json(response))
+}
+
+/// POST /ledger/:coop_id/payment/convert - Create a cross-currency payment
+///
+/// Executes a payment where the sender pays in one currency and the recipient
+/// receives in another. Uses the exchange rate oracle for conversion.
+#[post("/{coop_id}/payment/convert")]
+pub async fn create_cross_payment(
+    http_req: HttpRequest,
+    ledger_mgr: web::Data<Arc<LedgerManager>>,
+    budget_store: web::Data<BudgetStore>,
+    velocity_limiter: web::Data<VelocityLimiter>,
+    trust_mgr: web::Data<Arc<TrustManager>>,
+    coop_id: web::Path<String>,
+    req: web::Json<CreateCrossPaymentRequest>,
+) -> Result<HttpResponse> {
+    // Check authorization
+    require_scope(&http_req, "ledger:write")?;
+    require_coop_access(&http_req, &coop_id)?;
+
+    // Verify authenticated DID matches payment sender
+    let claims = get_claims(&http_req)
+        .ok_or_else(|| GatewayError::AuthenticationFailed("No claims found".to_string()))?;
+
+    if claims.sub != req.from {
+        return Err(GatewayError::AuthorizationFailed(format!(
+            "Cannot create payments from other accounts (authenticated as {}, attempted to send from {})",
+            claims.sub, req.from
+        )));
+    }
+
+    let from = req
+        .from
+        .parse()
+        .map_err(|e| GatewayError::BadRequest(format!("Invalid from DID: {e}")))?;
+
+    let to = req
+        .to
+        .parse()
+        .map_err(|e| GatewayError::BadRequest(format!("Invalid to DID: {e}")))?;
+
+    // Prevent self-payments
+    if from == to {
+        return Err(GatewayError::BadRequest(
+            "Self-payments not allowed (sender and recipient cannot be the same)".to_string(),
+        ));
+    }
+
+    // Validate cross-currency specific: currencies must differ
+    if req.from_currency == req.to_currency {
+        return Err(GatewayError::BadRequest(
+            "For same-currency payments, use /payment endpoint instead".to_string(),
+        ));
+    }
+
+    // Validate input fields
+    validation::validate_payment_amount(req.amount)?;
+    validation::validate_currency(&req.from_currency)?;
+    validation::validate_currency(&req.to_currency)?;
+    validation::validate_memo(&req.memo)?;
+
+    // Check budget limits
+    let can_spend = budget_store
+        .check_spending(&req.from, req.amount)
+        .map_err(|e| GatewayError::InternalError(e.to_string()))?;
+    if !can_spend {
+        return Err(GatewayError::BadRequest(
+            "Payment exceeds budget limit".to_string(),
+        ));
+    }
+
+    // Check transaction velocity limit
+    let trust_score = trust_mgr.compute_trust_score_for_velocity(&from).await;
+    velocity_limiter.check_and_record(&req.from, trust_score)?;
+
+    // Execute the cross-currency payment
+    let response = ledger_mgr
+        .create_cross_payment(
+            &coop_id,
+            &from,
+            &to,
+            req.amount,
+            &req.from_currency,
+            &req.to_currency,
+            req.max_target_amount,
+            req.memo.clone(),
+        )
+        .await?;
+
+    // Record spending in budget tracker
+    let notified_budgets = budget_store
+        .record_spending(&req.from, req.amount)
+        .map_err(|e| GatewayError::InternalError(e.to_string()))?;
+    if !notified_budgets.is_empty() {
+        info!(
+            budgets = ?notified_budgets,
+            "Budget threshold notifications triggered"
+        );
+    }
+
+    // Track metrics
+    gateway::payments_created_inc();
+    gateway::payment_amount_record(&req.from_currency, req.amount);
+
+    Ok(HttpResponse::Created().json(response))
+}
+
+/// POST /ledger/:coop_id/payment/convert/quote - Get a cross-currency payment quote
+///
+/// Returns a preview of what a cross-currency payment would look like without
+/// actually executing it. Useful for showing users the expected conversion.
+#[post("/{coop_id}/payment/convert/quote")]
+pub async fn get_cross_payment_quote(
+    http_req: HttpRequest,
+    ledger_mgr: web::Data<Arc<LedgerManager>>,
+    coop_id: web::Path<String>,
+    req: web::Json<CrossPaymentQuoteRequest>,
+) -> Result<HttpResponse> {
+    // Check authorization
+    require_scope(&http_req, "ledger:read")?;
+    require_coop_access(&http_req, &coop_id)?;
+
+    // Validate currencies must differ
+    if req.from_currency == req.to_currency {
+        return Err(GatewayError::BadRequest(
+            "Quote requires different currencies".to_string(),
+        ));
+    }
+
+    // Validate input fields
+    validation::validate_payment_amount(req.amount)?;
+    validation::validate_currency(&req.from_currency)?;
+    validation::validate_currency(&req.to_currency)?;
+
+    // Get the quote
+    let quote = ledger_mgr
+        .get_cross_payment_quote(&coop_id, req.amount, &req.from_currency, &req.to_currency)
+        .await?;
+
+    Ok(HttpResponse::Ok().json(quote))
 }
 
 #[cfg(test)]

--- a/icn/crates/icn-gateway/src/api/ledger.rs
+++ b/icn/crates/icn-gateway/src/api/ledger.rs
@@ -472,6 +472,12 @@ pub async fn create_cross_payment(
     gateway::payments_created_inc();
     gateway::payment_amount_record(&req.from_currency, req.amount);
 
+    // Track FX-specific metrics
+    gateway::fx_payments_total_inc(&req.from_currency, &req.to_currency);
+    gateway::fx_payment_source_amount_record(&req.from_currency, req.amount);
+    gateway::fx_payment_target_amount_record(&req.to_currency, response.net_target_amount);
+    gateway::fx_payment_fee_amount_record(&req.to_currency, response.fee_amount);
+
     Ok(HttpResponse::Created().json(response))
 }
 
@@ -506,6 +512,9 @@ pub async fn get_cross_payment_quote(
     let quote = ledger_mgr
         .get_cross_payment_quote(&coop_id, req.amount, &req.from_currency, &req.to_currency)
         .await?;
+
+    // Track FX quote metrics
+    gateway::fx_quote_requests_inc(&req.from_currency, &req.to_currency);
 
     Ok(HttpResponse::Ok().json(quote))
 }

--- a/icn/crates/icn-gateway/src/api/ledger.rs
+++ b/icn/crates/icn-gateway/src/api/ledger.rs
@@ -960,4 +960,237 @@ mod tests {
         let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
     }
+
+    #[actix_web::test]
+    async fn test_cross_payment_same_currency_rejected() {
+        let ledger_mgr = Arc::new(LedgerManager::new());
+        let db = sled::Config::new().temporary(true).open().unwrap();
+        let budget_store = BudgetStore::new(db);
+        let velocity_limiter = VelocityLimiter::default();
+        let trust_mgr = Arc::new(TrustManager::new());
+        let alice = IdentityBundle::generate().unwrap();
+        let bob = IdentityBundle::generate().unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(ledger_mgr.clone()))
+                .app_data(web::Data::new(budget_store.clone()))
+                .app_data(web::Data::new(velocity_limiter.clone()))
+                .app_data(web::Data::new(trust_mgr.clone()))
+                .service(web::scope("/ledger").service(create_cross_payment)),
+        )
+        .await;
+
+        // Try cross-payment with same currency (should fail)
+        let req_body = CreateCrossPaymentRequest {
+            from: alice.did().to_string(),
+            to: bob.did().to_string(),
+            amount: 10,
+            from_currency: "hours".to_string(),
+            to_currency: "hours".to_string(), // Same currency!
+            max_target_amount: None,
+            memo: None,
+        };
+
+        let claims = TokenClaims {
+            sub: alice.did().to_string(),
+            iat: 1000000000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["ledger:write".to_string()],
+            exp: 9999999999,
+        };
+
+        let req = test::TestRequest::post()
+            .uri("/ledger/test-coop/payment/convert")
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[actix_web::test]
+    async fn test_cross_payment_self_payment_rejected() {
+        let ledger_mgr = Arc::new(LedgerManager::new());
+        let db = sled::Config::new().temporary(true).open().unwrap();
+        let budget_store = BudgetStore::new(db);
+        let velocity_limiter = VelocityLimiter::default();
+        let trust_mgr = Arc::new(TrustManager::new());
+        let alice = IdentityBundle::generate().unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(ledger_mgr.clone()))
+                .app_data(web::Data::new(budget_store.clone()))
+                .app_data(web::Data::new(velocity_limiter.clone()))
+                .app_data(web::Data::new(trust_mgr.clone()))
+                .service(web::scope("/ledger").service(create_cross_payment)),
+        )
+        .await;
+
+        // Try cross-payment to self (should fail)
+        let req_body = CreateCrossPaymentRequest {
+            from: alice.did().to_string(),
+            to: alice.did().to_string(), // Self-payment!
+            amount: 10,
+            from_currency: "hours".to_string(),
+            to_currency: "USD".to_string(),
+            max_target_amount: None,
+            memo: None,
+        };
+
+        let claims = TokenClaims {
+            sub: alice.did().to_string(),
+            iat: 1000000000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["ledger:write".to_string()],
+            exp: 9999999999,
+        };
+
+        let req = test::TestRequest::post()
+            .uri("/ledger/test-coop/payment/convert")
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[actix_web::test]
+    async fn test_cross_payment_authorization_check() {
+        let ledger_mgr = Arc::new(LedgerManager::new());
+        let db = sled::Config::new().temporary(true).open().unwrap();
+        let budget_store = BudgetStore::new(db);
+        let velocity_limiter = VelocityLimiter::default();
+        let trust_mgr = Arc::new(TrustManager::new());
+        let alice = IdentityBundle::generate().unwrap();
+        let bob = IdentityBundle::generate().unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(ledger_mgr.clone()))
+                .app_data(web::Data::new(budget_store.clone()))
+                .app_data(web::Data::new(velocity_limiter.clone()))
+                .app_data(web::Data::new(trust_mgr.clone()))
+                .service(web::scope("/ledger").service(create_cross_payment)),
+        )
+        .await;
+
+        // Try cross-payment with read-only scope (should fail)
+        let req_body = CreateCrossPaymentRequest {
+            from: alice.did().to_string(),
+            to: bob.did().to_string(),
+            amount: 10,
+            from_currency: "hours".to_string(),
+            to_currency: "USD".to_string(),
+            max_target_amount: None,
+            memo: None,
+        };
+
+        let claims = TokenClaims {
+            sub: alice.did().to_string(),
+            iat: 1000000000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["ledger:read".to_string()], // Wrong scope!
+            exp: 9999999999,
+        };
+
+        let req = test::TestRequest::post()
+            .uri("/ledger/test-coop/payment/convert")
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::FORBIDDEN);
+    }
+
+    #[actix_web::test]
+    async fn test_cross_payment_quote_same_currency_rejected() {
+        let ledger_mgr = Arc::new(LedgerManager::new());
+        let alice = IdentityBundle::generate().unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(ledger_mgr.clone()))
+                .service(web::scope("/ledger").service(get_cross_payment_quote)),
+        )
+        .await;
+
+        // Try quote with same currency (should fail)
+        let req_body = CrossPaymentQuoteRequest {
+            amount: 10,
+            from_currency: "hours".to_string(),
+            to_currency: "hours".to_string(), // Same currency!
+        };
+
+        let claims = TokenClaims {
+            sub: alice.did().to_string(),
+            iat: 1000000000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["ledger:read".to_string()],
+            exp: 9999999999,
+        };
+
+        let req = test::TestRequest::post()
+            .uri("/ledger/test-coop/payment/convert/quote")
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[actix_web::test]
+    async fn test_cross_payment_from_other_account_rejected() {
+        let ledger_mgr = Arc::new(LedgerManager::new());
+        let db = sled::Config::new().temporary(true).open().unwrap();
+        let budget_store = BudgetStore::new(db);
+        let velocity_limiter = VelocityLimiter::default();
+        let trust_mgr = Arc::new(TrustManager::new());
+        let alice = IdentityBundle::generate().unwrap();
+        let bob = IdentityBundle::generate().unwrap();
+        let charlie = IdentityBundle::generate().unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(ledger_mgr.clone()))
+                .app_data(web::Data::new(budget_store.clone()))
+                .app_data(web::Data::new(velocity_limiter.clone()))
+                .app_data(web::Data::new(trust_mgr.clone()))
+                .service(web::scope("/ledger").service(create_cross_payment)),
+        )
+        .await;
+
+        // Alice tries to create cross-payment from Bob's account (should fail)
+        let req_body = CreateCrossPaymentRequest {
+            from: bob.did().to_string(), // Bob's account
+            to: charlie.did().to_string(),
+            amount: 10,
+            from_currency: "hours".to_string(),
+            to_currency: "USD".to_string(),
+            max_target_amount: None,
+            memo: None,
+        };
+
+        let claims = TokenClaims {
+            sub: alice.did().to_string(), // Alice authenticated
+            iat: 1000000000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["ledger:write".to_string()],
+            exp: 9999999999,
+        };
+
+        let req = test::TestRequest::post()
+            .uri("/ledger/test-coop/payment/convert")
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::FORBIDDEN);
+    }
 }

--- a/icn/crates/icn-gateway/src/events.rs
+++ b/icn/crates/icn-gateway/src/events.rs
@@ -94,6 +94,18 @@ pub enum GatewayEvent {
         amount: i64,
         currency: String,
     },
+    /// A cross-currency payment was created
+    CrossPaymentCreated {
+        coop_id: String,
+        hash: String,
+        from: String,
+        to: String,
+        source_amount: i64,
+        from_currency: String,
+        target_amount: i64,
+        to_currency: String,
+        rate: f64,
+    },
     /// A member was added to a cooperative
     MemberAdded {
         coop_id: String,

--- a/icn/crates/icn-gateway/src/ledger_events.rs
+++ b/icn/crates/icn-gateway/src/ledger_events.rs
@@ -218,6 +218,27 @@ impl LedgerEventBridge {
                     .await;
                 warn!("Forwarded RollbackPerformed event");
             }
+
+            LedgerEvent::CrossCurrencyTransfer(cct) => {
+                let coop_id = cct
+                    .domain_id
+                    .unwrap_or_else(|| self.default_coop_id.clone());
+                let gateway_event = GatewayEvent::CrossPaymentCreated {
+                    coop_id: coop_id.clone(),
+                    hash: cct.entry_hash,
+                    from: cct.from,
+                    to: cct.to,
+                    source_amount: cct.source_amount,
+                    from_currency: cct.from_currency,
+                    target_amount: cct.net_target_amount,
+                    to_currency: cct.to_currency,
+                    rate: cct.rate,
+                };
+                self.gateway_broadcaster
+                    .broadcast(&coop_id, gateway_event)
+                    .await;
+                debug!("Forwarded CrossCurrencyTransfer event");
+            }
         }
     }
 }

--- a/icn/crates/icn-gateway/src/ledger_mgr.rs
+++ b/icn/crates/icn-gateway/src/ledger_mgr.rs
@@ -460,13 +460,8 @@ impl LedgerManager {
             .convert(amount)
             .ok_or_else(|| GatewayError::InternalError("Conversion would overflow".to_string()))?;
 
-        // Calculate fee
-        let fee_amount = if fx_config.fee_basis_points > 0 && fx_config.treasury_did.is_some() {
-            (gross_target_amount as f64 * fx_config.fee_basis_points as f64 / 10000.0).round()
-                as i64
-        } else {
-            0
-        };
+        // Calculate fee using same logic as actual execution for consistency
+        let fee_amount = fx_config.calculate_fee(gross_target_amount);
 
         let net_target_amount = gross_target_amount - fee_amount;
 

--- a/icn/crates/icn-gateway/src/ledger_mgr.rs
+++ b/icn/crates/icn-gateway/src/ledger_mgr.rs
@@ -5,8 +5,12 @@ use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
 use icn_identity::Did;
-use icn_ledger::{entry::JournalEntryBuilder, Ledger, SharedEventEmitter};
+use icn_ledger::{
+    entry::JournalEntryBuilder, CurrencyPair, FxConversionDetails, Ledger, SharedEventEmitter,
+};
 use icn_store::{SledStore, Store};
+
+use crate::models::{CrossPaymentQuote, CrossPaymentResponse};
 
 use crate::coop::CoopId;
 use crate::error::{GatewayError, Result};
@@ -292,6 +296,215 @@ impl LedgerManager {
         }
 
         Ok((transaction_count, total_hours_exchanged))
+    }
+
+    /// Create a cross-currency payment
+    ///
+    /// Transfers funds between two currencies using the exchange rate oracle.
+    /// The sender pays in `from_currency` and the recipient receives in `to_currency`.
+    ///
+    /// Returns the entry hash and conversion details for audit/display.
+    ///
+    /// # Note on locking
+    /// This method holds a read lock across an await point during preparation.
+    /// This is acceptable because read locks allow concurrent readers and don't block.
+    #[allow(clippy::await_holding_lock)]
+    pub async fn create_cross_payment(
+        &self,
+        coop_id: &CoopId,
+        from: &Did,
+        to: &Did,
+        amount: i64,
+        from_currency: &str,
+        to_currency: &str,
+        max_target_amount: Option<i64>,
+        _memo: Option<String>,
+    ) -> Result<CrossPaymentResponse> {
+        // Enforce budget limits if store is available
+        if let Some(store) = &self.budget_store {
+            let from_account = from.to_string();
+            if !store
+                .check_spending(&from_account, amount)
+                .map_err(|e| GatewayError::InternalError(format!("Budget check failed: {e}")))?
+            {
+                return Err(GatewayError::BudgetExceeded(format!(
+                    "Budget exceeded for account {from_account}"
+                )));
+            }
+        }
+
+        let ledger_arc = self.get_ledger(coop_id)?;
+
+        // Prepare the transfer (fetches rate from oracle) - only needs read lock
+        let prepared = {
+            let ledger = ledger_arc
+                .read()
+                .map_err(|e| GatewayError::InternalError(format!("Lock poisoned: {e}")))?;
+
+            ledger
+                .prepare_cross_currency_transfer(
+                    from,
+                    to,
+                    amount,
+                    from_currency,
+                    to_currency,
+                    max_target_amount,
+                )
+                .await
+                .map_err(|e| GatewayError::InternalError(format!("FX error: {e}")))?
+        };
+
+        // Execute the transfer (writes to ledger) - needs write lock
+        let (hash, details) = {
+            let mut ledger = ledger_arc
+                .write()
+                .map_err(|e| GatewayError::InternalError(format!("Lock poisoned: {e}")))?;
+
+            let (hash, details) = ledger
+                .execute_cross_currency_transfer(prepared)
+                .map_err(|e| GatewayError::InternalError(format!("FX execution error: {e}")))?;
+
+            (hash.to_hex(), details)
+        };
+
+        // Record spending in budget store
+        if let Some(store) = &self.budget_store {
+            let from_account = from.to_string();
+            if let Err(e) = store.record_spending(&from_account, amount) {
+                tracing::error!("Failed to record spending for {}: {}", from_account, e);
+            }
+        }
+
+        // Broadcast event if broadcaster is available
+        if let Some(broadcaster) = &self.event_broadcaster {
+            let event = GatewayEvent::CrossPaymentCreated {
+                coop_id: coop_id.clone(),
+                hash: hash.clone(),
+                from: from.to_string(),
+                to: to.to_string(),
+                source_amount: amount,
+                from_currency: from_currency.to_string(),
+                target_amount: details.net_target_amount,
+                to_currency: to_currency.to_string(),
+                rate: details.rate,
+            };
+            let broadcaster = broadcaster.clone();
+            let coop_id = coop_id.clone();
+            tokio::spawn(async move {
+                broadcaster.broadcast(&coop_id, event).await;
+            });
+        }
+
+        Ok(CrossPaymentResponse {
+            hash,
+            from: from.to_string(),
+            to: to.to_string(),
+            source_amount: amount,
+            from_currency: from_currency.to_string(),
+            gross_target_amount: details.gross_target_amount,
+            fee_amount: details.fee_amount,
+            net_target_amount: details.net_target_amount,
+            to_currency: to_currency.to_string(),
+            rate_used: details.rate,
+            rate_timestamp: details.rate_timestamp,
+            rate_sources: details.rate_sources,
+        })
+    }
+
+    /// Get a quote for a cross-currency payment without executing it
+    ///
+    /// Returns the expected conversion details including rate, fees, and amounts.
+    /// The quote is valid for a limited time based on oracle TTL.
+    pub async fn get_cross_payment_quote(
+        &self,
+        coop_id: &CoopId,
+        amount: i64,
+        from_currency: &str,
+        to_currency: &str,
+    ) -> Result<CrossPaymentQuote> {
+        let ledger_arc = self.get_ledger(coop_id)?;
+
+        // Get FX config and oracle under lock, then release before await
+        let (fx_config, oracle) = {
+            let ledger = ledger_arc
+                .read()
+                .map_err(|e| GatewayError::InternalError(format!("Lock poisoned: {e}")))?;
+
+            let fx_config = ledger.fx_config().cloned().ok_or_else(|| {
+                GatewayError::InternalError("Cross-currency payments not configured".to_string())
+            })?;
+
+            let oracle = ledger.oracle_manager().cloned().ok_or_else(|| {
+                GatewayError::InternalError("Exchange rate oracle not configured".to_string())
+            })?;
+
+            (fx_config, oracle)
+        };
+
+        // Get current rate (after releasing lock)
+        let pair = CurrencyPair::new(from_currency, to_currency);
+        let rate = oracle
+            .get_rate(&pair)
+            .await
+            .map_err(|e| GatewayError::InternalError(format!("Oracle error: {e}")))?;
+
+        // Check staleness
+        if rate.is_stale && !fx_config.allow_stale_rates {
+            return Err(GatewayError::InternalError(
+                "Exchange rate is stale and stale rates are not allowed".to_string(),
+            ));
+        }
+
+        // Calculate conversion
+        let gross_target_amount = rate
+            .convert(amount)
+            .ok_or_else(|| GatewayError::InternalError("Conversion would overflow".to_string()))?;
+
+        // Calculate fee
+        let fee_amount = if fx_config.fee_basis_points > 0 && fx_config.treasury_did.is_some() {
+            (gross_target_amount as f64 * fx_config.fee_basis_points as f64 / 10000.0).round()
+                as i64
+        } else {
+            0
+        };
+
+        let net_target_amount = gross_target_amount - fee_amount;
+
+        // Quote valid until rate expires
+        let valid_until = rate.aggregated_at + rate.ttl_secs;
+
+        Ok(CrossPaymentQuote {
+            source_amount: amount,
+            from_currency: from_currency.to_string(),
+            gross_target_amount,
+            fee_amount,
+            net_target_amount,
+            to_currency: to_currency.to_string(),
+            rate: rate.rate,
+            valid_until,
+            is_stale: rate.is_stale,
+        })
+    }
+
+    /// Get conversion details for a cross-currency transfer
+    ///
+    /// This is a lower-level method that returns the FxConversionDetails directly.
+    #[allow(dead_code)]
+    pub fn get_fx_conversion_details(&self, details: &FxConversionDetails) -> CrossPaymentResponse {
+        CrossPaymentResponse {
+            hash: String::new(), // Not available without actual execution
+            from: String::new(),
+            to: String::new(),
+            source_amount: details.source_amount,
+            from_currency: details.from_currency.clone(),
+            gross_target_amount: details.gross_target_amount,
+            fee_amount: details.fee_amount,
+            net_target_amount: details.net_target_amount,
+            to_currency: details.to_currency.clone(),
+            rate_used: details.rate,
+            rate_timestamp: details.rate_timestamp,
+            rate_sources: details.rate_sources.clone(),
+        }
     }
 }
 

--- a/icn/crates/icn-gateway/src/ledger_mgr.rs
+++ b/icn/crates/icn-gateway/src/ledger_mgr.rs
@@ -481,6 +481,8 @@ impl LedgerManager {
             net_target_amount,
             to_currency: to_currency.to_string(),
             rate: rate.rate,
+            rate_timestamp: rate.aggregated_at,
+            rate_sources: rate.sources(),
             valid_until,
             is_stale: rate.is_stale,
         })

--- a/icn/crates/icn-gateway/src/models.rs
+++ b/icn/crates/icn-gateway/src/models.rs
@@ -486,6 +486,10 @@ pub struct CrossPaymentQuote {
     pub to_currency: String,
     /// Exchange rate
     pub rate: f64,
+    /// When the rate was fetched (Unix seconds)
+    pub rate_timestamp: u64,
+    /// Sources that provided the rate
+    pub rate_sources: Vec<String>,
     /// When this quote expires (Unix seconds)
     pub valid_until: u64,
     /// Whether the rate is considered stale

--- a/icn/crates/icn-gateway/src/models.rs
+++ b/icn/crates/icn-gateway/src/models.rs
@@ -404,3 +404,90 @@ pub struct DelegationListResponse {
     /// Delegations received by the caller
     pub received: Vec<DelegationResponse>,
 }
+
+// === Cross-Currency Payments ===
+
+/// Create a cross-currency payment
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct CreateCrossPaymentRequest {
+    /// Sender DID
+    pub from: String,
+    /// Recipient DID
+    pub to: String,
+    /// Amount to send in source currency
+    pub amount: i64,
+    /// Source currency (what sender pays)
+    pub from_currency: String,
+    /// Target currency (what recipient receives)
+    pub to_currency: String,
+    /// Optional slippage protection: max target amount to receive
+    /// If the converted amount exceeds this, the transfer is rejected
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_target_amount: Option<i64>,
+    /// Optional memo/note for the payment
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memo: Option<String>,
+}
+
+/// Response for a cross-currency payment
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct CrossPaymentResponse {
+    /// Hash of the journal entry
+    pub hash: String,
+    /// Sender DID
+    pub from: String,
+    /// Recipient DID
+    pub to: String,
+    /// Amount debited from sender
+    pub source_amount: i64,
+    /// Source currency
+    pub from_currency: String,
+    /// Gross amount before fees
+    pub gross_target_amount: i64,
+    /// Fee amount (sent to treasury)
+    pub fee_amount: i64,
+    /// Net amount credited to recipient
+    pub net_target_amount: i64,
+    /// Target currency
+    pub to_currency: String,
+    /// Exchange rate used
+    pub rate_used: f64,
+    /// When the rate was fetched (Unix seconds)
+    pub rate_timestamp: u64,
+    /// Sources that provided the rate
+    pub rate_sources: Vec<String>,
+}
+
+/// Request for a cross-currency payment quote
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct CrossPaymentQuoteRequest {
+    /// Amount to send in source currency
+    pub amount: i64,
+    /// Source currency (what sender pays)
+    pub from_currency: String,
+    /// Target currency (what recipient receives)
+    pub to_currency: String,
+}
+
+/// Quote for a cross-currency payment (preview without execution)
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct CrossPaymentQuote {
+    /// Amount that would be debited from sender
+    pub source_amount: i64,
+    /// Source currency
+    pub from_currency: String,
+    /// Gross amount before fees
+    pub gross_target_amount: i64,
+    /// Fee amount that would be deducted
+    pub fee_amount: i64,
+    /// Net amount that would be credited to recipient
+    pub net_target_amount: i64,
+    /// Target currency
+    pub to_currency: String,
+    /// Exchange rate
+    pub rate: f64,
+    /// When this quote expires (Unix seconds)
+    pub valid_until: u64,
+    /// Whether the rate is considered stale
+    pub is_stale: bool,
+}

--- a/icn/crates/icn-gateway/src/notification_triggers.rs
+++ b/icn/crates/icn-gateway/src/notification_triggers.rs
@@ -160,6 +160,51 @@ impl LedgerNotificationTrigger {
                 );
             }
 
+            LedgerEvent::CrossCurrencyTransfer(cct) => {
+                let coop_id = cct
+                    .domain_id
+                    .unwrap_or_else(|| self.default_coop_id.clone());
+
+                // Notify recipient of cross-currency payment
+                let notif = QueuedNotification::new(
+                    &cct.to,
+                    &coop_id,
+                    "Cross-Currency Payment Received",
+                    format!(
+                        "You received {} {} (converted from {} {}) from {}",
+                        cct.net_target_amount,
+                        &cct.to_currency,
+                        cct.source_amount,
+                        &cct.from_currency,
+                        &cct.from
+                    ),
+                    NotificationType::PaymentReceived,
+                );
+                self.queue.queue(notif).await?;
+
+                // Notify sender
+                let notif = QueuedNotification::new(
+                    &cct.from,
+                    &coop_id,
+                    "Cross-Currency Payment Sent",
+                    format!(
+                        "You sent {} {} (converted to {} {}) to {}",
+                        cct.source_amount,
+                        &cct.from_currency,
+                        cct.net_target_amount,
+                        &cct.to_currency,
+                        &cct.to
+                    ),
+                    NotificationType::PaymentSent,
+                );
+                self.queue.queue(notif).await?;
+
+                debug!(
+                    entry_hash = %cct.entry_hash,
+                    "Queued cross-currency payment notifications"
+                );
+            }
+
             // Skip other events for notification purposes
             LedgerEvent::TransactionConfirmed(_) => {}
             LedgerEvent::BatchBalanceChanged(_) => {}

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -849,6 +849,8 @@ impl GatewayServer {
                                 .service(api::ledger::get_balance)
                                 .service(api::ledger::create_payment)
                                 .service(api::ledger::get_history)
+                                .service(api::ledger::create_cross_payment)
+                                .service(api::ledger::get_cross_payment_quote)
                                 // Apply auth first, then rate limiting (wrapping order: last runs first)
                                 .wrap(middleware::from_fn(
                                     crate::rate_limit::rate_limit_middleware,

--- a/icn/crates/icn-ledger/src/events.rs
+++ b/icn/crates/icn-ledger/src/events.rs
@@ -43,6 +43,9 @@ pub enum LedgerEvent {
 
     /// A ledger rollback occurred
     RollbackPerformed(RollbackPerformed),
+
+    /// A cross-currency transfer was executed
+    CrossCurrencyTransfer(CrossCurrencyTransfer),
 }
 
 /// Event: A new transaction was created
@@ -221,6 +224,52 @@ pub struct RollbackPerformed {
 
     /// Unix timestamp when performed
     pub performed_at: u64,
+}
+
+/// Event: A cross-currency transfer was executed
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CrossCurrencyTransfer {
+    /// Hash of the journal entry
+    pub entry_hash: String,
+
+    /// Sender DID
+    pub from: String,
+
+    /// Recipient DID
+    pub to: String,
+
+    /// Amount debited from sender
+    pub source_amount: i64,
+
+    /// Source currency
+    pub from_currency: String,
+
+    /// Gross amount before fees
+    pub gross_target_amount: i64,
+
+    /// Fee amount (sent to treasury)
+    pub fee_amount: i64,
+
+    /// Net amount credited to recipient
+    pub net_target_amount: i64,
+
+    /// Target currency
+    pub to_currency: String,
+
+    /// Exchange rate used
+    pub rate: f64,
+
+    /// When the rate was fetched
+    pub rate_timestamp: u64,
+
+    /// Sources that provided the rate
+    pub rate_sources: Vec<String>,
+
+    /// Unix timestamp of the transfer
+    pub timestamp: u64,
+
+    /// Domain/cooperative this belongs to (if known)
+    pub domain_id: Option<String>,
 }
 
 /// Event emitter for broadcasting ledger events
@@ -409,6 +458,43 @@ impl LedgerEventEmitter {
             archived_count,
             reason: reason.to_string(),
             performed_at,
+        }))
+    }
+
+    /// Emit a CrossCurrencyTransfer event
+    #[allow(clippy::too_many_arguments)]
+    pub fn emit_cross_currency_transfer(
+        &self,
+        entry_hash: &ContentHash,
+        from: &Did,
+        to: &Did,
+        source_amount: i64,
+        from_currency: &str,
+        gross_target_amount: i64,
+        fee_amount: i64,
+        net_target_amount: i64,
+        to_currency: &str,
+        rate: f64,
+        rate_timestamp: u64,
+        rate_sources: Vec<String>,
+        timestamp: u64,
+        domain_id: Option<String>,
+    ) -> usize {
+        self.emit(LedgerEvent::CrossCurrencyTransfer(CrossCurrencyTransfer {
+            entry_hash: entry_hash.to_hex(),
+            from: from.to_string(),
+            to: to.to_string(),
+            source_amount,
+            from_currency: from_currency.to_string(),
+            gross_target_amount,
+            fee_amount,
+            net_target_amount,
+            to_currency: to_currency.to_string(),
+            rate,
+            rate_timestamp,
+            rate_sources,
+            timestamp,
+            domain_id,
         }))
     }
 }

--- a/icn/crates/icn-ledger/src/fx.rs
+++ b/icn/crates/icn-ledger/src/fx.rs
@@ -165,8 +165,12 @@ impl FxConfig {
         }
 
         // Calculate absolute percentage difference in basis points
-        let diff = (actual - expected).abs() as i128;
-        let pct = diff * 10000 / expected.abs() as i128;
+        // Use i128 for intermediate calculations to prevent overflow
+        // Note: For extreme values where diff*10000 would overflow i128,
+        // saturating_mul returns i128::MAX which correctly triggers slippage rejection
+        let diff = (actual as i128).saturating_sub(expected as i128).abs();
+        let expected_abs = (expected as i128).abs().max(1); // Avoid division by zero
+        let pct = diff.saturating_mul(10000) / expected_abs;
 
         pct <= self.max_slippage_basis_points as i128
     }
@@ -178,6 +182,12 @@ impl FxConfig {
 /// for transparency and dispute resolution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FxConversionDetails {
+    /// Sender DID
+    pub from_did: String,
+
+    /// Recipient DID
+    pub to_did: String,
+
     /// Source currency (what sender pays)
     pub from_currency: String,
 
@@ -214,7 +224,10 @@ pub struct FxConversionDetails {
 
 impl FxConversionDetails {
     /// Create new conversion details
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
+        from_did: String,
+        to_did: String,
         from_currency: String,
         to_currency: String,
         source_amount: i64,
@@ -228,6 +241,8 @@ impl FxConversionDetails {
         fee_basis_points: u16,
     ) -> Self {
         Self {
+            from_did,
+            to_did,
             from_currency,
             to_currency,
             rate,
@@ -447,6 +462,8 @@ mod tests {
     #[test]
     fn test_conversion_details() {
         let details = FxConversionDetails::new(
+            "did:icn:alice".to_string(),
+            "did:icn:bob".to_string(),
             "hours".to_string(),
             "USD".to_string(),
             10,    // source amount
@@ -460,6 +477,8 @@ mod tests {
             100, // fee bps
         );
 
+        assert_eq!(details.from_did, "did:icn:alice");
+        assert_eq!(details.to_did, "did:icn:bob");
         assert_eq!(details.from_currency, "hours");
         assert_eq!(details.to_currency, "USD");
         assert_eq!(details.source_amount, 10);

--- a/icn/crates/icn-ledger/src/fx.rs
+++ b/icn/crates/icn-ledger/src/fx.rs
@@ -32,6 +32,9 @@ use crate::types::{ContentHash, JournalEntry};
 use icn_identity::Did;
 use serde::{Deserialize, Serialize};
 
+/// Basis points scale factor (100 basis points = 1%)
+const BASIS_POINTS_SCALE: i128 = 10_000;
+
 /// Configuration for cross-currency (FX) transfers
 ///
 /// Controls fee structure, slippage limits, and system accounts
@@ -141,9 +144,10 @@ impl FxConfig {
             return 0;
         }
 
-        // fee = gross_amount * fee_basis_points / 10000
+        // fee = gross_amount * fee_basis_points / BASIS_POINTS_SCALE
         // Use i128 to avoid overflow during multiplication
-        let fee = (gross_amount as i128 * self.fee_basis_points as i128 / 10000) as i64;
+        let fee =
+            (gross_amount as i128 * self.fee_basis_points as i128 / BASIS_POINTS_SCALE) as i64;
         fee.max(0) // Ensure non-negative
     }
 
@@ -166,11 +170,11 @@ impl FxConfig {
 
         // Calculate absolute percentage difference in basis points
         // Use i128 for intermediate calculations to prevent overflow
-        // Note: For extreme values where diff*10000 would overflow i128,
+        // Note: For extreme values where diff*BASIS_POINTS_SCALE would overflow i128,
         // saturating_mul returns i128::MAX which correctly triggers slippage rejection
         let diff = (actual as i128).saturating_sub(expected as i128).abs();
         let expected_abs = (expected as i128).abs().max(1); // Avoid division by zero
-        let pct = diff.saturating_mul(10000) / expected_abs;
+        let pct = diff.saturating_mul(BASIS_POINTS_SCALE) / expected_abs;
 
         pct <= self.max_slippage_basis_points as i128
     }
@@ -735,5 +739,102 @@ mod integration_tests {
 
         // Bob gets full amount
         assert_eq!(ledger.get_balance(&bob, "USD"), 250);
+    }
+
+    #[tokio::test]
+    async fn test_clearing_account_balance_verification() {
+        // Verify that the 4/5-leg entry balances net to zero per currency
+        let (mut ledger, alice, bob, clearing) = setup_ledger_with_fx().await;
+
+        // Execute multiple transfers to verify clearing account balances
+        let (_, details) = ledger
+            .transfer_with_conversion(&alice, &bob, 10, "hours", "USD", None)
+            .await
+            .expect("execute transfer 1");
+
+        // Verify clearing account maintains double-entry invariant per currency:
+        // Clearing receives hours (credit = positive in ICN semantics)
+        // Clearing sends USD (debit = negative in ICN semantics)
+        let clearing_hours = ledger.get_balance(&clearing, "hours");
+        let clearing_usd = ledger.get_balance(&clearing, "USD");
+
+        // Clearing receives 10 hours
+        assert_eq!(clearing_hours, 10);
+        // Clearing sends 250 USD (gross amount)
+        assert_eq!(clearing_usd, -details.gross_target_amount);
+
+        // Verify the sum of all balances per currency equals zero (double-entry invariant)
+        let alice_hours = ledger.get_balance(&alice, "hours");
+        // Bob's USD balance is verified in detail assertions below
+        let _bob_usd = ledger.get_balance(&bob, "USD");
+
+        // Hours: alice (-10) + clearing (+10) = 0
+        assert_eq!(
+            alice_hours + clearing_hours,
+            0,
+            "Hours currency should sum to zero"
+        );
+
+        // USD: clearing (-250) + bob (248) + treasury (2) = 0
+        // Treasury gets the 2 USD fee
+        // Note: We can't easily get treasury balance without the DID, but we can verify:
+        assert_eq!(
+            details.gross_target_amount,
+            details.net_target_amount + details.fee_amount,
+            "Gross = Net + Fee"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fee_with_treasury_configured() {
+        // This test explicitly verifies the P1 fix:
+        // When fee_amount > 0 AND treasury is configured, the fee goes to treasury
+        let store = Arc::new(SledStore::temporary().expect("create temp store"));
+        let mut ledger = Ledger::new(store.clone()).expect("create ledger");
+
+        let alice = KeyPair::generate().expect("generate").did().clone();
+        let bob = KeyPair::generate().expect("generate").did().clone();
+        let clearing = KeyPair::generate().expect("generate").did().clone();
+        let treasury = KeyPair::generate().expect("generate").did().clone();
+
+        // Set up oracle
+        let oracle = Arc::new(OracleManager::new(store.clone()));
+        let manual_source = Arc::new(ManualRateSource::new(store.clone()));
+
+        manual_source
+            .set_rate(
+                &crate::oracle::CurrencyPair::new("hours", "USD"),
+                100.0, // 1 hour = 100 USD for easier math
+                &clearing.to_string(),
+                None,
+            )
+            .expect("set rate");
+
+        oracle.register_source(manual_source).await;
+        ledger.set_oracle_manager(oracle);
+
+        // FX config WITH fee AND treasury
+        let fx_config = FxConfig::new(clearing.clone())
+            .with_fee(100) // 1%
+            .with_treasury(treasury.clone());
+        ledger.set_fx_config(fx_config);
+
+        // Execute transfer: 10 hours -> 1000 USD gross, 10 USD fee, 990 USD net
+        let (_, details) = ledger
+            .transfer_with_conversion(&alice, &bob, 10, "hours", "USD", None)
+            .await
+            .expect("execute transfer");
+
+        // Verify fee calculation
+        assert_eq!(details.gross_target_amount, 1000);
+        assert_eq!(details.fee_amount, 10); // 1% of 1000
+        assert_eq!(details.net_target_amount, 990);
+
+        // Verify balances
+        assert_eq!(ledger.get_balance(&alice, "hours"), -10);
+        assert_eq!(ledger.get_balance(&bob, "USD"), 990); // Net amount
+        assert_eq!(ledger.get_balance(&treasury, "USD"), 10); // Fee
+        assert_eq!(ledger.get_balance(&clearing, "hours"), 10);
+        assert_eq!(ledger.get_balance(&clearing, "USD"), -1000); // Gross
     }
 }

--- a/icn/crates/icn-ledger/src/fx.rs
+++ b/icn/crates/icn-ledger/src/fx.rs
@@ -1,0 +1,720 @@
+//! Foreign Exchange (FX) types for cross-currency payments
+//!
+//! This module provides types for executing payments where the sender pays
+//! in one currency and the recipient receives in another, using the oracle
+//! for rate conversion.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use icn_ledger::{Ledger, fx::FxConfig};
+//! use icn_identity::KeyPair;
+//! use icn_store::SledStore;
+//! use std::sync::Arc;
+//!
+//! # async fn example() -> anyhow::Result<()> {
+//! let store = Arc::new(SledStore::temporary()?);
+//! let mut ledger = Ledger::new(store)?;
+//!
+//! // Configure FX with 1% fee
+//! let config = FxConfig {
+//!     fee_basis_points: 100,
+//!     treasury_did: None, // No fee collection
+//!     clearing_did: KeyPair::generate()?.did().clone(),
+//!     ..Default::default()
+//! };
+//! ledger.set_fx_config(config);
+//! # Ok(())
+//! # }
+//! ```
+
+use crate::types::{ContentHash, JournalEntry};
+use icn_identity::Did;
+use serde::{Deserialize, Serialize};
+
+/// Configuration for cross-currency (FX) transfers
+///
+/// Controls fee structure, slippage limits, and system accounts
+/// used during currency conversion.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FxConfig {
+    /// FX fee in basis points (100 = 1%)
+    ///
+    /// This fee is deducted from the target currency amount
+    /// and sent to the treasury account.
+    pub fee_basis_points: u16,
+
+    /// Maximum allowed fee in basis points (default: 500 = 5%)
+    ///
+    /// Safety cap to prevent misconfiguration.
+    pub max_fee_basis_points: u16,
+
+    /// Treasury account where FX fees are collected
+    ///
+    /// If None, no fee is collected (fee_basis_points is ignored).
+    pub treasury_did: Option<Did>,
+
+    /// Clearing account for intermediate transfers
+    ///
+    /// Cross-currency transfers use a 4-leg entry pattern:
+    /// 1. DEBIT sender (source currency)
+    /// 2. CREDIT clearing (source currency)
+    /// 3. DEBIT clearing (target currency)
+    /// 4. CREDIT recipient (target currency)
+    ///
+    /// This maintains the double-entry invariant per currency.
+    pub clearing_did: Did,
+
+    /// Maximum slippage in basis points (default: 100 = 1%)
+    ///
+    /// If the converted amount differs from expected by more than
+    /// this percentage, the transfer is rejected.
+    pub max_slippage_basis_points: u16,
+
+    /// Whether to accept stale rates from the oracle
+    ///
+    /// If false (default), transfers with stale rates are rejected.
+    /// If true, stale rates are used with a warning in the details.
+    pub allow_stale_rates: bool,
+}
+
+impl Default for FxConfig {
+    fn default() -> Self {
+        // Default clearing DID is a placeholder - must be set by cooperative
+        // Using from_str which should succeed for valid DID format
+        let placeholder_clearing =
+            Did::from_str("did:icn:clearing0000000000000000000000000000000000000000")
+                .unwrap_or_else(|_| {
+                    // Fallback: create from a deterministic 32-byte array
+                    Did::from_anchor_id(&[0u8; 32])
+                });
+
+        Self {
+            fee_basis_points: 0,
+            max_fee_basis_points: 500,
+            treasury_did: None,
+            clearing_did: placeholder_clearing,
+            max_slippage_basis_points: 100,
+            allow_stale_rates: false,
+        }
+    }
+}
+
+impl FxConfig {
+    /// Create a new FX config with required clearing account
+    pub fn new(clearing_did: Did) -> Self {
+        Self {
+            clearing_did,
+            ..Default::default()
+        }
+    }
+
+    /// Set the FX fee (in basis points, 100 = 1%)
+    pub fn with_fee(mut self, fee_basis_points: u16) -> Self {
+        self.fee_basis_points = fee_basis_points.min(self.max_fee_basis_points);
+        self
+    }
+
+    /// Set the treasury account for fee collection
+    pub fn with_treasury(mut self, treasury_did: Did) -> Self {
+        self.treasury_did = Some(treasury_did);
+        self
+    }
+
+    /// Set maximum slippage tolerance
+    pub fn with_max_slippage(mut self, basis_points: u16) -> Self {
+        self.max_slippage_basis_points = basis_points;
+        self
+    }
+
+    /// Allow stale rates from oracle
+    pub fn allow_stale(mut self) -> Self {
+        self.allow_stale_rates = true;
+        self
+    }
+
+    /// Calculate fee amount from gross target amount
+    ///
+    /// Returns the fee portion that goes to treasury.
+    pub fn calculate_fee(&self, gross_amount: i64) -> i64 {
+        if self.treasury_did.is_none() {
+            return 0;
+        }
+
+        // fee = gross_amount * fee_basis_points / 10000
+        // Use i128 to avoid overflow during multiplication
+        let fee = (gross_amount as i128 * self.fee_basis_points as i128 / 10000) as i64;
+        fee.max(0) // Ensure non-negative
+    }
+
+    /// Calculate net amount after fee deduction
+    pub fn calculate_net(&self, gross_amount: i64) -> i64 {
+        gross_amount - self.calculate_fee(gross_amount)
+    }
+
+    /// Check if slippage is within tolerance
+    ///
+    /// # Arguments
+    /// * `expected` - Expected target amount
+    /// * `actual` - Actual converted amount
+    ///
+    /// Returns true if the difference is within `max_slippage_basis_points`.
+    pub fn is_slippage_acceptable(&self, expected: i64, actual: i64) -> bool {
+        if expected == 0 {
+            return actual == 0;
+        }
+
+        // Calculate absolute percentage difference in basis points
+        let diff = (actual - expected).abs() as i128;
+        let pct = diff * 10000 / expected.abs() as i128;
+
+        pct <= self.max_slippage_basis_points as i128
+    }
+}
+
+/// Details of a cross-currency conversion for audit trail
+///
+/// This struct records all aspects of a currency conversion
+/// for transparency and dispute resolution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FxConversionDetails {
+    /// Source currency (what sender pays)
+    pub from_currency: String,
+
+    /// Target currency (what recipient receives)
+    pub to_currency: String,
+
+    /// Exchange rate used (target per source unit)
+    pub rate: f64,
+
+    /// When the rate was fetched (Unix seconds)
+    pub rate_timestamp: u64,
+
+    /// Sources that provided the rate
+    pub rate_sources: Vec<String>,
+
+    /// Whether the rate was marked as stale
+    pub rate_was_stale: bool,
+
+    /// Gross target amount before fees
+    pub gross_target_amount: i64,
+
+    /// Fee amount deducted (sent to treasury)
+    pub fee_amount: i64,
+
+    /// Net target amount to recipient
+    pub net_target_amount: i64,
+
+    /// Fee rate in basis points
+    pub fee_basis_points: u16,
+
+    /// Source amount (what sender paid)
+    pub source_amount: i64,
+}
+
+impl FxConversionDetails {
+    /// Create new conversion details
+    pub fn new(
+        from_currency: String,
+        to_currency: String,
+        source_amount: i64,
+        rate: f64,
+        rate_timestamp: u64,
+        rate_sources: Vec<String>,
+        rate_was_stale: bool,
+        gross_target_amount: i64,
+        fee_amount: i64,
+        net_target_amount: i64,
+        fee_basis_points: u16,
+    ) -> Self {
+        Self {
+            from_currency,
+            to_currency,
+            rate,
+            rate_timestamp,
+            rate_sources,
+            rate_was_stale,
+            gross_target_amount,
+            fee_amount,
+            net_target_amount,
+            fee_basis_points,
+            source_amount,
+        }
+    }
+
+    /// Effective exchange rate after fees
+    pub fn effective_rate(&self) -> f64 {
+        if self.source_amount == 0 {
+            return 0.0;
+        }
+        self.net_target_amount as f64 / self.source_amount as f64
+    }
+}
+
+/// A prepared cross-currency transfer ready for execution
+///
+/// This struct represents a transfer that has been validated and
+/// rate-locked but not yet committed to the ledger. The caller can:
+/// - Inspect the details and abort if conditions aren't acceptable
+/// - Execute the transfer to commit it
+#[derive(Debug, Clone)]
+pub struct PreparedFxTransfer {
+    /// The journal entry to be committed (4-leg or 5-leg with fee)
+    pub entry: JournalEntry,
+
+    /// Conversion details for audit trail
+    pub details: FxConversionDetails,
+
+    /// When this prepared transfer expires (Unix seconds)
+    ///
+    /// The rate is only valid until this time; after that,
+    /// a new rate should be fetched.
+    pub valid_until: u64,
+}
+
+impl PreparedFxTransfer {
+    /// Check if this prepared transfer is still valid
+    pub fn is_valid(&self) -> bool {
+        let now = crate::current_timestamp_secs();
+        now < self.valid_until
+    }
+
+    /// Get the entry hash (if computed)
+    pub fn entry_hash(&self) -> Option<&ContentHash> {
+        self.entry.id.as_ref()
+    }
+
+    /// Get sender DID
+    pub fn sender(&self) -> &Did {
+        &self.entry.author
+    }
+}
+
+/// Errors specific to FX operations
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum FxError {
+    /// FX configuration not set on ledger
+    #[error("FX not configured: set FxConfig before using cross-currency transfers")]
+    NotConfigured,
+
+    /// Oracle not configured on ledger
+    #[error("Oracle not configured: set oracle_manager before using cross-currency transfers")]
+    OracleNotConfigured,
+
+    /// Same currency specified (use regular transfer instead)
+    #[error("Same currency transfer: use regular transfer for {0} -> {0}")]
+    SameCurrency(String),
+
+    /// Rate not available
+    #[error("Exchange rate not available for {from}/{to}: {reason}")]
+    RateNotAvailable {
+        from: String,
+        to: String,
+        reason: String,
+    },
+
+    /// Rate is stale and stale rates are not allowed
+    #[error("Exchange rate is stale for {from}/{to}; set allow_stale_rates=true to accept")]
+    StaleRate { from: String, to: String },
+
+    /// Slippage exceeded
+    #[error("Slippage exceeded: expected {expected}, got {actual} (max {max_slippage_bps} bps)")]
+    SlippageExceeded {
+        expected: i64,
+        actual: i64,
+        max_slippage_bps: u16,
+    },
+
+    /// Prepared transfer expired
+    #[error("Prepared transfer expired at {expired_at}, current time {current_time}")]
+    TransferExpired { expired_at: u64, current_time: u64 },
+
+    /// Amount validation failed
+    #[error("Invalid amount: {0}")]
+    InvalidAmount(String),
+
+    /// Conversion would overflow
+    #[error(
+        "Conversion overflow: {source_amount} {from_currency} at rate {rate} exceeds i64 bounds"
+    )]
+    ConversionOverflow {
+        source_amount: i64,
+        from_currency: String,
+        rate: f64,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_clearing_did() -> Did {
+        Did::from_anchor_id(&[1u8; 32])
+    }
+
+    fn test_treasury_did() -> Did {
+        Did::from_anchor_id(&[2u8; 32])
+    }
+
+    #[test]
+    fn test_fx_config_default() {
+        let config = FxConfig::default();
+        assert_eq!(config.fee_basis_points, 0);
+        assert_eq!(config.max_fee_basis_points, 500);
+        assert_eq!(config.max_slippage_basis_points, 100);
+        assert!(!config.allow_stale_rates);
+        assert!(config.treasury_did.is_none());
+    }
+
+    #[test]
+    fn test_fx_config_builder() {
+        let clearing = test_clearing_did();
+        let treasury = test_treasury_did();
+
+        let config = FxConfig::new(clearing.clone())
+            .with_fee(100)
+            .with_treasury(treasury.clone())
+            .with_max_slippage(200);
+
+        assert_eq!(config.fee_basis_points, 100);
+        assert_eq!(config.max_slippage_basis_points, 200);
+        assert_eq!(config.clearing_did, clearing);
+        assert_eq!(config.treasury_did, Some(treasury));
+    }
+
+    #[test]
+    fn test_fee_calculation() {
+        let clearing = test_clearing_did();
+        let treasury = test_treasury_did();
+
+        let config = FxConfig::new(clearing)
+            .with_fee(100)
+            .with_treasury(treasury);
+
+        // 1% of 10000 = 100
+        assert_eq!(config.calculate_fee(10000), 100);
+        assert_eq!(config.calculate_net(10000), 9900);
+
+        // 1% of 250 = 2 (rounded down)
+        assert_eq!(config.calculate_fee(250), 2);
+        assert_eq!(config.calculate_net(250), 248);
+
+        // Small amounts
+        assert_eq!(config.calculate_fee(50), 0); // 0.5 rounds to 0
+        assert_eq!(config.calculate_net(50), 50);
+    }
+
+    #[test]
+    fn test_no_fee_without_treasury() {
+        let clearing = test_clearing_did();
+        let config = FxConfig::new(clearing).with_fee(100); // No treasury
+
+        assert_eq!(config.calculate_fee(10000), 0);
+        assert_eq!(config.calculate_net(10000), 10000);
+    }
+
+    #[test]
+    fn test_slippage_check() {
+        let clearing = test_clearing_did();
+        let config = FxConfig::new(clearing).with_max_slippage(100); // 1%
+
+        // Exact match
+        assert!(config.is_slippage_acceptable(1000, 1000));
+
+        // Within 1%
+        assert!(config.is_slippage_acceptable(1000, 1010));
+        assert!(config.is_slippage_acceptable(1000, 990));
+
+        // Exceeds 1%
+        assert!(!config.is_slippage_acceptable(1000, 1011));
+        assert!(!config.is_slippage_acceptable(1000, 989));
+
+        // Edge case: zero expected
+        assert!(config.is_slippage_acceptable(0, 0));
+        assert!(!config.is_slippage_acceptable(0, 1));
+    }
+
+    #[test]
+    fn test_fee_cap() {
+        let clearing = test_clearing_did();
+
+        // Try to set fee above max
+        let config = FxConfig::new(clearing).with_fee(1000); // 10%, but max is 5%
+
+        assert_eq!(config.fee_basis_points, 500); // Capped at 5%
+    }
+
+    #[test]
+    fn test_conversion_details() {
+        let details = FxConversionDetails::new(
+            "hours".to_string(),
+            "USD".to_string(),
+            10,    // source amount
+            25.0,  // rate
+            12345, // timestamp
+            vec!["manual".to_string()],
+            false,
+            250, // gross
+            2,   // fee
+            248, // net
+            100, // fee bps
+        );
+
+        assert_eq!(details.from_currency, "hours");
+        assert_eq!(details.to_currency, "USD");
+        assert_eq!(details.source_amount, 10);
+        assert_eq!(details.gross_target_amount, 250);
+        assert_eq!(details.net_target_amount, 248);
+
+        // Effective rate: 248 / 10 = 24.8
+        assert!((details.effective_rate() - 24.8).abs() < 0.001);
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+    use crate::oracle::{ManualRateSource, OracleManager};
+    use crate::Ledger;
+    use icn_identity::KeyPair;
+    use icn_store::SledStore;
+    use std::sync::Arc;
+
+    async fn setup_ledger_with_fx() -> (Ledger, Did, Did, Did) {
+        let store = Arc::new(SledStore::temporary().expect("create temp store"));
+        let mut ledger = Ledger::new(store.clone()).expect("create ledger");
+
+        // Create test accounts
+        let alice_kp = KeyPair::generate().expect("generate alice");
+        let bob_kp = KeyPair::generate().expect("generate bob");
+        let clearing_kp = KeyPair::generate().expect("generate clearing");
+        let treasury_kp = KeyPair::generate().expect("generate treasury");
+
+        let alice = alice_kp.did().clone();
+        let bob = bob_kp.did().clone();
+        let clearing = clearing_kp.did().clone();
+        let treasury = treasury_kp.did().clone();
+
+        // Set up oracle with manual rate source
+        let oracle = Arc::new(OracleManager::new(store.clone()));
+        let manual_source = Arc::new(ManualRateSource::new(store.clone()));
+
+        // Set up a rate: 1 hour = 25 USD
+        manual_source
+            .set_rate(
+                &crate::oracle::CurrencyPair::new("hours", "USD"),
+                25.0,
+                &clearing.to_string(),
+                None,
+            )
+            .expect("set rate");
+
+        // Register the source
+        oracle.register_source(manual_source).await;
+
+        ledger.set_oracle_manager(oracle);
+
+        // Set up FX config with 1% fee
+        let fx_config = FxConfig::new(clearing.clone())
+            .with_fee(100)
+            .with_treasury(treasury.clone())
+            .with_max_slippage(200); // 2% slippage
+
+        ledger.set_fx_config(fx_config);
+
+        (ledger, alice, bob, clearing)
+    }
+
+    #[tokio::test]
+    async fn test_prepare_cross_currency_transfer() {
+        let (ledger, alice, bob, _) = setup_ledger_with_fx().await;
+
+        // Prepare transfer: 10 hours -> USD
+        let prepared = ledger
+            .prepare_cross_currency_transfer(&alice, &bob, 10, "hours", "USD", None)
+            .await
+            .expect("prepare transfer");
+
+        // Verify conversion details
+        assert_eq!(prepared.details.source_amount, 10);
+        assert_eq!(prepared.details.from_currency, "hours");
+        assert_eq!(prepared.details.to_currency, "USD");
+        assert!((prepared.details.rate - 25.0).abs() < 0.001);
+
+        // 10 hours * 25 = 250 USD gross
+        assert_eq!(prepared.details.gross_target_amount, 250);
+
+        // 1% fee = 2 USD (rounded down from 2.5)
+        assert_eq!(prepared.details.fee_amount, 2);
+
+        // Net = 250 - 2 = 248 USD
+        assert_eq!(prepared.details.net_target_amount, 248);
+
+        // Entry should have 5 legs (with fee)
+        assert_eq!(prepared.entry.accounts.len(), 5);
+    }
+
+    #[tokio::test]
+    async fn test_transfer_with_conversion_basic() {
+        let (mut ledger, alice, bob, clearing) = setup_ledger_with_fx().await;
+
+        // Execute transfer: 10 hours -> USD
+        let (hash, details) = ledger
+            .transfer_with_conversion(&alice, &bob, 10, "hours", "USD", None)
+            .await
+            .expect("execute transfer");
+
+        // Verify entry was created
+        assert!(!hash.to_hex().is_empty());
+
+        // Verify conversion details
+        assert_eq!(details.source_amount, 10);
+        assert_eq!(details.gross_target_amount, 250);
+        assert_eq!(details.fee_amount, 2);
+        assert_eq!(details.net_target_amount, 248);
+
+        // Check balances
+        // Alice: debited 10 hours
+        assert_eq!(ledger.get_balance(&alice, "hours"), -10);
+
+        // Bob: credited 248 USD (net of fee)
+        assert_eq!(ledger.get_balance(&bob, "USD"), 248);
+
+        // Clearing: 10 hours credit, 250 USD debit
+        assert_eq!(ledger.get_balance(&clearing, "hours"), 10);
+        assert_eq!(ledger.get_balance(&clearing, "USD"), -250);
+    }
+
+    #[tokio::test]
+    async fn test_transfer_with_slippage_protection() {
+        let (ledger, alice, bob, _) = setup_ledger_with_fx().await;
+
+        // Set max target amount below what we'd get
+        // 10 hours * 25 = 250 USD, but we cap at 200
+        let result = ledger
+            .prepare_cross_currency_transfer(&alice, &bob, 10, "hours", "USD", Some(200))
+            .await;
+
+        // Should fail due to slippage
+        assert!(matches!(result, Err(FxError::SlippageExceeded { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_transfer_same_currency_rejected() {
+        let (ledger, alice, bob, _) = setup_ledger_with_fx().await;
+
+        let result = ledger
+            .prepare_cross_currency_transfer(&alice, &bob, 10, "hours", "hours", None)
+            .await;
+
+        assert!(matches!(result, Err(FxError::SameCurrency(_))));
+    }
+
+    #[tokio::test]
+    async fn test_transfer_invalid_amount() {
+        let (ledger, alice, bob, _) = setup_ledger_with_fx().await;
+
+        // Zero amount
+        let result = ledger
+            .prepare_cross_currency_transfer(&alice, &bob, 0, "hours", "USD", None)
+            .await;
+
+        assert!(matches!(result, Err(FxError::InvalidAmount(_))));
+
+        // Negative amount
+        let result = ledger
+            .prepare_cross_currency_transfer(&alice, &bob, -10, "hours", "USD", None)
+            .await;
+
+        assert!(matches!(result, Err(FxError::InvalidAmount(_))));
+    }
+
+    #[tokio::test]
+    async fn test_transfer_no_fx_config() {
+        let store = Arc::new(SledStore::temporary().expect("create temp store"));
+        let ledger = Ledger::new(store.clone()).expect("create ledger");
+
+        let alice = KeyPair::generate().expect("generate").did().clone();
+        let bob = KeyPair::generate().expect("generate").did().clone();
+
+        let result = ledger
+            .prepare_cross_currency_transfer(&alice, &bob, 10, "hours", "USD", None)
+            .await;
+
+        assert!(matches!(result, Err(FxError::NotConfigured)));
+    }
+
+    #[tokio::test]
+    async fn test_transfer_no_oracle() {
+        let store = Arc::new(SledStore::temporary().expect("create temp store"));
+        let mut ledger = Ledger::new(store).expect("create ledger");
+
+        let alice = KeyPair::generate().expect("generate").did().clone();
+        let bob = KeyPair::generate().expect("generate").did().clone();
+        let clearing = KeyPair::generate().expect("generate").did().clone();
+
+        // Set FX config but no oracle
+        ledger.set_fx_config(FxConfig::new(clearing));
+
+        let result = ledger
+            .prepare_cross_currency_transfer(&alice, &bob, 10, "hours", "USD", None)
+            .await;
+
+        assert!(matches!(result, Err(FxError::OracleNotConfigured)));
+    }
+
+    #[tokio::test]
+    async fn test_transfer_rate_not_available() {
+        let (ledger, alice, bob, _) = setup_ledger_with_fx().await;
+
+        // Try to convert to a currency we don't have a rate for
+        let result = ledger
+            .prepare_cross_currency_transfer(&alice, &bob, 10, "hours", "EUR", None)
+            .await;
+
+        assert!(matches!(result, Err(FxError::RateNotAvailable { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_transfer_without_fee() {
+        let store = Arc::new(SledStore::temporary().expect("create temp store"));
+        let mut ledger = Ledger::new(store.clone()).expect("create ledger");
+
+        let alice = KeyPair::generate().expect("generate").did().clone();
+        let bob = KeyPair::generate().expect("generate").did().clone();
+        let clearing = KeyPair::generate().expect("generate").did().clone();
+
+        // Set up oracle
+        let oracle = Arc::new(OracleManager::new(store.clone()));
+        let manual_source = Arc::new(ManualRateSource::new(store.clone()));
+
+        manual_source
+            .set_rate(
+                &crate::oracle::CurrencyPair::new("hours", "USD"),
+                25.0,
+                &clearing.to_string(),
+                None,
+            )
+            .expect("set rate");
+
+        oracle.register_source(manual_source).await;
+        ledger.set_oracle_manager(oracle);
+
+        // FX config without fee (no treasury)
+        ledger.set_fx_config(FxConfig::new(clearing.clone()));
+
+        // Execute transfer
+        let (_, details) = ledger
+            .transfer_with_conversion(&alice, &bob, 10, "hours", "USD", None)
+            .await
+            .expect("execute transfer");
+
+        // No fee should be taken
+        assert_eq!(details.fee_amount, 0);
+        assert_eq!(details.gross_target_amount, 250);
+        assert_eq!(details.net_target_amount, 250);
+
+        // Bob gets full amount
+        assert_eq!(ledger.get_balance(&bob, "USD"), 250);
+    }
+}

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -146,6 +146,10 @@ pub struct Ledger {
     /// Exchange rate oracle for multi-currency support
     /// When set, enables currency conversion operations.
     oracle_manager: Option<Arc<crate::oracle::OracleManager>>,
+
+    /// FX configuration for cross-currency transfers
+    /// When set, enables cross-currency payment operations.
+    fx_config: Option<crate::fx::FxConfig>,
 }
 
 impl Ledger {
@@ -179,6 +183,7 @@ impl Ledger {
             progressive_limit_manager: None, // Set via set_progressive_limit_manager()
             dynamic_limit_manager: None,     // Set via set_dynamic_limit_manager()
             oracle_manager: None,            // Set via set_oracle_manager()
+            fx_config: None,                 // Set via set_fx_config()
         };
 
         // Load cached balances from storage
@@ -426,6 +431,257 @@ impl Ledger {
 
         let converted = oracle.convert_amount(amount, from, to).await?;
         Ok(Some(converted))
+    }
+
+    /// Set the FX configuration for cross-currency transfers
+    ///
+    /// This must be set before calling cross-currency transfer methods.
+    /// The clearing account DID in the config must be a valid system account.
+    pub fn set_fx_config(&mut self, config: crate::fx::FxConfig) {
+        self.fx_config = Some(config);
+    }
+
+    /// Get the FX configuration (if set)
+    pub fn fx_config(&self) -> Option<&crate::fx::FxConfig> {
+        self.fx_config.as_ref()
+    }
+
+    /// Prepare a cross-currency transfer without committing
+    ///
+    /// This fetches the current exchange rate and builds a journal entry
+    /// that can be inspected before committing. The prepared transfer
+    /// expires after the rate's TTL.
+    ///
+    /// # Arguments
+    /// * `from` - Sender DID
+    /// * `to` - Recipient DID
+    /// * `source_amount` - Amount to debit from sender (in source currency)
+    /// * `from_currency` - Source currency code
+    /// * `to_currency` - Target currency code
+    /// * `max_target_amount` - Optional slippage protection (reject if converted > max)
+    ///
+    /// # Errors
+    /// - `FxError::NotConfigured` if FX config not set
+    /// - `FxError::OracleNotConfigured` if oracle not set
+    /// - `FxError::SameCurrency` if from/to currencies match
+    /// - `FxError::RateNotAvailable` if oracle has no rate
+    /// - `FxError::StaleRate` if rate is stale and not allowed
+    /// - `FxError::SlippageExceeded` if converted amount exceeds max
+    pub async fn prepare_cross_currency_transfer(
+        &self,
+        from: &Did,
+        to: &Did,
+        source_amount: i64,
+        from_currency: &str,
+        to_currency: &str,
+        max_target_amount: Option<i64>,
+    ) -> std::result::Result<crate::fx::PreparedFxTransfer, crate::fx::FxError> {
+        use crate::entry::JournalEntryBuilder;
+        use crate::fx::{FxConversionDetails, FxError, PreparedFxTransfer};
+        use crate::oracle::CurrencyPair;
+
+        // Validate configuration
+        let fx_config = self.fx_config.as_ref().ok_or(FxError::NotConfigured)?;
+
+        let oracle = self
+            .oracle_manager
+            .as_ref()
+            .ok_or(FxError::OracleNotConfigured)?;
+
+        // Validate currencies differ
+        if from_currency == to_currency {
+            return Err(FxError::SameCurrency(from_currency.to_string()));
+        }
+
+        // Validate amount
+        if source_amount <= 0 {
+            return Err(FxError::InvalidAmount(format!(
+                "Source amount must be positive, got: {source_amount}"
+            )));
+        }
+
+        // Get exchange rate from oracle
+        let pair = CurrencyPair::new(from_currency, to_currency);
+        let rate = oracle
+            .get_rate(&pair)
+            .await
+            .map_err(|e| FxError::RateNotAvailable {
+                from: from_currency.to_string(),
+                to: to_currency.to_string(),
+                reason: e.to_string(),
+            })?;
+
+        // Check staleness
+        if rate.is_stale && !fx_config.allow_stale_rates {
+            return Err(FxError::StaleRate {
+                from: from_currency.to_string(),
+                to: to_currency.to_string(),
+            });
+        }
+
+        // Convert amount using oracle rate
+        let gross_target_amount =
+            rate.convert(source_amount)
+                .ok_or(FxError::ConversionOverflow {
+                    source_amount,
+                    from_currency: from_currency.to_string(),
+                    rate: rate.rate,
+                })?;
+
+        // Check slippage if max specified
+        if let Some(max) = max_target_amount {
+            if gross_target_amount > max {
+                return Err(FxError::SlippageExceeded {
+                    expected: max,
+                    actual: gross_target_amount,
+                    max_slippage_bps: fx_config.max_slippage_basis_points,
+                });
+            }
+        }
+
+        // Calculate fee and net amount
+        let fee_amount = fx_config.calculate_fee(gross_target_amount);
+        let net_target_amount = gross_target_amount - fee_amount;
+
+        // Build 4-leg (or 5-leg with fee) journal entry
+        // In ICN mutual credit: CREDIT = sending (balance decreases), DEBIT = receiving (balance increases)
+        // 1. CREDIT sender (source currency) - sender's balance decreases
+        // 2. DEBIT clearing (source currency) - clearing receives source
+        // 3. CREDIT clearing (target currency) - clearing sends target
+        // 4. DEBIT recipient (target currency) - recipient's balance increases
+        // 5. DEBIT treasury (target currency) - treasury receives fee, only if fee > 0
+        let mut builder = JournalEntryBuilder::new(from.clone())
+            .credit(from.clone(), from_currency.to_string(), source_amount)
+            .debit(
+                fx_config.clearing_did.clone(),
+                from_currency.to_string(),
+                source_amount,
+            )
+            .credit(
+                fx_config.clearing_did.clone(),
+                to_currency.to_string(),
+                gross_target_amount,
+            );
+
+        // Add treasury fee leg if applicable
+        if fee_amount > 0 {
+            if let Some(treasury) = &fx_config.treasury_did {
+                builder = builder
+                    .debit(treasury.clone(), to_currency.to_string(), fee_amount)
+                    .debit(to.clone(), to_currency.to_string(), net_target_amount);
+            } else {
+                // No treasury configured, net = gross
+                builder = builder.debit(to.clone(), to_currency.to_string(), gross_target_amount);
+            }
+        } else {
+            builder = builder.debit(to.clone(), to_currency.to_string(), gross_target_amount);
+        }
+
+        let entry = builder
+            .build()
+            .map_err(|e| FxError::InvalidAmount(format!("Failed to build journal entry: {e}")))?;
+
+        // Calculate expiration (use rate TTL)
+        let valid_until = rate.aggregated_at.saturating_add(rate.ttl_secs);
+
+        // Build conversion details for audit
+        let details = FxConversionDetails::new(
+            from_currency.to_string(),
+            to_currency.to_string(),
+            source_amount,
+            rate.rate,
+            rate.aggregated_at,
+            rate.sources(),
+            rate.is_stale,
+            gross_target_amount,
+            fee_amount,
+            if fee_amount > 0 && fx_config.treasury_did.is_some() {
+                net_target_amount
+            } else {
+                gross_target_amount
+            },
+            fx_config.fee_basis_points,
+        );
+
+        Ok(PreparedFxTransfer {
+            entry,
+            details,
+            valid_until,
+        })
+    }
+
+    /// Execute a prepared cross-currency transfer
+    ///
+    /// Commits the journal entry from a prepared transfer to the ledger.
+    /// The prepared transfer must not be expired.
+    ///
+    /// # Arguments
+    /// * `prepared` - The prepared transfer from `prepare_cross_currency_transfer`
+    ///
+    /// # Returns
+    /// The content hash of the committed entry and conversion details.
+    pub fn execute_cross_currency_transfer(
+        &mut self,
+        prepared: crate::fx::PreparedFxTransfer,
+    ) -> std::result::Result<(ContentHash, crate::fx::FxConversionDetails), crate::fx::FxError>
+    {
+        use crate::fx::FxError;
+
+        // Check if prepared transfer is still valid
+        let now = crate::current_timestamp_secs();
+        if now >= prepared.valid_until {
+            return Err(FxError::TransferExpired {
+                expired_at: prepared.valid_until,
+                current_time: now,
+            });
+        }
+
+        // Append the entry to the ledger
+        let hash = self
+            .append_entry(prepared.entry)
+            .map_err(|e| FxError::InvalidAmount(format!("Failed to append entry: {e}")))?;
+
+        Ok((hash, prepared.details))
+    }
+
+    /// Execute a cross-currency transfer in one step
+    ///
+    /// Convenience method that prepares and executes a transfer atomically.
+    /// Use `prepare_cross_currency_transfer` + `execute_cross_currency_transfer`
+    /// if you need to inspect the transfer before committing.
+    ///
+    /// # Arguments
+    /// * `from` - Sender DID
+    /// * `to` - Recipient DID
+    /// * `source_amount` - Amount to debit from sender (in source currency)
+    /// * `from_currency` - Source currency code
+    /// * `to_currency` - Target currency code
+    /// * `max_target_amount` - Optional slippage protection
+    ///
+    /// # Returns
+    /// The content hash and conversion details.
+    pub async fn transfer_with_conversion(
+        &mut self,
+        from: &Did,
+        to: &Did,
+        source_amount: i64,
+        from_currency: &str,
+        to_currency: &str,
+        max_target_amount: Option<i64>,
+    ) -> std::result::Result<(ContentHash, crate::fx::FxConversionDetails), crate::fx::FxError>
+    {
+        let prepared = self
+            .prepare_cross_currency_transfer(
+                from,
+                to,
+                source_amount,
+                from_currency,
+                to_currency,
+                max_target_amount,
+            )
+            .await?;
+
+        self.execute_cross_currency_transfer(prepared)
     }
 
     /// Append a journal entry to the ledger

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -586,6 +586,8 @@ impl Ledger {
 
         // Build conversion details for audit
         let details = FxConversionDetails::new(
+            from.to_string(),
+            to.to_string(),
             from_currency.to_string(),
             to_currency.to_string(),
             source_amount,
@@ -640,6 +642,32 @@ impl Ledger {
         let hash = self
             .append_entry(prepared.entry)
             .map_err(|e| FxError::InvalidAmount(format!("Failed to append entry: {e}")))?;
+
+        // Emit cross-currency transfer event
+        if let Some(ref emitter) = self.event_emitter {
+            // Parse DIDs from the details (they were just converted to strings from DIDs)
+            if let (Ok(from_did), Ok(to_did)) = (
+                Did::from_str(&prepared.details.from_did),
+                Did::from_str(&prepared.details.to_did),
+            ) {
+                emitter.emit_cross_currency_transfer(
+                    &hash,
+                    &from_did,
+                    &to_did,
+                    prepared.details.source_amount,
+                    &prepared.details.from_currency,
+                    prepared.details.gross_target_amount,
+                    prepared.details.fee_amount,
+                    prepared.details.net_target_amount,
+                    &prepared.details.to_currency,
+                    prepared.details.rate,
+                    prepared.details.rate_timestamp,
+                    prepared.details.rate_sources.clone(),
+                    now,
+                    self.domain_id.clone(),
+                );
+            }
+        }
 
         Ok((hash, prepared.details))
     }

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -564,17 +564,26 @@ impl Ledger {
             );
 
         // Add treasury fee leg if applicable
-        if fee_amount > 0 {
+        // Simplified logic: fee is only collected when both fee_amount > 0 AND treasury is configured
+        // Note: calculate_fee() already returns 0 when treasury_did.is_none(), but we make this
+        // explicit here for clarity and to prevent any drift between the two conditions.
+        let (recipient_amount, has_treasury_fee) =
+            if fee_amount > 0 && fx_config.treasury_did.is_some() {
+                (net_target_amount, true)
+            } else {
+                (gross_target_amount, false)
+            };
+
+        if has_treasury_fee {
+            // Use if-let pattern to satisfy clippy::unwrap_used lint
+            // has_treasury_fee is true only when treasury_did.is_some()
             if let Some(treasury) = &fx_config.treasury_did {
                 builder = builder
                     .debit(treasury.clone(), to_currency.to_string(), fee_amount)
-                    .debit(to.clone(), to_currency.to_string(), net_target_amount);
-            } else {
-                // No treasury configured, net = gross
-                builder = builder.debit(to.clone(), to_currency.to_string(), gross_target_amount);
+                    .debit(to.clone(), to_currency.to_string(), recipient_amount);
             }
         } else {
-            builder = builder.debit(to.clone(), to_currency.to_string(), gross_target_amount);
+            builder = builder.debit(to.clone(), to_currency.to_string(), recipient_amount);
         }
 
         let entry = builder
@@ -585,6 +594,7 @@ impl Ledger {
         let valid_until = rate.aggregated_at.saturating_add(rate.ttl_secs);
 
         // Build conversion details for audit
+        // Note: recipient_amount is calculated above and matches the journal entry logic
         let details = FxConversionDetails::new(
             from.to_string(),
             to.to_string(),
@@ -597,11 +607,7 @@ impl Ledger {
             rate.is_stale,
             gross_target_amount,
             fee_amount,
-            if fee_amount > 0 && fx_config.treasury_did.is_some() {
-                net_target_amount
-            } else {
-                gross_target_amount
-            },
+            recipient_amount, // Uses same logic as journal entry builder
             fx_config.fee_basis_points,
         );
 
@@ -630,8 +636,14 @@ impl Ledger {
         use crate::fx::FxError;
 
         // Check if prepared transfer is still valid
+        // Safety margin: reject 1 second before expiry to prevent TOCTOU race conditions
+        // (e.g., GC pause between check and append could allow expired rate to be committed)
+        const EXPIRATION_SAFETY_MARGIN_SECS: u64 = 1;
         let now = crate::current_timestamp_secs();
-        if now >= prepared.valid_until {
+        let effective_expiry = prepared
+            .valid_until
+            .saturating_sub(EXPIRATION_SAFETY_MARGIN_SECS);
+        if now >= effective_expiry {
             return Err(FxError::TransferExpired {
                 expired_at: prepared.valid_until,
                 current_time: now,

--- a/icn/crates/icn-ledger/src/lib.rs
+++ b/icn/crates/icn-ledger/src/lib.rs
@@ -60,6 +60,7 @@ pub mod events;
 #[allow(missing_docs)]
 pub mod fork_resolution;
 pub mod freeze;
+pub mod fx;
 pub mod hash;
 pub mod ledger;
 pub mod membership;
@@ -101,11 +102,14 @@ pub use types::{
     DisputeStatus, JournalEntry, QuarantineReason, QuarantinedEntry, Resolution, Signature,
 };
 
+// FX (cross-currency) support
+pub use fx::{FxConfig, FxConversionDetails, FxError, PreparedFxTransfer};
+
 // Event types for real-time notifications
 pub use events::{
-    create_shared_emitter, BalanceChanged, BatchBalanceChanged, ForkDetected, ForkResolved,
-    LedgerEvent, LedgerEventEmitter, MemberFrozen, MemberUnfrozen, RollbackPerformed,
-    SharedEventEmitter, TransactionConfirmed, TransactionCreated, Transfer,
+    create_shared_emitter, BalanceChanged, BatchBalanceChanged, CrossCurrencyTransfer,
+    ForkDetected, ForkResolved, LedgerEvent, LedgerEventEmitter, MemberFrozen, MemberUnfrozen,
+    RollbackPerformed, SharedEventEmitter, TransactionConfirmed, TransactionCreated, Transfer,
 };
 
 // Exchange rate oracle

--- a/icn/crates/icn-obs/src/metrics/gateway.rs
+++ b/icn/crates/icn-obs/src/metrics/gateway.rs
@@ -425,3 +425,82 @@ pub fn oracle_outliers_filtered_inc(pair: &str, count: usize) {
 pub fn oracle_cached_pairs_set(count: usize) {
     gauge!("icn_gateway_oracle_cached_pairs").set(count as f64);
 }
+
+// FX (Cross-Currency) Payment metrics
+
+/// Increment cross-currency payments total counter
+pub fn fx_payments_total_inc(from_currency: &str, to_currency: &str) {
+    counter!(
+        "icn_gateway_fx_payments_total",
+        "from_currency" => from_currency.to_string(),
+        "to_currency" => to_currency.to_string()
+    )
+    .increment(1);
+}
+
+/// Record cross-currency payment source amount
+pub fn fx_payment_source_amount_record(currency: &str, amount: i64) {
+    counter!(
+        "icn_gateway_fx_payment_source_amount_total",
+        "currency" => currency.to_string()
+    )
+    .increment(amount.unsigned_abs());
+}
+
+/// Record cross-currency payment target amount (net after fees)
+pub fn fx_payment_target_amount_record(currency: &str, amount: i64) {
+    counter!(
+        "icn_gateway_fx_payment_target_amount_total",
+        "currency" => currency.to_string()
+    )
+    .increment(amount.unsigned_abs());
+}
+
+/// Record cross-currency payment fee amount
+pub fn fx_payment_fee_amount_record(currency: &str, amount: i64) {
+    counter!(
+        "icn_gateway_fx_payment_fee_amount_total",
+        "currency" => currency.to_string()
+    )
+    .increment(amount.unsigned_abs());
+}
+
+/// Increment cross-currency quote requests counter
+pub fn fx_quote_requests_inc(from_currency: &str, to_currency: &str) {
+    counter!(
+        "icn_gateway_fx_quote_requests_total",
+        "from_currency" => from_currency.to_string(),
+        "to_currency" => to_currency.to_string()
+    )
+    .increment(1);
+}
+
+/// Increment cross-currency payment slippage rejections counter
+pub fn fx_slippage_rejections_inc(from_currency: &str, to_currency: &str) {
+    counter!(
+        "icn_gateway_fx_slippage_rejections_total",
+        "from_currency" => from_currency.to_string(),
+        "to_currency" => to_currency.to_string()
+    )
+    .increment(1);
+}
+
+/// Increment cross-currency payment stale rate rejections counter
+pub fn fx_stale_rate_rejections_inc(from_currency: &str, to_currency: &str) {
+    counter!(
+        "icn_gateway_fx_stale_rate_rejections_total",
+        "from_currency" => from_currency.to_string(),
+        "to_currency" => to_currency.to_string()
+    )
+    .increment(1);
+}
+
+/// Increment cross-currency payment expired rate rejections counter
+pub fn fx_expired_rate_rejections_inc(from_currency: &str, to_currency: &str) {
+    counter!(
+        "icn_gateway_fx_expired_rate_rejections_total",
+        "from_currency" => from_currency.to_string(),
+        "to_currency" => to_currency.to_string()
+    )
+    .increment(1);
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -55,6 +55,10 @@ import {
   Balance,
   PaymentRequest,
   PaymentResponse,
+  CrossPaymentRequest,
+  CrossPaymentResponse,
+  CrossPaymentQuoteRequest,
+  CrossPaymentQuote,
   TransactionHistory,
   GovernanceDomain,
   CreateDomainRequest,
@@ -666,6 +670,55 @@ export class ICNClient {
    */
   async pay(coopId: string, req: PaymentRequest): Promise<PaymentResponse> {
     return this.post<PaymentResponse>(`/ledger/${coopId}/payment`, req);
+  }
+
+  /**
+   * Create a cross-currency payment
+   *
+   * Executes a payment where the sender pays in one currency and the recipient
+   * receives in another. Uses the exchange rate oracle for conversion.
+   *
+   * @example
+   * ```typescript
+   * // Send 10 hours, recipient receives USD equivalent
+   * const result = await client.crossPay('my-coop', {
+   *   from: 'did:icn:alice...',
+   *   to: 'did:icn:bob...',
+   *   amount: 10,
+   *   from_currency: 'hours',
+   *   to_currency: 'USD',
+   *   max_target_amount: 260, // Slippage protection
+   * });
+   * console.log(`Bob received ${result.net_target_amount} USD`);
+   * ```
+   */
+  async crossPay(coopId: string, req: CrossPaymentRequest): Promise<CrossPaymentResponse> {
+    return this.post<CrossPaymentResponse>(`/ledger/${coopId}/payment/convert`, req);
+  }
+
+  /**
+   * Get a cross-currency payment quote
+   *
+   * Returns a preview of what a cross-currency payment would look like without
+   * actually executing it. Useful for showing users the expected conversion.
+   *
+   * @example
+   * ```typescript
+   * // Get quote for converting 10 hours to USD
+   * const quote = await client.getCrossPaymentQuote('my-coop', {
+   *   amount: 10,
+   *   from_currency: 'hours',
+   *   to_currency: 'USD',
+   * });
+   * console.log(`Rate: ${quote.rate}, Fee: ${quote.fee_amount}`);
+   * console.log(`You would receive: ${quote.net_target_amount} USD`);
+   * if (quote.is_stale) {
+   *   console.warn('Warning: Rate may be outdated');
+   * }
+   * ```
+   */
+  async getCrossPaymentQuote(coopId: string, req: CrossPaymentQuoteRequest): Promise<CrossPaymentQuote> {
+    return this.post<CrossPaymentQuote>(`/ledger/${coopId}/payment/convert/quote`, req);
   }
 
   /**

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -150,6 +150,101 @@ export interface PaymentResponse {
   timestamp: number;
 }
 
+// ============================================================================
+// Cross-Currency Payments
+// ============================================================================
+
+/**
+ * Request for a cross-currency payment where sender pays in one currency
+ * and recipient receives in another.
+ */
+export interface CrossPaymentRequest {
+  /** Sender DID */
+  from: string;
+  /** Recipient DID */
+  to: string;
+  /** Amount to send in source currency */
+  amount: number;
+  /** Source currency (what sender pays) */
+  from_currency: string;
+  /** Target currency (what recipient receives) */
+  to_currency: string;
+  /** Maximum target amount for slippage protection (optional) */
+  max_target_amount?: number;
+  /** Optional memo */
+  memo?: string;
+}
+
+/**
+ * Response from a cross-currency payment
+ */
+export interface CrossPaymentResponse {
+  /** Transaction hash */
+  hash: string;
+  /** Sender DID */
+  from: string;
+  /** Recipient DID */
+  to: string;
+  /** Amount debited from sender */
+  source_amount: number;
+  /** Source currency */
+  from_currency: string;
+  /** Gross amount before fees */
+  gross_target_amount: number;
+  /** Fee amount deducted */
+  fee_amount: number;
+  /** Net amount credited to recipient */
+  net_target_amount: number;
+  /** Target currency */
+  to_currency: string;
+  /** Exchange rate used */
+  rate_used: number;
+  /** When the rate was fetched */
+  rate_timestamp: number;
+  /** Sources that provided the rate */
+  rate_sources: string[];
+}
+
+/**
+ * Request for a cross-currency payment quote (preview without execution)
+ */
+export interface CrossPaymentQuoteRequest {
+  /** Amount to send in source currency */
+  amount: number;
+  /** Source currency (what sender pays) */
+  from_currency: string;
+  /** Target currency (what recipient receives) */
+  to_currency: string;
+}
+
+/**
+ * Quote for a cross-currency payment
+ */
+export interface CrossPaymentQuote {
+  /** Amount that would be debited from sender */
+  source_amount: number;
+  /** Source currency */
+  from_currency: string;
+  /** Gross amount before fees */
+  gross_target_amount: number;
+  /** Fee amount that would be deducted */
+  fee_amount: number;
+  /** Net amount that would be credited to recipient */
+  net_target_amount: number;
+  /** Target currency */
+  to_currency: string;
+  /** Exchange rate */
+  rate: number;
+  /** When the rate was fetched */
+  rate_timestamp: number;
+  /** Sources that provided the rate */
+  rate_sources: string[];
+  /** When this quote expires (Unix seconds) */
+  valid_until: number;
+  /** Whether the rate is considered stale */
+  is_stale: boolean;
+}
+
 export interface Transaction {
   id: string;
   from: string;


### PR DESCRIPTION
## Summary

Implements complete cross-currency payment functionality for Issue #207 (all 4 phases).

### Phase 1-2: Core Types & Transfer Logic (icn-ledger)
- **FxConfig**: Configuration for FX transfers including fee basis points, treasury/clearing accounts, and slippage tolerance
- **FxConversionDetails**: Audit trail for currency conversions
- **PreparedFxTransfer**: Rate-locked transfer that can be inspected before execution
- **CrossCurrencyTransfer event**: Real-time notification for FX transactions
- Ledger methods: `prepare_cross_currency_transfer()`, `execute_cross_currency_transfer()`, `transfer_with_conversion()`

### Phase 3: Gateway Integration (icn-gateway)
- `POST /ledger/{coop_id}/payment/convert` - Execute cross-currency payment
- `GET /ledger/{coop_id}/payment/convert/quote` - Get quote without execution
- Request/response types: `CreateCrossPaymentRequest`, `CrossPaymentResponse`, `CrossPaymentQuote`
- Integration tests for validation, authorization, and slippage

### Phase 4: SDK & Metrics
- TypeScript SDK methods: `crossPay()`, `getCrossPaymentQuote()`
- TypeScript types: `CrossPaymentRequest`, `CrossPaymentResponse`, `CrossPaymentQuote`
- Prometheus metrics: `icn_gateway_fx_payments_total`, `icn_gateway_fx_payment_*_amount_total`, etc.

## Design

Uses 4-leg (or 5-leg with fee) journal entry pattern to maintain double-entry invariant per currency:
```
1. CREDIT sender (source currency) - balance decreases
2. DEBIT clearing (source currency) - clearing receives
3. CREDIT clearing (target currency) - clearing sends
4. DEBIT recipient (target currency) - balance increases
5. DEBIT treasury (target currency) - fee (if configured)
```

Example: Alice sends 10 hours → Bob receives 248 USD (at rate 25.0, 1% fee = 2 USD)

## Test plan

- [x] 18 unit tests for FX conversion logic
- [x] 5 integration tests for Gateway API validation
- [x] All 183 icn-ledger tests pass
- [x] TypeScript SDK tests pass (125 tests)
- [x] clippy clean
- [x] fmt clean

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)