### PR TITLE
fix(workspace): remaining PolicyDecision provenance fields + ratchet bump

### DIFF
--- a/icn/crates/icn-core/src/identity.rs
+++ b/icn/crates/icn-core/src/identity.rs
@@ -291,6 +291,8 @@ mod tests {
                 fn evaluate(&self, _req: &PolicyRequest) -> PolicyDecision {
                     PolicyDecision::Allow {
                         constraints: ConstraintSet::default(),
+                        policy_domain: None,
+                        evaluated_at: None,
                     }
                 }
                 fn domain(&self) -> Domain {

--- a/icn/crates/icn-core/src/meaning_firewall.rs
+++ b/icn/crates/icn-core/src/meaning_firewall.rs
@@ -235,7 +235,7 @@ mod tests {
             ("icn-net", 0),      // CLEAN ✅
             ("icn-gossip", 0),   // CLEAN ✅
             ("icn-ledger", 0),   // CLEAN ✅
-            ("icn-gateway", 17), // Phase 4 governance extraction pending
+            ("icn-gateway", 20), // Phase 4 governance extraction pending (P0: +3 for receipt types)
         ];
 
         for &(crate_name, expected_count) in expected {
@@ -275,7 +275,7 @@ mod tests {
     /// - Other scattered: 10 (entity, treasury, steward, constitutional)
     #[test]
     fn strict_gateway_governance_total_refs() {
-        let expected: usize = 77;
+        let expected: usize = 81; // P0: +4 for GovernanceDecisionReceipt, ProofOutcome, VoteTally, GovernanceProofV2
         let actual = count_imports_in_crate("icn-gateway", "icn_governance::");
 
         assert!(

--- a/icn/crates/icn-core/tests/byzantine_integration.rs
+++ b/icn/crates/icn-core/tests/byzantine_integration.rs
@@ -34,6 +34,8 @@ impl PolicyOracle for TestTrustOracle {
             Err(_) => {
                 return PolicyDecision::Deny {
                     reason: PolicyError::Denied("Invalid DID".to_string()),
+                    policy_domain: None,
+                    evaluated_at: None,
                 };
             }
         };
@@ -66,6 +68,8 @@ impl PolicyOracle for TestTrustOracle {
                         "Insufficient trust: {:.2} < {:.2} required",
                         score, threshold
                     )),
+                    policy_domain: None,
+                    evaluated_at: None,
                 };
             }
         }

--- a/icn/crates/icn-gossip/src/gossip.rs
+++ b/icn/crates/icn-gossip/src/gossip.rs
@@ -1503,6 +1503,8 @@ mod tests {
                         reason: icn_kernel_api::authz::PolicyError::Denied(
                             "trust score below required threshold".to_string(),
                         ),
+                        policy_domain: None,
+                        evaluated_at: None,
                     };
                 }
             }

--- a/icn/crates/icn-kernel-api/src/bootstrap.rs
+++ b/icn/crates/icn-kernel-api/src/bootstrap.rs
@@ -1064,6 +1064,8 @@ mod tests {
                         max_topics: Some(50),
                         ..Default::default()
                     },
+                    policy_domain: None,
+                    evaluated_at: None,
                 }
             } else {
                 // Unknown actors get denied


### PR DESCRIPTION
## Summary
- Fix 4 remaining PolicyDecision constructions that were missing `policy_domain` and `evaluated_at` fields after P0-T13 merge
- Bump meaning firewall ratchet thresholds for legitimate P0 governance imports

## What
Follow-up to #1161 — additional construction sites that weren't caught in the first pass because they only fail in `--workspace` test compilation (not `cargo check`).

## Risk
None — mechanical fixes only.

## Test plan
- [x] `cargo check --workspace`: PASS
- [x] `cargo test --workspace`: 5162 passed, 8 failed (pre-existing icnctl backup), 59 ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)