### PR TITLE
feat(testkit): Add adaptive polling with exponential backoff

### DIFF
--- a/icn/crates/icn-testkit/src/cluster.rs
+++ b/icn/crates/icn-testkit/src/cluster.rs
@@ -1,11 +1,12 @@
 //! Multi-node test cluster management
 
 use anyhow::{Context, Result};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tracing::info;
 
 use crate::node::{NodeConfig, TestNode};
 use crate::simulation::PartitionConfig;
+use crate::util::BackoffConfig;
 
 /// A cluster of test nodes for multi-node integration tests
 ///
@@ -131,16 +132,22 @@ impl TestCluster {
     /// Wait for gossip to converge on a specific topic
     ///
     /// Waits until all nodes have the same number of entries for the topic,
-    /// or the timeout expires.
+    /// or the timeout expires. Uses exponential backoff to balance responsiveness
+    /// with CPU efficiency.
     pub async fn await_gossip_convergence(
         &self,
         topic: &str,
         expected_count: usize,
         timeout: Duration,
     ) -> Result<()> {
-        let start = std::time::Instant::now();
+        let start = Instant::now();
+        let backoff = BackoffConfig::new(
+            Duration::from_millis(10),  // Start checking quickly
+            Duration::from_millis(100), // Cap at 100ms between checks
+        );
+        let mut delay = backoff.initial_delay;
 
-        while start.elapsed() < timeout {
+        loop {
             let mut all_converged = true;
             for node in &self.nodes {
                 if node.entry_count(topic).await != expected_count {
@@ -151,33 +158,42 @@ impl TestCluster {
 
             if all_converged {
                 info!(
-                    "Gossip converged: all {} nodes have {} entries for topic '{}'",
+                    "Gossip converged: all {} nodes have {} entries for topic '{}' in {:?}",
                     self.nodes.len(),
                     expected_count,
-                    topic
+                    topic,
+                    start.elapsed()
                 );
                 return Ok(());
             }
 
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
+            if start.elapsed() >= timeout {
+                // Build detailed error message
+                let mut counts = Vec::new();
+                for node in &self.nodes {
+                    counts.push(format!(
+                        "node {}: {}",
+                        node.index,
+                        node.entry_count(topic).await
+                    ));
+                }
 
-        // Build detailed error message
-        let mut counts = Vec::new();
-        for node in &self.nodes {
-            counts.push(format!(
-                "node {}: {}",
-                node.index,
-                node.entry_count(topic).await
-            ));
-        }
+                anyhow::bail!(
+                    "Gossip did not converge within {:?}. Expected {} entries. Counts: {}",
+                    timeout,
+                    expected_count,
+                    counts.join(", ")
+                );
+            }
 
-        anyhow::bail!(
-            "Gossip did not converge within {:?}. Expected {} entries. Counts: {}",
-            timeout,
-            expected_count,
-            counts.join(", ")
-        )
+            // Sleep with exponential backoff
+            let remaining = timeout.saturating_sub(start.elapsed());
+            tokio::time::sleep(delay.min(remaining)).await;
+
+            // Increase delay, capped at max
+            delay = Duration::from_secs_f64(delay.as_secs_f64() * backoff.multiplier)
+                .min(backoff.max_delay);
+        }
     }
 
     /// Create a network partition by disconnecting nodes across groups

--- a/icn/crates/icn-testkit/src/lib.rs
+++ b/icn/crates/icn-testkit/src/lib.rs
@@ -50,13 +50,13 @@ mod util;
 pub use cluster::TestCluster;
 pub use node::{NodeConfig, TestNode};
 pub use simulation::{NetworkCondition, PartitionConfig};
-pub use util::{install_crypto_provider, pick_port, TestResult};
+pub use util::{install_crypto_provider, pick_port, poll_with_backoff, BackoffConfig, TestResult};
 
 /// Re-export common types for convenience
 pub mod prelude {
     pub use crate::{
-        install_crypto_provider, pick_port, NetworkCondition, NodeConfig, PartitionConfig,
-        TestCluster, TestNode, TestResult,
+        install_crypto_provider, pick_port, poll_with_backoff, BackoffConfig, NetworkCondition,
+        NodeConfig, PartitionConfig, TestCluster, TestNode, TestResult,
     };
     pub use anyhow::Result;
     pub use std::time::Duration;

--- a/icn/crates/icn-testkit/src/node.rs
+++ b/icn/crates/icn-testkit/src/node.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use tokio::sync::{broadcast, watch, Mutex, RwLock};
 use tracing::{debug, info, warn};
 
-use crate::util::pick_port;
+use crate::util::{pick_port, BackoffConfig};
 
 /// Guard that triggers shutdown on drop unless disarmed
 ///
@@ -400,15 +400,30 @@ impl TestNode {
     }
 
     /// Wait for connection to a specific peer
+    ///
+    /// Uses exponential backoff starting at 10ms, capped at 100ms between checks.
     pub async fn wait_connected(&self, did: &Did, timeout: Duration) -> Result<()> {
         let start = std::time::Instant::now();
-        while start.elapsed() < timeout {
+        let backoff = BackoffConfig::new(
+            Duration::from_millis(10),  // Start checking quickly
+            Duration::from_millis(100), // Cap at 100ms between checks
+        );
+        let mut delay = backoff.initial_delay;
+
+        loop {
             if self.network.is_peer_connected(did).await.unwrap_or(false) {
                 return Ok(());
             }
-            tokio::time::sleep(Duration::from_millis(50)).await;
+
+            if start.elapsed() >= timeout {
+                anyhow::bail!("Timeout waiting for connection to {did}");
+            }
+
+            let remaining = timeout.saturating_sub(start.elapsed());
+            tokio::time::sleep(delay.min(remaining)).await;
+            delay = Duration::from_secs_f64(delay.as_secs_f64() * backoff.multiplier)
+                .min(backoff.max_delay);
         }
-        anyhow::bail!("Timeout waiting for connection to {did}")
     }
 
     /// Disconnect from a specific peer
@@ -429,11 +444,18 @@ impl TestNode {
     /// Wait for disconnection from a specific peer
     ///
     /// Waits until the peer is no longer connected or the timeout expires.
+    /// Uses exponential backoff starting at 10ms, capped at 100ms between checks.
     /// If the connection state cannot be determined (error), treats as disconnected
     /// since the peer handle may have been cleaned up.
     pub async fn wait_disconnected(&self, did: &Did, timeout: Duration) -> Result<()> {
         let start = std::time::Instant::now();
-        while start.elapsed() < timeout {
+        let backoff = BackoffConfig::new(
+            Duration::from_millis(10),  // Start checking quickly
+            Duration::from_millis(100), // Cap at 100ms between checks
+        );
+        let mut delay = backoff.initial_delay;
+
+        loop {
             match self.network.is_peer_connected(did).await {
                 Ok(false) => return Ok(()), // Confirmed disconnected
                 Ok(true) => {}              // Still connected, keep waiting
@@ -443,9 +465,16 @@ impl TestNode {
                     return Ok(());
                 }
             }
-            tokio::time::sleep(Duration::from_millis(50)).await;
+
+            if start.elapsed() >= timeout {
+                anyhow::bail!("Timeout waiting for disconnection from {did}");
+            }
+
+            let remaining = timeout.saturating_sub(start.elapsed());
+            tokio::time::sleep(delay.min(remaining)).await;
+            delay = Duration::from_secs_f64(delay.as_secs_f64() * backoff.multiplier)
+                .min(backoff.max_delay);
         }
-        anyhow::bail!("Timeout waiting for disconnection from {did}")
     }
 }
 

--- a/icn/crates/icn-testkit/src/node.rs
+++ b/icn/crates/icn-testkit/src/node.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use tokio::sync::{broadcast, watch, Mutex, RwLock};
 use tracing::{debug, info, warn};
 
-use crate::util::{pick_port, BackoffConfig};
+use crate::util::{pick_port, poll_with_backoff, BackoffConfig};
 
 /// Guard that triggers shutdown on drop unless disarmed
 ///
@@ -403,27 +403,20 @@ impl TestNode {
     ///
     /// Uses exponential backoff starting at 10ms, capped at 100ms between checks.
     pub async fn wait_connected(&self, did: &Did, timeout: Duration) -> Result<()> {
-        let start = std::time::Instant::now();
-        let backoff = BackoffConfig::new(
-            Duration::from_millis(10),  // Start checking quickly
-            Duration::from_millis(100), // Cap at 100ms between checks
-        );
-        let mut delay = backoff.initial_delay;
+        let network = self.network.clone();
+        let target_did = did.clone();
 
-        loop {
-            if self.network.is_peer_connected(did).await.unwrap_or(false) {
-                return Ok(());
-            }
-
-            if start.elapsed() >= timeout {
-                anyhow::bail!("Timeout waiting for connection to {did}");
-            }
-
-            let remaining = timeout.saturating_sub(start.elapsed());
-            tokio::time::sleep(delay.min(remaining)).await;
-            delay = Duration::from_secs_f64(delay.as_secs_f64() * backoff.multiplier)
-                .min(backoff.max_delay);
-        }
+        poll_with_backoff(
+            move || {
+                let net = network.clone();
+                let did = target_did.clone();
+                async move { net.is_peer_connected(&did).await.unwrap_or(false) }
+            },
+            BackoffConfig::new(Duration::from_millis(10), Duration::from_millis(100)),
+            timeout,
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for connection to {did}"))
     }
 
     /// Disconnect from a specific peer
@@ -448,33 +441,27 @@ impl TestNode {
     /// If the connection state cannot be determined (error), treats as disconnected
     /// since the peer handle may have been cleaned up.
     pub async fn wait_disconnected(&self, did: &Did, timeout: Duration) -> Result<()> {
-        let start = std::time::Instant::now();
-        let backoff = BackoffConfig::new(
-            Duration::from_millis(10),  // Start checking quickly
-            Duration::from_millis(100), // Cap at 100ms between checks
-        );
-        let mut delay = backoff.initial_delay;
+        let network = self.network.clone();
+        let target_did = did.clone();
 
-        loop {
-            match self.network.is_peer_connected(did).await {
-                Ok(false) => return Ok(()), // Confirmed disconnected
-                Ok(true) => {}              // Still connected, keep waiting
-                Err(_) => {
-                    // Can't determine state - peer handle likely cleaned up
-                    // Treat as disconnected since verification failed
-                    return Ok(());
+        poll_with_backoff(
+            move || {
+                let net = network.clone();
+                let did = target_did.clone();
+                async move {
+                    // Return true (done) if disconnected or if we can't determine state
+                    match net.is_peer_connected(&did).await {
+                        Ok(false) => true,  // Confirmed disconnected
+                        Ok(true) => false,  // Still connected, keep waiting
+                        Err(_) => true,     // Can't determine - treat as disconnected
+                    }
                 }
-            }
-
-            if start.elapsed() >= timeout {
-                anyhow::bail!("Timeout waiting for disconnection from {did}");
-            }
-
-            let remaining = timeout.saturating_sub(start.elapsed());
-            tokio::time::sleep(delay.min(remaining)).await;
-            delay = Duration::from_secs_f64(delay.as_secs_f64() * backoff.multiplier)
-                .min(backoff.max_delay);
-        }
+            },
+            BackoffConfig::new(Duration::from_millis(10), Duration::from_millis(100)),
+            timeout,
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for disconnection from {did}"))
     }
 }
 

--- a/icn/crates/icn-testkit/src/util.rs
+++ b/icn/crates/icn-testkit/src/util.rs
@@ -1,11 +1,116 @@
 //! Utility functions for test setup
 
 use anyhow::Result;
+use std::future::Future;
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::Once;
+use std::time::{Duration, Instant};
 
 /// Type alias for test results
 pub type TestResult<T = ()> = Result<T>;
+
+/// Configuration for exponential backoff polling
+#[derive(Debug, Clone)]
+pub struct BackoffConfig {
+    /// Initial delay between polls
+    pub initial_delay: Duration,
+    /// Maximum delay between polls
+    pub max_delay: Duration,
+    /// Multiplier for delay increase (default: 2.0)
+    pub multiplier: f64,
+}
+
+impl Default for BackoffConfig {
+    fn default() -> Self {
+        Self {
+            initial_delay: Duration::from_millis(10),
+            max_delay: Duration::from_millis(200),
+            multiplier: 2.0,
+        }
+    }
+}
+
+impl BackoffConfig {
+    /// Create a new backoff config with custom initial and max delays
+    pub fn new(initial: Duration, max: Duration) -> Self {
+        Self {
+            initial_delay: initial,
+            max_delay: max,
+            multiplier: 2.0,
+        }
+    }
+
+    /// Set the multiplier for delay increase
+    pub fn with_multiplier(mut self, multiplier: f64) -> Self {
+        self.multiplier = multiplier;
+        self
+    }
+}
+
+/// Poll a condition with exponential backoff until it returns true or timeout
+///
+/// This is useful for waiting on asynchronous conditions (connections, gossip
+/// convergence, etc.) without using fixed delays that may be too short under
+/// load or too long in fast environments.
+///
+/// # Arguments
+///
+/// * `check` - Async function returning `true` when the condition is met
+/// * `config` - Backoff configuration (initial delay, max delay, multiplier)
+/// * `timeout` - Maximum time to wait before returning an error
+///
+/// # Returns
+///
+/// `Ok(())` if the condition became true, `Err` if timeout was reached
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use icn_testkit::util::{poll_with_backoff, BackoffConfig};
+///
+/// poll_with_backoff(
+///     || async { node.is_connected_to(&peer).await },
+///     BackoffConfig::default(),
+///     Duration::from_secs(5),
+/// ).await?;
+/// ```
+pub async fn poll_with_backoff<F, Fut>(
+    mut check: F,
+    config: BackoffConfig,
+    timeout: Duration,
+) -> Result<()>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = bool>,
+{
+    let start = Instant::now();
+    let mut delay = config.initial_delay;
+
+    loop {
+        if check().await {
+            return Ok(());
+        }
+
+        if start.elapsed() >= timeout {
+            anyhow::bail!(
+                "Timeout after {:?} (polled with backoff from {:?} to {:?})",
+                timeout,
+                config.initial_delay,
+                delay
+            );
+        }
+
+        // Don't sleep longer than remaining time
+        let remaining = timeout.saturating_sub(start.elapsed());
+        let sleep_time = delay.min(remaining);
+
+        tokio::time::sleep(sleep_time).await;
+
+        // Increase delay with exponential backoff, capped at max
+        delay = Duration::from_secs_f64(delay.as_secs_f64() * config.multiplier)
+            .min(config.max_delay);
+    }
+}
 
 static CRYPTO_INIT: Once = Once::new();
 
@@ -57,6 +162,8 @@ pub fn init_test_tracing() {
 mod tests {
     use super::*;
     use std::collections::HashSet;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
 
     #[test]
     fn test_pick_port_returns_valid_ports() {
@@ -81,5 +188,72 @@ mod tests {
         install_crypto_provider();
         install_crypto_provider();
         install_crypto_provider();
+    }
+
+    #[test]
+    fn test_backoff_config_defaults() {
+        let config = BackoffConfig::default();
+        assert_eq!(config.initial_delay, Duration::from_millis(10));
+        assert_eq!(config.max_delay, Duration::from_millis(200));
+        assert!((config.multiplier - 2.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_backoff_config_builder() {
+        let config = BackoffConfig::new(Duration::from_millis(5), Duration::from_millis(50))
+            .with_multiplier(1.5);
+        assert_eq!(config.initial_delay, Duration::from_millis(5));
+        assert_eq!(config.max_delay, Duration::from_millis(50));
+        assert!((config.multiplier - 1.5).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn test_poll_with_backoff_succeeds_immediately() {
+        // Condition is immediately true
+        let result = poll_with_backoff(
+            || async { true },
+            BackoffConfig::default(),
+            Duration::from_secs(1),
+        )
+        .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_poll_with_backoff_succeeds_after_retries() {
+        // Condition becomes true after a few polls
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_clone = counter.clone();
+
+        let result = poll_with_backoff(
+            move || {
+                let c = counter_clone.clone();
+                async move {
+                    let count = c.fetch_add(1, Ordering::SeqCst);
+                    count >= 3 // True on 4th poll (indices 0, 1, 2, 3)
+                }
+            },
+            BackoffConfig::new(Duration::from_millis(1), Duration::from_millis(10)),
+            Duration::from_secs(1),
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert!(counter.load(Ordering::SeqCst) >= 4);
+    }
+
+    #[tokio::test]
+    async fn test_poll_with_backoff_times_out() {
+        // Condition never becomes true
+        let result = poll_with_backoff(
+            || async { false },
+            BackoffConfig::new(Duration::from_millis(5), Duration::from_millis(10)),
+            Duration::from_millis(50),
+        )
+        .await;
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("Timeout"), "Expected timeout error: {err_msg}");
     }
 }

--- a/icn/crates/icn-testkit/src/util.rs
+++ b/icn/crates/icn-testkit/src/util.rs
@@ -31,17 +31,35 @@ impl Default for BackoffConfig {
 }
 
 impl BackoffConfig {
-    /// Create a new backoff config with custom initial and max delays
+    /// Create a new backoff config with custom initial and max delays.
+    ///
+    /// If `initial` is greater than `max`, the values are swapped to ensure
+    /// `initial_delay <= max_delay`.
     pub fn new(initial: Duration, max: Duration) -> Self {
+        let (initial_delay, max_delay) = if initial <= max {
+            (initial, max)
+        } else {
+            (max, initial)
+        };
+
         Self {
-            initial_delay: initial,
-            max_delay: max,
+            initial_delay,
+            max_delay,
             multiplier: 2.0,
         }
     }
 
-    /// Set the multiplier for delay increase
+    /// Set the multiplier for delay increase.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `multiplier <= 1.0`. The multiplier must be greater than 1.0
+    /// to ensure exponential backoff behavior.
     pub fn with_multiplier(mut self, multiplier: f64) -> Self {
+        assert!(
+            multiplier > 1.0,
+            "BackoffConfig::with_multiplier requires multiplier > 1.0 (got {multiplier})"
+        );
         self.multiplier = multiplier;
         self
     }
@@ -205,6 +223,20 @@ mod tests {
         assert_eq!(config.initial_delay, Duration::from_millis(5));
         assert_eq!(config.max_delay, Duration::from_millis(50));
         assert!((config.multiplier - 1.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_backoff_config_swaps_inverted_delays() {
+        // When initial > max, values should be swapped
+        let config = BackoffConfig::new(Duration::from_millis(100), Duration::from_millis(10));
+        assert_eq!(config.initial_delay, Duration::from_millis(10));
+        assert_eq!(config.max_delay, Duration::from_millis(100));
+    }
+
+    #[test]
+    #[should_panic(expected = "requires multiplier > 1.0")]
+    fn test_backoff_config_panics_on_invalid_multiplier() {
+        BackoffConfig::default().with_multiplier(1.0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Add `BackoffConfig` struct for configuring exponential backoff parameters
- Add `poll_with_backoff` utility function for polling async conditions with backoff
- Update `await_gossip_convergence` to use exponential backoff (10ms-100ms)
- Update `wait_connected` and `wait_disconnected` to use exponential backoff
- Add comprehensive unit tests for backoff behavior

## Why

Fixed delays in tests are problematic:
- Too short delays cause flaky tests under CI load
- Too long delays slow down tests unnecessarily in fast environments

Exponential backoff starts fast (10ms) for quick conditions and backs off to a reasonable cap (100ms) for slower conditions, balancing responsiveness with CPU efficiency.

## Test plan

- [x] All new unit tests pass (`cargo test -p icn-testkit --lib`)
- [x] No clippy warnings
- [x] Existing testkit tests continue to pass

Closes #611

🤖 Generated with [Claude Code](https://claude.ai/code)