### PR TITLE
test(net): Add tests for invalid/wrong cached PQ key error paths

### DIFF
--- a/icn/crates/icn-net/src/handlers/signed.rs
+++ b/icn/crates/icn-net/src/handlers/signed.rs
@@ -560,4 +560,129 @@ mod tests {
             "Hybrid envelope should be forwarded with deferred verification"
         );
     }
+
+    /// Test that hybrid envelopes fail verification when cached PQ key is invalid/corrupted
+    #[tokio::test]
+    #[cfg(feature = "post-quantum")]
+    async fn test_hybrid_verification_fails_with_invalid_cached_key() {
+        use crate::actor::PeerConnectionInfo;
+        use crate::version::CapabilityFlags;
+
+        let (ctx, forward_count) = create_test_context(None);
+        let sender = KeyPair::generate().unwrap();
+
+        // Sender should have PQ keys
+        assert!(sender.has_pq_keys(), "Sender should have PQ keys");
+
+        // Cache an INVALID/corrupted ML-DSA public key (wrong size/format)
+        {
+            let mut connections = ctx.peer_connections.write().await;
+            connections.insert(
+                sender.did().clone(),
+                PeerConnectionInfo {
+                    did: sender.did().clone(),
+                    negotiated_version: 1,
+                    peer_capabilities: CapabilityFlags::HYBRID_SIGNATURES,
+                    peer_software: "test".to_string(),
+                    x25519_key: [0u8; 32],
+                    ml_dsa_public: Some(vec![0xDE, 0xAD, 0xBE, 0xEF]), // Invalid: too short
+                    ml_kem_public: None,
+                },
+            );
+        }
+
+        // Create a valid hybrid envelope
+        let envelope = SignedEnvelope::new_hybrid(
+            sender.did(),
+            &sender,
+            1,
+            PayloadType::Gossip,
+            b"test invalid key".to_vec(),
+        )
+        .expect("Failed to create hybrid envelope");
+
+        assert!(envelope.is_hybrid(), "Envelope should be hybrid");
+
+        let message = NetworkMessage {
+            version: 1,
+            from: sender.did().clone(),
+            to: None,
+            trace_context: None,
+            payload: MessagePayload::Signed(envelope.clone()),
+        };
+
+        // Handle the signed message - should fail due to invalid cached key
+        ctx.handle_signed(message, &envelope).await;
+
+        // Message should NOT be forwarded (verification failed)
+        assert_eq!(
+            forward_count.load(Ordering::SeqCst),
+            0,
+            "Hybrid envelope should NOT be forwarded when cached PQ key is invalid"
+        );
+    }
+
+    /// Test that hybrid envelopes fail verification when cached PQ key doesn't match sender
+    #[tokio::test]
+    #[cfg(feature = "post-quantum")]
+    async fn test_hybrid_verification_fails_with_wrong_cached_key() {
+        use crate::actor::PeerConnectionInfo;
+        use crate::version::CapabilityFlags;
+
+        let (ctx, forward_count) = create_test_context(None);
+        let sender = KeyPair::generate().unwrap();
+        let other = KeyPair::generate().unwrap(); // Different keypair
+
+        // Sender should have PQ keys
+        assert!(sender.has_pq_keys(), "Sender should have PQ keys");
+        assert!(other.has_pq_keys(), "Other should have PQ keys");
+
+        // Cache the WRONG peer's PQ key (other's key instead of sender's)
+        let wrong_ml_dsa_public = other.pq_public_key().map(|pk| pk.as_bytes().to_vec());
+        {
+            let mut connections = ctx.peer_connections.write().await;
+            connections.insert(
+                sender.did().clone(),
+                PeerConnectionInfo {
+                    did: sender.did().clone(),
+                    negotiated_version: 1,
+                    peer_capabilities: CapabilityFlags::HYBRID_SIGNATURES,
+                    peer_software: "test".to_string(),
+                    x25519_key: [0u8; 32],
+                    ml_dsa_public: wrong_ml_dsa_public, // Wrong key!
+                    ml_kem_public: None,
+                },
+            );
+        }
+
+        // Create a valid hybrid envelope signed by sender
+        let envelope = SignedEnvelope::new_hybrid(
+            sender.did(),
+            &sender,
+            1,
+            PayloadType::Gossip,
+            b"test wrong key".to_vec(),
+        )
+        .expect("Failed to create hybrid envelope");
+
+        assert!(envelope.is_hybrid(), "Envelope should be hybrid");
+
+        let message = NetworkMessage {
+            version: 1,
+            from: sender.did().clone(),
+            to: None,
+            trace_context: None,
+            payload: MessagePayload::Signed(envelope.clone()),
+        };
+
+        // Handle the signed message - should fail because cached key is wrong
+        ctx.handle_signed(message, &envelope).await;
+
+        // Message should NOT be forwarded (ML-DSA signature won't verify with wrong key)
+        assert_eq!(
+            forward_count.load(Ordering::SeqCst),
+            0,
+            "Hybrid envelope should NOT be forwarded when cached PQ key doesn't match"
+        );
+    }
 }

--- a/icn/crates/icn-net/src/handlers/signed.rs
+++ b/icn/crates/icn-net/src/handlers/signed.rs
@@ -568,13 +568,17 @@ mod tests {
         use crate::actor::PeerConnectionInfo;
         use crate::version::CapabilityFlags;
 
-        let (ctx, forward_count) = create_test_context(None);
+        let detector = Arc::new(RwLock::new(MisbehaviorDetector::new(
+            MisbehaviorThresholds::default(),
+        )));
+        let (ctx, forward_count) = create_test_context(Some(detector.clone()));
         let sender = KeyPair::generate().unwrap();
 
         // Sender should have PQ keys
         assert!(sender.has_pq_keys(), "Sender should have PQ keys");
 
         // Cache an INVALID/corrupted ML-DSA public key (wrong size/format)
+        // ML-DSA-65 public keys are 1952 bytes; this 4-byte value will fail from_bytes()
         {
             let mut connections = ctx.peer_connections.write().await;
             connections.insert(
@@ -585,7 +589,7 @@ mod tests {
                     peer_capabilities: CapabilityFlags::HYBRID_SIGNATURES,
                     peer_software: "test".to_string(),
                     x25519_key: [0u8; 32],
-                    ml_dsa_public: Some(vec![0xDE, 0xAD, 0xBE, 0xEF]), // Invalid: too short
+                    ml_dsa_public: Some(vec![0xDE, 0xAD, 0xBE, 0xEF]), // Invalid: 4 bytes vs required 1952
                     ml_kem_public: None,
                 },
             );
@@ -620,6 +624,21 @@ mod tests {
             0,
             "Hybrid envelope should NOT be forwarded when cached PQ key is invalid"
         );
+
+        // Should record an InvalidSignature violation for Byzantine fault detection
+        let detector_guard = detector.read().await;
+        let violations = detector_guard.get_violations(sender.did());
+        assert!(
+            !violations.is_empty(),
+            "Should record a violation for invalid PQ key"
+        );
+        assert!(
+            matches!(
+                violations[0].violation,
+                icn_security::Violation::InvalidSignature { .. }
+            ),
+            "Violation should be InvalidSignature"
+        );
     }
 
     /// Test that hybrid envelopes fail verification when cached PQ key doesn't match sender
@@ -629,7 +648,10 @@ mod tests {
         use crate::actor::PeerConnectionInfo;
         use crate::version::CapabilityFlags;
 
-        let (ctx, forward_count) = create_test_context(None);
+        let detector = Arc::new(RwLock::new(MisbehaviorDetector::new(
+            MisbehaviorThresholds::default(),
+        )));
+        let (ctx, forward_count) = create_test_context(Some(detector.clone()));
         let sender = KeyPair::generate().unwrap();
         let other = KeyPair::generate().unwrap(); // Different keypair
 
@@ -683,6 +705,21 @@ mod tests {
             forward_count.load(Ordering::SeqCst),
             0,
             "Hybrid envelope should NOT be forwarded when cached PQ key doesn't match"
+        );
+
+        // Should record an InvalidSignature violation for Byzantine fault detection
+        let detector_guard = detector.read().await;
+        let violations = detector_guard.get_violations(sender.did());
+        assert!(
+            !violations.is_empty(),
+            "Should record a violation for wrong PQ key"
+        );
+        assert!(
+            matches!(
+                violations[0].violation,
+                icn_security::Violation::InvalidSignature { .. }
+            ),
+            "Violation should be InvalidSignature"
         );
     }
 }


### PR DESCRIPTION
## Summary

Adds test coverage for the error paths when a cached ML-DSA key is invalid or doesn't match the sender.

## Changes

Two new tests:

1. **`test_hybrid_verification_fails_with_invalid_cached_key`**
   - Caches a corrupted/malformed ML-DSA public key (4 bytes instead of ~1952)
   - Verifies that `from_bytes()` fails and verification rejects the message
   - Message is NOT forwarded

2. **`test_hybrid_verification_fails_with_wrong_cached_key`**  
   - Caches a different peer's valid ML-DSA public key
   - Verifies that ML-DSA signature verification fails (key mismatch)
   - Confirms defense-in-depth: even with a valid PQ key format, wrong key cannot forge signatures

## Test Plan

```bash
cargo test -p icn-net --features post-quantum --lib -- test_hybrid_verification_fails
```

Both tests pass ✅

Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)