### PR TITLE
fix(governance): Replace confusing let _ = ...unwrap() pattern in SDIS tests

### DIFF
--- a/icn/crates/icn-governance/src/sdis.rs
+++ b/icn/crates/icn-governance/src/sdis.rs
@@ -653,10 +653,22 @@ mod tests {
             steward_did: test_did(),
         };
 
-        // Just verify serialization works
-        let _ = serde_json::to_string(&anchor_target).unwrap();
-        let _ = serde_json::to_string(&keybundle_target).unwrap();
-        let _ = serde_json::to_string(&attestation_target).unwrap();
-        let _ = serde_json::to_string(&steward_target).unwrap();
+        // Verify all variants serialize successfully
+        assert!(
+            serde_json::to_string(&anchor_target).is_ok(),
+            "Anchor variant should serialize"
+        );
+        assert!(
+            serde_json::to_string(&keybundle_target).is_ok(),
+            "KeyBundle variant should serialize"
+        );
+        assert!(
+            serde_json::to_string(&attestation_target).is_ok(),
+            "Attestation variant should serialize"
+        );
+        assert!(
+            serde_json::to_string(&steward_target).is_ok(),
+            "StewardStatus variant should serialize"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Replaces confusing `let _ = serde_json::to_string(...).unwrap()` pattern with explicit `assert!(...is_ok())` in test code.

## Changes

- `icn-governance/src/sdis.rs`: Replace 4 instances of `let _ = ...unwrap()` with `assert!(is_ok())` pattern

## Motivation

The original pattern was confusing because:
- `let _ =` suggests ignoring the result
- But `.unwrap()` still panics on error
- Unclear whether we're testing success or just discarding output

The new pattern makes intent explicit: we're verifying that all `RevocationTarget` variants serialize successfully.

## Issue Resolution

**Closes #408**

**Also addressed #409** - After investigation, all patterns mentioned in that issue were found to be in test code only, where `unwrap()` is explicitly allowed by project convention (`#![cfg_attr(test, allow(clippy::unwrap_used))]`). Issue #409 was closed as "not planned" since it's not a production bug.

## Test Plan

- [x] `cargo test -p icn-governance test_revocation_targets` passes
- [x] `cargo clippy -p icn-governance` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)