### PR TITLE
feat(ledger): Add per-currency-pair oracle rate thresholds (#474)

### DIFF
--- a/config/icn.toml.example
+++ b/config/icn.toml.example
@@ -251,6 +251,35 @@ max_concurrent_recoveries = 50
 token_validity_secs = 604800
 
 # =============================================================================
+# LEDGER & ORACLE (Exchange Rates)
+# =============================================================================
+[ledger.oracle]
+# Default TTL for cached exchange rates (seconds)
+default_ttl_secs = 3600
+
+# Minimum sources required for rate consensus
+min_sources_for_consensus = 1
+
+# Maximum deviation from median for valid rate (0.15 = 15%)
+outlier_threshold = 0.15
+
+# Staleness threshold for rates (seconds)
+staleness_threshold_secs = 86400
+
+# Default suspicious rate threshold for unconfigured currency pairs.
+# Rates exceeding this trigger additional validation.
+# Most major pairs (EUR/USD, GBP/USD) range 0.01 to ~150.
+default_suspicious_rate_threshold = 1000.0
+
+# Per-currency-pair rate thresholds.
+# Use for pairs that legitimately exceed the default (e.g., JPY, crypto).
+# Key format: "FROM:TO" (e.g., "USD:JPY", "BTC:USD")
+[ledger.oracle.suspicious_rate_thresholds]
+# "USD:JPY" = 200.0      # JPY pairs typically ~100-150
+# "BTC:USD" = 100000.0   # Crypto pairs can be very high
+# "hours:USD" = 500.0    # Cooperative time credits
+
+# =============================================================================
 # SUPERVISOR (Background Tasks & Timeouts)
 # =============================================================================
 [supervisor]

--- a/icn/crates/icn-core/src/config/ledger.rs
+++ b/icn/crates/icn-core/src/config/ledger.rs
@@ -1,0 +1,233 @@
+//! Ledger configuration
+//!
+//! Configuration for the mutual credit ledger and exchange rate oracle.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Default suspicious rate threshold for unconfigured pairs
+pub const DEFAULT_SUSPICIOUS_RATE_THRESHOLD: f64 = 1000.0;
+
+/// Configuration for the ledger subsystem
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LedgerConfig {
+    /// Oracle configuration for exchange rates
+    #[serde(default)]
+    pub oracle: OracleNodeConfig,
+}
+
+/// Configuration for the exchange rate oracle
+///
+/// This configuration controls how exchange rates are validated and
+/// what thresholds are used for suspicious rate detection.
+///
+/// # Example Configuration
+///
+/// ```toml
+/// [ledger.oracle]
+/// default_ttl_secs = 3600
+/// min_sources_for_consensus = 1
+/// outlier_threshold = 0.15
+/// staleness_threshold_secs = 86400
+/// default_suspicious_rate_threshold = 1000.0
+///
+/// # Per-currency-pair rate thresholds
+/// [ledger.oracle.suspicious_rate_thresholds]
+/// "USD:JPY" = 200.0      # JPY pairs have higher absolute rates
+/// "BTC:USD" = 100000.0   # Crypto pairs can be very high
+/// "hours:USD" = 500.0    # Cooperative time credits
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OracleNodeConfig {
+    /// Default TTL for cached rates (seconds)
+    #[serde(default = "default_ttl_secs")]
+    pub default_ttl_secs: u64,
+
+    /// Minimum number of sources for consensus
+    #[serde(default = "default_min_sources")]
+    pub min_sources_for_consensus: usize,
+
+    /// Maximum deviation from median to be considered valid (e.g., 0.15 = 15%)
+    #[serde(default = "default_outlier_threshold")]
+    pub outlier_threshold: f64,
+
+    /// Staleness threshold (seconds since last update)
+    #[serde(default = "default_staleness_threshold")]
+    pub staleness_threshold_secs: u64,
+
+    /// Default suspicious rate threshold for pairs not in `suspicious_rate_thresholds`
+    ///
+    /// Exchange rates exceeding this value trigger additional validation.
+    /// Most major currency pairs (EUR/USD, GBP/USD) range from 0.01 to ~150.
+    /// Higher values may indicate oracle misconfiguration.
+    #[serde(default = "default_suspicious_threshold")]
+    pub default_suspicious_rate_threshold: f64,
+
+    /// Per-currency-pair suspicious rate thresholds
+    ///
+    /// Key format: "FROM:TO" (e.g., "USD:JPY", "BTC:USD").
+    /// Use this to configure appropriate thresholds for pairs that
+    /// legitimately exceed the default threshold.
+    ///
+    /// Common examples:
+    /// - "USD:JPY" = 200.0 (typically ~100-150)
+    /// - "BTC:USD" = 100000.0 (can be very high)
+    /// - "hours:USD" = 500.0 (cooperative time credits)
+    #[serde(default)]
+    pub suspicious_rate_thresholds: HashMap<String, f64>,
+}
+
+fn default_ttl_secs() -> u64 {
+    3600 // 1 hour
+}
+
+fn default_min_sources() -> usize {
+    1
+}
+
+fn default_outlier_threshold() -> f64 {
+    0.15 // 15%
+}
+
+fn default_staleness_threshold() -> u64 {
+    86400 // 24 hours
+}
+
+fn default_suspicious_threshold() -> f64 {
+    DEFAULT_SUSPICIOUS_RATE_THRESHOLD
+}
+
+impl Default for OracleNodeConfig {
+    fn default() -> Self {
+        Self {
+            default_ttl_secs: default_ttl_secs(),
+            min_sources_for_consensus: default_min_sources(),
+            outlier_threshold: default_outlier_threshold(),
+            staleness_threshold_secs: default_staleness_threshold(),
+            default_suspicious_rate_threshold: default_suspicious_threshold(),
+            suspicious_rate_thresholds: HashMap::new(),
+        }
+    }
+}
+
+impl OracleNodeConfig {
+    /// Convert to the icn-ledger OracleConfig type
+    pub fn to_oracle_config(&self) -> icn_ledger::oracle::OracleConfig {
+        let mut config = icn_ledger::oracle::OracleConfig {
+            default_ttl_secs: self.default_ttl_secs,
+            min_sources_for_consensus: self.min_sources_for_consensus,
+            outlier_threshold: self.outlier_threshold,
+            staleness_threshold_secs: self.staleness_threshold_secs,
+            default_suspicious_rate_threshold: self.default_suspicious_rate_threshold,
+            suspicious_rate_thresholds: self.suspicious_rate_thresholds.clone(),
+        };
+
+        // Ensure per-pair thresholds are set
+        for (pair, threshold) in &self.suspicious_rate_thresholds {
+            config
+                .suspicious_rate_thresholds
+                .insert(pair.clone(), *threshold);
+        }
+
+        config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ledger_config_defaults() {
+        let config = LedgerConfig::default();
+
+        assert_eq!(config.oracle.default_ttl_secs, 3600);
+        assert_eq!(config.oracle.min_sources_for_consensus, 1);
+        assert!((config.oracle.outlier_threshold - 0.15).abs() < f64::EPSILON);
+        assert_eq!(config.oracle.staleness_threshold_secs, 86400);
+        assert!(
+            (config.oracle.default_suspicious_rate_threshold - DEFAULT_SUSPICIOUS_RATE_THRESHOLD)
+                .abs()
+                < f64::EPSILON
+        );
+        assert!(config.oracle.suspicious_rate_thresholds.is_empty());
+    }
+
+    #[test]
+    fn test_oracle_config_serialization() {
+        let toml_str = r#"
+default_ttl_secs = 7200
+min_sources_for_consensus = 2
+outlier_threshold = 0.10
+staleness_threshold_secs = 43200
+default_suspicious_rate_threshold = 500.0
+
+[suspicious_rate_thresholds]
+"USD:JPY" = 200.0
+"BTC:USD" = 100000.0
+"hours:USD" = 500.0
+"#;
+
+        let config: OracleNodeConfig = toml::from_str(toml_str).unwrap();
+
+        assert_eq!(config.default_ttl_secs, 7200);
+        assert_eq!(config.min_sources_for_consensus, 2);
+        assert!((config.outlier_threshold - 0.10).abs() < f64::EPSILON);
+        assert_eq!(config.staleness_threshold_secs, 43200);
+        assert!((config.default_suspicious_rate_threshold - 500.0).abs() < f64::EPSILON);
+        assert_eq!(
+            config.suspicious_rate_thresholds.get("USD:JPY"),
+            Some(&200.0)
+        );
+        assert_eq!(
+            config.suspicious_rate_thresholds.get("BTC:USD"),
+            Some(&100000.0)
+        );
+        assert_eq!(
+            config.suspicious_rate_thresholds.get("hours:USD"),
+            Some(&500.0)
+        );
+    }
+
+    #[test]
+    fn test_to_oracle_config() {
+        let mut node_config = OracleNodeConfig::default();
+        node_config.default_suspicious_rate_threshold = 500.0;
+        node_config
+            .suspicious_rate_thresholds
+            .insert("USD:JPY".to_string(), 200.0);
+
+        let oracle_config = node_config.to_oracle_config();
+
+        assert_eq!(oracle_config.default_ttl_secs, 3600);
+        assert!((oracle_config.default_suspicious_rate_threshold - 500.0).abs() < f64::EPSILON);
+        assert_eq!(
+            oracle_config.suspicious_rate_thresholds.get("USD:JPY"),
+            Some(&200.0)
+        );
+    }
+
+    #[test]
+    fn test_partial_config() {
+        // Test that we can provide only some fields and get defaults for others
+        let toml_str = r#"
+default_suspicious_rate_threshold = 2000.0
+
+[suspicious_rate_thresholds]
+"BTC:USD" = 150000.0
+"#;
+
+        let config: OracleNodeConfig = toml::from_str(toml_str).unwrap();
+
+        // Custom values
+        assert!((config.default_suspicious_rate_threshold - 2000.0).abs() < f64::EPSILON);
+        assert_eq!(
+            config.suspicious_rate_thresholds.get("BTC:USD"),
+            Some(&150000.0)
+        );
+
+        // Default values
+        assert_eq!(config.default_ttl_secs, 3600);
+        assert_eq!(config.min_sources_for_consensus, 1);
+    }
+}

--- a/icn/crates/icn-core/src/config/ledger.rs
+++ b/icn/crates/icn-core/src/config/ledger.rs
@@ -5,8 +5,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-/// Default suspicious rate threshold for unconfigured pairs
-pub const DEFAULT_SUSPICIOUS_RATE_THRESHOLD: f64 = 1000.0;
+// Re-export from icn-ledger to maintain single source of truth
+pub use icn_ledger::oracle::DEFAULT_SUSPICIOUS_RATE_THRESHOLD;
 
 /// Configuration for the ledger subsystem
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -113,23 +113,14 @@ impl Default for OracleNodeConfig {
 impl OracleNodeConfig {
     /// Convert to the icn-ledger OracleConfig type
     pub fn to_oracle_config(&self) -> icn_ledger::oracle::OracleConfig {
-        let mut config = icn_ledger::oracle::OracleConfig {
+        icn_ledger::oracle::OracleConfig {
             default_ttl_secs: self.default_ttl_secs,
             min_sources_for_consensus: self.min_sources_for_consensus,
             outlier_threshold: self.outlier_threshold,
             staleness_threshold_secs: self.staleness_threshold_secs,
             default_suspicious_rate_threshold: self.default_suspicious_rate_threshold,
             suspicious_rate_thresholds: self.suspicious_rate_thresholds.clone(),
-        };
-
-        // Ensure per-pair thresholds are set
-        for (pair, threshold) in &self.suspicious_rate_thresholds {
-            config
-                .suspicious_rate_thresholds
-                .insert(pair.clone(), *threshold);
         }
-
-        config
     }
 }
 
@@ -191,11 +182,14 @@ default_suspicious_rate_threshold = 500.0
 
     #[test]
     fn test_to_oracle_config() {
-        let mut node_config = OracleNodeConfig::default();
-        node_config.default_suspicious_rate_threshold = 500.0;
-        node_config
-            .suspicious_rate_thresholds
-            .insert("USD:JPY".to_string(), 200.0);
+        let mut thresholds = std::collections::HashMap::new();
+        thresholds.insert("USD:JPY".to_string(), 200.0);
+
+        let node_config = OracleNodeConfig {
+            default_suspicious_rate_threshold: 500.0,
+            suspicious_rate_thresholds: thresholds,
+            ..Default::default()
+        };
 
         let oracle_config = node_config.to_oracle_config();
 

--- a/icn/crates/icn-core/src/config/mod.rs
+++ b/icn/crates/icn-core/src/config/mod.rs
@@ -6,6 +6,7 @@
 mod cooperative;
 mod federation;
 mod gateway;
+mod ledger;
 mod network;
 mod observability;
 mod privacy;
@@ -16,6 +17,7 @@ mod supervisor;
 pub use cooperative::*;
 pub use federation::*;
 pub use gateway::*;
+pub use ledger::*;
 pub use network::*;
 pub use observability::*;
 pub use privacy::*;
@@ -71,6 +73,10 @@ pub struct Config {
     /// Supervisor configuration for background tasks and timeouts
     #[serde(default)]
     pub supervisor: SupervisorConfig,
+
+    /// Ledger configuration for mutual credit and exchange rate oracle
+    #[serde(default)]
+    pub ledger: LedgerConfig,
 }
 
 impl Default for Config {
@@ -108,6 +114,7 @@ impl Default for Config {
             cooperative: CooperativeConfig::default(),
             steward: StewardNodeConfig::default(),
             supervisor: SupervisorConfig::default(),
+            ledger: LedgerConfig::default(),
         }
     }
 }

--- a/icn/crates/icn-core/src/supervisor/init_ledger.rs
+++ b/icn/crates/icn-core/src/supervisor/init_ledger.rs
@@ -10,7 +10,7 @@ use tracing::info;
 use icn_gossip::GossipActor;
 use icn_identity::Did;
 use icn_ledger::{
-    CreditPolicy, CreditPolicyManager, DisputeManager, Ledger, NewMemberPolicy,
+    CreditPolicy, CreditPolicyManager, DisputeManager, Ledger, NewMemberPolicy, OracleManager,
     SledMembershipStore, TreasuryManager,
 };
 use icn_security::MisbehaviorDetector;
@@ -68,6 +68,24 @@ pub async fn init_ledger_services(
     ledger.set_gossip(deps.gossip_handle.clone());
     ledger.set_misbehavior_detector(deps.misbehavior_detector.clone());
     ledger.set_trust_graph(deps.trust_graph.clone());
+
+    // Initialize oracle manager with per-pair rate thresholds from config (Issue #474)
+    let oracle_config = config.ledger.oracle.to_oracle_config();
+    let threshold_count = oracle_config.suspicious_rate_thresholds.len();
+    let oracle_manager = Arc::new(OracleManager::with_config(store.clone(), oracle_config));
+    ledger.set_oracle_manager(oracle_manager);
+
+    if threshold_count > 0 {
+        info!(
+            "Oracle manager initialized with {} per-pair rate threshold(s)",
+            threshold_count
+        );
+    } else {
+        info!(
+            "Oracle manager initialized with default threshold {}",
+            config.ledger.oracle.default_suspicious_rate_threshold
+        );
+    }
 
     // Initialize membership store for tracking when members joined
     // Used for new member credit limit ramping


### PR DESCRIPTION
## Summary

Implements configurable per-currency-pair suspicious rate thresholds for the exchange rate oracle, addressing issue #474.

- Adds `LedgerConfig` with `OracleNodeConfig` to node configuration
- Wires oracle config from node config to ledger initialization  
- Adds config documentation with examples for JPY, BTC, and hours pairs
- Updates `icn.toml.example` with `[ledger.oracle]` section

## Configuration Example

```toml
[ledger.oracle]
default_ttl_secs = 3600
min_sources_for_consensus = 1
outlier_threshold = 0.15
staleness_threshold_secs = 86400
default_suspicious_rate_threshold = 1000.0

[ledger.oracle.suspicious_rate_thresholds]
"USD:JPY" = 200.0      # JPY pairs typically ~100-150
"BTC:USD" = 100000.0   # Crypto pairs can be very high
"hours:USD" = 500.0    # Cooperative time credits
```

## Test plan

- [x] All config tests pass (`cargo test -p icn-core --lib config::`)
- [x] Clippy clean
- [x] Example config parses correctly

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)