### PR TITLE
feat(ledger): add replay protection for commons credits (#967)

### DIFF
--- a/icn/crates/icn-compute/tests/commons_integration.rs
+++ b/icn/crates/icn-compute/tests/commons_integration.rs
@@ -150,7 +150,44 @@ fn test_scheduling_enforces_credits() {
     unimplemented!("credit enforcement at scheduling time is deferred to a future epic");
 }
 
-/// Test 6: Pool participant lifecycle — add, aggregate, remove, re-aggregate.
+/// Test 6: Receipt-backed earn entries produce distinct hashes (replay protection).
+#[test]
+fn test_receipt_backed_earn_entries_are_distinct() {
+    use icn_ledger::commons_credits::{build_earn_entry_with_receipt, SettlementDedup};
+
+    let contributor =
+        icn_identity::Did::from_str("did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9")
+            .unwrap();
+
+    // Simulate two separate execution receipts for the same amount
+    let receipt_a = [0xAA; 32];
+    let receipt_b = [0xBB; 32];
+
+    let entry_a = build_earn_entry_with_receipt(&contributor, 1000, receipt_a).unwrap();
+    let entry_b = build_earn_entry_with_receipt(&contributor, 1000, receipt_b).unwrap();
+
+    // Different receipt_ids → different content hashes
+    assert_ne!(
+        entry_a.id.as_ref().unwrap().0,
+        entry_b.id.as_ref().unwrap().0,
+        "two receipts for same amount must produce distinct journal entries"
+    );
+
+    // Both have nonces set
+    assert_eq!(entry_a.nonce, Some(receipt_a));
+    assert_eq!(entry_b.nonce, Some(receipt_b));
+
+    // SettlementDedup prevents double-settlement
+    let mut dedup = SettlementDedup::new();
+    assert!(dedup.try_settle(receipt_a).is_ok(), "first settlement ok");
+    assert!(dedup.try_settle(receipt_b).is_ok(), "second receipt ok");
+    assert!(
+        dedup.try_settle(receipt_a).is_err(),
+        "replaying receipt_a must fail"
+    );
+}
+
+/// Test 7: Pool participant lifecycle — add, aggregate, remove, re-aggregate.
 #[test]
 fn test_pool_participant_lifecycle() {
     let mut pool = CommonsPool::new();

--- a/icn/crates/icn-core/tests/treasury_integration.rs
+++ b/icn/crates/icn-core/tests/treasury_integration.rs
@@ -242,6 +242,7 @@ async fn test_spending_rule_enforcement() -> Result<()> {
             )],
             parents: vec![],
             signature: None,
+            nonce: None,
         };
 
         let result = guard.validate_entry(&entry);
@@ -275,6 +276,7 @@ async fn test_spending_rule_enforcement() -> Result<()> {
             )],
             parents: vec![],
             signature: None,
+            nonce: None,
         };
 
         let result = guard.validate_entry(&entry);
@@ -331,6 +333,7 @@ async fn test_spending_below_threshold_allowed() -> Result<()> {
             )],
             parents: vec![],
             signature: None,
+            nonce: None,
         };
 
         let result = guard.validate_entry(&entry);

--- a/icn/crates/icn-ledger/src/commons_credits.rs
+++ b/icn/crates/icn-ledger/src/commons_credits.rs
@@ -633,8 +633,7 @@ mod tests {
         let consumer =
             Did::from_str("did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9").unwrap();
 
-        let entry_with_nonce =
-            build_spend_entry_with_receipt(&consumer, 200, [0xCC; 32]).unwrap();
+        let entry_with_nonce = build_spend_entry_with_receipt(&consumer, 200, [0xCC; 32]).unwrap();
         assert!(
             entry_with_nonce.nonce.is_some(),
             "receipt-backed spend entry must have nonce set"

--- a/icn/crates/icn-ledger/src/commons_credits.rs
+++ b/icn/crates/icn-ledger/src/commons_credits.rs
@@ -385,11 +385,13 @@ impl SettlementDedup {
     }
 
     /// Number of receipts tracked.
+    #[must_use]
     pub fn len(&self) -> usize {
         self.settled.len()
     }
 
     /// Whether the tracker is empty.
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.settled.is_empty()
     }

--- a/icn/crates/icn-ledger/src/commons_credits.rs
+++ b/icn/crates/icn-ledger/src/commons_credits.rs
@@ -331,9 +331,13 @@ impl std::error::Error for InsufficientCredits {}
 /// Tracks which execution receipts have already been settled, preventing
 /// double-settlement of the same receipt.
 ///
-/// **Thread safety**: Wrap in `Arc<Mutex<_>>` or `Arc<RwLock<_>>` for
-/// concurrent access. This struct is intentionally not `Sync` — the
-/// caller chooses the locking strategy.
+/// **Thread safety**: This struct is `Send + Sync` but provides no
+/// internal synchronisation. Wrap in `Arc<Mutex<_>>` or `Arc<RwLock<_>>`
+/// for concurrent access — the caller chooses the locking strategy.
+///
+/// ```ignore
+/// let dedup = Arc::new(Mutex::new(SettlementDedup::new()));
+/// ```
 ///
 /// **Persistence**: In-memory only. On restart, the ledger's content-hash
 /// dedup provides a secondary defense (entries with the same nonce produce
@@ -629,7 +633,8 @@ mod tests {
         let consumer =
             Did::from_str("did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9").unwrap();
 
-        let entry_with_nonce = build_spend_entry_with_receipt(&consumer, 200, [0xCC; 32]).unwrap();
+        let entry_with_nonce =
+            build_spend_entry_with_receipt(&consumer, 200, [0xCC; 32]).unwrap();
         assert!(
             entry_with_nonce.nonce.is_some(),
             "receipt-backed spend entry must have nonce set"

--- a/icn/crates/icn-ledger/src/commons_credits.rs
+++ b/icn/crates/icn-ledger/src/commons_credits.rs
@@ -16,7 +16,7 @@ use crate::entry::JournalEntryBuilder;
 use crate::types::JournalEntry;
 use anyhow::Result;
 use icn_identity::Did;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 
 /// Currency identifier for commons credits.
@@ -184,22 +184,55 @@ pub fn compute_credits_earned(
 ///
 /// Debits the commons mint and credits the contributor.
 /// Rejects `amount <= 0`.
+///
+/// **Warning**: Without a nonce, identical earn amounts for the same
+/// contributor produce identical content hashes, which the ledger
+/// deduplicates. Prefer [`build_earn_entry_with_receipt`] for
+/// receipt-backed earnings.
 #[must_use = "journal entry should be appended to the ledger"]
 pub fn build_earn_entry(contributor: &Did, amount: i64) -> Result<JournalEntry> {
+    build_earn_entry_inner(contributor, amount, None)
+}
+
+/// Build a double-entry earn entry tied to a specific execution receipt.
+///
+/// The `receipt_id` is used as a nonce in the journal entry, ensuring
+/// that two separate earn events for the same amount produce distinct
+/// content hashes. This prevents silent deduplication of legitimate
+/// repeat earnings.
+#[must_use = "journal entry should be appended to the ledger"]
+pub fn build_earn_entry_with_receipt(
+    contributor: &Did,
+    amount: i64,
+    receipt_id: [u8; 32],
+) -> Result<JournalEntry> {
+    build_earn_entry_inner(contributor, amount, Some(receipt_id))
+}
+
+fn build_earn_entry_inner(
+    contributor: &Did,
+    amount: i64,
+    nonce: Option<[u8; 32]>,
+) -> Result<JournalEntry> {
     if amount <= 0 {
         anyhow::bail!("earn amount must be positive, got {amount}");
     }
 
     let mint_did = COMMONS_MINT_DID.clone();
 
-    let entry = JournalEntryBuilder::new(mint_did.clone())
+    let mut builder = JournalEntryBuilder::new(mint_did.clone())
         .debit(mint_did, COMMONS_CREDIT_CURRENCY.to_string(), amount)
         .credit(
             contributor.clone(),
             COMMONS_CREDIT_CURRENCY.to_string(),
             amount,
-        )
-        .build()?;
+        );
+
+    if let Some(n) = nonce {
+        builder = builder.nonce(n);
+    }
+
+    let entry = builder.build()?;
 
     icn_obs::metrics::compute::commons_credits_earned_add(amount as u64);
     Ok(entry)
@@ -209,22 +242,52 @@ pub fn build_earn_entry(contributor: &Did, amount: i64) -> Result<JournalEntry> 
 ///
 /// Debits the consumer and credits the commons mint.
 /// Rejects `amount <= 0`.
+///
+/// **Warning**: Without a nonce, identical spend amounts produce
+/// identical content hashes. Prefer [`build_spend_entry_with_receipt`]
+/// for receipt-backed spending.
 #[must_use = "journal entry should be appended to the ledger"]
 pub fn build_spend_entry(consumer: &Did, amount: i64) -> Result<JournalEntry> {
+    build_spend_entry_inner(consumer, amount, None)
+}
+
+/// Build a double-entry spend entry tied to a specific execution receipt.
+///
+/// The `receipt_id` is used as a nonce in the journal entry, preventing
+/// silent deduplication of legitimate repeat spend events.
+#[must_use = "journal entry should be appended to the ledger"]
+pub fn build_spend_entry_with_receipt(
+    consumer: &Did,
+    amount: i64,
+    receipt_id: [u8; 32],
+) -> Result<JournalEntry> {
+    build_spend_entry_inner(consumer, amount, Some(receipt_id))
+}
+
+fn build_spend_entry_inner(
+    consumer: &Did,
+    amount: i64,
+    nonce: Option<[u8; 32]>,
+) -> Result<JournalEntry> {
     if amount <= 0 {
         anyhow::bail!("spend amount must be positive, got {amount}");
     }
 
     let mint_did = COMMONS_MINT_DID.clone();
 
-    let entry = JournalEntryBuilder::new(consumer.clone())
+    let mut builder = JournalEntryBuilder::new(consumer.clone())
         .debit(
             consumer.clone(),
             COMMONS_CREDIT_CURRENCY.to_string(),
             amount,
         )
-        .credit(mint_did, COMMONS_CREDIT_CURRENCY.to_string(), amount)
-        .build()?;
+        .credit(mint_did, COMMONS_CREDIT_CURRENCY.to_string(), amount);
+
+    if let Some(n) = nonce {
+        builder = builder.nonce(n);
+    }
+
+    let entry = builder.build()?;
 
     icn_obs::metrics::compute::commons_credits_spent_add(amount as u64);
     Ok(entry)
@@ -260,6 +323,83 @@ impl std::fmt::Display for InsufficientCredits {
 }
 
 impl std::error::Error for InsufficientCredits {}
+
+// ---------------------------------------------------------------------------
+// Settlement deduplication (replay protection)
+// ---------------------------------------------------------------------------
+
+/// Tracks which execution receipts have already been settled, preventing
+/// double-settlement of the same receipt.
+///
+/// **Thread safety**: Wrap in `Arc<Mutex<_>>` or `Arc<RwLock<_>>` for
+/// concurrent access. This struct is intentionally not `Sync` — the
+/// caller chooses the locking strategy.
+///
+/// **Persistence**: In-memory only. On restart, the ledger's content-hash
+/// dedup provides a secondary defense (entries with the same nonce produce
+/// the same hash). For durable dedup across restarts, persist the set to
+/// the store.
+#[derive(Debug)]
+pub struct SettlementDedup {
+    settled: HashSet<[u8; 32]>,
+}
+
+/// Error returned when a receipt has already been settled.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DuplicateSettlement {
+    pub receipt_id: [u8; 32],
+}
+
+impl std::fmt::Display for DuplicateSettlement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "duplicate settlement: receipt {} already settled",
+            hex::encode(self.receipt_id)
+        )
+    }
+}
+
+impl std::error::Error for DuplicateSettlement {}
+
+impl SettlementDedup {
+    /// Create an empty dedup tracker.
+    pub fn new() -> Self {
+        Self {
+            settled: HashSet::new(),
+        }
+    }
+
+    /// Check and record a receipt_id. Returns `Ok(())` if this is the
+    /// first settlement, or `Err(DuplicateSettlement)` if already seen.
+    pub fn try_settle(&mut self, receipt_id: [u8; 32]) -> Result<(), DuplicateSettlement> {
+        if !self.settled.insert(receipt_id) {
+            return Err(DuplicateSettlement { receipt_id });
+        }
+        Ok(())
+    }
+
+    /// Check whether a receipt has already been settled without recording it.
+    pub fn is_settled(&self, receipt_id: &[u8; 32]) -> bool {
+        self.settled.contains(receipt_id)
+    }
+
+    /// Number of receipts tracked.
+    pub fn len(&self) -> usize {
+        self.settled.len()
+    }
+
+    /// Whether the tracker is empty.
+    pub fn is_empty(&self) -> bool {
+        self.settled.is_empty()
+    }
+}
+
+impl Default for SettlementDedup {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -424,5 +564,132 @@ mod tests {
         // DID B has its own cap
         let allowed = tracker.try_earn(&did_b, 500).unwrap();
         assert_eq!(allowed, 500);
+    }
+
+    // --- Replay protection tests ---
+
+    #[test]
+    fn test_earn_with_receipt_produces_distinct_hashes() {
+        let contributor =
+            Did::from_str("did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9").unwrap();
+
+        let entry1 = build_earn_entry_with_receipt(&contributor, 500, [0xAA; 32]).unwrap();
+        let entry2 = build_earn_entry_with_receipt(&contributor, 500, [0xBB; 32]).unwrap();
+
+        // Same amount, different receipt_ids → different content hashes
+        assert_ne!(
+            entry1.id.as_ref().unwrap().0,
+            entry2.id.as_ref().unwrap().0,
+            "different receipt_ids must produce different content hashes"
+        );
+    }
+
+    #[test]
+    fn test_earn_with_receipt_nonce_included_in_hash() {
+        // Verify the nonce actually affects the hash by comparing
+        // an entry with nonce vs without nonce (same amount, same author).
+        // Since timestamps differ between calls, we verify indirectly:
+        // two entries with different nonces always differ.
+        let contributor =
+            Did::from_str("did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9").unwrap();
+
+        let entry_with_nonce =
+            build_earn_entry_with_receipt(&contributor, 500, [0xAA; 32]).unwrap();
+        assert!(
+            entry_with_nonce.nonce.is_some(),
+            "receipt-backed entry must have nonce set"
+        );
+
+        let entry_without_nonce = build_earn_entry(&contributor, 500).unwrap();
+        assert!(
+            entry_without_nonce.nonce.is_none(),
+            "plain entry must not have nonce"
+        );
+    }
+
+    #[test]
+    fn test_spend_with_receipt_produces_distinct_hashes() {
+        let consumer =
+            Did::from_str("did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9").unwrap();
+
+        let entry1 = build_spend_entry_with_receipt(&consumer, 200, [0xCC; 32]).unwrap();
+        let entry2 = build_spend_entry_with_receipt(&consumer, 200, [0xDD; 32]).unwrap();
+
+        assert_ne!(
+            entry1.id.as_ref().unwrap().0,
+            entry2.id.as_ref().unwrap().0,
+            "different receipt_ids must produce different content hashes"
+        );
+    }
+
+    #[test]
+    fn test_spend_with_receipt_nonce_included_in_hash() {
+        let consumer =
+            Did::from_str("did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9").unwrap();
+
+        let entry_with_nonce = build_spend_entry_with_receipt(&consumer, 200, [0xCC; 32]).unwrap();
+        assert!(
+            entry_with_nonce.nonce.is_some(),
+            "receipt-backed spend entry must have nonce set"
+        );
+
+        let entry_without_nonce = build_spend_entry(&consumer, 200).unwrap();
+        assert!(
+            entry_without_nonce.nonce.is_none(),
+            "plain spend entry must not have nonce"
+        );
+    }
+
+    #[test]
+    fn test_earn_entry_has_nonce() {
+        let contributor =
+            Did::from_str("did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9").unwrap();
+
+        let entry = build_earn_entry_with_receipt(&contributor, 100, [0xFF; 32]).unwrap();
+        assert_eq!(entry.nonce, Some([0xFF; 32]));
+    }
+
+    #[test]
+    fn test_earn_entry_without_receipt_has_no_nonce() {
+        let contributor =
+            Did::from_str("did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9").unwrap();
+
+        let entry = build_earn_entry(&contributor, 100).unwrap();
+        assert_eq!(entry.nonce, None);
+    }
+
+    // --- Settlement dedup tests ---
+
+    #[test]
+    fn test_settlement_dedup_first_settle_succeeds() {
+        let mut dedup = SettlementDedup::new();
+        assert!(dedup.try_settle([0x01; 32]).is_ok());
+        assert_eq!(dedup.len(), 1);
+    }
+
+    #[test]
+    fn test_settlement_dedup_rejects_duplicate() {
+        let mut dedup = SettlementDedup::new();
+        assert!(dedup.try_settle([0x01; 32]).is_ok());
+
+        let err = dedup.try_settle([0x01; 32]).unwrap_err();
+        assert_eq!(err.receipt_id, [0x01; 32]);
+    }
+
+    #[test]
+    fn test_settlement_dedup_different_receipts_independent() {
+        let mut dedup = SettlementDedup::new();
+        assert!(dedup.try_settle([0x01; 32]).is_ok());
+        assert!(dedup.try_settle([0x02; 32]).is_ok());
+        assert_eq!(dedup.len(), 2);
+    }
+
+    #[test]
+    fn test_settlement_dedup_is_settled_query() {
+        let mut dedup = SettlementDedup::new();
+        assert!(!dedup.is_settled(&[0x01; 32]));
+        let _ = dedup.try_settle([0x01; 32]);
+        assert!(dedup.is_settled(&[0x01; 32]));
+        assert!(!dedup.is_settled(&[0x02; 32]));
     }
 }

--- a/icn/crates/icn-ledger/src/entry.rs
+++ b/icn/crates/icn-ledger/src/entry.rs
@@ -11,6 +11,7 @@ pub struct JournalEntryBuilder {
     contract_ref: Option<ContentHash>,
     accounts: Vec<AccountDelta>,
     parents: Vec<ContentHash>,
+    nonce: Option<[u8; 32]>,
 }
 
 impl JournalEntryBuilder {
@@ -21,6 +22,7 @@ impl JournalEntryBuilder {
             contract_ref: None,
             accounts: Vec::new(),
             parents: Vec::new(),
+            nonce: None,
         }
     }
 
@@ -56,6 +58,16 @@ impl JournalEntryBuilder {
         self
     }
 
+    /// Set a nonce for replay protection.
+    ///
+    /// When set, the nonce is included in the content hash, ensuring
+    /// entries with identical content produce distinct hashes. Use this
+    /// for commons credit entries where the nonce is the `receipt_id`.
+    pub fn nonce(mut self, nonce: [u8; 32]) -> Self {
+        self.nonce = Some(nonce);
+        self
+    }
+
     /// Build and validate the journal entry
     pub fn build(self) -> Result<JournalEntry> {
         // Validate double-entry invariant: Σ debits == Σ credits per currency
@@ -76,6 +88,7 @@ impl JournalEntryBuilder {
             accounts: self.accounts,
             parents: self.parents,
             signature: None, // Will be set by caller
+            nonce: self.nonce,
         };
 
         // Compute the content hash

--- a/icn/crates/icn-ledger/src/fork_resolution.rs
+++ b/icn/crates/icn-ledger/src/fork_resolution.rs
@@ -438,6 +438,7 @@ mod tests {
             }],
             parents,
             signature: None,
+            nonce: None,
         }
     }
 

--- a/icn/crates/icn-ledger/src/fx.rs
+++ b/icn/crates/icn-ledger/src/fx.rs
@@ -823,6 +823,7 @@ mod tests {
             accounts: vec![],
             parents: vec![],
             signature: None,
+            nonce: None,
         };
 
         PreparedFxTransfer {

--- a/icn/crates/icn-ledger/src/hash.rs
+++ b/icn/crates/icn-ledger/src/hash.rs
@@ -15,6 +15,7 @@ pub fn compute_entry_hash(entry: &JournalEntry) -> Result<ContentHash> {
         contract_ref: entry.contract_ref.as_ref(),
         accounts: &entry.accounts,
         parents: &entry.parents,
+        nonce: entry.nonce.as_ref(),
     };
 
     // Serialize to canonical JSON (sorted keys)
@@ -40,6 +41,8 @@ struct HashableEntry<'a> {
     contract_ref: Option<&'a ContentHash>,
     accounts: &'a [crate::types::AccountDelta],
     parents: &'a [ContentHash],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nonce: Option<&'a [u8; 32]>,
 }
 
 impl JournalEntry {
@@ -81,6 +84,7 @@ mod tests {
             ],
             parents: vec![],
             signature: None,
+            nonce: None,
         };
 
         let mut entry2 = entry1.clone();
@@ -107,6 +111,7 @@ mod tests {
             ],
             parents: vec![],
             signature: None,
+            nonce: None,
         };
 
         let mut entry2 = entry1.clone();
@@ -118,6 +123,68 @@ mod tests {
         assert_ne!(
             hash1, hash2,
             "Different content should produce different hash"
+        );
+    }
+
+    #[test]
+    fn test_nonce_changes_hash() {
+        let keypair = KeyPair::generate().unwrap();
+        let did = keypair.did().clone();
+
+        let mut entry1 = JournalEntry {
+            id: None,
+            timestamp: 1234567890,
+            author: did.clone(),
+            contract_ref: None,
+            accounts: vec![
+                AccountDelta::debit(did.clone(), "hours".to_string(), 10),
+                AccountDelta::credit(did.clone(), "hours".to_string(), 10),
+            ],
+            parents: vec![],
+            signature: None,
+            nonce: Some([0xAA; 32]),
+        };
+
+        let mut entry2 = entry1.clone();
+        entry2.nonce = Some([0xBB; 32]);
+
+        let hash1 = entry1.compute_hash().unwrap();
+        let hash2 = entry2.compute_hash().unwrap();
+
+        assert_ne!(
+            hash1, hash2,
+            "Different nonces should produce different hashes"
+        );
+    }
+
+    #[test]
+    fn test_nonce_vs_no_nonce_different_hash() {
+        let keypair = KeyPair::generate().unwrap();
+        let did = keypair.did().clone();
+
+        let mut entry_with = JournalEntry {
+            id: None,
+            timestamp: 1234567890,
+            author: did.clone(),
+            contract_ref: None,
+            accounts: vec![
+                AccountDelta::debit(did.clone(), "hours".to_string(), 10),
+                AccountDelta::credit(did.clone(), "hours".to_string(), 10),
+            ],
+            parents: vec![],
+            signature: None,
+            nonce: Some([0xAA; 32]),
+        };
+
+        let mut entry_without = entry_with.clone();
+        entry_without.nonce = None;
+
+        let hash_with = entry_with.compute_hash().unwrap();
+        let hash_without = entry_without.compute_hash().unwrap();
+
+        assert_ne!(
+            hash_with, hash_without,
+            "Entry with nonce must hash differently from entry without nonce"
         );
     }
 }

--- a/icn/crates/icn-ledger/src/hash.rs
+++ b/icn/crates/icn-ledger/src/hash.rs
@@ -41,7 +41,6 @@ struct HashableEntry<'a> {
     contract_ref: Option<&'a ContentHash>,
     accounts: &'a [crate::types::AccountDelta],
     parents: &'a [ContentHash],
-    #[serde(skip_serializing_if = "Option::is_none")]
     nonce: Option<&'a [u8; 32]>,
 }
 

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -4494,6 +4494,7 @@ mod tests {
             ],
             parents: vec![],
             signature: None,
+            nonce: None,
         };
 
         let current_time = icn_time::current_timestamp_secs();

--- a/icn/crates/icn-ledger/src/types.rs
+++ b/icn/crates/icn-ledger/src/types.rs
@@ -60,6 +60,22 @@ pub struct JournalEntry {
 
     /// Signature by author
     pub signature: Option<Signature>,
+
+    /// Optional nonce for replay protection.
+    ///
+    /// When present, the nonce is included in the content hash computation,
+    /// ensuring that entries with identical amounts/accounts/timestamps
+    /// produce distinct hashes. This prevents silent deduplication of
+    /// legitimate repeat transactions (e.g., two separate earn events
+    /// for the same amount).
+    ///
+    /// For commons credit entries, this should be set to the `receipt_id`
+    /// of the `ExecutionReceipt` that triggered the earn/spend.
+    ///
+    /// Note: Do NOT use `skip_serializing_if` here — postcard (used for
+    /// persistent storage) is a non-self-describing format and requires
+    /// the Option discriminant to always be present.
+    pub nonce: Option<[u8; 32]>,
 }
 
 /// Delta for a single account in a journal entry
@@ -289,7 +305,7 @@ pub enum Resolution {
     Reject,
 
     /// Merge with modifications
-    Merge(JournalEntry),
+    Merge(Box<JournalEntry>),
 }
 
 /// Dispute status for a journal entry

--- a/icn/crates/icn-ledger/src/types.rs
+++ b/icn/crates/icn-ledger/src/types.rs
@@ -72,9 +72,10 @@ pub struct JournalEntry {
     /// For commons credit entries, this should be set to the `receipt_id`
     /// of the `ExecutionReceipt` that triggered the earn/spend.
     ///
-    /// Note: Do NOT use `skip_serializing_if` here — postcard (used for
-    /// persistent storage) is a non-self-describing format and requires
-    /// the Option discriminant to always be present.
+    /// Note: Do NOT use `skip_serializing_if` here — while the ledger
+    /// currently uses serde_json (which tolerates missing fields),
+    /// omitting `None` would change the canonical JSON representation
+    /// and thus the content hash, breaking deduplication.
     pub nonce: Option<[u8; 32]>,
 }
 


### PR DESCRIPTION
## Summary

- Adds `nonce: Option<[u8; 32]>` field to `JournalEntry`, included in content hash computation — entries with identical amounts/accounts but different nonces produce distinct hashes
- Adds `build_earn_entry_with_receipt()` and `build_spend_entry_with_receipt()` that accept a `receipt_id` as nonce, tying journal entries to specific `ExecutionReceipt`s
- Adds `SettlementDedup` tracker (in-memory `HashSet<[u8; 32]>`) that rejects double-settlement of the same receipt, providing fast-path dedup before the ledger's content-hash dedup layer

Closes #967

## What was the problem?

Without a nonce, two earn events for the same DID and amount produce identical content hashes. The ledger's content-hash dedup silently drops the second entry — credits are lost. An attacker could also replay a settlement to double-earn.

## How it works

Three layers of defense:
1. **JournalEntry nonce** — makes identical-looking entries produce distinct hashes
2. **Receipt-backed builders** — tie journal entries to specific execution receipts via `receipt_id`
3. **SettlementDedup** — fast in-memory check before hitting the ledger

Existing `build_earn_entry()` / `build_spend_entry()` still work (no nonce, backward compatible). Receipt-backed variants are opt-in.

## Test plan
- [x] `test_nonce_changes_hash` — different nonces → different hashes
- [x] `test_nonce_vs_no_nonce_different_hash` — nonce vs no-nonce → different hashes
- [x] `test_earn_with_receipt_produces_distinct_hashes` — same amount, different receipts → distinct entries
- [x] `test_earn_entry_has_nonce` / `test_earn_entry_without_receipt_has_no_nonce` — nonce field presence
- [x] `test_settlement_dedup_*` — 4 tests for SettlementDedup (first settle, reject dup, independent receipts, is_settled query)
- [x] `test_receipt_backed_earn_entries_are_distinct` — integration test in icn-compute
- [x] All 338 icn-ledger tests pass
- [x] All dependent crate tests pass (icn-core, icn-compute, icn-ccl, icn-gateway)
- [x] clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)