### PR TITLE
refactor(core): move Version type to icn-kernel-api, decouple upgrade.rs and version_tracker.rs

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -3148,6 +3148,7 @@ dependencies = [
  "icn-entity",
  "icn-federation",
  "icn-identity",
+ "icn-kernel-api",
  "icn-ledger",
  "icn-obs",
  "icn-store",

--- a/icn/crates/icn-core/src/lib.rs
+++ b/icn/crates/icn-core/src/lib.rs
@@ -61,7 +61,7 @@ pub use runtime::Runtime;
 pub use storage_challenge::{ChallengeScheduler, ChallengeSchedulerHandle};
 pub use trust_propagation::{AttestationLimits, AttestationRateLimiter, TRUST_ATTESTATIONS_TOPIC};
 pub use upgrade::{
-    proposal_to_pending_upgrade, PendingUpgrade, UpgradeAdoptionStats, UpgradeCoordinator,
+    create_pending_upgrade, PendingUpgrade, UpgradeAdoptionStats, UpgradeCoordinator,
     CURRENT_VERSION,
 };
 pub use upgrade_actor::{

--- a/icn/crates/icn-core/src/supervisor/init_governance.rs
+++ b/icn/crates/icn-core/src/supervisor/init_governance.rs
@@ -88,7 +88,7 @@ pub async fn init_governance_services(
     info!("✓ Governance actor spawned at {}", gov_store_path.display());
 
     // Spawn UpgradeActor for network-wide upgrade coordination
-    let current_version = icn_governance::proposal::Version::new(
+    let current_version = icn_kernel_api::Version::new(
         crate::upgrade::CURRENT_VERSION.0,
         crate::upgrade::CURRENT_VERSION.1,
         crate::upgrade::CURRENT_VERSION.2,

--- a/icn/crates/icn-core/src/supervisor/version_tracker.rs
+++ b/icn/crates/icn-core/src/supervisor/version_tracker.rs
@@ -2,7 +2,7 @@
 //!
 //! Tracks peer versions, monitors adoption rates, and manages protocol upgrades.
 
-use icn_governance::proposal::Version;
+use icn_kernel_api::Version;
 use icn_identity::Did;
 use std::collections::HashMap;
 use tracing::info;

--- a/icn/crates/icn-core/src/supervisor/version_tracker.rs
+++ b/icn/crates/icn-core/src/supervisor/version_tracker.rs
@@ -2,8 +2,8 @@
 //!
 //! Tracks peer versions, monitors adoption rates, and manages protocol upgrades.
 
-use icn_kernel_api::Version;
 use icn_identity::Did;
+use icn_kernel_api::Version;
 use std::collections::HashMap;
 use tracing::info;
 

--- a/icn/crates/icn-core/src/upgrade.rs
+++ b/icn/crates/icn-core/src/upgrade.rs
@@ -6,8 +6,8 @@
 //! - Deadline enforcement for deprecated versions
 //! - Metrics for upgrade progress
 
-use icn_kernel_api::Version;
 use icn_identity::Did;
+use icn_kernel_api::Version;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};

--- a/icn/crates/icn-core/src/upgrade.rs
+++ b/icn/crates/icn-core/src/upgrade.rs
@@ -6,7 +6,7 @@
 //! - Deadline enforcement for deprecated versions
 //! - Metrics for upgrade progress
 
-use icn_governance::proposal::{ProposalPayload, Version};
+use icn_kernel_api::Version;
 use icn_identity::Did;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -344,27 +344,26 @@ impl Default for UpgradeCoordinator {
     }
 }
 
-/// Convert a governance ProtocolUpgrade proposal into a PendingUpgrade
-pub fn proposal_to_pending_upgrade(
-    proposal: &ProposalPayload,
+/// Create a `PendingUpgrade` from primitive values.
+///
+/// This replaces the former `proposal_to_pending_upgrade` which took
+/// `ProposalPayload` (an icn-governance type). Callers that have a
+/// `ProposalPayload` should destructure it and pass the fields directly.
+pub fn create_pending_upgrade(
+    version: Version,
+    deadline: u64,
+    breaking_changes: Vec<String>,
+    migration_guide: Option<String>,
+    min_required_version: Option<Version>,
     approved_at: u64,
-) -> Result<PendingUpgrade, String> {
-    match proposal {
-        ProposalPayload::ProtocolUpgrade {
-            version,
-            breaking_changes,
-            migration_guide,
-            deadline,
-            min_required_version,
-        } => Ok(PendingUpgrade {
-            version: version.clone(),
-            deadline: *deadline,
-            breaking_changes: breaking_changes.clone(),
-            migration_guide: migration_guide.clone(),
-            min_required_version: min_required_version.clone(),
-            approved_at,
-        }),
-        _ => Err("Not a ProtocolUpgrade proposal".to_string()),
+) -> PendingUpgrade {
+    PendingUpgrade {
+        version,
+        deadline,
+        breaking_changes,
+        migration_guide,
+        min_required_version,
+        approved_at,
     }
 }
 

--- a/icn/crates/icn-governance/Cargo.toml
+++ b/icn/crates/icn-governance/Cargo.toml
@@ -12,6 +12,7 @@ async-trait = "0.1"
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
 icn-encoding = { path = "../icn-encoding" }
+icn-kernel-api = { path = "../icn-kernel-api" }
 icn-entity = { path = "../icn-entity" }
 icn-federation = { path = "../icn-federation" }
 icn-identity = { path = "../icn-identity" }

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -115,7 +115,7 @@ pub use profile::{DecisionOutcome, GovernanceProfile, GovernanceProfileId, Gover
 pub use proposal::{
     DataSharingLevel, DisputeResolutionMethod, DisputeResolutionOutcome, FederationProposal,
     FederationTerms, ForcedOutcome, MembershipAction, Proposal, ProposalId, ProposalPayload,
-    ProposalState, ResourceAccessAction, TreasuryApprovalType, TreasuryProposalOperation,
+    ProposalState, ResourceAccessAction, TreasuryApprovalType, TreasuryProposalOperation, Version,
 };
 pub use resolver::{MembershipResolver, StaticMembershipResolver};
 pub use sdis::{

--- a/icn/crates/icn-governance/src/proposal.rs
+++ b/icn/crates/icn-governance/src/proposal.rs
@@ -813,64 +813,8 @@ pub enum TreasuryApprovalType {
     Emergency,
 }
 
-/// Semantic version for protocol versioning
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
-pub struct Version {
-    pub major: u32,
-    pub minor: u32,
-    pub patch: u32,
-}
-
-impl Version {
-    /// Create a new version
-    pub fn new(major: u32, minor: u32, patch: u32) -> Self {
-        Self {
-            major,
-            minor,
-            patch,
-        }
-    }
-
-    /// Parse version from string (e.g., "1.2.3")
-    pub fn parse(s: &str) -> Result<Self, String> {
-        let parts: Vec<&str> = s.split('.').collect();
-        if parts.len() != 3 {
-            return Err(format!("Invalid version format: {s}"));
-        }
-
-        let major = parts[0]
-            .parse::<u32>()
-            .map_err(|_| format!("Invalid major version: {}", parts[0]))?;
-        let minor = parts[1]
-            .parse::<u32>()
-            .map_err(|_| format!("Invalid minor version: {}", parts[1]))?;
-        let patch = parts[2]
-            .parse::<u32>()
-            .map_err(|_| format!("Invalid patch version: {}", parts[2]))?;
-
-        Ok(Self::new(major, minor, patch))
-    }
-
-    /// Check if this version is compatible with another
-    ///
-    /// Compatible means:
-    /// - Same major version (no breaking changes)
-    /// - Minor/patch can differ
-    pub fn is_compatible_with(&self, other: &Version) -> bool {
-        self.major == other.major
-    }
-
-    /// Check if this version has breaking changes vs another
-    pub fn has_breaking_changes_vs(&self, other: &Version) -> bool {
-        self.major != other.major
-    }
-}
-
-impl std::fmt::Display for Version {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
-    }
-}
+/// Semantic version for protocol versioning (re-exported from kernel API)
+pub use icn_kernel_api::Version;
 
 /// Possible outcomes for a dispute resolution governance proposal
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/icn/crates/icn-kernel-api/src/lib.rs
+++ b/icn/crates/icn-kernel-api/src/lib.rs
@@ -44,6 +44,7 @@ pub mod services;
 pub mod state;
 pub mod time;
 pub mod types;
+pub mod version;
 
 // Re-export primary traits for convenience
 pub use authz::{
@@ -68,6 +69,7 @@ pub use services::{
 };
 pub use state::{BlobService, KvService, LogService, ObjectReplication, ReplicationPolicy};
 pub use time::TimeService;
+pub use version::Version;
 
 // Re-export common types
 pub use types::*;

--- a/icn/crates/icn-kernel-api/src/version.rs
+++ b/icn/crates/icn-kernel-api/src/version.rs
@@ -1,0 +1,125 @@
+//! Semantic versioning for protocol versioning
+//!
+//! This is a kernel-level type used by upgrade coordination and version
+//! tracking. It lives here so that `icn-core` can use it without importing
+//! `icn-governance`.
+
+use serde::{Deserialize, Serialize};
+
+/// Semantic version for protocol versioning
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
+pub struct Version {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+}
+
+impl Version {
+    /// Create a new version
+    pub fn new(major: u32, minor: u32, patch: u32) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    /// Parse version from string (e.g., "1.2.3")
+    pub fn parse(s: &str) -> Result<Self, String> {
+        let parts: Vec<&str> = s.split('.').collect();
+        if parts.len() != 3 {
+            return Err(format!("Invalid version format: {s}"));
+        }
+
+        let major = parts[0]
+            .parse::<u32>()
+            .map_err(|_| format!("Invalid major version: {}", parts[0]))?;
+        let minor = parts[1]
+            .parse::<u32>()
+            .map_err(|_| format!("Invalid minor version: {}", parts[1]))?;
+        let patch = parts[2]
+            .parse::<u32>()
+            .map_err(|_| format!("Invalid patch version: {}", parts[2]))?;
+
+        Ok(Self::new(major, minor, patch))
+    }
+
+    /// Check if this version is compatible with another
+    ///
+    /// Compatible means:
+    /// - Same major version (no breaking changes)
+    /// - Minor/patch can differ
+    pub fn is_compatible_with(&self, other: &Version) -> bool {
+        self.major == other.major
+    }
+
+    /// Check if this version has breaking changes vs another
+    pub fn has_breaking_changes_vs(&self, other: &Version) -> bool {
+        self.major != other.major
+    }
+}
+
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_version_new() {
+        let v = Version::new(1, 2, 3);
+        assert_eq!(v.major, 1);
+        assert_eq!(v.minor, 2);
+        assert_eq!(v.patch, 3);
+    }
+
+    #[test]
+    fn test_version_parse() {
+        let v = Version::parse("1.2.3").unwrap();
+        assert_eq!(v, Version::new(1, 2, 3));
+    }
+
+    #[test]
+    fn test_version_parse_invalid() {
+        assert!(Version::parse("1.2").is_err());
+        assert!(Version::parse("abc").is_err());
+        assert!(Version::parse("1.2.abc").is_err());
+    }
+
+    #[test]
+    fn test_version_display() {
+        assert_eq!(Version::new(1, 2, 3).to_string(), "1.2.3");
+    }
+
+    #[test]
+    fn test_version_compatibility() {
+        let v1 = Version::new(1, 0, 0);
+        let v2 = Version::new(1, 5, 0);
+        let v3 = Version::new(2, 0, 0);
+
+        assert!(v1.is_compatible_with(&v2));
+        assert!(!v1.is_compatible_with(&v3));
+    }
+
+    #[test]
+    fn test_version_breaking_changes() {
+        let v1 = Version::new(1, 0, 0);
+        let v2 = Version::new(1, 5, 0);
+        let v3 = Version::new(2, 0, 0);
+
+        assert!(!v1.has_breaking_changes_vs(&v2));
+        assert!(v1.has_breaking_changes_vs(&v3));
+    }
+
+    #[test]
+    fn test_version_ordering() {
+        assert!(Version::new(1, 0, 0) < Version::new(2, 0, 0));
+        assert!(Version::new(1, 0, 0) < Version::new(1, 1, 0));
+        assert!(Version::new(1, 0, 0) < Version::new(1, 0, 1));
+        assert!(Version::new(1, 0, 0) == Version::new(1, 0, 0));
+    }
+}


### PR DESCRIPTION
## Summary

- Moves `Version` struct from `icn-governance::proposal` to `icn-kernel-api::version`, making it a kernel-level type
- `icn-governance` re-exports `Version` via `pub use icn_kernel_api::Version` for backward compatibility
- Replaces `proposal_to_pending_upgrade(ProposalPayload, u64)` with `create_pending_upgrade(Version, u64, Vec<String>, Option<String>, Option<Version>, u64)` — takes primitives only
- `upgrade.rs` and `version_tracker.rs` now import from `icn-kernel-api` instead of `icn-governance`

This removes 2 of the 19 icn-governance imports from icn-core.

## Test plan

- [x] `cargo test -p icn-kernel-api -- version` — 7 new tests pass
- [x] `cargo test -p icn-governance --lib -- version` — 4 tests pass (re-export works)
- [x] `cargo test -p icn-core --lib -- upgrade` — 6 tests pass
- [x] `cargo test -p icn-core --lib -- version_tracker` — 5 tests pass
- [x] `cargo clippy -p icn-kernel-api -p icn-governance -p icn-core --all-targets -- -D warnings` — clean
- [x] No `icn_governance` imports in `upgrade.rs` or `version_tracker.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)