### PR TITLE
refactor(ledger): decouple config/ledger.rs from icn-ledger imports

### DIFF
--- a/apps/ledger/Cargo.toml
+++ b/apps/ledger/Cargo.toml
@@ -25,6 +25,7 @@ tokio = { version = "1", features = ["sync", "rt"] }
 
 # Error handling
 anyhow = "1.0"
+thiserror = "2.0"
 
 # Logging
 tracing = "0.1"

--- a/apps/ledger/src/config.rs
+++ b/apps/ledger/src/config.rs
@@ -16,7 +16,7 @@ pub use icn_ledger::oracle::DEFAULT_SUSPICIOUS_RATE_THRESHOLD;
 pub enum WitnessConfigError {
     /// Invalid policy string
     #[error(
-        "Invalid witness policy '{0}'. Valid options: none, counterparty, quorum, all_parties"
+        "Invalid witness policy '{0}'. Valid options: none, counterparty, quorum, all_parties, allparties"
     )]
     InvalidPolicy(String),
 
@@ -58,17 +58,15 @@ pub fn build_witness_config(
             let required = quorum_required.ok_or(WitnessConfigError::MissingField(
                 "quorum_required for quorum policy",
             ))?;
-            let witness_strs =
-                quorum_witnesses.ok_or(WitnessConfigError::MissingField(
-                    "quorum_witnesses for quorum policy",
-                ))?;
+            let witness_strs = quorum_witnesses.ok_or(WitnessConfigError::MissingField(
+                "quorum_witnesses for quorum policy",
+            ))?;
 
             let mut witnesses = Vec::with_capacity(witness_strs.len());
             let mut seen_dids = std::collections::HashSet::new();
             for did_str in witness_strs {
-                let did = Did::from_str(did_str).map_err(|e| {
-                    WitnessConfigError::InvalidDid(did_str.clone(), e.to_string())
-                })?;
+                let did = Did::from_str(did_str)
+                    .map_err(|e| WitnessConfigError::InvalidDid(did_str.clone(), e.to_string()))?;
                 if !seen_dids.insert(did.clone()) {
                     return Err(WitnessConfigError::DuplicateWitness(did_str.clone()));
                 }
@@ -124,16 +122,15 @@ pub fn build_oracle_config(
 mod tests {
     use super::*;
 
-    // Drift guard: icn-core's serde default for this field is 1000.0.
+    // Drift guard: icn-core's inline default for this field is 1000.0.
     // If icn-ledger ever changes the constant, this test fails so we
-    // update the serde default in lockstep.
+    // update the inline default in lockstep.
     #[test]
     fn threshold_drift_guard() {
         assert!(
             (DEFAULT_SUSPICIOUS_RATE_THRESHOLD - 1000.0).abs() < f64::EPSILON,
-            "DEFAULT_SUSPICIOUS_RATE_THRESHOLD changed from 1000.0 to {}; \
-             update the serde default in icn-core/src/config/ledger.rs",
-            DEFAULT_SUSPICIOUS_RATE_THRESHOLD,
+            "DEFAULT_SUSPICIOUS_RATE_THRESHOLD changed from 1000.0 to {DEFAULT_SUSPICIOUS_RATE_THRESHOLD}; \
+             update the inline default in icn-core/src/config/ledger.rs",
         );
     }
 
@@ -273,9 +270,7 @@ mod tests {
         let oracle_config = build_oracle_config(3600, 1, 0.15, 86400, 500.0, thresholds);
 
         assert_eq!(oracle_config.default_ttl_secs, 3600);
-        assert!(
-            (oracle_config.default_suspicious_rate_threshold - 500.0).abs() < f64::EPSILON
-        );
+        assert!((oracle_config.default_suspicious_rate_threshold - 500.0).abs() < f64::EPSILON);
         assert_eq!(
             oracle_config.suspicious_rate_thresholds.get("USD:JPY"),
             Some(&200.0)

--- a/apps/ledger/src/config.rs
+++ b/apps/ledger/src/config.rs
@@ -1,0 +1,284 @@
+//! Configuration conversion for ledger services
+//!
+//! Provides conversion functions that take primitive config values and produce
+//! `icn_ledger` config types. This keeps `icn-core` config structs free of
+//! `icn_ledger` imports — the mapping from config fields to primitives lives
+//! in `icnd` (the daemon binary), not here.
+
+use icn_identity::Did;
+use std::collections::HashMap;
+
+// Re-export from icn-ledger so icnd and drift-guard tests can reference it.
+pub use icn_ledger::oracle::DEFAULT_SUSPICIOUS_RATE_THRESHOLD;
+
+/// Error when converting witness settings to WitnessConfig
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum WitnessConfigError {
+    /// Invalid policy string
+    #[error(
+        "Invalid witness policy '{0}'. Valid options: none, counterparty, quorum, all_parties"
+    )]
+    InvalidPolicy(String),
+
+    /// Missing required field for quorum policy
+    #[error("Missing required field: {0}")]
+    MissingField(&'static str),
+
+    /// Invalid DID format
+    #[error("Invalid DID '{0}': {1}")]
+    InvalidDid(String, String),
+
+    /// Duplicate witness in quorum configuration
+    #[error("Duplicate witness DID in quorum configuration: '{0}'")]
+    DuplicateWitness(String),
+
+    /// Quorum requires more signatures than available witnesses
+    #[error("Quorum requires {required} signatures but only {available} witnesses configured")]
+    QuorumTooLarge { required: u32, available: usize },
+}
+
+/// Build a [`icn_ledger::WitnessConfig`] from primitive config values.
+///
+/// This is the single place that interprets witness policy strings and
+/// constructs the domain type. All parameters are primitives so the caller
+/// (icnd) does not need to depend on `icn_ledger`.
+pub fn build_witness_config(
+    default_policy: &str,
+    threshold: Option<u64>,
+    quorum_required: Option<u32>,
+    quorum_witnesses: Option<&[String]>,
+    collection_timeout_secs: u64,
+    min_witness_trust: Option<f64>,
+) -> Result<icn_ledger::WitnessConfig, WitnessConfigError> {
+    let policy = match default_policy.to_lowercase().as_str() {
+        "none" => icn_ledger::WitnessPolicy::None,
+        "counterparty" => icn_ledger::WitnessPolicy::Counterparty,
+        "all_parties" | "allparties" => icn_ledger::WitnessPolicy::AllParties,
+        "quorum" => {
+            let required = quorum_required.ok_or(WitnessConfigError::MissingField(
+                "quorum_required for quorum policy",
+            ))?;
+            let witness_strs =
+                quorum_witnesses.ok_or(WitnessConfigError::MissingField(
+                    "quorum_witnesses for quorum policy",
+                ))?;
+
+            let mut witnesses = Vec::with_capacity(witness_strs.len());
+            let mut seen_dids = std::collections::HashSet::new();
+            for did_str in witness_strs {
+                let did = Did::from_str(did_str).map_err(|e| {
+                    WitnessConfigError::InvalidDid(did_str.clone(), e.to_string())
+                })?;
+                if !seen_dids.insert(did.clone()) {
+                    return Err(WitnessConfigError::DuplicateWitness(did_str.clone()));
+                }
+                witnesses.push(did);
+            }
+
+            if (required as usize) > witnesses.len() {
+                return Err(WitnessConfigError::QuorumTooLarge {
+                    required,
+                    available: witnesses.len(),
+                });
+            }
+
+            icn_ledger::WitnessPolicy::Quorum {
+                required,
+                witnesses,
+            }
+        }
+        other => return Err(WitnessConfigError::InvalidPolicy(other.to_string())),
+    };
+
+    Ok(icn_ledger::WitnessConfig {
+        default_policy: policy,
+        threshold,
+        collection_timeout_secs,
+        min_witness_trust,
+    })
+}
+
+/// Build an [`icn_ledger::oracle::OracleConfig`] from primitive config values.
+///
+/// All parameters are primitives so the caller (icnd) does not need to
+/// depend on `icn_ledger`.
+pub fn build_oracle_config(
+    default_ttl_secs: u64,
+    min_sources_for_consensus: usize,
+    outlier_threshold: f64,
+    staleness_threshold_secs: u64,
+    default_suspicious_rate_threshold: f64,
+    suspicious_rate_thresholds: HashMap<String, f64>,
+) -> icn_ledger::oracle::OracleConfig {
+    icn_ledger::oracle::OracleConfig {
+        default_ttl_secs,
+        min_sources_for_consensus,
+        outlier_threshold,
+        staleness_threshold_secs,
+        default_suspicious_rate_threshold,
+        suspicious_rate_thresholds,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Drift guard: icn-core's serde default for this field is 1000.0.
+    // If icn-ledger ever changes the constant, this test fails so we
+    // update the serde default in lockstep.
+    #[test]
+    fn threshold_drift_guard() {
+        assert!(
+            (DEFAULT_SUSPICIOUS_RATE_THRESHOLD - 1000.0).abs() < f64::EPSILON,
+            "DEFAULT_SUSPICIOUS_RATE_THRESHOLD changed from 1000.0 to {}; \
+             update the serde default in icn-core/src/config/ledger.rs",
+            DEFAULT_SUSPICIOUS_RATE_THRESHOLD,
+        );
+    }
+
+    #[test]
+    fn test_witness_settings_none_policy() {
+        let config = build_witness_config("none", None, None, None, 300, None).unwrap();
+        assert!(matches!(
+            config.default_policy,
+            icn_ledger::WitnessPolicy::None
+        ));
+    }
+
+    #[test]
+    fn test_witness_settings_counterparty_policy() {
+        let config =
+            build_witness_config("counterparty", Some(1000), None, None, 300, None).unwrap();
+        assert!(matches!(
+            config.default_policy,
+            icn_ledger::WitnessPolicy::Counterparty
+        ));
+        assert_eq!(config.threshold, Some(1000));
+    }
+
+    #[test]
+    fn test_witness_settings_all_parties_policy() {
+        let config = build_witness_config("all_parties", None, None, None, 300, None).unwrap();
+        assert!(matches!(
+            config.default_policy,
+            icn_ledger::WitnessPolicy::AllParties
+        ));
+    }
+
+    #[test]
+    fn test_witness_settings_quorum_policy() {
+        let keypair1 = icn_identity::KeyPair::generate().unwrap();
+        let keypair2 = icn_identity::KeyPair::generate().unwrap();
+        let keypair3 = icn_identity::KeyPair::generate().unwrap();
+
+        let witnesses = vec![
+            keypair1.did().to_string(),
+            keypair2.did().to_string(),
+            keypair3.did().to_string(),
+        ];
+
+        let config =
+            build_witness_config("quorum", None, Some(2), Some(&witnesses), 600, None).unwrap();
+
+        if let icn_ledger::WitnessPolicy::Quorum {
+            required,
+            witnesses,
+        } = config.default_policy
+        {
+            assert_eq!(required, 2);
+            assert_eq!(witnesses.len(), 3);
+        } else {
+            panic!("Expected Quorum policy");
+        }
+        assert_eq!(config.collection_timeout_secs, 600);
+    }
+
+    #[test]
+    fn test_witness_settings_quorum_missing_required() {
+        let witnesses = vec!["did:icn:test".to_string()];
+        let result = build_witness_config("quorum", None, None, Some(&witnesses), 300, None);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            WitnessConfigError::MissingField(_)
+        ));
+    }
+
+    #[test]
+    fn test_witness_settings_quorum_missing_witnesses() {
+        let result = build_witness_config("quorum", None, Some(2), None, 300, None);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            WitnessConfigError::MissingField(_)
+        ));
+    }
+
+    #[test]
+    fn test_witness_settings_quorum_too_large() {
+        let keypair1 = icn_identity::KeyPair::generate().unwrap();
+        let keypair2 = icn_identity::KeyPair::generate().unwrap();
+
+        let witnesses = vec![keypair1.did().to_string(), keypair2.did().to_string()];
+
+        let result = build_witness_config("quorum", None, Some(5), Some(&witnesses), 300, None);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            WitnessConfigError::QuorumTooLarge { .. }
+        ));
+    }
+
+    #[test]
+    fn test_witness_settings_duplicate_witness() {
+        let keypair = icn_identity::KeyPair::generate().unwrap();
+
+        let witnesses = vec![keypair.did().to_string(), keypair.did().to_string()];
+
+        let result = build_witness_config("quorum", None, Some(2), Some(&witnesses), 300, None);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            WitnessConfigError::DuplicateWitness(_)
+        ));
+    }
+
+    #[test]
+    fn test_witness_settings_invalid_policy() {
+        let result = build_witness_config("invalid_policy", None, None, None, 300, None);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            WitnessConfigError::InvalidPolicy(_)
+        ));
+    }
+
+    #[test]
+    fn test_witness_settings_invalid_did() {
+        let witnesses = vec!["not-a-valid-did".to_string()];
+        let result = build_witness_config("quorum", None, Some(1), Some(&witnesses), 300, None);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            WitnessConfigError::InvalidDid(_, _)
+        ));
+    }
+
+    #[test]
+    fn test_to_oracle_config() {
+        let mut thresholds = HashMap::new();
+        thresholds.insert("USD:JPY".to_string(), 200.0);
+
+        let oracle_config = build_oracle_config(3600, 1, 0.15, 86400, 500.0, thresholds);
+
+        assert_eq!(oracle_config.default_ttl_secs, 3600);
+        assert!(
+            (oracle_config.default_suspicious_rate_threshold - 500.0).abs() < f64::EPSILON
+        );
+        assert_eq!(
+            oracle_config.suspicious_rate_thresholds.get("USD:JPY"),
+            Some(&200.0)
+        );
+    }
+}

--- a/apps/ledger/src/lib.rs
+++ b/apps/ledger/src/lib.rs
@@ -32,6 +32,7 @@
 //! `LedgerService` trait from `icn-kernel-api`. This provides a clean
 //! abstraction that the kernel can use without domain knowledge.
 
+pub mod config;
 pub mod oracle;
 pub mod service;
 

--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -3271,6 +3271,7 @@ dependencies = [
  "icn-store",
  "metrics",
  "parking_lot 0.12.5",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]

--- a/icn/crates/icn-core/src/config/ledger.rs
+++ b/icn/crates/icn-core/src/config/ledger.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 /// Default suspicious rate threshold.
 ///
 /// Must match `icn_ledger::oracle::DEFAULT_SUSPICIOUS_RATE_THRESHOLD`.
-/// A compile-time drift guard in `icn-ledger-app` (apps/ledger) ensures this.
+/// A CI/unit-test drift guard in `icn-ledger-app` (apps/ledger) ensures this.
 const DEFAULT_SUSPICIOUS_RATE_THRESHOLD: f64 = 1000.0;
 
 /// Configuration for the ledger subsystem
@@ -318,9 +318,7 @@ mod tests {
         assert_eq!(config.oracle.min_sources_for_consensus, 1);
         assert!((config.oracle.outlier_threshold - 0.15).abs() < f64::EPSILON);
         assert_eq!(config.oracle.staleness_threshold_secs, 86400);
-        assert!(
-            (config.oracle.default_suspicious_rate_threshold - 1000.0).abs() < f64::EPSILON
-        );
+        assert!((config.oracle.default_suspicious_rate_threshold - 1000.0).abs() < f64::EPSILON);
         assert!(config.oracle.suspicious_rate_thresholds.is_empty());
     }
 

--- a/icn/crates/icn-core/src/config/ledger.rs
+++ b/icn/crates/icn-core/src/config/ledger.rs
@@ -7,8 +7,11 @@ use icn_identity::Did;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-// Re-export from icn-ledger to maintain single source of truth
-pub use icn_ledger::oracle::DEFAULT_SUSPICIOUS_RATE_THRESHOLD;
+/// Default suspicious rate threshold.
+///
+/// Must match `icn_ledger::oracle::DEFAULT_SUSPICIOUS_RATE_THRESHOLD`.
+/// A compile-time drift guard in `icn-ledger-app` (apps/ledger) ensures this.
+const DEFAULT_SUSPICIOUS_RATE_THRESHOLD: f64 = 1000.0;
 
 /// Configuration for the ledger subsystem
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -316,9 +319,7 @@ mod tests {
         assert!((config.oracle.outlier_threshold - 0.15).abs() < f64::EPSILON);
         assert_eq!(config.oracle.staleness_threshold_secs, 86400);
         assert!(
-            (config.oracle.default_suspicious_rate_threshold - DEFAULT_SUSPICIOUS_RATE_THRESHOLD)
-                .abs()
-                < f64::EPSILON
+            (config.oracle.default_suspicious_rate_threshold - 1000.0).abs() < f64::EPSILON
         );
         assert!(config.oracle.suspicious_rate_thresholds.is_empty());
     }
@@ -360,27 +361,6 @@ default_suspicious_rate_threshold = 500.0
     }
 
     #[test]
-    fn test_to_oracle_config() {
-        let mut thresholds = std::collections::HashMap::new();
-        thresholds.insert("USD:JPY".to_string(), 200.0);
-
-        let node_config = OracleNodeConfig {
-            default_suspicious_rate_threshold: 500.0,
-            suspicious_rate_thresholds: thresholds,
-            ..Default::default()
-        };
-
-        let oracle_config = node_config.to_oracle_config();
-
-        assert_eq!(oracle_config.default_ttl_secs, 3600);
-        assert!((oracle_config.default_suspicious_rate_threshold - 500.0).abs() < f64::EPSILON);
-        assert_eq!(
-            oracle_config.suspicious_rate_thresholds.get("USD:JPY"),
-            Some(&200.0)
-        );
-    }
-
-    #[test]
     fn test_partial_config() {
         // Test that we can provide only some fields and get defaults for others
         let toml_str = r#"
@@ -415,189 +395,6 @@ default_suspicious_rate_threshold = 2000.0
         assert!(settings.quorum_required.is_none());
         assert!(settings.quorum_witnesses.is_none());
         assert_eq!(settings.collection_timeout_secs, 300);
-    }
-
-    #[test]
-    fn test_witness_settings_none_policy() {
-        let settings = WitnessSettings::default();
-        let config = settings.to_witness_config().unwrap();
-
-        assert!(matches!(
-            config.default_policy,
-            icn_ledger::WitnessPolicy::None
-        ));
-    }
-
-    #[test]
-    fn test_witness_settings_counterparty_policy() {
-        let settings = WitnessSettings {
-            default_policy: "counterparty".to_string(),
-            threshold: Some(1000),
-            ..Default::default()
-        };
-        let config = settings.to_witness_config().unwrap();
-
-        assert!(matches!(
-            config.default_policy,
-            icn_ledger::WitnessPolicy::Counterparty
-        ));
-        assert_eq!(config.threshold, Some(1000));
-    }
-
-    #[test]
-    fn test_witness_settings_all_parties_policy() {
-        let settings = WitnessSettings {
-            default_policy: "all_parties".to_string(),
-            ..Default::default()
-        };
-        let config = settings.to_witness_config().unwrap();
-
-        assert!(matches!(
-            config.default_policy,
-            icn_ledger::WitnessPolicy::AllParties
-        ));
-    }
-
-    #[test]
-    fn test_witness_settings_quorum_policy() {
-        // Generate valid DIDs using keypairs
-        let keypair1 = icn_identity::KeyPair::generate().unwrap();
-        let keypair2 = icn_identity::KeyPair::generate().unwrap();
-        let keypair3 = icn_identity::KeyPair::generate().unwrap();
-
-        let settings = WitnessSettings {
-            default_policy: "quorum".to_string(),
-            quorum_required: Some(2),
-            quorum_witnesses: Some(vec![
-                keypair1.did().to_string(),
-                keypair2.did().to_string(),
-                keypair3.did().to_string(),
-            ]),
-            collection_timeout_secs: 600,
-            ..Default::default()
-        };
-        let config = settings.to_witness_config().unwrap();
-
-        if let icn_ledger::WitnessPolicy::Quorum {
-            required,
-            witnesses,
-        } = config.default_policy
-        {
-            assert_eq!(required, 2);
-            assert_eq!(witnesses.len(), 3);
-        } else {
-            panic!("Expected Quorum policy");
-        }
-        assert_eq!(config.collection_timeout_secs, 600);
-    }
-
-    #[test]
-    fn test_witness_settings_quorum_missing_required() {
-        let settings = WitnessSettings {
-            default_policy: "quorum".to_string(),
-            quorum_witnesses: Some(vec!["did:icn:test".to_string()]),
-            ..Default::default()
-        };
-
-        let result = settings.to_witness_config();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            WitnessConfigError::MissingField(_)
-        ));
-    }
-
-    #[test]
-    fn test_witness_settings_quorum_missing_witnesses() {
-        let settings = WitnessSettings {
-            default_policy: "quorum".to_string(),
-            quorum_required: Some(2),
-            ..Default::default()
-        };
-
-        let result = settings.to_witness_config();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            WitnessConfigError::MissingField(_)
-        ));
-    }
-
-    #[test]
-    fn test_witness_settings_quorum_too_large() {
-        let keypair1 = icn_identity::KeyPair::generate().unwrap();
-        let keypair2 = icn_identity::KeyPair::generate().unwrap();
-
-        let settings = WitnessSettings {
-            default_policy: "quorum".to_string(),
-            quorum_required: Some(5),
-            quorum_witnesses: Some(vec![
-                keypair1.did().to_string(),
-                keypair2.did().to_string(), // Only 2 distinct witnesses, require 5
-            ]),
-            ..Default::default()
-        };
-
-        let result = settings.to_witness_config();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            WitnessConfigError::QuorumTooLarge { .. }
-        ));
-    }
-
-    #[test]
-    fn test_witness_settings_duplicate_witness() {
-        let keypair = icn_identity::KeyPair::generate().unwrap();
-
-        let settings = WitnessSettings {
-            default_policy: "quorum".to_string(),
-            quorum_required: Some(2),
-            quorum_witnesses: Some(vec![
-                keypair.did().to_string(),
-                keypair.did().to_string(), // Same DID twice
-            ]),
-            ..Default::default()
-        };
-
-        let result = settings.to_witness_config();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            WitnessConfigError::DuplicateWitness(_)
-        ));
-    }
-
-    #[test]
-    fn test_witness_settings_invalid_policy() {
-        let settings = WitnessSettings {
-            default_policy: "invalid_policy".to_string(),
-            ..Default::default()
-        };
-
-        let result = settings.to_witness_config();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            WitnessConfigError::InvalidPolicy(_)
-        ));
-    }
-
-    #[test]
-    fn test_witness_settings_invalid_did() {
-        let settings = WitnessSettings {
-            default_policy: "quorum".to_string(),
-            quorum_required: Some(1),
-            quorum_witnesses: Some(vec!["not-a-valid-did".to_string()]),
-            ..Default::default()
-        };
-
-        let result = settings.to_witness_config();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            WitnessConfigError::InvalidDid(_, _)
-        ));
     }
 
     #[test]

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -600,6 +600,14 @@ impl ServiceRegistry {
     pub const LEDGER_KEY: &str = "ledger";
     /// Key for `Arc<SledStore>` raw handle (shared with DisputeManager/TreasuryManager)
     pub const LEDGER_STORE_KEY: &str = "ledger_store";
+    /// Key for `Arc<RwLock<DisputeManager>>` raw handle
+    pub const DISPUTE_MANAGER_KEY: &str = "dispute_manager";
+    /// Key for `Arc<RwLock<TreasuryManager>>` raw handle
+    pub const TREASURY_MANAGER_KEY: &str = "treasury_manager";
+    /// Key for `Arc<RwLock<ContractRuntime>>` raw handle
+    pub const CONTRACT_RUNTIME_KEY: &str = "contract_runtime";
+    /// Key for `Arc<RwLock<ContractActor>>` raw handle
+    pub const CONTRACT_ACTOR_KEY: &str = "contract_actor";
 
     /// Create a new empty service registry
     pub fn new() -> Self {


### PR DESCRIPTION
## Summary
- Replace `pub use icn_ledger::oracle::DEFAULT_SUSPICIOUS_RATE_THRESHOLD` re-export with inline constant in icn-core, guarded by a drift test in `apps/ledger`
- Create `apps/ledger/src/config.rs` with `build_witness_config()` and `build_oracle_config()` — conversion functions that take primitive values only (no icn-ledger types in signature)
- Move witness/oracle conversion tests from icn-core to apps/ledger config module (12 tests)
- Add `ServiceRegistry` key constants: `DISPUTE_MANAGER_KEY`, `TREASURY_MANAGER_KEY`, `CONTRACT_RUNTIME_KEY`, `CONTRACT_ACTOR_KEY` (prep for PR 3.2B)
- Keep `to_witness_config()`/`to_oracle_config()` on icn-core structs temporarily (still called by `init_ledger.rs`, removed in next PR)

**Previous PRs**: #977 (Tier 1, icn-trust), #979 (Tier 3.1, ResourceEnforcerActor)

## What
Config structs in `icn-core/src/config/ledger.rs` no longer import `icn_ledger` constants. The conversion logic that creates `WitnessConfig` and `OracleConfig` from primitive config values now lives in `apps/ledger/src/config.rs`.

## Why
Part of the "Liberate icn-core" sprint — removing domain crate (`icn-ledger`) dependencies from kernel crate (`icn-core`). The `to_witness_config()` and `to_oracle_config()` methods are kept temporarily because `init_ledger.rs` (still in icn-core) calls them; they'll be deleted when init_ledger.rs moves to apps/ledger in the next PR.

## Risk
Low. No behavioral changes — same defaults, same serde field names, same conversion logic. Drift guard test ensures the inline constant stays in sync with icn-ledger's canonical value.

## Test plan
- `cargo test -p icn-core --lib -- config::ledger` (6 serde tests pass)
- `cd apps/ledger && cargo test -- config` (12 conversion tests pass, incl. drift guard)
- `cargo clippy -p icn-core --all-targets -- -D warnings` (clean)
- `cargo check -p icnd` (builds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)