### PR TITLE
feat(ledger): Require witness signatures for material transactions

### DIFF
--- a/icn/crates/icn-ledger/Cargo.toml
+++ b/icn/crates/icn-ledger/Cargo.toml
@@ -23,11 +23,11 @@ tokio.workspace = true
 bytes.workspace = true
 sha2 = "0.10"
 hex = "0.4"
+ed25519-dalek.workspace = true
 
 [dev-dependencies]
 tempfile = "3.24"
 criterion = "0.5"
-ed25519-dalek = "2.2"
 rand = "0.8"
 
 [[bench]]

--- a/icn/crates/icn-ledger/src/fork_resolution.rs
+++ b/icn/crates/icn-ledger/src/fork_resolution.rs
@@ -283,10 +283,20 @@ impl ForkResolver {
     }
 
     /// Count unique signers for an entry
-    fn count_signers(&self, _entry: &JournalEntry) -> usize {
-        // Current implementation: only author signature
-        // Future: multi-party signatures would be counted here
-        1
+    ///
+    /// Currently counts the author signature if present. Future work (Issue #676)
+    /// will add witness signature storage to enable counting co-signers for
+    /// fork resolution. This requires persisting witness signatures alongside
+    /// entries rather than just validating them at append time.
+    fn count_signers(&self, entry: &JournalEntry) -> usize {
+        // Count 1 if author signature is present, 0 otherwise
+        // TODO(#676): Look up witness signatures from storage once implemented
+        if entry.signature.is_some() {
+            1
+        } else {
+            // Entry without signature - still count author as implicit signer
+            1
+        }
     }
 }
 

--- a/icn/crates/icn-ledger/src/fork_resolution.rs
+++ b/icn/crates/icn-ledger/src/fork_resolution.rs
@@ -284,19 +284,14 @@ impl ForkResolver {
 
     /// Count unique signers for an entry
     ///
-    /// Currently counts the author signature if present. Future work (Issue #676)
+    /// Currently always returns 1 (counting the author). Future work (Issue #676)
     /// will add witness signature storage to enable counting co-signers for
     /// fork resolution. This requires persisting witness signatures alongside
     /// entries rather than just validating them at append time.
-    fn count_signers(&self, entry: &JournalEntry) -> usize {
-        // Count 1 if author signature is present, 0 otherwise
+    fn count_signers(&self, _entry: &JournalEntry) -> usize {
         // TODO(#676): Look up witness signatures from storage once implemented
-        if entry.signature.is_some() {
-            1
-        } else {
-            // Entry without signature - still count author as implicit signer
-            1
-        }
+        // For now, always count the author as 1 signer (with or without explicit signature)
+        1
     }
 }
 

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -1008,10 +1008,7 @@ impl Ledger {
     /// Validate witness signatures on a witnessed entry
     ///
     /// Verifies that all signatures are valid Ed25519 signatures over the entry hash.
-    fn validate_witness_signatures(
-        &self,
-        witnessed: &crate::types::WitnessedEntry,
-    ) -> Result<()> {
+    fn validate_witness_signatures(&self, witnessed: &crate::types::WitnessedEntry) -> Result<()> {
         use ed25519_dalek::{Signature, Verifier};
 
         let entry_hash = witnessed
@@ -1033,10 +1030,7 @@ impl Ledger {
             verifying_key
                 .verify(entry_hash.as_bytes(), &signature)
                 .with_context(|| {
-                    format!(
-                        "Witness signature verification failed for {}",
-                        sig.witness
-                    )
+                    format!("Witness signature verification failed for {}", sig.witness)
                 })?;
 
             debug!(witness = %sig.witness, "Witness signature verified");
@@ -1065,16 +1059,16 @@ impl Ledger {
             None => false,
             Some(config) => {
                 let value = self.calculate_entry_value(entry);
-                !matches!(config.effective_policy(value), crate::types::WitnessPolicy::None)
+                !matches!(
+                    config.effective_policy(value),
+                    crate::types::WitnessPolicy::None
+                )
             }
         }
     }
 
     /// Get the effective witness policy for an entry
-    pub fn effective_witness_policy(
-        &self,
-        entry: &JournalEntry,
-    ) -> crate::types::WitnessPolicy {
+    pub fn effective_witness_policy(&self, entry: &JournalEntry) -> crate::types::WitnessPolicy {
         match &self.witness_config {
             None => crate::types::WitnessPolicy::None,
             Some(config) => {
@@ -1618,7 +1612,10 @@ impl Ledger {
                 }
             }
 
-            LedgerSyncMessage::NewWitnessedEntry { hash, mut witnessed } => {
+            LedgerSyncMessage::NewWitnessedEntry {
+                hash,
+                mut witnessed,
+            } => {
                 observe_sync_lag(witnessed.entry.timestamp);
 
                 // Check if we already have this entry

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -157,6 +157,10 @@ pub struct Ledger {
     /// FX configuration for cross-currency transfers
     /// When set, enables cross-currency payment operations.
     fx_config: Option<crate::fx::FxConfig>,
+
+    /// Witness configuration for requiring co-signatures on entries
+    /// When set, entries above threshold require witness signatures (Issue #676)
+    witness_config: Option<crate::types::WitnessConfig>,
 }
 
 impl Ledger {
@@ -191,6 +195,7 @@ impl Ledger {
             dynamic_limit_manager: None,     // Set via set_dynamic_limit_manager()
             oracle_manager: None,            // Set via set_oracle_manager()
             fx_config: None,                 // Set via set_fx_config()
+            witness_config: None,            // Set via set_witness_config()
         };
 
         // Load cached balances from storage
@@ -451,6 +456,20 @@ impl Ledger {
     /// Get the FX configuration (if set)
     pub fn fx_config(&self) -> Option<&crate::fx::FxConfig> {
         self.fx_config.as_ref()
+    }
+
+    /// Set the witness configuration for requiring co-signatures
+    ///
+    /// When set, entries above the configured threshold require witness
+    /// signatures before acceptance. This provides Byzantine fault tolerance
+    /// against authorizer misbehavior.
+    pub fn set_witness_config(&mut self, config: crate::types::WitnessConfig) {
+        self.witness_config = Some(config);
+    }
+
+    /// Get the witness configuration (if set)
+    pub fn witness_config(&self) -> Option<&crate::types::WitnessConfig> {
+        self.witness_config.as_ref()
     }
 
     /// Get prerequisites for cross-currency transfers
@@ -949,6 +968,106 @@ impl Ledger {
         self.append_entry_internal(entry, false).await
     }
 
+    /// Append a witnessed entry with signature validation
+    ///
+    /// This method validates witness signatures before appending. Use this when
+    /// witness requirements are configured on the ledger.
+    #[instrument(skip(self, witnessed), fields(entry_hash = witnessed.entry.id.as_ref().map(|h| h.to_hex()).unwrap_or_else(|| "none".to_string()), witness_count = witnessed.witness_signatures.len()))]
+    pub async fn append_witnessed_entry(
+        &mut self,
+        witnessed: crate::types::WitnessedEntry,
+    ) -> Result<ContentHash> {
+        // Validate witness signatures
+        self.validate_witness_signatures(&witnessed)?;
+
+        // Check if sufficient signatures for the policy
+        if !witnessed.has_sufficient_signatures() {
+            anyhow::bail!(
+                "Insufficient witness signatures: have {}, policy requires more",
+                witnessed.unique_witness_count()
+            );
+        }
+
+        // Append the underlying entry
+        self.append_entry_internal(witnessed.entry, true).await
+    }
+
+    /// Validate witness signatures on a witnessed entry
+    ///
+    /// Verifies that all signatures are valid Ed25519 signatures over the entry hash.
+    fn validate_witness_signatures(
+        &self,
+        witnessed: &crate::types::WitnessedEntry,
+    ) -> Result<()> {
+        use ed25519_dalek::{Signature, Verifier};
+
+        let entry_hash = witnessed
+            .entry
+            .id
+            .as_ref()
+            .context("Entry must have hash for witness validation")?;
+
+        for sig in &witnessed.witness_signatures {
+            // Extract public key from witness DID using icn-identity
+            let verifying_key = sig
+                .witness
+                .to_verifying_key()
+                .context("Failed to extract verifying key from witness DID")?;
+
+            let signature = Signature::from_slice(&sig.signature)
+                .context("Invalid Ed25519 signature format")?;
+
+            verifying_key
+                .verify(entry_hash.as_bytes(), &signature)
+                .context(format!(
+                    "Witness signature verification failed for {}",
+                    sig.witness
+                ))?;
+
+            debug!(witness = %sig.witness, "Witness signature verified");
+        }
+
+        Ok(())
+    }
+
+    /// Calculate the total absolute value of an entry (for threshold comparison)
+    pub fn calculate_entry_value(&self, entry: &JournalEntry) -> u64 {
+        entry
+            .accounts
+            .iter()
+            .map(|delta| {
+                let debit = delta.debit.unwrap_or(0).unsigned_abs();
+                let credit = delta.credit.unwrap_or(0).unsigned_abs();
+                debit.max(credit)
+            })
+            .sum()
+    }
+
+    /// Check if an entry requires witness signatures based on current config
+    pub fn requires_witnesses(&self, entry: &JournalEntry) -> bool {
+        match &self.witness_config {
+            None => false,
+            Some(config) => {
+                let value = self.calculate_entry_value(entry);
+                !matches!(config.effective_policy(value), crate::types::WitnessPolicy::None)
+            }
+        }
+    }
+
+    /// Get the effective witness policy for an entry
+    pub fn effective_witness_policy(
+        &self,
+        entry: &JournalEntry,
+    ) -> crate::types::WitnessPolicy {
+        match &self.witness_config {
+            None => crate::types::WitnessPolicy::None,
+            Some(config) => {
+                let value = self.calculate_entry_value(entry);
+                config.effective_policy(value).clone()
+            }
+        }
+    }
+
     /// Internal append method with control over gossip publishing
     ///
     /// # Arguments
@@ -1431,6 +1550,7 @@ impl Ledger {
     /// Handle an incoming sync message from gossip
     #[instrument(skip(self, msg), fields(message_type = match &msg {
         LedgerSyncMessage::NewEntry { .. } => "NewEntry",
+        LedgerSyncMessage::NewWitnessedEntry { .. } => "NewWitnessedEntry",
         LedgerSyncMessage::RequestEntry { .. } => "RequestEntry",
         LedgerSyncMessage::EntryResponse { .. } => "EntryResponse",
         LedgerSyncMessage::RollbackNotification { .. } => "RollbackNotification",
@@ -1476,6 +1596,65 @@ impl Ledger {
                             entry_hash = %hash,
                             error = %e,
                             "Failed to store received entry"
+                        );
+                        Ok(()) // Don't propagate error, just log it
+                    }
+                }
+            }
+
+            LedgerSyncMessage::NewWitnessedEntry { hash, mut witnessed } => {
+                observe_sync_lag(witnessed.entry.timestamp);
+
+                // Check if we already have this entry
+                if self.get_entry(&hash)?.is_some() {
+                    debug!(
+                        entry_hash = %hash,
+                        "Already have witnessed entry, skipping duplicate"
+                    );
+                    return Ok(());
+                }
+
+                // Ensure entry has the correct ID
+                witnessed.entry.id = Some(hash.clone());
+
+                // Validate witness signatures before accepting
+                if let Err(e) = self.validate_witness_signatures(&witnessed) {
+                    warn!(
+                        entry_hash = %hash,
+                        error = %e,
+                        "Witnessed entry signature validation failed"
+                    );
+                    return Ok(()); // Reject silently
+                }
+
+                // Check sufficient signatures
+                if !witnessed.has_sufficient_signatures() {
+                    warn!(
+                        entry_hash = %hash,
+                        witness_count = witnessed.unique_witness_count(),
+                        "Witnessed entry has insufficient signatures"
+                    );
+                    return Ok(()); // Reject silently
+                }
+
+                // Store the underlying entry (without re-broadcasting)
+                let result = self.append_entry_from_sync(witnessed.entry).await;
+
+                match result {
+                    Ok(h) => {
+                        info!(
+                            entry_hash = %h,
+                            witness_count = witnessed.witness_signatures.len(),
+                            source = "gossip",
+                            "Received and stored witnessed ledger entry"
+                        );
+                        Ok(())
+                    }
+                    Err(e) => {
+                        warn!(
+                            entry_hash = %hash,
+                            error = %e,
+                            "Failed to store received witnessed entry"
                         );
                         Ok(()) // Don't propagate error, just log it
                     }

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -978,18 +978,31 @@ impl Ledger {
         witnessed: crate::types::WitnessedEntry,
     ) -> Result<ContentHash> {
         // Validate witness signatures
-        self.validate_witness_signatures(&witnessed)?;
+        if let Err(e) = self.validate_witness_signatures(&witnessed) {
+            icn_obs::metrics::ledger::witnessed_entries_rejected_invalid_signature_inc();
+            return Err(e);
+        }
 
         // Check if sufficient signatures for the policy
         if !witnessed.has_sufficient_signatures() {
+            icn_obs::metrics::ledger::witnessed_entries_rejected_insufficient_inc();
             anyhow::bail!(
                 "Insufficient witness signatures: have {}, policy requires more",
                 witnessed.unique_witness_count()
             );
         }
 
+        // Record witness count metric
+        let witness_count = witnessed.witness_signatures.len() as u64;
+
         // Append the underlying entry
-        self.append_entry_internal(witnessed.entry, true).await
+        let hash = self.append_entry_internal(witnessed.entry, true).await?;
+
+        // Record success metrics
+        icn_obs::metrics::ledger::witnessed_entries_accepted_inc();
+        icn_obs::metrics::ledger::witness_signature_count_record(witness_count);
+
+        Ok(hash)
     }
 
     /// Validate witness signatures on a witnessed entry
@@ -1019,10 +1032,12 @@ impl Ledger {
 
             verifying_key
                 .verify(entry_hash.as_bytes(), &signature)
-                .context(format!(
-                    "Witness signature verification failed for {}",
-                    sig.witness
-                ))?;
+                .with_context(|| {
+                    format!(
+                        "Witness signature verification failed for {}",
+                        sig.witness
+                    )
+                })?;
 
             debug!(witness = %sig.witness, "Witness signature verified");
         }
@@ -1031,15 +1046,16 @@ impl Ledger {
     }
 
     /// Calculate the total absolute value of an entry (for threshold comparison)
+    ///
+    /// Uses only debits to determine transaction value. In a balanced double-entry
+    /// system, total debits equal total credits, so this correctly represents the
+    /// transaction size without double-counting.
     pub fn calculate_entry_value(&self, entry: &JournalEntry) -> u64 {
         entry
             .accounts
             .iter()
-            .map(|delta| {
-                let debit = delta.debit.unwrap_or(0).unsigned_abs();
-                let credit = delta.credit.unwrap_or(0).unsigned_abs();
-                debit.max(credit)
-            })
+            .filter_map(|delta| delta.debit)
+            .map(|d| d.unsigned_abs())
             .sum()
     }
 
@@ -1624,6 +1640,7 @@ impl Ledger {
                         error = %e,
                         "Witnessed entry signature validation failed"
                     );
+                    icn_obs::metrics::ledger::witnessed_entries_rejected_invalid_signature_inc();
                     return Ok(()); // Reject silently
                 }
 
@@ -1634,8 +1651,11 @@ impl Ledger {
                         witness_count = witnessed.unique_witness_count(),
                         "Witnessed entry has insufficient signatures"
                     );
+                    icn_obs::metrics::ledger::witnessed_entries_rejected_insufficient_inc();
                     return Ok(()); // Reject silently
                 }
+
+                let witness_count = witnessed.witness_signatures.len() as u64;
 
                 // Store the underlying entry (without re-broadcasting)
                 let result = self.append_entry_from_sync(witnessed.entry).await;
@@ -1644,10 +1664,12 @@ impl Ledger {
                     Ok(h) => {
                         info!(
                             entry_hash = %h,
-                            witness_count = witnessed.witness_signatures.len(),
+                            witness_count = witness_count,
                             source = "gossip",
                             "Received and stored witnessed ledger entry"
                         );
+                        icn_obs::metrics::ledger::witnessed_entries_accepted_inc();
+                        icn_obs::metrics::ledger::witness_signature_count_record(witness_count);
                         Ok(())
                     }
                     Err(e) => {

--- a/icn/crates/icn-ledger/src/lib.rs
+++ b/icn/crates/icn-ledger/src/lib.rs
@@ -102,6 +102,7 @@ pub use treasury::{
 pub use types::{
     AccountBalances, AccountDelta, ContentHash, CreditLimit, Currency, Dispute, DisputeOutcome,
     DisputeStatus, JournalEntry, QuarantineReason, QuarantinedEntry, Resolution, Signature,
+    WitnessConfig, WitnessPolicy, WitnessSignature, WitnessedEntry,
 };
 
 // Labor shares and cooperative bonds (Razeto integration)

--- a/icn/crates/icn-ledger/src/sync.rs
+++ b/icn/crates/icn-ledger/src/sync.rs
@@ -1,16 +1,25 @@
 //! Ledger synchronization via gossip
 
-use crate::types::{ContentHash, JournalEntry};
+use crate::types::{ContentHash, JournalEntry, WitnessedEntry};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 /// Message types for ledger synchronization
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum LedgerSyncMessage {
-    /// Announce a new journal entry
+    /// Announce a new journal entry (without witness signatures)
     NewEntry {
         hash: ContentHash,
         entry: JournalEntry,
+    },
+
+    /// Announce a new witnessed entry with signatures (Issue #676)
+    ///
+    /// Used when the ledger requires witness signatures for entries above
+    /// a certain threshold. Receivers validate signatures before accepting.
+    NewWitnessedEntry {
+        hash: ContentHash,
+        witnessed: WitnessedEntry,
     },
 
     /// Request a journal entry by hash

--- a/icn/crates/icn-ledger/src/types.rs
+++ b/icn/crates/icn-ledger/src/types.rs
@@ -446,7 +446,10 @@ impl WitnessConfig {
     /// Create config requiring quorum for all entries
     pub fn quorum(required: u32, witnesses: Vec<Did>) -> Self {
         WitnessConfig {
-            default_policy: WitnessPolicy::Quorum { required, witnesses },
+            default_policy: WitnessPolicy::Quorum {
+                required,
+                witnesses,
+            },
             threshold: None,
             collection_timeout_secs: 300,
         }
@@ -540,7 +543,10 @@ impl WitnessedEntry {
                     .iter()
                     .any(|s| counterparties.contains(&s.witness))
             }
-            WitnessPolicy::Quorum { required, witnesses } => {
+            WitnessPolicy::Quorum {
+                required,
+                witnesses,
+            } => {
                 // Only count signatures from authorized witnesses (unique DIDs)
                 let allowed_witnesses: std::collections::HashSet<_> = witnesses.iter().collect();
                 let signed_authorized: std::collections::HashSet<_> = self

--- a/icn/crates/icn-ledger/src/types.rs
+++ b/icn/crates/icn-ledger/src/types.rs
@@ -383,9 +383,10 @@ pub struct Dispute {
 /// Witness signatures provide Byzantine fault tolerance by requiring
 /// multiple parties to co-sign transactions, preventing unilateral
 /// manipulation by ledger authorizers.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum WitnessPolicy {
     /// No witnesses required (current behavior, suitable for low-value transactions)
+    #[default]
     None,
 
     /// Require counterparty signature (the other party to the transaction)
@@ -403,12 +404,6 @@ pub enum WitnessPolicy {
     AllParties,
 }
 
-impl Default for WitnessPolicy {
-    fn default() -> Self {
-        WitnessPolicy::None
-    }
-}
-
 /// Configuration for witness requirements on a ledger
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WitnessConfig {
@@ -419,8 +414,12 @@ pub struct WitnessConfig {
     /// If None, policy applies to all entries regardless of value
     pub threshold: Option<u64>,
 
-    /// Grace period (in seconds) to collect witness signatures
-    /// After this time, unsigned entries may be rejected
+    /// Grace period (in seconds) to collect witness signatures.
+    /// After this time, unsigned entries may be rejected.
+    ///
+    /// TODO(witness-timeout): Implement timestamp validation against this timeout
+    /// in `validate_witness_signatures()`. Currently signatures are validated
+    /// cryptographically but not checked for expiration.
     pub collection_timeout_secs: u64,
 }
 
@@ -471,7 +470,10 @@ pub struct WitnessSignature {
     /// Ed25519 signature over the entry hash
     pub signature: Vec<u8>,
 
-    /// Timestamp when signature was created
+    /// Timestamp when signature was created (Unix epoch seconds).
+    ///
+    /// TODO(witness-timeout): This timestamp should be validated against
+    /// `WitnessConfig::collection_timeout_secs` to reject expired signatures.
     pub signed_at: u64,
 }
 
@@ -519,16 +521,38 @@ impl WitnessedEntry {
     }
 
     /// Check if the entry has sufficient signatures for the applied policy
+    ///
+    /// Note: This only checks that the policy requirements are met structurally.
+    /// Cryptographic signature validation must be performed separately by the caller.
     pub fn has_sufficient_signatures(&self) -> bool {
         match &self.policy_applied {
             WitnessPolicy::None => true,
-            WitnessPolicy::Counterparty => !self.witness_signatures.is_empty(),
-            WitnessPolicy::Quorum { required, .. } => {
-                self.witness_signatures.len() >= *required as usize
+            WitnessPolicy::Counterparty => {
+                // Require at least one witness who is a non-author counterparty
+                let counterparties: std::collections::HashSet<_> = self
+                    .entry
+                    .accounts
+                    .iter()
+                    .map(|d| &d.account_id)
+                    .filter(|id| **id != self.entry.author)
+                    .collect();
+                self.witness_signatures
+                    .iter()
+                    .any(|s| counterparties.contains(&s.witness))
+            }
+            WitnessPolicy::Quorum { required, witnesses } => {
+                // Only count signatures from authorized witnesses (unique DIDs)
+                let allowed_witnesses: std::collections::HashSet<_> = witnesses.iter().collect();
+                let signed_authorized: std::collections::HashSet<_> = self
+                    .witness_signatures
+                    .iter()
+                    .map(|s| &s.witness)
+                    .filter(|w| allowed_witnesses.contains(w))
+                    .collect();
+                signed_authorized.len() >= *required as usize
             }
             WitnessPolicy::AllParties => {
-                // Need to check against entry participants - caller must verify
-                // For now, require at least one signature per non-author account
+                // Each non-author account must have signed as a witness
                 let unique_accounts: std::collections::HashSet<_> = self
                     .entry
                     .accounts

--- a/icn/crates/icn-ledger/src/types.rs
+++ b/icn/crates/icn-ledger/src/types.rs
@@ -373,3 +373,185 @@ pub struct Dispute {
     /// Optional mediator assigned
     pub mediator: Option<Did>,
 }
+
+// ============================================================================
+// Witness Signature Types (BFT Hardening - Issue #676)
+// ============================================================================
+
+/// Policy for requiring witness signatures on ledger entries
+///
+/// Witness signatures provide Byzantine fault tolerance by requiring
+/// multiple parties to co-sign transactions, preventing unilateral
+/// manipulation by ledger authorizers.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum WitnessPolicy {
+    /// No witnesses required (current behavior, suitable for low-value transactions)
+    None,
+
+    /// Require counterparty signature (the other party to the transaction)
+    Counterparty,
+
+    /// Require N-of-M designated witnesses to co-sign
+    Quorum {
+        /// Minimum signatures required
+        required: u32,
+        /// List of authorized witnesses
+        witnesses: Vec<Did>,
+    },
+
+    /// Require all parties involved in the transaction to sign
+    AllParties,
+}
+
+impl Default for WitnessPolicy {
+    fn default() -> Self {
+        WitnessPolicy::None
+    }
+}
+
+/// Configuration for witness requirements on a ledger
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WitnessConfig {
+    /// Default policy for all entries
+    pub default_policy: WitnessPolicy,
+
+    /// Value threshold above which witnesses are required
+    /// If None, policy applies to all entries regardless of value
+    pub threshold: Option<u64>,
+
+    /// Grace period (in seconds) to collect witness signatures
+    /// After this time, unsigned entries may be rejected
+    pub collection_timeout_secs: u64,
+}
+
+impl Default for WitnessConfig {
+    fn default() -> Self {
+        WitnessConfig {
+            default_policy: WitnessPolicy::None,
+            threshold: None,
+            collection_timeout_secs: 300, // 5 minutes default
+        }
+    }
+}
+
+impl WitnessConfig {
+    /// Create config requiring counterparty signature above threshold
+    pub fn counterparty_above(threshold: u64) -> Self {
+        WitnessConfig {
+            default_policy: WitnessPolicy::Counterparty,
+            threshold: Some(threshold),
+            collection_timeout_secs: 300,
+        }
+    }
+
+    /// Create config requiring quorum for all entries
+    pub fn quorum(required: u32, witnesses: Vec<Did>) -> Self {
+        WitnessConfig {
+            default_policy: WitnessPolicy::Quorum { required, witnesses },
+            threshold: None,
+            collection_timeout_secs: 300,
+        }
+    }
+
+    /// Determine the effective policy for a given entry value
+    pub fn effective_policy(&self, entry_value: u64) -> &WitnessPolicy {
+        match self.threshold {
+            Some(thresh) if entry_value < thresh => &WitnessPolicy::None,
+            _ => &self.default_policy,
+        }
+    }
+}
+
+/// A witness signature on a ledger entry
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WitnessSignature {
+    /// DID of the witness who signed
+    pub witness: Did,
+
+    /// Ed25519 signature over the entry hash
+    pub signature: Vec<u8>,
+
+    /// Timestamp when signature was created
+    pub signed_at: u64,
+}
+
+impl WitnessSignature {
+    /// Create a new witness signature
+    pub fn new(witness: Did, signature: Vec<u8>, signed_at: u64) -> Self {
+        WitnessSignature {
+            witness,
+            signature,
+            signed_at,
+        }
+    }
+}
+
+/// A journal entry with attached witness signatures
+///
+/// This wraps a JournalEntry with the required witness signatures
+/// based on the ledger's WitnessPolicy. The entry hash is signed
+/// by witnesses, not the full entry content.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WitnessedEntry {
+    /// The underlying journal entry
+    pub entry: JournalEntry,
+
+    /// Witness signatures collected for this entry
+    pub witness_signatures: Vec<WitnessSignature>,
+
+    /// The policy that was applied when collecting signatures
+    pub policy_applied: WitnessPolicy,
+}
+
+impl WitnessedEntry {
+    /// Create a new witnessed entry with no signatures yet
+    pub fn new(entry: JournalEntry, policy: WitnessPolicy) -> Self {
+        WitnessedEntry {
+            entry,
+            witness_signatures: Vec::new(),
+            policy_applied: policy,
+        }
+    }
+
+    /// Add a witness signature
+    pub fn add_signature(&mut self, sig: WitnessSignature) {
+        self.witness_signatures.push(sig);
+    }
+
+    /// Check if the entry has sufficient signatures for the applied policy
+    pub fn has_sufficient_signatures(&self) -> bool {
+        match &self.policy_applied {
+            WitnessPolicy::None => true,
+            WitnessPolicy::Counterparty => !self.witness_signatures.is_empty(),
+            WitnessPolicy::Quorum { required, .. } => {
+                self.witness_signatures.len() >= *required as usize
+            }
+            WitnessPolicy::AllParties => {
+                // Need to check against entry participants - caller must verify
+                // For now, require at least one signature per non-author account
+                let unique_accounts: std::collections::HashSet<_> = self
+                    .entry
+                    .accounts
+                    .iter()
+                    .map(|d| &d.account_id)
+                    .filter(|id| **id != self.entry.author)
+                    .collect();
+                let signed_witnesses: std::collections::HashSet<_> =
+                    self.witness_signatures.iter().map(|s| &s.witness).collect();
+                unique_accounts.iter().all(|a| signed_witnesses.contains(a))
+            }
+        }
+    }
+
+    /// Get the entry hash that witnesses should sign
+    pub fn entry_hash(&self) -> Option<&ContentHash> {
+        self.entry.id.as_ref()
+    }
+
+    /// Count unique witnesses who have signed
+    pub fn unique_witness_count(&self) -> usize {
+        let witnesses: std::collections::HashSet<_> =
+            self.witness_signatures.iter().map(|s| &s.witness).collect();
+        witnesses.len()
+    }
+}

--- a/icn/crates/icn-ledger/tests/gossip_sync.rs
+++ b/icn/crates/icn-ledger/tests/gossip_sync.rs
@@ -3,7 +3,10 @@
 
 use icn_gossip::GossipActor;
 use icn_identity::KeyPair;
-use icn_ledger::{entry::JournalEntryBuilder, Ledger, LedgerSyncMessage};
+use icn_ledger::{
+    entry::JournalEntryBuilder, Ledger, LedgerSyncMessage, WitnessConfig, WitnessPolicy,
+    WitnessSignature, WitnessedEntry,
+};
 use icn_store::SledStore;
 use icn_trust::TrustClass;
 use std::sync::Arc;
@@ -208,4 +211,222 @@ async fn test_duplicate_entry_handling() {
     assert_eq!(all_entries.len(), 1);
 
     println!("Duplicate entry handling successful");
+}
+
+// ============================================================================
+// Witness Signature Tests (Issue #676)
+// ============================================================================
+
+#[tokio::test]
+async fn test_witnessed_entry_with_valid_signature() {
+    // Create a simple ledger with witness config
+    let (mut ledger, _temp) = create_simple_ledger();
+    ledger.set_witness_config(WitnessConfig::counterparty_above(0)); // Require witness for all
+
+    let alice_kp = KeyPair::generate().unwrap();
+    let bob_kp = KeyPair::generate().unwrap();
+    let alice = alice_kp.did().clone();
+    let bob = bob_kp.did().clone();
+
+    // Create an entry
+    let entry = JournalEntryBuilder::new(alice.clone())
+        .debit(alice.clone(), "hours".to_string(), 10)
+        .credit(bob.clone(), "hours".to_string(), 10)
+        .build()
+        .unwrap();
+
+    let hash = entry.id.clone().unwrap();
+
+    // Create witness signature from Bob
+    let signature = bob_kp.sign(hash.as_bytes());
+    let witness_sig = WitnessSignature::new(
+        bob.clone(),
+        signature.to_bytes().to_vec(),
+        icn_time::current_timestamp_secs(),
+    );
+
+    // Create witnessed entry with counterparty policy
+    let mut witnessed = WitnessedEntry::new(entry, WitnessPolicy::Counterparty);
+    witnessed.add_signature(witness_sig);
+
+    // Append should succeed
+    let result_hash = ledger.append_witnessed_entry(witnessed).await.unwrap();
+    assert_eq!(result_hash, hash);
+
+    // Verify entry was stored
+    assert!(ledger.get_entry(&hash).unwrap().is_some());
+    assert_eq!(ledger.get_balance(&alice, "hours"), 10);
+
+    println!("Witnessed entry with valid signature accepted");
+}
+
+#[tokio::test]
+async fn test_witnessed_entry_with_invalid_signature() {
+    // Create a simple ledger
+    let (mut ledger, _temp) = create_simple_ledger();
+    ledger.set_witness_config(WitnessConfig::counterparty_above(0));
+
+    let alice_kp = KeyPair::generate().unwrap();
+    let bob_kp = KeyPair::generate().unwrap();
+    let wrong_kp = KeyPair::generate().unwrap(); // Different key
+    let alice = alice_kp.did().clone();
+    let bob = bob_kp.did().clone();
+
+    // Create an entry
+    let entry = JournalEntryBuilder::new(alice.clone())
+        .debit(alice.clone(), "hours".to_string(), 10)
+        .credit(bob.clone(), "hours".to_string(), 10)
+        .build()
+        .unwrap();
+
+    let hash = entry.id.clone().unwrap();
+
+    // Create signature with wrong key but claim it's from Bob
+    let wrong_signature = wrong_kp.sign(hash.as_bytes());
+    let witness_sig = WitnessSignature::new(
+        bob.clone(), // Claims to be Bob
+        wrong_signature.to_bytes().to_vec(),
+        icn_time::current_timestamp_secs(),
+    );
+
+    let mut witnessed = WitnessedEntry::new(entry, WitnessPolicy::Counterparty);
+    witnessed.add_signature(witness_sig);
+
+    // Append should fail due to invalid signature
+    let result = ledger.append_witnessed_entry(witnessed).await;
+    assert!(result.is_err(), "Expected error for invalid signature");
+
+    // Verify entry was NOT stored
+    assert!(ledger.get_entry(&hash).unwrap().is_none());
+
+    println!("Witnessed entry with invalid signature rejected");
+}
+
+#[tokio::test]
+async fn test_witnessed_entry_insufficient_signatures() {
+    let (mut ledger, _temp) = create_simple_ledger();
+
+    // Require 2-of-3 quorum
+    let witness1 = KeyPair::generate().unwrap().did().clone();
+    let witness2 = KeyPair::generate().unwrap().did().clone();
+    let witness3 = KeyPair::generate().unwrap().did().clone();
+
+    ledger.set_witness_config(WitnessConfig::quorum(
+        2,
+        vec![witness1.clone(), witness2.clone(), witness3.clone()],
+    ));
+
+    let alice_kp = KeyPair::generate().unwrap();
+    let bob_kp = KeyPair::generate().unwrap();
+    let alice = alice_kp.did().clone();
+    let bob = bob_kp.did().clone();
+
+    let entry = JournalEntryBuilder::new(alice.clone())
+        .debit(alice.clone(), "hours".to_string(), 10)
+        .credit(bob.clone(), "hours".to_string(), 10)
+        .build()
+        .unwrap();
+
+    // Create witnessed entry with only one signature (need 2)
+    let witnessed = WitnessedEntry::new(entry, WitnessPolicy::Quorum {
+        required: 2,
+        witnesses: vec![witness1, witness2, witness3],
+    });
+    // No signatures added
+
+    // Should fail due to insufficient signatures
+    let result = ledger.append_witnessed_entry(witnessed).await;
+    assert!(result.is_err(), "Expected error for insufficient signatures");
+
+    println!("Witnessed entry with insufficient signatures rejected");
+}
+
+#[tokio::test]
+async fn test_witnessed_entry_sync_message() {
+    // Create two simple ledgers
+    let (mut ledger1, _temp1) = create_simple_ledger();
+    let (mut ledger2, _temp2) = create_simple_ledger();
+
+    let alice_kp = KeyPair::generate().unwrap();
+    let bob_kp = KeyPair::generate().unwrap();
+    let alice = alice_kp.did().clone();
+    let bob = bob_kp.did().clone();
+
+    // Create an entry
+    let entry = JournalEntryBuilder::new(alice.clone())
+        .debit(alice.clone(), "hours".to_string(), 10)
+        .credit(bob.clone(), "hours".to_string(), 10)
+        .build()
+        .unwrap();
+
+    let hash = entry.id.clone().unwrap();
+
+    // Create witness signature from Bob
+    let signature = bob_kp.sign(hash.as_bytes());
+    let witness_sig = WitnessSignature::new(
+        bob.clone(),
+        signature.to_bytes().to_vec(),
+        icn_time::current_timestamp_secs(),
+    );
+
+    let mut witnessed = WitnessedEntry::new(entry, WitnessPolicy::Counterparty);
+    witnessed.add_signature(witness_sig);
+
+    // Append to ledger1 directly (without witness validation in this case)
+    ledger1
+        .append_entry(witnessed.entry.clone())
+        .await
+        .unwrap();
+
+    // Create sync message for ledger2
+    let sync_msg = LedgerSyncMessage::NewWitnessedEntry {
+        hash: hash.clone(),
+        witnessed,
+    };
+
+    // Send to ledger2
+    ledger2.handle_sync_message(sync_msg).await.unwrap();
+
+    // Verify ledger2 has the entry
+    assert!(ledger2.get_entry(&hash).unwrap().is_some());
+    assert_eq!(ledger2.get_balance(&alice, "hours"), 10);
+
+    println!("Witnessed entry sync message handled successfully");
+}
+
+#[tokio::test]
+async fn test_witness_policy_threshold() {
+    let (mut ledger, _temp) = create_simple_ledger();
+
+    // Only require witnesses for entries above 100 units
+    ledger.set_witness_config(WitnessConfig::counterparty_above(100));
+
+    let alice_kp = KeyPair::generate().unwrap();
+    let bob_kp = KeyPair::generate().unwrap();
+    let alice = alice_kp.did().clone();
+    let bob = bob_kp.did().clone();
+
+    // Small entry (10 units) - should NOT require witnesses
+    let small_entry = JournalEntryBuilder::new(alice.clone())
+        .debit(alice.clone(), "hours".to_string(), 10)
+        .credit(bob.clone(), "hours".to_string(), 10)
+        .build()
+        .unwrap();
+
+    assert!(!ledger.requires_witnesses(&small_entry));
+
+    // Large entry (200 units) - SHOULD require witnesses
+    let large_entry = JournalEntryBuilder::new(alice.clone())
+        .debit(alice.clone(), "hours".to_string(), 200)
+        .credit(bob.clone(), "hours".to_string(), 200)
+        .build()
+        .unwrap();
+
+    assert!(ledger.requires_witnesses(&large_entry));
+
+    // Small entry can be appended without witnesses
+    ledger.append_entry(small_entry).await.unwrap();
+    assert_eq!(ledger.get_balance(&alice, "hours"), 10);
+
+    println!("Witness threshold policy works correctly");
 }

--- a/icn/crates/icn-ledger/tests/gossip_sync.rs
+++ b/icn/crates/icn-ledger/tests/gossip_sync.rs
@@ -328,15 +328,21 @@ async fn test_witnessed_entry_insufficient_signatures() {
         .unwrap();
 
     // Create witnessed entry with only one signature (need 2)
-    let witnessed = WitnessedEntry::new(entry, WitnessPolicy::Quorum {
-        required: 2,
-        witnesses: vec![witness1, witness2, witness3],
-    });
+    let witnessed = WitnessedEntry::new(
+        entry,
+        WitnessPolicy::Quorum {
+            required: 2,
+            witnesses: vec![witness1, witness2, witness3],
+        },
+    );
     // No signatures added
 
     // Should fail due to insufficient signatures
     let result = ledger.append_witnessed_entry(witnessed).await;
-    assert!(result.is_err(), "Expected error for insufficient signatures");
+    assert!(
+        result.is_err(),
+        "Expected error for insufficient signatures"
+    );
 
     println!("Witnessed entry with insufficient signatures rejected");
 }
@@ -373,10 +379,7 @@ async fn test_witnessed_entry_sync_message() {
     witnessed.add_signature(witness_sig);
 
     // Append to ledger1 directly (without witness validation in this case)
-    ledger1
-        .append_entry(witnessed.entry.clone())
-        .await
-        .unwrap();
+    ledger1.append_entry(witnessed.entry.clone()).await.unwrap();
 
     // Create sync message for ledger2
     let sync_msg = LedgerSyncMessage::NewWitnessedEntry {

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -2414,6 +2414,28 @@ pub mod ledger {
     pub fn entries_rejected_missing_parents_inc() {
         counter!("icn_ledger_entries_rejected_missing_parents_total").increment(1);
     }
+
+    // Witness signature metrics (Issue #676)
+
+    /// Increment counter when a witnessed entry is successfully validated and stored
+    pub fn witnessed_entries_accepted_inc() {
+        counter!("icn_ledger_witnessed_entries_accepted_total").increment(1);
+    }
+
+    /// Increment counter when a witnessed entry is rejected due to invalid signature
+    pub fn witnessed_entries_rejected_invalid_signature_inc() {
+        counter!("icn_ledger_witnessed_entries_rejected_invalid_signature_total").increment(1);
+    }
+
+    /// Increment counter when a witnessed entry is rejected due to insufficient signatures
+    pub fn witnessed_entries_rejected_insufficient_inc() {
+        counter!("icn_ledger_witnessed_entries_rejected_insufficient_total").increment(1);
+    }
+
+    /// Record the number of witness signatures on an accepted entry
+    pub fn witness_signature_count_record(count: u64) {
+        histogram!("icn_ledger_witness_signature_count").record(count as f64);
+    }
 }
 
 /// Governance execution metrics

--- a/icn/crates/icn-trust/src/evidence_validator.rs
+++ b/icn/crates/icn-trust/src/evidence_validator.rs
@@ -202,7 +202,7 @@ impl EvidenceValidator {
             Ok(None) => {
                 // Contract not found, try agreement store if agreement_id provided
                 if let Some(aid) = agreement_id {
-                    let agreement_key = format!("agreements/{}", aid);
+                    let agreement_key = format!("agreements/{aid}");
                     if self
                         .store
                         .get(agreement_key.as_bytes())


### PR DESCRIPTION
## Summary

Implements initial infrastructure for requiring witness co-signatures on ledger entries (#676). This is part of BFT hardening to prevent authorizer misbehavior.

- Add `WitnessPolicy` enum (None, Counterparty, Quorum, AllParties)
- Add `WitnessConfig` for configuring witness requirements per ledger
- Add `WitnessSignature` and `WitnessedEntry` types
- Add `append_witnessed_entry()` with Ed25519 signature validation
- Add `NewWitnessedEntry` gossip message for syncing witnessed entries

## Test plan

- [x] All 237 icn-ledger unit tests pass
- [x] Doc tests pass
- [ ] Add integration tests for witness flows (future commit)
- [ ] Add metrics for witnessed entries (future commit)

## Remaining work

This PR covers the core types and validation. Still needed for full #676:
- Fork resolution considering witness count
- Metrics (`icn_witnessed_entries_total`, `icn_witness_validation_failures_total`)
- Integration tests for two-node witness flows
- Migration strategy for existing entries

## Part of

Epic: #672 (Byzantine Fault Tolerance Hardening)
Closes: partial progress on #676

🤖 Generated with [Claude Code](https://claude.ai/code)