### PR TITLE
fix(gateway): Use separate Sled DB path for entity audit store

### DIFF
--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -449,9 +449,10 @@ impl GatewayServer {
         info!("Budget store initialized");
 
         // Create entity audit manager for compliance logging
+        // Uses a separate store path to avoid Sled lock conflicts with gateway_store
         let entity_audit_store: Arc<dyn icn_store::Store> =
             if let Some(ref data_dir) = self.data_dir {
-                let store_path = data_dir.join("gateway_store");
+                let store_path = data_dir.join("entity_audit_store");
                 Arc::new(SledStore::open(&store_path).map_err(|e| {
                     GatewayError::InternalError(format!("Failed to open entity audit store: {e}"))
                 })?)


### PR DESCRIPTION
## Summary
- Fixes Sled database lock conflict in deployed K3s environment
- The entity audit store was trying to open the same path as the main gateway storage

## Problem
The gateway was opening `gateway_store` twice:
1. Line 422: `sled::open(&db_path)` for main gateway storage
2. Line 454: `SledStore::open(&store_path)` for entity audit (same path)

Sled doesn't allow multiple opens of the same database - they must share the handle.

## Solution
Changed the entity audit store to use a separate path: `entity_audit_store`

## Test plan
- [x] `cargo build -p icn-gateway` - builds successfully
- [ ] Deploy to K3s and verify no lock conflict errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)