### PR TITLE
feat(net): Add wire protocol negotiation for postcard encoding

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -3276,6 +3276,7 @@ dependencies = [
  "icn-trust",
  "mdns-sd",
  "portpicker",
+ "postcard",
  "quinn",
  "rand 0.8.5",
  "rand_core 0.6.4",

--- a/icn/crates/icn-net/Cargo.toml
+++ b/icn/crates/icn-net/Cargo.toml
@@ -28,6 +28,7 @@ sha2.workspace = true
 serde.workspace = true
 serde_json = "1.0"
 bincode.workspace = true
+postcard.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/icn/crates/icn-net/src/lib.rs
+++ b/icn/crates/icn-net/src/lib.rs
@@ -40,9 +40,9 @@ pub use envelope::{PayloadType, SignedEnvelope};
 pub use error::{NetError, Result};
 pub use global_rate_limit::GlobalRateLimiter;
 pub use protocol::{
-    read_message, read_message_compressed, write_message, write_message_compressed,
-    CompressionFormat, KnownPeer, MessagePayload, NetworkMessage, PeerExchangeMessage,
-    COMPRESSION_THRESHOLD,
+    read_message, read_message_compressed, read_message_negotiated, write_message,
+    write_message_compressed, write_message_negotiated, CompressionFormat, EncodingFormat,
+    KnownPeer, MessagePayload, NetworkMessage, PeerExchangeMessage, COMPRESSION_THRESHOLD,
 };
 pub use rate_limit::{RateLimitConfig, RateLimiter, TrustGatedRateLimitConfig};
 pub use replay_guard::ReplayGuard;

--- a/icn/crates/icn-net/src/protocol.rs
+++ b/icn/crates/icn-net/src/protocol.rs
@@ -46,6 +46,54 @@ impl TryFrom<u8> for CompressionFormat {
     }
 }
 
+/// Wire format encoding type
+///
+/// Used in combination with compression to indicate how messages are serialized.
+/// The wire format byte combines encoding and compression:
+/// - Low nibble (bits 0-3): compression format
+/// - High nibble (bits 4-7): encoding format
+///
+/// This allows backward compatibility: old nodes only check the low nibble,
+/// while new nodes can distinguish between bincode and postcard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum EncodingFormat {
+    /// Bincode encoding (legacy, compatible with all nodes)
+    Bincode = 0,
+    /// Postcard encoding (more compact, requires POSTCARD_ENCODING capability)
+    Postcard = 1,
+}
+
+impl EncodingFormat {
+    /// Create wire format byte from encoding and compression
+    pub fn to_wire_byte(self, compression: CompressionFormat) -> u8 {
+        ((self as u8) << 4) | (compression as u8)
+    }
+
+    /// Parse encoding format from wire format byte
+    pub fn from_wire_byte(byte: u8) -> Result<(Self, CompressionFormat)> {
+        let encoding = match byte >> 4 {
+            0 => EncodingFormat::Bincode,
+            1 => EncodingFormat::Postcard,
+            n => anyhow::bail!("Unknown encoding format: {n}"),
+        };
+        let compression = CompressionFormat::try_from(byte & 0x0F)?;
+        Ok((encoding, compression))
+    }
+}
+
+impl TryFrom<u8> for EncodingFormat {
+    type Error = anyhow::Error;
+
+    fn try_from(value: u8) -> Result<Self> {
+        match value {
+            0 => Ok(EncodingFormat::Bincode),
+            1 => Ok(EncodingFormat::Postcard),
+            _ => anyhow::bail!("Unknown encoding format: {value}"),
+        }
+    }
+}
+
 /// Re-export TraceContext from icn-obs for distributed tracing propagation
 pub use icn_obs::TraceContext;
 
@@ -717,6 +765,127 @@ impl NetworkMessage {
         Ok(msg)
     }
 
+    /// Serialize to bytes with encoding and compression negotiation
+    ///
+    /// Wire format: [format_byte: 1 byte][payload: variable]
+    /// - format_byte high nibble (bits 4-7): encoding format (0=bincode, 1=postcard)
+    /// - format_byte low nibble (bits 0-3): compression format (0=none, 1=zstd)
+    ///
+    /// Use this for peers that support POSTCARD_ENCODING capability.
+    /// Falls back to bincode for peers without this capability.
+    pub fn to_bytes_negotiated(
+        &self,
+        use_postcard: bool,
+        enable_compression: bool,
+    ) -> Result<Vec<u8>> {
+        let encoding = if use_postcard {
+            EncodingFormat::Postcard
+        } else {
+            EncodingFormat::Bincode
+        };
+
+        let raw_bytes = if use_postcard {
+            postcard::to_allocvec(self).context("Failed to serialize with postcard")?
+        } else {
+            bincode::serde::encode_to_vec(self, bincode::config::legacy())
+                .context("Failed to serialize with bincode")?
+        };
+
+        let bytes_before = raw_bytes.len();
+
+        // Only compress if enabled, above threshold, and would reduce size
+        if enable_compression && raw_bytes.len() >= COMPRESSION_THRESHOLD {
+            let compressed =
+                zstd::encode_all(raw_bytes.as_slice(), 3).context("Failed to compress message")?;
+
+            if compressed.len() < raw_bytes.len() {
+                let format_byte = encoding.to_wire_byte(CompressionFormat::Zstd);
+                let mut result = Vec::with_capacity(1 + compressed.len());
+                result.push(format_byte);
+                result.extend(compressed);
+
+                if result.len() > MAX_MESSAGE_SIZE {
+                    anyhow::bail!(
+                        "Compressed message too large: {} bytes (max {})",
+                        result.len(),
+                        MAX_MESSAGE_SIZE
+                    );
+                }
+
+                icn_obs::metrics::gossip::bytes_before_compression_add(bytes_before as u64);
+                icn_obs::metrics::gossip::bytes_after_compression_add(result.len() as u64);
+                icn_obs::metrics::gossip::compression_ratio_record(
+                    bytes_before as f64 / result.len() as f64,
+                );
+
+                return Ok(result);
+            }
+        }
+
+        // No compression
+        let format_byte = encoding.to_wire_byte(CompressionFormat::None);
+        let mut result = Vec::with_capacity(1 + raw_bytes.len());
+        result.push(format_byte);
+        result.extend(raw_bytes);
+
+        if result.len() > MAX_MESSAGE_SIZE {
+            anyhow::bail!(
+                "Message too large: {} bytes (max {})",
+                result.len(),
+                MAX_MESSAGE_SIZE
+            );
+        }
+
+        icn_obs::metrics::gossip::bytes_before_compression_add(bytes_before as u64);
+        icn_obs::metrics::gossip::bytes_after_compression_add(result.len() as u64);
+
+        Ok(result)
+    }
+
+    /// Deserialize from bytes with encoding and compression negotiation
+    ///
+    /// Auto-detects encoding format from wire format byte and handles both
+    /// bincode and postcard encoded messages.
+    ///
+    /// This method is backward-compatible: it can decode messages from both
+    /// old nodes (bincode-only) and new nodes (postcard-capable).
+    pub fn from_bytes_negotiated(bytes: &[u8]) -> Result<Self> {
+        if bytes.is_empty() {
+            anyhow::bail!("Empty message");
+        }
+
+        if bytes.len() > MAX_MESSAGE_SIZE {
+            anyhow::bail!(
+                "Message too large: {} bytes (max {})",
+                bytes.len(),
+                MAX_MESSAGE_SIZE
+            );
+        }
+
+        let (encoding, compression) = EncodingFormat::from_wire_byte(bytes[0])?;
+        let payload = &bytes[1..];
+
+        let decompressed = match compression {
+            CompressionFormat::None => payload.to_vec(),
+            CompressionFormat::Zstd => {
+                zstd::decode_all(payload).context("Failed to decompress message")?
+            }
+        };
+
+        let msg: NetworkMessage = match encoding {
+            EncodingFormat::Bincode => {
+                bincode::serde::decode_from_slice(&decompressed, bincode::config::legacy())
+                    .map(|(v, _)| v)
+                    .context("Failed to deserialize with bincode")?
+            }
+            EncodingFormat::Postcard => postcard::from_bytes(&decompressed)
+                .context("Failed to deserialize with postcard")?,
+        };
+
+        Self::validate_version(msg.version)?;
+        Ok(msg)
+    }
+
     /// Validate protocol version compatibility
     ///
     /// Returns Ok if the version is supported, Err otherwise.
@@ -878,6 +1047,80 @@ pub async fn write_message_compressed(
     use tokio::io::AsyncWriteExt;
 
     let bytes = msg.to_bytes_compressed(enable_compression)?;
+    let len = bytes.len() as u32;
+
+    // Write 4-byte length prefix (big-endian)
+    send.write_all(&len.to_be_bytes())
+        .await
+        .context("Failed to write message length")?;
+
+    // Write message bytes
+    send.write_all(&bytes)
+        .await
+        .context("Failed to write message body")?;
+
+    send.flush().await.context("Failed to flush stream")?;
+
+    // Return total bytes: 4 (length prefix) + message body
+    Ok(4 + bytes.len())
+}
+
+/// Helper for reading length-prefixed messages with negotiated encoding
+///
+/// Use this for peers that support both POSTCARD_ENCODING and MESSAGE_COMPRESSION capabilities.
+/// Auto-detects encoding format from wire format byte.
+/// Returns the message and the number of bytes read (including 4-byte length prefix)
+pub async fn read_message_negotiated(
+    recv: &mut quinn::RecvStream,
+) -> Result<(NetworkMessage, usize)> {
+    // Read 4-byte length prefix (big-endian)
+    let mut len_buf = [0u8; 4];
+    recv.read_exact(&mut len_buf)
+        .await
+        .context("Failed to read message length")?;
+    let len_u32 = u32::from_be_bytes(len_buf);
+
+    // Validate message size BEFORE casting to usize to prevent overflow on 32-bit systems
+    if len_u32 == 0 {
+        anyhow::bail!("Invalid message: zero length");
+    }
+    if len_u32 > MAX_MESSAGE_SIZE as u32 {
+        anyhow::bail!("Message too large: {len_u32} bytes (max {MAX_MESSAGE_SIZE})");
+    }
+
+    // Safe to cast after validation
+    let len = len_u32 as usize;
+
+    // Allocate buffer (size is now validated)
+    let mut buf = vec![0u8; len];
+    recv.read_exact(&mut buf)
+        .await
+        .context("Failed to read message body")?;
+
+    let msg = NetworkMessage::from_bytes_negotiated(&buf)?;
+    // Return total bytes: 4 (length prefix) + message body
+    Ok((msg, 4 + len))
+}
+
+/// Helper for writing length-prefixed messages with negotiated encoding
+///
+/// Use this for peers that support both POSTCARD_ENCODING and MESSAGE_COMPRESSION capabilities.
+/// Returns the number of bytes written (including 4-byte length prefix)
+///
+/// # Arguments
+/// * `send` - QUIC send stream
+/// * `msg` - Message to send
+/// * `use_postcard` - Use postcard encoding (true if peer supports POSTCARD_ENCODING)
+/// * `enable_compression` - Enable zstd compression (true if peer supports MESSAGE_COMPRESSION)
+pub async fn write_message_negotiated(
+    send: &mut quinn::SendStream,
+    msg: &NetworkMessage,
+    use_postcard: bool,
+    enable_compression: bool,
+) -> Result<usize> {
+    use tokio::io::AsyncWriteExt;
+
+    let bytes = msg.to_bytes_negotiated(use_postcard, enable_compression)?;
     let len = bytes.len() as u32;
 
     // Write 4-byte length prefix (big-endian)
@@ -1607,5 +1850,243 @@ mod tests {
             "Should accept timestamp at edge of max age: {:?}",
             result
         );
+    }
+
+    // Issue #539: Wire protocol negotiated encoding tests
+
+    #[test]
+    fn test_encoding_format_conversion() {
+        assert_eq!(
+            EncodingFormat::try_from(0).unwrap(),
+            EncodingFormat::Bincode
+        );
+        assert_eq!(
+            EncodingFormat::try_from(1).unwrap(),
+            EncodingFormat::Postcard
+        );
+        assert!(EncodingFormat::try_from(2).is_err());
+    }
+
+    #[test]
+    fn test_wire_byte_roundtrip() {
+        // Test all combinations of encoding and compression
+        let combinations = [
+            (EncodingFormat::Bincode, CompressionFormat::None, 0x00),
+            (EncodingFormat::Bincode, CompressionFormat::Zstd, 0x01),
+            (EncodingFormat::Postcard, CompressionFormat::None, 0x10),
+            (EncodingFormat::Postcard, CompressionFormat::Zstd, 0x11),
+        ];
+
+        for (encoding, compression, expected_byte) in combinations {
+            let wire_byte = encoding.to_wire_byte(compression);
+            assert_eq!(
+                wire_byte, expected_byte,
+                "Wire byte mismatch for {:?}/{:?}",
+                encoding, compression
+            );
+
+            let (parsed_encoding, parsed_compression) =
+                EncodingFormat::from_wire_byte(wire_byte).unwrap();
+            assert_eq!(
+                parsed_encoding, encoding,
+                "Encoding mismatch for byte {:#x}",
+                wire_byte
+            );
+            assert_eq!(
+                parsed_compression, compression,
+                "Compression mismatch for byte {:#x}",
+                wire_byte
+            );
+        }
+    }
+
+    #[test]
+    fn test_negotiated_bincode_roundtrip() {
+        let alice = KeyPair::generate().unwrap().did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        let msg = NetworkMessage::ping(alice.clone(), bob.clone());
+
+        // Bincode without compression
+        let bytes = msg.to_bytes_negotiated(false, false).unwrap();
+        assert_eq!(bytes[0], 0x00, "Should be bincode without compression");
+
+        let decoded = NetworkMessage::from_bytes_negotiated(&bytes).unwrap();
+        assert_eq!(decoded.from, alice);
+        assert_eq!(decoded.to, Some(bob));
+        assert!(matches!(decoded.payload, MessagePayload::Ping { .. }));
+    }
+
+    #[test]
+    fn test_negotiated_postcard_roundtrip() {
+        let alice = KeyPair::generate().unwrap().did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        let msg = NetworkMessage::ping(alice.clone(), bob.clone());
+
+        // Postcard without compression
+        let bytes = msg.to_bytes_negotiated(true, false).unwrap();
+        assert_eq!(bytes[0], 0x10, "Should be postcard without compression");
+
+        let decoded = NetworkMessage::from_bytes_negotiated(&bytes).unwrap();
+        assert_eq!(decoded.from, alice);
+        assert_eq!(decoded.to, Some(bob));
+        assert!(matches!(decoded.payload, MessagePayload::Ping { .. }));
+    }
+
+    #[test]
+    fn test_postcard_is_more_compact() {
+        let alice = KeyPair::generate().unwrap().did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        let msg = NetworkMessage::ping(alice, bob);
+
+        let bincode_bytes = msg.to_bytes_negotiated(false, false).unwrap();
+        let postcard_bytes = msg.to_bytes_negotiated(true, false).unwrap();
+
+        // Postcard is typically more compact
+        println!(
+            "Bincode: {} bytes, Postcard: {} bytes",
+            bincode_bytes.len(),
+            postcard_bytes.len()
+        );
+
+        // Both should decode correctly
+        let decoded_bincode = NetworkMessage::from_bytes_negotiated(&bincode_bytes).unwrap();
+        let decoded_postcard = NetworkMessage::from_bytes_negotiated(&postcard_bytes).unwrap();
+
+        assert!(matches!(
+            decoded_bincode.payload,
+            MessagePayload::Ping { .. }
+        ));
+        assert!(matches!(
+            decoded_postcard.payload,
+            MessagePayload::Ping { .. }
+        ));
+    }
+
+    #[test]
+    fn test_negotiated_postcard_with_compression() {
+        let alice = KeyPair::generate().unwrap().did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        // Create a large, compressible message
+        let mut clock = VectorClock::new();
+        clock.increment(&alice);
+
+        let large_data = vec![42u8; 4096]; // 4KB of same byte
+        let gossip_msg = GossipMessage::Response {
+            entry: icn_gossip::types::GossipEntry {
+                hash: [1u8; 32],
+                author: alice.clone(),
+                clock,
+                topic: "test".to_string(),
+                data: large_data,
+                compressed: false,
+                timestamp: 0,
+                replica_offered: None,
+            },
+        };
+
+        let msg = NetworkMessage::gossip(alice.clone(), Some(bob.clone()), gossip_msg);
+
+        // Postcard with compression
+        let bytes = msg.to_bytes_negotiated(true, true).unwrap();
+        assert_eq!(bytes[0], 0x11, "Should be postcard with zstd compression");
+
+        // Should be smaller than without compression
+        let uncompressed = msg.to_bytes_negotiated(true, false).unwrap();
+        assert!(
+            bytes.len() < uncompressed.len(),
+            "Compressed ({}) should be smaller than uncompressed ({})",
+            bytes.len(),
+            uncompressed.len()
+        );
+
+        let decoded = NetworkMessage::from_bytes_negotiated(&bytes).unwrap();
+        assert_eq!(decoded.from, alice);
+        assert!(matches!(decoded.payload, MessagePayload::Gossip(_)));
+    }
+
+    #[test]
+    fn test_negotiated_bincode_with_compression() {
+        let alice = KeyPair::generate().unwrap().did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        // Create a large, compressible message
+        let mut clock = VectorClock::new();
+        clock.increment(&alice);
+
+        let large_data = vec![42u8; 4096];
+        let gossip_msg = GossipMessage::Response {
+            entry: icn_gossip::types::GossipEntry {
+                hash: [1u8; 32],
+                author: alice.clone(),
+                clock,
+                topic: "test".to_string(),
+                data: large_data,
+                compressed: false,
+                timestamp: 0,
+                replica_offered: None,
+            },
+        };
+
+        let msg = NetworkMessage::gossip(alice.clone(), Some(bob.clone()), gossip_msg);
+
+        // Bincode with compression
+        let bytes = msg.to_bytes_negotiated(false, true).unwrap();
+        assert_eq!(bytes[0], 0x01, "Should be bincode with zstd compression");
+
+        let decoded = NetworkMessage::from_bytes_negotiated(&bytes).unwrap();
+        assert_eq!(decoded.from, alice);
+        assert!(matches!(decoded.payload, MessagePayload::Gossip(_)));
+    }
+
+    #[test]
+    fn test_negotiated_unknown_encoding_rejected() {
+        // Create a message with invalid encoding format (0x20)
+        let wire_byte = 0x20; // encoding = 2 (invalid)
+        let result = EncodingFormat::from_wire_byte(wire_byte);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Unknown encoding"));
+    }
+
+    #[test]
+    fn test_negotiated_unknown_compression_rejected() {
+        // Create a message with invalid compression format (0x02)
+        let wire_byte = 0x02; // encoding = 0, compression = 2 (invalid)
+        let result = EncodingFormat::from_wire_byte(wire_byte);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unknown compression"));
+    }
+
+    #[test]
+    fn test_negotiated_empty_message_rejected() {
+        let result = NetworkMessage::from_bytes_negotiated(&[]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Empty message"));
+    }
+
+    #[test]
+    fn test_backward_compatible_wire_byte() {
+        // Verify that old nodes reading new wire format bytes correctly parse
+        // the compression format (low nibble) even if they ignore the encoding (high nibble)
+
+        // 0x00 = bincode + none -> old nodes see compression = 0 (none)
+        assert_eq!(0x00 & 0x0F, 0);
+
+        // 0x01 = bincode + zstd -> old nodes see compression = 1 (zstd)
+        assert_eq!(0x01 & 0x0F, 1);
+
+        // 0x10 = postcard + none -> old nodes see compression = 0 (none)
+        // They'll fail to decode postcard, but at least won't crash on decompression
+        assert_eq!(0x10 & 0x0F, 0);
+
+        // 0x11 = postcard + zstd -> old nodes see compression = 1 (zstd)
+        // They'll decompress successfully, then fail to decode postcard
+        assert_eq!(0x11 & 0x0F, 1);
     }
 }

--- a/icn/crates/icn-net/src/protocol.rs
+++ b/icn/crates/icn-net/src/protocol.rs
@@ -2146,8 +2146,7 @@ mod tests {
 
         // Verify wire byte indicates bincode + zstd (high nibble = 0, low nibble = 1)
         assert_eq!(
-            bincode_compressed[0],
-            0x01,
+            bincode_compressed[0], 0x01,
             "Old node should use bincode + zstd"
         );
 

--- a/icn/crates/icn-net/src/protocol.rs
+++ b/icn/crates/icn-net/src/protocol.rs
@@ -75,7 +75,7 @@ impl EncodingFormat {
         let encoding = match byte >> 4 {
             0 => EncodingFormat::Bincode,
             1 => EncodingFormat::Postcard,
-            n => anyhow::bail!("Unknown encoding format: {n}"),
+            n => anyhow::bail!("Unknown encoding format: {n} (wire byte: {byte:#04x})"),
         };
         let compression = CompressionFormat::try_from(byte & 0x0F)?;
         Ok((encoding, compression))
@@ -804,6 +804,13 @@ impl NetworkMessage {
                 result.push(format_byte);
                 result.extend(compressed);
 
+                // Record metrics before size check so we track oversized messages too
+                icn_obs::metrics::gossip::bytes_before_compression_add(bytes_before as u64);
+                icn_obs::metrics::gossip::bytes_after_compression_add(result.len() as u64);
+                icn_obs::metrics::gossip::compression_ratio_record(
+                    bytes_before as f64 / result.len() as f64,
+                );
+
                 if result.len() > MAX_MESSAGE_SIZE {
                     anyhow::bail!(
                         "Compressed message too large: {} bytes (max {})",
@@ -811,12 +818,6 @@ impl NetworkMessage {
                         MAX_MESSAGE_SIZE
                     );
                 }
-
-                icn_obs::metrics::gossip::bytes_before_compression_add(bytes_before as u64);
-                icn_obs::metrics::gossip::bytes_after_compression_add(result.len() as u64);
-                icn_obs::metrics::gossip::compression_ratio_record(
-                    bytes_before as f64 / result.len() as f64,
-                );
 
                 return Ok(result);
             }
@@ -828,6 +829,10 @@ impl NetworkMessage {
         result.push(format_byte);
         result.extend(raw_bytes);
 
+        // Record metrics before size check so we track oversized messages too
+        icn_obs::metrics::gossip::bytes_before_compression_add(bytes_before as u64);
+        icn_obs::metrics::gossip::bytes_after_compression_add(result.len() as u64);
+
         if result.len() > MAX_MESSAGE_SIZE {
             anyhow::bail!(
                 "Message too large: {} bytes (max {})",
@@ -835,9 +840,6 @@ impl NetworkMessage {
                 MAX_MESSAGE_SIZE
             );
         }
-
-        icn_obs::metrics::gossip::bytes_before_compression_add(bytes_before as u64);
-        icn_obs::metrics::gossip::bytes_after_compression_add(result.len() as u64);
 
         Ok(result)
     }

--- a/icn/crates/icn-net/src/protocol.rs
+++ b/icn/crates/icn-net/src/protocol.rs
@@ -1881,21 +1881,18 @@ mod tests {
             let wire_byte = encoding.to_wire_byte(compression);
             assert_eq!(
                 wire_byte, expected_byte,
-                "Wire byte mismatch for {:?}/{:?}",
-                encoding, compression
+                "Wire byte mismatch for {encoding:?}/{compression:?}",
             );
 
             let (parsed_encoding, parsed_compression) =
                 EncodingFormat::from_wire_byte(wire_byte).unwrap();
             assert_eq!(
                 parsed_encoding, encoding,
-                "Encoding mismatch for byte {:#x}",
-                wire_byte
+                "Encoding mismatch for byte {wire_byte:#x}",
             );
             assert_eq!(
                 parsed_compression, compression,
-                "Compression mismatch for byte {:#x}",
-                wire_byte
+                "Compression mismatch for byte {wire_byte:#x}",
             );
         }
     }
@@ -2071,6 +2068,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::erasing_op)] // Intentional: documenting that old nodes see compression = 0
     fn test_backward_compatible_wire_byte() {
         // Verify that old nodes reading new wire format bytes correctly parse
         // the compression format (low nibble) even if they ignore the encoding (high nibble)

--- a/icn/crates/icn-net/src/protocol.rs
+++ b/icn/crates/icn-net/src/protocol.rs
@@ -2087,4 +2087,73 @@ mod tests {
         // They'll decompress successfully, then fail to decode postcard
         assert_eq!(0x11 & 0x0F, 1);
     }
+
+    #[test]
+    fn test_forward_compatible_postcard_node_decodes_bincode() {
+        // Verify that a postcard-capable node can decode bincode messages from old nodes.
+        // This tests forward compatibility: new nodes must understand old wire format.
+        let alice = KeyPair::generate().unwrap().did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        let msg = NetworkMessage::ping(alice.clone(), bob.clone());
+
+        // Simulate old node: sends bincode-encoded message (use_postcard = false)
+        let bincode_bytes = msg.to_bytes_negotiated(false, false).unwrap();
+
+        // Verify wire byte indicates bincode encoding (high nibble = 0)
+        assert_eq!(
+            bincode_bytes[0] >> 4,
+            0,
+            "Old node should use bincode encoding"
+        );
+
+        // New postcard-capable node should decode it via from_bytes_negotiated
+        let decoded = NetworkMessage::from_bytes_negotiated(&bincode_bytes).unwrap();
+
+        assert_eq!(decoded.from, alice);
+        assert_eq!(decoded.to, Some(bob));
+        assert!(matches!(decoded.payload, MessagePayload::Ping { .. }));
+    }
+
+    #[test]
+    fn test_forward_compatible_postcard_node_decodes_bincode_compressed() {
+        // Same as above but with compression enabled
+        let alice = KeyPair::generate().unwrap().did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        // Create a large, compressible message (similar to other compression tests)
+        let mut clock = VectorClock::new();
+        clock.increment(&alice);
+
+        let large_data = vec![42u8; 4096]; // 4KB of same byte (compresses well)
+        let gossip_msg = GossipMessage::Response {
+            entry: icn_gossip::types::GossipEntry {
+                hash: [1u8; 32],
+                author: alice.clone(),
+                clock,
+                topic: "test".to_string(),
+                data: large_data,
+                compressed: false,
+                timestamp: 0,
+                replica_offered: None,
+            },
+        };
+
+        let msg = NetworkMessage::gossip(alice.clone(), Some(bob), gossip_msg);
+
+        // Simulate old node: sends bincode + zstd (use_postcard = false, compression = true)
+        let bincode_compressed = msg.to_bytes_negotiated(false, true).unwrap();
+
+        // Verify wire byte indicates bincode + zstd (high nibble = 0, low nibble = 1)
+        assert_eq!(
+            bincode_compressed[0],
+            0x01,
+            "Old node should use bincode + zstd"
+        );
+
+        // New postcard-capable node should decode it
+        let decoded = NetworkMessage::from_bytes_negotiated(&bincode_compressed).unwrap();
+        assert_eq!(decoded.from, alice);
+        assert!(matches!(decoded.payload, MessagePayload::Gossip(_)));
+    }
 }

--- a/icn/crates/icn-net/src/replay_guard.rs
+++ b/icn/crates/icn-net/src/replay_guard.rs
@@ -1416,7 +1416,7 @@ mod tests {
                     &keypair,
                     seq,
                     PayloadType::Gossip,
-                    format!("msg{}", seq).as_bytes().to_vec(),
+                    format!("msg{seq}").as_bytes().to_vec(),
                 )
                 .unwrap(),
             );

--- a/icn/crates/icn-net/src/version.rs
+++ b/icn/crates/icn-net/src/version.rs
@@ -83,6 +83,11 @@ bitflags::bitflags! {
         /// Supports hybrid post-quantum key encapsulation (X25519 + ML-KEM)
         const HYBRID_KEM = 0b10000000000;
 
+        /// Supports postcard wire encoding (more compact than bincode)
+        /// When both peers support this, messages are encoded with postcard.
+        /// Falls back to bincode for peers without this capability.
+        const POSTCARD_ENCODING = 0b100000000000;
+
         // Future capabilities can be added here
         // Reserve high bits for future use
     }
@@ -120,7 +125,8 @@ impl CapabilityFlags {
             | Self::GOSSIP_PULL
             | Self::MULTI_DEVICE
             | Self::ECONOMIC_SAFETY
-            | Self::MESSAGE_COMPRESSION;
+            | Self::MESSAGE_COMPRESSION
+            | Self::POSTCARD_ENCODING;
 
         // Add post-quantum capabilities if feature is enabled
         #[cfg(feature = "post-quantum")]
@@ -166,6 +172,9 @@ impl CapabilityFlags {
         }
         if self.contains(Self::HYBRID_KEM) {
             features.push("hybrid_kem");
+        }
+        if self.contains(Self::POSTCARD_ENCODING) {
+            features.push("postcard_encoding");
         }
         features
     }
@@ -427,6 +436,7 @@ mod tests {
         assert!(caps.contains(CapabilityFlags::MULTI_DEVICE));
         assert!(caps.contains(CapabilityFlags::ECONOMIC_SAFETY));
         assert!(caps.contains(CapabilityFlags::MESSAGE_COMPRESSION));
+        assert!(caps.contains(CapabilityFlags::POSTCARD_ENCODING));
     }
 
     #[test]

--- a/icn/crates/icn-net/tests/encoding_negotiation_integration.rs
+++ b/icn/crates/icn-net/tests/encoding_negotiation_integration.rs
@@ -1,0 +1,308 @@
+//! Integration tests for wire encoding negotiation
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//!
+//! Tests that verify encoding negotiation between nodes with different capabilities:
+//! - Both nodes support postcard: use postcard encoding
+//! - One node doesn't support postcard: fall back to bincode
+//! - Version info exchange includes POSTCARD_ENCODING capability
+
+use anyhow::Result;
+use icn_identity::KeyPair;
+use icn_net::{
+    common_capabilities, CapabilityFlags, EncodingFormat, MessagePayload, NetworkMessage,
+    VersionInfo,
+};
+
+/// Test that POSTCARD_ENCODING capability is included in current capabilities
+#[test]
+fn test_current_capabilities_include_postcard() {
+    let caps = CapabilityFlags::current();
+    assert!(
+        caps.contains(CapabilityFlags::POSTCARD_ENCODING),
+        "Current capabilities should include POSTCARD_ENCODING"
+    );
+}
+
+/// Test capability negotiation when both nodes support postcard
+#[test]
+fn test_both_nodes_support_postcard() {
+    let local = VersionInfo::new("icnd-test".to_string());
+    let remote = VersionInfo::new("icnd-test".to_string());
+
+    let common = common_capabilities(&local, &remote);
+
+    assert!(
+        common.contains(CapabilityFlags::POSTCARD_ENCODING),
+        "Common capabilities should include POSTCARD_ENCODING when both support it"
+    );
+    assert!(
+        common.contains(CapabilityFlags::MESSAGE_COMPRESSION),
+        "Common capabilities should include MESSAGE_COMPRESSION"
+    );
+}
+
+/// Test capability negotiation when remote node doesn't support postcard
+#[test]
+fn test_remote_node_without_postcard() {
+    let local = VersionInfo::new("icnd-test".to_string());
+
+    // Create a remote node that doesn't have POSTCARD_ENCODING
+    let mut remote = VersionInfo::new("icnd-legacy".to_string());
+    remote.capabilities = CapabilityFlags::E2E_ENCRYPTION
+        | CapabilityFlags::SIGNED_MESSAGES
+        | CapabilityFlags::MESSAGE_COMPRESSION;
+
+    let common = common_capabilities(&local, &remote);
+
+    assert!(
+        !common.contains(CapabilityFlags::POSTCARD_ENCODING),
+        "Common capabilities should NOT include POSTCARD_ENCODING when remote doesn't support it"
+    );
+    assert!(
+        common.contains(CapabilityFlags::MESSAGE_COMPRESSION),
+        "Common capabilities should still include MESSAGE_COMPRESSION"
+    );
+}
+
+/// Test that messages can roundtrip with bincode when postcard is not negotiated
+#[test]
+fn test_bincode_fallback_roundtrip() -> Result<()> {
+    let alice = KeyPair::generate()?.did().clone();
+    let bob = KeyPair::generate()?.did().clone();
+
+    let original = NetworkMessage::ping(alice.clone(), bob.clone());
+
+    // Simulate: both nodes don't support postcard, use bincode
+    let use_postcard = false;
+    let enable_compression = true;
+
+    let bytes = original.to_bytes_negotiated(use_postcard, enable_compression)?;
+
+    // Verify wire format byte indicates bincode
+    let (encoding, _) = EncodingFormat::from_wire_byte(bytes[0])?;
+    assert_eq!(encoding, EncodingFormat::Bincode);
+
+    let decoded = NetworkMessage::from_bytes_negotiated(&bytes)?;
+
+    assert_eq!(decoded.from, alice);
+    assert_eq!(decoded.to, Some(bob));
+    assert!(matches!(decoded.payload, MessagePayload::Ping { .. }));
+
+    Ok(())
+}
+
+/// Test that messages can roundtrip with postcard when both support it
+#[test]
+fn test_postcard_roundtrip() -> Result<()> {
+    let alice = KeyPair::generate()?.did().clone();
+    let bob = KeyPair::generate()?.did().clone();
+
+    let original = NetworkMessage::ping(alice.clone(), bob.clone());
+
+    // Simulate: both nodes support postcard
+    let use_postcard = true;
+    let enable_compression = true;
+
+    let bytes = original.to_bytes_negotiated(use_postcard, enable_compression)?;
+
+    // Verify wire format byte indicates postcard
+    let (encoding, _) = EncodingFormat::from_wire_byte(bytes[0])?;
+    assert_eq!(encoding, EncodingFormat::Postcard);
+
+    let decoded = NetworkMessage::from_bytes_negotiated(&bytes)?;
+
+    assert_eq!(decoded.from, alice);
+    assert_eq!(decoded.to, Some(bob));
+    assert!(matches!(decoded.payload, MessagePayload::Ping { .. }));
+
+    Ok(())
+}
+
+/// Test that postcard encoding produces smaller messages than bincode
+#[test]
+fn test_postcard_more_compact() -> Result<()> {
+    let alice = KeyPair::generate()?.did().clone();
+    let bob = KeyPair::generate()?.did().clone();
+
+    let msg = NetworkMessage::ping(alice, bob);
+
+    let bincode_bytes = msg.to_bytes_negotiated(false, false)?;
+    let postcard_bytes = msg.to_bytes_negotiated(true, false)?;
+
+    println!(
+        "Message size comparison: bincode={} bytes, postcard={} bytes",
+        bincode_bytes.len(),
+        postcard_bytes.len()
+    );
+
+    // Postcard should typically be more compact for most messages
+    // (though for very small messages the difference may be negligible)
+    // Both should decode correctly regardless of which is smaller
+    let decoded_bincode = NetworkMessage::from_bytes_negotiated(&bincode_bytes)?;
+    let decoded_postcard = NetworkMessage::from_bytes_negotiated(&postcard_bytes)?;
+
+    assert!(matches!(
+        decoded_bincode.payload,
+        MessagePayload::Ping { .. }
+    ));
+    assert!(matches!(
+        decoded_postcard.payload,
+        MessagePayload::Ping { .. }
+    ));
+
+    Ok(())
+}
+
+/// Test mixed encoding scenario: sender uses postcard, receiver can decode
+#[test]
+fn test_cross_encoding_decode() -> Result<()> {
+    let alice = KeyPair::generate()?.did().clone();
+    let bob = KeyPair::generate()?.did().clone();
+
+    let msg = NetworkMessage::ping(alice.clone(), bob.clone());
+
+    // Alice sends with postcard
+    let postcard_bytes = msg.to_bytes_negotiated(true, false)?;
+
+    // Bob receives and decodes (from_bytes_negotiated auto-detects encoding)
+    let decoded = NetworkMessage::from_bytes_negotiated(&postcard_bytes)?;
+
+    assert_eq!(decoded.from, alice);
+    assert_eq!(decoded.to, Some(bob.clone()));
+    assert!(matches!(decoded.payload, MessagePayload::Ping { .. }));
+
+    // Now test bincode sender
+    let bincode_bytes = msg.to_bytes_negotiated(false, false)?;
+    let decoded = NetworkMessage::from_bytes_negotiated(&bincode_bytes)?;
+
+    assert_eq!(decoded.from, alice);
+    assert_eq!(decoded.to, Some(bob.clone()));
+    assert!(matches!(decoded.payload, MessagePayload::Ping { .. }));
+
+    Ok(())
+}
+
+/// Test capability flag serialization roundtrip
+#[test]
+fn test_capability_flag_serialization() -> Result<()> {
+    let caps = CapabilityFlags::current();
+
+    // Serialize and deserialize
+    let json = serde_json::to_string(&caps)?;
+    let deserialized: CapabilityFlags = serde_json::from_str(&json)?;
+
+    assert_eq!(caps, deserialized);
+    assert!(deserialized.contains(CapabilityFlags::POSTCARD_ENCODING));
+
+    Ok(())
+}
+
+/// Test VersionInfo with POSTCARD_ENCODING in Hello message
+#[test]
+fn test_version_info_in_hello() -> Result<()> {
+    use icn_identity::IdentityBundle;
+
+    let keypair = KeyPair::generate()?;
+    let identity = IdentityBundle::from_keypair(keypair.clone())?;
+    let did = identity.did().clone();
+
+    let other_keypair = KeyPair::generate()?;
+    let other_did = other_keypair.did().clone();
+
+    let version_info = VersionInfo::new("icnd-test".to_string());
+    let binding_info = identity.binding_info();
+
+    // Create Hello message with version info
+    let hello = NetworkMessage::hello(
+        did.clone(),
+        other_did.clone(),
+        binding_info,
+        version_info.clone(),
+        None, // No topology info
+        *identity.x25519_public_bytes(),
+        None, // No ML-DSA
+        None, // No ML-KEM
+    );
+
+    // Serialize with postcard
+    let bytes = hello.to_bytes_negotiated(true, false)?;
+
+    // Deserialize
+    let decoded = NetworkMessage::from_bytes_negotiated(&bytes)?;
+
+    // Verify Hello payload
+    if let MessagePayload::Hello {
+        version_info: Some(decoded_version),
+        ..
+    } = decoded.payload
+    {
+        assert!(decoded_version
+            .capabilities
+            .contains(CapabilityFlags::POSTCARD_ENCODING));
+        assert_eq!(decoded_version.software_version, "icnd-test");
+    } else {
+        panic!("Expected Hello message with version_info");
+    }
+
+    Ok(())
+}
+
+/// Test that compression works with both encodings
+#[test]
+fn test_compression_with_both_encodings() -> Result<()> {
+    use icn_gossip::{types::GossipEntry, GossipMessage, VectorClock};
+
+    let alice = KeyPair::generate()?.did().clone();
+    let bob = KeyPair::generate()?.did().clone();
+
+    // Create a large message that will benefit from compression
+    let mut clock = VectorClock::new();
+    clock.increment(&alice);
+
+    let large_data = vec![42u8; 4096]; // 4KB of compressible data
+    let gossip = GossipMessage::Response {
+        entry: GossipEntry {
+            hash: [1u8; 32],
+            author: alice.clone(),
+            clock,
+            topic: "test".to_string(),
+            data: large_data,
+            compressed: false,
+            timestamp: 0,
+            replica_offered: None,
+        },
+    };
+
+    let msg = NetworkMessage::gossip(alice.clone(), Some(bob.clone()), gossip);
+
+    // Test bincode + compression
+    let bincode_compressed = msg.to_bytes_negotiated(false, true)?;
+    let bincode_uncompressed = msg.to_bytes_negotiated(false, false)?;
+
+    assert!(
+        bincode_compressed.len() < bincode_uncompressed.len(),
+        "Bincode compression should reduce size"
+    );
+
+    // Test postcard + compression
+    let postcard_compressed = msg.to_bytes_negotiated(true, true)?;
+    let postcard_uncompressed = msg.to_bytes_negotiated(true, false)?;
+
+    assert!(
+        postcard_compressed.len() < postcard_uncompressed.len(),
+        "Postcard compression should reduce size"
+    );
+
+    // All should decode correctly
+    let decoded1 = NetworkMessage::from_bytes_negotiated(&bincode_compressed)?;
+    let decoded2 = NetworkMessage::from_bytes_negotiated(&bincode_uncompressed)?;
+    let decoded3 = NetworkMessage::from_bytes_negotiated(&postcard_compressed)?;
+    let decoded4 = NetworkMessage::from_bytes_negotiated(&postcard_uncompressed)?;
+
+    assert!(matches!(decoded1.payload, MessagePayload::Gossip(_)));
+    assert!(matches!(decoded2.payload, MessagePayload::Gossip(_)));
+    assert!(matches!(decoded3.payload, MessagePayload::Gossip(_)));
+    assert!(matches!(decoded4.payload, MessagePayload::Gossip(_)));
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
Phase 3 of bincode→postcard migration (Issue #539).

- Add `POSTCARD_ENCODING` capability flag for capability negotiation
- Add `EncodingFormat` enum with combined wire byte encoding
- Implement dual encoding support in `NetworkMessage`:
  - `to_bytes_negotiated()` - serialize with negotiated encoding
  - `from_bytes_negotiated()` - deserialize with auto-detection
- Add stream helpers: `read_message_negotiated()`, `write_message_negotiated()`
- Wire format byte combines encoding and compression:
  - High nibble (bits 4-7): encoding format (0=bincode, 1=postcard)
  - Low nibble (bits 0-3): compression format (0=none, 1=zstd)

## Wire Format Combinations
| Byte | Encoding | Compression |
|------|----------|-------------|
| 0x00 | bincode  | none        |
| 0x01 | bincode  | zstd        |
| 0x10 | postcard | none        |
| 0x11 | postcard | zstd        |

## Test plan
- [x] 11 new unit tests for encoding negotiation
- [x] Wire byte roundtrip tests for all combinations
- [x] Backward compatibility verification
- [x] All 204 icn-net tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)