### PR TITLE
feat(compute,ledger): commons resource pool and credit accounting (Epic 6 #925)

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -2842,6 +2842,7 @@ dependencies = [
  "icn-federation",
  "icn-identity",
  "icn-kernel-api",
+ "icn-ledger",
  "icn-obs",
  "icn-security",
  "icn-time",

--- a/icn/crates/icn-compute/Cargo.toml
+++ b/icn/crates/icn-compute/Cargo.toml
@@ -57,6 +57,7 @@ wat = "1.244"
 criterion = "0.5"
 tempfile = "3.24"
 icn-identity = { path = "../icn-identity" }
+icn-ledger = { path = "../icn-ledger" }
 
 [[bench]]
 name = "compute_bench"

--- a/icn/crates/icn-compute/src/actor/mod.rs
+++ b/icn/crates/icn-compute/src/actor/mod.rs
@@ -103,6 +103,9 @@ pub struct ComputeActor {
     capacity_budget: Arc<RwLock<crate::scheduler::CapacityBudget>>,
     /// Configuration for demand-feedback adjustment loop (Epic 2 #933)
     demand_adjustment_config: crate::scheduler::DemandAdjustmentConfig,
+    /// Commons resource pool for tracking nodes contributing to the commons (Epic 6 #946).
+    /// Advisory scheduling state only — ledger is authoritative economic state.
+    commons_pool: Arc<RwLock<crate::commons_pool::CommonsPool>>,
     /// Resource refresh configuration
     resource_refresh_config: crate::scheduler::ResourceRefreshConfig,
     /// Current cached resource profile
@@ -146,6 +149,7 @@ impl ComputeActor {
             task_scope_map: Arc::new(Mutex::new(HashMap::new())),
             capacity_budget: Arc::new(RwLock::new(crate::scheduler::CapacityBudget::default())),
             demand_adjustment_config: crate::scheduler::DemandAdjustmentConfig::default(),
+            commons_pool: Arc::new(RwLock::new(crate::commons_pool::CommonsPool::new())),
             resource_refresh_config: crate::scheduler::ResourceRefreshConfig::default(),
             cached_capacity: Arc::new(Mutex::new(None)),
             shutdown_tx: tokio::sync::broadcast::channel(1).0,
@@ -482,6 +486,8 @@ impl ComputeActor {
                                     let msg = crate::types::ComputeMessage::NodeCapacityAnnounce {
                                         executor: own_did.clone(),
                                         capacity: new_capacity.clone(),
+                                        cell_id: None,
+                                        capacity_budget: None,
                                     };
                                     send_cb(msg);
                                 }
@@ -804,8 +810,14 @@ impl ComputeActor {
                 )
                 .await
             }
-            ComputeMessage::NodeCapacityAnnounce { executor, capacity } => {
-                self.on_capacity_announce(executor, capacity).await
+            ComputeMessage::NodeCapacityAnnounce {
+                executor,
+                capacity,
+                cell_id,
+                capacity_budget,
+            } => {
+                self.on_capacity_announce(executor, capacity, cell_id, capacity_budget)
+                    .await
             }
 
             // Phase 16D: Checkpoint & Migration messages

--- a/icn/crates/icn-compute/src/actor/placement.rs
+++ b/icn/crates/icn-compute/src/actor/placement.rs
@@ -768,9 +768,11 @@ impl ComputeActor {
             let count = pool.participant_count();
             let agg = pool.total_commons_capacity();
             drop(pool);
+            icn_obs::metrics::compute::commons_pool_updates_inc("add");
             icn_obs::metrics::compute::commons_pool_participants_set(count as f64);
             icn_obs::metrics::compute::commons_pool_cpu_cores_set(agg.cpu_cores);
             icn_obs::metrics::compute::commons_pool_memory_mb_set(agg.memory_mb as f64);
+            icn_obs::metrics::compute::commons_pool_storage_mb_set(agg.storage_mb as f64);
             tracing::debug!(
                 executor = %executor,
                 commons_share,
@@ -783,9 +785,11 @@ impl ComputeActor {
             let count = pool.participant_count();
             let agg = pool.total_commons_capacity();
             drop(pool);
+            icn_obs::metrics::compute::commons_pool_updates_inc("remove");
             icn_obs::metrics::compute::commons_pool_participants_set(count as f64);
             icn_obs::metrics::compute::commons_pool_cpu_cores_set(agg.cpu_cores);
             icn_obs::metrics::compute::commons_pool_memory_mb_set(agg.memory_mb as f64);
+            icn_obs::metrics::compute::commons_pool_storage_mb_set(agg.storage_mb as f64);
             tracing::debug!(
                 executor = %executor,
                 "Removed node from commons pool (zero commons share)"

--- a/icn/crates/icn-compute/src/actor/placement.rs
+++ b/icn/crates/icn-compute/src/actor/placement.rs
@@ -751,6 +751,10 @@ impl ComputeActor {
         };
 
         // Lock discipline: acquire write lock, mutate, release immediately.
+        //
+        // SECURITY NOTE: Unaffiliated nodes (cell_id=None) are granted full commons
+        // participation without Sybil resistance. This is intentional for the pilot
+        // phase but requires governance intervention before production scale.
         let commons_share = effective_budget.commons_share;
         if commons_share > 0.0 {
             let participant = crate::commons_pool::CommonsParticipant {
@@ -762,7 +766,11 @@ impl ComputeActor {
             let mut pool = self.commons_pool.write().await;
             pool.add_participant(participant);
             let count = pool.participant_count();
+            let agg = pool.total_commons_capacity();
             drop(pool);
+            icn_obs::metrics::compute::commons_pool_participants_set(count as f64);
+            icn_obs::metrics::compute::commons_pool_cpu_cores_set(agg.cpu_cores);
+            icn_obs::metrics::compute::commons_pool_memory_mb_set(agg.memory_mb as f64);
             tracing::debug!(
                 executor = %executor,
                 commons_share,
@@ -772,7 +780,12 @@ impl ComputeActor {
         } else {
             let mut pool = self.commons_pool.write().await;
             pool.remove_participant(&executor);
+            let count = pool.participant_count();
+            let agg = pool.total_commons_capacity();
             drop(pool);
+            icn_obs::metrics::compute::commons_pool_participants_set(count as f64);
+            icn_obs::metrics::compute::commons_pool_cpu_cores_set(agg.cpu_cores);
+            icn_obs::metrics::compute::commons_pool_memory_mb_set(agg.memory_mb as f64);
             tracing::debug!(
                 executor = %executor,
                 "Removed node from commons pool (zero commons share)"

--- a/icn/crates/icn-compute/src/actor/placement.rs
+++ b/icn/crates/icn-compute/src/actor/placement.rs
@@ -669,11 +669,15 @@ impl ComputeActor {
         &self,
         executor: String,
         capacity: crate::scheduler::NodeCapacity,
+        cell_id: Option<icn_kernel_api::CellId>,
+        capacity_budget: Option<crate::scheduler::CapacityBudget>,
     ) -> Result<(), ComputeError> {
         tracing::debug!(
             executor = %executor,
             cpu_available = capacity.cpu_cores_available,
             memory_available = capacity.memory_mb_available,
+            has_cell = cell_id.is_some(),
+            has_budget = capacity_budget.is_some(),
             "Received capacity announcement"
         );
 
@@ -714,6 +718,66 @@ impl ComputeActor {
 
         // Update metrics for executor capacity
         icn_obs::metrics::compute::executors_available_set(registry.len() as f64);
+        drop(registry);
+
+        // --- Commons pool decision matrix (Epic 6 #947) ---
+        //
+        // | cell_id | capacity_budget | Behavior                                     |
+        // |---------|-----------------|----------------------------------------------|
+        // | None    | None            | Unaffiliated. Full commons: commons_share=1.0 |
+        // | None    | Some(b)         | Unaffiliated with explicit budget. Use b.     |
+        // | Some(_) | None            | Affiliated, no explicit budget. Use default.  |
+        // | Some(_) | Some(b)         | Affiliated with explicit budget. Use b.       |
+        //
+        // Invariant: affiliated nodes without explicit budget default to
+        // `CapacityBudget::default()` (0.10 commons), NOT full commons.
+        let effective_budget = match (&cell_id, capacity_budget) {
+            (None, None) => {
+                // Unaffiliated node — full commons participation.
+                crate::scheduler::CapacityBudget {
+                    local_reserve: 0.0,
+                    cell_share: 0.0,
+                    org_share: 0.0,
+                    federation_share: 0.0,
+                    commons_share: 1.0,
+                }
+            }
+            (None, Some(b)) => b,
+            (Some(_), None) => {
+                // Affiliated with no explicit budget — use default (0.10 commons).
+                crate::scheduler::CapacityBudget::default()
+            }
+            (Some(_), Some(b)) => b,
+        };
+
+        // Lock discipline: acquire write lock, mutate, release immediately.
+        let commons_share = effective_budget.commons_share;
+        if commons_share > 0.0 {
+            let participant = crate::commons_pool::CommonsParticipant {
+                did: executor.clone(),
+                capacity,
+                budget: effective_budget,
+                last_announce: std::time::Instant::now(),
+            };
+            let mut pool = self.commons_pool.write().await;
+            pool.add_participant(participant);
+            let count = pool.participant_count();
+            drop(pool);
+            tracing::debug!(
+                executor = %executor,
+                commons_share,
+                pool_size = count,
+                "Added/updated node in commons pool"
+            );
+        } else {
+            let mut pool = self.commons_pool.write().await;
+            pool.remove_participant(&executor);
+            drop(pool);
+            tracing::debug!(
+                executor = %executor,
+                "Removed node from commons pool (zero commons share)"
+            );
+        }
 
         Ok(())
     }

--- a/icn/crates/icn-compute/src/commons_pool.rs
+++ b/icn/crates/icn-compute/src/commons_pool.rs
@@ -1,0 +1,221 @@
+//! Commons resource pool tracking.
+//!
+//! **Architectural invariant**: `CommonsPool` is advisory scheduling state.
+//! It is ephemeral, rebuilt from gossip announcements. The ledger is
+//! authoritative economic state — this pool must never mutate economic truth.
+//!
+//! **Architectural invariant**: Affiliated nodes without an explicit budget
+//! default to `CapacityBudget::default()` (0.10 commons share), not full
+//! commons. Omitting a budget must never accidentally opt a node fully into
+//! commons — that is a governance footgun.
+
+use std::collections::HashMap;
+use std::time::Instant;
+
+use crate::scheduler::{CapacityBudget, NodeCapacity};
+
+/// A node participating in the commons resource pool.
+#[derive(Debug, Clone)]
+pub struct CommonsParticipant {
+    /// DID of the participating node.
+    pub did: String,
+    /// Reported capacity of the node.
+    pub capacity: NodeCapacity,
+    /// Capacity budget controlling how much is shared with each scope.
+    pub budget: CapacityBudget,
+    /// When we last heard from this node. In-memory only — not serialized,
+    /// not sent over the wire. Enables future stale-participant expiry
+    /// without migration.
+    pub last_announce: Instant,
+}
+
+/// Aggregate capacity across all commons participants.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AggregateCapacity {
+    /// Total commons-weighted CPU cores.
+    pub cpu_cores: f64,
+    /// Total commons-weighted memory in MB.
+    pub memory_mb: u64,
+    /// Total commons-weighted storage in MB.
+    pub storage_mb: u64,
+    /// Number of participating nodes.
+    pub node_count: usize,
+}
+
+/// Advisory pool of nodes contributing to the commons.
+///
+/// **This is advisory scheduling state.** Ephemeral, rebuilt from gossip.
+/// The ledger is authoritative economic state.
+///
+/// **Lock discipline**: Never hold a write lock on `CommonsPool` during
+/// heavy computation. Acquire, mutate, release.
+#[derive(Debug)]
+pub struct CommonsPool {
+    participants: HashMap<String, CommonsParticipant>,
+}
+
+impl CommonsPool {
+    /// Create an empty commons pool.
+    pub fn new() -> Self {
+        Self {
+            participants: HashMap::new(),
+        }
+    }
+
+    /// Add or update a participant in the pool.
+    pub fn add_participant(&mut self, participant: CommonsParticipant) {
+        self.participants
+            .insert(participant.did.clone(), participant);
+    }
+
+    /// Remove a participant by DID. Returns the removed participant if present.
+    pub fn remove_participant(&mut self, did: &str) -> Option<CommonsParticipant> {
+        self.participants.remove(did)
+    }
+
+    /// Number of participants currently in the pool.
+    pub fn participant_count(&self) -> usize {
+        self.participants.len()
+    }
+
+    /// Check whether a DID is in the pool.
+    pub fn contains(&self, did: &str) -> bool {
+        self.participants.contains_key(did)
+    }
+
+    /// Get a participant by DID.
+    pub fn get_participant(&self, did: &str) -> Option<&CommonsParticipant> {
+        self.participants.get(did)
+    }
+
+    /// Iterate over all participants.
+    pub fn participants(&self) -> impl Iterator<Item = &CommonsParticipant> {
+        self.participants.values()
+    }
+
+    /// Compute the total commons-weighted capacity across all participants.
+    ///
+    /// Each node's capacity is weighted by its `budget.commons_share`.
+    pub fn total_commons_capacity(&self) -> AggregateCapacity {
+        let mut cpu_cores: f64 = 0.0;
+        let mut memory_mb: u128 = 0;
+        let mut storage_mb: u128 = 0;
+
+        for p in self.participants.values() {
+            let share = p.budget.commons_share;
+            cpu_cores += p.capacity.cpu_cores_available * share;
+            memory_mb += (p.capacity.memory_mb_available as f64 * share) as u128;
+            storage_mb += (p.capacity.storage_mb_available as f64 * share) as u128;
+        }
+
+        AggregateCapacity {
+            cpu_cores,
+            // Clamp u128 → u64 with saturation
+            memory_mb: memory_mb.min(u64::MAX as u128) as u64,
+            storage_mb: storage_mb.min(u64::MAX as u128) as u64,
+            node_count: self.participants.len(),
+        }
+    }
+}
+
+impl Default for CommonsPool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_capacity(cpu: f64, mem: u64, storage: u64) -> NodeCapacity {
+        NodeCapacity {
+            cpu_cores_total: cpu,
+            cpu_cores_available: cpu,
+            memory_mb_total: mem,
+            memory_mb_available: mem,
+            storage_mb_available: storage,
+            network_mbps: 100.0,
+            gpu_devices: vec![],
+            updated_at: 1000,
+        }
+    }
+
+    fn make_participant(
+        did: &str,
+        cpu: f64,
+        mem: u64,
+        storage: u64,
+        share: f64,
+    ) -> CommonsParticipant {
+        CommonsParticipant {
+            did: did.to_string(),
+            capacity: make_capacity(cpu, mem, storage),
+            budget: CapacityBudget {
+                commons_share: share,
+                ..CapacityBudget::default()
+            },
+            last_announce: Instant::now(),
+        }
+    }
+
+    #[test]
+    fn test_add_remove_participant() {
+        let mut pool = CommonsPool::new();
+        assert_eq!(pool.participant_count(), 0);
+        assert!(!pool.contains("did:icn:alice"));
+
+        pool.add_participant(make_participant("did:icn:alice", 4.0, 8192, 50000, 0.5));
+        assert_eq!(pool.participant_count(), 1);
+        assert!(pool.contains("did:icn:alice"));
+
+        let removed = pool.remove_participant("did:icn:alice");
+        assert!(removed.is_some());
+        assert_eq!(pool.participant_count(), 0);
+        assert!(!pool.contains("did:icn:alice"));
+    }
+
+    #[test]
+    fn test_weighted_aggregation() {
+        let mut pool = CommonsPool::new();
+
+        // Node A: 4 cores, 8GB, 50GB — 50% commons share
+        pool.add_participant(make_participant("did:icn:a", 4.0, 8192, 50000, 0.5));
+        // Node B: 8 cores, 16GB, 100GB — 100% commons share (unaffiliated)
+        pool.add_participant(make_participant("did:icn:b", 8.0, 16384, 100000, 1.0));
+
+        let agg = pool.total_commons_capacity();
+        assert_eq!(agg.node_count, 2);
+        // A contributes 4*0.5=2.0 cores, B contributes 8*1.0=8.0 cores → 10.0
+        assert!((agg.cpu_cores - 10.0).abs() < f64::EPSILON);
+        // A: 8192*0.5=4096, B: 16384*1.0=16384 → 20480
+        assert_eq!(agg.memory_mb, 20480);
+        // A: 50000*0.5=25000, B: 100000*1.0=100000 → 125000
+        assert_eq!(agg.storage_mb, 125000);
+    }
+
+    #[test]
+    fn test_empty_pool() {
+        let pool = CommonsPool::new();
+        let agg = pool.total_commons_capacity();
+        assert_eq!(agg.node_count, 0);
+        assert!((agg.cpu_cores).abs() < f64::EPSILON);
+        assert_eq!(agg.memory_mb, 0);
+        assert_eq!(agg.storage_mb, 0);
+    }
+
+    #[test]
+    fn test_contains_and_get() {
+        let mut pool = CommonsPool::new();
+        pool.add_participant(make_participant("did:icn:alice", 4.0, 8192, 50000, 0.5));
+
+        assert!(pool.contains("did:icn:alice"));
+        assert!(!pool.contains("did:icn:bob"));
+
+        let p = pool.get_participant("did:icn:alice");
+        assert!(p.is_some());
+        assert_eq!(p.unwrap().did, "did:icn:alice");
+
+        assert!(pool.get_participant("did:icn:bob").is_none());
+    }
+}

--- a/icn/crates/icn-compute/src/commons_pool.rs
+++ b/icn/crates/icn-compute/src/commons_pool.rs
@@ -26,6 +26,8 @@ pub struct CommonsParticipant {
     /// When we last heard from this node. In-memory only — not serialized,
     /// not sent over the wire. Enables future stale-participant expiry
     /// without migration.
+    // TODO(#925): Implement stale participant expiry using last_announce.
+    // Nodes not announcing for >5 minutes should be removed from the pool.
     pub last_announce: Instant,
 }
 
@@ -96,6 +98,13 @@ impl CommonsPool {
     /// Compute the total commons-weighted capacity across all participants.
     ///
     /// Each node's capacity is weighted by its `budget.commons_share`.
+    ///
+    /// # Thread Safety
+    ///
+    /// This method takes `&self` and iterates over the participants map.
+    /// Callers are responsible for ensuring exclusive access — in practice
+    /// this is always called while holding an `RwLock` (read or write)
+    /// on the `CommonsPool`.
     pub fn total_commons_capacity(&self) -> AggregateCapacity {
         let mut cpu_cores: f64 = 0.0;
         let mut memory_mb: u128 = 0;
@@ -110,7 +119,7 @@ impl CommonsPool {
 
         AggregateCapacity {
             cpu_cores,
-            // Clamp u128 → u64 with saturation
+            // Saturate u128 → u64: values above u64::MAX are clamped.
             memory_mb: memory_mb.min(u64::MAX as u128) as u64,
             storage_mb: storage_mb.min(u64::MAX as u128) as u64,
             node_count: self.participants.len(),

--- a/icn/crates/icn-compute/src/error.rs
+++ b/icn/crates/icn-compute/src/error.rs
@@ -79,6 +79,11 @@ pub enum ComputeError {
     /// Lock error
     #[error("lock error")]
     LockError,
+
+    /// Insufficient commons credits for the requested operation (Epic 6 #948).
+    /// Accounting infrastructure only — enforcement at scheduling time is deferred.
+    #[error("insufficient commons credits: balance={balance}, required={required}")]
+    InsufficientCommonsCredits { balance: i64, required: i64 },
 }
 
 impl From<icn_encoding::Error> for ComputeError {

--- a/icn/crates/icn-compute/src/lib.rs
+++ b/icn/crates/icn-compute/src/lib.rs
@@ -29,6 +29,7 @@ mod actor;
 mod actor_model;
 mod actor_runtime;
 mod checkpoint_store;
+pub mod commons_pool;
 mod dispute;
 mod error;
 mod executor;
@@ -59,6 +60,7 @@ pub use actor_runtime::{
 pub use checkpoint_store::{
     CheckpointBackend, CheckpointStore, InMemoryBackend, SledCheckpointBackend,
 };
+pub use commons_pool::{AggregateCapacity, CommonsParticipant, CommonsPool};
 pub use dispute::{
     ComputeDispute, ComputeResult as DisputeComputeResult, DisputeManager, DisputeResolution,
     DisputeStatus, Evidence, EvidenceType, VerificationMode,

--- a/icn/crates/icn-compute/src/types.rs
+++ b/icn/crates/icn-compute/src/types.rs
@@ -411,6 +411,13 @@ pub enum ComputeMessage {
     NodeCapacityAnnounce {
         executor: String,
         capacity: crate::scheduler::NodeCapacity,
+        /// Cell this node belongs to. `None` = unaffiliated (Epic 6 #947).
+        #[serde(default)]
+        cell_id: Option<icn_kernel_api::CellId>,
+        /// Explicit capacity budget. `None` means use default for the
+        /// affiliation status (Epic 6 #947).
+        #[serde(default)]
+        capacity_budget: Option<crate::scheduler::CapacityBudget>,
     },
 
     // === Phase 16D: Actor Checkpointing & Migration ===

--- a/icn/crates/icn-compute/tests/commons_integration.rs
+++ b/icn/crates/icn-compute/tests/commons_integration.rs
@@ -1,0 +1,174 @@
+//! Integration tests for the commons resource pool and credit accounting (Epic 6 #949).
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use icn_compute::commons_pool::{CommonsParticipant, CommonsPool};
+use icn_compute::{CapacityBudget, NodeCapacity};
+use std::time::Instant;
+
+/// Helper to create a NodeCapacity for testing.
+fn test_capacity(cpu: f64, mem: u64, storage: u64) -> NodeCapacity {
+    NodeCapacity {
+        cpu_cores_total: cpu,
+        cpu_cores_available: cpu,
+        memory_mb_total: mem,
+        memory_mb_available: mem,
+        storage_mb_available: storage,
+        network_mbps: 100.0,
+        gpu_devices: vec![],
+        updated_at: 1000,
+    }
+}
+
+/// Test 1: Unaffiliated node joins pool with full commons share.
+#[test]
+fn test_unaffiliated_node_joins_pool() {
+    let mut pool = CommonsPool::new();
+
+    // Unaffiliated node: no cell_id, full commons share (1.0)
+    let participant = CommonsParticipant {
+        did: "did:icn:unaffiliated1".to_string(),
+        capacity: test_capacity(8.0, 16384, 100000),
+        budget: CapacityBudget {
+            local_reserve: 0.0,
+            cell_share: 0.0,
+            org_share: 0.0,
+            federation_share: 0.0,
+            commons_share: 1.0,
+        },
+        last_announce: Instant::now(),
+    };
+
+    pool.add_participant(participant);
+    assert!(pool.contains("did:icn:unaffiliated1"));
+    assert_eq!(pool.participant_count(), 1);
+
+    let agg = pool.total_commons_capacity();
+    assert_eq!(agg.node_count, 1);
+    // Full share: 8.0 * 1.0 = 8.0 cores
+    assert!((agg.cpu_cores - 8.0).abs() < f64::EPSILON);
+    // Full share: 16384 * 1.0 = 16384 MB
+    assert_eq!(agg.memory_mb, 16384);
+    assert_eq!(agg.storage_mb, 100000);
+}
+
+/// Test 2: Earn credits from metered resources.
+#[test]
+fn test_earn_credits_from_receipt() {
+    use icn_ledger::commons_credits::{
+        build_earn_entry, compute_credits_earned, COMMONS_CREDIT_CURRENCY,
+    };
+
+    // Simulate metered resource usage
+    let cpu_millis = 5_000;
+    let memory_mb_millis = 2_000_000;
+    let storage_bytes = 50_000_000;
+    let egress_bytes = 1_000_000;
+
+    let credits = compute_credits_earned(cpu_millis, memory_mb_millis, storage_bytes, egress_bytes);
+    // 5000 + 2000000/1000 + 50000000/1000000 + 1000000/100000
+    // = 5000 + 2000 + 50 + 10 = 7060
+    assert_eq!(credits, 7060);
+
+    // Build earn entry
+    let contributor =
+        icn_identity::Did::from_str("did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9")
+            .unwrap();
+    let entry = build_earn_entry(&contributor, credits as i64).unwrap();
+
+    // Verify double-entry: 2 account deltas
+    assert_eq!(entry.accounts.len(), 2);
+
+    // One should be a debit (commons-mint), one a credit (contributor)
+    let has_debit = entry
+        .accounts
+        .iter()
+        .any(|a| a.debit.is_some() && a.currency == COMMONS_CREDIT_CURRENCY);
+    let has_credit = entry
+        .accounts
+        .iter()
+        .any(|a| a.credit.is_some() && a.currency == COMMONS_CREDIT_CURRENCY);
+    assert!(has_debit);
+    assert!(has_credit);
+}
+
+/// Test 3: Earn then spend — balance tracking.
+#[test]
+fn test_earn_then_spend() {
+    use icn_ledger::commons_credits::{
+        build_earn_entry, build_spend_entry, check_sufficient_balance,
+    };
+
+    let did = icn_identity::Did::from_str("did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9")
+        .unwrap();
+
+    // Earn 500
+    let earn = build_earn_entry(&did, 500);
+    assert!(earn.is_ok());
+
+    // Simulate balance of 500 after earning
+    let balance = 500_i64;
+
+    // Spend 200
+    let spend = build_spend_entry(&did, 200);
+    assert!(spend.is_ok());
+
+    // Check remaining balance
+    let remaining = check_sufficient_balance(balance, 200).unwrap();
+    assert_eq!(remaining, 300);
+}
+
+/// Test 4: Insufficient credits rejected.
+#[test]
+fn test_insufficient_credits_rejected() {
+    use icn_ledger::commons_credits::check_sufficient_balance;
+
+    let result = check_sufficient_balance(100, 200);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.balance, 100);
+    assert_eq!(err.required, 200);
+}
+
+/// Test 5: Pool participant lifecycle — add, aggregate, remove, re-aggregate.
+#[test]
+fn test_pool_participant_lifecycle() {
+    let mut pool = CommonsPool::new();
+
+    // Add 3 nodes with different commons shares
+    let nodes = vec![
+        ("did:icn:node1", 4.0, 8192_u64, 50000_u64, 1.0_f64),
+        ("did:icn:node2", 8.0, 16384, 100000, 0.5),
+        ("did:icn:node3", 2.0, 4096, 20000, 0.1),
+    ];
+
+    for (did, cpu, mem, storage, share) in &nodes {
+        pool.add_participant(CommonsParticipant {
+            did: did.to_string(),
+            capacity: test_capacity(*cpu, *mem, *storage),
+            budget: CapacityBudget {
+                commons_share: *share,
+                ..CapacityBudget::default()
+            },
+            last_announce: Instant::now(),
+        });
+    }
+
+    assert_eq!(pool.participant_count(), 3);
+
+    let agg = pool.total_commons_capacity();
+    assert_eq!(agg.node_count, 3);
+    // node1: 4*1.0=4.0, node2: 8*0.5=4.0, node3: 2*0.1=0.2 → 8.2
+    assert!((agg.cpu_cores - 8.2).abs() < 1e-10);
+
+    // Remove node2
+    let removed = pool.remove_participant("did:icn:node2");
+    assert!(removed.is_some());
+    assert_eq!(pool.participant_count(), 2);
+
+    let agg2 = pool.total_commons_capacity();
+    assert_eq!(agg2.node_count, 2);
+    // node1: 4*1.0=4.0, node3: 2*0.1=0.2 → 4.2
+    assert!((agg2.cpu_cores - 4.2).abs() < 1e-10);
+    // node1: 8192*1.0=8192, node3: 4096*0.1=409 → 8601
+    assert_eq!(agg2.memory_mb, 8601);
+}

--- a/icn/crates/icn-compute/tests/commons_integration.rs
+++ b/icn/crates/icn-compute/tests/commons_integration.rs
@@ -129,7 +129,27 @@ fn test_insufficient_credits_rejected() {
     assert_eq!(err.required, 200);
 }
 
-/// Test 5: Pool participant lifecycle — add, aggregate, remove, re-aggregate.
+/// Test 5: Scheduling enforcement rejects tasks when credits are insufficient.
+///
+/// This test documents the intended integration point for credit enforcement
+/// at scheduling time. Currently deferred — Epic 6 is accounting only.
+#[test]
+#[ignore = "enforcement not yet implemented — Epic 6 is accounting infrastructure only"]
+fn test_scheduling_enforces_credits() {
+    // When integrated with the scheduler, this should look like:
+    //
+    //   let result = schedule_task_on_commons(task, submitter_did);
+    //   assert!(matches!(
+    //       result,
+    //       Err(icn_compute::ComputeError::InsufficientCommonsCredits { .. })
+    //   ));
+    //
+    // The InsufficientCommonsCredits error variant is defined in
+    // icn-compute/src/error.rs but not yet emitted in any code path.
+    unimplemented!("credit enforcement at scheduling time is deferred to a future epic");
+}
+
+/// Test 6: Pool participant lifecycle — add, aggregate, remove, re-aggregate.
 #[test]
 fn test_pool_participant_lifecycle() {
     let mut pool = CommonsPool::new();

--- a/icn/crates/icn-ledger/src/commons_credits.rs
+++ b/icn/crates/icn-ledger/src/commons_credits.rs
@@ -1,0 +1,224 @@
+//! Commons credit accounting for cooperative compute.
+//!
+//! This module provides credit computation and journal entry construction
+//! for the commons resource pool. Credits are earned by contributing
+//! compute resources and spent by consuming them.
+//!
+//! **Architectural invariant**: The commons-mint DID is only accessible
+//! through [`build_earn_entry`] and [`build_spend_entry`]. No generic
+//! ledger helpers should allow arbitrary debit/credit to the mint. This
+//! prevents credit laundering through the journal entry builder.
+//!
+//! **Architectural invariant**: The credit formula is an accounting
+//! heuristic, not a market price. Subject to governance adjustment.
+
+use crate::entry::JournalEntryBuilder;
+use crate::types::JournalEntry;
+use anyhow::Result;
+use icn_identity::Did;
+use std::sync::LazyLock;
+
+/// Currency identifier for commons credits.
+pub const COMMONS_CREDIT_CURRENCY: &str = "commons-credits";
+
+/// Synthetic DID for the commons mint.
+///
+/// Derived deterministically from the well-known seed `[0xCC; 32]` (0xCC = "Commons Credit").
+/// This DID is **only accessible through `build_earn_entry` / `build_spend_entry`.**
+/// Do not reference directly in generic journal entry construction.
+static COMMONS_MINT_DID: LazyLock<Did> = LazyLock::new(|| {
+    // Deterministic seed for the commons-mint identity.
+    // We only need the DID (public key), not signing capability.
+    let seed: [u8; 32] = [0xCC; 32];
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(&seed);
+    let verifying_key = signing_key.verifying_key();
+    Did::from_public_key(&verifying_key)
+});
+
+/// Compute credits earned from contributed resources.
+///
+/// This is an **accounting heuristic, not a market price**. The formula
+/// weights different resource types and is subject to governance adjustment.
+///
+/// Uses `u128` internally for accumulation, clamps to `u64` on output.
+/// All arithmetic is saturating to prevent overflow panics.
+pub fn compute_credits_earned(
+    cpu_millis: u64,
+    memory_mb_millis: u64,
+    storage_bytes: u64,
+    egress_bytes: u64,
+) -> u64 {
+    let acc: u128 = (cpu_millis as u128)
+        .saturating_add((memory_mb_millis as u128) / 1_000)
+        .saturating_add((storage_bytes as u128) / 1_000_000)
+        .saturating_add((egress_bytes as u128) / 100_000);
+
+    // Clamp u128 → u64
+    acc.min(u64::MAX as u128) as u64
+}
+
+/// Build a double-entry journal entry crediting the contributor.
+///
+/// Debits the commons mint and credits the contributor.
+/// Rejects `amount <= 0`.
+pub fn build_earn_entry(contributor: &Did, amount: i64) -> Result<JournalEntry> {
+    if amount <= 0 {
+        anyhow::bail!("earn amount must be positive, got {amount}");
+    }
+
+    let mint_did = COMMONS_MINT_DID.clone();
+
+    JournalEntryBuilder::new(mint_did.clone())
+        .debit(mint_did, COMMONS_CREDIT_CURRENCY.to_string(), amount)
+        .credit(
+            contributor.clone(),
+            COMMONS_CREDIT_CURRENCY.to_string(),
+            amount,
+        )
+        .build()
+}
+
+/// Build a double-entry journal entry debiting the consumer.
+///
+/// Debits the consumer and credits the commons mint.
+/// Rejects `amount <= 0`.
+pub fn build_spend_entry(consumer: &Did, amount: i64) -> Result<JournalEntry> {
+    if amount <= 0 {
+        anyhow::bail!("spend amount must be positive, got {amount}");
+    }
+
+    let mint_did = COMMONS_MINT_DID.clone();
+
+    JournalEntryBuilder::new(consumer.clone())
+        .debit(
+            consumer.clone(),
+            COMMONS_CREDIT_CURRENCY.to_string(),
+            amount,
+        )
+        .credit(mint_did, COMMONS_CREDIT_CURRENCY.to_string(), amount)
+        .build()
+}
+
+/// Check if the balance is sufficient for a required amount.
+///
+/// Returns the remaining balance (`balance - required`) on success,
+/// or an error if insufficient. Balance floor is zero.
+pub fn check_sufficient_balance(balance: i64, required: i64) -> Result<i64, InsufficientCredits> {
+    if balance < required {
+        return Err(InsufficientCredits { balance, required });
+    }
+    Ok(balance.saturating_sub(required))
+}
+
+/// Error returned when a commons credit balance is insufficient.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InsufficientCredits {
+    pub balance: i64,
+    pub required: i64,
+}
+
+impl std::fmt::Display for InsufficientCredits {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "insufficient commons credits: balance={}, required={}",
+            self.balance, self.required
+        )
+    }
+}
+
+impl std::error::Error for InsufficientCredits {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_credit_formula_known_inputs() {
+        // 1000 cpu_millis + 5_000_000 mem_mb_millis/1000 + 10_000_000 storage/1M + 500_000 egress/100k
+        // = 1000 + 5000 + 10 + 5 = 6015
+        let credits = compute_credits_earned(1_000, 5_000_000, 10_000_000, 500_000);
+        assert_eq!(credits, 6015);
+    }
+
+    #[test]
+    fn test_credit_formula_zero_inputs() {
+        assert_eq!(compute_credits_earned(0, 0, 0, 0), 0);
+    }
+
+    #[test]
+    fn test_credit_formula_u128_overflow_safety() {
+        // All u64::MAX — should not panic, should clamp to u64::MAX
+        let credits = compute_credits_earned(u64::MAX, u64::MAX, u64::MAX, u64::MAX);
+        assert_eq!(credits, u64::MAX);
+    }
+
+    #[test]
+    fn test_earn_entry_valid() {
+        let contributor =
+            Did::from_str("did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9").unwrap();
+        let entry = build_earn_entry(&contributor, 500);
+        assert!(entry.is_ok());
+        let entry = entry.unwrap();
+        assert_eq!(entry.accounts.len(), 2);
+    }
+
+    #[test]
+    fn test_spend_entry_valid() {
+        let consumer =
+            Did::from_str("did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9").unwrap();
+        let entry = build_spend_entry(&consumer, 200);
+        assert!(entry.is_ok());
+        let entry = entry.unwrap();
+        assert_eq!(entry.accounts.len(), 2);
+    }
+
+    #[test]
+    fn test_earn_rejects_zero() {
+        let contributor =
+            Did::from_str("did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9").unwrap();
+        assert!(build_earn_entry(&contributor, 0).is_err());
+    }
+
+    #[test]
+    fn test_earn_rejects_negative() {
+        let contributor =
+            Did::from_str("did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9").unwrap();
+        assert!(build_earn_entry(&contributor, -10).is_err());
+    }
+
+    #[test]
+    fn test_spend_rejects_zero() {
+        let consumer =
+            Did::from_str("did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9").unwrap();
+        assert!(build_spend_entry(&consumer, 0).is_err());
+    }
+
+    #[test]
+    fn test_spend_rejects_negative() {
+        let consumer =
+            Did::from_str("did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9").unwrap();
+        assert!(build_spend_entry(&consumer, -10).is_err());
+    }
+
+    #[test]
+    fn test_sufficient_balance() {
+        let remaining = check_sufficient_balance(500, 200);
+        assert_eq!(remaining, Ok(300));
+    }
+
+    #[test]
+    fn test_insufficient_balance() {
+        let result = check_sufficient_balance(100, 200);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.balance, 100);
+        assert_eq!(err.required, 200);
+    }
+
+    #[test]
+    fn test_exact_balance() {
+        let remaining = check_sufficient_balance(300, 300);
+        assert_eq!(remaining, Ok(0));
+    }
+}

--- a/icn/crates/icn-ledger/src/commons_credits.rs
+++ b/icn/crates/icn-ledger/src/commons_credits.rs
@@ -81,14 +81,17 @@ pub fn build_earn_entry(contributor: &Did, amount: i64) -> Result<JournalEntry> 
 
     let mint_did = COMMONS_MINT_DID.clone();
 
-    JournalEntryBuilder::new(mint_did.clone())
+    let entry = JournalEntryBuilder::new(mint_did.clone())
         .debit(mint_did, COMMONS_CREDIT_CURRENCY.to_string(), amount)
         .credit(
             contributor.clone(),
             COMMONS_CREDIT_CURRENCY.to_string(),
             amount,
         )
-        .build()
+        .build()?;
+
+    icn_obs::metrics::compute::commons_credits_earned_add(amount as u64);
+    Ok(entry)
 }
 
 /// Build a double-entry journal entry debiting the consumer.
@@ -103,14 +106,17 @@ pub fn build_spend_entry(consumer: &Did, amount: i64) -> Result<JournalEntry> {
 
     let mint_did = COMMONS_MINT_DID.clone();
 
-    JournalEntryBuilder::new(consumer.clone())
+    let entry = JournalEntryBuilder::new(consumer.clone())
         .debit(
             consumer.clone(),
             COMMONS_CREDIT_CURRENCY.to_string(),
             amount,
         )
         .credit(mint_did, COMMONS_CREDIT_CURRENCY.to_string(), amount)
-        .build()
+        .build()?;
+
+    icn_obs::metrics::compute::commons_credits_spent_add(amount as u64);
+    Ok(entry)
 }
 
 /// Check if the balance is sufficient for a required amount.

--- a/icn/crates/icn-ledger/src/commons_credits.rs
+++ b/icn/crates/icn-ledger/src/commons_credits.rs
@@ -21,6 +21,17 @@ use std::sync::LazyLock;
 /// Currency identifier for commons credits.
 pub const COMMONS_CREDIT_CURRENCY: &str = "commons-credits";
 
+// --- Credit formula weights (subject to governance adjustment) ---
+// TODO(governance): These constants should be configurable via CCL governance
+// parameters once governance hooks are available (Phase 29).
+
+/// Divisor for memory contribution (MB-millis → credits).
+const MEMORY_DIVISOR: u128 = 1_000;
+/// Divisor for storage contribution (bytes → credits).
+const STORAGE_DIVISOR: u128 = 1_000_000;
+/// Divisor for egress contribution (bytes → credits).
+const EGRESS_DIVISOR: u128 = 100_000;
+
 /// Synthetic DID for the commons mint.
 ///
 /// Derived deterministically from the well-known seed `[0xCC; 32]` (0xCC = "Commons Credit").
@@ -42,6 +53,7 @@ static COMMONS_MINT_DID: LazyLock<Did> = LazyLock::new(|| {
 ///
 /// Uses `u128` internally for accumulation, clamps to `u64` on output.
 /// All arithmetic is saturating to prevent overflow panics.
+#[must_use = "computed credits should be used to build a journal entry"]
 pub fn compute_credits_earned(
     cpu_millis: u64,
     memory_mb_millis: u64,
@@ -49,11 +61,11 @@ pub fn compute_credits_earned(
     egress_bytes: u64,
 ) -> u64 {
     let acc: u128 = (cpu_millis as u128)
-        .saturating_add((memory_mb_millis as u128) / 1_000)
-        .saturating_add((storage_bytes as u128) / 1_000_000)
-        .saturating_add((egress_bytes as u128) / 100_000);
+        .saturating_add((memory_mb_millis as u128) / MEMORY_DIVISOR)
+        .saturating_add((storage_bytes as u128) / STORAGE_DIVISOR)
+        .saturating_add((egress_bytes as u128) / EGRESS_DIVISOR);
 
-    // Clamp u128 → u64
+    // Saturate u128 → u64: values above u64::MAX are clamped.
     acc.min(u64::MAX as u128) as u64
 }
 
@@ -61,6 +73,7 @@ pub fn compute_credits_earned(
 ///
 /// Debits the commons mint and credits the contributor.
 /// Rejects `amount <= 0`.
+#[must_use = "journal entry should be appended to the ledger"]
 pub fn build_earn_entry(contributor: &Did, amount: i64) -> Result<JournalEntry> {
     if amount <= 0 {
         anyhow::bail!("earn amount must be positive, got {amount}");
@@ -82,6 +95,7 @@ pub fn build_earn_entry(contributor: &Did, amount: i64) -> Result<JournalEntry> 
 ///
 /// Debits the consumer and credits the commons mint.
 /// Rejects `amount <= 0`.
+#[must_use = "journal entry should be appended to the ledger"]
 pub fn build_spend_entry(consumer: &Did, amount: i64) -> Result<JournalEntry> {
     if amount <= 0 {
         anyhow::bail!("spend amount must be positive, got {amount}");
@@ -103,6 +117,7 @@ pub fn build_spend_entry(consumer: &Did, amount: i64) -> Result<JournalEntry> {
 ///
 /// Returns the remaining balance (`balance - required`) on success,
 /// or an error if insufficient. Balance floor is zero.
+#[must_use = "check result indicates whether operation should proceed"]
 pub fn check_sufficient_balance(balance: i64, required: i64) -> Result<i64, InsufficientCredits> {
     if balance < required {
         return Err(InsufficientCredits { balance, required });

--- a/icn/crates/icn-ledger/src/lib.rs
+++ b/icn/crates/icn-ledger/src/lib.rs
@@ -51,6 +51,7 @@
 //! ```
 
 pub mod balance;
+pub mod commons_credits;
 pub mod credit_policy;
 pub mod dispute;
 pub mod dynamic_limits;

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -3750,6 +3750,32 @@ pub mod compute {
     pub fn commons_pool_memory_mb_set(value: f64) {
         gauge!("icn_compute_commons_pool_memory_mb").set(value);
     }
+
+    /// Set the aggregate commons-weighted storage (MB) across all pool participants.
+    pub fn commons_pool_storage_mb_set(value: f64) {
+        gauge!("icn_compute_commons_pool_storage_mb").set(value);
+    }
+
+    /// Record a commons pool membership change (add or remove).
+    pub fn commons_pool_updates_inc(operation: &str) {
+        counter!(
+            "icn_compute_commons_pool_updates_total",
+            "operation" => operation.to_string()
+        )
+        .increment(1);
+    }
+
+    // === Commons Credit Accounting Metrics (Epic 6 #925) ===
+
+    /// Record commons credits earned by a contributor.
+    pub fn commons_credits_earned_add(amount: u64) {
+        counter!("icn_compute_commons_credits_earned_total").increment(amount);
+    }
+
+    /// Record commons credits spent by a consumer.
+    pub fn commons_credits_spent_add(amount: u64) {
+        counter!("icn_compute_commons_credits_spent_total").increment(amount);
+    }
 }
 
 /// Misbehavior detection metrics (Phase 18)

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -3733,6 +3733,23 @@ pub mod compute {
     pub fn task_scope_map_size_set(size: f64) {
         gauge!("icn_compute_task_scope_map_size").set(size);
     }
+
+    // === Commons Pool Metrics (Epic 6 #925) ===
+
+    /// Set the number of nodes currently in the commons resource pool.
+    pub fn commons_pool_participants_set(count: f64) {
+        gauge!("icn_compute_commons_pool_participants").set(count);
+    }
+
+    /// Set the aggregate commons-weighted CPU cores across all pool participants.
+    pub fn commons_pool_cpu_cores_set(value: f64) {
+        gauge!("icn_compute_commons_pool_cpu_cores").set(value);
+    }
+
+    /// Set the aggregate commons-weighted memory (MB) across all pool participants.
+    pub fn commons_pool_memory_mb_set(value: f64) {
+        gauge!("icn_compute_commons_pool_memory_mb").set(value);
+    }
 }
 
 /// Misbehavior detection metrics (Phase 18)


### PR DESCRIPTION
## Summary

Implements **Epic 6 — Commons Resource Pool and Contribution Accounting** (#925) across four sub-issues:

- **#946**: `CommonsPool` type with `CommonsParticipant`, `AggregateCapacity`, and weighted capacity aggregation
- **#947**: Unaffiliated node participation — extends `NodeCapacityAnnounce` with `cell_id` and `capacity_budget` fields (both `#[serde(default)]` for backward compat), implements decision matrix in `on_capacity_announce`
- **#948**: Commons credit formula (`compute_credits_earned` with u128 accumulator → u64 clamp), mint-restricted `build_earn_entry`/`build_spend_entry`, `check_sufficient_balance`, and `InsufficientCommonsCredits` error variant
- **#949**: 5 integration tests + 16 unit tests covering pool lifecycle, credit accounting, and edge cases

### Key Architectural Invariants

1. **CommonsPool is advisory scheduling state.** Ledger state is authoritative economic state. The pool is ephemeral, rebuilt from gossip.
2. **Commons-mint DID only accessible through `build_earn_entry()` / `build_spend_entry()`.** No generic ledger helpers allow arbitrary debit/credit to the mint.
3. **Affiliated nodes without explicit budget default to `CapacityBudget::default()` (0.10 commons share)**, not full commons.
4. **Credit formula uses u128 accumulator internally**, clamps to u64 on output. Saturating arithmetic throughout.
5. **Lock discipline**: CommonsPool write lock acquired, mutated, released immediately.

### Decision Matrix (NodeCapacityAnnounce)

| `cell_id` | `capacity_budget` | Behavior |
|-----------|-------------------|----------|
| `None` | `None` | Unaffiliated → full commons (1.0) |
| `None` | `Some(b)` | Unaffiliated with explicit budget |
| `Some(_)` | `None` | Affiliated → default budget (0.10 commons) |
| `Some(_)` | `Some(b)` | Affiliated with explicit budget |

### Intentionally Deferred

- **No economic enforcement at scheduling time** — this is accounting infrastructure only
- Commons governance, persistent storage, PolicyOracle, stale participant expiry logic

### Files Changed

| File | Action |
|------|--------|
| `icn-compute/src/commons_pool.rs` | **New** — CommonsPool, CommonsParticipant, AggregateCapacity |
| `icn-compute/src/lib.rs` | Module + re-exports |
| `icn-compute/src/actor/mod.rs` | CommonsPool field + init |
| `icn-compute/src/actor/placement.rs` | Decision matrix in on_capacity_announce |
| `icn-compute/src/types.rs` | cell_id + capacity_budget on NodeCapacityAnnounce |
| `icn-compute/src/error.rs` | InsufficientCommonsCredits variant |
| `icn-compute/Cargo.toml` | icn-ledger dev-dependency |
| `icn-compute/tests/commons_integration.rs` | **New** — 5 integration tests |
| `icn-ledger/src/commons_credits.rs` | **New** — credit formula + journal entries |
| `icn-ledger/src/lib.rs` | Module declaration |

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -p icn-compute -p icn-ledger --all-targets --all-features -- -D warnings` clean
- [x] `cargo test -p icn-compute` — all 270+ tests pass
- [x] `cargo test -p icn-ledger` — all tests pass
- [x] `cargo check --all-targets` — full workspace compiles
- [ ] CI pipeline passes

Closes #946, #947, #948, #949
Part of #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)