### PR TITLE
refactor(ledger): move init_ledger.rs to apps/ledger and wire via ServiceRegistry

### DIFF
--- a/apps/ledger/Cargo.toml
+++ b/apps/ledger/Cargo.toml
@@ -19,9 +19,15 @@ icn-identity = { path = "../../icn/crates/icn-identity" }
 # Storage
 icn-store = { path = "../../icn/crates/icn-store" }
 
+# Contract execution (for ContractRuntime, ContractActor, CharterValidator)
+icn-ccl = { path = "../../icn/crates/icn-ccl" }
+
+# Observability (for treasury validation metrics)
+icn-obs = { path = "../../icn/crates/icn-obs" }
+
 # Sync primitives (for PolicyOracle sync requirement)
 parking_lot = "0.12"
-tokio = { version = "1", features = ["sync", "rt"] }
+tokio = { version = "1", features = ["sync", "rt", "time"] }
 
 # Error handling
 anyhow = "1.0"

--- a/apps/ledger/src/init.rs
+++ b/apps/ledger/src/init.rs
@@ -1,32 +1,35 @@
-//! Ledger and contract initialization
+//! Ledger service initialization
 //!
-//! Initializes the double-entry ledger, dispute management, and contract execution.
+//! Initializes the ledger configuration (oracle, witness, membership, credit policy),
+//! dispute management, treasury management, contract runtime, and validation hooks.
+//!
+//! The caller is responsible for:
+//! - Creating `Ledger` + `SledStore` beforehand
+//! - Wiring runtime handles (gossip, misbehavior, trust) AFTER calling this
+//!
+//! This module takes only primitive/domain types — no `icn-core` config types.
 
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
 use tracing::info;
 
-use icn_gossip::GossipActor;
 use icn_identity::Did;
 use icn_ledger::{
     CreditPolicy, CreditPolicyManager, DisputeManager, Ledger, NewMemberPolicy, OracleManager,
     SledMembershipStore, TreasuryManager,
 };
-use icn_security::MisbehaviorDetector;
 use icn_store::SledStore;
 
-use crate::config::Config;
-
-/// Timeout for acquiring treasury validation lock (milliseconds)
+/// Timeout for acquiring treasury validation lock (milliseconds).
 /// Set to 1000ms (1 second) to handle high load and slow storage backends.
 /// If validation times out, the transaction is rejected to prevent unauthorized withdrawals.
 const TREASURY_VALIDATION_LOCK_TIMEOUT_MS: u64 = 1000;
 
-/// Services initialized during ledger setup
+/// Services created during ledger initialization.
+///
+/// Does NOT include `ledger_handle` or `ledger_store` — the caller already owns those.
 pub struct LedgerServices {
-    /// The ledger handle
-    pub ledger_handle: Arc<RwLock<Ledger>>,
     /// Dispute manager for handling payment disputes
     pub dispute_manager: Arc<RwLock<DisputeManager>>,
     /// Treasury manager for cooperative treasury operations
@@ -35,75 +38,37 @@ pub struct LedgerServices {
     pub contract_runtime: Arc<RwLock<icn_ccl::ContractRuntime>>,
     /// Contract actor for contract lifecycle management
     pub contract_actor: Arc<RwLock<icn_ccl::ContractActor>>,
-    /// Ledger store (shared with dispute manager)
-    pub ledger_store: Arc<SledStore>,
 }
 
-/// Dependencies for ledger initialization
-pub struct LedgerDeps {
-    pub gossip_handle: Arc<RwLock<GossipActor>>,
-    pub misbehavior_detector: Arc<RwLock<MisbehaviorDetector>>,
-    /// Trust service for kernel/app separated trust score queries
-    pub trust_service: Option<Arc<dyn icn_kernel_api::services::TrustService>>,
-    /// Pre-created ledger handle from daemon (daemon owns lifecycle)
-    pub ledger_handle: Option<Arc<RwLock<Ledger>>>,
-    /// Pre-opened ledger store from daemon (avoids double sled open;
-    /// sled uses exclusive file locking so re-opening the same path fails)
-    pub ledger_store: Option<Arc<SledStore>>,
-}
-
-/// Initialize ledger and contract services
+/// Initialize ledger services (oracle, witness, membership, credit, dispute, treasury, contracts).
 ///
-/// Creates:
-/// - Ledger with gossip and misbehavior integration
-/// - DisputeManager for payment dispute resolution
-/// - ContractRuntime for CCL execution
-/// - ContractActor for contract lifecycle
+/// This configures the ledger with oracle, witness, membership, and credit policies,
+/// then creates the DisputeManager, TreasuryManager, ContractRuntime, charter validator,
+/// combined validation hook, and ContractActor.
+///
+/// # Arguments
+/// * `ledger_handle` - Pre-created Ledger handle (owned by daemon)
+/// * `store` - Pre-opened SledStore (shared with Ledger, DisputeManager, TreasuryManager)
+/// * `did` - Node's DID
+/// * `oracle_config` - Oracle configuration (built from primitive config values by daemon)
+/// * `witness_config` - Witness configuration (built from primitive config values by daemon)
 pub async fn init_ledger_services(
-    config: &Config,
+    ledger_handle: Arc<RwLock<Ledger>>,
+    store: Arc<SledStore>,
     did: Did,
-    deps: LedgerDeps,
+    oracle_config: icn_ledger::oracle::OracleConfig,
+    witness_config: icn_ledger::WitnessConfig,
 ) -> anyhow::Result<LedgerServices> {
-    // Reuse daemon-provided store or open a new one.
-    // sled uses exclusive file locking, so re-opening the same path would fail
-    // if the daemon already opened it.
-    let store_path = config.ledger_store_path();
-    let store = if let Some(s) = deps.ledger_store {
-        info!("Using daemon-provided ledger store");
-        s
-    } else {
-        Arc::new(SledStore::open(&store_path)?)
-    };
-
-    // Use daemon-provided ledger handle or create a new one
-    let ledger_handle = if let Some(handle) = deps.ledger_handle {
-        info!("Using daemon-provided Ledger handle");
-        handle
-    } else {
-        Arc::new(RwLock::new(Ledger::new(store.clone())?))
-    };
-
-    // Configure ledger with gossip, misbehavior detection, trust, and policies.
-    // Note: This write lock is held for the entire configuration block (~60 lines).
+    // Configure ledger with oracle, witness, membership, and credit policies.
+    // Note: This write lock is held for the entire configuration block.
     // This is acceptable because it runs during supervisor startup before any
     // concurrent readers exist. No contention is possible at this point.
     {
         let mut ledger = ledger_handle.write().await;
 
-        ledger.set_gossip(deps.gossip_handle.clone());
-        ledger.set_misbehavior_detector(deps.misbehavior_detector.clone());
-
-        // Set TrustService for kernel/app separated trust queries
-        if let Some(trust_service) = deps.trust_service.clone() {
-            ledger.set_trust_service(trust_service);
-            info!("Ledger initialized with TrustService");
-        } else {
-            info!("Ledger initialized without TrustService (trust validation disabled)");
-        }
-
         // Initialize oracle manager with per-pair rate thresholds from config (Issue #474)
-        let oracle_config = config.ledger.oracle.to_oracle_config();
         let threshold_count = oracle_config.suspicious_rate_thresholds.len();
+        let default_threshold = oracle_config.default_suspicious_rate_threshold;
         let oracle_manager = Arc::new(OracleManager::with_config(store.clone(), oracle_config));
         ledger.set_oracle_manager(oracle_manager);
 
@@ -115,26 +80,27 @@ pub async fn init_ledger_services(
         } else {
             info!(
                 "Oracle manager initialized with default threshold {}",
-                config.ledger.oracle.default_suspicious_rate_threshold
+                default_threshold
             );
         }
 
         // Initialize witness config for material transaction signatures (Issue #676)
-        let witness_config = config.ledger.witness.to_witness_config()?;
         let witness_policy = format!("{:?}", witness_config.default_policy);
+        let witness_threshold = witness_config.threshold;
+        let witness_timeout = witness_config.collection_timeout_secs;
         ledger.set_witness_config(witness_config);
 
-        match &config.ledger.witness.threshold {
+        match witness_threshold {
             Some(threshold) => {
                 info!(
                     "Witness signatures configured: policy={}, threshold={} (timeout={}s)",
-                    witness_policy, threshold, config.ledger.witness.collection_timeout_secs
+                    witness_policy, threshold, witness_timeout
                 );
             }
             None => {
                 info!(
                     "Witness signatures configured: policy={} for all transactions (timeout={}s)",
-                    witness_policy, config.ledger.witness.collection_timeout_secs
+                    witness_policy, witness_timeout
                 );
             }
         }
@@ -156,7 +122,7 @@ pub async fn init_ledger_services(
         );
     }
 
-    info!("Ledger initialized at {}", store_path.display());
+    info!("Ledger configured");
 
     // Initialize DisputeManager (shares store with Ledger)
     let dispute_manager = DisputeManager::new(store.clone())?;
@@ -250,11 +216,9 @@ pub async fn init_ledger_services(
     info!("Contract actor created");
 
     Ok(LedgerServices {
-        ledger_handle,
         dispute_manager: dispute_manager_handle,
         treasury_manager: treasury_manager_handle,
         contract_runtime: contract_runtime_handle,
         contract_actor: contract_actor_handle,
-        ledger_store: store,
     })
 }

--- a/apps/ledger/src/lib.rs
+++ b/apps/ledger/src/lib.rs
@@ -33,6 +33,7 @@
 //! abstraction that the kernel can use without domain knowledge.
 
 pub mod config;
+pub mod init;
 pub mod oracle;
 pub mod service;
 

--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -3265,9 +3265,11 @@ name = "icn-ledger-app"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "icn-ccl",
  "icn-identity",
  "icn-kernel-api",
  "icn-ledger",
+ "icn-obs",
  "icn-store",
  "metrics",
  "parking_lot 0.12.5",

--- a/icn/bins/icnd/src/main.rs
+++ b/icn/bins/icnd/src/main.rs
@@ -73,7 +73,10 @@ struct Args {
 /// This creates the app-level services (trust, governance, ledger) and
 /// packages them in a ServiceRegistry for injection into the kernel.
 /// This is the key point where domain logic is separated from kernel logic.
-fn build_service_registry(
+///
+/// All mapping from icn-core config structs to primitive adapter args lives here
+/// (in the daemon binary), keeping apps/ledger free of icn-core dependencies.
+async fn build_service_registry(
     config: &Config,
     identity_bundle: Option<&icn_identity::IdentityBundle>,
 ) -> Result<ServiceRegistry> {
@@ -90,7 +93,7 @@ fn build_service_registry(
             Arc::new(icn_store::SledStore::open(&trust_store_path)?);
 
         // Create TrustGraph with tokio lock (for icn-core compatibility)
-        let trust_graph = icn_trust::TrustGraph::new(trust_store, own_did);
+        let trust_graph = icn_trust::TrustGraph::new(trust_store, own_did.clone());
         let trust_graph_handle = Arc::new(RwLock::new(trust_graph));
 
         // Create TrustService from apps/trust
@@ -133,8 +136,6 @@ fn build_service_registry(
         tracing::info!("Governance service initialized from apps/governance");
 
         // Create LedgerService from apps/ledger
-        // Ledger is created minimally here; supervisor configures it further
-        // (gossip, trust, oracle, witnesses, credit policy, validation hooks)
         let ledger_store_path = config.ledger_store_path();
         std::fs::create_dir_all(&ledger_store_path).with_context(|| {
             format!(
@@ -156,10 +157,49 @@ fn build_service_registry(
         let ledger_handle = Arc::new(RwLock::new(ledger));
         let ledger_service = icn_ledger_app::create_service(ledger_handle.clone());
         registry = registry.with_ledger(ledger_service);
-        registry = registry.with_raw_handle(ServiceRegistry::LEDGER_KEY, ledger_handle);
-        // Pass concrete SledStore so supervisor can reuse it for DisputeManager/TreasuryManager
-        // without re-opening the sled DB (sled uses exclusive file locking per open)
-        registry = registry.with_raw_handle(ServiceRegistry::LEDGER_STORE_KEY, ledger_store);
+        registry = registry.with_raw_handle(ServiceRegistry::LEDGER_KEY, ledger_handle.clone());
+        registry = registry.with_raw_handle(ServiceRegistry::LEDGER_STORE_KEY, ledger_store.clone());
+
+        // Initialize ledger services (oracle, witness, membership, credit, dispute,
+        // treasury, contracts). Config→primitive mapping stays in the daemon binary.
+        let oracle_config = icn_ledger_app::config::build_oracle_config(
+            config.ledger.oracle.default_ttl_secs,
+            config.ledger.oracle.min_sources_for_consensus,
+            config.ledger.oracle.outlier_threshold,
+            config.ledger.oracle.staleness_threshold_secs,
+            config.ledger.oracle.default_suspicious_rate_threshold,
+            config.ledger.oracle.suspicious_rate_thresholds.clone(),
+        );
+        let witness_config = icn_ledger_app::config::build_witness_config(
+            &config.ledger.witness.default_policy,
+            config.ledger.witness.threshold,
+            config.ledger.witness.quorum_required,
+            config.ledger.witness.quorum_witnesses.as_deref(),
+            config.ledger.witness.collection_timeout_secs,
+            config.ledger.witness.min_witness_trust,
+        )
+        .context("Invalid witness configuration")?;
+        let ledger_services = icn_ledger_app::init::init_ledger_services(
+            ledger_handle, ledger_store, own_did.clone(), oracle_config, witness_config,
+        )
+        .await
+        .context("Failed to initialize ledger services")?;
+        registry = registry.with_raw_handle(
+            ServiceRegistry::DISPUTE_MANAGER_KEY,
+            ledger_services.dispute_manager,
+        );
+        registry = registry.with_raw_handle(
+            ServiceRegistry::TREASURY_MANAGER_KEY,
+            ledger_services.treasury_manager,
+        );
+        registry = registry.with_raw_handle(
+            ServiceRegistry::CONTRACT_RUNTIME_KEY,
+            ledger_services.contract_runtime,
+        );
+        registry = registry.with_raw_handle(
+            ServiceRegistry::CONTRACT_ACTOR_KEY,
+            ledger_services.contract_actor,
+        );
         tracing::info!("Ledger service initialized from apps/ledger");
     }
 
@@ -365,7 +405,7 @@ async fn main() -> Result<()> {
 
     // Build service registry with domain app services
     // This injects app-level services into the kernel for proper separation
-    let service_registry = build_service_registry(&config, identity_bundle.as_ref())?;
+    let service_registry = build_service_registry(&config, identity_bundle.as_ref()).await?;
 
     // Create runtime with injected services
     let runtime = Runtime::new(config.clone(), identity_bundle).with_services(service_registry);

--- a/icn/bins/icnd/src/main.rs
+++ b/icn/bins/icnd/src/main.rs
@@ -158,7 +158,8 @@ async fn build_service_registry(
         let ledger_service = icn_ledger_app::create_service(ledger_handle.clone());
         registry = registry.with_ledger(ledger_service);
         registry = registry.with_raw_handle(ServiceRegistry::LEDGER_KEY, ledger_handle.clone());
-        registry = registry.with_raw_handle(ServiceRegistry::LEDGER_STORE_KEY, ledger_store.clone());
+        registry =
+            registry.with_raw_handle(ServiceRegistry::LEDGER_STORE_KEY, ledger_store.clone());
 
         // Initialize ledger services (oracle, witness, membership, credit, dispute,
         // treasury, contracts). Config→primitive mapping stays in the daemon binary.
@@ -180,7 +181,11 @@ async fn build_service_registry(
         )
         .context("Invalid witness configuration")?;
         let ledger_services = icn_ledger_app::init::init_ledger_services(
-            ledger_handle, ledger_store, own_did.clone(), oracle_config, witness_config,
+            ledger_handle,
+            ledger_store,
+            own_did.clone(),
+            oracle_config,
+            witness_config,
         )
         .await
         .context("Failed to initialize ledger services")?;

--- a/icn/crates/icn-core/src/config/ledger.rs
+++ b/icn/crates/icn-core/src/config/ledger.rs
@@ -1,9 +1,9 @@
 //! Ledger configuration
 //!
-//! Configuration for the mutual credit ledger, exchange rate oracle,
-//! and witness signatures for material transactions.
+//! Pure serde configuration structs for the mutual credit ledger, exchange rate
+//! oracle, and witness signatures. No `icn-ledger` types are imported here.
+//! Conversion to domain types happens in `apps/ledger/src/config.rs`.
 
-use icn_identity::Did;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -113,91 +113,6 @@ impl Default for WitnessSettings {
     }
 }
 
-impl WitnessSettings {
-    /// Convert to the icn-ledger WitnessConfig type
-    ///
-    /// Returns an error if the configuration is invalid (e.g., quorum policy
-    /// without required/witnesses fields, or invalid DID format).
-    pub fn to_witness_config(&self) -> Result<icn_ledger::WitnessConfig, WitnessConfigError> {
-        let policy = match self.default_policy.to_lowercase().as_str() {
-            "none" => icn_ledger::WitnessPolicy::None,
-            "counterparty" => icn_ledger::WitnessPolicy::Counterparty,
-            "all_parties" | "allparties" => icn_ledger::WitnessPolicy::AllParties,
-            "quorum" => {
-                let required = self
-                    .quorum_required
-                    .ok_or(WitnessConfigError::MissingField(
-                        "quorum_required for quorum policy",
-                    ))?;
-                let witness_strs =
-                    self.quorum_witnesses
-                        .as_ref()
-                        .ok_or(WitnessConfigError::MissingField(
-                            "quorum_witnesses for quorum policy",
-                        ))?;
-
-                let mut witnesses = Vec::with_capacity(witness_strs.len());
-                let mut seen_dids = std::collections::HashSet::new();
-                for did_str in witness_strs {
-                    let did = Did::from_str(did_str).map_err(|e| {
-                        WitnessConfigError::InvalidDid(did_str.clone(), e.to_string())
-                    })?;
-                    if !seen_dids.insert(did.clone()) {
-                        return Err(WitnessConfigError::DuplicateWitness(did_str.clone()));
-                    }
-                    witnesses.push(did);
-                }
-
-                if (required as usize) > witnesses.len() {
-                    return Err(WitnessConfigError::QuorumTooLarge {
-                        required,
-                        available: witnesses.len(),
-                    });
-                }
-
-                icn_ledger::WitnessPolicy::Quorum {
-                    required,
-                    witnesses,
-                }
-            }
-            other => return Err(WitnessConfigError::InvalidPolicy(other.to_string())),
-        };
-
-        Ok(icn_ledger::WitnessConfig {
-            default_policy: policy,
-            threshold: self.threshold,
-            collection_timeout_secs: self.collection_timeout_secs,
-            min_witness_trust: self.min_witness_trust,
-        })
-    }
-}
-
-/// Error when converting WitnessSettings to WitnessConfig
-#[derive(Debug, Clone, thiserror::Error)]
-pub enum WitnessConfigError {
-    /// Invalid policy string
-    #[error(
-        "Invalid witness policy '{0}'. Valid options: none, counterparty, quorum, all_parties"
-    )]
-    InvalidPolicy(String),
-
-    /// Missing required field for quorum policy
-    #[error("Missing required field: {0}")]
-    MissingField(&'static str),
-
-    /// Invalid DID format
-    #[error("Invalid DID '{0}': {1}")]
-    InvalidDid(String, String),
-
-    /// Duplicate witness in quorum configuration
-    #[error("Duplicate witness DID in quorum configuration: '{0}'")]
-    DuplicateWitness(String),
-
-    /// Quorum requires more signatures than available witnesses
-    #[error("Quorum requires {required} signatures but only {available} witnesses configured")]
-    QuorumTooLarge { required: u32, available: usize },
-}
-
 /// Configuration for the exchange rate oracle
 ///
 /// This configuration controls how exchange rates are validated and
@@ -292,20 +207,6 @@ impl Default for OracleNodeConfig {
     }
 }
 
-impl OracleNodeConfig {
-    /// Convert to the icn-ledger OracleConfig type
-    pub fn to_oracle_config(&self) -> icn_ledger::oracle::OracleConfig {
-        icn_ledger::oracle::OracleConfig {
-            default_ttl_secs: self.default_ttl_secs,
-            min_sources_for_consensus: self.min_sources_for_consensus,
-            outlier_threshold: self.outlier_threshold,
-            staleness_threshold_secs: self.staleness_threshold_secs,
-            default_suspicious_rate_threshold: self.default_suspicious_rate_threshold,
-            suspicious_rate_thresholds: self.suspicious_rate_thresholds.clone(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -360,7 +261,6 @@ default_suspicious_rate_threshold = 500.0
 
     #[test]
     fn test_partial_config() {
-        // Test that we can provide only some fields and get defaults for others
         let toml_str = r#"
 default_suspicious_rate_threshold = 2000.0
 
@@ -370,19 +270,15 @@ default_suspicious_rate_threshold = 2000.0
 
         let config: OracleNodeConfig = toml::from_str(toml_str).unwrap();
 
-        // Custom values
         assert!((config.default_suspicious_rate_threshold - 2000.0).abs() < f64::EPSILON);
         assert_eq!(
             config.suspicious_rate_thresholds.get("BTC:USD"),
             Some(&150000.0)
         );
 
-        // Default values
         assert_eq!(config.default_ttl_secs, 3600);
         assert_eq!(config.min_sources_for_consensus, 1);
     }
-
-    // Witness Settings Tests (Issue #676)
 
     #[test]
     fn test_witness_settings_defaults() {
@@ -414,10 +310,7 @@ collection_timeout_secs = 600
     fn test_ledger_config_with_witness_defaults() {
         let config = LedgerConfig::default();
 
-        // Oracle defaults
         assert_eq!(config.oracle.default_ttl_secs, 3600);
-
-        // Witness defaults
         assert_eq!(config.witness.default_policy, "none");
         assert!(config.witness.threshold.is_none());
     }

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -215,12 +215,34 @@ async fn spawn_actors_with_identity(
 
     let did = identity_bundle.did().clone();
 
-    // Extract daemon-provided ledger handles from ServiceRegistry early
-    // (needed before ledger init which happens before governance init)
+    // Extract pre-initialized ledger handles from ServiceRegistry.
+    // These were created by icn_ledger_app::init::init_ledger_services() in the daemon.
     let ledger_from_daemon: Option<Arc<RwLock<icn_ledger::Ledger>>> = service_registry
         .and_then(|r| r.raw_handle::<RwLock<icn_ledger::Ledger>>(ServiceRegistry::LEDGER_KEY));
     let ledger_store_from_daemon: Option<Arc<icn_store::SledStore>> = service_registry
         .and_then(|r| r.raw_handle::<icn_store::SledStore>(ServiceRegistry::LEDGER_STORE_KEY));
+    let dispute_manager_from_daemon: Option<Arc<RwLock<icn_ledger::DisputeManager>>> =
+        service_registry.and_then(|r| {
+            r.raw_handle::<RwLock<icn_ledger::DisputeManager>>(
+                ServiceRegistry::DISPUTE_MANAGER_KEY,
+            )
+        });
+    let treasury_manager_from_daemon: Option<Arc<RwLock<icn_ledger::TreasuryManager>>> =
+        service_registry.and_then(|r| {
+            r.raw_handle::<RwLock<icn_ledger::TreasuryManager>>(
+                ServiceRegistry::TREASURY_MANAGER_KEY,
+            )
+        });
+    let contract_runtime_from_daemon: Option<Arc<RwLock<icn_ccl::ContractRuntime>>> =
+        service_registry.and_then(|r| {
+            r.raw_handle::<RwLock<icn_ccl::ContractRuntime>>(
+                ServiceRegistry::CONTRACT_RUNTIME_KEY,
+            )
+        });
+    let contract_actor_from_daemon: Option<Arc<RwLock<icn_ccl::ContractActor>>> = service_registry
+        .and_then(|r| {
+            r.raw_handle::<RwLock<icn_ccl::ContractActor>>(ServiceRegistry::CONTRACT_ACTOR_KEY)
+        });
 
     // Create NodeProfile with hardware sensing (Phase 17)
     let node_profile = crate::node::create_node_profile(
@@ -301,28 +323,37 @@ async fn spawn_actors_with_identity(
     let gossip_store = gossip_services.gossip_store.clone();
     let loaded_snapshot = gossip_services.loaded_snapshot;
 
-    // Initialize ledger and contract services
-    // Pass TrustService for kernel/app separation if available
-    let ledger_services = super::init_ledger::init_ledger_services(
-        config,
-        did.clone(),
-        super::init_ledger::LedgerDeps {
-            gossip_handle: gossip_handle.clone(),
-            misbehavior_detector: misbehavior_detector.clone(),
-            trust_service: trust_service_from_registry.clone(),
-            ledger_handle: ledger_from_daemon,
-            ledger_store: ledger_store_from_daemon,
-        },
-    )
-    .await?;
+    // Extract pre-initialized ledger handles from ServiceRegistry.
+    // Ledger services were created in the daemon by icn_ledger_app::init::init_ledger_services().
+    let ledger_handle = ledger_from_daemon
+        .ok_or_else(|| anyhow::anyhow!("Ledger not in ServiceRegistry"))?;
+    let dispute_manager_handle = dispute_manager_from_daemon
+        .ok_or_else(|| anyhow::anyhow!("DisputeManager not in ServiceRegistry"))?;
+    let treasury_manager_handle = treasury_manager_from_daemon
+        .ok_or_else(|| anyhow::anyhow!("TreasuryManager not in ServiceRegistry"))?;
+    let contract_runtime_handle = contract_runtime_from_daemon
+        .ok_or_else(|| anyhow::anyhow!("ContractRuntime not in ServiceRegistry"))?;
+    let contract_actor_handle = contract_actor_from_daemon
+        .ok_or_else(|| anyhow::anyhow!("ContractActor not in ServiceRegistry"))?;
+    let ledger_store = ledger_store_from_daemon
+        .ok_or_else(|| anyhow::anyhow!("LedgerStore not in ServiceRegistry"))?;
+
+    // Wire runtime handles into the pre-initialized Ledger.
+    // These depend on gossip/trust which are only available after gossip init.
+    {
+        let mut ledger = ledger_handle.write().await;
+        ledger.set_gossip(gossip_handle.clone());
+        ledger.set_misbehavior_detector(misbehavior_detector.clone());
+        if let Some(trust_service) = trust_service_from_registry.clone() {
+            ledger.set_trust_service(trust_service);
+            info!("Ledger wired with TrustService");
+        } else {
+            info!("Ledger initialized without TrustService (trust validation disabled)");
+        }
+    }
+    info!("Ledger runtime handles wired");
     icn_obs::metrics::supervisor::actor_spawned_inc("ledger");
     icn_obs::metrics::supervisor::actor_active_set("ledger", true);
-    let ledger_handle = ledger_services.ledger_handle.clone();
-    let dispute_manager_handle = ledger_services.dispute_manager.clone();
-    let treasury_manager_handle = ledger_services.treasury_manager.clone();
-    let contract_runtime_handle = ledger_services.contract_runtime.clone();
-    let contract_actor_handle = ledger_services.contract_actor.clone();
-    let ledger_store = ledger_services.ledger_store.clone();
 
     // Initialize cooperative services
     let coop_services =

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -223,9 +223,7 @@ async fn spawn_actors_with_identity(
         .and_then(|r| r.raw_handle::<icn_store::SledStore>(ServiceRegistry::LEDGER_STORE_KEY));
     let dispute_manager_from_daemon: Option<Arc<RwLock<icn_ledger::DisputeManager>>> =
         service_registry.and_then(|r| {
-            r.raw_handle::<RwLock<icn_ledger::DisputeManager>>(
-                ServiceRegistry::DISPUTE_MANAGER_KEY,
-            )
+            r.raw_handle::<RwLock<icn_ledger::DisputeManager>>(ServiceRegistry::DISPUTE_MANAGER_KEY)
         });
     let treasury_manager_from_daemon: Option<Arc<RwLock<icn_ledger::TreasuryManager>>> =
         service_registry.and_then(|r| {
@@ -235,9 +233,7 @@ async fn spawn_actors_with_identity(
         });
     let contract_runtime_from_daemon: Option<Arc<RwLock<icn_ccl::ContractRuntime>>> =
         service_registry.and_then(|r| {
-            r.raw_handle::<RwLock<icn_ccl::ContractRuntime>>(
-                ServiceRegistry::CONTRACT_RUNTIME_KEY,
-            )
+            r.raw_handle::<RwLock<icn_ccl::ContractRuntime>>(ServiceRegistry::CONTRACT_RUNTIME_KEY)
         });
     let contract_actor_from_daemon: Option<Arc<RwLock<icn_ccl::ContractActor>>> = service_registry
         .and_then(|r| {
@@ -325,8 +321,8 @@ async fn spawn_actors_with_identity(
 
     // Extract pre-initialized ledger handles from ServiceRegistry.
     // Ledger services were created in the daemon by icn_ledger_app::init::init_ledger_services().
-    let ledger_handle = ledger_from_daemon
-        .ok_or_else(|| anyhow::anyhow!("Ledger not in ServiceRegistry"))?;
+    let ledger_handle =
+        ledger_from_daemon.ok_or_else(|| anyhow::anyhow!("Ledger not in ServiceRegistry"))?;
     let dispute_manager_handle = dispute_manager_from_daemon
         .ok_or_else(|| anyhow::anyhow!("DisputeManager not in ServiceRegistry"))?;
     let treasury_manager_handle = treasury_manager_from_daemon

--- a/icn/crates/icn-core/src/supervisor/mod.rs
+++ b/icn/crates/icn-core/src/supervisor/mod.rs
@@ -23,7 +23,6 @@ pub mod init_federation;
 pub mod init_gateway;
 pub mod init_gossip;
 pub mod init_governance;
-pub mod init_ledger;
 pub mod init_network;
 pub mod init_notifications;
 pub mod init_resource_enforcer;


### PR DESCRIPTION
## Summary

- Moves ledger initialization logic from `icn-core/src/supervisor/init_ledger.rs` to `apps/ledger/src/init.rs`, eliminating icn-core's last init-time dependency on icn-ledger
- Daemon (`icnd`) now calls `icn_ledger_app::init::init_ledger_services()` with primitive config values and stores handles in `ServiceRegistry`
- `lifecycle.rs` extracts pre-initialized handles from `ServiceRegistry` and wires runtime dependencies (gossip, misbehavior, trust) after gossip init
- Strips remaining conversion methods (`to_witness_config`, `to_oracle_config`, `WitnessConfigError`) from `config/ledger.rs` — now pure serde structs

**Net**: -65 lines from icn-core, `init_ledger.rs` deleted entirely.

**Depends on**: #980 (config decoupling, merged)

## Files changed

| File | Change |
|------|--------|
| `apps/ledger/src/init.rs` | **New** — `init_ledger_services()` + `LedgerServices` struct |
| `apps/ledger/Cargo.toml` | Add `icn-ccl`, `icn-obs` deps; tokio `time` feature |
| `apps/ledger/src/lib.rs` | Add `pub mod init;` |
| `apps/ledger/src/config.rs` | Fix clippy lint in drift guard |
| `icn/bins/icnd/src/main.rs` | Async `build_service_registry`, config→primitive mapping, ServiceRegistry storage |
| `icn/crates/icn-core/src/supervisor/lifecycle.rs` | Extract handles from ServiceRegistry, wire runtime deps |
| `icn/crates/icn-core/src/supervisor/init_ledger.rs` | **Deleted** |
| `icn/crates/icn-core/src/supervisor/mod.rs` | Remove `pub mod init_ledger;` |
| `icn/crates/icn-core/src/config/ledger.rs` | Remove conversion methods — pure serde structs only |

## Test plan

- [x] `cargo test -p icn-core` — all tests pass
- [x] `cargo test` in `apps/ledger/` — all 21 tests pass
- [x] `cargo clippy -p icn-core --all-targets -- -D warnings` — clean
- [x] `cargo clippy --all-targets -- -D warnings` in `apps/ledger/` — clean
- [x] `cargo check -p icnd` — builds
- [x] `init_ledger.rs` deleted from icn-core
- [x] No `init_ledger_services` code references in icn-core (only comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)