### PR TITLE
refactor(governance): Extract shared scopes_overlap helper

### DIFF
--- a/icn/crates/icn-core/src/governance/actor.rs
+++ b/icn/crates/icn-core/src/governance/actor.rs
@@ -1414,6 +1414,7 @@ impl GovernanceActor {
                             "Storage error during cycle detection - assuming overlap conservatively. \
                              This may block valid delegations; check storage health."
                         );
+                        icn_obs::metrics::governance::scope_overlap_storage_errors_inc();
                         true
                     }
                 }

--- a/icn/crates/icn-core/src/governance/actor.rs
+++ b/icn/crates/icn-core/src/governance/actor.rs
@@ -1379,6 +1379,17 @@ impl GovernanceActor {
     /// The shared function only has a single `default_on_unknown` parameter and
     /// cannot distinguish between "not found" and "storage error" cases.
     ///
+    /// ## Example Error Handling Difference
+    ///
+    /// ```text
+    /// Shared helper with default_on_unknown=false:
+    ///   - Storage error → returns false (permissive, no metric)
+    ///
+    /// GovernanceActor (this implementation):
+    ///   - Proposal not found → returns false (permissive)
+    ///   - Storage error → returns true (conservative) + emits metric
+    /// ```
+    ///
     /// # Eventual Consistency
     ///
     /// In a distributed gossip-based system, proposal info may not have propagated

--- a/icn/crates/icn-core/src/governance/actor.rs
+++ b/icn/crates/icn-core/src/governance/actor.rs
@@ -1366,10 +1366,18 @@ impl GovernanceActor {
 
     /// Check if two delegation scopes overlap (for cycle detection)
     ///
-    /// For Domain/Proposal combinations, we look up the proposal to get its domain
-    /// and check for precise overlap. If proposal is not found, assumes NO overlap
-    /// (proposal-specific delegations are narrower than domain delegations).
-    /// Falls back to conservative (assume overlap) only on storage errors.
+    /// This method handles scope overlap checking for the storage-backed GovernanceActor.
+    ///
+    /// # Why Not Using Shared Helper
+    ///
+    /// Unlike `DelegationManager` and `GovernanceMgr` which use the shared
+    /// [`icn_governance::scopes_overlap`] function, this implementation has special
+    /// error handling requirements:
+    /// - `Ok(None)` (not found) → `false` (permissive - allow delegation)
+    /// - `Err(e)` (storage error) → `true` (conservative - block delegation)
+    ///
+    /// The shared function only has a single `default_on_unknown` parameter and
+    /// cannot distinguish between "not found" and "storage error" cases.
     ///
     /// # Eventual Consistency
     ///

--- a/icn/crates/icn-gateway/src/governance_mgr.rs
+++ b/icn/crates/icn-gateway/src/governance_mgr.rs
@@ -17,11 +17,11 @@
 
 use anyhow::Result;
 use icn_governance::{
-    Comment, CommentId, Delegation, DelegationId, DelegationScope, Discussion, DiscussionStore,
-    GovernanceConfig, GovernanceDomain, GovernanceDomainId, GovernanceOps, GovernanceParams,
-    GovernanceProfileId, InMemoryDiscussionStore, MembershipConfig, MembershipSource, Proposal,
-    ProposalId, ProposalPayload, ProposalState, Timestamp, Vote, VoteChoice, VoteTally,
-    DEFAULT_MAX_DELEGATION_DEPTH,
+    scopes_overlap, Comment, CommentId, Delegation, DelegationId, DelegationScope, Discussion,
+    DiscussionStore, GovernanceConfig, GovernanceDomain, GovernanceDomainId, GovernanceOps,
+    GovernanceParams, GovernanceProfileId, InMemoryDiscussionStore, MembershipConfig,
+    MembershipSource, Proposal, ProposalDomainLookup, ProposalId, ProposalPayload, ProposalState,
+    Timestamp, Vote, VoteChoice, VoteTally, DEFAULT_MAX_DELEGATION_DEPTH,
 };
 use icn_identity::Did;
 use std::collections::{HashMap, HashSet};
@@ -958,40 +958,35 @@ impl Default for GovernanceManager {
 // Delegation Cycle Detection Helpers
 // ============================================================================
 
+/// Wrapper to implement `ProposalDomainLookup` for HashMap<ProposalId, Proposal>.
+///
+/// Used to pass proposal storage to the shared `scopes_overlap` function.
+struct ProposalMapLookup<'a>(&'a HashMap<ProposalId, Proposal>);
+
+impl ProposalDomainLookup for ProposalMapLookup<'_> {
+    fn lookup_proposal_domain(&self, proposal_id: &ProposalId) -> Option<GovernanceDomainId> {
+        self.0.get(proposal_id).map(|p| p.domain_id.clone())
+    }
+}
+
 /// Check if two delegation scopes overlap (for cycle detection)
 ///
 /// Returns true if delegations with these scopes could conflict.
-/// Uses proposal domain lookup for precise Domain/Proposal overlap checking.
+/// Delegates to the shared `scopes_overlap` function from icn-governance.
 ///
 /// # Eventual Consistency
 ///
 /// If proposal is not found, assumes NO overlap (proposal-specific delegations
 /// are narrower than domain delegations). This allows delegations to proceed
 /// when proposal info hasn't propagated via gossip yet.
-///
-/// Cycles that form during this window are detected when the proposal is
-/// registered in [`DelegationManager::register_proposal`], which triggers
-/// reconciliation and emits metrics for operator alerting.
-fn scopes_overlap(
+fn gateway_scopes_overlap(
     a: &DelegationScope,
     b: &DelegationScope,
     proposals: &HashMap<ProposalId, Proposal>,
 ) -> bool {
-    match (a, b) {
-        (DelegationScope::Blanket, _) | (_, DelegationScope::Blanket) => true,
-        (DelegationScope::Domain(d1), DelegationScope::Domain(d2)) => d1 == d2,
-        (DelegationScope::Domain(d), DelegationScope::Proposal(p))
-        | (DelegationScope::Proposal(p), DelegationScope::Domain(d)) => {
-            // Use proposal lookup for precise domain checking
-            match proposals.get(p) {
-                Some(proposal) => &proposal.domain_id == d,
-                // Proposal-specific delegations are narrower than domain delegations,
-                // so assume no overlap when proposal is not found
-                None => false,
-            }
-        }
-        (DelegationScope::Proposal(p1), DelegationScope::Proposal(p2)) => p1 == p2,
-    }
+    let lookup = ProposalMapLookup(proposals);
+    // Use permissive default: assume no overlap when proposal unknown
+    scopes_overlap(a, b, &lookup, false)
 }
 
 /// Find a delegation cycle if adding delegator→delegate would create one
@@ -1041,7 +1036,7 @@ fn find_delegation_cycle(
             .find(|d| {
                 d.delegator == current
                     && d.is_active(now)
-                    && scopes_overlap(&d.scope, scope, proposals)
+                    && gateway_scopes_overlap(&d.scope, scope, proposals)
             })
             .map(|d| d.delegate.clone());
 
@@ -1101,7 +1096,7 @@ fn compute_incoming_depth_recursive(
         .filter(|d| {
             d.delegate == *delegate
                 && d.is_active(now)
-                && scopes_overlap(&d.scope, scope, proposals)
+                && gateway_scopes_overlap(&d.scope, scope, proposals)
         })
         .map(|d| d.delegator.clone())
         .collect();

--- a/icn/crates/icn-gateway/src/governance_mgr.rs
+++ b/icn/crates/icn-gateway/src/governance_mgr.rs
@@ -985,7 +985,8 @@ fn gateway_scopes_overlap(
     proposals: &HashMap<ProposalId, Proposal>,
 ) -> bool {
     let lookup = ProposalMapLookup(proposals);
-    // Use permissive default: assume no overlap when proposal unknown
+    // default_on_unknown=false: assume no overlap when proposal is unknown
+    // (permissive behavior allows delegations to proceed during gossip propagation)
     scopes_overlap(a, b, &lookup, false)
 }
 

--- a/icn/crates/icn-governance/src/delegation.rs
+++ b/icn/crates/icn-governance/src/delegation.rs
@@ -114,6 +114,95 @@ impl DelegationScope {
     }
 }
 
+/// Trait for looking up which domain a proposal belongs to.
+///
+/// This abstracts the proposal domain lookup mechanism, allowing the shared
+/// `scopes_overlap` function to work with different storage backends:
+/// - In-memory HashMap (DelegationManager, GovernanceMgr)
+/// - Persistent store with error handling (GovernanceActor)
+///
+/// # Implementation Notes
+///
+/// Implementations should return `Some(domain_id)` if the proposal exists and
+/// its domain is known, or `None` if the proposal is not registered/found.
+/// Storage errors should be converted to `None` or handled by the caller.
+pub trait ProposalDomainLookup {
+    /// Look up the governance domain for a proposal.
+    ///
+    /// Returns `Some(GovernanceDomainId)` if the proposal's domain is known,
+    /// or `None` if the proposal is not registered or an error occurred.
+    fn lookup_proposal_domain(&self, proposal_id: &ProposalId) -> Option<GovernanceDomainId>;
+}
+
+/// Check if two delegation scopes overlap (for cycle detection).
+///
+/// This is the shared implementation used by DelegationManager, GovernanceActor,
+/// and GovernanceMgr to determine if two delegations could conflict.
+///
+/// # Arguments
+///
+/// * `a` - First delegation scope
+/// * `b` - Second delegation scope
+/// * `lookup` - Implementation of `ProposalDomainLookup` for resolving proposal domains
+/// * `default_on_unknown` - Value to return when a proposal's domain is unknown:
+///   - `false`: Assume no overlap (allow delegation, used for permissive behavior)
+///   - `true`: Assume overlap (block delegation, used for conservative behavior)
+///
+/// # Behavior
+///
+/// - Blanket scope overlaps with all scopes
+/// - Domain scopes overlap only if they match
+/// - Proposal scopes overlap only if they match
+/// - Domain + Proposal: uses lookup to determine if proposal is in the domain.
+///   If lookup returns None, uses `default_on_unknown`.
+///
+/// # Example
+///
+/// ```rust
+/// use icn_governance::delegation::{DelegationScope, ProposalDomainLookup, scopes_overlap};
+/// use icn_governance::domain::GovernanceDomainId;
+/// use icn_governance::proposal::ProposalId;
+/// use std::collections::HashMap;
+///
+/// // Simple HashMap-based lookup
+/// struct MapLookup(HashMap<ProposalId, GovernanceDomainId>);
+///
+/// impl ProposalDomainLookup for MapLookup {
+///     fn lookup_proposal_domain(&self, proposal_id: &ProposalId) -> Option<GovernanceDomainId> {
+///         self.0.get(proposal_id).cloned()
+///     }
+/// }
+///
+/// let lookup = MapLookup(HashMap::new());
+///
+/// // Blanket overlaps with everything
+/// assert!(scopes_overlap(
+///     &DelegationScope::Blanket,
+///     &DelegationScope::Domain(GovernanceDomainId::new("test")),
+///     &lookup,
+///     false,
+/// ));
+/// ```
+pub fn scopes_overlap<L: ProposalDomainLookup>(
+    a: &DelegationScope,
+    b: &DelegationScope,
+    lookup: &L,
+    default_on_unknown: bool,
+) -> bool {
+    match (a, b) {
+        (DelegationScope::Blanket, _) | (_, DelegationScope::Blanket) => true,
+        (DelegationScope::Domain(d1), DelegationScope::Domain(d2)) => d1 == d2,
+        (DelegationScope::Domain(d), DelegationScope::Proposal(p))
+        | (DelegationScope::Proposal(p), DelegationScope::Domain(d)) => {
+            match lookup.lookup_proposal_domain(p) {
+                Some(proposal_domain) => &proposal_domain == d,
+                None => default_on_unknown,
+            }
+        }
+        (DelegationScope::Proposal(p1), DelegationScope::Proposal(p2)) => p1 == p2,
+    }
+}
+
 /// A vote delegation from one member to another
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Delegation {
@@ -254,6 +343,12 @@ pub struct DelegationManager {
 
     /// Proposal to domain mapping for precise scope overlap checking
     proposal_domains: HashMap<ProposalId, GovernanceDomainId>,
+}
+
+impl ProposalDomainLookup for DelegationManager {
+    fn lookup_proposal_domain(&self, proposal_id: &ProposalId) -> Option<GovernanceDomainId> {
+        self.proposal_domains.get(proposal_id).cloned()
+    }
 }
 
 impl DelegationManager {
@@ -732,34 +827,13 @@ impl DelegationManager {
 
     /// Check if two scopes overlap (for cycle detection)
     ///
-    /// This function is used to determine if two delegations could conflict.
-    /// Uses registered proposal domains for precise overlap checking when available.
-    ///
-    /// # Behavior
-    ///
-    /// - Blanket scope overlaps with all scopes
-    /// - Domain scopes overlap only if they match
-    /// - Proposal scopes overlap only if they match
-    /// - Domain + Proposal: uses registered domain mapping for precise check.
-    ///   If proposal is not registered, assumes NO overlap (proposal-specific
-    ///   delegations are narrower than domain delegations, so actual conflicts
-    ///   will be detected when the proposal is properly registered).
+    /// Delegates to the shared [`scopes_overlap`] function with `default_on_unknown=false`
+    /// (assumes no overlap when proposal domain is unknown, as proposal-specific
+    /// delegations are narrower than domain delegations).
     fn scopes_overlap(&self, a: &DelegationScope, b: &DelegationScope) -> bool {
-        match (a, b) {
-            (DelegationScope::Blanket, _) | (_, DelegationScope::Blanket) => true,
-            (DelegationScope::Domain(d1), DelegationScope::Domain(d2)) => d1 == d2,
-            (DelegationScope::Domain(d), DelegationScope::Proposal(p))
-            | (DelegationScope::Proposal(p), DelegationScope::Domain(d)) => {
-                // Use registered domain mapping for precise check
-                match self.proposal_domains.get(p) {
-                    Some(proposal_domain) => proposal_domain == d,
-                    // Proposal-specific delegations are narrower than domain delegations,
-                    // so assume no overlap when proposal domain is unknown
-                    None => false,
-                }
-            }
-            (DelegationScope::Proposal(p1), DelegationScope::Proposal(p2)) => p1 == p2,
-        }
+        // Use shared helper with permissive default: assume no overlap when proposal unknown
+        // This allows delegations to proceed; conflicts detected when proposal is registered
+        scopes_overlap(a, b, self, false)
     }
 
     /// Compute the incoming delegation chain depth to a person

--- a/icn/crates/icn-governance/src/delegation.rs
+++ b/icn/crates/icn-governance/src/delegation.rs
@@ -1586,4 +1586,132 @@ mod tests {
             "Error should mention cycle"
         );
     }
+
+    /// Test the shared `scopes_overlap` function directly to document its behavior matrix.
+    ///
+    /// This tests all combinations of scope types and the `default_on_unknown` parameter.
+    #[test]
+    fn test_scopes_overlap_behavior_matrix() {
+        use std::collections::HashMap;
+
+        let domain_a = GovernanceDomainId::new("domain-a");
+        let domain_b = GovernanceDomainId::new("domain-b");
+        let proposal_1 = ProposalId::new("proposal-1");
+        let proposal_2 = ProposalId::new("proposal-2");
+        let unknown_proposal = ProposalId::new("unknown");
+
+        // Lookup that knows proposal_1 is in domain_a
+        struct TestLookup(HashMap<ProposalId, GovernanceDomainId>);
+        impl ProposalDomainLookup for TestLookup {
+            fn lookup_proposal_domain(
+                &self,
+                proposal_id: &ProposalId,
+            ) -> Option<GovernanceDomainId> {
+                self.0.get(proposal_id).cloned()
+            }
+        }
+
+        let mut known_proposals = HashMap::new();
+        known_proposals.insert(proposal_1.clone(), domain_a.clone());
+        known_proposals.insert(proposal_2.clone(), domain_b.clone());
+        let lookup = TestLookup(known_proposals);
+
+        // === Blanket scope tests ===
+        // Blanket overlaps with everything
+        assert!(scopes_overlap(
+            &DelegationScope::Blanket,
+            &DelegationScope::Blanket,
+            &lookup,
+            false
+        ));
+        assert!(scopes_overlap(
+            &DelegationScope::Blanket,
+            &DelegationScope::Domain(domain_a.clone()),
+            &lookup,
+            false
+        ));
+        assert!(scopes_overlap(
+            &DelegationScope::Domain(domain_a.clone()),
+            &DelegationScope::Blanket,
+            &lookup,
+            false
+        ));
+        assert!(scopes_overlap(
+            &DelegationScope::Blanket,
+            &DelegationScope::Proposal(proposal_1.clone()),
+            &lookup,
+            false
+        ));
+
+        // === Domain scope tests ===
+        // Same domain overlaps
+        assert!(scopes_overlap(
+            &DelegationScope::Domain(domain_a.clone()),
+            &DelegationScope::Domain(domain_a.clone()),
+            &lookup,
+            false
+        ));
+        // Different domains don't overlap
+        assert!(!scopes_overlap(
+            &DelegationScope::Domain(domain_a.clone()),
+            &DelegationScope::Domain(domain_b.clone()),
+            &lookup,
+            false
+        ));
+
+        // === Proposal scope tests ===
+        // Same proposal overlaps
+        assert!(scopes_overlap(
+            &DelegationScope::Proposal(proposal_1.clone()),
+            &DelegationScope::Proposal(proposal_1.clone()),
+            &lookup,
+            false
+        ));
+        // Different proposals don't overlap
+        assert!(!scopes_overlap(
+            &DelegationScope::Proposal(proposal_1.clone()),
+            &DelegationScope::Proposal(proposal_2.clone()),
+            &lookup,
+            false
+        ));
+
+        // === Domain/Proposal combination tests ===
+        // Known proposal in same domain overlaps
+        assert!(scopes_overlap(
+            &DelegationScope::Domain(domain_a.clone()),
+            &DelegationScope::Proposal(proposal_1.clone()),
+            &lookup,
+            false
+        ));
+        // Known proposal in different domain doesn't overlap
+        assert!(!scopes_overlap(
+            &DelegationScope::Domain(domain_b.clone()),
+            &DelegationScope::Proposal(proposal_1.clone()),
+            &lookup,
+            false
+        ));
+        // Symmetry check
+        assert!(scopes_overlap(
+            &DelegationScope::Proposal(proposal_1.clone()),
+            &DelegationScope::Domain(domain_a.clone()),
+            &lookup,
+            false
+        ));
+
+        // === Unknown proposal tests (default_on_unknown behavior) ===
+        // Unknown proposal with default_on_unknown=false (permissive)
+        assert!(!scopes_overlap(
+            &DelegationScope::Domain(domain_a.clone()),
+            &DelegationScope::Proposal(unknown_proposal.clone()),
+            &lookup,
+            false // permissive: assume no overlap
+        ));
+        // Unknown proposal with default_on_unknown=true (conservative)
+        assert!(scopes_overlap(
+            &DelegationScope::Domain(domain_a.clone()),
+            &DelegationScope::Proposal(unknown_proposal.clone()),
+            &lookup,
+            true // conservative: assume overlap
+        ));
+    }
 }

--- a/icn/crates/icn-governance/src/delegation.rs
+++ b/icn/crates/icn-governance/src/delegation.rs
@@ -136,8 +136,11 @@ pub trait ProposalDomainLookup {
 
 /// Check if two delegation scopes overlap (for cycle detection).
 ///
-/// This is the shared implementation used by DelegationManager, GovernanceActor,
-/// and GovernanceMgr to determine if two delegations could conflict.
+/// This is the shared implementation used by DelegationManager and GovernanceMgr
+/// to determine if two delegations could conflict.
+///
+/// Note: GovernanceActor uses its own implementation due to special error handling
+/// requirements (distinguishing storage errors from "not found" cases).
 ///
 /// # Arguments
 ///

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -91,8 +91,8 @@ pub use charter::{
 pub use charter_store::{CharterStore, CharterStoreBackend, InMemoryCharterStore};
 pub use config::{EmergencyThresholds, GovernanceConfig, GovernanceParams};
 pub use delegation::{
-    Delegation, DelegationError, DelegationId, DelegationManager, DelegationScope,
-    DEFAULT_MAX_DELEGATION_DEPTH,
+    scopes_overlap, Delegation, DelegationError, DelegationId, DelegationManager, DelegationScope,
+    ProposalDomainLookup, DEFAULT_MAX_DELEGATION_DEPTH,
 };
 pub use discussion::{
     Comment, CommentId, Discussion, DiscussionError, DiscussionStore, InMemoryDiscussionStore,

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -2317,6 +2317,19 @@ pub mod governance {
     pub fn delegation_reconciliation_duration_observe(duration_secs: f64) {
         histogram!("icn_governance_delegation_reconciliation_duration_seconds").record(duration_secs);
     }
+
+    /// Record when a storage error occurs during scope overlap checking
+    ///
+    /// This can indicate:
+    /// - Disk corruption or sled database issues
+    /// - Storage exhaustion (potential DoS vector)
+    /// - Transient I/O failures
+    ///
+    /// When this occurs, the system conservatively assumes overlap to prevent
+    /// potentially dangerous delegations from being created.
+    pub fn scope_overlap_storage_errors_inc() {
+        counter!("icn_governance_scope_overlap_storage_errors_total").increment(1);
+    }
 }
 
 /// Protocol parameter metrics (delayed execution)


### PR DESCRIPTION
## Summary

Extracts the duplicate `scopes_overlap` logic from three locations into a shared helper function with a trait-based abstraction.

Closes #303

## Changes

- Add `ProposalDomainLookup` trait for abstracting proposal domain lookup
- Add shared `scopes_overlap()` function in `icn-governance::delegation`
- Add `default_on_unknown` parameter for configurable behavior when proposal is unknown
- Refactor `DelegationManager` to implement trait and use shared function
- Refactor gateway's `governance_mgr.rs` to use `ProposalMapLookup` wrapper
- Document why core `GovernanceActor` can't use the shared helper (needs special error handling)

## Why GovernanceActor is Different

The core `GovernanceActor` has special error handling requirements that can't be expressed with the shared helper:
- `Ok(None)` (not found) → `false` (permissive - allow delegation)
- `Err(e)` (storage error) → `true` (conservative - block delegation)

The shared function only has a single `default_on_unknown` parameter and cannot distinguish between "not found" and "storage error" cases.

## Test Plan

- [x] All governance tests pass (290 tests)
- [x] Doc tests pass
- [x] Clippy clean
- [x] Fmt check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)