### PR TITLE
feat(obs): Add hybrid verification cache metrics

### DIFF
--- a/icn/crates/icn-net/src/handlers/signed.rs
+++ b/icn/crates/icn-net/src/handlers/signed.rs
@@ -174,7 +174,7 @@ impl ConnectionContext {
                         Ok(key) => key,
                         Err(e) => {
                             icn_obs::metrics::network::hybrid_verification_failed_inc(
-                                "invalid_pq_key",
+                                icn_obs::metrics::network::HybridVerificationFailure::InvalidPqKey,
                             );
                             return Err(anyhow::anyhow!("Invalid cached ML-DSA key: {e}"));
                         }
@@ -186,12 +186,23 @@ impl ConnectionContext {
                     );
 
                     let result = envelope.verify_with_pq_key(max_age_secs, &pq_key);
-                    if result.is_ok() {
-                        icn_obs::metrics::network::hybrid_verification_cache_hit_inc();
-                    } else {
-                        icn_obs::metrics::network::hybrid_verification_failed_inc(
-                            "pq_signature_mismatch",
-                        );
+                    match &result {
+                        Ok(()) => {
+                            icn_obs::metrics::network::hybrid_verification_cache_hit_inc();
+                        }
+                        Err(_) => {
+                            // Distinguish classical vs PQ signature failures:
+                            // If classical-only verify also fails -> classical signature issue
+                            // If classical-only verify succeeds -> PQ-side issue
+                            let failure_reason = if envelope.verify(max_age_secs).is_ok() {
+                                icn_obs::metrics::network::HybridVerificationFailure::PqSignatureMismatch
+                            } else {
+                                icn_obs::metrics::network::HybridVerificationFailure::ClassicalSignatureFailed
+                            };
+                            icn_obs::metrics::network::hybrid_verification_failed_inc(
+                                failure_reason,
+                            );
+                        }
                     }
                     return result;
                 }

--- a/icn/crates/icn-net/src/handlers/signed.rs
+++ b/icn/crates/icn-net/src/handlers/signed.rs
@@ -170,15 +170,30 @@ impl ConnectionContext {
             if let Some(peer_info) = connections.get(&envelope.from) {
                 if let Some(ref ml_dsa_bytes) = peer_info.ml_dsa_public {
                     // We have the sender's PQ key - perform full hybrid verification
-                    let pq_key = icn_crypto_pq::MlDsaPublicKey::from_bytes(ml_dsa_bytes)
-                        .map_err(|e| anyhow::anyhow!("Invalid cached ML-DSA key: {e}"))?;
+                    let pq_key = match icn_crypto_pq::MlDsaPublicKey::from_bytes(ml_dsa_bytes) {
+                        Ok(key) => key,
+                        Err(e) => {
+                            icn_obs::metrics::network::hybrid_verification_failed_inc(
+                                "invalid_pq_key",
+                            );
+                            return Err(anyhow::anyhow!("Invalid cached ML-DSA key: {e}"));
+                        }
+                    };
 
                     debug!(
                         "Performing full hybrid verification for {} using cached PQ key",
                         envelope.from
                     );
 
-                    return envelope.verify_with_pq_key(max_age_secs, &pq_key);
+                    let result = envelope.verify_with_pq_key(max_age_secs, &pq_key);
+                    if result.is_ok() {
+                        icn_obs::metrics::network::hybrid_verification_cache_hit_inc();
+                    } else {
+                        icn_obs::metrics::network::hybrid_verification_failed_inc(
+                            "pq_signature_mismatch",
+                        );
+                    }
+                    return result;
                 }
             }
             // No cached PQ key - fall through to deferred verification
@@ -186,6 +201,7 @@ impl ConnectionContext {
                 "No cached PQ key for {} - using deferred hybrid verification",
                 envelope.from
             );
+            icn_obs::metrics::network::hybrid_verification_cache_miss_inc();
         }
 
         // Classical envelope or no cached PQ key - use standard verification

--- a/icn/crates/icn-obs/src/metrics/network.rs
+++ b/icn/crates/icn-obs/src/metrics/network.rs
@@ -316,14 +316,34 @@ pub fn hybrid_verification_cache_miss_inc() {
     counter!("icn_network_hybrid_verification_cache_miss_total").increment(1);
 }
 
+/// Failure reason for hybrid signature verification
+#[derive(Debug, Clone, Copy)]
+pub enum HybridVerificationFailure {
+    /// Cached ML-DSA key is malformed/corrupted
+    InvalidPqKey,
+    /// ML-DSA signature didn't verify with cached key
+    PqSignatureMismatch,
+    /// Ed25519 (classical) signature verification failed
+    ClassicalSignatureFailed,
+}
+
+impl HybridVerificationFailure {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::InvalidPqKey => "invalid_pq_key",
+            Self::PqSignatureMismatch => "pq_signature_mismatch",
+            Self::ClassicalSignatureFailed => "classical_signature_failed",
+        }
+    }
+}
+
 /// Increment hybrid verification failed counter with reason
 ///
 /// Called when hybrid signature verification fails.
-/// Reasons: "invalid_pq_key", "pq_signature_mismatch", "ed25519_failed"
-pub fn hybrid_verification_failed_inc(reason: &str) {
+pub fn hybrid_verification_failed_inc(reason: HybridVerificationFailure) {
     counter!(
         "icn_network_hybrid_verification_failed_total",
-        "reason" => reason.to_string()
+        "reason" => reason.as_str()
     )
     .increment(1);
 }

--- a/icn/crates/icn-obs/src/metrics/network.rs
+++ b/icn/crates/icn-obs/src/metrics/network.rs
@@ -119,6 +119,19 @@ pub fn init_descriptions() {
         "icn_network_encryption_circuit_breaker_trips_total",
         "Total number of times the encryption cleanup circuit breaker has tripped"
     );
+    // Hybrid PQ verification metrics (Issue #530)
+    describe_counter!(
+        "icn_network_hybrid_verification_cache_hit_total",
+        "Total number of hybrid signature verifications using cached PQ key (full verification)"
+    );
+    describe_counter!(
+        "icn_network_hybrid_verification_cache_miss_total",
+        "Total number of hybrid signature verifications with no cached PQ key (deferred verification)"
+    );
+    describe_counter!(
+        "icn_network_hybrid_verification_failed_total",
+        "Total number of hybrid signature verifications that failed"
+    );
 }
 
 // Simple counters
@@ -283,6 +296,36 @@ pub fn encryption_sequence_pairs_set(count: u64) {
 /// be degraded. Operators should investigate immediately.
 pub fn encryption_circuit_breaker_trips_inc() {
     counter!("icn_network_encryption_circuit_breaker_trips_total").increment(1);
+}
+
+// Hybrid PQ verification metrics (Issue #530)
+
+/// Increment hybrid verification cache hit counter
+///
+/// Called when a hybrid signature is verified using a cached PQ public key.
+/// This indicates full hybrid verification (both Ed25519 + ML-DSA verified).
+pub fn hybrid_verification_cache_hit_inc() {
+    counter!("icn_network_hybrid_verification_cache_hit_total").increment(1);
+}
+
+/// Increment hybrid verification cache miss counter
+///
+/// Called when a hybrid signature cannot be fully verified because no
+/// PQ public key is cached for the sender. Falls back to deferred verification.
+pub fn hybrid_verification_cache_miss_inc() {
+    counter!("icn_network_hybrid_verification_cache_miss_total").increment(1);
+}
+
+/// Increment hybrid verification failed counter with reason
+///
+/// Called when hybrid signature verification fails.
+/// Reasons: "invalid_pq_key", "pq_signature_mismatch", "ed25519_failed"
+pub fn hybrid_verification_failed_inc(reason: &str) {
+    counter!(
+        "icn_network_hybrid_verification_failed_total",
+        "reason" => reason.to_string()
+    )
+    .increment(1);
 }
 
 // Complex function with custom logic


### PR DESCRIPTION
## Summary

Adds Prometheus metrics to monitor hybrid PQ signature verification cache behavior.

## New Metrics

| Metric | Description |
|--------|-------------|
| `icn_network_hybrid_verification_cache_hit_total` | Full hybrid verification using cached PQ key (both Ed25519 + ML-DSA verified) |
| `icn_network_hybrid_verification_cache_miss_total` | Deferred verification with no cached PQ key (Ed25519 only) |
| `icn_network_hybrid_verification_failed_total{reason}` | Verification failures by reason |

### Failure Reasons

- `invalid_pq_key` - Cached ML-DSA key is malformed/corrupted
- `pq_signature_mismatch` - ML-DSA signature didn't verify with cached key

## Operator Value

These metrics help operators:
- **Monitor PQ adoption** across the network (cache hit rate)
- **Identify nodes** that haven't exchanged Hello messages (high miss rate)
- **Alert on failures** indicating key corruption or attacks

## Test Plan

- [x] `cargo check -p icn-obs -p icn-net --features post-quantum`
- [x] Existing hybrid tests pass

Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)