### PR TITLE
fix(cli,rpc): unblock icnctl network/ledger commands

### DIFF
--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -2014,13 +2014,13 @@ async fn main() -> Result<()> {
             handle_trust_command(trust_cmd, &data_dir, &args.endpoint).await?
         }
 
-        Commands::Ledger(ledger_cmd) => handle_ledger_command(ledger_cmd, &args.endpoint)?,
+        Commands::Ledger(ledger_cmd) => handle_ledger_command(ledger_cmd, &args.endpoint).await?,
 
         Commands::Contract(contract_cmd) => {
             handle_contract_command(contract_cmd, &args.endpoint, &data_dir).await?
         }
 
-        Commands::Network(net_cmd) => handle_network_command(net_cmd, &args.endpoint)?,
+        Commands::Network(net_cmd) => handle_network_command(net_cmd, &args.endpoint).await?,
 
         Commands::Federation(fed_cmd) => {
             handle_federation_command(fed_cmd, &data_dir, &args.endpoint).await?
@@ -2907,7 +2907,6 @@ async fn handle_status_command(data_dir: &std::path::Path, endpoint: &str) -> Re
     Ok(())
 }
 
-#[tokio::main]
 async fn handle_network_command(cmd: NetworkCommands, endpoint: &str) -> Result<()> {
     // Network commands communicate with daemon via RPC
     let rpc_addr = endpoint.parse()?;
@@ -3958,7 +3957,6 @@ fn parse_peer_url(url: &str) -> Result<(String, String)> {
     Ok((parts[0].to_string(), parts[1].to_string()))
 }
 
-#[tokio::main]
 async fn handle_ledger_command(cmd: LedgerCommands, endpoint: &str) -> Result<()> {
     // Ledger commands communicate with daemon via RPC
     let rpc_addr = endpoint.parse()?;

--- a/icn/crates/icn-rpc/src/server.rs
+++ b/icn/crates/icn-rpc/src/server.rs
@@ -61,32 +61,23 @@ use crate::receipt::ReceiptStore;
 use crate::types::{RpcRequest, RpcResponse};
 
 use icn_gossip::GossipActor;
-use icn_identity::KeyPair;
 use std::sync::LazyLock;
 
-/// Synthetic DID for rate-limiting anonymous/unauthenticated requests
+/// Synthetic DID for rate-limiting anonymous/unauthenticated requests.
 /// All anonymous requests share this single DID bucket, applying
 /// Isolated-level limits (10 req/sec, burst 2) to the aggregate.
 ///
-/// Uses a deterministic keypair derived from all-zero seed so the DID
-/// is consistent across restarts.
-///
-/// SAFETY: The keypair is created from fixed bytes which always succeeds.
-/// The expect runs once during initialization, not in response to user input.
-#[allow(clippy::expect_used)]
+/// Derives the DID from the Ed25519 public key corresponding to an
+/// all-zero secret seed. We only need the DID string (not a signing
+/// capability), so we derive the verifying key directly without
+/// constructing a full KeyPair.
 static ANONYMOUS_DID: LazyLock<Did> = LazyLock::new(|| {
-    // Generate a deterministic keypair from fixed seed
-    // The seed is all zeros - this creates a valid DID that:
-    // 1. Is extremely unlikely to match any real keypair (no one would use all-zeros)
-    //    Note: Even if someone did, authenticated users get their own rate limit bucket
-    //    based on their JWT claims.sub, so this only affects truly unauthenticated requests.
-    // 2. Is consistent across restarts (same bucket)
-    // 3. Passes DID format validation
-    let seed = [0u8; 32];
-    let public_seed = [0u8; 32];
-    let kp = KeyPair::from_bytes(&seed, &public_seed)
-        .expect("Fixed-seed keypair creation is infallible");
-    kp.did().clone()
+    use ed25519_dalek::SigningKey;
+    // Derive the verifying (public) key from a fixed all-zero seed.
+    // This is deterministic across restarts and extremely unlikely to
+    // collide with any real identity.
+    let signing_key = SigningKey::from_bytes(&[0u8; 32]);
+    Did::from_public_key(&signing_key.verifying_key())
 });
 
 /// Get the synthetic anonymous DID for rate limiting


### PR DESCRIPTION
## Summary

Two surgical fixes that unblock `icnctl network status` and `icnctl ledger *` commands. Both were completely broken — anyone trying to verify NAT traversal via CLI would see crashes.

**Why bundled:** These are independent fixes but share a single user-facing outcome: `icnctl network status` no longer panics and unauthenticated RPC no longer crashes the server. The CLI fix unblocks the command path; the RPC fix prevents the server crash on the first request. Together they restore the intended validation workflow — splitting them would leave a broken intermediate state where the command runs but the server panics.

### Fix 1: Remove nested tokio runtimes (icnctl)

`handle_network_command` and `handle_ledger_command` both had `#[tokio::main]` attributes, creating nested runtimes when called from `main()`'s existing runtime. This caused:

```
Cannot start a runtime from within a runtime
```

**Fix:** Remove the redundant `#[tokio::main]` and call both handlers with `.await?` like all other async command handlers.

### Fix 2: Prevent RPC server crash on unauthenticated requests (icn-rpc)

`ANONYMOUS_DID` used `KeyPair::from_bytes` with mismatched seeds (all-zero secret + all-zero public), but Ed25519 derives a *different* public key from the zero secret. This panicked:

```
Public key does not match secret key
```

The panic poisoned the `LazyLock`, crashing *all* subsequent unauthenticated RPC requests.

**Fix:** Derive the verifying key directly from `SigningKey::from_bytes` — we only need the DID string for rate-limit bucketing, not a signing capability. The anonymous DID is only used in the rate limiter path (`check_rate_limit`), never as an authenticated identity.

## Risk

- **Minimal**: Both fixes are strictly correctness patches with no behavioral change to the happy path.
- The icnctl fix makes two handler functions consistent with all other async handlers in the same file.
- The RPC fix removes a `KeyPair` construction that was never needed (only the DID string matters).

## Test Plan

- [x] `cargo check -p icnctl` — compiles
- [x] `cargo check -p icn-rpc` — compiles
- [x] `cargo clippy -p icnctl --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p icn-rpc --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

## Invariants Checklist

- [x] **No panics**: Removes a panic path (the whole point)
- [x] **Kernel/app boundary**: No domain imports changed
- [x] **Adversarial-by-default**: Anonymous rate-limiting still works, now without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
