### PR TITLE
refactor(core): remove raw_handles transition mechanism

### DIFF
--- a/icn/bins/icnd/src/main.rs
+++ b/icn/bins/icnd/src/main.rs
@@ -105,7 +105,9 @@ async fn build_services(
     let trust_graph = icn_trust::TrustGraph::new(trust_store, own_did.clone());
     let trust_graph_handle = Arc::new(RwLock::new(trust_graph));
 
-    // Create TrustService from apps/trust (keypair is required for signing attestations)
+    // Create TrustService from apps/trust.
+    // TrustGraph is owned by the service — no separate handle in BootstrapHandles.
+    // All kernel components use the TrustService trait (not direct TrustGraph access).
     //
     // NOTE: `bundle.keypair()` will fail for hardware-backed keys (PKCS#11, TPM),
     // because those backends cannot expose a raw keypair. This is currently safe
@@ -114,11 +116,10 @@ async fn build_services(
     // TODO(hardware-keys): When hardware-backed key support is implemented, refactor
     // TrustService construction to use `bundle.did_key()` and `bundle.sign()` so that
     // both software and hardware-backed keys are supported here.
-    let keypair = bundle.keypair().context(
-        "Cannot create TrustService: failed to extract keypair from identity bundle",
-    )?;
-    let trust_service =
-        icn_trust_app::create_service_tokio(trust_graph_handle, keypair);
+    let keypair = bundle
+        .keypair()
+        .context("Cannot create TrustService: failed to extract keypair from identity bundle")?;
+    let trust_service = icn_trust_app::create_service_tokio(trust_graph_handle, keypair);
     registry = registry.with_trust(trust_service);
     tracing::info!("Trust service initialized from apps/trust");
 

--- a/icn/bins/icnd/src/main.rs
+++ b/icn/bins/icnd/src/main.rs
@@ -68,159 +68,148 @@ struct Args {
     tracing_sampling_rate: Option<f64>,
 }
 
-/// Build the service registry with domain app services
+/// Build the service registry and bootstrap handles with domain app services
 ///
 /// This creates the app-level services (trust, governance, ledger) and
-/// packages them in a ServiceRegistry for injection into the kernel.
+/// packages them for injection into the kernel:
+/// - `ServiceRegistry` carries trait-based service abstractions
+/// - `BootstrapHandles` carries typed concrete domain handles
+///
 /// This is the key point where domain logic is separated from kernel logic.
 ///
 /// All mapping from icn-core config structs to primitive adapter args lives here
 /// (in the daemon binary), keeping apps/ledger free of icn-core dependencies.
-async fn build_service_registry(
+async fn build_services(
     config: &Config,
     identity_bundle: Option<&icn_identity::IdentityBundle>,
-) -> Result<ServiceRegistry> {
+) -> Result<(
+    ServiceRegistry,
+    Option<icn_core::supervisor::BootstrapHandles>,
+)> {
     let mut registry = ServiceRegistry::new();
 
-    // Only create trust service if we have an identity
-    if let Some(bundle) = identity_bundle {
-        let own_did = bundle.did().clone();
+    // Only create services if we have an identity
+    let Some(bundle) = identity_bundle else {
+        return Ok((registry, None));
+    };
 
-        // Open trust store
-        let trust_store_path = config.store_path().join("trust");
-        std::fs::create_dir_all(&trust_store_path)?;
-        let trust_store: Arc<dyn icn_store::Store> =
-            Arc::new(icn_store::SledStore::open(&trust_store_path)?);
+    let own_did = bundle.did().clone();
 
-        // Create TrustGraph with tokio lock (for icn-core compatibility)
-        let trust_graph = icn_trust::TrustGraph::new(trust_store, own_did.clone());
-        let trust_graph_handle = Arc::new(RwLock::new(trust_graph));
+    // Open trust store
+    let trust_store_path = config.store_path().join("trust");
+    std::fs::create_dir_all(&trust_store_path)?;
+    let trust_store: Arc<dyn icn_store::Store> =
+        Arc::new(icn_store::SledStore::open(&trust_store_path)?);
 
-        // Create TrustService from apps/trust (keypair is required for signing attestations)
-        //
-        // NOTE: `bundle.keypair()` will fail for hardware-backed keys (PKCS#11, TPM),
-        // because those backends cannot expose a raw keypair. This is currently safe
-        // because hardware key backends are not yet implemented and keystore unlock
-        // fails early for such configurations.
-        // TODO(hardware-keys): When hardware-backed key support is implemented, refactor
-        // TrustService construction to use `bundle.did_key()` and `bundle.sign()` so that
-        // both software and hardware-backed keys are supported here.
-        let keypair = bundle.keypair().context(
-            "Cannot create TrustService: failed to extract keypair from identity bundle",
-        )?;
-        let trust_service =
-            icn_trust_app::create_service_tokio(trust_graph_handle.clone(), keypair);
-        registry = registry.with_trust(trust_service);
+    // Create TrustGraph with tokio lock (for icn-core compatibility)
+    let trust_graph = icn_trust::TrustGraph::new(trust_store, own_did.clone());
+    let trust_graph_handle = Arc::new(RwLock::new(trust_graph));
 
-        // Also pass raw TrustGraph handle for components that still need direct access
-        // during the transition period (MisbehaviorDetector, ReplicationManager).
-        // This should be removed when those components migrate to use TrustService.
-        registry = registry.with_raw_handle(ServiceRegistry::TRUST_GRAPH_KEY, trust_graph_handle);
+    // Create TrustService from apps/trust (keypair is required for signing attestations)
+    //
+    // NOTE: `bundle.keypair()` will fail for hardware-backed keys (PKCS#11, TPM),
+    // because those backends cannot expose a raw keypair. This is currently safe
+    // because hardware key backends are not yet implemented and keystore unlock
+    // fails early for such configurations.
+    // TODO(hardware-keys): When hardware-backed key support is implemented, refactor
+    // TrustService construction to use `bundle.did_key()` and `bundle.sign()` so that
+    // both software and hardware-backed keys are supported here.
+    let keypair = bundle.keypair().context(
+        "Cannot create TrustService: failed to extract keypair from identity bundle",
+    )?;
+    let trust_service =
+        icn_trust_app::create_service_tokio(trust_graph_handle, keypair);
+    registry = registry.with_trust(trust_service);
+    tracing::info!("Trust service initialized from apps/trust");
 
-        tracing::info!("Trust service initialized from apps/trust");
-        tracing::debug!("  - Raw trust_graph handle passed for transition components");
+    // Create GovernanceService from apps/governance
+    let param_store_path = config.protocol_params_path();
+    std::fs::create_dir_all(&param_store_path).with_context(|| {
+        format!(
+            "Failed to create protocol params store directory: {}",
+            param_store_path.display()
+        )
+    })?;
+    let param_db = sled::open(&param_store_path).with_context(|| {
+        format!(
+            "Failed to open protocol params sled database: {}",
+            param_store_path.display()
+        )
+    })?;
+    let parameter_store = Arc::new(
+        icn_governance::SledParameterStore::new(Arc::new(param_db))
+            .context("Failed to initialize SledParameterStore")?,
+    );
+    let parameter_store_trait: Arc<dyn icn_governance::ProtocolParameterStore> =
+        parameter_store.clone();
+    let governance_service = icn_governance_app::create_service(parameter_store_trait);
+    registry = registry.with_governance(governance_service);
+    tracing::info!("Governance service initialized from apps/governance");
 
-        // Create GovernanceService from apps/governance
-        let param_store_path = config.protocol_params_path();
-        std::fs::create_dir_all(&param_store_path).with_context(|| {
+    // Create LedgerService from apps/ledger
+    let ledger_store_path = config.ledger_store_path();
+    std::fs::create_dir_all(&ledger_store_path).with_context(|| {
+        format!(
+            "Failed to create ledger store directory: {}",
+            ledger_store_path.display()
+        )
+    })?;
+    let ledger_store = Arc::new(icn_store::SledStore::open(&ledger_store_path).with_context(
+        || {
             format!(
-                "Failed to create protocol params store directory: {}",
-                param_store_path.display()
-            )
-        })?;
-        let param_db = sled::open(&param_store_path).with_context(|| {
-            format!(
-                "Failed to open protocol params sled database: {}",
-                param_store_path.display()
-            )
-        })?;
-        let parameter_store = Arc::new(
-            icn_governance::SledParameterStore::new(Arc::new(param_db))
-                .context("Failed to initialize SledParameterStore")?,
-        );
-        let parameter_store_trait: Arc<dyn icn_governance::ProtocolParameterStore> =
-            parameter_store.clone();
-        let governance_service = icn_governance_app::create_service(parameter_store_trait);
-        registry = registry.with_governance(governance_service);
-        // Store concrete type for raw_handle (dyn traits are !Sized)
-        registry =
-            registry.with_raw_handle(ServiceRegistry::PROTOCOL_PARAM_STORE_KEY, parameter_store);
-        tracing::info!("Governance service initialized from apps/governance");
-
-        // Create LedgerService from apps/ledger
-        let ledger_store_path = config.ledger_store_path();
-        std::fs::create_dir_all(&ledger_store_path).with_context(|| {
-            format!(
-                "Failed to create ledger store directory: {}",
+                "Failed to open ledger store: {}",
                 ledger_store_path.display()
             )
-        })?;
-        let ledger_store = Arc::new(icn_store::SledStore::open(&ledger_store_path).with_context(
-            || {
-                format!(
-                    "Failed to open ledger store: {}",
-                    ledger_store_path.display()
-                )
-            },
-        )?);
-        let ledger_store_trait: Arc<dyn icn_store::Store> = ledger_store.clone();
-        let ledger =
-            icn_ledger::Ledger::new(ledger_store_trait).context("Failed to initialize Ledger")?;
-        let ledger_handle = Arc::new(RwLock::new(ledger));
-        let ledger_service = icn_ledger_app::create_service(ledger_handle.clone());
-        registry = registry.with_ledger(ledger_service);
-        registry = registry.with_raw_handle(ServiceRegistry::LEDGER_KEY, ledger_handle.clone());
-        registry =
-            registry.with_raw_handle(ServiceRegistry::LEDGER_STORE_KEY, ledger_store.clone());
+        },
+    )?);
+    let ledger_store_trait: Arc<dyn icn_store::Store> = ledger_store.clone();
+    let ledger =
+        icn_ledger::Ledger::new(ledger_store_trait).context("Failed to initialize Ledger")?;
+    let ledger_handle = Arc::new(RwLock::new(ledger));
+    let ledger_service = icn_ledger_app::create_service(ledger_handle.clone());
+    registry = registry.with_ledger(ledger_service);
 
-        // Initialize ledger services (oracle, witness, membership, credit, dispute,
-        // treasury, contracts). Config→primitive mapping stays in the daemon binary.
-        let oracle_config = icn_ledger_app::config::build_oracle_config(
-            config.ledger.oracle.default_ttl_secs,
-            config.ledger.oracle.min_sources_for_consensus,
-            config.ledger.oracle.outlier_threshold,
-            config.ledger.oracle.staleness_threshold_secs,
-            config.ledger.oracle.default_suspicious_rate_threshold,
-            config.ledger.oracle.suspicious_rate_thresholds.clone(),
-        );
-        let witness_config = icn_ledger_app::config::build_witness_config(
-            &config.ledger.witness.default_policy,
-            config.ledger.witness.threshold,
-            config.ledger.witness.quorum_required,
-            config.ledger.witness.quorum_witnesses.as_deref(),
-            config.ledger.witness.collection_timeout_secs,
-            config.ledger.witness.min_witness_trust,
-        )
-        .context("Invalid witness configuration")?;
-        let ledger_services = icn_ledger_app::init::init_ledger_services(
-            ledger_handle,
-            ledger_store,
-            own_did.clone(),
-            oracle_config,
-            witness_config,
-        )
-        .await
-        .context("Failed to initialize ledger services")?;
-        registry = registry.with_raw_handle(
-            ServiceRegistry::DISPUTE_MANAGER_KEY,
-            ledger_services.dispute_manager,
-        );
-        registry = registry.with_raw_handle(
-            ServiceRegistry::TREASURY_MANAGER_KEY,
-            ledger_services.treasury_manager,
-        );
-        registry = registry.with_raw_handle(
-            ServiceRegistry::CONTRACT_RUNTIME_KEY,
-            ledger_services.contract_runtime,
-        );
-        registry = registry.with_raw_handle(
-            ServiceRegistry::CONTRACT_ACTOR_KEY,
-            ledger_services.contract_actor,
-        );
-        tracing::info!("Ledger service initialized from apps/ledger");
-    }
+    // Initialize ledger services (oracle, witness, membership, credit, dispute,
+    // treasury, contracts). Config→primitive mapping stays in the daemon binary.
+    let oracle_config = icn_ledger_app::config::build_oracle_config(
+        config.ledger.oracle.default_ttl_secs,
+        config.ledger.oracle.min_sources_for_consensus,
+        config.ledger.oracle.outlier_threshold,
+        config.ledger.oracle.staleness_threshold_secs,
+        config.ledger.oracle.default_suspicious_rate_threshold,
+        config.ledger.oracle.suspicious_rate_thresholds.clone(),
+    );
+    let witness_config = icn_ledger_app::config::build_witness_config(
+        &config.ledger.witness.default_policy,
+        config.ledger.witness.threshold,
+        config.ledger.witness.quorum_required,
+        config.ledger.witness.quorum_witnesses.as_deref(),
+        config.ledger.witness.collection_timeout_secs,
+        config.ledger.witness.min_witness_trust,
+    )
+    .context("Invalid witness configuration")?;
+    let ledger_services = icn_ledger_app::init::init_ledger_services(
+        ledger_handle.clone(),
+        ledger_store.clone(),
+        own_did.clone(),
+        oracle_config,
+        witness_config,
+    )
+    .await
+    .context("Failed to initialize ledger services")?;
+    tracing::info!("Ledger service initialized from apps/ledger");
 
-    Ok(registry)
+    let bootstrap_handles = icn_core::supervisor::BootstrapHandles {
+        ledger: ledger_handle,
+        ledger_store,
+        dispute_manager: ledger_services.dispute_manager,
+        treasury_manager: ledger_services.treasury_manager,
+        contract_runtime: ledger_services.contract_runtime,
+        contract_actor: ledger_services.contract_actor,
+        protocol_parameter_store: parameter_store,
+    };
+
+    Ok((registry, Some(bootstrap_handles)))
 }
 
 #[tokio::main]
@@ -420,12 +409,16 @@ async fn main() -> Result<()> {
         None
     };
 
-    // Build service registry with domain app services
-    // This injects app-level services into the kernel for proper separation
-    let service_registry = build_service_registry(&config, identity_bundle.as_ref()).await?;
+    // Build service registry and bootstrap handles with domain app services.
+    // ServiceRegistry carries trait abstractions; BootstrapHandles carries typed domain objects.
+    let (service_registry, bootstrap_handles) =
+        build_services(&config, identity_bundle.as_ref()).await?;
 
-    // Create runtime with injected services
-    let runtime = Runtime::new(config.clone(), identity_bundle).with_services(service_registry);
+    // Create runtime with injected services and bootstrap handles
+    let mut runtime = Runtime::new(config.clone(), identity_bundle).with_services(service_registry);
+    if let Some(handles) = bootstrap_handles {
+        runtime = runtime.with_bootstrap_handles(handles);
+    }
 
     // Get shutdown signal before moving runtime
     let shutdown_tx = runtime.shutdown_tx();

--- a/icn/crates/icn-core/src/meaning_firewall.rs
+++ b/icn/crates/icn-core/src/meaning_firewall.rs
@@ -292,7 +292,7 @@ mod tests {
     /// - actors.rs: 1 (CoreActorHandles LedgerHandle type)
     #[test]
     fn strict_core_ledger_reference_ratchet() {
-        let expected: usize = 31;
+        let expected: usize = 28;
         let actual = count_imports_in_crate("icn-core", "icn_ledger::");
 
         assert!(
@@ -326,7 +326,7 @@ mod tests {
     /// - actors.rs: 2 (BootstrapHandles placeholder — from B3 when merged)
     #[test]
     fn strict_core_ccl_reference_ratchet() {
-        let expected: usize = 34;
+        let expected: usize = 32;
         let actual = count_imports_in_crate("icn-core", "icn_ccl::");
 
         assert!(
@@ -365,7 +365,7 @@ mod tests {
     /// - actors.rs: 1 (CoreActorHandles governance handle)
     #[test]
     fn strict_core_governance_reference_ratchet() {
-        let expected: usize = 84;
+        let expected: usize = 83;
         let actual = count_imports_in_crate("icn-core", "icn_governance::");
 
         assert!(

--- a/icn/crates/icn-core/src/runtime.rs
+++ b/icn/crates/icn-core/src/runtime.rs
@@ -7,6 +7,7 @@ use tokio::sync::broadcast;
 use tracing::info;
 
 use crate::config::Config;
+use crate::supervisor::BootstrapHandles;
 
 /// Shutdown signal broadcaster
 pub type ShutdownTx = broadcast::Sender<()>;
@@ -23,6 +24,11 @@ pub struct Runtime {
     /// creating its own. This enables proper kernel/app separation where
     /// the daemon constructs domain services from app crates.
     service_registry: Option<ServiceRegistry>,
+    /// Optional typed domain handles from the daemon
+    ///
+    /// These carry concrete domain objects (ledger, contract runtime, etc.)
+    /// that the supervisor wires into actors during initialization.
+    bootstrap_handles: Option<BootstrapHandles>,
 }
 
 impl Runtime {
@@ -35,6 +41,7 @@ impl Runtime {
             identity_bundle,
             shutdown_tx,
             service_registry: None,
+            bootstrap_handles: None,
         }
     }
 
@@ -54,6 +61,16 @@ impl Runtime {
     /// ```
     pub fn with_services(mut self, registry: ServiceRegistry) -> Self {
         self.service_registry = Some(registry);
+        self
+    }
+
+    /// Set typed domain handles for supervisor initialization
+    ///
+    /// These handles carry concrete domain objects (ledger, contract runtime,
+    /// parameter store, etc.) that the daemon creates and the supervisor
+    /// wires into actors.
+    pub fn with_bootstrap_handles(mut self, handles: BootstrapHandles) -> Self {
+        self.bootstrap_handles = Some(handles);
         self
     }
 
@@ -82,6 +99,7 @@ impl Runtime {
             self.identity_bundle,
             self.shutdown_tx.clone(),
             self.service_registry,
+            self.bootstrap_handles,
         );
 
         // Run supervisor

--- a/icn/crates/icn-core/src/supervisor/actors.rs
+++ b/icn/crates/icn-core/src/supervisor/actors.rs
@@ -43,3 +43,29 @@ pub struct EventSubscriptionHandles {
     pub governance_event_subscription: Option<crate::events::SubscriptionHandle>,
     pub policy_governance_subscription: Option<crate::events::SubscriptionHandle>,
 }
+
+/// Typed handles for domain objects passed from daemon to supervisor.
+///
+/// This replaces the type-erased `raw_handles` HashMap that was previously
+/// on `ServiceRegistry`. Each field is a concrete, typed handle — no
+/// `Any` downcasting required.
+///
+/// The daemon constructs these objects (opening sled stores, initializing
+/// ledger services, etc.) and passes them to the supervisor. The supervisor
+/// wires them into actors during initialization.
+pub struct BootstrapHandles {
+    /// Pre-initialized ledger handle.
+    pub ledger: Arc<RwLock<icn_ledger::Ledger>>,
+    /// Shared sled store for ledger (prevents double-open due to exclusive flock).
+    pub ledger_store: Arc<icn_store::SledStore>,
+    /// Dispute manager for payment dispute resolution.
+    pub dispute_manager: Arc<RwLock<icn_ledger::DisputeManager>>,
+    /// Treasury manager for cooperative treasury operations.
+    pub treasury_manager: Arc<RwLock<icn_ledger::TreasuryManager>>,
+    /// Contract runtime for CCL execution.
+    pub contract_runtime: Arc<RwLock<icn_ccl::ContractRuntime>>,
+    /// Contract actor for contract lifecycle management.
+    pub contract_actor: Arc<RwLock<icn_ccl::ContractActor>>,
+    /// Protocol parameter store (concrete type for sled-backed governance params).
+    pub protocol_parameter_store: Arc<icn_governance::SledParameterStore>,
+}

--- a/icn/crates/icn-core/src/supervisor/actors.rs
+++ b/icn/crates/icn-core/src/supervisor/actors.rs
@@ -53,6 +53,13 @@ pub struct EventSubscriptionHandles {
 /// The daemon constructs these objects (opening sled stores, initializing
 /// ledger services, etc.) and passes them to the supervisor. The supervisor
 /// wires them into actors during initialization.
+///
+/// **Note**: `TrustGraph` is intentionally absent — all kernel components
+/// (MisbehaviorDetector, ReplicationManager, StorageChallenge, RPC) have
+/// migrated to the `TrustService` trait on `ServiceRegistry`. The daemon
+/// passes trust via `ServiceRegistry::with_trust()` instead.
+///
+/// See `icn-kernel-api::services::ServiceRegistry` for trait-based abstractions.
 pub struct BootstrapHandles {
     /// Pre-initialized ledger handle.
     pub ledger: Arc<RwLock<icn_ledger::Ledger>>,

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -40,6 +40,7 @@ pub async fn run_supervisor(
     identity_bundle: Option<IdentityBundle>,
     shutdown_tx: ShutdownTx,
     service_registry: Option<ServiceRegistry>,
+    bootstrap_handles: Option<super::BootstrapHandles>,
 ) -> Result<()> {
     info!("Supervisor starting");
 
@@ -95,6 +96,7 @@ pub async fn run_supervisor(
             &mut event_subscriptions,
             &mut shutdown_handles,
             service_registry.as_ref(),
+            bootstrap_handles,
         )
         .await?
     } else {
@@ -210,35 +212,11 @@ async fn spawn_actors_with_identity(
     event_subscriptions: &mut EventSubscriptionHandles,
     shutdown_handles: &mut ShutdownHandles,
     service_registry: Option<&ServiceRegistry>,
+    bootstrap_handles: Option<super::BootstrapHandles>,
 ) -> Result<CoreActorHandles> {
     info!("Identity bundle available - spawning actors");
 
     let did = identity_bundle.did().clone();
-
-    // Extract pre-initialized ledger handles from ServiceRegistry.
-    // These were created by icn_ledger_app::init::init_ledger_services() in the daemon.
-    let ledger_from_daemon: Option<Arc<RwLock<icn_ledger::Ledger>>> = service_registry
-        .and_then(|r| r.raw_handle::<RwLock<icn_ledger::Ledger>>(ServiceRegistry::LEDGER_KEY));
-    let ledger_store_from_daemon: Option<Arc<icn_store::SledStore>> = service_registry
-        .and_then(|r| r.raw_handle::<icn_store::SledStore>(ServiceRegistry::LEDGER_STORE_KEY));
-    let dispute_manager_from_daemon: Option<Arc<RwLock<icn_ledger::DisputeManager>>> =
-        service_registry.and_then(|r| {
-            r.raw_handle::<RwLock<icn_ledger::DisputeManager>>(ServiceRegistry::DISPUTE_MANAGER_KEY)
-        });
-    let treasury_manager_from_daemon: Option<Arc<RwLock<icn_ledger::TreasuryManager>>> =
-        service_registry.and_then(|r| {
-            r.raw_handle::<RwLock<icn_ledger::TreasuryManager>>(
-                ServiceRegistry::TREASURY_MANAGER_KEY,
-            )
-        });
-    let contract_runtime_from_daemon: Option<Arc<RwLock<icn_ccl::ContractRuntime>>> =
-        service_registry.and_then(|r| {
-            r.raw_handle::<RwLock<icn_ccl::ContractRuntime>>(ServiceRegistry::CONTRACT_RUNTIME_KEY)
-        });
-    let contract_actor_from_daemon: Option<Arc<RwLock<icn_ccl::ContractActor>>> = service_registry
-        .and_then(|r| {
-            r.raw_handle::<RwLock<icn_ccl::ContractActor>>(ServiceRegistry::CONTRACT_ACTOR_KEY)
-        });
 
     // Create NodeProfile with hardware sensing (Phase 17)
     let node_profile = crate::node::create_node_profile(
@@ -319,20 +297,18 @@ async fn spawn_actors_with_identity(
     let gossip_store = gossip_services.gossip_store.clone();
     let loaded_snapshot = gossip_services.loaded_snapshot;
 
-    // Extract pre-initialized ledger handles from ServiceRegistry.
-    // Ledger services were created in the daemon by icn_ledger_app::init::init_ledger_services().
-    let ledger_handle =
-        ledger_from_daemon.ok_or_else(|| anyhow::anyhow!("Ledger not in ServiceRegistry"))?;
-    let dispute_manager_handle = dispute_manager_from_daemon
-        .ok_or_else(|| anyhow::anyhow!("DisputeManager not in ServiceRegistry"))?;
-    let treasury_manager_handle = treasury_manager_from_daemon
-        .ok_or_else(|| anyhow::anyhow!("TreasuryManager not in ServiceRegistry"))?;
-    let contract_runtime_handle = contract_runtime_from_daemon
-        .ok_or_else(|| anyhow::anyhow!("ContractRuntime not in ServiceRegistry"))?;
-    let contract_actor_handle = contract_actor_from_daemon
-        .ok_or_else(|| anyhow::anyhow!("ContractActor not in ServiceRegistry"))?;
-    let ledger_store = ledger_store_from_daemon
-        .ok_or_else(|| anyhow::anyhow!("LedgerStore not in ServiceRegistry"))?;
+    // Extract pre-initialized domain handles from BootstrapHandles.
+    // These were created by icn_ledger_app::init::init_ledger_services() in the daemon.
+    let handles = bootstrap_handles
+        .ok_or_else(|| anyhow::anyhow!("BootstrapHandles not provided by daemon"))?;
+    let ledger_handle = handles.ledger;
+    let ledger_store = handles.ledger_store;
+    let dispute_manager_handle = handles.dispute_manager;
+    let treasury_manager_handle = handles.treasury_manager;
+    let contract_runtime_handle = handles.contract_runtime;
+    let contract_actor_handle = handles.contract_actor;
+    let protocol_parameter_store_from_daemon: Arc<dyn icn_governance::ProtocolParameterStore> =
+        handles.protocol_parameter_store;
 
     // Wire runtime handles into the pre-initialized Ledger.
     // These depend on gossip/trust which are only available after gossip init.
@@ -528,17 +504,7 @@ async fn spawn_actors_with_identity(
     let event_bus = Arc::new(crate::events::EventBus::new());
     info!("Event bus created");
 
-    // Extract daemon-provided parameter store from ServiceRegistry (if available).
-    // SledParameterStore is stored as concrete type since raw_handle requires Sized.
-    let protocol_parameter_store_from_daemon: Option<
-        Arc<dyn icn_governance::ProtocolParameterStore>,
-    > = service_registry
-        .and_then(|r| {
-            r.raw_handle::<icn_governance::SledParameterStore>(
-                ServiceRegistry::PROTOCOL_PARAM_STORE_KEY,
-            )
-        })
-        .map(|s| s as Arc<dyn icn_governance::ProtocolParameterStore>);
+    // Protocol parameter store was extracted from BootstrapHandles above.
 
     // Initialize governance services
     let governance_services = super::init_governance::init_governance_services(
@@ -548,7 +514,7 @@ async fn spawn_actors_with_identity(
             gossip_handle: gossip_handle.clone(),
             event_bus: event_bus.clone(),
             shutdown_rx: shutdown_tx.subscribe(),
-            protocol_parameter_store: protocol_parameter_store_from_daemon,
+            protocol_parameter_store: Some(protocol_parameter_store_from_daemon),
         },
     )
     .await?;

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -299,8 +299,14 @@ async fn spawn_actors_with_identity(
 
     // Extract pre-initialized domain handles from BootstrapHandles.
     // These were created by icn_ledger_app::init::init_ledger_services() in the daemon.
-    let handles = bootstrap_handles
-        .ok_or_else(|| anyhow::anyhow!("BootstrapHandles not provided by daemon"))?;
+    let handles = bootstrap_handles.ok_or_else(|| {
+        anyhow::anyhow!(
+            "BootstrapHandles not provided by daemon. When running with an identity, \
+             the daemon must configure the runtime via Runtime::with_bootstrap_handles(...) \
+             and supply ledger, ledger_store, dispute_manager, treasury_manager, \
+             contract_runtime, contract_actor, and protocol_parameter_store handles."
+        )
+    })?;
     let ledger_handle = handles.ledger;
     let ledger_store = handles.ledger_store;
     let dispute_manager_handle = handles.dispute_manager;

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -302,9 +302,10 @@ async fn spawn_actors_with_identity(
     let handles = bootstrap_handles.ok_or_else(|| {
         anyhow::anyhow!(
             "BootstrapHandles not provided by daemon. When running with an identity, \
-             the daemon must configure the runtime via Runtime::with_bootstrap_handles(...) \
-             and supply ledger, ledger_store, dispute_manager, treasury_manager, \
-             contract_runtime, contract_actor, and protocol_parameter_store handles."
+             the daemon must call Runtime::with_bootstrap_handles(...) to supply \
+             ledger, ledger_store, dispute_manager, treasury_manager, contract_runtime, \
+             contract_actor, and protocol_parameter_store handles. This requires a \
+             successfully unlocked identity bundle."
         )
     })?;
     let ledger_handle = handles.ledger;

--- a/icn/crates/icn-core/src/supervisor/mod.rs
+++ b/icn/crates/icn-core/src/supervisor/mod.rs
@@ -43,6 +43,8 @@ use icn_kernel_api::services::ServiceRegistry;
 use crate::config::Config;
 use crate::runtime::ShutdownTx;
 
+pub use actors::BootstrapHandles;
+
 /// Supervisor manages all actors and restarts them on failure
 pub struct Supervisor {
     config: Config,
@@ -53,6 +55,11 @@ pub struct Supervisor {
     /// When provided, services from this registry are used instead of
     /// creating internal implementations. This enables kernel/app separation.
     service_registry: Option<ServiceRegistry>,
+    /// Optional typed domain handles from daemon
+    ///
+    /// These carry concrete domain objects (ledger, contract runtime, etc.)
+    /// that the supervisor wires into actors during initialization.
+    bootstrap_handles: Option<BootstrapHandles>,
 }
 
 impl Supervisor {
@@ -62,12 +69,14 @@ impl Supervisor {
         identity_bundle: Option<IdentityBundle>,
         shutdown_tx: ShutdownTx,
         service_registry: Option<ServiceRegistry>,
+        bootstrap_handles: Option<BootstrapHandles>,
     ) -> Self {
         Supervisor {
             config,
             identity_bundle,
             shutdown_tx,
             service_registry,
+            bootstrap_handles,
         }
     }
 
@@ -78,6 +87,7 @@ impl Supervisor {
             self.identity_bundle,
             self.shutdown_tx,
             self.service_registry,
+            self.bootstrap_handles,
         )
         .await
     }

--- a/icn/crates/icn-core/tests/bootstrap_handles_wiring.rs
+++ b/icn/crates/icn-core/tests/bootstrap_handles_wiring.rs
@@ -1,8 +1,12 @@
 //! Bootstrap Handles Wiring Integration Tests
 //!
-//! Verifies that daemon-provided handles (governance parameter store, ledger)
-//! can be correctly shared via typed fields, preventing double sled opens
-//! and avoiding type-erased downcasting.
+//! Verifies that daemon-provided handles can be correctly shared via typed
+//! fields, preventing double sled opens and avoiding type-erased downcasting.
+//!
+//! Current coverage:
+//! - Parameter store Arc upcast and trait-object sharing
+//! - Mutation propagation across cloned Arc handles
+//! - Sled exclusive lock prevents double-open (motivating BootstrapHandles)
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 

--- a/icn/crates/icn-core/tests/service_registry_wiring.rs
+++ b/icn/crates/icn-core/tests/service_registry_wiring.rs
@@ -1,102 +1,38 @@
-//! Service Registry Wiring Integration Tests
+//! Bootstrap Handles Wiring Integration Tests
 //!
 //! Verifies that daemon-provided handles (governance parameter store, ledger)
-//! are correctly extracted from ServiceRegistry and reused by supervisor init
-//! functions, preventing double sled opens.
+//! can be correctly shared via typed fields, preventing double sled opens
+//! and avoiding type-erased downcasting.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use std::sync::Arc;
-use tokio::sync::RwLock;
 
 use icn_governance::{ProtocolParameterStore, SledParameterStore};
-use icn_kernel_api::ServiceRegistry;
 use icn_store::SledStore;
 
-/// Test that a SledParameterStore round-trips through raw_handle correctly.
-///
-/// The daemon stores Arc<SledParameterStore> (concrete, Sized) and the supervisor
-/// retrieves it, then upcasts to Arc<dyn ProtocolParameterStore>.
+/// Test that the parameter store can be upcast to the trait object
+/// that governance init expects (mirrors lifecycle.rs extraction pattern).
 #[test]
-fn test_parameter_store_raw_handle_roundtrip() {
+fn test_parameter_store_upcast() {
     let tmp = tempfile::tempdir().unwrap();
     let param_db = sled::open(tmp.path().join("params")).unwrap();
     let store = Arc::new(SledParameterStore::new(Arc::new(param_db)).unwrap());
 
-    // Simulate daemon: store concrete type
-    let registry = ServiceRegistry::new()
-        .with_raw_handle(ServiceRegistry::PROTOCOL_PARAM_STORE_KEY, store.clone());
+    // Upcast to trait object — this is what lifecycle.rs does with the
+    // protocol_parameter_store field from BootstrapHandles.
+    let as_trait: Arc<dyn ProtocolParameterStore> = store;
 
-    // Simulate supervisor: retrieve and upcast
-    let retrieved: Option<Arc<SledParameterStore>> =
-        registry.raw_handle(ServiceRegistry::PROTOCOL_PARAM_STORE_KEY);
-    assert!(
-        retrieved.is_some(),
-        "raw_handle should return the stored SledParameterStore"
-    );
-
-    let as_trait: Arc<dyn ProtocolParameterStore> = retrieved.unwrap();
     // Verify it's functional
     let params = as_trait.list().unwrap();
     assert!(params.is_empty(), "Fresh store should have no parameters");
 }
 
-/// Test that a Ledger handle round-trips through raw_handle correctly.
-#[test]
-fn test_ledger_handle_raw_handle_roundtrip() {
-    let tmp = tempfile::tempdir().unwrap();
-    let store: Arc<dyn icn_store::Store> =
-        Arc::new(SledStore::open(tmp.path().join("ledger")).unwrap());
-    let ledger = icn_ledger::Ledger::new(store).unwrap();
-    let handle = Arc::new(RwLock::new(ledger));
-
-    // Simulate daemon: store handle
-    let registry =
-        ServiceRegistry::new().with_raw_handle(ServiceRegistry::LEDGER_KEY, handle.clone());
-
-    // Simulate supervisor: retrieve
-    let retrieved: Option<Arc<RwLock<icn_ledger::Ledger>>> =
-        registry.raw_handle(ServiceRegistry::LEDGER_KEY);
-    assert!(
-        retrieved.is_some(),
-        "raw_handle should return the stored Ledger handle"
-    );
-
-    // Verify it's the same Arc (not a copy)
-    assert!(Arc::ptr_eq(&handle, &retrieved.unwrap()));
-}
-
-/// Test that raw_handle returns None for a missing key.
-#[test]
-fn test_raw_handle_missing_key_returns_none() {
-    let registry = ServiceRegistry::new();
-    let result: Option<Arc<SledParameterStore>> = registry.raw_handle("nonexistent");
-    assert!(result.is_none());
-}
-
-/// Test that raw_handle returns None for a type mismatch.
-#[test]
-fn test_raw_handle_type_mismatch_returns_none() {
-    let tmp = tempfile::tempdir().unwrap();
-    let param_db = sled::open(tmp.path().join("params")).unwrap();
-    let store = Arc::new(SledParameterStore::new(Arc::new(param_db)).unwrap());
-
-    let registry =
-        ServiceRegistry::new().with_raw_handle(ServiceRegistry::PROTOCOL_PARAM_STORE_KEY, store);
-
-    // Try to retrieve as wrong type
-    let result: Option<Arc<RwLock<icn_ledger::Ledger>>> =
-        registry.raw_handle(ServiceRegistry::PROTOCOL_PARAM_STORE_KEY);
-    assert!(
-        result.is_none(),
-        "Type mismatch should return None, not panic"
-    );
-}
-
-/// Test that mutations through the daemon's Arc are visible through the supervisor's Arc.
+/// Test that mutations through the daemon's Arc are visible through a clone.
 ///
-/// This verifies that raw_handle truly shares the same Arc instance (not a clone),
-/// so writes by the daemon propagate to the supervisor's view.
+/// This verifies that typed handle sharing (via BootstrapHandles fields)
+/// propagates writes between daemon and supervisor, just as the old
+/// raw_handle mechanism did.
 #[test]
 fn test_parameter_store_mutation_propagation() {
     use icn_governance::{ParameterValue, ProtocolParameter};
@@ -105,14 +41,8 @@ fn test_parameter_store_mutation_propagation() {
     let param_db = sled::open(tmp.path().join("params")).unwrap();
     let store = Arc::new(SledParameterStore::new(Arc::new(param_db)).unwrap());
 
-    // Simulate daemon: register in registry
-    let registry = ServiceRegistry::new()
-        .with_raw_handle(ServiceRegistry::PROTOCOL_PARAM_STORE_KEY, store.clone());
-
-    // Simulate supervisor: retrieve from registry
-    let supervisor_store: Arc<SledParameterStore> = registry
-        .raw_handle(ServiceRegistry::PROTOCOL_PARAM_STORE_KEY)
-        .unwrap();
+    // Clone for "supervisor side" (same as BootstrapHandles sharing)
+    let supervisor_store = store.clone();
 
     // Daemon writes a parameter
     let param = ProtocolParameter::new(
@@ -129,89 +59,12 @@ fn test_parameter_store_mutation_propagation() {
     assert_eq!(retrieved.unwrap().id, "test.param");
 }
 
-/// Test the full daemon→supervisor extraction pattern.
-///
-/// Simulates the complete flow: daemon creates all services and stores,
-/// registers them in ServiceRegistry, then supervisor extracts them
-/// (mirroring lifecycle.rs extraction logic).
-#[test]
-fn test_daemon_to_supervisor_registry_extraction() {
-    use icn_governance::ParameterValue;
-
-    let tmp = tempfile::tempdir().unwrap();
-
-    // === Daemon side: create all handles ===
-    let param_db = sled::open(tmp.path().join("params")).unwrap();
-    let param_store = Arc::new(SledParameterStore::new(Arc::new(param_db)).unwrap());
-
-    let ledger_store = Arc::new(SledStore::open(tmp.path().join("ledger")).unwrap());
-    let ledger_store_trait: Arc<dyn icn_store::Store> = ledger_store.clone();
-    let ledger = icn_ledger::Ledger::new(ledger_store_trait).unwrap();
-    let ledger_handle = Arc::new(RwLock::new(ledger));
-
-    let registry = ServiceRegistry::new()
-        .with_raw_handle(
-            ServiceRegistry::PROTOCOL_PARAM_STORE_KEY,
-            param_store.clone(),
-        )
-        .with_raw_handle(ServiceRegistry::LEDGER_KEY, ledger_handle.clone())
-        .with_raw_handle(ServiceRegistry::LEDGER_STORE_KEY, ledger_store.clone());
-
-    // === Supervisor side: extract handles (mirrors lifecycle.rs) ===
-
-    // Ledger handle extraction (lifecycle.rs ~line 221)
-    let sup_ledger: Option<Arc<RwLock<icn_ledger::Ledger>>> =
-        registry.raw_handle(ServiceRegistry::LEDGER_KEY);
-    assert!(sup_ledger.is_some());
-    assert!(Arc::ptr_eq(&ledger_handle, sup_ledger.as_ref().unwrap()));
-
-    // Ledger store extraction (lifecycle.rs ~line 223)
-    let sup_store: Option<Arc<SledStore>> = registry.raw_handle(ServiceRegistry::LEDGER_STORE_KEY);
-    assert!(sup_store.is_some());
-    assert!(Arc::ptr_eq(&ledger_store, sup_store.as_ref().unwrap()));
-
-    // Parameter store extraction with upcast (lifecycle.rs ~line 496-502)
-    let sup_params: Option<Arc<SledParameterStore>> =
-        registry.raw_handle(ServiceRegistry::PROTOCOL_PARAM_STORE_KEY);
-    assert!(sup_params.is_some());
-    let sup_params_trait: Arc<dyn icn_governance::ProtocolParameterStore> = sup_params.unwrap();
-
-    // Verify functional: daemon writes, supervisor reads
-    let param = icn_governance::ProtocolParameter::new(
-        "test.integration",
-        "Integration Test",
-        "Verifies daemon-supervisor handle sharing",
-        ParameterValue::Integer(99),
-    );
-    param_store.set(param, None, None).unwrap();
-    let read_back = sup_params_trait.get("test.integration").unwrap();
-    assert!(read_back.is_some());
-    assert_eq!(read_back.unwrap().id, "test.integration");
-}
-
-/// Test that the ledger store can be shared via raw_handle.
-///
-/// This verifies the fix for the sled double-open bug: the daemon creates
-/// a single SledStore and passes it through raw_handle so the supervisor
-/// doesn't need to re-open the same sled path.
-#[test]
-fn test_ledger_store_shared_via_raw_handle() {
-    let tmp = tempfile::tempdir().unwrap();
-    let store = Arc::new(SledStore::open(tmp.path().join("ledger")).unwrap());
-
-    let registry =
-        ServiceRegistry::new().with_raw_handle(ServiceRegistry::LEDGER_STORE_KEY, store.clone());
-
-    let retrieved: Option<Arc<SledStore>> = registry.raw_handle(ServiceRegistry::LEDGER_STORE_KEY);
-    assert!(retrieved.is_some(), "Should retrieve ledger store");
-    assert!(Arc::ptr_eq(&store, &retrieved.unwrap()));
-}
-
 /// Verify that opening the same sled path twice fails with exclusive locking.
 ///
-/// This test documents WHY the daemon must share store handles via raw_handle
-/// rather than letting the supervisor re-open the same path. On Linux, sled uses
-/// `flock(LOCK_EX)` which rejects a second open from a different file descriptor.
+/// This test documents WHY the daemon must share store handles via
+/// `BootstrapHandles` rather than letting the supervisor re-open the same
+/// path. On Linux, sled uses `flock(LOCK_EX)` which rejects a second open
+/// from a different file descriptor.
 #[test]
 fn test_sled_double_open_fails() {
     let tmp = tempfile::tempdir().unwrap();

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -600,46 +600,15 @@ pub trait CellService: Send + Sync {
 /// This allows the daemon to construct services and inject them into the kernel.
 /// The kernel never needs to know about concrete implementations.
 ///
-/// # Transition Handles
-///
-/// During the kernel/app separation migration, some components may still need
-/// direct access to domain objects (e.g., TrustGraph for MisbehaviorDetector).
-/// The `raw_handles` field provides type-erased storage for these transition
-/// needs. These should be removed as components are fully migrated.
-///
-/// # Raw Handle Type Pattern
-///
-/// `raw_handle<T>` requires `T: Sized`, so `dyn Trait` objects cannot be stored
-/// directly. Use the appropriate pattern based on the stored type:
-///
-/// **Concrete type with trait upcast** (when consumers need a trait object):
-/// ```ignore
-/// // Store: Arc<SledParameterStore> (concrete, Sized)
-/// registry.with_raw_handle(ServiceRegistry::PROTOCOL_PARAM_STORE_KEY, store);
-/// // Retrieve concrete, then upcast:
-/// let store: Arc<SledParameterStore> = registry.raw_handle(KEY)?;
-/// let trait_obj: Arc<dyn ProtocolParameterStore> = store;
-/// ```
-///
-/// **Wrapped type** (when the wrapper is Sized, e.g., `RwLock<T>`):
-/// ```ignore
-/// // Store and retrieve directly:
-/// registry.with_raw_handle(ServiceRegistry::LEDGER_KEY, ledger_handle);
-/// let handle: Arc<RwLock<Ledger>> = registry.raw_handle(KEY)?;
-/// ```
+/// Concrete domain handles (ledger, contract runtime, parameter store, etc.)
+/// are passed separately via `BootstrapHandles` in `icn-core`, keeping this
+/// registry free of domain types.
 pub struct ServiceRegistry {
     trust: Option<Arc<dyn TrustService>>,
     security: Option<Arc<dyn SecurityService>>,
     governance: Option<Arc<dyn GovernanceService>>,
     ledger: Option<Arc<dyn LedgerService>>,
     cell: Option<Arc<dyn CellService>>,
-    /// Type-erased handles for transition period
-    ///
-    /// Keys use string identifiers like "trust_graph", "ledger_handle", etc.
-    /// Values are type-erased via Any trait. The supervisor downcasts as needed.
-    ///
-    /// **This is a transition mechanism and should be removed when migration is complete.**
-    raw_handles: std::collections::HashMap<String, Arc<dyn std::any::Any + Send + Sync>>,
 }
 
 impl Default for ServiceRegistry {
@@ -649,26 +618,6 @@ impl Default for ServiceRegistry {
 }
 
 impl ServiceRegistry {
-    // Raw handle key constants — use these instead of string literals to prevent typos.
-    // A typo in the key results in silent `None` at runtime.
-
-    /// Key for `Arc<RwLock<TrustGraph>>` raw handle
-    pub const TRUST_GRAPH_KEY: &str = "trust_graph";
-    /// Key for `Arc<SledParameterStore>` raw handle (concrete type; upcast after retrieval)
-    pub const PROTOCOL_PARAM_STORE_KEY: &str = "protocol_parameter_store";
-    /// Key for `Arc<RwLock<Ledger>>` raw handle
-    pub const LEDGER_KEY: &str = "ledger";
-    /// Key for `Arc<SledStore>` raw handle (shared with DisputeManager/TreasuryManager)
-    pub const LEDGER_STORE_KEY: &str = "ledger_store";
-    /// Key for `Arc<RwLock<DisputeManager>>` raw handle
-    pub const DISPUTE_MANAGER_KEY: &str = "dispute_manager";
-    /// Key for `Arc<RwLock<TreasuryManager>>` raw handle
-    pub const TREASURY_MANAGER_KEY: &str = "treasury_manager";
-    /// Key for `Arc<RwLock<ContractRuntime>>` raw handle
-    pub const CONTRACT_RUNTIME_KEY: &str = "contract_runtime";
-    /// Key for `Arc<RwLock<ContractActor>>` raw handle
-    pub const CONTRACT_ACTOR_KEY: &str = "contract_actor";
-
     /// Create a new empty service registry
     pub fn new() -> Self {
         Self {
@@ -677,7 +626,6 @@ impl ServiceRegistry {
             governance: None,
             ledger: None,
             cell: None,
-            raw_handles: std::collections::HashMap::new(),
         }
     }
 
@@ -709,39 +657,6 @@ impl ServiceRegistry {
     pub fn with_cell(mut self, service: Arc<dyn CellService>) -> Self {
         self.cell = Some(service);
         self
-    }
-
-    /// Register a raw handle for transition period
-    ///
-    /// **This is a transition mechanism.** Use this to pass domain objects
-    /// (like TrustGraph handles) that some components still need directly.
-    /// These should be migrated to use proper service interfaces.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// let trust_graph = Arc::new(RwLock::new(TrustGraph::new(...)));
-    /// registry = registry.with_raw_handle("trust_graph", trust_graph);
-    /// ```
-    pub fn with_raw_handle<T: Send + Sync + 'static>(mut self, key: &str, handle: Arc<T>) -> Self {
-        self.raw_handles.insert(key.to_string(), handle);
-        self
-    }
-
-    /// Get a raw handle by key, downcasting to the expected type
-    ///
-    /// **This is a transition mechanism.** Returns None if key doesn't exist
-    /// or type doesn't match.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// let trust_graph: Option<Arc<RwLock<TrustGraph>>> = registry.raw_handle("trust_graph");
-    /// ```
-    pub fn raw_handle<T: Send + Sync + 'static>(&self, key: &str) -> Option<Arc<T>> {
-        self.raw_handles
-            .get(key)
-            .and_then(|any| any.clone().downcast::<T>().ok())
     }
 
     /// Get the trust service (if registered)


### PR DESCRIPTION
## Summary

- Replaces the type-erased `HashMap<String, Arc<dyn Any>>` `raw_handles` field on `ServiceRegistry` with a typed `BootstrapHandles` struct in `icn-core`
- `ServiceRegistry` (in `icn-kernel-api`) now contains only trait-based service abstractions — no `Any` downcasting
- Concrete domain handles (ledger, dispute/treasury managers, contract runtime/actor, parameter store) live in `BootstrapHandles` with typed fields
- Integration tests updated to verify typed handle sharing pattern

## What changed

| File | Change |
|------|--------|
| `icn-kernel-api/src/services.rs` | Removed `raw_handles` field, `with_raw_handle()`, `raw_handle()`, 8 KEY constants |
| `icn-core/src/supervisor/actors.rs` | Added `BootstrapHandles` struct |
| `icn-core/src/supervisor/mod.rs` | Thread `BootstrapHandles` through `Supervisor` |
| `icn-core/src/runtime.rs` | Added `with_bootstrap_handles()` to `Runtime` |
| `icn-core/src/supervisor/lifecycle.rs` | Extract typed handles from `BootstrapHandles` instead of `raw_handle()` |
| `icnd/src/main.rs` | Build `BootstrapHandles` separately from `ServiceRegistry` |
| `icn-core/tests/service_registry_wiring.rs` | Simplified tests for typed handle pattern |

## Why

The `raw_handles` mechanism was a transition shim during kernel/app separation. It used `Arc<dyn Any>` downcasting which is error-prone (typos in string keys cause silent `None` at runtime, type mismatches are invisible until the downcast). Typed fields eliminate this class of bugs entirely.

## Risk

- Supervisor initialization now requires `BootstrapHandles` when an identity is present (previously required raw_handles in ServiceRegistry — same constraint, different type)
- No behavioral change — same handles flow through the same path, just with type safety

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` — all tests pass
- [x] `cargo test -p icn-core --test service_registry_wiring` — 3/3 pass
- [x] `cargo test -p icn-core -- meaning_firewall` — 7/7 ratchet tests pass

Closes #911

🤖 Generated with [Claude Code](https://claude.com/claude-code)