### PR TITLE
feat(net): Add replay guard and Bloom rotation metrics (#153, #154)

### DIFF
--- a/icn/crates/icn-net/src/actor.rs
+++ b/icn/crates/icn-net/src/actor.rs
@@ -1104,7 +1104,7 @@ impl NetworkActor {
                     }
                 }
                 _ = cleanup_interval.tick() => {
-                    // Cleanup stale replay guard entries using single write lock
+                    // Cleanup stale replay guard entries using single write lock (#153)
                     let (peer_count_before, peer_count_after) = {
                         let mut guard = self.replay_guard.write().await;
                         let before = guard.peer_count();
@@ -1113,13 +1113,16 @@ impl NetworkActor {
                         (before, after)
                     };
 
-                    // Update metric
+                    // Update metrics (#153)
                     icn_obs::metrics::network::replay_guard_peers_set(peer_count_after as u64);
+                    icn_obs::metrics::network::replay_guard_cleanups_inc();
 
-                    if peer_count_before != peer_count_after {
+                    let peers_cleaned = peer_count_before.saturating_sub(peer_count_after);
+                    if peers_cleaned > 0 {
+                        icn_obs::metrics::network::replay_guard_peers_cleaned_add(peers_cleaned as u64);
                         info!(
-                            "Replay guard cleanup: {} -> {} peers",
-                            peer_count_before, peer_count_after
+                            "Replay guard cleanup: {} -> {} peers ({} removed)",
+                            peer_count_before, peer_count_after, peers_cleaned
                         );
                     }
 

--- a/icn/crates/icn-net/src/protocol.rs
+++ b/icn/crates/icn-net/src/protocol.rs
@@ -78,6 +78,7 @@ impl PqBindingProof {
     pub const FUTURE_TOLERANCE_MILLIS: u64 = 60_000;
 
     /// Get current timestamp in milliseconds with safe u128->u64 conversion
+    #[allow(dead_code)] // Used by post-quantum feature
     fn current_timestamp_millis() -> Result<u64, anyhow::Error> {
         use anyhow::anyhow;
         std::time::SystemTime::now()

--- a/icn/crates/icn-net/src/replay_guard.rs
+++ b/icn/crates/icn-net/src/replay_guard.rs
@@ -650,7 +650,7 @@ impl SequenceWindow {
         self.insertion_count += 1;
     }
 
-    /// Rotate (reset) the Bloom filter to prevent saturation
+    /// Rotate (reset) the Bloom filter to prevent saturation (#154)
     ///
     /// After rotation:
     /// - The filter is empty and can accept new sequences
@@ -668,6 +668,9 @@ impl SequenceWindow {
         );
         self.recent = BloomFilter::new(BLOOM_CAPACITY, 0.001);
         self.insertion_count = 0;
+
+        // Track rotation for monitoring (#154)
+        icn_obs::metrics::network::replay_guard_bloom_rotations_inc();
     }
 }
 

--- a/icn/crates/icn-obs/src/metrics/network.rs
+++ b/icn/crates/icn-obs/src/metrics/network.rs
@@ -90,6 +90,18 @@ pub fn init_descriptions() {
         "icn_network_replay_guard_peers",
         "Number of peers tracked in replay guard"
     );
+    describe_counter!(
+        "icn_network_replay_guard_cleanups_total",
+        "Total number of replay guard cleanup cycles executed"
+    );
+    describe_counter!(
+        "icn_network_replay_guard_peers_cleaned_total",
+        "Total number of stale peers removed during cleanup"
+    );
+    describe_counter!(
+        "icn_network_replay_guard_bloom_rotations_total",
+        "Total number of Bloom filter rotations to prevent saturation"
+    );
     // E2E Encryption metrics (Issue #404)
     describe_counter!(
         "icn_network_encrypted_messages_sent_total",
@@ -238,6 +250,21 @@ pub fn peer_capability_set(capability: &str, count: u64) {
 /// Set the number of peers tracked in replay guard
 pub fn replay_guard_peers_set(value: u64) {
     gauge!("icn_network_replay_guard_peers").set(value as f64);
+}
+
+/// Increment replay guard cleanup cycles counter (#153)
+pub fn replay_guard_cleanups_inc() {
+    counter!("icn_network_replay_guard_cleanups_total").increment(1);
+}
+
+/// Add to the count of peers removed during cleanup (#153)
+pub fn replay_guard_peers_cleaned_add(count: u64) {
+    counter!("icn_network_replay_guard_peers_cleaned_total").increment(count);
+}
+
+/// Increment Bloom filter rotation counter (#154)
+pub fn replay_guard_bloom_rotations_inc() {
+    counter!("icn_network_replay_guard_bloom_rotations_total").increment(1);
 }
 
 // E2E Encryption metrics (Issue #404)


### PR DESCRIPTION
## Summary
- Add metrics for replay guard cleanup cycles and Bloom filter rotations
- These features were already implemented, just lacked observability

## Changes
- `icn_network_replay_guard_cleanups_total`: Tracks cleanup cycles (every 60s)
- `icn_network_replay_guard_peers_cleaned_total`: Tracks peers removed
- `icn_network_replay_guard_bloom_rotations_total`: Tracks filter rotations

## Note
Issues #153 and #154 core functionality was already implemented:
- #153: Cleanup scheduled every 60s in `actor.rs:1106-1132`
- #154: Bloom rotation at 8K insertions in `replay_guard.rs:644-674`

This PR adds the metrics both issues requested.

## Test plan
- [x] All 18 replay_guard tests pass
- [x] Clippy clean
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)