### PR TITLE
fix(trust): add transitive cache invalidation on edge mutations

### DIFF
--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -2267,6 +2267,15 @@ pub mod scalability {
             .increment(downstream_count);
     }
 
+    /// Record a cache invalidation error (storage failure during transitive lookup).
+    ///
+    /// When `get_outgoing_edges` fails during `invalidate_affected`, the direct
+    /// target is still invalidated but transitive targets may remain stale until
+    /// TTL expiry. Monitor this metric to detect storage issues.
+    pub fn trust_cache_invalidation_errors_inc() {
+        counter!("icn_scalability_trust_cache_invalidation_errors_total").increment(1);
+    }
+
     pub fn trust_cache_size_set(size: usize) {
         gauge!("icn_scalability_trust_cache_size").set(size as f64);
     }

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -2258,6 +2258,15 @@ pub mod scalability {
         counter!("icn_scalability_trust_cache_invalidations_total").increment(1);
     }
 
+    /// Record a transitive cache invalidation event.
+    ///
+    /// Emitted when an edge mutation triggers one-hop-out invalidation
+    /// of downstream DIDs (e.g., A→B change invalidates B's outgoing targets).
+    pub fn trust_cache_transitive_invalidations_inc(downstream_count: u64) {
+        counter!("icn_scalability_trust_cache_transitive_invalidations_total")
+            .increment(downstream_count);
+    }
+
     pub fn trust_cache_size_set(size: usize) {
         gauge!("icn_scalability_trust_cache_size").set(size as f64);
     }

--- a/icn/crates/icn-trust/src/lib.rs
+++ b/icn/crates/icn-trust/src/lib.rs
@@ -87,7 +87,7 @@ use icn_identity::Did;
 use icn_store::Store;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tracing::{debug, info, instrument};
+use tracing::{debug, info, instrument, warn};
 
 /// Trust classification for a peer
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -809,15 +809,16 @@ impl TrustGraph {
                     self.cache.invalidate(&edge.target);
                 }
                 if !outgoing.is_empty() {
+                    let count = outgoing.len() as u64;
+                    icn_obs::metrics::scalability::trust_cache_transitive_invalidations_inc(count);
                     debug!(
                         "Transitive cache invalidation: {} + {} downstream DIDs",
-                        target,
-                        outgoing.len()
+                        target, count
                     );
                 }
             }
             Err(e) => {
-                debug!(
+                warn!(
                     "Failed to get outgoing edges during cache invalidation for {}: {}",
                     target, e
                 );

--- a/icn/crates/icn-trust/src/lib.rs
+++ b/icn/crates/icn-trust/src/lib.rs
@@ -721,9 +721,10 @@ impl TrustGraph {
 
     /// Remove a trust edge
     pub fn remove_edge(&mut self, source: &Did, target: &Did) -> Result<()> {
-        // Collect transitive targets BEFORE removing the edge, since
-        // remove deletes the edge from storage and we need the target's
-        // outgoing edges for transitive invalidation.
+        // Invalidate caches and derived state related to this target before
+        // removing the edge from storage. This ordering is for semantic clarity
+        // (treat invalidation as part of the mutation), not because the target's
+        // outgoing edges would be unavailable afterward.
         self.invalidate_affected(target);
 
         let key = self.edge_key(source, target);
@@ -786,7 +787,6 @@ impl TrustGraph {
         Ok(trusted_dids)
     }
 
-    /// Clear the trust score cache
     /// Invalidate cached scores for a DID and all transitively affected DIDs.
     ///
     /// When edge X→target changes, target's score is directly affected.
@@ -803,20 +803,29 @@ impl TrustGraph {
 
         // Invalidate transitive targets: DIDs that target has outgoing edges to.
         // These scores may depend on trust flowing through `target`.
-        if let Ok(outgoing) = self.get_outgoing_edges(target) {
-            for edge in &outgoing {
-                self.cache.invalidate(&edge.target);
+        match self.get_outgoing_edges(target) {
+            Ok(outgoing) => {
+                for edge in &outgoing {
+                    self.cache.invalidate(&edge.target);
+                }
+                if !outgoing.is_empty() {
+                    debug!(
+                        "Transitive cache invalidation: {} + {} downstream DIDs",
+                        target,
+                        outgoing.len()
+                    );
+                }
             }
-            if !outgoing.is_empty() {
+            Err(e) => {
                 debug!(
-                    "Transitive cache invalidation: {} + {} downstream DIDs",
-                    target,
-                    outgoing.len()
+                    "Failed to get outgoing edges during cache invalidation for {}: {}",
+                    target, e
                 );
             }
         }
     }
 
+    /// Clear the entire trust score cache.
     pub fn clear_cache(&self) {
         self.cache.clear();
     }

--- a/icn/crates/icn-trust/src/lib.rs
+++ b/icn/crates/icn-trust/src/lib.rs
@@ -373,8 +373,13 @@ impl TrustGraph {
 
         self.store.put(key.as_bytes(), &value)?;
 
-        // Invalidate cache for target (LRU cache with TTL)
-        self.cache.invalidate(&edge.target);
+        // Invalidate cache for target and transitively affected DIDs.
+        //
+        // When edge A→B changes, B's score changes (direct invalidation).
+        // Additionally, any DID C where B→C exists may have a stale cached
+        // score because the transitive path through B changed. We invalidate
+        // those too to prevent serving stale scores.
+        self.invalidate_affected(&edge.target);
 
         // Update reachability filter for both direct and transitive paths
         if edge.source == self.own_did {
@@ -716,11 +721,13 @@ impl TrustGraph {
 
     /// Remove a trust edge
     pub fn remove_edge(&mut self, source: &Did, target: &Did) -> Result<()> {
+        // Collect transitive targets BEFORE removing the edge, since
+        // remove deletes the edge from storage and we need the target's
+        // outgoing edges for transitive invalidation.
+        self.invalidate_affected(target);
+
         let key = self.edge_key(source, target);
         self.store.delete(key.as_bytes())?;
-
-        // Invalidate cache for target
-        self.cache.invalidate(target);
 
         Ok(())
     }
@@ -780,6 +787,36 @@ impl TrustGraph {
     }
 
     /// Clear the trust score cache
+    /// Invalidate cached scores for a DID and all transitively affected DIDs.
+    ///
+    /// When edge X→target changes, target's score is directly affected.
+    /// Additionally, any DID C where target→C exists may have a stale
+    /// score because the transitive path (X→target→C) changed. We
+    /// invalidate those one-hop-out DIDs as well.
+    ///
+    /// This is bounded: we only go one hop out from `target`, not the
+    /// full graph. The scoring algorithm is two-hop (direct + transitive),
+    /// so one additional hop of invalidation is sufficient.
+    fn invalidate_affected(&self, target: &Did) {
+        // Always invalidate the direct target
+        self.cache.invalidate(target);
+
+        // Invalidate transitive targets: DIDs that target has outgoing edges to.
+        // These scores may depend on trust flowing through `target`.
+        if let Ok(outgoing) = self.get_outgoing_edges(target) {
+            for edge in &outgoing {
+                self.cache.invalidate(&edge.target);
+            }
+            if !outgoing.is_empty() {
+                debug!(
+                    "Transitive cache invalidation: {} + {} downstream DIDs",
+                    target,
+                    outgoing.len()
+                );
+            }
+        }
+    }
+
     pub fn clear_cache(&self) {
         self.cache.clear();
     }
@@ -1159,5 +1196,130 @@ mod tests {
         let incoming = graph.get_incoming_edges(&bob).unwrap();
         assert_eq!(incoming.len(), 1, "Expired edges should be filtered out");
         assert_eq!(incoming[0].source, alice);
+    }
+
+    // ================================================================
+    // Cache invalidation tests (#878)
+    // ================================================================
+
+    #[test]
+    fn cache_hit_after_score_computation() {
+        let store = Arc::new(SledStore::temporary().unwrap());
+        let alice = KeyPair::generate().unwrap().did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        let mut graph = TrustGraph::new(store, alice.clone());
+        let edge = TrustEdge::new(alice.clone(), bob.clone(), TrustScore::unchecked(0.6));
+        graph.add_edge(edge).unwrap();
+
+        // First call computes and caches
+        let score1 = graph.compute_trust_score(&bob).unwrap();
+        assert!((score1 - 0.42).abs() < 0.01); // 0.6 * 0.7 direct weight
+
+        // Second call should return cached value
+        let score2 = graph.compute_trust_score(&bob).unwrap();
+        assert_eq!(score1, score2);
+    }
+
+    #[test]
+    fn cache_invalidated_on_edge_mutation() {
+        let store = Arc::new(SledStore::temporary().unwrap());
+        let alice = KeyPair::generate().unwrap().did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        let mut graph = TrustGraph::new(store, alice.clone());
+
+        // Add edge and compute score (populates cache)
+        let edge = TrustEdge::new(alice.clone(), bob.clone(), TrustScore::unchecked(0.6));
+        graph.add_edge(edge).unwrap();
+        let score_before = graph.compute_trust_score(&bob).unwrap();
+
+        // Mutate the edge (update score)
+        let updated = TrustEdge::new(alice.clone(), bob.clone(), TrustScore::unchecked(0.9));
+        graph.add_edge(updated).unwrap();
+
+        // Recompute — should NOT return stale cached value
+        let score_after = graph.compute_trust_score(&bob).unwrap();
+        assert!(
+            score_after > score_before,
+            "Score should increase after edge update: {score_before} -> {score_after}"
+        );
+    }
+
+    #[test]
+    fn cache_invalidated_on_edge_removal() {
+        let store = Arc::new(SledStore::temporary().unwrap());
+        let alice = KeyPair::generate().unwrap().did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        let mut graph = TrustGraph::new(store, alice.clone());
+
+        let edge = TrustEdge::new(alice.clone(), bob.clone(), TrustScore::unchecked(0.8));
+        graph.add_edge(edge).unwrap();
+
+        // Compute score (populates cache)
+        let score = graph.compute_trust_score(&bob).unwrap();
+        assert!(score > 0.0);
+
+        // Remove the edge
+        graph.remove_edge(&alice, &bob).unwrap();
+
+        // Recompute — should be 0 now
+        let score_after = graph.compute_trust_score(&bob).unwrap();
+        assert_eq!(score_after, 0.0, "Score should be 0 after edge removal");
+    }
+
+    #[test]
+    fn transitive_cache_invalidation() {
+        let store = Arc::new(SledStore::temporary().unwrap());
+        let alice = KeyPair::generate().unwrap().did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+        let carol = KeyPair::generate().unwrap().did().clone();
+
+        let mut graph = TrustGraph::new(store, alice.clone());
+
+        // Alice trusts Bob
+        graph
+            .add_edge(TrustEdge::new(
+                alice.clone(),
+                bob.clone(),
+                TrustScore::unchecked(0.8),
+            ))
+            .unwrap();
+
+        // Bob trusts Carol (transitive: Alice → Bob → Carol)
+        graph
+            .add_edge(TrustEdge::new(
+                bob.clone(),
+                carol.clone(),
+                TrustScore::unchecked(0.7),
+            ))
+            .unwrap();
+
+        // Compute Carol's transitive score (populates cache)
+        let carol_score_before = graph.compute_trust_score(&carol).unwrap();
+        assert!(
+            carol_score_before > 0.0,
+            "Carol should have transitive trust"
+        );
+
+        // Mutate Alice→Bob edge (lower trust in Bob)
+        // This should invalidate Carol's cache because the transitive path changed
+        graph
+            .add_edge(TrustEdge::new(
+                alice.clone(),
+                bob.clone(),
+                TrustScore::unchecked(0.2),
+            ))
+            .unwrap();
+
+        // Recompute Carol's score — should reflect lowered trust through Bob
+        let carol_score_after = graph.compute_trust_score(&carol).unwrap();
+        assert!(
+            carol_score_after < carol_score_before,
+            "Carol's score should decrease when Alice's trust in Bob decreases: {} -> {}",
+            carol_score_before,
+            carol_score_after,
+        );
     }
 }

--- a/icn/crates/icn-trust/src/lib.rs
+++ b/icn/crates/icn-trust/src/lib.rs
@@ -721,10 +721,10 @@ impl TrustGraph {
 
     /// Remove a trust edge
     pub fn remove_edge(&mut self, source: &Did, target: &Did) -> Result<()> {
-        // Invalidate caches and derived state related to this target before
-        // removing the edge from storage. This ordering is for semantic clarity
-        // (treat invalidation as part of the mutation), not because the target's
-        // outgoing edges would be unavailable afterward.
+        // Invalidate caches before removing the edge from storage. This ordering
+        // is defensive: `get_outgoing_edges(target)` inside `invalidate_affected`
+        // can still read target's edges, ensuring transitive invalidations are
+        // complete even under concurrent edge deletion scenarios.
         self.invalidate_affected(target);
 
         let key = self.edge_key(source, target);
@@ -789,10 +789,10 @@ impl TrustGraph {
 
     /// Invalidate cached scores for a DID and all transitively affected DIDs.
     ///
-    /// When edge X→target changes, target's score is directly affected.
-    /// Additionally, any DID C where target→C exists may have a stale
-    /// score because the transitive path (X→target→C) changed. We
-    /// invalidate those one-hop-out DIDs as well.
+    /// When any edge with `target` as the target node changes (regardless of
+    /// source), `target`'s score is directly affected. Additionally, any DID C
+    /// where target→C exists may have a stale score because the transitive path
+    /// (source→target→C) changed. We invalidate those one-hop-out DIDs as well.
     ///
     /// This is bounded: we only go one hop out from `target`, not the
     /// full graph. The scoring algorithm is two-hop (direct + transitive),
@@ -812,8 +812,9 @@ impl TrustGraph {
                     let count = outgoing.len() as u64;
                     icn_obs::metrics::scalability::trust_cache_transitive_invalidations_inc(count);
                     debug!(
-                        "Transitive cache invalidation: {} + {} downstream DIDs",
-                        target, count
+                        target = %target,
+                        downstream_count = count,
+                        "Transitive cache invalidation for {target}: {count} downstream DIDs",
                     );
                 }
             }

--- a/icn/crates/icn-trust/src/lib.rs
+++ b/icn/crates/icn-trust/src/lib.rs
@@ -1,4 +1,18 @@
 //! ICN Trust - Trust graph management and policy enforcement
+//!
+//! ## Cache Invalidation Strategy
+//!
+//! Trust scores are cached with a configurable TTL (default 5 minutes in the
+//! LRU cache). When trust edges change, affected scores must be invalidated
+//! immediately to prevent stale trust decisions (security issue #878).
+//!
+//! **Invalidation scope**: When edge A→B changes:
+//! 1. **Direct**: Invalidate B's cached score
+//! 2. **Transitive**: Invalidate all C where B→C exists
+//!
+//! This is bounded to one hop beyond the modified edge, which is sufficient
+//! for our two-hop scoring algorithm (direct + one level of transitivity).
+//! See [`TrustGraph::invalidate_affected`] for implementation details.
 #![allow(missing_docs)]
 // Prevent panics in production code paths
 #![deny(clippy::unwrap_used)]
@@ -797,6 +811,15 @@ impl TrustGraph {
     /// This is bounded: we only go one hop out from `target`, not the
     /// full graph. The scoring algorithm is two-hop (direct + transitive),
     /// so one additional hop of invalidation is sufficient.
+    ///
+    /// # Thread safety
+    ///
+    /// This method must be called while the caller holds a write lock on the
+    /// `TrustGraph` (or equivalent exclusive access). This prevents a TOCTOU
+    /// race where a concurrent reader could compute and cache a score using
+    /// stale edges between the store mutation and cache invalidation. The
+    /// actor model in `icn-core` guarantees serial message processing, so
+    /// this is satisfied in production. Tests must ensure exclusive access.
     fn invalidate_affected(&self, target: &Did) {
         // Always invalidate the direct target
         self.cache.invalidate(target);
@@ -805,11 +828,16 @@ impl TrustGraph {
         // These scores may depend on trust flowing through `target`.
         match self.get_outgoing_edges(target) {
             Ok(outgoing) => {
+                let mut count = 0u64;
                 for edge in &outgoing {
+                    // Skip self-loops (A→A) — already invalidated above
+                    if edge.target == *target {
+                        continue;
+                    }
                     self.cache.invalidate(&edge.target);
+                    count += 1;
                 }
-                if !outgoing.is_empty() {
-                    let count = outgoing.len() as u64;
+                if count > 0 {
                     icn_obs::metrics::scalability::trust_cache_transitive_invalidations_inc(count);
                     debug!(
                         target = %target,
@@ -819,6 +847,7 @@ impl TrustGraph {
                 }
             }
             Err(e) => {
+                icn_obs::metrics::scalability::trust_cache_invalidation_errors_inc();
                 warn!(
                     "Failed to get outgoing edges during cache invalidation for {}: {}",
                     target, e


### PR DESCRIPTION
## Summary
- Fixes stale cache entries when trust edges change
- When edge A→B is added/updated/removed, also invalidates cached scores for all DIDs that B has outgoing edges to (B→C₁, B→C₂, ...)
- This prevents serving stale transitive scores through modified intermediaries
- Bounded at one hop out from the target (sufficient for the two-hop scoring algorithm)

## The bug
Previously, `add_edge(A→B)` only invalidated B's cached score. But trust is transitive — Alice's score for Carol (via Alice→Bob→Carol) would remain cached at the old value even after Alice's trust in Bob changed. This means the gateway could serve a stale trust score for Carol.

## Test plan
- [x] `cache_hit_after_score_computation` — verify caching works (baseline)
- [x] `cache_invalidated_on_edge_mutation` — update edge → no stale score
- [x] `cache_invalidated_on_edge_removal` — remove edge → score drops to 0
- [x] `transitive_cache_invalidation` — A→B change invalidates Carol's transitive score
- [x] All 152+ icn-trust tests pass
- [x] `cargo clippy -p icn-trust --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Full workspace `cargo check` clean

Closes #878

🤖 Generated with [Claude Code](https://claude.com/claude-code)