### PR TITLE
feat(compute): wire WASM execution end-to-end via wasmtime

### DIFF
--- a/deploy/Dockerfile.icnd
+++ b/deploy/Dockerfile.icnd
@@ -21,7 +21,7 @@ COPY . .
 # RUST_MIN_STACK: Increase rustc stack size to prevent SIGSEGV on complex crates
 # -j 2: Limit parallelism to reduce peak memory usage
 ENV RUST_MIN_STACK=33554432
-RUN cargo build --release --bin icnd --bin icnctl -j 2
+RUN cargo build --release --bin icnd --bin icnctl --features wasm -j 2
 
 # Runtime image
 FROM debian:bookworm-slim
@@ -38,12 +38,12 @@ COPY --from=builder /build/target/release/icnctl /usr/local/bin/
 # Create data directory
 RUN mkdir -p /root/.icn
 
-# Expose ports
-EXPOSE 7777 8080 9090 5601
+# Expose ports: 8000=gateway, 9000=p2p
+EXPOSE 8000 9000
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:8080/v1/health || exit 1
+    CMD curl -f http://localhost:8000/v1/health || exit 1
 
 # Run icnd
 ENTRYPOINT ["icnd"]

--- a/icn/bins/icnd/Cargo.toml
+++ b/icn/bins/icnd/Cargo.toml
@@ -10,6 +10,8 @@ path = "src/main.rs"
 
 [features]
 default = []
+# WASM execution via wasmtime
+wasm = ["icn-core/wasm"]
 # HSM support via PKCS#11 (requires cryptoki system library)
 hsm = ["icn-identity/hsm"]
 # TPM 2.0 support (experimental, requires tss2 system libraries)

--- a/icn/crates/icn-compute/src/actor/mod.rs
+++ b/icn/crates/icn-compute/src/actor/mod.rs
@@ -295,6 +295,30 @@ impl ComputeActor {
         self.wasm_registry = Some(registry);
     }
 
+    /// Wire the WASM executor into the local executor.
+    ///
+    /// Creates a `WasmExecutor` with the given registry and installs it
+    /// inside the `LocalExecutor` so that `WasmRef` and `WasmInline` tasks
+    /// are delegated to wasmtime instead of returning "not supported".
+    #[cfg(feature = "wasm")]
+    pub async fn wire_wasm_executor(&self, registry: Arc<WasmRegistry>) {
+        use crate::wasm_executor::WasmExecutor;
+
+        match WasmExecutor::new() {
+            Ok(wasm_exec) => {
+                let wasm_exec = wasm_exec.with_registry(registry);
+                self.executor
+                    .write()
+                    .await
+                    .set_wasm_executor(Arc::new(wasm_exec));
+                tracing::info!("WASM executor wired into LocalExecutor");
+            }
+            Err(e) => {
+                tracing::error!("Failed to create WasmExecutor: {e}");
+            }
+        }
+    }
+
     /// Set the demand adjustment configuration (Epic 2 #933).
     pub fn set_demand_adjustment_config(
         &mut self,

--- a/icn/crates/icn-compute/src/executor.rs
+++ b/icn/crates/icn-compute/src/executor.rs
@@ -55,6 +55,9 @@ pub struct LocalExecutor {
     capabilities: Vec<ExecutorCapability>,
     /// Optional contract resolver for CclRef resolution
     contract_resolver: Option<ContractResolverCallback>,
+    /// Optional WASM executor for WasmRef/WasmInline tasks
+    #[cfg(feature = "wasm")]
+    wasm_executor: Option<Arc<crate::wasm_executor::WasmExecutor>>,
 }
 
 impl LocalExecutor {
@@ -63,12 +66,24 @@ impl LocalExecutor {
         Self {
             capabilities: vec![ExecutorCapability::Ccl],
             contract_resolver: None,
+            #[cfg(feature = "wasm")]
+            wasm_executor: None,
         }
     }
 
     /// Set the contract resolver callback for CclRef resolution
     pub fn set_contract_resolver(&mut self, resolver: ContractResolverCallback) {
         self.contract_resolver = Some(resolver);
+    }
+
+    /// Set the WASM executor for WasmRef/WasmInline tasks
+    #[cfg(feature = "wasm")]
+    pub fn set_wasm_executor(&mut self, executor: Arc<crate::wasm_executor::WasmExecutor>) {
+        // Add Wasm capability when executor is set
+        if !self.capabilities.contains(&ExecutorCapability::Wasm) {
+            self.capabilities.push(ExecutorCapability::Wasm);
+        }
+        self.wasm_executor = Some(executor);
     }
 
     /// Execute a CCL contract with a specific rule
@@ -337,7 +352,21 @@ impl Executor for LocalExecutor {
                 }
             }
             TaskCode::WasmRef(_) | TaskCode::WasmInline(_) => {
-                ExecutionOutcome::Failed("WASM not yet supported".into())
+                #[cfg(feature = "wasm")]
+                {
+                    if let Some(ref wasm_exec) = self.wasm_executor {
+                        return wasm_exec.execute(task, ctx);
+                    }
+                    ExecutionOutcome::Failed(
+                        "WASM executor not configured. Registry may not be initialized.".into(),
+                    )
+                }
+                #[cfg(not(feature = "wasm"))]
+                {
+                    ExecutionOutcome::Failed(
+                        "WASM support not enabled. Rebuild with --features wasm".into(),
+                    )
+                }
             }
         }
     }

--- a/icn/crates/icn-core/Cargo.toml
+++ b/icn/crates/icn-core/Cargo.toml
@@ -68,5 +68,9 @@ reqwest.workspace = true
 # Enable test-util for time mocking in integration tests
 tokio = { version = "1.49", features = ["test-util"] }
 
+[features]
+default = []
+wasm = ["icn-compute/wasm"]
+
 [lints]
 workspace = true

--- a/icn/crates/icn-core/src/supervisor/init_compute.rs
+++ b/icn/crates/icn-core/src/supervisor/init_compute.rs
@@ -377,6 +377,26 @@ pub async fn init_compute_services(deps: ComputeDeps) -> anyhow::Result<ComputeS
         info!("Contract registry set for CclRef resolution");
     }
 
+    // Wire WASM registry and executor
+    #[cfg(feature = "wasm")]
+    {
+        let wasm_store_path = deps.store_path.join("wasm");
+        match sled::open(&wasm_store_path) {
+            Ok(db) => {
+                let registry = std::sync::Arc::new(
+                    icn_compute::WasmRegistry::with_store(db),
+                );
+                compute_actor.set_wasm_registry(registry.clone());
+                compute_actor.wire_wasm_executor(registry).await;
+                info!("WASM registry and executor wired (sled path: {:?})", wasm_store_path);
+            }
+            Err(e) => {
+                warn!("Failed to open WASM sled store at {:?}: {e}", wasm_store_path);
+                warn!("WASM execution will not be available");
+            }
+        }
+    }
+
     // Spawn the compute actor
     let compute_handle = compute_actor.spawn();
     icn_obs::metrics::supervisor::actor_spawned_inc("compute");


### PR DESCRIPTION
## Summary
- Wire existing `WasmExecutor` (wasmtime) into `LocalExecutor` so WASM tasks execute instead of returning "WASM not yet supported"
- Add `wasm` feature gate chain: `icn-compute/wasm` → `icn-core/wasm` → `icnd/wasm`
- Wire WASM registry (sled-backed) in `init_compute.rs` before actor spawn
- Fix Dockerfile: build with `--features wasm`, correct `EXPOSE` ports

## What Changed

| File | Change |
|------|--------|
| `executor.rs` | Add optional `WasmExecutor` field to `LocalExecutor`, delegate `WasmRef`/`WasmInline` |
| `actor/mod.rs` | Add `wire_wasm_executor()` — creates `WasmExecutor` with registry, installs via `RwLock` |
| `init_compute.rs` | Open sled at `data_dir/wasm`, create `WasmRegistry`, wire before spawn |
| `icn-core/Cargo.toml` | Add `[features] wasm = ["icn-compute/wasm"]` |
| `icnd/Cargo.toml` | Add `wasm = ["icn-core/wasm"]` feature |
| `Dockerfile.icnd` | Build with `--features wasm`, fix `EXPOSE 8000 9000` |

## Design
- `LocalExecutor` gains an `Option<Arc<WasmExecutor>>` (behind `#[cfg(feature = "wasm")]`)
- When WASM tasks arrive, they delegate to the `WasmExecutor` which handles wasmtime instantiation, memory limits, fuel, and ICN host functions
- Without the feature, WASM tasks return a clear "not enabled" message
- No `Arc::get_mut` — uses existing `RwLock` pattern

## Test plan
- [x] `cargo test -p icn-compute --features wasm` — 331 tests pass
- [x] `cargo test -p icn-compute` — 329 tests pass (graceful "not enabled")
- [x] `cargo check -p icnd --features wasm` — compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)