### PR TITLE
docs(agents): add worktree workflow awareness to agent instructions

### DIFF
--- a/.claude/agents/icn-planner.md
+++ b/.claude/agents/icn-planner.md
@@ -95,3 +95,4 @@ You have deep expertise in:
 - Include rollback strategy for risky changes
 - Be specific about file paths and crate names
 - Include exact verification commands
+- When assigning parallel tasks, use separate worktrees (`./scripts/worktrees.sh create <name>`). See `docs/dev/WORKTREES.md`.

--- a/.claude/agents/icn-rust-core.md
+++ b/.claude/agents/icn-rust-core.md
@@ -26,6 +26,7 @@ You have deep expertise in:
 - Avoid `unwrap()`/`expect()` outside tests
 - Use `thiserror` for crate-local errors, `anyhow` at service boundaries
 - Prefer message passing (mpsc/oneshot) over shared mutable state
+- **If running in a worktree** (`../icn-wt/<agent>/`): you are on your own branch; commit freely, push when ready. See `docs/dev/WORKTREES.md`.
 
 ## Mandatory Work Loop
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,31 @@ See `.github/agents/README.md` for the full list and usage instructions.
 
 ---
 
+## Multi-agent worktree workflow
+
+When running multiple agents in parallel, each agent gets its own Git worktree with an isolated branch and working directory. See `docs/dev/WORKTREES.md` for full documentation.
+
+**Quick reference:**
+
+```bash
+# Create an agent worktree
+./scripts/worktrees.sh create agent-d
+
+# List all worktrees
+./scripts/worktrees.sh list
+
+# Remove when done
+./scripts/worktrees.sh remove agent-d
+```
+
+**Rules:**
+- One agent = one branch = one worktree
+- Never commit to `main` — all work on feature branches
+- Worktrees live in `../icn-wt/` (sibling to repo root)
+- Override defaults via `ICN_WT_DIR`, `ICN_WT_REMOTE`, `ICN_WT_BASE_REF`
+
+---
+
 ## Repo-provided agent rules (must follow)
 
 - **Copilot instructions**: `.github/copilot-instructions.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,6 +302,10 @@ See [docs/dev-journal/ROADMAP.md](docs/dev-journal/ROADMAP.md) for full details 
 
 Examples: `feat/gossip-compression`, `fix/trust-rate-limit-overflow`, `refactor/actor-message-routing`
 
+### Multi-Agent Parallel Work
+
+For running multiple agents simultaneously, use Git worktrees. Each agent gets an isolated working directory and branch. See `docs/dev/WORKTREES.md` for full documentation and `scripts/worktrees.sh` for the helper script.
+
 ### Daily Flow
 
 ```bash


### PR DESCRIPTION
## Summary

- Add "Multi-agent worktree workflow" section to AGENTS.md with quick reference commands and rules
- Add "Multi-Agent Parallel Work" pointer in CLAUDE.md Git Workflow section
- Add worktree context note to icn-rust-core.md agent instructions
- Add worktree guidance to icn-planner.md planning guidelines

## Why

PR #1153 added the worktree infrastructure (`scripts/worktrees.sh`, `docs/dev/WORKTREES.md`), but agents wouldn't know about it unless their instructions mention it.

## Test plan

- [x] Docs-only change, no code affected
- [x] All 4 files updated with consistent references to `docs/dev/WORKTREES.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)