### PR TITLE
fix(test): resolve icnctl backup test failures and flaky connection_flapping

### DIFF
--- a/icn/bins/icnctl/tests/backup_restore_test.rs
+++ b/icn/bins/icnctl/tests/backup_restore_test.rs
@@ -7,11 +7,10 @@ use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
 
-/// Get the path to the icnctl binary
+/// Get the path to the icnctl binary.
+/// Uses CARGO_BIN_EXE which respects custom target directories.
 fn icnctl_bin() -> PathBuf {
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.push("../../target/debug/icnctl");
-    path
+    PathBuf::from(env!("CARGO_BIN_EXE_icnctl"))
 }
 
 #[test]

--- a/icn/crates/icn-testkit/tests/chaos_tests.rs
+++ b/icn/crates/icn-testkit/tests/chaos_tests.rs
@@ -208,9 +208,10 @@ async fn test_connection_flapping() -> Result<()> {
     // Final connect and wait for sync
     cluster.nodes[0].connect(&cluster.nodes[1]).await?;
 
-    // Wait for convergence (6 entries total)
+    // Wait for convergence (6 entries total).
+    // Use generous timeout — CI runners can be slow after rapid connect/disconnect cycles.
     cluster
-        .await_gossip_convergence(topic, 6, Duration::from_secs(10))
+        .await_gossip_convergence(topic, 6, Duration::from_secs(30))
         .await?;
 
     // Verify all entries on both nodes


### PR DESCRIPTION
## Summary

Fixes two pre-existing test issues that have been failing/flaky in CI:

- **icnctl backup_restore_test** (8 tests): Used hardcoded relative path `../../target/debug/icnctl` which fails with custom `CARGO_TARGET_DIR`. Fixed with `env!("CARGO_BIN_EXE_icnctl")`.
- **test_connection_flapping**: Convergence timeout of 10s too tight for slow CI runners. Increased to 30s.

## Why

These failures were pre-existing on `main` (backup tests) and intermittent in CI (flapping test). Cleaning them up before launching parallel B2/C2/D2 work.

## Risk

Minimal — one is a path fix, the other a timeout increase.

## Test plan

- [x] `cargo test -p icnctl --test backup_restore_test` — 8/8 pass (were 0/8)
- [x] `cargo test -p icn-testkit --test chaos_tests test_connection_flapping` — passes
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)