### PR TITLE
refactor(governance): Extract shared parameter validation helpers

### DIFF
--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -58,6 +58,8 @@ pub mod protocol_defaults;
 #[allow(missing_docs)]
 pub mod protocol_store;
 #[allow(missing_docs)]
+pub mod protocol_validation;
+#[allow(missing_docs)]
 pub mod resolver;
 #[allow(missing_docs)]
 pub mod sdis;
@@ -131,6 +133,9 @@ pub use protocol::{
 pub use protocol_defaults::{default_parameters, get_default_parameter, ParameterCategory};
 pub use protocol_store::{
     InMemoryParameterStore, ParameterStoreError, ProtocolParameterStore, SledParameterStore,
+};
+pub use protocol_validation::{
+    validate_parameter_update, validate_parameter_value, validate_scope_override, validate_version,
 };
 
 // Orphan cleanup types (Phase 21)

--- a/icn/crates/icn-governance/src/protocol_store.rs
+++ b/icn/crates/icn-governance/src/protocol_store.rs
@@ -498,7 +498,8 @@ impl ProtocolParameterStore for InMemoryParameterStore {
             // scope override permission, and optimistic locking
             validate_parameter_value(&param.value, &param, Some(stored))
                 .map_err(|e| anyhow::anyhow!("Parameter validation failed for '{id}': {e}"))?;
-            validate_scope_override(&id, &param.scope, Some(stored))?;
+            validate_scope_override(&id, &param.scope, Some(stored))
+                .map_err(|e| anyhow::anyhow!("Parameter '{id}' scope validation failed: {e}"))?;
             validate_version(&id, param.version, stored.version)?;
 
             // Increment version for the update
@@ -1122,7 +1123,8 @@ impl ProtocolParameterStore for SledParameterStore {
         let global_param = self.get(&id)?;
         validate_parameter_value(&param.value, &param, global_param.as_ref())
             .map_err(|e| anyhow::anyhow!("Parameter validation failed for '{id}': {e}"))?;
-        validate_scope_override(&id, &param.scope, global_param.as_ref())?;
+        validate_scope_override(&id, &param.scope, global_param.as_ref())
+            .map_err(|e| anyhow::anyhow!("Parameter '{id}' scope validation failed: {e}"))?;
 
         // Prepare the key for this parameter
         let is_scoped = !matches!(param.scope, ParameterScope::Global);
@@ -1180,7 +1182,18 @@ impl ProtocolParameterStore for SledParameterStore {
         let global_key = Self::param_key(&id);
         let global_key_clone = global_key.clone();
 
-        // Use transaction to atomically verify version, update parameter, and record history
+        // Use transaction to atomically verify version, update parameter, and record history.
+        //
+        // NOTE: Validation is intentionally duplicated between pre-validation (using shared helpers)
+        // and transaction validation (inline). This is NOT redundant - it's required for security:
+        //
+        // - Pre-validation (above): Catches most errors quickly, uses shared helpers for consistency
+        // - Transaction validation (below): Detects TOCTOU races where state changed between
+        //   pre-validation and transaction. CANNOT use shared helpers because Sled transactions
+        //   don't allow calling &self methods, and validation must happen atomically.
+        //
+        // The shared helpers ensure pre-validation logic stays consistent with InMemoryParameterStore.
+        // The transaction validation ensures atomic correctness for concurrent operations.
         self.db
             .transaction(|tx| {
                 // Read stored parameter INSIDE the transaction for atomic state check

--- a/icn/crates/icn-governance/src/protocol_store.rs
+++ b/icn/crates/icn-governance/src/protocol_store.rs
@@ -496,7 +496,8 @@ impl ProtocolParameterStore for InMemoryParameterStore {
         let old_value = if let Some(ref stored) = stored_param {
             // Use shared validation helpers for constraint bypass prevention,
             // scope override permission, and optimistic locking
-            validate_parameter_value(&id, &param.value, &param, Some(stored))?;
+            validate_parameter_value(&param.value, &param, Some(stored))
+                .map_err(|e| anyhow::anyhow!("Parameter validation failed for '{id}': {e}"))?;
             validate_scope_override(&id, &param.scope, Some(stored))?;
             validate_version(&id, param.version, stored.version)?;
 
@@ -505,7 +506,8 @@ impl ProtocolParameterStore for InMemoryParameterStore {
             Some(stored.value.clone())
         } else {
             // For new parameters (initial setup), validate against the parameter's own constraints
-            validate_parameter_value(&id, &param.value, &param, None)?;
+            validate_parameter_value(&param.value, &param, None)
+                .map_err(|e| anyhow::anyhow!("Parameter validation failed for '{id}': {e}"))?;
             // New parameter starts at version 0
             param.version = 0;
             None
@@ -1118,7 +1120,8 @@ impl ProtocolParameterStore for SledParameterStore {
         // - The transaction verifies version hasn't changed, which implicitly verifies constraints
         // - For scoped parameters, we explicitly verify allow_override inside the transaction
         let global_param = self.get(&id)?;
-        validate_parameter_value(&id, &param.value, &param, global_param.as_ref())?;
+        validate_parameter_value(&param.value, &param, global_param.as_ref())
+            .map_err(|e| anyhow::anyhow!("Parameter validation failed for '{id}': {e}"))?;
         validate_scope_override(&id, &param.scope, global_param.as_ref())?;
 
         // Prepare the key for this parameter

--- a/icn/crates/icn-governance/src/protocol_store.rs
+++ b/icn/crates/icn-governance/src/protocol_store.rs
@@ -481,47 +481,31 @@ impl ProtocolParameterStore for InMemoryParameterStore {
         proposal_id: Option<String>,
         changed_by: Option<String>,
     ) -> Result<()> {
+        use crate::protocol_validation::{
+            validate_parameter_value, validate_scope_override, validate_version,
+        };
+
         let id = param.id.clone();
         let scope_key = Self::scope_key(&param.scope);
 
         // Warn about unknown categories (non-blocking)
         warn_unknown_category(&id);
 
-        // For updates, validate against the STORED parameter's constraints (not the new one's)
-        // This prevents constraint bypass attacks where an attacker submits a parameter
-        // with modified constraints that allow any value
-        let old_value = if let Some(stored_param) = self.get(&id)? {
-            stored_param
-                .validate(&param.value)
-                .map_err(|e| anyhow::anyhow!("Parameter validation failed for '{id}': {e}"))?;
-
-            // Validate scope override permissions for non-global scopes
-            if !matches!(param.scope, ParameterScope::Global)
-                && !stored_param.constraints.allow_override
-            {
-                return Err(anyhow::anyhow!(
-                    "Parameter '{id}' does not allow scope overrides"
-                ));
-            }
-
-            // Optimistic locking: check version matches
-            if param.version != stored_param.version {
-                return Err(anyhow::anyhow!(
-                    "Concurrent modification detected for parameter '{id}': \
-                     expected version {}, found {}. Please retry.",
-                    param.version,
-                    stored_param.version
-                ));
-            }
+        // Validate and update parameter
+        let stored_param = self.get(&id)?;
+        let old_value = if let Some(ref stored) = stored_param {
+            // Use shared validation helpers for constraint bypass prevention,
+            // scope override permission, and optimistic locking
+            validate_parameter_value(&id, &param.value, &param, Some(stored))?;
+            validate_scope_override(&id, &param.scope, Some(stored))?;
+            validate_version(&id, param.version, stored.version)?;
 
             // Increment version for the update
-            param.version = stored_param.version + 1;
-            Some(stored_param.value)
+            param.version = stored.version + 1;
+            Some(stored.value.clone())
         } else {
             // For new parameters (initial setup), validate against the parameter's own constraints
-            param
-                .validate(&param.value)
-                .map_err(|e| anyhow::anyhow!("Parameter validation failed for '{id}': {e}"))?;
+            validate_parameter_value(&id, &param.value, &param, None)?;
             // New parameter starts at version 0
             param.version = 0;
             None
@@ -1117,6 +1101,7 @@ impl ProtocolParameterStore for SledParameterStore {
         proposal_id: Option<String>,
         changed_by: Option<String>,
     ) -> Result<()> {
+        use crate::protocol_validation::{validate_parameter_value, validate_scope_override};
         use sled::transaction::ConflictableTransactionError;
 
         let id = param.id.clone();
@@ -1125,35 +1110,16 @@ impl ProtocolParameterStore for SledParameterStore {
         // Warn about unknown categories (non-blocking)
         warn_unknown_category(&id);
 
-        // For updates, validate against the STORED parameter's constraints (not the new one's)
-        // This prevents constraint bypass attacks where an attacker submits a parameter
-        // with modified constraints that allow any value
+        // Pre-validation for efficiency (additional verification happens inside transaction)
+        // Use shared validation helpers for constraint bypass prevention and scope override checks.
+        // NOTE: Version check is NOT done here - it must happen inside the transaction for atomicity.
         //
-        // NOTE: Pre-validation is done outside the transaction for efficiency with additional
-        // verification inside the transaction for safety:
         // - Constraints (including allow_override) are immutable once a parameter is created
         // - The transaction verifies version hasn't changed, which implicitly verifies constraints
         // - For scoped parameters, we explicitly verify allow_override inside the transaction
         let global_param = self.get(&id)?;
-        if let Some(ref stored_param) = global_param {
-            stored_param
-                .validate(&param.value)
-                .map_err(|e| anyhow::anyhow!("Parameter validation failed for '{id}': {e}"))?;
-
-            // Pre-check scope override permissions (will be re-verified inside transaction)
-            if !matches!(param.scope, ParameterScope::Global)
-                && !stored_param.constraints.allow_override
-            {
-                return Err(anyhow::anyhow!(
-                    "Parameter '{id}' does not allow scope overrides"
-                ));
-            }
-        } else {
-            // For new parameters (initial setup), validate against the parameter's own constraints
-            param
-                .validate(&param.value)
-                .map_err(|e| anyhow::anyhow!("Parameter validation failed for '{id}': {e}"))?;
-        }
+        validate_parameter_value(&id, &param.value, &param, global_param.as_ref())?;
+        validate_scope_override(&id, &param.scope, global_param.as_ref())?;
 
         // Prepare the key for this parameter
         let is_scoped = !matches!(param.scope, ParameterScope::Global);

--- a/icn/crates/icn-governance/src/protocol_validation.rs
+++ b/icn/crates/icn-governance/src/protocol_validation.rs
@@ -36,7 +36,6 @@ use crate::protocol_store::ParameterStoreError;
 ///
 /// # Arguments
 ///
-/// * `param_id` - The parameter ID (for error messages)
 /// * `new_value` - The value to validate
 /// * `new_param` - The incoming parameter (used for new parameter validation)
 /// * `stored_param` - The existing stored parameter, if updating
@@ -45,8 +44,16 @@ use crate::protocol_store::ParameterStoreError;
 ///
 /// * `Ok(())` if validation passes
 /// * `Err(ParameterStoreError::Validation)` if validation fails
+///
+/// # Note
+///
+/// This function returns a generic validation error. Callers should wrap the error
+/// with context including the parameter ID for better debugging, e.g.:
+/// ```ignore
+/// validate_parameter_value(&param.value, &param, stored.as_ref())
+///     .map_err(|e| anyhow::anyhow!("Parameter validation failed for '{}': {e}", id))?;
+/// ```
 pub fn validate_parameter_value(
-    _param_id: &str,
     new_value: &ParameterValue,
     new_param: &ProtocolParameter,
     stored_param: Option<&ProtocolParameter>,
@@ -154,7 +161,7 @@ pub fn validate_parameter_update(
     stored_param: Option<&ProtocolParameter>,
 ) -> Result<(), ParameterStoreError> {
     // 1. Validate value against constraints
-    validate_parameter_value(&param.id, &param.value, param, stored_param)?;
+    validate_parameter_value(&param.value, param, stored_param)?;
 
     // 2. Check scope override permissions
     validate_scope_override(&param.id, &param.scope, stored_param)?;
@@ -207,21 +214,14 @@ mod tests {
         let new_param = make_param("test.param", 75, 1, true);
 
         // Valid value within constraints
-        assert!(validate_parameter_value(
-            "test.param",
-            &ParameterValue::Integer(75),
-            &new_param,
-            Some(&stored)
-        )
-        .is_ok());
+        assert!(
+            validate_parameter_value(&ParameterValue::Integer(75), &new_param, Some(&stored))
+                .is_ok()
+        );
 
         // Invalid value (exceeds max)
-        let result = validate_parameter_value(
-            "test.param",
-            &ParameterValue::Integer(150),
-            &new_param,
-            Some(&stored),
-        );
+        let result =
+            validate_parameter_value(&ParameterValue::Integer(150), &new_param, Some(&stored));
         assert!(matches!(result, Err(ParameterStoreError::Validation(_))));
     }
 
@@ -230,21 +230,10 @@ mod tests {
         let new_param = make_param("test.param", 50, 0, true);
 
         // Valid value for new param
-        assert!(validate_parameter_value(
-            "test.param",
-            &ParameterValue::Integer(50),
-            &new_param,
-            None
-        )
-        .is_ok());
+        assert!(validate_parameter_value(&ParameterValue::Integer(50), &new_param, None).is_ok());
 
         // Invalid value for new param
-        let result = validate_parameter_value(
-            "test.param",
-            &ParameterValue::Integer(150),
-            &new_param,
-            None,
-        );
+        let result = validate_parameter_value(&ParameterValue::Integer(150), &new_param, None);
         assert!(matches!(result, Err(ParameterStoreError::Validation(_))));
     }
 

--- a/icn/crates/icn-governance/src/protocol_validation.rs
+++ b/icn/crates/icn-governance/src/protocol_validation.rs
@@ -11,6 +11,16 @@
 //! 2. Scope override permission check
 //! 3. Version check (optimistic locking)
 //!
+//! # New vs. Existing Parameters
+//!
+//! Validation differs based on whether the parameter already exists:
+//!
+//! - **Existing parameter (update)**: Validates against the STORED parameter's constraints.
+//!   This prevents constraint bypass attacks where an attacker submits modified constraints.
+//!
+//! - **New parameter (create)**: Validates against the parameter's OWN constraints since
+//!   there is no stored version. New parameters start at version 0.
+//!
 //! # Security Considerations
 //!
 //! - **Constraint Bypass Prevention**: For updates, we validate against the STORED

--- a/icn/crates/icn-governance/src/protocol_validation.rs
+++ b/icn/crates/icn-governance/src/protocol_validation.rs
@@ -1,0 +1,311 @@
+//! Protocol Parameter Validation Helpers
+//!
+//! This module provides shared validation logic for parameter store implementations.
+//! Both `InMemoryParameterStore` and `SledParameterStore` use these helpers to ensure
+//! consistent validation behavior.
+//!
+//! # Validation Order
+//!
+//! The validation sequence for parameter updates is:
+//! 1. Value validation against stored constraints (prevents constraint bypass attacks)
+//! 2. Scope override permission check
+//! 3. Version check (optimistic locking)
+//!
+//! # Security Considerations
+//!
+//! - **Constraint Bypass Prevention**: For updates, we validate against the STORED
+//!   parameter's constraints, not the incoming parameter's constraints. This prevents
+//!   attackers from submitting parameters with modified constraints.
+//!
+//! - **Scope Override Check**: Parameters can optionally allow/disallow overrides at
+//!   cooperative or federation scopes. This is checked before allowing non-global scope updates.
+//!
+//! - **Optimistic Locking**: Version checks prevent lost updates from concurrent modifications.
+
+use crate::protocol::{ParameterScope, ParameterValue, ProtocolParameter};
+use crate::protocol_store::ParameterStoreError;
+
+/// Validate a parameter value against the appropriate constraints.
+///
+/// For updates (when `stored_param` is `Some`), validates against the stored parameter's
+/// constraints to prevent constraint bypass attacks where an attacker submits a parameter
+/// with modified constraints.
+///
+/// For new parameters (when `stored_param` is `None`), validates against the parameter's
+/// own constraints.
+///
+/// # Arguments
+///
+/// * `param_id` - The parameter ID (for error messages)
+/// * `new_value` - The value to validate
+/// * `new_param` - The incoming parameter (used for new parameter validation)
+/// * `stored_param` - The existing stored parameter, if updating
+///
+/// # Returns
+///
+/// * `Ok(())` if validation passes
+/// * `Err(ParameterStoreError::Validation)` if validation fails
+pub fn validate_parameter_value(
+    _param_id: &str,
+    new_value: &ParameterValue,
+    new_param: &ProtocolParameter,
+    stored_param: Option<&ProtocolParameter>,
+) -> Result<(), ParameterStoreError> {
+    if let Some(stored) = stored_param {
+        // For updates, validate against the STORED parameter's constraints
+        // This prevents constraint bypass attacks
+        stored.validate(new_value)?;
+    } else {
+        // For new parameters (initial setup), validate against own constraints
+        new_param.validate(new_value)?;
+    }
+    Ok(())
+}
+
+/// Check if a scope override is allowed for the parameter.
+///
+/// Parameters can be configured to allow or disallow overrides at non-global scopes
+/// (cooperative or federation). This check enforces that restriction.
+///
+/// # Arguments
+///
+/// * `param_id` - The parameter ID (for error messages)
+/// * `scope` - The scope being set (Global, Federation, or Cooperative)
+/// * `stored_param` - The existing stored parameter (must exist for scope overrides)
+///
+/// # Returns
+///
+/// * `Ok(())` if the scope override is allowed (or scope is Global)
+/// * `Err(ParameterStoreError::ScopeOverrideNotAllowed)` if overrides are disallowed
+pub fn validate_scope_override(
+    param_id: &str,
+    scope: &ParameterScope,
+    stored_param: Option<&ProtocolParameter>,
+) -> Result<(), ParameterStoreError> {
+    // Global scope is always allowed
+    if matches!(scope, ParameterScope::Global) {
+        return Ok(());
+    }
+
+    // For non-global scopes, we need a stored parameter to check allow_override
+    if let Some(stored) = stored_param {
+        if !stored.constraints.allow_override {
+            return Err(ParameterStoreError::ScopeOverrideNotAllowed {
+                parameter_id: param_id.to_string(),
+            });
+        }
+    }
+    // Note: If no stored param exists, this is a new scoped parameter
+    // The caller should handle this case (typically by requiring the global
+    // parameter to exist first)
+
+    Ok(())
+}
+
+/// Validate version for optimistic locking.
+///
+/// Compares the provided version against the stored version to detect concurrent
+/// modifications. If versions don't match, another process updated the parameter
+/// between the read and write.
+///
+/// # Arguments
+///
+/// * `param_id` - The parameter ID (for error messages)
+/// * `provided_version` - The version from the incoming update
+/// * `stored_version` - The version currently in storage
+///
+/// # Returns
+///
+/// * `Ok(())` if versions match
+/// * `Err(ParameterStoreError::ConcurrentModification)` if versions differ
+pub fn validate_version(
+    param_id: &str,
+    provided_version: u64,
+    stored_version: u64,
+) -> Result<(), ParameterStoreError> {
+    if provided_version != stored_version {
+        return Err(ParameterStoreError::ConcurrentModification {
+            parameter_id: param_id.to_string(),
+            expected_version: provided_version,
+            actual_version: stored_version,
+        });
+    }
+    Ok(())
+}
+
+/// Perform all pre-update validations in sequence.
+///
+/// This is a convenience function that runs all validation checks in the correct order:
+/// 1. Value validation
+/// 2. Scope override permission check
+/// 3. Version check (if stored parameter exists)
+///
+/// # Arguments
+///
+/// * `param` - The incoming parameter to validate
+/// * `stored_param` - The existing stored parameter, if updating
+///
+/// # Returns
+///
+/// * `Ok(())` if all validations pass
+/// * `Err(ParameterStoreError)` with the specific validation failure
+pub fn validate_parameter_update(
+    param: &ProtocolParameter,
+    stored_param: Option<&ProtocolParameter>,
+) -> Result<(), ParameterStoreError> {
+    // 1. Validate value against constraints
+    validate_parameter_value(&param.id, &param.value, param, stored_param)?;
+
+    // 2. Check scope override permissions
+    validate_scope_override(&param.id, &param.scope, stored_param)?;
+
+    // 3. Check version for optimistic locking (only for updates)
+    if let Some(stored) = stored_param {
+        validate_version(&param.id, param.version, stored.version)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::{
+        ParameterConstraints, ParameterScope, ParameterValue, ProtocolParameter,
+    };
+    use icn_entity::EntityId;
+
+    fn make_param(id: &str, value: i64, version: u64, allow_override: bool) -> ProtocolParameter {
+        ProtocolParameter {
+            id: id.to_string(),
+            name: format!("{} Name", id),
+            description: format!("{} Description", id),
+            value: ParameterValue::Integer(value),
+            constraints: ParameterConstraints {
+                min: Some(ParameterValue::Integer(0)),
+                max: Some(ParameterValue::Integer(100)),
+                allowed_values: None,
+                allow_override,
+                requires_restart: false,
+            },
+            version,
+            scope: ParameterScope::Global,
+            updated_at: 0,
+            updated_by: None,
+        }
+    }
+
+    fn coop_scope(name: &str) -> ParameterScope {
+        ParameterScope::Cooperative {
+            id: EntityId::cooperative(name).expect("valid coop name"),
+        }
+    }
+
+    #[test]
+    fn test_validate_value_against_stored_constraints() {
+        let stored = make_param("test.param", 50, 1, true);
+        let new_param = make_param("test.param", 75, 1, true);
+
+        // Valid value within constraints
+        assert!(validate_parameter_value(
+            "test.param",
+            &ParameterValue::Integer(75),
+            &new_param,
+            Some(&stored)
+        )
+        .is_ok());
+
+        // Invalid value (exceeds max)
+        let result = validate_parameter_value(
+            "test.param",
+            &ParameterValue::Integer(150),
+            &new_param,
+            Some(&stored),
+        );
+        assert!(matches!(result, Err(ParameterStoreError::Validation(_))));
+    }
+
+    #[test]
+    fn test_validate_value_for_new_param() {
+        let new_param = make_param("test.param", 50, 0, true);
+
+        // Valid value for new param
+        assert!(validate_parameter_value(
+            "test.param",
+            &ParameterValue::Integer(50),
+            &new_param,
+            None
+        )
+        .is_ok());
+
+        // Invalid value for new param
+        let result = validate_parameter_value(
+            "test.param",
+            &ParameterValue::Integer(150),
+            &new_param,
+            None,
+        );
+        assert!(matches!(result, Err(ParameterStoreError::Validation(_))));
+    }
+
+    #[test]
+    fn test_validate_scope_override_allowed() {
+        let stored = make_param("test.param", 50, 1, true);
+
+        // Global scope always allowed
+        assert!(
+            validate_scope_override("test.param", &ParameterScope::Global, Some(&stored)).is_ok()
+        );
+
+        // Cooperative scope allowed when allow_override=true
+        assert!(validate_scope_override("test.param", &coop_scope("test"), Some(&stored)).is_ok());
+    }
+
+    #[test]
+    fn test_validate_scope_override_disallowed() {
+        let stored = make_param("test.param", 50, 1, false);
+
+        // Cooperative scope disallowed when allow_override=false
+        let result = validate_scope_override("test.param", &coop_scope("test"), Some(&stored));
+        assert!(matches!(
+            result,
+            Err(ParameterStoreError::ScopeOverrideNotAllowed { .. })
+        ));
+    }
+
+    #[test]
+    fn test_validate_version_match() {
+        assert!(validate_version("test.param", 5, 5).is_ok());
+    }
+
+    #[test]
+    fn test_validate_version_mismatch() {
+        let result = validate_version("test.param", 5, 10);
+        assert!(matches!(
+            result,
+            Err(ParameterStoreError::ConcurrentModification {
+                expected_version: 5,
+                actual_version: 10,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn test_validate_parameter_update_all_checks() {
+        let stored = make_param("test.param", 50, 1, true);
+        let mut new_param = make_param("test.param", 75, 1, true);
+        new_param.scope = coop_scope("test");
+
+        // All validations pass
+        assert!(validate_parameter_update(&new_param, Some(&stored)).is_ok());
+
+        // Fails on version mismatch
+        new_param.version = 0;
+        let result = validate_parameter_update(&new_param, Some(&stored));
+        assert!(matches!(
+            result,
+            Err(ParameterStoreError::ConcurrentModification { .. })
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

Extracts duplicate validation logic from `InMemoryParameterStore` and `SledParameterStore` into a new `protocol_validation` module with reusable helper functions.

Closes #285

## Changes

**New file: `icn/crates/icn-governance/src/protocol_validation.rs`**

Added shared validation helper functions:
- `validate_parameter_value()` - Validates against stored constraints (prevents constraint bypass attacks)
- `validate_scope_override()` - Checks if scope overrides are allowed for non-global scopes
- `validate_version()` - Optimistic locking version check
- `validate_parameter_update()` - Convenience function combining all checks

**Updated: `InMemoryParameterStore::set()`**
- Replaced ~40 lines of duplicate validation logic with calls to shared helpers
- Behavior unchanged; all existing tests pass

**Updated: `SledParameterStore::set()`**  
- Replaced pre-validation logic with calls to shared helpers
- Transaction-based version check retained (must be atomic)
- Behavior unchanged; all existing tests pass

## Why This Matters

1. **Single source of truth**: Validation logic is now in one place
2. **Easier maintenance**: Changes to validation rules only need to be made once
3. **Consistent behavior**: Both stores use identical validation
4. **Better testability**: Helpers have dedicated unit tests (7 new tests)

## Test Plan

- [x] All 290 governance unit tests pass
- [x] All 33 governance integration tests pass
- [x] 7 new tests for validation helpers pass
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)