### PR TITLE
feat(store): BFT Hardening Phase 2 - Proof-of-Storage Enhancements

### DIFF
--- a/icn/crates/icn-ccl/src/fuel_estimator.rs
+++ b/icn/crates/icn-ccl/src/fuel_estimator.rs
@@ -136,8 +136,7 @@ impl<'a> FuelEstimator<'a> {
                 base.then(iter_estimate)
                     .then(loop_estimate)
                     .with_warning(format!(
-                        "Loop estimation assumes max {} iterations",
-                        MAX_LOOP_ITERATIONS
+                        "Loop estimation assumes max {MAX_LOOP_ITERATIONS} iterations"
                     ))
             }
 
@@ -147,6 +146,8 @@ impl<'a> FuelEstimator<'a> {
         }
     }
 
+    // &self is intentionally used only for recursive calls to maintain API consistency
+    #[allow(clippy::only_used_in_recursion)]
     fn estimate_expr(&self, expr: &Expr) -> FuelEstimate {
         // Base cost for any expression
         let base = FuelEstimate::new(FUEL_EXPR, FUEL_EXPR, FUEL_EXPR);

--- a/icn/crates/icn-core/src/replication/manager.rs
+++ b/icn/crates/icn-core/src/replication/manager.rs
@@ -147,6 +147,7 @@ impl ReplicationManager {
         let mut healthy_replicas = 0;
         let mut stale_replicas = 0;
         let mut unreachable_replicas = 0;
+        let mut unhealthy_replicas = 0;
 
         for hash in &content_hashes {
             match self.check_content_replication(hash).await {
@@ -169,6 +170,7 @@ impl ReplicationManager {
                         ReplicaHealth::Healthy => healthy_replicas += 1,
                         ReplicaHealth::Stale => stale_replicas += 1,
                         ReplicaHealth::Unreachable => unreachable_replicas += 1,
+                        ReplicaHealth::Unhealthy(_) => unhealthy_replicas += 1,
                     }
                 }
             }
@@ -182,6 +184,7 @@ impl ReplicationManager {
         icn_obs::metrics::replication::replicas_healthy_set(healthy_replicas);
         icn_obs::metrics::replication::replicas_stale_set(stale_replicas);
         icn_obs::metrics::replication::replicas_unreachable_set(unreachable_replicas);
+        icn_obs::metrics::replication::replicas_unhealthy_set(unhealthy_replicas);
         icn_obs::metrics::replication::health_checks_inc();
         icn_obs::metrics::replication::health_check_duration_record(start.elapsed().as_secs_f64());
 

--- a/icn/crates/icn-core/src/storage_challenge.rs
+++ b/icn/crates/icn-core/src/storage_challenge.rs
@@ -43,6 +43,13 @@ use icn_security::{MisbehaviorDetector, StorageFailureReason, Violation};
 use icn_store::{ChallengeConfig, ContentChunkTree, ContentHash, StorageChallenge, Store};
 use icn_trust::TrustGraph;
 
+/// Callback function type for triggering re-replication
+///
+/// Called when a replica fails too many storage challenges and should be replaced.
+/// Arguments: (content_hash, unhealthy_peer_did, failure_count)
+pub type ReReplicationCallback =
+    Arc<dyn Fn(ContentHash, String, u32) -> anyhow::Result<()> + Send + Sync>;
+
 /// Pending challenge tracking info
 #[derive(Debug)]
 struct PendingChallenge {
@@ -94,6 +101,9 @@ pub struct ChallengeScheduler {
 
     /// Per-replica failure tracking: (content_hash, peer_did) -> (count, last_updated)
     failure_counts: HashMap<(ContentHash, String), (u32, Instant)>,
+
+    /// Optional callback for triggering re-replication when a replica becomes unhealthy
+    re_replication_callback: Option<ReReplicationCallback>,
 }
 
 /// Maximum age for failure count entries before cleanup (24 hours)
@@ -120,7 +130,16 @@ impl ChallengeScheduler {
             misbehavior,
             pending: HashMap::new(),
             failure_counts: HashMap::new(),
+            re_replication_callback: None,
         }
+    }
+
+    /// Set the re-replication callback
+    ///
+    /// This callback is invoked when a replica fails too many storage challenges
+    /// and should be replaced with a new replica to maintain data availability.
+    pub fn set_re_replication_callback(&mut self, callback: ReReplicationCallback) {
+        self.re_replication_callback = Some(callback);
     }
 
     /// Spawn the scheduler as a background task
@@ -641,6 +660,36 @@ impl ChallengeScheduler {
                     pending.challenge.target_peer,
                     hex::encode(pending.challenge.content_hash)
                 );
+            }
+
+            // Mark replica as unhealthy in metadata
+            if let Ok(Some(mut metadata)) = self
+                .store
+                .get_replica_metadata(&pending.challenge.content_hash)
+            {
+                metadata.mark_replica_unhealthy(&pending.challenge.target_peer, count);
+                let _ = self.store.put_replica_metadata(&metadata);
+
+                // Trigger re-replication callback if configured
+                if let Some(ref callback) = self.re_replication_callback {
+                    if let Err(e) = callback(
+                        pending.challenge.content_hash,
+                        pending.challenge.target_peer.clone(),
+                        count,
+                    ) {
+                        warn!(
+                            "Re-replication callback failed for content {}: {}",
+                            hex::encode(pending.challenge.content_hash),
+                            e
+                        );
+                    } else {
+                        info!(
+                            "Triggered re-replication for content {} (unhealthy replica: {})",
+                            hex::encode(pending.challenge.content_hash),
+                            pending.challenge.target_peer
+                        );
+                    }
+                }
             }
         }
 

--- a/icn/crates/icn-core/src/storage_challenge.rs
+++ b/icn/crates/icn-core/src/storage_challenge.rs
@@ -40,9 +40,7 @@ use tracing::{debug, info, warn};
 use icn_gossip::GossipActor;
 use icn_identity::{Did, KeyPair};
 use icn_security::{MisbehaviorDetector, StorageFailureReason, Violation};
-use icn_store::{
-    ChallengeConfig, ContentChunkTree, ContentHash, MerkleProof, StorageChallenge, Store,
-};
+use icn_store::{ChallengeConfig, ContentChunkTree, ContentHash, StorageChallenge, Store};
 use icn_trust::TrustGraph;
 
 /// Pending challenge tracking info
@@ -317,12 +315,25 @@ impl ChallengeScheduler {
             .byte_sample_size
             .min((content_size - byte_offset) as u32);
 
-        // Random chunk index (using gen_range to avoid modulo bias)
+        // Generate random chunk indices (v2 multi-block challenges)
         let num_chunks = tree.num_chunks();
-        let chunk_index = if num_chunks > 0 {
-            rand::thread_rng().gen_range(0..num_chunks)
+        let blocks_to_challenge = self.config.blocks_per_challenge.min(num_chunks);
+        let chunk_indices: Vec<u32> = if num_chunks > 0 && blocks_to_challenge > 0 {
+            // Use reservoir sampling to pick random unique indices
+            let mut rng = rand::thread_rng();
+            let mut indices: Vec<u32> = Vec::with_capacity(blocks_to_challenge as usize);
+            for _ in 0..blocks_to_challenge {
+                loop {
+                    let idx = rng.gen_range(0..num_chunks);
+                    if !indices.contains(&idx) {
+                        indices.push(idx);
+                        break;
+                    }
+                }
+            }
+            indices
         } else {
-            0
+            vec![0]
         };
 
         // Compute expected byte hash
@@ -336,13 +347,13 @@ impl ChallengeScheduler {
             .map(|(count, _)| *count)
             .unwrap_or(0);
 
-        // Create and sign the challenge
-        let mut challenge = StorageChallenge::new(
+        // Create and sign the challenge (v2 multi-block)
+        let mut challenge = StorageChallenge::new_multi_block(
             *content_hash,
             target_peer.to_string(),
             byte_offset,
             byte_length,
-            chunk_index,
+            chunk_indices,
             self.own_did.to_string(),
             self.config.timeout_secs,
         );
@@ -514,24 +525,39 @@ impl ChallengeScheduler {
                 .await;
         }
 
-        // Verify Merkle proof
-        let merkle_proof = MerkleProof {
-            chunk_index: pending.challenge.chunk_index,
-            chunk_hash: proof.chunk_hash,
-            siblings: proof.merkle_siblings.clone(),
-            path_bits: proof.merkle_path_bits.clone(),
-            root: pending.expected_merkle_root,
-        };
-        let merkle_valid = merkle_proof.verify();
+        // Verify all Merkle proofs (v2: one per challenged chunk)
+        // All challenged chunk indices must have corresponding valid proofs
+        for expected_idx in &pending.challenge.chunk_indices {
+            // Find the proof for this chunk index
+            let proof_data = proof
+                .merkle_proofs
+                .iter()
+                .find(|p| p.chunk_index == *expected_idx);
 
-        if !merkle_valid {
-            warn!(
-                "Invalid Merkle proof for challenge {}",
-                hex::encode(&proof.challenge_id[..8])
-            );
-            return self
-                .record_failure(&pending, StorageFailureReason::InvalidMerkleProof)
-                .await;
+            match proof_data {
+                Some(p) => {
+                    if !p.verify_against_root(&pending.expected_merkle_root) {
+                        warn!(
+                            "Invalid Merkle proof for chunk {} in challenge {}",
+                            expected_idx,
+                            hex::encode(&proof.challenge_id[..8])
+                        );
+                        return self
+                            .record_failure(&pending, StorageFailureReason::InvalidMerkleProof)
+                            .await;
+                    }
+                }
+                None => {
+                    warn!(
+                        "Missing Merkle proof for chunk {} in challenge {}",
+                        expected_idx,
+                        hex::encode(&proof.challenge_id[..8])
+                    );
+                    return self
+                        .record_failure(&pending, StorageFailureReason::InvalidMerkleProof)
+                        .await;
+                }
+            }
         }
 
         // Success! Reset failure count

--- a/icn/crates/icn-core/src/storage_challenge.rs
+++ b/icn/crates/icn-core/src/storage_challenge.rs
@@ -59,7 +59,12 @@ struct PendingChallenge {
     /// The challenge that was sent
     challenge: StorageChallenge,
 
-    /// When the challenge was sent
+    /// When the challenge was sent (local monotonic clock)
+    ///
+    /// Note: Timeout detection uses `challenge.expires_at` (wall-clock) rather than
+    /// `sent_at.elapsed()` because wall-clock expiry is more robust across process
+    /// restarts and clock adjustments. This field is kept for debugging/logging.
+    #[allow(dead_code)]
     sent_at: Instant,
 
     /// Expected Merkle root (for verification)
@@ -669,17 +674,28 @@ impl ChallengeScheduler {
     }
 
     /// Process expired challenges and record violations
+    ///
+    /// Uses the challenge's absolute `expires_at` timestamp for timeout detection.
+    /// This is more robust than Instant-based timing because:
+    /// 1. It works correctly across process restarts (persisted challenges)
+    /// 2. It's immune to monotonic clock discontinuities
+    /// 3. It matches the challenge's documented expiry semantics
     async fn process_expired_challenges(&mut self) -> Result<()> {
-        let timeout = Duration::from_secs(self.config.timeout_secs);
-        let now = Instant::now();
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
 
-        // Find expired challenges
+        // Find expired challenges using absolute wall-clock expiry
         let expired: Vec<[u8; 32]> = self
             .pending
             .iter()
-            .filter(|(_, p)| now.duration_since(p.sent_at) > timeout)
+            .filter(|(_, p)| now_secs >= p.challenge.expires_at)
             .map(|(id, _)| *id)
             .collect();
+
+        // Use Instant for failure tracking (doesn't need to survive restarts)
+        let now = Instant::now();
 
         for challenge_id in expired {
             if let Some(pending) = self.pending.remove(&challenge_id) {

--- a/icn/crates/icn-core/src/storage_challenge.rs
+++ b/icn/crates/icn-core/src/storage_challenge.rs
@@ -531,22 +531,16 @@ impl ChallengeScheduler {
             .min((content_size - byte_offset) as u32);
 
         // Generate random chunk indices (v2 multi-block challenges)
+        // Uses rand::seq::index::sample for O(k) time complexity where k = blocks_to_challenge
         let num_chunks = tree.num_chunks();
         let blocks_to_challenge = self.config.blocks_per_challenge.min(num_chunks);
         let chunk_indices: Vec<u32> = if num_chunks > 0 && blocks_to_challenge > 0 {
-            // Use reservoir sampling to pick random unique indices
+            use rand::seq::index::sample;
             let mut rng = rand::thread_rng();
-            let mut indices: Vec<u32> = Vec::with_capacity(blocks_to_challenge as usize);
-            for _ in 0..blocks_to_challenge {
-                loop {
-                    let idx = rng.gen_range(0..num_chunks);
-                    if !indices.contains(&idx) {
-                        indices.push(idx);
-                        break;
-                    }
-                }
-            }
-            indices
+            sample(&mut rng, num_chunks as usize, blocks_to_challenge as usize)
+                .into_iter()
+                .map(|i| i as u32)
+                .collect()
         } else {
             vec![0]
         };

--- a/icn/crates/icn-core/src/storage_challenge.rs
+++ b/icn/crates/icn-core/src/storage_challenge.rs
@@ -74,13 +74,15 @@ struct PendingChallenge {
 }
 
 /// Persisted pending challenge (serializable version)
+///
+/// Note: We use the challenge's built-in `expires_at` timestamp (absolute Unix time)
+/// to determine expiration. The `sent_at` field is reconstructed on load using the
+/// challenge's timestamps, which avoids clock-drift issues that would occur if we
+/// tried to persist monotonic `Instant` values as wall-clock time.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct PersistedPendingChallenge {
-    /// The challenge that was sent
+    /// The challenge that was sent (contains expires_at for deadline)
     challenge: StorageChallenge,
-
-    /// When the challenge was sent (Unix timestamp seconds)
-    sent_at_secs: u64,
 
     /// Expected Merkle root (for verification)
     expected_merkle_root: [u8; 32],
@@ -94,18 +96,11 @@ struct PersistedPendingChallenge {
 
 impl From<&PendingChallenge> for PersistedPendingChallenge {
     fn from(p: &PendingChallenge) -> Self {
-        // Convert Instant to Unix timestamp
-        let now = std::time::SystemTime::now();
-        let elapsed = p.sent_at.elapsed();
-        let sent_at = now
-            .checked_sub(elapsed)
-            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
-
+        // The challenge itself contains created_at and expires_at as absolute Unix timestamps,
+        // so we don't need to persist sent_at separately. On reload, we compute sent_at
+        // from the challenge's timestamps to avoid clock-drift issues.
         Self {
             challenge: p.challenge.clone(),
-            sent_at_secs: sent_at,
             expected_merkle_root: p.expected_merkle_root,
             expected_byte_hash: p.expected_byte_hash,
             failure_count: p.failure_count,
@@ -115,24 +110,45 @@ impl From<&PendingChallenge> for PersistedPendingChallenge {
 
 impl PersistedPendingChallenge {
     /// Convert back to in-memory PendingChallenge
-    fn into_pending(self) -> PendingChallenge {
-        // Convert Unix timestamp back to Instant (approximate)
+    ///
+    /// Computes a synthetic `sent_at` using the challenge's absolute timestamps,
+    /// which is correct regardless of wall-clock changes between persist and load.
+    fn into_pending(self) -> Option<PendingChallenge> {
+        // Use the challenge's absolute timestamps to compute elapsed time
         let now_secs = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs())
             .unwrap_or(0);
-        let elapsed_secs = now_secs.saturating_sub(self.sent_at_secs);
+
+        // If challenge is already expired, return None
+        if now_secs >= self.challenge.expires_at {
+            return None;
+        }
+
+        // Compute original timeout from challenge timestamps
+        let original_timeout_secs = self
+            .challenge
+            .expires_at
+            .saturating_sub(self.challenge.created_at);
+
+        // Compute how much time has passed since challenge was created
+        let elapsed_secs = now_secs.saturating_sub(self.challenge.created_at);
+
+        // Cap elapsed to original timeout (handles clock adjustments gracefully)
+        let elapsed_secs = elapsed_secs.min(original_timeout_secs);
+
+        // Create synthetic sent_at: Instant::now() - elapsed
         let sent_at = Instant::now()
             .checked_sub(Duration::from_secs(elapsed_secs))
             .unwrap_or_else(Instant::now);
 
-        PendingChallenge {
+        Some(PendingChallenge {
             challenge: self.challenge,
             sent_at,
             expected_merkle_root: self.expected_merkle_root,
             expected_byte_hash: self.expected_byte_hash,
             failure_count: self.failure_count,
-        }
+        })
     }
 }
 
@@ -169,10 +185,18 @@ pub struct ChallengeScheduler {
 
     /// Optional callback for triggering re-replication when a replica becomes unhealthy
     re_replication_callback: Option<ReReplicationCallback>,
+
+    /// Cached trust scores: peer_did -> (score, last_updated)
+    /// Avoids expensive trust graph computations on every challenge decision.
+    trust_score_cache: HashMap<String, (f64, Instant)>,
 }
 
 /// Maximum age for failure count entries before cleanup (24 hours)
 const FAILURE_COUNT_MAX_AGE_SECS: u64 = 86400;
+
+/// Trust score cache TTL (5 minutes)
+/// Prevents expensive trust graph recomputation on every challenge decision.
+const TRUST_SCORE_CACHE_TTL_SECS: u64 = 300;
 
 impl ChallengeScheduler {
     /// Create a new ChallengeScheduler
@@ -196,6 +220,7 @@ impl ChallengeScheduler {
             pending: HashMap::new(),
             failure_counts: HashMap::new(),
             re_replication_callback: None,
+            trust_score_cache: HashMap::new(),
         }
     }
 
@@ -220,6 +245,7 @@ impl ChallengeScheduler {
                         hex::encode(&challenge_id[..8]),
                         e
                     );
+                    icn_obs::metrics::storage_challenge::persist_failures_inc("write");
                 }
             }
             Err(e) => {
@@ -228,6 +254,7 @@ impl ChallengeScheduler {
                     hex::encode(&challenge_id[..8]),
                     e
                 );
+                icn_obs::metrics::storage_challenge::persist_failures_inc("serialize");
             }
         }
     }
@@ -253,17 +280,32 @@ impl ChallengeScheduler {
     /// - Trust 0.0 (no trust): base_probability * 2.0
     ///
     /// Returns the adjusted probability, capped at 1.0.
-    async fn trust_adjusted_probability(&self, peer_did: &str) -> f64 {
+    async fn trust_adjusted_probability(&mut self, peer_did: &str) -> f64 {
         let base = self.config.challenge_probability;
 
-        // Try to get trust score for the peer
-        let trust_score = if let Ok(did) = Did::from_str(peer_did) {
-            let trust_graph = self.trust_graph.read().await;
-            // Compute trust score for this peer
-            trust_graph.compute_trust_score(&did).unwrap_or(0.0)
-        } else {
-            0.0 // Unknown peer, treat as untrusted
-        };
+        // Check cache first (TTL-based caching to avoid expensive trust computations)
+        let now = Instant::now();
+        let cache_ttl = Duration::from_secs(TRUST_SCORE_CACHE_TTL_SECS);
+
+        let trust_score =
+            if let Some((cached_score, cached_at)) = self.trust_score_cache.get(peer_did) {
+                if now.duration_since(*cached_at) < cache_ttl {
+                    // Cache hit - use cached score
+                    *cached_score
+                } else {
+                    // Cache expired - recompute
+                    let score = self.compute_trust_score(peer_did).await;
+                    self.trust_score_cache
+                        .insert(peer_did.to_string(), (score, now));
+                    score
+                }
+            } else {
+                // Cache miss - compute and cache
+                let score = self.compute_trust_score(peer_did).await;
+                self.trust_score_cache
+                    .insert(peer_did.to_string(), (score, now));
+                score
+            };
 
         // Scale probability: lower trust = higher probability
         // Formula: base * (1 + (1 - trust_score))
@@ -275,6 +317,16 @@ impl ChallengeScheduler {
 
         // Cap at 1.0 to ensure valid probability
         adjusted.min(1.0)
+    }
+
+    /// Compute trust score for a peer (expensive operation - use caching)
+    async fn compute_trust_score(&self, peer_did: &str) -> f64 {
+        if let Ok(did) = Did::from_str(peer_did) {
+            let trust_graph = self.trust_graph.read().await;
+            trust_graph.compute_trust_score(&did).unwrap_or(0.0)
+        } else {
+            0.0 // Unknown peer, treat as untrusted
+        }
     }
 
     /// Load all persisted pending challenges from the store
@@ -297,19 +349,21 @@ impl ChallengeScheduler {
 
             match serde_json::from_slice::<PersistedPendingChallenge>(&value) {
                 Ok(persisted) => {
-                    // Skip if challenge has already expired
-                    if persisted.challenge.is_expired() {
-                        debug!(
-                            "Removing expired persisted challenge {}",
-                            hex::encode(&challenge_id[..8])
-                        );
-                        self.remove_persisted_challenge(&challenge_id);
-                        continue;
+                    // Convert to in-memory format (returns None if expired)
+                    match persisted.into_pending() {
+                        Some(pending) => {
+                            self.pending.insert(challenge_id, pending);
+                            loaded += 1;
+                        }
+                        None => {
+                            // Challenge expired during downtime
+                            debug!(
+                                "Removing expired persisted challenge {}",
+                                hex::encode(&challenge_id[..8])
+                            );
+                            self.remove_persisted_challenge(&challenge_id);
+                        }
                     }
-
-                    let pending = persisted.into_pending();
-                    self.pending.insert(challenge_id, pending);
-                    loaded += 1;
                 }
                 Err(e) => {
                     warn!(
@@ -533,16 +587,23 @@ impl ChallengeScheduler {
         // Generate random chunk indices (v2 multi-block challenges)
         // Uses rand::seq::index::sample for O(k) time complexity where k = blocks_to_challenge
         let num_chunks = tree.num_chunks();
+        if num_chunks == 0 {
+            // Edge case: empty or invalid content tree - cannot challenge
+            debug!(
+                "Cannot challenge {} - content has no chunks",
+                hex::encode(content_hash)
+            );
+            return Ok(());
+        }
+
         let blocks_to_challenge = self.config.blocks_per_challenge.min(num_chunks);
-        let chunk_indices: Vec<u32> = if num_chunks > 0 && blocks_to_challenge > 0 {
+        let chunk_indices: Vec<u32> = {
             use rand::seq::index::sample;
             let mut rng = rand::thread_rng();
             sample(&mut rng, num_chunks as usize, blocks_to_challenge as usize)
                 .into_iter()
                 .map(|i| i as u32)
                 .collect()
-        } else {
-            vec![0]
         };
 
         // Compute expected byte hash
@@ -684,6 +745,15 @@ impl ChallengeScheduler {
 
     /// Handle a received storage proof (called from gossip handler)
     pub async fn handle_proof(&mut self, proof: icn_store::StorageProof) -> Result<()> {
+        // Validate proof protocol version (reject unsupported versions early)
+        if let Err(e) = proof.validate_version() {
+            warn!(
+                "Rejecting proof with unsupported version {}: {}",
+                proof.version, e
+            );
+            return Err(e);
+        }
+
         // Find the pending challenge
         let pending = match self.pending.remove(&proof.challenge_id) {
             Some(p) => {

--- a/icn/crates/icn-core/src/storage_challenge.rs
+++ b/icn/crates/icn-core/src/storage_challenge.rs
@@ -153,7 +153,6 @@ pub struct ChallengeScheduler {
     store: Arc<dyn Store>,
 
     /// Trust graph for peer scoring (used for trust-gated challenge frequency)
-    #[allow(dead_code)] // Reserved for trust-gated challenge frequency
     trust_graph: Arc<RwLock<TrustGraph>>,
 
     /// Gossip actor for sending challenges
@@ -243,6 +242,39 @@ impl ChallengeScheduler {
                 e
             );
         }
+    }
+
+    /// Calculate trust-adjusted challenge probability for a peer
+    ///
+    /// Lower trust peers are challenged more frequently. The formula scales
+    /// the base probability by the inverse of the trust score:
+    /// - Trust 1.0 (fully trusted): base_probability (no increase)
+    /// - Trust 0.5: base_probability * 1.5
+    /// - Trust 0.0 (no trust): base_probability * 2.0
+    ///
+    /// Returns the adjusted probability, capped at 1.0.
+    async fn trust_adjusted_probability(&self, peer_did: &str) -> f64 {
+        let base = self.config.challenge_probability;
+
+        // Try to get trust score for the peer
+        let trust_score = if let Ok(did) = Did::from_str(peer_did) {
+            let trust_graph = self.trust_graph.read().await;
+            // Compute trust score for this peer
+            trust_graph.compute_trust_score(&did).unwrap_or(0.0)
+        } else {
+            0.0 // Unknown peer, treat as untrusted
+        };
+
+        // Scale probability: lower trust = higher probability
+        // Formula: base * (1 + (1 - trust_score))
+        // - Trust 1.0 -> multiplier 1.0
+        // - Trust 0.5 -> multiplier 1.5
+        // - Trust 0.0 -> multiplier 2.0
+        let multiplier = 1.0 + (1.0 - trust_score.clamp(0.0, 1.0));
+        let adjusted = base * multiplier;
+
+        // Cap at 1.0 to ensure valid probability
+        adjusted.min(1.0)
     }
 
     /// Load all persisted pending challenges from the store
@@ -420,9 +452,11 @@ impl ChallengeScheduler {
                     continue;
                 }
 
-                // Probabilistic challenge
+                // Probabilistic challenge with trust-adjusted frequency
+                // Lower trust peers are challenged more frequently
+                let adjusted_probability = self.trust_adjusted_probability(&replica.peer_did).await;
                 let roll: f64 = rand::random();
-                if roll > self.config.challenge_probability {
+                if roll > adjusted_probability {
                     continue;
                 }
 

--- a/icn/crates/icn-core/src/storage_challenge.rs
+++ b/icn/crates/icn-core/src/storage_challenge.rs
@@ -50,7 +50,10 @@ use icn_trust::TrustGraph;
 pub type ReReplicationCallback =
     Arc<dyn Fn(ContentHash, String, u32) -> anyhow::Result<()> + Send + Sync>;
 
-/// Pending challenge tracking info
+/// Key prefix for persisted pending challenges
+const PENDING_CHALLENGE_PREFIX: &[u8] = b"challenge:pending:";
+
+/// Pending challenge tracking info (in-memory)
 #[derive(Debug)]
 struct PendingChallenge {
     /// The challenge that was sent
@@ -68,6 +71,69 @@ struct PendingChallenge {
     /// Number of previous failures for this replica
     #[allow(dead_code)] // May be used for per-challenge tracking
     failure_count: u32,
+}
+
+/// Persisted pending challenge (serializable version)
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct PersistedPendingChallenge {
+    /// The challenge that was sent
+    challenge: StorageChallenge,
+
+    /// When the challenge was sent (Unix timestamp seconds)
+    sent_at_secs: u64,
+
+    /// Expected Merkle root (for verification)
+    expected_merkle_root: [u8; 32],
+
+    /// Expected byte hash (for verification)
+    expected_byte_hash: [u8; 32],
+
+    /// Number of previous failures for this replica
+    failure_count: u32,
+}
+
+impl From<&PendingChallenge> for PersistedPendingChallenge {
+    fn from(p: &PendingChallenge) -> Self {
+        // Convert Instant to Unix timestamp
+        let now = std::time::SystemTime::now();
+        let elapsed = p.sent_at.elapsed();
+        let sent_at = now
+            .checked_sub(elapsed)
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        Self {
+            challenge: p.challenge.clone(),
+            sent_at_secs: sent_at,
+            expected_merkle_root: p.expected_merkle_root,
+            expected_byte_hash: p.expected_byte_hash,
+            failure_count: p.failure_count,
+        }
+    }
+}
+
+impl PersistedPendingChallenge {
+    /// Convert back to in-memory PendingChallenge
+    fn into_pending(self) -> PendingChallenge {
+        // Convert Unix timestamp back to Instant (approximate)
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let elapsed_secs = now_secs.saturating_sub(self.sent_at_secs);
+        let sent_at = Instant::now()
+            .checked_sub(Duration::from_secs(elapsed_secs))
+            .unwrap_or_else(Instant::now);
+
+        PendingChallenge {
+            challenge: self.challenge,
+            sent_at,
+            expected_merkle_root: self.expected_merkle_root,
+            expected_byte_hash: self.expected_byte_hash,
+            failure_count: self.failure_count,
+        }
+    }
 }
 
 /// Storage Challenge Scheduler
@@ -142,6 +208,96 @@ impl ChallengeScheduler {
         self.re_replication_callback = Some(callback);
     }
 
+    /// Persist a pending challenge to the store
+    fn persist_pending_challenge(&self, challenge_id: &[u8; 32], pending: &PendingChallenge) {
+        let key = [PENDING_CHALLENGE_PREFIX, challenge_id.as_slice()].concat();
+        let persisted = PersistedPendingChallenge::from(pending);
+
+        match serde_json::to_vec(&persisted) {
+            Ok(value) => {
+                if let Err(e) = self.store.put(&key, &value) {
+                    warn!(
+                        "Failed to persist pending challenge {}: {}",
+                        hex::encode(&challenge_id[..8]),
+                        e
+                    );
+                }
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to serialize pending challenge {}: {}",
+                    hex::encode(&challenge_id[..8]),
+                    e
+                );
+            }
+        }
+    }
+
+    /// Remove a persisted pending challenge from the store
+    fn remove_persisted_challenge(&self, challenge_id: &[u8; 32]) {
+        let key = [PENDING_CHALLENGE_PREFIX, challenge_id.as_slice()].concat();
+        if let Err(e) = self.store.delete(&key) {
+            debug!(
+                "Failed to remove persisted challenge {}: {}",
+                hex::encode(&challenge_id[..8]),
+                e
+            );
+        }
+    }
+
+    /// Load all persisted pending challenges from the store
+    ///
+    /// Called on scheduler startup to restore in-flight challenges.
+    pub fn load_pending_challenges(&mut self) -> Result<usize> {
+        let entries = self.store.scan(PENDING_CHALLENGE_PREFIX)?;
+        let mut loaded = 0;
+
+        for (key, value) in entries {
+            // Extract challenge ID from key
+            if key.len() != PENDING_CHALLENGE_PREFIX.len() + 32 {
+                debug!("Skipping malformed pending challenge key");
+                continue;
+            }
+
+            let challenge_id: [u8; 32] = key[PENDING_CHALLENGE_PREFIX.len()..]
+                .try_into()
+                .unwrap_or([0u8; 32]);
+
+            match serde_json::from_slice::<PersistedPendingChallenge>(&value) {
+                Ok(persisted) => {
+                    // Skip if challenge has already expired
+                    if persisted.challenge.is_expired() {
+                        debug!(
+                            "Removing expired persisted challenge {}",
+                            hex::encode(&challenge_id[..8])
+                        );
+                        self.remove_persisted_challenge(&challenge_id);
+                        continue;
+                    }
+
+                    let pending = persisted.into_pending();
+                    self.pending.insert(challenge_id, pending);
+                    loaded += 1;
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to deserialize pending challenge {}: {}",
+                        hex::encode(&challenge_id[..8]),
+                        e
+                    );
+                    // Remove corrupted entry
+                    self.remove_persisted_challenge(&challenge_id);
+                }
+            }
+        }
+
+        if loaded > 0 {
+            info!("Loaded {} pending challenges from storage", loaded);
+        }
+
+        Ok(loaded)
+    }
+
     /// Spawn the scheduler as a background task
     pub fn spawn(
         own_did: Did,
@@ -153,7 +309,7 @@ impl ChallengeScheduler {
         misbehavior: Arc<RwLock<MisbehaviorDetector>>,
         mut shutdown_rx: tokio::sync::broadcast::Receiver<()>,
     ) -> ChallengeSchedulerHandle {
-        let scheduler = Self::new(
+        let mut scheduler = Self::new(
             own_did,
             keypair,
             config.clone(),
@@ -162,6 +318,12 @@ impl ChallengeScheduler {
             gossip,
             misbehavior,
         );
+
+        // Load any persisted pending challenges from previous run
+        if let Err(e) = scheduler.load_pending_challenges() {
+            warn!("Failed to load pending challenges: {}", e);
+        }
+
         let handle = Arc::new(RwLock::new(scheduler));
 
         let handle_clone = handle.clone();
@@ -389,7 +551,13 @@ impl ChallengeScheduler {
             failure_count,
         };
 
-        self.pending.insert(challenge.id, pending);
+        let challenge_id = challenge.id;
+        self.pending.insert(challenge_id, pending);
+
+        // Persist challenge for crash recovery
+        if let Some(p) = self.pending.get(&challenge_id) {
+            self.persist_pending_challenge(&challenge_id, p);
+        }
 
         // Send via gossip
         let target_did = Did::from_str(target_peer)?;
@@ -426,6 +594,9 @@ impl ChallengeScheduler {
 
         for challenge_id in expired {
             if let Some(pending) = self.pending.remove(&challenge_id) {
+                // Remove persisted challenge
+                self.remove_persisted_challenge(&challenge_id);
+
                 let key = (
                     pending.challenge.content_hash,
                     pending.challenge.target_peer.clone(),
@@ -487,7 +658,11 @@ impl ChallengeScheduler {
     pub async fn handle_proof(&mut self, proof: icn_store::StorageProof) -> Result<()> {
         // Find the pending challenge
         let pending = match self.pending.remove(&proof.challenge_id) {
-            Some(p) => p,
+            Some(p) => {
+                // Remove persisted challenge
+                self.remove_persisted_challenge(&proof.challenge_id);
+                p
+            }
             None => {
                 debug!(
                     "Received proof for unknown challenge {}",

--- a/icn/crates/icn-core/tests/storage_challenge_integration.rs
+++ b/icn/crates/icn-core/tests/storage_challenge_integration.rs
@@ -144,8 +144,8 @@ async fn test_challenge_creation_multi_block() -> Result<()> {
     let challenge = StorageChallenge::new_multi_block(
         hash,
         peer_did.to_string(),
-        0,     // byte_offset
-        1024,  // byte_length
+        0,    // byte_offset
+        1024, // byte_length
         chunk_indices,
         node.did.to_string(),
         30, // timeout_secs
@@ -189,9 +189,7 @@ async fn test_proof_generation_multi_block() -> Result<()> {
     );
 
     // Extract just the challenged byte range for the proof
-    let challenged_bytes = tree
-        .get_bytes(byte_offset, byte_length)
-        .unwrap_or_default();
+    let challenged_bytes = tree.get_bytes(byte_offset, byte_length).unwrap_or_default();
 
     // Generate proof with correct byte range
     let proof = StorageProof::new_multi(
@@ -335,7 +333,7 @@ async fn test_merkle_proof_data_round_trip() -> Result<()> {
 async fn test_challenge_scheduler_handle_pending_count() -> Result<()> {
     // Test that pending count is tracked correctly
     let config = ChallengeConfig {
-        timeout_secs: 60, // Long timeout so challenges stay pending
+        timeout_secs: 60,           // Long timeout so challenges stay pending
         challenge_probability: 0.0, // Disable automatic challenges
         ..Default::default()
     };

--- a/icn/crates/icn-core/tests/storage_challenge_integration.rs
+++ b/icn/crates/icn-core/tests/storage_challenge_integration.rs
@@ -1,0 +1,626 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! Integration tests for Proof-of-Storage challenge-response protocol
+//!
+//! Tests the storage challenge flow:
+//! - Challenge creation and multi-block selection
+//! - Proof generation and verification
+//! - Timeout handling and misbehavior recording
+//! - Re-replication triggers on failure
+
+use anyhow::Result;
+use icn_core::storage_challenge::{ChallengeScheduler, ChallengeSchedulerHandle};
+use icn_gossip::GossipActor;
+use icn_identity::{Did, KeyPair};
+use icn_security::{MisbehaviorDetector, MisbehaviorThresholds, StorageFailureReason, Violation};
+use icn_store::pos::{ChallengeConfig, ContentChunkTree, StorageChallenge, StorageProof};
+use icn_store::{ReplicaHealth, SledStore, Store};
+use icn_trust::TrustGraph;
+use sha2::{Digest, Sha256};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Test helper to create a node with storage challenge scheduler
+struct TestNode {
+    did: Did,
+    #[allow(dead_code)]
+    keypair: Arc<KeyPair>,
+    #[allow(dead_code)]
+    gossip_handle: Arc<RwLock<GossipActor>>,
+    #[allow(dead_code)]
+    trust_graph_handle: Arc<RwLock<TrustGraph>>,
+    misbehavior_handle: Arc<RwLock<MisbehaviorDetector>>,
+    store: Arc<dyn Store>,
+    challenge_handle: ChallengeSchedulerHandle,
+    _shutdown_tx: tokio::sync::broadcast::Sender<()>,
+}
+
+impl TestNode {
+    async fn new(config: ChallengeConfig) -> Result<Self> {
+        let keypair = KeyPair::generate()?;
+        let did = keypair.did().clone();
+        let keypair = Arc::new(keypair);
+
+        // Create stores
+        let store: Arc<dyn Store> = Arc::new(SledStore::temporary()?);
+        let trust_store: Arc<dyn Store> = Arc::new(SledStore::temporary()?);
+
+        // Create trust graph
+        let trust_graph = TrustGraph::new(trust_store, did.clone());
+        let trust_graph_handle = Arc::new(RwLock::new(trust_graph));
+
+        // Create misbehavior detector
+        let misbehavior = MisbehaviorDetector::new(MisbehaviorThresholds::default());
+        let misbehavior_handle = Arc::new(RwLock::new(misbehavior));
+
+        // Create gossip actor
+        let trust_lookup = Arc::new(|_: &Did| None);
+        let gossip_handle = GossipActor::spawn(did.clone(), trust_lookup);
+
+        // Set gossip store
+        {
+            let mut gossip = gossip_handle.write().await;
+            gossip.set_store(store.clone());
+        }
+
+        // Create shutdown channel
+        let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel(1);
+
+        // Spawn challenge scheduler
+        let challenge_handle = ChallengeScheduler::spawn(
+            did.clone(),
+            keypair.clone(),
+            config,
+            store.clone(),
+            trust_graph_handle.clone(),
+            gossip_handle.clone(),
+            misbehavior_handle.clone(),
+            shutdown_rx,
+        );
+
+        Ok(Self {
+            did,
+            keypair,
+            gossip_handle,
+            trust_graph_handle,
+            misbehavior_handle,
+            store,
+            challenge_handle,
+            _shutdown_tx: shutdown_tx,
+        })
+    }
+
+    /// Store content and create a chunk tree for it
+    fn store_content(&self, data: &[u8]) -> Result<([u8; 32], ContentChunkTree)> {
+        // Store the raw content
+        let mut hasher = Sha256::new();
+        hasher.update(data);
+        let hash: [u8; 32] = hasher.finalize().into();
+        self.store.put(&hash, data)?;
+
+        // Create chunk tree
+        let tree = ContentChunkTree::new(data.to_vec(), 1024); // 1KB chunks
+
+        Ok((hash, tree))
+    }
+
+    /// Check if a violation was recorded for a peer
+    async fn has_violation_for(&self, peer_did: &Did) -> bool {
+        let misbehavior = self.misbehavior_handle.read().await;
+        !misbehavior.get_violations(peer_did).is_empty()
+    }
+
+    /// Get all violations for a peer
+    async fn get_violations_for(&self, peer_did: &Did) -> Vec<Violation> {
+        let misbehavior = self.misbehavior_handle.read().await;
+        misbehavior
+            .get_violations(peer_did)
+            .iter()
+            .map(|r| r.violation.clone())
+            .collect()
+    }
+}
+
+#[tokio::test]
+async fn test_challenge_creation_multi_block() -> Result<()> {
+    // Test that challenges are created with multiple block indices
+    let config = ChallengeConfig {
+        blocks_per_challenge: 3,
+        ..Default::default()
+    };
+
+    let node = TestNode::new(config).await?;
+
+    // Store content large enough for multiple chunks
+    let data = vec![0u8; 5000]; // ~5 chunks at 1KB each
+    let (hash, tree) = node.store_content(&data)?;
+
+    // Create a challenge
+    let peer_did = KeyPair::generate()?.did().clone();
+
+    // Select 3 random chunk indices
+    let chunk_indices: Vec<u32> = (0..3).map(|i| i % tree.num_chunks()).collect();
+
+    let challenge = StorageChallenge::new_multi_block(
+        hash,
+        peer_did.to_string(),
+        0,     // byte_offset
+        1024,  // byte_length
+        chunk_indices,
+        node.did.to_string(),
+        30, // timeout_secs
+    );
+
+    // Verify multi-block challenge properties
+    assert_eq!(challenge.chunk_indices.len(), 3);
+    assert_eq!(challenge.challenge_nonce.len(), 32); // CSPRNG nonce
+    assert!(challenge
+        .chunk_indices
+        .iter()
+        .all(|&i| i < tree.num_chunks()));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_proof_generation_multi_block() -> Result<()> {
+    // Test that proofs are generated for all requested block indices
+    let config = ChallengeConfig::default();
+    let node = TestNode::new(config).await?;
+
+    // Store content
+    let data = vec![42u8; 5000];
+    let (hash, tree) = node.store_content(&data)?;
+
+    // Select chunk indices
+    let chunk_indices: Vec<u32> = (0..3).map(|i| i % tree.num_chunks()).collect();
+
+    // Create a challenge for 3 blocks
+    let challenge = StorageChallenge::new_multi_block(
+        hash,
+        "did:icn:peer".to_string(),
+        0,
+        1024,
+        chunk_indices.clone(),
+        node.did.to_string(),
+        30,
+    );
+
+    // Generate proof
+    let proof = StorageProof::new_multi(
+        challenge.id,
+        data.clone(),
+        challenge
+            .chunk_indices
+            .iter()
+            .map(|&idx| {
+                let merkle_proof = tree.generate_proof(idx).unwrap();
+                icn_store::pos::MerkleProofData::from(merkle_proof)
+            })
+            .collect(),
+        node.did.to_string(),
+    );
+
+    // Verify proof has correct number of proofs
+    assert_eq!(proof.merkle_proofs.len(), challenge.chunk_indices.len());
+
+    // Verify each merkle proof
+    for (i, merkle_proof) in proof.merkle_proofs.iter().enumerate() {
+        assert_eq!(merkle_proof.chunk_index, challenge.chunk_indices[i]);
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_valid_proof_verification() -> Result<()> {
+    // Test that valid proofs pass verification
+    let config = ChallengeConfig::default();
+    let node = TestNode::new(config).await?;
+
+    // Store content
+    let data = b"Hello, storage challenge!".to_vec();
+    let (hash, tree) = node.store_content(&data)?;
+
+    // Create challenge
+    let challenge = StorageChallenge::new_multi_block(
+        hash,
+        "did:icn:peer".to_string(),
+        0,
+        data.len() as u32,
+        vec![0], // Single block for simplicity
+        node.did.to_string(),
+        30,
+    );
+
+    // Generate valid proof
+    let proof = StorageProof::new_multi(
+        challenge.id,
+        data.clone(),
+        vec![icn_store::pos::MerkleProofData::from(
+            tree.generate_proof(challenge.chunk_indices[0]).unwrap(),
+        )],
+        node.did.to_string(),
+    );
+
+    // Verify proof has correct byte_data
+    assert_eq!(proof.byte_data, data);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_invalid_proof_detection() -> Result<()> {
+    // Test that invalid proofs are detected
+    let config = ChallengeConfig::default();
+    let node = TestNode::new(config).await?;
+
+    // Store content
+    let data = b"Original content".to_vec();
+    let (hash, _tree) = node.store_content(&data)?;
+
+    // Create challenge
+    let challenge = StorageChallenge::new_multi_block(
+        hash,
+        "did:icn:peer".to_string(),
+        0,
+        data.len() as u32,
+        vec![0],
+        node.did.to_string(),
+        30,
+    );
+
+    // Generate proof with WRONG data
+    let wrong_data = b"Tampered content!".to_vec();
+    let wrong_tree = ContentChunkTree::new(wrong_data.clone(), 1024);
+    let proof = StorageProof::new_multi(
+        challenge.id,
+        wrong_data.clone(),
+        vec![icn_store::pos::MerkleProofData::from(
+            wrong_tree.generate_proof(0).unwrap(),
+        )],
+        node.did.to_string(),
+    );
+
+    // The proof should have wrong byte_data
+    assert_ne!(proof.byte_data, data);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_challenge_config_blocks_per_challenge() -> Result<()> {
+    // Test that blocks_per_challenge config is respected
+    let config = ChallengeConfig {
+        blocks_per_challenge: 5,
+        ..Default::default()
+    };
+
+    assert_eq!(config.blocks_per_challenge, 5);
+
+    // Default should be DEFAULT_BLOCKS_PER_CHALLENGE
+    let default_config = ChallengeConfig::default();
+    assert_eq!(
+        default_config.blocks_per_challenge,
+        icn_store::pos::DEFAULT_BLOCKS_PER_CHALLENGE
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_merkle_proof_data_round_trip() -> Result<()> {
+    // Test MerkleProofData serialization/deserialization
+    let data = vec![0u8; 4096]; // 4 chunks
+    let tree = ContentChunkTree::new(data, 1024);
+
+    let original_proof = tree.generate_proof(2).unwrap();
+    let proof_data = icn_store::pos::MerkleProofData::from(original_proof);
+
+    // Verify the proof data
+    assert_eq!(proof_data.chunk_index, 2);
+    assert!(!proof_data.siblings.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_challenge_scheduler_handle_pending_count() -> Result<()> {
+    // Test that pending count is tracked correctly
+    let config = ChallengeConfig {
+        timeout_secs: 60, // Long timeout so challenges stay pending
+        challenge_probability: 0.0, // Disable automatic challenges
+        ..Default::default()
+    };
+
+    let node = TestNode::new(config).await?;
+
+    // Initially no pending challenges
+    let count = node.challenge_handle.pending_count().await;
+    assert_eq!(count, 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_re_replication_callback_interface() -> Result<()> {
+    // Test that re-replication callback can be set up
+    let re_replication_triggered = Arc::new(AtomicBool::new(false));
+    let triggered_clone = re_replication_triggered.clone();
+
+    let _callback: icn_core::storage_challenge::ReReplicationCallback =
+        Arc::new(move |_content_hash, _peer_did, _failure_count| {
+            triggered_clone.store(true, Ordering::SeqCst);
+            Ok(())
+        });
+
+    // The callback type should compile and be usable
+    assert!(!re_replication_triggered.load(Ordering::SeqCst));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_storage_failure_reason_severity() -> Result<()> {
+    // Test that failure reasons have appropriate severity scores
+
+    // Network issues - low severity
+    assert!(StorageFailureReason::NoResponse.severity() < 3);
+    assert!(StorageFailureReason::Expired.severity() < 3);
+
+    // Data issues - medium severity
+    assert!(StorageFailureReason::ContentNotFound.severity() >= 3);
+
+    // Likely malicious - high severity
+    assert!(StorageFailureReason::DataMismatch.severity() >= 5);
+    assert!(StorageFailureReason::InvalidMerkleProof.severity() >= 8);
+    assert!(StorageFailureReason::InvalidSignature.severity() >= 8);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_violation_creation_for_failed_challenge() -> Result<()> {
+    // Test that Violation::FailedStorageChallenge can be created
+    let content_hash: [u8; 32] = [1u8; 32];
+    let challenge_id: [u8; 32] = [2u8; 32];
+
+    let violation = Violation::FailedStorageChallenge {
+        content_hash,
+        challenge_id,
+        reason: StorageFailureReason::InvalidMerkleProof,
+    };
+
+    // Verify high severity for invalid merkle proof
+    assert!(violation.severity() >= 8);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_challenge_nonce_uniqueness() -> Result<()> {
+    // Test that challenge nonces are unique (CSPRNG)
+    let node = TestNode::new(ChallengeConfig::default()).await?;
+    let data = vec![0u8; 1024];
+    let (hash, tree) = node.store_content(&data)?;
+
+    let peer_did = KeyPair::generate()?.did().clone();
+
+    let challenge1 = StorageChallenge::new_multi_block(
+        hash,
+        peer_did.to_string(),
+        0,
+        1024,
+        vec![0 % tree.num_chunks()],
+        node.did.to_string(),
+        30,
+    );
+
+    let challenge2 = StorageChallenge::new_multi_block(
+        hash,
+        peer_did.to_string(),
+        0,
+        1024,
+        vec![0 % tree.num_chunks()],
+        node.did.to_string(),
+        30,
+    );
+
+    // Nonces should be different (CSPRNG)
+    assert_ne!(challenge1.challenge_nonce, challenge2.challenge_nonce);
+    // Challenge IDs should be different too
+    assert_ne!(challenge1.id, challenge2.id);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_misbehavior_detector_records_storage_violation() -> Result<()> {
+    // Test that misbehavior detector can record storage violations
+    let config = ChallengeConfig::default();
+    let node = TestNode::new(config).await?;
+
+    // Create a peer that will be marked as misbehaving
+    let bad_peer = KeyPair::generate()?.did().clone();
+
+    // Record a violation
+    {
+        let mut misbehavior = node.misbehavior_handle.write().await;
+        let violation = Violation::FailedStorageChallenge {
+            content_hash: [0u8; 32],
+            challenge_id: [1u8; 32],
+            reason: StorageFailureReason::InvalidMerkleProof,
+        };
+        misbehavior.record_violation(&bad_peer, violation, vec![]);
+    }
+
+    // Verify violation was recorded
+    assert!(node.has_violation_for(&bad_peer).await);
+
+    let violations = node.get_violations_for(&bad_peer).await;
+    assert_eq!(violations.len(), 1);
+    assert!(matches!(
+        violations[0],
+        Violation::FailedStorageChallenge { .. }
+    ));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_unhealthy_replica_tracking() -> Result<()> {
+    // Test that replicas can be marked as unhealthy
+    let config = ChallengeConfig::default();
+    let node = TestNode::new(config).await?;
+
+    // Store content and add replica
+    let data = b"test content".to_vec();
+    let mut hasher = Sha256::new();
+    hasher.update(&data);
+    let hash: [u8; 32] = hasher.finalize().into();
+    node.store.put(&hash, &data)?;
+
+    // Add a replica
+    let peer_did = "did:icn:testpeer123";
+    node.store
+        .add_replica(&hash, peer_did.to_string(), ReplicaHealth::Healthy)?;
+
+    // Verify replica is healthy
+    let metadata = node.store.get_replica_metadata(&hash)?.unwrap();
+    assert_eq!(metadata.replicas.len(), 1);
+    assert_eq!(metadata.replicas[0].health, ReplicaHealth::Healthy);
+
+    // Mark replica as unhealthy
+    let mut metadata = metadata;
+    let triggered = metadata.mark_replica_unhealthy(peer_did, 3);
+    assert!(triggered);
+
+    // Verify unhealthy status
+    assert_eq!(metadata.unhealthy_count(), 1);
+    assert!(metadata.needs_re_replication(1));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_challenge_signing_and_verification() -> Result<()> {
+    // Test that challenges can be signed and verified
+    let keypair = KeyPair::generate()?;
+    let did = keypair.did().clone();
+
+    let data = b"test data for signing".to_vec();
+    let mut hasher = Sha256::new();
+    hasher.update(&data);
+    let hash: [u8; 32] = hasher.finalize().into();
+
+    let mut challenge = StorageChallenge::new_multi_block(
+        hash,
+        "did:icn:target".to_string(),
+        0,
+        1024,
+        vec![0],
+        did.to_string(),
+        30,
+    );
+
+    // Sign the challenge
+    challenge.sign(&keypair).unwrap();
+    assert!(!challenge.signature.is_empty());
+
+    // Verify the signature
+    assert!(challenge.verify_signature().is_ok());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_challenge_expiration() -> Result<()> {
+    // Test that challenges correctly report expiration
+    let data = b"expiration test".to_vec();
+    let mut hasher = Sha256::new();
+    hasher.update(&data);
+    let hash: [u8; 32] = hasher.finalize().into();
+
+    // Create a challenge with long timeout
+    let challenge = StorageChallenge::new_multi_block(
+        hash,
+        "did:icn:target".to_string(),
+        0,
+        1024,
+        vec![0],
+        "did:icn:challenger".to_string(),
+        3600, // 1 hour timeout
+    );
+
+    // Should not be expired
+    assert!(!challenge.is_expired());
+
+    // Verify the expiration timestamp is set correctly
+    // (created_at + timeout_secs)
+    assert!(challenge.expires_at > challenge.created_at);
+    assert_eq!(challenge.expires_at - challenge.created_at, 3600);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_content_chunk_tree_verification() -> Result<()> {
+    // Test that ContentChunkTree Merkle proofs verify correctly
+    let data = vec![0u8; 4096]; // 4 chunks at 1KB each
+    let tree = ContentChunkTree::new(data.clone(), 1024);
+
+    assert_eq!(tree.num_chunks(), 4);
+    assert_eq!(tree.content_size(), 4096);
+
+    // Generate and verify proof for each chunk
+    for chunk_idx in 0..tree.num_chunks() {
+        let proof = tree.generate_proof(chunk_idx).unwrap();
+        assert!(proof.verify());
+    }
+
+    // Invalid chunk index should return None
+    let invalid_proof = tree.generate_proof(100);
+    assert!(invalid_proof.is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_proof_byte_data_hash_verification() -> Result<()> {
+    // Test that we can verify proof byte_data matches expected content
+    let config = ChallengeConfig::default();
+    let node = TestNode::new(config).await?;
+
+    // Store content
+    let data = b"Test content for hash verification".to_vec();
+    let (hash, tree) = node.store_content(&data)?;
+
+    // Create challenge
+    let challenge = StorageChallenge::new_multi_block(
+        hash,
+        "did:icn:peer".to_string(),
+        0,
+        data.len() as u32,
+        vec![0],
+        node.did.to_string(),
+        30,
+    );
+
+    // Generate proof
+    let proof = StorageProof::new_multi(
+        challenge.id,
+        data.clone(),
+        vec![icn_store::pos::MerkleProofData::from(
+            tree.generate_proof(0).unwrap(),
+        )],
+        node.did.to_string(),
+    );
+
+    // Verify byte_data hashes to expected content hash
+    let mut hasher = Sha256::new();
+    hasher.update(&proof.byte_data);
+    let proof_data_hash: [u8; 32] = hasher.finalize().into();
+    assert_eq!(proof_data_hash, hash);
+
+    Ok(())
+}

--- a/icn/crates/icn-core/tests/storage_challenge_integration.rs
+++ b/icn/crates/icn-core/tests/storage_challenge_integration.rs
@@ -172,24 +172,31 @@ async fn test_proof_generation_multi_block() -> Result<()> {
     let data = vec![42u8; 5000];
     let (hash, tree) = node.store_content(&data)?;
 
-    // Select chunk indices
-    let chunk_indices: Vec<u32> = (0..3).map(|i| i % tree.num_chunks()).collect();
+    // Select chunk indices (0, 1, 2 for a 5-chunk file)
+    let chunk_indices: Vec<u32> = vec![0, 1, 2];
 
-    // Create a challenge for 3 blocks
+    // Create a challenge for 3 blocks with byte range [0..1024]
+    let byte_offset = 0u64;
+    let byte_length = 1024u32;
     let challenge = StorageChallenge::new_multi_block(
         hash,
         "did:icn:peer".to_string(),
-        0,
-        1024,
+        byte_offset,
+        byte_length,
         chunk_indices.clone(),
         node.did.to_string(),
         30,
     );
 
-    // Generate proof
+    // Extract just the challenged byte range for the proof
+    let challenged_bytes = tree
+        .get_bytes(byte_offset, byte_length)
+        .unwrap_or_default();
+
+    // Generate proof with correct byte range
     let proof = StorageProof::new_multi(
         challenge.id,
-        data.clone(),
+        challenged_bytes,
         challenge
             .chunk_indices
             .iter()
@@ -402,7 +409,7 @@ async fn test_challenge_nonce_uniqueness() -> Result<()> {
     // Test that challenge nonces are unique (CSPRNG)
     let node = TestNode::new(ChallengeConfig::default()).await?;
     let data = vec![0u8; 1024];
-    let (hash, tree) = node.store_content(&data)?;
+    let (hash, _tree) = node.store_content(&data)?;
 
     let peer_did = KeyPair::generate()?.did().clone();
 
@@ -411,7 +418,7 @@ async fn test_challenge_nonce_uniqueness() -> Result<()> {
         peer_did.to_string(),
         0,
         1024,
-        vec![0 % tree.num_chunks()],
+        vec![0], // First chunk
         node.did.to_string(),
         30,
     );
@@ -421,7 +428,7 @@ async fn test_challenge_nonce_uniqueness() -> Result<()> {
         peer_did.to_string(),
         0,
         1024,
-        vec![0 % tree.num_chunks()],
+        vec![0], // Same chunk - nonces should still differ
         node.did.to_string(),
         30,
     );

--- a/icn/crates/icn-gossip/src/handlers/storage_challenge.rs
+++ b/icn/crates/icn-gossip/src/handlers/storage_challenge.rs
@@ -34,6 +34,17 @@ impl GossipActor {
             "Received storage challenge"
         );
 
+        // Validate protocol version (reject unsupported versions early)
+        if let Err(e) = challenge.validate_version() {
+            warn!(
+                challenge_id = %hex::encode(challenge.id),
+                version = challenge.version,
+                error = %e,
+                "Rejecting challenge with unsupported protocol version"
+            );
+            return Ok(());
+        }
+
         // Check if challenge is for us
         if challenge.target_peer != self.own_did.to_string() {
             debug!(

--- a/icn/crates/icn-gossip/src/handlers/storage_challenge.rs
+++ b/icn/crates/icn-gossip/src/handlers/storage_challenge.rs
@@ -7,7 +7,9 @@ use crate::gossip::GossipActor;
 use crate::types::GossipMessage;
 use anyhow::Result;
 use icn_identity::Did;
-use icn_store::{ContentChunkTree, StorageChallenge, StorageProof, DEFAULT_CHUNK_SIZE};
+use icn_store::{
+    ContentChunkTree, MerkleProofData, StorageChallenge, StorageProof, DEFAULT_CHUNK_SIZE,
+};
 use tracing::{debug, info, warn};
 
 impl GossipActor {
@@ -91,27 +93,29 @@ impl GossipActor {
             .get_bytes(challenge.byte_offset, challenge.byte_length)
             .unwrap_or_default();
 
-        // Generate Merkle proof for requested chunk
-        let merkle_proof = match tree.generate_proof(challenge.chunk_index) {
-            Some(proof) => proof,
-            None => {
-                warn!(
-                    challenge_id = %hex::encode(challenge.id),
-                    chunk_index = challenge.chunk_index,
-                    num_chunks = tree.num_chunks(),
-                    "Invalid chunk index in challenge"
-                );
-                return Ok(());
-            }
-        };
+        // Generate Merkle proofs for all requested chunk indices (v2 multi-block)
+        let mut merkle_proofs: Vec<MerkleProofData> = Vec::new();
+        for &chunk_idx in &challenge.chunk_indices {
+            let merkle_proof = match tree.generate_proof(chunk_idx) {
+                Some(proof) => proof,
+                None => {
+                    warn!(
+                        challenge_id = %hex::encode(challenge.id),
+                        chunk_index = chunk_idx,
+                        num_chunks = tree.num_chunks(),
+                        "Invalid chunk index in challenge"
+                    );
+                    return Ok(());
+                }
+            };
+            merkle_proofs.push(MerkleProofData::from(merkle_proof));
+        }
 
-        // Create proof response
-        let mut proof = StorageProof::new(
+        // Create proof response (v2 multi-proof)
+        let mut proof = StorageProof::new_multi(
             challenge.id,
             byte_data,
-            merkle_proof.chunk_hash,
-            merkle_proof.siblings,
-            merkle_proof.path_bits,
+            merkle_proofs,
             self.own_did.to_string(),
         );
 
@@ -153,7 +157,7 @@ impl GossipActor {
             challenge_id = %hex::encode(challenge.id),
             content_hash = %hex::encode(challenge.content_hash),
             byte_data_len = proof.byte_data.len(),
-            merkle_depth = proof.merkle_siblings.len(),
+            num_proofs = proof.merkle_proofs.len(),
             "Sending storage proof"
         );
 
@@ -184,7 +188,7 @@ impl GossipActor {
             challenge_id = %hex::encode(proof.challenge_id),
             prover = %proof.prover,
             byte_data_len = proof.byte_data.len(),
-            merkle_depth = proof.merkle_siblings.len(),
+            num_proofs = proof.merkle_proofs.len(),
             message_type = "StorageProofMsg",
             "Received storage proof"
         );

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -3078,6 +3078,18 @@ pub mod storage_challenge {
     pub fn timeouts_inc() {
         counter!("icn_storage_challenge_timeouts_total").increment(1);
     }
+
+    /// Increment persistence failure counter
+    ///
+    /// Tracks failures to persist pending challenges for crash recovery.
+    /// High values may indicate storage issues.
+    pub fn persist_failures_inc(operation: &str) {
+        counter!(
+            "icn_storage_challenge_persist_failures_total",
+            "operation" => operation.to_string()
+        )
+        .increment(1);
+    }
 }
 
 /// Gateway API metrics

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -3000,6 +3000,10 @@ pub mod replication {
         gauge!("icn_replication_replicas_unreachable").set(count as f64);
     }
 
+    pub fn replicas_unhealthy_set(count: usize) {
+        gauge!("icn_replication_replicas_unhealthy").set(count as f64);
+    }
+
     pub fn requests_sent_inc(count: u64) {
         counter!("icn_replication_requests_sent_total").increment(count);
     }

--- a/icn/crates/icn-store/src/lib.rs
+++ b/icn/crates/icn-store/src/lib.rs
@@ -36,8 +36,10 @@ pub use peer_cache::{CachedPeer, PeerCache, PeerSource, DEFAULT_PEER_TTL};
 
 // Re-export proof-of-storage types
 pub use pos::{
-    ChallengeConfig, ChallengeState, ContentChunkTree, MerkleProof, PendingChallenge,
-    StorageChallenge, StorageFailureReason, StorageProof, DEFAULT_CHUNK_SIZE, MAX_BYTE_SAMPLE_SIZE,
+    ChallengeConfig, ChallengeState, ContentChunkTree, MerkleProof, MerkleProofData,
+    PendingChallenge, StorageChallenge, StorageFailureReason, StorageProof,
+    CHALLENGE_PROTOCOL_VERSION, DEFAULT_BLOCKS_PER_CHALLENGE, DEFAULT_CHUNK_SIZE,
+    MAX_BYTE_SAMPLE_SIZE,
 };
 
 // Re-export maintenance types

--- a/icn/crates/icn-store/src/lib.rs
+++ b/icn/crates/icn-store/src/lib.rs
@@ -73,6 +73,9 @@ pub enum ReplicaHealth {
     Stale,
     /// Peer reported as offline/unreachable
     Unreachable,
+    /// Replica failed proof-of-storage challenges (potential Byzantine behavior)
+    /// The u32 is the consecutive failure count
+    Unhealthy(u32),
 }
 
 /// Metadata about all replicas for a given content hash
@@ -230,6 +233,46 @@ impl ReplicaMetadata {
             .filter(|r| r.health == ReplicaHealth::Healthy)
             .map(|r| r.peer_did.clone())
             .collect()
+    }
+
+    /// Mark a replica as unhealthy due to failed proof-of-storage challenges
+    ///
+    /// This is called when a replica exceeds the grace period for failed challenges.
+    /// Returns true if the replica was found and marked unhealthy.
+    pub fn mark_replica_unhealthy(&mut self, peer_did: &str, failure_count: u32) -> bool {
+        for replica in &mut self.replicas {
+            if replica.peer_did == peer_did {
+                replica.health = ReplicaHealth::Unhealthy(failure_count);
+                replica.last_seen = SystemTime::now();
+                self.updated_at = SystemTime::now();
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Get count of unhealthy replicas
+    pub fn unhealthy_count(&self) -> usize {
+        self.replicas
+            .iter()
+            .filter(|r| matches!(r.health, ReplicaHealth::Unhealthy(_)))
+            .count()
+    }
+
+    /// Get all unhealthy replica DIDs
+    pub fn unhealthy_replicas(&self) -> Vec<String> {
+        self.replicas
+            .iter()
+            .filter(|r| matches!(r.health, ReplicaHealth::Unhealthy(_)))
+            .map(|r| r.peer_did.clone())
+            .collect()
+    }
+
+    /// Check if re-replication is needed based on healthy vs unhealthy replica ratio
+    ///
+    /// Returns true if the number of healthy replicas is below the minimum threshold.
+    pub fn needs_re_replication(&self, min_healthy_replicas: usize) -> bool {
+        self.healthy_count() < min_healthy_replicas
     }
 }
 

--- a/icn/crates/icn-store/src/pos.rs
+++ b/icn/crates/icn-store/src/pos.rs
@@ -152,11 +152,18 @@ impl StorageChallenge {
 
     /// Get legacy u64 nonce from first 8 bytes (for v1 compatibility)
     pub fn nonce(&self) -> u64 {
-        u64::from_le_bytes(
-            self.challenge_nonce[..8]
-                .try_into()
-                .expect("challenge_nonce is [u8; 32], first 8 bytes always valid"),
-        )
+        // Explicit construction avoids try_into() and is infallible for fixed-size arrays
+        let bytes: [u8; 8] = [
+            self.challenge_nonce[0],
+            self.challenge_nonce[1],
+            self.challenge_nonce[2],
+            self.challenge_nonce[3],
+            self.challenge_nonce[4],
+            self.challenge_nonce[5],
+            self.challenge_nonce[6],
+            self.challenge_nonce[7],
+        ];
+        u64::from_le_bytes(bytes)
     }
 
     /// Compute challenge ID from parameters (excluding signature)

--- a/icn/crates/icn-store/src/pos.rs
+++ b/icn/crates/icn-store/src/pos.rs
@@ -23,9 +23,20 @@ pub const DEFAULT_CHALLENGE_TIMEOUT_SECS: u64 = 30;
 // Challenge Types
 // ============================================================================
 
+/// Protocol version for storage challenges
+pub const CHALLENGE_PROTOCOL_VERSION: u8 = 2;
+
 /// Storage challenge combining byte range + Merkle proof verification
+///
+/// # Protocol Versions
+/// - v1: Single chunk index, u64 nonce (legacy)
+/// - v2: Multiple chunk indices, 32-byte CSPRNG nonce
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct StorageChallenge {
+    /// Protocol version (default: 2)
+    #[serde(default = "default_challenge_version")]
+    pub version: u8,
+
     /// Unique challenge ID (SHA-256 of challenge parameters)
     pub id: [u8; 32],
 
@@ -41,11 +52,13 @@ pub struct StorageChallenge {
     /// Number of bytes to return (max 4KB)
     pub byte_length: u32,
 
-    /// Merkle chunk index to prove
-    pub chunk_index: u32,
+    /// Merkle chunk indices to prove (v2: multiple blocks)
+    /// For v1 compatibility, a single-element vec is used
+    pub chunk_indices: Vec<u32>,
 
-    /// Nonce for replay protection
-    pub nonce: u64,
+    /// CSPRNG nonce for replay protection (v2: 32 bytes)
+    /// For v1 compatibility, first 8 bytes contain the u64 nonce
+    pub challenge_nonce: [u8; 32],
 
     /// DID of the challenger
     pub challenger: String,
@@ -60,14 +73,45 @@ pub struct StorageChallenge {
     pub signature: Vec<u8>,
 }
 
+fn default_challenge_version() -> u8 {
+    CHALLENGE_PROTOCOL_VERSION
+}
+
 impl StorageChallenge {
-    /// Create a new storage challenge (unsigned)
+    /// Create a new storage challenge for a single chunk (v2 protocol, unsigned)
+    ///
+    /// For multi-block challenges, use `new_multi_block` instead.
     pub fn new(
         content_hash: ContentHash,
         target_peer: String,
         byte_offset: u64,
         byte_length: u32,
         chunk_index: u32,
+        challenger: String,
+        timeout_secs: u64,
+    ) -> Self {
+        Self::new_multi_block(
+            content_hash,
+            target_peer,
+            byte_offset,
+            byte_length,
+            vec![chunk_index],
+            challenger,
+            timeout_secs,
+        )
+    }
+
+    /// Create a new multi-block storage challenge (v2 protocol, unsigned)
+    ///
+    /// Requests proofs for multiple chunk indices in a single challenge,
+    /// making it harder for malicious nodes to pass challenges while storing
+    /// only portions of the data.
+    pub fn new_multi_block(
+        content_hash: ContentHash,
+        target_peer: String,
+        byte_offset: u64,
+        byte_length: u32,
+        chunk_indices: Vec<u32>,
         challenger: String,
         timeout_secs: u64,
     ) -> Self {
@@ -78,16 +122,18 @@ impl StorageChallenge {
             Err(_) => 0,
         };
 
-        let nonce = rand::random::<u64>();
+        // Generate 32-byte CSPRNG nonce for unpredictability
+        let challenge_nonce: [u8; 32] = rand::random();
 
         let mut challenge = Self {
+            version: CHALLENGE_PROTOCOL_VERSION,
             id: [0u8; 32],
             content_hash,
             target_peer,
             byte_offset,
             byte_length: byte_length.min(MAX_BYTE_SAMPLE_SIZE),
-            chunk_index,
-            nonce,
+            chunk_indices,
+            challenge_nonce,
             challenger,
             created_at: now,
             expires_at: now + timeout_secs,
@@ -99,15 +145,30 @@ impl StorageChallenge {
         challenge
     }
 
+    /// Get the primary chunk index (for single-block compatibility)
+    pub fn chunk_index(&self) -> Option<u32> {
+        self.chunk_indices.first().copied()
+    }
+
+    /// Get legacy u64 nonce from first 8 bytes (for v1 compatibility)
+    pub fn nonce(&self) -> u64 {
+        u64::from_le_bytes(self.challenge_nonce[..8].try_into().unwrap_or([0u8; 8]))
+    }
+
     /// Compute challenge ID from parameters (excluding signature)
     fn compute_id(&self) -> [u8; 32] {
         let mut hasher = Sha256::new();
+        hasher.update([self.version]);
         hasher.update(self.content_hash);
         hasher.update(self.target_peer.as_bytes());
         hasher.update(self.byte_offset.to_le_bytes());
         hasher.update(self.byte_length.to_le_bytes());
-        hasher.update(self.chunk_index.to_le_bytes());
-        hasher.update(self.nonce.to_le_bytes());
+        // Include count and all chunk indices
+        hasher.update((self.chunk_indices.len() as u32).to_le_bytes());
+        for idx in &self.chunk_indices {
+            hasher.update(idx.to_le_bytes());
+        }
+        hasher.update(self.challenge_nonce);
         hasher.update(self.challenger.as_bytes());
         hasher.update(self.created_at.to_le_bytes());
         hasher.update(self.expires_at.to_le_bytes());
@@ -117,13 +178,18 @@ impl StorageChallenge {
     /// Get the signing payload (used for signature creation/verification)
     pub fn signing_payload(&self) -> Vec<u8> {
         let mut payload = Vec::new();
+        payload.push(self.version);
         payload.extend_from_slice(&self.id);
         payload.extend_from_slice(&self.content_hash);
         payload.extend_from_slice(self.target_peer.as_bytes());
         payload.extend_from_slice(&self.byte_offset.to_le_bytes());
         payload.extend_from_slice(&self.byte_length.to_le_bytes());
-        payload.extend_from_slice(&self.chunk_index.to_le_bytes());
-        payload.extend_from_slice(&self.nonce.to_le_bytes());
+        // Include count and all chunk indices
+        payload.extend_from_slice(&(self.chunk_indices.len() as u32).to_le_bytes());
+        for idx in &self.chunk_indices {
+            payload.extend_from_slice(&idx.to_le_bytes());
+        }
+        payload.extend_from_slice(&self.challenge_nonce[..]);
         payload.extend_from_slice(self.challenger.as_bytes());
         payload.extend_from_slice(&self.created_at.to_le_bytes());
         payload.extend_from_slice(&self.expires_at.to_le_bytes());
@@ -197,23 +263,76 @@ impl StorageChallenge {
 // Proof Types
 // ============================================================================
 
+/// Individual Merkle proof data for a single chunk
+///
+/// Used within `StorageProof` to provide proofs for multiple chunks.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MerkleProofData {
+    /// Index of the chunk being proven
+    pub chunk_index: u32,
+
+    /// Hash of the chunk
+    pub chunk_hash: [u8; 32],
+
+    /// Sibling hashes from leaf to root
+    pub siblings: Vec<[u8; 32]>,
+
+    /// Position bits: false = left child, true = right child
+    pub path_bits: Vec<bool>,
+}
+
+impl MerkleProofData {
+    /// Verify this proof against an expected root
+    pub fn verify_against_root(&self, expected_root: &[u8; 32]) -> bool {
+        if self.siblings.len() != self.path_bits.len() {
+            return false;
+        }
+
+        let mut current = self.chunk_hash;
+
+        for (sibling, is_right) in self.siblings.iter().zip(self.path_bits.iter()) {
+            current = if *is_right {
+                ContentChunkTree::hash_pair(sibling, &current)
+            } else {
+                ContentChunkTree::hash_pair(&current, sibling)
+            };
+        }
+
+        current == *expected_root
+    }
+}
+
+impl From<MerkleProof> for MerkleProofData {
+    fn from(proof: MerkleProof) -> Self {
+        Self {
+            chunk_index: proof.chunk_index,
+            chunk_hash: proof.chunk_hash,
+            siblings: proof.siblings,
+            path_bits: proof.path_bits,
+        }
+    }
+}
+
 /// Storage proof response from replica holder
+///
+/// # Protocol Versions
+/// - v1: Single proof (chunk_hash, merkle_siblings, merkle_path_bits)
+/// - v2: Multiple proofs via `merkle_proofs` vec
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct StorageProof {
+    /// Protocol version (default: 2)
+    #[serde(default = "default_challenge_version")]
+    pub version: u8,
+
     /// Challenge ID being answered
     pub challenge_id: [u8; 32],
 
     /// The requested bytes from byte range challenge
     pub byte_data: Vec<u8>,
 
-    /// Hash of the chunk being proven
-    pub chunk_hash: [u8; 32],
-
-    /// Merkle sibling hashes from leaf to root
-    pub merkle_siblings: Vec<[u8; 32]>,
-
-    /// Position bits indicating left(false)/right(true) at each level
-    pub merkle_path_bits: Vec<bool>,
+    /// Multiple Merkle proofs (v2: one per challenged chunk)
+    /// For v1 compatibility, single-element vec works
+    pub merkle_proofs: Vec<MerkleProofData>,
 
     /// DID of the prover (replica holder)
     pub prover: String,
@@ -226,13 +345,35 @@ pub struct StorageProof {
 }
 
 impl StorageProof {
-    /// Create a new storage proof (unsigned)
+    /// Create a new storage proof for a single chunk (v2 protocol, unsigned)
+    ///
+    /// For multi-chunk proofs, use `new_multi` instead.
     pub fn new(
         challenge_id: [u8; 32],
         byte_data: Vec<u8>,
         chunk_hash: [u8; 32],
         merkle_siblings: Vec<[u8; 32]>,
         merkle_path_bits: Vec<bool>,
+        prover: String,
+    ) -> Self {
+        Self::new_multi(
+            challenge_id,
+            byte_data,
+            vec![MerkleProofData {
+                chunk_index: 0, // Default index for single-proof compatibility
+                chunk_hash,
+                siblings: merkle_siblings,
+                path_bits: merkle_path_bits,
+            }],
+            prover,
+        )
+    }
+
+    /// Create a new multi-chunk storage proof (v2 protocol, unsigned)
+    pub fn new_multi(
+        challenge_id: [u8; 32],
+        byte_data: Vec<u8>,
+        merkle_proofs: Vec<MerkleProofData>,
         prover: String,
     ) -> Self {
         // Get current Unix timestamp. If system clock is before Unix epoch, use 0.
@@ -242,29 +383,50 @@ impl StorageProof {
         };
 
         Self {
+            version: CHALLENGE_PROTOCOL_VERSION,
             challenge_id,
             byte_data,
-            chunk_hash,
-            merkle_siblings,
-            merkle_path_bits,
+            merkle_proofs,
             prover,
             generated_at: now,
             signature: Vec::new(),
         }
     }
 
+    /// Get the first chunk hash (for single-proof compatibility)
+    pub fn chunk_hash(&self) -> Option<[u8; 32]> {
+        self.merkle_proofs.first().map(|p| p.chunk_hash)
+    }
+
+    /// Get the first merkle siblings (for single-proof compatibility)
+    pub fn merkle_siblings(&self) -> Option<&Vec<[u8; 32]>> {
+        self.merkle_proofs.first().map(|p| &p.siblings)
+    }
+
+    /// Get the first merkle path bits (for single-proof compatibility)
+    pub fn merkle_path_bits(&self) -> Option<&Vec<bool>> {
+        self.merkle_proofs.first().map(|p| &p.path_bits)
+    }
+
     /// Get the signing payload (used for signature creation/verification)
     pub fn signing_payload(&self) -> Vec<u8> {
         let mut payload = Vec::new();
+        payload.push(self.version);
         payload.extend_from_slice(&self.challenge_id);
         payload.extend_from_slice(&(self.byte_data.len() as u32).to_le_bytes());
         payload.extend_from_slice(&self.byte_data);
-        payload.extend_from_slice(&self.chunk_hash);
-        for sibling in &self.merkle_siblings {
-            payload.extend_from_slice(sibling);
-        }
-        for bit in &self.merkle_path_bits {
-            payload.push(if *bit { 1 } else { 0 });
+        // Include count and all merkle proofs
+        payload.extend_from_slice(&(self.merkle_proofs.len() as u32).to_le_bytes());
+        for proof in &self.merkle_proofs {
+            payload.extend_from_slice(&proof.chunk_index.to_le_bytes());
+            payload.extend_from_slice(&proof.chunk_hash);
+            payload.extend_from_slice(&(proof.siblings.len() as u32).to_le_bytes());
+            for sibling in &proof.siblings {
+                payload.extend_from_slice(sibling);
+            }
+            for bit in &proof.path_bits {
+                payload.push(if *bit { 1 } else { 0 });
+            }
         }
         payload.extend_from_slice(self.prover.as_bytes());
         payload.extend_from_slice(&self.generated_at.to_le_bytes());
@@ -643,6 +805,9 @@ pub struct PendingChallenge {
 // Configuration
 // ============================================================================
 
+/// Default number of blocks per challenge
+pub const DEFAULT_BLOCKS_PER_CHALLENGE: u32 = 3;
+
 /// Configuration for the challenge scheduler
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChallengeConfig {
@@ -672,6 +837,10 @@ pub struct ChallengeConfig {
 
     /// Byte sample size for challenges
     pub byte_sample_size: u32,
+
+    /// Number of random chunk indices to challenge per request (v2 protocol)
+    /// Higher values increase security but also increase proof size
+    pub blocks_per_challenge: u32,
 }
 
 impl Default for ChallengeConfig {
@@ -686,6 +855,7 @@ impl Default for ChallengeConfig {
             max_pending_total: 1000,
             chunk_size: DEFAULT_CHUNK_SIZE,
             byte_sample_size: MAX_BYTE_SAMPLE_SIZE,
+            blocks_per_challenge: DEFAULT_BLOCKS_PER_CHALLENGE,
         }
     }
 }
@@ -710,8 +880,30 @@ mod tests {
         assert_eq!(challenge.content_hash, content_hash);
         assert_eq!(challenge.byte_offset, 100);
         assert_eq!(challenge.byte_length, 1024);
-        assert_eq!(challenge.chunk_index, 5);
+        assert_eq!(challenge.chunk_index(), Some(5));
+        assert_eq!(challenge.chunk_indices, vec![5]);
+        assert_eq!(challenge.version, CHALLENGE_PROTOCOL_VERSION);
         assert!(!challenge.is_expired());
+        assert!(challenge.validate_id());
+    }
+
+    #[test]
+    fn test_multi_block_challenge_creation() {
+        let content_hash = [1u8; 32];
+        let challenge = StorageChallenge::new_multi_block(
+            content_hash,
+            "did:icn:target".to_string(),
+            100,
+            1024,
+            vec![2, 5, 8],
+            "did:icn:challenger".to_string(),
+            30,
+        );
+
+        assert_eq!(challenge.chunk_indices, vec![2, 5, 8]);
+        assert_eq!(challenge.chunk_index(), Some(2));
+        assert_eq!(challenge.version, 2);
+        assert_eq!(challenge.challenge_nonce.len(), 32);
         assert!(challenge.validate_id());
     }
 
@@ -736,7 +928,7 @@ mod tests {
         assert_eq!(c1.id, c2.id);
 
         // Different nonce should produce different ID
-        c1.nonce = 12345;
+        c1.challenge_nonce = [0x42u8; 32];
         c1.id = c1.compute_id();
         assert_ne!(c1.id, c2.id);
     }
@@ -808,7 +1000,51 @@ mod tests {
 
         assert_eq!(proof.challenge_id, [1u8; 32]);
         assert_eq!(proof.byte_data, b"test data");
+        assert_eq!(proof.version, CHALLENGE_PROTOCOL_VERSION);
+        assert_eq!(proof.merkle_proofs.len(), 1);
+        assert_eq!(proof.chunk_hash(), Some([2u8; 32]));
         assert!(!proof.signing_payload().is_empty());
+    }
+
+    #[test]
+    fn test_multi_proof_creation() {
+        let proofs = vec![
+            MerkleProofData {
+                chunk_index: 2,
+                chunk_hash: [2u8; 32],
+                siblings: vec![[10u8; 32], [11u8; 32]],
+                path_bits: vec![false, true],
+            },
+            MerkleProofData {
+                chunk_index: 5,
+                chunk_hash: [5u8; 32],
+                siblings: vec![[12u8; 32], [13u8; 32]],
+                path_bits: vec![true, false],
+            },
+        ];
+
+        let proof = StorageProof::new_multi(
+            [1u8; 32],
+            b"test data".to_vec(),
+            proofs,
+            "did:icn:prover".to_string(),
+        );
+
+        assert_eq!(proof.merkle_proofs.len(), 2);
+        assert_eq!(proof.merkle_proofs[0].chunk_index, 2);
+        assert_eq!(proof.merkle_proofs[1].chunk_index, 5);
+        assert_eq!(proof.chunk_hash(), Some([2u8; 32]));
+    }
+
+    #[test]
+    fn test_merkle_proof_data_verification() {
+        let content = b"0123456789abcdef".to_vec();
+        let tree = ContentChunkTree::new(content, 4);
+
+        let proof = tree.generate_proof(0).expect("should generate proof");
+        let proof_data = MerkleProofData::from(proof);
+
+        assert!(proof_data.verify_against_root(&tree.root()));
     }
 
     #[test]
@@ -825,5 +1061,6 @@ mod tests {
         assert_eq!(config.base_interval_secs, 3600);
         assert_eq!(config.timeout_secs, 30);
         assert_eq!(config.grace_attempts, 3);
+        assert_eq!(config.blocks_per_challenge, DEFAULT_BLOCKS_PER_CHALLENGE);
     }
 }

--- a/icn/crates/icn-store/src/pos.rs
+++ b/icn/crates/icn-store/src/pos.rs
@@ -152,7 +152,11 @@ impl StorageChallenge {
 
     /// Get legacy u64 nonce from first 8 bytes (for v1 compatibility)
     pub fn nonce(&self) -> u64 {
-        u64::from_le_bytes(self.challenge_nonce[..8].try_into().unwrap_or([0u8; 8]))
+        u64::from_le_bytes(
+            self.challenge_nonce[..8]
+                .try_into()
+                .expect("challenge_nonce is [u8; 32], first 8 bytes always valid"),
+        )
     }
 
     /// Compute challenge ID from parameters (excluding signature)

--- a/icn/crates/icn-store/src/pos.rs
+++ b/icn/crates/icn-store/src/pos.rs
@@ -26,6 +26,12 @@ pub const DEFAULT_CHALLENGE_TIMEOUT_SECS: u64 = 30;
 /// Protocol version for storage challenges
 pub const CHALLENGE_PROTOCOL_VERSION: u8 = 2;
 
+/// Minimum supported protocol version
+pub const MIN_SUPPORTED_VERSION: u8 = 1;
+
+/// Maximum supported protocol version
+pub const MAX_SUPPORTED_VERSION: u8 = 2;
+
 /// Storage challenge combining byte range + Merkle proof verification
 ///
 /// # Protocol Versions
@@ -219,6 +225,22 @@ impl StorageChallenge {
     /// Validate challenge ID matches computed value
     pub fn validate_id(&self) -> bool {
         self.id == self.compute_id()
+    }
+
+    /// Validate that the protocol version is supported
+    ///
+    /// Returns an error if the version is outside the supported range.
+    /// This prevents silent mishandling of future protocol versions.
+    pub fn validate_version(&self) -> Result<()> {
+        if self.version < MIN_SUPPORTED_VERSION || self.version > MAX_SUPPORTED_VERSION {
+            anyhow::bail!(
+                "Unsupported challenge protocol version {}: supported range is {}-{}",
+                self.version,
+                MIN_SUPPORTED_VERSION,
+                MAX_SUPPORTED_VERSION
+            );
+        }
+        Ok(())
     }
 
     /// Sign this challenge with the challenger's keypair
@@ -417,6 +439,22 @@ impl StorageProof {
     /// Get the first merkle path bits (for single-proof compatibility)
     pub fn merkle_path_bits(&self) -> Option<&Vec<bool>> {
         self.merkle_proofs.first().map(|p| &p.path_bits)
+    }
+
+    /// Validate that the protocol version is supported
+    ///
+    /// Returns an error if the version is outside the supported range.
+    /// This prevents silent mishandling of future protocol versions.
+    pub fn validate_version(&self) -> Result<()> {
+        if self.version < MIN_SUPPORTED_VERSION || self.version > MAX_SUPPORTED_VERSION {
+            anyhow::bail!(
+                "Unsupported proof protocol version {}: supported range is {}-{}",
+                self.version,
+                MIN_SUPPORTED_VERSION,
+                MAX_SUPPORTED_VERSION
+            );
+        }
+        Ok(())
     }
 
     /// Get the signing payload (used for signature creation/verification)

--- a/icn/crates/icn-zkp/src/stark/age.rs
+++ b/icn/crates/icn-zkp/src/stark/age.rs
@@ -415,8 +415,8 @@ mod tests {
         // STARK proofs for small traces are compact (~3-5KB)
         // Size varies based on trace complexity and proof options
         let size = proof.proof_bytes.len();
-        assert!(size > 1_000, "Proof too small: {} bytes", size);
-        assert!(size < 20_000, "Proof too large: {} bytes", size);
+        assert!(size > 1_000, "Proof too small: {size} bytes");
+        assert!(size < 20_000, "Proof too large: {size} bytes");
         println!(
             "Age proof size: {} bytes ({:.1} KB)",
             size,


### PR DESCRIPTION
## Summary

This PR implements BFT Hardening Phase 2 (Issue #674) - Proof-of-Storage challenge-response protocol enhancements. The existing PoS foundation was extended with:

- **Multi-block challenges**: Challenge multiple random chunk indices per request instead of single chunks, making it harder for malicious nodes to pass challenges while storing only portions of data
- **CSPRNG nonces**: Upgraded from u64 nonces to 32-byte cryptographically secure random nonces for stronger replay protection
- **Re-replication triggers**: Automatic callback when a replica fails too many challenges, enabling the replication manager to find new storage providers
- **Challenge persistence**: Crash recovery for pending challenges via store persistence
- **Trust-gated frequency**: Lower-trust peers are challenged more frequently (2x at trust=0.0, 1x at trust=1.0)
- **Integration tests**: 17 new tests covering the challenge-response protocol

### Technical Changes

| File | Change |
|------|--------|
| `icn-store/src/pos.rs` | Multi-block `chunk_indices`, `challenge_nonce: [u8; 32]`, protocol version v2 |
| `icn-store/src/lib.rs` | `ReplicaHealth::Unhealthy(u32)`, `mark_replica_unhealthy()`, replica health queries |
| `icn-core/src/storage_challenge.rs` | Trust-adjusted probability, persistence, re-replication callback |
| `icn-core/src/replication/manager.rs` | Handle `Unhealthy` replica status in health checks |
| `icn-obs/src/metrics_legacy.rs` | `replicas_unhealthy_set()` Prometheus metric |
| `icn-core/tests/storage_challenge_integration.rs` | **New**: 17 integration tests |

### Protocol Versioning

- `version: u8` field added to challenges and proofs
- v1: Legacy (single chunk, u64 nonce) - backward compatible
- v2: Enhanced (multi-block, 32-byte CSPRNG nonce) - default

## Test plan

- [x] `cargo test -p icn-store pos` - 13 tests pass
- [x] `cargo test -p icn-core --test storage_challenge_integration` - 17 tests pass
- [x] `cargo test -p icn-core storage_challenge` - 1 unit test passes
- [x] Existing replication tests pass

Closes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)