### PR TITLE
feat(coop): wire treasury auto-creation into cooperative activation

### DIFF
--- a/icn/apps/membership/src/coop_core/actor.rs
+++ b/icn/apps/membership/src/coop_core/actor.rs
@@ -331,7 +331,46 @@ impl CoopActor {
         charter_hash: String,
     ) -> Result<Cooperative> {
         let coop = self.store.get_cooperative(&coop_id)?;
-        let (coop, treasury_id) = self.lifecycle.activate(coop, charter_hash).await?;
+        let (mut coop, treasury_id) = self.lifecycle.activate(coop, charter_hash).await?;
+
+        // Wire treasury: assign DID to cooperative
+        let treasury_did_str = super::lifecycle::derive_treasury_did(&coop_id);
+        coop.assign_treasury(treasury_did_str.clone())
+            .map_err(super::error::CoopError::Governance)?;
+
+        // Register treasury account in ledger if treasury manager is available
+        if let Some(ref treasury_mgr) = self.treasury_manager {
+            let anchor = super::lifecycle::derive_treasury_anchor(&coop_id);
+            let mut anchor_32 = [0u8; 32];
+            anchor_32[..16].copy_from_slice(&anchor);
+            let treasury_did = Did::from_anchor_id(&anchor_32);
+
+            let created_by = self
+                .store
+                .list_members(&coop_id)
+                .ok()
+                .and_then(|members| members.first().map(|m| m.did.clone()))
+                .unwrap_or_else(|| treasury_did.clone());
+
+            let mut treasury_guard = treasury_mgr.write().await;
+            treasury_guard
+                .register_treasury(
+                    treasury_did.clone(),
+                    coop_id.clone(),
+                    "HOURS".to_string(),
+                    created_by,
+                    Some(format!("Treasury for cooperative {}", coop_id)),
+                )
+                .map_err(|e| super::error::CoopError::Ledger(e.to_string()))?;
+
+            tracing::info!(
+                coop_id = %coop_id,
+                treasury_id = %treasury_id,
+                treasury_did = %treasury_did,
+                "Registered treasury in ledger during activation"
+            );
+        }
+
         self.store.save_cooperative(&coop)?;
 
         tracing::info!(
@@ -821,6 +860,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(coop.status, CoopStatus::Forming);
+        assert!(
+            coop.treasury_did.is_none(),
+            "Treasury should be None before activation"
+        );
 
         let activated = handle
             .activate_cooperative(coop.id.clone(), "charter-hash-123".to_string())
@@ -829,6 +872,73 @@ mod tests {
 
         assert_eq!(activated.status, CoopStatus::Active);
         assert_eq!(activated.charter_hash, Some("charter-hash-123".to_string()));
+        assert!(
+            activated.treasury_did.is_some(),
+            "Treasury DID should be assigned on activation"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_activate_cooperative_registers_treasury_in_ledger() {
+        let (handle, treasury_mgr) = spawn_test_actor_with_treasury();
+        let founder = create_test_did();
+
+        let coop = handle
+            .create_cooperative(
+                Some("activate-treasury-coop".to_string()),
+                "Activation Treasury Test".to_string(),
+                CoopType::Worker,
+                founder,
+            )
+            .await
+            .unwrap();
+
+        // Activate — should auto-create and register treasury
+        let activated = handle
+            .activate_cooperative(coop.id.clone(), "charter-abc".to_string())
+            .await
+            .unwrap();
+
+        assert_eq!(activated.status, CoopStatus::Active);
+        assert!(activated.treasury_did.is_some());
+
+        // Verify treasury was registered in the ledger
+        let guard = treasury_mgr.read().await;
+        let treasury = guard.get_treasury_by_coop(&coop.id);
+        assert!(
+            treasury.is_some(),
+            "Treasury should be registered in ledger on activation"
+        );
+
+        let treasury = treasury.unwrap();
+        assert_eq!(treasury.coop_id, coop.id);
+        assert_eq!(treasury.currency, "HOURS");
+        assert!(treasury.is_active);
+    }
+
+    #[tokio::test]
+    async fn test_activate_then_create_treasury_rejects_duplicate() {
+        let handle = spawn_test_actor();
+        let founder = create_test_did();
+
+        let coop = handle
+            .create_cooperative(None, "Dup Test".to_string(), CoopType::Worker, founder)
+            .await
+            .unwrap();
+
+        // Activate assigns treasury
+        let activated = handle
+            .activate_cooperative(coop.id.clone(), "charter-dup".to_string())
+            .await
+            .unwrap();
+        assert!(activated.treasury_did.is_some());
+
+        // Separate CreateTreasury should fail since activation already assigned one
+        let result = handle.create_treasury(coop.id).await;
+        assert!(
+            result.is_err(),
+            "CreateTreasury after activation should be rejected"
+        );
     }
 
     #[tokio::test]

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -49,6 +49,7 @@ export interface Cooperative {
   owner: string;
   created_at: number;
   settings: CoopSettings;
+  treasury_did?: string;
 }
 
 export interface CoopSettings {


### PR DESCRIPTION
## Summary

Closes #1139 (B1: Treasury-Coop Integration)

- Wire treasury auto-creation into `handle_activate_cooperative` — when a cooperative is activated, the treasury DID is now automatically assigned to the cooperative and registered in the ledger (if a `TreasuryManager` is available)
- Previously, activation derived a treasury ID but never persisted it, requiring a separate `CreateTreasury` call
- Add `treasury_did?: string` to the TypeScript SDK `Cooperative` interface

## What changed

**`icn/apps/membership/src/coop_core/actor.rs`**:
- `handle_activate_cooperative` now calls `coop.assign_treasury()` after `lifecycle.activate()` to set the treasury DID on the cooperative
- If `self.treasury_manager` is `Some`, registers the treasury in the ledger via `TreasuryManager::register_treasury()` (same pattern used by `handle_create_treasury`)
- 3 new tests: `test_activate_cooperative` (updated to verify treasury_did), `test_activate_cooperative_registers_treasury_in_ledger`, `test_activate_then_create_treasury_rejects_duplicate`

**`sdk/typescript/src/types.ts`**:
- Added optional `treasury_did` field to `Cooperative` interface

## Why

This is the critical-path item that unblocks the vertical slice (#1145). Without auto-creation on activation, clients had to make a separate `CreateTreasury` call after activation, which was error-prone and left a window where the coop existed without a treasury.

## Risk

Low — the treasury registration pattern is identical to `handle_create_treasury` (which has been tested since PR #1139's initial scaffolding). The activation flow now simply runs the same logic inline.

## Invariants checklist

- [x] **Adversarial-by-default**: `assign_treasury` rejects double-assign; `CreateTreasury` correctly rejects after activation
- [x] **Determinism**: Treasury DID derived deterministically from coop ID via `derive_treasury_did`
- [x] **Canonical encodings**: No new wire formats
- [x] **No panics**: All errors use `Result` with `CoopError` variants
- [x] **Kernel/app boundary**: Changes are entirely in app layer (`icn-membership-app`); no kernel crate modifications

## Test plan

- [x] `cargo test -p icn-membership-app --lib -- test_activate` (7 pass)
- [x] `cargo test -p icn-membership-app --lib -- treasury` (36 pass)
- [x] `cargo test -p icn-membership-app --lib` (402 pass)
- [x] `cargo check --workspace` (clean)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all --check` (clean)

## NOTE

`icn-coop` (the pre-consolidation crate in `crates/icn-coop/`) has the same gap in its `handle_activate_cooperative`. It is not used by `icnd` and was not modified to keep scope tight. Can be addressed in a follow-up cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)