### PR TITLE
docs(gateway): Document dev-mode CSP usage and add security tests

### DIFF
--- a/docs/security/GATEWAY_CSP.md
+++ b/docs/security/GATEWAY_CSP.md
@@ -1,0 +1,126 @@
+# Gateway Content Security Policy
+
+This document describes the Content Security Policy (CSP) configuration for the ICN Gateway API.
+
+## Overview
+
+Content Security Policy is a security header that helps prevent XSS attacks, clickjacking, and other code injection attacks by controlling which resources the browser is allowed to load.
+
+## CSP Configurations
+
+The gateway provides different CSP configurations for development and production environments.
+
+### Production CSP (Default)
+
+```
+default-src 'self';
+script-src 'self';
+style-src 'self' 'unsafe-inline';
+img-src 'self' data:;
+connect-src 'self' ws: wss:
+```
+
+| Directive | Value | Purpose |
+|-----------|-------|---------|
+| `default-src` | `'self'` | Only load resources from same origin |
+| `script-src` | `'self'` | Scripts only from same origin (no inline) |
+| `style-src` | `'self' 'unsafe-inline'` | Styles from same origin + inline styles |
+| `img-src` | `'self' data:` | Images from same origin + data URIs |
+| `connect-src` | `'self' ws: wss:` | API calls to same origin + WebSocket |
+
+**Note:** `'unsafe-inline'` in `style-src` is intentionally allowed for production. This is a common pattern because:
+- Many UI frameworks require inline styles for dynamic styling
+- Inline styles are lower risk than inline scripts
+- The alternative (nonces or hashes) adds significant complexity
+
+### Development CSP
+
+The development configuration includes relaxed CSP directives to support hot module replacement (HMR) and development tooling:
+
+- Allows inline scripts and styles
+- Allows dynamic code execution for HMR
+- Permits connections to any localhost port
+
+**Security Warning:** The development CSP includes directives that would be dangerous in production. These are required for development tooling but **MUST NOT** be used in production deployments.
+
+## Configuration Usage
+
+### Code Examples
+
+```rust
+use icn_gateway::security::SecurityConfig;
+
+// Production (recommended)
+let config = SecurityConfig::production();
+
+// Production with custom origins
+let config = SecurityConfig::production_with_origins(vec![
+    "https://app.icn.coop".to_string(),
+    "https://admin.icn.coop".to_string(),
+]);
+
+// Development only
+let config = SecurityConfig::development();
+```
+
+### Environment Detection
+
+The gateway does NOT automatically detect environment. You must explicitly choose:
+
+```rust
+let config = if cfg!(debug_assertions) {
+    SecurityConfig::development()
+} else {
+    SecurityConfig::production()
+};
+```
+
+## Security Checklist
+
+Before deploying to production, verify:
+
+- [ ] Using `SecurityConfig::production()` or `production_with_origins()`
+- [ ] CSP does not include dangerous directives (check for development config leakage)
+- [ ] CORS properly configured (preferably `CorsMode::Disabled` with reverse proxy handling)
+- [ ] HTTPS enforced (HSTS header is set by default)
+- [ ] Security headers enabled (`enable_security_headers: true`)
+
+## Other Security Headers
+
+The gateway also sets these security headers (enabled by default):
+
+| Header | Value | Purpose |
+|--------|-------|---------|
+| `X-Frame-Options` | `DENY` | Prevent clickjacking |
+| `X-Content-Type-Options` | `nosniff` | Prevent MIME sniffing |
+| `X-XSS-Protection` | `1; mode=block` | Legacy XSS protection |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Limit referrer leakage |
+| `Permissions-Policy` | Restrictive | Disable geolocation, mic, camera, payment |
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` | Enforce HTTPS |
+
+## Testing CSP
+
+### Manual Verification
+
+Check response headers in browser DevTools (Network tab) or curl:
+
+```bash
+curl -I https://your-gateway/api/health
+```
+
+Look for `Content-Security-Policy` header.
+
+### Automated Verification
+
+The gateway includes tests to verify CSP configuration is secure for production.
+
+## Related Files
+
+- `icn-gateway/src/security.rs` - Security middleware implementation
+- `icn-core/src/config/gateway.rs` - Gateway configuration
+- `docs/production-hardening.md` - Overall security hardening guide
+
+## References
+
+- [MDN: Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
+- [OWASP: Content Security Policy Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html)

--- a/docs/security/GATEWAY_CSP.md
+++ b/docs/security/GATEWAY_CSP.md
@@ -17,7 +17,7 @@ default-src 'self';
 script-src 'self';
 style-src 'self' 'unsafe-inline';
 img-src 'self' data:;
-connect-src 'self' ws: wss:
+connect-src 'self' ws: wss:;
 ```
 
 | Directive | Value | Purpose |

--- a/docs/security/GATEWAY_CSP.md
+++ b/docs/security/GATEWAY_CSP.md
@@ -20,6 +20,8 @@ img-src 'self' data:;
 connect-src 'self' ws: wss:;
 ```
 
+**Note:** The CSP is sent as a single-line HTTP header. The formatting above is for readability.
+
 | Directive | Value | Purpose |
 |-----------|-------|---------|
 | `default-src` | `'self'` | Only load resources from same origin |

--- a/icn/crates/icn-gateway/src/security.rs
+++ b/icn/crates/icn-gateway/src/security.rs
@@ -471,9 +471,8 @@ mod tests {
     #[test]
     fn test_production_with_origins_has_strict_csp() {
         // Even with custom origins, CSP should be strict
-        let config = SecurityConfig::production_with_origins(vec![
-            "https://app.icn.coop".to_string(),
-        ]);
+        let config =
+            SecurityConfig::production_with_origins(vec!["https://app.icn.coop".to_string()]);
         let dangerous_directive = "unsafe-".to_string() + "eval";
         assert!(
             !config.csp_directive.contains(&dangerous_directive),

--- a/icn/crates/icn-gateway/src/security.rs
+++ b/icn/crates/icn-gateway/src/security.rs
@@ -443,4 +443,68 @@ mod tests {
             panic!("Development config should use AllowedOrigins");
         }
     }
+
+    // CSP Security Tests (Issue #415)
+
+    #[test]
+    fn test_production_csp_is_strict() {
+        // Production CSP must not allow dynamic code execution
+        let config = SecurityConfig::production();
+        // Check that dangerous CSP directives are not present
+        let dangerous_directive = "unsafe-".to_string() + "eval";
+        assert!(
+            !config.csp_directive.contains(&dangerous_directive),
+            "Production CSP must not allow dynamic code execution"
+        );
+    }
+
+    #[test]
+    fn test_production_csp_has_default_self() {
+        // Production CSP must restrict default-src to 'self'
+        let config = SecurityConfig::production();
+        assert!(
+            config.csp_directive.contains("default-src 'self'"),
+            "Production CSP must have default-src 'self'"
+        );
+    }
+
+    #[test]
+    fn test_production_with_origins_has_strict_csp() {
+        // Even with custom origins, CSP should be strict
+        let config = SecurityConfig::production_with_origins(vec![
+            "https://app.icn.coop".to_string(),
+        ]);
+        let dangerous_directive = "unsafe-".to_string() + "eval";
+        assert!(
+            !config.csp_directive.contains(&dangerous_directive),
+            "production_with_origins CSP must be strict"
+        );
+        assert!(
+            config.csp_directive.contains("default-src 'self'"),
+            "production_with_origins CSP must have default-src 'self'"
+        );
+    }
+
+    #[test]
+    fn test_development_csp_differs_from_production() {
+        // Development CSP should be more permissive than production
+        let dev_config = SecurityConfig::development();
+        let prod_config = SecurityConfig::production();
+
+        // Development allows more things
+        assert_ne!(
+            dev_config.csp_directive, prod_config.csp_directive,
+            "Development and production CSP should differ"
+        );
+
+        // Development connects to localhost
+        assert!(
+            dev_config.csp_directive.contains("localhost"),
+            "Development CSP should allow localhost connections"
+        );
+        assert!(
+            !prod_config.csp_directive.contains("localhost"),
+            "Production CSP should not reference localhost"
+        );
+    }
 }

--- a/icn/crates/icn-gateway/src/security.rs
+++ b/icn/crates/icn-gateway/src/security.rs
@@ -451,9 +451,10 @@ mod tests {
         // Production CSP must not allow dynamic code execution
         let config = SecurityConfig::production();
         // Check that dangerous CSP directives are not present
-        let dangerous_directive = "unsafe-".to_string() + "eval";
+        // CSP keywords use single quotes, e.g., 'unsafe-eval'
+        let dangerous_directive = "'unsafe-eval'";
         assert!(
-            !config.csp_directive.contains(&dangerous_directive),
+            !config.csp_directive.contains(dangerous_directive),
             "Production CSP must not allow dynamic code execution"
         );
     }
@@ -473,9 +474,10 @@ mod tests {
         // Even with custom origins, CSP should be strict
         let config =
             SecurityConfig::production_with_origins(vec!["https://app.icn.coop".to_string()]);
-        let dangerous_directive = "unsafe-".to_string() + "eval";
+        // CSP keywords use single quotes, e.g., 'unsafe-eval'
+        let dangerous_directive = "'unsafe-eval'";
         assert!(
-            !config.csp_directive.contains(&dangerous_directive),
+            !config.csp_directive.contains(dangerous_directive),
             "production_with_origins CSP must be strict"
         );
         assert!(

--- a/icn/crates/icn-gateway/src/security.rs
+++ b/icn/crates/icn-gateway/src/security.rs
@@ -508,4 +508,18 @@ mod tests {
             "Production CSP should not reference localhost"
         );
     }
+
+    #[test]
+    fn test_development_csp_allows_required_unsafe_directives() {
+        // Development needs unsafe-inline and unsafe-eval for HMR/hot reloading
+        let config = SecurityConfig::development();
+        assert!(
+            config.csp_directive.contains("'unsafe-inline'"),
+            "Development CSP should allow unsafe-inline for framework support"
+        );
+        assert!(
+            config.csp_directive.contains("'unsafe-eval'"),
+            "Development CSP should allow unsafe-eval for HMR"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Add comprehensive CSP documentation at docs/security/GATEWAY_CSP.md
- Document production vs development CSP differences with security warnings
- Add security checklist for production deployments
- Add 4 CSP security tests to verify production config is strict

Closes #415

## Changes

### Documentation (`docs/security/GATEWAY_CSP.md`)
- Production CSP directives table with purposes
- Development CSP explanation with security warnings
- Configuration code examples (production, production_with_origins, development)
- Environment detection guidance
- Security checklist for production deployment
- Other security headers reference (X-Frame-Options, HSTS, etc.)
- Testing guidance (manual and automated)

### Tests (`icn-gateway/src/security.rs`)
- `test_production_csp_is_strict` - verifies no dangerous directives in production
- `test_production_csp_has_default_self` - verifies default-src 'self' is set
- `test_production_with_origins_has_strict_csp` - verifies custom origins maintain strict CSP
- `test_development_csp_differs_from_production` - confirms dev/prod CSP policies differ

## Test plan
- [x] All existing gateway tests pass (24 tests)
- [x] New CSP security tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)