### PR TITLE
feat(ledger): remove TrustGraph dependency, use TrustService exclusively (#867)

### DIFF
--- a/icn/crates/icn-core/src/supervisor/init_ledger.rs
+++ b/icn/crates/icn-core/src/supervisor/init_ledger.rs
@@ -15,7 +15,6 @@ use icn_ledger::{
 };
 use icn_security::MisbehaviorDetector;
 use icn_store::SledStore;
-use icn_trust::TrustGraph;
 
 use crate::config::Config;
 
@@ -44,10 +43,7 @@ pub struct LedgerServices {
 pub struct LedgerDeps {
     pub gossip_handle: Arc<RwLock<GossipActor>>,
     pub misbehavior_detector: Arc<RwLock<MisbehaviorDetector>>,
-    /// Trust graph for fallback (deprecated, kept for backward compatibility)
-    pub trust_graph: Arc<RwLock<TrustGraph>>,
-    /// Trust service for proper kernel/app separation
-    /// When provided, passed to Ledger.set_trust_service()
+    /// Trust service for kernel/app separated trust score queries
     pub trust_service: Option<Arc<dyn icn_kernel_api::services::TrustService>>,
     /// Pre-created ledger handle from daemon (daemon owns lifecycle)
     pub ledger_handle: Option<Arc<RwLock<Ledger>>>,
@@ -97,13 +93,12 @@ pub async fn init_ledger_services(
         ledger.set_gossip(deps.gossip_handle.clone());
         ledger.set_misbehavior_detector(deps.misbehavior_detector.clone());
 
-        // Use TrustService if available (kernel/app separation), else fall back to TrustGraph
+        // Set TrustService for kernel/app separated trust queries
         if let Some(trust_service) = deps.trust_service.clone() {
             ledger.set_trust_service(trust_service);
-            info!("Ledger initialized with TrustService (kernel/app separated)");
+            info!("Ledger initialized with TrustService");
         } else {
-            ledger.set_trust_graph(deps.trust_graph.clone());
-            info!("Ledger initialized with TrustGraph (deprecated fallback)");
+            info!("Ledger initialized without TrustService (trust validation disabled)");
         }
 
         // Initialize oracle manager with per-pair rate thresholds from config (Issue #474)
@@ -238,10 +233,12 @@ pub async fn init_ledger_services(
     info!("Charter and treasury validators initialized with validation hook");
 
     // Create ContractActor
+    // Note: TrustGraph is no longer passed via LedgerDeps; ContractActor will
+    // receive it via ServiceRegistry in a future migration (CCL extraction).
     let contract_actor = icn_ccl::ContractActor::new(
         did,
         contract_runtime_handle.clone(),
-        Some(deps.trust_graph.clone()),
+        None, // TrustGraph moved to app layer; CCL migration pending
     );
     let contract_actor_handle = Arc::new(RwLock::new(contract_actor));
 

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -297,7 +297,6 @@ async fn spawn_actors_with_identity(
         super::init_ledger::LedgerDeps {
             gossip_handle: gossip_handle.clone(),
             misbehavior_detector: misbehavior_detector.clone(),
-            trust_graph: trust_graph_handle.clone(),
             trust_service: trust_service_from_registry.clone(),
             ledger_handle: ledger_from_daemon,
             ledger_store: ledger_store_from_daemon,

--- a/icn/crates/icn-core/tests/fork_resolution_integration.rs
+++ b/icn/crates/icn-core/tests/fork_resolution_integration.rs
@@ -20,6 +20,7 @@
 
 use anyhow::Result;
 use icn_identity::{Did, KeyPair};
+use icn_kernel_api::services::TrustService;
 use icn_ledger::{
     balance::compute_all_balances, entry::JournalEntryBuilder, Fork, ForkDetector, ForkResolution,
     ForkResolutionStrategy, ForkResolver, Ledger,
@@ -32,7 +33,42 @@ use std::time::SystemTime;
 use tempfile::TempDir;
 use tracing::info;
 
-/// Test node with ledger and trust graph
+/// Test TrustService wrapping a TrustGraph for integration tests
+struct TestTrustService {
+    graph: Arc<tokio::sync::RwLock<TrustGraph>>,
+}
+
+impl TestTrustService {
+    fn new(graph: Arc<tokio::sync::RwLock<TrustGraph>>) -> Self {
+        Self { graph }
+    }
+}
+
+impl TrustService for TestTrustService {
+    fn oracle(&self) -> Arc<dyn icn_kernel_api::authz::PolicyOracle> {
+        unimplemented!("oracle not needed for fork resolution tests")
+    }
+
+    fn trust_score(&self, actor: &icn_kernel_api::types::Did) -> f64 {
+        let graph = self.graph.clone();
+        let actor_str = actor.clone();
+        tokio::task::block_in_place(|| {
+            let rt = tokio::runtime::Handle::current();
+            rt.block_on(async {
+                let g = graph.read().await;
+                if let Ok(did) = actor_str.parse::<icn_identity::Did>() {
+                    g.compute_trust_score(&did).unwrap_or(0.0)
+                } else {
+                    0.0
+                }
+            })
+        })
+    }
+
+    fn record_event(&self, _actor: &icn_kernel_api::types::Did, _event: icn_kernel_api::services::TrustEvent) {}
+}
+
+/// Test node with ledger and trust service
 #[allow(dead_code)]
 struct TestLedgerNode {
     did: Did,
@@ -63,10 +99,14 @@ impl TestLedgerNode {
             did.clone(),
         )));
 
+        // Create TrustService wrapping the graph
+        let trust_service: Arc<dyn TrustService> =
+            Arc::new(TestTrustService::new(trust_graph.clone()));
+
         // Create fork resolution components
         let fork_detector = ForkDetector::new();
         let mut fork_resolver = ForkResolver::new(ForkResolutionStrategy::Hybrid);
-        fork_resolver.set_trust_graph(trust_graph.clone());
+        fork_resolver.set_trust_service(trust_service);
 
         Ok(Self {
             did,
@@ -443,8 +483,10 @@ async fn test_fork_resolution_trust_weighted() -> Result<()> {
     // Set up trust edges: Alice trusts Bob highly, Charlie less
     // Note: In real system this would be through trust_graph.add_edge()
 
+    let trust_service: Arc<dyn TrustService> =
+        Arc::new(TestTrustService::new(trust_graph));
     let mut resolver = ForkResolver::new(ForkResolutionStrategy::TrustWeighted);
-    resolver.set_trust_graph(trust_graph);
+    resolver.set_trust_service(trust_service);
 
     let parent = icn_ledger::ContentHash([0u8; 32]);
 

--- a/icn/crates/icn-core/tests/fork_resolution_integration.rs
+++ b/icn/crates/icn-core/tests/fork_resolution_integration.rs
@@ -50,6 +50,9 @@ impl TrustService for TestTrustService {
     }
 
     fn trust_score(&self, actor: &icn_kernel_api::types::Did) -> f64 {
+        // Uses block_in_place because the TrustGraph is behind a tokio::sync::RwLock
+        // (shared with async test code). A std::sync::RwLock would be simpler but
+        // would require a separate lock type from the rest of the test infrastructure.
         let graph = self.graph.clone();
         let actor_str = actor.clone();
         tokio::task::block_in_place(|| {
@@ -65,7 +68,12 @@ impl TrustService for TestTrustService {
         })
     }
 
-    fn record_event(&self, _actor: &icn_kernel_api::types::Did, _event: icn_kernel_api::services::TrustEvent) {}
+    fn record_event(
+        &self,
+        _actor: &icn_kernel_api::types::Did,
+        _event: icn_kernel_api::services::TrustEvent,
+    ) {
+    }
 }
 
 /// Test node with ledger and trust service
@@ -483,8 +491,7 @@ async fn test_fork_resolution_trust_weighted() -> Result<()> {
     // Set up trust edges: Alice trusts Bob highly, Charlie less
     // Note: In real system this would be through trust_graph.add_edge()
 
-    let trust_service: Arc<dyn TrustService> =
-        Arc::new(TestTrustService::new(trust_graph));
+    let trust_service: Arc<dyn TrustService> = Arc::new(TestTrustService::new(trust_graph));
     let mut resolver = ForkResolver::new(ForkResolutionStrategy::TrustWeighted);
     resolver.set_trust_service(trust_service);
 

--- a/icn/crates/icn-ledger/Cargo.toml
+++ b/icn/crates/icn-ledger/Cargo.toml
@@ -31,7 +31,6 @@ tempfile = "3.24"
 criterion = "0.5"
 rand = "0.8"
 icn-governance = { path = "../icn-governance" }
-icn-kernel-api = { path = "../icn-kernel-api" }
 icn-trust = { path = "../icn-trust" }
 
 [[bench]]

--- a/icn/crates/icn-ledger/Cargo.toml
+++ b/icn/crates/icn-ledger/Cargo.toml
@@ -11,7 +11,6 @@ icn-entity = { path = "../icn-entity" }
 icn-time = { path = "../icn-time" }
 icn-store.workspace = true
 icn-gossip.workspace = true
-icn-trust.workspace = true
 icn-kernel-api.workspace = true
 icn-obs.workspace = true
 icn-security.workspace = true
@@ -33,6 +32,7 @@ criterion = "0.5"
 rand = "0.8"
 icn-governance = { path = "../icn-governance" }
 icn-kernel-api = { path = "../icn-kernel-api" }
+icn-trust = { path = "../icn-trust" }
 
 [[bench]]
 name = "ledger_bench"

--- a/icn/crates/icn-ledger/src/credit_policy.rs
+++ b/icn/crates/icn-ledger/src/credit_policy.rs
@@ -9,7 +9,6 @@ use crate::ledger::Ledger;
 use crate::types::CreditLimit;
 use anyhow::Result;
 use icn_identity::Did;
-use icn_trust::TrustGraph;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -90,13 +89,9 @@ impl CreditPolicy {
         &self,
         member: &Did,
         ledger: &Ledger,
-        trust_graph: &TrustGraph,
+        trust_score: f64,
     ) -> Result<i64> {
-        // Get trust score (0.0 = untrusted, 1.0 = fully trusted)
-        let trust_score = trust_graph
-            .compute_trust_score(member)
-            .unwrap_or(0.0)
-            .clamp(0.0, 1.0);
+        let trust_score = trust_score.clamp(0.0, 1.0);
 
         // Get cleared volume (sum of all cleared credits)
         let cleared_volume = ledger.total_cleared_by(member, &self.currency)?;
@@ -270,12 +265,12 @@ impl CreditPolicyManager {
         member_since: u64,
         current_time: u64,
         ledger: &Ledger,
-        trust_graph: &TrustGraph,
+        trust_score: f64,
     ) -> Result<CreditLimit> {
         // Calculate base limit from credit policy
         let base_limit = self
             .credit_policy
-            .calculate_limit(member, ledger, trust_graph)?;
+            .calculate_limit(member, ledger, trust_score)?;
 
         // Get cleared volume for new member check
         let cleared_volume = ledger.total_cleared_by(member, &self.credit_policy.currency)?;
@@ -310,10 +305,10 @@ impl CreditPolicyManager {
         current_balance: i64,
         transaction_delta: i64,
         ledger: &Ledger,
-        trust_graph: &TrustGraph,
+        trust_score: f64,
     ) -> Result<bool> {
         let limit =
-            self.calculate_credit_limit(member, member_since, current_time, ledger, trust_graph)?;
+            self.calculate_credit_limit(member, member_since, current_time, ledger, trust_score)?;
 
         let would_exceed = self.credit_policy.would_exceed_limit(
             member,

--- a/icn/crates/icn-ledger/src/credit_policy.rs
+++ b/icn/crates/icn-ledger/src/credit_policy.rs
@@ -85,12 +85,7 @@ impl CreditPolicy {
     /// Limit = 100 + (100 * 0.8 * 0.3) + (1000 * 0.05)
     ///       = 100 + 24 + 50
     ///       = 174 hours
-    pub fn calculate_limit(
-        &self,
-        member: &Did,
-        ledger: &Ledger,
-        trust_score: f64,
-    ) -> Result<i64> {
+    pub fn calculate_limit(&self, member: &Did, ledger: &Ledger, trust_score: f64) -> Result<i64> {
         let trust_score = trust_score.clamp(0.0, 1.0);
 
         // Get cleared volume (sum of all cleared credits)

--- a/icn/crates/icn-ledger/src/error.rs
+++ b/icn/crates/icn-ledger/src/error.rs
@@ -37,9 +37,9 @@ pub enum LedgerError {
     #[error("fork resolution failed: {0}")]
     ForkResolutionFailed(String),
 
-    /// Trust graph required
-    #[error("trust graph required for this operation")]
-    TrustGraphRequired,
+    /// Trust service required
+    #[error("trust service required for this operation")]
+    TrustServiceRequired,
 
     /// Duplicate entry
     #[error("duplicate entry: {0}")]

--- a/icn/crates/icn-ledger/src/fork_resolution.rs
+++ b/icn/crates/icn-ledger/src/fork_resolution.rs
@@ -11,7 +11,6 @@ use crate::types::{ContentHash, JournalEntry, WitnessSignature};
 use anyhow::{anyhow, Result};
 use icn_kernel_api::services::TrustService;
 use icn_store::Store;
-use icn_trust::TrustGraph;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -74,8 +73,6 @@ const WITNESS_PREFIX: &str = "ledger:witnesses:";
 /// Fork resolution system
 pub struct ForkResolver {
     strategy: ForkResolutionStrategy,
-    /// Trust graph for trust-weighted resolution (deprecated)
-    trust_graph: Option<Arc<tokio::sync::RwLock<TrustGraph>>>,
     /// Trust service for trust-weighted resolution (kernel/app separated)
     trust_service: Option<Arc<dyn TrustService>>,
     store: Option<Arc<dyn Store>>,
@@ -86,17 +83,9 @@ impl ForkResolver {
     pub fn new(strategy: ForkResolutionStrategy) -> Self {
         Self {
             strategy,
-            trust_graph: None,
             trust_service: None,
             store: None,
         }
-    }
-
-    /// Set the trust graph for trust-weighted resolution (deprecated)
-    ///
-    /// Use `set_trust_service()` instead for proper kernel/app separation.
-    pub fn set_trust_graph(&mut self, trust_graph: Arc<tokio::sync::RwLock<TrustGraph>>) {
-        self.trust_graph = Some(trust_graph);
     }
 
     /// Set the trust service for trust-weighted resolution (kernel/app separated)
@@ -109,26 +98,11 @@ impl ForkResolver {
         self.store = Some(store);
     }
 
-    /// Get trust score for a DID using TrustService (preferred) or TrustGraph (fallback)
+    /// Get trust score for a DID using TrustService
     fn get_trust_score(&self, did: &icn_identity::Did) -> f64 {
-        // Prefer TrustService if available (kernel/app separation)
         if let Some(ref trust_service) = self.trust_service {
             let kernel_did = icn_kernel_api::types::Did::from(did.to_string());
             return trust_service.trust_score(&kernel_did);
-        }
-
-        // Fall back to TrustGraph (deprecated path)
-        if let Some(ref trust_graph) = self.trust_graph {
-            // Use block_in_place for async lock from sync context
-            let trust_graph_clone = trust_graph.clone();
-            let did_clone = did.clone();
-            return tokio::task::block_in_place(|| {
-                let rt = tokio::runtime::Handle::current();
-                rt.block_on(async {
-                    let graph = trust_graph_clone.read().await;
-                    graph.compute_trust_score(&did_clone).unwrap_or(0.0)
-                })
-            });
         }
 
         0.0
@@ -201,10 +175,9 @@ impl ForkResolver {
         entry1: &JournalEntry,
         entry2: &JournalEntry,
     ) -> Result<ForkResolution> {
-        // Check that we have a trust source (TrustService or TrustGraph)
-        if self.trust_service.is_none() && self.trust_graph.is_none() {
+        if self.trust_service.is_none() {
             return Err(anyhow!(
-                "Trust source required for trust-weighted resolution"
+                "TrustService required for trust-weighted resolution"
             ));
         }
 
@@ -287,8 +260,7 @@ impl ForkResolver {
         let mut score = 0.0;
 
         // Trust component (40% weight)
-        // Use TrustService if available, else TrustGraph (via helper method)
-        if self.trust_service.is_some() || self.trust_graph.is_some() {
+        if self.trust_service.is_some() {
             let trust = self.get_trust_score(&entry.author);
             score += trust * 0.4;
         }

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -207,7 +207,6 @@ use anyhow::{Context, Result};
 use icn_gossip::GossipHandle;
 use icn_identity::Did;
 use icn_store::Store;
-use icn_trust::TrustGraph;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -302,15 +301,8 @@ pub struct Ledger {
     pub(crate) misbehavior_detector:
         Option<Arc<tokio::sync::RwLock<icn_security::MisbehaviorDetector>>>,
 
-    /// Trust graph for entry validation (wrapped in RwLock for live updates)
-    ///
-    /// **Deprecated**: Use `trust_service` instead for proper kernel/app separation.
-    /// This field is kept for backward compatibility during migration.
-    pub(crate) trust_graph: Option<Arc<tokio::sync::RwLock<TrustGraph>>>,
-
     /// Trust service for entry validation (kernel/app separated)
     ///
-    /// When set, takes precedence over `trust_graph` for trust score queries.
     /// This enables proper separation between kernel (ledger) and domain (trust).
     pub(crate) trust_service: Option<Arc<dyn icn_kernel_api::services::TrustService>>,
 
@@ -386,7 +378,6 @@ impl Ledger {
             fork_resolver: ForkResolver::new(ForkResolutionStrategy::default()), // Hybrid strategy
             misbehavior_detector: None, // Set via set_misbehavior_detector()
             freeze_manager,
-            trust_graph: None,   // Deprecated: use trust_service instead
             trust_service: None, // Set via set_trust_service()
             min_trust_for_entry: DEFAULT_MIN_TRUST_FOR_ENTRY,
             journal_version,
@@ -447,20 +438,10 @@ impl Ledger {
         self.journal_version
     }
 
-    /// Set the trust graph for trust-weighted fork resolution and entry validation
-    ///
-    /// **Deprecated**: Use `set_trust_service()` instead for proper kernel/app separation.
-    /// This method is kept for backward compatibility during migration.
-    pub fn set_trust_graph(&mut self, trust_graph: Arc<tokio::sync::RwLock<TrustGraph>>) {
-        self.trust_graph = Some(trust_graph.clone());
-        self.fork_resolver.set_trust_graph(trust_graph);
-    }
-
     /// Set the trust service for entry validation (kernel/app separated)
     ///
-    /// When set, the ledger uses TrustService for trust score queries instead of
-    /// directly accessing TrustGraph. This enables proper separation between
-    /// kernel components (ledger) and domain components (trust).
+    /// When set, the ledger uses TrustService for trust score queries.
+    /// This enables proper separation between kernel (ledger) and domain (trust).
     pub fn set_trust_service(
         &mut self,
         trust_service: Arc<dyn icn_kernel_api::services::TrustService>,
@@ -470,21 +451,13 @@ impl Ledger {
         self.fork_resolver.set_trust_service(trust_service);
     }
 
-    /// Get trust score for a DID using TrustService (preferred) or TrustGraph (fallback)
+    /// Get trust score for a DID using TrustService
     ///
-    /// Returns 0.0 if no trust source is configured or DID parsing fails.
+    /// Returns 0.0 if no trust service is configured or DID parsing fails.
     pub(crate) fn get_trust_score(&self, did: &icn_identity::Did) -> f64 {
-        // Prefer TrustService if available (kernel/app separation)
         if let Some(ref trust_service) = self.trust_service {
             let kernel_did = icn_kernel_api::types::Did::from(did.to_string());
             return trust_service.trust_score(&kernel_did);
-        }
-
-        // Fall back to TrustGraph (deprecated path)
-        if let Some(ref trust_graph) = self.trust_graph {
-            if let Ok(graph) = trust_graph.try_read() {
-                return graph.compute_trust_score(did).unwrap_or(0.0);
-            }
         }
 
         0.0
@@ -492,21 +465,10 @@ impl Ledger {
 
     /// Get trust score for a DID asynchronously (for async contexts)
     ///
-    /// Returns 0.0 if no trust source is configured or DID parsing fails.
+    /// Returns 0.0 if no trust service is configured or DID parsing fails.
     pub(crate) async fn get_trust_score_async(&self, did: &icn_identity::Did) -> f64 {
-        // Prefer TrustService if available (kernel/app separation)
-        if let Some(ref trust_service) = self.trust_service {
-            let kernel_did = icn_kernel_api::types::Did::from(did.to_string());
-            return trust_service.trust_score(&kernel_did);
-        }
-
-        // Fall back to TrustGraph (deprecated path)
-        if let Some(ref trust_graph) = self.trust_graph {
-            let graph = trust_graph.read().await;
-            return graph.compute_trust_score(did).unwrap_or(0.0);
-        }
-
-        0.0
+        // TrustService::trust_score() is synchronous
+        self.get_trust_score(did)
     }
 
     /// Set the minimum trust score required for entry acceptance
@@ -630,11 +592,11 @@ impl Ledger {
     /// per (DID, currency) pair by the ledger's transaction validation layer.
     ///
     /// # Warning
-    /// If no trust source is set (trust_service or trust_graph), all trust scores
-    /// will default to 0.0, which results in baseline-only credit limits (no trust multiplier bonus).
+    /// If no trust service is set, all trust scores will default to 0.0,
+    /// which results in baseline-only credit limits (no trust multiplier bonus).
     pub fn set_dynamic_limit_manager(&mut self, manager: Arc<DynamicCreditLimitManager>) {
-        if self.trust_service.is_none() && self.trust_graph.is_none() {
-            warn!("Dynamic credit limits set without trust source; all trust scores will be 0.0");
+        if self.trust_service.is_none() {
+            warn!("Dynamic credit limits set without TrustService; all trust scores will be 0.0");
         }
         self.dynamic_limit_manager = Some(manager);
     }
@@ -1369,7 +1331,7 @@ impl Ledger {
 
         // Trust-based entry validation (H5 fix)
         // Skip trust check if no trust source configured (allows local-only operation)
-        if self.trust_service.is_some() || self.trust_graph.is_some() {
+        if self.trust_service.is_some() {
             let author_did = &entry.author;
             let min_trust = self.min_trust_for_entry;
             let trust_score = self.get_trust_score_async(author_did).await;
@@ -1576,7 +1538,7 @@ impl Ledger {
                 .collect();
 
             for (did, currency) in unique_pairs {
-                // Get trust score for the account (uses TrustService if available, else TrustGraph)
+                // Get trust score for the account via TrustService
                 // Activity recording is non-critical, so we use 0.0 if no trust source
                 let trust_score = self.get_trust_score(did).clamp(0.0, 1.0);
 
@@ -2840,7 +2802,7 @@ impl Ledger {
                 let currency = &delta.currency;
                 let current_balance = self.get_balance(account, currency);
 
-                // Get trust score for the account (uses TrustService if available, else TrustGraph)
+                // Get trust score for the account via TrustService
                 let trust_score = self.get_trust_score(account).clamp(0.0, 1.0);
 
                 // Get cleared volume for history bonus

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -438,10 +438,18 @@ impl Ledger {
         self.journal_version
     }
 
-    /// Set the trust service for entry validation (kernel/app separated)
+    /// Set the trust service for entry validation (kernel/app separated).
     ///
-    /// When set, the ledger uses TrustService for trust score queries.
+    /// When set, the ledger uses `TrustService` for trust score queries.
     /// This enables proper separation between kernel (ledger) and domain (trust).
+    ///
+    /// # Degradation behaviour
+    ///
+    /// If no trust service is configured (or it is removed), every trust
+    /// query returns **0.0**.  This means:
+    /// - Fork resolution falls back to timestamp-based tie-breaking.
+    /// - Credit limit calculations use baseline-only values.
+    /// - Witness validation is skipped (with a metrics counter bump).
     pub fn set_trust_service(
         &mut self,
         trust_service: Arc<dyn icn_kernel_api::services::TrustService>,
@@ -456,6 +464,8 @@ impl Ledger {
     /// Returns 0.0 if no trust service is configured or DID parsing fails.
     pub(crate) fn get_trust_score(&self, did: &icn_identity::Did) -> f64 {
         if let Some(ref trust_service) = self.trust_service {
+            // TODO: implement From<&icn_identity::Did> for kernel Did to avoid
+            //       the string allocation here (low impact — once per entry).
             let kernel_did = icn_kernel_api::types::Did::from(did.to_string());
             return trust_service.trust_score(&kernel_did);
         }
@@ -463,11 +473,17 @@ impl Ledger {
         0.0
     }
 
-    /// Get trust score for a DID asynchronously (for async contexts)
+    /// Get trust score for a DID asynchronously (for async contexts).
     ///
     /// Returns 0.0 if no trust service is configured or DID parsing fails.
+    ///
+    /// # Deprecation
+    ///
+    /// `TrustService::trust_score()` is synchronous, so this wrapper adds no
+    /// value.  Prefer [`get_trust_score`](Self::get_trust_score) directly.
+    #[deprecated(note = "TrustService::trust_score() is sync — use get_trust_score() instead")]
+    #[allow(dead_code)]
     pub(crate) async fn get_trust_score_async(&self, did: &icn_identity::Did) -> f64 {
-        // TrustService::trust_score() is synchronous
         self.get_trust_score(did)
     }
 
@@ -1334,7 +1350,7 @@ impl Ledger {
         if self.trust_service.is_some() {
             let author_did = &entry.author;
             let min_trust = self.min_trust_for_entry;
-            let trust_score = self.get_trust_score_async(author_did).await;
+            let trust_score = self.get_trust_score(author_did);
 
             if trust_score < min_trust {
                 warn!(

--- a/icn/crates/icn-ledger/src/ledger_impl/witness_ops.rs
+++ b/icn/crates/icn-ledger/src/ledger_impl/witness_ops.rs
@@ -163,16 +163,16 @@ async fn validate_witness_trust_score(
     _parties: &HashSet<Did>, // Reserved for future per-party validation
     min_trust: f64,
 ) -> Result<()> {
-    // If no trust graph is available, skip trust validation with a warning.
+    // If no trust service is available, skip trust validation with a warning.
     // SECURITY NOTE: This graceful degradation prioritizes availability over strict
     // enforcement. Cooperatives configuring min_witness_trust MUST also call
-    // set_trust_graph() or trust validation will be skipped silently.
+    // set_trust_service() or trust validation will be skipped silently.
     // The metric below allows monitoring for this misconfiguration.
-    let trust_graph = match &ledger.trust_graph {
-        Some(tg) => tg,
+    let trust_service = match &ledger.trust_service {
+        Some(ts) => ts,
         None => {
             tracing::warn!(
-                "Trust validation requested but no trust graph available, skipping trust check for witness {}",
+                "Trust validation requested but no TrustService available, skipping trust check for witness {}",
                 witness
             );
             icn_obs::metrics::ledger::witness_trust_validation_skipped_inc();
@@ -180,13 +180,10 @@ async fn validate_witness_trust_score(
         }
     };
 
-    // Compute trust score from trust graph owner's perspective
+    // Compute trust score via TrustService (kernel/app separated)
     // TODO: For future enhancement, compute trust from each party's perspective
-    // by creating per-party trust lookups or using party-specific trust graphs
-    let trust_score = {
-        let graph = trust_graph.read().await;
-        graph.compute_trust_score(witness).unwrap_or(0.0)
-    };
+    let kernel_did = icn_kernel_api::types::Did::from(witness.to_string());
+    let trust_score = trust_service.trust_score(&kernel_did);
 
     if trust_score < min_trust {
         icn_obs::metrics::ledger::witness_trust_validation_failed_inc();

--- a/icn/crates/icn-ledger/tests/witness_trust.rs
+++ b/icn/crates/icn-ledger/tests/witness_trust.rs
@@ -42,7 +42,12 @@ impl TrustService for TestTrustService {
         0.0
     }
 
-    fn record_event(&self, _actor: &icn_kernel_api::types::Did, _event: icn_kernel_api::services::TrustEvent) {}
+    fn record_event(
+        &self,
+        _actor: &icn_kernel_api::types::Did,
+        _event: icn_kernel_api::services::TrustEvent,
+    ) {
+    }
 }
 
 /// Create a test ledger with trust service backed by a TrustGraph owned by a specific DID

--- a/icn/crates/icn-ledger/tests/witness_trust.rs
+++ b/icn/crates/icn-ledger/tests/witness_trust.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use icn_identity::KeyPair;
+use icn_kernel_api::services::TrustService;
 use icn_ledger::{
     entry::JournalEntryBuilder, Ledger, WitnessConfig, WitnessPolicy, WitnessSignature,
     WitnessedEntry,
@@ -15,7 +16,36 @@ use std::sync::Arc;
 use tempfile::TempDir;
 use tokio::sync::RwLock;
 
-/// Create a test ledger with trust graph owned by a specific DID
+/// A test TrustService that wraps a TrustGraph for witness trust tests
+struct TestTrustService {
+    graph: Arc<RwLock<TrustGraph>>,
+}
+
+impl TestTrustService {
+    fn new(graph: Arc<RwLock<TrustGraph>>) -> Self {
+        Self { graph }
+    }
+}
+
+impl TrustService for TestTrustService {
+    fn oracle(&self) -> Arc<dyn icn_kernel_api::authz::PolicyOracle> {
+        unimplemented!("oracle not needed for witness trust tests")
+    }
+
+    fn trust_score(&self, actor: &icn_kernel_api::types::Did) -> f64 {
+        // Use try_read for non-blocking access (tests don't have write contention)
+        if let Ok(g) = self.graph.try_read() {
+            if let Ok(did) = actor.parse::<icn_identity::Did>() {
+                return g.compute_trust_score(&did).unwrap_or(0.0);
+            }
+        }
+        0.0
+    }
+
+    fn record_event(&self, _actor: &icn_kernel_api::types::Did, _event: icn_kernel_api::services::TrustEvent) {}
+}
+
+/// Create a test ledger with trust service backed by a TrustGraph owned by a specific DID
 fn create_ledger_with_trust_for_owner(
     owner_did: icn_identity::Did,
 ) -> (Ledger, TempDir, Arc<RwLock<TrustGraph>>) {
@@ -27,9 +57,11 @@ fn create_ledger_with_trust_for_owner(
     let trust_graph = TrustGraph::new(trust_store, owner_did);
     let trust_graph_arc = Arc::new(RwLock::new(trust_graph));
 
-    // Create ledger with trust graph
+    // Create ledger with TrustService (wrapping TrustGraph)
+    let trust_service: Arc<dyn TrustService> =
+        Arc::new(TestTrustService::new(trust_graph_arc.clone()));
     let mut ledger = Ledger::new(store).unwrap();
-    ledger.set_trust_graph(trust_graph_arc.clone());
+    ledger.set_trust_service(trust_service);
 
     // Disable entry author trust validation for these tests
     // (we're testing witness trust validation, not entry author validation)


### PR DESCRIPTION
## Summary

- Remove direct `icn-trust::TrustGraph` dependency from `icn-ledger` production code
- All trust score queries now go through `TrustService` trait (kernel/app separation)
- `icn-trust` moved from `[dependencies]` to `[dev-dependencies]` in icn-ledger
- Closes Phase 2.5: Ledger entry validation via oracle

## Changes

**icn-ledger/src/fork_resolution.rs**: Remove `trust_graph` field, `set_trust_graph()`, TrustGraph fallback in `get_trust_score()`. ForkResolver now uses TrustService only.

**icn-ledger/src/credit_policy.rs**: `CreditPolicy::calculate_limit()` now takes `trust_score: f64` instead of `&TrustGraph`. Same for `CreditPolicyManager::calculate_credit_limit()` and `check_transaction()`.

**icn-ledger/src/ledger.rs**: Remove `trust_graph` field, `set_trust_graph()`, TrustGraph fallback in `get_trust_score()` and `get_trust_score_async()`. `get_trust_score_async()` now delegates to sync `get_trust_score()` since TrustService is sync.

**icn-ledger/src/ledger_impl/witness_ops.rs**: `validate_witness_trust_score()` uses `ledger.trust_service` instead of `ledger.trust_graph`.

**icn-core/src/supervisor/init_ledger.rs**: Remove `trust_graph` from `LedgerDeps`. ContractActor gets `None` for trust_graph (CCL migration pending).

**icn-ledger/Cargo.toml**: `icn-trust` moved to `[dev-dependencies]`.

**Tests**: Fork resolution integration and witness trust tests use `TestTrustService` wrapper backed by TrustGraph.

## Risk

- `ContractActor::new()` now receives `None` for trust_graph. This may affect CCL contract execution that queries trust. However, CCL already has its own migration path and this was a deprecated code path.
- External code calling `set_trust_graph()` on Ledger or ForkResolver will get compile errors — must switch to `set_trust_service()`.

## Test plan

- [x] All 360+ icn-ledger unit tests pass
- [x] 7 witness_trust integration tests pass (using TestTrustService)
- [x] 7 fork_resolution_integration tests pass
- [x] Clippy clean on icn-ledger and icn-core
- [x] Full workspace build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)