### PR TITLE
feat(trust): add attestation reducer + enriched score query

### DIFF
--- a/apps/trust/Cargo.toml
+++ b/apps/trust/Cargo.toml
@@ -28,6 +28,9 @@ tokio = { version = "1", features = ["sync", "rt"] }
 # Serialization (for TrustService edge queries)
 serde_json = "1.0"
 
+# Hashing for reducer provenance
+sha2 = "0.10"
+
 # Error handling
 anyhow = "1.0"
 

--- a/apps/trust/src/lib.rs
+++ b/apps/trust/src/lib.rs
@@ -34,6 +34,7 @@
 
 pub mod oracle;
 pub mod oracle_tokio;
+pub mod reducer;
 pub mod service;
 pub mod service_tokio;
 

--- a/apps/trust/src/reducer.rs
+++ b/apps/trust/src/reducer.rs
@@ -13,7 +13,7 @@
 //!                                     ├── verify signatures
 //!                                     ├── filter expired
 //!                                     ├── deduplicate (issuer, subject, graph_type)
-//!                                     ├── compute weighted score
+//!                                     ├── compute average score
 //!                                     └── hash inputs for provenance
 //! ```
 
@@ -131,6 +131,7 @@ impl AttestationReducer {
             a.issuer
                 .to_string()
                 .cmp(&b.issuer.to_string())
+                .then_with(|| a.subject.to_string().cmp(&b.subject.to_string()))
                 .then_with(|| a.graph_type.as_str().cmp(b.graph_type.as_str()))
         });
 

--- a/apps/trust/src/reducer.rs
+++ b/apps/trust/src/reducer.rs
@@ -1,0 +1,481 @@
+//! Attestation Reducer — pure scoring from attestation sets.
+//!
+//! The reducer is a **pure function**: given the same set of attestations,
+//! it always produces the same score and the same inputs hash. This makes
+//! scoring deterministic across nodes and cache-safe with version-keyed
+//! entries.
+//!
+//! # Architecture
+//!
+//! ```text
+//! Vec<TrustAttestation>  ───>  AttestationReducer::reduce()  ───>  ReducedScore
+//!                                     │
+//!                                     ├── verify signatures
+//!                                     ├── filter expired
+//!                                     ├── deduplicate (issuer, subject, graph_type)
+//!                                     ├── compute weighted score
+//!                                     └── hash inputs for provenance
+//! ```
+
+use icn_trust::TrustAttestation;
+use sha2::{Digest, Sha256};
+
+/// Current reducer algorithm version.
+///
+/// Bump this when the scoring algorithm changes. Cache consumers compare
+/// this against cached entries to detect stale results.
+pub const REDUCER_VERSION: &str = "1.0.0";
+
+/// Result of reducing a set of attestations into a single score.
+///
+/// This is the app-side counterpart to `TrustScoreResult` in kernel-api.
+/// It contains the same provenance fields plus internal details that
+/// the kernel does not need to see.
+#[derive(Debug, Clone)]
+pub struct ReducedScore {
+    /// Computed trust score (0.0-1.0)
+    pub score: f64,
+    /// Number of valid attestation inputs after filtering
+    pub input_count: u32,
+    /// SHA-256 hash of the canonical input representation.
+    /// Deterministic: same inputs (regardless of order) → same hash.
+    pub inputs_hash: [u8; 32],
+    /// Reducer algorithm version
+    pub reducer_version: String,
+    /// Per-issuer breakdown (issuer DID string → score they assigned)
+    pub issuer_scores: Vec<(String, f64)>,
+}
+
+/// Pure attestation reducer.
+///
+/// Stateless — all configuration is provided at construction time.
+/// Call `reduce()` with a set of attestations to get a deterministic score.
+pub struct AttestationReducer {
+    /// Current time for expiration filtering (Unix seconds).
+    /// Injected for determinism in tests.
+    now: u64,
+}
+
+impl AttestationReducer {
+    /// Create a reducer with the given "current time" for expiry checks.
+    pub fn new(now: u64) -> Self {
+        Self { now }
+    }
+
+    /// Create a reducer using the actual wall clock.
+    pub fn now() -> Self {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        Self { now }
+    }
+
+    /// Reduce a set of attestations into a single score.
+    ///
+    /// # Algorithm
+    ///
+    /// 1. **Filter**: Remove attestations with invalid signatures or that are expired.
+    /// 2. **Deduplicate**: For each `(issuer, subject, graph_type)` triple, keep only
+    ///    the "winning" attestation using `should_supersede()` ordering.
+    /// 3. **Score**: Compute the arithmetic mean of the surviving attestation scores.
+    /// 4. **Hash**: Produce a deterministic hash of the surviving attestation set
+    ///    (sorted by issuer DID for ordering stability).
+    ///
+    /// # Determinism guarantee
+    ///
+    /// Given the same set of attestations and the same `now` timestamp,
+    /// `reduce()` ALWAYS returns the same `ReducedScore`, regardless of
+    /// input ordering.
+    pub fn reduce(&self, attestations: &[TrustAttestation]) -> ReducedScore {
+        // Step 1: Filter — only verified, non-expired attestations
+        let valid: Vec<&TrustAttestation> = attestations
+            .iter()
+            .filter(|a| a.verify().is_ok() && !a.is_expired(self.now))
+            .collect();
+
+        if valid.is_empty() {
+            return ReducedScore {
+                score: 0.0,
+                input_count: 0,
+                inputs_hash: [0u8; 32],
+                reducer_version: REDUCER_VERSION.to_string(),
+                issuer_scores: Vec::new(),
+            };
+        }
+
+        // Step 2: Deduplicate by (issuer, subject, graph_type)
+        // Keep the "winning" attestation per triple.
+        let mut best: std::collections::HashMap<(String, String, String), &TrustAttestation> =
+            std::collections::HashMap::new();
+
+        for att in &valid {
+            let key = (
+                att.issuer.to_string(),
+                att.subject.to_string(),
+                att.graph_type.as_str().to_string(),
+            );
+            let entry = best.entry(key);
+            entry
+                .and_modify(|existing| {
+                    if att.should_supersede(existing.created_at, existing.score) {
+                        *existing = att;
+                    }
+                })
+                .or_insert(att);
+        }
+
+        // Step 3: Collect winners sorted by issuer for determinism
+        let mut winners: Vec<&&TrustAttestation> = best.values().collect();
+        winners.sort_by(|a, b| {
+            a.issuer
+                .to_string()
+                .cmp(&b.issuer.to_string())
+                .then_with(|| a.graph_type.as_str().cmp(b.graph_type.as_str()))
+        });
+
+        // Step 4: Compute score — arithmetic mean of surviving attestation scores
+        let sum: f64 = winners.iter().map(|a| a.score).sum();
+        let count = winners.len() as f64;
+        let score = (sum / count).clamp(0.0, 1.0);
+
+        // Step 5: Compute deterministic inputs hash
+        let inputs_hash = self.hash_inputs(&winners);
+
+        // Step 6: Collect issuer breakdown
+        let issuer_scores: Vec<(String, f64)> = winners
+            .iter()
+            .map(|a| (a.issuer.to_string(), a.score))
+            .collect();
+
+        ReducedScore {
+            score,
+            input_count: winners.len() as u32,
+            inputs_hash,
+            reducer_version: REDUCER_VERSION.to_string(),
+            issuer_scores,
+        }
+    }
+
+    /// Compute a deterministic SHA-256 hash over the canonical input set.
+    ///
+    /// The hash covers: for each winning attestation (sorted by issuer),
+    /// `issuer || subject || score_le_bytes || created_at_le_bytes || graph_type`.
+    fn hash_inputs(&self, winners: &[&&TrustAttestation]) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        // Prefix with reducer version so algorithm changes produce different hashes
+        hasher.update(REDUCER_VERSION.as_bytes());
+        for att in winners {
+            hasher.update(att.issuer.as_str().as_bytes());
+            hasher.update(att.subject.as_str().as_bytes());
+            hasher.update(att.score.to_le_bytes());
+            hasher.update(att.created_at.to_le_bytes());
+            hasher.update(att.graph_type.as_str().as_bytes());
+        }
+        hasher.finalize().into()
+    }
+}
+
+impl ReducedScore {
+    /// Convert to the kernel-api `TrustScoreResult` type.
+    pub fn to_kernel_result(&self, epoch: u64) -> icn_kernel_api::services::TrustScoreResult {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        icn_kernel_api::services::TrustScoreResult {
+            score: self.score,
+            epoch,
+            computed_at: now,
+            input_count: self.input_count,
+            inputs_hash: self.inputs_hash,
+            reducer_version: self.reducer_version.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use icn_identity::KeyPair;
+    use icn_trust::types::TrustGraphType;
+
+    /// Helper to create a signed attestation.
+    fn make_signed(
+        issuer: &KeyPair,
+        subject: &icn_identity::Did,
+        score: f64,
+        created_at: u64,
+    ) -> TrustAttestation {
+        let mut att = TrustAttestation::new_typed(
+            issuer.did().clone(),
+            subject.clone(),
+            score,
+            TrustGraphType::Social,
+        );
+        att.created_at = created_at;
+        att.sign(issuer).expect("signing failed");
+        att
+    }
+
+    // ====================================================================
+    // DETERMINISM TESTS — the core guarantee of the reducer
+    // ====================================================================
+
+    #[test]
+    fn deterministic_same_inputs_same_output() {
+        let alice = KeyPair::generate().unwrap();
+        let bob = KeyPair::generate().unwrap();
+        let carol = KeyPair::generate().unwrap();
+        let target = KeyPair::generate().unwrap();
+
+        let now = 10_000u64;
+        let atts = vec![
+            make_signed(&alice, target.did(), 0.8, now - 100),
+            make_signed(&bob, target.did(), 0.6, now - 200),
+            make_signed(&carol, target.did(), 0.9, now - 50),
+        ];
+
+        let reducer = AttestationReducer::new(now);
+        let r1 = reducer.reduce(&atts);
+        let r2 = reducer.reduce(&atts);
+
+        assert_eq!(r1.score, r2.score);
+        assert_eq!(r1.inputs_hash, r2.inputs_hash);
+        assert_eq!(r1.input_count, r2.input_count);
+    }
+
+    #[test]
+    fn deterministic_regardless_of_input_order() {
+        let alice = KeyPair::generate().unwrap();
+        let bob = KeyPair::generate().unwrap();
+        let target = KeyPair::generate().unwrap();
+
+        let now = 10_000u64;
+        let a = make_signed(&alice, target.did(), 0.7, now - 100);
+        let b = make_signed(&bob, target.did(), 0.3, now - 100);
+
+        let reducer = AttestationReducer::new(now);
+        let r1 = reducer.reduce(&[a.clone(), b.clone()]);
+        let r2 = reducer.reduce(&[b, a]);
+
+        assert_eq!(r1.score, r2.score);
+        assert_eq!(r1.inputs_hash, r2.inputs_hash);
+    }
+
+    // ====================================================================
+    // FILTERING TESTS
+    // ====================================================================
+
+    #[test]
+    fn expired_attestations_are_filtered() {
+        let alice = KeyPair::generate().unwrap();
+        let target = KeyPair::generate().unwrap();
+
+        // Default TTL is 30 days = 2,592,000 seconds
+        // Created at 1000, so expires at 2,593,000
+        let att = make_signed(&alice, target.did(), 0.8, 1000);
+        let now = 2_593_001; // 1 second after expiry
+
+        let reducer = AttestationReducer::new(now);
+        let result = reducer.reduce(&[att]);
+
+        assert_eq!(result.score, 0.0);
+        assert_eq!(result.input_count, 0);
+    }
+
+    #[test]
+    fn unsigned_attestations_are_filtered() {
+        let alice = KeyPair::generate().unwrap();
+        let target = KeyPair::generate().unwrap();
+
+        let now = 10_000u64;
+        // Unsigned (no sign() call)
+        let mut att = TrustAttestation::new(alice.did().clone(), target.did().clone(), 0.5);
+        att.created_at = now - 100;
+
+        let reducer = AttestationReducer::new(now);
+        let result = reducer.reduce(&[att]);
+
+        assert_eq!(result.score, 0.0);
+        assert_eq!(result.input_count, 0);
+    }
+
+    #[test]
+    fn tampered_attestations_are_filtered() {
+        let alice = KeyPair::generate().unwrap();
+        let target = KeyPair::generate().unwrap();
+
+        let now = 10_000u64;
+        let mut att = make_signed(&alice, target.did(), 0.5, now - 100);
+        att.score = 0.99; // tamper
+
+        let reducer = AttestationReducer::new(now);
+        let result = reducer.reduce(&[att]);
+
+        assert_eq!(result.score, 0.0);
+        assert_eq!(result.input_count, 0);
+    }
+
+    // ====================================================================
+    // DEDUPLICATION TESTS
+    // ====================================================================
+
+    #[test]
+    fn dedup_keeps_superseding_attestation() {
+        let alice = KeyPair::generate().unwrap();
+        let target = KeyPair::generate().unwrap();
+
+        let now = 10_000u64;
+        let old = make_signed(&alice, target.did(), 0.3, now - 500);
+        let new = make_signed(&alice, target.did(), 0.9, now - 100);
+
+        let reducer = AttestationReducer::new(now);
+        let result = reducer.reduce(&[old, new]);
+
+        // Only one attestation should survive (same issuer)
+        assert_eq!(result.input_count, 1);
+        // The newer one (0.9) should win
+        assert!((result.score - 0.9).abs() < 0.001);
+    }
+
+    // ====================================================================
+    // SCORING TESTS
+    // ====================================================================
+
+    #[test]
+    fn score_is_mean_of_surviving_attestations() {
+        let alice = KeyPair::generate().unwrap();
+        let bob = KeyPair::generate().unwrap();
+        let target = KeyPair::generate().unwrap();
+
+        let now = 10_000u64;
+        let a = make_signed(&alice, target.did(), 0.8, now - 100);
+        let b = make_signed(&bob, target.did(), 0.4, now - 100);
+
+        let reducer = AttestationReducer::new(now);
+        let result = reducer.reduce(&[a, b]);
+
+        assert_eq!(result.input_count, 2);
+        assert!((result.score - 0.6).abs() < 0.001); // mean of 0.8 and 0.4
+    }
+
+    #[test]
+    fn empty_input_returns_zero() {
+        let reducer = AttestationReducer::new(10_000);
+        let result = reducer.reduce(&[]);
+
+        assert_eq!(result.score, 0.0);
+        assert_eq!(result.input_count, 0);
+        assert_eq!(result.inputs_hash, [0u8; 32]);
+    }
+
+    // ====================================================================
+    // PROVENANCE TESTS
+    // ====================================================================
+
+    #[test]
+    fn inputs_hash_changes_when_inputs_differ() {
+        let alice = KeyPair::generate().unwrap();
+        let bob = KeyPair::generate().unwrap();
+        let target = KeyPair::generate().unwrap();
+
+        let now = 10_000u64;
+        let a = make_signed(&alice, target.did(), 0.8, now - 100);
+        let b = make_signed(&bob, target.did(), 0.4, now - 100);
+
+        let reducer = AttestationReducer::new(now);
+        let r1 = reducer.reduce(&[a.clone()]);
+        let r2 = reducer.reduce(&[a, b]);
+
+        // Different input sets → different hashes
+        assert_ne!(r1.inputs_hash, r2.inputs_hash);
+    }
+
+    #[test]
+    fn reducer_version_is_set() {
+        let alice = KeyPair::generate().unwrap();
+        let target = KeyPair::generate().unwrap();
+
+        let now = 10_000u64;
+        let a = make_signed(&alice, target.did(), 0.5, now - 100);
+
+        let reducer = AttestationReducer::new(now);
+        let result = reducer.reduce(&[a]);
+
+        assert_eq!(result.reducer_version, REDUCER_VERSION);
+    }
+
+    #[test]
+    fn issuer_breakdown_is_populated() {
+        let alice = KeyPair::generate().unwrap();
+        let bob = KeyPair::generate().unwrap();
+        let target = KeyPair::generate().unwrap();
+
+        let now = 10_000u64;
+        let a = make_signed(&alice, target.did(), 0.8, now - 100);
+        let b = make_signed(&bob, target.did(), 0.4, now - 100);
+
+        let reducer = AttestationReducer::new(now);
+        let result = reducer.reduce(&[a, b]);
+
+        assert_eq!(result.issuer_scores.len(), 2);
+    }
+
+    // ====================================================================
+    // SCHEMA CONTRACT TEST
+    // ====================================================================
+
+    #[test]
+    fn trust_attestation_schema_contract() {
+        // This test catches silent breakage in the TrustAttestation wire format.
+        // If serialization changes (field renames, type changes, new required fields),
+        // this test will fail and force a conscious decision.
+
+        let alice = KeyPair::generate().unwrap();
+        let bob = KeyPair::generate().unwrap();
+
+        let mut att = TrustAttestation::new_typed(
+            alice.did().clone(),
+            bob.did().clone(),
+            0.75,
+            TrustGraphType::Social,
+        );
+        att.created_at = 1700000000;
+        att.labels = vec!["partner".to_string()];
+        att.evidence = vec!["evidence_ref_1".to_string()];
+        att.sign(&alice).unwrap();
+
+        // Round-trip through JSON
+        let json = serde_json::to_value(&att).unwrap();
+
+        // Assert required fields exist with correct types
+        assert!(json["issuer"].is_string(), "issuer must be string");
+        assert!(json["subject"].is_string(), "subject must be string");
+        assert!(json["score"].is_f64(), "score must be f64");
+        assert!(json["ttl_seconds"].is_u64(), "ttl_seconds must be u64");
+        assert!(json["created_at"].is_u64(), "created_at must be u64");
+        assert!(json["signature"].is_array(), "signature must be array");
+        assert!(json["graph_type"].is_string(), "graph_type must be string");
+        assert!(json["labels"].is_array(), "labels must be array");
+        assert!(json["evidence"].is_array(), "evidence must be array");
+
+        // Verify round-trip deserialization preserves values
+        let bytes = serde_json::to_vec(&att).unwrap();
+        let deser: TrustAttestation = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(deser.issuer, att.issuer);
+        assert_eq!(deser.subject, att.subject);
+        assert_eq!(deser.score, att.score);
+        assert_eq!(deser.created_at, att.created_at);
+        assert_eq!(deser.labels, att.labels);
+        assert_eq!(deser.evidence, att.evidence);
+        assert_eq!(deser.graph_type, att.graph_type);
+        assert!(!deser.signature.is_empty());
+
+        // Verify deserialized attestation still passes signature verification
+        assert!(
+            deser.verify().is_ok(),
+            "round-tripped attestation must verify"
+        );
+    }
+}

--- a/apps/trust/src/reducer.rs
+++ b/apps/trust/src/reducer.rs
@@ -11,7 +11,7 @@
 //! Vec<TrustAttestation>  ───>  AttestationReducer::reduce()  ───>  ReducedScore
 //!                                     │
 //!                                     ├── verify signatures
-//!                                     ├── filter expired
+//!                                     ├── filter expired + future-dated
 //!                                     ├── deduplicate (issuer, subject, graph_type)
 //!                                     ├── compute average score
 //!                                     └── hash inputs for provenance
@@ -25,6 +25,13 @@ use sha2::{Digest, Sha256};
 /// Bump this when the scoring algorithm changes. Cache consumers compare
 /// this against cached entries to detect stale results.
 pub const REDUCER_VERSION: &str = "1.0.0";
+
+/// Maximum clock skew tolerance for future-dated attestations (5 minutes).
+///
+/// Attestations with `created_at` more than this far ahead of `now` are
+/// rejected. This prevents a malicious node from creating attestations with
+/// far-future timestamps that persist longer than intended.
+const CLOCK_SKEW_TOLERANCE_SECS: u64 = 300;
 
 /// Result of reducing a set of attestations into a single score.
 ///
@@ -75,7 +82,8 @@ impl AttestationReducer {
     ///
     /// # Algorithm
     ///
-    /// 1. **Filter**: Remove attestations with invalid signatures or that are expired.
+    /// 1. **Filter**: Remove attestations with invalid signatures, expired, or future-dated
+    ///    (beyond clock skew tolerance).
     /// 2. **Deduplicate**: For each `(issuer, subject, graph_type)` triple, keep only
     ///    the "winning" attestation using `should_supersede()` ordering.
     /// 3. **Score**: Compute the arithmetic mean of the surviving attestation scores.
@@ -87,11 +95,21 @@ impl AttestationReducer {
     /// Given the same set of attestations and the same `now` timestamp,
     /// `reduce()` ALWAYS returns the same `ReducedScore`, regardless of
     /// input ordering.
+    ///
+    /// **Platform caveat**: Floating-point division (`sum / count`) may produce
+    /// slightly different results across CPU architectures (x86 vs ARM) or
+    /// compiler optimization levels. The determinism guarantee holds within
+    /// the same platform and compiler version. Cross-platform determinism
+    /// would require fixed-point arithmetic (tracked as future work).
     pub fn reduce(&self, attestations: &[TrustAttestation]) -> ReducedScore {
-        // Step 1: Filter — only verified, non-expired attestations
+        // Step 1: Filter — only verified, non-expired, non-future attestations
         let valid: Vec<&TrustAttestation> = attestations
             .iter()
-            .filter(|a| a.verify().is_ok() && !a.is_expired(self.now))
+            .filter(|a| {
+                a.verify().is_ok()
+                    && !a.is_expired(self.now)
+                    && a.created_at <= self.now + CLOCK_SKEW_TOLERANCE_SECS
+            })
             .collect();
 
         if valid.is_empty() {
@@ -316,6 +334,62 @@ mod tests {
 
         assert_eq!(result.score, 0.0);
         assert_eq!(result.input_count, 0);
+    }
+
+    #[test]
+    fn all_invalid_attestations_return_zero() {
+        let alice = KeyPair::generate().unwrap();
+        let target = KeyPair::generate().unwrap();
+
+        // One unsigned, one expired, one tampered — all invalid
+        let now = 3_000_000u64; // far enough for 30-day TTL to expire created_at=1
+
+        let mut unsigned = TrustAttestation::new(alice.did().clone(), target.did().clone(), 0.5);
+        unsigned.created_at = now - 100;
+
+        let expired = make_signed(&alice, target.did(), 0.8, 1); // created_at=1, expired long ago
+
+        let mut tampered = make_signed(&alice, target.did(), 0.7, now - 100);
+        tampered.score = 0.99; // invalidate signature
+
+        let reducer = AttestationReducer::new(now);
+        let result = reducer.reduce(&[unsigned, expired, tampered]);
+
+        assert_eq!(result.score, 0.0);
+        assert_eq!(result.input_count, 0);
+        assert_eq!(result.inputs_hash, [0u8; 32]);
+    }
+
+    #[test]
+    fn future_dated_attestations_are_filtered() {
+        let alice = KeyPair::generate().unwrap();
+        let target = KeyPair::generate().unwrap();
+
+        let now = 10_000u64;
+        // Created 1 hour in the future (well beyond 5-minute tolerance)
+        let att = make_signed(&alice, target.did(), 0.8, now + 3600);
+
+        let reducer = AttestationReducer::new(now);
+        let result = reducer.reduce(&[att]);
+
+        assert_eq!(result.score, 0.0);
+        assert_eq!(result.input_count, 0);
+    }
+
+    #[test]
+    fn within_clock_skew_tolerance_accepted() {
+        let alice = KeyPair::generate().unwrap();
+        let target = KeyPair::generate().unwrap();
+
+        let now = 10_000u64;
+        // Created 2 minutes in the future (within 5-minute tolerance)
+        let att = make_signed(&alice, target.did(), 0.8, now + 120);
+
+        let reducer = AttestationReducer::new(now);
+        let result = reducer.reduce(&[att]);
+
+        assert_eq!(result.input_count, 1);
+        assert!((result.score - 0.8).abs() < 0.001);
     }
 
     // ====================================================================

--- a/apps/trust/src/reducer.rs
+++ b/apps/trust/src/reducer.rs
@@ -414,6 +414,26 @@ mod tests {
         assert!((result.score - 0.9).abs() < 0.001);
     }
 
+    #[test]
+    fn deterministic_identical_timestamp_and_score() {
+        let alice = KeyPair::generate().unwrap();
+        let target = KeyPair::generate().unwrap();
+
+        let now = 10_000u64;
+        // Two attestations with identical timestamp and score from same issuer
+        let a = make_signed(&alice, target.did(), 0.7, now - 100);
+        let b = make_signed(&alice, target.did(), 0.7, now - 100);
+
+        let reducer = AttestationReducer::new(now);
+        let r1 = reducer.reduce(&[a.clone(), b.clone()]);
+        let r2 = reducer.reduce(&[b, a]);
+
+        // Same result regardless of input order
+        assert_eq!(r1.score, r2.score);
+        assert_eq!(r1.inputs_hash, r2.inputs_hash);
+        assert_eq!(r1.input_count, 1); // Deduped to one
+    }
+
     // ====================================================================
     // SCORING TESTS
     // ====================================================================

--- a/apps/trust/src/service.rs
+++ b/apps/trust/src/service.rs
@@ -81,14 +81,9 @@ impl TrustService for TrustServiceImpl {
                 let penalty = severity * EVENT_SCORE_DELTA;
                 let current = {
                     let graph = self.graph.read();
-                    match graph.compute_trust_score(&identity_did) {
-                        Ok(score) => score,
-                        Err(_) => {
-                            // Unknown actors start at 0.0 trust — penalty still
-                            // creates a trust edge recording the violation.
-                            0.0
-                        }
-                    }
+                    // Unknown actors start at 0.0 trust — penalty still
+                    // creates a trust edge recording the violation.
+                    graph.compute_trust_score(&identity_did).unwrap_or(0.0)
                 };
                 let new_score = (current - penalty).max(0.0);
                 debug_assert!(
@@ -156,7 +151,6 @@ impl TrustService for TrustServiceImpl {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icn_kernel_api::services::TrustService as _;
 
     #[test]
     fn test_trust_service_creation() {
@@ -177,7 +171,7 @@ mod tests {
         let unknown_keypair = icn_identity::KeyPair::generate().unwrap();
         let unknown_did = icn_kernel_api::types::Did::from(unknown_keypair.did().to_string());
         let score = service.trust_score(&unknown_did);
-        assert!(score >= 0.0 && score <= 1.0);
+        assert!((0.0..=1.0).contains(&score));
 
         // Should return an oracle
         let _oracle = service.oracle();

--- a/apps/trust/src/service_tokio.rs
+++ b/apps/trust/src/service_tokio.rs
@@ -11,16 +11,18 @@
 //! tokio runtime.
 
 use icn_kernel_api::authz::PolicyOracle;
-use icn_kernel_api::services::{TrustEvent, TrustService};
+use icn_kernel_api::services::{TrustEvent, TrustScoreResult, TrustService};
 use icn_trust::TrustGraph;
 
 /// Maximum reputation score delta per single event (25%).
 /// Applied as a penalty for ProtocolViolation and as a boost for PositiveInteraction.
 const EVENT_SCORE_DELTA: f64 = 0.25;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::oracle_tokio::TrustPolicyOracleTokio;
+use crate::reducer;
 
 /// Trust service implementation for tokio locks.
 ///
@@ -32,6 +34,10 @@ pub struct TrustServiceImplTokio {
     own_did: icn_identity::Did,
     /// Keypair for signing outgoing attestations.
     keypair: icn_identity::KeyPair,
+    /// Monotonic epoch counter — incremented on each state mutation
+    /// (new edge, removed edge, trust event). Used by `TrustScoreResult`
+    /// so caches can detect when scores may have changed.
+    epoch: Arc<AtomicU64>,
 }
 
 impl TrustServiceImplTokio {
@@ -46,6 +52,36 @@ impl TrustServiceImplTokio {
             oracle,
             own_did,
             keypair,
+            epoch: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Get the current epoch (for testing/diagnostics)
+    pub fn epoch(&self) -> u64 {
+        self.epoch.load(Ordering::Relaxed)
+    }
+
+    /// Increment the epoch counter (called on state mutations)
+    fn bump_epoch(&self) {
+        self.epoch.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Return a zero-valued TrustScoreResult (for error/unknown cases).
+    ///
+    /// Falls back to `computed_at = 0` if the system clock is before Unix epoch,
+    /// which would indicate a misconfigured system clock.
+    fn empty_score_result(&self) -> TrustScoreResult {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0); // Pre-epoch clock → 0 (misconfigured system)
+        TrustScoreResult {
+            score: 0.0,
+            epoch: self.epoch.load(Ordering::Relaxed),
+            computed_at: now,
+            input_count: 0,
+            inputs_hash: [0u8; 32],
+            reducer_version: reducer::REDUCER_VERSION.to_string(),
         }
     }
 
@@ -88,6 +124,66 @@ impl TrustService for TrustServiceImplTokio {
         })
     }
 
+    fn trust_score_detailed(&self, actor: &icn_kernel_api::types::Did) -> TrustScoreResult {
+        tokio::task::block_in_place(|| {
+            let rt = tokio::runtime::Handle::current();
+            rt.block_on(async {
+                let graph = self.graph.read().await;
+                let identity_did = match actor.to_string().parse::<icn_identity::Did>() {
+                    Ok(d) => d,
+                    Err(_) => return self.empty_score_result(),
+                };
+
+                let score = graph.compute_trust_score(&identity_did).unwrap_or(0.0);
+
+                // Collect edges pointing to this actor to derive input count + hash
+                let input_edges = graph
+                    .get_all_known_dids()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter_map(|did| {
+                        graph
+                            .get_outgoing_edges(&did)
+                            .ok()
+                            .and_then(|edges| edges.into_iter().find(|e| e.target == identity_did))
+                    })
+                    .collect::<Vec<_>>();
+
+                let input_count = input_edges.len() as u32;
+
+                // Compute deterministic hash over the input edges
+                use sha2::{Digest, Sha256};
+                let mut hasher = Sha256::new();
+                hasher.update(reducer::REDUCER_VERSION.as_bytes());
+                // Sort by source DID for determinism
+                let mut sorted = input_edges;
+                sorted.sort_by(|a, b| a.source.to_string().cmp(&b.source.to_string()));
+                for edge in &sorted {
+                    hasher.update(edge.source.as_str().as_bytes());
+                    hasher.update(edge.target.as_str().as_bytes());
+                    hasher.update(edge.score.value().to_le_bytes());
+                    hasher.update(edge.created_at.to_le_bytes());
+                    hasher.update(edge.graph_type.as_str().as_bytes());
+                }
+                let inputs_hash: [u8; 32] = hasher.finalize().into();
+
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0);
+
+                TrustScoreResult {
+                    score,
+                    epoch: self.epoch.load(Ordering::Relaxed),
+                    computed_at: now,
+                    input_count,
+                    inputs_hash,
+                    reducer_version: reducer::REDUCER_VERSION.to_string(),
+                }
+            })
+        })
+    }
+
     fn record_event(&self, actor: &icn_kernel_api::types::Did, event: TrustEvent) {
         let identity_did = match actor.to_string().parse::<icn_identity::Did>() {
             Ok(did) => did,
@@ -113,14 +209,9 @@ impl TrustService for TrustServiceImplTokio {
                     rt.block_on(async {
                         let current = {
                             let graph = self.graph.read().await;
-                            match graph.compute_trust_score(&identity_did) {
-                                Ok(score) => score,
-                                Err(_) => {
-                                    // Unknown actors start at 0.0 trust — penalty
-                                    // still creates a trust edge recording the violation.
-                                    0.0
-                                }
-                            }
+                            // Unknown actors start at 0.0 trust — penalty
+                            // still creates a trust edge recording the violation.
+                            graph.compute_trust_score(&identity_did).unwrap_or(0.0)
                         };
                         let new_score = (current - penalty).max(0.0);
                         debug_assert!(
@@ -140,6 +231,7 @@ impl TrustService for TrustServiceImplTokio {
                                 e
                             );
                         } else {
+                            self.bump_epoch();
                             tracing::debug!(
                                 actor = %actor,
                                 current = current,
@@ -183,6 +275,7 @@ impl TrustService for TrustServiceImplTokio {
                                 e
                             );
                         } else {
+                            self.bump_epoch();
                             tracing::debug!(
                                 actor = %actor,
                                 new_score = new_score,
@@ -270,6 +363,7 @@ impl TrustService for TrustServiceImplTokio {
                 }
 
                 graph.add_edge(edge.clone()).map_err(|e| format!("{e}"))?;
+                self.bump_epoch();
 
                 tracing::info!(
                     "Applied remote trust attestation: {} -> {} (score: {})",
@@ -338,6 +432,7 @@ impl TrustService for TrustServiceImplTokio {
             rt.block_on(async {
                 let mut graph = self.graph.write().await;
                 graph.add_edge(edge.clone()).map_err(|e| format!("{e}"))?;
+                self.bump_epoch();
                 // Sign attestation before gossip broadcast
                 let mut attestation = icn_trust::TrustAttestation::from_trust_edge(&edge);
                 attestation
@@ -360,6 +455,7 @@ impl TrustService for TrustServiceImplTokio {
                 graph
                     .remove_edge(&self.own_did, &target_did)
                     .map_err(|e| format!("{e}"))?;
+                self.bump_epoch();
                 // Return empty bytes (no gossip message for revocation currently)
                 Ok(Vec::new())
             })
@@ -410,7 +506,6 @@ impl TrustService for TrustServiceImplTokio {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icn_kernel_api::services::TrustService as _;
 
     fn create_test_graph() -> (Arc<RwLock<TrustGraph>>, icn_identity::KeyPair) {
         let store = icn_store::SledStore::temporary().unwrap();
@@ -434,7 +529,7 @@ mod tests {
         let unknown_keypair = icn_identity::KeyPair::generate().unwrap();
         let unknown_did = icn_kernel_api::types::Did::from(unknown_keypair.did().to_string());
         let score = service.trust_score(&unknown_did);
-        assert!(score >= 0.0 && score <= 1.0);
+        assert!((0.0..=1.0).contains(&score));
 
         // Should return an oracle
         let _oracle = service.oracle();

--- a/apps/trust/src/service_tokio.rs
+++ b/apps/trust/src/service_tokio.rs
@@ -120,9 +120,7 @@ impl TrustService for TrustServiceImplTokio {
             rt.block_on(async {
                 let graph = self.graph.read().await;
                 if let Some(identity_did) = Self::parse_kernel_did(actor) {
-                    graph
-                        .compute_trust_score(&identity_did)
-                        .unwrap_or(0.0) // Unknown actors start at zero trust
+                    graph.compute_trust_score(&identity_did).unwrap_or(0.0) // Unknown actors start at zero trust
                 } else {
                     0.0
                 }
@@ -130,10 +128,10 @@ impl TrustService for TrustServiceImplTokio {
         })
     }
 
-    // TODO: Refactor to use `AttestationReducer` once the compute handler pipeline
-    // converts TrustEdges to TrustAttestations. Currently the reducer is used by
-    // the compute handler path; this method reimplements hash logic directly from
-    // the graph's edge storage for the service query path.
+    // TODO(#1000): Refactor to use `AttestationReducer` once the compute handler
+    // pipeline converts TrustEdges to TrustAttestations. Currently the reducer is
+    // used by the compute handler path; this method reimplements hash logic directly
+    // from the graph's edge storage for the service query path.
     fn trust_score_detailed(&self, actor: &icn_kernel_api::types::Did) -> TrustScoreResult {
         tokio::task::block_in_place(|| {
             let rt = tokio::runtime::Handle::current();
@@ -144,9 +142,7 @@ impl TrustService for TrustServiceImplTokio {
                     None => return self.empty_score_result(),
                 };
 
-                let score = graph
-                    .compute_trust_score(&identity_did)
-                    .unwrap_or(0.0); // Unknown actors start at zero trust
+                let score = graph.compute_trust_score(&identity_did).unwrap_or(0.0); // Unknown actors start at zero trust
 
                 // Collect edges pointing to this actor to derive input count + hash
                 let input_edges = graph

--- a/apps/trust/src/service_tokio.rs
+++ b/apps/trust/src/service_tokio.rs
@@ -124,6 +124,10 @@ impl TrustService for TrustServiceImplTokio {
         })
     }
 
+    // TODO: Refactor to use `AttestationReducer` once the compute handler pipeline
+    // converts TrustEdges to TrustAttestations. Currently the reducer is used by
+    // the compute handler path; this method reimplements hash logic directly from
+    // the graph's edge storage for the service query path.
     fn trust_score_detailed(&self, actor: &icn_kernel_api::types::Did) -> TrustScoreResult {
         tokio::task::block_in_place(|| {
             let rt = tokio::runtime::Handle::current();
@@ -151,7 +155,15 @@ impl TrustService for TrustServiceImplTokio {
 
                 let input_count = input_edges.len() as u32;
 
-                // Compute deterministic hash over the input edges
+                // Compute deterministic hash over the input edges.
+                //
+                // NOTE: This hashes TrustEdges (storage format) while AttestationReducer
+                // hashes TrustAttestations (wire format). These two hash methods serve
+                // different purposes and should not be compared:
+                // - This method: live score provenance from the graph's current state
+                // - AttestationReducer: pure scoring from a set of attestations
+                // When the reducer is integrated into this method (see TODO below),
+                // both paths will use the same attestation-based hashing.
                 use sha2::{Digest, Sha256};
                 let mut hasher = Sha256::new();
                 hasher.update(reducer::REDUCER_VERSION.as_bytes());
@@ -549,6 +561,80 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_epoch_starts_at_zero() {
+        let (graph, keypair) = create_test_graph();
+        let service = TrustServiceImplTokio::new(graph, keypair);
+        assert_eq!(service.epoch(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_epoch_increments_on_mutations() {
+        let (graph, keypair) = create_test_graph();
+        let service = TrustServiceImplTokio::new(graph, keypair);
+        assert_eq!(service.epoch(), 0);
+
+        // submit_attestation should bump epoch
+        let target = icn_identity::KeyPair::generate().unwrap();
+        let target_did = icn_kernel_api::types::Did::from(target.did().to_string());
+        service
+            .submit_attestation(&target_did, 0.5, vec![])
+            .unwrap();
+        assert_eq!(service.epoch(), 1);
+
+        // record_event (ProtocolViolation) should bump epoch
+        service.record_event(
+            &target_did,
+            TrustEvent::ProtocolViolation {
+                severity: 0.5,
+                category: "test".to_string(),
+            },
+        );
+        assert_eq!(service.epoch(), 2);
+
+        // revoke_trust should bump epoch
+        service.revoke_trust(&target_did).unwrap();
+        assert_eq!(service.epoch(), 3);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_trust_score_detailed_returns_enriched_result() {
+        let (graph, keypair) = create_test_graph();
+        let service = TrustServiceImplTokio::new(graph, keypair);
+
+        let target = icn_identity::KeyPair::generate().unwrap();
+        let target_did = icn_kernel_api::types::Did::from(target.did().to_string());
+
+        // Unknown actor returns zero score with epoch
+        let result = service.trust_score_detailed(&target_did);
+        assert_eq!(result.score, 0.0);
+        assert_eq!(result.epoch, 0);
+        assert_eq!(result.input_count, 0);
+        assert_eq!(result.reducer_version, reducer::REDUCER_VERSION);
+
+        // After adding a trust edge, detailed result should reflect it
+        service
+            .submit_attestation(&target_did, 0.8, vec![])
+            .unwrap();
+        let result = service.trust_score_detailed(&target_did);
+        assert!(result.score > 0.0, "score should be non-zero after edge");
+        assert_eq!(result.epoch, 1);
+        assert_eq!(result.input_count, 1);
+        assert_ne!(result.inputs_hash, [0u8; 32], "hash should be non-zero");
+        assert!(result.computed_at > 0, "timestamp should be set");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_trust_score_detailed_invalid_did() {
+        let (graph, keypair) = create_test_graph();
+        let service = TrustServiceImplTokio::new(graph, keypair);
+
+        let bad_did = icn_kernel_api::types::Did::from("not-a-valid-did".to_string());
+        let result = service.trust_score_detailed(&bad_did);
+        assert_eq!(result.score, 0.0);
+        assert_eq!(result.input_count, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_submit_attestation_is_signed() {
         let (graph, keypair) = create_test_graph();
         let service = TrustServiceImplTokio::new(graph, keypair);
@@ -693,5 +779,6 @@ mod tests {
             "Attestation with spoofed issuer must be rejected, got: {:?}",
             result
         );
+
     }
 }

--- a/apps/trust/src/service_tokio.rs
+++ b/apps/trust/src/service_tokio.rs
@@ -85,6 +85,11 @@ impl TrustServiceImplTokio {
         }
     }
 
+    /// Parse a kernel-api DID into an identity DID.
+    fn parse_kernel_did(did: &icn_kernel_api::types::Did) -> Option<icn_identity::Did> {
+        did.to_string().parse().ok()
+    }
+
     /// Get direct access to the TrustGraph
     ///
     /// This is for use by other domain apps that need TrustGraph access.
@@ -114,9 +119,10 @@ impl TrustService for TrustServiceImplTokio {
             let rt = tokio::runtime::Handle::current();
             rt.block_on(async {
                 let graph = self.graph.read().await;
-                // Convert from kernel Did to identity Did using FromStr
-                if let Ok(identity_did) = actor.to_string().parse::<icn_identity::Did>() {
-                    graph.compute_trust_score(&identity_did).unwrap_or(0.0)
+                if let Some(identity_did) = Self::parse_kernel_did(actor) {
+                    graph
+                        .compute_trust_score(&identity_did)
+                        .unwrap_or(0.0) // Unknown actors start at zero trust
                 } else {
                     0.0
                 }
@@ -133,12 +139,14 @@ impl TrustService for TrustServiceImplTokio {
             let rt = tokio::runtime::Handle::current();
             rt.block_on(async {
                 let graph = self.graph.read().await;
-                let identity_did = match actor.to_string().parse::<icn_identity::Did>() {
-                    Ok(d) => d,
-                    Err(_) => return self.empty_score_result(),
+                let identity_did = match Self::parse_kernel_did(actor) {
+                    Some(d) => d,
+                    None => return self.empty_score_result(),
                 };
 
-                let score = graph.compute_trust_score(&identity_did).unwrap_or(0.0);
+                let score = graph
+                    .compute_trust_score(&identity_did)
+                    .unwrap_or(0.0); // Unknown actors start at zero trust
 
                 // Collect edges pointing to this actor to derive input count + hash
                 let input_edges = graph
@@ -197,9 +205,9 @@ impl TrustService for TrustServiceImplTokio {
     }
 
     fn record_event(&self, actor: &icn_kernel_api::types::Did, event: TrustEvent) {
-        let identity_did = match actor.to_string().parse::<icn_identity::Did>() {
-            Ok(did) => did,
-            Err(_) => {
+        let identity_did = match Self::parse_kernel_did(actor) {
+            Some(did) => did,
+            None => {
                 tracing::warn!(actor = %actor, "Invalid DID format, ignoring trust event");
                 return;
             }

--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -3558,6 +3558,7 @@ dependencies = [
  "icn-trust",
  "parking_lot 0.12.5",
  "serde_json",
+ "sha2",
  "tokio",
  "tracing",
 ]

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -113,6 +113,43 @@ impl std::fmt::Display for TrustClass {
     }
 }
 
+/// Enriched trust score with provenance metadata.
+///
+/// This is the kernel-safe counterpart of a "scored result" — it includes
+/// enough metadata to make caching safe (version + epoch) and debugging
+/// possible (input_count + computed_at) without leaking domain semantics.
+///
+/// The `reducer_version` field tracks which scoring algorithm produced this
+/// result. Cache consumers can use it to invalidate entries when the
+/// algorithm changes.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct TrustScoreResult {
+    /// The computed trust score (0.0-1.0)
+    pub score: f64,
+    /// Monotonic epoch — incremented each time inputs change
+    pub epoch: u64,
+    /// Unix timestamp when this score was computed
+    pub computed_at: u64,
+    /// Number of attestation inputs that fed into this score
+    pub input_count: u32,
+    /// Hash of the inputs (for determinism verification)
+    ///
+    /// Two nodes with the same inputs_hash MUST produce the same score.
+    pub inputs_hash: [u8; 32],
+    /// Reducer algorithm version (e.g. "1.0.0")
+    ///
+    /// Changing the scoring algorithm increments this, signaling caches to
+    /// invalidate.
+    pub reducer_version: String,
+}
+
+impl TrustScoreResult {
+    /// Get the score value (convenience accessor)
+    pub fn value(&self) -> f64 {
+        self.score
+    }
+}
+
 /// Abstract trust service interface
 ///
 /// This trait provides trust-related functionality to the kernel without
@@ -147,6 +184,29 @@ pub trait TrustService: Send + Sync {
     /// The kernel may use this for routing decisions, but NEVER interprets
     /// the semantic meaning of the score.
     fn trust_score(&self, actor: &Did) -> f64;
+
+    /// Get enriched trust score with provenance metadata.
+    ///
+    /// Returns a `TrustScoreResult` that includes the score, epoch,
+    /// inputs hash, and reducer version. This is used by caches to
+    /// determine staleness and by auditors to verify determinism.
+    ///
+    /// Default implementation wraps `trust_score()` with minimal metadata.
+    fn trust_score_detailed(&self, actor: &Did) -> TrustScoreResult {
+        let score = self.trust_score(actor);
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        TrustScoreResult {
+            score,
+            epoch: 0,
+            computed_at: now,
+            input_count: 0,
+            inputs_hash: [0u8; 32],
+            reducer_version: "0.0.0".to_string(),
+        }
+    }
 
     /// Check if an actor meets a minimum trust threshold
     ///


### PR DESCRIPTION
## Summary
- Adds `TrustScoreResult` type to `icn-kernel-api` — enriched score response with provenance (epoch, inputs_hash, reducer_version, computed_at)
- Adds `trust_score_detailed()` to `TrustService` trait with backward-compatible default implementation
- Implements `AttestationReducer` in `apps/trust/src/reducer.rs` — a **pure, deterministic** function: given the same attestations, always produces the same score + hash
- Adds monotonic epoch counter to `TrustServiceImplTokio`, incremented on every graph mutation
- Adds trust attestation schema contract test to catch silent wire format breakage

## Reducer algorithm
1. **Filter**: Reject unsigned, tampered, and expired attestations
2. **Deduplicate**: Keep one "winning" attestation per `(issuer, subject, graph_type)` triple using `should_supersede()` 
3. **Score**: Arithmetic mean of surviving attestation scores
4. **Hash**: SHA-256 over canonical sorted input set (version-prefixed)

## Test plan
- [x] 16 new tests in `reducer::tests` — determinism, filtering, dedup, scoring, provenance, schema contract
- [x] All 29 tests in `icn-trust-app` pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Full workspace `cargo check` clean

Closes #877

🤖 Generated with [Claude Code](https://claude.com/claude-code)