### PR TITLE
feat(federation): Add inter-cooperative agreement framework

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -3106,6 +3106,7 @@ dependencies = [
  "tokio",
  "tracing",
  "urlencoding",
+ "uuid",
  "wiremock",
 ]
 

--- a/icn/crates/icn-federation/Cargo.toml
+++ b/icn/crates/icn-federation/Cargo.toml
@@ -39,6 +39,9 @@ metrics.workspace = true
 ed25519-dalek.workspace = true
 sha2.workspace = true
 
+# UUID generation
+uuid = { version = "1", features = ["v4"] }
+
 # HTTP client for remote DID resolution
 reqwest = { version = "0.12", features = ["json"] }
 urlencoding = "2.1"

--- a/icn/crates/icn-federation/src/agreement/gossip.rs
+++ b/icn/crates/icn-federation/src/agreement/gossip.rs
@@ -254,11 +254,19 @@ impl<S: AgreementStoreOps> AgreementGossipHandler<S> {
         agreement.signatures.push(signature.clone());
 
         // Check if all signatures are collected - auto-activate
-        if agreement.status.is_proposed()
-            && agreement.is_fully_signed()
-            && agreement.activate().is_ok()
-        {
-            info!("Agreement {} activated via gossip signatures", agreement_id);
+        if agreement.status.is_proposed() && agreement.is_fully_signed() {
+            match agreement.activate() {
+                Ok(()) => {
+                    info!("Agreement {} activated via gossip signatures", agreement_id);
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to activate agreement {} despite full signatures: {}",
+                        agreement_id, e
+                    );
+                    // Don't propagate error - just log it and continue
+                }
+            }
         }
 
         self.store.store_agreement(&agreement)?;
@@ -371,12 +379,21 @@ impl<S: AgreementStoreOps> AgreementGossipHandler<S> {
             }
         };
 
-        // Add signature if not duplicate
+        // Add signature if not duplicate and valid
         if !amendment
             .signatures
             .iter()
             .any(|s| s.signer == signature.signer)
         {
+            // Verify signature before adding
+            if let Err(e) = amendment.verify_signature(&signature) {
+                warn!(
+                    "Invalid amendment signature from {}: {}",
+                    signature.signer, e
+                );
+                return Ok(());
+            }
+
             amendment.add_signature(signature);
             self.store.store_amendment(amendment)?;
             debug!(

--- a/icn/crates/icn-federation/src/agreement/gossip.rs
+++ b/icn/crates/icn-federation/src/agreement/gossip.rs
@@ -187,10 +187,7 @@ impl<S: AgreementStoreOps> AgreementGossipHandler<S> {
     fn handle_proposed(&self, agreement: Agreement) -> Result<()> {
         // Only store if we're a party to this agreement
         if !self.is_party_to(&agreement) {
-            debug!(
-                "Ignoring proposed agreement {} - not a party",
-                agreement.id
-            );
+            debug!("Ignoring proposed agreement {} - not a party", agreement.id);
             return Ok(());
         }
 
@@ -209,23 +206,21 @@ impl<S: AgreementStoreOps> AgreementGossipHandler<S> {
         }
 
         self.store.store_agreement(&agreement)?;
-        info!(
-            "Stored proposed agreement {} from gossip",
-            agreement.id
-        );
+        info!("Stored proposed agreement {} from gossip", agreement.id);
         Ok(())
     }
 
     /// Handle a signature message
-    fn handle_signed(&self, agreement_id: AgreementId, signature: AgreementSignature) -> Result<()> {
+    fn handle_signed(
+        &self,
+        agreement_id: AgreementId,
+        signature: AgreementSignature,
+    ) -> Result<()> {
         // Get the agreement
         let mut agreement = match self.store.get_agreement(&agreement_id)? {
             Some(a) => a,
             None => {
-                debug!(
-                    "Received signature for unknown agreement {}",
-                    agreement_id
-                );
+                debug!("Received signature for unknown agreement {}", agreement_id);
                 return Ok(());
             }
         };
@@ -305,10 +300,7 @@ impl<S: AgreementStoreOps> AgreementGossipHandler<S> {
         agreement.status = new_status;
         self.store.store_agreement(&agreement)?;
 
-        info!(
-            "Updated status of agreement {} via gossip",
-            agreement_id
-        );
+        info!("Updated status of agreement {} via gossip", agreement_id);
         Ok(())
     }
 
@@ -318,10 +310,7 @@ impl<S: AgreementStoreOps> AgreementGossipHandler<S> {
         let agreement = match self.store.get_agreement(&amendment.agreement_id)? {
             Some(a) => a,
             None => {
-                debug!(
-                    "Amendment for unknown agreement {}",
-                    amendment.agreement_id
-                );
+                debug!("Amendment for unknown agreement {}", amendment.agreement_id);
                 return Ok(());
             }
         };
@@ -331,7 +320,11 @@ impl<S: AgreementStoreOps> AgreementGossipHandler<S> {
         }
 
         // Verify the proposer is a party
-        if !agreement.parties.iter().any(|p| p.did == amendment.proposed_by) {
+        if !agreement
+            .parties
+            .iter()
+            .any(|p| p.did == amendment.proposed_by)
+        {
             warn!(
                 "Amendment from non-party {} for agreement {}",
                 amendment.proposed_by, amendment.agreement_id
@@ -370,18 +363,29 @@ impl<S: AgreementStoreOps> AgreementGossipHandler<S> {
         let amendment = match amendments.iter_mut().find(|a| a.id == amendment_id) {
             Some(a) => a,
             None => {
-                debug!("Amendment {} not found for agreement {}", amendment_id, agreement_id);
+                debug!(
+                    "Amendment {} not found for agreement {}",
+                    amendment_id, agreement_id
+                );
                 return Ok(());
             }
         };
 
         // Add signature if not duplicate
-        if !amendment.signatures.iter().any(|s| s.signer == signature.signer) {
+        if !amendment
+            .signatures
+            .iter()
+            .any(|s| s.signer == signature.signer)
+        {
             amendment.add_signature(signature);
             self.store.store_amendment(amendment)?;
             debug!(
                 "Recorded amendment signature from {} for {}",
-                amendment.signatures.last().map(|s| s.signer.to_string()).unwrap_or_default(),
+                amendment
+                    .signatures
+                    .last()
+                    .map(|s| s.signer.to_string())
+                    .unwrap_or_default(),
                 amendment_id
             );
         }
@@ -504,7 +508,11 @@ mod tests {
             },
         )
         .with_party(proposer.did().clone(), "coop-a", PartyRole::Proposer)
-        .with_party(counterparty.did().clone(), "coop-b", PartyRole::Counterparty)
+        .with_party(
+            counterparty.did().clone(),
+            "coop-b",
+            PartyRole::Counterparty,
+        )
     }
 
     #[test]
@@ -519,7 +527,9 @@ mod tests {
         let decoded = AgreementMessage::from_bytes(&bytes).unwrap();
 
         match decoded {
-            AgreementMessage::Proposed { agreement: decoded_agreement } => {
+            AgreementMessage::Proposed {
+                agreement: decoded_agreement,
+            } => {
                 assert_eq!(decoded_agreement.id, agreement.id);
             }
             _ => panic!("Wrong message type"),
@@ -543,7 +553,9 @@ mod tests {
         let message = AgreementMessage::Proposed {
             agreement: Box::new(agreement.clone()),
         };
-        handler.handle_message(&message.to_bytes().unwrap()).unwrap();
+        handler
+            .handle_message(&message.to_bytes().unwrap())
+            .unwrap();
 
         // Should not be stored since we're not a party
         assert!(store.get_agreement(&agreement.id).unwrap().is_none());
@@ -572,12 +584,18 @@ mod tests {
             },
         )
         .with_party(own_kp.did().clone(), "our-coop", PartyRole::Proposer)
-        .with_party(counterparty.did().clone(), "other-coop", PartyRole::Counterparty);
+        .with_party(
+            counterparty.did().clone(),
+            "other-coop",
+            PartyRole::Counterparty,
+        );
 
         let message = AgreementMessage::Proposed {
             agreement: Box::new(agreement.clone()),
         };
-        handler.handle_message(&message.to_bytes().unwrap()).unwrap();
+        handler
+            .handle_message(&message.to_bytes().unwrap())
+            .unwrap();
 
         // Should be stored since we're a party
         let stored = store.get_agreement(&agreement.id).unwrap();
@@ -589,11 +607,8 @@ mod tests {
     fn test_publish_with_callback() {
         let store = Arc::new(InMemoryAgreementStore::new());
         let own_kp = KeyPair::generate().unwrap();
-        let mut handler = AgreementGossipHandler::new(
-            store,
-            own_kp.did().clone(),
-            "our-coop".to_string(),
-        );
+        let mut handler =
+            AgreementGossipHandler::new(store, own_kp.did().clone(), "our-coop".to_string());
 
         let publish_count = Arc::new(AtomicUsize::new(0));
         let count_clone = publish_count.clone();

--- a/icn/crates/icn-federation/src/agreement/gossip.rs
+++ b/icn/crates/icn-federation/src/agreement/gossip.rs
@@ -1,0 +1,611 @@
+//! Agreement Gossip Integration
+//!
+//! Gossip message types and handlers for synchronizing agreement state
+//! across the federation network.
+
+use super::store::AgreementStoreOps;
+use super::types::{Agreement, AgreementId, AgreementSignature, AgreementStatus, Amendment};
+use crate::error::{FederationError, Result};
+use crate::TOPIC_FEDERATION_AGREEMENTS;
+use icn_identity::Did;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tracing::{debug, info, warn};
+
+/// Messages for agreement synchronization over gossip
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AgreementMessage {
+    /// A new agreement has been proposed
+    Proposed {
+        /// The full agreement object (boxed to reduce enum size)
+        agreement: Box<Agreement>,
+    },
+
+    /// A party has signed an agreement
+    Signed {
+        /// Agreement ID
+        agreement_id: AgreementId,
+        /// The signature
+        signature: AgreementSignature,
+    },
+
+    /// Agreement status has changed
+    StatusUpdate {
+        /// Agreement ID
+        agreement_id: AgreementId,
+        /// New status
+        new_status: AgreementStatus,
+        /// Who initiated the change
+        updated_by: Did,
+    },
+
+    /// An amendment has been proposed
+    AmendmentProposed {
+        /// The amendment
+        amendment: Amendment,
+    },
+
+    /// An amendment has been signed
+    AmendmentSigned {
+        /// Agreement ID
+        agreement_id: AgreementId,
+        /// Amendment ID
+        amendment_id: String,
+        /// The signature
+        signature: AgreementSignature,
+    },
+
+    /// Request for agreement sync
+    SyncRequest {
+        /// DIDs of agreements we want
+        agreement_ids: Vec<AgreementId>,
+        /// Requester DID
+        requester: Did,
+    },
+
+    /// Response with requested agreements
+    SyncResponse {
+        /// Requested agreements
+        agreements: Vec<Agreement>,
+        /// Responder DID
+        responder: Did,
+    },
+}
+
+impl AgreementMessage {
+    /// Get the message type name for metrics/logging
+    pub fn message_type(&self) -> &'static str {
+        match self {
+            AgreementMessage::Proposed { .. } => "proposed",
+            AgreementMessage::Signed { .. } => "signed",
+            AgreementMessage::StatusUpdate { .. } => "status_update",
+            AgreementMessage::AmendmentProposed { .. } => "amendment_proposed",
+            AgreementMessage::AmendmentSigned { .. } => "amendment_signed",
+            AgreementMessage::SyncRequest { .. } => "sync_request",
+            AgreementMessage::SyncResponse { .. } => "sync_response",
+        }
+    }
+
+    /// Serialize to bytes for gossip
+    pub fn to_bytes(&self) -> Result<Vec<u8>> {
+        serde_json::to_vec(self).map_err(|e| FederationError::SerializationError(e.to_string()))
+    }
+
+    /// Deserialize from bytes
+    pub fn from_bytes(data: &[u8]) -> Result<Self> {
+        serde_json::from_slice(data)
+            .map_err(|e| FederationError::DeserializationError(e.to_string()))
+    }
+}
+
+/// Callback for sending agreement messages via gossip
+pub type AgreementGossipCallback = Arc<dyn Fn(&str, Vec<u8>) -> Result<()> + Send + Sync>;
+
+/// Handler for agreement gossip messages
+pub struct AgreementGossipHandler<S: AgreementStoreOps> {
+    store: Arc<S>,
+    own_did: Did,
+    #[allow(dead_code)] // Reserved for future use in message signing
+    own_coop_id: String,
+    send_callback: Option<AgreementGossipCallback>,
+}
+
+impl<S: AgreementStoreOps> AgreementGossipHandler<S> {
+    /// Create a new agreement gossip handler
+    pub fn new(store: Arc<S>, own_did: Did, own_coop_id: String) -> Self {
+        Self {
+            store,
+            own_did,
+            own_coop_id,
+            send_callback: None,
+        }
+    }
+
+    /// Set the callback for sending gossip messages
+    pub fn set_send_callback(&mut self, callback: AgreementGossipCallback) {
+        self.send_callback = Some(callback);
+    }
+
+    /// Publish an agreement message to the gossip network
+    pub fn publish(&self, message: AgreementMessage) -> Result<()> {
+        if let Some(ref callback) = self.send_callback {
+            let data = message.to_bytes()?;
+            callback(TOPIC_FEDERATION_AGREEMENTS, data)?;
+            debug!("Published agreement message: {}", message.message_type());
+        } else {
+            warn!("No send callback configured for agreement gossip");
+        }
+        Ok(())
+    }
+
+    /// Handle an incoming agreement gossip message
+    pub fn handle_message(&self, data: &[u8]) -> Result<()> {
+        let message = AgreementMessage::from_bytes(data)?;
+
+        debug!(
+            "Received agreement message: {} from network",
+            message.message_type()
+        );
+
+        match message {
+            AgreementMessage::Proposed { agreement } => self.handle_proposed(*agreement),
+            AgreementMessage::Signed {
+                agreement_id,
+                signature,
+            } => self.handle_signed(agreement_id, signature),
+            AgreementMessage::StatusUpdate {
+                agreement_id,
+                new_status,
+                updated_by,
+            } => self.handle_status_update(agreement_id, new_status, updated_by),
+            AgreementMessage::AmendmentProposed { amendment } => {
+                self.handle_amendment_proposed(amendment)
+            }
+            AgreementMessage::AmendmentSigned {
+                agreement_id,
+                amendment_id,
+                signature,
+            } => self.handle_amendment_signed(agreement_id, amendment_id, signature),
+            AgreementMessage::SyncRequest {
+                agreement_ids,
+                requester,
+            } => self.handle_sync_request(agreement_ids, requester),
+            AgreementMessage::SyncResponse {
+                agreements,
+                responder,
+            } => self.handle_sync_response(agreements, responder),
+        }
+    }
+
+    /// Check if this node is a party to an agreement
+    fn is_party_to(&self, agreement: &Agreement) -> bool {
+        agreement.parties.iter().any(|p| p.did == self.own_did)
+    }
+
+    /// Handle a proposed agreement
+    fn handle_proposed(&self, agreement: Agreement) -> Result<()> {
+        // Only store if we're a party to this agreement
+        if !self.is_party_to(&agreement) {
+            debug!(
+                "Ignoring proposed agreement {} - not a party",
+                agreement.id
+            );
+            return Ok(());
+        }
+
+        // Check if we already have this agreement
+        if self.store.get_agreement(&agreement.id)?.is_some() {
+            debug!("Already have agreement {}", agreement.id);
+            return Ok(());
+        }
+
+        // Validate the agreement
+        if agreement.parties.len() < 2 {
+            warn!("Invalid agreement {} - insufficient parties", agreement.id);
+            return Err(FederationError::InvalidState(
+                "Agreement must have at least 2 parties".to_string(),
+            ));
+        }
+
+        self.store.store_agreement(&agreement)?;
+        info!(
+            "Stored proposed agreement {} from gossip",
+            agreement.id
+        );
+        Ok(())
+    }
+
+    /// Handle a signature message
+    fn handle_signed(&self, agreement_id: AgreementId, signature: AgreementSignature) -> Result<()> {
+        // Get the agreement
+        let mut agreement = match self.store.get_agreement(&agreement_id)? {
+            Some(a) => a,
+            None => {
+                debug!(
+                    "Received signature for unknown agreement {}",
+                    agreement_id
+                );
+                return Ok(());
+            }
+        };
+
+        // Only process if we're a party
+        if !self.is_party_to(&agreement) {
+            return Ok(());
+        }
+
+        // Verify the signer is a party
+        if !agreement.parties.iter().any(|p| p.did == signature.signer) {
+            warn!(
+                "Signature from non-party {} for agreement {}",
+                signature.signer, agreement_id
+            );
+            return Err(FederationError::InvalidState(
+                "Signer is not a party to the agreement".to_string(),
+            ));
+        }
+
+        // Don't add duplicate signatures
+        if agreement.has_signed(&signature.signer) {
+            debug!(
+                "Already have signature from {} for {}",
+                signature.signer, agreement_id
+            );
+            return Ok(());
+        }
+
+        // Add the signature
+        agreement.signatures.push(signature.clone());
+
+        // Check if all signatures are collected - auto-activate
+        if agreement.status.is_proposed()
+            && agreement.is_fully_signed()
+            && agreement.activate().is_ok()
+        {
+            info!("Agreement {} activated via gossip signatures", agreement_id);
+        }
+
+        self.store.store_agreement(&agreement)?;
+        debug!(
+            "Recorded signature from {} for agreement {}",
+            signature.signer, agreement_id
+        );
+        Ok(())
+    }
+
+    /// Handle a status update message
+    fn handle_status_update(
+        &self,
+        agreement_id: AgreementId,
+        new_status: AgreementStatus,
+        updated_by: Did,
+    ) -> Result<()> {
+        let mut agreement = match self.store.get_agreement(&agreement_id)? {
+            Some(a) => a,
+            None => return Ok(()),
+        };
+
+        if !self.is_party_to(&agreement) {
+            return Ok(());
+        }
+
+        // Verify the updater is a party
+        if !agreement.parties.iter().any(|p| p.did == updated_by) {
+            warn!(
+                "Status update from non-party {} for agreement {}",
+                updated_by, agreement_id
+            );
+            return Err(FederationError::Unauthorized(
+                "Updater is not a party".to_string(),
+            ));
+        }
+
+        // Apply the status update
+        agreement.status = new_status;
+        self.store.store_agreement(&agreement)?;
+
+        info!(
+            "Updated status of agreement {} via gossip",
+            agreement_id
+        );
+        Ok(())
+    }
+
+    /// Handle a proposed amendment
+    fn handle_amendment_proposed(&self, amendment: Amendment) -> Result<()> {
+        // Verify we have the agreement
+        let agreement = match self.store.get_agreement(&amendment.agreement_id)? {
+            Some(a) => a,
+            None => {
+                debug!(
+                    "Amendment for unknown agreement {}",
+                    amendment.agreement_id
+                );
+                return Ok(());
+            }
+        };
+
+        if !self.is_party_to(&agreement) {
+            return Ok(());
+        }
+
+        // Verify the proposer is a party
+        if !agreement.parties.iter().any(|p| p.did == amendment.proposed_by) {
+            warn!(
+                "Amendment from non-party {} for agreement {}",
+                amendment.proposed_by, amendment.agreement_id
+            );
+            return Err(FederationError::Unauthorized(
+                "Amendment proposer is not a party".to_string(),
+            ));
+        }
+
+        self.store.store_amendment(&amendment)?;
+        info!(
+            "Stored amendment {} for agreement {} from gossip",
+            amendment.id, amendment.agreement_id
+        );
+        Ok(())
+    }
+
+    /// Handle an amendment signature
+    fn handle_amendment_signed(
+        &self,
+        agreement_id: AgreementId,
+        amendment_id: String,
+        signature: AgreementSignature,
+    ) -> Result<()> {
+        let agreement = match self.store.get_agreement(&agreement_id)? {
+            Some(a) => a,
+            None => return Ok(()),
+        };
+
+        if !self.is_party_to(&agreement) {
+            return Ok(());
+        }
+
+        // Get the amendment
+        let mut amendments = self.store.get_amendments(&agreement_id)?;
+        let amendment = match amendments.iter_mut().find(|a| a.id == amendment_id) {
+            Some(a) => a,
+            None => {
+                debug!("Amendment {} not found for agreement {}", amendment_id, agreement_id);
+                return Ok(());
+            }
+        };
+
+        // Add signature if not duplicate
+        if !amendment.signatures.iter().any(|s| s.signer == signature.signer) {
+            amendment.add_signature(signature);
+            self.store.store_amendment(amendment)?;
+            debug!(
+                "Recorded amendment signature from {} for {}",
+                amendment.signatures.last().map(|s| s.signer.to_string()).unwrap_or_default(),
+                amendment_id
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Handle a sync request
+    fn handle_sync_request(&self, agreement_ids: Vec<AgreementId>, requester: Did) -> Result<()> {
+        // Only respond if we have agreements to share
+        let mut agreements = Vec::new();
+
+        for id in agreement_ids {
+            if let Some(agreement) = self.store.get_agreement(&id)? {
+                // Only share if the requester is a party
+                if agreement.parties.iter().any(|p| p.did == requester) {
+                    agreements.push(agreement);
+                }
+            }
+        }
+
+        if !agreements.is_empty() {
+            self.publish(AgreementMessage::SyncResponse {
+                agreements,
+                responder: self.own_did.clone(),
+            })?;
+        }
+
+        Ok(())
+    }
+
+    /// Handle a sync response
+    fn handle_sync_response(&self, agreements: Vec<Agreement>, _responder: Did) -> Result<()> {
+        for agreement in agreements {
+            if self.is_party_to(&agreement) {
+                // Only update if we don't have it or ours is older
+                let should_store = match self.store.get_agreement(&agreement.id)? {
+                    Some(existing) => agreement.updated_at > existing.updated_at,
+                    None => true,
+                };
+
+                if should_store {
+                    self.store.store_agreement(&agreement)?;
+                    debug!("Synced agreement {} from gossip", agreement.id);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Request sync for specific agreements
+    pub fn request_sync(&self, agreement_ids: Vec<AgreementId>) -> Result<()> {
+        if agreement_ids.is_empty() {
+            return Ok(());
+        }
+
+        self.publish(AgreementMessage::SyncRequest {
+            agreement_ids,
+            requester: self.own_did.clone(),
+        })
+    }
+
+    /// Broadcast a proposed agreement
+    pub fn broadcast_proposed(&self, agreement: &Agreement) -> Result<()> {
+        self.publish(AgreementMessage::Proposed {
+            agreement: Box::new(agreement.clone()),
+        })
+    }
+
+    /// Broadcast a signature
+    pub fn broadcast_signature(
+        &self,
+        agreement_id: &AgreementId,
+        signature: AgreementSignature,
+    ) -> Result<()> {
+        self.publish(AgreementMessage::Signed {
+            agreement_id: agreement_id.clone(),
+            signature,
+        })
+    }
+
+    /// Broadcast a status update
+    pub fn broadcast_status_update(
+        &self,
+        agreement_id: &AgreementId,
+        new_status: AgreementStatus,
+    ) -> Result<()> {
+        self.publish(AgreementMessage::StatusUpdate {
+            agreement_id: agreement_id.clone(),
+            new_status,
+            updated_by: self.own_did.clone(),
+        })
+    }
+
+    /// Broadcast a proposed amendment
+    pub fn broadcast_amendment(&self, amendment: &Amendment) -> Result<()> {
+        self.publish(AgreementMessage::AmendmentProposed {
+            amendment: amendment.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agreement::{AgreementType, InMemoryAgreementStore, PartyRole, TradeItem};
+    use icn_identity::KeyPair;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn create_test_agreement() -> Agreement {
+        let proposer = KeyPair::generate().unwrap();
+        let counterparty = KeyPair::generate().unwrap();
+
+        Agreement::new(
+            "Test Agreement",
+            "For testing gossip",
+            AgreementType::Trade {
+                items: vec![TradeItem::new("item", 10, "units", 100, "USD")],
+                currency: "USD".to_string(),
+            },
+        )
+        .with_party(proposer.did().clone(), "coop-a", PartyRole::Proposer)
+        .with_party(counterparty.did().clone(), "coop-b", PartyRole::Counterparty)
+    }
+
+    #[test]
+    fn test_message_serialization() {
+        let agreement = create_test_agreement();
+
+        let message = AgreementMessage::Proposed {
+            agreement: Box::new(agreement.clone()),
+        };
+
+        let bytes = message.to_bytes().unwrap();
+        let decoded = AgreementMessage::from_bytes(&bytes).unwrap();
+
+        match decoded {
+            AgreementMessage::Proposed { agreement: decoded_agreement } => {
+                assert_eq!(decoded_agreement.id, agreement.id);
+            }
+            _ => panic!("Wrong message type"),
+        }
+    }
+
+    #[test]
+    fn test_handler_filters_non_party_agreements() {
+        let store = Arc::new(InMemoryAgreementStore::new());
+        let own_kp = KeyPair::generate().unwrap();
+        let handler = AgreementGossipHandler::new(
+            store.clone(),
+            own_kp.did().clone(),
+            "our-coop".to_string(),
+        );
+
+        // Create an agreement where we're NOT a party
+        let agreement = create_test_agreement();
+
+        // Handle the proposed message
+        let message = AgreementMessage::Proposed {
+            agreement: Box::new(agreement.clone()),
+        };
+        handler.handle_message(&message.to_bytes().unwrap()).unwrap();
+
+        // Should not be stored since we're not a party
+        assert!(store.get_agreement(&agreement.id).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_handler_stores_party_agreements() {
+        let store = Arc::new(InMemoryAgreementStore::new());
+        let own_kp = KeyPair::generate().unwrap();
+        let counterparty = KeyPair::generate().unwrap();
+
+        let handler = AgreementGossipHandler::new(
+            store.clone(),
+            own_kp.did().clone(),
+            "our-coop".to_string(),
+        );
+
+        // Create an agreement where we ARE a party
+        let agreement = Agreement::new(
+            "Test Agreement",
+            "For testing",
+            AgreementType::Credit {
+                credit_limit: 5000,
+                interest_rate_bps: 300,
+                currency: "USD".to_string(),
+            },
+        )
+        .with_party(own_kp.did().clone(), "our-coop", PartyRole::Proposer)
+        .with_party(counterparty.did().clone(), "other-coop", PartyRole::Counterparty);
+
+        let message = AgreementMessage::Proposed {
+            agreement: Box::new(agreement.clone()),
+        };
+        handler.handle_message(&message.to_bytes().unwrap()).unwrap();
+
+        // Should be stored since we're a party
+        let stored = store.get_agreement(&agreement.id).unwrap();
+        assert!(stored.is_some());
+        assert_eq!(stored.unwrap().title, "Test Agreement");
+    }
+
+    #[test]
+    fn test_publish_with_callback() {
+        let store = Arc::new(InMemoryAgreementStore::new());
+        let own_kp = KeyPair::generate().unwrap();
+        let mut handler = AgreementGossipHandler::new(
+            store,
+            own_kp.did().clone(),
+            "our-coop".to_string(),
+        );
+
+        let publish_count = Arc::new(AtomicUsize::new(0));
+        let count_clone = publish_count.clone();
+
+        handler.set_send_callback(Arc::new(move |_topic, _data| {
+            count_clone.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }));
+
+        let agreement = create_test_agreement();
+        handler.broadcast_proposed(&agreement).unwrap();
+
+        assert_eq!(publish_count.load(Ordering::SeqCst), 1);
+    }
+}

--- a/icn/crates/icn-federation/src/agreement/manager.rs
+++ b/icn/crates/icn-federation/src/agreement/manager.rs
@@ -1,0 +1,924 @@
+//! Agreement Manager
+//!
+//! Business logic for managing inter-cooperative agreements including lifecycle
+//! state transitions, signature collection, and event notifications.
+
+use super::store::AgreementStoreOps;
+use super::types::{
+    Agreement, AgreementId, AgreementParty, AgreementSignature, AgreementStatus, AgreementTerms,
+    AgreementType, Amendment, AmendmentChange, AmendmentStatus, PartyRole, TerminationReason,
+};
+use crate::error::{FederationError, Result};
+use crate::types::current_timestamp;
+use icn_identity::{Did, KeyPair};
+use std::sync::Arc;
+use tracing::{debug, info};
+
+/// Callback type for agreement events
+pub type AgreementEventCallback = Box<dyn Fn(AgreementEvent) + Send + Sync>;
+
+/// Events emitted by the agreement manager
+#[derive(Debug, Clone)]
+pub enum AgreementEvent {
+    /// A new agreement was created
+    Created {
+        agreement_id: AgreementId,
+        proposer: Did,
+    },
+
+    /// An agreement was proposed (moved from Draft to Proposed)
+    Proposed {
+        agreement_id: AgreementId,
+        awaiting_signatures: Vec<Did>,
+    },
+
+    /// A party signed an agreement
+    Signed {
+        agreement_id: AgreementId,
+        signer: Did,
+        remaining_signers: Vec<Did>,
+    },
+
+    /// An agreement became active (all parties signed)
+    Activated {
+        agreement_id: AgreementId,
+        activated_at: u64,
+    },
+
+    /// An agreement was suspended
+    Suspended {
+        agreement_id: AgreementId,
+        suspended_by: Did,
+        reason: String,
+    },
+
+    /// An agreement was resumed
+    Resumed {
+        agreement_id: AgreementId,
+        resumed_by: Did,
+    },
+
+    /// An agreement was terminated
+    Terminated {
+        agreement_id: AgreementId,
+        reason: TerminationReason,
+    },
+
+    /// An amendment was proposed
+    AmendmentProposed {
+        agreement_id: AgreementId,
+        amendment_id: String,
+        proposed_by: Did,
+    },
+
+    /// An amendment was signed
+    AmendmentSigned {
+        agreement_id: AgreementId,
+        amendment_id: String,
+        signer: Did,
+    },
+
+    /// An amendment was ratified
+    AmendmentRatified {
+        agreement_id: AgreementId,
+        amendment_id: String,
+        new_version: u32,
+    },
+}
+
+/// Manager for inter-cooperative agreements
+pub struct AgreementManager<S: AgreementStoreOps> {
+    store: Arc<S>,
+    own_coop_id: String,
+    own_did: Did,
+    keypair: Option<Arc<KeyPair>>,
+    event_callback: Option<AgreementEventCallback>,
+}
+
+impl<S: AgreementStoreOps> AgreementManager<S> {
+    /// Create a new agreement manager
+    pub fn new(store: Arc<S>, own_coop_id: String, own_did: Did) -> Self {
+        Self {
+            store,
+            own_coop_id,
+            own_did,
+            keypair: None,
+            event_callback: None,
+        }
+    }
+
+    /// Set the keypair for signing operations
+    pub fn with_keypair(mut self, keypair: Arc<KeyPair>) -> Self {
+        self.keypair = Some(keypair);
+        self
+    }
+
+    /// Set the event callback
+    pub fn with_event_callback(mut self, callback: AgreementEventCallback) -> Self {
+        self.event_callback = Some(callback);
+        self
+    }
+
+    /// Emit an event
+    fn emit_event(&self, event: AgreementEvent) {
+        debug!("Agreement event: {:?}", event);
+        if let Some(ref callback) = self.event_callback {
+            callback(event);
+        }
+    }
+
+    /// Create a new draft agreement
+    ///
+    /// The caller is automatically added as the proposer.
+    pub fn create_draft(
+        &self,
+        title: impl Into<String>,
+        description: impl Into<String>,
+        agreement_type: AgreementType,
+    ) -> Result<Agreement> {
+        let agreement = Agreement::new(title, description, agreement_type)
+            .with_party(self.own_did.clone(), &self.own_coop_id, PartyRole::Proposer);
+
+        self.store.store_agreement(&agreement)?;
+
+        self.emit_event(AgreementEvent::Created {
+            agreement_id: agreement.id.clone(),
+            proposer: self.own_did.clone(),
+        });
+
+        info!("Created draft agreement {}", agreement.id);
+        Ok(agreement)
+    }
+
+    /// Add a party to a draft agreement
+    pub fn add_party(
+        &self,
+        agreement_id: &AgreementId,
+        party: AgreementParty,
+    ) -> Result<Agreement> {
+        let mut agreement = self.get_agreement_required(agreement_id)?;
+
+        if !agreement.status.is_draft() {
+            return Err(FederationError::InvalidState(
+                "Can only add parties to draft agreements".to_string(),
+            ));
+        }
+
+        // Check for duplicate
+        if agreement.parties.iter().any(|p| p.did == party.did) {
+            return Err(FederationError::InvalidState(
+                "Party already exists in agreement".to_string(),
+            ));
+        }
+
+        agreement.parties.push(party);
+        agreement.updated_at = current_timestamp();
+        self.store.store_agreement(&agreement)?;
+
+        Ok(agreement)
+    }
+
+    /// Set terms on a draft agreement
+    pub fn set_terms(
+        &self,
+        agreement_id: &AgreementId,
+        terms: AgreementTerms,
+    ) -> Result<Agreement> {
+        let mut agreement = self.get_agreement_required(agreement_id)?;
+
+        if !agreement.status.is_draft() {
+            return Err(FederationError::InvalidState(
+                "Can only set terms on draft agreements".to_string(),
+            ));
+        }
+
+        agreement.terms = terms;
+        agreement.updated_at = current_timestamp();
+        self.store.store_agreement(&agreement)?;
+
+        Ok(agreement)
+    }
+
+    /// Propose a draft agreement (transition to Proposed status)
+    pub fn propose(&self, agreement_id: &AgreementId) -> Result<Agreement> {
+        let mut agreement = self.get_agreement_required(agreement_id)?;
+
+        // Verify caller is the proposer
+        if let Some(proposer) = agreement.proposer() {
+            if proposer.did != self.own_did {
+                return Err(FederationError::Unauthorized(
+                    "Only the proposer can propose an agreement".to_string(),
+                ));
+            }
+        } else {
+            return Err(FederationError::InvalidState(
+                "Agreement has no proposer".to_string(),
+            ));
+        }
+
+        agreement
+            .propose()
+            .map_err(|e| FederationError::InvalidState(e.to_string()))?;
+
+        self.store.store_agreement(&agreement)?;
+
+        let awaiting = agreement.pending_signers();
+        self.emit_event(AgreementEvent::Proposed {
+            agreement_id: agreement.id.clone(),
+            awaiting_signatures: awaiting.clone(),
+        });
+
+        info!(
+            "Proposed agreement {} (awaiting {} signatures)",
+            agreement.id,
+            awaiting.len()
+        );
+        Ok(agreement)
+    }
+
+    /// Sign an agreement
+    ///
+    /// If all required parties have signed, the agreement is automatically activated.
+    pub fn sign(&self, agreement_id: &AgreementId) -> Result<Agreement> {
+        let mut agreement = self.get_agreement_required(agreement_id)?;
+
+        // Verify agreement is in Proposed status
+        if !agreement.status.is_proposed() {
+            return Err(FederationError::InvalidState(
+                "Can only sign proposed agreements".to_string(),
+            ));
+        }
+
+        // Verify caller is a party who needs to sign
+        let is_signer = agreement
+            .parties
+            .iter()
+            .any(|p| p.did == self.own_did && p.role.requires_signature());
+
+        if !is_signer {
+            return Err(FederationError::Unauthorized(
+                "Caller is not a party requiring signature".to_string(),
+            ));
+        }
+
+        // Check if already signed
+        if agreement.has_signed(&self.own_did) {
+            return Err(FederationError::InvalidState(
+                "Already signed this agreement".to_string(),
+            ));
+        }
+
+        // Sign the agreement
+        let keypair = self
+            .keypair
+            .as_ref()
+            .ok_or_else(|| FederationError::Config("No keypair configured for signing".to_string()))?;
+
+        agreement.sign(keypair, &self.own_coop_id);
+        let remaining = agreement.pending_signers();
+
+        self.emit_event(AgreementEvent::Signed {
+            agreement_id: agreement.id.clone(),
+            signer: self.own_did.clone(),
+            remaining_signers: remaining.clone(),
+        });
+
+        // Check if we should auto-activate
+        if agreement.try_auto_activate() {
+            if let AgreementStatus::Active { activated_at, .. } = &agreement.status {
+                self.emit_event(AgreementEvent::Activated {
+                    agreement_id: agreement.id.clone(),
+                    activated_at: *activated_at,
+                });
+                info!("Agreement {} activated (all parties signed)", agreement.id);
+            }
+        }
+
+        self.store.store_agreement(&agreement)?;
+
+        debug!(
+            "Signed agreement {} ({} signers remaining)",
+            agreement.id,
+            remaining.len()
+        );
+        Ok(agreement)
+    }
+
+    /// Record a signature received from another party (e.g., via gossip)
+    pub fn record_signature(
+        &self,
+        agreement_id: &AgreementId,
+        signature: AgreementSignature,
+    ) -> Result<Agreement> {
+        let mut agreement = self.get_agreement_required(agreement_id)?;
+
+        // Verify agreement is in Proposed status
+        if !agreement.status.is_proposed() {
+            return Err(FederationError::InvalidState(
+                "Can only add signatures to proposed agreements".to_string(),
+            ));
+        }
+
+        // Verify signer is a party
+        let is_party = agreement.parties.iter().any(|p| p.did == signature.signer);
+        if !is_party {
+            return Err(FederationError::InvalidState(
+                "Signer is not a party to this agreement".to_string(),
+            ));
+        }
+
+        // Don't add duplicate signatures
+        if agreement.has_signed(&signature.signer) {
+            return Ok(agreement);
+        }
+
+        // Verify signature version matches
+        if signature.version_signed != agreement.version {
+            return Err(FederationError::InvalidState(format!(
+                "Signature version {} doesn't match agreement version {}",
+                signature.version_signed, agreement.version
+            )));
+        }
+
+        // Add the signature
+        agreement.signatures.push(signature.clone());
+        let remaining = agreement.pending_signers();
+
+        self.emit_event(AgreementEvent::Signed {
+            agreement_id: agreement.id.clone(),
+            signer: signature.signer.clone(),
+            remaining_signers: remaining.clone(),
+        });
+
+        // Check for auto-activation
+        if agreement.try_auto_activate() {
+            if let AgreementStatus::Active { activated_at, .. } = &agreement.status {
+                self.emit_event(AgreementEvent::Activated {
+                    agreement_id: agreement.id.clone(),
+                    activated_at: *activated_at,
+                });
+                info!("Agreement {} activated (all parties signed)", agreement.id);
+            }
+        }
+
+        self.store.store_agreement(&agreement)?;
+        Ok(agreement)
+    }
+
+    /// Suspend an active agreement
+    pub fn suspend(&self, agreement_id: &AgreementId, reason: impl Into<String>) -> Result<Agreement> {
+        let mut agreement = self.get_agreement_required(agreement_id)?;
+
+        // Verify caller is a party
+        if !agreement.parties.iter().any(|p| p.did == self.own_did) {
+            return Err(FederationError::Unauthorized(
+                "Only parties can suspend an agreement".to_string(),
+            ));
+        }
+
+        let reason_str = reason.into();
+        agreement
+            .suspend(&reason_str, self.own_did.clone())
+            .map_err(|e| FederationError::InvalidState(e.to_string()))?;
+
+        self.store.store_agreement(&agreement)?;
+
+        self.emit_event(AgreementEvent::Suspended {
+            agreement_id: agreement.id.clone(),
+            suspended_by: self.own_did.clone(),
+            reason: reason_str,
+        });
+
+        info!("Suspended agreement {}", agreement.id);
+        Ok(agreement)
+    }
+
+    /// Resume a suspended agreement
+    pub fn resume(&self, agreement_id: &AgreementId) -> Result<Agreement> {
+        let mut agreement = self.get_agreement_required(agreement_id)?;
+
+        agreement
+            .resume(&self.own_did)
+            .map_err(|e| FederationError::InvalidState(e.to_string()))?;
+
+        self.store.store_agreement(&agreement)?;
+
+        self.emit_event(AgreementEvent::Resumed {
+            agreement_id: agreement.id.clone(),
+            resumed_by: self.own_did.clone(),
+        });
+
+        info!("Resumed agreement {}", agreement.id);
+        Ok(agreement)
+    }
+
+    /// Terminate an agreement
+    pub fn terminate(&self, agreement_id: &AgreementId, reason: TerminationReason) -> Result<Agreement> {
+        let mut agreement = self.get_agreement_required(agreement_id)?;
+
+        // Verify caller is a party
+        if !agreement.parties.iter().any(|p| p.did == self.own_did) {
+            return Err(FederationError::Unauthorized(
+                "Only parties can terminate an agreement".to_string(),
+            ));
+        }
+
+        agreement
+            .terminate(reason.clone())
+            .map_err(|e| FederationError::InvalidState(e.to_string()))?;
+
+        self.store.store_agreement(&agreement)?;
+
+        self.emit_event(AgreementEvent::Terminated {
+            agreement_id: agreement.id.clone(),
+            reason,
+        });
+
+        info!("Terminated agreement {}", agreement.id);
+        Ok(agreement)
+    }
+
+    /// Reject a proposed agreement (return to Draft)
+    pub fn reject(&self, agreement_id: &AgreementId) -> Result<Agreement> {
+        let mut agreement = self.get_agreement_required(agreement_id)?;
+
+        // Verify caller is a party
+        if !agreement.parties.iter().any(|p| p.did == self.own_did) {
+            return Err(FederationError::Unauthorized(
+                "Only parties can reject an agreement".to_string(),
+            ));
+        }
+
+        agreement
+            .reject()
+            .map_err(|e| FederationError::InvalidState(e.to_string()))?;
+
+        self.store.store_agreement(&agreement)?;
+
+        info!("Rejected agreement {} (returned to draft)", agreement.id);
+        Ok(agreement)
+    }
+
+    /// Delete a draft agreement
+    pub fn delete_draft(&self, agreement_id: &AgreementId) -> Result<()> {
+        let agreement = self.get_agreement_required(agreement_id)?;
+
+        if !agreement.status.is_draft() {
+            return Err(FederationError::InvalidState(
+                "Can only delete draft agreements".to_string(),
+            ));
+        }
+
+        // Verify caller is the proposer
+        if let Some(proposer) = agreement.proposer() {
+            if proposer.did != self.own_did {
+                return Err(FederationError::Unauthorized(
+                    "Only the proposer can delete a draft".to_string(),
+                ));
+            }
+        }
+
+        self.store.delete_agreement(agreement_id)?;
+        info!("Deleted draft agreement {}", agreement_id);
+        Ok(())
+    }
+
+    // === Query Methods ===
+
+    /// Get an agreement by ID
+    pub fn get_agreement(&self, id: &AgreementId) -> Result<Option<Agreement>> {
+        self.store.get_agreement(id)
+    }
+
+    /// Get an agreement by ID, returning an error if not found
+    fn get_agreement_required(&self, id: &AgreementId) -> Result<Agreement> {
+        self.store.get_agreement(id)?.ok_or_else(|| {
+            FederationError::NotFound(format!("Agreement not found: {id}"))
+        })
+    }
+
+    /// List all agreements
+    pub fn list_agreements(&self) -> Result<Vec<Agreement>> {
+        self.store.list_agreements()
+    }
+
+    /// List agreements where this cooperative is a party
+    pub fn list_my_agreements(&self) -> Result<Vec<Agreement>> {
+        self.store.list_agreements_for_party(&self.own_did)
+    }
+
+    /// List agreements by status
+    pub fn list_by_status(&self, status_type: &str) -> Result<Vec<Agreement>> {
+        self.store.list_agreements_by_status(status_type)
+    }
+
+    /// Get agreements pending signature from this cooperative
+    pub fn pending_signatures(&self) -> Result<Vec<Agreement>> {
+        let agreements = self.list_my_agreements()?;
+        Ok(agreements
+            .into_iter()
+            .filter(|a| {
+                a.status.is_proposed() && !a.has_signed(&self.own_did)
+            })
+            .collect())
+    }
+
+    // === Amendment Methods ===
+
+    /// Propose an amendment to an active agreement
+    pub fn propose_amendment(
+        &self,
+        agreement_id: &AgreementId,
+        description: impl Into<String>,
+        changes: Vec<AmendmentChange>,
+    ) -> Result<Amendment> {
+        let agreement = self.get_agreement_required(agreement_id)?;
+
+        // Must be active
+        if !agreement.status.is_active() {
+            return Err(FederationError::InvalidState(
+                "Can only amend active agreements".to_string(),
+            ));
+        }
+
+        // Verify caller is a party
+        if !agreement.parties.iter().any(|p| p.did == self.own_did) {
+            return Err(FederationError::Unauthorized(
+                "Only parties can propose amendments".to_string(),
+            ));
+        }
+
+        let mut amendment = Amendment::new(
+            agreement_id.clone(),
+            description,
+            self.own_did.clone(),
+        );
+
+        for change in changes {
+            amendment.changes.push(change);
+        }
+
+        self.store.store_amendment(&amendment)?;
+
+        self.emit_event(AgreementEvent::AmendmentProposed {
+            agreement_id: agreement_id.clone(),
+            amendment_id: amendment.id.clone(),
+            proposed_by: self.own_did.clone(),
+        });
+
+        info!(
+            "Proposed amendment {} for agreement {}",
+            amendment.id, agreement_id
+        );
+        Ok(amendment)
+    }
+
+    /// Sign an amendment
+    pub fn sign_amendment(
+        &self,
+        agreement_id: &AgreementId,
+        amendment_id: &str,
+    ) -> Result<Amendment> {
+        let agreement = self.get_agreement_required(agreement_id)?;
+        let mut amendments = self.store.get_amendments(agreement_id)?;
+
+        let amendment = amendments
+            .iter_mut()
+            .find(|a| a.id == amendment_id)
+            .ok_or_else(|| FederationError::NotFound(format!("Amendment not found: {amendment_id}")))?;
+
+        if amendment.status != AmendmentStatus::Proposed {
+            return Err(FederationError::InvalidState(
+                "Can only sign proposed amendments".to_string(),
+            ));
+        }
+
+        // Verify caller is a party
+        if !agreement.parties.iter().any(|p| p.did == self.own_did) {
+            return Err(FederationError::Unauthorized(
+                "Only parties can sign amendments".to_string(),
+            ));
+        }
+
+        // Check if already signed
+        if amendment.signatures.iter().any(|s| s.signer == self.own_did) {
+            return Err(FederationError::InvalidState(
+                "Already signed this amendment".to_string(),
+            ));
+        }
+
+        // Add signature (simplified - in production would verify signature properly)
+        let sig = AgreementSignature::new(
+            self.own_did.clone(),
+            &self.own_coop_id,
+            vec![], // Signature bytes - simplified
+            agreement.version,
+        );
+        amendment.add_signature(sig);
+
+        self.emit_event(AgreementEvent::AmendmentSigned {
+            agreement_id: agreement_id.clone(),
+            amendment_id: amendment_id.to_string(),
+            signer: self.own_did.clone(),
+        });
+
+        // Check if all parties have signed
+        let required_signers: Vec<_> = agreement
+            .parties
+            .iter()
+            .filter(|p| p.role.requires_signature())
+            .map(|p| &p.did)
+            .collect();
+
+        if amendment.is_fully_signed(&required_signers.iter().map(|d| (*d).clone()).collect::<Vec<_>>()) {
+            amendment.status = AmendmentStatus::Ratified;
+
+            // Apply the amendment to the agreement
+            let mut updated_agreement = agreement.clone();
+            let amendment_clone = amendment.clone();
+            updated_agreement.apply_amendment(amendment_clone)?;
+            self.store.store_agreement(&updated_agreement)?;
+
+            self.emit_event(AgreementEvent::AmendmentRatified {
+                agreement_id: agreement_id.clone(),
+                amendment_id: amendment_id.to_string(),
+                new_version: updated_agreement.version,
+            });
+
+            info!(
+                "Ratified amendment {} for agreement {} (new version: {})",
+                amendment_id, agreement_id, updated_agreement.version
+            );
+        }
+
+        self.store.store_amendment(amendment)?;
+        Ok(amendment.clone())
+    }
+
+    /// Get amendments for an agreement
+    pub fn get_amendments(&self, agreement_id: &AgreementId) -> Result<Vec<Amendment>> {
+        self.store.get_amendments(agreement_id)
+    }
+
+    /// Check for expired agreements and mark them as terminated
+    pub fn check_expirations(&self) -> Result<Vec<AgreementId>> {
+        let now = current_timestamp();
+        let active = self.list_by_status("active")?;
+        let mut expired = Vec::new();
+
+        for agreement in active {
+            if agreement.status.is_expired(now) {
+                let mut updated = agreement;
+                if updated.terminate(TerminationReason::Expired).is_ok() {
+                    self.store.store_agreement(&updated)?;
+
+                    self.emit_event(AgreementEvent::Terminated {
+                        agreement_id: updated.id.clone(),
+                        reason: TerminationReason::Expired,
+                    });
+
+                    expired.push(updated.id);
+                }
+            }
+        }
+
+        if !expired.is_empty() {
+            info!("Marked {} agreements as expired", expired.len());
+        }
+
+        Ok(expired)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agreement::{InMemoryAgreementStore, TradeItem};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn create_manager() -> (AgreementManager<InMemoryAgreementStore>, Arc<KeyPair>) {
+        let store = Arc::new(InMemoryAgreementStore::new());
+        let keypair = Arc::new(KeyPair::generate().unwrap());
+        let did = keypair.did().clone();
+        let manager = AgreementManager::new(store, "test-coop".to_string(), did)
+            .with_keypair(keypair.clone());
+        (manager, keypair)
+    }
+
+    #[test]
+    fn test_create_and_propose() {
+        let (manager, _) = create_manager();
+
+        // Create draft
+        let agreement = manager
+            .create_draft(
+                "Test Agreement",
+                "Testing",
+                AgreementType::Trade {
+                    items: vec![TradeItem::new("item", 10, "units", 100, "USD")],
+                    currency: "USD".to_string(),
+                },
+            )
+            .unwrap();
+
+        assert!(agreement.status.is_draft());
+        assert_eq!(agreement.parties.len(), 1);
+
+        // Add counterparty
+        let counterparty_did = KeyPair::generate().unwrap().did().clone();
+        let agreement = manager
+            .add_party(
+                &agreement.id,
+                AgreementParty::new(counterparty_did, "other-coop", PartyRole::Counterparty),
+            )
+            .unwrap();
+
+        assert_eq!(agreement.parties.len(), 2);
+
+        // Propose
+        let agreement = manager.propose(&agreement.id).unwrap();
+        assert!(agreement.status.is_proposed());
+    }
+
+    #[test]
+    fn test_signing_workflow() {
+        let (manager1, _kp1) = create_manager();
+
+        // Manager 2 for the counterparty
+        let store2 = Arc::new(InMemoryAgreementStore::new());
+        let kp2 = Arc::new(KeyPair::generate().unwrap());
+        let manager2 = AgreementManager::new(
+            store2.clone(),
+            "other-coop".to_string(),
+            kp2.did().clone(),
+        )
+        .with_keypair(kp2.clone());
+
+        // Manager 1 creates and proposes
+        let agreement = manager1
+            .create_draft(
+                "Trade Agreement",
+                "For testing",
+                AgreementType::Credit {
+                    credit_limit: 5000,
+                    interest_rate_bps: 300,
+                    currency: "USD".to_string(),
+                },
+            )
+            .unwrap();
+
+        let agreement = manager1
+            .add_party(
+                &agreement.id,
+                AgreementParty::new(kp2.did().clone(), "other-coop", PartyRole::Counterparty),
+            )
+            .unwrap();
+
+        let agreement = manager1.propose(&agreement.id).unwrap();
+
+        // Copy to manager2's store
+        store2.store_agreement(&agreement).unwrap();
+
+        // Manager 1 signs
+        let agreement = manager1.sign(&agreement.id).unwrap();
+        assert!(!agreement.status.is_active()); // Not yet, need counterparty
+
+        // Update manager2's copy
+        store2.store_agreement(&agreement).unwrap();
+
+        // Manager 2 signs - should activate
+        let agreement = manager2.sign(&agreement.id).unwrap();
+        assert!(agreement.status.is_active());
+    }
+
+    #[test]
+    fn test_suspend_and_resume() {
+        let (manager, _kp) = create_manager();
+
+        // Create agreement with a separate counterparty
+        let counterparty_kp = KeyPair::generate().unwrap();
+        let agreement = manager
+            .create_draft(
+                "Test",
+                "Test",
+                AgreementType::Custom {
+                    agreement_type_name: "test".to_string(),
+                    terms_json: "{}".to_string(),
+                },
+            )
+            .unwrap();
+
+        let agreement = manager
+            .add_party(
+                &agreement.id,
+                AgreementParty::new(counterparty_kp.did().clone(), "other-coop", PartyRole::Counterparty),
+            )
+            .unwrap();
+
+        let agreement = manager.propose(&agreement.id).unwrap();
+        let mut agreement = manager.sign(&agreement.id).unwrap();
+
+        // Add counterparty signature to activate
+        agreement.signatures.push(AgreementSignature::new(
+            counterparty_kp.did().clone(),
+            "other-coop",
+            vec![1, 2, 3], // Mock signature
+            1,
+        ));
+        // Force activate by setting status directly (skip verification for test)
+        agreement.status = AgreementStatus::Active {
+            activated_at: current_timestamp(),
+            expires_at: None,
+        };
+        manager.store.store_agreement(&agreement).unwrap();
+
+        // Suspend
+        let agreement = manager.suspend(&agreement.id, "Testing suspension").unwrap();
+        assert!(agreement.status.is_suspended());
+
+        // Resume
+        let agreement = manager.resume(&agreement.id).unwrap();
+        assert!(agreement.status.is_active());
+    }
+
+    #[test]
+    fn test_event_callback() {
+        let store = Arc::new(InMemoryAgreementStore::new());
+        let keypair = Arc::new(KeyPair::generate().unwrap());
+        let did = keypair.did().clone();
+
+        let event_count = Arc::new(AtomicUsize::new(0));
+        let count_clone = event_count.clone();
+
+        let manager = AgreementManager::new(store, "test-coop".to_string(), did)
+            .with_keypair(keypair)
+            .with_event_callback(Box::new(move |_event| {
+                count_clone.fetch_add(1, Ordering::SeqCst);
+            }));
+
+        // Create should emit Created event
+        let agreement = manager
+            .create_draft(
+                "Test",
+                "Test",
+                AgreementType::Custom {
+                    agreement_type_name: "test".to_string(),
+                    terms_json: "{}".to_string(),
+                },
+            )
+            .unwrap();
+
+        assert_eq!(event_count.load(Ordering::SeqCst), 1);
+
+        // Add party and propose
+        let kp2 = KeyPair::generate().unwrap();
+        manager
+            .add_party(
+                &agreement.id,
+                AgreementParty::new(kp2.did().clone(), "other", PartyRole::Counterparty),
+            )
+            .unwrap();
+
+        manager.propose(&agreement.id).unwrap();
+        assert_eq!(event_count.load(Ordering::SeqCst), 2); // Proposed event
+    }
+
+    #[test]
+    fn test_pending_signatures() {
+        let (manager, _kp) = create_manager();
+
+        // Create and propose an agreement
+        let agreement = manager
+            .create_draft(
+                "Test",
+                "Test",
+                AgreementType::Credit {
+                    credit_limit: 1000,
+                    interest_rate_bps: 100,
+                    currency: "USD".to_string(),
+                },
+            )
+            .unwrap();
+
+        let kp2 = KeyPair::generate().unwrap();
+        manager
+            .add_party(
+                &agreement.id,
+                AgreementParty::new(kp2.did().clone(), "other", PartyRole::Counterparty),
+            )
+            .unwrap();
+
+        manager.propose(&agreement.id).unwrap();
+
+        // Should show as pending
+        let pending = manager.pending_signatures().unwrap();
+        assert_eq!(pending.len(), 1);
+
+        // Sign it
+        manager.sign(&agreement.id).unwrap();
+
+        // No longer pending for us
+        let pending = manager.pending_signatures().unwrap();
+        assert_eq!(pending.len(), 0);
+    }
+}

--- a/icn/crates/icn-federation/src/agreement/manager.rs
+++ b/icn/crates/icn-federation/src/agreement/manager.rs
@@ -136,8 +136,11 @@ impl<S: AgreementStoreOps> AgreementManager<S> {
         description: impl Into<String>,
         agreement_type: AgreementType,
     ) -> Result<Agreement> {
-        let agreement = Agreement::new(title, description, agreement_type)
-            .with_party(self.own_did.clone(), &self.own_coop_id, PartyRole::Proposer);
+        let agreement = Agreement::new(title, description, agreement_type).with_party(
+            self.own_did.clone(),
+            &self.own_coop_id,
+            PartyRole::Proposer,
+        );
 
         self.store.store_agreement(&agreement)?;
 
@@ -269,10 +272,9 @@ impl<S: AgreementStoreOps> AgreementManager<S> {
         }
 
         // Sign the agreement
-        let keypair = self
-            .keypair
-            .as_ref()
-            .ok_or_else(|| FederationError::Config("No keypair configured for signing".to_string()))?;
+        let keypair = self.keypair.as_ref().ok_or_else(|| {
+            FederationError::Config("No keypair configured for signing".to_string())
+        })?;
 
         agreement.sign(keypair, &self.own_coop_id);
         let remaining = agreement.pending_signers();
@@ -366,7 +368,11 @@ impl<S: AgreementStoreOps> AgreementManager<S> {
     }
 
     /// Suspend an active agreement
-    pub fn suspend(&self, agreement_id: &AgreementId, reason: impl Into<String>) -> Result<Agreement> {
+    pub fn suspend(
+        &self,
+        agreement_id: &AgreementId,
+        reason: impl Into<String>,
+    ) -> Result<Agreement> {
         let mut agreement = self.get_agreement_required(agreement_id)?;
 
         // Verify caller is a party
@@ -413,7 +419,11 @@ impl<S: AgreementStoreOps> AgreementManager<S> {
     }
 
     /// Terminate an agreement
-    pub fn terminate(&self, agreement_id: &AgreementId, reason: TerminationReason) -> Result<Agreement> {
+    pub fn terminate(
+        &self,
+        agreement_id: &AgreementId,
+        reason: TerminationReason,
+    ) -> Result<Agreement> {
         let mut agreement = self.get_agreement_required(agreement_id)?;
 
         // Verify caller is a party
@@ -492,9 +502,9 @@ impl<S: AgreementStoreOps> AgreementManager<S> {
 
     /// Get an agreement by ID, returning an error if not found
     fn get_agreement_required(&self, id: &AgreementId) -> Result<Agreement> {
-        self.store.get_agreement(id)?.ok_or_else(|| {
-            FederationError::NotFound(format!("Agreement not found: {id}"))
-        })
+        self.store
+            .get_agreement(id)?
+            .ok_or_else(|| FederationError::NotFound(format!("Agreement not found: {id}")))
     }
 
     /// List all agreements
@@ -517,9 +527,7 @@ impl<S: AgreementStoreOps> AgreementManager<S> {
         let agreements = self.list_my_agreements()?;
         Ok(agreements
             .into_iter()
-            .filter(|a| {
-                a.status.is_proposed() && !a.has_signed(&self.own_did)
-            })
+            .filter(|a| a.status.is_proposed() && !a.has_signed(&self.own_did))
             .collect())
     }
 
@@ -548,11 +556,7 @@ impl<S: AgreementStoreOps> AgreementManager<S> {
             ));
         }
 
-        let mut amendment = Amendment::new(
-            agreement_id.clone(),
-            description,
-            self.own_did.clone(),
-        );
+        let mut amendment = Amendment::new(agreement_id.clone(), description, self.own_did.clone());
 
         for change in changes {
             amendment.changes.push(change);
@@ -585,7 +589,9 @@ impl<S: AgreementStoreOps> AgreementManager<S> {
         let amendment = amendments
             .iter_mut()
             .find(|a| a.id == amendment_id)
-            .ok_or_else(|| FederationError::NotFound(format!("Amendment not found: {amendment_id}")))?;
+            .ok_or_else(|| {
+                FederationError::NotFound(format!("Amendment not found: {amendment_id}"))
+            })?;
 
         if amendment.status != AmendmentStatus::Proposed {
             return Err(FederationError::InvalidState(
@@ -601,7 +607,11 @@ impl<S: AgreementStoreOps> AgreementManager<S> {
         }
 
         // Check if already signed
-        if amendment.signatures.iter().any(|s| s.signer == self.own_did) {
+        if amendment
+            .signatures
+            .iter()
+            .any(|s| s.signer == self.own_did)
+        {
             return Err(FederationError::InvalidState(
                 "Already signed this amendment".to_string(),
             ));
@@ -630,7 +640,12 @@ impl<S: AgreementStoreOps> AgreementManager<S> {
             .map(|p| &p.did)
             .collect();
 
-        if amendment.is_fully_signed(&required_signers.iter().map(|d| (*d).clone()).collect::<Vec<_>>()) {
+        if amendment.is_fully_signed(
+            &required_signers
+                .iter()
+                .map(|d| (*d).clone())
+                .collect::<Vec<_>>(),
+        ) {
             amendment.status = AmendmentStatus::Ratified;
 
             // Apply the amendment to the agreement
@@ -747,12 +762,9 @@ mod tests {
         // Manager 2 for the counterparty
         let store2 = Arc::new(InMemoryAgreementStore::new());
         let kp2 = Arc::new(KeyPair::generate().unwrap());
-        let manager2 = AgreementManager::new(
-            store2.clone(),
-            "other-coop".to_string(),
-            kp2.did().clone(),
-        )
-        .with_keypair(kp2.clone());
+        let manager2 =
+            AgreementManager::new(store2.clone(), "other-coop".to_string(), kp2.did().clone())
+                .with_keypair(kp2.clone());
 
         // Manager 1 creates and proposes
         let agreement = manager1
@@ -811,7 +823,11 @@ mod tests {
         let agreement = manager
             .add_party(
                 &agreement.id,
-                AgreementParty::new(counterparty_kp.did().clone(), "other-coop", PartyRole::Counterparty),
+                AgreementParty::new(
+                    counterparty_kp.did().clone(),
+                    "other-coop",
+                    PartyRole::Counterparty,
+                ),
             )
             .unwrap();
 
@@ -833,7 +849,9 @@ mod tests {
         manager.store.store_agreement(&agreement).unwrap();
 
         // Suspend
-        let agreement = manager.suspend(&agreement.id, "Testing suspension").unwrap();
+        let agreement = manager
+            .suspend(&agreement.id, "Testing suspension")
+            .unwrap();
         assert!(agreement.status.is_suspended());
 
         // Resume

--- a/icn/crates/icn-federation/src/agreement/mod.rs
+++ b/icn/crates/icn-federation/src/agreement/mod.rs
@@ -1,0 +1,56 @@
+//! Inter-Cooperative Agreement Framework
+//!
+//! This module provides a framework for formal agreements between cooperatives,
+//! enabling structured economic relationships with lifecycle management,
+//! multi-party signatures, and gossip synchronization.
+//!
+//! # Agreement Lifecycle
+//!
+//! ```text
+//! Draft ──propose()──> Proposed ──all_signed()──> Active ──expire()──> Terminated
+//!                          │                        │
+//!                     reject()                  suspend()
+//!                          │                        │
+//!                          v                        v
+//!                        Draft                  Suspended
+//!                                                   │
+//!                                             terminate()
+//!                                                   │
+//!                                                   v
+//!                                              Terminated
+//! ```
+//!
+//! # Agreement Types
+//!
+//! - **Trade**: Exchange of goods/services with specified items and currency
+//! - **Credit**: Credit line with limit, interest rate, and currency
+//! - **ResourceSharing**: Shared use of resources with compensation model
+//! - **FederationMembership**: Terms for joining a federation network
+//!
+//! # Example
+//!
+//! ```ignore
+//! use icn_federation::agreement::{Agreement, AgreementType, PartyRole};
+//!
+//! // Create a trade agreement draft
+//! let agreement = Agreement::new(
+//!     "Trade agreement between Food Coop and Tech Coop",
+//!     "Monthly produce exchange",
+//!     AgreementType::Trade {
+//!         items: vec![TradeItem::new("organic vegetables", 100, "USD")],
+//!         currency: "USD".to_string(),
+//!     },
+//! )
+//! .with_party(food_coop_did, "food-coop", PartyRole::Proposer)
+//! .with_party(tech_coop_did, "tech-coop", PartyRole::Counterparty);
+//! ```
+
+mod gossip;
+mod manager;
+mod store;
+mod types;
+
+pub use gossip::{AgreementGossipCallback, AgreementGossipHandler, AgreementMessage};
+pub use manager::{AgreementEvent, AgreementEventCallback, AgreementManager};
+pub use store::{AgreementStore, AgreementStoreOps, InMemoryAgreementStore};
+pub use types::*;

--- a/icn/crates/icn-federation/src/agreement/store.rs
+++ b/icn/crates/icn-federation/src/agreement/store.rs
@@ -1,0 +1,602 @@
+//! Agreement Storage Layer
+//!
+//! Persistent storage for inter-cooperative agreements with secondary indexes
+//! for efficient lookups by party.
+
+use super::types::{Agreement, AgreementId, AgreementStatus, Amendment};
+use crate::error::Result;
+use icn_identity::Did;
+use icn_store::Store;
+use lru::LruCache;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::sync::RwLock;
+use tracing::{debug, warn};
+
+/// Storage key prefixes
+const AGREEMENT_PREFIX: &[u8] = b"federation/agreements/";
+const AGREEMENT_PARTY_INDEX: &[u8] = b"idx_agreement_party/";
+const AMENDMENT_PREFIX: &[u8] = b"federation/amendments/";
+
+/// Default cache size for agreements
+const DEFAULT_CACHE_SIZE: usize = 500;
+
+/// Trait for agreement storage operations
+pub trait AgreementStoreOps: Send + Sync {
+    /// Store an agreement
+    fn store_agreement(&self, agreement: &Agreement) -> Result<()>;
+
+    /// Retrieve an agreement by ID
+    fn get_agreement(&self, id: &AgreementId) -> Result<Option<Agreement>>;
+
+    /// Delete an agreement
+    fn delete_agreement(&self, id: &AgreementId) -> Result<()>;
+
+    /// List all agreements
+    fn list_agreements(&self) -> Result<Vec<Agreement>>;
+
+    /// List agreements for a specific party
+    fn list_agreements_for_party(&self, party_did: &Did) -> Result<Vec<Agreement>>;
+
+    /// List agreements by status
+    fn list_agreements_by_status(&self, status_type: &str) -> Result<Vec<Agreement>>;
+
+    /// Store an amendment
+    fn store_amendment(&self, amendment: &Amendment) -> Result<()>;
+
+    /// Get amendments for an agreement
+    fn get_amendments(&self, agreement_id: &AgreementId) -> Result<Vec<Amendment>>;
+}
+
+/// Persistent agreement store using Sled
+pub struct AgreementStore {
+    store: Arc<dyn Store>,
+    cache: RwLock<LruCache<AgreementId, Agreement>>,
+}
+
+impl AgreementStore {
+    /// Create a new agreement store
+    pub fn new(store: Arc<dyn Store>) -> Self {
+        #[allow(clippy::unwrap_used)]
+        let capacity = NonZeroUsize::new(DEFAULT_CACHE_SIZE).unwrap();
+        Self {
+            store,
+            cache: RwLock::new(LruCache::new(capacity)),
+        }
+    }
+
+    /// Create with custom cache size
+    pub fn with_cache_size(store: Arc<dyn Store>, cache_size: usize) -> Self {
+        #[allow(clippy::unwrap_used)]
+        let capacity = NonZeroUsize::new(cache_size.max(1)).unwrap();
+        Self {
+            store,
+            cache: RwLock::new(LruCache::new(capacity)),
+        }
+    }
+
+    /// Get the storage key for an agreement
+    fn agreement_key(id: &AgreementId) -> Vec<u8> {
+        let mut key = AGREEMENT_PREFIX.to_vec();
+        key.extend(id.as_str().as_bytes());
+        key
+    }
+
+    /// Get the index key for a party-to-agreement mapping
+    fn party_index_key(party_did: &Did, agreement_id: &AgreementId) -> Vec<u8> {
+        let mut key = AGREEMENT_PARTY_INDEX.to_vec();
+        key.extend(party_did.as_str().as_bytes());
+        key.push(b'/');
+        key.extend(agreement_id.as_str().as_bytes());
+        key
+    }
+
+    /// Get the prefix for all agreements for a party
+    fn party_index_prefix(party_did: &Did) -> Vec<u8> {
+        let mut key = AGREEMENT_PARTY_INDEX.to_vec();
+        key.extend(party_did.as_str().as_bytes());
+        key.push(b'/');
+        key
+    }
+
+    /// Get the amendment key
+    fn amendment_key(agreement_id: &AgreementId, amendment_id: &str) -> Vec<u8> {
+        let mut key = AMENDMENT_PREFIX.to_vec();
+        key.extend(agreement_id.as_str().as_bytes());
+        key.push(b'/');
+        key.extend(amendment_id.as_bytes());
+        key
+    }
+
+    /// Get the prefix for all amendments for an agreement
+    fn amendment_prefix(agreement_id: &AgreementId) -> Vec<u8> {
+        let mut key = AMENDMENT_PREFIX.to_vec();
+        key.extend(agreement_id.as_str().as_bytes());
+        key.push(b'/');
+        key
+    }
+
+    /// Invalidate cache entry
+    fn invalidate_cache(&self, id: &AgreementId) {
+        self.cache
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Agreement cache lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .pop(id);
+    }
+
+    /// Update cache with an agreement
+    fn update_cache(&self, agreement: &Agreement) {
+        self.cache
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Agreement cache lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .put(agreement.id.clone(), agreement.clone());
+    }
+
+    /// Update party indexes for an agreement
+    fn update_party_indexes(&self, agreement: &Agreement) -> Result<()> {
+        // Add index entry for each party
+        for party in &agreement.parties {
+            let index_key = Self::party_index_key(&party.did, &agreement.id);
+            self.store.put(&index_key, agreement.id.as_str().as_bytes())?;
+        }
+        Ok(())
+    }
+
+    /// Remove party indexes for an agreement
+    fn remove_party_indexes(&self, agreement: &Agreement) -> Result<()> {
+        for party in &agreement.parties {
+            let index_key = Self::party_index_key(&party.did, &agreement.id);
+            self.store.delete(&index_key)?;
+        }
+        Ok(())
+    }
+
+    /// Get status type string for filtering
+    fn status_type(status: &AgreementStatus) -> &'static str {
+        match status {
+            AgreementStatus::Draft => "draft",
+            AgreementStatus::Proposed { .. } => "proposed",
+            AgreementStatus::Active { .. } => "active",
+            AgreementStatus::Suspended { .. } => "suspended",
+            AgreementStatus::Terminated { .. } => "terminated",
+        }
+    }
+}
+
+impl AgreementStoreOps for AgreementStore {
+    fn store_agreement(&self, agreement: &Agreement) -> Result<()> {
+        let key = Self::agreement_key(&agreement.id);
+        let value = serde_json::to_vec(agreement)?;
+
+        // Store the agreement
+        self.store.put(&key, &value)?;
+
+        // Update indexes
+        self.update_party_indexes(agreement)?;
+
+        // Update cache
+        self.update_cache(agreement);
+
+        debug!("Stored agreement {} (status: {:?})", agreement.id, agreement.status);
+        Ok(())
+    }
+
+    fn get_agreement(&self, id: &AgreementId) -> Result<Option<Agreement>> {
+        // Check cache first
+        if let Some(cached) = self
+            .cache
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Agreement cache lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .get(id)
+        {
+            return Ok(Some(cached.clone()));
+        }
+
+        // Load from storage
+        let key = Self::agreement_key(id);
+        match self.store.get(&key)? {
+            Some(value) => {
+                let agreement: Agreement = serde_json::from_slice(&value)?;
+                self.update_cache(&agreement);
+                Ok(Some(agreement))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn delete_agreement(&self, id: &AgreementId) -> Result<()> {
+        // Load agreement first to get party list for index cleanup
+        if let Some(agreement) = self.get_agreement(id)? {
+            // Remove party indexes
+            self.remove_party_indexes(&agreement)?;
+
+            // Remove any amendments
+            let amendment_prefix = Self::amendment_prefix(id);
+            let amendments = self.store.scan(&amendment_prefix)?;
+            for (key, _) in amendments {
+                self.store.delete(&key)?;
+            }
+        }
+
+        // Remove the agreement itself
+        let key = Self::agreement_key(id);
+        self.store.delete(&key)?;
+
+        // Invalidate cache
+        self.invalidate_cache(id);
+
+        debug!("Deleted agreement {}", id);
+        Ok(())
+    }
+
+    fn list_agreements(&self) -> Result<Vec<Agreement>> {
+        let entries = self.store.scan(AGREEMENT_PREFIX)?;
+        let mut agreements = Vec::new();
+
+        for (_key, value) in entries {
+            if let Ok(agreement) = serde_json::from_slice::<Agreement>(&value) {
+                agreements.push(agreement);
+            }
+        }
+
+        // Sort by created_at descending (most recent first)
+        agreements.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+        Ok(agreements)
+    }
+
+    fn list_agreements_for_party(&self, party_did: &Did) -> Result<Vec<Agreement>> {
+        let prefix = Self::party_index_prefix(party_did);
+        let index_entries = self.store.scan(&prefix)?;
+
+        let mut agreements = Vec::new();
+        for (_key, value) in index_entries {
+            // Value contains the agreement ID
+            if let Ok(id_str) = String::from_utf8(value) {
+                let id = AgreementId::new(id_str);
+                if let Some(agreement) = self.get_agreement(&id)? {
+                    agreements.push(agreement);
+                }
+            }
+        }
+
+        // Sort by created_at descending
+        agreements.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+        Ok(agreements)
+    }
+
+    fn list_agreements_by_status(&self, status_type: &str) -> Result<Vec<Agreement>> {
+        let all = self.list_agreements()?;
+        Ok(all
+            .into_iter()
+            .filter(|a| Self::status_type(&a.status) == status_type)
+            .collect())
+    }
+
+    fn store_amendment(&self, amendment: &Amendment) -> Result<()> {
+        let key = Self::amendment_key(&amendment.agreement_id, &amendment.id);
+        let value = serde_json::to_vec(amendment)?;
+        self.store.put(&key, &value)?;
+
+        // Invalidate agreement cache since amendments affect the agreement
+        self.invalidate_cache(&amendment.agreement_id);
+
+        debug!(
+            "Stored amendment {} for agreement {}",
+            amendment.id, amendment.agreement_id
+        );
+        Ok(())
+    }
+
+    fn get_amendments(&self, agreement_id: &AgreementId) -> Result<Vec<Amendment>> {
+        let prefix = Self::amendment_prefix(agreement_id);
+        let entries = self.store.scan(&prefix)?;
+
+        let mut amendments = Vec::new();
+        for (_key, value) in entries {
+            if let Ok(amendment) = serde_json::from_slice::<Amendment>(&value) {
+                amendments.push(amendment);
+            }
+        }
+
+        // Sort by proposed_at
+        amendments.sort_by(|a, b| a.proposed_at.cmp(&b.proposed_at));
+
+        Ok(amendments)
+    }
+}
+
+/// In-memory agreement store for testing
+pub struct InMemoryAgreementStore {
+    agreements: RwLock<std::collections::HashMap<AgreementId, Agreement>>,
+    amendments: RwLock<std::collections::HashMap<String, Amendment>>,
+}
+
+impl InMemoryAgreementStore {
+    /// Create a new in-memory store
+    pub fn new() -> Self {
+        Self {
+            agreements: RwLock::new(std::collections::HashMap::new()),
+            amendments: RwLock::new(std::collections::HashMap::new()),
+        }
+    }
+}
+
+impl Default for InMemoryAgreementStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AgreementStoreOps for InMemoryAgreementStore {
+    fn store_agreement(&self, agreement: &Agreement) -> Result<()> {
+        let mut guard = self.agreements.write().unwrap_or_else(|p| {
+            warn!("Agreement store lock poisoned, recovering");
+            p.into_inner()
+        });
+        guard.insert(agreement.id.clone(), agreement.clone());
+        Ok(())
+    }
+
+    fn get_agreement(&self, id: &AgreementId) -> Result<Option<Agreement>> {
+        let guard = self.agreements.read().unwrap_or_else(|p| {
+            warn!("Agreement store lock poisoned, recovering");
+            p.into_inner()
+        });
+        Ok(guard.get(id).cloned())
+    }
+
+    fn delete_agreement(&self, id: &AgreementId) -> Result<()> {
+        let mut guard = self.agreements.write().unwrap_or_else(|p| {
+            warn!("Agreement store lock poisoned, recovering");
+            p.into_inner()
+        });
+        guard.remove(id);
+
+        // Also remove amendments
+        let mut amend_guard = self.amendments.write().unwrap_or_else(|p| {
+            warn!("Amendment store lock poisoned, recovering");
+            p.into_inner()
+        });
+        amend_guard.retain(|_, a| &a.agreement_id != id);
+
+        Ok(())
+    }
+
+    fn list_agreements(&self) -> Result<Vec<Agreement>> {
+        let guard = self.agreements.read().unwrap_or_else(|p| {
+            warn!("Agreement store lock poisoned, recovering");
+            p.into_inner()
+        });
+        let mut agreements: Vec<_> = guard.values().cloned().collect();
+        agreements.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(agreements)
+    }
+
+    fn list_agreements_for_party(&self, party_did: &Did) -> Result<Vec<Agreement>> {
+        let guard = self.agreements.read().unwrap_or_else(|p| {
+            warn!("Agreement store lock poisoned, recovering");
+            p.into_inner()
+        });
+        let mut agreements: Vec<_> = guard
+            .values()
+            .filter(|a| a.parties.iter().any(|p| &p.did == party_did))
+            .cloned()
+            .collect();
+        agreements.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(agreements)
+    }
+
+    fn list_agreements_by_status(&self, status_type: &str) -> Result<Vec<Agreement>> {
+        let guard = self.agreements.read().unwrap_or_else(|p| {
+            warn!("Agreement store lock poisoned, recovering");
+            p.into_inner()
+        });
+
+        let status_matches = |status: &AgreementStatus| -> bool {
+            matches!(
+                (status, status_type),
+                (AgreementStatus::Draft, "draft")
+                    | (AgreementStatus::Proposed { .. }, "proposed")
+                    | (AgreementStatus::Active { .. }, "active")
+                    | (AgreementStatus::Suspended { .. }, "suspended")
+                    | (AgreementStatus::Terminated { .. }, "terminated")
+            )
+        };
+
+        let agreements: Vec<_> = guard
+            .values()
+            .filter(|a| status_matches(&a.status))
+            .cloned()
+            .collect();
+        Ok(agreements)
+    }
+
+    fn store_amendment(&self, amendment: &Amendment) -> Result<()> {
+        let mut guard = self.amendments.write().unwrap_or_else(|p| {
+            warn!("Amendment store lock poisoned, recovering");
+            p.into_inner()
+        });
+        guard.insert(amendment.id.clone(), amendment.clone());
+        Ok(())
+    }
+
+    fn get_amendments(&self, agreement_id: &AgreementId) -> Result<Vec<Amendment>> {
+        let guard = self.amendments.read().unwrap_or_else(|p| {
+            warn!("Amendment store lock poisoned, recovering");
+            p.into_inner()
+        });
+        let mut amendments: Vec<_> = guard
+            .values()
+            .filter(|a| &a.agreement_id == agreement_id)
+            .cloned()
+            .collect();
+        amendments.sort_by(|a, b| a.proposed_at.cmp(&b.proposed_at));
+        Ok(amendments)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agreement::{AgreementType, PartyRole};
+    use icn_identity::KeyPair;
+
+    fn test_did() -> Did {
+        KeyPair::generate().unwrap().did().clone()
+    }
+
+    fn create_test_agreement() -> Agreement {
+        let proposer = test_did();
+        let counterparty = test_did();
+
+        Agreement::new(
+            "Test Agreement",
+            "Test description",
+            AgreementType::Credit {
+                credit_limit: 5000,
+                interest_rate_bps: 300,
+                currency: "USD".to_string(),
+            },
+        )
+        .with_party(proposer, "coop-a", PartyRole::Proposer)
+        .with_party(counterparty, "coop-b", PartyRole::Counterparty)
+    }
+
+    #[test]
+    fn test_in_memory_store_crud() {
+        let store = InMemoryAgreementStore::new();
+
+        // Create
+        let agreement = create_test_agreement();
+        let id = agreement.id.clone();
+        store.store_agreement(&agreement).unwrap();
+
+        // Read
+        let loaded = store.get_agreement(&id).unwrap();
+        assert!(loaded.is_some());
+        assert_eq!(loaded.unwrap().title, "Test Agreement");
+
+        // List
+        let all = store.list_agreements().unwrap();
+        assert_eq!(all.len(), 1);
+
+        // Delete
+        store.delete_agreement(&id).unwrap();
+        assert!(store.get_agreement(&id).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_list_by_party() {
+        let store = InMemoryAgreementStore::new();
+
+        let proposer = test_did();
+        let counterparty1 = test_did();
+        let counterparty2 = test_did();
+
+        // Agreement 1: proposer + counterparty1
+        let agreement1 = Agreement::new(
+            "Agreement 1",
+            "First agreement",
+            AgreementType::Credit {
+                credit_limit: 5000,
+                interest_rate_bps: 300,
+                currency: "USD".to_string(),
+            },
+        )
+        .with_party(proposer.clone(), "coop-a", PartyRole::Proposer)
+        .with_party(counterparty1.clone(), "coop-b", PartyRole::Counterparty);
+
+        // Agreement 2: proposer + counterparty2
+        let agreement2 = Agreement::new(
+            "Agreement 2",
+            "Second agreement",
+            AgreementType::Credit {
+                credit_limit: 10000,
+                interest_rate_bps: 400,
+                currency: "USD".to_string(),
+            },
+        )
+        .with_party(proposer.clone(), "coop-a", PartyRole::Proposer)
+        .with_party(counterparty2.clone(), "coop-c", PartyRole::Counterparty);
+
+        store.store_agreement(&agreement1).unwrap();
+        store.store_agreement(&agreement2).unwrap();
+
+        // Proposer should see both
+        let proposer_agreements = store.list_agreements_for_party(&proposer).unwrap();
+        assert_eq!(proposer_agreements.len(), 2);
+
+        // Each counterparty should see only one
+        let cp1_agreements = store.list_agreements_for_party(&counterparty1).unwrap();
+        assert_eq!(cp1_agreements.len(), 1);
+        assert_eq!(cp1_agreements[0].title, "Agreement 1");
+
+        let cp2_agreements = store.list_agreements_for_party(&counterparty2).unwrap();
+        assert_eq!(cp2_agreements.len(), 1);
+        assert_eq!(cp2_agreements[0].title, "Agreement 2");
+    }
+
+    #[test]
+    fn test_list_by_status() {
+        let store = InMemoryAgreementStore::new();
+
+        let agreement1 = create_test_agreement();
+        let mut agreement2 = create_test_agreement();
+
+        // Keep agreement1 as draft
+        store.store_agreement(&agreement1).unwrap();
+
+        // Propose agreement2
+        agreement2.propose().unwrap();
+        store.store_agreement(&agreement2).unwrap();
+
+        // List by status
+        let drafts = store.list_agreements_by_status("draft").unwrap();
+        assert_eq!(drafts.len(), 1);
+
+        let proposed = store.list_agreements_by_status("proposed").unwrap();
+        assert_eq!(proposed.len(), 1);
+
+        let active = store.list_agreements_by_status("active").unwrap();
+        assert_eq!(active.len(), 0);
+    }
+
+    #[test]
+    fn test_amendments() {
+        let store = InMemoryAgreementStore::new();
+
+        let agreement = create_test_agreement();
+        let agreement_id = agreement.id.clone();
+        store.store_agreement(&agreement).unwrap();
+
+        // Create amendments
+        let amendment1 = Amendment::new(
+            agreement_id.clone(),
+            "First amendment",
+            test_did(),
+        );
+        let amendment2 = Amendment::new(
+            agreement_id.clone(),
+            "Second amendment",
+            test_did(),
+        );
+
+        store.store_amendment(&amendment1).unwrap();
+        store.store_amendment(&amendment2).unwrap();
+
+        // Get amendments
+        let amendments = store.get_amendments(&agreement_id).unwrap();
+        assert_eq!(amendments.len(), 2);
+    }
+}

--- a/icn/crates/icn-federation/src/agreement/store.rs
+++ b/icn/crates/icn-federation/src/agreement/store.rs
@@ -143,7 +143,8 @@ impl AgreementStore {
         // Add index entry for each party
         for party in &agreement.parties {
             let index_key = Self::party_index_key(&party.did, &agreement.id);
-            self.store.put(&index_key, agreement.id.as_str().as_bytes())?;
+            self.store
+                .put(&index_key, agreement.id.as_str().as_bytes())?;
         }
         Ok(())
     }
@@ -183,7 +184,10 @@ impl AgreementStoreOps for AgreementStore {
         // Update cache
         self.update_cache(agreement);
 
-        debug!("Stored agreement {} (status: {:?})", agreement.id, agreement.status);
+        debug!(
+            "Stored agreement {} (status: {:?})",
+            agreement.id, agreement.status
+        );
         Ok(())
     }
 
@@ -581,16 +585,8 @@ mod tests {
         store.store_agreement(&agreement).unwrap();
 
         // Create amendments
-        let amendment1 = Amendment::new(
-            agreement_id.clone(),
-            "First amendment",
-            test_did(),
-        );
-        let amendment2 = Amendment::new(
-            agreement_id.clone(),
-            "Second amendment",
-            test_did(),
-        );
+        let amendment1 = Amendment::new(agreement_id.clone(), "First amendment", test_did());
+        let amendment2 = Amendment::new(agreement_id.clone(), "Second amendment", test_did());
 
         store.store_amendment(&amendment1).unwrap();
         store.store_amendment(&amendment2).unwrap();

--- a/icn/crates/icn-federation/src/agreement/types.rs
+++ b/icn/crates/icn-federation/src/agreement/types.rs
@@ -1,0 +1,1352 @@
+//! Inter-Cooperative Agreement Types
+//!
+//! Core types for the agreement framework including Agreement, AgreementType,
+//! AgreementStatus, and related structures.
+
+use icn_identity::Did;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::types::current_timestamp;
+
+/// Unique identifier for an agreement
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct AgreementId(pub String);
+
+impl AgreementId {
+    /// Generate a new random agreement ID
+    pub fn generate() -> Self {
+        Self(format!("agr-{}", Uuid::new_v4()))
+    }
+
+    /// Create from an existing ID string
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    /// Get the inner string value
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for AgreementId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl AsRef<str> for AgreementId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Types of inter-cooperative agreements
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AgreementType {
+    /// Trade agreement for exchange of goods/services
+    Trade {
+        /// Items being traded
+        items: Vec<TradeItem>,
+        /// Settlement currency
+        currency: String,
+    },
+
+    /// Credit agreement establishing a credit line
+    Credit {
+        /// Maximum credit limit
+        credit_limit: i64,
+        /// Interest rate in basis points (1 bp = 0.01%)
+        interest_rate_bps: u32,
+        /// Currency for the credit line
+        currency: String,
+    },
+
+    /// Resource sharing agreement
+    ResourceSharing {
+        /// Type of resource being shared
+        resource_type: ResourceType,
+        /// Duration of the sharing agreement in days
+        duration_days: u32,
+        /// Compensation model for resource usage
+        compensation: CompensationModel,
+    },
+
+    /// Federation membership agreement
+    FederationMembership {
+        /// Federation network identifier
+        federation_id: String,
+        /// Membership terms
+        terms: FederationMembershipTerms,
+    },
+
+    /// Custom agreement with free-form terms
+    Custom {
+        /// Custom agreement type name
+        agreement_type_name: String,
+        /// JSON-encoded custom terms
+        terms_json: String,
+    },
+}
+
+impl AgreementType {
+    /// Get the type name for display/metrics
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            AgreementType::Trade { .. } => "trade",
+            AgreementType::Credit { .. } => "credit",
+            AgreementType::ResourceSharing { .. } => "resource_sharing",
+            AgreementType::FederationMembership { .. } => "federation_membership",
+            AgreementType::Custom { .. } => "custom",
+        }
+    }
+}
+
+/// An item in a trade agreement
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TradeItem {
+    /// Description of the item
+    pub description: String,
+    /// Quantity
+    pub quantity: u32,
+    /// Unit of measurement (e.g., "kg", "hours", "units")
+    pub unit: String,
+    /// Price per unit
+    pub unit_price: i64,
+    /// Currency
+    pub currency: String,
+}
+
+impl TradeItem {
+    /// Create a new trade item
+    pub fn new(
+        description: impl Into<String>,
+        quantity: u32,
+        unit: impl Into<String>,
+        unit_price: i64,
+        currency: impl Into<String>,
+    ) -> Self {
+        Self {
+            description: description.into(),
+            quantity,
+            unit: unit.into(),
+            unit_price,
+            currency: currency.into(),
+        }
+    }
+
+    /// Calculate total value
+    pub fn total_value(&self) -> i64 {
+        self.unit_price * i64::from(self.quantity)
+    }
+}
+
+/// Types of resources that can be shared
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ResourceType {
+    /// Physical equipment
+    Equipment,
+    /// Physical space/facility
+    Facility,
+    /// Computational resources
+    Compute,
+    /// Storage resources
+    Storage,
+    /// Human labor/expertise
+    Labor,
+    /// Intellectual property/licenses
+    IntellectualProperty,
+    /// Custom resource type
+    Other(String),
+}
+
+/// Compensation model for resource sharing
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "model", rename_all = "snake_case")]
+pub enum CompensationModel {
+    /// Fixed periodic payment
+    FixedRate {
+        /// Amount per period
+        amount: i64,
+        /// Currency
+        currency: String,
+        /// Period in days
+        period_days: u32,
+    },
+
+    /// Pay per use
+    PerUse {
+        /// Amount per use
+        amount: i64,
+        /// Currency
+        currency: String,
+        /// Unit of use measurement
+        unit: String,
+    },
+
+    /// Revenue sharing
+    RevenueShare {
+        /// Percentage of revenue (0-100)
+        percentage: u8,
+    },
+
+    /// Reciprocal exchange (no monetary compensation)
+    Reciprocal {
+        /// Description of reciprocal arrangement
+        description: String,
+    },
+
+    /// No compensation (donation/grant)
+    None,
+}
+
+/// Terms for federation membership
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FederationMembershipTerms {
+    /// Required trust threshold for membership
+    pub min_trust_threshold: f64,
+    /// Whether governance decisions are binding
+    pub governance_binding: bool,
+    /// Data sharing requirements
+    pub data_sharing_level: DataSharingLevel,
+    /// Contribution requirements
+    pub contribution_requirements: Option<String>,
+}
+
+impl Default for FederationMembershipTerms {
+    fn default() -> Self {
+        Self {
+            min_trust_threshold: 0.5,
+            governance_binding: true,
+            data_sharing_level: DataSharingLevel::MetadataOnly,
+            contribution_requirements: None,
+        }
+    }
+}
+
+/// Level of data sharing required
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum DataSharingLevel {
+    /// No automatic data sharing
+    None,
+    /// Share metadata only (summaries, not individual transactions)
+    #[default]
+    MetadataOnly,
+    /// Full transparency
+    Full,
+}
+
+/// State of an agreement in its lifecycle
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum AgreementStatus {
+    /// Draft agreement, not yet proposed
+    Draft,
+
+    /// Proposed and awaiting signatures
+    Proposed {
+        /// When the agreement was proposed
+        proposed_at: u64,
+        /// DIDs of parties who still need to sign
+        awaiting_signatures: Vec<Did>,
+    },
+
+    /// Active agreement
+    Active {
+        /// When the agreement became active
+        activated_at: u64,
+        /// Optional expiration timestamp
+        expires_at: Option<u64>,
+    },
+
+    /// Temporarily suspended
+    Suspended {
+        /// When the agreement was suspended
+        suspended_at: u64,
+        /// Reason for suspension
+        reason: String,
+        /// DID of the party who suspended
+        suspended_by: Did,
+    },
+
+    /// Permanently terminated
+    Terminated {
+        /// When the agreement was terminated
+        terminated_at: u64,
+        /// Reason for termination
+        reason: TerminationReason,
+    },
+}
+
+impl AgreementStatus {
+    /// Check if the agreement is in draft state
+    pub fn is_draft(&self) -> bool {
+        matches!(self, AgreementStatus::Draft)
+    }
+
+    /// Check if the agreement is proposed and awaiting signatures
+    pub fn is_proposed(&self) -> bool {
+        matches!(self, AgreementStatus::Proposed { .. })
+    }
+
+    /// Check if the agreement is active
+    pub fn is_active(&self) -> bool {
+        matches!(self, AgreementStatus::Active { .. })
+    }
+
+    /// Check if the agreement is suspended
+    pub fn is_suspended(&self) -> bool {
+        matches!(self, AgreementStatus::Suspended { .. })
+    }
+
+    /// Check if the agreement is terminated
+    pub fn is_terminated(&self) -> bool {
+        matches!(self, AgreementStatus::Terminated { .. })
+    }
+
+    /// Check if the agreement is in a terminal state
+    pub fn is_terminal(&self) -> bool {
+        self.is_terminated()
+    }
+
+    /// Get the expiration timestamp if active
+    pub fn expires_at(&self) -> Option<u64> {
+        match self {
+            AgreementStatus::Active { expires_at, .. } => *expires_at,
+            _ => None,
+        }
+    }
+
+    /// Check if the agreement has expired
+    pub fn is_expired(&self, current_time: u64) -> bool {
+        match self {
+            AgreementStatus::Active { expires_at: Some(exp), .. } => current_time >= *exp,
+            _ => false,
+        }
+    }
+}
+
+/// Reason for agreement termination
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "reason_type", rename_all = "snake_case")]
+pub enum TerminationReason {
+    /// Agreement expired naturally
+    Expired,
+
+    /// Mutual consent of all parties
+    MutualConsent {
+        /// Optional explanation
+        explanation: Option<String>,
+    },
+
+    /// Breach of terms by a party
+    Breach {
+        /// DID of the breaching party
+        breaching_party: Did,
+        /// Description of the breach
+        breach_description: String,
+    },
+
+    /// Unilateral withdrawal (if permitted by terms)
+    Withdrawal {
+        /// DID of the withdrawing party
+        withdrawing_party: Did,
+        /// Notice period observed (in days)
+        notice_days: u32,
+    },
+
+    /// Force majeure or external circumstances
+    ForceMajeure {
+        /// Description of the circumstances
+        description: String,
+    },
+}
+
+/// Role of a party in an agreement
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PartyRole {
+    /// The party who initiated/proposed the agreement
+    Proposer,
+    /// A counterparty to the agreement
+    Counterparty,
+    /// A witness to the agreement (doesn't sign, but validates)
+    Witness,
+    /// A guarantor backing the agreement
+    Guarantor,
+}
+
+impl PartyRole {
+    /// Check if this role requires a signature
+    pub fn requires_signature(&self) -> bool {
+        matches!(self, PartyRole::Proposer | PartyRole::Counterparty | PartyRole::Guarantor)
+    }
+}
+
+/// A party to an agreement
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgreementParty {
+    /// DID of the party
+    pub did: Did,
+    /// Cooperative/organization ID
+    pub coop_id: String,
+    /// Role in the agreement
+    pub role: PartyRole,
+    /// Display name (optional)
+    pub display_name: Option<String>,
+}
+
+impl AgreementParty {
+    /// Create a new agreement party
+    pub fn new(did: Did, coop_id: impl Into<String>, role: PartyRole) -> Self {
+        Self {
+            did,
+            coop_id: coop_id.into(),
+            role,
+            display_name: None,
+        }
+    }
+
+    /// Add a display name
+    pub fn with_display_name(mut self, name: impl Into<String>) -> Self {
+        self.display_name = Some(name.into());
+        self
+    }
+}
+
+/// A signature on an agreement
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgreementSignature {
+    /// DID of the signer
+    pub signer: Did,
+    /// Cooperative ID of the signer
+    pub coop_id: String,
+    /// Ed25519 signature bytes
+    pub signature: Vec<u8>,
+    /// When the signature was created
+    pub signed_at: u64,
+    /// Agreement version that was signed
+    pub version_signed: u32,
+}
+
+impl AgreementSignature {
+    /// Create a new signature
+    pub fn new(
+        signer: Did,
+        coop_id: impl Into<String>,
+        signature: Vec<u8>,
+        version_signed: u32,
+    ) -> Self {
+        Self {
+            signer,
+            coop_id: coop_id.into(),
+            signature,
+            signed_at: current_timestamp(),
+            version_signed,
+        }
+    }
+}
+
+/// Terms and conditions of an agreement
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct AgreementTerms {
+    /// Effective date (when the agreement takes effect)
+    pub effective_date: Option<u64>,
+    /// Expiration date
+    pub expiration_date: Option<u64>,
+    /// Auto-renewal settings
+    pub auto_renewal: Option<AutoRenewal>,
+    /// Notice period for termination (in days)
+    pub termination_notice_days: Option<u32>,
+    /// Dispute resolution method
+    pub dispute_resolution: Option<String>,
+    /// Governing law/jurisdiction
+    pub governing_law: Option<String>,
+    /// Additional terms as free-form text
+    pub additional_terms: Option<String>,
+}
+
+impl AgreementTerms {
+    /// Create a new empty terms object
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the effective date
+    pub fn with_effective_date(mut self, date: u64) -> Self {
+        self.effective_date = Some(date);
+        self
+    }
+
+    /// Set the expiration date
+    pub fn with_expiration_date(mut self, date: u64) -> Self {
+        self.expiration_date = Some(date);
+        self
+    }
+
+    /// Set auto-renewal
+    pub fn with_auto_renewal(mut self, renewal: AutoRenewal) -> Self {
+        self.auto_renewal = Some(renewal);
+        self
+    }
+
+    /// Set termination notice period
+    pub fn with_termination_notice(mut self, days: u32) -> Self {
+        self.termination_notice_days = Some(days);
+        self
+    }
+
+    /// Set dispute resolution method
+    pub fn with_dispute_resolution(mut self, method: impl Into<String>) -> Self {
+        self.dispute_resolution = Some(method.into());
+        self
+    }
+}
+
+/// Auto-renewal configuration
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AutoRenewal {
+    /// Whether auto-renewal is enabled
+    pub enabled: bool,
+    /// Renewal period in days
+    pub period_days: u32,
+    /// Maximum number of renewals (None = unlimited)
+    pub max_renewals: Option<u32>,
+    /// Days before expiration to notify parties
+    pub notification_days: u32,
+}
+
+impl Default for AutoRenewal {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            period_days: 365,
+            max_renewals: None,
+            notification_days: 30,
+        }
+    }
+}
+
+/// An amendment to an existing agreement
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Amendment {
+    /// Unique amendment ID
+    pub id: String,
+    /// Agreement being amended
+    pub agreement_id: AgreementId,
+    /// Description of the amendment
+    pub description: String,
+    /// Changes being made
+    pub changes: Vec<AmendmentChange>,
+    /// Signatures on the amendment
+    pub signatures: Vec<AgreementSignature>,
+    /// Amendment status
+    pub status: AmendmentStatus,
+    /// When the amendment was proposed
+    pub proposed_at: u64,
+    /// DID of the proposer
+    pub proposed_by: Did,
+}
+
+impl Amendment {
+    /// Generate a new amendment ID
+    pub fn generate_id() -> String {
+        format!("amd-{}", Uuid::new_v4())
+    }
+
+    /// Create a new amendment
+    pub fn new(
+        agreement_id: AgreementId,
+        description: impl Into<String>,
+        proposed_by: Did,
+    ) -> Self {
+        Self {
+            id: Self::generate_id(),
+            agreement_id,
+            description: description.into(),
+            changes: Vec::new(),
+            signatures: Vec::new(),
+            status: AmendmentStatus::Proposed,
+            proposed_at: current_timestamp(),
+            proposed_by,
+        }
+    }
+
+    /// Add a change to the amendment
+    pub fn with_change(mut self, change: AmendmentChange) -> Self {
+        self.changes.push(change);
+        self
+    }
+
+    /// Check if all required parties have signed
+    pub fn is_fully_signed(&self, required_signers: &[Did]) -> bool {
+        required_signers.iter().all(|did| {
+            self.signatures.iter().any(|sig| sig.signer == *did)
+        })
+    }
+
+    /// Add a signature
+    pub fn add_signature(&mut self, signature: AgreementSignature) {
+        // Don't add duplicate signatures
+        if !self.signatures.iter().any(|s| s.signer == signature.signer) {
+            self.signatures.push(signature);
+        }
+    }
+}
+
+/// A specific change in an amendment
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "change_type", rename_all = "snake_case")]
+pub enum AmendmentChange {
+    /// Update a term
+    UpdateTerm {
+        /// Field being updated
+        field: String,
+        /// Old value (JSON-encoded)
+        old_value: String,
+        /// New value (JSON-encoded)
+        new_value: String,
+    },
+
+    /// Add a new party
+    AddParty {
+        /// The party being added
+        party: AgreementParty,
+    },
+
+    /// Remove a party
+    RemoveParty {
+        /// DID of the party being removed
+        party_did: Did,
+    },
+
+    /// Extend the agreement duration
+    ExtendDuration {
+        /// New expiration date
+        new_expiration: u64,
+    },
+
+    /// Modify the agreement type details
+    ModifyType {
+        /// New agreement type configuration (JSON-encoded)
+        new_type_json: String,
+    },
+}
+
+/// Status of an amendment
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AmendmentStatus {
+    /// Proposed, awaiting signatures
+    Proposed,
+    /// Ratified (all parties signed)
+    Ratified,
+    /// Rejected by one or more parties
+    Rejected,
+    /// Withdrawn by the proposer
+    Withdrawn,
+}
+
+/// The core agreement structure
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Agreement {
+    /// Unique agreement identifier
+    pub id: AgreementId,
+    /// Agreement title
+    pub title: String,
+    /// Detailed description
+    pub description: String,
+    /// Type of agreement
+    pub agreement_type: AgreementType,
+    /// Parties to the agreement
+    pub parties: Vec<AgreementParty>,
+    /// Current status
+    pub status: AgreementStatus,
+    /// Terms and conditions
+    pub terms: AgreementTerms,
+    /// Collected signatures
+    pub signatures: Vec<AgreementSignature>,
+    /// Amendments history
+    pub amendments: Vec<Amendment>,
+    /// Current version (increments with each amendment)
+    pub version: u32,
+    /// When the agreement was created
+    pub created_at: u64,
+    /// When the agreement was last updated
+    pub updated_at: u64,
+}
+
+impl Agreement {
+    /// Create a new draft agreement
+    pub fn new(
+        title: impl Into<String>,
+        description: impl Into<String>,
+        agreement_type: AgreementType,
+    ) -> Self {
+        let now = current_timestamp();
+        Self {
+            id: AgreementId::generate(),
+            title: title.into(),
+            description: description.into(),
+            agreement_type,
+            parties: Vec::new(),
+            status: AgreementStatus::Draft,
+            terms: AgreementTerms::default(),
+            signatures: Vec::new(),
+            amendments: Vec::new(),
+            version: 1,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    /// Create with a specific ID (for testing or restoration)
+    pub fn with_id(mut self, id: AgreementId) -> Self {
+        self.id = id;
+        self
+    }
+
+    /// Add a party to the agreement
+    pub fn with_party(mut self, did: Did, coop_id: impl Into<String>, role: PartyRole) -> Self {
+        self.parties.push(AgreementParty::new(did, coop_id, role));
+        self.updated_at = current_timestamp();
+        self
+    }
+
+    /// Set the agreement terms
+    pub fn with_terms(mut self, terms: AgreementTerms) -> Self {
+        self.terms = terms;
+        self.updated_at = current_timestamp();
+        self
+    }
+
+    /// Get the proposer (if any)
+    pub fn proposer(&self) -> Option<&AgreementParty> {
+        self.parties.iter().find(|p| p.role == PartyRole::Proposer)
+    }
+
+    /// Get all counterparties
+    pub fn counterparties(&self) -> Vec<&AgreementParty> {
+        self.parties
+            .iter()
+            .filter(|p| p.role == PartyRole::Counterparty)
+            .collect()
+    }
+
+    /// Get all parties that need to sign
+    pub fn required_signers(&self) -> Vec<&Did> {
+        self.parties
+            .iter()
+            .filter(|p| p.role.requires_signature())
+            .map(|p| &p.did)
+            .collect()
+    }
+
+    /// Check if a specific party has signed
+    pub fn has_signed(&self, did: &Did) -> bool {
+        self.signatures.iter().any(|s| &s.signer == did)
+    }
+
+    /// Check if all required parties have signed
+    pub fn is_fully_signed(&self) -> bool {
+        self.required_signers().iter().all(|did| self.has_signed(did))
+    }
+
+    /// Get the DIDs of parties who still need to sign
+    pub fn pending_signers(&self) -> Vec<Did> {
+        self.required_signers()
+            .into_iter()
+            .filter(|did| !self.has_signed(did))
+            .cloned()
+            .collect()
+    }
+
+    /// Get the canonical bytes for signing
+    ///
+    /// This creates a deterministic byte representation of the agreement
+    /// excluding the signatures, so all parties sign the same content.
+    pub fn signing_bytes(&self) -> Vec<u8> {
+        // Create a signable version without signatures
+        let signable = SignableAgreement {
+            id: &self.id,
+            title: &self.title,
+            description: &self.description,
+            agreement_type: &self.agreement_type,
+            parties: &self.parties,
+            terms: &self.terms,
+            version: self.version,
+            created_at: self.created_at,
+        };
+
+        serde_json::to_vec(&signable).unwrap_or_default()
+    }
+
+    /// Sign the agreement
+    pub fn sign(&mut self, keypair: &icn_identity::KeyPair, coop_id: impl Into<String>) {
+        let bytes = self.signing_bytes();
+        let signature_bytes = keypair.sign(&bytes);
+
+        let signature = AgreementSignature::new(
+            keypair.did().clone(),
+            coop_id,
+            signature_bytes.to_vec(),
+            self.version,
+        );
+
+        // Don't add duplicate signatures
+        if !self.has_signed(&signature.signer) {
+            self.signatures.push(signature);
+            self.updated_at = current_timestamp();
+        }
+    }
+
+    /// Verify all signatures on the agreement
+    pub fn verify_signatures(&self) -> Result<(), String> {
+        let bytes = self.signing_bytes();
+
+        for sig in &self.signatures {
+            // Find the party with this DID
+            let party = self.parties.iter().find(|p| p.did == sig.signer);
+            if party.is_none() {
+                return Err(format!("Signer {} is not a party to this agreement", sig.signer));
+            }
+
+            // Verify the signature
+            let public_key = sig.signer.to_verifying_key()
+                .map_err(|e| format!("Invalid public key for {}: {e}", sig.signer))?;
+
+            let signature = ed25519_dalek::Signature::from_slice(&sig.signature)
+                .map_err(|e| format!("Invalid signature format: {e}"))?;
+
+            use ed25519_dalek::Verifier;
+            public_key.verify(&bytes, &signature)
+                .map_err(|e| format!("Signature verification failed for {}: {e}", sig.signer))?;
+        }
+
+        Ok(())
+    }
+
+    /// Propose the agreement (transition from Draft to Proposed)
+    pub fn propose(&mut self) -> Result<(), String> {
+        if !self.status.is_draft() {
+            return Err("Can only propose agreements in Draft status".to_string());
+        }
+
+        if self.parties.len() < 2 {
+            return Err("Agreement must have at least 2 parties".to_string());
+        }
+
+        if self.proposer().is_none() {
+            return Err("Agreement must have a proposer".to_string());
+        }
+
+        let awaiting = self.pending_signers();
+        self.status = AgreementStatus::Proposed {
+            proposed_at: current_timestamp(),
+            awaiting_signatures: awaiting,
+        };
+        self.updated_at = current_timestamp();
+
+        Ok(())
+    }
+
+    /// Activate the agreement (transition from Proposed to Active)
+    pub fn activate(&mut self) -> Result<(), String> {
+        if !self.status.is_proposed() {
+            return Err("Can only activate agreements in Proposed status".to_string());
+        }
+
+        if !self.is_fully_signed() {
+            let pending: Vec<_> = self.pending_signers().iter().map(|d| d.to_string()).collect();
+            return Err(format!("Not all parties have signed. Pending: {}", pending.join(", ")));
+        }
+
+        // Verify all signatures before activation
+        self.verify_signatures()?;
+
+        let expires_at = self.terms.expiration_date;
+        self.status = AgreementStatus::Active {
+            activated_at: current_timestamp(),
+            expires_at,
+        };
+        self.updated_at = current_timestamp();
+
+        Ok(())
+    }
+
+    /// Suspend the agreement (transition from Active to Suspended)
+    pub fn suspend(&mut self, reason: impl Into<String>, suspended_by: Did) -> Result<(), String> {
+        if !self.status.is_active() {
+            return Err("Can only suspend agreements in Active status".to_string());
+        }
+
+        // Verify the suspender is a party
+        if !self.parties.iter().any(|p| p.did == suspended_by) {
+            return Err("Only parties to the agreement can suspend it".to_string());
+        }
+
+        self.status = AgreementStatus::Suspended {
+            suspended_at: current_timestamp(),
+            reason: reason.into(),
+            suspended_by,
+        };
+        self.updated_at = current_timestamp();
+
+        Ok(())
+    }
+
+    /// Resume the agreement (transition from Suspended to Active)
+    pub fn resume(&mut self, resumed_by: &Did) -> Result<(), String> {
+        match &self.status {
+            AgreementStatus::Suspended { suspended_by, .. } => {
+                // Only the party who suspended can resume
+                if resumed_by != suspended_by {
+                    return Err("Only the party who suspended can resume".to_string());
+                }
+            }
+            _ => return Err("Can only resume agreements in Suspended status".to_string()),
+        }
+
+        let expires_at = self.terms.expiration_date;
+        self.status = AgreementStatus::Active {
+            activated_at: current_timestamp(),
+            expires_at,
+        };
+        self.updated_at = current_timestamp();
+
+        Ok(())
+    }
+
+    /// Terminate the agreement
+    pub fn terminate(&mut self, reason: TerminationReason) -> Result<(), String> {
+        if self.status.is_terminated() {
+            return Err("Agreement is already terminated".to_string());
+        }
+
+        if self.status.is_draft() {
+            return Err("Cannot terminate a draft agreement. Delete it instead.".to_string());
+        }
+
+        self.status = AgreementStatus::Terminated {
+            terminated_at: current_timestamp(),
+            reason,
+        };
+        self.updated_at = current_timestamp();
+
+        Ok(())
+    }
+
+    /// Reject the agreement (transition from Proposed to Draft)
+    pub fn reject(&mut self) -> Result<(), String> {
+        if !self.status.is_proposed() {
+            return Err("Can only reject agreements in Proposed status".to_string());
+        }
+
+        // Clear signatures and return to draft
+        self.signatures.clear();
+        self.status = AgreementStatus::Draft;
+        self.updated_at = current_timestamp();
+
+        Ok(())
+    }
+
+    /// Check if the agreement should be auto-activated
+    /// (call this after adding a signature)
+    pub fn try_auto_activate(&mut self) -> bool {
+        if self.status.is_proposed() && self.is_fully_signed() {
+            self.activate().is_ok()
+        } else {
+            false
+        }
+    }
+
+    /// Apply a ratified amendment
+    pub fn apply_amendment(&mut self, amendment: Amendment) -> Result<(), String> {
+        if amendment.status != AmendmentStatus::Ratified {
+            return Err("Can only apply ratified amendments".to_string());
+        }
+
+        if amendment.agreement_id != self.id {
+            return Err("Amendment is for a different agreement".to_string());
+        }
+
+        // Apply each change
+        for change in &amendment.changes {
+            match change {
+                AmendmentChange::ExtendDuration { new_expiration } => {
+                    self.terms.expiration_date = Some(*new_expiration);
+                    if let AgreementStatus::Active { activated_at, .. } = self.status {
+                        self.status = AgreementStatus::Active {
+                            activated_at,
+                            expires_at: Some(*new_expiration),
+                        };
+                    }
+                }
+                AmendmentChange::AddParty { party } => {
+                    if !self.parties.iter().any(|p| p.did == party.did) {
+                        self.parties.push(party.clone());
+                    }
+                }
+                AmendmentChange::RemoveParty { party_did } => {
+                    self.parties.retain(|p| p.did != *party_did);
+                    self.signatures.retain(|s| s.signer != *party_did);
+                }
+                _ => {
+                    // Other changes require custom handling
+                }
+            }
+        }
+
+        self.version += 1;
+        self.amendments.push(amendment);
+        self.updated_at = current_timestamp();
+
+        Ok(())
+    }
+}
+
+/// Helper struct for creating signing bytes
+#[derive(Serialize)]
+struct SignableAgreement<'a> {
+    id: &'a AgreementId,
+    title: &'a str,
+    description: &'a str,
+    agreement_type: &'a AgreementType,
+    parties: &'a [AgreementParty],
+    terms: &'a AgreementTerms,
+    version: u32,
+    created_at: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use icn_identity::KeyPair;
+
+    fn test_did() -> Did {
+        KeyPair::generate().unwrap().did().clone()
+    }
+
+    #[test]
+    fn test_agreement_id_generation() {
+        let id1 = AgreementId::generate();
+        let id2 = AgreementId::generate();
+
+        assert!(id1.0.starts_with("agr-"));
+        assert!(id2.0.starts_with("agr-"));
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn test_trade_agreement_creation() {
+        let proposer = test_did();
+        let counterparty = test_did();
+
+        let agreement = Agreement::new(
+            "Produce Exchange",
+            "Monthly exchange of organic vegetables",
+            AgreementType::Trade {
+                items: vec![TradeItem::new("vegetables", 100, "kg", 5, "USD")],
+                currency: "USD".to_string(),
+            },
+        )
+        .with_party(proposer.clone(), "food-coop", PartyRole::Proposer)
+        .with_party(counterparty.clone(), "tech-coop", PartyRole::Counterparty);
+
+        assert_eq!(agreement.title, "Produce Exchange");
+        assert!(agreement.status.is_draft());
+        assert_eq!(agreement.parties.len(), 2);
+        assert_eq!(agreement.version, 1);
+    }
+
+    #[test]
+    fn test_agreement_lifecycle() {
+        let proposer_kp = KeyPair::generate().unwrap();
+        let counterparty_kp = KeyPair::generate().unwrap();
+
+        let mut agreement = Agreement::new(
+            "Test Agreement",
+            "A test agreement",
+            AgreementType::Credit {
+                credit_limit: 10000,
+                interest_rate_bps: 500,
+                currency: "USD".to_string(),
+            },
+        )
+        .with_party(proposer_kp.did().clone(), "coop-a", PartyRole::Proposer)
+        .with_party(counterparty_kp.did().clone(), "coop-b", PartyRole::Counterparty);
+
+        // Draft -> Proposed
+        assert!(agreement.propose().is_ok());
+        assert!(agreement.status.is_proposed());
+
+        // Sign by proposer
+        agreement.sign(&proposer_kp, "coop-a");
+        assert!(agreement.has_signed(proposer_kp.did()));
+        assert!(!agreement.is_fully_signed());
+
+        // Sign by counterparty
+        agreement.sign(&counterparty_kp, "coop-b");
+        assert!(agreement.is_fully_signed());
+
+        // Proposed -> Active
+        assert!(agreement.activate().is_ok());
+        assert!(agreement.status.is_active());
+
+        // Active -> Suspended
+        assert!(agreement.suspend("Need review", proposer_kp.did().clone()).is_ok());
+        assert!(agreement.status.is_suspended());
+
+        // Suspended -> Active
+        assert!(agreement.resume(proposer_kp.did()).is_ok());
+        assert!(agreement.status.is_active());
+
+        // Active -> Terminated
+        assert!(agreement.terminate(TerminationReason::MutualConsent {
+            explanation: Some("Agreement fulfilled".to_string()),
+        }).is_ok());
+        assert!(agreement.status.is_terminated());
+    }
+
+    #[test]
+    fn test_signature_verification() {
+        let proposer_kp = KeyPair::generate().unwrap();
+        let counterparty_kp = KeyPair::generate().unwrap();
+
+        let mut agreement = Agreement::new(
+            "Signature Test",
+            "Testing signature verification",
+            AgreementType::Custom {
+                agreement_type_name: "test".to_string(),
+                terms_json: "{}".to_string(),
+            },
+        )
+        .with_party(proposer_kp.did().clone(), "coop-a", PartyRole::Proposer)
+        .with_party(counterparty_kp.did().clone(), "coop-b", PartyRole::Counterparty);
+
+        agreement.sign(&proposer_kp, "coop-a");
+        agreement.sign(&counterparty_kp, "coop-b");
+
+        assert!(agreement.verify_signatures().is_ok());
+    }
+
+    #[test]
+    fn test_required_signers() {
+        let proposer = test_did();
+        let counterparty = test_did();
+        let witness = test_did();
+
+        let agreement = Agreement::new(
+            "Test",
+            "Test",
+            AgreementType::Custom {
+                agreement_type_name: "test".to_string(),
+                terms_json: "{}".to_string(),
+            },
+        )
+        .with_party(proposer.clone(), "coop-a", PartyRole::Proposer)
+        .with_party(counterparty.clone(), "coop-b", PartyRole::Counterparty)
+        .with_party(witness.clone(), "coop-c", PartyRole::Witness);
+
+        let required = agreement.required_signers();
+        assert_eq!(required.len(), 2); // Proposer and Counterparty
+        assert!(required.contains(&&proposer));
+        assert!(required.contains(&&counterparty));
+        assert!(!required.contains(&&witness)); // Witness doesn't sign
+    }
+
+    #[test]
+    fn test_auto_activate() {
+        let proposer_kp = KeyPair::generate().unwrap();
+        let counterparty_kp = KeyPair::generate().unwrap();
+
+        let mut agreement = Agreement::new(
+            "Auto Activate Test",
+            "Test",
+            AgreementType::Credit {
+                credit_limit: 5000,
+                interest_rate_bps: 300,
+                currency: "USD".to_string(),
+            },
+        )
+        .with_party(proposer_kp.did().clone(), "coop-a", PartyRole::Proposer)
+        .with_party(counterparty_kp.did().clone(), "coop-b", PartyRole::Counterparty);
+
+        agreement.propose().unwrap();
+
+        agreement.sign(&proposer_kp, "coop-a");
+        assert!(!agreement.try_auto_activate()); // Not all signed yet
+
+        agreement.sign(&counterparty_kp, "coop-b");
+        assert!(agreement.try_auto_activate()); // Should activate now
+        assert!(agreement.status.is_active());
+    }
+
+    #[test]
+    fn test_trade_item_total_value() {
+        let item = TradeItem::new("widgets", 10, "units", 100, "USD");
+        assert_eq!(item.total_value(), 1000);
+    }
+
+    #[test]
+    fn test_agreement_type_names() {
+        assert_eq!(
+            AgreementType::Trade {
+                items: vec![],
+                currency: "USD".to_string()
+            }
+            .type_name(),
+            "trade"
+        );
+        assert_eq!(
+            AgreementType::Credit {
+                credit_limit: 0,
+                interest_rate_bps: 0,
+                currency: "USD".to_string()
+            }
+            .type_name(),
+            "credit"
+        );
+        assert_eq!(
+            AgreementType::ResourceSharing {
+                resource_type: ResourceType::Equipment,
+                duration_days: 30,
+                compensation: CompensationModel::None,
+            }
+            .type_name(),
+            "resource_sharing"
+        );
+    }
+
+    #[test]
+    fn test_amendment_workflow() {
+        let proposer_kp = KeyPair::generate().unwrap();
+        let counterparty_kp = KeyPair::generate().unwrap();
+
+        // Create and activate an agreement
+        let mut agreement = Agreement::new(
+            "Amendment Test",
+            "Testing amendments",
+            AgreementType::Credit {
+                credit_limit: 5000,
+                interest_rate_bps: 300,
+                currency: "USD".to_string(),
+            },
+        )
+        .with_party(proposer_kp.did().clone(), "coop-a", PartyRole::Proposer)
+        .with_party(counterparty_kp.did().clone(), "coop-b", PartyRole::Counterparty);
+
+        agreement.propose().unwrap();
+        agreement.sign(&proposer_kp, "coop-a");
+        agreement.sign(&counterparty_kp, "coop-b");
+        agreement.activate().unwrap();
+
+        assert_eq!(agreement.version, 1);
+
+        // Create an amendment
+        let mut amendment = Amendment::new(
+            agreement.id.clone(),
+            "Extend agreement duration",
+            proposer_kp.did().clone(),
+        )
+        .with_change(AmendmentChange::ExtendDuration {
+            new_expiration: current_timestamp() + 365 * 24 * 3600,
+        });
+
+        // Sign the amendment
+        let sig1 = AgreementSignature::new(
+            proposer_kp.did().clone(),
+            "coop-a",
+            vec![1, 2, 3], // Mock signature
+            1,
+        );
+        let sig2 = AgreementSignature::new(
+            counterparty_kp.did().clone(),
+            "coop-b",
+            vec![4, 5, 6], // Mock signature
+            1,
+        );
+
+        amendment.add_signature(sig1);
+        amendment.add_signature(sig2);
+        amendment.status = AmendmentStatus::Ratified;
+
+        // Apply the amendment
+        assert!(agreement.apply_amendment(amendment).is_ok());
+        assert_eq!(agreement.version, 2);
+        assert_eq!(agreement.amendments.len(), 1);
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        let proposer = test_did();
+        let counterparty = test_did();
+
+        let agreement = Agreement::new(
+            "Serialization Test",
+            "Testing JSON roundtrip",
+            AgreementType::Trade {
+                items: vec![TradeItem::new("item", 5, "units", 100, "USD")],
+                currency: "USD".to_string(),
+            },
+        )
+        .with_party(proposer, "coop-a", PartyRole::Proposer)
+        .with_party(counterparty, "coop-b", PartyRole::Counterparty)
+        .with_terms(
+            AgreementTerms::new()
+                .with_termination_notice(30)
+                .with_dispute_resolution("mediation"),
+        );
+
+        let json = serde_json::to_string(&agreement).unwrap();
+        let deserialized: Agreement = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(agreement.id, deserialized.id);
+        assert_eq!(agreement.title, deserialized.title);
+        assert_eq!(agreement.parties.len(), deserialized.parties.len());
+    }
+
+    #[test]
+    fn test_party_role_requires_signature() {
+        assert!(PartyRole::Proposer.requires_signature());
+        assert!(PartyRole::Counterparty.requires_signature());
+        assert!(PartyRole::Guarantor.requires_signature());
+        assert!(!PartyRole::Witness.requires_signature());
+    }
+
+    #[test]
+    fn test_cannot_propose_with_insufficient_parties() {
+        let proposer = test_did();
+
+        let mut agreement = Agreement::new(
+            "Single Party",
+            "Only one party",
+            AgreementType::Custom {
+                agreement_type_name: "test".to_string(),
+                terms_json: "{}".to_string(),
+            },
+        )
+        .with_party(proposer, "coop-a", PartyRole::Proposer);
+
+        assert!(agreement.propose().is_err());
+    }
+
+    #[test]
+    fn test_status_checks() {
+        let status = AgreementStatus::Active {
+            activated_at: 1000,
+            expires_at: Some(2000),
+        };
+
+        assert!(status.is_active());
+        assert!(!status.is_draft());
+        assert!(!status.is_terminated());
+        assert_eq!(status.expires_at(), Some(2000));
+        assert!(!status.is_expired(1500));
+        assert!(status.is_expired(2500));
+    }
+}

--- a/icn/crates/icn-federation/src/agreement/types.rs
+++ b/icn/crates/icn-federation/src/agreement/types.rs
@@ -138,8 +138,16 @@ impl TradeItem {
     }
 
     /// Calculate total value
-    pub fn total_value(&self) -> i64 {
-        self.unit_price * i64::from(self.quantity)
+    /// Returns None if multiplication would overflow
+    pub fn total_value(&self) -> Result<i64, String> {
+        self.unit_price
+            .checked_mul(i64::from(self.quantity))
+            .ok_or_else(|| {
+                format!(
+                    "Integer overflow: {} * {} exceeds i64::MAX",
+                    self.unit_price, self.quantity
+                )
+            })
     }
 }
 
@@ -602,6 +610,38 @@ impl Amendment {
             self.signatures.push(signature);
         }
     }
+
+    /// Verify a single signature for this amendment
+    pub fn verify_signature(&self, sig: &AgreementSignature) -> Result<(), String> {
+        // Get the amendment bytes to verify
+        let bytes = self.signing_bytes();
+
+        // Get the public key from the DID
+        let public_key = sig
+            .signer
+            .to_verifying_key()
+            .map_err(|e| format!("Invalid public key for {}: {}", sig.signer, e))?;
+
+        // Parse the signature
+        let signature = ed25519_dalek::Signature::from_slice(&sig.signature)
+            .map_err(|e| format!("Invalid signature format: {}", e))?;
+
+        // Verify
+        use ed25519_dalek::Verifier;
+        public_key
+            .verify(&bytes, &signature)
+            .map_err(|e| format!("Signature verification failed for {}: {}", sig.signer, e))
+    }
+
+    /// Get the canonical bytes for signing
+    fn signing_bytes(&self) -> Vec<u8> {
+        // Use a deterministic encoding
+        format!(
+            "{}:{}:{}:{}",
+            self.id, self.agreement_id, self.description, self.proposed_at
+        )
+        .into_bytes()
+    }
 }
 
 /// A specific change in an amendment
@@ -858,6 +898,19 @@ impl Agreement {
             return Err("Agreement must have a proposer".to_string());
         }
 
+        // Validate timestamps
+        let now = current_timestamp();
+        if let Some(effective) = self.terms.effective_date {
+            if effective < now {
+                return Err("Effective date must be in the future".to_string());
+            }
+            if let Some(expiration) = self.terms.expiration_date {
+                if expiration <= effective {
+                    return Err("Expiration date must be after effective date".to_string());
+                }
+            }
+        }
+
         let awaiting = self.pending_signers();
         self.status = AgreementStatus::Proposed {
             proposed_at: current_timestamp(),
@@ -1016,8 +1069,11 @@ impl Agreement {
                     self.parties.retain(|p| p.did != *party_did);
                     self.signatures.retain(|s| s.signer != *party_did);
                 }
-                _ => {
-                    // Other changes require custom handling
+                AmendmentChange::UpdateTerm { .. } | AmendmentChange::ModifyType { .. } => {
+                    return Err(format!(
+                        "Amendment change type {:?} not yet supported",
+                        change
+                    ));
                 }
             }
         }
@@ -1226,7 +1282,11 @@ mod tests {
     #[test]
     fn test_trade_item_total_value() {
         let item = TradeItem::new("widgets", 10, "units", 100, "USD");
-        assert_eq!(item.total_value(), 1000);
+        assert_eq!(item.total_value().unwrap(), 1000);
+
+        // Test overflow
+        let overflow_item = TradeItem::new("widgets", 1_000_000, "units", i64::MAX / 100, "USD");
+        assert!(overflow_item.total_value().is_err());
     }
 
     #[test]

--- a/icn/crates/icn-federation/src/agreement/types.rs
+++ b/icn/crates/icn-federation/src/agreement/types.rs
@@ -324,7 +324,10 @@ impl AgreementStatus {
     /// Check if the agreement has expired
     pub fn is_expired(&self, current_time: u64) -> bool {
         match self {
-            AgreementStatus::Active { expires_at: Some(exp), .. } => current_time >= *exp,
+            AgreementStatus::Active {
+                expires_at: Some(exp),
+                ..
+            } => current_time >= *exp,
             _ => false,
         }
     }
@@ -383,7 +386,10 @@ pub enum PartyRole {
 impl PartyRole {
     /// Check if this role requires a signature
     pub fn requires_signature(&self) -> bool {
-        matches!(self, PartyRole::Proposer | PartyRole::Counterparty | PartyRole::Guarantor)
+        matches!(
+            self,
+            PartyRole::Proposer | PartyRole::Counterparty | PartyRole::Guarantor
+        )
     }
 }
 
@@ -584,9 +590,9 @@ impl Amendment {
 
     /// Check if all required parties have signed
     pub fn is_fully_signed(&self, required_signers: &[Did]) -> bool {
-        required_signers.iter().all(|did| {
-            self.signatures.iter().any(|sig| sig.signer == *did)
-        })
+        required_signers
+            .iter()
+            .all(|did| self.signatures.iter().any(|sig| sig.signer == *did))
     }
 
     /// Add a signature
@@ -753,7 +759,9 @@ impl Agreement {
 
     /// Check if all required parties have signed
     pub fn is_fully_signed(&self) -> bool {
-        self.required_signers().iter().all(|did| self.has_signed(did))
+        self.required_signers()
+            .iter()
+            .all(|did| self.has_signed(did))
     }
 
     /// Get the DIDs of parties who still need to sign
@@ -812,18 +820,24 @@ impl Agreement {
             // Find the party with this DID
             let party = self.parties.iter().find(|p| p.did == sig.signer);
             if party.is_none() {
-                return Err(format!("Signer {} is not a party to this agreement", sig.signer));
+                return Err(format!(
+                    "Signer {} is not a party to this agreement",
+                    sig.signer
+                ));
             }
 
             // Verify the signature
-            let public_key = sig.signer.to_verifying_key()
+            let public_key = sig
+                .signer
+                .to_verifying_key()
                 .map_err(|e| format!("Invalid public key for {}: {e}", sig.signer))?;
 
             let signature = ed25519_dalek::Signature::from_slice(&sig.signature)
                 .map_err(|e| format!("Invalid signature format: {e}"))?;
 
             use ed25519_dalek::Verifier;
-            public_key.verify(&bytes, &signature)
+            public_key
+                .verify(&bytes, &signature)
                 .map_err(|e| format!("Signature verification failed for {}: {e}", sig.signer))?;
         }
 
@@ -861,8 +875,15 @@ impl Agreement {
         }
 
         if !self.is_fully_signed() {
-            let pending: Vec<_> = self.pending_signers().iter().map(|d| d.to_string()).collect();
-            return Err(format!("Not all parties have signed. Pending: {}", pending.join(", ")));
+            let pending: Vec<_> = self
+                .pending_signers()
+                .iter()
+                .map(|d| d.to_string())
+                .collect();
+            return Err(format!(
+                "Not all parties have signed. Pending: {}",
+                pending.join(", ")
+            ));
         }
 
         // Verify all signatures before activation
@@ -1078,7 +1099,11 @@ mod tests {
             },
         )
         .with_party(proposer_kp.did().clone(), "coop-a", PartyRole::Proposer)
-        .with_party(counterparty_kp.did().clone(), "coop-b", PartyRole::Counterparty);
+        .with_party(
+            counterparty_kp.did().clone(),
+            "coop-b",
+            PartyRole::Counterparty,
+        );
 
         // Draft -> Proposed
         assert!(agreement.propose().is_ok());
@@ -1098,7 +1123,9 @@ mod tests {
         assert!(agreement.status.is_active());
 
         // Active -> Suspended
-        assert!(agreement.suspend("Need review", proposer_kp.did().clone()).is_ok());
+        assert!(agreement
+            .suspend("Need review", proposer_kp.did().clone())
+            .is_ok());
         assert!(agreement.status.is_suspended());
 
         // Suspended -> Active
@@ -1106,9 +1133,11 @@ mod tests {
         assert!(agreement.status.is_active());
 
         // Active -> Terminated
-        assert!(agreement.terminate(TerminationReason::MutualConsent {
-            explanation: Some("Agreement fulfilled".to_string()),
-        }).is_ok());
+        assert!(agreement
+            .terminate(TerminationReason::MutualConsent {
+                explanation: Some("Agreement fulfilled".to_string()),
+            })
+            .is_ok());
         assert!(agreement.status.is_terminated());
     }
 
@@ -1126,7 +1155,11 @@ mod tests {
             },
         )
         .with_party(proposer_kp.did().clone(), "coop-a", PartyRole::Proposer)
-        .with_party(counterparty_kp.did().clone(), "coop-b", PartyRole::Counterparty);
+        .with_party(
+            counterparty_kp.did().clone(),
+            "coop-b",
+            PartyRole::Counterparty,
+        );
 
         agreement.sign(&proposer_kp, "coop-a");
         agreement.sign(&counterparty_kp, "coop-b");
@@ -1174,7 +1207,11 @@ mod tests {
             },
         )
         .with_party(proposer_kp.did().clone(), "coop-a", PartyRole::Proposer)
-        .with_party(counterparty_kp.did().clone(), "coop-b", PartyRole::Counterparty);
+        .with_party(
+            counterparty_kp.did().clone(),
+            "coop-b",
+            PartyRole::Counterparty,
+        );
 
         agreement.propose().unwrap();
 
@@ -1238,7 +1275,11 @@ mod tests {
             },
         )
         .with_party(proposer_kp.did().clone(), "coop-a", PartyRole::Proposer)
-        .with_party(counterparty_kp.did().clone(), "coop-b", PartyRole::Counterparty);
+        .with_party(
+            counterparty_kp.did().clone(),
+            "coop-b",
+            PartyRole::Counterparty,
+        );
 
         agreement.propose().unwrap();
         agreement.sign(&proposer_kp, "coop-a");

--- a/icn/crates/icn-federation/src/error.rs
+++ b/icn/crates/icn-federation/src/error.rs
@@ -116,6 +116,22 @@ pub enum FederationError {
     #[error("Identity error: {0}")]
     IdentityError(String),
 
+    // Agreement errors
+    #[error("Agreement not found: {0}")]
+    AgreementNotFound(String),
+
+    #[error("Invalid state: {0}")]
+    InvalidState(String),
+
+    #[error("Unauthorized: {0}")]
+    Unauthorized(String),
+
+    #[error("Resource not found: {0}")]
+    NotFound(String),
+
+    #[error("Configuration error: {0}")]
+    Config(String),
+
     // Internal errors
     #[error("Internal error: {0}")]
     Internal(String),
@@ -142,6 +158,12 @@ impl From<ed25519_dalek::SignatureError> for FederationError {
 impl From<anyhow::Error> for FederationError {
     fn from(err: anyhow::Error) -> Self {
         FederationError::Internal(err.to_string())
+    }
+}
+
+impl From<String> for FederationError {
+    fn from(err: String) -> Self {
+        FederationError::Internal(err)
     }
 }
 

--- a/icn/crates/icn-federation/src/lib.rs
+++ b/icn/crates/icn-federation/src/lib.rs
@@ -52,6 +52,9 @@ pub mod router;
 // Phase F5: DID Resolution
 pub mod resolver;
 
+// Inter-Cooperative Agreements (Issue #317)
+pub mod agreement;
+
 // Re-exports
 pub use attestation::{EvidenceSummary, FederatedTrustAttestation, TrustContext};
 pub use attestation_store::AttestationStore;
@@ -73,10 +76,20 @@ pub use types::{
     SigningScope, Vouch,
 };
 
+// Agreement re-exports
+pub use agreement::{
+    Agreement, AgreementEvent, AgreementEventCallback, AgreementGossipCallback,
+    AgreementGossipHandler, AgreementId, AgreementManager, AgreementMessage, AgreementParty,
+    AgreementSignature, AgreementStatus, AgreementStore, AgreementStoreOps, AgreementTerms,
+    AgreementType, Amendment, AmendmentChange, AmendmentStatus, AutoRenewal, CompensationModel,
+    InMemoryAgreementStore, PartyRole, ResourceType, TerminationReason, TradeItem,
+};
+
 /// Topic constants for federation gossip (re-exported at crate level)
 pub const TOPIC_FEDERATION_REGISTRY: &str = "federation:registry";
 pub const TOPIC_FEDERATION_TRUST: &str = "federation:trust";
 pub const TOPIC_FEDERATION_CLEARING: &str = "federation:clearing";
+pub const TOPIC_FEDERATION_AGREEMENTS: &str = "federation:agreements";
 
 /// Federation gossip topics
 pub mod topics {

--- a/icn/crates/icn-gateway/src/api/agreements.rs
+++ b/icn/crates/icn-gateway/src/api/agreements.rs
@@ -1,0 +1,658 @@
+//! Inter-Cooperative Agreement API endpoints
+//!
+//! RESTful API for managing inter-cooperative agreements including:
+//! - Agreement lifecycle (create, propose, sign, suspend, resume, terminate)
+//! - Party management
+//! - Amendment workflow
+//! - Status queries
+
+use actix_web::{delete, get, post, put, web, HttpRequest, HttpResponse};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::error::{GatewayError, Result};
+use crate::middleware::{get_claims, require_scope};
+
+// ============================================================================
+// Request/Response Models
+// ============================================================================
+
+/// Request to create a new agreement draft
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateAgreementRequest {
+    /// Agreement title
+    pub title: String,
+    /// Agreement description
+    pub description: String,
+    /// Type of agreement
+    pub agreement_type: AgreementTypeRequest,
+}
+
+/// Agreement type configuration
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AgreementTypeRequest {
+    Trade {
+        items: Vec<TradeItemRequest>,
+        currency: String,
+    },
+    Credit {
+        credit_limit: i64,
+        interest_rate_bps: u32,
+        currency: String,
+    },
+    ResourceSharing {
+        resource_type: String,
+        duration_days: u32,
+        compensation_model: String,
+    },
+    FederationMembership {
+        federation_id: String,
+        min_trust_threshold: f64,
+        governance_binding: bool,
+    },
+    Custom {
+        agreement_type_name: String,
+        terms_json: String,
+    },
+}
+
+/// Trade item in a trade agreement
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct TradeItemRequest {
+    pub description: String,
+    pub quantity: u32,
+    pub unit: String,
+    pub unit_price: i64,
+    pub currency: String,
+}
+
+/// Request to add a party to an agreement
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct AddPartyRequest {
+    /// DID of the party
+    pub did: String,
+    /// Cooperative ID
+    pub coop_id: String,
+    /// Role: proposer, counterparty, witness, guarantor
+    pub role: String,
+    /// Optional display name
+    pub display_name: Option<String>,
+}
+
+/// Request to set agreement terms
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct SetTermsRequest {
+    /// Effective date (Unix timestamp)
+    pub effective_date: Option<u64>,
+    /// Expiration date (Unix timestamp)
+    pub expiration_date: Option<u64>,
+    /// Termination notice period in days
+    pub termination_notice_days: Option<u32>,
+    /// Dispute resolution method
+    pub dispute_resolution: Option<String>,
+    /// Additional terms
+    pub additional_terms: Option<String>,
+}
+
+/// Request to suspend an agreement
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct SuspendRequest {
+    /// Reason for suspension
+    pub reason: String,
+}
+
+/// Request to terminate an agreement
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct TerminateRequest {
+    /// Termination reason type: expired, mutual_consent, breach, withdrawal, force_majeure
+    pub reason_type: String,
+    /// Additional details
+    pub details: Option<String>,
+}
+
+/// Request to propose an amendment
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ProposeAmendmentRequest {
+    /// Description of the amendment
+    pub description: String,
+    /// List of changes
+    pub changes: Vec<AmendmentChangeRequest>,
+}
+
+/// Amendment change specification
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(tag = "change_type", rename_all = "snake_case")]
+pub enum AmendmentChangeRequest {
+    ExtendDuration { new_expiration: u64 },
+    UpdateTerm { field: String, new_value: String },
+    AddParty { did: String, coop_id: String, role: String },
+    RemoveParty { party_did: String },
+}
+
+/// Agreement list response
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AgreementListResponse {
+    pub agreements: Vec<AgreementSummary>,
+    pub total: usize,
+}
+
+/// Agreement summary for lists
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AgreementSummary {
+    pub id: String,
+    pub title: String,
+    pub status: String,
+    pub agreement_type: String,
+    pub parties_count: usize,
+    pub created_at: u64,
+    pub updated_at: u64,
+}
+
+/// Agreement detail response
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AgreementDetailResponse {
+    pub id: String,
+    pub title: String,
+    pub description: String,
+    pub status: String,
+    pub status_details: serde_json::Value,
+    pub agreement_type: String,
+    pub agreement_type_details: serde_json::Value,
+    pub parties: Vec<PartyInfo>,
+    pub signatures: Vec<SignatureInfo>,
+    pub terms: serde_json::Value,
+    pub version: u32,
+    pub created_at: u64,
+    pub updated_at: u64,
+}
+
+/// Party information
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PartyInfo {
+    pub did: String,
+    pub coop_id: String,
+    pub role: String,
+    pub display_name: Option<String>,
+    pub has_signed: bool,
+}
+
+/// Signature information
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SignatureInfo {
+    pub signer_did: String,
+    pub coop_id: String,
+    pub signed_at: u64,
+    pub version_signed: u32,
+}
+
+/// Amendment response
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AmendmentResponse {
+    pub id: String,
+    pub agreement_id: String,
+    pub description: String,
+    pub status: String,
+    pub proposed_by: String,
+    pub proposed_at: u64,
+    pub signatures_count: usize,
+    pub required_signatures: usize,
+}
+
+// ============================================================================
+// API Endpoints
+// ============================================================================
+
+/// GET /agreements - List all agreements
+///
+/// Query parameters:
+/// - status: Filter by status (draft, proposed, active, suspended, terminated)
+/// - party: Filter by party DID
+#[utoipa::path(
+    get,
+    path = "/agreements",
+    tag = "agreements",
+    responses(
+        (status = 200, description = "List of agreements", body = AgreementListResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden - insufficient scope")
+    ),
+    security(("bearer_auth" = []))
+)]
+#[get("")]
+pub async fn list_agreements(
+    http_req: HttpRequest,
+    _query: web::Query<ListAgreementsQuery>,
+) -> Result<HttpResponse> {
+    require_scope(&http_req, "agreements:read")?;
+
+    let _claims = get_claims(&http_req)
+        .ok_or_else(|| GatewayError::AuthenticationFailed("No claims found".to_string()))?;
+
+    // TODO: Get agreements from AgreementManager
+    // For now, return empty list as placeholder
+
+    let response = AgreementListResponse {
+        agreements: vec![],
+        total: 0,
+    };
+
+    Ok(HttpResponse::Ok().json(response))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListAgreementsQuery {
+    pub status: Option<String>,
+    pub party: Option<String>,
+}
+
+/// POST /agreements - Create a new agreement draft
+#[utoipa::path(
+    post,
+    path = "/agreements",
+    tag = "agreements",
+    request_body = CreateAgreementRequest,
+    responses(
+        (status = 201, description = "Agreement created", body = AgreementDetailResponse),
+        (status = 400, description = "Bad request"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden")
+    ),
+    security(("bearer_auth" = []))
+)]
+#[post("")]
+pub async fn create_agreement(
+    http_req: HttpRequest,
+    _req: web::Json<CreateAgreementRequest>,
+) -> Result<HttpResponse> {
+    require_scope(&http_req, "agreements:write")?;
+
+    let _claims = get_claims(&http_req)
+        .ok_or_else(|| GatewayError::AuthenticationFailed("No claims found".to_string()))?;
+
+    // TODO: Create agreement using AgreementManager
+
+    Err(GatewayError::InternalError(
+        "Agreement creation not yet integrated".to_string(),
+    ))
+}
+
+/// GET /agreements/{id} - Get agreement details
+#[utoipa::path(
+    get,
+    path = "/agreements/{id}",
+    tag = "agreements",
+    params(
+        ("id" = String, Path, description = "Agreement ID")
+    ),
+    responses(
+        (status = 200, description = "Agreement details", body = AgreementDetailResponse),
+        (status = 404, description = "Agreement not found"),
+        (status = 401, description = "Unauthorized")
+    ),
+    security(("bearer_auth" = []))
+)]
+#[get("/{id}")]
+pub async fn get_agreement(
+    http_req: HttpRequest,
+    path: web::Path<String>,
+) -> Result<HttpResponse> {
+    require_scope(&http_req, "agreements:read")?;
+
+    let _agreement_id = path.into_inner();
+
+    // TODO: Get agreement from AgreementManager
+
+    Err(GatewayError::InternalError(
+        "Agreement retrieval not yet integrated".to_string(),
+    ))
+}
+
+/// DELETE /agreements/{id} - Delete a draft agreement
+#[utoipa::path(
+    delete,
+    path = "/agreements/{id}",
+    tag = "agreements",
+    params(
+        ("id" = String, Path, description = "Agreement ID")
+    ),
+    responses(
+        (status = 204, description = "Agreement deleted"),
+        (status = 404, description = "Agreement not found"),
+        (status = 400, description = "Cannot delete non-draft agreement")
+    ),
+    security(("bearer_auth" = []))
+)]
+#[delete("/{id}")]
+pub async fn delete_agreement(
+    http_req: HttpRequest,
+    path: web::Path<String>,
+) -> Result<HttpResponse> {
+    require_scope(&http_req, "agreements:write")?;
+
+    let _agreement_id = path.into_inner();
+
+    // TODO: Delete draft agreement
+
+    Err(GatewayError::InternalError(
+        "Agreement deletion not yet integrated".to_string(),
+    ))
+}
+
+/// POST /agreements/{id}/parties - Add a party to draft agreement
+#[utoipa::path(
+    post,
+    path = "/agreements/{id}/parties",
+    tag = "agreements",
+    params(
+        ("id" = String, Path, description = "Agreement ID")
+    ),
+    request_body = AddPartyRequest,
+    responses(
+        (status = 200, description = "Party added", body = AgreementDetailResponse),
+        (status = 400, description = "Bad request"),
+        (status = 404, description = "Agreement not found")
+    ),
+    security(("bearer_auth" = []))
+)]
+#[post("/{id}/parties")]
+pub async fn add_party(
+    http_req: HttpRequest,
+    path: web::Path<String>,
+    _req: web::Json<AddPartyRequest>,
+) -> Result<HttpResponse> {
+    require_scope(&http_req, "agreements:write")?;
+
+    let _agreement_id = path.into_inner();
+
+    Err(GatewayError::InternalError(
+        "Add party not yet integrated".to_string(),
+    ))
+}
+
+/// PUT /agreements/{id}/terms - Set agreement terms
+#[utoipa::path(
+    put,
+    path = "/agreements/{id}/terms",
+    tag = "agreements",
+    params(
+        ("id" = String, Path, description = "Agreement ID")
+    ),
+    request_body = SetTermsRequest,
+    responses(
+        (status = 200, description = "Terms set", body = AgreementDetailResponse),
+        (status = 400, description = "Bad request")
+    ),
+    security(("bearer_auth" = []))
+)]
+#[put("/{id}/terms")]
+pub async fn set_terms(
+    http_req: HttpRequest,
+    path: web::Path<String>,
+    _req: web::Json<SetTermsRequest>,
+) -> Result<HttpResponse> {
+    require_scope(&http_req, "agreements:write")?;
+
+    let _agreement_id = path.into_inner();
+
+    Err(GatewayError::InternalError(
+        "Set terms not yet integrated".to_string(),
+    ))
+}
+
+/// POST /agreements/{id}/propose - Propose the agreement
+#[utoipa::path(
+    post,
+    path = "/agreements/{id}/propose",
+    tag = "agreements",
+    params(
+        ("id" = String, Path, description = "Agreement ID")
+    ),
+    responses(
+        (status = 200, description = "Agreement proposed", body = AgreementDetailResponse),
+        (status = 400, description = "Cannot propose - invalid state or missing parties")
+    ),
+    security(("bearer_auth" = []))
+)]
+#[post("/{id}/propose")]
+pub async fn propose_agreement(
+    http_req: HttpRequest,
+    path: web::Path<String>,
+) -> Result<HttpResponse> {
+    require_scope(&http_req, "agreements:write")?;
+
+    let _agreement_id = path.into_inner();
+
+    Err(GatewayError::InternalError(
+        "Propose agreement not yet integrated".to_string(),
+    ))
+}
+
+/// POST /agreements/{id}/sign - Sign the agreement
+#[utoipa::path(
+    post,
+    path = "/agreements/{id}/sign",
+    tag = "agreements",
+    params(
+        ("id" = String, Path, description = "Agreement ID")
+    ),
+    responses(
+        (status = 200, description = "Agreement signed", body = AgreementDetailResponse),
+        (status = 400, description = "Cannot sign - invalid state or not a party")
+    ),
+    security(("bearer_auth" = []))
+)]
+#[post("/{id}/sign")]
+pub async fn sign_agreement(
+    http_req: HttpRequest,
+    path: web::Path<String>,
+) -> Result<HttpResponse> {
+    require_scope(&http_req, "agreements:write")?;
+
+    let _agreement_id = path.into_inner();
+
+    Err(GatewayError::InternalError(
+        "Sign agreement not yet integrated".to_string(),
+    ))
+}
+
+/// POST /agreements/{id}/suspend - Suspend an active agreement
+#[utoipa::path(
+    post,
+    path = "/agreements/{id}/suspend",
+    tag = "agreements",
+    params(
+        ("id" = String, Path, description = "Agreement ID")
+    ),
+    request_body = SuspendRequest,
+    responses(
+        (status = 200, description = "Agreement suspended", body = AgreementDetailResponse),
+        (status = 400, description = "Cannot suspend")
+    ),
+    security(("bearer_auth" = []))
+)]
+#[post("/{id}/suspend")]
+pub async fn suspend_agreement(
+    http_req: HttpRequest,
+    path: web::Path<String>,
+    _req: web::Json<SuspendRequest>,
+) -> Result<HttpResponse> {
+    require_scope(&http_req, "agreements:admin")?;
+
+    let _agreement_id = path.into_inner();
+
+    Err(GatewayError::InternalError(
+        "Suspend agreement not yet integrated".to_string(),
+    ))
+}
+
+/// POST /agreements/{id}/resume - Resume a suspended agreement
+#[utoipa::path(
+    post,
+    path = "/agreements/{id}/resume",
+    tag = "agreements",
+    params(
+        ("id" = String, Path, description = "Agreement ID")
+    ),
+    responses(
+        (status = 200, description = "Agreement resumed", body = AgreementDetailResponse),
+        (status = 400, description = "Cannot resume")
+    ),
+    security(("bearer_auth" = []))
+)]
+#[post("/{id}/resume")]
+pub async fn resume_agreement(
+    http_req: HttpRequest,
+    path: web::Path<String>,
+) -> Result<HttpResponse> {
+    require_scope(&http_req, "agreements:admin")?;
+
+    let _agreement_id = path.into_inner();
+
+    Err(GatewayError::InternalError(
+        "Resume agreement not yet integrated".to_string(),
+    ))
+}
+
+/// POST /agreements/{id}/terminate - Terminate an agreement
+#[utoipa::path(
+    post,
+    path = "/agreements/{id}/terminate",
+    tag = "agreements",
+    params(
+        ("id" = String, Path, description = "Agreement ID")
+    ),
+    request_body = TerminateRequest,
+    responses(
+        (status = 200, description = "Agreement terminated", body = AgreementDetailResponse),
+        (status = 400, description = "Cannot terminate")
+    ),
+    security(("bearer_auth" = []))
+)]
+#[post("/{id}/terminate")]
+pub async fn terminate_agreement(
+    http_req: HttpRequest,
+    path: web::Path<String>,
+    _req: web::Json<TerminateRequest>,
+) -> Result<HttpResponse> {
+    require_scope(&http_req, "agreements:admin")?;
+
+    let _agreement_id = path.into_inner();
+
+    Err(GatewayError::InternalError(
+        "Terminate agreement not yet integrated".to_string(),
+    ))
+}
+
+// ============================================================================
+// Amendment Endpoints
+// ============================================================================
+
+/// GET /agreements/{id}/amendments - List amendments for an agreement
+#[utoipa::path(
+    get,
+    path = "/agreements/{id}/amendments",
+    tag = "agreements",
+    params(
+        ("id" = String, Path, description = "Agreement ID")
+    ),
+    responses(
+        (status = 200, description = "List of amendments", body = Vec<AmendmentResponse>)
+    ),
+    security(("bearer_auth" = []))
+)]
+#[get("/{id}/amendments")]
+pub async fn list_amendments(
+    http_req: HttpRequest,
+    path: web::Path<String>,
+) -> Result<HttpResponse> {
+    require_scope(&http_req, "agreements:read")?;
+
+    let _agreement_id = path.into_inner();
+
+    Ok(HttpResponse::Ok().json(Vec::<AmendmentResponse>::new()))
+}
+
+/// POST /agreements/{id}/amendments - Propose an amendment
+#[utoipa::path(
+    post,
+    path = "/agreements/{id}/amendments",
+    tag = "agreements",
+    params(
+        ("id" = String, Path, description = "Agreement ID")
+    ),
+    request_body = ProposeAmendmentRequest,
+    responses(
+        (status = 201, description = "Amendment proposed", body = AmendmentResponse),
+        (status = 400, description = "Cannot amend")
+    ),
+    security(("bearer_auth" = []))
+)]
+#[post("/{id}/amendments")]
+pub async fn propose_amendment(
+    http_req: HttpRequest,
+    path: web::Path<String>,
+    _req: web::Json<ProposeAmendmentRequest>,
+) -> Result<HttpResponse> {
+    require_scope(&http_req, "agreements:write")?;
+
+    let _agreement_id = path.into_inner();
+
+    Err(GatewayError::InternalError(
+        "Propose amendment not yet integrated".to_string(),
+    ))
+}
+
+/// POST /agreements/{id}/amendments/{amendment_id}/sign - Sign an amendment
+#[utoipa::path(
+    post,
+    path = "/agreements/{id}/amendments/{amendment_id}/sign",
+    tag = "agreements",
+    params(
+        ("id" = String, Path, description = "Agreement ID"),
+        ("amendment_id" = String, Path, description = "Amendment ID")
+    ),
+    responses(
+        (status = 200, description = "Amendment signed", body = AmendmentResponse),
+        (status = 400, description = "Cannot sign")
+    ),
+    security(("bearer_auth" = []))
+)]
+#[post("/{id}/amendments/{amendment_id}/sign")]
+pub async fn sign_amendment(
+    http_req: HttpRequest,
+    path: web::Path<(String, String)>,
+) -> Result<HttpResponse> {
+    require_scope(&http_req, "agreements:write")?;
+
+    let (_agreement_id, _amendment_id) = path.into_inner();
+
+    Err(GatewayError::InternalError(
+        "Sign amendment not yet integrated".to_string(),
+    ))
+}
+
+// ============================================================================
+// Route Configuration
+// ============================================================================
+
+/// Configure agreement routes
+pub fn configure(cfg: &mut web::ServiceConfig) {
+    cfg.service(
+        web::scope("/agreements")
+            .service(list_agreements)
+            .service(create_agreement)
+            .service(get_agreement)
+            .service(delete_agreement)
+            .service(add_party)
+            .service(set_terms)
+            .service(propose_agreement)
+            .service(sign_agreement)
+            .service(suspend_agreement)
+            .service(resume_agreement)
+            .service(terminate_agreement)
+            .service(list_amendments)
+            .service(propose_amendment)
+            .service(sign_amendment),
+    );
+}

--- a/icn/crates/icn-gateway/src/api/agreements.rs
+++ b/icn/crates/icn-gateway/src/api/agreements.rs
@@ -124,10 +124,21 @@ pub struct ProposeAmendmentRequest {
 #[derive(Debug, Deserialize, ToSchema)]
 #[serde(tag = "change_type", rename_all = "snake_case")]
 pub enum AmendmentChangeRequest {
-    ExtendDuration { new_expiration: u64 },
-    UpdateTerm { field: String, new_value: String },
-    AddParty { did: String, coop_id: String, role: String },
-    RemoveParty { party_did: String },
+    ExtendDuration {
+        new_expiration: u64,
+    },
+    UpdateTerm {
+        field: String,
+        new_value: String,
+    },
+    AddParty {
+        did: String,
+        coop_id: String,
+        role: String,
+    },
+    RemoveParty {
+        party_did: String,
+    },
 }
 
 /// Agreement list response
@@ -293,10 +304,7 @@ pub async fn create_agreement(
     security(("bearer_auth" = []))
 )]
 #[get("/{id}")]
-pub async fn get_agreement(
-    http_req: HttpRequest,
-    path: web::Path<String>,
-) -> Result<HttpResponse> {
+pub async fn get_agreement(http_req: HttpRequest, path: web::Path<String>) -> Result<HttpResponse> {
     require_scope(&http_req, "agreements:read")?;
 
     let _agreement_id = path.into_inner();

--- a/icn/crates/icn-gateway/src/api/mod.rs
+++ b/icn/crates/icn-gateway/src/api/mod.rs
@@ -1,5 +1,6 @@
 //! API endpoint modules
 
+pub mod agreements;
 pub mod auth;
 pub mod budgets;
 pub mod charter;


### PR DESCRIPTION
## Summary

Implements a comprehensive framework for formal agreements between cooperatives (Issue #317), enabling structured economic relationships with:

- **Lifecycle management**: Draft → Proposed → Active → Suspended → Terminated state machine
- **Multi-party signatures**: Ed25519 signature collection and verification from all required parties
- **Gossip synchronization**: Cross-node sync via `federation:agreements` topic
- **Amendment workflow**: Propose, sign, and ratify amendments to active agreements

### Agreement Types
- **Trade**: Item-based trade agreements with quantity, pricing, and currency
- **Credit**: Credit lines with limits, interest rates (basis points), and currency
- **ResourceSharing**: Resource sharing with compensation models and duration
- **FederationMembership**: Federation membership terms with trust thresholds
- **Custom**: Extensible custom agreement types for domain-specific needs

### New Files
| File | Purpose |
|------|---------|
| `icn-federation/src/agreement/types.rs` | Core types (Agreement, AgreementType, AgreementStatus, etc.) |
| `icn-federation/src/agreement/store.rs` | Storage trait + InMemoryAgreementStore |
| `icn-federation/src/agreement/manager.rs` | Business logic with state machine |
| `icn-federation/src/agreement/gossip.rs` | Gossip messages + handler |
| `icn-gateway/src/api/agreements.rs` | 14 REST API endpoints |

### Gateway API Endpoints
- `GET/POST /agreements` - List/create agreements
- `GET/DELETE /agreements/{id}` - Get/delete agreement
- `POST /agreements/{id}/parties` - Add party
- `PUT /agreements/{id}/terms` - Set terms
- `POST /agreements/{id}/propose` - Propose draft
- `POST /agreements/{id}/sign` - Sign agreement
- `POST /agreements/{id}/suspend` - Suspend active agreement
- `POST /agreements/{id}/resume` - Resume suspended agreement
- `POST /agreements/{id}/terminate` - Terminate agreement
- `GET/POST /agreements/{id}/amendments` - List/propose amendments
- `POST /agreements/{id}/amendments/{aid}/sign` - Sign amendment

## Test plan

- [x] 26 new unit tests for agreement module pass
- [x] 88 total icn-federation tests pass
- [x] 388 icn-gateway library tests pass
- [x] 22 federation integration tests pass
- [x] Zero clippy warnings
- [x] Build succeeds

```bash
cargo test -p icn-federation  # 88 tests pass
cargo test -p icn-gateway --lib  # 388 tests pass
cargo clippy -p icn-federation -p icn-gateway --all-features  # No warnings
```

## Notes

Gateway API endpoints have stub implementations returning "not yet integrated" - full integration with AgreementManager requires wiring through the supervisor in a follow-up PR.

Closes #317

🤖 Generated with [Claude Code](https://claude.ai/code)