### PR TITLE
feat(core): escrow release vertical slice with saga pattern

### DIFF
--- a/icn/crates/icn-core/src/supervisor/decision_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/decision_executor.rs
@@ -254,7 +254,8 @@ fn extract_decision_hash(effects: &[KernelEffect]) -> Option<String> {
     for effect in effects {
         if let KernelEffect::Treasury(
             TreasuryEffect::Spend { decision_hash, .. }
-            | TreasuryEffect::CreateBudget { decision_hash, .. },
+            | TreasuryEffect::CreateBudget { decision_hash, .. }
+            | TreasuryEffect::ReleaseEscrow { decision_hash, .. },
         ) = effect
         {
             if !decision_hash.is_empty() {

--- a/icn/crates/icn-core/src/supervisor/decision_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/decision_executor.rs
@@ -1,0 +1,614 @@
+//! Decision Executor — idempotent, persistent wrapper around EffectDispatcher.
+//!
+//! The `DecisionExecutor` sits between the governance event subscription and the
+//! `EffectDispatcher`. It provides:
+//!
+//! 1. **Idempotency**: If a decision_hash has already been executed (status = Confirmed),
+//!    the executor returns early. This prevents double-execution from replayed events.
+//!
+//! 2. **Execution logging**: Every decision's execution status is persisted to sled.
+//!    This survives restarts and enables audit.
+//!
+//! 3. **Saga-ready structure**: The `ExecutionRecord` status machine
+//!    (Pending → Executing → Confirmed/Failed) is the foundation for future
+//!    saga patterns (retry, compensation, dead-letter routing).
+//!
+//! # Architecture
+//!
+//! ```text
+//! [App Layer]
+//! GovernanceEvent → translate_payload_to_effects() → Vec<KernelEffect>
+//!                                                          |
+//!                                                          v
+//! [DecisionExecutor]  ←── idempotency check (sled)
+//!       |   record Pending
+//!       |   record Executing
+//!       v
+//! [EffectDispatcher]  ←── existing execution path
+//!       |
+//!       v
+//! [DecisionExecutor]  ←── record Confirmed/Failed
+//! ```
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use tracing::{debug, error, info, warn};
+
+use icn_kernel_api::effects::{EffectResult, KernelEffect};
+use icn_kernel_api::execution::{ExecutionRecord, ExecutionStatus, ExecutionStore};
+
+use super::effect_dispatcher::EffectDispatcher;
+
+/// Maximum number of automatic retries before marking permanently failed.
+const MAX_RETRIES: u32 = 3;
+
+/// Wraps `EffectDispatcher` with persistent idempotency and execution logging.
+pub struct DecisionExecutor {
+    dispatcher: Arc<EffectDispatcher>,
+    store: Arc<dyn ExecutionStore>,
+}
+
+impl DecisionExecutor {
+    /// Create a new DecisionExecutor.
+    pub fn new(dispatcher: Arc<EffectDispatcher>, store: Arc<dyn ExecutionStore>) -> Self {
+        Self { dispatcher, store }
+    }
+
+    /// Execute effects for a governance decision, with idempotency.
+    ///
+    /// # Arguments
+    /// * `effects` - Pre-translated kernel effects
+    /// * `decision_receipt_id` - Receipt ID for audit linkage
+    /// * `decision_hash` - Canonical decision hash (idempotency key)
+    /// * `proposal_id` - The originating proposal ID
+    ///
+    /// # Returns
+    /// Effect results, or an empty vec if already executed.
+    pub async fn execute(
+        &self,
+        effects: Vec<KernelEffect>,
+        decision_receipt_id: &str,
+        decision_hash: &str,
+        proposal_id: &str,
+    ) -> Result<Vec<EffectResult>> {
+        // 1. Idempotency check
+        if let Some(existing) = self.store.get(decision_hash)? {
+            if existing.is_terminal() {
+                debug!(
+                    decision_hash = %decision_hash,
+                    status = ?existing.status,
+                    "Decision already executed (idempotency check), skipping"
+                );
+                return Ok(vec![]);
+            }
+
+            // If it's in Executing state, another execution may be in progress
+            // or a prior attempt crashed. For the skeleton, we log and proceed.
+            if existing.status == ExecutionStatus::Executing {
+                warn!(
+                    decision_hash = %decision_hash,
+                    "Decision in Executing state (possible crash recovery), re-executing"
+                );
+            }
+
+            // If it's in Failed state, check retry limit
+            if existing.status == ExecutionStatus::Failed && existing.retries >= MAX_RETRIES {
+                warn!(
+                    decision_hash = %decision_hash,
+                    retries = existing.retries,
+                    "Decision exceeded max retries, marking permanently failed"
+                );
+                let mut record = existing;
+                record.mark_permanently_failed("Max retries exceeded");
+                self.store.put(&record)?;
+                return Ok(vec![]);
+            }
+        }
+
+        // 2. Record Pending
+        let mut record =
+            ExecutionRecord::new_pending(decision_hash, proposal_id, decision_receipt_id);
+        self.store.put(&record)?;
+
+        // 3. Transition to Executing
+        record.mark_executing();
+        self.store.put(&record)?;
+
+        info!(
+            decision_hash = %decision_hash,
+            proposal_id = %proposal_id,
+            effect_count = effects.len(),
+            "Executing governance decision"
+        );
+
+        // 4. Delegate to EffectDispatcher
+        let results = match self
+            .dispatcher
+            .execute_effects(effects, decision_receipt_id)
+            .await
+        {
+            Ok(results) => results,
+            Err(e) => {
+                error!(
+                    decision_hash = %decision_hash,
+                    error = %e,
+                    "Effect dispatcher returned error"
+                );
+                record.mark_failed(e.to_string());
+                self.store.put(&record)?;
+                return Err(e);
+            }
+        };
+
+        // 5. Check results and record outcome
+        let all_success = results.iter().all(|r| r.success);
+        if all_success {
+            let state_change_hashes: Vec<String> = results
+                .iter()
+                .filter_map(|r| r.state_change_hash.clone())
+                .collect();
+            // Note: ledger_entry_ids will be populated when treasury executor
+            // is wired to return entry IDs in EffectResult.
+            record.mark_confirmed(vec![], state_change_hashes);
+            self.store.put(&record)?;
+
+            info!(
+                decision_hash = %decision_hash,
+                result_count = results.len(),
+                "Decision execution confirmed"
+            );
+        } else {
+            let failures: Vec<String> = results
+                .iter()
+                .filter(|r| !r.success)
+                .map(|r| r.message.clone())
+                .collect();
+            let error_msg = failures.join("; ");
+
+            warn!(
+                decision_hash = %decision_hash,
+                failures = ?failures,
+                "Decision execution had failures"
+            );
+
+            record.mark_failed(error_msg);
+            self.store.put(&record)?;
+        }
+
+        Ok(results)
+    }
+
+    /// Query execution status for a decision hash.
+    pub fn get_status(&self, decision_hash: &str) -> Result<Option<ExecutionRecord>> {
+        self.store.get(decision_hash)
+    }
+
+    /// List all records with a given status.
+    pub fn list_by_status(&self, status: ExecutionStatus) -> Result<Vec<ExecutionRecord>> {
+        self.store.list_by_status(status)
+    }
+}
+
+/// Create an effect executor callback that routes through the DecisionExecutor.
+///
+/// This replaces `create_effect_executor_callback` from `effect_dispatcher.rs`
+/// when the DecisionExecutor is wired. The callback extracts decision_hash
+/// from the effects (if present) and delegates to DecisionExecutor::execute.
+pub fn create_decision_executor_callback(
+    executor: Arc<DecisionExecutor>,
+) -> Arc<dyn Fn(Vec<KernelEffect>, String) + Send + Sync> {
+    Arc::new(move |effects, decision_receipt_id| {
+        if effects.is_empty() {
+            debug!(
+                receipt_id = %decision_receipt_id,
+                "No effects to execute (empty batch)"
+            );
+            return;
+        }
+
+        let executor = executor.clone();
+        let effect_count = effects.len();
+
+        // Extract decision_hash from first effect that carries one.
+        // Treasury and some other effects embed decision_hash.
+        let decision_hash =
+            extract_decision_hash(&effects).unwrap_or_else(|| decision_receipt_id.clone());
+
+        // Use receipt_id as proposal_id fallback — the app layer should
+        // pass a richer context once the bridge is fully wired.
+        let proposal_id = decision_receipt_id.clone();
+
+        tokio::spawn(async move {
+            match executor
+                .execute(effects, &decision_receipt_id, &decision_hash, &proposal_id)
+                .await
+            {
+                Ok(results) => {
+                    let success_count = results.iter().filter(|r| r.success).count();
+                    info!(
+                        receipt_id = %decision_receipt_id,
+                        decision_hash = %decision_hash,
+                        total = results.len(),
+                        success = success_count,
+                        "Decision execution complete"
+                    );
+                }
+                Err(e) => {
+                    error!(
+                        receipt_id = %decision_receipt_id,
+                        decision_hash = %decision_hash,
+                        effect_count = effect_count,
+                        error = %e,
+                        "Decision execution failed"
+                    );
+                }
+            }
+        });
+    })
+}
+
+/// Extract `decision_hash` from the first effect that carries one.
+fn extract_decision_hash(effects: &[KernelEffect]) -> Option<String> {
+    use icn_kernel_api::effects::TreasuryEffect;
+    for effect in effects {
+        if let KernelEffect::Treasury(
+            TreasuryEffect::Spend { decision_hash, .. }
+            | TreasuryEffect::CreateBudget { decision_hash, .. },
+        ) = effect
+        {
+            if !decision_hash.is_empty() {
+                return Some(decision_hash.clone());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use icn_kernel_api::effects::TreasuryEffect;
+    use icn_kernel_api::execution::ExecutionRecord;
+    use std::collections::HashMap;
+    use std::sync::RwLock;
+
+    /// In-memory execution store for testing.
+    struct MemoryExecutionStore {
+        records: RwLock<HashMap<String, ExecutionRecord>>,
+    }
+
+    impl MemoryExecutionStore {
+        fn new() -> Self {
+            Self {
+                records: RwLock::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl ExecutionStore for MemoryExecutionStore {
+        fn get(&self, decision_hash: &str) -> Result<Option<ExecutionRecord>> {
+            Ok(self
+                .records
+                .read()
+                .map_err(|e| anyhow::anyhow!("lock: {e}"))?
+                .get(decision_hash)
+                .cloned())
+        }
+
+        fn put(&self, record: &ExecutionRecord) -> Result<()> {
+            self.records
+                .write()
+                .map_err(|e| anyhow::anyhow!("lock: {e}"))?
+                .insert(record.decision_hash.clone(), record.clone());
+            Ok(())
+        }
+
+        fn list_by_status(&self, status: ExecutionStatus) -> Result<Vec<ExecutionRecord>> {
+            Ok(self
+                .records
+                .read()
+                .map_err(|e| anyhow::anyhow!("lock: {e}"))?
+                .values()
+                .filter(|r| r.status == status)
+                .cloned()
+                .collect())
+        }
+
+        fn count_by_status(&self) -> Result<HashMap<ExecutionStatus, usize>> {
+            let mut counts = HashMap::new();
+            for record in self
+                .records
+                .read()
+                .map_err(|e| anyhow::anyhow!("lock: {e}"))?
+                .values()
+            {
+                *counts.entry(record.status).or_insert(0) += 1;
+            }
+            Ok(counts)
+        }
+    }
+
+    /// Helper: create a DecisionExecutor with in-memory stores and no ledger.
+    fn make_test_executor() -> (Arc<DecisionExecutor>, Arc<MemoryExecutionStore>) {
+        use icn_kernel_api::protocol_params::*;
+
+        // Minimal param store stub
+        struct StubParamStore;
+        impl ProtocolParameterStore for StubParamStore {
+            fn get(&self, _: &str) -> Result<Option<ProtocolParameter>> {
+                Ok(None)
+            }
+            fn get_effective(
+                &self,
+                _: &str,
+                _: Option<&str>,
+                _: Option<&str>,
+            ) -> Result<Option<ProtocolParameter>> {
+                Ok(None)
+            }
+            fn set(
+                &self,
+                _: ProtocolParameter,
+                _: Option<String>,
+                _: Option<String>,
+            ) -> Result<()> {
+                Ok(())
+            }
+            fn list(&self) -> Result<Vec<ProtocolParameter>> {
+                Ok(vec![])
+            }
+            fn list_by_category(&self, _: &str) -> Result<Vec<ProtocolParameter>> {
+                Ok(vec![])
+            }
+            fn get_history(&self, _: &str) -> Result<Vec<ParameterChange>> {
+                Ok(vec![])
+            }
+            fn get_history_paginated(
+                &self,
+                _: &str,
+                _: usize,
+                _: usize,
+            ) -> Result<(Vec<ParameterChange>, usize)> {
+                Ok((vec![], 0))
+            }
+            fn prune_history(&self, _: &str, _: usize) -> Result<usize> {
+                Ok(0)
+            }
+            fn delete(&self, _: &str) -> Result<()> {
+                Ok(())
+            }
+            fn exists(&self, _: &str) -> Result<bool> {
+                Ok(false)
+            }
+            fn count(&self) -> Result<usize> {
+                Ok(0)
+            }
+            fn total_history_count(&self) -> Result<usize> {
+                Ok(0)
+            }
+            fn validate(
+                &self,
+                _: &str,
+                _: &ParameterValue,
+            ) -> std::result::Result<(), ParameterValidationError> {
+                Ok(())
+            }
+            fn list_scoped_parameters(&self) -> Result<Vec<ProtocolParameter>> {
+                Ok(vec![])
+            }
+            fn delete_scoped_parameter(&self, _: &str, _: &ParameterScope) -> Result<bool> {
+                Ok(false)
+            }
+            fn add_pending_change(&self, _: PendingParameterChange) -> Result<()> {
+                Ok(())
+            }
+            fn get_pending_change(
+                &self,
+                _: &PendingChangeId,
+            ) -> Result<Option<PendingParameterChange>> {
+                Ok(None)
+            }
+            fn list_pending_changes(&self) -> Result<Vec<PendingParameterChange>> {
+                Ok(vec![])
+            }
+            fn list_pending_changes_for_parameter(
+                &self,
+                _: &str,
+            ) -> Result<Vec<PendingParameterChange>> {
+                Ok(vec![])
+            }
+            fn get_changes_due_before(&self, _: u64) -> Result<Vec<PendingParameterChange>> {
+                Ok(vec![])
+            }
+            fn update_pending_change(&self, _: PendingParameterChange) -> Result<()> {
+                Ok(())
+            }
+            fn cancel_pending_change(&self, _: &PendingChangeId, _: &str) -> Result<()> {
+                Ok(())
+            }
+            fn count_pending_changes(&self) -> Result<usize> {
+                Ok(0)
+            }
+        }
+
+        let param_store = Arc::new(StubParamStore);
+        let kernel_executor =
+            Arc::new(super::super::governance_executor::KernelGovernanceExecutor::new(param_store));
+        let dispatcher = Arc::new(EffectDispatcher::new(kernel_executor));
+        let exec_store = Arc::new(MemoryExecutionStore::new());
+
+        let decision_executor = Arc::new(DecisionExecutor::new(dispatcher, exec_store.clone()));
+
+        (decision_executor, exec_store)
+    }
+
+    #[tokio::test]
+    async fn test_execute_records_status() {
+        let (executor, store) = make_test_executor();
+
+        let effects = vec![KernelEffect::NoOp {
+            reason: "test".to_string(),
+        }];
+
+        let results = executor
+            .execute(effects, "receipt-1", "hash-1", "proposal-1")
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].success);
+
+        // Verify record was persisted with Confirmed status
+        let record = store.get("hash-1").unwrap().unwrap();
+        assert_eq!(record.status, ExecutionStatus::Confirmed);
+        assert_eq!(record.proposal_id, "proposal-1");
+        assert!(record.finished_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_idempotency_skips_confirmed() {
+        let (executor, store) = make_test_executor();
+
+        // First execution
+        let effects = vec![KernelEffect::NoOp {
+            reason: "first".to_string(),
+        }];
+        let results1 = executor
+            .execute(effects, "receipt-1", "hash-1", "proposal-1")
+            .await
+            .unwrap();
+        assert_eq!(results1.len(), 1);
+
+        // Second execution with same decision_hash — should be skipped
+        let effects2 = vec![KernelEffect::NoOp {
+            reason: "duplicate".to_string(),
+        }];
+        let results2 = executor
+            .execute(effects2, "receipt-1", "hash-1", "proposal-1")
+            .await
+            .unwrap();
+        assert!(
+            results2.is_empty(),
+            "Duplicate execution should return empty"
+        );
+
+        // Status should still be Confirmed
+        let record = store.get("hash-1").unwrap().unwrap();
+        assert_eq!(record.status, ExecutionStatus::Confirmed);
+    }
+
+    #[tokio::test]
+    async fn test_idempotency_skips_permanently_failed() {
+        let (executor, store) = make_test_executor();
+
+        // Manually insert a permanently failed record
+        let mut record = ExecutionRecord::new_pending("hash-pf", "p-1", "r-1");
+        record.mark_permanently_failed("Non-recoverable");
+        store.put(&record).unwrap();
+
+        // Attempt execution — should be skipped
+        let effects = vec![KernelEffect::NoOp {
+            reason: "retry".to_string(),
+        }];
+        let results = executor
+            .execute(effects, "r-1", "hash-pf", "p-1")
+            .await
+            .unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_treasury_effect_with_decision_hash() {
+        let (executor, store) = make_test_executor();
+
+        let effects = vec![KernelEffect::Treasury(TreasuryEffect::Spend {
+            treasury_did: "did:icn:treasury".to_string(),
+            recipient_did: "did:icn:alice".to_string(),
+            amount: 500,
+            currency: "HOURS".to_string(),
+            memo: "Test".to_string(),
+            decision_receipt_id: "receipt-t1".to_string(),
+            decision_hash: "sha256:treasury-hash-1".to_string(),
+        })];
+
+        let results = executor
+            .execute(
+                effects,
+                "receipt-t1",
+                "sha256:treasury-hash-1",
+                "proposal-t1",
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].success);
+
+        let record = store.get("sha256:treasury-hash-1").unwrap().unwrap();
+        assert_eq!(record.status, ExecutionStatus::Confirmed);
+    }
+
+    #[tokio::test]
+    async fn test_extract_decision_hash_from_effects() {
+        let effects = vec![
+            KernelEffect::NoOp {
+                reason: "first".to_string(),
+            },
+            KernelEffect::Treasury(TreasuryEffect::Spend {
+                treasury_did: "t".to_string(),
+                recipient_did: "r".to_string(),
+                amount: 100,
+                currency: "ICN".to_string(),
+                memo: "m".to_string(),
+                decision_receipt_id: "r1".to_string(),
+                decision_hash: "extracted-hash".to_string(),
+            }),
+        ];
+
+        assert_eq!(
+            extract_decision_hash(&effects),
+            Some("extracted-hash".to_string())
+        );
+
+        // No treasury effects → None
+        let no_hash = vec![KernelEffect::NoOp {
+            reason: "only".to_string(),
+        }];
+        assert_eq!(extract_decision_hash(&no_hash), None);
+    }
+
+    #[tokio::test]
+    async fn test_different_decisions_execute_independently() {
+        let (executor, store) = make_test_executor();
+
+        // Decision A
+        executor
+            .execute(
+                vec![KernelEffect::NoOp { reason: "a".into() }],
+                "r-a",
+                "hash-a",
+                "p-a",
+            )
+            .await
+            .unwrap();
+
+        // Decision B
+        executor
+            .execute(
+                vec![KernelEffect::NoOp { reason: "b".into() }],
+                "r-b",
+                "hash-b",
+                "p-b",
+            )
+            .await
+            .unwrap();
+
+        // Both should be independently confirmed
+        let a = store.get("hash-a").unwrap().unwrap();
+        let b = store.get("hash-b").unwrap().unwrap();
+        assert_eq!(a.status, ExecutionStatus::Confirmed);
+        assert_eq!(b.status, ExecutionStatus::Confirmed);
+        assert_ne!(a.proposal_id, b.proposal_id);
+    }
+}

--- a/icn/crates/icn-core/src/supervisor/escrow_store.rs
+++ b/icn/crates/icn-core/src/supervisor/escrow_store.rs
@@ -1,0 +1,161 @@
+//! Sled-backed escrow store for persistent escrow records.
+//!
+//! Follows the same pattern as `SledExecutionStore`: prefix-scoped keys,
+//! JSON serialization, prefix scans for scope queries.
+
+use anyhow::{Context, Result};
+use icn_kernel_api::escrow::{EscrowRecord, EscrowStore};
+use std::sync::Arc;
+
+/// Sled-backed implementation of `EscrowStore`.
+///
+/// Keys: `escrow:<escrow_id>`
+/// Values: JSON-serialized `EscrowRecord`
+pub struct SledEscrowStore<S: icn_store::Store> {
+    store: Arc<S>,
+}
+
+impl<S: icn_store::Store> SledEscrowStore<S> {
+    const PREFIX: &'static [u8] = b"escrow:";
+
+    /// Create a new escrow store backed by the given sled store.
+    pub fn new(store: Arc<S>) -> Self {
+        Self { store }
+    }
+
+    fn entry_key(escrow_id: &str) -> Vec<u8> {
+        let mut key = Self::PREFIX.to_vec();
+        key.extend_from_slice(escrow_id.as_bytes());
+        key
+    }
+}
+
+impl<S: icn_store::Store> EscrowStore for SledEscrowStore<S> {
+    fn get(&self, escrow_id: &str) -> Result<Option<EscrowRecord>> {
+        let key = Self::entry_key(escrow_id);
+        match self.store.get(&key)? {
+            Some(data) => {
+                let record: EscrowRecord =
+                    serde_json::from_slice(&data).context("Failed to deserialize escrow record")?;
+                Ok(Some(record))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn put(&self, record: &EscrowRecord) -> Result<()> {
+        let key = Self::entry_key(&record.escrow_id);
+        let value = serde_json::to_vec(record).context("Failed to serialize escrow record")?;
+        self.store
+            .put(&key, &value)
+            .context("Failed to store escrow record")?;
+        Ok(())
+    }
+
+    fn list_by_scope(&self, scope_id: &str) -> Result<Vec<EscrowRecord>> {
+        let entries = self.store.scan(Self::PREFIX)?;
+        let mut result = Vec::new();
+
+        for (_key, value) in entries {
+            let record: EscrowRecord =
+                serde_json::from_slice(&value).context("Failed to deserialize escrow record")?;
+            if record.scope_id == scope_id {
+                result.push(record);
+            }
+        }
+
+        result.sort_by_key(|r| r.created_at);
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use icn_kernel_api::escrow::EscrowStatus;
+    use icn_store::SledStore;
+
+    fn test_store() -> Arc<SledStore> {
+        Arc::new(SledStore::temporary().unwrap())
+    }
+
+    #[test]
+    fn test_put_and_get() {
+        let store = test_store();
+        let escrow_store = SledEscrowStore::new(store);
+
+        let record = EscrowRecord::new_locked(
+            "esc-1",
+            "coop-alpha",
+            "did:treasury",
+            "did:alice",
+            5000,
+            "HOURS",
+        );
+        escrow_store.put(&record).unwrap();
+
+        let retrieved = escrow_store.get("esc-1").unwrap().unwrap();
+        assert_eq!(retrieved.escrow_id, "esc-1");
+        assert_eq!(retrieved.status, EscrowStatus::Locked);
+        assert_eq!(retrieved.amount, 5000);
+    }
+
+    #[test]
+    fn test_get_nonexistent() {
+        let store = test_store();
+        let escrow_store = SledEscrowStore::new(store);
+
+        assert!(escrow_store.get("nonexistent").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_update_on_release() {
+        let store = test_store();
+        let escrow_store = SledEscrowStore::new(store);
+
+        let mut record = EscrowRecord::new_locked(
+            "esc-2",
+            "coop-alpha",
+            "did:treasury",
+            "did:bob",
+            3000,
+            "HOURS",
+        );
+        escrow_store.put(&record).unwrap();
+
+        // Release the escrow
+        record.release("decision-hash-1").unwrap();
+        escrow_store.put(&record).unwrap();
+
+        let retrieved = escrow_store.get("esc-2").unwrap().unwrap();
+        assert_eq!(retrieved.status, EscrowStatus::Released);
+        assert_eq!(
+            retrieved.release_decision_hash.as_deref(),
+            Some("decision-hash-1")
+        );
+        assert!(retrieved.released_at.is_some());
+    }
+
+    #[test]
+    fn test_list_by_scope() {
+        let store = test_store();
+        let escrow_store = SledEscrowStore::new(store);
+
+        let r1 =
+            EscrowRecord::new_locked("esc-a", "coop-alpha", "did:t", "did:alice", 1000, "HOURS");
+        let r2 = EscrowRecord::new_locked("esc-b", "coop-alpha", "did:t", "did:bob", 2000, "HOURS");
+        let r3 =
+            EscrowRecord::new_locked("esc-c", "coop-beta", "did:t", "did:carol", 3000, "HOURS");
+
+        escrow_store.put(&r1).unwrap();
+        escrow_store.put(&r2).unwrap();
+        escrow_store.put(&r3).unwrap();
+
+        let alpha = escrow_store.list_by_scope("coop-alpha").unwrap();
+        assert_eq!(alpha.len(), 2);
+
+        let beta = escrow_store.list_by_scope("coop-beta").unwrap();
+        assert_eq!(beta.len(), 1);
+        assert_eq!(beta[0].escrow_id, "esc-c");
+    }
+}

--- a/icn/crates/icn-core/src/supervisor/escrow_store.rs
+++ b/icn/crates/icn-core/src/supervisor/escrow_store.rs
@@ -123,8 +123,9 @@ mod tests {
         );
         escrow_store.put(&record).unwrap();
 
-        // Release the escrow
-        record.release("decision-hash-1").unwrap();
+        // Release the escrow (two-phase saga)
+        record.begin_release("decision-hash-1").unwrap();
+        record.confirm_release();
         escrow_store.put(&record).unwrap();
 
         let retrieved = escrow_store.get("esc-2").unwrap().unwrap();

--- a/icn/crates/icn-core/src/supervisor/execution_store.rs
+++ b/icn/crates/icn-core/src/supervisor/execution_store.rs
@@ -1,0 +1,181 @@
+//! Sled-backed execution store for persistent decision execution records.
+//!
+//! Follows the same pattern as `DeadLetterQueue`: prefix-scoped keys,
+//! JSON serialization, prefix scans for status queries.
+
+use anyhow::{Context, Result};
+use icn_kernel_api::execution::{ExecutionRecord, ExecutionStatus, ExecutionStore};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Sled-backed implementation of `ExecutionStore`.
+///
+/// Keys: `exec:<decision_hash>`
+/// Values: JSON-serialized `ExecutionRecord`
+pub struct SledExecutionStore<S: icn_store::Store> {
+    store: Arc<S>,
+}
+
+impl<S: icn_store::Store> SledExecutionStore<S> {
+    const PREFIX: &'static [u8] = b"exec:";
+
+    /// Create a new execution store backed by the given sled store.
+    pub fn new(store: Arc<S>) -> Self {
+        Self { store }
+    }
+
+    fn entry_key(decision_hash: &str) -> Vec<u8> {
+        let mut key = Self::PREFIX.to_vec();
+        key.extend_from_slice(decision_hash.as_bytes());
+        key
+    }
+}
+
+impl<S: icn_store::Store> ExecutionStore for SledExecutionStore<S> {
+    fn get(&self, decision_hash: &str) -> Result<Option<ExecutionRecord>> {
+        let key = Self::entry_key(decision_hash);
+        match self.store.get(&key)? {
+            Some(data) => {
+                let record: ExecutionRecord = serde_json::from_slice(&data)
+                    .context("Failed to deserialize execution record")?;
+                Ok(Some(record))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn put(&self, record: &ExecutionRecord) -> Result<()> {
+        let key = Self::entry_key(&record.decision_hash);
+        let value = serde_json::to_vec(record).context("Failed to serialize execution record")?;
+        self.store
+            .put(&key, &value)
+            .context("Failed to store execution record")?;
+        Ok(())
+    }
+
+    fn list_by_status(&self, status: ExecutionStatus) -> Result<Vec<ExecutionRecord>> {
+        let entries = self.store.scan(Self::PREFIX)?;
+        let mut result = Vec::new();
+
+        for (_key, value) in entries {
+            let record: ExecutionRecord =
+                serde_json::from_slice(&value).context("Failed to deserialize execution record")?;
+            if record.status == status {
+                result.push(record);
+            }
+        }
+
+        result.sort_by_key(|r| r.started_at);
+        Ok(result)
+    }
+
+    fn count_by_status(&self) -> Result<HashMap<ExecutionStatus, usize>> {
+        let entries = self.store.scan(Self::PREFIX)?;
+        let mut counts = HashMap::new();
+
+        for (_key, value) in entries {
+            let record: ExecutionRecord =
+                serde_json::from_slice(&value).context("Failed to deserialize execution record")?;
+            *counts.entry(record.status).or_insert(0) += 1;
+        }
+
+        Ok(counts)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use icn_store::SledStore;
+
+    fn test_store() -> Arc<SledStore> {
+        Arc::new(SledStore::temporary().unwrap())
+    }
+
+    #[test]
+    fn test_put_and_get() {
+        let store = test_store();
+        let exec_store = SledExecutionStore::new(store);
+
+        let record = ExecutionRecord::new_pending("hash123", "proposal-1", "receipt-1");
+        exec_store.put(&record).unwrap();
+
+        let retrieved = exec_store.get("hash123").unwrap().unwrap();
+        assert_eq!(retrieved.decision_hash, "hash123");
+        assert_eq!(retrieved.proposal_id, "proposal-1");
+        assert_eq!(retrieved.status, ExecutionStatus::Pending);
+    }
+
+    #[test]
+    fn test_get_nonexistent() {
+        let store = test_store();
+        let exec_store = SledExecutionStore::new(store);
+
+        assert!(exec_store.get("nonexistent").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_update() {
+        let store = test_store();
+        let exec_store = SledExecutionStore::new(store);
+
+        let mut record = ExecutionRecord::new_pending("hash456", "proposal-2", "receipt-2");
+        exec_store.put(&record).unwrap();
+
+        record.mark_executing();
+        exec_store.put(&record).unwrap();
+
+        record.mark_confirmed(vec!["entry-1".into()], vec!["state-1".into()]);
+        exec_store.put(&record).unwrap();
+
+        let retrieved = exec_store.get("hash456").unwrap().unwrap();
+        assert_eq!(retrieved.status, ExecutionStatus::Confirmed);
+        assert_eq!(retrieved.ledger_entry_ids, vec!["entry-1"]);
+    }
+
+    #[test]
+    fn test_list_by_status() {
+        let store = test_store();
+        let exec_store = SledExecutionStore::new(store);
+
+        // Add records in different states
+        let pending = ExecutionRecord::new_pending("h1", "p1", "r1");
+        exec_store.put(&pending).unwrap();
+
+        let mut confirmed = ExecutionRecord::new_pending("h2", "p2", "r2");
+        confirmed.mark_confirmed(vec![], vec![]);
+        exec_store.put(&confirmed).unwrap();
+
+        let mut failed = ExecutionRecord::new_pending("h3", "p3", "r3");
+        failed.mark_failed("oops");
+        exec_store.put(&failed).unwrap();
+
+        let pending_list = exec_store.list_by_status(ExecutionStatus::Pending).unwrap();
+        assert_eq!(pending_list.len(), 1);
+        assert_eq!(pending_list[0].decision_hash, "h1");
+
+        let confirmed_list = exec_store
+            .list_by_status(ExecutionStatus::Confirmed)
+            .unwrap();
+        assert_eq!(confirmed_list.len(), 1);
+    }
+
+    #[test]
+    fn test_count_by_status() {
+        let store = test_store();
+        let exec_store = SledExecutionStore::new(store);
+
+        let r1 = ExecutionRecord::new_pending("a", "p1", "r1");
+        let r2 = ExecutionRecord::new_pending("b", "p2", "r2");
+        let mut r3 = ExecutionRecord::new_pending("c", "p3", "r3");
+        r3.mark_confirmed(vec![], vec![]);
+
+        exec_store.put(&r1).unwrap();
+        exec_store.put(&r2).unwrap();
+        exec_store.put(&r3).unwrap();
+
+        let counts = exec_store.count_by_status().unwrap();
+        assert_eq!(counts.get(&ExecutionStatus::Pending), Some(&2));
+        assert_eq!(counts.get(&ExecutionStatus::Confirmed), Some(&1));
+    }
+}

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -15,7 +15,10 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use icn_kernel_api::effects::{ControlEffect, EffectResult, KernelEffect, MembershipEffect};
+use icn_kernel_api::effects::{
+    ControlEffect, EffectResult, KernelEffect, MembershipEffect, TreasuryEffect,
+};
+use icn_kernel_api::escrow::{EscrowReleaseError, EscrowStore};
 use icn_kernel_api::governance::{
     federation_effect_to_operation, DecisionReceiptId, EffectExecutor, ExecutionOutcome,
     FederationExecutor, FederationOperation, GovernanceExecutor, ProtocolChange, ProtocolExecutor,
@@ -37,6 +40,8 @@ pub struct KernelGovernanceExecutor {
     federation: Arc<KernelFederationExecutor>,
     control: Arc<KernelControlExecutor>,
     membership: Arc<KernelMembershipExecutor>,
+    /// Escrow store for domain-level idempotency on escrow releases.
+    escrow_store: Option<Arc<dyn EscrowStore>>,
 }
 
 impl KernelGovernanceExecutor {
@@ -51,6 +56,7 @@ impl KernelGovernanceExecutor {
             federation: Arc::new(KernelFederationExecutor::new()),
             control: Arc::new(KernelControlExecutor::new()),
             membership: Arc::new(KernelMembershipExecutor::new()),
+            escrow_store: None,
         }
     }
 
@@ -83,6 +89,12 @@ impl KernelGovernanceExecutor {
         self.membership = Arc::new(KernelMembershipExecutor::with_service(service));
         self
     }
+
+    /// Set the escrow store for domain-level idempotency on escrow releases.
+    pub fn with_escrow_store(mut self, store: Arc<dyn EscrowStore>) -> Self {
+        self.escrow_store = Some(store);
+        self
+    }
 }
 
 impl GovernanceExecutor for KernelGovernanceExecutor {
@@ -109,6 +121,123 @@ impl EffectExecutor for KernelGovernanceExecutor {
         let receipt_id = DecisionReceiptId::new(decision_receipt_id);
 
         match effect {
+            KernelEffect::Treasury(TreasuryEffect::ReleaseEscrow {
+                ref escrow_id,
+                ref decision_hash,
+                ..
+            }) => {
+                // Domain-level idempotency: check escrow store BEFORE ledger mutation.
+                let escrow_store = match &self.escrow_store {
+                    Some(store) => store,
+                    None => {
+                        warn!(
+                            escrow_id = %escrow_id,
+                            "Escrow store not configured — cannot release escrow"
+                        );
+                        return Ok(EffectResult {
+                            effect_id: decision_receipt_id.to_string(),
+                            success: false,
+                            message: "Escrow store not configured".to_string(),
+                            state_change_hash: None,
+                        });
+                    }
+                };
+
+                // Look up escrow
+                let mut escrow = match escrow_store.get(escrow_id)? {
+                    Some(e) => e,
+                    None => {
+                        warn!(
+                            escrow_id = %escrow_id,
+                            "Escrow not found"
+                        );
+                        return Ok(EffectResult {
+                            effect_id: decision_receipt_id.to_string(),
+                            success: false,
+                            message: format!("Escrow not found: {}", escrow_id),
+                            state_change_hash: None,
+                        });
+                    }
+                };
+
+                // Domain-level idempotency check
+                match escrow.release(decision_hash) {
+                    Ok(()) => {
+                        // Persist the Released status
+                        escrow_store.put(&escrow)?;
+                        info!(
+                            escrow_id = %escrow_id,
+                            decision_hash = %decision_hash,
+                            "Escrow released, proceeding to ledger mutation"
+                        );
+                    }
+                    Err(EscrowReleaseError::AlreadyReleasedSameDecision) => {
+                        // Idempotent — same decision already released this escrow.
+                        // Return success (not an error from the caller's perspective).
+                        info!(
+                            escrow_id = %escrow_id,
+                            decision_hash = %decision_hash,
+                            "Escrow already released by this decision (idempotent)"
+                        );
+                        return Ok(EffectResult {
+                            effect_id: decision_receipt_id.to_string(),
+                            success: true,
+                            message: format!(
+                                "Escrow {} already released by this decision (idempotent)",
+                                escrow_id
+                            ),
+                            state_change_hash: None,
+                        });
+                    }
+                    Err(EscrowReleaseError::AlreadyReleasedByOther {
+                        existing_decision_hash,
+                    }) => {
+                        warn!(
+                            escrow_id = %escrow_id,
+                            decision_hash = %decision_hash,
+                            existing_decision_hash = %existing_decision_hash,
+                            "Escrow already released by a different decision — conflict"
+                        );
+                        return Ok(EffectResult {
+                            effect_id: decision_receipt_id.to_string(),
+                            success: false,
+                            message: format!(
+                                "Escrow {} already released by decision {}",
+                                escrow_id, existing_decision_hash
+                            ),
+                            state_change_hash: None,
+                        });
+                    }
+                    Err(EscrowReleaseError::Cancelled) => {
+                        warn!(
+                            escrow_id = %escrow_id,
+                            "Cannot release cancelled escrow"
+                        );
+                        return Ok(EffectResult {
+                            effect_id: decision_receipt_id.to_string(),
+                            success: false,
+                            message: format!("Escrow {} was cancelled", escrow_id),
+                            state_change_hash: None,
+                        });
+                    }
+                }
+
+                // Escrow is now Released — delegate to treasury for the actual ledger mutation.
+                // We destructure here to get owned values for TreasuryOperation.
+                if let KernelEffect::Treasury(ref treasury_effect) = effect {
+                    let operation = treasury_effect_to_operation(treasury_effect);
+                    let outcome = self
+                        .treasury
+                        .execute_treasury_operation(&receipt_id, operation)
+                        .await?;
+                    Ok(execution_outcome_to_effect_result(
+                        outcome,
+                        decision_receipt_id,
+                    ))
+                } else {
+                    unreachable!("already matched Treasury variant")
+                }
+            }
             KernelEffect::Treasury(treasury_effect) => {
                 // Convert TreasuryEffect to TreasuryOperation
                 let operation = treasury_effect_to_operation(&treasury_effect);
@@ -786,6 +915,23 @@ fn treasury_effect_to_operation(
             recipient: Some(to_did.clone()),
             memo: memo.clone(),
             decision_hash: None, // No decision provenance for this variant
+        },
+        TreasuryEffect::ReleaseEscrow {
+            treasury_did,
+            beneficiary_did,
+            amount,
+            currency,
+            escrow_id,
+            decision_hash,
+            ..
+        } => TreasuryOperation {
+            treasury_id: treasury_did.clone(),
+            operation_type: icn_kernel_api::governance::TreasuryOperationType::Release,
+            amount: *amount,
+            currency: currency.clone(),
+            recipient: Some(beneficiary_did.clone()),
+            memo: format!("Escrow release: {}", escrow_id),
+            decision_hash: Some(decision_hash.clone()),
         },
         // Other treasury effects mapped to basic operations
         _ => TreasuryOperation {

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -18,11 +18,11 @@ use async_trait::async_trait;
 use icn_kernel_api::effects::{
     ControlEffect, EffectResult, KernelEffect, MembershipEffect, TreasuryEffect,
 };
-use icn_kernel_api::escrow::{EscrowReleaseError, EscrowStore};
+use icn_kernel_api::escrow::{BeginReleaseOutcome, EscrowReleaseError, EscrowStore};
 use icn_kernel_api::governance::{
-    federation_effect_to_operation, DecisionReceiptId, EffectExecutor, ExecutionOutcome,
-    FederationExecutor, FederationOperation, GovernanceExecutor, ProtocolChange, ProtocolExecutor,
-    TreasuryExecutor, TreasuryOperation,
+    federation_effect_to_operation, treasury_effect_to_operation, DecisionReceiptId,
+    EffectExecutor, ExecutionOutcome, FederationExecutor, FederationOperation, GovernanceExecutor,
+    ProtocolChange, ProtocolExecutor, TreasuryExecutor, TreasuryOperation,
 };
 use icn_kernel_api::protocol_params::ProtocolParameterStore;
 use icn_kernel_api::{ControlService, ForceCloseProposalRequest, VetoProposalRequest};
@@ -126,7 +126,9 @@ impl EffectExecutor for KernelGovernanceExecutor {
                 ref decision_hash,
                 ..
             }) => {
-                // Domain-level idempotency: check escrow store BEFORE ledger mutation.
+                // Domain-level idempotency via saga: Locked → Releasing → Released.
+                // Releasing is persisted BEFORE ledger mutation so crash recovery
+                // can detect the in-flight state and re-attempt.
                 let escrow_store = match &self.escrow_store {
                     Some(store) => store,
                     None => {
@@ -160,20 +162,29 @@ impl EffectExecutor for KernelGovernanceExecutor {
                     }
                 };
 
-                // Domain-level idempotency check
-                match escrow.release(decision_hash) {
-                    Ok(()) => {
-                        // Persist the Released status
+                // Phase 1: Record intent to release (saga).
+                // begin_release transitions Locked → Releasing, or signals retry/idempotent.
+                match escrow.begin_release(decision_hash) {
+                    Ok(BeginReleaseOutcome::Proceed) => {
+                        // Fresh release — persist Releasing state BEFORE ledger mutation.
                         escrow_store.put(&escrow)?;
                         info!(
                             escrow_id = %escrow_id,
                             decision_hash = %decision_hash,
-                            "Escrow released, proceeding to ledger mutation"
+                            "Escrow entering Releasing state, proceeding to ledger mutation"
+                        );
+                    }
+                    Ok(BeginReleaseOutcome::RetryNeeded) => {
+                        // Crash recovery — escrow already in Releasing with same hash.
+                        // Re-attempt the ledger mutation (skip redundant persist).
+                        info!(
+                            escrow_id = %escrow_id,
+                            decision_hash = %decision_hash,
+                            "Escrow in Releasing state (crash recovery), retrying ledger mutation"
                         );
                     }
                     Err(EscrowReleaseError::AlreadyReleasedSameDecision) => {
-                        // Idempotent — same decision already released this escrow.
-                        // Return success (not an error from the caller's perspective).
+                        // Fully released — same decision already completed this escrow.
                         info!(
                             escrow_id = %escrow_id,
                             decision_hash = %decision_hash,
@@ -222,18 +233,47 @@ impl EffectExecutor for KernelGovernanceExecutor {
                     }
                 }
 
-                // Escrow is now Released — delegate to treasury for the actual ledger mutation.
-                // We destructure here to get owned values for TreasuryOperation.
+                // Phase 2: Execute ledger mutation (escrow is now in Releasing state).
                 if let KernelEffect::Treasury(ref treasury_effect) = effect {
                     let operation = treasury_effect_to_operation(treasury_effect);
-                    let outcome = self
+                    match self
                         .treasury
                         .execute_treasury_operation(&receipt_id, operation)
-                        .await?;
-                    Ok(execution_outcome_to_effect_result(
-                        outcome,
-                        decision_receipt_id,
-                    ))
+                        .await
+                    {
+                        Ok(outcome) => {
+                            let result =
+                                execution_outcome_to_effect_result(outcome, decision_receipt_id);
+                            if result.success {
+                                // Phase 3: Confirm release — ledger mutation succeeded.
+                                // Transition Releasing → Released.
+                                escrow.confirm_release();
+                                escrow_store.put(&escrow)?;
+                                info!(
+                                    escrow_id = %escrow_id,
+                                    "Escrow release confirmed (Released)"
+                                );
+                            } else {
+                                // Treasury returned logical failure (e.g. insufficient funds).
+                                // Escrow stays in Releasing — retry via same decision_hash.
+                                warn!(
+                                    escrow_id = %escrow_id,
+                                    message = %result.message,
+                                    "Treasury operation failed, escrow stays in Releasing for retry"
+                                );
+                            }
+                            Ok(result)
+                        }
+                        Err(e) => {
+                            // System error — escrow stays in Releasing for crash recovery.
+                            warn!(
+                                escrow_id = %escrow_id,
+                                error = %e,
+                                "Ledger mutation error, escrow stays in Releasing"
+                            );
+                            Err(e)
+                        }
+                    }
                 } else {
                     unreachable!("already matched Treasury variant")
                 }
@@ -845,105 +885,6 @@ fn parse_bytes(s: &str) -> Result<u64> {
         .map_err(|e| anyhow::anyhow!("Invalid byte size value '{}': {}", s, e))?;
 
     Ok(num * multiplier)
-}
-
-/// Convert a TreasuryEffect to a TreasuryOperation
-fn treasury_effect_to_operation(
-    effect: &icn_kernel_api::effects::TreasuryEffect,
-) -> TreasuryOperation {
-    use icn_kernel_api::effects::TreasuryEffect;
-    match effect {
-        TreasuryEffect::Spend {
-            treasury_did,
-            recipient_did,
-            amount,
-            currency,
-            memo,
-            decision_hash,
-            ..
-        } => TreasuryOperation {
-            treasury_id: treasury_did.clone(),
-            operation_type: icn_kernel_api::governance::TreasuryOperationType::Spend,
-            amount: *amount,
-            currency: currency.clone(),
-            recipient: Some(recipient_did.clone()),
-            memo: memo.clone(),
-            decision_hash: Some(decision_hash.clone()),
-        },
-        TreasuryEffect::CreateBudget {
-            treasury_did,
-            budget_id,
-            total_amount,
-            currency,
-            name,
-            decision_hash,
-            ..
-        } => TreasuryOperation {
-            treasury_id: treasury_did.clone(),
-            operation_type: icn_kernel_api::governance::TreasuryOperationType::Allocate,
-            amount: *total_amount,
-            currency: currency.clone(),
-            recipient: Some(budget_id.clone()),
-            memo: name.clone(),
-            decision_hash: Some(decision_hash.clone()),
-        },
-        TreasuryEffect::Allocate {
-            treasury_did,
-            budget_id,
-            amount,
-            currency,
-        } => TreasuryOperation {
-            treasury_id: treasury_did.clone(),
-            operation_type: icn_kernel_api::governance::TreasuryOperationType::Allocate,
-            amount: *amount,
-            currency: currency.clone(),
-            recipient: Some(budget_id.clone()),
-            memo: "Budget allocation".to_string(),
-            decision_hash: None, // No decision provenance for this variant
-        },
-        TreasuryEffect::Transfer {
-            from_did,
-            to_did,
-            amount,
-            currency,
-            memo,
-        } => TreasuryOperation {
-            treasury_id: from_did.clone(),
-            operation_type: icn_kernel_api::governance::TreasuryOperationType::Spend,
-            amount: *amount,
-            currency: currency.clone(),
-            recipient: Some(to_did.clone()),
-            memo: memo.clone(),
-            decision_hash: None, // No decision provenance for this variant
-        },
-        TreasuryEffect::ReleaseEscrow {
-            treasury_did,
-            beneficiary_did,
-            amount,
-            currency,
-            escrow_id,
-            decision_hash,
-            ..
-        } => TreasuryOperation {
-            treasury_id: treasury_did.clone(),
-            operation_type: icn_kernel_api::governance::TreasuryOperationType::Release,
-            amount: *amount,
-            currency: currency.clone(),
-            recipient: Some(beneficiary_did.clone()),
-            memo: format!("Escrow release: {}", escrow_id),
-            decision_hash: Some(decision_hash.clone()),
-        },
-        // Other treasury effects mapped to basic operations
-        _ => TreasuryOperation {
-            treasury_id: String::new(),
-            operation_type: icn_kernel_api::governance::TreasuryOperationType::Reserve,
-            amount: 0,
-            currency: "UNKNOWN".to_string(),
-            recipient: None,
-            memo: "Unmapped treasury effect".to_string(),
-            decision_hash: None,
-        },
-    }
 }
 
 /// Convert a ProtocolEffect to a ProtocolChange (if applicable)

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -627,6 +627,15 @@ async fn spawn_actors_with_identity(
         kernel_executor = kernel_executor.with_membership_service(membership_service);
         info!("✓ Membership service wired to governance executor");
 
+        // Create escrow store for domain-level idempotency
+        let escrow_store_path = config.store_path().join("escrow");
+        let escrow_sled_store: Arc<icn_store::SledStore> =
+            Arc::new(icn_store::SledStore::open(&escrow_store_path)?);
+        let escrow_store: Arc<dyn icn_kernel_api::escrow::EscrowStore> =
+            Arc::new(super::escrow_store::SledEscrowStore::new(escrow_sled_store));
+        kernel_executor = kernel_executor.with_escrow_store(escrow_store);
+        info!("✓ Escrow store wired to governance executor");
+
         // Create effect dispatcher
         let effect_dispatcher = Arc::new(super::effect_dispatcher::EffectDispatcher::new(
             Arc::new(kernel_executor),

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -632,9 +632,27 @@ async fn spawn_actors_with_identity(
             Arc::new(kernel_executor),
         ));
 
-        // Create callback that routes effects through dispatcher
+        // Create execution store for persistent idempotency tracking
+        let exec_store_path = config.store_path().join("execution");
+        let exec_sled_store: Arc<icn_store::SledStore> =
+            Arc::new(icn_store::SledStore::open(&exec_store_path)?);
+        let execution_store: Arc<dyn icn_kernel_api::execution::ExecutionStore> = Arc::new(
+            super::execution_store::SledExecutionStore::new(exec_sled_store),
+        );
+        info!(
+            "Execution store opened at {} for decision idempotency",
+            exec_store_path.display()
+        );
+
+        // Wrap dispatcher with DecisionExecutor for idempotent execution
+        let decision_executor = Arc::new(super::decision_executor::DecisionExecutor::new(
+            effect_dispatcher,
+            execution_store,
+        ));
+
+        // Create callback that routes effects through DecisionExecutor
         let effect_callback =
-            super::effect_dispatcher::create_effect_executor_callback(effect_dispatcher);
+            super::decision_executor::create_decision_executor_callback(decision_executor);
 
         // Create effect-based subscription via factory from BootstrapHandles
         // (avoids direct icn_governance_actor reference from lifecycle.rs)

--- a/icn/crates/icn-core/src/supervisor/mod.rs
+++ b/icn/crates/icn-core/src/supervisor/mod.rs
@@ -12,7 +12,9 @@
 pub mod actors;
 pub mod background_tasks;
 pub mod bridge;
+pub mod decision_executor;
 pub mod effect_dispatcher;
+pub mod execution_store;
 pub mod governance_executor;
 pub mod init_bootstrap;
 pub mod init_community;

--- a/icn/crates/icn-core/src/supervisor/mod.rs
+++ b/icn/crates/icn-core/src/supervisor/mod.rs
@@ -14,6 +14,7 @@ pub mod background_tasks;
 pub mod bridge;
 pub mod decision_executor;
 pub mod effect_dispatcher;
+pub mod escrow_store;
 pub mod execution_store;
 pub mod governance_executor;
 pub mod init_bootstrap;

--- a/icn/crates/icn-core/tests/escrow_release_integration.rs
+++ b/icn/crates/icn-core/tests/escrow_release_integration.rs
@@ -1,0 +1,601 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::expect_fun_call)]
+//! Integration tests for the escrow release vertical slice.
+//!
+//! These tests prove the end-to-end path:
+//! GovernanceDecision → TreasuryEffect::ReleaseEscrow → escrow check → ledger mutation
+//!
+//! Three required tests:
+//! 1. Replay doesn't double-spend (idempotency)
+//! 2. Crash mid-execution recovers correctly
+//! 3. Conflicting release decisions are rejected
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use icn_kernel_api::effects::{KernelEffect, TreasuryEffect};
+use icn_kernel_api::escrow::{EscrowRecord, EscrowStatus, EscrowStore};
+use icn_kernel_api::execution::{ExecutionRecord, ExecutionStatus, ExecutionStore};
+use icn_kernel_api::protocol_params::*;
+
+use icn_core::supervisor::decision_executor::DecisionExecutor;
+use icn_core::supervisor::effect_dispatcher::EffectDispatcher;
+use icn_core::supervisor::governance_executor::KernelGovernanceExecutor;
+
+// =============================================================================
+// In-memory test doubles
+// =============================================================================
+
+/// In-memory escrow store for integration testing.
+struct MemoryEscrowStore {
+    records: RwLock<HashMap<String, EscrowRecord>>,
+}
+
+impl MemoryEscrowStore {
+    fn new() -> Self {
+        Self {
+            records: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Pre-load an escrow for testing.
+    fn insert(&self, record: EscrowRecord) {
+        self.records
+            .write()
+            .unwrap()
+            .insert(record.escrow_id.clone(), record);
+    }
+
+    /// Get current escrow state (test inspection).
+    fn get_record(&self, escrow_id: &str) -> Option<EscrowRecord> {
+        self.records.read().unwrap().get(escrow_id).cloned()
+    }
+}
+
+impl EscrowStore for MemoryEscrowStore {
+    fn get(&self, escrow_id: &str) -> anyhow::Result<Option<EscrowRecord>> {
+        Ok(self.records.read().unwrap().get(escrow_id).cloned())
+    }
+
+    fn put(&self, record: &EscrowRecord) -> anyhow::Result<()> {
+        self.records
+            .write()
+            .unwrap()
+            .insert(record.escrow_id.clone(), record.clone());
+        Ok(())
+    }
+
+    fn list_by_scope(&self, scope_id: &str) -> anyhow::Result<Vec<EscrowRecord>> {
+        Ok(self
+            .records
+            .read()
+            .unwrap()
+            .values()
+            .filter(|r| r.scope_id == scope_id)
+            .cloned()
+            .collect())
+    }
+}
+
+/// In-memory execution store for integration testing.
+struct MemoryExecutionStore {
+    records: RwLock<HashMap<String, ExecutionRecord>>,
+}
+
+impl MemoryExecutionStore {
+    fn new() -> Self {
+        Self {
+            records: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl ExecutionStore for MemoryExecutionStore {
+    fn get(&self, decision_hash: &str) -> anyhow::Result<Option<ExecutionRecord>> {
+        Ok(self.records.read().unwrap().get(decision_hash).cloned())
+    }
+
+    fn put(&self, record: &ExecutionRecord) -> anyhow::Result<()> {
+        self.records
+            .write()
+            .unwrap()
+            .insert(record.decision_hash.clone(), record.clone());
+        Ok(())
+    }
+
+    fn list_by_status(&self, status: ExecutionStatus) -> anyhow::Result<Vec<ExecutionRecord>> {
+        Ok(self
+            .records
+            .read()
+            .unwrap()
+            .values()
+            .filter(|r| r.status == status)
+            .cloned()
+            .collect())
+    }
+
+    fn count_by_status(&self) -> anyhow::Result<HashMap<ExecutionStatus, usize>> {
+        let mut counts = HashMap::new();
+        for record in self.records.read().unwrap().values() {
+            *counts.entry(record.status).or_insert(0) += 1;
+        }
+        Ok(counts)
+    }
+}
+
+/// Minimal param store stub (no protocol params needed for escrow tests).
+struct StubParamStore;
+
+impl ProtocolParameterStore for StubParamStore {
+    fn get(&self, _: &str) -> anyhow::Result<Option<ProtocolParameter>> {
+        Ok(None)
+    }
+    fn get_effective(
+        &self,
+        _: &str,
+        _: Option<&str>,
+        _: Option<&str>,
+    ) -> anyhow::Result<Option<ProtocolParameter>> {
+        Ok(None)
+    }
+    fn set(
+        &self,
+        _: ProtocolParameter,
+        _: Option<String>,
+        _: Option<String>,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+    fn list(&self) -> anyhow::Result<Vec<ProtocolParameter>> {
+        Ok(vec![])
+    }
+    fn list_by_category(&self, _: &str) -> anyhow::Result<Vec<ProtocolParameter>> {
+        Ok(vec![])
+    }
+    fn get_history(&self, _: &str) -> anyhow::Result<Vec<ParameterChange>> {
+        Ok(vec![])
+    }
+    fn get_history_paginated(
+        &self,
+        _: &str,
+        _: usize,
+        _: usize,
+    ) -> anyhow::Result<(Vec<ParameterChange>, usize)> {
+        Ok((vec![], 0))
+    }
+    fn prune_history(&self, _: &str, _: usize) -> anyhow::Result<usize> {
+        Ok(0)
+    }
+    fn delete(&self, _: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    fn exists(&self, _: &str) -> anyhow::Result<bool> {
+        Ok(false)
+    }
+    fn count(&self) -> anyhow::Result<usize> {
+        Ok(0)
+    }
+    fn total_history_count(&self) -> anyhow::Result<usize> {
+        Ok(0)
+    }
+    fn validate(
+        &self,
+        _: &str,
+        _: &ParameterValue,
+    ) -> std::result::Result<(), ParameterValidationError> {
+        Ok(())
+    }
+    fn list_scoped_parameters(&self) -> anyhow::Result<Vec<ProtocolParameter>> {
+        Ok(vec![])
+    }
+    fn delete_scoped_parameter(&self, _: &str, _: &ParameterScope) -> anyhow::Result<bool> {
+        Ok(false)
+    }
+    fn add_pending_change(&self, _: PendingParameterChange) -> anyhow::Result<()> {
+        Ok(())
+    }
+    fn get_pending_change(
+        &self,
+        _: &PendingChangeId,
+    ) -> anyhow::Result<Option<PendingParameterChange>> {
+        Ok(None)
+    }
+    fn list_pending_changes(&self) -> anyhow::Result<Vec<PendingParameterChange>> {
+        Ok(vec![])
+    }
+    fn list_pending_changes_for_parameter(
+        &self,
+        _: &str,
+    ) -> anyhow::Result<Vec<PendingParameterChange>> {
+        Ok(vec![])
+    }
+    fn get_changes_due_before(&self, _: u64) -> anyhow::Result<Vec<PendingParameterChange>> {
+        Ok(vec![])
+    }
+    fn update_pending_change(&self, _: PendingParameterChange) -> anyhow::Result<()> {
+        Ok(())
+    }
+    fn cancel_pending_change(&self, _: &PendingChangeId, _: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    fn count_pending_changes(&self) -> anyhow::Result<usize> {
+        Ok(0)
+    }
+}
+
+// =============================================================================
+// Test helpers
+// =============================================================================
+
+/// Build a test executor with a shared escrow store.
+fn make_executor(
+    escrow_store: Arc<MemoryEscrowStore>,
+) -> (Arc<DecisionExecutor>, Arc<MemoryExecutionStore>) {
+    let param_store = Arc::new(StubParamStore);
+    let kernel_executor = KernelGovernanceExecutor::new(param_store)
+        .with_escrow_store(escrow_store as Arc<dyn EscrowStore>);
+    let dispatcher = Arc::new(EffectDispatcher::new(Arc::new(kernel_executor)));
+    let exec_store = Arc::new(MemoryExecutionStore::new());
+    let decision_executor = Arc::new(DecisionExecutor::new(dispatcher, exec_store.clone()));
+    (decision_executor, exec_store)
+}
+
+/// Build a ReleaseEscrow effect.
+fn release_escrow_effect(escrow_id: &str, decision_hash: &str) -> Vec<KernelEffect> {
+    vec![KernelEffect::Treasury(TreasuryEffect::ReleaseEscrow {
+        escrow_id: escrow_id.to_string(),
+        treasury_did: "did:icn:treasury:coop-alpha".to_string(),
+        beneficiary_did: "did:icn:member:alice".to_string(),
+        amount: 5000,
+        currency: "HOURS".to_string(),
+        decision_receipt_id: format!("receipt-{}", decision_hash),
+        decision_hash: decision_hash.to_string(),
+    })]
+}
+
+// =============================================================================
+// Test 1: Replay doesn't double-spend
+// =============================================================================
+
+/// Replay the same decision event 100 times. The escrow must be released
+/// exactly once — subsequent replays are idempotent at two levels:
+/// 1. Decision-level: ExecutionStore returns Confirmed → short-circuit
+/// 2. Domain-level: EscrowRecord.release() returns AlreadyReleasedSameDecision
+#[tokio::test]
+async fn test_replay_does_not_double_spend() {
+    let escrow_store = Arc::new(MemoryEscrowStore::new());
+
+    // Pre-load a locked escrow
+    escrow_store.insert(EscrowRecord::new_locked(
+        "esc-replay",
+        "coop-alpha",
+        "did:icn:treasury:coop-alpha",
+        "did:icn:member:alice",
+        5000,
+        "HOURS",
+    ));
+
+    let (executor, exec_store) = make_executor(escrow_store.clone());
+
+    // First execution — should succeed
+    let results = executor
+        .execute(
+            release_escrow_effect("esc-replay", "hash-replay-1"),
+            "receipt-hash-replay-1",
+            "hash-replay-1",
+            "proposal-replay",
+        )
+        .await
+        .expect("first execution should succeed");
+
+    assert_eq!(results.len(), 1);
+    assert!(results[0].success, "First execution should succeed");
+
+    // Verify escrow is now Released
+    let escrow = escrow_store.get_record("esc-replay").unwrap();
+    assert_eq!(escrow.status, EscrowStatus::Released);
+    assert_eq!(
+        escrow.release_decision_hash.as_deref(),
+        Some("hash-replay-1")
+    );
+
+    // Verify execution record is Confirmed
+    let record = exec_store.get("hash-replay-1").unwrap().unwrap();
+    assert_eq!(record.status, ExecutionStatus::Confirmed);
+
+    // Replay 99 more times — all should short-circuit via decision-level idempotency
+    for i in 2..=100 {
+        let results = executor
+            .execute(
+                release_escrow_effect("esc-replay", "hash-replay-1"),
+                "receipt-hash-replay-1",
+                "hash-replay-1",
+                "proposal-replay",
+            )
+            .await
+            .expect(&format!("replay {} should succeed", i));
+
+        // DecisionExecutor returns empty vec for already-confirmed decisions
+        assert!(
+            results.is_empty(),
+            "Replay {} should return empty (idempotent skip)",
+            i
+        );
+    }
+
+    // Escrow should still show exactly one release
+    let escrow_final = escrow_store.get_record("esc-replay").unwrap();
+    assert_eq!(escrow_final.status, EscrowStatus::Released);
+    assert_eq!(
+        escrow_final.release_decision_hash.as_deref(),
+        Some("hash-replay-1"),
+        "Should still be released by original decision"
+    );
+}
+
+// =============================================================================
+// Test 2: Crash mid-execution recovers correctly
+// =============================================================================
+
+/// Simulate crash recovery:
+/// 1. First executor processes escrow release → Confirmed
+/// 2. Simulate "crash" by creating a NEW executor with the SAME escrow store
+///    but a FRESH execution store (simulating lost in-flight state)
+/// 3. Replay the same decision → domain-level check catches it
+///
+/// Also tests the case where execution store shows Executing (crashed mid-flight):
+/// the executor should re-enter and the escrow domain check prevents double-spend.
+#[tokio::test]
+async fn test_crash_recovery_no_double_spend() {
+    let escrow_store = Arc::new(MemoryEscrowStore::new());
+
+    // Pre-load a locked escrow
+    escrow_store.insert(EscrowRecord::new_locked(
+        "esc-crash",
+        "coop-alpha",
+        "did:icn:treasury:coop-alpha",
+        "did:icn:member:bob",
+        3000,
+        "HOURS",
+    ));
+
+    // --- Phase 1: Normal execution succeeds ---
+    let (executor1, _exec_store1) = make_executor(escrow_store.clone());
+    let results = executor1
+        .execute(
+            release_escrow_effect("esc-crash", "hash-crash-1"),
+            "receipt-hash-crash-1",
+            "hash-crash-1",
+            "proposal-crash",
+        )
+        .await
+        .expect("first execution should succeed");
+    assert_eq!(results.len(), 1);
+    assert!(results[0].success);
+
+    // Escrow is now Released
+    let escrow = escrow_store.get_record("esc-crash").unwrap();
+    assert_eq!(escrow.status, EscrowStatus::Released);
+
+    // --- Phase 2: "Crash" — create fresh executor with same escrow store ---
+    // The execution store is fresh (simulates lost state), but escrow store
+    // retains the Released status (it's durable).
+    let (executor2, _exec_store2) = make_executor(escrow_store.clone());
+
+    // Replay the same decision on the "recovered" node.
+    // Since execution store is fresh, the decision-level check won't find it.
+    // But the escrow domain-level check will catch it.
+    let results2 = executor2
+        .execute(
+            release_escrow_effect("esc-crash", "hash-crash-1"),
+            "receipt-hash-crash-1",
+            "hash-crash-1",
+            "proposal-crash",
+        )
+        .await
+        .expect("crash recovery should not error");
+
+    assert_eq!(results2.len(), 1);
+    assert!(
+        results2[0].success,
+        "Domain-level idempotent release should return success: {}",
+        results2[0].message
+    );
+    assert!(
+        results2[0].message.contains("idempotent"),
+        "Message should indicate idempotent release: {}",
+        results2[0].message
+    );
+
+    // Escrow still shows original release
+    let escrow_final = escrow_store.get_record("esc-crash").unwrap();
+    assert_eq!(escrow_final.status, EscrowStatus::Released);
+    assert_eq!(
+        escrow_final.release_decision_hash.as_deref(),
+        Some("hash-crash-1")
+    );
+
+    // --- Phase 3: Test Executing state (mid-flight crash) ---
+    let escrow_store2 = Arc::new(MemoryEscrowStore::new());
+    escrow_store2.insert(EscrowRecord::new_locked(
+        "esc-midcrash",
+        "coop-alpha",
+        "did:icn:treasury:coop-alpha",
+        "did:icn:member:carol",
+        2000,
+        "HOURS",
+    ));
+
+    let (executor3, exec_store3) = make_executor(escrow_store2.clone());
+
+    // Manually insert an Executing record (simulates mid-flight crash)
+    let mut crashed_record =
+        ExecutionRecord::new_pending("hash-midcrash", "proposal-mid", "receipt-mid");
+    crashed_record.mark_executing();
+    exec_store3.put(&crashed_record).unwrap();
+
+    // Re-execute — should recover and complete
+    let results3 = executor3
+        .execute(
+            release_escrow_effect("esc-midcrash", "hash-midcrash"),
+            "receipt-mid",
+            "hash-midcrash",
+            "proposal-mid",
+        )
+        .await
+        .expect("mid-crash recovery should succeed");
+
+    assert_eq!(results3.len(), 1);
+    assert!(results3[0].success, "Recovery should succeed");
+
+    // Escrow should be released
+    let escrow_mid = escrow_store2.get_record("esc-midcrash").unwrap();
+    assert_eq!(escrow_mid.status, EscrowStatus::Released);
+}
+
+// =============================================================================
+// Test 3: Conflicting release decisions are rejected
+// =============================================================================
+
+/// Two different governance decisions try to release the same escrow.
+/// The first one succeeds. The second one is rejected with a conflict error.
+#[tokio::test]
+async fn test_conflicting_release_rejected() {
+    let escrow_store = Arc::new(MemoryEscrowStore::new());
+
+    // Pre-load a locked escrow
+    escrow_store.insert(EscrowRecord::new_locked(
+        "esc-conflict",
+        "coop-alpha",
+        "did:icn:treasury:coop-alpha",
+        "did:icn:member:dave",
+        7000,
+        "HOURS",
+    ));
+
+    let (executor, exec_store) = make_executor(escrow_store.clone());
+
+    // Decision A releases the escrow
+    let results_a = executor
+        .execute(
+            release_escrow_effect("esc-conflict", "hash-decision-A"),
+            "receipt-A",
+            "hash-decision-A",
+            "proposal-A",
+        )
+        .await
+        .expect("decision A should succeed");
+
+    assert_eq!(results_a.len(), 1);
+    assert!(results_a[0].success, "Decision A should succeed");
+
+    // Verify escrow is released by decision A
+    let escrow = escrow_store.get_record("esc-conflict").unwrap();
+    assert_eq!(escrow.status, EscrowStatus::Released);
+    assert_eq!(
+        escrow.release_decision_hash.as_deref(),
+        Some("hash-decision-A")
+    );
+
+    // Decision B tries to release the same escrow — different decision_hash
+    let results_b = executor
+        .execute(
+            release_escrow_effect("esc-conflict", "hash-decision-B"),
+            "receipt-B",
+            "hash-decision-B",
+            "proposal-B",
+        )
+        .await
+        .expect("decision B should not error");
+
+    assert_eq!(results_b.len(), 1);
+    assert!(
+        !results_b[0].success,
+        "Decision B should FAIL (conflict): {}",
+        results_b[0].message
+    );
+    assert!(
+        results_b[0].message.contains("already released"),
+        "Error message should mention already released: {}",
+        results_b[0].message
+    );
+    assert!(
+        results_b[0].message.contains("hash-decision-A"),
+        "Error message should mention the conflicting decision: {}",
+        results_b[0].message
+    );
+
+    // Verify decision B's execution record shows failure
+    let record_b = exec_store.get("hash-decision-B").unwrap().unwrap();
+    assert_eq!(
+        record_b.status,
+        ExecutionStatus::Failed,
+        "Conflicting decision should be marked Failed"
+    );
+
+    // Escrow is still released by decision A (unchanged)
+    let escrow_final = escrow_store.get_record("esc-conflict").unwrap();
+    assert_eq!(
+        escrow_final.release_decision_hash.as_deref(),
+        Some("hash-decision-A"),
+        "Escrow should still be released by decision A, not B"
+    );
+}
+
+// =============================================================================
+// Additional edge case tests
+// =============================================================================
+
+/// Releasing a nonexistent escrow should fail gracefully.
+#[tokio::test]
+async fn test_release_nonexistent_escrow_fails() {
+    let escrow_store = Arc::new(MemoryEscrowStore::new());
+    // No escrow pre-loaded
+    let (executor, _) = make_executor(escrow_store);
+
+    let results = executor
+        .execute(
+            release_escrow_effect("esc-does-not-exist", "hash-ghost"),
+            "receipt-ghost",
+            "hash-ghost",
+            "proposal-ghost",
+        )
+        .await
+        .expect("should not error");
+
+    assert_eq!(results.len(), 1);
+    assert!(!results[0].success, "Should fail for missing escrow");
+    assert!(results[0].message.contains("not found"));
+}
+
+/// Releasing a cancelled escrow should fail.
+#[tokio::test]
+async fn test_release_cancelled_escrow_fails() {
+    let escrow_store = Arc::new(MemoryEscrowStore::new());
+
+    let mut cancelled = EscrowRecord::new_locked(
+        "esc-cancelled",
+        "coop-alpha",
+        "did:icn:treasury:coop-alpha",
+        "did:icn:member:eve",
+        1000,
+        "HOURS",
+    );
+    cancelled.status = EscrowStatus::Cancelled;
+    escrow_store.insert(cancelled);
+
+    let (executor, _) = make_executor(escrow_store);
+
+    let results = executor
+        .execute(
+            release_escrow_effect("esc-cancelled", "hash-cancel"),
+            "receipt-cancel",
+            "hash-cancel",
+            "proposal-cancel",
+        )
+        .await
+        .expect("should not error");
+
+    assert_eq!(results.len(), 1);
+    assert!(!results[0].success);
+    assert!(results[0].message.contains("cancelled"));
+}

--- a/icn/crates/icn-kernel-api/src/effects.rs
+++ b/icn/crates/icn-kernel-api/src/effects.rs
@@ -115,6 +115,27 @@ pub enum TreasuryEffect {
         maturity_date: u64,
         currency: String,
     },
+    /// Release an escrow — governance decided, now move the money.
+    ///
+    /// The escrow store provides domain-level idempotency: even if the
+    /// decision-level executor replays this effect, the escrow record's
+    /// `release_decision_hash` prevents double-disbursement.
+    ReleaseEscrow {
+        /// The escrow being released.
+        escrow_id: String,
+        /// Treasury funding the escrow (debit side).
+        treasury_did: String,
+        /// Beneficiary receiving funds (credit side).
+        beneficiary_did: String,
+        /// Amount to release.
+        amount: i64,
+        /// Currency / asset type.
+        currency: String,
+        /// Links back to governance decision receipt.
+        decision_receipt_id: String,
+        /// Canonical content hash for verification + idempotency.
+        decision_hash: String,
+    },
 }
 
 // =============================================================================
@@ -602,6 +623,15 @@ mod tests {
                 interest_rate_bps: 500,
                 maturity_date: 1750000000,
                 currency: "USD".into(),
+            },
+            TreasuryEffect::ReleaseEscrow {
+                escrow_id: "esc-1".into(),
+                treasury_did: "did:icn:t1".into(),
+                beneficiary_did: "did:icn:alice".into(),
+                amount: 5000,
+                currency: "HOURS".into(),
+                decision_receipt_id: "r1".into(),
+                decision_hash: "h1".into(),
             },
         ];
 

--- a/icn/crates/icn-kernel-api/src/escrow.rs
+++ b/icn/crates/icn-kernel-api/src/escrow.rs
@@ -4,6 +4,21 @@
 //! governance decision within the escrow's governing scope. The kernel enforces
 //! the lock; the app layer decides when to release.
 //!
+//! # Saga State Machine
+//!
+//! ```text
+//! Locked → Releasing(decision_hash) → Released(decision_hash)
+//!                                   ↘ (crash) → Releasing → retry
+//! ```
+//!
+//! The `Releasing` state prevents the "state flip before side-effect" bug:
+//! - `begin_release()` transitions to `Releasing` (intent recorded)
+//! - Ledger mutation happens
+//! - `confirm_release()` transitions to `Released` (side-effect confirmed)
+//!
+//! On crash between `Releasing` and `Released`, replay detects `Releasing`
+//! with the same `decision_hash` and re-attempts the ledger mutation.
+//!
 //! # Domain-Level Idempotency
 //!
 //! `EscrowRecord.release_decision_hash` provides the second idempotency lock:
@@ -20,7 +35,10 @@ use serde::{Deserialize, Serialize};
 pub enum EscrowStatus {
     /// Funds are locked, awaiting governance decision.
     Locked,
-    /// Funds have been released to the beneficiary.
+    /// Release in progress — intent recorded, ledger mutation pending.
+    /// On crash recovery, this state triggers a retry of the ledger mutation.
+    Releasing,
+    /// Funds have been released to the beneficiary (ledger mutation confirmed).
     Released,
     /// Escrow was cancelled, funds returned to funder.
     Cancelled,
@@ -94,29 +112,45 @@ impl EscrowRecord {
         self.status == EscrowStatus::Locked
     }
 
-    /// Mark as released with the authorizing decision hash.
+    /// Phase 1 of the saga: record intent to release.
     ///
-    /// Returns `Err` if already released (with the conflicting decision hash).
-    pub fn release(&mut self, decision_hash: &str) -> Result<(), EscrowReleaseError> {
+    /// Transitions `Locked → Releasing` and records the `decision_hash`.
+    /// This MUST be persisted BEFORE attempting the ledger mutation.
+    ///
+    /// If the escrow is already `Releasing` with the same decision_hash,
+    /// returns `Ok(BeginReleaseOutcome::RetryNeeded)` — the caller should
+    /// re-attempt the ledger mutation (crash recovery path).
+    ///
+    /// If the escrow is already `Released` with the same decision_hash,
+    /// returns `Err(AlreadyReleasedSameDecision)` — fully idempotent.
+    pub fn begin_release(
+        &mut self,
+        decision_hash: &str,
+    ) -> Result<BeginReleaseOutcome, EscrowReleaseError> {
         match self.status {
             EscrowStatus::Locked => {
-                self.status = EscrowStatus::Released;
+                self.status = EscrowStatus::Releasing;
                 self.release_decision_hash = Some(decision_hash.to_string());
-                self.released_at = Some(
-                    std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map(|d| d.as_secs())
-                        .unwrap_or(0),
-                );
-                Ok(())
+                Ok(BeginReleaseOutcome::Proceed)
+            }
+            EscrowStatus::Releasing => {
+                let existing_hash = self.release_decision_hash.as_deref().unwrap_or("unknown");
+                if existing_hash == decision_hash {
+                    // Same decision in Releasing state — crash recovery.
+                    // The ledger mutation may not have completed. Caller should retry.
+                    Ok(BeginReleaseOutcome::RetryNeeded)
+                } else {
+                    // Different decision trying to release — conflict.
+                    Err(EscrowReleaseError::AlreadyReleasedByOther {
+                        existing_decision_hash: existing_hash.to_string(),
+                    })
+                }
             }
             EscrowStatus::Released => {
                 let existing_hash = self.release_decision_hash.as_deref().unwrap_or("unknown");
                 if existing_hash == decision_hash {
-                    // Same decision — idempotent, already released
                     Err(EscrowReleaseError::AlreadyReleasedSameDecision)
                 } else {
-                    // Different decision — conflict
                     Err(EscrowReleaseError::AlreadyReleasedByOther {
                         existing_decision_hash: existing_hash.to_string(),
                     })
@@ -125,6 +159,35 @@ impl EscrowRecord {
             EscrowStatus::Cancelled => Err(EscrowReleaseError::Cancelled),
         }
     }
+
+    /// Phase 2 of the saga: confirm release after successful ledger mutation.
+    ///
+    /// Transitions `Releasing → Released` and sets `released_at`.
+    /// Only valid when status is `Releasing`.
+    pub fn confirm_release(&mut self) {
+        debug_assert_eq!(
+            self.status,
+            EscrowStatus::Releasing,
+            "confirm_release called on non-Releasing escrow"
+        );
+        self.status = EscrowStatus::Released;
+        self.released_at = Some(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+        );
+    }
+}
+
+/// Outcome of `begin_release()` — tells the caller what to do next.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BeginReleaseOutcome {
+    /// Fresh release — proceed with ledger mutation.
+    Proceed,
+    /// Crash recovery — the escrow was already in `Releasing` state
+    /// with the same decision_hash. Re-attempt the ledger mutation.
+    RetryNeeded,
 }
 
 /// Error returned when an escrow release fails.
@@ -193,7 +256,7 @@ mod tests {
     }
 
     #[test]
-    fn test_release_success() {
+    fn test_saga_begin_and_confirm() {
         let mut escrow = EscrowRecord::new_locked(
             "esc-1",
             "coop-alpha",
@@ -202,14 +265,22 @@ mod tests {
             5000,
             "HOURS",
         );
-        assert!(escrow.release("hash-1").is_ok());
-        assert_eq!(escrow.status, EscrowStatus::Released);
+
+        // Phase 1: begin_release → Releasing
+        let outcome = escrow.begin_release("hash-1").unwrap();
+        assert_eq!(outcome, BeginReleaseOutcome::Proceed);
+        assert_eq!(escrow.status, EscrowStatus::Releasing);
         assert_eq!(escrow.release_decision_hash.as_deref(), Some("hash-1"));
+        assert!(escrow.released_at.is_none()); // Not yet finalized
+
+        // Phase 2: confirm_release → Released
+        escrow.confirm_release();
+        assert_eq!(escrow.status, EscrowStatus::Released);
         assert!(escrow.released_at.is_some());
     }
 
     #[test]
-    fn test_release_idempotent_same_decision() {
+    fn test_saga_crash_recovery_same_decision() {
         let mut escrow = EscrowRecord::new_locked(
             "esc-1",
             "coop-alpha",
@@ -218,14 +289,65 @@ mod tests {
             5000,
             "HOURS",
         );
-        escrow.release("hash-1").unwrap();
 
-        let err = escrow.release("hash-1").unwrap_err();
+        // Phase 1: begin_release → Releasing
+        escrow.begin_release("hash-1").unwrap();
+        assert_eq!(escrow.status, EscrowStatus::Releasing);
+
+        // Simulate crash (no confirm_release). On recovery, same decision retries:
+        let outcome = escrow.begin_release("hash-1").unwrap();
+        assert_eq!(
+            outcome,
+            BeginReleaseOutcome::RetryNeeded,
+            "Same decision in Releasing should signal retry"
+        );
+    }
+
+    #[test]
+    fn test_saga_releasing_conflict_different_decision() {
+        let mut escrow = EscrowRecord::new_locked(
+            "esc-1",
+            "coop-alpha",
+            "did:treasury",
+            "did:alice",
+            5000,
+            "HOURS",
+        );
+
+        // Phase 1: begin_release with decision A
+        escrow.begin_release("hash-A").unwrap();
+        assert_eq!(escrow.status, EscrowStatus::Releasing);
+
+        // Different decision B tries during Releasing → conflict
+        let err = escrow.begin_release("hash-B").unwrap_err();
+        assert_eq!(
+            err,
+            EscrowReleaseError::AlreadyReleasedByOther {
+                existing_decision_hash: "hash-A".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_released_idempotent_same_decision() {
+        let mut escrow = EscrowRecord::new_locked(
+            "esc-1",
+            "coop-alpha",
+            "did:treasury",
+            "did:alice",
+            5000,
+            "HOURS",
+        );
+        escrow.begin_release("hash-1").unwrap();
+        escrow.confirm_release();
+
+        // Same decision on fully Released escrow → idempotent
+        let err = escrow.begin_release("hash-1").unwrap_err();
         assert_eq!(err, EscrowReleaseError::AlreadyReleasedSameDecision);
     }
 
     #[test]
-    fn test_release_conflict_different_decision() {
+    fn test_released_conflict_different_decision() {
         let mut escrow = EscrowRecord::new_locked(
             "esc-1",
             "coop-alpha",
@@ -234,9 +356,10 @@ mod tests {
             5000,
             "HOURS",
         );
-        escrow.release("hash-1").unwrap();
+        escrow.begin_release("hash-1").unwrap();
+        escrow.confirm_release();
 
-        let err = escrow.release("hash-2").unwrap_err();
+        let err = escrow.begin_release("hash-2").unwrap_err();
         assert_eq!(
             err,
             EscrowReleaseError::AlreadyReleasedByOther {
@@ -257,7 +380,7 @@ mod tests {
         );
         escrow.status = EscrowStatus::Cancelled;
 
-        let err = escrow.release("hash-1").unwrap_err();
+        let err = escrow.begin_release("hash-1").unwrap_err();
         assert_eq!(err, EscrowReleaseError::Cancelled);
     }
 
@@ -265,11 +388,26 @@ mod tests {
     fn test_serde_roundtrip() {
         let mut escrow =
             EscrowRecord::new_locked("esc-1", "scope", "funder", "beneficiary", 1000, "USD");
-        escrow.release("hash-x").unwrap();
+        escrow.begin_release("hash-x").unwrap();
+        escrow.confirm_release();
 
         let json = serde_json::to_string(&escrow).unwrap();
         let parsed: EscrowRecord = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.status, EscrowStatus::Released);
         assert_eq!(parsed.release_decision_hash.as_deref(), Some("hash-x"));
+    }
+
+    #[test]
+    fn test_serde_roundtrip_releasing() {
+        let mut escrow =
+            EscrowRecord::new_locked("esc-2", "scope", "funder", "beneficiary", 2000, "USD");
+        escrow.begin_release("hash-y").unwrap();
+        // Deliberately NOT calling confirm_release — testing Releasing state
+
+        let json = serde_json::to_string(&escrow).unwrap();
+        let parsed: EscrowRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.status, EscrowStatus::Releasing);
+        assert_eq!(parsed.release_decision_hash.as_deref(), Some("hash-y"));
+        assert!(parsed.released_at.is_none());
     }
 }

--- a/icn/crates/icn-kernel-api/src/escrow.rs
+++ b/icn/crates/icn-kernel-api/src/escrow.rs
@@ -1,0 +1,275 @@
+//! Escrow types for the kernel execution layer.
+//!
+//! An escrow is a locked allocation that can only be released by a confirmed
+//! governance decision within the escrow's governing scope. The kernel enforces
+//! the lock; the app layer decides when to release.
+//!
+//! # Domain-Level Idempotency
+//!
+//! `EscrowRecord.release_decision_hash` provides the second idempotency lock:
+//! - Decision-level: `ExecutionStore` prevents replaying the same decision
+//! - Domain-level: `EscrowStore` prevents releasing the same escrow twice
+//!
+//! Together they handle: replayed events, crash recovery, and conflicting releases.
+
+use serde::{Deserialize, Serialize};
+
+/// Status of an escrow allocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EscrowStatus {
+    /// Funds are locked, awaiting governance decision.
+    Locked,
+    /// Funds have been released to the beneficiary.
+    Released,
+    /// Escrow was cancelled, funds returned to funder.
+    Cancelled,
+}
+
+/// A locked allocation that can be released by governance decision.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EscrowRecord {
+    /// Unique escrow identifier.
+    pub escrow_id: String,
+
+    /// Governing scope (cooperative DID or federation ID).
+    pub scope_id: String,
+
+    /// Who funded the escrow (treasury DID or member DID).
+    pub funder_did: String,
+
+    /// Who receives funds on release.
+    pub beneficiary_did: String,
+
+    /// Locked amount.
+    pub amount: i64,
+
+    /// Currency / asset type.
+    pub currency: String,
+
+    /// Current status.
+    pub status: EscrowStatus,
+
+    /// Unix timestamp (seconds) when escrow was created.
+    pub created_at: u64,
+
+    /// Decision hash that released this escrow (set on release).
+    pub release_decision_hash: Option<String>,
+
+    /// Unix timestamp (seconds) when escrow was released (if any).
+    pub released_at: Option<u64>,
+}
+
+impl EscrowRecord {
+    /// Create a new locked escrow.
+    pub fn new_locked(
+        escrow_id: impl Into<String>,
+        scope_id: impl Into<String>,
+        funder_did: impl Into<String>,
+        beneficiary_did: impl Into<String>,
+        amount: i64,
+        currency: impl Into<String>,
+    ) -> Self {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        Self {
+            escrow_id: escrow_id.into(),
+            scope_id: scope_id.into(),
+            funder_did: funder_did.into(),
+            beneficiary_did: beneficiary_did.into(),
+            amount,
+            currency: currency.into(),
+            status: EscrowStatus::Locked,
+            created_at: now,
+            release_decision_hash: None,
+            released_at: None,
+        }
+    }
+
+    /// Whether this escrow can be released.
+    pub fn is_locked(&self) -> bool {
+        self.status == EscrowStatus::Locked
+    }
+
+    /// Mark as released with the authorizing decision hash.
+    ///
+    /// Returns `Err` if already released (with the conflicting decision hash).
+    pub fn release(&mut self, decision_hash: &str) -> Result<(), EscrowReleaseError> {
+        match self.status {
+            EscrowStatus::Locked => {
+                self.status = EscrowStatus::Released;
+                self.release_decision_hash = Some(decision_hash.to_string());
+                self.released_at = Some(
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs())
+                        .unwrap_or(0),
+                );
+                Ok(())
+            }
+            EscrowStatus::Released => {
+                let existing_hash = self.release_decision_hash.as_deref().unwrap_or("unknown");
+                if existing_hash == decision_hash {
+                    // Same decision — idempotent, already released
+                    Err(EscrowReleaseError::AlreadyReleasedSameDecision)
+                } else {
+                    // Different decision — conflict
+                    Err(EscrowReleaseError::AlreadyReleasedByOther {
+                        existing_decision_hash: existing_hash.to_string(),
+                    })
+                }
+            }
+            EscrowStatus::Cancelled => Err(EscrowReleaseError::Cancelled),
+        }
+    }
+}
+
+/// Error returned when an escrow release fails.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EscrowReleaseError {
+    /// Escrow was already released by the same decision (idempotent — not a real error).
+    AlreadyReleasedSameDecision,
+    /// Escrow was already released by a different decision (conflict).
+    AlreadyReleasedByOther { existing_decision_hash: String },
+    /// Escrow was cancelled.
+    Cancelled,
+}
+
+impl std::fmt::Display for EscrowReleaseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AlreadyReleasedSameDecision => {
+                write!(f, "escrow already released by this decision (idempotent)")
+            }
+            Self::AlreadyReleasedByOther {
+                existing_decision_hash,
+            } => {
+                write!(
+                    f,
+                    "escrow already released by decision {}",
+                    existing_decision_hash
+                )
+            }
+            Self::Cancelled => write!(f, "escrow was cancelled"),
+        }
+    }
+}
+
+/// Trait for persistent escrow storage.
+///
+/// Implementations must be durable (survive restarts).
+/// Keyed by `escrow_id`.
+pub trait EscrowStore: Send + Sync {
+    /// Get an escrow record by ID.
+    fn get(&self, escrow_id: &str) -> anyhow::Result<Option<EscrowRecord>>;
+
+    /// Insert or update an escrow record.
+    fn put(&self, record: &EscrowRecord) -> anyhow::Result<()>;
+
+    /// List escrows by scope.
+    fn list_by_scope(&self, scope_id: &str) -> anyhow::Result<Vec<EscrowRecord>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_locked() {
+        let escrow = EscrowRecord::new_locked(
+            "esc-1",
+            "coop-alpha",
+            "did:treasury",
+            "did:alice",
+            5000,
+            "HOURS",
+        );
+        assert!(escrow.is_locked());
+        assert_eq!(escrow.status, EscrowStatus::Locked);
+        assert!(escrow.release_decision_hash.is_none());
+    }
+
+    #[test]
+    fn test_release_success() {
+        let mut escrow = EscrowRecord::new_locked(
+            "esc-1",
+            "coop-alpha",
+            "did:treasury",
+            "did:alice",
+            5000,
+            "HOURS",
+        );
+        assert!(escrow.release("hash-1").is_ok());
+        assert_eq!(escrow.status, EscrowStatus::Released);
+        assert_eq!(escrow.release_decision_hash.as_deref(), Some("hash-1"));
+        assert!(escrow.released_at.is_some());
+    }
+
+    #[test]
+    fn test_release_idempotent_same_decision() {
+        let mut escrow = EscrowRecord::new_locked(
+            "esc-1",
+            "coop-alpha",
+            "did:treasury",
+            "did:alice",
+            5000,
+            "HOURS",
+        );
+        escrow.release("hash-1").unwrap();
+
+        let err = escrow.release("hash-1").unwrap_err();
+        assert_eq!(err, EscrowReleaseError::AlreadyReleasedSameDecision);
+    }
+
+    #[test]
+    fn test_release_conflict_different_decision() {
+        let mut escrow = EscrowRecord::new_locked(
+            "esc-1",
+            "coop-alpha",
+            "did:treasury",
+            "did:alice",
+            5000,
+            "HOURS",
+        );
+        escrow.release("hash-1").unwrap();
+
+        let err = escrow.release("hash-2").unwrap_err();
+        assert_eq!(
+            err,
+            EscrowReleaseError::AlreadyReleasedByOther {
+                existing_decision_hash: "hash-1".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_release_cancelled() {
+        let mut escrow = EscrowRecord::new_locked(
+            "esc-1",
+            "coop-alpha",
+            "did:treasury",
+            "did:alice",
+            5000,
+            "HOURS",
+        );
+        escrow.status = EscrowStatus::Cancelled;
+
+        let err = escrow.release("hash-1").unwrap_err();
+        assert_eq!(err, EscrowReleaseError::Cancelled);
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let mut escrow =
+            EscrowRecord::new_locked("esc-1", "scope", "funder", "beneficiary", 1000, "USD");
+        escrow.release("hash-x").unwrap();
+
+        let json = serde_json::to_string(&escrow).unwrap();
+        let parsed: EscrowRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.status, EscrowStatus::Released);
+        assert_eq!(parsed.release_decision_hash.as_deref(), Some("hash-x"));
+    }
+}

--- a/icn/crates/icn-kernel-api/src/execution.rs
+++ b/icn/crates/icn-kernel-api/src/execution.rs
@@ -1,0 +1,236 @@
+//! Execution record types for the Decision Executor.
+//!
+//! These types persist the status of governance decision execution,
+//! providing idempotency (no double-execution) and auditability
+//! (every decision's execution history is durable).
+//!
+//! # Idempotency
+//!
+//! The idempotency key is `decision_hash` — the canonical blake3 hash
+//! from `GovernanceDecisionReceipt`. This hash is deterministic across
+//! nodes for the same decision, so replayed events are safely rejected.
+//!
+//! # Status Machine
+//!
+//! ```text
+//! Pending → Executing → Confirmed
+//!                    ↘ Failed → (retry) → Executing
+//!                              ↘ PermanentlyFailed
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+/// Status of a governance decision's execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionStatus {
+    /// Recorded but not yet started.
+    Pending,
+    /// Execution in progress.
+    Executing,
+    /// All effects applied successfully.
+    Confirmed,
+    /// Execution failed (retryable).
+    Failed,
+    /// Exhausted retries or non-recoverable error.
+    PermanentlyFailed,
+}
+
+/// Persistent record of a governance decision execution.
+///
+/// Keyed by `decision_hash` in the execution store.
+/// Survives restarts, prevents re-execution, enables audit.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutionRecord {
+    /// Canonical decision hash (blake3, 32 bytes hex-encoded).
+    /// This is the idempotency key.
+    pub decision_hash: String,
+
+    /// The proposal ID that produced this decision.
+    pub proposal_id: String,
+
+    /// The decision receipt ID linking to `GovernanceDecisionReceipt`.
+    pub decision_receipt_id: String,
+
+    /// Current execution status.
+    pub status: ExecutionStatus,
+
+    /// Unix timestamp (seconds) when execution was first attempted.
+    pub started_at: u64,
+
+    /// Unix timestamp (seconds) when execution completed (if any).
+    pub finished_at: Option<u64>,
+
+    /// Ledger entry IDs produced by this execution.
+    pub ledger_entry_ids: Vec<String>,
+
+    /// State change hashes from effect results.
+    pub state_change_hashes: Vec<String>,
+
+    /// Error message if execution failed.
+    pub error: Option<String>,
+
+    /// Number of retry attempts.
+    pub retries: u32,
+}
+
+impl ExecutionRecord {
+    /// Create a new pending execution record.
+    pub fn new_pending(
+        decision_hash: impl Into<String>,
+        proposal_id: impl Into<String>,
+        decision_receipt_id: impl Into<String>,
+    ) -> Self {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        Self {
+            decision_hash: decision_hash.into(),
+            proposal_id: proposal_id.into(),
+            decision_receipt_id: decision_receipt_id.into(),
+            status: ExecutionStatus::Pending,
+            started_at: now,
+            finished_at: None,
+            ledger_entry_ids: Vec::new(),
+            state_change_hashes: Vec::new(),
+            error: None,
+            retries: 0,
+        }
+    }
+
+    /// Transition to Executing.
+    pub fn mark_executing(&mut self) {
+        self.status = ExecutionStatus::Executing;
+    }
+
+    /// Transition to Confirmed with results.
+    pub fn mark_confirmed(
+        &mut self,
+        ledger_entry_ids: Vec<String>,
+        state_change_hashes: Vec<String>,
+    ) {
+        self.status = ExecutionStatus::Confirmed;
+        self.ledger_entry_ids = ledger_entry_ids;
+        self.state_change_hashes = state_change_hashes;
+        self.finished_at = Some(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+        );
+    }
+
+    /// Transition to Failed with error.
+    pub fn mark_failed(&mut self, error: impl Into<String>) {
+        self.status = ExecutionStatus::Failed;
+        self.error = Some(error.into());
+        self.retries += 1;
+        self.finished_at = Some(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+        );
+    }
+
+    /// Transition to PermanentlyFailed.
+    pub fn mark_permanently_failed(&mut self, error: impl Into<String>) {
+        self.status = ExecutionStatus::PermanentlyFailed;
+        self.error = Some(error.into());
+        self.finished_at = Some(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+        );
+    }
+
+    /// Whether this record represents a terminal state (no more transitions).
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self.status,
+            ExecutionStatus::Confirmed | ExecutionStatus::PermanentlyFailed
+        )
+    }
+}
+
+/// Trait for persistent storage of execution records.
+///
+/// Implementations must be durable (survive restarts).
+/// The store is keyed by `decision_hash`.
+pub trait ExecutionStore: Send + Sync {
+    /// Get an execution record by decision hash.
+    fn get(&self, decision_hash: &str) -> anyhow::Result<Option<ExecutionRecord>>;
+
+    /// Insert or update an execution record.
+    fn put(&self, record: &ExecutionRecord) -> anyhow::Result<()>;
+
+    /// List records by status.
+    fn list_by_status(&self, status: ExecutionStatus) -> anyhow::Result<Vec<ExecutionRecord>>;
+
+    /// Count records by status.
+    fn count_by_status(&self) -> anyhow::Result<std::collections::HashMap<ExecutionStatus, usize>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_execution_record_lifecycle() {
+        let mut record = ExecutionRecord::new_pending("abc123hash", "proposal-42", "receipt-42");
+
+        assert_eq!(record.status, ExecutionStatus::Pending);
+        assert!(!record.is_terminal());
+
+        record.mark_executing();
+        assert_eq!(record.status, ExecutionStatus::Executing);
+
+        record.mark_confirmed(vec!["entry-1".to_string()], vec!["hash-1".to_string()]);
+        assert_eq!(record.status, ExecutionStatus::Confirmed);
+        assert!(record.is_terminal());
+        assert!(record.finished_at.is_some());
+        assert_eq!(record.ledger_entry_ids, vec!["entry-1"]);
+    }
+
+    #[test]
+    fn test_execution_record_failure_path() {
+        let mut record = ExecutionRecord::new_pending("abc123hash", "proposal-42", "receipt-42");
+
+        record.mark_executing();
+        record.mark_failed("Ledger unavailable");
+
+        assert_eq!(record.status, ExecutionStatus::Failed);
+        assert_eq!(record.retries, 1);
+        assert_eq!(record.error.as_deref(), Some("Ledger unavailable"));
+        assert!(!record.is_terminal());
+
+        record.mark_permanently_failed("Max retries exceeded");
+        assert!(record.is_terminal());
+    }
+
+    #[test]
+    fn test_execution_status_serde() {
+        let status = ExecutionStatus::Confirmed;
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(json, "\"confirmed\"");
+
+        let parsed: ExecutionStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, ExecutionStatus::Confirmed);
+    }
+
+    #[test]
+    fn test_execution_record_serde_roundtrip() {
+        let mut record = ExecutionRecord::new_pending("deadbeef", "proposal-1", "receipt-1");
+        record.mark_confirmed(vec!["e1".into()], vec!["h1".into()]);
+
+        let json = serde_json::to_string(&record).unwrap();
+        let parsed: ExecutionRecord = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.decision_hash, "deadbeef");
+        assert_eq!(parsed.status, ExecutionStatus::Confirmed);
+        assert_eq!(parsed.ledger_entry_ids, vec!["e1"]);
+    }
+}

--- a/icn/crates/icn-kernel-api/src/governance.rs
+++ b/icn/crates/icn-kernel-api/src/governance.rs
@@ -268,8 +268,10 @@ impl EffectExecutor for DefaultEffectExecutor {
     }
 }
 
-/// Convert a TreasuryEffect to a TreasuryOperation
-fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperation {
+/// Convert a TreasuryEffect to a TreasuryOperation.
+///
+/// This is the canonical mapping — icn-core delegates here to avoid drift.
+pub fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperation {
     match effect {
         TreasuryEffect::Spend {
             treasury_did,

--- a/icn/crates/icn-kernel-api/src/governance.rs
+++ b/icn/crates/icn-kernel-api/src/governance.rs
@@ -334,6 +334,23 @@ fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperation {
             memo: memo.clone(),
             decision_hash: None,
         },
+        TreasuryEffect::ReleaseEscrow {
+            treasury_did,
+            beneficiary_did,
+            amount,
+            currency,
+            escrow_id,
+            decision_hash,
+            ..
+        } => TreasuryOperation {
+            treasury_id: treasury_did.clone(),
+            operation_type: TreasuryOperationType::Release,
+            amount: *amount,
+            currency: currency.clone(),
+            recipient: Some(beneficiary_did.clone()),
+            memo: format!("Escrow release: {}", escrow_id),
+            decision_hash: Some(decision_hash.clone()),
+        },
         // Other treasury effects mapped to basic operations
         _ => TreasuryOperation {
             treasury_id: String::new(),

--- a/icn/crates/icn-kernel-api/src/lib.rs
+++ b/icn/crates/icn-kernel-api/src/lib.rs
@@ -41,6 +41,7 @@ pub mod economics;
 pub mod effects;
 pub mod error;
 pub mod events;
+pub mod execution;
 pub mod governance;
 pub mod identity;
 pub mod naming;
@@ -75,6 +76,7 @@ pub use effects::{
 };
 pub use error::{ErrCode, IcnError};
 pub use events::{EventCallback, EventEmitter, SystemEvent};
+pub use execution::{ExecutionRecord, ExecutionStatus, ExecutionStore};
 pub use governance::{
     federation_effect_to_operation, DecisionReceiptId, DefaultEffectExecutor, EffectExecutor,
     ExecutionOutcome, FederationExecutor, FederationOperation, FederationOperationType,

--- a/icn/crates/icn-kernel-api/src/lib.rs
+++ b/icn/crates/icn-kernel-api/src/lib.rs
@@ -76,7 +76,9 @@ pub use effects::{
     ProtocolEffect, ResourceEffect, SdisEffect, TreasuryEffect,
 };
 pub use error::{ErrCode, IcnError};
-pub use escrow::{EscrowRecord, EscrowReleaseError, EscrowStatus, EscrowStore};
+pub use escrow::{
+    BeginReleaseOutcome, EscrowRecord, EscrowReleaseError, EscrowStatus, EscrowStore,
+};
 pub use events::{EventCallback, EventEmitter, SystemEvent};
 pub use execution::{ExecutionRecord, ExecutionStatus, ExecutionStore};
 pub use governance::{

--- a/icn/crates/icn-kernel-api/src/lib.rs
+++ b/icn/crates/icn-kernel-api/src/lib.rs
@@ -40,6 +40,7 @@ pub mod coord;
 pub mod economics;
 pub mod effects;
 pub mod error;
+pub mod escrow;
 pub mod events;
 pub mod execution;
 pub mod governance;
@@ -75,6 +76,7 @@ pub use effects::{
     ProtocolEffect, ResourceEffect, SdisEffect, TreasuryEffect,
 };
 pub use error::{ErrCode, IcnError};
+pub use escrow::{EscrowRecord, EscrowReleaseError, EscrowStatus, EscrowStore};
 pub use events::{EventCallback, EventEmitter, SystemEvent};
 pub use execution::{ExecutionRecord, ExecutionStatus, ExecutionStore};
 pub use governance::{


### PR DESCRIPTION
## Summary

First vertical slice of the Decision Executor: **governance approves escrow release → journal entry created → balance updated**.

This proves the pattern for every future "decision causes economic mutation" flow.

### Invariant

> **Escrow funds move *at most once* per escrow_id, and *only* after a confirmed governance decision; crashes cannot produce "Released-without-ledger" or double-disbursement.**

### Mechanisms

| Level | Mechanism | Key | Prevents |
|-------|-----------|-----|----------|
| Decision | `ExecutionStore` | `decision_hash` | Replaying the same governance decision |
| Domain | `EscrowRecord.release_decision_hash` | `decision_hash` | Releasing the same escrow twice |
| Ordering | Saga (Releasing intermediate state) | `EscrowStatus::Releasing` | Released-without-ledger on crash |

### Saga State Machine

```
Locked → Releasing(decision_hash) → Released(decision_hash)
                                   ↘ (crash) → Releasing → retry
```

The `Releasing` intermediate state prevents the "state flip before side-effect" bug:
1. `begin_release()` transitions to `Releasing` (intent recorded, persisted)
2. Ledger mutation happens
3. `confirm_release()` transitions to `Released` (side-effect confirmed)

On crash between `Releasing` and `Released`, replay detects `Releasing` with the same `decision_hash` and returns `RetryNeeded` — the caller re-attempts the ledger mutation without double-disbursement.

On treasury failure (logical or system), escrow stays `Releasing` and `DecisionExecutor` marks the decision **Failed** (not Confirmed), preserving retry capability.

### What Changed

**New types** (`icn-kernel-api`):
- `EscrowStatus` enum (Locked, Releasing, Released, Cancelled)
- `EscrowRecord` with saga methods (`begin_release`, `confirm_release`)
- `BeginReleaseOutcome` (Proceed / RetryNeeded)
- `EscrowReleaseError` (AlreadyReleasedSameDecision / AlreadyReleasedByOther / Cancelled)
- `EscrowStore` trait
- `TreasuryEffect::ReleaseEscrow` variant

**New implementation** (`icn-core`):
- `SledEscrowStore` (prefix-scoped, JSON serialization)
- Saga handler in `KernelGovernanceExecutor::execute_effect`
- Wired into supervisor lifecycle

**Drift elimination**:
- Removed duplicate `treasury_effect_to_operation` from `governance_executor.rs`
- Canonical mapping now lives in `icn-kernel-api::governance` (pub fn), icn-core delegates

### Tests

5 integration tests + 9 unit tests + 4 store tests = 18 escrow tests total.

**Required three:**
1. **Replay (100x)** — same decision replayed 100 times, exactly one ledger mutation
2. **Crash recovery** — fresh executor with same escrow store, domain-level check catches it
3. **Conflicting release** — different decision on same escrow → rejected with conflict error

**Edge cases:** nonexistent escrow, cancelled escrow

### ICN Invariants Checklist

- [x] **Adversarial-by-default**: Domain-level idempotency prevents double-spend even under replay
- [x] **Determinism**: Same decision_hash → same outcome on any node
- [x] **Canonical encodings**: JSON serde with `rename_all = "snake_case"`
- [x] **No panics**: All error paths return `Result`, `debug_assert` only in confirm_release
- [x] **Kernel/app boundary**: Escrow types in kernel-api, saga logic domain-agnostic

### Known limitation

An escrow can remain `Releasing` indefinitely if treasury fails logically (insufficient funds). Tracked in follow-up issue. Does not block this slice — the saga is safe (no data loss), just needs operator tooling for stuck escrows.

## Test plan

- [x] `cargo test -p icn-kernel-api escrow` — 9 unit tests pass
- [x] `cargo test -p icn-core --lib -- escrow_store` — 4 store tests pass
- [x] `cargo test -p icn-core --test escrow_release_integration` — 5 integration tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --all --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)