### PR TITLE
refactor(core): remove TrustScore and TrustGraph from config and policy layers (#912)

### DIFF
--- a/icn/crates/icn-core/src/config/gossip.rs
+++ b/icn/crates/icn-core/src/config/gossip.rs
@@ -20,7 +20,6 @@
 //! heal_interval_secs = 60          # How often to attempt healing
 //! ```
 
-
 use serde::{Deserialize, Serialize};
 
 /// Gossip protocol configuration

--- a/icn/crates/icn-core/src/config/gossip.rs
+++ b/icn/crates/icn-core/src/config/gossip.rs
@@ -20,7 +20,7 @@
 //! heal_interval_secs = 60          # How often to attempt healing
 //! ```
 
-use icn_trust::TrustScore;
+
 use serde::{Deserialize, Serialize};
 
 /// Gossip protocol configuration
@@ -45,7 +45,7 @@ pub struct ReplicationConfig {
     /// Minimum trust class required to serve as replica (Known = 0.1, Partner = 0.4, Federated = 0.7)
     /// Default: 0.4 (Partner)
     #[serde(default = "default_min_replica_trust")]
-    pub min_replica_trust: TrustScore,
+    pub min_replica_trust: f64,
 
     /// Health check interval in seconds
     #[serde(default = "default_health_check_interval_secs")]
@@ -76,8 +76,8 @@ fn default_target_replicas() -> usize {
     3
 }
 
-fn default_min_replica_trust() -> TrustScore {
-    TrustScore::unchecked(0.4) // Partner trust class
+fn default_min_replica_trust() -> f64 {
+    0.4 // Partner trust class
 }
 
 fn default_health_check_interval_secs() -> u64 {
@@ -144,7 +144,7 @@ impl ReplicationConfig {
     pub fn to_manager_config(&self) -> crate::replication::ReplicationConfig {
         crate::replication::ReplicationConfig {
             target_replicas: self.target_replicas,
-            min_trust_score: self.min_replica_trust.value(),
+            min_trust_score: self.min_replica_trust,
             health_check_interval_secs: self.health_check_interval_secs,
             stale_threshold_secs: self.stale_threshold_secs,
             unreachable_threshold_secs: self.unreachable_threshold_secs,
@@ -171,7 +171,7 @@ mod tests {
     fn test_gossip_config_defaults() {
         let config = GossipConfig::default();
         assert_eq!(config.replication.target_replicas, 3);
-        assert_eq!(config.replication.min_replica_trust.value(), 0.4);
+        assert!((config.replication.min_replica_trust - 0.4).abs() < f64::EPSILON);
         assert_eq!(config.replication.health_check_interval_secs, 60);
         assert_eq!(config.replication.stale_threshold_secs, 300);
         assert_eq!(config.replication.unreachable_threshold_secs, 900);
@@ -186,7 +186,7 @@ mod tests {
     fn test_replication_config_defaults() {
         let config = ReplicationConfig::default();
         assert_eq!(config.target_replicas, 3);
-        assert_eq!(config.min_replica_trust.value(), 0.4);
+        assert!((config.min_replica_trust - 0.4).abs() < f64::EPSILON);
         assert_eq!(config.health_check_interval_secs, 60);
         assert_eq!(config.stale_threshold_secs, 300);
         assert_eq!(config.unreachable_threshold_secs, 900);
@@ -206,7 +206,7 @@ mod tests {
         let config = GossipConfig {
             replication: ReplicationConfig {
                 target_replicas: 5,
-                min_replica_trust: TrustScore::unchecked(0.5),
+                min_replica_trust: 0.5,
                 health_check_interval_secs: 120,
                 stale_threshold_secs: 600,
                 unreachable_threshold_secs: 1800,
@@ -223,7 +223,7 @@ mod tests {
         let deserialized: GossipConfig = toml::from_str(&toml_str).unwrap();
 
         assert_eq!(deserialized.replication.target_replicas, 5);
-        assert_eq!(deserialized.replication.min_replica_trust.value(), 0.5);
+        assert!((deserialized.replication.min_replica_trust - 0.5).abs() < f64::EPSILON);
         assert_eq!(deserialized.replication.health_check_interval_secs, 120);
         assert_eq!(deserialized.replication.stale_threshold_secs, 600);
         assert_eq!(deserialized.replication.unreachable_threshold_secs, 1800);
@@ -251,7 +251,7 @@ silence_threshold_secs = 400
         assert_eq!(config.partition.silence_threshold_secs, 400);
 
         // Default values
-        assert_eq!(config.replication.min_replica_trust.value(), 0.4);
+        assert!((config.replication.min_replica_trust - 0.4).abs() < f64::EPSILON);
         assert_eq!(config.replication.health_check_interval_secs, 60);
         assert_eq!(config.partition.check_interval_secs, 30);
         assert!(config.partition.auto_heal_enabled);
@@ -261,7 +261,7 @@ silence_threshold_secs = 400
     fn test_replication_config_to_manager_config() {
         let config = ReplicationConfig {
             target_replicas: 5,
-            min_replica_trust: TrustScore::unchecked(0.7),
+            min_replica_trust: 0.7,
             health_check_interval_secs: 90,
             stale_threshold_secs: 450,
             unreachable_threshold_secs: 1200,

--- a/icn/crates/icn-core/src/config/mod.rs
+++ b/icn/crates/icn-core/src/config/mod.rs
@@ -227,10 +227,8 @@ impl Config {
             errors.push("network.listen_addr cannot be empty".to_string());
         }
 
-        // TrustScore already validates range [0.0, 1.0] at construction time
-
         // Trust threshold warnings
-        if self.network.min_trust_threshold.value() == 0.0 {
+        if self.network.min_trust_threshold == 0.0 {
             warnings.push(
                 "network.min_trust_threshold is 0.0 - trust-gated TLS is disabled, \
                  all authenticated DIDs will be accepted"
@@ -298,7 +296,6 @@ impl Config {
         }
 
         // Trust validation
-        // Note: TrustScore validates range [0.0, 1.0] at construction time
         if self.trust.propagation.max_path_length == 0 {
             errors.push("trust.propagation.max_path_length cannot be 0".to_string());
         }
@@ -307,8 +304,6 @@ impl Config {
         if self.gossip.replication.target_replicas == 0 {
             errors.push("gossip.replication.target_replicas cannot be 0".to_string());
         }
-        // Note: TrustScore validates range [0.0, 1.0] at construction time
-
         // Compute validation
         if self.compute.verification.consensus_threshold < 0.0
             || self.compute.verification.consensus_threshold > 1.0
@@ -362,8 +357,6 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icn_trust::TrustScore;
-
     #[test]
     fn test_config_serialization() {
         let config = Config::default();
@@ -808,7 +801,7 @@ log_level = "info"
 "#;
 
         let config: Config = toml::from_str(custom_toml).unwrap();
-        assert!((config.network.min_trust_threshold.value() - 0.0).abs() < f64::EPSILON);
+        assert!((config.network.min_trust_threshold - 0.0).abs() < f64::EPSILON);
 
         // Test that fallback config can be generated
         let _fallback = config.rate_limiting.to_fallback_config();
@@ -861,20 +854,24 @@ log_level = "info"
 
     #[test]
     fn test_config_validation_trust_threshold_range() {
-        // TrustScore validates range during deserialization
-        let invalid_toml = r#"
-[network]
+        // With f64, any value deserializes — range checking is a runtime concern.
+        // Parse just the NetworkConfig sub-section to avoid missing required Config fields.
+        let toml_str = r#"
+mdns_enabled = true
+listen_addr = "0.0.0.0:7777"
+rpc_port = 5601
+bootstrap_peers = []
 min_trust_threshold = 1.5
 "#;
-        let result: Result<Config, _> = toml::from_str(invalid_toml);
-        // Should fail during TOML parsing since TrustScore rejects invalid values
-        assert!(result.is_err());
+        let result: Result<NetworkConfig, _> = toml::from_str(toml_str);
+        assert!(result.is_ok());
+        assert!((result.unwrap().min_trust_threshold - 1.5).abs() < f64::EPSILON);
     }
 
     #[test]
     fn test_config_validation_zero_trust_warning() {
         let mut config = Config::default();
-        config.network.min_trust_threshold = TrustScore::unchecked(0.0);
+        config.network.min_trust_threshold = 0.0;
 
         let result = config.validate();
         assert!(result.is_ok());
@@ -886,26 +883,26 @@ min_trust_threshold = 1.5
 
     #[test]
     fn test_config_validation_trust_decay_factor_range() {
-        // TrustScore validates range during deserialization
-        let invalid_toml = r#"
-[trust.propagation]
+        // With f64, any value deserializes — parse just the PropagationConfig sub-section.
+        let toml_str = r#"
+max_path_length = 3
 decay_factor = 1.5
 "#;
-        let result: Result<Config, _> = toml::from_str(invalid_toml);
-        // Should fail during TOML parsing since TrustScore rejects invalid values
-        assert!(result.is_err());
+        let result: Result<PropagationConfig, _> = toml::from_str(toml_str);
+        assert!(result.is_ok());
+        assert!((result.unwrap().decay_factor - 1.5).abs() < f64::EPSILON);
     }
 
     #[test]
     fn test_config_validation_gossip_replica_trust_range() {
-        // TrustScore validates range during deserialization
-        let invalid_toml = r#"
-[gossip.replication]
+        // With f64, any value deserializes — parse just the ReplicationConfig sub-section.
+        let toml_str = r#"
+target_replicas = 3
 min_replica_trust = -0.5
 "#;
-        let result: Result<Config, _> = toml::from_str(invalid_toml);
-        // Should fail during TOML parsing since TrustScore rejects invalid values
-        assert!(result.is_err());
+        let result: Result<ReplicationConfig, _> = toml::from_str(toml_str);
+        assert!(result.is_ok());
+        assert!((result.unwrap().min_replica_trust - (-0.5)).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -1100,14 +1097,14 @@ enabled = false
         assert_eq!(deserialized.gossip.replication.target_replicas, 3);
         assert_eq!(deserialized.compute.max_concurrent_tasks, 10);
         assert!(
-            (deserialized.trust.attestation.min_attester_trust.value() - 0.3).abs() < f64::EPSILON
+            (deserialized.trust.attestation.min_attester_trust - 0.3).abs() < f64::EPSILON
         );
 
         // Test with explicit values to ensure they serialize
         let mut custom_config = Config::default();
         custom_config.gossip.replication.target_replicas = 5;
         custom_config.compute.max_concurrent_tasks = 20;
-        custom_config.trust.attestation.min_attester_trust = TrustScore::unchecked(0.5);
+        custom_config.trust.attestation.min_attester_trust = 0.5;
 
         let custom_toml = toml::to_string_pretty(&custom_config).unwrap();
         let custom_deserialized: Config = toml::from_str(&custom_toml).unwrap();
@@ -1115,14 +1112,7 @@ enabled = false
         assert_eq!(custom_deserialized.gossip.replication.target_replicas, 5);
         assert_eq!(custom_deserialized.compute.max_concurrent_tasks, 20);
         assert!(
-            (custom_deserialized
-                .trust
-                .attestation
-                .min_attester_trust
-                .value()
-                - 0.5)
-                .abs()
-                < f64::EPSILON
+            (custom_deserialized.trust.attestation.min_attester_trust - 0.5).abs() < f64::EPSILON
         );
     }
 
@@ -1168,12 +1158,12 @@ enabled = false
 
         // Test boundary cases
         let mut config_known = GossipConfig::default();
-        config_known.replication.min_replica_trust = TrustScore::unchecked(0.3);
+        config_known.replication.min_replica_trust = 0.3;
         let manager_known = config_known.replication.to_manager_config();
         assert_eq!(manager_known.min_trust_score, 0.3);
 
         let mut config_federated = GossipConfig::default();
-        config_federated.replication.min_replica_trust = TrustScore::unchecked(0.8);
+        config_federated.replication.min_replica_trust = 0.8;
         let manager_federated = config_federated.replication.to_manager_config();
         assert_eq!(manager_federated.min_trust_score, 0.8);
     }

--- a/icn/crates/icn-core/src/config/mod.rs
+++ b/icn/crates/icn-core/src/config/mod.rs
@@ -241,6 +241,44 @@ impl Config {
             );
         }
 
+        // Validate all trust-score config fields are in [0.0, 1.0]
+        let trust_fields: &[(&str, f64)] = &[
+            (
+                "gossip.replication.min_replica_trust",
+                self.gossip.replication.min_replica_trust,
+            ),
+            ("privacy.min_relay_trust", self.privacy.min_relay_trust),
+            (
+                "trust.attestation.min_attester_trust",
+                self.trust.attestation.min_attester_trust,
+            ),
+            (
+                "trust.attestation.min_evidence_score",
+                self.trust.attestation.min_evidence_score,
+            ),
+            (
+                "trust.propagation.decay_factor",
+                self.trust.propagation.decay_factor,
+            ),
+            (
+                "trust.propagation.min_edge_trust",
+                self.trust.propagation.min_edge_trust,
+            ),
+            (
+                "trust.sybil_resistance.max_trust_concentration",
+                self.trust.sybil_resistance.max_trust_concentration,
+            ),
+            (
+                "trust.sybil_resistance.min_diversity_ratio",
+                self.trust.sybil_resistance.min_diversity_ratio,
+            ),
+        ];
+        for (name, value) in trust_fields {
+            if !(0.0..=1.0).contains(value) {
+                errors.push(format!("{name} must be in [0.0, 1.0], got {value}"));
+            }
+        }
+
         // Federation validation
         if self.federation.enabled {
             if self.federation.coop_id.is_empty() {
@@ -899,6 +937,29 @@ min_trust_threshold = 1.5
         assert!(warnings
             .iter()
             .any(|w| w.contains("trust-gated TLS is disabled")));
+    }
+
+    #[test]
+    fn test_config_validation_rejects_out_of_range_trust_fields() {
+        let mut config = Config::default();
+        // Set one trust field out of range
+        config.trust.propagation.decay_factor = 1.5;
+        let result = config.validate();
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors
+            .iter()
+            .any(|e| e.contains("trust.propagation.decay_factor")));
+
+        // Reset and try another
+        let mut config = Config::default();
+        config.gossip.replication.min_replica_trust = -0.1;
+        let result = config.validate();
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors
+            .iter()
+            .any(|e| e.contains("gossip.replication.min_replica_trust")));
     }
 
     #[test]

--- a/icn/crates/icn-core/src/config/mod.rs
+++ b/icn/crates/icn-core/src/config/mod.rs
@@ -227,8 +227,13 @@ impl Config {
             errors.push("network.listen_addr cannot be empty".to_string());
         }
 
-        // Trust threshold warnings
-        if self.network.min_trust_threshold == 0.0 {
+        // Trust threshold validation
+        if self.network.min_trust_threshold < 0.0 || self.network.min_trust_threshold > 1.0 {
+            errors.push(format!(
+                "network.min_trust_threshold must be in [0.0, 1.0], got {}",
+                self.network.min_trust_threshold
+            ));
+        } else if self.network.min_trust_threshold == 0.0 {
             warnings.push(
                 "network.min_trust_threshold is 0.0 - trust-gated TLS is disabled, \
                  all authenticated DIDs will be accepted"
@@ -853,9 +858,8 @@ log_level = "info"
     }
 
     #[test]
-    fn test_config_validation_trust_threshold_range() {
-        // With f64, any value deserializes — range checking is a runtime concern.
-        // Parse just the NetworkConfig sub-section to avoid missing required Config fields.
+    fn test_config_deser_accepts_out_of_range_trust() {
+        // f64 fields deserialize any numeric value — range is validated at runtime.
         let toml_str = r#"
 mdns_enabled = true
 listen_addr = "0.0.0.0:7777"
@@ -866,6 +870,22 @@ min_trust_threshold = 1.5
         let result: Result<NetworkConfig, _> = toml::from_str(toml_str);
         assert!(result.is_ok());
         assert!((result.unwrap().min_trust_threshold - 1.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_config_validation_rejects_out_of_range_trust() {
+        let mut config = Config::default();
+        config.network.min_trust_threshold = 1.5;
+        let result = config.validate();
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors
+            .iter()
+            .any(|e| e.contains("min_trust_threshold must be in [0.0, 1.0]")));
+
+        config.network.min_trust_threshold = -0.5;
+        let result = config.validate();
+        assert!(result.is_err());
     }
 
     #[test]
@@ -1096,9 +1116,7 @@ enabled = false
         // Verify defaults are properly restored
         assert_eq!(deserialized.gossip.replication.target_replicas, 3);
         assert_eq!(deserialized.compute.max_concurrent_tasks, 10);
-        assert!(
-            (deserialized.trust.attestation.min_attester_trust - 0.3).abs() < f64::EPSILON
-        );
+        assert!((deserialized.trust.attestation.min_attester_trust - 0.3).abs() < f64::EPSILON);
 
         // Test with explicit values to ensure they serialize
         let mut custom_config = Config::default();

--- a/icn/crates/icn-core/src/config/network.rs
+++ b/icn/crates/icn-core/src/config/network.rs
@@ -1,6 +1,5 @@
 //! Network layer configuration
 
-use icn_trust::TrustScore;
 use serde::{Deserialize, Serialize};
 
 /// Network layer configuration
@@ -34,7 +33,7 @@ pub struct NetworkConfig {
     ///
     /// For controlled/trusted environments, set to 0.0 to disable trust gating
     #[serde(default = "default_min_trust_threshold")]
-    pub min_trust_threshold: TrustScore,
+    pub min_trust_threshold: f64,
 
     /// TURN relay server for NAT traversal fallback (format: "IP:PORT")
     /// Used when direct connection fails (e.g., symmetric NAT)
@@ -257,8 +256,8 @@ pub(crate) fn default_stun_servers() -> Vec<String> {
     ]
 }
 
-pub(crate) fn default_min_trust_threshold() -> TrustScore {
-    TrustScore::unchecked(0.1) // Require at least "Known" trust class by default
+pub(crate) fn default_min_trust_threshold() -> f64 {
+    0.1 // Require at least "Known" trust class by default
 }
 
 pub(crate) fn default_true() -> bool {

--- a/icn/crates/icn-core/src/config/privacy.rs
+++ b/icn/crates/icn-core/src/config/privacy.rs
@@ -1,6 +1,5 @@
 //! Privacy configuration for metadata protection and onion routing
 
-use icn_trust::TrustScore;
 use serde::{Deserialize, Serialize};
 
 /// Privacy configuration for metadata protection and onion routing
@@ -23,7 +22,7 @@ pub struct PrivacyConfig {
     /// Minimum trust score for relay selection (0.0 to 1.0)
     /// Higher values = fewer relays but more trusted
     #[serde(default = "default_min_relay_trust")]
-    pub min_relay_trust: TrustScore,
+    pub min_relay_trust: f64,
 
     /// Enable topic name encryption
     /// Topic names will be encrypted so observers can't see what topics are subscribed
@@ -54,8 +53,8 @@ fn default_onion_hops() -> usize {
     2 // Default to 2 relay hops
 }
 
-fn default_min_relay_trust() -> TrustScore {
-    TrustScore::unchecked(0.3) // Minimum trust score for relay selection
+fn default_min_relay_trust() -> f64 {
+    0.3 // Minimum trust score for relay selection
 }
 
 fn default_padding_target() -> usize {

--- a/icn/crates/icn-core/src/config/trust.rs
+++ b/icn/crates/icn-core/src/config/trust.rs
@@ -27,7 +27,6 @@
 //! min_diversity_ratio = 0.2     # Required attester diversity
 //! ```
 
-use icn_trust::TrustScore;
 use serde::{Deserialize, Serialize};
 
 /// Trust graph configuration
@@ -52,7 +51,7 @@ pub struct AttestationConfig {
     /// Minimum trust score required to create attestations (0.0-1.0)
     /// Default: 0.3 (basic trust relationship)
     #[serde(default = "default_min_attester_trust")]
-    pub min_attester_trust: TrustScore,
+    pub min_attester_trust: f64,
 
     /// Maximum attestations per day per attester
     #[serde(default = "default_max_attestations_per_day")]
@@ -64,7 +63,7 @@ pub struct AttestationConfig {
 
     /// Minimum evidence score for attestations (0.0-1.0)
     #[serde(default = "default_min_evidence_score")]
-    pub min_evidence_score: TrustScore,
+    pub min_evidence_score: f64,
 }
 
 impl Default for AttestationConfig {
@@ -78,16 +77,16 @@ impl Default for AttestationConfig {
     }
 }
 
-fn default_min_attester_trust() -> TrustScore {
-    TrustScore::unchecked(0.3) // Require moderate trust to attest
+fn default_min_attester_trust() -> f64 {
+    0.3 // Require moderate trust to attest
 }
 
 fn default_max_attestations_per_day() -> usize {
     10 // Prevent spam while allowing legitimate use
 }
 
-fn default_min_evidence_score() -> TrustScore {
-    TrustScore::unchecked(0.5) // Require reasonable evidence quality
+fn default_min_evidence_score() -> f64 {
+    0.5 // Require reasonable evidence quality
 }
 
 /// Trust propagation configuration
@@ -100,11 +99,11 @@ pub struct PropagationConfig {
     /// Decay factor per hop (0.0-1.0)
     /// Trust score is multiplied by this factor for each hop
     #[serde(default = "default_decay_factor")]
-    pub decay_factor: TrustScore,
+    pub decay_factor: f64,
 
     /// Minimum edge trust to include in propagation (0.0-1.0)
     #[serde(default = "default_min_edge_trust")]
-    pub min_edge_trust: TrustScore,
+    pub min_edge_trust: f64,
 
     /// Enable trust caching for performance
     #[serde(default = "default_true")]
@@ -131,12 +130,12 @@ fn default_max_path_length() -> usize {
     3 // Balance reach and computation cost
 }
 
-fn default_decay_factor() -> TrustScore {
-    TrustScore::unchecked(0.8) // 20% decay per hop
+fn default_decay_factor() -> f64 {
+    0.8 // 20% decay per hop
 }
 
-fn default_min_edge_trust() -> TrustScore {
-    TrustScore::unchecked(0.1) // Include weak edges but not zero trust
+fn default_min_edge_trust() -> f64 {
+    0.1 // Include weak edges but not zero trust
 }
 
 fn default_cache_ttl_secs() -> u64 {
@@ -154,7 +153,7 @@ pub struct SybilResistanceConfig {
     /// If an attester vouches for entities with combined trust exceeding this,
     /// additional attestations have reduced weight
     #[serde(default = "default_max_trust_concentration")]
-    pub max_trust_concentration: TrustScore,
+    pub max_trust_concentration: f64,
 
     /// Network sampling size for sybil detection
     #[serde(default = "default_sample_size")]
@@ -163,7 +162,7 @@ pub struct SybilResistanceConfig {
     /// Minimum network diversity ratio (0.0-1.0)
     /// Entities with low diversity (few unique attesters) have reduced trust
     #[serde(default = "default_min_diversity_ratio")]
-    pub min_diversity_ratio: TrustScore,
+    pub min_diversity_ratio: f64,
 }
 
 impl Default for SybilResistanceConfig {
@@ -177,16 +176,16 @@ impl Default for SybilResistanceConfig {
     }
 }
 
-fn default_max_trust_concentration() -> TrustScore {
-    TrustScore::unchecked(0.3) // Prevent single attester from dominating
+fn default_max_trust_concentration() -> f64 {
+    0.3 // Prevent single attester from dominating
 }
 
 fn default_sample_size() -> usize {
     100 // Sample size for network analysis
 }
 
-fn default_min_diversity_ratio() -> TrustScore {
-    TrustScore::unchecked(0.2) // Require 20% unique attesters
+fn default_min_diversity_ratio() -> f64 {
+    0.2 // Require 20% unique attesters
 }
 
 fn default_true() -> bool {
@@ -202,40 +201,40 @@ mod tests {
         let config = TrustConfig::default();
 
         // Attestation defaults
-        assert_eq!(config.attestation.min_attester_trust.value(), 0.3);
+        assert_eq!(config.attestation.min_attester_trust, 0.3);
         assert_eq!(config.attestation.max_attestations_per_day, 10);
         assert!(config.attestation.evidence_required);
-        assert_eq!(config.attestation.min_evidence_score.value(), 0.5);
+        assert_eq!(config.attestation.min_evidence_score, 0.5);
 
         // Propagation defaults
         assert_eq!(config.propagation.max_path_length, 3);
-        assert_eq!(config.propagation.decay_factor.value(), 0.8);
-        assert_eq!(config.propagation.min_edge_trust.value(), 0.1);
+        assert_eq!(config.propagation.decay_factor, 0.8);
+        assert_eq!(config.propagation.min_edge_trust, 0.1);
         assert!(config.propagation.cache_enabled);
         assert_eq!(config.propagation.cache_ttl_secs, 300);
 
         // Sybil resistance defaults
         assert!(config.sybil_resistance.enabled);
-        assert_eq!(config.sybil_resistance.max_trust_concentration.value(), 0.3);
+        assert_eq!(config.sybil_resistance.max_trust_concentration, 0.3);
         assert_eq!(config.sybil_resistance.sample_size, 100);
-        assert_eq!(config.sybil_resistance.min_diversity_ratio.value(), 0.2);
+        assert_eq!(config.sybil_resistance.min_diversity_ratio, 0.2);
     }
 
     #[test]
     fn test_attestation_config_defaults() {
         let config = AttestationConfig::default();
-        assert_eq!(config.min_attester_trust.value(), 0.3);
+        assert_eq!(config.min_attester_trust, 0.3);
         assert_eq!(config.max_attestations_per_day, 10);
         assert!(config.evidence_required);
-        assert_eq!(config.min_evidence_score.value(), 0.5);
+        assert_eq!(config.min_evidence_score, 0.5);
     }
 
     #[test]
     fn test_propagation_config_defaults() {
         let config = PropagationConfig::default();
         assert_eq!(config.max_path_length, 3);
-        assert_eq!(config.decay_factor.value(), 0.8);
-        assert_eq!(config.min_edge_trust.value(), 0.1);
+        assert_eq!(config.decay_factor, 0.8);
+        assert_eq!(config.min_edge_trust, 0.1);
         assert!(config.cache_enabled);
         assert_eq!(config.cache_ttl_secs, 300);
     }
@@ -244,32 +243,32 @@ mod tests {
     fn test_sybil_resistance_config_defaults() {
         let config = SybilResistanceConfig::default();
         assert!(config.enabled);
-        assert_eq!(config.max_trust_concentration.value(), 0.3);
+        assert_eq!(config.max_trust_concentration, 0.3);
         assert_eq!(config.sample_size, 100);
-        assert_eq!(config.min_diversity_ratio.value(), 0.2);
+        assert_eq!(config.min_diversity_ratio, 0.2);
     }
 
     #[test]
     fn test_trust_config_toml_serialization() {
         let config = TrustConfig {
             attestation: AttestationConfig {
-                min_attester_trust: TrustScore::unchecked(0.5),
+                min_attester_trust: 0.5,
                 max_attestations_per_day: 20,
                 evidence_required: false,
-                min_evidence_score: TrustScore::unchecked(0.6),
+                min_evidence_score: 0.6,
             },
             propagation: PropagationConfig {
                 max_path_length: 5,
-                decay_factor: TrustScore::unchecked(0.9),
-                min_edge_trust: TrustScore::unchecked(0.2),
+                decay_factor: 0.9,
+                min_edge_trust: 0.2,
                 cache_enabled: false,
                 cache_ttl_secs: 600,
             },
             sybil_resistance: SybilResistanceConfig {
                 enabled: false,
-                max_trust_concentration: TrustScore::unchecked(0.4),
+                max_trust_concentration: 0.4,
                 sample_size: 200,
-                min_diversity_ratio: TrustScore::unchecked(0.3),
+                min_diversity_ratio: 0.3,
             },
         };
 
@@ -277,32 +276,23 @@ mod tests {
         let deserialized: TrustConfig = toml::from_str(&toml_str).unwrap();
 
         // Attestation
-        assert_eq!(deserialized.attestation.min_attester_trust.value(), 0.5);
+        assert_eq!(deserialized.attestation.min_attester_trust, 0.5);
         assert_eq!(deserialized.attestation.max_attestations_per_day, 20);
         assert!(!deserialized.attestation.evidence_required);
-        assert_eq!(deserialized.attestation.min_evidence_score.value(), 0.6);
+        assert_eq!(deserialized.attestation.min_evidence_score, 0.6);
 
         // Propagation
         assert_eq!(deserialized.propagation.max_path_length, 5);
-        assert_eq!(deserialized.propagation.decay_factor.value(), 0.9);
-        assert_eq!(deserialized.propagation.min_edge_trust.value(), 0.2);
+        assert_eq!(deserialized.propagation.decay_factor, 0.9);
+        assert_eq!(deserialized.propagation.min_edge_trust, 0.2);
         assert!(!deserialized.propagation.cache_enabled);
         assert_eq!(deserialized.propagation.cache_ttl_secs, 600);
 
         // Sybil resistance
         assert!(!deserialized.sybil_resistance.enabled);
-        assert_eq!(
-            deserialized
-                .sybil_resistance
-                .max_trust_concentration
-                .value(),
-            0.4
-        );
+        assert_eq!(deserialized.sybil_resistance.max_trust_concentration, 0.4);
         assert_eq!(deserialized.sybil_resistance.sample_size, 200);
-        assert_eq!(
-            deserialized.sybil_resistance.min_diversity_ratio.value(),
-            0.3
-        );
+        assert_eq!(deserialized.sybil_resistance.min_diversity_ratio, 0.3);
     }
 
     #[test]
@@ -321,13 +311,13 @@ sample_size = 150
         let config: TrustConfig = toml::from_str(toml_str).unwrap();
 
         // Explicitly set values
-        assert_eq!(config.attestation.min_attester_trust.value(), 0.4);
+        assert_eq!(config.attestation.min_attester_trust, 0.4);
         assert_eq!(config.propagation.max_path_length, 4);
         assert_eq!(config.sybil_resistance.sample_size, 150);
 
         // Default values
         assert_eq!(config.attestation.max_attestations_per_day, 10);
-        assert_eq!(config.propagation.decay_factor.value(), 0.8);
+        assert_eq!(config.propagation.decay_factor, 0.8);
         assert!(config.sybil_resistance.enabled);
     }
 
@@ -336,10 +326,10 @@ sample_size = 150
         let config = AttestationConfig::default();
 
         // Trust scores should be between 0 and 1
-        assert!(config.min_attester_trust.value() >= 0.0);
-        assert!(config.min_attester_trust.value() <= 1.0);
-        assert!(config.min_evidence_score.value() >= 0.0);
-        assert!(config.min_evidence_score.value() <= 1.0);
+        assert!(config.min_attester_trust >= 0.0);
+        assert!(config.min_attester_trust <= 1.0);
+        assert!(config.min_evidence_score >= 0.0);
+        assert!(config.min_evidence_score <= 1.0);
     }
 
     #[test]
@@ -347,10 +337,10 @@ sample_size = 150
         let config = PropagationConfig::default();
 
         // Trust scores and decay factor should be between 0 and 1
-        assert!(config.decay_factor.value() >= 0.0);
-        assert!(config.decay_factor.value() <= 1.0);
-        assert!(config.min_edge_trust.value() >= 0.0);
-        assert!(config.min_edge_trust.value() <= 1.0);
+        assert!(config.decay_factor >= 0.0);
+        assert!(config.decay_factor <= 1.0);
+        assert!(config.min_edge_trust >= 0.0);
+        assert!(config.min_edge_trust <= 1.0);
     }
 
     #[test]
@@ -358,10 +348,10 @@ sample_size = 150
         let config = SybilResistanceConfig::default();
 
         // Trust scores should be between 0 and 1
-        assert!(config.max_trust_concentration.value() >= 0.0);
-        assert!(config.max_trust_concentration.value() <= 1.0);
-        assert!(config.min_diversity_ratio.value() >= 0.0);
-        assert!(config.min_diversity_ratio.value() <= 1.0);
+        assert!(config.max_trust_concentration >= 0.0);
+        assert!(config.max_trust_concentration <= 1.0);
+        assert!(config.min_diversity_ratio >= 0.0);
+        assert!(config.min_diversity_ratio <= 1.0);
     }
 
     #[test]
@@ -371,8 +361,8 @@ sample_size = 150
         // Decay factor of 0.8 means 20% decay per hop, which is reasonable
         // Should be > 0 (otherwise trust would disappear immediately)
         // Should be < 1 (otherwise trust wouldn't decay)
-        assert!(config.decay_factor.value() > 0.0);
-        assert!(config.decay_factor.value() < 1.0);
+        assert!(config.decay_factor > 0.0);
+        assert!(config.decay_factor < 1.0);
     }
 
     #[test]

--- a/icn/crates/icn-core/src/lib.rs
+++ b/icn/crates/icn-core/src/lib.rs
@@ -46,7 +46,10 @@ pub use node::{
     CapabilityValue, ExtendedCapabilities, NodePolicy, NodeProfile, NodeStage, ProfileMessage,
     ResourceCaps, RolePolicy, ServiceRole, TOPIC_NODE_PROFILES,
 };
-pub use policy::{Capability, CapabilityQuota, DefaultPolicySource, PolicySource, TrustPolicy};
+pub use policy::{
+    Capability, CapabilityQuota, DefaultPolicySource, PolicySource, TrustPolicy,
+    TrustScoreProvider,
+};
 pub use replication::{
     AdjusterConfig, RepairAction, ReplicationConfig, ReplicationHandle, ReplicationManager,
     ScopeHealth, ScopedReplicationAdjuster,

--- a/icn/crates/icn-core/src/lib.rs
+++ b/icn/crates/icn-core/src/lib.rs
@@ -47,8 +47,7 @@ pub use node::{
     ResourceCaps, RolePolicy, ServiceRole, TOPIC_NODE_PROFILES,
 };
 pub use policy::{
-    Capability, CapabilityQuota, DefaultPolicySource, PolicySource, TrustPolicy,
-    TrustScoreProvider,
+    Capability, CapabilityQuota, DefaultPolicySource, PolicySource, TrustPolicy, TrustScoreProvider,
 };
 pub use replication::{
     AdjusterConfig, RepairAction, ReplicationConfig, ReplicationHandle, ReplicationManager,

--- a/icn/crates/icn-core/src/policy.rs
+++ b/icn/crates/icn-core/src/policy.rs
@@ -273,7 +273,31 @@ impl CapabilityQuota {
 /// ```
 #[async_trait::async_trait]
 pub trait TrustScoreProvider: Send + Sync {
-    /// Compute the trust score for a DID. Returns 0.0 for unknown DIDs.
+    /// Compute the trust score for a DID.
+    ///
+    /// # Contract
+    ///
+    /// - **Range**: Implementations MUST return a value in `[0.0, 1.0]`.
+    ///   Values outside this range will be clamped by consumers but indicate
+    ///   a bug in the provider.
+    /// - **Unknown DIDs**: Return `0.0` (Isolated trust class).
+    /// - **NaN / Infinity**: Must never be returned. Callers may treat NaN
+    ///   as 0.0 but this is a provider bug.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use icn_core::TrustScoreProvider;
+    ///
+    /// struct GraphProvider { /* wraps TrustGraph */ }
+    ///
+    /// #[async_trait::async_trait]
+    /// impl TrustScoreProvider for GraphProvider {
+    ///     async fn trust_score_for(&self, did: &icn_identity::Did) -> f64 {
+    ///         self.graph.compute_trust_score(did).unwrap_or(0.0)
+    ///     }
+    /// }
+    /// ```
     async fn trust_score_for(&self, did: &Did) -> f64;
 }
 

--- a/icn/crates/icn-core/src/policy.rs
+++ b/icn/crates/icn-core/src/policy.rs
@@ -251,6 +251,26 @@ impl CapabilityQuota {
 ///
 /// Implementations bridge from domain-specific trust computation
 /// (e.g. TrustGraph) to a simple f64 score the kernel can use.
+///
+/// # Production Usage
+///
+/// The production implementation lives in `apps/trust` and wraps a
+/// `TrustGraph`. Kernel code should obtain this via `TrustService`
+/// from the `ServiceRegistry` rather than constructing directly.
+///
+/// ```ignore
+/// struct TrustGraphProvider {
+///     graph: Arc<RwLock<TrustGraph>>,
+/// }
+///
+/// #[async_trait::async_trait]
+/// impl TrustScoreProvider for TrustGraphProvider {
+///     async fn trust_score_for(&self, did: &Did) -> f64 {
+///         let g = self.graph.read().await;
+///         g.compute_trust_score(did).unwrap_or(0.0)
+///     }
+/// }
+/// ```
 #[async_trait::async_trait]
 pub trait TrustScoreProvider: Send + Sync {
     /// Compute the trust score for a DID. Returns 0.0 for unknown DIDs.

--- a/icn/crates/icn-core/src/policy.rs
+++ b/icn/crates/icn-core/src/policy.rs
@@ -9,46 +9,18 @@
 //! - **PolicySource trait**: Abstraction for policy lookup
 //! - **TrustPolicy struct**: Per-peer policy combining limits + capabilities
 //! - **Capability enum**: Fine-grained permissions for operations
-//! - **DefaultPolicySource**: Default implementation using TrustGraph
-//!
-//! # Usage
-//!
-//! ```rust,no_run
-//! use icn_core::policy::{DefaultPolicySource, PolicySource, Capability};
-//! use std::sync::Arc;
-//! use tokio::sync::RwLock;
-//!
-//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! // Create policy source from trust graph
-//! let keypair = icn_identity::KeyPair::generate()?;
-//! let own_did = keypair.did().clone();
-//! let store = Arc::new(icn_store::SledStore::temporary()?);
-//! let trust_graph = Arc::new(RwLock::new(icn_trust::TrustGraph::new(store, own_did)));
-//! let policy_source = DefaultPolicySource::new(trust_graph);
-//!
-//! // Look up policy for a peer
-//! let peer_did = icn_identity::KeyPair::generate()?.did().clone();
-//! let policy = policy_source.policy_for(&peer_did).await;
-//!
-//! // Check capabilities
-//! if policy.has_capability(&Capability::DeployContract) {
-//!     // Allow contract deployment
-//! }
-//! # Ok(())
-//! # }
-//! ```
+//! - **TrustScoreProvider trait**: Abstraction for trust score computation
+//! - **DefaultPolicySource**: Implementation using any `TrustScoreProvider`
 
 use icn_identity::Did;
 use icn_kernel_api::TrustClass;
-use icn_trust::TrustGraph;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::RwLock;
 
 /// Trait for looking up trust policies
 ///
 /// This abstraction allows for different policy sources:
-/// - DefaultPolicySource: Uses TrustGraph
+/// - DefaultPolicySource: Uses a TrustScoreProvider
 /// - StaticPolicySource: Fixed policies for testing
 /// - RemotePolicySource: Fetch policies from remote server
 #[async_trait::async_trait]
@@ -275,26 +247,33 @@ impl CapabilityQuota {
     }
 }
 
-/// Default policy source using TrustGraph
+/// Trait for providing trust scores without depending on icn-trust types.
+///
+/// Implementations bridge from domain-specific trust computation
+/// (e.g. TrustGraph) to a simple f64 score the kernel can use.
+#[async_trait::async_trait]
+pub trait TrustScoreProvider: Send + Sync {
+    /// Compute the trust score for a DID. Returns 0.0 for unknown DIDs.
+    async fn trust_score_for(&self, did: &Did) -> f64;
+}
+
+/// Default policy source using a [`TrustScoreProvider`].
 pub struct DefaultPolicySource {
-    trust_graph: Arc<RwLock<TrustGraph>>,
+    provider: Arc<dyn TrustScoreProvider>,
 }
 
 impl DefaultPolicySource {
-    /// Create a new default policy source
-    pub fn new(trust_graph: Arc<RwLock<TrustGraph>>) -> Self {
-        DefaultPolicySource { trust_graph }
+    /// Create a new default policy source from any trust score provider.
+    pub fn new(provider: Arc<dyn TrustScoreProvider>) -> Self {
+        DefaultPolicySource { provider }
     }
 }
 
 #[async_trait::async_trait]
 impl PolicySource for DefaultPolicySource {
     async fn policy_for(&self, did: &Did) -> TrustPolicy {
-        let trust_graph = self.trust_graph.read().await;
-        // Get trust score and convert to kernel-api TrustClass
-        let score = trust_graph.compute_trust_score(did).unwrap_or(0.0);
+        let score = self.provider.trust_score_for(did).await;
         let class = TrustClass::from_score(score);
-
         TrustPolicy::for_trust_class(class)
     }
 }
@@ -303,7 +282,32 @@ impl PolicySource for DefaultPolicySource {
 mod tests {
     use super::*;
     use icn_identity::KeyPair;
-    use icn_trust::{TrustEdge, TrustScore};
+    use std::collections::HashMap as StdHashMap;
+    use tokio::sync::RwLock;
+
+    /// Mock trust score provider for testing
+    struct MockTrustScoreProvider {
+        scores: RwLock<StdHashMap<String, f64>>,
+    }
+
+    impl MockTrustScoreProvider {
+        fn new() -> Self {
+            Self {
+                scores: RwLock::new(StdHashMap::new()),
+            }
+        }
+
+        async fn set_score(&self, did: &str, score: f64) {
+            self.scores.write().await.insert(did.to_string(), score);
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl TrustScoreProvider for MockTrustScoreProvider {
+        async fn trust_score_for(&self, did: &Did) -> f64 {
+            *self.scores.read().await.get(did.as_str()).unwrap_or(&0.0)
+        }
+    }
 
     #[test]
     fn test_policy_isolated() {
@@ -367,14 +371,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_default_policy_source_isolated() {
-        use icn_store::SledStore;
+        let provider = Arc::new(MockTrustScoreProvider::new());
+        let policy_source = DefaultPolicySource::new(provider);
 
-        let store = Arc::new(SledStore::temporary().unwrap()) as Arc<dyn icn_store::Store>;
-        let own_did = KeyPair::generate().unwrap().did().clone();
-        let trust_graph = Arc::new(RwLock::new(TrustGraph::new(store, own_did)));
-        let policy_source = DefaultPolicySource::new(trust_graph.clone());
-
-        // Unknown peer should get isolated policy
+        // Unknown peer should get isolated policy (score 0.0)
         let unknown_did = KeyPair::generate().unwrap().did().clone();
         let policy = policy_source.policy_for(&unknown_did).await;
 
@@ -384,26 +384,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_default_policy_source_known() {
-        use icn_store::SledStore;
+        let provider = Arc::new(MockTrustScoreProvider::new());
 
-        let store = Arc::new(SledStore::temporary().unwrap()) as Arc<dyn icn_store::Store>;
-        let alice = KeyPair::generate().unwrap().did().clone();
-        let trust_graph = Arc::new(RwLock::new(TrustGraph::new(store, alice.clone())));
-        let policy_source = DefaultPolicySource::new(trust_graph.clone());
-
-        // Add trust edge - single edge gives Known class
+        // Set a trust score that maps to Known class (0.1-0.4)
         let bob = KeyPair::generate().unwrap().did().clone();
+        provider.set_score(bob.as_str(), 0.2).await;
 
-        {
-            let mut tg = trust_graph.write().await;
-            let _ = tg.add_edge(TrustEdge::new(
-                alice.clone(),
-                bob.clone(),
-                TrustScore::unchecked(0.5),
-            ));
-        }
-
+        let policy_source = DefaultPolicySource::new(provider);
         let policy = policy_source.policy_for(&bob).await;
+
         assert_eq!(policy.class, TrustClass::Known);
         assert_eq!(policy.max_messages_per_second, 50);
         assert!(policy.has_capability(&Capability::ReadLedger));


### PR DESCRIPTION
## Summary

- Replace all `TrustScore` newtype references with plain `f64` in config modules (`trust.rs`, `gossip.rs`, `network.rs`, `privacy.rs`, `mod.rs`)
- Introduce `TrustScoreProvider` trait in `policy.rs` to decouple `DefaultPolicySource` from concrete `icn_trust::TrustGraph`
- Remove 6 `use icn_trust::*` statements from production code

This is the first step toward fully removing `icn-trust` from kernel crates (#912). The remaining production files (identity.rs, trust_propagation.rs, supervisor/init_*.rs) use `TrustGraph` as a concrete type for graph mutations and will require a `TrustGraphOps` abstraction trait in a follow-up.

### Config Changes
- `min_replica_trust`, `min_trust_threshold`, `min_relay_trust`, and all trust config fields now use `f64` instead of `TrustScore`
- Range validation that was handled by `TrustScore::new()` at deserialization time is now a runtime concern
- Tests updated to parse sub-configs directly and verify f64 acceptance

### Policy Changes
- New `TrustScoreProvider` trait with `async trust_score_for(did) -> f64`
- `DefaultPolicySource` now accepts `Arc<dyn TrustScoreProvider>` instead of `Arc<RwLock<TrustGraph>>`
- Tests use `MockTrustScoreProvider` instead of real `TrustGraph`

## Remaining Work (follow-up)
- `identity.rs`: Needs abstract trust graph mutation interface
- `trust_propagation.rs`: Move to app crate (domain logic)
- `supervisor/init_*.rs`, `lifecycle.rs`, `actors.rs`: Replace `Arc<RwLock<TrustGraph>>` with abstract trait

## Test plan
- [x] `cargo check -p icn-core` — clean
- [x] `cargo clippy -p icn-core -- -D warnings` — clean
- [x] `cargo test -p icn-core --lib -- config` — 101 tests pass
- [x] `cargo test -p icn-core --lib -- validation` — 14 tests pass
- [x] `cargo test -p icn-core --lib -- policy` — 14 tests pass
- [x] Config TOML files (`icn-alpha.toml`, `icn-beta.toml`) still parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)