### PR TITLE
feat(governance): Add federation governance proposals (Issue #514)

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -3015,6 +3015,7 @@ dependencies = [
  "async-trait",
  "hex",
  "icn-entity",
+ "icn-federation",
  "icn-identity",
  "icn-ledger",
  "icn-obs",

--- a/icn/crates/icn-core/src/supervisor/governance_handlers.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_handlers.rs
@@ -2447,6 +2447,8 @@ impl GovernanceEventHandler {
                     "   Terms: trust_threshold={}, governance_binding={}, data_sharing={:?}",
                     terms.min_trust_threshold, terms.governance_binding, terms.data_sharing_level
                 );
+                // TODO: Check if already a member (prevent duplicate join)
+                // TODO: Verify sponsor_coop_id is valid if provided
                 // TODO: Register with CooperativeRegistry, announce to federation:registry topic
                 icn_obs::metrics::governance::proposals_executed_inc("federation_join");
             }
@@ -2460,6 +2462,7 @@ impl GovernanceEventHandler {
                     federation_id, grace_period_days
                 );
                 info!("   Reason: {}", reason);
+                // TODO: Verify cooperative is actually a member of this federation
                 // TODO: Initiate wind-down, settle clearing balances, remove from registry
                 icn_obs::metrics::governance::proposals_executed_inc("federation_leave");
             }
@@ -2478,6 +2481,8 @@ impl GovernanceEventHandler {
                     "   Terms: max_imbalance={} {}, settlement={:?}",
                     max_imbalance, currency, settlement_interval
                 );
+                // TODO: Verify partner DID matches partner_coop_id via registry lookup
+                // TODO: Check if clearing agreement already exists (prevent duplicate)
                 // TODO: Create BilateralClearingAgreement via ClearingManager
                 icn_obs::metrics::governance::proposals_executed_inc(
                     "federation_establish_clearing",
@@ -2489,6 +2494,7 @@ impl GovernanceEventHandler {
             } => {
                 info!("   Action: Terminate clearing with '{}'", partner_coop_id);
                 info!("   Reason: {}", reason);
+                // TODO: Verify clearing agreement exists with this partner
                 // TODO: Settle outstanding balances and remove clearing agreement
                 icn_obs::metrics::governance::proposals_executed_inc(
                     "federation_terminate_clearing",
@@ -2509,6 +2515,8 @@ impl GovernanceEventHandler {
                 if let Some(ev) = evidence {
                     info!("   Evidence: {}", ev);
                 }
+                // TODO: Verify target DID matches target_coop_id via registry lookup
+                // TODO: Check if vouch already exists (update or reject duplicate)
                 // TODO: Create FederatedTrustAttestation via AttestationStore
                 icn_obs::metrics::governance::proposals_executed_inc("federation_vouch");
             }
@@ -2518,6 +2526,7 @@ impl GovernanceEventHandler {
             } => {
                 info!("   Action: Revoke vouch for '{}'", target_coop_id);
                 info!("   Reason: {}", reason);
+                // TODO: Verify vouch exists for this target
                 // TODO: Remove attestation from AttestationStore
                 icn_obs::metrics::governance::proposals_executed_inc("federation_revoke_vouch");
             }

--- a/icn/crates/icn-core/src/supervisor/governance_handlers.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_handlers.rs
@@ -381,6 +381,10 @@ impl GovernanceEventHandler {
                 );
                 // TODO: Open bond for subscription
             }
+            // Federation governance (Issue #514)
+            ProposalPayload::Federation(federation_proposal) => {
+                self.handle_federation_proposal(proposal_id, federation_proposal);
+            }
         }
     }
 
@@ -2407,6 +2411,133 @@ impl GovernanceEventHandler {
             _ => {
                 info!("   Action: Other SDIS operation");
                 icn_obs::metrics::governance::proposals_executed_inc("sdis_other");
+            }
+        }
+    }
+
+    /// Handle a federation governance proposal (Issue #514)
+    ///
+    /// Federation proposals enable governance-controlled management of inter-cooperative
+    /// relationships including joining/leaving federations, establishing clearing agreements,
+    /// and managing trust attestations.
+    fn handle_federation_proposal(
+        &self,
+        proposal_id: ProposalId,
+        proposal: icn_governance::FederationProposal,
+    ) {
+        use icn_governance::FederationProposal;
+
+        info!(
+            "🌐 Federation proposal {} accepted: {}",
+            proposal_id.0,
+            proposal.action_name()
+        );
+
+        match proposal {
+            FederationProposal::JoinFederation {
+                federation_id,
+                terms,
+                sponsor_coop_id,
+            } => {
+                info!(
+                    "   Action: Join federation '{}' (sponsor: {:?})",
+                    federation_id, sponsor_coop_id
+                );
+                info!(
+                    "   Terms: trust_threshold={}, governance_binding={}, data_sharing={:?}",
+                    terms.min_trust_threshold, terms.governance_binding, terms.data_sharing_level
+                );
+                // TODO: Register with CooperativeRegistry, announce to federation:registry topic
+                icn_obs::metrics::governance::proposals_executed_inc("federation_join");
+            }
+            FederationProposal::LeaveFederation {
+                federation_id,
+                reason,
+                grace_period_days,
+            } => {
+                info!(
+                    "   Action: Leave federation '{}' (grace period: {} days)",
+                    federation_id, grace_period_days
+                );
+                info!("   Reason: {}", reason);
+                // TODO: Initiate wind-down, settle clearing balances, remove from registry
+                icn_obs::metrics::governance::proposals_executed_inc("federation_leave");
+            }
+            FederationProposal::EstablishClearing {
+                partner_coop_id,
+                partner_coop_did,
+                max_imbalance,
+                settlement_interval,
+                currency,
+            } => {
+                info!(
+                    "   Action: Establish clearing with '{}' ({})",
+                    partner_coop_id, partner_coop_did
+                );
+                info!(
+                    "   Terms: max_imbalance={} {}, settlement={:?}",
+                    max_imbalance, currency, settlement_interval
+                );
+                // TODO: Create BilateralClearingAgreement via ClearingManager
+                icn_obs::metrics::governance::proposals_executed_inc(
+                    "federation_establish_clearing",
+                );
+            }
+            FederationProposal::TerminateClearing {
+                partner_coop_id,
+                reason,
+            } => {
+                info!("   Action: Terminate clearing with '{}'", partner_coop_id);
+                info!("   Reason: {}", reason);
+                // TODO: Settle outstanding balances and remove clearing agreement
+                icn_obs::metrics::governance::proposals_executed_inc(
+                    "federation_terminate_clearing",
+                );
+            }
+            FederationProposal::VouchForCooperative {
+                target_coop_id,
+                target_coop_did,
+                trust_score,
+                context,
+                evidence,
+            } => {
+                info!(
+                    "   Action: Vouch for '{}' ({}) with score {}",
+                    target_coop_id, target_coop_did, trust_score
+                );
+                info!("   Context: {}", context);
+                if let Some(ev) = evidence {
+                    info!("   Evidence: {}", ev);
+                }
+                // TODO: Create FederatedTrustAttestation via AttestationStore
+                icn_obs::metrics::governance::proposals_executed_inc("federation_vouch");
+            }
+            FederationProposal::RevokeVouch {
+                target_coop_id,
+                reason,
+            } => {
+                info!("   Action: Revoke vouch for '{}'", target_coop_id);
+                info!("   Reason: {}", reason);
+                // TODO: Remove attestation from AttestationStore
+                icn_obs::metrics::governance::proposals_executed_inc("federation_revoke_vouch");
+            }
+            FederationProposal::UpdateFederationPolicy {
+                auto_accept_vouch_threshold,
+                trust_decay_factor,
+                max_attestations_per_minute,
+            } => {
+                info!("   Action: Update federation policy");
+                if let Some(threshold) = auto_accept_vouch_threshold {
+                    info!("   Auto-accept vouch threshold: {}", threshold);
+                }
+                if let Some(decay) = trust_decay_factor {
+                    info!("   Trust decay factor: {}", decay);
+                }
+                if let Some(rate) = max_attestations_per_minute {
+                    info!("   Max attestations per minute: {}", rate);
+                }
+                // TODO: Update local federation configuration
+                icn_obs::metrics::governance::proposals_executed_inc("federation_update_policy");
             }
         }
     }

--- a/icn/crates/icn-governance/Cargo.toml
+++ b/icn/crates/icn-governance/Cargo.toml
@@ -12,6 +12,7 @@ async-trait = "0.1"
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
 icn-entity = { path = "../icn-entity" }
+icn-federation = { path = "../icn-federation" }
 icn-identity = { path = "../icn-identity" }
 icn-ledger = { path = "../icn-ledger" }
 icn-obs = { path = "../icn-obs" }

--- a/icn/crates/icn-governance/src/config.rs
+++ b/icn/crates/icn-governance/src/config.rs
@@ -138,7 +138,8 @@ impl GovernanceConfig {
             | ProposalPayload::ProtocolChange { .. }
             | ProposalPayload::SurplusAllocation { .. }
             | ProposalPayload::ShareRedemption { .. }
-            | ProposalPayload::BondIssuance { .. } => ProposalThresholds::new(
+            | ProposalPayload::BondIssuance { .. }
+            | ProposalPayload::Federation(_) => ProposalThresholds::new(
                 self.params.quorum_percentage,
                 self.params.approval_threshold_percentage,
             ),

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -107,8 +107,9 @@ pub use membership::{MembershipConfig, MembershipSource};
 pub use message::{GovernanceMessage, ProposalOutcome, TallySnapshot};
 pub use profile::{DecisionOutcome, GovernanceProfile, GovernanceProfileId, GovernanceRule};
 pub use proposal::{
-    DisputeResolutionOutcome, ForcedOutcome, MembershipAction, Proposal, ProposalId,
-    ProposalPayload, ProposalState, TreasuryApprovalType, TreasuryProposalOperation,
+    DataSharingLevel, DisputeResolutionMethod, DisputeResolutionOutcome, FederationProposal,
+    FederationTerms, ForcedOutcome, MembershipAction, Proposal, ProposalId, ProposalPayload,
+    ProposalState, TreasuryApprovalType, TreasuryProposalOperation,
 };
 pub use resolver::{MembershipResolver, StaticMembershipResolver};
 pub use sdis::{

--- a/icn/crates/icn-governance/src/proposal.rs
+++ b/icn/crates/icn-governance/src/proposal.rs
@@ -677,6 +677,21 @@ impl Default for FederationTerms {
     }
 }
 
+impl FederationTerms {
+    /// Validate the federation terms
+    ///
+    /// Returns an error message if validation fails.
+    pub fn validate(&self) -> Result<(), String> {
+        if !(0.0..=1.0).contains(&self.min_trust_threshold) {
+            let threshold = self.min_trust_threshold;
+            return Err(format!(
+                "min_trust_threshold must be between 0.0 and 1.0, got {threshold}"
+            ));
+        }
+        Ok(())
+    }
+}
+
 /// Level of data sharing agreed to in federation terms
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum DataSharingLevel {
@@ -812,6 +827,116 @@ impl FederationProposal {
             FederationProposal::RevokeVouch { .. } => "revoke_vouch",
             FederationProposal::UpdateFederationPolicy { .. } => "update_federation_policy",
         }
+    }
+
+    /// Validate the federation proposal
+    ///
+    /// Returns an error message if validation fails.
+    pub fn validate(&self) -> Result<(), String> {
+        match self {
+            FederationProposal::JoinFederation {
+                federation_id,
+                terms,
+                ..
+            } => {
+                if federation_id.is_empty() {
+                    return Err("federation_id cannot be empty".to_string());
+                }
+                terms.validate()?;
+            }
+            FederationProposal::LeaveFederation {
+                federation_id,
+                reason,
+                ..
+            } => {
+                if federation_id.is_empty() {
+                    return Err("federation_id cannot be empty".to_string());
+                }
+                if reason.is_empty() {
+                    return Err("reason cannot be empty".to_string());
+                }
+            }
+            FederationProposal::EstablishClearing {
+                partner_coop_id,
+                max_imbalance,
+                currency,
+                ..
+            } => {
+                if partner_coop_id.is_empty() {
+                    return Err("partner_coop_id cannot be empty".to_string());
+                }
+                if *max_imbalance <= 0 {
+                    return Err(format!(
+                        "max_imbalance must be positive, got {max_imbalance}"
+                    ));
+                }
+                if currency.is_empty() {
+                    return Err("currency cannot be empty".to_string());
+                }
+            }
+            FederationProposal::TerminateClearing {
+                partner_coop_id,
+                reason,
+            } => {
+                if partner_coop_id.is_empty() {
+                    return Err("partner_coop_id cannot be empty".to_string());
+                }
+                if reason.is_empty() {
+                    return Err("reason cannot be empty".to_string());
+                }
+            }
+            FederationProposal::VouchForCooperative {
+                target_coop_id,
+                trust_score,
+                context,
+                ..
+            } => {
+                if target_coop_id.is_empty() {
+                    return Err("target_coop_id cannot be empty".to_string());
+                }
+                if !(0.0..=1.0).contains(trust_score) {
+                    return Err(format!(
+                        "trust_score must be between 0.0 and 1.0, got {trust_score}"
+                    ));
+                }
+                if context.is_empty() {
+                    return Err("context cannot be empty".to_string());
+                }
+            }
+            FederationProposal::RevokeVouch {
+                target_coop_id,
+                reason,
+            } => {
+                if target_coop_id.is_empty() {
+                    return Err("target_coop_id cannot be empty".to_string());
+                }
+                if reason.is_empty() {
+                    return Err("reason cannot be empty".to_string());
+                }
+            }
+            FederationProposal::UpdateFederationPolicy {
+                auto_accept_vouch_threshold,
+                trust_decay_factor,
+                ..
+            } => {
+                if let Some(threshold) = auto_accept_vouch_threshold {
+                    // -1.0 is valid (means disabled), otherwise must be in [0.0, 1.0]
+                    if *threshold != -1.0 && !(0.0..=1.0).contains(threshold) {
+                        return Err(format!(
+                            "auto_accept_vouch_threshold must be -1.0 (disabled) or between 0.0 and 1.0, got {threshold}"
+                        ));
+                    }
+                }
+                if let Some(decay) = trust_decay_factor {
+                    if !(0.0..=1.0).contains(decay) {
+                        return Err(format!(
+                            "trust_decay_factor must be between 0.0 and 1.0, got {decay}"
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -1552,5 +1677,209 @@ mod tests {
             terms.dispute_resolution,
             DisputeResolutionMethod::FederationMediation
         );
+    }
+
+    #[test]
+    fn test_federation_terms_validation() {
+        // Valid terms
+        let valid_terms = FederationTerms::default();
+        assert!(valid_terms.validate().is_ok());
+
+        // Invalid trust threshold (too high)
+        let invalid_high = FederationTerms {
+            min_trust_threshold: 1.5,
+            ..Default::default()
+        };
+        assert!(invalid_high.validate().is_err());
+        assert!(invalid_high
+            .validate()
+            .unwrap_err()
+            .contains("min_trust_threshold"));
+
+        // Invalid trust threshold (negative)
+        let invalid_negative = FederationTerms {
+            min_trust_threshold: -0.1,
+            ..Default::default()
+        };
+        assert!(invalid_negative.validate().is_err());
+
+        // Edge cases that should be valid
+        let edge_zero = FederationTerms {
+            min_trust_threshold: 0.0,
+            ..Default::default()
+        };
+        assert!(edge_zero.validate().is_ok());
+
+        let edge_one = FederationTerms {
+            min_trust_threshold: 1.0,
+            ..Default::default()
+        };
+        assert!(edge_one.validate().is_ok());
+    }
+
+    #[test]
+    fn test_federation_proposal_validation() {
+        let target_did = KeyPair::generate().unwrap().did().clone();
+
+        // Valid vouch
+        let valid_vouch = FederationProposal::VouchForCooperative {
+            target_coop_id: "test-coop".to_string(),
+            target_coop_did: target_did.clone(),
+            trust_score: 0.8,
+            context: "trade".to_string(),
+            evidence: None,
+        };
+        assert!(valid_vouch.validate().is_ok());
+
+        // Invalid trust score (too high)
+        let invalid_score = FederationProposal::VouchForCooperative {
+            target_coop_id: "test-coop".to_string(),
+            target_coop_did: target_did.clone(),
+            trust_score: 1.5,
+            context: "trade".to_string(),
+            evidence: None,
+        };
+        assert!(invalid_score.validate().is_err());
+        assert!(invalid_score
+            .validate()
+            .unwrap_err()
+            .contains("trust_score"));
+
+        // Empty target_coop_id
+        let empty_id = FederationProposal::VouchForCooperative {
+            target_coop_id: "".to_string(),
+            target_coop_did: target_did.clone(),
+            trust_score: 0.5,
+            context: "trade".to_string(),
+            evidence: None,
+        };
+        assert!(empty_id.validate().is_err());
+        assert!(empty_id.validate().unwrap_err().contains("target_coop_id"));
+
+        // Empty context
+        let empty_context = FederationProposal::VouchForCooperative {
+            target_coop_id: "test-coop".to_string(),
+            target_coop_did: target_did.clone(),
+            trust_score: 0.5,
+            context: "".to_string(),
+            evidence: None,
+        };
+        assert!(empty_context.validate().is_err());
+
+        // Invalid max_imbalance (zero)
+        let zero_imbalance = FederationProposal::EstablishClearing {
+            partner_coop_id: "test-coop".to_string(),
+            partner_coop_did: target_did.clone(),
+            max_imbalance: 0,
+            settlement_interval: SettlementInterval::Weekly,
+            currency: "HOURS".to_string(),
+        };
+        assert!(zero_imbalance.validate().is_err());
+        assert!(zero_imbalance
+            .validate()
+            .unwrap_err()
+            .contains("max_imbalance"));
+
+        // Valid policy update with -1.0 (disabled)
+        let valid_policy = FederationProposal::UpdateFederationPolicy {
+            auto_accept_vouch_threshold: Some(-1.0),
+            trust_decay_factor: Some(0.5),
+            max_attestations_per_minute: Some(10),
+        };
+        assert!(valid_policy.validate().is_ok());
+
+        // Invalid policy update
+        let invalid_policy = FederationProposal::UpdateFederationPolicy {
+            auto_accept_vouch_threshold: Some(-0.5), // not -1.0 and not in [0,1]
+            trust_decay_factor: None,
+            max_attestations_per_minute: None,
+        };
+        assert!(invalid_policy.validate().is_err());
+    }
+
+    #[test]
+    fn test_federation_proposal_serialization_roundtrip() {
+        let target_did = KeyPair::generate().unwrap().did().clone();
+
+        let proposals = vec![
+            FederationProposal::JoinFederation {
+                federation_id: "test-fed".to_string(),
+                terms: FederationTerms::default(),
+                sponsor_coop_id: Some("sponsor".to_string()),
+            },
+            FederationProposal::LeaveFederation {
+                federation_id: "test-fed".to_string(),
+                reason: "Strategic change".to_string(),
+                grace_period_days: 30,
+            },
+            FederationProposal::EstablishClearing {
+                partner_coop_id: "partner".to_string(),
+                partner_coop_did: target_did.clone(),
+                max_imbalance: 50000,
+                settlement_interval: SettlementInterval::Weekly,
+                currency: "HOURS".to_string(),
+            },
+            FederationProposal::VouchForCooperative {
+                target_coop_id: "target".to_string(),
+                target_coop_did: target_did,
+                trust_score: 0.75,
+                context: "trade".to_string(),
+                evidence: Some("Good history".to_string()),
+            },
+        ];
+
+        for proposal in proposals {
+            let json = serde_json::to_string(&proposal).unwrap();
+            let deserialized: FederationProposal = serde_json::from_str(&json).unwrap();
+            assert_eq!(proposal.action_name(), deserialized.action_name());
+        }
+    }
+
+    #[test]
+    fn test_federation_terms_serialization_roundtrip() {
+        let terms = FederationTerms {
+            min_trust_threshold: 0.7,
+            governance_binding: true,
+            data_sharing_level: DataSharingLevel::Full,
+            dispute_resolution: DisputeResolutionMethod::FederationVote,
+        };
+
+        let json = serde_json::to_string(&terms).unwrap();
+        let deserialized: FederationTerms = serde_json::from_str(&json).unwrap();
+
+        assert!((terms.min_trust_threshold - deserialized.min_trust_threshold).abs() < 0.001);
+        assert_eq!(terms.governance_binding, deserialized.governance_binding);
+        assert_eq!(terms.data_sharing_level, deserialized.data_sharing_level);
+        assert_eq!(terms.dispute_resolution, deserialized.dispute_resolution);
+    }
+
+    #[test]
+    fn test_data_sharing_level_serialization() {
+        for level in [
+            DataSharingLevel::None,
+            DataSharingLevel::MetadataOnly,
+            DataSharingLevel::Full,
+        ] {
+            let json = serde_json::to_string(&level).unwrap();
+            let deserialized: DataSharingLevel = serde_json::from_str(&json).unwrap();
+            assert_eq!(level, deserialized);
+        }
+    }
+
+    #[test]
+    fn test_dispute_resolution_method_serialization() {
+        let methods = vec![
+            DisputeResolutionMethod::FederationMediation,
+            DisputeResolutionMethod::ArbitratorCooperative {
+                arbitrator_id: "arbitrator-coop".to_string(),
+            },
+            DisputeResolutionMethod::FederationVote,
+        ];
+
+        for method in methods {
+            let json = serde_json::to_string(&method).unwrap();
+            let deserialized: DisputeResolutionMethod = serde_json::from_str(&json).unwrap();
+            assert_eq!(method, deserialized);
+        }
     }
 }

--- a/icn/crates/icn-governance/src/proposal.rs
+++ b/icn/crates/icn-governance/src/proposal.rs
@@ -688,6 +688,19 @@ impl FederationTerms {
                 "min_trust_threshold must be between 0.0 and 1.0, got {threshold}"
             ));
         }
+
+        // Validate dispute resolution-specific fields
+        if let DisputeResolutionMethod::ArbitratorCooperative { arbitrator_id } =
+            &self.dispute_resolution
+        {
+            if arbitrator_id.is_empty() {
+                return Err(
+                    "arbitrator_id must be non-empty when using ArbitratorCooperative dispute resolution"
+                        .to_string(),
+                );
+            }
+        }
+
         Ok(())
     }
 }
@@ -929,7 +942,7 @@ impl FederationProposal {
             FederationProposal::UpdateFederationPolicy {
                 auto_accept_vouch_threshold,
                 trust_decay_factor,
-                ..
+                max_attestations_per_minute,
             } => {
                 if let Some(threshold) = auto_accept_vouch_threshold {
                     // -1.0 is valid (means disabled), otherwise must be in [0.0, 1.0]
@@ -944,6 +957,13 @@ impl FederationProposal {
                         return Err(format!(
                             "trust_decay_factor must be between 0.0 and 1.0, got {decay}"
                         ));
+                    }
+                }
+                if let Some(rate) = max_attestations_per_minute {
+                    if *rate == 0 {
+                        return Err(
+                            "max_attestations_per_minute must be greater than 0".to_string()
+                        );
                     }
                 }
             }
@@ -1677,6 +1697,34 @@ mod tests {
             .action_name(),
             "vouch_for_cooperative"
         );
+
+        assert_eq!(
+            FederationProposal::TerminateClearing {
+                partner_coop_id: "test".to_string(),
+                reason: "ending partnership".to_string(),
+            }
+            .action_name(),
+            "terminate_clearing"
+        );
+
+        assert_eq!(
+            FederationProposal::RevokeVouch {
+                target_coop_id: "test".to_string(),
+                reason: "trust violation".to_string(),
+            }
+            .action_name(),
+            "revoke_vouch"
+        );
+
+        assert_eq!(
+            FederationProposal::UpdateFederationPolicy {
+                auto_accept_vouch_threshold: Some(0.5),
+                trust_decay_factor: None,
+                max_attestations_per_minute: None,
+            }
+            .action_name(),
+            "update_federation_policy"
+        );
     }
 
     #[test]
@@ -1727,6 +1775,28 @@ mod tests {
             ..Default::default()
         };
         assert!(edge_one.validate().is_ok());
+
+        // ArbitratorCooperative with empty arbitrator_id
+        let empty_arbitrator = FederationTerms {
+            dispute_resolution: DisputeResolutionMethod::ArbitratorCooperative {
+                arbitrator_id: "".to_string(),
+            },
+            ..Default::default()
+        };
+        assert!(empty_arbitrator.validate().is_err());
+        assert!(empty_arbitrator
+            .validate()
+            .unwrap_err()
+            .contains("arbitrator_id"));
+
+        // ArbitratorCooperative with valid arbitrator_id
+        let valid_arbitrator = FederationTerms {
+            dispute_resolution: DisputeResolutionMethod::ArbitratorCooperative {
+                arbitrator_id: "arbitrator-coop".to_string(),
+            },
+            ..Default::default()
+        };
+        assert!(valid_arbitrator.validate().is_ok());
     }
 
     #[test]
@@ -1842,6 +1912,85 @@ mod tests {
             grace_period_days: 365,
         };
         assert!(max_grace.validate().is_ok());
+
+        // JoinFederation validation - empty federation_id
+        let empty_fed_id = FederationProposal::JoinFederation {
+            federation_id: "".to_string(),
+            terms: FederationTerms::default(),
+            sponsor_coop_id: None,
+        };
+        assert!(empty_fed_id.validate().is_err());
+        assert!(empty_fed_id
+            .validate()
+            .unwrap_err()
+            .contains("federation_id"));
+
+        // JoinFederation validation - invalid terms
+        let invalid_terms_join = FederationProposal::JoinFederation {
+            federation_id: "test-fed".to_string(),
+            terms: FederationTerms {
+                min_trust_threshold: 1.5, // invalid
+                ..Default::default()
+            },
+            sponsor_coop_id: None,
+        };
+        assert!(invalid_terms_join.validate().is_err());
+
+        // TerminateClearing validation - empty partner_coop_id
+        let empty_partner_terminate = FederationProposal::TerminateClearing {
+            partner_coop_id: "".to_string(),
+            reason: "Ending partnership".to_string(),
+        };
+        assert!(empty_partner_terminate.validate().is_err());
+        assert!(empty_partner_terminate
+            .validate()
+            .unwrap_err()
+            .contains("partner_coop_id"));
+
+        // TerminateClearing validation - empty reason
+        let empty_reason_terminate = FederationProposal::TerminateClearing {
+            partner_coop_id: "partner-coop".to_string(),
+            reason: "".to_string(),
+        };
+        assert!(empty_reason_terminate.validate().is_err());
+        assert!(empty_reason_terminate
+            .validate()
+            .unwrap_err()
+            .contains("reason"));
+
+        // RevokeVouch validation - empty target_coop_id
+        let empty_target_revoke = FederationProposal::RevokeVouch {
+            target_coop_id: "".to_string(),
+            reason: "Trust violation".to_string(),
+        };
+        assert!(empty_target_revoke.validate().is_err());
+        assert!(empty_target_revoke
+            .validate()
+            .unwrap_err()
+            .contains("target_coop_id"));
+
+        // RevokeVouch validation - empty reason
+        let empty_reason_revoke = FederationProposal::RevokeVouch {
+            target_coop_id: "target-coop".to_string(),
+            reason: "".to_string(),
+        };
+        assert!(empty_reason_revoke.validate().is_err());
+        assert!(empty_reason_revoke
+            .validate()
+            .unwrap_err()
+            .contains("reason"));
+
+        // UpdateFederationPolicy - max_attestations_per_minute = 0
+        let zero_attestations = FederationProposal::UpdateFederationPolicy {
+            auto_accept_vouch_threshold: None,
+            trust_decay_factor: None,
+            max_attestations_per_minute: Some(0),
+        };
+        assert!(zero_attestations.validate().is_err());
+        assert!(zero_attestations
+            .validate()
+            .unwrap_err()
+            .contains("max_attestations_per_minute"));
     }
 
     #[test]
@@ -1872,6 +2021,19 @@ mod tests {
                 trust_score: 0.75,
                 context: "trade".to_string(),
                 evidence: Some("Good history".to_string()),
+            },
+            FederationProposal::TerminateClearing {
+                partner_coop_id: "partner".to_string(),
+                reason: "Partnership ended".to_string(),
+            },
+            FederationProposal::RevokeVouch {
+                target_coop_id: "target".to_string(),
+                reason: "Trust violation".to_string(),
+            },
+            FederationProposal::UpdateFederationPolicy {
+                auto_accept_vouch_threshold: Some(0.7),
+                trust_decay_factor: Some(0.05),
+                max_attestations_per_minute: Some(30),
             },
         ];
 

--- a/icn/crates/icn-governance/src/proposal.rs
+++ b/icn/crates/icn-governance/src/proposal.rs
@@ -2,6 +2,7 @@
 
 use crate::domain::GovernanceDomainId;
 use crate::Timestamp;
+use icn_federation::SettlementInterval;
 use icn_identity::Did;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -386,6 +387,17 @@ pub enum ProposalPayload {
         /// The bond offering details
         bond_offering: icn_ledger::BondOffering,
     },
+
+    // === Federation Governance (Issue #514) ===
+    /// Federation relationship management
+    ///
+    /// Enables governance-controlled management of federation relationships
+    /// including joining/leaving federations, establishing clearing agreements,
+    /// and vouching for other cooperatives.
+    ///
+    /// Federation actions require member approval to ensure democratic control
+    /// over inter-cooperative relationships.
+    Federation(FederationProposal),
 }
 
 impl ProposalPayload {
@@ -410,6 +422,7 @@ impl ProposalPayload {
             ProposalPayload::SurplusAllocation { .. } => "surplus_allocation",
             ProposalPayload::ShareRedemption { .. } => "share_redemption",
             ProposalPayload::BondIssuance { .. } => "bond_issuance",
+            ProposalPayload::Federation(_) => "federation",
         }
     }
 
@@ -634,6 +647,172 @@ pub enum ForcedOutcome {
 pub enum MembershipAction {
     Add,
     Remove,
+}
+
+// === Federation Governance (Issue #514) ===
+
+/// Terms for joining a federation
+///
+/// Specifies the obligations and expectations when a cooperative joins a federation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FederationTerms {
+    /// Required trust threshold for federation membership
+    pub min_trust_threshold: f64,
+    /// Whether the cooperative agrees to follow federation governance
+    pub governance_binding: bool,
+    /// Data sharing level (none, metadata_only, full)
+    pub data_sharing_level: DataSharingLevel,
+    /// Dispute resolution method
+    pub dispute_resolution: DisputeResolutionMethod,
+}
+
+impl Default for FederationTerms {
+    fn default() -> Self {
+        Self {
+            min_trust_threshold: 0.5,
+            governance_binding: true,
+            data_sharing_level: DataSharingLevel::MetadataOnly,
+            dispute_resolution: DisputeResolutionMethod::FederationMediation,
+        }
+    }
+}
+
+/// Level of data sharing agreed to in federation terms
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum DataSharingLevel {
+    /// No automatic data sharing
+    None,
+    /// Share metadata only (activity summaries, not individual transactions)
+    #[default]
+    MetadataOnly,
+    /// Full transparency (all ledger data visible to federation)
+    Full,
+}
+
+/// Method for resolving disputes within a federation
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum DisputeResolutionMethod {
+    /// Disputes escalate to federation mediators
+    #[default]
+    FederationMediation,
+    /// Disputes resolved by designated arbitrator cooperative
+    ArbitratorCooperative { arbitrator_id: String },
+    /// Disputes resolved by member vote across federation
+    FederationVote,
+}
+
+/// Federation-related governance proposals
+///
+/// These proposals enable governance-controlled management of federation relationships.
+/// All federation actions require member approval through the proposal system.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum FederationProposal {
+    /// Join an existing federation network
+    ///
+    /// Requires member approval as it commits the cooperative to federation rules.
+    /// The cooperative will be announced to the federation registry upon approval.
+    JoinFederation {
+        /// Federation network identifier
+        federation_id: String,
+        /// Terms agreed to for joining
+        terms: FederationTerms,
+        /// Optional sponsor cooperative that vouches for the joining coop
+        sponsor_coop_id: Option<String>,
+    },
+
+    /// Leave a federation network
+    ///
+    /// Triggers wind-down process including settlement of pending clearing balances.
+    /// The cooperative will be removed from the federation registry.
+    LeaveFederation {
+        /// Federation network identifier
+        federation_id: String,
+        /// Reason for leaving
+        reason: String,
+        /// Grace period in days before full departure (for settlement)
+        grace_period_days: u32,
+    },
+
+    /// Establish bilateral clearing agreement with another cooperative
+    ///
+    /// Sets up the ability to transact across cooperative boundaries with
+    /// periodic settlement of balances.
+    EstablishClearing {
+        /// Partner cooperative's identifier
+        partner_coop_id: String,
+        /// Partner cooperative's DID
+        partner_coop_did: Did,
+        /// Maximum credit imbalance before requiring settlement
+        max_imbalance: i64,
+        /// How often to settle balances
+        settlement_interval: SettlementInterval,
+        /// Currency for the clearing arrangement
+        currency: String,
+    },
+
+    /// Terminate an existing clearing agreement
+    ///
+    /// Requires settling all outstanding balances before termination.
+    TerminateClearing {
+        /// Partner cooperative's identifier
+        partner_coop_id: String,
+        /// Reason for termination
+        reason: String,
+    },
+
+    /// Vouch for another cooperative's trustworthiness
+    ///
+    /// Creates a federated trust attestation that other cooperatives can use
+    /// when evaluating the target cooperative.
+    VouchForCooperative {
+        /// Cooperative being vouched for
+        target_coop_id: String,
+        /// Target cooperative's DID
+        target_coop_did: Did,
+        /// Trust score (0.0 to 1.0) being attested
+        trust_score: f64,
+        /// Context for the vouch (e.g., "trade", "governance", "technical")
+        context: String,
+        /// Optional evidence/justification
+        evidence: Option<String>,
+    },
+
+    /// Revoke a previous vouch for a cooperative
+    ///
+    /// Removes the trust attestation, affecting the target's federated trust score.
+    RevokeVouch {
+        /// Cooperative whose vouch is being revoked
+        target_coop_id: String,
+        /// Reason for revocation
+        reason: String,
+    },
+
+    /// Update federation policy for the cooperative
+    ///
+    /// Modifies how the cooperative participates in federation activities.
+    UpdateFederationPolicy {
+        /// New auto-accept threshold for incoming vouches (-1.0 to disable)
+        auto_accept_vouch_threshold: Option<f64>,
+        /// New default trust decay factor for attestations
+        trust_decay_factor: Option<f64>,
+        /// New maximum attestations per minute (rate limiting)
+        max_attestations_per_minute: Option<u32>,
+    },
+}
+
+impl FederationProposal {
+    /// Get a descriptive name for the federation action
+    pub fn action_name(&self) -> &'static str {
+        match self {
+            FederationProposal::JoinFederation { .. } => "join_federation",
+            FederationProposal::LeaveFederation { .. } => "leave_federation",
+            FederationProposal::EstablishClearing { .. } => "establish_clearing",
+            FederationProposal::TerminateClearing { .. } => "terminate_clearing",
+            FederationProposal::VouchForCooperative { .. } => "vouch_for_cooperative",
+            FederationProposal::RevokeVouch { .. } => "revoke_vouch",
+            FederationProposal::UpdateFederationPolicy { .. } => "update_federation_policy",
+        }
+    }
 }
 
 /// A proposal for a decision
@@ -1187,5 +1366,191 @@ mod tests {
             ProposalPayload::BondIssuance { ref bond_offering }
             if bond_offering.principal_requested == 500_000 && bond_offering.interest_rate_bps == 300
         ));
+    }
+
+    // ========== Federation Proposal Tests (Issue #514) ==========
+
+    #[test]
+    fn test_federation_join_proposal() {
+        let kp = KeyPair::generate().unwrap();
+        let did = kp.did().clone();
+        let domain_id = GovernanceDomainId::new("test-coop");
+
+        let terms = FederationTerms {
+            min_trust_threshold: 0.6,
+            governance_binding: true,
+            data_sharing_level: DataSharingLevel::MetadataOnly,
+            dispute_resolution: DisputeResolutionMethod::FederationMediation,
+        };
+
+        let proposal = Proposal::new(
+            domain_id,
+            did,
+            "Join Regional Food Federation".to_string(),
+            "Proposal to join the regional food cooperative federation".to_string(),
+            ProposalPayload::Federation(FederationProposal::JoinFederation {
+                federation_id: "regional-food-fed".to_string(),
+                terms: terms.clone(),
+                sponsor_coop_id: Some("organic-farms-coop".to_string()),
+            }),
+        );
+
+        assert_eq!(proposal.title, "Join Regional Food Federation");
+        assert!(matches!(
+            proposal.payload,
+            ProposalPayload::Federation(FederationProposal::JoinFederation { ref federation_id, .. })
+            if federation_id == "regional-food-fed"
+        ));
+    }
+
+    #[test]
+    fn test_federation_establish_clearing_proposal() {
+        let kp = KeyPair::generate().unwrap();
+        let did = kp.did().clone();
+        let domain_id = GovernanceDomainId::new("test-coop");
+
+        let partner_kp = KeyPair::generate().unwrap();
+        let partner_did = partner_kp.did().clone();
+
+        let proposal = Proposal::new(
+            domain_id,
+            did,
+            "Establish Clearing with Farm Coop".to_string(),
+            "Set up bilateral clearing for cross-coop transactions".to_string(),
+            ProposalPayload::Federation(FederationProposal::EstablishClearing {
+                partner_coop_id: "farm-coop".to_string(),
+                partner_coop_did: partner_did.clone(),
+                max_imbalance: 50_000,
+                settlement_interval: SettlementInterval::Weekly,
+                currency: "HOURS".to_string(),
+            }),
+        );
+
+        assert!(matches!(
+            proposal.payload,
+            ProposalPayload::Federation(FederationProposal::EstablishClearing {
+                ref partner_coop_id,
+                max_imbalance,
+                ..
+            })
+            if partner_coop_id == "farm-coop" && max_imbalance == 50_000
+        ));
+    }
+
+    #[test]
+    fn test_federation_vouch_proposal() {
+        let kp = KeyPair::generate().unwrap();
+        let did = kp.did().clone();
+        let domain_id = GovernanceDomainId::new("test-coop");
+
+        let target_kp = KeyPair::generate().unwrap();
+        let target_did = target_kp.did().clone();
+
+        let proposal = Proposal::new(
+            domain_id,
+            did,
+            "Vouch for New Coop".to_string(),
+            "Vouch for the newly formed worker cooperative".to_string(),
+            ProposalPayload::Federation(FederationProposal::VouchForCooperative {
+                target_coop_id: "new-worker-coop".to_string(),
+                target_coop_did: target_did.clone(),
+                trust_score: 0.75,
+                context: "trade".to_string(),
+                evidence: Some(
+                    "We have been trading with them successfully for 6 months".to_string(),
+                ),
+            }),
+        );
+
+        assert!(matches!(
+            proposal.payload,
+            ProposalPayload::Federation(FederationProposal::VouchForCooperative {
+                trust_score,
+                ref context,
+                ..
+            })
+            if (trust_score - 0.75).abs() < 0.001 && context == "trade"
+        ));
+    }
+
+    #[test]
+    fn test_federation_proposal_type_name() {
+        let kp = KeyPair::generate().unwrap();
+        let did = kp.did().clone();
+        let domain_id = GovernanceDomainId::new("test-coop");
+
+        let proposal = Proposal::new(
+            domain_id,
+            did,
+            "Federation Test".to_string(),
+            "Test proposal".to_string(),
+            ProposalPayload::Federation(FederationProposal::LeaveFederation {
+                federation_id: "test-fed".to_string(),
+                reason: "Strategic realignment".to_string(),
+                grace_period_days: 30,
+            }),
+        );
+
+        assert_eq!(proposal.payload.type_name(), "federation");
+    }
+
+    #[test]
+    fn test_federation_proposal_action_names() {
+        assert_eq!(
+            FederationProposal::JoinFederation {
+                federation_id: "test".to_string(),
+                terms: FederationTerms::default(),
+                sponsor_coop_id: None,
+            }
+            .action_name(),
+            "join_federation"
+        );
+
+        assert_eq!(
+            FederationProposal::LeaveFederation {
+                federation_id: "test".to_string(),
+                reason: "test".to_string(),
+                grace_period_days: 30,
+            }
+            .action_name(),
+            "leave_federation"
+        );
+
+        let target_did = KeyPair::generate().unwrap().did().clone();
+        assert_eq!(
+            FederationProposal::EstablishClearing {
+                partner_coop_id: "test".to_string(),
+                partner_coop_did: target_did.clone(),
+                max_imbalance: 1000,
+                settlement_interval: SettlementInterval::Daily,
+                currency: "HOURS".to_string(),
+            }
+            .action_name(),
+            "establish_clearing"
+        );
+
+        assert_eq!(
+            FederationProposal::VouchForCooperative {
+                target_coop_id: "test".to_string(),
+                target_coop_did: target_did,
+                trust_score: 0.8,
+                context: "trade".to_string(),
+                evidence: None,
+            }
+            .action_name(),
+            "vouch_for_cooperative"
+        );
+    }
+
+    #[test]
+    fn test_federation_terms_default() {
+        let terms = FederationTerms::default();
+        assert!((terms.min_trust_threshold - 0.5).abs() < 0.001);
+        assert!(terms.governance_binding);
+        assert_eq!(terms.data_sharing_level, DataSharingLevel::MetadataOnly);
+        assert_eq!(
+            terms.dispute_resolution,
+            DisputeResolutionMethod::FederationMediation
+        );
     }
 }

--- a/icn/crates/icn-governance/src/proposal.rs
+++ b/icn/crates/icn-governance/src/proposal.rs
@@ -832,6 +832,12 @@ impl FederationProposal {
     /// Validate the federation proposal
     ///
     /// Returns an error message if validation fails.
+    ///
+    /// Note: This performs structural validation only. Full validation
+    /// (e.g., verifying that a DID corresponds to a cooperative ID, or
+    /// checking for existing memberships/agreements) requires federation
+    /// registry lookup and should be done at proposal creation time by
+    /// the gateway or at execution time by the handler.
     pub fn validate(&self) -> Result<(), String> {
         match self {
             FederationProposal::JoinFederation {
@@ -847,13 +853,19 @@ impl FederationProposal {
             FederationProposal::LeaveFederation {
                 federation_id,
                 reason,
-                ..
+                grace_period_days,
             } => {
                 if federation_id.is_empty() {
                     return Err("federation_id cannot be empty".to_string());
                 }
                 if reason.is_empty() {
                     return Err("reason cannot be empty".to_string());
+                }
+                if *grace_period_days == 0 {
+                    return Err("grace_period_days must be at least 1".to_string());
+                }
+                if *grace_period_days > 365 {
+                    return Err("grace_period_days cannot exceed 365".to_string());
                 }
             }
             FederationProposal::EstablishClearing {
@@ -1795,6 +1807,41 @@ mod tests {
             max_attestations_per_minute: None,
         };
         assert!(invalid_policy.validate().is_err());
+
+        // Invalid grace_period_days (zero)
+        let zero_grace = FederationProposal::LeaveFederation {
+            federation_id: "test-fed".to_string(),
+            reason: "Leaving".to_string(),
+            grace_period_days: 0,
+        };
+        assert!(zero_grace.validate().is_err());
+        assert!(zero_grace
+            .validate()
+            .unwrap_err()
+            .contains("grace_period_days"));
+
+        // Invalid grace_period_days (too long)
+        let long_grace = FederationProposal::LeaveFederation {
+            federation_id: "test-fed".to_string(),
+            reason: "Leaving".to_string(),
+            grace_period_days: 500,
+        };
+        assert!(long_grace.validate().is_err());
+
+        // Valid grace_period_days (edge cases)
+        let min_grace = FederationProposal::LeaveFederation {
+            federation_id: "test-fed".to_string(),
+            reason: "Leaving".to_string(),
+            grace_period_days: 1,
+        };
+        assert!(min_grace.validate().is_ok());
+
+        let max_grace = FederationProposal::LeaveFederation {
+            federation_id: "test-fed".to_string(),
+            reason: "Leaving".to_string(),
+            grace_period_days: 365,
+        };
+        assert!(max_grace.validate().is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds governance-controlled federation relationship management, enabling cooperatives to manage inter-cooperative relationships through the proposal system.

## Changes

### New Types (icn-governance/src/proposal.rs)
- `FederationProposal` enum with 7 variants:
  - `JoinFederation` - Join a federation network with agreed terms
  - `LeaveFederation` - Leave a federation with grace period
  - `EstablishClearing` - Set up bilateral clearing agreement
  - `TerminateClearing` - End a clearing agreement
  - `VouchForCooperative` - Create federated trust attestation
  - `RevokeVouch` - Remove a trust attestation
  - `UpdateFederationPolicy` - Modify federation participation settings
- `FederationTerms` struct for join parameters
- `DataSharingLevel` enum (None, MetadataOnly, Full)
- `DisputeResolutionMethod` enum (FederationMediation, ArbitratorCooperative, FederationVote)

### Integration
- `ProposalPayload::Federation(FederationProposal)` variant
- Execution hook in `governance_handlers.rs` with metrics for each action type
- Uses `SettlementInterval` from `icn-federation` crate

### Tests
- 6 new unit tests covering:
  - Federation join proposal creation
  - Establish clearing proposal creation
  - Vouch proposal creation
  - Federation proposal type_name
  - Federation proposal action_names
  - FederationTerms default values

## What's Deferred
- Actual integration with `CooperativeRegistry` and `ClearingManager` (marked with TODOs)
- Gateway REST API endpoints for creating federation proposals
- Integration tests with real federation layer

## Test plan

- [x] All 319 governance unit tests pass
- [x] All workspace tests pass (600+)
- [x] Clippy clean with `-D warnings`
- [x] Code formatted with `cargo fmt`

Closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)