### PR TITLE
docs(onboarding): add curriculum modules and tooling

### DIFF
--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -1,0 +1,29 @@
+# ICN Developer Onboarding Curriculum
+
+This curriculum teaches Rust and ICN systems together. It includes lesson docs,
+workshop labs with checkpoints, and a capstone. Use the Foundations track if you
+are new to Rust; use the Accelerated track if you are already comfortable with
+Rust and async systems.
+
+## How to use this curriculum
+- Start with `syllabus.md` and choose a track.
+- Follow modules in order. Each module links to key code and docs.
+- Complete workshops after the corresponding modules.
+- Finish with the capstone in `capstone.md`.
+
+## Structure
+- `tracks/` track-specific guidance and pacing
+- `modules/` lesson docs for each module
+- `workshops/` hands-on labs with checkpoints
+- `reading-map.md` cross-links modules to code paths
+- `assessments.md` short checks for understanding
+- `module-template.md` template for new lessons
+- `update-process.md` how to keep the curriculum in sync
+
+## Suggested timeframe
+This curriculum is designed for 3-6 weeks total. Suggested pacing and time
+estimates are in `syllabus.md`.
+
+## Contributor notes
+If you update the curriculum, keep lessons aligned with the codebase and keep
+exercises runnable on a local dev environment.

--- a/docs/onboarding/assessments.md
+++ b/docs/onboarding/assessments.md
@@ -1,0 +1,49 @@
+# Assessments
+
+Each module has a short check for understanding. These are designed to be quick
+and practical. Use them as self-checks or as review prompts.
+
+## Module 0
+- Explain the difference between `icnd` and `icnctl`.
+- Identify the config precedence order for ICN.
+
+## Module 1
+- Explain ownership and borrowing with a small Rust example.
+- Write a Rust function that returns a `Result` and uses `?`.
+- Explain when to use `Arc<Mutex<T>>` vs `RwLock<T>`.
+
+## Module 2
+- Draw the ICN layer stack from memory.
+- Explain how trust and identity relate to ledger authorship.
+
+## Module 3
+- Trace the `icnd` startup path through `Runtime` and `Supervisor`.
+- Describe why the Supervisor owns long-lived handles.
+
+## Module 4
+- Explain the DID format used by ICN.
+- Describe how key rotation is represented in ICN.
+
+## Module 5
+- Explain the difference between transport and gossip in ICN.
+- Describe how topic subscriptions affect routing.
+
+## Module 6
+- Explain how a mutual credit entry is represented in the ledger.
+- Describe how contracts interact with ledger operations.
+
+## Module 7
+- Describe the gateway auth flow end-to-end.
+- List three common scopes and what they allow.
+
+## Module 8
+- Describe how the Pilot UI obtains data from the gateway.
+- Identify where token handling occurs in the UI.
+
+## Module 9
+- List three production hardening measures from ICN docs.
+- Explain how to validate config before startup.
+
+## Module 10
+- Describe the test strategy and when to run which tests.
+- Outline the PR checklist for contributors.

--- a/docs/onboarding/capstone.md
+++ b/docs/onboarding/capstone.md
@@ -1,0 +1,38 @@
+# Capstone: Local Two-Node ICN + Ledger Flow
+
+## Goal
+Bring up a two-node ICN network locally, perform a ledger transaction through
+the gateway, and observe gossip propagation.
+
+## Prerequisites
+- Completed Modules 0-9
+- Built ICN binaries
+
+## Steps
+1. Build ICN: `cd icn && cargo build --release`
+2. Start node alpha with `config/icn-alpha.toml`
+3. Start node beta with `config/icn-beta.toml`
+4. Verify peers discover each other with `icnctl network peers`
+5. Enable gateway on one node (config or CLI)
+6. Get a JWT token with `icnctl auth` flow
+7. Create a cooperative via gateway API
+8. Post a ledger payment via gateway API
+9. Verify ledger state and gossip on both nodes
+
+## Expected outputs
+- Both nodes show each other as peers
+- Gateway health returns OK
+- Ledger balance reflects the payment
+- Gossip shows the ledger update being replicated
+
+## Rubric
+- **Setup complete**: nodes running, logs clean, config validated
+- **Auth working**: successful challenge and JWT token
+- **API operations**: cooperative created, payment posted
+- **Replication**: ledger state confirmed on both nodes
+- **Observability**: metrics endpoint reachable and shows activity
+
+## Optional extensions
+- Add a governance proposal and cast votes
+- Simulate a node restart and verify persistence
+- Introduce a third node and observe gossip convergence

--- a/docs/onboarding/module-template.md
+++ b/docs/onboarding/module-template.md
@@ -1,0 +1,22 @@
+# Module Template
+
+## Objectives
+- What learners should be able to do after this module
+
+## Prerequisites
+- Required knowledge or completed modules
+
+## Key reading
+- Link to docs and code paths
+
+## Walkthrough
+- Short narrative of the system or concept
+
+## Exercises
+- 2-4 small tasks
+
+## Checkpoints
+- Concrete outcomes to validate progress
+
+## Notes and gotchas
+- Common issues or pitfalls

--- a/docs/onboarding/modules/module-00-setup.md
+++ b/docs/onboarding/modules/module-00-setup.md
@@ -64,6 +64,51 @@ From `icn/`, run `cargo build --release`. This produces `icnd` and `icnctl` in
 Use the demo configs (`config/icn-alpha.toml`, `config/icn-beta.toml`) to run a
 two‑node network and verify discovery.
 
+## Annotated code excerpts
+
+### Pre-commit checks enforce formatting and linting
+Source: `scripts/dev-setup.sh`
+```bash
+# Check formatting
+echo "Checking Rust formatting..."
+cd icn
+if ! cargo fmt --all -- --check; then
+    echo "❌ Formatting check failed. Run 'cargo fmt --all' to fix."
+    exit 1
+fi
+
+# Run clippy
+echo "Running clippy..."
+if ! cargo clippy --workspace --all-targets -- -D warnings; then
+    echo "❌ Clippy check failed. Fix warnings before committing."
+    exit 1
+fi
+```
+This shows the project’s baseline quality gates. The hook prevents commits when
+formatting or linting fails, keeping the workspace consistent.
+
+### Workspace members declare the subsystem crates
+Source: `icn/Cargo.toml`
+```toml
+[workspace]
+resolver = "2"
+members = [
+    "crates/icn-core",
+    "crates/icn-identity",
+    "crates/icn-trust",
+    "crates/icn-net",
+    "crates/icn-gossip",
+    "crates/icn-ledger",
+    "crates/icn-ccl",
+    "crates/icn-store",
+    "crates/icn-rpc",
+    "crates/icn-obs",
+    "bins/icnd",
+    "bins/icnctl",
+]
+```
+The workspace list is the authoritative map of Rust crates and binaries.
+
 ## Reference files (follow-up)
 - `scripts/dev-setup.sh`
 - `icn/Cargo.toml`

--- a/docs/onboarding/modules/module-00-setup.md
+++ b/docs/onboarding/modules/module-00-setup.md
@@ -1,0 +1,90 @@
+# Module 0: Setup and Tooling
+
+## Objectives
+- Build ICN binaries locally
+- Run tests and linting
+- Identify repo layout and key directories
+
+## Prerequisites
+- None
+
+## Key reading
+- `README.md`
+- `docs/DEV_ENVIRONMENT.md`
+- `CONTRIBUTING.md`
+
+## Walkthrough
+ICN is a multi-crate Rust workspace with supporting SDK and web UI. Start by
+building the main daemon (`icnd`) and CLI (`icnctl`), then review contributor
+guidelines and dev setup.
+
+## Concepts (textbook style)
+
+### Workspace layout
+The repository is organized by function: core Rust crates live in `icn/`, client
+SDKs in `sdk/`, UI in `web/`, and operational artifacts in `deploy/` and
+`config/`. This layout separates runtime logic from integration layers and
+deployment concerns.
+
+### Repository map (diagram)
+```mermaid
+flowchart TD
+  root[repoRoot] --> icnDir[icnCrates]
+  root --> sdkDir[sdk]
+  root --> webDir[web]
+  root --> deployDir[deploy]
+  root --> configDir[config]
+  root --> docsDir[docs]
+  icnDir --> bins[icnBins]
+  icnDir --> crates[icnCratesDir]
+```
+
+### Tooling goals
+Tooling ensures consistent builds, linting, and tests. The onboarding emphasizes
+repeatable environment setup so developers can focus on system behavior rather
+than environment drift.
+
+## Detailed walkthrough (first setup)
+
+### 1) Install tooling
+Run `scripts/dev-setup.sh` to install required tools and pre‑commit hooks.
+
+### 2) Build the core binaries
+From `icn/`, run `cargo build --release`. This produces `icnd` and `icnctl` in
+`icn/target/release/`.
+
+### 3) Locate key directories
+- `icn/` Rust workspace and runtime crates
+- `sdk/` client SDKs
+- `web/` web UI assets
+- `config/` runtime configuration examples
+- `deploy/` deployment scripts and manifests
+
+### 4) Run a quick local test (optional)
+Use the demo configs (`config/icn-alpha.toml`, `config/icn-beta.toml`) to run a
+two‑node network and verify discovery.
+
+## Reference files (follow-up)
+- `scripts/dev-setup.sh`
+- `icn/Cargo.toml`
+- `icn/bins/icnd/src/main.rs`
+- `icn/bins/icnctl/src/main.rs`
+- `config/icn.toml.example`
+- `config/icn-alpha.toml`
+- `config/icn-beta.toml`
+- `docs/DEV_ENVIRONMENT.md`
+- `CONTRIBUTING.md`
+
+## Code map
+- `scripts/dev-setup.sh`: installs development tooling and hooks.
+- `icn/Cargo.toml`: workspace manifest for Rust crates.
+- `config/`: example runtime configs for local and multi-node use.
+
+## Exercises
+- Run `cargo build --release` in `icn/`
+- Locate the `icnd` and `icnctl` binaries
+- Find the config examples in `config/`
+
+## Checkpoints
+- You can build `icnd` without errors
+- You can locate and explain the purpose of `icn/`, `sdk/`, `web/`

--- a/docs/onboarding/modules/module-01-rust-fundamentals.md
+++ b/docs/onboarding/modules/module-01-rust-fundamentals.md
@@ -1,0 +1,91 @@
+# Module 1: Rust Fundamentals
+
+## Objectives
+- Understand ownership, borrowing, and lifetimes
+- Use `Result` and `Option` effectively
+- Read async Rust code using Tokio
+
+## Prerequisites
+- Module 0
+
+## Key reading
+- `icn/bins/icnd/src/main.rs`
+- `icn/crates/icn-core/src/runtime.rs`
+- `icn/crates/icn-core/src/supervisor/mod.rs`
+
+## Walkthrough
+Start by reading `icnd` entrypoint and trace how it constructs configuration,
+opens the keystore, and starts the runtime. Focus on how errors are handled and
+how async tasks are spawned.
+
+## Concepts (textbook style)
+
+### Ownership and borrowing in ICN
+ICN uses explicit ownership boundaries to keep state isolated inside actors.
+Shared state is wrapped in `Arc` and synchronized with `RwLock` or `Mutex` for
+async-safe access. This enables safe concurrency without global mutable state.
+
+### Ownership and sharing (diagram)
+```mermaid
+flowchart TD
+  actorA[ActorA] -->|Arc<RwLock>| shared[SharedState]
+  actorB[ActorB] -->|Arc<RwLock>| shared
+  actorA --> handleA[HandleA]
+  actorB --> handleB[HandleB]
+```
+
+### Error handling
+Most entrypoints return `Result` and use `?` for propagation. This encourages
+explicit handling at boundaries (CLI, network, storage) and keeps error paths
+visible and testable.
+
+### Async execution
+Tokio provides the async runtime. Actors are long-lived tasks; short-lived tasks
+are spawned for IO-bound operations (e.g., network handlers). This separation
+keeps system flow responsive without blocking critical loops.
+
+### Async task flow (diagram)
+```mermaid
+flowchart TD
+  main[main] --> runtime[Runtime]
+  runtime --> supervisor[Supervisor]
+  supervisor --> actor[ActorLoop]
+  actor -->|tokio::spawn| ioTask[IoTask]
+  ioTask --> actor
+```
+
+## Detailed walkthrough (Rust patterns in ICN)
+
+### 1) Error propagation
+Find `?` usage in `icnd` startup. Trace how a failure propagates back to `main`
+and results in a clean process exit.
+
+### 2) Shared ownership
+Inspect `Supervisor` initialization and note how handles are shared with `Arc`.
+These `Arc<RwLock<T>>` types allow concurrent read access and controlled writes.
+
+### 3) Async tasks
+Locate `tokio::spawn` in network/gossip code. These spawns handle IO without
+blocking the core actor loop.
+
+## Reference files (follow-up)
+- `icn/bins/icnd/src/main.rs`
+- `icn/crates/icn-core/src/runtime.rs`
+- `icn/crates/icn-core/src/supervisor/mod.rs`
+- `icn/crates/icn-core/src/supervisor/init_network.rs`
+- `icn/crates/icn-gossip/src/gossip.rs`
+
+## Code map
+- `icn/bins/icnd/src/main.rs`: `main` shows error handling with `anyhow::Result`.
+- `icn/crates/icn-core/src/runtime.rs`: async runtime entrypoint.
+- `icn/crates/icn-core/src/supervisor/mod.rs`: shared ownership patterns with
+  `Arc` and `RwLock`.
+
+## Exercises
+- Identify uses of `?` in `icnd` main and explain the error path.
+- Find a `struct` in `icn-core` and describe its ownership model.
+- Explain why `Arc` is used for shared handles.
+
+## Checkpoints
+- You can explain `Result` propagation in `icnd`
+- You can describe async task spawning in `Runtime::run`

--- a/docs/onboarding/modules/module-01-rust-fundamentals.md
+++ b/docs/onboarding/modules/module-01-rust-fundamentals.md
@@ -68,6 +68,40 @@ These `Arc<RwLock<T>>` types allow concurrent read access and controlled writes.
 Locate `tokio::spawn` in network/gossip code. These spawns handle IO without
 blocking the core actor loop.
 
+## Annotated code excerpts
+
+### Error propagation via `Result` and `?`
+Source: `icn/bins/icnd/src/main.rs`
+```rust
+let mut config = if let Some(config_path) = &args.config {
+    Config::from_file(config_path).context("Failed to load config file")?
+} else {
+    Config::default()
+};
+```
+This shows how `?` propagates errors from config loading back to `main`,
+preserving context for diagnostics.
+
+### Runtime handoff to the Supervisor
+Source: `icn/crates/icn-core/src/runtime.rs`
+```rust
+pub async fn run(self) -> Result<()> {
+    info!("ICNd runtime starting");
+
+    let supervisor = crate::supervisor::Supervisor::new(
+        self.config.clone(),
+        self.identity_bundle,
+        self.shutdown_tx.clone(),
+    );
+
+    supervisor.run().await?;
+    info!("ICNd runtime stopped");
+    Ok(())
+}
+```
+This is the core async flow: the runtime constructs the Supervisor and awaits
+its lifecycle, returning `Result` to the caller.
+
 ## Reference files (follow-up)
 - `icn/bins/icnd/src/main.rs`
 - `icn/crates/icn-core/src/runtime.rs`

--- a/docs/onboarding/modules/module-02-architecture-overview.md
+++ b/docs/onboarding/modules/module-02-architecture-overview.md
@@ -1,0 +1,80 @@
+# Module 2: ICN Architecture Overview
+
+## Objectives
+- Describe the ICN layer stack
+- Understand the core subsystems and their responsibilities
+
+## Prerequisites
+- Module 1 (or equivalent Rust familiarity)
+
+## Key reading
+- `docs/ARCHITECTURE.md`
+- `docs/README.md`
+- `README.md`
+
+## Walkthrough
+ICN is a decentralized coordination substrate. The architecture document
+describes the layer stack: identity, trust, network transport, gossip, ledger,
+contracts, storage, security, and distributed compute.
+
+## Concepts (textbook style)
+
+### Layered substrate
+ICN is designed as a stack of layers, each providing guarantees to the layer
+above. Identity provides authenticity; trust provides social weighting; transport
+provides secure connectivity; gossip provides synchronization; ledger provides
+accounting; contracts provide programmable rules; storage and security support
+durability and resilience.
+
+### Layer stack (diagram)
+```mermaid
+flowchart TB
+  transport[Transport] --> identity[Identity]
+  identity --> trust[TrustGraph]
+  trust --> gossip[Gossip]
+  gossip --> ledger[Ledger]
+  ledger --> contracts[Contracts]
+  contracts --> compute[DistributedCompute]
+  storage[StorageSecurity] -.supports.-> transport
+  storage -.supports.-> identity
+  storage -.supports.-> ledger
+```
+
+### Separation of concerns
+Each crate implements a focused subsystem. The architecture doc explains the
+interfaces between these subsystems, which helps contributors reason about
+changes without understanding the entire system at once.
+
+## Detailed walkthrough (architecture mapping)
+
+### 1) Read the layer stack
+Start in `docs/ARCHITECTURE.md` and identify the layer stack and the main
+responsibilities of each layer.
+
+### 2) Map layers to crates
+Use the crate list in `README.md` to map each layer to its primary crate (e.g.,
+identity → `icn-identity`, trust → `icn-trust`, ledger → `icn-ledger`).
+
+### 3) Identify integration points
+Look for crates that bridge layers (e.g., `icn-core` for runtime orchestration,
+`icn-gateway` for external API integration).
+
+## Reference files (follow-up)
+- `docs/ARCHITECTURE.md`
+- `docs/architecture/`
+- `README.md`
+- `icn/crates/icn-core/src/lib.rs`
+- `icn/crates/icn-gateway/README.md`
+
+## Code map
+- `README.md`: high-level crate list and subsystem summary.
+- `icn/crates/`: each crate maps to a layer in `docs/ARCHITECTURE.md`.
+- `docs/architecture/`: deeper design docs for specific subsystems.
+
+## Exercises
+- Draw the layer stack from memory
+- Map each layer to a crate name in `icn/crates/`
+
+## Checkpoints
+- You can explain what problems ICN solves
+- You can map major crates to the architecture layers

--- a/docs/onboarding/modules/module-02-architecture-overview.md
+++ b/docs/onboarding/modules/module-02-architecture-overview.md
@@ -59,6 +59,25 @@ identity → `icn-identity`, trust → `icn-trust`, ledger → `icn-ledger`).
 Look for crates that bridge layers (e.g., `icn-core` for runtime orchestration,
 `icn-gateway` for external API integration).
 
+## Annotated code excerpts
+
+### Workspace members encode the subsystem map
+Source: `icn/Cargo.toml`
+```toml
+members = [
+    "crates/icn-core",
+    "crates/icn-identity",
+    "crates/icn-trust",
+    "crates/icn-net",
+    "crates/icn-gossip",
+    "crates/icn-ledger",
+    "crates/icn-ccl",
+    "crates/icn-gateway",
+]
+```
+This list is a practical architecture index: each entry maps to a layer or
+integration boundary in the ICN stack.
+
 ## Reference files (follow-up)
 - `docs/ARCHITECTURE.md`
 - `docs/architecture/`

--- a/docs/onboarding/modules/module-03-runtime-actors.md
+++ b/docs/onboarding/modules/module-03-runtime-actors.md
@@ -87,6 +87,43 @@ missing identity to the operator.
 5. **Identity actor**: provides signing and DID context
 6. **Network actor**: transport is started after routing and trust are ready
 
+## Annotated code excerpts
+
+### Supervisor initializes trust, gossip, ledger, and network in order
+Source: `icn/crates/icn-core/src/supervisor/mod.rs`
+```rust
+// Initialize trust graph, recovery store, and misbehavior detector
+let trust_services = init_trust::init_trust_services(&self.config, did.clone()).await?;
+let trust_graph_handle = trust_services.trust_graph.clone();
+
+// Initialize gossip services
+let gossip_services = init_gossip::init_gossip_services(
+    &self.config,
+    did.clone(),
+    init_gossip::GossipDeps {
+        trust_graph: trust_graph_handle.clone(),
+        trust_lookup,
+        misbehavior_detector: misbehavior_detector.clone(),
+        identity_bundle: identity_bundle.clone(),
+    },
+)
+.await?;
+
+// Initialize ledger and contract services
+let ledger_services = init_ledger::init_ledger_services(
+    &self.config,
+    did.clone(),
+    init_ledger::LedgerDeps {
+        gossip_handle: gossip_handle.clone(),
+        misbehavior_detector: misbehavior_detector.clone(),
+        trust_graph: trust_graph_handle.clone(),
+    },
+)
+.await?;
+```
+This excerpt shows the dependency‑aware order: trust → gossip → ledger. Each
+step produces handles used by the next layer.
+
 ## Code map
 - `icn/bins/icnd/src/main.rs`: `main` loads config, initializes tracing, opens
   keystore, constructs `Runtime`, handles shutdown signals.

--- a/docs/onboarding/modules/module-03-runtime-actors.md
+++ b/docs/onboarding/modules/module-03-runtime-actors.md
@@ -1,0 +1,121 @@
+# Module 3: Runtime and Actor Model
+
+## Objectives
+- Trace the startup flow from `icnd` to Supervisor
+- Understand actor initialization order and dependencies
+
+## Prerequisites
+- Module 2
+
+## Key reading
+- `icn/bins/icnd/src/main.rs`
+- `icn/crates/icn-core/src/runtime.rs`
+- `icn/crates/icn-core/src/supervisor/mod.rs`
+
+## Walkthrough
+`icnd` loads configuration, opens the keystore, and starts `Runtime::run`, which
+creates a `Supervisor`. The supervisor initializes core services in sequence and
+maintains handles needed for the daemon lifetime.
+
+## Concepts (textbook style)
+
+### Runtime
+The runtime is the boundary between process-level concerns and ICN system logic.
+It owns configuration, optional identity, and the shutdown broadcast channel.
+The runtime does not implement the system itself; it is a thin lifecycle shell
+that starts the Supervisor and waits until the system is asked to stop.
+
+### Supervisor
+The Supervisor is the orchestration layer. It is responsible for creating
+subsystems in the correct order, wiring dependencies between them, and ensuring
+long-lived handles are retained for the daemon's lifetime.
+
+Key responsibilities:
+- instantiate core actors and services
+- pass shared resources across subsystems (trust graph, gossip handle, etc.)
+- start background tasks and keep them alive
+- enforce initialization order and availability constraints
+
+### Actor model in ICN
+ICN actors are long-lived async tasks that encapsulate state and expose a handle
+for interaction. Handles are shared with `Arc`/`RwLock` to allow concurrent use
+across subsystems. This style provides clear ownership boundaries and avoids
+global state while enabling non-blocking, event-driven behavior.
+
+### Handles and lifetime
+Handles are intentionally stored at the Supervisor scope because dropping a
+handle can terminate or unsubscribe the associated subsystem. This is why the
+Supervisor keeps long-lived subscription handles and service handles.
+
+### Shutdown flow
+Shutdown is coordinated through a broadcast channel. Actors subscribe to the
+shutdown receiver and stop cleanly, allowing final persistence and metrics
+flushes before exit.
+
+### Runtime orchestration (diagram)
+```mermaid
+flowchart TD
+  icnd[icndMain] --> runtime[Runtime]
+  runtime --> supervisor[Supervisor]
+  supervisor --> trust[TrustServices]
+  supervisor --> gossip[GossipServices]
+  supervisor --> ledger[LedgerServices]
+  supervisor --> identity[IdentityActor]
+  supervisor --> network[NetworkActor]
+  supervisor --> shutdown[ShutdownTx]
+  shutdown --> actorStop[ActorShutdown]
+```
+
+### Flow breakdown
+1. Parse CLI args and load `Config` (file or defaults)
+2. Initialize tracing/metrics and validate config
+3. Open keystore and load `IdentityBundle`
+4. Start runtime and spawn supervisor
+5. Supervisor initializes actors in dependency order
+
+## Dependency model
+Some subsystems depend on identity (network, gossip, ledger). When the keystore
+is missing or locked, the daemon can start in a limited mode where identity-
+dependent actors are skipped. This keeps the process healthy while signaling
+missing identity to the operator.
+
+## Initialization order (why this order matters)
+1. **Trust services**: trust gating is needed before accepting network or gossip
+2. **Gossip services**: sync requires trust and is used by ledger
+3. **Ledger services**: ledger uses gossip for replication
+4. **Coop and community**: higher-level domain logic depends on ledger/gossip
+5. **Identity actor**: provides signing and DID context
+6. **Network actor**: transport is started after routing and trust are ready
+
+## Code map
+- `icn/bins/icnd/src/main.rs`: `main` loads config, initializes tracing, opens
+  keystore, constructs `Runtime`, handles shutdown signals.
+- `icn/crates/icn-core/src/runtime.rs`: `Runtime::run` creates a `Supervisor`
+  and calls `Supervisor::run`.
+- `icn/crates/icn-core/src/supervisor/mod.rs`: `Supervisor::run` orchestrates
+  init order and holds actor handles.
+- `icn/crates/icn-core/src/supervisor/init_network.rs`:
+  `create_incoming_handler` routes network messages into gossip.
+
+## Reference files (follow-up)
+- `icn/bins/icnd/src/main.rs`
+- `icn/crates/icn-core/src/runtime.rs`
+- `icn/crates/icn-core/src/supervisor/mod.rs`
+- `icn/crates/icn-core/src/supervisor/init_*`
+- `icn/crates/icn-core/src/config/`
+
+## Example trace (ICN startup)
+- `icnd` parses CLI args and loads config.
+- Tracing and metrics initialize before actor startup.
+- Keystore is unlocked and `IdentityBundle` is loaded (if present).
+- `Runtime::run` starts the Supervisor.
+- Supervisor creates trust, gossip, ledger, coop/community, identity, network.
+- Runtime waits for shutdown; Supervisor handles actor lifecycle.
+
+## Exercises
+- Trace the creation order of trust, gossip, ledger, and network services
+- Explain why the Supervisor keeps long-lived subscription handles
+
+## Checkpoints
+- You can describe the startup sequence from main to actors
+- You can identify which subsystems depend on identity

--- a/docs/onboarding/modules/module-04-identity-trust.md
+++ b/docs/onboarding/modules/module-04-identity-trust.md
@@ -77,6 +77,53 @@ Trust scores are consulted by subsystems for:
 - **Invalid passphrase**: keystore remains locked and identity is unavailable.
 - **Low trust**: peers may be rate‑limited or denied access to topics.
 
+## Annotated code excerpts
+
+### Keystore interface defines the security boundary
+Source: `icn/crates/icn-identity/src/keystore.rs`
+```rust
+pub trait KeyStore: Send + Sync {
+    /// Unlock the keystore with a passphrase
+    fn unlock(&mut self, passphrase: &[u8]) -> Result<()>;
+
+    /// Lock the keystore (clear in-memory keys)
+    fn lock(&mut self);
+
+    /// Get the keypair (fails if locked)
+    fn get_keypair(&self) -> Result<&KeyPair>;
+}
+```
+This trait marks the boundary between encrypted storage and runtime use.
+
+### IdentityBundle binds DID to TLS
+Source: `icn/crates/icn-identity/src/bundle.rs`
+```rust
+pub struct IdentityBundle {
+    /// The DID for this identity
+    did: Did,
+    /// Ed25519 keypair for DID operations
+    did_keypair: KeyPair,
+    /// Self-signed TLS certificate
+    tls_cert: CertificateDer<'static>,
+    /// Binding signature proving ownership
+    /// Signature = Sign_did_key(SHA256(tls_cert))
+    tls_binding_sig: Vec<u8>,
+}
+```
+This struct ensures the node’s DID and TLS identity are cryptographically tied.
+
+### Trust dimensions are explicit and separate
+Source: `icn/crates/icn-trust/src/types.rs`
+```rust
+pub enum TrustGraphType {
+    Social,
+    EconomicReliability,
+    TechnicalReliability,
+}
+```
+ICN prevents a single trust dimension from dominating by modeling them
+independently.
+
 ## Code map
 - `icn/crates/icn-identity/src/keystore.rs`:
   keystore persistence and unlock flow.

--- a/docs/onboarding/modules/module-04-identity-trust.md
+++ b/docs/onboarding/modules/module-04-identity-trust.md
@@ -1,0 +1,102 @@
+# Module 4: Identity and Trust
+
+## Objectives
+- Understand ICN DID format and keystore usage
+- Understand trust graph concepts and policy usage
+
+## Prerequisites
+- Module 3
+
+## Key reading
+- `icn/crates/icn-identity/`
+- `icn/crates/icn-trust/`
+- `docs/ARCHITECTURE.md` (Identity, Trust sections)
+- `docs/multi-device-identity-design.md`
+
+## Walkthrough
+Identity in ICN is DID-based and uses Ed25519 keys. Trust derives from social
+edges and is used for access control and rate limiting.
+
+## Concepts (textbook style)
+
+### Identity
+Identity is the root of accountability and authentication. ICN uses DID-style
+identifiers derived from Ed25519 keys. This makes identity self-certifying: the
+public key is the identity.
+
+### Key storage
+Private keys are stored in an encrypted keystore. The keystore is unlocked at
+startup to obtain an `IdentityBundle`, which is then used for signing and TLS
+binding.
+
+### Trust graph
+Trust is modeled as a weighted graph of social edges. Trust scores influence
+rate limits, access control, and other policy decisions. This aligns system
+behavior with community relationships rather than global consensus.
+
+### Identity and trust flow (diagram)
+```mermaid
+flowchart TD
+  keystore[KeyStore] --> bundle[IdentityBundle]
+  bundle --> sign[Signing]
+  bundle --> tls[DidTlsBinding]
+  trustEdges[TrustEdges] --> trustGraph[TrustGraph]
+  trustGraph --> policies[PolicyDecisions]
+```
+
+## Detailed walkthrough (identity lifecycle)
+
+### 1) Identity creation
+An operator initializes identity via `icnctl id init`, which generates a keypair
+and writes an encrypted keystore.
+
+### 2) Keystore unlock at startup
+`icnd` loads the keystore from the data directory and unlocks it using a
+passphrase. The result is an `IdentityBundle` (DID + keypair + metadata).
+
+### 3) Identity usage
+The identity bundle is used for:
+- signing messages
+- DID‑TLS binding for transport
+- authoring ledger entries and contracts
+
+## Detailed walkthrough (trust usage)
+
+### 1) Trust graph maintenance
+Trust edges are stored and updated through trust services. They may be modified
+via governance or operator tools.
+
+### 2) Trust in enforcement
+Trust scores are consulted by subsystems for:
+- rate limiting and admission control
+- topic subscription policies
+- ledger acceptance thresholds (optional)
+
+## Failure modes and safeguards
+- **Missing keystore**: daemon starts in limited mode and logs warnings.
+- **Invalid passphrase**: keystore remains locked and identity is unavailable.
+- **Low trust**: peers may be rate‑limited or denied access to topics.
+
+## Code map
+- `icn/crates/icn-identity/src/keystore.rs`:
+  keystore persistence and unlock flow.
+- `icn/crates/icn-identity/src/bundle.rs`:
+  `IdentityBundle` aggregates DID, keypair, and metadata.
+- `icn/crates/icn-trust/src/types.rs` and `icn/crates/icn-trust/src/lib.rs`:
+  trust graph types and public API.
+
+## Reference files (follow-up)
+- `icn/crates/icn-identity/src/keystore.rs`
+- `icn/crates/icn-identity/src/bundle.rs`
+- `icn/crates/icn-identity/src/multi_device.rs`
+- `icn/crates/icn-trust/src/lib.rs`
+- `icn/crates/icn-trust/src/types.rs`
+- `docs/multi-device-identity-design.md`
+
+## Exercises
+- Locate the DID type and key storage in `icn-identity`
+- Find where trust scores are used to gate behavior
+
+## Checkpoints
+- You can explain DID format and key storage
+- You can describe how trust influences system behavior

--- a/docs/onboarding/modules/module-05-network-gossip.md
+++ b/docs/onboarding/modules/module-05-network-gossip.md
@@ -1,0 +1,107 @@
+# Module 5: Network and Gossip
+
+## Objectives
+- Understand transport vs gossip responsibilities
+- Understand topic subscriptions and message routing
+
+## Prerequisites
+- Module 4
+
+## Key reading
+- `icn/crates/icn-net/`
+- `icn/crates/icn-gossip/`
+- `docs/ARCHITECTURE.md` (Network, Gossip)
+- `docs/gossip-signed-envelope-migration.md`
+
+## Walkthrough
+Transport provides secure sessions and peer discovery. Gossip handles topic-
+based sync and anti-entropy. Together they move data between nodes.
+
+## Concepts (textbook style)
+
+### Transport vs gossip
+Transport is responsible for connectivity and secure sessions (QUIC/TLS, peer
+discovery, and message integrity). Gossip is responsible for data movement and
+convergence: it disseminates entries, handles anti-entropy, and enforces topic
+policies.
+
+### Topics and subscriptions
+Gossip is organized around topics. Nodes subscribe to topics to receive relevant
+updates. This allows coarse access control and reduces bandwidth for unrelated
+data.
+
+### Message routing (diagram)
+```mermaid
+flowchart TD
+  net[NetworkActor] --> handler[IncomingHandler]
+  handler --> gossip[GossipActor]
+  gossip --> topics[Topics]
+  gossip --> subs[Subscriptions]
+  gossip --> peers[PeerSync]
+```
+
+## Detailed walkthrough (message to gossip)
+
+### 1) Transport receives a network message
+The network actor receives a `NetworkMessage` from a peer. This layer already
+handles connection security and message integrity.
+
+### 2) Incoming handler routes by payload type
+The Supervisor wires a message handler that inspects the payload:
+- `Gossip` payloads are forwarded to `GossipActor::handle_message`
+- `Subscribe` / `Unsubscribe` update topic membership
+- Signed envelopes are decoded and routed by payload type
+
+### 3) Gossip validates and applies
+The gossip actor checks topic access and message structure, then updates:
+- topic state
+- entry sets and bloom filters
+- per‑peer sync state
+
+### 4) Notify subscribers
+If the message changes topic state, subscribers are notified and sync continues.
+
+## Detailed walkthrough (subscriptions)
+
+1. Peer sends `Subscribe { topics }`
+2. Gossip updates subscription lists
+3. Optional `SubscribeAck` is returned
+4. Future entries in those topics are forwarded to the subscriber
+
+## Anti‑entropy and convergence
+Gossip uses anti‑entropy exchanges to reconcile missing entries. This is how
+nodes converge even after temporary disconnects or partitions.
+
+## Failure modes and safeguards
+- **Unauthorized subscriptions** are rejected based on access policies.
+- **Invalid payloads** are dropped or logged.
+- **Partition detection** triggers healing strategies when enabled.
+
+### Flow breakdown
+1. Network actor receives a `NetworkMessage`
+2. Incoming handler routes payloads to gossip
+3. Gossip validates and applies message to topic state
+4. Notifications and subscriptions are updated
+
+## Code map
+- `icn/crates/icn-core/src/supervisor/init_network.rs`:
+  `create_incoming_handler` routes `MessagePayload::Gossip`, `Subscribe`, and
+  `Unsubscribe` into `GossipActor`.
+- `icn/crates/icn-gossip/src/gossip.rs`:
+  `GossipActor::handle_message` processes incoming gossip messages.
+- `icn/crates/icn-gossip/src/gossip.rs`:
+  `GossipActor::subscribe` and `GossipActor::unsubscribe` manage topic listeners.
+
+## Reference files (follow-up)
+- `icn/crates/icn-net/`
+- `icn/crates/icn-gossip/src/gossip.rs`
+- `icn/crates/icn-core/src/supervisor/init_network.rs`
+- `docs/gossip-signed-envelope-migration.md`
+
+## Exercises
+- Find where incoming network messages are routed to gossip
+- Identify how topic subscriptions are created and used
+
+## Checkpoints
+- You can describe the difference between transport and gossip
+- You can explain how a message is accepted and routed

--- a/docs/onboarding/modules/module-05-network-gossip.md
+++ b/docs/onboarding/modules/module-05-network-gossip.md
@@ -77,6 +77,52 @@ nodes converge even after temporary disconnects or partitions.
 - **Invalid payloads** are dropped or logged.
 - **Partition detection** triggers healing strategies when enabled.
 
+## Annotated code excerpts
+
+### Incoming handler routes network payloads
+Source: `icn/crates/icn-core/src/supervisor/init_network.rs`
+```rust
+match net_msg.payload {
+    icn_net::MessagePayload::Gossip(gossip_msg) => {
+        let gossip = gossip_handle.clone();
+        let sender = sender_did.clone();
+        tokio::spawn(async move {
+            let mut gossip = gossip.write().await;
+            if let Err(e) = gossip.handle_message(&sender, gossip_msg).await {
+                warn!("Failed to handle gossip message: {}", e);
+            }
+        });
+    }
+    icn_net::MessagePayload::Subscribe { topics } => {
+        // Subscribe peers to topics
+    }
+    icn_net::MessagePayload::Unsubscribe { topics } => {
+        // Remove topic subscriptions
+    }
+    _ => { /* other payloads */ }
+}
+```
+This is the routing hub between transport and gossip.
+
+### Gossip validates trust before processing messages
+Source: `icn/crates/icn-gossip/src/gossip.rs`
+```rust
+const MIN_TRUST_FOR_MESSAGE: f64 = 0.1; // Known trust class minimum
+
+if let Some(ref trust_graph) = self.trust_graph {
+    if let Ok(tg) = trust_graph.try_read() {
+        match tg.compute_trust_score(sender) {
+            Ok(score) if score < MIN_TRUST_FOR_MESSAGE => {
+                anyhow::bail!("Message sender {sender} has insufficient trust ({score:.3} < {MIN_TRUST_FOR_MESSAGE:.3})");
+            }
+            Ok(_) => { /* Trust validated */ }
+            Err(e) => { anyhow::bail!("Cannot verify trust for message sender {sender}: {e}"); }
+        }
+    }
+}
+```
+Trust gating makes gossip traffic depend on social/economic/technical trust.
+
 ### Flow breakdown
 1. Network actor receives a `NetworkMessage`
 2. Incoming handler routes payloads to gossip

--- a/docs/onboarding/modules/module-06-ledger-contracts.md
+++ b/docs/onboarding/modules/module-06-ledger-contracts.md
@@ -1,0 +1,148 @@
+# Module 6: Ledger and Contracts
+
+## Objectives
+- Understand mutual credit ledger flow
+- Understand contract runtime integration
+
+## Prerequisites
+- Module 5
+
+## Key reading
+- `icn/crates/icn-ledger/`
+- `icn/crates/icn-ccl/`
+- `docs/ARCHITECTURE.md` (Ledger, Contracts)
+- `docs/governance-primitives.md`
+
+## Walkthrough
+The ledger is a double-entry mutual credit system. Contracts execute with
+capability-based permissions and can write to the ledger.
+
+## Concepts (textbook style)
+
+### Mutual credit ledger
+The ledger records transfers as balanced debit/credit pairs. Every entry is a
+journal record with a cryptographic hash. This provides an auditable history and
+supports replicated state across peers.
+
+### Journal entries
+Journal entries enforce the double-entry invariant: total debits must equal
+total credits per currency. Validation happens before entries are accepted and
+persisted.
+
+### Contracts and capabilities
+Contracts provide programmable rules. Capabilities define what contracts are
+allowed to do. When a contract emits ledger operations, the runtime validates
+them and applies them as ledger entries.
+
+### Ledger flow (diagram)
+```mermaid
+flowchart TD
+  api[GatewayAPI] --> ledgerMgr[LedgerManager]
+  ledgerMgr --> builder[JournalEntryBuilder]
+  builder --> ledger[Ledger]
+  ledger --> store[Storage]
+  ledger --> gossip[Gossip]
+  contracts[ContractRuntime] --> ledger
+```
+
+## Detailed walkthrough (ledger payment path)
+
+### 1) Request enters the system
+A payment commonly enters via the gateway API. The endpoint validates:
+- the caller has `ledger:write` scope
+- the caller’s DID matches the `from` field
+- the coop context matches the request (prevents cross‑coop writes)
+- amount, currency, and memo are valid
+
+These checks happen in the gateway layer, before the ledger is touched.
+
+### 2) Journal entry is built
+The gateway’s `LedgerManager` creates a `JournalEntry` using
+`JournalEntryBuilder`. This enforces:
+- **double‑entry**: debits equal credits per currency
+- **non‑negative**: amounts must be positive
+- **time validity**: timestamps must be valid
+
+The builder computes a content hash so the entry is immutable and auditable.
+
+### 3) Append and persist
+`Ledger::append_entry` persists the entry and updates in‑memory indices. The
+ledger uses:
+- a key/value store for journal entries and indexes
+- cached balances for fast read queries
+- quarantine and fork detectors for safety under divergence
+
+### 4) Gossip replication
+Once appended, the ledger can publish the entry via gossip (when a gossip handle
+is configured). This propagates the update to peers, enabling eventual
+convergence without centralized coordination.
+
+## Detailed walkthrough (contract‑driven transfer)
+
+### 1) Contract execution
+`ContractRuntime::execute_rule` runs the interpreter for a contract rule and
+produces an `ExecutionResult`.
+
+### 2) Ledger operations emitted
+The execution result may include `LedgerOperation`s (e.g., transfers). These
+operations are mapped to journal entries using the same builder and validation
+logic as direct payments.
+
+### 3) Ledger update and replication
+Each operation becomes a journal entry appended to the ledger, which then
+propagates via gossip if configured.
+
+## Key data structures
+
+### JournalEntry
+A signed, hashed record containing:
+- author DID
+- timestamp
+- account deltas (debits/credits)
+- parent hashes (for DAG structure)
+
+### Ledger
+Owns storage, cached balances, and validation hooks. It enforces:
+- trust thresholds (optional)
+- credit policy limits (optional)
+- invariant checks on entries
+
+### ContractRuntime
+Executes contracts and bridges interpreter outputs into ledger entries.
+
+## Failure modes and safeguards
+- **Unbalanced entries** are rejected by the builder.
+- **Invalid DID or currency** is rejected at gateway validation.
+- **Policy violations** (credit limits, freezes) are enforced by ledger managers.
+- **Forks** are detected and resolved through fork detectors and resolvers.
+
+### Flow breakdown
+1. Ledger API or contract runtime builds a `JournalEntry`
+2. Entry validation enforces double-entry invariants
+3. Ledger appends entry and persists state
+4. Gossip publishes updates to peers
+
+## Code map
+- `icn/crates/icn-ledger/src/entry.rs`:
+  `JournalEntryBuilder` builds and validates double-entry invariants.
+- `icn/crates/icn-ledger/src/ledger.rs`:
+  `Ledger::append_entry` persists entries and triggers gossip.
+- `icn/crates/icn-ccl/src/runtime.rs`:
+  `ContractRuntime::execute_rule` applies `LedgerOperation` updates.
+- `icn/crates/icn-gateway/src/ledger_mgr.rs`:
+  `LedgerManager::create_payment` builds a journal entry and appends it.
+
+## Reference files (follow-up)
+- `icn/crates/icn-ledger/src/entry.rs`
+- `icn/crates/icn-ledger/src/ledger.rs`
+- `icn/crates/icn-ledger/src/types.rs`
+- `icn/crates/icn-ccl/src/runtime.rs`
+- `icn/crates/icn-gateway/src/ledger_mgr.rs`
+
+## Exercises
+- Find the ledger actor entry points for creating a payment
+- Trace how contract execution produces ledger effects
+
+## Checkpoints
+- You can describe ledger state changes for a payment
+- You can explain where contracts are executed and authorized

--- a/docs/onboarding/modules/module-06-ledger-contracts.md
+++ b/docs/onboarding/modules/module-06-ledger-contracts.md
@@ -116,6 +116,53 @@ Executes contracts and bridges interpreter outputs into ledger entries.
 - **Policy violations** (credit limits, freezes) are enforced by ledger managers.
 - **Forks** are detected and resolved through fork detectors and resolvers.
 
+## Annotated code excerpts
+
+### JournalEntryBuilder enforces double-entry invariants
+Source: `icn/crates/icn-ledger/src/entry.rs`
+```rust
+pub fn build(self) -> Result<JournalEntry> {
+    // Validate double-entry invariant: Σ debits == Σ credits per currency
+    validate_double_entry(&self.accounts)?;
+    // Validate that amounts are positive
+    validate_positive_amounts(&self.accounts)?;
+    // Get current timestamp in milliseconds
+    let timestamp = icn_time::try_current_timestamp_millis()
+        .map_err(|e| anyhow::anyhow!("Cannot create journal entry: {e}"))?;
+    let mut entry = JournalEntry {
+        id: None,
+        timestamp,
+        author: self.author,
+        contract_ref: self.contract_ref,
+        accounts: self.accounts,
+        parents: self.parents,
+        signature: None,
+    };
+    entry.compute_hash()?;
+    Ok(entry)
+}
+```
+This guarantees all ledger entries are balanced and timestamped before acceptance.
+
+### Contract runtime applies ledger operations
+Source: `icn/crates/icn-ccl/src/runtime.rs`
+```rust
+match op {
+    LedgerOperation::Transfer { from, to, amount, currency } => {
+        let entry = JournalEntryBuilder::new(from.clone())
+            .debit(to.clone(), currency.clone(), *amount)
+            .credit(from.clone(), currency.clone(), *amount)
+            .build()?;
+        ledger.append_entry(entry).await?;
+    }
+    LedgerOperation::SetCreditLimit { .. } => {
+        // Credit limit updates are recorded separately
+    }
+}
+```
+Contract outputs are converted into the same journal entry format as direct API
+payments, keeping the ledger path consistent.
+
 ### Flow breakdown
 1. Ledger API or contract runtime builds a `JournalEntry`
 2. Entry validation enforces double-entry invariants

--- a/docs/onboarding/modules/module-07-gateway-sdk.md
+++ b/docs/onboarding/modules/module-07-gateway-sdk.md
@@ -76,6 +76,42 @@ notifications.
 - **Cross‑coop access**: blocked at request validation.
 - **Self‑payment**: explicitly rejected in the ledger API.
 
+## Annotated code excerpts
+
+### Challenge endpoint creates a nonce and enforces rate limits
+Source: `icn/crates/icn-gateway/src/api/auth.rs`
+```rust
+let client_ip = get_client_ip(&http_req);
+ip_limiter.check_rate_limit(&client_ip)?;
+
+let did = req
+    .did
+    .parse()
+    .map_err(|e| crate::error::GatewayError::BadRequest(format!("Invalid DID: {e}")))?;
+
+let nonce = auth.create_challenge(&did)?;
+```
+Unauthenticated auth endpoints are guarded with IP‑based rate limiting.
+
+### Payment endpoint enforces identity and scope
+Source: `icn/crates/icn-gateway/src/api/ledger.rs`
+```rust
+require_scope(&http_req, "ledger:write")?;
+require_coop_access(&http_req, &coop_id)?;
+
+let claims = get_claims(&http_req).ok_or_else(|| {
+    crate::error::GatewayError::AuthenticationFailed("No claims found".to_string())
+})?;
+
+if claims.sub != req.from {
+    return Err(crate::error::GatewayError::AuthorizationFailed(
+        format!("Cannot create payments from other accounts (authenticated as {}, attempted to send from {})",
+            claims.sub, req.from)
+    ));
+}
+```
+The gateway ensures only the authenticated DID can create payments from itself.
+
 ### Flow breakdown
 1. Client calls `/auth/challenge` to receive a nonce
 2. Client signs nonce with Ed25519 private key
@@ -93,6 +129,13 @@ notifications.
   `LedgerManager::create_payment` bridges API to ledger.
 - `sdk/typescript/README.md`:
   `ICNClient` auth and request patterns.
+
+## Reference files (follow-up)
+- `icn/crates/icn-gateway/src/server.rs`
+- `icn/crates/icn-gateway/src/api/auth.rs`
+- `icn/crates/icn-gateway/src/api/ledger.rs`
+- `icn/crates/icn-gateway/src/ledger_mgr.rs`
+- `sdk/typescript/README.md`
 
 ## Exercises
 - Describe the auth flow from challenge to JWT

--- a/docs/onboarding/modules/module-07-gateway-sdk.md
+++ b/docs/onboarding/modules/module-07-gateway-sdk.md
@@ -1,0 +1,103 @@
+# Module 7: Gateway API and SDK
+
+## Objectives
+- Understand gateway auth flow and scopes
+- Use the TypeScript SDK to call APIs
+
+## Prerequisites
+- Module 6
+
+## Key reading
+- `icn/crates/icn-gateway/README.md`
+- `sdk/typescript/README.md`
+- `docs/api/`
+
+## Walkthrough
+The gateway exposes REST and WebSocket APIs with JWT auth. The SDK implements
+challenge/verify and common ledger, coop, and governance operations.
+
+## Concepts (textbook style)
+
+### Gateway as system boundary
+The gateway is the primary integration surface for apps. It translates HTTP
+requests into ICN operations and enforces auth, rate limits, and scopes. This
+keeps core runtime concerns isolated from external clients.
+
+### Authentication flow
+Authentication is DID-based: a client requests a challenge, signs it with its
+private key, and exchanges the signature for a JWT. The JWT carries scopes and
+cooperative context.
+
+### SDK role
+The TypeScript SDK encapsulates the gateway protocol and makes client usage
+consistent across applications.
+
+## Detailed walkthrough (auth flow)
+
+### 1) Challenge request
+Client calls `/auth/challenge` with a DID. The gateway:
+- validates DID formatting
+- applies IP‑based rate limiting for unauthenticated calls
+- returns a nonce with a short expiry
+
+### 2) Challenge verification
+Client signs the nonce with its Ed25519 private key and posts `/auth/verify`.
+The gateway:
+- validates scopes and coop ID
+- verifies signature length and content
+- issues a JWT with requested scopes
+
+### 3) Authenticated requests
+Clients include `Authorization: Bearer <token>` to call protected endpoints.
+
+## Detailed walkthrough (ledger payment)
+
+### 1) Authorization
+Gateway validates scope and coop context, then verifies the authenticated DID
+matches the payment sender.
+
+### 2) Input validation
+Payment amount, currency, and memo are validated before touching the ledger.
+
+### 3) Rate limiting and budgets
+Velocity limits and optional budget constraints are applied.
+
+### 4) Ledger write
+The gateway calls `LedgerManager::create_payment`, which builds a journal entry
+and appends it to the ledger.
+
+### 5) Events and notifications
+On success, the gateway publishes events to WebSocket subscribers and triggers
+notifications.
+
+## Failure modes and safeguards
+- **Invalid DID or signature**: rejected before token issuance.
+- **Scope violations**: request is denied by middleware.
+- **Cross‑coop access**: blocked at request validation.
+- **Self‑payment**: explicitly rejected in the ledger API.
+
+### Flow breakdown
+1. Client calls `/auth/challenge` to receive a nonce
+2. Client signs nonce with Ed25519 private key
+3. Client posts `/auth/verify` to receive JWT
+4. Client calls protected endpoints with `Authorization: Bearer <token>`
+
+## Code map
+- `icn/crates/icn-gateway/src/server.rs`:
+  `GatewayServer` builds Actix app and wires routes and middleware.
+- `icn/crates/icn-gateway/src/api/auth.rs`:
+  `challenge` and `verify` implement auth flow.
+- `icn/crates/icn-gateway/src/api/ledger.rs`:
+  `create_payment` and `get_balance` implement ledger endpoints.
+- `icn/crates/icn-gateway/src/ledger_mgr.rs`:
+  `LedgerManager::create_payment` bridges API to ledger.
+- `sdk/typescript/README.md`:
+  `ICNClient` auth and request patterns.
+
+## Exercises
+- Describe the auth flow from challenge to JWT
+- Use the SDK to call health and balance endpoints
+
+## Checkpoints
+- You can explain the gateway auth flow
+- You can call an API using the SDK

--- a/docs/onboarding/modules/module-08-web-ui.md
+++ b/docs/onboarding/modules/module-08-web-ui.md
@@ -63,6 +63,34 @@ WebSocket for real‑time events.
 - **Auth failure**: login fails and displays a user‑friendly message.
 - **Expired token**: UI warns and requires re‑authentication.
 
+## Annotated code excerpts
+
+### Login validates inputs and persists session
+Source: `web/pilot-ui/app.js`
+```javascript
+state.gatewayUrl = elements.gatewayUrl.value.trim().replace(/\/$/, '');
+state.coopId = elements.coopId.value.trim();
+state.did = elements.did.value.trim();
+state.token = elements.token.value.trim();
+
+if (!state.gatewayUrl || !state.coopId || !state.did || !state.token) {
+    showError(elements.loginError, 'Please fill in all fields');
+    return;
+}
+
+await apiRequest('GET', '/health');
+await apiRequest('GET', `/ledger/${state.coopId}/balance/${encodeURIComponent(state.did)}`);
+
+state.tokenExpiry = Date.now() + (24 * 60 * 60 * 1000);
+localStorage.setItem('icn-gateway', state.gatewayUrl);
+localStorage.setItem('icn-coop', state.coopId);
+localStorage.setItem('icn-did', state.did);
+localStorage.setItem('icn-token', state.token);
+localStorage.setItem('icn-token-expiry', state.tokenExpiry.toString());
+```
+The UI performs a health check and a balance check to confirm auth before
+persisting session data.
+
 ## Code map
 - `web/pilot-ui/index.html`: app entry and layout.
 - `web/pilot-ui/app.js`: gateway interaction and core UI logic.

--- a/docs/onboarding/modules/module-08-web-ui.md
+++ b/docs/onboarding/modules/module-08-web-ui.md
@@ -1,0 +1,84 @@
+# Module 8: Web UI Integration
+
+## Objectives
+- Understand how the Pilot UI connects to ICN
+- Trace how UI actions map to gateway APIs
+
+## Prerequisites
+- Module 7
+
+## Key reading
+- `web/pilot-ui/README.md`
+- `web/pilot-ui/GETTING-STARTED.md`
+- `web/pilot-ui/SUMMARY.md`
+
+## Walkthrough
+The Pilot UI is a static web app that talks to the gateway using JWTs. It
+surfaces ledger activity, membership, and governance operations.
+
+## Concepts (textbook style)
+
+### UI as client of the gateway
+The Pilot UI is a thin client: it does not implement ICN logic. Instead, it
+authenticates with the gateway and renders responses. This separation keeps the
+UI simple and the ICN substrate authoritative.
+
+### Session and token handling
+The UI stores the JWT and attaches it to requests. Token expiry handling is a
+core UX concern because it determines when users must re-authenticate.
+
+### UI data flow (diagram)
+```mermaid
+flowchart TD
+  user[User] --> ui[PilotUI]
+  ui --> gateway[GatewayApi]
+  gateway --> ledger[LedgerData]
+  gateway --> members[Members]
+  gateway --> governance[Governance]
+  gateway --> ws[WebSocketEvents]
+  ws --> ui
+```
+
+## Detailed walkthrough (login and data flow)
+
+### 1) User inputs connection details
+The user provides gateway URL, coop ID, DID, and JWT. These are stored in
+in‑memory state and validated for presence.
+
+### 2) Connection verification
+The UI validates connectivity by calling:
+- `GET /health` (gateway liveness)
+- `GET /ledger/{coopId}/balance/{did}` (auth check)
+
+### 3) Session persistence
+On success, the UI stores gateway URL, coop ID, DID, token, and token expiry in
+`localStorage` for persistence across reloads.
+
+### 4) Data loading and live updates
+The UI loads balance, members, transactions, and proposals, then connects a
+WebSocket for real‑time events.
+
+## Failure modes and safeguards
+- **Missing fields**: login is blocked with a friendly error.
+- **Auth failure**: login fails and displays a user‑friendly message.
+- **Expired token**: UI warns and requires re‑authentication.
+
+## Code map
+- `web/pilot-ui/index.html`: app entry and layout.
+- `web/pilot-ui/app.js`: gateway interaction and core UI logic.
+- `web/pilot-ui/components/`: feature-level UI modules.
+
+## Reference files (follow-up)
+- `web/pilot-ui/index.html`
+- `web/pilot-ui/app.js`
+- `web/pilot-ui/README.md`
+- `web/pilot-ui/GETTING-STARTED.md`
+- `web/pilot-ui/SUMMARY.md`
+
+## Exercises
+- Identify how the UI obtains and stores the JWT
+- Map UI actions to gateway endpoints
+
+## Checkpoints
+- You can explain the UI login flow
+- You can trace a UI action to a gateway API call

--- a/docs/onboarding/modules/module-09-ops-deploy.md
+++ b/docs/onboarding/modules/module-09-ops-deploy.md
@@ -1,0 +1,87 @@
+# Module 9: Operations and Deployment
+
+## Objectives
+- Understand configuration and deployment options
+- Understand observability and hardening basics
+
+## Prerequisites
+- Module 8
+
+## Key reading
+- `deploy/README.md`
+- `config/README.md`
+- `docs/production-hardening.md`
+- `docs/ops/`
+
+## Walkthrough
+ICN supports native, Docker, and Kubernetes deployment. Configuration is layered
+and can be validated before startup. Observability includes metrics and health
+endpoints.
+
+## Concepts (textbook style)
+
+### Configuration layering
+ICN loads defaults, then file config, then environment overrides, then CLI flags.
+This allows a safe baseline with flexible overrides for deployment environments.
+
+### Configuration precedence (diagram)
+```mermaid
+flowchart TD
+  defaults[Defaults] --> fileConfig[ConfigFile]
+  fileConfig --> env[EnvOverrides]
+  env --> cli[CliFlags]
+```
+
+### Observability
+Metrics and health endpoints are required for production readiness. They provide
+insight into node liveness and subsystem behavior.
+
+### Deployment models
+Native, Docker, and Kubernetes deployments serve different operational needs.
+The core runtime remains the same; only the surrounding infrastructure changes.
+
+### Deployment options (diagram)
+```mermaid
+flowchart TD
+  icnd[icnd] --> native[NativeSystemd]
+  icnd --> compose[DockerCompose]
+  icnd --> k8s[Kubernetes]
+```
+
+## Detailed walkthrough (config and validation)
+
+### 1) Choose a config file
+Start from `config/icn.toml.example` or the minimal template and customize
+network ports, data directory, and gateway settings.
+
+### 2) Validate before running
+Use `icnd --validate-config` to catch missing or invalid configuration early.
+
+### 3) Start the daemon
+Run `icnd` with `--config` and check logs for initialization warnings.
+
+### 4) Verify health and metrics
+Check `/health` and `/metrics` endpoints to confirm liveness and observability.
+
+## Code map
+- `deploy/README.md`: deployment options and quickstart.
+- `deploy/docker-compose.yml`: local stack composition.
+- `config/icn.toml.example`: full config reference.
+- `docs/production-hardening.md`: security and hardening guidance.
+
+## Reference files (follow-up)
+- `deploy/README.md`
+- `deploy/docker-compose.yml`
+- `deploy/kubernetes/`
+- `deploy/helm/`
+- `config/README.md`
+- `config/icn.toml.example`
+- `docs/production-hardening.md`
+
+## Exercises
+- Validate a config file with `--validate-config`
+- Identify the ports used for transport, RPC, metrics, and health
+
+## Checkpoints
+- You can explain config precedence
+- You can describe how to deploy locally with Docker

--- a/docs/onboarding/modules/module-09-ops-deploy.md
+++ b/docs/onboarding/modules/module-09-ops-deploy.md
@@ -63,6 +63,33 @@ Run `icnd` with `--config` and check logs for initialization warnings.
 ### 4) Verify health and metrics
 Check `/health` and `/metrics` endpoints to confirm liveness and observability.
 
+## Annotated code excerpts
+
+### Config precedence is explicit
+Source: `config/README.md`
+```md
+ICN reads configuration in this order (later sources override earlier):
+1. Built-in defaults
+2. Config file (if specified with `--config`)
+3. `~/.icn/icn.toml` (if exists and no `--config`)
+4. Environment variables
+5. CLI flags
+```
+This ordering guarantees predictable overrides across environments.
+
+### Runtime validation blocks unsafe configs
+Source: `icn/bins/icnd/src/main.rs`
+```rust
+if args.validate_config {
+    println!("Validating configuration...\n");
+    match config.validate() {
+        Ok(warnings) => { /* print warnings, exit 0 */ }
+        Err(errors) => { /* print errors, exit 1 */ }
+    }
+}
+```
+Operators can verify configuration before startup to avoid unsafe runtime states.
+
 ## Code map
 - `deploy/README.md`: deployment options and quickstart.
 - `deploy/docker-compose.yml`: local stack composition.

--- a/docs/onboarding/modules/module-10-contributor-workflow.md
+++ b/docs/onboarding/modules/module-10-contributor-workflow.md
@@ -1,0 +1,75 @@
+# Module 10: Contributor Workflow
+
+## Objectives
+- Understand tests, linting, and CI expectations
+- Follow the repo contribution process
+
+## Prerequisites
+- Module 9
+
+## Key reading
+- `CONTRIBUTING.md`
+- `docs/testing/`
+- `docs/ci/`
+
+## Walkthrough
+ICN uses a standard Rust workflow with formatting, linting, and tests. CI
+enforces checks for core crates and integration points.
+
+## Concepts (textbook style)
+
+### Contribution discipline
+The contribution workflow ensures changes remain safe and reviewable. Formatting
+and linting enforce consistency; tests validate behavior; CI provides a shared
+gate for quality.
+
+### Test scope
+Tests are scoped by crate and feature area. Understanding where a change lands
+helps decide which tests are required before review.
+
+### Contribution loop (diagram)
+```mermaid
+flowchart TD
+  plan[PlanChange] --> code[Implement]
+  code --> checks[LocalChecks]
+  checks --> docs[DocsUpdate]
+  docs --> pr[SubmitPR]
+  pr --> review[Review]
+  review --> merge[Merge]
+```
+
+## Detailed walkthrough (contribution loop)
+
+### 1) Prepare the change
+Create a small, focused diff aligned with an issue or decision.
+
+### 2) Run local checks
+Use `cargo fmt`, `cargo clippy`, and relevant tests for impacted crates.
+
+### 3) Verify documentation
+If the change affects behavior or public APIs, update docs and onboarding
+materials (see `docs/onboarding/update-process.md`).
+
+### 4) Submit for review
+Follow the PR checklist in `CONTRIBUTING.md`, including test results and
+motivation.
+
+## Code map
+- `CONTRIBUTING.md`: contribution process and expectations.
+- `docs/testing/TESTING_QUICKSTART.md`: test suite guidance.
+- `docs/ci/`: CI status and reports.
+
+## Reference files (follow-up)
+- `CONTRIBUTING.md`
+- `docs/testing/TESTING_QUICKSTART.md`
+- `docs/testing/`
+- `docs/ci/`
+- `docs/onboarding/update-process.md`
+
+## Exercises
+- Run `cargo fmt` and `cargo clippy` (if tooling is installed)
+- Identify which tests to run for a change in `icn-core`
+
+## Checkpoints
+- You can describe the PR checklist
+- You can identify the right test scope for a change

--- a/docs/onboarding/modules/module-10-contributor-workflow.md
+++ b/docs/onboarding/modules/module-10-contributor-workflow.md
@@ -54,14 +54,44 @@ materials (see `docs/onboarding/update-process.md`).
 Follow the PR checklist in `CONTRIBUTING.md`, including test results and
 motivation.
 
+## Annotated code excerpts
+
+### Local quality gates before pushing
+Source: `CONTRIBUTING.md`
+```bash
+# Run tests
+cargo test --workspace
+
+# Run clippy (linter)
+cargo clippy --workspace --all-targets
+
+# Check formatting
+cargo fmt --all -- --check
+```
+These commands are the minimum expected checks before submitting a PR.
+
+### Quick verification for security-critical areas
+Source: `docs/testing/TESTING_SUMMARY.md`
+```bash
+# Test scope allowlist
+cargo test -p icn-gateway --test scope_validation_integration
+
+# Test TLS config
+cargo test -p icn-net --lib test_create
+
+# Verify build
+cargo check --release
+```
+This is a fast path for validating key security invariants.
+
 ## Code map
 - `CONTRIBUTING.md`: contribution process and expectations.
-- `docs/testing/TESTING_QUICKSTART.md`: test suite guidance.
+- `docs/testing/TESTING_SUMMARY.md`: test suite guidance.
 - `docs/ci/`: CI status and reports.
 
 ## Reference files (follow-up)
 - `CONTRIBUTING.md`
-- `docs/testing/TESTING_QUICKSTART.md`
+- `docs/testing/TESTING_SUMMARY.md`
 - `docs/testing/`
 - `docs/ci/`
 - `docs/onboarding/update-process.md`

--- a/docs/onboarding/reading-map.md
+++ b/docs/onboarding/reading-map.md
@@ -1,0 +1,62 @@
+# Reading Map
+
+This map links each module to the highest-signal files and docs.
+
+## Module 0: Setup and tooling
+- `README.md`
+- `docs/DEV_ENVIRONMENT.md`
+- `CONTRIBUTING.md`
+- `scripts/dev-setup.sh`
+
+## Module 1: Rust fundamentals
+- `icn/` crate structure
+- `icn/crates/*/src/lib.rs` (public APIs)
+
+## Module 2: ICN architecture overview
+- `docs/ARCHITECTURE.md`
+- `docs/README.md`
+- `docs/architecture/`
+
+## Module 3: Runtime and actor model
+- `icn/bins/icnd/src/main.rs`
+- `icn/crates/icn-core/src/runtime.rs`
+- `icn/crates/icn-core/src/supervisor/mod.rs`
+
+## Module 4: Identity and trust
+- `icn/crates/icn-identity/`
+- `icn/crates/icn-trust/`
+- `docs/ARCHITECTURE.md` (Identity, Trust sections)
+- `docs/multi-device-identity-design.md`
+
+## Module 5: Network and gossip
+- `icn/crates/icn-net/`
+- `icn/crates/icn-gossip/`
+- `docs/ARCHITECTURE.md` (Network, Gossip sections)
+- `docs/gossip-signed-envelope-migration.md`
+
+## Module 6: Ledger and contracts
+- `icn/crates/icn-ledger/`
+- `icn/crates/icn-ccl/`
+- `docs/ARCHITECTURE.md` (Ledger, Contracts sections)
+- `docs/governance-primitives.md`
+
+## Module 7: Gateway API and SDK
+- `icn/crates/icn-gateway/README.md`
+- `sdk/typescript/README.md`
+- `docs/api/`
+
+## Module 8: Web UI integration
+- `web/pilot-ui/README.md`
+- `web/pilot-ui/GETTING-STARTED.md`
+- `web/pilot-ui/SUMMARY.md`
+
+## Module 9: Operations and deployment
+- `deploy/README.md`
+- `config/README.md`
+- `docs/production-hardening.md`
+- `docs/ops/`
+
+## Module 10: Contributor workflow
+- `CONTRIBUTING.md`
+- `docs/CI_ALL_GREEN_REPORT.md`
+- `docs/testing/`

--- a/docs/onboarding/reading-map.md
+++ b/docs/onboarding/reading-map.md
@@ -58,5 +58,5 @@ This map links each module to the highest-signal files and docs.
 
 ## Module 10: Contributor workflow
 - `CONTRIBUTING.md`
-- `docs/CI_ALL_GREEN_REPORT.md`
+- `docs/ci/CI_ALL_GREEN_REPORT.md`
 - `docs/testing/`

--- a/docs/onboarding/review-plan.md
+++ b/docs/onboarding/review-plan.md
@@ -1,0 +1,26 @@
+# Curriculum Gap Analysis and Iteration Plan
+
+## Gap analysis checklist
+- Core runtime: `icnd` -> `Runtime` -> `Supervisor`
+- Identity and trust: DID, keystore, trust graph, policy usage
+- Network and gossip: transport, routing, topic subscriptions
+- Ledger and contracts: mutual credit and CCL execution
+- Gateway and SDK: auth, scopes, client usage
+- Web UI: pilot workflow and token handling
+- Ops: configuration, observability, deployment
+- Contributor workflow: tests, linting, CI expectations
+
+## Known gaps to validate
+- Specific ledger data model types and storage layout
+- Error handling patterns across actors
+- Testing conventions for each crate
+- Security model details beyond the architecture doc
+
+## Iteration plan
+1. After each cohort, collect feedback by module.
+2. Add a short troubleshooting section per module.
+3. Add diagrams for the top 3 confusing flows:
+   - Auth challenge/verify
+   - Gossip propagation
+   - Ledger transaction lifecycle
+4. Review docs quarterly to align with code changes.

--- a/docs/onboarding/syllabus.md
+++ b/docs/onboarding/syllabus.md
@@ -1,0 +1,37 @@
+# Syllabus
+
+This syllabus is split into two tracks:
+- Foundations: new to Rust, learn Rust and ICN together
+- Accelerated: Rust-intermediate, focus on ICN systems and advanced Rust
+
+Time estimates are per module. Total target: 3-6 weeks.
+
+| Module | Topic | Foundations | Accelerated |
+| --- | --- | --- | --- |
+| 0 | Setup and tooling | 0.5 day | 0.5 day |
+| 1 | Rust fundamentals | 4-5 days | 1-2 days |
+| 2 | ICN architecture overview | 1 day | 0.5 day |
+| 3 | Runtime and actor model | 2 days | 1 day |
+| 4 | Identity and trust | 2 days | 1 day |
+| 5 | Network and gossip | 2 days | 1 day |
+| 6 | Ledger and contracts | 2-3 days | 1-2 days |
+| 7 | Gateway API and SDK | 1-2 days | 1 day |
+| 8 | Web UI integration | 1 day | 0.5 day |
+| 9 | Operations and deployment | 1-2 days | 1 day |
+| 10 | Contributor workflow | 1 day | 0.5 day |
+
+## Weekly pacing examples
+
+### Foundations (5-6 weeks)
+- Week 1: Modules 0-1
+- Week 2: Modules 2-3
+- Week 3: Modules 4-5
+- Week 4: Module 6
+- Week 5: Modules 7-8
+- Week 6: Modules 9-10 + capstone
+
+### Accelerated (3-4 weeks)
+- Week 1: Modules 0-3
+- Week 2: Modules 4-6
+- Week 3: Modules 7-8
+- Week 4: Modules 9-10 + capstone

--- a/docs/onboarding/tracks/accelerated.md
+++ b/docs/onboarding/tracks/accelerated.md
@@ -1,0 +1,18 @@
+# Accelerated Track
+
+For developers already comfortable with Rust and async systems. Focus on ICN
+architecture, code paths, and system behavior.
+
+## Prerequisites
+- Solid Rust fundamentals
+- Familiarity with Tokio or async runtimes
+- Experience reading multi-crate Rust projects
+
+## Focus areas
+- Runtime orchestration and actor model
+- Protocol surfaces and message flow
+- Storage, replication, and fault handling
+- Gateway, SDK, and UI integration
+
+## Suggested pacing
+Follow the schedule in `../syllabus.md` with deeper dives in Modules 3-6.

--- a/docs/onboarding/tracks/foundations.md
+++ b/docs/onboarding/tracks/foundations.md
@@ -1,0 +1,22 @@
+# Foundations Track
+
+For developers new to Rust. Focus on fundamentals while learning ICN systems.
+
+## Prerequisites
+- Familiarity with at least one programming language
+- Comfort with command line basics
+
+## Focus areas
+- Rust ownership/borrowing, traits, and error handling
+- Async fundamentals with Tokio
+- Reading and navigating a large Rust codebase
+- Mapping architecture docs to code
+
+## Suggested pacing
+Follow the schedule in `../syllabus.md` with extra time for Modules 1, 3, and 6.
+
+## Rust learning checkpoints
+- Write small CLI utilities in Rust
+- Explain and use `Result`, `Option`, and `?`
+- Understand `Arc`, `Mutex`, and async tasks
+- Read and reason about lifetimes in signatures

--- a/docs/onboarding/update-process.md
+++ b/docs/onboarding/update-process.md
@@ -1,0 +1,31 @@
+# Curriculum Update Process
+
+This process keeps onboarding content aligned with code changes and flags
+lessons that need review.
+
+## When to update
+- Any change to code paths referenced in `docs/onboarding/` should trigger a
+  review of the related module.
+- API surface changes (gateway, SDK) require module 7 review.
+- Runtime or actor initialization changes require module 3 review.
+
+## Automated flagging
+Use the script `scripts/check-onboarding-maps.sh` in CI or locally. It:
+- scans onboarding docs for backticked file paths
+- fails if referenced files are missing
+- flags if referenced files changed in the current git diff
+
+Example:
+```bash
+./scripts/check-onboarding-maps.sh origin/main
+```
+
+## Manual review checklist
+- Verify module objectives still match code behavior
+- Confirm key reading links are valid
+- Re-run exercises to ensure they still work
+- Update any code references in lessons
+
+## Ownership
+- Each module should have an owner in sprint planning
+- Owners review their modules when related crates change

--- a/docs/onboarding/workshops/workshop-00-setup.md
+++ b/docs/onboarding/workshops/workshop-00-setup.md
@@ -1,0 +1,14 @@
+# Workshop 0: Local Build and Repo Orientation
+
+## Goal
+Build ICN locally and identify key directories and binaries.
+
+## Steps
+1. Run `./scripts/dev-setup.sh` if needed.
+2. Build the workspace: `cd icn && cargo build --release`
+3. Locate binaries in `icn/target/release/`
+4. Skim `README.md` and `docs/ARCHITECTURE.md`
+
+## Checkpoints
+- `icnd` and `icnctl` are built
+- You can point to the crates directory and name at least five crates

--- a/docs/onboarding/workshops/workshop-03-runtime.md
+++ b/docs/onboarding/workshops/workshop-03-runtime.md
@@ -1,0 +1,15 @@
+# Workshop 3: Startup Path Walkthrough
+
+## Goal
+Trace the daemon startup path and identify actor initialization order.
+
+## Steps
+1. Open `icn/bins/icnd/src/main.rs`
+2. Identify config loading and validation flow
+3. Open `icn/crates/icn-core/src/runtime.rs`
+4. Open `icn/crates/icn-core/src/supervisor/mod.rs`
+5. List the order of subsystem initialization
+
+## Checkpoints
+- You can explain where the keystore is opened
+- You can describe the order of trust, gossip, ledger, and network init

--- a/docs/onboarding/workshops/workshop-05-network-gossip.md
+++ b/docs/onboarding/workshops/workshop-05-network-gossip.md
@@ -1,0 +1,13 @@
+# Workshop 5: Message Flow Across Network and Gossip
+
+## Goal
+Understand how a message moves from transport to gossip.
+
+## Steps
+1. Find the incoming handler wiring in `icn-core` supervisor
+2. Locate the gossip message handling entry point in `icn-gossip`
+3. Identify how topics and subscriptions are checked
+
+## Checkpoints
+- You can describe the bridge between network and gossip
+- You can explain where topic filtering occurs

--- a/docs/onboarding/workshops/workshop-06-ledger-contracts.md
+++ b/docs/onboarding/workshops/workshop-06-ledger-contracts.md
@@ -1,0 +1,14 @@
+# Workshop 6: Ledger and Contract Flow
+
+## Goal
+Trace a ledger payment flow and identify contract runtime touchpoints.
+
+## Steps
+1. Locate ledger actor entry points in `icn-ledger`
+2. Identify how ledger writes are validated
+3. Locate the contract runtime in `icn-ccl`
+4. Trace how a contract can affect ledger state
+
+## Checkpoints
+- You can describe the steps of a ledger payment
+- You can identify where contract execution is triggered

--- a/docs/onboarding/workshops/workshop-07-gateway-sdk.md
+++ b/docs/onboarding/workshops/workshop-07-gateway-sdk.md
@@ -1,0 +1,14 @@
+# Workshop 7: Gateway Auth and SDK Usage
+
+## Goal
+Authenticate against the gateway and perform a ledger read.
+
+## Steps
+1. Read the gateway auth flow in `icn/crates/icn-gateway/README.md`
+2. Use the SDK example in `sdk/typescript/README.md`
+3. Request a challenge, sign it, and verify for a token
+4. Use the token to call a ledger balance endpoint
+
+## Checkpoints
+- You can obtain a JWT token
+- You can successfully call a protected endpoint

--- a/docs/onboarding/workshops/workshop-09-ops.md
+++ b/docs/onboarding/workshops/workshop-09-ops.md
@@ -1,0 +1,14 @@
+# Workshop 9: Local Deployment and Observability
+
+## Goal
+Run a local deployment and verify health and metrics endpoints.
+
+## Steps
+1. Review `deploy/README.md` and `config/README.md`
+2. Start ICN with Docker Compose or native run
+3. Verify health: `curl http://localhost:8080/health` (or configured port)
+4. Verify metrics: `curl http://localhost:9100/metrics`
+
+## Checkpoints
+- You can explain the deployment option you used
+- You can confirm health and metrics endpoints are reachable

--- a/scripts/check-onboarding-maps.sh
+++ b/scripts/check-onboarding-maps.sh
@@ -8,13 +8,15 @@ if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
   exit 2
 fi
 
+export BASE_REF
+
 python3 - <<'PY'
 import os
 import re
 import subprocess
 import sys
 
-base_ref = sys.argv[1]
+base_ref = os.environ.get('BASE_REF', 'HEAD~1')
 
 def run(cmd):
     return subprocess.check_output(cmd, text=True).strip()
@@ -41,7 +43,7 @@ if missing:
         print(f"  - {p}")
     sys.exit(1)
 
-changed = run(["git", "diff", "--name-only", f"{base_ref}...HEAD"]).splitlines()
+changed = run(["git", "diff", "--name-only", f"{base_ref}..HEAD"]).splitlines()
 changed_set = set(changed)
 
 impacted = sorted([p for p in paths if p in changed_set])
@@ -52,4 +54,4 @@ if impacted:
     sys.exit(1)
 
 print("Onboarding mapping check passed.")
-PY "$BASE_REF"
+PY

--- a/scripts/check-onboarding-maps.sh
+++ b/scripts/check-onboarding-maps.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${1:-HEAD~1}"
+
+if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+  echo "Base ref '$BASE_REF' not found. Pass a valid ref." >&2
+  exit 2
+fi
+
+python3 - <<'PY'
+import os
+import re
+import subprocess
+import sys
+
+base_ref = sys.argv[1]
+
+def run(cmd):
+    return subprocess.check_output(cmd, text=True).strip()
+
+onboarding_root = "docs/onboarding"
+paths = set()
+
+path_re = re.compile(r"`([^`]+)`")
+
+for root, _, files in os.walk(onboarding_root):
+    for name in files:
+        if not name.endswith(".md"):
+            continue
+        path = os.path.join(root, name)
+        with open(path, "r", encoding="utf-8") as f:
+            for match in path_re.findall(f.read()):
+                if match.startswith(("icn/", "docs/", "sdk/", "web/", "deploy/", "config/", "scripts/")):
+                    paths.add(match)
+
+missing = [p for p in sorted(paths) if not os.path.exists(p)]
+if missing:
+    print("Onboarding references missing files:")
+    for p in missing:
+        print(f"  - {p}")
+    sys.exit(1)
+
+changed = run(["git", "diff", "--name-only", f"{base_ref}...HEAD"]).splitlines()
+changed_set = set(changed)
+
+impacted = sorted([p for p in paths if p in changed_set])
+if impacted:
+    print("Onboarding references changed files:")
+    for p in impacted:
+        print(f"  - {p}")
+    sys.exit(1)
+
+print("Onboarding mapping check passed.")
+PY "$BASE_REF"


### PR DESCRIPTION
## Summary
- add a full onboarding curriculum with textbook-style modules and diagrams
- include workshops, assessments, reading maps, and capstone guidance
- add onboarding update process and mapping-check script

## Test plan
- Not run (docs only)