### PR TITLE
fix(ci): Enable strict cargo audit security checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,13 +153,22 @@ jobs:
         with:
           workspaces: "icn -> target"
 
-      - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+      - name: Install security tools
+        run: |
+          cargo install cargo-audit --locked
+          cargo install cargo-deny --locked
 
-      - name: Run security audit
+      - name: Run cargo-audit
         run: cargo audit
         working-directory: ./icn
-        continue-on-error: true  # Don't fail CI on advisories yet, just warn
+
+      - name: Run cargo-deny advisories check
+        run: cargo deny check advisories
+        working-directory: ./icn
+
+      - name: Run cargo-deny licenses check
+        run: cargo deny check licenses
+        working-directory: ./icn
 
   build:
     name: Build Release

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           cargo install cargo-audit --locked
           cargo install cargo-deny --locked
+          cargo install cargo-outdated --locked
 
       - name: Run cargo-audit
         run: cargo audit

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,85 @@
+name: Weekly Security Audit
+
+on:
+  schedule:
+    # Run every Monday at 6:00 AM UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:  # Allow manual trigger
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  security-audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "icn -> target"
+
+      - name: Install security tools
+        run: |
+          cargo install cargo-audit --locked
+          cargo install cargo-deny --locked
+
+      - name: Run cargo-audit
+        run: cargo audit
+        working-directory: ./icn
+
+      - name: Run cargo-deny full check
+        run: cargo deny check
+        working-directory: ./icn
+
+      - name: Check for outdated dependencies
+        run: cargo outdated --workspace --depth 1
+        working-directory: ./icn
+        continue-on-error: true  # Informational only
+
+      - name: Create issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = 'Weekly Security Audit Failed';
+            const body = `The weekly security audit has detected issues that need attention.
+
+            **Workflow Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}
+
+            Please review the workflow logs and address any security advisories.
+
+            ---
+            _This issue was automatically created by the weekly security audit workflow._`;
+
+            // Check if an issue already exists
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'security-audit'
+            });
+
+            const existingIssue = issues.data.find(issue => issue.title === title);
+
+            if (existingIssue) {
+              // Add a comment to the existing issue
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingIssue.number,
+                body: `Another security audit failure detected.\n\n**Workflow Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+              });
+            } else {
+              // Create a new issue
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: title,
+                body: body,
+                labels: ['security-audit', 'security', 'priority:high']
+              });
+            }

--- a/icn/deny.toml
+++ b/icn/deny.toml
@@ -7,7 +7,39 @@ version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 ignore = [
-    # Add advisory IDs to ignore here
+    # These are "unmaintained" warnings from transitive dependencies, not
+    # security vulnerabilities. They are tracked but don't block CI.
+
+    # fxhash is unmaintained but only used transitively by sled.
+    # sled is in maintenance mode and fxhash has no known vulnerabilities.
+    # We'll migrate away from sled in a future release.
+    "RUSTSEC-2025-0057",  # fxhash unmaintained
+
+    # instant is unmaintained, used transitively by sled via parking_lot.
+    # Recommended replacement is web-time, but sled needs to update first.
+    "RUSTSEC-2024-0384",  # instant unmaintained
+
+    # rustls-pemfile is unmaintained, used transitively by reqwest.
+    # Functionality now in rustls-pki-types. reqwest needs to update.
+    "RUSTSEC-2025-0134",  # rustls-pemfile unmaintained
+
+    # paste is unmaintained, used by ratatui for icn-console TUI.
+    # Replacement pastey is available but ratatui needs to update.
+    "RUSTSEC-2024-0436",  # paste unmaintained
+
+    # pqcrypto-dilithium replaced by pqcrypto-mldsa (FIPS204-compatible).
+    # TODO: Migrate icn-crypto-pq to use ml-dsa crate directly.
+    # Tracked in issue #292 (Post-quantum cryptography integration).
+    "RUSTSEC-2024-0380",  # pqcrypto-dilithium replaced
+
+    # pqcrypto-kyber replaced by pqcrypto-mlkem (FIPS203-compatible).
+    # TODO: Migrate icn-crypto-pq to use ml-kem crate directly.
+    # Tracked in issue #292 (Post-quantum cryptography integration).
+    "RUSTSEC-2024-0381",  # pqcrypto-kyber replaced
+
+    # proc-macro-error is unmaintained, used by i18n-embed-fl (via age)
+    # and utoipa-gen. Both upstream deps need to migrate to alternatives.
+    "RUSTSEC-2024-0370",  # proc-macro-error unmaintained
 ]
 
 [licenses]
@@ -16,14 +48,157 @@ version = 2
 allow = [
     "MIT",
     "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "0BSD",
     "ISC",
     "MPL-2.0",
     "CC0-1.0",
     "Unlicense",
+    "OpenSSL",
+    "Zlib",
+    "Unicode-3.0",
+    "CDLA-Permissive-2.0",
 ]
 confidence-threshold = 0.8
+
+# Allow workspace crates that don't have licenses declared yet
+# TODO: Add proper license field to all ICN crates
+[[licenses.clarify]]
+name = "icn-ccl"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-community"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-compute"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-console"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-coop"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-core"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-crypto-pq"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-entity"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-federation"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-gateway"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-gossip"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-governance"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-identity"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-ledger"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-net"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-obs"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-privacy"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-rpc"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-security"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-snapshot"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-steward"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-store"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-testkit"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-trust"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icn-zkp"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icnctl"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "icnd"
+expression = "Apache-2.0"
+license-files = []
 
 [bans]
 multiple-versions = "warn"

--- a/icn/deny.toml
+++ b/icn/deny.toml
@@ -191,6 +191,11 @@ expression = "Apache-2.0"
 license-files = []
 
 [[licenses.clarify]]
+name = "icn-time"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
 name = "icnctl"
 expression = "Apache-2.0"
 license-files = []


### PR DESCRIPTION
## Summary

Enables strict security auditing in CI by:
- Removing `continue-on-error: true` from the security audit job
- Adding cargo-deny for comprehensive dependency checking (advisories + licenses)
- Creating a weekly scheduled security audit workflow

## Changes

### CI Workflow (`ci.yml`)
- Security audit job now fails the build if vulnerabilities are found
- Added cargo-deny checks for both advisories and licenses

### Weekly Security Audit (`security-audit.yml`)
- New workflow runs every Monday at 6:00 AM UTC
- Runs full cargo-deny check (advisories, licenses, bans, sources)
- Creates GitHub issue automatically on failure
- Can be triggered manually via workflow_dispatch

### Deny Configuration (`deny.toml`)
Updated with comprehensive configuration:

**Ignored Advisories** (unmaintained transitive dependencies):
- `RUSTSEC-2025-0057` - fxhash (via sled)
- `RUSTSEC-2024-0384` - instant (via sled/parking_lot)
- `RUSTSEC-2025-0134` - rustls-pemfile (via reqwest)
- `RUSTSEC-2024-0436` - paste (via ratatui)
- `RUSTSEC-2024-0380` - pqcrypto-dilithium (tracked in #292)
- `RUSTSEC-2024-0381` - pqcrypto-kyber (tracked in #292)
- `RUSTSEC-2024-0370` - proc-macro-error (via age/utoipa)

**Allowed Licenses**:
- MIT, Apache-2.0, Apache-2.0 WITH LLVM-exception
- BSD-2-Clause, BSD-3-Clause, 0BSD, ISC
- MPL-2.0, CC0-1.0, Unlicense
- OpenSSL, Zlib, Unicode-3.0, CDLA-Permissive-2.0

**License Clarifications**:
- All ICN workspace crates are clarified as Apache-2.0 (TODO: add proper license field to Cargo.toml)

## Test Plan

- [x] `cargo deny check advisories` passes locally
- [x] `cargo deny check licenses` passes locally
- [x] `cargo deny check` (full) passes locally
- [ ] CI security audit passes

## Closes

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)