### PR TITLE
fix(trust): sign attestations before gossip broadcast

### DIFF
--- a/apps/trust/src/lib.rs
+++ b/apps/trust/src/lib.rs
@@ -94,13 +94,15 @@ pub fn create_service(
 ///
 /// # Arguments
 /// * `trust_graph` - The trust graph with tokio RwLock wrapper.
+/// * `keypair` - The node's keypair for signing outgoing attestations.
 ///
 /// # Panics
 /// If called outside of a tokio multi-threaded runtime context.
 pub fn create_service_tokio(
     trust_graph: Arc<tokio::sync::RwLock<icn_trust::TrustGraph>>,
+    keypair: icn_identity::KeyPair,
 ) -> Arc<dyn icn_kernel_api::services::TrustService> {
-    Arc::new(TrustServiceImplTokio::new(trust_graph))
+    Arc::new(TrustServiceImplTokio::new(trust_graph, keypair))
 }
 
 #[cfg(test)]

--- a/apps/trust/src/service_tokio.rs
+++ b/apps/trust/src/service_tokio.rs
@@ -221,8 +221,8 @@ impl TrustService for TrustServiceImplTokio {
                 attestation.issuer, attestation.subject, e
             );
             return Err(format!(
-                "Invalid attestation signature from {} -> {}: {e}",
-                attestation.issuer, attestation.subject
+                "Invalid attestation signature from {} -> {} (envelope source: {}): {e}",
+                attestation.issuer, attestation.subject, source
             ));
         }
 
@@ -311,6 +311,11 @@ impl TrustService for TrustServiceImplTokio {
         })
     }
 
+    /// Submit a trust attestation and return Ed25519-signed bytes for gossip broadcast.
+    ///
+    /// The attestation is signed with the node's keypair before serialization.
+    /// Receiving nodes will verify the signature via `ingest_attestation()` before
+    /// applying to their trust graph — unsigned or tampered attestations are rejected.
     fn submit_attestation(
         &self,
         target: &icn_kernel_api::types::Did,
@@ -517,5 +522,81 @@ mod tests {
         service_b
             .ingest_attestation(&bytes, &source_a)
             .expect("ingest of signed attestation should succeed");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_ingest_rejects_tampered_attestation() {
+        let (graph, keypair) = create_test_graph();
+        let service = TrustServiceImplTokio::new(graph, keypair);
+
+        let issuer = icn_identity::KeyPair::generate().unwrap();
+        let target = icn_identity::KeyPair::generate().unwrap();
+
+        // Create a properly signed attestation, then tamper with the score
+        let mut attestation =
+            icn_trust::TrustAttestation::new(issuer.did().clone(), target.did().clone(), 0.5);
+        attestation.sign(&issuer).unwrap();
+        attestation.score = 0.99; // tamper after signing
+
+        let bytes = serde_json::to_vec(&attestation).unwrap();
+        let source = icn_kernel_api::types::Did::from(issuer.did().to_string());
+        let result = service.ingest_attestation(&bytes, &source);
+        assert!(
+            result.is_err(),
+            "Tampered attestation must be rejected, got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_ingest_rejects_expired_signed_attestation() {
+        let (graph, keypair) = create_test_graph();
+        let service = TrustServiceImplTokio::new(graph, keypair);
+
+        let issuer = icn_identity::KeyPair::generate().unwrap();
+        let target = icn_identity::KeyPair::generate().unwrap();
+
+        // Create a signed attestation that is already expired
+        // Default TTL is 30 days (2,592,000 seconds)
+        let mut attestation =
+            icn_trust::TrustAttestation::new(issuer.did().clone(), target.did().clone(), 0.5);
+        attestation.created_at = 1000; // ancient timestamp
+        attestation.sign(&issuer).unwrap();
+
+        let bytes = serde_json::to_vec(&attestation).unwrap();
+        let source = icn_kernel_api::types::Did::from(issuer.did().to_string());
+        // Expired attestations return Ok(()) — silently dropped, not an error
+        let result = service.ingest_attestation(&bytes, &source);
+        assert!(
+            result.is_ok(),
+            "Expired attestations are silently dropped, not errors: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_ingest_rejects_spoofed_issuer() {
+        let (graph, keypair) = create_test_graph();
+        let service = TrustServiceImplTokio::new(graph, keypair);
+
+        let alice = icn_identity::KeyPair::generate().unwrap();
+        let bob = icn_identity::KeyPair::generate().unwrap();
+        let target = icn_identity::KeyPair::generate().unwrap();
+
+        // Alice signs a valid attestation, then changes issuer to Bob's DID
+        // (simulating an attacker trying to impersonate Bob)
+        let mut attestation =
+            icn_trust::TrustAttestation::new(alice.did().clone(), target.did().clone(), 0.5);
+        attestation.sign(&alice).unwrap();
+        attestation.issuer = bob.did().clone(); // spoof issuer after signing
+
+        let bytes = serde_json::to_vec(&attestation).unwrap();
+        let source = icn_kernel_api::types::Did::from(alice.did().to_string());
+        let result = service.ingest_attestation(&bytes, &source);
+        assert!(
+            result.is_err(),
+            "Attestation with spoofed issuer must be rejected, got: {:?}",
+            result
+        );
     }
 }

--- a/apps/trust/src/service_tokio.rs
+++ b/apps/trust/src/service_tokio.rs
@@ -30,22 +30,22 @@ pub struct TrustServiceImplTokio {
     graph: Arc<RwLock<TrustGraph>>,
     oracle: Arc<TrustPolicyOracleTokio>,
     own_did: icn_identity::Did,
+    /// Keypair for signing outgoing attestations.
+    keypair: icn_identity::KeyPair,
 }
 
 impl TrustServiceImplTokio {
-    /// Create a new trust service with the given TrustGraph
-    pub fn new(graph: Arc<RwLock<TrustGraph>>) -> Self {
-        let own_did = {
-            let rt = tokio::runtime::Handle::current();
-            tokio::task::block_in_place(|| {
-                rt.block_on(async { graph.read().await.own_did().clone() })
-            })
-        };
+    /// Create a new trust service with the given TrustGraph and keypair.
+    ///
+    /// The keypair is used to sign outgoing attestations before gossip broadcast.
+    pub fn new(graph: Arc<RwLock<TrustGraph>>, keypair: icn_identity::KeyPair) -> Self {
+        let own_did = keypair.did().clone();
         let oracle = Arc::new(TrustPolicyOracleTokio::new(graph.clone()));
         Self {
             graph,
             oracle,
             own_did,
+            keypair,
         }
     }
 
@@ -213,14 +213,17 @@ impl TrustService for TrustServiceImplTokio {
         let attestation: TrustAttestation =
             serde_json::from_slice(bytes).map_err(|e| format!("Invalid attestation: {e}"))?;
 
-        // Verify signature
+        // Verify signature — reject unsigned or invalid attestations
         if let Err(e) = attestation.verify() {
             tracing::warn!(
                 source = %source,
                 "Rejecting trust attestation with invalid signature: {} -> {} (error: {})",
                 attestation.issuer, attestation.subject, e
             );
-            return Ok(()); // Silently reject invalid signatures
+            return Err(format!(
+                "Invalid attestation signature from {} -> {}: {e}",
+                attestation.issuer, attestation.subject
+            ));
         }
 
         // Check if expired
@@ -330,8 +333,11 @@ impl TrustService for TrustServiceImplTokio {
             rt.block_on(async {
                 let mut graph = self.graph.write().await;
                 graph.add_edge(edge.clone()).map_err(|e| format!("{e}"))?;
-                // Return serialized attestation for gossip broadcast
-                let attestation = icn_trust::TrustAttestation::from_trust_edge(&edge);
+                // Sign attestation before gossip broadcast
+                let mut attestation = icn_trust::TrustAttestation::from_trust_edge(&edge);
+                attestation
+                    .sign(&self.keypair)
+                    .map_err(|e| format!("Failed to sign attestation: {e}"))?;
                 serde_json::to_vec(&attestation).map_err(|e| format!("{e}"))
             })
         })
@@ -401,7 +407,7 @@ mod tests {
     use super::*;
     use icn_kernel_api::services::TrustService as _;
 
-    fn create_test_graph() -> (Arc<RwLock<TrustGraph>>, icn_identity::Did) {
+    fn create_test_graph() -> (Arc<RwLock<TrustGraph>>, icn_identity::KeyPair) {
         let store = icn_store::SledStore::temporary().unwrap();
         let store: Arc<dyn icn_store::Store> = Arc::new(store);
 
@@ -410,14 +416,14 @@ mod tests {
 
         (
             Arc::new(RwLock::new(TrustGraph::new(store, did.clone()))),
-            did,
+            keypair,
         )
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_trust_service_tokio_creation() {
-        let (graph, _did) = create_test_graph();
-        let service = TrustServiceImplTokio::new(graph);
+        let (graph, keypair) = create_test_graph();
+        let service = TrustServiceImplTokio::new(graph, keypair);
 
         // Should have zero trust for unknown actors
         let unknown_keypair = icn_identity::KeyPair::generate().unwrap();
@@ -431,8 +437,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_trust_score_unknown_actor() {
-        let (graph, _did) = create_test_graph();
-        let service = TrustServiceImplTokio::new(graph);
+        let (graph, keypair) = create_test_graph();
+        let service = TrustServiceImplTokio::new(graph, keypair);
 
         let unknown_keypair = icn_identity::KeyPair::generate().unwrap();
         let unknown_did = icn_kernel_api::types::Did::from(unknown_keypair.did().to_string());
@@ -440,5 +446,76 @@ mod tests {
         // Unknown actors should get 0.0 trust
         let score = service.trust_score(&unknown_did);
         assert_eq!(score, 0.0);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_submit_attestation_is_signed() {
+        let (graph, keypair) = create_test_graph();
+        let service = TrustServiceImplTokio::new(graph, keypair);
+
+        let target = icn_identity::KeyPair::generate().unwrap();
+        let target_did = icn_kernel_api::types::Did::from(target.did().to_string());
+
+        // Submit attestation — should be signed
+        let bytes = service
+            .submit_attestation(&target_did, 0.7, vec!["partner".into()])
+            .expect("submit_attestation should succeed");
+
+        // Deserialize and verify signature
+        let attestation: icn_trust::TrustAttestation =
+            serde_json::from_slice(&bytes).expect("should deserialize");
+        assert!(
+            !attestation.signature.is_empty(),
+            "Attestation must be signed before gossip broadcast"
+        );
+        attestation
+            .verify()
+            .expect("Attestation signature must be valid");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_ingest_rejects_unsigned_attestation() {
+        let (graph, keypair) = create_test_graph();
+        let service = TrustServiceImplTokio::new(graph, keypair);
+
+        let issuer = icn_identity::KeyPair::generate().unwrap();
+        let target = icn_identity::KeyPair::generate().unwrap();
+
+        // Create an unsigned attestation
+        let attestation =
+            icn_trust::TrustAttestation::new(issuer.did().clone(), target.did().clone(), 0.5);
+        let bytes = serde_json::to_vec(&attestation).unwrap();
+
+        let source = icn_kernel_api::types::Did::from(issuer.did().to_string());
+        let result = service.ingest_attestation(&bytes, &source);
+        assert!(
+            result.is_err(),
+            "Unsigned attestations must be rejected, got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_submit_then_ingest_roundtrip() {
+        // Node A submits attestation, Node B ingests it
+        let (graph_a, keypair_a) = create_test_graph();
+        let service_a = TrustServiceImplTokio::new(graph_a, keypair_a);
+
+        let (graph_b, keypair_b) = create_test_graph();
+        let service_b = TrustServiceImplTokio::new(graph_b, keypair_b);
+
+        let target = icn_identity::KeyPair::generate().unwrap();
+        let target_did = icn_kernel_api::types::Did::from(target.did().to_string());
+
+        // Node A submits signed attestation
+        let bytes = service_a
+            .submit_attestation(&target_did, 0.8, vec!["validator".into()])
+            .expect("submit should succeed");
+
+        // Node B ingests it — should succeed because it's signed
+        let source_a = icn_kernel_api::types::Did::from(service_a.own_did.to_string());
+        service_b
+            .ingest_attestation(&bytes, &source_a)
+            .expect("ingest of signed attestation should succeed");
     }
 }

--- a/icn/bins/icnd/src/main.rs
+++ b/icn/bins/icnd/src/main.rs
@@ -97,6 +97,14 @@ async fn build_service_registry(
         let trust_graph_handle = Arc::new(RwLock::new(trust_graph));
 
         // Create TrustService from apps/trust (keypair is required for signing attestations)
+        //
+        // NOTE: `bundle.keypair()` will fail for hardware-backed keys (PKCS#11, TPM),
+        // because those backends cannot expose a raw keypair. This is currently safe
+        // because hardware key backends are not yet implemented and keystore unlock
+        // fails early for such configurations.
+        // TODO(hardware-keys): When hardware-backed key support is implemented, refactor
+        // TrustService construction to use `bundle.did_key()` and `bundle.sign()` so that
+        // both software and hardware-backed keys are supported here.
         let keypair = bundle.keypair().context(
             "Cannot create TrustService: failed to extract keypair from identity bundle",
         )?;

--- a/icn/bins/icnd/src/main.rs
+++ b/icn/bins/icnd/src/main.rs
@@ -96,8 +96,12 @@ async fn build_service_registry(
         let trust_graph = icn_trust::TrustGraph::new(trust_store, own_did.clone());
         let trust_graph_handle = Arc::new(RwLock::new(trust_graph));
 
-        // Create TrustService from apps/trust
-        let trust_service = icn_trust_app::create_service_tokio(trust_graph_handle.clone());
+        // Create TrustService from apps/trust (keypair is required for signing attestations)
+        let keypair = bundle.keypair().context(
+            "Cannot create TrustService: failed to extract keypair from identity bundle",
+        )?;
+        let trust_service =
+            icn_trust_app::create_service_tokio(trust_graph_handle.clone(), keypair);
         registry = registry.with_trust(trust_service);
 
         // Also pass raw TrustGraph handle for components that still need direct access


### PR DESCRIPTION
## Summary
- Attestations are now Ed25519-signed at the submit path before gossip broadcast
- Receivers reject unsigned/invalid attestations with explicit errors
- End-to-end signing roundtrip tested

## What
`submit_attestation()` was creating `TrustAttestation::from_trust_edge()` and serializing it without calling `sign()`. The resulting attestation had an empty signature field, meaning receivers would silently reject it via `verify()`.

## Why
Closes #978 — No unsigned attestation should influence trust scoring. This is gate A0 of the trust hardening sprint.

## How
- `TrustServiceImplTokio` now holds the node's `KeyPair` (injected at construction)
- `submit_attestation()` calls `attestation.sign(&self.keypair)` before serialization
- `ingest_attestation()` returns `Err` instead of silently returning `Ok(())` on invalid signatures
- `create_service_tokio()` API updated to require `KeyPair` parameter
- `icnd` daemon passes `bundle.keypair()` to the trust service

## Risk
- **API breaking change**: `create_service_tokio()` now requires a `KeyPair` parameter. Only one call site (icnd daemon).
- `ingest_attestation()` now returns `Err` for invalid signatures instead of `Ok(())`. The handler in `init_notifications.rs` already logs errors from this method, so behavior is unchanged except for clearer error reporting.

## Test plan
- `cargo test -p icn-trust-app` — 20 tests pass (3 new)
  - `test_submit_attestation_is_signed`: verifies signature is present and valid
  - `test_ingest_rejects_unsigned_attestation`: verifies rejection path
  - `test_submit_then_ingest_roundtrip`: end-to-end A→B attestation flow
- `cargo check -p icnd` — daemon compiles
- `cargo clippy --all-targets --all-features -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)