### PR TITLE
feat(gateway): Map FX errors to structured error codes

### DIFF
--- a/icn/crates/icn-gateway/src/api/ledger.rs
+++ b/icn/crates/icn-gateway/src/api/ledger.rs
@@ -1202,4 +1202,139 @@ mod tests {
         let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status(), actix_web::http::StatusCode::FORBIDDEN);
     }
+
+    /// Test that FX errors return structured error response with code field (Issue #374)
+    ///
+    /// This test verifies that when an FxError is returned from LedgerManager,
+    /// the HTTP response includes both 'error' and 'code' fields for programmatic handling.
+    #[actix_web::test]
+    async fn test_fx_error_response_includes_error_code() {
+        let ledger_mgr = Arc::new(LedgerManager::new());
+        let db = sled::Config::new().temporary(true).open().unwrap();
+        let budget_store = BudgetStore::new(db);
+        let velocity_limiter = VelocityLimiter::default();
+        let trust_mgr = Arc::new(TrustManager::new());
+        let alice = IdentityBundle::generate().unwrap();
+        let bob = IdentityBundle::generate().unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(ledger_mgr.clone()))
+                .app_data(web::Data::new(budget_store.clone()))
+                .app_data(web::Data::new(velocity_limiter.clone()))
+                .app_data(web::Data::new(trust_mgr.clone()))
+                .service(web::scope("/ledger").service(create_cross_payment)),
+        )
+        .await;
+
+        // Cross-payment with different currencies - will reach FX code which returns
+        // FX_NOT_CONFIGURED since no oracle is configured in test LedgerManager
+        let req_body = CreateCrossPaymentRequest {
+            from: alice.did().to_string(),
+            to: bob.did().to_string(),
+            amount: 100,
+            from_currency: "hours".to_string(),
+            to_currency: "USD".to_string(), // Different currencies -> reaches FX code
+            max_target_amount: None,
+            memo: None,
+        };
+
+        let claims = TokenClaims {
+            sub: alice.did().to_string(),
+            iat: 1000000000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["ledger:write".to_string()],
+            exp: 9999999999,
+        };
+
+        let req = test::TestRequest::post()
+            .uri("/ledger/test-coop/payment/convert")
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        // FX not configured is a server error (500)
+        assert_eq!(
+            resp.status(),
+            actix_web::http::StatusCode::INTERNAL_SERVER_ERROR
+        );
+
+        // Verify the response body has both error and code fields
+        let body = test::read_body(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert!(
+            json.get("error").is_some(),
+            "Response should have 'error' field"
+        );
+        assert!(
+            json.get("code").is_some(),
+            "Response should have 'code' field"
+        );
+        assert_eq!(
+            json["code"], "FX_NOT_CONFIGURED",
+            "Error code should be FX_NOT_CONFIGURED"
+        );
+    }
+
+    /// Test that quote endpoint also returns structured error codes (Issue #374)
+    #[actix_web::test]
+    async fn test_fx_quote_error_response_includes_error_code() {
+        let ledger_mgr = Arc::new(LedgerManager::new());
+        let alice = IdentityBundle::generate().unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(ledger_mgr.clone()))
+                .service(web::scope("/ledger").service(get_cross_payment_quote)),
+        )
+        .await;
+
+        // Quote with different currencies - will reach FX code which returns
+        // FX_NOT_CONFIGURED since no oracle is configured in test LedgerManager
+        let req_body = CrossPaymentQuoteRequest {
+            amount: 100,
+            from_currency: "hours".to_string(),
+            to_currency: "USD".to_string(), // Different currencies -> reaches FX code
+        };
+
+        let claims = TokenClaims {
+            sub: alice.did().to_string(),
+            iat: 1000000000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["ledger:read".to_string()],
+            exp: 9999999999,
+        };
+
+        let req = test::TestRequest::post()
+            .uri("/ledger/test-coop/payment/convert/quote")
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        // FX not configured is a server error (500)
+        assert_eq!(
+            resp.status(),
+            actix_web::http::StatusCode::INTERNAL_SERVER_ERROR
+        );
+
+        // Verify the response body has both error and code fields
+        let body = test::read_body(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert!(
+            json.get("error").is_some(),
+            "Response should have 'error' field"
+        );
+        assert!(
+            json.get("code").is_some(),
+            "Response should have 'code' field"
+        );
+        assert_eq!(
+            json["code"], "FX_NOT_CONFIGURED",
+            "Error code should be FX_NOT_CONFIGURED"
+        );
+    }
 }

--- a/icn/crates/icn-gateway/src/error.rs
+++ b/icn/crates/icn-gateway/src/error.rs
@@ -1,6 +1,7 @@
 //! Error types for ICN Gateway
 
 use actix_web::{http::StatusCode, HttpResponse, ResponseError};
+use icn_ledger::fx::FxError;
 
 /// Gateway result type
 pub type Result<T> = std::result::Result<T, GatewayError>;
@@ -40,6 +41,33 @@ pub enum GatewayError {
 
     #[error("I/O error: {0}")]
     IoError(#[from] std::io::Error),
+
+    #[error("FX error: {0}")]
+    Fx(#[from] FxError),
+}
+
+impl GatewayError {
+    /// Get the error code for structured error responses
+    ///
+    /// Returns a machine-readable error code that SDK clients can use for
+    /// programmatic error handling.
+    pub fn error_code(&self) -> Option<&'static str> {
+        match self {
+            GatewayError::AuthenticationFailed(_) => Some("AUTHENTICATION_FAILED"),
+            GatewayError::AuthorizationFailed(_) => Some("AUTHORIZATION_FAILED"),
+            GatewayError::Forbidden(_) => Some("FORBIDDEN"),
+            GatewayError::NotFound(_) => Some("NOT_FOUND"),
+            GatewayError::BadRequest(_) => Some("BAD_REQUEST"),
+            GatewayError::RateLimitExceeded(_) => Some("RATE_LIMIT_EXCEEDED"),
+            GatewayError::BudgetExceeded(_) => Some("BUDGET_EXCEEDED"),
+            GatewayError::ServiceUnavailable(_) => Some("SERVICE_UNAVAILABLE"),
+            GatewayError::Fx(fx_err) => Some(fx_err.error_code()),
+            // Internal errors don't expose codes
+            GatewayError::InternalError(_) => None,
+            GatewayError::SubstrateError(_) => None,
+            GatewayError::IoError(_) => None,
+        }
+    }
 }
 
 impl ResponseError for GatewayError {
@@ -56,6 +84,15 @@ impl ResponseError for GatewayError {
             GatewayError::ServiceUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
             GatewayError::SubstrateError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             GatewayError::IoError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            GatewayError::Fx(fx_err) => {
+                if fx_err.is_client_error() {
+                    StatusCode::BAD_REQUEST
+                } else if fx_err.is_not_found() {
+                    StatusCode::NOT_FOUND
+                } else {
+                    StatusCode::INTERNAL_SERVER_ERROR
+                }
+            }
         }
     }
 
@@ -73,6 +110,9 @@ impl ResponseError for GatewayError {
             GatewayError::BudgetExceeded(msg) => msg.clone(),
             GatewayError::ServiceUnavailable(msg) => msg.clone(),
 
+            // FX errors - user-facing with structured codes
+            GatewayError::Fx(fx_err) => fx_err.to_string(),
+
             // Internal errors - sanitize to prevent information leakage
             // Log the full error for debugging but return generic message to client
             GatewayError::InternalError(details) => {
@@ -89,8 +129,15 @@ impl ResponseError for GatewayError {
             }
         };
 
-        HttpResponse::build(self.status_code()).json(serde_json::json!({
+        // Build response with optional error code
+        let mut response = serde_json::json!({
             "error": error_message,
-        }))
+        });
+
+        if let Some(code) = self.error_code() {
+            response["code"] = serde_json::Value::String(code.to_string());
+        }
+
+        HttpResponse::build(self.status_code()).json(response)
     }
 }

--- a/icn/crates/icn-gateway/src/ledger_mgr.rs
+++ b/icn/crates/icn-gateway/src/ledger_mgr.rs
@@ -470,13 +470,24 @@ impl LedgerManager {
         }
 
         // Calculate conversion
-        let gross_target_amount =
-            rate.convert(amount)
-                .ok_or_else(|| icn_ledger::fx::FxError::ConversionOverflow {
-                    source_amount: amount,
-                    from_currency: from_currency.to_string(),
-                    rate: rate.rate,
-                })?;
+        let gross_target_amount = rate.convert(amount).ok_or_else(|| {
+            // Log a warning if overflow occurs with a suspiciously high rate
+            // This could indicate oracle misconfiguration
+            if rate.rate > 1000.0 {
+                tracing::warn!(
+                    rate = rate.rate,
+                    amount = amount,
+                    from_currency = from_currency,
+                    to_currency = to_currency,
+                    "Conversion overflow with high exchange rate - possible oracle misconfiguration"
+                );
+            }
+            icn_ledger::fx::FxError::ConversionOverflow {
+                source_amount: amount,
+                from_currency: from_currency.to_string(),
+                rate: rate.rate,
+            }
+        })?;
 
         // Calculate fee using same logic as actual execution for consistency
         let fee_amount = fx_config.calculate_fee(gross_target_amount);

--- a/icn/crates/icn-gateway/src/ledger_mgr.rs
+++ b/icn/crates/icn-gateway/src/ledger_mgr.rs
@@ -360,8 +360,7 @@ impl LedgerManager {
                     to_currency,
                     max_target_amount,
                 )
-                .await
-                .map_err(|e| GatewayError::InternalError(format!("FX error: {e}")))?
+                .await?
         };
 
         // Execute the transfer (writes to ledger) - needs write lock
@@ -370,9 +369,7 @@ impl LedgerManager {
                 .write()
                 .map_err(|e| GatewayError::InternalError(format!("Lock poisoned: {e}")))?;
 
-            let (hash, details) = ledger
-                .execute_cross_currency_transfer(prepared)
-                .map_err(|e| GatewayError::InternalError(format!("FX execution error: {e}")))?;
+            let (hash, details) = ledger.execute_cross_currency_transfer(prepared)?;
 
             (hash.to_hex(), details)
         };
@@ -440,35 +437,46 @@ impl LedgerManager {
                 .read()
                 .map_err(|e| GatewayError::InternalError(format!("Lock poisoned: {e}")))?;
 
-            let fx_config = ledger.fx_config().cloned().ok_or_else(|| {
-                GatewayError::InternalError("Cross-currency payments not configured".to_string())
-            })?;
+            let fx_config = ledger
+                .fx_config()
+                .cloned()
+                .ok_or(icn_ledger::fx::FxError::NotConfigured)?;
 
-            let oracle = ledger.oracle_manager().cloned().ok_or_else(|| {
-                GatewayError::InternalError("Exchange rate oracle not configured".to_string())
-            })?;
+            let oracle = ledger
+                .oracle_manager()
+                .cloned()
+                .ok_or(icn_ledger::fx::FxError::OracleNotConfigured)?;
 
             (fx_config, oracle)
         };
 
         // Get current rate (after releasing lock)
         let pair = CurrencyPair::new(from_currency, to_currency);
-        let rate = oracle
-            .get_rate(&pair)
-            .await
-            .map_err(|e| GatewayError::InternalError(format!("Oracle error: {e}")))?;
+        let rate = oracle.get_rate(&pair).await.map_err(|e| {
+            icn_ledger::fx::FxError::RateNotAvailable {
+                from: from_currency.to_string(),
+                to: to_currency.to_string(),
+                reason: e.to_string(),
+            }
+        })?;
 
         // Check staleness
         if rate.is_stale && !fx_config.allow_stale_rates {
-            return Err(GatewayError::InternalError(
-                "Exchange rate is stale and stale rates are not allowed".to_string(),
-            ));
+            return Err(icn_ledger::fx::FxError::StaleRate {
+                from: from_currency.to_string(),
+                to: to_currency.to_string(),
+            }
+            .into());
         }
 
         // Calculate conversion
-        let gross_target_amount = rate
-            .convert(amount)
-            .ok_or_else(|| GatewayError::InternalError("Conversion would overflow".to_string()))?;
+        let gross_target_amount =
+            rate.convert(amount)
+                .ok_or_else(|| icn_ledger::fx::FxError::ConversionOverflow {
+                    source_amount: amount,
+                    from_currency: from_currency.to_string(),
+                    rate: rate.rate,
+                })?;
 
         // Calculate fee using same logic as actual execution for consistency
         let fee_amount = fx_config.calculate_fee(gross_target_amount);

--- a/icn/crates/icn-ledger/src/fx.rs
+++ b/icn/crates/icn-ledger/src/fx.rs
@@ -781,6 +781,12 @@ mod tests {
         }
         .is_client_error());
         assert!(FxError::InvalidAmount("test".to_string()).is_client_error());
+        assert!(FxError::ConversionOverflow {
+            source_amount: 1000,
+            from_currency: "USD".to_string(),
+            rate: 1e20,
+        }
+        .is_client_error());
 
         // Not found errors
         assert!(FxError::RateNotAvailable {

--- a/icn/crates/icn-ledger/src/fx.rs
+++ b/icn/crates/icn-ledger/src/fx.rs
@@ -422,6 +422,51 @@ pub enum FxError {
     },
 }
 
+impl FxError {
+    /// Get the machine-readable error code for this FX error
+    ///
+    /// These codes are stable and can be used by SDK clients for
+    /// programmatic error handling.
+    pub fn error_code(&self) -> &'static str {
+        match self {
+            FxError::NotConfigured => "FX_NOT_CONFIGURED",
+            FxError::OracleNotConfigured => "ORACLE_NOT_CONFIGURED",
+            FxError::SameCurrency(_) => "SAME_CURRENCY",
+            FxError::RateNotAvailable { .. } => "RATE_NOT_AVAILABLE",
+            FxError::StaleRate { .. } => "STALE_RATE",
+            FxError::SlippageExceeded { .. } => "SLIPPAGE_EXCEEDED",
+            FxError::TransferExpired { .. } => "RATE_EXPIRED",
+            FxError::InvalidAmount(_) => "INVALID_AMOUNT",
+            FxError::ConversionOverflow { .. } => "CONVERSION_OVERFLOW",
+        }
+    }
+
+    /// Check if this error is a client error (bad request)
+    ///
+    /// Returns true for errors caused by invalid client input.
+    pub fn is_client_error(&self) -> bool {
+        matches!(
+            self,
+            FxError::SameCurrency(_)
+                | FxError::SlippageExceeded { .. }
+                | FxError::StaleRate { .. }
+                | FxError::TransferExpired { .. }
+                | FxError::InvalidAmount(_)
+                | FxError::ConversionOverflow { .. }
+        )
+    }
+
+    /// Check if this error is a not-found error
+    pub fn is_not_found(&self) -> bool {
+        matches!(self, FxError::RateNotAvailable { .. })
+    }
+
+    /// Check if this error is a server configuration error
+    pub fn is_server_error(&self) -> bool {
+        matches!(self, FxError::NotConfigured | FxError::OracleNotConfigured)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -652,6 +697,111 @@ mod tests {
             }
             _ => panic!("Expected TransferExpired error"),
         }
+    }
+
+    #[test]
+    fn test_fx_error_codes() {
+        // Test error codes for each variant
+        assert_eq!(FxError::NotConfigured.error_code(), "FX_NOT_CONFIGURED");
+        assert_eq!(
+            FxError::OracleNotConfigured.error_code(),
+            "ORACLE_NOT_CONFIGURED"
+        );
+        assert_eq!(
+            FxError::SameCurrency("USD".to_string()).error_code(),
+            "SAME_CURRENCY"
+        );
+        assert_eq!(
+            FxError::RateNotAvailable {
+                from: "A".to_string(),
+                to: "B".to_string(),
+                reason: "test".to_string()
+            }
+            .error_code(),
+            "RATE_NOT_AVAILABLE"
+        );
+        assert_eq!(
+            FxError::StaleRate {
+                from: "A".to_string(),
+                to: "B".to_string()
+            }
+            .error_code(),
+            "STALE_RATE"
+        );
+        assert_eq!(
+            FxError::SlippageExceeded {
+                expected: 100,
+                actual: 110,
+                max_slippage_bps: 100
+            }
+            .error_code(),
+            "SLIPPAGE_EXCEEDED"
+        );
+        assert_eq!(
+            FxError::TransferExpired {
+                expired_at: 100,
+                current_time: 200
+            }
+            .error_code(),
+            "RATE_EXPIRED"
+        );
+        assert_eq!(
+            FxError::InvalidAmount("test".to_string()).error_code(),
+            "INVALID_AMOUNT"
+        );
+        assert_eq!(
+            FxError::ConversionOverflow {
+                source_amount: 100,
+                from_currency: "USD".to_string(),
+                rate: 1.5
+            }
+            .error_code(),
+            "CONVERSION_OVERFLOW"
+        );
+    }
+
+    #[test]
+    fn test_fx_error_classification() {
+        // Client errors
+        assert!(FxError::SameCurrency("USD".to_string()).is_client_error());
+        assert!(FxError::SlippageExceeded {
+            expected: 100,
+            actual: 110,
+            max_slippage_bps: 100
+        }
+        .is_client_error());
+        assert!(FxError::StaleRate {
+            from: "A".to_string(),
+            to: "B".to_string()
+        }
+        .is_client_error());
+        assert!(FxError::TransferExpired {
+            expired_at: 100,
+            current_time: 200
+        }
+        .is_client_error());
+        assert!(FxError::InvalidAmount("test".to_string()).is_client_error());
+
+        // Not found errors
+        assert!(FxError::RateNotAvailable {
+            from: "A".to_string(),
+            to: "B".to_string(),
+            reason: "test".to_string()
+        }
+        .is_not_found());
+
+        // Server errors
+        assert!(FxError::NotConfigured.is_server_error());
+        assert!(FxError::OracleNotConfigured.is_server_error());
+
+        // Cross-check: client errors are not server errors
+        assert!(!FxError::SlippageExceeded {
+            expected: 100,
+            actual: 110,
+            max_slippage_bps: 100
+        }
+        .is_server_error());
+        assert!(!FxError::NotConfigured.is_client_error());
     }
 }
 

--- a/icn/crates/icn-ledger/src/fx.rs
+++ b/icn/crates/icn-ledger/src/fx.rs
@@ -4,6 +4,22 @@
 //! in one currency and the recipient receives in another, using the oracle
 //! for rate conversion.
 //!
+//! # Error Codes
+//!
+//! All FX errors provide machine-readable error codes for SDK clients:
+//!
+//! | Error Code | HTTP Status | Description |
+//! |------------|-------------|-------------|
+//! | `FX_NOT_CONFIGURED` | 500 | FX module not configured for this coop |
+//! | `ORACLE_NOT_CONFIGURED` | 500 | Exchange rate oracle not set up |
+//! | `SAME_CURRENCY` | 400 | Same currency specified for source and target |
+//! | `RATE_NOT_AVAILABLE` | 404 | No exchange rate available for currency pair |
+//! | `STALE_RATE` | 400 | Rate is stale and stale rates are not allowed |
+//! | `SLIPPAGE_EXCEEDED` | 400 | Converted amount exceeds max_target_amount |
+//! | `RATE_EXPIRED` | 400 | Prepared transfer expired before execution |
+//! | `INVALID_AMOUNT` | 400 | Amount is invalid or cannot be processed |
+//! | `CONVERSION_OVERFLOW` | 400 | Conversion would exceed numeric limits |
+//!
 //! # Example
 //!
 //! ```rust,no_run

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -520,13 +520,24 @@ impl Ledger {
         }
 
         // Convert amount using oracle rate
-        let gross_target_amount =
-            rate.convert(source_amount)
-                .ok_or(FxError::ConversionOverflow {
-                    source_amount,
-                    from_currency: from_currency.to_string(),
-                    rate: rate.rate,
-                })?;
+        let gross_target_amount = rate.convert(source_amount).ok_or_else(|| {
+            // Log a warning if overflow occurs with a suspiciously high rate
+            // This could indicate oracle misconfiguration
+            if rate.rate > 1000.0 {
+                tracing::warn!(
+                    rate = rate.rate,
+                    source_amount = source_amount,
+                    from_currency = from_currency,
+                    to_currency = to_currency,
+                    "Conversion overflow with high exchange rate - possible oracle misconfiguration"
+                );
+            }
+            FxError::ConversionOverflow {
+                source_amount,
+                from_currency: from_currency.to_string(),
+                rate: rate.rate,
+            }
+        })?;
 
         // Check slippage if max specified
         if let Some(max) = max_target_amount {

--- a/icn/crates/icn-net/src/sequence_tracker.rs
+++ b/icn/crates/icn-net/src/sequence_tracker.rs
@@ -636,10 +636,10 @@ mod tests {
 
         assert_eq!(tracker.pair_count().await, 2);
 
-        // Cleanup with 0 retention - should remove nothing (entries are fresh)
-        // Actually with 0 retention, entries created "now" shouldn't be removed
-        // because their timestamp is >= cutoff
-        let removed = tracker.cleanup_stale_entries(0).await.unwrap();
+        // Cleanup with 1 second retention - should remove nothing (entries are fresh)
+        // Note: We use 1 second instead of 0 to avoid timing races where
+        // the cleanup timestamp is slightly after the entry creation timestamp
+        let removed = tracker.cleanup_stale_entries(1).await.unwrap();
         assert_eq!(removed, 0);
 
         // Cleanup with very long retention - should remove nothing

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -689,6 +689,7 @@ export class ICNClient {
    *   - `STALE_RATE` - Exchange rate is stale and stale rates not allowed
    *   - `RATE_EXPIRED` - Prepared transfer expired before execution
    *   - `SAME_CURRENCY` - Same currency specified (use regular payment)
+   *   - `INVALID_AMOUNT` - Amount is invalid or cannot be processed
    *   - `RATE_NOT_AVAILABLE` - No rate available for currency pair
    *   - `CONVERSION_OVERFLOW` - Conversion would exceed numeric limits
    *

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -684,14 +684,13 @@ export class ICNClient {
    *
    * @throws {ValidationError} If amount <= 0, currencies are invalid, or same currency used
    * @throws {AuthorizationError} If authenticated DID doesn't match the sender
-   * @throws {ICNError} For FX-related error conditions including:
-   *   - Slippage exceeded (converted amount > max_target_amount)
-   *   - Stale exchange rate (when stale rates are not allowed)
-   *   - Rate expired (prepared transfer expired before execution)
-   *   - Budget exceeded or insufficient balance
-   *
-   *   Note: FX errors are currently wrapped as internal server errors by the gateway.
-   *   Check the error message for specific failure details.
+   * @throws {ICNError} For FX-related errors with structured error codes:
+   *   - `SLIPPAGE_EXCEEDED` - Converted amount exceeds max_target_amount
+   *   - `STALE_RATE` - Exchange rate is stale and stale rates not allowed
+   *   - `RATE_EXPIRED` - Prepared transfer expired before execution
+   *   - `SAME_CURRENCY` - Same currency specified (use regular payment)
+   *   - `RATE_NOT_AVAILABLE` - No rate available for currency pair
+   *   - `CONVERSION_OVERFLOW` - Conversion would exceed numeric limits
    *
    * @example
    * ```typescript
@@ -714,8 +713,17 @@ export class ICNClient {
    *   } else if (e instanceof AuthorizationError) {
    *     console.error('Not authorized to send from this account');
    *   } else if (e instanceof ICNError) {
-   *     // FX errors include: slippage exceeded, stale/expired rate, insufficient balance
-   *     console.error('Payment failed:', e.message);
+   *     // Handle specific FX error codes
+   *     switch (e.code) {
+   *       case 'SLIPPAGE_EXCEEDED':
+   *         console.error('Rate changed too much, try again');
+   *         break;
+   *       case 'STALE_RATE':
+   *         console.error('Exchange rate is outdated');
+   *         break;
+   *       default:
+   *         console.error('Payment failed:', e.message);
+   *     }
    *   }
    * }
    * ```
@@ -736,8 +744,12 @@ export class ICNClient {
    * @returns Promise resolving to the quote with rate, fees, and validity info
    *
    * @throws {ValidationError} If amount <= 0, currencies are invalid, or same currency used
-   * @throws {ICNError} If exchange rate oracle is not configured or no rate exists for the currency pair.
-   *   Note: These conditions are currently wrapped as internal server errors by the gateway.
+   * @throws {ICNError} For FX-related errors with structured error codes:
+   *   - `ORACLE_NOT_CONFIGURED` - Exchange rate oracle not set up
+   *   - `FX_NOT_CONFIGURED` - Cross-currency payments not configured
+   *   - `RATE_NOT_AVAILABLE` - No rate exists for the currency pair
+   *   - `STALE_RATE` - Exchange rate is stale and stale rates not allowed
+   *   - `SAME_CURRENCY` - Same currency specified (use regular payment)
    *
    * @example
    * ```typescript


### PR DESCRIPTION
## Summary

Implements structured error codes for FX operations, enabling SDK clients to programmatically handle specific error conditions instead of parsing error messages.

Closes #374

## Changes

### Gateway Error Handling (`error.rs`)
- Add `Fx(FxError)` variant with automatic conversion via `#[from]`
- Add `error_code()` method returning machine-readable codes
- Update `error_response()` to include `code` field in JSON responses
- Map FX errors to appropriate HTTP status codes

### FxError Methods (`fx.rs`)
- Add `error_code()` returning stable machine-readable codes
- Add `is_client_error()`, `is_not_found()`, `is_server_error()` helpers

### Gateway Ledger Manager (`ledger_mgr.rs`)
- Use automatic FxError conversion via `?` operator
- Replace manual `InternalError` wrapping with proper FxError types

### SDK Documentation (`index.ts`)
- Update JSDoc with structured error codes
- Add example showing error code switch handling

## Error Code Reference

| Error Code | HTTP Status | Description |
|------------|-------------|-------------|
| `SLIPPAGE_EXCEEDED` | 400 | Converted amount exceeds max_target_amount |
| `STALE_RATE` | 400 | Exchange rate is stale |
| `RATE_EXPIRED` | 400 | Prepared transfer expired |
| `SAME_CURRENCY` | 400 | Same currency specified |
| `INVALID_AMOUNT` | 400 | Invalid amount value |
| `CONVERSION_OVERFLOW` | 400 | Conversion exceeds limits |
| `RATE_NOT_AVAILABLE` | 404 | No rate for currency pair |
| `FX_NOT_CONFIGURED` | 500 | FX config not set |
| `ORACLE_NOT_CONFIGURED` | 500 | Oracle not configured |

## Example Response

```json
{
  "error": "Slippage exceeded: expected 250, got 260 (max 100 bps)",
  "code": "SLIPPAGE_EXCEEDED"
}
```

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features` clean
- [x] `cargo test -p icn-ledger fx::` passes (23 tests)
- [x] SDK tests pass (125 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)