### PR TITLE
feat(ledger): Add witness config and metrics (#676)

### DIFF
--- a/icn/crates/icn-core/src/config/ledger.rs
+++ b/icn/crates/icn-core/src/config/ledger.rs
@@ -1,7 +1,9 @@
 //! Ledger configuration
 //!
-//! Configuration for the mutual credit ledger and exchange rate oracle.
+//! Configuration for the mutual credit ledger, exchange rate oracle,
+//! and witness signatures for material transactions.
 
+use icn_identity::Did;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -14,6 +16,165 @@ pub struct LedgerConfig {
     /// Oracle configuration for exchange rates
     #[serde(default)]
     pub oracle: OracleNodeConfig,
+
+    /// Witness signature requirements for material transactions (Issue #676)
+    #[serde(default)]
+    pub witness: WitnessSettings,
+}
+
+/// Configuration for witness signatures on ledger entries
+///
+/// Witness signatures provide Byzantine fault tolerance by requiring
+/// multiple parties to co-sign material transactions.
+///
+/// # Example Configuration
+///
+/// ```toml
+/// [ledger.witness]
+/// # Witness policy: "none", "counterparty", "quorum", "all_parties"
+/// default_policy = "counterparty"
+///
+/// # Only require witnesses for transactions above this value
+/// threshold = 1000
+///
+/// # Timeout for collecting signatures (seconds)
+/// collection_timeout_secs = 300
+///
+/// # For quorum policy only:
+/// # quorum_required = 2
+/// # quorum_witnesses = ["did:icn:abc123", "did:icn:def456", "did:icn:ghi789"]
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WitnessSettings {
+    /// Default witness policy
+    ///
+    /// - "none": No witnesses required (default)
+    /// - "counterparty": Other party must co-sign
+    /// - "quorum": N-of-M designated witnesses
+    /// - "all_parties": All transaction participants must sign
+    #[serde(default = "default_witness_policy")]
+    pub default_policy: String,
+
+    /// Value threshold above which witnesses are required
+    ///
+    /// If None, the policy applies to all entries regardless of value.
+    /// If set, entries below this threshold don't require witnesses.
+    #[serde(default)]
+    pub threshold: Option<u64>,
+
+    /// Number of signatures required for quorum policy
+    ///
+    /// Only used when `default_policy` is "quorum".
+    #[serde(default)]
+    pub quorum_required: Option<u32>,
+
+    /// List of authorized witness DIDs for quorum policy
+    ///
+    /// Only used when `default_policy` is "quorum".
+    #[serde(default)]
+    pub quorum_witnesses: Option<Vec<String>>,
+
+    /// Grace period (seconds) to collect witness signatures
+    ///
+    /// After this time, unsigned entries may be rejected.
+    #[serde(default = "default_collection_timeout")]
+    pub collection_timeout_secs: u64,
+}
+
+fn default_witness_policy() -> String {
+    "none".to_string()
+}
+
+fn default_collection_timeout() -> u64 {
+    300 // 5 minutes
+}
+
+impl Default for WitnessSettings {
+    fn default() -> Self {
+        Self {
+            default_policy: default_witness_policy(),
+            threshold: None,
+            quorum_required: None,
+            quorum_witnesses: None,
+            collection_timeout_secs: default_collection_timeout(),
+        }
+    }
+}
+
+impl WitnessSettings {
+    /// Convert to the icn-ledger WitnessConfig type
+    ///
+    /// Returns an error if the configuration is invalid (e.g., quorum policy
+    /// without required/witnesses fields, or invalid DID format).
+    pub fn to_witness_config(&self) -> Result<icn_ledger::WitnessConfig, WitnessConfigError> {
+        let policy = match self.default_policy.to_lowercase().as_str() {
+            "none" => icn_ledger::WitnessPolicy::None,
+            "counterparty" => icn_ledger::WitnessPolicy::Counterparty,
+            "all_parties" | "allparties" => icn_ledger::WitnessPolicy::AllParties,
+            "quorum" => {
+                let required = self
+                    .quorum_required
+                    .ok_or(WitnessConfigError::MissingField(
+                        "quorum_required for quorum policy",
+                    ))?;
+                let witness_strs =
+                    self.quorum_witnesses
+                        .as_ref()
+                        .ok_or(WitnessConfigError::MissingField(
+                            "quorum_witnesses for quorum policy",
+                        ))?;
+
+                let mut witnesses = Vec::with_capacity(witness_strs.len());
+                for did_str in witness_strs {
+                    let did = Did::from_str(did_str).map_err(|e| {
+                        WitnessConfigError::InvalidDid(did_str.clone(), e.to_string())
+                    })?;
+                    witnesses.push(did);
+                }
+
+                if (required as usize) > witnesses.len() {
+                    return Err(WitnessConfigError::QuorumTooLarge {
+                        required,
+                        available: witnesses.len(),
+                    });
+                }
+
+                icn_ledger::WitnessPolicy::Quorum {
+                    required,
+                    witnesses,
+                }
+            }
+            other => return Err(WitnessConfigError::InvalidPolicy(other.to_string())),
+        };
+
+        Ok(icn_ledger::WitnessConfig {
+            default_policy: policy,
+            threshold: self.threshold,
+            collection_timeout_secs: self.collection_timeout_secs,
+        })
+    }
+}
+
+/// Error when converting WitnessSettings to WitnessConfig
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum WitnessConfigError {
+    /// Invalid policy string
+    #[error(
+        "Invalid witness policy '{0}'. Valid options: none, counterparty, quorum, all_parties"
+    )]
+    InvalidPolicy(String),
+
+    /// Missing required field for quorum policy
+    #[error("Missing required field: {0}")]
+    MissingField(&'static str),
+
+    /// Invalid DID format
+    #[error("Invalid DID '{0}': {1}")]
+    InvalidDid(String, String),
+
+    /// Quorum requires more signatures than available witnesses
+    #[error("Quorum requires {required} signatures but only {available} witnesses configured")]
+    QuorumTooLarge { required: u32, available: usize },
 }
 
 /// Configuration for the exchange rate oracle
@@ -223,5 +384,205 @@ default_suspicious_rate_threshold = 2000.0
         // Default values
         assert_eq!(config.default_ttl_secs, 3600);
         assert_eq!(config.min_sources_for_consensus, 1);
+    }
+
+    // Witness Settings Tests (Issue #676)
+
+    #[test]
+    fn test_witness_settings_defaults() {
+        let settings = WitnessSettings::default();
+
+        assert_eq!(settings.default_policy, "none");
+        assert!(settings.threshold.is_none());
+        assert!(settings.quorum_required.is_none());
+        assert!(settings.quorum_witnesses.is_none());
+        assert_eq!(settings.collection_timeout_secs, 300);
+    }
+
+    #[test]
+    fn test_witness_settings_none_policy() {
+        let settings = WitnessSettings::default();
+        let config = settings.to_witness_config().unwrap();
+
+        assert!(matches!(
+            config.default_policy,
+            icn_ledger::WitnessPolicy::None
+        ));
+    }
+
+    #[test]
+    fn test_witness_settings_counterparty_policy() {
+        let settings = WitnessSettings {
+            default_policy: "counterparty".to_string(),
+            threshold: Some(1000),
+            ..Default::default()
+        };
+        let config = settings.to_witness_config().unwrap();
+
+        assert!(matches!(
+            config.default_policy,
+            icn_ledger::WitnessPolicy::Counterparty
+        ));
+        assert_eq!(config.threshold, Some(1000));
+    }
+
+    #[test]
+    fn test_witness_settings_all_parties_policy() {
+        let settings = WitnessSettings {
+            default_policy: "all_parties".to_string(),
+            ..Default::default()
+        };
+        let config = settings.to_witness_config().unwrap();
+
+        assert!(matches!(
+            config.default_policy,
+            icn_ledger::WitnessPolicy::AllParties
+        ));
+    }
+
+    #[test]
+    fn test_witness_settings_quorum_policy() {
+        // Generate valid DIDs using keypairs
+        let keypair1 = icn_identity::KeyPair::generate().unwrap();
+        let keypair2 = icn_identity::KeyPair::generate().unwrap();
+        let keypair3 = icn_identity::KeyPair::generate().unwrap();
+
+        let settings = WitnessSettings {
+            default_policy: "quorum".to_string(),
+            quorum_required: Some(2),
+            quorum_witnesses: Some(vec![
+                keypair1.did().to_string(),
+                keypair2.did().to_string(),
+                keypair3.did().to_string(),
+            ]),
+            collection_timeout_secs: 600,
+            ..Default::default()
+        };
+        let config = settings.to_witness_config().unwrap();
+
+        if let icn_ledger::WitnessPolicy::Quorum {
+            required,
+            witnesses,
+        } = config.default_policy
+        {
+            assert_eq!(required, 2);
+            assert_eq!(witnesses.len(), 3);
+        } else {
+            panic!("Expected Quorum policy");
+        }
+        assert_eq!(config.collection_timeout_secs, 600);
+    }
+
+    #[test]
+    fn test_witness_settings_quorum_missing_required() {
+        let settings = WitnessSettings {
+            default_policy: "quorum".to_string(),
+            quorum_witnesses: Some(vec!["did:icn:test".to_string()]),
+            ..Default::default()
+        };
+
+        let result = settings.to_witness_config();
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            WitnessConfigError::MissingField(_)
+        ));
+    }
+
+    #[test]
+    fn test_witness_settings_quorum_missing_witnesses() {
+        let settings = WitnessSettings {
+            default_policy: "quorum".to_string(),
+            quorum_required: Some(2),
+            ..Default::default()
+        };
+
+        let result = settings.to_witness_config();
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            WitnessConfigError::MissingField(_)
+        ));
+    }
+
+    #[test]
+    fn test_witness_settings_quorum_too_large() {
+        let keypair = icn_identity::KeyPair::generate().unwrap();
+
+        let settings = WitnessSettings {
+            default_policy: "quorum".to_string(),
+            quorum_required: Some(5),
+            quorum_witnesses: Some(vec![
+                keypair.did().to_string(),
+                keypair.did().to_string(), // Only 2 witnesses, require 5
+            ]),
+            ..Default::default()
+        };
+
+        let result = settings.to_witness_config();
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            WitnessConfigError::QuorumTooLarge { .. }
+        ));
+    }
+
+    #[test]
+    fn test_witness_settings_invalid_policy() {
+        let settings = WitnessSettings {
+            default_policy: "invalid_policy".to_string(),
+            ..Default::default()
+        };
+
+        let result = settings.to_witness_config();
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            WitnessConfigError::InvalidPolicy(_)
+        ));
+    }
+
+    #[test]
+    fn test_witness_settings_invalid_did() {
+        let settings = WitnessSettings {
+            default_policy: "quorum".to_string(),
+            quorum_required: Some(1),
+            quorum_witnesses: Some(vec!["not-a-valid-did".to_string()]),
+            ..Default::default()
+        };
+
+        let result = settings.to_witness_config();
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            WitnessConfigError::InvalidDid(_, _)
+        ));
+    }
+
+    #[test]
+    fn test_witness_settings_serialization() {
+        let toml_str = r#"
+default_policy = "counterparty"
+threshold = 5000
+collection_timeout_secs = 600
+"#;
+
+        let settings: WitnessSettings = toml::from_str(toml_str).unwrap();
+
+        assert_eq!(settings.default_policy, "counterparty");
+        assert_eq!(settings.threshold, Some(5000));
+        assert_eq!(settings.collection_timeout_secs, 600);
+    }
+
+    #[test]
+    fn test_ledger_config_with_witness_defaults() {
+        let config = LedgerConfig::default();
+
+        // Oracle defaults
+        assert_eq!(config.oracle.default_ttl_secs, 3600);
+
+        // Witness defaults
+        assert_eq!(config.witness.default_policy, "none");
+        assert!(config.witness.threshold.is_none());
     }
 }

--- a/icn/crates/icn-core/src/config/ledger.rs
+++ b/icn/crates/icn-core/src/config/ledger.rs
@@ -125,10 +125,14 @@ impl WitnessSettings {
                         ))?;
 
                 let mut witnesses = Vec::with_capacity(witness_strs.len());
+                let mut seen_dids = std::collections::HashSet::new();
                 for did_str in witness_strs {
                     let did = Did::from_str(did_str).map_err(|e| {
                         WitnessConfigError::InvalidDid(did_str.clone(), e.to_string())
                     })?;
+                    if !seen_dids.insert(did.clone()) {
+                        return Err(WitnessConfigError::DuplicateWitness(did_str.clone()));
+                    }
                     witnesses.push(did);
                 }
 
@@ -171,6 +175,10 @@ pub enum WitnessConfigError {
     /// Invalid DID format
     #[error("Invalid DID '{0}': {1}")]
     InvalidDid(String, String),
+
+    /// Duplicate witness in quorum configuration
+    #[error("Duplicate witness DID in quorum configuration: '{0}'")]
+    DuplicateWitness(String),
 
     /// Quorum requires more signatures than available witnesses
     #[error("Quorum requires {required} signatures but only {available} witnesses configured")]
@@ -507,14 +515,15 @@ default_suspicious_rate_threshold = 2000.0
 
     #[test]
     fn test_witness_settings_quorum_too_large() {
-        let keypair = icn_identity::KeyPair::generate().unwrap();
+        let keypair1 = icn_identity::KeyPair::generate().unwrap();
+        let keypair2 = icn_identity::KeyPair::generate().unwrap();
 
         let settings = WitnessSettings {
             default_policy: "quorum".to_string(),
             quorum_required: Some(5),
             quorum_witnesses: Some(vec![
-                keypair.did().to_string(),
-                keypair.did().to_string(), // Only 2 witnesses, require 5
+                keypair1.did().to_string(),
+                keypair2.did().to_string(), // Only 2 distinct witnesses, require 5
             ]),
             ..Default::default()
         };
@@ -524,6 +533,28 @@ default_suspicious_rate_threshold = 2000.0
         assert!(matches!(
             result.unwrap_err(),
             WitnessConfigError::QuorumTooLarge { .. }
+        ));
+    }
+
+    #[test]
+    fn test_witness_settings_duplicate_witness() {
+        let keypair = icn_identity::KeyPair::generate().unwrap();
+
+        let settings = WitnessSettings {
+            default_policy: "quorum".to_string(),
+            quorum_required: Some(2),
+            quorum_witnesses: Some(vec![
+                keypair.did().to_string(),
+                keypair.did().to_string(), // Same DID twice
+            ]),
+            ..Default::default()
+        };
+
+        let result = settings.to_witness_config();
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            WitnessConfigError::DuplicateWitness(_)
         ));
     }
 

--- a/icn/crates/icn-core/src/supervisor/init_ledger.rs
+++ b/icn/crates/icn-core/src/supervisor/init_ledger.rs
@@ -87,6 +87,26 @@ pub async fn init_ledger_services(
         );
     }
 
+    // Initialize witness config for material transaction signatures (Issue #676)
+    let witness_config = config.ledger.witness.to_witness_config()?;
+    let witness_policy = format!("{:?}", witness_config.default_policy);
+    ledger.set_witness_config(witness_config);
+
+    match &config.ledger.witness.threshold {
+        Some(threshold) => {
+            info!(
+                "Witness signatures configured: policy={}, threshold={} (timeout={}s)",
+                witness_policy, threshold, config.ledger.witness.collection_timeout_secs
+            );
+        }
+        None => {
+            info!(
+                "Witness signatures configured: policy={} for all transactions (timeout={}s)",
+                witness_policy, config.ledger.witness.collection_timeout_secs
+            );
+        }
+    }
+
     // Initialize membership store for tracking when members joined
     // Used for new member credit limit ramping
     let membership_store = Arc::new(SledMembershipStore::new(store.clone()));

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -1800,6 +1800,24 @@ pub fn init_descriptions() {
         "icn_ledger_entries_rejected_missing_parents_total",
         "Total local entries rejected due to missing parents"
     );
+
+    // Witness signature metrics (Issue #676)
+    describe_counter!(
+        "icn_ledger_witnessed_entries_accepted_total",
+        "Total witnessed entries successfully validated and stored"
+    );
+    describe_counter!(
+        "icn_ledger_witnessed_entries_rejected_invalid_signature_total",
+        "Total witnessed entries rejected due to invalid signature"
+    );
+    describe_counter!(
+        "icn_ledger_witnessed_entries_rejected_insufficient_total",
+        "Total witnessed entries rejected due to insufficient signatures"
+    );
+    describe_histogram!(
+        "icn_ledger_witness_signature_count",
+        "Number of witness signatures on accepted entries"
+    );
 }
 
 /// Network metrics


### PR DESCRIPTION
## Summary

Complete the witness signature feature for material transactions (Issue #676) by adding:

- **Metric descriptions** for witness signatures in `icn-obs` 
- **WitnessSettings configuration** in `icn-core/src/config/ledger.rs`
- **Configuration wiring** to ledger initialization

## Changes

### 1. Metrics (`icn-obs/src/metrics_legacy.rs`)

Added descriptions for existing witness metrics:
- `icn_ledger_witnessed_entries_accepted_total` - Counter for accepted witnessed entries
- `icn_ledger_witnessed_entries_rejected_invalid_signature_total` - Rejection due to invalid signature
- `icn_ledger_witnessed_entries_rejected_insufficient_total` - Rejection due to insufficient signatures
- `icn_ledger_witness_signature_count` - Histogram of signature counts

### 2. Configuration (`icn-core/src/config/ledger.rs`)

Added `WitnessSettings` struct with:
- `default_policy`: "none", "counterparty", "quorum", or "all_parties"
- `threshold`: Optional value threshold above which witnesses are required
- `quorum_required`: Number of signatures for quorum policy
- `quorum_witnesses`: List of authorized witness DIDs
- `collection_timeout_secs`: Grace period for signature collection

Example TOML:
```toml
[ledger.witness]
default_policy = "counterparty"
threshold = 1000
collection_timeout_secs = 300
```

### 3. Wiring (`icn-core/src/supervisor/init_ledger.rs`)

- Converts `WitnessSettings` to `icn_ledger::WitnessConfig`
- Calls `ledger.set_witness_config()` during initialization
- Logs witness configuration at startup

## Test plan

- [x] `cargo test -p icn-core --lib test_witness` - 11 tests pass
- [x] `cargo test -p icn-ledger witness` - 18 tests pass
- [x] `cargo clippy -p icn-core -p icn-ledger -p icn-obs -- -D warnings` - No warnings
- [x] `cargo build -p icn-core` - Builds successfully

## Related

- Issue: #676
- Epic: #672 (Byzantine Fault Tolerance Hardening)

🤖 Generated with [Claude Code](https://claude.ai/code)