### PR TITLE
refactor(core): decouple events.rs from icn-governance ProposalPayload and ProposalId

### DIFF
--- a/icn/crates/icn-core/src/events.rs
+++ b/icn/crates/icn-core/src/events.rs
@@ -347,4 +347,70 @@ mod tests {
         // Callback should NOT have been called (subscription was dropped)
         assert_eq!(counter.load(Ordering::SeqCst), 0);
     }
+
+    #[tokio::test]
+    async fn test_invalid_payload_triggers_execution_failed() {
+        // Regression test: when a ProposalAccepted event carries a payload that
+        // cannot be deserialized back to ProposalPayload, the subscriber should
+        // emit ProposalExecutionFailed (not silently drop the event).
+        let bus = EventBus::new();
+        let failure_seen = Arc::new(AtomicUsize::new(0));
+
+        // Subscriber 1: simulates create_governance_subscription behavior.
+        // On deserialization failure, it spawns a task to emit ProposalExecutionFailed.
+        let bus_for_sub1 = bus.clone();
+        let _handle1 = bus
+            .subscribe(Arc::new(move |event| {
+                if let SystemEvent::ProposalAccepted {
+                    proposal_id,
+                    payload,
+                    ..
+                } = event
+                {
+                    // Attempt to deserialize — this should fail for our test payload
+                    if serde_json::from_value::<icn_governance::ProposalPayload>(payload).is_err() {
+                        let bus = bus_for_sub1.clone();
+                        let pid = proposal_id;
+                        tokio::spawn(async move {
+                            bus.emit(SystemEvent::ProposalExecutionFailed {
+                                proposal_id: pid,
+                                proposal_type: "unknown".to_string(),
+                                error: "payload deserialization failed".to_string(),
+                                failed_at: 0,
+                            })
+                            .await;
+                        });
+                    }
+                }
+            }))
+            .await;
+
+        // Subscriber 2: observes ProposalExecutionFailed events
+        let fs = failure_seen.clone();
+        let _handle2 = bus
+            .subscribe(Arc::new(move |event| {
+                if let SystemEvent::ProposalExecutionFailed { .. } = event {
+                    fs.fetch_add(1, Ordering::SeqCst);
+                }
+            }))
+            .await;
+
+        // Emit ProposalAccepted with an invalid payload (not a valid ProposalPayload)
+        bus.emit(SystemEvent::ProposalAccepted {
+            proposal_id: "bad-payload-test".to_string(),
+            domain_id: "test".to_string(),
+            payload: serde_json::json!({"NotAValidVariant": true}),
+            decided_at: 0,
+        })
+        .await;
+
+        // Wait for the spawned task to complete
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        assert_eq!(
+            failure_seen.load(Ordering::SeqCst),
+            1,
+            "ProposalExecutionFailed should have been emitted for invalid payload"
+        );
+    }
 }

--- a/icn/crates/icn-core/src/events.rs
+++ b/icn/crates/icn-core/src/events.rs
@@ -3,7 +3,6 @@
 //! This module provides a simple event bus for coordinating actions across actors.
 //! Key use case: Governance proposals triggering ledger transactions or contract execution.
 
-use icn_governance::{ProposalId, ProposalPayload};
 use icn_identity::Did;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -14,20 +13,20 @@ use tracing::{debug, warn};
 pub enum SystemEvent {
     /// A governance proposal was accepted
     ProposalAccepted {
-        /// Unique identifier for the proposal
-        proposal_id: ProposalId,
+        /// Unique identifier for the proposal (was `ProposalId`)
+        proposal_id: String,
         /// Domain in which the proposal was made
         domain_id: String,
-        /// Payload describing the proposal action
-        payload: ProposalPayload,
+        /// Payload describing the proposal action (serialized `ProposalPayload`)
+        payload: serde_json::Value,
         /// Unix timestamp when the proposal was decided
         decided_at: u64,
     },
 
     /// A governance proposal was rejected or failed to reach quorum
     ProposalRejected {
-        /// Unique identifier for the proposal
-        proposal_id: ProposalId,
+        /// Unique identifier for the proposal (was `ProposalId`)
+        proposal_id: String,
         /// Domain in which the proposal was made
         domain_id: String,
         /// Unix timestamp when the proposal was decided
@@ -58,8 +57,8 @@ pub enum SystemEvent {
 
     /// A proposal execution failed (proposal was accepted but could not be applied)
     ProposalExecutionFailed {
-        /// Unique identifier for the proposal
-        proposal_id: ProposalId,
+        /// Unique identifier for the proposal (was `ProposalId`)
+        proposal_id: String,
         /// Type of the proposal (e.g., "protocol_change", "treasury")
         proposal_type: String,
         /// Human-readable error message
@@ -239,11 +238,12 @@ mod tests {
 
         // Emit event
         let event = SystemEvent::ProposalAccepted {
-            proposal_id: ProposalId("test-proposal".to_string()),
+            proposal_id: "test-proposal".to_string(),
             domain_id: "test-domain".to_string(),
-            payload: ProposalPayload::Text {
+            payload: serde_json::to_value(&icn_governance::ProposalPayload::Text {
                 body: "Test proposal".to_string(),
-            },
+            })
+            .unwrap(),
             decided_at: 1234567890,
         };
 
@@ -276,7 +276,7 @@ mod tests {
 
         // Emit event
         let event = SystemEvent::ProposalRejected {
-            proposal_id: ProposalId("rejected".to_string()),
+            proposal_id: "rejected".to_string(),
             domain_id: "domain".to_string(),
             decided_at: 9999,
         };
@@ -333,11 +333,12 @@ mod tests {
 
         // Emit event
         let event = SystemEvent::ProposalAccepted {
-            proposal_id: ProposalId("test".to_string()),
+            proposal_id: "test".to_string(),
             domain_id: "test".to_string(),
-            payload: ProposalPayload::Text {
+            payload: serde_json::to_value(&icn_governance::ProposalPayload::Text {
                 body: "test".to_string(),
-            },
+            })
+            .unwrap(),
             decided_at: 1234567890,
         };
 

--- a/icn/crates/icn-core/src/governance/actor.rs
+++ b/icn/crates/icn-core/src/governance/actor.rs
@@ -1524,13 +1524,16 @@ impl GovernanceActor {
                 if let Some(ref event_bus) = self.event_bus {
                     let event = match outcome_result {
                         DecisionOutcome::Accepted => SystemEvent::ProposalAccepted {
-                            proposal_id: proposal_id.clone(),
+                            proposal_id: proposal_id.0.clone(),
                             domain_id: proposal.domain_id.0.clone(),
-                            payload: proposal.payload.clone(),
+                            payload: serde_json::to_value(&proposal.payload)
+                                .unwrap_or_else(|e| {
+                                    serde_json::Value::String(format!("serialization_error: {e}"))
+                                }),
                             decided_at: now,
                         },
                         _ => SystemEvent::ProposalRejected {
-                            proposal_id: proposal_id.clone(),
+                            proposal_id: proposal_id.0.clone(),
                             domain_id: proposal.domain_id.0.clone(),
                             decided_at: now,
                         },
@@ -1574,7 +1577,7 @@ impl GovernanceActor {
                     let now = now_seconds();
                     event_bus
                         .emit(SystemEvent::ProposalRejected {
-                            proposal_id: proposal_id.clone(),
+                            proposal_id: proposal_id.0.clone(),
                             domain_id: proposal.domain_id.0.clone(),
                             decided_at: now,
                         })
@@ -1624,13 +1627,16 @@ impl GovernanceActor {
                     let now = now_seconds();
                     let event = match forced_outcome {
                         ForcedOutcome::Accept => SystemEvent::ProposalAccepted {
-                            proposal_id: proposal_id.clone(),
+                            proposal_id: proposal_id.0.clone(),
                             domain_id: proposal.domain_id.0.clone(),
-                            payload: proposal.payload.clone(),
+                            payload: serde_json::to_value(&proposal.payload)
+                                .unwrap_or_else(|e| {
+                                    serde_json::Value::String(format!("serialization_error: {e}"))
+                                }),
                             decided_at: now,
                         },
                         _ => SystemEvent::ProposalRejected {
-                            proposal_id: proposal_id.clone(),
+                            proposal_id: proposal_id.0.clone(),
                             domain_id: proposal.domain_id.0.clone(),
                             decided_at: now,
                         },

--- a/icn/crates/icn-core/src/governance/actor.rs
+++ b/icn/crates/icn-core/src/governance/actor.rs
@@ -1639,28 +1639,26 @@ impl GovernanceActor {
                 if let Some(ref event_bus) = self.event_bus {
                     let now = now_seconds();
                     let event = match forced_outcome {
-                        ForcedOutcome::Accept => {
-                            match serde_json::to_value(&proposal.payload) {
-                                Ok(payload) => SystemEvent::ProposalAccepted {
-                                    proposal_id: proposal_id.0.clone(),
-                                    domain_id: proposal.domain_id.0.clone(),
-                                    payload,
-                                    decided_at: now,
-                                },
-                                Err(e) => {
-                                    warn!(
+                        ForcedOutcome::Accept => match serde_json::to_value(&proposal.payload) {
+                            Ok(payload) => SystemEvent::ProposalAccepted {
+                                proposal_id: proposal_id.0.clone(),
+                                domain_id: proposal.domain_id.0.clone(),
+                                payload,
+                                decided_at: now,
+                            },
+                            Err(e) => {
+                                warn!(
                                         "Failed to serialize payload for force-accepted proposal {}: {e}",
                                         proposal_id.0
                                     );
-                                    SystemEvent::ProposalExecutionFailed {
-                                        proposal_id: proposal_id.0.clone(),
-                                        proposal_type: proposal.payload.type_name().to_string(),
-                                        error: format!("payload serialization failed: {e}"),
-                                        failed_at: now,
-                                    }
+                                SystemEvent::ProposalExecutionFailed {
+                                    proposal_id: proposal_id.0.clone(),
+                                    proposal_type: proposal.payload.type_name().to_string(),
+                                    error: format!("payload serialization failed: {e}"),
+                                    failed_at: now,
                                 }
                             }
-                        }
+                        },
                         _ => SystemEvent::ProposalRejected {
                             proposal_id: proposal_id.0.clone(),
                             domain_id: proposal.domain_id.0.clone(),

--- a/icn/crates/icn-core/src/governance/actor.rs
+++ b/icn/crates/icn-core/src/governance/actor.rs
@@ -1523,15 +1523,28 @@ impl GovernanceActor {
                 // Emit event for downstream processing (e.g., ledger transactions)
                 if let Some(ref event_bus) = self.event_bus {
                     let event = match outcome_result {
-                        DecisionOutcome::Accepted => SystemEvent::ProposalAccepted {
-                            proposal_id: proposal_id.0.clone(),
-                            domain_id: proposal.domain_id.0.clone(),
-                            payload: serde_json::to_value(&proposal.payload)
-                                .unwrap_or_else(|e| {
-                                    serde_json::Value::String(format!("serialization_error: {e}"))
-                                }),
-                            decided_at: now,
-                        },
+                        DecisionOutcome::Accepted => {
+                            match serde_json::to_value(&proposal.payload) {
+                                Ok(payload) => SystemEvent::ProposalAccepted {
+                                    proposal_id: proposal_id.0.clone(),
+                                    domain_id: proposal.domain_id.0.clone(),
+                                    payload,
+                                    decided_at: now,
+                                },
+                                Err(e) => {
+                                    warn!(
+                                        "Failed to serialize payload for accepted proposal {}: {e}",
+                                        proposal_id.0
+                                    );
+                                    SystemEvent::ProposalExecutionFailed {
+                                        proposal_id: proposal_id.0.clone(),
+                                        proposal_type: proposal.payload.type_name().to_string(),
+                                        error: format!("payload serialization failed: {e}"),
+                                        failed_at: now,
+                                    }
+                                }
+                            }
+                        }
                         _ => SystemEvent::ProposalRejected {
                             proposal_id: proposal_id.0.clone(),
                             domain_id: proposal.domain_id.0.clone(),
@@ -1626,15 +1639,28 @@ impl GovernanceActor {
                 if let Some(ref event_bus) = self.event_bus {
                     let now = now_seconds();
                     let event = match forced_outcome {
-                        ForcedOutcome::Accept => SystemEvent::ProposalAccepted {
-                            proposal_id: proposal_id.0.clone(),
-                            domain_id: proposal.domain_id.0.clone(),
-                            payload: serde_json::to_value(&proposal.payload)
-                                .unwrap_or_else(|e| {
-                                    serde_json::Value::String(format!("serialization_error: {e}"))
-                                }),
-                            decided_at: now,
-                        },
+                        ForcedOutcome::Accept => {
+                            match serde_json::to_value(&proposal.payload) {
+                                Ok(payload) => SystemEvent::ProposalAccepted {
+                                    proposal_id: proposal_id.0.clone(),
+                                    domain_id: proposal.domain_id.0.clone(),
+                                    payload,
+                                    decided_at: now,
+                                },
+                                Err(e) => {
+                                    warn!(
+                                        "Failed to serialize payload for force-accepted proposal {}: {e}",
+                                        proposal_id.0
+                                    );
+                                    SystemEvent::ProposalExecutionFailed {
+                                        proposal_id: proposal_id.0.clone(),
+                                        proposal_type: proposal.payload.type_name().to_string(),
+                                        error: format!("payload serialization failed: {e}"),
+                                        failed_at: now,
+                                    }
+                                }
+                            }
+                        }
                         _ => SystemEvent::ProposalRejected {
                             proposal_id: proposal_id.0.clone(),
                             domain_id: proposal.domain_id.0.clone(),

--- a/icn/crates/icn-core/src/supervisor/governance_handlers.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_handlers.rs
@@ -4181,6 +4181,11 @@ pub fn create_governance_subscription(
                             proposal_id,
                             e
                         );
+                        handler.emit_execution_failure(
+                            &icn_governance::ProposalId(proposal_id.clone()),
+                            "unknown",
+                            &format!("payload deserialization failed: {e}"),
+                        );
                     }
                 }
             }

--- a/icn/crates/icn-core/src/supervisor/governance_handlers.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_handlers.rs
@@ -229,7 +229,7 @@ impl GovernanceEventHandler {
         if let Some(ref bus) = self.event_bus {
             let bus = bus.clone();
             let event = crate::events::SystemEvent::ProposalExecutionFailed {
-                proposal_id: proposal_id.clone(),
+                proposal_id: proposal_id.0.clone(),
                 proposal_type: proposal_type.to_string(),
                 error: error.to_string(),
                 failed_at: icn_time::current_timestamp_secs(),
@@ -4165,15 +4165,27 @@ pub fn create_governance_subscription(
                 domain_id,
                 ..
             } => {
-                handler.handle_proposal_accepted(
-                    proposal_id.clone(),
-                    payload.clone(),
-                    *decided_at,
-                    domain_id.clone(),
-                );
+                // Deserialize the payload back to ProposalPayload for dispatch
+                match serde_json::from_value::<icn_governance::ProposalPayload>(payload.clone()) {
+                    Ok(proposal_payload) => {
+                        handler.handle_proposal_accepted(
+                            icn_governance::ProposalId(proposal_id.clone()),
+                            proposal_payload,
+                            *decided_at,
+                            domain_id.clone(),
+                        );
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "Failed to deserialize ProposalPayload for proposal {}: {}",
+                            proposal_id,
+                            e
+                        );
+                    }
+                }
             }
             SystemEvent::ProposalRejected { proposal_id, .. } => {
-                info!("❌ Proposal {} rejected - no action taken", proposal_id.0);
+                info!("❌ Proposal {} rejected - no action taken", proposal_id);
             }
             _ => {}
         }
@@ -4312,25 +4324,27 @@ pub fn create_policy_subscription(
 ) -> Arc<dyn Fn(crate::events::SystemEvent) + Send + Sync> {
     Arc::new(move |event| {
         use crate::events::SystemEvent;
-        use icn_governance::ProposalPayload;
 
         if let SystemEvent::ProposalAccepted {
             proposal_id,
-            payload:
-                ProposalPayload::SchedulingPolicy {
-                    coop_id,
-                    policy_json,
-                },
+            payload,
             decided_at,
             ..
         } = &event
         {
-            handler.handle_scheduling_policy(
-                proposal_id.clone(),
-                coop_id.clone(),
-                policy_json.clone(),
-                *decided_at,
-            );
+            // Deserialize and check if it's a SchedulingPolicy proposal
+            if let Ok(icn_governance::ProposalPayload::SchedulingPolicy {
+                coop_id,
+                policy_json,
+            }) = serde_json::from_value::<icn_governance::ProposalPayload>(payload.clone())
+            {
+                handler.handle_scheduling_policy(
+                    icn_governance::ProposalId(proposal_id.clone()),
+                    coop_id,
+                    policy_json,
+                    *decided_at,
+                );
+            }
         }
     })
 }

--- a/icn/crates/icn-core/tests/governance_ledger_idempotency.rs
+++ b/icn/crates/icn-core/tests/governance_ledger_idempotency.rs
@@ -46,19 +46,19 @@ async fn test_duplicate_proposal_event_is_idempotent() -> Result<()> {
             .subscribe(Arc::new(move |event| {
                 if let SystemEvent::ProposalAccepted {
                     proposal_id,
-                    payload:
-                        ProposalPayload::Budget {
-                            amount,
-                            recipient,
-                            currency,
-                            ..
-                        },
+                    payload,
                     ..
                 } = event
                 {
+                    let Ok(ProposalPayload::Budget {
+                        amount,
+                        recipient,
+                        currency,
+                        ..
+                    }) = serde_json::from_value::<ProposalPayload>(payload.clone()) else { return };
                     info!(
                         "📊 Executing budget proposal {}: {} {} to {}",
-                        proposal_id.0, amount, currency, recipient
+                        proposal_id, amount, currency, recipient
                     );
 
                     let ledger = ledger_clone.clone();
@@ -71,12 +71,12 @@ async fn test_duplicate_proposal_event_is_idempotent() -> Result<()> {
 
                         // IDEMPOTENCY CHECK: Skip if proposal already executed
                         // Uses fail-safe pattern: refuse execution if cannot verify
-                        let audit_key = format!("gov:audit:{}", prop_id.0);
+                        let audit_key = format!("gov:audit:{}", prop_id);
                         match store.get(audit_key.as_bytes()) {
                             Ok(Some(_)) => {
                                 info!(
                                     "Proposal {} already executed, skipping duplicate event",
-                                    prop_id.0
+                                    prop_id
                                 );
                                 return;
                             }
@@ -87,7 +87,7 @@ async fn test_duplicate_proposal_event_is_idempotent() -> Result<()> {
                                 // Store read error: REFUSE to execute (fail-safe)
                                 eprintln!(
                                     "ERROR: Failed to check audit trail for proposal {}: {}",
-                                    prop_id.0, e
+                                    prop_id, e
                                 );
                                 eprintln!(
                                     "       Refusing to execute to prevent potential duplicate"
@@ -108,9 +108,9 @@ async fn test_duplicate_proposal_event_is_idempotent() -> Result<()> {
                                 info!("✅ Executed: {} {}", amount, currency);
 
                                 // Store audit trail
-                                let audit_key = format!("gov:audit:{}", prop_id.0);
+                                let audit_key = format!("gov:audit:{}", prop_id);
                                 let audit_record = serde_json::json!({
-                                    "proposal_id": prop_id.0,
+                                    "proposal_id": prop_id,
                                     "ledger_entry_hash": hex::encode(entry_hash.0),
                                     "amount": amount,
                                     "currency": currency,
@@ -129,16 +129,16 @@ async fn test_duplicate_proposal_event_is_idempotent() -> Result<()> {
     };
 
     // Create proposal event
-    let proposal_id = icn_governance::ProposalId("test-proposal".to_string());
+    let proposal_id = "test-proposal".to_string();
     let event = SystemEvent::ProposalAccepted {
         proposal_id: proposal_id.clone(),
         domain_id: "test-domain".to_string(),
-        payload: ProposalPayload::Budget {
+        payload: serde_json::to_value(&ProposalPayload::Budget {
             amount: 5000,
             recipient: recipient_did.clone(),
             currency: "credits".to_string(),
             purpose: "Test payment".to_string(),
-        },
+        }).unwrap(),
         decided_at: 1234567890,
     };
 

--- a/icn/crates/icn-core/tests/governance_ledger_idempotency.rs
+++ b/icn/crates/icn-core/tests/governance_ledger_idempotency.rs
@@ -55,7 +55,10 @@ async fn test_duplicate_proposal_event_is_idempotent() -> Result<()> {
                         recipient,
                         currency,
                         ..
-                    }) = serde_json::from_value::<ProposalPayload>(payload.clone()) else { return };
+                    }) = serde_json::from_value::<ProposalPayload>(payload.clone())
+                    else {
+                        return;
+                    };
                     info!(
                         "📊 Executing budget proposal {}: {} {} to {}",
                         proposal_id, amount, currency, recipient
@@ -138,7 +141,8 @@ async fn test_duplicate_proposal_event_is_idempotent() -> Result<()> {
             recipient: recipient_did.clone(),
             currency: "credits".to_string(),
             purpose: "Test payment".to_string(),
-        }).unwrap(),
+        })
+        .unwrap(),
         decided_at: 1234567890,
     };
 

--- a/icn/crates/icn-core/tests/governance_ledger_integration.rs
+++ b/icn/crates/icn-core/tests/governance_ledger_integration.rs
@@ -77,12 +77,14 @@ async fn test_budget_proposal_executes_ledger_transaction() -> Result<()> {
         event_bus.subscribe(Arc::new(move |event| {
             if let SystemEvent::ProposalAccepted {
                 proposal_id,
-                payload: ProposalPayload::Budget { amount, recipient, currency, purpose: _ },
+                payload,
                 decided_at,
                 ..
             } = event {
+                let Ok(ProposalPayload::Budget { amount, recipient, currency, purpose: _ }) =
+                    serde_json::from_value::<ProposalPayload>(payload.clone()) else { return };
                 info!("📊 Executing budget proposal {}: {} {} to {}",
-                      proposal_id.0, amount, currency, recipient);
+                      proposal_id, amount, currency, recipient);
 
                 let ledger = ledger_clone.clone();
                 let prop_id = proposal_id.clone();
@@ -106,12 +108,12 @@ async fn test_budget_proposal_executes_ledger_transaction() -> Result<()> {
                             match ledger_guard.append_entry(entry).await {
                                 Ok(entry_hash) => {
                                     info!("✅ Budget proposal {} executed: {} {} transferred to {}",
-                                          prop_id.0, amount, currency, recipient);
+                                          prop_id, amount, currency, recipient);
 
                                     // Store audit trail
-                                    let audit_key = format!("gov:audit:{}", prop_id.0);
+                                    let audit_key = format!("gov:audit:{}", prop_id);
                                     let audit_record = serde_json::json!({
-                                        "proposal_id": prop_id.0,
+                                        "proposal_id": prop_id,
                                         "ledger_entry_hash": hex::encode(entry_hash.0),
                                         "amount": amount,
                                         "currency": currency,
@@ -125,19 +127,19 @@ async fn test_budget_proposal_executes_ledger_transaction() -> Result<()> {
 
                                     if let Ok(audit_json) = serde_json::to_vec(&audit_record) {
                                         if let Err(e) = store.put(audit_key.as_bytes(), &audit_json) {
-                                            tracing::warn!("Failed to store audit trail for {}: {}", prop_id.0, e);
+                                            tracing::warn!("Failed to store audit trail for {}: {}", prop_id, e);
                                         } else {
-                                            info!("📋 Audit trail recorded for proposal {}", prop_id.0);
+                                            info!("📋 Audit trail recorded for proposal {}", prop_id);
                                         }
                                     }
                                 }
                                 Err(e) => {
-                                    tracing::warn!("❌ Failed to append ledger entry for proposal {}: {}", prop_id.0, e);
+                                    tracing::warn!("❌ Failed to append ledger entry for proposal {}: {}", prop_id, e);
                                 }
                             }
                         }
                         Err(e) => {
-                            tracing::warn!("❌ Failed to build ledger entry for proposal {}: {}", prop_id.0, e);
+                            tracing::warn!("❌ Failed to build ledger entry for proposal {}: {}", prop_id, e);
                         }
                     }
                 });
@@ -205,14 +207,14 @@ async fn test_budget_proposal_executes_ledger_transaction() -> Result<()> {
         .as_secs();
 
     let acceptance_event = SystemEvent::ProposalAccepted {
-        proposal_id: proposal_id.clone(),
+        proposal_id: proposal_id.0.clone(),
         domain_id: domain_id.0.clone(),
-        payload: ProposalPayload::Budget {
+        payload: serde_json::to_value(&ProposalPayload::Budget {
             amount: 5000,
             recipient: recipient_did.clone(),
             currency: "credits".to_string(),
             purpose: "Office supplies from Acme Corp".to_string(),
-        },
+        }).unwrap(),
         decided_at: now,
     };
 
@@ -325,18 +327,18 @@ async fn test_rejected_proposal_does_not_execute() -> Result<()> {
             .subscribe(Arc::new(move |event| match event {
                 SystemEvent::ProposalAccepted {
                     proposal_id,
-                    payload:
-                        ProposalPayload::Budget {
-                            amount,
-                            recipient,
-                            currency,
-                            ..
-                        },
+                    payload,
                     ..
                 } => {
+                    let Ok(ProposalPayload::Budget {
+                        amount,
+                        recipient,
+                        currency,
+                        ..
+                    }) = serde_json::from_value::<ProposalPayload>(payload.clone()) else { return };
                     info!(
                         "📊 Executing budget proposal {}: {} {} to {}",
-                        proposal_id.0, amount, currency, recipient
+                        proposal_id, amount, currency, recipient
                     );
 
                     let ledger = ledger_clone.clone();
@@ -358,7 +360,7 @@ async fn test_rejected_proposal_does_not_execute() -> Result<()> {
                     });
                 }
                 SystemEvent::ProposalRejected { proposal_id, .. } => {
-                    info!("❌ Proposal {} rejected - no action taken", proposal_id.0);
+                    info!("❌ Proposal {} rejected - no action taken", proposal_id);
                 }
                 _ => {}
             }))
@@ -400,7 +402,7 @@ async fn test_rejected_proposal_does_not_execute() -> Result<()> {
         .as_secs();
 
     let rejection_event = SystemEvent::ProposalRejected {
-        proposal_id: proposal_id.clone(),
+        proposal_id: proposal_id.0.clone(),
         domain_id: domain.id.0.clone(),
         decided_at: now,
     };

--- a/icn/crates/icn-core/tests/governance_ledger_integration.rs
+++ b/icn/crates/icn-core/tests/governance_ledger_integration.rs
@@ -214,7 +214,8 @@ async fn test_budget_proposal_executes_ledger_transaction() -> Result<()> {
             recipient: recipient_did.clone(),
             currency: "credits".to_string(),
             purpose: "Office supplies from Acme Corp".to_string(),
-        }).unwrap(),
+        })
+        .unwrap(),
         decided_at: now,
     };
 
@@ -335,7 +336,10 @@ async fn test_rejected_proposal_does_not_execute() -> Result<()> {
                         recipient,
                         currency,
                         ..
-                    }) = serde_json::from_value::<ProposalPayload>(payload.clone()) else { return };
+                    }) = serde_json::from_value::<ProposalPayload>(payload.clone())
+                    else {
+                        return;
+                    };
                     info!(
                         "📊 Executing budget proposal {}: {} {} to {}",
                         proposal_id, amount, currency, recipient

--- a/icn/crates/icn-core/tests/governance_policy_integration.rs
+++ b/icn/crates/icn-core/tests/governance_policy_integration.rs
@@ -12,7 +12,7 @@ use icn_compute::{
     ComputeActor, CoopSchedulingPolicy, EnforcementMode, MemberQuota, PolicyManager, UsageTracker,
 };
 use icn_core::{EventBus, SystemEvent};
-use icn_governance::{ProposalId, ProposalPayload};
+use icn_governance::ProposalPayload;
 use icn_identity::KeyPair;
 use icn_store::{SledStore, Store};
 use std::sync::Arc;
@@ -66,12 +66,14 @@ async fn test_scheduling_policy_proposal_execution() -> Result<()> {
         event_bus.subscribe(Arc::new(move |event| {
             if let SystemEvent::ProposalAccepted {
                 proposal_id,
-                payload: ProposalPayload::SchedulingPolicy { coop_id, policy_json },
+                payload,
                 decided_at,
                 ..
             } = event {
+                let Ok(ProposalPayload::SchedulingPolicy { coop_id, policy_json }) =
+                    serde_json::from_value::<ProposalPayload>(payload.clone()) else { return };
                 info!("📋 Executing scheduling policy proposal {}: update policy for {}",
-                      proposal_id.0, coop_id);
+                      proposal_id, coop_id);
 
                 // Spawn async task to apply policy update
                 let compute_handle = compute.clone();
@@ -83,17 +85,17 @@ async fn test_scheduling_policy_proposal_execution() -> Result<()> {
 
                     tokio::spawn(async move {
                         // IDEMPOTENCY CHECK: Skip if proposal already executed
-                        let audit_key = format!("gov:audit:policy:{}", prop_id.0);
+                        let audit_key = format!("gov:audit:policy:{}", prop_id);
                         match store.get(audit_key.as_bytes()) {
                             Ok(Some(_)) => {
-                                info!("Policy proposal {} already executed, skipping duplicate", prop_id.0);
+                                info!("Policy proposal {} already executed, skipping duplicate", prop_id);
                                 return;
                             }
                             Ok(None) => {
                                 // Not executed yet, proceed
                             }
                             Err(e) => {
-                                eprintln!("🚨 Failed to check audit trail for policy proposal {}: {}", prop_id.0, e);
+                                eprintln!("🚨 Failed to check audit trail for policy proposal {}: {}", prop_id, e);
                                 eprintln!("   Refusing to execute to prevent potential duplicate");
                                 return;
                             }
@@ -106,11 +108,11 @@ async fn test_scheduling_policy_proposal_execution() -> Result<()> {
                                 match compute_handle.set_policy(policy.clone()).await {
                                     Ok(_) => {
                                         info!("✅ Scheduling policy proposal {} executed: policy updated for {}",
-                                              prop_id.0, coop);
+                                              prop_id, coop);
 
                                         // Store audit trail
                                         let audit_record = serde_json::json!({
-                                            "proposal_id": prop_id.0,
+                                            "proposal_id": prop_id,
                                             "coop_id": coop,
                                             "decided_at": decision_time,
                                             "executed_at": std::time::SystemTime::now()
@@ -121,19 +123,19 @@ async fn test_scheduling_policy_proposal_execution() -> Result<()> {
 
                                         if let Ok(audit_json) = serde_json::to_vec(&audit_record) {
                                             if let Err(e) = store.put(audit_key.as_bytes(), &audit_json) {
-                                                eprintln!("🚨 Failed to store audit trail for policy proposal {}: {}", prop_id.0, e);
+                                                eprintln!("🚨 Failed to store audit trail for policy proposal {}: {}", prop_id, e);
                                             } else {
-                                                info!("📋 Audit trail recorded for policy proposal {}", prop_id.0);
+                                                info!("📋 Audit trail recorded for policy proposal {}", prop_id);
                                             }
                                         }
                                     }
                                     Err(e) => {
-                                        eprintln!("❌ Failed to apply scheduling policy for proposal {}: {}", prop_id.0, e);
+                                        eprintln!("❌ Failed to apply scheduling policy for proposal {}: {}", prop_id, e);
                                     }
                                 }
                             }
                             Err(e) => {
-                                eprintln!("❌ Failed to parse policy JSON for proposal {}: {}", prop_id.0, e);
+                                eprintln!("❌ Failed to parse policy JSON for proposal {}: {}", prop_id, e);
                             }
                         }
                     });
@@ -163,26 +165,26 @@ async fn test_scheduling_policy_proposal_execution() -> Result<()> {
     info!("Created test scheduling policy");
 
     // 6. Create and fire a ProposalAccepted event
-    let proposal_id = ProposalId::new("test-policy-proposal-123");
+    let proposal_id = "test-policy-proposal-123".to_string();
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)?
         .as_secs();
 
-    let payload = ProposalPayload::SchedulingPolicy {
+    let payload = serde_json::to_value(&ProposalPayload::SchedulingPolicy {
         coop_id: "test-coop".to_string(),
         policy_json: policy_json.clone(),
-    };
+    }).unwrap();
 
     info!(
         "Firing ProposalAccepted event for proposal {}",
-        proposal_id.0
+        proposal_id
     );
 
     event_bus
         .emit(SystemEvent::ProposalAccepted {
             proposal_id: proposal_id.clone(),
             domain_id: "test-domain".to_string(),
-            payload,
+            payload: payload.clone(),
             decided_at: now,
         })
         .await;
@@ -203,12 +205,12 @@ async fn test_scheduling_policy_proposal_execution() -> Result<()> {
     info!("✅ Verified policy was applied to compute actor");
 
     // 9. Verify audit trail was stored
-    let audit_key = format!("gov:audit:policy:{}", proposal_id.0);
+    let audit_key = format!("gov:audit:policy:{}", proposal_id);
     let audit_data = gov_store.get(audit_key.as_bytes())?;
     assert!(audit_data.is_some(), "Audit trail should have been stored");
 
     let audit_json: serde_json::Value = serde_json::from_slice(&audit_data.unwrap())?;
-    assert_eq!(audit_json["proposal_id"], proposal_id.0);
+    assert_eq!(audit_json["proposal_id"], proposal_id);
     assert_eq!(audit_json["coop_id"], "test-coop");
 
     info!("✅ Verified audit trail was stored");
@@ -220,10 +222,10 @@ async fn test_scheduling_policy_proposal_execution() -> Result<()> {
         .emit(SystemEvent::ProposalAccepted {
             proposal_id: proposal_id.clone(),
             domain_id: "test-domain".to_string(),
-            payload: ProposalPayload::SchedulingPolicy {
+            payload: serde_json::to_value(&ProposalPayload::SchedulingPolicy {
                 coop_id: "test-coop".to_string(),
                 policy_json: policy_json.clone(),
-            },
+            }).unwrap(),
             decided_at: now,
         })
         .await;
@@ -283,15 +285,15 @@ async fn test_invalid_policy_json_handling() -> Result<()> {
             .subscribe(Arc::new(move |event| {
                 if let SystemEvent::ProposalAccepted {
                     proposal_id,
-                    payload:
-                        ProposalPayload::SchedulingPolicy {
-                            coop_id,
-                            policy_json,
-                        },
+                    payload,
                     decided_at,
                     ..
                 } = event
                 {
+                    let Ok(ProposalPayload::SchedulingPolicy {
+                        coop_id,
+                        policy_json,
+                    }) = serde_json::from_value::<ProposalPayload>(payload.clone()) else { return };
                     let compute_handle = compute.clone();
                     let prop_id = proposal_id.clone();
                     let store = audit_store.clone();
@@ -300,7 +302,7 @@ async fn test_invalid_policy_json_handling() -> Result<()> {
                     let _decision_time = decided_at;
 
                     tokio::spawn(async move {
-                        let audit_key = format!("gov:audit:policy:{}", prop_id.0);
+                        let audit_key = format!("gov:audit:policy:{}", prop_id);
                         match store.get(audit_key.as_bytes()) {
                             Ok(Some(_)) => return,
                             Ok(None) => {}
@@ -322,7 +324,7 @@ async fn test_invalid_policy_json_handling() -> Result<()> {
     };
 
     // 4. Fire an event with invalid JSON
-    let proposal_id = ProposalId::new("invalid-json-proposal");
+    let proposal_id = "invalid-json-proposal".to_string();
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)?
         .as_secs();
@@ -331,10 +333,10 @@ async fn test_invalid_policy_json_handling() -> Result<()> {
         .emit(SystemEvent::ProposalAccepted {
             proposal_id: proposal_id.clone(),
             domain_id: "test-domain".to_string(),
-            payload: ProposalPayload::SchedulingPolicy {
+            payload: serde_json::to_value(&ProposalPayload::SchedulingPolicy {
                 coop_id: "test-coop".to_string(),
                 policy_json: "{invalid json}".to_string(),
-            },
+            }).unwrap(),
             decided_at: now,
         })
         .await;
@@ -350,7 +352,7 @@ async fn test_invalid_policy_json_handling() -> Result<()> {
     );
 
     // 7. Verify no audit trail was stored (execution failed)
-    let audit_key = format!("gov:audit:policy:{}", proposal_id.0);
+    let audit_key = format!("gov:audit:policy:{}", proposal_id);
     let audit_data = gov_store.get(audit_key.as_bytes())?;
     assert!(
         audit_data.is_none(),

--- a/icn/crates/icn-core/tests/governance_policy_integration.rs
+++ b/icn/crates/icn-core/tests/governance_policy_integration.rs
@@ -173,12 +173,10 @@ async fn test_scheduling_policy_proposal_execution() -> Result<()> {
     let payload = serde_json::to_value(&ProposalPayload::SchedulingPolicy {
         coop_id: "test-coop".to_string(),
         policy_json: policy_json.clone(),
-    }).unwrap();
+    })
+    .unwrap();
 
-    info!(
-        "Firing ProposalAccepted event for proposal {}",
-        proposal_id
-    );
+    info!("Firing ProposalAccepted event for proposal {}", proposal_id);
 
     event_bus
         .emit(SystemEvent::ProposalAccepted {
@@ -225,7 +223,8 @@ async fn test_scheduling_policy_proposal_execution() -> Result<()> {
             payload: serde_json::to_value(&ProposalPayload::SchedulingPolicy {
                 coop_id: "test-coop".to_string(),
                 policy_json: policy_json.clone(),
-            }).unwrap(),
+            })
+            .unwrap(),
             decided_at: now,
         })
         .await;
@@ -293,7 +292,10 @@ async fn test_invalid_policy_json_handling() -> Result<()> {
                     let Ok(ProposalPayload::SchedulingPolicy {
                         coop_id,
                         policy_json,
-                    }) = serde_json::from_value::<ProposalPayload>(payload.clone()) else { return };
+                    }) = serde_json::from_value::<ProposalPayload>(payload.clone())
+                    else {
+                        return;
+                    };
                     let compute_handle = compute.clone();
                     let prop_id = proposal_id.clone();
                     let store = audit_store.clone();
@@ -336,7 +338,8 @@ async fn test_invalid_policy_json_handling() -> Result<()> {
             payload: serde_json::to_value(&ProposalPayload::SchedulingPolicy {
                 coop_id: "test-coop".to_string(),
                 policy_json: "{invalid json}".to_string(),
-            }).unwrap(),
+            })
+            .unwrap(),
             decided_at: now,
         })
         .await;


### PR DESCRIPTION
## Summary

- Replaces `ProposalId` with `String` and `ProposalPayload` with `serde_json::Value` in `SystemEvent` enum variants
- Emitters (`governance/actor.rs`) serialize `ProposalPayload` via `serde_json::to_value`
- Consumers (`governance_handlers.rs`) deserialize back to `ProposalPayload` where dispatch is needed
- Removes the `use icn_governance::{ProposalId, ProposalPayload}` import from `events.rs` production code
- Updates all integration tests to match new types

This removes 1 of the 19 icn-governance imports from icn-core (events.rs is now governance-free).

### Behavior change (intentional)

**Serialization failures:** Previously, if `serde_json::to_value(&proposal.payload)` failed, the code emitted `ProposalAccepted` with a string fallback payload (`"serialization_error: ..."`). Downstream consumers would then fail to deserialize and silently drop the event. Now, serialization failures emit `ProposalExecutionFailed` instead, making the failure explicit and observable.

**Deserialization failures:** Previously, when `create_governance_subscription` failed to deserialize the `serde_json::Value` back to `ProposalPayload`, it only logged an error. Now it also emits `ProposalExecutionFailed` via the existing `emit_execution_failure()` helper (which spawns a tokio task to avoid re-entrant emit), making the failure visible to event consumers and metrics.

Both changes improve failure semantics: accepted proposals that cannot be executed are now surfaced as execution failures rather than silently dropped.

## Files changed

| File | Change |
|------|--------|
| `events.rs` | `ProposalId` -> `String`, `ProposalPayload` -> `serde_json::Value` |
| `governance/actor.rs` | Serialize payload at emit sites; on failure emit `ProposalExecutionFailed` |
| `governance_handlers.rs` | Deserialize payload at consume sites; on failure emit execution failure |
| `tests/governance_ledger_integration.rs` | Update event construction + match arms |
| `tests/governance_policy_integration.rs` | Update event construction + match arms |
| `tests/governance_ledger_idempotency.rs` | Update event construction + match arms |

## Test plan

- [x] `cargo test -p icn-core` -- all tests pass
- [x] `cargo clippy -p icn-core --all-targets -- -D warnings` -- clean
- [x] `cargo fmt --check` -- clean
- [x] No `use icn_governance` in `events.rs`
- [x] No `ProposalPayload`/`ProposalId` types in `events.rs` production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)