### PR TITLE
feat(trust-app): Add trust app skeleton with TrustPolicyOracle

### DIFF
--- a/.claude/project_rules.md
+++ b/.claude/project_rules.md
@@ -1,0 +1,47 @@
+# ICN Development Rules
+
+## Architectural Rules
+
+### Rule 1: Meaning Firewall
+- Kernel crates MUST NOT import `icn-trust`, `icn-governance`, `icn-ccl` or any domain-specific crate
+- Apps import domain crates and expose generic `ConstraintSet` to kernel
+- Run firewall check: `grep -r 'use icn_trust::' crates/icn-{net,gateway,gossip,ledger}/src && exit 1`
+
+### Rule 2: PolicyOracle is Synchronous
+- `PolicyOracle::evaluate()` is sync by design
+- Use `parking_lot::RwLock` (not `tokio::sync::RwLock`) for app state accessed in evaluate()
+- Tech debt tracked in #874 for async migration
+
+### Rule 3: Reducer Purity
+- Reducers receive immutable `StateSnapshot`
+- Reducers return state delta, not mutated state
+- Reducers have NO access to async runtime, network, or time
+
+### Rule 4: Bootstrap Security
+- Genesis capabilities expire after 60 seconds
+- Running phase denies requests for unregistered domains
+- Never allow permanent backdoors
+
+## Code Review Checklist
+
+- [ ] No domain imports in kernel crates
+- [ ] PolicyOracle returns only generic constraints (no trust_score in custom)
+- [ ] Reducers are pure (no async, no side effects)
+- [ ] Error handling: log before fallback, never silent failures
+- [ ] Tests cover error paths, not just happy path
+- [ ] TTL/cache values have documented security trade-offs
+
+## Issue Labels
+
+- `kernel-api`: Changes to kernel primitive traits
+- `core`: Runtime, supervisor, dispatcher
+- `trust`: Trust graph and PolicyOracle
+- `ccl`: Cooperative Contract Language
+- `meaning-firewall`: Violations of kernel/app separation
+
+## PR Conventions
+
+- Title: `feat|fix|refactor(scope): description`
+- Scope: `kernel-api`, `core`, `trust-app`, `ccl`, `net`, `gateway`, `gossip`, `ledger`
+- Co-author: Include `Co-Authored-By: claude` for AI-assisted commits
+- Squash merge for feature PRs

--- a/.github/ISSUE_TEMPLATE/kernel_app_separation.md
+++ b/.github/ISSUE_TEMPLATE/kernel_app_separation.md
@@ -1,0 +1,31 @@
+---
+name: Kernel/App Separation Work
+about: Track extraction of domain logic from kernel to apps
+title: ''
+labels: ['core', 'architecture']
+assignees: ''
+---
+
+## Summary
+<!-- What domain logic is being extracted? -->
+
+## Current Location
+<!-- Which kernel crate(s) contain this logic? -->
+
+## Target Location
+<!-- Which app will own this logic? -->
+
+## Infection Points
+<!-- How many direct imports/usages exist? Use: grep -r 'pattern' crates/ | wc -l -->
+
+## Migration Pattern
+<!-- How will the kernel access this via PolicyOracle? -->
+
+## Acceptance Criteria
+- [ ] No domain imports in kernel crates
+- [ ] App implements PolicyOracle (if applicable)
+- [ ] All tests pass
+- [ ] Meaning firewall verification passes
+
+## Phase
+<!-- Which phase of kernel/app separation? -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -398,3 +398,84 @@ See [docs/production-hardening.md](docs/production-hardening.md) for complete de
 - Shutdown via `tokio::sync::broadcast`
 - Integration tests need unique ports per node
 - Vector clocks prevent duplicate gossip processing
+
+## Kernel/App Separation Architecture
+
+### The Meaning Firewall
+
+The kernel enforces constraints WITHOUT understanding their semantic origin. This is the core architectural principle.
+
+**Rule**: Domain semantics (trust scores, governance rules, membership criteria) stay in apps. Kernel only sees:
+- `ConstraintSet` (rate limits, credit multipliers, voting weights)
+- `PolicyDecision` (Allow/Deny)
+- Capabilities (bearer tokens)
+
+**Violation Detection**:
+```rust
+// VIOLATION - kernel code importing domain types
+use icn_trust::{TrustGraph, TrustClass};  // ❌ NEVER in kernel crates
+
+// CORRECT - kernel code using generic types
+use icn_kernel_api::{PolicyOracle, ConstraintSet};  // ✅
+```
+
+### PolicyOracle Pattern
+
+Apps implement `PolicyOracle` to provide domain-specific authorization:
+
+```rust
+impl PolicyOracle for TrustPolicyOracle {
+    fn evaluate(&self, request: &PolicyRequest) -> PolicyDecision {
+        // 1. Compute domain-specific value (trust score)
+        let score = self.graph.compute_trust_score(&actor);
+
+        // 2. Convert to generic constraints (MEANING FIREWALL BOUNDARY)
+        let constraints = ConstraintSet::new()
+            .with_rate_limit(score_to_rate_limit(score))
+            .with_credit_multiplier(score);
+
+        // 3. Return decision kernel can enforce blindly
+        PolicyDecision::Allow { constraints }
+    }
+}
+```
+
+### App Lifecycle
+
+```
+[Prepare] → [Install] → [Start] → [Stop] → [Uninstall]
+     ↓           ↓          ↓         ↓
+  Validate   Create     Spawn    Signal    Remove
+  manifest   state      task     shutdown  from
+             handles              +timeout  registry
+```
+
+### CCL (Cooperative Contract Language)
+
+CCL is the constitutional layer for governed entities:
+- **Entities**: Community, Cooperative, Federation, Individual
+- **Governance**: Bodies, decisions, delegation, thresholds
+- **Economics**: Capital, surplus allocation, credit policy
+- **Agreements**: Federation treaties, boundary protocols
+
+CCL documents are stored as state, interpreted by apps, and converted to `ConstraintSet` for kernel enforcement.
+
+### Bootstrap Phases
+
+1. **Genesis**: AllowAllOracle active, genesis capabilities can be issued
+2. **CoreApps**: First-party apps loading, trust oracle registering
+3. **Running**: Deny-by-default for unknown domains, full enforcement
+
+### Crate Organization
+
+**Kernel crates** (domain-agnostic):
+- `icn-kernel-api`: Primitive traits (PolicyOracle, State, Compute, Comms)
+- `icn-core`: Runtime, supervisor, dispatcher
+- `icn-net`, `icn-gateway`, `icn-gossip`: Network primitives
+
+**App crates** (domain-specific):
+- `apps/trust`: Trust graph → PolicyOracle
+- `apps/governance`: CCL governance → PolicyOracle (future)
+- `apps/membership`: Entity management (future)
+
+**Never import domain crates into kernel crates.**

--- a/apps/trust/Cargo.toml
+++ b/apps/trust/Cargo.toml
@@ -1,22 +1,43 @@
 [package]
-name = "icn-app-trust"
+name = "icn-trust-app"
 version = "0.1.0"
 edition = "2021"
-description = "ICN Trust App - Policy oracle for trust-based authorization"
+description = "Trust app - provides trust-based policy decisions for the ICN kernel"
 license = "MIT OR Apache-2.0"
+publish = false
 
 [dependencies]
-icn-core = { path = "../../icn/crates/icn-core" }
+# Kernel API for PolicyOracle trait and types
 icn-kernel-api = { path = "../../icn/crates/icn-kernel-api" }
+
+# Internal trust graph implementation (not exposed to kernel)
 icn-trust = { path = "../../icn/crates/icn-trust" }
-icn-identity = { path = "../../icn/crates/icn-identity" }
+
+# App runtime support
+icn-core = { path = "../../icn/crates/icn-core" }
+
+# Storage for trust state
 icn-store = { path = "../../icn/crates/icn-store" }
+
+# Identity types (for Did conversion)
+icn-identity = { path = "../../icn/crates/icn-identity" }
+
+# Async runtime
+async-trait = "0.1"
+tokio = { version = "1", features = ["sync"] }
+
+# Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-async-trait = "0.1"
-tokio = { version = "1.0", features = ["sync"] }
+
+# Sync primitives (for PolicyOracle sync requirement)
+parking_lot = "0.12"
+
+# Logging
 tracing = "0.1"
-ordered-float = "4.2"
 
 [dev-dependencies]
-tokio = { version = "1.0", features = ["full", "test-util"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tempfile = "3"
+ed25519-dalek = { version = "2.1", features = ["rand_core"] }
+rand = "0.8"

--- a/apps/trust/manifest.yaml
+++ b/apps/trust/manifest.yaml
@@ -42,8 +42,8 @@ state:
     - name: scores_cache
       max_keys: 5000
 
-# Compute handlers (TODO: Implement in Phase 2.2)
-# These are commented out until handlers are implemented to prevent runtime errors.
+# Compute handlers (TODO: See #877 for implementation)
+# Commented out until attestation_reducer and score_query are implemented.
 # compute:
 #   reducers:
 #     - name: attestation_reducer

--- a/apps/trust/manifest.yaml
+++ b/apps/trust/manifest.yaml
@@ -1,36 +1,57 @@
+# Trust App Manifest
+#
+# This app provides trust-based policy decisions for the ICN kernel.
+# It wraps the internal TrustGraph implementation and exposes it via
+# the PolicyOracle interface, maintaining the Meaning Firewall.
+
+schema_version: 1
 name: trust
 version: 0.1.0
-publisher: did:icn:system
+publisher: did:icn:icn-foundation
 
-description: >
-  Trust policy oracle for the ICN kernel/app separation architecture.
+description: |
+  Trust app providing trust-based policy decisions. The kernel calls this
+  app's PolicyOracle to get rate limits, credit multipliers, and other
+  constraints based on trust scores. The kernel never sees trust scores
+  directly - only the constraints derived from them.
 
-  Implements PolicyOracle to convert trust graph computations into
-  kernel-enforceable constraints (rate limits, credit multipliers,
-  voting weights). The kernel enforces these constraints without
-  understanding trust semantics.
-
+# Capabilities this app needs from the kernel
 capabilities_required:
   - state:kv:read:self
   - state:kv:write:self
+  - state:logs:append:self
 
+# Capabilities this app provides to others
 capabilities_provided:
   - oracle:trust:policy
 
+# State configuration
 state:
+  logs:
+    - name: attestations
+      ordering: causal
   kv:
+    # Edge stores scale with membership (1000+ members = 1M+ potential edges)
     - name: social_edges
+      max_keys: 100000
     - name: economic_edges
+      max_keys: 100000
     - name: technical_edges
-    - name: score_cache
+      max_keys: 100000
+    # Score cache only needs active peer working set
+    - name: scores_cache
+      max_keys: 5000
 
-compute:
-  reducers:
-    - name: trust_edge_reducer
-      event_type: trust:edge:update
-  services:
-    - name: trust_query
-      request_type: trust:query
+# Compute handlers (TODO: Implement in Phase 2.2)
+# These are commented out until handlers are implemented to prevent runtime errors.
+# compute:
+#   reducers:
+#     - name: attestation_reducer
+#       event_type: trust:attestation
+#   services:
+#     - name: score_query
+#       request_type: trust:query
 
+# Oracle configuration
 oracle:
   domain: trust

--- a/apps/trust/src/lib.rs
+++ b/apps/trust/src/lib.rs
@@ -1,532 +1,82 @@
-//! ICN Trust App
+//! Trust App
 //!
-//! Policy oracle for trust-based authorization in the ICN kernel/app separation.
+//! Provides trust-based policy decisions for the ICN kernel.
 //!
-//! # Purpose
+//! # The Meaning Firewall
 //!
-//! This app implements the trust domain's `PolicyOracle`, converting trust graph
-//! computations into kernel-enforceable constraints. The kernel enforces these
-//! constraints without understanding trust semantics (the "meaning firewall").
+//! This app wraps the internal `TrustGraph` implementation and exposes
+//! it via the `PolicyOracle` interface. The kernel never sees trust
+//! scores, trust classes, or any semantic trust concepts directly.
+//! It only sees the constraints derived from trust decisions.
 //!
 //! # Architecture
 //!
 //! ```text
-//! ┌─────────────────────────────────────────────────────────────────┐
-//! │                         Trust App                                │
-//! │  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐  │
-//! │  │ TrustEdgeReducer│  │ TrustQuerySvc   │  │ TrustPolicyOracle│ │
-//! │  │ (state updates) │  │ (score queries) │  │ (authz decisions)│ │
-//! │  └────────┬────────┘  └────────┬────────┘  └────────┬────────┘  │
-//! │           │                    │                    │            │
-//! │           ▼                    ▼                    ▼            │
-//! │  ┌─────────────────────────────────────────────────────────────┐│
-//! │  │                    MultiTrustGraph                          ││
-//! │  │  ┌───────────┐  ┌───────────────┐  ┌─────────────────────┐  ││
-//! │  │  │ Social    │  │ Economic      │  │ Technical           │  ││
-//! │  │  │ Graph     │  │ Graph         │  │ Graph               │  ││
-//! │  │  └───────────┘  └───────────────┘  └─────────────────────┘  ││
-//! │  └─────────────────────────────────────────────────────────────┘│
-//! └─────────────────────────────────────────────────────────────────┘
-//!                              │
-//!                              ▼ PolicyDecision
-//! ┌─────────────────────────────────────────────────────────────────┐
-//! │                         Kernel                                   │
-//! │  Enforces: rate_limit, credit_multiplier, voting_weight, etc.   │
-//! │  Does NOT understand: trust classes, graph semantics            │
-//! └─────────────────────────────────────────────────────────────────┘
+//! Kernel                    Trust App                    Internal
+//! ------                    ---------                    --------
+//! PolicyRequest  ────────>  TrustPolicyOracle  ───────>  TrustGraph
+//!                                   │
+//!                                   │ score_to_constraints()
+//!                                   │ (MEANING FIREWALL BOUNDARY)
+//!                                   v
+//! ConstraintSet  <────────  PolicyDecision
 //! ```
 //!
-//! # Usage
-//!
-//! ```ignore
-//! use icn_app_trust::{register_handlers, TrustPolicyOracle};
-//!
-//! // In app runtime initialization:
-//! let builder = runtime.prepare(manifest).await?;
-//! let builder = register_handlers(builder, graph.clone());
-//! runtime.install(builder, &caps).await?;
-//!
-//! // Oracle is automatically registered with OracleRegistry
-//! ```
+//! The kernel calls `PolicyOracle::evaluate()` and receives a `PolicyDecision`
+//! with `ConstraintSet`. It enforces these constraints without knowing they
+//! came from trust scores.
 
 pub mod oracle;
 
-use icn_core::apps::{
-    AppBuilder, DispatchError, Event, Reducer, Request, Response, Service, StateDelta,
-    StateSnapshot,
-};
-use icn_trust::{MultiTrustGraph, TrustEdge, TrustGraphType, TrustScore};
-use serde::{Deserialize, Serialize};
+use icn_core::apps::dispatcher::{BoxedReducer, BoxedService};
+use icn_core::apps::runtime::AppRuntime;
 use std::sync::Arc;
-use tokio::sync::{mpsc, RwLock};
-use tracing::debug;
 
-pub use oracle::{SimpleTrustOracle, TrustPolicyOracle};
+pub use oracle::TrustPolicyOracle;
 
-/// Trust edge update event payload.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct TrustEdgeUpdate {
-    /// Source DID (truster)
-    pub source: String,
-    /// Target DID (trustee)
-    pub target: String,
-    /// Trust score (0.0 to 1.0)
-    pub score: f64,
-    /// Which graph type (social, economic, technical)
-    pub graph_type: String,
-    /// Optional labels for the relationship
-    #[serde(default)]
-    pub labels: Vec<String>,
-    /// Optional expiration timestamp
-    pub expires_at: Option<u64>,
-}
-
-/// Trust query request.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct TrustQuery {
-    /// Query type: "score", "class", "edges", "all_trusted"
-    pub query_type: String,
-    /// Target DID for score/class queries
-    pub target: Option<String>,
-    /// Graph type filter (optional)
-    pub graph_type: Option<String>,
-    /// Threshold for "all_trusted" queries
-    pub threshold: Option<f64>,
-}
-
-/// Trust query response.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct TrustQueryResponse {
-    /// Trust score (for "score" query)
-    pub score: Option<f64>,
-    /// Trust class (for "class" query)
-    pub trust_class: Option<String>,
-    /// List of DIDs (for "edges" or "all_trusted" queries)
-    pub dids: Vec<String>,
-    /// Success indicator
-    pub success: bool,
-    /// Error message if any
-    pub error: Option<String>,
-}
-
-/// Trust edge reducer - updates trust graph from events.
+/// Register trust app handlers with the runtime.
 ///
-/// This reducer handles trust:edge:update events and applies them
-/// to the appropriate trust graph (social, economic, or technical).
-pub struct TrustEdgeReducer {
-    graph: Arc<RwLock<MultiTrustGraph>>,
-}
-
-impl TrustEdgeReducer {
-    /// Create a new trust edge reducer.
-    pub fn new(graph: Arc<RwLock<MultiTrustGraph>>) -> Self {
-        Self { graph }
-    }
-}
-
-impl Reducer for TrustEdgeReducer {
-    fn reduce(&self, _state: &StateSnapshot, event: &Event) -> Result<StateDelta, DispatchError> {
-        // Parse the update
-        let update: TrustEdgeUpdate = event.parse_payload()?;
-
-        debug!(
-            "Processing trust edge update: {} -> {} (score: {}, type: {})",
-            update.source, update.target, update.score, update.graph_type
-        );
-
-        // Validate score
-        if !(0.0..=1.0).contains(&update.score) {
-            return Err(DispatchError::Handler(format!(
-                "Invalid trust score: {} (must be 0.0-1.0)",
-                update.score
-            )));
-        }
-
-        // Parse graph type
-        let graph_type = match update.graph_type.to_lowercase().as_str() {
-            "social" => TrustGraphType::Social,
-            "economic" => TrustGraphType::EconomicReliability,
-            "technical" => TrustGraphType::TechnicalReliability,
-            _ => {
-                return Err(DispatchError::Handler(format!(
-                    "Invalid graph type: {} (must be social, economic, or technical)",
-                    update.graph_type
-                )));
-            }
-        };
-
-        // Parse DIDs
-        let source_did = icn_identity::Did::from_str(&update.source)
-            .map_err(|e| DispatchError::Handler(format!("Invalid source DID: {e}")))?;
-        let target_did = icn_identity::Did::from_str(&update.target)
-            .map_err(|e| DispatchError::Handler(format!("Invalid target DID: {e}")))?;
-
-        // Build trust edge
-        let mut edge = TrustEdge::new_typed(
-            source_did,
-            target_did,
-            TrustScore::unchecked(update.score),
-            graph_type,
-        );
-
-        for label in &update.labels {
-            edge = edge.with_label(label.clone());
-        }
-
-        if let Some(expires_at) = update.expires_at {
-            edge = edge.with_expiry(expires_at);
-        }
-
-        // Apply to graph (blocking) - use block_in_place for tokio compatibility
-        tokio::task::block_in_place(|| {
-            let mut graph = self.graph.blocking_write();
-            let typed_graph = match graph_type {
-                TrustGraphType::Social => graph.social_mut(),
-                TrustGraphType::EconomicReliability => graph.economic_mut(),
-                TrustGraphType::TechnicalReliability => graph.technical_mut(),
-            };
-
-            typed_graph
-                .add_edge(edge)
-                .map_err(|e| DispatchError::Handler(format!("Failed to add edge: {e}")))
-        })?;
-
-        // Create state delta for persistence
-        // Store a record in the appropriate KV store
-        let mut delta = StateDelta::new();
-
-        let store_name = match graph_type {
-            TrustGraphType::Social => "social_edges",
-            TrustGraphType::EconomicReliability => "economic_edges",
-            TrustGraphType::TechnicalReliability => "technical_edges",
-        };
-
-        let key = format!("{}:{}", update.source, update.target);
-        let value = serde_json::to_vec(&update)
-            .map_err(|e| DispatchError::Serialization(e.to_string()))?;
-
-        delta.kv_set(store_name, key, value);
-
-        Ok(delta)
-    }
-}
-
-/// Trust query service - handles trust score queries.
-pub struct TrustQueryService {
-    graph: Arc<RwLock<MultiTrustGraph>>,
-}
-
-impl TrustQueryService {
-    /// Create a new trust query service.
-    pub fn new(graph: Arc<RwLock<MultiTrustGraph>>) -> Self {
-        Self { graph }
-    }
-}
-
-#[async_trait::async_trait]
-impl Service for TrustQueryService {
-    async fn handle(
-        &self,
-        request: Request,
-        _state: &StateSnapshot,
-        _event_tx: mpsc::Sender<Event>,
-    ) -> Result<Response, DispatchError> {
-        let query: TrustQuery = request.parse_payload()?;
-
-        let response = match query.query_type.as_str() {
-            "score" => {
-                let target_str = query.target.ok_or_else(|| {
-                    DispatchError::Handler("Missing target for score query".to_string())
-                })?;
-
-                // Parse target as DID
-                let target = icn_identity::Did::from_str(&target_str)
-                    .map_err(|e| DispatchError::Handler(format!("Invalid DID: {e}")))?;
-
-                let graph = self.graph.read().await;
-                let score = graph
-                    .compute_combined_trust_score(&target)
-                    .unwrap_or_default();
-
-                TrustQueryResponse {
-                    score: Some(score),
-                    trust_class: None,
-                    dids: vec![],
-                    success: true,
-                    error: None,
-                }
-            }
-
-            "class" => {
-                let target_str = query.target.ok_or_else(|| {
-                    DispatchError::Handler("Missing target for class query".to_string())
-                })?;
-
-                // Parse target as DID
-                let target = icn_identity::Did::from_str(&target_str)
-                    .map_err(|e| DispatchError::Handler(format!("Invalid DID: {e}")))?;
-
-                let graph = self.graph.read().await;
-                let score = graph
-                    .compute_combined_trust_score(&target)
-                    .unwrap_or_default();
-
-                let class = icn_trust::TrustClass::from_score(score);
-
-                TrustQueryResponse {
-                    score: Some(score),
-                    trust_class: Some(format!("{class:?}")),
-                    dids: vec![],
-                    success: true,
-                    error: None,
-                }
-            }
-
-            "all_trusted" => {
-                let threshold = query.threshold.unwrap_or(0.1);
-                let graph = self.graph.read().await;
-
-                // Get all DIDs above threshold and convert to strings
-                let dids: Vec<String> = graph
-                    .social()
-                    .get_dids_above_threshold(threshold)
-                    .unwrap_or_default()
-                    .into_iter()
-                    .map(|d| d.to_string())
-                    .collect();
-
-                TrustQueryResponse {
-                    score: None,
-                    trust_class: None,
-                    dids,
-                    success: true,
-                    error: None,
-                }
-            }
-
-            _ => TrustQueryResponse {
-                score: None,
-                trust_class: None,
-                dids: vec![],
-                success: false,
-                error: Some(format!("Unknown query type: {}", query.query_type)),
-            },
-        };
-
-        Response::success_with(&request.id, &response)
-    }
-}
-
-/// Register trust app handlers with a builder.
-///
-/// This sets up:
-/// - TrustEdgeReducer for processing edge update events
-/// - TrustQueryService for handling trust queries
-/// - TrustPolicyOracle for authorization decisions
+/// Called by the supervisor during app startup.
 pub fn register_handlers(
-    builder: AppBuilder,
-    graph: Arc<RwLock<MultiTrustGraph>>,
-) -> AppBuilder {
-    let oracle = Arc::new(TrustPolicyOracle::new(graph.clone()));
+    _runtime: &AppRuntime,
+) -> (
+    Vec<(&'static str, BoxedReducer)>,
+    Vec<(&'static str, BoxedService)>,
+) {
+    // TODO: Implement attestation reducer and score query service
+    // For now, return empty - the main value is the PolicyOracle
+    (vec![], vec![])
+}
 
-    builder
-        .with_reducer("trust:edge:update", Box::new(TrustEdgeReducer::new(graph.clone())))
-        .with_service("trust:query", Box::new(TrustQueryService::new(graph)))
-        .with_oracle(oracle)
+/// Create a TrustPolicyOracle instance.
+///
+/// This is the main entry point for kernel integration.
+/// The kernel registers this oracle with the OracleRegistry.
+pub fn create_oracle(
+    trust_graph: Arc<parking_lot::RwLock<icn_trust::TrustGraph>>,
+) -> Arc<dyn icn_kernel_api::authz::PolicyOracle> {
+    Arc::new(TrustPolicyOracle::new(trust_graph))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icn_core::apps::{
-        AppNamespace, AppRuntime, KvConfig, Manifest, StateConfig, StateFactory, StateSnapshot,
-    };
-    use icn_identity::KeyPair;
-    use icn_kernel_api::authz::{Capability, Constraints};
-    use icn_kernel_api::bootstrap::{CapabilitySet, OracleRegistry};
-    use icn_store::SledStore;
 
-    fn root_caps() -> CapabilitySet {
-        let mut set = CapabilitySet::new();
-        set.add(Capability {
-            id: "root".to_string(),
-            resource: "*".to_string(),
-            action: "*".to_string(),
-            constraints: Constraints::default(),
-            holder: None,
-            issuer: "did:icn:root".to_string(),
-            expiration: u64::MAX,
-            signature: vec![],
-        });
-        set
-    }
+    #[test]
+    fn test_create_oracle() {
+        // Create a minimal trust graph for testing
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = icn_store::SledStore::open(temp_dir.path()).unwrap();
 
-    fn create_test_graph() -> Arc<RwLock<MultiTrustGraph>> {
-        let store = Arc::new(SledStore::temporary().unwrap());
-        let own_did = KeyPair::generate().unwrap().did().clone();
-        Arc::new(RwLock::new(MultiTrustGraph::new(store, own_did)))
-    }
+        // Create a valid test DID using ed25519 keygen
+        let keypair = ed25519_dalek::SigningKey::generate(&mut rand::thread_rng());
+        let own_did = icn_identity::Did::from_public_key(&keypair.verifying_key());
 
-    async fn create_empty_state() -> icn_core::apps::AppState {
-        let factory = StateFactory::new();
-        let namespace = AppNamespace::new("did:icn:test", "trust");
-        let config = StateConfig {
-            kv: vec![
-                KvConfig { name: "social_edges".to_string() },
-                KvConfig { name: "economic_edges".to_string() },
-                KvConfig { name: "technical_edges".to_string() },
-                KvConfig { name: "score_cache".to_string() },
-            ],
-            ..Default::default()
-        };
+        let graph = icn_trust::TrustGraph::new(std::sync::Arc::new(store), own_did);
 
-        factory
-            .create_for_app(namespace, &config)
-            .await
-            .expect("Failed to create state")
-    }
+        let oracle = create_oracle(Arc::new(parking_lot::RwLock::new(graph)));
 
-    const TRUST_MANIFEST: &str = include_str!("../manifest.yaml");
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_trust_edge_reducer() {
-        let store = Arc::new(SledStore::temporary().unwrap());
-        let alice = KeyPair::generate().unwrap().did().clone();
-        let bob = KeyPair::generate().unwrap().did().clone();
-
-        let graph = Arc::new(RwLock::new(MultiTrustGraph::new(store, alice.clone())));
-        let reducer = TrustEdgeReducer::new(graph.clone());
-
-        // Create edge update event with valid DIDs
-        let update = TrustEdgeUpdate {
-            source: alice.to_string(),
-            target: bob.to_string(),
-            score: 0.75,
-            graph_type: "social".to_string(),
-            labels: vec!["partner".to_string()],
-            expires_at: None,
-        };
-
-        let event = Event::with_payload("trust:edge:update", &update, "test")
-            .expect("Failed to create event");
-
-        // Create snapshot for reducer
-        let snapshot = StateSnapshot::from_app_state(&create_empty_state().await).await;
-
-        // Reduce
-        let delta = reducer.reduce(&snapshot, &event).expect("Reduce failed");
-
-        // Verify delta
-        assert_eq!(delta.kv_ops.len(), 1);
-
-        // Verify graph was updated
-        let g = graph.read().await;
-        let edge = g.social().get_edge(&alice, &bob).unwrap();
-
-        assert!(edge.is_some());
-        let edge = edge.unwrap();
-        assert_eq!(edge.score.value(), 0.75);
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_trust_query_service() {
-        let store = Arc::new(SledStore::temporary().unwrap());
-        let own_did = KeyPair::generate().unwrap().did().clone();
-        let peer_did = KeyPair::generate().unwrap().did().clone();
-
-        let graph = Arc::new(RwLock::new(MultiTrustGraph::new(store, own_did.clone())));
-
-        // Add trust edge
-        {
-            let mut g = graph.write().await;
-            g.social_mut()
-                .add_edge(TrustEdge::new(
-                    own_did.clone(),
-                    peer_did.clone(),
-                    TrustScore::unchecked(0.8),
-                ))
-                .unwrap();
-        }
-
-        let service = TrustQueryService::new(graph);
-
-        // Query score - use String for the target
-        let query = TrustQuery {
-            query_type: "score".to_string(),
-            target: Some(peer_did.to_string()),
-            graph_type: None,
-            threshold: None,
-        };
-
-        let request = Request::with_payload("trust:query", &query, "test")
-            .expect("Failed to create request");
-
-        let (tx, _rx) = mpsc::channel(1);
-        let snapshot = StateSnapshot::from_app_state(&create_empty_state().await).await;
-
-        let response = service
-            .handle(request, &snapshot, tx)
-            .await
-            .expect("Handle failed");
-
-        assert!(response.success);
-
-        let result: TrustQueryResponse = response.parse_payload().expect("Failed to parse");
-        assert!(result.success);
-        assert!(result.score.is_some());
-        // Combined score calculation:
-        // - Social: 0.8 * 0.6 (60/40 weighting) = 0.48, then * 0.5 (combined weight) = 0.24
-        // - Economic: 0.05 fallback * 0.3 = 0.015
-        // - Technical: 0.05 fallback * 0.2 = 0.01
-        // Total: 0.24 + 0.015 + 0.01 = 0.265
-        let score = result.score.unwrap();
-        assert!(score > 0.2 && score < 0.35, "Expected score ~0.265, got {}", score);
-    }
-
-    #[tokio::test]
-    async fn test_trust_app_manifest_parsing() {
-        let manifest = Manifest::parse(TRUST_MANIFEST).expect("Failed to parse manifest");
-
-        assert_eq!(manifest.name, "trust");
-        assert_eq!(manifest.version, "0.1.0");
-        assert!(manifest.capabilities_required.contains(&"state:kv:read:self".to_string()));
-        assert!(manifest.capabilities_provided.contains(&"oracle:trust:policy".to_string()));
-    }
-
-    #[tokio::test]
-    async fn test_trust_app_lifecycle() {
-        let registry = Arc::new(OracleRegistry::new());
-        let runtime = AppRuntime::new(registry.clone());
-
-        let manifest = Manifest::parse(TRUST_MANIFEST).expect("Failed to parse manifest");
-
-        // Prepare app
-        let builder = runtime.prepare(manifest).await.expect("Failed to prepare");
-
-        // Register handlers
-        let graph = create_test_graph();
-        let builder = register_handlers(builder, graph);
-
-        // Install
-        let app_id = runtime
-            .install(builder, &root_caps())
-            .await
-            .expect("Failed to install");
-
-        // Start
-        runtime.start(&app_id).await.expect("Failed to start");
-
-        // Verify oracle is registered
-        let oracle = registry.get(&icn_kernel_api::authz::Domain::trust());
-        assert!(oracle.domain() == icn_kernel_api::authz::Domain::trust());
-
-        // Stop
-        runtime.stop(&app_id).await.expect("Failed to stop");
-
-        // Uninstall
-        runtime
-            .uninstall(&app_id)
-            .await
-            .expect("Failed to uninstall");
+        // Verify oracle domain
+        assert_eq!(oracle.domain().as_str(), "trust");
     }
 }

--- a/apps/trust/src/oracle.rs
+++ b/apps/trust/src/oracle.rs
@@ -1,418 +1,363 @@
 //! Trust Policy Oracle
 //!
-//! Implements `PolicyOracle` to convert trust graph computations into
-//! kernel-enforceable constraints. The kernel enforces these constraints
-//! without understanding trust semantics (the "meaning firewall").
+//! Implements the PolicyOracle trait, converting trust semantics into
+//! kernel-enforceable constraints.
 //!
-//! # Trust-to-Constraint Mapping
+//! # The Meaning Firewall
 //!
-//! | Trust Score | Trust Class | Rate Limit | Credit Mult | Max Topics |
-//! |-------------|-------------|------------|-------------|------------|
-//! | 0.0 - 0.1   | Isolated    | 10 msg/s   | 0.1         | 5          |
-//! | 0.1 - 0.4   | Known       | 50 msg/s   | 0.5         | 25         |
-//! | 0.4 - 0.7   | Partner     | 100 msg/s  | 1.0         | 100        |
-//! | 0.7 - 1.0   | Federated   | 200 msg/s  | 2.0         | 500        |
+//! Everything above `score_to_constraints()` is trust semantics.
+//! Everything below is generic kernel constraints.
+//!
+//! The kernel never knows:
+//! - What a "trust score" is
+//! - What "Isolated", "Known", "Partner", "Federated" mean
+//! - How trust is computed
+//!
+//! It only knows:
+//! - Rate limits to enforce
+//! - Credit multipliers to apply
+//! - Topic limits to check
 
-use icn_identity::Did as IdentityDid;
 use icn_kernel_api::authz::{
-    ConstraintSet, ConstraintValue, Domain, PolicyDecision, PolicyOracle, PolicyRequest, RateLimit,
+    ActionKind, ConstraintSet, Domain, PolicyDecision, PolicyOracle, PolicyRequest, RateLimit,
 };
-use ordered_float::OrderedFloat;
-
-// Re-export for tests that need it
-#[cfg(test)]
-use icn_kernel_api::authz::ActionKind;
-use icn_trust::{MultiTrustGraph, TrustClass, TrustGraph};
+use icn_trust::TrustGraph;
+use parking_lot::RwLock;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::RwLock;
-use tracing::{debug, instrument};
 
-/// Trust policy oracle for ICN.
+/// Trust app's PolicyOracle implementation.
 ///
-/// Converts trust graph computations into kernel-enforceable constraints.
-/// This oracle:
-/// - Computes trust scores using the multi-graph architecture
-/// - Maps scores to trust classes
-/// - Returns constraints the kernel can enforce blindly
+/// This wraps TrustGraph internally but exposes only ConstraintSet to the kernel.
+/// The kernel never sees TrustGraph, TrustClass, or trust scores directly.
 ///
 /// # Thread Safety
 ///
-/// Uses `RwLock` for concurrent read access to trust graphs.
-/// Most operations are reads (score computation), writes are infrequent
-/// (edge updates via reducer).
+/// Uses `parking_lot::RwLock` instead of `tokio::sync::RwLock` because
+/// `PolicyOracle::evaluate()` is synchronous. This is intentional - see
+/// the tech debt note in the `PolicyOracle` trait documentation.
 pub struct TrustPolicyOracle {
-    /// The multi-graph containing social, economic, and technical trust
-    graph: Arc<RwLock<MultiTrustGraph>>,
-    /// Cache TTL for policy decisions (default: 60 seconds)
-    cache_ttl: Duration,
+    graph: Arc<RwLock<TrustGraph>>,
 }
 
 impl TrustPolicyOracle {
-    /// Create a new trust policy oracle.
-    pub fn new(graph: Arc<RwLock<MultiTrustGraph>>) -> Self {
-        Self {
-            graph,
-            cache_ttl: Duration::from_secs(60),
-        }
+    /// Create a new TrustPolicyOracle wrapping a TrustGraph.
+    pub fn new(graph: Arc<RwLock<TrustGraph>>) -> Self {
+        Self { graph }
     }
 
-    /// Create with custom cache TTL.
-    pub fn with_cache_ttl(graph: Arc<RwLock<MultiTrustGraph>>, cache_ttl: Duration) -> Self {
-        Self { graph, cache_ttl }
-    }
-
-    /// Compute combined trust score for an actor (async version).
+    /// Convert trust score to kernel-enforceable constraints.
     ///
-    /// Uses weighted combination of social, economic, and technical scores.
-    /// Converts from kernel's Did (String) to identity's Did for graph lookup.
+    /// # THIS IS THE MEANING FIREWALL BOUNDARY
     ///
-    /// Note: Currently unused as PolicyOracle::evaluate is sync. Will be used
-    /// when the oracle registry is made async-aware.
-    #[allow(dead_code)]
-    async fn compute_score(&self, actor: &str) -> f64 {
-        // Convert kernel Did (String) to identity Did
-        let identity_did = match IdentityDid::from_str(actor) {
-            Ok(did) => did,
-            Err(_) => return 0.0, // Invalid DID gets zero trust
+    /// Above this function: trust semantics (scores, classes, graph operations)
+    /// Below this function: generic kernel constraints (rate limits, multipliers)
+    ///
+    /// The kernel cannot determine WHY these constraint values were chosen.
+    ///
+    /// # Parameters
+    ///
+    /// - `score`: Trust score in range [0.0, 1.0]
+    /// - `_action`: Reserved for future per-action constraints (e.g., read-only peers
+    ///   could have different limits than writers). Currently unused but kept for
+    ///   forward compatibility.
+    fn score_to_constraints(&self, score: f64, _action: &ActionKind) -> ConstraintSet {
+        // Rate limiting based on trust score
+        // The kernel sees rate limits, not trust classes
+        //
+        // Rate limit tiers (from authz.rs):
+        //   unlimited: u32::MAX msg/s (Federated)
+        //   standard:  100 msg/s      (Partner)
+        //   throttled: 20 msg/s       (Known)
+        //   restricted: 5 msg/s       (Isolated)
+        let rate_limit = match score {
+            s if s >= 0.7 => RateLimit::unlimited(), // Federated class
+            s if s >= 0.4 => RateLimit::standard(),  // Partner class
+            s if s >= 0.1 => RateLimit::throttled(), // Known class
+            _ => RateLimit::restricted(),            // Isolated class
         };
 
-        let graph = self.graph.read().await;
-        graph
-            .compute_combined_trust_score(&identity_did)
-            .unwrap_or_default()
-    }
+        // Max topics aligned with rate limits
+        // Higher trust = more topic subscriptions allowed
+        // Rationale: topic count should scale with message capacity
+        let max_topics = match score {
+            s if s >= 0.7 => 500, // Federated: unlimited rate, many topics
+            s if s >= 0.4 => 100, // Partner: standard rate
+            s if s >= 0.1 => 25,  // Known: throttled rate
+            _ => 5,               // Isolated: restricted rate, minimal topics
+        };
 
-    /// Map trust score to rate limit constraints.
-    fn rate_limit_for_score(score: f64) -> RateLimit {
-        let trust_class = TrustClass::from_score(score);
-        match trust_class {
-            TrustClass::Isolated => RateLimit::new(10, 5),
-            TrustClass::Known => RateLimit::new(50, 15),
-            TrustClass::Partner => RateLimit::new(100, 25),
-            TrustClass::Federated => RateLimit::new(200, 50),
-        }
-    }
+        // TODO(Phase 2.2): max_connections will be enforced by icn-net
+        // after rate_limit.rs migration to PolicyOracle. Currently set but not enforced.
+        let max_connections = match score {
+            s if s >= 0.7 => 100,
+            s if s >= 0.4 => 50,
+            s if s >= 0.1 => 20,
+            _ => 5,
+        };
 
-    /// Map trust score to credit multiplier.
-    fn credit_multiplier_for_score(score: f64) -> f64 {
-        let trust_class = TrustClass::from_score(score);
-        match trust_class {
-            TrustClass::Isolated => 0.1,
-            TrustClass::Known => 0.5,
-            TrustClass::Partner => 1.0,
-            TrustClass::Federated => 2.0,
-        }
-    }
-
-    /// Map trust score to max topics.
-    fn max_topics_for_score(score: f64) -> u32 {
-        let trust_class = TrustClass::from_score(score);
-        match trust_class {
-            TrustClass::Isolated => 5,
-            TrustClass::Known => 25,
-            TrustClass::Partner => 100,
-            TrustClass::Federated => 500,
-        }
-    }
-
-    /// Map trust score to max connections.
-    fn max_connections_for_score(score: f64) -> u32 {
-        let trust_class = TrustClass::from_score(score);
-        match trust_class {
-            TrustClass::Isolated => 2,
-            TrustClass::Known => 10,
-            TrustClass::Partner => 50,
-            TrustClass::Federated => 100,
-        }
-    }
-
-    /// Build constraint set from trust score.
-    fn constraints_for_score(score: f64) -> ConstraintSet {
         ConstraintSet::new()
-            .with_rate_limit(Self::rate_limit_for_score(score))
-            .with_credit_multiplier(Self::credit_multiplier_for_score(score))
-            .with_max_topics(Self::max_topics_for_score(score))
-            .with_max_connections(Self::max_connections_for_score(score))
-            .with_voting_weight(score) // Voting weight equals trust score
-            .with_custom("trust_score", ConstraintValue::Float(OrderedFloat(score)))
-            .with_custom(
-                "trust_class",
-                ConstraintValue::String(format!("{:?}", TrustClass::from_score(score))),
-            )
-    }
-
-    /// Evaluate a request synchronously (blocking).
-    ///
-    /// This is used by the PolicyOracle trait which requires sync evaluation.
-    /// Uses `block_in_place` to safely block within a tokio runtime.
-    #[instrument(skip(self), fields(actor = %request.actor()))]
-    fn evaluate_sync(&self, request: &PolicyRequest) -> PolicyDecision {
-        // Convert kernel Did (String) to identity Did
-        let identity_did = match IdentityDid::from_str(request.actor()) {
-            Ok(did) => did,
-            Err(_) => {
-                // Invalid DID gets Isolated constraints (lowest trust)
-                return PolicyDecision::allow_with(Self::constraints_for_score(0.0));
-            }
-        };
-
-        // Use block_in_place to safely block within a tokio runtime
-        let score = tokio::task::block_in_place(|| {
-            let graph = self.graph.blocking_read();
-            graph
-                .compute_combined_trust_score(&identity_did)
-                .unwrap_or_default()
-        });
-
-        debug!(
-            "Trust score for {}: {} (class: {:?})",
-            request.actor(),
-            score,
-            TrustClass::from_score(score)
-        );
-
-        // Handle specific resource queries
-        if let Some(resource) = &request.ext.resource {
-            match resource.as_str() {
-                "score" => {
-                    // Caller wants just the score
-                    let constraints = ConstraintSet::new()
-                        .with_custom("trust_score", ConstraintValue::Float(OrderedFloat(score)));
-                    return PolicyDecision::allow_with(constraints);
-                }
-                "class" => {
-                    // Caller wants the trust class
-                    let constraints = ConstraintSet::new().with_custom(
-                        "trust_class",
-                        ConstraintValue::String(format!("{:?}", TrustClass::from_score(score))),
-                    );
-                    return PolicyDecision::allow_with(constraints);
-                }
-                _ => {}
-            }
-        }
-
-        // Default: return full constraints
-        let constraints = Self::constraints_for_score(score);
-        PolicyDecision::allow_with(constraints)
+            .with_rate_limit(rate_limit)
+            .with_max_topics(max_topics)
+            .with_max_connections(max_connections)
+            .with_credit_multiplier(score) // Direct multiplier from score
+            .with_voting_weight(score) // Direct weight from score
     }
 }
 
 impl PolicyOracle for TrustPolicyOracle {
     fn evaluate(&self, request: &PolicyRequest) -> PolicyDecision {
-        self.evaluate_sync(request)
-    }
+        let graph = self.graph.read();
 
-    fn cache_ttl(&self) -> Duration {
-        self.cache_ttl
-    }
-
-    fn handles_cross_org(&self) -> bool {
-        // Trust oracle can handle cross-org requests via federation
-        true
-    }
-
-    fn domain(&self) -> Domain {
-        Domain::trust()
-    }
-}
-
-/// Simplified trust oracle for single-graph deployments.
-///
-/// Use this when you don't need the multi-graph architecture.
-pub struct SimpleTrustOracle {
-    graph: Arc<RwLock<TrustGraph>>,
-    cache_ttl: Duration,
-}
-
-impl SimpleTrustOracle {
-    /// Create a new simple trust oracle.
-    pub fn new(graph: Arc<RwLock<TrustGraph>>) -> Self {
-        Self {
-            graph,
-            cache_ttl: Duration::from_secs(60),
-        }
-    }
-}
-
-impl PolicyOracle for SimpleTrustOracle {
-    fn evaluate(&self, request: &PolicyRequest) -> PolicyDecision {
-        // Convert kernel Did (String) to identity Did
-        let identity_did = match IdentityDid::from_str(request.actor()) {
+        // Convert kernel-api Did (String) to icn-identity Did
+        // This is a type boundary - kernel uses String DIDs, trust uses validated DIDs
+        let actor_did = match icn_identity::Did::from_str(&request.core.actor) {
             Ok(did) => did,
-            Err(_) => {
-                // Invalid DID gets Isolated constraints
-                return PolicyDecision::allow_with(TrustPolicyOracle::constraints_for_score(0.0));
+            Err(e) => {
+                // Invalid DID format - return minimal trust constraints
+                tracing::warn!(
+                    actor = %request.core.actor,
+                    error = %e,
+                    "Invalid DID format, returning minimal trust"
+                );
+                return PolicyDecision::allow_with(
+                    self.score_to_constraints(0.0, &request.core.action),
+                );
             }
         };
 
-        // Use block_in_place to safely block within a tokio runtime
-        let score = tokio::task::block_in_place(|| {
-            let graph = self.graph.blocking_read();
-            graph
-                .compute_trust_score(&identity_did)
-                .unwrap_or_default()
-        });
+        // Compute trust score internally (trust semantics stay here)
+        // Log errors (storage corruption, lock issues) before falling back to minimal trust
+        let score = match graph.compute_trust_score(&actor_did) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(
+                    actor = %request.core.actor,
+                    error = %e,
+                    "Failed to compute trust score, returning minimal trust"
+                );
+                0.0
+            }
+        };
 
-        let constraints = TrustPolicyOracle::constraints_for_score(score);
+        // Log for debugging (semantic info stays in app)
+        tracing::debug!(
+            actor = %request.core.actor,
+            score = %score,
+            domain = %request.core.domain,
+            action = ?request.core.action,
+            "Trust oracle evaluated request"
+        );
+
+        // Convert to constraints (kernel only sees this)
+        // THIS IS WHERE THE MEANING FIREWALL IS ENFORCED
+        let constraints = self.score_to_constraints(score, &request.core.action);
+
         PolicyDecision::allow_with(constraints)
-    }
-
-    fn cache_ttl(&self) -> Duration {
-        self.cache_ttl
     }
 
     fn domain(&self) -> Domain {
         Domain::trust()
+    }
+
+    fn cache_ttl(&self) -> Duration {
+        // Trust scores don't change frequently, cache for 30 seconds.
+        //
+        // Trade-off:
+        // - Shorter TTL (10-15s): Tighter security, faster response to trust changes
+        // - Longer TTL (60s+): Lower computation load, less responsive to changes
+        //
+        // 30s balances security and performance. In Phase 2.2, consider adding
+        // cache invalidation when trust edges change for immediate response.
+        Duration::from_secs(30)
+    }
+
+    fn handles_cross_org(&self) -> bool {
+        // Trust app handles federation trust bridging
+        true
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icn_identity::KeyPair;
     use icn_store::SledStore;
-    use icn_trust::TrustEdge;
+    use tempfile::tempdir;
 
-    fn create_test_graph() -> Arc<RwLock<MultiTrustGraph>> {
-        let store = Arc::new(SledStore::temporary().unwrap());
-        let own_did = KeyPair::generate().unwrap().did().clone();
-        Arc::new(RwLock::new(MultiTrustGraph::new(store, own_did)))
+    /// Create a minimal TrustPolicyOracle for testing.
+    ///
+    /// Note: The actual trust score for test subjects will be 0.0 (unknown)
+    /// since we're not adding edges. For constraint mapping tests, we test
+    /// `score_to_constraints` directly.
+    fn create_test_oracle() -> TrustPolicyOracle {
+        let temp_dir = tempdir().unwrap();
+        let store = SledStore::open(temp_dir.path()).unwrap();
+
+        // Create a valid test DID using ed25519 keygen
+        let keypair = ed25519_dalek::SigningKey::generate(&mut rand::thread_rng());
+        let own_did = icn_identity::Did::from_public_key(&keypair.verifying_key());
+
+        let graph = TrustGraph::new(std::sync::Arc::new(store), own_did);
+
+        TrustPolicyOracle::new(Arc::new(RwLock::new(graph)))
     }
 
-    #[test]
-    fn test_rate_limit_mapping() {
-        // Isolated: < 0.1
-        let rl = TrustPolicyOracle::rate_limit_for_score(0.05);
-        assert_eq!(rl.messages_per_second, 10);
-
-        // Known: 0.1 - 0.4
-        let rl = TrustPolicyOracle::rate_limit_for_score(0.25);
-        assert_eq!(rl.messages_per_second, 50);
-
-        // Partner: 0.4 - 0.7
-        let rl = TrustPolicyOracle::rate_limit_for_score(0.55);
-        assert_eq!(rl.messages_per_second, 100);
-
-        // Federated: >= 0.7
-        let rl = TrustPolicyOracle::rate_limit_for_score(0.85);
-        assert_eq!(rl.messages_per_second, 200);
-    }
+    // ================================================================
+    // Direct score_to_constraints tests (unit tests for meaning firewall)
+    // ================================================================
 
     #[test]
-    fn test_credit_multiplier_mapping() {
-        assert_eq!(TrustPolicyOracle::credit_multiplier_for_score(0.05), 0.1);
-        assert_eq!(TrustPolicyOracle::credit_multiplier_for_score(0.25), 0.5);
-        assert_eq!(TrustPolicyOracle::credit_multiplier_for_score(0.55), 1.0);
-        assert_eq!(TrustPolicyOracle::credit_multiplier_for_score(0.85), 2.0);
-    }
+    fn test_high_trust_score_gets_unlimited_rate() {
+        let oracle = create_test_oracle();
+        let constraints = oracle.score_to_constraints(0.8, &ActionKind::Write);
 
-    #[test]
-    fn test_constraints_for_score() {
-        let constraints = TrustPolicyOracle::constraints_for_score(0.55);
-
+        // High trust (>= 0.7) should get unlimited rate
         assert!(constraints.rate_limit.is_some());
-        assert_eq!(constraints.rate_limit.as_ref().unwrap().messages_per_second, 100);
-        assert_eq!(constraints.credit_multiplier, Some(1.0));
-        assert_eq!(constraints.max_topics, Some(100));
+        let rate = constraints.rate_limit.as_ref().unwrap();
+        assert_eq!(rate.messages_per_second, u32::MAX);
+        assert_eq!(constraints.max_topics, Some(500)); // Aligned with unlimited rate
+        assert_eq!(constraints.max_connections, Some(100));
+    }
+
+    #[test]
+    fn test_medium_trust_score_gets_standard_rate() {
+        let oracle = create_test_oracle();
+        let constraints = oracle.score_to_constraints(0.5, &ActionKind::Write);
+
+        // Medium trust (0.4-0.7) should get standard rate
+        assert!(constraints.rate_limit.is_some());
+        let rate = constraints.rate_limit.as_ref().unwrap();
+        assert_eq!(rate.messages_per_second, 100);
+        assert_eq!(constraints.max_topics, Some(100)); // Aligned with standard rate
         assert_eq!(constraints.max_connections, Some(50));
-        assert_eq!(constraints.voting_weight, Some(0.55));
-
-        // Check custom constraints
-        assert!(matches!(
-            constraints.custom.get("trust_score"),
-            Some(ConstraintValue::Float(s)) if (s.into_inner() - 0.55).abs() < 0.001
-        ));
-        assert!(matches!(
-            constraints.custom.get("trust_class"),
-            Some(ConstraintValue::String(s)) if s == "Partner"
-        ));
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_oracle_evaluate_unknown_actor() {
-        let graph = create_test_graph();
-        let oracle = TrustPolicyOracle::new(graph);
+    #[test]
+    fn test_low_trust_score_gets_throttled_rate() {
+        let oracle = create_test_oracle();
+        let constraints = oracle.score_to_constraints(0.2, &ActionKind::Write);
 
-        let unknown_did = KeyPair::generate().unwrap().did().clone();
-        // Convert identity Did to kernel Did (String)
-        let request = PolicyRequest::new(unknown_did.to_string(), ActionKind::Read, Domain::trust());
-
-        let decision = oracle.evaluate(&request);
-
-        // Unknown actor should get Isolated constraints
-        assert!(decision.is_allowed());
-        let constraints = decision.constraints().unwrap();
-        assert_eq!(constraints.rate_limit.as_ref().unwrap().messages_per_second, 10);
-        assert_eq!(constraints.credit_multiplier, Some(0.1));
+        // Low trust (0.1-0.4) should get throttled rate
+        assert!(constraints.rate_limit.is_some());
+        let rate = constraints.rate_limit.as_ref().unwrap();
+        assert_eq!(rate.messages_per_second, 20);
+        assert_eq!(constraints.max_topics, Some(25)); // Aligned with throttled rate
+        assert_eq!(constraints.max_connections, Some(20));
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_oracle_evaluate_with_trust() {
-        let store = Arc::new(SledStore::temporary().unwrap());
-        let own_did = KeyPair::generate().unwrap().did().clone();
-        let peer_did = KeyPair::generate().unwrap().did().clone();
+    #[test]
+    fn test_zero_trust_score_gets_restricted_rate() {
+        let oracle = create_test_oracle();
+        let constraints = oracle.score_to_constraints(0.05, &ActionKind::Write);
 
-        let graph = Arc::new(RwLock::new(MultiTrustGraph::new(store, own_did.clone())));
+        // Very low trust (< 0.1) should get restricted rate
+        assert!(constraints.rate_limit.is_some());
+        let rate = constraints.rate_limit.as_ref().unwrap();
+        assert_eq!(rate.messages_per_second, 5);
+        assert_eq!(constraints.max_topics, Some(5)); // Aligned with restricted rate
+        assert_eq!(constraints.max_connections, Some(5)); // Reduced for isolated peers
+    }
 
-        // Add trust edge
-        {
-            let mut g = graph.write().await;
-            g.social_mut()
-                .add_edge(TrustEdge::new(
-                    own_did.clone(),
-                    peer_did.clone(),
-                    icn_trust::TrustScore::unchecked(0.8),
-                ))
-                .unwrap();
+    #[test]
+    fn test_credit_multiplier_equals_score() {
+        let oracle = create_test_oracle();
+
+        for score in [0.0, 0.25, 0.5, 0.75, 1.0] {
+            let constraints = oracle.score_to_constraints(score, &ActionKind::Write);
+            assert_eq!(constraints.credit_multiplier, Some(score));
+            assert_eq!(constraints.voting_weight, Some(score));
         }
-
-        let oracle = TrustPolicyOracle::new(graph);
-        // Convert identity Did to kernel Did (String)
-        let request = PolicyRequest::new(peer_did.to_string(), ActionKind::Read, Domain::trust());
-
-        let decision = oracle.evaluate(&request);
-
-        // Peer should get constraints based on their trust score
-        assert!(decision.is_allowed());
-        let constraints = decision.constraints().unwrap();
-
-        // Combined score calculation with only social edge at 0.8:
-        // - Social: 0.8 * 0.6 (60/40 weighting) = 0.48, then * 0.5 (combined weight) = 0.24
-        // - Economic: 0.05 fallback * 0.3 = 0.015
-        // - Technical: 0.05 fallback * 0.2 = 0.01
-        // Total: ~0.265 -> Known class (0.1-0.4) -> 50 msg/s rate limit
-        assert_eq!(constraints.rate_limit.as_ref().unwrap().messages_per_second, 50);
     }
 
     #[test]
-    fn test_oracle_domain() {
-        let graph = create_test_graph();
-        let oracle = TrustPolicyOracle::new(graph);
+    fn test_meaning_firewall_constraint_set_is_generic() {
+        let oracle = create_test_oracle();
+        let constraints = oracle.score_to_constraints(0.5, &ActionKind::Read);
 
-        assert_eq!(oracle.domain(), Domain::trust());
+        // Verify response contains only generic constraints
+        // No TrustClass, no trust score explanation, no semantic meaning
+
+        // These are generic kernel constraints
+        assert!(constraints.rate_limit.is_some());
+        assert!(constraints.max_topics.is_some());
+        assert!(constraints.max_connections.is_some());
+        assert!(constraints.credit_multiplier.is_some());
+        assert!(constraints.voting_weight.is_some());
+
+        // The ConstraintSet struct has no field for "trust class" or "trust score"
+        // The kernel cannot tell WHY these values were chosen
     }
 
+    // ================================================================
+    // Oracle trait method tests
+    // ================================================================
+
     #[test]
-    fn test_oracle_cache_ttl() {
-        let graph = create_test_graph();
-        let oracle = TrustPolicyOracle::new(graph);
-
-        assert_eq!(oracle.cache_ttl(), Duration::from_secs(60));
-
-        let oracle_custom = TrustPolicyOracle::with_cache_ttl(
-            create_test_graph(),
-            Duration::from_secs(120),
-        );
-        assert_eq!(oracle_custom.cache_ttl(), Duration::from_secs(120));
+    fn test_oracle_domain_is_trust() {
+        let oracle = create_test_oracle();
+        assert_eq!(oracle.domain().as_str(), "trust");
     }
 
     #[test]
     fn test_oracle_handles_cross_org() {
-        let graph = create_test_graph();
-        let oracle = TrustPolicyOracle::new(graph);
-
+        let oracle = create_test_oracle();
         assert!(oracle.handles_cross_org());
+    }
+
+    #[test]
+    fn test_cache_ttl_is_30_seconds() {
+        let oracle = create_test_oracle();
+        assert_eq!(oracle.cache_ttl(), Duration::from_secs(30));
+    }
+
+    // ================================================================
+    // Full evaluate() flow tests
+    // ================================================================
+
+    #[test]
+    fn test_evaluate_unknown_actor_gets_zero_trust() {
+        let oracle = create_test_oracle();
+
+        // Create a valid test DID for the actor
+        let actor_keypair = ed25519_dalek::SigningKey::generate(&mut rand::thread_rng());
+        let actor_did = icn_identity::Did::from_public_key(&actor_keypair.verifying_key());
+
+        let request = PolicyRequest::new(
+            actor_did.as_str().to_string(),
+            ActionKind::Read,
+            Domain::trust(),
+        );
+
+        let decision = oracle.evaluate(&request);
+
+        // Unknown actor should still be allowed, but with minimal constraints
+        assert!(decision.is_allowed());
+
+        let constraints = decision.constraints().unwrap();
+        // Unknown actors get 0.0 trust score -> restricted rate
+        let rate = constraints.rate_limit.as_ref().unwrap();
+        assert_eq!(rate.messages_per_second, 5);
+    }
+
+    #[test]
+    fn test_evaluate_invalid_did_format_gets_zero_trust() {
+        let oracle = create_test_oracle();
+
+        // Invalid DID format (not a proper did:icn: format)
+        let request = PolicyRequest::new(
+            "not-a-valid-did".to_string(),
+            ActionKind::Write,
+            Domain::trust(),
+        );
+
+        let decision = oracle.evaluate(&request);
+
+        // Invalid DID should still be allowed, but with minimal constraints
+        assert!(decision.is_allowed());
+
+        let constraints = decision.constraints().unwrap();
+        // Invalid DID -> 0.0 trust -> restricted rate
+        let rate = constraints.rate_limit.as_ref().unwrap();
+        assert_eq!(rate.messages_per_second, 5);
     }
 }

--- a/apps/trust/src/oracle.rs
+++ b/apps/trust/src/oracle.rs
@@ -87,8 +87,8 @@ impl TrustPolicyOracle {
             _ => 5,               // Isolated: restricted rate, minimal topics
         };
 
-        // TODO(Phase 2.2): max_connections will be enforced by icn-net
-        // after rate_limit.rs migration to PolicyOracle. Currently set but not enforced.
+        // TODO(#868): max_connections will be enforced by icn-net after
+        // rate_limit.rs migration to PolicyOracle (Phase 2.2). Currently set but not enforced.
         let max_connections = match score {
             s if s >= 0.7 => 100,
             s if s >= 0.4 => 50,
@@ -167,8 +167,8 @@ impl PolicyOracle for TrustPolicyOracle {
         // - Shorter TTL (10-15s): Tighter security, faster response to trust changes
         // - Longer TTL (60s+): Lower computation load, less responsive to changes
         //
-        // 30s balances security and performance. In Phase 2.2, consider adding
-        // cache invalidation when trust edges change for immediate response.
+        // 30s balances security and performance. See #878 for cache invalidation
+        // when trust edges change (tighter security for immediate response).
         Duration::from_secs(30)
     }
 

--- a/icn/crates/icn-ccl/src/schema/economics.rs
+++ b/icn/crates/icn-ccl/src/schema/economics.rs
@@ -153,9 +153,13 @@ impl EconomicsSchema {
             for rule in &surplus.allocation {
                 // Parse fraction - for now, simple float parsing
                 // In production, would parse expressions properly
-                if let Ok(f) = rule.fraction.parse::<f64>() {
-                    total += f;
-                }
+                let f = rule.fraction.parse::<f64>().map_err(|e| {
+                    SchemaError::Validation(format!(
+                        "Invalid surplus allocation fraction '{}': {}",
+                        rule.fraction, e
+                    ))
+                })?;
+                total += f;
             }
             if total > 1.0 + f64::EPSILON {
                 return Err(SchemaError::Validation(format!(

--- a/icn/crates/icn-ccl/src/schema/entity.rs
+++ b/icn/crates/icn-ccl/src/schema/entity.rs
@@ -35,7 +35,7 @@ pub enum EntitySubtype {
     // Federation subtypes
     Trade,
     Geographic,
-    Sectoral2, // Different from community sectoral
+    FederationSectoral, // Different from community sectoral
     // Custom
     Custom(String),
 }


### PR DESCRIPTION
## Summary

Phase 2.1 of kernel/app separation - creates the trust app that wraps TrustGraph and exposes it through the PolicyOracle interface.

- **TrustPolicyOracle**: Implements `PolicyOracle` trait from icn-kernel-api
- **Meaning Firewall**: `score_to_constraints()` converts trust scores to generic kernel constraints
- **App manifest**: Capability declarations and state configuration

The kernel never sees trust scores, classes, or semantic trust concepts - only `ConstraintSet` with rate limits, credit multipliers, max topics, and voting weights.

## Dependencies

⚠️ **Must be merged after PR #855** - depends on PolicyOracle infrastructure and App Runtime.

## Test plan

- [x] All 12 trust app tests pass
- [x] Workspace builds successfully
- [ ] Rebase onto main after #855 merges

Closes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)