### PR TITLE
chore: add justfile, bootstrap script, and nextest config

### DIFF
--- a/icn/.config/nextest.toml
+++ b/icn/.config/nextest.toml
@@ -1,0 +1,21 @@
+# nextest configuration for the ICN workspace.
+# See: https://nexte.st/docs/configuration/
+
+[profile.default]
+# Kill tests that take longer than 120s (2 min)
+slow-timeout = { period = "60s", terminate-after = 2 }
+
+# Fail-fast: stop on first failure in CI-like contexts
+fail-fast = false
+
+# ─── Test groups ─────────────────────────────────────────────────────
+#
+# Scrypt-based keystore tests use ~256MB each. Running many in parallel
+# causes OOM or flaky decryption failures. Cap concurrency for these.
+
+[test-groups.crypto-heavy]
+max-threads = 2
+
+[[profile.default.overrides]]
+filter = "test(keystore::) | test(sdis_) | test(migration)"
+test-group = "crypto-heavy"

--- a/justfile
+++ b/justfile
@@ -1,0 +1,121 @@
+# ICN development commands
+# Run `just --list` to see all available recipes.
+
+set dotenv-load := false
+
+# Workspace directory
+workspace := "icn"
+
+# Overridable knobs (e.g., JOBS=8 just build)
+export JOBS := env("JOBS", "")
+export TEST_THREADS := env("TEST_THREADS", "")
+
+# ─── Build ───────────────────────────────────────────────────────────
+
+# Compile the workspace
+build *FLAGS:
+    cd {{workspace}} && cargo build {{FLAGS}}
+
+# Compile release binaries
+build-release *FLAGS:
+    cd {{workspace}} && cargo build --release {{FLAGS}}
+
+# Remove build artifacts
+clean:
+    cd {{workspace}} && cargo clean
+
+# ─── Test ────────────────────────────────────────────────────────────
+
+# Run tests (nextest if available, else cargo test)
+test *FLAGS:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd {{workspace}}
+    if command -v cargo-nextest &>/dev/null; then
+        cargo nextest run {{FLAGS}}
+    else
+        cargo test {{FLAGS}}
+    fi
+
+# Run tests with reduced parallelism (memory-constrained machines)
+test-safe *FLAGS:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd {{workspace}}
+    export CARGO_BUILD_JOBS="${JOBS:-2}"
+    export RUST_TEST_THREADS="${TEST_THREADS:-2}"
+    if command -v cargo-nextest &>/dev/null; then
+        cargo nextest run -j 2 {{FLAGS}}
+    else
+        cargo test {{FLAGS}}
+    fi
+
+# Run tests matching CI exactly (unit parallel, integration serial)
+test-ci:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd {{workspace}}
+    echo "=== Unit tests (parallel) ==="
+    if command -v cargo-nextest &>/dev/null; then
+        cargo nextest run --lib
+    else
+        cargo test --workspace --lib
+    fi
+    echo "=== Integration tests (serial) ==="
+    cargo test --workspace --test '*' -- --test-threads=1
+
+# ─── Lint ────────────────────────────────────────────────────────────
+
+# Run fmt + clippy
+check:
+    cd {{workspace}} && cargo fmt --all --check
+    cd {{workspace}} && cargo clippy --workspace --all-targets -- -D warnings
+
+# Run fmt only
+fmt:
+    cd {{workspace}} && cargo fmt --all
+
+# Run clippy only
+clippy *FLAGS:
+    cd {{workspace}} && cargo clippy --workspace --all-targets {{FLAGS}} -- -D warnings
+
+# ─── Devnet ──────────────────────────────────────────────────────────
+
+# Start 3-node devnet
+devnet-up:
+    make -C deploy/devnet up
+
+# Stop devnet
+devnet-down:
+    make -C deploy/devnet down
+
+# Restart devnet
+devnet-restart:
+    make -C deploy/devnet restart
+
+# Show devnet logs
+devnet-logs:
+    make -C deploy/devnet logs
+
+# Show devnet status
+devnet-status:
+    make -C deploy/devnet status
+
+# Run devnet smoke tests
+devnet-test:
+    make -C deploy/devnet test
+
+# Clean devnet data
+devnet-clean:
+    make -C deploy/devnet clean
+
+# ─── Utilities ───────────────────────────────────────────────────────
+
+# Run bootstrap script to install dev tools
+bootstrap:
+    ./scripts/bootstrap.sh
+
+# Run security audits
+audit:
+    cd {{workspace}} && cargo audit
+    cd {{workspace}} && cargo deny check

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# ICN development environment bootstrap.
+# Installs required tools and checks system dependencies.
+# Run: ./scripts/bootstrap.sh
+
+set -euo pipefail
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+ok()   { printf "${GREEN}✓${NC} %s\n" "$1"; }
+warn() { printf "${YELLOW}!${NC} %s\n" "$1"; }
+fail() { printf "${RED}✗${NC} %s\n" "$1"; }
+
+# ─── Helpers ─────────────────────────────────────────────────────────
+
+has_cmd() { command -v "$1" &>/dev/null; }
+
+# Install a cargo tool: try cargo-binstall first, then cargo install.
+install_cargo_tool() {
+    local name="$1"
+    local pkg="${2:-$1}"
+    if has_cmd "$name"; then
+        ok "$name already installed ($(command -v "$name"))"
+        return
+    fi
+    if has_cmd cargo-binstall; then
+        echo "  Installing $pkg via cargo-binstall..."
+        cargo binstall "$pkg" --locked --no-confirm 2>/dev/null && { ok "$name installed via binstall"; return; }
+    fi
+    echo "  Installing $pkg via cargo install (this may take a while)..."
+    cargo install "$pkg" --locked && ok "$name installed via cargo install" || fail "Failed to install $name"
+}
+
+# ─── Rust toolchain ──────────────────────────────────────────────────
+
+echo "=== Rust Toolchain ==="
+if has_cmd rustup; then
+    # Ensure the pinned toolchain is installed
+    if [ -f icn/rust-toolchain.toml ]; then
+        rustup show active-toolchain 2>/dev/null | head -1
+        ok "Toolchain managed by icn/rust-toolchain.toml"
+    fi
+else
+    fail "rustup not found — install from https://rustup.rs"
+    exit 1
+fi
+echo ""
+
+# ─── System dependencies ─────────────────────────────────────────────
+
+echo "=== System Dependencies ==="
+for dep in clang mold pkg-config; do
+    if has_cmd "$dep"; then
+        ok "$dep found"
+    else
+        fail "$dep not found — install with: sudo apt-get install -y $dep"
+    fi
+done
+echo ""
+
+# ─── cargo-binstall (install first, speeds up everything else) ───────
+
+echo "=== Cargo Tools ==="
+if ! has_cmd cargo-binstall; then
+    echo "  Installing cargo-binstall (speeds up subsequent installs)..."
+    cargo install cargo-binstall --locked 2>/dev/null && ok "cargo-binstall installed" || warn "cargo-binstall failed, will use cargo install for remaining tools"
+else
+    ok "cargo-binstall already installed"
+fi
+
+# ─── just ────────────────────────────────────────────────────────────
+
+if has_cmd just; then
+    ok "just already installed ($(just --version 2>/dev/null || echo 'unknown version'))"
+else
+    # Try apt first (Ubuntu 24.04+ has it)
+    if sudo apt-get install -y just 2>/dev/null; then
+        ok "just installed via apt"
+    else
+        install_cargo_tool just
+    fi
+fi
+
+# ─── Cargo development tools ─────────────────────────────────────────
+
+install_cargo_tool cargo-nextest cargo-nextest
+install_cargo_tool cargo-deny cargo-deny
+install_cargo_tool cargo-audit cargo-audit
+install_cargo_tool cargo-llvm-cov cargo-llvm-cov
+install_cargo_tool cargo-machete cargo-machete
+echo ""
+
+# ─── sccache detection ───────────────────────────────────────────────
+
+echo "=== Environment Check ==="
+if grep -q 'rustc-wrapper.*sccache' "$HOME/.cargo/config.toml" 2>/dev/null; then
+    warn "Global sccache detected in ~/.cargo/config.toml"
+    if [ -f icn/.cargo/config.user.toml ]; then
+        ok "Local override exists (icn/.cargo/config.user.toml)"
+    else
+        warn "If you see SIGSEGV during compilation, run:"
+        echo "    cp icn/.cargo/config.user.toml.example icn/.cargo/config.user.toml"
+        echo "  Or use: ICN_DISABLE_SCCACHE=1 just test"
+    fi
+else
+    ok "No global sccache detected"
+fi
+echo ""
+
+# ─── Summary ─────────────────────────────────────────────────────────
+
+echo "=== Tool Versions ==="
+echo "  rustc:        $(rustc --version 2>/dev/null || echo 'not found')"
+echo "  cargo:        $(cargo --version 2>/dev/null || echo 'not found')"
+echo "  just:         $(just --version 2>/dev/null || echo 'not found')"
+echo "  cargo-nextest: $(cargo nextest --version 2>/dev/null || echo 'not found')"
+echo "  mold:         $(mold --version 2>/dev/null || echo 'not found')"
+echo "  clang:        $(clang --version 2>/dev/null | head -1 || echo 'not found')"
+echo ""
+ok "Bootstrap complete. Run 'just test' to verify."


### PR DESCRIPTION
## Summary

Three dev-experience files that were sitting untracked in the working tree. All solve real problems:

- **`justfile`**: Command runner replacing ad-hoc cargo incantations. `just test`, `just check`, `just devnet-up`, `just test-ci` (matches CI behavior), `just test-safe` (memory-constrained, caps at 2 jobs)
- **`scripts/bootstrap.sh`**: One-command dev setup. Installs cargo-nextest, cargo-deny, cargo-audit, cargo-llvm-cov, cargo-machete. Checks system deps (clang, mold, pkg-config). Detects sccache conflicts.
- **`icn/.config/nextest.toml`**: 120s test timeout, `crypto-heavy` test group caps scrypt keystore tests at 2 threads (prevents OOM on CI and dev machines)

## Why now

These were untracked files causing "Warning: 3 uncommitted changes" on every PR creation. Committing them cleans the working tree and makes them available to all contributors.

## Test plan

- [x] `just --list` shows all recipes
- [x] `bash -n scripts/bootstrap.sh` syntax check passes
- [x] nextest.toml is valid TOML

🤖 Generated with [Claude Code](https://claude.com/claude-code)