### PR TITLE
feat(federation): Connect AgreementGossipHandler to gossip system

### DIFF
--- a/icn/crates/icn-core/src/supervisor/init_federation.rs
+++ b/icn/crates/icn-core/src/supervisor/init_federation.rs
@@ -157,16 +157,161 @@ pub async fn init_federation_services(
     let agreement_store = Arc::new(icn_federation::agreement::AgreementStore::new(
         agreement_store_backend,
     ));
+
+    // Set up send callback for agreement gossip (reuse federation callback pattern)
+    let gossip_for_agreements = deps.gossip_handle.clone();
+    let agreement_send_callback: icn_federation::agreement::AgreementGossipCallback =
+        Arc::new(move |topic: &str, data: Vec<u8>| {
+            let gossip = gossip_for_agreements.clone();
+            let topic_owned = topic.to_string();
+            tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(async {
+                    let mut gossip = gossip.write().await;
+                    gossip
+                        .publish(&topic_owned, data)
+                        .await
+                        .map(|_| ())
+                        .map_err(|e| {
+                            icn_federation::FederationError::GossipPublishFailed(e.to_string())
+                        })
+                })
+            })
+        });
+
+    // Create agreement gossip handler with send callback
+    // Note: set_send_callback requires &mut self, so we configure before wrapping in Arc
+    let mut agreement_gossip_handler = icn_federation::agreement::AgreementGossipHandler::new(
+        agreement_store.clone(),
+        deps.did.clone(),
+        coop_id.clone(),
+    );
+    agreement_gossip_handler.set_send_callback(agreement_send_callback);
+    let agreement_gossip_handler = Arc::new(agreement_gossip_handler);
+
+    // Register agreement handler with federation handler for message routing
+    federation_handler.register_agreement_handler(agreement_gossip_handler.clone());
+    info!("✓ Agreement gossip handler registered");
+
+    // Create agreement manager with event callback to broadcast to gossip
+    // The callback fetches full objects from the store since events only contain IDs
+    let gossip_handler_for_events = agreement_gossip_handler.clone();
+    let store_for_events = agreement_store.clone();
+    let agreement_event_callback: icn_federation::agreement::AgreementEventCallback =
+        Box::new(move |event| {
+            use icn_federation::agreement::{AgreementEvent, AgreementStoreOps};
+            match &event {
+                AgreementEvent::Proposed { agreement_id, .. } => {
+                    // Fetch full agreement from store and broadcast
+                    match store_for_events.get_agreement(agreement_id) {
+                        Ok(Some(agreement)) => {
+                            if let Err(e) = gossip_handler_for_events.broadcast_proposed(&agreement)
+                            {
+                                tracing::warn!("Failed to broadcast proposed agreement: {}", e);
+                            }
+                        }
+                        Ok(None) => {
+                            tracing::warn!("Agreement {} not found for broadcast", agreement_id);
+                        }
+                        Err(e) => {
+                            tracing::warn!("Failed to fetch agreement for broadcast: {}", e);
+                        }
+                    }
+                }
+                AgreementEvent::Signed {
+                    agreement_id,
+                    signer,
+                    ..
+                } => {
+                    // Fetch agreement to get the signature
+                    match store_for_events.get_agreement(agreement_id) {
+                        Ok(Some(agreement)) => {
+                            if let Some(sig) =
+                                agreement.signatures.iter().find(|s| &s.signer == signer)
+                            {
+                                if let Err(e) = gossip_handler_for_events
+                                    .broadcast_signature(agreement_id, sig.clone())
+                                {
+                                    tracing::warn!("Failed to broadcast signature: {}", e);
+                                }
+                            }
+                        }
+                        Ok(None) => {
+                            tracing::warn!(
+                                "Agreement {} not found for signature broadcast",
+                                agreement_id
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "Failed to fetch agreement for signature broadcast: {}",
+                                e
+                            );
+                        }
+                    }
+                }
+                AgreementEvent::Suspended { agreement_id, .. }
+                | AgreementEvent::Resumed { agreement_id, .. }
+                | AgreementEvent::Terminated { agreement_id, .. }
+                | AgreementEvent::Activated { agreement_id, .. } => {
+                    // Fetch agreement to get current status
+                    match store_for_events.get_agreement(agreement_id) {
+                        Ok(Some(agreement)) => {
+                            if let Err(e) = gossip_handler_for_events
+                                .broadcast_status_update(agreement_id, agreement.status.clone())
+                            {
+                                tracing::warn!("Failed to broadcast status update: {}", e);
+                            }
+                        }
+                        Ok(None) => {
+                            tracing::warn!(
+                                "Agreement {} not found for status broadcast",
+                                agreement_id
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!("Failed to fetch agreement for status broadcast: {}", e);
+                        }
+                    }
+                }
+                AgreementEvent::AmendmentProposed {
+                    agreement_id,
+                    amendment_id,
+                    ..
+                } => {
+                    // Fetch amendment from store and broadcast
+                    match store_for_events.get_amendments(agreement_id) {
+                        Ok(amendments) => {
+                            if let Some(amendment) =
+                                amendments.iter().find(|a| &a.id == amendment_id)
+                            {
+                                if let Err(e) =
+                                    gossip_handler_for_events.broadcast_amendment(amendment)
+                                {
+                                    tracing::warn!("Failed to broadcast amendment: {}", e);
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!("Failed to fetch amendments for broadcast: {}", e);
+                        }
+                    }
+                }
+                // Other events don't need gossip broadcast
+                _ => {}
+            }
+        });
+
     let agreement_manager = Arc::new(
         icn_federation::agreement::AgreementManager::new(
             agreement_store.clone(),
             coop_id.clone(),
             deps.did.clone(),
         )
-        .with_keypair(deps.keypair.clone()),
+        .with_keypair(deps.keypair.clone())
+        .with_event_callback(agreement_event_callback),
     );
     info!(
-        "✓ Agreement manager initialized: store={}",
+        "✓ Agreement manager initialized with gossip sync: store={}",
         agreement_store_path.display()
     );
 

--- a/icn/crates/icn-core/src/supervisor/init_gossip.rs
+++ b/icn/crates/icn-core/src/supervisor/init_gossip.rs
@@ -267,6 +267,15 @@ pub async fn subscribe_standard_topics(
         } else {
             info!("Subscribed to federation:clearing topic");
         }
+
+        if let Err(e) = gossip
+            .subscribe(icn_federation::TOPIC_FEDERATION_AGREEMENTS, did.clone())
+            .await
+        {
+            warn!("Failed to subscribe to federation:agreements topic: {}", e);
+        } else {
+            info!("Subscribed to federation:agreements topic");
+        }
     }
 }
 

--- a/icn/crates/icn-federation/src/gossip.rs
+++ b/icn/crates/icn-federation/src/gossip.rs
@@ -5,15 +5,22 @@
 //! - Vouch messages for policy enforcement
 //! - Federation requests and responses
 
+use crate::agreement::{AgreementGossipHandler, AgreementStoreOps};
 use crate::error::{FederationError, Result};
 use crate::metrics;
 use crate::registry::CooperativeRegistry;
 use crate::types::{current_timestamp, CooperativeInfo, FederationMessage, Vouch};
-use crate::{TOPIC_FEDERATION_CLEARING, TOPIC_FEDERATION_REGISTRY, TOPIC_FEDERATION_TRUST};
+use crate::{
+    TOPIC_FEDERATION_AGREEMENTS, TOPIC_FEDERATION_CLEARING, TOPIC_FEDERATION_REGISTRY,
+    TOPIC_FEDERATION_TRUST,
+};
 use icn_identity::{Did, KeyPair};
 use std::sync::Arc;
 use std::sync::RwLock;
 use tracing::{debug, info, warn};
+
+/// Type-erased callback for handling agreement gossip messages
+pub type AgreementMessageHandler = Arc<dyn Fn(&[u8]) -> Result<()> + Send + Sync>;
 
 /// Callback for sending gossip messages to the network
 pub type GossipSendCallback = Arc<dyn Fn(&str, Vec<u8>) -> Result<()> + Send + Sync>;
@@ -31,6 +38,9 @@ pub struct FederationGossipHandler {
 
     /// Callback to send messages via gossip
     send_callback: RwLock<Option<GossipSendCallback>>,
+
+    /// Handler for agreement gossip messages (type-erased for flexibility)
+    agreement_handler: RwLock<Option<AgreementMessageHandler>>,
 }
 
 impl FederationGossipHandler {
@@ -41,7 +51,24 @@ impl FederationGossipHandler {
             own_coop: RwLock::new(None),
             keypair: RwLock::new(None),
             send_callback: RwLock::new(None),
+            agreement_handler: RwLock::new(None),
         }
+    }
+
+    /// Register an agreement gossip handler for routing agreement messages
+    ///
+    /// The handler receives raw message bytes and is responsible for deserialization.
+    pub fn register_agreement_handler<S: AgreementStoreOps + 'static>(
+        &self,
+        handler: Arc<AgreementGossipHandler<S>>,
+    ) {
+        let handler_fn: AgreementMessageHandler =
+            Arc::new(move |data: &[u8]| handler.handle_message(data));
+        *self.agreement_handler.write().unwrap_or_else(|poisoned| {
+            warn!("Agreement handler lock poisoned, recovering");
+            poisoned.into_inner()
+        }) = Some(handler_fn);
+        info!("Registered agreement gossip handler");
     }
 
     /// Set the send callback for gossip messages
@@ -82,6 +109,12 @@ impl FederationGossipHandler {
 
     /// Handle an incoming federation message
     pub fn handle_message(&self, topic: &str, data: &[u8]) -> Result<()> {
+        // Route agreement messages to the dedicated handler
+        if topic == TOPIC_FEDERATION_AGREEMENTS {
+            return self.handle_agreement_message(data);
+        }
+
+        // Parse as FederationMessage for other topics
         let message: FederationMessage = serde_json::from_slice(data)
             .map_err(|e| FederationError::DeserializationError(e.to_string()))?;
 
@@ -93,6 +126,21 @@ impl FederationGossipHandler {
                 debug!("Ignoring message on unknown federation topic: {}", topic);
                 Ok(())
             }
+        }
+    }
+
+    /// Route agreement messages to the registered handler
+    fn handle_agreement_message(&self, data: &[u8]) -> Result<()> {
+        let handler = self.agreement_handler.read().unwrap_or_else(|poisoned| {
+            warn!("Agreement handler lock poisoned, recovering");
+            poisoned.into_inner()
+        });
+
+        if let Some(ref handler_fn) = *handler {
+            handler_fn(data)
+        } else {
+            debug!("No agreement handler registered, ignoring agreement message");
+            Ok(())
         }
     }
 
@@ -877,6 +925,76 @@ mod tests {
         // Should be silently rejected (signature won't verify against accepter's DID)
         handler
             .handle_message("federation:registry", &forged_data)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_agreement_message_routing() {
+        use crate::agreement::{
+            AgreementGossipHandler, AgreementMessage, AgreementStoreOps, AgreementType,
+            InMemoryAgreementStore, PartyRole, TradeItem,
+        };
+
+        let registry = create_test_registry();
+        let handler = FederationGossipHandler::new(registry);
+
+        // Create agreement store and gossip handler
+        let agreement_store = Arc::new(InMemoryAgreementStore::new());
+        let own_kp = test_keypair();
+        let counterparty_kp = test_keypair();
+
+        let agreement_handler = Arc::new(AgreementGossipHandler::new(
+            agreement_store.clone(),
+            own_kp.did().clone(),
+            "our-coop".to_string(),
+        ));
+
+        // Register agreement handler
+        handler.register_agreement_handler(agreement_handler);
+
+        // Create a test agreement where we're a party
+        let agreement = crate::agreement::Agreement::new(
+            "Test Agreement",
+            "For routing test",
+            AgreementType::Trade {
+                items: vec![TradeItem::new("widgets", 10, "units", 100, "USD")],
+                currency: "USD".to_string(),
+            },
+        )
+        .with_party(own_kp.did().clone(), "our-coop", PartyRole::Proposer)
+        .with_party(
+            counterparty_kp.did().clone(),
+            "other-coop",
+            PartyRole::Counterparty,
+        );
+
+        // Serialize agreement message
+        let message = AgreementMessage::Proposed {
+            agreement: Box::new(agreement.clone()),
+        };
+        let data = message.to_bytes().unwrap();
+
+        // Route through federation handler
+        handler
+            .handle_message("federation:agreements", &data)
+            .unwrap();
+
+        // Verify agreement was stored
+        let stored = agreement_store.get_agreement(&agreement.id).unwrap();
+        assert!(stored.is_some());
+        assert_eq!(stored.unwrap().title, "Test Agreement");
+    }
+
+    #[test]
+    fn test_agreement_routing_without_handler() {
+        let registry = create_test_registry();
+        let handler = FederationGossipHandler::new(registry);
+
+        // Don't register any agreement handler
+
+        // Should not panic, just ignore the message
+        handler
+            .handle_message("federation:agreements", b"invalid")
             .unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- Wire AgreementGossipHandler into gossip system for cross-node agreement synchronization
- Route `federation:agreements` topic messages through FederationGossipHandler
- Broadcast agreement events (proposed, signed, status changes, amendments) to gossip network
- Subscribe nodes to `federation:agreements` topic

## Changes

### icn-federation/src/gossip.rs
- Add `agreement_handler` field to `FederationGossipHandler`
- Add `register_agreement_handler()` for routing messages to the agreement handler
- Route `federation:agreements` topic messages through `handle_agreement_message()`
- Add 2 unit tests for message routing

### icn-core/src/supervisor/init_federation.rs
- Create `AgreementGossipHandler` with send callback
- Register it with `FederationGossipHandler`
- Wire `AgreementManager` event callback to broadcast:
  - Proposed agreements
  - Signatures
  - Status updates (suspend/resume/terminate/activate)
  - Amendments

### icn-core/src/supervisor/init_gossip.rs
- Subscribe to `federation:agreements` topic when federation is enabled

## Architecture

```
Node A                           Node B
  │                                │
  ├─ AgreementManager             ├─ AgreementManager
  │  └─ create/sign/suspend()     │
  │         │                     │
  │         ▼ (event callback)    │
  ├─ AgreementGossipHandler       ├─ AgreementGossipHandler
  │  └─ broadcast_proposed()      │  └─ handle_message()
  │         │                     │         │
  │         ▼                     │         ▼
  ├─ Gossip: Publish              │  ← Gossip: Receive
  │  "federation:agreements"      │     "federation:agreements"
  │                               │         │
  │                               │         ▼
  │                               │     Update local store
```

## Related Issues
Closes #655

## Test Plan
- [x] All existing tests pass
- [x] New unit tests verify message routing
- [x] `test_agreement_message_routing` - agreement stored via gossip routing
- [x] `test_agreement_routing_without_handler` - graceful degradation

🤖 Generated with [Claude Code](https://claude.com/claude-code)