### PR TITLE
fix(net): Schedule replay guard cleanup in actor loop

### DIFF
--- a/icn/crates/icn-net/src/actor.rs
+++ b/icn/crates/icn-net/src/actor.rs
@@ -1045,8 +1045,7 @@ impl NetworkActor {
         let mut shutdown_rx = shutdown_tx.subscribe();
 
         // Cleanup interval for replay guard and rate limiter (60 seconds)
-        let mut cleanup_interval =
-            tokio::time::interval(tokio::time::Duration::from_secs(60));
+        let mut cleanup_interval = tokio::time::interval(tokio::time::Duration::from_secs(60));
 
         loop {
             tokio::select! {

--- a/icn/crates/icn-net/src/actor.rs
+++ b/icn/crates/icn-net/src/actor.rs
@@ -1044,6 +1044,10 @@ impl NetworkActor {
 
         let mut shutdown_rx = shutdown_tx.subscribe();
 
+        // Cleanup interval for replay guard and rate limiter (60 seconds)
+        let mut cleanup_interval =
+            tokio::time::interval(tokio::time::Duration::from_secs(60));
+
         loop {
             tokio::select! {
                 msg = self.rx.recv() => {
@@ -1054,6 +1058,38 @@ impl NetworkActor {
                             break;
                         }
                     }
+                }
+                _ = cleanup_interval.tick() => {
+                    // Cleanup stale replay guard entries
+                    let peer_count_before = {
+                        let guard = self.replay_guard.read().await;
+                        guard.peer_count()
+                    };
+
+                    {
+                        let mut guard = self.replay_guard.write().await;
+                        guard.cleanup();
+                    }
+
+                    let peer_count_after = {
+                        let guard = self.replay_guard.read().await;
+                        guard.peer_count()
+                    };
+
+                    // Update metric
+                    icn_obs::metrics::network::replay_guard_peers_set(peer_count_after as u64);
+
+                    if peer_count_before != peer_count_after {
+                        info!(
+                            "Replay guard cleanup: {} -> {} peers",
+                            peer_count_before, peer_count_after
+                        );
+                    }
+
+                    // Also cleanup stale rate limiter buckets
+                    self.rate_limiter
+                        .cleanup_old_buckets(std::time::Duration::from_secs(300))
+                        .await;
                 }
                 _ = shutdown_rx.recv() => {
                     info!("Network actor received shutdown signal");

--- a/icn/crates/icn-net/src/actor.rs
+++ b/icn/crates/icn-net/src/actor.rs
@@ -24,6 +24,9 @@ use crate::{
     CapabilityFlags, Discovery, PeerInfo, SessionManager,
 };
 
+/// Max age for rate limiter buckets before cleanup (5 minutes)
+const RATE_LIMITER_BUCKET_MAX_AGE_SECS: u64 = 300;
+
 /// Per-peer connection metadata
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PeerConnectionInfo {
@@ -1046,6 +1049,7 @@ impl NetworkActor {
 
         // Cleanup interval for replay guard and rate limiter (60 seconds)
         let mut cleanup_interval = tokio::time::interval(tokio::time::Duration::from_secs(60));
+        cleanup_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         loop {
             tokio::select! {
@@ -1059,20 +1063,13 @@ impl NetworkActor {
                     }
                 }
                 _ = cleanup_interval.tick() => {
-                    // Cleanup stale replay guard entries
-                    let peer_count_before = {
-                        let guard = self.replay_guard.read().await;
-                        guard.peer_count()
-                    };
-
-                    {
+                    // Cleanup stale replay guard entries using single write lock
+                    let (peer_count_before, peer_count_after) = {
                         let mut guard = self.replay_guard.write().await;
+                        let before = guard.peer_count();
                         guard.cleanup();
-                    }
-
-                    let peer_count_after = {
-                        let guard = self.replay_guard.read().await;
-                        guard.peer_count()
+                        let after = guard.peer_count();
+                        (before, after)
                     };
 
                     // Update metric
@@ -1087,7 +1084,7 @@ impl NetworkActor {
 
                     // Also cleanup stale rate limiter buckets
                     self.rate_limiter
-                        .cleanup_old_buckets(std::time::Duration::from_secs(300))
+                        .cleanup_old_buckets(std::time::Duration::from_secs(RATE_LIMITER_BUCKET_MAX_AGE_SECS))
                         .await;
                 }
                 _ = shutdown_rx.recv() => {

--- a/icn/crates/icn-obs/src/metrics/network.rs
+++ b/icn/crates/icn-obs/src/metrics/network.rs
@@ -86,6 +86,10 @@ pub fn init_descriptions() {
         "icn_network_version_negotiation_success_total",
         "Total number of successful version negotiations"
     );
+    describe_gauge!(
+        "icn_network_replay_guard_peers",
+        "Number of peers tracked in replay guard"
+    );
 }
 
 // Simple counters
@@ -187,6 +191,11 @@ pub fn peer_capability_set(capability: &str, count: u64) {
         "capability" => capability.to_string()
     )
     .set(count as f64);
+}
+
+/// Set the number of peers tracked in replay guard
+pub fn replay_guard_peers_set(value: u64) {
+    gauge!("icn_network_replay_guard_peers").set(value as f64);
 }
 
 // Complex function with custom logic


### PR DESCRIPTION
## Summary

Fixes #420 - The replay guard cleanup method existed but was never called, leading to memory growth from stale peer entries.

## Changes

- Add 60-second cleanup interval to NetworkActor event loop
- Call `replay_guard.cleanup()` to remove inactive peer windows
- Call `rate_limiter.cleanup_old_buckets()` to remove stale buckets
- Add `icn_network_replay_guard_peers` Prometheus gauge metric
- Log when peer count changes after cleanup

## How it Works

The cleanup removes:
- Peer windows inactive for >max_peer_age_secs (configurable, default 3600s)
- Finalized sequences older than 24 hours
- Rate limiter buckets older than 5 minutes

## Test Plan

- [x] `cargo check -p icn-net -p icn-obs` compiles
- [x] `cargo clippy -p icn-net -p icn-obs` passes
- [x] `cargo test -p icn-net` passes
- [ ] Verify metric appears in Prometheus

🤖 Generated with [Claude Code](https://claude.com/claude-code)