### PR TITLE
feat(ledger): Add timestamp validation for witness signatures

### DIFF
--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -1020,10 +1020,15 @@ impl Ledger {
             .as_ref()
             .context("Entry must have hash for witness validation")?;
 
-        // Get current time for timestamp validation
-        let current_time = icn_time::current_timestamp_secs();
+        // Get current time for timestamp validation, failing closed on clock errors
+        // to prevent accepting invalid timestamps when the system clock is misconfigured
+        let current_time = icn_time::try_current_timestamp_secs()
+            .context("Failed to get current time for witness validation")?;
 
-        // Maximum allowed clock skew (5 seconds) to tolerate minor time differences
+        // Maximum allowed clock skew for witness signatures (5 seconds).
+        // This is intentionally stricter than icn-time::MAX_CLOCK_SKEW (300s) because
+        // ledger security requires tighter timestamp validation to limit the replay
+        // attack window. Witness signatures should be created and validated promptly.
         const MAX_CLOCK_SKEW_SECS: u64 = 5;
 
         for sig in &witnessed.witness_signatures {
@@ -4631,6 +4636,131 @@ mod tests {
         assert!(
             result.is_ok(),
             "Timestamp within clock skew tolerance should be accepted: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_witness_signature_exactly_at_clock_skew_boundary() {
+        let (mut ledger, _temp) = create_test_ledger();
+        let alice_kp = KeyPair::generate().unwrap();
+        let alice = alice_kp.did().clone();
+        let bob_kp = KeyPair::generate().unwrap();
+        let bob = bob_kp.did().clone();
+
+        // Configure witness requirements
+        ledger.set_witness_config(crate::types::WitnessConfig::counterparty_above(0));
+
+        let entry = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 10)
+            .credit(bob.clone(), "hours".to_string(), 10)
+            .build()
+            .unwrap();
+
+        let entry_hash = entry.id.clone().unwrap();
+
+        // Create signature with timestamp exactly at the boundary (5s in future)
+        let at_boundary = icn_time::current_timestamp_secs() + 5;
+        let signature = bob_kp.sign(entry_hash.as_bytes());
+        let witness_sig = crate::types::WitnessSignature::new(
+            bob.clone(),
+            signature.to_bytes().to_vec(),
+            at_boundary,
+        );
+
+        let witnessed = crate::types::WitnessedEntry {
+            entry,
+            witness_signatures: vec![witness_sig],
+            policy_applied: crate::types::WitnessPolicy::Counterparty,
+        };
+
+        let result = ledger.validate_witness_signatures(&witnessed);
+        assert!(
+            result.is_ok(),
+            "Timestamp exactly at clock skew boundary should be accepted: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_witness_signature_just_past_clock_skew_boundary() {
+        let (mut ledger, _temp) = create_test_ledger();
+        let alice_kp = KeyPair::generate().unwrap();
+        let alice = alice_kp.did().clone();
+        let bob_kp = KeyPair::generate().unwrap();
+        let bob = bob_kp.did().clone();
+
+        // Configure witness requirements
+        ledger.set_witness_config(crate::types::WitnessConfig::counterparty_above(0));
+
+        let entry = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 10)
+            .credit(bob.clone(), "hours".to_string(), 10)
+            .build()
+            .unwrap();
+
+        let entry_hash = entry.id.clone().unwrap();
+
+        // Create signature with timestamp just past the boundary (6s in future)
+        let past_boundary = icn_time::current_timestamp_secs() + 6;
+        let signature = bob_kp.sign(entry_hash.as_bytes());
+        let witness_sig = crate::types::WitnessSignature::new(
+            bob.clone(),
+            signature.to_bytes().to_vec(),
+            past_boundary,
+        );
+
+        let witnessed = crate::types::WitnessedEntry {
+            entry,
+            witness_signatures: vec![witness_sig],
+            policy_applied: crate::types::WitnessPolicy::Counterparty,
+        };
+
+        let result = ledger.validate_witness_signatures(&witnessed);
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("in the future"),
+            "Error should mention 'in the future'"
+        );
+    }
+
+    #[test]
+    fn test_witness_signature_future_rejected_without_witness_config() {
+        // Test that future validation still works even without witness_config
+        let (ledger, _temp) = create_test_ledger();
+        // Don't set witness_config - ledger has None
+        let alice_kp = KeyPair::generate().unwrap();
+        let alice = alice_kp.did().clone();
+        let bob_kp = KeyPair::generate().unwrap();
+        let bob = bob_kp.did().clone();
+
+        let entry = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 10)
+            .credit(bob.clone(), "hours".to_string(), 10)
+            .build()
+            .unwrap();
+
+        let entry_hash = entry.id.clone().unwrap();
+
+        // Create signature with timestamp far in the future
+        let future_time = icn_time::current_timestamp_secs() + 3600;
+        let signature = bob_kp.sign(entry_hash.as_bytes());
+        let witness_sig = crate::types::WitnessSignature::new(
+            bob.clone(),
+            signature.to_bytes().to_vec(),
+            future_time,
+        );
+
+        let witnessed = crate::types::WitnessedEntry {
+            entry,
+            witness_signatures: vec![witness_sig],
+            policy_applied: crate::types::WitnessPolicy::Counterparty,
+        };
+
+        // Future validation should still work without witness_config
+        let result = ledger.validate_witness_signatures(&witnessed);
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("in the future"),
+            "Future timestamps should be rejected even without witness_config"
         );
     }
 }

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -1007,7 +1007,10 @@ impl Ledger {
 
     /// Validate witness signatures on a witnessed entry
     ///
-    /// Verifies that all signatures are valid Ed25519 signatures over the entry hash.
+    /// Verifies that all signatures are:
+    /// 1. Valid Ed25519 signatures over the entry hash
+    /// 2. Not timestamped in the future (with small tolerance for clock skew)
+    /// 3. Not expired (if `WitnessConfig::collection_timeout_secs` is configured)
     fn validate_witness_signatures(&self, witnessed: &crate::types::WitnessedEntry) -> Result<()> {
         use ed25519_dalek::{Signature, Verifier};
 
@@ -1016,6 +1019,12 @@ impl Ledger {
             .id
             .as_ref()
             .context("Entry must have hash for witness validation")?;
+
+        // Get current time for timestamp validation
+        let current_time = icn_time::current_timestamp_secs();
+
+        // Maximum allowed clock skew (5 seconds) to tolerate minor time differences
+        const MAX_CLOCK_SKEW_SECS: u64 = 5;
 
         for sig in &witnessed.witness_signatures {
             // Extract public key from witness DID using icn-identity
@@ -1033,7 +1042,34 @@ impl Ledger {
                     format!("Witness signature verification failed for {}", sig.witness)
                 })?;
 
-            debug!(witness = %sig.witness, "Witness signature verified");
+            // Validate timestamp is not in the future (with clock skew tolerance)
+            if sig.signed_at > current_time + MAX_CLOCK_SKEW_SECS {
+                anyhow::bail!(
+                    "Witness signature timestamp is in the future: {} (signed_at: {}, current: {})",
+                    sig.witness,
+                    sig.signed_at,
+                    current_time
+                );
+            }
+
+            // Validate timestamp is not expired based on witness config
+            if let Some(config) = &self.witness_config {
+                let age = current_time.saturating_sub(sig.signed_at);
+                if age > config.collection_timeout_secs {
+                    anyhow::bail!(
+                        "Witness signature expired for {} (age: {}s, max: {}s)",
+                        sig.witness,
+                        age,
+                        config.collection_timeout_secs
+                    );
+                }
+            }
+
+            debug!(
+                witness = %sig.witness,
+                signed_at = sig.signed_at,
+                "Witness signature verified"
+            );
         }
 
         Ok(())
@@ -4425,6 +4461,176 @@ mod tests {
         assert!(
             result.is_ok(),
             "Entry without parents should be accepted: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_witness_signature_timestamp_future_rejected() {
+        let (mut ledger, _temp) = create_test_ledger();
+        let alice_kp = KeyPair::generate().unwrap();
+        let alice = alice_kp.did().clone();
+        let bob_kp = KeyPair::generate().unwrap();
+        let bob = bob_kp.did().clone();
+
+        // Configure witness requirements
+        ledger.set_witness_config(crate::types::WitnessConfig::counterparty_above(0));
+
+        let entry = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 10)
+            .credit(bob.clone(), "hours".to_string(), 10)
+            .build()
+            .unwrap();
+
+        let entry_hash = entry.id.clone().unwrap();
+
+        // Create signature with timestamp far in the future
+        let future_time = icn_time::current_timestamp_secs() + 3600; // 1 hour in the future
+        let signature = bob_kp.sign(entry_hash.as_bytes());
+        let witness_sig = crate::types::WitnessSignature::new(
+            bob.clone(),
+            signature.to_bytes().to_vec(),
+            future_time,
+        );
+
+        let witnessed = crate::types::WitnessedEntry {
+            entry,
+            witness_signatures: vec![witness_sig],
+            policy_applied: crate::types::WitnessPolicy::Counterparty,
+        };
+
+        let result = ledger.validate_witness_signatures(&witnessed);
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("in the future"),
+            "Error should mention 'in the future'"
+        );
+    }
+
+    #[test]
+    fn test_witness_signature_timestamp_expired_rejected() {
+        let (mut ledger, _temp) = create_test_ledger();
+        let alice_kp = KeyPair::generate().unwrap();
+        let alice = alice_kp.did().clone();
+        let bob_kp = KeyPair::generate().unwrap();
+        let bob = bob_kp.did().clone();
+
+        // Configure witness requirements with 60 second timeout
+        let mut config = crate::types::WitnessConfig::counterparty_above(0);
+        config.collection_timeout_secs = 60;
+        ledger.set_witness_config(config);
+
+        let entry = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 10)
+            .credit(bob.clone(), "hours".to_string(), 10)
+            .build()
+            .unwrap();
+
+        let entry_hash = entry.id.clone().unwrap();
+
+        // Create signature with timestamp 120 seconds in the past (expired)
+        let expired_time = icn_time::current_timestamp_secs().saturating_sub(120);
+        let signature = bob_kp.sign(entry_hash.as_bytes());
+        let witness_sig = crate::types::WitnessSignature::new(
+            bob.clone(),
+            signature.to_bytes().to_vec(),
+            expired_time,
+        );
+
+        let witnessed = crate::types::WitnessedEntry {
+            entry,
+            witness_signatures: vec![witness_sig],
+            policy_applied: crate::types::WitnessPolicy::Counterparty,
+        };
+
+        let result = ledger.validate_witness_signatures(&witnessed);
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("expired"),
+            "Error should mention 'expired'"
+        );
+    }
+
+    #[test]
+    fn test_witness_signature_timestamp_valid_accepted() {
+        let (mut ledger, _temp) = create_test_ledger();
+        let alice_kp = KeyPair::generate().unwrap();
+        let alice = alice_kp.did().clone();
+        let bob_kp = KeyPair::generate().unwrap();
+        let bob = bob_kp.did().clone();
+
+        // Configure witness requirements
+        let mut config = crate::types::WitnessConfig::counterparty_above(0);
+        config.collection_timeout_secs = 300; // 5 minutes
+        ledger.set_witness_config(config);
+
+        let entry = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 10)
+            .credit(bob.clone(), "hours".to_string(), 10)
+            .build()
+            .unwrap();
+
+        let entry_hash = entry.id.clone().unwrap();
+
+        // Create signature with current timestamp (valid)
+        let current_time = icn_time::current_timestamp_secs();
+        let signature = bob_kp.sign(entry_hash.as_bytes());
+        let witness_sig = crate::types::WitnessSignature::new(
+            bob.clone(),
+            signature.to_bytes().to_vec(),
+            current_time,
+        );
+
+        let witnessed = crate::types::WitnessedEntry {
+            entry,
+            witness_signatures: vec![witness_sig],
+            policy_applied: crate::types::WitnessPolicy::Counterparty,
+        };
+
+        let result = ledger.validate_witness_signatures(&witnessed);
+        assert!(
+            result.is_ok(),
+            "Valid timestamp should be accepted: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_witness_signature_timestamp_within_clock_skew_accepted() {
+        let (mut ledger, _temp) = create_test_ledger();
+        let alice_kp = KeyPair::generate().unwrap();
+        let alice = alice_kp.did().clone();
+        let bob_kp = KeyPair::generate().unwrap();
+        let bob = bob_kp.did().clone();
+
+        // Configure witness requirements
+        ledger.set_witness_config(crate::types::WitnessConfig::counterparty_above(0));
+
+        let entry = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 10)
+            .credit(bob.clone(), "hours".to_string(), 10)
+            .build()
+            .unwrap();
+
+        let entry_hash = entry.id.clone().unwrap();
+
+        // Create signature with timestamp 3 seconds in the future (within 5s tolerance)
+        let near_future = icn_time::current_timestamp_secs() + 3;
+        let signature = bob_kp.sign(entry_hash.as_bytes());
+        let witness_sig = crate::types::WitnessSignature::new(
+            bob.clone(),
+            signature.to_bytes().to_vec(),
+            near_future,
+        );
+
+        let witnessed = crate::types::WitnessedEntry {
+            entry,
+            witness_signatures: vec![witness_sig],
+            policy_applied: crate::types::WitnessPolicy::Counterparty,
+        };
+
+        let result = ledger.validate_witness_signatures(&witnessed);
+        assert!(
+            result.is_ok(),
+            "Timestamp within clock skew tolerance should be accepted: {result:?}"
         );
     }
 }

--- a/icn/crates/icn-ledger/src/types.rs
+++ b/icn/crates/icn-ledger/src/types.rs
@@ -417,9 +417,8 @@ pub struct WitnessConfig {
     /// Grace period (in seconds) to collect witness signatures.
     /// After this time, unsigned entries may be rejected.
     ///
-    /// TODO(witness-timeout): Implement timestamp validation against this timeout
-    /// in `validate_witness_signatures()`. Currently signatures are validated
-    /// cryptographically but not checked for expiration.
+    /// This is validated in `Ledger::validate_witness_signatures()` which
+    /// rejects signatures older than this timeout.
     pub collection_timeout_secs: u64,
 }
 
@@ -475,8 +474,9 @@ pub struct WitnessSignature {
 
     /// Timestamp when signature was created (Unix epoch seconds).
     ///
-    /// TODO(witness-timeout): This timestamp should be validated against
-    /// `WitnessConfig::collection_timeout_secs` to reject expired signatures.
+    /// Validated in `Ledger::validate_witness_signatures()`:
+    /// - Rejects future timestamps (beyond 5s clock skew tolerance)
+    /// - Rejects expired signatures (older than `WitnessConfig::collection_timeout_secs`)
     pub signed_at: u64,
 }
 


### PR DESCRIPTION
## Summary

- Implement timestamp validation in `validate_witness_signatures()` to prevent replay attacks
- Reject future-dated signatures (with 5s clock skew tolerance)
- Reject expired signatures based on `WitnessConfig::collection_timeout_secs`
- Update documentation in types.rs to reflect implemented validation
- Add 4 unit tests for timestamp validation scenarios

## Related

- Closes #686
- Epic: #672 (Byzantine Fault Tolerance Hardening)
- Parent: #676 (Witness Signatures)

## Test plan

- [x] Unit tests: `test_witness_signature_timestamp_future_rejected`
- [x] Unit tests: `test_witness_signature_timestamp_expired_rejected`
- [x] Unit tests: `test_witness_signature_timestamp_valid_accepted`
- [x] Unit tests: `test_witness_signature_timestamp_within_clock_skew_accepted`
- [x] All existing ledger tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)