### PR TITLE
feat(core): budget enforcement vertical slice with saga pattern

### DIFF
--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -294,6 +294,7 @@ fn translate_treasury_operation(
             amount: *amount,
             currency: currency.clone(),
             memo: purpose.clone(),
+            budget_id: None, // TODO: wire budget_id from proposal payload
             decision_receipt_id: decision_receipt_id.to_string(),
             decision_hash: "pending".to_string(), // Wired when full context available
         })],

--- a/icn/crates/icn-core/src/supervisor/budget_store.rs
+++ b/icn/crates/icn-core/src/supervisor/budget_store.rs
@@ -1,0 +1,189 @@
+//! Sled-backed budget store for the execution bridge.
+//!
+//! Stores budget records keyed by `budget_id` under the `exec:budget:` prefix.
+//! All operations are synchronous (sled is a blocking B-tree) wrapped in the
+//! `BudgetStore` trait for the executor.
+
+use anyhow::Result;
+use icn_kernel_api::budget::{BudgetRecord, BudgetStore};
+
+/// Sled-backed implementation of [`BudgetStore`].
+pub struct SledBudgetStore {
+    tree: sled::Tree,
+}
+
+impl SledBudgetStore {
+    /// Open or create the budget store in the given sled DB.
+    pub fn new(db: &sled::Db) -> Result<Self> {
+        let tree = db.open_tree("exec:budget")?;
+        Ok(Self { tree })
+    }
+
+    fn key(budget_id: &str) -> Vec<u8> {
+        format!("budget:{}", budget_id).into_bytes()
+    }
+
+    fn scope_prefix(scope_id: &str) -> String {
+        format!("scope:{}:", scope_id)
+    }
+
+    fn scope_key(scope_id: &str, budget_id: &str) -> Vec<u8> {
+        format!("scope:{}:{}", scope_id, budget_id).into_bytes()
+    }
+}
+
+impl BudgetStore for SledBudgetStore {
+    fn get(&self, budget_id: &str) -> Result<Option<BudgetRecord>> {
+        match self.tree.get(Self::key(budget_id))? {
+            Some(bytes) => {
+                let record: BudgetRecord = serde_json::from_slice(&bytes)?;
+                Ok(Some(record))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn put(&self, record: &BudgetRecord) -> Result<()> {
+        let bytes = serde_json::to_vec(record)?;
+        self.tree.insert(Self::key(&record.budget_id), bytes)?;
+
+        // Also maintain scope index
+        let scope_key = Self::scope_key(&record.scope_id, &record.budget_id);
+        self.tree
+            .insert(scope_key, record.budget_id.as_bytes().to_vec())?;
+
+        self.tree.flush()?;
+        Ok(())
+    }
+
+    fn list_by_scope(&self, scope_id: &str) -> Result<Vec<BudgetRecord>> {
+        let prefix = Self::scope_prefix(scope_id);
+        let mut records = Vec::new();
+
+        for entry in self.tree.scan_prefix(prefix.as_bytes()) {
+            let (_, budget_id_bytes) = entry?;
+            let budget_id = String::from_utf8(budget_id_bytes.to_vec())?;
+            if let Some(record) = self.get(&budget_id)? {
+                records.push(record);
+            }
+        }
+
+        Ok(records)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use icn_kernel_api::budget::BudgetStatus;
+
+    fn temp_db() -> sled::Db {
+        sled::Config::new().temporary(true).open().unwrap()
+    }
+
+    #[test]
+    fn test_put_and_get() {
+        let db = temp_db();
+        let store = SledBudgetStore::new(&db).unwrap();
+
+        let record = BudgetRecord::new(
+            "budget-1".into(),
+            "coop-1".into(),
+            "did:icn:treasury".into(),
+            "HOURS".into(),
+            5000,
+            "decision-create-1".into(),
+            1000,
+        );
+
+        store.put(&record).unwrap();
+
+        let retrieved = store.get("budget-1").unwrap().unwrap();
+        assert_eq!(retrieved.budget_id, "budget-1");
+        assert_eq!(retrieved.total_limit, 5000);
+        assert_eq!(retrieved.status, BudgetStatus::Active);
+    }
+
+    #[test]
+    fn test_get_nonexistent() {
+        let db = temp_db();
+        let store = SledBudgetStore::new(&db).unwrap();
+        assert!(store.get("nonexistent").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_list_by_scope() {
+        let db = temp_db();
+        let store = SledBudgetStore::new(&db).unwrap();
+
+        // Two budgets for coop-1, one for coop-2
+        let b1 = BudgetRecord::new(
+            "budget-1".into(),
+            "coop-1".into(),
+            "did:icn:t1".into(),
+            "HOURS".into(),
+            1000,
+            "d1".into(),
+            100,
+        );
+        let b2 = BudgetRecord::new(
+            "budget-2".into(),
+            "coop-1".into(),
+            "did:icn:t1".into(),
+            "USD".into(),
+            2000,
+            "d2".into(),
+            200,
+        );
+        let b3 = BudgetRecord::new(
+            "budget-3".into(),
+            "coop-2".into(),
+            "did:icn:t2".into(),
+            "HOURS".into(),
+            3000,
+            "d3".into(),
+            300,
+        );
+
+        store.put(&b1).unwrap();
+        store.put(&b2).unwrap();
+        store.put(&b3).unwrap();
+
+        let coop1_budgets = store.list_by_scope("coop-1").unwrap();
+        assert_eq!(coop1_budgets.len(), 2);
+
+        let coop2_budgets = store.list_by_scope("coop-2").unwrap();
+        assert_eq!(coop2_budgets.len(), 1);
+        assert_eq!(coop2_budgets[0].budget_id, "budget-3");
+    }
+
+    #[test]
+    fn test_update_after_spend() {
+        let db = temp_db();
+        let store = SledBudgetStore::new(&db).unwrap();
+
+        let mut record = BudgetRecord::new(
+            "budget-1".into(),
+            "coop-1".into(),
+            "did:icn:t1".into(),
+            "HOURS".into(),
+            1000,
+            "d1".into(),
+            100,
+        );
+
+        store.put(&record).unwrap();
+
+        // Simulate a spend saga
+        record.begin_spend("spend-decision-1", 300).unwrap();
+        store.put(&record).unwrap(); // Persist Spending state
+
+        record.confirm_spend();
+        store.put(&record).unwrap(); // Persist confirmed state
+
+        let retrieved = store.get("budget-1").unwrap().unwrap();
+        assert_eq!(retrieved.spent_total, 300);
+        assert_eq!(retrieved.remaining(), 700);
+        assert!(retrieved.pending_spend.is_none());
+    }
+}

--- a/icn/crates/icn-core/src/supervisor/decision_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/decision_executor.rs
@@ -529,6 +529,7 @@ mod tests {
             amount: 500,
             currency: "HOURS".to_string(),
             memo: "Test".to_string(),
+            budget_id: None,
             decision_receipt_id: "receipt-t1".to_string(),
             decision_hash: "sha256:treasury-hash-1".to_string(),
         })];
@@ -562,6 +563,7 @@ mod tests {
                 amount: 100,
                 currency: "ICN".to_string(),
                 memo: "m".to_string(),
+                budget_id: None,
                 decision_receipt_id: "r1".to_string(),
                 decision_hash: "extracted-hash".to_string(),
             }),

--- a/icn/crates/icn-core/src/supervisor/effect_dispatcher.rs
+++ b/icn/crates/icn-core/src/supervisor/effect_dispatcher.rs
@@ -383,6 +383,7 @@ mod tests {
             amount: 1000,
             currency: "ICN".to_string(),
             memo: "Test payment".to_string(),
+            budget_id: None,
             decision_receipt_id: "test-receipt-001".to_string(),
             decision_hash: "sha256:abc123".to_string(),
         })];
@@ -446,6 +447,7 @@ mod tests {
                     amount: 100,
                     currency: "ICN".to_string(),
                     memo: "test".to_string(),
+                    budget_id: None,
                     decision_receipt_id: "r1".to_string(),
                     decision_hash: "sha256:test".to_string(),
                 }
@@ -594,6 +596,7 @@ mod tests {
             amount,
             currency: currency.to_string(),
             memo: "Development grant for Q1".to_string(),
+            budget_id: None,
             decision_receipt_id: decision_receipt_id.to_string(),
             decision_hash: "sha256:governance-decision-2024-001".to_string(),
         };

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use icn_kernel_api::budget::{BeginSpendOutcome, BudgetRecord, BudgetSpendError, BudgetStore};
 use icn_kernel_api::effects::{
     ControlEffect, EffectResult, KernelEffect, MembershipEffect, TreasuryEffect,
 };
@@ -42,6 +43,8 @@ pub struct KernelGovernanceExecutor {
     membership: Arc<KernelMembershipExecutor>,
     /// Escrow store for domain-level idempotency on escrow releases.
     escrow_store: Option<Arc<dyn EscrowStore>>,
+    /// Budget store for budget enforcement.
+    budget_store: Option<Arc<dyn BudgetStore>>,
 }
 
 impl KernelGovernanceExecutor {
@@ -57,6 +60,7 @@ impl KernelGovernanceExecutor {
             control: Arc::new(KernelControlExecutor::new()),
             membership: Arc::new(KernelMembershipExecutor::new()),
             escrow_store: None,
+            budget_store: None,
         }
     }
 
@@ -94,6 +98,205 @@ impl KernelGovernanceExecutor {
     pub fn with_escrow_store(mut self, store: Arc<dyn EscrowStore>) -> Self {
         self.escrow_store = Some(store);
         self
+    }
+
+    /// Set the budget store for budget enforcement.
+    pub fn with_budget_store(mut self, store: Arc<dyn BudgetStore>) -> Self {
+        self.budget_store = Some(store);
+        self
+    }
+
+    /// Execute a treasury effect with optional budget enforcement.
+    ///
+    /// Three paths:
+    /// 1. `CreateBudget` → create a BudgetRecord in the store, then delegate to treasury
+    /// 2. `Spend { budget_id: Some(...) }` → saga-enforced budget check, then treasury
+    /// 3. All other treasury effects → delegate directly to treasury executor
+    async fn execute_treasury_with_budget(
+        &self,
+        treasury_effect: TreasuryEffect,
+        receipt_id: &DecisionReceiptId,
+        decision_receipt_id: &str,
+    ) -> Result<EffectResult> {
+        match &treasury_effect {
+            // Path 1: CreateBudget → persist BudgetRecord
+            TreasuryEffect::CreateBudget {
+                treasury_did,
+                budget_id,
+                total_amount,
+                currency,
+                decision_hash,
+                ..
+            } => {
+                if let Some(ref budget_store) = self.budget_store {
+                    // Check for idempotent re-creation
+                    if let Some(existing) = budget_store.get(budget_id)? {
+                        if existing.decision_hash == *decision_hash {
+                            info!(
+                                budget_id = %budget_id,
+                                "Budget already created (idempotent)"
+                            );
+                            return Ok(EffectResult {
+                                effect_id: decision_receipt_id.to_string(),
+                                success: true,
+                                message: format!(
+                                    "Budget {} already exists (idempotent)",
+                                    budget_id
+                                ),
+                                state_change_hash: None,
+                            });
+                        }
+                    }
+
+                    // Use treasury_did as scope_id (the treasury owns the budget)
+                    let record = BudgetRecord::new(
+                        budget_id.clone(),
+                        treasury_did.clone(),
+                        treasury_did.clone(),
+                        currency.clone(),
+                        *total_amount,
+                        decision_hash.clone(),
+                        std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_secs(),
+                    );
+                    budget_store.put(&record)?;
+                    info!(
+                        budget_id = %budget_id,
+                        total_limit = total_amount,
+                        currency = %currency,
+                        "Budget record created"
+                    );
+                }
+
+                // Also delegate to treasury executor for ledger entry
+                let operation = treasury_effect_to_operation(&treasury_effect);
+                let outcome = self
+                    .treasury
+                    .execute_treasury_operation(receipt_id, operation)
+                    .await?;
+                Ok(execution_outcome_to_effect_result(
+                    outcome,
+                    decision_receipt_id,
+                ))
+            }
+
+            // Path 2: Spend with budget_id → saga-enforced budget check
+            TreasuryEffect::Spend {
+                budget_id: Some(budget_id),
+                decision_hash,
+                amount,
+                ..
+            } => {
+                let budget_store = match &self.budget_store {
+                    Some(store) => store,
+                    None => {
+                        warn!(
+                            budget_id = %budget_id,
+                            "Spend references budget but no budget store configured"
+                        );
+                        return Ok(EffectResult {
+                            effect_id: decision_receipt_id.to_string(),
+                            success: false,
+                            message: "Budget store not configured".to_string(),
+                            state_change_hash: None,
+                        });
+                    }
+                };
+
+                let mut budget = match budget_store.get(budget_id)? {
+                    Some(b) => b,
+                    None => {
+                        return Ok(EffectResult {
+                            effect_id: decision_receipt_id.to_string(),
+                            success: false,
+                            message: format!("Budget {} not found", budget_id),
+                            state_change_hash: None,
+                        });
+                    }
+                };
+
+                // Phase 1: begin_spend (validates capacity, records pending)
+                match budget.begin_spend(decision_hash, *amount) {
+                    Ok(BeginSpendOutcome::Proceed) => {
+                        budget_store.put(&budget)?;
+                    }
+                    Ok(BeginSpendOutcome::RetryNeeded) => {
+                        // Crash recovery — pending spend already recorded, skip persist
+                    }
+                    Err(BudgetSpendError::AlreadySpentSameDecision) => {
+                        return Ok(EffectResult {
+                            effect_id: decision_receipt_id.to_string(),
+                            success: true,
+                            message: format!(
+                                "Budget spend already confirmed (idempotent, budget={})",
+                                budget_id
+                            ),
+                            state_change_hash: None,
+                        });
+                    }
+                    Err(e) => {
+                        warn!(
+                            budget_id = %budget_id,
+                            error = %e,
+                            "Budget spend rejected"
+                        );
+                        return Ok(EffectResult {
+                            effect_id: decision_receipt_id.to_string(),
+                            success: false,
+                            message: e.to_string(),
+                            state_change_hash: None,
+                        });
+                    }
+                }
+
+                // Phase 2: Ledger mutation
+                let operation = treasury_effect_to_operation(&treasury_effect);
+                match self
+                    .treasury
+                    .execute_treasury_operation(receipt_id, operation)
+                    .await
+                {
+                    Ok(outcome) => {
+                        let result =
+                            execution_outcome_to_effect_result(outcome, decision_receipt_id);
+                        if result.success {
+                            // Phase 3: confirm_spend
+                            budget.confirm_spend();
+                            budget_store.put(&budget)?;
+                            info!(
+                                budget_id = %budget_id,
+                                spent_total = budget.spent_total,
+                                remaining = budget.remaining(),
+                                "Budget spend confirmed"
+                            );
+                        }
+                        // If !result.success, budget stays with pending_spend
+                        // for crash recovery
+                        Ok(result)
+                    }
+                    Err(e) => {
+                        // Ledger error — budget stays in pending state
+                        // for retry by DecisionExecutor
+                        Err(e)
+                    }
+                }
+            }
+
+            // Path 3: All other treasury effects → direct delegation
+            _ => {
+                let operation = treasury_effect_to_operation(&treasury_effect);
+                let outcome = self
+                    .treasury
+                    .execute_treasury_operation(receipt_id, operation)
+                    .await?;
+                Ok(execution_outcome_to_effect_result(
+                    outcome,
+                    decision_receipt_id,
+                ))
+            }
+        }
     }
 }
 
@@ -278,17 +481,15 @@ impl EffectExecutor for KernelGovernanceExecutor {
                     unreachable!("already matched Treasury variant")
                 }
             }
-            KernelEffect::Treasury(treasury_effect) => {
-                // Convert TreasuryEffect to TreasuryOperation
-                let operation = treasury_effect_to_operation(&treasury_effect);
-                let outcome = self
-                    .treasury
-                    .execute_treasury_operation(&receipt_id, operation)
-                    .await?;
-                Ok(execution_outcome_to_effect_result(
-                    outcome,
+            KernelEffect::Treasury(ref treasury_effect) => {
+                // Budget-aware treasury dispatch: handles CreateBudget, Spend with budget_id,
+                // and all other treasury effects (direct passthrough).
+                self.execute_treasury_with_budget(
+                    treasury_effect.clone(),
+                    &receipt_id,
                     decision_receipt_id,
-                ))
+                )
+                .await
             }
             KernelEffect::Protocol(protocol_effect) => {
                 // Convert ProtocolEffect to ProtocolChange

--- a/icn/crates/icn-core/src/supervisor/mod.rs
+++ b/icn/crates/icn-core/src/supervisor/mod.rs
@@ -12,6 +12,7 @@
 pub mod actors;
 pub mod background_tasks;
 pub mod bridge;
+pub mod budget_store;
 pub mod decision_executor;
 pub mod effect_dispatcher;
 pub mod escrow_store;

--- a/icn/crates/icn-core/tests/budget_enforcement_integration.rs
+++ b/icn/crates/icn-core/tests/budget_enforcement_integration.rs
@@ -1,0 +1,744 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! Integration tests for budget enforcement vertical slice.
+//!
+//! These tests exercise the full flow: CreateBudget → Spend → enforcement
+//! through the DecisionExecutor → EffectDispatcher → KernelGovernanceExecutor
+//! → BudgetStore pipeline.
+//!
+//! Three required scenarios:
+//! 1. Overspend prevention — spend exceeding budget is rejected
+//! 2. Replay idempotency — replayed decision produces no double-spend
+//! 3. Crash recovery — budget stays safe across saga boundaries
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use icn_kernel_api::budget::{BudgetRecord, BudgetStore};
+use icn_kernel_api::effects::{KernelEffect, TreasuryEffect};
+use icn_kernel_api::execution::{ExecutionRecord, ExecutionStatus, ExecutionStore};
+
+use anyhow::Result;
+
+// ============================================================================
+// Test infrastructure
+// ============================================================================
+
+/// In-memory execution store for testing.
+struct MemoryExecutionStore {
+    records: RwLock<HashMap<String, ExecutionRecord>>,
+}
+
+impl MemoryExecutionStore {
+    fn new() -> Self {
+        Self {
+            records: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl ExecutionStore for MemoryExecutionStore {
+    fn get(&self, decision_hash: &str) -> Result<Option<ExecutionRecord>> {
+        Ok(self.records.read().unwrap().get(decision_hash).cloned())
+    }
+
+    fn put(&self, record: &ExecutionRecord) -> Result<()> {
+        self.records
+            .write()
+            .unwrap()
+            .insert(record.decision_hash.clone(), record.clone());
+        Ok(())
+    }
+
+    fn list_by_status(&self, status: ExecutionStatus) -> Result<Vec<ExecutionRecord>> {
+        Ok(self
+            .records
+            .read()
+            .unwrap()
+            .values()
+            .filter(|r| r.status == status)
+            .cloned()
+            .collect())
+    }
+
+    fn count_by_status(&self) -> Result<HashMap<ExecutionStatus, usize>> {
+        let mut counts = HashMap::new();
+        for record in self.records.read().unwrap().values() {
+            *counts.entry(record.status).or_insert(0) += 1;
+        }
+        Ok(counts)
+    }
+}
+
+/// In-memory budget store for testing.
+struct MemoryBudgetStore {
+    records: RwLock<HashMap<String, BudgetRecord>>,
+}
+
+impl MemoryBudgetStore {
+    fn new() -> Self {
+        Self {
+            records: RwLock::new(HashMap::new()),
+        }
+    }
+
+    fn get_record(&self, budget_id: &str) -> Option<BudgetRecord> {
+        self.records.read().unwrap().get(budget_id).cloned()
+    }
+}
+
+impl BudgetStore for MemoryBudgetStore {
+    fn get(&self, budget_id: &str) -> Result<Option<BudgetRecord>> {
+        Ok(self.records.read().unwrap().get(budget_id).cloned())
+    }
+
+    fn put(&self, record: &BudgetRecord) -> Result<()> {
+        self.records
+            .write()
+            .unwrap()
+            .insert(record.budget_id.clone(), record.clone());
+        Ok(())
+    }
+
+    fn list_by_scope(&self, scope_id: &str) -> Result<Vec<BudgetRecord>> {
+        Ok(self
+            .records
+            .read()
+            .unwrap()
+            .values()
+            .filter(|r| r.scope_id == scope_id)
+            .cloned()
+            .collect())
+    }
+}
+
+/// Stub protocol parameter store.
+struct StubParamStore;
+
+impl icn_kernel_api::protocol_params::ProtocolParameterStore for StubParamStore {
+    fn get(&self, _: &str) -> Result<Option<icn_kernel_api::protocol_params::ProtocolParameter>> {
+        Ok(None)
+    }
+    fn get_effective(
+        &self,
+        _: &str,
+        _: Option<&str>,
+        _: Option<&str>,
+    ) -> Result<Option<icn_kernel_api::protocol_params::ProtocolParameter>> {
+        Ok(None)
+    }
+    fn set(
+        &self,
+        _: icn_kernel_api::protocol_params::ProtocolParameter,
+        _: Option<String>,
+        _: Option<String>,
+    ) -> Result<()> {
+        Ok(())
+    }
+    fn list(&self) -> Result<Vec<icn_kernel_api::protocol_params::ProtocolParameter>> {
+        Ok(vec![])
+    }
+    fn list_by_category(
+        &self,
+        _: &str,
+    ) -> Result<Vec<icn_kernel_api::protocol_params::ProtocolParameter>> {
+        Ok(vec![])
+    }
+    fn get_history(
+        &self,
+        _: &str,
+    ) -> Result<Vec<icn_kernel_api::protocol_params::ParameterChange>> {
+        Ok(vec![])
+    }
+    fn get_history_paginated(
+        &self,
+        _: &str,
+        _: usize,
+        _: usize,
+    ) -> Result<(Vec<icn_kernel_api::protocol_params::ParameterChange>, usize)> {
+        Ok((vec![], 0))
+    }
+    fn prune_history(&self, _: &str, _: usize) -> Result<usize> {
+        Ok(0)
+    }
+    fn delete(&self, _: &str) -> Result<()> {
+        Ok(())
+    }
+    fn exists(&self, _: &str) -> Result<bool> {
+        Ok(false)
+    }
+    fn count(&self) -> Result<usize> {
+        Ok(0)
+    }
+    fn total_history_count(&self) -> Result<usize> {
+        Ok(0)
+    }
+    fn validate(
+        &self,
+        _: &str,
+        _: &icn_kernel_api::protocol_params::ParameterValue,
+    ) -> std::result::Result<(), icn_kernel_api::protocol_params::ParameterValidationError> {
+        Ok(())
+    }
+    fn list_scoped_parameters(
+        &self,
+    ) -> Result<Vec<icn_kernel_api::protocol_params::ProtocolParameter>> {
+        Ok(vec![])
+    }
+    fn delete_scoped_parameter(
+        &self,
+        _: &str,
+        _: &icn_kernel_api::protocol_params::ParameterScope,
+    ) -> Result<bool> {
+        Ok(false)
+    }
+    fn add_pending_change(
+        &self,
+        _: icn_kernel_api::protocol_params::PendingParameterChange,
+    ) -> Result<()> {
+        Ok(())
+    }
+    fn get_pending_change(
+        &self,
+        _: &icn_kernel_api::protocol_params::PendingChangeId,
+    ) -> Result<Option<icn_kernel_api::protocol_params::PendingParameterChange>> {
+        Ok(None)
+    }
+    fn list_pending_changes(
+        &self,
+    ) -> Result<Vec<icn_kernel_api::protocol_params::PendingParameterChange>> {
+        Ok(vec![])
+    }
+    fn list_pending_changes_for_parameter(
+        &self,
+        _: &str,
+    ) -> Result<Vec<icn_kernel_api::protocol_params::PendingParameterChange>> {
+        Ok(vec![])
+    }
+    fn get_changes_due_before(
+        &self,
+        _: u64,
+    ) -> Result<Vec<icn_kernel_api::protocol_params::PendingParameterChange>> {
+        Ok(vec![])
+    }
+    fn update_pending_change(
+        &self,
+        _: icn_kernel_api::protocol_params::PendingParameterChange,
+    ) -> Result<()> {
+        Ok(())
+    }
+    fn cancel_pending_change(
+        &self,
+        _: &icn_kernel_api::protocol_params::PendingChangeId,
+        _: &str,
+    ) -> Result<()> {
+        Ok(())
+    }
+    fn count_pending_changes(&self) -> Result<usize> {
+        Ok(0)
+    }
+}
+
+/// Build a DecisionExecutor with budget store wired in.
+fn make_test_executor(
+    budget_store: Arc<MemoryBudgetStore>,
+) -> (
+    Arc<icn_core::supervisor::decision_executor::DecisionExecutor>,
+    Arc<MemoryExecutionStore>,
+) {
+    let param_store = Arc::new(StubParamStore);
+    let kernel_executor = Arc::new(
+        icn_core::supervisor::governance_executor::KernelGovernanceExecutor::new(param_store)
+            .with_budget_store(budget_store),
+    );
+    let dispatcher =
+        Arc::new(icn_core::supervisor::effect_dispatcher::EffectDispatcher::new(kernel_executor));
+    let exec_store = Arc::new(MemoryExecutionStore::new());
+
+    let decision_executor = Arc::new(
+        icn_core::supervisor::decision_executor::DecisionExecutor::new(
+            dispatcher,
+            exec_store.clone(),
+        ),
+    );
+
+    (decision_executor, exec_store)
+}
+
+/// Helper: create a CreateBudget effect.
+fn create_budget_effect(
+    budget_id: &str,
+    treasury_did: &str,
+    total_amount: i64,
+    decision_hash: &str,
+) -> KernelEffect {
+    KernelEffect::Treasury(TreasuryEffect::CreateBudget {
+        treasury_did: treasury_did.to_string(),
+        budget_id: budget_id.to_string(),
+        total_amount,
+        currency: "HOURS".to_string(),
+        name: format!("Test budget {}", budget_id),
+        validity_start: 0,
+        validity_end: u64::MAX,
+        decision_receipt_id: format!("receipt:{}", decision_hash),
+        decision_hash: decision_hash.to_string(),
+    })
+}
+
+/// Helper: create a Spend effect with budget_id.
+fn spend_from_budget_effect(
+    budget_id: &str,
+    treasury_did: &str,
+    recipient_did: &str,
+    amount: i64,
+    decision_hash: &str,
+) -> KernelEffect {
+    KernelEffect::Treasury(TreasuryEffect::Spend {
+        treasury_did: treasury_did.to_string(),
+        recipient_did: recipient_did.to_string(),
+        amount,
+        currency: "HOURS".to_string(),
+        memo: "Test spend".to_string(),
+        budget_id: Some(budget_id.to_string()),
+        decision_receipt_id: format!("receipt:{}", decision_hash),
+        decision_hash: decision_hash.to_string(),
+    })
+}
+
+// ============================================================================
+// Test 1: Overspend Prevention
+// ============================================================================
+
+#[tokio::test]
+async fn test_budget_overspend_rejected() {
+    let budget_store = Arc::new(MemoryBudgetStore::new());
+    let (executor, exec_store) = make_test_executor(budget_store.clone());
+
+    let treasury_did = "did:icn:treasury:ops";
+
+    // Step 1: Create budget with 1000 limit
+    let create_effects = vec![create_budget_effect(
+        "budget-ops-2024",
+        treasury_did,
+        1000,
+        "hash:create-budget",
+    )];
+    let results = executor
+        .execute(
+            create_effects,
+            "receipt:create-budget",
+            "hash:create-budget",
+            "proposal:create-budget",
+        )
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 1);
+    assert!(results[0].success, "CreateBudget should succeed");
+
+    // Verify budget record was created
+    let budget = budget_store.get_record("budget-ops-2024").unwrap();
+    assert_eq!(budget.total_limit, 1000);
+    assert_eq!(budget.spent_total, 0);
+
+    // Step 2: Spend 600 (within budget)
+    let spend_ok = vec![spend_from_budget_effect(
+        "budget-ops-2024",
+        treasury_did,
+        "did:icn:alice",
+        600,
+        "hash:spend-600",
+    )];
+    let results = executor
+        .execute(
+            spend_ok,
+            "receipt:spend-600",
+            "hash:spend-600",
+            "proposal:spend-600",
+        )
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 1);
+    assert!(
+        results[0].success,
+        "Spend 600 should succeed (within budget)"
+    );
+
+    // Verify budget updated
+    let budget = budget_store.get_record("budget-ops-2024").unwrap();
+    assert_eq!(budget.spent_total, 600);
+    assert_eq!(budget.remaining(), 400);
+
+    // Step 3: Attempt to spend 500 (exceeds remaining 400)
+    let spend_over = vec![spend_from_budget_effect(
+        "budget-ops-2024",
+        treasury_did,
+        "did:icn:bob",
+        500,
+        "hash:spend-over",
+    )];
+    let results = executor
+        .execute(
+            spend_over,
+            "receipt:spend-over",
+            "hash:spend-over",
+            "proposal:spend-over",
+        )
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 1);
+    assert!(
+        !results[0].success,
+        "Overspend should be rejected: {}",
+        results[0].message
+    );
+    assert!(
+        results[0].message.contains("over limit") || results[0].message.contains("remaining=400"),
+        "Error should explain budget constraint: {}",
+        results[0].message
+    );
+
+    // Verify budget unchanged
+    let budget = budget_store.get_record("budget-ops-2024").unwrap();
+    assert_eq!(
+        budget.spent_total, 600,
+        "spent_total should be unchanged after rejection"
+    );
+    assert!(
+        budget.pending_spend.is_none(),
+        "No pending spend should remain after rejection"
+    );
+
+    // Step 4: Verify the overspend was marked as Failed in execution store
+    let exec_record = exec_store.get("hash:spend-over").unwrap().unwrap();
+    assert_eq!(exec_record.status, ExecutionStatus::Failed);
+
+    // Step 5: Spend exactly 400 (use remaining budget)
+    let spend_exact = vec![spend_from_budget_effect(
+        "budget-ops-2024",
+        treasury_did,
+        "did:icn:carol",
+        400,
+        "hash:spend-exact",
+    )];
+    let results = executor
+        .execute(
+            spend_exact,
+            "receipt:spend-exact",
+            "hash:spend-exact",
+            "proposal:spend-exact",
+        )
+        .await
+        .unwrap();
+    assert!(results[0].success, "Exact remaining spend should succeed");
+
+    let budget = budget_store.get_record("budget-ops-2024").unwrap();
+    assert_eq!(budget.spent_total, 1000);
+    assert_eq!(budget.remaining(), 0);
+    assert_eq!(
+        budget.status,
+        icn_kernel_api::budget::BudgetStatus::Exceeded
+    );
+}
+
+// ============================================================================
+// Test 2: Replay Idempotency
+// ============================================================================
+
+#[tokio::test]
+async fn test_budget_spend_replay_idempotent() {
+    let budget_store = Arc::new(MemoryBudgetStore::new());
+    let (executor, _exec_store) = make_test_executor(budget_store.clone());
+
+    let treasury_did = "did:icn:treasury:ops";
+
+    // Step 1: Create budget
+    let create_effects = vec![create_budget_effect(
+        "budget-replay",
+        treasury_did,
+        1000,
+        "hash:create-replay",
+    )];
+    executor
+        .execute(
+            create_effects,
+            "receipt:create-replay",
+            "hash:create-replay",
+            "proposal:create-replay",
+        )
+        .await
+        .unwrap();
+
+    // Step 2: Spend 300
+    let spend = vec![spend_from_budget_effect(
+        "budget-replay",
+        treasury_did,
+        "did:icn:alice",
+        300,
+        "hash:spend-300",
+    )];
+    let results = executor
+        .execute(
+            spend.clone(),
+            "receipt:spend-300",
+            "hash:spend-300",
+            "proposal:spend-300",
+        )
+        .await
+        .unwrap();
+    assert!(results[0].success);
+
+    let budget_after_first = budget_store.get_record("budget-replay").unwrap();
+    assert_eq!(budget_after_first.spent_total, 300);
+
+    // Step 3: Replay same decision — should be caught by DecisionExecutor
+    let results2 = executor
+        .execute(
+            spend,
+            "receipt:spend-300",
+            "hash:spend-300",
+            "proposal:spend-300",
+        )
+        .await
+        .unwrap();
+    assert!(
+        results2.is_empty(),
+        "Replayed decision should return empty (idempotent skip)"
+    );
+
+    // Verify budget unchanged after replay
+    let budget_after_replay = budget_store.get_record("budget-replay").unwrap();
+    assert_eq!(
+        budget_after_replay.spent_total, 300,
+        "spent_total must not change on replay"
+    );
+}
+
+// ============================================================================
+// Test 3: Crash Recovery (saga safety)
+// ============================================================================
+
+#[tokio::test]
+async fn test_budget_crash_recovery_saga_safe() {
+    // This test verifies that if we crash between begin_spend and confirm_spend,
+    // the budget stays with a pending_spend and can be retried.
+    let budget_store = Arc::new(MemoryBudgetStore::new());
+
+    // Manually create a budget with a pending spend (simulating crash state)
+    let mut budget = BudgetRecord::new(
+        "budget-crash".into(),
+        "did:icn:treasury:crash".into(),
+        "did:icn:treasury:crash".into(),
+        "HOURS".into(),
+        1000,
+        "hash:create-crash".into(),
+        0,
+    );
+
+    // Simulate: begin_spend was called but confirm_spend was not (process crashed)
+    budget.begin_spend("hash:spend-crash", 500).unwrap();
+    budget_store.put(&budget).unwrap();
+
+    // Verify the crash state
+    let crashed = budget_store.get_record("budget-crash").unwrap();
+    assert!(crashed.pending_spend.is_some());
+    assert_eq!(crashed.spent_total, 0, "spent_total not yet incremented");
+
+    // Now create executor and retry the spend
+    let (executor, _exec_store) = make_test_executor(budget_store.clone());
+
+    let retry_spend = vec![spend_from_budget_effect(
+        "budget-crash",
+        "did:icn:treasury:crash",
+        "did:icn:alice",
+        500,
+        "hash:spend-crash",
+    )];
+
+    let results = executor
+        .execute(
+            retry_spend,
+            "receipt:spend-crash",
+            "hash:spend-crash",
+            "proposal:spend-crash",
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        results[0].success,
+        "Retry after crash should succeed: {}",
+        results[0].message
+    );
+
+    // Verify budget was properly confirmed
+    let recovered = budget_store.get_record("budget-crash").unwrap();
+    assert_eq!(recovered.spent_total, 500, "spent_total should be updated");
+    assert!(
+        recovered.pending_spend.is_none(),
+        "pending_spend should be cleared"
+    );
+    assert_eq!(recovered.remaining(), 500);
+}
+
+// ============================================================================
+// Test 4: CreateBudget idempotency
+// ============================================================================
+
+#[tokio::test]
+async fn test_create_budget_idempotent() {
+    let budget_store = Arc::new(MemoryBudgetStore::new());
+    let (executor, _exec_store) = make_test_executor(budget_store.clone());
+
+    let create = vec![create_budget_effect(
+        "budget-idem",
+        "did:icn:treasury",
+        5000,
+        "hash:create-idem",
+    )];
+
+    // First creation
+    let results = executor
+        .execute(
+            create.clone(),
+            "receipt:create-idem",
+            "hash:create-idem",
+            "proposal:create-idem",
+        )
+        .await
+        .unwrap();
+    assert!(results[0].success);
+
+    // The DecisionExecutor will catch the replay at decision level
+    let results2 = executor
+        .execute(
+            create,
+            "receipt:create-idem",
+            "hash:create-idem",
+            "proposal:create-idem",
+        )
+        .await
+        .unwrap();
+    assert!(
+        results2.is_empty(),
+        "Replayed CreateBudget caught by DecisionExecutor"
+    );
+
+    // Verify budget unchanged
+    let budget = budget_store.get_record("budget-idem").unwrap();
+    assert_eq!(budget.total_limit, 5000);
+    assert_eq!(budget.spent_total, 0);
+}
+
+// ============================================================================
+// Test 5: Spend without budget (backward compatibility)
+// ============================================================================
+
+#[tokio::test]
+async fn test_spend_without_budget_passes_through() {
+    let budget_store = Arc::new(MemoryBudgetStore::new());
+    let (executor, _exec_store) = make_test_executor(budget_store.clone());
+
+    // Spend with no budget_id — should pass through to treasury executor directly
+    let spend = vec![KernelEffect::Treasury(TreasuryEffect::Spend {
+        treasury_did: "did:icn:treasury".to_string(),
+        recipient_did: "did:icn:alice".to_string(),
+        amount: 1000,
+        currency: "HOURS".to_string(),
+        memo: "No budget".to_string(),
+        budget_id: None,
+        decision_receipt_id: "receipt:no-budget".to_string(),
+        decision_hash: "hash:no-budget".to_string(),
+    })];
+
+    let results = executor
+        .execute(
+            spend,
+            "receipt:no-budget",
+            "hash:no-budget",
+            "proposal:no-budget",
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        results[0].success,
+        "Spend without budget should pass through: {}",
+        results[0].message
+    );
+}
+
+// ============================================================================
+// Test 6: Budget queryability
+// ============================================================================
+
+#[tokio::test]
+async fn test_budget_state_queryable() {
+    let budget_store = Arc::new(MemoryBudgetStore::new());
+    let (executor, _exec_store) = make_test_executor(budget_store.clone());
+
+    let treasury_did = "did:icn:treasury:query";
+
+    // Create two budgets for same scope
+    executor
+        .execute(
+            vec![create_budget_effect(
+                "budget-a",
+                treasury_did,
+                5000,
+                "hash:create-a",
+            )],
+            "receipt:create-a",
+            "hash:create-a",
+            "proposal:create-a",
+        )
+        .await
+        .unwrap();
+
+    executor
+        .execute(
+            vec![create_budget_effect(
+                "budget-b",
+                treasury_did,
+                3000,
+                "hash:create-b",
+            )],
+            "receipt:create-b",
+            "hash:create-b",
+            "proposal:create-b",
+        )
+        .await
+        .unwrap();
+
+    // Spend from budget-a
+    executor
+        .execute(
+            vec![spend_from_budget_effect(
+                "budget-a",
+                treasury_did,
+                "did:icn:alice",
+                2000,
+                "hash:spend-a",
+            )],
+            "receipt:spend-a",
+            "hash:spend-a",
+            "proposal:spend-a",
+        )
+        .await
+        .unwrap();
+
+    // Query: list budgets by scope
+    let budgets = budget_store.list_by_scope(treasury_did).unwrap();
+    assert_eq!(budgets.len(), 2, "Should have 2 budgets for this scope");
+
+    // Query: individual budget state
+    let budget_a = budget_store.get_record("budget-a").unwrap();
+    assert_eq!(budget_a.total_limit, 5000);
+    assert_eq!(budget_a.spent_total, 2000);
+    assert_eq!(budget_a.remaining(), 3000);
+
+    let budget_b = budget_store.get_record("budget-b").unwrap();
+    assert_eq!(budget_b.total_limit, 3000);
+    assert_eq!(budget_b.spent_total, 0);
+    assert_eq!(budget_b.remaining(), 3000);
+}

--- a/icn/crates/icn-core/tests/federated_two_node_pilot.rs
+++ b/icn/crates/icn-core/tests/federated_two_node_pilot.rs
@@ -129,6 +129,7 @@ async fn test_two_node_treasury_spend_determinism() -> Result<()> {
         amount,
         currency: currency.clone(),
         memo: "Pilot equipment purchase".to_string(),
+        budget_id: None,
         decision_receipt_id: decision_receipt_id.to_string(),
         decision_hash: decision_hash.clone(),
     };

--- a/icn/crates/icn-kernel-api/src/budget.rs
+++ b/icn/crates/icn-kernel-api/src/budget.rs
@@ -1,0 +1,385 @@
+//! Budget enforcement types for the execution bridge.
+//!
+//! These types provide budget tracking at the kernel level, enabling
+//! the executor to enforce spending limits before treasury operations
+//! reach the ledger.
+//!
+//! # Saga Pattern
+//!
+//! Budget spending uses a two-phase saga to prevent the "state flip
+//! before side-effect" bug:
+//!
+//! ```text
+//! begin_spend(decision_hash, amount)
+//!   → PendingSpend recorded, spent_total NOT yet incremented
+//!   → BudgetRecord persisted in "Spending" state
+//!   → Ledger mutation happens
+//! confirm_spend()
+//!   → spent_total incremented by pending amount
+//!   → PendingSpend cleared
+//!   → BudgetRecord persisted in final state
+//! ```
+//!
+//! If the process crashes between begin_spend and confirm_spend,
+//! the budget stays in the Spending state with the PendingSpend
+//! recorded. On retry, `begin_spend` detects the pending spend
+//! and returns `RetryNeeded` to skip re-persisting.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+/// A kernel-level budget record for enforcement.
+///
+/// This is deliberately minimal — it tracks only what the kernel needs
+/// to enforce: total limit, total spent, and pending saga state.
+/// Richer budget metadata (categories, approval chains, velocity limits)
+/// lives in the app layer (icn-ledger).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BudgetRecord {
+    /// Unique budget identifier (matches governance CreateBudget effect)
+    pub budget_id: String,
+    /// Scope: which cooperative/entity this budget belongs to
+    pub scope_id: String,
+    /// Treasury DID that funds this budget
+    pub treasury_did: String,
+    /// Currency denomination
+    pub currency: String,
+    /// Total spending limit for this budget
+    pub total_limit: i64,
+    /// Total amount spent so far (confirmed only)
+    pub spent_total: i64,
+    /// Current status
+    pub status: BudgetStatus,
+    /// In-flight spend (saga intermediate state)
+    pub pending_spend: Option<PendingSpend>,
+    /// When the budget was created (epoch seconds)
+    pub created_at: u64,
+    /// Decision hash that created this budget
+    pub decision_hash: String,
+}
+
+/// Budget lifecycle status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BudgetStatus {
+    /// Budget is active and accepting spends
+    Active,
+    /// Budget has been exhausted (spent_total >= total_limit)
+    Exceeded,
+    /// Budget has been frozen by governance action
+    Frozen,
+}
+
+/// In-flight spend during saga execution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingSpend {
+    /// Decision hash that initiated this spend
+    pub decision_hash: String,
+    /// Amount being spent
+    pub amount: i64,
+}
+
+/// Outcome of `begin_spend` — tells the caller what to do next.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BeginSpendOutcome {
+    /// Fresh spend initiated. Caller should persist the record, then
+    /// execute the ledger mutation, then call `confirm_spend`.
+    Proceed,
+    /// A prior attempt with the same decision_hash crashed mid-saga.
+    /// The PendingSpend is already recorded — skip persist, retry
+    /// the ledger mutation, then call `confirm_spend`.
+    RetryNeeded,
+}
+
+/// Errors from `begin_spend`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BudgetSpendError {
+    /// This exact spend was already confirmed (idempotent success).
+    AlreadySpentSameDecision,
+    /// Budget limit would be exceeded.
+    OverBudget {
+        budget_id: String,
+        remaining: i64,
+        requested: i64,
+    },
+    /// Budget is frozen.
+    BudgetFrozen,
+    /// Budget is already exceeded.
+    BudgetExceeded,
+    /// A different spend is already in flight.
+    ConflictingPendingSpend { existing_decision_hash: String },
+}
+
+impl std::fmt::Display for BudgetSpendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AlreadySpentSameDecision => {
+                write!(f, "Spend already confirmed for this decision")
+            }
+            Self::OverBudget {
+                budget_id,
+                remaining,
+                requested,
+            } => write!(
+                f,
+                "Budget {} over limit: remaining={}, requested={}",
+                budget_id, remaining, requested
+            ),
+            Self::BudgetFrozen => write!(f, "Budget is frozen"),
+            Self::BudgetExceeded => write!(f, "Budget is already exceeded"),
+            Self::ConflictingPendingSpend {
+                existing_decision_hash,
+            } => write!(
+                f,
+                "Another spend is in flight (decision_hash={})",
+                existing_decision_hash
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BudgetSpendError {}
+
+impl BudgetRecord {
+    /// Create a new budget record from a CreateBudget effect.
+    pub fn new(
+        budget_id: String,
+        scope_id: String,
+        treasury_did: String,
+        currency: String,
+        total_limit: i64,
+        decision_hash: String,
+        created_at: u64,
+    ) -> Self {
+        Self {
+            budget_id,
+            scope_id,
+            treasury_did,
+            currency,
+            total_limit,
+            spent_total: 0,
+            status: BudgetStatus::Active,
+            pending_spend: None,
+            created_at,
+            decision_hash,
+        }
+    }
+
+    /// Remaining budget capacity.
+    pub fn remaining(&self) -> i64 {
+        self.total_limit - self.spent_total
+    }
+
+    /// Phase 1 of the spend saga: validate and record the pending spend.
+    ///
+    /// Returns `Proceed` for a fresh spend, `RetryNeeded` if a prior attempt
+    /// with the same decision_hash is already pending (crash recovery).
+    pub fn begin_spend(
+        &mut self,
+        decision_hash: &str,
+        amount: i64,
+    ) -> std::result::Result<BeginSpendOutcome, BudgetSpendError> {
+        // Check status
+        match self.status {
+            BudgetStatus::Frozen => return Err(BudgetSpendError::BudgetFrozen),
+            BudgetStatus::Exceeded => return Err(BudgetSpendError::BudgetExceeded),
+            BudgetStatus::Active => {}
+        }
+
+        // Check for existing pending spend (crash recovery)
+        if let Some(ref pending) = self.pending_spend {
+            if pending.decision_hash == decision_hash {
+                // Same decision — this is a retry after crash
+                return Ok(BeginSpendOutcome::RetryNeeded);
+            }
+            // Different decision — conflict
+            return Err(BudgetSpendError::ConflictingPendingSpend {
+                existing_decision_hash: pending.decision_hash.clone(),
+            });
+        }
+
+        // Check budget capacity (including pending amount)
+        let effective_remaining = self.remaining();
+        if amount > effective_remaining {
+            return Err(BudgetSpendError::OverBudget {
+                budget_id: self.budget_id.clone(),
+                remaining: effective_remaining,
+                requested: amount,
+            });
+        }
+
+        // Record the pending spend
+        self.pending_spend = Some(PendingSpend {
+            decision_hash: decision_hash.to_string(),
+            amount,
+        });
+
+        Ok(BeginSpendOutcome::Proceed)
+    }
+
+    /// Phase 2 of the spend saga: confirm the spend after successful ledger mutation.
+    ///
+    /// Increments `spent_total` by the pending amount and clears the pending spend.
+    /// Updates status to `Exceeded` if the budget is now fully consumed.
+    pub fn confirm_spend(&mut self) {
+        if let Some(pending) = self.pending_spend.take() {
+            self.spent_total += pending.amount;
+            if self.spent_total >= self.total_limit {
+                self.status = BudgetStatus::Exceeded;
+            }
+        }
+    }
+}
+
+/// Persistent store for budget records.
+///
+/// Implementations must provide durable storage (e.g., sled) so that
+/// budget state survives process restarts.
+pub trait BudgetStore: Send + Sync {
+    /// Get a budget record by ID.
+    fn get(&self, budget_id: &str) -> Result<Option<BudgetRecord>>;
+
+    /// Persist a budget record (insert or update).
+    fn put(&self, record: &BudgetRecord) -> Result<()>;
+
+    /// List all budgets for a given scope.
+    fn list_by_scope(&self, scope_id: &str) -> Result<Vec<BudgetRecord>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_budget(limit: i64) -> BudgetRecord {
+        BudgetRecord::new(
+            "budget-1".into(),
+            "coop-1".into(),
+            "did:icn:treasury".into(),
+            "HOURS".into(),
+            limit,
+            "decision-hash-create".into(),
+            1000,
+        )
+    }
+
+    #[test]
+    fn test_begin_spend_proceed() {
+        let mut budget = make_budget(1000);
+        let result = budget.begin_spend("decision-1", 500);
+        assert_eq!(result, Ok(BeginSpendOutcome::Proceed));
+        assert!(budget.pending_spend.is_some());
+        assert_eq!(budget.spent_total, 0); // NOT yet incremented
+    }
+
+    #[test]
+    fn test_confirm_spend() {
+        let mut budget = make_budget(1000);
+        budget.begin_spend("decision-1", 500).unwrap();
+        budget.confirm_spend();
+        assert_eq!(budget.spent_total, 500);
+        assert!(budget.pending_spend.is_none());
+        assert_eq!(budget.status, BudgetStatus::Active);
+    }
+
+    #[test]
+    fn test_overspend_rejected() {
+        let mut budget = make_budget(1000);
+        let result = budget.begin_spend("decision-1", 1500);
+        assert_eq!(
+            result,
+            Err(BudgetSpendError::OverBudget {
+                budget_id: "budget-1".into(),
+                remaining: 1000,
+                requested: 1500,
+            })
+        );
+    }
+
+    #[test]
+    fn test_exact_limit_spend() {
+        let mut budget = make_budget(1000);
+        budget.begin_spend("decision-1", 1000).unwrap();
+        budget.confirm_spend();
+        assert_eq!(budget.spent_total, 1000);
+        assert_eq!(budget.status, BudgetStatus::Exceeded);
+    }
+
+    #[test]
+    fn test_retry_same_decision() {
+        let mut budget = make_budget(1000);
+        budget.begin_spend("decision-1", 500).unwrap();
+        // Simulate crash recovery — same decision_hash
+        let result = budget.begin_spend("decision-1", 500);
+        assert_eq!(result, Ok(BeginSpendOutcome::RetryNeeded));
+    }
+
+    #[test]
+    fn test_conflicting_pending_spend() {
+        let mut budget = make_budget(1000);
+        budget.begin_spend("decision-1", 500).unwrap();
+        // Different decision while one is pending
+        let result = budget.begin_spend("decision-2", 300);
+        assert_eq!(
+            result,
+            Err(BudgetSpendError::ConflictingPendingSpend {
+                existing_decision_hash: "decision-1".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_frozen_budget_rejects_spend() {
+        let mut budget = make_budget(1000);
+        budget.status = BudgetStatus::Frozen;
+        let result = budget.begin_spend("decision-1", 100);
+        assert_eq!(result, Err(BudgetSpendError::BudgetFrozen));
+    }
+
+    #[test]
+    fn test_exceeded_budget_rejects_spend() {
+        let mut budget = make_budget(1000);
+        budget.status = BudgetStatus::Exceeded;
+        let result = budget.begin_spend("decision-1", 100);
+        assert_eq!(result, Err(BudgetSpendError::BudgetExceeded));
+    }
+
+    #[test]
+    fn test_multiple_spends_track_remaining() {
+        let mut budget = make_budget(1000);
+
+        // First spend: 300
+        budget.begin_spend("d1", 300).unwrap();
+        budget.confirm_spend();
+        assert_eq!(budget.remaining(), 700);
+
+        // Second spend: 400
+        budget.begin_spend("d2", 400).unwrap();
+        budget.confirm_spend();
+        assert_eq!(budget.remaining(), 300);
+
+        // Third spend: 301 — should fail
+        let result = budget.begin_spend("d3", 301);
+        assert_eq!(
+            result,
+            Err(BudgetSpendError::OverBudget {
+                budget_id: "budget-1".into(),
+                remaining: 300,
+                requested: 301,
+            })
+        );
+
+        // Third spend: 300 — should succeed (exact remaining)
+        budget.begin_spend("d3", 300).unwrap();
+        budget.confirm_spend();
+        assert_eq!(budget.remaining(), 0);
+        assert_eq!(budget.status, BudgetStatus::Exceeded);
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let budget = make_budget(5000);
+        let json = serde_json::to_string(&budget).unwrap();
+        let parsed: BudgetRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(budget, parsed);
+    }
+}

--- a/icn/crates/icn-kernel-api/src/effects.rs
+++ b/icn/crates/icn-kernel-api/src/effects.rs
@@ -70,6 +70,11 @@ pub enum TreasuryEffect {
         amount: i64,
         currency: String,
         memo: String,
+        /// Optional budget to charge this spend against.
+        /// When present, the executor enforces the budget limit
+        /// before submitting the ledger entry.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        budget_id: Option<String>,
         /// Links back to governance decision receipt
         decision_receipt_id: String,
         /// Canonical content hash for verification
@@ -362,6 +367,7 @@ mod tests {
             amount: 100,
             currency: "HOURS".into(),
             memo: "Tool purchase".into(),
+            budget_id: None,
             decision_receipt_id: "receipt-456".into(),
             decision_hash: "abc123".into(),
         };
@@ -385,6 +391,7 @@ mod tests {
             amount: 50,
             currency: "USD".into(),
             memo: "test".into(),
+            budget_id: None,
             decision_receipt_id: "r1".into(),
             decision_hash: "hash1".into(),
         });
@@ -418,6 +425,7 @@ mod tests {
             amount: 0i64,
             currency: String::new(),
             memo: String::new(),
+            budget_id: None,
             decision_receipt_id: String::new(),
             decision_hash: String::new(),
         };
@@ -463,6 +471,7 @@ mod tests {
                 amount: 100,
                 currency: "HOURS".into(),
                 memo: "Tool purchase".into(),
+                budget_id: None,
                 decision_receipt_id: "receipt-456".into(),
                 decision_hash: "abc123".into(),
             }),
@@ -587,6 +596,7 @@ mod tests {
                 amount: 100,
                 currency: "USD".into(),
                 memo: "test".into(),
+                budget_id: None,
                 decision_receipt_id: "r1".into(),
                 decision_hash: "h1".into(),
             },

--- a/icn/crates/icn-kernel-api/src/lib.rs
+++ b/icn/crates/icn-kernel-api/src/lib.rs
@@ -34,6 +34,7 @@
 
 pub mod authz;
 pub mod bootstrap;
+pub mod budget;
 pub mod comms;
 pub mod compute;
 pub mod coord;
@@ -67,6 +68,9 @@ pub use bootstrap::{
     BootstrapPhase, CacheStats, CapabilityRequest, CapabilitySet, DecisionCache,
     GenesisCapabilities, OracleRegistry,
 };
+pub use budget::{
+    BeginSpendOutcome, BudgetRecord, BudgetSpendError, BudgetStatus, BudgetStore, PendingSpend,
+};
 pub use comms::{PubSub, RequestResponse, Streams};
 pub use compute::{ComputeEngine, DeterminismClass, Job, OperatorMode, PrivacyClass, Trigger};
 pub use coord::Coordination;
@@ -82,10 +86,10 @@ pub use escrow::{
 pub use events::{EventCallback, EventEmitter, SystemEvent};
 pub use execution::{ExecutionRecord, ExecutionStatus, ExecutionStore};
 pub use governance::{
-    federation_effect_to_operation, DecisionReceiptId, DefaultEffectExecutor, EffectExecutor,
-    ExecutionOutcome, FederationExecutor, FederationOperation, FederationOperationType,
-    GovernanceExecutor, ProtocolChange, ProtocolExecutor, TreasuryExecutor, TreasuryOperation,
-    TreasuryOperationType,
+    federation_effect_to_operation, treasury_effect_to_operation, DecisionReceiptId,
+    DefaultEffectExecutor, EffectExecutor, ExecutionOutcome, FederationExecutor,
+    FederationOperation, FederationOperationType, GovernanceExecutor, ProtocolChange,
+    ProtocolExecutor, TreasuryExecutor, TreasuryOperation, TreasuryOperationType,
 };
 pub use identity::{DidResolver, IdentityService, Keystore};
 pub use naming::{


### PR DESCRIPTION
## Summary

- Adds budget enforcement as the second vertical slice of the execution bridge
- Governance can now create budgets (via `CreateBudget` effect) and enforce spending limits (via `Spend` with `budget_id`) before treasury operations reach the ledger
- Uses the same two-phase saga pattern proven in the escrow slice (#1194)

## What Changed

### icn-kernel-api
- **New module: `budget.rs`** — `BudgetRecord`, `BudgetStatus`, `PendingSpend`, `BeginSpendOutcome`, `BudgetSpendError`, `BudgetStore` trait
- **`effects.rs`** — Added `budget_id: Option<String>` to `TreasuryEffect::Spend` (backward-compatible: `None` means no budget enforcement)
- **`governance.rs`** — Made `treasury_effect_to_operation` public (eliminates drift from duplicate in icn-core)

### icn-core
- **New module: `budget_store.rs`** — `SledBudgetStore` with scope indexing
- **`governance_executor.rs`** — Budget enforcement in `execute_treasury_with_budget()`:
  - Path 1: `CreateBudget` → persist `BudgetRecord`, delegate to treasury
  - Path 2: `Spend { budget_id: Some(...) }` → saga-enforced budget check → treasury → confirm
  - Path 3: All other treasury effects → direct passthrough (backward compatible)
- Removed duplicate `treasury_effect_to_operation` (now imports from kernel-api)

## Invariants

| Property | Mechanism |
|----------|-----------|
| No overspend | `begin_spend` validates `amount <= remaining` before recording `PendingSpend` |
| No double-spend | DecisionExecutor idempotency (decision_hash key) + BudgetRecord saga |
| Crash-safe | `PendingSpend` persisted before ledger mutation; `confirm_spend` after success |
| Serialized access | Only one `PendingSpend` per budget at a time (conflicting spend rejected) |

## Saga Pattern

```
begin_spend(decision_hash, amount)
  → validates budget capacity
  → records PendingSpend (spent_total NOT incremented)
  → persists BudgetRecord
  
[ledger mutation happens here]

confirm_spend()
  → increments spent_total by pending amount
  → clears PendingSpend
  → persists final state
```

If crash occurs between begin_spend and confirm_spend: budget retains PendingSpend, retry detects same decision_hash → `RetryNeeded` (skip re-persist, retry ledger).

## Tests

**20 new tests total:**
- 10 unit tests (`budget.rs`): spend lifecycle, overspend, retry, frozen/exceeded, serde
- 4 unit tests (`budget_store.rs`): CRUD, scope listing, spend persistence
- 6 integration tests (`budget_enforcement_integration.rs`):
  1. `test_budget_overspend_rejected` — spend exceeding budget fails deterministically
  2. `test_budget_spend_replay_idempotent` — replayed decision produces no double-spend
  3. `test_budget_crash_recovery_saga_safe` — budget safe across saga boundaries
  4. `test_create_budget_idempotent` — replayed CreateBudget is caught
  5. `test_spend_without_budget_passes_through` — backward compatibility
  6. `test_budget_state_queryable` — budgets queryable by scope

## Known Limitations

- Budget enforcement is at executor level (not consensus-level); will need migration to ledger consensus for production hardening (tracked in plan milestone 3)
- `budget_id` on Spend is `Option<String>` — governance app wiring (`execution.rs`) has a TODO to populate from proposal payload

## Test Plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings  
- [x] `cargo test -p icn-kernel-api budget` — 10/10 pass
- [x] `cargo test -p icn-core budget_store` — 4/4 pass
- [x] `cargo test -p icn-core --test budget_enforcement_integration` — 6/6 pass
- [x] `cargo test -p icn-core --lib` — 303/303 pass
- [x] Effect path tests (tripwire, group, treasury governance) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)