### PR TITLE
docs(ops): update NAT pilot guide to reflect current state

### DIFF
--- a/docs/guides/operations/nat-traversal-pilot-test.md
+++ b/docs/guides/operations/nat-traversal-pilot-test.md
@@ -1,49 +1,89 @@
 # NAT Traversal Pilot Test Guide
 
-Manual testing guide for the C3 NAT Traversal feature (PR #1183).
+Manual testing guide for the C3 NAT Traversal feature.
+
+## 5-Minute Smoke Test
+
+Start a node and verify the full stack in two commands:
+
+```bash
+cd icn
+cargo build --release -p icnd -p icnctl
+
+export ICND=./target/release/icnd
+export ICNCTL=./target/release/icnctl
+export BASE=/tmp/icn-pilot-test
+
+mkdir -p $BASE/node-a
+ICN_KEYSTORE_PASSPHRASE=test $ICND --init --data-dir $BASE/node-a
+sed -i 's/min_trust_threshold = 0.1/min_trust_threshold = 0.0/' $BASE/node-a/config.toml
+
+ICN_KEYSTORE_PASSPHRASE=test $ICND --config $BASE/node-a/config.toml &
+sleep 5
+
+ICN_KEYSTORE_PASSPHRASE=test $ICNCTL --data-dir $BASE/node-a -e 127.0.0.1:5601 network status
+ICN_KEYSTORE_PASSPHRASE=test $ICNCTL --data-dir $BASE/node-a -e 127.0.0.1:5601 ledger head
+```
+
+**Expected output:**
+
+```
+Network Actor Status:
+  Running:               true
+  Listening on:      127.0.0.1:5601
+  NAT Traversal:
+    Public endpoint:  <your-public-IP>:<port>
+    TURN relay:       none
+    Active relays:    0
+    Last traversal:   Unknown
+```
+
+```
+Ledger is empty
+```
+
+If both commands succeed, the following are all functioning:
+- STUN public endpoint discovery
+- NAT classification and candidate derivation
+- Authenticated CLI-to-RPC path
+- Keystore unlock via `ICN_KEYSTORE_PASSPHRASE`
+- Gossip topic initialization (`network:candidates`)
+- Clean null-result handling for empty ledger state
 
 ## Prerequisites
 
-- ICN repo checked out on `feat/c3-nat-traversal` branch
-- Rust toolchain installed (stable)
-- Two terminals (or `tmux`/`screen`)
+- ICN repo on `main` (commit `861dec3c` or later)
+- Rust toolchain (stable)
+- Two terminals (or `tmux`/`screen`) for two-node testing
 - Internet access (for STUN servers)
 
-## 1. Build
+## Full Two-Node Test
+
+### 1. Build
 
 ```bash
 cd icn
 cargo build --release -p icnd -p icnctl
 ```
 
-Binaries land in `target/release/` (or `$CARGO_TARGET_DIR/release/` if configured).
-
-## 2. Initialize Two Nodes
+### 2. Initialize Two Nodes
 
 ```bash
-# Terminal setup
 export ICND=./target/release/icnd
 export ICNCTL=./target/release/icnctl
 export BASE=/tmp/icn-pilot-test
 
 mkdir -p $BASE/node-a $BASE/node-b
 
-# Init Node A
 ICN_KEYSTORE_PASSPHRASE=test $ICND --init --data-dir $BASE/node-a
-
-# Init Node B
 ICN_KEYSTORE_PASSPHRASE=test $ICND --init --data-dir $BASE/node-b
 ```
 
-**Record the DIDs** printed during init — you'll need them for Step 5.
+Record the DIDs printed during init — you'll need them for peer connectivity.
 
-## 3. Configure Non-Conflicting Ports
+### 3. Configure Non-Conflicting Ports
 
-Both nodes default to the same ports. Edit Node B's config to avoid conflicts:
-
-```bash
-# Edit $BASE/node-b/config.toml - change these values:
-```
+Both nodes default to the same ports. Edit Node B's config:
 
 | Setting | Node A (default) | Node B (change to) |
 |---------|------------------|--------------------|
@@ -53,95 +93,64 @@ Both nodes default to the same ports. Edit Node B's config to avoid conflicts:
 | `[observability] health_port` | `8080` | `8081` |
 | `[gateway] bind_addr` | `0.0.0.0:8000` | `0.0.0.0:8001` |
 
-**For LAN testing** (both nodes on same machine), also set on both nodes:
+On **both** nodes, set `min_trust_threshold = 0.0` so fresh nodes (with no mutual trust) can connect:
 
 ```toml
 [network]
 min_trust_threshold = 0.0
 ```
 
-This disables trust-gated TLS so the two fresh nodes (with no mutual trust) can connect.
-
-## 4. Start Both Nodes
+### 4. Start Both Nodes
 
 **Terminal 1 (Node A):**
 ```bash
-ICN_KEYSTORE_PASSPHRASE=test $ICND \
-  --config $BASE/node-a/config.toml \
-  --gateway-enable \
-  --insecure-gateway-no-jwt
+ICN_KEYSTORE_PASSPHRASE=test $ICND --config $BASE/node-a/config.toml
 ```
 
 **Terminal 2 (Node B):**
 ```bash
-ICN_KEYSTORE_PASSPHRASE=test $ICND \
-  --config $BASE/node-b/config.toml \
-  --gateway-enable \
-  --insecure-gateway-no-jwt
+ICN_KEYSTORE_PASSPHRASE=test $ICND --config $BASE/node-b/config.toml
 ```
 
-## 5. Verify Startup
+The gateway starts automatically (enabled by default in the generated config).
 
-### Health check (gateway)
+### 5. Verify Both Nodes
+
+**Primary check — `network status`:**
 
 ```bash
 # Node A
-curl -s http://127.0.0.1:8000/v1/health | python3 -m json.tool
-# Expected: {"status":"ok","version":"0.1.0"}
+ICN_KEYSTORE_PASSPHRASE=test $ICNCTL --data-dir $BASE/node-a -e 127.0.0.1:5601 network status
 
 # Node B
-curl -s http://127.0.0.1:8001/v1/health | python3 -m json.tool
-# Expected: {"status":"ok","version":"0.1.0"}
+ICN_KEYSTORE_PASSPHRASE=test $ICNCTL --data-dir $BASE/node-b -e 127.0.0.1:5602 network status
 ```
 
-### Detailed health
+Both should show:
+- `Running: true`
+- A STUN-derived public endpoint (e.g. `173.x.x.x:port`)
+- NAT traversal section with relay status and traversal mode
+
+**Gateway health:**
 
 ```bash
-curl -s http://127.0.0.1:8000/v1/health/detailed | python3 -m json.tool
+curl -s http://127.0.0.1:8000/v1/health
+# {"status":"ok","version":"0.1.0"}
+
+curl -s http://127.0.0.1:8001/v1/health
+# {"status":"ok","version":"0.1.0"}
 ```
 
-Expected: `status: ok` with components (identity, ledger, coop_manager, etc.)
-
-### STUN discovery (check logs)
-
-Look for this line in each terminal's output:
-```
-INFO icn_net::session: ✅ Discovered public endpoint: <IP>:<PORT> (local: 0.0.0.0:9000)
-```
-
-If you see this, STUN is working and the node knows its public address.
-
-### NAT candidate announcement (check logs)
-
-Look for:
-```
-INFO icn_core::supervisor::init_bootstrap: Connection candidate: local=0.0.0.0:9000, public=Some(<IP>:<PORT>), relay=None
-```
-
-This confirms the node is announcing its NAT traversal candidate (local + public + relay addresses).
-
-**Note:** You may see `WARN: Failed to publish connection candidate: Topic 'network:candidates' not found` — this is expected. The gossip topic for candidate exchange isn't auto-created yet. Candidates still work via mDNS and direct dial.
-
-## 6. Check Prometheus Metrics
+**Ledger (confirms RPC null-result handling):**
 
 ```bash
-# Node A metrics
-curl -s http://127.0.0.1:9100/metrics | grep -E "nat|stun|relay|traversal"
-
-# Node B metrics
-curl -s http://127.0.0.1:9101/metrics | grep -E "nat|stun|relay|traversal"
+ICN_KEYSTORE_PASSPHRASE=test $ICNCTL --data-dir $BASE/node-a -e 127.0.0.1:5601 ledger head
+# Ledger is empty
 ```
 
-Expected metrics:
-| Metric | Meaning |
-|--------|---------|
-| `icn_stun_discovery_total{result="success"}` | STUN binding request succeeded |
-| `icn_nat_dial_attempts_total{type="candidate_change"}` | NAT dial triggered by address change |
-| `icn_nat_relay_active` | Number of active TURN relay sessions (0 without TURN config) |
+### 6. NAT Traversal Config
 
-## 7. NAT Traversal Config Options
-
-The `config.toml` has a `[network.nat_dial]` section:
+The generated config includes a `[network.nat_dial]` section:
 
 ```toml
 [network.nat_dial]
@@ -152,9 +161,9 @@ relay_dial_timeout_ms = 30000     # TURN relay dial timeout
 candidate_announce_interval_secs = 150  # How often to re-announce
 ```
 
-### Optional: TURN relay config
+### Optional: TURN relay testing
 
-To test relay fallback, add TURN server config to `config.toml`:
+To test relay fallback, add TURN server config:
 
 ```toml
 [network]
@@ -163,85 +172,59 @@ turn_username = "user"
 turn_password = "pass"
 ```
 
-**Note:** Without a real TURN server, relay paths won't be available. The transport layer will attempt direct connections only.
+Without a TURN server, relay paths won't activate. The transport layer will use direct connections only. The relay path is covered by the `relay_fallback` integration test.
 
-## 8. Known Limitations (Pre-existing, Not NAT-Related)
+### 7. Cleanup
 
-### `icnctl network status` doesn't work
+```bash
+# Stop both nodes (Ctrl+C in each terminal)
+rm -rf /tmp/icn-pilot-test
+```
 
-Two pre-existing bugs prevent `icnctl network status` from functioning:
+## Advanced Diagnostics
 
-1. **Nested tokio runtime** — `handle_network_command()` in `icnctl/src/main.rs:2910` has `#[tokio::main]` but is called from within the main async runtime. Produces: `Cannot start a runtime from within a runtime`.
+Use these steps only if `network status` shows unexpected values.
 
-2. **RPC server crash on unauthenticated request** — `ANONYMOUS_DID` construction in `icn-rpc/src/server.rs:87` uses all-zero seeds for `KeyPair::from_bytes()`, which panics because the public key doesn't match the derived key. This poisons the `LazyLock` and crashes all subsequent unauthenticated RPC requests.
+### STUN discovery (log inspection)
 
-**Workaround:** Use gateway health endpoints and Prometheus metrics (shown above) to verify node status. The NAT status fields are fully wired in the RPC handler and will work once these pre-existing bugs are fixed.
+Look for this line in daemon output:
+```
+INFO icn_net::session: Discovered public endpoint: <IP>:<PORT> (local: 0.0.0.0:9000)
+```
 
-### Peer connectivity requires bootstrap peers
+### NAT candidate announcement (log inspection)
 
-Two nodes on the same machine will discover each other via mDNS but won't automatically establish QUIC sessions without being configured as bootstrap peers or having a shared gossip topic. To force a connection, add the other node as a bootstrap peer:
+```
+INFO icn_core::supervisor::init_bootstrap: Connection candidate: local=0.0.0.0:9000, public=Some(<IP>:<PORT>), relay=None
+```
+
+### Prometheus metrics
+
+```bash
+curl -s http://127.0.0.1:9100/metrics | grep -E "stun|nat_|relay"
+```
+
+| Metric | Meaning |
+|--------|---------|
+| `icn_stun_discovery_total{result="success"}` | STUN binding succeeded |
+| `icn_nat_dial_attempts_total{type="candidate_change"}` | NAT dial triggered |
+| `icn_nat_relay_active` | Active TURN relay sessions (0 without TURN) |
+
+### Peer connectivity
+
+Two nodes on the same machine discover each other via mDNS but may not auto-establish QUIC sessions. To force a connection, add the other node as a bootstrap peer:
 
 ```toml
 [network]
 bootstrap_peers = ["127.0.0.1:9001"]  # In node-a's config, point to node-b
 ```
 
-## 9. Cleanup
+## What This Pilot Proves
 
-```bash
-# Stop both nodes (Ctrl+C in each terminal)
-# Remove test data
-rm -rf /tmp/icn-pilot-test
-```
-
-## What This PR Tests
-
-| Feature | Status | How to Verify |
-|---------|--------|---------------|
-| STUN public endpoint discovery | Working | Check logs for `Discovered public endpoint` |
-| NatStatus struct in NetworkActor | Working | Prometheus metrics (stun/relay/dial counters) |
-| Connection candidate announcement | Working | Check logs for `Connection candidate: local=..., public=..., relay=...` |
-| `icnctl network status` NAT section | Blocked | Pre-existing bugs in icnctl + RPC (not NAT-related) |
-| TURN relay fallback | Code complete | Requires real TURN server; covered by integration test |
-| Configurable dial timeout | Working | Set in `[network.nat_dial]` section |
-| Parallel direct+relay dial | Working | `parallel_dial = true` in config (default) |
-| Relay proxy (Quinn-over-TURN) | Code complete | Covered by `relay_fallback` integration test |
-
-## Quick Smoke Test (Copy-Paste)
-
-```bash
-# Full smoke test - run from icn/ directory
-export ICND=./target/release/icnd
-export BASE=/tmp/icn-pilot-test
-
-# Build
-cargo build --release -p icnd -p icnctl
-
-# Init
-mkdir -p $BASE/node-a
-ICN_KEYSTORE_PASSPHRASE=test $ICND --init --data-dir $BASE/node-a
-
-# Patch config
-sed -i 's/min_trust_threshold = 0.1/min_trust_threshold = 0.0/' $BASE/node-a/config.toml
-
-# Start (background)
-ICN_KEYSTORE_PASSPHRASE=test $ICND --config $BASE/node-a/config.toml \
-  --gateway-enable --insecure-gateway-no-jwt &
-ICND_PID=$!
-sleep 5
-
-# Verify
-echo "=== Health ==="
-curl -s http://127.0.0.1:8000/v1/health
-
-echo -e "\n=== NAT Metrics ==="
-curl -s http://127.0.0.1:9100/metrics | grep -E "stun|nat_"
-
-echo -e "\n=== Logs (NAT lines) ==="
-grep -E "public endpoint|Connection candidate|TURN|relay" $BASE/node-a/stdout.log 2>/dev/null || \
-  echo "(logs go to terminal, check there)"
-
-# Cleanup
-kill $ICND_PID 2>/dev/null
-rm -rf $BASE
-```
+- Full STUN public endpoint discovery
+- NAT classification and address derivation
+- Connection candidate gossip initialization
+- Authenticated CLI-to-RPC path (unified passphrase handling)
+- Clean empty-state responses (ledger, network)
+- Configurable dial timeouts and parallel dial strategy
+- TURN relay fallback (with integration test; requires real TURN server for live test)


### PR DESCRIPTION
## Summary

Updates the NAT traversal pilot test guide to reflect reality after PRs #1184, #1185, #1186, #1189, #1190 landed.

**Key changes:**
- **`icnctl network status` is now the primary verification step** — no longer blocked by nested-runtime or RPC auth bugs
- **5-minute smoke test** at the top with copy-paste commands and expected output
- **Removed "Known Limitations"** section documenting fixed bugs (archaeology belongs in PR history, not ops guides)
- **Removed `--gateway-enable --insecure-gateway-no-jwt`** flags — gateway starts from config by default
- **Reframed manual steps as "Advanced Diagnostics"** — only needed when `network status` shows problems
- **Added "What This Pilot Proves"** summary

## Risk

- **None**: Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>