### PR TITLE
refactor(encoding): Remove unnecessary bincode derives from test code

### DIFF
--- a/icn/crates/icn-encoding/src/lib.rs
+++ b/icn/crates/icn-encoding/src/lib.rs
@@ -212,7 +212,7 @@ mod tests {
     use super::*;
     use serde::{Deserialize, Serialize};
 
-    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, bincode::Encode, bincode::Decode)]
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
     struct TestData {
         name: String,
         value: u64,


### PR DESCRIPTION
## Summary

Remove unnecessary `bincode::Encode` and `bincode::Decode` derives from the test struct in `icn-encoding`. These are not needed since we use `bincode::serde::*` functions which work with only serde derives.

## Why

This is a small step toward the Phase 4 goal of removing the bincode dependency (#540).

## Migration Status Assessment

After analyzing the codebase, the full bincode removal requires:

### Current State
- **17 crates** have bincode in Cargo.toml
- **200+ direct bincode usages** across the codebase
- Wire protocol encoding negotiation is **complete** (icn-net)
- Storage versioned encoding is **available** in icn-encoding but not yet adopted

### What Phase 4 Actually Requires

1. **Storage Migration (Phase 2)**: Migrate all storage operations to use `icn_encoding::encode_versioned` / `decode_versioned`
   - icn-identity (sync.rs, recovery.rs, keybundle.rs, multi_device.rs)
   - icn-coop, icn-community, icn-compute storage
   - icn-ccl registry
   - icn-snapshot coordinator

2. **Wire Protocol (Phase 3)**: Already complete via `CapabilityFlags::POSTCARD_ENCODING` negotiation

3. **Error Type Migration**: Update `From<bincode::error::*>` implementations in:
   - icn-coop, icn-compute, icn-ledger, icn-core error types

4. **Test/Benchmark Code**: Convert direct bincode usage to icn-encoding
   - 25+ test files using bincode directly
   - 4 benchmark files

### Prerequisites Not Met

The issue's prerequisites #537, #538, #539 don't exist as issues. The migration work needs to be tracked properly.

## Risk

- None: This only removes unused derives from test code

## Test Plan

- [x] `cargo test -p icn-encoding` passes
- [x] `cargo test -p icn-identity -p icn-gossip -p icn-ledger` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)