### PR TITLE
feat(net): Add size limits to blob location registry

### DIFF
--- a/icn/crates/icn-compute/src/actor_runtime.rs
+++ b/icn/crates/icn-compute/src/actor_runtime.rs
@@ -503,30 +503,32 @@ impl StatefulActorRegistry {
                     // This callback may be invoked from within a tokio task (e.g., MigrationManager),
                     // and block_on alone would panic. block_in_place moves other tasks off this
                     // thread before blocking.
-                    tokio::task::block_in_place(|| handle.block_on(async {
-                        let mut actors = actors.write().await;
-                        let info = actors.get_mut(&actor_id).ok_or_else(|| {
-                            ComputeError::Internal(format!(
-                                "Actor {} not found",
-                                hex::encode(actor_id)
-                            ))
-                        })?;
+                    tokio::task::block_in_place(|| {
+                        handle.block_on(async {
+                            let mut actors = actors.write().await;
+                            let info = actors.get_mut(&actor_id).ok_or_else(|| {
+                                ComputeError::Internal(format!(
+                                    "Actor {} not found",
+                                    hex::encode(actor_id)
+                                ))
+                            })?;
 
-                        if info.state != StatefulActorState::Running {
-                            return Err(ComputeError::Internal(format!(
-                                "Cannot pause actor {} in state {:?}",
-                                hex::encode(actor_id),
-                                info.state
-                            )));
-                        }
+                            if info.state != StatefulActorState::Running {
+                                return Err(ComputeError::Internal(format!(
+                                    "Cannot pause actor {} in state {:?}",
+                                    hex::encode(actor_id),
+                                    info.state
+                                )));
+                            }
 
-                        info.state = StatefulActorState::Paused {
-                            reason,
-                            paused_at: now_millis(),
-                        };
+                            info.state = StatefulActorState::Paused {
+                                reason,
+                                paused_at: now_millis(),
+                            };
 
-                        Ok(())
-                    }))
+                            Ok(())
+                        })
+                    })
                 }
 
                 ActorRuntimeCommand::Resume { actor_id } => {
@@ -534,26 +536,28 @@ impl StatefulActorRegistry {
                         .map_err(|e| ComputeError::Internal(e.to_string()))?;
 
                     // SAFETY: Use block_in_place to safely run blocking code from async context.
-                    tokio::task::block_in_place(|| handle.block_on(async {
-                        let mut actors = actors.write().await;
-                        let info = actors.get_mut(&actor_id).ok_or_else(|| {
-                            ComputeError::Internal(format!(
-                                "Actor {} not found",
-                                hex::encode(actor_id)
-                            ))
-                        })?;
+                    tokio::task::block_in_place(|| {
+                        handle.block_on(async {
+                            let mut actors = actors.write().await;
+                            let info = actors.get_mut(&actor_id).ok_or_else(|| {
+                                ComputeError::Internal(format!(
+                                    "Actor {} not found",
+                                    hex::encode(actor_id)
+                                ))
+                            })?;
 
-                        if !matches!(info.state, StatefulActorState::Paused { .. }) {
-                            return Err(ComputeError::Internal(format!(
-                                "Cannot resume actor {} in state {:?}",
-                                hex::encode(actor_id),
-                                info.state
-                            )));
-                        }
+                            if !matches!(info.state, StatefulActorState::Paused { .. }) {
+                                return Err(ComputeError::Internal(format!(
+                                    "Cannot resume actor {} in state {:?}",
+                                    hex::encode(actor_id),
+                                    info.state
+                                )));
+                            }
 
-                        info.state = StatefulActorState::Running;
-                        Ok(())
-                    }))
+                            info.state = StatefulActorState::Running;
+                            Ok(())
+                        })
+                    })
                 }
 
                 ActorRuntimeCommand::Restore {
@@ -564,21 +568,23 @@ impl StatefulActorRegistry {
                         .map_err(|e| ComputeError::Internal(e.to_string()))?;
 
                     // SAFETY: Use block_in_place to safely run blocking code from async context.
-                    tokio::task::block_in_place(|| handle.block_on(async {
-                        let mut actors = actors.write().await;
+                    tokio::task::block_in_place(|| {
+                        handle.block_on(async {
+                            let mut actors = actors.write().await;
 
-                        // Create new entry or update existing
-                        let info = actors.entry(actor_id).or_insert_with(|| {
-                            StatefulActorInfo::new(actor_id, ActorMode::default())
-                        });
+                            // Create new entry or update existing
+                            let info = actors.entry(actor_id).or_insert_with(|| {
+                                StatefulActorInfo::new(actor_id, ActorMode::default())
+                            });
 
-                        info.current_state = checkpoint.state;
-                        info.last_checkpoint_seq = checkpoint.sequence;
-                        info.state = StatefulActorState::Running;
-                        info.memory_bytes = info.current_state.len() as u64;
+                            info.current_state = checkpoint.state;
+                            info.last_checkpoint_seq = checkpoint.sequence;
+                            info.state = StatefulActorState::Running;
+                            info.memory_bytes = info.current_state.len() as u64;
 
-                        Ok(())
-                    }))
+                            Ok(())
+                        })
+                    })
                 }
 
                 ActorRuntimeCommand::Terminate { actor_id, reason } => {
@@ -586,22 +592,24 @@ impl StatefulActorRegistry {
                         .map_err(|e| ComputeError::Internal(e.to_string()))?;
 
                     // SAFETY: Use block_in_place to safely run blocking code from async context.
-                    tokio::task::block_in_place(|| handle.block_on(async {
-                        let mut actors = actors.write().await;
-                        let info = actors.get_mut(&actor_id).ok_or_else(|| {
-                            ComputeError::Internal(format!(
-                                "Actor {} not found",
-                                hex::encode(actor_id)
-                            ))
-                        })?;
+                    tokio::task::block_in_place(|| {
+                        handle.block_on(async {
+                            let mut actors = actors.write().await;
+                            let info = actors.get_mut(&actor_id).ok_or_else(|| {
+                                ComputeError::Internal(format!(
+                                    "Actor {} not found",
+                                    hex::encode(actor_id)
+                                ))
+                            })?;
 
-                        info.state = StatefulActorState::Terminated {
-                            reason,
-                            terminated_at: now_millis(),
-                        };
+                            info.state = StatefulActorState::Terminated {
+                                reason,
+                                terminated_at: now_millis(),
+                            };
 
-                        Ok(())
-                    }))
+                            Ok(())
+                        })
+                    })
                 }
 
                 ActorRuntimeCommand::GetState { actor_id: _ } => {

--- a/icn/crates/icn-core/src/config.rs
+++ b/icn/crates/icn-core/src/config.rs
@@ -209,6 +209,61 @@ pub struct NetworkConfig {
     /// NAT traversal dial strategy configuration
     #[serde(default)]
     pub nat_dial: NatDialConfig,
+
+    /// Blob registry configuration for distributed data tracking
+    #[serde(default)]
+    pub blob_registry: BlobRegistryConfig,
+}
+
+/// Blob registry configuration for distributed data tracking
+///
+/// Controls size limits and quotas to prevent memory exhaustion attacks.
+/// The blob registry tracks which peers have which data blobs for
+/// locality-aware task placement.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlobRegistryConfig {
+    /// Maximum size of a single blob in bytes (default: 10MB)
+    ///
+    /// Blobs larger than this are rejected. This prevents malicious peers
+    /// from announcing extremely large blobs that could exhaust memory.
+    #[serde(default = "default_max_blob_size")]
+    pub max_blob_size: u64,
+
+    /// Maximum total size of all blobs in the registry in bytes (default: 100MB)
+    ///
+    /// When this limit is reached, the oldest entries are evicted (LRU)
+    /// to make room for new announcements.
+    #[serde(default = "default_max_registry_size")]
+    pub max_registry_size: u64,
+
+    /// Maximum total blob size per peer in bytes (default: 10MB)
+    ///
+    /// This prevents a single peer from consuming too much of the registry
+    /// capacity. Announcements from peers exceeding their quota are rejected.
+    #[serde(default = "default_max_per_peer_size")]
+    pub max_per_peer_size: u64,
+}
+
+impl Default for BlobRegistryConfig {
+    fn default() -> Self {
+        Self {
+            max_blob_size: default_max_blob_size(),
+            max_registry_size: default_max_registry_size(),
+            max_per_peer_size: default_max_per_peer_size(),
+        }
+    }
+}
+
+fn default_max_blob_size() -> u64 {
+    10 * 1024 * 1024 // 10MB
+}
+
+fn default_max_registry_size() -> u64 {
+    100 * 1024 * 1024 // 100MB
+}
+
+fn default_max_per_peer_size() -> u64 {
+    10 * 1024 * 1024 // 10MB
 }
 
 /// NAT traversal dial strategy configuration
@@ -855,6 +910,7 @@ impl Default for Config {
                 e2e_encryption_enabled: true,
                 encryption_cleanup_circuit_breaker_threshold: 3,
                 nat_dial: NatDialConfig::default(),
+                blob_registry: BlobRegistryConfig::default(),
             },
             observability: ObservabilityConfig {
                 metrics_port: 9100,

--- a/icn/crates/icn-gateway/src/api/trust.rs
+++ b/icn/crates/icn-gateway/src/api/trust.rs
@@ -166,7 +166,9 @@ pub async fn get_trust_network(
         .map_err(|e| GatewayError::BadRequest(format!("Invalid DID: {e}")))?;
 
     let max_distance = query.depth.unwrap_or(2).min(5); // Cap at 5 hops
-    let network = trust_manager.get_trust_network_async(&did, max_distance).await;
+    let network = trust_manager
+        .get_trust_network_async(&did, max_distance)
+        .await;
 
     Ok(HttpResponse::Ok().json(network))
 }

--- a/icn/crates/icn-net/src/actor.rs
+++ b/icn/crates/icn-net/src/actor.rs
@@ -453,10 +453,11 @@ impl NetworkHandle {
     ) {
         // Update local registry
         if let Some(ref registry) = self.blob_registry {
-            if let Err(e) = registry
-                .write()
-                .await
-                .announce_blob(blob_hash, peer_did.clone(), size_bytes)
+            if let Err(e) =
+                registry
+                    .write()
+                    .await
+                    .announce_blob(blob_hash, peer_did.clone(), size_bytes)
             {
                 tracing::warn!(
                     error = %e,

--- a/icn/crates/icn-net/src/actor.rs
+++ b/icn/crates/icn-net/src/actor.rs
@@ -453,10 +453,18 @@ impl NetworkHandle {
     ) {
         // Update local registry
         if let Some(ref registry) = self.blob_registry {
-            registry
+            if let Err(e) = registry
                 .write()
                 .await
-                .announce_blob(blob_hash, peer_did.clone(), size_bytes);
+                .announce_blob(blob_hash, peer_did.clone(), size_bytes)
+            {
+                tracing::warn!(
+                    error = %e,
+                    blob_size = size_bytes,
+                    "Failed to register local blob announcement"
+                );
+                return; // Don't broadcast if we can't register locally
+            }
         }
 
         // Broadcast BlobAnnounce message via gossip
@@ -1666,11 +1674,18 @@ impl NetworkActor {
 
                                         // Update blob location registry
                                         if let Some(ref registry) = blob_registry {
-                                            registry.write().await.announce_blob(
+                                            if let Err(e) = registry.write().await.announce_blob(
                                                 *blob_hash,
                                                 peer_did.clone(),
                                                 *size_bytes,
-                                            );
+                                            ) {
+                                                debug!(
+                                                    error = %e,
+                                                    peer_did = %peer_did,
+                                                    blob_size = size_bytes,
+                                                    "Rejected blob announcement from peer"
+                                                );
+                                            }
                                         }
                                     }
 

--- a/icn/crates/icn-net/src/blob_registry.rs
+++ b/icn/crates/icn-net/src/blob_registry.rs
@@ -8,21 +8,23 @@
 //!
 //! - **BlobLocationRegistry**: Central registry mapping blob hashes to peer locations
 //! - **TTL-based expiration**: Locations expire after 24 hours to handle churn
-//! - **Gossip integration**: Peers announce blob availability via gossip protocol
-//! - **Query API**: Executors query registry to find data-local placement
+//! - **Size limits**: Configurable limits prevent memory exhaustion attacks
+//! - **LRU eviction**: Oldest entries evicted when capacity is reached
+//! - **Per-peer quotas**: Prevent any single peer from dominating the registry
 //!
 //! ## Usage
 //!
 //! ```rust,ignore
-//! use icn_net::BlobLocationRegistry;
+//! use icn_net::{BlobLocationRegistry, BlobRegistryConfig};
 //! use icn_identity::Did;
 //!
-//! let mut registry = BlobLocationRegistry::new();
+//! let config = BlobRegistryConfig::default();
+//! let mut registry = BlobLocationRegistry::with_config(config);
 //!
 //! // Peer announces blob availability
 //! let blob_hash = [0u8; 32];
 //! let peer_did: Did = /* valid DID */;
-//! registry.announce_blob(blob_hash, peer_did.clone(), 1024);
+//! registry.announce_blob(blob_hash, peer_did.clone(), 1024)?;
 //!
 //! // Query peers with blob
 //! let peers = registry.get_peers_with_blob(&blob_hash);
@@ -31,8 +33,53 @@
 
 use icn_gossip::types::ContentHash;
 use icn_identity::Did;
-use std::collections::HashMap;
+use icn_obs::metrics::network::{
+    blob_evicted_inc, blob_rejected_inc, blob_registry_entries_set, blob_registry_size_set,
+    BlobRejectionReason,
+};
+use std::collections::{HashMap, VecDeque};
 use std::time::{Duration, Instant};
+use thiserror::Error;
+
+/// Errors that can occur when interacting with the blob registry
+#[derive(Debug, Error)]
+pub enum BlobRegistryError {
+    /// Blob size exceeds the maximum allowed size
+    #[error("blob size {size} exceeds maximum allowed size {max}")]
+    BlobTooLarge { size: u64, max: u64 },
+
+    /// Peer has exceeded their quota
+    #[error("peer {peer} quota exceeded: using {used}, limit {limit}, requested {requested}")]
+    PeerQuotaExceeded {
+        peer: String,
+        used: u64,
+        limit: u64,
+        requested: u64,
+    },
+}
+
+/// Configuration for the blob location registry
+#[derive(Debug, Clone)]
+pub struct BlobRegistryConfig {
+    /// Maximum size of a single blob in bytes (default: 10MB)
+    pub max_blob_size: u64,
+
+    /// Maximum total size of all blobs in the registry in bytes (default: 100MB)
+    pub max_registry_size: u64,
+
+    /// Maximum total blob size per peer in bytes (default: 10MB)
+    pub max_per_peer_size: u64,
+}
+
+impl Default for BlobRegistryConfig {
+    fn default() -> Self {
+        Self {
+            max_blob_size: 10 * 1024 * 1024,      // 10MB
+            max_registry_size: 100 * 1024 * 1024, // 100MB
+            max_per_peer_size: 10 * 1024 * 1024,  // 10MB
+        }
+    }
+}
 
 /// Location information for a blob on a specific peer
 #[derive(Debug, Clone)]
@@ -71,15 +118,48 @@ impl BlobLocation {
 /// Registry tracking blob locations across the network
 #[derive(Debug)]
 pub struct BlobLocationRegistry {
+    /// Configuration for size limits
+    config: BlobRegistryConfig,
+
     /// Map from blob hash to list of peers that have it
     locations: HashMap<ContentHash, Vec<BlobLocation>>,
+
+    /// LRU order: (blob_hash, peer_did) pairs, oldest at front
+    lru_order: VecDeque<(ContentHash, Did)>,
+
+    /// Total size of all blobs in the registry
+    total_size: u64,
+
+    /// Size used by each peer
+    per_peer_size: HashMap<Did, u64>,
+
+    /// Statistics: number of blobs rejected for being too large
+    rejected_too_large: u64,
+
+    /// Statistics: number of blobs rejected for peer quota exceeded
+    rejected_quota_exceeded: u64,
+
+    /// Statistics: number of entries evicted due to capacity
+    evicted_count: u64,
 }
 
 impl BlobLocationRegistry {
-    /// Create a new empty registry
+    /// Create a new empty registry with default configuration
     pub fn new() -> Self {
+        Self::with_config(BlobRegistryConfig::default())
+    }
+
+    /// Create a new registry with the specified configuration
+    pub fn with_config(config: BlobRegistryConfig) -> Self {
         Self {
+            config,
             locations: HashMap::new(),
+            lru_order: VecDeque::new(),
+            total_size: 0,
+            per_peer_size: HashMap::new(),
+            rejected_too_large: 0,
+            rejected_quota_exceeded: 0,
+            evicted_count: 0,
         }
     }
 
@@ -87,19 +167,143 @@ impl BlobLocationRegistry {
     ///
     /// This updates the registry with the peer's location information.
     /// If the peer already announced this blob, updates the timestamp.
-    pub fn announce_blob(&mut self, blob_hash: ContentHash, peer_did: Did, size_bytes: u64) {
-        let location = BlobLocation::new(peer_did.clone(), size_bytes);
-
-        let locations = self.locations.entry(blob_hash).or_default();
-
-        // Check if peer already announced this blob
-        if let Some(existing) = locations.iter_mut().find(|loc| loc.peer_did == peer_did) {
-            // Update existing entry
-            *existing = location;
-        } else {
-            // Add new entry
-            locations.push(location);
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The blob size exceeds `max_blob_size`
+    /// - The peer would exceed their quota (`max_per_peer_size`)
+    pub fn announce_blob(
+        &mut self,
+        blob_hash: ContentHash,
+        peer_did: Did,
+        size_bytes: u64,
+    ) -> Result<(), BlobRegistryError> {
+        // Check per-blob size limit
+        if size_bytes > self.config.max_blob_size {
+            self.rejected_too_large += 1;
+            blob_rejected_inc(BlobRejectionReason::TooLarge);
+            return Err(BlobRegistryError::BlobTooLarge {
+                size: size_bytes,
+                max: self.config.max_blob_size,
+            });
         }
+
+        // Calculate the net size change for this peer
+        let existing_size = self.get_existing_size(&blob_hash, &peer_did);
+        let size_delta = size_bytes.saturating_sub(existing_size);
+
+        // Check per-peer quota (only for new size, not updates)
+        if size_delta > 0 {
+            let current_peer_size = self.per_peer_size.get(&peer_did).copied().unwrap_or(0);
+            let new_peer_size = current_peer_size + size_delta;
+
+            if new_peer_size > self.config.max_per_peer_size {
+                self.rejected_quota_exceeded += 1;
+                blob_rejected_inc(BlobRejectionReason::PeerQuotaExceeded);
+                return Err(BlobRegistryError::PeerQuotaExceeded {
+                    peer: peer_did.to_string(),
+                    used: current_peer_size,
+                    limit: self.config.max_per_peer_size,
+                    requested: size_bytes,
+                });
+            }
+        }
+
+        // Evict old entries if we would exceed total capacity
+        while self.total_size + size_delta > self.config.max_registry_size {
+            if !self.evict_oldest() {
+                // Nothing left to evict, but we still need space
+                // This shouldn't happen if max_blob_size <= max_registry_size
+                break;
+            }
+        }
+
+        // Remove existing entry if updating (to recalculate sizes)
+        if existing_size > 0 {
+            self.remove_entry(&blob_hash, &peer_did);
+        }
+
+        // Add the new entry
+        let location = BlobLocation::new(peer_did.clone(), size_bytes);
+        let locations = self.locations.entry(blob_hash).or_default();
+        locations.push(location);
+
+        // Update LRU order
+        self.lru_order.push_back((blob_hash, peer_did.clone()));
+
+        // Update size tracking
+        self.total_size += size_bytes;
+        *self.per_peer_size.entry(peer_did).or_insert(0) += size_bytes;
+
+        // Update gauge metrics
+        blob_registry_size_set(self.total_size);
+        blob_registry_entries_set(self.location_count());
+
+        Ok(())
+    }
+
+    /// Get the existing size of a blob announcement for a specific peer
+    fn get_existing_size(&self, blob_hash: &ContentHash, peer_did: &Did) -> u64 {
+        self.locations
+            .get(blob_hash)
+            .and_then(|locs| locs.iter().find(|loc| &loc.peer_did == peer_did))
+            .map(|loc| loc.size_bytes)
+            .unwrap_or(0)
+    }
+
+    /// Remove a specific entry from the registry
+    fn remove_entry(&mut self, blob_hash: &ContentHash, peer_did: &Did) {
+        if let Some(locations) = self.locations.get_mut(blob_hash) {
+            if let Some(idx) = locations.iter().position(|loc| &loc.peer_did == peer_did) {
+                let removed = locations.remove(idx);
+
+                // Update size tracking
+                self.total_size = self.total_size.saturating_sub(removed.size_bytes);
+                if let Some(peer_size) = self.per_peer_size.get_mut(peer_did) {
+                    *peer_size = peer_size.saturating_sub(removed.size_bytes);
+                    if *peer_size == 0 {
+                        self.per_peer_size.remove(peer_did);
+                    }
+                }
+            }
+
+            // Remove blob entry if no locations remain
+            if locations.is_empty() {
+                self.locations.remove(blob_hash);
+            }
+        }
+
+        // Remove from LRU order (may have duplicates, remove first match)
+        if let Some(idx) = self
+            .lru_order
+            .iter()
+            .position(|(h, p)| h == blob_hash && p == peer_did)
+        {
+            self.lru_order.remove(idx);
+        }
+    }
+
+    /// Evict the oldest entry from the registry
+    ///
+    /// Returns true if an entry was evicted, false if the registry is empty.
+    fn evict_oldest(&mut self) -> bool {
+        // Find the oldest non-expired entry
+        while let Some((blob_hash, peer_did)) = self.lru_order.pop_front() {
+            // Check if this entry still exists (may have been removed by cleanup)
+            if self
+                .locations
+                .get(&blob_hash)
+                .map(|locs| locs.iter().any(|loc| loc.peer_did == peer_did))
+                .unwrap_or(false)
+            {
+                self.remove_entry(&blob_hash, &peer_did);
+                self.evicted_count += 1;
+                blob_evicted_inc();
+                return true;
+            }
+        }
+        false
     }
 
     /// Get all peers that have a specific blob
@@ -164,13 +368,25 @@ impl BlobLocationRegistry {
     ///
     /// This should be called periodically to clean up stale entries.
     pub fn cleanup_expired(&mut self) {
-        // Remove expired locations from each blob's list
-        for locations in self.locations.values_mut() {
-            locations.retain(|loc| !loc.is_expired());
+        // Collect entries to remove
+        let mut to_remove: Vec<(ContentHash, Did)> = Vec::new();
+
+        for (hash, locations) in &self.locations {
+            for loc in locations {
+                if loc.is_expired() {
+                    to_remove.push((*hash, loc.peer_did.clone()));
+                }
+            }
         }
 
-        // Remove blobs with no valid locations
-        self.locations.retain(|_, locs| !locs.is_empty());
+        // Remove expired entries
+        for (hash, peer) in to_remove {
+            self.remove_entry(&hash, &peer);
+        }
+
+        // Update gauge metrics after cleanup
+        blob_registry_size_set(self.total_size);
+        blob_registry_entries_set(self.location_count());
     }
 
     /// Get total number of tracked blobs
@@ -178,19 +394,49 @@ impl BlobLocationRegistry {
         self.locations.len()
     }
 
-    /// Get total number of location entries (before cleanup)
+    /// Get total number of location entries
     pub fn location_count(&self) -> usize {
         self.locations.values().map(|v| v.len()).sum()
     }
 
+    /// Get total size of all blobs in the registry
+    pub fn total_size(&self) -> u64 {
+        self.total_size
+    }
+
+    /// Get the size used by a specific peer
+    pub fn peer_size(&self, peer_did: &Did) -> u64 {
+        self.per_peer_size.get(peer_did).copied().unwrap_or(0)
+    }
+
+    /// Get statistics about rejected blobs
+    pub fn rejected_stats(&self) -> (u64, u64) {
+        (self.rejected_too_large, self.rejected_quota_exceeded)
+    }
+
+    /// Get count of evicted entries
+    pub fn evicted_count(&self) -> u64 {
+        self.evicted_count
+    }
+
     /// Remove all locations for a specific peer (e.g., when peer disconnects)
     pub fn remove_peer(&mut self, peer_did: &Did) {
-        for locations in self.locations.values_mut() {
-            locations.retain(|loc| &loc.peer_did != peer_did);
+        // Collect blob hashes where this peer has entries
+        let blob_hashes: Vec<_> = self
+            .locations
+            .iter()
+            .filter(|(_, locs)| locs.iter().any(|loc| &loc.peer_did == peer_did))
+            .map(|(hash, _)| *hash)
+            .collect();
+
+        // Remove entries for this peer
+        for hash in blob_hashes {
+            self.remove_entry(&hash, peer_did);
         }
 
-        // Remove blobs with no remaining locations
-        self.locations.retain(|_, locs| !locs.is_empty());
+        // Update gauge metrics after removal
+        blob_registry_size_set(self.total_size);
+        blob_registry_entries_set(self.location_count());
     }
 }
 
@@ -209,6 +455,14 @@ mod tests {
         KeyPair::generate().unwrap().did().clone()
     }
 
+    fn create_test_config() -> BlobRegistryConfig {
+        BlobRegistryConfig {
+            max_blob_size: 1024 * 1024,      // 1MB
+            max_registry_size: 10 * 1024 * 1024, // 10MB
+            max_per_peer_size: 2 * 1024 * 1024,  // 2MB
+        }
+    }
+
     #[test]
     fn test_announce_and_query_blob() {
         let mut registry = BlobLocationRegistry::new();
@@ -216,7 +470,7 @@ mod tests {
         let peer1 = create_test_did();
 
         // Announce blob
-        registry.announce_blob(blob_hash, peer1.clone(), 1024);
+        registry.announce_blob(blob_hash, peer1.clone(), 1024).unwrap();
 
         // Query should return the peer
         let peers = registry.get_peers_with_blob(&blob_hash);
@@ -233,8 +487,8 @@ mod tests {
         let peer2 = create_test_did();
 
         // Multiple peers announce same blob
-        registry.announce_blob(blob_hash, peer1.clone(), 1024);
-        registry.announce_blob(blob_hash, peer2.clone(), 2048);
+        registry.announce_blob(blob_hash, peer1.clone(), 1024).unwrap();
+        registry.announce_blob(blob_hash, peer2.clone(), 2048).unwrap();
 
         let peers = registry.get_peers_with_blob(&blob_hash);
         assert_eq!(peers.len(), 2);
@@ -247,13 +501,13 @@ mod tests {
         let peer = create_test_did();
 
         // First announcement
-        registry.announce_blob(blob_hash, peer.clone(), 1024);
+        registry.announce_blob(blob_hash, peer.clone(), 1024).unwrap();
         let peers1 = registry.get_peers_with_blob(&blob_hash);
         assert_eq!(peers1.len(), 1);
         assert_eq!(peers1[0].size_bytes, 1024);
 
         // Update announcement (different size)
-        registry.announce_blob(blob_hash, peer.clone(), 2048);
+        registry.announce_blob(blob_hash, peer.clone(), 2048).unwrap();
         let peers2 = registry.get_peers_with_blob(&blob_hash);
         assert_eq!(peers2.len(), 1); // Still one entry
         assert_eq!(peers2[0].size_bytes, 2048); // Size updated
@@ -267,8 +521,8 @@ mod tests {
         let blob3 = [3u8; 32];
         let peer = create_test_did();
 
-        registry.announce_blob(blob1, peer.clone(), 1024);
-        registry.announce_blob(blob2, peer.clone(), 2048);
+        registry.announce_blob(blob1, peer.clone(), 1024).unwrap();
+        registry.announce_blob(blob2, peer.clone(), 2048).unwrap();
         // blob3 not announced
 
         let result = registry.query_blobs(&[blob1, blob2, blob3]);
@@ -290,15 +544,15 @@ mod tests {
         let peer_c = create_test_did();
 
         // Peer A has blob1 and blob2
-        registry.announce_blob(blob1, peer_a.clone(), 1024);
-        registry.announce_blob(blob2, peer_a.clone(), 1024);
+        registry.announce_blob(blob1, peer_a.clone(), 1024).unwrap();
+        registry.announce_blob(blob2, peer_a.clone(), 1024).unwrap();
 
         // Peer B has blob1 and blob3
-        registry.announce_blob(blob1, peer_b.clone(), 1024);
-        registry.announce_blob(blob3, peer_b.clone(), 1024);
+        registry.announce_blob(blob1, peer_b.clone(), 1024).unwrap();
+        registry.announce_blob(blob3, peer_b.clone(), 1024).unwrap();
 
         // Peer C has only blob1
-        registry.announce_blob(blob1, peer_c.clone(), 1024);
+        registry.announce_blob(blob1, peer_c.clone(), 1024).unwrap();
 
         // Query for blob1 and blob2
         let result = registry.find_peers_with_all(&[blob1, blob2]);
@@ -315,9 +569,9 @@ mod tests {
         let peer_a = create_test_did();
         let peer_b = create_test_did();
 
-        registry.announce_blob(blob1, peer_a.clone(), 1024);
-        registry.announce_blob(blob1, peer_b.clone(), 1024);
-        registry.announce_blob(blob2, peer_a.clone(), 2048);
+        registry.announce_blob(blob1, peer_a.clone(), 1024).unwrap();
+        registry.announce_blob(blob1, peer_b.clone(), 1024).unwrap();
+        registry.announce_blob(blob2, peer_a.clone(), 2048).unwrap();
 
         assert_eq!(registry.blob_count(), 2);
         assert_eq!(registry.location_count(), 3);
@@ -335,16 +589,11 @@ mod tests {
         let blob_hash = [1u8; 32];
         let peer = create_test_did();
 
-        registry.announce_blob(blob_hash, peer, 1024);
+        registry.announce_blob(blob_hash, peer, 1024).unwrap();
         assert_eq!(registry.blob_count(), 1);
 
-        // Manually mark as expired (can't wait 24 hours in test)
-        // In real usage, expired entries would be filtered by get_peers_with_blob()
-        // and removed by cleanup_expired()
-
-        // This test demonstrates the API exists
-        registry.cleanup_expired();
         // Fresh announcements won't be cleaned up
+        registry.cleanup_expired();
         assert_eq!(registry.blob_count(), 1);
     }
 
@@ -355,5 +604,155 @@ mod tests {
 
         let peers = registry.get_peers_with_blob(&blob_hash);
         assert_eq!(peers.len(), 0);
+    }
+
+    // === New tests for size limits ===
+
+    #[test]
+    fn test_reject_blob_too_large() {
+        let config = create_test_config();
+        let mut registry = BlobLocationRegistry::with_config(config);
+        let blob_hash = [1u8; 32];
+        let peer = create_test_did();
+
+        // Try to announce a blob larger than max_blob_size (1MB)
+        let result = registry.announce_blob(blob_hash, peer, 2 * 1024 * 1024);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            BlobRegistryError::BlobTooLarge { .. }
+        ));
+        assert_eq!(registry.rejected_stats().0, 1);
+    }
+
+    #[test]
+    fn test_reject_peer_quota_exceeded() {
+        let config = create_test_config();
+        let mut registry = BlobLocationRegistry::with_config(config);
+        let peer = create_test_did();
+
+        // Announce blobs up to the per-peer quota (2MB)
+        registry.announce_blob([1u8; 32], peer.clone(), 1024 * 1024).unwrap();
+        registry.announce_blob([2u8; 32], peer.clone(), 1024 * 1024).unwrap();
+
+        // This should exceed the quota
+        let result = registry.announce_blob([3u8; 32], peer, 1024 * 1024);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            BlobRegistryError::PeerQuotaExceeded { .. }
+        ));
+        assert_eq!(registry.rejected_stats().1, 1);
+    }
+
+    #[test]
+    fn test_lru_eviction_on_capacity() {
+        let config = BlobRegistryConfig {
+            max_blob_size: 1024,
+            max_registry_size: 2048, // Only room for 2 blobs of 1024 bytes
+            max_per_peer_size: 10 * 1024 * 1024,
+        };
+        let mut registry = BlobLocationRegistry::with_config(config);
+
+        let peer1 = create_test_did();
+        let peer2 = create_test_did();
+        let peer3 = create_test_did();
+
+        // Add three blobs, each from a different peer (to avoid per-peer quota issues)
+        registry.announce_blob([1u8; 32], peer1.clone(), 1024).unwrap();
+        registry.announce_blob([2u8; 32], peer2.clone(), 1024).unwrap();
+
+        // Adding a third should evict the oldest
+        registry.announce_blob([3u8; 32], peer3.clone(), 1024).unwrap();
+
+        // Should have evicted the first blob
+        assert_eq!(registry.evicted_count(), 1);
+        assert_eq!(registry.location_count(), 2);
+
+        // First blob should be gone
+        let peers1 = registry.get_peers_with_blob(&[1u8; 32]);
+        assert_eq!(peers1.len(), 0);
+
+        // Second and third should still be present
+        let peers2 = registry.get_peers_with_blob(&[2u8; 32]);
+        let peers3 = registry.get_peers_with_blob(&[3u8; 32]);
+        assert_eq!(peers2.len(), 1);
+        assert_eq!(peers3.len(), 1);
+    }
+
+    #[test]
+    fn test_total_size_tracking() {
+        let mut registry = BlobLocationRegistry::new();
+        let peer = create_test_did();
+
+        registry.announce_blob([1u8; 32], peer.clone(), 1024).unwrap();
+        assert_eq!(registry.total_size(), 1024);
+
+        registry.announce_blob([2u8; 32], peer.clone(), 2048).unwrap();
+        assert_eq!(registry.total_size(), 3072);
+
+        // Update first blob with smaller size
+        registry.announce_blob([1u8; 32], peer.clone(), 512).unwrap();
+        assert_eq!(registry.total_size(), 2560); // 512 + 2048
+    }
+
+    #[test]
+    fn test_per_peer_size_tracking() {
+        let mut registry = BlobLocationRegistry::new();
+        let peer1 = create_test_did();
+        let peer2 = create_test_did();
+
+        registry.announce_blob([1u8; 32], peer1.clone(), 1024).unwrap();
+        registry.announce_blob([2u8; 32], peer1.clone(), 2048).unwrap();
+        registry.announce_blob([3u8; 32], peer2.clone(), 512).unwrap();
+
+        assert_eq!(registry.peer_size(&peer1), 3072);
+        assert_eq!(registry.peer_size(&peer2), 512);
+
+        // Remove peer1
+        registry.remove_peer(&peer1);
+        assert_eq!(registry.peer_size(&peer1), 0);
+        assert_eq!(registry.peer_size(&peer2), 512);
+    }
+
+    #[test]
+    fn test_update_within_quota() {
+        // Config: max_blob_size=1MB, max_per_peer_size=2MB
+        let config = create_test_config();
+        let mut registry = BlobLocationRegistry::with_config(config);
+        let peer = create_test_did();
+
+        // Use most of quota with two blobs (1MB + 0.5MB = 1.5MB of 2MB quota)
+        registry.announce_blob([1u8; 32], peer.clone(), 1024 * 1024).unwrap();
+        registry.announce_blob([2u8; 32], peer.clone(), 512 * 1024).unwrap();
+
+        // Update first blob with same size should work (no net increase)
+        let result = registry.announce_blob([1u8; 32], peer.clone(), 1024 * 1024);
+        assert!(result.is_ok(), "Updating blob with same size should succeed");
+
+        // Update first blob with smaller size should work
+        let result = registry.announce_blob([1u8; 32], peer.clone(), 512 * 1024);
+        assert!(result.is_ok(), "Updating blob with smaller size should succeed");
+    }
+
+    #[test]
+    fn test_with_config() {
+        let config = BlobRegistryConfig {
+            max_blob_size: 5000,
+            max_registry_size: 50000,
+            max_per_peer_size: 15000,
+        };
+
+        let mut registry = BlobLocationRegistry::with_config(config);
+        let peer = create_test_did();
+
+        // Should accept blob up to 5000 bytes
+        registry.announce_blob([1u8; 32], peer.clone(), 5000).unwrap();
+
+        // Should reject blob over 5000 bytes
+        let result = registry.announce_blob([2u8; 32], peer, 5001);
+        assert!(result.is_err());
     }
 }

--- a/icn/crates/icn-net/src/blob_registry.rs
+++ b/icn/crates/icn-net/src/blob_registry.rs
@@ -34,7 +34,7 @@
 use icn_gossip::types::ContentHash;
 use icn_identity::Did;
 use icn_obs::metrics::network::{
-    blob_evicted_inc, blob_rejected_inc, blob_registry_entries_set, blob_registry_size_set,
+    blob_evicted_inc, blob_registry_entries_set, blob_registry_size_set, blob_rejected_inc,
     BlobRejectionReason,
 };
 use std::collections::{HashMap, VecDeque};
@@ -457,7 +457,7 @@ mod tests {
 
     fn create_test_config() -> BlobRegistryConfig {
         BlobRegistryConfig {
-            max_blob_size: 1024 * 1024,      // 1MB
+            max_blob_size: 1024 * 1024,          // 1MB
             max_registry_size: 10 * 1024 * 1024, // 10MB
             max_per_peer_size: 2 * 1024 * 1024,  // 2MB
         }
@@ -470,7 +470,9 @@ mod tests {
         let peer1 = create_test_did();
 
         // Announce blob
-        registry.announce_blob(blob_hash, peer1.clone(), 1024).unwrap();
+        registry
+            .announce_blob(blob_hash, peer1.clone(), 1024)
+            .unwrap();
 
         // Query should return the peer
         let peers = registry.get_peers_with_blob(&blob_hash);
@@ -487,8 +489,12 @@ mod tests {
         let peer2 = create_test_did();
 
         // Multiple peers announce same blob
-        registry.announce_blob(blob_hash, peer1.clone(), 1024).unwrap();
-        registry.announce_blob(blob_hash, peer2.clone(), 2048).unwrap();
+        registry
+            .announce_blob(blob_hash, peer1.clone(), 1024)
+            .unwrap();
+        registry
+            .announce_blob(blob_hash, peer2.clone(), 2048)
+            .unwrap();
 
         let peers = registry.get_peers_with_blob(&blob_hash);
         assert_eq!(peers.len(), 2);
@@ -501,13 +507,17 @@ mod tests {
         let peer = create_test_did();
 
         // First announcement
-        registry.announce_blob(blob_hash, peer.clone(), 1024).unwrap();
+        registry
+            .announce_blob(blob_hash, peer.clone(), 1024)
+            .unwrap();
         let peers1 = registry.get_peers_with_blob(&blob_hash);
         assert_eq!(peers1.len(), 1);
         assert_eq!(peers1[0].size_bytes, 1024);
 
         // Update announcement (different size)
-        registry.announce_blob(blob_hash, peer.clone(), 2048).unwrap();
+        registry
+            .announce_blob(blob_hash, peer.clone(), 2048)
+            .unwrap();
         let peers2 = registry.get_peers_with_blob(&blob_hash);
         assert_eq!(peers2.len(), 1); // Still one entry
         assert_eq!(peers2[0].size_bytes, 2048); // Size updated
@@ -633,8 +643,12 @@ mod tests {
         let peer = create_test_did();
 
         // Announce blobs up to the per-peer quota (2MB)
-        registry.announce_blob([1u8; 32], peer.clone(), 1024 * 1024).unwrap();
-        registry.announce_blob([2u8; 32], peer.clone(), 1024 * 1024).unwrap();
+        registry
+            .announce_blob([1u8; 32], peer.clone(), 1024 * 1024)
+            .unwrap();
+        registry
+            .announce_blob([2u8; 32], peer.clone(), 1024 * 1024)
+            .unwrap();
 
         // This should exceed the quota
         let result = registry.announce_blob([3u8; 32], peer, 1024 * 1024);
@@ -661,11 +675,17 @@ mod tests {
         let peer3 = create_test_did();
 
         // Add three blobs, each from a different peer (to avoid per-peer quota issues)
-        registry.announce_blob([1u8; 32], peer1.clone(), 1024).unwrap();
-        registry.announce_blob([2u8; 32], peer2.clone(), 1024).unwrap();
+        registry
+            .announce_blob([1u8; 32], peer1.clone(), 1024)
+            .unwrap();
+        registry
+            .announce_blob([2u8; 32], peer2.clone(), 1024)
+            .unwrap();
 
         // Adding a third should evict the oldest
-        registry.announce_blob([3u8; 32], peer3.clone(), 1024).unwrap();
+        registry
+            .announce_blob([3u8; 32], peer3.clone(), 1024)
+            .unwrap();
 
         // Should have evicted the first blob
         assert_eq!(registry.evicted_count(), 1);
@@ -687,14 +707,20 @@ mod tests {
         let mut registry = BlobLocationRegistry::new();
         let peer = create_test_did();
 
-        registry.announce_blob([1u8; 32], peer.clone(), 1024).unwrap();
+        registry
+            .announce_blob([1u8; 32], peer.clone(), 1024)
+            .unwrap();
         assert_eq!(registry.total_size(), 1024);
 
-        registry.announce_blob([2u8; 32], peer.clone(), 2048).unwrap();
+        registry
+            .announce_blob([2u8; 32], peer.clone(), 2048)
+            .unwrap();
         assert_eq!(registry.total_size(), 3072);
 
         // Update first blob with smaller size
-        registry.announce_blob([1u8; 32], peer.clone(), 512).unwrap();
+        registry
+            .announce_blob([1u8; 32], peer.clone(), 512)
+            .unwrap();
         assert_eq!(registry.total_size(), 2560); // 512 + 2048
     }
 
@@ -704,9 +730,15 @@ mod tests {
         let peer1 = create_test_did();
         let peer2 = create_test_did();
 
-        registry.announce_blob([1u8; 32], peer1.clone(), 1024).unwrap();
-        registry.announce_blob([2u8; 32], peer1.clone(), 2048).unwrap();
-        registry.announce_blob([3u8; 32], peer2.clone(), 512).unwrap();
+        registry
+            .announce_blob([1u8; 32], peer1.clone(), 1024)
+            .unwrap();
+        registry
+            .announce_blob([2u8; 32], peer1.clone(), 2048)
+            .unwrap();
+        registry
+            .announce_blob([3u8; 32], peer2.clone(), 512)
+            .unwrap();
 
         assert_eq!(registry.peer_size(&peer1), 3072);
         assert_eq!(registry.peer_size(&peer2), 512);
@@ -725,16 +757,26 @@ mod tests {
         let peer = create_test_did();
 
         // Use most of quota with two blobs (1MB + 0.5MB = 1.5MB of 2MB quota)
-        registry.announce_blob([1u8; 32], peer.clone(), 1024 * 1024).unwrap();
-        registry.announce_blob([2u8; 32], peer.clone(), 512 * 1024).unwrap();
+        registry
+            .announce_blob([1u8; 32], peer.clone(), 1024 * 1024)
+            .unwrap();
+        registry
+            .announce_blob([2u8; 32], peer.clone(), 512 * 1024)
+            .unwrap();
 
         // Update first blob with same size should work (no net increase)
         let result = registry.announce_blob([1u8; 32], peer.clone(), 1024 * 1024);
-        assert!(result.is_ok(), "Updating blob with same size should succeed");
+        assert!(
+            result.is_ok(),
+            "Updating blob with same size should succeed"
+        );
 
         // Update first blob with smaller size should work
         let result = registry.announce_blob([1u8; 32], peer.clone(), 512 * 1024);
-        assert!(result.is_ok(), "Updating blob with smaller size should succeed");
+        assert!(
+            result.is_ok(),
+            "Updating blob with smaller size should succeed"
+        );
     }
 
     #[test]
@@ -749,7 +791,9 @@ mod tests {
         let peer = create_test_did();
 
         // Should accept blob up to 5000 bytes
-        registry.announce_blob([1u8; 32], peer.clone(), 5000).unwrap();
+        registry
+            .announce_blob([1u8; 32], peer.clone(), 5000)
+            .unwrap();
 
         // Should reject blob over 5000 bytes
         let result = registry.announce_blob([2u8; 32], peer, 5001);

--- a/icn/crates/icn-net/src/blob_registry.rs
+++ b/icn/crates/icn-net/src/blob_registry.rs
@@ -59,6 +59,9 @@ pub enum BlobRegistryError {
 }
 
 /// Configuration for the blob location registry
+///
+/// NOTE: This struct is duplicated in `icn-core/src/config.rs` for configuration loading.
+/// Keep both definitions in sync when making changes.
 #[derive(Debug, Clone)]
 pub struct BlobRegistryConfig {
     /// Maximum size of a single blob in bytes (default: 10MB)

--- a/icn/crates/icn-net/src/lib.rs
+++ b/icn/crates/icn-net/src/lib.rs
@@ -29,7 +29,9 @@ pub mod turn;
 pub mod version;
 
 pub use actor::{IncomingMessageHandler, NetworkActor, NetworkHandle, NetworkMsg, NetworkStats};
-pub use blob_registry::{BlobLocation, BlobLocationRegistry, BlobRegistryConfig, BlobRegistryError};
+pub use blob_registry::{
+    BlobLocation, BlobLocationRegistry, BlobRegistryConfig, BlobRegistryError,
+};
 pub use candidate::ConnectionCandidate;
 pub use candidate_cache::CandidateCache;
 pub use discovery::{Discovery, PeerInfo};

--- a/icn/crates/icn-net/src/lib.rs
+++ b/icn/crates/icn-net/src/lib.rs
@@ -29,7 +29,7 @@ pub mod turn;
 pub mod version;
 
 pub use actor::{IncomingMessageHandler, NetworkActor, NetworkHandle, NetworkMsg, NetworkStats};
-pub use blob_registry::{BlobLocation, BlobLocationRegistry};
+pub use blob_registry::{BlobLocation, BlobLocationRegistry, BlobRegistryConfig, BlobRegistryError};
 pub use candidate::ConnectionCandidate;
 pub use candidate_cache::CandidateCache;
 pub use discovery::{Discovery, PeerInfo};

--- a/icn/crates/icn-obs/src/metrics/network.rs
+++ b/icn/crates/icn-obs/src/metrics/network.rs
@@ -144,6 +144,23 @@ pub fn init_descriptions() {
         "icn_network_hybrid_verification_failed_total",
         "Total number of hybrid signature verifications that failed"
     );
+    // Blob registry metrics (Issue #570)
+    describe_counter!(
+        "icn_network_blob_rejected_total",
+        "Total number of blob announcements rejected"
+    );
+    describe_counter!(
+        "icn_network_blob_evicted_total",
+        "Total number of blob entries evicted due to capacity limits"
+    );
+    describe_gauge!(
+        "icn_network_blob_registry_size_bytes",
+        "Current total size of all blobs in the registry"
+    );
+    describe_gauge!(
+        "icn_network_blob_registry_entries",
+        "Current number of blob location entries in the registry"
+    );
 }
 
 // Simple counters
@@ -400,4 +417,52 @@ pub fn connections_rejected_untrusted_inc(_peer_did: &str, trust_score: f64) {
         "class" => trust_class.to_string()
     )
     .increment(1);
+}
+
+// Blob registry metrics (Issue #570)
+
+/// Reason for blob announcement rejection
+#[derive(Debug, Clone, Copy)]
+pub enum BlobRejectionReason {
+    /// Blob size exceeds the maximum allowed size
+    TooLarge,
+    /// Peer has exceeded their quota
+    PeerQuotaExceeded,
+}
+
+impl BlobRejectionReason {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::TooLarge => "too_large",
+            Self::PeerQuotaExceeded => "peer_quota_exceeded",
+        }
+    }
+}
+
+/// Increment blob rejection counter with reason
+///
+/// Called when a blob announcement is rejected due to size limits or quotas.
+pub fn blob_rejected_inc(reason: BlobRejectionReason) {
+    counter!(
+        "icn_network_blob_rejected_total",
+        "reason" => reason.as_str()
+    )
+    .increment(1);
+}
+
+/// Increment blob eviction counter
+///
+/// Called when a blob entry is evicted to make room for new entries.
+pub fn blob_evicted_inc() {
+    counter!("icn_network_blob_evicted_total").increment(1);
+}
+
+/// Set the current total size of all blobs in the registry
+pub fn blob_registry_size_set(bytes: u64) {
+    gauge!("icn_network_blob_registry_size_bytes").set(bytes as f64);
+}
+
+/// Set the current number of blob location entries in the registry
+pub fn blob_registry_entries_set(count: usize) {
+    gauge!("icn_network_blob_registry_entries").set(count as f64);
 }


### PR DESCRIPTION
## Summary

- Add configurable size limits to prevent DoS via unbounded blob registry growth
- Per-blob size limit (10MB default), total registry limit (100MB), per-peer quota (10MB)
- LRU eviction when capacity is exceeded
- Add metrics for monitoring rejections and registry state

Closes #570

## Test plan

- [x] Run `cargo test -p icn-net blob_registry` - 15 tests pass
- [x] Run `cargo clippy -p icn-net -p icn-obs` - no warnings
- [x] Run `cargo test -p icn-net -p icn-core --lib` - 188 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)