### PR TITLE
feat(rpc): Add observability metrics for token revocation list

### DIFF
--- a/icn/crates/icn-obs/src/lib.rs
+++ b/icn/crates/icn-obs/src/lib.rs
@@ -104,6 +104,7 @@ pub fn init_metrics() -> Result<()> {
     // Initialize new submodule metrics descriptions
     metrics::gateway::init_descriptions();
     metrics::network::init_descriptions();
+    metrics::rpc::init_descriptions();
     tracing::info!("Metrics descriptions initialized");
     Ok(())
 }

--- a/icn/crates/icn-obs/src/metrics/mod.rs
+++ b/icn/crates/icn-obs/src/metrics/mod.rs
@@ -30,3 +30,4 @@ pub use legacy::*;
 pub mod gateway;
 pub mod nat;
 pub mod network;
+pub mod rpc;

--- a/icn/crates/icn-obs/src/metrics/rpc.rs
+++ b/icn/crates/icn-obs/src/metrics/rpc.rs
@@ -39,4 +39,8 @@ pub fn init_descriptions() {
         "icn_rpc_revocation_add_duration_seconds",
         "Time taken to add a token to the revocation list"
     );
+    describe_counter!(
+        "icn_rpc_revocation_errors_total",
+        "Total number of revocation operation errors (storage, serialization, lock)"
+    );
 }

--- a/icn/crates/icn-obs/src/metrics/rpc.rs
+++ b/icn/crates/icn-obs/src/metrics/rpc.rs
@@ -1,0 +1,42 @@
+//! RPC metrics
+//!
+//! Metrics for RPC authentication and token revocation.
+
+use metrics::{describe_counter, describe_gauge, describe_histogram};
+
+/// Initialize RPC metric descriptions
+pub fn init_descriptions() {
+    // Token revocation metrics
+    describe_counter!(
+        "icn_rpc_revocation_checks_total",
+        "Total number of token revocation checks performed"
+    );
+    describe_counter!(
+        "icn_rpc_revocation_hits_total",
+        "Total number of revocation checks that found a revoked token (cache hits)"
+    );
+    describe_gauge!(
+        "icn_rpc_revoked_tokens_total",
+        "Current number of revoked tokens in the cache"
+    );
+    describe_histogram!(
+        "icn_rpc_revocation_load_duration_seconds",
+        "Time taken to load token revocation list from storage on startup"
+    );
+    describe_histogram!(
+        "icn_rpc_revocation_cleanup_duration_seconds",
+        "Time taken to clean up expired revocations"
+    );
+    describe_counter!(
+        "icn_rpc_revocation_cleanup_total",
+        "Total number of expired revocation entries cleaned up"
+    );
+    describe_gauge!(
+        "icn_rpc_revocation_scan_entries",
+        "Number of entries scanned during the last cleanup operation"
+    );
+    describe_histogram!(
+        "icn_rpc_revocation_add_duration_seconds",
+        "Time taken to add a token to the revocation list"
+    );
+}

--- a/icn/crates/icn-rpc/src/auth.rs
+++ b/icn/crates/icn-rpc/src/auth.rs
@@ -249,18 +249,20 @@ impl<S: Store> TokenRevocationList<S> {
         // Store persistently
         let key = Self::make_key(jti);
         let value = serde_json::to_vec(&revoked).map_err(|e| {
+            counter!("icn_rpc_revocation_errors_total").increment(1);
             AuthError::InternalError(format!("Failed to serialize revoked token: {e}"))
         })?;
 
-        self.store
-            .put(&key, &value)
-            .map_err(|e| AuthError::InternalError(format!("Failed to store revoked token: {e}")))?;
+        self.store.put(&key, &value).map_err(|e| {
+            counter!("icn_rpc_revocation_errors_total").increment(1);
+            AuthError::InternalError(format!("Failed to store revoked token: {e}"))
+        })?;
 
         // Update cache
-        let mut cache = self
-            .cache
-            .write()
-            .map_err(|e| AuthError::InternalError(format!("Lock poisoned: {e}")))?;
+        let mut cache = self.cache.write().map_err(|e| {
+            counter!("icn_rpc_revocation_errors_total").increment(1);
+            AuthError::InternalError(format!("Lock poisoned: {e}"))
+        })?;
 
         cache.insert(jti.to_string());
 
@@ -279,14 +281,15 @@ impl<S: Store> TokenRevocationList<S> {
     pub fn cleanup_expired(&self) -> Result<usize, AuthError> {
         let start = Instant::now();
 
-        let entries = self
-            .store
-            .scan(REVOKED_TOKEN_PREFIX)
-            .map_err(|e| AuthError::InternalError(format!("Failed to scan revoked tokens: {e}")))?;
+        let entries = self.store.scan(REVOKED_TOKEN_PREFIX).map_err(|e| {
+            counter!("icn_rpc_revocation_errors_total").increment(1);
+            AuthError::InternalError(format!("Failed to scan revoked tokens: {e}"))
+        })?;
 
         let now = Self::current_timestamp()?;
         let mut cleaned = 0;
         let mut scanned = 0;
+        let mut to_remove = Vec::new();
 
         for (key, value) in entries {
             scanned += 1;
@@ -294,19 +297,25 @@ impl<S: Store> TokenRevocationList<S> {
                 if revoked.original_expiry <= now {
                     // Token has expired, remove revocation record
                     self.store.delete(&key).map_err(|e| {
+                        counter!("icn_rpc_revocation_errors_total").increment(1);
                         AuthError::InternalError(format!(
                             "Failed to delete expired revocation: {e}"
                         ))
                     })?;
                     cleaned += 1;
-
-                    // Remove from cache - propagate lock errors
-                    let mut cache = self
-                        .cache
-                        .write()
-                        .map_err(|e| AuthError::InternalError(format!("Lock poisoned: {e}")))?;
-                    cache.remove(&revoked.jti);
+                    to_remove.push(revoked.jti);
                 }
+            }
+        }
+
+        // Batch remove from cache - single lock acquisition instead of O(n)
+        if !to_remove.is_empty() {
+            let mut cache = self.cache.write().map_err(|e| {
+                counter!("icn_rpc_revocation_errors_total").increment(1);
+                AuthError::InternalError(format!("Lock poisoned: {e}"))
+            })?;
+            for jti in to_remove {
+                cache.remove(&jti);
             }
         }
 
@@ -1308,6 +1317,9 @@ mod tests {
     /// of the same token correctly. The revoke() operation is idempotent - multiple
     /// threads revoking the same token will all succeed, but the token will only
     /// appear once in the cache (HashMap::insert overwrites).
+    ///
+    /// Note: This test validates in-memory concurrency only. It does not test
+    /// concurrent access from different process instances sharing the same storage.
     #[test]
     fn test_concurrent_token_revocation() {
         use std::sync::Arc;

--- a/icn/crates/icn-rpc/src/auth.rs
+++ b/icn/crates/icn-rpc/src/auth.rs
@@ -230,6 +230,7 @@ impl<S: Store> TokenRevocationList<S> {
         original_expiry: u64,
         reason: Option<String>,
     ) -> Result<(), AuthError> {
+        let start = Instant::now();
         let now = Self::current_timestamp()?;
 
         // Don't revoke already-expired tokens
@@ -265,6 +266,9 @@ impl<S: Store> TokenRevocationList<S> {
 
         // Update gauge with current count
         gauge!("icn_rpc_revoked_tokens_total").set(cache.len() as f64);
+
+        // Record operation duration
+        histogram!("icn_rpc_revocation_add_duration_seconds").record(start.elapsed().as_secs_f64());
 
         tracing::info!(jti = %jti, subject = %subject, "Token revoked");
 
@@ -312,11 +316,9 @@ impl<S: Store> TokenRevocationList<S> {
         counter!("icn_rpc_revocation_cleanup_total").increment(cleaned as u64);
         gauge!("icn_rpc_revocation_scan_entries").set(scanned as f64);
 
-        // Update the revoked tokens gauge after cleanup
-        if cleaned > 0 {
-            if let Ok(cache) = self.cache.read() {
-                gauge!("icn_rpc_revoked_tokens_total").set(cache.len() as f64);
-            }
+        // Always update the revoked tokens gauge to reflect current cache size
+        if let Ok(cache) = self.cache.read() {
+            gauge!("icn_rpc_revoked_tokens_total").set(cache.len() as f64);
         }
 
         Ok(cleaned)
@@ -1300,6 +1302,12 @@ mod tests {
         assert!(!trl.is_revoked("old-jti"));
     }
 
+    /// Test concurrent token revocation from multiple threads.
+    ///
+    /// Verifies that the TRL is thread-safe and handles concurrent revocations
+    /// of the same token correctly. The revoke() operation is idempotent - multiple
+    /// threads revoking the same token will all succeed, but the token will only
+    /// appear once in the cache (HashMap::insert overwrites).
     #[test]
     fn test_concurrent_token_revocation() {
         use std::sync::Arc;

--- a/icn/crates/icn-rpc/src/auth.rs
+++ b/icn/crates/icn-rpc/src/auth.rs
@@ -13,10 +13,11 @@
 
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::broadcast;
 
 use ed25519_dalek::{Signature, Verifier};
+use metrics::{counter, gauge, histogram};
 use icn_identity::Did;
 use icn_store::Store;
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
@@ -155,6 +156,8 @@ impl<S: Store> TokenRevocationList<S> {
 
     /// Load revoked tokens from persistent storage into memory cache
     fn load_cache(&self) -> Result<(), AuthError> {
+        let start = Instant::now();
+
         let entries = self
             .store
             .scan(REVOKED_TOKEN_PREFIX)
@@ -166,8 +169,10 @@ impl<S: Store> TokenRevocationList<S> {
             .map_err(|e| AuthError::InternalError(format!("Lock poisoned: {e}")))?;
 
         let now = Self::current_timestamp()?;
+        let mut scanned = 0;
 
         for (_key, value) in entries {
+            scanned += 1;
             if let Ok(revoked) = serde_json::from_slice::<RevokedToken>(&value) {
                 // Only cache tokens that haven't expired yet
                 if revoked.original_expiry > now {
@@ -175,6 +180,18 @@ impl<S: Store> TokenRevocationList<S> {
                 }
             }
         }
+
+        // Record load metrics
+        let duration = start.elapsed();
+        histogram!("icn_rpc_revocation_load_duration_seconds").record(duration.as_secs_f64());
+        gauge!("icn_rpc_revoked_tokens_total").set(cache.len() as f64);
+
+        tracing::info!(
+            loaded = cache.len(),
+            scanned = scanned,
+            duration_ms = duration.as_millis(),
+            "Loaded token revocation list from storage"
+        );
 
         Ok(())
     }
@@ -187,13 +204,22 @@ impl<S: Store> TokenRevocationList<S> {
     /// - The persistent storage is the source of truth; cache is only a performance optimization
     /// - Better to allow one potentially-revoked token through than reject all valid tokens
     pub fn is_revoked(&self, jti: &str) -> bool {
-        self.cache
+        counter!("icn_rpc_revocation_checks_total").increment(1);
+
+        let is_revoked = self
+            .cache
             .read()
             .map(|cache| cache.contains(jti))
             .unwrap_or_else(|e| {
                 tracing::warn!(error = %e, jti = %jti, "Cache lock poisoned in is_revoked, failing open");
                 false
-            })
+            });
+
+        if is_revoked {
+            counter!("icn_rpc_revocation_hits_total").increment(1);
+        }
+
+        is_revoked
     }
 
     /// Revoke a token
@@ -237,6 +263,9 @@ impl<S: Store> TokenRevocationList<S> {
 
         cache.insert(jti.to_string());
 
+        // Update gauge with current count
+        gauge!("icn_rpc_revoked_tokens_total").set(cache.len() as f64);
+
         tracing::info!(jti = %jti, subject = %subject, "Token revoked");
 
         Ok(())
@@ -244,6 +273,8 @@ impl<S: Store> TokenRevocationList<S> {
 
     /// Clean up expired revocations from storage
     pub fn cleanup_expired(&self) -> Result<usize, AuthError> {
+        let start = Instant::now();
+
         let entries = self
             .store
             .scan(REVOKED_TOKEN_PREFIX)
@@ -251,8 +282,10 @@ impl<S: Store> TokenRevocationList<S> {
 
         let now = Self::current_timestamp()?;
         let mut cleaned = 0;
+        let mut scanned = 0;
 
         for (key, value) in entries {
+            scanned += 1;
             if let Ok(revoked) = serde_json::from_slice::<RevokedToken>(&value) {
                 if revoked.original_expiry <= now {
                     // Token has expired, remove revocation record
@@ -270,6 +303,19 @@ impl<S: Store> TokenRevocationList<S> {
                         .map_err(|e| AuthError::InternalError(format!("Lock poisoned: {e}")))?;
                     cache.remove(&revoked.jti);
                 }
+            }
+        }
+
+        // Record cleanup metrics
+        let duration = start.elapsed();
+        histogram!("icn_rpc_revocation_cleanup_duration_seconds").record(duration.as_secs_f64());
+        counter!("icn_rpc_revocation_cleanup_total").increment(cleaned as u64);
+        gauge!("icn_rpc_revocation_scan_entries").set(scanned as f64);
+
+        // Update the revoked tokens gauge after cleanup
+        if cleaned > 0 {
+            if let Ok(cache) = self.cache.read() {
+                gauge!("icn_rpc_revoked_tokens_total").set(cache.len() as f64);
             }
         }
 
@@ -1252,5 +1298,69 @@ mod tests {
         assert_eq!(trl.count(), 1);
         assert!(trl.is_revoked("new-jti"));
         assert!(!trl.is_revoked("old-jti"));
+    }
+
+    #[test]
+    fn test_concurrent_token_revocation() {
+        use std::sync::Arc;
+        use std::thread;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let store = Arc::new(icn_store::SledStore::temporary().unwrap());
+        let trl = Arc::new(TokenRevocationList::new(Arc::clone(&store)).unwrap());
+
+        // Token expiry 1 hour from now
+        let expiry = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 3600;
+
+        let jti = "concurrent-test-jti";
+        let subject = "did:icn:concurrent-test";
+
+        // Spawn multiple threads all trying to revoke the same token
+        let num_threads = 10;
+        let handles: Vec<_> = (0..num_threads)
+            .map(|i| {
+                let trl = Arc::clone(&trl);
+                let jti = jti.to_string();
+                let subject = subject.to_string();
+                thread::spawn(move || {
+                    // Each thread tries to revoke the same token
+                    let result = trl.revoke(&jti, &subject, expiry, Some(format!("thread-{i}")));
+                    // Should succeed (idempotent operation)
+                    result.is_ok()
+                })
+            })
+            .collect();
+
+        // Wait for all threads and collect results
+        let results: Vec<bool> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+        // All threads should have succeeded
+        assert!(
+            results.iter().all(|&r| r),
+            "All concurrent revocations should succeed"
+        );
+
+        // Token should be revoked exactly once in the cache
+        assert_eq!(trl.count(), 1, "Token should be in cache exactly once");
+        assert!(trl.is_revoked(jti), "Token should be marked as revoked");
+
+        // Verify concurrent reads don't cause issues
+        let read_handles: Vec<_> = (0..num_threads)
+            .map(|_| {
+                let trl = Arc::clone(&trl);
+                let jti = jti.to_string();
+                thread::spawn(move || trl.is_revoked(&jti))
+            })
+            .collect();
+
+        let read_results: Vec<bool> = read_handles.into_iter().map(|h| h.join().unwrap()).collect();
+        assert!(
+            read_results.iter().all(|&r| r),
+            "All concurrent reads should return revoked"
+        );
     }
 }

--- a/icn/crates/icn-rpc/src/auth.rs
+++ b/icn/crates/icn-rpc/src/auth.rs
@@ -17,10 +17,10 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::broadcast;
 
 use ed25519_dalek::{Signature, Verifier};
-use metrics::{counter, gauge, histogram};
 use icn_identity::Did;
 use icn_store::Store;
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
+use metrics::{counter, gauge, histogram};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -1365,7 +1365,10 @@ mod tests {
             })
             .collect();
 
-        let read_results: Vec<bool> = read_handles.into_iter().map(|h| h.join().unwrap()).collect();
+        let read_results: Vec<bool> = read_handles
+            .into_iter()
+            .map(|h| h.join().unwrap())
+            .collect();
         assert!(
             read_results.iter().all(|&r| r),
             "All concurrent reads should return revoked"


### PR DESCRIPTION
## Summary
- Add comprehensive metrics to the TokenRevocationList for monitoring revocation operations
- Add concurrent revocation test to verify thread safety of the TRL implementation

## Metrics Added
| Metric | Type | Description |
|--------|------|-------------|
| `icn_rpc_revocation_checks_total` | Counter | Total revocation check calls |
| `icn_rpc_revocation_hits_total` | Counter | Cache hits (revoked tokens found) |
| `icn_rpc_revoked_tokens_total` | Gauge | Active revoked tokens in cache |
| `icn_rpc_revocation_load_duration_seconds` | Histogram | Cache load time on startup |
| `icn_rpc_revocation_cleanup_duration_seconds` | Histogram | Cleanup operation duration |
| `icn_rpc_revocation_cleanup_total` | Counter | Entries cleaned up (expired) |
| `icn_rpc_revocation_scan_entries` | Gauge | Entries scanned per operation |

## Test plan
- [x] All 14 auth tests pass
- [x] New concurrent revocation test verifies thread safety with 10 threads

Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)