### PR TITLE
feat(entity): add labor exchange types

### DIFF
--- a/icn/crates/icn-entity/src/labor_exchange.rs
+++ b/icn/crates/icn-entity/src/labor_exchange.rs
@@ -50,7 +50,7 @@ pub enum RoutingMode {
     ThroughHomeCoop,
     /// Credits go directly to the worker, home cooperative gets a fee.
     DirectToWorker,
-    /// Split between worker (direct) and home cooperative (0-100).
+    /// Split between worker (direct) and home cooperative (1-100, inclusive).
     Split { worker_pct: u8 },
 }
 
@@ -59,7 +59,7 @@ pub enum RoutingMode {
 pub struct CreditRouting {
     /// How credits flow.
     pub routing_mode: RoutingMode,
-    /// Home cooperative's coordination fee in basis points (0-10000).
+    /// Home cooperative's coordination fee in basis points (0-10000, inclusive).
     pub admin_fee_bps: u16,
     /// Whether host contributes to worker's home cooperative shares.
     pub share_contribution: bool,
@@ -103,9 +103,9 @@ impl RoutingMode {
     /// Validate routing configuration invariants.
     pub fn validate(&self) -> Result<()> {
         if let RoutingMode::Split { worker_pct } = self {
-            if *worker_pct > 100 {
+            if *worker_pct == 0 || *worker_pct > 100 {
                 return Err(EntityError::InvalidFormat(format!(
-                    "worker_pct must be between 0 and 100, got {worker_pct}"
+                    "worker_pct must be between 1 and 100, got {worker_pct}"
                 )));
             }
         }
@@ -331,7 +331,7 @@ mod tests {
         routing.validate().unwrap();
 
         let routing = CreditRouting {
-            routing_mode: RoutingMode::Split { worker_pct: 120 },
+            routing_mode: RoutingMode::Split { worker_pct: 0 },
             admin_fee_bps: 150,
             share_contribution: false,
         };
@@ -343,11 +343,21 @@ mod tests {
             share_contribution: false,
         };
         assert!(routing.validate().is_err());
+
+        let routing = CreditRouting {
+            routing_mode: RoutingMode::Split { worker_pct: 120 },
+            admin_fee_bps: 150,
+            share_contribution: false,
+        };
+        assert!(routing.validate().is_err());
     }
 
     #[test]
     fn test_assignment_date_validation() {
         let mut assignment = sample_assignment();
+        assignment.validate().unwrap();
+
+        assignment.end_date = None;
         assignment.validate().unwrap();
 
         assignment.end_date = Some(assignment.start_date);

--- a/icn/crates/icn-entity/src/labor_exchange.rs
+++ b/icn/crates/icn-entity/src/labor_exchange.rs
@@ -3,6 +3,7 @@
 //! These types model cooperative labor assignments, labor pools, and credit routing
 //! for inter-cooperative work arrangements.
 
+use crate::error::{EntityError, Result};
 use serde::{Deserialize, Serialize};
 
 // ============================================================================
@@ -49,7 +50,7 @@ pub enum RoutingMode {
     ThroughHomeCoop,
     /// Credits go directly to the worker, home cooperative gets a fee.
     DirectToWorker,
-    /// Split between worker (direct) and home cooperative.
+    /// Split between worker (direct) and home cooperative (0-100).
     Split { worker_pct: u8 },
 }
 
@@ -58,7 +59,7 @@ pub enum RoutingMode {
 pub struct CreditRouting {
     /// How credits flow.
     pub routing_mode: RoutingMode,
-    /// Home cooperative's coordination fee in basis points.
+    /// Home cooperative's coordination fee in basis points (0-10000).
     pub admin_fee_bps: u16,
     /// Whether host contributes to worker's home cooperative shares.
     pub share_contribution: bool,
@@ -88,7 +89,7 @@ pub struct LaborAssignment {
     pub assignment_type: AssignmentType,
     /// Start date (unix timestamp).
     pub start_date: u64,
-    /// End date (None for open-ended).
+    /// End date (None for open-ended, must be greater than start date).
     pub end_date: Option<u64>,
     /// Credit routing configuration.
     pub credit_routing: CreditRouting,
@@ -96,6 +97,50 @@ pub struct LaborAssignment {
     pub status: AssignmentStatus,
     /// Governance proposals (from both cooperatives).
     pub approvals: AssignmentApprovals,
+}
+
+impl RoutingMode {
+    /// Validate routing configuration invariants.
+    pub fn validate(&self) -> Result<()> {
+        if let RoutingMode::Split { worker_pct } = self {
+            if *worker_pct > 100 {
+                return Err(EntityError::InvalidFormat(format!(
+                    "worker_pct must be between 0 and 100, got {worker_pct}"
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl CreditRouting {
+    /// Validate routing configuration invariants.
+    pub fn validate(&self) -> Result<()> {
+        self.routing_mode.validate()?;
+        if self.admin_fee_bps > 10_000 {
+            return Err(EntityError::InvalidFormat(format!(
+                "admin_fee_bps must be between 0 and 10000, got {}",
+                self.admin_fee_bps
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl LaborAssignment {
+    /// Validate assignment invariants.
+    pub fn validate(&self) -> Result<()> {
+        self.credit_routing.validate()?;
+        if let Some(end_date) = self.end_date {
+            if end_date <= self.start_date {
+                return Err(EntityError::InvalidFormat(format!(
+                    "end_date must be greater than start_date (start_date={}, end_date={})",
+                    self.start_date, end_date
+                )));
+            }
+        }
+        Ok(())
+    }
 }
 
 // ============================================================================
@@ -200,6 +245,113 @@ mod tests {
         let json = serde_json::to_string(&assignment).unwrap();
         let parsed: LaborAssignment = serde_json::from_str(&json).unwrap();
         assert_eq!(assignment, parsed);
+    }
+
+    #[test]
+    fn test_assignment_type_roundtrip_variants() {
+        let variants = vec![
+            AssignmentType::Project {
+                project_id: "project-xyz".to_string(),
+            },
+            AssignmentType::Seasonal {
+                season: "winter".to_string(),
+            },
+            AssignmentType::Trial { duration_days: 90 },
+            AssignmentType::DualMembership,
+        ];
+
+        for variant in variants {
+            let json = serde_json::to_string(&variant).unwrap();
+            let parsed: AssignmentType = serde_json::from_str(&json).unwrap();
+            assert_eq!(variant, parsed);
+        }
+    }
+
+    #[test]
+    fn test_assignment_status_roundtrip_variants() {
+        let variants = vec![
+            AssignmentStatus::Proposed,
+            AssignmentStatus::Active,
+            AssignmentStatus::Completed {
+                completed_at: 1_700_000_000,
+            },
+            AssignmentStatus::Terminated {
+                at: 1_700_000_500,
+                reason: "mutual".to_string(),
+            },
+        ];
+
+        for variant in variants {
+            let json = serde_json::to_string(&variant).unwrap();
+            let parsed: AssignmentStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(variant, parsed);
+        }
+    }
+
+    #[test]
+    fn test_routing_mode_roundtrip_variants() {
+        let variants = vec![
+            RoutingMode::ThroughHomeCoop,
+            RoutingMode::DirectToWorker,
+            RoutingMode::Split { worker_pct: 50 },
+        ];
+
+        for variant in variants {
+            let json = serde_json::to_string(&variant).unwrap();
+            let parsed: RoutingMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(variant, parsed);
+        }
+    }
+
+    #[test]
+    fn test_availability_roundtrip_variants() {
+        let variants = vec![
+            Availability::Immediate,
+            Availability::FromDate(1_700_000_000),
+            Availability::Seasonal {
+                seasons: vec!["winter".to_string(), "summer".to_string()],
+            },
+            Availability::PartTime { hours_per_week: 20 },
+        ];
+
+        for variant in variants {
+            let json = serde_json::to_string(&variant).unwrap();
+            let parsed: Availability = serde_json::from_str(&json).unwrap();
+            assert_eq!(variant, parsed);
+        }
+    }
+
+    #[test]
+    fn test_credit_routing_validation() {
+        let routing = CreditRouting {
+            routing_mode: RoutingMode::Split { worker_pct: 80 },
+            admin_fee_bps: 150,
+            share_contribution: true,
+        };
+        routing.validate().unwrap();
+
+        let routing = CreditRouting {
+            routing_mode: RoutingMode::Split { worker_pct: 120 },
+            admin_fee_bps: 150,
+            share_contribution: false,
+        };
+        assert!(routing.validate().is_err());
+
+        let routing = CreditRouting {
+            routing_mode: RoutingMode::ThroughHomeCoop,
+            admin_fee_bps: 20_000,
+            share_contribution: false,
+        };
+        assert!(routing.validate().is_err());
+    }
+
+    #[test]
+    fn test_assignment_date_validation() {
+        let mut assignment = sample_assignment();
+        assignment.validate().unwrap();
+
+        assignment.end_date = Some(assignment.start_date);
+        assert!(assignment.validate().is_err());
     }
 
     #[test]

--- a/icn/crates/icn-entity/src/labor_exchange.rs
+++ b/icn/crates/icn-entity/src/labor_exchange.rs
@@ -1,0 +1,235 @@
+//! Labor exchange types for worker mobility between cooperatives.
+//!
+//! These types model cooperative labor assignments, labor pools, and credit routing
+//! for inter-cooperative work arrangements.
+
+use serde::{Deserialize, Serialize};
+
+// ============================================================================
+// Labor Assignments
+// ============================================================================
+
+/// Unique identifier for a labor assignment.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct AssignmentId(pub String);
+
+/// Type of labor assignment.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AssignmentType {
+    /// Fixed-term project work.
+    Project { project_id: String },
+    /// Seasonal or cyclical work.
+    Seasonal { season: String },
+    /// Trial period before potential membership.
+    Trial { duration_days: u32 },
+    /// Dual membership arrangement.
+    DualMembership,
+}
+
+/// Assignment status.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AssignmentStatus {
+    /// Proposed, awaiting governance approval.
+    Proposed,
+    /// Active assignment.
+    Active,
+    /// Completed normally.
+    Completed { completed_at: u64 },
+    /// Terminated early.
+    Terminated { at: u64, reason: String },
+}
+
+/// How credits earned at host flow to worker/home cooperative.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RoutingMode {
+    /// All credits go through home cooperative, which pays the worker.
+    ThroughHomeCoop,
+    /// Credits go directly to the worker, home cooperative gets a fee.
+    DirectToWorker,
+    /// Split between worker (direct) and home cooperative.
+    Split { worker_pct: u8 },
+}
+
+/// Credit routing configuration for an assignment.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CreditRouting {
+    /// How credits flow.
+    pub routing_mode: RoutingMode,
+    /// Home cooperative's coordination fee in basis points.
+    pub admin_fee_bps: u16,
+    /// Whether host contributes to worker's home cooperative shares.
+    pub share_contribution: bool,
+}
+
+/// Required approvals for a labor assignment.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AssignmentApprovals {
+    /// Governance proposal ID for the home cooperative.
+    pub home_coop_proposal: Option<String>,
+    /// Governance proposal ID for the host cooperative.
+    pub host_coop_proposal: Option<String>,
+}
+
+/// Worker assignment to a host cooperative.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LaborAssignment {
+    /// Unique identifier.
+    pub id: AssignmentId,
+    /// Worker being assigned (individual entity ID string).
+    pub worker: String,
+    /// Cooperative holding worker's primary membership.
+    pub home_coop: String,
+    /// Cooperative where work happens.
+    pub host_coop: String,
+    /// Type of assignment.
+    pub assignment_type: AssignmentType,
+    /// Start date (unix timestamp).
+    pub start_date: u64,
+    /// End date (None for open-ended).
+    pub end_date: Option<u64>,
+    /// Credit routing configuration.
+    pub credit_routing: CreditRouting,
+    /// Current status.
+    pub status: AssignmentStatus,
+    /// Governance proposals (from both cooperatives).
+    pub approvals: AssignmentApprovals,
+}
+
+// ============================================================================
+// Labor Pool
+// ============================================================================
+
+/// Worker registration in a labor pool.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PoolRegistration {
+    /// Worker entity ID string.
+    pub worker: String,
+    /// Home cooperative entity ID string.
+    pub home_coop: String,
+    /// Worker skills.
+    pub skills: Vec<String>,
+    /// Availability specification.
+    pub availability: Availability,
+    /// Registration timestamp (unix seconds).
+    pub registered_at: u64,
+}
+
+/// Availability specification for labor pool matching.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Availability {
+    /// Ready to start immediately.
+    Immediate,
+    /// Available from a specific date.
+    FromDate(u64),
+    /// Seasonal availability.
+    Seasonal { seasons: Vec<String> },
+    /// Part-time availability by hours per week.
+    PartTime { hours_per_week: u32 },
+}
+
+/// Open position in a labor pool.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LaborNeed {
+    /// Unique identifier.
+    pub id: String,
+    /// Cooperative requesting the worker.
+    pub requesting_coop: String,
+    /// Role description.
+    pub role: String,
+    /// Required skills for the role.
+    pub skills_required: Vec<String>,
+    /// Optional duration in days.
+    pub duration: Option<u32>,
+    /// Timestamp of posting.
+    pub posted_at: u64,
+}
+
+/// Labor pool for federation-wide coordination.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LaborPool {
+    /// Unique identifier.
+    pub id: String,
+    /// Federation managing this pool.
+    pub manager: String,
+    /// Available workers.
+    pub available_workers: Vec<PoolRegistration>,
+    /// Open positions.
+    pub open_needs: Vec<LaborNeed>,
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn sample_assignment() -> LaborAssignment {
+        LaborAssignment {
+            id: AssignmentId("assign-001".to_string()),
+            worker: "entity:icn:individual:worker-123".to_string(),
+            home_coop: "entity:icn:cooperative:home-coop".to_string(),
+            host_coop: "entity:icn:cooperative:host-coop".to_string(),
+            assignment_type: AssignmentType::Project {
+                project_id: "project-xyz".to_string(),
+            },
+            start_date: 1_700_000_000,
+            end_date: Some(1_700_086_400),
+            credit_routing: CreditRouting {
+                routing_mode: RoutingMode::Split { worker_pct: 80 },
+                admin_fee_bps: 150,
+                share_contribution: true,
+            },
+            status: AssignmentStatus::Proposed,
+            approvals: AssignmentApprovals {
+                home_coop_proposal: Some("proposal-home".to_string()),
+                host_coop_proposal: None,
+            },
+        }
+    }
+
+    #[test]
+    fn test_assignment_roundtrip() {
+        let assignment = sample_assignment();
+        let json = serde_json::to_string(&assignment).unwrap();
+        let parsed: LaborAssignment = serde_json::from_str(&json).unwrap();
+        assert_eq!(assignment, parsed);
+    }
+
+    #[test]
+    fn test_labor_pool_roundtrip() {
+        let registration = PoolRegistration {
+            worker: "entity:icn:individual:worker-123".to_string(),
+            home_coop: "entity:icn:cooperative:home-coop".to_string(),
+            skills: vec!["welding".to_string(), "maintenance".to_string()],
+            availability: Availability::Immediate,
+            registered_at: 1_700_000_100,
+        };
+
+        let need = LaborNeed {
+            id: "need-456".to_string(),
+            requesting_coop: "entity:icn:cooperative:host-coop".to_string(),
+            role: "Technician".to_string(),
+            skills_required: vec!["maintenance".to_string()],
+            duration: Some(30),
+            posted_at: 1_700_000_200,
+        };
+
+        let pool = LaborPool {
+            id: "pool-001".to_string(),
+            manager: "entity:icn:federation:midwest".to_string(),
+            available_workers: vec![registration],
+            open_needs: vec![need],
+        };
+
+        let json = serde_json::to_string(&pool).unwrap();
+        let parsed: LaborPool = serde_json::from_str(&json).unwrap();
+        assert_eq!(pool, parsed);
+    }
+}

--- a/icn/crates/icn-entity/src/lib.rs
+++ b/icn/crates/icn-entity/src/lib.rs
@@ -66,6 +66,7 @@
 //! # Modules
 //!
 //! - [`entity`] - Core types: `EntityId`, `EntityType`, `CooperativeEntity`
+//! - [`labor_exchange`] - Labor exchange types for worker mobility
 //! - [`membership`] - Membership types: `Membership`, `MembershipRole`
 //! - [`registry`] - Registry trait and in-memory implementation
 //! - [`lifecycle`] - Lifecycle events and state transitions
@@ -73,6 +74,7 @@
 
 pub mod entity;
 pub mod error;
+pub mod labor_exchange;
 pub mod lifecycle;
 pub mod membership;
 pub mod registry;
@@ -83,6 +85,10 @@ pub use entity::{
     AccountId, AccountReference, CooperativeEntity, EntityId, EntityStatus, EntityType,
 };
 pub use error::{EntityError, Result};
+pub use labor_exchange::{
+    AssignmentApprovals, AssignmentId, AssignmentStatus, AssignmentType, Availability,
+    CreditRouting, LaborAssignment, LaborNeed, LaborPool, PoolRegistration, RoutingMode,
+};
 pub use lifecycle::{EntityLifecycle, LifecycleEvent};
 pub use membership::{Membership, MembershipCapability, MembershipRole, MembershipStatus};
 pub use registry::{EntityRegistry, EntityRegistryHandle, InMemoryRegistry};

--- a/icn/crates/icn-entity/src/membership.rs
+++ b/icn/crates/icn-entity/src/membership.rs
@@ -855,6 +855,41 @@ mod tests {
     }
 
     #[test]
+    fn test_assignment_remove() {
+        let member = create_test_individual();
+        let coop = create_test_coop();
+        let mut membership = Membership::active(member, coop, MembershipRole::Worker);
+
+        membership.add_assignment("assign-001");
+        membership.add_assignment("assign-002");
+        assert_eq!(membership.assignments.len(), 2);
+
+        membership.remove_assignment("assign-001");
+        assert_eq!(membership.assignments.len(), 1);
+        assert!(!membership.assignments.contains(&"assign-001".to_string()));
+        assert!(membership.assignments.contains(&"assign-002".to_string()));
+    }
+
+    #[test]
+    fn test_assignment_duplicate_add() {
+        let member = create_test_individual();
+        let coop = create_test_coop();
+        let mut membership = Membership::active(member, coop, MembershipRole::Worker);
+
+        membership.add_assignment("assign-001");
+        let timestamp_after_first = membership.updated_at;
+
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        membership.add_assignment("assign-001");
+        assert_eq!(membership.assignments.len(), 1);
+        assert_eq!(
+            membership.updated_at, timestamp_after_first,
+            "Duplicate add should not update timestamp"
+        );
+    }
+
+    #[test]
     fn test_is_primary_default() {
         let member = create_test_individual();
         let coop = create_test_coop();

--- a/icn/crates/icn-entity/src/membership.rs
+++ b/icn/crates/icn-entity/src/membership.rs
@@ -50,6 +50,15 @@ pub struct Membership {
     pub notes: Option<String>,
 
     // ========================================
+    // Labor Exchange Fields (Issue #718)
+    // ========================================
+    /// Active labor assignments (working at other cooperatives).
+    ///
+    /// Stored as strings to avoid a dependency on labor exchange types.
+    #[serde(default)]
+    pub assignments: Vec<String>,
+
+    // ========================================
     // Labor Share Fields (Issue #390)
     // ========================================
     /// Labor share IDs held by this member (references `icn_ledger::ShareId`)
@@ -92,6 +101,7 @@ impl Membership {
             shares: 1, // Default to 1 share (one member, one vote)
             capabilities,
             notes: None,
+            assignments: Vec::new(),
             labor_shares: Vec::new(),
             is_primary: true, // Default to primary for single-coop workers
         }
@@ -164,6 +174,37 @@ impl Membership {
     }
 
     // ========================================
+    // Labor Assignment Methods (Issue #718)
+    // ========================================
+
+    /// Add an active labor assignment.
+    ///
+    /// Updates `updated_at` timestamp for audit trail accuracy.
+    pub fn add_assignment(&mut self, assignment_id: impl Into<String>) {
+        let assignment_id = assignment_id.into();
+        if !self.assignments.contains(&assignment_id) {
+            self.assignments.push(assignment_id);
+            self.updated_at = icn_time::current_timestamp_secs();
+        }
+    }
+
+    /// Remove a labor assignment.
+    ///
+    /// Updates `updated_at` timestamp for audit trail accuracy.
+    pub fn remove_assignment(&mut self, assignment_id: &str) {
+        let before_len = self.assignments.len();
+        self.assignments.retain(|id| id != assignment_id);
+        if self.assignments.len() != before_len {
+            self.updated_at = icn_time::current_timestamp_secs();
+        }
+    }
+
+    /// Check if member has any active labor assignments.
+    pub fn has_active_assignments(&self) -> bool {
+        !self.assignments.is_empty()
+    }
+
+    // ========================================
     // Labor Share Methods (Issue #390)
     // ========================================
 
@@ -229,6 +270,15 @@ impl Membership {
     /// update `updated_at`. Use `add_labor_share()` to modify after creation.
     pub fn with_labor_shares(mut self, shares: Vec<String>) -> Self {
         self.labor_shares = shares;
+        self
+    }
+
+    /// Builder method to add initial assignments.
+    ///
+    /// **Note:** Builder methods are for initial construction and do not
+    /// update `updated_at`. Use `add_assignment()` to modify after creation.
+    pub fn with_assignments(mut self, assignments: Vec<String>) -> Self {
+        self.assignments = assignments;
         self
     }
 }
@@ -699,6 +749,8 @@ mod tests {
         let coop = create_test_coop();
         let membership = Membership::new(member, coop, MembershipRole::Worker);
 
+        assert!(membership.assignments.is_empty());
+        assert!(!membership.has_active_assignments());
         assert!(membership.labor_shares.is_empty());
         assert!(!membership.has_labor_shares());
         assert_eq!(membership.labor_share_count(), 0);
@@ -778,6 +830,31 @@ mod tests {
     }
 
     #[test]
+    fn test_assignment_updates_timestamp() {
+        let member = create_test_individual();
+        let coop = create_test_coop();
+        let mut membership = Membership::active(member, coop, MembershipRole::Worker);
+        let original = membership.updated_at;
+
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        membership.add_assignment("assign-123");
+        assert!(
+            membership.updated_at >= original,
+            "add_assignment should update timestamp"
+        );
+
+        let after_add = membership.updated_at;
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        membership.remove_assignment("assign-123");
+        assert!(
+            membership.updated_at >= after_add,
+            "remove_assignment should update timestamp"
+        );
+    }
+
+    #[test]
     fn test_is_primary_default() {
         let member = create_test_individual();
         let coop = create_test_coop();
@@ -810,9 +887,11 @@ mod tests {
         let coop = create_test_coop();
         let membership = Membership::active(member, coop, MembershipRole::Worker)
             .with_labor_shares(vec!["share-001".to_string(), "share-002".to_string()])
+            .with_assignments(vec!["assign-001".to_string()])
             .with_primary(false);
 
         assert_eq!(membership.labor_share_count(), 2);
+        assert!(membership.has_active_assignments());
         assert!(!membership.is_primary);
     }
 
@@ -823,12 +902,14 @@ mod tests {
         let mut membership =
             Membership::active(member.clone(), coop.clone(), MembershipRole::Worker);
         membership.add_labor_share("share-xyz");
+        membership.add_assignment("assign-777");
         membership.set_primary(false);
 
         let json = serde_json::to_string(&membership).unwrap();
         let parsed: Membership = serde_json::from_str(&json).unwrap();
 
         assert_eq!(parsed.labor_shares, vec!["share-xyz".to_string()]);
+        assert_eq!(parsed.assignments, vec!["assign-777".to_string()]);
         assert!(!parsed.is_primary);
     }
 
@@ -851,6 +932,7 @@ mod tests {
         let parsed: Membership = serde_json::from_str(legacy_json).unwrap();
 
         // New fields should have defaults
+        assert!(parsed.assignments.is_empty());
         assert!(parsed.labor_shares.is_empty());
         assert!(parsed.is_primary);
     }


### PR DESCRIPTION
## Summary
- add labor exchange types and labor pool models
- export labor exchange module from icn-entity
- extend membership with assignment tracking

## Testing
- cargo build
- cargo test -p icn-entity
- cargo clippy -p icn-entity --all-targets --all-features -- -D warnings

Fixes #718