### PR TITLE
feat(governance): wire GovernanceProof into proposal close

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -3189,6 +3189,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "ed25519-dalek",
+ "hex",
  "icn-entity",
  "icn-gossip",
  "icn-governance",

--- a/icn/apps/governance/Cargo.toml
+++ b/icn/apps/governance/Cargo.toml
@@ -31,6 +31,10 @@ icn-obs = { path = "../../crates/icn-obs" }
 # Time utilities
 icn-time = { path = "../../crates/icn-time" }
 
+# Cryptography (for GovernanceProof signing)
+ed25519-dalek.workspace = true
+hex = "0.4"
+
 # Error handling
 anyhow = "1.0"
 

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -11,7 +11,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, RwLock};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use icn_gossip::GossipActor;
 use icn_identity::Did;
@@ -302,7 +302,18 @@ impl GovernanceHandle {
         let actor = self.inner.read().await;
         let proof_key = format!("governance:proof:{}", proposal_id.0);
         match actor.store.get(proof_key.as_bytes())? {
-            Some(bytes) => Ok(Some(serde_json::from_slice(&bytes)?)),
+            Some(bytes) => match serde_json::from_slice(&bytes) {
+                Ok(proof) => Ok(Some(proof)),
+                Err(err) => {
+                    // Treat invalid/malformed stored proofs as missing to avoid
+                    // poisoning the gateway call path with persistent 500 errors
+                    warn!(
+                        "Failed to deserialize GovernanceProof for {}: {}",
+                        proposal_id.0, err
+                    );
+                    Ok(None)
+                }
+            },
             None => Ok(None),
         }
     }
@@ -2360,11 +2371,67 @@ fn handle_incoming(store: &dyn Store, msg: GovernanceMessage) -> Result<()> {
                 proposal.close(new_state)?;
                 store.put(&proposal_key(&id), &serde_json::to_vec(&proposal)?)?;
             }
-            // Persist proof from remote node (if included)
+            // Persist proof from remote node (if included and valid)
             if let Some(bytes) = proof_bytes {
                 let proof_key = format!("governance:proof:{}", id.0);
-                store.put(proof_key.as_bytes(), &bytes)?;
-                info!("Stored governance proof from remote for proposal {}", id.0);
+
+                // Don't overwrite a locally-generated proof with a remote one
+                if store.get(proof_key.as_bytes())?.is_some() {
+                    debug!(
+                        "Skipping remote proof for proposal {} — local proof already exists",
+                        id.0
+                    );
+                } else {
+                    // Validate remote proof before storing (untrusted gossip input)
+                    match serde_json::from_slice::<icn_governance::GovernanceProof>(&bytes) {
+                        Ok(proof) => {
+                            // Verify binding hash (tamper check)
+                            if !proof.verify_binding() {
+                                warn!(
+                                    "Rejected remote proof for proposal {} — binding hash mismatch",
+                                    id.0
+                                );
+                            } else if proof.proposal_id != id.0 {
+                                warn!(
+                                    "Rejected remote proof — proposal_id mismatch: expected {}, got {}",
+                                    id.0, proof.proposal_id
+                                );
+                            } else {
+                                // Verify signature via DID resolution
+                                match Did::from_str(&proof.signer_did)
+                                    .and_then(|did| did.to_verifying_key())
+                                {
+                                    Ok(vk) => {
+                                        if proof.verify_signature(&vk) {
+                                            store.put(proof_key.as_bytes(), &bytes)?;
+                                            info!(
+                                                "Stored validated governance proof from remote for proposal {}",
+                                                id.0
+                                            );
+                                        } else {
+                                            warn!(
+                                                "Rejected remote proof for proposal {} — invalid signature",
+                                                id.0
+                                            );
+                                        }
+                                    }
+                                    Err(e) => {
+                                        warn!(
+                                            "Rejected remote proof for proposal {} — cannot resolve signer DID: {}",
+                                            id.0, e
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            warn!(
+                                "Rejected remote proof for proposal {} — invalid JSON: {}",
+                                id.0, e
+                            );
+                        }
+                    }
+                }
             }
         }
 

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -294,6 +294,19 @@ impl GovernanceHandle {
         self.inner.read().await.get_voter_dids(proposal_id)
     }
 
+    /// Get the GovernanceProof for a closed proposal (if one was generated)
+    pub async fn get_proof(
+        &self,
+        proposal_id: &ProposalId,
+    ) -> Result<Option<icn_governance::GovernanceProof>> {
+        let actor = self.inner.read().await;
+        let proof_key = format!("governance:proof:{}", proposal_id.0);
+        match actor.store.get(proof_key.as_bytes())? {
+            Some(bytes) => Ok(Some(serde_json::from_slice(&bytes)?)),
+            None => Ok(None),
+        }
+    }
+
     /// Start deliberation period for a proposal
     ///
     /// Transitions the proposal from Draft to Deliberation state.
@@ -861,6 +874,13 @@ impl icn_governance::GovernanceOps for GovernanceHandle {
         Self::get_voter_dids(self, proposal_id).await
     }
 
+    async fn get_proof(
+        &self,
+        proposal_id: &ProposalId,
+    ) -> Result<Option<icn_governance::GovernanceProof>> {
+        Self::get_proof(self, proposal_id).await
+    }
+
     // Protocol parameter operations (Phase 20)
 
     async fn list_protocol_parameters(&self) -> Result<Vec<ProtocolParameter>> {
@@ -897,6 +917,8 @@ pub struct GovernanceActor {
     event_bus: Option<Arc<dyn EventEmitter>>,
     /// Protocol parameter store for governable parameters (Phase 20)
     protocol_params: Option<Arc<dyn ProtocolParameterStore>>,
+    /// Ed25519 signing key for generating GovernanceProofs
+    signing_key: Option<Arc<ed25519_dalek::SigningKey>>,
 }
 
 impl GovernanceActor {
@@ -907,6 +929,7 @@ impl GovernanceActor {
         gossip: Arc<RwLock<GossipActor>>,
         resolver: Arc<dyn MembershipResolver + Send + Sync>,
         event_bus: Option<Arc<dyn EventEmitter>>,
+        signing_key: Option<Arc<ed25519_dalek::SigningKey>>,
     ) -> Result<GovernanceHandle> {
         info!("Spawning GovernanceActor for DID: {}", did);
 
@@ -959,6 +982,7 @@ impl GovernanceActor {
             cancel_tx,
             event_bus,
             protocol_params: None,
+            signing_key,
         };
 
         let handle = GovernanceHandle {
@@ -1425,9 +1449,12 @@ impl GovernanceActor {
                     .load_domain(&proposal.domain_id)?
                     .ok_or_else(|| anyhow::anyhow!("Domain not found: {}", proposal.domain_id.0))?;
 
-                // Load and tally votes
+                // Load and tally votes (keep votes for proof generation)
                 let votes = self.load_votes(&proposal_id)?;
-                let tally = VoteTally::from(votes);
+                let mut tally = VoteTally::empty();
+                for v in &votes {
+                    tally.add_vote(v);
+                }
 
                 // Resolve eligible membership
                 let eligible_count = self.resolver.member_count(&domain)?;
@@ -1498,6 +1525,44 @@ impl GovernanceActor {
                 self.store
                     .put(&proposal_key(&proposal_id), &serde_json::to_vec(&proposal)?)?;
 
+                // Generate GovernanceProof if signing key is available
+                let proof_bytes = if let Some(ref signing_key) = self.signing_key {
+                    use icn_governance::ProofOutcome;
+
+                    let proof_outcome = match outcome_result {
+                        DecisionOutcome::Accepted => ProofOutcome::Accepted,
+                        DecisionOutcome::Rejected => ProofOutcome::Rejected,
+                        DecisionOutcome::NoQuorum => ProofOutcome::NoQuorum,
+                    };
+
+                    let mut proof = icn_governance::GovernanceProof::new(
+                        proposal_id.0.clone(),
+                        proposal.domain_id.0.clone(),
+                        proof_outcome,
+                        tally.clone(),
+                        &votes,
+                        now,
+                        self.did.to_string(),
+                    );
+                    proof.sign(signing_key);
+
+                    let serialized = serde_json::to_vec(&proof)?;
+
+                    // Persist proof for later retrieval
+                    let proof_key = format!("governance:proof:{}", proposal_id.0);
+                    self.store.put(proof_key.as_bytes(), &serialized)?;
+
+                    info!(
+                        "GovernanceProof signed for proposal {} (hash: {})",
+                        proposal_id.0,
+                        hex::encode(proof.proof_hash)
+                    );
+
+                    Some(serialized)
+                } else {
+                    None
+                };
+
                 // Create tally snapshot for broadcast
                 let tally_snapshot = TallySnapshot::new(
                     tally.for_votes,
@@ -1519,6 +1584,7 @@ impl GovernanceActor {
                     outcome_msg,
                     now,
                     tally_snapshot,
+                    proof_bytes,
                 ))
                 .await?;
 
@@ -2282,6 +2348,7 @@ fn handle_incoming(store: &dyn Store, msg: GovernanceMessage) -> Result<()> {
             id,
             outcome,
             closed_at,
+            proof_bytes,
             ..
         } => {
             if let Some(mut proposal) = load_json::<Proposal>(store, &proposal_key(&id))? {
@@ -2292,6 +2359,12 @@ fn handle_incoming(store: &dyn Store, msg: GovernanceMessage) -> Result<()> {
                 };
                 proposal.close(new_state)?;
                 store.put(&proposal_key(&id), &serde_json::to_vec(&proposal)?)?;
+            }
+            // Persist proof from remote node (if included)
+            if let Some(bytes) = proof_bytes {
+                let proof_key = format!("governance:proof:{}", id.0);
+                store.put(proof_key.as_bytes(), &bytes)?;
+                info!("Stored governance proof from remote for proposal {}", id.0);
             }
         }
 

--- a/icn/crates/icn-core/src/supervisor/init_governance.rs
+++ b/icn/crates/icn-core/src/supervisor/init_governance.rs
@@ -32,6 +32,8 @@ pub struct GovernanceDeps {
     pub shutdown_rx: tokio::sync::broadcast::Receiver<()>,
     /// Pre-created parameter store from daemon (with defaults already loaded)
     pub protocol_parameter_store: Arc<dyn ProtocolParameterStore>,
+    /// Ed25519 signing key for GovernanceProof generation (None if keystore unavailable)
+    pub signing_key: Option<Arc<ed25519_dalek::SigningKey>>,
 }
 
 /// Services returned from governance initialization
@@ -83,6 +85,7 @@ pub async fn init_governance_services(
         deps.gossip_handle.clone(),
         gov_resolver,
         Some(deps.event_bus.clone()),
+        deps.signing_key,
     )
     .await?;
 

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -540,6 +540,12 @@ async fn spawn_actors_with_identity(
 
     // Protocol parameter store was extracted from BootstrapHandles above.
 
+    // Extract signing key for GovernanceProof generation
+    let governance_signing_key = identity_bundle.keypair().ok().map(|kp| {
+        let bytes = kp.to_signing_key_bytes();
+        Arc::new(ed25519_dalek::SigningKey::from_bytes(&bytes))
+    });
+
     // Initialize governance services
     let governance_services = super::init_governance::init_governance_services(
         config,
@@ -549,6 +555,7 @@ async fn spawn_actors_with_identity(
             event_bus: event_bus.clone(),
             shutdown_rx: shutdown_tx.subscribe(),
             protocol_parameter_store: protocol_parameter_store_from_daemon,
+            signing_key: governance_signing_key,
         },
     )
     .await?;

--- a/icn/crates/icn-core/tests/governance_integration.rs
+++ b/icn/crates/icn-core/tests/governance_integration.rs
@@ -160,7 +160,7 @@ impl TestNode {
                             id,
                             outcome,
                             closed_at,
-                            tally: _,
+                            ..
                         } => {
                             if let Some(proposal) = proposals_clone.write().await.get_mut(&id) {
                                 // Update proposal state based on outcome
@@ -455,8 +455,13 @@ impl TestNode {
             eligible_count,
         );
 
-        let msg =
-            GovernanceMessage::proposal_closed(proposal_id, outcome.clone(), now, tally_snapshot);
+        let msg = GovernanceMessage::proposal_closed(
+            proposal_id,
+            outcome.clone(),
+            now,
+            tally_snapshot,
+            None,
+        );
         self.publish_governance(msg).await?;
 
         Ok(outcome)

--- a/icn/crates/icn-core/tests/governance_ledger_integration.rs
+++ b/icn/crates/icn-core/tests/governance_ledger_integration.rs
@@ -158,6 +158,7 @@ async fn test_budget_proposal_executes_ledger_transaction() -> Result<()> {
         gossip_handle,
         membership_resolver,
         Some(event_bus.clone()),
+        None, // No signing key in test — proof generation optional
     )
     .await?;
 

--- a/icn/crates/icn-gateway/src/api/governance.rs
+++ b/icn/crates/icn-gateway/src/api/governance.rs
@@ -627,6 +627,27 @@ pub async fn get_votes(
     Ok(HttpResponse::Ok().json(response))
 }
 
+/// GET /gov/proposals/{id}/proof - Get cryptographic proof of proposal outcome
+#[get("/proposals/{id}/proof")]
+pub async fn get_proposal_proof(
+    http_req: HttpRequest,
+    gov_mgr: web::Data<Arc<GovernanceManager>>,
+    id: web::Path<String>,
+) -> Result<HttpResponse> {
+    require_scope(&http_req, "gov:read")?;
+
+    let proposal_id = ProposalId(id.into_inner());
+
+    let proof = gov_mgr.get_proof(&proposal_id).await?.ok_or_else(|| {
+        crate::error::GatewayError::NotFound(format!(
+            "No proof found for proposal: {}",
+            proposal_id.0
+        ))
+    })?;
+
+    Ok(HttpResponse::Ok().json(proof))
+}
+
 /// POST /gov/proposals/{id}/open - Open a proposal for voting
 #[post("/proposals/{id}/open")]
 pub async fn open_proposal(

--- a/icn/crates/icn-gateway/src/api/governance.rs
+++ b/icn/crates/icn-gateway/src/api/governance.rs
@@ -645,6 +645,18 @@ pub async fn get_proposal_proof(
         ))
     })?;
 
+    // Verify cryptographic binding before serving to clients
+    if !proof.verify_binding() {
+        tracing::warn!(
+            "Invalid proof binding for proposal {} — not serving",
+            proposal_id.0
+        );
+        return Err(crate::error::GatewayError::NotFound(format!(
+            "No valid proof found for proposal: {}",
+            proposal_id.0
+        )));
+    }
+
     Ok(HttpResponse::Ok().json(proof))
 }
 

--- a/icn/crates/icn-gateway/src/governance_mgr.rs
+++ b/icn/crates/icn-gateway/src/governance_mgr.rs
@@ -726,6 +726,18 @@ impl GovernanceManager {
         Ok(voter_dids)
     }
 
+    /// Get the GovernanceProof for a closed proposal (if one was generated)
+    pub async fn get_proof(
+        &self,
+        proposal_id: &ProposalId,
+    ) -> Result<Option<icn_governance::GovernanceProof>> {
+        if let Some(ref handle) = self.governance_handle {
+            return handle.get_proof(proposal_id).await;
+        }
+        // Standalone mode: no proof generation
+        Ok(None)
+    }
+
     /// Cast a vote on a proposal
     ///
     /// In actor-backed mode, the `voter` parameter is ignored - the actor

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -1065,6 +1065,7 @@ impl GatewayServer {
                                 .service(api::governance::list_proposals)
                                 .service(api::governance::get_proposal)
                                 .service(api::governance::get_votes)
+                                .service(api::governance::get_proposal_proof)
                                 .service(api::governance::open_proposal)
                                 .service(api::governance::close_proposal)
                                 // Federation proposal endpoints

--- a/icn/crates/icn-governance/src/handle.rs
+++ b/icn/crates/icn-governance/src/handle.rs
@@ -136,6 +136,12 @@ pub trait GovernanceOps: Send + Sync {
     /// Useful for notifications and audit purposes.
     async fn get_voter_dids(&self, proposal_id: &ProposalId) -> Result<Vec<Did>>;
 
+    /// Get the GovernanceProof for a closed proposal
+    ///
+    /// Returns the cryptographic proof (blake3 binding hash + Ed25519 signature)
+    /// generated when a proposal was closed, if one exists.
+    async fn get_proof(&self, proposal_id: &ProposalId) -> Result<Option<crate::GovernanceProof>>;
+
     // Protocol parameter operations (Phase 20)
 
     /// List all protocol parameters

--- a/icn/crates/icn-governance/src/message.rs
+++ b/icn/crates/icn-governance/src/message.rs
@@ -561,4 +561,63 @@ mod tests {
             "ProposalOpened"
         );
     }
+
+    #[test]
+    fn test_proposal_closed_backward_compat_no_proof_bytes() {
+        // Simulate a ProposalClosed message serialized before proof_bytes was added.
+        // Old nodes omit proof_bytes entirely; new nodes must deserialize this fine.
+        let json = r#"{
+            "ProposalClosed": {
+                "id": "test-proposal-id",
+                "outcome": "Accepted",
+                "closed_at": 12345678,
+                "tally": {
+                    "for_votes": 60,
+                    "against_votes": 30,
+                    "abstain_votes": 10,
+                    "eligible_voters": 100
+                }
+            }
+        }"#;
+
+        let msg: GovernanceMessage = serde_json::from_str(json).unwrap();
+        match msg {
+            GovernanceMessage::ProposalClosed {
+                id,
+                outcome,
+                proof_bytes,
+                ..
+            } => {
+                assert_eq!(id.0, "test-proposal-id");
+                assert_eq!(outcome, ProposalOutcome::Accepted);
+                // proof_bytes defaults to None when absent
+                assert!(proof_bytes.is_none());
+            }
+            _ => panic!("Wrong message type"),
+        }
+    }
+
+    #[test]
+    fn test_proposal_closed_with_proof_bytes_roundtrip() {
+        let tally = TallySnapshot::new(60, 30, 10, 100);
+        let proof_data = b"some-proof-bytes".to_vec();
+
+        let msg = GovernanceMessage::proposal_closed(
+            ProposalId("test-id".into()),
+            ProposalOutcome::Accepted,
+            12345678,
+            tally,
+            Some(proof_data.clone()),
+        );
+
+        let json = serde_json::to_string(&msg).unwrap();
+        let deserialized: GovernanceMessage = serde_json::from_str(&json).unwrap();
+
+        match deserialized {
+            GovernanceMessage::ProposalClosed { proof_bytes, .. } => {
+                assert_eq!(proof_bytes, Some(proof_data));
+            }
+            _ => panic!("Wrong message type"),
+        }
+    }
 }

--- a/icn/crates/icn-governance/src/message.rs
+++ b/icn/crates/icn-governance/src/message.rs
@@ -64,6 +64,10 @@ pub enum GovernanceMessage {
 
         /// Vote tally snapshot
         tally: TallySnapshot,
+
+        /// Serialized GovernanceProof (JSON bytes), if signing key was available
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        proof_bytes: Option<Vec<u8>>,
     },
 
     /// A proposal has been cancelled
@@ -250,12 +254,14 @@ impl GovernanceMessage {
         outcome: ProposalOutcome,
         closed_at: u64,
         tally: TallySnapshot,
+        proof_bytes: Option<Vec<u8>>,
     ) -> Self {
         Self::ProposalClosed {
             id,
             outcome,
             closed_at,
             tally,
+            proof_bytes,
         }
     }
 
@@ -504,6 +510,7 @@ mod tests {
             ProposalOutcome::Accepted,
             12345678,
             tally.clone(),
+            None,
         );
 
         match msg {

--- a/icn/crates/icn-governance/tests/governance_integration.rs
+++ b/icn/crates/icn-governance/tests/governance_integration.rs
@@ -1133,3 +1133,100 @@ fn test_proposal_emergency_type_identification() {
     assert_eq!(budget.emergency_type(), None);
     assert!(!budget.is_emergency());
 }
+
+// =============================================================================
+// GovernanceProof Integration Tests
+// =============================================================================
+
+#[test]
+fn test_governance_proof_roundtrip() {
+    use icn_governance::{GovernanceProof, ProofOutcome};
+
+    let signer_kp = KeyPair::generate().unwrap();
+    let voter1 = KeyPair::generate().unwrap();
+    let voter2 = KeyPair::generate().unwrap();
+    let voter3 = KeyPair::generate().unwrap();
+    let proposal_id = ProposalId::generate();
+
+    let votes = vec![
+        Vote::new(proposal_id.clone(), voter1.did().clone(), VoteChoice::For),
+        Vote::new(proposal_id.clone(), voter2.did().clone(), VoteChoice::For),
+        Vote::new(
+            proposal_id.clone(),
+            voter3.did().clone(),
+            VoteChoice::Against,
+        ),
+    ];
+
+    let tally = VoteTally::new(2, 1, 0);
+
+    let mut proof = GovernanceProof::new(
+        proposal_id.0.clone(),
+        "test-domain".to_string(),
+        ProofOutcome::Accepted,
+        tally,
+        &votes,
+        1234567890,
+        signer_kp.did().to_string(),
+    );
+
+    // Before signing: binding hash is valid, signature is empty
+    assert!(proof.verify_binding());
+    assert!(proof.signature.is_empty());
+
+    // Sign with the signer's key
+    let signing_key_bytes = signer_kp.to_signing_key_bytes();
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(&signing_key_bytes);
+    proof.sign(&signing_key);
+
+    // After signing: both binding and signature should verify
+    assert!(proof.verify_binding());
+    assert!(proof.verify_signature(&signing_key.verifying_key()));
+
+    // Verify via DID resolution (the key path that Node B would use)
+    let resolved_key = signer_kp.did().to_verifying_key().unwrap();
+    assert!(proof.verify_signature(&resolved_key));
+
+    // Serialize and deserialize (simulates gossip transport)
+    let json = serde_json::to_vec(&proof).unwrap();
+    let deserialized: GovernanceProof = serde_json::from_slice(&json).unwrap();
+    assert!(deserialized.verify_binding());
+    assert!(deserialized.verify_signature(&resolved_key));
+}
+
+#[test]
+fn test_governance_proof_tamper_detection() {
+    use icn_governance::{GovernanceProof, ProofOutcome};
+
+    let signer_kp = KeyPair::generate().unwrap();
+    let voter1 = KeyPair::generate().unwrap();
+    let proposal_id = ProposalId::generate();
+
+    let votes = vec![Vote::new(
+        proposal_id.clone(),
+        voter1.did().clone(),
+        VoteChoice::For,
+    )];
+
+    let tally = VoteTally::new(1, 0, 0);
+
+    let mut proof = GovernanceProof::new(
+        proposal_id.0.clone(),
+        "test-domain".to_string(),
+        ProofOutcome::Accepted,
+        tally,
+        &votes,
+        1234567890,
+        signer_kp.did().to_string(),
+    );
+
+    let signing_key_bytes = signer_kp.to_signing_key_bytes();
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(&signing_key_bytes);
+    proof.sign(&signing_key);
+
+    // Tamper with the outcome
+    proof.outcome = ProofOutcome::Rejected;
+
+    // Binding hash should now fail (fields don't match proof_hash)
+    assert!(!proof.verify_binding());
+}


### PR DESCRIPTION
## Summary

- Wire the existing `GovernanceProof` (blake3 + Ed25519, 20 tests in `icn-governance/src/proof.rs`) into the proposal close flow so governance outcomes become cryptographically provable
- Add `signing_key: Option<Arc<SigningKey>>` to `GovernanceActor`, sourced from `IdentityBundle` at startup
- Generate, sign, and persist `GovernanceProof` when a proposal closes (only when signing key is available)
- Broadcast proof bytes in `ProposalClosed` gossip message (backward-compatible via `#[serde(default)]`)
- Store remote proofs received via gossip for federation-ready verification
- Add `GET /v1/gov/proposals/{id}/proof` gateway endpoint
- Add `get_proof()` to `GovernanceOps` trait for gateway integration

## Changed files (13 files, ~410 LOC)

| File | Change |
|------|--------|
| `apps/governance/src/actor.rs` | Add `signing_key` field, proof generation in `CloseProposal`, `get_proof()` method, remote proof storage |
| `apps/governance/Cargo.toml` | Add `ed25519-dalek`, `hex` deps |
| `icn-governance/src/message.rs` | Add `proof_bytes: Option<Vec<u8>>` to `ProposalClosed` |
| `icn-governance/src/handle.rs` | Add `get_proof()` to `GovernanceOps` trait |
| `icn-core/src/supervisor/init_governance.rs` | Thread `signing_key` through `GovernanceDeps` |
| `icn-core/src/supervisor/lifecycle.rs` | Extract signing key from `IdentityBundle` |
| `icn-core/tests/governance_integration.rs` | Update `ProposalClosed` pattern match |
| `icn-core/tests/governance_ledger_integration.rs` | Pass `None` signing_key to `spawn()` |
| `icn-gateway/src/api/governance.rs` | Add `get_proposal_proof` endpoint |
| `icn-gateway/src/governance_mgr.rs` | Add `get_proof()` delegation |
| `icn-gateway/src/server.rs` | Register proof route |
| `icn-governance/tests/governance_integration.rs` | 2 new tests: roundtrip + tamper detection |

## Invariants checklist

- [x] **Adversarial-by-default**: Proof verification uses blake3 binding hash + Ed25519 signature; tamper detection test included
- [x] **Determinism**: GovernanceProof sorts votes by (voter DID, choice ordinal) before hashing
- [x] **Canonical encodings**: Proof uses blake3 domain separation (`icn-governance-proof-v1`)
- [x] **No panics**: All paths use `Result`, signing key is `Option` (graceful degradation)
- [x] **Kernel/app boundary**: GovernanceProof lives in app crate (icn-governance), no domain imports in kernel

## Test plan

- [x] `cargo test -p icn-governance` — 2 new integration tests (roundtrip + tamper detection) + existing 20 proof tests
- [x] `cargo test -p icn-core` — governance integration tests updated
- [x] `cargo clippy` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>