### PR TITLE
refactor(core): extract governance imports from icn-core (#913)

### DIFF
--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -60,7 +60,7 @@ pub use icn_kernel_api::governance::{
 // Re-export governance types needed by supervisor initialization.
 // This allows icn-core to import from icn_governance_actor instead of
 // icn_governance directly, reducing direct governance coupling.
-pub use icn_governance::{MembershipResolver, StaticMembershipResolver};
+pub use icn_governance::{ForcedOutcome, MembershipResolver, ProposalId, StaticMembershipResolver};
 
 /// Create a ProposalExecutor instance.
 ///

--- a/icn/crates/icn-core/src/governance/mod.rs
+++ b/icn/crates/icn-core/src/governance/mod.rs
@@ -6,5 +6,6 @@
 
 pub use icn_governance_actor::actor;
 pub use icn_governance_actor::{
-    GovernanceActor, GovernanceCommand, GovernanceConfigLite, GovernanceHandle,
+    ForcedOutcome, GovernanceActor, GovernanceCommand, GovernanceConfigLite, GovernanceHandle,
+    ProposalId,
 };

--- a/icn/crates/icn-core/src/meaning_firewall.rs
+++ b/icn/crates/icn-core/src/meaning_firewall.rs
@@ -389,24 +389,23 @@ mod tests {
         }
     }
 
-    /// Pinned count of ALL `icn_governance::` references in icn-core source.
+    /// Pinned count of ALL governance-crate references in icn-core source.
     ///
-    /// Tracks both `use icn_governance::` import statements AND inline qualified
-    /// paths like `icn_governance::Body`. Consistent with ledger/CCL ratchets.
+    /// Tracks both import statements AND inline qualified paths.
+    /// Consistent with ledger/CCL ratchets.
     ///
     /// Target state: 0 after governance extraction to apps/governance (#913).
     ///
-    /// Current state (2026-02-11):
-    /// governance_handlers/ has been DELETED (Sprint 4 migration complete).
-    /// Remaining references are:
-    /// - actors.rs: GatewayActorHandles governance handle
-    /// - init_gateway.rs: GovernanceManager import
-    /// - Other initialization/wiring files
+    /// Current state (2026-02-14):
+    /// CLEAN - all governance-crate references eliminated from icn-core.
+    /// - actors.rs: uses gateway governance handle type alias
+    /// - init_gateway.rs: uses gateway governance handle type alias
+    /// - control_service.rs: uses crate::governance re-exports from actor crate
     ///
-    /// All proposal execution now routes through the effect path.
+    /// All proposal execution routes through the effect path.
     #[test]
     fn strict_core_governance_reference_ratchet() {
-        let expected: usize = 3; // Dropped from 44 after governance_handlers deletion
+        let expected: usize = 0; // CLEAN: all references routed through actor crate or gateway
         let actual = count_imports_in_crate("icn-core", "icn_governance::");
 
         assert!(

--- a/icn/crates/icn-core/src/services/control_service.rs
+++ b/icn/crates/icn-core/src/services/control_service.rs
@@ -18,8 +18,7 @@ use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};
 
-use crate::governance::GovernanceHandle;
-use icn_governance::{ForcedOutcome, ProposalId};
+use crate::governance::{ForcedOutcome, GovernanceHandle, ProposalId};
 use icn_kernel_api::{
     ControlService, ForceCloseProposalRequest, ForceCloseProposalResult, VetoProposalRequest,
     VetoProposalResult,

--- a/icn/crates/icn-core/src/supervisor/actors.rs
+++ b/icn/crates/icn-core/src/supervisor/actors.rs
@@ -14,7 +14,7 @@ pub struct GatewayActorHandles {
     pub coop: Option<icn_coop::CoopHandle>,
     pub community: Option<icn_community::CommunityHandle>,
     pub trust_service: Option<Arc<dyn icn_kernel_api::services::TrustService>>,
-    pub governance: Option<Arc<dyn icn_governance::GovernanceOps + Send + Sync>>,
+    pub governance: Option<icn_gateway::governance_mgr::GovernanceHandle>,
     pub treasury: Option<icn_gateway::TreasuryHandle>,
     pub ledger: Option<icn_gateway::LedgerHandle>,
     pub entity: Option<icn_entity::EntityHandle>,

--- a/icn/crates/icn-core/src/supervisor/init_gateway.rs
+++ b/icn/crates/icn-core/src/supervisor/init_gateway.rs
@@ -26,7 +26,7 @@ pub struct GatewayHandles {
     /// Trust service for trust queries (kernel/app separated)
     pub trust_service: Option<Arc<dyn icn_kernel_api::services::TrustService>>,
     /// Governance handle for governance operations
-    pub governance: Option<Arc<dyn icn_governance::GovernanceOps + Send + Sync>>,
+    pub governance: Option<icn_gateway::governance_mgr::GovernanceHandle>,
     /// Treasury handle for treasury operations
     pub treasury: Option<icn_gateway::TreasuryHandle>,
     /// Ledger handle for balance queries


### PR DESCRIPTION
## Summary
- Remove direct `icn_governance::` references from icn-core (governance ratchet 3→0)
- Move governance initialization concerns to `apps/governance`
- Update meaning_firewall.rs to use generic governance types
- Update supervisor actors and init_gateway to use abstracted governance path

## Test plan
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test --workspace --lib

🤖 Generated with [Claude Code](https://claude.com/claude-code)