### PR TITLE
feat(federation): Replace InMemoryAgreementStore with persistent Sled storage

### DIFF
--- a/icn/crates/icn-core/src/supervisor/init_federation.rs
+++ b/icn/crates/icn-core/src/supervisor/init_federation.rs
@@ -28,12 +28,9 @@ pub struct FederationServices {
     pub clearing_manager: Arc<icn_federation::ClearingManager>,
     /// The attestation store for trust attestations
     pub attestation_store: Arc<icn_federation::AttestationStore>,
-    /// The agreement manager for inter-cooperative agreements
-    pub agreement_manager: Arc<
-        icn_federation::agreement::AgreementManager<
-            icn_federation::agreement::InMemoryAgreementStore,
-        >,
-    >,
+    /// The agreement manager for inter-cooperative agreements (persistent storage)
+    pub agreement_manager:
+        Arc<icn_federation::agreement::AgreementManager<icn_federation::agreement::AgreementStore>>,
 }
 
 /// Dependencies for federation initialization
@@ -153,8 +150,13 @@ pub async fn init_federation_services(
         });
     federation_handler.set_send_callback(federation_send_callback);
 
-    // Create agreement manager
-    let agreement_store = Arc::new(icn_federation::agreement::InMemoryAgreementStore::new());
+    // Create agreement manager with persistent Sled storage
+    let agreement_store_path = deps.store_path.join("agreements");
+    let agreement_store_backend: Arc<dyn icn_store::Store> =
+        Arc::new(SledStore::open(&agreement_store_path)?);
+    let agreement_store = Arc::new(icn_federation::agreement::AgreementStore::new(
+        agreement_store_backend,
+    ));
     let agreement_manager = Arc::new(
         icn_federation::agreement::AgreementManager::new(
             agreement_store.clone(),
@@ -163,7 +165,10 @@ pub async fn init_federation_services(
         )
         .with_keypair(deps.keypair.clone()),
     );
-    info!("✓ Agreement manager initialized");
+    info!(
+        "✓ Agreement manager initialized: store={}",
+        agreement_store_path.display()
+    );
 
     info!(
         "✓ Federation enabled: coop_id={}, coop_name={}, store={}",

--- a/icn/crates/icn-federation/src/agreement/mod.rs
+++ b/icn/crates/icn-federation/src/agreement/mod.rs
@@ -57,8 +57,8 @@ pub use manager::{AgreementEvent, AgreementEventCallback, AgreementManager};
 pub use store::{AgreementStore, AgreementStoreOps, InMemoryAgreementStore};
 pub use types::*;
 
-/// Type alias for AgreementManager handle with InMemoryAgreementStore
+/// Type alias for AgreementManager handle with persistent AgreementStore
 ///
 /// This is the default manager type used during wiring through supervisor.
-/// Can be replaced with persistent storage (SledAgreementStore) in future.
-pub type AgreementManagerHandle = Arc<AgreementManager<InMemoryAgreementStore>>;
+/// Uses Sled-backed storage for persistence across daemon restarts.
+pub type AgreementManagerHandle = Arc<AgreementManager<AgreementStore>>;

--- a/icn/crates/icn-federation/src/agreement/store.rs
+++ b/icn/crates/icn-federation/src/agreement/store.rs
@@ -595,4 +595,138 @@ mod tests {
         let amendments = store.get_amendments(&agreement_id).unwrap();
         assert_eq!(amendments.len(), 2);
     }
+
+    #[test]
+    fn test_persistent_store_crud() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store_path = temp_dir.path().join("agreements");
+
+        let sled_store: Arc<dyn Store> = Arc::new(icn_store::SledStore::open(&store_path).unwrap());
+        let store = AgreementStore::new(sled_store);
+
+        // Create
+        let agreement = create_test_agreement();
+        let id = agreement.id.clone();
+        store.store_agreement(&agreement).unwrap();
+
+        // Read
+        let loaded = store.get_agreement(&id).unwrap();
+        assert!(loaded.is_some());
+        assert_eq!(loaded.unwrap().title, "Test Agreement");
+
+        // List
+        let all = store.list_agreements().unwrap();
+        assert_eq!(all.len(), 1);
+
+        // Delete
+        store.delete_agreement(&id).unwrap();
+        assert!(store.get_agreement(&id).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_persistent_store_survives_restart() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store_path = temp_dir.path().join("agreements");
+
+        // First "session" - create and store agreement
+        let agreement_id;
+        let party_did;
+        {
+            let sled_store: Arc<dyn Store> =
+                Arc::new(icn_store::SledStore::open(&store_path).unwrap());
+            let store = AgreementStore::new(sled_store);
+
+            let proposer = test_did();
+            party_did = proposer.clone();
+            let counterparty = test_did();
+
+            let agreement = Agreement::new(
+                "Persistent Agreement",
+                "This should survive restart",
+                AgreementType::Credit {
+                    credit_limit: 10000,
+                    interest_rate_bps: 500,
+                    currency: "ICN".to_string(),
+                },
+            )
+            .with_party(proposer, "coop-persisted", PartyRole::Proposer)
+            .with_party(counterparty, "coop-other", PartyRole::Counterparty);
+
+            agreement_id = agreement.id.clone();
+            store.store_agreement(&agreement).unwrap();
+
+            // Verify it's stored
+            assert!(store.get_agreement(&agreement_id).unwrap().is_some());
+        }
+        // Store is dropped here, simulating daemon shutdown
+
+        // Second "session" - reopen and verify data persists
+        {
+            let sled_store: Arc<dyn Store> =
+                Arc::new(icn_store::SledStore::open(&store_path).unwrap());
+            let store = AgreementStore::new(sled_store);
+
+            // Agreement should still exist
+            let loaded = store.get_agreement(&agreement_id).unwrap();
+            assert!(loaded.is_some(), "Agreement should persist across restart");
+
+            let agreement = loaded.unwrap();
+            assert_eq!(agreement.title, "Persistent Agreement");
+            assert_eq!(agreement.description, "This should survive restart");
+
+            // Party index should also persist
+            let party_agreements = store.list_agreements_for_party(&party_did).unwrap();
+            assert_eq!(party_agreements.len(), 1);
+            assert_eq!(party_agreements[0].id, agreement_id);
+
+            // List should return the agreement
+            let all = store.list_agreements().unwrap();
+            assert_eq!(all.len(), 1);
+        }
+    }
+
+    #[test]
+    fn test_persistent_store_amendments_survive_restart() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store_path = temp_dir.path().join("agreements");
+
+        let agreement_id;
+        let amendment_id;
+
+        // First session - create agreement and amendment
+        {
+            let sled_store: Arc<dyn Store> =
+                Arc::new(icn_store::SledStore::open(&store_path).unwrap());
+            let store = AgreementStore::new(sled_store);
+
+            let agreement = create_test_agreement();
+            agreement_id = agreement.id.clone();
+            store.store_agreement(&agreement).unwrap();
+
+            let amendment =
+                Amendment::new(agreement_id.clone(), "Persistent amendment", test_did());
+            amendment_id = amendment.id.clone();
+            store.store_amendment(&amendment).unwrap();
+
+            // Verify
+            let amendments = store.get_amendments(&agreement_id).unwrap();
+            assert_eq!(amendments.len(), 1);
+        }
+
+        // Second session - verify amendments persist
+        {
+            let sled_store: Arc<dyn Store> =
+                Arc::new(icn_store::SledStore::open(&store_path).unwrap());
+            let store = AgreementStore::new(sled_store);
+
+            let amendments = store.get_amendments(&agreement_id).unwrap();
+            assert_eq!(
+                amendments.len(),
+                1,
+                "Amendment should persist across restart"
+            );
+            assert_eq!(amendments[0].id, amendment_id);
+            assert_eq!(amendments[0].description, "Persistent amendment");
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Replace InMemoryAgreementStore with AgreementStore (Sled-backed) in supervisor wiring
- Update AgreementManagerHandle type alias to use persistent store
- Add dedicated storage path at `{store_path}/agreements`
- Add 3 persistence tests verifying data survives restart

## Why
Agreements were lost on daemon restart - not production-ready. This change persists agreements using the same Sled storage pattern used by other federation components (registry, clearing manager, attestation store).

## Changes
- `icn-core/supervisor/init_federation.rs`: Wire Sled store for agreements
- `icn-federation/agreement/mod.rs`: Update type alias
- `icn-federation/agreement/store.rs`: Add 3 persistence tests

## Test plan
- [x] `cargo test -p icn-federation agreement::store` - all 7 tests pass
- [x] New tests verify agreements/amendments survive store close/reopen

Closes #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)