### PR TITLE
refactor: Remove/document dead code in gossip and compute (#155, #156)

### DIFF
--- a/icn/crates/icn-compute/src/actor/mod.rs
+++ b/icn/crates/icn-compute/src/actor/mod.rs
@@ -50,7 +50,8 @@ pub struct ComputeActor {
     payment_callback: Option<PaymentCallback>,
     /// Callback to broadcast compute events
     event_callback: Option<EventCallback>,
-    /// Signing key for results (placeholder)
+    /// Signing key for results
+    /// Reserved: Result signing for verifiable execution proofs
     #[allow(dead_code)]
     signing_key: Vec<u8>,
     /// Registry of available executors

--- a/icn/crates/icn-compute/src/actor/placement.rs
+++ b/icn/crates/icn-compute/src/actor/placement.rs
@@ -45,6 +45,9 @@ impl ComputeActor {
     }
 
     /// Get list of available executors with required capabilities
+    ///
+    /// Reserved: Capability-based executor filtering for task placement.
+    /// Currently placement uses scheduler directly; this is for future API use.
     #[allow(dead_code)]
     pub async fn find_executors(&self, required_caps: &[ExecutorCapability]) -> Vec<String> {
         let registry = self.executor_registry.lock().await;
@@ -63,6 +66,7 @@ impl ComputeActor {
     /// Get capacity information for an executor
     ///
     /// Returns None if the executor is not registered or has no capacity info.
+    /// Reserved: Capacity monitoring API for gateway/admin interfaces.
     #[allow(dead_code)]
     pub async fn get_executor_capacity(
         &self,
@@ -77,6 +81,7 @@ impl ComputeActor {
     /// Get capacity information for all registered executors
     ///
     /// Returns a map of executor DID to capacity. Executors without capacity info are excluded.
+    /// Reserved: Cluster-wide capacity dashboard for operators.
     #[allow(dead_code)]
     pub async fn get_all_executor_capacities(
         &self,

--- a/icn/crates/icn-compute/src/actor/types.rs
+++ b/icn/crates/icn-compute/src/actor/types.rs
@@ -6,26 +6,34 @@ use crate::scheduler::NodeCapacity;
 use crate::types::{ComputeMessage, ComputeResult, ExecutorCapability, TaskHash};
 
 /// Information about an available executor
+///
+/// Some fields are reserved for future federated compute features and are
+/// currently unused. See Phase 29 cleanup (#156) for tracking.
 #[derive(Debug, Clone)]
 pub(crate) struct ExecutorInfo {
     /// Executor's DID
     pub did: String,
     /// Cooperative ID this executor belongs to (None = local/same cooperative)
+    /// Reserved: Federated compute - cross-cooperative task routing
     #[allow(dead_code)]
     pub cooperative_id: Option<String>,
     /// Whether this executor is from a federated cooperative
+    /// Reserved: Federated compute - trust attenuation for remote executors
     #[allow(dead_code)]
     pub is_federated: bool,
     /// Capabilities this executor offers
     pub capabilities: Vec<ExecutorCapability>,
     /// Current trust score (local, from icn-trust)
+    /// Reserved: Trust-gated execution - minimum trust for task assignment
     #[allow(dead_code)]
     pub trust_score: f64,
     /// Federated trust score (attenuated based on coop trust)
     /// Formula: federated_trust = local_trust × coop_trust × attenuation_factor
+    /// Reserved: Federated compute - cross-cooperative trust scoring
     #[allow(dead_code)]
     pub federated_trust_score: Option<f64>,
     /// Last announcement timestamp (milliseconds since epoch, used for staleness detection)
+    /// Reserved: Executor health - detect stale/offline executors
     #[allow(dead_code)]
     pub last_seen: u64,
     /// Number of tasks currently executing
@@ -33,14 +41,18 @@ pub(crate) struct ExecutorInfo {
     /// Current capacity (CPU, memory, storage, GPU)
     pub capacity: Option<NodeCapacity>,
     /// Gateway endpoint for federated executors (used for result delivery)
+    /// Reserved: Federated compute - route results back through gateway
     #[allow(dead_code)]
     pub gateway_endpoint: Option<String>,
 }
 
 /// Consensus tracking for task results
+///
+/// Tracks results from multiple executors for Byzantine fault tolerance.
 #[derive(Debug, Clone)]
 pub(crate) struct ResultConsensus {
     /// Task hash (used for tracking in HashMap)
+    /// Reserved: Multi-executor consensus - correlate results across executors
     #[allow(dead_code)]
     pub task_hash: TaskHash,
     /// Results received from different executors

--- a/icn/crates/icn-gossip/src/gossip.rs
+++ b/icn/crates/icn-gossip/src/gossip.rs
@@ -969,53 +969,12 @@ impl GossipActor {
         missing
     }
 
-    /// Get all entry hashes for a topic
-    #[allow(dead_code)]
-    fn get_topic_hashes(&self, topic: &str) -> Vec<ContentHash> {
-        self.entries
-            .get(topic)
-            .map(|entries| entries.keys().copied().collect())
-            .unwrap_or_default()
-    }
-
-    /// Find entries we have that remote might not have (based on bloom filter)
-    #[allow(dead_code)]
-    fn find_entries_to_push(&self, topic: &str, remote_bloom: &BloomFilter) -> Vec<ContentHash> {
-        let mut to_push = Vec::new();
-
-        if let Some(entries) = self.entries.get(topic) {
-            for hash in entries.keys() {
-                // If remote bloom says they don't have it, we should offer it
-                if !remote_bloom.contains(hash) {
-                    to_push.push(*hash);
-                }
-            }
-        }
-
-        to_push
-    }
-
-    /// Find entries we're missing based on remote vector clock
-    #[allow(dead_code)]
-    fn find_entries_to_pull(&self, topic: &str, remote_vector: &VectorClock) -> Vec<ContentHash> {
-        let to_pull = Vec::new();
-
-        if let Some(entries) = self.entries.get(topic) {
-            // Check each entry we have
-            for entry in entries.values() {
-                // If remote clock is ahead of this entry's clock, we might be missing entries
-                if remote_vector.happened_after(&entry.clock) {
-                    // This entry is causally before remote state
-                    // We might be missing newer entries from remote
-                    continue;
-                }
-            }
-        }
-
-        // For now, we'll use a simpler heuristic: compare local bloom against remote
-        // A full implementation would track per-peer vector clocks and compute diffs
-        to_pull
-    }
+    // Note: Legacy dead code removed in Phase 29 (#155):
+    // - get_topic_hashes() - unused helper
+    // - find_entries_to_push() - superseded by Digest-based protocol
+    // - find_entries_to_pull() - incomplete implementation, never used
+    // The gossip protocol uses Digest → PullRequest → PullResponse flow.
+    // See handle_digest(), handle_pull_request(), handle_pull_response().
 
     /// Handle incoming gossip message from network
     #[instrument(skip(self, message), fields(peer_did = %sender, message_type = message.variant_name()))]


### PR DESCRIPTION
## Summary
Phase 29 code quality cleanup - removing dead code and documenting reserved fields.

## Changes

### icn-gossip/src/gossip.rs
Removed 3 dead functions (-47 lines):
- `find_entries_to_pull()` - incomplete implementation, always returned empty
- `find_entries_to_push()` - superseded by Digest-based protocol
- `get_topic_hashes()` - unused helper

Added note explaining the actual gossip flow: Digest → PullRequest → PullResponse

### icn-compute/src/actor/types.rs
Documented reserved fields for future federated compute:
- `cooperative_id`, `is_federated`, `federated_trust_score`, `gateway_endpoint` - cross-coop routing
- `trust_score`, `last_seen` - trust-gated execution and health monitoring
- `task_hash` in ResultConsensus - multi-executor correlation

### icn-compute/src/actor/placement.rs
Documented reserved methods:
- `find_executors()` - capability-based filtering
- `get_executor_capacity()` - monitoring API
- `get_all_executor_capacities()` - operator dashboard

### icn-compute/src/actor/mod.rs
- `signing_key` - reserved for verifiable execution proofs

## Test plan
- [x] Build succeeds
- [x] Clippy clean
- [x] No functional changes (documentation only for compute, removal for gossip)

Closes #155, Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)