### PR TITLE
docs(safety): Add SAFETY comments to blocking async patterns

### DIFF
--- a/icn/crates/icn-core/src/supervisor/init_ledger.rs
+++ b/icn/crates/icn-core/src/supervisor/init_ledger.rs
@@ -137,7 +137,9 @@ pub async fn init_ledger_services(
             // Use timeout-based lock acquisition to balance availability with security.
             let timeout_duration = Duration::from_millis(TREASURY_VALIDATION_LOCK_TIMEOUT_MS);
 
-            // Use block_in_place to acquire async lock in sync validation context
+            // SAFETY: Use block_in_place to acquire async lock in sync validation context.
+            // The validation callback is sync (required by ledger API), but treasury access
+            // is async. block_in_place moves other tokio tasks off this thread before blocking.
             let validation_result = tokio::task::block_in_place(|| {
                 let rt = tokio::runtime::Handle::current();
                 rt.block_on(async {

--- a/icn/crates/icn-core/src/supervisor/shutdown.rs
+++ b/icn/crates/icn-core/src/supervisor/shutdown.rs
@@ -63,7 +63,9 @@ async fn export_state(
 
     // Export network state
     if let Some(network_handle) = network_handle {
-        // Need to use blocking context for async export_state
+        // SAFETY: Use block_in_place to safely call async export_state from sync context.
+        // This moves other tokio tasks off the current thread before blocking.
+        // catch_unwind handles any panics from runtime state issues during shutdown.
         match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             tokio::task::block_in_place(|| {
                 tokio::runtime::Handle::current()

--- a/icn/crates/icn-ledger/src/fork_resolution.rs
+++ b/icn/crates/icn-ledger/src/fork_resolution.rs
@@ -159,7 +159,8 @@ impl ForkResolver {
             .ok_or_else(|| anyhow!("Trust graph required for trust-weighted resolution"))?;
 
         // Compute trust scores for both authors
-        // Use block_in_place to handle async lock from sync context (may be called from tokio runtime)
+        // SAFETY: Use block_in_place to handle async lock from sync context.
+        // This may be called from tokio runtime; block_in_place moves other tasks off this thread.
         let trust_graph_clone = trust_graph.clone();
         let author1 = entry1.author.clone();
         let author2 = entry2.author.clone();
@@ -249,7 +250,8 @@ impl ForkResolver {
 
         // Trust component (40% weight)
         if let Some(ref trust_graph) = self.trust_graph {
-            // Use block_in_place to handle async lock from sync context (may be called from tokio runtime)
+            // SAFETY: Use block_in_place to handle async lock from sync context.
+            // This may be called from tokio runtime; block_in_place moves other tasks off this thread.
             let trust_graph_clone = trust_graph.clone();
             let author_clone = entry.author.clone();
             let trust = tokio::task::block_in_place(|| {

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -2162,7 +2162,8 @@ impl Ledger {
                 entry2: conflicting_hash.as_bytes().try_into().unwrap_or([0u8; 32]),
             };
 
-            // Report violation using block_in_place (may be called from tokio runtime)
+            // SAFETY: Use block_in_place to report violation from sync context.
+            // This may be called from tokio runtime; block_in_place moves other tasks off this thread.
             let detector_clone = detector.clone();
             let author = entry.author.clone();
             tokio::task::block_in_place(|| {


### PR DESCRIPTION
## Summary
- Audited all `block_in_place` + `block_on` patterns across the codebase
- Added standardized SAFETY comments explaining the pattern
- Verified all blocking patterns are correctly wrapped

## Changes
Adds SAFETY comments to 4 files:
- `icn-core/src/supervisor/shutdown.rs` - network state export
- `icn-core/src/supervisor/init_ledger.rs` - treasury validation  
- `icn-ledger/src/ledger.rs` - misbehavior violation reporting
- `icn-ledger/src/fork_resolution.rs` - trust score computation

## Audit Results

### Phase 1 (P0 - Panic Risk)
✅ All `block_on` calls are wrapped in `block_in_place` - no panic risk

### Phase 2 (P1 - Deprecated APIs) 
✅ Deprecated sync APIs in `trust_mgr.rs` properly marked, only used in tests

### Phase 3 (P2 - Callbacks)
✅ Added SAFETY comments to all callback patterns

### Phase 4 (P3 - Ignored Tests)
✅ Ignored tests use safe async patterns - ignored for functional reasons (timing/trust setup)

## Test plan
- [x] `cargo check -p icn-core -p icn-ledger` passes
- [x] Changes are documentation only (SAFETY comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)