### PR TITLE
fix(net): resolve QUIC serialization mismatch breaking gossip delivery

### DIFF
--- a/icn/crates/icn-net/src/protocol.rs
+++ b/icn/crates/icn-net/src/protocol.rs
@@ -964,8 +964,11 @@ impl NetworkMessage {
     }
 }
 
-/// Helper for reading length-prefixed messages from QUIC streams (legacy format)
 /// Read a length-prefixed message from a QUIC stream
+///
+/// Uses the negotiated wire format (1-byte format header + payload) which all
+/// write paths now produce via `write_message` / `write_message_negotiated`.
+///
 /// Returns the message and the number of bytes read (including 4-byte length prefix)
 pub async fn read_message(recv: &mut quinn::RecvStream) -> Result<(NetworkMessage, usize)> {
     // Read 4-byte length prefix (big-endian)
@@ -992,7 +995,7 @@ pub async fn read_message(recv: &mut quinn::RecvStream) -> Result<(NetworkMessag
         .await
         .context("Failed to read message body")?;
 
-    let msg = NetworkMessage::from_bytes(&buf)?;
+    let msg = NetworkMessage::from_bytes_negotiated(&buf)?;
     // Return total bytes: 4 (length prefix) + message body
     Ok((msg, 4 + len))
 }
@@ -1032,28 +1035,15 @@ pub async fn read_message_compressed(
     Ok((msg, 4 + len))
 }
 
-/// Helper for writing length-prefixed messages to QUIC streams (legacy format)
+/// Helper for writing length-prefixed messages to QUIC streams
+///
+/// Delegates to `write_message_negotiated` with default encoding (postcard, no
+/// compression) so that all write paths produce the same wire format that
+/// `read_message` (via `from_bytes_negotiated`) expects.
+///
 /// Returns the number of bytes written (including 4-byte length prefix)
 pub async fn write_message(send: &mut quinn::SendStream, msg: &NetworkMessage) -> Result<usize> {
-    use tokio::io::AsyncWriteExt;
-
-    let bytes = msg.to_bytes()?;
-    let len = bytes.len() as u32;
-
-    // Write 4-byte length prefix (big-endian)
-    send.write_all(&len.to_be_bytes())
-        .await
-        .context("Failed to write message length")?;
-
-    // Write message bytes
-    send.write_all(&bytes)
-        .await
-        .context("Failed to write message body")?;
-
-    send.flush().await.context("Failed to flush stream")?;
-
-    // Return total bytes: 4 (length prefix) + message body
-    Ok(4 + bytes.len())
+    write_message_negotiated(send, msg, false, false).await
 }
 
 /// Helper for writing length-prefixed messages with compression support

--- a/icn/crates/icn-testkit/src/cluster.rs
+++ b/icn/crates/icn-testkit/src/cluster.rs
@@ -327,7 +327,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore] // QUIC connection timing issues in CI - see issue #319
     async fn test_fully_connect() -> Result<()> {
         let cluster = TestCluster::new(3).await?;
         cluster.fully_connect().await?;
@@ -348,7 +347,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore] // QUIC connection timing issues in CI - see issue #319
     async fn test_gossip_propagation() -> Result<()> {
         let cluster = TestCluster::new(3).await?;
         cluster.fully_connect().await?;

--- a/icn/crates/icn-testkit/src/node.rs
+++ b/icn/crates/icn-testkit/src/node.rs
@@ -1,7 +1,9 @@
 //! Test node implementation with full ICN stack
 
 use anyhow::{Context, Result};
-use icn_gossip::{AccessControl, GossipActor, GossipEntry, GossipMessage, Topic};
+use icn_gossip::{
+    start_digest_emitter, AccessControl, GossipActor, GossipEntry, GossipMessage, Topic,
+};
 use icn_identity::{Did, IdentityBundle, KeyPair};
 use icn_kernel_api::authz::{ConstraintSet, Domain, PolicyDecision, PolicyOracle, PolicyRequest};
 use icn_net::{
@@ -450,6 +452,16 @@ impl TestNode {
             g.set_send_callback(send_callback);
         }
 
+        // Start periodic digest emitter so gossip entries propagate between
+        // test nodes via the pull-based anti-entropy protocol (Digest -> PullRequest
+        // -> PullResponse). Uses a short interval for fast convergence in tests.
+        let _digest_handle = start_digest_emitter(
+            gossip.clone(),
+            200, // 200ms interval (production uses 10s+)
+            0,   // no jitter for deterministic test timing
+            shutdown_tx.subscribe(),
+        );
+
         info!("Test node {} listening on {}", index, addr);
 
         // Spawn succeeded - disarm the cleanup guard
@@ -819,9 +831,7 @@ mod tests {
     /// Integration test for network condition with actual message delivery
     ///
     /// This test verifies that network conditions affect actual gossip delivery.
-    /// Marked as ignored due to QUIC connection timing issues in CI - see issue #319
     #[tokio::test]
-    #[ignore]
     async fn test_network_condition_latency_integration() -> Result<()> {
         use crate::simulation::NetworkCondition;
         use std::time::Instant;

--- a/icn/crates/icn-testkit/tests/chaos_tests.rs
+++ b/icn/crates/icn-testkit/tests/chaos_tests.rs
@@ -25,7 +25,6 @@ use std::time::Duration;
 /// 5. Heal partition
 /// 6. Verify all nodes converge to same state
 #[tokio::test]
-#[ignore] // QUIC connection timing issues in CI - see issue #319
 async fn test_network_partition_recovery() -> Result<()> {
     let cluster = TestCluster::new(4).await?;
     cluster.fully_connect().await?;
@@ -114,7 +113,6 @@ async fn test_network_partition_recovery() -> Result<()> {
 /// 3. Publish entries on both sides
 /// 4. Heal and verify convergence
 #[tokio::test]
-#[ignore] // QUIC connection timing issues in CI - see issue #319
 async fn test_single_node_isolation() -> Result<()> {
     let cluster = TestCluster::new(4).await?;
     cluster.fully_connect().await?;
@@ -175,7 +173,6 @@ async fn test_single_node_isolation() -> Result<()> {
 /// 2. Connect, publish, disconnect, repeat
 /// 3. Verify entries eventually converge
 #[tokio::test]
-#[ignore] // QUIC connection timing issues in CI - see issue #319
 async fn test_connection_flapping() -> Result<()> {
     let cluster = TestCluster::new(2).await?;
 


### PR DESCRIPTION
## Summary

- **Root cause**: `write_message` (Hello/Ping/Pong) used `to_bytes()` (no wire format header) while `send_message_to_peer`/`broadcast_message` used `to_bytes_negotiated()` (with 1-byte format header). The reader in `handle_connection` always used `from_bytes()` (expects no header), so all non-Hello QUIC messages silently failed to deserialize -- errors were logged but the accept loop continued, masking complete gossip delivery failure over QUIC.
- **Fix**: Align `write_message` to delegate to `write_message_negotiated` and `read_message` to use `from_bytes_negotiated`, making all wire paths consistent. Also start the digest emitter in TestNode so pull-based anti-entropy propagation works.
- **Result**: Un-ignores 6 QUIC timing tests that were masked by this bug (issue #319)

## Changes

| File | Change |
|------|--------|
| `icn-net/src/protocol.rs` | `read_message` uses `from_bytes_negotiated`; `write_message` delegates to `write_message_negotiated` |
| `icn-testkit/src/node.rs` | Start `digest_emitter` (200ms interval) in TestNode for gossip propagation |
| `icn-testkit/src/cluster.rs` | Remove `#[ignore]` from `test_fully_connect`, `test_gossip_propagation` |
| `icn-testkit/tests/chaos_tests.rs` | Remove `#[ignore]` from 3 QUIC chaos tests |

## Test plan

- [x] `cargo test -p icn-testkit --lib` -- 22/22 pass (0 ignored)
- [x] `cargo test -p icn-testkit --test chaos_tests` -- 9/9 pass (1 ignored: stress test)
- [x] `cargo test -p icn-testkit --test example_integration` -- 6/6 pass
- [x] `cargo test -p icn-net --lib` -- 232/232 pass
- [x] `cargo test -p icn-core --test federated_two_node_pilot` -- 6/6 pass
- [x] `cargo fmt --check` -- clean
- [x] `cargo clippy -p icn-net -p icn-testkit --all-targets -- -D warnings` -- clean

## Invariants checklist

- [x] No panics in protocol paths
- [x] No meaning firewall violations (change is in kernel net crate only)
- [x] Deterministic encoding (postcard with format header, no compression)
- [x] Backward compatible wire format (negotiated reader handles both legacy and new markers)

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)