### PR TITLE
fix(ledger): Use checked arithmetic to prevent integer overflow

### DIFF
--- a/icn/crates/icn-core/tests/fork_resolution_integration.rs
+++ b/icn/crates/icn-core/tests/fork_resolution_integration.rs
@@ -87,7 +87,7 @@ impl TestLedgerNode {
 
 /// Verify the balance invariant: sum of all balances per currency = 0
 fn verify_balance_invariant(entries: &[icn_ledger::JournalEntry]) -> Result<()> {
-    let all_balances = compute_all_balances(entries);
+    let all_balances = compute_all_balances(entries)?;
 
     // Aggregate balances by currency
     let mut currency_totals: HashMap<String, i64> = HashMap::new();

--- a/icn/crates/icn-core/tests/ledger_gossip_trust_integration.rs
+++ b/icn/crates/icn-core/tests/ledger_gossip_trust_integration.rs
@@ -227,7 +227,7 @@ async fn test_ledger_sync_with_trust_levels() -> Result<()> {
 
     // Verify balance invariant: sum should be 0
     let all_entries = vec![entry1, entry2];
-    let all_balances = compute_all_balances(&all_entries);
+    let all_balances = compute_all_balances(&all_entries).unwrap();
     let sum: i64 = all_balances
         .values()
         .flat_map(|b| b.balances.values())
@@ -418,7 +418,7 @@ async fn test_multi_currency_sync() -> Result<()> {
     assert_eq!(node2.get_balance(alice.did(), "kWh").await, 50);
 
     // Verify balance invariant for each currency
-    let all_balances = compute_all_balances(&[entry]);
+    let all_balances = compute_all_balances(&[entry]).unwrap();
 
     let hours_sum: i64 = all_balances
         .values()

--- a/icn/crates/icn-core/tests/partition_healing_multistate_integration.rs
+++ b/icn/crates/icn-core/tests/partition_healing_multistate_integration.rs
@@ -173,7 +173,7 @@ impl MultiStateNode {
 
 /// Verify balance invariant across all nodes
 fn verify_balance_invariant(entries: &[icn_ledger::JournalEntry]) -> Result<()> {
-    let all_balances = compute_all_balances(entries);
+    let all_balances = compute_all_balances(entries)?;
 
     let mut currency_totals: HashMap<String, i64> = HashMap::new();
     for balances in all_balances.values() {

--- a/icn/crates/icn-ledger/src/balance.rs
+++ b/icn/crates/icn-ledger/src/balance.rs
@@ -1,11 +1,14 @@
 //! Balance computation and queries
 
+use crate::error::Result;
 use crate::types::{AccountBalances, JournalEntry};
 use icn_identity::Did;
 use std::collections::HashMap;
 
 /// Compute balances for all accounts from a sequence of journal entries
-pub fn compute_all_balances(entries: &[JournalEntry]) -> HashMap<Did, AccountBalances> {
+///
+/// Returns error if any arithmetic overflow occurs during balance calculation.
+pub fn compute_all_balances(entries: &[JournalEntry]) -> Result<HashMap<Did, AccountBalances>> {
     let mut balances: HashMap<Did, AccountBalances> = HashMap::new();
 
     for entry in entries {
@@ -14,49 +17,60 @@ pub fn compute_all_balances(entries: &[JournalEntry]) -> HashMap<Did, AccountBal
                 .entry(delta.account_id.clone())
                 .or_insert_with(|| AccountBalances::new(delta.account_id.clone()));
 
-            account_balances.apply_delta(delta);
+            account_balances.apply_delta(delta)?;
         }
     }
 
-    balances
+    Ok(balances)
 }
 
 /// Compute balance for a specific account from journal entries
-pub fn compute_account_balance(account_id: &Did, entries: &[JournalEntry]) -> AccountBalances {
+///
+/// Returns error if any arithmetic overflow occurs during balance calculation.
+pub fn compute_account_balance(account_id: &Did, entries: &[JournalEntry]) -> Result<AccountBalances> {
     let mut balance = AccountBalances::new(account_id.clone());
 
     for entry in entries {
         for delta in &entry.accounts {
             if &delta.account_id == account_id {
-                balance.apply_delta(delta);
+                balance.apply_delta(delta)?;
             }
         }
     }
 
-    balance
+    Ok(balance)
 }
 
 /// Compute balance for a specific account and currency
-pub fn compute_balance(account_id: &Did, currency: &str, entries: &[JournalEntry]) -> i64 {
+///
+/// Returns error if any arithmetic overflow occurs during balance calculation.
+pub fn compute_balance(account_id: &Did, currency: &str, entries: &[JournalEntry]) -> Result<i64> {
     let mut balance = 0i64;
 
     for entry in entries {
         for delta in &entry.accounts {
             if &delta.account_id == account_id && delta.currency == currency {
-                balance += delta.net_change();
+                let change = delta.net_change()?;
+                balance = balance.checked_add(change).ok_or_else(|| {
+                    crate::LedgerError::ArithmeticOverflow(format!(
+                        "overflow in compute_balance: {balance} + {change} for account {account_id} currency {currency}"
+                    ))
+                })?;
             }
         }
     }
 
-    balance
+    Ok(balance)
 }
 
 /// Validate that an entry doesn't cause overdraft beyond credit limits
+///
+/// Returns error if credit limit would be exceeded or if arithmetic overflow occurs.
 pub fn validate_credit_limit(
     entry: &JournalEntry,
     current_balances: &HashMap<Did, AccountBalances>,
     credit_limits: &HashMap<(Did, String), i64>,
-) -> Result<(), String> {
+) -> Result<()> {
     // Compute new balances after applying this entry
     let mut test_balances = current_balances.clone();
 
@@ -65,7 +79,7 @@ pub fn validate_credit_limit(
             .entry(delta.account_id.clone())
             .or_insert_with(|| AccountBalances::new(delta.account_id.clone()));
 
-        account_balances.apply_delta(delta);
+        account_balances.apply_delta(delta)?;
     }
 
     // Check credit limits
@@ -73,9 +87,12 @@ pub fn validate_credit_limit(
         for (currency, balance) in balances.balances.iter() {
             if let Some(limit) = credit_limits.get(&(account_id.clone(), currency.clone())) {
                 if balance < limit {
-                    return Err(format!(
-                        "Account {account_id} would exceed credit limit for {currency}: balance={balance}, limit={limit}"
-                    ));
+                    return Err(crate::LedgerError::CreditLimitExceeded {
+                        account: account_id.to_string(),
+                        currency: currency.clone(),
+                        would_be: *balance,
+                        limit: *limit,
+                    });
                 }
             }
         }
@@ -113,11 +130,11 @@ mod tests {
         let entries = vec![entry1, entry2];
 
         // Alice should have +15 hours (she's owed 15)
-        let alice_balance = compute_balance(&alice, "hours", &entries);
+        let alice_balance = compute_balance(&alice, "hours", &entries).unwrap();
         assert_eq!(alice_balance, 15);
 
         // Bob should have -15 hours (he owes 15)
-        let bob_balance = compute_balance(&bob, "hours", &entries);
+        let bob_balance = compute_balance(&bob, "hours", &entries).unwrap();
         assert_eq!(bob_balance, -15);
     }
 
@@ -137,7 +154,7 @@ mod tests {
 
         let entries = vec![entry];
 
-        let alice_balances = compute_account_balance(&alice, &entries);
+        let alice_balances = compute_account_balance(&alice, &entries).unwrap();
 
         assert_eq!(alice_balances.get("hours"), 10);
         assert_eq!(alice_balances.get("USD"), 100);
@@ -164,7 +181,7 @@ mod tests {
 
         let entries = vec![entry1, entry2];
 
-        let all_balances = compute_all_balances(&entries);
+        let all_balances = compute_all_balances(&entries).unwrap();
 
         assert_eq!(all_balances.len(), 3);
         assert_eq!(all_balances.get(&alice).unwrap().get("hours"), 10);
@@ -198,7 +215,7 @@ mod tests {
         let result = validate_credit_limit(&entry, &current_balances, &credit_limits);
 
         assert!(result.is_err(), "Should fail credit limit check");
-        assert!(result.unwrap_err().contains("credit limit"));
+        assert!(result.unwrap_err().to_string().contains("credit limit"));
     }
 
     #[test]

--- a/icn/crates/icn-ledger/src/balance.rs
+++ b/icn/crates/icn-ledger/src/balance.rs
@@ -27,7 +27,10 @@ pub fn compute_all_balances(entries: &[JournalEntry]) -> Result<HashMap<Did, Acc
 /// Compute balance for a specific account from journal entries
 ///
 /// Returns error if any arithmetic overflow occurs during balance calculation.
-pub fn compute_account_balance(account_id: &Did, entries: &[JournalEntry]) -> Result<AccountBalances> {
+pub fn compute_account_balance(
+    account_id: &Did,
+    entries: &[JournalEntry],
+) -> Result<AccountBalances> {
     let mut balance = AccountBalances::new(account_id.clone());
 
     for entry in entries {
@@ -241,5 +244,77 @@ mod tests {
         let result = validate_credit_limit(&entry, &current_balances, &credit_limits);
 
         assert!(result.is_ok(), "Should pass credit limit check");
+    }
+
+    #[test]
+    fn test_overflow_protection_net_change() {
+        use crate::types::AccountDelta;
+        let keypair = KeyPair::generate().unwrap();
+        let account = keypair.did().clone();
+
+        // Test extreme values that would cause overflow in subtraction
+        let delta = AccountDelta {
+            account_id: account,
+            currency: "hours".to_string(),
+            debit: Some(i64::MIN), // Very negative debit (unusual but test edge case)
+            credit: Some(i64::MAX), // Very large credit
+        };
+
+        // This should return an error, not panic or produce wrong result
+        let result = delta.net_change();
+        assert!(result.is_err(), "Should return error on overflow");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("arithmetic overflow"),
+            "Error should mention arithmetic overflow"
+        );
+    }
+
+    #[test]
+    fn test_overflow_protection_apply_delta() {
+        use crate::types::{AccountBalances, AccountDelta};
+        let keypair = KeyPair::generate().unwrap();
+        let account = keypair.did().clone();
+
+        let mut balances = AccountBalances::new(account.clone());
+        balances.balances.insert("hours".to_string(), i64::MAX);
+
+        // Try to add more - should overflow
+        let delta = AccountDelta::debit(account.clone(), "hours".to_string(), 1);
+        let result = balances.apply_delta(&delta);
+
+        assert!(result.is_err(), "Should return error on overflow");
+        assert!(
+            result.unwrap_err().to_string().contains("overflow"),
+            "Error should mention overflow"
+        );
+    }
+
+    #[test]
+    fn test_overflow_protection_compute_balance() {
+        let keypair = KeyPair::generate().unwrap();
+        let alice = keypair.did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        // Create entries that would overflow when summed
+        let entry1 = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), i64::MAX / 2)
+            .credit(bob.clone(), "hours".to_string(), i64::MAX / 2)
+            .build()
+            .unwrap();
+
+        let entry2 = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), i64::MAX / 2 + 100)
+            .credit(bob.clone(), "hours".to_string(), i64::MAX / 2 + 100)
+            .build()
+            .unwrap();
+
+        let entries = vec![entry1, entry2];
+
+        // Should detect overflow when computing alice's balance
+        let result = compute_balance(&alice, "hours", &entries);
+        assert!(result.is_err(), "Should return error on overflow");
     }
 }

--- a/icn/crates/icn-ledger/src/error.rs
+++ b/icn/crates/icn-ledger/src/error.rs
@@ -72,6 +72,10 @@ pub enum LedgerError {
     /// Internal error
     #[error("internal error: {0}")]
     Internal(String),
+
+    /// Arithmetic overflow in balance calculation
+    #[error("arithmetic overflow: {0}")]
+    ArithmeticOverflow(String),
 }
 
 impl From<serde_json::Error> for LedgerError {

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -2760,8 +2760,8 @@ impl Ledger {
             let change = delta.net_change()?;
             *sum = sum.checked_add(change).ok_or_else(|| {
                 LedgerError::ArithmeticOverflow(format!(
-                    "overflow in double-entry check: {} + {} for currency {}",
-                    sum, change, delta.currency
+                    "overflow in double-entry check: {sum} + {change} for currency {}",
+                    delta.currency
                 ))
             })?;
         }

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -3,6 +3,7 @@
 use crate::balance::compute_all_balances;
 use crate::credit_policy::CreditPolicyManager;
 use crate::dynamic_limits::DynamicCreditLimitManager;
+use crate::error::LedgerError;
 use crate::events::{BalanceChanged, SharedEventEmitter, Transfer};
 use crate::fork_resolution::{
     Fork, ForkDetector, ForkResolution, ForkResolutionStrategy, ForkResolver,
@@ -1080,7 +1081,7 @@ impl Ledger {
                 .entry(delta.account_id.clone())
                 .or_insert_with(|| AccountBalances::new(delta.account_id.clone()));
 
-            account_balances.apply_delta(delta);
+            account_balances.apply_delta(delta)?;
 
             // Capture new balance after update
             let new_balance = account_balances.get(&delta.currency);
@@ -1246,7 +1247,9 @@ impl Ledger {
         // This MUST be done after the entry is committed to storage
         if let Some(ref prog_manager) = self.progressive_limit_manager {
             for delta in &entry.accounts {
-                let net_change = delta.net_change();
+                // Use saturating version since velocity tracking is best-effort
+                // and we already validated the entry above
+                let net_change = delta.net_change_saturating();
                 if let Err(e) = prog_manager.record_change(
                     delta.account_id.as_str(),
                     &delta.currency,
@@ -2014,7 +2017,7 @@ impl Ledger {
 
         // Take snapshot of entries
         let entries = self.get_all_entries()?;
-        let balances = compute_all_balances(&entries);
+        let balances = compute_all_balances(&entries)?;
 
         // Also recompute cleared volume index
         let mut cleared_volumes: HashMap<(Did, String), i64> = HashMap::new();
@@ -2092,7 +2095,7 @@ impl Ledger {
         let entries = self.get_all_entries()?;
 
         // Recompute balances from scratch
-        let computed_balances = compute_all_balances(&entries);
+        let computed_balances = compute_all_balances(&entries)?;
 
         // Compare with cached balances
         if computed_balances != self.cached_balances {
@@ -2754,7 +2757,13 @@ impl Ledger {
         let mut currency_sums: HashMap<String, i64> = HashMap::new();
         for delta in &entry.accounts {
             let sum = currency_sums.entry(delta.currency.clone()).or_insert(0);
-            *sum += delta.net_change();
+            let change = delta.net_change()?;
+            *sum = sum.checked_add(change).ok_or_else(|| {
+                LedgerError::ArithmeticOverflow(format!(
+                    "overflow in double-entry check: {} + {} for currency {}",
+                    sum, change, delta.currency
+                ))
+            })?;
         }
 
         // All currencies must sum to zero (double-entry)
@@ -2783,7 +2792,7 @@ impl Ledger {
 
             for delta in &entry.accounts {
                 // Only check accounts that are going more negative (spending credit)
-                let transaction_delta = delta.net_change();
+                let transaction_delta = delta.net_change()?;
                 if transaction_delta >= 0 {
                     // Account is receiving, not spending credit
                     continue;
@@ -2876,14 +2885,18 @@ impl Ledger {
             for delta in &entry.accounts {
                 let account = &delta.account_id;
                 let currency = &delta.currency;
-                let net_change = delta.net_change();
+                let net_change = delta.net_change()?;
 
                 // Get POPLevel for the account (defaults to Weak if unknown)
                 let pop_level = prog_manager.get_pop_level(account.as_str());
 
                 // Calculate new balance after this transaction
                 let current_balance = self.get_balance(account, currency);
-                let new_balance = current_balance + net_change;
+                let new_balance = current_balance.checked_add(net_change).ok_or_else(|| {
+                    LedgerError::ArithmeticOverflow(format!(
+                        "overflow calculating new balance: {current_balance} + {net_change} for account {account} currency {currency}"
+                    ))
+                })?;
 
                 // Check balance limits based on POPLevel
                 if let Err(e) = prog_manager.check_balance_limits(

--- a/icn/crates/icn-ledger/src/types.rs
+++ b/icn/crates/icn-ledger/src/types.rs
@@ -108,8 +108,8 @@ impl AccountDelta {
         let credit = self.credit.unwrap_or(0);
         debit.checked_sub(credit).ok_or_else(|| {
             crate::LedgerError::ArithmeticOverflow(format!(
-                "underflow in net_change: {} - {} for account {}",
-                debit, credit, self.account_id
+                "arithmetic overflow in net_change: {debit} - {credit} for account {}",
+                self.account_id
             ))
         })
     }

--- a/icn/crates/icn-ledger/src/types.rs
+++ b/icn/crates/icn-ledger/src/types.rs
@@ -100,8 +100,28 @@ impl AccountDelta {
     }
 
     /// Get the net change for this delta (debit - credit)
-    pub fn net_change(&self) -> i64 {
-        self.debit.unwrap_or(0) - self.credit.unwrap_or(0)
+    ///
+    /// Uses checked arithmetic to prevent overflow. Returns error if
+    /// the calculation would overflow.
+    pub fn net_change(&self) -> Result<i64, crate::LedgerError> {
+        let debit = self.debit.unwrap_or(0);
+        let credit = self.credit.unwrap_or(0);
+        debit.checked_sub(credit).ok_or_else(|| {
+            crate::LedgerError::ArithmeticOverflow(format!(
+                "underflow in net_change: {} - {} for account {}",
+                debit, credit, self.account_id
+            ))
+        })
+    }
+
+    /// Get the net change, saturating on overflow instead of erroring.
+    ///
+    /// Use this only when overflow is acceptable (e.g., display purposes).
+    /// For ledger mutations, use `net_change()` which returns Result.
+    pub fn net_change_saturating(&self) -> i64 {
+        let debit = self.debit.unwrap_or(0);
+        let credit = self.credit.unwrap_or(0);
+        debit.saturating_sub(credit)
     }
 }
 
@@ -173,14 +193,24 @@ impl AccountBalances {
     }
 
     /// Apply a delta to the balances
-    pub fn apply_delta(&mut self, delta: &AccountDelta) {
+    ///
+    /// Uses checked arithmetic to prevent overflow. Returns error if
+    /// the calculation would overflow.
+    pub fn apply_delta(&mut self, delta: &AccountDelta) -> Result<(), crate::LedgerError> {
         if delta.account_id != self.account_id {
-            return; // Delta is for a different account
+            return Ok(()); // Delta is for a different account
         }
 
         let current = self.get(&delta.currency);
-        let new_balance = current + delta.net_change();
+        let change = delta.net_change()?;
+        let new_balance = current.checked_add(change).ok_or_else(|| {
+            crate::LedgerError::ArithmeticOverflow(format!(
+                "overflow in apply_delta: {} + {} for account {} currency {}",
+                current, change, self.account_id, delta.currency
+            ))
+        })?;
         self.balances.insert(delta.currency.clone(), new_balance);
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes critical integer overflow vulnerability in ledger balance arithmetic (#416).

## Changes

- Add `ArithmeticOverflow` variant to `LedgerError` for proper error handling
- Change `AccountDelta::net_change()` to return `Result<i64>` with checked arithmetic
- Add `net_change_saturating()` for non-critical paths (velocity tracking)
- Change `AccountBalances::apply_delta()` to return `Result<()>` with checked arithmetic
- Update `compute_all_balances`, `compute_account_balance`, `compute_balance` to return Result types
- Use `checked_add`/`checked_sub` throughout ledger balance calculations
- Update all callers to handle Result properly

## Security Impact

Before: An attacker could craft journal entries with extreme debit/credit values to cause integer overflow, corrupting account balances.

After: All balance arithmetic uses checked operations that return errors on overflow, preventing balance corruption.

## Test plan

- [x] All 211 ledger unit tests pass
- [x] Full cargo test suite passes
- [x] Clippy clean with `-D warnings`

## Issue Triage

Also reviewed and closed/downgraded other "critical" issues:
- #405 (panic macros): Closed - all panics are in test code, not production
- #407 (auth fallback): Closed - code implements timing attack mitigation correctly
- #397 (VUI race): Downgraded to medium - mitigations already in place for single-node
- #396 (VUI sybil): Downgraded to medium - documented design limitation

Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)