### PR TITLE
feat(runtime): wire GovernanceService and LedgerService into daemon

### DIFF
--- a/apps/governance/src/oracle.rs
+++ b/apps/governance/src/oracle.rs
@@ -109,8 +109,7 @@ impl PolicyOracle for GovernancePolicyOracle {
 mod tests {
     use super::*;
     use icn_governance::{
-        ParameterConstraints, ParameterScope, ParameterValue, ProtocolParameter,
-        SledParameterStore,
+        ParameterConstraints, ParameterScope, ParameterValue, ProtocolParameter, SledParameterStore,
     };
     use icn_kernel_api::authz::ActionKind;
     use icn_kernel_api::types::Did;

--- a/apps/governance/src/service.rs
+++ b/apps/governance/src/service.rs
@@ -113,8 +113,7 @@ impl GovernanceService for GovernanceServiceImpl {
 mod tests {
     use super::*;
     use icn_governance::{
-        ParameterConstraints, ParameterScope, ParameterValue, ProtocolParameter,
-        SledParameterStore,
+        ParameterConstraints, ParameterScope, ParameterValue, ProtocolParameter, SledParameterStore,
     };
     use icn_kernel_api::types::Did;
 

--- a/docs/architecture/KERNEL_APP_SEPARATION.md
+++ b/docs/architecture/KERNEL_APP_SEPARATION.md
@@ -1,7 +1,7 @@
 # Kernel/App Separation Architecture
 
 **Status**: Living Document  
-**Last Updated**: 2026-01-29  
+**Last Updated**: 2026-01-30
 **Related Issues**: Phase 19+ (Trust Extraction, PolicyOracle Migration)
 
 ---
@@ -336,20 +336,69 @@ impl ServiceRegistry {
 }
 ```
 
-**Usage in icnd**:
+**Key Constants** (prevent typo-induced silent `None`):
 
 ```rust
-// In icnd main.rs (conceptual)
-let trust_graph = Arc::new(RwLock::new(TrustGraph::new(store)));
-let trust_service = Arc::new(TrustGraphService::new(trust_graph.clone()));
-
-let registry = ServiceRegistry::new()
-    .with_trust(trust_service)
-    .with_raw_handle("trust_graph", trust_graph);  // Transition
-
-let runtime = Runtime::new(config, registry)?;
-runtime.run().await?;
+impl ServiceRegistry {
+    pub const TRUST_GRAPH_KEY: &str = "trust_graph";
+    pub const PROTOCOL_PARAM_STORE_KEY: &str = "protocol_parameter_store";
+    pub const LEDGER_KEY: &str = "ledger";
+    pub const LEDGER_STORE_KEY: &str = "ledger_store";
+}
 ```
+
+Always use these constants instead of string literals when calling `with_raw_handle()` or `raw_handle()`.
+
+**Usage in icnd** (all three services wired):
+
+```rust
+// In icnd main.rs — build_service_registry()
+// 1. Trust
+let trust_graph_handle = Arc::new(RwLock::new(TrustGraph::new(store, did)));
+let trust_service = icn_trust_app::create_service_tokio(trust_graph_handle.clone());
+registry = registry.with_trust(trust_service);
+registry = registry.with_raw_handle(ServiceRegistry::TRUST_GRAPH_KEY, trust_graph_handle);
+
+// 2. Governance
+let parameter_store = Arc::new(SledParameterStore::new(Arc::new(param_db))?);
+let governance_service = icn_governance_app::create_service(parameter_store.clone() as _);
+registry = registry.with_governance(governance_service);
+registry = registry.with_raw_handle(ServiceRegistry::PROTOCOL_PARAM_STORE_KEY, parameter_store);
+
+// 3. Ledger
+let ledger_store = Arc::new(SledStore::open(&ledger_store_path)?);
+let ledger = Ledger::new(ledger_store.clone() as _)?;
+let ledger_handle = Arc::new(RwLock::new(ledger));
+let ledger_service = icn_ledger_app::create_service(ledger_handle.clone());
+registry = registry.with_ledger(ledger_service);
+registry = registry.with_raw_handle(ServiceRegistry::LEDGER_KEY, ledger_handle);
+registry = registry.with_raw_handle(ServiceRegistry::LEDGER_STORE_KEY, ledger_store);
+```
+
+#### raw_handle Type Patterns
+
+The `raw_handle<T>` method requires `T: Sized`. This creates two patterns depending on the stored type:
+
+**Pattern A: Concrete type with trait upcast** (for trait objects like `dyn ProtocolParameterStore`):
+```rust
+// Store concrete type (Sized)
+registry.with_raw_handle(ServiceRegistry::PROTOCOL_PARAM_STORE_KEY, arc_sled_param_store);
+
+// Retrieve as concrete, then upcast
+let store: Arc<SledParameterStore> = registry.raw_handle(ServiceRegistry::PROTOCOL_PARAM_STORE_KEY)?;
+let trait_obj: Arc<dyn ProtocolParameterStore> = store;  // upcast
+```
+
+**Pattern B: Direct storage** (for wrapped types like `Arc<RwLock<Ledger>>`):
+```rust
+// Store directly (RwLock<Ledger> is Sized)
+registry.with_raw_handle(ServiceRegistry::LEDGER_KEY, ledger_handle);
+
+// Retrieve directly
+let handle: Arc<RwLock<Ledger>> = registry.raw_handle(ServiceRegistry::LEDGER_KEY)?;
+```
+
+**Why the daemon passes stores separately**: Sled uses exclusive file locking (`flock` on Linux). Opening the same sled path twice in the same process fails. The daemon creates stores once and passes them through `raw_handle` so the supervisor can reuse them for ancillary services (DisputeManager, TreasuryManager) without re-opening.
 
 ### 3.4 ConstraintSet
 
@@ -621,6 +670,8 @@ fn check_access(&self, score: f64) -> bool {
 | PolicySource → kernel TrustClass | 2026-01-28 | Type migration |
 | IdentityHandle → kernel TrustClass | 2026-01-28 | Type migration |
 | GossipDeps → PolicyOracle | 2026-01-27 | Removed TrustGraphOracle fallback |
+| GovernanceService wired in icnd | 2026-01-30 | Daemon owns SledParameterStore lifecycle |
+| LedgerService wired in icnd | 2026-01-30 | Daemon owns Ledger + SledStore lifecycle |
 
 ### 6.2 Remaining Work
 
@@ -629,14 +680,18 @@ fn check_access(&self, score: f64) -> bool {
 | MisbehaviorDetector | icn-core/security | Needs TrustService | Uses TrustGraph directly |
 | GatewayServer trust routes | icn-gateway | Partial | Some endpoints still use TrustGraph |
 | init_trust.rs cleanup | icn-core/supervisor | Done | Documentation added |
+| ContractActor | icn-ccl | Needs TrustService | Still accepts `Option<Arc<RwLock<TrustGraph>>>` |
 
 ### 6.3 Transition Handles
 
 These `raw_handles` exist for components not yet migrated:
 
-```rust
-registry.with_raw_handle("trust_graph", trust_graph.clone())
-```
+| Key | Type | Used By | Remove When |
+|-----|------|---------|-------------|
+| `TRUST_GRAPH_KEY` | `Arc<RwLock<TrustGraph>>` | MisbehaviorDetector, ContractActor | Components migrated to TrustService |
+| `PROTOCOL_PARAM_STORE_KEY` | `Arc<SledParameterStore>` | Supervisor init_governance | Supervisor creates its own (standalone mode only) |
+| `LEDGER_KEY` | `Arc<RwLock<Ledger>>` | Supervisor init_ledger | Supervisor creates its own (standalone mode only) |
+| `LEDGER_STORE_KEY` | `Arc<SledStore>` | Supervisor init_ledger (DisputeManager, TreasuryManager) | Sled replaced or all stores created by daemon |
 
 **Goal**: Remove all `raw_handles` when migration is complete.
 
@@ -766,7 +821,24 @@ Kernel code should only use `icn_kernel_api::TrustClass`.
 
 ---
 
-## Appendix: Key Files
+## Appendix A: Store Path Structure
+
+The daemon creates sled-backed stores under `config.store_path()` (default: `~/.icn/store/`):
+
+| Path | Owner | Contents |
+|------|-------|----------|
+| `store/trust/` | Daemon → TrustGraph | Trust attestations, scores |
+| `store/protocol_params/` | Daemon → GovernanceService | Protocol parameter values |
+| `store/ledger/` | Daemon → Ledger + DisputeManager + TreasuryManager | Double-entry transactions, disputes |
+
+Each path is opened exactly once by the daemon. The supervisor receives handles via `ServiceRegistry.raw_handle()` to avoid double-opening sled databases.
+
+Helper methods on `Config`:
+- `config.store_path()` → base store directory
+- `config.protocol_params_path()` → `store/protocol_params/`
+- `config.ledger_store_path()` → `store/ledger/`
+
+## Appendix B: Key Files
 
 | File | Purpose |
 |------|---------|
@@ -775,5 +847,10 @@ Kernel code should only use `icn_kernel_api::TrustClass`.
 | `icn/crates/icn-kernel-api/src/services.rs` | TrustService, ServiceRegistry |
 | `icn/crates/icn-core/src/supervisor/lifecycle.rs` | Service injection |
 | `icn/crates/icn-core/src/supervisor/init_trust.rs` | Trust initialization |
+| `icn/crates/icn-core/src/supervisor/init_governance.rs` | Governance initialization |
+| `icn/crates/icn-core/src/supervisor/init_ledger.rs` | Ledger initialization |
 | `icn/crates/icn-gateway/src/trust_policy.rs` | TrustPolicyOracle implementation |
+| `apps/trust/` | TrustService app implementation |
+| `apps/governance/` | GovernanceService app implementation |
+| `apps/ledger/` | LedgerService app implementation |
 | `CLAUDE.md` | Agent guidance (Kernel/App section) |

--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -3166,6 +3166,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "icn-governance-app"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "icn-governance",
+ "icn-identity",
+ "icn-kernel-api",
+ "icn-store",
+ "parking_lot 0.12.5",
+ "tracing",
+]
+
+[[package]]
 name = "icn-identity"
 version = "0.1.0"
 dependencies = [
@@ -3243,6 +3256,20 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "icn-ledger-app"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "icn-identity",
+ "icn-kernel-api",
+ "icn-ledger",
+ "icn-store",
+ "parking_lot 0.12.5",
  "tokio",
  "tracing",
 ]
@@ -3616,9 +3643,12 @@ dependencies = [
  "icn-ccl",
  "icn-core",
  "icn-gossip",
+ "icn-governance",
+ "icn-governance-app",
  "icn-identity",
  "icn-kernel-api",
  "icn-ledger",
+ "icn-ledger-app",
  "icn-net",
  "icn-obs",
  "icn-rpc",
@@ -3627,6 +3657,7 @@ dependencies = [
  "icn-trust-app",
  "rpassword",
  "rustls",
+ "sled",
  "tokio",
  "tracing",
  "zeroize",

--- a/icn/bins/icnd/Cargo.toml
+++ b/icn/bins/icnd/Cargo.toml
@@ -39,6 +39,12 @@ icn-obs.workspace = true
 
 # App crates (domain logic - lives outside kernel)
 icn-trust-app = { path = "../../../apps/trust" }
+icn-governance-app = { path = "../../../apps/governance" }
+icn-ledger-app = { path = "../../../apps/ledger" }
+
+# Needed for parameter store construction in daemon
+sled.workspace = true
+icn-governance.workspace = true
 
 [lints]
 workspace = true

--- a/icn/bins/icnd/src/main.rs
+++ b/icn/bins/icnd/src/main.rs
@@ -106,11 +106,15 @@ fn build_service_registry(
         tracing::debug!("  - Raw trust_graph handle passed for transition components");
 
         // Create GovernanceService from apps/governance
-        let param_store_path = config.store_path().join("protocol_params");
-        std::fs::create_dir_all(&param_store_path)?;
-        let param_db = sled::open(&param_store_path)?;
-        let parameter_store =
-            Arc::new(icn_governance::SledParameterStore::new(Arc::new(param_db))?);
+        let param_store_path = config.protocol_params_path();
+        std::fs::create_dir_all(&param_store_path)
+            .context("Failed to create protocol params store directory")?;
+        let param_db = sled::open(&param_store_path)
+            .context("Failed to open protocol params sled database")?;
+        let parameter_store = Arc::new(
+            icn_governance::SledParameterStore::new(Arc::new(param_db))
+                .context("Failed to initialize SledParameterStore")?,
+        );
         let parameter_store_trait: Arc<dyn icn_governance::ProtocolParameterStore> =
             parameter_store.clone();
         let governance_service = icn_governance_app::create_service(parameter_store_trait);
@@ -122,11 +126,15 @@ fn build_service_registry(
         // Create LedgerService from apps/ledger
         // Ledger is created minimally here; supervisor configures it further
         // (gossip, trust, oracle, witnesses, credit policy, validation hooks)
-        let ledger_store_path = config.store_path().join("ledger");
-        std::fs::create_dir_all(&ledger_store_path)?;
-        let ledger_store: Arc<dyn icn_store::Store> =
-            Arc::new(icn_store::SledStore::open(&ledger_store_path)?);
-        let ledger = icn_ledger::Ledger::new(ledger_store)?;
+        let ledger_store_path = config.ledger_store_path();
+        std::fs::create_dir_all(&ledger_store_path)
+            .context("Failed to create ledger store directory")?;
+        let ledger_store: Arc<dyn icn_store::Store> = Arc::new(
+            icn_store::SledStore::open(&ledger_store_path)
+                .context("Failed to open ledger store")?,
+        );
+        let ledger =
+            icn_ledger::Ledger::new(ledger_store).context("Failed to initialize Ledger")?;
         let ledger_handle = Arc::new(RwLock::new(ledger));
         let ledger_service = icn_ledger_app::create_service(ledger_handle.clone());
         registry = registry.with_ledger(ledger_service);

--- a/icn/bins/icnd/src/main.rs
+++ b/icn/bins/icnd/src/main.rs
@@ -100,17 +100,25 @@ fn build_service_registry(
         // Also pass raw TrustGraph handle for components that still need direct access
         // during the transition period (MisbehaviorDetector, ReplicationManager).
         // This should be removed when those components migrate to use TrustService.
-        registry = registry.with_raw_handle("trust_graph", trust_graph_handle);
+        registry = registry.with_raw_handle(ServiceRegistry::TRUST_GRAPH_KEY, trust_graph_handle);
 
         tracing::info!("Trust service initialized from apps/trust");
         tracing::debug!("  - Raw trust_graph handle passed for transition components");
 
         // Create GovernanceService from apps/governance
         let param_store_path = config.protocol_params_path();
-        std::fs::create_dir_all(&param_store_path)
-            .context("Failed to create protocol params store directory")?;
-        let param_db = sled::open(&param_store_path)
-            .context("Failed to open protocol params sled database")?;
+        std::fs::create_dir_all(&param_store_path).with_context(|| {
+            format!(
+                "Failed to create protocol params store directory: {}",
+                param_store_path.display()
+            )
+        })?;
+        let param_db = sled::open(&param_store_path).with_context(|| {
+            format!(
+                "Failed to open protocol params sled database: {}",
+                param_store_path.display()
+            )
+        })?;
         let parameter_store = Arc::new(
             icn_governance::SledParameterStore::new(Arc::new(param_db))
                 .context("Failed to initialize SledParameterStore")?,
@@ -120,25 +128,38 @@ fn build_service_registry(
         let governance_service = icn_governance_app::create_service(parameter_store_trait);
         registry = registry.with_governance(governance_service);
         // Store concrete type for raw_handle (dyn traits are !Sized)
-        registry = registry.with_raw_handle("protocol_parameter_store", parameter_store);
+        registry =
+            registry.with_raw_handle(ServiceRegistry::PROTOCOL_PARAM_STORE_KEY, parameter_store);
         tracing::info!("Governance service initialized from apps/governance");
 
         // Create LedgerService from apps/ledger
         // Ledger is created minimally here; supervisor configures it further
         // (gossip, trust, oracle, witnesses, credit policy, validation hooks)
         let ledger_store_path = config.ledger_store_path();
-        std::fs::create_dir_all(&ledger_store_path)
-            .context("Failed to create ledger store directory")?;
-        let ledger_store: Arc<dyn icn_store::Store> = Arc::new(
-            icn_store::SledStore::open(&ledger_store_path)
-                .context("Failed to open ledger store")?,
-        );
+        std::fs::create_dir_all(&ledger_store_path).with_context(|| {
+            format!(
+                "Failed to create ledger store directory: {}",
+                ledger_store_path.display()
+            )
+        })?;
+        let ledger_store = Arc::new(icn_store::SledStore::open(&ledger_store_path).with_context(
+            || {
+                format!(
+                    "Failed to open ledger store: {}",
+                    ledger_store_path.display()
+                )
+            },
+        )?);
+        let ledger_store_trait: Arc<dyn icn_store::Store> = ledger_store.clone();
         let ledger =
-            icn_ledger::Ledger::new(ledger_store).context("Failed to initialize Ledger")?;
+            icn_ledger::Ledger::new(ledger_store_trait).context("Failed to initialize Ledger")?;
         let ledger_handle = Arc::new(RwLock::new(ledger));
         let ledger_service = icn_ledger_app::create_service(ledger_handle.clone());
         registry = registry.with_ledger(ledger_service);
-        registry = registry.with_raw_handle("ledger", ledger_handle);
+        registry = registry.with_raw_handle(ServiceRegistry::LEDGER_KEY, ledger_handle);
+        // Pass concrete SledStore so supervisor can reuse it for DisputeManager/TreasuryManager
+        // without re-opening the sled DB (sled uses exclusive file locking per open)
+        registry = registry.with_raw_handle(ServiceRegistry::LEDGER_STORE_KEY, ledger_store);
         tracing::info!("Ledger service initialized from apps/ledger");
     }
 

--- a/icn/bins/icnd/src/main.rs
+++ b/icn/bins/icnd/src/main.rs
@@ -104,10 +104,35 @@ fn build_service_registry(
 
         tracing::info!("Trust service initialized from apps/trust");
         tracing::debug!("  - Raw trust_graph handle passed for transition components");
-    }
 
-    // TODO: Add governance service from apps/governance when available
-    // TODO: Add ledger service from apps/ledger when available
+        // Create GovernanceService from apps/governance
+        let param_store_path = config.store_path().join("protocol_params");
+        std::fs::create_dir_all(&param_store_path)?;
+        let param_db = sled::open(&param_store_path)?;
+        let parameter_store =
+            Arc::new(icn_governance::SledParameterStore::new(Arc::new(param_db))?);
+        let parameter_store_trait: Arc<dyn icn_governance::ProtocolParameterStore> =
+            parameter_store.clone();
+        let governance_service = icn_governance_app::create_service(parameter_store_trait);
+        registry = registry.with_governance(governance_service);
+        // Store concrete type for raw_handle (dyn traits are !Sized)
+        registry = registry.with_raw_handle("protocol_parameter_store", parameter_store);
+        tracing::info!("Governance service initialized from apps/governance");
+
+        // Create LedgerService from apps/ledger
+        // Ledger is created minimally here; supervisor configures it further
+        // (gossip, trust, oracle, witnesses, credit policy, validation hooks)
+        let ledger_store_path = config.store_path().join("ledger");
+        std::fs::create_dir_all(&ledger_store_path)?;
+        let ledger_store: Arc<dyn icn_store::Store> =
+            Arc::new(icn_store::SledStore::open(&ledger_store_path)?);
+        let ledger = icn_ledger::Ledger::new(ledger_store)?;
+        let ledger_handle = Arc::new(RwLock::new(ledger));
+        let ledger_service = icn_ledger_app::create_service(ledger_handle.clone());
+        registry = registry.with_ledger(ledger_service);
+        registry = registry.with_raw_handle("ledger", ledger_handle);
+        tracing::info!("Ledger service initialized from apps/ledger");
+    }
 
     Ok(registry)
 }

--- a/icn/crates/icn-core/src/config/mod.rs
+++ b/icn/crates/icn-core/src/config/mod.rs
@@ -172,6 +172,16 @@ impl Config {
         self.data_dir.join("store")
     }
 
+    /// Get the protocol parameter store path (sled DB for governance parameters)
+    pub fn protocol_params_path(&self) -> PathBuf {
+        self.store_path().join("protocol_params")
+    }
+
+    /// Get the ledger store path (sled DB for double-entry ledger)
+    pub fn ledger_store_path(&self) -> PathBuf {
+        self.store_path().join("ledger")
+    }
+
     /// Validate configuration and return a list of warnings/errors
     ///
     /// Returns Ok(warnings) if config is valid (warnings are non-fatal),

--- a/icn/crates/icn-core/src/config/mod.rs
+++ b/icn/crates/icn-core/src/config/mod.rs
@@ -167,7 +167,14 @@ impl Config {
         self.data_dir.join("identity.age")
     }
 
-    /// Get the store path
+    /// Get the base store path (`{data_dir}/store/`)
+    ///
+    /// Subdirectory layout (each opened once by the daemon):
+    /// - `store/trust/`           — Trust attestations and scores
+    /// - `store/protocol_params/` — Governance protocol parameters
+    /// - `store/ledger/`          — Double-entry transactions, disputes, treasury
+    /// - `store/governance/`      — Governance actor state (proposals, votes)
+    /// - `store/dead_letter/`     — Failed operation recovery queue
     pub fn store_path(&self) -> PathBuf {
         self.data_dir.join("store")
     }

--- a/icn/crates/icn-core/src/supervisor/init_governance.rs
+++ b/icn/crates/icn-core/src/supervisor/init_governance.rs
@@ -29,6 +29,8 @@ pub struct GovernanceDeps {
     pub event_bus: EventBus,
     /// Shutdown signal receiver
     pub shutdown_rx: tokio::sync::broadcast::Receiver<()>,
+    /// Pre-created parameter store from daemon (avoids double sled open)
+    pub protocol_parameter_store: Option<Arc<dyn ProtocolParameterStore>>,
 }
 
 /// Services returned from governance initialization
@@ -121,10 +123,15 @@ pub async fn init_governance_services(
     );
 
     // Initialize protocol parameter store (Phase 20)
-    let param_store_path = config.store_path().join("protocol_params");
-    let param_db = sled::open(&param_store_path)?;
     let protocol_parameter_store: Arc<dyn ProtocolParameterStore> =
-        Arc::new(SledParameterStore::new(Arc::new(param_db))?);
+        if let Some(store) = deps.protocol_parameter_store {
+            info!("Using daemon-provided protocol parameter store");
+            store
+        } else {
+            let param_store_path = config.store_path().join("protocol_params");
+            let param_db = sled::open(&param_store_path)?;
+            Arc::new(SledParameterStore::new(Arc::new(param_db))?)
+        };
 
     // Load default parameters on first run (if store is empty)
     {

--- a/icn/crates/icn-core/src/supervisor/init_governance.rs
+++ b/icn/crates/icn-core/src/supervisor/init_governance.rs
@@ -128,7 +128,7 @@ pub async fn init_governance_services(
             info!("Using daemon-provided protocol parameter store");
             store
         } else {
-            let param_store_path = config.store_path().join("protocol_params");
+            let param_store_path = config.protocol_params_path();
             let param_db = sled::open(&param_store_path)?;
             Arc::new(SledParameterStore::new(Arc::new(param_db))?)
         };

--- a/icn/crates/icn-core/src/supervisor/init_ledger.rs
+++ b/icn/crates/icn-core/src/supervisor/init_ledger.rs
@@ -49,6 +49,8 @@ pub struct LedgerDeps {
     /// Trust service for proper kernel/app separation
     /// When provided, passed to Ledger.set_trust_service()
     pub trust_service: Option<Arc<dyn icn_kernel_api::services::TrustService>>,
+    /// Pre-created ledger handle from daemon (daemon owns lifecycle)
+    pub ledger_handle: Option<Arc<RwLock<Ledger>>>,
 }
 
 /// Initialize ledger and contract services
@@ -63,88 +65,88 @@ pub async fn init_ledger_services(
     did: Did,
     deps: LedgerDeps,
 ) -> anyhow::Result<LedgerServices> {
-    // Create ledger store
+    // Create ledger store (needed for DisputeManager, TreasuryManager even if ledger is daemon-provided)
     let store_path = config.store_path().join("ledger");
     let store = Arc::new(SledStore::open(&store_path)?);
 
-    // Initialize ledger with gossip, misbehavior detection, and trust
-    let mut ledger = Ledger::new(store.clone())?;
-    ledger.set_gossip(deps.gossip_handle.clone());
-    ledger.set_misbehavior_detector(deps.misbehavior_detector.clone());
-
-    // Use TrustService if available (kernel/app separation), else fall back to TrustGraph
-    if let Some(trust_service) = deps.trust_service.clone() {
-        ledger.set_trust_service(trust_service);
-        info!("Ledger initialized with TrustService (kernel/app separated)");
+    // Use daemon-provided ledger handle or create a new one
+    let ledger_handle = if let Some(handle) = deps.ledger_handle {
+        info!("Using daemon-provided Ledger handle");
+        handle
     } else {
-        ledger.set_trust_graph(deps.trust_graph.clone());
-        info!("Ledger initialized with TrustGraph (deprecated fallback)");
-    }
+        Arc::new(RwLock::new(Ledger::new(store.clone())?))
+    };
 
-    // Initialize oracle manager with per-pair rate thresholds from config (Issue #474)
-    let oracle_config = config.ledger.oracle.to_oracle_config();
-    let threshold_count = oracle_config.suspicious_rate_thresholds.len();
-    let oracle_manager = Arc::new(OracleManager::with_config(store.clone(), oracle_config));
-    ledger.set_oracle_manager(oracle_manager);
+    // Configure ledger with gossip, misbehavior detection, trust, and policies
+    {
+        let mut ledger = ledger_handle.write().await;
 
-    if threshold_count > 0 {
-        info!(
-            "Oracle manager initialized with {} per-pair rate threshold(s)",
-            threshold_count
-        );
-    } else {
-        info!(
-            "Oracle manager initialized with default threshold {}",
-            config.ledger.oracle.default_suspicious_rate_threshold
-        );
-    }
+        ledger.set_gossip(deps.gossip_handle.clone());
+        ledger.set_misbehavior_detector(deps.misbehavior_detector.clone());
 
-    // Initialize witness config for material transaction signatures (Issue #676)
-    let witness_config = config.ledger.witness.to_witness_config()?;
-    let witness_policy = format!("{:?}", witness_config.default_policy);
-    ledger.set_witness_config(witness_config);
+        // Use TrustService if available (kernel/app separation), else fall back to TrustGraph
+        if let Some(trust_service) = deps.trust_service.clone() {
+            ledger.set_trust_service(trust_service);
+            info!("Ledger initialized with TrustService (kernel/app separated)");
+        } else {
+            ledger.set_trust_graph(deps.trust_graph.clone());
+            info!("Ledger initialized with TrustGraph (deprecated fallback)");
+        }
 
-    match &config.ledger.witness.threshold {
-        Some(threshold) => {
+        // Initialize oracle manager with per-pair rate thresholds from config (Issue #474)
+        let oracle_config = config.ledger.oracle.to_oracle_config();
+        let threshold_count = oracle_config.suspicious_rate_thresholds.len();
+        let oracle_manager = Arc::new(OracleManager::with_config(store.clone(), oracle_config));
+        ledger.set_oracle_manager(oracle_manager);
+
+        if threshold_count > 0 {
             info!(
-                "Witness signatures configured: policy={}, threshold={} (timeout={}s)",
-                witness_policy, threshold, config.ledger.witness.collection_timeout_secs
+                "Oracle manager initialized with {} per-pair rate threshold(s)",
+                threshold_count
+            );
+        } else {
+            info!(
+                "Oracle manager initialized with default threshold {}",
+                config.ledger.oracle.default_suspicious_rate_threshold
             );
         }
-        None => {
-            info!(
-                "Witness signatures configured: policy={} for all transactions (timeout={}s)",
-                witness_policy, config.ledger.witness.collection_timeout_secs
-            );
+
+        // Initialize witness config for material transaction signatures (Issue #676)
+        let witness_config = config.ledger.witness.to_witness_config()?;
+        let witness_policy = format!("{:?}", witness_config.default_policy);
+        ledger.set_witness_config(witness_config);
+
+        match &config.ledger.witness.threshold {
+            Some(threshold) => {
+                info!(
+                    "Witness signatures configured: policy={}, threshold={} (timeout={}s)",
+                    witness_policy, threshold, config.ledger.witness.collection_timeout_secs
+                );
+            }
+            None => {
+                info!(
+                    "Witness signatures configured: policy={} for all transactions (timeout={}s)",
+                    witness_policy, config.ledger.witness.collection_timeout_secs
+                );
+            }
         }
+
+        // Initialize membership store for tracking when members joined
+        let membership_store = Arc::new(SledMembershipStore::new(store.clone()));
+        ledger.set_membership_store(membership_store);
+        info!("Membership store initialized for new member tracking");
+
+        // Initialize credit policy for server-side credit limit enforcement
+        let credit_policy = CreditPolicy::conservative("hours".to_string());
+        let new_member_policy = NewMemberPolicy::conservative("hours".to_string());
+        let credit_manager = CreditPolicyManager::new(credit_policy, new_member_policy);
+        ledger.set_credit_policy_manager(credit_manager);
+
+        info!(
+            "Credit policy manager initialized with conservative policy for 'hours' currency \
+             (new members: 10hr initial, 90-day ramp, 50hr contribution threshold)"
+        );
     }
-
-    // Initialize membership store for tracking when members joined
-    // Used for new member credit limit ramping
-    let membership_store = Arc::new(SledMembershipStore::new(store.clone()));
-    ledger.set_membership_store(membership_store);
-
-    info!("Membership store initialized for new member tracking");
-
-    // Initialize credit policy for server-side credit limit enforcement.
-    // Dynamic limits: baseline + trust bonus + history bonus.
-    // Note: Using "hours" as the default currency unit for cooperatives.
-    let credit_policy = CreditPolicy::conservative("hours".to_string());
-
-    // New member protection policy configuration.
-    // New members start with 10 hour limit, ramping to full over 90 days.
-    // Members who contribute 50+ hours get full limit regardless of tenure.
-    let new_member_policy = NewMemberPolicy::conservative("hours".to_string());
-
-    let credit_manager = CreditPolicyManager::new(credit_policy, new_member_policy);
-    ledger.set_credit_policy_manager(credit_manager);
-
-    info!(
-        "Credit policy manager initialized with conservative policy for 'hours' currency \
-         (new members: 10hr initial, 90-day ramp, 50hr contribution threshold)"
-    );
-
-    let ledger_handle = Arc::new(RwLock::new(ledger));
 
     info!("Ledger initialized at {}", store_path.display());
 

--- a/icn/crates/icn-core/src/supervisor/init_ledger.rs
+++ b/icn/crates/icn-core/src/supervisor/init_ledger.rs
@@ -51,6 +51,9 @@ pub struct LedgerDeps {
     pub trust_service: Option<Arc<dyn icn_kernel_api::services::TrustService>>,
     /// Pre-created ledger handle from daemon (daemon owns lifecycle)
     pub ledger_handle: Option<Arc<RwLock<Ledger>>>,
+    /// Pre-opened ledger store from daemon (avoids double sled open;
+    /// sled uses exclusive file locking so re-opening the same path fails)
+    pub ledger_store: Option<Arc<SledStore>>,
 }
 
 /// Initialize ledger and contract services
@@ -65,11 +68,16 @@ pub async fn init_ledger_services(
     did: Did,
     deps: LedgerDeps,
 ) -> anyhow::Result<LedgerServices> {
-    // Open ledger store for DisputeManager, TreasuryManager, and (if no daemon handle) the Ledger.
-    // Safe to call even when the daemon already opened this path: sled internally caches
-    // DB instances by path and returns the same reference-counted sled::Db.
+    // Reuse daemon-provided store or open a new one.
+    // sled uses exclusive file locking, so re-opening the same path would fail
+    // if the daemon already opened it.
     let store_path = config.ledger_store_path();
-    let store = Arc::new(SledStore::open(&store_path)?);
+    let store = if let Some(s) = deps.ledger_store {
+        info!("Using daemon-provided ledger store");
+        s
+    } else {
+        Arc::new(SledStore::open(&store_path)?)
+    };
 
     // Use daemon-provided ledger handle or create a new one
     let ledger_handle = if let Some(handle) = deps.ledger_handle {

--- a/icn/crates/icn-core/src/supervisor/init_ledger.rs
+++ b/icn/crates/icn-core/src/supervisor/init_ledger.rs
@@ -66,7 +66,7 @@ pub async fn init_ledger_services(
     deps: LedgerDeps,
 ) -> anyhow::Result<LedgerServices> {
     // Create ledger store (needed for DisputeManager, TreasuryManager even if ledger is daemon-provided)
-    let store_path = config.store_path().join("ledger");
+    let store_path = config.ledger_store_path();
     let store = Arc::new(SledStore::open(&store_path)?);
 
     // Use daemon-provided ledger handle or create a new one

--- a/icn/crates/icn-core/src/supervisor/init_ledger.rs
+++ b/icn/crates/icn-core/src/supervisor/init_ledger.rs
@@ -65,7 +65,9 @@ pub async fn init_ledger_services(
     did: Did,
     deps: LedgerDeps,
 ) -> anyhow::Result<LedgerServices> {
-    // Create ledger store (needed for DisputeManager, TreasuryManager even if ledger is daemon-provided)
+    // Open ledger store for DisputeManager, TreasuryManager, and (if no daemon handle) the Ledger.
+    // Safe to call even when the daemon already opened this path: sled internally caches
+    // DB instances by path and returns the same reference-counted sled::Db.
     let store_path = config.ledger_store_path();
     let store = Arc::new(SledStore::open(&store_path)?);
 

--- a/icn/crates/icn-core/src/supervisor/init_ledger.rs
+++ b/icn/crates/icn-core/src/supervisor/init_ledger.rs
@@ -87,7 +87,10 @@ pub async fn init_ledger_services(
         Arc::new(RwLock::new(Ledger::new(store.clone())?))
     };
 
-    // Configure ledger with gossip, misbehavior detection, trust, and policies
+    // Configure ledger with gossip, misbehavior detection, trust, and policies.
+    // Note: This write lock is held for the entire configuration block (~60 lines).
+    // This is acceptable because it runs during supervisor startup before any
+    // concurrent readers exist. No contention is possible at this point.
     {
         let mut ledger = ledger_handle.write().await;
 

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -216,10 +216,12 @@ async fn spawn_actors_with_identity(
 
     let did = identity_bundle.did().clone();
 
-    // Extract daemon-provided ledger handle from ServiceRegistry early
+    // Extract daemon-provided ledger handles from ServiceRegistry early
     // (needed before ledger init which happens before governance init)
-    let ledger_from_daemon: Option<Arc<RwLock<icn_ledger::Ledger>>> =
-        service_registry.and_then(|r| r.raw_handle::<RwLock<icn_ledger::Ledger>>("ledger"));
+    let ledger_from_daemon: Option<Arc<RwLock<icn_ledger::Ledger>>> = service_registry
+        .and_then(|r| r.raw_handle::<RwLock<icn_ledger::Ledger>>(ServiceRegistry::LEDGER_KEY));
+    let ledger_store_from_daemon: Option<Arc<icn_store::SledStore>> = service_registry
+        .and_then(|r| r.raw_handle::<icn_store::SledStore>(ServiceRegistry::LEDGER_STORE_KEY));
 
     // Create NodeProfile with hardware sensing (Phase 17)
     let node_profile = crate::node::create_node_profile(
@@ -241,9 +243,9 @@ async fn spawn_actors_with_identity(
     // Initialize trust graph, recovery store, and misbehavior detector
     // If service_registry provides a trust_graph handle, use it instead of creating a new one.
     // This enables proper kernel/app separation where the daemon owns the TrustGraph.
-    let trust_services = if let Some(trust_graph_from_daemon) =
-        service_registry.and_then(|r| r.raw_handle::<RwLock<icn_trust::TrustGraph>>("trust_graph"))
-    {
+    let trust_services = if let Some(trust_graph_from_daemon) = service_registry.and_then(|r| {
+        r.raw_handle::<RwLock<icn_trust::TrustGraph>>(ServiceRegistry::TRUST_GRAPH_KEY)
+    }) {
         info!("Using TrustGraph from daemon-provided ServiceRegistry");
         super::init_trust::init_trust_services_with_graph(
             config,
@@ -298,6 +300,7 @@ async fn spawn_actors_with_identity(
             trust_graph: trust_graph_handle.clone(),
             trust_service: trust_service_from_registry.clone(),
             ledger_handle: ledger_from_daemon,
+            ledger_store: ledger_store_from_daemon,
         },
     )
     .await?;
@@ -494,7 +497,9 @@ async fn spawn_actors_with_identity(
         Arc<dyn icn_governance::ProtocolParameterStore>,
     > = service_registry
         .and_then(|r| {
-            r.raw_handle::<icn_governance::SledParameterStore>("protocol_parameter_store")
+            r.raw_handle::<icn_governance::SledParameterStore>(
+                ServiceRegistry::PROTOCOL_PARAM_STORE_KEY,
+            )
         })
         .map(|s| s as Arc<dyn icn_governance::ProtocolParameterStore>);
 

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -216,6 +216,11 @@ async fn spawn_actors_with_identity(
 
     let did = identity_bundle.did().clone();
 
+    // Extract daemon-provided ledger handle from ServiceRegistry early
+    // (needed before ledger init which happens before governance init)
+    let ledger_from_daemon: Option<Arc<RwLock<icn_ledger::Ledger>>> =
+        service_registry.and_then(|r| r.raw_handle::<RwLock<icn_ledger::Ledger>>("ledger"));
+
     // Create NodeProfile with hardware sensing (Phase 17)
     let node_profile = crate::node::create_node_profile(
         did.clone(),
@@ -292,6 +297,7 @@ async fn spawn_actors_with_identity(
             misbehavior_detector: misbehavior_detector.clone(),
             trust_graph: trust_graph_handle.clone(),
             trust_service: trust_service_from_registry.clone(),
+            ledger_handle: ledger_from_daemon,
         },
     )
     .await?;
@@ -482,6 +488,16 @@ async fn spawn_actors_with_identity(
     let event_bus = Arc::new(crate::events::EventBus::new());
     info!("Event bus created");
 
+    // Extract daemon-provided parameter store from ServiceRegistry (if available).
+    // SledParameterStore is stored as concrete type since raw_handle requires Sized.
+    let protocol_parameter_store_from_daemon: Option<
+        Arc<dyn icn_governance::ProtocolParameterStore>,
+    > = service_registry
+        .and_then(|r| {
+            r.raw_handle::<icn_governance::SledParameterStore>("protocol_parameter_store")
+        })
+        .map(|s| s as Arc<dyn icn_governance::ProtocolParameterStore>);
+
     // Initialize governance services
     let governance_services = super::init_governance::init_governance_services(
         config,
@@ -490,6 +506,7 @@ async fn spawn_actors_with_identity(
             gossip_handle: gossip_handle.clone(),
             event_bus: event_bus.clone(),
             shutdown_rx: shutdown_tx.subscribe(),
+            protocol_parameter_store: protocol_parameter_store_from_daemon,
         },
     )
     .await?;

--- a/icn/crates/icn-core/tests/service_registry_wiring.rs
+++ b/icn/crates/icn-core/tests/service_registry_wiring.rs
@@ -24,12 +24,12 @@ fn test_parameter_store_raw_handle_roundtrip() {
     let store = Arc::new(SledParameterStore::new(Arc::new(param_db)).unwrap());
 
     // Simulate daemon: store concrete type
-    let registry =
-        ServiceRegistry::new().with_raw_handle("protocol_parameter_store", store.clone());
+    let registry = ServiceRegistry::new()
+        .with_raw_handle(ServiceRegistry::PROTOCOL_PARAM_STORE_KEY, store.clone());
 
     // Simulate supervisor: retrieve and upcast
     let retrieved: Option<Arc<SledParameterStore>> =
-        registry.raw_handle("protocol_parameter_store");
+        registry.raw_handle(ServiceRegistry::PROTOCOL_PARAM_STORE_KEY);
     assert!(
         retrieved.is_some(),
         "raw_handle should return the stored SledParameterStore"
@@ -51,10 +51,12 @@ fn test_ledger_handle_raw_handle_roundtrip() {
     let handle = Arc::new(RwLock::new(ledger));
 
     // Simulate daemon: store handle
-    let registry = ServiceRegistry::new().with_raw_handle("ledger", handle.clone());
+    let registry =
+        ServiceRegistry::new().with_raw_handle(ServiceRegistry::LEDGER_KEY, handle.clone());
 
     // Simulate supervisor: retrieve
-    let retrieved: Option<Arc<RwLock<icn_ledger::Ledger>>> = registry.raw_handle("ledger");
+    let retrieved: Option<Arc<RwLock<icn_ledger::Ledger>>> =
+        registry.raw_handle(ServiceRegistry::LEDGER_KEY);
     assert!(
         retrieved.is_some(),
         "raw_handle should return the stored Ledger handle"
@@ -79,13 +81,68 @@ fn test_raw_handle_type_mismatch_returns_none() {
     let param_db = sled::open(tmp.path().join("params")).unwrap();
     let store = Arc::new(SledParameterStore::new(Arc::new(param_db)).unwrap());
 
-    let registry = ServiceRegistry::new().with_raw_handle("protocol_parameter_store", store);
+    let registry =
+        ServiceRegistry::new().with_raw_handle(ServiceRegistry::PROTOCOL_PARAM_STORE_KEY, store);
 
     // Try to retrieve as wrong type
     let result: Option<Arc<RwLock<icn_ledger::Ledger>>> =
-        registry.raw_handle("protocol_parameter_store");
+        registry.raw_handle(ServiceRegistry::PROTOCOL_PARAM_STORE_KEY);
     assert!(
         result.is_none(),
         "Type mismatch should return None, not panic"
     );
+}
+
+/// Test that mutations through the daemon's Arc are visible through the supervisor's Arc.
+///
+/// This verifies that raw_handle truly shares the same Arc instance (not a clone),
+/// so writes by the daemon propagate to the supervisor's view.
+#[test]
+fn test_parameter_store_mutation_propagation() {
+    use icn_governance::{ParameterValue, ProtocolParameter};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let param_db = sled::open(tmp.path().join("params")).unwrap();
+    let store = Arc::new(SledParameterStore::new(Arc::new(param_db)).unwrap());
+
+    // Simulate daemon: register in registry
+    let registry = ServiceRegistry::new()
+        .with_raw_handle(ServiceRegistry::PROTOCOL_PARAM_STORE_KEY, store.clone());
+
+    // Simulate supervisor: retrieve from registry
+    let supervisor_store: Arc<SledParameterStore> = registry
+        .raw_handle(ServiceRegistry::PROTOCOL_PARAM_STORE_KEY)
+        .unwrap();
+
+    // Daemon writes a parameter
+    let param = ProtocolParameter::new(
+        "test.param",
+        "Test Param",
+        "A test parameter",
+        ParameterValue::Integer(42),
+    );
+    store.set(param, None, None).unwrap();
+
+    // Supervisor should see it
+    let retrieved = supervisor_store.get("test.param").unwrap();
+    assert!(retrieved.is_some(), "Supervisor should see daemon's write");
+    assert_eq!(retrieved.unwrap().id, "test.param");
+}
+
+/// Test that the ledger store can be shared via raw_handle.
+///
+/// This verifies the fix for the sled double-open bug: the daemon creates
+/// a single SledStore and passes it through raw_handle so the supervisor
+/// doesn't need to re-open the same sled path.
+#[test]
+fn test_ledger_store_shared_via_raw_handle() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = Arc::new(SledStore::open(tmp.path().join("ledger")).unwrap());
+
+    let registry =
+        ServiceRegistry::new().with_raw_handle(ServiceRegistry::LEDGER_STORE_KEY, store.clone());
+
+    let retrieved: Option<Arc<SledStore>> = registry.raw_handle(ServiceRegistry::LEDGER_STORE_KEY);
+    assert!(retrieved.is_some(), "Should retrieve ledger store");
+    assert!(Arc::ptr_eq(&store, &retrieved.unwrap()));
 }

--- a/icn/crates/icn-core/tests/service_registry_wiring.rs
+++ b/icn/crates/icn-core/tests/service_registry_wiring.rs
@@ -129,6 +129,66 @@ fn test_parameter_store_mutation_propagation() {
     assert_eq!(retrieved.unwrap().id, "test.param");
 }
 
+/// Test the full daemon→supervisor extraction pattern.
+///
+/// Simulates the complete flow: daemon creates all services and stores,
+/// registers them in ServiceRegistry, then supervisor extracts them
+/// (mirroring lifecycle.rs extraction logic).
+#[test]
+fn test_daemon_to_supervisor_registry_extraction() {
+    use icn_governance::ParameterValue;
+
+    let tmp = tempfile::tempdir().unwrap();
+
+    // === Daemon side: create all handles ===
+    let param_db = sled::open(tmp.path().join("params")).unwrap();
+    let param_store = Arc::new(SledParameterStore::new(Arc::new(param_db)).unwrap());
+
+    let ledger_store = Arc::new(SledStore::open(tmp.path().join("ledger")).unwrap());
+    let ledger_store_trait: Arc<dyn icn_store::Store> = ledger_store.clone();
+    let ledger = icn_ledger::Ledger::new(ledger_store_trait).unwrap();
+    let ledger_handle = Arc::new(RwLock::new(ledger));
+
+    let registry = ServiceRegistry::new()
+        .with_raw_handle(
+            ServiceRegistry::PROTOCOL_PARAM_STORE_KEY,
+            param_store.clone(),
+        )
+        .with_raw_handle(ServiceRegistry::LEDGER_KEY, ledger_handle.clone())
+        .with_raw_handle(ServiceRegistry::LEDGER_STORE_KEY, ledger_store.clone());
+
+    // === Supervisor side: extract handles (mirrors lifecycle.rs) ===
+
+    // Ledger handle extraction (lifecycle.rs ~line 221)
+    let sup_ledger: Option<Arc<RwLock<icn_ledger::Ledger>>> =
+        registry.raw_handle(ServiceRegistry::LEDGER_KEY);
+    assert!(sup_ledger.is_some());
+    assert!(Arc::ptr_eq(&ledger_handle, sup_ledger.as_ref().unwrap()));
+
+    // Ledger store extraction (lifecycle.rs ~line 223)
+    let sup_store: Option<Arc<SledStore>> = registry.raw_handle(ServiceRegistry::LEDGER_STORE_KEY);
+    assert!(sup_store.is_some());
+    assert!(Arc::ptr_eq(&ledger_store, sup_store.as_ref().unwrap()));
+
+    // Parameter store extraction with upcast (lifecycle.rs ~line 496-502)
+    let sup_params: Option<Arc<SledParameterStore>> =
+        registry.raw_handle(ServiceRegistry::PROTOCOL_PARAM_STORE_KEY);
+    assert!(sup_params.is_some());
+    let sup_params_trait: Arc<dyn icn_governance::ProtocolParameterStore> = sup_params.unwrap();
+
+    // Verify functional: daemon writes, supervisor reads
+    let param = icn_governance::ProtocolParameter::new(
+        "test.integration",
+        "Integration Test",
+        "Verifies daemon-supervisor handle sharing",
+        ParameterValue::Integer(99),
+    );
+    param_store.set(param, None, None).unwrap();
+    let read_back = sup_params_trait.get("test.integration").unwrap();
+    assert!(read_back.is_some());
+    assert_eq!(read_back.unwrap().id, "test.integration");
+}
+
 /// Test that the ledger store can be shared via raw_handle.
 ///
 /// This verifies the fix for the sled double-open bug: the daemon creates

--- a/icn/crates/icn-core/tests/service_registry_wiring.rs
+++ b/icn/crates/icn-core/tests/service_registry_wiring.rs
@@ -206,3 +206,24 @@ fn test_ledger_store_shared_via_raw_handle() {
     assert!(retrieved.is_some(), "Should retrieve ledger store");
     assert!(Arc::ptr_eq(&store, &retrieved.unwrap()));
 }
+
+/// Verify that opening the same sled path twice fails with exclusive locking.
+///
+/// This test documents WHY the daemon must share store handles via raw_handle
+/// rather than letting the supervisor re-open the same path. On Linux, sled uses
+/// `flock(LOCK_EX)` which rejects a second open from a different file descriptor.
+#[test]
+fn test_sled_double_open_fails() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("exclusive_db");
+
+    // First open succeeds
+    let _db1 = SledStore::open(&path).unwrap();
+
+    // Second open on the same path should fail (exclusive file lock)
+    let result = SledStore::open(&path);
+    assert!(
+        result.is_err(),
+        "Opening the same sled path twice should fail due to exclusive file locking"
+    );
+}

--- a/icn/crates/icn-core/tests/service_registry_wiring.rs
+++ b/icn/crates/icn-core/tests/service_registry_wiring.rs
@@ -1,0 +1,91 @@
+//! Service Registry Wiring Integration Tests
+//!
+//! Verifies that daemon-provided handles (governance parameter store, ledger)
+//! are correctly extracted from ServiceRegistry and reused by supervisor init
+//! functions, preventing double sled opens.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use icn_governance::{ProtocolParameterStore, SledParameterStore};
+use icn_kernel_api::ServiceRegistry;
+use icn_store::SledStore;
+
+/// Test that a SledParameterStore round-trips through raw_handle correctly.
+///
+/// The daemon stores Arc<SledParameterStore> (concrete, Sized) and the supervisor
+/// retrieves it, then upcasts to Arc<dyn ProtocolParameterStore>.
+#[test]
+fn test_parameter_store_raw_handle_roundtrip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let param_db = sled::open(tmp.path().join("params")).unwrap();
+    let store = Arc::new(SledParameterStore::new(Arc::new(param_db)).unwrap());
+
+    // Simulate daemon: store concrete type
+    let registry =
+        ServiceRegistry::new().with_raw_handle("protocol_parameter_store", store.clone());
+
+    // Simulate supervisor: retrieve and upcast
+    let retrieved: Option<Arc<SledParameterStore>> =
+        registry.raw_handle("protocol_parameter_store");
+    assert!(
+        retrieved.is_some(),
+        "raw_handle should return the stored SledParameterStore"
+    );
+
+    let as_trait: Arc<dyn ProtocolParameterStore> = retrieved.unwrap();
+    // Verify it's functional
+    let params = as_trait.list().unwrap();
+    assert!(params.is_empty(), "Fresh store should have no parameters");
+}
+
+/// Test that a Ledger handle round-trips through raw_handle correctly.
+#[test]
+fn test_ledger_handle_raw_handle_roundtrip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store: Arc<dyn icn_store::Store> =
+        Arc::new(SledStore::open(tmp.path().join("ledger")).unwrap());
+    let ledger = icn_ledger::Ledger::new(store).unwrap();
+    let handle = Arc::new(RwLock::new(ledger));
+
+    // Simulate daemon: store handle
+    let registry = ServiceRegistry::new().with_raw_handle("ledger", handle.clone());
+
+    // Simulate supervisor: retrieve
+    let retrieved: Option<Arc<RwLock<icn_ledger::Ledger>>> = registry.raw_handle("ledger");
+    assert!(
+        retrieved.is_some(),
+        "raw_handle should return the stored Ledger handle"
+    );
+
+    // Verify it's the same Arc (not a copy)
+    assert!(Arc::ptr_eq(&handle, &retrieved.unwrap()));
+}
+
+/// Test that raw_handle returns None for a missing key.
+#[test]
+fn test_raw_handle_missing_key_returns_none() {
+    let registry = ServiceRegistry::new();
+    let result: Option<Arc<SledParameterStore>> = registry.raw_handle("nonexistent");
+    assert!(result.is_none());
+}
+
+/// Test that raw_handle returns None for a type mismatch.
+#[test]
+fn test_raw_handle_type_mismatch_returns_none() {
+    let tmp = tempfile::tempdir().unwrap();
+    let param_db = sled::open(tmp.path().join("params")).unwrap();
+    let store = Arc::new(SledParameterStore::new(Arc::new(param_db)).unwrap());
+
+    let registry = ServiceRegistry::new().with_raw_handle("protocol_parameter_store", store);
+
+    // Try to retrieve as wrong type
+    let result: Option<Arc<RwLock<icn_ledger::Ledger>>> =
+        registry.raw_handle("protocol_parameter_store");
+    assert!(
+        result.is_none(),
+        "Type mismatch should return None, not panic"
+    );
+}

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -421,6 +421,18 @@ impl Default for ServiceRegistry {
 }
 
 impl ServiceRegistry {
+    // Raw handle key constants — use these instead of string literals to prevent typos.
+    // A typo in the key results in silent `None` at runtime.
+
+    /// Key for `Arc<RwLock<TrustGraph>>` raw handle
+    pub const TRUST_GRAPH_KEY: &str = "trust_graph";
+    /// Key for `Arc<SledParameterStore>` raw handle (concrete type; upcast after retrieval)
+    pub const PROTOCOL_PARAM_STORE_KEY: &str = "protocol_parameter_store";
+    /// Key for `Arc<RwLock<Ledger>>` raw handle
+    pub const LEDGER_KEY: &str = "ledger";
+    /// Key for `Arc<SledStore>` raw handle (shared with DisputeManager/TreasuryManager)
+    pub const LEDGER_STORE_KEY: &str = "ledger_store";
+
     /// Create a new empty service registry
     pub fn new() -> Self {
         Self {

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -399,6 +399,27 @@ pub trait CellService: Send + Sync {
 /// direct access to domain objects (e.g., TrustGraph for MisbehaviorDetector).
 /// The `raw_handles` field provides type-erased storage for these transition
 /// needs. These should be removed as components are fully migrated.
+///
+/// # Raw Handle Type Pattern
+///
+/// `raw_handle<T>` requires `T: Sized`, so `dyn Trait` objects cannot be stored
+/// directly. Use the appropriate pattern based on the stored type:
+///
+/// **Concrete type with trait upcast** (when consumers need a trait object):
+/// ```ignore
+/// // Store: Arc<SledParameterStore> (concrete, Sized)
+/// registry.with_raw_handle(ServiceRegistry::PROTOCOL_PARAM_STORE_KEY, store);
+/// // Retrieve concrete, then upcast:
+/// let store: Arc<SledParameterStore> = registry.raw_handle(KEY)?;
+/// let trait_obj: Arc<dyn ProtocolParameterStore> = store;
+/// ```
+///
+/// **Wrapped type** (when the wrapper is Sized, e.g., `RwLock<T>`):
+/// ```ignore
+/// // Store and retrieve directly:
+/// registry.with_raw_handle(ServiceRegistry::LEDGER_KEY, ledger_handle);
+/// let handle: Arc<RwLock<Ledger>> = registry.raw_handle(KEY)?;
+/// ```
 pub struct ServiceRegistry {
     trust: Option<Arc<dyn TrustService>>,
     security: Option<Arc<dyn SecurityService>>,


### PR DESCRIPTION
## Summary

- Connects `apps/governance` and `apps/ledger` to icnd's `ServiceRegistry`, completing kernel/app separation for all three domain services (trust, governance, ledger)
- Daemon now owns store lifecycles (sled DBs for protocol params and ledger) and passes handles via `raw_handle` to the supervisor, preventing double sled opens
- Supervisor init functions (`init_governance`, `init_ledger`) accept optional daemon-provided handles and reuse them when available, falling back to internal creation for standalone use

## Changes

| File | Change |
|------|--------|
| `icn/bins/icnd/Cargo.toml` | Add `icn-governance-app`, `icn-ledger-app`, `sled`, `icn-governance` deps |
| `icn/bins/icnd/src/main.rs` | Wire GovernanceService + LedgerService in `build_service_registry()` |
| `icn/crates/icn-core/src/supervisor/init_governance.rs` | Accept optional `protocol_parameter_store` in `GovernanceDeps` |
| `icn/crates/icn-core/src/supervisor/init_ledger.rs` | Accept optional `ledger_handle` in `LedgerDeps`; configure via write lock |
| `icn/crates/icn-core/src/supervisor/lifecycle.rs` | Extract raw handles from registry, route to init functions |

## Design notes

- `SledParameterStore` is stored as concrete type in `raw_handle` (since `dyn Trait` is `!Sized` and `raw_handle<T>` requires `T: Sized`), then upcast to `Arc<dyn ProtocolParameterStore>` at retrieval
- When daemon provides a ledger handle, all configuration (gossip, trust, oracle, witness, credit policy) is applied via write lock — no duplicate ledger created

## Test plan

- [x] `cargo build -p icnd -p icn-core` passes
- [x] `cargo clippy -p icnd -p icn-core --all-targets --all-features -- -D warnings` clean
- [x] `cargo test -p icn-core` passes
- [x] `cargo fmt --check` clean
- [ ] CI full test suite

Closes #908, closes #909

🤖 Generated with [Claude Code](https://claude.com/claude-code)