### PR TITLE
fix(identity): Use Zeroizing wrapper for secret key material

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -8552,6 +8552,7 @@ version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
+ "serde",
  "zeroize_derive",
 ]
 

--- a/icn/Cargo.toml
+++ b/icn/Cargo.toml
@@ -60,7 +60,7 @@ x25519-dalek = "2.0"
 chacha20poly1305 = "0.10"
 rand_core = { version = "0.6", features = ["getrandom"] }
 rand = "0.8"
-zeroize = "1.7"
+zeroize = { version = "1.7", features = ["serde"] }
 rcgen = "0.14"
 sha2 = "0.10"
 pem = "3.0"

--- a/icn/crates/icn-identity/src/bundle.rs
+++ b/icn/crates/icn-identity/src/bundle.rs
@@ -33,8 +33,8 @@ pub struct IdentityBundle {
     /// Self-signed TLS certificate
     tls_cert: CertificateDer<'static>,
 
-    /// TLS private key (stored as bytes for cloning)
-    tls_key_der: Vec<u8>,
+    /// TLS private key (stored as bytes for cloning, zeroized on drop)
+    tls_key_der: Zeroizing<Vec<u8>>,
 
     /// Binding signature proving ownership
     /// Signature = Sign_did_key(SHA256(tls_cert))
@@ -64,7 +64,7 @@ impl Clone for IdentityBundle {
             did: self.did.clone(),
             did_keypair: self.did_keypair.clone(),
             tls_cert: self.tls_cert.clone(),
-            tls_key_der: self.tls_key_der.clone(),
+            tls_key_der: Zeroizing::new(self.tls_key_der.to_vec()),
             tls_binding_sig: self.tls_binding_sig.clone(),
             created_at: self.created_at,
             x25519_secret: Zeroizing::new(self.x25519_secret.to_vec()),
@@ -146,7 +146,7 @@ impl IdentityBundle {
             did,
             did_keypair,
             tls_cert,
-            tls_key_der,
+            tls_key_der: Zeroizing::new(tls_key_der),
             tls_binding_sig,
             created_at,
             x25519_secret,
@@ -162,14 +162,15 @@ impl IdentityBundle {
     ///
     /// This is used by the keystore to restore a previously saved bundle.
     /// The TLS certificate and binding signature are already generated.
+    /// Secret parameters are wrapped in Zeroizing to prevent copies.
     #[allow(clippy::too_many_arguments)]
     pub fn from_stored(
         did_keypair: KeyPair,
         tls_cert_der: Vec<u8>,
-        tls_key_der: Vec<u8>,
+        tls_key_der: Zeroizing<Vec<u8>>,
         tls_binding_sig: Vec<u8>,
         created_at: u64,
-        x25519_secret_bytes: Vec<u8>,
+        x25519_secret_bytes: Zeroizing<Vec<u8>>,
         x25519_public_bytes: [u8; 32],
     ) -> Result<Self> {
         #[cfg(feature = "post-quantum")]
@@ -208,7 +209,7 @@ impl IdentityBundle {
                 tls_key_der,
                 tls_binding_sig,
                 created_at,
-                x25519_secret: Zeroizing::new(x25519_secret_bytes),
+                x25519_secret: x25519_secret_bytes,
                 x25519_public: x25519_public_bytes,
             })
         }
@@ -218,17 +219,18 @@ impl IdentityBundle {
     ///
     /// This is used by the keystore to restore a previously saved bundle
     /// that may include post-quantum KEM keys.
+    /// Secret parameters are wrapped in Zeroizing to prevent copies.
     #[cfg(feature = "post-quantum")]
     #[allow(clippy::too_many_arguments)]
     pub fn from_stored_with_kem(
         did_keypair: KeyPair,
         tls_cert_der: Vec<u8>,
-        tls_key_der: Vec<u8>,
+        tls_key_der: Zeroizing<Vec<u8>>,
         tls_binding_sig: Vec<u8>,
         created_at: u64,
-        x25519_secret_bytes: Vec<u8>,
+        x25519_secret_bytes: Zeroizing<Vec<u8>>,
         x25519_public_bytes: [u8; 32],
-        kem_pq_secret: Option<Vec<u8>>,
+        kem_pq_secret: Option<Zeroizing<Vec<u8>>>,
         kem_pq_public: Option<Vec<u8>>,
     ) -> Result<Self> {
         let did = did_keypair.did().clone();
@@ -252,9 +254,9 @@ impl IdentityBundle {
             tls_key_der,
             tls_binding_sig,
             created_at,
-            x25519_secret: Zeroizing::new(x25519_secret_bytes),
+            x25519_secret: x25519_secret_bytes,
             x25519_public: x25519_public_bytes,
-            kem_pq_secret: kem_pq_secret.map(Zeroizing::new),
+            kem_pq_secret,
             kem_pq_public,
         })
     }
@@ -298,7 +300,9 @@ impl IdentityBundle {
 
     /// Get the TLS private key
     pub fn tls_key(&self) -> PrivateKeyDer<'static> {
-        PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(self.tls_key_der.clone()))
+        // Note: Creates a copy of the key bytes for the PrivateKeyDer wrapper.
+        // The source remains protected by Zeroizing.
+        PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(self.tls_key_der.to_vec()))
     }
 
     /// Get the raw TLS private key bytes (DER format)

--- a/icn/crates/icn-identity/src/keystore.rs
+++ b/icn/crates/icn-identity/src/keystore.rs
@@ -434,12 +434,12 @@ impl AgeKeyStore {
         let upgraded_bundle = IdentityBundle::from_stored_with_kem(
             upgraded_keypair,
             identity_bundle.tls_cert().as_ref().to_vec(),
-            identity_bundle.tls_key_der_bytes().to_vec(),
+            Zeroizing::new(identity_bundle.tls_key_der_bytes().to_vec()),
             identity_bundle.binding_info().tls_binding_sig.clone(),
             identity_bundle.binding_info().created_at,
-            identity_bundle.x25519_secret_bytes().to_vec(),
+            Zeroizing::new(identity_bundle.x25519_secret_bytes().to_vec()),
             *identity_bundle.x25519_public_bytes(),
-            Some(kem_keypair.secret_key_bytes().to_vec()),
+            Some(Zeroizing::new(kem_keypair.secret_key_bytes().to_vec())),
             Some(kem_keypair.public_key().as_bytes().to_vec()),
         )?;
 

--- a/icn/crates/icn-identity/src/keystore.rs
+++ b/icn/crates/icn-identity/src/keystore.rs
@@ -107,19 +107,19 @@ struct StoredKeyV3 {
     /// Format version (always 3 for this struct)
     version: u8,
 
-    /// This device's identity keys (SENSITIVE - must be zeroized)
-    secret_bytes: [u8; 32],
+    /// This device's identity keys (SENSITIVE - auto-zeroized via Zeroizing)
+    secret_bytes: Zeroizing<[u8; 32]>,
     public_bytes: [u8; 32],
     did: String,
 
-    /// TLS binding (from IdentityBundle) (SENSITIVE - must be zeroized)
+    /// TLS binding (from IdentityBundle) (SENSITIVE - auto-zeroized via Zeroizing)
     tls_cert_der: Vec<u8>,
-    tls_key_der: Vec<u8>,
+    tls_key_der: Zeroizing<Vec<u8>>,
     tls_binding_sig: Vec<u8>,
     created_at: u64,
 
-    /// X25519 encryption keys (SENSITIVE - must be zeroized)
-    x25519_secret: Vec<u8>,
+    /// X25519 encryption keys (SENSITIVE - auto-zeroized via Zeroizing)
+    x25519_secret: Zeroizing<Vec<u8>>,
     x25519_public: [u8; 32],
 
     /// DID Document (public, no need to zeroize)
@@ -132,14 +132,7 @@ struct StoredKeyV3 {
     rotation_chain: Vec<RotationEvent>,
 }
 
-impl Drop for StoredKeyV3 {
-    fn drop(&mut self) {
-        // Zeroize sensitive fields
-        self.secret_bytes.zeroize();
-        self.x25519_secret.zeroize();
-        self.tls_key_der.zeroize();
-    }
-}
+// Note: No manual Drop needed - Zeroizing handles secure cleanup automatically
 
 /// Keystore v4 format: SDIS support with Anchor and KeyBundles
 #[derive(Serialize, Deserialize)]
@@ -148,19 +141,19 @@ struct StoredKeyV4 {
     version: u8,
 
     // === Legacy fields from v3 (for backward compatibility) ===
-    /// This device's Ed25519 identity keys (SENSITIVE)
-    secret_bytes: [u8; 32],
+    /// This device's Ed25519 identity keys (SENSITIVE - auto-zeroized via Zeroizing)
+    secret_bytes: Zeroizing<[u8; 32]>,
     public_bytes: [u8; 32],
     did: String,
 
-    /// TLS binding (SENSITIVE)
+    /// TLS binding (SENSITIVE - auto-zeroized via Zeroizing)
     tls_cert_der: Vec<u8>,
-    tls_key_der: Vec<u8>,
+    tls_key_der: Zeroizing<Vec<u8>>,
     tls_binding_sig: Vec<u8>,
     created_at: u64,
 
-    /// X25519 encryption keys (SENSITIVE)
-    x25519_secret: Vec<u8>,
+    /// X25519 encryption keys (SENSITIVE - auto-zeroized via Zeroizing)
+    x25519_secret: Zeroizing<Vec<u8>>,
     x25519_public: [u8; 32],
 
     /// DID Document
@@ -186,22 +179,22 @@ struct StoredKeyV4 {
     current_keybundle_version: u32,
 
     // === Post-Quantum fields (v5 additions) ===
-    /// PQ signature secret key for core identity (ML-DSA) (feature-gated)
+    /// PQ signature secret key for core identity (ML-DSA) (SENSITIVE - auto-zeroized)
     #[cfg(feature = "post-quantum")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pq_secret: Option<Vec<u8>>,
+    pq_secret: Option<Zeroizing<Vec<u8>>>,
 
-    /// PQ signature public key for core identity (ML-DSA) (feature-gated)
+    /// PQ signature public key for core identity (ML-DSA)
     #[cfg(feature = "post-quantum")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pq_public: Option<Vec<u8>>,
 
-    /// PQ encryption secret key (ML-KEM) (feature-gated)
+    /// PQ encryption secret key (ML-KEM) (SENSITIVE - auto-zeroized)
     #[cfg(feature = "post-quantum")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    kem_pq_secret: Option<Vec<u8>>,
+    kem_pq_secret: Option<Zeroizing<Vec<u8>>>,
 
-    /// PQ encryption public key (ML-KEM) (feature-gated)
+    /// PQ encryption public key (ML-KEM)
     #[cfg(feature = "post-quantum")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     kem_pq_public: Option<Vec<u8>>,
@@ -218,16 +211,16 @@ struct StoredKeyBundleV4 {
     /// KeyBundle version
     version: u32,
 
-    /// Ed25519 signing key (from hybrid keypair) (SENSITIVE)
-    classical_secret: Vec<u8>,
+    /// Ed25519 signing key (from hybrid keypair) (SENSITIVE - auto-zeroized)
+    classical_secret: Zeroizing<Vec<u8>>,
     classical_public: Vec<u8>,
 
-    /// ML-DSA signing key (from hybrid keypair) (SENSITIVE)
-    pq_secret: Vec<u8>,
+    /// ML-DSA signing key (from hybrid keypair) (SENSITIVE - auto-zeroized)
+    pq_secret: Zeroizing<Vec<u8>>,
     pq_public: Vec<u8>,
 
-    /// X25519 encryption key for this bundle (SENSITIVE)
-    bundle_x25519_secret: Vec<u8>,
+    /// X25519 encryption key for this bundle (SENSITIVE - auto-zeroized)
+    bundle_x25519_secret: Zeroizing<Vec<u8>>,
     bundle_x25519_public: [u8; 32],
 
     /// Timestamps
@@ -238,28 +231,8 @@ struct StoredKeyBundleV4 {
     revoked_at: Option<u64>,
 }
 
-impl Drop for StoredKeyV4 {
-    fn drop(&mut self) {
-        // Zeroize sensitive fields
-        self.secret_bytes.zeroize();
-        self.x25519_secret.zeroize();
-        self.tls_key_der.zeroize();
-        #[cfg(feature = "post-quantum")]
-        {
-            if let Some(ref mut pq_sec) = self.pq_secret {
-                pq_sec.zeroize();
-            }
-            if let Some(ref mut kem_sec) = self.kem_pq_secret {
-                kem_sec.zeroize();
-            }
-        }
-        for kb in &mut self.keybundles {
-            kb.classical_secret.zeroize();
-            kb.pq_secret.zeroize();
-            kb.bundle_x25519_secret.zeroize();
-        }
-    }
-}
+// Note: No manual Drop needed for StoredKeyV4 or StoredKeyBundleV4
+// Zeroizing<T> handles secure cleanup automatically when dropped
 
 /// Age-encrypted key storage
 pub struct AgeKeyStore {
@@ -505,11 +478,11 @@ impl AgeKeyStore {
             .iter()
             .map(|kb| StoredKeyBundleV4 {
                 version: kb.version,
-                classical_secret: kb.classical_secret_bytes().to_vec(),
+                classical_secret: Zeroizing::new(kb.classical_secret_bytes().to_vec()),
                 classical_public: kb.classical_public_bytes(),
-                pq_secret: kb.pq_secret_bytes().to_vec(),
+                pq_secret: Zeroizing::new(kb.pq_secret_bytes().to_vec()),
                 pq_public: kb.pq_public_bytes(),
-                bundle_x25519_secret: kb.x25519_secret_bytes().to_vec(),
+                bundle_x25519_secret: Zeroizing::new(kb.x25519_secret_bytes().to_vec()),
                 bundle_x25519_public: kb.x25519_public(),
                 issued_at: kb.issued_at,
                 expires_at: kb.expires_at,
@@ -519,14 +492,14 @@ impl AgeKeyStore {
 
         let stored = StoredKeyV4 {
             version: 4,
-            secret_bytes: *identity_bundle.keypair().secret_bytes(),
+            secret_bytes: Zeroizing::new(*identity_bundle.keypair().secret_bytes()),
             public_bytes: identity_bundle.keypair().verifying_key().to_bytes(),
             did: identity_bundle.did().as_str().to_string(),
             tls_cert_der: identity_bundle.tls_cert().as_ref().to_vec(),
-            tls_key_der: identity_bundle.tls_key_der_bytes().to_vec(),
+            tls_key_der: Zeroizing::new(identity_bundle.tls_key_der_bytes().to_vec()),
             tls_binding_sig: identity_bundle.binding_info().tls_binding_sig.clone(),
             created_at: identity_bundle.binding_info().created_at,
-            x25519_secret: identity_bundle.x25519_secret_bytes().to_vec(),
+            x25519_secret: Zeroizing::new(identity_bundle.x25519_secret_bytes().to_vec()),
             x25519_public: *identity_bundle.x25519_public_bytes(),
             did_document: did_document.clone(),
             device_id: device_id.clone(),
@@ -539,7 +512,7 @@ impl AgeKeyStore {
                 .keypair()
                 .pq_keypair
                 .as_ref()
-                .map(|kp| kp.secret_key_bytes().to_vec()),
+                .map(|kp| Zeroizing::new(kp.secret_key_bytes().to_vec())),
             #[cfg(feature = "post-quantum")]
             pq_public: identity_bundle
                 .keypair()
@@ -547,7 +520,9 @@ impl AgeKeyStore {
                 .as_ref()
                 .map(|kp| kp.public_key().as_bytes().to_vec()),
             #[cfg(feature = "post-quantum")]
-            kem_pq_secret: identity_bundle.kem_pq_secret_bytes().map(|s| s.to_vec()),
+            kem_pq_secret: identity_bundle
+                .kem_pq_secret_bytes()
+                .map(|s| Zeroizing::new(s.to_vec())),
             #[cfg(feature = "post-quantum")]
             kem_pq_public: identity_bundle.kem_pq_public_bytes().map(|p| p.to_vec()),
             #[cfg(feature = "post-quantum")]
@@ -686,14 +661,14 @@ impl AgeKeyStore {
         let keypair = identity_bundle.keypair();
         let stored_v3 = StoredKeyV3 {
             version: 3,
-            secret_bytes: *keypair.secret_bytes(),
+            secret_bytes: Zeroizing::new(*keypair.secret_bytes()),
             public_bytes: keypair.verifying_key().to_bytes(),
             did: identity_bundle.did().as_str().to_string(),
             tls_cert_der: identity_bundle.tls_cert().as_ref().to_vec(),
-            tls_key_der: identity_bundle.tls_key_der_bytes().to_vec(),
+            tls_key_der: Zeroizing::new(identity_bundle.tls_key_der_bytes().to_vec()),
             tls_binding_sig: identity_bundle.binding_info().tls_binding_sig.clone(),
             created_at: identity_bundle.binding_info().created_at,
-            x25519_secret: identity_bundle.x25519_secret_bytes().to_vec(),
+            x25519_secret: Zeroizing::new(identity_bundle.x25519_secret_bytes().to_vec()),
             x25519_public: *identity_bundle.x25519_public_bytes(),
             did_document: did_document.clone(),
             device_id: device_id.clone(),
@@ -742,14 +717,14 @@ impl AgeKeyStore {
         let keypair = identity_bundle.keypair();
         let stored_v3 = StoredKeyV3 {
             version: 3,
-            secret_bytes: *keypair.secret_bytes(),
+            secret_bytes: Zeroizing::new(*keypair.secret_bytes()),
             public_bytes: keypair.verifying_key().to_bytes(),
             did: identity_bundle.did().as_str().to_string(),
             tls_cert_der: identity_bundle.tls_cert().as_ref().to_vec(),
-            tls_key_der: identity_bundle.tls_key_der_bytes().to_vec(),
+            tls_key_der: Zeroizing::new(identity_bundle.tls_key_der_bytes().to_vec()),
             tls_binding_sig: identity_bundle.binding_info().tls_binding_sig.clone(),
             created_at: identity_bundle.binding_info().created_at,
-            x25519_secret: identity_bundle.x25519_secret_bytes().to_vec(),
+            x25519_secret: Zeroizing::new(identity_bundle.x25519_secret_bytes().to_vec()),
             x25519_public: *identity_bundle.x25519_public_bytes(),
             did_document: did_document.clone(),
             device_id: "device-1".to_string(),
@@ -1068,13 +1043,16 @@ impl KeyStore for AgeKeyStore {
             stored.tls_binding_sig.clone(),
             stored.created_at,
         ) {
+            // Wrap TLS key in Zeroizing for secure handling
+            let tls_key_der = Zeroizing::new(tls_key_der);
+
             // Check if we have X25519 keys (v2.1+)
             let (x25519_secret, x25519_public) = if let (Some(secret), Some(public)) =
                 (stored.x25519_secret.clone(), stored.x25519_public)
             {
-                // V2.1+ keystore: has X25519 keys
+                // V2.1+ keystore: has X25519 keys - wrap in Zeroizing
                 info!("Unlocked v2.1 keystore, migrating to v3 (multi-device)");
-                (secret, public)
+                (Zeroizing::new(secret), public)
             } else {
                 // V2.0 keystore: has TLS but no X25519, generate new X25519 keys
                 info!("Unlocked v2.0 keystore, migrating to v3 with X25519 keys");
@@ -1086,7 +1064,7 @@ impl KeyStore for AgeKeyStore {
 
                 let secret_key = StaticSecret::random_from_rng(OsRng);
                 let public_key = PublicKey::from(&secret_key);
-                let secret_bytes = secret_key.to_bytes().to_vec();
+                let secret_bytes = Zeroizing::new(secret_key.to_bytes().to_vec());
                 let public_bytes = public_key.to_bytes();
 
                 (secret_bytes, public_bytes)
@@ -1121,14 +1099,14 @@ impl KeyStore for AgeKeyStore {
         // Save as v3 keystore
         let stored_v3 = StoredKeyV3 {
             version: 3,
-            secret_bytes: *identity_bundle.keypair().secret_bytes(),
+            secret_bytes: Zeroizing::new(*identity_bundle.keypair().secret_bytes()),
             public_bytes: identity_bundle.keypair().verifying_key().to_bytes(),
             did: identity_bundle.did().as_str().to_string(),
             tls_cert_der: identity_bundle.tls_cert().as_ref().to_vec(),
-            tls_key_der: identity_bundle.tls_key_der_bytes().to_vec(),
+            tls_key_der: Zeroizing::new(identity_bundle.tls_key_der_bytes().to_vec()),
             tls_binding_sig: identity_bundle.binding_info().tls_binding_sig.clone(),
             created_at: identity_bundle.binding_info().created_at,
-            x25519_secret: identity_bundle.x25519_secret_bytes().to_vec(),
+            x25519_secret: Zeroizing::new(identity_bundle.x25519_secret_bytes().to_vec()),
             x25519_public: *identity_bundle.x25519_public_bytes(),
             did_document: did_document.clone(),
             device_id: "device-1".to_string(),


### PR DESCRIPTION
## Summary
- Wraps secret key bytes in `Zeroizing<T>` wrappers to ensure automatic zeroization on drop
- Updates `StoredKeyV3`, `StoredKeyV4`, and `StoredKeyBundleV4` structs to use `Zeroizing` for secret fields
- Updates `IdentityBundle::from_stored()` and `from_stored_with_kem()` to accept `Zeroizing` parameters
- Removes manual `Drop` implementations (no longer needed with `Zeroizing` wrapper)

## Motivation
Fixes #573 - Secret key bytes were being copied during keystore serialization via plain `Vec<u8>` fields, leaving copies in memory that weren't zeroized.

## How it works
The `zeroize` crate's `Zeroizing<T>` wrapper provides:
- Automatic zeroization when the value is dropped
- Serde support (enabled via `serde` feature) for serialization without copies
- Prevention of compiler optimizations that might skip zeroization

## Changed files
- `Cargo.toml` - Enable `serde` feature for `zeroize`
- `crates/icn-identity/src/keystore.rs` - Wrap secret fields in stored structs
- `crates/icn-identity/src/bundle.rs` - Update `from_stored` function signatures

## Test plan
- [x] `cargo test -p icn-identity` - All 176 tests pass
- [x] `cargo test -p icn-core --lib` - All 133 tests pass
- [x] `cargo build -p icn-identity` - Builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)