### PR TITLE
fix(gossip): Enforce strict defaults for topic access control

### DIFF
--- a/icn/crates/icn-gossip/src/gossip.rs
+++ b/icn/crates/icn-gossip/src/gossip.rs
@@ -199,6 +199,10 @@ pub struct GossipActor {
 
     /// Adaptive fanout configuration (M2 #484 - dynamic fanout based on network size)
     adaptive_fanout_config: crate::types::AdaptiveFanoutConfig,
+
+    /// Topic auto-creation policy (Issue #473 - strict defaults)
+    /// Controls what happens when publishing to an undeclared topic
+    topic_auto_creation_policy: crate::types::TopicAutoCreationPolicy,
 }
 
 impl GossipActor {
@@ -236,6 +240,7 @@ impl GossipActor {
             storage_quota_manager: None, // Phase 18 Week 6: Set via set_storage_quota_manager()
             bloom_resize_config: crate::bloom::BloomResizeConfig::default(), // M2: Dynamic Bloom sizing
             adaptive_fanout_config: crate::types::AdaptiveFanoutConfig::default(), // M2 #484: Adaptive fanout
+            topic_auto_creation_policy: crate::types::TopicAutoCreationPolicy::default(), // Issue #473: Strict defaults
         };
 
         // Create default topics with appropriate scopes
@@ -345,6 +350,22 @@ impl GossipActor {
         manager: Arc<RwLock<icn_store::StorageQuotaManager>>,
     ) {
         self.storage_quota_manager = Some(manager);
+    }
+
+    /// Set the topic auto-creation policy (Issue #473)
+    ///
+    /// Controls what happens when attempting to publish to an undeclared topic.
+    /// By default, publishes to undeclared topics are rejected for security.
+    pub fn set_topic_auto_creation_policy(
+        &mut self,
+        policy: crate::types::TopicAutoCreationPolicy,
+    ) {
+        self.topic_auto_creation_policy = policy;
+    }
+
+    /// Get the current topic auto-creation policy
+    pub fn topic_auto_creation_policy(&self) -> crate::types::TopicAutoCreationPolicy {
+        self.topic_auto_creation_policy
     }
 
     /// Attempt to heal partition with a reconnected peer (Phase 18 Week 3)
@@ -487,10 +508,38 @@ impl GossipActor {
     /// Publish an entry to a topic
     #[instrument(skip(self, data), fields(topic = %topic, data_size = data.len()))]
     pub async fn publish(&mut self, topic: &str, data: Vec<u8>) -> Result<ContentHash> {
-        // Auto-create topic if it doesn't exist (as public topic)
+        // Handle undeclared topics according to policy (Issue #473)
         if !self.topics.contains_key(topic) {
-            debug!("Auto-creating public topic: {}", topic);
-            self.create_topic(Topic::new(topic.to_string(), AccessControl::Public));
+            use crate::types::TopicAutoCreationPolicy;
+
+            match self.topic_auto_creation_policy {
+                TopicAutoCreationPolicy::Reject => {
+                    warn!(
+                        topic = %topic,
+                        "Rejecting publish to undeclared topic (policy: Reject)"
+                    );
+                    bail!(
+                        "Topic '{topic}' not found. Topics must be explicitly created before use."
+                    );
+                }
+                TopicAutoCreationPolicy::CreateWithStrictDefaults => {
+                    warn!(
+                        topic = %topic,
+                        "Auto-creating topic with strict defaults (Federated trust required). \
+                         Consider explicitly creating topics with appropriate access control."
+                    );
+                    // Use the strict default (AccessControl::default() = TrustGated(Federated))
+                    self.create_topic(Topic::new(topic.to_string(), AccessControl::default()));
+                }
+                TopicAutoCreationPolicy::CreatePublic => {
+                    warn!(
+                        topic = %topic,
+                        "Auto-creating public topic (INSECURE - legacy behavior). \
+                         This allows anyone to publish/subscribe. Consider using CreateWithStrictDefaults or Reject."
+                    );
+                    self.create_topic(Topic::new(topic.to_string(), AccessControl::Public));
+                }
+            }
         }
 
         let topic_obj = self.topics.get(topic).context("Topic not found")?;
@@ -2323,6 +2372,12 @@ mod tests {
         let owner = KeyPair::generate().unwrap().did().clone();
         let mut gossip = GossipActor::new(owner.clone(), Arc::new(mock_trust_lookup));
 
+        // Create topic first (required since Issue #473 - topics must be explicitly created)
+        gossip.create_topic(Topic::new(
+            "test:no-subs".to_string(),
+            AccessControl::Public,
+        ));
+
         let notification_count = Arc::new(Mutex::new(0));
         let count_clone = notification_count.clone();
 
@@ -3163,5 +3218,139 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    // Issue #473: Topic auto-creation policy tests
+
+    #[tokio::test]
+    async fn test_topic_auto_creation_policy_reject() {
+        let owner = KeyPair::generate().unwrap().did().clone();
+        let mut gossip = GossipActor::new(owner.clone(), Arc::new(mock_trust_lookup));
+
+        // Default policy is Reject
+        assert_eq!(
+            gossip.topic_auto_creation_policy(),
+            crate::types::TopicAutoCreationPolicy::Reject
+        );
+
+        // Try to publish to undeclared topic - should fail
+        let result = gossip.publish("undeclared:topic", b"test".to_vec()).await;
+        assert!(
+            result.is_err(),
+            "Publishing to undeclared topic should fail with Reject policy"
+        );
+
+        let error = result.unwrap_err().to_string();
+        assert!(
+            error.contains("not found") || error.contains("must be explicitly created"),
+            "Error should indicate topic not found: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_topic_auto_creation_policy_create_with_strict_defaults() {
+        let owner = KeyPair::generate().unwrap().did().clone();
+
+        // Use Federated trust so we can publish to the auto-created topic
+        let trust_lookup: TrustLookup = Arc::new(|_did| Some(TrustClass::Federated));
+        let mut gossip = GossipActor::new(owner.clone(), trust_lookup);
+
+        // Set policy to CreateWithStrictDefaults
+        gossip.set_topic_auto_creation_policy(
+            crate::types::TopicAutoCreationPolicy::CreateWithStrictDefaults,
+        );
+
+        // Publish to undeclared topic - should succeed (with Federated trust)
+        let result = gossip.publish("auto:strict", b"test".to_vec()).await;
+        assert!(
+            result.is_ok(),
+            "Publishing should succeed with Federated trust"
+        );
+
+        // Verify topic was created with strict defaults (Federated trust required)
+        let topic_obj = gossip.topics.get("auto:strict");
+        assert!(topic_obj.is_some(), "Topic should have been created");
+        assert_eq!(
+            topic_obj.unwrap().acl,
+            AccessControl::TrustClass(TrustClass::Federated),
+            "Auto-created topic should have Federated trust ACL"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_topic_auto_creation_policy_create_with_strict_defaults_denies_low_trust() {
+        let owner = KeyPair::generate().unwrap().did().clone();
+
+        // Use Known trust (below Federated threshold)
+        let trust_lookup: TrustLookup = Arc::new(|_did| Some(TrustClass::Known));
+        let mut gossip = GossipActor::new(owner.clone(), trust_lookup);
+
+        // Set policy to CreateWithStrictDefaults
+        gossip.set_topic_auto_creation_policy(
+            crate::types::TopicAutoCreationPolicy::CreateWithStrictDefaults,
+        );
+
+        // Publish to undeclared topic - should fail (Known < Federated)
+        let result = gossip.publish("auto:strict", b"test".to_vec()).await;
+        assert!(
+            result.is_err(),
+            "Publishing should fail with Known trust (below Federated requirement)"
+        );
+
+        let error = result.unwrap_err().to_string();
+        assert!(
+            error.contains("Not authorized"),
+            "Error should indicate authorization failure: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_topic_auto_creation_policy_create_public() {
+        let owner = KeyPair::generate().unwrap().did().clone();
+        let mut gossip = GossipActor::new(owner.clone(), Arc::new(mock_trust_lookup));
+
+        // Set policy to CreatePublic (legacy behavior)
+        gossip.set_topic_auto_creation_policy(crate::types::TopicAutoCreationPolicy::CreatePublic);
+
+        // Publish to undeclared topic - should succeed
+        let result = gossip.publish("auto:public", b"test".to_vec()).await;
+        assert!(
+            result.is_ok(),
+            "Publishing should succeed with CreatePublic policy"
+        );
+
+        // Verify topic was created as public
+        let topic_obj = gossip.topics.get("auto:public");
+        assert!(topic_obj.is_some(), "Topic should have been created");
+        assert_eq!(
+            topic_obj.unwrap().acl,
+            AccessControl::Public,
+            "Auto-created topic should have Public ACL"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_explicit_topic_creation_bypasses_policy() {
+        let owner = KeyPair::generate().unwrap().did().clone();
+        let mut gossip = GossipActor::new(owner.clone(), Arc::new(mock_trust_lookup));
+
+        // Default policy is Reject
+        assert_eq!(
+            gossip.topic_auto_creation_policy(),
+            crate::types::TopicAutoCreationPolicy::Reject
+        );
+
+        // Explicitly create topic
+        gossip.create_topic(Topic::new(
+            "explicit:topic".to_string(),
+            AccessControl::Public,
+        ));
+
+        // Now publish should succeed
+        let result = gossip.publish("explicit:topic", b"test".to_vec()).await;
+        assert!(
+            result.is_ok(),
+            "Publishing to explicitly created topic should succeed"
+        );
     }
 }

--- a/icn/crates/icn-gossip/src/gossip.rs
+++ b/icn/crates/icn-gossip/src/gossip.rs
@@ -278,7 +278,7 @@ impl GossipActor {
         gossip.create_topic(
             Topic::new(
                 crate::labor_shares::topics::BONDS_PAYMENTS.to_string(),
-                AccessControl::TrustClass(TrustClass::Partner), // TrustGated - Partner+
+                AccessControl::TrustClass(TrustClass::Partner), // TrustClass::Partner
             )
             .with_scope(crate::types::Scope::Regional), // Payment notifications are regional
         );
@@ -528,7 +528,7 @@ impl GossipActor {
                         "Auto-creating topic with strict defaults (Federated trust required). \
                          Consider explicitly creating topics with appropriate access control."
                     );
-                    // Use the strict default (AccessControl::default() = TrustGated(Federated))
+                    // Use the strict default (AccessControl::default() = TrustClass(Federated))
                     self.create_topic(Topic::new(topic.to_string(), AccessControl::default()));
                 }
                 TopicAutoCreationPolicy::CreatePublic => {

--- a/icn/crates/icn-gossip/src/lib.rs
+++ b/icn/crates/icn-gossip/src/lib.rs
@@ -65,7 +65,7 @@ pub use scalability::{CompressedVectorClock, ShardStats, ShardedTopic, TopicShar
 pub use sync::{Backoff, PeerSyncManager, PeerSyncState};
 pub use types::{
     AccessControl, AdaptiveFanoutConfig, ContentHash, GossipEntry, GossipMessage, Scope,
-    Subscription, SyncCursor, Topic, TrustResourceLimits,
+    Subscription, SyncCursor, Topic, TopicAutoCreationPolicy, TrustResourceLimits,
 };
 pub use vector_clock::VectorClock;
 

--- a/icn/crates/icn-gossip/src/types.rs
+++ b/icn/crates/icn-gossip/src/types.rs
@@ -434,6 +434,10 @@ impl Topic {
 }
 
 /// Access control for topics
+///
+/// Defaults to the most restrictive access level (Federated trust class)
+/// to ensure security by default. Topics must explicitly opt into
+/// more permissive access.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AccessControl {
     /// Anyone can publish/subscribe
@@ -444,6 +448,36 @@ pub enum AccessControl {
 
     /// Only specific participants (e.g., contract members)
     Participants(Vec<Did>),
+}
+
+impl Default for AccessControl {
+    /// Returns the most restrictive access control by default.
+    ///
+    /// This ensures that undeclared or auto-created topics default to
+    /// requiring Federated-level trust (0.7+), preventing unauthorized
+    /// access or information leakage.
+    fn default() -> Self {
+        AccessControl::TrustClass(TrustClass::Federated)
+    }
+}
+
+/// Policy for handling undeclared topics during publish operations
+///
+/// Controls what happens when a peer attempts to publish to a topic
+/// that hasn't been explicitly registered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TopicAutoCreationPolicy {
+    /// Reject publishes to undeclared topics (most secure)
+    #[default]
+    Reject,
+
+    /// Auto-create with strict default access control (TrustClass::Federated)
+    /// Logs a warning when this happens
+    CreateWithStrictDefaults,
+
+    /// Auto-create with public access (legacy behavior, not recommended)
+    /// Logs a warning when this happens
+    CreatePublic,
 }
 
 /// Resource limits for a specific trust class
@@ -629,6 +663,78 @@ mod tests {
         assert!(topic.can_publish(&alice, None));
         assert!(topic.can_publish(&bob, None));
         assert!(!topic.can_publish(&charlie, None));
+    }
+
+    // Issue #473: Test strict access control defaults
+
+    #[test]
+    fn test_access_control_default_is_strict() {
+        // Verify default is TrustClass(Federated) - the strictest level
+        let default_acl = AccessControl::default();
+        assert_eq!(
+            default_acl,
+            AccessControl::TrustClass(TrustClass::Federated),
+            "Default AccessControl should be TrustClass(Federated) for security"
+        );
+    }
+
+    #[test]
+    fn test_access_control_default_requires_high_trust() {
+        let topic = Topic::new("test".to_string(), AccessControl::default());
+        let did = KeyPair::generate().unwrap().did().clone();
+
+        // No trust - denied
+        assert!(
+            !topic.can_publish(&did, None),
+            "Default ACL should deny peers with no trust"
+        );
+
+        // Isolated - denied
+        assert!(
+            !topic.can_publish(&did, Some(TrustClass::Isolated)),
+            "Default ACL should deny Isolated trust"
+        );
+
+        // Known - denied
+        assert!(
+            !topic.can_publish(&did, Some(TrustClass::Known)),
+            "Default ACL should deny Known trust"
+        );
+
+        // Partner - denied (below Federated)
+        assert!(
+            !topic.can_publish(&did, Some(TrustClass::Partner)),
+            "Default ACL should deny Partner trust"
+        );
+
+        // Federated - allowed (matches requirement)
+        assert!(
+            topic.can_publish(&did, Some(TrustClass::Federated)),
+            "Default ACL should allow Federated trust"
+        );
+    }
+
+    #[test]
+    fn test_topic_auto_creation_policy_default() {
+        // Default policy should be Reject (most secure)
+        let policy = TopicAutoCreationPolicy::default();
+        assert_eq!(
+            policy,
+            TopicAutoCreationPolicy::Reject,
+            "Default policy should be Reject for security"
+        );
+    }
+
+    #[test]
+    fn test_topic_auto_creation_policy_variants() {
+        // Verify all variants exist and are distinguishable
+        let reject = TopicAutoCreationPolicy::Reject;
+        let strict = TopicAutoCreationPolicy::CreateWithStrictDefaults;
+        let public = TopicAutoCreationPolicy::CreatePublic;
+
+        assert_ne!(reject, strict);
+        assert_ne!(strict, public);
+        assert_ne!(reject, public);
     }
 
     #[test]

--- a/icn/crates/icn-ledger/tests/gossip_sync.rs
+++ b/icn/crates/icn-ledger/tests/gossip_sync.rs
@@ -10,7 +10,9 @@ use std::sync::Arc;
 use tempfile::TempDir;
 
 /// Create a test ledger with gossip integration
-fn create_test_node() -> (Ledger, TempDir, Arc<tokio::sync::RwLock<GossipActor>>) {
+async fn create_test_node() -> (Ledger, TempDir, Arc<tokio::sync::RwLock<GossipActor>>) {
+    use icn_gossip::{AccessControl, Topic};
+
     let temp_dir = TempDir::new().unwrap();
     let store = Arc::new(SledStore::open(temp_dir.path()).unwrap());
 
@@ -20,6 +22,16 @@ fn create_test_node() -> (Ledger, TempDir, Arc<tokio::sync::RwLock<GossipActor>>
     // Create gossip actor
     let trust_lookup = Arc::new(|_: &icn_identity::Did| Some(TrustClass::Partner));
     let gossip = GossipActor::spawn(did.clone(), trust_lookup);
+
+    // Create the ledger topic before use (required with strict access control defaults)
+    {
+        let mut actor = gossip.write().await;
+        let topic = Topic::new(
+            "ledger:hours".to_string(),
+            AccessControl::TrustClass(TrustClass::Known),
+        );
+        actor.create_topic(topic);
+    }
 
     // Create ledger with gossip
     let mut ledger = Ledger::new(store).unwrap();
@@ -78,7 +90,7 @@ async fn test_direct_sync_message() {
 #[tokio::test]
 async fn test_ledger_publishes_to_gossip() {
     // Create a node with gossip integration
-    let (mut ledger, _temp, gossip) = create_test_node();
+    let (mut ledger, _temp, gossip) = create_test_node().await;
 
     let alice = KeyPair::generate().unwrap().did().clone();
     let bob = KeyPair::generate().unwrap().did().clone();
@@ -123,7 +135,7 @@ async fn test_ledger_publishes_to_gossip() {
 #[tokio::test]
 async fn test_multiple_entries_to_gossip() {
     // Create a node with gossip
-    let (mut ledger, _temp, gossip) = create_test_node();
+    let (mut ledger, _temp, gossip) = create_test_node().await;
 
     let alice = KeyPair::generate().unwrap().did().clone();
     let bob = KeyPair::generate().unwrap().did().clone();


### PR DESCRIPTION
## Summary
- Adds strict default access control for gossip topics (issue #473)
- Undeclared topics now require Federated-level trust (0.7+) by default
- Provides configurable policy for handling undeclared topics

## Changes
- **`types.rs`**:
  - `AccessControl` now implements `Default` returning `TrustClass(Federated)`
  - New `TopicAutoCreationPolicy` enum with three modes:
    - `Reject` (default): Most secure, rejects all undeclared topic publishes
    - `CreateWithStrictDefaults`: Auto-creates with Federated trust requirement
    - `CreatePublic`: Legacy behavior (logs warning)
- **`gossip.rs`**:
  - Added `topic_auto_creation_policy` field to `GossipActor`
  - Updated `publish()` to use policy-based topic handling
  - Added setter/getter for policy configuration
  - Warning logs for all auto-creation scenarios
- **`lib.rs`**: Exports `TopicAutoCreationPolicy`

## Test plan
- [x] `test_access_control_default_is_strict` - Verifies default is Federated
- [x] `test_access_control_default_requires_high_trust` - Tests trust level enforcement
- [x] `test_topic_auto_creation_policy_default` - Verifies default is Reject
- [x] `test_topic_auto_creation_policy_reject` - Tests rejection of undeclared topics
- [x] `test_topic_auto_creation_policy_create_with_strict_defaults` - Tests strict auto-creation
- [x] `test_topic_auto_creation_policy_create_with_strict_defaults_denies_low_trust` - Tests trust enforcement
- [x] `test_topic_auto_creation_policy_create_public` - Tests legacy mode
- [x] `test_explicit_topic_creation_bypasses_policy` - Tests explicit creation works
- [x] All 128 tests pass
- [x] `cargo clippy` clean

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)