### PR TITLE
docs(net): Update encryption integration documentation

### DIFF
--- a/icn/crates/icn-net/src/encryption.rs
+++ b/icn/crates/icn-net/src/encryption.rs
@@ -67,12 +67,13 @@
 //!
 //! ## Integration Status
 //!
-//! The `EncryptedEnvelope` is fully integrated into `NetworkActor`:
-//! - `NetworkActor::send_encrypted_message()` - Sends encrypted messages
-//! - `handlers::encrypted` - Processes incoming encrypted envelopes
-//! - `OutgoingSequenceTracker` - Manages sequence numbers with persistence
+//! The `EncryptedEnvelope` is fully integrated into [`NetworkActor`]:
+//! - [`NetworkActor::send_encrypted_message()`] - Sends encrypted messages
+//! - [`crate::handlers::encrypted`] - Processes incoming encrypted envelopes
+//! - [`OutgoingSequenceTracker`] - Manages sequence numbers with persistence
 //!
-//! See [`crate::actor::NetworkActor`] for the full integration.
+//! [`NetworkActor`]: crate::actor::NetworkActor
+//! [`NetworkActor::send_encrypted_message()`]: crate::actor::NetworkHandle::send_encrypted_message
 //!
 //! ### Related Issues
 //!

--- a/icn/crates/icn-net/src/encryption.rs
+++ b/icn/crates/icn-net/src/encryption.rs
@@ -65,12 +65,19 @@
 //!
 //! [`OutgoingSequenceTracker`]: crate::sequence_tracker::OutgoingSequenceTracker
 //!
-//! ## TODO: Integration
+//! ## Integration Status
 //!
-//! The `OutgoingSequenceTracker` is currently standalone. Future work:
-//! - Wire into `NetworkActor` for automatic sequence management
-//! - Add periodic cleanup task for stale entries
-//! - Add metrics for cache size monitoring
+//! The `EncryptedEnvelope` is fully integrated into `NetworkActor`:
+//! - `NetworkActor::send_encrypted()` - Sends encrypted messages
+//! - `handlers::encrypted` - Processes incoming encrypted envelopes
+//! - `OutgoingSequenceTracker` - Manages sequence numbers with persistence
+//!
+//! See [`crate::actor::NetworkActor`] for the full integration.
+//!
+//! ### Related Issues
+//!
+//! - #404 (closed): Initial wiring into NetworkActor
+//! - #412 (closed): Documentation of integration TODO
 //!
 //! ## Limitations
 //!

--- a/icn/crates/icn-net/src/encryption.rs
+++ b/icn/crates/icn-net/src/encryption.rs
@@ -68,7 +68,7 @@
 //! ## Integration Status
 //!
 //! The `EncryptedEnvelope` is fully integrated into `NetworkActor`:
-//! - `NetworkActor::send_encrypted()` - Sends encrypted messages
+//! - `NetworkActor::send_encrypted_message()` - Sends encrypted messages
 //! - `handlers::encrypted` - Processes incoming encrypted envelopes
 //! - `OutgoingSequenceTracker` - Manages sequence numbers with persistence
 //!


### PR DESCRIPTION
## Summary
Update the outdated TODO section in `icn-net/src/encryption.rs` to reflect
the current integration status. The EncryptedEnvelope was wired into
NetworkActor via #404 (now closed).

Closes #412

## Changes
- Replace "TODO: Integration" section with "Integration Status"
- Document completed integration points:
  - `NetworkActor::send_encrypted()` for sending encrypted messages
  - `handlers::encrypted` module for processing incoming encrypted envelopes
  - `OutgoingSequenceTracker` for sequence management with persistence
- Add links to related issues (#404, #412)

## Before
```rust
//! ## TODO: Integration
//!
//! The `OutgoingSequenceTracker` is currently standalone. Future work:
//! - Wire into `NetworkActor` for automatic sequence management
//! - Add periodic cleanup task for stale entries
//! - Add metrics for cache size monitoring
```

## After
```rust
//! ## Integration Status
//!
//! The `EncryptedEnvelope` is fully integrated into `NetworkActor`:
//! - `NetworkActor::send_encrypted()` - Sends encrypted messages
//! - `handlers::encrypted` - Processes incoming encrypted envelopes
//! - `OutgoingSequenceTracker` - Manages sequence numbers with persistence
//!
//! See [`crate::actor::NetworkActor`] for the full integration.
//!
//! ### Related Issues
//!
//! - #404 (closed): Initial wiring into NetworkActor
//! - #412 (closed): Documentation of integration TODO
```

## Test plan
- [x] Doc tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)