### PR TITLE
feat(i18n): Add Spanish translations

### DIFF
--- a/icn/bins/icnctl/locales/es.yaml
+++ b/icn/bins/icnctl/locales/es.yaml
@@ -1,0 +1,292 @@
+# ICN CLI Translations - Spanish (Espanol)
+# Format: {command}.{subcommand}.{message_type}
+# Variables: {var_name} for interpolation
+
+cli:
+  # Common messages
+  common:
+    no_identity: "No se encontro identidad. Ejecuta 'icnctl id init' para crear una."
+    error: "Error"
+    success: "Exito"
+    failed: "Fallido"
+
+  # Prompts
+  prompts:
+    enter_passphrase: "Introduce la contrasena: "
+    confirm_passphrase: "Confirma la contrasena: "
+    choose_passphrase: "Elige una contrasena: "
+
+  # Status command
+  status:
+    checking: "Verificando estado del daemon..."
+    connected: "Conectado al daemon ICN"
+    not_running: "El daemon no esta en ejecucion"
+    endpoint: "Punto de conexion"
+
+  # Network commands
+  network:
+    peers:
+      title: "Pares Descubiertos"
+      no_peers: "Aun no se han descubierto pares"
+      header: "DID                                          Direccion"
+      tip: "Consejo: Asegurate de que otros nodos ICN esten ejecutandose en la red."
+
+    dial:
+      connecting: "Conectando al par..."
+      success: "Conexion establecida"
+      failed: "Conexion fallida"
+
+    stats:
+      title: "Estadisticas de Red"
+      active_connections: "Conexiones activas"
+      bytes_sent: "Bytes enviados"
+      bytes_received: "Bytes recibidos"
+      uptime: "Tiempo activo"
+
+    status:
+      title: "Estado del Actor de Red"
+      listening: "Escuchando en"
+      peer_count: "Pares conectados"
+
+  # Trust commands
+  trust:
+    add:
+      success: "Arista de confianza anadida exitosamente"
+      did_label: "DID destino"
+      score_label: "Puntuacion de confianza"
+      label_label: "Etiqueta"
+
+    list:
+      title: "Aristas de Confianza"
+      no_edges: "No se encontraron aristas de confianza"
+      header: "DID                                          Puntuacion  Etiqueta"
+
+    show:
+      title: "Puntuacion de Confianza"
+      computed_score: "Puntuacion de confianza calculada"
+      direct_score: "Puntuacion de confianza directa"
+      transitive: "Confianza transitiva"
+      class_label: "Clase"
+      class_isolated: "Aislado"
+      class_known: "Conocido"
+      class_partner: "Socio"
+      class_federated: "Federado"
+
+    remove:
+      success: "Arista de confianza eliminada"
+      not_found: "Arista de confianza no encontrada"
+
+  # Ledger commands
+  ledger:
+    head:
+      title: "Cabecera del Libro Mayor"
+      no_entries: "El libro mayor esta vacio"
+      entry_hash: "Hash de entrada"
+      timestamp: "Marca de tiempo"
+
+    balance:
+      title: "Saldo de Cuenta"
+      account_label: "Cuenta"
+      currency_label: "Moneda"
+      balance_label: "Saldo"
+      no_balance: "No se encontro saldo para esta cuenta"
+
+    history:
+      title: "Historial del Libro Mayor"
+      no_entries: "No se encontraron entradas en el libro mayor"
+      showing: "Mostrando las {count} entradas mas recientes"
+      header: "Hash                             Marca de tiempo      Tipo"
+      hash: "Hash"
+      author: "Autor"
+      accounts_label: "Cuentas"
+      debit_label: "debito"
+      credit_label: "credito"
+
+  # Backup commands
+  backup:
+    creating: "Creando copia de seguridad..."
+    success: "Copia de seguridad creada exitosamente"
+    output_label: "Archivo de respaldo"
+    includes: "La copia incluye: almacen de claves, grafo de confianza, libro mayor, estado de gobernanza"
+
+  restore:
+    checking: "Verificando integridad del respaldo..."
+    restoring: "Restaurando desde copia de seguridad..."
+    success: "Restauracion completada exitosamente"
+    backup_info: "Informacion del Respaldo"
+    created_at: "Creado"
+    node_did: "DID del Nodo"
+    warning_overwrite: "ADVERTENCIA: Esto sobreescribira los datos existentes en {path}"
+
+  verify_backup:
+    verifying: "Verificando copia de seguridad..."
+    valid: "La copia de seguridad es valida"
+    invalid: "La copia de seguridad es invalida"
+    checksum_match: "Suma de verificacion coincide"
+    checksum_mismatch: "Suma de verificacion no coincide"
+
+  # Identity commands
+  id:
+    init:
+      starting: "Inicializando nueva identidad ICN..."
+      generating: "Generando par de claves Ed25519"
+      success: "Identidad creada exitosamente!"
+      did_label: "DID"
+      keystore_label: "Almacen de claves"
+      important: "IMPORTANTE: Guarda tu contrasena de forma segura. No se puede recuperar."
+      already_exists: "Ya existe una identidad en {path}."
+
+    show:
+      title: "Identidad:"
+      did_label: "  DID:"
+      keystore_label: "  Almacen de claves:"
+
+    rotate:
+      starting: "Rotando clave de identidad..."
+      generating: "Generando nuevo par de claves Ed25519"
+      success: "Rotacion de clave exitosa!"
+      old_did: "DID anterior"
+      new_did: "Nuevo DID"
+      reason: "Razon"
+      important: "IMPORTANTE: Publica la prueba de rotacion para mantener la continuidad de identidad."
+      timestamp: "Marca de tiempo"
+
+    export:
+      exporting: "Exportando identidad..."
+      success: "Identidad exportada exitosamente"
+      output_label: "Archivo de exportacion"
+
+    import:
+      importing: "Importando identidad..."
+      success: "Identidad importada exitosamente"
+      input_label: "Archivo de importacion"
+
+  # Device commands (multi-device identity)
+  device:
+    list:
+      title: "Dispositivos"
+      no_devices: "No se encontraron dispositivos"
+      header: "ID                 Etiqueta           Estado      Anadido"
+      current: "(dispositivo actual)"
+
+    add:
+      creating: "Creando solicitud de agregar dispositivo..."
+      success: "Solicitud de agregar dispositivo creada"
+      file_saved: "Solicitud guardada en"
+      instructions: "Transfiere este archivo a tu dispositivo principal y apruebalo con: icnctl device approve {file}"
+
+    approve:
+      approving: "Aprobando dispositivo..."
+      success: "Dispositivo aprobado exitosamente"
+      device_label: "Dispositivo"
+      device_id: "ID de dispositivo"
+
+    revoke:
+      revoking: "Revocando dispositivo..."
+      success: "Dispositivo revocado exitosamente"
+      reason_label: "Razon"
+
+  # Contract commands
+  contract:
+    deploy:
+      deploying: "Desplegando contrato..."
+      success: "Contrato desplegado exitosamente"
+      code_hash: "Hash del codigo"
+
+    call:
+      calling: "Llamando contrato..."
+      success: "Contrato ejecutado exitosamente"
+      result: "Resultado"
+      fuel_used: "Combustible usado"
+
+    list:
+      title: "Contratos Desplegados"
+      no_contracts: "No hay contratos desplegados"
+      header: "Hash del Codigo                  Desplegado Por"
+
+  # Governance commands
+  gov:
+    domain:
+      create:
+        creating: "Creando dominio de gobernanza..."
+        success: "Dominio creado exitosamente"
+        domain_id: "ID de Dominio"
+
+      show:
+        title: "Detalles del Dominio"
+        members_label: "Miembros"
+        quorum_label: "Quorum"
+        approval_label: "Umbral de aprobacion"
+
+      list:
+        title: "Dominios de Gobernanza"
+        no_domains: "No se encontraron dominios"
+        header: "ID                    Nombre               Miembros  Quorum"
+
+    proposal:
+      create:
+        creating: "Creando propuesta..."
+        success: "Propuesta creada exitosamente"
+        proposal_id: "ID de Propuesta"
+
+      list:
+        title: "Propuestas"
+        no_proposals: "No se encontraron propuestas"
+        header: "ID            Titulo                   Estado     Votos"
+
+      show:
+        title: "Detalles de la Propuesta"
+        state_label: "Estado"
+        votes_for: "Votos a favor"
+        votes_against: "Votos en contra"
+        quorum_reached: "Quorum alcanzado"
+
+    vote:
+      cast:
+        casting: "Registrando voto..."
+        success: "Voto registrado exitosamente"
+        choice_label: "Eleccion"
+
+  # Compute commands
+  compute:
+    submit:
+      submitting: "Enviando tarea..."
+      success: "Tarea enviada exitosamente"
+      task_id: "ID de Tarea"
+      task_hash: "Hash de tarea"
+
+    status:
+      title: "Estado de la Tarea"
+      state_label: "Estado"
+      result_label: "Resultado"
+      fuel_used: "Combustible usado"
+
+    cancel:
+      cancelling: "Cancelando tarea..."
+      success: "Tarea cancelada exitosamente"
+
+  # Snapshot commands
+  snapshot:
+    create:
+      creating: "Creando instantanea..."
+      success: "Instantanea creada exitosamente"
+      filename: "Archivo de instantanea"
+
+    list:
+      title: "Instantaneas Disponibles"
+      no_snapshots: "No se encontraron instantaneas"
+      header: "Nombre                Creada               Tamano"
+
+    verify:
+      verifying: "Verificando instantanea..."
+      valid: "La instantanea es valida"
+      invalid: "La instantanea es invalida"
+
+    delete:
+      deleting: "Eliminando instantanea..."
+      success: "Instantanea eliminada exitosamente"
+
+    cleanup:
+      cleaning: "Limpiando instantaneas antiguas..."
+      deleted_count: "Se eliminaron {count} instantanea(s) antigua(s)"
+      kept_count: "Se conservaron {count} instantanea(s) reciente(s)"

--- a/icn/crates/icn-gateway/locales/es.yaml
+++ b/icn/crates/icn-gateway/locales/es.yaml
@@ -1,0 +1,60 @@
+# ICN Gateway API Translations - Spanish (Espanol)
+# Format: {category}.{error_type}.{variant}
+# Variables: {var_name} for interpolation
+#
+# Note: Some keys (auth_required, token_expired, etc.) are defined for future
+# use when more specific error variants are added. Currently, the *_prefix keys
+# are used with dynamic content appended via Rust's format!() macro.
+
+gateway:
+  errors:
+    # Authentication errors
+    auth_failed_prefix: "Autenticacion fallida"
+    auth_required: "Se requiere autenticacion"
+    token_expired: "El token de autenticacion ha expirado"
+    invalid_token: "Token de autenticacion invalido"
+
+    # Authorization errors
+    authz_failed_prefix: "Autorizacion fallida"
+    forbidden_prefix: "Acceso prohibido"
+    insufficient_permissions: "Permisos insuficientes para esta operacion"
+
+    # Resource errors
+    not_found_prefix: "Recurso no encontrado"
+    already_exists: "El recurso ya existe: {resource}"
+
+    # Request errors
+    bad_request_prefix: "Solicitud invalida"
+    validation_failed: "Validacion fallida: {reason}"
+
+    # Rate limiting
+    rate_limit_exceeded: "Limite de tasa excedido"
+    rate_limit_exceeded_prefix: "Limite de tasa excedido para DID"
+    budget_exceeded_prefix: "Presupuesto excedido"
+
+    # Server errors
+    internal: "Error interno del servidor"
+    service_unavailable: "Servicio temporalmente no disponible"
+
+  # Health check messages
+  health:
+    status_ok: "El servicio esta saludable"
+    status_degraded: "El servicio esta degradado"
+    status_unavailable: "El servicio no esta disponible"
+    component_available: "Disponible"
+    component_unavailable: "No disponible"
+
+  # API responses
+  responses:
+    success: "Operacion completada exitosamente"
+    created: "Recurso creado exitosamente"
+    updated: "Recurso actualizado exitosamente"
+    deleted: "Recurso eliminado exitosamente"
+
+  # Validation messages
+  validation:
+    required_field: "{field} es requerido"
+    invalid_format: "Formato invalido para {field}"
+    invalid_did: "Formato de DID invalido"
+    invalid_amount: "Cantidad invalida: debe ser positiva"
+    amount_too_large: "La cantidad excede el maximo permitido"

--- a/sdk/react-native/examples/CoopWallet/src/i18n/locales/es.json
+++ b/sdk/react-native/examples/CoopWallet/src/i18n/locales/es.json
@@ -1,0 +1,248 @@
+{
+  "common": {
+    "loading": "Cargando...",
+    "error": "Ocurrio un error",
+    "retry": "Reintentar",
+    "cancel": "Cancelar",
+    "confirm": "Confirmar",
+    "save": "Guardar",
+    "delete": "Eliminar",
+    "edit": "Editar",
+    "done": "Hecho",
+    "next": "Siguiente",
+    "back": "Atras",
+    "close": "Cerrar",
+    "logout": "Cerrar sesion",
+    "search": "Buscar",
+    "noData": "No hay datos disponibles"
+  },
+
+  "nav": {
+    "home": "Inicio",
+    "payments": "Pagos",
+    "contacts": "Contactos",
+    "governance": "Gobernanza",
+    "settings": "Configuracion",
+    "identity": "Identidad",
+    "steward": "Administrador"
+  },
+
+  "home": {
+    "title": "Inicio",
+    "welcome": "Bienvenido de nuevo",
+    "balance": {
+      "label": "Saldo Disponible",
+      "currency": "horas"
+    },
+    "status": {
+      "connected": "Conectado",
+      "offline": "Sin conexion",
+      "syncing": "Sincronizando..."
+    },
+    "actions": {
+      "send": "Enviar",
+      "receive": "Recibir",
+      "scan": "Escanear",
+      "vote": "Votar",
+      "trust": "Confianza"
+    },
+    "transactions": {
+      "title": "Transacciones Recientes",
+      "seeAll": "Ver Todas",
+      "empty": "Aun no hay transacciones",
+      "to": "A: {{did}}",
+      "from": "De: {{did}}"
+    }
+  },
+
+  "login": {
+    "title": "Unirse a la Cooperativa",
+    "scanQr": "Escanear Codigo QR",
+    "pasteCode": "Pegar Codigo de Inscripcion",
+    "enrollmentCode": "Codigo de Inscripcion",
+    "placeholder": "Introduce los datos de inscripcion...",
+    "submit": "Unirse",
+    "generating": "Generando prueba de dispositivo...",
+    "verifying": "Verificando con la cooperativa...",
+    "success": "Inscripcion verificada!",
+    "successTitle": "Inscripcion Exitosa"
+  },
+
+  "payments": {
+    "title": "Enviar Pago",
+    "recipient": "Destinatario",
+    "recipientPlaceholder": "Introduce DID o selecciona contacto",
+    "amount": "Cantidad",
+    "amountPlaceholder": "0.00",
+    "currency": "Moneda",
+    "memo": "Memo (opcional)",
+    "memoPlaceholder": "Para que es esto?",
+    "send": "Enviar Pago",
+    "confirm": {
+      "title": "Confirmar Pago",
+      "message": "Enviar {{amount}} {{currency}} a {{recipient}}?"
+    },
+    "success": "Pago enviado exitosamente!",
+    "history": {
+      "title": "Historial de Transacciones",
+      "empty": "No se encontraron transacciones"
+    }
+  },
+
+  "receive": {
+    "title": "Recibir Pago",
+    "yourDid": "Tu DID",
+    "qrCode": "Codigo QR",
+    "copyDid": "Copiar DID",
+    "copied": "DID copiado al portapapeles",
+    "share": "Compartir"
+  },
+
+  "contacts": {
+    "title": "Contactos",
+    "search": "Buscar contactos...",
+    "add": "Agregar Contacto",
+    "empty": "Aun no hay contactos",
+    "form": {
+      "did": "DID",
+      "didPlaceholder": "did:icn:...",
+      "name": "Nombre (opcional)",
+      "namePlaceholder": "Nombre del contacto"
+    },
+    "delete": {
+      "title": "Eliminar Contacto",
+      "message": "Estas seguro de que deseas eliminar este contacto?"
+    },
+    "errors": {
+      "invalidDid": "Formato de DID invalido. Debe comenzar con did:icn:",
+      "alreadyExists": "El contacto ya existe",
+      "saveFailed": "Error al guardar contacto",
+      "loadFailed": "Error al cargar contactos"
+    }
+  },
+
+  "governance": {
+    "title": "Gobernanza",
+    "proposals": {
+      "title": "Propuestas Activas",
+      "empty": "No hay propuestas activas",
+      "vote": "Votar",
+      "voted": "Votado",
+      "approved": "Aprobado",
+      "rejected": "Rechazado",
+      "pending": "Pendiente"
+    },
+    "voting": {
+      "title": "Emitir Tu Voto",
+      "approve": "Aprobar",
+      "reject": "Rechazar",
+      "abstain": "Abstenerse",
+      "confirm": "Estas seguro de que deseas votar {{vote}} en esta propuesta?"
+    }
+  },
+
+  "trust": {
+    "title": "Red de Confianza",
+    "attestation": {
+      "title": "Atestacion de Confianza",
+      "for": "Atestando confianza para",
+      "score": "Puntuacion de Confianza",
+      "context": "Contexto",
+      "reason": "Razon (opcional)",
+      "submit": "Enviar Atestacion"
+    },
+    "vouch": {
+      "title": "Avalar a un Miembro",
+      "confirm": "Confirmar Aval",
+      "success": "Aval enviado exitosamente"
+    },
+    "history": {
+      "title": "Historial de Avales",
+      "empty": "Sin historial de avales"
+    }
+  },
+
+  "identity": {
+    "title": "Mi Identidad",
+    "did": "Tu DID",
+    "memberSince": "Miembro desde",
+    "trustScore": "Puntuacion de Confianza",
+    "cooperative": "Cooperativa",
+    "devices": {
+      "title": "Dispositivos Vinculados",
+      "this": "Este Dispositivo",
+      "add": "Vincular Nuevo Dispositivo"
+    }
+  },
+
+  "steward": {
+    "dashboard": {
+      "title": "Panel de Administrador",
+      "pendingEnrollments": "Inscripciones Pendientes",
+      "approvedToday": "Aprobadas Hoy",
+      "pendingVouches": "Avales Pendientes"
+    },
+    "enrollment": {
+      "title": "Solicitud de Inscripcion",
+      "approve": "Aprobar",
+      "reject": "Rechazar",
+      "rejectReason": "Razon del rechazo...",
+      "rejectReasonRequired": "Por favor proporciona una razon para el rechazo.",
+      "rejected": "Inscripcion rechazada"
+    },
+    "verification": {
+      "title": "Historial de Verificaciones",
+      "empty": "Aun no hay verificaciones"
+    }
+  },
+
+  "settings": {
+    "title": "Configuracion",
+    "account": {
+      "title": "Cuenta",
+      "profile": "Perfil",
+      "security": "Seguridad"
+    },
+    "app": {
+      "title": "Configuracion de la App",
+      "language": "Idioma",
+      "theme": "Tema",
+      "notifications": "Notificaciones"
+    },
+    "about": {
+      "title": "Acerca de",
+      "version": "Version",
+      "terms": "Terminos de Servicio",
+      "privacy": "Politica de Privacidad"
+    },
+    "logout": {
+      "title": "Cerrar Sesion",
+      "confirm": "Estas seguro de que deseas cerrar sesion?"
+    }
+  },
+
+  "scan": {
+    "title": "Escanear Codigo QR",
+    "instructions": "Apunta la camara al codigo QR",
+    "permissionDenied": "Permiso de camara denegado",
+    "requestPermission": "Conceder Acceso a la Camara"
+  },
+
+  "errors": {
+    "network": "Error de red. Por favor verifica tu conexion.",
+    "auth": "Autenticacion fallida. Por favor inicia sesion de nuevo.",
+    "notFound": "Recurso no encontrado",
+    "forbidden": "No tienes permiso para esta accion",
+    "serverError": "Error del servidor. Por favor intenta mas tarde.",
+    "validation": "Por favor verifica tu entrada",
+    "unknown": "Ocurrio un error inesperado"
+  },
+
+  "accessibility": {
+    "badge": "{{count}} notificaciones",
+    "selected": "Seleccionado",
+    "notSelected": "No seleccionado",
+    "loading": "Cargando contenido",
+    "error": "Mensaje de error"
+  }
+}

--- a/web/pilot-ui/locales/es.json
+++ b/web/pilot-ui/locales/es.json
@@ -1,0 +1,197 @@
+{
+  "app": {
+    "title": "ICN Banco de Tiempo",
+    "subtitle": "Banco de Tiempo Cooperativo"
+  },
+
+  "nav": {
+    "overview": "Resumen",
+    "network": "Red",
+    "ledger": "Libro Mayor",
+    "governance": "Gobernanza",
+    "compute": "Tareas de Computo",
+    "federation": "Federacion",
+    "metrics": "Metricas del Sistema",
+    "logs": "Registros del Sistema",
+    "settings": "Configuracion"
+  },
+
+  "status": {
+    "online": "En linea",
+    "offline": "Sin conexion",
+    "connecting": "Conectando...",
+    "syncing": "Sincronizando...",
+    "error": "Error"
+  },
+
+  "common": {
+    "loading": "Cargando...",
+    "noData": "No hay datos disponibles",
+    "error": "Ocurrio un error",
+    "retry": "Reintentar",
+    "refresh": "Actualizar",
+    "save": "Guardar",
+    "cancel": "Cancelar",
+    "confirm": "Confirmar",
+    "delete": "Eliminar",
+    "edit": "Editar",
+    "close": "Cerrar",
+    "search": "Buscar",
+    "filter": "Filtrar",
+    "all": "Todos",
+    "none": "Ninguno",
+    "yes": "Si",
+    "no": "No"
+  },
+
+  "auth": {
+    "title": "Autenticacion",
+    "signIn": "Iniciar Sesion",
+    "signOut": "Cerrar Sesion",
+    "challenge": "Desafio de Autenticacion",
+    "verify": "Verificar",
+    "enterDid": "Introduce tu DID",
+    "enterSignature": "Introduce la firma",
+    "help": {
+      "title": "Ayuda de Autenticacion",
+      "step1": "1. Copia el desafio a continuacion",
+      "step2": "2. Firmalo con tu identidad ICN",
+      "step3": "3. Pega la firma para autenticarte"
+    },
+    "errors": {
+      "invalidDid": "Formato de DID invalido",
+      "invalidSignature": "Firma invalida",
+      "expired": "Desafio expirado, por favor actualiza",
+      "failed": "Autenticacion fallida"
+    }
+  },
+
+  "overview": {
+    "title": "Resumen del Panel",
+    "nodeInfo": "Informacion del Nodo",
+    "did": "DID del Nodo",
+    "version": "Version",
+    "uptime": "Tiempo Activo",
+    "recentActivity": "Actividad Reciente",
+    "noActivity": "Sin actividad reciente"
+  },
+
+  "network": {
+    "title": "Estado de la Red",
+    "connectedPeers": "Pares Conectados",
+    "noPeers": "Sin pares conectados",
+    "peerDid": "DID del Par",
+    "address": "Direccion",
+    "latency": "Latencia",
+    "lastSeen": "Ultima Vez Visto",
+    "errors": {
+      "loadFailed": "Error al cargar pares"
+    }
+  },
+
+  "ledger": {
+    "title": "Libro Mayor",
+    "entries": "Entradas",
+    "balance": "Saldo",
+    "transactions": "Transacciones",
+    "filter": {
+      "all": "Todas las Entradas",
+      "today": "Hoy",
+      "week": "Esta Semana",
+      "month": "Este Mes"
+    },
+    "columns": {
+      "date": "Fecha",
+      "from": "De",
+      "to": "A",
+      "amount": "Cantidad",
+      "currency": "Moneda",
+      "memo": "Memo"
+    },
+    "noEntries": "No se encontraron entradas en el libro mayor",
+    "errors": {
+      "loadFailed": "Error al cargar entradas del libro mayor"
+    }
+  },
+
+  "governance": {
+    "title": "Gobernanza",
+    "proposals": "Propuestas",
+    "voting": "Votacion",
+    "domains": "Dominios",
+    "noProposals": "Sin propuestas activas"
+  },
+
+  "compute": {
+    "title": "Tareas de Computo",
+    "filter": {
+      "all": "Todas las Tareas",
+      "queued": "En Cola",
+      "running": "En Ejecucion",
+      "completed": "Completadas",
+      "failed": "Fallidas"
+    },
+    "columns": {
+      "taskId": "ID de Tarea",
+      "status": "Estado",
+      "submitted": "Enviada",
+      "duration": "Duracion"
+    },
+    "noTasks": "Sin tareas de computo"
+  },
+
+  "federation": {
+    "title": "Federacion",
+    "networks": "Redes Federadas",
+    "noNetworks": "Sin redes federadas"
+  },
+
+  "metrics": {
+    "title": "Metricas del Sistema",
+    "noMetrics": "Sin metricas disponibles"
+  },
+
+  "logs": {
+    "title": "Registros del Sistema",
+    "level": {
+      "all": "Todos los Niveles",
+      "error": "Error",
+      "warn": "Advertencia",
+      "info": "Informacion",
+      "debug": "Depuracion"
+    },
+    "noLogs": "Sin entradas de registro"
+  },
+
+  "settings": {
+    "title": "Configuracion",
+    "gateway": {
+      "title": "Configuracion del Gateway",
+      "apiEndpoint": "Punto de Acceso API del Gateway",
+      "wsEndpoint": "Punto de Acceso WebSocket",
+      "refreshInterval": "Intervalo de Actualizacion (segundos)"
+    },
+    "appearance": {
+      "title": "Apariencia",
+      "theme": "Tema",
+      "darkMode": "Modo Oscuro",
+      "lightMode": "Modo Claro"
+    },
+    "save": "Guardar Configuracion",
+    "reset": "Restablecer Valores Predeterminados"
+  },
+
+  "errors": {
+    "connectionFailed": "Error al conectar con el nodo",
+    "fetchFailed": "Error al obtener datos",
+    "saveFailed": "Error al guardar cambios",
+    "unknownError": "Ocurrio un error desconocido"
+  },
+
+  "accessibility": {
+    "skipToContent": "Saltar al contenido principal",
+    "toggleTheme": "Alternar modo oscuro/claro",
+    "openMenu": "Abrir menu de navegacion",
+    "closeMenu": "Cerrar menu de navegacion"
+  }
+}


### PR DESCRIPTION
## Summary

- Add Spanish (es) locale files for all platforms as the first non-English translation
- CLI, Gateway, React Native, and Web UI now support Spanish

## Changes

| Platform | File |
|----------|------|
| CLI | `icn/bins/icnctl/locales/es.yaml` |
| Gateway | `icn/crates/icn-gateway/locales/es.yaml` |
| React Native | `sdk/react-native/examples/CoopWallet/src/i18n/locales/es.json` |
| Web UI | `web/pilot-ui/locales/es.json` |

## Motivation

Spanish is a natural first addition given the cooperative movement's strong presence in Spanish-speaking communities. Cooperative organizations in Latin America and Spain are key stakeholders in the ICN ecosystem.

## Translation Coverage

All keys from the English locale files have been translated:
- CLI: 293 lines of YAML
- Gateway: 61 lines of YAML
- React Native: 248 lines of JSON
- Web UI: 197 lines of JSON

## Notes

- Translation keys match English structure exactly
- Uses consistent terminology based on docs/glossary.md
- Variables preserved in proper format (`{var}` for YAML, `{{var}}` for JSON)

## Test Plan

- [ ] Verify YAML files are valid syntax
- [ ] Verify JSON files are valid syntax
- [ ] Spot-check key translations against glossary

Closes #637

---

🤖 Generated with [Claude Code](https://claude.ai/code)