### PR TITLE
chore(ci): Make accessibility tests blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,6 @@ jobs:
       - name: Run accessibility tests
         id: a11y-tests
         run: npm run test:a11y
-        continue-on-error: true  # Don't fail build initially while fixing violations
 
       - name: Upload accessibility report
         if: always()


### PR DESCRIPTION
## Summary

Make the accessibility tests a blocking CI check by removing `continue-on-error: true`.

## Background

PR #633 added axe-core accessibility testing with `continue-on-error: true` to allow the team to gradually fix existing violations. The baseline has now been established:

- All critical/serious WCAG 2.1 AA violations have been resolved
- The accessibility tests have been passing consistently on main
- Recent runs confirm stability: all 3 most recent main branch runs show `success`

## Changes

- Removed `continue-on-error: true` from the "Run accessibility tests" step
- Accessibility report still uploads on pass or fail (preserved `if: always()`)

## Impact

Going forward, any new accessibility violations that fail axe-core tests will block the CI pipeline, ensuring WCAG 2.1 AA compliance is maintained.

## Test Plan

- [x] Verified recent CI runs pass accessibility tests
- [x] CI will validate this PR passes accessibility tests

## Related

- Closes #639
- Parent PR: #633 (accessibility infrastructure)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)