### PR TITLE
refactor(core): decouple ResourceEnforcerActor from icn-ledger via LedgerService (#914)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed - Decouple ResourceEnforcerActor from icn-ledger (2026-01-30)
+
+**PR 3.1 Kernel/App Separation** (PR #979):
+
+Replace direct `icn-ledger` type imports in `ResourceEnforcerActor` with `LedgerService` trait calls from `icn-kernel-api`. The enforcer now queries resources and revokes access through the abstract service interface, removing 6 raw type imports.
+
+- Add `list_enforceable_resources()` and `revoke_resource_access()` to `LedgerService` trait with kernel-level DTOs (`ResourceAccessInfo`, `IdleViolationInfo`, `RevokeResourceAccessRequest`)
+- Replace `ResourceAccessStore`, `AccessModel`, `AntiSpeculationRules` imports with `LedgerService` method calls
+- Change `RevocationEvent.holder` and `ResourceAccessInfo.holder` to `Did` type (was `String`)
+- Add default implementations for new `LedgerService` methods (empty list / "not supported" error)
+- Add `test_enforce_without_gossip` test verifying enforcement works without gossip dependency
+- Rewrite `resource_enforcer_gossip` integration tests to use `LedgerService`-based stubs
+
+**Known Limitations**: Resource access enforcement is a no-op until PR 3.2 wires `SledResourceAccessStore` into `apps/ledger`. The `list_enforceable_resources()` stub returns an empty list, so no resources are checked or revoked in production.
+
 ### Changed - Remove icn-trust from icn-core (2026-01-31)
 
 **Tier 1 Kernel/App Separation** (PR #977):

--- a/apps/ledger/Cargo.toml
+++ b/apps/ledger/Cargo.toml
@@ -29,6 +29,9 @@ anyhow = "1.0"
 # Logging
 tracing = "0.1"
 
+# Metrics
+metrics = "0.24"
+
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tempfile = "3"

--- a/apps/ledger/src/service.rs
+++ b/apps/ledger/src/service.rs
@@ -42,7 +42,7 @@ impl LedgerServiceImpl {
     fn to_identity_did(did: &Did) -> Result<icn_identity::Did, anyhow::Error> {
         did.to_string()
             .parse::<icn_identity::Did>()
-            .map_err(|e| anyhow::anyhow!("Invalid DID format: {}", e))
+            .map_err(|e| anyhow::anyhow!("Invalid DID format: {e}"))
     }
 }
 
@@ -57,6 +57,7 @@ impl LedgerService for LedgerServiceImpl {
             Ok(did) => did,
             Err(e) => {
                 warn!(error = %e, "Failed to parse DID for balance query");
+                metrics::counter!("icn_ledger_did_parse_failures_total").increment(1);
                 return 0;
             }
         };
@@ -153,7 +154,8 @@ impl LedgerService for LedgerServiceImpl {
     fn revoke_resource_access(&self, _req: &RevokeResourceAccessRequest) -> Result<(), String> {
         // TODO(PR 3.2): Wire SledResourceAccessStore when init_ledger moves
         // to apps/ledger.
-        Err("Resource access revocation not yet implemented".to_string())
+        // TODO(PR 3.2): Wire SledResourceAccessStore
+        Err("Resource access revocation not supported".to_string())
     }
 }
 

--- a/apps/ledger/src/service.rs
+++ b/apps/ledger/src/service.rs
@@ -4,7 +4,9 @@
 //! This provides the full ledger interface for kernel integration.
 
 use icn_kernel_api::authz::PolicyOracle;
-use icn_kernel_api::services::{LedgerEvent, LedgerService};
+use icn_kernel_api::services::{
+    LedgerEvent, LedgerService, ResourceAccessInfo, RevokeResourceAccessRequest,
+};
 use icn_kernel_api::types::Did;
 use icn_ledger::Ledger;
 use std::sync::Arc;
@@ -136,6 +138,22 @@ impl LedgerService for LedgerServiceImpl {
 
         // TODO: Emit metrics
         // icn_obs::metrics::ledger::event_recorded_inc(&event_type);
+    }
+
+    fn list_enforceable_resources(
+        &self,
+        _current_time: u64,
+    ) -> Result<Vec<ResourceAccessInfo>, String> {
+        // TODO(PR 3.2): Wire SledResourceAccessStore when init_ledger moves
+        // to apps/ledger. Currently returns empty because no persistent
+        // resource access backend is connected to the ledger.
+        Ok(Vec::new())
+    }
+
+    fn revoke_resource_access(&self, _req: &RevokeResourceAccessRequest) -> Result<(), String> {
+        // TODO(PR 3.2): Wire SledResourceAccessStore when init_ledger moves
+        // to apps/ledger.
+        Err("Resource access revocation not yet implemented".to_string())
     }
 }
 

--- a/apps/ledger/src/service.rs
+++ b/apps/ledger/src/service.rs
@@ -154,7 +154,6 @@ impl LedgerService for LedgerServiceImpl {
     fn revoke_resource_access(&self, _req: &RevokeResourceAccessRequest) -> Result<(), String> {
         // TODO(PR 3.2): Wire SledResourceAccessStore when init_ledger moves
         // to apps/ledger.
-        // TODO(PR 3.2): Wire SledResourceAccessStore
         Err("Resource access revocation not supported".to_string())
     }
 }

--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -3269,6 +3269,7 @@ dependencies = [
  "icn-kernel-api",
  "icn-ledger",
  "icn-store",
+ "metrics",
  "parking_lot 0.12.5",
  "tokio",
  "tracing",

--- a/icn/crates/icn-core/src/lib.rs
+++ b/icn/crates/icn-core/src/lib.rs
@@ -54,8 +54,8 @@ pub use replication::{
     ScopeHealth, ScopedReplicationAdjuster,
 };
 pub use resource_enforcer_actor::{
-    EnforcementResult, EnforcementStats, ResourceAccessEnforcerActor, ResourceAccessStore,
-    ResourceEnforcerConfig, ResourceEnforcerHandle, RevocationEvent, RESOURCE_REVOCATIONS_TOPIC,
+    EnforcementResult, EnforcementStats, ResourceAccessEnforcerActor, ResourceEnforcerConfig,
+    ResourceEnforcerDeps, ResourceEnforcerHandle, RevocationEvent, RESOURCE_REVOCATIONS_TOPIC,
 };
 pub use runtime::Runtime;
 pub use storage_challenge::{ChallengeScheduler, ChallengeSchedulerHandle};

--- a/icn/crates/icn-core/src/resource_enforcer_actor.rs
+++ b/icn/crates/icn-core/src/resource_enforcer_actor.rs
@@ -6,9 +6,8 @@
 //!
 //! # Architecture
 //! - Runs as a background task with configurable interval
-//! - Queries storage for all ResourceAccess entries
-//! - Validates each against idle period rules
-//! - Auto-revokes access that exceeds max_idle_period_seconds
+//! - Queries the LedgerService for enforceable resources with idle violations
+//! - Revokes resources that exceed max_idle_period_seconds
 //! - Emits revocation events for audit trail
 //! - Publishes revocations to gossip topic for cluster-wide notification
 //!
@@ -21,12 +20,15 @@
 //! }
 //! ```
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use rand::Rng;
 use std::sync::Arc;
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::mpsc;
 use tokio::time::{interval, Duration, MissedTickBehavior};
 use tracing::{debug, error, info, warn};
+
+use icn_kernel_api::services::LedgerService;
+use icn_kernel_api::types::Did;
 
 use crate::runtime::ShutdownRx;
 
@@ -100,8 +102,8 @@ impl ResourceEnforcerConfig {
 pub struct RevocationEvent {
     /// Resource ID that was revoked
     pub resource_id: String,
-    /// Entity whose access was revoked
-    pub holder: icn_entity::EntityId,
+    /// DID of the entity whose access was revoked
+    pub holder: Did,
     /// Reason for revocation
     pub reason: String,
     /// Timestamp when revoked
@@ -180,30 +182,21 @@ impl ResourceEnforcerHandle {
     }
 }
 
-/// Storage interface for ResourceAccess entries
-///
-/// This trait abstracts the storage layer to allow for testing
-/// and different storage backends.
-pub trait ResourceAccessStore: Send + Sync {
-    /// List all resource access entries
-    ///
-    /// Returns a list of (resource_id, ResourceAccess) pairs.
-    /// In a real implementation, this would query the persistent store.
-    fn list_all(&self) -> Result<Vec<(String, icn_ledger::ResourceAccess)>>;
-
-    /// Update a resource access entry after revocation
-    fn update(&mut self, resource_id: &str, access: &icn_ledger::ResourceAccess) -> Result<()>;
-
-    /// Emit a revocation event for audit trail
-    fn emit_revocation(&mut self, event: RevocationEvent) -> Result<()>;
+/// Dependencies for spawning the resource enforcer actor
+pub struct ResourceEnforcerDeps {
+    /// The ledger service used to query and revoke resource access
+    pub ledger_service: Arc<dyn LedgerService>,
+    /// Optional gossip handle for publishing revocations cluster-wide
+    pub gossip_handle: Option<Arc<tokio::sync::RwLock<icn_gossip::GossipActor>>>,
 }
 
 /// Resource Access Enforcer Actor
 ///
-/// Periodically checks resource access entries and revokes idle ones.
+/// Periodically checks resource access entries and revokes idle ones
+/// using the LedgerService interface.
 pub struct ResourceAccessEnforcerActor {
     config: ResourceEnforcerConfig,
-    store: Arc<RwLock<dyn ResourceAccessStore>>,
+    deps: ResourceEnforcerDeps,
     stats: EnforcementStats,
 }
 
@@ -212,21 +205,21 @@ impl ResourceAccessEnforcerActor {
     ///
     /// # Arguments
     /// * `config` - Enforcement configuration
-    /// * `store` - Storage backend for ResourceAccess entries
+    /// * `deps` - Dependencies (LedgerService, optional gossip)
     /// * `shutdown_rx` - Shutdown signal receiver
     ///
     /// # Returns
     /// Handle for interacting with the actor
     pub fn spawn(
         config: ResourceEnforcerConfig,
-        store: Arc<RwLock<dyn ResourceAccessStore>>,
+        deps: ResourceEnforcerDeps,
         mut shutdown_rx: ShutdownRx,
     ) -> ResourceEnforcerHandle {
         let (tx, mut rx) = mpsc::channel::<EnforcerActorMsg>(32);
 
         let mut actor = ResourceAccessEnforcerActor {
             config: config.clone(),
-            store,
+            deps,
             stats: EnforcementStats {
                 checks_performed: 0,
                 resources_checked: 0,
@@ -310,20 +303,10 @@ impl ResourceAccessEnforcerActor {
         }
     }
 
-    /// Perform an enforcement check on all resource access entries
+    /// Perform an enforcement check using LedgerService
     ///
-    /// This method batches updates to reduce lock contention. It first identifies
-    /// all resources that need revocation during a read phase, then acquires the
-    /// write lock once to perform all updates together.
-    ///
-    /// # Performance Note
-    ///
-    /// Currently, `list_all()` loads all resources into memory before processing.
-    /// The `batch_size` config only affects the iteration chunk size for CPU-bound
-    /// work, not memory usage. For deployments with 10K+ resources, consider:
-    /// - Adding pagination support to [`ResourceAccessStore::list_all`]
-    /// - Implementing cursor-based iteration
-    /// - Monitoring memory usage via metrics
+    /// Queries the ledger for enforceable resources, identifies idle violations,
+    /// revokes violating resources, and publishes revocation events.
     async fn perform_enforcement_check(&mut self) -> Result<EnforcementResult> {
         let current_time = icn_time::current_timestamp_secs();
         debug!("Starting enforcement check at timestamp {}", current_time);
@@ -331,85 +314,64 @@ impl ResourceAccessEnforcerActor {
         self.stats.checks_performed += 1;
         self.stats.last_check_time = Some(current_time);
 
-        // Phase 1: Read all resources and identify which need revocation
-        let store_read = self.store.read().await;
-        let all_resources = store_read
-            .list_all()
-            .context("Failed to list resource access entries")?;
-        drop(store_read);
+        // Query LedgerService for all enforceable resources with idle status
+        let resources = self
+            .deps
+            .ledger_service
+            .list_enforceable_resources(current_time)
+            .map_err(|e| anyhow::anyhow!("Failed to list enforceable resources: {e}"))?;
 
-        let resources_checked = all_resources.len();
+        let resources_checked = resources.len();
 
-        // Collect resources that need revocation (resource_id, updated_access, event)
-        let mut pending_revocations: Vec<(String, icn_ledger::ResourceAccess, RevocationEvent)> =
-            Vec::new();
+        // Identify and process resources with idle violations
+        let mut revocations = 0;
 
-        // Process in batches to identify revocations
-        // Note: We iterate by reference first, only cloning resources that need revocation.
-        // This avoids cloning every resource, which is important for large collections.
-        for chunk in all_resources.chunks(self.config.batch_size) {
-            for (resource_id, access) in chunk.iter() {
-                // Skip already revoked resources
-                if access.is_revoked() {
+        for chunk in resources.chunks(self.config.batch_size) {
+            for resource in chunk {
+                if resource.is_revoked {
                     continue;
                 }
 
-                // Validate against anti-speculation rules
-                if let Err(icn_ledger::AccessError::IdleTooLong {
-                    idle_seconds,
-                    max_idle_seconds,
-                }) = access.validate_rules(current_time)
-                {
-                    // Clone only when revocation is needed
-                    let mut access_clone = access.clone();
-
-                    // Revoke the access
+                if let Some(ref violation) = resource.idle_violation {
                     let reason = format!(
                         "Automatically revoked: idle for {}s (max: {}s)",
-                        idle_seconds, max_idle_seconds
+                        violation.idle_seconds, violation.max_idle_seconds
                     );
 
                     info!(
                         "Revoking access for resource '{}' (holder: {}): {}",
-                        resource_id, access_clone.holder, reason
+                        resource.resource_id, resource.holder, reason
                     );
 
-                    access_clone.revoke(reason.clone());
-
-                    // Prepare revocation event
-                    let event = RevocationEvent {
-                        resource_id: resource_id.clone(),
-                        holder: access_clone.holder.clone(),
-                        reason,
-                        timestamp: current_time,
-                        idle_seconds,
+                    // Revoke via LedgerService
+                    let req = icn_kernel_api::services::RevokeResourceAccessRequest {
+                        resource_id: resource.resource_id.clone(),
+                        reason: reason.clone(),
                     };
 
-                    pending_revocations.push((resource_id.clone(), access_clone, event));
+                    if let Err(e) = self.deps.ledger_service.revoke_resource_access(&req) {
+                        warn!(
+                            "Failed to revoke resource '{}': {}",
+                            resource.resource_id, e
+                        );
+                        continue;
+                    }
+
+                    // Publish revocation event to gossip
+                    let event = RevocationEvent {
+                        resource_id: resource.resource_id.clone(),
+                        holder: resource.holder.clone(),
+                        reason,
+                        timestamp: current_time,
+                        idle_seconds: violation.idle_seconds,
+                    };
+
+                    self.publish_revocation(&event).await;
+
+                    revocations += 1;
+                    metrics::counter!("icn_resource_access_revoked_total").increment(1);
                 }
             }
-        }
-
-        let revocations = pending_revocations.len();
-
-        // Phase 2: Acquire write lock once and apply all revocations
-        if !pending_revocations.is_empty() {
-            let mut store_write = self.store.write().await;
-
-            for (resource_id, access, event) in pending_revocations {
-                store_write
-                    .update(&resource_id, &access)
-                    .context("Failed to update resource access")?;
-
-                store_write
-                    .emit_revocation(event)
-                    .context("Failed to emit revocation event")?;
-
-                // Update per-revocation metrics
-                metrics::counter!("icn_resource_access_revoked_total").increment(1);
-            }
-
-            drop(store_write);
         }
 
         self.stats.resources_checked += resources_checked as u64;
@@ -420,7 +382,7 @@ impl ResourceAccessEnforcerActor {
             resources_checked, revocations
         );
 
-        // Update metrics - using counters for cumulative tracking
+        // Update metrics
         metrics::counter!("icn_resource_enforcer_checks_total").increment(1);
         metrics::counter!("icn_resource_enforcer_resources_checked_total")
             .increment(resources_checked as u64);
@@ -432,71 +394,51 @@ impl ResourceAccessEnforcerActor {
             timestamp: current_time,
         })
     }
+
+    /// Publish a revocation event to gossip for cluster-wide notification.
+    ///
+    /// Best-effort: if gossip is unavailable, the event is logged but not retried.
+    async fn publish_revocation(&self, event: &RevocationEvent) {
+        let gossip_handle = match &self.deps.gossip_handle {
+            Some(h) => h.clone(),
+            None => return,
+        };
+
+        let serialized = match serde_json::to_vec(event) {
+            Ok(data) => data,
+            Err(e) => {
+                warn!("Failed to serialize revocation event: {}", e);
+                metrics::counter!(
+                    "icn_resource_revocation_gossip_failures_total",
+                    "reason" => "serialization"
+                )
+                .increment(1);
+                return;
+            }
+        };
+
+        let mut gossip = gossip_handle.write().await;
+        if let Err(e) = gossip.publish(RESOURCE_REVOCATIONS_TOPIC, serialized).await {
+            warn!("Failed to publish revocation to gossip: {}", e);
+            metrics::counter!(
+                "icn_resource_revocation_gossip_failures_total",
+                "reason" => "publish"
+            )
+            .increment(1);
+        } else {
+            info!(
+                resource_id = %event.resource_id,
+                holder = %event.holder,
+                "Published revocation event to gossip"
+            );
+            metrics::counter!("icn_resource_revocation_gossip_published_total").increment(1);
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icn_entity::EntityId;
-    use icn_identity::KeyPair;
-    use icn_ledger::{AccessModel, AntiSpeculationRules, ResourceAccess};
-    use std::collections::HashMap;
-    use std::sync::Mutex;
-
-    /// Mock storage for testing
-    struct MockResourceAccessStore {
-        resources: Mutex<HashMap<String, ResourceAccess>>,
-        events: Mutex<Vec<RevocationEvent>>,
-    }
-
-    impl MockResourceAccessStore {
-        fn new() -> Self {
-            Self {
-                resources: Mutex::new(HashMap::new()),
-                events: Mutex::new(Vec::new()),
-            }
-        }
-
-        fn add_resource(&self, id: String, access: ResourceAccess) {
-            self.resources.lock().map(|mut r| r.insert(id, access)).ok();
-        }
-
-        #[allow(dead_code)]
-        fn get_events(&self) -> Vec<RevocationEvent> {
-            self.events.lock().map(|e| e.clone()).unwrap_or_default()
-        }
-    }
-
-    impl ResourceAccessStore for MockResourceAccessStore {
-        fn list_all(&self) -> Result<Vec<(String, ResourceAccess)>> {
-            let resources = self
-                .resources
-                .lock()
-                .map_err(|e| anyhow::anyhow!("Failed to lock resources: {}", e))?;
-            Ok(resources
-                .iter()
-                .map(|(k, v)| (k.clone(), v.clone()))
-                .collect())
-        }
-
-        fn update(&mut self, resource_id: &str, access: &ResourceAccess) -> Result<()> {
-            let mut resources = self
-                .resources
-                .lock()
-                .map_err(|e| anyhow::anyhow!("Failed to lock resources: {}", e))?;
-            resources.insert(resource_id.to_string(), access.clone());
-            Ok(())
-        }
-
-        fn emit_revocation(&mut self, event: RevocationEvent) -> Result<()> {
-            let mut events = self
-                .events
-                .lock()
-                .map_err(|e| anyhow::anyhow!("Failed to lock events: {}", e))?;
-            events.push(event);
-            Ok(())
-        }
-    }
 
     #[test]
     fn test_config_defaults() {
@@ -525,216 +467,89 @@ mod tests {
         assert_eq!(config.enabled, deserialized.enabled);
     }
 
+    #[test]
+    fn test_revocation_event_serialization() {
+        let event = RevocationEvent {
+            resource_id: "test-resource".to_string(),
+            holder: "did:icn:abc123".to_string(),
+            reason: "Idle too long".to_string(),
+            timestamp: 1000000,
+            idle_seconds: 86400,
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        let deserialized: RevocationEvent = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(event.resource_id, deserialized.resource_id);
+        assert_eq!(event.holder, deserialized.holder);
+        assert_eq!(event.idle_seconds, deserialized.idle_seconds);
+    }
+
+    /// Verify that the actor works correctly when gossip_handle is None.
+    /// Enforcement should still occur; revocations are just not broadcast.
     #[tokio::test]
-    async fn test_enforcement_check_idle_revocation() {
-        let store = Arc::new(RwLock::new(MockResourceAccessStore::new()));
+    async fn test_enforce_without_gossip() {
+        use icn_kernel_api::services::{LedgerService, ResourceAccessInfo};
 
-        // Create a resource with strict idle rules (7 days)
-        let entity = EntityId::from_did(KeyPair::generate().unwrap().did());
-        let mut access = ResourceAccess::new(
-            "test-resource-001".to_string(),
-            entity.clone(),
-            AccessModel::UseAccess {
-                duration_seconds: 90 * 24 * 3600, // 90 days
-                renewable: true,
-                max_accumulated: 4,
-            },
-        )
-        .with_rules(AntiSpeculationRules::strict()); // 7-day idle limit
-
-        // Record usage at grant time
-        access
-            .record_usage(access.granted_at, "Initial use".to_string())
-            .unwrap();
-
-        // Add to mock store
-        store
-            .write()
-            .await
-            .add_resource("test-resource-001".to_string(), access.clone());
-
-        // Fast-forward time by 8 days (exceeds 7-day limit)
-        // Note: In a real test, we'd need to mock icn_time::current_timestamp_secs()
-        // For now, we test the logic manually
-
-        let current_time = access.granted_at + 8 * 24 * 3600;
-
-        // Manually test the validation logic
-        let validation_result = access.validate_rules(current_time);
-        assert!(validation_result.is_err());
-
-        if let Err(icn_ledger::AccessError::IdleTooLong { idle_seconds, .. }) = validation_result {
-            assert!(idle_seconds >= 7 * 24 * 3600);
-        } else {
-            panic!("Expected IdleTooLong error");
+        struct StubLedger;
+        impl LedgerService for StubLedger {
+            fn oracle(&self) -> Arc<dyn icn_kernel_api::authz::PolicyOracle> {
+                unimplemented!()
+            }
+            fn balance(&self, _: &icn_kernel_api::types::Did, _: &str) -> i64 {
+                0
+            }
+            fn credit_limit(&self, _: &icn_kernel_api::types::Did, _: &str) -> i64 {
+                0
+            }
+            fn record_event(&self, _: icn_kernel_api::services::LedgerEvent) {}
+            fn list_enforceable_resources(
+                &self,
+                _current_time: u64,
+            ) -> Result<Vec<ResourceAccessInfo>, String> {
+                Ok(vec![ResourceAccessInfo {
+                    resource_id: "res-1".to_string(),
+                    holder: "did:icn:holder1".to_string(),
+                    granted_at: 0,
+                    is_revoked: false,
+                    idle_violation: Some(icn_kernel_api::services::IdleViolationInfo {
+                        idle_seconds: 999,
+                        max_idle_seconds: 100,
+                    }),
+                }])
+            }
+            fn revoke_resource_access(
+                &self,
+                _req: &icn_kernel_api::services::RevokeResourceAccessRequest,
+            ) -> Result<(), String> {
+                Ok(())
+            }
         }
-    }
 
-    #[tokio::test]
-    async fn test_enforcement_skip_already_revoked() {
-        let store = Arc::new(RwLock::new(MockResourceAccessStore::new()));
-
-        let entity = EntityId::from_did(KeyPair::generate().unwrap().did());
-        let mut access = ResourceAccess::new(
-            "test-resource-002".to_string(),
-            entity.clone(),
-            AccessModel::UseAccess {
-                duration_seconds: 30 * 24 * 3600,
-                renewable: true,
-                max_accumulated: 4,
-            },
-        );
-
-        // Already revoke it
-        access.revoke("Previously revoked".to_string());
-        assert!(access.is_revoked());
-
-        store
-            .write()
-            .await
-            .add_resource("test-resource-002".to_string(), access.clone());
-
-        // Enforcement should skip this resource (verified by checking is_revoked)
-        assert!(access.is_revoked());
-    }
-
-    /// End-to-end integration test with tokio time mocking.
-    ///
-    /// Tests the full actor lifecycle: spawn → periodic tick → enforcement check → revocation.
-    /// Uses `start_paused = true` to control time advancement and verify periodic behavior.
-    #[tokio::test(start_paused = true)]
-    async fn test_periodic_enforcement_integration() {
-        use tokio::sync::broadcast;
-        use tokio::time::Duration;
-
-        // Create mock store
-        let store = Arc::new(RwLock::new(MockResourceAccessStore::new()));
-
-        // Create a resource that is already past its idle limit
-        // Set granted_at to 30 days ago (relative to current system time)
-        let current_time = icn_time::current_timestamp_secs();
-        let thirty_days_ago = current_time.saturating_sub(30 * 24 * 3600);
-
-        let entity = EntityId::from_did(KeyPair::generate().unwrap().did());
-        let mut access = ResourceAccess::new(
-            "idle-resource".to_string(),
-            entity.clone(),
-            AccessModel::UseAccess {
-                duration_seconds: 90 * 24 * 3600, // 90 days
-                renewable: true,
-                max_accumulated: 4,
-            },
-        )
-        .with_rules(AntiSpeculationRules::strict()); // 7-day idle limit
-
-        // Override granted_at and record last usage 30 days ago
-        // This makes the resource idle for 30 days, exceeding the 7-day limit
-        access.granted_at = thirty_days_ago;
-        access
-            .record_usage(thirty_days_ago, "Initial use".to_string())
-            .unwrap();
-
-        // Add to store
-        store
-            .write()
-            .await
-            .add_resource("idle-resource".to_string(), access);
-
-        // Also add a recently-used resource that should NOT be revoked
-        let entity2 = EntityId::from_did(KeyPair::generate().unwrap().did());
-        let mut active_access = ResourceAccess::new(
-            "active-resource".to_string(),
-            entity2.clone(),
-            AccessModel::UseAccess {
-                duration_seconds: 90 * 24 * 3600,
-                renewable: true,
-                max_accumulated: 4,
-            },
-        )
-        .with_rules(AntiSpeculationRules::strict());
-
-        // Record recent usage (just now)
-        active_access
-            .record_usage(current_time, "Recent use".to_string())
-            .unwrap();
-
-        store
-            .write()
-            .await
-            .add_resource("active-resource".to_string(), active_access);
-
-        // Create shutdown channel
-        let (shutdown_tx, shutdown_rx) = broadcast::channel::<()>(1);
-
-        // Spawn actor with short interval (5 seconds for test)
         let config = ResourceEnforcerConfig {
-            check_interval_seconds: 5,
+            check_interval_seconds: 3600,
             batch_size: 100,
             enabled: true,
         };
 
-        let handle = ResourceAccessEnforcerActor::spawn(config, store.clone(), shutdown_rx);
+        let deps = ResourceEnforcerDeps {
+            ledger_service: Arc::new(StubLedger),
+            gossip_handle: None, // No gossip — should not panic
+        };
 
-        // Allow initial startup jitter to complete (max 0.5s jitter for 5s interval)
-        // Advance time past the jitter
-        tokio::time::advance(Duration::from_secs(1)).await;
-        tokio::task::yield_now().await;
+        let (shutdown_tx, _) = tokio::sync::broadcast::channel(1);
+        let shutdown_rx = shutdown_tx.subscribe();
+        let handle = ResourceAccessEnforcerActor::spawn(config, deps, shutdown_rx);
 
-        // Advance time past the first interval tick (5 seconds)
-        tokio::time::advance(Duration::from_secs(6)).await;
-        tokio::task::yield_now().await;
+        // Force a check — should revoke 1 resource without crashing on None gossip
+        let result = handle.force_check().await.unwrap();
+        assert_eq!(result.resources_checked, 1);
+        assert_eq!(result.revocations, 1);
 
-        // Give the actor time to process
-        tokio::time::advance(Duration::from_millis(100)).await;
-        tokio::task::yield_now().await;
-
-        // Verify stats show at least one check was performed
         let stats = handle.get_stats().await.unwrap();
-        assert!(
-            stats.checks_performed >= 1,
-            "Expected at least 1 check, got {}",
-            stats.checks_performed
-        );
+        assert_eq!(stats.total_revocations, 1);
 
-        // Verify the idle resource was revoked
-        let store_read = store.read().await;
-        let resources = store_read.list_all().unwrap();
-        drop(store_read);
-
-        let idle_resource = resources
-            .iter()
-            .find(|(id, _)| id == "idle-resource")
-            .map(|(_, access)| access);
-        let active_resource = resources
-            .iter()
-            .find(|(id, _)| id == "active-resource")
-            .map(|(_, access)| access);
-
-        assert!(
-            idle_resource.is_some(),
-            "Idle resource should still exist in store"
-        );
-        assert!(
-            idle_resource.unwrap().is_revoked(),
-            "Idle resource should be revoked"
-        );
-
-        assert!(
-            active_resource.is_some(),
-            "Active resource should still exist in store"
-        );
-        assert!(
-            !active_resource.unwrap().is_revoked(),
-            "Active resource should NOT be revoked"
-        );
-
-        // Verify revocation events were emitted
-        let events = store.read().await.events.lock().unwrap().clone();
-        assert_eq!(events.len(), 1, "Should have exactly 1 revocation event");
-        assert_eq!(events[0].resource_id, "idle-resource");
-        assert!(events[0].reason.contains("idle"));
-
-        // Clean shutdown
         let _ = shutdown_tx.send(());
+        tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }

--- a/icn/crates/icn-core/src/resource_enforcer_actor.rs
+++ b/icn/crates/icn-core/src/resource_enforcer_actor.rs
@@ -319,6 +319,7 @@ impl ResourceAccessEnforcerActor {
     /// Queries the ledger for enforceable resources, identifies idle violations,
     /// revokes violating resources, and publishes revocation events.
     async fn perform_enforcement_check(&mut self) -> Result<EnforcementResult> {
+        let check_start = tokio::time::Instant::now();
         let current_time = icn_time::current_timestamp_secs();
         debug!("Starting enforcement check at timestamp {}", current_time);
 
@@ -405,6 +406,9 @@ impl ResourceAccessEnforcerActor {
         icn_obs::metrics::resource_enforcer::checks_total_inc();
         icn_obs::metrics::resource_enforcer::resources_checked_inc(resources_checked as u64);
         icn_obs::metrics::resource_enforcer::revocations_total_inc(revocations as u64);
+        icn_obs::metrics::resource_enforcer::check_duration_observe(
+            check_start.elapsed().as_secs_f64(),
+        );
 
         Ok(EnforcementResult {
             resources_checked,
@@ -647,6 +651,96 @@ mod tests {
 
         // Both revocations were attempted
         assert_eq!(REVOKE_CALLS.load(Ordering::SeqCst), 2);
+
+        let _ = shutdown_tx.send(());
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    /// Verify that 1000+ resources are processed correctly across batches.
+    /// Exercises the chunked iteration path and confirms stats accumulate.
+    #[tokio::test]
+    async fn test_large_batch_processing() {
+        use icn_kernel_api::services::{LedgerService, ResourceAccessInfo};
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        static LARGE_REVOKE_COUNT: AtomicU32 = AtomicU32::new(0);
+
+        struct LargeBatchLedger;
+        impl LedgerService for LargeBatchLedger {
+            fn oracle(&self) -> Arc<dyn icn_kernel_api::authz::PolicyOracle> {
+                unimplemented!()
+            }
+            fn balance(&self, _: &icn_kernel_api::types::Did, _: &str) -> i64 {
+                0
+            }
+            fn credit_limit(&self, _: &icn_kernel_api::types::Did, _: &str) -> i64 {
+                0
+            }
+            fn record_event(&self, _: icn_kernel_api::services::LedgerEvent) {}
+            fn list_enforceable_resources(
+                &self,
+                _current_time: u64,
+            ) -> Result<Vec<ResourceAccessInfo>, String> {
+                let violation = Some(icn_kernel_api::services::IdleViolationInfo {
+                    idle_seconds: 999,
+                    max_idle_seconds: 100,
+                });
+                // Return 1500 resources: 1000 with violations, 500 already revoked
+                let mut resources = Vec::with_capacity(1500);
+                for i in 0..1000 {
+                    resources.push(ResourceAccessInfo {
+                        resource_id: format!("res-{i}"),
+                        holder: format!("did:icn:holder-{i}"),
+                        granted_at: 0,
+                        is_revoked: false,
+                        idle_violation: violation.clone(),
+                    });
+                }
+                for i in 1000..1500 {
+                    resources.push(ResourceAccessInfo {
+                        resource_id: format!("res-{i}"),
+                        holder: format!("did:icn:holder-{i}"),
+                        granted_at: 0,
+                        is_revoked: true,
+                        idle_violation: violation.clone(),
+                    });
+                }
+                Ok(resources)
+            }
+            fn revoke_resource_access(
+                &self,
+                _req: &icn_kernel_api::services::RevokeResourceAccessRequest,
+            ) -> Result<(), String> {
+                LARGE_REVOKE_COUNT.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+
+        LARGE_REVOKE_COUNT.store(0, Ordering::SeqCst);
+
+        let config = ResourceEnforcerConfig {
+            check_interval_seconds: 3600,
+            batch_size: 200, // 1500 resources / 200 = 8 batches
+            enabled: true,
+        };
+        let deps = ResourceEnforcerDeps {
+            ledger_service: Arc::new(LargeBatchLedger),
+            gossip_handle: None,
+        };
+
+        let (shutdown_tx, _) = tokio::sync::broadcast::channel(1);
+        let shutdown_rx = shutdown_tx.subscribe();
+        let handle = ResourceAccessEnforcerActor::spawn(config, deps, shutdown_rx);
+
+        let result = handle.force_check().await.unwrap();
+        // All 1500 resources checked, but only the 1000 non-revoked ones get revoked
+        assert_eq!(result.resources_checked, 1500);
+        assert_eq!(result.revocations, 1000);
+        assert_eq!(LARGE_REVOKE_COUNT.load(Ordering::SeqCst), 1000);
+
+        let stats = handle.get_stats().await.unwrap();
+        assert_eq!(stats.resources_checked, 1500);
+        assert_eq!(stats.total_revocations, 1000);
 
         let _ = shutdown_tx.send(());
         tokio::time::sleep(Duration::from_millis(100)).await;

--- a/icn/crates/icn-core/src/resource_enforcer_actor.rs
+++ b/icn/crates/icn-core/src/resource_enforcer_actor.rs
@@ -388,7 +388,7 @@ impl ResourceAccessEnforcerActor {
                     self.publish_revocation(&event).await;
 
                     revocations += 1;
-                    metrics::counter!("icn_resource_access_revoked_total").increment(1);
+                    icn_obs::metrics::resource_enforcer::access_revoked_inc();
                 }
             }
         }
@@ -402,10 +402,9 @@ impl ResourceAccessEnforcerActor {
         );
 
         // Update metrics
-        metrics::counter!("icn_resource_enforcer_checks_total").increment(1);
-        metrics::counter!("icn_resource_enforcer_resources_checked_total")
-            .increment(resources_checked as u64);
-        metrics::counter!("icn_resource_enforcer_revocations_total").increment(revocations as u64);
+        icn_obs::metrics::resource_enforcer::checks_total_inc();
+        icn_obs::metrics::resource_enforcer::resources_checked_inc(resources_checked as u64);
+        icn_obs::metrics::resource_enforcer::revocations_total_inc(revocations as u64);
 
         Ok(EnforcementResult {
             resources_checked,
@@ -427,11 +426,7 @@ impl ResourceAccessEnforcerActor {
             Ok(data) => data,
             Err(e) => {
                 warn!("Failed to serialize revocation event: {}", e);
-                metrics::counter!(
-                    "icn_resource_revocation_gossip_failures_total",
-                    "reason" => "serialization"
-                )
-                .increment(1);
+                icn_obs::metrics::resource_enforcer::gossip_failure_inc("serialization");
                 return;
             }
         };
@@ -439,18 +434,14 @@ impl ResourceAccessEnforcerActor {
         let mut gossip = gossip_handle.write().await;
         if let Err(e) = gossip.publish(RESOURCE_REVOCATIONS_TOPIC, serialized).await {
             warn!("Failed to publish revocation to gossip: {}", e);
-            metrics::counter!(
-                "icn_resource_revocation_gossip_failures_total",
-                "reason" => "publish"
-            )
-            .increment(1);
+            icn_obs::metrics::resource_enforcer::gossip_failure_inc("publish");
         } else {
             info!(
                 resource_id = %event.resource_id,
                 holder = %event.holder,
                 "Published revocation event to gossip"
             );
-            metrics::counter!("icn_resource_revocation_gossip_published_total").increment(1);
+            icn_obs::metrics::resource_enforcer::gossip_published_inc();
         }
     }
 }

--- a/icn/crates/icn-core/src/resource_enforcer_actor.rs
+++ b/icn/crates/icn-core/src/resource_enforcer_actor.rs
@@ -323,6 +323,13 @@ impl ResourceAccessEnforcerActor {
 
         let resources_checked = resources.len();
 
+        if resources_checked == 0 && self.stats.checks_performed == 1 {
+            warn!(
+                "LedgerService returned 0 enforceable resources on first check. \
+                 Enforcement is a no-op until LedgerService is wired to a persistent store."
+            );
+        }
+
         // Identify and process resources with idle violations
         let mut revocations = 0;
 
@@ -526,8 +533,9 @@ mod tests {
             }
         }
 
+        // Use small interval so startup jitter is 0 (jitter = interval/10)
         let config = ResourceEnforcerConfig {
-            check_interval_seconds: 3600,
+            check_interval_seconds: 1,
             batch_size: 100,
             enabled: true,
         };
@@ -548,6 +556,96 @@ mod tests {
 
         let stats = handle.get_stats().await.unwrap();
         assert_eq!(stats.total_revocations, 1);
+
+        let _ = shutdown_tx.send(());
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    /// Verify that partial revocation failures don't abort the entire check.
+    /// If one resource fails to revoke, the actor should continue and revoke others.
+    #[tokio::test]
+    async fn test_partial_revocation_failure() {
+        use icn_kernel_api::services::{LedgerService, ResourceAccessInfo};
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        static REVOKE_CALLS: AtomicU32 = AtomicU32::new(0);
+
+        struct PartialFailLedger;
+        impl LedgerService for PartialFailLedger {
+            fn oracle(&self) -> Arc<dyn icn_kernel_api::authz::PolicyOracle> {
+                unimplemented!()
+            }
+            fn balance(&self, _: &icn_kernel_api::types::Did, _: &str) -> i64 {
+                0
+            }
+            fn credit_limit(&self, _: &icn_kernel_api::types::Did, _: &str) -> i64 {
+                0
+            }
+            fn record_event(&self, _: icn_kernel_api::services::LedgerEvent) {}
+            fn list_enforceable_resources(
+                &self,
+                _current_time: u64,
+            ) -> Result<Vec<ResourceAccessInfo>, String> {
+                let violation = Some(icn_kernel_api::services::IdleViolationInfo {
+                    idle_seconds: 999,
+                    max_idle_seconds: 100,
+                });
+                Ok(vec![
+                    ResourceAccessInfo {
+                        resource_id: "res-fail".to_string(),
+                        holder: "did:icn:holder1".to_string(),
+                        granted_at: 0,
+                        is_revoked: false,
+                        idle_violation: violation.clone(),
+                    },
+                    ResourceAccessInfo {
+                        resource_id: "res-ok".to_string(),
+                        holder: "did:icn:holder2".to_string(),
+                        granted_at: 0,
+                        is_revoked: false,
+                        idle_violation: violation,
+                    },
+                ])
+            }
+            fn revoke_resource_access(
+                &self,
+                req: &icn_kernel_api::services::RevokeResourceAccessRequest,
+            ) -> Result<(), String> {
+                let call = REVOKE_CALLS.fetch_add(1, Ordering::SeqCst);
+                if req.resource_id == "res-fail" {
+                    Err("simulated failure".to_string())
+                } else {
+                    let _ = call;
+                    Ok(())
+                }
+            }
+        }
+
+        // Reset counter
+        REVOKE_CALLS.store(0, Ordering::SeqCst);
+
+        // Use small interval so startup jitter is 0 (jitter = interval/10)
+        let config = ResourceEnforcerConfig {
+            check_interval_seconds: 1,
+            batch_size: 100,
+            enabled: true,
+        };
+        let deps = ResourceEnforcerDeps {
+            ledger_service: Arc::new(PartialFailLedger),
+            gossip_handle: None,
+        };
+
+        let (shutdown_tx, _) = tokio::sync::broadcast::channel(1);
+        let shutdown_rx = shutdown_tx.subscribe();
+        let handle = ResourceAccessEnforcerActor::spawn(config, deps, shutdown_rx);
+
+        let result = handle.force_check().await.unwrap();
+        // Both resources checked, but only 1 successfully revoked
+        assert_eq!(result.resources_checked, 2);
+        assert_eq!(result.revocations, 1);
+
+        // Both revocations were attempted
+        assert_eq!(REVOKE_CALLS.load(Ordering::SeqCst), 2);
 
         let _ = shutdown_tx.send(());
         tokio::time::sleep(Duration::from_millis(100)).await;

--- a/icn/crates/icn-core/src/resource_enforcer_actor.rs
+++ b/icn/crates/icn-core/src/resource_enforcer_actor.rs
@@ -198,6 +198,7 @@ pub struct ResourceAccessEnforcerActor {
     config: ResourceEnforcerConfig,
     deps: ResourceEnforcerDeps,
     stats: EnforcementStats,
+    warned_empty: bool,
 }
 
 impl ResourceAccessEnforcerActor {
@@ -227,6 +228,7 @@ impl ResourceAccessEnforcerActor {
                 last_check_time: None,
                 error_count: 0,
             },
+            warned_empty: false,
         };
 
         tokio::spawn(async move {
@@ -243,8 +245,9 @@ impl ResourceAccessEnforcerActor {
                 config.check_interval_seconds, config.batch_size
             );
 
-            // Add startup jitter (0-10% of interval) to prevent thundering herd
-            // when multiple nodes start simultaneously
+            // Startup jitter (0-10% of interval) to prevent thundering herd
+            // when multiple nodes start simultaneously. Jitter gates periodic
+            // ticks but NOT message handling, so force_check() is always responsive.
             let jitter_secs = {
                 let max_jitter = config.check_interval_seconds / 10;
                 if max_jitter > 0 {
@@ -253,9 +256,12 @@ impl ResourceAccessEnforcerActor {
                     0
                 }
             };
+            let jitter_sleep = tokio::time::sleep(Duration::from_secs(jitter_secs));
+            tokio::pin!(jitter_sleep);
+            let mut jitter_done = jitter_secs == 0;
+
             if jitter_secs > 0 {
-                debug!("Applying startup jitter of {}s", jitter_secs);
-                tokio::time::sleep(Duration::from_secs(jitter_secs)).await;
+                debug!("Applying startup jitter of {jitter_secs}s");
             }
 
             // Periodic enforcement check
@@ -274,7 +280,12 @@ impl ResourceAccessEnforcerActor {
                         actor.handle_message(msg).await;
                     }
 
-                    _ = check_interval.tick() => {
+                    _ = &mut jitter_sleep, if !jitter_done => {
+                        jitter_done = true;
+                        debug!("Startup jitter complete, periodic checks enabled");
+                    }
+
+                    _ = check_interval.tick(), if jitter_done => {
                         if let Err(e) = actor.perform_enforcement_check().await {
                             error!("Enforcement check failed: {}", e);
                             actor.stats.error_count += 1;
@@ -323,9 +334,10 @@ impl ResourceAccessEnforcerActor {
 
         let resources_checked = resources.len();
 
-        if resources_checked == 0 && self.stats.checks_performed == 1 {
+        if resources_checked == 0 && !self.warned_empty {
+            self.warned_empty = true;
             warn!(
-                "LedgerService returned 0 enforceable resources on first check. \
+                "LedgerService returned 0 enforceable resources. \
                  Enforcement is a no-op until LedgerService is wired to a persistent store."
             );
         }
@@ -533,9 +545,8 @@ mod tests {
             }
         }
 
-        // Use small interval so startup jitter is 0 (jitter = interval/10)
         let config = ResourceEnforcerConfig {
-            check_interval_seconds: 1,
+            check_interval_seconds: 3600,
             batch_size: 100,
             enabled: true,
         };
@@ -624,9 +635,8 @@ mod tests {
         // Reset counter
         REVOKE_CALLS.store(0, Ordering::SeqCst);
 
-        // Use small interval so startup jitter is 0 (jitter = interval/10)
         let config = ResourceEnforcerConfig {
-            check_interval_seconds: 1,
+            check_interval_seconds: 3600,
             batch_size: 100,
             enabled: true,
         };

--- a/icn/crates/icn-core/src/supervisor/init_resource_enforcer.rs
+++ b/icn/crates/icn-core/src/supervisor/init_resource_enforcer.rs
@@ -63,8 +63,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_spawn_resource_enforcer() {
+        // Use small interval so startup jitter is 0 (jitter = interval/10)
         let config = ResourceEnforcerConfig {
-            check_interval_seconds: 3600,
+            check_interval_seconds: 1,
             batch_size: 100,
             enabled: true,
         };

--- a/icn/crates/icn-core/src/supervisor/init_resource_enforcer.rs
+++ b/icn/crates/icn-core/src/supervisor/init_resource_enforcer.rs
@@ -1,16 +1,13 @@
 //! Resource Access Enforcer Actor initialization
 //!
-//! Spawns the ResourceAccessEnforcerActor with storage backend and gossip integration.
+//! Spawns the ResourceAccessEnforcerActor with LedgerService and gossip integration.
 
 use anyhow::Result;
-use icn_gossip::GossipActor;
-use std::sync::Arc;
-use tokio::sync::RwLock;
-use tracing::{info, warn};
+use tracing::info;
 
 use crate::resource_enforcer_actor::{
-    ResourceAccessEnforcerActor, ResourceAccessStore, ResourceEnforcerConfig,
-    ResourceEnforcerHandle, RevocationEvent, RESOURCE_REVOCATIONS_TOPIC,
+    ResourceAccessEnforcerActor, ResourceEnforcerConfig, ResourceEnforcerDeps,
+    ResourceEnforcerHandle,
 };
 use crate::runtime::ShutdownTx;
 
@@ -18,14 +15,14 @@ use crate::runtime::ShutdownTx;
 ///
 /// # Arguments
 /// * `config` - Enforcement configuration
-/// * `store` - Storage backend for ResourceAccess entries (already wrapped with gossip if needed)
+/// * `deps` - Dependencies (LedgerService + optional gossip)
 /// * `shutdown_tx` - Shutdown signal transmitter
 ///
 /// # Returns
 /// Handle for interacting with the enforcer actor
 pub fn spawn_resource_enforcer(
     config: &ResourceEnforcerConfig,
-    store: Arc<RwLock<dyn ResourceAccessStore>>,
+    deps: ResourceEnforcerDeps,
     shutdown_tx: &ShutdownTx,
 ) -> Result<ResourceEnforcerHandle> {
     info!(
@@ -34,179 +31,34 @@ pub fn spawn_resource_enforcer(
     );
 
     let shutdown_rx = shutdown_tx.subscribe();
-    let handle = ResourceAccessEnforcerActor::spawn(config.clone(), store, shutdown_rx);
+    let handle = ResourceAccessEnforcerActor::spawn(config.clone(), deps, shutdown_rx);
 
     Ok(handle)
-}
-
-/// Null storage implementation for when no persistent storage is available
-///
-/// This is used as a placeholder when the ledger or storage backend
-/// is not yet implemented or not available.
-pub struct NullResourceAccessStore;
-
-impl ResourceAccessStore for NullResourceAccessStore {
-    fn list_all(&self) -> Result<Vec<(String, icn_ledger::ResourceAccess)>> {
-        // Return empty list - no resources to check
-        Ok(Vec::new())
-    }
-
-    fn update(&mut self, _resource_id: &str, _access: &icn_ledger::ResourceAccess) -> Result<()> {
-        // No-op: nothing to persist
-        Ok(())
-    }
-
-    fn emit_revocation(&mut self, _event: RevocationEvent) -> Result<()> {
-        // No-op: no event bus to emit to
-        Ok(())
-    }
-}
-
-/// Gossip-aware resource access store wrapper
-///
-/// This wraps an underlying storage implementation and publishes
-/// revocation events to a gossip topic for cluster-wide notification.
-///
-/// # Visibility
-///
-/// This type is public for use in integration tests and internal supervisor
-/// wiring, but is not re-exported from `icn-core`'s root. External crates
-/// should not depend on this type directly; it is an internal implementation
-/// detail of the resource enforcer subsystem.
-///
-/// # Example (internal testing)
-///
-/// ```ignore
-/// use icn_core::supervisor::init_resource_enforcer::GossipResourceAccessStore;
-/// let store = GossipResourceAccessStore::new(inner, gossip_handle);
-/// ```
-pub struct GossipResourceAccessStore {
-    /// Underlying storage implementation
-    inner: Box<dyn ResourceAccessStore>,
-    /// Gossip actor handle for publishing revocations
-    gossip_handle: Arc<RwLock<GossipActor>>,
-}
-
-impl GossipResourceAccessStore {
-    /// Create a new gossip-aware resource access store
-    pub fn new(
-        inner: Box<dyn ResourceAccessStore>,
-        gossip_handle: Arc<RwLock<GossipActor>>,
-    ) -> Self {
-        Self {
-            inner,
-            gossip_handle,
-        }
-    }
-}
-
-impl ResourceAccessStore for GossipResourceAccessStore {
-    fn list_all(&self) -> Result<Vec<(String, icn_ledger::ResourceAccess)>> {
-        self.inner.list_all()
-    }
-
-    fn update(&mut self, resource_id: &str, access: &icn_ledger::ResourceAccess) -> Result<()> {
-        self.inner.update(resource_id, access)
-    }
-
-    fn emit_revocation(&mut self, event: RevocationEvent) -> Result<()> {
-        // Clone once for the async gossip task before passing ownership to inner store
-        let event_for_gossip = event.clone();
-
-        // First emit through the inner store (for local audit trail)
-        self.inner.emit_revocation(event)?;
-
-        // Then publish to gossip for cluster-wide notification
-        let gossip_handle = self.gossip_handle.clone();
-
-        // Spawn async task to publish to gossip (don't block the enforcer)
-        // Note: Revocation gossip publication is best-effort. If gossip is unavailable,
-        // the event may not reach other cluster nodes until the next enforcement cycle.
-        tokio::spawn(async move {
-            let serialized = match serde_json::to_vec(&event_for_gossip) {
-                Ok(data) => data,
-                Err(e) => {
-                    warn!("Failed to serialize revocation event: {}", e);
-                    metrics::counter!("icn_resource_revocation_gossip_failures_total", "reason" => "serialization").increment(1);
-                    return;
-                }
-            };
-
-            let mut gossip = gossip_handle.write().await;
-            if let Err(e) = gossip.publish(RESOURCE_REVOCATIONS_TOPIC, serialized).await {
-                warn!("Failed to publish revocation to gossip: {}", e);
-                metrics::counter!("icn_resource_revocation_gossip_failures_total", "reason" => "publish").increment(1);
-            } else {
-                info!(
-                    resource_id = %event_for_gossip.resource_id,
-                    holder = %event_for_gossip.holder,
-                    "Published revocation event to gossip"
-                );
-                metrics::counter!("icn_resource_revocation_gossip_published_total").increment(1);
-            }
-        });
-
-        Ok(())
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icn_entity::EntityId;
-    use icn_identity::KeyPair;
-    use icn_ledger::{AccessModel, ResourceAccess};
-    use std::collections::HashMap;
-    use std::sync::Mutex;
+    use icn_kernel_api::services::LedgerService;
+    use std::sync::Arc;
 
-    /// Wait time for async gossip publication tasks to complete.
-    /// 100ms provides sufficient margin for:
-    /// - tokio::spawn task scheduling
-    /// - Gossip actor lock acquisition
-    /// - Serialization and publication
-    const ASYNC_PUBLISH_WAIT_MS: u64 = 100;
+    /// Minimal LedgerService for testing the enforcer spawning
+    struct StubLedgerService;
 
-    struct TestStore {
-        resources: Mutex<HashMap<String, ResourceAccess>>,
-    }
-
-    impl TestStore {
-        fn new() -> Self {
-            Self {
-                resources: Mutex::new(HashMap::new()),
-            }
+    impl LedgerService for StubLedgerService {
+        fn oracle(&self) -> Arc<dyn icn_kernel_api::authz::PolicyOracle> {
+            unimplemented!("not needed for enforcer tests")
         }
 
-        #[allow(dead_code)]
-        fn add(&self, id: String, access: ResourceAccess) {
-            self.resources.lock().map(|mut r| r.insert(id, access)).ok();
-        }
-    }
-
-    impl ResourceAccessStore for TestStore {
-        fn list_all(&self) -> Result<Vec<(String, ResourceAccess)>> {
-            let resources = self
-                .resources
-                .lock()
-                .map_err(|e| anyhow::anyhow!("Lock error: {}", e))?;
-            Ok(resources
-                .iter()
-                .map(|(k, v)| (k.clone(), v.clone()))
-                .collect())
+        fn balance(&self, _account: &icn_kernel_api::types::Did, _currency: &str) -> i64 {
+            0
         }
 
-        fn update(&mut self, resource_id: &str, access: &ResourceAccess) -> Result<()> {
-            let mut resources = self
-                .resources
-                .lock()
-                .map_err(|e| anyhow::anyhow!("Lock error: {}", e))?;
-            resources.insert(resource_id.to_string(), access.clone());
-            Ok(())
+        fn credit_limit(&self, _account: &icn_kernel_api::types::Did, _currency: &str) -> i64 {
+            0
         }
 
-        fn emit_revocation(&mut self, _event: RevocationEvent) -> Result<()> {
-            Ok(())
-        }
+        fn record_event(&self, _event: icn_kernel_api::services::LedgerEvent) {}
     }
 
     #[tokio::test]
@@ -217,11 +69,15 @@ mod tests {
             enabled: true,
         };
 
-        let store = Arc::new(RwLock::new(TestStore::new()));
+        let deps = ResourceEnforcerDeps {
+            ledger_service: Arc::new(StubLedgerService),
+            gossip_handle: None,
+        };
+
         let (shutdown_tx, _shutdown_rx) = tokio::sync::broadcast::channel(1);
 
-        let handle = spawn_resource_enforcer(&config, store.clone(), &shutdown_tx)
-            .expect("Failed to spawn enforcer");
+        let handle =
+            spawn_resource_enforcer(&config, deps, &shutdown_tx).expect("Failed to spawn enforcer");
 
         // Get stats to verify actor is running
         let stats = handle.get_stats().await.expect("Failed to get stats");
@@ -233,109 +89,5 @@ mod tests {
 
         // Give actor time to shut down
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-    }
-
-    #[test]
-    fn test_null_store() {
-        let store = NullResourceAccessStore;
-        let resources = store.list_all().unwrap();
-        assert!(resources.is_empty());
-
-        let entity = EntityId::from_did(KeyPair::generate().unwrap().did());
-        let access = ResourceAccess::new(
-            "test".to_string(),
-            entity,
-            AccessModel::UseAccess {
-                duration_seconds: 3600,
-                renewable: false,
-                max_accumulated: 1,
-            },
-        );
-
-        let mut store = NullResourceAccessStore;
-        assert!(store.update("test", &access).is_ok());
-        assert!(store
-            .emit_revocation(RevocationEvent {
-                resource_id: "test".to_string(),
-                holder: access.holder,
-                reason: "test".to_string(),
-                timestamp: 0,
-                idle_seconds: 0,
-            })
-            .is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_gossip_store_publishes_revocations() {
-        use icn_gossip::GossipActor;
-        use std::sync::{Arc, Mutex as StdMutex};
-
-        // Create a mock store that tracks revocation events
-        let events_log: Arc<StdMutex<Vec<RevocationEvent>>> = Arc::new(StdMutex::new(Vec::new()));
-
-        struct MockStore {
-            events: Arc<StdMutex<Vec<RevocationEvent>>>,
-        }
-
-        impl ResourceAccessStore for MockStore {
-            fn list_all(&self) -> Result<Vec<(String, ResourceAccess)>> {
-                Ok(Vec::new())
-            }
-
-            fn update(&mut self, _resource_id: &str, _access: &ResourceAccess) -> Result<()> {
-                Ok(())
-            }
-
-            fn emit_revocation(&mut self, event: RevocationEvent) -> Result<()> {
-                self.events.lock().unwrap().push(event);
-                Ok(())
-            }
-        }
-
-        // Create gossip actor - no oracle needed, test only verifies gossip publication
-        let keypair = KeyPair::generate().unwrap();
-        let did = keypair.did();
-        let gossip_handle = GossipActor::spawn(did.clone(), None);
-
-        // Set keypair for signing and create the revocation topic
-        {
-            let mut gossip = gossip_handle.write().await;
-            gossip.set_keypair(keypair);
-            gossip.create_topic(icn_gossip::Topic::new(
-                RESOURCE_REVOCATIONS_TOPIC.to_string(),
-                icn_gossip::AccessControl::Public,
-            ));
-        }
-
-        // Create gossip-aware store
-        let inner_store = Box::new(MockStore {
-            events: events_log.clone(),
-        });
-        let mut gossip_store = GossipResourceAccessStore::new(inner_store, gossip_handle.clone());
-
-        // Create and emit a revocation event
-        let entity = EntityId::from_did(KeyPair::generate().unwrap().did());
-        let event = RevocationEvent {
-            resource_id: "test-resource".to_string(),
-            holder: entity,
-            reason: "Idle for too long".to_string(),
-            timestamp: icn_time::current_timestamp_secs(),
-            idle_seconds: 86400, // 1 day
-        };
-
-        // Emit the revocation
-        gossip_store.emit_revocation(event.clone()).unwrap();
-
-        // Wait for async publication task
-        tokio::time::sleep(tokio::time::Duration::from_millis(ASYNC_PUBLISH_WAIT_MS)).await;
-
-        // Verify event was logged
-        let logged_events = events_log.lock().unwrap();
-        assert_eq!(logged_events.len(), 1);
-        assert_eq!(logged_events[0].resource_id, "test-resource");
-        assert_eq!(logged_events[0].reason, "Idle for too long");
-
-        // Verify event was published to gossip
-        // (We can't easily check this without subscribing, but the log should show it)
     }
 }

--- a/icn/crates/icn-core/src/supervisor/init_resource_enforcer.rs
+++ b/icn/crates/icn-core/src/supervisor/init_resource_enforcer.rs
@@ -63,9 +63,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_spawn_resource_enforcer() {
-        // Use small interval so startup jitter is 0 (jitter = interval/10)
         let config = ResourceEnforcerConfig {
-            check_interval_seconds: 1,
+            check_interval_seconds: 3600,
             batch_size: 100,
             enabled: true,
         };

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -651,6 +651,10 @@ async fn spawn_actors_with_identity(
     );
     gateway_handles.compute = Some(rpc_compute_handle);
 
+    // Extract LedgerService for background tasks (resource enforcer)
+    let ledger_service_for_bg: Option<Arc<dyn icn_kernel_api::services::LedgerService>> =
+        service_registry.and_then(|r| r.ledger().cloned());
+
     // Spawn background tasks
     spawn_background_tasks(
         config,
@@ -659,6 +663,7 @@ async fn spawn_actors_with_identity(
         &did,
         protocol_parameter_store,
         ledger_store,
+        ledger_service_for_bg,
         shutdown_tx,
         background_tasks,
     )
@@ -1033,6 +1038,7 @@ async fn spawn_background_tasks(
     did: &icn_identity::Did,
     protocol_parameter_store: Arc<dyn icn_governance::ProtocolParameterStore>,
     ledger_store: Arc<icn_store::SledStore>,
+    ledger_service: Option<Arc<dyn icn_kernel_api::services::LedgerService>>,
     shutdown_tx: &ShutdownTx,
     _background_tasks: &mut JoinSet<()>,
 ) {
@@ -1120,73 +1126,60 @@ async fn spawn_background_tasks(
 
     // Resource access enforcer
     if config.supervisor.resource_enforcer.enabled {
-        // Wrap NullResourceAccessStore with gossip integration
-        // In the future, this should be replaced with a real persistent backend
-        // (see TODO comment below about SledResourceAccessStore)
-        let inner_store = Box::new(super::init_resource_enforcer::NullResourceAccessStore);
-        let gossip_store = super::init_resource_enforcer::GossipResourceAccessStore::new(
-            inner_store,
-            gossip_handle.clone(),
-        );
-        let store = Arc::new(RwLock::new(gossip_store));
-
-        // Create and subscribe to revocations topic for cluster-wide notifications
-        {
-            let mut gossip = gossip_handle.write().await;
-
-            // Create the topic with explicit retention for audit trail.
-            // - 7-day retention provides sufficient window for cluster synchronization
-            // - 1000 max entries prevents unbounded growth while allowing burst activity
-            gossip.create_topic(icn_gossip::types::Topic {
-                name: crate::resource_enforcer_actor::RESOURCE_REVOCATIONS_TOPIC.to_string(),
-                acl: icn_gossip::AccessControl::Public,
-                scope: icn_gossip::types::Scope::Global,
-                min_trust_threshold: None,
-                retention: std::time::Duration::from_secs(86400 * 7), // 7 days
-                max_entries: 1000,
-            });
-
-            if let Err(e) = gossip
-                .subscribe(
-                    crate::resource_enforcer_actor::RESOURCE_REVOCATIONS_TOPIC,
-                    did.clone(),
-                )
-                .await
+        if let Some(ledger_svc) = ledger_service {
+            // Create and subscribe to revocations topic for cluster-wide notifications
             {
-                warn!("Failed to subscribe to resource:revocations topic: {}", e);
-            } else {
-                info!("Subscribed to resource:revocations topic");
+                let mut gossip = gossip_handle.write().await;
+
+                // Create the topic with explicit retention for audit trail.
+                // - 7-day retention provides sufficient window for cluster synchronization
+                // - 1000 max entries prevents unbounded growth while allowing burst activity
+                gossip.create_topic(icn_gossip::types::Topic {
+                    name: crate::resource_enforcer_actor::RESOURCE_REVOCATIONS_TOPIC.to_string(),
+                    acl: icn_gossip::AccessControl::Public,
+                    scope: icn_gossip::types::Scope::Global,
+                    min_trust_threshold: None,
+                    retention: std::time::Duration::from_secs(86400 * 7), // 7 days
+                    max_entries: 1000,
+                });
+
+                if let Err(e) = gossip
+                    .subscribe(
+                        crate::resource_enforcer_actor::RESOURCE_REVOCATIONS_TOPIC,
+                        did.clone(),
+                    )
+                    .await
+                {
+                    warn!("Failed to subscribe to resource:revocations topic: {}", e);
+                } else {
+                    info!("Subscribed to resource:revocations topic");
+                }
             }
-        }
 
-        // The resource enforcer actor is fully autonomous and only needs the shutdown
-        // signal via the broadcast channel. We intentionally discard the handle for now;
-        // future work may expose it via the Gateway API for manual checks or statistics
-        // queries if needed.
-        if let Ok(_enforcer_handle) = super::init_resource_enforcer::spawn_resource_enforcer(
-            &config.supervisor.resource_enforcer,
-            store,
-            shutdown_tx,
-        ) {
-            info!(
-                "Resource access enforcer task spawned (interval: {} seconds, gossip: enabled)",
-                config.supervisor.resource_enforcer.check_interval_seconds
-            );
+            let deps = crate::resource_enforcer_actor::ResourceEnforcerDeps {
+                ledger_service: ledger_svc,
+                gossip_handle: Some(gossip_handle.clone()),
+            };
+
+            // The resource enforcer actor is fully autonomous and only needs the shutdown
+            // signal via the broadcast channel. We intentionally discard the handle for now;
+            // future work may expose it via the Gateway API for manual checks or statistics
+            // queries if needed.
+            if let Ok(_enforcer_handle) = super::init_resource_enforcer::spawn_resource_enforcer(
+                &config.supervisor.resource_enforcer,
+                deps,
+                shutdown_tx,
+            ) {
+                info!(
+                    "Resource access enforcer task spawned (interval: {} seconds, gossip: enabled)",
+                    config.supervisor.resource_enforcer.check_interval_seconds
+                );
+            } else {
+                warn!("Failed to spawn resource access enforcer");
+            }
         } else {
-            warn!("Failed to spawn resource access enforcer");
+            info!("Resource access enforcer skipped: no LedgerService registered");
         }
-
-        // TODO: Replace `NullResourceAccessStore` with a real persistent backend.
-        //
-        // Integration plan:
-        // 1. Storage backend:
-        //    - Use the sled-backed SledResourceAccessStore from `icn-ledger` as the
-        //      concrete implementation for `ResourceAccessStore`.
-        // 2. Persistence layout:
-        //    - Resource access entries are persisted in the ledger store using the
-        //      `ledger:resource_access:` key prefix (see icn-ledger/src/use_access.rs).
-        // 3. The GossipResourceAccessStore wrapper will handle cluster-wide notification
-        //    when the real backend is integrated.
     } else {
         info!("Resource access enforcer disabled by configuration");
     }

--- a/icn/crates/icn-core/tests/resource_enforcer_gossip.rs
+++ b/icn/crates/icn-core/tests/resource_enforcer_gossip.rs
@@ -140,9 +140,8 @@ async fn test_enforcer_actor_with_gossip_deps() {
     }
 
     // Create enforcer with gossip-enabled deps
-    // Use small interval so startup jitter is 0 (jitter = interval/10)
     let config = ResourceEnforcerConfig {
-        check_interval_seconds: 1,
+        check_interval_seconds: 3600,
         batch_size: 100,
         enabled: true,
     };
@@ -243,9 +242,8 @@ async fn test_enforcer_with_violations_publishes_gossip() {
         });
     }
 
-    // Use small interval so startup jitter is 0 (jitter = interval/10)
     let config = ResourceEnforcerConfig {
-        check_interval_seconds: 1,
+        check_interval_seconds: 3600,
         batch_size: 100,
         enabled: true,
     };

--- a/icn/crates/icn-core/tests/resource_enforcer_gossip.rs
+++ b/icn/crates/icn-core/tests/resource_enforcer_gossip.rs
@@ -6,61 +6,10 @@
 // Allow unwrap/expect in test code - panics are acceptable for tests
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use icn_core::resource_enforcer_actor::{
-    ResourceAccessStore, RevocationEvent, RESOURCE_REVOCATIONS_TOPIC,
-};
-use icn_entity::EntityId;
+use icn_core::resource_enforcer_actor::{RevocationEvent, RESOURCE_REVOCATIONS_TOPIC};
 use icn_gossip::GossipActor;
 use icn_identity::KeyPair;
-use icn_ledger::{AccessModel, AntiSpeculationRules, ResourceAccess};
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
-
-/// Wait time for async gossip publication tasks to complete.
-/// 200ms provides margin for multi-node scenarios where gossip
-/// publication involves actor communication and potential network delays.
-const ASYNC_PUBLISH_WAIT_MS: u64 = 200;
-
-/// Mock store for testing that tracks revocation events
-struct MockResourceAccessStore {
-    resources: Mutex<HashMap<String, ResourceAccess>>,
-    revocations: Arc<Mutex<Vec<RevocationEvent>>>,
-}
-
-impl MockResourceAccessStore {
-    fn new(revocations_log: Arc<Mutex<Vec<RevocationEvent>>>) -> Self {
-        Self {
-            resources: Mutex::new(HashMap::new()),
-            revocations: revocations_log,
-        }
-    }
-
-    #[allow(dead_code)]
-    fn add_resource(&self, id: String, access: ResourceAccess) {
-        self.resources.lock().unwrap().insert(id, access);
-    }
-}
-
-impl ResourceAccessStore for MockResourceAccessStore {
-    fn list_all(&self) -> anyhow::Result<Vec<(String, ResourceAccess)>> {
-        let resources = self.resources.lock().unwrap();
-        Ok(resources
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect())
-    }
-
-    fn update(&mut self, resource_id: &str, access: &ResourceAccess) -> anyhow::Result<()> {
-        let mut resources = self.resources.lock().unwrap();
-        resources.insert(resource_id.to_string(), access.clone());
-        Ok(())
-    }
-
-    fn emit_revocation(&mut self, event: RevocationEvent) -> anyhow::Result<()> {
-        self.revocations.lock().unwrap().push(event);
-        Ok(())
-    }
-}
+use std::sync::Arc;
 
 #[tokio::test]
 async fn test_revocation_event_gossip_publication() {
@@ -117,11 +66,10 @@ async fn test_revocation_event_gossip_publication() {
             .unwrap();
     }
 
-    // Create a revocation event
-    let entity = EntityId::from_did(node1_did);
+    // Create a revocation event (holder is now a String, not EntityId)
     let event = RevocationEvent {
         resource_id: "test-resource-123".to_string(),
-        holder: entity,
+        holder: node1_did.to_string(),
         reason: "Resource idle for 8 days".to_string(),
         timestamp: icn_time::current_timestamp_secs(),
         idle_seconds: 8 * 24 * 3600, // 8 days
@@ -148,60 +96,81 @@ async fn test_revocation_event_gossip_publication() {
 }
 
 #[tokio::test]
-async fn test_gossip_store_wrapper_integration() {
-    use icn_core::supervisor::init_resource_enforcer::GossipResourceAccessStore;
+async fn test_enforcer_actor_with_gossip_deps() {
+    use icn_core::resource_enforcer_actor::{
+        ResourceAccessEnforcerActor, ResourceEnforcerConfig, ResourceEnforcerDeps,
+    };
+    use icn_kernel_api::services::LedgerService;
 
-    // Create revocation log for tracking
-    let revocations_log = Arc::new(Mutex::new(Vec::new()));
+    /// Stub LedgerService for integration testing
+    struct StubLedgerService;
+
+    impl LedgerService for StubLedgerService {
+        fn oracle(&self) -> Arc<dyn icn_kernel_api::authz::PolicyOracle> {
+            unimplemented!("not needed for enforcer integration tests")
+        }
+
+        fn balance(&self, _account: &icn_kernel_api::types::Did, _currency: &str) -> i64 {
+            0
+        }
+
+        fn credit_limit(&self, _account: &icn_kernel_api::types::Did, _currency: &str) -> i64 {
+            0
+        }
+
+        fn record_event(&self, _event: icn_kernel_api::services::LedgerEvent) {}
+    }
 
     // Create gossip actor
     let keypair = KeyPair::generate().unwrap();
-    let keypair_clone = keypair.clone();
-    let did = keypair_clone.did();
+    let did = keypair.did();
     let gossip_handle = GossipActor::spawn(did.clone(), None);
 
-    // Set keypair for signing
+    // Create revocation topic
     {
         let mut gossip = gossip_handle.write().await;
-        gossip.set_keypair(keypair);
+        gossip.create_topic(icn_gossip::types::Topic {
+            name: RESOURCE_REVOCATIONS_TOPIC.to_string(),
+            acl: icn_gossip::types::AccessControl::Public,
+            scope: icn_gossip::types::Scope::Global,
+            min_trust_threshold: None,
+            retention: std::time::Duration::from_secs(86400 * 7),
+            max_entries: 1000,
+        });
     }
 
-    // Create gossip-aware store
-    let inner_store = Box::new(MockResourceAccessStore::new(revocations_log.clone()));
-    let mut gossip_store = GossipResourceAccessStore::new(inner_store, gossip_handle.clone());
-
-    // Create a resource and track it
-    let entity = EntityId::from_did(did);
-    let access = ResourceAccess::new(
-        "resource-456".to_string(),
-        entity.clone(),
-        AccessModel::UseAccess {
-            duration_seconds: 90 * 24 * 3600, // 90 days
-            renewable: true,
-            max_accumulated: 4,
-        },
-    )
-    .with_rules(AntiSpeculationRules::strict());
-
-    gossip_store.update("resource-456", &access).unwrap();
-
-    // Emit a revocation
-    let event = RevocationEvent {
-        resource_id: "resource-456".to_string(),
-        holder: entity,
-        reason: "Automatic revocation: idle".to_string(),
-        timestamp: icn_time::current_timestamp_secs(),
-        idle_seconds: 10 * 24 * 3600, // 10 days
+    // Create enforcer with gossip-enabled deps
+    let config = ResourceEnforcerConfig {
+        check_interval_seconds: 3600,
+        batch_size: 100,
+        enabled: true,
     };
 
-    gossip_store.emit_revocation(event.clone()).unwrap();
+    let deps = ResourceEnforcerDeps {
+        ledger_service: Arc::new(StubLedgerService),
+        gossip_handle: Some(gossip_handle.clone()),
+    };
 
-    // Wait for async publication
-    tokio::time::sleep(tokio::time::Duration::from_millis(ASYNC_PUBLISH_WAIT_MS)).await;
+    let (shutdown_tx, _) = tokio::sync::broadcast::channel(1);
+    let shutdown_rx = shutdown_tx.subscribe();
 
-    // Verify event was logged locally
-    let logged = revocations_log.lock().unwrap();
-    assert_eq!(logged.len(), 1);
-    assert_eq!(logged[0].resource_id, "resource-456");
-    assert_eq!(logged[0].reason, "Automatic revocation: idle");
+    let handle = ResourceAccessEnforcerActor::spawn(config, deps, shutdown_rx);
+
+    // Verify actor is running
+    let stats = handle.get_stats().await.expect("Failed to get stats");
+    assert_eq!(stats.checks_performed, 0);
+    assert_eq!(stats.total_revocations, 0);
+
+    // Force a check (stub returns no enforceable resources, so 0 revocations)
+    let result = handle.force_check().await.expect("Failed to force check");
+    assert_eq!(result.resources_checked, 0);
+    assert_eq!(result.revocations, 0);
+
+    // Verify stats updated
+    let stats = handle.get_stats().await.expect("Failed to get stats");
+    assert_eq!(stats.checks_performed, 1);
+
+    // Signal shutdown
+    let _ = shutdown_tx.send(());
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 }

--- a/icn/crates/icn-core/tests/resource_enforcer_gossip.rs
+++ b/icn/crates/icn-core/tests/resource_enforcer_gossip.rs
@@ -140,8 +140,9 @@ async fn test_enforcer_actor_with_gossip_deps() {
     }
 
     // Create enforcer with gossip-enabled deps
+    // Use small interval so startup jitter is 0 (jitter = interval/10)
     let config = ResourceEnforcerConfig {
-        check_interval_seconds: 3600,
+        check_interval_seconds: 1,
         batch_size: 100,
         enabled: true,
     };
@@ -171,6 +172,103 @@ async fn test_enforcer_actor_with_gossip_deps() {
     assert_eq!(stats.checks_performed, 1);
 
     // Signal shutdown
+    let _ = shutdown_tx.send(());
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+}
+
+/// Test that enforcement with violating resources publishes revocation events to gossip.
+#[tokio::test]
+async fn test_enforcer_with_violations_publishes_gossip() {
+    use icn_core::resource_enforcer_actor::{
+        ResourceAccessEnforcerActor, ResourceEnforcerConfig, ResourceEnforcerDeps,
+    };
+    use icn_kernel_api::services::{LedgerService, ResourceAccessInfo};
+
+    /// LedgerService that returns resources with idle violations
+    struct ViolatingLedgerService;
+
+    impl LedgerService for ViolatingLedgerService {
+        fn oracle(&self) -> Arc<dyn icn_kernel_api::authz::PolicyOracle> {
+            unimplemented!("not needed for enforcer integration tests")
+        }
+
+        fn balance(&self, _account: &icn_kernel_api::types::Did, _currency: &str) -> i64 {
+            0
+        }
+
+        fn credit_limit(&self, _account: &icn_kernel_api::types::Did, _currency: &str) -> i64 {
+            0
+        }
+
+        fn record_event(&self, _event: icn_kernel_api::services::LedgerEvent) {}
+
+        fn list_enforceable_resources(
+            &self,
+            _current_time: u64,
+        ) -> Result<Vec<ResourceAccessInfo>, String> {
+            Ok(vec![ResourceAccessInfo {
+                resource_id: "idle-resource-1".to_string(),
+                holder: "did:icn:test_holder".to_string(),
+                granted_at: 0,
+                is_revoked: false,
+                idle_violation: Some(icn_kernel_api::services::IdleViolationInfo {
+                    idle_seconds: 7 * 24 * 3600,
+                    max_idle_seconds: 5 * 24 * 3600,
+                }),
+            }])
+        }
+
+        fn revoke_resource_access(
+            &self,
+            _req: &icn_kernel_api::services::RevokeResourceAccessRequest,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    // Create gossip actor with revocation topic
+    let keypair = KeyPair::generate().unwrap();
+    let did = keypair.did();
+    let gossip_handle = GossipActor::spawn(did.clone(), None);
+
+    {
+        let mut gossip = gossip_handle.write().await;
+        gossip.create_topic(icn_gossip::types::Topic {
+            name: RESOURCE_REVOCATIONS_TOPIC.to_string(),
+            acl: icn_gossip::types::AccessControl::Public,
+            scope: icn_gossip::types::Scope::Global,
+            min_trust_threshold: None,
+            retention: std::time::Duration::from_secs(86400 * 7),
+            max_entries: 1000,
+        });
+    }
+
+    // Use small interval so startup jitter is 0 (jitter = interval/10)
+    let config = ResourceEnforcerConfig {
+        check_interval_seconds: 1,
+        batch_size: 100,
+        enabled: true,
+    };
+
+    let deps = ResourceEnforcerDeps {
+        ledger_service: Arc::new(ViolatingLedgerService),
+        gossip_handle: Some(gossip_handle.clone()),
+    };
+
+    let (shutdown_tx, _) = tokio::sync::broadcast::channel(1);
+    let shutdown_rx = shutdown_tx.subscribe();
+    let handle = ResourceAccessEnforcerActor::spawn(config, deps, shutdown_rx);
+
+    // Force a check — should revoke the idle resource and publish to gossip
+    let result = handle.force_check().await.expect("Failed to force check");
+    assert_eq!(result.resources_checked, 1);
+    assert_eq!(result.revocations, 1);
+
+    // Verify stats
+    let stats = handle.get_stats().await.expect("Failed to get stats");
+    assert_eq!(stats.total_revocations, 1);
+    assert_eq!(stats.checks_performed, 1);
+
     let _ = shutdown_tx.send(());
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 }

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -385,6 +385,70 @@ pub trait LedgerService: Send + Sync {
     ///
     /// Called by the kernel when ledger-relevant actions occur.
     fn record_event(&self, event: LedgerEvent);
+
+    /// List resource access entries with their idle-violation status.
+    ///
+    /// The ledger service evaluates anti-speculation rules internally and
+    /// returns kernel-level DTOs. `current_time` is seconds since epoch.
+    ///
+    /// Default implementation returns an empty list (no resource access tracking).
+    fn list_enforceable_resources(
+        &self,
+        _current_time: u64,
+    ) -> Result<Vec<ResourceAccessInfo>, String> {
+        Ok(Vec::new())
+    }
+
+    /// Revoke resource access and persist the change.
+    ///
+    /// The ledger service handles the domain-level revocation logic
+    /// (updating internal state, audit trail, etc.).
+    ///
+    /// Default implementation returns an error (not supported).
+    fn revoke_resource_access(&self, _req: &RevokeResourceAccessRequest) -> Result<(), String> {
+        Err("Resource access revocation not supported".to_string())
+    }
+}
+
+// ============================================================================
+// Resource Access DTOs
+// ============================================================================
+
+/// A resource access entry as seen by the kernel.
+///
+/// This is a kernel-level view of resource access. The ledger service
+/// translates its internal `ResourceAccess` into this type so the kernel
+/// can enforce idle-resource revocation without importing domain types.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ResourceAccessInfo {
+    /// Unique identifier of the resource
+    pub resource_id: String,
+    /// DID of the resource holder
+    pub holder: Did,
+    /// Timestamp when access was granted (seconds since epoch)
+    pub granted_at: u64,
+    /// Whether the access has already been revoked
+    pub is_revoked: bool,
+    /// Present when the resource violates idle rules at the queried time
+    pub idle_violation: Option<IdleViolationInfo>,
+}
+
+/// Information about an idle rule violation.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct IdleViolationInfo {
+    /// How long the resource has been idle (seconds)
+    pub idle_seconds: u64,
+    /// Maximum allowed idle time (seconds)
+    pub max_idle_seconds: u64,
+}
+
+/// Request to revoke resource access.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RevokeResourceAccessRequest {
+    /// Resource to revoke
+    pub resource_id: String,
+    /// Reason for revocation (for audit trail)
+    pub reason: String,
 }
 
 /// Ledger events that the kernel can report

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -365,6 +365,13 @@ pub enum GovernanceEvent {
 /// - Record ledger events
 ///
 /// The kernel NEVER interprets ledger rules - it just enforces constraints.
+///
+/// # Sync/Async Note
+///
+/// Methods are synchronous for ergonomic kernel integration. Implementations
+/// using async locks (e.g. `tokio::RwLock`) should use
+/// `tokio::task::block_in_place()` to bridge sync/async contexts safely.
+/// This requires a multi-threaded tokio runtime.
 pub trait LedgerService: Send + Sync {
     /// Get the PolicyOracle for ledger authorization
     ///

--- a/icn/crates/icn-obs/src/lib.rs
+++ b/icn/crates/icn-obs/src/lib.rs
@@ -110,6 +110,7 @@ pub fn init_metrics() -> Result<()> {
     metrics::ledger::init_descriptions();
     metrics::nat::init_descriptions();
     metrics::network::init_descriptions();
+    metrics::resource_enforcer::init_descriptions();
     metrics::rpc::init_descriptions();
     metrics::storage::init_descriptions();
     tracing::info!("Metrics descriptions initialized");

--- a/icn/crates/icn-obs/src/metrics/mod.rs
+++ b/icn/crates/icn-obs/src/metrics/mod.rs
@@ -36,6 +36,7 @@ pub mod governance;
 pub mod ledger;
 pub mod nat;
 pub mod network;
+pub mod resource_enforcer;
 pub mod rpc;
 pub mod service_discovery;
 pub mod storage;

--- a/icn/crates/icn-obs/src/metrics/resource_enforcer.rs
+++ b/icn/crates/icn-obs/src/metrics/resource_enforcer.rs
@@ -3,7 +3,7 @@
 //! Metrics for monitoring the resource access enforcement actor,
 //! including enforcement checks, revocations, and gossip publication.
 
-use metrics::{counter, describe_counter};
+use metrics::{counter, describe_counter, describe_histogram, histogram};
 
 /// Initialize resource enforcer metric descriptions
 pub fn init_descriptions() {
@@ -31,6 +31,10 @@ pub fn init_descriptions() {
     describe_counter!(
         "icn_resource_revocation_gossip_failures_total",
         "Total number of failed attempts to publish revocation events to gossip (by reason label)"
+    );
+    describe_histogram!(
+        "icn_resource_enforcer_check_duration_seconds",
+        "Duration of each enforcement check cycle in seconds"
     );
 }
 
@@ -63,4 +67,9 @@ pub fn gossip_published_inc() {
 pub fn gossip_failure_inc(reason: &str) {
     counter!("icn_resource_revocation_gossip_failures_total", "reason" => reason.to_string())
         .increment(1);
+}
+
+/// Record enforcement check duration in seconds
+pub fn check_duration_observe(seconds: f64) {
+    histogram!("icn_resource_enforcer_check_duration_seconds").record(seconds);
 }

--- a/icn/crates/icn-obs/src/metrics/resource_enforcer.rs
+++ b/icn/crates/icn-obs/src/metrics/resource_enforcer.rs
@@ -1,0 +1,66 @@
+//! Resource access enforcer metrics
+//!
+//! Metrics for monitoring the resource access enforcement actor,
+//! including enforcement checks, revocations, and gossip publication.
+
+use metrics::{counter, describe_counter};
+
+/// Initialize resource enforcer metric descriptions
+pub fn init_descriptions() {
+    describe_counter!(
+        "icn_resource_enforcer_checks_total",
+        "Total number of enforcement check cycles performed"
+    );
+    describe_counter!(
+        "icn_resource_enforcer_resources_checked_total",
+        "Total number of resources evaluated during enforcement checks"
+    );
+    describe_counter!(
+        "icn_resource_enforcer_revocations_total",
+        "Total number of enforcement cycles that produced revocations"
+    );
+    describe_counter!(
+        "icn_resource_access_revoked_total",
+        "Total number of individual resource access entries revoked"
+    );
+    describe_counter!(
+        "icn_resource_revocation_gossip_published_total",
+        "Total number of revocation events successfully published to gossip"
+    );
+    // Labels: reason={serialization, publish}
+    describe_counter!(
+        "icn_resource_revocation_gossip_failures_total",
+        "Total number of failed attempts to publish revocation events to gossip (by reason label)"
+    );
+}
+
+/// Increment the enforcement checks counter
+pub fn checks_total_inc() {
+    counter!("icn_resource_enforcer_checks_total").increment(1);
+}
+
+/// Increment resources checked counter
+pub fn resources_checked_inc(count: u64) {
+    counter!("icn_resource_enforcer_resources_checked_total").increment(count);
+}
+
+/// Increment revocations counter
+pub fn revocations_total_inc(count: u64) {
+    counter!("icn_resource_enforcer_revocations_total").increment(count);
+}
+
+/// Increment individual access revoked counter
+pub fn access_revoked_inc() {
+    counter!("icn_resource_access_revoked_total").increment(1);
+}
+
+/// Increment gossip published counter
+pub fn gossip_published_inc() {
+    counter!("icn_resource_revocation_gossip_published_total").increment(1);
+}
+
+/// Increment gossip failure counter with reason label
+pub fn gossip_failure_inc(reason: &str) {
+    counter!("icn_resource_revocation_gossip_failures_total", "reason" => reason.to_string())
+        .increment(1);
+}


### PR DESCRIPTION
## Summary

- **Expand LedgerService trait** with `list_enforceable_resources()` and `revoke_resource_access()` methods using typed kernel-level DTOs (`ResourceAccessInfo`, `IdleViolationInfo`, `RevokeResourceAccessRequest`) — no `serde_json::Value`
- **Rewrite ResourceEnforcerActor** to use `LedgerService` instead of the removed `ResourceAccessStore` trait, eliminating `icn_ledger` imports from `resource_enforcer_actor.rs` and `init_resource_enforcer.rs`
- **Remove NullResourceAccessStore and GossipResourceAccessStore** (-300 lines); gossip publication now handled directly by the actor via `ResourceEnforcerDeps { ledger_service, gossip_handle }`
- **RevocationEvent.holder** uses kernel `Did` type instead of `icn_entity::EntityId`

## Grep ratchet

`use icn_ledger::` in `icn-core/src/`: **15 → 13**

Remaining imports in `init_ledger.rs`, `init_rpc.rs`, `config/ledger.rs`, `governance_handlers.rs` — scoped for PR 3.2 / Tier 2.

## Net impact

-383 lines across 7 files.

## Test plan

- [x] `cargo check -p icn-core --all-targets` — clean
- [x] `cargo clippy -p icn-core --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p icn-core --check` — clean
- [x] Unit tests: 5 pass (`test_config_defaults`, `test_config_serialization`, `test_revocation_event_serialization`, `test_enforce_without_gossip`, `test_spawn_resource_enforcer`)
- [x] Integration tests: 2 pass (`test_revocation_event_gossip_publication`, `test_enforcer_actor_with_gossip_deps`)
- [x] `gossip_handle: None` tested — enforcement works without gossip (no panic, revocations still occur)

🤖 Generated with [Claude Code](https://claude.com/claude-code)