### PR TITLE
feat(federation): Wire AgreementManager through supervisor to Gateway API

### DIFF
--- a/icn/crates/icn-core/src/supervisor/init_federation.rs
+++ b/icn/crates/icn-core/src/supervisor/init_federation.rs
@@ -28,6 +28,8 @@ pub struct FederationServices {
     pub clearing_manager: Arc<icn_federation::ClearingManager>,
     /// The attestation store for trust attestations
     pub attestation_store: Arc<icn_federation::AttestationStore>,
+    /// The agreement manager for inter-cooperative agreements
+    pub agreement_manager: Arc<icn_federation::agreement::AgreementManager<icn_federation::agreement::InMemoryAgreementStore>>,
 }
 
 /// Dependencies for federation initialization
@@ -145,6 +147,17 @@ pub async fn init_federation_services(
         });
     federation_handler.set_send_callback(federation_send_callback);
 
+    // Create agreement manager
+    let agreement_store = Arc::new(icn_federation::agreement::InMemoryAgreementStore::new());
+    let agreement_manager = Arc::new(
+        icn_federation::agreement::AgreementManager::new(
+            agreement_store.clone(),
+            coop_id.clone(),
+            deps.did.clone(),
+        )
+    );
+    info!("✓ Agreement manager initialized");
+
     info!(
         "✓ Federation enabled: coop_id={}, coop_name={}, store={}",
         coop_id,
@@ -157,6 +170,7 @@ pub async fn init_federation_services(
         registry,
         clearing_manager,
         attestation_store,
+        agreement_manager,
     }))
 }
 

--- a/icn/crates/icn-core/src/supervisor/init_federation.rs
+++ b/icn/crates/icn-core/src/supervisor/init_federation.rs
@@ -29,7 +29,11 @@ pub struct FederationServices {
     /// The attestation store for trust attestations
     pub attestation_store: Arc<icn_federation::AttestationStore>,
     /// The agreement manager for inter-cooperative agreements
-    pub agreement_manager: Arc<icn_federation::agreement::AgreementManager<icn_federation::agreement::InMemoryAgreementStore>>,
+    pub agreement_manager: Arc<
+        icn_federation::agreement::AgreementManager<
+            icn_federation::agreement::InMemoryAgreementStore,
+        >,
+    >,
 }
 
 /// Dependencies for federation initialization
@@ -149,13 +153,11 @@ pub async fn init_federation_services(
 
     // Create agreement manager
     let agreement_store = Arc::new(icn_federation::agreement::InMemoryAgreementStore::new());
-    let agreement_manager = Arc::new(
-        icn_federation::agreement::AgreementManager::new(
-            agreement_store.clone(),
-            coop_id.clone(),
-            deps.did.clone(),
-        )
-    );
+    let agreement_manager = Arc::new(icn_federation::agreement::AgreementManager::new(
+        agreement_store.clone(),
+        coop_id.clone(),
+        deps.did.clone(),
+    ));
     info!("✓ Agreement manager initialized");
 
     info!(

--- a/icn/crates/icn-core/src/supervisor/init_gateway.rs
+++ b/icn/crates/icn-core/src/supervisor/init_gateway.rs
@@ -37,7 +37,7 @@ pub struct GatewayHandles {
     /// Steward handle for SDIS ceremonies
     pub steward: Option<icn_steward::StewardHandle>,
     /// Agreement manager for inter-cooperative agreements
-    pub agreement_manager: Option<Arc<icn_federation::agreement::AgreementManager<icn_federation::agreement::InMemoryAgreementStore>>>,
+    pub agreement_manager: Option<icn_federation::agreement::AgreementManagerHandle>,
 }
 
 /// Spawn the Gateway API server if enabled

--- a/icn/crates/icn-core/src/supervisor/init_gateway.rs
+++ b/icn/crates/icn-core/src/supervisor/init_gateway.rs
@@ -36,6 +36,8 @@ pub struct GatewayHandles {
     pub entity: Option<super::init_entity::EntityHandle>,
     /// Steward handle for SDIS ceremonies
     pub steward: Option<icn_steward::StewardHandle>,
+    /// Agreement manager for inter-cooperative agreements
+    pub agreement_manager: Option<Arc<icn_federation::agreement::AgreementManager<icn_federation::agreement::InMemoryAgreementStore>>>,
 }
 
 /// Spawn the Gateway API server if enabled
@@ -94,6 +96,7 @@ pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: Gateway
     let ledger_handle = handles.ledger;
     let entity_handle = handles.entity;
     let steward_handle = handles.steward;
+    let agreement_manager_handle = handles.agreement_manager;
 
     // Spawn gateway in a dedicated thread (actix-web has its own runtime)
     std::thread::spawn(move || {
@@ -147,6 +150,10 @@ pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: Gateway
 
             if let Some(handle) = steward_handle {
                 gateway_server = gateway_server.with_steward_handle(handle);
+            }
+
+            if let Some(handle) = agreement_manager_handle {
+                gateway_server = gateway_server.with_agreement_manager_handle(handle);
             }
 
             if let Err(e) = gateway_server.run().await {

--- a/icn/crates/icn-core/src/supervisor/mod.rs
+++ b/icn/crates/icn-core/src/supervisor/mod.rs
@@ -274,7 +274,9 @@ impl Supervisor {
         let steward_handle_for_gateway: Option<icn_steward::StewardHandle>;
 
         // Agreement manager for gateway integration
-        let agreement_manager_for_gateway: Option<icn_federation::agreement::AgreementManagerHandle>;
+        let agreement_manager_for_gateway: Option<
+            icn_federation::agreement::AgreementManagerHandle,
+        >;
 
         // Governance event subscription handles - MUST persist for daemon lifetime
         // Stored at function scope to prevent premature Drop (which would unsubscribe)

--- a/icn/crates/icn-core/src/supervisor/mod.rs
+++ b/icn/crates/icn-core/src/supervisor/mod.rs
@@ -273,6 +273,9 @@ impl Supervisor {
         // Steward handle for gateway integration
         let steward_handle_for_gateway: Option<icn_steward::StewardHandle>;
 
+        // Agreement manager for gateway integration
+        let agreement_manager_for_gateway: Option<Arc<icn_federation::agreement::AgreementManager<icn_federation::agreement::InMemoryAgreementStore>>>;
+
         // Governance event subscription handles - MUST persist for daemon lifetime
         // Stored at function scope to prevent premature Drop (which would unsubscribe)
         let governance_event_subscription: Option<crate::events::SubscriptionHandle>;
@@ -614,11 +617,13 @@ impl Supervisor {
                     attestation_store_for_governance = Some(services.attestation_store.clone());
                     federation_handler_for_notifications =
                         Some(services.federation_handler.clone());
+                    agreement_manager_for_gateway = Some(services.agreement_manager.clone());
                 } else {
                     federation_registry_for_rpc = None;
                     clearing_manager_for_governance = None;
                     attestation_store_for_governance = None;
                     federation_handler_for_notifications = None;
+                    agreement_manager_for_gateway = None;
                 };
 
                 // Clone federation handler for announcement task (before it's moved into notification callback)
@@ -1041,6 +1046,7 @@ impl Supervisor {
             treasury_handle_for_gateway = None;
             ledger_handle_for_gateway = None;
             entity_handle_for_gateway = None;
+            agreement_manager_for_gateway = None;
 
             // No misbehavior detector without identity
             misbehavior_detector_for_shutdown = None;
@@ -1064,6 +1070,7 @@ impl Supervisor {
                 ledger: ledger_handle_for_gateway,
                 entity: entity_handle_for_gateway,
                 steward: steward_handle_for_gateway,
+                agreement_manager: agreement_manager_for_gateway,
             },
         );
 

--- a/icn/crates/icn-core/src/supervisor/mod.rs
+++ b/icn/crates/icn-core/src/supervisor/mod.rs
@@ -274,7 +274,7 @@ impl Supervisor {
         let steward_handle_for_gateway: Option<icn_steward::StewardHandle>;
 
         // Agreement manager for gateway integration
-        let agreement_manager_for_gateway: Option<Arc<icn_federation::agreement::AgreementManager<icn_federation::agreement::InMemoryAgreementStore>>>;
+        let agreement_manager_for_gateway: Option<icn_federation::agreement::AgreementManagerHandle>;
 
         // Governance event subscription handles - MUST persist for daemon lifetime
         // Stored at function scope to prevent premature Drop (which would unsubscribe)

--- a/icn/crates/icn-federation/src/agreement/mod.rs
+++ b/icn/crates/icn-federation/src/agreement/mod.rs
@@ -45,6 +45,8 @@
 //! .with_party(tech_coop_did, "tech-coop", PartyRole::Counterparty);
 //! ```
 
+use std::sync::Arc;
+
 mod gossip;
 mod manager;
 mod store;
@@ -54,3 +56,9 @@ pub use gossip::{AgreementGossipCallback, AgreementGossipHandler, AgreementMessa
 pub use manager::{AgreementEvent, AgreementEventCallback, AgreementManager};
 pub use store::{AgreementStore, AgreementStoreOps, InMemoryAgreementStore};
 pub use types::*;
+
+/// Type alias for AgreementManager handle with InMemoryAgreementStore
+///
+/// This is the default manager type used during wiring through supervisor.
+/// Can be replaced with persistent storage (SledAgreementStore) in future.
+pub type AgreementManagerHandle = Arc<AgreementManager<InMemoryAgreementStore>>;

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -93,6 +93,8 @@ pub struct GatewayServer {
     community_handle: Option<icn_community::CommunityHandle>,
     /// Optional handle to daemon's StewardActor (for SDIS ceremonies)
     steward_handle: Option<icn_steward::StewardHandle>,
+    /// Optional handle to daemon's AgreementManager (for inter-cooperative agreements)
+    agreement_manager_handle: Option<Arc<icn_federation::agreement::AgreementManager<icn_federation::agreement::InMemoryAgreementStore>>>,
     /// Audit pruning configuration
     audit_prune_config: Option<AuditPruneConfig>,
 }
@@ -117,6 +119,7 @@ impl GatewayServer {
             entity_handle: None,
             community_handle: None,
             steward_handle: None,
+            agreement_manager_handle: None,
             audit_prune_config: None,
         }
     }
@@ -144,6 +147,7 @@ impl GatewayServer {
             entity_handle: None,
             community_handle: None,
             steward_handle: None,
+            agreement_manager_handle: None,
             audit_prune_config: None,
         }
     }
@@ -172,6 +176,7 @@ impl GatewayServer {
             entity_handle: None,
             community_handle: None,
             steward_handle: None,
+            agreement_manager_handle: None,
             audit_prune_config: None,
         }
     }
@@ -273,6 +278,18 @@ impl GatewayServer {
     /// EntityRegistry, ensuring persistence and consistent state.
     pub fn with_entity_handle(mut self, handle: EntityHandle) -> Self {
         self.entity_handle = Some(handle);
+        self
+    }
+
+    /// Set agreement manager handle for inter-cooperative agreements
+    ///
+    /// When set, the agreement API endpoints will use the daemon's
+    /// AgreementManager for managing formal agreements between cooperatives.
+    pub fn with_agreement_manager_handle(
+        mut self,
+        handle: Arc<icn_federation::agreement::AgreementManager<icn_federation::agreement::InMemoryAgreementStore>>,
+    ) -> Self {
+        self.agreement_manager_handle = Some(handle);
         self
     }
 
@@ -380,6 +397,16 @@ impl GatewayServer {
 
         let federation_manager = Arc::new(FederationManager::new());
         let commons_manager = Arc::new(CommonsManager::new());
+
+        // Setup agreement manager if provided (for inter-cooperative agreements)
+        let agreement_manager: Option<Arc<icn_federation::agreement::AgreementManager<icn_federation::agreement::InMemoryAgreementStore>>> =
+            if let Some(handle) = self.agreement_manager_handle {
+                info!("Agreement manager connected to daemon");
+                Some(handle)
+            } else {
+                info!("Agreement manager not configured (agreements API will return stubs)");
+                None
+            };
 
         // Create entity manager (uses actor if handle available, otherwise in-memory)
         let entity_manager: Arc<EntityManager> = if let Some(handle) = self.entity_handle {
@@ -768,6 +795,8 @@ impl GatewayServer {
                 .app_data(web::Data::new(velocity_limiter.clone()))
                 // Contract registry (optional - for contract management API)
                 .app_data(web::Data::new(contract_registry.clone()))
+                // Agreement manager (optional - for inter-cooperative agreements)
+                .app_data(web::Data::new(agreement_manager.clone()))
                 // JSON payload size limit (256KB - we're not handling file uploads)
                 .app_data(web::JsonConfig::default().limit(262_144))
                 // Middleware (order: last wrapped runs first for REQUEST, first runs last for RESPONSE)

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -94,7 +94,7 @@ pub struct GatewayServer {
     /// Optional handle to daemon's StewardActor (for SDIS ceremonies)
     steward_handle: Option<icn_steward::StewardHandle>,
     /// Optional handle to daemon's AgreementManager (for inter-cooperative agreements)
-    agreement_manager_handle: Option<Arc<icn_federation::agreement::AgreementManager<icn_federation::agreement::InMemoryAgreementStore>>>,
+    agreement_manager_handle: Option<icn_federation::agreement::AgreementManagerHandle>,
     /// Audit pruning configuration
     audit_prune_config: Option<AuditPruneConfig>,
 }
@@ -287,7 +287,7 @@ impl GatewayServer {
     /// AgreementManager for managing formal agreements between cooperatives.
     pub fn with_agreement_manager_handle(
         mut self,
-        handle: Arc<icn_federation::agreement::AgreementManager<icn_federation::agreement::InMemoryAgreementStore>>,
+        handle: icn_federation::agreement::AgreementManagerHandle,
     ) -> Self {
         self.agreement_manager_handle = Some(handle);
         self
@@ -399,7 +399,7 @@ impl GatewayServer {
         let commons_manager = Arc::new(CommonsManager::new());
 
         // Setup agreement manager if provided (for inter-cooperative agreements)
-        let agreement_manager: Option<Arc<icn_federation::agreement::AgreementManager<icn_federation::agreement::InMemoryAgreementStore>>> =
+        let agreement_manager: Option<icn_federation::agreement::AgreementManagerHandle> =
             if let Some(handle) = self.agreement_manager_handle {
                 info!("Agreement manager connected to daemon");
                 Some(handle)


### PR DESCRIPTION
## Summary

Completes the integration of the Agreement framework (from PR #642) by wiring AgreementManager through the supervisor to make it available for Gateway API endpoints.

## Changes

### Core Integration

**init_federation.rs**:
- Added `agreement_manager` field to `FederationServices` struct
- Initialize `AgreementManager` with `InMemoryAgreementStore`
- Pass coop_id and DID for proper agreement ownership

**init_gateway.rs**:
- Added `agreement_manager` field to `GatewayHandles` struct  
- Extract and pass agreement_manager handle to gateway thread
- Wire through `with_agreement_manager_handle()` method

**supervisor/mod.rs**:
- Declared `agreement_manager_for_gateway` variable at supervisor scope
- Extract agreement_manager from federation_services when federation is enabled
- Initialize to `None` in no-identity branch (graceful fallback)
- Pass to gateway via `GatewayHandles`

**server.rs**:
- Added `agreement_manager_handle` optional field to `GatewayServer`
- Updated all three constructors (new, new_with_storage, new_with_broadcaster)
- Implemented `with_agreement_manager_handle()` builder method
- Setup agreement_manager as `app_data` for actix-web routes

## Architecture

The implementation follows the existing handle pattern used for other managers:

1. **Supervisor** initializes AgreementManager during federation setup
2. **Handle** is extracted and stored in supervisor scope
3. **Gateway** receives handle via `GatewayHandles` struct
4. **Server** makes it available to API routes via `web::Data`

The AgreementManager is optional - the gateway falls back gracefully if federation is disabled or identity is not available.

## Type Signature

```rust
Option<Arc<icn_federation::agreement::AgreementManager<icn_federation::agreement::InMemoryAgreementStore>>>
```

## Storage

Currently uses `InMemoryAgreementStore` for simplicity. This can be upgraded to persistent Sled storage in a future PR once the API endpoints are fully implemented and tested.

## Testing

- ✅ All existing tests pass (`cargo test -p icn-core`)
- ✅ Compilation successful with no warnings
- ✅ Graceful fallback when federation disabled
- ✅ No breaking changes to existing functionality

## Next Steps (Separate PRs)

The AgreementManager is now wired and available, but the API endpoints in `api/agreements.rs` still return stub responses. Follow-up work:

1. **Update API endpoints** to use the injected AgreementManager
2. **Add integration tests** for end-to-end agreement workflows  
3. **Upgrade to persistent storage** (replace InMemoryAgreementStore with Sled)
4. **Connect gossip handler** for cross-node agreement synchronization
5. **Add metrics** for agreement lifecycle events (Issue #648)

## Acceptance Criteria

- [x] AgreementManager added to Supervisor (via FederationServices)
- [x] AgreementManager initialized during supervisor startup
- [x] AgreementManager accessible via Gateway (via GatewayHandles)
- [x] Gateway server wired to AgreementManager (app_data)
- [x] All tests pass
- [ ] ~~API endpoints functional~~ (deferred to follow-up PR)
- [ ] ~~AgreementGossipHandler connected~~ (deferred to follow-up PR)
- [ ] ~~Integration test~~ (deferred to follow-up PR)

## Related

- Closes #647
- Builds on PR #642 (agreement framework implementation)
- Unblocks API endpoint implementation

---

Ready for review! The wiring is complete, and the AgreementManager is now available to Gateway API routes. 🔌