### PR TITLE
feat(ledger): Add quarantine support for witness validation failures

### DIFF
--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -1668,13 +1668,53 @@ impl Ledger {
 
                 // Check sufficient signatures
                 if !witnessed.has_sufficient_signatures() {
+                    let have = witnessed.unique_witness_count() as u32;
+                    let required = match &witnessed.policy_applied {
+                        crate::types::WitnessPolicy::None => 0,
+                        crate::types::WitnessPolicy::Counterparty => 1,
+                        crate::types::WitnessPolicy::Quorum { required, .. } => *required,
+                        crate::types::WitnessPolicy::AllParties => {
+                            // All non-author accounts must sign
+                            witnessed
+                                .entry
+                                .accounts
+                                .iter()
+                                .map(|d| &d.account_id)
+                                .filter(|id| **id != witnessed.entry.author)
+                                .collect::<std::collections::HashSet<_>>()
+                                .len() as u32
+                        }
+                    };
+
                     warn!(
                         entry_hash = %hash,
-                        witness_count = witnessed.unique_witness_count(),
-                        "Witnessed entry has insufficient signatures"
+                        witness_count = have,
+                        required = required,
+                        "Witnessed entry has insufficient signatures, quarantining"
                     );
+
+                    // Quarantine the entry for governance review
+                    let quarantine_item = QuarantineItem {
+                        entry_id: hash.clone(),
+                        reason: QuarantineReason::InsufficientWitnesses { have, required },
+                        author: witnessed.entry.author.clone(),
+                        observed_at: icn_time::current_timestamp_secs(),
+                        metadata: Some(format!("policy={:?}", witnessed.policy_applied)),
+                    };
+
+                    if let Err(qe) = self
+                        .quarantine
+                        .add(witnessed.entry.clone(), quarantine_item)
+                    {
+                        warn!(
+                            entry_hash = %hash,
+                            error = %qe,
+                            "Failed to quarantine witnessed entry"
+                        );
+                    }
+
                     icn_obs::metrics::ledger::witnessed_entries_rejected_insufficient_inc();
-                    return Ok(()); // Reject silently
+                    return Ok(());
                 }
 
                 let witness_count = witnessed.witness_signatures.len() as u64;

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -1635,10 +1635,35 @@ impl Ledger {
                     warn!(
                         entry_hash = %hash,
                         error = %e,
-                        "Witnessed entry signature validation failed"
+                        "Witnessed entry signature validation failed, quarantining"
                     );
+
+                    // Quarantine the entry for governance review
+                    let quarantine_item = QuarantineItem {
+                        entry_id: hash.clone(),
+                        reason: QuarantineReason::WitnessValidationFailed(e.to_string()),
+                        author: witnessed.entry.author.clone(),
+                        observed_at: icn_time::current_timestamp_secs(),
+                        metadata: Some(format!(
+                            "witness_count={}, policy={:?}",
+                            witnessed.witness_signatures.len(),
+                            witnessed.policy_applied
+                        )),
+                    };
+
+                    if let Err(qe) = self
+                        .quarantine
+                        .add(witnessed.entry.clone(), quarantine_item)
+                    {
+                        warn!(
+                            entry_hash = %hash,
+                            error = %qe,
+                            "Failed to quarantine witnessed entry"
+                        );
+                    }
+
                     icn_obs::metrics::ledger::witnessed_entries_rejected_invalid_signature_inc();
-                    return Ok(()); // Reject silently
+                    return Ok(());
                 }
 
                 // Check sufficient signatures

--- a/icn/crates/icn-ledger/src/types.rs
+++ b/icn/crates/icn-ledger/src/types.rs
@@ -253,6 +253,14 @@ pub enum QuarantineReason {
 
     /// Witness validation failed - signature verification or timestamp issues
     WitnessValidationFailed(String),
+
+    /// Insufficient witness signatures - entry has fewer signatures than policy requires
+    InsufficientWitnesses {
+        /// Number of unique witnesses that signed
+        have: u32,
+        /// Number required by policy
+        required: u32,
+    },
 }
 
 /// Quarantined entry awaiting resolution

--- a/icn/crates/icn-ledger/src/types.rs
+++ b/icn/crates/icn-ledger/src/types.rs
@@ -250,6 +250,9 @@ pub enum QuarantineReason {
 
     /// Charter rule violation - entry violates cooperative charter policies
     CharterViolation,
+
+    /// Witness validation failed - signature verification or timestamp issues
+    WitnessValidationFailed(String),
 }
 
 /// Quarantined entry awaiting resolution

--- a/icn/crates/icn-ledger/tests/gossip_sync.rs
+++ b/icn/crates/icn-ledger/tests/gossip_sync.rs
@@ -496,3 +496,75 @@ async fn test_witnessed_entry_invalid_signature_quarantined_via_sync() {
 
     println!("Witnessed entry with invalid signature quarantined via sync");
 }
+
+#[tokio::test]
+async fn test_witnessed_entry_insufficient_signatures_quarantined_via_sync() {
+    let (mut ledger, _temp) = create_simple_ledger();
+
+    // Require 2-of-3 quorum
+    let witness1 = KeyPair::generate().unwrap().did().clone();
+    let witness2 = KeyPair::generate().unwrap().did().clone();
+    let witness3 = KeyPair::generate().unwrap().did().clone();
+
+    ledger.set_witness_config(WitnessConfig::quorum(
+        2,
+        vec![witness1.clone(), witness2.clone(), witness3.clone()],
+    ));
+
+    let alice_kp = KeyPair::generate().unwrap();
+    let bob_kp = KeyPair::generate().unwrap();
+    let alice = alice_kp.did().clone();
+    let bob = bob_kp.did().clone();
+
+    let entry = JournalEntryBuilder::new(alice.clone())
+        .debit(alice.clone(), "hours".to_string(), 10)
+        .credit(bob.clone(), "hours".to_string(), 10)
+        .build()
+        .unwrap();
+
+    let hash = entry.id.clone().unwrap();
+
+    // Create witnessed entry with zero signatures (need 2)
+    let witnessed = WitnessedEntry::new(
+        entry,
+        WitnessPolicy::Quorum {
+            required: 2,
+            witnesses: vec![witness1, witness2, witness3],
+        },
+    );
+    // No signatures added
+
+    // Send via sync message (simulates receiving from gossip)
+    let sync_msg = LedgerSyncMessage::NewWitnessedEntry {
+        hash: hash.clone(),
+        witnessed,
+    };
+
+    // Handle sync message - should quarantine the entry
+    ledger.handle_sync_message(sync_msg).await.unwrap();
+
+    // Verify entry was NOT stored in main ledger
+    assert!(
+        ledger.get_entry(&hash).unwrap().is_none(),
+        "Entry with insufficient signatures should not be stored"
+    );
+
+    // Verify entry was quarantined
+    let quarantine_items = ledger.quarantine().list().unwrap();
+    assert_eq!(quarantine_items.len(), 1, "Entry should be quarantined");
+
+    // Verify quarantine reason
+    let quarantined = &quarantine_items[0];
+    assert!(
+        matches!(
+            quarantined.reason,
+            icn_ledger::QuarantineReason::InsufficientWitnesses {
+                have: 0,
+                required: 2
+            }
+        ),
+        "Quarantine reason should be InsufficientWitnesses with have=0, required=2"
+    );
+
+    println!("Witnessed entry with insufficient signatures quarantined via sync");
+}

--- a/icn/crates/icn-ledger/tests/gossip_sync.rs
+++ b/icn/crates/icn-ledger/tests/gossip_sync.rs
@@ -433,3 +433,66 @@ async fn test_witness_policy_threshold() {
 
     println!("Witness threshold policy works correctly");
 }
+
+#[tokio::test]
+async fn test_witnessed_entry_invalid_signature_quarantined_via_sync() {
+    let (mut ledger, _temp) = create_simple_ledger();
+    ledger.set_witness_config(WitnessConfig::counterparty_above(0));
+
+    let alice_kp = KeyPair::generate().unwrap();
+    let bob_kp = KeyPair::generate().unwrap();
+    let wrong_kp = KeyPair::generate().unwrap(); // Different key
+    let alice = alice_kp.did().clone();
+    let bob = bob_kp.did().clone();
+
+    // Create an entry
+    let entry = JournalEntryBuilder::new(alice.clone())
+        .debit(alice.clone(), "hours".to_string(), 10)
+        .credit(bob.clone(), "hours".to_string(), 10)
+        .build()
+        .unwrap();
+
+    let hash = entry.id.clone().unwrap();
+
+    // Create signature with wrong key but claim it's from Bob
+    let wrong_signature = wrong_kp.sign(hash.as_bytes());
+    let witness_sig = WitnessSignature::new(
+        bob.clone(), // Claims to be Bob
+        wrong_signature.to_bytes().to_vec(),
+        icn_time::current_timestamp_secs(),
+    );
+
+    let mut witnessed = WitnessedEntry::new(entry, WitnessPolicy::Counterparty);
+    witnessed.add_signature(witness_sig);
+
+    // Send via sync message (simulates receiving from gossip)
+    let sync_msg = LedgerSyncMessage::NewWitnessedEntry {
+        hash: hash.clone(),
+        witnessed,
+    };
+
+    // Handle sync message - should quarantine the entry
+    ledger.handle_sync_message(sync_msg).await.unwrap();
+
+    // Verify entry was NOT stored in main ledger
+    assert!(
+        ledger.get_entry(&hash).unwrap().is_none(),
+        "Entry with invalid signature should not be stored"
+    );
+
+    // Verify entry was quarantined
+    let quarantine_items = ledger.quarantine().list().unwrap();
+    assert_eq!(quarantine_items.len(), 1, "Entry should be quarantined");
+
+    // Verify quarantine reason
+    let quarantined = &quarantine_items[0];
+    assert!(
+        matches!(
+            quarantined.reason,
+            icn_ledger::QuarantineReason::WitnessValidationFailed(_)
+        ),
+        "Quarantine reason should be WitnessValidationFailed"
+    );
+
+    println!("Witnessed entry with invalid signature quarantined via sync");
+}


### PR DESCRIPTION
## Summary

- Add `WitnessValidationFailed(String)` variant to `QuarantineReason` enum
- Update `NewWitnessedEntry` sync handler to quarantine entries with invalid signatures
- Include validation error, witness count, and policy in quarantine metadata
- Add integration test verifying quarantine behavior

## Context

From PR #682 code review:
- Failed witness validation previously returned `Ok(())` with only a `warn!` log
- Regular entry validation quarantines failed entries with `CharterViolation`
- Witness validation failures should follow the same pattern for better observability

## Related

- Closes #687
- Epic: #672 (Byzantine Fault Tolerance Hardening)
- Parent: #676 (Witness Signatures)

## Test plan

- [x] New test: `test_witnessed_entry_invalid_signature_quarantined_via_sync`
- [x] All existing ledger tests pass (244 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)