### PR TITLE
feat(compute): add ExecutionReceipt type with chained Ed25519 signing (#938, #939)

### DIFF
--- a/icn/crates/icn-compute/src/lib.rs
+++ b/icn/crates/icn-compute/src/lib.rs
@@ -36,6 +36,7 @@ mod federation;
 mod migration_manager;
 mod migration_policy;
 mod policy;
+pub mod receipt;
 mod result_quorum;
 mod scheduler;
 mod task;
@@ -76,6 +77,7 @@ pub use policy::{
     CoopSchedulingPolicy, EnforcementMode, MemberQuota, PlacementConstraints, PolicyDecision,
     PolicyManager, SchedulingRule, UsageRecord, UsageTracker,
 };
+pub use receipt::{ExecutionReceipt, ReceiptHash, SettlementMessage, SignatureBytes};
 pub use result_quorum::{
     CollectedResult, QuorumStatus, ResultAggregator, ResultQuorumManager, TaskValue,
     TaskVerification, VerificationConfig, CLOCK_SKEW_TOLERANCE_MS, DEFAULT_COLLECTION_WINDOW_MS,
@@ -121,6 +123,12 @@ pub const TOPIC_DISPUTE: &str = "compute:dispute";
 
 /// Gossip topic for cross-cooperative federation (Phase 21)
 pub const TOPIC_FEDERATION: &str = "compute:federation";
+
+/// Gossip topic for settlement receipts (Epic 4)
+pub const TOPIC_SETTLEMENT_RECEIPT: &str = "settlement:receipt";
+
+/// Gossip topic for settlement disputes (Epic 4)
+pub const TOPIC_SETTLEMENT_DISPUTE: &str = "settlement:dispute";
 
 /// Minimum trust score to submit tasks (0.0 - 1.0)
 pub const MIN_TRUST_SUBMIT: f64 = 0.1;

--- a/icn/crates/icn-compute/src/receipt.rs
+++ b/icn/crates/icn-compute/src/receipt.rs
@@ -1,0 +1,871 @@
+//! Execution receipts for compute task metering and settlement.
+//!
+//! An [`ExecutionReceipt`] captures the resource usage of a completed task
+//! and carries a chain of Ed25519 signatures: executor → submitter → attester.
+//! Each signature uses a domain-separated payload to prevent cross-role reuse.
+
+use ed25519_dalek::Signer;
+use icn_kernel_api::ScopeLevel;
+use serde::{Deserialize, Serialize};
+
+use crate::error::ComputeError;
+
+/// Blake3 hash identifying a receipt by its content (non-signature fields).
+pub type ReceiptHash = [u8; 32];
+
+// ---------------------------------------------------------------------------
+// Domain-separation prefixes (byte constants, single source of truth)
+// ---------------------------------------------------------------------------
+
+/// Prefix for executor signing payload.
+pub const SIGN_PREFIX_EXECUTOR: &[u8] = b"icn-receipt-executor-v1:";
+
+/// Prefix for submitter acknowledgement payload.
+pub const SIGN_PREFIX_SUBMITTER: &[u8] = b"icn-receipt-submitter-v1:";
+
+/// Prefix for attester signing payload.
+pub const SIGN_PREFIX_ATTESTER: &[u8] = b"icn-receipt-attester-v1:";
+
+// ---------------------------------------------------------------------------
+// SignatureBytes — fixed-size Ed25519 signature with serde support
+// ---------------------------------------------------------------------------
+
+/// A 64-byte Ed25519 signature with hex-based serde serialization.
+///
+/// Using a newtype instead of raw `[u8; 64]` gives us:
+/// - Type-level length enforcement (no accidental truncation)
+/// - Deterministic hex serialization (readable in JSON, stable across platforms)
+/// - Clean `From`/`Into` conversions with `ed25519_dalek::Signature`
+///
+/// `Copy` is intentionally **not** derived — signatures should not be
+/// implicitly copied, only explicitly cloned or borrowed via [`as_bytes()`].
+#[derive(Clone, PartialEq, Eq)]
+pub struct SignatureBytes(pub [u8; 64]);
+
+impl SignatureBytes {
+    /// View as a reference to the underlying 64-byte array.
+    pub fn as_bytes(&self) -> &[u8; 64] {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for SignatureBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Sig({}..)", hex::encode(&self.0[..4]))
+    }
+}
+
+impl Serialize for SignatureBytes {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&hex::encode(self.0))
+    }
+}
+
+impl<'de> Deserialize<'de> for SignatureBytes {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        let bytes = hex::decode(&s).map_err(serde::de::Error::custom)?;
+        let arr: [u8; 64] = bytes
+            .try_into()
+            .map_err(|_| serde::de::Error::custom("expected 64 bytes for Ed25519 signature"))?;
+        Ok(SignatureBytes(arr))
+    }
+}
+
+impl From<[u8; 64]> for SignatureBytes {
+    fn from(bytes: [u8; 64]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl From<ed25519_dalek::Signature> for SignatureBytes {
+    fn from(sig: ed25519_dalek::Signature) -> Self {
+        Self(sig.to_bytes())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Protocol-stable scope encoding
+// ---------------------------------------------------------------------------
+
+/// Encode [`ScopeLevel`] as a protocol-stable byte.
+///
+/// This explicit match decouples the receipt wire format from the enum's
+/// `#[repr(u8)]` discriminants, preventing silent breakage if kernel-api
+/// reorders or adds variants.
+fn scope_to_wire(scope: ScopeLevel) -> u8 {
+    match scope {
+        ScopeLevel::Local => 0,
+        ScopeLevel::Cell => 1,
+        ScopeLevel::Org => 2,
+        ScopeLevel::Federation => 3,
+        ScopeLevel::Commons => 4,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ExecutionReceipt
+// ---------------------------------------------------------------------------
+
+/// A signed attestation of resource consumption for a completed compute task.
+///
+/// The receipt binds metering data to a chain of three signatures:
+///
+/// 1. **Executor** — the node that ran the task, signs the raw metering.
+/// 2. **Submitter** — the node that submitted the task, acknowledges the cost.
+/// 3. **Attester** — an independent witness, vouches for the receipt.
+///
+/// All metering values use deterministic integer units to guarantee
+/// bit-exact signing payloads across architectures.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ExecutionReceipt {
+    // -- Identity --
+    /// Blake3 hash of the original [`ComputeTask`].
+    pub task_hash: [u8; 32],
+    /// DID of the executor node (e.g. `did:icn:z6Mk...`).
+    pub executor: String,
+    /// DID of the task submitter.
+    pub submitter: String,
+    /// Scope at which this task was executed.
+    pub scope: ScopeLevel,
+
+    // -- Metering (deterministic integer units) --
+    /// CPU time consumed, in milliseconds.
+    pub cpu_millis: u64,
+    /// Memory usage, in megabyte-milliseconds.
+    pub memory_mb_millis: u64,
+    /// Persistent storage consumed, in bytes.
+    pub storage_bytes: u64,
+    /// Network egress, in bytes.
+    pub egress_bytes: u64,
+
+    // -- Cost --
+    /// Fuel consumed during execution.
+    pub fuel_used: u64,
+    /// Total cost in the settlement currency's smallest unit.
+    pub cost: u64,
+
+    // -- Signatures (Ed25519 = 64 bytes fixed) --
+    /// Executor's signature over the base signing payload.
+    pub executor_signature: Option<SignatureBytes>,
+    /// Submitter's acknowledgement signature (includes executor sig in payload).
+    pub submitter_ack: Option<SignatureBytes>,
+    /// DID of the independent attester, if present.
+    pub attester: Option<String>,
+    /// Attester's signature (includes both prior sigs in payload).
+    pub attester_signature: Option<SignatureBytes>,
+
+    // -- Timestamp --
+    /// Unix timestamp (seconds) when the receipt was created.
+    pub created_at: u64,
+}
+
+impl ExecutionReceipt {
+    /// Deterministic byte payload of all non-signature fields.
+    ///
+    /// This is the content that signatures bind to. Field order is fixed and
+    /// all variable-length strings are length-prefixed to prevent ambiguity.
+    pub fn signing_payload(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(256);
+
+        // Identity
+        buf.extend_from_slice(&self.task_hash);
+        buf.extend_from_slice(&(self.executor.len() as u32).to_le_bytes());
+        buf.extend_from_slice(self.executor.as_bytes());
+        buf.extend_from_slice(&(self.submitter.len() as u32).to_le_bytes());
+        buf.extend_from_slice(self.submitter.as_bytes());
+        buf.push(scope_to_wire(self.scope));
+
+        // Metering
+        buf.extend_from_slice(&self.cpu_millis.to_le_bytes());
+        buf.extend_from_slice(&self.memory_mb_millis.to_le_bytes());
+        buf.extend_from_slice(&self.storage_bytes.to_le_bytes());
+        buf.extend_from_slice(&self.egress_bytes.to_le_bytes());
+
+        // Cost
+        buf.extend_from_slice(&self.fuel_used.to_le_bytes());
+        buf.extend_from_slice(&self.cost.to_le_bytes());
+
+        // Timestamp
+        buf.extend_from_slice(&self.created_at.to_le_bytes());
+
+        buf
+    }
+
+    /// Content hash of the receipt (blake3 over the signing payload).
+    ///
+    /// This identifies the logical receipt — same task + same metering +
+    /// same participants → same hash, regardless of signatures.
+    /// Used as the deduplication key for settlement.
+    pub fn receipt_hash(&self) -> ReceiptHash {
+        *blake3::hash(&self.signing_payload()).as_bytes()
+    }
+
+    /// Returns `true` if all three signatures are present.
+    pub fn is_fully_attested(&self) -> bool {
+        self.executor_signature.is_some()
+            && self.submitter_ack.is_some()
+            && self.attester.is_some()
+            && self.attester_signature.is_some()
+    }
+
+    /// Validate structural invariants (DID format, metering sanity).
+    pub fn validate(&self) -> Result<(), ComputeError> {
+        if !self.executor.starts_with("did:icn:") {
+            return Err(ComputeError::InvalidInput(format!(
+                "executor DID has invalid format: {}",
+                self.executor
+            )));
+        }
+        if !self.submitter.starts_with("did:icn:") {
+            return Err(ComputeError::InvalidInput(format!(
+                "submitter DID has invalid format: {}",
+                self.submitter
+            )));
+        }
+        if let Some(ref attester) = self.attester {
+            if !attester.starts_with("did:icn:") {
+                return Err(ComputeError::InvalidInput(format!(
+                    "attester DID has invalid format: {attester}"
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    // -- Signing (builder-style, consumes and returns Result) ---------------
+
+    /// Sign as executor. Sets `executor_signature`.
+    ///
+    /// Payload: `SIGN_PREFIX_EXECUTOR || signing_payload()`
+    pub fn sign_executor(mut self, key: &ed25519_dalek::SigningKey) -> Self {
+        let payload = self.executor_sign_payload();
+        let sig = key.sign(&payload);
+        self.executor_signature = Some(SignatureBytes::from(sig));
+        self
+    }
+
+    /// Sign as submitter. Sets `submitter_ack`.
+    ///
+    /// Payload: `SIGN_PREFIX_SUBMITTER || signing_payload() || executor_signature`
+    ///
+    /// Returns `Err` if `executor_signature` is not present — the chain
+    /// must be built in order.
+    pub fn sign_submitter_ack(
+        mut self,
+        key: &ed25519_dalek::SigningKey,
+    ) -> Result<Self, ComputeError> {
+        if self.executor_signature.is_none() {
+            return Err(ComputeError::InvalidInput(
+                "cannot sign submitter ack: executor_signature missing".into(),
+            ));
+        }
+        let payload = self.submitter_sign_payload();
+        let sig = key.sign(&payload);
+        self.submitter_ack = Some(SignatureBytes::from(sig));
+        Ok(self)
+    }
+
+    /// Sign as attester. Sets `attester` and `attester_signature`.
+    ///
+    /// Payload: `SIGN_PREFIX_ATTESTER || signing_payload() || executor_signature || submitter_ack`
+    ///
+    /// Returns `Err` if either prior signature is missing.
+    pub fn sign_attester(
+        mut self,
+        attester_did: String,
+        key: &ed25519_dalek::SigningKey,
+    ) -> Result<Self, ComputeError> {
+        if self.executor_signature.is_none() {
+            return Err(ComputeError::InvalidInput(
+                "cannot sign attester: executor_signature missing".into(),
+            ));
+        }
+        if self.submitter_ack.is_none() {
+            return Err(ComputeError::InvalidInput(
+                "cannot sign attester: submitter_ack missing".into(),
+            ));
+        }
+        self.attester = Some(attester_did);
+        let payload = self.attester_sign_payload();
+        let sig = key.sign(&payload);
+        self.attester_signature = Some(SignatureBytes::from(sig));
+        Ok(self)
+    }
+
+    // -- Verification -------------------------------------------------------
+
+    /// Verify the executor's signature against the given DID.
+    pub fn verify_executor(&self, executor_did: &icn_identity::Did) -> Result<(), ComputeError> {
+        let sig = self
+            .executor_signature
+            .as_ref()
+            .ok_or_else(|| ComputeError::InvalidSignature("executor signature missing".into()))?;
+        self.verify_sig(executor_did, sig, &self.executor_sign_payload())
+    }
+
+    /// Verify the submitter's acknowledgement signature against the given DID.
+    ///
+    /// Also enforces that `executor_signature` is present — a submitter ack
+    /// verified against an empty executor sig slot would be meaningless.
+    pub fn verify_submitter_ack(
+        &self,
+        submitter_did: &icn_identity::Did,
+    ) -> Result<(), ComputeError> {
+        if self.executor_signature.is_none() {
+            return Err(ComputeError::InvalidSignature(
+                "cannot verify submitter ack: executor signature missing".into(),
+            ));
+        }
+        let sig = self
+            .submitter_ack
+            .as_ref()
+            .ok_or_else(|| ComputeError::InvalidSignature("submitter ack missing".into()))?;
+        self.verify_sig(submitter_did, sig, &self.submitter_sign_payload())
+    }
+
+    /// Verify the attester's signature against the given DID.
+    ///
+    /// Also enforces that both prior signatures are present.
+    pub fn verify_attester(&self, attester_did: &icn_identity::Did) -> Result<(), ComputeError> {
+        if self.executor_signature.is_none() || self.submitter_ack.is_none() {
+            return Err(ComputeError::InvalidSignature(
+                "cannot verify attester: prior signatures missing".into(),
+            ));
+        }
+        let sig = self
+            .attester_signature
+            .as_ref()
+            .ok_or_else(|| ComputeError::InvalidSignature("attester signature missing".into()))?;
+        self.verify_sig(attester_did, sig, &self.attester_sign_payload())
+    }
+
+    // -- Internal helpers ---------------------------------------------------
+
+    fn executor_sign_payload(&self) -> Vec<u8> {
+        let base = self.signing_payload();
+        let mut buf = Vec::with_capacity(SIGN_PREFIX_EXECUTOR.len() + base.len());
+        buf.extend_from_slice(SIGN_PREFIX_EXECUTOR);
+        buf.extend_from_slice(&base);
+        buf
+    }
+
+    fn submitter_sign_payload(&self) -> Vec<u8> {
+        let base = self.signing_payload();
+        let exec_sig: &[u8] = self
+            .executor_signature
+            .as_ref()
+            .map(|s| s.as_bytes().as_slice())
+            .unwrap_or(&[]);
+        let mut buf = Vec::with_capacity(SIGN_PREFIX_SUBMITTER.len() + base.len() + exec_sig.len());
+        buf.extend_from_slice(SIGN_PREFIX_SUBMITTER);
+        buf.extend_from_slice(&base);
+        buf.extend_from_slice(exec_sig);
+        buf
+    }
+
+    fn attester_sign_payload(&self) -> Vec<u8> {
+        let base = self.signing_payload();
+        let exec_sig: &[u8] = self
+            .executor_signature
+            .as_ref()
+            .map(|s| s.as_bytes().as_slice())
+            .unwrap_or(&[]);
+        let sub_sig: &[u8] = self
+            .submitter_ack
+            .as_ref()
+            .map(|s| s.as_bytes().as_slice())
+            .unwrap_or(&[]);
+        let mut buf = Vec::with_capacity(
+            SIGN_PREFIX_ATTESTER.len() + base.len() + exec_sig.len() + sub_sig.len(),
+        );
+        buf.extend_from_slice(SIGN_PREFIX_ATTESTER);
+        buf.extend_from_slice(&base);
+        buf.extend_from_slice(exec_sig);
+        buf.extend_from_slice(sub_sig);
+        buf
+    }
+
+    fn verify_sig(
+        &self,
+        did: &icn_identity::Did,
+        sig_bytes: &SignatureBytes,
+        payload: &[u8],
+    ) -> Result<(), ComputeError> {
+        use ed25519_dalek::Verifier;
+
+        let verifying_key = did.to_verifying_key().map_err(|e| {
+            ComputeError::InvalidSignature(format!("cannot extract public key from DID: {e}"))
+        })?;
+
+        let signature = ed25519_dalek::Signature::from_bytes(sig_bytes.as_bytes());
+
+        verifying_key.verify(payload, &signature).map_err(|e| {
+            ComputeError::InvalidSignature(format!("signature verification failed: {e}"))
+        })?;
+
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SettlementMessage — gossip envelope for receipt distribution
+// ---------------------------------------------------------------------------
+
+/// Messages sent over gossip for settlement coordination.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum SettlementMessage {
+    /// A fully-attested execution receipt ready for settlement.
+    Receipt(Box<ExecutionReceipt>),
+    /// A dispute raised against a previously submitted receipt.
+    Dispute {
+        receipt_hash: ReceiptHash,
+        disputer: String,
+        reason: String,
+        timestamp: u64,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: build a minimal valid receipt with no signatures.
+    fn sample_receipt() -> ExecutionReceipt {
+        ExecutionReceipt {
+            task_hash: [0xAB; 32],
+            executor: "did:icn:z6MkExecutor".to_string(),
+            submitter: "did:icn:z6MkSubmitter".to_string(),
+            scope: ScopeLevel::Cell,
+            cpu_millis: 1500,
+            memory_mb_millis: 4096,
+            storage_bytes: 2048,
+            egress_bytes: 512,
+            fuel_used: 100,
+            cost: 50,
+            executor_signature: None,
+            submitter_ack: None,
+            attester: None,
+            attester_signature: None,
+            created_at: 1_700_000_000,
+        }
+    }
+
+    // -- Step 1: Determinism and structural tests ---
+
+    #[test]
+    fn test_signing_payload_deterministic() {
+        let r1 = sample_receipt();
+        let r2 = sample_receipt();
+        assert_eq!(r1.signing_payload(), r2.signing_payload());
+    }
+
+    #[test]
+    fn test_signing_payload_changes_on_field_mutation() {
+        let base = sample_receipt();
+        let base_payload = base.signing_payload();
+
+        let mut r = sample_receipt();
+        r.task_hash[0] = 0x00;
+        assert_ne!(r.signing_payload(), base_payload, "task_hash mutation");
+
+        let mut r = sample_receipt();
+        r.executor = "did:icn:z6MkOtherExecutor".to_string();
+        assert_ne!(r.signing_payload(), base_payload, "executor mutation");
+
+        let mut r = sample_receipt();
+        r.submitter = "did:icn:z6MkOtherSubmitter".to_string();
+        assert_ne!(r.signing_payload(), base_payload, "submitter mutation");
+
+        let mut r = sample_receipt();
+        r.scope = ScopeLevel::Federation;
+        assert_ne!(r.signing_payload(), base_payload, "scope mutation");
+
+        let mut r = sample_receipt();
+        r.cpu_millis = 9999;
+        assert_ne!(r.signing_payload(), base_payload, "cpu_millis mutation");
+
+        let mut r = sample_receipt();
+        r.memory_mb_millis = 9999;
+        assert_ne!(
+            r.signing_payload(),
+            base_payload,
+            "memory_mb_millis mutation"
+        );
+
+        let mut r = sample_receipt();
+        r.storage_bytes = 9999;
+        assert_ne!(r.signing_payload(), base_payload, "storage_bytes mutation");
+
+        let mut r = sample_receipt();
+        r.egress_bytes = 9999;
+        assert_ne!(r.signing_payload(), base_payload, "egress_bytes mutation");
+
+        let mut r = sample_receipt();
+        r.fuel_used = 9999;
+        assert_ne!(r.signing_payload(), base_payload, "fuel_used mutation");
+
+        let mut r = sample_receipt();
+        r.cost = 9999;
+        assert_ne!(r.signing_payload(), base_payload, "cost mutation");
+
+        let mut r = sample_receipt();
+        r.created_at = 9999;
+        assert_ne!(r.signing_payload(), base_payload, "created_at mutation");
+    }
+
+    #[test]
+    fn test_signing_payload_length_prefix_prevents_collision() {
+        let mut r1 = sample_receipt();
+        r1.executor = "did:icn:ab".to_string();
+        r1.submitter = "did:icn:cd".to_string();
+
+        let mut r2 = sample_receipt();
+        r2.executor = "did:icn:abc".to_string();
+        r2.submitter = "did:icn:d".to_string();
+
+        assert_ne!(
+            r1.signing_payload(),
+            r2.signing_payload(),
+            "length-prefix must disambiguate string boundaries"
+        );
+    }
+
+    #[test]
+    fn test_receipt_hash_deterministic() {
+        let r1 = sample_receipt();
+        let r2 = sample_receipt();
+        assert_eq!(r1.receipt_hash(), r2.receipt_hash());
+    }
+
+    #[test]
+    fn test_receipt_hash_changes_on_mutation() {
+        let base = sample_receipt();
+        let mut r = sample_receipt();
+        r.cost = 9999;
+        assert_ne!(r.receipt_hash(), base.receipt_hash());
+    }
+
+    #[test]
+    fn test_is_fully_attested() {
+        let mut r = sample_receipt();
+        assert!(!r.is_fully_attested());
+
+        r.executor_signature = Some(SignatureBytes([0x11; 64]));
+        assert!(!r.is_fully_attested());
+
+        r.submitter_ack = Some(SignatureBytes([0x22; 64]));
+        assert!(!r.is_fully_attested(), "missing attester DID + sig");
+
+        r.attester = Some("did:icn:z6MkAttester".to_string());
+        assert!(!r.is_fully_attested(), "missing attester signature");
+
+        r.attester_signature = Some(SignatureBytes([0x33; 64]));
+        assert!(r.is_fully_attested());
+    }
+
+    #[test]
+    fn test_validate_rejects_bad_executor_did() {
+        let mut r = sample_receipt();
+        r.executor = "not-a-did".to_string();
+        let err = r.validate().unwrap_err();
+        assert!(err.to_string().contains("executor DID"));
+    }
+
+    #[test]
+    fn test_validate_rejects_bad_submitter_did() {
+        let mut r = sample_receipt();
+        r.submitter = "bad-format".to_string();
+        let err = r.validate().unwrap_err();
+        assert!(err.to_string().contains("submitter DID"));
+    }
+
+    #[test]
+    fn test_validate_rejects_bad_attester_did() {
+        let mut r = sample_receipt();
+        r.attester = Some("garbage".to_string());
+        let err = r.validate().unwrap_err();
+        assert!(err.to_string().contains("attester DID"));
+    }
+
+    #[test]
+    fn test_validate_accepts_valid_receipt() {
+        let r = sample_receipt();
+        assert!(r.validate().is_ok());
+    }
+
+    #[test]
+    fn test_signature_bytes_serde_roundtrip() {
+        let sig = SignatureBytes([0xAA; 64]);
+        let json = serde_json::to_string(&sig).unwrap();
+        let deserialized: SignatureBytes = serde_json::from_str(&json).unwrap();
+        assert_eq!(sig, deserialized);
+    }
+
+    #[test]
+    fn test_receipt_serde_roundtrip() {
+        let mut r = sample_receipt();
+        r.executor_signature = Some(SignatureBytes([0x11; 64]));
+        let json = serde_json::to_string(&r).unwrap();
+        let deserialized: ExecutionReceipt = serde_json::from_str(&json).unwrap();
+        assert_eq!(r, deserialized);
+    }
+
+    // -- Step 2: Signing and verification tests ---
+
+    /// Construct an `ed25519_dalek::SigningKey` from a `KeyPair`.
+    fn to_signing_key(kp: &icn_identity::KeyPair) -> ed25519_dalek::SigningKey {
+        ed25519_dalek::SigningKey::from_bytes(&kp.to_signing_key_bytes())
+    }
+
+    /// Build a receipt with executor DID matching a real keypair.
+    fn receipt_with_real_keys() -> (ExecutionReceipt, icn_identity::KeyPair) {
+        let executor_kp = icn_identity::KeyPair::generate().unwrap();
+        let r = ExecutionReceipt {
+            task_hash: [0xAB; 32],
+            executor: executor_kp.did().to_string(),
+            submitter: "did:icn:z6MkSubmitter".to_string(),
+            scope: ScopeLevel::Cell,
+            cpu_millis: 1500,
+            memory_mb_millis: 4096,
+            storage_bytes: 2048,
+            egress_bytes: 512,
+            fuel_used: 100,
+            cost: 50,
+            executor_signature: None,
+            submitter_ack: None,
+            attester: None,
+            attester_signature: None,
+            created_at: 1_700_000_000,
+        };
+        (r, executor_kp)
+    }
+
+    #[test]
+    fn test_sign_verify_executor() {
+        let (r, kp) = receipt_with_real_keys();
+        let r = r.sign_executor(&to_signing_key(&kp));
+        assert!(r.executor_signature.is_some());
+        assert!(r.verify_executor(kp.did()).is_ok());
+    }
+
+    #[test]
+    fn test_sign_verify_submitter_ack() {
+        let (r, executor_kp) = receipt_with_real_keys();
+        let submitter_kp = icn_identity::KeyPair::generate().unwrap();
+        let mut r = r.sign_executor(&to_signing_key(&executor_kp));
+        r.submitter = submitter_kp.did().to_string();
+        let r = r
+            .sign_submitter_ack(&to_signing_key(&submitter_kp))
+            .unwrap();
+        assert!(r.submitter_ack.is_some());
+        assert!(r.verify_submitter_ack(submitter_kp.did()).is_ok());
+    }
+
+    #[test]
+    fn test_sign_verify_attester() {
+        let (r, executor_kp) = receipt_with_real_keys();
+        let submitter_kp = icn_identity::KeyPair::generate().unwrap();
+        let attester_kp = icn_identity::KeyPair::generate().unwrap();
+
+        let mut r = r.sign_executor(&to_signing_key(&executor_kp));
+        r.submitter = submitter_kp.did().to_string();
+        let r = r
+            .sign_submitter_ack(&to_signing_key(&submitter_kp))
+            .unwrap()
+            .sign_attester(attester_kp.did().to_string(), &to_signing_key(&attester_kp))
+            .unwrap();
+
+        assert!(r.is_fully_attested());
+        assert!(r.verify_attester(attester_kp.did()).is_ok());
+    }
+
+    #[test]
+    fn test_verify_executor_wrong_key() {
+        let (r, executor_kp) = receipt_with_real_keys();
+        let r = r.sign_executor(&to_signing_key(&executor_kp));
+
+        let wrong_kp = icn_identity::KeyPair::generate().unwrap();
+        let err = r.verify_executor(wrong_kp.did()).unwrap_err();
+        assert!(err.to_string().contains("verification failed"));
+    }
+
+    #[test]
+    fn test_verify_executor_tampered() {
+        let (r, executor_kp) = receipt_with_real_keys();
+        let mut r = r.sign_executor(&to_signing_key(&executor_kp));
+
+        // Tamper with cost after signing
+        r.cost = 9999;
+        let err = r.verify_executor(executor_kp.did()).unwrap_err();
+        assert!(err.to_string().contains("verification failed"));
+    }
+
+    #[test]
+    fn test_submitter_payload_includes_executor_sig() {
+        // Identical base fields, only vary executor signature bytes.
+        // This directly proves the submitter payload binds to the executor sig.
+        let mut r1 = sample_receipt();
+        r1.executor_signature = Some(SignatureBytes([0x11; 64]));
+
+        let mut r2 = sample_receipt();
+        r2.executor_signature = Some(SignatureBytes([0x22; 64]));
+
+        assert_ne!(
+            r1.submitter_sign_payload(),
+            r2.submitter_sign_payload(),
+            "submitter payload must bind to executor signature bytes"
+        );
+    }
+
+    #[test]
+    fn test_attester_payload_includes_both_prior_sigs() {
+        let mut r1 = sample_receipt();
+        r1.executor_signature = Some(SignatureBytes([0x11; 64]));
+        r1.submitter_ack = Some(SignatureBytes([0xAA; 64]));
+
+        let mut r2 = sample_receipt();
+        r2.executor_signature = Some(SignatureBytes([0x11; 64]));
+        r2.submitter_ack = Some(SignatureBytes([0xBB; 64]));
+
+        assert_ne!(
+            r1.attester_sign_payload(),
+            r2.attester_sign_payload(),
+            "attester payload must bind to submitter ack bytes"
+        );
+    }
+
+    #[test]
+    fn test_builder_chain() {
+        let executor_kp = icn_identity::KeyPair::generate().unwrap();
+        let submitter_kp = icn_identity::KeyPair::generate().unwrap();
+        let attester_kp = icn_identity::KeyPair::generate().unwrap();
+
+        let r = ExecutionReceipt {
+            task_hash: [0xCC; 32],
+            executor: executor_kp.did().to_string(),
+            submitter: submitter_kp.did().to_string(),
+            scope: ScopeLevel::Org,
+            cpu_millis: 500,
+            memory_mb_millis: 1024,
+            storage_bytes: 0,
+            egress_bytes: 0,
+            fuel_used: 10,
+            cost: 5,
+            executor_signature: None,
+            submitter_ack: None,
+            attester: None,
+            attester_signature: None,
+            created_at: 1_700_000_001,
+        };
+
+        let r = r
+            .sign_executor(&to_signing_key(&executor_kp))
+            .sign_submitter_ack(&to_signing_key(&submitter_kp))
+            .unwrap()
+            .sign_attester(attester_kp.did().to_string(), &to_signing_key(&attester_kp))
+            .unwrap();
+
+        assert!(r.is_fully_attested());
+        assert!(r.verify_executor(executor_kp.did()).is_ok());
+        assert!(r.verify_submitter_ack(submitter_kp.did()).is_ok());
+        assert!(r.verify_attester(attester_kp.did()).is_ok());
+    }
+
+    #[test]
+    fn test_settlement_message_serde() {
+        let r = sample_receipt();
+        let msg = SettlementMessage::Receipt(Box::new(r));
+        let json = serde_json::to_string(&msg).unwrap();
+        let deserialized: SettlementMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, deserialized);
+
+        let dispute = SettlementMessage::Dispute {
+            receipt_hash: [0xFF; 32],
+            disputer: "did:icn:z6MkDisputer".to_string(),
+            reason: "incorrect metering".to_string(),
+            timestamp: 1_700_000_100,
+        };
+        let json = serde_json::to_string(&dispute).unwrap();
+        let deserialized: SettlementMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(dispute, deserialized);
+    }
+
+    // -- Signature prerequisite enforcement tests ---
+
+    #[test]
+    fn test_verify_missing_executor_sig() {
+        let (r, kp) = receipt_with_real_keys();
+        let err = r.verify_executor(kp.did()).unwrap_err();
+        assert!(err.to_string().contains("missing"));
+    }
+
+    #[test]
+    fn test_verify_missing_submitter_ack() {
+        let (r, kp) = receipt_with_real_keys();
+        let r = r.sign_executor(&to_signing_key(&kp));
+        let submitter_kp = icn_identity::KeyPair::generate().unwrap();
+        let err = r.verify_submitter_ack(submitter_kp.did()).unwrap_err();
+        assert!(err.to_string().contains("missing"));
+    }
+
+    #[test]
+    fn test_verify_submitter_rejects_missing_executor_sig() {
+        // A receipt with submitter_ack but no executor_signature must fail
+        // verification — the chain is broken.
+        let mut r = sample_receipt();
+        r.submitter_ack = Some(SignatureBytes([0xAA; 64])); // fake, but present
+        let submitter_kp = icn_identity::KeyPair::generate().unwrap();
+        let err = r.verify_submitter_ack(submitter_kp.did()).unwrap_err();
+        assert!(
+            err.to_string().contains("executor signature missing"),
+            "should enforce chain prerequisite, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_verify_attester_rejects_missing_prior_sigs() {
+        let mut r = sample_receipt();
+        r.attester_signature = Some(SignatureBytes([0xBB; 64])); // fake, but present
+        let attester_kp = icn_identity::KeyPair::generate().unwrap();
+        let err = r.verify_attester(attester_kp.did()).unwrap_err();
+        assert!(
+            err.to_string().contains("prior signatures missing"),
+            "should enforce chain prerequisite, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_sign_submitter_without_executor_returns_error() {
+        let r = sample_receipt();
+        let kp = icn_identity::KeyPair::generate().unwrap();
+        let err = r.sign_submitter_ack(&to_signing_key(&kp)).unwrap_err();
+        assert!(err.to_string().contains("executor_signature missing"));
+    }
+
+    #[test]
+    fn test_sign_attester_without_submitter_returns_error() {
+        let (r, executor_kp) = receipt_with_real_keys();
+        let r = r.sign_executor(&to_signing_key(&executor_kp));
+        let kp = icn_identity::KeyPair::generate().unwrap();
+        let err = r
+            .sign_attester(kp.did().to_string(), &to_signing_key(&kp))
+            .unwrap_err();
+        assert!(err.to_string().contains("submitter_ack missing"));
+    }
+
+    #[test]
+    fn test_sign_attester_without_executor_returns_error() {
+        let r = sample_receipt();
+        let kp = icn_identity::KeyPair::generate().unwrap();
+        let err = r
+            .sign_attester(kp.did().to_string(), &to_signing_key(&kp))
+            .unwrap_err();
+        assert!(err.to_string().contains("executor_signature missing"));
+    }
+}

--- a/icn/crates/icn-compute/src/receipt.rs
+++ b/icn/crates/icn-compute/src/receipt.rs
@@ -39,13 +39,24 @@ pub const SIGN_PREFIX_ATTESTER: &[u8] = b"icn-receipt-attester-v1:";
 ///
 /// `Copy` is intentionally **not** derived — signatures should not be
 /// implicitly copied, only explicitly cloned or borrowed via [`as_bytes()`].
+///
+/// The inner field is private to enforce that all access goes through
+/// explicit methods, preserving the non-Copy invariant.
 #[derive(Clone, PartialEq, Eq)]
-pub struct SignatureBytes(pub [u8; 64]);
+pub struct SignatureBytes([u8; 64]);
 
 impl SignatureBytes {
     /// View as a reference to the underlying 64-byte array.
     pub fn as_bytes(&self) -> &[u8; 64] {
         &self.0
+    }
+
+    /// Return an owned copy of the underlying 64-byte array.
+    ///
+    /// This makes creating owned copies an explicit operation, preserving
+    /// the intent behind not implementing `Copy` for `SignatureBytes`.
+    pub fn to_bytes(&self) -> [u8; 64] {
+        self.0
     }
 }
 
@@ -57,18 +68,30 @@ impl std::fmt::Debug for SignatureBytes {
 
 impl Serialize for SignatureBytes {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&hex::encode(self.0))
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&hex::encode(self.0))
+        } else {
+            serializer.serialize_bytes(&self.0)
+        }
     }
 }
 
 impl<'de> Deserialize<'de> for SignatureBytes {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let s = String::deserialize(deserializer)?;
-        let bytes = hex::decode(&s).map_err(serde::de::Error::custom)?;
-        let arr: [u8; 64] = bytes
-            .try_into()
-            .map_err(|_| serde::de::Error::custom("expected 64 bytes for Ed25519 signature"))?;
-        Ok(SignatureBytes(arr))
+        if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            let bytes = hex::decode(&s).map_err(serde::de::Error::custom)?;
+            let arr: [u8; 64] = bytes
+                .try_into()
+                .map_err(|_| serde::de::Error::custom("expected 64 bytes for Ed25519 signature"))?;
+            Ok(SignatureBytes(arr))
+        } else {
+            let bytes = <Vec<u8>>::deserialize(deserializer)?;
+            let arr: [u8; 64] = bytes
+                .try_into()
+                .map_err(|_| serde::de::Error::custom("expected 64 bytes for Ed25519 signature"))?;
+            Ok(SignatureBytes(arr))
+        }
     }
 }
 
@@ -305,9 +328,11 @@ impl ExecutionReceipt {
         Ok(())
     }
 
-    // -- Signing (builder-style, consumes and returns Result) ---------------
+    // -- Signing (builder-style; executor infallible, later steps return Result) --
 
     /// Sign as executor. Sets `executor_signature`.
+    ///
+    /// This step is infallible and returns `Self` for ergonomic chaining.
     ///
     /// Payload: `SIGN_PREFIX_EXECUTOR || signing_payload()`
     pub fn sign_executor(mut self, key: &ed25519_dalek::SigningKey) -> Self {
@@ -368,7 +393,16 @@ impl ExecutionReceipt {
     // -- Verification -------------------------------------------------------
 
     /// Verify the executor's signature against the given DID.
+    ///
+    /// Enforces that `executor_did` matches the receipt's `executor` field,
+    /// preventing verification against a DID that doesn't match the claimed identity.
     pub fn verify_executor(&self, executor_did: &icn_identity::Did) -> Result<(), ComputeError> {
+        if executor_did.to_string() != self.executor {
+            return Err(ComputeError::InvalidSignature(format!(
+                "DID mismatch: receipt claims executor={}, but verifying against {}",
+                self.executor, executor_did
+            )));
+        }
         let sig = self
             .executor_signature
             .as_ref()
@@ -378,12 +412,19 @@ impl ExecutionReceipt {
 
     /// Verify the submitter's acknowledgement signature against the given DID.
     ///
-    /// Also enforces that `executor_signature` is present — a submitter ack
-    /// verified against an empty executor sig slot would be meaningless.
+    /// Enforces that:
+    /// - `submitter_did` matches the receipt's `submitter` field
+    /// - `executor_signature` is present (chain prerequisite)
     pub fn verify_submitter_ack(
         &self,
         submitter_did: &icn_identity::Did,
     ) -> Result<(), ComputeError> {
+        if submitter_did.to_string() != self.submitter {
+            return Err(ComputeError::InvalidSignature(format!(
+                "DID mismatch: receipt claims submitter={}, but verifying against {}",
+                self.submitter, submitter_did
+            )));
+        }
         if self.executor_signature.is_none() {
             return Err(ComputeError::InvalidSignature(
                 "cannot verify submitter ack: executor signature missing".into(),
@@ -398,8 +439,23 @@ impl ExecutionReceipt {
 
     /// Verify the attester's signature against the given DID.
     ///
-    /// Also enforces that both prior signatures are present.
+    /// Enforces that:
+    /// - `self.attester` is `Some` and matches `attester_did`
+    /// - Both prior signatures are present (chain prerequisite)
     pub fn verify_attester(&self, attester_did: &icn_identity::Did) -> Result<(), ComputeError> {
+        match &self.attester {
+            None => {
+                return Err(ComputeError::InvalidSignature(
+                    "cannot verify attester: attester DID not set on receipt".into(),
+                ));
+            }
+            Some(claimed) if claimed != &attester_did.to_string() => {
+                return Err(ComputeError::InvalidSignature(format!(
+                    "DID mismatch: receipt claims attester={claimed}, but verifying against {attester_did}"
+                )));
+            }
+            _ => {}
+        }
         if self.executor_signature.is_none() || self.submitter_ack.is_none() {
             return Err(ComputeError::InvalidSignature(
                 "cannot verify attester: prior signatures missing".into(),
@@ -632,16 +688,16 @@ mod tests {
         let mut r = sample_receipt();
         assert!(!r.is_fully_attested());
 
-        r.executor_signature = Some(SignatureBytes([0x11; 64]));
+        r.executor_signature = Some(SignatureBytes::from([0x11; 64]));
         assert!(!r.is_fully_attested());
 
-        r.submitter_ack = Some(SignatureBytes([0x22; 64]));
+        r.submitter_ack = Some(SignatureBytes::from([0x22; 64]));
         assert!(!r.is_fully_attested(), "missing attester DID + sig");
 
         r.attester = Some("did:icn:z6MkAttester".to_string());
         assert!(!r.is_fully_attested(), "missing attester signature");
 
-        r.attester_signature = Some(SignatureBytes([0x33; 64]));
+        r.attester_signature = Some(SignatureBytes::from([0x33; 64]));
         assert!(r.is_fully_attested());
     }
 
@@ -677,7 +733,7 @@ mod tests {
 
     #[test]
     fn test_signature_bytes_serde_roundtrip() {
-        let sig = SignatureBytes([0xAA; 64]);
+        let sig = SignatureBytes::from([0xAA; 64]);
         let json = serde_json::to_string(&sig).unwrap();
         let deserialized: SignatureBytes = serde_json::from_str(&json).unwrap();
         assert_eq!(sig, deserialized);
@@ -686,7 +742,7 @@ mod tests {
     #[test]
     fn test_receipt_serde_roundtrip() {
         let mut r = sample_receipt();
-        r.executor_signature = Some(SignatureBytes([0x11; 64]));
+        r.executor_signature = Some(SignatureBytes::from([0x11; 64]));
         let json = serde_json::to_string(&r).unwrap();
         let deserialized: ExecutionReceipt = serde_json::from_str(&json).unwrap();
         assert_eq!(r, deserialized);
@@ -763,13 +819,16 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_executor_wrong_key() {
+    fn test_verify_executor_wrong_did_rejected() {
         let (r, executor_kp) = receipt_with_real_keys();
         let r = r.sign_executor(&to_signing_key(&executor_kp));
 
         let wrong_kp = icn_identity::KeyPair::generate().unwrap();
         let err = r.verify_executor(wrong_kp.did()).unwrap_err();
-        assert!(err.to_string().contains("verification failed"));
+        assert!(
+            err.to_string().contains("DID mismatch"),
+            "should reject DID that doesn't match receipt's executor field, got: {err}"
+        );
     }
 
     #[test]
@@ -788,10 +847,10 @@ mod tests {
         // Identical base fields, only vary executor signature bytes.
         // This directly proves the submitter payload binds to the executor sig.
         let mut r1 = sample_receipt();
-        r1.executor_signature = Some(SignatureBytes([0x11; 64]));
+        r1.executor_signature = Some(SignatureBytes::from([0x11; 64]));
 
         let mut r2 = sample_receipt();
-        r2.executor_signature = Some(SignatureBytes([0x22; 64]));
+        r2.executor_signature = Some(SignatureBytes::from([0x22; 64]));
 
         assert_ne!(
             r1.submitter_sign_payload(),
@@ -803,12 +862,12 @@ mod tests {
     #[test]
     fn test_attester_payload_includes_both_prior_sigs() {
         let mut r1 = sample_receipt();
-        r1.executor_signature = Some(SignatureBytes([0x11; 64]));
-        r1.submitter_ack = Some(SignatureBytes([0xAA; 64]));
+        r1.executor_signature = Some(SignatureBytes::from([0x11; 64]));
+        r1.submitter_ack = Some(SignatureBytes::from([0xAA; 64]));
 
         let mut r2 = sample_receipt();
-        r2.executor_signature = Some(SignatureBytes([0x11; 64]));
-        r2.submitter_ack = Some(SignatureBytes([0xBB; 64]));
+        r2.executor_signature = Some(SignatureBytes::from([0x11; 64]));
+        r2.submitter_ack = Some(SignatureBytes::from([0xBB; 64]));
 
         assert_ne!(
             r1.attester_sign_payload(),
@@ -885,20 +944,26 @@ mod tests {
 
     #[test]
     fn test_verify_missing_submitter_ack() {
-        let (r, kp) = receipt_with_real_keys();
-        let r = r.sign_executor(&to_signing_key(&kp));
+        let (r, executor_kp) = receipt_with_real_keys();
         let submitter_kp = icn_identity::KeyPair::generate().unwrap();
+        // Set submitter DID to match the keypair we'll verify against
+        let mut r = r.sign_executor(&to_signing_key(&executor_kp));
+        r.submitter = submitter_kp.did().to_string();
         let err = r.verify_submitter_ack(submitter_kp.did()).unwrap_err();
-        assert!(err.to_string().contains("missing"));
+        assert!(
+            err.to_string().contains("submitter ack missing"),
+            "got: {err}"
+        );
     }
 
     #[test]
     fn test_verify_submitter_rejects_missing_executor_sig() {
         // A receipt with submitter_ack but no executor_signature must fail
         // verification — the chain is broken.
-        let mut r = sample_receipt();
-        r.submitter_ack = Some(SignatureBytes([0xAA; 64])); // fake, but present
         let submitter_kp = icn_identity::KeyPair::generate().unwrap();
+        let mut r = sample_receipt();
+        r.submitter = submitter_kp.did().to_string();
+        r.submitter_ack = Some(SignatureBytes::from([0xAA; 64])); // fake, but present
         let err = r.verify_submitter_ack(submitter_kp.did()).unwrap_err();
         assert!(
             err.to_string().contains("executor signature missing"),
@@ -908,9 +973,10 @@ mod tests {
 
     #[test]
     fn test_verify_attester_rejects_missing_prior_sigs() {
-        let mut r = sample_receipt();
-        r.attester_signature = Some(SignatureBytes([0xBB; 64])); // fake, but present
         let attester_kp = icn_identity::KeyPair::generate().unwrap();
+        let mut r = sample_receipt();
+        r.attester = Some(attester_kp.did().to_string());
+        r.attester_signature = Some(SignatureBytes::from([0xBB; 64])); // fake, but present
         let err = r.verify_attester(attester_kp.did()).unwrap_err();
         assert!(
             err.to_string().contains("prior signatures missing"),
@@ -1026,5 +1092,97 @@ mod tests {
         r.egress_bytes = MAX_EGRESS_BYTES + 1;
         let err = r.validate().unwrap_err();
         assert!(err.to_string().contains("egress_bytes"), "got: {err}");
+    }
+
+    // -- DID identity binding tests ---
+
+    #[test]
+    fn test_verify_submitter_wrong_did_rejected() {
+        let (r, executor_kp) = receipt_with_real_keys();
+        let submitter_kp = icn_identity::KeyPair::generate().unwrap();
+        let mut r = r.sign_executor(&to_signing_key(&executor_kp));
+        r.submitter = submitter_kp.did().to_string();
+        let r = r
+            .sign_submitter_ack(&to_signing_key(&submitter_kp))
+            .unwrap();
+
+        let wrong_kp = icn_identity::KeyPair::generate().unwrap();
+        let err = r.verify_submitter_ack(wrong_kp.did()).unwrap_err();
+        assert!(
+            err.to_string().contains("DID mismatch"),
+            "should reject DID that doesn't match receipt's submitter field, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_verify_attester_wrong_did_rejected() {
+        let (r, executor_kp) = receipt_with_real_keys();
+        let submitter_kp = icn_identity::KeyPair::generate().unwrap();
+        let attester_kp = icn_identity::KeyPair::generate().unwrap();
+
+        let mut r = r.sign_executor(&to_signing_key(&executor_kp));
+        r.submitter = submitter_kp.did().to_string();
+        let r = r
+            .sign_submitter_ack(&to_signing_key(&submitter_kp))
+            .unwrap()
+            .sign_attester(attester_kp.did().to_string(), &to_signing_key(&attester_kp))
+            .unwrap();
+
+        let wrong_kp = icn_identity::KeyPair::generate().unwrap();
+        let err = r.verify_attester(wrong_kp.did()).unwrap_err();
+        assert!(
+            err.to_string().contains("DID mismatch"),
+            "should reject DID that doesn't match receipt's attester field, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_verify_attester_rejects_missing_attester_did() {
+        // Receipt has attester_signature but no attester DID set
+        let mut r = sample_receipt();
+        r.executor_signature = Some(SignatureBytes::from([0x11; 64]));
+        r.submitter_ack = Some(SignatureBytes::from([0x22; 64]));
+        r.attester_signature = Some(SignatureBytes::from([0x33; 64]));
+        // attester is None
+        let kp = icn_identity::KeyPair::generate().unwrap();
+        let err = r.verify_attester(kp.did()).unwrap_err();
+        assert!(
+            err.to_string().contains("attester DID not set"),
+            "should reject when receipt has no attester DID, got: {err}"
+        );
+    }
+
+    // -- Wire format tests ---
+
+    #[test]
+    fn test_settlement_message_icn_encoding_roundtrip() {
+        let r = sample_receipt();
+        let msg = SettlementMessage::Receipt(Box::new(r));
+        let encoded = icn_encoding::encode(&msg).unwrap();
+        let decoded: SettlementMessage = icn_encoding::decode(&encoded).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn test_receipt_icn_encoding_roundtrip() {
+        let mut r = sample_receipt();
+        r.executor_signature = Some(SignatureBytes::from([0x11; 64]));
+        let encoded = icn_encoding::encode(&r).unwrap();
+        let decoded: ExecutionReceipt = icn_encoding::decode(&encoded).unwrap();
+        assert_eq!(r, decoded);
+    }
+
+    #[test]
+    fn test_signature_bytes_binary_serde_compact() {
+        // Verify that binary serialization is more compact than hex JSON
+        let sig = SignatureBytes::from([0xAA; 64]);
+        let json_bytes = serde_json::to_vec(&sig).unwrap();
+        let postcard_bytes = icn_encoding::encode(&sig).unwrap();
+        assert!(
+            postcard_bytes.len() < json_bytes.len(),
+            "binary encoding ({} bytes) should be smaller than JSON ({} bytes)",
+            postcard_bytes.len(),
+            json_bytes.len()
+        );
     }
 }

--- a/icn/crates/icn-compute/src/receipt.rs
+++ b/icn/crates/icn-compute/src/receipt.rs
@@ -107,6 +107,24 @@ fn scope_to_wire(scope: ScopeLevel) -> u8 {
 // ExecutionReceipt
 // ---------------------------------------------------------------------------
 
+/// Maximum valid CPU time: 24 hours in milliseconds.
+const MAX_CPU_MILLIS: u64 = 86_400_000;
+
+/// Maximum valid memory: 1 TB-second in megabyte-milliseconds (1_000_000 MB * 1000 ms).
+const MAX_MEMORY_MB_MILLIS: u64 = 1_000_000_000;
+
+/// Maximum valid storage: 1 TB.
+const MAX_STORAGE_BYTES: u64 = 1_099_511_627_776;
+
+/// Maximum valid egress: 100 GB.
+const MAX_EGRESS_BYTES: u64 = 107_374_182_400;
+
+/// Minimum plausible Unix timestamp (2020-09-13).
+const MIN_VALID_TIMESTAMP: u64 = 1_600_000_000;
+
+/// Maximum allowed clock skew into the future, in seconds.
+const MAX_CLOCK_SKEW_SECS: u64 = 300;
+
 /// A signed attestation of resource consumption for a completed compute task.
 ///
 /// The receipt binds metering data to a chain of three signatures:
@@ -117,9 +135,18 @@ fn scope_to_wire(scope: ScopeLevel) -> u8 {
 ///
 /// All metering values use deterministic integer units to guarantee
 /// bit-exact signing payloads across architectures.
+///
+/// The `receipt_id` field is a random 32-byte nonce that provides replay
+/// protection. Even if all other fields are identical, a new nonce
+/// produces a unique signing payload and receipt hash.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ExecutionReceipt {
     // -- Identity --
+    /// Random 32-byte nonce for replay protection.
+    ///
+    /// Must be unique per receipt. Ensures that identical tasks produce
+    /// distinct receipts and signing payloads.
+    pub receipt_id: [u8; 32],
     /// Blake3 hash of the original [`ComputeTask`].
     pub task_hash: [u8; 32],
     /// DID of the executor node (e.g. `did:icn:z6Mk...`).
@@ -168,6 +195,9 @@ impl ExecutionReceipt {
     pub fn signing_payload(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(256);
 
+        // Nonce (replay protection)
+        buf.extend_from_slice(&self.receipt_id);
+
         // Identity
         buf.extend_from_slice(&self.task_hash);
         buf.extend_from_slice(&(self.executor.len() as u32).to_le_bytes());
@@ -194,9 +224,8 @@ impl ExecutionReceipt {
 
     /// Content hash of the receipt (blake3 over the signing payload).
     ///
-    /// This identifies the logical receipt — same task + same metering +
-    /// same participants → same hash, regardless of signatures.
-    /// Used as the deduplication key for settlement.
+    /// Includes `receipt_id` nonce, so identical tasks with different nonces
+    /// produce different hashes. Used as the deduplication key for settlement.
     pub fn receipt_hash(&self) -> ReceiptHash {
         *blake3::hash(&self.signing_payload()).as_bytes()
     }
@@ -209,8 +238,9 @@ impl ExecutionReceipt {
             && self.attester_signature.is_some()
     }
 
-    /// Validate structural invariants (DID format, metering sanity).
+    /// Validate structural invariants (DID format, timestamp, metering bounds).
     pub fn validate(&self) -> Result<(), ComputeError> {
+        // DID format
         if !self.executor.starts_with("did:icn:") {
             return Err(ComputeError::InvalidInput(format!(
                 "executor DID has invalid format: {}",
@@ -229,6 +259,47 @@ impl ExecutionReceipt {
                     "attester DID has invalid format: {attester}"
                 )));
             }
+        }
+
+        // Timestamp bounds
+        if self.created_at < MIN_VALID_TIMESTAMP {
+            return Err(ComputeError::InvalidInput(format!(
+                "created_at {} is before minimum valid timestamp {}",
+                self.created_at, MIN_VALID_TIMESTAMP
+            )));
+        }
+        let now = icn_time::current_timestamp_secs();
+        if self.created_at > now + MAX_CLOCK_SKEW_SECS {
+            return Err(ComputeError::InvalidInput(format!(
+                "created_at {} is more than {}s in the future (now={})",
+                self.created_at, MAX_CLOCK_SKEW_SECS, now
+            )));
+        }
+
+        // Metering bounds
+        if self.cpu_millis > MAX_CPU_MILLIS {
+            return Err(ComputeError::InvalidInput(format!(
+                "cpu_millis {} exceeds maximum {}",
+                self.cpu_millis, MAX_CPU_MILLIS
+            )));
+        }
+        if self.memory_mb_millis > MAX_MEMORY_MB_MILLIS {
+            return Err(ComputeError::InvalidInput(format!(
+                "memory_mb_millis {} exceeds maximum {}",
+                self.memory_mb_millis, MAX_MEMORY_MB_MILLIS
+            )));
+        }
+        if self.storage_bytes > MAX_STORAGE_BYTES {
+            return Err(ComputeError::InvalidInput(format!(
+                "storage_bytes {} exceeds maximum {}",
+                self.storage_bytes, MAX_STORAGE_BYTES
+            )));
+        }
+        if self.egress_bytes > MAX_EGRESS_BYTES {
+            return Err(ComputeError::InvalidInput(format!(
+                "egress_bytes {} exceeds maximum {}",
+                self.egress_bytes, MAX_EGRESS_BYTES
+            )));
         }
 
         Ok(())
@@ -438,6 +509,7 @@ mod tests {
     /// Helper: build a minimal valid receipt with no signatures.
     fn sample_receipt() -> ExecutionReceipt {
         ExecutionReceipt {
+            receipt_id: [0x01; 32],
             task_hash: [0xAB; 32],
             executor: "did:icn:z6MkExecutor".to_string(),
             submitter: "did:icn:z6MkSubmitter".to_string(),
@@ -469,6 +541,10 @@ mod tests {
     fn test_signing_payload_changes_on_field_mutation() {
         let base = sample_receipt();
         let base_payload = base.signing_payload();
+
+        let mut r = sample_receipt();
+        r.receipt_id[0] = 0xFF;
+        assert_ne!(r.signing_payload(), base_payload, "receipt_id mutation");
 
         let mut r = sample_receipt();
         r.task_hash[0] = 0x00;
@@ -627,6 +703,7 @@ mod tests {
     fn receipt_with_real_keys() -> (ExecutionReceipt, icn_identity::KeyPair) {
         let executor_kp = icn_identity::KeyPair::generate().unwrap();
         let r = ExecutionReceipt {
+            receipt_id: [0x02; 32],
             task_hash: [0xAB; 32],
             executor: executor_kp.did().to_string(),
             submitter: "did:icn:z6MkSubmitter".to_string(),
@@ -747,6 +824,7 @@ mod tests {
         let attester_kp = icn_identity::KeyPair::generate().unwrap();
 
         let r = ExecutionReceipt {
+            receipt_id: [0x03; 32],
             task_hash: [0xCC; 32],
             executor: executor_kp.did().to_string(),
             submitter: submitter_kp.did().to_string(),
@@ -867,5 +945,86 @@ mod tests {
             .sign_attester(kp.did().to_string(), &to_signing_key(&kp))
             .unwrap_err();
         assert!(err.to_string().contains("executor_signature missing"));
+    }
+
+    // -- Replay protection tests ---
+
+    #[test]
+    fn test_different_receipt_id_produces_different_payload() {
+        let mut r1 = sample_receipt();
+        r1.receipt_id = [0xAA; 32];
+        let mut r2 = sample_receipt();
+        r2.receipt_id = [0xBB; 32];
+
+        assert_ne!(
+            r1.signing_payload(),
+            r2.signing_payload(),
+            "different receipt_id must produce different signing payloads"
+        );
+        assert_ne!(
+            r1.receipt_hash(),
+            r2.receipt_hash(),
+            "different receipt_id must produce different receipt hashes"
+        );
+    }
+
+    // -- Timestamp validation tests ---
+
+    #[test]
+    fn test_validate_rejects_ancient_timestamp() {
+        let mut r = sample_receipt();
+        r.created_at = 1_000_000; // Way before MIN_VALID_TIMESTAMP
+        let err = r.validate().unwrap_err();
+        assert!(err.to_string().contains("before minimum"), "got: {err}");
+    }
+
+    #[test]
+    fn test_validate_rejects_future_timestamp() {
+        let mut r = sample_receipt();
+        r.created_at = icn_time::current_timestamp_secs() + MAX_CLOCK_SKEW_SECS + 1000;
+        let err = r.validate().unwrap_err();
+        assert!(err.to_string().contains("in the future"), "got: {err}");
+    }
+
+    #[test]
+    fn test_validate_accepts_recent_timestamp() {
+        let mut r = sample_receipt();
+        // Use a timestamp that's clearly in the past but after MIN_VALID_TIMESTAMP
+        r.created_at = icn_time::current_timestamp_secs() - 60;
+        assert!(r.validate().is_ok());
+    }
+
+    // -- Metering bounds tests ---
+
+    #[test]
+    fn test_validate_rejects_excessive_cpu_millis() {
+        let mut r = sample_receipt();
+        r.cpu_millis = MAX_CPU_MILLIS + 1;
+        let err = r.validate().unwrap_err();
+        assert!(err.to_string().contains("cpu_millis"), "got: {err}");
+    }
+
+    #[test]
+    fn test_validate_rejects_excessive_memory() {
+        let mut r = sample_receipt();
+        r.memory_mb_millis = MAX_MEMORY_MB_MILLIS + 1;
+        let err = r.validate().unwrap_err();
+        assert!(err.to_string().contains("memory_mb_millis"), "got: {err}");
+    }
+
+    #[test]
+    fn test_validate_rejects_excessive_storage() {
+        let mut r = sample_receipt();
+        r.storage_bytes = MAX_STORAGE_BYTES + 1;
+        let err = r.validate().unwrap_err();
+        assert!(err.to_string().contains("storage_bytes"), "got: {err}");
+    }
+
+    #[test]
+    fn test_validate_rejects_excessive_egress() {
+        let mut r = sample_receipt();
+        r.egress_bytes = MAX_EGRESS_BYTES + 1;
+        let err = r.validate().unwrap_err();
+        assert!(err.to_string().contains("egress_bytes"), "got: {err}");
     }
 }

--- a/icn/crates/icn-ledger/src/lib.rs
+++ b/icn/crates/icn-ledger/src/lib.rs
@@ -71,6 +71,7 @@ pub mod merge;
 pub mod oracle;
 pub mod progressive_limits;
 pub mod quarantine;
+pub mod settlement;
 #[allow(missing_docs)]
 pub mod sync;
 pub mod treasury;
@@ -96,6 +97,7 @@ pub use progressive_limits::{
     FnCommonsHolderLookup, ProgressiveLimitConfig, ProgressiveLimitManager, VelocityLimitConfig,
 };
 pub use quarantine::QuarantineStore;
+pub use settlement::{SettlementEngine, SettlementRequest};
 pub use sync::{deserialize_sync_message, ledger_topic, serialize_sync_message, LedgerSyncMessage};
 pub use treasury::{
     ApprovalType, BudgetStatus, PaginatedAuditTrail, SpendingRule, Treasury, TreasuryAuditRecord,

--- a/icn/crates/icn-ledger/src/settlement.rs
+++ b/icn/crates/icn-ledger/src/settlement.rs
@@ -1,0 +1,446 @@
+//! Settlement engine for converting verified execution receipts into journal entries.
+//!
+//! This module provides the `SettlementEngine` which accepts `SettlementRequest` DTOs
+//! (converted from `ExecutionReceipt` by the caller) and creates balanced double-entry
+//! journal entries in the ledger.
+//!
+//! # Scope routing
+//!
+//! - **Local / Cell / Org**: Settle directly via `JournalEntryBuilder`.
+//! - **Federation / Commons**: Rejected — caller must route to `ReceiptClearingManager`
+//!   in `icn-federation`.
+//!
+//! # Deduplication
+//!
+//! Each receipt is deduplicated by `sha256(task_hash || executor_did_bytes)`. The engine
+//! tracks settled receipts in an in-memory `HashSet` (sled persistence is future work).
+//!
+//! # Design
+//!
+//! `SettlementRequest` is a DTO — it does NOT depend on `icn-compute`. The caller is
+//! responsible for verifying receipt signatures before constructing the request and
+//! setting `executor_verified = true`.
+
+use crate::entry::JournalEntryBuilder;
+use crate::error::LedgerError;
+use crate::types::JournalEntry;
+use icn_identity::Did;
+use icn_kernel_api::scope::ScopeLevel;
+use sha2::{Digest, Sha256};
+use std::collections::HashSet;
+use std::sync::RwLock;
+
+/// A settlement request DTO.
+///
+/// Constructed by the caller from a verified `ExecutionReceipt`. The caller must:
+/// 1. Verify all receipt signatures (executor, submitter ack, optionally attester).
+/// 2. Set `executor_verified = true` after verification.
+/// 3. Parse DID strings into `Did` values.
+///
+/// The engine will reject requests where `executor_verified` is false.
+#[derive(Debug, Clone)]
+pub struct SettlementRequest {
+    /// Hash of the compute task (from ExecutionReceipt.task_hash)
+    pub task_hash: [u8; 32],
+
+    /// DID of the executor who performed the work
+    pub executor: Did,
+
+    /// DID of the submitter who requested the work
+    pub submitter: Did,
+
+    /// Scope level of the original task
+    pub scope: ScopeLevel,
+
+    /// Cost in the settlement currency (from ExecutionReceipt.cost)
+    pub cost: u64,
+
+    /// Currency for settlement (e.g., "credits")
+    pub currency: String,
+
+    /// Whether the caller has verified the executor's signature.
+    /// The engine rejects requests where this is false.
+    pub executor_verified: bool,
+}
+
+/// Settlement engine for converting verified receipts into journal entries.
+///
+/// Handles deduplication and scope validation, then delegates to
+/// `JournalEntryBuilder` for balanced double-entry creation.
+pub struct SettlementEngine {
+    /// In-memory dedup set of settled receipt keys.
+    /// Each key is `sha256(task_hash || executor_did_bytes)`.
+    settled: RwLock<HashSet<[u8; 32]>>,
+}
+
+impl SettlementEngine {
+    /// Create a new settlement engine with an empty dedup set.
+    pub fn new() -> Self {
+        SettlementEngine {
+            settled: RwLock::new(HashSet::new()),
+        }
+    }
+
+    /// Settle a verified receipt, creating a balanced journal entry.
+    ///
+    /// # Errors
+    ///
+    /// - `LedgerError::InvalidEntry` if `executor_verified` is false
+    /// - `LedgerError::InvalidEntry` if scope is Federation or Commons
+    /// - `LedgerError::DuplicateEntry` if this receipt has already been settled
+    /// - `LedgerError::InvalidEntry` if cost is zero
+    /// - Propagates `JournalEntryBuilder::build()` errors
+    pub fn settle_receipt(&self, request: &SettlementRequest) -> Result<JournalEntry, LedgerError> {
+        // 1. Reject unverified receipts
+        if !request.executor_verified {
+            return Err(LedgerError::InvalidEntry(
+                "receipt executor signature not verified".to_string(),
+            ));
+        }
+
+        // 2. Reject federation/commons scope — must use clearing
+        match request.scope {
+            ScopeLevel::Federation => {
+                return Err(LedgerError::InvalidEntry(
+                    "federation-scope receipts must use cross-cooperative clearing".to_string(),
+                ));
+            }
+            ScopeLevel::Commons => {
+                return Err(LedgerError::InvalidEntry(
+                    "commons-scope receipts must use cross-cooperative clearing".to_string(),
+                ));
+            }
+            ScopeLevel::Local | ScopeLevel::Cell | ScopeLevel::Org => {}
+        }
+
+        // 3. Reject zero-cost receipts
+        if request.cost == 0 {
+            return Err(LedgerError::InvalidEntry(
+                "receipt cost must be non-zero".to_string(),
+            ));
+        }
+
+        // 4. Check deduplication
+        let dedup_key = Self::dedup_key(&request.task_hash, &request.executor);
+        {
+            let settled = self
+                .settled
+                .read()
+                .map_err(|_| LedgerError::Internal("settlement lock poisoned".to_string()))?;
+            if settled.contains(&dedup_key) {
+                return Err(LedgerError::DuplicateEntry(format!(
+                    "receipt already settled: task={} executor={}",
+                    hex::encode(request.task_hash),
+                    request.executor
+                )));
+            }
+        }
+
+        // 5. Build balanced journal entry: debit submitter, credit executor
+        let cost_i64 = i64::try_from(request.cost).map_err(|_| {
+            LedgerError::ArithmeticOverflow(format!(
+                "receipt cost {} exceeds i64::MAX",
+                request.cost
+            ))
+        })?;
+
+        let entry = JournalEntryBuilder::new(request.submitter.clone())
+            .debit(
+                request.submitter.clone(),
+                request.currency.clone(),
+                cost_i64,
+            )
+            .credit(request.executor.clone(), request.currency.clone(), cost_i64)
+            .build()
+            .map_err(|e| LedgerError::InvalidEntry(e.to_string()))?;
+
+        // 6. Record dedup key
+        {
+            let mut settled = self
+                .settled
+                .write()
+                .map_err(|_| LedgerError::Internal("settlement lock poisoned".to_string()))?;
+            settled.insert(dedup_key);
+        }
+
+        Ok(entry)
+    }
+
+    /// Check whether a receipt has already been settled.
+    pub fn is_settled(&self, task_hash: &[u8; 32], executor: &Did) -> bool {
+        let key = Self::dedup_key(task_hash, executor);
+        self.settled
+            .read()
+            .map(|s| s.contains(&key))
+            .unwrap_or(false)
+    }
+
+    /// Number of settled receipts tracked.
+    pub fn settled_count(&self) -> usize {
+        self.settled.read().map(|s| s.len()).unwrap_or(0)
+    }
+
+    /// Compute deduplication key: `sha256(task_hash || executor_did_string_bytes)`.
+    fn dedup_key(task_hash: &[u8; 32], executor: &Did) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(task_hash);
+        hasher.update(executor.to_string().as_bytes());
+        let result = hasher.finalize();
+        let mut key = [0u8; 32];
+        key.copy_from_slice(&result);
+        key
+    }
+}
+
+impl Default for SettlementEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use icn_identity::KeyPair;
+
+    fn make_request(scope: ScopeLevel, cost: u64, verified: bool) -> SettlementRequest {
+        let executor_kp = KeyPair::generate().unwrap();
+        let submitter_kp = KeyPair::generate().unwrap();
+        SettlementRequest {
+            task_hash: [0xAA; 32],
+            executor: executor_kp.did().clone(),
+            submitter: submitter_kp.did().clone(),
+            scope,
+            cost,
+            currency: "credits".to_string(),
+            executor_verified: verified,
+        }
+    }
+
+    fn make_request_with_keys(
+        executor: &KeyPair,
+        submitter: &KeyPair,
+        task_hash: [u8; 32],
+    ) -> SettlementRequest {
+        SettlementRequest {
+            task_hash,
+            executor: executor.did().clone(),
+            submitter: submitter.did().clone(),
+            scope: ScopeLevel::Local,
+            cost: 100,
+            currency: "credits".to_string(),
+            executor_verified: true,
+        }
+    }
+
+    #[test]
+    fn test_settle_creates_balanced_entry() {
+        let engine = SettlementEngine::new();
+        let executor_kp = KeyPair::generate().unwrap();
+        let submitter_kp = KeyPair::generate().unwrap();
+
+        let request = SettlementRequest {
+            task_hash: [0xBB; 32],
+            executor: executor_kp.did().clone(),
+            submitter: submitter_kp.did().clone(),
+            scope: ScopeLevel::Local,
+            cost: 500,
+            currency: "credits".to_string(),
+            executor_verified: true,
+        };
+
+        let entry = engine.settle_receipt(&request).unwrap();
+
+        // Should have exactly 2 account deltas: one debit, one credit
+        assert_eq!(entry.accounts.len(), 2);
+
+        let debit = &entry.accounts[0];
+        assert_eq!(debit.account_id, *submitter_kp.did());
+        assert_eq!(debit.debit, Some(500));
+        assert_eq!(debit.credit, None);
+        assert_eq!(debit.currency, "credits");
+
+        let credit = &entry.accounts[1];
+        assert_eq!(credit.account_id, *executor_kp.did());
+        assert_eq!(credit.credit, Some(500));
+        assert_eq!(credit.debit, None);
+        assert_eq!(credit.currency, "credits");
+
+        // Author should be the submitter
+        assert_eq!(entry.author, *submitter_kp.did());
+    }
+
+    #[test]
+    fn test_settle_deduplication() {
+        let engine = SettlementEngine::new();
+        let executor_kp = KeyPair::generate().unwrap();
+        let submitter_kp = KeyPair::generate().unwrap();
+
+        let request = make_request_with_keys(&executor_kp, &submitter_kp, [0xCC; 32]);
+
+        // First settlement succeeds
+        let result = engine.settle_receipt(&request);
+        assert!(result.is_ok());
+
+        // Second attempt is rejected as duplicate
+        let result = engine.settle_receipt(&request);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("already settled"), "got: {err}");
+    }
+
+    #[test]
+    fn test_settle_federation_scope_rejected() {
+        let engine = SettlementEngine::new();
+        let request = make_request(ScopeLevel::Federation, 100, true);
+
+        let result = engine.settle_receipt(&request);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("cross-cooperative clearing"), "got: {err}");
+    }
+
+    #[test]
+    fn test_settle_commons_scope_rejected() {
+        let engine = SettlementEngine::new();
+        let request = make_request(ScopeLevel::Commons, 100, true);
+
+        let result = engine.settle_receipt(&request);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("cross-cooperative clearing"), "got: {err}");
+    }
+
+    #[test]
+    fn test_settle_local_scope_accepted() {
+        let engine = SettlementEngine::new();
+        let request = make_request(ScopeLevel::Local, 100, true);
+        assert!(engine.settle_receipt(&request).is_ok());
+    }
+
+    #[test]
+    fn test_settle_cell_scope_accepted() {
+        let engine = SettlementEngine::new();
+        let request = make_request(ScopeLevel::Cell, 100, true);
+        assert!(engine.settle_receipt(&request).is_ok());
+    }
+
+    #[test]
+    fn test_settle_org_scope_accepted() {
+        let engine = SettlementEngine::new();
+        let request = make_request(ScopeLevel::Org, 100, true);
+        assert!(engine.settle_receipt(&request).is_ok());
+    }
+
+    #[test]
+    fn test_settle_unverified_rejected() {
+        let engine = SettlementEngine::new();
+        let request = make_request(ScopeLevel::Local, 100, false);
+
+        let result = engine.settle_receipt(&request);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("not verified"), "got: {err}");
+    }
+
+    #[test]
+    fn test_settle_zero_cost_rejected() {
+        let engine = SettlementEngine::new();
+        let request = make_request(ScopeLevel::Local, 0, true);
+
+        let result = engine.settle_receipt(&request);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("non-zero"), "got: {err}");
+    }
+
+    #[test]
+    fn test_is_settled() {
+        let engine = SettlementEngine::new();
+        let executor_kp = KeyPair::generate().unwrap();
+        let submitter_kp = KeyPair::generate().unwrap();
+        let task_hash = [0xDD; 32];
+
+        // Not settled yet
+        assert!(!engine.is_settled(&task_hash, executor_kp.did()));
+
+        // Settle it
+        let request = make_request_with_keys(&executor_kp, &submitter_kp, task_hash);
+        engine.settle_receipt(&request).unwrap();
+
+        // Now it is settled
+        assert!(engine.is_settled(&task_hash, executor_kp.did()));
+    }
+
+    #[test]
+    fn test_different_executor_same_task_not_duplicate() {
+        let engine = SettlementEngine::new();
+        let executor_a = KeyPair::generate().unwrap();
+        let executor_b = KeyPair::generate().unwrap();
+        let submitter = KeyPair::generate().unwrap();
+        let task_hash = [0xEE; 32];
+
+        let request_a = make_request_with_keys(&executor_a, &submitter, task_hash);
+        let request_b = make_request_with_keys(&executor_b, &submitter, task_hash);
+
+        // Both should succeed — different executors
+        assert!(engine.settle_receipt(&request_a).is_ok());
+        assert!(engine.settle_receipt(&request_b).is_ok());
+        assert_eq!(engine.settled_count(), 2);
+    }
+
+    #[test]
+    fn test_same_executor_different_task_not_duplicate() {
+        let engine = SettlementEngine::new();
+        let executor = KeyPair::generate().unwrap();
+        let submitter = KeyPair::generate().unwrap();
+
+        let request_a = make_request_with_keys(&executor, &submitter, [0x11; 32]);
+        let request_b = make_request_with_keys(&executor, &submitter, [0x22; 32]);
+
+        // Both should succeed — different tasks
+        assert!(engine.settle_receipt(&request_a).is_ok());
+        assert!(engine.settle_receipt(&request_b).is_ok());
+        assert_eq!(engine.settled_count(), 2);
+    }
+
+    #[test]
+    fn test_settled_count() {
+        let engine = SettlementEngine::new();
+        assert_eq!(engine.settled_count(), 0);
+
+        let request = make_request(ScopeLevel::Local, 50, true);
+        engine.settle_receipt(&request).unwrap();
+        assert_eq!(engine.settled_count(), 1);
+    }
+
+    #[test]
+    fn test_dedup_key_deterministic() {
+        let kp = KeyPair::generate().unwrap();
+        let task_hash = [0xFF; 32];
+
+        let key1 = SettlementEngine::dedup_key(&task_hash, kp.did());
+        let key2 = SettlementEngine::dedup_key(&task_hash, kp.did());
+        assert_eq!(key1, key2);
+    }
+
+    #[test]
+    fn test_dedup_key_changes_on_different_executor() {
+        let kp_a = KeyPair::generate().unwrap();
+        let kp_b = KeyPair::generate().unwrap();
+        let task_hash = [0xFF; 32];
+
+        let key_a = SettlementEngine::dedup_key(&task_hash, kp_a.did());
+        let key_b = SettlementEngine::dedup_key(&task_hash, kp_b.did());
+        assert_ne!(key_a, key_b);
+    }
+
+    #[test]
+    fn test_dedup_key_changes_on_different_task() {
+        let kp = KeyPair::generate().unwrap();
+
+        let key_a = SettlementEngine::dedup_key(&[0x11; 32], kp.did());
+        let key_b = SettlementEngine::dedup_key(&[0x22; 32], kp.did());
+        assert_ne!(key_a, key_b);
+    }
+}

--- a/icn/crates/icn-ledger/src/settlement.rs
+++ b/icn/crates/icn-ledger/src/settlement.rs
@@ -12,8 +12,10 @@
 //!
 //! # Deduplication
 //!
-//! Each receipt is deduplicated by `sha256(task_hash || executor_did_bytes)`. The engine
-//! tracks settled receipts in an in-memory `HashSet` (sled persistence is future work).
+//! Each receipt is deduplicated by `sha256("icn-ledger:settlement:v1:" || receipt_hash)`.
+//! The domain-separation prefix prevents cross-feature sha256 collisions.
+//! The engine tracks settled receipts in an in-memory `HashSet` (sled persistence is
+//! future work).
 //!
 //! # Design
 //!
@@ -30,6 +32,11 @@ use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::sync::RwLock;
 
+/// Domain-separation prefix for settlement dedup keys.
+///
+/// Prevents accidental collision with other sha256 usages in the codebase.
+const DEDUP_PREFIX: &[u8] = b"icn-ledger:settlement:v1:";
+
 /// A settlement request DTO.
 ///
 /// Constructed by the caller from a verified `ExecutionReceipt`. The caller must:
@@ -40,22 +47,31 @@ use std::sync::RwLock;
 /// The engine will reject requests where `executor_verified` is false.
 #[derive(Debug, Clone)]
 pub struct SettlementRequest {
-    /// Hash of the compute task (from ExecutionReceipt.task_hash)
-    pub task_hash: [u8; 32],
+    /// Content hash identifying this receipt (opaque 32 bytes from compute layer).
+    ///
+    /// The ledger treats this as an opaque identifier — it does not know or care
+    /// how compute derived it. This is the primary dedup input.
+    pub receipt_hash: [u8; 32],
 
-    /// DID of the executor who performed the work
+    /// DID of the executor who performed the work (earns credit).
     pub executor: Did,
 
-    /// DID of the submitter who requested the work
+    /// DID of the submitter who requested the work (pays debit).
     pub submitter: Did,
 
-    /// Scope level of the original task
+    /// Optional attester DID for governance / audit trail.
+    pub attester: Option<Did>,
+
+    /// Scope level of the original task.
     pub scope: ScopeLevel,
 
-    /// Cost in the settlement currency (from ExecutionReceipt.cost)
-    pub cost: u64,
+    /// Amount to settle in the ledger currency's smallest unit.
+    ///
+    /// Uses `i64` to match the existing `AccountDelta` convention.
+    /// Must be positive (> 0).
+    pub amount: i64,
 
-    /// Currency for settlement (e.g., "credits")
+    /// Currency for settlement (e.g., "credits").
     pub currency: String,
 
     /// Whether the caller has verified the executor's signature.
@@ -65,11 +81,11 @@ pub struct SettlementRequest {
 
 /// Settlement engine for converting verified receipts into journal entries.
 ///
-/// Handles deduplication and scope validation, then delegates to
-/// `JournalEntryBuilder` for balanced double-entry creation.
+/// Handles deduplication, scope validation, and invariant checking, then
+/// delegates to `JournalEntryBuilder` for balanced double-entry creation.
 pub struct SettlementEngine {
     /// In-memory dedup set of settled receipt keys.
-    /// Each key is `sha256(task_hash || executor_did_bytes)`.
+    /// Each key is `sha256(DEDUP_PREFIX || receipt_hash)`.
     settled: RwLock<HashSet<[u8; 32]>>,
 }
 
@@ -87,8 +103,9 @@ impl SettlementEngine {
     ///
     /// - `LedgerError::InvalidEntry` if `executor_verified` is false
     /// - `LedgerError::InvalidEntry` if scope is Federation or Commons
+    /// - `LedgerError::InvalidEntry` if amount is not positive
+    /// - `LedgerError::InvalidEntry` if executor == submitter (self-dealing)
     /// - `LedgerError::DuplicateEntry` if this receipt has already been settled
-    /// - `LedgerError::InvalidEntry` if cost is zero
     /// - Propagates `JournalEntryBuilder::build()` errors
     pub fn settle_receipt(&self, request: &SettlementRequest) -> Result<JournalEntry, LedgerError> {
         // 1. Reject unverified receipts
@@ -113,15 +130,22 @@ impl SettlementEngine {
             ScopeLevel::Local | ScopeLevel::Cell | ScopeLevel::Org => {}
         }
 
-        // 3. Reject zero-cost receipts
-        if request.cost == 0 {
+        // 3. Reject non-positive amounts
+        if request.amount <= 0 {
             return Err(LedgerError::InvalidEntry(
-                "receipt cost must be non-zero".to_string(),
+                "settlement amount must be positive".to_string(),
             ));
         }
 
-        // 4. Check deduplication
-        let dedup_key = Self::dedup_key(&request.task_hash, &request.executor);
+        // 4. Reject self-dealing (executor == submitter)
+        if request.executor == request.submitter {
+            return Err(LedgerError::InvalidEntry(
+                "executor and submitter must be different DIDs".to_string(),
+            ));
+        }
+
+        // 5. Check deduplication
+        let dedup_key = Self::dedup_key(&request.receipt_hash);
         {
             let settled = self
                 .settled
@@ -129,32 +153,28 @@ impl SettlementEngine {
                 .map_err(|_| LedgerError::Internal("settlement lock poisoned".to_string()))?;
             if settled.contains(&dedup_key) {
                 return Err(LedgerError::DuplicateEntry(format!(
-                    "receipt already settled: task={} executor={}",
-                    hex::encode(request.task_hash),
-                    request.executor
+                    "receipt already settled: {}",
+                    hex::encode(request.receipt_hash),
                 )));
             }
         }
 
-        // 5. Build balanced journal entry: debit submitter, credit executor
-        let cost_i64 = i64::try_from(request.cost).map_err(|_| {
-            LedgerError::ArithmeticOverflow(format!(
-                "receipt cost {} exceeds i64::MAX",
-                request.cost
-            ))
-        })?;
-
+        // 6. Build balanced journal entry: debit submitter, credit executor
         let entry = JournalEntryBuilder::new(request.submitter.clone())
             .debit(
                 request.submitter.clone(),
                 request.currency.clone(),
-                cost_i64,
+                request.amount,
             )
-            .credit(request.executor.clone(), request.currency.clone(), cost_i64)
+            .credit(
+                request.executor.clone(),
+                request.currency.clone(),
+                request.amount,
+            )
             .build()
             .map_err(|e| LedgerError::InvalidEntry(e.to_string()))?;
 
-        // 6. Record dedup key
+        // 7. Record dedup key
         {
             let mut settled = self
                 .settled
@@ -167,8 +187,8 @@ impl SettlementEngine {
     }
 
     /// Check whether a receipt has already been settled.
-    pub fn is_settled(&self, task_hash: &[u8; 32], executor: &Did) -> bool {
-        let key = Self::dedup_key(task_hash, executor);
+    pub fn is_settled(&self, receipt_hash: &[u8; 32]) -> bool {
+        let key = Self::dedup_key(receipt_hash);
         self.settled
             .read()
             .map(|s| s.contains(&key))
@@ -180,11 +200,15 @@ impl SettlementEngine {
         self.settled.read().map(|s| s.len()).unwrap_or(0)
     }
 
-    /// Compute deduplication key: `sha256(task_hash || executor_did_string_bytes)`.
-    fn dedup_key(task_hash: &[u8; 32], executor: &Did) -> [u8; 32] {
+    /// Compute deduplication key: `sha256(DEDUP_PREFIX || receipt_hash)`.
+    ///
+    /// The receipt_hash already uniquely identifies a receipt (it includes
+    /// the receipt_id nonce from compute layer). Scope is intentionally
+    /// excluded — a receipt can only settle once regardless of scope.
+    fn dedup_key(receipt_hash: &[u8; 32]) -> [u8; 32] {
         let mut hasher = Sha256::new();
-        hasher.update(task_hash);
-        hasher.update(executor.to_string().as_bytes());
+        hasher.update(DEDUP_PREFIX);
+        hasher.update(receipt_hash);
         let result = hasher.finalize();
         let mut key = [0u8; 32];
         key.copy_from_slice(&result);
@@ -203,15 +227,16 @@ mod tests {
     use super::*;
     use icn_identity::KeyPair;
 
-    fn make_request(scope: ScopeLevel, cost: u64, verified: bool) -> SettlementRequest {
+    fn make_request(scope: ScopeLevel, amount: i64, verified: bool) -> SettlementRequest {
         let executor_kp = KeyPair::generate().unwrap();
         let submitter_kp = KeyPair::generate().unwrap();
         SettlementRequest {
-            task_hash: [0xAA; 32],
+            receipt_hash: [0xAA; 32],
             executor: executor_kp.did().clone(),
             submitter: submitter_kp.did().clone(),
+            attester: None,
             scope,
-            cost,
+            amount,
             currency: "credits".to_string(),
             executor_verified: verified,
         }
@@ -220,14 +245,15 @@ mod tests {
     fn make_request_with_keys(
         executor: &KeyPair,
         submitter: &KeyPair,
-        task_hash: [u8; 32],
+        receipt_hash: [u8; 32],
     ) -> SettlementRequest {
         SettlementRequest {
-            task_hash,
+            receipt_hash,
             executor: executor.did().clone(),
             submitter: submitter.did().clone(),
+            attester: None,
             scope: ScopeLevel::Local,
-            cost: 100,
+            amount: 100,
             currency: "credits".to_string(),
             executor_verified: true,
         }
@@ -240,11 +266,12 @@ mod tests {
         let submitter_kp = KeyPair::generate().unwrap();
 
         let request = SettlementRequest {
-            task_hash: [0xBB; 32],
+            receipt_hash: [0xBB; 32],
             executor: executor_kp.did().clone(),
             submitter: submitter_kp.did().clone(),
+            attester: None,
             scope: ScopeLevel::Local,
-            cost: 500,
+            amount: 500,
             currency: "credits".to_string(),
             executor_verified: true,
         };
@@ -344,14 +371,47 @@ mod tests {
     }
 
     #[test]
-    fn test_settle_zero_cost_rejected() {
+    fn test_settle_zero_amount_rejected() {
         let engine = SettlementEngine::new();
         let request = make_request(ScopeLevel::Local, 0, true);
 
         let result = engine.settle_receipt(&request);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("non-zero"), "got: {err}");
+        assert!(err.contains("positive"), "got: {err}");
+    }
+
+    #[test]
+    fn test_settle_negative_amount_rejected() {
+        let engine = SettlementEngine::new();
+        let request = make_request(ScopeLevel::Local, -50, true);
+
+        let result = engine.settle_receipt(&request);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("positive"), "got: {err}");
+    }
+
+    #[test]
+    fn test_settle_self_dealing_rejected() {
+        let engine = SettlementEngine::new();
+        let kp = KeyPair::generate().unwrap();
+
+        let request = SettlementRequest {
+            receipt_hash: [0xDD; 32],
+            executor: kp.did().clone(),
+            submitter: kp.did().clone(), // same as executor
+            attester: None,
+            scope: ScopeLevel::Local,
+            amount: 100,
+            currency: "credits".to_string(),
+            executor_verified: true,
+        };
+
+        let result = engine.settle_receipt(&request);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("different DIDs"), "got: {err}");
     }
 
     #[test]
@@ -359,38 +419,21 @@ mod tests {
         let engine = SettlementEngine::new();
         let executor_kp = KeyPair::generate().unwrap();
         let submitter_kp = KeyPair::generate().unwrap();
-        let task_hash = [0xDD; 32];
+        let receipt_hash = [0xDD; 32];
 
         // Not settled yet
-        assert!(!engine.is_settled(&task_hash, executor_kp.did()));
+        assert!(!engine.is_settled(&receipt_hash));
 
         // Settle it
-        let request = make_request_with_keys(&executor_kp, &submitter_kp, task_hash);
+        let request = make_request_with_keys(&executor_kp, &submitter_kp, receipt_hash);
         engine.settle_receipt(&request).unwrap();
 
         // Now it is settled
-        assert!(engine.is_settled(&task_hash, executor_kp.did()));
+        assert!(engine.is_settled(&receipt_hash));
     }
 
     #[test]
-    fn test_different_executor_same_task_not_duplicate() {
-        let engine = SettlementEngine::new();
-        let executor_a = KeyPair::generate().unwrap();
-        let executor_b = KeyPair::generate().unwrap();
-        let submitter = KeyPair::generate().unwrap();
-        let task_hash = [0xEE; 32];
-
-        let request_a = make_request_with_keys(&executor_a, &submitter, task_hash);
-        let request_b = make_request_with_keys(&executor_b, &submitter, task_hash);
-
-        // Both should succeed — different executors
-        assert!(engine.settle_receipt(&request_a).is_ok());
-        assert!(engine.settle_receipt(&request_b).is_ok());
-        assert_eq!(engine.settled_count(), 2);
-    }
-
-    #[test]
-    fn test_same_executor_different_task_not_duplicate() {
+    fn test_different_receipt_hash_not_duplicate() {
         let engine = SettlementEngine::new();
         let executor = KeyPair::generate().unwrap();
         let submitter = KeyPair::generate().unwrap();
@@ -398,7 +441,7 @@ mod tests {
         let request_a = make_request_with_keys(&executor, &submitter, [0x11; 32]);
         let request_b = make_request_with_keys(&executor, &submitter, [0x22; 32]);
 
-        // Both should succeed — different tasks
+        // Both should succeed — different receipt hashes
         assert!(engine.settle_receipt(&request_a).is_ok());
         assert!(engine.settle_receipt(&request_b).is_ok());
         assert_eq!(engine.settled_count(), 2);
@@ -416,31 +459,57 @@ mod tests {
 
     #[test]
     fn test_dedup_key_deterministic() {
-        let kp = KeyPair::generate().unwrap();
-        let task_hash = [0xFF; 32];
-
-        let key1 = SettlementEngine::dedup_key(&task_hash, kp.did());
-        let key2 = SettlementEngine::dedup_key(&task_hash, kp.did());
+        let hash = [0xFF; 32];
+        let key1 = SettlementEngine::dedup_key(&hash);
+        let key2 = SettlementEngine::dedup_key(&hash);
         assert_eq!(key1, key2);
     }
 
     #[test]
-    fn test_dedup_key_changes_on_different_executor() {
-        let kp_a = KeyPair::generate().unwrap();
-        let kp_b = KeyPair::generate().unwrap();
-        let task_hash = [0xFF; 32];
-
-        let key_a = SettlementEngine::dedup_key(&task_hash, kp_a.did());
-        let key_b = SettlementEngine::dedup_key(&task_hash, kp_b.did());
+    fn test_dedup_key_changes_on_different_receipt() {
+        let key_a = SettlementEngine::dedup_key(&[0x11; 32]);
+        let key_b = SettlementEngine::dedup_key(&[0x22; 32]);
         assert_ne!(key_a, key_b);
     }
 
     #[test]
-    fn test_dedup_key_changes_on_different_task() {
-        let kp = KeyPair::generate().unwrap();
+    fn test_dedup_key_domain_separated() {
+        // Verify the prefix actually changes the output vs raw sha256(receipt_hash)
+        let receipt_hash = [0xAA; 32];
+        let with_prefix = SettlementEngine::dedup_key(&receipt_hash);
 
-        let key_a = SettlementEngine::dedup_key(&[0x11; 32], kp.did());
-        let key_b = SettlementEngine::dedup_key(&[0x22; 32], kp.did());
-        assert_ne!(key_a, key_b);
+        let mut raw_hasher = Sha256::new();
+        raw_hasher.update(receipt_hash);
+        let raw_result = raw_hasher.finalize();
+        let mut raw_key = [0u8; 32];
+        raw_key.copy_from_slice(&raw_result);
+
+        assert_ne!(
+            with_prefix, raw_key,
+            "domain prefix must change the dedup key output"
+        );
+    }
+
+    #[test]
+    fn test_attester_field_preserved() {
+        let engine = SettlementEngine::new();
+        let executor_kp = KeyPair::generate().unwrap();
+        let submitter_kp = KeyPair::generate().unwrap();
+        let attester_kp = KeyPair::generate().unwrap();
+
+        let request = SettlementRequest {
+            receipt_hash: [0xEE; 32],
+            executor: executor_kp.did().clone(),
+            submitter: submitter_kp.did().clone(),
+            attester: Some(attester_kp.did().clone()),
+            scope: ScopeLevel::Local,
+            amount: 100,
+            currency: "credits".to_string(),
+            executor_verified: true,
+        };
+
+        // Settlement should succeed — attester is informational, not blocking
+        let result = engine.settle_receipt(&request);
+        assert!(result.is_ok());
     }
 }


### PR DESCRIPTION
## Summary

- Adds `ExecutionReceipt` with **deterministic signing payload** and **chained Ed25519 signatures** (executor → submitter ack → attester).
- Introduces `SignatureBytes([u8;64])` **without Copy**; private inner field, access via `as_bytes()` / `to_bytes()`.
- Makes receipt scope encoding **protocol-stable** via explicit `scope_to_wire()` mapping.
- Makes signing chain **fallible** (`Result`) and verification **enforces prerequisites** to prevent meaningless signature checks.
- Adds `SettlementMessage` enum and topic constants for gossip distribution.
- Adds `SettlementEngine` with dedup, scope routing, and double-entry journal creation (#940).
- 42 receipt tests + 18 settlement tests covering determinism, chain binding, identity mismatch, encoding roundtrips, and dedup.

## Context

Epic 4 (#923): ExecutionReceipt and Settlement Pipeline.
- Wave A: #938 (receipt type) + #939 (signing/verification)
- Wave B: #940 (settlement engine)
- Wave C: #941 (cross-scope clearing) — not in this PR

### Design decisions

| Decision | Rationale |
|----------|-----------|
| Integer-only metering (`cpu_millis`, `memory_mb_millis`) | Avoids f64 non-determinism in signing payloads |
| `SignatureBytes` newtype without `Copy` | Prevents dangling references from implicit copies of `[u8; 64]` |
| Private inner field + `as_bytes()`/`to_bytes()` | Encapsulation — no casual `.0` poking |
| `is_human_readable()` serde switch | Hex in JSON (debuggable), raw bytes in postcard/icn_encoding (compact wire) |
| Domain-separated signing prefixes as byte constants | Prevents cross-role signature reuse |
| Chained signatures (submitter binds executor sig, attester binds both) | Creates unforgeable attestation chain |
| Explicit `scope_to_wire()` match | Decouples protocol byte format from Rust enum repr |
| Fallible sign methods | Missing prerequisites are errors, not silent no-ops |
| Verify methods enforce identity binding + chain prerequisites | Rejects mismatched claimed-vs-provided DID and floating signatures |
| `receipt_id` nonce | Replay protection — same task re-execution yields distinct receipts |
| Metering bounds + timestamp validation | Sanity caps prevent absurd values from propagating |
| `SettlementRequest` DTO in icn-ledger | No dependency on icn-compute — clean layering boundary |
| Domain-separated dedup key | Prevents cross-subsystem hash collisions |
| Executor ≠ submitter guard | Prevents self-dealing |

### Follow-up fixes (review feedback)

Applied after initial commit based on PR review:

**Cross-crate polish (`e03417a`):**
- `receipt_id` nonce for replay protection
- Timestamp validation (min 2020, max 300s clock skew)
- Metering bounds (cpu, memory, storage, egress caps)
- Settlement API: `receipt_hash` naming, `amount: i64`, attester field, self-dealing guard
- Domain-separated dedup key

**Copilot review feedback (`e182850`):**
- `SignatureBytes` inner field made private (was `pub`)
- Added `to_bytes()` explicit copy method
- `is_human_readable()` for serde (hex JSON, raw bytes postcard)
- Fixed signing comment (executor is infallible, later steps return Result)
- DID identity binding in all 3 verify methods (reject mismatched claimed vs provided)
- `verify_attester` requires `self.attester` is `Some` and matches
- New tests: icn_encoding roundtrips (ExecutionReceipt + SettlementMessage), binary compactness, DID mismatch ×3, missing attester DID

### Layering boundary

`icn-compute` defines protocol DTOs (`ExecutionReceipt`, `SettlementMessage`, `SignatureBytes`).
`icn-ledger` defines domain DTOs (`SettlementRequest`, `SettlementEngine`, `JournalEntry`).
No cross-imports. Adapter (future: gateway/service) maps `ExecutionReceipt` → `SettlementRequest`.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — zero warnings
- [x] `cargo test -p icn-compute` — 281 tests (248 unit + 32 integration + 1 doc)
- [x] `cargo test -p icn-ledger` — 348 tests (315 unit + 33 integration + 7 doc)
- [x] 42 receipt tests: signing, verification, serde, validation, chain binding, prerequisite enforcement, identity mismatch, encoding roundtrips
- [x] 18 settlement tests: balanced entries, dedup, scope routing, self-dealing, attester field

🤖 Generated with [Claude Code](https://claude.com/claude-code)