### PR TITLE
feat: Add causal ordering, trust latency, and supervisor metrics

### DIFF
--- a/icn/crates/icn-core/src/supervisor/mod.rs
+++ b/icn/crates/icn-core/src/supervisor/mod.rs
@@ -326,6 +326,7 @@ impl Supervisor {
             )
             .await?;
             icn_obs::metrics::supervisor::actor_spawned_inc("gossip");
+            icn_obs::metrics::supervisor::actor_active_set("gossip", true);
             let gossip_handle = gossip_services.gossip_handle.clone();
             let gossip_store = gossip_services.gossip_store.clone(); // Used for encryption sequence tracking
             let loaded_snapshot = gossip_services.loaded_snapshot;
@@ -342,6 +343,7 @@ impl Supervisor {
             )
             .await?;
             icn_obs::metrics::supervisor::actor_spawned_inc("ledger");
+            icn_obs::metrics::supervisor::actor_active_set("ledger", true);
             let ledger_handle = ledger_services.ledger_handle.clone();
             let dispute_manager_handle = ledger_services.dispute_manager.clone();
             let treasury_manager_handle = ledger_services.treasury_manager.clone();
@@ -353,6 +355,7 @@ impl Supervisor {
                 init_coop::init_coop_services(&self.config, gossip_handle.clone(), did.clone())
                     .await?;
             icn_obs::metrics::supervisor::actor_spawned_inc("coop");
+            icn_obs::metrics::supervisor::actor_active_set("coop", true);
             let coop_handle = coop_services.coop_handle.clone();
             let coop_store = coop_services.coop_store.clone(); // Used for gossip sync
 
@@ -483,6 +486,7 @@ impl Supervisor {
             *network_handle_for_handler.write().await = Some(network_handle.clone());
 
             icn_obs::metrics::supervisor::actor_spawned_inc("network");
+            icn_obs::metrics::supervisor::actor_active_set("network", true);
             info!("Network actor spawned on {}", listen_addr);
 
             // Restore network state from snapshot if available (re-use snapshot loaded earlier)
@@ -1578,6 +1582,7 @@ impl Supervisor {
                 });
 
                 icn_obs::metrics::supervisor::actor_spawned_inc("gateway");
+                icn_obs::metrics::supervisor::actor_active_set("gateway", true);
                 info!("Gateway API spawned on {}", gateway_addr);
             }
         } else {

--- a/icn/crates/icn-core/src/supervisor/mod.rs
+++ b/icn/crates/icn-core/src/supervisor/mod.rs
@@ -1340,6 +1340,7 @@ impl Supervisor {
             });
 
             icn_obs::metrics::supervisor::actor_spawned_inc("rpc_server");
+            icn_obs::metrics::supervisor::actor_active_set("rpc_server", true);
             info!("RPC server spawned on {}", rpc_addr);
 
             // Spawn anti-entropy task

--- a/icn/crates/icn-core/src/trust_propagation.rs
+++ b/icn/crates/icn-core/src/trust_propagation.rs
@@ -211,6 +211,8 @@ pub async fn broadcast_trust_attestation(
     keypair: &KeyPair,
     gossip: &GossipHandle,
 ) -> Result<()> {
+    let start = Instant::now();
+
     // Sign the attestation
     attestation.sign(keypair)?;
 
@@ -221,9 +223,13 @@ pub async fn broadcast_trust_attestation(
     let mut gossip_actor = gossip.write().await;
     let hash = gossip_actor.publish(TRUST_ATTESTATIONS_TOPIC, data).await?;
 
+    // Issue #498: Record local propagation latency
+    let propagation_duration = start.elapsed();
+    icn_obs::metrics::trust::propagation_local_record(propagation_duration.as_secs_f64());
+
     debug!(
-        "Broadcasted trust attestation: {} -> {} (hash: {:?})",
-        attestation.issuer, attestation.subject, hash
+        "Broadcasted trust attestation: {} -> {} (hash: {:?}, latency: {:?})",
+        attestation.issuer, attestation.subject, hash, propagation_duration
     );
 
     // Record metric
@@ -248,6 +254,9 @@ pub async fn handle_trust_attestation_entry(
     own_did: &Did,
     rate_limiter: Option<&AttestationRateLimiter>,
 ) -> Result<()> {
+    // Issue #498: Track processing start time for propagation metrics
+    let process_start = Instant::now();
+
     // Decompress if needed
     let data = entry.get_data()?;
 
@@ -343,9 +352,21 @@ pub async fn handle_trust_attestation_entry(
 
     graph.add_edge(edge.clone())?;
 
+    // Issue #498: Record propagation metrics
+    let process_duration = process_start.elapsed();
+    icn_obs::metrics::trust::propagation_remote_record(process_duration.as_secs_f64());
+
+    // Calculate sync lag (how old was the attestation when we processed it)
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let sync_lag = now_secs.saturating_sub(attestation.created_at) as f64;
+    icn_obs::metrics::trust::sync_lag_set(sync_lag);
+
     info!(
-        "Applied remote trust attestation: {} -> {} (score: {})",
-        edge.source, edge.target, edge.score
+        "Applied remote trust attestation: {} -> {} (score: {}, latency: {:?}, sync_lag: {}s)",
+        edge.source, edge.target, edge.score, process_duration, sync_lag
     );
 
     // Record metrics

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -1045,6 +1045,49 @@ impl Ledger {
         // Validate entry invariants (double-entry, frozen members, credit limits)
         self.validate_entry(&entry)?;
 
+        // Issue #499: Validate parent entries exist (hybrid causal ordering)
+        // For local operations (broadcast=true): reject if parents are missing
+        // For sync operations (broadcast=false): accept but track as orphan
+        if !entry.parents.is_empty() {
+            let missing_parents: Vec<_> = entry
+                .parents
+                .iter()
+                .filter(|parent_hash| {
+                    self.get_entry(parent_hash)
+                        .map(|opt| opt.is_none())
+                        .unwrap_or(true)
+                })
+                .collect();
+
+            if !missing_parents.is_empty() {
+                let missing_count = missing_parents.len();
+                icn_obs::metrics::ledger::missing_parents_add(missing_count as u64);
+
+                if broadcast {
+                    // Local operation: reject entry with missing parents
+                    icn_obs::metrics::ledger::entries_rejected_missing_parents_inc();
+                    warn!(
+                        entry_hash = %hash,
+                        missing_count = missing_count,
+                        missing_parents = ?missing_parents.iter().map(|h| h.to_hex()).collect::<Vec<_>>(),
+                        "Rejecting local entry with missing parent entries"
+                    );
+                    anyhow::bail!(
+                        "Entry {hash} references {missing_count} missing parent entries; ensure parents are committed first"
+                    );
+                } else {
+                    // Sync operation: accept but track as orphan
+                    icn_obs::metrics::ledger::orphan_entries_inc();
+                    debug!(
+                        entry_hash = %hash,
+                        missing_count = missing_count,
+                        "Accepting orphan entry from sync (missing {} parents)",
+                        missing_count
+                    );
+                }
+            }
+        }
+
         // Serialize and store
         let key = format!("{}{}", JOURNAL_PREFIX, hash.to_hex());
         let value = serde_json::to_vec(&entry)?;
@@ -2903,12 +2946,15 @@ impl Ledger {
 
     /// Validate a journal entry before accepting it
     ///
-    /// This is a simplified validation. A real implementation would:
-    /// - Verify signatures
-    /// - Check double-entry invariants (Σ debits == Σ credits per currency)
-    /// - Enforce credit limits
-    /// - Validate parent links in Merkle-DAG
-    /// - Check for frozen members (Issue #25)
+    /// This validates:
+    /// - Entry has at least one account delta
+    /// - Author and affected accounts are not frozen (Issue #25)
+    /// - Double-entry invariants (Σ debits == Σ credits per currency)
+    /// - Credit limits are respected
+    ///
+    /// Note: Parent validation (Merkle-DAG links) is done separately in
+    /// `append_entry_internal` with different behavior for local vs sync operations
+    /// (Issue #499: hybrid causal ordering).
     fn validate_entry(&mut self, entry: &JournalEntry) -> Result<()> {
         // Check that entry has at least one account delta
         if entry.accounts.is_empty() {
@@ -4058,5 +4104,117 @@ mod tests {
                 "Entries should be in descending timestamp order"
             );
         }
+    }
+
+    // Issue #499: Causal ordering tests
+
+    #[tokio::test]
+    async fn test_local_entry_with_missing_parent_rejected() {
+        let (mut ledger, _temp) = create_test_ledger();
+
+        let alice = KeyPair::generate().unwrap().did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        // Create an entry that references a non-existent parent
+        let fake_parent = ContentHash::from_bytes([0xDE; 32]);
+
+        let entry = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 10)
+            .credit(bob.clone(), "hours".to_string(), 10)
+            .add_parent(fake_parent)
+            .build()
+            .unwrap();
+
+        // Local append should fail due to missing parent
+        let result = ledger.append_entry(entry).await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("missing parent"),
+            "Error should mention missing parent: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sync_entry_with_missing_parent_accepted_as_orphan() {
+        let (mut ledger, _temp) = create_test_ledger();
+
+        let alice = KeyPair::generate().unwrap().did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        // Create an entry that references a non-existent parent
+        let fake_parent = ContentHash::from_bytes([0xDE; 32]);
+
+        let entry = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 10)
+            .credit(bob.clone(), "hours".to_string(), 10)
+            .add_parent(fake_parent)
+            .build()
+            .unwrap();
+
+        let hash = entry.id.clone().unwrap();
+
+        // Sync append should succeed (orphan tracking)
+        let result = ledger.append_entry_from_sync(entry).await;
+        assert!(result.is_ok(), "Sync entry should be accepted: {result:?}");
+
+        // Verify entry was stored
+        let stored = ledger.get_entry(&hash).unwrap();
+        assert!(stored.is_some(), "Entry should be stored as orphan");
+    }
+
+    #[tokio::test]
+    async fn test_entry_with_valid_parent_accepted() {
+        let (mut ledger, _temp) = create_test_ledger();
+
+        let alice = KeyPair::generate().unwrap().did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        // Create first entry (no parent)
+        let entry1 = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 10)
+            .credit(bob.clone(), "hours".to_string(), 10)
+            .build()
+            .unwrap();
+        let hash1 = entry1.id.clone().unwrap();
+        ledger.append_entry(entry1).await.unwrap();
+
+        // Create second entry referencing the first as parent
+        let entry2 = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 5)
+            .credit(bob.clone(), "hours".to_string(), 5)
+            .add_parent(hash1.clone())
+            .build()
+            .unwrap();
+        let hash2 = entry2.id.clone().unwrap();
+
+        // Local append should succeed since parent exists
+        let result = ledger.append_entry(entry2).await;
+        assert!(result.is_ok(), "Entry with valid parent should be accepted");
+
+        // Verify both entries exist
+        assert!(ledger.get_entry(&hash1).unwrap().is_some());
+        assert!(ledger.get_entry(&hash2).unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_entry_without_parents_accepted() {
+        let (mut ledger, _temp) = create_test_ledger();
+
+        let alice = KeyPair::generate().unwrap().did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        // Entry with no parents (genesis-style) should be accepted
+        let entry = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 10)
+            .credit(bob.clone(), "hours".to_string(), 10)
+            .build()
+            .unwrap();
+
+        let result = ledger.append_entry(entry).await;
+        assert!(
+            result.is_ok(),
+            "Entry without parents should be accepted: {result:?}"
+        );
     }
 }

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -693,6 +693,44 @@ pub fn init_descriptions() {
     describe_gauge!("icn_system_uptime_seconds", "System uptime in seconds");
     describe_gauge!("icn_system_actors_active", "Number of active actors");
 
+    // Supervisor metrics (Issue #493)
+    describe_counter!(
+        "icn_supervisor_errors_total",
+        "Total supervisor errors by operation type"
+    );
+    describe_counter!(
+        "icn_supervisor_startup_phases_total",
+        "Startup phase completions by phase name"
+    );
+    describe_gauge!(
+        "icn_supervisor_state",
+        "Supervisor state: 0=stopped, 1=starting, 2=running, 3=stopping"
+    );
+    describe_counter!(
+        "icn_supervisor_actors_spawned_total",
+        "Total actors spawned by actor type"
+    );
+    describe_counter!(
+        "icn_supervisor_actor_spawn_failures_total",
+        "Actor spawn failures by actor type"
+    );
+    describe_counter!(
+        "icn_supervisor_actor_restarts_total",
+        "Actor restart count by actor type"
+    );
+    describe_gauge!(
+        "icn_supervisor_actor_restart_backoff_seconds",
+        "Current restart backoff delay by actor"
+    );
+    describe_counter!(
+        "icn_supervisor_actor_restart_limit_exceeded_total",
+        "Times an actor exceeded max restart attempts"
+    );
+    describe_gauge!(
+        "icn_supervisor_actor_active",
+        "Whether actor is currently active (1=active, 0=inactive)"
+    );
+
     // Core infrastructure metrics (dead-letter queue)
     describe_counter!(
         "icn_core_dead_letter_enqueued_total",
@@ -3877,6 +3915,15 @@ pub mod supervisor {
             "actor" => actor.to_string()
         )
         .increment(1);
+    }
+
+    /// Issue #493: Set actor active state (1=active, 0=inactive)
+    pub fn actor_active_set(actor: &str, active: bool) {
+        gauge!(
+            "icn_supervisor_actor_active",
+            "actor" => actor.to_string()
+        )
+        .set(if active { 1.0 } else { 0.0 });
     }
 }
 

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -1674,6 +1674,20 @@ pub fn init_descriptions() {
         "icn_ledger_dynamic_limit_recalculations_total",
         "Total times a limit was recalculated due to trust changes"
     );
+
+    // Causal ordering metrics (Issue #499)
+    describe_counter!(
+        "icn_ledger_orphan_entries_total",
+        "Total entries accepted without all parent entries present"
+    );
+    describe_counter!(
+        "icn_ledger_missing_parents_total",
+        "Total missing parent entries encountered"
+    );
+    describe_counter!(
+        "icn_ledger_entries_rejected_missing_parents_total",
+        "Total local entries rejected due to missing parents"
+    );
 }
 
 /// Network metrics
@@ -2228,6 +2242,21 @@ pub mod ledger {
     /// Increment counter when a limit is recalculated (trust change, etc.)
     pub fn dynamic_limit_recalculations_inc() {
         counter!("icn_ledger_dynamic_limit_recalculations_total").increment(1);
+    }
+
+    /// Issue #499: Increment counter when an entry is accepted without all parents present
+    pub fn orphan_entries_inc() {
+        counter!("icn_ledger_orphan_entries_total").increment(1);
+    }
+
+    /// Issue #499: Increment counter for each missing parent entry encountered
+    pub fn missing_parents_add(count: u64) {
+        counter!("icn_ledger_missing_parents_total").increment(count);
+    }
+
+    /// Issue #499: Increment counter when a local entry is rejected due to missing parents
+    pub fn entries_rejected_missing_parents_inc() {
+        counter!("icn_ledger_entries_rejected_missing_parents_total").increment(1);
     }
 }
 

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -559,6 +559,24 @@ pub fn init_descriptions() {
         "Trust score distribution by graph type"
     );
 
+    // Trust propagation metrics (Issue #498)
+    describe_histogram!(
+        "icn_trust_propagation_local_seconds",
+        "Time from trust attestation creation to gossip publish (local node)"
+    );
+    describe_histogram!(
+        "icn_trust_propagation_remote_seconds",
+        "Time from gossip receive to trust graph update (remote attestation)"
+    );
+    describe_gauge!(
+        "icn_trust_sync_lag_seconds",
+        "Trust sync lag based on attestation timestamp vs receive time"
+    );
+    describe_gauge!(
+        "icn_trust_updates_pending",
+        "Number of trust updates pending processing"
+    );
+
     // Contract metrics
     describe_gauge!(
         "icn_contract_installed_total",
@@ -2492,6 +2510,30 @@ pub mod trust {
     /// Issue #181: Increment trust computation errors counter
     pub fn computation_errors_inc() {
         counter!("icn_trust_computation_errors_total").increment(1);
+    }
+
+    // ========================================
+    // Propagation metrics (Issue #498)
+    // ========================================
+
+    /// Record time from attestation creation to gossip publish (local node)
+    pub fn propagation_local_record(duration_secs: f64) {
+        histogram!("icn_trust_propagation_local_seconds").record(duration_secs);
+    }
+
+    /// Record time from gossip receive to trust graph update (remote attestation)
+    pub fn propagation_remote_record(duration_secs: f64) {
+        histogram!("icn_trust_propagation_remote_seconds").record(duration_secs);
+    }
+
+    /// Set the trust sync lag based on attestation timestamp vs receive time
+    pub fn sync_lag_set(lag_secs: f64) {
+        gauge!("icn_trust_sync_lag_seconds").set(lag_secs);
+    }
+
+    /// Set the number of pending trust updates
+    pub fn updates_pending_set(count: u64) {
+        gauge!("icn_trust_updates_pending").set(count as f64);
     }
 }
 


### PR DESCRIPTION
## Summary

This PR addresses three issues with observability and ledger improvements:

### Issue #499: Hybrid Causal Ordering for Ledger
- **Local operations** (`append_entry`): Reject entries with missing parents
- **Sync operations** (`append_entry_from_sync`): Accept orphan entries, track via metrics
- Add metrics: `icn_ledger_orphan_entries_total`, `icn_ledger_missing_parents_total`
- Add 4 unit tests for parent validation behavior

### Issue #498: Trust Propagation Latency Monitoring
- `icn_trust_propagation_local_seconds`: Time from attestation creation to gossip publish
- `icn_trust_propagation_remote_seconds`: Time from gossip receive to trust graph update
- `icn_trust_sync_lag_seconds`: Lag based on attestation timestamp vs receive time

### Issue #493: Supervisor Health Metrics
- `icn_supervisor_actor_active{actor}`: Per-actor active state (1=active, 0=inactive)
- Add metric descriptions for all existing supervisor metrics
- Instrument core actors (gossip, ledger, coop, network, gateway)

## Test plan

- [x] All unit tests pass (`cargo test -p icn-ledger "parent"`)
- [x] All icn-core lib tests pass (129 tests)
- [x] Clippy passes with no warnings
- [x] Format check passes

Closes #499, Closes #498, Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)