### PR TITLE
fix(deps,security): upgrade dependencies and harden security

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -1157,15 +1157,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2075,21 +2066,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,22 +2555,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2795,7 +2755,7 @@ dependencies = [
  "icn-store",
  "icn-trust",
  "ratatui",
- "reqwest",
+ "reqwest 0.13.1",
  "rpassword",
  "serde",
  "serde_json",
@@ -2944,7 +2904,7 @@ dependencies = [
  "lru",
  "metrics",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "sha2",
@@ -3002,7 +2962,7 @@ dependencies = [
  "metrics",
  "prometheus",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.13.1",
  "rust-i18n",
  "serde",
  "serde_bytes",
@@ -3248,7 +3208,7 @@ dependencies = [
  "jsonwebtoken",
  "metrics",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "sha2",
@@ -3456,7 +3416,7 @@ dependencies = [
  "icn-store",
  "icn-trust",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.13.1",
  "rpassword",
  "rust-i18n",
  "serde",
@@ -3614,9 +3574,9 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+checksum = "bf39cc0423ee66021dc5eccface85580e4a001e0c5288bae8bea7ecb69225e90"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -4103,15 +4063,17 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mdns-sd"
-version = "0.11.5"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe7c11a1eb3cfbfcf702d1601c1f5f4c102cdc8665b8a557783ef634741676e"
+checksum = "183d7ebd9fe3815c1635cd039d1ed95f1d315731cc13e6d504e4ae039d527b8d"
 dependencies = [
+ "fastrand",
  "flume",
  "if-addrs",
  "log",
- "polling",
- "socket2 0.5.10",
+ "mio",
+ "socket-pktinfo",
+ "socket2 0.6.1",
 ]
 
 [[package]]
@@ -4280,23 +4242,6 @@ name = "mutually_exclusive_features"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94e1e6445d314f972ff7395df2de295fe51b71821694f0b0e1e79c4f12c8577"
-
-[[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 2.11.1",
- "security-framework-sys",
- "tempfile",
-]
 
 [[package]]
 name = "nix"
@@ -4468,48 +4413,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -4535,7 +4442,7 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.12.26",
 ]
 
 [[package]]
@@ -4550,7 +4457,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.12.26",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -4873,22 +4780,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "polling"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if",
- "concurrent-queue",
- "libc",
- "log",
- "pin-project-lite",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5208,6 +5099,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "fastbloom",
  "getrandom 0.3.4",
@@ -5580,6 +5472,40 @@ checksum = "3b4c14b2d9afca6a60277086b0cc6a6ae0b568f6f7916c943a8cdc79f8be240f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
  "encoding_rs",
  "futures-channel",
  "futures-core",
@@ -5590,21 +5516,22 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -5811,7 +5738,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.5.1",
+ "security-framework",
 ]
 
 [[package]]
@@ -5839,7 +5766,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.5.1",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -5938,19 +5865,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.10.0",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
 ]
 
 [[package]]
@@ -6263,6 +6177,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket-pktinfo"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927136cc2ae6a1b0e66ac6b1210902b75c3f726db004a73bc18686dcd0dcd22f"
+dependencies = [
+ "libc",
+ "socket2 0.6.1",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6686,16 +6611,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -7239,12 +7154,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -7970,15 +7879,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -8030,21 +7930,6 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -8084,12 +7969,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -8108,12 +7987,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -8129,12 +8002,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8168,12 +8035,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -8189,12 +8050,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8216,12 +8071,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -8237,12 +8086,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/icn/Cargo.toml
+++ b/icn/Cargo.toml
@@ -52,7 +52,7 @@ tonic = "0.14"
 prost = "0.14"
 
 # Discovery
-mdns-sd = "0.11"
+mdns-sd = "0.17"
 
 # Identity & Crypto
 ed25519-dalek = { version = "2.1", features = ["rand_core", "batch"] }
@@ -95,6 +95,9 @@ sys-locale = "0.3"
 # Error handling
 anyhow = "1.0"
 thiserror = "2.0"
+
+# HTTP client
+reqwest = { version = "0.13", features = ["json", "form"] }
 
 # Utilities
 bytes = "1.11"

--- a/icn/bins/icn-console/Cargo.toml
+++ b/icn/bins/icn-console/Cargo.toml
@@ -22,7 +22,7 @@ crossterm = "0.29"
 tokio = { version = "1", features = ["full"] }
 
 # HTTP client for gateway API
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { workspace = true }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/icn/bins/icnctl/Cargo.toml
+++ b/icn/bins/icnctl/Cargo.toml
@@ -34,7 +34,7 @@ tar = "0.4"
 walkdir = "2.4"
 chrono = "0.4"
 tempfile = "3.24"
-reqwest = { version = "0.12", features = ["blocking", "json"] }
+reqwest = { workspace = true, features = ["blocking"] }
 uuid = { version = "1.7", features = ["v4"] }
 
 # ICN crates

--- a/icn/crates/icn-federation/Cargo.toml
+++ b/icn/crates/icn-federation/Cargo.toml
@@ -43,7 +43,7 @@ sha2.workspace = true
 uuid = { version = "1", features = ["v4"] }
 
 # HTTP client for remote DID resolution
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { workspace = true }
 urlencoding = "2.1"
 
 [dev-dependencies]

--- a/icn/crates/icn-gateway/Cargo.toml
+++ b/icn/crates/icn-gateway/Cargo.toml
@@ -95,14 +95,14 @@ utoipa = { version = "4", features = ["actix_extras"] }
 utoipa-swagger-ui = { version = "6", features = ["actix-web"] }
 
 # HTTP client for FCM
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { workspace = true }
 
 # Email/SMTP
 lettre = { version = "0.11", default-features = false, features = ["tokio1-rustls-tls", "smtp-transport", "builder"] }
 
 [dev-dependencies]
 futures = "0.3"
-reqwest = "0.12"
+reqwest = { workspace = true }
 tempfile = "3"
 criterion = { version = "0.5", features = ["async_tokio"] }
 prometheus = "0.14"

--- a/icn/crates/icn-gateway/src/fcm_client.rs
+++ b/icn/crates/icn-gateway/src/fcm_client.rs
@@ -5,6 +5,7 @@
 
 use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
@@ -355,11 +356,10 @@ impl FcmClient {
         // Sign the JWT
         let jwt = self.sign_jwt(&claims)?;
 
-        // Exchange JWT for access token
-        let params = [
-            ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
-            ("assertion", &jwt),
-        ];
+        // Exchange JWT for access token (reqwest 0.13+ requires Serialize for form())
+        let mut params = HashMap::new();
+        params.insert("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer");
+        params.insert("assertion", jwt.as_str());
 
         let response = self
             .http_client

--- a/icn/crates/icn-gateway/src/security.rs
+++ b/icn/crates/icn-gateway/src/security.rs
@@ -244,17 +244,18 @@ where
                 // Content Security Policy
                 // Custom directives should use with_csp_directive(), which validates the input.
                 // Using unwrap_or with a safe fallback rather than expect() due to crate lint rules.
-                let csp_value = HeaderValue::from_str(&config.csp_directive).unwrap_or_else(|err| {
-                    // This should never happen with configs constructed via with_csp_directive(),
-                    // but provide a safe fallback for any invalid custom values.
-                    tracing::error!(
-                        error = ?err,
-                        directive_len = config.csp_directive.len(),
-                        "Invalid CSP directive in config - using restrictive default. \
-                         Prefer with_csp_directive() to construct validated custom directives."
-                    );
-                    HeaderValue::from_static("default-src 'none'")
-                });
+                let csp_value =
+                    HeaderValue::from_str(&config.csp_directive).unwrap_or_else(|err| {
+                        // This should never happen with configs constructed via with_csp_directive(),
+                        // but provide a safe fallback for any invalid custom values.
+                        tracing::error!(
+                            error = ?err,
+                            directive_len = config.csp_directive.len(),
+                            "Invalid CSP directive in config - using restrictive default. \
+                             Prefer with_csp_directive() to construct validated custom directives."
+                        );
+                        HeaderValue::from_static("default-src 'none'")
+                    });
                 headers.insert(
                     HeaderName::from_static("content-security-policy"),
                     csp_value,

--- a/icn/crates/icn-gateway/src/security.rs
+++ b/icn/crates/icn-gateway/src/security.rs
@@ -540,4 +540,46 @@ mod tests {
             "Development CSP should allow unsafe-eval for HMR"
         );
     }
+
+    #[test]
+    fn test_with_csp_directive_accepts_valid() {
+        let config = SecurityConfig::default();
+        let result = config.with_csp_directive("default-src 'self'".to_string());
+        assert!(result.is_ok());
+        let updated = result.unwrap();
+        assert_eq!(updated.csp_directive, "default-src 'self'");
+    }
+
+    #[test]
+    fn test_with_csp_directive_accepts_complex_policy() {
+        let config = SecurityConfig::default();
+        let complex_csp = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:".to_string();
+        let result = config.with_csp_directive(complex_csp.clone());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().csp_directive, complex_csp);
+    }
+
+    #[test]
+    fn test_with_csp_directive_rejects_newline() {
+        let config = SecurityConfig::default();
+        let result = config.with_csp_directive("default-src 'self'\nmalicious".to_string());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid CSP directive"));
+    }
+
+    #[test]
+    fn test_with_csp_directive_rejects_carriage_return() {
+        let config = SecurityConfig::default();
+        let result = config.with_csp_directive("default-src 'self'\rmalicious".to_string());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid CSP directive"));
+    }
+
+    #[test]
+    fn test_with_csp_directive_rejects_null_byte() {
+        let config = SecurityConfig::default();
+        let result = config.with_csp_directive("default-src\x00".to_string());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid CSP directive"));
+    }
 }

--- a/icn/crates/icn-gateway/src/security.rs
+++ b/icn/crates/icn-gateway/src/security.rs
@@ -74,6 +74,7 @@ impl Default for SecurityConfig {
 impl SecurityConfig {
     /// Validate and set a custom CSP directive.
     /// Returns an error if the directive contains invalid header characters.
+    #[must_use = "CSP directive validation result must be checked"]
     pub fn with_csp_directive(mut self, directive: String) -> Result<Self, String> {
         // Validate that the directive can be parsed as a header value
         actix_web::http::header::HeaderValue::from_str(&directive)
@@ -241,14 +242,16 @@ where
                 let headers = res.headers_mut();
 
                 // Content Security Policy
-                // SAFETY: Default CSP directives are hardcoded valid strings.
-                // Custom directives must use with_csp_directive() which validates the input.
+                // Custom directives should use with_csp_directive(), which validates the input.
                 // Using unwrap_or with a safe fallback rather than expect() due to crate lint rules.
-                let csp_value = HeaderValue::from_str(&config.csp_directive).unwrap_or_else(|_| {
-                    // This should never happen with validated configs, but provide safe fallback
+                let csp_value = HeaderValue::from_str(&config.csp_directive).unwrap_or_else(|err| {
+                    // This should never happen with configs constructed via with_csp_directive(),
+                    // but provide a safe fallback for any invalid custom values.
                     tracing::error!(
+                        error = ?err,
+                        directive_len = config.csp_directive.len(),
                         "Invalid CSP directive in config - using restrictive default. \
-                             Use with_csp_directive() to validate custom directives."
+                         Prefer with_csp_directive() to construct validated custom directives."
                     );
                     HeaderValue::from_static("default-src 'none'")
                 });

--- a/icn/crates/icn-gateway/src/security.rs
+++ b/icn/crates/icn-gateway/src/security.rs
@@ -72,6 +72,16 @@ impl Default for SecurityConfig {
 }
 
 impl SecurityConfig {
+    /// Validate and set a custom CSP directive.
+    /// Returns an error if the directive contains invalid header characters.
+    pub fn with_csp_directive(mut self, directive: String) -> Result<Self, String> {
+        // Validate that the directive can be parsed as a header value
+        actix_web::http::header::HeaderValue::from_str(&directive)
+            .map_err(|e| format!("Invalid CSP directive: {}", e))?;
+        self.csp_directive = directive;
+        Ok(self)
+    }
+
     /// Development configuration (permissive CORS for local development)
     pub fn development() -> Self {
         Self {
@@ -231,9 +241,17 @@ where
                 let headers = res.headers_mut();
 
                 // Content Security Policy
-                // SAFETY: csp_directive is validated at config load time
-                #[allow(clippy::unwrap_used)]
-                let csp_value = HeaderValue::from_str(&config.csp_directive).unwrap();
+                // SAFETY: Default CSP directives are hardcoded valid strings.
+                // Custom directives must use with_csp_directive() which validates the input.
+                // Using unwrap_or with a safe fallback rather than expect() due to crate lint rules.
+                let csp_value = HeaderValue::from_str(&config.csp_directive).unwrap_or_else(|_| {
+                    // This should never happen with validated configs, but provide safe fallback
+                    tracing::error!(
+                        "Invalid CSP directive in config - using restrictive default. \
+                             Use with_csp_directive() to validate custom directives."
+                    );
+                    HeaderValue::from_static("default-src 'none'")
+                });
                 headers.insert(
                     HeaderName::from_static("content-security-policy"),
                     csp_value,

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -314,14 +314,14 @@ impl GatewayServer {
             ));
         }
 
-        // SECURITY: Warn if JWT secret is too short
+        // SECURITY: Enforce minimum JWT secret length for HS256 security
         if self.jwt_secret.len() < 32 {
-            warn!(
-                "SECURITY WARNING: JWT secret is only {} bytes. \
-                 Recommended minimum is 32 bytes for HS256. \
-                 Tokens may be vulnerable to brute-force attacks.",
+            return Err(GatewayError::InternalError(format!(
+                "SECURITY: JWT secret is only {} bytes. \
+                 Minimum 32 bytes required for HS256 to resist brute-force attacks. \
+                 Generate a secure secret with: openssl rand -base64 32",
                 self.jwt_secret.len()
-            );
+            )));
         }
 
         // Create shared managers

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -1237,3 +1237,80 @@ fn get_static_dir() -> PathBuf {
     // Fallback to current directory
     PathBuf::from("static")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_jwt_secret_empty_fails_startup() {
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let server = GatewayServer::new(addr, vec![]);
+
+        let result = server.run().await;
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("empty JWT secret"),
+            "Expected empty JWT secret error, got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jwt_secret_too_short_fails_startup() {
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        // 16 bytes is too short (minimum is 32)
+        let short_secret = vec![0u8; 16];
+        let server = GatewayServer::new(addr, short_secret);
+
+        let result = server.run().await;
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("32 bytes required") || err_msg.contains("16 bytes"),
+            "Expected JWT secret length error, got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jwt_secret_31_bytes_fails_startup() {
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        // 31 bytes is still too short (minimum is 32)
+        let almost_enough = vec![0u8; 31];
+        let server = GatewayServer::new(addr, almost_enough);
+
+        let result = server.run().await;
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("32 bytes required") || err_msg.contains("31 bytes"),
+            "Expected JWT secret length error, got: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn test_jwt_secret_32_bytes_passes_validation() {
+        // This test verifies the validation logic allows 32+ byte secrets
+        // We can't fully test run() without starting a server, but we can
+        // verify the constructor accepts the secret
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let valid_secret = vec![0u8; 32];
+        let server = GatewayServer::new(addr, valid_secret.clone());
+
+        // The server should be created with the secret intact
+        assert_eq!(server.jwt_secret.len(), 32);
+    }
+
+    #[test]
+    fn test_jwt_secret_64_bytes_passes_validation() {
+        // Longer secrets should also work
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let long_secret = vec![0u8; 64];
+        let server = GatewayServer::new(addr, long_secret.clone());
+
+        assert_eq!(server.jwt_secret.len(), 64);
+    }
+}

--- a/icn/crates/icn-ledger/src/dynamic_limits.rs
+++ b/icn/crates/icn-ledger/src/dynamic_limits.rs
@@ -1025,9 +1025,14 @@ mod tests {
             let store = Arc::new(SledStore::open(temp_dir.path()).unwrap());
             let base_policy = CreditPolicy::conservative("hours".to_string());
             let config = DynamicLimitConfig::default();
-            let manager = DynamicCreditLimitManager::new(store, base_policy, config);
+            let manager = DynamicCreditLimitManager::new(store.clone(), base_policy, config);
 
             manager.record_activity(&did, "hours", 0.5, 1000).unwrap();
+
+            // Flush and explicitly drop store to release lock before reopening
+            store.flush().unwrap();
+            drop(manager);
+            drop(store);
         }
 
         // Create new manager with same store

--- a/icn/crates/icn-net/src/discovery.rs
+++ b/icn/crates/icn-net/src/discovery.rs
@@ -147,8 +147,9 @@ impl Discovery {
                 // Extract DID from TXT properties
                 if let Some(did_str) = info.get_property_val_str("did") {
                     // Parse socket address
+                    // mdns-sd 0.17+ returns ScopedIp; extract the IpAddr for SocketAddr
                     let addr = match info.get_addresses().iter().next() {
-                        Some(ip) => SocketAddr::new(*ip, info.get_port()),
+                        Some(scoped_ip) => SocketAddr::new(scoped_ip.to_ip_addr(), info.get_port()),
                         None => {
                             debug!("No address for peer {}", did_str);
                             return;

--- a/icn/crates/icn-rpc/Cargo.toml
+++ b/icn/crates/icn-rpc/Cargo.toml
@@ -13,7 +13,7 @@ tracing.workspace = true
 hyper.workspace = true
 hyper-util = "0.1"
 http-body-util = "0.1"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { workspace = true }
 sha2 = "0.10"
 hex = "0.4"
 base64 = "0.22"


### PR DESCRIPTION
## Summary
- Upgrades mdns-sd (0.11 → 0.17) and reqwest (0.12 → 0.13) with required code changes
- Enforces JWT secret minimum length (32 bytes) instead of just warning
- Adds validation for custom CSP directives with safe fallback

## Dependency Upgrades

### mdns-sd 0.11 → 0.17
- **Why**: Fixes IPv6 scoped address handling (`ScopedIp` type)
- **Impact**: Critical for correct peer discovery on multi-interface IPv6 networks
- **Code change**: `discovery.rs` - use `to_ip_addr()` method to extract `IpAddr`

### reqwest 0.12 → 0.13
- **Why**: Improved TLS security and modern HTTP standards
- **Impact**: Better transport security for FCM push notifications and external API calls
- **Code changes**: 
  - `fcm_client.rs` - use `HashMap` for form data (`.form()` API change)
  - Centralized reqwest in workspace `Cargo.toml`
  - Added `form` feature

## Security Hardening

### JWT Secret Enforcement
- **Before**: Only warned if JWT secret < 32 bytes
- **After**: Fails startup with clear error message and generation command
- **Why**: Weak JWT secrets can be brute-forced; 32 bytes provides adequate HS256 security

### CSP Header Validation
- Added `with_csp_directive()` method to validate custom directives at config time
- Fallback to restrictive `"default-src 'none'"` with error logging if invalid
- Prevents potential panic from invalid header characters

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace` passes
- [x] `cargo fmt --check` passes

## Risk
- **Low**: Both dependency upgrades are minor version bumps with contained code changes
- **Medium**: JWT secret enforcement may break existing deployments with weak secrets (intentional - they should upgrade)

---

🤖 Generated with [Claude Code](https://claude.ai/code)