### PR TITLE
fix(security): Add evidence size limits in misbehavior tracking

### DIFF
--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -3311,6 +3311,12 @@ pub mod misbehavior {
         )
         .increment(1);
     }
+
+    /// Increment counter when evidence is truncated due to size limits.
+    /// This helps operators detect storage exhaustion attack attempts.
+    pub fn evidence_truncated_inc() {
+        counter!("icn_misbehavior_evidence_truncated_total").increment(1);
+    }
 }
 
 /// Partition detection and healing metrics (Phase 18 Week 3)

--- a/icn/crates/icn-security/src/misbehavior.rs
+++ b/icn/crates/icn-security/src/misbehavior.rs
@@ -326,14 +326,15 @@ impl MisbehaviorDetector {
         sanitized
     }
 
-    /// Prune old violations for a peer if they exceed the per-peer limit.
+    /// Prune oldest violations for a peer if they exceed the per-peer limit.
     ///
     /// Keeps the most recent MAX_VIOLATIONS_PER_PEER violations.
+    /// Violations are stored newest-first (inserted at front), so pruning
+    /// simply truncates from the back in O(1) amortized time.
     fn prune_violations_for_peer(&mut self, did: &Did) {
         if let Some(violations) = self.violations.get_mut(did) {
             if violations.len() > MAX_VIOLATIONS_PER_PEER {
-                // Sort by timestamp and keep only the most recent
-                violations.sort_by(|a, b| b.detected_at.cmp(&a.detected_at));
+                // Violations are stored newest-first, so truncate from back (oldest)
                 violations.truncate(MAX_VIOLATIONS_PER_PEER);
 
                 debug!(
@@ -362,10 +363,13 @@ impl MisbehaviorDetector {
             evidence: sanitized_evidence,
         };
 
-        // Add to violation history
-        self.violations.entry(did.clone()).or_default().push(record);
+        // Add to violation history (newest-first for O(1) pruning)
+        self.violations
+            .entry(did.clone())
+            .or_default()
+            .insert(0, record);
 
-        // Prune old violations to prevent unbounded growth
+        // Prune old violations to prevent unbounded growth (O(1) truncation from back)
         self.prune_violations_for_peer(did);
 
         // Update reputation score and capture thresholds for later checks
@@ -402,8 +406,8 @@ impl MisbehaviorDetector {
             self.quarantine_peer(did);
         }
 
-        // Cleanup old violations
-        self.cleanup_old_violations();
+        // Note: cleanup_old_violations() is called periodically via check_quarantine_releases()
+        // rather than on every violation for better performance
     }
 
     /// Get violations for a DID
@@ -1053,8 +1057,10 @@ mod tests {
         let mut detector = MisbehaviorDetector::new(MisbehaviorThresholds::default());
         let did = test_did();
 
+        let total_violations = MAX_VIOLATIONS_PER_PEER + 50;
+
         // Record more than MAX_VIOLATIONS_PER_PEER violations
-        for i in 0..(MAX_VIOLATIONS_PER_PEER + 50) {
+        for i in 0..total_violations {
             let violation = Violation::ExcessiveResourceUse {
                 metric: format!("test_{i}"),
                 observed: 10,
@@ -1071,6 +1077,31 @@ mod tests {
             MAX_VIOLATIONS_PER_PEER,
             violations.len()
         );
+
+        // Verify that the MOST RECENT violations are kept (newest-first order)
+        // The first violation in the list should be the most recent (test_{total-1})
+        // The last violation should be the oldest kept (test_{total-MAX})
+        if let Violation::ExcessiveResourceUse { metric, .. } = &violations[0].violation {
+            let expected_newest = format!("test_{}", total_violations - 1);
+            assert_eq!(
+                metric, &expected_newest,
+                "First violation should be the most recent"
+            );
+        } else {
+            panic!("Expected ExcessiveResourceUse violation");
+        }
+
+        if let Violation::ExcessiveResourceUse { metric, .. } =
+            &violations[violations.len() - 1].violation
+        {
+            let expected_oldest_kept = format!("test_{}", total_violations - MAX_VIOLATIONS_PER_PEER);
+            assert_eq!(
+                metric, &expected_oldest_kept,
+                "Last violation should be the oldest kept"
+            );
+        } else {
+            panic!("Expected ExcessiveResourceUse violation");
+        }
     }
 
     #[test]

--- a/icn/crates/icn-security/src/misbehavior.rs
+++ b/icn/crates/icn-security/src/misbehavior.rs
@@ -294,6 +294,14 @@ impl MisbehaviorDetector {
         self.trust_penalty_callback = Some(callback);
     }
 
+    /// Truncation marker components for self-documenting length calculation
+    const TRUNCATION_MARKER_PREFIX: &'static [u8] = b"\n[TRUNCATED:sha256=";
+    const TRUNCATION_MARKER_SUFFIX: &'static [u8] = b"]";
+    /// SHA-256 produces 32 bytes = 64 hex characters
+    const SHA256_HEX_LEN: usize = 64;
+    /// Total marker length: prefix (20) + 64 hex chars + suffix (1) = 85 bytes
+    const TRUNCATION_MARKER_LEN: usize = 20 + Self::SHA256_HEX_LEN + 1; // Can't use .len() in const context
+
     /// Sanitize evidence to prevent storage exhaustion attacks.
     ///
     /// If evidence exceeds MAX_EVIDENCE_SIZE, it is truncated and a SHA-256 hash
@@ -303,25 +311,25 @@ impl MisbehaviorDetector {
             return evidence;
         }
 
-        // Marker format: "\n[TRUNCATED:sha256=<64 hex chars>]"
-        // Total marker length: 1 + 19 + 64 + 1 = 85 bytes
-        const MARKER_LEN: usize = 85;
-        let truncate_at = MAX_EVIDENCE_SIZE.saturating_sub(MARKER_LEN);
+        let truncate_at = MAX_EVIDENCE_SIZE.saturating_sub(Self::TRUNCATION_MARKER_LEN);
         let mut sanitized = evidence[..truncate_at].to_vec();
 
         // Compute hash of full evidence for forensic reference
         let hash = Sha256::digest(&evidence);
 
         // Append marker and hash
-        sanitized.extend_from_slice(b"\n[TRUNCATED:sha256=");
+        sanitized.extend_from_slice(Self::TRUNCATION_MARKER_PREFIX);
         sanitized.extend_from_slice(hex::encode(hash).as_bytes());
-        sanitized.extend_from_slice(b"]");
+        sanitized.extend_from_slice(Self::TRUNCATION_MARKER_SUFFIX);
 
         debug!(
             "Evidence truncated from {} to {} bytes",
             evidence.len(),
             sanitized.len()
         );
+
+        // Emit metric for monitoring truncation attempts
+        metrics::evidence_truncated_inc();
 
         sanitized
     }
@@ -1094,7 +1102,8 @@ mod tests {
         if let Violation::ExcessiveResourceUse { metric, .. } =
             &violations[violations.len() - 1].violation
         {
-            let expected_oldest_kept = format!("test_{}", total_violations - MAX_VIOLATIONS_PER_PEER);
+            let expected_oldest_kept =
+                format!("test_{}", total_violations - MAX_VIOLATIONS_PER_PEER);
             assert_eq!(
                 metric, &expected_oldest_kept,
                 "Last violation should be the oldest kept"
@@ -1126,6 +1135,47 @@ mod tests {
         assert!(
             stored_evidence.len() <= MAX_EVIDENCE_SIZE,
             "Stored evidence should be sanitized"
+        );
+    }
+
+    #[test]
+    fn test_evidence_one_byte_over_limit() {
+        // Test boundary case: exactly one byte over the limit
+        let evidence = vec![42u8; MAX_EVIDENCE_SIZE + 1];
+        let sanitized = MisbehaviorDetector::sanitize_evidence(evidence);
+
+        assert!(
+            sanitized.len() <= MAX_EVIDENCE_SIZE,
+            "Evidence one byte over limit should be truncated"
+        );
+        assert!(
+            String::from_utf8_lossy(&sanitized).contains("[TRUNCATED:sha256="),
+            "Should contain truncation marker"
+        );
+    }
+
+    #[test]
+    fn test_truncation_hash_is_correct() {
+        // Verify that the hash in the truncation marker matches the original evidence
+        let large_evidence = vec![0xDE; 128 * 1024]; // 128KB
+        let expected_hash = hex::encode(Sha256::digest(&large_evidence));
+
+        let sanitized = MisbehaviorDetector::sanitize_evidence(large_evidence);
+        let sanitized_str = String::from_utf8_lossy(&sanitized);
+
+        // Extract hash from marker
+        let hash_start = sanitized_str
+            .find("sha256=")
+            .expect("should have sha256 marker")
+            + 7;
+        let hash_end = sanitized_str
+            .find(']')
+            .expect("should have closing bracket");
+        let actual_hash = &sanitized_str[hash_start..hash_end];
+
+        assert_eq!(
+            actual_hash, expected_hash,
+            "Hash in truncation marker should match SHA-256 of original evidence"
         );
     }
 }

--- a/icn/crates/icn-security/src/misbehavior.rs
+++ b/icn/crates/icn-security/src/misbehavior.rs
@@ -9,9 +9,18 @@ use icn_identity::Did;
 use icn_obs::metrics::misbehavior as metrics;
 use icn_store::ContentHash;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime};
 use tracing::{debug, info, warn};
+
+/// Maximum size of evidence in bytes (64KB).
+/// Evidence larger than this will be truncated and hashed.
+pub const MAX_EVIDENCE_SIZE: usize = 64 * 1024;
+
+/// Maximum stored violations per peer before pruning oldest.
+/// This prevents unbounded memory growth from malicious peers.
+pub const MAX_VIOLATIONS_PER_PEER: usize = 100;
 
 /// Types of misbehavior that can be detected
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -285,6 +294,56 @@ impl MisbehaviorDetector {
         self.trust_penalty_callback = Some(callback);
     }
 
+    /// Sanitize evidence to prevent storage exhaustion attacks.
+    ///
+    /// If evidence exceeds MAX_EVIDENCE_SIZE, it is truncated and a SHA-256 hash
+    /// of the full evidence is appended, preserving a summary while bounding storage.
+    fn sanitize_evidence(evidence: Vec<u8>) -> Vec<u8> {
+        if evidence.len() <= MAX_EVIDENCE_SIZE {
+            return evidence;
+        }
+
+        // Marker format: "\n[TRUNCATED:sha256=<64 hex chars>]"
+        // Total marker length: 1 + 19 + 64 + 1 = 85 bytes
+        const MARKER_LEN: usize = 85;
+        let truncate_at = MAX_EVIDENCE_SIZE.saturating_sub(MARKER_LEN);
+        let mut sanitized = evidence[..truncate_at].to_vec();
+
+        // Compute hash of full evidence for forensic reference
+        let hash = Sha256::digest(&evidence);
+
+        // Append marker and hash
+        sanitized.extend_from_slice(b"\n[TRUNCATED:sha256=");
+        sanitized.extend_from_slice(hex::encode(hash).as_bytes());
+        sanitized.extend_from_slice(b"]");
+
+        debug!(
+            "Evidence truncated from {} to {} bytes",
+            evidence.len(),
+            sanitized.len()
+        );
+
+        sanitized
+    }
+
+    /// Prune old violations for a peer if they exceed the per-peer limit.
+    ///
+    /// Keeps the most recent MAX_VIOLATIONS_PER_PEER violations.
+    fn prune_violations_for_peer(&mut self, did: &Did) {
+        if let Some(violations) = self.violations.get_mut(did) {
+            if violations.len() > MAX_VIOLATIONS_PER_PEER {
+                // Sort by timestamp and keep only the most recent
+                violations.sort_by(|a, b| b.detected_at.cmp(&a.detected_at));
+                violations.truncate(MAX_VIOLATIONS_PER_PEER);
+
+                debug!(
+                    "Pruned violations for {} to {} entries",
+                    did, MAX_VIOLATIONS_PER_PEER
+                );
+            }
+        }
+    }
+
     /// Record a violation for a DID
     pub fn record_violation(&mut self, did: &Did, violation: Violation, evidence: Vec<u8>) {
         info!(
@@ -293,15 +352,21 @@ impl MisbehaviorDetector {
             violation.description()
         );
 
+        // Sanitize evidence to prevent storage exhaustion
+        let sanitized_evidence = Self::sanitize_evidence(evidence);
+
         // Create violation record
         let record = ViolationRecord {
             violation: violation.clone(),
             detected_at: SystemTime::now(),
-            evidence,
+            evidence: sanitized_evidence,
         };
 
         // Add to violation history
         self.violations.entry(did.clone()).or_default().push(record);
+
+        // Prune old violations to prevent unbounded growth
+        self.prune_violations_for_peer(did);
 
         // Update reputation score and capture thresholds for later checks
         let (is_auto_ban, should_ban, should_quarantine) = {
@@ -927,6 +992,109 @@ mod tests {
             call_count.load(Ordering::SeqCst),
             1,
             "Callback should be called on quarantine release"
+        );
+    }
+
+    #[test]
+    fn test_evidence_under_size_limit_unchanged() {
+        let small_evidence = vec![1u8; 1000]; // 1KB, well under 64KB limit
+        let sanitized = MisbehaviorDetector::sanitize_evidence(small_evidence.clone());
+
+        assert_eq!(
+            sanitized, small_evidence,
+            "Evidence under size limit should be unchanged"
+        );
+    }
+
+    #[test]
+    fn test_evidence_over_size_limit_truncated() {
+        let large_evidence = vec![42u8; 128 * 1024]; // 128KB, over 64KB limit
+        let sanitized = MisbehaviorDetector::sanitize_evidence(large_evidence.clone());
+
+        // Should be truncated to approximately MAX_EVIDENCE_SIZE
+        assert!(
+            sanitized.len() <= MAX_EVIDENCE_SIZE,
+            "Sanitized evidence should be at most {} bytes, got {}",
+            MAX_EVIDENCE_SIZE,
+            sanitized.len()
+        );
+
+        // Should contain truncation marker
+        let sanitized_str = String::from_utf8_lossy(&sanitized);
+        assert!(
+            sanitized_str.contains("[TRUNCATED:sha256="),
+            "Truncated evidence should contain hash marker"
+        );
+
+        // Hash should be a valid hex string (64 chars for SHA-256)
+        let hash_start = sanitized_str.find("sha256=").unwrap() + 7;
+        let hash_end = sanitized_str.find(']').unwrap();
+        let hash_hex = &sanitized_str[hash_start..hash_end];
+        assert_eq!(hash_hex.len(), 64, "SHA-256 hash should be 64 hex chars");
+        assert!(
+            hash_hex.chars().all(|c| c.is_ascii_hexdigit()),
+            "Hash should be valid hex"
+        );
+    }
+
+    #[test]
+    fn test_evidence_at_exact_limit() {
+        let exact_evidence = vec![99u8; MAX_EVIDENCE_SIZE];
+        let sanitized = MisbehaviorDetector::sanitize_evidence(exact_evidence.clone());
+
+        assert_eq!(
+            sanitized, exact_evidence,
+            "Evidence at exact limit should be unchanged"
+        );
+    }
+
+    #[test]
+    fn test_per_peer_violation_pruning() {
+        let mut detector = MisbehaviorDetector::new(MisbehaviorThresholds::default());
+        let did = test_did();
+
+        // Record more than MAX_VIOLATIONS_PER_PEER violations
+        for i in 0..(MAX_VIOLATIONS_PER_PEER + 50) {
+            let violation = Violation::ExcessiveResourceUse {
+                metric: format!("test_{i}"),
+                observed: 10,
+                limit: 5,
+            };
+            detector.record_violation(&did, violation, vec![]);
+        }
+
+        // Should have at most MAX_VIOLATIONS_PER_PEER violations
+        let violations = detector.get_violations(&did);
+        assert!(
+            violations.len() <= MAX_VIOLATIONS_PER_PEER,
+            "Should have at most {} violations, got {}",
+            MAX_VIOLATIONS_PER_PEER,
+            violations.len()
+        );
+    }
+
+    #[test]
+    fn test_oversized_evidence_recorded_correctly() {
+        let mut detector = MisbehaviorDetector::new(MisbehaviorThresholds::default());
+        let did = test_did();
+
+        // Create oversized evidence
+        let large_evidence = vec![0xAB; 100 * 1024]; // 100KB
+        let violation = Violation::InvalidSignature {
+            message_hash: [0u8; 32],
+        };
+
+        detector.record_violation(&did, violation, large_evidence);
+
+        // Verify violation was recorded
+        let violations = detector.get_violations(&did);
+        assert_eq!(violations.len(), 1);
+
+        // Verify evidence was sanitized
+        let stored_evidence = &violations[0].evidence;
+        assert!(
+            stored_evidence.len() <= MAX_EVIDENCE_SIZE,
+            "Stored evidence should be sanitized"
         );
     }
 }


### PR DESCRIPTION
## Summary

Prevents storage exhaustion attacks where malicious peers could craft violations with massive evidence payloads to exhaust node storage.

Closes #480

## Changes

- Add `MAX_EVIDENCE_SIZE` constant (64KB) for evidence truncation
- Add `MAX_VIOLATIONS_PER_PEER` constant (100) for per-peer pruning  
- Implement `sanitize_evidence()` to truncate oversized evidence and append SHA-256 hash for forensic reference
- Implement `prune_violations_for_peer()` to cap stored violations per peer
- Add comprehensive tests for evidence handling and pruning

## Defense Mechanism

When evidence exceeds 64KB:
1. Truncates to 64KB minus marker length
2. Computes SHA-256 hash of full evidence
3. Appends marker: `\n[TRUNCATED:sha256=<hash>]`

This preserves the beginning of the evidence for debugging while providing a cryptographic reference to the full payload.

## Test Plan

- [x] `test_evidence_under_size_limit_unchanged` - small evidence passes through unchanged
- [x] `test_evidence_over_size_limit_truncated` - large evidence is truncated with hash
- [x] `test_evidence_at_exact_limit` - evidence at exact limit is unchanged
- [x] `test_per_peer_violation_pruning` - violations are pruned to 100 per peer
- [x] `test_oversized_evidence_recorded_correctly` - integration test for record_violation
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)