### PR TITLE
deps(identity): Upgrade age crate from 0.10 to 0.11

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "age"
-version = "0.10.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77de71da1ca673855aacea507a7aed363beb8934cf61b62364fc4b479d2e8cda"
+checksum = "bf640be7658959746f1f0f2faab798f6098a9436a8e18e148d18bc9875e13c4b"
 dependencies = [
  "age-core",
  "base64 0.21.7",
@@ -360,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "age-core"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5f11899bc2bbddd135edbc30c36b1924fa59d0746bb45beb5933fafe3fe509b"
+checksum = "e2bf6a89c984ca9d850913ece2da39e1d200563b0a94b002b253beee4c5acf99"
 dependencies = [
  "base64 0.21.7",
  "chacha20poly1305",
@@ -1078,7 +1078,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -1583,7 +1583,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.111",
 ]
 
@@ -1596,19 +1596,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.111",
-]
-
-[[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core 0.9.12",
 ]
 
 [[package]]
@@ -2649,9 +2636,9 @@ dependencies = [
 
 [[package]]
 name = "i18n-embed"
-version = "0.14.1"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94205d95764f5bb9db9ea98fa77f89653365ca748e27161f5bbea2ffd50e459c"
+checksum = "669ffc2c93f97e6ddf06ddbe999fcd6782e3342978bb85f7d3c087c7978404c4"
 dependencies = [
  "arc-swap",
  "fluent",
@@ -2659,7 +2646,6 @@ dependencies = [
  "fluent-syntax",
  "i18n-embed-impl",
  "intl-memoizer",
- "lazy_static",
  "log",
  "parking_lot 0.12.5",
  "rust-embed",
@@ -2670,21 +2656,19 @@ dependencies = [
 
 [[package]]
 name = "i18n-embed-fl"
-version = "0.7.0"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc1f8715195dffc4caddcf1cf3128da15fe5d8a137606ea8856c9300047d5a2"
+checksum = "04b2969d0b3fc6143776c535184c19722032b43e6a642d710fa3f88faec53c2d"
 dependencies = [
- "dashmap 5.5.3",
  "find-crate",
  "fluent",
  "fluent-syntax",
  "i18n-config",
  "i18n-embed",
- "lazy_static",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn 2.0.111",
  "unic-langid",
 ]
@@ -2988,7 +2972,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "criterion",
- "dashmap 6.1.0",
+ "dashmap",
  "ed25519-dalek",
  "futures-util",
  "hex",
@@ -5028,6 +5012,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5918,9 +5924,9 @@ dependencies = [
 
 [[package]]
 name = "secrecy"
-version = "0.8.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
 ]
@@ -6319,12 +6325,6 @@ name = "strfmt"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fdc163db75f7b5ffa3daf0c5a7136fb0d4b2f35523cd1769da05e034159feb"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
@@ -7800,7 +7800,7 @@ checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
  "ordered-float 4.6.0",
- "strsim 0.11.1",
+ "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
 ]

--- a/icn/crates/icn-identity/Cargo.toml
+++ b/icn/crates/icn-identity/Cargo.toml
@@ -23,8 +23,8 @@ icn-crypto-pq.workspace = true
 icn-time.workspace = true
 icn-encoding = { path = "../icn-encoding" }
 multibase = "0.9"
-age = "0.10"
-secrecy = "0.8"
+age = "0.11"
+secrecy = "0.10"
 serde_json = "1.0"
 base64 = "0.22"
 rcgen.workspace = true

--- a/icn/crates/icn-identity/src/keystore.rs
+++ b/icn/crates/icn-identity/src/keystore.rs
@@ -11,10 +11,11 @@ use crate::anchor::Anchor;
 use crate::keybundle::KeyBundle;
 use crate::{Did, DidDocument, IdentityBundle, KeyPair, RotationEvent};
 use anyhow::{Context, Result};
-use secrecy::{Secret, Zeroize};
+use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use tracing::{info, warn};
+use zeroize::Zeroize;
 use zeroize::Zeroizing;
 
 /// Trait for secure key storage backends
@@ -536,8 +537,10 @@ impl AgeKeyStore {
     fn encrypt_and_save_v4(path: &Path, stored: &StoredKeyV4, passphrase: &[u8]) -> Result<()> {
         let json = Zeroizing::new(serde_json::to_vec(stored)?);
 
-        let encryptor = age::Encryptor::with_user_passphrase(Secret::new(
-            String::from_utf8(passphrase.to_vec()).context("Passphrase must be valid UTF-8")?,
+        let encryptor = age::Encryptor::with_user_passphrase(SecretString::new(
+            String::from_utf8(passphrase.to_vec())
+                .context("Passphrase must be valid UTF-8")?
+                .into_boxed_str(),
         ));
 
         let mut encrypted = Vec::new();
@@ -564,18 +567,20 @@ impl AgeKeyStore {
         let encrypted = std::fs::read(path).context("Failed to read keystore file")?;
 
         // Create age decryptor
-        let decryptor = match age::Decryptor::new(encrypted.as_slice())? {
-            age::Decryptor::Passphrase(d) => d,
-            _ => anyhow::bail!("Unsupported age encryption type"),
-        };
+        let decryptor = age::Decryptor::new(encrypted.as_slice())?;
+        if !decryptor.is_scrypt() {
+            anyhow::bail!("Unsupported age encryption type");
+        }
 
-        // Decrypt
+        // Decrypt with scrypt identity
         let passphrase_str =
             String::from_utf8(passphrase.to_vec()).context("Passphrase must be valid UTF-8")?;
+        let identity =
+            age::scrypt::Identity::new(SecretString::new(passphrase_str.into_boxed_str()));
 
         let mut decrypted = Vec::new();
         let mut reader = decryptor
-            .decrypt(&Secret::new(passphrase_str), None)
+            .decrypt(std::iter::once(&identity as &dyn age::Identity))
             .context("Failed to decrypt (wrong passphrase?)")?;
 
         std::io::copy(&mut reader, &mut decrypted).context("Failed to read decrypted data")?;
@@ -773,8 +778,10 @@ impl AgeKeyStore {
         let json = Zeroizing::new(serde_json::to_vec(stored)?);
 
         // Create age encryptor with passphrase
-        let encryptor = age::Encryptor::with_user_passphrase(Secret::new(
-            String::from_utf8(passphrase.to_vec()).context("Passphrase must be valid UTF-8")?,
+        let encryptor = age::Encryptor::with_user_passphrase(SecretString::new(
+            String::from_utf8(passphrase.to_vec())
+                .context("Passphrase must be valid UTF-8")?
+                .into_boxed_str(),
         ));
 
         // Encrypt
@@ -804,18 +811,20 @@ impl AgeKeyStore {
         let encrypted = std::fs::read(path).context("Failed to read keystore file")?;
 
         // Create age decryptor
-        let decryptor = match age::Decryptor::new(encrypted.as_slice())? {
-            age::Decryptor::Passphrase(d) => d,
-            _ => anyhow::bail!("Unsupported age encryption type"),
-        };
+        let decryptor = age::Decryptor::new(encrypted.as_slice())?;
+        if !decryptor.is_scrypt() {
+            anyhow::bail!("Unsupported age encryption type");
+        }
 
-        // Decrypt
+        // Decrypt with scrypt identity
         let passphrase_str =
             String::from_utf8(passphrase.to_vec()).context("Passphrase must be valid UTF-8")?;
+        let identity =
+            age::scrypt::Identity::new(SecretString::new(passphrase_str.into_boxed_str()));
 
         let mut decrypted = Vec::new();
         let mut reader = decryptor
-            .decrypt(&Secret::new(passphrase_str), None)
+            .decrypt(std::iter::once(&identity as &dyn age::Identity))
             .context("Failed to decrypt (wrong passphrase?)")?;
 
         std::io::copy(&mut reader, &mut decrypted).context("Failed to read decrypted data")?;
@@ -833,8 +842,10 @@ impl AgeKeyStore {
         let json = Zeroizing::new(serde_json::to_vec(stored)?);
 
         // Create age encryptor with passphrase
-        let encryptor = age::Encryptor::with_user_passphrase(Secret::new(
-            String::from_utf8(passphrase.to_vec()).context("Passphrase must be valid UTF-8")?,
+        let encryptor = age::Encryptor::with_user_passphrase(SecretString::new(
+            String::from_utf8(passphrase.to_vec())
+                .context("Passphrase must be valid UTF-8")?
+                .into_boxed_str(),
         ));
 
         // Encrypt
@@ -864,18 +875,20 @@ impl AgeKeyStore {
         let encrypted = std::fs::read(path).context("Failed to read keystore file")?;
 
         // Create age decryptor
-        let decryptor = match age::Decryptor::new(encrypted.as_slice())? {
-            age::Decryptor::Passphrase(d) => d,
-            _ => anyhow::bail!("Unsupported age encryption type"),
-        };
+        let decryptor = age::Decryptor::new(encrypted.as_slice())?;
+        if !decryptor.is_scrypt() {
+            anyhow::bail!("Unsupported age encryption type");
+        }
 
-        // Decrypt
+        // Decrypt with scrypt identity
         let passphrase_str =
             String::from_utf8(passphrase.to_vec()).context("Passphrase must be valid UTF-8")?;
+        let identity =
+            age::scrypt::Identity::new(SecretString::new(passphrase_str.into_boxed_str()));
 
         let mut decrypted = Vec::new();
         let mut reader = decryptor
-            .decrypt(&Secret::new(passphrase_str), None)
+            .decrypt(std::iter::once(&identity as &dyn age::Identity))
             .context("Failed to decrypt (wrong passphrase?)")?;
 
         std::io::copy(&mut reader, &mut decrypted).context("Failed to read decrypted data")?;


### PR DESCRIPTION
## Summary

Upgrade the age encryption library from 0.10 to 0.11, along with the secrecy crate from 0.8 to 0.10.

- Updated age decryption API to use new opaque `Decryptor` with `is_scrypt()` method
- Changed to `age::scrypt::Identity::new()` pattern for passphrase-based decryption
- Updated `SecretString::new()` calls to take `Box<str>` instead of `String`
- Updated zeroize import to come from zeroize crate directly

## Changes

| File | Description |
|------|-------------|
| `Cargo.toml` | Updated `age = "0.11"` and `secrecy = "0.10"` |
| `keystore.rs` | Updated 4 functions (`decrypt_and_load_v4`, `decrypt_and_load`, `decrypt_and_load_v3`, `encrypt_and_save*`) to use new API |

## Breaking Changes in age 0.11

1. **Decryptor is now opaque**: Cannot pattern match on `Decryptor::Passphrase(d)`. Use `is_scrypt()` method instead.
2. **scrypt::Identity for decryption**: Create identity with `age::scrypt::Identity::new(SecretString)` and pass to `decrypt()`.
3. **SecretString API**: `SecretString::new()` now takes `Box<str>` instead of `String`. Use `.into_boxed_str()`.

## Test plan

- [x] All 181 icn-identity tests pass
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] CI tests pass

Closes #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)