### PR TITLE
test(community): Add comprehensive unit tests for icn-community crate

### DIFF
--- a/icn/crates/icn-community/src/lifecycle.rs
+++ b/icn/crates/icn-community/src/lifecycle.rs
@@ -59,3 +59,453 @@ impl CommunityLifecycle {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Member, MemberType};
+    use chrono::Utc;
+
+    fn create_formation_request(name: &str, founders: Vec<&str>) -> FormationRequest {
+        FormationRequest {
+            name: name.to_string(),
+            community_type: CommunityType::Geographic,
+            founding_members: founders.iter().map(|s| s.to_string()).collect(),
+            charter_ccl: "charter://v1/test".to_string(),
+        }
+    }
+
+    // === CommunityLifecycle creation tests ===
+
+    #[test]
+    fn test_lifecycle_new() {
+        let lifecycle = CommunityLifecycle::new(3);
+        assert_eq!(lifecycle.min_founders, 3);
+    }
+
+    #[test]
+    fn test_lifecycle_new_zero_founders() {
+        let lifecycle = CommunityLifecycle::new(0);
+        assert_eq!(lifecycle.min_founders, 0);
+    }
+
+    // === FormationRequest tests ===
+
+    #[test]
+    fn test_formation_request_creation() {
+        let request = FormationRequest {
+            name: "Worker Collective".to_string(),
+            community_type: CommunityType::Solidarity,
+            founding_members: vec!["alice".to_string(), "bob".to_string()],
+            charter_ccl: "charter://v1".to_string(),
+        };
+
+        assert_eq!(request.name, "Worker Collective");
+        assert_eq!(request.community_type, CommunityType::Solidarity);
+        assert_eq!(request.founding_members.len(), 2);
+        assert_eq!(request.charter_ccl, "charter://v1");
+    }
+
+    #[test]
+    fn test_formation_request_all_community_types() {
+        for ctype in [
+            CommunityType::Geographic,
+            CommunityType::Interest,
+            CommunityType::Solidarity,
+            CommunityType::Ecosystem,
+        ] {
+            let request = FormationRequest {
+                name: "Test".to_string(),
+                community_type: ctype,
+                founding_members: vec!["founder".to_string()],
+                charter_ccl: "charter".to_string(),
+            };
+
+            assert_eq!(request.community_type, ctype);
+        }
+    }
+
+    #[test]
+    fn test_formation_request_serialization() {
+        let request = FormationRequest {
+            name: "Test Community".to_string(),
+            community_type: CommunityType::Interest,
+            founding_members: vec!["did:icn:alice".to_string(), "did:icn:bob".to_string()],
+            charter_ccl: "charter://test".to_string(),
+        };
+
+        let serialized = serde_json::to_string(&request).unwrap();
+        let deserialized: FormationRequest = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized.name, request.name);
+        assert_eq!(deserialized.community_type, request.community_type);
+        assert_eq!(deserialized.founding_members, request.founding_members);
+        assert_eq!(deserialized.charter_ccl, request.charter_ccl);
+    }
+
+    // === form() tests ===
+
+    #[test]
+    fn test_form_basic() {
+        let lifecycle = CommunityLifecycle::new(2);
+        let request = create_formation_request("Worker Coop", vec!["alice", "bob"]);
+
+        let community = lifecycle.form(request, "domain-1".to_string()).unwrap();
+
+        assert_eq!(community.id, "community:worker-coop");
+        assert_eq!(community.name, "Worker Coop");
+        assert_eq!(community.community_type, CommunityType::Geographic);
+        assert_eq!(community.status, CommunityStatus::Forming);
+        assert_eq!(community.charter, "charter://v1/test");
+        assert_eq!(community.governance_domain, "domain-1");
+    }
+
+    #[test]
+    fn test_form_generates_id_from_name() {
+        let lifecycle = CommunityLifecycle::new(1);
+
+        // Test various name formats
+        let test_cases = vec![
+            ("Simple", "community:simple"),
+            ("Two Words", "community:two-words"),
+            ("Multiple Word Name", "community:multiple-word-name"),
+            ("UPPERCASE", "community:uppercase"),
+            ("MixedCase Name", "community:mixedcase-name"),
+        ];
+
+        for (name, expected_id) in test_cases {
+            let request = create_formation_request(name, vec!["founder"]);
+            let community = lifecycle.form(request, "domain".to_string()).unwrap();
+            assert_eq!(community.id, expected_id, "Failed for name: {name}");
+        }
+    }
+
+    #[test]
+    fn test_form_insufficient_founders() {
+        let lifecycle = CommunityLifecycle::new(3);
+        let request = create_formation_request("Test", vec!["alice", "bob"]); // Only 2
+
+        let result = lifecycle.form(request, "domain".to_string());
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            CommunityError::NotPermitted(msg) => {
+                assert!(msg.contains("3"));
+                assert!(msg.contains("2"));
+            }
+            _ => panic!("Expected NotPermitted error"),
+        }
+    }
+
+    #[test]
+    fn test_form_exact_minimum_founders() {
+        let lifecycle = CommunityLifecycle::new(3);
+        let request = create_formation_request("Test", vec!["a", "b", "c"]); // Exactly 3
+
+        let community = lifecycle.form(request, "domain".to_string()).unwrap();
+        assert_eq!(community.status, CommunityStatus::Forming);
+    }
+
+    #[test]
+    fn test_form_more_than_minimum_founders() {
+        let lifecycle = CommunityLifecycle::new(2);
+        let request = create_formation_request("Test", vec!["a", "b", "c", "d", "e"]); // 5
+
+        let community = lifecycle.form(request, "domain".to_string()).unwrap();
+        assert_eq!(community.status, CommunityStatus::Forming);
+    }
+
+    #[test]
+    fn test_form_zero_founder_requirement() {
+        let lifecycle = CommunityLifecycle::new(0);
+        let request = create_formation_request("Test", vec![]); // No founders
+
+        let community = lifecycle.form(request, "domain".to_string()).unwrap();
+        assert_eq!(community.status, CommunityStatus::Forming);
+    }
+
+    #[test]
+    fn test_form_sets_charter() {
+        let lifecycle = CommunityLifecycle::new(1);
+        let mut request = create_formation_request("Test", vec!["founder"]);
+        request.charter_ccl = "custom://charter/agreement".to_string();
+
+        let community = lifecycle.form(request, "domain".to_string()).unwrap();
+        assert_eq!(community.charter, "custom://charter/agreement");
+    }
+
+    // === activate() tests ===
+
+    #[test]
+    fn test_activate_from_forming() {
+        let lifecycle = CommunityLifecycle::new(1);
+        let request = create_formation_request("Test", vec!["founder"]);
+        let mut community = lifecycle.form(request, "domain".to_string()).unwrap();
+
+        assert_eq!(community.status, CommunityStatus::Forming);
+
+        let original_updated_at = community.updated_at;
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        lifecycle.activate(&mut community).unwrap();
+
+        assert_eq!(community.status, CommunityStatus::Active);
+        assert!(community.updated_at > original_updated_at);
+    }
+
+    #[test]
+    fn test_activate_from_active_fails() {
+        let lifecycle = CommunityLifecycle::new(1);
+        let request = create_formation_request("Test", vec!["founder"]);
+        let mut community = lifecycle.form(request, "domain".to_string()).unwrap();
+
+        lifecycle.activate(&mut community).unwrap();
+        assert_eq!(community.status, CommunityStatus::Active);
+
+        // Try to activate again
+        let result = lifecycle.activate(&mut community);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            CommunityError::InvalidStatusTransition { from, to } => {
+                assert_eq!(from, CommunityStatus::Active);
+                assert_eq!(to, CommunityStatus::Active);
+            }
+            _ => panic!("Expected InvalidStatusTransition error"),
+        }
+    }
+
+    #[test]
+    fn test_activate_from_suspended_fails() {
+        let lifecycle = CommunityLifecycle::new(1);
+        let mut community = Community::new(
+            "test".to_string(),
+            "Test".to_string(),
+            CommunityType::Geographic,
+            "domain".to_string(),
+        );
+        community.status = CommunityStatus::Suspended;
+
+        let result = lifecycle.activate(&mut community);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            CommunityError::InvalidStatusTransition { from, to } => {
+                assert_eq!(from, CommunityStatus::Suspended);
+                assert_eq!(to, CommunityStatus::Active);
+            }
+            _ => panic!("Expected InvalidStatusTransition error"),
+        }
+    }
+
+    #[test]
+    fn test_activate_from_dissolved_fails() {
+        let lifecycle = CommunityLifecycle::new(1);
+        let mut community = Community::new(
+            "test".to_string(),
+            "Test".to_string(),
+            CommunityType::Geographic,
+            "domain".to_string(),
+        );
+        community.status = CommunityStatus::Dissolved;
+
+        let result = lifecycle.activate(&mut community);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            CommunityError::InvalidStatusTransition { from, to } => {
+                assert_eq!(from, CommunityStatus::Dissolved);
+                assert_eq!(to, CommunityStatus::Active);
+            }
+            _ => panic!("Expected InvalidStatusTransition error"),
+        }
+    }
+
+    // === dissolve() tests ===
+
+    #[test]
+    fn test_dissolve_from_forming() {
+        let lifecycle = CommunityLifecycle::new(1);
+        let request = create_formation_request("Test", vec!["founder"]);
+        let mut community = lifecycle.form(request, "domain".to_string()).unwrap();
+
+        let original_updated_at = community.updated_at;
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        lifecycle.dissolve(&mut community).unwrap();
+
+        assert_eq!(community.status, CommunityStatus::Dissolved);
+        assert!(community.updated_at > original_updated_at);
+    }
+
+    #[test]
+    fn test_dissolve_from_active() {
+        let lifecycle = CommunityLifecycle::new(1);
+        let request = create_formation_request("Test", vec!["founder"]);
+        let mut community = lifecycle.form(request, "domain".to_string()).unwrap();
+        lifecycle.activate(&mut community).unwrap();
+
+        lifecycle.dissolve(&mut community).unwrap();
+
+        assert_eq!(community.status, CommunityStatus::Dissolved);
+    }
+
+    #[test]
+    fn test_dissolve_deactivates_all_members() {
+        let lifecycle = CommunityLifecycle::new(1);
+        let request = create_formation_request("Test", vec!["founder"]);
+        let mut community = lifecycle.form(request, "domain".to_string()).unwrap();
+
+        // Add some members
+        for i in 1..=5 {
+            community.members.insert(
+                format!("member-{i}"),
+                Member {
+                    id: format!("member-{i}"),
+                    member_type: MemberType::Individual(format!("did:icn:user{i}")),
+                    joined_at: Utc::now(),
+                    voting_weight: 1,
+                    active: true,
+                },
+            );
+        }
+
+        assert_eq!(community.active_member_count(), 5);
+
+        lifecycle.dissolve(&mut community).unwrap();
+
+        // All members should be inactive
+        assert_eq!(community.active_member_count(), 0);
+        assert_eq!(community.total_voting_weight(), 0);
+
+        for member in community.members.values() {
+            assert!(!member.active, "Member {} should be inactive", member.id);
+        }
+    }
+
+    #[test]
+    fn test_dissolve_already_dissolved() {
+        let lifecycle = CommunityLifecycle::new(1);
+        let mut community = Community::new(
+            "test".to_string(),
+            "Test".to_string(),
+            CommunityType::Geographic,
+            "domain".to_string(),
+        );
+        community.status = CommunityStatus::Dissolved;
+
+        // Dissolving again should still work (idempotent)
+        lifecycle.dissolve(&mut community).unwrap();
+        assert_eq!(community.status, CommunityStatus::Dissolved);
+    }
+
+    #[test]
+    fn test_dissolve_from_suspended() {
+        let lifecycle = CommunityLifecycle::new(1);
+        let mut community = Community::new(
+            "test".to_string(),
+            "Test".to_string(),
+            CommunityType::Geographic,
+            "domain".to_string(),
+        );
+        community.status = CommunityStatus::Suspended;
+
+        lifecycle.dissolve(&mut community).unwrap();
+        assert_eq!(community.status, CommunityStatus::Dissolved);
+    }
+
+    // === Full lifecycle workflow tests ===
+
+    #[test]
+    fn test_full_lifecycle_form_activate_dissolve() {
+        let lifecycle = CommunityLifecycle::new(2);
+        let request = FormationRequest {
+            name: "Worker Collective".to_string(),
+            community_type: CommunityType::Solidarity,
+            founding_members: vec!["alice".to_string(), "bob".to_string()],
+            charter_ccl: "cooperative://charter/v1".to_string(),
+        };
+
+        // Form
+        let mut community = lifecycle.form(request, "domain".to_string()).unwrap();
+        assert_eq!(community.status, CommunityStatus::Forming);
+
+        // Add members
+        community.members.insert(
+            "alice".to_string(),
+            Member {
+                id: "alice".to_string(),
+                member_type: MemberType::Individual("did:icn:alice".to_string()),
+                joined_at: Utc::now(),
+                voting_weight: 1,
+                active: true,
+            },
+        );
+        community.members.insert(
+            "bob".to_string(),
+            Member {
+                id: "bob".to_string(),
+                member_type: MemberType::Individual("did:icn:bob".to_string()),
+                joined_at: Utc::now(),
+                voting_weight: 1,
+                active: true,
+            },
+        );
+
+        assert_eq!(community.active_member_count(), 2);
+
+        // Activate
+        lifecycle.activate(&mut community).unwrap();
+        assert_eq!(community.status, CommunityStatus::Active);
+        assert_eq!(community.active_member_count(), 2);
+
+        // Dissolve
+        lifecycle.dissolve(&mut community).unwrap();
+        assert_eq!(community.status, CommunityStatus::Dissolved);
+        assert_eq!(community.active_member_count(), 0);
+    }
+
+    #[test]
+    fn test_lifecycle_preserves_community_data() {
+        let lifecycle = CommunityLifecycle::new(1);
+        let request = FormationRequest {
+            name: "Data Test".to_string(),
+            community_type: CommunityType::Ecosystem,
+            founding_members: vec!["founder".to_string()],
+            charter_ccl: "test-charter".to_string(),
+        };
+
+        let mut community = lifecycle.form(request, "domain-1".to_string()).unwrap();
+
+        // Add some data
+        community
+            .metadata
+            .insert("key1".to_string(), "value1".to_string());
+        community.resource_pools.insert(
+            "compute".to_string(),
+            crate::types::ResourcePool {
+                name: "compute".to_string(),
+                resource_type: "cpu".to_string(),
+                total_capacity: 100,
+                allocated: 0,
+                unit: "cores".to_string(),
+            },
+        );
+
+        // Activate
+        lifecycle.activate(&mut community).unwrap();
+
+        // Data should be preserved
+        assert_eq!(community.metadata.get("key1").unwrap(), "value1");
+        assert!(community.resource_pools.contains_key("compute"));
+        assert_eq!(community.charter, "test-charter");
+        assert_eq!(community.governance_domain, "domain-1");
+
+        // Dissolve
+        lifecycle.dissolve(&mut community).unwrap();
+
+        // Data should still be preserved
+        assert_eq!(community.metadata.get("key1").unwrap(), "value1");
+        assert!(community.resource_pools.contains_key("compute"));
+    }
+}

--- a/icn/crates/icn-community/src/lifecycle.rs
+++ b/icn/crates/icn-community/src/lifecycle.rs
@@ -245,12 +245,11 @@ mod tests {
         assert_eq!(community.status, CommunityStatus::Forming);
 
         let original_updated_at = community.updated_at;
-        std::thread::sleep(std::time::Duration::from_millis(10));
 
         lifecycle.activate(&mut community).unwrap();
 
         assert_eq!(community.status, CommunityStatus::Active);
-        assert!(community.updated_at > original_updated_at);
+        assert!(community.updated_at >= original_updated_at);
     }
 
     #[test]
@@ -330,12 +329,11 @@ mod tests {
         let mut community = lifecycle.form(request, "domain".to_string()).unwrap();
 
         let original_updated_at = community.updated_at;
-        std::thread::sleep(std::time::Duration::from_millis(10));
 
         lifecycle.dissolve(&mut community).unwrap();
 
         assert_eq!(community.status, CommunityStatus::Dissolved);
-        assert!(community.updated_at > original_updated_at);
+        assert!(community.updated_at >= original_updated_at);
     }
 
     #[test]

--- a/icn/crates/icn-community/src/membership.rs
+++ b/icn/crates/icn-community/src/membership.rs
@@ -57,3 +57,434 @@ impl Default for MembershipManager {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{CommunityStatus, CommunityType};
+
+    fn create_test_community() -> Community {
+        Community::new(
+            "test-comm".to_string(),
+            "Test Community".to_string(),
+            CommunityType::Solidarity,
+            "test-domain".to_string(),
+        )
+    }
+
+    // === MembershipManager creation tests ===
+
+    #[test]
+    fn test_membership_manager_new() {
+        let _manager = MembershipManager::new();
+    }
+
+    #[test]
+    fn test_membership_manager_default() {
+        let _manager: MembershipManager = Default::default();
+    }
+
+    // === MemberApplication tests ===
+
+    #[test]
+    fn test_member_application_creation() {
+        let application = MemberApplication {
+            community_id: "comm-1".to_string(),
+            applicant_id: "applicant-1".to_string(),
+            member_type: MemberType::Individual("did:icn:abc123".to_string()),
+            statement: "I want to join this community".to_string(),
+        };
+
+        assert_eq!(application.community_id, "comm-1");
+        assert_eq!(application.applicant_id, "applicant-1");
+        assert_eq!(application.statement, "I want to join this community");
+    }
+
+    #[test]
+    fn test_member_application_with_cooperative() {
+        let application = MemberApplication {
+            community_id: "comm-1".to_string(),
+            applicant_id: "coop-xyz".to_string(),
+            member_type: MemberType::Cooperative("coop:worker-collective".to_string()),
+            statement: "Our cooperative seeks to participate".to_string(),
+        };
+
+        if let MemberType::Cooperative(id) = &application.member_type {
+            assert_eq!(id, "coop:worker-collective");
+        } else {
+            panic!("Expected Cooperative member type");
+        }
+    }
+
+    #[test]
+    fn test_member_application_serialization() {
+        let application = MemberApplication {
+            community_id: "comm-1".to_string(),
+            applicant_id: "member-1".to_string(),
+            member_type: MemberType::Individual("did:icn:test".to_string()),
+            statement: "Test statement".to_string(),
+        };
+
+        let serialized = serde_json::to_string(&application).unwrap();
+        let deserialized: MemberApplication = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized.community_id, application.community_id);
+        assert_eq!(deserialized.applicant_id, application.applicant_id);
+        assert_eq!(deserialized.statement, application.statement);
+    }
+
+    // === add_member tests ===
+
+    #[test]
+    fn test_add_member_individual() {
+        let manager = MembershipManager::new();
+        let mut community = create_test_community();
+        let original_updated_at = community.updated_at;
+
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        manager
+            .add_member(
+                &mut community,
+                "member-1".to_string(),
+                MemberType::Individual("did:icn:alice".to_string()),
+                1,
+            )
+            .unwrap();
+
+        assert_eq!(community.members.len(), 1);
+        let member = community.members.get("member-1").unwrap();
+        assert_eq!(member.id, "member-1");
+        assert_eq!(member.voting_weight, 1);
+        assert!(member.active);
+        assert!(community.updated_at > original_updated_at);
+    }
+
+    #[test]
+    fn test_add_member_cooperative() {
+        let manager = MembershipManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .add_member(
+                &mut community,
+                "coop-member".to_string(),
+                MemberType::Cooperative("coop:workers".to_string()),
+                5,
+            )
+            .unwrap();
+
+        let member = community.members.get("coop-member").unwrap();
+        if let MemberType::Cooperative(id) = &member.member_type {
+            assert_eq!(id, "coop:workers");
+        } else {
+            panic!("Expected Cooperative member type");
+        }
+        assert_eq!(member.voting_weight, 5);
+    }
+
+    #[test]
+    fn test_add_multiple_members() {
+        let manager = MembershipManager::new();
+        let mut community = create_test_community();
+
+        for i in 1..=5 {
+            manager
+                .add_member(
+                    &mut community,
+                    format!("member-{i}"),
+                    MemberType::Individual(format!("did:icn:user{i}")),
+                    i,
+                )
+                .unwrap();
+        }
+
+        assert_eq!(community.members.len(), 5);
+        assert_eq!(community.active_member_count(), 5);
+        assert_eq!(community.total_voting_weight(), 15); // 1+2+3+4+5
+    }
+
+    #[test]
+    fn test_add_member_duplicate_fails() {
+        let manager = MembershipManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .add_member(
+                &mut community,
+                "member-1".to_string(),
+                MemberType::Individual("did:icn:alice".to_string()),
+                1,
+            )
+            .unwrap();
+
+        // Try to add same member again
+        let result = manager.add_member(
+            &mut community,
+            "member-1".to_string(),
+            MemberType::Individual("did:icn:bob".to_string()),
+            2,
+        );
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            CommunityError::MemberAlreadyExists(id) => {
+                assert_eq!(id, "member-1");
+            }
+            _ => panic!("Expected MemberAlreadyExists error"),
+        }
+
+        // Original member should be unchanged
+        let member = community.members.get("member-1").unwrap();
+        if let MemberType::Individual(did) = &member.member_type {
+            assert_eq!(did, "did:icn:alice");
+        }
+        assert_eq!(member.voting_weight, 1);
+    }
+
+    #[test]
+    fn test_add_member_with_zero_voting_weight() {
+        let manager = MembershipManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .add_member(
+                &mut community,
+                "observer".to_string(),
+                MemberType::Individual("did:icn:observer".to_string()),
+                0,
+            )
+            .unwrap();
+
+        let member = community.members.get("observer").unwrap();
+        assert_eq!(member.voting_weight, 0);
+        assert_eq!(community.total_voting_weight(), 0);
+    }
+
+    #[test]
+    fn test_add_member_with_high_voting_weight() {
+        let manager = MembershipManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .add_member(
+                &mut community,
+                "major-coop".to_string(),
+                MemberType::Cooperative("coop:large".to_string()),
+                1000,
+            )
+            .unwrap();
+
+        let member = community.members.get("major-coop").unwrap();
+        assert_eq!(member.voting_weight, 1000);
+    }
+
+    // === remove_member tests ===
+
+    #[test]
+    fn test_remove_member_deactivates() {
+        let manager = MembershipManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .add_member(
+                &mut community,
+                "member-1".to_string(),
+                MemberType::Individual("did:icn:alice".to_string()),
+                1,
+            )
+            .unwrap();
+
+        assert!(community.members.get("member-1").unwrap().active);
+
+        let original_updated_at = community.updated_at;
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        manager.remove_member(&mut community, "member-1").unwrap();
+
+        // Member should still exist but be inactive
+        let member = community.members.get("member-1").unwrap();
+        assert!(!member.active);
+        assert!(community.updated_at > original_updated_at);
+    }
+
+    #[test]
+    fn test_remove_member_affects_active_count() {
+        let manager = MembershipManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .add_member(
+                &mut community,
+                "member-1".to_string(),
+                MemberType::Individual("did:icn:alice".to_string()),
+                1,
+            )
+            .unwrap();
+
+        manager
+            .add_member(
+                &mut community,
+                "member-2".to_string(),
+                MemberType::Individual("did:icn:bob".to_string()),
+                2,
+            )
+            .unwrap();
+
+        assert_eq!(community.active_member_count(), 2);
+        assert_eq!(community.total_voting_weight(), 3);
+
+        manager.remove_member(&mut community, "member-1").unwrap();
+
+        assert_eq!(community.active_member_count(), 1);
+        assert_eq!(community.total_voting_weight(), 2); // Only member-2's weight
+    }
+
+    #[test]
+    fn test_remove_nonexistent_member_fails() {
+        let manager = MembershipManager::new();
+        let mut community = create_test_community();
+
+        let result = manager.remove_member(&mut community, "nonexistent");
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            CommunityError::MemberNotFound(id) => {
+                assert_eq!(id, "nonexistent");
+            }
+            _ => panic!("Expected MemberNotFound error"),
+        }
+    }
+
+    #[test]
+    fn test_remove_already_inactive_member() {
+        let manager = MembershipManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .add_member(
+                &mut community,
+                "member-1".to_string(),
+                MemberType::Individual("did:icn:alice".to_string()),
+                1,
+            )
+            .unwrap();
+
+        // Remove twice
+        manager.remove_member(&mut community, "member-1").unwrap();
+        manager.remove_member(&mut community, "member-1").unwrap(); // Should still work
+
+        assert!(!community.members.get("member-1").unwrap().active);
+    }
+
+    // === Workflow tests ===
+
+    #[test]
+    fn test_add_remove_add_workflow() {
+        let manager = MembershipManager::new();
+        let mut community = create_test_community();
+
+        // Add member
+        manager
+            .add_member(
+                &mut community,
+                "member-1".to_string(),
+                MemberType::Individual("did:icn:alice".to_string()),
+                1,
+            )
+            .unwrap();
+
+        assert_eq!(community.active_member_count(), 1);
+
+        // Remove (deactivate) member
+        manager.remove_member(&mut community, "member-1").unwrap();
+        assert_eq!(community.active_member_count(), 0);
+
+        // Cannot add with same ID again (still exists, just inactive)
+        let result = manager.add_member(
+            &mut community,
+            "member-1".to_string(),
+            MemberType::Individual("did:icn:alice".to_string()),
+            1,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_mixed_member_types() {
+        let manager = MembershipManager::new();
+        let mut community = create_test_community();
+
+        // Add individuals
+        manager
+            .add_member(
+                &mut community,
+                "individual-1".to_string(),
+                MemberType::Individual("did:icn:alice".to_string()),
+                1,
+            )
+            .unwrap();
+
+        manager
+            .add_member(
+                &mut community,
+                "individual-2".to_string(),
+                MemberType::Individual("did:icn:bob".to_string()),
+                1,
+            )
+            .unwrap();
+
+        // Add cooperatives
+        manager
+            .add_member(
+                &mut community,
+                "coop-1".to_string(),
+                MemberType::Cooperative("coop:workers".to_string()),
+                5,
+            )
+            .unwrap();
+
+        manager
+            .add_member(
+                &mut community,
+                "coop-2".to_string(),
+                MemberType::Cooperative("coop:farmers".to_string()),
+                3,
+            )
+            .unwrap();
+
+        assert_eq!(community.members.len(), 4);
+        assert_eq!(community.total_voting_weight(), 10); // 1+1+5+3
+    }
+
+    // === Community status tests ===
+
+    #[test]
+    fn test_operations_on_different_community_statuses() {
+        let manager = MembershipManager::new();
+
+        for status in [
+            CommunityStatus::Forming,
+            CommunityStatus::Active,
+            CommunityStatus::Suspended,
+            CommunityStatus::Dissolved,
+        ] {
+            let mut community = create_test_community();
+            community.status = status;
+
+            manager
+                .add_member(
+                    &mut community,
+                    "member-1".to_string(),
+                    MemberType::Individual("did:icn:test".to_string()),
+                    1,
+                )
+                .unwrap();
+
+            manager.remove_member(&mut community, "member-1").unwrap();
+
+            assert!(!community.members.get("member-1").unwrap().active);
+        }
+    }
+}

--- a/icn/crates/icn-community/src/membership.rs
+++ b/icn/crates/icn-community/src/membership.rs
@@ -141,8 +141,6 @@ mod tests {
         let mut community = create_test_community();
         let original_updated_at = community.updated_at;
 
-        std::thread::sleep(std::time::Duration::from_millis(10));
-
         manager
             .add_member(
                 &mut community,
@@ -157,7 +155,7 @@ mod tests {
         assert_eq!(member.id, "member-1");
         assert_eq!(member.voting_weight, 1);
         assert!(member.active);
-        assert!(community.updated_at > original_updated_at);
+        assert!(community.updated_at >= original_updated_at);
     }
 
     #[test]
@@ -298,14 +296,13 @@ mod tests {
         assert!(community.members.get("member-1").unwrap().active);
 
         let original_updated_at = community.updated_at;
-        std::thread::sleep(std::time::Duration::from_millis(10));
 
         manager.remove_member(&mut community, "member-1").unwrap();
 
         // Member should still exist but be inactive
         let member = community.members.get("member-1").unwrap();
         assert!(!member.active);
-        assert!(community.updated_at > original_updated_at);
+        assert!(community.updated_at >= original_updated_at);
     }
 
     #[test]

--- a/icn/crates/icn-community/src/resources.rs
+++ b/icn/crates/icn-community/src/resources.rs
@@ -77,3 +77,642 @@ impl Default for ResourceManager {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{CommunityStatus, CommunityType};
+    use chrono::Utc;
+
+    fn create_test_community() -> Community {
+        Community::new(
+            "test-comm".to_string(),
+            "Test Community".to_string(),
+            CommunityType::Ecosystem,
+            "test-domain".to_string(),
+        )
+    }
+
+    // === ResourceManager creation tests ===
+
+    #[test]
+    fn test_resource_manager_new() {
+        let _manager = ResourceManager::new();
+        // ResourceManager is a unit struct, just verify it constructs
+    }
+
+    #[test]
+    fn test_resource_manager_default() {
+        let _manager: ResourceManager = Default::default();
+        // Verify Default trait implementation works
+    }
+
+    // === ResourceAllocation tests ===
+
+    #[test]
+    fn test_resource_allocation_creation() {
+        let allocation = ResourceAllocation {
+            pool_name: "compute".to_string(),
+            member_id: "member-1".to_string(),
+            amount: 50,
+            expires_at: None,
+        };
+
+        assert_eq!(allocation.pool_name, "compute");
+        assert_eq!(allocation.member_id, "member-1");
+        assert_eq!(allocation.amount, 50);
+        assert!(allocation.expires_at.is_none());
+    }
+
+    #[test]
+    fn test_resource_allocation_with_expiration() {
+        let expiry = Utc::now() + chrono::Duration::hours(24);
+        let allocation = ResourceAllocation {
+            pool_name: "storage".to_string(),
+            member_id: "member-2".to_string(),
+            amount: 100,
+            expires_at: Some(expiry),
+        };
+
+        assert!(allocation.expires_at.is_some());
+        assert_eq!(allocation.expires_at.unwrap(), expiry);
+    }
+
+    #[test]
+    fn test_resource_allocation_serialization() {
+        let allocation = ResourceAllocation {
+            pool_name: "credits".to_string(),
+            member_id: "did:icn:abc123".to_string(),
+            amount: 1000,
+            expires_at: None,
+        };
+
+        let serialized = serde_json::to_string(&allocation).unwrap();
+        let deserialized: ResourceAllocation = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized.pool_name, allocation.pool_name);
+        assert_eq!(deserialized.member_id, allocation.member_id);
+        assert_eq!(deserialized.amount, allocation.amount);
+    }
+
+    // === create_pool tests ===
+
+    #[test]
+    fn test_create_pool_basic() {
+        let manager = ResourceManager::new();
+        let mut community = create_test_community();
+        let original_updated_at = community.updated_at;
+
+        // Small delay to ensure timestamp changes
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        manager
+            .create_pool(
+                &mut community,
+                "compute".to_string(),
+                "cpu".to_string(),
+                100,
+                "cores".to_string(),
+            )
+            .unwrap();
+
+        assert!(community.resource_pools.contains_key("compute"));
+        let pool = community.resource_pools.get("compute").unwrap();
+        assert_eq!(pool.name, "compute");
+        assert_eq!(pool.resource_type, "cpu");
+        assert_eq!(pool.total_capacity, 100);
+        assert_eq!(pool.allocated, 0);
+        assert_eq!(pool.unit, "cores");
+        assert!(community.updated_at > original_updated_at);
+    }
+
+    #[test]
+    fn test_create_multiple_pools() {
+        let manager = ResourceManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .create_pool(
+                &mut community,
+                "compute".to_string(),
+                "cpu".to_string(),
+                100,
+                "cores".to_string(),
+            )
+            .unwrap();
+
+        manager
+            .create_pool(
+                &mut community,
+                "storage".to_string(),
+                "disk".to_string(),
+                1000,
+                "GB".to_string(),
+            )
+            .unwrap();
+
+        manager
+            .create_pool(
+                &mut community,
+                "credits".to_string(),
+                "mutual_credit".to_string(),
+                5000,
+                "credits".to_string(),
+            )
+            .unwrap();
+
+        assert_eq!(community.resource_pools.len(), 3);
+        assert!(community.resource_pools.contains_key("compute"));
+        assert!(community.resource_pools.contains_key("storage"));
+        assert!(community.resource_pools.contains_key("credits"));
+    }
+
+    #[test]
+    fn test_create_pool_overwrites_existing() {
+        let manager = ResourceManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .create_pool(
+                &mut community,
+                "compute".to_string(),
+                "cpu".to_string(),
+                100,
+                "cores".to_string(),
+            )
+            .unwrap();
+
+        // Overwrite with new capacity
+        manager
+            .create_pool(
+                &mut community,
+                "compute".to_string(),
+                "gpu".to_string(),
+                50,
+                "units".to_string(),
+            )
+            .unwrap();
+
+        assert_eq!(community.resource_pools.len(), 1);
+        let pool = community.resource_pools.get("compute").unwrap();
+        assert_eq!(pool.resource_type, "gpu");
+        assert_eq!(pool.total_capacity, 50);
+    }
+
+    #[test]
+    fn test_create_pool_zero_capacity() {
+        let manager = ResourceManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .create_pool(
+                &mut community,
+                "empty".to_string(),
+                "nothing".to_string(),
+                0,
+                "units".to_string(),
+            )
+            .unwrap();
+
+        let pool = community.resource_pools.get("empty").unwrap();
+        assert_eq!(pool.total_capacity, 0);
+        assert_eq!(pool.available(), 0);
+    }
+
+    // === allocate tests ===
+
+    #[test]
+    fn test_allocate_basic() {
+        let manager = ResourceManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .create_pool(
+                &mut community,
+                "compute".to_string(),
+                "cpu".to_string(),
+                100,
+                "cores".to_string(),
+            )
+            .unwrap();
+
+        let original_updated_at = community.updated_at;
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        manager.allocate(&mut community, "compute", 30).unwrap();
+
+        let pool = community.resource_pools.get("compute").unwrap();
+        assert_eq!(pool.allocated, 30);
+        assert_eq!(pool.available(), 70);
+        assert!(community.updated_at > original_updated_at);
+    }
+
+    #[test]
+    fn test_allocate_multiple_times() {
+        let manager = ResourceManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .create_pool(
+                &mut community,
+                "compute".to_string(),
+                "cpu".to_string(),
+                100,
+                "cores".to_string(),
+            )
+            .unwrap();
+
+        manager.allocate(&mut community, "compute", 20).unwrap();
+        manager.allocate(&mut community, "compute", 30).unwrap();
+        manager.allocate(&mut community, "compute", 25).unwrap();
+
+        let pool = community.resource_pools.get("compute").unwrap();
+        assert_eq!(pool.allocated, 75);
+        assert_eq!(pool.available(), 25);
+    }
+
+    #[test]
+    fn test_allocate_exact_capacity() {
+        let manager = ResourceManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .create_pool(
+                &mut community,
+                "compute".to_string(),
+                "cpu".to_string(),
+                100,
+                "cores".to_string(),
+            )
+            .unwrap();
+
+        manager.allocate(&mut community, "compute", 100).unwrap();
+
+        let pool = community.resource_pools.get("compute").unwrap();
+        assert_eq!(pool.allocated, 100);
+        assert_eq!(pool.available(), 0);
+    }
+
+    #[test]
+    fn test_allocate_zero_amount() {
+        let manager = ResourceManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .create_pool(
+                &mut community,
+                "compute".to_string(),
+                "cpu".to_string(),
+                100,
+                "cores".to_string(),
+            )
+            .unwrap();
+
+        manager.allocate(&mut community, "compute", 0).unwrap();
+
+        let pool = community.resource_pools.get("compute").unwrap();
+        assert_eq!(pool.allocated, 0);
+    }
+
+    #[test]
+    fn test_allocate_insufficient_resources() {
+        let manager = ResourceManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .create_pool(
+                &mut community,
+                "compute".to_string(),
+                "cpu".to_string(),
+                100,
+                "cores".to_string(),
+            )
+            .unwrap();
+
+        let result = manager.allocate(&mut community, "compute", 150);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            CommunityError::InsufficientResources {
+                required,
+                available,
+            } => {
+                assert_eq!(required, 150);
+                assert_eq!(available, 100);
+            }
+            _ => panic!("Expected InsufficientResources error"),
+        }
+    }
+
+    #[test]
+    fn test_allocate_after_partial_use() {
+        let manager = ResourceManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .create_pool(
+                &mut community,
+                "compute".to_string(),
+                "cpu".to_string(),
+                100,
+                "cores".to_string(),
+            )
+            .unwrap();
+
+        manager.allocate(&mut community, "compute", 60).unwrap();
+
+        // Try to allocate more than remaining
+        let result = manager.allocate(&mut community, "compute", 50);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            CommunityError::InsufficientResources {
+                required,
+                available,
+            } => {
+                assert_eq!(required, 50);
+                assert_eq!(available, 40);
+            }
+            _ => panic!("Expected InsufficientResources error"),
+        }
+    }
+
+    #[test]
+    fn test_allocate_nonexistent_pool() {
+        let manager = ResourceManager::new();
+        let mut community = create_test_community();
+
+        let result = manager.allocate(&mut community, "nonexistent", 10);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            CommunityError::NotFound(msg) => {
+                assert!(msg.contains("nonexistent"));
+            }
+            _ => panic!("Expected NotFound error"),
+        }
+    }
+
+    // === deallocate tests ===
+
+    #[test]
+    fn test_deallocate_basic() {
+        let manager = ResourceManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .create_pool(
+                &mut community,
+                "compute".to_string(),
+                "cpu".to_string(),
+                100,
+                "cores".to_string(),
+            )
+            .unwrap();
+
+        manager.allocate(&mut community, "compute", 50).unwrap();
+
+        let original_updated_at = community.updated_at;
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        manager.deallocate(&mut community, "compute", 20).unwrap();
+
+        let pool = community.resource_pools.get("compute").unwrap();
+        assert_eq!(pool.allocated, 30);
+        assert_eq!(pool.available(), 70);
+        assert!(community.updated_at > original_updated_at);
+    }
+
+    #[test]
+    fn test_deallocate_all() {
+        let manager = ResourceManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .create_pool(
+                &mut community,
+                "compute".to_string(),
+                "cpu".to_string(),
+                100,
+                "cores".to_string(),
+            )
+            .unwrap();
+
+        manager.allocate(&mut community, "compute", 75).unwrap();
+        manager.deallocate(&mut community, "compute", 75).unwrap();
+
+        let pool = community.resource_pools.get("compute").unwrap();
+        assert_eq!(pool.allocated, 0);
+        assert_eq!(pool.available(), 100);
+    }
+
+    #[test]
+    fn test_deallocate_more_than_allocated_saturates() {
+        let manager = ResourceManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .create_pool(
+                &mut community,
+                "compute".to_string(),
+                "cpu".to_string(),
+                100,
+                "cores".to_string(),
+            )
+            .unwrap();
+
+        manager.allocate(&mut community, "compute", 30).unwrap();
+
+        // Deallocate more than allocated - should saturate at 0
+        manager.deallocate(&mut community, "compute", 100).unwrap();
+
+        let pool = community.resource_pools.get("compute").unwrap();
+        assert_eq!(pool.allocated, 0);
+    }
+
+    #[test]
+    fn test_deallocate_zero_amount() {
+        let manager = ResourceManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .create_pool(
+                &mut community,
+                "compute".to_string(),
+                "cpu".to_string(),
+                100,
+                "cores".to_string(),
+            )
+            .unwrap();
+
+        manager.allocate(&mut community, "compute", 50).unwrap();
+        manager.deallocate(&mut community, "compute", 0).unwrap();
+
+        let pool = community.resource_pools.get("compute").unwrap();
+        assert_eq!(pool.allocated, 50);
+    }
+
+    #[test]
+    fn test_deallocate_nonexistent_pool() {
+        let manager = ResourceManager::new();
+        let mut community = create_test_community();
+
+        let result = manager.deallocate(&mut community, "nonexistent", 10);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            CommunityError::NotFound(msg) => {
+                assert!(msg.contains("nonexistent"));
+            }
+            _ => panic!("Expected NotFound error"),
+        }
+    }
+
+    #[test]
+    fn test_deallocate_from_empty_pool() {
+        let manager = ResourceManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .create_pool(
+                &mut community,
+                "compute".to_string(),
+                "cpu".to_string(),
+                100,
+                "cores".to_string(),
+            )
+            .unwrap();
+
+        // Pool is empty (allocated = 0), deallocating should still work
+        manager.deallocate(&mut community, "compute", 50).unwrap();
+
+        let pool = community.resource_pools.get("compute").unwrap();
+        assert_eq!(pool.allocated, 0);
+    }
+
+    // === Combined allocate/deallocate workflow tests ===
+
+    #[test]
+    fn test_allocate_deallocate_cycle() {
+        let manager = ResourceManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .create_pool(
+                &mut community,
+                "compute".to_string(),
+                "cpu".to_string(),
+                100,
+                "cores".to_string(),
+            )
+            .unwrap();
+
+        // Allocate -> deallocate -> allocate again
+        manager.allocate(&mut community, "compute", 80).unwrap();
+        assert_eq!(
+            community.resource_pools.get("compute").unwrap().available(),
+            20
+        );
+
+        manager.deallocate(&mut community, "compute", 50).unwrap();
+        assert_eq!(
+            community.resource_pools.get("compute").unwrap().available(),
+            70
+        );
+
+        manager.allocate(&mut community, "compute", 40).unwrap();
+        assert_eq!(
+            community.resource_pools.get("compute").unwrap().allocated,
+            70
+        );
+    }
+
+    #[test]
+    fn test_multiple_pools_independent() {
+        let manager = ResourceManager::new();
+        let mut community = create_test_community();
+
+        manager
+            .create_pool(
+                &mut community,
+                "compute".to_string(),
+                "cpu".to_string(),
+                100,
+                "cores".to_string(),
+            )
+            .unwrap();
+
+        manager
+            .create_pool(
+                &mut community,
+                "storage".to_string(),
+                "disk".to_string(),
+                1000,
+                "GB".to_string(),
+            )
+            .unwrap();
+
+        // Allocate from compute only
+        manager.allocate(&mut community, "compute", 50).unwrap();
+
+        // Storage should be unaffected
+        assert_eq!(
+            community.resource_pools.get("compute").unwrap().allocated,
+            50
+        );
+        assert_eq!(
+            community.resource_pools.get("storage").unwrap().allocated,
+            0
+        );
+
+        // Allocate from storage
+        manager.allocate(&mut community, "storage", 300).unwrap();
+
+        // Compute should be unaffected
+        assert_eq!(
+            community.resource_pools.get("compute").unwrap().allocated,
+            50
+        );
+        assert_eq!(
+            community.resource_pools.get("storage").unwrap().allocated,
+            300
+        );
+    }
+
+    // === Community status tests ===
+
+    #[test]
+    fn test_operations_on_different_community_statuses() {
+        let manager = ResourceManager::new();
+
+        for status in [
+            CommunityStatus::Forming,
+            CommunityStatus::Active,
+            CommunityStatus::Suspended,
+            CommunityStatus::Dissolved,
+        ] {
+            let mut community = create_test_community();
+            community.status = status;
+
+            // All operations should work regardless of status
+            // (business logic for status restrictions would be in higher layers)
+            manager
+                .create_pool(
+                    &mut community,
+                    "compute".to_string(),
+                    "cpu".to_string(),
+                    100,
+                    "cores".to_string(),
+                )
+                .unwrap();
+
+            manager.allocate(&mut community, "compute", 50).unwrap();
+            manager.deallocate(&mut community, "compute", 25).unwrap();
+
+            assert_eq!(
+                community.resource_pools.get("compute").unwrap().allocated,
+                25
+            );
+        }
+    }
+}

--- a/icn/crates/icn-community/src/resources.rs
+++ b/icn/crates/icn-community/src/resources.rs
@@ -163,9 +163,6 @@ mod tests {
         let mut community = create_test_community();
         let original_updated_at = community.updated_at;
 
-        // Small delay to ensure timestamp changes
-        std::thread::sleep(std::time::Duration::from_millis(10));
-
         manager
             .create_pool(
                 &mut community,
@@ -183,7 +180,7 @@ mod tests {
         assert_eq!(pool.total_capacity, 100);
         assert_eq!(pool.allocated, 0);
         assert_eq!(pool.unit, "cores");
-        assert!(community.updated_at > original_updated_at);
+        assert!(community.updated_at >= original_updated_at);
     }
 
     #[test]
@@ -297,14 +294,13 @@ mod tests {
             .unwrap();
 
         let original_updated_at = community.updated_at;
-        std::thread::sleep(std::time::Duration::from_millis(10));
 
         manager.allocate(&mut community, "compute", 30).unwrap();
 
         let pool = community.resource_pools.get("compute").unwrap();
         assert_eq!(pool.allocated, 30);
         assert_eq!(pool.available(), 70);
-        assert!(community.updated_at > original_updated_at);
+        assert!(community.updated_at >= original_updated_at);
     }
 
     #[test]
@@ -473,14 +469,13 @@ mod tests {
         manager.allocate(&mut community, "compute", 50).unwrap();
 
         let original_updated_at = community.updated_at;
-        std::thread::sleep(std::time::Duration::from_millis(10));
 
         manager.deallocate(&mut community, "compute", 20).unwrap();
 
         let pool = community.resource_pools.get("compute").unwrap();
         assert_eq!(pool.allocated, 30);
         assert_eq!(pool.available(), 70);
-        assert!(community.updated_at > original_updated_at);
+        assert!(community.updated_at >= original_updated_at);
     }
 
     #[test]

--- a/icn/crates/icn-community/src/store.rs
+++ b/icn/crates/icn-community/src/store.rs
@@ -71,25 +71,433 @@ impl CommunityStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::CommunityType;
+    use crate::types::{CommunityType, Member, MemberType};
+    use chrono::Utc;
     use icn_store::SledStore;
+
+    fn create_test_store() -> CommunityStore {
+        let store: Arc<dyn Store> = Arc::new(SledStore::temporary().unwrap());
+        CommunityStore::new(store)
+    }
+
+    fn create_test_community(id: &str, name: &str, ctype: CommunityType) -> Community {
+        Community::new(
+            id.to_string(),
+            name.to_string(),
+            ctype,
+            format!("domain-{id}"),
+        )
+    }
+
+    // === Basic put/get tests ===
 
     #[test]
     fn test_store_and_retrieve() {
-        let store: Arc<dyn Store> = Arc::new(SledStore::temporary().unwrap());
-        let comm_store = CommunityStore::new(store);
+        let comm_store = create_test_store();
 
-        let community = Community::new(
-            "test-comm".to_string(),
-            "Test Community".to_string(),
-            CommunityType::Geographic,
-            "test-domain".to_string(),
-        );
+        let community =
+            create_test_community("test-comm", "Test Community", CommunityType::Geographic);
 
         comm_store.put(&community).unwrap();
         let retrieved = comm_store.get(&"test-comm".to_string()).unwrap();
 
         assert!(retrieved.is_some());
         assert_eq!(retrieved.unwrap().name, "Test Community");
+    }
+
+    #[test]
+    fn test_get_non_existent_returns_none() {
+        let comm_store = create_test_store();
+
+        let result = comm_store.get(&"non-existent".to_string()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_put_overwrites_existing() {
+        let comm_store = create_test_store();
+
+        let community1 =
+            create_test_community("comm-1", "Original Name", CommunityType::Geographic);
+        comm_store.put(&community1).unwrap();
+
+        let mut community2 =
+            create_test_community("comm-1", "Updated Name", CommunityType::Interest);
+        community2.status = CommunityStatus::Active;
+
+        comm_store.put(&community2).unwrap();
+
+        let retrieved = comm_store.get(&"comm-1".to_string()).unwrap().unwrap();
+        assert_eq!(retrieved.name, "Updated Name");
+        assert_eq!(retrieved.community_type, CommunityType::Interest);
+        assert_eq!(retrieved.status, CommunityStatus::Active);
+    }
+
+    #[test]
+    fn test_store_all_community_types() {
+        let comm_store = create_test_store();
+
+        for (i, ctype) in [
+            CommunityType::Geographic,
+            CommunityType::Interest,
+            CommunityType::Solidarity,
+            CommunityType::Ecosystem,
+        ]
+        .iter()
+        .enumerate()
+        {
+            let community =
+                create_test_community(&format!("comm-{i}"), &format!("Community {i}"), *ctype);
+            comm_store.put(&community).unwrap();
+
+            let retrieved = comm_store.get(&format!("comm-{i}")).unwrap().unwrap();
+            assert_eq!(retrieved.community_type, *ctype);
+        }
+    }
+
+    // === Delete tests ===
+
+    #[test]
+    fn test_delete_existing_community() {
+        let comm_store = create_test_store();
+
+        let community = create_test_community("to-delete", "Delete Me", CommunityType::Geographic);
+        comm_store.put(&community).unwrap();
+
+        // Verify it exists
+        assert!(comm_store.get(&"to-delete".to_string()).unwrap().is_some());
+
+        // Delete it
+        comm_store.delete(&"to-delete".to_string()).unwrap();
+
+        // Verify it's gone
+        assert!(comm_store.get(&"to-delete".to_string()).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_delete_non_existent_succeeds() {
+        let comm_store = create_test_store();
+
+        // Should not error when deleting non-existent key
+        let result = comm_store.delete(&"never-existed".to_string());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_delete_does_not_affect_other_communities() {
+        let comm_store = create_test_store();
+
+        let community1 = create_test_community("comm-1", "Community 1", CommunityType::Geographic);
+        let community2 = create_test_community("comm-2", "Community 2", CommunityType::Interest);
+
+        comm_store.put(&community1).unwrap();
+        comm_store.put(&community2).unwrap();
+
+        // Delete first, second should remain
+        comm_store.delete(&"comm-1".to_string()).unwrap();
+
+        assert!(comm_store.get(&"comm-1".to_string()).unwrap().is_none());
+        assert!(comm_store.get(&"comm-2".to_string()).unwrap().is_some());
+    }
+
+    // === List tests ===
+
+    #[test]
+    fn test_list_empty_store() {
+        let comm_store = create_test_store();
+
+        let communities = comm_store.list().unwrap();
+        assert!(communities.is_empty());
+    }
+
+    #[test]
+    fn test_list_single_community() {
+        let comm_store = create_test_store();
+
+        let community =
+            create_test_community("single", "Single Community", CommunityType::Geographic);
+        comm_store.put(&community).unwrap();
+
+        let communities = comm_store.list().unwrap();
+        assert_eq!(communities.len(), 1);
+        assert_eq!(communities[0].id, "single");
+    }
+
+    #[test]
+    fn test_list_multiple_communities() {
+        let comm_store = create_test_store();
+
+        for i in 0..5 {
+            let community = create_test_community(
+                &format!("comm-{i}"),
+                &format!("Community {i}"),
+                CommunityType::Geographic,
+            );
+            comm_store.put(&community).unwrap();
+        }
+
+        let communities = comm_store.list().unwrap();
+        assert_eq!(communities.len(), 5);
+
+        // Verify all IDs are present (order may vary)
+        let ids: Vec<_> = communities.iter().map(|c| c.id.as_str()).collect();
+        for i in 0..5 {
+            assert!(ids.contains(&format!("comm-{i}").as_str()));
+        }
+    }
+
+    #[test]
+    fn test_list_after_delete() {
+        let comm_store = create_test_store();
+
+        for i in 0..3 {
+            let community = create_test_community(
+                &format!("comm-{i}"),
+                &format!("Community {i}"),
+                CommunityType::Interest,
+            );
+            comm_store.put(&community).unwrap();
+        }
+
+        // Delete middle one
+        comm_store.delete(&"comm-1".to_string()).unwrap();
+
+        let communities = comm_store.list().unwrap();
+        assert_eq!(communities.len(), 2);
+
+        let ids: Vec<_> = communities.iter().map(|c| c.id.as_str()).collect();
+        assert!(ids.contains(&"comm-0"));
+        assert!(!ids.contains(&"comm-1"));
+        assert!(ids.contains(&"comm-2"));
+    }
+
+    // === Community with members tests ===
+
+    #[test]
+    fn test_store_community_with_members() {
+        let comm_store = create_test_store();
+
+        let mut community =
+            create_test_community("with-members", "With Members", CommunityType::Solidarity);
+
+        // Add some members
+        community.members.insert(
+            "member-1".to_string(),
+            Member {
+                id: "member-1".to_string(),
+                member_type: MemberType::Individual("did:icn:alice".to_string()),
+                joined_at: Utc::now(),
+                voting_weight: 1,
+                active: true,
+            },
+        );
+        community.members.insert(
+            "member-2".to_string(),
+            Member {
+                id: "member-2".to_string(),
+                member_type: MemberType::Cooperative("coop:workers".to_string()),
+                joined_at: Utc::now(),
+                voting_weight: 5,
+                active: true,
+            },
+        );
+
+        comm_store.put(&community).unwrap();
+
+        let retrieved = comm_store
+            .get(&"with-members".to_string())
+            .unwrap()
+            .unwrap();
+        assert_eq!(retrieved.members.len(), 2);
+        assert!(retrieved.members.contains_key("member-1"));
+        assert!(retrieved.members.contains_key("member-2"));
+        assert_eq!(retrieved.total_voting_weight(), 6);
+    }
+
+    // === Community with resource pools tests ===
+
+    #[test]
+    fn test_store_community_with_resource_pools() {
+        let comm_store = create_test_store();
+
+        let mut community =
+            create_test_community("with-resources", "With Resources", CommunityType::Ecosystem);
+
+        // Add resource pools
+        community.resource_pools.insert(
+            "compute".to_string(),
+            crate::types::ResourcePool {
+                name: "compute".to_string(),
+                resource_type: "cpu".to_string(),
+                total_capacity: 100,
+                allocated: 25,
+                unit: "cores".to_string(),
+            },
+        );
+        community.resource_pools.insert(
+            "storage".to_string(),
+            crate::types::ResourcePool {
+                name: "storage".to_string(),
+                resource_type: "disk".to_string(),
+                total_capacity: 1000,
+                allocated: 500,
+                unit: "GB".to_string(),
+            },
+        );
+
+        comm_store.put(&community).unwrap();
+
+        let retrieved = comm_store
+            .get(&"with-resources".to_string())
+            .unwrap()
+            .unwrap();
+        assert_eq!(retrieved.resource_pools.len(), 2);
+        assert!(retrieved.resource_pools.contains_key("compute"));
+        assert!(retrieved.resource_pools.contains_key("storage"));
+
+        let compute = retrieved.resource_pools.get("compute").unwrap();
+        assert_eq!(compute.available(), 75);
+    }
+
+    // === Community with metadata tests ===
+
+    #[test]
+    fn test_store_community_with_metadata() {
+        let comm_store = create_test_store();
+
+        let mut community =
+            create_test_community("with-metadata", "With Metadata", CommunityType::Geographic);
+
+        community
+            .metadata
+            .insert("region".to_string(), "pacific-northwest".to_string());
+        community
+            .metadata
+            .insert("language".to_string(), "en-US".to_string());
+        community.charter = "cooperative://charter/v1".to_string();
+
+        comm_store.put(&community).unwrap();
+
+        let retrieved = comm_store
+            .get(&"with-metadata".to_string())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            retrieved.metadata.get("region").unwrap(),
+            "pacific-northwest"
+        );
+        assert_eq!(retrieved.metadata.get("language").unwrap(), "en-US");
+        assert_eq!(retrieved.charter, "cooperative://charter/v1");
+    }
+
+    // === Community status persistence ===
+
+    #[test]
+    fn test_store_all_community_statuses() {
+        let comm_store = create_test_store();
+
+        for (i, status) in [
+            CommunityStatus::Forming,
+            CommunityStatus::Active,
+            CommunityStatus::Suspended,
+            CommunityStatus::Dissolved,
+        ]
+        .iter()
+        .enumerate()
+        {
+            let mut community = create_test_community(
+                &format!("status-{i}"),
+                &format!("Status {i}"),
+                CommunityType::Geographic,
+            );
+            community.status = *status;
+
+            comm_store.put(&community).unwrap();
+
+            let retrieved = comm_store.get(&format!("status-{i}")).unwrap().unwrap();
+            assert_eq!(retrieved.status, *status);
+        }
+    }
+
+    // === CommunityQuery tests ===
+
+    #[test]
+    fn test_community_query_default() {
+        let query = CommunityQuery::default();
+        assert!(query.status.is_none());
+        assert!(query.member_id.is_none());
+    }
+
+    #[test]
+    fn test_community_query_with_status() {
+        let query = CommunityQuery {
+            status: Some(CommunityStatus::Active),
+            member_id: None,
+        };
+        assert_eq!(query.status, Some(CommunityStatus::Active));
+    }
+
+    #[test]
+    fn test_community_query_with_member_id() {
+        let query = CommunityQuery {
+            status: None,
+            member_id: Some("did:icn:abc123".to_string()),
+        };
+        assert_eq!(query.member_id, Some("did:icn:abc123".to_string()));
+    }
+
+    // === Edge cases ===
+
+    #[test]
+    fn test_store_community_with_empty_name() {
+        let comm_store = create_test_store();
+
+        let community = create_test_community("empty-name", "", CommunityType::Geographic);
+        comm_store.put(&community).unwrap();
+
+        let retrieved = comm_store.get(&"empty-name".to_string()).unwrap().unwrap();
+        assert_eq!(retrieved.name, "");
+    }
+
+    #[test]
+    fn test_store_community_with_unicode_name() {
+        let comm_store = create_test_store();
+
+        let mut community = Community::new(
+            "unicode-comm".to_string(),
+            "合作社 Кооператив 協同組合".to_string(),
+            CommunityType::Interest,
+            "global-domain".to_string(),
+        );
+        community.metadata.insert(
+            "description".to_string(),
+            "🌍 International 合作".to_string(),
+        );
+
+        comm_store.put(&community).unwrap();
+
+        let retrieved = comm_store
+            .get(&"unicode-comm".to_string())
+            .unwrap()
+            .unwrap();
+        assert_eq!(retrieved.name, "合作社 Кооператив 協同組合");
+        assert_eq!(
+            retrieved.metadata.get("description").unwrap(),
+            "🌍 International 合作"
+        );
+    }
+
+    #[test]
+    fn test_store_community_with_long_id() {
+        let comm_store = create_test_store();
+
+        let long_id = "a".repeat(256);
+        let community =
+            create_test_community(&long_id, "Long ID Community", CommunityType::Geographic);
+
+        comm_store.put(&community).unwrap();
+
+        let retrieved = comm_store.get(&long_id).unwrap().unwrap();
+        assert_eq!(retrieved.id, long_id);
     }
 }

--- a/icn/crates/icn-community/src/types.rs
+++ b/icn/crates/icn-community/src/types.rs
@@ -107,3 +107,406 @@ impl Community {
             .sum()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // === ResourcePool tests ===
+
+    #[test]
+    fn test_resource_pool_available_full_capacity() {
+        let pool = ResourcePool {
+            name: "compute".to_string(),
+            resource_type: "cpu".to_string(),
+            total_capacity: 100,
+            allocated: 0,
+            unit: "cores".to_string(),
+        };
+        assert_eq!(pool.available(), 100);
+    }
+
+    #[test]
+    fn test_resource_pool_available_partial() {
+        let pool = ResourcePool {
+            name: "storage".to_string(),
+            resource_type: "disk".to_string(),
+            total_capacity: 1000,
+            allocated: 350,
+            unit: "GB".to_string(),
+        };
+        assert_eq!(pool.available(), 650);
+    }
+
+    #[test]
+    fn test_resource_pool_available_fully_allocated() {
+        let pool = ResourcePool {
+            name: "credits".to_string(),
+            resource_type: "mutual_credit".to_string(),
+            total_capacity: 500,
+            allocated: 500,
+            unit: "credits".to_string(),
+        };
+        assert_eq!(pool.available(), 0);
+    }
+
+    #[test]
+    fn test_resource_pool_available_over_allocated_saturates() {
+        // Edge case: allocated > total_capacity (shouldn't happen, but saturating_sub handles it)
+        let pool = ResourcePool {
+            name: "test".to_string(),
+            resource_type: "test".to_string(),
+            total_capacity: 100,
+            allocated: 150,
+            unit: "units".to_string(),
+        };
+        assert_eq!(pool.available(), 0);
+    }
+
+    #[test]
+    fn test_resource_pool_can_allocate_sufficient() {
+        let pool = ResourcePool {
+            name: "compute".to_string(),
+            resource_type: "cpu".to_string(),
+            total_capacity: 100,
+            allocated: 30,
+            unit: "cores".to_string(),
+        };
+        assert!(pool.can_allocate(50));
+        assert!(pool.can_allocate(70));
+    }
+
+    #[test]
+    fn test_resource_pool_can_allocate_exact() {
+        let pool = ResourcePool {
+            name: "compute".to_string(),
+            resource_type: "cpu".to_string(),
+            total_capacity: 100,
+            allocated: 30,
+            unit: "cores".to_string(),
+        };
+        assert!(pool.can_allocate(70)); // Exactly available amount
+    }
+
+    #[test]
+    fn test_resource_pool_cannot_allocate_insufficient() {
+        let pool = ResourcePool {
+            name: "storage".to_string(),
+            resource_type: "disk".to_string(),
+            total_capacity: 100,
+            allocated: 80,
+            unit: "GB".to_string(),
+        };
+        assert!(!pool.can_allocate(25)); // Need 25, only 20 available
+        assert!(!pool.can_allocate(100));
+    }
+
+    #[test]
+    fn test_resource_pool_can_allocate_zero() {
+        let pool = ResourcePool {
+            name: "test".to_string(),
+            resource_type: "test".to_string(),
+            total_capacity: 0,
+            allocated: 0,
+            unit: "units".to_string(),
+        };
+        assert!(pool.can_allocate(0));
+        assert!(!pool.can_allocate(1));
+    }
+
+    // === Community tests ===
+
+    #[test]
+    fn test_community_new() {
+        let community = Community::new(
+            "comm-1".to_string(),
+            "Test Community".to_string(),
+            CommunityType::Geographic,
+            "domain-1".to_string(),
+        );
+
+        assert_eq!(community.id, "comm-1");
+        assert_eq!(community.name, "Test Community");
+        assert_eq!(community.community_type, CommunityType::Geographic);
+        assert_eq!(community.status, CommunityStatus::Forming);
+        assert_eq!(community.governance_domain, "domain-1");
+        assert!(community.members.is_empty());
+        assert!(community.resource_pools.is_empty());
+        assert!(community.charter.is_empty());
+        assert!(community.metadata.is_empty());
+    }
+
+    #[test]
+    fn test_community_new_all_types() {
+        for community_type in [
+            CommunityType::Geographic,
+            CommunityType::Interest,
+            CommunityType::Solidarity,
+            CommunityType::Ecosystem,
+        ] {
+            let community = Community::new(
+                format!("comm-{community_type:?}"),
+                "Test".to_string(),
+                community_type,
+                "domain".to_string(),
+            );
+            assert_eq!(community.community_type, community_type);
+            assert_eq!(community.status, CommunityStatus::Forming);
+        }
+    }
+
+    #[test]
+    fn test_community_active_member_count_empty() {
+        let community = Community::new(
+            "comm".to_string(),
+            "Test".to_string(),
+            CommunityType::Geographic,
+            "domain".to_string(),
+        );
+        assert_eq!(community.active_member_count(), 0);
+    }
+
+    #[test]
+    fn test_community_active_member_count_all_active() {
+        let mut community = Community::new(
+            "comm".to_string(),
+            "Test".to_string(),
+            CommunityType::Geographic,
+            "domain".to_string(),
+        );
+
+        for i in 1..=5 {
+            community.members.insert(
+                format!("member-{i}"),
+                Member {
+                    id: format!("member-{i}"),
+                    member_type: MemberType::Individual(format!("did:icn:{i}")),
+                    joined_at: Utc::now(),
+                    voting_weight: 1,
+                    active: true,
+                },
+            );
+        }
+
+        assert_eq!(community.active_member_count(), 5);
+    }
+
+    #[test]
+    fn test_community_active_member_count_mixed() {
+        let mut community = Community::new(
+            "comm".to_string(),
+            "Test".to_string(),
+            CommunityType::Interest,
+            "domain".to_string(),
+        );
+
+        // Add 3 active members
+        for i in 1..=3 {
+            community.members.insert(
+                format!("active-{i}"),
+                Member {
+                    id: format!("active-{i}"),
+                    member_type: MemberType::Individual(format!("did:icn:active{i}")),
+                    joined_at: Utc::now(),
+                    voting_weight: 1,
+                    active: true,
+                },
+            );
+        }
+
+        // Add 2 inactive members
+        for i in 1..=2 {
+            community.members.insert(
+                format!("inactive-{i}"),
+                Member {
+                    id: format!("inactive-{i}"),
+                    member_type: MemberType::Individual(format!("did:icn:inactive{i}")),
+                    joined_at: Utc::now(),
+                    voting_weight: 1,
+                    active: false,
+                },
+            );
+        }
+
+        assert_eq!(community.active_member_count(), 3);
+    }
+
+    #[test]
+    fn test_community_total_voting_weight_empty() {
+        let community = Community::new(
+            "comm".to_string(),
+            "Test".to_string(),
+            CommunityType::Solidarity,
+            "domain".to_string(),
+        );
+        assert_eq!(community.total_voting_weight(), 0);
+    }
+
+    #[test]
+    fn test_community_total_voting_weight_equal_weights() {
+        let mut community = Community::new(
+            "comm".to_string(),
+            "Test".to_string(),
+            CommunityType::Ecosystem,
+            "domain".to_string(),
+        );
+
+        for i in 1..=4 {
+            community.members.insert(
+                format!("member-{i}"),
+                Member {
+                    id: format!("member-{i}"),
+                    member_type: MemberType::Cooperative(format!("coop-{i}")),
+                    joined_at: Utc::now(),
+                    voting_weight: 1,
+                    active: true,
+                },
+            );
+        }
+
+        assert_eq!(community.total_voting_weight(), 4);
+    }
+
+    #[test]
+    fn test_community_total_voting_weight_varied_weights() {
+        let mut community = Community::new(
+            "comm".to_string(),
+            "Test".to_string(),
+            CommunityType::Ecosystem,
+            "domain".to_string(),
+        );
+
+        // Add members with different voting weights
+        community.members.insert(
+            "founder".to_string(),
+            Member {
+                id: "founder".to_string(),
+                member_type: MemberType::Individual("did:icn:founder".to_string()),
+                joined_at: Utc::now(),
+                voting_weight: 3,
+                active: true,
+            },
+        );
+        community.members.insert(
+            "large-coop".to_string(),
+            Member {
+                id: "large-coop".to_string(),
+                member_type: MemberType::Cooperative("coop-large".to_string()),
+                joined_at: Utc::now(),
+                voting_weight: 5,
+                active: true,
+            },
+        );
+        community.members.insert(
+            "small-coop".to_string(),
+            Member {
+                id: "small-coop".to_string(),
+                member_type: MemberType::Cooperative("coop-small".to_string()),
+                joined_at: Utc::now(),
+                voting_weight: 2,
+                active: true,
+            },
+        );
+
+        assert_eq!(community.total_voting_weight(), 10); // 3 + 5 + 2
+    }
+
+    #[test]
+    fn test_community_total_voting_weight_excludes_inactive() {
+        let mut community = Community::new(
+            "comm".to_string(),
+            "Test".to_string(),
+            CommunityType::Interest,
+            "domain".to_string(),
+        );
+
+        // Active member with weight 5
+        community.members.insert(
+            "active".to_string(),
+            Member {
+                id: "active".to_string(),
+                member_type: MemberType::Individual("did:icn:active".to_string()),
+                joined_at: Utc::now(),
+                voting_weight: 5,
+                active: true,
+            },
+        );
+
+        // Inactive member with weight 10 (should NOT count)
+        community.members.insert(
+            "inactive".to_string(),
+            Member {
+                id: "inactive".to_string(),
+                member_type: MemberType::Individual("did:icn:inactive".to_string()),
+                joined_at: Utc::now(),
+                voting_weight: 10,
+                active: false,
+            },
+        );
+
+        assert_eq!(community.total_voting_weight(), 5); // Only active member counts
+    }
+
+    // === Member and MemberType tests ===
+
+    #[test]
+    fn test_member_type_individual() {
+        let member_type = MemberType::Individual("did:icn:abc123".to_string());
+        if let MemberType::Individual(did) = member_type {
+            assert_eq!(did, "did:icn:abc123");
+        } else {
+            panic!("Expected Individual variant");
+        }
+    }
+
+    #[test]
+    fn test_member_type_cooperative() {
+        let member_type = MemberType::Cooperative("coop:worker-collective".to_string());
+        if let MemberType::Cooperative(coop_id) = member_type {
+            assert_eq!(coop_id, "coop:worker-collective");
+        } else {
+            panic!("Expected Cooperative variant");
+        }
+    }
+
+    #[test]
+    fn test_member_creation() {
+        let now = Utc::now();
+        let member = Member {
+            id: "member-1".to_string(),
+            member_type: MemberType::Individual("did:icn:test".to_string()),
+            joined_at: now,
+            voting_weight: 2,
+            active: true,
+        };
+
+        assert_eq!(member.id, "member-1");
+        assert_eq!(member.voting_weight, 2);
+        assert!(member.active);
+    }
+
+    // === CommunityStatus tests ===
+
+    #[test]
+    fn test_community_status_equality() {
+        assert_eq!(CommunityStatus::Forming, CommunityStatus::Forming);
+        assert_eq!(CommunityStatus::Active, CommunityStatus::Active);
+        assert_eq!(CommunityStatus::Suspended, CommunityStatus::Suspended);
+        assert_eq!(CommunityStatus::Dissolved, CommunityStatus::Dissolved);
+
+        assert_ne!(CommunityStatus::Forming, CommunityStatus::Active);
+        assert_ne!(CommunityStatus::Active, CommunityStatus::Dissolved);
+    }
+
+    // === CommunityType tests ===
+
+    #[test]
+    fn test_community_type_equality() {
+        assert_eq!(CommunityType::Geographic, CommunityType::Geographic);
+        assert_eq!(CommunityType::Interest, CommunityType::Interest);
+        assert_eq!(CommunityType::Solidarity, CommunityType::Solidarity);
+        assert_eq!(CommunityType::Ecosystem, CommunityType::Ecosystem);
+
+        assert_ne!(CommunityType::Geographic, CommunityType::Interest);
+    }
+}

--- a/icn/crates/icn-compute/src/actor_runtime.rs
+++ b/icn/crates/icn-compute/src/actor_runtime.rs
@@ -503,30 +503,32 @@ impl StatefulActorRegistry {
                     // This callback may be invoked from within a tokio task (e.g., MigrationManager),
                     // and block_on alone would panic. block_in_place moves other tasks off this
                     // thread before blocking.
-                    tokio::task::block_in_place(|| handle.block_on(async {
-                        let mut actors = actors.write().await;
-                        let info = actors.get_mut(&actor_id).ok_or_else(|| {
-                            ComputeError::Internal(format!(
-                                "Actor {} not found",
-                                hex::encode(actor_id)
-                            ))
-                        })?;
+                    tokio::task::block_in_place(|| {
+                        handle.block_on(async {
+                            let mut actors = actors.write().await;
+                            let info = actors.get_mut(&actor_id).ok_or_else(|| {
+                                ComputeError::Internal(format!(
+                                    "Actor {} not found",
+                                    hex::encode(actor_id)
+                                ))
+                            })?;
 
-                        if info.state != StatefulActorState::Running {
-                            return Err(ComputeError::Internal(format!(
-                                "Cannot pause actor {} in state {:?}",
-                                hex::encode(actor_id),
-                                info.state
-                            )));
-                        }
+                            if info.state != StatefulActorState::Running {
+                                return Err(ComputeError::Internal(format!(
+                                    "Cannot pause actor {} in state {:?}",
+                                    hex::encode(actor_id),
+                                    info.state
+                                )));
+                            }
 
-                        info.state = StatefulActorState::Paused {
-                            reason,
-                            paused_at: now_millis(),
-                        };
+                            info.state = StatefulActorState::Paused {
+                                reason,
+                                paused_at: now_millis(),
+                            };
 
-                        Ok(())
-                    }))
+                            Ok(())
+                        })
+                    })
                 }
 
                 ActorRuntimeCommand::Resume { actor_id } => {
@@ -534,26 +536,28 @@ impl StatefulActorRegistry {
                         .map_err(|e| ComputeError::Internal(e.to_string()))?;
 
                     // SAFETY: Use block_in_place to safely run blocking code from async context.
-                    tokio::task::block_in_place(|| handle.block_on(async {
-                        let mut actors = actors.write().await;
-                        let info = actors.get_mut(&actor_id).ok_or_else(|| {
-                            ComputeError::Internal(format!(
-                                "Actor {} not found",
-                                hex::encode(actor_id)
-                            ))
-                        })?;
+                    tokio::task::block_in_place(|| {
+                        handle.block_on(async {
+                            let mut actors = actors.write().await;
+                            let info = actors.get_mut(&actor_id).ok_or_else(|| {
+                                ComputeError::Internal(format!(
+                                    "Actor {} not found",
+                                    hex::encode(actor_id)
+                                ))
+                            })?;
 
-                        if !matches!(info.state, StatefulActorState::Paused { .. }) {
-                            return Err(ComputeError::Internal(format!(
-                                "Cannot resume actor {} in state {:?}",
-                                hex::encode(actor_id),
-                                info.state
-                            )));
-                        }
+                            if !matches!(info.state, StatefulActorState::Paused { .. }) {
+                                return Err(ComputeError::Internal(format!(
+                                    "Cannot resume actor {} in state {:?}",
+                                    hex::encode(actor_id),
+                                    info.state
+                                )));
+                            }
 
-                        info.state = StatefulActorState::Running;
-                        Ok(())
-                    }))
+                            info.state = StatefulActorState::Running;
+                            Ok(())
+                        })
+                    })
                 }
 
                 ActorRuntimeCommand::Restore {
@@ -564,21 +568,23 @@ impl StatefulActorRegistry {
                         .map_err(|e| ComputeError::Internal(e.to_string()))?;
 
                     // SAFETY: Use block_in_place to safely run blocking code from async context.
-                    tokio::task::block_in_place(|| handle.block_on(async {
-                        let mut actors = actors.write().await;
+                    tokio::task::block_in_place(|| {
+                        handle.block_on(async {
+                            let mut actors = actors.write().await;
 
-                        // Create new entry or update existing
-                        let info = actors.entry(actor_id).or_insert_with(|| {
-                            StatefulActorInfo::new(actor_id, ActorMode::default())
-                        });
+                            // Create new entry or update existing
+                            let info = actors.entry(actor_id).or_insert_with(|| {
+                                StatefulActorInfo::new(actor_id, ActorMode::default())
+                            });
 
-                        info.current_state = checkpoint.state;
-                        info.last_checkpoint_seq = checkpoint.sequence;
-                        info.state = StatefulActorState::Running;
-                        info.memory_bytes = info.current_state.len() as u64;
+                            info.current_state = checkpoint.state;
+                            info.last_checkpoint_seq = checkpoint.sequence;
+                            info.state = StatefulActorState::Running;
+                            info.memory_bytes = info.current_state.len() as u64;
 
-                        Ok(())
-                    }))
+                            Ok(())
+                        })
+                    })
                 }
 
                 ActorRuntimeCommand::Terminate { actor_id, reason } => {
@@ -586,22 +592,24 @@ impl StatefulActorRegistry {
                         .map_err(|e| ComputeError::Internal(e.to_string()))?;
 
                     // SAFETY: Use block_in_place to safely run blocking code from async context.
-                    tokio::task::block_in_place(|| handle.block_on(async {
-                        let mut actors = actors.write().await;
-                        let info = actors.get_mut(&actor_id).ok_or_else(|| {
-                            ComputeError::Internal(format!(
-                                "Actor {} not found",
-                                hex::encode(actor_id)
-                            ))
-                        })?;
+                    tokio::task::block_in_place(|| {
+                        handle.block_on(async {
+                            let mut actors = actors.write().await;
+                            let info = actors.get_mut(&actor_id).ok_or_else(|| {
+                                ComputeError::Internal(format!(
+                                    "Actor {} not found",
+                                    hex::encode(actor_id)
+                                ))
+                            })?;
 
-                        info.state = StatefulActorState::Terminated {
-                            reason,
-                            terminated_at: now_millis(),
-                        };
+                            info.state = StatefulActorState::Terminated {
+                                reason,
+                                terminated_at: now_millis(),
+                            };
 
-                        Ok(())
-                    }))
+                            Ok(())
+                        })
+                    })
                 }
 
                 ActorRuntimeCommand::GetState { actor_id: _ } => {

--- a/icn/crates/icn-gateway/src/api/trust.rs
+++ b/icn/crates/icn-gateway/src/api/trust.rs
@@ -166,7 +166,9 @@ pub async fn get_trust_network(
         .map_err(|e| GatewayError::BadRequest(format!("Invalid DID: {e}")))?;
 
     let max_distance = query.depth.unwrap_or(2).min(5); // Cap at 5 hops
-    let network = trust_manager.get_trust_network_async(&did, max_distance).await;
+    let network = trust_manager
+        .get_trust_network_async(&did, max_distance)
+        .await;
 
     Ok(HttpResponse::Ok().json(network))
 }


### PR DESCRIPTION
## Summary

- Increase test coverage from 29 to 137 tests (4.7x improvement)
- Add comprehensive unit tests for all icn-community modules
- Cover error handling, status transitions, and edge cases

## Changes by Module

**types.rs (22 tests)**
- ResourcePool: available(), can_allocate(), edge cases
- Community: new(), active_member_count(), total_voting_weight()
- Member and MemberType variants
- CommunityType and CommunityStatus equality

**store.rs (21 tests)**
- CRUD operations: put/get/delete/list
- Error cases: get non-existent returns None
- Community with members, resource pools, metadata
- Edge cases: empty name, unicode, long IDs

**resources.rs (25 tests)**
- ResourceManager: new(), create_pool(), allocate(), deallocate()
- Error cases: insufficient resources, nonexistent pool
- Edge cases: zero amount, saturating deallocate
- Workflow tests: allocate/deallocate cycles

**membership.rs (18 tests)**
- MembershipManager: add_member(), remove_member()
- Error cases: duplicate member, nonexistent member
- MemberApplication creation and serialization
- Workflow tests: add/remove cycles

**lifecycle.rs (23 tests)**
- CommunityLifecycle: form(), activate(), dissolve()
- Error cases: insufficient founders, invalid transitions
- FormationRequest creation and serialization
- Full lifecycle workflow tests

## Test Plan

- [x] All 137 tests pass locally
- [x] Clippy passes with no warnings
- [x] Formatting verified with cargo fmt

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)