### PR TITLE
fix(time): Validate timestamps before i64 cast to prevent overflow

### DIFF
--- a/icn/crates/icn-time/src/error.rs
+++ b/icn/crates/icn-time/src/error.rs
@@ -27,6 +27,9 @@ pub enum TimeError {
 
     #[error("System clock error: time before UNIX epoch")]
     SystemClockError,
+
+    #[error("Invalid timestamp: {0}ms exceeds safe range for offset calculation")]
+    InvalidTimestamp(u64),
 }
 
 pub type Result<T> = std::result::Result<T, TimeError>;

--- a/icn/crates/icn-time/src/sync.rs
+++ b/icn/crates/icn-time/src/sync.rs
@@ -19,9 +19,9 @@ pub const MAX_CLOCK_SKEW: Duration = Duration::from_secs(300);
 /// Minimum servers required for median calculation
 pub const MIN_SERVERS: usize = 3;
 
-/// Maximum reasonable timestamp in milliseconds for safe i64 conversion
-/// i64::MAX is ~292 billion years in milliseconds, but we use a more
-/// conservative limit (~292 million years) to catch clearly malicious values
+/// Maximum reasonable timestamp in milliseconds for safe i64 conversion.
+/// i64::MAX milliseconds is approximately 292 million years; we use this
+/// maximum safe value to catch clearly malicious timestamp values.
 const MAX_REASONABLE_TIMESTAMP_MS: u64 = i64::MAX as u64;
 
 /// Timeout for individual time server queries
@@ -508,5 +508,30 @@ mod tests {
         // Applying offset: network = local - offset = 4800 - (-200) = 5000
         let network = (local_time as i64 - offset) as u64;
         assert_eq!(network, median_time);
+    }
+
+    #[test]
+    fn test_max_reasonable_timestamp_constant() {
+        // Verify the constant is set correctly for safe i64 conversion
+        assert_eq!(MAX_REASONABLE_TIMESTAMP_MS, i64::MAX as u64);
+
+        // Any value at or below this is safe to cast to i64
+        let safe_value = MAX_REASONABLE_TIMESTAMP_MS;
+        let as_i64 = safe_value as i64;
+        assert_eq!(as_i64, i64::MAX);
+
+        // Verify values above would wrap (demonstrating the need for validation)
+        let unsafe_value = MAX_REASONABLE_TIMESTAMP_MS + 1;
+        let wrapped = unsafe_value as i64;
+        assert!(wrapped < 0, "Values above MAX should wrap to negative");
+    }
+
+    #[test]
+    fn test_invalid_timestamp_error() {
+        // Test that InvalidTimestamp error can be created and displays correctly
+        let err = TimeError::InvalidTimestamp(u64::MAX);
+        let msg = format!("{}", err);
+        assert!(msg.contains("exceeds safe range"));
+        assert!(msg.contains(&u64::MAX.to_string()));
     }
 }

--- a/icn/crates/icn-time/src/sync.rs
+++ b/icn/crates/icn-time/src/sync.rs
@@ -19,9 +19,10 @@ pub const MAX_CLOCK_SKEW: Duration = Duration::from_secs(300);
 /// Minimum servers required for median calculation
 pub const MIN_SERVERS: usize = 3;
 
-/// Maximum reasonable timestamp in milliseconds for safe i64 conversion.
-/// i64::MAX milliseconds is approximately 292 million years; we use this
-/// maximum safe value to catch clearly malicious timestamp values.
+/// Maximum timestamp in milliseconds that can be safely cast to i64.
+/// i64::MAX milliseconds is approximately 292 million years from epoch.
+/// Any timestamp beyond this indicates either malicious input or severe
+/// system clock corruption, and must be rejected to prevent overflow.
 const MAX_REASONABLE_TIMESTAMP_MS: u64 = i64::MAX as u64;
 
 /// Timeout for individual time server queries
@@ -278,9 +279,20 @@ impl ClockSync {
 
         let now = Self::system_time_millis();
 
+        // Validate timestamp before i64 cast (guards against system clock corruption)
+        if now > MAX_REASONABLE_TIMESTAMP_MS {
+            warn!(
+                "System clock timestamp {}ms exceeds safe range in network_time()",
+                now
+            );
+            return Err(TimeError::InvalidTimestamp(now));
+        }
+
         // Apply signed offset: network_time = local_time - offset
         // - If offset > 0 (local ahead): subtract offset to get network time
         // - If offset < 0 (local behind): subtract negative = add to get network time
+        // SAFETY: now is validated to be <= i64::MAX, and offset_millis was validated
+        // during sync(), so the subtraction cannot overflow.
         let network_time = (now as i64 - self.offset_millis).max(0) as u64;
 
         Ok(network_time)

--- a/icn/crates/icn-time/src/sync.rs
+++ b/icn/crates/icn-time/src/sync.rs
@@ -19,6 +19,11 @@ pub const MAX_CLOCK_SKEW: Duration = Duration::from_secs(300);
 /// Minimum servers required for median calculation
 pub const MIN_SERVERS: usize = 3;
 
+/// Maximum reasonable timestamp in milliseconds for safe i64 conversion
+/// i64::MAX is ~292 billion years in milliseconds, but we use a more
+/// conservative limit (~292 million years) to catch clearly malicious values
+const MAX_REASONABLE_TIMESTAMP_MS: u64 = i64::MAX as u64;
+
 /// Timeout for individual time server queries
 pub const QUERY_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -129,9 +134,27 @@ impl ClockSync {
         let median_time = self.compute_median(&responses)?;
         let now = Self::system_time_millis();
 
+        // Validate timestamps before i64 conversion to prevent overflow
+        // This guards against malicious time servers returning extreme values
+        if now > MAX_REASONABLE_TIMESTAMP_MS {
+            warn!(
+                "Local clock timestamp {}ms exceeds safe range, rejecting",
+                now
+            );
+            return Err(TimeError::InvalidTimestamp(now));
+        }
+        if median_time > MAX_REASONABLE_TIMESTAMP_MS {
+            warn!(
+                "Median time {}ms from servers exceeds safe range, possible malicious response",
+                median_time
+            );
+            return Err(TimeError::InvalidTimestamp(median_time));
+        }
+
         // Calculate signed offset in milliseconds
         // Positive = local ahead (subtract to get network time)
         // Negative = local behind (add to get network time)
+        // SAFETY: Both values are validated to be <= i64::MAX above
         self.offset_millis = now as i64 - median_time as i64;
 
         // Calculate uncertainty (based on RTT variance)


### PR DESCRIPTION
## Summary

Adds validation to the clock sync offset calculation to prevent potential overflow when casting u64 timestamps to i64.

## Problem

**File:** `icn-time/src/sync.rs:135`

```rust
self.offset_millis = now as i64 - median_time as i64;
```

If `now` or `median_time` exceeds i64::MAX (unlikely but possible if malicious time server), the cast causes wrapping which produces incorrect offset values.

## Solution

Validate timestamps before the calculation:

```rust
const MAX_REASONABLE_TIMESTAMP_MS: u64 = i64::MAX as u64;

if now > MAX_REASONABLE_TIMESTAMP_MS {
    warn!("Local clock timestamp exceeds safe range");
    return Err(TimeError::InvalidTimestamp(now));
}
if median_time > MAX_REASONABLE_TIMESTAMP_MS {
    warn!("Median time exceeds safe range, possible malicious response");
    return Err(TimeError::InvalidTimestamp(median_time));
}
```

## Changes

- Add `InvalidTimestamp(u64)` error variant to `TimeError`
- Add `MAX_REASONABLE_TIMESTAMP_MS` constant
- Validate both local and median timestamps before subtraction
- Log warnings for suspicious timestamp values

## Test Plan

- [x] `cargo test -p icn-time` passes (30 tests + 7 doctests)
- [x] `cargo clippy -p icn-time` passes

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)