### PR TITLE
fix(testkit): Eliminate race condition in network handle initialization

### DIFF
--- a/icn/crates/icn-testkit/src/node.rs
+++ b/icn/crates/icn-testkit/src/node.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{broadcast, Mutex, RwLock};
+use tokio::sync::{broadcast, watch, Mutex, RwLock};
 use tracing::{debug, info};
 
 use crate::util::pick_port;
@@ -122,9 +122,11 @@ impl TestNode {
         }
 
         // Set up network message handler
+        // Use watch channel to safely share network handle with message handler
+        // This eliminates the race condition where messages could arrive before
+        // the handle is stored in the RwLock
         let gossip_clone = gossip.clone();
-        let network_holder = Arc::new(RwLock::new(None::<NetworkHandle>));
-        let network_holder_clone = network_holder.clone();
+        let (network_tx, network_rx) = watch::channel(None::<NetworkHandle>);
         let own_did = did.clone();
 
         let incoming_handler: IncomingMessageHandler = Arc::new(move |net_msg| {
@@ -145,7 +147,7 @@ impl TestNode {
                 MessagePayload::Subscribe { topics } => {
                     let gossip = gossip_clone.clone();
                     let sender = sender.clone();
-                    let net_holder = network_holder_clone.clone();
+                    let mut net_rx = network_rx.clone();
                     let own = own_did.clone();
                     tokio::spawn(async move {
                         let mut g = gossip.write().await;
@@ -156,11 +158,35 @@ impl TestNode {
                             }
                         }
                         if !acked.is_empty() {
-                            tokio::time::sleep(Duration::from_millis(10)).await;
-                            if let Some(net) = net_holder.read().await.as_ref() {
-                                let ack = NetworkMessage::subscribe_ack(own, sender.clone(), acked);
-                                if let Err(e) = net.send_message(sender, ack).await {
-                                    debug!("Failed to send SubscribeAck: {}", e);
+                            // Wait for network handle to be available (fixes race condition)
+                            // Timeout after 1 second to avoid hanging forever
+                            let net = tokio::time::timeout(Duration::from_secs(1), async {
+                                loop {
+                                    if let Some(net) = net_rx.borrow().clone() {
+                                        return Some(net);
+                                    }
+                                    if net_rx.changed().await.is_err() {
+                                        break;
+                                    }
+                                }
+                                // Channel closed, return current value if any
+                                net_rx.borrow().clone()
+                            })
+                            .await;
+
+                            match net {
+                                Ok(Some(net)) => {
+                                    let ack =
+                                        NetworkMessage::subscribe_ack(own, sender.clone(), acked);
+                                    if let Err(e) = net.send_message(sender, ack).await {
+                                        debug!("Failed to send SubscribeAck: {}", e);
+                                    }
+                                }
+                                Ok(None) => {
+                                    debug!("Network handle not available for SubscribeAck");
+                                }
+                                Err(_) => {
+                                    debug!("Timeout waiting for network handle");
                                 }
                             }
                         }
@@ -208,8 +234,8 @@ impl TestNode {
         )
         .await?;
 
-        // Store network handle for message handler
-        *network_holder.write().await = Some(network.clone());
+        // Send network handle to message handler (fixes race condition)
+        let _ = network_tx.send(Some(network.clone()));
 
         // Set up gossip send callback
         {


### PR DESCRIPTION
## Summary
- Replace `RwLock<Option<NetworkHandle>>` with `tokio::sync::watch` channel to safely share the network handle with message handlers
- Fix race condition where Subscribe messages could arrive before the network handle was stored

## Problem
The previous implementation had a race condition:
1. `NetworkActor::spawn()` is called and returns the network handle
2. A message handler is registered before the handle is stored
3. If a Subscribe message arrives between steps 1 and 2, the handler tries to access the handle before it's available
4. The SubscribeAck is silently dropped

## Solution
Use `tokio::sync::watch` channel instead:
- Handlers wait for the network handle to become available with `changed().await`
- 1-second timeout prevents indefinite hanging
- Proper error logging for all failure cases
- More elegant than oneshot since watch supports multiple receivers

## Test plan
- [x] All existing tests pass
- [x] Clippy passes with no warnings
- [x] Format check passes
- [x] Manual verification of Subscribe flow

Closes #610

🤖 Generated with [Claude Code](https://claude.ai/code)