### PR TITLE
feat(gateway): Add REST API endpoints for federation proposals

### DIFF
--- a/icn/crates/icn-gateway/src/api/governance.rs
+++ b/icn/crates/icn-gateway/src/api/governance.rs
@@ -3616,4 +3616,720 @@ mod tests {
         let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status(), 200); // Success
     }
+
+    // ============================================================================
+    // Federation Proposal Tests
+    // ============================================================================
+
+    #[actix_web::test]
+    async fn test_create_join_federation_proposal() {
+        let gov_mgr = Arc::new(GovernanceManager::new());
+        let event_broadcaster = Arc::new(EventBroadcaster::new());
+        let alice = IdentityBundle::generate().unwrap();
+
+        // Create domain first
+        gov_mgr
+            .create_domain(
+                GovernanceDomainId("coop:food".to_string()),
+                "Food Coop".to_string(),
+                "cooperative".to_string(),
+                GovernanceParams::new(50, 66, 7 * 86400),
+                MembershipConfig::static_list(vec![alice.did().clone()]),
+            )
+            .await
+            .unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(gov_mgr.clone()))
+                .app_data(web::Data::new(event_broadcaster.clone()))
+                .service(web::scope("/gov").service(create_join_federation_proposal)),
+        )
+        .await;
+
+        // Create join federation proposal
+        let req_body = JoinFederationProposalRequest {
+            domain_id: "coop:food".to_string(),
+            title: "Join Regional Food Federation".to_string(),
+            description: "Proposal to join the regional food cooperative federation".to_string(),
+            federation_id: "regional-food-fed".to_string(),
+            terms: crate::models::FederationTermsRequest {
+                min_trust_threshold: 0.6,
+                governance_binding: true,
+                data_sharing_level: "metadata_only".to_string(),
+                dispute_resolution: "federation_mediation".to_string(),
+            },
+            sponsor_coop_id: Some("organic-farms-coop".to_string()),
+        };
+
+        let claims = create_test_claims(&alice.did().to_string(), vec!["gov:write"]);
+        let req = test::TestRequest::post()
+            .uri("/gov/proposals/federation/join")
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp: Proposal = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(resp.title, "Join Regional Food Federation");
+        assert!(matches!(resp.state, ProposalState::Draft));
+        assert!(matches!(
+            resp.payload,
+            icn_governance::ProposalPayload::Federation(
+                icn_governance::FederationProposal::JoinFederation { .. }
+            )
+        ));
+    }
+
+    #[actix_web::test]
+    async fn test_create_leave_federation_proposal() {
+        let gov_mgr = Arc::new(GovernanceManager::new());
+        let event_broadcaster = Arc::new(EventBroadcaster::new());
+        let alice = IdentityBundle::generate().unwrap();
+
+        gov_mgr
+            .create_domain(
+                GovernanceDomainId("coop:food".to_string()),
+                "Food Coop".to_string(),
+                "cooperative".to_string(),
+                GovernanceParams::new(50, 66, 7 * 86400),
+                MembershipConfig::static_list(vec![alice.did().clone()]),
+            )
+            .await
+            .unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(gov_mgr.clone()))
+                .app_data(web::Data::new(event_broadcaster.clone()))
+                .service(web::scope("/gov").service(create_leave_federation_proposal)),
+        )
+        .await;
+
+        let req_body = LeaveFederationProposalRequest {
+            domain_id: "coop:food".to_string(),
+            title: "Leave Regional Federation".to_string(),
+            description: "Strategic realignment requires leaving federation".to_string(),
+            federation_id: "regional-food-fed".to_string(),
+            reason: "Strategic realignment".to_string(),
+            grace_period_days: 30,
+        };
+
+        let claims = create_test_claims(&alice.did().to_string(), vec!["gov:write"]);
+        let req = test::TestRequest::post()
+            .uri("/gov/proposals/federation/leave")
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp: Proposal = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(resp.title, "Leave Regional Federation");
+        assert!(matches!(
+            resp.payload,
+            icn_governance::ProposalPayload::Federation(
+                icn_governance::FederationProposal::LeaveFederation { .. }
+            )
+        ));
+    }
+
+    #[actix_web::test]
+    async fn test_create_establish_clearing_proposal() {
+        let gov_mgr = Arc::new(GovernanceManager::new());
+        let event_broadcaster = Arc::new(EventBroadcaster::new());
+        let alice = IdentityBundle::generate().unwrap();
+        let partner = IdentityBundle::generate().unwrap();
+
+        gov_mgr
+            .create_domain(
+                GovernanceDomainId("coop:food".to_string()),
+                "Food Coop".to_string(),
+                "cooperative".to_string(),
+                GovernanceParams::new(50, 66, 7 * 86400),
+                MembershipConfig::static_list(vec![alice.did().clone()]),
+            )
+            .await
+            .unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(gov_mgr.clone()))
+                .app_data(web::Data::new(event_broadcaster.clone()))
+                .service(web::scope("/gov").service(create_establish_clearing_proposal)),
+        )
+        .await;
+
+        let req_body = EstablishClearingProposalRequest {
+            domain_id: "coop:food".to_string(),
+            title: "Establish Clearing with Partner Coop".to_string(),
+            description: "Setup bilateral clearing for cross-coop transactions".to_string(),
+            partner_coop_id: "partner-coop".to_string(),
+            partner_coop_did: partner.did().to_string(),
+            max_imbalance: 10000,
+            settlement_interval: "weekly".to_string(),
+            currency: "HOURS".to_string(),
+        };
+
+        let claims = create_test_claims(&alice.did().to_string(), vec!["gov:write"]);
+        let req = test::TestRequest::post()
+            .uri("/gov/proposals/federation/clearing")
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp: Proposal = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(resp.title, "Establish Clearing with Partner Coop");
+        assert!(matches!(
+            resp.payload,
+            icn_governance::ProposalPayload::Federation(
+                icn_governance::FederationProposal::EstablishClearing { .. }
+            )
+        ));
+    }
+
+    #[actix_web::test]
+    async fn test_create_terminate_clearing_proposal() {
+        let gov_mgr = Arc::new(GovernanceManager::new());
+        let event_broadcaster = Arc::new(EventBroadcaster::new());
+        let alice = IdentityBundle::generate().unwrap();
+
+        gov_mgr
+            .create_domain(
+                GovernanceDomainId("coop:food".to_string()),
+                "Food Coop".to_string(),
+                "cooperative".to_string(),
+                GovernanceParams::new(50, 66, 7 * 86400),
+                MembershipConfig::static_list(vec![alice.did().clone()]),
+            )
+            .await
+            .unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(gov_mgr.clone()))
+                .app_data(web::Data::new(event_broadcaster.clone()))
+                .service(web::scope("/gov").service(create_terminate_clearing_proposal)),
+        )
+        .await;
+
+        let req_body = TerminateClearingProposalRequest {
+            domain_id: "coop:food".to_string(),
+            title: "Terminate Clearing Agreement".to_string(),
+            description: "End the clearing agreement with partner coop".to_string(),
+            partner_coop_id: "partner-coop".to_string(),
+            reason: "Partnership no longer beneficial".to_string(),
+        };
+
+        let claims = create_test_claims(&alice.did().to_string(), vec!["gov:write"]);
+        let req = test::TestRequest::post()
+            .uri("/gov/proposals/federation/clearing/terminate")
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp: Proposal = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(resp.title, "Terminate Clearing Agreement");
+        assert!(matches!(
+            resp.payload,
+            icn_governance::ProposalPayload::Federation(
+                icn_governance::FederationProposal::TerminateClearing { .. }
+            )
+        ));
+    }
+
+    #[actix_web::test]
+    async fn test_create_vouch_proposal() {
+        let gov_mgr = Arc::new(GovernanceManager::new());
+        let event_broadcaster = Arc::new(EventBroadcaster::new());
+        let alice = IdentityBundle::generate().unwrap();
+        let target = IdentityBundle::generate().unwrap();
+
+        gov_mgr
+            .create_domain(
+                GovernanceDomainId("coop:food".to_string()),
+                "Food Coop".to_string(),
+                "cooperative".to_string(),
+                GovernanceParams::new(50, 66, 7 * 86400),
+                MembershipConfig::static_list(vec![alice.did().clone()]),
+            )
+            .await
+            .unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(gov_mgr.clone()))
+                .app_data(web::Data::new(event_broadcaster.clone()))
+                .service(web::scope("/gov").service(create_vouch_proposal)),
+        )
+        .await;
+
+        let req_body = VouchProposalRequest {
+            domain_id: "coop:food".to_string(),
+            title: "Vouch for New Worker Coop".to_string(),
+            description: "Recommend this cooperative for federation membership".to_string(),
+            target_coop_id: "new-worker-coop".to_string(),
+            target_coop_did: target.did().to_string(),
+            trust_score: 0.75,
+            context: "trade".to_string(),
+            evidence: Some("Six months of successful trading".to_string()),
+        };
+
+        let claims = create_test_claims(&alice.did().to_string(), vec!["gov:write"]);
+        let req = test::TestRequest::post()
+            .uri("/gov/proposals/federation/vouch")
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp: Proposal = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(resp.title, "Vouch for New Worker Coop");
+        assert!(matches!(
+            resp.payload,
+            icn_governance::ProposalPayload::Federation(
+                icn_governance::FederationProposal::VouchForCooperative { .. }
+            )
+        ));
+    }
+
+    #[actix_web::test]
+    async fn test_create_revoke_vouch_proposal() {
+        let gov_mgr = Arc::new(GovernanceManager::new());
+        let event_broadcaster = Arc::new(EventBroadcaster::new());
+        let alice = IdentityBundle::generate().unwrap();
+
+        gov_mgr
+            .create_domain(
+                GovernanceDomainId("coop:food".to_string()),
+                "Food Coop".to_string(),
+                "cooperative".to_string(),
+                GovernanceParams::new(50, 66, 7 * 86400),
+                MembershipConfig::static_list(vec![alice.did().clone()]),
+            )
+            .await
+            .unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(gov_mgr.clone()))
+                .app_data(web::Data::new(event_broadcaster.clone()))
+                .service(web::scope("/gov").service(create_revoke_vouch_proposal)),
+        )
+        .await;
+
+        let req_body = RevokeVouchProposalRequest {
+            domain_id: "coop:food".to_string(),
+            title: "Revoke Vouch for Problem Coop".to_string(),
+            description: "Remove our endorsement due to trust violations".to_string(),
+            target_coop_id: "problem-coop".to_string(),
+            reason: "Repeated contract violations".to_string(),
+        };
+
+        let claims = create_test_claims(&alice.did().to_string(), vec!["gov:write"]);
+        let req = test::TestRequest::post()
+            .uri("/gov/proposals/federation/vouch/revoke")
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp: Proposal = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(resp.title, "Revoke Vouch for Problem Coop");
+        assert!(matches!(
+            resp.payload,
+            icn_governance::ProposalPayload::Federation(
+                icn_governance::FederationProposal::RevokeVouch { .. }
+            )
+        ));
+    }
+
+    #[actix_web::test]
+    async fn test_create_update_federation_policy_proposal() {
+        let gov_mgr = Arc::new(GovernanceManager::new());
+        let event_broadcaster = Arc::new(EventBroadcaster::new());
+        let alice = IdentityBundle::generate().unwrap();
+
+        gov_mgr
+            .create_domain(
+                GovernanceDomainId("coop:food".to_string()),
+                "Food Coop".to_string(),
+                "cooperative".to_string(),
+                GovernanceParams::new(50, 66, 7 * 86400),
+                MembershipConfig::static_list(vec![alice.did().clone()]),
+            )
+            .await
+            .unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(gov_mgr.clone()))
+                .app_data(web::Data::new(event_broadcaster.clone()))
+                .service(web::scope("/gov").service(create_update_federation_policy_proposal)),
+        )
+        .await;
+
+        let req_body = UpdateFederationPolicyProposalRequest {
+            domain_id: "coop:food".to_string(),
+            title: "Update Federation Policy".to_string(),
+            description: "Adjust auto-accept threshold and rate limits".to_string(),
+            auto_accept_vouch_threshold: Some(0.7),
+            trust_decay_factor: Some(0.05),
+            max_attestations_per_minute: Some(30),
+        };
+
+        let claims = create_test_claims(&alice.did().to_string(), vec!["gov:write"]);
+        let req = test::TestRequest::post()
+            .uri("/gov/proposals/federation/policy")
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp: Proposal = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(resp.title, "Update Federation Policy");
+        assert!(matches!(
+            resp.payload,
+            icn_governance::ProposalPayload::Federation(
+                icn_governance::FederationProposal::UpdateFederationPolicy { .. }
+            )
+        ));
+    }
+
+    #[actix_web::test]
+    async fn test_federation_proposal_invalid_trust_score() {
+        let gov_mgr = Arc::new(GovernanceManager::new());
+        let event_broadcaster = Arc::new(EventBroadcaster::new());
+        let alice = IdentityBundle::generate().unwrap();
+
+        gov_mgr
+            .create_domain(
+                GovernanceDomainId("coop:food".to_string()),
+                "Food Coop".to_string(),
+                "cooperative".to_string(),
+                GovernanceParams::new(50, 66, 7 * 86400),
+                MembershipConfig::static_list(vec![alice.did().clone()]),
+            )
+            .await
+            .unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(gov_mgr.clone()))
+                .app_data(web::Data::new(event_broadcaster.clone()))
+                .service(web::scope("/gov").service(create_join_federation_proposal)),
+        )
+        .await;
+
+        // Trust score too high (> 1.0)
+        let req_body = JoinFederationProposalRequest {
+            domain_id: "coop:food".to_string(),
+            title: "Join Federation".to_string(),
+            description: "Test proposal".to_string(),
+            federation_id: "test-fed".to_string(),
+            terms: crate::models::FederationTermsRequest {
+                min_trust_threshold: 1.5, // Invalid - too high
+                governance_binding: true,
+                data_sharing_level: "metadata_only".to_string(),
+                dispute_resolution: "federation_mediation".to_string(),
+            },
+            sponsor_coop_id: None,
+        };
+
+        let claims = create_test_claims(&alice.did().to_string(), vec!["gov:write"]);
+        let req = test::TestRequest::post()
+            .uri("/gov/proposals/federation/join")
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), 400); // Bad Request
+    }
+
+    #[actix_web::test]
+    async fn test_federation_proposal_invalid_grace_period() {
+        let gov_mgr = Arc::new(GovernanceManager::new());
+        let event_broadcaster = Arc::new(EventBroadcaster::new());
+        let alice = IdentityBundle::generate().unwrap();
+
+        gov_mgr
+            .create_domain(
+                GovernanceDomainId("coop:food".to_string()),
+                "Food Coop".to_string(),
+                "cooperative".to_string(),
+                GovernanceParams::new(50, 66, 7 * 86400),
+                MembershipConfig::static_list(vec![alice.did().clone()]),
+            )
+            .await
+            .unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(gov_mgr.clone()))
+                .app_data(web::Data::new(event_broadcaster.clone()))
+                .service(web::scope("/gov").service(create_leave_federation_proposal)),
+        )
+        .await;
+
+        // Grace period too long (> 365)
+        let req_body = LeaveFederationProposalRequest {
+            domain_id: "coop:food".to_string(),
+            title: "Leave Federation".to_string(),
+            description: "Test proposal".to_string(),
+            federation_id: "test-fed".to_string(),
+            reason: "Test reason".to_string(),
+            grace_period_days: 500, // Invalid - too long
+        };
+
+        let claims = create_test_claims(&alice.did().to_string(), vec!["gov:write"]);
+        let req = test::TestRequest::post()
+            .uri("/gov/proposals/federation/leave")
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), 400); // Bad Request
+    }
+
+    #[actix_web::test]
+    async fn test_federation_proposal_invalid_settlement_interval() {
+        let gov_mgr = Arc::new(GovernanceManager::new());
+        let event_broadcaster = Arc::new(EventBroadcaster::new());
+        let alice = IdentityBundle::generate().unwrap();
+        let partner = IdentityBundle::generate().unwrap();
+
+        gov_mgr
+            .create_domain(
+                GovernanceDomainId("coop:food".to_string()),
+                "Food Coop".to_string(),
+                "cooperative".to_string(),
+                GovernanceParams::new(50, 66, 7 * 86400),
+                MembershipConfig::static_list(vec![alice.did().clone()]),
+            )
+            .await
+            .unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(gov_mgr.clone()))
+                .app_data(web::Data::new(event_broadcaster.clone()))
+                .service(web::scope("/gov").service(create_establish_clearing_proposal)),
+        )
+        .await;
+
+        let req_body = EstablishClearingProposalRequest {
+            domain_id: "coop:food".to_string(),
+            title: "Establish Clearing".to_string(),
+            description: "Test proposal".to_string(),
+            partner_coop_id: "partner-coop".to_string(),
+            partner_coop_did: partner.did().to_string(),
+            max_imbalance: 10000,
+            settlement_interval: "yearly".to_string(), // Invalid
+            currency: "HOURS".to_string(),
+        };
+
+        let claims = create_test_claims(&alice.did().to_string(), vec!["gov:write"]);
+        let req = test::TestRequest::post()
+            .uri("/gov/proposals/federation/clearing")
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), 400); // Bad Request
+    }
+
+    #[actix_web::test]
+    async fn test_federation_proposal_requires_auth() {
+        let gov_mgr = Arc::new(GovernanceManager::new());
+        let event_broadcaster = Arc::new(EventBroadcaster::new());
+        let alice = IdentityBundle::generate().unwrap();
+
+        gov_mgr
+            .create_domain(
+                GovernanceDomainId("coop:food".to_string()),
+                "Food Coop".to_string(),
+                "cooperative".to_string(),
+                GovernanceParams::new(50, 66, 7 * 86400),
+                MembershipConfig::static_list(vec![alice.did().clone()]),
+            )
+            .await
+            .unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(gov_mgr.clone()))
+                .app_data(web::Data::new(event_broadcaster.clone()))
+                .service(web::scope("/gov").service(create_join_federation_proposal)),
+        )
+        .await;
+
+        let req_body = JoinFederationProposalRequest {
+            domain_id: "coop:food".to_string(),
+            title: "Join Federation".to_string(),
+            description: "Test proposal".to_string(),
+            federation_id: "test-fed".to_string(),
+            terms: crate::models::FederationTermsRequest {
+                min_trust_threshold: 0.5,
+                governance_binding: true,
+                data_sharing_level: "metadata_only".to_string(),
+                dispute_resolution: "federation_mediation".to_string(),
+            },
+            sponsor_coop_id: None,
+        };
+
+        // Request without claims (no auth)
+        let req = test::TestRequest::post()
+            .uri("/gov/proposals/federation/join")
+            .set_json(&req_body)
+            .to_request();
+        // Note: no claims inserted
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), 401); // Unauthorized - no auth token
+    }
+
+    #[actix_web::test]
+    async fn test_federation_proposal_requires_write_scope() {
+        let gov_mgr = Arc::new(GovernanceManager::new());
+        let event_broadcaster = Arc::new(EventBroadcaster::new());
+        let alice = IdentityBundle::generate().unwrap();
+
+        gov_mgr
+            .create_domain(
+                GovernanceDomainId("coop:food".to_string()),
+                "Food Coop".to_string(),
+                "cooperative".to_string(),
+                GovernanceParams::new(50, 66, 7 * 86400),
+                MembershipConfig::static_list(vec![alice.did().clone()]),
+            )
+            .await
+            .unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(gov_mgr.clone()))
+                .app_data(web::Data::new(event_broadcaster.clone()))
+                .service(web::scope("/gov").service(create_join_federation_proposal)),
+        )
+        .await;
+
+        let req_body = JoinFederationProposalRequest {
+            domain_id: "coop:food".to_string(),
+            title: "Join Federation".to_string(),
+            description: "Test proposal".to_string(),
+            federation_id: "test-fed".to_string(),
+            terms: crate::models::FederationTermsRequest {
+                min_trust_threshold: 0.5,
+                governance_binding: true,
+                data_sharing_level: "metadata_only".to_string(),
+                dispute_resolution: "federation_mediation".to_string(),
+            },
+            sponsor_coop_id: None,
+        };
+
+        // Request with only read scope (not write)
+        let claims = create_test_claims(&alice.did().to_string(), vec!["gov:read"]);
+        let req = test::TestRequest::post()
+            .uri("/gov/proposals/federation/join")
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), 403); // Forbidden - wrong scope
+    }
+
+    #[actix_web::test]
+    async fn test_update_policy_requires_at_least_one_field() {
+        let gov_mgr = Arc::new(GovernanceManager::new());
+        let event_broadcaster = Arc::new(EventBroadcaster::new());
+        let alice = IdentityBundle::generate().unwrap();
+
+        gov_mgr
+            .create_domain(
+                GovernanceDomainId("coop:food".to_string()),
+                "Food Coop".to_string(),
+                "cooperative".to_string(),
+                GovernanceParams::new(50, 66, 7 * 86400),
+                MembershipConfig::static_list(vec![alice.did().clone()]),
+            )
+            .await
+            .unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(gov_mgr.clone()))
+                .app_data(web::Data::new(event_broadcaster.clone()))
+                .service(web::scope("/gov").service(create_update_federation_policy_proposal)),
+        )
+        .await;
+
+        // No policy fields provided
+        let req_body = UpdateFederationPolicyProposalRequest {
+            domain_id: "coop:food".to_string(),
+            title: "Update Policy".to_string(),
+            description: "Test proposal".to_string(),
+            auto_accept_vouch_threshold: None,
+            trust_decay_factor: None,
+            max_attestations_per_minute: None,
+        };
+
+        let claims = create_test_claims(&alice.did().to_string(), vec!["gov:write"]);
+        let req = test::TestRequest::post()
+            .uri("/gov/proposals/federation/policy")
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), 400); // Bad Request - no fields provided
+    }
+
+    #[actix_web::test]
+    async fn test_federation_proposal_arbitrator_dispute_resolution() {
+        let gov_mgr = Arc::new(GovernanceManager::new());
+        let event_broadcaster = Arc::new(EventBroadcaster::new());
+        let alice = IdentityBundle::generate().unwrap();
+
+        gov_mgr
+            .create_domain(
+                GovernanceDomainId("coop:food".to_string()),
+                "Food Coop".to_string(),
+                "cooperative".to_string(),
+                GovernanceParams::new(50, 66, 7 * 86400),
+                MembershipConfig::static_list(vec![alice.did().clone()]),
+            )
+            .await
+            .unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(gov_mgr.clone()))
+                .app_data(web::Data::new(event_broadcaster.clone()))
+                .service(web::scope("/gov").service(create_join_federation_proposal)),
+        )
+        .await;
+
+        // Test arbitrator dispute resolution format
+        let req_body = JoinFederationProposalRequest {
+            domain_id: "coop:food".to_string(),
+            title: "Join Federation with Arbitrator".to_string(),
+            description: "Using arbitrator for dispute resolution".to_string(),
+            federation_id: "test-fed".to_string(),
+            terms: crate::models::FederationTermsRequest {
+                min_trust_threshold: 0.5,
+                governance_binding: true,
+                data_sharing_level: "full".to_string(),
+                dispute_resolution: "arbitrator:neutral-coop".to_string(),
+            },
+            sponsor_coop_id: None,
+        };
+
+        let claims = create_test_claims(&alice.did().to_string(), vec!["gov:write"]);
+        let req = test::TestRequest::post()
+            .uri("/gov/proposals/federation/join")
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp: Proposal = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(resp.title, "Join Federation with Arbitrator");
+    }
 }

--- a/icn/crates/icn-gateway/src/api/governance.rs
+++ b/icn/crates/icn-gateway/src/api/governance.rs
@@ -862,19 +862,30 @@ pub async fn close_proposal(
 // Federation Proposal Endpoints
 // ============================================================================
 
-/// POST /gov/proposals/federation/join - Create a "join federation" proposal
-#[post("/proposals/federation/join")]
-pub async fn create_join_federation_proposal(
-    http_req: HttpRequest,
-    gov_mgr: web::Data<Arc<GovernanceManager>>,
-    event_broadcaster: web::Data<Arc<EventBroadcaster>>,
-    req: web::Json<JoinFederationProposalRequest>,
-) -> Result<HttpResponse> {
+// ============================================================================
+// Federation Proposal Helpers
+// ============================================================================
+
+/// Common fields for federation proposals
+struct FederationProposalCommon {
+    domain_id: String,
+    title: String,
+    description: String,
+    proposer_did: Did,
+}
+
+/// Extract common authorization and validation for federation proposals
+fn extract_federation_common(
+    http_req: &HttpRequest,
+    domain_id: &str,
+    title: &str,
+    description: &str,
+) -> Result<FederationProposalCommon> {
     // Check authorization
-    require_scope(&http_req, "gov:write")?;
+    require_scope(http_req, "gov:write")?;
 
     // Extract authenticated DID from JWT claims
-    let claims = get_claims(&http_req).ok_or_else(|| {
+    let claims = get_claims(http_req).ok_or_else(|| {
         crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
     })?;
 
@@ -883,9 +894,130 @@ pub async fn create_join_federation_proposal(
     })?;
 
     // Validate common fields
-    validation::validate_domain_id(&req.domain_id)?;
-    validation::validate_proposal_title(&req.title)?;
-    validation::validate_proposal_description(&req.description)?;
+    validation::validate_domain_id(domain_id)?;
+    validation::validate_proposal_title(title)?;
+    validation::validate_proposal_description(description)?;
+
+    Ok(FederationProposalCommon {
+        domain_id: domain_id.to_string(),
+        title: title.to_string(),
+        description: description.to_string(),
+        proposer_did,
+    })
+}
+
+/// Create a federation proposal with the common workflow
+async fn create_federation_proposal_impl(
+    gov_mgr: &GovernanceManager,
+    event_broadcaster: &EventBroadcaster,
+    common: FederationProposalCommon,
+    fed_proposal: FederationProposal,
+) -> Result<HttpResponse> {
+    // Validate the federation proposal itself
+    fed_proposal
+        .validate()
+        .map_err(crate::error::GatewayError::BadRequest)?;
+
+    // Wrap in ProposalPayload
+    let payload = ProposalPayload::Federation(fed_proposal);
+
+    // Create proposal via governance manager
+    let domain_id = GovernanceDomainId(common.domain_id.clone());
+    let suggested_id = ProposalId(format!("prop-{}", uuid::Uuid::new_v4()));
+
+    let proposal_id = gov_mgr
+        .create_proposal(
+            suggested_id,
+            domain_id,
+            common.proposer_did.clone(),
+            common.title.clone(),
+            common.description.clone(),
+            payload,
+        )
+        .await?;
+
+    // Track proposal creation
+    gateway::governance_proposals_created_inc();
+
+    // Broadcast event to WebSocket subscribers
+    event_broadcaster
+        .broadcast(
+            &common.domain_id,
+            GatewayEvent::GovernanceProposalCreated {
+                proposal_id: proposal_id.0.clone(),
+                domain_id: common.domain_id.clone(),
+                proposer: common.proposer_did.to_string(),
+                title: common.title.clone(),
+                payload_type: "federation".to_string(),
+            },
+        )
+        .await;
+
+    // Return created proposal
+    let proposal = gov_mgr.get_proposal(&proposal_id).await?.ok_or_else(|| {
+        crate::error::GatewayError::InternalError(
+            "Proposal creation succeeded but proposal not found".to_string(),
+        )
+    })?;
+
+    Ok(HttpResponse::Created().json(proposal))
+}
+
+/// Parse data sharing level string to enum
+fn parse_data_sharing_level(s: &str) -> Result<DataSharingLevel> {
+    match s {
+        "none" => Ok(DataSharingLevel::None),
+        "metadata_only" => Ok(DataSharingLevel::MetadataOnly),
+        "full" => Ok(DataSharingLevel::Full),
+        _ => Err(crate::error::GatewayError::InternalError(format!(
+            "Invalid data_sharing_level after validation: '{s}'"
+        ))),
+    }
+}
+
+/// Parse dispute resolution string to enum
+fn parse_dispute_resolution(s: &str) -> Result<DisputeResolutionMethod> {
+    if s.starts_with("arbitrator:") {
+        let arbitrator_id = s.strip_prefix("arbitrator:").unwrap_or("").to_string();
+        Ok(DisputeResolutionMethod::ArbitratorCooperative { arbitrator_id })
+    } else {
+        match s {
+            "federation_mediation" => Ok(DisputeResolutionMethod::FederationMediation),
+            "federation_vote" => Ok(DisputeResolutionMethod::FederationVote),
+            _ => Err(crate::error::GatewayError::InternalError(format!(
+                "Invalid dispute_resolution after validation: '{s}'"
+            ))),
+        }
+    }
+}
+
+/// Parse settlement interval string to enum
+fn parse_settlement_interval(s: &str) -> Result<SettlementInterval> {
+    match s {
+        "daily" => Ok(SettlementInterval::Daily),
+        "weekly" => Ok(SettlementInterval::Weekly),
+        "monthly" => Ok(SettlementInterval::Monthly),
+        "manual" => Ok(SettlementInterval::Manual),
+        _ => Err(crate::error::GatewayError::InternalError(format!(
+            "Invalid settlement_interval after validation: '{s}'"
+        ))),
+    }
+}
+
+// ============================================================================
+// Federation Proposal Endpoints
+// ============================================================================
+
+/// POST /gov/proposals/federation/join - Create a "join federation" proposal
+#[post("/proposals/federation/join")]
+pub async fn create_join_federation_proposal(
+    http_req: HttpRequest,
+    gov_mgr: web::Data<Arc<GovernanceManager>>,
+    event_broadcaster: web::Data<Arc<EventBroadcaster>>,
+    req: web::Json<JoinFederationProposalRequest>,
+) -> Result<HttpResponse> {
+    let common =
+        extract_federation_common(&http_req, &req.domain_id, &req.title, &req.description)?;
 
     // Validate federation-specific fields
     validation::validate_federation_id(&req.federation_id)?;
@@ -896,26 +1028,8 @@ pub async fn create_join_federation_proposal(
         validation::validate_dispute_resolution(&req.terms.dispute_resolution)?;
 
     // Convert string types to enums
-    let data_sharing_level = match data_sharing_level_str.as_str() {
-        "none" => DataSharingLevel::None,
-        "metadata_only" => DataSharingLevel::MetadataOnly,
-        "full" => DataSharingLevel::Full,
-        _ => unreachable!(), // validation ensures valid value
-    };
-
-    let dispute_resolution = if dispute_resolution_str.starts_with("arbitrator:") {
-        let arbitrator_id = dispute_resolution_str
-            .strip_prefix("arbitrator:")
-            .unwrap_or("")
-            .to_string();
-        DisputeResolutionMethod::ArbitratorCooperative { arbitrator_id }
-    } else {
-        match dispute_resolution_str.as_str() {
-            "federation_mediation" => DisputeResolutionMethod::FederationMediation,
-            "federation_vote" => DisputeResolutionMethod::FederationVote,
-            _ => unreachable!(), // validation ensures valid value
-        }
-    };
+    let data_sharing_level = parse_data_sharing_level(&data_sharing_level_str)?;
+    let dispute_resolution = parse_dispute_resolution(&dispute_resolution_str)?;
 
     // Build FederationTerms
     let terms = FederationTerms {
@@ -932,54 +1046,7 @@ pub async fn create_join_federation_proposal(
         sponsor_coop_id: req.sponsor_coop_id.clone(),
     };
 
-    // Validate the federation proposal itself
-    fed_proposal
-        .validate()
-        .map_err(crate::error::GatewayError::BadRequest)?;
-
-    // Wrap in ProposalPayload
-    let payload = ProposalPayload::Federation(fed_proposal);
-
-    // Create proposal via governance manager
-    let domain_id = GovernanceDomainId(req.domain_id.clone());
-    let suggested_id = ProposalId(format!("prop-{}", uuid::Uuid::new_v4()));
-
-    let proposal_id = gov_mgr
-        .create_proposal(
-            suggested_id,
-            domain_id,
-            proposer_did.clone(),
-            req.title.clone(),
-            req.description.clone(),
-            payload,
-        )
-        .await?;
-
-    // Track proposal creation
-    gateway::governance_proposals_created_inc();
-
-    // Broadcast event to WebSocket subscribers
-    event_broadcaster
-        .broadcast(
-            &req.domain_id,
-            GatewayEvent::GovernanceProposalCreated {
-                proposal_id: proposal_id.0.clone(),
-                domain_id: req.domain_id.clone(),
-                proposer: proposer_did.to_string(),
-                title: req.title.clone(),
-                payload_type: "federation".to_string(),
-            },
-        )
-        .await;
-
-    // Return created proposal
-    let proposal = gov_mgr.get_proposal(&proposal_id).await?.ok_or_else(|| {
-        crate::error::GatewayError::InternalError(
-            "Proposal creation succeeded but proposal not found".to_string(),
-        )
-    })?;
-
-    Ok(HttpResponse::Created().json(proposal))
+    create_federation_proposal_impl(&gov_mgr, &event_broadcaster, common, fed_proposal).await
 }
 
 /// POST /gov/proposals/federation/leave - Create a "leave federation" proposal
@@ -990,22 +1057,8 @@ pub async fn create_leave_federation_proposal(
     event_broadcaster: web::Data<Arc<EventBroadcaster>>,
     req: web::Json<LeaveFederationProposalRequest>,
 ) -> Result<HttpResponse> {
-    // Check authorization
-    require_scope(&http_req, "gov:write")?;
-
-    // Extract authenticated DID from JWT claims
-    let claims = get_claims(&http_req).ok_or_else(|| {
-        crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
-    })?;
-
-    let proposer_did: Did = claims.sub.parse().map_err(|e| {
-        crate::error::GatewayError::BadRequest(format!("Invalid DID in token: {e}"))
-    })?;
-
-    // Validate common fields
-    validation::validate_domain_id(&req.domain_id)?;
-    validation::validate_proposal_title(&req.title)?;
-    validation::validate_proposal_description(&req.description)?;
+    let common =
+        extract_federation_common(&http_req, &req.domain_id, &req.title, &req.description)?;
 
     // Validate federation-specific fields
     validation::validate_federation_id(&req.federation_id)?;
@@ -1019,54 +1072,7 @@ pub async fn create_leave_federation_proposal(
         grace_period_days: req.grace_period_days,
     };
 
-    // Validate the federation proposal itself
-    fed_proposal
-        .validate()
-        .map_err(crate::error::GatewayError::BadRequest)?;
-
-    // Wrap in ProposalPayload
-    let payload = ProposalPayload::Federation(fed_proposal);
-
-    // Create proposal via governance manager
-    let domain_id = GovernanceDomainId(req.domain_id.clone());
-    let suggested_id = ProposalId(format!("prop-{}", uuid::Uuid::new_v4()));
-
-    let proposal_id = gov_mgr
-        .create_proposal(
-            suggested_id,
-            domain_id,
-            proposer_did.clone(),
-            req.title.clone(),
-            req.description.clone(),
-            payload,
-        )
-        .await?;
-
-    // Track proposal creation
-    gateway::governance_proposals_created_inc();
-
-    // Broadcast event to WebSocket subscribers
-    event_broadcaster
-        .broadcast(
-            &req.domain_id,
-            GatewayEvent::GovernanceProposalCreated {
-                proposal_id: proposal_id.0.clone(),
-                domain_id: req.domain_id.clone(),
-                proposer: proposer_did.to_string(),
-                title: req.title.clone(),
-                payload_type: "federation".to_string(),
-            },
-        )
-        .await;
-
-    // Return created proposal
-    let proposal = gov_mgr.get_proposal(&proposal_id).await?.ok_or_else(|| {
-        crate::error::GatewayError::InternalError(
-            "Proposal creation succeeded but proposal not found".to_string(),
-        )
-    })?;
-
-    Ok(HttpResponse::Created().json(proposal))
+    create_federation_proposal_impl(&gov_mgr, &event_broadcaster, common, fed_proposal).await
 }
 
 /// POST /gov/proposals/federation/clearing - Create an "establish clearing" proposal
@@ -1077,22 +1083,8 @@ pub async fn create_establish_clearing_proposal(
     event_broadcaster: web::Data<Arc<EventBroadcaster>>,
     req: web::Json<EstablishClearingProposalRequest>,
 ) -> Result<HttpResponse> {
-    // Check authorization
-    require_scope(&http_req, "gov:write")?;
-
-    // Extract authenticated DID from JWT claims
-    let claims = get_claims(&http_req).ok_or_else(|| {
-        crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
-    })?;
-
-    let proposer_did: Did = claims.sub.parse().map_err(|e| {
-        crate::error::GatewayError::BadRequest(format!("Invalid DID in token: {e}"))
-    })?;
-
-    // Validate common fields
-    validation::validate_domain_id(&req.domain_id)?;
-    validation::validate_proposal_title(&req.title)?;
-    validation::validate_proposal_description(&req.description)?;
+    let common =
+        extract_federation_common(&http_req, &req.domain_id, &req.title, &req.description)?;
 
     // Validate federation-specific fields
     validation::validate_federation_id(&req.partner_coop_id)?;
@@ -1107,13 +1099,7 @@ pub async fn create_establish_clearing_proposal(
     })?;
 
     // Convert settlement interval string to enum
-    let settlement_interval = match settlement_interval_str.as_str() {
-        "daily" => SettlementInterval::Daily,
-        "weekly" => SettlementInterval::Weekly,
-        "monthly" => SettlementInterval::Monthly,
-        "manual" => SettlementInterval::Manual,
-        _ => unreachable!(), // validation ensures valid value
-    };
+    let settlement_interval = parse_settlement_interval(&settlement_interval_str)?;
 
     // Build FederationProposal
     let fed_proposal = FederationProposal::EstablishClearing {
@@ -1124,54 +1110,7 @@ pub async fn create_establish_clearing_proposal(
         currency: req.currency.clone(),
     };
 
-    // Validate the federation proposal itself
-    fed_proposal
-        .validate()
-        .map_err(crate::error::GatewayError::BadRequest)?;
-
-    // Wrap in ProposalPayload
-    let payload = ProposalPayload::Federation(fed_proposal);
-
-    // Create proposal via governance manager
-    let domain_id = GovernanceDomainId(req.domain_id.clone());
-    let suggested_id = ProposalId(format!("prop-{}", uuid::Uuid::new_v4()));
-
-    let proposal_id = gov_mgr
-        .create_proposal(
-            suggested_id,
-            domain_id,
-            proposer_did.clone(),
-            req.title.clone(),
-            req.description.clone(),
-            payload,
-        )
-        .await?;
-
-    // Track proposal creation
-    gateway::governance_proposals_created_inc();
-
-    // Broadcast event to WebSocket subscribers
-    event_broadcaster
-        .broadcast(
-            &req.domain_id,
-            GatewayEvent::GovernanceProposalCreated {
-                proposal_id: proposal_id.0.clone(),
-                domain_id: req.domain_id.clone(),
-                proposer: proposer_did.to_string(),
-                title: req.title.clone(),
-                payload_type: "federation".to_string(),
-            },
-        )
-        .await;
-
-    // Return created proposal
-    let proposal = gov_mgr.get_proposal(&proposal_id).await?.ok_or_else(|| {
-        crate::error::GatewayError::InternalError(
-            "Proposal creation succeeded but proposal not found".to_string(),
-        )
-    })?;
-
-    Ok(HttpResponse::Created().json(proposal))
+    create_federation_proposal_impl(&gov_mgr, &event_broadcaster, common, fed_proposal).await
 }
 
 /// POST /gov/proposals/federation/clearing/terminate - Create a "terminate clearing" proposal
@@ -1182,22 +1121,8 @@ pub async fn create_terminate_clearing_proposal(
     event_broadcaster: web::Data<Arc<EventBroadcaster>>,
     req: web::Json<TerminateClearingProposalRequest>,
 ) -> Result<HttpResponse> {
-    // Check authorization
-    require_scope(&http_req, "gov:write")?;
-
-    // Extract authenticated DID from JWT claims
-    let claims = get_claims(&http_req).ok_or_else(|| {
-        crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
-    })?;
-
-    let proposer_did: Did = claims.sub.parse().map_err(|e| {
-        crate::error::GatewayError::BadRequest(format!("Invalid DID in token: {e}"))
-    })?;
-
-    // Validate common fields
-    validation::validate_domain_id(&req.domain_id)?;
-    validation::validate_proposal_title(&req.title)?;
-    validation::validate_proposal_description(&req.description)?;
+    let common =
+        extract_federation_common(&http_req, &req.domain_id, &req.title, &req.description)?;
 
     // Validate federation-specific fields
     validation::validate_federation_id(&req.partner_coop_id)?;
@@ -1209,54 +1134,7 @@ pub async fn create_terminate_clearing_proposal(
         reason: req.reason.clone(),
     };
 
-    // Validate the federation proposal itself
-    fed_proposal
-        .validate()
-        .map_err(crate::error::GatewayError::BadRequest)?;
-
-    // Wrap in ProposalPayload
-    let payload = ProposalPayload::Federation(fed_proposal);
-
-    // Create proposal via governance manager
-    let domain_id = GovernanceDomainId(req.domain_id.clone());
-    let suggested_id = ProposalId(format!("prop-{}", uuid::Uuid::new_v4()));
-
-    let proposal_id = gov_mgr
-        .create_proposal(
-            suggested_id,
-            domain_id,
-            proposer_did.clone(),
-            req.title.clone(),
-            req.description.clone(),
-            payload,
-        )
-        .await?;
-
-    // Track proposal creation
-    gateway::governance_proposals_created_inc();
-
-    // Broadcast event to WebSocket subscribers
-    event_broadcaster
-        .broadcast(
-            &req.domain_id,
-            GatewayEvent::GovernanceProposalCreated {
-                proposal_id: proposal_id.0.clone(),
-                domain_id: req.domain_id.clone(),
-                proposer: proposer_did.to_string(),
-                title: req.title.clone(),
-                payload_type: "federation".to_string(),
-            },
-        )
-        .await;
-
-    // Return created proposal
-    let proposal = gov_mgr.get_proposal(&proposal_id).await?.ok_or_else(|| {
-        crate::error::GatewayError::InternalError(
-            "Proposal creation succeeded but proposal not found".to_string(),
-        )
-    })?;
-
-    Ok(HttpResponse::Created().json(proposal))
+    create_federation_proposal_impl(&gov_mgr, &event_broadcaster, common, fed_proposal).await
 }
 
 /// POST /gov/proposals/federation/vouch - Create a "vouch for cooperative" proposal
@@ -1267,22 +1145,8 @@ pub async fn create_vouch_proposal(
     event_broadcaster: web::Data<Arc<EventBroadcaster>>,
     req: web::Json<VouchProposalRequest>,
 ) -> Result<HttpResponse> {
-    // Check authorization
-    require_scope(&http_req, "gov:write")?;
-
-    // Extract authenticated DID from JWT claims
-    let claims = get_claims(&http_req).ok_or_else(|| {
-        crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
-    })?;
-
-    let proposer_did: Did = claims.sub.parse().map_err(|e| {
-        crate::error::GatewayError::BadRequest(format!("Invalid DID in token: {e}"))
-    })?;
-
-    // Validate common fields
-    validation::validate_domain_id(&req.domain_id)?;
-    validation::validate_proposal_title(&req.title)?;
-    validation::validate_proposal_description(&req.description)?;
+    let common =
+        extract_federation_common(&http_req, &req.domain_id, &req.title, &req.description)?;
 
     // Validate federation-specific fields
     validation::validate_federation_id(&req.target_coop_id)?;
@@ -1304,54 +1168,7 @@ pub async fn create_vouch_proposal(
         evidence: req.evidence.clone(),
     };
 
-    // Validate the federation proposal itself
-    fed_proposal
-        .validate()
-        .map_err(crate::error::GatewayError::BadRequest)?;
-
-    // Wrap in ProposalPayload
-    let payload = ProposalPayload::Federation(fed_proposal);
-
-    // Create proposal via governance manager
-    let domain_id = GovernanceDomainId(req.domain_id.clone());
-    let suggested_id = ProposalId(format!("prop-{}", uuid::Uuid::new_v4()));
-
-    let proposal_id = gov_mgr
-        .create_proposal(
-            suggested_id,
-            domain_id,
-            proposer_did.clone(),
-            req.title.clone(),
-            req.description.clone(),
-            payload,
-        )
-        .await?;
-
-    // Track proposal creation
-    gateway::governance_proposals_created_inc();
-
-    // Broadcast event to WebSocket subscribers
-    event_broadcaster
-        .broadcast(
-            &req.domain_id,
-            GatewayEvent::GovernanceProposalCreated {
-                proposal_id: proposal_id.0.clone(),
-                domain_id: req.domain_id.clone(),
-                proposer: proposer_did.to_string(),
-                title: req.title.clone(),
-                payload_type: "federation".to_string(),
-            },
-        )
-        .await;
-
-    // Return created proposal
-    let proposal = gov_mgr.get_proposal(&proposal_id).await?.ok_or_else(|| {
-        crate::error::GatewayError::InternalError(
-            "Proposal creation succeeded but proposal not found".to_string(),
-        )
-    })?;
-
-    Ok(HttpResponse::Created().json(proposal))
+    create_federation_proposal_impl(&gov_mgr, &event_broadcaster, common, fed_proposal).await
 }
 
 /// POST /gov/proposals/federation/vouch/revoke - Create a "revoke vouch" proposal
@@ -1362,22 +1179,8 @@ pub async fn create_revoke_vouch_proposal(
     event_broadcaster: web::Data<Arc<EventBroadcaster>>,
     req: web::Json<RevokeVouchProposalRequest>,
 ) -> Result<HttpResponse> {
-    // Check authorization
-    require_scope(&http_req, "gov:write")?;
-
-    // Extract authenticated DID from JWT claims
-    let claims = get_claims(&http_req).ok_or_else(|| {
-        crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
-    })?;
-
-    let proposer_did: Did = claims.sub.parse().map_err(|e| {
-        crate::error::GatewayError::BadRequest(format!("Invalid DID in token: {e}"))
-    })?;
-
-    // Validate common fields
-    validation::validate_domain_id(&req.domain_id)?;
-    validation::validate_proposal_title(&req.title)?;
-    validation::validate_proposal_description(&req.description)?;
+    let common =
+        extract_federation_common(&http_req, &req.domain_id, &req.title, &req.description)?;
 
     // Validate federation-specific fields
     validation::validate_federation_id(&req.target_coop_id)?;
@@ -1389,54 +1192,7 @@ pub async fn create_revoke_vouch_proposal(
         reason: req.reason.clone(),
     };
 
-    // Validate the federation proposal itself
-    fed_proposal
-        .validate()
-        .map_err(crate::error::GatewayError::BadRequest)?;
-
-    // Wrap in ProposalPayload
-    let payload = ProposalPayload::Federation(fed_proposal);
-
-    // Create proposal via governance manager
-    let domain_id = GovernanceDomainId(req.domain_id.clone());
-    let suggested_id = ProposalId(format!("prop-{}", uuid::Uuid::new_v4()));
-
-    let proposal_id = gov_mgr
-        .create_proposal(
-            suggested_id,
-            domain_id,
-            proposer_did.clone(),
-            req.title.clone(),
-            req.description.clone(),
-            payload,
-        )
-        .await?;
-
-    // Track proposal creation
-    gateway::governance_proposals_created_inc();
-
-    // Broadcast event to WebSocket subscribers
-    event_broadcaster
-        .broadcast(
-            &req.domain_id,
-            GatewayEvent::GovernanceProposalCreated {
-                proposal_id: proposal_id.0.clone(),
-                domain_id: req.domain_id.clone(),
-                proposer: proposer_did.to_string(),
-                title: req.title.clone(),
-                payload_type: "federation".to_string(),
-            },
-        )
-        .await;
-
-    // Return created proposal
-    let proposal = gov_mgr.get_proposal(&proposal_id).await?.ok_or_else(|| {
-        crate::error::GatewayError::InternalError(
-            "Proposal creation succeeded but proposal not found".to_string(),
-        )
-    })?;
-
-    Ok(HttpResponse::Created().json(proposal))
+    create_federation_proposal_impl(&gov_mgr, &event_broadcaster, common, fed_proposal).await
 }
 
 /// POST /gov/proposals/federation/policy - Create an "update federation policy" proposal
@@ -1447,22 +1203,8 @@ pub async fn create_update_federation_policy_proposal(
     event_broadcaster: web::Data<Arc<EventBroadcaster>>,
     req: web::Json<UpdateFederationPolicyProposalRequest>,
 ) -> Result<HttpResponse> {
-    // Check authorization
-    require_scope(&http_req, "gov:write")?;
-
-    // Extract authenticated DID from JWT claims
-    let claims = get_claims(&http_req).ok_or_else(|| {
-        crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
-    })?;
-
-    let proposer_did: Did = claims.sub.parse().map_err(|e| {
-        crate::error::GatewayError::BadRequest(format!("Invalid DID in token: {e}"))
-    })?;
-
-    // Validate common fields
-    validation::validate_domain_id(&req.domain_id)?;
-    validation::validate_proposal_title(&req.title)?;
-    validation::validate_proposal_description(&req.description)?;
+    let common =
+        extract_federation_common(&http_req, &req.domain_id, &req.title, &req.description)?;
 
     // Validate federation-specific fields
     validation::validate_auto_accept_threshold(req.auto_accept_vouch_threshold)?;
@@ -1486,54 +1228,7 @@ pub async fn create_update_federation_policy_proposal(
         max_attestations_per_minute: req.max_attestations_per_minute,
     };
 
-    // Validate the federation proposal itself
-    fed_proposal
-        .validate()
-        .map_err(crate::error::GatewayError::BadRequest)?;
-
-    // Wrap in ProposalPayload
-    let payload = ProposalPayload::Federation(fed_proposal);
-
-    // Create proposal via governance manager
-    let domain_id = GovernanceDomainId(req.domain_id.clone());
-    let suggested_id = ProposalId(format!("prop-{}", uuid::Uuid::new_v4()));
-
-    let proposal_id = gov_mgr
-        .create_proposal(
-            suggested_id,
-            domain_id,
-            proposer_did.clone(),
-            req.title.clone(),
-            req.description.clone(),
-            payload,
-        )
-        .await?;
-
-    // Track proposal creation
-    gateway::governance_proposals_created_inc();
-
-    // Broadcast event to WebSocket subscribers
-    event_broadcaster
-        .broadcast(
-            &req.domain_id,
-            GatewayEvent::GovernanceProposalCreated {
-                proposal_id: proposal_id.0.clone(),
-                domain_id: req.domain_id.clone(),
-                proposer: proposer_did.to_string(),
-                title: req.title.clone(),
-                payload_type: "federation".to_string(),
-            },
-        )
-        .await;
-
-    // Return created proposal
-    let proposal = gov_mgr.get_proposal(&proposal_id).await?.ok_or_else(|| {
-        crate::error::GatewayError::InternalError(
-            "Proposal creation succeeded but proposal not found".to_string(),
-        )
-    })?;
-
-    Ok(HttpResponse::Created().json(proposal))
+    create_federation_proposal_impl(&gov_mgr, &event_broadcaster, common, fed_proposal).await
 }
 
 // ============================================================================

--- a/icn/crates/icn-gateway/src/api/governance.rs
+++ b/icn/crates/icn-gateway/src/api/governance.rs
@@ -11,13 +11,18 @@ use crate::governance_mgr::GovernanceManager;
 use crate::middleware::{get_claims, require_scope};
 use crate::models::{
     CastVoteRequest, CreateDelegationRequest, CreateDomainRequest, CreateProposalRequest,
-    DelegationListResponse, DelegationResponse, OpenProposalRequest, ProposalPayloadRequest,
+    DelegationListResponse, DelegationResponse, EstablishClearingProposalRequest,
+    JoinFederationProposalRequest, LeaveFederationProposalRequest, OpenProposalRequest,
+    ProposalPayloadRequest, RevokeVouchProposalRequest, TerminateClearingProposalRequest,
+    UpdateFederationPolicyProposalRequest, VouchProposalRequest,
 };
 use crate::pagination::{ListPagination, ListQuery, ListResponse};
 use crate::validation;
+use icn_federation::SettlementInterval;
 use icn_governance::{
-    Delegation, DelegationScope, GovernanceDomainId, GovernanceParams, MembershipConfig,
-    ProposalId, ProposalPayload, VoteChoice,
+    DataSharingLevel, Delegation, DelegationScope, DisputeResolutionMethod, FederationProposal,
+    FederationTerms, GovernanceDomainId, GovernanceParams, MembershipConfig, ProposalId,
+    ProposalPayload, VoteChoice,
 };
 use icn_identity::Did;
 use icn_obs::metrics::gateway;
@@ -851,6 +856,684 @@ pub async fn close_proposal(
     }
 
     Ok(HttpResponse::Ok().json(proposal))
+}
+
+// ============================================================================
+// Federation Proposal Endpoints
+// ============================================================================
+
+/// POST /gov/proposals/federation/join - Create a "join federation" proposal
+#[post("/proposals/federation/join")]
+pub async fn create_join_federation_proposal(
+    http_req: HttpRequest,
+    gov_mgr: web::Data<Arc<GovernanceManager>>,
+    event_broadcaster: web::Data<Arc<EventBroadcaster>>,
+    req: web::Json<JoinFederationProposalRequest>,
+) -> Result<HttpResponse> {
+    // Check authorization
+    require_scope(&http_req, "gov:write")?;
+
+    // Extract authenticated DID from JWT claims
+    let claims = get_claims(&http_req).ok_or_else(|| {
+        crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
+    })?;
+
+    let proposer_did: Did = claims.sub.parse().map_err(|e| {
+        crate::error::GatewayError::BadRequest(format!("Invalid DID in token: {e}"))
+    })?;
+
+    // Validate common fields
+    validation::validate_domain_id(&req.domain_id)?;
+    validation::validate_proposal_title(&req.title)?;
+    validation::validate_proposal_description(&req.description)?;
+
+    // Validate federation-specific fields
+    validation::validate_federation_id(&req.federation_id)?;
+    validation::validate_trust_score(req.terms.min_trust_threshold)?;
+    let data_sharing_level_str =
+        validation::validate_data_sharing_level(&req.terms.data_sharing_level)?;
+    let dispute_resolution_str =
+        validation::validate_dispute_resolution(&req.terms.dispute_resolution)?;
+
+    // Convert string types to enums
+    let data_sharing_level = match data_sharing_level_str.as_str() {
+        "none" => DataSharingLevel::None,
+        "metadata_only" => DataSharingLevel::MetadataOnly,
+        "full" => DataSharingLevel::Full,
+        _ => unreachable!(), // validation ensures valid value
+    };
+
+    let dispute_resolution = if dispute_resolution_str.starts_with("arbitrator:") {
+        let arbitrator_id = dispute_resolution_str
+            .strip_prefix("arbitrator:")
+            .unwrap_or("")
+            .to_string();
+        DisputeResolutionMethod::ArbitratorCooperative { arbitrator_id }
+    } else {
+        match dispute_resolution_str.as_str() {
+            "federation_mediation" => DisputeResolutionMethod::FederationMediation,
+            "federation_vote" => DisputeResolutionMethod::FederationVote,
+            _ => unreachable!(), // validation ensures valid value
+        }
+    };
+
+    // Build FederationTerms
+    let terms = FederationTerms {
+        min_trust_threshold: req.terms.min_trust_threshold,
+        governance_binding: req.terms.governance_binding,
+        data_sharing_level,
+        dispute_resolution,
+    };
+
+    // Build FederationProposal
+    let fed_proposal = FederationProposal::JoinFederation {
+        federation_id: req.federation_id.clone(),
+        terms,
+        sponsor_coop_id: req.sponsor_coop_id.clone(),
+    };
+
+    // Validate the federation proposal itself
+    fed_proposal
+        .validate()
+        .map_err(crate::error::GatewayError::BadRequest)?;
+
+    // Wrap in ProposalPayload
+    let payload = ProposalPayload::Federation(fed_proposal);
+
+    // Create proposal via governance manager
+    let domain_id = GovernanceDomainId(req.domain_id.clone());
+    let suggested_id = ProposalId(format!("prop-{}", uuid::Uuid::new_v4()));
+
+    let proposal_id = gov_mgr
+        .create_proposal(
+            suggested_id,
+            domain_id,
+            proposer_did.clone(),
+            req.title.clone(),
+            req.description.clone(),
+            payload,
+        )
+        .await?;
+
+    // Track proposal creation
+    gateway::governance_proposals_created_inc();
+
+    // Broadcast event to WebSocket subscribers
+    event_broadcaster
+        .broadcast(
+            &req.domain_id,
+            GatewayEvent::GovernanceProposalCreated {
+                proposal_id: proposal_id.0.clone(),
+                domain_id: req.domain_id.clone(),
+                proposer: proposer_did.to_string(),
+                title: req.title.clone(),
+                payload_type: "federation".to_string(),
+            },
+        )
+        .await;
+
+    // Return created proposal
+    let proposal = gov_mgr.get_proposal(&proposal_id).await?.ok_or_else(|| {
+        crate::error::GatewayError::InternalError(
+            "Proposal creation succeeded but proposal not found".to_string(),
+        )
+    })?;
+
+    Ok(HttpResponse::Created().json(proposal))
+}
+
+/// POST /gov/proposals/federation/leave - Create a "leave federation" proposal
+#[post("/proposals/federation/leave")]
+pub async fn create_leave_federation_proposal(
+    http_req: HttpRequest,
+    gov_mgr: web::Data<Arc<GovernanceManager>>,
+    event_broadcaster: web::Data<Arc<EventBroadcaster>>,
+    req: web::Json<LeaveFederationProposalRequest>,
+) -> Result<HttpResponse> {
+    // Check authorization
+    require_scope(&http_req, "gov:write")?;
+
+    // Extract authenticated DID from JWT claims
+    let claims = get_claims(&http_req).ok_or_else(|| {
+        crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
+    })?;
+
+    let proposer_did: Did = claims.sub.parse().map_err(|e| {
+        crate::error::GatewayError::BadRequest(format!("Invalid DID in token: {e}"))
+    })?;
+
+    // Validate common fields
+    validation::validate_domain_id(&req.domain_id)?;
+    validation::validate_proposal_title(&req.title)?;
+    validation::validate_proposal_description(&req.description)?;
+
+    // Validate federation-specific fields
+    validation::validate_federation_id(&req.federation_id)?;
+    validation::validate_reason(&req.reason)?;
+    validation::validate_grace_period_days(req.grace_period_days)?;
+
+    // Build FederationProposal
+    let fed_proposal = FederationProposal::LeaveFederation {
+        federation_id: req.federation_id.clone(),
+        reason: req.reason.clone(),
+        grace_period_days: req.grace_period_days,
+    };
+
+    // Validate the federation proposal itself
+    fed_proposal
+        .validate()
+        .map_err(crate::error::GatewayError::BadRequest)?;
+
+    // Wrap in ProposalPayload
+    let payload = ProposalPayload::Federation(fed_proposal);
+
+    // Create proposal via governance manager
+    let domain_id = GovernanceDomainId(req.domain_id.clone());
+    let suggested_id = ProposalId(format!("prop-{}", uuid::Uuid::new_v4()));
+
+    let proposal_id = gov_mgr
+        .create_proposal(
+            suggested_id,
+            domain_id,
+            proposer_did.clone(),
+            req.title.clone(),
+            req.description.clone(),
+            payload,
+        )
+        .await?;
+
+    // Track proposal creation
+    gateway::governance_proposals_created_inc();
+
+    // Broadcast event to WebSocket subscribers
+    event_broadcaster
+        .broadcast(
+            &req.domain_id,
+            GatewayEvent::GovernanceProposalCreated {
+                proposal_id: proposal_id.0.clone(),
+                domain_id: req.domain_id.clone(),
+                proposer: proposer_did.to_string(),
+                title: req.title.clone(),
+                payload_type: "federation".to_string(),
+            },
+        )
+        .await;
+
+    // Return created proposal
+    let proposal = gov_mgr.get_proposal(&proposal_id).await?.ok_or_else(|| {
+        crate::error::GatewayError::InternalError(
+            "Proposal creation succeeded but proposal not found".to_string(),
+        )
+    })?;
+
+    Ok(HttpResponse::Created().json(proposal))
+}
+
+/// POST /gov/proposals/federation/clearing - Create an "establish clearing" proposal
+#[post("/proposals/federation/clearing")]
+pub async fn create_establish_clearing_proposal(
+    http_req: HttpRequest,
+    gov_mgr: web::Data<Arc<GovernanceManager>>,
+    event_broadcaster: web::Data<Arc<EventBroadcaster>>,
+    req: web::Json<EstablishClearingProposalRequest>,
+) -> Result<HttpResponse> {
+    // Check authorization
+    require_scope(&http_req, "gov:write")?;
+
+    // Extract authenticated DID from JWT claims
+    let claims = get_claims(&http_req).ok_or_else(|| {
+        crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
+    })?;
+
+    let proposer_did: Did = claims.sub.parse().map_err(|e| {
+        crate::error::GatewayError::BadRequest(format!("Invalid DID in token: {e}"))
+    })?;
+
+    // Validate common fields
+    validation::validate_domain_id(&req.domain_id)?;
+    validation::validate_proposal_title(&req.title)?;
+    validation::validate_proposal_description(&req.description)?;
+
+    // Validate federation-specific fields
+    validation::validate_federation_id(&req.partner_coop_id)?;
+    validation::validate_max_imbalance(req.max_imbalance)?;
+    validation::validate_currency(&req.currency)?;
+    let settlement_interval_str =
+        validation::validate_settlement_interval(&req.settlement_interval)?;
+
+    // Parse partner DID
+    let partner_coop_did: Did = req.partner_coop_did.parse().map_err(|e| {
+        crate::error::GatewayError::BadRequest(format!("Invalid partner_coop_did: {e}"))
+    })?;
+
+    // Convert settlement interval string to enum
+    let settlement_interval = match settlement_interval_str.as_str() {
+        "daily" => SettlementInterval::Daily,
+        "weekly" => SettlementInterval::Weekly,
+        "monthly" => SettlementInterval::Monthly,
+        "manual" => SettlementInterval::Manual,
+        _ => unreachable!(), // validation ensures valid value
+    };
+
+    // Build FederationProposal
+    let fed_proposal = FederationProposal::EstablishClearing {
+        partner_coop_id: req.partner_coop_id.clone(),
+        partner_coop_did,
+        max_imbalance: req.max_imbalance,
+        settlement_interval,
+        currency: req.currency.clone(),
+    };
+
+    // Validate the federation proposal itself
+    fed_proposal
+        .validate()
+        .map_err(crate::error::GatewayError::BadRequest)?;
+
+    // Wrap in ProposalPayload
+    let payload = ProposalPayload::Federation(fed_proposal);
+
+    // Create proposal via governance manager
+    let domain_id = GovernanceDomainId(req.domain_id.clone());
+    let suggested_id = ProposalId(format!("prop-{}", uuid::Uuid::new_v4()));
+
+    let proposal_id = gov_mgr
+        .create_proposal(
+            suggested_id,
+            domain_id,
+            proposer_did.clone(),
+            req.title.clone(),
+            req.description.clone(),
+            payload,
+        )
+        .await?;
+
+    // Track proposal creation
+    gateway::governance_proposals_created_inc();
+
+    // Broadcast event to WebSocket subscribers
+    event_broadcaster
+        .broadcast(
+            &req.domain_id,
+            GatewayEvent::GovernanceProposalCreated {
+                proposal_id: proposal_id.0.clone(),
+                domain_id: req.domain_id.clone(),
+                proposer: proposer_did.to_string(),
+                title: req.title.clone(),
+                payload_type: "federation".to_string(),
+            },
+        )
+        .await;
+
+    // Return created proposal
+    let proposal = gov_mgr.get_proposal(&proposal_id).await?.ok_or_else(|| {
+        crate::error::GatewayError::InternalError(
+            "Proposal creation succeeded but proposal not found".to_string(),
+        )
+    })?;
+
+    Ok(HttpResponse::Created().json(proposal))
+}
+
+/// POST /gov/proposals/federation/clearing/terminate - Create a "terminate clearing" proposal
+#[post("/proposals/federation/clearing/terminate")]
+pub async fn create_terminate_clearing_proposal(
+    http_req: HttpRequest,
+    gov_mgr: web::Data<Arc<GovernanceManager>>,
+    event_broadcaster: web::Data<Arc<EventBroadcaster>>,
+    req: web::Json<TerminateClearingProposalRequest>,
+) -> Result<HttpResponse> {
+    // Check authorization
+    require_scope(&http_req, "gov:write")?;
+
+    // Extract authenticated DID from JWT claims
+    let claims = get_claims(&http_req).ok_or_else(|| {
+        crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
+    })?;
+
+    let proposer_did: Did = claims.sub.parse().map_err(|e| {
+        crate::error::GatewayError::BadRequest(format!("Invalid DID in token: {e}"))
+    })?;
+
+    // Validate common fields
+    validation::validate_domain_id(&req.domain_id)?;
+    validation::validate_proposal_title(&req.title)?;
+    validation::validate_proposal_description(&req.description)?;
+
+    // Validate federation-specific fields
+    validation::validate_federation_id(&req.partner_coop_id)?;
+    validation::validate_reason(&req.reason)?;
+
+    // Build FederationProposal
+    let fed_proposal = FederationProposal::TerminateClearing {
+        partner_coop_id: req.partner_coop_id.clone(),
+        reason: req.reason.clone(),
+    };
+
+    // Validate the federation proposal itself
+    fed_proposal
+        .validate()
+        .map_err(crate::error::GatewayError::BadRequest)?;
+
+    // Wrap in ProposalPayload
+    let payload = ProposalPayload::Federation(fed_proposal);
+
+    // Create proposal via governance manager
+    let domain_id = GovernanceDomainId(req.domain_id.clone());
+    let suggested_id = ProposalId(format!("prop-{}", uuid::Uuid::new_v4()));
+
+    let proposal_id = gov_mgr
+        .create_proposal(
+            suggested_id,
+            domain_id,
+            proposer_did.clone(),
+            req.title.clone(),
+            req.description.clone(),
+            payload,
+        )
+        .await?;
+
+    // Track proposal creation
+    gateway::governance_proposals_created_inc();
+
+    // Broadcast event to WebSocket subscribers
+    event_broadcaster
+        .broadcast(
+            &req.domain_id,
+            GatewayEvent::GovernanceProposalCreated {
+                proposal_id: proposal_id.0.clone(),
+                domain_id: req.domain_id.clone(),
+                proposer: proposer_did.to_string(),
+                title: req.title.clone(),
+                payload_type: "federation".to_string(),
+            },
+        )
+        .await;
+
+    // Return created proposal
+    let proposal = gov_mgr.get_proposal(&proposal_id).await?.ok_or_else(|| {
+        crate::error::GatewayError::InternalError(
+            "Proposal creation succeeded but proposal not found".to_string(),
+        )
+    })?;
+
+    Ok(HttpResponse::Created().json(proposal))
+}
+
+/// POST /gov/proposals/federation/vouch - Create a "vouch for cooperative" proposal
+#[post("/proposals/federation/vouch")]
+pub async fn create_vouch_proposal(
+    http_req: HttpRequest,
+    gov_mgr: web::Data<Arc<GovernanceManager>>,
+    event_broadcaster: web::Data<Arc<EventBroadcaster>>,
+    req: web::Json<VouchProposalRequest>,
+) -> Result<HttpResponse> {
+    // Check authorization
+    require_scope(&http_req, "gov:write")?;
+
+    // Extract authenticated DID from JWT claims
+    let claims = get_claims(&http_req).ok_or_else(|| {
+        crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
+    })?;
+
+    let proposer_did: Did = claims.sub.parse().map_err(|e| {
+        crate::error::GatewayError::BadRequest(format!("Invalid DID in token: {e}"))
+    })?;
+
+    // Validate common fields
+    validation::validate_domain_id(&req.domain_id)?;
+    validation::validate_proposal_title(&req.title)?;
+    validation::validate_proposal_description(&req.description)?;
+
+    // Validate federation-specific fields
+    validation::validate_federation_id(&req.target_coop_id)?;
+    validation::validate_trust_score(req.trust_score)?;
+    validation::validate_context(&req.context)?;
+    validation::validate_evidence(&req.evidence)?;
+
+    // Parse target DID
+    let target_coop_did: Did = req.target_coop_did.parse().map_err(|e| {
+        crate::error::GatewayError::BadRequest(format!("Invalid target_coop_did: {e}"))
+    })?;
+
+    // Build FederationProposal
+    let fed_proposal = FederationProposal::VouchForCooperative {
+        target_coop_id: req.target_coop_id.clone(),
+        target_coop_did,
+        trust_score: req.trust_score,
+        context: req.context.clone(),
+        evidence: req.evidence.clone(),
+    };
+
+    // Validate the federation proposal itself
+    fed_proposal
+        .validate()
+        .map_err(crate::error::GatewayError::BadRequest)?;
+
+    // Wrap in ProposalPayload
+    let payload = ProposalPayload::Federation(fed_proposal);
+
+    // Create proposal via governance manager
+    let domain_id = GovernanceDomainId(req.domain_id.clone());
+    let suggested_id = ProposalId(format!("prop-{}", uuid::Uuid::new_v4()));
+
+    let proposal_id = gov_mgr
+        .create_proposal(
+            suggested_id,
+            domain_id,
+            proposer_did.clone(),
+            req.title.clone(),
+            req.description.clone(),
+            payload,
+        )
+        .await?;
+
+    // Track proposal creation
+    gateway::governance_proposals_created_inc();
+
+    // Broadcast event to WebSocket subscribers
+    event_broadcaster
+        .broadcast(
+            &req.domain_id,
+            GatewayEvent::GovernanceProposalCreated {
+                proposal_id: proposal_id.0.clone(),
+                domain_id: req.domain_id.clone(),
+                proposer: proposer_did.to_string(),
+                title: req.title.clone(),
+                payload_type: "federation".to_string(),
+            },
+        )
+        .await;
+
+    // Return created proposal
+    let proposal = gov_mgr.get_proposal(&proposal_id).await?.ok_or_else(|| {
+        crate::error::GatewayError::InternalError(
+            "Proposal creation succeeded but proposal not found".to_string(),
+        )
+    })?;
+
+    Ok(HttpResponse::Created().json(proposal))
+}
+
+/// POST /gov/proposals/federation/vouch/revoke - Create a "revoke vouch" proposal
+#[post("/proposals/federation/vouch/revoke")]
+pub async fn create_revoke_vouch_proposal(
+    http_req: HttpRequest,
+    gov_mgr: web::Data<Arc<GovernanceManager>>,
+    event_broadcaster: web::Data<Arc<EventBroadcaster>>,
+    req: web::Json<RevokeVouchProposalRequest>,
+) -> Result<HttpResponse> {
+    // Check authorization
+    require_scope(&http_req, "gov:write")?;
+
+    // Extract authenticated DID from JWT claims
+    let claims = get_claims(&http_req).ok_or_else(|| {
+        crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
+    })?;
+
+    let proposer_did: Did = claims.sub.parse().map_err(|e| {
+        crate::error::GatewayError::BadRequest(format!("Invalid DID in token: {e}"))
+    })?;
+
+    // Validate common fields
+    validation::validate_domain_id(&req.domain_id)?;
+    validation::validate_proposal_title(&req.title)?;
+    validation::validate_proposal_description(&req.description)?;
+
+    // Validate federation-specific fields
+    validation::validate_federation_id(&req.target_coop_id)?;
+    validation::validate_reason(&req.reason)?;
+
+    // Build FederationProposal
+    let fed_proposal = FederationProposal::RevokeVouch {
+        target_coop_id: req.target_coop_id.clone(),
+        reason: req.reason.clone(),
+    };
+
+    // Validate the federation proposal itself
+    fed_proposal
+        .validate()
+        .map_err(crate::error::GatewayError::BadRequest)?;
+
+    // Wrap in ProposalPayload
+    let payload = ProposalPayload::Federation(fed_proposal);
+
+    // Create proposal via governance manager
+    let domain_id = GovernanceDomainId(req.domain_id.clone());
+    let suggested_id = ProposalId(format!("prop-{}", uuid::Uuid::new_v4()));
+
+    let proposal_id = gov_mgr
+        .create_proposal(
+            suggested_id,
+            domain_id,
+            proposer_did.clone(),
+            req.title.clone(),
+            req.description.clone(),
+            payload,
+        )
+        .await?;
+
+    // Track proposal creation
+    gateway::governance_proposals_created_inc();
+
+    // Broadcast event to WebSocket subscribers
+    event_broadcaster
+        .broadcast(
+            &req.domain_id,
+            GatewayEvent::GovernanceProposalCreated {
+                proposal_id: proposal_id.0.clone(),
+                domain_id: req.domain_id.clone(),
+                proposer: proposer_did.to_string(),
+                title: req.title.clone(),
+                payload_type: "federation".to_string(),
+            },
+        )
+        .await;
+
+    // Return created proposal
+    let proposal = gov_mgr.get_proposal(&proposal_id).await?.ok_or_else(|| {
+        crate::error::GatewayError::InternalError(
+            "Proposal creation succeeded but proposal not found".to_string(),
+        )
+    })?;
+
+    Ok(HttpResponse::Created().json(proposal))
+}
+
+/// POST /gov/proposals/federation/policy - Create an "update federation policy" proposal
+#[post("/proposals/federation/policy")]
+pub async fn create_update_federation_policy_proposal(
+    http_req: HttpRequest,
+    gov_mgr: web::Data<Arc<GovernanceManager>>,
+    event_broadcaster: web::Data<Arc<EventBroadcaster>>,
+    req: web::Json<UpdateFederationPolicyProposalRequest>,
+) -> Result<HttpResponse> {
+    // Check authorization
+    require_scope(&http_req, "gov:write")?;
+
+    // Extract authenticated DID from JWT claims
+    let claims = get_claims(&http_req).ok_or_else(|| {
+        crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
+    })?;
+
+    let proposer_did: Did = claims.sub.parse().map_err(|e| {
+        crate::error::GatewayError::BadRequest(format!("Invalid DID in token: {e}"))
+    })?;
+
+    // Validate common fields
+    validation::validate_domain_id(&req.domain_id)?;
+    validation::validate_proposal_title(&req.title)?;
+    validation::validate_proposal_description(&req.description)?;
+
+    // Validate federation-specific fields
+    validation::validate_auto_accept_threshold(req.auto_accept_vouch_threshold)?;
+    validation::validate_trust_decay_factor(req.trust_decay_factor)?;
+    validation::validate_max_attestations_per_minute(req.max_attestations_per_minute)?;
+
+    // Ensure at least one policy field is provided
+    if req.auto_accept_vouch_threshold.is_none()
+        && req.trust_decay_factor.is_none()
+        && req.max_attestations_per_minute.is_none()
+    {
+        return Err(crate::error::GatewayError::BadRequest(
+            "At least one policy field must be provided".to_string(),
+        ));
+    }
+
+    // Build FederationProposal
+    let fed_proposal = FederationProposal::UpdateFederationPolicy {
+        auto_accept_vouch_threshold: req.auto_accept_vouch_threshold,
+        trust_decay_factor: req.trust_decay_factor,
+        max_attestations_per_minute: req.max_attestations_per_minute,
+    };
+
+    // Validate the federation proposal itself
+    fed_proposal
+        .validate()
+        .map_err(crate::error::GatewayError::BadRequest)?;
+
+    // Wrap in ProposalPayload
+    let payload = ProposalPayload::Federation(fed_proposal);
+
+    // Create proposal via governance manager
+    let domain_id = GovernanceDomainId(req.domain_id.clone());
+    let suggested_id = ProposalId(format!("prop-{}", uuid::Uuid::new_v4()));
+
+    let proposal_id = gov_mgr
+        .create_proposal(
+            suggested_id,
+            domain_id,
+            proposer_did.clone(),
+            req.title.clone(),
+            req.description.clone(),
+            payload,
+        )
+        .await?;
+
+    // Track proposal creation
+    gateway::governance_proposals_created_inc();
+
+    // Broadcast event to WebSocket subscribers
+    event_broadcaster
+        .broadcast(
+            &req.domain_id,
+            GatewayEvent::GovernanceProposalCreated {
+                proposal_id: proposal_id.0.clone(),
+                domain_id: req.domain_id.clone(),
+                proposer: proposer_did.to_string(),
+                title: req.title.clone(),
+                payload_type: "federation".to_string(),
+            },
+        )
+        .await;
+
+    // Return created proposal
+    let proposal = gov_mgr.get_proposal(&proposal_id).await?.ok_or_else(|| {
+        crate::error::GatewayError::InternalError(
+            "Proposal creation succeeded but proposal not found".to_string(),
+        )
+    })?;
+
+    Ok(HttpResponse::Created().json(proposal))
 }
 
 // ============================================================================

--- a/icn/crates/icn-gateway/src/models.rs
+++ b/icn/crates/icn-gateway/src/models.rs
@@ -495,3 +495,157 @@ pub struct CrossPaymentQuote {
     /// Whether the rate is considered stale
     pub is_stale: bool,
 }
+
+// === Federation Proposal Requests (Issue #518) ===
+
+/// Common fields for federation proposal requests
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct FederationProposalCommon {
+    /// Governance domain to create proposal in
+    pub domain_id: String,
+    /// Short title for the proposal
+    pub title: String,
+    /// Rationale/explanation for the proposal
+    pub description: String,
+}
+
+/// Federation terms for join proposals
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct FederationTermsRequest {
+    /// Minimum trust score required for federation members (0.0-1.0)
+    pub min_trust_threshold: f64,
+    /// Whether federation governance decisions are binding
+    pub governance_binding: bool,
+    /// Data sharing level: "none", "metadata_only", "full"
+    pub data_sharing_level: String,
+    /// Dispute resolution: "federation_mediation", "federation_vote", or "arbitrator:<coop_id>"
+    pub dispute_resolution: String,
+}
+
+/// Request to create a "join federation" proposal
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct JoinFederationProposalRequest {
+    /// Governance domain to create proposal in
+    pub domain_id: String,
+    /// Short title for the proposal
+    pub title: String,
+    /// Rationale/explanation for the proposal
+    pub description: String,
+    /// ID of the federation to join
+    pub federation_id: String,
+    /// Terms for joining the federation
+    pub terms: FederationTermsRequest,
+    /// Optional sponsor cooperative ID
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sponsor_coop_id: Option<String>,
+}
+
+/// Request to create a "leave federation" proposal
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct LeaveFederationProposalRequest {
+    /// Governance domain to create proposal in
+    pub domain_id: String,
+    /// Short title for the proposal
+    pub title: String,
+    /// Rationale/explanation for the proposal
+    pub description: String,
+    /// ID of the federation to leave
+    pub federation_id: String,
+    /// Reason for leaving
+    pub reason: String,
+    /// Grace period in days (1-365)
+    pub grace_period_days: u32,
+}
+
+/// Request to create an "establish clearing" proposal
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct EstablishClearingProposalRequest {
+    /// Governance domain to create proposal in
+    pub domain_id: String,
+    /// Short title for the proposal
+    pub title: String,
+    /// Rationale/explanation for the proposal
+    pub description: String,
+    /// Partner cooperative ID
+    pub partner_coop_id: String,
+    /// Partner cooperative DID
+    pub partner_coop_did: String,
+    /// Maximum allowed imbalance (must be positive)
+    pub max_imbalance: i64,
+    /// Settlement interval: "daily", "weekly", "monthly", "manual"
+    pub settlement_interval: String,
+    /// Currency for the clearing agreement
+    pub currency: String,
+}
+
+/// Request to create a "terminate clearing" proposal
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct TerminateClearingProposalRequest {
+    /// Governance domain to create proposal in
+    pub domain_id: String,
+    /// Short title for the proposal
+    pub title: String,
+    /// Rationale/explanation for the proposal
+    pub description: String,
+    /// Partner cooperative ID
+    pub partner_coop_id: String,
+    /// Reason for termination
+    pub reason: String,
+}
+
+/// Request to create a "vouch for cooperative" proposal
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct VouchProposalRequest {
+    /// Governance domain to create proposal in
+    pub domain_id: String,
+    /// Short title for the proposal
+    pub title: String,
+    /// Rationale/explanation for the proposal
+    pub description: String,
+    /// Target cooperative ID to vouch for
+    pub target_coop_id: String,
+    /// Target cooperative DID
+    pub target_coop_did: String,
+    /// Trust score (0.0-1.0)
+    pub trust_score: f64,
+    /// Context for the vouch (e.g., "trade", "governance", "technical")
+    pub context: String,
+    /// Optional evidence/documentation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<String>,
+}
+
+/// Request to create a "revoke vouch" proposal
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct RevokeVouchProposalRequest {
+    /// Governance domain to create proposal in
+    pub domain_id: String,
+    /// Short title for the proposal
+    pub title: String,
+    /// Rationale/explanation for the proposal
+    pub description: String,
+    /// Target cooperative ID to revoke vouch from
+    pub target_coop_id: String,
+    /// Reason for revoking the vouch
+    pub reason: String,
+}
+
+/// Request to create an "update federation policy" proposal
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct UpdateFederationPolicyProposalRequest {
+    /// Governance domain to create proposal in
+    pub domain_id: String,
+    /// Short title for the proposal
+    pub title: String,
+    /// Rationale/explanation for the proposal
+    pub description: String,
+    /// Auto-accept vouch threshold (-1.0 to disable, or 0.0-1.0)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auto_accept_vouch_threshold: Option<f64>,
+    /// Trust decay factor (0.0-1.0)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trust_decay_factor: Option<f64>,
+    /// Maximum attestations per minute (must be > 0)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_attestations_per_minute: Option<u32>,
+}

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -918,6 +918,15 @@ impl GatewayServer {
                                 .service(api::governance::get_votes)
                                 .service(api::governance::open_proposal)
                                 .service(api::governance::close_proposal)
+                                // Federation proposal endpoints
+                                .service(api::governance::create_join_federation_proposal)
+                                .service(api::governance::create_leave_federation_proposal)
+                                .service(api::governance::create_establish_clearing_proposal)
+                                .service(api::governance::create_terminate_clearing_proposal)
+                                .service(api::governance::create_vouch_proposal)
+                                .service(api::governance::create_revoke_vouch_proposal)
+                                .service(api::governance::create_update_federation_policy_proposal)
+                                // Vote endpoints
                                 .service(api::governance::cast_vote)
                                 // Delegation endpoints
                                 .service(api::governance::create_delegation)

--- a/icn/crates/icn-gateway/src/validation.rs
+++ b/icn/crates/icn-gateway/src/validation.rs
@@ -510,6 +510,233 @@ pub fn validate_governance_params(
     Ok(())
 }
 
+// === Federation Proposal Validation (Issue #518) ===
+
+/// Maximum length for federation ID
+pub const MAX_FEDERATION_ID_LEN: usize = 128;
+
+/// Maximum length for reason strings (leave, terminate, revoke)
+pub const MAX_REASON_LEN: usize = 2000;
+
+/// Maximum length for evidence string
+pub const MAX_EVIDENCE_LEN: usize = 5000;
+
+/// Maximum length for context string
+pub const MAX_CONTEXT_LEN: usize = 256;
+
+/// Maximum grace period in days
+pub const MAX_GRACE_PERIOD_DAYS: u32 = 365;
+
+/// Validate federation ID
+pub fn validate_federation_id(id: &str) -> Result<()> {
+    if id.is_empty() || id.trim().is_empty() {
+        return Err(GatewayError::BadRequest(
+            "Federation ID cannot be empty".to_string(),
+        ));
+    }
+
+    if id.len() > MAX_FEDERATION_ID_LEN {
+        return Err(GatewayError::BadRequest(format!(
+            "Federation ID exceeds maximum length of {MAX_FEDERATION_ID_LEN} characters"
+        )));
+    }
+
+    // Validate characters (alphanumeric, hyphens, underscores, colons)
+    if !id
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_' || c == ':')
+    {
+        return Err(GatewayError::BadRequest(
+            "Federation ID must contain only alphanumeric characters, hyphens, underscores, and colons"
+                .to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate trust score (must be in [0.0, 1.0])
+pub fn validate_trust_score(score: f64) -> Result<()> {
+    if !score.is_finite() {
+        return Err(GatewayError::BadRequest(
+            "Trust score must be a finite number".to_string(),
+        ));
+    }
+
+    if !(0.0..=1.0).contains(&score) {
+        return Err(GatewayError::BadRequest(
+            "Trust score must be between 0.0 and 1.0".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate grace period in days (must be 1-365)
+pub fn validate_grace_period_days(days: u32) -> Result<()> {
+    if days == 0 {
+        return Err(GatewayError::BadRequest(
+            "Grace period must be at least 1 day".to_string(),
+        ));
+    }
+
+    if days > MAX_GRACE_PERIOD_DAYS {
+        return Err(GatewayError::BadRequest(format!(
+            "Grace period cannot exceed {MAX_GRACE_PERIOD_DAYS} days"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Validate settlement interval string and return parsed enum
+pub fn validate_settlement_interval(interval: &str) -> Result<String> {
+    match interval.to_lowercase().as_str() {
+        "daily" | "weekly" | "monthly" | "manual" => Ok(interval.to_lowercase()),
+        _ => Err(GatewayError::BadRequest(format!(
+            "Invalid settlement interval: '{interval}'. Valid values: daily, weekly, monthly, manual"
+        ))),
+    }
+}
+
+/// Validate data sharing level string and return parsed enum
+pub fn validate_data_sharing_level(level: &str) -> Result<String> {
+    match level.to_lowercase().as_str() {
+        "none" | "metadata_only" | "full" => Ok(level.to_lowercase()),
+        _ => Err(GatewayError::BadRequest(format!(
+            "Invalid data sharing level: '{level}'. Valid values: none, metadata_only, full"
+        ))),
+    }
+}
+
+/// Validate dispute resolution string and return normalized version
+pub fn validate_dispute_resolution(method: &str) -> Result<String> {
+    let lower = method.to_lowercase();
+    match lower.as_str() {
+        "federation_mediation" | "federation_vote" => Ok(lower),
+        s if s.starts_with("arbitrator:") => {
+            let arbitrator_id = s.strip_prefix("arbitrator:").unwrap_or("");
+            if arbitrator_id.is_empty() || arbitrator_id.trim().is_empty() {
+                return Err(GatewayError::BadRequest(
+                    "Arbitrator ID cannot be empty in dispute resolution".to_string(),
+                ));
+            }
+            Ok(method.to_string())
+        }
+        _ => Err(GatewayError::BadRequest(format!(
+            "Invalid dispute resolution: '{method}'. Valid values: federation_mediation, federation_vote, arbitrator:<coop_id>"
+        ))),
+    }
+}
+
+/// Validate reason string (for leave, terminate, revoke)
+pub fn validate_reason(reason: &str) -> Result<()> {
+    if reason.is_empty() || reason.trim().is_empty() {
+        return Err(GatewayError::BadRequest(
+            "Reason cannot be empty".to_string(),
+        ));
+    }
+
+    if reason.len() > MAX_REASON_LEN {
+        return Err(GatewayError::BadRequest(format!(
+            "Reason exceeds maximum length of {MAX_REASON_LEN} characters"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Validate context string (for vouch)
+pub fn validate_context(context: &str) -> Result<()> {
+    if context.is_empty() || context.trim().is_empty() {
+        return Err(GatewayError::BadRequest(
+            "Context cannot be empty".to_string(),
+        ));
+    }
+
+    if context.len() > MAX_CONTEXT_LEN {
+        return Err(GatewayError::BadRequest(format!(
+            "Context exceeds maximum length of {MAX_CONTEXT_LEN} characters"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Validate optional evidence string
+pub fn validate_evidence(evidence: &Option<String>) -> Result<()> {
+    if let Some(ev) = evidence {
+        if ev.len() > MAX_EVIDENCE_LEN {
+            return Err(GatewayError::BadRequest(format!(
+                "Evidence exceeds maximum length of {MAX_EVIDENCE_LEN} characters"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate max imbalance (must be positive)
+pub fn validate_max_imbalance(max_imbalance: i64) -> Result<()> {
+    if max_imbalance <= 0 {
+        return Err(GatewayError::BadRequest(
+            "Max imbalance must be positive".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate auto-accept vouch threshold (-1.0 to disable, or 0.0-1.0)
+pub fn validate_auto_accept_threshold(threshold: Option<f64>) -> Result<()> {
+    if let Some(t) = threshold {
+        if !t.is_finite() {
+            return Err(GatewayError::BadRequest(
+                "Auto-accept threshold must be a finite number".to_string(),
+            ));
+        }
+        // -1.0 means disabled, otherwise must be in [0.0, 1.0]
+        if t != -1.0 && !(0.0..=1.0).contains(&t) {
+            return Err(GatewayError::BadRequest(
+                "Auto-accept threshold must be -1.0 (disabled) or between 0.0 and 1.0".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate trust decay factor (0.0-1.0)
+pub fn validate_trust_decay_factor(factor: Option<f64>) -> Result<()> {
+    if let Some(f) = factor {
+        if !f.is_finite() {
+            return Err(GatewayError::BadRequest(
+                "Trust decay factor must be a finite number".to_string(),
+            ));
+        }
+        if !(0.0..=1.0).contains(&f) {
+            return Err(GatewayError::BadRequest(
+                "Trust decay factor must be between 0.0 and 1.0".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate max attestations per minute (must be > 0)
+pub fn validate_max_attestations_per_minute(rate: Option<u32>) -> Result<()> {
+    if let Some(r) = rate {
+        if r == 0 {
+            return Err(GatewayError::BadRequest(
+                "Max attestations per minute must be greater than 0".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/icn/crates/icn-gateway/src/validation.rs
+++ b/icn/crates/icn-gateway/src/validation.rs
@@ -666,6 +666,11 @@ pub fn validate_context(context: &str) -> Result<()> {
 /// Validate optional evidence string
 pub fn validate_evidence(evidence: &Option<String>) -> Result<()> {
     if let Some(ev) = evidence {
+        if ev.is_empty() || ev.trim().is_empty() {
+            return Err(GatewayError::BadRequest(
+                "Evidence cannot be empty if provided".to_string(),
+            ));
+        }
         if ev.len() > MAX_EVIDENCE_LEN {
             return Err(GatewayError::BadRequest(format!(
                 "Evidence exceeds maximum length of {MAX_EVIDENCE_LEN} characters"
@@ -953,5 +958,198 @@ mod tests {
 
         // Invalid voting period (too long)
         assert!(validate_governance_params(50, 66, MAX_VOTING_PERIOD_SECONDS + 1).is_err());
+    }
+
+    // ============================================================================
+    // Federation Validation Tests
+    // ============================================================================
+
+    #[test]
+    fn test_validate_federation_id() {
+        // Valid IDs
+        assert!(validate_federation_id("test-federation").is_ok());
+        assert!(validate_federation_id("regional-food-fed").is_ok());
+        assert!(validate_federation_id("coop123").is_ok());
+
+        // Invalid IDs
+        assert!(validate_federation_id("").is_err()); // Empty
+        assert!(validate_federation_id("   ").is_err()); // Whitespace-only
+        assert!(validate_federation_id(&"a".repeat(MAX_FEDERATION_ID_LEN + 1)).is_err()); // Too long
+        assert!(validate_federation_id("test federation").is_err()); // Space
+        assert!(validate_federation_id("test@federation").is_err()); // Special char
+    }
+
+    #[test]
+    fn test_validate_trust_score() {
+        // Valid scores
+        assert!(validate_trust_score(0.0).is_ok());
+        assert!(validate_trust_score(0.5).is_ok());
+        assert!(validate_trust_score(1.0).is_ok());
+
+        // Invalid scores
+        assert!(validate_trust_score(-0.1).is_err()); // Negative
+        assert!(validate_trust_score(1.1).is_err()); // Too high
+        assert!(validate_trust_score(f64::NAN).is_err()); // NaN
+        assert!(validate_trust_score(f64::INFINITY).is_err()); // Infinity
+        assert!(validate_trust_score(f64::NEG_INFINITY).is_err()); // Negative infinity
+    }
+
+    #[test]
+    fn test_validate_grace_period_days() {
+        // Valid periods
+        assert!(validate_grace_period_days(1).is_ok());
+        assert!(validate_grace_period_days(30).is_ok());
+        assert!(validate_grace_period_days(365).is_ok());
+
+        // Invalid periods
+        assert!(validate_grace_period_days(0).is_err()); // Zero
+        assert!(validate_grace_period_days(366).is_err()); // > 365
+        assert!(validate_grace_period_days(1000).is_err()); // Way too long
+    }
+
+    #[test]
+    fn test_validate_settlement_interval() {
+        // Valid intervals
+        assert!(validate_settlement_interval("daily").is_ok());
+        assert!(validate_settlement_interval("DAILY").is_ok()); // Case insensitive
+        assert!(validate_settlement_interval("weekly").is_ok());
+        assert!(validate_settlement_interval("monthly").is_ok());
+        assert!(validate_settlement_interval("manual").is_ok());
+
+        // Returns normalized lowercase
+        assert_eq!(
+            validate_settlement_interval("WEEKLY").unwrap(),
+            "weekly".to_string()
+        );
+
+        // Invalid intervals
+        assert!(validate_settlement_interval("yearly").is_err());
+        assert!(validate_settlement_interval("hourly").is_err());
+        assert!(validate_settlement_interval("").is_err());
+    }
+
+    #[test]
+    fn test_validate_data_sharing_level() {
+        // Valid levels
+        assert!(validate_data_sharing_level("none").is_ok());
+        assert!(validate_data_sharing_level("NONE").is_ok()); // Case insensitive
+        assert!(validate_data_sharing_level("metadata_only").is_ok());
+        assert!(validate_data_sharing_level("full").is_ok());
+
+        // Returns normalized lowercase
+        assert_eq!(
+            validate_data_sharing_level("FULL").unwrap(),
+            "full".to_string()
+        );
+
+        // Invalid levels
+        assert!(validate_data_sharing_level("partial").is_err());
+        assert!(validate_data_sharing_level("").is_err());
+    }
+
+    #[test]
+    fn test_validate_dispute_resolution() {
+        // Valid methods
+        assert!(validate_dispute_resolution("federation_mediation").is_ok());
+        assert!(validate_dispute_resolution("FEDERATION_MEDIATION").is_ok()); // Case insensitive
+        assert!(validate_dispute_resolution("federation_vote").is_ok());
+        assert!(validate_dispute_resolution("arbitrator:neutral-coop").is_ok());
+
+        // Arbitrator with empty ID
+        assert!(validate_dispute_resolution("arbitrator:").is_err());
+        assert!(validate_dispute_resolution("arbitrator:   ").is_err());
+
+        // Invalid methods
+        assert!(validate_dispute_resolution("court").is_err());
+        assert!(validate_dispute_resolution("").is_err());
+    }
+
+    #[test]
+    fn test_validate_reason() {
+        // Valid reasons
+        assert!(validate_reason("Strategic realignment").is_ok());
+        assert!(validate_reason("a").is_ok()); // Single char
+
+        // Invalid reasons
+        assert!(validate_reason("").is_err()); // Empty
+        assert!(validate_reason("   ").is_err()); // Whitespace-only
+        assert!(validate_reason(&"a".repeat(MAX_REASON_LEN + 1)).is_err()); // Too long
+    }
+
+    #[test]
+    fn test_validate_context() {
+        // Valid contexts
+        assert!(validate_context("trade").is_ok());
+        assert!(validate_context("governance").is_ok());
+
+        // Invalid contexts
+        assert!(validate_context("").is_err()); // Empty
+        assert!(validate_context("   ").is_err()); // Whitespace-only
+        assert!(validate_context(&"a".repeat(MAX_CONTEXT_LEN + 1)).is_err()); // Too long
+    }
+
+    #[test]
+    fn test_validate_evidence() {
+        // Valid evidence
+        assert!(validate_evidence(&None).is_ok());
+        assert!(validate_evidence(&Some("Supporting documentation".to_string())).is_ok());
+
+        // Invalid evidence
+        assert!(validate_evidence(&Some("".to_string())).is_err()); // Empty string
+        assert!(validate_evidence(&Some("   ".to_string())).is_err()); // Whitespace-only
+        assert!(validate_evidence(&Some("a".repeat(MAX_EVIDENCE_LEN + 1))).is_err());
+        // Too long
+    }
+
+    #[test]
+    fn test_validate_max_imbalance() {
+        // Valid imbalances
+        assert!(validate_max_imbalance(1).is_ok());
+        assert!(validate_max_imbalance(1000).is_ok());
+        assert!(validate_max_imbalance(1_000_000).is_ok());
+
+        // Invalid imbalances
+        assert!(validate_max_imbalance(0).is_err()); // Zero
+        assert!(validate_max_imbalance(-100).is_err()); // Negative
+    }
+
+    #[test]
+    fn test_validate_auto_accept_threshold() {
+        // Valid thresholds
+        assert!(validate_auto_accept_threshold(None).is_ok());
+        assert!(validate_auto_accept_threshold(Some(0.0)).is_ok());
+        assert!(validate_auto_accept_threshold(Some(0.5)).is_ok());
+        assert!(validate_auto_accept_threshold(Some(1.0)).is_ok());
+        assert!(validate_auto_accept_threshold(Some(-1.0)).is_ok()); // Disabled
+
+        // Invalid thresholds
+        assert!(validate_auto_accept_threshold(Some(-0.5)).is_err()); // Not -1.0 and negative
+        assert!(validate_auto_accept_threshold(Some(1.1)).is_err()); // Too high
+        assert!(validate_auto_accept_threshold(Some(f64::NAN)).is_err()); // NaN
+    }
+
+    #[test]
+    fn test_validate_trust_decay_factor() {
+        // Valid factors
+        assert!(validate_trust_decay_factor(None).is_ok());
+        assert!(validate_trust_decay_factor(Some(0.0)).is_ok());
+        assert!(validate_trust_decay_factor(Some(0.05)).is_ok());
+        assert!(validate_trust_decay_factor(Some(1.0)).is_ok());
+
+        // Invalid factors
+        assert!(validate_trust_decay_factor(Some(-0.1)).is_err()); // Negative
+        assert!(validate_trust_decay_factor(Some(1.1)).is_err()); // Too high
+        assert!(validate_trust_decay_factor(Some(f64::NAN)).is_err()); // NaN
+    }
+
+    #[test]
+    fn test_validate_max_attestations_per_minute() {
+        // Valid rates
+        assert!(validate_max_attestations_per_minute(None).is_ok());
+        assert!(validate_max_attestations_per_minute(Some(1)).is_ok());
+        assert!(validate_max_attestations_per_minute(Some(100)).is_ok());
+
+        // Invalid rates
+        assert!(validate_max_attestations_per_minute(Some(0)).is_err()); // Zero
     }
 }


### PR DESCRIPTION
## Summary

Implements Issue #518: Add 7 REST API endpoints for creating federation governance proposals.

## Endpoints Added

| Endpoint | Handler | Description |
|----------|---------|-------------|
| `POST /gov/proposals/federation/join` | `create_join_federation_proposal` | Create proposal to join a federation |
| `POST /gov/proposals/federation/leave` | `create_leave_federation_proposal` | Create proposal to leave a federation |
| `POST /gov/proposals/federation/clearing` | `create_establish_clearing_proposal` | Create proposal to establish clearing agreement |
| `POST /gov/proposals/federation/clearing/terminate` | `create_terminate_clearing_proposal` | Create proposal to terminate clearing agreement |
| `POST /gov/proposals/federation/vouch` | `create_vouch_proposal` | Create proposal to vouch for a cooperative |
| `POST /gov/proposals/federation/vouch/revoke` | `create_revoke_vouch_proposal` | Create proposal to revoke a vouch |
| `POST /gov/proposals/federation/policy` | `create_update_federation_policy_proposal` | Create proposal to update federation policy |

## Changes

### models.rs
- Add 9 request structs for federation proposals
- All structs derive `ToSchema` for OpenAPI documentation

### validation.rs
- Add 12 validation functions for federation-specific fields
- Includes length limits, range validation, and enum string parsing

### api/governance.rs
- Add 7 handler functions following the existing proposal pattern
- Each handler: validates inputs → builds FederationProposal → validates structurally → creates via GovernanceManager → broadcasts event → returns proposal

### server.rs
- Register 7 new routes under `/gov` scope

## Request Example

```json
POST /api/v1/gov/proposals/federation/join
{
  "domain_id": "coop:food",
  "title": "Join Regional Food Federation",
  "description": "Proposal to join the regional food cooperative federation",
  "federation_id": "regional-food-fed",
  "terms": {
    "min_trust_threshold": 0.6,
    "governance_binding": true,
    "data_sharing_level": "metadata_only",
    "dispute_resolution": "federation_mediation"
  },
  "sponsor_coop_id": "organic-farms-coop"
}
```

## Test plan

- [x] `cargo check -p icn-gateway` passes
- [x] `cargo clippy -p icn-gateway --all-features -- -D warnings` passes
- [x] `cargo fmt -p icn-gateway -- --check` passes
- [x] `cargo test -p icn-gateway` passes (353 tests)

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)