### PR TITLE
fix(governance): Make max execution delay configurable per cooperative

### DIFF
--- a/icn/crates/icn-core/src/governance/actor.rs
+++ b/icn/crates/icn-core/src/governance/actor.rs
@@ -553,9 +553,18 @@ impl icn_governance::GovernanceOps for GovernanceHandle {
                     )
                 })?;
                 if effective_at > max_allowed {
-                    let max_days = max_delay_seconds / (24 * 60 * 60);
+                    // Format the max delay in human-readable units
+                    let max_display = if max_delay_seconds >= 24 * 60 * 60 {
+                        let days = max_delay_seconds / (24 * 60 * 60);
+                        format!("{days} days")
+                    } else if max_delay_seconds >= 60 * 60 {
+                        let hours = max_delay_seconds / (60 * 60);
+                        format!("{hours} hours")
+                    } else {
+                        format!("{max_delay_seconds} seconds")
+                    };
                     bail!(
-                        "Cannot create ProtocolChange proposal: effective_at is too far in the future (max: {max_days} days)"
+                        "Cannot create ProtocolChange proposal: effective_at is too far in the future (max: {max_display})"
                     );
                 }
             }

--- a/icn/crates/icn-core/src/governance/actor.rs
+++ b/icn/crates/icn-core/src/governance/actor.rs
@@ -535,18 +535,27 @@ impl icn_governance::GovernanceOps for GovernanceHandle {
                     );
                 }
 
-                // Optional: max delay limit (1 year = 365 * 24 * 60 * 60 = 31536000 seconds)
-                const MAX_DELAY_SECONDS: u64 = 31_536_000;
+                // Get max delay from domain params (configurable per cooperative)
+                // Default: 1 year (31536000 seconds) if domain not found
+                let max_delay_seconds = self
+                    .get_domain(&domain_id)
+                    .await
+                    .ok()
+                    .flatten()
+                    .map(|d| d.config.params.max_execution_delay_seconds)
+                    .unwrap_or(365 * 24 * 60 * 60);
+
                 // Use checked arithmetic to prevent overflow if now is close to u64::MAX.
                 // If overflow occurs, reject the proposal rather than allowing arbitrary future dates.
-                let max_allowed = now.checked_add(MAX_DELAY_SECONDS).ok_or_else(|| {
+                let max_allowed = now.checked_add(max_delay_seconds).ok_or_else(|| {
                     anyhow::anyhow!(
                         "Cannot create ProtocolChange proposal: timestamp overflow when calculating max allowed effective_at"
                     )
                 })?;
                 if effective_at > max_allowed {
+                    let max_days = max_delay_seconds / (24 * 60 * 60);
                     bail!(
-                        "Cannot create ProtocolChange proposal: effective_at is too far in the future (max: 1 year)"
+                        "Cannot create ProtocolChange proposal: effective_at is too far in the future (max: {max_days} days)"
                     );
                 }
             }

--- a/icn/crates/icn-core/src/governance/actor.rs
+++ b/icn/crates/icn-core/src/governance/actor.rs
@@ -536,14 +536,14 @@ impl icn_governance::GovernanceOps for GovernanceHandle {
                 }
 
                 // Get max delay from domain params (configurable per cooperative)
-                // Default: 1 year (31536000 seconds) if domain not found
+                // Falls back to default (1 year) if domain not found
                 let max_delay_seconds = self
                     .get_domain(&domain_id)
                     .await
                     .ok()
                     .flatten()
                     .map(|d| d.config.params.max_execution_delay_seconds)
-                    .unwrap_or(365 * 24 * 60 * 60);
+                    .unwrap_or_else(icn_governance::default_max_execution_delay);
 
                 // Use checked arithmetic to prevent overflow if now is close to u64::MAX.
                 // If overflow occurs, reject the proposal rather than allowing arbitrary future dates.

--- a/icn/crates/icn-governance/src/config.rs
+++ b/icn/crates/icn-governance/src/config.rs
@@ -308,8 +308,9 @@ pub struct GovernanceParams {
     pub max_execution_delay_seconds: u64,
 }
 
-/// Default max execution delay: 1 year
-fn default_max_execution_delay() -> u64 {
+/// Default max execution delay: 1 year (31536000 seconds)
+/// Public so icn-core can use the same default for fallback
+pub fn default_max_execution_delay() -> u64 {
     365 * 24 * 60 * 60 // 31536000 seconds
 }
 
@@ -661,5 +662,49 @@ mod tests {
         assert_eq!(config.emergency.freeze_quorum_percentage, 80);
         assert_eq!(config.emergency.freeze_approval_percentage, 90);
         assert_eq!(config.emergency.rollback_approval_percentage, 95);
+    }
+
+    #[test]
+    fn test_max_execution_delay_default() {
+        let params = GovernanceParams::default();
+        // Default should be 1 year
+        assert_eq!(params.max_execution_delay_seconds, 365 * 24 * 60 * 60);
+        assert_eq!(
+            params.max_execution_delay_seconds,
+            default_max_execution_delay()
+        );
+    }
+
+    #[test]
+    fn test_max_execution_delay_validation_minimum() {
+        // Valid: exactly 1 hour
+        let valid_params = GovernanceParams {
+            max_execution_delay_seconds: 3600,
+            ..Default::default()
+        };
+        assert!(valid_params.validate().is_ok());
+
+        // Invalid: less than 1 hour
+        let invalid_params = GovernanceParams {
+            max_execution_delay_seconds: 3599,
+            ..Default::default()
+        };
+        let result = invalid_params.validate();
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("must be at least 1 hour"));
+    }
+
+    #[test]
+    fn test_max_execution_delay_custom_value() {
+        // Custom: 30 days
+        let params = GovernanceParams {
+            max_execution_delay_seconds: 30 * 24 * 60 * 60,
+            ..Default::default()
+        };
+        assert!(params.validate().is_ok());
+        assert_eq!(params.max_execution_delay_seconds, 2592000);
     }
 }

--- a/icn/crates/icn-governance/src/config.rs
+++ b/icn/crates/icn-governance/src/config.rs
@@ -304,6 +304,12 @@ pub struct GovernanceParams {
     /// Maximum execution delay for proposals (in seconds)
     /// Limits how far into the future a proposal's effective_at can be set
     /// Default: 31536000 (1 year = 365 days)
+    ///
+    /// Example values for different cooperative needs:
+    /// - 86400 (1 day): Fast-moving tech cooperatives
+    /// - 2592000 (30 days): Standard governance changes
+    /// - 31536000 (1 year, default): Major protocol changes
+    /// - 63072000 (2 years): Constitutional amendments
     #[serde(default = "default_max_execution_delay")]
     pub max_execution_delay_seconds: u64,
 }

--- a/icn/crates/icn-governance/src/config.rs
+++ b/icn/crates/icn-governance/src/config.rs
@@ -300,6 +300,17 @@ pub struct GovernanceParams {
     /// Cannot set deliberation longer than this
     /// Default: 2592000 (30 days)
     pub max_deliberation_seconds: u64,
+
+    /// Maximum execution delay for proposals (in seconds)
+    /// Limits how far into the future a proposal's effective_at can be set
+    /// Default: 31536000 (1 year = 365 days)
+    #[serde(default = "default_max_execution_delay")]
+    pub max_execution_delay_seconds: u64,
+}
+
+/// Default max execution delay: 1 year
+fn default_max_execution_delay() -> u64 {
+    365 * 24 * 60 * 60 // 31536000 seconds
 }
 
 impl Default for GovernanceParams {
@@ -312,6 +323,7 @@ impl Default for GovernanceParams {
             require_deliberation: true,
             min_deliberation_seconds: 24 * 60 * 60, // 1 day
             max_deliberation_seconds: 30 * 24 * 60 * 60, // 30 days
+            max_execution_delay_seconds: default_max_execution_delay(),
         }
     }
 }

--- a/icn/crates/icn-governance/src/config.rs
+++ b/icn/crates/icn-governance/src/config.rs
@@ -419,6 +419,15 @@ impl GovernanceParams {
             );
         }
 
+        // Execution delay validation: minimum 1 hour to prevent misconfiguration
+        const MIN_EXECUTION_DELAY_SECONDS: u64 = 3600; // 1 hour
+        if self.max_execution_delay_seconds < MIN_EXECUTION_DELAY_SECONDS {
+            anyhow::bail!(
+                "Max execution delay ({} seconds) must be at least 1 hour (3600 seconds)",
+                self.max_execution_delay_seconds
+            );
+        }
+
         Ok(())
     }
 

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -89,7 +89,9 @@ pub use charter::{
     OrgType,
 };
 pub use charter_store::{CharterStore, CharterStoreBackend, InMemoryCharterStore};
-pub use config::{EmergencyThresholds, GovernanceConfig, GovernanceParams};
+pub use config::{
+    default_max_execution_delay, EmergencyThresholds, GovernanceConfig, GovernanceParams,
+};
 pub use delegation::{
     scopes_overlap, Delegation, DelegationError, DelegationId, DelegationManager, DelegationScope,
     ProposalDomainLookup, DEFAULT_MAX_DELEGATION_DEPTH,


### PR DESCRIPTION
## Summary

Makes the maximum execution delay for proposals configurable per cooperative instead of using a hardcoded 1-year constant.

Closes #414

## Changes

- Added `max_execution_delay_seconds` field to `GovernanceParams` in icn-governance
- Default remains 1 year (31536000 seconds) for backward compatibility
- Uses `#[serde(default)]` for safe deserialization of existing configs
- Updated icn-core governance actor to read from domain params
- Error message now shows the configured maximum in days

## Impact

Cooperatives can now customize:
- Shorter delays for urgent security fixes or time-sensitive proposals
- Longer delays for major governance changes requiring extended deliberation
- Per-cooperative limits based on their specific governance needs

## Test plan

- [x] `cargo check -p icn-governance -p icn-core`
- [x] `cargo clippy -p icn-governance -p icn-core`
- [x] `cargo test -p icn-governance --lib` (299 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)