### PR TITLE
fix(ci): Fix doctest and disk space failures in CI

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: 'Show disk space before and after cleanup'
     required: false
     default: 'false'
+  aggressive:
+    description: 'Enable more aggressive cleanup (removes additional caches)'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -19,6 +23,7 @@ runs:
         fi
 
         echo "Removing preinstalled software to free space..."
+        # Large language runtimes and SDKs
         sudo rm -rf /usr/share/dotnet
         sudo rm -rf /usr/local/lib/android
         sudo rm -rf /opt/ghc
@@ -36,8 +41,42 @@ runs:
         sudo rm -rf /usr/local/share/vcpkg
         sudo rm -rf /usr/share/miniconda
         sudo rm -rf /imagegeneration
+
+        # Docker cleanup
         docker system prune -af || true
+
+        # APT cleanup
         sudo apt-get clean || true
+
+        # Additional large directories
+        sudo rm -rf /usr/share/az_* || true
+        sudo rm -rf /usr/share/gradle-* || true
+        sudo rm -rf /usr/share/kotlinc || true
+        sudo rm -rf /usr/share/sbt || true
+        sudo rm -rf /usr/local/julia* || true
+        sudo rm -rf /opt/pipx || true
+
+        if [ "${{ inputs.aggressive }}" = "true" ]; then
+          echo "Running aggressive cleanup..."
+          # Clear runner tool cache except what we need
+          sudo rm -rf /opt/hostedtoolcache/PyPy || true
+          sudo rm -rf /opt/hostedtoolcache/Java* || true
+
+          # Clear large documentation
+          sudo rm -rf /usr/share/doc/* || true
+          sudo rm -rf /usr/share/man/* || true
+
+          # Clear unused locales
+          sudo rm -rf /usr/share/locale/* || true
+
+          # Clear temporary files
+          sudo rm -rf /tmp/* || true
+          sudo rm -rf /var/tmp/* || true
+
+          # Clear package manager caches
+          sudo rm -rf /var/cache/apt/archives/* || true
+          sudo rm -rf /var/lib/apt/lists/* || true
+        fi
 
         if [ "${{ inputs.verbose }}" = "true" ]; then
           echo "Disk space after cleanup:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,9 @@ jobs:
 
       - name: Free disk space
         uses: ./.github/actions/free-disk-space
+        with:
+          verbose: 'true'
+          aggressive: 'true'
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -171,6 +174,16 @@ jobs:
 
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin --locked
+
+      - name: Pre-tarpaulin cleanup
+        run: |
+          echo "Cleaning build artifacts before tarpaulin..."
+          # Remove debug artifacts from cache - tarpaulin needs fresh instrumented builds
+          rm -rf ./icn/target/debug/deps || true
+          rm -rf ./icn/target/debug/build || true
+          rm -rf ./icn/target/debug/.fingerprint || true
+          # Show remaining space
+          df -h /
 
       - name: Generate coverage
         run: cargo tarpaulin --workspace --timeout 300 --out Xml --output-dir ./coverage

--- a/.github/workflows/docker-build-deploy.yml
+++ b/.github/workflows/docker-build-deploy.yml
@@ -33,34 +33,13 @@ jobs:
     # Skip test on scheduled runs (cleanup only)
     if: github.event_name != 'schedule'
     steps:
-      - name: Free disk space
-        run: |
-          echo "Disk space before cleanup:"
-          df -h /
-          echo "Removing preinstalled software to free space..."
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/local/share/powershell
-          sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/local/.ghcup
-          sudo rm -rf /usr/lib/jvm
-          sudo rm -rf /opt/microsoft
-          sudo rm -rf /opt/hostedtoolcache/go
-          sudo rm -rf /opt/hostedtoolcache/node
-          sudo rm -rf /opt/hostedtoolcache/Python
-          sudo rm -rf /opt/hostedtoolcache/Ruby
-          sudo rm -rf /usr/local/share/chromium
-          sudo rm -rf /usr/local/share/vcpkg
-          sudo rm -rf /usr/share/miniconda
-          sudo rm -rf /imagegeneration
-          docker system prune -af || true
-          sudo apt-get clean || true
-          echo "Disk space after cleanup:"
-          df -h /
-
       - uses: actions/checkout@v6
+
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
+        with:
+          verbose: 'true'
+          aggressive: 'true'
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/icn/crates/icn-trust/src/types.rs
+++ b/icn/crates/icn-trust/src/types.rs
@@ -316,9 +316,10 @@ impl TrustScore {
     /// let test_score = TrustScore::unchecked(0.8);
     ///
     /// // Good: After explicit clamping
-    /// let raw_value: f64 = some_calculation();
+    /// let raw_value: f64 = 1.5; // e.g., from some calculation
     /// let clamped = raw_value.clamp(0.0, 1.0);
     /// let score = TrustScore::unchecked(clamped);
+    /// assert_eq!(score.value(), 1.0);
     /// ```
     pub const fn unchecked(value: f64) -> Self {
         Self(value)


### PR DESCRIPTION
## Summary
Fixes CI failures on main:

1. **Doctest failure** - The doctest for `TrustScore::unchecked` referenced `some_calculation()` which doesn't exist. Replaced with a literal value that demonstrates the clamping pattern.

2. **Disk space failure** - Test Coverage job was failing with "No space left on device". Fixed by:
   - Adding `aggressive` option to the free-disk-space action for extra cleanup
   - Adding pre-tarpaulin cleanup step to remove cached build artifacts
   - Updating K3s workflow to use the shared cleanup action

## Test plan
- [x] Local doctest passes: `cargo test --doc -p icn-trust -- types::TrustScore::unchecked`
- [ ] CI Test Coverage job passes
- [ ] K3s Test job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)