### PR TITLE
feat(net): Add DID-PQ key binding verification

### DIFF
--- a/icn/crates/icn-identity/src/lib.rs
+++ b/icn/crates/icn-identity/src/lib.rs
@@ -444,6 +444,12 @@ impl KeyPair {
         self.pq_keypair.as_ref().map(|kp| kp.public_key().clone())
     }
 
+    /// Get the PQ keypair for signing operations
+    #[cfg(feature = "post-quantum")]
+    pub fn pq_keypair(&self) -> Option<&icn_crypto_pq::MlDsaKeypair> {
+        self.pq_keypair.as_ref()
+    }
+
     /// Sign a message
     pub fn sign(&self, message: &[u8]) -> ed25519_dalek::Signature {
         use ed25519_dalek::Signer;

--- a/icn/crates/icn-net/src/actor.rs
+++ b/icn/crates/icn-net/src/actor.rs
@@ -1577,6 +1577,7 @@ impl NetworkActor {
                                     x25519_public,
                                     ml_dsa_public,
                                     ml_kem_public,
+                                    pq_binding_proof,
                                 } => {
                                     ctx.handle_hello(
                                         &connection,
@@ -1587,6 +1588,7 @@ impl NetworkActor {
                                         x25519_public,
                                         ml_dsa_public.clone(),
                                         ml_kem_public.clone(),
+                                        pq_binding_proof.clone(),
                                     )
                                     .await?;
                                 }

--- a/icn/crates/icn-net/src/actor.rs
+++ b/icn/crates/icn-net/src/actor.rs
@@ -1218,21 +1218,31 @@ impl NetworkActor {
                                 role: topo_cfg.role,
                             });
 
-                        // Include PQ public keys if available
+                        // Build Hello message with PQ binding proof if available
                         #[cfg(feature = "post-quantum")]
-                        let (ml_dsa_public, ml_kem_public) = {
+                        let hello_msg = {
                             let keypair = self.identity_bundle.keypair();
                             let ml_dsa = keypair.pq_public_key().map(|pk| pk.as_bytes().to_vec());
                             let ml_kem = self
                                 .identity_bundle
                                 .kem_pq_public_bytes()
                                 .map(|b| b.to_vec());
-                            (ml_dsa, ml_kem)
+
+                            // Use hello_with_binding to include DID-PQ binding proof
+                            NetworkMessage::hello_with_binding(
+                                self.own_did.clone(),
+                                did.clone(),
+                                binding_info,
+                                version_info,
+                                topology_info,
+                                x25519_public,
+                                ml_dsa,
+                                ml_kem,
+                                keypair,
+                            )
                         };
 
                         #[cfg(not(feature = "post-quantum"))]
-                        let (ml_dsa_public, ml_kem_public) = (None, None);
-
                         let hello_msg = NetworkMessage::hello(
                             self.own_did.clone(),
                             did.clone(),
@@ -1240,8 +1250,8 @@ impl NetworkActor {
                             version_info,
                             topology_info,
                             x25519_public,
-                            ml_dsa_public,
-                            ml_kem_public,
+                            None,
+                            None,
                         );
 
                         let session_mgr = self.session_manager.clone();

--- a/icn/crates/icn-net/src/handlers/hello.rs
+++ b/icn/crates/icn-net/src/handlers/hello.rs
@@ -56,8 +56,22 @@ impl ConnectionContext {
         );
 
         // Verify DID-PQ binding if proof is present
-        let pq_binding_verified =
+        // Returns: Ok(true) = verified, Ok(false) = no PQ key or legacy (no proof), Err = invalid proof
+        let pq_binding_result =
             Self::verify_pq_binding(from, ml_dsa_public.as_deref(), pq_binding_proof.as_ref());
+
+        // If binding verification explicitly failed (invalid proof), reject the connection
+        // This is a fail-closed security approach for potential attacks
+        if let Err(e) = &pq_binding_result {
+            warn!(
+                peer_did = %from,
+                error = %e,
+                "Rejecting connection: DID-PQ binding verification failed"
+            );
+            return Err(anyhow::anyhow!("DID-PQ binding verification failed: {e}"));
+        }
+
+        let pq_binding_verified = pq_binding_result.unwrap_or(false);
 
         // Perform version negotiation
         let local_version_info =
@@ -143,6 +157,18 @@ impl ConnectionContext {
                     None
                 }
             }
+        } else {
+            validated_ml_dsa
+        };
+
+        // Discard ML-DSA keys if binding wasn't verified (legacy nodes without proofs)
+        // This ensures we don't use unverified PQ keys for hybrid verification
+        let validated_ml_dsa = if !pq_binding_verified && validated_ml_dsa.is_some() {
+            debug!(
+                peer_did = %from,
+                "Discarding ML-DSA key: binding not verified (legacy node without proof)"
+            );
+            None
         } else {
             validated_ml_dsa
         };
@@ -289,6 +315,11 @@ impl ConnectionContext {
         );
 
         let connection_clone = connection.clone();
+        #[cfg(feature = "post-quantum")]
+        let log_msg = "Sent Hello response with X25519 public key and PQ binding";
+        #[cfg(not(feature = "post-quantum"))]
+        let log_msg = "Sent Hello response with X25519 public key";
+
         tokio::spawn(async move {
             match connection_clone.open_bi().await {
                 Ok((mut send, _recv)) => {
@@ -296,7 +327,7 @@ impl ConnectionContext {
                     {
                         warn!("Failed to write Hello response: {}", e);
                     } else {
-                        info!("Sent Hello response with X25519 public key and PQ binding");
+                        info!("{}", log_msg);
                     }
                 }
                 Err(e) => {
@@ -339,18 +370,19 @@ impl ConnectionContext {
 
     /// Verify DID-PQ key binding proof
     ///
-    /// Returns true if:
-    /// - No ML-DSA key is present (nothing to bind)
-    /// - ML-DSA key is present with valid binding proof
+    /// Returns:
+    /// - `Ok(true)` if ML-DSA key is present with valid binding proof
+    /// - `Ok(false)` if no ML-DSA key is present, or legacy node (no proof but no attack)
+    /// - `Err(e)` if ML-DSA key is present with INVALID binding proof (potential attack)
     ///
-    /// Returns false and logs warning if:
-    /// - ML-DSA key is present but no binding proof (legacy node or attack)
-    /// - ML-DSA key is present but binding proof is invalid
+    /// Security policy:
+    /// - Invalid proofs cause connection rejection (fail-closed)
+    /// - Missing proofs from legacy nodes are accepted but ML-DSA keys are discarded
     fn verify_pq_binding(
         peer_did: &Did,
         ml_dsa_public: Option<&[u8]>,
         binding_proof: Option<&PqBindingProof>,
-    ) -> bool {
+    ) -> Result<bool, anyhow::Error> {
         match (ml_dsa_public, binding_proof) {
             // No PQ key - nothing to verify
             (None, _) => {
@@ -358,7 +390,7 @@ impl ConnectionContext {
                     peer_did = %peer_did,
                     "No ML-DSA key present, skipping DID-PQ binding verification"
                 );
-                true
+                Ok(false)
             }
 
             // PQ key present with binding proof - verify it
@@ -368,27 +400,24 @@ impl ConnectionContext {
                         peer_did = %peer_did,
                         "DID-PQ binding verification successful"
                     );
-                    true
+                    Ok(true)
                 }
                 Err(e) => {
-                    warn!(
-                        peer_did = %peer_did,
-                        error = %e,
-                        "DID-PQ binding verification failed"
-                    );
-                    false
+                    // Invalid proof is a potential attack - return error to reject connection
+                    Err(anyhow::anyhow!(
+                        "Invalid DID-PQ binding proof from {peer_did}: {e}"
+                    ))
                 }
             },
 
-            // PQ key present but no binding proof - legacy node or potential attack
+            // PQ key present but no binding proof - legacy node
+            // Accept connection but return Ok(false) to discard ML-DSA keys
             (Some(_), None) => {
                 warn!(
                     peer_did = %peer_did,
-                    "ML-DSA key present without DID-PQ binding proof (legacy node or attack)"
+                    "ML-DSA key present without binding proof (legacy node); discarding PQ key"
                 );
-                // Accept but log warning - backward compatibility with nodes
-                // that haven't upgraded to include binding proofs
-                false
+                Ok(false)
             }
         }
     }

--- a/icn/crates/icn-net/src/handlers/hello.rs
+++ b/icn/crates/icn-net/src/handlers/hello.rs
@@ -5,10 +5,11 @@
 //! - Protocol version negotiation
 //! - Capability exchange
 //! - X25519 key exchange for E2E encryption
+//! - Post-quantum key binding verification (DID-PQ binding)
 
 use super::ConnectionContext;
 use crate::actor::PeerConnectionInfo;
-use crate::protocol::NetworkMessage;
+use crate::protocol::{NetworkMessage, PqBindingProof};
 use crate::topology::{NeighborLimitsConfig, PeerId, TopologyInfo};
 use anyhow::Result;
 use icn_identity::Did;
@@ -24,9 +25,10 @@ impl ConnectionContext {
     /// 3. Capability exchange
     /// 4. X25519 key storage for E2E encryption
     /// 5. PQ public key storage for hybrid crypto (if present)
-    /// 6. Connection storage in session manager
-    /// 7. Neighbor set updates (if topology enabled)
-    /// 8. Hello response with our info
+    /// 6. DID-PQ binding verification (if proof present)
+    /// 7. Connection storage in session manager
+    /// 8. Neighbor set updates (if topology enabled)
+    /// 9. Hello response with our info
     pub async fn handle_hello(
         &self,
         connection: &quinn::Connection,
@@ -37,6 +39,7 @@ impl ConnectionContext {
         x25519_public: &[u8; 32],
         ml_dsa_public: Option<Vec<u8>>,
         ml_kem_public: Option<Vec<u8>>,
+        pq_binding_proof: Option<PqBindingProof>,
     ) -> Result<()> {
         // Verify DID-TLS binding using TOFU model
         if let Err(e) = icn_identity::verify_did_matches_binding(from, binding_info) {
@@ -51,6 +54,10 @@ impl ConnectionContext {
             peer_did = %from,
             "DID-TLS binding verified successfully"
         );
+
+        // Verify DID-PQ binding if proof is present
+        let pq_binding_verified =
+            Self::verify_pq_binding(from, ml_dsa_public.as_deref(), pq_binding_proof.as_ref());
 
         // Perform version negotiation
         let local_version_info =
@@ -160,6 +167,7 @@ impl ConnectionContext {
                 peer_software = %peer_software,
                 capabilities = ?common_caps.describe(),
                 has_pq_keys = has_pq_keys,
+                pq_binding_verified = pq_binding_verified,
                 "Stored peer connection info"
             );
         }
@@ -244,21 +252,31 @@ impl ConnectionContext {
             role: topo_cfg.role,
         });
 
-        // Include PQ public keys if available
+        // Build Hello response with PQ binding proof if available
         #[cfg(feature = "post-quantum")]
-        let (ml_dsa_public, ml_kem_public) = {
+        let hello_response = {
             let keypair = self.identity_bundle.keypair();
             let ml_dsa = keypair.pq_public_key().map(|pk| pk.as_bytes().to_vec());
             let ml_kem = self
                 .identity_bundle
                 .kem_pq_public_bytes()
                 .map(|b| b.to_vec());
-            (ml_dsa, ml_kem)
+
+            // Use hello_with_binding to include DID-PQ binding proof
+            NetworkMessage::hello_with_binding(
+                self.own_did.clone(),
+                to.clone(),
+                binding_info,
+                version_info,
+                topology_info,
+                x25519_public,
+                ml_dsa,
+                ml_kem,
+                keypair,
+            )
         };
 
         #[cfg(not(feature = "post-quantum"))]
-        let (ml_dsa_public, ml_kem_public) = (None, None);
-
         let hello_response = NetworkMessage::hello(
             self.own_did.clone(),
             to.clone(),
@@ -266,8 +284,8 @@ impl ConnectionContext {
             version_info,
             topology_info,
             x25519_public,
-            ml_dsa_public,
-            ml_kem_public,
+            None,
+            None,
         );
 
         let connection_clone = connection.clone();
@@ -278,7 +296,7 @@ impl ConnectionContext {
                     {
                         warn!("Failed to write Hello response: {}", e);
                     } else {
-                        info!("Sent Hello response with X25519 public key");
+                        info!("Sent Hello response with X25519 public key and PQ binding");
                     }
                 }
                 Err(e) => {
@@ -316,6 +334,62 @@ impl ConnectionContext {
                 None
             }
             (None, _) => None,
+        }
+    }
+
+    /// Verify DID-PQ key binding proof
+    ///
+    /// Returns true if:
+    /// - No ML-DSA key is present (nothing to bind)
+    /// - ML-DSA key is present with valid binding proof
+    ///
+    /// Returns false and logs warning if:
+    /// - ML-DSA key is present but no binding proof (legacy node or attack)
+    /// - ML-DSA key is present but binding proof is invalid
+    fn verify_pq_binding(
+        peer_did: &Did,
+        ml_dsa_public: Option<&[u8]>,
+        binding_proof: Option<&PqBindingProof>,
+    ) -> bool {
+        match (ml_dsa_public, binding_proof) {
+            // No PQ key - nothing to verify
+            (None, _) => {
+                debug!(
+                    peer_did = %peer_did,
+                    "No ML-DSA key present, skipping DID-PQ binding verification"
+                );
+                true
+            }
+
+            // PQ key present with binding proof - verify it
+            (Some(ml_dsa_bytes), Some(proof)) => match proof.verify(peer_did, ml_dsa_bytes) {
+                Ok(()) => {
+                    info!(
+                        peer_did = %peer_did,
+                        "DID-PQ binding verification successful"
+                    );
+                    true
+                }
+                Err(e) => {
+                    warn!(
+                        peer_did = %peer_did,
+                        error = %e,
+                        "DID-PQ binding verification failed"
+                    );
+                    false
+                }
+            },
+
+            // PQ key present but no binding proof - legacy node or potential attack
+            (Some(_), None) => {
+                warn!(
+                    peer_did = %peer_did,
+                    "ML-DSA key present without DID-PQ binding proof (legacy node or attack)"
+                );
+                // Accept but log warning - backward compatibility with nodes
+                // that haven't upgraded to include binding proofs
+                false
+            }
         }
     }
 }

--- a/icn/crates/icn-net/src/protocol.rs
+++ b/icn/crates/icn-net/src/protocol.rs
@@ -1415,6 +1415,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "post-quantum")]
     fn test_pq_binding_proof_fails_for_invalid_key_bytes() {
         // Test with invalid ML-DSA key bytes
         let keypair = KeyPair::generate().unwrap();

--- a/icn/crates/icn-net/src/protocol.rs
+++ b/icn/crates/icn-net/src/protocol.rs
@@ -49,6 +49,104 @@ impl TryFrom<u8> for CompressionFormat {
 /// Re-export TraceContext from icn-obs for distributed tracing propagation
 pub use icn_obs::TraceContext;
 
+/// Post-quantum key binding proof
+///
+/// Cryptographic proof that the sender controls both the Ed25519 key (DID)
+/// and the ML-DSA key. This prevents an attacker from claiming someone else's
+/// PQ public key in a Hello message.
+///
+/// The proof is an ML-DSA signature over the binding message:
+/// `"DID-PQ-BINDING-V1:<did>:<timestamp_millis>"`
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PqBindingProof {
+    /// Unix timestamp in milliseconds when the proof was created
+    pub timestamp_millis: u64,
+    /// ML-DSA signature over the binding message
+    pub signature: Vec<u8>,
+}
+
+impl PqBindingProof {
+    /// Binding message version prefix
+    pub const VERSION_PREFIX: &'static str = "DID-PQ-BINDING-V1";
+
+    /// Maximum age of a binding proof (5 minutes)
+    /// This prevents replay attacks while allowing for clock skew
+    pub const MAX_AGE_MILLIS: u64 = 5 * 60 * 1000;
+
+    /// Create the canonical binding message to sign
+    pub fn binding_message(did: &Did, timestamp_millis: u64) -> Vec<u8> {
+        format!("{}:{}:{}", Self::VERSION_PREFIX, did, timestamp_millis).into_bytes()
+    }
+
+    /// Create a new binding proof
+    #[cfg(feature = "post-quantum")]
+    pub fn create(did: &Did, keypair: &icn_identity::KeyPair) -> Option<Self> {
+        let pq_keypair = keypair.pq_keypair()?;
+        let timestamp_millis = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .ok()?
+            .as_millis() as u64;
+
+        let message = Self::binding_message(did, timestamp_millis);
+        let signature = pq_keypair.sign(&message).ok()?.as_bytes().to_vec();
+
+        Some(Self {
+            timestamp_millis,
+            signature,
+        })
+    }
+
+    /// Verify a binding proof against a DID and ML-DSA public key
+    #[cfg(feature = "post-quantum")]
+    pub fn verify(&self, did: &Did, ml_dsa_public: &[u8]) -> Result<(), anyhow::Error> {
+        use anyhow::anyhow;
+
+        // Check timestamp is not in the future (with small tolerance for clock skew)
+        let now_millis = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| anyhow!("System time error: {e}"))?
+            .as_millis() as u64;
+
+        // Allow 1 minute of future tolerance for clock skew
+        if self.timestamp_millis > now_millis + 60_000 {
+            return Err(anyhow!("Binding proof timestamp is in the future"));
+        }
+
+        // Check proof is not too old
+        if now_millis.saturating_sub(self.timestamp_millis) > Self::MAX_AGE_MILLIS {
+            return Err(anyhow!(
+                "Binding proof expired (older than {} seconds)",
+                Self::MAX_AGE_MILLIS / 1000
+            ));
+        }
+
+        // Parse the ML-DSA public key
+        let pq_pubkey = icn_crypto_pq::MlDsaPublicKey::from_bytes(ml_dsa_public)
+            .map_err(|e| anyhow!("Invalid ML-DSA public key: {e}"))?;
+
+        // Reconstruct the binding message
+        let message = Self::binding_message(did, self.timestamp_millis);
+
+        // Parse the signature
+        let signature = icn_crypto_pq::MlDsaSignature::from_bytes(&self.signature)
+            .map_err(|e| anyhow!("Invalid ML-DSA signature format: {e}"))?;
+
+        // Verify the signature using static method
+        if !icn_crypto_pq::MlDsaKeypair::verify(&pq_pubkey, &message, &signature) {
+            return Err(anyhow!("Binding proof signature verification failed"));
+        }
+        Ok(())
+    }
+
+    /// Verify without post-quantum feature (always fails)
+    #[cfg(not(feature = "post-quantum"))]
+    pub fn verify(&self, _did: &Did, _ml_dsa_public: &[u8]) -> Result<(), anyhow::Error> {
+        Err(anyhow::anyhow!(
+            "Post-quantum feature not enabled, cannot verify binding proof"
+        ))
+    }
+}
+
 /// Wire-format message envelope
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkMessage {
@@ -125,6 +223,11 @@ pub enum MessagePayload {
         /// Sent when HYBRID_KEM capability is advertised
         #[serde(default)]
         ml_kem_public: Option<Vec<u8>>,
+        /// DID-PQ key binding proof (post-quantum)
+        /// ML-DSA signature over "DID-PQ-BINDING-V1:<did>:<timestamp>" proving
+        /// the sender controls both Ed25519 (DID) and ML-DSA keys
+        #[serde(default)]
+        pq_binding_proof: Option<PqBindingProof>,
     },
 
     /// Handshake with topology information (legacy, kept for compatibility)
@@ -351,6 +454,46 @@ impl NetworkMessage {
                 x25519_public,
                 ml_dsa_public,
                 ml_kem_public,
+                pq_binding_proof: None, // Use hello_with_binding for PQ binding
+            },
+        )
+    }
+
+    /// Create a Hello message with post-quantum key binding proof
+    ///
+    /// This is the preferred method for nodes with hybrid capabilities.
+    /// The binding proof cryptographically proves the sender controls both
+    /// the Ed25519 key (DID) and the ML-DSA key.
+    #[cfg(feature = "post-quantum")]
+    pub fn hello_with_binding(
+        from: Did,
+        to: Did,
+        binding_info: BindingInfo,
+        version_info: VersionInfo,
+        topology_info: Option<crate::TopologyInfo>,
+        x25519_public: [u8; 32],
+        ml_dsa_public: Option<Vec<u8>>,
+        ml_kem_public: Option<Vec<u8>>,
+        keypair: &icn_identity::KeyPair,
+    ) -> Self {
+        // Generate binding proof if we have PQ keys
+        let pq_binding_proof = if ml_dsa_public.is_some() {
+            PqBindingProof::create(&from, keypair)
+        } else {
+            None
+        };
+
+        Self::new(
+            from,
+            Some(to),
+            MessagePayload::Hello {
+                binding_info,
+                version_info: Some(version_info),
+                topology_info,
+                x25519_public,
+                ml_dsa_public,
+                ml_kem_public,
+                pq_binding_proof,
             },
         )
     }
@@ -1177,5 +1320,136 @@ mod tests {
     fn test_compression_threshold() {
         // Verify the threshold constant
         assert_eq!(COMPRESSION_THRESHOLD, 1024);
+    }
+
+    // Issue #528: DID-PQ key binding verification tests
+
+    #[test]
+    fn test_pq_binding_message_format() {
+        let alice = KeyPair::generate().unwrap();
+        let timestamp = 1704067200000u64; // 2024-01-01 00:00:00 UTC
+
+        let message = PqBindingProof::binding_message(alice.did(), timestamp);
+        let expected = format!(
+            "{}:{}:{}",
+            PqBindingProof::VERSION_PREFIX,
+            alice.did(),
+            timestamp
+        );
+
+        assert_eq!(message, expected.as_bytes());
+    }
+
+    #[test]
+    #[cfg(feature = "post-quantum")]
+    fn test_pq_binding_proof_create_and_verify() {
+        // KeyPair::generate() creates hybrid keypairs when post-quantum feature is enabled
+        let keypair = KeyPair::generate().unwrap();
+        let did = keypair.did().clone();
+
+        // Create binding proof
+        let proof = PqBindingProof::create(&did, &keypair);
+        assert!(
+            proof.is_some(),
+            "Should create binding proof for hybrid keypair"
+        );
+
+        let proof = proof.unwrap();
+        assert!(!proof.signature.is_empty(), "Signature should not be empty");
+
+        // Verify the binding proof
+        let ml_dsa_public = keypair.pq_public_key().unwrap().as_bytes().to_vec();
+        let result = proof.verify(&did, &ml_dsa_public);
+        assert!(
+            result.is_ok(),
+            "Valid binding proof should verify: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "post-quantum")]
+    fn test_pq_binding_proof_fails_for_wrong_did() {
+        let keypair = KeyPair::generate().unwrap();
+        let did = keypair.did().clone();
+
+        // Create binding proof
+        let proof = PqBindingProof::create(&did, &keypair).unwrap();
+
+        // Try to verify with a different DID
+        let other_keypair = KeyPair::generate().unwrap();
+        let ml_dsa_public = keypair.pq_public_key().unwrap().as_bytes().to_vec();
+
+        let result = proof.verify(other_keypair.did(), &ml_dsa_public);
+        assert!(result.is_err(), "Should fail for wrong DID");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("verification failed"),
+            "Error should mention verification failure"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "post-quantum")]
+    fn test_pq_binding_proof_fails_for_wrong_key() {
+        let keypair = KeyPair::generate().unwrap();
+        let did = keypair.did().clone();
+
+        // Create binding proof
+        let proof = PqBindingProof::create(&did, &keypair).unwrap();
+
+        // Try to verify with a different ML-DSA public key
+        let other_keypair = KeyPair::generate().unwrap();
+        let wrong_ml_dsa_public = other_keypair.pq_public_key().unwrap().as_bytes().to_vec();
+
+        let result = proof.verify(&did, &wrong_ml_dsa_public);
+        assert!(result.is_err(), "Should fail for wrong public key");
+    }
+
+    #[test]
+    fn test_pq_binding_proof_fails_for_invalid_key_bytes() {
+        // Test with invalid ML-DSA key bytes
+        let keypair = KeyPair::generate().unwrap();
+        let proof = PqBindingProof {
+            timestamp_millis: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as u64,
+            signature: vec![0u8; 100], // Garbage signature
+        };
+
+        // Invalid key bytes should fail
+        let result = proof.verify(keypair.did(), &[0xDE, 0xAD, 0xBE, 0xEF]);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("Invalid ML-DSA public key"),
+            "Error should mention invalid key: {}",
+            err
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "post-quantum")]
+    fn test_pq_binding_proof_non_hybrid_keypair_returns_none() {
+        // Create a legacy (classical-only) keypair using from_bytes
+        use ed25519_dalek::SigningKey;
+        use rand::rngs::OsRng;
+
+        let signing_key = SigningKey::generate(&mut OsRng);
+        let secret_bytes: [u8; 32] = signing_key.to_bytes();
+        let public_bytes: [u8; 32] = signing_key.verifying_key().to_bytes();
+
+        // from_bytes creates a keypair WITHOUT PQ component
+        let keypair = KeyPair::from_bytes(&secret_bytes, &public_bytes).unwrap();
+
+        // Classical-only keypair should return None
+        let proof = PqBindingProof::create(keypair.did(), &keypair);
+        assert!(
+            proof.is_none(),
+            "Non-hybrid keypair should not create binding proof"
+        );
     }
 }

--- a/icn/crates/icn-net/src/protocol.rs
+++ b/icn/crates/icn-net/src/protocol.rs
@@ -73,6 +73,19 @@ impl PqBindingProof {
     /// This prevents replay attacks while allowing for clock skew
     pub const MAX_AGE_MILLIS: u64 = 5 * 60 * 1000;
 
+    /// Future tolerance for clock skew (1 minute)
+    /// Proofs with timestamps up to this far in the future are accepted
+    pub const FUTURE_TOLERANCE_MILLIS: u64 = 60_000;
+
+    /// Get current timestamp in milliseconds with safe u128->u64 conversion
+    fn current_timestamp_millis() -> Result<u64, anyhow::Error> {
+        use anyhow::anyhow;
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| anyhow!("System time error: {e}"))
+            .map(|d| d.as_millis().min(u64::MAX as u128) as u64)
+    }
+
     /// Create the canonical binding message to sign
     pub fn binding_message(did: &Did, timestamp_millis: u64) -> Vec<u8> {
         format!("{}:{}:{}", Self::VERSION_PREFIX, did, timestamp_millis).into_bytes()
@@ -82,10 +95,7 @@ impl PqBindingProof {
     #[cfg(feature = "post-quantum")]
     pub fn create(did: &Did, keypair: &icn_identity::KeyPair) -> Option<Self> {
         let pq_keypair = keypair.pq_keypair()?;
-        let timestamp_millis = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .ok()?
-            .as_millis() as u64;
+        let timestamp_millis = Self::current_timestamp_millis().ok()?;
 
         let message = Self::binding_message(did, timestamp_millis);
         let signature = pq_keypair.sign(&message).ok()?.as_bytes().to_vec();
@@ -101,14 +111,10 @@ impl PqBindingProof {
     pub fn verify(&self, did: &Did, ml_dsa_public: &[u8]) -> Result<(), anyhow::Error> {
         use anyhow::anyhow;
 
-        // Check timestamp is not in the future (with small tolerance for clock skew)
-        let now_millis = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_err(|e| anyhow!("System time error: {e}"))?
-            .as_millis() as u64;
+        let now_millis = Self::current_timestamp_millis()?;
 
-        // Allow 1 minute of future tolerance for clock skew
-        if self.timestamp_millis > now_millis + 60_000 {
+        // Check timestamp is not in the future (beyond clock skew tolerance)
+        if self.timestamp_millis > now_millis + Self::FUTURE_TOLERANCE_MILLIS {
             return Err(anyhow!("Binding proof timestamp is in the future"));
         }
 
@@ -454,7 +460,7 @@ impl NetworkMessage {
                 x25519_public,
                 ml_dsa_public,
                 ml_kem_public,
-                pq_binding_proof: None, // Use hello_with_binding for PQ binding
+                pq_binding_proof: None,
             },
         )
     }
@@ -1450,6 +1456,154 @@ mod tests {
         assert!(
             proof.is_none(),
             "Non-hybrid keypair should not create binding proof"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "post-quantum")]
+    fn test_pq_binding_proof_rejects_future_timestamp() {
+        let keypair = KeyPair::generate().unwrap();
+        let did = keypair.did().clone();
+
+        // Create a proof with timestamp far in the future (beyond 1 minute tolerance)
+        let future_timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64
+            + PqBindingProof::FUTURE_TOLERANCE_MILLIS
+            + 60_000; // 2 minutes in future
+
+        let message = PqBindingProof::binding_message(&did, future_timestamp);
+        let signature = keypair
+            .pq_keypair()
+            .unwrap()
+            .sign(&message)
+            .unwrap()
+            .as_bytes()
+            .to_vec();
+
+        let proof = PqBindingProof {
+            timestamp_millis: future_timestamp,
+            signature,
+        };
+
+        let ml_dsa_public = keypair.pq_public_key().unwrap().as_bytes().to_vec();
+        let result = proof.verify(&did, &ml_dsa_public);
+        assert!(result.is_err(), "Should reject future timestamp");
+        assert!(
+            result.unwrap_err().to_string().contains("in the future"),
+            "Error should mention future timestamp"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "post-quantum")]
+    fn test_pq_binding_proof_rejects_expired_timestamp() {
+        let keypair = KeyPair::generate().unwrap();
+        let did = keypair.did().clone();
+
+        // Create a proof with expired timestamp (6 minutes ago, beyond 5 minute max age)
+        let expired_timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64
+            - PqBindingProof::MAX_AGE_MILLIS
+            - 60_000; // 6 minutes ago
+
+        let message = PqBindingProof::binding_message(&did, expired_timestamp);
+        let signature = keypair
+            .pq_keypair()
+            .unwrap()
+            .sign(&message)
+            .unwrap()
+            .as_bytes()
+            .to_vec();
+
+        let proof = PqBindingProof {
+            timestamp_millis: expired_timestamp,
+            signature,
+        };
+
+        let ml_dsa_public = keypair.pq_public_key().unwrap().as_bytes().to_vec();
+        let result = proof.verify(&did, &ml_dsa_public);
+        assert!(result.is_err(), "Should reject expired timestamp");
+        assert!(
+            result.unwrap_err().to_string().contains("expired"),
+            "Error should mention expiration"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "post-quantum")]
+    fn test_pq_binding_proof_accepts_edge_of_tolerance() {
+        let keypair = KeyPair::generate().unwrap();
+        let did = keypair.did().clone();
+
+        // Create a proof at the edge of future tolerance (should be accepted)
+        let edge_timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64
+            + PqBindingProof::FUTURE_TOLERANCE_MILLIS
+            - 1000; // Just under 1 minute in future
+
+        let message = PqBindingProof::binding_message(&did, edge_timestamp);
+        let signature = keypair
+            .pq_keypair()
+            .unwrap()
+            .sign(&message)
+            .unwrap()
+            .as_bytes()
+            .to_vec();
+
+        let proof = PqBindingProof {
+            timestamp_millis: edge_timestamp,
+            signature,
+        };
+
+        let ml_dsa_public = keypair.pq_public_key().unwrap().as_bytes().to_vec();
+        let result = proof.verify(&did, &ml_dsa_public);
+        assert!(
+            result.is_ok(),
+            "Should accept timestamp at edge of tolerance: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "post-quantum")]
+    fn test_pq_binding_proof_accepts_edge_of_max_age() {
+        let keypair = KeyPair::generate().unwrap();
+        let did = keypair.did().clone();
+
+        // Create a proof at the edge of max age (should be accepted)
+        let edge_timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64
+            - PqBindingProof::MAX_AGE_MILLIS
+            + 1000; // Just under 5 minutes ago
+
+        let message = PqBindingProof::binding_message(&did, edge_timestamp);
+        let signature = keypair
+            .pq_keypair()
+            .unwrap()
+            .sign(&message)
+            .unwrap()
+            .as_bytes()
+            .to_vec();
+
+        let proof = PqBindingProof {
+            timestamp_millis: edge_timestamp,
+            signature,
+        };
+
+        let ml_dsa_public = keypair.pq_public_key().unwrap().as_bytes().to_vec();
+        let result = proof.verify(&did, &ml_dsa_public);
+        assert!(
+            result.is_ok(),
+            "Should accept timestamp at edge of max age: {:?}",
+            result
         );
     }
 }


### PR DESCRIPTION
## Summary

Implements cryptographic binding between DID identity and ML-DSA post-quantum keys to prevent key substitution attacks during Hello message exchange.

Closes #528

## Changes

- **`icn-net/src/protocol.rs`**: Add `PqBindingProof` struct with:
  - `VERSION_PREFIX` for versioned binding messages (`DID-PQ-BINDING-V1`)
  - `create()` to sign binding with ML-DSA keypair
  - `verify()` to validate binding against DID and public key
  - `MAX_AGE_MILLIS` (5 minutes) to prevent replay attacks
  - `pq_binding_proof` field in Hello message payload
  - `hello_with_binding()` constructor

- **`icn-net/src/handlers/hello.rs`**: 
  - Update `handle_hello` to verify binding proofs
  - Add `verify_pq_binding()` helper method
  - Update `send_hello_response` to include binding proof when PQ available

- **`icn-identity/src/lib.rs`**: Add `pq_keypair()` accessor method

## Security Design

The binding message format prevents:
- **Cross-protocol attacks**: Version prefix scopes signatures
- **Replay attacks**: 5-minute timestamp validity window
- **Key substitution**: DID is bound in the signed message

Binding message: `DID-PQ-BINDING-V1:<did>:<timestamp_millis>`

## Test Plan

- [x] `test_pq_binding_message_format` - Verifies message format
- [x] `test_pq_binding_proof_create_and_verify` - End-to-end create/verify
- [x] `test_pq_binding_proof_fails_for_wrong_did` - Wrong DID rejected
- [x] `test_pq_binding_proof_fails_for_wrong_key` - Wrong key rejected
- [x] `test_pq_binding_proof_fails_for_invalid_key_bytes` - Invalid bytes rejected
- [x] `test_pq_binding_proof_non_hybrid_keypair_returns_none` - Classical keys return None
- [x] All existing tests pass with `--features post-quantum`

🤖 Generated with [Claude Code](https://claude.com/claude-code)