### PR TITLE
refactor(ledger): Remove await-under-lock in cross-currency payments

### DIFF
--- a/icn/crates/icn-gateway/src/ledger_mgr.rs
+++ b/icn/crates/icn-gateway/src/ledger_mgr.rs
@@ -305,20 +305,13 @@ impl LedgerManager {
     ///
     /// Returns the entry hash and conversion details for audit/display.
     ///
-    /// # Note on locking
+    /// # Locking Strategy
     ///
-    /// This method holds a read lock across an await point during the
-    /// `prepare_cross_currency_transfer` call, which fetches the exchange rate
-    /// from the oracle.
-    ///
-    /// This is acceptable because:
-    /// - Read locks allow concurrent readers (other payments can proceed)
-    /// - The oracle call typically completes quickly (cached rates)
-    /// - Write lock is only held during the final `execute_cross_currency_transfer`
-    ///
-    /// For high-throughput scenarios, consider refactoring to extract the oracle
-    /// call outside the lock (see issue #367).
-    #[allow(clippy::await_holding_lock)]
+    /// This method uses a lock-free pattern for the async oracle call:
+    /// 1. Short read lock to get FX config and oracle reference
+    /// 2. No lock during async oracle rate fetch
+    /// 3. Read lock for synchronous transfer preparation
+    /// 4. Write lock for final execution
     pub async fn create_cross_payment(
         &self,
         coop_id: &CoopId,
@@ -330,6 +323,8 @@ impl LedgerManager {
         max_target_amount: Option<i64>,
         _memo: Option<String>,
     ) -> Result<CrossPaymentResponse> {
+        use icn_ledger::oracle::CurrencyPair;
+
         // Enforce budget limits if store is available
         if let Some(store) = &self.budget_store {
             let from_account = from.to_string();
@@ -345,22 +340,41 @@ impl LedgerManager {
 
         let ledger_arc = self.get_ledger(coop_id)?;
 
-        // Prepare the transfer (fetches rate from oracle) - only needs read lock
+        // Step 1: Get FX prerequisites (short read lock)
+        let oracle = {
+            let ledger = ledger_arc
+                .read()
+                .map_err(|e| GatewayError::InternalError(format!("Lock poisoned: {e}")))?;
+
+            let (_fx_config, oracle) = ledger.fx_prerequisites()?;
+            oracle
+        };
+
+        // Step 2: Fetch exchange rate from oracle (no lock held)
+        let pair = CurrencyPair::new(from_currency, to_currency);
+        let rate = oracle.get_rate(&pair).await.map_err(|e| {
+            icn_ledger::fx::FxError::RateNotAvailable {
+                from: from_currency.to_string(),
+                to: to_currency.to_string(),
+                reason: e.to_string(),
+            }
+        })?;
+
+        // Step 3: Prepare the transfer with the fetched rate (read lock, sync)
         let prepared = {
             let ledger = ledger_arc
                 .read()
                 .map_err(|e| GatewayError::InternalError(format!("Lock poisoned: {e}")))?;
 
-            ledger
-                .prepare_cross_currency_transfer(
-                    from,
-                    to,
-                    amount,
-                    from_currency,
-                    to_currency,
-                    max_target_amount,
-                )
-                .await?
+            ledger.prepare_cross_currency_transfer_with_rate(
+                from,
+                to,
+                amount,
+                from_currency,
+                to_currency,
+                max_target_amount,
+                &rate,
+            )?
         };
 
         // Execute the transfer (writes to ledger) - needs write lock

--- a/icn/crates/icn-ledger/src/fx.rs
+++ b/icn/crates/icn-ledger/src/fx.rs
@@ -1248,4 +1248,78 @@ mod integration_tests {
     // The configuration tests (test_max_rate_age_configuration) verify the feature works.
     // The staleness logic itself is simple (subtraction + comparison).
     // Full end-to-end staleness testing would require mocking the cache or time.
+
+    #[tokio::test]
+    async fn test_fx_prerequisites() {
+        let (ledger, _, _, _) = setup_ledger_with_fx().await;
+
+        // Should return FxConfig and OracleManager
+        let (fx_config, oracle) = ledger.fx_prerequisites().expect("get prerequisites");
+
+        // Verify config was cloned correctly
+        assert_eq!(fx_config.fee_basis_points, 100);
+
+        // Verify oracle works
+        let pair = crate::oracle::CurrencyPair::new("hours", "USD");
+        let rate = oracle.get_rate(&pair).await.expect("get rate");
+        assert!((rate.rate - 25.0).abs() < 0.001);
+    }
+
+    #[tokio::test]
+    async fn test_fx_prerequisites_no_config() {
+        let store = Arc::new(SledStore::temporary().expect("create temp store"));
+        let ledger = Ledger::new(store).expect("create ledger");
+
+        let result = ledger.fx_prerequisites();
+        assert!(matches!(result, Err(FxError::NotConfigured)));
+    }
+
+    #[tokio::test]
+    async fn test_fx_prerequisites_no_oracle() {
+        let store = Arc::new(SledStore::temporary().expect("create temp store"));
+        let mut ledger = Ledger::new(store).expect("create ledger");
+
+        let clearing = KeyPair::generate().expect("generate").did().clone();
+        ledger.set_fx_config(FxConfig::new(clearing));
+
+        let result = ledger.fx_prerequisites();
+        assert!(matches!(result, Err(FxError::OracleNotConfigured)));
+    }
+
+    #[tokio::test]
+    async fn test_prepare_with_rate() {
+        let (ledger, alice, bob, _) = setup_ledger_with_fx().await;
+
+        // Get prerequisites and fetch rate outside lock (simulating gateway pattern)
+        let (_fx_config, oracle) = ledger.fx_prerequisites().expect("get prerequisites");
+        let pair = crate::oracle::CurrencyPair::new("hours", "USD");
+        let rate = oracle.get_rate(&pair).await.expect("get rate");
+
+        // Use prepare_cross_currency_transfer_with_rate
+        let prepared = ledger
+            .prepare_cross_currency_transfer_with_rate(
+                &alice, &bob, 10, "hours", "USD", None, &rate,
+            )
+            .expect("prepare with rate");
+
+        assert_eq!(prepared.details.source_amount, 10);
+        assert_eq!(prepared.details.gross_target_amount, 250);
+        assert!(prepared.is_valid());
+    }
+
+    #[tokio::test]
+    async fn test_prepare_with_rate_wrong_pair() {
+        let (ledger, alice, bob, _) = setup_ledger_with_fx().await;
+
+        // Get rate for hours/USD
+        let (_fx_config, oracle) = ledger.fx_prerequisites().expect("get prerequisites");
+        let pair = crate::oracle::CurrencyPair::new("hours", "USD");
+        let rate = oracle.get_rate(&pair).await.expect("get rate");
+
+        // Try to use it for EUR/USD - should fail
+        let result = ledger
+            .prepare_cross_currency_transfer_with_rate(&alice, &bob, 10, "EUR", "USD", None, &rate);
+
+        assert!(matches!(result, Err(FxError::RateNotAvailable { .. })));
+    }
 }

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -744,6 +744,10 @@ impl Ledger {
         }
 
         // Validate rate is for the correct currency pair
+        // Note: This comparison is intentionally case-sensitive. Currency codes
+        // should be normalized (e.g., uppercase) at the API boundary. The oracle
+        // and ledger use consistent codes from CurrencyPair::new() which stores
+        // strings as-is without normalization.
         if rate.pair.from != from_currency || rate.pair.to != to_currency {
             return Err(FxError::RateNotAvailable {
                 from: from_currency.to_string(),

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -580,8 +580,11 @@ impl Ledger {
 
         // Convert amount using oracle rate
         let gross_target_amount = rate.convert(source_amount).ok_or_else(|| {
-            // Log a warning if overflow occurs with a suspiciously high rate
-            // This could indicate oracle misconfiguration
+            // Log a warning if overflow occurs with a suspiciously high rate.
+            // Threshold of 1000.0 catches potential oracle misconfigurations:
+            // - Most major currency pairs range from 0.01 to ~150
+            // - Rates above 1000.0 are rare even for exotic pairs
+            // - Common causes: decimal point errors, stale data, oracle bugs
             if rate.rate > 1000.0 {
                 tracing::warn!(
                     rate = rate.rate,
@@ -796,6 +799,11 @@ impl Ledger {
 
         // Convert amount using oracle rate
         let gross_target_amount = rate.convert(source_amount).ok_or_else(|| {
+            // Log a warning if overflow occurs with a suspiciously high rate.
+            // Threshold of 1000.0 catches potential oracle misconfigurations:
+            // - Most major currency pairs range from 0.01 to ~150
+            // - Rates above 1000.0 are rare even for exotic pairs
+            // - Common causes: decimal point errors, stale data, oracle bugs
             if rate.rate > 1000.0 {
                 tracing::warn!(
                     rate = rate.rate,

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -47,6 +47,11 @@ pub struct ForkStats {
 /// Key prefix for cached balances in storage
 const BALANCE_PREFIX: &str = "ledger:balance:";
 
+/// Threshold for logging warnings about suspiciously high exchange rates.
+/// Most major currency pairs range from 0.01 to ~150. Rates above this threshold
+/// may indicate oracle misconfiguration (decimal point errors, stale data, bugs).
+const SUSPICIOUS_RATE_THRESHOLD: f64 = 1000.0;
+
 /// Key prefix for cleared volume index (total credits received per account/currency)
 const CLEARED_VOLUME_PREFIX: &str = "ledger:cleared_volume:";
 
@@ -580,12 +585,8 @@ impl Ledger {
 
         // Convert amount using oracle rate
         let gross_target_amount = rate.convert(source_amount).ok_or_else(|| {
-            // Log a warning if overflow occurs with a suspiciously high rate.
-            // Threshold of 1000.0 catches potential oracle misconfigurations:
-            // - Most major currency pairs range from 0.01 to ~150
-            // - Rates above 1000.0 are rare even for exotic pairs
-            // - Common causes: decimal point errors, stale data, oracle bugs
-            if rate.rate > 1000.0 {
+            // Log a warning if overflow occurs with a suspiciously high rate
+            if rate.rate > SUSPICIOUS_RATE_THRESHOLD {
                 tracing::warn!(
                     rate = rate.rate,
                     source_amount = source_amount,
@@ -799,12 +800,8 @@ impl Ledger {
 
         // Convert amount using oracle rate
         let gross_target_amount = rate.convert(source_amount).ok_or_else(|| {
-            // Log a warning if overflow occurs with a suspiciously high rate.
-            // Threshold of 1000.0 catches potential oracle misconfigurations:
-            // - Most major currency pairs range from 0.01 to ~150
-            // - Rates above 1000.0 are rare even for exotic pairs
-            // - Common causes: decimal point errors, stale data, oracle bugs
-            if rate.rate > 1000.0 {
+            // Log a warning if overflow occurs with a suspiciously high rate
+            if rate.rate > SUSPICIOUS_RATE_THRESHOLD {
                 tracing::warn!(
                     rate = rate.rate,
                     source_amount = source_amount,

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -548,6 +548,20 @@ impl Ledger {
             // is in the future (due to NTP drift), age is treated as 0 (fresh).
             let now = crate::current_timestamp_secs();
             let rate_age = now.saturating_sub(rate.aggregated_at);
+
+            // Warn when rate is approaching staleness (>80% of max age)
+            let warning_threshold = max_age * 80 / 100;
+            if rate_age > warning_threshold && rate_age <= max_age {
+                tracing::warn!(
+                    from_currency = from_currency,
+                    to_currency = to_currency,
+                    rate_age_secs = rate_age,
+                    max_age_secs = max_age,
+                    remaining_secs = max_age.saturating_sub(rate_age),
+                    "Exchange rate approaching staleness threshold"
+                );
+            }
+
             if rate_age > max_age {
                 return Err(FxError::StaleRateAge {
                     from: from_currency.to_string(),
@@ -746,6 +760,20 @@ impl Ledger {
             // Time-based staleness check
             let now = crate::current_timestamp_secs();
             let rate_age = now.saturating_sub(rate.aggregated_at);
+
+            // Warn when rate is approaching staleness (>80% of max age)
+            let warning_threshold = max_age * 80 / 100;
+            if rate_age > warning_threshold && rate_age <= max_age {
+                tracing::warn!(
+                    from_currency = from_currency,
+                    to_currency = to_currency,
+                    rate_age_secs = rate_age,
+                    max_age_secs = max_age,
+                    remaining_secs = max_age.saturating_sub(rate_age),
+                    "Exchange rate approaching staleness threshold"
+                );
+            }
+
             if rate_age > max_age {
                 return Err(FxError::StaleRateAge {
                     from: from_currency.to_string(),

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -446,6 +446,36 @@ impl Ledger {
         self.fx_config.as_ref()
     }
 
+    /// Get prerequisites for cross-currency transfers
+    ///
+    /// Returns cloned copies of FxConfig and OracleManager for use outside
+    /// the ledger lock. This enables fetching exchange rates without holding
+    /// a lock on the ledger.
+    ///
+    /// # Returns
+    /// Tuple of (FxConfig, Arc<OracleManager>)
+    ///
+    /// # Errors
+    /// - `FxError::NotConfigured` if FX config not set
+    /// - `FxError::OracleNotConfigured` if oracle not set
+    pub fn fx_prerequisites(
+        &self,
+    ) -> std::result::Result<
+        (crate::fx::FxConfig, Arc<crate::oracle::OracleManager>),
+        crate::fx::FxError,
+    > {
+        use crate::fx::FxError;
+
+        let fx_config = self.fx_config.clone().ok_or(FxError::NotConfigured)?;
+
+        let oracle = self
+            .oracle_manager
+            .clone()
+            .ok_or(FxError::OracleNotConfigured)?;
+
+        Ok((fx_config, oracle))
+    }
+
     /// Prepare a cross-currency transfer without committing
     ///
     /// This fetches the current exchange rate and builds a journal entry
@@ -634,6 +664,190 @@ impl Ledger {
             gross_target_amount,
             fee_amount,
             recipient_amount, // Uses same logic as journal entry builder
+            fx_config.fee_basis_points,
+        );
+
+        Ok(PreparedFxTransfer {
+            entry,
+            details,
+            valid_until,
+        })
+    }
+
+    /// Prepare a cross-currency transfer with a pre-fetched exchange rate
+    ///
+    /// This is a synchronous version of `prepare_cross_currency_transfer` that
+    /// takes an already-fetched exchange rate. Use this when you need to avoid
+    /// holding a lock during the async oracle call.
+    ///
+    /// # Workflow
+    /// 1. Call `fx_prerequisites()` to get FxConfig and OracleManager (short lock)
+    /// 2. Fetch rate from oracle outside the lock: `oracle.get_rate(&pair).await`
+    /// 3. Call this method with the fetched rate (read lock, but sync - no await)
+    /// 4. Call `execute_cross_currency_transfer()` to commit (write lock)
+    ///
+    /// # Arguments
+    /// * `from` - Sender DID
+    /// * `to` - Recipient DID
+    /// * `source_amount` - Amount to debit from sender (in source currency)
+    /// * `from_currency` - Source currency code
+    /// * `to_currency` - Target currency code
+    /// * `max_target_amount` - Optional slippage protection
+    /// * `rate` - Pre-fetched exchange rate from the oracle
+    ///
+    /// # Errors
+    /// - `FxError::NotConfigured` if FX config not set
+    /// - `FxError::SameCurrency` if from/to currencies match
+    /// - `FxError::StaleRate` / `FxError::StaleRateAge` if rate is stale
+    /// - `FxError::SlippageExceeded` if converted amount exceeds max
+    /// - `FxError::RateNotAvailable` if rate is for wrong currency pair
+    pub fn prepare_cross_currency_transfer_with_rate(
+        &self,
+        from: &Did,
+        to: &Did,
+        source_amount: i64,
+        from_currency: &str,
+        to_currency: &str,
+        max_target_amount: Option<i64>,
+        rate: &crate::oracle::ExchangeRate,
+    ) -> std::result::Result<crate::fx::PreparedFxTransfer, crate::fx::FxError> {
+        use crate::entry::JournalEntryBuilder;
+        use crate::fx::{FxConversionDetails, FxError, PreparedFxTransfer};
+
+        // Validate configuration
+        let fx_config = self.fx_config.as_ref().ok_or(FxError::NotConfigured)?;
+
+        // Validate currencies differ
+        if from_currency == to_currency {
+            return Err(FxError::SameCurrency(from_currency.to_string()));
+        }
+
+        // Validate amount
+        if source_amount <= 0 {
+            return Err(FxError::InvalidAmount(format!(
+                "Source amount must be positive, got: {source_amount}"
+            )));
+        }
+
+        // Validate rate is for the correct currency pair
+        if rate.pair.from != from_currency || rate.pair.to != to_currency {
+            return Err(FxError::RateNotAvailable {
+                from: from_currency.to_string(),
+                to: to_currency.to_string(),
+                reason: format!(
+                    "Rate is for {}/{} but expected {}/{}",
+                    rate.pair.from, rate.pair.to, from_currency, to_currency
+                ),
+            });
+        }
+
+        // Check staleness based on configuration
+        if let Some(max_age) = fx_config.max_rate_age_secs {
+            // Time-based staleness check
+            let now = crate::current_timestamp_secs();
+            let rate_age = now.saturating_sub(rate.aggregated_at);
+            if rate_age > max_age {
+                return Err(FxError::StaleRateAge {
+                    from: from_currency.to_string(),
+                    to: to_currency.to_string(),
+                    age_secs: rate_age,
+                    max_age_secs: max_age,
+                });
+            }
+        } else if rate.is_stale {
+            // Fallback to oracle's is_stale flag when max_rate_age_secs is None
+            return Err(FxError::StaleRate {
+                from: from_currency.to_string(),
+                to: to_currency.to_string(),
+            });
+        }
+
+        // Convert amount using oracle rate
+        let gross_target_amount = rate.convert(source_amount).ok_or_else(|| {
+            if rate.rate > 1000.0 {
+                tracing::warn!(
+                    rate = rate.rate,
+                    source_amount = source_amount,
+                    from_currency = from_currency,
+                    to_currency = to_currency,
+                    "Conversion overflow with high exchange rate - possible oracle misconfiguration"
+                );
+            }
+            FxError::ConversionOverflow {
+                source_amount,
+                from_currency: from_currency.to_string(),
+                rate: rate.rate,
+            }
+        })?;
+
+        // Check slippage if max specified
+        if let Some(max) = max_target_amount {
+            if gross_target_amount > max {
+                return Err(FxError::SlippageExceeded {
+                    expected: max,
+                    actual: gross_target_amount,
+                    max_slippage_bps: fx_config.max_slippage_basis_points,
+                });
+            }
+        }
+
+        // Calculate fee and net amount
+        let fee_amount = fx_config.calculate_fee(gross_target_amount);
+        let net_target_amount = gross_target_amount - fee_amount;
+
+        // Build 4-leg (or 5-leg with fee) journal entry
+        let mut builder = JournalEntryBuilder::new(from.clone())
+            .credit(from.clone(), from_currency.to_string(), source_amount)
+            .debit(
+                fx_config.clearing_did.clone(),
+                from_currency.to_string(),
+                source_amount,
+            )
+            .credit(
+                fx_config.clearing_did.clone(),
+                to_currency.to_string(),
+                gross_target_amount,
+            );
+
+        // Add treasury fee leg if applicable
+        let (recipient_amount, has_treasury_fee) =
+            if fee_amount > 0 && fx_config.treasury_did.is_some() {
+                (net_target_amount, true)
+            } else {
+                (gross_target_amount, false)
+            };
+
+        if has_treasury_fee {
+            if let Some(treasury) = &fx_config.treasury_did {
+                builder = builder
+                    .debit(treasury.clone(), to_currency.to_string(), fee_amount)
+                    .debit(to.clone(), to_currency.to_string(), recipient_amount);
+            }
+        } else {
+            builder = builder.debit(to.clone(), to_currency.to_string(), recipient_amount);
+        }
+
+        let entry = builder
+            .build()
+            .map_err(|e| FxError::InvalidAmount(format!("Failed to build journal entry: {e}")))?;
+
+        // Calculate expiration (use rate TTL)
+        let valid_until = rate.aggregated_at.saturating_add(rate.ttl_secs);
+
+        // Build conversion details for audit
+        let details = FxConversionDetails::new(
+            from.to_string(),
+            to.to_string(),
+            from_currency.to_string(),
+            to_currency.to_string(),
+            source_amount,
+            rate.rate,
+            rate.aggregated_at,
+            rate.sources(),
+            rate.is_stale,
+            gross_target_amount,
+            fee_amount,
+            recipient_amount,
             fx_config.fee_basis_points,
         );
 


### PR DESCRIPTION
## Summary

Refactors `create_cross_payment` to avoid holding RwLock during async oracle calls, improving scalability for high-throughput scenarios.

**Depends on:** #376 (time-based staleness threshold)

## Changes

- Add `fx_prerequisites()` method to get FxConfig and OracleManager without long lock
- Add `prepare_cross_currency_transfer_with_rate()` synchronous method that takes pre-fetched rate
- Refactor `create_cross_payment` to use lock-free oracle pattern:
  1. **Short read lock:** get FX prerequisites (clone Arc and FxConfig)
  2. **No lock:** fetch rate from oracle asynchronously
  3. **Read lock:** prepare transfer (sync, no await)
  4. **Write lock:** execute transfer
- Remove `#[allow(clippy::await_holding_lock)]` directive

## Why This Matters

The previous pattern held a read lock across an await point during `oracle.get_rate()`. While read locks allow concurrent readers, this pattern:
- Blocks writer operations during oracle fetches
- Can cause priority inversion under load
- Clippy warns about potential deadlocks

The new pattern ensures locks are only held during synchronous operations.

Closes #367

## Test plan

- [x] New `test_fx_prerequisites` tests pass
- [x] New `test_prepare_with_rate` tests pass
- [x] New `test_prepare_with_rate_wrong_pair` test passes
- [x] All existing FX tests pass (31 total)
- [x] `cargo clippy` passes (no more `await_holding_lock` warning)
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)