### PR TITLE
refactor(core): extract GovernanceActor to apps/governance

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -2925,6 +2925,7 @@ dependencies = [
  "icn-gateway",
  "icn-gossip",
  "icn-governance",
+ "icn-governance-actor",
  "icn-identity",
  "icn-kernel-api",
  "icn-ledger",
@@ -3164,6 +3165,26 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "icn-governance-actor"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "icn-entity",
+ "icn-gossip",
+ "icn-governance",
+ "icn-identity",
+ "icn-kernel-api",
+ "icn-obs",
+ "icn-store",
+ "icn-time",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/icn/Cargo.toml
+++ b/icn/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "crates/icn-entity",
     "crates/icn-encoding",
     "crates/icn-api",
+    "apps/governance",
 ]
 
 [workspace.package]

--- a/icn/apps/governance/Cargo.toml
+++ b/icn/apps/governance/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "icn-governance-actor"
+version = "0.1.0"
+edition = "2021"
+description = "ICN Governance Actor — distributed decision-making for the cooperative network"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+# Kernel API for EventEmitter trait and SystemEvent types
+icn-kernel-api = { path = "../../crates/icn-kernel-api" }
+
+# Governance domain types (proposals, votes, domains, etc.)
+icn-governance = { path = "../../crates/icn-governance" }
+
+# Identity types (Did)
+icn-identity = { path = "../../crates/icn-identity" }
+
+# Entity types (EntityId, EntityRegistry)
+icn-entity = { path = "../../crates/icn-entity" }
+
+# Storage trait
+icn-store = { path = "../../crates/icn-store" }
+
+# Gossip actor (for governance message broadcast)
+icn-gossip = { path = "../../crates/icn-gossip" }
+
+# Observability metrics
+icn-obs = { path = "../../crates/icn-obs" }
+
+# Time utilities
+icn-time = { path = "../../crates/icn-time" }
+
+# Error handling
+anyhow = "1.0"
+
+# Async
+async-trait = "0.1"
+tokio = { version = "1", features = ["sync", "time", "rt"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# Logging
+tracing = "0.1"

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -26,7 +26,7 @@ use icn_governance::{
     VoteChoice, VoteTally,
 };
 
-use crate::events::{EventBus, SystemEvent};
+use icn_kernel_api::events::{EventEmitter, SystemEvent};
 
 /// Gossip topic for governance messages
 const GOVERNANCE_TOPIC: &str = "governance:proposal";
@@ -896,7 +896,7 @@ pub struct GovernanceActor {
     profile: GovernanceProfile,
     event_scheduler: Arc<RwLock<BinaryHeap<Reverse<ScheduledGovernanceEvent>>>>,
     cancel_tx: mpsc::UnboundedSender<ProposalId>,
-    event_bus: Option<Arc<EventBus>>,
+    event_bus: Option<Arc<dyn EventEmitter>>,
     /// Protocol parameter store for governable parameters (Phase 20)
     protocol_params: Option<Arc<dyn ProtocolParameterStore>>,
 }
@@ -908,7 +908,7 @@ impl GovernanceActor {
         store: Arc<dyn Store>,
         gossip: Arc<RwLock<GossipActor>>,
         resolver: Arc<dyn MembershipResolver + Send + Sync>,
-        event_bus: Option<Arc<EventBus>>,
+        event_bus: Option<Arc<dyn EventEmitter>>,
     ) -> Result<GovernanceHandle> {
         info!("Spawning GovernanceActor for DID: {}", did);
 

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -1,0 +1,19 @@
+//! ICN Governance Actor
+//!
+//! This crate provides the [`GovernanceActor`] for distributed decision-making
+//! across the ICN network. It manages governance state, proposal lifecycle,
+//! voting, and outcome evaluation.
+//!
+//! ## Architecture
+//!
+//! The governance actor is a domain-specific application that sits above the
+//! kernel layer. It depends on kernel-api traits (e.g., [`EventEmitter`],
+//! [`ProtocolParameterStore`]) rather than concrete kernel implementations,
+//! maintaining clean separation between kernel mechanisms and domain semantics.
+//!
+//! [`EventEmitter`]: icn_kernel_api::events::EventEmitter
+//! [`ProtocolParameterStore`]: icn_kernel_api::protocol_params::ProtocolParameterStore
+
+pub mod actor;
+
+pub use actor::{GovernanceActor, GovernanceCommand, GovernanceConfigLite, GovernanceHandle};

--- a/icn/crates/icn-core/Cargo.toml
+++ b/icn/crates/icn-core/Cargo.toml
@@ -48,6 +48,7 @@ icn-compute = { path = "../icn-compute" }
 icn-security.workspace = true
 icn-federation.workspace = true
 icn-steward.workspace = true
+icn-governance-actor = { path = "../../apps/governance" }
 icn-coop = { path = "../icn-coop" }
 icn-community = { path = "../icn-community" }
 

--- a/icn/crates/icn-core/src/events.rs
+++ b/icn/crates/icn-core/src/events.rs
@@ -2,106 +2,17 @@
 //!
 //! This module provides a simple event bus for coordinating actions across actors.
 //! Key use case: Governance proposals triggering ledger transactions or contract execution.
+//!
+//! The [`SystemEvent`] enum and [`EventEmitter`] trait are defined in `icn-kernel-api`
+//! and re-exported here. The [`EventBus`] implementation lives in icn-core.
 
-use icn_identity::Did;
+use async_trait::async_trait;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{debug, warn};
 
-/// System-wide events that actors can emit and subscribe to
-#[derive(Clone, Debug)]
-pub enum SystemEvent {
-    /// A governance proposal was accepted
-    ProposalAccepted {
-        /// Unique identifier for the proposal (was `ProposalId`)
-        proposal_id: String,
-        /// Domain in which the proposal was made
-        domain_id: String,
-        /// Payload describing the proposal action (serialized `ProposalPayload`)
-        payload: serde_json::Value,
-        /// Unix timestamp when the proposal was decided
-        decided_at: u64,
-    },
-
-    /// A governance proposal was rejected or failed to reach quorum
-    ProposalRejected {
-        /// Unique identifier for the proposal (was `ProposalId`)
-        proposal_id: String,
-        /// Domain in which the proposal was made
-        domain_id: String,
-        /// Unix timestamp when the proposal was decided
-        decided_at: u64,
-    },
-
-    /// A ledger transaction was executed (for contracts listening to ledger changes)
-    TransactionExecuted {
-        /// Hash of the ledger entry
-        entry_hash: [u8; 32],
-        /// Source DID of the transaction
-        from: Did,
-        /// Destination DID of the transaction
-        to: Did,
-        /// Transaction amount
-        amount: i64,
-        /// Currency identifier
-        currency: String,
-    },
-
-    /// A contract was executed
-    ContractExecuted {
-        /// Contract identifier
-        contract_id: String,
-        /// Execution outcome as JSON
-        outcome: serde_json::Value,
-    },
-
-    /// A proposal execution failed (proposal was accepted but could not be applied)
-    ProposalExecutionFailed {
-        /// Unique identifier for the proposal (was `ProposalId`)
-        proposal_id: String,
-        /// Type of the proposal (e.g., "protocol_change", "treasury")
-        proposal_type: String,
-        /// Human-readable error message
-        error: String,
-        /// Unix timestamp when the failure occurred
-        failed_at: u64,
-    },
-
-    /// Protocol parameters were initialized (first run)
-    ProtocolParametersInitialized {
-        /// Number of parameters initialized
-        count: usize,
-        /// Unix timestamp when the initialization occurred
-        initialized_at: u64,
-    },
-
-    /// Protocol parameter store was loaded (existing parameters)
-    ProtocolParametersLoaded {
-        /// Number of parameters loaded
-        count: usize,
-        /// Unix timestamp when the store was loaded
-        loaded_at: u64,
-    },
-
-    /// A protocol parameter was changed (for audit logging)
-    ProtocolParameterChanged {
-        /// Parameter ID that was changed
-        parameter_id: String,
-        /// Old value (serialized as string for logging)
-        old_value: String,
-        /// New value (serialized as string for logging)
-        new_value: String,
-        /// Proposal ID that authorized the change (if any)
-        proposal_id: Option<String>,
-        /// DID of the actor who made the change
-        changed_by: Option<String>,
-        /// Unix timestamp when the change occurred
-        changed_at: u64,
-    },
-}
-
-/// Callback function for event subscribers
-pub type EventCallback = Arc<dyn Fn(SystemEvent) + Send + Sync>;
+// Re-export event types and trait from kernel-api
+pub use icn_kernel_api::events::{EventCallback, EventEmitter, SystemEvent};
 
 /// Subscription handle that automatically unsubscribes when dropped
 ///
@@ -209,6 +120,14 @@ impl EventBus {
                 warn!("Event subscriber {} panicked: {:?}", id, e);
             }
         }
+    }
+}
+
+#[async_trait]
+impl EventEmitter for EventBus {
+    async fn emit(&self, event: SystemEvent) {
+        // Delegate to the inherent method
+        EventBus::emit(self, event).await;
     }
 }
 

--- a/icn/crates/icn-core/src/governance/mod.rs
+++ b/icn/crates/icn-core/src/governance/mod.rs
@@ -1,12 +1,10 @@
 //! Governance actor for decentralized decision-making
 //!
-//! This module provides a production-ready governance actor that:
-//! - Subscribes to governance gossip messages
-//! - Persists domains, proposals, and votes to the node's store
-//! - Handles proposal lifecycle (create → open → vote → close)
-//! - Evaluates outcomes via governance profiles
-//! - Broadcasts state changes to peers
+//! The GovernanceActor implementation has been extracted to the
+//! `icn-governance-actor` crate (apps/governance). This module
+//! re-exports its public types for backwards compatibility.
 
-pub mod actor;
-
-pub use actor::{GovernanceActor, GovernanceCommand, GovernanceConfigLite, GovernanceHandle};
+pub use icn_governance_actor::actor;
+pub use icn_governance_actor::{
+    GovernanceActor, GovernanceCommand, GovernanceConfigLite, GovernanceHandle,
+};

--- a/icn/crates/icn-core/src/meaning_firewall.rs
+++ b/icn/crates/icn-core/src/meaning_firewall.rs
@@ -359,7 +359,7 @@ mod tests {
     /// - governance_handlers/treasury.rs: 9 (treasury governance handlers)
     /// - governance_handlers/protocol.rs: 7 (protocol change handlers)
     /// - governance_handlers/federation.rs: 3 (federation handlers)
-    /// - governance/actor.rs: 27 (governance actor message types, body/proposal)
+    /// - governance/actor.rs: 0 (extracted to apps/governance icn-governance-actor)
     /// - init_governance.rs: 3 (GovernanceManager, GovernanceSled)
     /// - events.rs: 0 (decoupled — tests use serde_json::json! directly)
     /// - actors.rs: 2 (CoreActorHandles governance handle)
@@ -370,7 +370,7 @@ mod tests {
     /// The module splits add +2 refs (each submodule needs its own `use` statement).
     #[test]
     fn strict_core_governance_reference_ratchet() {
-        let expected: usize = 74;
+        let expected: usize = 47;
         let actual = count_imports_in_crate("icn-core", "icn_governance::");
 
         assert!(

--- a/icn/crates/icn-kernel-api/src/events.rs
+++ b/icn/crates/icn-kernel-api/src/events.rs
@@ -1,0 +1,117 @@
+//! System-wide event types and emitter trait
+//!
+//! Provides the `SystemEvent` enum and `EventEmitter` trait for inter-actor
+//! communication. The kernel treats events as opaque coordination primitives —
+//! it routes them without interpreting their semantics.
+
+use async_trait::async_trait;
+use std::sync::Arc;
+
+/// System-wide events that actors can emit and subscribe to.
+///
+/// All fields use primitive or stringly-typed values so that kernel-api
+/// remains free of domain crate dependencies.
+#[derive(Clone, Debug)]
+pub enum SystemEvent {
+    /// A governance proposal was accepted
+    ProposalAccepted {
+        /// Unique identifier for the proposal
+        proposal_id: String,
+        /// Domain in which the proposal was made
+        domain_id: String,
+        /// Payload describing the proposal action (serialized)
+        payload: serde_json::Value,
+        /// Unix timestamp when the proposal was decided
+        decided_at: u64,
+    },
+
+    /// A governance proposal was rejected or failed to reach quorum
+    ProposalRejected {
+        /// Unique identifier for the proposal
+        proposal_id: String,
+        /// Domain in which the proposal was made
+        domain_id: String,
+        /// Unix timestamp when the proposal was decided
+        decided_at: u64,
+    },
+
+    /// A ledger transaction was executed
+    TransactionExecuted {
+        /// Hash of the ledger entry
+        entry_hash: [u8; 32],
+        /// Source DID (as string)
+        from: String,
+        /// Destination DID (as string)
+        to: String,
+        /// Transaction amount
+        amount: i64,
+        /// Currency identifier
+        currency: String,
+    },
+
+    /// A contract was executed
+    ContractExecuted {
+        /// Contract identifier
+        contract_id: String,
+        /// Execution outcome as JSON
+        outcome: serde_json::Value,
+    },
+
+    /// A proposal execution failed (proposal was accepted but could not be applied)
+    ProposalExecutionFailed {
+        /// Unique identifier for the proposal
+        proposal_id: String,
+        /// Type of the proposal (e.g., "protocol_change", "treasury")
+        proposal_type: String,
+        /// Human-readable error message
+        error: String,
+        /// Unix timestamp when the failure occurred
+        failed_at: u64,
+    },
+
+    /// Protocol parameters were initialized (first run)
+    ProtocolParametersInitialized {
+        /// Number of parameters initialized
+        count: usize,
+        /// Unix timestamp when the initialization occurred
+        initialized_at: u64,
+    },
+
+    /// Protocol parameter store was loaded (existing parameters)
+    ProtocolParametersLoaded {
+        /// Number of parameters loaded
+        count: usize,
+        /// Unix timestamp when the store was loaded
+        loaded_at: u64,
+    },
+
+    /// A protocol parameter was changed (for audit logging)
+    ProtocolParameterChanged {
+        /// Parameter ID that was changed
+        parameter_id: String,
+        /// Old value (serialized as string for logging)
+        old_value: String,
+        /// New value (serialized as string for logging)
+        new_value: String,
+        /// Proposal ID that authorized the change (if any)
+        proposal_id: Option<String>,
+        /// DID of the actor who made the change
+        changed_by: Option<String>,
+        /// Unix timestamp when the change occurred
+        changed_at: u64,
+    },
+}
+
+/// Callback function for event subscribers
+pub type EventCallback = Arc<dyn Fn(SystemEvent) + Send + Sync>;
+
+/// Trait for emitting system events.
+///
+/// Implementations handle the actual broadcast mechanism (e.g., in-memory
+/// subscriber list, channel-based dispatch). The kernel provides a default
+/// `EventBus` implementation.
+#[async_trait]
+pub trait EventEmitter: Send + Sync {
+    /// Emit an event to all subscribers
+    async fn emit(&self, event: SystemEvent);
+}

--- a/icn/crates/icn-kernel-api/src/lib.rs
+++ b/icn/crates/icn-kernel-api/src/lib.rs
@@ -37,6 +37,7 @@ pub mod bootstrap;
 pub mod comms;
 pub mod compute;
 pub mod coord;
+pub mod events;
 pub mod identity;
 pub mod naming;
 pub mod protocol_params;
@@ -60,6 +61,7 @@ pub use bootstrap::{
 pub use comms::{PubSub, RequestResponse, Streams};
 pub use compute::{ComputeEngine, Job, Trigger};
 pub use coord::Coordination;
+pub use events::{EventCallback, EventEmitter, SystemEvent};
 pub use identity::{DidResolver, IdentityService, Keystore};
 pub use naming::{Discovery, NamingService, ScopedDiscovery, ServiceEndpoint, ServiceEndpointId};
 pub use scope::{CellId, MockCellService, ScopeLevel};


### PR DESCRIPTION
## Summary
- Extract GovernanceActor (2,352 lines) from `icn-core` to new `icn-governance-actor` crate in `apps/governance/`
- Add `SystemEvent` enum and `EventEmitter` trait to `icn-kernel-api` (events module)
- `EventBus` in icn-core now implements `EventEmitter`
- GovernanceActor takes `Arc<dyn EventEmitter>` instead of concrete `Arc<EventBus>`
- icn-core re-exports from `icn-governance-actor` for backwards compatibility

## Ratchet
- Governance refs: **75 → 48** (-27 references removed from icn-core)
- This is the main payoff of the governance extraction sprint (#859)

## Architecture
The `GovernanceActor` no longer depends on `icn-core` — it uses `icn-kernel-api::EventEmitter` instead of concrete `EventBus`. This breaks the circular dependency and establishes the proper kernel/app boundary.

Dependency flow: `icn-core` → `icn-governance-actor` → `icn-kernel-api` (no reverse dependency)

## Files changed
- **New**: `apps/governance/` — `icn-governance-actor` crate with moved actor
- **New**: `crates/icn-kernel-api/src/events.rs` — `SystemEvent`, `EventEmitter` trait
- **Modified**: `crates/icn-core/src/events.rs` — re-exports from kernel-api, implements `EventEmitter`
- **Modified**: `crates/icn-core/src/governance/mod.rs` — re-exports from `icn-governance-actor`
- **Deleted**: `crates/icn-core/src/governance/actor.rs` — moved to apps/governance

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` — full workspace passes (all 153 test suites, 0 failures)
- [x] Meaning firewall ratchet updated (75 → 48)
- [x] `governance/actor.rs` no longer exists in icn-core
- [x] `apps/governance/src/actor.rs` exists and compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)