### PR TITLE
feat(gossip): blob transfer state machine (#1070)

### DIFF
--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -1,0 +1,19 @@
+name: 'Install Build Tools'
+description: 'Install clang and mold linker required by .cargo/config.toml'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install clang and mold linker
+      shell: bash
+      run: |
+        PACKAGES=""
+        if ! command -v clang &> /dev/null; then
+          PACKAGES="$PACKAGES clang"
+        fi
+        if ! command -v mold &> /dev/null; then
+          PACKAGES="$PACKAGES mold"
+        fi
+        if [ -n "$PACKAGES" ]; then
+          sudo apt-get update -qq && sudo apt-get install -y -qq $PACKAGES
+        fi

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Free disk space
         uses: ./.github/actions/free-disk-space
 
+      - name: Install build tools (clang + mold linker)
+        uses: ./.github/actions/install-build-tools
+
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
@@ -75,6 +78,16 @@ jobs:
 
       - name: Free disk space
         uses: ./baseline/.github/actions/free-disk-space
+
+      - name: Install build tools (clang + mold linker)
+        shell: bash
+        run: |
+          PACKAGES=""
+          if ! command -v clang &> /dev/null; then PACKAGES="$PACKAGES clang"; fi
+          if ! command -v mold &> /dev/null; then PACKAGES="$PACKAGES mold"; fi
+          if [ -n "$PACKAGES" ]; then
+            sudo apt-get update -qq && sudo apt-get install -y -qq $PACKAGES
+          fi
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install build tools
+        uses: ./.github/actions/install-build-tools
+
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Check kernel crates for forbidden deps (bash version)
@@ -138,6 +141,9 @@ jobs:
       - name: Free disk space
         uses: ./.github/actions/free-disk-space
 
+      - name: Install build tools
+        uses: ./.github/actions/install-build-tools
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -160,6 +166,9 @@ jobs:
         uses: ./.github/actions/free-disk-space
         with:
           verbose: 'true'
+
+      - name: Install build tools
+        uses: ./.github/actions/install-build-tools
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -187,6 +196,9 @@ jobs:
 
       - name: Free disk space
         uses: ./.github/actions/free-disk-space
+
+      - name: Install build tools
+        uses: ./.github/actions/install-build-tools
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -229,6 +241,9 @@ jobs:
           verbose: 'true'
           aggressive: 'true'
 
+      - name: Install build tools
+        uses: ./.github/actions/install-build-tools
+
       - uses: dtolnay/rust-toolchain@stable
 
       # NOTE: No rust-cache for coverage job - tarpaulin needs fresh instrumented
@@ -267,6 +282,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install build tools
+        uses: ./.github/actions/install-build-tools
+
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
@@ -298,6 +316,9 @@ jobs:
 
       - name: Free disk space
         uses: ./.github/actions/free-disk-space
+
+      - name: Install build tools
+        uses: ./.github/actions/install-build-tools
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/icn/.cargo/config.toml
+++ b/icn/.cargo/config.toml
@@ -4,8 +4,8 @@
 jobs = 4
 
 [target.x86_64-unknown-linux-gnu]
-# Use mold linker if available - much faster and uses less memory than ld
-# Falls back to default linker if mold is not installed
+# Requires clang + mold: `sudo apt-get install clang mold`
+# CI installs via .github/actions/install-build-tools
 linker = "clang"
 rustflags = ["-C", "debuginfo=1", "-C", "link-arg=-fuse-ld=mold"]
 

--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -3143,6 +3143,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "sha2",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -1642,7 +1642,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.111",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6970,9 +6970,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -6993,9 +6993,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/icn/crates/icn-gossip/Cargo.toml
+++ b/icn/crates/icn-gossip/Cargo.toml
@@ -30,6 +30,7 @@ ed25519-dalek = { version = "2.1", features = ["rand_core"] }
 [dev-dependencies]
 icn-store.workspace = true
 criterion = "0.5"
+tempfile = "3"
 
 [[bench]]
 name = "gossip_bench"

--- a/icn/crates/icn-gossip/src/gossip.rs
+++ b/icn/crates/icn-gossip/src/gossip.rs
@@ -95,7 +95,7 @@ pub struct GossipActor {
     pub(crate) oracle: Option<Arc<dyn PolicyOracle>>,
 
     /// Send message callback (optional, for sending responses)
-    send_callback: Option<SendMessageCallback>,
+    pub(crate) send_callback: Option<SendMessageCallback>,
 
     /// Entry notification callback (optional, for notifying subscribers)
     notification_callback: Option<EntryNotificationCallback>,
@@ -147,6 +147,13 @@ pub struct GossipActor {
     /// Blob transfer nonce guard for replay protection (PR2b #1069)
     /// Prevents duplicate processing of BlobRequest and BlobTransferChunk messages
     pub(crate) blob_nonce_guard: crate::handlers::blob_nonce_guard::BlobNonceGuard,
+
+    /// Blob storage backend for serving/storing blobs (PR2c #1070)
+    pub(crate) blob_store: Option<Arc<dyn icn_kernel_api::state::BlobService>>,
+
+    /// Blob transfer session manager (PR2c #1070)
+    pub(crate) transfer_manager:
+        Option<std::sync::Mutex<crate::handlers::blob_transfer_state::TransferSessionManager>>,
 }
 
 impl GossipActor {
@@ -178,6 +185,8 @@ impl GossipActor {
             topic_auto_creation_policy: crate::types::TopicAutoCreationPolicy::default(), // Issue #473: Strict defaults
             key_rotation_cache: crate::key_rotation::KeyRotationCache::new(), // Issue #469: Key rotation tracking
             blob_nonce_guard: crate::handlers::blob_nonce_guard::BlobNonceGuard::default_config(), // PR2b: Blob replay protection
+            blob_store: None,       // PR2c: Set via set_blob_store()
+            transfer_manager: None, // PR2c: Set via set_transfer_manager()
         };
 
         // Create default topics with appropriate scopes
@@ -322,6 +331,19 @@ impl GossipActor {
     /// Get the current topic auto-creation policy
     pub fn topic_auto_creation_policy(&self) -> crate::types::TopicAutoCreationPolicy {
         self.topic_auto_creation_policy
+    }
+
+    /// Set the blob storage backend for serving and storing blobs (PR2c #1070)
+    pub fn set_blob_store(&mut self, store: Arc<dyn icn_kernel_api::state::BlobService>) {
+        self.blob_store = Some(store);
+    }
+
+    /// Set the transfer session manager for blob transfers (PR2c #1070)
+    pub fn set_transfer_manager(
+        &mut self,
+        manager: crate::handlers::blob_transfer_state::TransferSessionManager,
+    ) {
+        self.transfer_manager = Some(std::sync::Mutex::new(manager));
     }
 
     // ==================== Key Rotation Methods (Issue #469) ====================

--- a/icn/crates/icn-gossip/src/handlers/blob_transfer.rs
+++ b/icn/crates/icn-gossip/src/handlers/blob_transfer.rs
@@ -1,8 +1,12 @@
 //! Blob transfer protocol handlers (Pilot)
 //!
 //! Handles BlobRequest and BlobTransferChunk messages for the blob gossip protocol.
-//! These are stub handlers that log and validate; actual transfer state machine
-//! is implemented in PR2c.
+//!
+//! **Provider side** (`handle_blob_request`): Looks up blob in BlobService,
+//! splits into 64KB chunks, sends via send_message callback.
+//!
+//! **Requester side** (`handle_blob_transfer_chunk`): Validates chunk, feeds
+//! into TransferSessionManager, handles assembly and ArtifactReceipt emission.
 //!
 //! # Security
 //!
@@ -12,10 +16,12 @@
 
 use crate::gossip::GossipActor;
 use crate::handlers::blob_nonce_guard::composite_chunk_nonce;
-use crate::types::ContentHash;
+use crate::handlers::blob_transfer_state::ChunkResult;
+use crate::types::{ContentHash, GossipMessage};
 use anyhow::Result;
 use icn_identity::Did;
-use tracing::{debug, warn};
+use icn_kernel_api::proofs::ArtifactReceipt;
+use tracing::{debug, info, warn};
 
 /// Maximum chunk size: 64 KB
 pub const MAX_CHUNK_SIZE: usize = 64 * 1024;
@@ -41,10 +47,10 @@ pub mod topics {
 }
 
 impl GossipActor {
-    /// Handle an incoming BlobRequest message.
+    /// Handle an incoming BlobRequest message (provider side).
     ///
-    /// Validates the request fields and logs the request. Actual blob lookup
-    /// and transfer initiation is implemented in PR2c (transfer state machine).
+    /// After validation (replay, expiry, sender match), looks up the blob
+    /// in BlobService and sends 64KB chunks back to the requester.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn handle_blob_request(
         &mut self,
@@ -100,16 +106,69 @@ impl GossipActor {
             return Ok(());
         }
 
-        // TODO(PR2c): Look up blob in BlobService, initiate chunked transfer
-        // For now, just log that we received a valid request
+        // Look up blob in BlobService
+        let blob_store = match &self.blob_store {
+            Some(store) => store.clone(),
+            None => {
+                warn!("No blob store configured, cannot serve BlobRequest");
+                return Ok(());
+            }
+        };
+
+        let blob_data = match blob_store.get(&blob_hash) {
+            Ok(data) => data,
+            Err(_) => {
+                debug!(
+                    blob_hash = %hex::encode(blob_hash),
+                    "Blob not found locally, cannot serve request"
+                );
+                return Ok(());
+            }
+        };
+
+        // Split into 64KB chunks and send
+        let send_callback = match &self.send_callback {
+            Some(cb) => cb.clone(),
+            None => {
+                warn!("No send callback configured, cannot respond to BlobRequest");
+                return Ok(());
+            }
+        };
+
+        let total_size = blob_data.len() as u64;
+        let chunks: Vec<&[u8]> = blob_data.chunks(MAX_CHUNK_SIZE).collect();
+        let total_chunks = chunks.len() as u32;
+
+        for (i, chunk) in chunks.iter().enumerate() {
+            let chunk_hash = *blake3::hash(chunk).as_bytes();
+            let msg = GossipMessage::BlobTransferChunk {
+                request_id,
+                blob_hash,
+                chunk_index: i as u32,
+                total_chunks,
+                chunk_hash,
+                total_size,
+                data: chunk.to_vec(),
+            };
+            send_callback(Some(requester_did.clone()), msg);
+        }
+
+        debug!(
+            blob_hash = %hex::encode(blob_hash),
+            total_chunks = total_chunks,
+            total_size = total_size,
+            requester = %requester_did,
+            "Sent blob chunks to requester"
+        );
 
         Ok(())
     }
 
-    /// Handle an incoming BlobTransferChunk message.
+    /// Handle an incoming BlobTransferChunk message (requester side).
     ///
-    /// Validates chunk fields (size, index bounds, chunk hash).
-    /// Actual reassembly state machine is implemented in PR2c.
+    /// After validation (chunk_hash, replay, size, bounds), feeds the chunk
+    /// into the TransferSessionManager. On AllChunksReceived, performs
+    /// two-phase assembly and emits ArtifactReceipt.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn handle_blob_transfer_chunk(
         &mut self,
@@ -201,8 +260,156 @@ impl GossipActor {
             return Ok(());
         }
 
-        // TODO(PR2c): Feed chunk into reassembly state machine
-        // For now, validation is complete
+        // Feed into transfer session manager
+        let transfer_manager = match &self.transfer_manager {
+            Some(mgr) => mgr,
+            None => {
+                warn!("No transfer manager configured, cannot process BlobTransferChunk");
+                return Ok(());
+            }
+        };
+
+        // Phase 1: receive chunk (lock held)
+        let chunk_result = {
+            let mut mgr = transfer_manager
+                .lock()
+                .map_err(|e| anyhow::anyhow!("Transfer manager lock poisoned: {e}"))?;
+            match mgr.receive_chunk(
+                request_id,
+                sender,
+                chunk_index,
+                total_chunks,
+                total_size,
+                &data,
+            ) {
+                Ok(result) => result,
+                Err(err_code) => {
+                    debug!(
+                        sender = %sender,
+                        request_id = %hex::encode(request_id),
+                        error = %err_code,
+                        "Transfer manager rejected chunk"
+                    );
+                    return Ok(());
+                }
+            }
+        };
+
+        if chunk_result != ChunkResult::AllChunksReceived {
+            return Ok(());
+        }
+
+        // All chunks received — begin two-phase assembly
+        // Phase 2a: begin_assembly (lock held) — marks Assembling, returns job
+        let assembly_job = {
+            let mut mgr = transfer_manager
+                .lock()
+                .map_err(|e| anyhow::anyhow!("Transfer manager lock poisoned: {e}"))?;
+            match mgr.begin_assembly(request_id) {
+                Ok(job) => job,
+                Err(err_code) => {
+                    warn!(
+                        request_id = %hex::encode(request_id),
+                        error = %err_code,
+                        "Failed to begin assembly"
+                    );
+                    return Ok(());
+                }
+            }
+        };
+
+        // Phase 2b: execute assembly (NO lock held — disk IO + hash verification)
+        let assembly_result = assembly_job.execute();
+
+        // Phase 2c: complete_assembly (lock held) — marks Verified/Failed
+        let assembled_data = {
+            let mut mgr = transfer_manager
+                .lock()
+                .map_err(|e| anyhow::anyhow!("Transfer manager lock poisoned: {e}"))?;
+            match &assembly_result {
+                Ok(_) => {
+                    mgr.complete_assembly(request_id, true)
+                        .map_err(|e| anyhow::anyhow!("complete_assembly failed: {e}"))?;
+                }
+                Err(_) => {
+                    let _ = mgr.complete_assembly(request_id, false);
+                    mgr.cleanup_session(request_id);
+                    warn!(
+                        request_id = %hex::encode(request_id),
+                        "Blob assembly failed, session cleaned up"
+                    );
+                    return Ok(());
+                }
+            }
+            assembly_result.map_err(|e| anyhow::anyhow!("Assembly failed: {e}"))?
+        };
+
+        // Store in BlobStore
+        if let Some(blob_store) = &self.blob_store {
+            let ns = icn_kernel_api::types::Namespace::new("blob", "transfer");
+            match blob_store.put(&ns, &assembled_data) {
+                Ok(_stored_hash) => {
+                    debug!(
+                        request_id = %hex::encode(request_id),
+                        blob_hash = %hex::encode(blob_hash),
+                        "Blob stored successfully"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        request_id = %hex::encode(request_id),
+                        error = %e,
+                        "Failed to store assembled blob"
+                    );
+                }
+            }
+        }
+
+        // Mark stored and get session metadata for receipt
+        let (provider_did, requester_did, scope_id) = {
+            let mut mgr = transfer_manager
+                .lock()
+                .map_err(|e| anyhow::anyhow!("Transfer manager lock poisoned: {e}"))?;
+            mgr.mark_stored(request_id);
+
+            let session = mgr.get_session(&request_id);
+            let meta = session.map(|s| {
+                (
+                    s.provider_did.clone(),
+                    s.requester_did.clone(),
+                    s.scope_id.clone(),
+                )
+            });
+
+            mgr.cleanup_session(request_id);
+            meta.unwrap_or_else(|| (sender.clone(), self.own_did.clone(), String::new()))
+        };
+
+        // Emit ArtifactReceipt
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        let receipt = ArtifactReceipt::new(
+            blob_hash,
+            provider_did.to_string(),
+            requester_did.to_string(),
+            request_id,
+            scope_id.clone(),
+            now,
+        );
+
+        info!(
+            request_id = %hex::encode(request_id),
+            blob_hash = %hex::encode(blob_hash),
+            provider_did = %provider_did,
+            requester_did = %requester_did,
+            scope_id = %scope_id,
+            receipt_hash = %hex::encode(receipt.receipt_hash),
+            verified_at = now,
+            "ArtifactReceipt emitted for verified blob transfer"
+        );
 
         Ok(())
     }
@@ -211,10 +418,76 @@ impl GossipActor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::handlers::blob_transfer_state::TransferSessionManager;
     use icn_identity::KeyPair;
+    use icn_kernel_api::state::{BlobMetadata, BlobService, StateError};
+    use icn_kernel_api::types::{Hash, Namespace};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
 
     fn make_test_did() -> Did {
         KeyPair::generate().unwrap().did().clone()
+    }
+
+    /// In-memory BlobService for testing
+    struct MockBlobStore {
+        blobs: Mutex<HashMap<Hash, (Vec<u8>, Namespace)>>,
+    }
+
+    impl MockBlobStore {
+        fn new() -> Self {
+            Self {
+                blobs: Mutex::new(HashMap::new()),
+            }
+        }
+
+        fn insert(&self, data: &[u8]) -> Hash {
+            let hash = *blake3::hash(data).as_bytes();
+            let mut blobs = self.blobs.lock().unwrap_or_else(|e| e.into_inner());
+            blobs.insert(hash, (data.to_vec(), Namespace::new("test", "blob")));
+            hash
+        }
+    }
+
+    impl BlobService for MockBlobStore {
+        fn put(&self, namespace: &Namespace, data: &[u8]) -> Result<Hash, StateError> {
+            let hash = *blake3::hash(data).as_bytes();
+            let mut blobs = self.blobs.lock().unwrap_or_else(|e| e.into_inner());
+            blobs.insert(hash, (data.to_vec(), namespace.clone()));
+            Ok(hash)
+        }
+
+        fn get(&self, hash: &Hash) -> Result<Vec<u8>, StateError> {
+            let blobs = self.blobs.lock().unwrap_or_else(|e| e.into_inner());
+            blobs
+                .get(hash)
+                .map(|(data, _)| data.clone())
+                .ok_or(StateError::BlobNotFound)
+        }
+
+        fn exists(&self, hash: &Hash) -> Result<bool, StateError> {
+            let blobs = self.blobs.lock().unwrap_or_else(|e| e.into_inner());
+            Ok(blobs.contains_key(hash))
+        }
+
+        fn delete(&self, hash: &Hash) -> Result<(), StateError> {
+            let mut blobs = self.blobs.lock().unwrap_or_else(|e| e.into_inner());
+            blobs.remove(hash);
+            Ok(())
+        }
+
+        fn metadata(&self, hash: &Hash) -> Result<BlobMetadata, StateError> {
+            let blobs = self.blobs.lock().unwrap_or_else(|e| e.into_inner());
+            blobs
+                .get(hash)
+                .map(|(data, ns)| BlobMetadata {
+                    size: data.len() as u64,
+                    namespace: ns.clone(),
+                    created_at: 0,
+                    content_type: None,
+                })
+                .ok_or(StateError::BlobNotFound)
+        }
     }
 
     #[test]
@@ -593,5 +866,145 @@ mod tests {
             .handle_blob_transfer_chunk(&sender, [0x11; 32], [0xAA; 32], 1, 5, hash, 500, data);
         assert!(r2.is_ok());
         assert_eq!(actor.blob_nonce_guard.nonce_count(&sender), 2);
+    }
+
+    // --- Integration tests (PR2c) ---
+
+    /// Helper: create a GossipActor with blob_store and transfer_manager
+    fn make_actor_with_transfer(
+        blob_store: Arc<MockBlobStore>,
+        tmp_dir: &std::path::Path,
+    ) -> (GossipActor, KeyPair) {
+        let kp = KeyPair::generate().unwrap();
+        let mut actor = GossipActor::new(kp.did().clone(), None);
+        actor.set_blob_store(blob_store);
+        actor.set_transfer_manager(TransferSessionManager::new(tmp_dir.to_path_buf()));
+        (actor, kp)
+    }
+
+    #[test]
+    fn blob_transfer_reassembly_and_verification() {
+        // End-to-end: provider serves blob → requester reassembles + verifies
+
+        let tmp_provider = tempfile::tempdir().unwrap();
+        let tmp_requester = tempfile::tempdir().unwrap();
+
+        // Create blob data (3 chunks worth)
+        let blob_data: Vec<u8> = (0..MAX_CHUNK_SIZE * 3).map(|i| (i % 256) as u8).collect();
+        let blob_hash = *blake3::hash(&blob_data).as_bytes();
+
+        // Provider: has the blob
+        let provider_store = Arc::new(MockBlobStore::new());
+        provider_store.insert(&blob_data);
+
+        let sent_messages: Arc<Mutex<Vec<GossipMessage>>> = Arc::new(Mutex::new(Vec::new()));
+        let sent_clone = sent_messages.clone();
+
+        let (mut provider_actor, _provider_kp) =
+            make_actor_with_transfer(provider_store, tmp_provider.path());
+        provider_actor.set_send_callback(Arc::new(move |_recipient, msg| {
+            sent_clone
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(msg);
+        }));
+
+        // Requester: wants the blob
+        let requester_store = Arc::new(MockBlobStore::new());
+        let (mut requester_actor, _requester_kp) =
+            make_actor_with_transfer(requester_store.clone(), tmp_requester.path());
+
+        let requester_did = requester_actor.own_did.clone();
+        let provider_did = provider_actor.own_did.clone();
+
+        // Requester creates a transfer session
+        let request_id = {
+            let mgr_mutex = requester_actor.transfer_manager.as_ref().unwrap();
+            let mut mgr = mgr_mutex.lock().unwrap();
+            mgr.start_request(
+                blob_hash,
+                vec![provider_did.clone()],
+                requester_did.clone(),
+                "test-scope".to_string(),
+                u64::MAX,
+            )
+            .unwrap()
+        };
+
+        // Provider handles the request
+        provider_actor
+            .handle_blob_request(
+                &requester_did,
+                request_id,
+                blob_hash,
+                requester_did.clone(),
+                u64::MAX,
+            )
+            .unwrap();
+
+        // Provider should have sent 3 chunks
+        let messages = sent_messages.lock().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(messages.len(), 3, "Provider should send 3 chunks");
+
+        // Requester processes each chunk
+        for msg in messages.iter() {
+            match msg {
+                GossipMessage::BlobTransferChunk {
+                    request_id: rid,
+                    blob_hash: bh,
+                    chunk_index,
+                    total_chunks,
+                    chunk_hash,
+                    total_size,
+                    data,
+                } => {
+                    requester_actor
+                        .handle_blob_transfer_chunk(
+                            &provider_did,
+                            *rid,
+                            *bh,
+                            *chunk_index,
+                            *total_chunks,
+                            *chunk_hash,
+                            *total_size,
+                            data.clone(),
+                        )
+                        .unwrap();
+                }
+                _ => panic!("Expected BlobTransferChunk"),
+            }
+        }
+
+        // Verify the blob was stored in the requester's store
+        assert!(
+            requester_store.exists(&blob_hash).unwrap(),
+            "Assembled blob should be stored in requester's BlobService"
+        );
+
+        let stored_data = requester_store.get(&blob_hash).unwrap();
+        assert_eq!(stored_data, blob_data, "Stored data should match original");
+    }
+
+    #[test]
+    fn reject_unsolicited_blob_transfer() {
+        // Adversarial: someone sends chunks without a prior request session
+
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Arc::new(MockBlobStore::new());
+        let (mut actor, _kp) = make_actor_with_transfer(store, tmp.path());
+
+        let attacker = make_test_did();
+        let data = vec![0x42u8; 100];
+        let chunk_hash = *blake3::hash(&data).as_bytes();
+
+        // No session exists for this request_id — chunk should be silently dropped
+        // by the transfer manager (InvalidRequest)
+        let result = actor.handle_blob_transfer_chunk(
+            &attacker, [0xFF; 32], // unknown request_id
+            [0xAA; 32], 0, 1, chunk_hash, 100, data,
+        );
+
+        // Handler returns Ok but the chunk is dropped internally
+        assert!(result.is_ok());
     }
 }

--- a/icn/crates/icn-gossip/src/handlers/blob_transfer.rs
+++ b/icn/crates/icn-gossip/src/handlers/blob_transfer.rs
@@ -16,11 +16,12 @@
 
 use crate::gossip::GossipActor;
 use crate::handlers::blob_nonce_guard::composite_chunk_nonce;
-use crate::handlers::blob_transfer_state::ChunkResult;
+use crate::handlers::blob_transfer_state::{ChunkResult, RequestId, TransferSessionManager};
 use crate::types::{ContentHash, GossipMessage};
 use anyhow::Result;
 use icn_identity::Did;
 use icn_kernel_api::proofs::ArtifactReceipt;
+use std::sync::Mutex;
 use tracing::{debug, info, warn};
 
 /// Maximum chunk size: 64 KB
@@ -44,6 +45,43 @@ pub mod topics {
     pub const BLOB_REQUEST: &str = "blob:request";
     /// Topic for blob transfer chunks
     pub const BLOB_TRANSFER: &str = "blob:transfer";
+}
+
+/// RAII guard for the two-phase assembly section.
+///
+/// Ensures `active_reassemblies` is decremented and the session is cleaned up
+/// even if an error occurs between `begin_assembly` and `complete_assembly`.
+/// Call `defuse()` after successful storage to prevent cleanup on drop.
+struct AssemblyGuard<'a> {
+    manager: &'a Mutex<TransferSessionManager>,
+    request_id: RequestId,
+    defused: bool,
+}
+
+impl<'a> AssemblyGuard<'a> {
+    fn new(manager: &'a Mutex<TransferSessionManager>, request_id: RequestId) -> Self {
+        Self {
+            manager,
+            request_id,
+            defused: false,
+        }
+    }
+
+    /// Mark the assembly as successful; drop will not clean up.
+    fn defuse(&mut self) {
+        self.defused = true;
+    }
+}
+
+impl Drop for AssemblyGuard<'_> {
+    fn drop(&mut self) {
+        if !self.defused {
+            if let Ok(mut mgr) = self.manager.lock() {
+                let _ = mgr.complete_assembly(self.request_id, false);
+                mgr.cleanup_session(self.request_id);
+            }
+        }
+    }
 }
 
 impl GossipActor {
@@ -91,10 +129,7 @@ impl GossipActor {
         }
 
         // Validate: check expiration
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+        let now = icn_time::current_timestamp_secs();
         if expires_at > 0 && now > expires_at {
             warn!(
                 sender = %sender,
@@ -299,7 +334,11 @@ impl GossipActor {
             return Ok(());
         }
 
-        // All chunks received — begin two-phase assembly
+        // All chunks received — begin two-phase assembly with RAII guard.
+        // The guard ensures active_reassemblies is decremented and the session
+        // is cleaned up even if an error occurs mid-assembly.
+        let mut guard = AssemblyGuard::new(transfer_manager, request_id);
+
         // Phase 2a: begin_assembly (lock held) — marks Assembling, returns job
         let assembly_job = {
             let mut mgr = transfer_manager
@@ -308,6 +347,9 @@ impl GossipActor {
             match mgr.begin_assembly(request_id) {
                 Ok(job) => job,
                 Err(err_code) => {
+                    // begin_assembly failed — guard has nothing to clean up since
+                    // active_reassemblies was never incremented
+                    guard.defuse();
                     warn!(
                         request_id = %hex::encode(request_id),
                         error = %err_code,
@@ -319,30 +361,27 @@ impl GossipActor {
         };
 
         // Phase 2b: execute assembly (NO lock held — disk IO + hash verification)
-        let assembly_result = assembly_job.execute();
+        let assembled_data = match assembly_job.execute() {
+            Ok(data) => data,
+            Err(err_code) => {
+                // Guard will call complete_assembly(false) + cleanup_session on drop
+                warn!(
+                    request_id = %hex::encode(request_id),
+                    error = %err_code,
+                    "Blob assembly failed, session cleaned up"
+                );
+                return Ok(());
+            }
+        };
 
-        // Phase 2c: complete_assembly (lock held) — marks Verified/Failed
-        let assembled_data = {
+        // Phase 2c: complete_assembly success (lock held) — marks Verified
+        {
             let mut mgr = transfer_manager
                 .lock()
                 .map_err(|e| anyhow::anyhow!("Transfer manager lock poisoned: {e}"))?;
-            match &assembly_result {
-                Ok(_) => {
-                    mgr.complete_assembly(request_id, true)
-                        .map_err(|e| anyhow::anyhow!("complete_assembly failed: {e}"))?;
-                }
-                Err(_) => {
-                    let _ = mgr.complete_assembly(request_id, false);
-                    mgr.cleanup_session(request_id);
-                    warn!(
-                        request_id = %hex::encode(request_id),
-                        "Blob assembly failed, session cleaned up"
-                    );
-                    return Ok(());
-                }
-            }
-            assembly_result.map_err(|e| anyhow::anyhow!("Assembly failed: {e}"))?
-        };
+            mgr.complete_assembly(request_id, true)
+                .map_err(|e| anyhow::anyhow!("complete_assembly failed: {e}"))?;
+        }
 
         // Store in BlobStore
         if let Some(blob_store) = &self.blob_store {
@@ -361,9 +400,14 @@ impl GossipActor {
                         error = %e,
                         "Failed to store assembled blob"
                     );
+                    // Guard will clean up on drop
+                    return Ok(());
                 }
             }
         }
+
+        // All done — defuse the guard so it doesn't clean up on drop
+        guard.defuse();
 
         // Mark stored and get session metadata for receipt
         let (provider_did, requester_did, scope_id) = {
@@ -386,10 +430,7 @@ impl GossipActor {
         };
 
         // Emit ArtifactReceipt
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+        let now = icn_time::current_timestamp_secs();
 
         let receipt = ArtifactReceipt::new(
             blob_hash,

--- a/icn/crates/icn-gossip/src/handlers/blob_transfer_state.rs
+++ b/icn/crates/icn-gossip/src/handlers/blob_transfer_state.rs
@@ -204,7 +204,11 @@ impl TransferSessionManager {
         }
 
         // Check per-peer limit for the requester
-        let count = self.per_peer_counts.get(&requester_did).copied().unwrap_or(0);
+        let count = self
+            .per_peer_counts
+            .get(&requester_did)
+            .copied()
+            .unwrap_or(0);
         if count >= MAX_REQUESTS_PER_PEER {
             return Err(ErrCode::Busy);
         }
@@ -221,7 +225,10 @@ impl TransferSessionManager {
         let request_id: RequestId = *hasher.finalize().as_bytes();
 
         // Pick first provider (PR2d will add ranking)
-        let provider_did = providers.into_iter().next().ok_or(ErrCode::InvalidRequest)?;
+        let provider_did = providers
+            .into_iter()
+            .next()
+            .ok_or(ErrCode::InvalidRequest)?;
 
         let session = TransferSession {
             request_id,
@@ -230,8 +237,8 @@ impl TransferSessionManager {
             requester_did: requester_did.clone(),
             scope_id,
             expires_at,
-            total_chunks: 0,  // Set on first chunk
-            total_size: 0,    // Set on first chunk
+            total_chunks: 0, // Set on first chunk
+            total_size: 0,   // Set on first chunk
             state: TransferState::Requested,
             created_at: now / 1_000_000_000, // Convert nanos to secs
         };
@@ -270,7 +277,9 @@ impl TransferSessionManager {
         // Compute session dir before borrowing sessions mutably
         let session_dir = self.session_dir(&request_id);
 
-        let session = self.sessions.get_mut(&request_id)
+        let session = self
+            .sessions
+            .get_mut(&request_id)
             .ok_or(ErrCode::InvalidRequest)?;
 
         // Check expiry
@@ -322,7 +331,10 @@ impl TransferSessionManager {
                     Ok(ChunkResult::Accepted)
                 }
             }
-            TransferState::Receiving { chunks_received, received_bytes } => {
+            TransferState::Receiving {
+                chunks_received,
+                received_bytes,
+            } => {
                 // Subsequent chunks: validate consistency
                 if total_chunks != session.total_chunks {
                     session.state = TransferState::Failed(ErrCode::InvalidRequest);
@@ -358,9 +370,7 @@ impl TransferSessionManager {
                 // Session already past receiving phase
                 Err(ErrCode::InvalidRequest)
             }
-            TransferState::Failed(_) => {
-                Err(ErrCode::InvalidRequest)
-            }
+            TransferState::Failed(_) => Err(ErrCode::InvalidRequest),
         }
     }
 
@@ -376,12 +386,16 @@ impl TransferSessionManager {
         // Compute dir before mutable borrow
         let partial_dir = self.session_dir(&request_id);
 
-        let session = self.sessions.get_mut(&request_id)
+        let session = self
+            .sessions
+            .get_mut(&request_id)
             .ok_or(ErrCode::InvalidRequest)?;
 
         // Only transition from Receiving with all chunks
         match &session.state {
-            TransferState::Receiving { chunks_received, .. } => {
+            TransferState::Receiving {
+                chunks_received, ..
+            } => {
                 if !chunks_received.iter().all(|&b| b) {
                     return Err(ErrCode::InvalidRequest);
                 }
@@ -409,7 +423,9 @@ impl TransferSessionManager {
         request_id: RequestId,
         success: bool,
     ) -> Result<(), ErrCode> {
-        let session = self.sessions.get_mut(&request_id)
+        let session = self
+            .sessions
+            .get_mut(&request_id)
             .ok_or(ErrCode::InvalidRequest)?;
 
         match session.state {
@@ -462,7 +478,9 @@ impl TransferSessionManager {
 
     /// Clean up all expired sessions. Returns count of cleaned sessions.
     pub fn cleanup_expired(&mut self, now: u64) -> usize {
-        let expired: Vec<RequestId> = self.sessions.iter()
+        let expired: Vec<RequestId> = self
+            .sessions
+            .iter()
             .filter(|(_, s)| s.expires_at > 0 && now > s.expires_at)
             .map(|(id, _)| *id)
             .collect();
@@ -529,13 +547,15 @@ mod tests {
         provider: &Did,
         requester: &Did,
     ) -> RequestId {
-        manager.start_request(
-            blob_hash,
-            vec![provider.clone()],
-            requester.clone(),
-            "test-scope".to_string(),
-            u64::MAX, // far future
-        ).expect("start_request should succeed")
+        manager
+            .start_request(
+                blob_hash,
+                vec![provider.clone()],
+                requester.clone(),
+                "test-scope".to_string(),
+                u64::MAX, // far future
+            )
+            .expect("start_request should succeed")
     }
 
     fn make_chunk_data(index: u32) -> Vec<u8> {
@@ -564,27 +584,57 @@ mod tests {
         let rid = start_session(&mut mgr, blob_hash, &provider, &requester);
 
         // Initially Requested
-        assert!(matches!(mgr.get_session(&rid).unwrap().state, TransferState::Requested));
+        assert!(matches!(
+            mgr.get_session(&rid).unwrap().state,
+            TransferState::Requested
+        ));
 
         // First chunk → Receiving
         let data0 = make_chunk_data(0);
-        let r = mgr.receive_chunk(rid, &provider, 0, total_chunks, total_chunks as u64 * 1024, &data0);
+        let r = mgr.receive_chunk(
+            rid,
+            &provider,
+            0,
+            total_chunks,
+            total_chunks as u64 * 1024,
+            &data0,
+        );
         assert_eq!(r.unwrap(), ChunkResult::Accepted);
-        assert!(matches!(mgr.get_session(&rid).unwrap().state, TransferState::Receiving { .. }));
+        assert!(matches!(
+            mgr.get_session(&rid).unwrap().state,
+            TransferState::Receiving { .. }
+        ));
 
         // Second chunk → still Receiving
         let data1 = make_chunk_data(1);
-        let r = mgr.receive_chunk(rid, &provider, 1, total_chunks, total_chunks as u64 * 1024, &data1);
+        let r = mgr.receive_chunk(
+            rid,
+            &provider,
+            1,
+            total_chunks,
+            total_chunks as u64 * 1024,
+            &data1,
+        );
         assert_eq!(r.unwrap(), ChunkResult::Accepted);
 
         // Third chunk → AllChunksReceived
         let data2 = make_chunk_data(2);
-        let r = mgr.receive_chunk(rid, &provider, 2, total_chunks, total_chunks as u64 * 1024, &data2);
+        let r = mgr.receive_chunk(
+            rid,
+            &provider,
+            2,
+            total_chunks,
+            total_chunks as u64 * 1024,
+            &data2,
+        );
         assert_eq!(r.unwrap(), ChunkResult::AllChunksReceived);
 
         // Begin assembly → Assembling
         let job = mgr.begin_assembly(rid).unwrap();
-        assert!(matches!(mgr.get_session(&rid).unwrap().state, TransferState::Assembling));
+        assert!(matches!(
+            mgr.get_session(&rid).unwrap().state,
+            TransferState::Assembling
+        ));
         assert_eq!(mgr.active_reassemblies(), 1);
 
         // Execute assembly (reads files, verifies hash)
@@ -593,12 +643,18 @@ mod tests {
 
         // Complete assembly → Verified
         mgr.complete_assembly(rid, true).unwrap();
-        assert!(matches!(mgr.get_session(&rid).unwrap().state, TransferState::Verified));
+        assert!(matches!(
+            mgr.get_session(&rid).unwrap().state,
+            TransferState::Verified
+        ));
         assert_eq!(mgr.active_reassemblies(), 0);
 
         // Mark stored → Stored
         mgr.mark_stored(rid);
-        assert!(matches!(mgr.get_session(&rid).unwrap().state, TransferState::Stored));
+        assert!(matches!(
+            mgr.get_session(&rid).unwrap().state,
+            TransferState::Stored
+        ));
 
         // Cleanup
         mgr.cleanup_session(rid);
@@ -637,13 +693,15 @@ mod tests {
         let requester = make_did();
 
         // Start with expires_at in the past
-        let rid = mgr.start_request(
-            [0xAA; 32],
-            vec![provider.clone()],
-            requester.clone(),
-            "test".to_string(),
-            1, // 1 second after epoch = expired
-        ).unwrap();
+        let rid = mgr
+            .start_request(
+                [0xAA; 32],
+                vec![provider.clone()],
+                requester.clone(),
+                "test".to_string(),
+                1, // 1 second after epoch = expired
+            )
+            .unwrap();
 
         let result = mgr.receive_chunk(rid, &provider, 0, 1, 1024, &[0u8; 100]);
         assert_eq!(result.unwrap_err(), ErrCode::Expired);
@@ -659,7 +717,10 @@ mod tests {
         let rid = start_session(&mut mgr, [0xAA; 32], &provider, &requester);
 
         let result = mgr.receive_chunk(
-            rid, &provider, 0, 200,
+            rid,
+            &provider,
+            0,
+            200,
             MAX_BLOB_SIZE + 1, // Over 10 MB
             &[0u8; 100],
         );
@@ -681,7 +742,8 @@ mod tests {
             let expected_hash = *blake3::hash(&data).as_bytes();
             let rid = start_session(&mut mgr, expected_hash, &provider, &requester);
 
-            mgr.receive_chunk(rid, &provider, 0, 1, data.len() as u64, &data).unwrap();
+            mgr.receive_chunk(rid, &provider, 0, 1, data.len() as u64, &data)
+                .unwrap();
             mgr.begin_assembly(rid).unwrap();
         }
 
@@ -693,7 +755,8 @@ mod tests {
         let data = make_chunk_data(99);
         let expected_hash = *blake3::hash(&data).as_bytes();
         let rid = start_session(&mut mgr, expected_hash, &provider, &requester);
-        mgr.receive_chunk(rid, &provider, 0, 1, data.len() as u64, &data).unwrap();
+        mgr.receive_chunk(rid, &provider, 0, 1, data.len() as u64, &data)
+            .unwrap();
 
         let result = mgr.begin_assembly(rid);
         assert_eq!(result.unwrap_err(), ErrCode::Busy);
@@ -707,13 +770,15 @@ mod tests {
         let requester = make_did();
 
         // Start with near-future expiry
-        let rid = mgr.start_request(
-            [0xAA; 32],
-            vec![provider.clone()],
-            requester.clone(),
-            "test".to_string(),
-            100, // expires at 100 seconds
-        ).unwrap();
+        let rid = mgr
+            .start_request(
+                [0xAA; 32],
+                vec![provider.clone()],
+                requester.clone(),
+                "test".to_string(),
+                100, // expires at 100 seconds
+            )
+            .unwrap();
 
         let session_dir = tmp.path().join(hex::encode(rid));
         assert!(session_dir.exists());
@@ -768,7 +833,8 @@ mod tests {
                 requester.clone(),
                 "test".to_string(),
                 u64::MAX,
-            ).unwrap();
+            )
+            .unwrap();
         }
 
         assert_eq!(mgr.peer_request_count(&requester), MAX_REQUESTS_PER_PEER);
@@ -797,7 +863,8 @@ mod tests {
             let data = make_chunk_data(0);
             let correct_hash = *blake3::hash(&data).as_bytes();
             let rid = start_session(&mut mgr, correct_hash, &provider, &requester);
-            mgr.receive_chunk(rid, &provider, 0, 1, data.len() as u64, &data).unwrap();
+            mgr.receive_chunk(rid, &provider, 0, 1, data.len() as u64, &data)
+                .unwrap();
 
             let job = mgr.begin_assembly(rid).unwrap();
             let result = job.execute();
@@ -814,7 +881,8 @@ mod tests {
             let data = make_chunk_data(0);
             let wrong_hash = [0xFF; 32]; // doesn't match data
             let rid = start_session(&mut mgr, wrong_hash, &provider, &requester);
-            mgr.receive_chunk(rid, &provider, 0, 1, data.len() as u64, &data).unwrap();
+            mgr.receive_chunk(rid, &provider, 0, 1, data.len() as u64, &data)
+                .unwrap();
 
             let job = mgr.begin_assembly(rid).unwrap();
             let result = job.execute();

--- a/icn/crates/icn-gossip/src/handlers/blob_transfer_state.rs
+++ b/icn/crates/icn-gossip/src/handlers/blob_transfer_state.rs
@@ -254,8 +254,9 @@ impl TransferSessionManager {
                 error = %e,
                 "Failed to create partial dir for transfer session"
             );
-            // Clean up session on failure
-            self.sessions.remove(&request_id);
+            // Clean up session AND per-peer counter on failure.
+            // cleanup_session handles both removal and counter decrement.
+            self.cleanup_session(request_id);
             return Err(ErrCode::Busy);
         }
 
@@ -308,6 +309,10 @@ impl TransferSessionManager {
                 // First chunk: initialize receiving state
                 if total_chunks == 0 {
                     session.state = TransferState::Failed(ErrCode::InvalidRequest);
+                    return Err(ErrCode::InvalidRequest);
+                }
+
+                if chunk_index >= total_chunks {
                     return Err(ErrCode::InvalidRequest);
                 }
 

--- a/icn/crates/icn-gossip/src/handlers/blob_transfer_state.rs
+++ b/icn/crates/icn-gossip/src/handlers/blob_transfer_state.rs
@@ -1,0 +1,824 @@
+//! Blob transfer state machine (PR2c — #1070)
+//!
+//! Manages the lifecycle of blob transfer sessions from request through
+//! chunk reception, reassembly, verification, and storage. Each session
+//! is keyed by `RequestId` and follows monotonic state transitions:
+//!
+//! ```text
+//! Requested → Receiving { bitmap } → Assembling → Verified → Stored
+//!                                         ↓
+//!                                   Failed(ErrCode) [terminal]
+//! ```
+//!
+//! # Resource Bounds
+//!
+//! - Max in-flight requests per peer: 8
+//! - Max concurrent reassemblies (global): 16
+//! - Chunk size: 64 KB (enforced by handler, not here)
+//! - Blob max size: 10 MB
+//!
+//! # Disk Layout
+//!
+//! Chunk bytes are stored on disk during transfer:
+//! `<partial_dir>/<hex(request_id)>/chunk_<NNNN>.bin`
+//!
+//! Temp dir is cleaned up on session completion or expiry.
+
+use icn_identity::Did;
+use icn_kernel_api::error::ErrCode;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use tracing::warn;
+
+use crate::types::ContentHash;
+
+/// Type alias for request identifiers (32-byte nonce)
+pub type RequestId = [u8; 32];
+
+/// Maximum in-flight blob requests per peer
+pub const MAX_REQUESTS_PER_PEER: usize = 8;
+
+/// Maximum concurrent reassemblies (global)
+pub const MAX_CONCURRENT_REASSEMBLIES: usize = 16;
+
+/// Maximum blob size in bytes (10 MB)
+const MAX_BLOB_SIZE: u64 = 10 * 1024 * 1024;
+
+/// State of a blob transfer session.
+///
+/// Transitions are monotonic — only one transition per event, no jumping.
+#[derive(Debug, Clone)]
+pub enum TransferState {
+    /// Request initiated, waiting for first chunk
+    Requested,
+    /// Receiving chunks; bitmap tracks which chunks have arrived
+    Receiving {
+        chunks_received: Vec<bool>,
+        received_bytes: u64,
+    },
+    /// All chunks received, reassembly in progress
+    Assembling,
+    /// Reassembly complete, hash verified
+    Verified,
+    /// Blob committed to BlobStore
+    Stored,
+    /// Terminal failure state
+    Failed(ErrCode),
+}
+
+/// A single blob transfer session.
+#[derive(Debug)]
+pub struct TransferSession {
+    pub request_id: RequestId,
+    pub blob_hash: ContentHash,
+    pub provider_did: Did,
+    pub requester_did: Did,
+    pub scope_id: String,
+    pub expires_at: u64,
+    pub total_chunks: u32,
+    pub total_size: u64,
+    pub state: TransferState,
+    pub created_at: u64,
+}
+
+/// Result of receiving a chunk.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ChunkResult {
+    /// Chunk accepted, more chunks needed
+    Accepted,
+    /// All chunks received, ready for assembly
+    AllChunksReceived,
+}
+
+/// Job context for two-phase assembly (phase 2 runs without lock held).
+#[derive(Debug)]
+pub struct AssemblyJob {
+    /// Directory containing chunk files
+    pub partial_dir: PathBuf,
+    /// Number of chunks to reassemble
+    pub total_chunks: u32,
+    /// Expected blake3 hash of the complete blob
+    pub blob_hash: ContentHash,
+}
+
+impl AssemblyJob {
+    /// Execute the assembly: read chunks, concatenate, verify hash.
+    ///
+    /// This runs WITHOUT the manager lock held, so it won't stall chunk handling.
+    pub fn execute(&self) -> Result<Vec<u8>, ErrCode> {
+        let mut assembled = Vec::new();
+        for i in 0..self.total_chunks {
+            let chunk_path = self.partial_dir.join(format!("chunk_{:04}.bin", i));
+            let chunk_data = std::fs::read(&chunk_path).map_err(|e| {
+                warn!(
+                    chunk_index = i,
+                    path = %chunk_path.display(),
+                    error = %e,
+                    "Failed to read chunk file during assembly"
+                );
+                ErrCode::InvalidRequest
+            })?;
+            assembled.extend_from_slice(&chunk_data);
+        }
+
+        let actual_hash = *blake3::hash(&assembled).as_bytes();
+        if actual_hash != self.blob_hash {
+            warn!(
+                expected = %hex::encode(self.blob_hash),
+                actual = %hex::encode(actual_hash),
+                "Blob hash mismatch after reassembly"
+            );
+            return Err(ErrCode::InvalidRequest);
+        }
+
+        Ok(assembled)
+    }
+}
+
+/// Write a chunk to disk atomically (write temp → rename).
+fn write_chunk(session_dir: &Path, chunk_index: u32, data: &[u8]) -> Result<(), ErrCode> {
+    let chunk_path = session_dir.join(format!("chunk_{:04}.bin", chunk_index));
+    let tmp_path = session_dir.join(format!("chunk_{:04}.tmp", chunk_index));
+
+    std::fs::write(&tmp_path, data).map_err(|e| {
+        warn!(
+            chunk_index = chunk_index,
+            path = %tmp_path.display(),
+            error = %e,
+            "Failed to write chunk temp file"
+        );
+        ErrCode::Busy
+    })?;
+
+    std::fs::rename(&tmp_path, &chunk_path).map_err(|e| {
+        warn!(
+            chunk_index = chunk_index,
+            error = %e,
+            "Failed to rename chunk temp to final"
+        );
+        ErrCode::Busy
+    })?;
+
+    Ok(())
+}
+
+/// Manages all active blob transfer sessions.
+pub struct TransferSessionManager {
+    /// Active sessions keyed by RequestId
+    sessions: HashMap<RequestId, TransferSession>,
+    /// Number of active requests per peer (for per-peer limits)
+    per_peer_counts: HashMap<Did, usize>,
+    /// Number of sessions currently in Assembling state
+    active_reassemblies: usize,
+    /// Base directory for partial chunk storage
+    partial_dir: PathBuf,
+}
+
+impl TransferSessionManager {
+    /// Create a new manager with the given partial directory.
+    pub fn new(partial_dir: PathBuf) -> Self {
+        Self {
+            sessions: HashMap::new(),
+            per_peer_counts: HashMap::new(),
+            active_reassemblies: 0,
+            partial_dir,
+        }
+    }
+
+    /// Start a new transfer request.
+    ///
+    /// Generates a request_id internally, picks the first provider from the list
+    /// (PR2d will control ordering/ranking).
+    ///
+    /// Returns the generated RequestId on success.
+    pub fn start_request(
+        &mut self,
+        blob_hash: ContentHash,
+        providers: Vec<Did>,
+        requester_did: Did,
+        scope_id: String,
+        expires_at: u64,
+    ) -> Result<RequestId, ErrCode> {
+        if providers.is_empty() {
+            return Err(ErrCode::InvalidRequest);
+        }
+
+        // Check per-peer limit for the requester
+        let count = self.per_peer_counts.get(&requester_did).copied().unwrap_or(0);
+        if count >= MAX_REQUESTS_PER_PEER {
+            return Err(ErrCode::Busy);
+        }
+
+        // Generate request_id from blake3(blob_hash || requester_did || timestamp)
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0);
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(&blob_hash);
+        hasher.update(requester_did.as_str().as_bytes());
+        hasher.update(&now.to_le_bytes());
+        let request_id: RequestId = *hasher.finalize().as_bytes();
+
+        // Pick first provider (PR2d will add ranking)
+        let provider_did = providers.into_iter().next().ok_or(ErrCode::InvalidRequest)?;
+
+        let session = TransferSession {
+            request_id,
+            blob_hash,
+            provider_did,
+            requester_did: requester_did.clone(),
+            scope_id,
+            expires_at,
+            total_chunks: 0,  // Set on first chunk
+            total_size: 0,    // Set on first chunk
+            state: TransferState::Requested,
+            created_at: now / 1_000_000_000, // Convert nanos to secs
+        };
+
+        self.sessions.insert(request_id, session);
+        *self.per_peer_counts.entry(requester_did).or_insert(0) += 1;
+
+        // Create partial directory for this request
+        let session_dir = self.session_dir(&request_id);
+        if let Err(e) = std::fs::create_dir_all(&session_dir) {
+            warn!(
+                request_id = %hex::encode(request_id),
+                error = %e,
+                "Failed to create partial dir for transfer session"
+            );
+            // Clean up session on failure
+            self.sessions.remove(&request_id);
+            return Err(ErrCode::Busy);
+        }
+
+        Ok(request_id)
+    }
+
+    /// Receive a chunk for an existing session.
+    ///
+    /// Called by the handler AFTER chunk_hash + replay checks pass.
+    pub fn receive_chunk(
+        &mut self,
+        request_id: RequestId,
+        sender: &Did,
+        chunk_index: u32,
+        total_chunks: u32,
+        total_size: u64,
+        data: &[u8],
+    ) -> Result<ChunkResult, ErrCode> {
+        // Compute session dir before borrowing sessions mutably
+        let session_dir = self.session_dir(&request_id);
+
+        let session = self.sessions.get_mut(&request_id)
+            .ok_or(ErrCode::InvalidRequest)?;
+
+        // Check expiry
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        if session.expires_at > 0 && now > session.expires_at {
+            session.state = TransferState::Failed(ErrCode::Expired);
+            return Err(ErrCode::Expired);
+        }
+
+        // Check provider
+        if *sender != session.provider_did {
+            return Err(ErrCode::Forbidden);
+        }
+
+        // Validate total_size
+        if total_size > MAX_BLOB_SIZE {
+            session.state = TransferState::Failed(ErrCode::Oversize);
+            return Err(ErrCode::Oversize);
+        }
+
+        match &mut session.state {
+            TransferState::Requested => {
+                // First chunk: initialize receiving state
+                if total_chunks == 0 {
+                    session.state = TransferState::Failed(ErrCode::InvalidRequest);
+                    return Err(ErrCode::InvalidRequest);
+                }
+
+                session.total_chunks = total_chunks;
+                session.total_size = total_size;
+
+                let mut bitmap = vec![false; total_chunks as usize];
+                bitmap[chunk_index as usize] = true;
+
+                // Write chunk to disk
+                write_chunk(&session_dir, chunk_index, data)?;
+
+                session.state = TransferState::Receiving {
+                    chunks_received: bitmap,
+                    received_bytes: data.len() as u64,
+                };
+
+                if total_chunks == 1 {
+                    Ok(ChunkResult::AllChunksReceived)
+                } else {
+                    Ok(ChunkResult::Accepted)
+                }
+            }
+            TransferState::Receiving { chunks_received, received_bytes } => {
+                // Subsequent chunks: validate consistency
+                if total_chunks != session.total_chunks {
+                    session.state = TransferState::Failed(ErrCode::InvalidRequest);
+                    return Err(ErrCode::InvalidRequest);
+                }
+                if total_size != session.total_size {
+                    session.state = TransferState::Failed(ErrCode::InvalidRequest);
+                    return Err(ErrCode::InvalidRequest);
+                }
+
+                if chunk_index >= total_chunks {
+                    return Err(ErrCode::InvalidRequest);
+                }
+
+                // Duplicate chunk (already received)
+                if chunks_received[chunk_index as usize] {
+                    return Ok(ChunkResult::Accepted);
+                }
+
+                // Write chunk to disk
+                write_chunk(&session_dir, chunk_index, data)?;
+
+                chunks_received[chunk_index as usize] = true;
+                *received_bytes += data.len() as u64;
+
+                if chunks_received.iter().all(|&b| b) {
+                    Ok(ChunkResult::AllChunksReceived)
+                } else {
+                    Ok(ChunkResult::Accepted)
+                }
+            }
+            TransferState::Assembling | TransferState::Verified | TransferState::Stored => {
+                // Session already past receiving phase
+                Err(ErrCode::InvalidRequest)
+            }
+            TransferState::Failed(_) => {
+                Err(ErrCode::InvalidRequest)
+            }
+        }
+    }
+
+    /// Phase 1 of two-phase assembly: mark as Assembling and return job.
+    ///
+    /// Must be called WITH the lock held. Returns the AssemblyJob for
+    /// phase 2 (which runs WITHOUT the lock).
+    pub fn begin_assembly(&mut self, request_id: RequestId) -> Result<AssemblyJob, ErrCode> {
+        if self.active_reassemblies >= MAX_CONCURRENT_REASSEMBLIES {
+            return Err(ErrCode::Busy);
+        }
+
+        // Compute dir before mutable borrow
+        let partial_dir = self.session_dir(&request_id);
+
+        let session = self.sessions.get_mut(&request_id)
+            .ok_or(ErrCode::InvalidRequest)?;
+
+        // Only transition from Receiving with all chunks
+        match &session.state {
+            TransferState::Receiving { chunks_received, .. } => {
+                if !chunks_received.iter().all(|&b| b) {
+                    return Err(ErrCode::InvalidRequest);
+                }
+            }
+            _ => return Err(ErrCode::InvalidRequest),
+        }
+
+        let total_chunks = session.total_chunks;
+        let blob_hash = session.blob_hash;
+        session.state = TransferState::Assembling;
+        self.active_reassemblies += 1;
+
+        Ok(AssemblyJob {
+            partial_dir,
+            total_chunks,
+            blob_hash,
+        })
+    }
+
+    /// Phase 3 of two-phase assembly: finalize state after assembly.
+    ///
+    /// Must be called WITH the lock held after phase 2 completes.
+    pub fn complete_assembly(
+        &mut self,
+        request_id: RequestId,
+        success: bool,
+    ) -> Result<(), ErrCode> {
+        let session = self.sessions.get_mut(&request_id)
+            .ok_or(ErrCode::InvalidRequest)?;
+
+        match session.state {
+            TransferState::Assembling => {
+                if success {
+                    session.state = TransferState::Verified;
+                } else {
+                    session.state = TransferState::Failed(ErrCode::InvalidRequest);
+                }
+                self.active_reassemblies = self.active_reassemblies.saturating_sub(1);
+                Ok(())
+            }
+            _ => Err(ErrCode::InvalidRequest),
+        }
+    }
+
+    /// Mark a session as Stored after blob has been committed.
+    pub fn mark_stored(&mut self, request_id: RequestId) {
+        if let Some(session) = self.sessions.get_mut(&request_id) {
+            if matches!(session.state, TransferState::Verified) {
+                session.state = TransferState::Stored;
+            }
+        }
+    }
+
+    /// Clean up a session: remove from registry, delete temp dir, update counters.
+    pub fn cleanup_session(&mut self, request_id: RequestId) {
+        if let Some(session) = self.sessions.remove(&request_id) {
+            // Decrement per-peer counter
+            if let Some(count) = self.per_peer_counts.get_mut(&session.requester_did) {
+                *count = count.saturating_sub(1);
+                if *count == 0 {
+                    self.per_peer_counts.remove(&session.requester_did);
+                }
+            }
+
+            // Clean up temp directory
+            let session_dir = self.session_dir(&request_id);
+            if session_dir.exists() {
+                if let Err(e) = std::fs::remove_dir_all(&session_dir) {
+                    warn!(
+                        request_id = %hex::encode(request_id),
+                        error = %e,
+                        "Failed to clean up partial dir"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Clean up all expired sessions. Returns count of cleaned sessions.
+    pub fn cleanup_expired(&mut self, now: u64) -> usize {
+        let expired: Vec<RequestId> = self.sessions.iter()
+            .filter(|(_, s)| s.expires_at > 0 && now > s.expires_at)
+            .map(|(id, _)| *id)
+            .collect();
+
+        let count = expired.len();
+        for id in expired {
+            // If assembling, decrement counter
+            if let Some(s) = self.sessions.get(&id) {
+                if matches!(s.state, TransferState::Assembling) {
+                    self.active_reassemblies = self.active_reassemblies.saturating_sub(1);
+                }
+            }
+            self.cleanup_session(id);
+        }
+        count
+    }
+
+    /// Get session metadata (for creating receipts etc.)
+    pub fn get_session(&self, request_id: &RequestId) -> Option<&TransferSession> {
+        self.sessions.get(request_id)
+    }
+
+    /// Number of active sessions
+    #[cfg(test)]
+    pub fn session_count(&self) -> usize {
+        self.sessions.len()
+    }
+
+    /// Number of active reassemblies
+    #[cfg(test)]
+    pub fn active_reassemblies(&self) -> usize {
+        self.active_reassemblies
+    }
+
+    /// Number of active sessions for a specific peer
+    #[cfg(test)]
+    pub fn peer_request_count(&self, peer: &Did) -> usize {
+        self.per_peer_counts.get(peer).copied().unwrap_or(0)
+    }
+
+    // --- Internal helpers ---
+
+    fn session_dir(&self, request_id: &RequestId) -> PathBuf {
+        self.partial_dir.join(hex::encode(request_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use icn_identity::KeyPair;
+
+    fn make_did() -> Did {
+        KeyPair::generate().unwrap().did().clone()
+    }
+
+    fn make_manager(dir: &Path) -> TransferSessionManager {
+        TransferSessionManager::new(dir.to_path_buf())
+    }
+
+    fn start_session(
+        manager: &mut TransferSessionManager,
+        blob_hash: ContentHash,
+        provider: &Did,
+        requester: &Did,
+    ) -> RequestId {
+        manager.start_request(
+            blob_hash,
+            vec![provider.clone()],
+            requester.clone(),
+            "test-scope".to_string(),
+            u64::MAX, // far future
+        ).expect("start_request should succeed")
+    }
+
+    fn make_chunk_data(index: u32) -> Vec<u8> {
+        let mut data = vec![0u8; 1024];
+        data[0..4].copy_from_slice(&index.to_be_bytes());
+        data
+    }
+
+    fn blob_hash_for_chunks(total_chunks: u32) -> ContentHash {
+        let mut assembled = Vec::new();
+        for i in 0..total_chunks {
+            assembled.extend_from_slice(&make_chunk_data(i));
+        }
+        *blake3::hash(&assembled).as_bytes()
+    }
+
+    #[test]
+    fn state_machine_transitions_correctly() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut mgr = make_manager(tmp.path());
+        let provider = make_did();
+        let requester = make_did();
+
+        let total_chunks = 3u32;
+        let blob_hash = blob_hash_for_chunks(total_chunks);
+        let rid = start_session(&mut mgr, blob_hash, &provider, &requester);
+
+        // Initially Requested
+        assert!(matches!(mgr.get_session(&rid).unwrap().state, TransferState::Requested));
+
+        // First chunk → Receiving
+        let data0 = make_chunk_data(0);
+        let r = mgr.receive_chunk(rid, &provider, 0, total_chunks, total_chunks as u64 * 1024, &data0);
+        assert_eq!(r.unwrap(), ChunkResult::Accepted);
+        assert!(matches!(mgr.get_session(&rid).unwrap().state, TransferState::Receiving { .. }));
+
+        // Second chunk → still Receiving
+        let data1 = make_chunk_data(1);
+        let r = mgr.receive_chunk(rid, &provider, 1, total_chunks, total_chunks as u64 * 1024, &data1);
+        assert_eq!(r.unwrap(), ChunkResult::Accepted);
+
+        // Third chunk → AllChunksReceived
+        let data2 = make_chunk_data(2);
+        let r = mgr.receive_chunk(rid, &provider, 2, total_chunks, total_chunks as u64 * 1024, &data2);
+        assert_eq!(r.unwrap(), ChunkResult::AllChunksReceived);
+
+        // Begin assembly → Assembling
+        let job = mgr.begin_assembly(rid).unwrap();
+        assert!(matches!(mgr.get_session(&rid).unwrap().state, TransferState::Assembling));
+        assert_eq!(mgr.active_reassemblies(), 1);
+
+        // Execute assembly (reads files, verifies hash)
+        let assembled = job.execute().unwrap();
+        assert_eq!(assembled.len(), total_chunks as usize * 1024);
+
+        // Complete assembly → Verified
+        mgr.complete_assembly(rid, true).unwrap();
+        assert!(matches!(mgr.get_session(&rid).unwrap().state, TransferState::Verified));
+        assert_eq!(mgr.active_reassemblies(), 0);
+
+        // Mark stored → Stored
+        mgr.mark_stored(rid);
+        assert!(matches!(mgr.get_session(&rid).unwrap().state, TransferState::Stored));
+
+        // Cleanup
+        mgr.cleanup_session(rid);
+        assert_eq!(mgr.session_count(), 0);
+    }
+
+    #[test]
+    fn reject_chunk_before_request() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut mgr = make_manager(tmp.path());
+        let sender = make_did();
+
+        let result = mgr.receive_chunk([0xFF; 32], &sender, 0, 5, 5000, &[0u8; 100]);
+        assert_eq!(result.unwrap_err(), ErrCode::InvalidRequest);
+    }
+
+    #[test]
+    fn reject_wrong_provider() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut mgr = make_manager(tmp.path());
+        let provider = make_did();
+        let requester = make_did();
+        let wrong_sender = make_did();
+
+        let rid = start_session(&mut mgr, [0xAA; 32], &provider, &requester);
+
+        let result = mgr.receive_chunk(rid, &wrong_sender, 0, 1, 1024, &[0u8; 100]);
+        assert_eq!(result.unwrap_err(), ErrCode::Forbidden);
+    }
+
+    #[test]
+    fn reject_expired() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut mgr = make_manager(tmp.path());
+        let provider = make_did();
+        let requester = make_did();
+
+        // Start with expires_at in the past
+        let rid = mgr.start_request(
+            [0xAA; 32],
+            vec![provider.clone()],
+            requester.clone(),
+            "test".to_string(),
+            1, // 1 second after epoch = expired
+        ).unwrap();
+
+        let result = mgr.receive_chunk(rid, &provider, 0, 1, 1024, &[0u8; 100]);
+        assert_eq!(result.unwrap_err(), ErrCode::Expired);
+    }
+
+    #[test]
+    fn reject_total_size_oversize() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut mgr = make_manager(tmp.path());
+        let provider = make_did();
+        let requester = make_did();
+
+        let rid = start_session(&mut mgr, [0xAA; 32], &provider, &requester);
+
+        let result = mgr.receive_chunk(
+            rid, &provider, 0, 200,
+            MAX_BLOB_SIZE + 1, // Over 10 MB
+            &[0u8; 100],
+        );
+        assert_eq!(result.unwrap_err(), ErrCode::Oversize);
+    }
+
+    #[test]
+    fn enforce_max_concurrent_reassemblies() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut mgr = make_manager(tmp.path());
+
+        // Fill up reassembly slots. Use multiple requesters to avoid
+        // hitting the per-peer limit (MAX_REQUESTS_PER_PEER = 8).
+        for i in 0..MAX_CONCURRENT_REASSEMBLIES {
+            let provider = make_did();
+            let requester = make_did(); // fresh requester each time
+            let _ = i;
+            let data = make_chunk_data(0);
+            let expected_hash = *blake3::hash(&data).as_bytes();
+            let rid = start_session(&mut mgr, expected_hash, &provider, &requester);
+
+            mgr.receive_chunk(rid, &provider, 0, 1, data.len() as u64, &data).unwrap();
+            mgr.begin_assembly(rid).unwrap();
+        }
+
+        assert_eq!(mgr.active_reassemblies(), MAX_CONCURRENT_REASSEMBLIES);
+
+        // One more should fail with Busy at begin_assembly
+        let provider = make_did();
+        let requester = make_did();
+        let data = make_chunk_data(99);
+        let expected_hash = *blake3::hash(&data).as_bytes();
+        let rid = start_session(&mut mgr, expected_hash, &provider, &requester);
+        mgr.receive_chunk(rid, &provider, 0, 1, data.len() as u64, &data).unwrap();
+
+        let result = mgr.begin_assembly(rid);
+        assert_eq!(result.unwrap_err(), ErrCode::Busy);
+    }
+
+    #[test]
+    fn cleanup_on_expiry_deletes_temp_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut mgr = make_manager(tmp.path());
+        let provider = make_did();
+        let requester = make_did();
+
+        // Start with near-future expiry
+        let rid = mgr.start_request(
+            [0xAA; 32],
+            vec![provider.clone()],
+            requester.clone(),
+            "test".to_string(),
+            100, // expires at 100 seconds
+        ).unwrap();
+
+        let session_dir = tmp.path().join(hex::encode(rid));
+        assert!(session_dir.exists());
+
+        // Cleanup with now=200 (past expiry)
+        let cleaned = mgr.cleanup_expired(200);
+        assert_eq!(cleaned, 1);
+        assert_eq!(mgr.session_count(), 0);
+        assert!(!session_dir.exists());
+    }
+
+    #[test]
+    fn receipt_hash_stable_across_runs() {
+        use icn_kernel_api::proofs::ArtifactReceipt;
+
+        let r1 = ArtifactReceipt::new(
+            [0xAA; 32],
+            "did:icn:provider".to_string(),
+            "did:icn:requester".to_string(),
+            [0xBB; 32],
+            "coop:scope".to_string(),
+            1700000000,
+        );
+        let r2 = ArtifactReceipt::new(
+            [0xAA; 32],
+            "did:icn:provider".to_string(),
+            "did:icn:requester".to_string(),
+            [0xBB; 32],
+            "coop:scope".to_string(),
+            1700000000,
+        );
+
+        assert_eq!(r1.receipt_hash, r2.receipt_hash);
+        assert!(r1.verify_binding());
+        assert!(r2.verify_binding());
+    }
+
+    #[test]
+    fn per_peer_request_limit_enforced() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut mgr = make_manager(tmp.path());
+        let requester = make_did();
+
+        // Fill up per-peer slots
+        for i in 0..MAX_REQUESTS_PER_PEER {
+            let provider = make_did();
+            let mut blob_hash = [0u8; 32];
+            blob_hash[0] = i as u8;
+            mgr.start_request(
+                blob_hash,
+                vec![provider],
+                requester.clone(),
+                "test".to_string(),
+                u64::MAX,
+            ).unwrap();
+        }
+
+        assert_eq!(mgr.peer_request_count(&requester), MAX_REQUESTS_PER_PEER);
+
+        // One more should fail with Busy
+        let result = mgr.start_request(
+            [0xFF; 32],
+            vec![make_did()],
+            requester.clone(),
+            "test".to_string(),
+            u64::MAX,
+        );
+        assert_eq!(result.unwrap_err(), ErrCode::Busy);
+    }
+
+    #[test]
+    fn assemble_verifies_blob_hash_match_and_mismatch() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Test match: correct hash
+        {
+            let mut mgr = make_manager(tmp.path());
+            let provider = make_did();
+            let requester = make_did();
+
+            let data = make_chunk_data(0);
+            let correct_hash = *blake3::hash(&data).as_bytes();
+            let rid = start_session(&mut mgr, correct_hash, &provider, &requester);
+            mgr.receive_chunk(rid, &provider, 0, 1, data.len() as u64, &data).unwrap();
+
+            let job = mgr.begin_assembly(rid).unwrap();
+            let result = job.execute();
+            assert!(result.is_ok());
+            assert_eq!(result.unwrap(), data);
+        }
+
+        // Test mismatch: wrong hash
+        {
+            let mut mgr = make_manager(tmp.path());
+            let provider = make_did();
+            let requester = make_did();
+
+            let data = make_chunk_data(0);
+            let wrong_hash = [0xFF; 32]; // doesn't match data
+            let rid = start_session(&mut mgr, wrong_hash, &provider, &requester);
+            mgr.receive_chunk(rid, &provider, 0, 1, data.len() as u64, &data).unwrap();
+
+            let job = mgr.begin_assembly(rid).unwrap();
+            let result = job.execute();
+            assert_eq!(result.unwrap_err(), ErrCode::InvalidRequest);
+        }
+    }
+}

--- a/icn/crates/icn-gossip/src/handlers/blob_transfer_state.rs
+++ b/icn/crates/icn-gossip/src/handlers/blob_transfer_state.rs
@@ -214,10 +214,7 @@ impl TransferSessionManager {
         }
 
         // Generate request_id from blake3(blob_hash || requester_did || timestamp)
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos() as u64)
-            .unwrap_or(0);
+        let now = icn_time::current_timestamp_nanos() as u64;
         let mut hasher = blake3::Hasher::new();
         hasher.update(&blob_hash);
         hasher.update(requester_did.as_str().as_bytes());
@@ -284,10 +281,7 @@ impl TransferSessionManager {
             .ok_or(ErrCode::InvalidRequest)?;
 
         // Check expiry
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+        let now = icn_time::current_timestamp_secs();
         if session.expires_at > 0 && now > session.expires_at {
             session.state = TransferState::Failed(ErrCode::Expired);
             return Err(ErrCode::Expired);

--- a/icn/crates/icn-gossip/src/handlers/mod.rs
+++ b/icn/crates/icn-gossip/src/handlers/mod.rs
@@ -15,6 +15,7 @@
 
 pub mod blob_nonce_guard;
 pub mod blob_transfer;
+pub mod blob_transfer_state;
 mod bloom;
 mod dispatch;
 mod partition;

--- a/icn/crates/icn-kernel-api/src/lib.rs
+++ b/icn/crates/icn-kernel-api/src/lib.rs
@@ -39,9 +39,9 @@ pub mod compute;
 pub mod coord;
 pub mod error;
 pub mod events;
-pub mod proofs;
 pub mod identity;
 pub mod naming;
+pub mod proofs;
 pub mod protocol_params;
 pub mod scope;
 pub mod services;
@@ -64,12 +64,12 @@ pub use comms::{PubSub, RequestResponse, Streams};
 pub use compute::{ComputeEngine, Job, Trigger};
 pub use coord::Coordination;
 pub use error::{ErrCode, IcnError};
-pub use proofs::ArtifactReceipt;
 pub use events::{EventCallback, EventEmitter, SystemEvent};
 pub use identity::{DidResolver, IdentityService, Keystore};
 pub use naming::{
     Discovery, EndpointType, NamingService, ScopedDiscovery, ServiceEndpoint, ServiceEndpointId,
 };
+pub use proofs::ArtifactReceipt;
 pub use scope::{CellId, MockCellService, ScopeLevel};
 pub use services::{
     CellService, GovernanceEvent, GovernanceService, LedgerEvent, LedgerService, SecurityService,

--- a/icn/crates/icn-kernel-api/src/lib.rs
+++ b/icn/crates/icn-kernel-api/src/lib.rs
@@ -39,6 +39,7 @@ pub mod compute;
 pub mod coord;
 pub mod error;
 pub mod events;
+pub mod proofs;
 pub mod identity;
 pub mod naming;
 pub mod protocol_params;
@@ -63,6 +64,7 @@ pub use comms::{PubSub, RequestResponse, Streams};
 pub use compute::{ComputeEngine, Job, Trigger};
 pub use coord::Coordination;
 pub use error::{ErrCode, IcnError};
+pub use proofs::ArtifactReceipt;
 pub use events::{EventCallback, EventEmitter, SystemEvent};
 pub use identity::{DidResolver, IdentityService, Keystore};
 pub use naming::{

--- a/icn/crates/icn-kernel-api/src/proofs.rs
+++ b/icn/crates/icn-kernel-api/src/proofs.rs
@@ -77,11 +77,19 @@ impl ArtifactReceipt {
         }
     }
 
+    /// Domain separation tag for receipt hashes.
+    ///
+    /// Prevents cross-protocol hash collisions if the same field layout is
+    /// reused in another proof type.
+    pub const DOMAIN_TAG: &[u8] = b"icn:artifact-receipt:v1";
+
     /// Compute the binding hash from the significant fields.
     ///
     /// This is a pure function used by `new()` and `verify_binding()`.
     /// Variable-length fields are length-prefixed (u64 LE) to prevent
     /// collision attacks from redistributing bytes between adjacent fields.
+    /// The domain separation tag is hashed first to prevent cross-protocol
+    /// collisions.
     pub fn compute_receipt_hash(
         request_id: &[u8; 32],
         blob_hash: &Hash,
@@ -90,6 +98,8 @@ impl ArtifactReceipt {
         scope_id: &str,
     ) -> Hash {
         let mut hasher = blake3::Hasher::new();
+        // Domain separation: prevents hash collisions with other proof types
+        hasher.update(Self::DOMAIN_TAG);
         // Fixed-length fields: no prefix needed
         hasher.update(request_id);
         hasher.update(blob_hash);
@@ -186,6 +196,28 @@ mod tests {
     fn signature_starts_empty() {
         let receipt = make_receipt();
         assert!(receipt.signature.as_bytes().is_empty());
+    }
+
+    #[test]
+    fn domain_tag_is_part_of_hash() {
+        // Compute the receipt hash the normal way (with domain tag)
+        let receipt = make_receipt();
+        let with_tag = receipt.receipt_hash;
+
+        // Compute manually without domain tag — must differ
+        let mut hasher = blake3::Hasher::new();
+        // Deliberately omit: hasher.update(ArtifactReceipt::DOMAIN_TAG);
+        hasher.update(&receipt.request_id);
+        hasher.update(&receipt.blob_hash);
+        hasher.update(&(receipt.requester_did.len() as u64).to_le_bytes());
+        hasher.update(receipt.requester_did.as_bytes());
+        hasher.update(&(receipt.provider_did.len() as u64).to_le_bytes());
+        hasher.update(receipt.provider_did.as_bytes());
+        hasher.update(&(receipt.scope_id.len() as u64).to_le_bytes());
+        hasher.update(receipt.scope_id.as_bytes());
+        let without_tag: Hash = *hasher.finalize().as_bytes();
+
+        assert_ne!(with_tag, without_tag, "domain tag must affect hash output");
     }
 
     #[test]

--- a/icn/crates/icn-kernel-api/src/proofs.rs
+++ b/icn/crates/icn-kernel-api/src/proofs.rs
@@ -1,0 +1,184 @@
+//! Proof artifacts for the ICN legitimacy architecture.
+//!
+//! Every significant state change in ICN produces a content-addressed,
+//! signed proof artifact. These proofs enable anyone to verify outcomes
+//! without trusting any party.
+//!
+//! # Artifact Types (v0 Set)
+//!
+//! - `ArtifactReceipt` — proves a blob transfer completed and verified (PR2c)
+//!
+//! # Self-Authenticating Design
+//!
+//! Each receipt contains a `receipt_hash` computed at construction time via
+//! blake3 binding of all significant fields. `verify_binding()` recomputes
+//! from fields and compares, enabling tamper detection without external context.
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::{Did, Hash, Signature};
+
+/// Proof that a blob transfer completed and the content was verified.
+///
+/// Produced by the requester after all chunks are received, reassembled,
+/// and the final blake3 hash matches the declared `blob_hash`.
+///
+/// The `receipt_hash` is self-authenticating: it is computed from the
+/// binding fields at construction and can be re-verified at any time
+/// via `verify_binding()`.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactReceipt {
+    /// blake3 hash of the complete blob
+    pub blob_hash: Hash,
+    /// DID of the node that served the blob
+    pub provider_did: Did,
+    /// DID of the node that requested and verified the blob
+    pub requester_did: Did,
+    /// Nonce binding this receipt to the originating request
+    pub request_id: [u8; 32],
+    /// Scope identifier for this transfer.
+    /// TODO: Converge with canonical ScopeId type once available in kernel-api.
+    /// Currently ScopeId lives only in icn-trust (domain crate, cannot import here).
+    pub scope_id: String,
+    /// Unix timestamp (seconds) when verification completed
+    pub verified_at: u64,
+    /// blake3 binding hash of all significant fields, computed at construction
+    pub receipt_hash: Hash,
+    /// Signature by the requester (empty until signed)
+    pub signature: Signature,
+}
+
+impl ArtifactReceipt {
+    /// Create a new receipt with computed binding hash and empty signature.
+    pub fn new(
+        blob_hash: Hash,
+        provider_did: Did,
+        requester_did: Did,
+        request_id: [u8; 32],
+        scope_id: String,
+        verified_at: u64,
+    ) -> Self {
+        let receipt_hash = Self::compute_receipt_hash(
+            &request_id,
+            &blob_hash,
+            &requester_did,
+            &provider_did,
+            &scope_id,
+        );
+        Self {
+            blob_hash,
+            provider_did,
+            requester_did,
+            request_id,
+            scope_id,
+            verified_at,
+            receipt_hash,
+            signature: Signature::new(Vec::new()),
+        }
+    }
+
+    /// Compute the binding hash from the significant fields.
+    ///
+    /// This is a pure function used by `new()` and `verify_binding()`.
+    /// The hash commits to: request_id || blob_hash || requester_did || provider_did || scope_id
+    pub fn compute_receipt_hash(
+        request_id: &[u8; 32],
+        blob_hash: &Hash,
+        requester_did: &Did,
+        provider_did: &Did,
+        scope_id: &str,
+    ) -> Hash {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(request_id);
+        hasher.update(blob_hash);
+        hasher.update(requester_did.as_bytes());
+        hasher.update(provider_did.as_bytes());
+        hasher.update(scope_id.as_bytes());
+        *hasher.finalize().as_bytes()
+    }
+
+    /// Verify that the stored `receipt_hash` matches a fresh computation.
+    ///
+    /// Returns `true` if the receipt has not been tampered with.
+    pub fn verify_binding(&self) -> bool {
+        let recomputed = Self::compute_receipt_hash(
+            &self.request_id,
+            &self.blob_hash,
+            &self.requester_did,
+            &self.provider_did,
+            &self.scope_id,
+        );
+        self.receipt_hash == recomputed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_receipt() -> ArtifactReceipt {
+        ArtifactReceipt::new(
+            [0xAA; 32],
+            "did:icn:provider123".to_string(),
+            "did:icn:requester456".to_string(),
+            [0xBB; 32],
+            "coop:test-scope".to_string(),
+            1700000000,
+        )
+    }
+
+    #[test]
+    fn receipt_hash_determinism() {
+        let r1 = make_receipt();
+        let r2 = make_receipt();
+        assert_eq!(r1.receipt_hash, r2.receipt_hash);
+        assert_ne!(r1.receipt_hash, [0u8; 32]);
+    }
+
+    #[test]
+    fn verify_binding_succeeds_for_fresh_receipt() {
+        let receipt = make_receipt();
+        assert!(receipt.verify_binding());
+    }
+
+    #[test]
+    fn tamper_blob_hash_detected() {
+        let mut receipt = make_receipt();
+        receipt.blob_hash = [0xFF; 32];
+        assert!(!receipt.verify_binding());
+    }
+
+    #[test]
+    fn tamper_provider_did_detected() {
+        let mut receipt = make_receipt();
+        receipt.provider_did = "did:icn:attacker".to_string();
+        assert!(!receipt.verify_binding());
+    }
+
+    #[test]
+    fn tamper_requester_did_detected() {
+        let mut receipt = make_receipt();
+        receipt.requester_did = "did:icn:attacker".to_string();
+        assert!(!receipt.verify_binding());
+    }
+
+    #[test]
+    fn tamper_request_id_detected() {
+        let mut receipt = make_receipt();
+        receipt.request_id = [0xFF; 32];
+        assert!(!receipt.verify_binding());
+    }
+
+    #[test]
+    fn tamper_scope_id_detected() {
+        let mut receipt = make_receipt();
+        receipt.scope_id = "evil-scope".to_string();
+        assert!(!receipt.verify_binding());
+    }
+
+    #[test]
+    fn signature_starts_empty() {
+        let receipt = make_receipt();
+        assert!(receipt.signature.as_bytes().is_empty());
+    }
+}

--- a/icn/crates/icn-kernel-api/src/proofs.rs
+++ b/icn/crates/icn-kernel-api/src/proofs.rs
@@ -80,7 +80,8 @@ impl ArtifactReceipt {
     /// Compute the binding hash from the significant fields.
     ///
     /// This is a pure function used by `new()` and `verify_binding()`.
-    /// The hash commits to: request_id || blob_hash || requester_did || provider_did || scope_id
+    /// Variable-length fields are length-prefixed (u64 LE) to prevent
+    /// collision attacks from redistributing bytes between adjacent fields.
     pub fn compute_receipt_hash(
         request_id: &[u8; 32],
         blob_hash: &Hash,
@@ -89,10 +90,15 @@ impl ArtifactReceipt {
         scope_id: &str,
     ) -> Hash {
         let mut hasher = blake3::Hasher::new();
+        // Fixed-length fields: no prefix needed
         hasher.update(request_id);
         hasher.update(blob_hash);
+        // Variable-length fields: length-prefix each one
+        hasher.update(&(requester_did.len() as u64).to_le_bytes());
         hasher.update(requester_did.as_bytes());
+        hasher.update(&(provider_did.len() as u64).to_le_bytes());
         hasher.update(provider_did.as_bytes());
+        hasher.update(&(scope_id.len() as u64).to_le_bytes());
         hasher.update(scope_id.as_bytes());
         *hasher.finalize().as_bytes()
     }
@@ -180,5 +186,30 @@ mod tests {
     fn signature_starts_empty() {
         let receipt = make_receipt();
         assert!(receipt.signature.as_bytes().is_empty());
+    }
+
+    #[test]
+    fn length_prefix_prevents_field_collision() {
+        // Without length prefixes, these two would hash identically because
+        // the concatenation of provider_did || scope_id is the same bytes.
+        let r1 = ArtifactReceipt::new(
+            [0xAA; 32],
+            "did:icn:ABC".to_string(),
+            "did:icn:requester".to_string(),
+            [0xBB; 32],
+            "XYZ".to_string(),
+            1700000000,
+        );
+        let r2 = ArtifactReceipt::new(
+            [0xAA; 32],
+            "did:icn:ABCXYZ".to_string(),
+            "did:icn:requester".to_string(),
+            [0xBB; 32],
+            "".to_string(),
+            1700000000,
+        );
+        assert_ne!(r1.receipt_hash, r2.receipt_hash);
+        assert!(r1.verify_binding());
+        assert!(r2.verify_binding());
     }
 }


### PR DESCRIPTION
## Summary

Implements the blob transfer session lifecycle (PR2c) that turns signed chunks into a verified artifact with an `ArtifactReceipt` proof. Builds on PR2a (#1104, message types) and PR2b (#1106, nonce replay guard).

### What's included

- **ArtifactReceipt proof type** (`icn-kernel-api/src/proofs.rs`): Self-authenticating receipt with blake3 binding hash, tamper detection via `verify_binding()`, signed by requester
- **TransferSessionManager** (`icn-gossip/src/handlers/blob_transfer_state.rs`): Monotonic state machine (Requested → Receiving → Assembling → Verified → Stored / Failed) with resource bounds (8 max/peer, 16 concurrent reassemblies, 64KB chunks, 10MB max blob)
- **Handler wiring** (`icn-gossip/src/handlers/blob_transfer.rs`): Provider serves chunks from BlobService; requester feeds into state machine with two-phase assembly (lock→mark→unlock→IO→lock→finalize)

### Key design decisions

- **Two-phase assembly**: Prevents stalling chunk handling during disk IO + hash verification
- **Self-authenticating receipts**: `receipt_hash` computed at construction via blake3, `verify_binding()` recomputes for tamper detection
- **All rejections use stable ErrCode**: No new error codes added (InvalidRequest, Forbidden, Expired, Oversize, Busy)
- **Per-peer resource limits**: MAX_REQUESTS_PER_PEER=8, MAX_CONCURRENT_REASSEMBLIES=16

## Commits

1. `feat(kernel-api): add ArtifactReceipt proof type` — 8 tests
2. `feat(gossip): add blob transfer state machine` — 10 tests
3. `feat(gossip): wire transfer state machine into blob handlers` — 2 integration tests

## Invariants checklist

- [x] **Adversarial-by-default**: Per-peer limits, nonce replay guard, chunk hash verification, blob hash verification on assembly, expired session cleanup
- [x] **Determinism**: Receipt hash is deterministic (blake3 over canonical field ordering)
- [x] **Canonical encodings**: ContentHash = [u8; 32] in gossip, Hash = [u8; 32] in kernel-api
- [x] **No panics**: All error paths return Result with ErrCode, no unwrap/expect in protocol paths
- [x] **Kernel/app boundary**: ArtifactReceipt in kernel-api uses generic types (Hash, Did, Signature), no domain imports

## Test plan

- [x] `cargo test -p icn-kernel-api` — 148 tests pass (8 new proof tests)
- [x] `cargo test -p icn-gossip` — 211 tests pass (10 new state machine + 2 new integration)
- [x] `cargo clippy -p icn-kernel-api -p icn-gossip --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Risk

- `send_callback` visibility changed from private to `pub(crate)` — only accessible within the gossip crate
- GossipActor gains two new optional fields (blob_store, transfer_manager) — initialized as None, no behavioral change without explicit setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)