### PR TITLE
fix(gossip): Enforce strict defaults for topic access control

### DIFF
--- a/icn/crates/icn-gossip/src/gossip.rs
+++ b/icn/crates/icn-gossip/src/gossip.rs
@@ -487,10 +487,15 @@ impl GossipActor {
     /// Publish an entry to a topic
     #[instrument(skip(self, data), fields(topic = %topic, data_size = data.len()))]
     pub async fn publish(&mut self, topic: &str, data: Vec<u8>) -> Result<ContentHash> {
-        // Auto-create topic if it doesn't exist (as public topic)
+        // Auto-create topic if it doesn't exist (with strict default ACL)
         if !self.topics.contains_key(topic) {
-            debug!("Auto-creating public topic: {}", topic);
-            self.create_topic(Topic::new(topic.to_string(), AccessControl::Public));
+            warn!(
+                topic = %topic,
+                "Auto-creating topic with default ACL (TrustClass::Partner). \
+                 Consider registering topics explicitly with appropriate access control."
+            );
+            icn_obs::metrics::gossip::topics_auto_created_inc();
+            self.create_topic(Topic::new(topic.to_string(), AccessControl::default()));
         }
 
         let topic_obj = self.topics.get(topic).context("Topic not found")?;

--- a/icn/crates/icn-gossip/src/types.rs
+++ b/icn/crates/icn-gossip/src/types.rs
@@ -434,6 +434,10 @@ impl Topic {
 }
 
 /// Access control for topics
+///
+/// **Security Note**: When creating topics, always specify explicit access control.
+/// The default is `TrustClass(Partner)` which requires a trust score >= 0.4.
+/// Use `AccessControl::Public` only for topics that genuinely need open access.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AccessControl {
     /// Anyone can publish/subscribe
@@ -444,6 +448,14 @@ pub enum AccessControl {
 
     /// Only specific participants (e.g., contract members)
     Participants(Vec<Did>),
+}
+
+impl Default for AccessControl {
+    /// Default to Partner trust class (score >= 0.4) for security.
+    /// This prevents unknown peers from publishing to auto-created topics.
+    fn default() -> Self {
+        AccessControl::TrustClass(TrustClass::Partner)
+    }
 }
 
 /// Resource limits for a specific trust class
@@ -629,6 +641,46 @@ mod tests {
         assert!(topic.can_publish(&alice, None));
         assert!(topic.can_publish(&bob, None));
         assert!(!topic.can_publish(&charlie, None));
+    }
+
+    #[test]
+    fn test_access_control_default_is_strict() {
+        // Default AccessControl should be TrustClass::Partner (strict)
+        // This prevents unknown peers from publishing to auto-created topics
+        let default_acl = AccessControl::default();
+        assert_eq!(
+            default_acl,
+            AccessControl::TrustClass(TrustClass::Partner),
+            "Default ACL should require Partner trust level"
+        );
+
+        // Verify a topic with default ACL requires Partner trust
+        let topic = Topic::new("auto-created".to_string(), default_acl);
+        let did = KeyPair::generate().unwrap().did().clone();
+
+        // No trust class - denied
+        assert!(
+            !topic.can_publish(&did, None),
+            "Default ACL should deny untrusted peers"
+        );
+        assert!(
+            !topic.can_publish(&did, Some(TrustClass::Isolated)),
+            "Default ACL should deny Isolated peers"
+        );
+        assert!(
+            !topic.can_publish(&did, Some(TrustClass::Known)),
+            "Default ACL should deny Known peers"
+        );
+
+        // Partner and above - allowed
+        assert!(
+            topic.can_publish(&did, Some(TrustClass::Partner)),
+            "Default ACL should allow Partner peers"
+        );
+        assert!(
+            topic.can_publish(&did, Some(TrustClass::Federated)),
+            "Default ACL should allow Federated peers"
+        );
     }
 
     #[test]

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -214,6 +214,10 @@ pub fn init_descriptions() {
 
     // Gossip metrics
     describe_gauge!("icn_gossip_topics_total", "Total number of gossip topics");
+    describe_counter!(
+        "icn_gossip_topics_auto_created_total",
+        "Topics auto-created with default ACL (indicates missing explicit registration)"
+    );
     describe_gauge!(
         "icn_gossip_entries_total",
         "Total number of gossip entries across all topics"
@@ -1954,6 +1958,11 @@ pub mod gossip {
 
     pub fn topics_total_set(value: u64) {
         gauge!("icn_gossip_topics_total").set(value as f64);
+    }
+
+    /// Increment counter for topics auto-created with default ACL
+    pub fn topics_auto_created_inc() {
+        counter!("icn_gossip_topics_auto_created_total").increment(1);
     }
 
     pub fn entries_total_set(value: u64) {


### PR DESCRIPTION
## Summary
Security fix: Auto-created topics now default to `TrustClass::Partner` instead of `Public`.

## Problem
When publishing to an undeclared topic, it was auto-created with `AccessControl::Public`, allowing any peer to publish/subscribe. This could lead to:
- Spam from untrusted peers
- Information leakage
- Potential abuse vectors

## Solution
- Add `Default` impl for `AccessControl` → `TrustClass(Partner)` (score >= 0.4)
- Auto-created topics now use the strict default
- Warning log emitted when topics are auto-created
- Metric added: `icn_gossip_topics_auto_created_total`

## Changes
| File | Change |
|------|--------|
| `types.rs` | Add `Default` impl for `AccessControl` |
| `gossip.rs` | Use `AccessControl::default()`, add warning + metric |
| `metrics_legacy.rs` | Add `topics_auto_created_inc()` metric |

## Test plan
- [x] Existing tests pass (142 tests)
- [x] New test: `test_access_control_default_is_strict`

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)