### PR TITLE
test(icnctl): make QR tests hermetic (use CARGO_BIN_EXE_icnctl)

### DIFF
--- a/icn/bins/icnctl/tests/qr_code_test.rs
+++ b/icn/bins/icnctl/tests/qr_code_test.rs
@@ -13,11 +13,9 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use tempfile::TempDir;
 
-/// Get the path to the icnctl binary
+/// Get the path to the icnctl binary (set by Cargo for integration tests)
 fn icnctl_bin() -> PathBuf {
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.push("../../target/debug/icnctl");
-    path
+    PathBuf::from(env!("CARGO_BIN_EXE_icnctl"))
 }
 
 /// Extract DID from `icnctl id show` output


### PR DESCRIPTION
## Summary

The `icnctl_bin()` test helper hardcoded a relative path to `../../target/debug/icnctl`, which breaks when the workspace uses a custom target directory (e.g. `~/.cache/cargo-target`). This caused all 6 QR code tests to fail locally with "No such file or directory" while passing in CI due to PATH differences.

**Fix:** Replace the hardcoded path with `env!("CARGO_BIN_EXE_icnctl")`, a compile-time macro Cargo sets automatically for integration tests when the binary is defined in the same package. Removes target-dir assumptions; tests now use Cargo-provided binary path so local runs match CI.

**Before:** 6/6 tests fail locally
**After:** 6/6 tests pass locally and in CI

## Files Changed

- `icn/bins/icnctl/tests/qr_code_test.rs` — 2 insertions, 4 deletions (net -2 lines)

## Risk

- **Minimal**: Only changes the test binary path resolution. No production code touched.

## Test Plan

- [x] `cargo test -p icnctl --test qr_code_test` — 6/6 pass (previously 0/6)
- [x] `cargo clippy -p icnctl --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

## Invariants Checklist

- [x] **No panics**: Test-only change
- [x] **Kernel/app boundary**: N/A (test infrastructure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
