### PR TITLE
fix(governance,obs): Apply lock poison patterns to remaining files

### DIFF
--- a/icn/crates/icn-governance/src/charter_store.rs
+++ b/icn/crates/icn-governance/src/charter_store.rs
@@ -10,6 +10,17 @@
 //! charters/by_type/<org_type>/<charter_id> -> timestamp (type index)
 //! charters/status/<status>/<charter_id>    -> timestamp (status index)
 //! ```
+//!
+//! ## Lock Poisoning Handling
+//!
+//! This module uses two patterns for lock poison recovery:
+//!
+//! - **Backend operations** (get, put, delete, scan): Fail-fast with error.
+//!   Poisoned locks indicate a prior panic and possibly corrupt state.
+//!   Silent recovery would risk data integrity issues.
+//!
+//! - **Cache operations**: Graceful degradation. Cache is non-critical; poison
+//!   is logged but the operation continues using the backend directly.
 
 use crate::charter::{Charter, CharterId, CharterStatus, OrgType};
 use anyhow::{Context, Result};
@@ -17,7 +28,7 @@ use lru::LruCache;
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, RwLock};
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 /// Storage key prefixes
 const CHARTER_PREFIX: &[u8] = b"charters/";
@@ -47,44 +58,36 @@ impl InMemoryCharterStore {
 
 impl CharterStoreBackend for InMemoryCharterStore {
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
-        Ok(self
-            .data
-            .read()
-            .unwrap_or_else(|poisoned| {
-                warn!("Data lock poisoned, recovering");
-                poisoned.into_inner()
-            })
-            .get(key)
-            .cloned())
+        let data = self.data.read().map_err(|e| {
+            error!("Lock poisoned in charter store get: {e}");
+            anyhow::anyhow!("Lock poisoned in get - store may contain corrupt state")
+        })?;
+        Ok(data.get(key).cloned())
     }
 
     fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
-        self.data
-            .write()
-            .unwrap_or_else(|poisoned| {
-                warn!("Data lock poisoned, recovering");
-                poisoned.into_inner()
-            })
-            .insert(key.to_vec(), value.to_vec());
+        let mut data = self.data.write().map_err(|e| {
+            error!("Lock poisoned in charter store put: {e}");
+            anyhow::anyhow!("Lock poisoned in put - store may contain corrupt state")
+        })?;
+        data.insert(key.to_vec(), value.to_vec());
         Ok(())
     }
 
     fn delete(&self, key: &[u8]) -> Result<()> {
-        self.data
-            .write()
-            .unwrap_or_else(|poisoned| {
-                warn!("Data lock poisoned, recovering");
-                poisoned.into_inner()
-            })
-            .remove(key);
+        let mut data = self.data.write().map_err(|e| {
+            error!("Lock poisoned in charter store delete: {e}");
+            anyhow::anyhow!("Lock poisoned in delete - store may contain corrupt state")
+        })?;
+        data.remove(key);
         Ok(())
     }
 
     fn scan(&self, prefix: &[u8]) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
-        let data = self.data.read().unwrap_or_else(|poisoned| {
-            warn!("Data lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let data = self.data.read().map_err(|e| {
+            error!("Lock poisoned in charter store scan: {e}");
+            anyhow::anyhow!("Lock poisoned in scan - store may contain corrupt state")
+        })?;
         Ok(data
             .range(prefix.to_vec()..)
             .take_while(|(k, _)| k.starts_with(prefix))
@@ -214,14 +217,12 @@ impl<S: CharterStoreBackend> CharterStore<S> {
         let status_key = Self::status_index_key(status_str, charter_id);
         self.store.put(&status_key, &timestamp)?;
 
-        // Update cache
-        self.cache
-            .write()
-            .unwrap_or_else(|poisoned| {
-                warn!("Cache lock poisoned, recovering");
-                poisoned.into_inner()
-            })
-            .put(*charter_id.as_bytes(), charter.clone());
+        // Update cache (non-critical - skip on poison)
+        if let Ok(mut cache) = self.cache.write() {
+            cache.put(*charter_id.as_bytes(), charter.clone());
+        } else {
+            warn!("Cache lock poisoned in store - skipping cache update");
+        }
 
         debug!("Stored Charter: {}", charter_id);
         Ok(())
@@ -229,17 +230,13 @@ impl<S: CharterStoreBackend> CharterStore<S> {
 
     /// Get a Charter by ID
     pub fn get(&self, charter_id: &CharterId) -> Result<Option<Charter>> {
-        // Check cache first
-        if let Some(cached) = self
-            .cache
-            .write()
-            .unwrap_or_else(|poisoned| {
-                warn!("Cache lock poisoned, recovering");
-                poisoned.into_inner()
-            })
-            .get(charter_id.as_bytes())
-        {
-            return Ok(Some(cached.clone()));
+        // Check cache first (non-critical - skip on poison)
+        if let Ok(mut cache) = self.cache.write() {
+            if let Some(cached) = cache.get(charter_id.as_bytes()) {
+                return Ok(Some(cached.clone()));
+            }
+        } else {
+            warn!("Cache lock poisoned in get - falling back to backend");
         }
 
         // Load from storage
@@ -248,14 +245,12 @@ impl<S: CharterStoreBackend> CharterStore<S> {
             let charter: Charter =
                 serde_json::from_slice(&value).context("Failed to deserialize Charter")?;
 
-            // Update cache
-            self.cache
-                .write()
-                .unwrap_or_else(|poisoned| {
-                    warn!("Cache lock poisoned, recovering");
-                    poisoned.into_inner()
-                })
-                .put(*charter_id.as_bytes(), charter.clone());
+            // Update cache (non-critical - skip on poison)
+            if let Ok(mut cache) = self.cache.write() {
+                cache.put(*charter_id.as_bytes(), charter.clone());
+            } else {
+                warn!("Cache lock poisoned in get - skipping cache update");
+            }
 
             return Ok(Some(charter));
         }
@@ -296,14 +291,12 @@ impl<S: CharterStoreBackend> CharterStore<S> {
             let status_key = Self::status_index_key(status_str, charter_id);
             self.store.delete(&status_key)?;
 
-            // Remove from cache
-            self.cache
-                .write()
-                .unwrap_or_else(|poisoned| {
-                    warn!("Cache lock poisoned, recovering");
-                    poisoned.into_inner()
-                })
-                .pop(charter_id.as_bytes());
+            // Remove from cache (non-critical - skip on poison)
+            if let Ok(mut cache) = self.cache.write() {
+                cache.pop(charter_id.as_bytes());
+            } else {
+                warn!("Cache lock poisoned in delete - skipping cache update");
+            }
 
             debug!("Deleted Charter: {}", charter_id);
             return Ok(true);
@@ -496,13 +489,11 @@ impl<S: CharterStoreBackend> CharterStore<S> {
 
     /// Clear the cache
     pub fn clear_cache(&self) {
-        self.cache
-            .write()
-            .unwrap_or_else(|poisoned| {
-                warn!("Cache lock poisoned, recovering");
-                poisoned.into_inner()
-            })
-            .clear();
+        if let Ok(mut cache) = self.cache.write() {
+            cache.clear();
+        } else {
+            warn!("Cache lock poisoned in clear_cache - cache already cleared by poison");
+        }
     }
 }
 
@@ -748,5 +739,147 @@ mod tests {
         // Now should be gone
         let gone = store.get(&charter_id).unwrap();
         assert!(gone.is_none());
+    }
+
+    // ========== Lock Poisoning Tests ==========
+
+    /// A backend that can simulate poison/failure states for testing
+    struct FailingBackend {
+        inner: InMemoryCharterStore,
+        should_fail: std::sync::atomic::AtomicBool,
+    }
+
+    impl FailingBackend {
+        fn new() -> Self {
+            Self {
+                inner: InMemoryCharterStore::new(),
+                should_fail: std::sync::atomic::AtomicBool::new(false),
+            }
+        }
+
+        fn set_failing(&self, fail: bool) {
+            self.should_fail
+                .store(fail, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    impl CharterStoreBackend for FailingBackend {
+        fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+            if self.should_fail.load(std::sync::atomic::Ordering::SeqCst) {
+                anyhow::bail!("Lock poisoned - store may contain corrupt state")
+            }
+            self.inner.get(key)
+        }
+
+        fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
+            if self.should_fail.load(std::sync::atomic::Ordering::SeqCst) {
+                anyhow::bail!("Lock poisoned - store may contain corrupt state")
+            }
+            self.inner.put(key, value)
+        }
+
+        fn delete(&self, key: &[u8]) -> Result<()> {
+            if self.should_fail.load(std::sync::atomic::Ordering::SeqCst) {
+                anyhow::bail!("Lock poisoned - store may contain corrupt state")
+            }
+            self.inner.delete(key)
+        }
+
+        fn scan(&self, prefix: &[u8]) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
+            if self.should_fail.load(std::sync::atomic::Ordering::SeqCst) {
+                anyhow::bail!("Lock poisoned - store may contain corrupt state")
+            }
+            self.inner.scan(prefix)
+        }
+    }
+
+    #[test]
+    fn test_backend_poison_fails_fast() {
+        // Test that backend failures propagate as errors (fail-fast behavior)
+        let backend = Arc::new(FailingBackend::new());
+        let store = CharterStore::new(backend.clone());
+
+        // Simulate backend poison BEFORE any operations
+        backend.set_failing(true);
+
+        // Store operation should fail
+        let charter = create_test_charter("test", OrgType::Cooperative);
+        let result = store.store(&charter);
+        assert!(
+            result.is_err(),
+            "store should fail when backend is poisoned"
+        );
+        assert!(
+            result.unwrap_err().to_string().contains("Lock poisoned"),
+            "error should mention lock poisoning"
+        );
+
+        // Get should fail (nothing in cache, backend is poisoned)
+        let result = store.get(&charter.charter_id);
+        assert!(result.is_err(), "get should fail when backend is poisoned");
+
+        // scan (via list_all) should fail
+        let result = store.list_all();
+        assert!(
+            result.is_err(),
+            "list_all should fail when backend is poisoned"
+        );
+
+        // Verify that when backend is restored, operations succeed
+        backend.set_failing(false);
+        let result = store.store(&charter);
+        assert!(
+            result.is_ok(),
+            "store should succeed when backend is restored"
+        );
+    }
+
+    #[test]
+    fn test_cache_poison_graceful_degradation() {
+        // Test that cache failures don't break the store (graceful degradation)
+        let store = create_test_store();
+
+        // Store a record
+        let charter = create_test_charter("test", OrgType::Cooperative);
+        store.store(&charter).expect("store should succeed");
+
+        // Poison the cache by panicking while holding the lock
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = store.cache.write().unwrap();
+            panic!("intentional panic to poison cache");
+        }));
+
+        // Verify the cache is actually poisoned
+        assert!(
+            store.cache.write().is_err(),
+            "cache should be poisoned after panic"
+        );
+
+        // The cache is now poisoned, but operations should still work via backend
+        // Store another record - should succeed (cache update is non-critical)
+        let charter2 = create_test_charter("test2", OrgType::Community);
+        let result = store.store(&charter2);
+        assert!(
+            result.is_ok(),
+            "store should succeed even with poisoned cache"
+        );
+
+        // Get should work (falls back to backend when cache is poisoned)
+        let result = store.get(&charter.charter_id);
+        assert!(
+            result.is_ok(),
+            "get should succeed even with poisoned cache"
+        );
+        assert!(
+            result.unwrap().is_some(),
+            "should retrieve charter from backend"
+        );
+
+        // Delete should work (cache update is non-critical)
+        let result = store.delete(&charter2.charter_id);
+        assert!(
+            result.is_ok(),
+            "delete should succeed even with poisoned cache"
+        );
     }
 }

--- a/icn/crates/icn-governance/src/store.rs
+++ b/icn/crates/icn-governance/src/store.rs
@@ -1,4 +1,10 @@
 //! Governance storage layer
+//!
+//! ## Lock Poisoning Handling
+//!
+//! This module uses fail-fast semantics for lock poisoning in storage operations.
+//! Poisoned locks indicate a prior panic and possibly corrupt state.
+//! Silent recovery would risk data integrity issues.
 
 use crate::{
     Delegation, DelegationId, DelegationScope, GovernanceDomain, GovernanceDomainId, Proposal,
@@ -8,7 +14,7 @@ use anyhow::Result;
 use icn_identity::Did;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tracing::warn;
+use tracing::{error, warn};
 
 /// Result of a paginated query
 #[derive(Debug, Clone)]
@@ -149,27 +155,27 @@ impl Default for InMemoryGovernanceStore {
 
 impl GovernanceStore for InMemoryGovernanceStore {
     fn store_domain(&self, domain: &GovernanceDomain) -> Result<()> {
-        let mut domains = self.domains.write().unwrap_or_else(|poisoned| {
-            warn!("Domains lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let mut domains = self.domains.write().map_err(|e| {
+            error!("Domains lock poisoned in store_domain: {e}");
+            anyhow::anyhow!("Lock poisoned in store_domain - store may contain corrupt state")
+        })?;
         domains.insert(domain.id.0.clone(), domain.clone());
         Ok(())
     }
 
     fn get_domain(&self, id: &GovernanceDomainId) -> Result<Option<GovernanceDomain>> {
-        let domains = self.domains.read().unwrap_or_else(|poisoned| {
-            warn!("Domains lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let domains = self.domains.read().map_err(|e| {
+            error!("Domains lock poisoned in get_domain: {e}");
+            anyhow::anyhow!("Lock poisoned in get_domain - store may contain corrupt state")
+        })?;
         Ok(domains.get(&id.0).cloned())
     }
 
     fn list_domains(&self) -> Result<Vec<GovernanceDomain>> {
-        let domains = self.domains.read().unwrap_or_else(|poisoned| {
-            warn!("Domains lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let domains = self.domains.read().map_err(|e| {
+            error!("Domains lock poisoned in list_domains: {e}");
+            anyhow::anyhow!("Lock poisoned in list_domains - store may contain corrupt state")
+        })?;
         Ok(domains.values().cloned().collect())
     }
 
@@ -178,10 +184,12 @@ impl GovernanceStore for InMemoryGovernanceStore {
         cursor: Option<&str>,
         limit: usize,
     ) -> Result<PaginatedResult<GovernanceDomain>> {
-        let domains = self.domains.read().unwrap_or_else(|poisoned| {
-            warn!("Domains lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let domains = self.domains.read().map_err(|e| {
+            error!("Domains lock poisoned in list_domains_paginated: {e}");
+            anyhow::anyhow!(
+                "Lock poisoned in list_domains_paginated - store may contain corrupt state"
+            )
+        })?;
 
         // Parse cursor as offset (format: "offset:<number>")
         // Log invalid cursors for debugging but default to 0 for resilience
@@ -227,27 +235,27 @@ impl GovernanceStore for InMemoryGovernanceStore {
     }
 
     fn store_proposal(&self, proposal: &Proposal) -> Result<()> {
-        let mut proposals = self.proposals.write().unwrap_or_else(|poisoned| {
-            warn!("Proposals lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let mut proposals = self.proposals.write().map_err(|e| {
+            error!("Proposals lock poisoned in store_proposal: {e}");
+            anyhow::anyhow!("Lock poisoned in store_proposal - store may contain corrupt state")
+        })?;
         proposals.insert(proposal.id.0.clone(), proposal.clone());
         Ok(())
     }
 
     fn get_proposal(&self, id: &ProposalId) -> Result<Option<Proposal>> {
-        let proposals = self.proposals.read().unwrap_or_else(|poisoned| {
-            warn!("Proposals lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let proposals = self.proposals.read().map_err(|e| {
+            error!("Proposals lock poisoned in get_proposal: {e}");
+            anyhow::anyhow!("Lock poisoned in get_proposal - store may contain corrupt state")
+        })?;
         Ok(proposals.get(&id.0).cloned())
     }
 
     fn list_proposals(&self, domain_id: &GovernanceDomainId) -> Result<Vec<Proposal>> {
-        let proposals = self.proposals.read().unwrap_or_else(|poisoned| {
-            warn!("Proposals lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let proposals = self.proposals.read().map_err(|e| {
+            error!("Proposals lock poisoned in list_proposals: {e}");
+            anyhow::anyhow!("Lock poisoned in list_proposals - store may contain corrupt state")
+        })?;
         Ok(proposals
             .values()
             .filter(|p| p.domain_id == *domain_id)
@@ -256,10 +264,10 @@ impl GovernanceStore for InMemoryGovernanceStore {
     }
 
     fn store_vote(&self, vote: &Vote) -> Result<()> {
-        let mut votes = self.votes.write().unwrap_or_else(|poisoned| {
-            warn!("Votes lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let mut votes = self.votes.write().map_err(|e| {
+            error!("Votes lock poisoned in store_vote: {e}");
+            anyhow::anyhow!("Lock poisoned in store_vote - store may contain corrupt state")
+        })?;
         let proposal_votes = votes.entry(vote.proposal_id.0.clone()).or_default();
 
         // Replace existing vote from same voter (allow vote changes)
@@ -270,20 +278,20 @@ impl GovernanceStore for InMemoryGovernanceStore {
     }
 
     fn get_vote(&self, proposal_id: &ProposalId, voter: &Did) -> Result<Option<Vote>> {
-        let votes = self.votes.read().unwrap_or_else(|poisoned| {
-            warn!("Votes lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let votes = self.votes.read().map_err(|e| {
+            error!("Votes lock poisoned in get_vote: {e}");
+            anyhow::anyhow!("Lock poisoned in get_vote - store may contain corrupt state")
+        })?;
         Ok(votes
             .get(&proposal_id.0)
             .and_then(|v| v.iter().find(|vote| vote.voter == *voter).cloned()))
     }
 
     fn list_votes(&self, proposal_id: &ProposalId) -> Result<Vec<Vote>> {
-        let votes = self.votes.read().unwrap_or_else(|poisoned| {
-            warn!("Votes lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let votes = self.votes.read().map_err(|e| {
+            error!("Votes lock poisoned in list_votes: {e}");
+            anyhow::anyhow!("Lock poisoned in list_votes - store may contain corrupt state")
+        })?;
         Ok(votes.get(&proposal_id.0).cloned().unwrap_or_default())
     }
 
@@ -295,27 +303,29 @@ impl GovernanceStore for InMemoryGovernanceStore {
     // === Delegation Methods ===
 
     fn store_delegation(&self, delegation: &Delegation) -> Result<()> {
-        let mut delegations = self.delegations.write().unwrap_or_else(|poisoned| {
-            warn!("Delegations lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let mut delegations = self.delegations.write().map_err(|e| {
+            error!("Delegations lock poisoned in store_delegation: {e}");
+            anyhow::anyhow!("Lock poisoned in store_delegation - store may contain corrupt state")
+        })?;
         delegations.insert(delegation.id.0.clone(), delegation.clone());
         Ok(())
     }
 
     fn get_delegation(&self, id: &DelegationId) -> Result<Option<Delegation>> {
-        let delegations = self.delegations.read().unwrap_or_else(|poisoned| {
-            warn!("Delegations lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let delegations = self.delegations.read().map_err(|e| {
+            error!("Delegations lock poisoned in get_delegation: {e}");
+            anyhow::anyhow!("Lock poisoned in get_delegation - store may contain corrupt state")
+        })?;
         Ok(delegations.get(&id.0).cloned())
     }
 
     fn get_delegations_from(&self, delegator: &Did) -> Result<Vec<Delegation>> {
-        let delegations = self.delegations.read().unwrap_or_else(|poisoned| {
-            warn!("Delegations lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let delegations = self.delegations.read().map_err(|e| {
+            error!("Delegations lock poisoned in get_delegations_from: {e}");
+            anyhow::anyhow!(
+                "Lock poisoned in get_delegations_from - store may contain corrupt state"
+            )
+        })?;
         Ok(delegations
             .values()
             .filter(|d| d.delegator == *delegator)
@@ -324,10 +334,10 @@ impl GovernanceStore for InMemoryGovernanceStore {
     }
 
     fn get_delegations_to(&self, delegate: &Did) -> Result<Vec<Delegation>> {
-        let delegations = self.delegations.read().unwrap_or_else(|poisoned| {
-            warn!("Delegations lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let delegations = self.delegations.read().map_err(|e| {
+            error!("Delegations lock poisoned in get_delegations_to: {e}");
+            anyhow::anyhow!("Lock poisoned in get_delegations_to - store may contain corrupt state")
+        })?;
         Ok(delegations
             .values()
             .filter(|d| d.delegate == *delegate)
@@ -341,10 +351,12 @@ impl GovernanceStore for InMemoryGovernanceStore {
         scope: &DelegationScope,
     ) -> Result<Option<Delegation>> {
         let now = icn_time::current_timestamp_secs();
-        let delegations = self.delegations.read().unwrap_or_else(|poisoned| {
-            warn!("Delegations lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let delegations = self.delegations.read().map_err(|e| {
+            error!("Delegations lock poisoned in get_active_delegation: {e}");
+            anyhow::anyhow!(
+                "Lock poisoned in get_active_delegation - store may contain corrupt state"
+            )
+        })?;
         Ok(delegations
             .values()
             .find(|d| d.delegator == *delegator && d.scope == *scope && d.is_active(now))
@@ -352,10 +364,10 @@ impl GovernanceStore for InMemoryGovernanceStore {
     }
 
     fn revoke_delegation(&self, id: &DelegationId, revoked_at: Timestamp) -> Result<()> {
-        let mut delegations = self.delegations.write().unwrap_or_else(|poisoned| {
-            warn!("Delegations lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let mut delegations = self.delegations.write().map_err(|e| {
+            error!("Delegations lock poisoned in revoke_delegation: {e}");
+            anyhow::anyhow!("Lock poisoned in revoke_delegation - store may contain corrupt state")
+        })?;
         if let Some(delegation) = delegations.get_mut(&id.0) {
             delegation.revoked_at = Some(revoked_at);
         }
@@ -364,10 +376,12 @@ impl GovernanceStore for InMemoryGovernanceStore {
 
     fn list_active_delegations(&self) -> Result<Vec<Delegation>> {
         let now = icn_time::current_timestamp_secs();
-        let delegations = self.delegations.read().unwrap_or_else(|poisoned| {
-            warn!("Delegations lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        let delegations = self.delegations.read().map_err(|e| {
+            error!("Delegations lock poisoned in list_active_delegations: {e}");
+            anyhow::anyhow!(
+                "Lock poisoned in list_active_delegations - store may contain corrupt state"
+            )
+        })?;
         Ok(delegations
             .values()
             .filter(|d| d.is_active(now))
@@ -1000,5 +1014,50 @@ mod tests {
         // Should no longer be in active list
         let active = store.list_active_delegations().unwrap();
         assert_eq!(active.len(), 0);
+    }
+
+    // ========== Lock Poisoning Tests ==========
+
+    #[test]
+    fn test_lock_poison_fails_fast() {
+        // Test that poisoned locks result in errors rather than silent recovery
+        let store = InMemoryGovernanceStore::new();
+        let config = GovernanceConfig::cooperative_default();
+        let domain = GovernanceDomain::new("Test Coop".to_string(), config);
+
+        // Store should work initially
+        store.store_domain(&domain).unwrap();
+
+        // Poison the domains lock by panicking while holding it
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = store.domains.write().unwrap();
+            panic!("intentional panic to poison lock");
+        }));
+
+        // Verify the lock is actually poisoned
+        assert!(
+            store.domains.write().is_err(),
+            "domains lock should be poisoned after panic"
+        );
+
+        // Now all operations that use this lock should fail
+        let result = store.store_domain(&domain);
+        assert!(
+            result.is_err(),
+            "store_domain should fail with poisoned lock"
+        );
+        assert!(
+            result.unwrap_err().to_string().contains("Lock poisoned"),
+            "error should mention lock poisoning"
+        );
+
+        let result = store.get_domain(&domain.id);
+        assert!(result.is_err(), "get_domain should fail with poisoned lock");
+
+        let result = store.list_domains();
+        assert!(
+            result.is_err(),
+            "list_domains should fail with poisoned lock"
+        );
     }
 }

--- a/icn/crates/icn-obs/src/health.rs
+++ b/icn/crates/icn-obs/src/health.rs
@@ -1,4 +1,11 @@
 //! Health check and monitoring endpoints
+//!
+//! ## Lock Poisoning Handling
+//!
+//! This module uses graceful degradation for lock poisoning. Health monitoring
+//! is critical infrastructure - a failed health check could cause cascading
+//! issues with load balancers and orchestrators. Better to report stale health
+//! data than to fail the health endpoint entirely.
 
 use axum::{
     extract::State,
@@ -10,7 +17,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use tracing::warn;
+use tracing::error;
 
 /// Health status of the ICN node
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -69,10 +76,15 @@ impl HealthService {
 
     /// Update health metrics
     pub fn update(&self, active_connections: u64, gossip_topics: u64, ledger_quarantine_size: u64) {
-        let mut status = self.inner.write().unwrap_or_else(|poisoned| {
-            warn!("Health status lock poisoned, recovering");
-            poisoned.into_inner()
-        });
+        // Use graceful degradation - skip update if lock is poisoned
+        // Health monitoring must remain available for load balancers
+        let mut status = match self.inner.write() {
+            Ok(guard) => guard,
+            Err(e) => {
+                error!("Health status lock poisoned in update - skipping update: {e}");
+                return;
+            }
+        };
 
         status.uptime_seconds = self
             .start_time
@@ -100,13 +112,32 @@ impl HealthService {
 
     /// Get current health status
     pub fn get_status(&self) -> HealthStatus {
-        self.inner
-            .read()
-            .unwrap_or_else(|poisoned| {
-                warn!("Health status lock poisoned, recovering");
-                poisoned.into_inner()
-            })
-            .clone()
+        // Use graceful degradation - return degraded status if lock is poisoned
+        // Health monitoring must remain available for load balancers
+        match self.inner.read() {
+            Ok(guard) => guard.clone(),
+            Err(e) => {
+                error!(
+                    "Health status lock poisoned in get_status - returning degraded status: {e}"
+                );
+                // Return a degraded status to indicate something is wrong
+                HealthStatus {
+                    status: HealthState::Degraded,
+                    uptime_seconds: self
+                        .start_time
+                        .elapsed()
+                        .unwrap_or(Duration::from_secs(0))
+                        .as_secs(),
+                    active_connections: 0,
+                    gossip_topics: 0,
+                    ledger_quarantine_size: 0,
+                    timestamp: SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap_or(Duration::from_secs(0))
+                        .as_secs(),
+                }
+            }
+        }
     }
 }
 
@@ -221,5 +252,49 @@ mod tests {
         health.update(5, 10, 1001);
         let status = health.get_status();
         assert_eq!(status.status, HealthState::Unhealthy);
+    }
+
+    // ========== Lock Poisoning Tests ==========
+
+    #[test]
+    fn test_lock_poison_graceful_degradation() {
+        // Test that poisoned locks result in graceful degradation, not errors
+        let health = HealthService::new();
+
+        // Set initial state
+        health.update(5, 10, 50);
+        let status = health.get_status();
+        assert_eq!(status.status, HealthState::Healthy);
+
+        // Poison the lock by panicking while holding it
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = health.inner.write().unwrap();
+            panic!("intentional panic to poison lock");
+        }));
+
+        // Verify the lock is actually poisoned
+        assert!(
+            health.inner.write().is_err(),
+            "inner lock should be poisoned after panic"
+        );
+
+        // get_status should still work and return degraded status
+        let status = health.get_status();
+        assert_eq!(
+            status.status,
+            HealthState::Degraded,
+            "should return degraded status when lock is poisoned"
+        );
+
+        // update should not panic - it should gracefully skip
+        health.update(10, 20, 100); // Should not panic
+
+        // get_status should still work
+        let status = health.get_status();
+        assert_eq!(
+            status.status,
+            HealthState::Degraded,
+            "should still return degraded status"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Applies consistent lock poisoning patterns to the remaining files identified in issues #436, #437, and #438.

## Changes

### charter_store.rs (#436)
- **Backend operations** (InMemoryCharterStore): Fail-fast with error propagation
- **Cache operations** (CharterStore): Graceful degradation - cache is non-critical
- Added `FailingBackend` test helper and comprehensive lock poisoning tests

### store.rs (#437)
- **All InMemoryGovernanceStore operations**: Fail-fast with `map_err` pattern
- Covers domains, proposals, votes, and delegations
- Added lock poisoning test for domain operations

### health.rs (#438)
- Uses **graceful degradation** (not fail-fast) because:
  - Health endpoints are critical for load balancers and orchestrators
  - A failed health check could cause cascading issues
  - Stale health data is better than failed health checks
  - Returns `HealthState::Degraded` when lock is poisoned
- Added comprehensive lock poisoning test

Each file includes module-level documentation explaining the pattern choice.

## Test plan

- [x] All existing tests pass
- [x] New lock poisoning tests pass
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes

Closes #436, #437, #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)