### PR TITLE
fix(obs): Make observability URLs configurable

### DIFF
--- a/icn/crates/icn-obs/src/otel.rs
+++ b/icn/crates/icn-obs/src/otel.rs
@@ -217,12 +217,38 @@ mod tests {
 
     #[test]
     fn test_tracing_config_defaults() {
+        // Save and clear env var to test true default
+        let saved = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok();
+        std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
+
         let config = TracingConfig::default();
         assert!(!config.enabled);
         assert_eq!(config.otlp_endpoint, "http://localhost:4317");
         assert!((config.sampling_rate - 0.1).abs() < f64::EPSILON);
         assert_eq!(config.service_name, "icnd");
         assert!(config.node_did.is_none());
+
+        // Restore env var if it was set
+        if let Some(val) = saved {
+            std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", val);
+        }
+    }
+
+    #[test]
+    fn test_tracing_config_respects_env_var() {
+        // Save current value
+        let saved = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok();
+
+        // Set env var and verify it's used
+        std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", "http://tempo:4317");
+        let config = TracingConfig::default();
+        assert_eq!(config.otlp_endpoint, "http://tempo:4317");
+
+        // Restore env var
+        match saved {
+            Some(val) => std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", val),
+            None => std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT"),
+        }
     }
 
     #[test]

--- a/icn/crates/icn-obs/src/otel.rs
+++ b/icn/crates/icn-obs/src/otel.rs
@@ -44,7 +44,9 @@ fn default_enabled() -> bool {
 }
 
 fn default_otlp_endpoint() -> String {
-    "http://localhost:4317".to_string()
+    // Check standard OpenTelemetry environment variable first
+    std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+        .unwrap_or_else(|_| "http://localhost:4317".to_string())
 }
 
 fn default_sampling_rate() -> f64 {

--- a/icn/crates/icn-obs/static/dashboard.html
+++ b/icn/crates/icn-obs/static/dashboard.html
@@ -130,7 +130,8 @@
     </div>
 
     <script>
-        // Use relative URL for same-origin metrics, or override via global variable
+        // Use relative URL for same-origin requests (dashboard and metrics both served by icnd on :8080)
+        // For embedding in external sites, set window.METRICS_URL = 'http://icnd.monitoring:9100/metrics'
         const METRICS_URL = window.METRICS_URL || '/metrics';
         const HEALTH_URL = window.HEALTH_URL || '/health';
         const REFRESH_INTERVAL = 5000; // 5 seconds

--- a/icn/crates/icn-obs/static/dashboard.html
+++ b/icn/crates/icn-obs/static/dashboard.html
@@ -130,8 +130,9 @@
     </div>
 
     <script>
-        const METRICS_URL = 'http://localhost:9100/metrics';
-        const HEALTH_URL = '/health';
+        // Use relative URL for same-origin metrics, or override via global variable
+        const METRICS_URL = window.METRICS_URL || '/metrics';
+        const HEALTH_URL = window.HEALTH_URL || '/health';
         const REFRESH_INTERVAL = 5000; // 5 seconds
 
         async function fetchHealth() {


### PR DESCRIPTION
## Summary

Fixes #413 - Hardcoded localhost URLs broke production deployments.

## Changes

| Component | Before | After |
|-----------|--------|-------|
| OTLP endpoint | `http://localhost:4317` | Checks `OTEL_EXPORTER_OTLP_ENDPOINT` env var first |
| Dashboard metrics | `http://localhost:9100/metrics` | `/metrics` (relative URL) |
| Dashboard health | `/health` | `window.HEALTH_URL \|\| '/health'` |

## Configuration Options

**OTLP Tracing:**
```bash
export OTEL_EXPORTER_OTLP_ENDPOINT="http://tempo.monitoring:4317"
```

**Dashboard (for embedding):**
```html
<script>
  window.METRICS_URL = 'http://icnd.monitoring:9100/metrics';
</script>
```

## Deployment Notes

For K8s deployment, set in ConfigMap:
```yaml
env:
  - name: OTEL_EXPORTER_OTLP_ENDPOINT
    value: "http://tempo:4317"
```

## Test Plan

- [x] `cargo check -p icn-obs` compiles
- [ ] Verify dashboard works with relative URLs locally
- [ ] Verify OTLP works with env var in K8s

🤖 Generated with [Claude Code](https://claude.com/claude-code)