### PR TITLE
refactor(time): Migrate security-critical callers to try_current_timestamp_* variants

### DIFF
--- a/icn/crates/icn-governance/src/proposal.rs
+++ b/icn/crates/icn-governance/src/proposal.rs
@@ -656,7 +656,8 @@ impl Proposal {
             anyhow::bail!("Can only start deliberation from Draft state");
         }
 
-        let now = icn_time::current_timestamp_secs();
+        let now = icn_time::try_current_timestamp_secs()
+            .map_err(|e| anyhow::anyhow!("Cannot start deliberation: {e}"))?;
 
         self.state = ProposalState::Deliberation {
             started_at: now,
@@ -674,7 +675,8 @@ impl Proposal {
     /// Can only be called after the deliberation period has ended.
     /// For early transition (before deliberation ends), use `force_end_deliberation()`.
     pub fn end_deliberation_and_open(&mut self, voting_period_seconds: u64) -> anyhow::Result<()> {
-        let now = icn_time::current_timestamp_secs();
+        let now = icn_time::try_current_timestamp_secs()
+            .map_err(|e| anyhow::anyhow!("Cannot end deliberation: {e}"))?;
 
         match &self.state {
             ProposalState::Deliberation { ends_at, .. } => {
@@ -708,7 +710,8 @@ impl Proposal {
             anyhow::bail!("Can only force end deliberation from Deliberation state");
         }
 
-        let now = icn_time::current_timestamp_secs();
+        let now = icn_time::try_current_timestamp_secs()
+            .map_err(|e| anyhow::anyhow!("Cannot force end deliberation: {e}"))?;
 
         self.state = ProposalState::Open {
             opened_at: now,
@@ -731,7 +734,8 @@ impl Proposal {
             anyhow::bail!("Can only open proposals in Draft state");
         }
 
-        let now = icn_time::current_timestamp_secs();
+        let now = icn_time::try_current_timestamp_secs()
+            .map_err(|e| anyhow::anyhow!("Cannot open proposal: {e}"))?;
 
         self.state = ProposalState::Open {
             opened_at: now,
@@ -753,7 +757,8 @@ impl Proposal {
         }
 
         self.state = final_state;
-        self.updated_at = icn_time::current_timestamp_secs();
+        self.updated_at = icn_time::try_current_timestamp_secs()
+            .map_err(|e| anyhow::anyhow!("Cannot close proposal: {e}"))?;
 
         Ok(())
     }
@@ -767,7 +772,8 @@ impl Proposal {
             anyhow::bail!("Cannot cancel a closed proposal");
         }
 
-        let now = icn_time::current_timestamp_secs();
+        let now = icn_time::try_current_timestamp_secs()
+            .map_err(|e| anyhow::anyhow!("Cannot cancel proposal: {e}"))?;
 
         self.state = ProposalState::Cancelled { cancelled_at: now };
         self.updated_at = now;
@@ -784,7 +790,8 @@ impl Proposal {
             anyhow::bail!("Cannot veto a closed proposal");
         }
 
-        let now = icn_time::current_timestamp_secs();
+        let now = icn_time::try_current_timestamp_secs()
+            .map_err(|e| anyhow::anyhow!("Cannot veto proposal: {e}"))?;
 
         self.state = ProposalState::Vetoed {
             vetoed_at: now,
@@ -808,7 +815,8 @@ impl Proposal {
             anyhow::bail!("Can only force close proposals in Deliberation or Open state");
         }
 
-        let now = icn_time::current_timestamp_secs();
+        let now = icn_time::try_current_timestamp_secs()
+            .map_err(|e| anyhow::anyhow!("Cannot force close proposal: {e}"))?;
 
         self.state = ProposalState::ForceClosed {
             closed_at: now,

--- a/icn/crates/icn-ledger/src/entry.rs
+++ b/icn/crates/icn-ledger/src/entry.rs
@@ -64,8 +64,9 @@ impl JournalEntryBuilder {
         // Validate that amounts are positive
         validate_positive_amounts(&self.accounts)?;
 
-        // Get current timestamp in milliseconds
-        let timestamp = icn_time::current_timestamp_millis();
+        // Get current timestamp in milliseconds (security-critical: reject if clock is invalid)
+        let timestamp = icn_time::try_current_timestamp_millis()
+            .map_err(|e| anyhow::anyhow!("Cannot create journal entry: {e}"))?;
 
         let mut entry = JournalEntry {
             id: None,


### PR DESCRIPTION
## Summary

- Migrate `icn-ledger/src/entry.rs` to use `try_current_timestamp_millis()` - journal entry timestamps are security-critical for ordering and duplicate detection
- Migrate `icn-governance/src/proposal.rs` to use `try_current_timestamp_secs()` for 8 state transition functions - voting deadlines are security-critical

Closes #425

## What Changed

Security-critical code should reject operations when the system clock is invalid rather than silently proceeding with timestamp=0 (the fallback behavior).

### icn-ledger/src/entry.rs
- `JournalEntryBuilder::build()` now fails with descriptive error if clock is invalid

### icn-governance/src/proposal.rs
Functions migrated (all return `Result`):
- `start_deliberation()`
- `end_deliberation_and_open()`
- `force_end_deliberation()`
- `open()`
- `close()`
- `cancel()`
- `veto()`
- `force_close()`

Note: Constructor functions (`new()`) and test code still use fallback variants - changing constructors would require breaking API changes.

## Risk

Low - These functions already return `Result`, so the error propagation is natural. Clock errors are rare but the security guarantee is important.

## Test plan

- [x] `cargo test -p icn-ledger -p icn-governance` passes
- [x] `cargo clippy -p icn-ledger -p icn-governance -- -D warnings` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)