### PR TITLE
fix(governance): Improve lock poisoning handling in steward store

### DIFF
--- a/icn/crates/icn-core/tests/contract_deployment_integration.rs
+++ b/icn/crates/icn-core/tests/contract_deployment_integration.rs
@@ -1136,6 +1136,7 @@ async fn test_contract_with_state_variables() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore] // Flaky: Hardcoded ports cause conflicts - see #403, PR #432
 async fn test_contract_with_ledger_integration() {
     // Create two nodes
     let node_a = TestNode::new(19012).await.expect("Failed to create node A");

--- a/icn/crates/icn-core/tests/contract_deployment_integration.rs
+++ b/icn/crates/icn-core/tests/contract_deployment_integration.rs
@@ -1136,7 +1136,6 @@ async fn test_contract_with_state_variables() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore] // Flaky: Hardcoded ports cause conflicts - see #403, PR #432
 async fn test_contract_with_ledger_integration() {
     // Create two nodes
     let node_a = TestNode::new(19012).await.expect("Failed to create node A");

--- a/icn/crates/icn-governance/src/steward_store.rs
+++ b/icn/crates/icn-governance/src/steward_store.rs
@@ -521,6 +521,7 @@ fn status_to_key(status: &StewardStatus) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     /// Valid test DIDs (proper multibase-encoded Ed25519 public keys)
     /// Generated from deterministic seeds
@@ -780,5 +781,131 @@ mod tests {
         assert!(store.get(&record1.steward_id).await.unwrap().is_some());
         assert!(store.get(&record2.steward_id).await.unwrap().is_some());
         assert!(store.get(&record3.steward_id).await.unwrap().is_some());
+    }
+
+    // ========== Lock Poisoning Tests ==========
+
+    /// A backend that can simulate poison/failure states for testing
+    struct FailingBackend {
+        inner: InMemoryStewardStore,
+        should_fail: AtomicBool,
+    }
+
+    impl FailingBackend {
+        fn new() -> Self {
+            Self {
+                inner: InMemoryStewardStore::new(),
+                should_fail: AtomicBool::new(false),
+            }
+        }
+
+        fn set_failing(&self, fail: bool) {
+            self.should_fail.store(fail, Ordering::SeqCst);
+        }
+    }
+
+    #[async_trait]
+    impl StewardStoreBackend for FailingBackend {
+        async fn get(&self, key: &[u8]) -> anyhow::Result<Option<Vec<u8>>> {
+            if self.should_fail.load(Ordering::SeqCst) {
+                anyhow::bail!("Lock poisoned - store may contain corrupt state")
+            }
+            self.inner.get(key).await
+        }
+
+        async fn set(&self, key: &[u8], value: &[u8]) -> anyhow::Result<()> {
+            if self.should_fail.load(Ordering::SeqCst) {
+                anyhow::bail!("Lock poisoned - store may contain corrupt state")
+            }
+            self.inner.set(key, value).await
+        }
+
+        async fn delete(&self, key: &[u8]) -> anyhow::Result<()> {
+            if self.should_fail.load(Ordering::SeqCst) {
+                anyhow::bail!("Lock poisoned - store may contain corrupt state")
+            }
+            self.inner.delete(key).await
+        }
+
+        async fn list_keys(&self, prefix: &[u8]) -> anyhow::Result<Vec<Vec<u8>>> {
+            if self.should_fail.load(Ordering::SeqCst) {
+                anyhow::bail!("Lock poisoned - store may contain corrupt state")
+            }
+            self.inner.list_keys(prefix).await
+        }
+    }
+
+    #[tokio::test]
+    async fn test_backend_poison_fails_fast() {
+        // Test that backend failures propagate as errors (fail-fast behavior)
+        let backend = FailingBackend::new();
+        let store = StewardStore::with_default_cache(backend);
+
+        // Now simulate backend poison BEFORE any operations
+        store.backend.set_failing(true);
+
+        // Store operation should fail
+        let record = create_test_record();
+        let result = store.store(&record).await;
+        assert!(result.is_err(), "store should fail when backend is poisoned");
+        assert!(
+            result.unwrap_err().to_string().contains("Lock poisoned"),
+            "error should mention lock poisoning"
+        );
+
+        // Get should fail (nothing in cache, backend is poisoned)
+        let result = store.get(&record.steward_id).await;
+        assert!(result.is_err(), "get should fail when backend is poisoned");
+
+        // list_keys (via count) should fail
+        let result = store.count().await;
+        assert!(result.is_err(), "count should fail when backend is poisoned");
+
+        // Verify that when backend is restored, operations succeed
+        store.backend.set_failing(false);
+        let result = store.store(&record).await;
+        assert!(result.is_ok(), "store should succeed when backend is restored");
+    }
+
+    #[tokio::test]
+    async fn test_cache_poison_graceful_degradation() {
+        // Test that cache failures don't break the store (graceful degradation)
+        // We simulate this by poisoning the cache and verifying operations still succeed
+        let backend = InMemoryStewardStore::new();
+        let store = StewardStore::with_default_cache(backend);
+
+        // Store a record
+        let record = create_test_record();
+        store.store(&record).await.expect("store should succeed");
+
+        // Poison the cache by panicking while holding the lock
+        // We use catch_unwind to safely panic and poison the lock
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = store.cache.write().unwrap();
+            panic!("intentional panic to poison cache");
+        }));
+
+        // Verify the cache is actually poisoned
+        assert!(
+            store.cache.write().is_err(),
+            "cache should be poisoned after panic"
+        );
+
+        // The cache is now poisoned, but operations should still work via backend
+        // Store another record - should succeed (cache update is non-critical)
+        let mut record2 = create_test_record();
+        record2.steward_did = TEST_DID_3.parse().unwrap();
+        record2.holder_did = TEST_DID_4.parse().unwrap();
+        let result = store.store(&record2).await;
+        assert!(result.is_ok(), "store should succeed even with poisoned cache");
+
+        // Get should work (falls back to backend when cache is poisoned)
+        let result = store.get(&record.steward_id).await;
+        assert!(result.is_ok(), "get should succeed even with poisoned cache");
+        assert!(result.unwrap().is_some(), "should retrieve record from backend");
+
+        // Delete should work (cache update is non-critical)
+        let result = store.delete(&record2.steward_id).await;
+        assert!(result.is_ok(), "delete should succeed even with poisoned cache");
     }
 }

--- a/icn/crates/icn-governance/src/steward_store.rs
+++ b/icn/crates/icn-governance/src/steward_store.rs
@@ -5,6 +5,17 @@
 //! - Indexes (by DID, holder, jurisdiction, status)
 //! - LRU caching for performance
 //! - Lifecycle operations (suspend, reinstate, retire, revoke)
+//!
+//! ## Lock Poisoning Handling
+//!
+//! This module uses two patterns for lock poison recovery:
+//!
+//! - **Backend operations** (get, set, delete, list_keys): Fail-fast with error.
+//!   Poisoned locks indicate a prior panic and possibly corrupt state.
+//!   Silent recovery would risk data integrity issues.
+//!
+//! - **Cache operations**: Graceful degradation. Cache is non-critical; poison
+//!   is logged but the operation continues using the backend directly.
 
 use crate::steward::{StewardId, StewardRecord, StewardStatus};
 use async_trait::async_trait;

--- a/icn/crates/icn-governance/src/steward_store.rs
+++ b/icn/crates/icn-governance/src/steward_store.rs
@@ -13,7 +13,7 @@ use lru::LruCache;
 use serde::{Deserialize, Serialize};
 use std::num::NonZeroUsize;
 use std::sync::RwLock;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 /// Storage key prefixes
 const PREFIX_STEWARD: &[u8] = b"steward/records/";
@@ -60,36 +60,36 @@ impl Default for InMemoryStewardStore {
 #[async_trait]
 impl StewardStoreBackend for InMemoryStewardStore {
     async fn get(&self, key: &[u8]) -> anyhow::Result<Option<Vec<u8>>> {
-        let data = self.data.read().unwrap_or_else(|poisoned| {
-            warn!("Data lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let data = self.data.read().map_err(|_| {
+            error!("Lock poisoned in steward store get - previous holder panicked");
+            anyhow::anyhow!("Lock poisoned - store may contain corrupt state")
+        })?;
         Ok(data.get(key).cloned())
     }
 
     async fn set(&self, key: &[u8], value: &[u8]) -> anyhow::Result<()> {
-        let mut data = self.data.write().unwrap_or_else(|poisoned| {
-            warn!("Data lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let mut data = self.data.write().map_err(|_| {
+            error!("Lock poisoned in steward store set - previous holder panicked");
+            anyhow::anyhow!("Lock poisoned - store may contain corrupt state")
+        })?;
         data.insert(key.to_vec(), value.to_vec());
         Ok(())
     }
 
     async fn delete(&self, key: &[u8]) -> anyhow::Result<()> {
-        let mut data = self.data.write().unwrap_or_else(|poisoned| {
-            warn!("Data lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let mut data = self.data.write().map_err(|_| {
+            error!("Lock poisoned in steward store delete - previous holder panicked");
+            anyhow::anyhow!("Lock poisoned - store may contain corrupt state")
+        })?;
         data.remove(key);
         Ok(())
     }
 
     async fn list_keys(&self, prefix: &[u8]) -> anyhow::Result<Vec<Vec<u8>>> {
-        let data = self.data.read().unwrap_or_else(|poisoned| {
-            warn!("Data lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let data = self.data.read().map_err(|_| {
+            error!("Lock poisoned in steward store list_keys - previous holder panicked");
+            anyhow::anyhow!("Lock poisoned - store may contain corrupt state")
+        })?;
         let keys: Vec<Vec<u8>> = data
             .keys()
             .filter(|k| k.starts_with(prefix))
@@ -143,13 +143,11 @@ impl<B: StewardStoreBackend> StewardStore<B> {
         // Update indexes
         self.update_indexes(record).await?;
 
-        // Update cache
-        {
-            let mut cache = self.cache.write().unwrap_or_else(|poisoned| {
-                warn!("Cache lock poisoned, recovering");
-                poisoned.into_inner()
-            });
+        // Update cache (non-critical - skip on poison)
+        if let Ok(mut cache) = self.cache.write() {
             cache.put(*steward_id, record.clone());
+        } else {
+            warn!("Cache lock poisoned in store - skipping cache update");
         }
 
         debug!("Stored steward record: {}", record.steward_id);
@@ -160,15 +158,13 @@ impl<B: StewardStoreBackend> StewardStore<B> {
     pub async fn get(&self, steward_id: &StewardId) -> anyhow::Result<Option<StewardRecord>> {
         let id_bytes = steward_id.as_bytes();
 
-        // Check cache first
-        {
-            let mut cache = self.cache.write().unwrap_or_else(|poisoned| {
-                warn!("Cache lock poisoned, recovering");
-                poisoned.into_inner()
-            });
+        // Check cache first (non-critical - skip on poison)
+        if let Ok(mut cache) = self.cache.write() {
             if let Some(record) = cache.get(id_bytes) {
                 return Ok(Some(record.clone()));
             }
+        } else {
+            warn!("Cache lock poisoned in get - falling back to backend");
         }
 
         // Load from backend
@@ -178,13 +174,11 @@ impl<B: StewardStoreBackend> StewardStore<B> {
         if let Some(data) = self.backend.get(&key).await? {
             let record: StewardRecord = serde_json::from_slice(&data)?;
 
-            // Update cache
-            {
-                let mut cache = self.cache.write().unwrap_or_else(|poisoned| {
-                    warn!("Cache lock poisoned, recovering");
-                    poisoned.into_inner()
-                });
+            // Update cache (non-critical - skip on poison)
+            if let Ok(mut cache) = self.cache.write() {
                 cache.put(*id_bytes, record.clone());
+            } else {
+                warn!("Cache lock poisoned in get - skipping cache update");
             }
 
             Ok(Some(record))
@@ -397,13 +391,11 @@ impl<B: StewardStoreBackend> StewardStore<B> {
             key.extend_from_slice(steward_id.as_bytes());
             self.backend.delete(&key).await?;
 
-            // Remove from cache
-            {
-                let mut cache = self.cache.write().unwrap_or_else(|poisoned| {
-                    warn!("Cache lock poisoned, recovering");
-                    poisoned.into_inner()
-                });
+            // Remove from cache (non-critical - skip on poison)
+            if let Ok(mut cache) = self.cache.write() {
                 cache.pop(steward_id.as_bytes());
+            } else {
+                warn!("Cache lock poisoned in delete - skipping cache update");
             }
 
             debug!("Deleted steward record: {steward_id}");

--- a/icn/crates/icn-governance/src/steward_store.rs
+++ b/icn/crates/icn-governance/src/steward_store.rs
@@ -71,35 +71,35 @@ impl Default for InMemoryStewardStore {
 #[async_trait]
 impl StewardStoreBackend for InMemoryStewardStore {
     async fn get(&self, key: &[u8]) -> anyhow::Result<Option<Vec<u8>>> {
-        let data = self.data.read().map_err(|_| {
-            error!("Lock poisoned in steward store get - previous holder panicked");
-            anyhow::anyhow!("Lock poisoned - store may contain corrupt state")
+        let data = self.data.read().map_err(|e| {
+            error!("Lock poisoned in steward store get: {e}");
+            anyhow::anyhow!("Lock poisoned in get - store may contain corrupt state")
         })?;
         Ok(data.get(key).cloned())
     }
 
     async fn set(&self, key: &[u8], value: &[u8]) -> anyhow::Result<()> {
-        let mut data = self.data.write().map_err(|_| {
-            error!("Lock poisoned in steward store set - previous holder panicked");
-            anyhow::anyhow!("Lock poisoned - store may contain corrupt state")
+        let mut data = self.data.write().map_err(|e| {
+            error!("Lock poisoned in steward store set: {e}");
+            anyhow::anyhow!("Lock poisoned in set - store may contain corrupt state")
         })?;
         data.insert(key.to_vec(), value.to_vec());
         Ok(())
     }
 
     async fn delete(&self, key: &[u8]) -> anyhow::Result<()> {
-        let mut data = self.data.write().map_err(|_| {
-            error!("Lock poisoned in steward store delete - previous holder panicked");
-            anyhow::anyhow!("Lock poisoned - store may contain corrupt state")
+        let mut data = self.data.write().map_err(|e| {
+            error!("Lock poisoned in steward store delete: {e}");
+            anyhow::anyhow!("Lock poisoned in delete - store may contain corrupt state")
         })?;
         data.remove(key);
         Ok(())
     }
 
     async fn list_keys(&self, prefix: &[u8]) -> anyhow::Result<Vec<Vec<u8>>> {
-        let data = self.data.read().map_err(|_| {
-            error!("Lock poisoned in steward store list_keys - previous holder panicked");
-            anyhow::anyhow!("Lock poisoned - store may contain corrupt state")
+        let data = self.data.read().map_err(|e| {
+            error!("Lock poisoned in steward store list_keys: {e}");
+            anyhow::anyhow!("Lock poisoned in list_keys - store may contain corrupt state")
         })?;
         let keys: Vec<Vec<u8>> = data
             .keys()

--- a/icn/crates/icn-governance/src/steward_store.rs
+++ b/icn/crates/icn-governance/src/steward_store.rs
@@ -847,7 +847,10 @@ mod tests {
         // Store operation should fail
         let record = create_test_record();
         let result = store.store(&record).await;
-        assert!(result.is_err(), "store should fail when backend is poisoned");
+        assert!(
+            result.is_err(),
+            "store should fail when backend is poisoned"
+        );
         assert!(
             result.unwrap_err().to_string().contains("Lock poisoned"),
             "error should mention lock poisoning"
@@ -859,12 +862,18 @@ mod tests {
 
         // list_keys (via count) should fail
         let result = store.count().await;
-        assert!(result.is_err(), "count should fail when backend is poisoned");
+        assert!(
+            result.is_err(),
+            "count should fail when backend is poisoned"
+        );
 
         // Verify that when backend is restored, operations succeed
         store.backend.set_failing(false);
         let result = store.store(&record).await;
-        assert!(result.is_ok(), "store should succeed when backend is restored");
+        assert!(
+            result.is_ok(),
+            "store should succeed when backend is restored"
+        );
     }
 
     #[tokio::test]
@@ -897,15 +906,27 @@ mod tests {
         record2.steward_did = TEST_DID_3.parse().unwrap();
         record2.holder_did = TEST_DID_4.parse().unwrap();
         let result = store.store(&record2).await;
-        assert!(result.is_ok(), "store should succeed even with poisoned cache");
+        assert!(
+            result.is_ok(),
+            "store should succeed even with poisoned cache"
+        );
 
         // Get should work (falls back to backend when cache is poisoned)
         let result = store.get(&record.steward_id).await;
-        assert!(result.is_ok(), "get should succeed even with poisoned cache");
-        assert!(result.unwrap().is_some(), "should retrieve record from backend");
+        assert!(
+            result.is_ok(),
+            "get should succeed even with poisoned cache"
+        );
+        assert!(
+            result.unwrap().is_some(),
+            "should retrieve record from backend"
+        );
 
         // Delete should work (cache update is non-critical)
         let result = store.delete(&record2.steward_id).await;
-        assert!(result.is_ok(), "delete should succeed even with poisoned cache");
+        assert!(
+            result.is_ok(),
+            "delete should succeed even with poisoned cache"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Partial fix for #411 - Demonstrates proper lock poison handling pattern.

## Problem

Previously, the code used `unwrap_or_else(|poisoned| poisoned.into_inner())` which:
- Silently continued operation after a panic in another thread
- Could return/store corrupt state
- Masked bugs that should be investigated

## Solution

Two patterns based on operation criticality:

### Critical Data Operations (Backend Store)
```rust
// Before: Silent recovery
let data = self.data.read().unwrap_or_else(|poisoned| {
    warn!("Data lock poisoned, recovering");
    poisoned.into_inner()
});

// After: Fail fast with error
let data = self.data.read().map_err(|_| {
    error!("Lock poisoned in steward store - previous holder panicked");
    anyhow::anyhow!("Lock poisoned - store may contain corrupt state")
})?;
```

### Non-Critical Operations (Cache)
```rust
// Before: Silent recovery
let mut cache = self.cache.write().unwrap_or_else(|poisoned| {
    warn!("Cache lock poisoned, recovering");
    poisoned.into_inner()
});

// After: Graceful degradation
if let Ok(mut cache) = self.cache.write() {
    cache.put(*id_bytes, record.clone());
} else {
    warn!("Cache lock poisoned - skipping cache update");
}
```

## Changes

- `steward_store.rs`: Applied pattern to all 8 occurrences

## Still TODO

- `charter_store.rs`: 10 occurrences
- `store.rs`: 17 occurrences
- `health.rs` in icn-obs: 2 occurrences

These will be addressed in follow-up PRs or this PR can be expanded.

## Test Plan

- [x] `cargo check -p icn-governance` compiles
- [x] No clippy warnings
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)