### PR TITLE
feat(ledger): Persist witness signatures for fork resolution

### DIFF
--- a/icn/crates/icn-ledger/src/fork_resolution.rs
+++ b/icn/crates/icn-ledger/src/fork_resolution.rs
@@ -7,8 +7,9 @@
 //! network partition or concurrent operations. This module provides multiple resolution
 //! strategies based on trust, timestamps, and participant consensus.
 
-use crate::types::{ContentHash, JournalEntry};
+use crate::types::{ContentHash, JournalEntry, WitnessSignature};
 use anyhow::{anyhow, Result};
+use icn_store::Store;
 use icn_trust::TrustGraph;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -66,10 +67,14 @@ pub enum ForkResolution {
     RequiresManual { reason: String },
 }
 
+/// Key prefix for witness signatures in storage (matches ledger.rs)
+const WITNESS_PREFIX: &str = "ledger:witnesses:";
+
 /// Fork resolution system
 pub struct ForkResolver {
     strategy: ForkResolutionStrategy,
     trust_graph: Option<Arc<tokio::sync::RwLock<TrustGraph>>>,
+    store: Option<Arc<dyn Store>>,
 }
 
 impl ForkResolver {
@@ -78,12 +83,18 @@ impl ForkResolver {
         Self {
             strategy,
             trust_graph: None,
+            store: None,
         }
     }
 
     /// Set the trust graph for trust-weighted resolution
     pub fn set_trust_graph(&mut self, trust_graph: Arc<tokio::sync::RwLock<TrustGraph>>) {
         self.trust_graph = Some(trust_graph);
+    }
+
+    /// Set the store for loading witness signatures (Issue #688)
+    pub fn set_store(&mut self, store: Arc<dyn Store>) {
+        self.store = Some(store);
     }
 
     /// Detect if two entries form a fork (same parents, different hashes)
@@ -282,16 +293,59 @@ impl ForkResolver {
         Ok(score)
     }
 
-    /// Count unique signers for an entry
+    /// Count unique signers for an entry (author + witnesses)
     ///
-    /// Currently always returns 1 (counting the author). Future work (Issue #676)
-    /// will add witness signature storage to enable counting co-signers for
-    /// fork resolution. This requires persisting witness signatures alongside
-    /// entries rather than just validating them at append time.
-    fn count_signers(&self, _entry: &JournalEntry) -> usize {
-        // TODO(#676): Look up witness signatures from storage once implemented
-        // For now, always count the author as 1 signer (with or without explicit signature)
-        1
+    /// Loads witness signatures from storage and counts unique DIDs.
+    /// Returns 1 (author only) if no store is configured or no witnesses found.
+    fn count_signers(&self, entry: &JournalEntry) -> usize {
+        // If no store configured, just count the author
+        let store = match &self.store {
+            Some(s) => s,
+            None => return 1,
+        };
+
+        // Get entry hash
+        let entry_hash = match &entry.id {
+            Some(h) => h,
+            None => return 1,
+        };
+
+        // Load witness signatures from storage
+        let key = format!("{}{}", WITNESS_PREFIX, entry_hash.to_hex());
+        match store.get(key.as_bytes()) {
+            Ok(Some(data)) => {
+                match serde_json::from_slice::<Vec<WitnessSignature>>(&data) {
+                    Ok(witnesses) => {
+                        // Count unique witness DIDs + 1 for the author
+                        let unique_witnesses: HashSet<_> =
+                            witnesses.iter().map(|w| &w.witness).collect();
+                        debug!(
+                            entry_hash = %entry_hash,
+                            witness_count = unique_witnesses.len(),
+                            "Loaded witness signatures for fork resolution"
+                        );
+                        unique_witnesses.len() + 1
+                    }
+                    Err(e) => {
+                        debug!(
+                            entry_hash = %entry_hash,
+                            error = %e,
+                            "Failed to deserialize witness signatures"
+                        );
+                        1
+                    }
+                }
+            }
+            Ok(None) => 1, // No witness signatures stored
+            Err(e) => {
+                debug!(
+                    entry_hash = %entry_hash,
+                    error = %e,
+                    "Failed to load witness signatures from store"
+                );
+                1
+            }
+        }
     }
 }
 
@@ -595,5 +649,111 @@ mod tests {
         assert_eq!(resolution2, ForkResolution::KeepSecond); // entry3 wins (earliest)
 
         // Final result: entry3 is the overall winner
+    }
+
+    #[test]
+    fn test_signature_resolution_with_witnesses() {
+        use icn_store::SledStore;
+        use tempfile::TempDir;
+
+        // Create a store and populate it with witness signatures
+        let temp_dir = TempDir::new().unwrap();
+        let store: Arc<dyn Store> = Arc::new(SledStore::open(temp_dir.path()).unwrap());
+
+        // Create two entries - entry1 has earlier timestamp but fewer signers
+        // entry2 has later timestamp but more signers
+        // With MajoritySignatures strategy, entry2 should win on signature count
+        let parent = ContentHash([0u8; 32]);
+        let author1 = make_test_did();
+        let author2 = make_test_did();
+
+        let entry1 = make_test_entry(author1.clone(), vec![parent.clone()], 1000);
+        let entry2 = make_test_entry(author2.clone(), vec![parent.clone()], 2000); // Later timestamp
+
+        // Store 2 witness signatures for entry2 (making it 3 signers total)
+        let witness1 = make_test_did();
+        let witness2 = make_test_did();
+        let witnesses = vec![
+            WitnessSignature {
+                witness: witness1,
+                signature: vec![0u8; 64], // Dummy signature
+                signed_at: 1000,
+            },
+            WitnessSignature {
+                witness: witness2,
+                signature: vec![0u8; 64],
+                signed_at: 1000,
+            },
+        ];
+
+        // Store witnesses for entry2
+        let entry2_hash = entry2.id.as_ref().unwrap();
+        let key = format!("{}{}", WITNESS_PREFIX, entry2_hash.to_hex());
+        store
+            .put(key.as_bytes(), &serde_json::to_vec(&witnesses).unwrap())
+            .unwrap();
+
+        // Verify the data was stored correctly
+        let stored = store.get(key.as_bytes()).unwrap();
+        assert!(stored.is_some(), "Witness data should be stored");
+
+        // Create resolver with store and use MajoritySignatures strategy
+        let mut resolver = ForkResolver::new(ForkResolutionStrategy::MajoritySignatures);
+        resolver.set_store(store.clone());
+
+        // Verify count_signers works correctly
+        let signers1 = resolver.count_signers(&entry1);
+        let signers2 = resolver.count_signers(&entry2);
+        assert_eq!(signers1, 1, "Entry1 should have 1 signer (author only)");
+        assert_eq!(signers2, 3, "Entry2 should have 3 signers (author + 2 witnesses)");
+
+        // Entry2 should win because it has more signers (3 vs 1)
+        // Even though entry1 has an earlier timestamp
+        let fork = Fork {
+            common_parents: vec![parent.clone()],
+            entry1: entry1.clone(),
+            entry2: entry2.clone(),
+            detected_at: SystemTime::now(),
+        };
+
+        let resolution = resolver.resolve_fork(&fork).unwrap();
+        assert_eq!(resolution, ForkResolution::KeepSecond);
+
+        // If we reverse the order, entry2 (now in position 1) should still win
+        let fork_reversed = Fork {
+            common_parents: vec![parent.clone()],
+            entry1: entry2,
+            entry2: entry1,
+            detected_at: SystemTime::now(),
+        };
+
+        let resolution_reversed = resolver.resolve_fork(&fork_reversed).unwrap();
+        assert_eq!(resolution_reversed, ForkResolution::KeepFirst);
+    }
+
+    #[test]
+    fn test_signature_resolution_no_store() {
+        // Without a store, both entries should have 1 signer (author only)
+        // In tie situations, it falls back to timestamp
+        let resolver = ForkResolver::new(ForkResolutionStrategy::MajoritySignatures);
+
+        let parent = ContentHash([0u8; 32]);
+        let author1 = make_test_did();
+        let author2 = make_test_did();
+
+        // Different timestamps - earlier wins
+        let entry1 = make_test_entry(author1.clone(), vec![parent.clone()], 1000);
+        let entry2 = make_test_entry(author2.clone(), vec![parent.clone()], 2000);
+
+        let fork = Fork {
+            common_parents: vec![parent.clone()],
+            entry1: entry1.clone(),
+            entry2: entry2.clone(),
+            detected_at: SystemTime::now(),
+        };
+
+        // Same signer count, so falls back to timestamp - entry1 wins
+        let resolution = resolver.resolve_fork(&fork).unwrap();
+        assert_eq!(resolution, ForkResolution::KeepFirst);
     }
 }

--- a/icn/crates/icn-ledger/src/fork_resolution.rs
+++ b/icn/crates/icn-ledger/src/fork_resolution.rs
@@ -297,6 +297,7 @@ impl ForkResolver {
     ///
     /// Loads witness signatures from storage and counts unique DIDs.
     /// Returns 1 (author only) if no store is configured or no witnesses found.
+    /// Note: Author is always counted once; witnesses matching the author DID are filtered.
     fn count_signers(&self, entry: &JournalEntry) -> usize {
         // If no store configured, just count the author
         let store = match &self.store {
@@ -316,9 +317,14 @@ impl ForkResolver {
             Ok(Some(data)) => {
                 match serde_json::from_slice::<Vec<WitnessSignature>>(&data) {
                     Ok(witnesses) => {
-                        // Count unique witness DIDs + 1 for the author
-                        let unique_witnesses: HashSet<_> =
-                            witnesses.iter().map(|w| &w.witness).collect();
+                        // Count unique witness DIDs excluding author (to prevent double-counting)
+                        // then add 1 for the author
+                        let author_did = &entry.author;
+                        let unique_witnesses: HashSet<_> = witnesses
+                            .iter()
+                            .map(|w| &w.witness)
+                            .filter(|did| *did != author_did)
+                            .collect();
                         debug!(
                             entry_hash = %entry_hash,
                             witness_count = unique_witnesses.len(),
@@ -705,7 +711,10 @@ mod tests {
         let signers1 = resolver.count_signers(&entry1);
         let signers2 = resolver.count_signers(&entry2);
         assert_eq!(signers1, 1, "Entry1 should have 1 signer (author only)");
-        assert_eq!(signers2, 3, "Entry2 should have 3 signers (author + 2 witnesses)");
+        assert_eq!(
+            signers2, 3,
+            "Entry2 should have 3 signers (author + 2 witnesses)"
+        );
 
         // Entry2 should win because it has more signers (3 vs 1)
         // Even though entry1 has an earlier timestamp

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -60,6 +60,10 @@ const CLEARED_VOLUME_PREFIX: &str = "ledger:cleared_volume:";
 /// Key prefix for archived entries (from rollback operations)
 const ARCHIVE_PREFIX: &str = "ledger:archive:";
 
+/// Key prefix for witness signatures (for fork resolution)
+/// Format: ledger:witnesses:{entry_hash_hex}
+const WITNESS_PREFIX: &str = "ledger:witnesses:";
+
 /// Record of an archived entry (from rollback operations)
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ArchiveRecord {
@@ -172,6 +176,9 @@ impl Ledger {
         // Load journal version from storage (or default to 0)
         let journal_version = Self::load_journal_version_from_store(&store)?;
 
+        // Clone store ref for fork resolver before moving into ledger
+        let store_for_fork_resolver = store.clone();
+
         let mut ledger = Ledger {
             store,
             cached_balances: HashMap::new(),
@@ -197,6 +204,9 @@ impl Ledger {
             fx_config: None,                 // Set via set_fx_config()
             witness_config: None,            // Set via set_witness_config()
         };
+
+        // Set store on fork resolver for witness signature lookups (Issue #688)
+        ledger.fork_resolver.set_store(store_for_fork_resolver);
 
         // Load cached balances from storage
         ledger.load_cached_balances()?;
@@ -995,8 +1005,17 @@ impl Ledger {
         // Record witness count metric
         let witness_count = witnessed.witness_signatures.len() as u64;
 
+        // Clone witness signatures before consuming the entry (for persistence)
+        let witness_signatures = witnessed.witness_signatures.clone();
+
         // Append the underlying entry
         let hash = self.append_entry_internal(witnessed.entry, true).await?;
+
+        // Persist witness signatures for fork resolution (Issue #688)
+        // This allows count_signers() to retrieve witness count when resolving forks
+        if !witness_signatures.is_empty() {
+            self.store_witness_signatures(&hash, &witness_signatures)?;
+        }
 
         // Record success metrics
         icn_obs::metrics::ledger::witnessed_entries_accepted_inc();
@@ -1037,6 +1056,72 @@ impl Ledger {
         }
 
         Ok(())
+    }
+
+    /// Store witness signatures for an entry (for fork resolution)
+    ///
+    /// Persists witness signatures alongside entries so that fork resolution
+    /// can count co-signers when comparing conflicting entries.
+    fn store_witness_signatures(
+        &self,
+        entry_hash: &ContentHash,
+        witnesses: &[crate::types::WitnessSignature],
+    ) -> Result<()> {
+        let key = format!("{}{}", WITNESS_PREFIX, entry_hash.to_hex());
+        let value = serde_json::to_vec(witnesses)?;
+        self.store.put(key.as_bytes(), &value)?;
+        debug!(
+            entry_hash = %entry_hash,
+            witness_count = witnesses.len(),
+            "Persisted witness signatures for fork resolution"
+        );
+        Ok(())
+    }
+
+    /// Load witness signatures for an entry (for fork resolution)
+    ///
+    /// Returns the stored witness signatures, or an empty vec if none exist.
+    pub fn load_witness_signatures(
+        &self,
+        entry_hash: &ContentHash,
+    ) -> Result<Vec<crate::types::WitnessSignature>> {
+        let key = format!("{}{}", WITNESS_PREFIX, entry_hash.to_hex());
+        match self.store.get(key.as_bytes())? {
+            Some(data) => {
+                let witnesses: Vec<crate::types::WitnessSignature> = serde_json::from_slice(&data)
+                    .context("Failed to deserialize witness signatures")?;
+                Ok(witnesses)
+            }
+            None => Ok(Vec::new()),
+        }
+    }
+
+    /// Count unique signers for an entry (author + witnesses)
+    ///
+    /// Loads witness signatures from storage and counts unique DIDs.
+    /// Returns 1 (author only) if no witness signatures are stored.
+    pub fn count_entry_signers(&self, entry: &JournalEntry) -> usize {
+        let entry_hash = match &entry.id {
+            Some(h) => h,
+            None => return 1, // No hash, just count author
+        };
+
+        match self.load_witness_signatures(entry_hash) {
+            Ok(witnesses) => {
+                // Count unique witness DIDs + 1 for the author
+                let unique_witnesses: std::collections::HashSet<_> =
+                    witnesses.iter().map(|w| &w.witness).collect();
+                unique_witnesses.len() + 1
+            }
+            Err(e) => {
+                debug!(
+                    entry_hash = %entry_hash,
+                    error = %e,
+                    "Failed to load witness signatures, counting author only"
+                );
+                1
+            }
+        }
     }
 
     /// Calculate the total absolute value of an entry (for threshold comparison)

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -1012,9 +1012,18 @@ impl Ledger {
         let hash = self.append_entry_internal(witnessed.entry, true).await?;
 
         // Persist witness signatures for fork resolution (Issue #688)
-        // This allows count_signers() to retrieve witness count when resolving forks
+        // This allows count_signers() to retrieve witness count when resolving forks.
+        // If persistence fails, the entry has already been appended. Treat this as
+        // degraded-but-successful: log error for observability but don't fail the append.
         if !witness_signatures.is_empty() {
-            self.store_witness_signatures(&hash, &witness_signatures)?;
+            if let Err(e) = self.store_witness_signatures(&hash, &witness_signatures) {
+                error!(
+                    entry_hash = %hash,
+                    witness_count = witness_signatures.len(),
+                    error = %e,
+                    "Failed to persist witness signatures - fork resolution may count fewer signers"
+                );
+            }
         }
 
         // Record success metrics
@@ -1100,6 +1109,7 @@ impl Ledger {
     ///
     /// Loads witness signatures from storage and counts unique DIDs.
     /// Returns 1 (author only) if no witness signatures are stored.
+    /// Note: Author is always counted once; witnesses matching the author DID are filtered.
     pub fn count_entry_signers(&self, entry: &JournalEntry) -> usize {
         let entry_hash = match &entry.id {
             Some(h) => h,
@@ -1108,9 +1118,14 @@ impl Ledger {
 
         match self.load_witness_signatures(entry_hash) {
             Ok(witnesses) => {
-                // Count unique witness DIDs + 1 for the author
-                let unique_witnesses: std::collections::HashSet<_> =
-                    witnesses.iter().map(|w| &w.witness).collect();
+                // Count unique witness DIDs excluding author (to prevent double-counting)
+                // then add 1 for the author
+                let author_did = &entry.author;
+                let unique_witnesses: std::collections::HashSet<_> = witnesses
+                    .iter()
+                    .map(|w| &w.witness)
+                    .filter(|did| *did != author_did)
+                    .collect();
                 unique_witnesses.len() + 1
             }
             Err(e) => {


### PR DESCRIPTION
## Summary

- Persists witness signatures alongside ledger entries in storage
- Updates ForkResolver to load witness data when counting signers
- Enables proper Byzantine fault tolerance in fork resolution

Closes #688

## Changes

### Storage Layer (`ledger.rs`)
- Added `WITNESS_PREFIX` storage key for witness signature data
- Added `store_witness_signatures()` to persist witnesses after successful append
- Added `load_witness_signatures()` and `count_entry_signers()` public methods

### Fork Resolution (`fork_resolution.rs`)
- Added optional `store` field to `ForkResolver` 
- Updated `count_signers()` to load witness signatures from storage
- Returns author + unique witness DIDs count instead of always 1

### Tests
- `test_signature_resolution_with_witnesses`: Verifies entries with more witnesses win
- `test_signature_resolution_no_store`: Verifies graceful fallback without store

## Context

From PR #682 code review, `count_signers()` always returned 1 because witness 
signatures were validated but not persisted. Fork resolution with `MajoritySignatures` 
strategy couldn't prefer entries with more co-signers.

Now entries with more witness signatures are correctly preferred during fork resolution,
improving Byzantine fault tolerance.

## Test plan

- [x] All existing fork resolution tests pass
- [x] New witness-based fork resolution tests pass
- [x] Clippy passes with no warnings
- [x] All icn-ledger tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)