### PR TITLE
fix(docker): increase RUST_MIN_STACK to prevent rustc SIGSEGV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY bins ./bins
 
 # Build release binaries
 # RUST_MIN_STACK: Increase rustc stack size to prevent SIGSEGV on complex crates
-# CARGO_BUILD_JOBS: Limit parallelism to reduce peak memory usage
+# -j 2: Limit parallelism to reduce peak memory usage
 ENV RUST_MIN_STACK=33554432
 RUN cargo build --release --bins -j 2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,10 @@ COPY crates ./crates
 COPY bins ./bins
 
 # Build release binaries
-RUN cargo build --release --bins
+# RUST_MIN_STACK: Increase rustc stack size to prevent SIGSEGV on complex crates
+# CARGO_BUILD_JOBS: Limit parallelism to reduce peak memory usage
+ENV RUST_MIN_STACK=33554432
+RUN cargo build --release --bins -j 2
 
 # Stage 2: Runtime (must match builder's glibc version)
 FROM debian:trixie-slim

--- a/deploy/Dockerfile.icnd
+++ b/deploy/Dockerfile.icnd
@@ -18,7 +18,10 @@ WORKDIR /build
 COPY . .
 
 # Build release binaries
-RUN cargo build --release --bin icnd --bin icnctl
+# RUST_MIN_STACK: Increase rustc stack size to prevent SIGSEGV on complex crates
+# -j 2: Limit parallelism to reduce peak memory usage
+ENV RUST_MIN_STACK=33554432
+RUN cargo build --release --bin icnd --bin icnctl -j 2
 
 # Runtime image
 FROM debian:bookworm-slim

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,10 @@ COPY icn/crates ./crates
 COPY icn/bins ./bins
 
 # Build release binaries
-RUN cargo build --release --locked \
+# RUST_MIN_STACK: Increase rustc stack size to prevent SIGSEGV on complex crates
+# -j 2: Limit parallelism to reduce peak memory usage
+ENV RUST_MIN_STACK=33554432
+RUN cargo build --release --locked -j 2 \
     && strip target/release/icnd \
     && strip target/release/icnctl
 


### PR DESCRIPTION
## Summary
- Fix rustc compiler crashes during Docker builds by increasing stack size
- Limit build parallelism to reduce peak memory usage

## Problem
The ICN workspace has 31 crates with heavy dependencies (async/await, cryptography, ZKP, networking). When compiling complex crates like `icn-steward`, rustc's default 2MB stack was being exhausted, causing SIGSEGV crashes during Docker builds on the self-hosted runner.

## Solution
- Set `RUST_MIN_STACK=33554432` (32MB) for rustc compiler
- Limit `CARGO_BUILD_JOBS=2` to reduce peak memory usage

## Files Changed
- `Dockerfile`
- `deploy/Dockerfile.icnd`
- `docker/Dockerfile`

## Test plan
- [x] Changes verified in all three Dockerfiles
- [ ] CI/CD pipeline should complete without SIGSEGV

🤖 Generated with [Claude Code](https://claude.com/claude-code)