### PR TITLE
feat(release): Add binary signing and SBOM generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       dry_run:
         description: 'Dry run (build but do not publish)'
         required: false
-        default: 'false'
+        default: false
         type: boolean
 
 permissions:
@@ -42,7 +42,7 @@ jobs:
             artifact_name: icn-macos-arm64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Free disk space (Linux)
         if: runner.os == 'Linux'
@@ -78,14 +78,18 @@ jobs:
 
       - name: Package binaries
         run: |
+          set -euo pipefail
           mkdir -p dist
           cp icn/target/${{ matrix.target }}/release/icnd dist/
           cp icn/target/${{ matrix.target }}/release/icnctl dist/
-          cp icn/target/${{ matrix.target }}/release/icn-console dist/ || true
+          # icn-console is optional; copy it if it was built
+          if [ -f "icn/target/${{ matrix.target }}/release/icn-console" ]; then
+            cp icn/target/${{ matrix.target }}/release/icn-console dist/
+          fi
           tar -czvf ${{ matrix.artifact_name }}.tar.gz -C dist .
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.artifact_name }}
           path: ${{ matrix.artifact_name }}.tar.gz
@@ -95,17 +99,22 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: artifacts
 
       - name: Flatten artifacts
         run: |
+          set -euo pipefail
           mkdir -p release
           find artifacts -name "*.tar.gz" -exec mv {} release/ \;
+          if ! ls release/*.tar.gz >/dev/null 2>&1; then
+            echo "Error: No .tar.gz artifacts found in release/ after flattening."
+            exit 1
+          fi
           ls -la release/
 
       - name: Install cosign
@@ -113,8 +122,15 @@ jobs:
 
       - name: Sign artifacts with cosign (keyless)
         run: |
+          set -euo pipefail
           cd release
-          for file in *.tar.gz; do
+          shopt -s nullglob
+          files=( *.tar.gz )
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "Error: No .tar.gz artifacts found to sign."
+            exit 1
+          fi
+          for file in "${files[@]}"; do
             echo "Signing $file..."
             cosign sign-blob --yes "$file" \
               --output-signature "${file}.sig" \
@@ -123,7 +139,7 @@ jobs:
           ls -la
 
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@v0.17
         with:
           path: ./icn
           artifact-name: sbom.spdx.json
@@ -131,8 +147,15 @@ jobs:
 
       - name: Generate checksums
         run: |
+          set -euo pipefail
           cd release
-          sha256sum *.tar.gz > SHA256SUMS.txt
+          shopt -s nullglob
+          files=( *.tar.gz )
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "Error: No .tar.gz artifacts found for checksum generation."
+            exit 1
+          fi
+          sha256sum "${files[@]}" > SHA256SUMS.txt
           cat SHA256SUMS.txt
 
       - name: Create attestation
@@ -141,7 +164,7 @@ jobs:
           subject-path: 'release/*.tar.gz'
 
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/') && github.event.inputs.dry_run != 'true'
+        if: startsWith(github.ref, 'refs/tags/') && (github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != true)
         uses: softprops/action-gh-release@v2
         with:
           files: |
@@ -173,7 +196,11 @@ jobs:
             ### Verify checksums
 
             ```bash
+            # Linux
             sha256sum -c SHA256SUMS.txt
+
+            # macOS
+            shasum -a 256 -c SHA256SUMS.txt
             ```
 
             ### Software Bill of Materials
@@ -182,7 +209,7 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## Release Artifacts 📦" >> $GITHUB_STEP_SUMMARY
+          echo "## Release Artifacts" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| File | Size |" >> $GITHUB_STEP_SUMMARY
           echo "|------|------|" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,198 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (build but do not publish)'
+        required: false
+        default: 'false'
+        type: boolean
+
+permissions:
+  contents: write
+  id-token: write  # Required for keyless signing with Sigstore
+  attestations: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact_name: icn-linux-amd64
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact_name: icn-linux-arm64
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            artifact_name: icn-macos-amd64
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            artifact_name: icn-macos-arm64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free disk space (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          df -h /
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation tools (Linux ARM64)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "icn -> target"
+          key: ${{ matrix.target }}
+
+      - name: Build release binaries
+        run: |
+          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ]; then
+            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+          fi
+          cargo build --release --target ${{ matrix.target }}
+        working-directory: ./icn
+
+      - name: Package binaries
+        run: |
+          mkdir -p dist
+          cp icn/target/${{ matrix.target }}/release/icnd dist/
+          cp icn/target/${{ matrix.target }}/release/icnctl dist/
+          cp icn/target/${{ matrix.target }}/release/icn-console dist/ || true
+          tar -czvf ${{ matrix.artifact_name }}.tar.gz -C dist .
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.artifact_name }}.tar.gz
+
+  sign-and-release:
+    name: Sign and Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Flatten artifacts
+        run: |
+          mkdir -p release
+          find artifacts -name "*.tar.gz" -exec mv {} release/ \;
+          ls -la release/
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign artifacts with cosign (keyless)
+        run: |
+          cd release
+          for file in *.tar.gz; do
+            echo "Signing $file..."
+            cosign sign-blob --yes "$file" \
+              --output-signature "${file}.sig" \
+              --output-certificate "${file}.pem"
+          done
+          ls -la
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: ./icn
+          artifact-name: sbom.spdx.json
+          output-file: release/sbom.spdx.json
+
+      - name: Generate checksums
+        run: |
+          cd release
+          sha256sum *.tar.gz > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
+      - name: Create attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: 'release/*.tar.gz'
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/') && github.event.inputs.dry_run != 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            release/*.tar.gz
+            release/*.sig
+            release/*.pem
+            release/SHA256SUMS.txt
+            release/sbom.spdx.json
+          generate_release_notes: true
+          body: |
+            ## Verification
+
+            All release artifacts are signed using [Sigstore](https://www.sigstore.dev/) keyless signing.
+
+            ### Verify signatures
+
+            ```bash
+            # Install cosign
+            # https://docs.sigstore.dev/cosign/system_config/installation/
+
+            # Verify a binary
+            cosign verify-blob icn-linux-amd64.tar.gz \
+              --signature icn-linux-amd64.tar.gz.sig \
+              --certificate icn-linux-amd64.tar.gz.pem \
+              --certificate-identity-regexp "https://github.com/InterCooperative-Network/icn" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+            ```
+
+            ### Verify checksums
+
+            ```bash
+            sha256sum -c SHA256SUMS.txt
+            ```
+
+            ### Software Bill of Materials
+
+            The `sbom.spdx.json` file contains a complete list of dependencies.
+
+      - name: Summary
+        run: |
+          echo "## Release Artifacts 📦" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| File | Size |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|------|" >> $GITHUB_STEP_SUMMARY
+          cd release
+          for file in *.tar.gz; do
+            size=$(ls -lh "$file" | awk '{print $5}')
+            echo "| $file | $size |" >> $GITHUB_STEP_SUMMARY
+          done
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Checksums" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          cat SHA256SUMS.txt >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -192,6 +192,34 @@ cat docs/PRODUCTION_DEPLOYMENT_GUIDE.md
 ```
 
 ---
+
+## 🔐 Release Verification
+
+All ICN release binaries are signed using [Sigstore](https://www.sigstore.dev/) keyless signing and include a Software Bill of Materials (SBOM).
+
+**Verify a release:**
+```bash
+# Install cosign
+# See: https://docs.sigstore.dev/cosign/system_config/installation/
+
+# Download release files
+curl -LO https://github.com/InterCooperative-Network/icn/releases/latest/download/icn-linux-amd64.tar.gz
+curl -LO https://github.com/InterCooperative-Network/icn/releases/latest/download/icn-linux-amd64.tar.gz.sig
+curl -LO https://github.com/InterCooperative-Network/icn/releases/latest/download/icn-linux-amd64.tar.gz.pem
+
+# Verify signature
+cosign verify-blob icn-linux-amd64.tar.gz \
+  --signature icn-linux-amd64.tar.gz.sig \
+  --certificate icn-linux-amd64.tar.gz.pem \
+  --certificate-identity-regexp "https://github.com/InterCooperative-Network/icn" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+
+# Verify checksum
+curl -LO https://github.com/InterCooperative-Network/icn/releases/latest/download/SHA256SUMS.txt
+sha256sum -c SHA256SUMS.txt --ignore-missing
+```
+
+---
 - [x] Phase 16: Intelligent scheduler (resource profiles, locality awareness, cooperative policies)
 - [x] Phase 17: Storage hardening & replication (99.9% durability target)
 - [x] Phase 18: Pre-pilot hardening (Byzantine detection, partition healing, conflict resolution)

--- a/README.md
+++ b/README.md
@@ -216,7 +216,10 @@ cosign verify-blob icn-linux-amd64.tar.gz \
 
 # Verify checksum
 curl -LO https://github.com/InterCooperative-Network/icn/releases/latest/download/SHA256SUMS.txt
+# Linux
 sha256sum -c SHA256SUMS.txt --ignore-missing
+# macOS
+shasum -a 256 -c SHA256SUMS.txt
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Add release workflow with Sigstore keyless signing
- Generate SBOM for each release
- Build for 4 platforms (linux/macos × amd64/arm64)
- Add verification instructions to README

## What
- New `.github/workflows/release.yml` triggered on `v*` tags
- Cosign keyless signing via GitHub OIDC
- SBOM generation with anchore/sbom-action
- Build provenance attestations
- SHA256 checksums

## Why
Supply chain security - unsigned binaries are vulnerable to tampering. Sigstore provides transparency logging via Rekor.

## How
1. Build matrix creates binaries for 4 targets
2. `sign-and-release` job signs all artifacts with cosign
3. GitHub Release created with all artifacts + signatures + SBOM

## Test plan
- [ ] Trigger workflow with `workflow_dispatch` (dry_run=true)
- [ ] Verify cosign signatures are created
- [ ] Create test tag and verify full release flow

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)