### PR TITLE
feat(federation): Add metrics for agreement lifecycle events

### DIFF
--- a/icn/crates/icn-federation/src/agreement/manager.rs
+++ b/icn/crates/icn-federation/src/agreement/manager.rs
@@ -11,6 +11,7 @@ use super::types::{
 use crate::error::{FederationError, Result};
 use crate::types::current_timestamp;
 use icn_identity::{Did, KeyPair};
+use icn_obs::metrics::agreement as metrics;
 use std::sync::Arc;
 use tracing::{debug, info};
 
@@ -143,6 +144,9 @@ impl<S: AgreementStoreOps> AgreementManager<S> {
         );
 
         self.store.store_agreement(&agreement)?;
+
+        // Record metrics
+        metrics::agreements_created_inc(agreement.agreement_type.type_name());
 
         self.emit_event(AgreementEvent::Created {
             agreement_id: agreement.id.clone(),
@@ -279,6 +283,9 @@ impl<S: AgreementStoreOps> AgreementManager<S> {
         agreement.sign(keypair, &self.own_coop_id);
         let remaining = agreement.pending_signers();
 
+        // Record signature metric
+        metrics::agreement_signatures_inc();
+
         self.emit_event(AgreementEvent::Signed {
             agreement_id: agreement.id.clone(),
             signer: self.own_did.clone(),
@@ -288,6 +295,9 @@ impl<S: AgreementStoreOps> AgreementManager<S> {
         // Check if we should auto-activate
         if agreement.try_auto_activate() {
             if let AgreementStatus::Active { activated_at, .. } = &agreement.status {
+                // Record activation metric
+                metrics::agreements_activated_inc();
+
                 self.emit_event(AgreementEvent::Activated {
                     agreement_id: agreement.id.clone(),
                     activated_at: *activated_at,
@@ -346,6 +356,9 @@ impl<S: AgreementStoreOps> AgreementManager<S> {
         agreement.signatures.push(signature.clone());
         let remaining = agreement.pending_signers();
 
+        // Record signature metric
+        metrics::agreement_signatures_inc();
+
         self.emit_event(AgreementEvent::Signed {
             agreement_id: agreement.id.clone(),
             signer: signature.signer.clone(),
@@ -355,6 +368,9 @@ impl<S: AgreementStoreOps> AgreementManager<S> {
         // Check for auto-activation
         if agreement.try_auto_activate() {
             if let AgreementStatus::Active { activated_at, .. } = &agreement.status {
+                // Record activation metric
+                metrics::agreements_activated_inc();
+
                 self.emit_event(AgreementEvent::Activated {
                     agreement_id: agreement.id.clone(),
                     activated_at: *activated_at,
@@ -389,6 +405,9 @@ impl<S: AgreementStoreOps> AgreementManager<S> {
 
         self.store.store_agreement(&agreement)?;
 
+        // Record suspension metric
+        metrics::agreements_suspended_inc();
+
         self.emit_event(AgreementEvent::Suspended {
             agreement_id: agreement.id.clone(),
             suspended_by: self.own_did.clone(),
@@ -408,6 +427,9 @@ impl<S: AgreementStoreOps> AgreementManager<S> {
             .map_err(|e| FederationError::InvalidState(e.to_string()))?;
 
         self.store.store_agreement(&agreement)?;
+
+        // Record resume metric
+        metrics::agreements_resumed_inc();
 
         self.emit_event(AgreementEvent::Resumed {
             agreement_id: agreement.id.clone(),
@@ -438,6 +460,9 @@ impl<S: AgreementStoreOps> AgreementManager<S> {
             .map_err(|e| FederationError::InvalidState(e.to_string()))?;
 
         self.store.store_agreement(&agreement)?;
+
+        // Record termination metric with reason
+        metrics::agreements_terminated_inc(reason.as_str());
 
         self.emit_event(AgreementEvent::Terminated {
             agreement_id: agreement.id.clone(),
@@ -564,6 +589,9 @@ impl<S: AgreementStoreOps> AgreementManager<S> {
 
         self.store.store_amendment(&amendment)?;
 
+        // Record amendment proposed metric
+        metrics::amendments_proposed_inc();
+
         self.emit_event(AgreementEvent::AmendmentProposed {
             agreement_id: agreement_id.clone(),
             amendment_id: amendment.id.clone(),
@@ -654,6 +682,9 @@ impl<S: AgreementStoreOps> AgreementManager<S> {
             updated_agreement.apply_amendment(amendment_clone)?;
             self.store.store_agreement(&updated_agreement)?;
 
+            // Record amendment ratification metric
+            metrics::amendments_ratified_inc();
+
             self.emit_event(AgreementEvent::AmendmentRatified {
                 agreement_id: agreement_id.clone(),
                 amendment_id: amendment_id.to_string(),
@@ -686,6 +717,9 @@ impl<S: AgreementStoreOps> AgreementManager<S> {
                 let mut updated = agreement;
                 if updated.terminate(TerminationReason::Expired).is_ok() {
                     self.store.store_agreement(&updated)?;
+
+                    // Record expiration metric
+                    metrics::agreements_terminated_inc("expired");
 
                     self.emit_event(AgreementEvent::Terminated {
                         agreement_id: updated.id.clone(),

--- a/icn/crates/icn-federation/src/agreement/types.rs
+++ b/icn/crates/icn-federation/src/agreement/types.rs
@@ -377,6 +377,19 @@ pub enum TerminationReason {
     },
 }
 
+impl TerminationReason {
+    /// Get the reason as a string for metrics/logging
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TerminationReason::Expired => "expired",
+            TerminationReason::MutualConsent { .. } => "mutual_consent",
+            TerminationReason::Breach { .. } => "breach",
+            TerminationReason::Withdrawal { .. } => "withdrawal",
+            TerminationReason::ForceMajeure { .. } => "force_majeure",
+        }
+    }
+}
+
 /// Role of a party in an agreement
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/icn/crates/icn-obs/src/metrics/agreement.rs
+++ b/icn/crates/icn-obs/src/metrics/agreement.rs
@@ -1,0 +1,212 @@
+//! Agreement metrics
+//!
+//! Prometheus metrics for inter-cooperative agreement lifecycle events.
+//! Tracks agreement creation, activation, termination, signatures, and amendments.
+
+use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
+
+/// Initialize agreement metric descriptions
+pub fn init_descriptions() {
+    // Counter metrics
+    describe_counter!(
+        "icn_agreement_created_total",
+        "Total number of agreements created by type"
+    );
+    describe_counter!(
+        "icn_agreement_activated_total",
+        "Total number of agreements activated"
+    );
+    describe_counter!(
+        "icn_agreement_terminated_total",
+        "Total number of agreements terminated by reason"
+    );
+    describe_counter!(
+        "icn_agreement_signatures_total",
+        "Total number of signatures added to agreements"
+    );
+    describe_counter!(
+        "icn_agreement_amendments_proposed_total",
+        "Total number of amendments proposed"
+    );
+    describe_counter!(
+        "icn_agreement_amendments_ratified_total",
+        "Total number of amendments ratified"
+    );
+    describe_counter!(
+        "icn_agreement_suspended_total",
+        "Total number of agreements suspended"
+    );
+    describe_counter!(
+        "icn_agreement_resumed_total",
+        "Total number of agreements resumed from suspension"
+    );
+
+    // Gauge metrics
+    describe_gauge!(
+        "icn_agreement_active",
+        "Current number of active agreements"
+    );
+    describe_gauge!(
+        "icn_agreement_pending",
+        "Current number of pending agreements awaiting signatures"
+    );
+    describe_gauge!(
+        "icn_agreement_suspended",
+        "Current number of suspended agreements"
+    );
+    describe_gauge!(
+        "icn_agreement_draft",
+        "Current number of draft agreements"
+    );
+
+    // Histogram metrics
+    describe_histogram!(
+        "icn_agreement_activation_duration_seconds",
+        "Time from proposal to activation in seconds"
+    );
+    describe_histogram!(
+        "icn_agreement_amendment_ratification_duration_seconds",
+        "Time from amendment proposal to ratification in seconds"
+    );
+}
+
+// Counter metrics
+
+/// Increment agreements created counter
+pub fn agreements_created_inc(agreement_type: &str) {
+    counter!(
+        "icn_agreement_created_total",
+        "agreement_type" => agreement_type.to_string()
+    )
+    .increment(1);
+}
+
+/// Increment agreements activated counter
+pub fn agreements_activated_inc() {
+    counter!("icn_agreement_activated_total").increment(1);
+}
+
+/// Increment agreements terminated counter
+pub fn agreements_terminated_inc(reason: &str) {
+    counter!(
+        "icn_agreement_terminated_total",
+        "reason" => reason.to_string()
+    )
+    .increment(1);
+}
+
+/// Increment agreement signatures counter
+pub fn agreement_signatures_inc() {
+    counter!("icn_agreement_signatures_total").increment(1);
+}
+
+/// Increment amendments proposed counter
+pub fn amendments_proposed_inc() {
+    counter!("icn_agreement_amendments_proposed_total").increment(1);
+}
+
+/// Increment amendments ratified counter
+pub fn amendments_ratified_inc() {
+    counter!("icn_agreement_amendments_ratified_total").increment(1);
+}
+
+/// Increment agreements suspended counter
+pub fn agreements_suspended_inc() {
+    counter!("icn_agreement_suspended_total").increment(1);
+}
+
+/// Increment agreements resumed counter
+pub fn agreements_resumed_inc() {
+    counter!("icn_agreement_resumed_total").increment(1);
+}
+
+// Gauge metrics
+
+/// Set current number of active agreements
+pub fn agreements_active_set(count: usize) {
+    gauge!("icn_agreement_active").set(count as f64);
+}
+
+/// Set current number of pending agreements
+pub fn agreements_pending_set(count: usize) {
+    gauge!("icn_agreement_pending").set(count as f64);
+}
+
+/// Set current number of suspended agreements
+pub fn agreements_suspended_set(count: usize) {
+    gauge!("icn_agreement_suspended").set(count as f64);
+}
+
+/// Set current number of draft agreements
+pub fn agreements_draft_set(count: usize) {
+    gauge!("icn_agreement_draft").set(count as f64);
+}
+
+// Histogram metrics
+
+/// Record time from proposal to activation
+pub fn agreement_activation_duration_observe(duration_secs: f64) {
+    histogram!("icn_agreement_activation_duration_seconds").record(duration_secs);
+}
+
+/// Record time from amendment proposal to ratification
+pub fn amendment_ratification_duration_observe(duration_secs: f64) {
+    histogram!("icn_agreement_amendment_ratification_duration_seconds").record(duration_secs);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_counter_metrics() {
+        // Test agreement type counters
+        agreements_created_inc("Trade");
+        agreements_created_inc("Credit");
+        agreements_created_inc("ResourceSharing");
+        agreements_created_inc("FederationMembership");
+
+        // Test activation counter
+        agreements_activated_inc();
+
+        // Test termination counters
+        agreements_terminated_inc("Expiration");
+        agreements_terminated_inc("MutualConsent");
+        agreements_terminated_inc("Breach");
+
+        // Test signature counter
+        agreement_signatures_inc();
+
+        // Test amendment counters
+        amendments_proposed_inc();
+        amendments_ratified_inc();
+
+        // Test suspend/resume counters
+        agreements_suspended_inc();
+        agreements_resumed_inc();
+    }
+
+    #[test]
+    fn test_gauge_metrics() {
+        agreements_active_set(10);
+        agreements_pending_set(5);
+        agreements_suspended_set(2);
+        agreements_draft_set(3);
+
+        // Test zero counts
+        agreements_active_set(0);
+        agreements_pending_set(0);
+    }
+
+    #[test]
+    fn test_histogram_metrics() {
+        // Test activation duration
+        agreement_activation_duration_observe(3600.0); // 1 hour
+        agreement_activation_duration_observe(86400.0); // 1 day
+        agreement_activation_duration_observe(0.5); // 500ms
+
+        // Test amendment ratification duration
+        amendment_ratification_duration_observe(7200.0); // 2 hours
+        amendment_ratification_duration_observe(172800.0); // 2 days
+    }
+}

--- a/icn/crates/icn-obs/src/metrics/agreement.rs
+++ b/icn/crates/icn-obs/src/metrics/agreement.rs
@@ -54,10 +54,7 @@ pub fn init_descriptions() {
         "icn_agreement_suspended",
         "Current number of suspended agreements"
     );
-    describe_gauge!(
-        "icn_agreement_draft",
-        "Current number of draft agreements"
-    );
+    describe_gauge!("icn_agreement_draft", "Current number of draft agreements");
 
     // Histogram metrics
     describe_histogram!(

--- a/icn/crates/icn-obs/src/metrics/mod.rs
+++ b/icn/crates/icn-obs/src/metrics/mod.rs
@@ -27,6 +27,7 @@ mod legacy {
 
 pub use legacy::*;
 
+pub mod agreement;
 pub mod gateway;
 pub mod nat;
 pub mod network;


### PR DESCRIPTION
## Summary

Add Prometheus metrics for agreement lifecycle events to enable monitoring and observability of the inter-cooperative agreement framework.

## Changes

### New Metrics Module (`icn-obs/src/metrics/agreement.rs`)

**Counter Metrics:**
- `icn_agreement_created_total` - Total agreements created by type
- `icn_agreement_activated_total` - Total agreements activated
- `icn_agreement_terminated_total` - Total agreements terminated by reason
- `icn_agreement_signatures_total` - Total signatures added
- `icn_agreement_amendments_proposed_total` - Total amendments proposed
- `icn_agreement_amendments_ratified_total` - Total amendments ratified
- `icn_agreement_suspended_total` - Total agreements suspended
- `icn_agreement_resumed_total` - Total agreements resumed

**Gauge Metrics:**
- `icn_agreement_active` - Current number of active agreements
- `icn_agreement_pending` - Current number of pending agreements
- `icn_agreement_suspended` - Current number of suspended agreements
- `icn_agreement_draft` - Current number of draft agreements

**Histogram Metrics:**
- `icn_agreement_activation_duration_seconds` - Time from proposal to activation
- `icn_agreement_amendment_ratification_duration_seconds` - Time from amendment proposal to ratification

### Integration in AgreementManager

Added metric calls at all lifecycle transition points:
- `create_draft()` - records created metric with agreement type
- `sign()` / `record_signature()` - records signature metric, activation on completion
- `suspend()` - records suspension metric
- `resume()` - records resume metric
- `terminate()` - records termination metric with reason label
- `propose_amendment()` - records amendment proposed metric
- `sign_amendment()` (on ratification) - records amendment ratified metric
- `check_expirations()` - records expired terminations

### Supporting Changes

- Added `TerminationReason::as_str()` method for metric labels

## Example Grafana Queries

```promql
# Rate of agreement creation
rate(icn_agreement_created_total[5m])

# Active agreements
icn_agreement_active

# Termination reasons breakdown
sum by (reason) (icn_agreement_terminated_total)

# Average time to activation
rate(icn_agreement_activation_duration_seconds_sum[5m]) 
/ rate(icn_agreement_activation_duration_seconds_count[5m])
```

## Test Plan

- [x] All existing agreement tests pass
- [x] New metric module tests pass
- [x] Verified compilation across affected crates

## Related

- Closes #648
- Builds on PR #642 (agreement framework)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)