### PR TITLE
refactor(core): extract governance actor init to apps/governance

### DIFF
--- a/icn/apps/governance/src/init.rs
+++ b/icn/apps/governance/src/init.rs
@@ -1,0 +1,95 @@
+//! Governance actor initialization
+//!
+//! Initializes the governance actor, gossip topic, and store.
+//!
+//! The caller is responsible for:
+//! - Providing a gossip handle and event bus
+//! - Wiring kernel executors (protocol params, governance executor) AFTER calling this
+//!
+//! This module takes only primitive/domain types -- no `icn-core` config types.
+
+use std::path::Path;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::info;
+
+use icn_gossip::GossipActor;
+use icn_identity::Did;
+use icn_kernel_api::events::EventEmitter;
+use icn_store::SledStore;
+
+use crate::actor::{GovernanceActor, GovernanceHandle};
+use icn_governance::{MembershipResolver, StaticMembershipResolver};
+
+/// Dependencies required for governance actor initialization.
+///
+/// Uses only kernel-api / domain types -- no icn-core config.
+pub struct GovernanceActorDeps {
+    /// Handle to the gossip actor
+    pub gossip_handle: Arc<RwLock<GossipActor>>,
+    /// Event bus for inter-actor communication
+    pub event_bus: Arc<dyn EventEmitter>,
+    /// Ed25519 signing key for GovernanceProof generation (None if keystore unavailable)
+    pub signing_key: Option<Arc<ed25519_dalek::SigningKey>>,
+}
+
+/// Services returned from governance actor initialization.
+pub struct GovernanceActorServices {
+    /// Handle to the governance actor
+    pub governance_handle: GovernanceHandle,
+    /// Governance store for audit trail
+    pub governance_store: Arc<dyn icn_store::Store>,
+}
+
+/// Initialize the governance actor.
+///
+/// Creates:
+/// - Governance gossip topic (`governance:proposal`)
+/// - Governance store (Sled)
+/// - Static membership resolver
+/// - GovernanceActor
+///
+/// The returned `GovernanceHandle` does NOT yet have protocol params or
+/// a kernel executor attached. The caller (typically icn-core supervisor)
+/// should wire those via `GovernanceHandle::with_protocol_params()` and
+/// `GovernanceHandle::with_executor()`.
+pub async fn init_governance_actor(
+    store_path: &Path,
+    did: Did,
+    deps: GovernanceActorDeps,
+) -> anyhow::Result<GovernanceActorServices> {
+    // Create governance topic before spawning GovernanceActor
+    {
+        let mut gossip = deps.gossip_handle.write().await;
+        gossip.create_topic(icn_gossip::Topic::new(
+            "governance:proposal".to_string(),
+            icn_gossip::AccessControl::Public,
+        ));
+    }
+
+    // Open governance store
+    let gov_store_path = store_path.join("governance");
+    let gov_store: Arc<dyn icn_store::Store> = Arc::new(SledStore::open(&gov_store_path)?);
+
+    // Create membership resolver
+    let gov_resolver: Arc<dyn MembershipResolver + Send + Sync> =
+        Arc::new(StaticMembershipResolver::new());
+
+    // Spawn GovernanceActor
+    let governance_handle = GovernanceActor::spawn(
+        did,
+        gov_store.clone(),
+        deps.gossip_handle.clone(),
+        gov_resolver,
+        Some(deps.event_bus),
+        deps.signing_key,
+    )
+    .await?;
+
+    info!("Governance actor spawned at {}", gov_store_path.display());
+
+    Ok(GovernanceActorServices {
+        governance_handle,
+        governance_store: gov_store,
+    })
+}

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -32,6 +32,7 @@
 pub mod actor;
 pub mod executor;
 pub mod handlers;
+pub mod init;
 pub mod registry;
 
 pub use actor::{GovernanceActor, GovernanceCommand, GovernanceConfigLite, GovernanceHandle};

--- a/icn/crates/icn-core/src/supervisor/init_governance.rs
+++ b/icn/crates/icn-core/src/supervisor/init_governance.rs
@@ -1,16 +1,15 @@
-//! Governance actor initialization
+//! Governance services initialization (thin wrapper)
 //!
-//! This module extracts the governance actor setup from the supervisor,
-//! providing a cleaner separation of concerns for governance services.
+//! Delegates governance actor spawning to `icn_governance_actor::init` and
+//! then creates kernel-level infrastructure (UpgradeActor, DeadLetterQueue,
+//! VersionTracker, KernelGovernanceExecutor) that belongs in icn-core.
 
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::info;
 
 use crate::config::Config;
-use icn_governance_actor::{
-    GovernanceActor, GovernanceHandle, MembershipResolver, StaticMembershipResolver,
-};
+use icn_governance_actor::GovernanceHandle;
 use icn_identity::Did;
 use icn_kernel_api::protocol_params::ProtocolParameterStore;
 use icn_store::SledStore;
@@ -56,42 +55,30 @@ pub struct GovernanceServices {
 
 /// Initialize governance services
 ///
-/// Creates:
-/// - GovernanceActor for proposal management
+/// Delegates governance actor spawning to `icn_governance_actor::init`, then
+/// creates kernel-level infrastructure:
 /// - UpgradeActor for network-wide upgrade coordination
 /// - Dead-letter queue for failed operations recovery
 /// - Version tracker for upgrade state
+/// - KernelGovernanceExecutor for proposal execution
 pub async fn init_governance_services(
     config: &Config,
     did: Did,
     deps: GovernanceDeps,
 ) -> anyhow::Result<GovernanceServices> {
-    // Create governance topic before spawning GovernanceActor
-    {
-        let mut gossip = deps.gossip_handle.write().await;
-        gossip.create_topic(icn_gossip::Topic::new(
-            "governance:proposal".to_string(),
-            icn_gossip::AccessControl::Public,
-        ));
-    }
-
-    // Spawn Governance actor
-    let gov_store_path = config.store_path().join("governance");
-    let gov_store: Arc<dyn icn_store::Store> = Arc::new(SledStore::open(&gov_store_path)?);
-    let gov_resolver: Arc<dyn MembershipResolver + Send + Sync> =
-        Arc::new(StaticMembershipResolver::new());
-
-    let governance_handle = GovernanceActor::spawn(
+    // Delegate governance actor spawning to the governance app crate
+    let actor_services = icn_governance_actor::init::init_governance_actor(
+        &config.store_path(),
         did.clone(),
-        gov_store.clone(),
-        deps.gossip_handle.clone(),
-        gov_resolver,
-        Some(deps.event_bus.clone()),
-        deps.signing_key,
+        icn_governance_actor::init::GovernanceActorDeps {
+            gossip_handle: deps.gossip_handle.clone(),
+            event_bus: deps.event_bus.clone(),
+            signing_key: deps.signing_key,
+        },
     )
     .await?;
 
-    info!("✓ Governance actor spawned at {}", gov_store_path.display());
+    // --- Kernel-level infrastructure below ---
 
     // Spawn UpgradeActor for network-wide upgrade coordination
     let current_version = icn_kernel_api::Version::new(
@@ -144,7 +131,8 @@ pub async fn init_governance_services(
     info!("✓ Governance executor created");
 
     // Attach protocol parameter store and executor to governance handle
-    let governance_handle = governance_handle
+    let governance_handle = actor_services
+        .governance_handle
         .with_protocol_params(protocol_parameter_store.clone())
         .with_executor(governance_executor);
 
@@ -153,7 +141,7 @@ pub async fn init_governance_services(
         upgrade_handle,
         version_tracker,
         dead_letter_queue,
-        governance_store: gov_store,
+        governance_store: actor_services.governance_store,
         protocol_parameter_store,
     })
 }


### PR DESCRIPTION
## Summary
- Extracts governance actor initialization logic from `icn-core/src/supervisor/init_governance.rs` into `apps/governance/src/init.rs`
- `init_governance.rs` in icn-core now delegates to the app crate for actor spawning, keeping only kernel-level concerns (UpgradeActor, DeadLetterQueue, VersionTracker, KernelGovernanceExecutor)
- Part of the Kernel/App Separation initiative (#1138)

## What changed
| File | Change |
|------|--------|
| `apps/governance/src/init.rs` | **New**: `GovernanceActorDeps`, `GovernanceActorServices`, `init_governance_actor()` — takes only primitive/domain types, no `icn-core` config |
| `apps/governance/src/lib.rs` | Added `pub mod init;` |
| `icn-core/src/supervisor/init_governance.rs` | Thinned to delegate to `icn_governance_actor::init::init_governance_actor()` |

## Verification
- `cargo check --workspace` — PASS
- `cargo fmt --check` — PASS
- `cargo clippy --workspace --all-targets -- -D warnings` — PASS
- `cargo test -p icn_governance_actor` — 48 tests pass
- `cargo test -p icn-core --lib governance` — 16 tests pass (including meaning firewall ratchets)
- Meaning firewall tests: ratchet counts unchanged

## Risk
Low — the governance actor init code is moved, not rewritten. The delegation preserves identical behavior.

## Invariants Checklist
- [x] Meaning firewall: app crate takes primitive types, not `Config`
- [x] No panics in protocol paths
- [x] No domain imports in kernel crates (governance init delegates to app)
- [x] Canonical encodings: N/A
- [x] Determinism: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>