### PR TITLE
fix(cli): wire up RPC auth for network and ledger commands

### DIFF
--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -2029,13 +2029,17 @@ async fn main() -> Result<()> {
             handle_trust_command(trust_cmd, &data_dir, &args.endpoint).await?
         }
 
-        Commands::Ledger(ledger_cmd) => handle_ledger_command(ledger_cmd, &args.endpoint).await?,
+        Commands::Ledger(ledger_cmd) => {
+            handle_ledger_command(ledger_cmd, &args.endpoint, &data_dir).await?
+        }
 
         Commands::Contract(contract_cmd) => {
             handle_contract_command(contract_cmd, &args.endpoint, &data_dir).await?
         }
 
-        Commands::Network(net_cmd) => handle_network_command(net_cmd, &args.endpoint).await?,
+        Commands::Network(net_cmd) => {
+            handle_network_command(net_cmd, &args.endpoint, &data_dir).await?
+        }
 
         Commands::Federation(fed_cmd) => {
             handle_federation_command(fed_cmd, &data_dir, &args.endpoint).await?
@@ -2922,10 +2926,13 @@ async fn handle_status_command(data_dir: &std::path::Path, endpoint: &str) -> Re
     Ok(())
 }
 
-async fn handle_network_command(cmd: NetworkCommands, endpoint: &str) -> Result<()> {
-    // Network commands communicate with daemon via RPC
-    let rpc_addr = endpoint.parse()?;
-    let mut client = icn_rpc::RpcClient::new(rpc_addr);
+async fn handle_network_command(
+    cmd: NetworkCommands,
+    endpoint: &str,
+    data_dir: &Path,
+) -> Result<()> {
+    // Network commands communicate with daemon via RPC (with auto-auth if keystore available)
+    let mut client = create_rpc_client(endpoint, data_dir, false)?;
 
     match cmd {
         NetworkCommands::Peers => {
@@ -4008,10 +4015,9 @@ fn parse_peer_url(url: &str) -> Result<(String, String)> {
     Ok((parts[0].to_string(), parts[1].to_string()))
 }
 
-async fn handle_ledger_command(cmd: LedgerCommands, endpoint: &str) -> Result<()> {
-    // Ledger commands communicate with daemon via RPC
-    let rpc_addr = endpoint.parse()?;
-    let mut client = icn_rpc::RpcClient::new(rpc_addr);
+async fn handle_ledger_command(cmd: LedgerCommands, endpoint: &str, data_dir: &Path) -> Result<()> {
+    // Ledger commands communicate with daemon via RPC (with auto-auth if keystore available)
+    let mut client = create_rpc_client(endpoint, data_dir, false)?;
 
     match cmd {
         LedgerCommands::Head => {

--- a/icn/crates/icn-rpc/src/client.rs
+++ b/icn/crates/icn-rpc/src/client.rs
@@ -190,9 +190,9 @@ impl RpcClient {
             anyhow::bail!("RPC error {}: {}", error.code, error.message);
         }
 
-        rpc_response
-            .result
-            .context("RPC response missing result field")
+        // serde deserializes JSON `null` as `None` for Option<Value>,
+        // so treat missing result (with no error) as Value::Null
+        Ok(rpc_response.result.unwrap_or(serde_json::Value::Null))
     }
 
     /// Get list of discovered peers


### PR DESCRIPTION
## Summary

Two fixes that complete the "icnctl can query a running daemon" story:

### Fix 1: Wire up RPC auth for network and ledger commands

`handle_network_command` and `handle_ledger_command` created bare `RpcClient::new()` without credentials, causing `-32401 Authentication required` errors. Every other handler used `create_rpc_client()` which auto-authenticates when `ICN_KEYSTORE_PASSPHRASE` is set.

**Fix:** Pass `data_dir` to both handlers and use `create_rpc_client()`.

### Fix 2: Handle JSON null result in RPC client

`RpcClient::call_raw()` treated a `null` result as a missing field and errored with "RPC response missing result field". This happens because serde deserializes `{"result": null}` as `Option::None` for `Option<Value>`. Methods like `ledger.head` legitimately return null for empty state.

**Fix:** `unwrap_or(Value::Null)` — null-with-no-error is a valid JSON-RPC success.

### Live smoke test results

```
$ icnctl --data-dir ./node-a -e 127.0.0.1:5601 network status
Network Actor Status:
  Running:               true
  Listening on:      127.0.0.1:5601
  NAT Traversal:
    Public endpoint:  173.188.38.108:16116
    TURN relay:       none
    Active relays:    0
    Last traversal:   Unknown

$ icnctl --data-dir ./node-a -e 127.0.0.1:5601 ledger head
Ledger is empty
```

## Files Changed

- `icn/bins/icnctl/src/main.rs` — wire `data_dir` to network/ledger handlers
- `icn/crates/icn-rpc/src/client.rs` — handle null JSON-RPC result

## Risk

- **Minimal**: Auth fix uses same pattern as all other handlers. Null-result fix is a one-line unwrap_or that makes the client more robust.

## Test Plan

- [x] `cargo check -p icnctl -p icn-rpc` — compiles
- [x] `cargo clippy -p icnctl -p icn-rpc --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Live-tested: `network status` returns NAT data, `ledger head` shows "Ledger is empty"

## Invariants Checklist

- [x] **Kernel/app boundary**: CLI + RPC client only, no kernel crates
- [x] **No panics**: `unwrap_or` is infallible
- [x] **Adversarial-by-default**: Auth now enforced where it should be

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>