### PR TITLE
feat(gossip): Add adaptive gossip fanout based on network size (#484)

### DIFF
--- a/icn/crates/icn-gossip/src/bloom.rs
+++ b/icn/crates/icn-gossip/src/bloom.rs
@@ -530,10 +530,7 @@ mod tests {
         // With only 100 entries, filter is oversized (>4x optimal)
         // Note: depends on optimal_size calculation, may or may not trigger
         let needs = filter.needs_resize(100, &config);
-        println!(
-            "Filter sized for 10k with 100 entries needs resize: {}",
-            needs
-        );
+        println!("Filter sized for 10k with 100 entries needs resize: {needs}");
     }
 
     #[test]

--- a/icn/crates/icn-gossip/src/gossip.rs
+++ b/icn/crates/icn-gossip/src/gossip.rs
@@ -196,6 +196,9 @@ pub struct GossipActor {
 
     /// Bloom filter resize configuration (M2 - dynamic sizing)
     bloom_resize_config: crate::bloom::BloomResizeConfig,
+
+    /// Adaptive fanout configuration (M2 #484 - dynamic fanout based on network size)
+    adaptive_fanout_config: crate::types::AdaptiveFanoutConfig,
 }
 
 impl GossipActor {
@@ -232,6 +235,7 @@ impl GossipActor {
             partition_healer: None,     // Phase 18 Week 3: Set via set_partition_healer()
             storage_quota_manager: None, // Phase 18 Week 6: Set via set_storage_quota_manager()
             bloom_resize_config: crate::bloom::BloomResizeConfig::default(), // M2: Dynamic Bloom sizing
+            adaptive_fanout_config: crate::types::AdaptiveFanoutConfig::default(), // M2 #484: Adaptive fanout
         };
 
         // Create default topics with appropriate scopes
@@ -1306,26 +1310,28 @@ impl GossipActor {
             nonce,
         };
 
-        // Get topic scope and fanout
+        // Get topic scope and calculate adaptive fanout (#484)
         // SAFETY: topic existence was checked above via contains_key()
         #[allow(clippy::unwrap_used)]
         let topic_obj = self.topics.get(topic).unwrap();
         let scope = topic_obj.scope;
-        let fanout = match scope {
-            crate::types::Scope::LocalCluster => 8, // Default local fanout
-            crate::types::Scope::Regional => 6,     // Default regional fanout
-            crate::types::Scope::Global => 4,       // Default global fanout
-        };
+
+        // M2 #484: Calculate adaptive fanout based on network size
+        let network_size = self.peer_sync.peer_count();
+        let fanout = self
+            .adaptive_fanout_config
+            .calculate_fanout(network_size, &scope);
 
         // Send with scope-aware peer selection
         debug!(
-            "Emitting digest for topic {} ({:?} scope, fanout={}): {} entries, nonce={}",
-            topic, scope, fanout, entry_count, nonce
+            "Emitting digest for topic {} ({:?} scope, fanout={}, peers={}): {} entries, nonce={}",
+            topic, scope, fanout, network_size, entry_count, nonce
         );
         self.send_message_scoped(scope, fanout, digest);
 
         // Track metrics
         icn_obs::metrics::gossip::digests_sent_inc();
+        icn_obs::metrics::gossip::adaptive_fanout_record(&scope.to_string(), fanout, network_size);
 
         Ok(())
     }

--- a/icn/crates/icn-gossip/src/lib.rs
+++ b/icn/crates/icn-gossip/src/lib.rs
@@ -64,8 +64,8 @@ pub use partition::{
 pub use scalability::{CompressedVectorClock, ShardStats, ShardedTopic, TopicShard, VarInt};
 pub use sync::{Backoff, PeerSyncManager, PeerSyncState};
 pub use types::{
-    AccessControl, ContentHash, GossipEntry, GossipMessage, Scope, Subscription, SyncCursor, Topic,
-    TrustResourceLimits,
+    AccessControl, AdaptiveFanoutConfig, ContentHash, GossipEntry, GossipMessage, Scope,
+    Subscription, SyncCursor, Topic, TrustResourceLimits,
 };
 pub use vector_clock::VectorClock;
 

--- a/icn/crates/icn-gossip/src/types.rs
+++ b/icn/crates/icn-gossip/src/types.rs
@@ -86,6 +86,16 @@ pub enum Scope {
     Global,
 }
 
+impl std::fmt::Display for Scope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Scope::LocalCluster => write!(f, "local"),
+            Scope::Regional => write!(f, "regional"),
+            Scope::Global => write!(f, "global"),
+        }
+    }
+}
+
 /// Replica health status (Phase 17)
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ReplicaHealth {
@@ -501,6 +511,75 @@ pub struct Subscription {
     pub subscriber: Did,
 }
 
+/// Configuration for adaptive gossip fanout (#484)
+///
+/// Adjusts gossip fanout dynamically based on network size using the formula:
+/// `fanout = clamp(ceil(log2(network_size) + 1), min, max)`
+///
+/// This prevents:
+/// - Over-messaging in small networks (wastes bandwidth)
+/// - Under-propagation in large networks (slow convergence)
+#[derive(Debug, Clone)]
+pub struct AdaptiveFanoutConfig {
+    /// Minimum fanout (for small networks or floor)
+    pub min_fanout: usize,
+
+    /// Maximum fanout (prevents flooding)
+    pub max_fanout: usize,
+
+    /// Multiplier per scope (Local=1.5, Regional=1.0, Global=0.75)
+    /// Higher multiplier for local scope where latency matters more
+    pub local_multiplier: f64,
+    pub regional_multiplier: f64,
+    pub global_multiplier: f64,
+
+    /// Minimum peers before adaptive fanout kicks in
+    /// Below this threshold, use min_fanout
+    pub min_peers_for_adaptive: usize,
+}
+
+impl Default for AdaptiveFanoutConfig {
+    fn default() -> Self {
+        Self {
+            min_fanout: 3,
+            max_fanout: 10,
+            local_multiplier: 1.5,
+            regional_multiplier: 1.0,
+            global_multiplier: 0.75,
+            min_peers_for_adaptive: 5,
+        }
+    }
+}
+
+impl AdaptiveFanoutConfig {
+    /// Calculate adaptive fanout based on network size and scope
+    ///
+    /// Formula: fanout = clamp(ceil(log2(network_size) + 1) * scope_multiplier, min, max)
+    pub fn calculate_fanout(&self, network_size: usize, scope: &Scope) -> usize {
+        // Below threshold, use minimum
+        if network_size < self.min_peers_for_adaptive {
+            return self.min_fanout;
+        }
+
+        // Base fanout: ceil(log2(n) + 1)
+        // This gives: 4->3, 8->4, 16->5, 32->6, 64->7, 128->8, etc.
+        let log2_size = (network_size as f64).log2();
+        let base_fanout = (log2_size + 1.0).ceil();
+
+        // Apply scope multiplier
+        let multiplier = match scope {
+            Scope::LocalCluster => self.local_multiplier,
+            Scope::Regional => self.regional_multiplier,
+            Scope::Global => self.global_multiplier,
+        };
+
+        let adjusted = (base_fanout * multiplier).ceil() as usize;
+
+        // Clamp to bounds
+        adjusted.clamp(self.min_fanout, self.max_fanout)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -710,5 +789,88 @@ mod tests {
 
         // Even with matching topic, expired cursor is invalid
         assert!(!cursor.is_valid_for_topic("my-topic"));
+    }
+
+    // Adaptive fanout tests (#484)
+
+    #[test]
+    fn test_adaptive_fanout_default_config() {
+        let config = AdaptiveFanoutConfig::default();
+        assert_eq!(config.min_fanout, 3);
+        assert_eq!(config.max_fanout, 10);
+        assert_eq!(config.min_peers_for_adaptive, 5);
+    }
+
+    #[test]
+    fn test_adaptive_fanout_small_network() {
+        let config = AdaptiveFanoutConfig::default();
+
+        // Below threshold, use min_fanout
+        assert_eq!(config.calculate_fanout(1, &Scope::Global), 3);
+        assert_eq!(config.calculate_fanout(4, &Scope::Global), 3);
+    }
+
+    #[test]
+    fn test_adaptive_fanout_scales_with_network_size() {
+        let config = AdaptiveFanoutConfig::default();
+
+        // Using Regional (multiplier=1.0) for cleaner math
+        // log2(8) + 1 = 4
+        assert_eq!(config.calculate_fanout(8, &Scope::Regional), 4);
+
+        // log2(16) + 1 = 5
+        assert_eq!(config.calculate_fanout(16, &Scope::Regional), 5);
+
+        // log2(32) + 1 = 6
+        assert_eq!(config.calculate_fanout(32, &Scope::Regional), 6);
+
+        // log2(64) + 1 = 7
+        assert_eq!(config.calculate_fanout(64, &Scope::Regional), 7);
+
+        // log2(128) + 1 = 8
+        assert_eq!(config.calculate_fanout(128, &Scope::Regional), 8);
+    }
+
+    #[test]
+    fn test_adaptive_fanout_scope_multipliers() {
+        let config = AdaptiveFanoutConfig::default();
+
+        // 32 peers: base = log2(32) + 1 = 6
+        // Local: 6 * 1.5 = 9
+        // Regional: 6 * 1.0 = 6
+        // Global: 6 * 0.75 = 4.5 -> 5
+        assert_eq!(config.calculate_fanout(32, &Scope::LocalCluster), 9);
+        assert_eq!(config.calculate_fanout(32, &Scope::Regional), 6);
+        assert_eq!(config.calculate_fanout(32, &Scope::Global), 5);
+    }
+
+    #[test]
+    fn test_adaptive_fanout_respects_max() {
+        let config = AdaptiveFanoutConfig::default();
+
+        // Very large network: log2(10000) + 1 = 14.3
+        // With local multiplier 1.5 = 21, but capped at max_fanout=10
+        assert_eq!(config.calculate_fanout(10000, &Scope::LocalCluster), 10);
+    }
+
+    #[test]
+    fn test_adaptive_fanout_custom_config() {
+        let config = AdaptiveFanoutConfig {
+            min_fanout: 2,
+            max_fanout: 5,
+            local_multiplier: 1.0,
+            regional_multiplier: 1.0,
+            global_multiplier: 1.0,
+            min_peers_for_adaptive: 3,
+        };
+
+        // Below threshold
+        assert_eq!(config.calculate_fanout(2, &Scope::Global), 2);
+
+        // At threshold: log2(3) + 1 ≈ 2.58 -> 3
+        assert_eq!(config.calculate_fanout(3, &Scope::Global), 3);
+
+        // Large network capped at 5
+        assert_eq!(config.calculate_fanout(1000, &Scope::Global), 5);
     }
 }

--- a/icn/crates/icn-gossip/src/types.rs
+++ b/icn/crates/icn-gossip/src/types.rs
@@ -89,7 +89,7 @@ pub enum Scope {
 impl std::fmt::Display for Scope {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Scope::LocalCluster => write!(f, "local"),
+            Scope::LocalCluster => write!(f, "local_cluster"),
             Scope::Regional => write!(f, "regional"),
             Scope::Global => write!(f, "global"),
         }

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -314,6 +314,14 @@ pub fn init_descriptions() {
         "icn_gossip_bloom_resize_total",
         "Total number of Bloom filter resizes"
     );
+    describe_gauge!(
+        "icn_gossip_adaptive_fanout",
+        "Current adaptive fanout value by scope"
+    );
+    describe_gauge!(
+        "icn_gossip_network_size_estimate",
+        "Estimated network size used for adaptive fanout calculation"
+    );
     describe_counter!(
         "icn_gossip_pull_truncated_total",
         "Total number of pull responses truncated due to size limits"
@@ -2059,6 +2067,12 @@ pub mod gossip {
     /// M2: Track Bloom filter resizes for dynamic sizing (#472)
     pub fn bloom_resize_inc() {
         counter!("icn_gossip_bloom_resize_total").increment(1);
+    }
+
+    /// M2 #484: Record adaptive fanout decision
+    pub fn adaptive_fanout_record(scope: &str, fanout: usize, network_size: usize) {
+        gauge!("icn_gossip_adaptive_fanout", "scope" => scope.to_string()).set(fanout as f64);
+        gauge!("icn_gossip_network_size_estimate").set(network_size as f64);
     }
 
     pub fn pull_truncated_inc() {


### PR DESCRIPTION
## Summary
- Dynamic fanout calculation based on network size and gossip scope
- Prevents over-messaging in small networks and under-propagation in large ones

## Formula
```
fanout = clamp(ceil(log2(network_size) + 1) * scope_multiplier, min, max)
```

## Configuration (AdaptiveFanoutConfig)
| Setting | Default | Description |
|---------|---------|-------------|
| min_fanout | 3 | Floor for small networks |
| max_fanout | 10 | Ceiling to prevent flooding |
| local_multiplier | 1.5 | Higher for latency-sensitive local |
| regional_multiplier | 1.0 | Baseline |
| global_multiplier | 0.75 | Lower for wide propagation |
| min_peers_for_adaptive | 5 | Threshold before adaptive kicks in |

## Example Fanouts (Regional scope)
| Peers | Fanout |
|-------|--------|
| 4 | 3 (min) |
| 8 | 4 |
| 32 | 6 |
| 128 | 8 |
| 10000 | 10 (max) |

## Metrics
- `icn_gossip_adaptive_fanout{scope=local|regional|global}`: Current fanout
- `icn_gossip_network_size_estimate`: Peer count used for calculation

## Test plan
- [x] 6 unit tests for AdaptiveFanoutConfig
- [x] Clippy clean
- [x] Build succeeds

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)