### PR TITLE
refactor(core): decouple events.rs tests from icn_governance

### DIFF
--- a/apps/trust/src/service_tokio.rs
+++ b/apps/trust/src/service_tokio.rs
@@ -783,6 +783,5 @@ mod tests {
             "Attestation with spoofed issuer must be rejected, got: {:?}",
             result
         );
-
     }
 }

--- a/icn/crates/icn-core/src/events.rs
+++ b/icn/crates/icn-core/src/events.rs
@@ -240,10 +240,9 @@ mod tests {
         let event = SystemEvent::ProposalAccepted {
             proposal_id: "test-proposal".to_string(),
             domain_id: "test-domain".to_string(),
-            payload: serde_json::to_value(&icn_governance::ProposalPayload::Text {
-                body: "Test proposal".to_string(),
-            })
-            .unwrap(),
+            payload: serde_json::json!({
+                "Text": { "body": "Test proposal" }
+            }),
             decided_at: 1234567890,
         };
 
@@ -335,10 +334,9 @@ mod tests {
         let event = SystemEvent::ProposalAccepted {
             proposal_id: "test".to_string(),
             domain_id: "test".to_string(),
-            payload: serde_json::to_value(&icn_governance::ProposalPayload::Text {
-                body: "test".to_string(),
-            })
-            .unwrap(),
+            payload: serde_json::json!({
+                "Text": { "body": "test" }
+            }),
             decided_at: 1234567890,
         };
 
@@ -368,7 +366,10 @@ mod tests {
                 } = event
                 {
                     // Attempt to deserialize — this should fail for our test payload
-                    if serde_json::from_value::<icn_governance::ProposalPayload>(payload).is_err() {
+                    if payload.get("Text").is_none()
+                        && payload.get("ProtocolChange").is_none()
+                        && payload.get("Treasury").is_none()
+                    {
                         let bus = bus_for_sub1.clone();
                         let pid = proposal_id;
                         tokio::spawn(async move {

--- a/icn/crates/icn-core/src/events.rs
+++ b/icn/crates/icn-core/src/events.rs
@@ -365,11 +365,9 @@ mod tests {
                     ..
                 } = event
                 {
-                    // Attempt to deserialize — this should fail for our test payload
-                    if payload.get("Text").is_none()
-                        && payload.get("ProtocolChange").is_none()
-                        && payload.get("Treasury").is_none()
-                    {
+                    // Check for invalid payload - in this test we specifically
+                    // emit {"NotAValidVariant": true} to simulate a deserialization failure
+                    if payload.get("NotAValidVariant").is_some() {
                         let bus = bus_for_sub1.clone();
                         let pid = proposal_id;
                         tokio::spawn(async move {

--- a/icn/crates/icn-core/src/meaning_firewall.rs
+++ b/icn/crates/icn-core/src/meaning_firewall.rs
@@ -360,12 +360,12 @@ mod tests {
     /// - lifecycle.rs: 4 (raw_handle extractions, fn signatures)
     /// - background_tasks.rs: 4 (governance polling types)
     /// - init_governance.rs: 3 (GovernanceManager, GovernanceSled)
-    /// - events.rs: 3 (ProposalPayload references)
+    /// - events.rs: 0 (decoupled — tests use serde_json::json! directly)
     /// - init_gateway.rs: 1 (GovernanceManager import)
     /// - actors.rs: 1 (CoreActorHandles governance handle)
     #[test]
     fn strict_core_governance_reference_ratchet() {
-        let expected: usize = 83;
+        let expected: usize = 80;
         let actual = count_imports_in_crate("icn-core", "icn_governance::");
 
         assert!(


### PR DESCRIPTION
## Summary
- Replace 3 `icn_governance::ProposalPayload` references in events.rs tests with `serde_json::json!` payload construction
- The SystemEvent already uses `serde_json::Value` for payload — tests don't need the domain type
- Ratchet governance refs 83 → 80

## Why
Part of #859 governance extraction sprint (Phase 4). This is a safe, independent win that removes test-only coupling to icn_governance from events.rs.

## How
- `ProposalPayload::Text { body: "..." }` → `json!({"Text": {"body": "..."}})` (2 occurrences)
- `serde_json::from_value::<ProposalPayload>(payload).is_err()` → variant key presence check (1 occurrence)
- Updated meaning_firewall ratchet from 83 → 80

## Risk
Low — test-only changes, no behavioral changes to production code.

## Test plan
- `cargo test -p icn-core --lib events` — all 5 tests pass
- `cargo test -p icn-core --lib meaning_firewall` — ratchet passes at 80

🤖 Generated with [Claude Code](https://claude.com/claude-code)