### PR TITLE
feat(gossip): create network:candidates topic on init

### DIFF
--- a/icn/crates/icn-gossip/src/gossip.rs
+++ b/icn/crates/icn-gossip/src/gossip.rs
@@ -243,6 +243,15 @@ impl GossipActor {
             .with_scope(crate::types::Scope::Global), // Key rotations propagate globally
         );
 
+        // NAT traversal connection candidate topic (#1144)
+        gossip.create_topic(
+            Topic::new(
+                "network:candidates".to_string(),
+                AccessControl::Public, // All peers need candidate exchange for connectivity
+            )
+            .with_scope(crate::types::Scope::Regional), // Candidates are relevant within a region
+        );
+
         gossip
     }
 


### PR DESCRIPTION
## Summary

The NAT traversal connection candidate announcement (`network:candidates`) published to a gossip topic that was never created. With the default `Reject` auto-creation policy, every publish failed with:

```
WARN: Failed to publish connection candidate: Topic 'network:candidates' not found. Topics must be explicitly created before use.
```

**Fix:** Create the `network:candidates` topic in `GossipActor::new()` with:
- `AccessControl::Public` — all peers need candidate exchange for connectivity
- `Scope::Regional` — candidates are locality-sensitive (a peer's local/public/relay addresses are only useful to peers that could plausibly reach them; global propagation wastes bandwidth on unreachable candidates)

## Context

The topic was subscribed-to in `subscribe_standard_topics()` (icn-core), but never created in `GossipActor::new()` (icn-gossip). Subscribe calls go through the message handler which checks topic existence, but the subscription was silently failing.

## Risk

- **Minimal**: Adds one more topic to the default set. No behavioral change to existing topics.
- Connection candidates were already being generated and logged — now they'll actually propagate via gossip.

## Test Plan

- [x] `cargo check -p icn-gossip` — compiles
- [x] `cargo clippy -p icn-gossip --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

## Invariants Checklist

- [x] **Kernel/app boundary**: `network:candidates` is kernel-layer (connectivity), not domain-specific
- [x] **Adversarial-by-default**: Public access is correct — all peers need to exchange candidates for connectivity

Relates to #1144

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>