### PR TITLE
feat(gossip): Add labor-shares topic subscriptions

### DIFF
--- a/icn/crates/icn-gossip/src/gossip.rs
+++ b/icn/crates/icn-gossip/src/gossip.rs
@@ -235,6 +235,29 @@ impl GossipActor {
             .with_scope(crate::types::Scope::Regional), // Trust attestations are regional
         );
 
+        // Labor share topics (Issue #391)
+        gossip.create_topic(
+            Topic::new(
+                crate::labor_shares::topics::LABOR_SHARES_ALLOCATIONS.to_string(),
+                AccessControl::TrustClass(TrustClass::Known), // FederationOpen equivalent
+            )
+            .with_scope(crate::types::Scope::Global), // Labor share events propagate globally
+        );
+        gossip.create_topic(
+            Topic::new(
+                crate::labor_shares::topics::BONDS_ISSUANCE.to_string(),
+                AccessControl::TrustClass(TrustClass::Known), // FederationOpen equivalent
+            )
+            .with_scope(crate::types::Scope::Global), // Bond offerings propagate globally
+        );
+        gossip.create_topic(
+            Topic::new(
+                crate::labor_shares::topics::BONDS_PAYMENTS.to_string(),
+                AccessControl::TrustClass(TrustClass::Partner), // TrustGated - Partner+
+            )
+            .with_scope(crate::types::Scope::Regional), // Payment notifications are regional
+        );
+
         gossip
     }
 

--- a/icn/crates/icn-gossip/src/labor_shares.rs
+++ b/icn/crates/icn-gossip/src/labor_shares.rs
@@ -1,0 +1,282 @@
+//! Labor share gossip messages (Issue #391)
+//!
+//! Message types for propagating labor share events across the network:
+//! - Surplus allocations
+//! - Bond issuance announcements
+//! - Bond payment notifications
+
+use icn_identity::Did;
+use serde::{Deserialize, Serialize};
+
+/// Labor share gossip message types
+///
+/// These messages propagate on the `labor-shares:allocations` topic.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum LaborShareMessage {
+    /// Announce a surplus allocation has been approved
+    ///
+    /// Sent when a cooperative approves periodic surplus distribution.
+    /// Subscribers can request details if they're affected.
+    AllocationAnnouncement {
+        /// Cooperative that made the allocation
+        cooperative_id: String,
+        /// Period identifier (e.g., "2026-Q1")
+        period: String,
+        /// Total surplus amount allocated
+        total_surplus: i64,
+        /// Currency of the allocation
+        currency: String,
+        /// Number of shares receiving allocation
+        share_count: u32,
+        /// Unix timestamp of announcement
+        timestamp: u64,
+    },
+
+    /// Request allocation details for a specific member
+    ///
+    /// Members can request their individual allocation details.
+    AllocationRequest {
+        /// Cooperative to query
+        cooperative_id: String,
+        /// Period to query
+        period: String,
+        /// Member requesting their allocation
+        member: Did,
+    },
+
+    /// Response with allocation details for a member
+    AllocationDetails {
+        /// Cooperative that made the allocation
+        cooperative_id: String,
+        /// Period of allocation
+        period: String,
+        /// Member's DID
+        member: Did,
+        /// Amount allocated to this member
+        amount: i64,
+        /// Currency
+        currency: String,
+        /// Basis for allocation (e.g., "hours_worked", "tenure", "equal")
+        basis: String,
+        /// Raw value used in calculation (e.g., hours worked)
+        basis_value: f64,
+    },
+
+    /// Announce a share redemption has been approved
+    ///
+    /// Sent when a departing member's shares are being redeemed.
+    RedemptionAnnouncement {
+        /// Cooperative processing the redemption
+        cooperative_id: String,
+        /// Member whose shares are being redeemed
+        member: Did,
+        /// Number of shares being redeemed
+        share_count: u32,
+        /// Total redemption value
+        total_value: i64,
+        /// Currency
+        currency: String,
+        /// Reason for redemption
+        reason: String,
+    },
+}
+
+/// Bond-related gossip message types
+///
+/// These messages propagate on `bonds:issuance` and `bonds:payments` topics.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum BondMessage {
+    /// Announce a new bond offering is open for subscription
+    ///
+    /// Propagates on `bonds:issuance` topic (`TrustClass::Known` - Known+).
+    BondOfferingAnnouncement {
+        /// Unique bond offering ID
+        bond_id: String,
+        /// Cooperative issuing the bond
+        issuing_cooperative: String,
+        /// Purpose of the bond (project funding, equipment, etc.)
+        purpose: String,
+        /// Principal amount requested
+        principal_requested: i64,
+        /// Currency
+        currency: String,
+        /// Interest rate in basis points (100 = 1%)
+        interest_rate_bps: u32,
+        /// Term in days
+        term_days: u32,
+        /// Minimum subscription amount
+        min_subscription: i64,
+        /// Maximum subscription amount (per investor)
+        max_subscription: Option<i64>,
+        /// Deadline for subscription (Unix timestamp)
+        subscription_deadline: u64,
+        /// Collateral description (if any)
+        collateral_description: Option<String>,
+    },
+
+    /// Announce bond subscription is now filled
+    ///
+    /// Sent when a bond offering reaches its target.
+    BondFilled {
+        /// Bond ID that was filled
+        bond_id: String,
+        /// Total amount subscribed
+        amount_subscribed: i64,
+        /// Number of subscribers
+        subscriber_count: u32,
+        /// Timestamp
+        timestamp: u64,
+    },
+
+    /// Announce a bond subscription by a cooperative/member
+    ///
+    /// Allows tracking of bond subscription activity.
+    BondSubscription {
+        /// Bond ID subscribed to
+        bond_id: String,
+        /// Subscriber (cooperative or individual DID)
+        subscriber: Did,
+        /// Amount subscribed
+        amount: i64,
+        /// Timestamp
+        timestamp: u64,
+    },
+
+    /// Bond payment notification (trust-gated)
+    ///
+    /// Propagates on `bonds:payments` topic (`TrustClass::Partner` - Partner+).
+    /// Only sent to subscribers with sufficient trust.
+    PaymentNotification {
+        /// Bond ID
+        bond_id: String,
+        /// Payment type
+        payment_type: BondPaymentType,
+        /// Payment amount
+        amount: i64,
+        /// Currency
+        currency: String,
+        /// Due date (Unix timestamp)
+        due_date: u64,
+        /// Whether payment was made on time
+        on_time: bool,
+        /// Timestamp of notification
+        timestamp: u64,
+    },
+
+    /// Bond maturity notification
+    ///
+    /// Sent when a bond reaches maturity.
+    BondMatured {
+        /// Bond ID
+        bond_id: String,
+        /// Issuing cooperative
+        issuing_cooperative: String,
+        /// Total principal repaid
+        principal_repaid: i64,
+        /// Total interest paid
+        total_interest_paid: i64,
+        /// Currency
+        currency: String,
+        /// Timestamp
+        timestamp: u64,
+    },
+}
+
+/// Type of bond payment (mirrors icn_ledger::BondPaymentType)
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum BondPaymentType {
+    /// Regular interest payment
+    Interest,
+    /// Principal repayment
+    Principal,
+    /// Combined interest and principal (at maturity)
+    InterestAndPrincipal,
+}
+
+/// Topic names for labor share gossip
+pub mod topics {
+    /// Surplus allocation announcements (`TrustClass::Known` - Known+)
+    pub const LABOR_SHARES_ALLOCATIONS: &str = "labor-shares:allocations";
+
+    /// Bond issuance announcements (`TrustClass::Known` - Known+)
+    pub const BONDS_ISSUANCE: &str = "bonds:issuance";
+
+    /// Bond payment notifications (`TrustClass::Partner` - Partner+)
+    pub const BONDS_PAYMENTS: &str = "bonds:payments";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_allocation_announcement_serialization() {
+        let msg = LaborShareMessage::AllocationAnnouncement {
+            cooperative_id: "coop-123".to_string(),
+            period: "2026-Q1".to_string(),
+            total_surplus: 100_000,
+            currency: "ICN".to_string(),
+            share_count: 50,
+            timestamp: 1735862400,
+        };
+
+        // Use bincode for binary serialization (gossip messages are binary)
+        let config = bincode::config::standard();
+        let serialized = bincode::serde::encode_to_vec(&msg, config).expect("serialize");
+        let (deserialized, _): (LaborShareMessage, _) =
+            bincode::serde::decode_from_slice(&serialized, config).expect("deserialize");
+
+        assert_eq!(msg, deserialized);
+    }
+
+    #[test]
+    fn test_bond_offering_serialization() {
+        let msg = BondMessage::BondOfferingAnnouncement {
+            bond_id: "bond-abc".to_string(),
+            issuing_cooperative: "worker-coop".to_string(),
+            purpose: "Equipment purchase".to_string(),
+            principal_requested: 50_000,
+            currency: "ICN".to_string(),
+            interest_rate_bps: 500, // 5%
+            term_days: 365,
+            min_subscription: 100,
+            max_subscription: Some(10_000),
+            subscription_deadline: 1738454400,
+            collateral_description: Some("Equipment lien".to_string()),
+        };
+
+        let config = bincode::config::standard();
+        let serialized = bincode::serde::encode_to_vec(&msg, config).expect("serialize");
+        let (deserialized, _): (BondMessage, _) =
+            bincode::serde::decode_from_slice(&serialized, config).expect("deserialize");
+
+        assert_eq!(msg, deserialized);
+    }
+
+    #[test]
+    fn test_payment_notification_serialization() {
+        let msg = BondMessage::PaymentNotification {
+            bond_id: "bond-xyz".to_string(),
+            payment_type: BondPaymentType::Interest,
+            amount: 250,
+            currency: "ICN".to_string(),
+            due_date: 1736467200,
+            on_time: true,
+            timestamp: 1736467100,
+        };
+
+        let config = bincode::config::standard();
+        let serialized = bincode::serde::encode_to_vec(&msg, config).expect("serialize");
+        let (deserialized, _): (BondMessage, _) =
+            bincode::serde::decode_from_slice(&serialized, config).expect("deserialize");
+
+        assert_eq!(msg, deserialized);
+    }
+
+    #[test]
+    fn test_topic_names() {
+        assert_eq!(topics::LABOR_SHARES_ALLOCATIONS, "labor-shares:allocations");
+        assert_eq!(topics::BONDS_ISSUANCE, "bonds:issuance");
+        assert_eq!(topics::BONDS_PAYMENTS, "bonds:payments");
+    }
+}

--- a/icn/crates/icn-gossip/src/lib.rs
+++ b/icn/crates/icn-gossip/src/lib.rs
@@ -41,6 +41,7 @@ pub mod bloom;
 pub mod error;
 pub mod gossip;
 mod handlers;
+pub mod labor_shares;
 #[allow(missing_docs)]
 pub mod partition;
 #[allow(missing_docs)]
@@ -67,3 +68,8 @@ pub use types::{
     TrustResourceLimits,
 };
 pub use vector_clock::VectorClock;
+
+// Labor share gossip messages (Issue #391)
+pub use labor_shares::{
+    topics as labor_share_topics, BondMessage, BondPaymentType, LaborShareMessage,
+};


### PR DESCRIPTION
## Summary

Adds gossip topic subscriptions for labor share events, enabling cross-node propagation of share allocations and bond offerings.

Part of #386 (Razeto's Four Intercooperative Bodies Integration).

## Changes

### New Topics

| Topic | Purpose | Access Control |
|-------|---------|----------------|
| `labor-shares:allocations` | Surplus allocation announcements | Known+ (TrustClass) |
| `bonds:issuance` | Bond offering announcements | Known+ (TrustClass) |
| `bonds:payments` | Bond payment notifications | Partner+ (TrustClass) |

### New Message Types

**LaborShareMessage**:
- `AllocationAnnouncement` - Announce surplus allocation approved
- `AllocationRequest` - Request allocation details for a member
- `AllocationDetails` - Response with member's allocation
- `RedemptionAnnouncement` - Announce share redemption approved

**BondMessage**:
- `BondOfferingAnnouncement` - Announce new bond offering open
- `BondFilled` - Announce bond subscription filled
- `BondSubscription` - Track bond subscription activity
- `PaymentNotification` - Bond payment notification (trust-gated)
- `BondMatured` - Announce bond maturity

## Files Changed

- `icn-gossip/src/labor_shares.rs` - New module with message types and topic constants
- `icn-gossip/src/lib.rs` - Export new module
- `icn-gossip/src/gossip.rs` - Register default topics

## Test Plan

- [x] Unit tests for message serialization (bincode)
- [x] Topic name constants verified
- [x] Clippy clean
- [ ] CI passes

## Follow-up Work

- Wire LedgerActor subscription to allocation events
- Integration test for allocation propagation across nodes

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)