### PR TITLE
fix(workspace): update PolicyDecision patterns for provenance fields

### DIFF
--- a/apps/governance/src/oracle.rs
+++ b/apps/governance/src/oracle.rs
@@ -101,7 +101,11 @@ impl PolicyOracle for GovernancePolicyOracle {
         // This crosses the meaning firewall - governance rules become generic limits
         let constraints = self.params_to_constraints(&request.context);
 
-        PolicyDecision::Allow { constraints }
+        PolicyDecision::Allow {
+            constraints,
+            policy_domain: None,
+            evaluated_at: None,
+        }
     }
 }
 
@@ -173,7 +177,7 @@ mod tests {
         );
 
         let decision = oracle.evaluate(&request);
-        if let PolicyDecision::Allow { constraints } = decision {
+        if let PolicyDecision::Allow { constraints, .. } = decision {
             assert!(constraints.rate_limit.is_some());
             assert_eq!(constraints.rate_limit.unwrap().messages_per_second, 100);
         } else {
@@ -194,7 +198,7 @@ mod tests {
 
         let decision = oracle.evaluate(&request);
         // Should allow with empty constraints (abstain)
-        if let PolicyDecision::Allow { constraints } = decision {
+        if let PolicyDecision::Allow { constraints, .. } = decision {
             assert!(constraints.rate_limit.is_none());
         } else {
             panic!("Expected Allow decision for non-governance domain");

--- a/apps/ledger/src/oracle.rs
+++ b/apps/ledger/src/oracle.rs
@@ -70,7 +70,11 @@ impl PolicyOracle for LedgerPolicyOracle {
         // This crosses the meaning firewall - ledger rules become generic limits
         let constraints = self.ledger_to_constraints(&request.context);
 
-        PolicyDecision::Allow { constraints }
+        PolicyDecision::Allow {
+            constraints,
+            policy_domain: None,
+            evaluated_at: None,
+        }
     }
 }
 
@@ -122,7 +126,7 @@ mod tests {
 
         let decision = oracle.evaluate(&request);
         // Should allow with empty constraints (abstain)
-        if let PolicyDecision::Allow { constraints } = decision {
+        if let PolicyDecision::Allow { constraints, .. } = decision {
             assert!(constraints.rate_limit.is_none());
         } else {
             panic!("Expected Allow decision for non-ledger domain");

--- a/icn/crates/icn-core/tests/byzantine_integration.rs
+++ b/icn/crates/icn-core/tests/byzantine_integration.rs
@@ -75,7 +75,11 @@ impl PolicyOracle for TestTrustOracle {
         constraints
             .custom
             .insert("trust_score".to_string(), score.into());
-        PolicyDecision::Allow { constraints }
+        PolicyDecision::Allow {
+            constraints,
+            policy_domain: None,
+            evaluated_at: None,
+        }
     }
 
     fn domain(&self) -> Domain {

--- a/icn/crates/icn-gateway/src/rate_limit.rs
+++ b/icn/crates/icn-gateway/src/rate_limit.rs
@@ -566,7 +566,7 @@ pub async fn trust_rate_limit_middleware(
     let decision = oracle.evaluate(&policy_req);
 
     match decision {
-        PolicyDecision::Allow { constraints } => {
+        PolicyDecision::Allow { constraints, .. } => {
             // Extract rate limit from constraints, using fallback if none specified
             let config = if let Some(limit) = constraints.rate_limit {
                 RateLimitConfig {
@@ -589,7 +589,7 @@ pub async fn trust_rate_limit_middleware(
                 Err(e) => Err(Error::from(e)),
             }
         }
-        PolicyDecision::Deny { reason } => {
+        PolicyDecision::Deny { reason, .. } => {
             warn!("Access denied by policy for DID {}: {}", did, reason);
             Err(Error::from(GatewayError::Forbidden(reason.to_string())))
         }

--- a/icn/crates/icn-gateway/src/trust_mgr.rs
+++ b/icn/crates/icn-gateway/src/trust_mgr.rs
@@ -684,7 +684,7 @@ impl TrustManager {
         let decision = oracle.evaluate(&request);
 
         match decision {
-            PolicyDecision::Allow { constraints } => {
+            PolicyDecision::Allow { constraints, .. } => {
                 // Check for custom "trust_score" constraint first
                 if let Some(icn_kernel_api::ConstraintValue::Float(score)) =
                     constraints.custom.get("trust_score")
@@ -1527,7 +1527,7 @@ mod tests {
         let decision = oracle.evaluate(&req);
 
         // Verify decision
-        if let PolicyDecision::Allow { constraints } = decision {
+        if let PolicyDecision::Allow { constraints, .. } = decision {
             let score_val = constraints.custom.get("trust_score").unwrap();
             let score = match score_val {
                 ConstraintValue::Float(f) => f.into_inner(),
@@ -1574,7 +1574,7 @@ mod tests {
         let decision = oracle.evaluate(&request);
 
         // Verify decision contains default trust score
-        if let icn_kernel_api::PolicyDecision::Allow { constraints } = decision {
+        if let icn_kernel_api::PolicyDecision::Allow { constraints, .. } = decision {
             // In standalone mode, compute_local is called which accepts strings
             // So we get a computed score (likely 0.0 for no edges), not DEFAULT_TRUST_SCORE
             // This test verifies the oracle doesn't panic on unusual input
@@ -1610,7 +1610,7 @@ mod tests {
         );
 
         let decision = oracle.evaluate(&request);
-        if let icn_kernel_api::PolicyDecision::Allow { constraints } = decision {
+        if let icn_kernel_api::PolicyDecision::Allow { constraints, .. } = decision {
             let score = constraints
                 .custom
                 .get("trust_score")
@@ -1641,7 +1641,7 @@ mod tests {
 
     /// Helper: extract trust_score from a PolicyDecision's constraints.
     fn extract_trust_score(decision: &PolicyDecision) -> f64 {
-        if let PolicyDecision::Allow { constraints } = decision {
+        if let PolicyDecision::Allow { constraints, .. } = decision {
             if let Some(icn_kernel_api::ConstraintValue::Float(f)) =
                 constraints.custom.get("trust_score")
             {

--- a/icn/crates/icn-gossip/src/gossip.rs
+++ b/icn/crates/icn-gossip/src/gossip.rs
@@ -806,7 +806,7 @@ impl GossipActor {
                 ),
                 context,
             );
-            if let PolicyDecision::Deny { reason } = oracle.evaluate(&req) {
+            if let PolicyDecision::Deny { reason, .. } = oracle.evaluate(&req) {
                 bail!("Not authorized to publish to topic: {topic} ({reason})");
             }
         }
@@ -1530,7 +1530,11 @@ mod tests {
                     .with_max_message_size(64 * 1024);
             }
 
-            PolicyDecision::Allow { constraints }
+            PolicyDecision::Allow {
+                constraints,
+                policy_domain: None,
+                evaluated_at: None,
+            }
         }
 
         fn domain(&self) -> Domain {

--- a/icn/crates/icn-gossip/src/handlers/pull.rs
+++ b/icn/crates/icn-gossip/src/handlers/pull.rs
@@ -96,7 +96,7 @@ impl GossipActor {
                 ActionKind::Subscribe, // treat pull as subscribe for now? Or generic access
                 Domain::trust(),
             );
-            if let icn_kernel_api::authz::PolicyDecision::Allow { constraints } =
+            if let icn_kernel_api::authz::PolicyDecision::Allow { constraints, .. } =
                 oracle.evaluate(&req)
             {
                 limits = ResourceLimits::from_constraints(&constraints);
@@ -373,7 +373,7 @@ impl GossipActor {
                         ActionKind::Subscribe,
                         Domain::trust(),
                     );
-                    if let icn_kernel_api::authz::PolicyDecision::Allow { constraints } =
+                    if let icn_kernel_api::authz::PolicyDecision::Allow { constraints, .. } =
                         oracle.evaluate(&req)
                     {
                         limits = ResourceLimits::from_constraints(&constraints);

--- a/icn/crates/icn-gossip/src/protocol.rs
+++ b/icn/crates/icn-gossip/src/protocol.rs
@@ -54,7 +54,7 @@ impl GossipActor {
                 icn_kernel_api::authz::PolicyDecision::Allow { .. } => {
                     debug!(peer_did = %sender, "Processing message from authorized sender");
                 }
-                icn_kernel_api::authz::PolicyDecision::Deny { reason } => {
+                icn_kernel_api::authz::PolicyDecision::Deny { reason, .. } => {
                     warn!(
                         peer_did = %sender,
                         reason = %reason,

--- a/icn/crates/icn-gossip/src/subscriptions.rs
+++ b/icn/crates/icn-gossip/src/subscriptions.rs
@@ -57,10 +57,10 @@ impl GossipActor {
             );
 
             match oracle.evaluate(&req) {
-                PolicyDecision::Allow { constraints } => {
+                PolicyDecision::Allow { constraints, .. } => {
                     limits = ResourceLimits::from_constraints(&constraints);
                 }
-                PolicyDecision::Deny { reason } => {
+                PolicyDecision::Deny { reason, .. } => {
                     warn!(
                         "PolicyOracle denied subscription for {}: {}",
                         subscriber, reason

--- a/icn/crates/icn-kernel-api/src/authz.rs
+++ b/icn/crates/icn-kernel-api/src/authz.rs
@@ -1059,7 +1059,7 @@ mod tests {
         assert!(!decision.is_allowed());
 
         match decision {
-            PolicyDecision::Deny { reason } => {
+            PolicyDecision::Deny { reason, .. } => {
                 assert!(matches!(reason, PolicyError::Denied(r) if r == "system locked"));
             }
             _ => panic!("Expected Deny"),
@@ -1124,7 +1124,7 @@ mod tests {
         assert!(!decision.is_allowed());
 
         match decision {
-            PolicyDecision::Deny { reason } => {
+            PolicyDecision::Deny { reason, .. } => {
                 assert!(matches!(
                     reason,
                     PolicyError::Denied(r) if r.contains("async test lockdown")

--- a/icn/crates/icn-kernel-api/src/bootstrap.rs
+++ b/icn/crates/icn-kernel-api/src/bootstrap.rs
@@ -797,7 +797,7 @@ mod tests {
 
         // Verify it's a proper denial with reason
         match decision {
-            PolicyDecision::Deny { reason } => match reason {
+            PolicyDecision::Deny { reason, .. } => match reason {
                 crate::authz::PolicyError::Denied(msg) => {
                     assert!(msg.contains("No oracle registered"));
                     assert!(msg.contains("trust"));

--- a/icn/crates/icn-ledger/examples/multi_node_sync.rs
+++ b/icn/crates/icn-ledger/examples/multi_node_sync.rs
@@ -26,7 +26,11 @@ impl PolicyOracle for MockPolicyOracle {
         constraints
             .custom
             .insert("trust_score".to_string(), 0.5.into());
-        PolicyDecision::Allow { constraints }
+        PolicyDecision::Allow {
+            constraints,
+            policy_domain: None,
+            evaluated_at: None,
+        }
     }
 
     fn domain(&self) -> Domain {

--- a/icn/crates/icn-ledger/tests/gossip_sync.rs
+++ b/icn/crates/icn-ledger/tests/gossip_sync.rs
@@ -24,7 +24,11 @@ impl PolicyOracle for MockPolicyOracle {
         constraints
             .custom
             .insert("trust_score".to_string(), 0.5.into());
-        PolicyDecision::Allow { constraints }
+        PolicyDecision::Allow {
+            constraints,
+            policy_domain: None,
+            evaluated_at: None,
+        }
     }
 
     fn domain(&self) -> Domain {

--- a/icn/crates/icn-net/src/rate_limit.rs
+++ b/icn/crates/icn-net/src/rate_limit.rs
@@ -292,7 +292,7 @@ impl RateLimiter {
         decision: PolicyDecision,
     ) -> Option<RateLimitConfig> {
         match decision {
-            PolicyDecision::Allow { constraints } => Some(Self::rate_limit_from_constraints(
+            PolicyDecision::Allow { constraints, .. } => Some(Self::rate_limit_from_constraints(
                 fallback_config,
                 &constraints,
             )),

--- a/icn/crates/icn-testkit/src/node.rs
+++ b/icn/crates/icn-testkit/src/node.rs
@@ -129,7 +129,11 @@ impl PolicyOracle for TestPolicyOracle {
             .custom
             .insert("trust_score".to_string(), score.into());
 
-        PolicyDecision::Allow { constraints }
+        PolicyDecision::Allow {
+            constraints,
+            policy_domain: None,
+            evaluated_at: None,
+        }
     }
 
     fn domain(&self) -> Domain {


### PR DESCRIPTION
## Summary
- Update all `PolicyDecision::Allow { constraints }` and `PolicyDecision::Deny { reason }` pattern matches to include `..` for the new `policy_domain` and `evaluated_at` fields
- Update all `PolicyDecision::Allow { constraints }` constructions to include `policy_domain: None, evaluated_at: None`

## What
After merging the constraint provenance stub (P0-T13 in PR #1160), `PolicyDecision::Allow` and `PolicyDecision::Deny` gained two new fields. This broke exhaustive pattern matches across the workspace.

## Why
Workspace doesn't compile without this fix.

## How
15 files across 9 crates: pattern matches get `..`, constructions get explicit `None` values.

## Risk
Very low — mechanical fix, no logic changes.

## Test plan
- [x] `cargo check --workspace`: PASS
- [x] `cargo fmt --all --check`: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)