### PR TITLE
fix(net): Ensure immediate PQ signature verification

### DIFF
--- a/icn/crates/icn-compute/src/actor_runtime.rs
+++ b/icn/crates/icn-compute/src/actor_runtime.rs
@@ -503,30 +503,32 @@ impl StatefulActorRegistry {
                     // This callback may be invoked from within a tokio task (e.g., MigrationManager),
                     // and block_on alone would panic. block_in_place moves other tasks off this
                     // thread before blocking.
-                    tokio::task::block_in_place(|| handle.block_on(async {
-                        let mut actors = actors.write().await;
-                        let info = actors.get_mut(&actor_id).ok_or_else(|| {
-                            ComputeError::Internal(format!(
-                                "Actor {} not found",
-                                hex::encode(actor_id)
-                            ))
-                        })?;
+                    tokio::task::block_in_place(|| {
+                        handle.block_on(async {
+                            let mut actors = actors.write().await;
+                            let info = actors.get_mut(&actor_id).ok_or_else(|| {
+                                ComputeError::Internal(format!(
+                                    "Actor {} not found",
+                                    hex::encode(actor_id)
+                                ))
+                            })?;
 
-                        if info.state != StatefulActorState::Running {
-                            return Err(ComputeError::Internal(format!(
-                                "Cannot pause actor {} in state {:?}",
-                                hex::encode(actor_id),
-                                info.state
-                            )));
-                        }
+                            if info.state != StatefulActorState::Running {
+                                return Err(ComputeError::Internal(format!(
+                                    "Cannot pause actor {} in state {:?}",
+                                    hex::encode(actor_id),
+                                    info.state
+                                )));
+                            }
 
-                        info.state = StatefulActorState::Paused {
-                            reason,
-                            paused_at: now_millis(),
-                        };
+                            info.state = StatefulActorState::Paused {
+                                reason,
+                                paused_at: now_millis(),
+                            };
 
-                        Ok(())
-                    }))
+                            Ok(())
+                        })
+                    })
                 }
 
                 ActorRuntimeCommand::Resume { actor_id } => {
@@ -534,26 +536,28 @@ impl StatefulActorRegistry {
                         .map_err(|e| ComputeError::Internal(e.to_string()))?;
 
                     // SAFETY: Use block_in_place to safely run blocking code from async context.
-                    tokio::task::block_in_place(|| handle.block_on(async {
-                        let mut actors = actors.write().await;
-                        let info = actors.get_mut(&actor_id).ok_or_else(|| {
-                            ComputeError::Internal(format!(
-                                "Actor {} not found",
-                                hex::encode(actor_id)
-                            ))
-                        })?;
+                    tokio::task::block_in_place(|| {
+                        handle.block_on(async {
+                            let mut actors = actors.write().await;
+                            let info = actors.get_mut(&actor_id).ok_or_else(|| {
+                                ComputeError::Internal(format!(
+                                    "Actor {} not found",
+                                    hex::encode(actor_id)
+                                ))
+                            })?;
 
-                        if !matches!(info.state, StatefulActorState::Paused { .. }) {
-                            return Err(ComputeError::Internal(format!(
-                                "Cannot resume actor {} in state {:?}",
-                                hex::encode(actor_id),
-                                info.state
-                            )));
-                        }
+                            if !matches!(info.state, StatefulActorState::Paused { .. }) {
+                                return Err(ComputeError::Internal(format!(
+                                    "Cannot resume actor {} in state {:?}",
+                                    hex::encode(actor_id),
+                                    info.state
+                                )));
+                            }
 
-                        info.state = StatefulActorState::Running;
-                        Ok(())
-                    }))
+                            info.state = StatefulActorState::Running;
+                            Ok(())
+                        })
+                    })
                 }
 
                 ActorRuntimeCommand::Restore {
@@ -564,21 +568,23 @@ impl StatefulActorRegistry {
                         .map_err(|e| ComputeError::Internal(e.to_string()))?;
 
                     // SAFETY: Use block_in_place to safely run blocking code from async context.
-                    tokio::task::block_in_place(|| handle.block_on(async {
-                        let mut actors = actors.write().await;
+                    tokio::task::block_in_place(|| {
+                        handle.block_on(async {
+                            let mut actors = actors.write().await;
 
-                        // Create new entry or update existing
-                        let info = actors.entry(actor_id).or_insert_with(|| {
-                            StatefulActorInfo::new(actor_id, ActorMode::default())
-                        });
+                            // Create new entry or update existing
+                            let info = actors.entry(actor_id).or_insert_with(|| {
+                                StatefulActorInfo::new(actor_id, ActorMode::default())
+                            });
 
-                        info.current_state = checkpoint.state;
-                        info.last_checkpoint_seq = checkpoint.sequence;
-                        info.state = StatefulActorState::Running;
-                        info.memory_bytes = info.current_state.len() as u64;
+                            info.current_state = checkpoint.state;
+                            info.last_checkpoint_seq = checkpoint.sequence;
+                            info.state = StatefulActorState::Running;
+                            info.memory_bytes = info.current_state.len() as u64;
 
-                        Ok(())
-                    }))
+                            Ok(())
+                        })
+                    })
                 }
 
                 ActorRuntimeCommand::Terminate { actor_id, reason } => {
@@ -586,22 +592,24 @@ impl StatefulActorRegistry {
                         .map_err(|e| ComputeError::Internal(e.to_string()))?;
 
                     // SAFETY: Use block_in_place to safely run blocking code from async context.
-                    tokio::task::block_in_place(|| handle.block_on(async {
-                        let mut actors = actors.write().await;
-                        let info = actors.get_mut(&actor_id).ok_or_else(|| {
-                            ComputeError::Internal(format!(
-                                "Actor {} not found",
-                                hex::encode(actor_id)
-                            ))
-                        })?;
+                    tokio::task::block_in_place(|| {
+                        handle.block_on(async {
+                            let mut actors = actors.write().await;
+                            let info = actors.get_mut(&actor_id).ok_or_else(|| {
+                                ComputeError::Internal(format!(
+                                    "Actor {} not found",
+                                    hex::encode(actor_id)
+                                ))
+                            })?;
 
-                        info.state = StatefulActorState::Terminated {
-                            reason,
-                            terminated_at: now_millis(),
-                        };
+                            info.state = StatefulActorState::Terminated {
+                                reason,
+                                terminated_at: now_millis(),
+                            };
 
-                        Ok(())
-                    }))
+                            Ok(())
+                        })
+                    })
                 }
 
                 ActorRuntimeCommand::GetState { actor_id: _ } => {

--- a/icn/crates/icn-gateway/src/api/trust.rs
+++ b/icn/crates/icn-gateway/src/api/trust.rs
@@ -166,7 +166,9 @@ pub async fn get_trust_network(
         .map_err(|e| GatewayError::BadRequest(format!("Invalid DID: {e}")))?;
 
     let max_distance = query.depth.unwrap_or(2).min(5); // Cap at 5 hops
-    let network = trust_manager.get_trust_network_async(&did, max_distance).await;
+    let network = trust_manager
+        .get_trust_network_async(&did, max_distance)
+        .await;
 
     Ok(HttpResponse::Ok().json(network))
 }

--- a/icn/crates/icn-net/src/handlers/signed.rs
+++ b/icn/crates/icn-net/src/handlers/signed.rs
@@ -49,7 +49,10 @@ impl ConnectionContext {
         }
 
         // Signature valid, now check for replay attack
-        match self.replay_guard.write().await.check(envelope) {
+        // Use check_replay_only since we already verified the signature above
+        // This avoids redundant signature verification and ensures immediate PQ
+        // verification (via verify_with_cached_pq_key) is the only path used
+        match self.replay_guard.write().await.check_replay_only(envelope) {
             Ok(()) => {
                 debug!(
                     "Verified signed message from {} (seq={}, type={:?})",

--- a/icn/crates/icn-net/src/replay_guard.rs
+++ b/icn/crates/icn-net/src/replay_guard.rs
@@ -297,81 +297,11 @@ impl ReplayGuard {
     ///
     /// This allows some out-of-order delivery while preventing replays.
     pub fn check(&mut self, envelope: &SignedEnvelope) -> Result<()> {
-        // Ensure initialized for persistent mode
-        if !self.initialized.load(Ordering::Acquire) {
-            self.load_and_apply_safety_gap()?;
-        }
-
         // 1. Verify signature and age
         envelope.verify(self.max_clock_skew)?;
 
-        // 2. Get or create sequence window for this sender
-        let window = self
-            .sequences
-            .entry(envelope.from.clone())
-            .or_insert_with(SequenceWindow::new);
-
-        // 3. Check if sequence is finalized (CRITICAL: prevents replay after processing)
-        if window.finalized.contains_key(&envelope.sequence) {
-            bail!(
-                "Replay attempt detected from {}: sequence {} is finalized (processed)",
-                envelope.from.as_str(),
-                envelope.sequence
-            );
-        }
-
-        // 4. Check against floor_seq (CRITICAL: prevents replay after restart)
-        // After restart, floor_seq is set to max_seq + RESTART_SAFETY_GAP
-        // All sequences at or below this are rejected (bloom filter is lost on restart)
-        if envelope.sequence <= window.floor_seq {
-            bail!(
-                "Replay detected from {}: sequence {} already seen (floor: {})",
-                envelope.from.as_str(),
-                envelope.sequence,
-                window.floor_seq
-            );
-        }
-
-        // 5. Check sequence number against Bloom filter
-        let seq_hash = hash_sequence(envelope.sequence);
-        if envelope.sequence <= window.max_seq {
-            // Potentially out-of-order or replay
-            if window.recent.contains(&seq_hash) {
-                bail!(
-                    "Replay detected from {}: sequence {} already seen (max: {})",
-                    envelope.from.as_str(),
-                    envelope.sequence,
-                    window.max_seq
-                );
-            }
-            // Not in filter: accept as out-of-order
-        }
-
-        // 6. Update window
-        let max_seq_changed = envelope.sequence > window.max_seq;
-        if max_seq_changed {
-            window.max_seq = envelope.sequence;
-        }
-        window.insert_sequence(&seq_hash);
-        window.last_update = Instant::now();
-
-        // 7. Persist max_seq if changed (best-effort: safety gap handles missed writes)
-        if max_seq_changed {
-            if let Err(e) = self.persist_max_seq(&envelope.from, envelope.sequence) {
-                tracing::warn!(
-                    peer = %envelope.from,
-                    seq = envelope.sequence,
-                    error = %e,
-                    "Failed to persist max_seq (continuing anyway)"
-                );
-                // Note: We continue despite persistence failure because:
-                // - The message has been validated and should be processed
-                // - The safety gap on restart handles missed persistence
-                // - Better to process valid messages than fail on storage issues
-            }
-        }
-
-        Ok(())
+        // 2. Perform replay detection (signature already verified, so use check_replay_only)
+        self.check_replay_only(envelope)
     }
 
     /// Check if message is fresh (not replayed) without verifying signature
@@ -1422,5 +1352,98 @@ mod tests {
         let result = guard.check_replay_only(&envelope);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("finalized"));
+    }
+
+    #[test]
+    fn test_check_and_check_replay_only_share_state() {
+        // Verifies that check() and check_replay_only() share the same
+        // replay detection state (since check() now calls check_replay_only())
+        let mut guard = ReplayGuard::new(300, 3600);
+        let keypair = KeyPair::generate().unwrap();
+
+        // Create two envelopes with different sequences
+        let envelope1 = SignedEnvelope::new(
+            keypair.did(),
+            &keypair,
+            1,
+            PayloadType::Gossip,
+            b"msg1".to_vec(),
+        )
+        .unwrap();
+
+        let envelope2 = SignedEnvelope::new(
+            keypair.did(),
+            &keypair,
+            2,
+            PayloadType::Gossip,
+            b"msg2".to_vec(),
+        )
+        .unwrap();
+
+        // Use check() for first envelope
+        assert!(guard.check(&envelope1).is_ok());
+
+        // Use check_replay_only() for second envelope
+        assert!(guard.check_replay_only(&envelope2).is_ok());
+
+        // Both sequences should now be tracked
+        assert_eq!(guard.get_max_seq(keypair.did()), Some(2));
+
+        // Replaying envelope1 via check_replay_only should fail
+        let result1 = guard.check_replay_only(&envelope1);
+        assert!(result1.is_err());
+        assert!(result1.unwrap_err().to_string().contains("Replay detected"));
+
+        // Replaying envelope2 via check() should also fail
+        let result2 = guard.check(&envelope2);
+        assert!(result2.is_err());
+        assert!(result2.unwrap_err().to_string().contains("Replay detected"));
+    }
+
+    #[test]
+    fn test_check_calls_check_replay_only_internally() {
+        // Verifies that check() properly calls check_replay_only() by checking
+        // that state is consistent between both methods
+        let mut guard = ReplayGuard::new(300, 3600);
+        let keypair = KeyPair::generate().unwrap();
+
+        // Create a sequence of envelopes
+        let mut envelopes = Vec::new();
+        for seq in 1..=5 {
+            envelopes.push(
+                SignedEnvelope::new(
+                    keypair.did(),
+                    &keypair,
+                    seq,
+                    PayloadType::Gossip,
+                    format!("msg{}", seq).as_bytes().to_vec(),
+                )
+                .unwrap(),
+            );
+        }
+
+        // Alternate between check() and check_replay_only()
+        assert!(guard.check(&envelopes[0]).is_ok()); // seq 1 via check()
+        assert!(guard.check_replay_only(&envelopes[1]).is_ok()); // seq 2 via check_replay_only()
+        assert!(guard.check(&envelopes[2]).is_ok()); // seq 3 via check()
+        assert!(guard.check_replay_only(&envelopes[3]).is_ok()); // seq 4 via check_replay_only()
+        assert!(guard.check(&envelopes[4]).is_ok()); // seq 5 via check()
+
+        // All 5 sequences should be tracked
+        assert_eq!(guard.get_max_seq(keypair.did()), Some(5));
+
+        // All should be rejected as replays regardless of which method is used
+        for (i, envelope) in envelopes.iter().enumerate() {
+            let result = if i % 2 == 0 {
+                guard.check(envelope)
+            } else {
+                guard.check_replay_only(envelope)
+            };
+            assert!(
+                result.is_err(),
+                "Sequence {} should be rejected as replay",
+                i + 1
+            );
+        }
     }
 }

--- a/icn/crates/icn-net/src/replay_guard.rs
+++ b/icn/crates/icn-net/src/replay_guard.rs
@@ -374,6 +374,91 @@ impl ReplayGuard {
         Ok(())
     }
 
+    /// Check if message is fresh (not replayed) without verifying signature
+    ///
+    /// Use this when signature has already been verified by the caller
+    /// (e.g., via `verify_with_cached_pq_key()` in the signed message handler).
+    ///
+    /// This method performs all replay detection checks but skips signature
+    /// verification to avoid redundant cryptographic operations.
+    ///
+    /// # When to use
+    ///
+    /// - Use `check()` when you need both signature verification and replay detection
+    /// - Use `check_replay_only()` when signature was already verified elsewhere
+    ///
+    /// # Safety
+    ///
+    /// Caller MUST ensure the signature has been verified before calling this method.
+    /// Failure to verify signatures before replay checking could allow attackers
+    /// to inject forged messages that bypass replay detection.
+    pub fn check_replay_only(&mut self, envelope: &SignedEnvelope) -> Result<()> {
+        // Ensure initialized for persistent mode
+        if !self.initialized.load(Ordering::Acquire) {
+            self.load_and_apply_safety_gap()?;
+        }
+
+        // Note: Signature verification is SKIPPED - caller must have already verified
+
+        // Get or create sequence window for this sender
+        let window = self
+            .sequences
+            .entry(envelope.from.clone())
+            .or_insert_with(SequenceWindow::new);
+
+        // Check if sequence is finalized (CRITICAL: prevents replay after processing)
+        if window.finalized.contains_key(&envelope.sequence) {
+            bail!(
+                "Replay attempt detected from {}: sequence {} is finalized (processed)",
+                envelope.from.as_str(),
+                envelope.sequence
+            );
+        }
+
+        // Check against floor_seq (CRITICAL: prevents replay after restart)
+        if envelope.sequence <= window.floor_seq {
+            bail!(
+                "Replay detected from {}: sequence {} already seen (floor: {})",
+                envelope.from.as_str(),
+                envelope.sequence,
+                window.floor_seq
+            );
+        }
+
+        // Check sequence number against Bloom filter
+        let seq_hash = hash_sequence(envelope.sequence);
+        if envelope.sequence <= window.max_seq && window.recent.contains(&seq_hash) {
+            bail!(
+                "Replay detected from {}: sequence {} already seen (max: {})",
+                envelope.from.as_str(),
+                envelope.sequence,
+                window.max_seq
+            );
+        }
+
+        // Update window
+        let max_seq_changed = envelope.sequence > window.max_seq;
+        if max_seq_changed {
+            window.max_seq = envelope.sequence;
+        }
+        window.insert_sequence(&seq_hash);
+        window.last_update = Instant::now();
+
+        // Persist max_seq if changed
+        if max_seq_changed {
+            if let Err(e) = self.persist_max_seq(&envelope.from, envelope.sequence) {
+                tracing::warn!(
+                    peer = %envelope.from,
+                    seq = envelope.sequence,
+                    error = %e,
+                    "Failed to persist max_seq (continuing anyway)"
+                );
+            }
+        }
+
+        Ok(())
+    }
+
     /// Finalize a sequence number (permanently prevent replay)
     ///
     /// Call this after successfully processing a message (e.g., ledger entry written).
@@ -1254,5 +1339,88 @@ mod tests {
 
         assert!(guard.check(&envelope).is_ok());
         assert!(guard.is_initialized());
+    }
+
+    #[test]
+    fn test_check_replay_only_skips_signature_verification() {
+        let mut guard = ReplayGuard::new(300, 3600);
+        let keypair = KeyPair::generate().unwrap();
+
+        // Create a valid envelope
+        let mut envelope = SignedEnvelope::new(
+            keypair.did(),
+            &keypair,
+            1,
+            PayloadType::Gossip,
+            b"test".to_vec(),
+        )
+        .unwrap();
+
+        // Tamper with the signature (would fail signature verification)
+        envelope.signature[0] ^= 0xFF;
+
+        // check() should fail because signature is invalid
+        let result = guard.check(&envelope);
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("signature"),
+            "Should fail signature verification"
+        );
+
+        // But check_replay_only() should succeed because it skips signature
+        // (caller is responsible for verifying signature first)
+        assert!(
+            guard.check_replay_only(&envelope).is_ok(),
+            "check_replay_only should skip signature verification"
+        );
+    }
+
+    #[test]
+    fn test_check_replay_only_still_detects_replays() {
+        let mut guard = ReplayGuard::new(300, 3600);
+        let keypair = KeyPair::generate().unwrap();
+
+        let envelope = SignedEnvelope::new(
+            keypair.did(),
+            &keypair,
+            1,
+            PayloadType::Gossip,
+            b"test".to_vec(),
+        )
+        .unwrap();
+
+        // First delivery via check_replay_only: OK
+        assert!(guard.check_replay_only(&envelope).is_ok());
+
+        // Replay via check_replay_only: Rejected
+        let result = guard.check_replay_only(&envelope);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Replay detected"));
+    }
+
+    #[test]
+    fn test_check_replay_only_respects_finalization() {
+        let mut guard = ReplayGuard::new(300, 3600);
+        let keypair = KeyPair::generate().unwrap();
+
+        let envelope = SignedEnvelope::new(
+            keypair.did(),
+            &keypair,
+            1,
+            PayloadType::Gossip,
+            b"test".to_vec(),
+        )
+        .unwrap();
+
+        // First delivery
+        assert!(guard.check_replay_only(&envelope).is_ok());
+
+        // Finalize
+        assert!(guard.finalize(keypair.did(), 1).is_ok());
+
+        // Replay of finalized sequence: Rejected
+        let result = guard.check_replay_only(&envelope);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("finalized"));
     }
 }


### PR DESCRIPTION
## Summary

- Add `check_replay_only()` method to ReplayGuard that skips signature verification
- Update signed message handler to use `check_replay_only()` since it already verifies signatures via `verify_with_cached_pq_key()`
- This ensures immediate PQ verification when cached key is available, without redundant signature checks

Closes #569

## Details

The issue was that signature verification was happening twice:
1. `verify_with_cached_pq_key()` - does immediate PQ verification if key cached
2. `replay_guard.check()` - verified signature again (redundant, and using deferred mode)

Now the flow is:
1. `verify_with_cached_pq_key()` - immediate PQ verification if key cached
2. `replay_guard.check_replay_only()` - only checks replay, no signature verification

## Test plan

- [x] Run `cargo test -p icn-net --lib check_replay_only` - 3 new tests pass
- [x] Run `cargo test -p icn-net --lib` - all 184 tests pass
- [x] Run `cargo clippy -p icn-net` - no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)