### PR TITLE
feat(obs): Add configurable priority-based trace sampling

### DIFF
--- a/icn/crates/icn-core/src/config/observability.rs
+++ b/icn/crates/icn-core/src/config/observability.rs
@@ -22,6 +22,16 @@ pub struct ObservabilityConfig {
 }
 
 /// Distributed tracing configuration with OpenTelemetry
+///
+/// # Priority Sampling
+///
+/// ICN uses priority-based sampling to ensure important traces are always captured
+/// while reducing overhead for routine operations:
+///
+/// - **Errors**: Always sampled (set `always_sample_errors = true`)
+/// - **Slow requests**: Always sampled if slower than `slow_threshold_ms`
+/// - **Security events**: Always sampled (spans with "security" in name)
+/// - **Normal operations**: Sampled at `sampling_rate`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TracingConfig {
     /// Enable distributed tracing export
@@ -33,8 +43,25 @@ pub struct TracingConfig {
     pub otlp_endpoint: String,
 
     /// Sampling rate (0.0 to 1.0). Default is 0.1 (10%) for production.
+    /// Note: Error and slow traces are sampled regardless of this rate
+    /// when `always_sample_errors` and `always_sample_slow` are enabled.
     #[serde(default = "default_sampling_rate")]
     pub sampling_rate: f64,
+
+    /// Always sample traces that contain errors.
+    /// This ensures debugging information is captured for all failures.
+    #[serde(default = "default_always_sample_errors")]
+    pub always_sample_errors: bool,
+
+    /// Always sample traces that exceed `slow_threshold_ms`.
+    /// This ensures performance issues are captured.
+    #[serde(default = "default_always_sample_slow")]
+    pub always_sample_slow: bool,
+
+    /// Threshold (in milliseconds) for considering a request "slow".
+    /// Traces exceeding this duration are always sampled if `always_sample_slow` is true.
+    #[serde(default = "default_slow_threshold_ms")]
+    pub slow_threshold_ms: u64,
 
     /// Service name for traces
     #[serde(default = "default_service_name")]
@@ -49,6 +76,18 @@ fn default_sampling_rate() -> f64 {
     0.1 // 10% sampling for production
 }
 
+fn default_always_sample_errors() -> bool {
+    true // Always capture errors by default
+}
+
+fn default_always_sample_slow() -> bool {
+    true // Always capture slow requests by default
+}
+
+fn default_slow_threshold_ms() -> u64 {
+    1000 // 1 second
+}
+
 fn default_service_name() -> String {
     "icnd".to_string()
 }
@@ -59,6 +98,9 @@ impl Default for TracingConfig {
             enabled: false,
             otlp_endpoint: default_otlp_endpoint(),
             sampling_rate: default_sampling_rate(),
+            always_sample_errors: default_always_sample_errors(),
+            always_sample_slow: default_always_sample_slow(),
+            slow_threshold_ms: default_slow_threshold_ms(),
             service_name: default_service_name(),
         }
     }
@@ -71,6 +113,9 @@ impl TracingConfig {
             enabled: self.enabled,
             otlp_endpoint: self.otlp_endpoint.clone(),
             sampling_rate: self.sampling_rate,
+            always_sample_errors: self.always_sample_errors,
+            always_sample_slow: self.always_sample_slow,
+            slow_threshold_ms: self.slow_threshold_ms,
             service_name: self.service_name.clone(),
             node_did,
         }

--- a/icn/crates/icn-core/src/config/observability.rs
+++ b/icn/crates/icn-core/src/config/observability.rs
@@ -88,11 +88,11 @@ fn default_sampling_rate() -> f64 {
 }
 
 fn default_always_sample_errors() -> bool {
-    true // Always capture errors by default
+    true // Reserved for collector-side tail-based sampling
 }
 
 fn default_always_sample_slow() -> bool {
-    true // Always capture slow requests by default
+    true // Reserved for collector-side tail-based sampling
 }
 
 fn default_slow_threshold_ms() -> u64 {

--- a/icn/crates/icn-core/src/config/observability.rs
+++ b/icn/crates/icn-core/src/config/observability.rs
@@ -25,13 +25,21 @@ pub struct ObservabilityConfig {
 ///
 /// # Priority Sampling
 ///
-/// ICN uses priority-based sampling to ensure important traces are always captured
-/// while reducing overhead for routine operations:
+/// ICN uses priority-based sampling to reduce overhead while capturing important traces:
 ///
-/// - **Errors**: Always sampled (set `always_sample_errors = true`)
-/// - **Slow requests**: Always sampled if slower than `slow_threshold_ms`
+/// ## Implemented (Head-Based)
+///
 /// - **Security events**: Always sampled (spans with "security" in name)
 /// - **Normal operations**: Sampled at `sampling_rate`
+///
+/// ## Requires Collector-Side Configuration (Tail-Based)
+///
+/// Error and slow request sampling require tail-based sampling decisions
+/// (decisions made after span completion). These must be configured in your
+/// OpenTelemetry Collector using tail-based sampling processors.
+///
+/// The `always_sample_errors` and `always_sample_slow` fields are reserved
+/// for future collector policy generation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TracingConfig {
     /// Enable distributed tracing export
@@ -43,23 +51,26 @@ pub struct TracingConfig {
     pub otlp_endpoint: String,
 
     /// Sampling rate (0.0 to 1.0). Default is 0.1 (10%) for production.
-    /// Note: Error and slow traces are sampled regardless of this rate
-    /// when `always_sample_errors` and `always_sample_slow` are enabled.
+    /// Security spans (names containing "security") are always sampled.
+    /// Error/slow sampling requires collector-side tail-based configuration.
     #[serde(default = "default_sampling_rate")]
     pub sampling_rate: f64,
 
-    /// Always sample traces that contain errors.
-    /// This ensures debugging information is captured for all failures.
+    /// Reserved for collector-side tail-based sampling configuration.
+    /// Error sampling requires post-span analysis at the collector level.
+    /// Set to true to indicate intent for collector policy generation.
     #[serde(default = "default_always_sample_errors")]
     pub always_sample_errors: bool,
 
-    /// Always sample traces that exceed `slow_threshold_ms`.
-    /// This ensures performance issues are captured.
+    /// Reserved for collector-side tail-based sampling configuration.
+    /// Duration-based sampling requires post-span analysis at the collector level.
+    /// Set to true to indicate intent for collector policy generation.
     #[serde(default = "default_always_sample_slow")]
     pub always_sample_slow: bool,
 
+    /// Reserved for collector-side tail-based sampling configuration.
     /// Threshold (in milliseconds) for considering a request "slow".
-    /// Traces exceeding this duration are always sampled if `always_sample_slow` is true.
+    /// Used by collector tail-sampling processors, not enforced at SDK level.
     #[serde(default = "default_slow_threshold_ms")]
     pub slow_threshold_ms: u64,
 

--- a/icn/crates/icn-obs/src/otel.rs
+++ b/icn/crates/icn-obs/src/otel.rs
@@ -21,13 +21,25 @@ use tracing_subscriber::EnvFilter;
 ///
 /// # Priority Sampling
 ///
-/// ICN uses priority-based sampling to ensure important traces are always captured
-/// while reducing overhead for routine operations:
+/// ICN uses priority-based sampling to reduce overhead while capturing important traces:
 ///
-/// - **Errors**: Always sampled (set `always_sample_errors = true`)
-/// - **Slow requests**: Always sampled if slower than `slow_threshold_ms`
+/// ## Implemented (Head-Based)
+///
 /// - **Security events**: Always sampled (spans with "security" in name)
 /// - **Normal operations**: Sampled at `sampling_rate`
+///
+/// ## Requires Collector-Side Configuration (Tail-Based)
+///
+/// Error and slow request sampling require tail-based sampling decisions (after span
+/// completion). These config fields are reserved for:
+///
+/// 1. **Collector policy generation**: Export config for Tempo/Jaeger tail-based policies
+/// 2. **Full capture mode**: Set `sampling_rate = 1.0` and filter at the collector
+/// 3. **Future integration**: Native tail-based sampling support
+///
+/// - `always_sample_errors` - Reserved for error-based tail sampling
+/// - `always_sample_slow` - Reserved for latency-based tail sampling
+/// - `slow_threshold_ms` - Threshold for slow request detection
 ///
 /// # Example Configuration
 ///
@@ -36,9 +48,9 @@ use tracing_subscriber::EnvFilter;
 /// enabled = true
 /// otlp_endpoint = "http://tempo:4317"
 /// sampling_rate = 0.1          # 10% of normal traces
-/// always_sample_errors = true  # Always capture errors
-/// always_sample_slow = true    # Always capture slow requests
-/// slow_threshold_ms = 1000     # Requests > 1s are "slow"
+/// always_sample_errors = true  # Reserved for collector-side error sampling
+/// always_sample_slow = true    # Reserved for collector-side latency sampling
+/// slow_threshold_ms = 1000     # Threshold for "slow" classification
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TracingConfig {
@@ -53,23 +65,33 @@ pub struct TracingConfig {
     /// Base sampling rate (0.0 to 1.0) for normal operations.
     /// Default is 0.1 (10%) for production.
     ///
-    /// Note: Error and slow traces are sampled regardless of this rate
-    /// when `always_sample_errors` and `always_sample_slow` are enabled.
+    /// Security spans (names containing "security") are always sampled
+    /// regardless of this rate.
     #[serde(default = "default_sampling_rate")]
     pub sampling_rate: f64,
 
-    /// Always sample traces that contain errors.
-    /// This ensures debugging information is captured for all failures.
+    /// Reserved for collector-side error sampling configuration.
+    ///
+    /// This field does NOT enable head-based error sampling (which is impossible
+    /// since errors are unknown at span start). Instead, use this to:
+    /// - Generate collector tail-sampling policies
+    /// - Document intent for full-capture + collector filtering setups
     #[serde(default = "default_always_sample_errors")]
     pub always_sample_errors: bool,
 
-    /// Always sample traces that exceed `slow_threshold_ms`.
-    /// This ensures performance issues are captured.
+    /// Reserved for collector-side latency sampling configuration.
+    ///
+    /// This field does NOT enable head-based slow request sampling (which is
+    /// impossible since duration is unknown at span start). Instead, use this to:
+    /// - Generate collector tail-sampling policies
+    /// - Document intent for full-capture + collector filtering setups
     #[serde(default = "default_always_sample_slow")]
     pub always_sample_slow: bool,
 
-    /// Threshold (in milliseconds) for considering a request "slow".
-    /// Traces exceeding this duration are always sampled if `always_sample_slow` is true.
+    /// Threshold (in milliseconds) for classifying a request as "slow".
+    ///
+    /// Used with collector-side tail-based sampling policies. Has no effect
+    /// on head-based sampling decisions.
     #[serde(default = "default_slow_threshold_ms")]
     pub slow_threshold_ms: u64,
 

--- a/icn/crates/icn-obs/src/otel.rs
+++ b/icn/crates/icn-obs/src/otel.rs
@@ -567,4 +567,56 @@ mod tests {
         let trace_id_low = TraceId::from_bytes([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
         assert!(!sampler_off.sample_by_trace_id(trace_id_low));
     }
+
+    #[test]
+    fn test_should_sample_integration() {
+        use opentelemetry::trace::{SamplingDecision, SpanKind};
+
+        let sampler = PrioritySampler::new(0.5); // 50% sampling
+
+        // Trace ID with high bytes = 0 will be sampled at 50% (0 < threshold)
+        let sampled_trace_id =
+            TraceId::from_bytes([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+        // Trace ID with high bytes = MAX will NOT be sampled at 50% (MAX >= threshold)
+        let not_sampled_trace_id = TraceId::from_bytes([
+            255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 1,
+        ]);
+
+        // Test 1: Security span is always sampled (even with high trace ID)
+        let result = sampler.should_sample(
+            None,
+            not_sampled_trace_id,
+            "handle_security_event",
+            &SpanKind::Internal,
+            &[],
+            &[],
+        );
+        assert_eq!(result.decision, SamplingDecision::RecordAndSample);
+        assert!(result
+            .attributes
+            .iter()
+            .any(|kv| kv.key.as_str() == "sampling.priority"));
+
+        // Test 2: Normal span with high trace ID is NOT sampled
+        let result = sampler.should_sample(
+            None,
+            not_sampled_trace_id,
+            "process_message",
+            &SpanKind::Internal,
+            &[],
+            &[],
+        );
+        assert_eq!(result.decision, SamplingDecision::Drop);
+
+        // Test 3: Normal span with low trace ID IS sampled
+        let result = sampler.should_sample(
+            None,
+            sampled_trace_id,
+            "process_message",
+            &SpanKind::Internal,
+            &[],
+            &[],
+        );
+        assert_eq!(result.decision, SamplingDecision::RecordAndSample);
+    }
 }

--- a/icn/crates/icn-obs/src/otel.rs
+++ b/icn/crates/icn-obs/src/otel.rs
@@ -4,10 +4,12 @@
 //! ICN nodes. It exports spans to an OTLP-compatible collector (e.g., Grafana Tempo).
 
 use anyhow::{Context, Result};
-use opentelemetry::trace::TracerProvider as _;
+use opentelemetry::trace::{
+    SamplingDecision, SamplingResult, SpanKind, TraceId, TracerProvider as _,
+};
 use opentelemetry::KeyValue;
 use opentelemetry_otlp::WithExportConfig;
-use opentelemetry_sdk::trace::{RandomIdGenerator, Sampler, SdkTracerProvider};
+use opentelemetry_sdk::trace::{RandomIdGenerator, SdkTracerProvider, ShouldSample};
 use opentelemetry_sdk::Resource;
 use serde::{Deserialize, Serialize};
 use tracing_opentelemetry::OpenTelemetryLayer;
@@ -16,6 +18,28 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 
 /// Configuration for distributed tracing
+///
+/// # Priority Sampling
+///
+/// ICN uses priority-based sampling to ensure important traces are always captured
+/// while reducing overhead for routine operations:
+///
+/// - **Errors**: Always sampled (set `always_sample_errors = true`)
+/// - **Slow requests**: Always sampled if slower than `slow_threshold_ms`
+/// - **Security events**: Always sampled (spans with "security" in name)
+/// - **Normal operations**: Sampled at `sampling_rate`
+///
+/// # Example Configuration
+///
+/// ```toml
+/// [tracing]
+/// enabled = true
+/// otlp_endpoint = "http://tempo:4317"
+/// sampling_rate = 0.1          # 10% of normal traces
+/// always_sample_errors = true  # Always capture errors
+/// always_sample_slow = true    # Always capture slow requests
+/// slow_threshold_ms = 1000     # Requests > 1s are "slow"
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TracingConfig {
     /// Whether tracing is enabled
@@ -26,9 +50,28 @@ pub struct TracingConfig {
     #[serde(default = "default_otlp_endpoint")]
     pub otlp_endpoint: String,
 
-    /// Sampling rate (0.0 to 1.0). Default is 0.1 (10%) for production.
+    /// Base sampling rate (0.0 to 1.0) for normal operations.
+    /// Default is 0.1 (10%) for production.
+    ///
+    /// Note: Error and slow traces are sampled regardless of this rate
+    /// when `always_sample_errors` and `always_sample_slow` are enabled.
     #[serde(default = "default_sampling_rate")]
     pub sampling_rate: f64,
+
+    /// Always sample traces that contain errors.
+    /// This ensures debugging information is captured for all failures.
+    #[serde(default = "default_always_sample_errors")]
+    pub always_sample_errors: bool,
+
+    /// Always sample traces that exceed `slow_threshold_ms`.
+    /// This ensures performance issues are captured.
+    #[serde(default = "default_always_sample_slow")]
+    pub always_sample_slow: bool,
+
+    /// Threshold (in milliseconds) for considering a request "slow".
+    /// Traces exceeding this duration are always sampled if `always_sample_slow` is true.
+    #[serde(default = "default_slow_threshold_ms")]
+    pub slow_threshold_ms: u64,
 
     /// Service name for traces
     #[serde(default = "default_service_name")]
@@ -53,6 +96,18 @@ fn default_sampling_rate() -> f64 {
     0.1 // 10% sampling for production
 }
 
+fn default_always_sample_errors() -> bool {
+    true // Always capture errors by default
+}
+
+fn default_always_sample_slow() -> bool {
+    true // Always capture slow requests by default
+}
+
+fn default_slow_threshold_ms() -> u64 {
+    1000 // 1 second
+}
+
 fn default_service_name() -> String {
     "icnd".to_string()
 }
@@ -63,8 +118,130 @@ impl Default for TracingConfig {
             enabled: default_enabled(),
             otlp_endpoint: default_otlp_endpoint(),
             sampling_rate: default_sampling_rate(),
+            always_sample_errors: default_always_sample_errors(),
+            always_sample_slow: default_always_sample_slow(),
+            slow_threshold_ms: default_slow_threshold_ms(),
             service_name: default_service_name(),
             node_did: None,
+        }
+    }
+}
+
+/// Priority sampler for ICN distributed tracing
+///
+/// This sampler implements head-based priority sampling:
+/// - **Security spans**: Always sampled (span names containing "security")
+/// - **Other spans**: Sampled according to `sampling_rate`
+///
+/// # Limitations (Head-Based Sampling)
+///
+/// Error and slow request sampling are not implemented here because they require
+/// tail-based sampling (decision after span completion). For those features:
+///
+/// 1. **Collector-side filtering**: Configure your OTLP collector (e.g., Grafana Tempo,
+///    Jaeger) to use tail-based sampling policies
+/// 2. **Full sampling**: Set `sampling_rate = 1.0` to capture all traces, then use
+///    collector-side filtering for storage
+///
+/// The `always_sample_errors` and `always_sample_slow` config fields are preserved
+/// for future tail-based sampling integration or collector policy generation.
+#[derive(Debug, Clone)]
+pub struct PrioritySampler {
+    /// Base sampling rate for normal traces (0.0 to 1.0)
+    sampling_rate: f64,
+    /// Pattern to match for always-sample spans (e.g., "security")
+    priority_pattern: &'static str,
+}
+
+impl PrioritySampler {
+    /// Create a new priority sampler with the given base sampling rate
+    ///
+    /// Security-related spans (containing "security" in their name) are always sampled.
+    pub fn new(sampling_rate: f64) -> Self {
+        Self {
+            sampling_rate: sampling_rate.clamp(0.0, 1.0),
+            priority_pattern: "security",
+        }
+    }
+
+    /// Check if this span should be prioritized (always sampled)
+    fn is_priority_span(&self, name: &str) -> bool {
+        name.to_lowercase().contains(self.priority_pattern)
+    }
+
+    /// Make sampling decision based on trace ID (consistent hashing)
+    fn sample_by_trace_id(&self, trace_id: TraceId) -> bool {
+        if self.sampling_rate >= 1.0 {
+            return true;
+        }
+        if self.sampling_rate <= 0.0 {
+            return false;
+        }
+
+        // Use trace ID ratio-based sampling (same algorithm as TraceIdRatioBased)
+        // This ensures consistent sampling decisions for the same trace ID
+        let trace_id_bytes = trace_id.to_bytes();
+        let trace_id_high = u64::from_be_bytes([
+            trace_id_bytes[0],
+            trace_id_bytes[1],
+            trace_id_bytes[2],
+            trace_id_bytes[3],
+            trace_id_bytes[4],
+            trace_id_bytes[5],
+            trace_id_bytes[6],
+            trace_id_bytes[7],
+        ]);
+
+        // Compare against threshold derived from sampling rate
+        let threshold = (self.sampling_rate * u64::MAX as f64) as u64;
+        trace_id_high < threshold
+    }
+}
+
+impl ShouldSample for PrioritySampler {
+    fn should_sample(
+        &self,
+        parent_context: Option<&opentelemetry::Context>,
+        trace_id: TraceId,
+        name: &str,
+        _span_kind: &SpanKind,
+        _attributes: &[KeyValue],
+        _links: &[opentelemetry::trace::Link],
+    ) -> SamplingResult {
+        // If parent context exists and is sampled, respect parent decision
+        if let Some(ctx) = parent_context {
+            use opentelemetry::trace::TraceContextExt;
+            let parent_span = ctx.span();
+            let span_context = parent_span.span_context();
+            if span_context.is_valid() && span_context.is_sampled() {
+                return SamplingResult {
+                    decision: SamplingDecision::RecordAndSample,
+                    attributes: vec![],
+                    trace_state: span_context.trace_state().clone(),
+                };
+            }
+        }
+
+        // Priority spans are always sampled
+        if self.is_priority_span(name) {
+            return SamplingResult {
+                decision: SamplingDecision::RecordAndSample,
+                attributes: vec![KeyValue::new("sampling.priority", "security")],
+                trace_state: Default::default(),
+            };
+        }
+
+        // Use trace ID ratio-based sampling for other spans
+        let decision = if self.sample_by_trace_id(trace_id) {
+            SamplingDecision::RecordAndSample
+        } else {
+            SamplingDecision::Drop
+        };
+
+        SamplingResult {
+            decision,
+            attributes: vec![],
+            trace_state: Default::default(),
         }
     }
 }
@@ -111,14 +288,9 @@ pub fn init_tracing(config: &TracingConfig) -> Result<()> {
         .build()
         .context("Failed to create OTLP exporter")?;
 
-    // Build the tracer provider with sampling
-    let sampler = if config.sampling_rate >= 1.0 {
-        Sampler::AlwaysOn
-    } else if config.sampling_rate <= 0.0 {
-        Sampler::AlwaysOff
-    } else {
-        Sampler::TraceIdRatioBased(config.sampling_rate)
-    };
+    // Build the tracer provider with priority-based sampling
+    // Security spans are always sampled, other spans use the configured rate
+    let sampler = PrioritySampler::new(config.sampling_rate);
 
     let provider = SdkTracerProvider::builder()
         .with_batch_exporter(exporter)
@@ -144,8 +316,11 @@ pub fn init_tracing(config: &TracingConfig) -> Result<()> {
     tracing::info!(
         endpoint = %config.otlp_endpoint,
         sampling_rate = config.sampling_rate,
+        always_sample_errors = config.always_sample_errors,
+        always_sample_slow = config.always_sample_slow,
+        slow_threshold_ms = config.slow_threshold_ms,
         service_name = %config.service_name,
-        "Distributed tracing initialized with OpenTelemetry"
+        "Distributed tracing initialized with priority sampling (security spans always sampled)"
     );
 
     Ok(())
@@ -274,5 +449,100 @@ mod tests {
         assert!((config.sampling_rate - 0.5).abs() < f64::EPSILON);
         assert_eq!(config.service_name, "test-node");
         assert_eq!(config.node_did.as_deref(), Some("did:icn:test123"));
+    }
+
+    #[test]
+    fn test_tracing_config_priority_sampling_defaults() {
+        // Save and clear env var to test true default
+        let saved = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok();
+        std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
+
+        let config = TracingConfig::default();
+
+        // Priority sampling should be enabled by default
+        assert!(config.always_sample_errors);
+        assert!(config.always_sample_slow);
+        assert_eq!(config.slow_threshold_ms, 1000); // 1 second default
+
+        // Restore env var if it was set
+        if let Some(val) = saved {
+            std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", val);
+        }
+    }
+
+    #[test]
+    fn test_tracing_config_priority_sampling_serde() {
+        let json = r#"{
+            "enabled": true,
+            "sampling_rate": 0.1,
+            "always_sample_errors": false,
+            "always_sample_slow": true,
+            "slow_threshold_ms": 500
+        }"#;
+
+        let config: TracingConfig = serde_json::from_str(json).expect("deserialize");
+        assert!(!config.always_sample_errors);
+        assert!(config.always_sample_slow);
+        assert_eq!(config.slow_threshold_ms, 500);
+    }
+
+    #[test]
+    fn test_priority_sampler_always_samples_security_spans() {
+        let sampler = PrioritySampler::new(0.0); // 0% base rate
+
+        // Security spans should always be sampled
+        assert!(sampler.is_priority_span("security_check"));
+        assert!(sampler.is_priority_span("verify_security"));
+        assert!(sampler.is_priority_span("SECURITY_AUDIT"));
+        assert!(sampler.is_priority_span("check_security_policy"));
+
+        // Non-security spans should not be prioritized
+        assert!(!sampler.is_priority_span("normal_operation"));
+        assert!(!sampler.is_priority_span("ledger_append"));
+        assert!(!sampler.is_priority_span("gossip_message"));
+    }
+
+    #[test]
+    fn test_priority_sampler_sampling_rate_bounds() {
+        // Test that sampling rate is clamped to [0.0, 1.0]
+        let sampler_high = PrioritySampler::new(2.0);
+        assert!((sampler_high.sampling_rate - 1.0).abs() < f64::EPSILON);
+
+        let sampler_low = PrioritySampler::new(-0.5);
+        assert!(sampler_low.sampling_rate.abs() < f64::EPSILON);
+
+        let sampler_normal = PrioritySampler::new(0.5);
+        assert!((sampler_normal.sampling_rate - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_priority_sampler_trace_id_sampling() {
+        let sampler = PrioritySampler::new(0.5);
+
+        // Test with known trace IDs to verify sampling behavior
+        // TraceId with high bytes = 0 should always be sampled at 50%
+        let trace_id_low = TraceId::from_bytes([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+        assert!(sampler.sample_by_trace_id(trace_id_low));
+
+        // TraceId with high bytes = max should never be sampled at 50%
+        let trace_id_high = TraceId::from_bytes([
+            255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 1,
+        ]);
+        assert!(!sampler.sample_by_trace_id(trace_id_high));
+    }
+
+    #[test]
+    fn test_priority_sampler_always_on_and_off() {
+        // 100% sampling rate should always sample
+        let sampler_on = PrioritySampler::new(1.0);
+        let trace_id_high = TraceId::from_bytes([
+            255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 1,
+        ]);
+        assert!(sampler_on.sample_by_trace_id(trace_id_high));
+
+        // 0% sampling rate should never sample
+        let sampler_off = PrioritySampler::new(0.0);
+        let trace_id_low = TraceId::from_bytes([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+        assert!(!sampler_off.sample_by_trace_id(trace_id_low));
     }
 }


### PR DESCRIPTION
## Summary

- Implements priority-based sampling for distributed tracing (#495)
- Security-related spans (names containing "security") are always sampled
- Adds configuration fields for future tail-based sampling integration:
  - `always_sample_errors` - reserved for collector-side error filtering
  - `always_sample_slow` - reserved for collector-side latency filtering
  - `slow_threshold_ms` - configurable slow request threshold

## Technical Details

- `PrioritySampler` implements `ShouldSample` trait from OpenTelemetry SDK
- Uses trace ID ratio-based sampling for consistency (same trace ID → same decision)
- Parent-based sampling: respects parent span sampling decisions
- Security spans detected via case-insensitive name matching

## Head-Based vs Tail-Based Sampling

⚠️ **Important**: Error and slow request sampling cannot be implemented at span creation time (head-based) because we don't know the outcome until the span completes.

For true error/slow sampling, configure tail-based policies at your OTLP collector (e.g., Grafana Tempo, Jaeger). The config fields are provided for:
1. Documentation of intended behavior
2. Future integration with collector policy generation
3. Setting `sampling_rate=1.0` with collector-side filtering

## Test plan

- [x] Run `cargo test -p icn-obs otel` - 10 tests pass
- [x] Run `cargo clippy -p icn-obs -p icn-core` - no warnings
- [x] Run `cargo fmt --check` - passes
- [ ] CI passes

## Files changed

- `icn-obs/src/otel.rs` - Add PrioritySampler and config fields
- `icn-core/src/config/observability.rs` - Add shadow config fields

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)