### PR TITLE
feat(econ): wire allocation receipt chain (B3) (#1141)

### DIFF
--- a/icn/crates/icn-core/tests/vertical_slice_integration.rs
+++ b/icn/crates/icn-core/tests/vertical_slice_integration.rs
@@ -17,12 +17,14 @@ use anyhow::Result;
 use icn_core::{EventBus, SystemEvent};
 use icn_gossip::GossipActor;
 use icn_governance::{
-    GovernanceDomainId, GovernanceParams, MembershipConfig, ProposalId, ProposalPayload,
-    StaticMembershipResolver, VoteChoice,
+    GovernanceDecisionReceipt, GovernanceDomainId, GovernanceParams, MembershipConfig,
+    ProofOutcome, ProposalId, ProposalPayload, StaticMembershipResolver, VoteChoice, VoteTally,
 };
 use icn_governance_actor::{GovernanceActor, GovernanceCommand, GovernanceConfigLite};
 use icn_identity::KeyPair;
+use icn_kernel_api::receipts::CanonicalReceipt;
 use icn_ledger::asset_types::{AssetClass, AssetCondition, AssetMetadata, AssetRegistry};
+use icn_ledger::create_budget_allocation;
 use icn_ledger::entry::JournalEntryBuilder;
 use icn_ledger::treasury::TreasuryManager;
 use icn_ledger::Ledger;
@@ -247,6 +249,44 @@ async fn test_tool_library_cooperative_vertical_slice() -> Result<()> {
                     });
                     let audit_json = serde_json::to_vec(&audit_record).unwrap();
                     store.put(audit_key.as_bytes(), &audit_json).unwrap();
+
+                    // ── Structured receipt chain (B3) ──
+                    let decision_receipt = GovernanceDecisionReceipt::new(
+                        prop_id.clone(),
+                        "tool-library-gov".to_string(),
+                        ProofOutcome::Accepted,
+                        VoteTally {
+                            for_votes: 1,
+                            against_votes: 0,
+                            abstain_votes: 0,
+                        },
+                        &[], // empty votes for simplicity — hash will still be deterministic
+                    );
+
+                    let allocation = create_budget_allocation(
+                        decision_receipt.decision_hash,
+                        &prop_id,
+                        &from_did.to_string(),
+                        &recipient.to_string(),
+                        amount as u64,
+                        &currency,
+                        &format!("Budget allocation for proposal {}", prop_id),
+                    );
+
+                    // Store allocation receipt keyed by canonical hash
+                    let alloc_hash = allocation.canonical_hash();
+                    let alloc_key = format!("receipt:allocation:{}", hex::encode(alloc_hash));
+                    let alloc_json = serde_json::to_vec(&allocation).unwrap();
+                    store.put(alloc_key.as_bytes(), &alloc_json).unwrap();
+
+                    // Store the decision hash for verification in Step 9
+                    let decision_key = format!("receipt:decision:{}", prop_id);
+                    store
+                        .put(
+                            decision_key.as_bytes(),
+                            hex::encode(decision_receipt.decision_hash).as_bytes(),
+                        )
+                        .unwrap();
                 });
             }
         }))
@@ -563,6 +603,75 @@ async fn test_tool_library_cooperative_vertical_slice() -> Result<()> {
     assert_eq!(audit_record["currency"], "HOURS");
     assert_eq!(audit_record["recipient"], supplier.did().to_string());
     info!("  Budget proposal audit trail: verified");
+
+    // ── Receipt chain verification ──
+    info!("  Verifying allocation receipt chain...");
+
+    // Load decision hash
+    let decision_key = format!("receipt:decision:{}", budget_proposal_id.0);
+    let decision_hash_hex = gov_store
+        .get(decision_key.as_bytes())?
+        .expect("Decision hash should be stored");
+    let decision_hash_str = String::from_utf8(decision_hash_hex).unwrap();
+    info!("  Decision hash: {}", &decision_hash_str[..16]);
+
+    // Scan for allocation receipts
+    let receipt_entries = gov_store.scan(b"receipt:allocation:")?;
+    assert!(
+        !receipt_entries.is_empty(),
+        "Should have at least one allocation receipt"
+    );
+
+    // Load and verify the first allocation receipt
+    let (_, receipt_bytes) = &receipt_entries[0];
+    let allocation: icn_kernel_api::receipts::AllocationReceipt =
+        serde_json::from_slice(receipt_bytes)?;
+
+    // Verify the chain links
+    let decision_hash_bytes = hex::decode(&decision_hash_str).unwrap();
+    let mut expected_hash = [0u8; 32];
+    expected_hash.copy_from_slice(&decision_hash_bytes);
+
+    assert_eq!(
+        allocation.decision_hash, expected_hash,
+        "AllocationReceipt must link to GovernanceDecisionReceipt"
+    );
+
+    assert_eq!(
+        allocation.intents.len(),
+        1,
+        "Should have exactly one settlement intent"
+    );
+    let intent = &allocation.intents[0];
+    assert_eq!(
+        intent.amount, 30,
+        "Intent amount should match budget proposal"
+    );
+    assert_eq!(
+        intent.unit, "HOURS",
+        "Intent unit should match budget currency"
+    );
+    assert_eq!(
+        intent.decision_hash, expected_hash,
+        "Intent must link to same decision"
+    );
+
+    // Verify provenance chain
+    assert!(
+        allocation
+            .provenance
+            .upstream_hashes
+            .contains(&expected_hash),
+        "Provenance must include decision hash"
+    );
+
+    info!("  Receipt chain verified: Decision -> Allocation -> Intent");
+    info!("    Decision hash: {}", &decision_hash_str[..16]);
+    info!("    Allocation intents: {}", allocation.intents.len());
+    info!(
+        "    Intent: {} {} from treasury to supplier",
+        intent.amount, intent.unit
+    );
 
     // Verify asset record via AssetRegistry
     let verified_asset = asset_registry

--- a/icn/crates/icn-ledger/src/allocations.rs
+++ b/icn/crates/icn-ledger/src/allocations.rs
@@ -1,0 +1,168 @@
+//! Allocation receipt creation for governance → economics bridge.
+//!
+//! Converts governance budget decision parameters into structured
+//! `AllocationReceipt` objects with `SettlementIntent` entries.
+//! These receipts form the provenance chain:
+//!
+//! ```text
+//! GovernanceDecisionReceipt.decision_hash
+//!     → AllocationReceipt.decision_hash
+//!         → SettlementIntent.decision_hash
+//!             → JournalEntry (ledger mutation)
+//! ```
+
+use icn_kernel_api::economics::SettlementIntent;
+use icn_kernel_api::receipts::{AllocationReceipt, Hash};
+use icn_kernel_api::ScopeLevel;
+
+/// Create an `AllocationReceipt` from a governance budget decision.
+///
+/// This is the bridge between governance decisions and economic settlement.
+/// The receipt links `decision_hash` to a `SettlementIntent` describing
+/// the treasury → recipient transfer.
+///
+/// # Arguments
+///
+/// * `decision_hash` — Canonical hash of the `GovernanceDecisionReceipt`
+/// * `proposal_id` — Governance proposal ID (used as `decision_receipt_id` on the intent)
+/// * `treasury_did` — Source account DID (treasury paying out)
+/// * `recipient_did` — Destination account DID (receiving the allocation)
+/// * `amount` — Transfer amount in smallest unit
+/// * `currency` — Currency/unit symbol (e.g. "HOURS")
+/// * `purpose` — Human-readable memo (excluded from canonical hash)
+pub fn create_budget_allocation(
+    decision_hash: Hash,
+    proposal_id: &str,
+    treasury_did: &str,
+    recipient_did: &str,
+    amount: u64,
+    currency: &str,
+    purpose: &str,
+) -> AllocationReceipt {
+    let now = icn_time::current_timestamp_secs();
+
+    let intent = SettlementIntent::new(
+        proposal_id,
+        decision_hash,
+        treasury_did,
+        recipient_did,
+        amount,
+        currency,
+    )
+    .with_memo(purpose)
+    .with_timestamp(now);
+
+    AllocationReceipt::new(decision_hash, ScopeLevel::Org)
+        .with_timestamp(now)
+        .add_intent(intent)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use icn_kernel_api::receipts::CanonicalReceipt;
+
+    const TEST_DECISION_HASH: Hash = [42u8; 32];
+
+    fn make_test_allocation() -> AllocationReceipt {
+        create_budget_allocation(
+            TEST_DECISION_HASH,
+            "prop-budget-001",
+            "did:icn:treasury",
+            "did:icn:supplier",
+            30,
+            "HOURS",
+            "Purchase drill press",
+        )
+    }
+
+    #[test]
+    fn test_creates_valid_receipt_with_one_intent() {
+        let receipt = make_test_allocation();
+        assert_eq!(receipt.intents.len(), 1);
+        assert_eq!(receipt.decision_hash, TEST_DECISION_HASH);
+        assert_eq!(receipt.scope, ScopeLevel::Org);
+        assert!(receipt.created_at > 0);
+    }
+
+    #[test]
+    fn test_decision_hash_propagates_to_intent() {
+        let receipt = make_test_allocation();
+        let intent = &receipt.intents[0];
+        assert_eq!(intent.decision_hash, TEST_DECISION_HASH);
+        assert_eq!(receipt.decision_hash, intent.decision_hash);
+    }
+
+    #[test]
+    fn test_intent_fields_match_inputs() {
+        let receipt = make_test_allocation();
+        let intent = &receipt.intents[0];
+
+        assert_eq!(intent.from, "did:icn:treasury");
+        assert_eq!(intent.to, "did:icn:supplier");
+        assert_eq!(intent.amount, 30);
+        assert_eq!(intent.unit, "HOURS");
+        assert_eq!(intent.decision_receipt_id, "prop-budget-001");
+        assert_eq!(intent.memo.as_deref(), Some("Purchase drill press"));
+    }
+
+    #[test]
+    fn test_provenance_chain_includes_decision_hash() {
+        let receipt = make_test_allocation();
+        assert!(
+            receipt
+                .provenance
+                .upstream_hashes
+                .contains(&TEST_DECISION_HASH),
+            "provenance must link to decision_hash"
+        );
+    }
+
+    #[test]
+    fn test_canonical_hash_is_stable() {
+        let r1 = create_budget_allocation(
+            TEST_DECISION_HASH,
+            "prop-001",
+            "did:icn:a",
+            "did:icn:b",
+            100,
+            "HOURS",
+            "test",
+        );
+        let r2 = create_budget_allocation(
+            TEST_DECISION_HASH,
+            "prop-001",
+            "did:icn:a",
+            "did:icn:b",
+            100,
+            "HOURS",
+            "test",
+        );
+
+        assert_eq!(r1.canonical_hash(), r2.canonical_hash());
+    }
+
+    #[test]
+    fn test_different_amounts_produce_different_hashes() {
+        let r1 = create_budget_allocation(
+            TEST_DECISION_HASH,
+            "prop-001",
+            "did:icn:a",
+            "did:icn:b",
+            100,
+            "HOURS",
+            "test",
+        );
+        let r2 = create_budget_allocation(
+            TEST_DECISION_HASH,
+            "prop-001",
+            "did:icn:a",
+            "did:icn:b",
+            200,
+            "HOURS",
+            "test",
+        );
+
+        assert_ne!(r1.canonical_hash(), r2.canonical_hash());
+    }
+}

--- a/icn/crates/icn-ledger/src/lib.rs
+++ b/icn/crates/icn-ledger/src/lib.rs
@@ -50,6 +50,7 @@
 //! }
 //! ```
 
+pub mod allocations;
 pub mod asset_types;
 pub mod balance;
 pub mod commons_credits;
@@ -80,6 +81,7 @@ pub mod treasury;
 pub mod types;
 pub mod use_access;
 
+pub use allocations::create_budget_allocation;
 pub use asset_types::{AssetClass, AssetCondition, AssetId, AssetMetadata, AssetRegistry};
 pub use credit_policy::{CreditPolicy, CreditPolicyManager, NewMemberPolicy};
 pub use dispute::DisputeManager;


### PR DESCRIPTION
## Summary
- Adds `create_budget_allocation()` function in `icn-ledger/src/allocations.rs` — pure bridge from governance decision hashes to `AllocationReceipt` + `SettlementIntent`
- Wires receipt production into vertical slice test's `ProposalAccepted` event handler
- Adds end-to-end receipt chain verification: Decision → Allocation → Intent

## What changed

**New: `icn-ledger/src/allocations.rs`** (168 lines)
- `create_budget_allocation(decision_hash, proposal_id, treasury, recipient, amount, currency, purpose) → AllocationReceipt`
- Uses existing `AllocationReceipt` and `SettlementIntent` from `icn-kernel-api` — no new types
- 6 unit tests: receipt structure, hash propagation, field correctness, provenance chain, canonical hash stability, hash divergence

**Modified: `vertical_slice_integration.rs`** (+113 lines)
- Step 6: After ledger mutation, produces `GovernanceDecisionReceipt` + `AllocationReceipt` and stores in KV
- Step 9: Loads receipt, verifies `decision_hash` linkage, intent fields, and provenance chain
- Existing ad-hoc JSON audit preserved (additive only)

## How to test
```bash
cargo test -p icn-ledger --lib allocations     # 6 unit tests
cargo test -p icn-core --test vertical_slice_integration  # full chain
```

## Invariants preserved
- [x] No new dependencies added
- [x] No new actors or traits
- [x] Kernel/app separation intact (uses `icn-kernel-api` types only)
- [x] No panics in non-test code
- [x] Deterministic canonical hashing via `CanonicalReceipt` trait
- [x] fmt + clippy clean

## Closes
Closes #1141

🤖 Generated with [Claude Code](https://claude.com/claude-code)