### PR TITLE
fix(net): Improve QUIC test stability infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,12 @@ jobs:
         with:
           workspaces: "icn -> target"
 
-      - name: Run tests
-        run: cargo test --workspace
+      - name: Run unit tests (parallel)
+        run: cargo test --workspace --lib
+        working-directory: ./icn
+
+      - name: Run integration tests (serial to avoid port conflicts)
+        run: cargo test --workspace --test '*' -- --test-threads=1
         working-directory: ./icn
 
       - name: Run sled storage tests

--- a/icn/crates/icn-net/src/actor.rs
+++ b/icn/crates/icn-net/src/actor.rs
@@ -1628,6 +1628,9 @@ impl NetworkActor {
                                 // Track rate limiting metric
                                 icn_obs::metrics::network::messages_rate_limited_inc();
 
+                                // Close stream before continuing to avoid resource leak
+                                let _ = send.finish();
+
                                 // Drop the message (don't call handler)
                                 continue;
                             }
@@ -1773,7 +1776,9 @@ impl NetworkActor {
                     }
 
                     // Close the stream
-                    let _ = send.finish();
+                    if let Err(e) = send.finish() {
+                        tracing::debug!("Stream finish error (normal during disconnect): {}", e);
+                    }
                 }
                 Err(quinn::ConnectionError::ApplicationClosed(_)) => {
                     info!("Connection closed by peer");

--- a/icn/crates/icn-net/src/actor.rs
+++ b/icn/crates/icn-net/src/actor.rs
@@ -1629,7 +1629,9 @@ impl NetworkActor {
                                 icn_obs::metrics::network::messages_rate_limited_inc();
 
                                 // Close stream before continuing to avoid resource leak
-                                let _ = send.finish();
+                                if let Err(e) = send.finish() {
+                                    tracing::debug!("Stream finish error during rate limit: {}", e);
+                                }
 
                                 // Drop the message (don't call handler)
                                 continue;

--- a/icn/crates/icn-net/src/protocol.rs
+++ b/icn/crates/icn-net/src/protocol.rs
@@ -2218,8 +2218,7 @@ mod tests {
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("Decompressed message too large"),
-            "Expected 'too large' error, got: {}",
-            err
+            "Expected 'too large' error, got: {err}"
         );
     }
 

--- a/icn/crates/icn-net/tests/client_cert_verification_integration.rs
+++ b/icn/crates/icn-net/tests/client_cert_verification_integration.rs
@@ -17,6 +17,11 @@ use std::time::Duration;
 use tokio::sync::{broadcast, mpsc, RwLock};
 use tracing::info;
 
+/// Get an available port to avoid conflicts when tests run in parallel
+fn pick_port() -> u16 {
+    portpicker::pick_unused_port().expect("No available ports")
+}
+
 /// Test helper for spawning nodes with configurable trust settings
 #[allow(dead_code)]
 struct SecureTestNode {
@@ -187,7 +192,7 @@ impl SecureTestNode {
 /// This test passes consistently locally but intermittently fails in CI.
 /// The actual functionality is well-tested by other integration tests.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "Flaky on CI runners - mDNS timing issues"]
+#[ignore = "QUIC deserialization issue - see issue for tracking"]
 async fn test_client_cert_verification_allows_trusted_peer() -> Result<()> {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     let _ = tracing_subscriber::fmt()
@@ -224,7 +229,7 @@ async fn test_client_cert_verification_allows_trusted_peer() -> Result<()> {
     });
 
     let alice_identity = IdentityBundle::from_keypair(alice_keypair)?;
-    let alice_addr: SocketAddr = "127.0.0.1:25000".parse()?;
+    let alice_addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
     let _alice_handle = NetworkActor::spawn(
         alice_identity,
         alice_addr,
@@ -250,7 +255,7 @@ async fn test_client_cert_verification_allows_trusted_peer() -> Result<()> {
     // Create Bob (no trust graph needed for client role)
     let (bob_shutdown_tx, _) = broadcast::channel(1);
     let bob_identity = IdentityBundle::from_keypair(bob_keypair)?;
-    let bob_addr: SocketAddr = "127.0.0.1:25001".parse()?;
+    let bob_addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
     let bob_handle = NetworkActor::spawn(
         bob_identity,
         bob_addr,
@@ -303,7 +308,7 @@ async fn test_client_cert_verification_allows_trusted_peer() -> Result<()> {
 
 /// Test that untrusted peer is REJECTED when client cert verification is enabled
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "Flaky in CI: QUIC stream failures in containerized environment"]
+#[ignore = "QUIC deserialization issue - see issue for tracking"]
 async fn test_client_cert_verification_rejects_untrusted_peer() -> Result<()> {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     let _ = tracing_subscriber::fmt()
@@ -326,7 +331,7 @@ async fn test_client_cert_verification_rejects_untrusted_peer() -> Result<()> {
 
     let (alice_shutdown_tx, _) = broadcast::channel(1);
     let alice_identity = IdentityBundle::from_keypair(alice_keypair)?;
-    let alice_addr: SocketAddr = "127.0.0.1:25100".parse()?;
+    let alice_addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
     let _alice_handle = NetworkActor::spawn(
         alice_identity,
         alice_addr,
@@ -352,7 +357,7 @@ async fn test_client_cert_verification_rejects_untrusted_peer() -> Result<()> {
     // Create Mallory
     let (mallory_shutdown_tx, _) = broadcast::channel(1);
     let mallory_identity = IdentityBundle::from_keypair(mallory_keypair)?;
-    let mallory_addr: SocketAddr = "127.0.0.1:25101".parse()?;
+    let mallory_addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
     let mallory_handle = NetworkActor::spawn(
         mallory_identity,
         mallory_addr,
@@ -409,13 +414,13 @@ async fn test_dev_mode_no_client_cert_verification() -> Result<()> {
     info!("=== Test: Dev mode without client cert verification ===");
 
     // Create node WITHOUT trust graph (dev mode)
-    let alice = SecureTestNode::spawn_no_trust(25200).await?;
+    let alice = SecureTestNode::spawn_no_trust(pick_port()).await?;
     info!("Alice started in dev mode (no client cert verification)");
 
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     // Create Bob (also no trust graph)
-    let bob = SecureTestNode::spawn_no_trust(25201).await?;
+    let bob = SecureTestNode::spawn_no_trust(pick_port()).await?;
     info!("Bob started in dev mode");
 
     // Bob should be able to connect (no verification)
@@ -474,7 +479,7 @@ async fn test_did_tls_binding_verified_on_hello() -> Result<()> {
 
     let (alice_shutdown_tx, _) = broadcast::channel(1);
     let alice_identity = IdentityBundle::from_keypair(alice_keypair)?;
-    let alice_addr: SocketAddr = "127.0.0.1:25300".parse()?;
+    let alice_addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
     let _alice_handle = NetworkActor::spawn(
         alice_identity,
         alice_addr,
@@ -501,7 +506,7 @@ async fn test_did_tls_binding_verified_on_hello() -> Result<()> {
 
     let (bob_shutdown_tx, _) = broadcast::channel(1);
     let bob_identity = IdentityBundle::from_keypair(bob_keypair)?;
-    let bob_addr: SocketAddr = "127.0.0.1:25301".parse()?;
+    let bob_addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
     let bob_handle = NetworkActor::spawn(
         bob_identity,
         bob_addr,

--- a/icn/crates/icn-net/tests/did_tls_binding_integration.rs
+++ b/icn/crates/icn-net/tests/did_tls_binding_integration.rs
@@ -16,6 +16,11 @@ use std::time::Duration;
 use tokio::sync::{broadcast, mpsc, RwLock};
 use tracing::info;
 
+/// Get an available port to avoid conflicts when tests run in parallel
+fn pick_port() -> u16 {
+    portpicker::pick_unused_port().expect("No available ports")
+}
+
 /// Test node helper
 struct TestNode {
     did: icn_identity::Did,
@@ -109,7 +114,7 @@ impl TestNode {
 }
 
 #[tokio::test]
-#[ignore = "Flaky in CI: QUIC stream failures in containerized environment"]
+#[ignore = "QUIC deserialization issue - see issue for tracking"]
 async fn test_successful_did_tls_binding_verification() -> Result<()> {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     let _ = tracing_subscriber::fmt::try_init();
@@ -117,8 +122,8 @@ async fn test_successful_did_tls_binding_verification() -> Result<()> {
     info!("=== Testing successful DID-TLS binding verification ===");
 
     // Spawn two nodes with valid identity bundles
-    let node_a = TestNode::spawn(24000).await?;
-    let node_b = TestNode::spawn(24001).await?;
+    let node_a = TestNode::spawn(pick_port()).await?;
+    let node_b = TestNode::spawn(pick_port()).await?;
 
     info!("Node A: {}", node_a.did);
     info!("Node B: {}", node_b.did);
@@ -151,15 +156,15 @@ async fn test_successful_did_tls_binding_verification() -> Result<()> {
 }
 
 #[tokio::test]
-#[ignore = "Flaky in CI: QUIC stream failures in containerized environment"]
+#[ignore = "QUIC deserialization issue - see issue for tracking"]
 async fn test_bidirectional_hello_exchange() -> Result<()> {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     let _ = tracing_subscriber::fmt::try_init();
 
     info!("=== Testing bidirectional Hello message exchange ===");
 
-    let node_a = TestNode::spawn(24100).await?;
-    let node_b = TestNode::spawn(24101).await?;
+    let node_a = TestNode::spawn(pick_port()).await?;
+    let node_b = TestNode::spawn(pick_port()).await?;
 
     info!("Node A: {} on {}", node_a.did, node_a.listen_addr);
     info!("Node B: {} on {}", node_b.did, node_b.listen_addr);
@@ -212,11 +217,11 @@ async fn test_multiple_connections_with_binding_verification() -> Result<()> {
     info!("=== Testing multiple connections with DID-TLS binding ===");
 
     // Create a hub node that will receive connections from multiple peers
-    let hub = TestNode::spawn(24200).await?;
+    let hub = TestNode::spawn(pick_port()).await?;
 
     // Create peer nodes (reduced to 2 for stability)
-    let peer1 = TestNode::spawn(24201).await?;
-    let peer2 = TestNode::spawn(24202).await?;
+    let peer1 = TestNode::spawn(pick_port()).await?;
+    let peer2 = TestNode::spawn(pick_port()).await?;
 
     info!("Hub: {}", hub.did);
     info!("Peer 1: {}", peer1.did);
@@ -375,8 +380,8 @@ async fn test_connection_resilience() -> Result<()> {
 
     info!("=== Testing connection resilience with DID-TLS binding ===");
 
-    let node_a = TestNode::spawn(24300).await?;
-    let node_b = TestNode::spawn(24301).await?;
+    let node_a = TestNode::spawn(pick_port()).await?;
+    let node_b = TestNode::spawn(pick_port()).await?;
 
     // Establish connection
     node_a.dial(&node_b).await?;

--- a/icn/crates/icn-net/tests/trust_gated_tls_integration.rs
+++ b/icn/crates/icn-net/tests/trust_gated_tls_integration.rs
@@ -9,10 +9,16 @@ use icn_identity::{IdentityBundle, KeyPair};
 use icn_net::NetworkActor;
 use icn_store::SledStore;
 use icn_trust::{TrustEdge, TrustGraph};
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
 use tracing::info;
+
+/// Get an available port to avoid conflicts when tests run in parallel
+fn pick_port() -> u16 {
+    portpicker::pick_unused_port().expect("No available ports")
+}
 
 /// Test that connections from trusted peers are accepted
 #[tokio::test]
@@ -53,11 +59,12 @@ async fn test_trusted_peer_connection_accepted() -> Result<()> {
 
     // Create IdentityBundle for Alice
     let alice_identity_bundle = IdentityBundle::from_keypair(alice_keypair).unwrap();
+    let alice_addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
 
     // Spawn Alice's network actor with trust-gated TLS (min threshold 0.4 = Partner)
     let _alice_handle = NetworkActor::spawn(
         alice_identity_bundle,
-        "127.0.0.1:15400".parse()?,
+        alice_addr,
         alice_shutdown_tx.clone(),
         None,
         Some(alice_trust.clone()),
@@ -79,9 +86,10 @@ async fn test_trusted_peer_connection_accepted() -> Result<()> {
     // Bob dials Alice - should succeed because Alice trusts Bob with score 0.8
     let bob_shutdown_tx = tokio::sync::broadcast::channel(16).0;
     let bob_identity_bundle = IdentityBundle::from_keypair(bob_keypair).unwrap();
+    let bob_addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
     let bob_handle = NetworkActor::spawn(
         bob_identity_bundle,
-        "127.0.0.1:15401".parse()?,
+        bob_addr,
         bob_shutdown_tx.clone(),
         None,
         None, // Bob has no trust graph (doesn't need to verify Alice)
@@ -98,9 +106,7 @@ async fn test_trusted_peer_connection_accepted() -> Result<()> {
     info!("Bob network actor started, attempting to dial Alice...");
 
     // Bob dials Alice
-    let result = bob_handle
-        .dial("127.0.0.1:15400".parse()?, alice_did.clone())
-        .await;
+    let result = bob_handle.dial(alice_addr, alice_did.clone()).await;
 
     assert!(
         result.is_ok(),
@@ -152,9 +158,10 @@ async fn test_untrusted_peer_connection_rejected() -> Result<()> {
     // Spawn Alice with trust-gated TLS (min threshold 0.1 = Known)
     use icn_net::rate_limit::TrustGatedRateLimitConfig;
     let alice_identity_bundle = IdentityBundle::from_keypair(alice_keypair).unwrap();
+    let alice_addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
     let _alice_handle = NetworkActor::spawn(
         alice_identity_bundle,
-        "127.0.0.1:15500".parse()?,
+        alice_addr,
         alice_shutdown_tx.clone(),
         None,
         Some(alice_trust.clone()),
@@ -179,9 +186,10 @@ async fn test_untrusted_peer_connection_rejected() -> Result<()> {
     // Mallory dials Alice - should FAIL because Alice doesn't trust Mallory
     let mallory_shutdown_tx = tokio::sync::broadcast::channel(16).0;
     let mallory_identity_bundle = IdentityBundle::from_keypair(mallory_keypair).unwrap();
+    let mallory_addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
     let mallory_handle = NetworkActor::spawn(
         mallory_identity_bundle,
-        "127.0.0.1:15501".parse()?,
+        mallory_addr,
         mallory_shutdown_tx.clone(),
         None,
         None,
@@ -198,9 +206,7 @@ async fn test_untrusted_peer_connection_rejected() -> Result<()> {
     info!("Mallory network actor started, attempting to dial Alice...");
 
     // Mallory attempts to dial Alice - should be rejected during TLS handshake
-    let result = mallory_handle
-        .dial("127.0.0.1:15500".parse()?, alice_did.clone())
-        .await;
+    let result = mallory_handle.dial(alice_addr, alice_did.clone()).await;
 
     // The connection should fail because Alice's TLS verifier rejects Mallory
     assert!(
@@ -256,9 +262,10 @@ async fn test_trust_threshold_boundary() -> Result<()> {
     let (alice_shutdown_tx, _) = tokio::sync::broadcast::channel(16);
     use icn_net::rate_limit::TrustGatedRateLimitConfig;
     let alice_identity_bundle = IdentityBundle::from_keypair(alice_keypair).unwrap();
+    let alice_addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
     let _alice_handle = NetworkActor::spawn(
         alice_identity_bundle,
-        "127.0.0.1:15600".parse()?,
+        alice_addr,
         alice_shutdown_tx.clone(),
         None,
         Some(alice_trust.clone()),
@@ -280,9 +287,10 @@ async fn test_trust_threshold_boundary() -> Result<()> {
     // Bob dials Alice - should succeed at exact threshold
     let bob_shutdown_tx = tokio::sync::broadcast::channel(16).0;
     let bob_identity_bundle = IdentityBundle::from_keypair(bob_keypair).unwrap();
+    let bob_addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
     let bob_handle = NetworkActor::spawn(
         bob_identity_bundle,
-        "127.0.0.1:15601".parse()?,
+        bob_addr,
         bob_shutdown_tx.clone(),
         None,
         None,
@@ -296,9 +304,7 @@ async fn test_trust_threshold_boundary() -> Result<()> {
     )
     .await?;
 
-    let result = bob_handle
-        .dial("127.0.0.1:15600".parse()?, alice_did.clone())
-        .await;
+    let result = bob_handle.dial(alice_addr, alice_did.clone()).await;
 
     assert!(
         result.is_ok(),


### PR DESCRIPTION
## Summary

- Replace hardcoded ports with `portpicker` in QUIC test files to avoid conflicts when tests run in parallel
- Update CI workflow to run integration tests serially (`--test-threads=1`) while unit tests run in parallel
- Fix rate-limited stream handling in NetworkActor to properly close streams before continuing
- Add debug logging for stream finish errors to aid troubleshooting

## Changes

### Test Infrastructure
- `client_cert_verification_integration.rs`: Use `pick_port()` instead of hardcoded ports 25000-25301
- `did_tls_binding_integration.rs`: Use `pick_port()` instead of hardcoded ports 24000-24301
- `trust_gated_tls_integration.rs`: Use `pick_port()` instead of hardcoded ports 15400-15601

### CI Configuration
- Split test step into unit tests (parallel) and integration tests (serial)
- Run `cargo test --workspace --lib` first (fast, parallel)
- Run `cargo test --workspace --test '*' -- --test-threads=1` (serial to avoid port conflicts)

### NetworkActor Fixes
- Add `send.finish()` before `continue` in rate-limiting block to avoid stream resource leaks
- Replace silent `let _ = send.finish()` with debug logging for troubleshooting

## Note

QUIC tests remain ignored due to a deeper deserialization issue causing ~8.8 exabyte memory allocation crashes. This appears to be a bincode/postcard deserialization issue when message payloads are corrupted during QUIC stream operations. This PR improves infrastructure in preparation for fixing the underlying protocol issue.

## Test plan

- [x] Local `cargo check --workspace` passes
- [x] Local `cargo clippy -p icn-net --all-targets -- -D warnings` passes
- [x] Non-QUIC tests pass (e.g., `test_identity_bundle_uniqueness`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)