### PR TITLE
fix(trust-app): Allow type_complexity for register_handlers

### DIFF
--- a/apps/trust/src/lib.rs
+++ b/apps/trust/src/lib.rs
@@ -37,6 +37,7 @@ pub use oracle::TrustPolicyOracle;
 /// Register trust app handlers with the runtime.
 ///
 /// Called by the supervisor during app startup.
+#[allow(clippy::type_complexity)]
 pub fn register_handlers(
     _runtime: &AppRuntime,
 ) -> (


### PR DESCRIPTION
## Summary
- Adds `#[allow(clippy::type_complexity)]` to `register_handlers` function in trust app
- The return type is intentionally complex to match the dispatcher API

## Test plan
- [x] `cargo test -p icn-trust-app` passes (12 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.ai/code)