### PR TITLE
feat(compute): Scope-aware capacity budgets and placement

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -2841,6 +2841,7 @@ dependencies = [
  "icn-encoding",
  "icn-federation",
  "icn-identity",
+ "icn-kernel-api",
  "icn-obs",
  "icn-security",
  "icn-time",

--- a/icn/crates/icn-compute/Cargo.toml
+++ b/icn/crates/icn-compute/Cargo.toml
@@ -10,6 +10,7 @@ description = "Distributed compute layer for ICN"
 # ICN crates
 icn-encoding = { path = "../icn-encoding" }
 icn-identity = { path = "../icn-identity" }
+icn-kernel-api = { path = "../icn-kernel-api" }
 icn-time = { path = "../icn-time" }
 icn-trust = { path = "../icn-trust" }
 icn-ccl = { path = "../icn-ccl" }

--- a/icn/crates/icn-compute/benches/compute_bench.rs
+++ b/icn/crates/icn-compute/benches/compute_bench.rs
@@ -167,6 +167,7 @@ fn bench_placement_scoring(c: &mut Criterion) {
                     },
                     executing_tasks: HashMap::new(),
                     queue_depth: i,
+                    scope_queue_depths: HashMap::new(),
                 };
                 (did, state)
             })

--- a/icn/crates/icn-compute/examples/scheduler_demo.rs
+++ b/icn/crates/icn-compute/examples/scheduler_demo.rs
@@ -118,11 +118,22 @@ fn demo_gpu_placement() {
             capacity,
             executing_tasks: HashMap::new(),
             queue_depth,
+            scope_queue_depths: HashMap::new(),
         };
 
         // Empty locality hints and context for demo
         let empty_hints: Vec<icn_compute::LocalityHint> = vec![];
         let empty_ctx = icn_compute::LocalityContext::empty();
+        let scope_ctx = icn_compute::ScopeContext::empty();
+        let request = icn_compute::PlacementRequest {
+            task_hash,
+            resource_profile: task_profile.clone(),
+            locality_hints: vec![],
+            max_cost: None,
+            requested_at: 0,
+            max_scope: None,
+            cell_affinity: None,
+        };
 
         match policy.score_task(
             &task_hash,
@@ -132,6 +143,8 @@ fn demo_gpu_placement() {
             trust,
             &empty_hints,
             &empty_ctx,
+            &scope_ctx,
+            &request,
         ) {
             Some(offer) => {
                 println!("  {}: score = {:.3}", did, offer.score);

--- a/icn/crates/icn-compute/examples/scheduler_demo.rs
+++ b/icn/crates/icn-compute/examples/scheduler_demo.rs
@@ -122,7 +122,6 @@ fn demo_gpu_placement() {
         };
 
         // Empty locality hints and context for demo
-        let empty_hints: Vec<icn_compute::LocalityHint> = vec![];
         let empty_ctx = icn_compute::LocalityContext::empty();
         let scope_ctx = icn_compute::ScopeContext::empty();
         let request = icn_compute::PlacementRequest {
@@ -136,15 +135,12 @@ fn demo_gpu_placement() {
         };
 
         match policy.score_task(
-            &task_hash,
-            &task_profile,
+            &request,
             "did:icn:submitter",
             &node_state,
             trust,
-            &empty_hints,
             &empty_ctx,
             &scope_ctx,
-            &request,
         ) {
             Some(offer) => {
                 println!("  {}: score = {:.3}", did, offer.score);

--- a/icn/crates/icn-compute/src/actor/lifecycle.rs
+++ b/icn/crates/icn-compute/src/actor/lifecycle.rs
@@ -1144,6 +1144,8 @@ impl ComputeActor {
                     locality_hints: vec![],      // Future enhancement
                     max_cost: task.payment_rate, // Use payment_rate as max cost
                     requested_at: now,
+                    max_scope: None,     // TODO: populate from task constraints
+                    cell_affinity: None, // TODO: populate from task constraints
                 });
             } else {
                 // Phase 15: Legacy immediate claiming

--- a/icn/crates/icn-compute/src/actor/mod.rs
+++ b/icn/crates/icn-compute/src/actor/mod.rs
@@ -676,6 +676,8 @@ impl ComputeActor {
                 locality_hints,
                 max_cost,
                 requested_at,
+                max_scope,
+                cell_affinity,
             } => {
                 self.on_placement_request(
                     task_hash,
@@ -684,6 +686,8 @@ impl ComputeActor {
                     locality_hints,
                     max_cost,
                     requested_at,
+                    max_scope,
+                    cell_affinity,
                 )
                 .await
             }

--- a/icn/crates/icn-compute/src/actor/placement.rs
+++ b/icn/crates/icn-compute/src/actor/placement.rs
@@ -100,6 +100,8 @@ impl ComputeActor {
         locality_hints: Vec<crate::scheduler::LocalityHint>,
         _max_cost: Option<u64>,
         requested_at: u64,
+        max_scope: Option<icn_kernel_api::ScopeLevel>,
+        cell_affinity: Option<icn_kernel_api::CellId>,
     ) -> Result<(), ComputeError> {
         let task_hash_str = hex::encode(task_hash);
 
@@ -324,21 +326,18 @@ impl ComputeActor {
             locality_hints: locality_hints.clone(),
             max_cost: _max_cost,
             requested_at,
-            max_scope: None,
-            cell_affinity: None,
+            max_scope,
+            cell_affinity,
         };
 
         // Score the task
         let offer = match policy.score_task(
-            &task_hash,
-            &resource_profile,
+            &placement_request,
             &submitter,
             &node_state,
             our_trust,
-            &locality_hints,
             &locality_ctx,
             &scope_ctx,
-            &placement_request,
         ) {
             Some(o) => o,
             None => {
@@ -962,6 +961,8 @@ impl ComputeActor {
                 locality_hints: vec![],
                 max_cost: Some(payment.amount),
                 requested_at,
+                max_scope: None,     // TODO: populate from federated task constraints
+                cell_affinity: None, // TODO: populate from federated task constraints
             });
         }
 

--- a/icn/crates/icn-compute/src/actor/placement.rs
+++ b/icn/crates/icn-compute/src/actor/placement.rs
@@ -153,6 +153,7 @@ impl ComputeActor {
                 .get(&self.own_did)
                 .map(|i| i.tasks_executing)
                 .unwrap_or(0),
+            scope_queue_depths: HashMap::new(),
         };
         drop(registry);
 
@@ -310,6 +311,20 @@ impl ComputeActor {
             }
         }
 
+        // Build scope context (default to Commons until CellService integration)
+        let scope_ctx = crate::scheduler::ScopeContext::empty();
+
+        // Build a PlacementRequest for the scoring call
+        let placement_request = crate::scheduler::PlacementRequest {
+            task_hash,
+            resource_profile: resource_profile.clone(),
+            locality_hints: locality_hints.clone(),
+            max_cost: _max_cost,
+            requested_at,
+            max_scope: None,
+            cell_affinity: None,
+        };
+
         // Score the task
         let offer = match policy.score_task(
             &task_hash,
@@ -319,6 +334,8 @@ impl ComputeActor {
             our_trust,
             &locality_hints,
             &locality_ctx,
+            &scope_ctx,
+            &placement_request,
         ) {
             Some(o) => o,
             None => {

--- a/icn/crates/icn-compute/src/actor/placement.rs
+++ b/icn/crates/icn-compute/src/actor/placement.rs
@@ -311,7 +311,10 @@ impl ComputeActor {
             }
         }
 
-        // Build scope context (default to Commons until CellService integration)
+        // TODO(icn-compute#921): Integrate CellService to populate scope context.
+        // Once CellService is wired into ComputeActor, use it to determine
+        // peer_scope (via cell_service.peer_scope(&submitter)) and executor_cell
+        // (via cell_service.local_cell()) instead of defaulting to Commons.
         let scope_ctx = crate::scheduler::ScopeContext::empty();
 
         // Build a PlacementRequest for the scoring call

--- a/icn/crates/icn-compute/src/actor/tests.rs
+++ b/icn/crates/icn-compute/src/actor/tests.rs
@@ -422,7 +422,7 @@ async fn test_placement_negotiation_multi_executor() {
 async fn test_locality_aware_placement_scoring() {
     use crate::scheduler::{
         DefaultPlacementPolicy, LocalityContext, LocalityHint, NodeCapacity, NodeState,
-        PlacementPolicy, ResourceProfile,
+        PlacementPolicy, PlacementRequest, ResourceProfile, ScopeContext,
     };
 
     // Create task requiring compute resources
@@ -442,12 +442,24 @@ async fn test_locality_aware_placement_scoring() {
         updated_at: 0,
     };
 
+    let scope_ctx = ScopeContext::empty();
+    let request = PlacementRequest {
+        task_hash,
+        resource_profile: profile.clone(),
+        locality_hints: vec![],
+        max_cost: None,
+        requested_at: 0,
+        max_scope: None,
+        cell_affinity: None,
+    };
+
     // Executor A: High trust (0.8), no locality information
     let node_a = NodeState {
         did: "did:icn:executor-a".to_string(),
         capacity: capacity.clone(),
         executing_tasks: std::collections::HashMap::new(),
         queue_depth: 0,
+        scope_queue_depths: std::collections::HashMap::new(),
     };
     let locality_a = LocalityContext::empty();
 
@@ -457,6 +469,7 @@ async fn test_locality_aware_placement_scoring() {
         capacity: capacity.clone(),
         executing_tasks: std::collections::HashMap::new(),
         queue_depth: 0,
+        scope_queue_depths: std::collections::HashMap::new(),
     };
     let locality_b = LocalityContext {
         submitter_rtt_ms: Some(10), // 10ms RTT
@@ -472,6 +485,7 @@ async fn test_locality_aware_placement_scoring() {
         capacity: capacity.clone(),
         executing_tasks: std::collections::HashMap::new(),
         queue_depth: 0,
+        scope_queue_depths: std::collections::HashMap::new(),
     };
     let locality_c = LocalityContext {
         submitter_rtt_ms: None,
@@ -487,6 +501,7 @@ async fn test_locality_aware_placement_scoring() {
         capacity: capacity.clone(),
         executing_tasks: std::collections::HashMap::new(),
         queue_depth: 0,
+        scope_queue_depths: std::collections::HashMap::new(),
     };
     let locality_d = LocalityContext {
         submitter_rtt_ms: Some(15), // 15ms RTT
@@ -508,6 +523,8 @@ async fn test_locality_aware_placement_scoring() {
             0.8,
             &no_hints,
             &locality_a,
+            &scope_ctx,
+            &request,
         )
         .unwrap();
 
@@ -520,6 +537,8 @@ async fn test_locality_aware_placement_scoring() {
             0.6,
             &no_hints,
             &locality_b,
+            &scope_ctx,
+            &request,
         )
         .unwrap();
 
@@ -532,6 +551,8 @@ async fn test_locality_aware_placement_scoring() {
             0.6,
             &no_hints,
             &locality_c,
+            &scope_ctx,
+            &request,
         )
         .unwrap();
 
@@ -544,6 +565,8 @@ async fn test_locality_aware_placement_scoring() {
             0.4,
             &no_hints,
             &locality_d,
+            &scope_ctx,
+            &request,
         )
         .unwrap();
 
@@ -565,20 +588,22 @@ async fn test_locality_aware_placement_scoring() {
         offer_d.score
     );
 
-    // Analysis: With rebalanced weights (Phase 16C Week 3):
-    // - Trust: 25% (was 40%)
-    // - Capacity: 20%
-    // - Queue: 15%
-    // - RTT: 15% (NEW)
-    // - Data locality: 15% (NEW)
-    // - Hints: 10% (NEW)
+    // Analysis: With scope-aware weights:
+    // - Trust: 20%
+    // - Capacity: 15%
+    // - Queue: 10%
+    // - RTT: 10%
+    // - Data locality: 10%
+    // - Scope affinity: 15% (all Commons = 0.00 here)
+    // - Cell affinity: 5%
+    // - Hints: 5%
     // - Jitter: 10%
 
-    // Expected scoring breakdown (approximate, excluding jitter):
-    // Executor A: trust(0.20) + capacity(0.20) + queue(0.15) = 0.55
-    // Executor B: trust(0.15) + capacity(0.20) + queue(0.15) + rtt(0.148) = 0.648
-    // Executor C: trust(0.15) + capacity(0.20) + queue(0.15) + data(0.15) = 0.65
-    // Executor D: trust(0.10) + capacity(0.20) + queue(0.15) + rtt(0.145) + data(0.15) = 0.745
+    // Expected scoring breakdown (approximate, excluding jitter, all Commons scope):
+    // Executor A: trust(0.16) + capacity(0.15) + queue(0.10) + scope(0.00) = 0.41
+    // Executor B: trust(0.12) + capacity(0.15) + queue(0.10) + rtt(0.098) + scope(0.00) = 0.468
+    // Executor C: trust(0.12) + capacity(0.15) + queue(0.10) + data(0.10) + scope(0.00) = 0.47
+    // Executor D: trust(0.08) + capacity(0.15) + queue(0.10) + rtt(0.097) + data(0.10) + scope(0.00) = 0.527
 
     // Verify that locality factors make a significant difference
     // Executor B (good RTT) should beat A (higher trust but no locality)

--- a/icn/crates/icn-compute/src/actor/tests.rs
+++ b/icn/crates/icn-compute/src/actor/tests.rs
@@ -330,6 +330,8 @@ async fn test_placement_negotiation_multi_executor() {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs(),
+        max_scope: None,
+        cell_affinity: None,
     };
 
     tracing::info!("Broadcasting PlacementRequest to all executors");
@@ -421,8 +423,8 @@ async fn test_placement_negotiation_multi_executor() {
 #[tokio::test]
 async fn test_locality_aware_placement_scoring() {
     use crate::scheduler::{
-        DefaultPlacementPolicy, LocalityContext, LocalityHint, NodeCapacity, NodeState,
-        PlacementPolicy, PlacementRequest, ResourceProfile, ScopeContext,
+        DefaultPlacementPolicy, LocalityContext, NodeCapacity, NodeState, PlacementPolicy,
+        PlacementRequest, ResourceProfile, ScopeContext,
     };
 
     // Create task requiring compute resources
@@ -511,63 +513,21 @@ async fn test_locality_aware_placement_scoring() {
         submitter_region: None,
     };
 
-    let no_hints: Vec<LocalityHint> = vec![];
-
     // Score all executors
     let offer_a = policy
-        .score_task(
-            &task_hash,
-            &profile,
-            "submitter",
-            &node_a,
-            0.8,
-            &no_hints,
-            &locality_a,
-            &scope_ctx,
-            &request,
-        )
+        .score_task(&request, "submitter", &node_a, 0.8, &locality_a, &scope_ctx)
         .unwrap();
 
     let offer_b = policy
-        .score_task(
-            &task_hash,
-            &profile,
-            "submitter",
-            &node_b,
-            0.6,
-            &no_hints,
-            &locality_b,
-            &scope_ctx,
-            &request,
-        )
+        .score_task(&request, "submitter", &node_b, 0.6, &locality_b, &scope_ctx)
         .unwrap();
 
     let offer_c = policy
-        .score_task(
-            &task_hash,
-            &profile,
-            "submitter",
-            &node_c,
-            0.6,
-            &no_hints,
-            &locality_c,
-            &scope_ctx,
-            &request,
-        )
+        .score_task(&request, "submitter", &node_c, 0.6, &locality_c, &scope_ctx)
         .unwrap();
 
     let offer_d = policy
-        .score_task(
-            &task_hash,
-            &profile,
-            "submitter",
-            &node_d,
-            0.4,
-            &no_hints,
-            &locality_d,
-            &scope_ctx,
-            &request,
-        )
+        .score_task(&request, "submitter", &node_d, 0.4, &locality_d, &scope_ctx)
         .unwrap();
 
     tracing::info!("=== Phase 16C Locality-Aware Placement Scoring ===");

--- a/icn/crates/icn-compute/src/lib.rs
+++ b/icn/crates/icn-compute/src/lib.rs
@@ -82,9 +82,10 @@ pub use result_quorum::{
     MAX_CONCURRENT_VERIFICATIONS,
 };
 pub use scheduler::{
-    DefaultPlacementPolicy, FederatedPlacementConstraints, FederationPolicy, GpuDevice, GpuSpec,
-    LocalityContext, LocalityHint, NodeCapacity, NodeState, PlacementOffer, PlacementPolicy,
-    PlacementRequest, ResourceChangeType, ResourceProfile, ResourceRefreshConfig,
+    CapacityBudget, DefaultPlacementPolicy, FederatedPlacementConstraints, FederationPolicy,
+    GpuDevice, GpuSpec, LocalityContext, LocalityHint, NodeCapacity, NodeState, PlacementOffer,
+    PlacementPolicy, PlacementRequest, ResourceChangeType, ResourceProfile, ResourceRefreshConfig,
+    ScopeContext,
 };
 pub use task::{TaskManager, TaskStatus};
 pub use types::{

--- a/icn/crates/icn-compute/src/scheduler.rs
+++ b/icn/crates/icn-compute/src/scheduler.rs
@@ -716,14 +716,20 @@ impl CapacityBudget {
         }
 
         let sum: f64 = fractions.iter().sum();
-        // Use a practical tolerance for floating-point accumulation across
-        // multiple adjustment rounds (f64::EPSILON is too tight).
-        if sum > 1.0 + 1e-9 {
+        if sum > 1.0 + Self::FLOAT_TOLERANCE {
             return Err("Fractions must sum to at most 1.0");
         }
 
         Ok(())
     }
+
+    /// Practical tolerance for floating-point comparisons.
+    ///
+    /// Using `f64::EPSILON` (~2.2e-16) is too tight when fractions are
+    /// adjusted over many rounds; accumulated rounding can exceed it.
+    /// 1e-9 is well above rounding noise but invisible at the 0.01 scale
+    /// of our smallest meaningful fraction.
+    const FLOAT_TOLERANCE: f64 = 1e-9;
 
     /// Minimum fraction per scope during demand adjustment.
     ///
@@ -744,8 +750,18 @@ impl CapacityBudget {
     /// conservative (moves at most `learning_rate` fraction per call).
     ///
     /// # Arguments
-    /// * `utilization` - Map of scope → utilization ratio (0.0 = idle, 1.0 = saturated)
-    /// * `learning_rate` - Maximum fraction to shift per adjustment (e.g., 0.05)
+    /// * `utilization` - Map of scope → utilization ratio (0.0 = idle, 1.0 = saturated).
+    ///   Scopes absent from the map are left unchanged (only scopes with data
+    ///   participate in the rebalancing).
+    /// * `learning_rate` - Maximum fraction to shift per adjustment (clamped to 0.0..0.1)
+    ///
+    /// # Bounds
+    ///
+    /// Fractions are clamped to [`MIN_SCOPE_FRACTION`, `MAX_SCOPE_FRACTION`]
+    /// (currently \[0.01, 0.80\]) to prevent starvation (min) and monopolization
+    /// (max), ensuring every scope retains headroom even under sustained
+    /// extreme demand patterns. After clamping, fractions are re-normalized
+    /// to preserve the original sum.
     pub fn adjust_from_demand(
         &mut self,
         utilization: &HashMap<ScopeLevel, f64>,
@@ -803,7 +819,7 @@ impl CapacityBudget {
         .iter()
         .sum();
         let new_sum: f64 = fractions.iter().sum();
-        if new_sum > f64::EPSILON {
+        if new_sum > Self::FLOAT_TOLERANCE {
             let scale = original_sum / new_sum;
             for f in &mut fractions {
                 *f = (*f * scale).clamp(0.0, 1.0);
@@ -1184,6 +1200,20 @@ impl DefaultPlacementPolicy {
     ///
     /// Used for scope budget estimation (queue depth limit calculation).
     const DEFAULT_CPU_PER_TASK: f64 = 0.1;
+
+    /// Placement affinity bonus for a given scope level.
+    ///
+    /// Narrower scope = stronger affinity, rewarding local execution.
+    /// These values are additive components of the overall placement score.
+    fn scope_affinity_bonus(scope: ScopeLevel) -> f64 {
+        match scope {
+            ScopeLevel::Local => 0.15,
+            ScopeLevel::Cell => 0.12,
+            ScopeLevel::Org => 0.08,
+            ScopeLevel::Federation => 0.04,
+            ScopeLevel::Commons => 0.00,
+        }
+    }
 }
 
 impl Default for DefaultPlacementPolicy {
@@ -1239,11 +1269,16 @@ impl PlacementPolicy for DefaultPlacementPolicy {
         let cpu_per_task = profile
             .cpu_cores
             .unwrap_or(DefaultPlacementPolicy::DEFAULT_CPU_PER_TASK);
-        let total_queue_budget = if scope_fraction > f64::EPSILON && cpu_per_task > f64::EPSILON {
-            (node_state.capacity.cpu_cores_total * scope_fraction / cpu_per_task).max(1.0) as usize
-        } else {
-            0
-        };
+        // Calculate max concurrent tasks this scope can run:
+        // (total_cpu * scope_fraction) gives available CPU for this scope,
+        // dividing by cpu_per_task gives the task slot capacity.
+        let available_cpu_for_scope = node_state.capacity.cpu_cores_total * scope_fraction;
+        let total_queue_budget =
+            if available_cpu_for_scope > f64::EPSILON && cpu_per_task > f64::EPSILON {
+                (available_cpu_for_scope / cpu_per_task).max(1.0) as usize
+            } else {
+                0
+            };
         if total_queue_budget > 0 && scope_queue >= total_queue_budget {
             return None; // Scope budget exhausted
         }
@@ -1274,14 +1309,7 @@ impl PlacementPolicy for DefaultPlacementPolicy {
 
         // Factor 6: Scope affinity (weight 0.15, NEW)
         // Narrower scope = stronger affinity bonus
-        let scope_bonus = match scope_ctx.peer_scope {
-            ScopeLevel::Local => 0.15,
-            ScopeLevel::Cell => 0.12,
-            ScopeLevel::Org => 0.08,
-            ScopeLevel::Federation => 0.04,
-            ScopeLevel::Commons => 0.00,
-        };
-        score += scope_bonus;
+        score += Self::scope_affinity_bonus(scope_ctx.peer_scope);
 
         // Factor 7: Cell affinity bonus (weight 0.05)
         // Extra bonus if executor is in the preferred cell
@@ -2287,5 +2315,45 @@ mod tests {
 
         // All fractions should remain valid
         assert!(budget.validate().is_ok());
+    }
+
+    #[test]
+    fn test_demand_adjustment_partial_data() {
+        let mut budget = CapacityBudget::default();
+        let original = budget.clone();
+
+        // Only provide metrics for 2 out of 5 scopes
+        let mut utilization = HashMap::new();
+        utilization.insert(ScopeLevel::Local, 0.90);
+        utilization.insert(ScopeLevel::Commons, 0.10);
+
+        budget.adjust_from_demand(&utilization, 0.05);
+
+        // Budget should still be valid
+        assert!(budget.validate().is_ok());
+
+        // Scopes without data (Cell, Org, Federation) should be unchanged
+        assert!(
+            (budget.cell_share - original.cell_share).abs() < 1e-6,
+            "Cell share should be unchanged: {} vs {}",
+            budget.cell_share,
+            original.cell_share
+        );
+        assert!(
+            (budget.org_share - original.org_share).abs() < 1e-6,
+            "Org share should be unchanged: {} vs {}",
+            budget.org_share,
+            original.org_share
+        );
+        assert!(
+            (budget.federation_share - original.federation_share).abs() < 1e-6,
+            "Federation share should be unchanged: {} vs {}",
+            budget.federation_share,
+            original.federation_share
+        );
+
+        // Local (high demand) should gain, Commons (low demand) should lose
+        assert!(budget.local_reserve > original.local_reserve);
+        assert!(budget.commons_share < original.commons_share);
     }
 }

--- a/icn/crates/icn-compute/src/scheduler.rs
+++ b/icn/crates/icn-compute/src/scheduler.rs
@@ -18,6 +18,7 @@
 //! - **Phase 16D**: Actor state and migration
 //! - **Phase 16E**: Cooperative scheduling policies
 
+use icn_kernel_api::{CellId, ScopeLevel};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::time::Duration;
@@ -608,6 +609,200 @@ impl NodeCapacity {
     }
 }
 
+// ============================================================================
+// Capacity Budget (scope-aware resource allocation)
+// ============================================================================
+
+/// Per-scope resource allocation fractions.
+///
+/// Defines what fraction of a node's total capacity is available to each
+/// scope level. The kernel uses these fractions for admission control without
+/// interpreting the organizational semantics behind scopes.
+///
+/// Fractions must sum to ≤ 1.0 (unused fraction is unallocated headroom).
+///
+/// # Example
+///
+/// ```
+/// use icn_compute::CapacityBudget;
+/// use icn_kernel_api::ScopeLevel;
+///
+/// let budget = CapacityBudget::default();
+/// assert_eq!(budget.fraction_for(ScopeLevel::Local), 0.30);
+/// assert_eq!(budget.fraction_for(ScopeLevel::Cell), 0.25);
+/// assert!(budget.validate().is_ok());
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CapacityBudget {
+    /// Fraction reserved for local tasks (default: 0.30)
+    pub local_reserve: f64,
+
+    /// Fraction shared with cell peers (default: 0.25)
+    pub cell_share: f64,
+
+    /// Fraction shared with org-wide tasks (default: 0.20)
+    pub org_share: f64,
+
+    /// Fraction shared with federation tasks (default: 0.15)
+    pub federation_share: f64,
+
+    /// Fraction shared with commons tasks (default: 0.10)
+    pub commons_share: f64,
+}
+
+impl Default for CapacityBudget {
+    fn default() -> Self {
+        Self {
+            local_reserve: 0.30,
+            cell_share: 0.25,
+            org_share: 0.20,
+            federation_share: 0.15,
+            commons_share: 0.10,
+        }
+    }
+}
+
+impl CapacityBudget {
+    /// Get the capacity fraction for a given scope level.
+    ///
+    /// Returns the fraction of total node capacity available to tasks
+    /// at the specified scope.
+    pub fn fraction_for(&self, scope: ScopeLevel) -> f64 {
+        match scope {
+            ScopeLevel::Local => self.local_reserve,
+            ScopeLevel::Cell => self.cell_share,
+            ScopeLevel::Org => self.org_share,
+            ScopeLevel::Federation => self.federation_share,
+            ScopeLevel::Commons => self.commons_share,
+        }
+    }
+
+    /// Get the cumulative capacity available at a given scope and below.
+    ///
+    /// Tasks at a wider scope can use capacity from all narrower scopes
+    /// that haven't been consumed. This returns the maximum fraction
+    /// available if the scope widened from Local up to the given level.
+    pub fn cumulative_fraction_up_to(&self, scope: ScopeLevel) -> f64 {
+        let mut total = self.local_reserve;
+        if scope >= ScopeLevel::Cell {
+            total += self.cell_share;
+        }
+        if scope >= ScopeLevel::Org {
+            total += self.org_share;
+        }
+        if scope >= ScopeLevel::Federation {
+            total += self.federation_share;
+        }
+        if scope >= ScopeLevel::Commons {
+            total += self.commons_share;
+        }
+        total
+    }
+
+    /// Validate that fractions are individually valid and sum to ≤ 1.0.
+    pub fn validate(&self) -> Result<(), &'static str> {
+        let fractions = [
+            self.local_reserve,
+            self.cell_share,
+            self.org_share,
+            self.federation_share,
+            self.commons_share,
+        ];
+
+        for &f in &fractions {
+            if !(0.0..=1.0).contains(&f) {
+                return Err("Each fraction must be in [0.0, 1.0]");
+            }
+        }
+
+        let sum: f64 = fractions.iter().sum();
+        if sum > 1.0 + f64::EPSILON {
+            return Err("Fractions must sum to at most 1.0");
+        }
+
+        Ok(())
+    }
+
+    /// Adjust budget based on observed demand.
+    ///
+    /// Takes utilization ratios (0.0-1.0) per scope and shifts unused
+    /// capacity toward scopes with higher demand. The adjustment is
+    /// conservative (moves at most `learning_rate` fraction per call).
+    ///
+    /// # Arguments
+    /// * `utilization` - Map of scope → utilization ratio (0.0 = idle, 1.0 = saturated)
+    /// * `learning_rate` - Maximum fraction to shift per adjustment (e.g., 0.05)
+    pub fn adjust_from_demand(
+        &mut self,
+        utilization: &HashMap<ScopeLevel, f64>,
+        learning_rate: f64,
+    ) {
+        let lr = learning_rate.clamp(0.0, 0.1);
+
+        let scopes = ScopeLevel::ALL;
+        let mut fractions = [
+            self.local_reserve,
+            self.cell_share,
+            self.org_share,
+            self.federation_share,
+            self.commons_share,
+        ];
+
+        // Calculate average utilization
+        let mut total_util = 0.0;
+        let mut count = 0;
+        for &scope in &scopes {
+            if let Some(&u) = utilization.get(&scope) {
+                total_util += u;
+                count += 1;
+            }
+        }
+        let avg_util = if count > 0 {
+            total_util / count as f64
+        } else {
+            return; // No data, no adjustment
+        };
+
+        // Shift capacity: over-utilized scopes gain, under-utilized lose
+        let mut deltas = [0.0f64; 5];
+        for (i, &scope) in scopes.iter().enumerate() {
+            if let Some(&u) = utilization.get(&scope) {
+                let diff = u - avg_util;
+                deltas[i] = diff * lr;
+            }
+        }
+
+        // Apply deltas, clamping each fraction to [0.01, 0.80]
+        for i in 0..5 {
+            fractions[i] = (fractions[i] + deltas[i]).clamp(0.01, 0.80);
+        }
+
+        // Normalize so sum stays the same as before
+        let original_sum: f64 = [
+            self.local_reserve,
+            self.cell_share,
+            self.org_share,
+            self.federation_share,
+            self.commons_share,
+        ]
+        .iter()
+        .sum();
+        let new_sum: f64 = fractions.iter().sum();
+        if new_sum > 0.0 {
+            let scale = original_sum / new_sum;
+            for f in &mut fractions {
+                *f *= scale;
+            }
+        }
+
+        self.local_reserve = fractions[0];
+        self.cell_share = fractions[1];
+        self.org_share = fractions[2];
+        self.federation_share = fractions[3];
+        self.commons_share = fractions[4];
+    }
+}
+
 /// Locality hints for task placement.
 ///
 /// These guide the scheduler to prefer certain execution locations.
@@ -734,6 +929,22 @@ pub struct PlacementRequest {
 
     /// When this request was sent
     pub requested_at: u64,
+
+    // -- Scope-aware placement fields (Epic 2) --
+    /// Maximum scope level the task is allowed to execute at.
+    ///
+    /// If `None`, no scope restriction (equivalent to `Commons`).
+    /// If set to e.g. `ScopeLevel::Org`, the task will not be placed
+    /// on nodes outside the submitter's organization.
+    #[serde(default)]
+    pub max_scope: Option<ScopeLevel>,
+
+    /// Preferred cell for execution (e.g., submitter's own cell).
+    ///
+    /// Executors in this cell receive a placement score bonus.
+    /// If `None`, no cell affinity preference.
+    #[serde(default)]
+    pub cell_affinity: Option<CellId>,
 }
 
 /// Executor's offer to run a task.
@@ -779,6 +990,41 @@ impl PartialOrd for PlacementOffer {
     }
 }
 
+/// Scope context for placement scoring.
+///
+/// Provides the relationship between a submitter and an executor
+/// so the placement policy can apply scope-aware score adjustments.
+#[derive(Debug, Clone)]
+pub struct ScopeContext {
+    /// The scope relationship between submitter and executor.
+    ///
+    /// - `Local` = same node
+    /// - `Cell` = same cell
+    /// - `Org` = same organization, different cell
+    /// - `Federation` = federated peer
+    /// - `Commons` = unknown / unaffiliated
+    pub peer_scope: ScopeLevel,
+
+    /// The executor's cell (if any)
+    pub executor_cell: Option<CellId>,
+
+    /// Capacity budget for scope-aware admission control
+    pub capacity_budget: CapacityBudget,
+}
+
+impl ScopeContext {
+    /// Create an empty scope context (no scope information).
+    ///
+    /// Defaults to `Commons` scope with default budget.
+    pub fn empty() -> Self {
+        Self {
+            peer_scope: ScopeLevel::Commons,
+            executor_cell: None,
+            capacity_budget: CapacityBudget::default(),
+        }
+    }
+}
+
 /// State needed for placement decisions.
 ///
 /// Maintained by each executor to score incoming tasks.
@@ -795,6 +1041,12 @@ pub struct NodeState {
 
     /// Queue depth (number of pending tasks)
     pub queue_depth: usize,
+
+    /// Per-scope queue depths for scope-aware load balancing.
+    ///
+    /// Tracks how many pending tasks originated from each scope level,
+    /// allowing the scheduler to respect per-scope capacity budgets.
+    pub scope_queue_depths: HashMap<ScopeLevel, usize>,
 }
 
 impl NodeState {
@@ -878,11 +1130,12 @@ pub trait PlacementPolicy: Send + Sync {
     /// Returns None if this node cannot or should not execute the task.
     /// Returns Some(offer) with a score between 0.0 and 1.0.
     ///
-    /// # Phase 16C Enhancement
+    /// # Parameters
     ///
-    /// Added `locality_hints` and `locality_ctx` parameters for network-aware scoring:
     /// - `locality_hints`: Task placement preferences (region, data locality, etc.)
     /// - `locality_ctx`: Network context for computing locality scores (RTT, blob locations)
+    /// - `scope_ctx`: Scope relationship between submitter and executor for scope-aware scoring
+    /// - `request`: The full placement request (includes max_scope, cell_affinity)
     fn score_task(
         &self,
         task_hash: &[u8; 32],
@@ -892,6 +1145,8 @@ pub trait PlacementPolicy: Send + Sync {
         trust_score: f64,
         locality_hints: &[LocalityHint],
         locality_ctx: &LocalityContext,
+        scope_ctx: &ScopeContext,
+        request: &PlacementRequest,
     ) -> Option<PlacementOffer>;
 }
 
@@ -929,10 +1184,20 @@ impl PlacementPolicy for DefaultPlacementPolicy {
         trust_score: f64,
         locality_hints: &[LocalityHint],
         locality_ctx: &LocalityContext,
+        scope_ctx: &ScopeContext,
+        request: &PlacementRequest,
     ) -> Option<PlacementOffer> {
         // Trust gate
         if trust_score < self.min_trust {
             return None;
+        }
+
+        // Scope gate: reject if the task's max_scope restricts us
+        // and the submitter-executor relationship exceeds it
+        if let Some(max_scope) = request.max_scope {
+            if scope_ctx.peer_scope > max_scope {
+                return None; // Executor is too far from submitter
+            }
         }
 
         // Capacity check
@@ -940,80 +1205,100 @@ impl PlacementPolicy for DefaultPlacementPolicy {
             return None;
         }
 
+        // Scope-aware capacity check: ensure scope budget isn't exhausted
+        let scope_queue = node_state
+            .scope_queue_depths
+            .get(&scope_ctx.peer_scope)
+            .copied()
+            .unwrap_or(0);
+        let scope_fraction = scope_ctx.capacity_budget.fraction_for(scope_ctx.peer_scope);
+        let total_queue_budget =
+            (node_state.capacity.cpu_cores_total / 0.1 * scope_fraction) as usize;
+        if total_queue_budget > 0 && scope_queue >= total_queue_budget {
+            return None; // Scope budget exhausted
+        }
+
         // Compute score (0.0 - 1.0)
-        // Phase 16C: Rebalanced weights to include locality factors
         let mut score = 0.0;
 
-        // Factor 1: Trust (weight 0.25, reduced from 0.4)
-        // Scale trust score to 0-0.25 range
-        score += (trust_score * 0.25).min(0.25);
+        // Factor 1: Trust (weight 0.20)
+        score += (trust_score * 0.20).min(0.20);
 
-        // Factor 2: Available capacity (weight 0.20, reduced from 0.3)
-        // Prefer nodes with more available resources
+        // Factor 2: Available capacity (weight 0.15)
         let capacity_ratio = node_state.capacity.available_ratio();
-        score += capacity_ratio * 0.20;
+        score += capacity_ratio * 0.15;
 
-        // Factor 3: Queue depth (weight 0.15, reduced from 0.2)
-        // Prefer nodes with shorter queues
+        // Factor 3: Queue depth (weight 0.10)
         let queue_penalty = (node_state.queue_depth as f64 / 10.0).min(1.0);
-        score += (1.0 - queue_penalty) * 0.15;
+        score += (1.0 - queue_penalty) * 0.10;
 
-        // Factor 4: Network latency (weight 0.15, NEW in Phase 16C)
-        // Prefer nodes with lower RTT to submitter
+        // Factor 4: Network latency (weight 0.10)
         if let Some(rtt_ms) = locality_ctx.submitter_rtt_ms {
-            // Convert RTT to score: lower RTT = higher score
-            // 0ms = 1.0, 500ms = 0.0 (linear interpolation)
             let rtt_score = (1.0 - (rtt_ms as f64 / 500.0).min(1.0)).max(0.0);
-            score += rtt_score * 0.15;
+            score += rtt_score * 0.10;
         }
-        // If no RTT data, no bonus (neutral)
 
-        // Factor 5: Data locality (weight 0.15, NEW in Phase 16C)
-        // Prefer nodes that already have input blobs
+        // Factor 5: Data locality (weight 0.10)
         let data_locality_ratio = locality_ctx.data_locality_ratio();
-        score += data_locality_ratio * 0.15;
+        score += data_locality_ratio * 0.10;
 
-        // Factor 6: Locality hints bonus (weight 0.10, NEW in Phase 16C)
-        // Apply bonus if we match submitter preferences
+        // Factor 6: Scope affinity (weight 0.15, NEW)
+        // Narrower scope = stronger affinity bonus
+        let scope_bonus = match scope_ctx.peer_scope {
+            ScopeLevel::Local => 0.15,
+            ScopeLevel::Cell => 0.12,
+            ScopeLevel::Org => 0.08,
+            ScopeLevel::Federation => 0.04,
+            ScopeLevel::Commons => 0.00,
+        };
+        score += scope_bonus;
+
+        // Factor 7: Cell affinity bonus (weight 0.05)
+        // Extra bonus if executor is in the preferred cell
+        if let (Some(ref preferred), Some(ref executor_cell)) =
+            (&request.cell_affinity, &scope_ctx.executor_cell)
+        {
+            if preferred == executor_cell {
+                score += 0.05;
+            }
+        }
+
+        // Factor 8: Locality hints bonus (weight 0.05)
         let mut hint_bonus: f64 = 0.0;
         for hint in locality_hints {
             match hint {
                 LocalityHint::PreferRegion(region) => {
                     if let Some(ref own_region) = locality_ctx.own_region {
                         if own_region == region {
-                            hint_bonus += 0.05; // 5% bonus for region match
+                            hint_bonus += 0.03;
                         }
                     }
                 }
                 LocalityHint::PreferDid(did) => {
                     if &node_state.did == did {
-                        hint_bonus += 0.10; // 10% bonus for direct DID preference
+                        hint_bonus += 0.05;
                     }
                 }
                 LocalityHint::AvoidDid(did) => {
                     if &node_state.did == did {
-                        return None; // Hard reject if blacklisted
+                        return None;
                     }
                 }
-                _ => {
-                    // DataLocality and ColocateWith handled via locality_ctx
-                }
+                _ => {}
             }
         }
-        score += hint_bonus.min(0.10); // Cap hint bonus at 10%
+        score += hint_bonus.min(0.05);
 
-        // Factor 7: Random jitter (weight 0.10, same as before, but rebalanced)
-        // Break ties and prevent thundering herd
+        // Factor 9: Random jitter (weight 0.10)
         use rand::Rng;
         let jitter = rand::thread_rng().gen::<f64>() * 0.10;
         score += jitter;
 
-        // Total weights: 0.25 + 0.20 + 0.15 + 0.15 + 0.15 + 0.10 + 0.10 = 1.10 max (with bonuses)
-        // Actual max without bonuses: 1.00
         // Cap final score at 1.0
+        // Max theoretical: 0.20 + 0.15 + 0.10 + 0.10 + 0.10 + 0.15 + 0.05 + 0.05 + 0.10 = 1.00
         score = score.min(1.0);
 
-        // Calculate cost (base cost + load multiplier)
+        // Calculate cost
         let load_factor = if node_state.queue_depth > 5 {
             self.load_multiplier
         } else {
@@ -1021,7 +1306,6 @@ impl PlacementPolicy for DefaultPlacementPolicy {
         };
         let cost = (self.base_cost as f64 * load_factor) as u64;
 
-        // Estimated start time
         let estimated_start = icn_time::current_timestamp_millis() + node_state.queue_depth_ms();
 
         Some(PlacementOffer {
@@ -1164,11 +1448,22 @@ mod tests {
             },
             executing_tasks: HashMap::new(),
             queue_depth: 2,
+            scope_queue_depths: HashMap::new(),
         };
 
         let task_hash = [0u8; 32];
         let empty_locality = LocalityContext::empty();
         let no_hints: Vec<LocalityHint> = vec![];
+        let scope_ctx = ScopeContext::empty();
+        let request = PlacementRequest {
+            task_hash,
+            resource_profile: profile.clone(),
+            locality_hints: vec![],
+            max_cost: None,
+            requested_at: 1000,
+            max_scope: None,
+            cell_affinity: None,
+        };
 
         // High trust, should get good score
         let offer = policy
@@ -1180,10 +1475,12 @@ mod tests {
                 0.8,
                 &no_hints,
                 &empty_locality,
+                &scope_ctx,
+                &request,
             )
             .unwrap();
 
-        assert!(offer.score > 0.4); // Trust (0.20) + capacity (0.15) + queue (0.12) + jitter
+        assert!(offer.score > 0.3); // Trust + capacity + queue + jitter
         assert_eq!(offer.cost, 10); // Base cost
 
         // Low trust, rejected
@@ -1195,6 +1492,8 @@ mod tests {
             0.1,
             &no_hints,
             &empty_locality,
+            &scope_ctx,
+            &request,
         );
         assert!(offer.is_none());
 
@@ -1213,21 +1512,39 @@ mod tests {
                 0.8,
                 &no_hints,
                 &empty_locality,
+                &scope_ctx,
+                &request,
             )
             .unwrap();
 
         assert_eq!(offer.cost, 15); // base_cost * load_multiplier
 
-        // Test with locality context (Phase 16C)
-        let locality_with_rtt = LocalityContext {
-            submitter_rtt_ms: Some(50), // 50ms RTT
-            local_blob_count: 0,
-            total_blob_count: 0,
-            own_region: None,
-            submitter_region: None,
+        // Test scope gate: reject if max_scope is exceeded
+        let local_only_request = PlacementRequest {
+            max_scope: Some(ScopeLevel::Cell),
+            ..request.clone()
         };
+        // scope_ctx has peer_scope=Commons which > Cell, should be rejected
+        let offer = policy.score_task(
+            &task_hash,
+            &profile,
+            "did:icn:alice",
+            &node_state,
+            0.8,
+            &no_hints,
+            &empty_locality,
+            &scope_ctx,
+            &local_only_request,
+        );
+        assert!(offer.is_none(), "Should reject when peer_scope > max_scope");
 
-        let offer_with_rtt = policy
+        // Same-cell context should get scope bonus
+        let cell_ctx = ScopeContext {
+            peer_scope: ScopeLevel::Cell,
+            executor_cell: None,
+            capacity_budget: CapacityBudget::default(),
+        };
+        let cell_offer = policy
             .score_task(
                 &task_hash,
                 &profile,
@@ -1235,38 +1552,14 @@ mod tests {
                 &node_state,
                 0.8,
                 &no_hints,
-                &locality_with_rtt,
+                &empty_locality,
+                &cell_ctx,
+                &request,
             )
             .unwrap();
-
-        // Should score higher than without RTT info (RTT bonus: 0.9 * 0.15 = 0.135)
-        // Use 0.05 threshold to account for random jitter variance (0-0.10 per invocation)
-        assert!(offer_with_rtt.score > offer.score + 0.05);
-
-        // Test with data locality
-        let locality_with_data = LocalityContext {
-            submitter_rtt_ms: None,
-            local_blob_count: 3,
-            total_blob_count: 3, // All blobs available locally
-            own_region: None,
-            submitter_region: None,
-        };
-
-        let offer_with_data = policy
-            .score_task(
-                &task_hash,
-                &profile,
-                "did:icn:alice",
-                &node_state,
-                0.8,
-                &no_hints,
-                &locality_with_data,
-            )
-            .unwrap();
-
-        // Should get full data locality bonus (1.0 * 0.15 = 0.15)
-        // Use 0.05 threshold to account for random jitter variance (0-0.10 per invocation)
-        assert!(offer_with_data.score > offer.score + 0.05);
+        // Cell scope bonus (0.12) vs Commons (0.00) = +0.12 advantage
+        // May vary by jitter, but on average cell should score higher
+        assert!(cell_offer.score > 0.3);
     }
 
     #[test]
@@ -1575,5 +1868,335 @@ mod tests {
         assert!(capacity.memory_mb_total > 0);
         assert!(capacity.memory_mb_available > 0);
         assert!(capacity.updated_at > 0);
+    }
+
+    // ================================================================
+    // Epic 2: Scope-aware capacity and placement tests
+    // ================================================================
+
+    #[test]
+    fn test_capacity_budget_default() {
+        let budget = CapacityBudget::default();
+        assert_eq!(budget.local_reserve, 0.30);
+        assert_eq!(budget.cell_share, 0.25);
+        assert_eq!(budget.org_share, 0.20);
+        assert_eq!(budget.federation_share, 0.15);
+        assert_eq!(budget.commons_share, 0.10);
+        assert!(budget.validate().is_ok());
+    }
+
+    #[test]
+    fn test_capacity_budget_fraction_for() {
+        let budget = CapacityBudget::default();
+        assert_eq!(budget.fraction_for(ScopeLevel::Local), 0.30);
+        assert_eq!(budget.fraction_for(ScopeLevel::Cell), 0.25);
+        assert_eq!(budget.fraction_for(ScopeLevel::Org), 0.20);
+        assert_eq!(budget.fraction_for(ScopeLevel::Federation), 0.15);
+        assert_eq!(budget.fraction_for(ScopeLevel::Commons), 0.10);
+    }
+
+    #[test]
+    fn test_capacity_budget_cumulative() {
+        let budget = CapacityBudget::default();
+        assert_eq!(budget.cumulative_fraction_up_to(ScopeLevel::Local), 0.30);
+        assert!(
+            (budget.cumulative_fraction_up_to(ScopeLevel::Cell) - 0.55).abs() < f64::EPSILON
+        );
+        assert!(
+            (budget.cumulative_fraction_up_to(ScopeLevel::Commons) - 1.00).abs() < f64::EPSILON
+        );
+    }
+
+    #[test]
+    fn test_capacity_budget_validation() {
+        // Valid: sums to 1.0
+        let budget = CapacityBudget::default();
+        assert!(budget.validate().is_ok());
+
+        // Valid: sums to < 1.0 (headroom)
+        let budget = CapacityBudget {
+            local_reserve: 0.20,
+            cell_share: 0.20,
+            org_share: 0.20,
+            federation_share: 0.10,
+            commons_share: 0.10,
+        };
+        assert!(budget.validate().is_ok());
+
+        // Invalid: negative fraction
+        let budget = CapacityBudget {
+            local_reserve: -0.1,
+            ..Default::default()
+        };
+        assert!(budget.validate().is_err());
+
+        // Invalid: fraction > 1.0
+        let budget = CapacityBudget {
+            local_reserve: 1.1,
+            ..Default::default()
+        };
+        assert!(budget.validate().is_err());
+
+        // Invalid: sum > 1.0
+        let budget = CapacityBudget {
+            local_reserve: 0.50,
+            cell_share: 0.50,
+            org_share: 0.20,
+            federation_share: 0.0,
+            commons_share: 0.0,
+        };
+        assert!(budget.validate().is_err());
+    }
+
+    #[test]
+    fn test_capacity_budget_demand_adjustment() {
+        let mut budget = CapacityBudget::default();
+        let original_sum: f64 = [
+            budget.local_reserve,
+            budget.cell_share,
+            budget.org_share,
+            budget.federation_share,
+            budget.commons_share,
+        ]
+        .iter()
+        .sum();
+
+        // Simulate high local demand, low commons demand
+        let mut utilization = HashMap::new();
+        utilization.insert(ScopeLevel::Local, 0.95);
+        utilization.insert(ScopeLevel::Cell, 0.50);
+        utilization.insert(ScopeLevel::Org, 0.30);
+        utilization.insert(ScopeLevel::Federation, 0.20);
+        utilization.insert(ScopeLevel::Commons, 0.05);
+
+        budget.adjust_from_demand(&utilization, 0.05);
+
+        // Local should have grown, commons should have shrunk
+        assert!(budget.local_reserve > 0.30);
+        assert!(budget.commons_share < 0.10);
+
+        // Sum should be preserved
+        let new_sum: f64 = [
+            budget.local_reserve,
+            budget.cell_share,
+            budget.org_share,
+            budget.federation_share,
+            budget.commons_share,
+        ]
+        .iter()
+        .sum();
+        assert!((new_sum - original_sum).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_scope_context_empty() {
+        let ctx = ScopeContext::empty();
+        assert_eq!(ctx.peer_scope, ScopeLevel::Commons);
+        assert!(ctx.executor_cell.is_none());
+    }
+
+    #[test]
+    fn test_placement_request_scope_fields_default() {
+        // Backward compatibility: new fields default to None
+        let request: PlacementRequest = serde_json::from_str(
+            r#"{
+                "task_hash": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+                "resource_profile": {"cpu_cores": 0.1, "memory_mb": 128},
+                "locality_hints": [],
+                "max_cost": null,
+                "requested_at": 1000
+            }"#,
+        )
+        .unwrap();
+        assert!(request.max_scope.is_none());
+        assert!(request.cell_affinity.is_none());
+    }
+
+    #[test]
+    fn test_scope_gate_rejects_out_of_scope() {
+        let policy = DefaultPlacementPolicy::default();
+        let profile = ResourceProfile::minimal();
+
+        let node_state = NodeState {
+            did: "did:icn:executor".into(),
+            capacity: NodeCapacity {
+                cpu_cores_total: 8.0,
+                cpu_cores_available: 6.0,
+                memory_mb_total: 16384,
+                memory_mb_available: 12288,
+                storage_mb_available: 100_000,
+                network_mbps: 1000.0,
+                gpu_devices: vec![],
+                updated_at: 1000,
+            },
+            executing_tasks: HashMap::new(),
+            queue_depth: 0,
+            scope_queue_depths: HashMap::new(),
+        };
+
+        let task_hash = [0u8; 32];
+        let empty_locality = LocalityContext::empty();
+        let no_hints: Vec<LocalityHint> = vec![];
+
+        // Request restricted to Cell scope
+        let request = PlacementRequest {
+            task_hash,
+            resource_profile: profile.clone(),
+            locality_hints: vec![],
+            max_cost: None,
+            requested_at: 1000,
+            max_scope: Some(ScopeLevel::Cell),
+            cell_affinity: None,
+        };
+
+        // Executor at Commons scope (too far) → rejected
+        let commons_ctx = ScopeContext {
+            peer_scope: ScopeLevel::Commons,
+            executor_cell: None,
+            capacity_budget: CapacityBudget::default(),
+        };
+        assert!(policy
+            .score_task(
+                &task_hash,
+                &profile,
+                "did:icn:alice",
+                &node_state,
+                0.8,
+                &no_hints,
+                &empty_locality,
+                &commons_ctx,
+                &request,
+            )
+            .is_none());
+
+        // Executor at Cell scope (within range) → accepted
+        let cell_ctx = ScopeContext {
+            peer_scope: ScopeLevel::Cell,
+            executor_cell: None,
+            capacity_budget: CapacityBudget::default(),
+        };
+        assert!(policy
+            .score_task(
+                &task_hash,
+                &profile,
+                "did:icn:alice",
+                &node_state,
+                0.8,
+                &no_hints,
+                &empty_locality,
+                &cell_ctx,
+                &request,
+            )
+            .is_some());
+
+        // Executor at Local scope (narrower than max) → accepted
+        let local_ctx = ScopeContext {
+            peer_scope: ScopeLevel::Local,
+            executor_cell: None,
+            capacity_budget: CapacityBudget::default(),
+        };
+        assert!(policy
+            .score_task(
+                &task_hash,
+                &profile,
+                "did:icn:alice",
+                &node_state,
+                0.8,
+                &no_hints,
+                &empty_locality,
+                &local_ctx,
+                &request,
+            )
+            .is_some());
+    }
+
+    #[test]
+    fn test_scope_affinity_scoring() {
+        let policy = DefaultPlacementPolicy::default();
+        let profile = ResourceProfile::minimal();
+
+        let node_state = NodeState {
+            did: "did:icn:executor".into(),
+            capacity: NodeCapacity {
+                cpu_cores_total: 8.0,
+                cpu_cores_available: 6.0,
+                memory_mb_total: 16384,
+                memory_mb_available: 12288,
+                storage_mb_available: 100_000,
+                network_mbps: 1000.0,
+                gpu_devices: vec![],
+                updated_at: 1000,
+            },
+            executing_tasks: HashMap::new(),
+            queue_depth: 0,
+            scope_queue_depths: HashMap::new(),
+        };
+
+        let task_hash = [0u8; 32];
+        let empty_locality = LocalityContext::empty();
+        let no_hints: Vec<LocalityHint> = vec![];
+        let request = PlacementRequest {
+            task_hash,
+            resource_profile: profile.clone(),
+            locality_hints: vec![],
+            max_cost: None,
+            requested_at: 1000,
+            max_scope: None,
+            cell_affinity: None,
+        };
+
+        // Collect scores from many runs to smooth out jitter
+        let n = 100;
+        let mut local_total = 0.0;
+        let mut commons_total = 0.0;
+
+        for _ in 0..n {
+            let local_ctx = ScopeContext {
+                peer_scope: ScopeLevel::Local,
+                executor_cell: None,
+                capacity_budget: CapacityBudget::default(),
+            };
+            let commons_ctx = ScopeContext::empty();
+
+            local_total += policy
+                .score_task(
+                    &task_hash,
+                    &profile,
+                    "did:icn:alice",
+                    &node_state,
+                    0.8,
+                    &no_hints,
+                    &empty_locality,
+                    &local_ctx,
+                    &request,
+                )
+                .unwrap()
+                .score;
+
+            commons_total += policy
+                .score_task(
+                    &task_hash,
+                    &profile,
+                    "did:icn:alice",
+                    &node_state,
+                    0.8,
+                    &no_hints,
+                    &empty_locality,
+                    &commons_ctx,
+                    &request,
+                )
+                .unwrap()
+                .score;
+        }
+
+        let local_avg = local_total / n as f64;
+        let commons_avg = commons_total / n as f64;
+
+        // Local scope should consistently score higher than Commons
+        // due to the 0.15 scope affinity bonus
+        assert!(
+            local_avg > commons_avg + 0.10,
+            "Local avg ({local_avg:.4}) should be > Commons avg ({commons_avg:.4}) + 0.10"
+        );
     }
 }

--- a/icn/crates/icn-compute/src/scheduler.rs
+++ b/icn/crates/icn-compute/src/scheduler.rs
@@ -1147,21 +1147,21 @@ pub trait PlacementPolicy: Send + Sync {
     ///
     /// # Parameters
     ///
-    /// - `locality_hints`: Task placement preferences (region, data locality, etc.)
+    /// - `request`: The full placement request (task_hash, resource_profile,
+    ///   locality_hints, max_scope, cell_affinity)
+    /// - `submitter`: DID of the task submitter
+    /// - `node_state`: Current executor node capacity and queue state
+    /// - `trust_score`: Submitter's trust score as seen by the executor
     /// - `locality_ctx`: Network context for computing locality scores (RTT, blob locations)
     /// - `scope_ctx`: Scope relationship between submitter and executor for scope-aware scoring
-    /// - `request`: The full placement request (includes max_scope, cell_affinity)
     fn score_task(
         &self,
-        task_hash: &[u8; 32],
-        profile: &ResourceProfile,
+        request: &PlacementRequest,
         submitter: &str,
         node_state: &NodeState,
         trust_score: f64,
-        locality_hints: &[LocalityHint],
         locality_ctx: &LocalityContext,
         scope_ctx: &ScopeContext,
-        request: &PlacementRequest,
     ) -> Option<PlacementOffer>;
 }
 
@@ -1199,16 +1199,14 @@ impl Default for DefaultPlacementPolicy {
 impl PlacementPolicy for DefaultPlacementPolicy {
     fn score_task(
         &self,
-        _task_hash: &[u8; 32],
-        profile: &ResourceProfile,
+        request: &PlacementRequest,
         _submitter: &str,
         node_state: &NodeState,
         trust_score: f64,
-        locality_hints: &[LocalityHint],
         locality_ctx: &LocalityContext,
         scope_ctx: &ScopeContext,
-        request: &PlacementRequest,
     ) -> Option<PlacementOffer> {
+        let profile = &request.resource_profile;
         // Trust gate
         if trust_score < self.min_trust {
             return None;
@@ -1297,7 +1295,7 @@ impl PlacementPolicy for DefaultPlacementPolicy {
 
         // Factor 8: Locality hints bonus (weight 0.05)
         let mut hint_bonus: f64 = 0.0;
-        for hint in locality_hints {
+        for hint in &request.locality_hints {
             match hint {
                 LocalityHint::PreferRegion(region) => {
                     if let Some(ref own_region) = locality_ctx.own_region {
@@ -1485,7 +1483,7 @@ mod tests {
 
         let task_hash = [0u8; 32];
         let empty_locality = LocalityContext::empty();
-        let no_hints: Vec<LocalityHint> = vec![];
+
         let scope_ctx = ScopeContext::empty();
         let request = PlacementRequest {
             task_hash,
@@ -1500,15 +1498,12 @@ mod tests {
         // High trust, should get good score
         let offer = policy
             .score_task(
-                &task_hash,
-                &profile,
+                &request,
                 "did:icn:alice",
                 &node_state,
                 0.8,
-                &no_hints,
                 &empty_locality,
                 &scope_ctx,
-                &request,
             )
             .unwrap();
 
@@ -1517,15 +1512,12 @@ mod tests {
 
         // Low trust, rejected
         let offer = policy.score_task(
-            &task_hash,
-            &profile,
+            &request,
             "did:icn:untrusted",
             &node_state,
             0.1,
-            &no_hints,
             &empty_locality,
             &scope_ctx,
-            &request,
         );
         assert!(offer.is_none());
 
@@ -1537,15 +1529,12 @@ mod tests {
 
         let offer = policy
             .score_task(
-                &task_hash,
-                &profile,
+                &request,
                 "did:icn:alice",
                 &busy_node,
                 0.8,
-                &no_hints,
                 &empty_locality,
                 &scope_ctx,
-                &request,
             )
             .unwrap();
 
@@ -1558,15 +1547,12 @@ mod tests {
         };
         // scope_ctx has peer_scope=Commons which > Cell, should be rejected
         let offer = policy.score_task(
-            &task_hash,
-            &profile,
+            &local_only_request,
             "did:icn:alice",
             &node_state,
             0.8,
-            &no_hints,
             &empty_locality,
             &scope_ctx,
-            &local_only_request,
         );
         assert!(offer.is_none(), "Should reject when peer_scope > max_scope");
 
@@ -1578,15 +1564,12 @@ mod tests {
         };
         let cell_offer = policy
             .score_task(
-                &task_hash,
-                &profile,
+                &request,
                 "did:icn:alice",
                 &node_state,
                 0.8,
-                &no_hints,
                 &empty_locality,
                 &cell_ctx,
-                &request,
             )
             .unwrap();
         // Cell scope bonus (0.12) vs Commons (0.00) = +0.12 advantage
@@ -2066,7 +2049,6 @@ mod tests {
 
         let task_hash = [0u8; 32];
         let empty_locality = LocalityContext::empty();
-        let no_hints: Vec<LocalityHint> = vec![];
 
         // Request restricted to Cell scope
         let request = PlacementRequest {
@@ -2087,15 +2069,12 @@ mod tests {
         };
         assert!(policy
             .score_task(
-                &task_hash,
-                &profile,
+                &request,
                 "did:icn:alice",
                 &node_state,
                 0.8,
-                &no_hints,
                 &empty_locality,
                 &commons_ctx,
-                &request,
             )
             .is_none());
 
@@ -2107,15 +2086,12 @@ mod tests {
         };
         assert!(policy
             .score_task(
-                &task_hash,
-                &profile,
+                &request,
                 "did:icn:alice",
                 &node_state,
                 0.8,
-                &no_hints,
                 &empty_locality,
                 &cell_ctx,
-                &request,
             )
             .is_some());
 
@@ -2127,15 +2103,12 @@ mod tests {
         };
         assert!(policy
             .score_task(
-                &task_hash,
-                &profile,
+                &request,
                 "did:icn:alice",
                 &node_state,
                 0.8,
-                &no_hints,
                 &empty_locality,
                 &local_ctx,
-                &request,
             )
             .is_some());
     }
@@ -2164,7 +2137,7 @@ mod tests {
 
         let task_hash = [0u8; 32];
         let empty_locality = LocalityContext::empty();
-        let no_hints: Vec<LocalityHint> = vec![];
+
         let request = PlacementRequest {
             task_hash,
             resource_profile: profile.clone(),
@@ -2190,30 +2163,24 @@ mod tests {
 
             local_total += policy
                 .score_task(
-                    &task_hash,
-                    &profile,
+                    &request,
                     "did:icn:alice",
                     &node_state,
                     0.8,
-                    &no_hints,
                     &empty_locality,
                     &local_ctx,
-                    &request,
                 )
                 .unwrap()
                 .score;
 
             commons_total += policy
                 .score_task(
-                    &task_hash,
-                    &profile,
+                    &request,
                     "did:icn:alice",
                     &node_state,
                     0.8,
-                    &no_hints,
                     &empty_locality,
                     &commons_ctx,
-                    &request,
                 )
                 .unwrap()
                 .score;

--- a/icn/crates/icn-compute/src/scheduler.rs
+++ b/icn/crates/icn-compute/src/scheduler.rs
@@ -1899,9 +1899,7 @@ mod tests {
     fn test_capacity_budget_cumulative() {
         let budget = CapacityBudget::default();
         assert_eq!(budget.cumulative_fraction_up_to(ScopeLevel::Local), 0.30);
-        assert!(
-            (budget.cumulative_fraction_up_to(ScopeLevel::Cell) - 0.55).abs() < f64::EPSILON
-        );
+        assert!((budget.cumulative_fraction_up_to(ScopeLevel::Cell) - 0.55).abs() < f64::EPSILON);
         assert!(
             (budget.cumulative_fraction_up_to(ScopeLevel::Commons) - 1.00).abs() < f64::EPSILON
         );

--- a/icn/crates/icn-compute/src/scheduler.rs
+++ b/icn/crates/icn-compute/src/scheduler.rs
@@ -716,12 +716,26 @@ impl CapacityBudget {
         }
 
         let sum: f64 = fractions.iter().sum();
-        if sum > 1.0 + f64::EPSILON {
+        // Use a practical tolerance for floating-point accumulation across
+        // multiple adjustment rounds (f64::EPSILON is too tight).
+        if sum > 1.0 + 1e-9 {
             return Err("Fractions must sum to at most 1.0");
         }
 
         Ok(())
     }
+
+    /// Minimum fraction per scope during demand adjustment.
+    ///
+    /// Prevents complete starvation of any scope, ensuring every scope
+    /// retains at least minimal capacity for burst traffic.
+    const MIN_SCOPE_FRACTION: f64 = 0.01;
+
+    /// Maximum fraction per scope during demand adjustment.
+    ///
+    /// Prevents any single scope from monopolizing capacity, leaving
+    /// headroom for other scopes even under sustained high demand.
+    const MAX_SCOPE_FRACTION: f64 = 0.80;
 
     /// Adjust budget based on observed demand.
     ///
@@ -750,7 +764,7 @@ impl CapacityBudget {
 
         // Calculate average utilization
         let mut total_util = 0.0;
-        let mut count = 0;
+        let mut count = 0usize;
         for &scope in &scopes {
             if let Some(&u) = utilization.get(&scope) {
                 total_util += u;
@@ -772,9 +786,10 @@ impl CapacityBudget {
             }
         }
 
-        // Apply deltas, clamping each fraction to [0.01, 0.80]
+        // Apply deltas, clamping to prevent starvation and monopolization
         for i in 0..5 {
-            fractions[i] = (fractions[i] + deltas[i]).clamp(0.01, 0.80);
+            fractions[i] = (fractions[i] + deltas[i])
+                .clamp(Self::MIN_SCOPE_FRACTION, Self::MAX_SCOPE_FRACTION);
         }
 
         // Normalize so sum stays the same as before
@@ -788,10 +803,10 @@ impl CapacityBudget {
         .iter()
         .sum();
         let new_sum: f64 = fractions.iter().sum();
-        if new_sum > 0.0 {
+        if new_sum > f64::EPSILON {
             let scale = original_sum / new_sum;
             for f in &mut fractions {
-                *f *= scale;
+                *f = (*f * scale).clamp(0.0, 1.0);
             }
         }
 
@@ -1164,6 +1179,13 @@ pub struct DefaultPlacementPolicy {
     pub load_multiplier: f64,
 }
 
+impl DefaultPlacementPolicy {
+    /// Default assumed CPU cores per task when the profile doesn't specify.
+    ///
+    /// Used for scope budget estimation (queue depth limit calculation).
+    const DEFAULT_CPU_PER_TASK: f64 = 0.1;
+}
+
 impl Default for DefaultPlacementPolicy {
     fn default() -> Self {
         Self {
@@ -1205,15 +1227,25 @@ impl PlacementPolicy for DefaultPlacementPolicy {
             return None;
         }
 
-        // Scope-aware capacity check: ensure scope budget isn't exhausted
+        // Scope-aware capacity check: ensure scope budget isn't exhausted.
+        //
+        // We estimate the max number of tasks allowed per scope based on total
+        // CPU cores and the scope's budget fraction. Uses a conservative estimate
+        // of CPU per task (the profile's requested cores, or a default if unset).
         let scope_queue = node_state
             .scope_queue_depths
             .get(&scope_ctx.peer_scope)
             .copied()
             .unwrap_or(0);
         let scope_fraction = scope_ctx.capacity_budget.fraction_for(scope_ctx.peer_scope);
-        let total_queue_budget =
-            (node_state.capacity.cpu_cores_total / 0.1 * scope_fraction) as usize;
+        let cpu_per_task = profile
+            .cpu_cores
+            .unwrap_or(DefaultPlacementPolicy::DEFAULT_CPU_PER_TASK);
+        let total_queue_budget = if scope_fraction > f64::EPSILON && cpu_per_task > f64::EPSILON {
+            (node_state.capacity.cpu_cores_total * scope_fraction / cpu_per_task).max(1.0) as usize
+        } else {
+            0
+        };
         if total_queue_budget > 0 && scope_queue >= total_queue_budget {
             return None; // Scope budget exhausted
         }
@@ -2196,5 +2228,97 @@ mod tests {
             local_avg > commons_avg + 0.10,
             "Local avg ({local_avg:.4}) should be > Commons avg ({commons_avg:.4}) + 0.10"
         );
+    }
+
+    #[test]
+    fn test_demand_adjustment_all_saturated() {
+        let mut budget = CapacityBudget::default();
+        let original = budget.clone();
+
+        // All scopes at 100% utilization — all equal, so no shift
+        let mut utilization = HashMap::new();
+        for &scope in &ScopeLevel::ALL {
+            utilization.insert(scope, 1.0);
+        }
+
+        budget.adjust_from_demand(&utilization, 0.05);
+
+        // Fractions should remain approximately unchanged (all at same util)
+        assert!((budget.local_reserve - original.local_reserve).abs() < 0.001);
+        assert!((budget.commons_share - original.commons_share).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_demand_adjustment_one_hot() {
+        let mut budget = CapacityBudget::default();
+
+        // Only Local at 100%, rest at 0%
+        let mut utilization = HashMap::new();
+        utilization.insert(ScopeLevel::Local, 1.0);
+        utilization.insert(ScopeLevel::Cell, 0.0);
+        utilization.insert(ScopeLevel::Org, 0.0);
+        utilization.insert(ScopeLevel::Federation, 0.0);
+        utilization.insert(ScopeLevel::Commons, 0.0);
+
+        budget.adjust_from_demand(&utilization, 0.05);
+
+        // Local should have gained, others should have shrunk
+        assert!(budget.local_reserve > 0.30);
+        assert!(budget.cell_share < 0.25);
+        assert!(budget.org_share < 0.20);
+        assert!(budget.federation_share < 0.15);
+        assert!(budget.commons_share < 0.10);
+
+        // All fractions still within bounds
+        assert!(budget.validate().is_ok());
+    }
+
+    #[test]
+    fn test_demand_adjustment_convergence() {
+        let mut budget = CapacityBudget::default();
+
+        // Simulate 50 rounds of adjustment with stable demand pattern
+        let mut utilization = HashMap::new();
+        utilization.insert(ScopeLevel::Local, 0.90);
+        utilization.insert(ScopeLevel::Cell, 0.70);
+        utilization.insert(ScopeLevel::Org, 0.30);
+        utilization.insert(ScopeLevel::Federation, 0.10);
+        utilization.insert(ScopeLevel::Commons, 0.05);
+
+        let original_sum: f64 = [
+            budget.local_reserve,
+            budget.cell_share,
+            budget.org_share,
+            budget.federation_share,
+            budget.commons_share,
+        ]
+        .iter()
+        .sum();
+
+        for _ in 0..50 {
+            budget.adjust_from_demand(&utilization, 0.05);
+        }
+
+        // Sum should be preserved after many rounds
+        let final_sum: f64 = [
+            budget.local_reserve,
+            budget.cell_share,
+            budget.org_share,
+            budget.federation_share,
+            budget.commons_share,
+        ]
+        .iter()
+        .sum();
+        assert!(
+            (final_sum - original_sum).abs() < 0.01,
+            "Sum should be preserved: original={original_sum}, final={final_sum}"
+        );
+
+        // Ordering should reflect demand: Local > Cell > Org > Fed > Commons
+        assert!(budget.local_reserve > budget.cell_share);
+        assert!(budget.cell_share > budget.org_share);
+
+        // All fractions should remain valid
+        assert!(budget.validate().is_ok());
     }
 }

--- a/icn/crates/icn-compute/src/scheduler.rs
+++ b/icn/crates/icn-compute/src/scheduler.rs
@@ -735,12 +735,20 @@ impl CapacityBudget {
     ///
     /// Prevents complete starvation of any scope, ensuring every scope
     /// retains at least minimal capacity for burst traffic.
+    ///
+    /// **Security**: Without this bound, an attacker could submit sustained
+    /// high-demand tasks in one scope to drive other scopes' budgets to zero
+    /// via the demand feedback loop, effectively denying service to those scopes.
     const MIN_SCOPE_FRACTION: f64 = 0.01;
 
     /// Maximum fraction per scope during demand adjustment.
     ///
     /// Prevents any single scope from monopolizing capacity, leaving
     /// headroom for other scopes even under sustained high demand.
+    ///
+    /// **Security**: Without this bound, a single dominant scope could absorb
+    /// nearly all capacity, leaving other scopes unable to schedule tasks
+    /// even when legitimate demand arises.
     const MAX_SCOPE_FRACTION: f64 = 0.80;
 
     /// Adjust budget based on observed demand.
@@ -790,7 +798,8 @@ impl CapacityBudget {
         let avg_util = if count > 0 {
             total_util / count as f64
         } else {
-            return; // No data, no adjustment
+            tracing::trace!("adjust_from_demand: no utilization data, skipping adjustment");
+            return;
         };
 
         // Shift capacity: over-utilized scopes gain, under-utilized lose
@@ -2355,5 +2364,79 @@ mod tests {
         // Local (high demand) should gain, Commons (low demand) should lose
         assert!(budget.local_reserve > original.local_reserve);
         assert!(budget.commons_share < original.commons_share);
+    }
+
+    #[test]
+    fn test_scope_budget_exhaustion() {
+        let policy = DefaultPlacementPolicy::default();
+        let profile = ResourceProfile::minimal();
+
+        // Node with 8 cores, default budget gives Cell 25% → 2.0 CPU for Cell
+        // At 0.1 CPU/task (DEFAULT_CPU_PER_TASK) → 20 task slots for Cell scope
+        let node_state = NodeState {
+            did: "did:icn:executor".into(),
+            capacity: NodeCapacity {
+                cpu_cores_total: 8.0,
+                cpu_cores_available: 6.0,
+                memory_mb_total: 16384,
+                memory_mb_available: 12288,
+                storage_mb_available: 100_000,
+                network_mbps: 1000.0,
+                gpu_devices: vec![],
+                updated_at: 1000,
+            },
+            executing_tasks: HashMap::new(),
+            queue_depth: 0,
+            scope_queue_depths: HashMap::new(),
+        };
+        let task_hash = [0u8; 32];
+        let empty_locality = LocalityContext::empty();
+        let request = PlacementRequest {
+            task_hash,
+            resource_profile: profile.clone(),
+            locality_hints: vec![],
+            max_cost: None,
+            requested_at: 1000,
+            max_scope: None,
+            cell_affinity: None,
+        };
+
+        // Cell scope with queue under budget → accepted
+        let cell_ctx_low = ScopeContext {
+            peer_scope: ScopeLevel::Cell,
+            executor_cell: None,
+            capacity_budget: CapacityBudget::default(),
+        };
+        let mut under_budget_state = node_state.clone();
+        under_budget_state
+            .scope_queue_depths
+            .insert(ScopeLevel::Cell, 10);
+        let offer = policy.score_task(
+            &request,
+            "did:icn:alice",
+            &under_budget_state,
+            0.8,
+            &empty_locality,
+            &cell_ctx_low,
+        );
+        assert!(offer.is_some(), "Should accept when queue is under budget");
+
+        // Cell scope with queue over budget → rejected
+        let mut over_budget_state = node_state.clone();
+        over_budget_state
+            .scope_queue_depths
+            .insert(ScopeLevel::Cell, 25);
+        let offer = policy.score_task(
+            &request,
+            "did:icn:alice",
+            &over_budget_state,
+            0.8,
+            &empty_locality,
+            &cell_ctx_low,
+        );
+        assert!(
+            offer.is_none(),
+            "Should reject when scope queue exceeds budget"
+        );
     }
 }

--- a/icn/crates/icn-compute/src/types.rs
+++ b/icn/crates/icn-compute/src/types.rs
@@ -385,6 +385,14 @@ pub enum ComputeMessage {
         locality_hints: Vec<crate::scheduler::LocalityHint>,
         max_cost: Option<u64>,
         requested_at: u64,
+        /// Maximum scope level for placement (Epic 2).
+        /// Backward-compatible: defaults to None (no restriction).
+        #[serde(default)]
+        max_scope: Option<icn_kernel_api::ScopeLevel>,
+        /// Preferred cell for placement (Epic 2).
+        /// Backward-compatible: defaults to None.
+        #[serde(default)]
+        cell_affinity: Option<icn_kernel_api::CellId>,
     },
     /// Executor offers to execute a task (Phase 16B)
     PlacementOffer {


### PR DESCRIPTION
## Summary

Implements Epic 2 (#921) of the Cells & Scopes architecture: scope-aware capacity budgets and hierarchical task placement for the compute scheduler.

- **CapacityBudget** (#930): Per-scope resource allocation fractions with validation, cumulative queries, and demand-feedback adjustment
- **PlacementRequest extension** (#931): `max_scope` and `cell_affinity` fields (backward-compatible defaults)
- **Hierarchical placement routing** (#932): Scope gate, scope affinity scoring, cell affinity bonus, per-scope queue depth tracking
- **Demand-feedback loop** (#933): `adjust_from_demand()` shifts budget toward high-utilization scopes with sum-preserving normalization

## Changes

| File | Change |
|------|--------|
| `icn-compute/Cargo.toml` | Add `icn-kernel-api` dependency |
| `icn-compute/src/scheduler.rs` | `CapacityBudget`, `ScopeContext`, extended `PlacementRequest`, `NodeState`, `PlacementPolicy` trait, `DefaultPlacementPolicy` scoring + 9 new tests |
| `icn-compute/src/lib.rs` | Re-export `CapacityBudget`, `ScopeContext` |
| `icn-compute/src/actor/placement.rs` | Add `scope_queue_depths`, `ScopeContext`, `PlacementRequest` to `on_placement_request` |
| `icn-compute/src/actor/tests.rs` | Update `test_locality_aware_placement_scoring` for new API |
| `icn-compute/benches/compute_bench.rs` | Add `scope_queue_depths` field |
| `icn-compute/examples/scheduler_demo.rs` | Add scope context to demo |

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] All 190 icn-compute unit tests pass
- [x] All 32 icn-compute integration tests pass
- [x] Doc test for `CapacityBudget` passes
- [x] Full workspace test suite passes (4000+ tests)
- [x] Backward compatibility: existing `PlacementRequest` JSON without scope fields deserializes correctly

Closes #930, #931, #932, #933
Part of #921

🤖 Generated with [Claude Code](https://claude.com/claude-code)