### PR TITLE
feat(core): Integrate storage maintenance with supervisor

### DIFF
--- a/config/icn.toml.example
+++ b/config/icn.toml.example
@@ -300,3 +300,17 @@ shutdown_timeout_secs = 5
 
 # Clock synchronization interval in seconds
 clock_sync_interval_secs = 600
+
+# Storage maintenance configuration
+# Periodic maintenance keeps the Sled database optimized
+[supervisor.storage_maintenance]
+# Enable periodic maintenance (default: true)
+enabled = true
+# Interval between maintenance runs in seconds (default: 3600 = 1 hour)
+interval_secs = 3600
+# Warn if space amplification exceeds this threshold (default: 2.0)
+amplification_threshold = 2.0
+# Warn if database size exceeds this threshold in bytes (default: 1GB)
+size_threshold_bytes = 1073741824
+# Flush data to disk during maintenance (default: true)
+flush_on_maintenance = true

--- a/docs/observability/storage-metrics.md
+++ b/docs/observability/storage-metrics.md
@@ -1,0 +1,126 @@
+# Storage Metrics Reference
+
+ICN exposes storage-related metrics via Prometheus for monitoring database health, performance, and maintenance operations.
+
+## Metric Naming Convention
+
+All storage metrics follow the pattern: `icn_storage_<component>_<measurement>_<unit>`
+
+## General Storage Metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `icn_storage_size_bytes` | Gauge | Current size of the storage backend on disk in bytes |
+| `icn_storage_space_amplification` | Gauge | Space amplification factor (actual size / logical size) |
+| `icn_storage_flush_total` | Counter | Total number of storage flush operations |
+| `icn_storage_flush_bytes_total` | Counter | Total bytes flushed to disk |
+| `icn_storage_flush_duration_seconds` | Histogram | Duration of flush operations in seconds |
+| `icn_storage_operations_total` | Counter | Total storage operations by type (labels: `operation`) |
+
+### Operation Labels
+
+The `icn_storage_operations_total` metric includes an `operation` label with these values:
+- `get` - Read operations
+- `put` - Write operations
+- `delete` - Delete operations
+- `scan` - Range scan operations
+
+## Maintenance Metrics
+
+These metrics track periodic storage maintenance operations (flush, space monitoring).
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `icn_storage_maintenance_runs_total` | Counter | Total number of maintenance runs |
+| `icn_storage_maintenance_duration_seconds` | Histogram | Duration of maintenance operations in seconds |
+| `icn_storage_maintenance_space_reclaimed_bytes` | Counter | Total bytes reclaimed by maintenance |
+| `icn_storage_maintenance_errors_total` | Counter | Total number of maintenance errors |
+
+### Maintenance Configuration
+
+Maintenance is configured in `icn.toml` under `[supervisor.storage_maintenance]`:
+
+```toml
+[supervisor.storage_maintenance]
+enabled = true                      # Enable periodic maintenance (default: true)
+interval_secs = 3600                # Interval between runs (default: 3600 = 1 hour)
+amplification_threshold = 2.0       # Warn if space amplification exceeds this
+size_threshold_bytes = 1073741824   # Warn if size exceeds this (default: 1GB)
+flush_on_maintenance = true         # Flush data to disk during maintenance
+```
+
+## Alerting Recommendations
+
+### Space Amplification Alert
+
+```yaml
+# Alert when space amplification is high for extended period
+- alert: StorageHighSpaceAmplification
+  expr: icn_storage_space_amplification > 2.5
+  for: 1h
+  labels:
+    severity: warning
+  annotations:
+    summary: "High storage space amplification"
+    description: "Space amplification {{ $value }} exceeds threshold"
+```
+
+### Maintenance Errors Alert
+
+```yaml
+# Alert on maintenance failures
+- alert: StorageMaintenanceErrors
+  expr: increase(icn_storage_maintenance_errors_total[1h]) > 0
+  labels:
+    severity: warning
+  annotations:
+    summary: "Storage maintenance errors detected"
+    description: "{{ $value }} maintenance errors in the last hour"
+```
+
+### Database Size Alert
+
+```yaml
+# Alert when database grows large
+- alert: StorageSizeLarge
+  expr: icn_storage_size_bytes > 5e9  # 5GB
+  for: 30m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Storage size exceeds threshold"
+    description: "Database size is {{ humanize $value }}"
+```
+
+## Grafana Dashboard Queries
+
+### Storage Size Over Time
+
+```promql
+icn_storage_size_bytes
+```
+
+### Maintenance Duration P99
+
+```promql
+histogram_quantile(0.99, sum(rate(icn_storage_maintenance_duration_seconds_bucket[5m])) by (le))
+```
+
+### Operations Rate by Type
+
+```promql
+sum(rate(icn_storage_operations_total[5m])) by (operation)
+```
+
+### Maintenance Health
+
+```promql
+# Successful maintenance rate
+1 - (rate(icn_storage_maintenance_errors_total[1h]) / rate(icn_storage_maintenance_runs_total[1h]))
+```
+
+## See Also
+
+- [Distributed Tracing](distributed-tracing.md)
+- [Tail-Based Sampling](tail-based-sampling.md)
+- [Production Hardening](../production-hardening.md)

--- a/icn/crates/icn-core/src/config/supervisor.rs
+++ b/icn/crates/icn-core/src/config/supervisor.rs
@@ -1,5 +1,6 @@
 //! Supervisor configuration for background tasks and timeouts
 
+use icn_store::MaintenanceConfig;
 use serde::{Deserialize, Serialize};
 
 /// Supervisor configuration for background tasks and timeouts (A5 fix)
@@ -34,6 +35,10 @@ pub struct SupervisorConfig {
     /// Actor restart policy configuration
     #[serde(default)]
     pub restart_policy: RestartPolicyConfig,
+
+    /// Storage maintenance configuration (compaction, cleanup)
+    #[serde(default)]
+    pub storage_maintenance: MaintenanceConfig,
 }
 
 /// Configuration for actor restart with exponential backoff.
@@ -130,6 +135,7 @@ impl Default for SupervisorConfig {
             shutdown_timeout_secs: default_shutdown_timeout_secs(),
             clock_sync_interval_secs: default_clock_sync_interval_secs(),
             restart_policy: RestartPolicyConfig::default(),
+            storage_maintenance: MaintenanceConfig::default(),
         }
     }
 }

--- a/icn/crates/icn-core/src/supervisor/background_tasks.rs
+++ b/icn/crates/icn-core/src/supervisor/background_tasks.rs
@@ -708,6 +708,40 @@ pub mod storage_challenge {
     }
 }
 
+/// Spawn the storage maintenance background task
+///
+/// This task periodically runs Sled database maintenance operations:
+/// - Flush data to disk for durability
+/// - Monitor space amplification
+/// - Generate warnings when thresholds are exceeded
+///
+/// # Parameters
+/// - `config`: Maintenance configuration (interval, thresholds)
+/// - `store`: The Sled store to maintain
+/// - `shutdown_rx`: Shutdown signal receiver from supervisor
+///
+/// # Returns
+/// A `MaintenanceHandle` that can be used to trigger immediate maintenance
+/// or stop the task.
+pub fn spawn_storage_maintenance_task(
+    config: icn_store::MaintenanceConfig,
+    store: Arc<icn_store::SledStore>,
+    mut shutdown_rx: BroadcastReceiver<()>,
+) -> icn_store::MaintenanceHandle {
+    let manager = Arc::new(icn_store::MaintenanceManager::new(store, config));
+    let handle = manager.start_background_task();
+
+    // Spawn a task that listens for supervisor shutdown and stops the maintenance task
+    let handle_for_shutdown = handle.clone();
+    tokio::spawn(async move {
+        let _ = shutdown_rx.recv().await;
+        info!("Stopping storage maintenance task due to supervisor shutdown");
+        handle_for_shutdown.stop();
+    });
+
+    handle
+}
+
 /// Configuration for bootstrap peer health checking task
 pub struct BootstrapHealthConfig {
     /// Interval between health checks (default: 60s)
@@ -954,5 +988,13 @@ mod tests {
         assert_eq!(config.check_interval, Duration::from_secs(60));
         assert_eq!(config.reconnect_timeout, Duration::from_secs(10));
         assert_eq!(config.max_failures, 3);
+    }
+
+    #[test]
+    fn test_maintenance_config_default() {
+        let config = icn_store::MaintenanceConfig::default();
+        assert!(config.enabled);
+        assert_eq!(config.interval_secs, 3600); // 1 hour
+        assert_eq!(config.amplification_threshold, 2.0);
     }
 }

--- a/icn/crates/icn-core/src/supervisor/mod.rs
+++ b/icn/crates/icn-core/src/supervisor/mod.rs
@@ -365,6 +365,7 @@ impl Supervisor {
             let treasury_manager_handle = ledger_services.treasury_manager.clone();
             let contract_runtime_handle = ledger_services.contract_runtime.clone();
             let contract_actor_handle = ledger_services.contract_actor.clone();
+            let ledger_store = ledger_services.ledger_store.clone(); // For maintenance task
 
             // Initialize cooperative services
             let coop_services =
@@ -985,6 +986,21 @@ impl Supervisor {
             );
 
             info!("Parameter scheduler task spawned (interval: 10 seconds)");
+
+            // Spawn storage maintenance task (Issue #702)
+            if self.config.supervisor.storage_maintenance.enabled {
+                let _maintenance_handle = background_tasks::spawn_storage_maintenance_task(
+                    self.config.supervisor.storage_maintenance.clone(),
+                    ledger_store.clone(),
+                    self.shutdown_tx.subscribe(),
+                );
+                info!(
+                    "Storage maintenance task spawned (interval: {} seconds)",
+                    self.config.supervisor.storage_maintenance.interval_secs
+                );
+            } else {
+                info!("Storage maintenance disabled by configuration");
+            }
 
             // Spawn connection candidate re-announcement task (Phase M2)
             let candidate_announce_config = background_tasks::CandidateAnnouncementConfig {

--- a/icn/crates/icn-core/src/supervisor/mod.rs
+++ b/icn/crates/icn-core/src/supervisor/mod.rs
@@ -988,7 +988,12 @@ impl Supervisor {
             info!("Parameter scheduler task spawned (interval: 10 seconds)");
 
             // Spawn storage maintenance task (Issue #702)
+            // Currently maintains the ledger store (highest write volume). Future: could extend
+            // to maintain multiple stores (trust, gossip, identity) via Vec<Arc<SledStore>>.
             if self.config.supervisor.storage_maintenance.enabled {
+                // Note: Handle not retained - maintenance runs purely on timer with graceful
+                // shutdown via broadcast channel. Future: retain handle for on-demand trigger
+                // via gRPC endpoint (e.g., `icnctl storage compact`).
                 let _maintenance_handle = background_tasks::spawn_storage_maintenance_task(
                     self.config.supervisor.storage_maintenance.clone(),
                     ledger_store.clone(),

--- a/icn/crates/icn-store/src/maintenance.rs
+++ b/icn/crates/icn-store/src/maintenance.rs
@@ -101,6 +101,7 @@ impl MaintenanceResult {
 }
 
 /// Handle for controlling the maintenance task
+#[derive(Clone)]
 pub struct MaintenanceHandle {
     shutdown: Arc<AtomicBool>,
     notify: Arc<Notify>,


### PR DESCRIPTION
## Summary

Integrates the storage maintenance module (from PR #701) with the supervisor for automatic background maintenance.

- Adds `storage_maintenance` configuration to `SupervisorConfig`
- Spawns maintenance task on daemon startup
- Handles graceful shutdown coordination
- Documents configuration in example config

## Changes

| File | Description |
|------|-------------|
| `icn-core/src/config/supervisor.rs` | Add `MaintenanceConfig` field |
| `icn-core/src/supervisor/background_tasks.rs` | Add `spawn_storage_maintenance_task()` |
| `icn-core/src/supervisor/mod.rs` | Wire up task spawning |
| `icn-store/src/maintenance.rs` | Add `Clone` to `MaintenanceHandle` |
| `config/icn.toml.example` | Document configuration |

## Configuration

```toml
[supervisor.storage_maintenance]
enabled = true
interval_secs = 3600           # 1 hour
amplification_threshold = 2.0  # Warn threshold
size_threshold_bytes = 1073741824  # 1GB warning
flush_on_maintenance = true
```

## Test plan

- [x] `cargo build` - builds successfully
- [x] `cargo test -p icn-core` - all 152 tests pass
- [x] `cargo test -p icn-store maintenance` - 6 tests pass
- [x] `cargo clippy` - no warnings

Closes #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)