### PR TITLE
feat(core): Decision Executor runtime loop with crash recovery

### DIFF
--- a/icn/crates/icn-core/src/supervisor/decision_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/decision_executor.rs
@@ -102,7 +102,16 @@ impl DecisionExecutor {
                 }
 
                 if record.status == ExecutionStatus::Failed && record.retries >= MAX_RETRIES {
-                    // Already exhausted retries
+                    // Exhausted retries — mark permanently failed
+                    let mut rec = record;
+                    rec.mark_permanently_failed("Max retries exceeded (recovery)");
+                    if let Err(e) = self.store.put(&rec) {
+                        warn!(
+                            decision_hash = %rec.decision_hash,
+                            error = %e,
+                            "Failed to mark exhausted decision as PermanentlyFailed"
+                        );
+                    }
                     report.skipped_max_retries += 1;
                     continue;
                 }
@@ -220,13 +229,33 @@ impl DecisionExecutor {
             }
         }
 
-        // 2. Record Pending (store effects for crash recovery)
-        let mut record = ExecutionRecord::new_pending(
-            decision_hash,
-            proposal_id,
-            decision_receipt_id,
-            effects.clone(),
-        );
+        // 2. Preserve existing record if present (retains retry count),
+        //    otherwise create a new Pending record.
+        let mut record = if let Some(existing) = self.store.get(decision_hash)? {
+            if !existing.is_terminal() {
+                // Preserve retry count, update effects for this attempt
+                let mut rec = existing;
+                rec.effects = effects.clone();
+                rec
+            } else {
+                // Terminal records were already caught by idempotency check above,
+                // but handle defensively.
+                ExecutionRecord::new_pending(
+                    decision_hash,
+                    proposal_id,
+                    decision_receipt_id,
+                    effects.clone(),
+                )
+            }
+        } else {
+            ExecutionRecord::new_pending(
+                decision_hash,
+                proposal_id,
+                decision_receipt_id,
+                effects.clone(),
+            )
+        };
+        record.status = ExecutionStatus::Pending;
         self.store.put(&record)?;
 
         // 3. Transition to Executing

--- a/icn/crates/icn-core/src/supervisor/decision_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/decision_executor.rs
@@ -33,6 +33,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
+use tokio::sync::Semaphore;
 use tracing::{debug, error, info, warn};
 
 use icn_kernel_api::effects::{EffectResult, KernelEffect};
@@ -43,16 +44,129 @@ use super::effect_dispatcher::EffectDispatcher;
 /// Maximum number of automatic retries before marking permanently failed.
 const MAX_RETRIES: u32 = 3;
 
+/// Maximum number of concurrent decision executions (backpressure).
+const MAX_CONCURRENT_EXECUTIONS: usize = 16;
+
 /// Wraps `EffectDispatcher` with persistent idempotency and execution logging.
 pub struct DecisionExecutor {
     dispatcher: Arc<EffectDispatcher>,
     store: Arc<dyn ExecutionStore>,
+    /// Bounded semaphore for backpressure on concurrent executions.
+    concurrency_limit: Arc<Semaphore>,
 }
 
 impl DecisionExecutor {
     /// Create a new DecisionExecutor.
     pub fn new(dispatcher: Arc<EffectDispatcher>, store: Arc<dyn ExecutionStore>) -> Self {
-        Self { dispatcher, store }
+        Self {
+            dispatcher,
+            store,
+            concurrency_limit: Arc::new(Semaphore::new(MAX_CONCURRENT_EXECUTIONS)),
+        }
+    }
+
+    /// Get a reference to the execution store.
+    pub fn store(&self) -> &Arc<dyn ExecutionStore> {
+        &self.store
+    }
+
+    /// Recover in-flight executions from a prior crash.
+    ///
+    /// Scans the ExecutionStore for records in non-terminal states
+    /// (Pending, Executing, Failed with retries remaining) and re-executes
+    /// them using the stored effects.
+    ///
+    /// Call this once at startup, after constructing the executor.
+    pub async fn recover_in_flight(&self) -> Result<RecoveryReport> {
+        let mut report = RecoveryReport::default();
+
+        // Collect records that need recovery
+        let mut recoverable = Vec::new();
+
+        for status in [
+            ExecutionStatus::Executing,
+            ExecutionStatus::Pending,
+            ExecutionStatus::Failed,
+        ] {
+            let records = self.store.list_by_status(status)?;
+            for record in records {
+                if record.effects.is_empty() {
+                    // Pre-existing record without stored effects — can't recover
+                    warn!(
+                        decision_hash = %record.decision_hash,
+                        status = ?record.status,
+                        "Cannot recover decision: no stored effects (pre-upgrade record)"
+                    );
+                    report.skipped_no_effects += 1;
+                    continue;
+                }
+
+                if record.status == ExecutionStatus::Failed && record.retries >= MAX_RETRIES {
+                    // Already exhausted retries
+                    report.skipped_max_retries += 1;
+                    continue;
+                }
+
+                recoverable.push(record);
+            }
+        }
+
+        if recoverable.is_empty() {
+            debug!("No in-flight decisions to recover");
+            return Ok(report);
+        }
+
+        info!(
+            count = recoverable.len(),
+            "Recovering in-flight decisions from prior crash"
+        );
+
+        for record in recoverable {
+            let decision_hash = record.decision_hash.clone();
+            let receipt_id = record.decision_receipt_id.clone();
+            let proposal_id = record.proposal_id.clone();
+            let effects = record.effects.clone();
+
+            match self
+                .execute(effects, &receipt_id, &decision_hash, &proposal_id)
+                .await
+            {
+                Ok(results) => {
+                    let all_success = results.iter().all(|r| r.success);
+                    if all_success {
+                        info!(
+                            decision_hash = %decision_hash,
+                            "Recovered decision: confirmed"
+                        );
+                        report.recovered_confirmed += 1;
+                    } else {
+                        warn!(
+                            decision_hash = %decision_hash,
+                            "Recovered decision: some effects failed"
+                        );
+                        report.recovered_failed += 1;
+                    }
+                }
+                Err(e) => {
+                    error!(
+                        decision_hash = %decision_hash,
+                        error = %e,
+                        "Recovery failed for decision"
+                    );
+                    report.recovered_failed += 1;
+                }
+            }
+        }
+
+        info!(
+            confirmed = report.recovered_confirmed,
+            failed = report.recovered_failed,
+            skipped_no_effects = report.skipped_no_effects,
+            skipped_max_retries = report.skipped_max_retries,
+            "Decision recovery complete"
+        );
+
+        Ok(report)
     }
 
     /// Execute effects for a governance decision, with idempotency.
@@ -106,9 +220,13 @@ impl DecisionExecutor {
             }
         }
 
-        // 2. Record Pending
-        let mut record =
-            ExecutionRecord::new_pending(decision_hash, proposal_id, decision_receipt_id);
+        // 2. Record Pending (store effects for crash recovery)
+        let mut record = ExecutionRecord::new_pending(
+            decision_hash,
+            proposal_id,
+            decision_receipt_id,
+            effects.clone(),
+        );
         self.store.put(&record)?;
 
         // 3. Transition to Executing
@@ -190,11 +308,34 @@ impl DecisionExecutor {
     }
 }
 
+/// Report from startup recovery scan.
+#[derive(Debug, Default)]
+pub struct RecoveryReport {
+    /// Decisions that were re-executed and confirmed.
+    pub recovered_confirmed: usize,
+    /// Decisions that were re-executed but failed again.
+    pub recovered_failed: usize,
+    /// Decisions skipped because they have no stored effects (pre-upgrade records).
+    pub skipped_no_effects: usize,
+    /// Decisions skipped because they exhausted retry limits.
+    pub skipped_max_retries: usize,
+}
+
+impl RecoveryReport {
+    /// Total decisions processed during recovery.
+    pub fn total(&self) -> usize {
+        self.recovered_confirmed
+            + self.recovered_failed
+            + self.skipped_no_effects
+            + self.skipped_max_retries
+    }
+}
+
 /// Create an effect executor callback that routes through the DecisionExecutor.
 ///
-/// This replaces `create_effect_executor_callback` from `effect_dispatcher.rs`
-/// when the DecisionExecutor is wired. The callback extracts decision_hash
-/// from the effects (if present) and delegates to DecisionExecutor::execute.
+/// The callback acquires a semaphore permit (backpressure) before spawning
+/// the execution task. If the semaphore is full, the task waits until a
+/// slot opens, preventing unbounded concurrent executions.
 pub fn create_decision_executor_callback(
     executor: Arc<DecisionExecutor>,
 ) -> Arc<dyn Fn(Vec<KernelEffect>, String) + Send + Sync> {
@@ -208,6 +349,7 @@ pub fn create_decision_executor_callback(
         }
 
         let executor = executor.clone();
+        let semaphore = executor.concurrency_limit.clone();
         let effect_count = effects.len();
 
         // Extract decision_hash from first effect that carries one.
@@ -220,6 +362,18 @@ pub fn create_decision_executor_callback(
         let proposal_id = decision_receipt_id.clone();
 
         tokio::spawn(async move {
+            // Backpressure: wait for a slot before executing
+            let _permit = match semaphore.acquire().await {
+                Ok(permit) => permit,
+                Err(_) => {
+                    error!(
+                        decision_hash = %decision_hash,
+                        "Semaphore closed — executor shutting down"
+                    );
+                    return;
+                }
+            };
+
             match executor
                 .execute(effects, &decision_receipt_id, &decision_hash, &proposal_id)
                 .await
@@ -244,6 +398,7 @@ pub fn create_decision_executor_callback(
                     );
                 }
             }
+            // _permit drops here, releasing the semaphore slot
         });
     })
 }
@@ -504,7 +659,7 @@ mod tests {
         let (executor, store) = make_test_executor();
 
         // Manually insert a permanently failed record
-        let mut record = ExecutionRecord::new_pending("hash-pf", "p-1", "r-1");
+        let mut record = ExecutionRecord::new_pending("hash-pf", "p-1", "r-1", vec![]);
         record.mark_permanently_failed("Non-recoverable");
         store.put(&record).unwrap();
 

--- a/icn/crates/icn-core/src/supervisor/execution_store.rs
+++ b/icn/crates/icn-core/src/supervisor/execution_store.rs
@@ -97,7 +97,7 @@ mod tests {
         let store = test_store();
         let exec_store = SledExecutionStore::new(store);
 
-        let record = ExecutionRecord::new_pending("hash123", "proposal-1", "receipt-1");
+        let record = ExecutionRecord::new_pending("hash123", "proposal-1", "receipt-1", vec![]);
         exec_store.put(&record).unwrap();
 
         let retrieved = exec_store.get("hash123").unwrap().unwrap();
@@ -119,7 +119,7 @@ mod tests {
         let store = test_store();
         let exec_store = SledExecutionStore::new(store);
 
-        let mut record = ExecutionRecord::new_pending("hash456", "proposal-2", "receipt-2");
+        let mut record = ExecutionRecord::new_pending("hash456", "proposal-2", "receipt-2", vec![]);
         exec_store.put(&record).unwrap();
 
         record.mark_executing();
@@ -139,14 +139,14 @@ mod tests {
         let exec_store = SledExecutionStore::new(store);
 
         // Add records in different states
-        let pending = ExecutionRecord::new_pending("h1", "p1", "r1");
+        let pending = ExecutionRecord::new_pending("h1", "p1", "r1", vec![]);
         exec_store.put(&pending).unwrap();
 
-        let mut confirmed = ExecutionRecord::new_pending("h2", "p2", "r2");
+        let mut confirmed = ExecutionRecord::new_pending("h2", "p2", "r2", vec![]);
         confirmed.mark_confirmed(vec![], vec![]);
         exec_store.put(&confirmed).unwrap();
 
-        let mut failed = ExecutionRecord::new_pending("h3", "p3", "r3");
+        let mut failed = ExecutionRecord::new_pending("h3", "p3", "r3", vec![]);
         failed.mark_failed("oops");
         exec_store.put(&failed).unwrap();
 
@@ -165,9 +165,9 @@ mod tests {
         let store = test_store();
         let exec_store = SledExecutionStore::new(store);
 
-        let r1 = ExecutionRecord::new_pending("a", "p1", "r1");
-        let r2 = ExecutionRecord::new_pending("b", "p2", "r2");
-        let mut r3 = ExecutionRecord::new_pending("c", "p3", "r3");
+        let r1 = ExecutionRecord::new_pending("a", "p1", "r1", vec![]);
+        let r2 = ExecutionRecord::new_pending("b", "p2", "r2", vec![]);
+        let mut r3 = ExecutionRecord::new_pending("c", "p3", "r3", vec![]);
         r3.mark_confirmed(vec![], vec![]);
 
         exec_store.put(&r1).unwrap();

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -636,6 +636,14 @@ async fn spawn_actors_with_identity(
         kernel_executor = kernel_executor.with_escrow_store(escrow_store);
         info!("✓ Escrow store wired to governance executor");
 
+        // Create budget store for budget enforcement
+        let budget_store_path = config.store_path().join("budget");
+        let budget_sled_db = sled::open(&budget_store_path)?;
+        let budget_store: Arc<dyn icn_kernel_api::budget::BudgetStore> =
+            Arc::new(super::budget_store::SledBudgetStore::new(&budget_sled_db)?);
+        kernel_executor = kernel_executor.with_budget_store(budget_store);
+        info!("✓ Budget store wired to governance executor");
+
         // Create effect dispatcher
         let effect_dispatcher = Arc::new(super::effect_dispatcher::EffectDispatcher::new(
             Arc::new(kernel_executor),
@@ -658,6 +666,31 @@ async fn spawn_actors_with_identity(
             effect_dispatcher,
             execution_store,
         ));
+
+        // Recover in-flight decisions from prior crash
+        // This must run BEFORE the event subscription is established
+        // so we don't race with new incoming decisions.
+        match decision_executor.recover_in_flight().await {
+            Ok(report) => {
+                if report.total() > 0 {
+                    info!(
+                        confirmed = report.recovered_confirmed,
+                        failed = report.recovered_failed,
+                        skipped = report.skipped_no_effects + report.skipped_max_retries,
+                        "Startup recovery: processed {} in-flight decisions",
+                        report.total()
+                    );
+                } else {
+                    debug!("Startup recovery: no in-flight decisions found");
+                }
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "Startup recovery failed (non-fatal, new decisions will still process)"
+                );
+            }
+        }
 
         // Create callback that routes effects through DecisionExecutor
         let effect_callback =

--- a/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
+++ b/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
@@ -1,0 +1,568 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! Integration tests for the Decision Executor runtime loop.
+//!
+//! These tests prove that:
+//! 1. A finalized decision auto-executes via the callback (no manual trigger)
+//! 2. Restart recovery picks up in-flight decisions
+//! 3. Double-execution is prevented (idempotency)
+//! 4. Backpressure doesn't deadlock
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use anyhow::Result;
+use icn_kernel_api::budget::{BudgetRecord, BudgetStore};
+use icn_kernel_api::effects::{KernelEffect, TreasuryEffect};
+use icn_kernel_api::execution::{ExecutionRecord, ExecutionStatus, ExecutionStore};
+
+// ---------------------------------------------------------------------------
+// In-memory stores for testing
+// ---------------------------------------------------------------------------
+
+struct MemoryExecutionStore {
+    records: RwLock<HashMap<String, ExecutionRecord>>,
+}
+
+impl MemoryExecutionStore {
+    fn new() -> Self {
+        Self {
+            records: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl ExecutionStore for MemoryExecutionStore {
+    fn get(&self, decision_hash: &str) -> Result<Option<ExecutionRecord>> {
+        Ok(self
+            .records
+            .read()
+            .map_err(|e| anyhow::anyhow!("lock: {e}"))?
+            .get(decision_hash)
+            .cloned())
+    }
+
+    fn put(&self, record: &ExecutionRecord) -> Result<()> {
+        self.records
+            .write()
+            .map_err(|e| anyhow::anyhow!("lock: {e}"))?
+            .insert(record.decision_hash.clone(), record.clone());
+        Ok(())
+    }
+
+    fn list_by_status(&self, status: ExecutionStatus) -> Result<Vec<ExecutionRecord>> {
+        Ok(self
+            .records
+            .read()
+            .map_err(|e| anyhow::anyhow!("lock: {e}"))?
+            .values()
+            .filter(|r| r.status == status)
+            .cloned()
+            .collect())
+    }
+
+    fn count_by_status(&self) -> Result<HashMap<ExecutionStatus, usize>> {
+        let mut counts = HashMap::new();
+        for record in self
+            .records
+            .read()
+            .map_err(|e| anyhow::anyhow!("lock: {e}"))?
+            .values()
+        {
+            *counts.entry(record.status).or_insert(0) += 1;
+        }
+        Ok(counts)
+    }
+}
+
+struct MemoryBudgetStore {
+    budgets: RwLock<HashMap<String, BudgetRecord>>,
+}
+
+impl MemoryBudgetStore {
+    fn new() -> Self {
+        Self {
+            budgets: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl BudgetStore for MemoryBudgetStore {
+    fn get(&self, budget_id: &str) -> Result<Option<BudgetRecord>> {
+        Ok(self
+            .budgets
+            .read()
+            .map_err(|e| anyhow::anyhow!("lock: {e}"))?
+            .get(budget_id)
+            .cloned())
+    }
+
+    fn put(&self, record: &BudgetRecord) -> Result<()> {
+        self.budgets
+            .write()
+            .map_err(|e| anyhow::anyhow!("lock: {e}"))?
+            .insert(record.budget_id.clone(), record.clone());
+        Ok(())
+    }
+
+    fn list_by_scope(&self, scope_id: &str) -> Result<Vec<BudgetRecord>> {
+        Ok(self
+            .budgets
+            .read()
+            .map_err(|e| anyhow::anyhow!("lock: {e}"))?
+            .values()
+            .filter(|b| b.scope_id == scope_id)
+            .cloned()
+            .collect())
+    }
+}
+
+struct StubParamStore;
+
+impl icn_kernel_api::protocol_params::ProtocolParameterStore for StubParamStore {
+    fn get(&self, _: &str) -> Result<Option<icn_kernel_api::protocol_params::ProtocolParameter>> {
+        Ok(None)
+    }
+    fn get_effective(
+        &self,
+        _: &str,
+        _: Option<&str>,
+        _: Option<&str>,
+    ) -> Result<Option<icn_kernel_api::protocol_params::ProtocolParameter>> {
+        Ok(None)
+    }
+    fn set(
+        &self,
+        _: icn_kernel_api::protocol_params::ProtocolParameter,
+        _: Option<String>,
+        _: Option<String>,
+    ) -> Result<()> {
+        Ok(())
+    }
+    fn list(&self) -> Result<Vec<icn_kernel_api::protocol_params::ProtocolParameter>> {
+        Ok(vec![])
+    }
+    fn list_by_category(
+        &self,
+        _: &str,
+    ) -> Result<Vec<icn_kernel_api::protocol_params::ProtocolParameter>> {
+        Ok(vec![])
+    }
+    fn get_history(
+        &self,
+        _: &str,
+    ) -> Result<Vec<icn_kernel_api::protocol_params::ParameterChange>> {
+        Ok(vec![])
+    }
+    fn get_history_paginated(
+        &self,
+        _: &str,
+        _: usize,
+        _: usize,
+    ) -> Result<(Vec<icn_kernel_api::protocol_params::ParameterChange>, usize)> {
+        Ok((vec![], 0))
+    }
+    fn prune_history(&self, _: &str, _: usize) -> Result<usize> {
+        Ok(0)
+    }
+    fn delete(&self, _: &str) -> Result<()> {
+        Ok(())
+    }
+    fn exists(&self, _: &str) -> Result<bool> {
+        Ok(false)
+    }
+    fn count(&self) -> Result<usize> {
+        Ok(0)
+    }
+    fn total_history_count(&self) -> Result<usize> {
+        Ok(0)
+    }
+    fn validate(
+        &self,
+        _: &str,
+        _: &icn_kernel_api::protocol_params::ParameterValue,
+    ) -> std::result::Result<(), icn_kernel_api::protocol_params::ParameterValidationError> {
+        Ok(())
+    }
+    fn list_scoped_parameters(
+        &self,
+    ) -> Result<Vec<icn_kernel_api::protocol_params::ProtocolParameter>> {
+        Ok(vec![])
+    }
+    fn delete_scoped_parameter(
+        &self,
+        _: &str,
+        _: &icn_kernel_api::protocol_params::ParameterScope,
+    ) -> Result<bool> {
+        Ok(false)
+    }
+    fn add_pending_change(
+        &self,
+        _: icn_kernel_api::protocol_params::PendingParameterChange,
+    ) -> Result<()> {
+        Ok(())
+    }
+    fn get_pending_change(
+        &self,
+        _: &icn_kernel_api::protocol_params::PendingChangeId,
+    ) -> Result<Option<icn_kernel_api::protocol_params::PendingParameterChange>> {
+        Ok(None)
+    }
+    fn list_pending_changes(
+        &self,
+    ) -> Result<Vec<icn_kernel_api::protocol_params::PendingParameterChange>> {
+        Ok(vec![])
+    }
+    fn list_pending_changes_for_parameter(
+        &self,
+        _: &str,
+    ) -> Result<Vec<icn_kernel_api::protocol_params::PendingParameterChange>> {
+        Ok(vec![])
+    }
+    fn get_changes_due_before(
+        &self,
+        _: u64,
+    ) -> Result<Vec<icn_kernel_api::protocol_params::PendingParameterChange>> {
+        Ok(vec![])
+    }
+    fn update_pending_change(
+        &self,
+        _: icn_kernel_api::protocol_params::PendingParameterChange,
+    ) -> Result<()> {
+        Ok(())
+    }
+    fn cancel_pending_change(
+        &self,
+        _: &icn_kernel_api::protocol_params::PendingChangeId,
+        _: &str,
+    ) -> Result<()> {
+        Ok(())
+    }
+    fn count_pending_changes(&self) -> Result<usize> {
+        Ok(0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_executor_with_budget(
+    budget_store: Arc<dyn BudgetStore>,
+) -> (
+    Arc<icn_core::supervisor::decision_executor::DecisionExecutor>,
+    Arc<MemoryExecutionStore>,
+) {
+    use icn_core::supervisor::decision_executor::DecisionExecutor;
+    use icn_core::supervisor::effect_dispatcher::EffectDispatcher;
+    use icn_core::supervisor::governance_executor::KernelGovernanceExecutor;
+
+    let kernel_executor =
+        KernelGovernanceExecutor::new(Arc::new(StubParamStore)).with_budget_store(budget_store);
+
+    let dispatcher = Arc::new(EffectDispatcher::new(Arc::new(kernel_executor)));
+    let exec_store = Arc::new(MemoryExecutionStore::new());
+    let executor = Arc::new(DecisionExecutor::new(dispatcher, exec_store.clone()));
+    (executor, exec_store)
+}
+
+fn make_executor() -> (
+    Arc<icn_core::supervisor::decision_executor::DecisionExecutor>,
+    Arc<MemoryExecutionStore>,
+) {
+    use icn_core::supervisor::decision_executor::DecisionExecutor;
+    use icn_core::supervisor::effect_dispatcher::EffectDispatcher;
+    use icn_core::supervisor::governance_executor::KernelGovernanceExecutor;
+
+    let kernel_executor = KernelGovernanceExecutor::new(Arc::new(StubParamStore));
+
+    let dispatcher = Arc::new(EffectDispatcher::new(Arc::new(kernel_executor)));
+    let exec_store = Arc::new(MemoryExecutionStore::new());
+    let executor = Arc::new(DecisionExecutor::new(dispatcher, exec_store.clone()));
+    (executor, exec_store)
+}
+
+fn spend_effect(decision_hash: &str) -> Vec<KernelEffect> {
+    vec![KernelEffect::Treasury(TreasuryEffect::Spend {
+        treasury_did: "did:icn:treasury".to_string(),
+        recipient_did: "did:icn:recipient".to_string(),
+        amount: 100,
+        currency: "HOURS".to_string(),
+        memo: "Test spend".to_string(),
+        budget_id: None,
+        decision_receipt_id: "receipt-1".to_string(),
+        decision_hash: decision_hash.to_string(),
+    })]
+}
+
+fn budget_spend_effect(decision_hash: &str, budget_id: &str, amount: i64) -> Vec<KernelEffect> {
+    vec![KernelEffect::Treasury(TreasuryEffect::Spend {
+        treasury_did: "did:icn:treasury".to_string(),
+        recipient_did: "did:icn:recipient".to_string(),
+        amount,
+        currency: "HOURS".to_string(),
+        memo: "Budget spend".to_string(),
+        budget_id: Some(budget_id.to_string()),
+        decision_receipt_id: "receipt-budget".to_string(),
+        decision_hash: decision_hash.to_string(),
+    })]
+}
+
+fn create_budget_effect(decision_hash: &str, budget_id: &str, limit: i64) -> Vec<KernelEffect> {
+    vec![KernelEffect::Treasury(TreasuryEffect::CreateBudget {
+        treasury_did: "did:icn:treasury".to_string(),
+        budget_id: budget_id.to_string(),
+        total_amount: limit,
+        currency: "HOURS".to_string(),
+        name: "Test Budget".to_string(),
+        validity_start: 0,
+        validity_end: u64::MAX,
+        decision_receipt_id: "receipt-create".to_string(),
+        decision_hash: decision_hash.to_string(),
+    })]
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Test 1: A finalized decision auto-executes via the callback.
+///
+/// This simulates what happens in the real runtime: the governance app
+/// emits effects, the callback fires, and the DecisionExecutor processes
+/// them asynchronously.
+#[tokio::test]
+async fn test_callback_auto_executes_decision() {
+    use icn_core::supervisor::decision_executor::create_decision_executor_callback;
+
+    let (executor, exec_store) = make_executor();
+    let callback = create_decision_executor_callback(executor);
+
+    // Simulate governance app emitting effects
+    let effects = spend_effect("hash-auto-1");
+    callback(effects, "receipt-auto-1".to_string());
+
+    // Wait for the spawned task to complete
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Assert execution record is Confirmed
+    let record = exec_store.get("hash-auto-1").unwrap().unwrap();
+    assert_eq!(
+        record.status,
+        ExecutionStatus::Confirmed,
+        "Decision should be confirmed after callback execution"
+    );
+    assert_eq!(record.decision_hash, "hash-auto-1");
+}
+
+/// Test 2: Calling the callback twice with the same decision_hash
+/// does not double-execute.
+#[tokio::test]
+async fn test_callback_idempotent_no_double_execute() {
+    use icn_core::supervisor::decision_executor::create_decision_executor_callback;
+
+    let (executor, exec_store) = make_executor();
+    let callback = create_decision_executor_callback(executor);
+
+    // First execution
+    let effects = spend_effect("hash-idem-1");
+    callback(effects.clone(), "receipt-idem-1".to_string());
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    let record1 = exec_store.get("hash-idem-1").unwrap().unwrap();
+    assert_eq!(record1.status, ExecutionStatus::Confirmed);
+
+    // Second execution (replay) — should be skipped
+    callback(effects, "receipt-idem-1".to_string());
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Still confirmed, not re-executed
+    let record2 = exec_store.get("hash-idem-1").unwrap().unwrap();
+    assert_eq!(record2.status, ExecutionStatus::Confirmed);
+}
+
+/// Test 3: Startup recovery picks up an Executing record and completes it.
+#[tokio::test]
+async fn test_startup_recovery_completes_executing_decision() {
+    let (executor, exec_store) = make_executor();
+
+    // Pre-seed an Executing record (simulates crash mid-execution)
+    let effects = spend_effect("hash-crash-1");
+    let mut crashed_record =
+        ExecutionRecord::new_pending("hash-crash-1", "proposal-crash", "receipt-crash", effects);
+    crashed_record.mark_executing();
+    exec_store.put(&crashed_record).unwrap();
+
+    // Verify it's in Executing state
+    let before = exec_store.get("hash-crash-1").unwrap().unwrap();
+    assert_eq!(before.status, ExecutionStatus::Executing);
+
+    // Run recovery
+    let report = executor.recover_in_flight().await.unwrap();
+
+    assert_eq!(report.recovered_confirmed, 1, "Should recover 1 decision");
+    assert_eq!(report.recovered_failed, 0);
+
+    // Verify it's now Confirmed
+    let after = exec_store.get("hash-crash-1").unwrap().unwrap();
+    assert_eq!(
+        after.status,
+        ExecutionStatus::Confirmed,
+        "Recovered decision should be confirmed"
+    );
+}
+
+/// Test 4: Startup recovery skips records that have no stored effects
+/// (pre-upgrade records from before effects storage was added).
+#[tokio::test]
+async fn test_startup_recovery_skips_records_without_effects() {
+    let (executor, exec_store) = make_executor();
+
+    // Pre-seed a record with empty effects (pre-upgrade)
+    let mut old_record =
+        ExecutionRecord::new_pending("hash-old-1", "proposal-old", "receipt-old", vec![]);
+    old_record.mark_executing();
+    exec_store.put(&old_record).unwrap();
+
+    // Run recovery
+    let report = executor.recover_in_flight().await.unwrap();
+
+    assert_eq!(
+        report.skipped_no_effects, 1,
+        "Should skip 1 record with no effects"
+    );
+    assert_eq!(report.recovered_confirmed, 0);
+
+    // Record should still be in Executing state (not modified)
+    let after = exec_store.get("hash-old-1").unwrap().unwrap();
+    assert_eq!(after.status, ExecutionStatus::Executing);
+}
+
+/// Test 5: Startup recovery re-attempts Failed records.
+#[tokio::test]
+async fn test_startup_recovery_retries_failed_decision() {
+    let (executor, exec_store) = make_executor();
+
+    // Pre-seed a Failed record with stored effects (retry 1 of 3)
+    let effects = vec![KernelEffect::NoOp {
+        reason: "test".to_string(),
+    }];
+    let mut failed_record =
+        ExecutionRecord::new_pending("hash-fail-retry", "proposal-fail", "receipt-fail", effects);
+    failed_record.mark_executing();
+    failed_record.mark_failed("Transient error");
+    assert_eq!(failed_record.retries, 1);
+    exec_store.put(&failed_record).unwrap();
+
+    // Run recovery
+    let report = executor.recover_in_flight().await.unwrap();
+
+    assert_eq!(
+        report.recovered_confirmed, 1,
+        "Should recover the failed decision on retry"
+    );
+
+    // Verify it's now Confirmed
+    let after = exec_store.get("hash-fail-retry").unwrap().unwrap();
+    assert_eq!(after.status, ExecutionStatus::Confirmed);
+}
+
+/// Test 6: Full end-to-end: create budget → spend against it → auto-execute.
+/// This proves the complete pipeline works through the callback.
+#[tokio::test]
+async fn test_callback_e2e_budget_create_and_spend() {
+    use icn_core::supervisor::decision_executor::create_decision_executor_callback;
+
+    let budget_store = Arc::new(MemoryBudgetStore::new());
+    let (executor, exec_store) = make_executor_with_budget(budget_store.clone());
+    let callback = create_decision_executor_callback(executor);
+
+    // Step 1: Create a budget via callback
+    let create_effects = create_budget_effect("hash-create-b1", "budget-1", 1000);
+    callback(create_effects, "receipt-create-b1".to_string());
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Verify budget was created
+    let budget = budget_store.get("budget-1").unwrap().unwrap();
+    assert_eq!(budget.total_limit, 1000);
+    assert_eq!(budget.spent_total, 0);
+
+    // Verify execution record
+    let create_record = exec_store.get("hash-create-b1").unwrap().unwrap();
+    assert_eq!(create_record.status, ExecutionStatus::Confirmed);
+
+    // Step 2: Spend against the budget via callback
+    let spend_effects = budget_spend_effect("hash-spend-b1", "budget-1", 300);
+    callback(spend_effects, "receipt-spend-b1".to_string());
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Verify budget was debited
+    let budget_after = budget_store.get("budget-1").unwrap().unwrap();
+    assert_eq!(budget_after.spent_total, 300);
+    assert_eq!(budget_after.remaining(), 700);
+
+    // Verify spend execution record
+    let spend_record = exec_store.get("hash-spend-b1").unwrap().unwrap();
+    assert_eq!(spend_record.status, ExecutionStatus::Confirmed);
+}
+
+/// Test 7: Backpressure does not deadlock under concurrent load.
+#[tokio::test]
+async fn test_backpressure_no_deadlock() {
+    use icn_core::supervisor::decision_executor::create_decision_executor_callback;
+
+    let (executor, exec_store) = make_executor();
+    let callback = create_decision_executor_callback(executor);
+
+    // Fire 32 decisions concurrently (exceeds MAX_CONCURRENT_EXECUTIONS = 16)
+    for i in 0..32 {
+        let hash = format!("hash-bp-{}", i);
+        let effects = vec![KernelEffect::NoOp {
+            reason: format!("backpressure-test-{}", i),
+        }];
+        callback(effects, format!("receipt-bp-{}", i));
+
+        // Cheat: the NoOp effects use receipt_id as decision_hash fallback
+        // since NoOp doesn't carry a decision_hash field.
+        let _ = hash; // hash unused — callback extracts from receipt_id
+    }
+
+    // Wait for all to complete (with backpressure, some will queue)
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    // Count confirmed records
+    let confirmed = exec_store
+        .list_by_status(ExecutionStatus::Confirmed)
+        .unwrap();
+    assert_eq!(
+        confirmed.len(),
+        32,
+        "All 32 decisions should complete despite backpressure"
+    );
+}
+
+/// Test 8: Recovery after restart does not re-execute already confirmed decisions.
+#[tokio::test]
+async fn test_recovery_does_not_re_execute_confirmed() {
+    let (executor, exec_store) = make_executor();
+
+    // Pre-seed a Confirmed record
+    let effects = spend_effect("hash-confirmed-already");
+    let mut confirmed_record = ExecutionRecord::new_pending(
+        "hash-confirmed-already",
+        "proposal-done",
+        "receipt-done",
+        effects,
+    );
+    confirmed_record.mark_executing();
+    confirmed_record.mark_confirmed(vec!["entry-1".into()], vec!["hash-1".into()]);
+    exec_store.put(&confirmed_record).unwrap();
+
+    // Run recovery — should find nothing to recover
+    let report = executor.recover_in_flight().await.unwrap();
+    assert_eq!(report.total(), 0, "No records should need recovery");
+
+    // Verify record is untouched
+    let after = exec_store.get("hash-confirmed-already").unwrap().unwrap();
+    assert_eq!(after.status, ExecutionStatus::Confirmed);
+    assert_eq!(after.ledger_entry_ids, vec!["entry-1"]);
+}

--- a/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
+++ b/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
@@ -466,7 +466,53 @@ async fn test_startup_recovery_retries_failed_decision() {
     assert_eq!(after.status, ExecutionStatus::Confirmed);
 }
 
-/// Test 6: Full end-to-end: create budget → spend against it → auto-execute.
+/// Test 6: Retry counter accumulates across recovery attempts
+/// and enforces MAX_RETRIES → PermanentlyFailed.
+///
+/// This uses a budget spend against a non-existent budget so the
+/// effect fails deterministically on every attempt.
+#[tokio::test]
+async fn test_retry_accumulation_and_max_retries() {
+    // Budget store with NO budgets — spend effects will always fail
+    let budget_store = Arc::new(MemoryBudgetStore::new());
+    let (executor, exec_store) = make_executor_with_budget(budget_store);
+
+    // Pre-seed a Failed record with 1 prior retry
+    let effects = budget_spend_effect("hash-retry-acc", "nonexistent-budget", 100);
+    let mut record =
+        ExecutionRecord::new_pending("hash-retry-acc", "proposal-retry", "receipt-retry", effects);
+    record.mark_executing();
+    record.mark_failed("First failure");
+    assert_eq!(record.retries, 1);
+    exec_store.put(&record).unwrap();
+
+    // Recovery attempt 2: should fail again, retries → 2
+    let _report = executor.recover_in_flight().await.unwrap();
+    let after = exec_store.get("hash-retry-acc").unwrap().unwrap();
+    assert_eq!(after.retries, 2, "Retry counter should accumulate to 2");
+    assert_eq!(
+        after.status,
+        ExecutionStatus::Failed,
+        "Should still be Failed (under MAX_RETRIES=3)"
+    );
+
+    // Recovery attempt 3: should fail, retries → 3 → hits MAX_RETRIES
+    let _report = executor.recover_in_flight().await.unwrap();
+    let after = exec_store.get("hash-retry-acc").unwrap().unwrap();
+    // At retries == 3 (== MAX_RETRIES), the next recovery call should mark PermanentlyFailed
+    assert_eq!(after.retries, 3);
+
+    // Recovery attempt 4: should hit MAX_RETRIES gate → PermanentlyFailed
+    let _report = executor.recover_in_flight().await.unwrap();
+    let after = exec_store.get("hash-retry-acc").unwrap().unwrap();
+    assert_eq!(
+        after.status,
+        ExecutionStatus::PermanentlyFailed,
+        "Should be PermanentlyFailed after exhausting MAX_RETRIES"
+    );
+}
+
+/// Test 7 (was 6): Full end-to-end: create budget → spend against it → auto-execute.
 /// This proves the complete pipeline works through the callback.
 #[tokio::test]
 async fn test_callback_e2e_budget_create_and_spend() {
@@ -505,7 +551,7 @@ async fn test_callback_e2e_budget_create_and_spend() {
     assert_eq!(spend_record.status, ExecutionStatus::Confirmed);
 }
 
-/// Test 7: Backpressure does not deadlock under concurrent load.
+/// Test 8: Backpressure does not deadlock under concurrent load.
 #[tokio::test]
 async fn test_backpressure_no_deadlock() {
     use icn_core::supervisor::decision_executor::create_decision_executor_callback;
@@ -513,17 +559,14 @@ async fn test_backpressure_no_deadlock() {
     let (executor, exec_store) = make_executor();
     let callback = create_decision_executor_callback(executor);
 
-    // Fire 32 decisions concurrently (exceeds MAX_CONCURRENT_EXECUTIONS = 16)
+    // Fire 32 decisions concurrently (exceeds MAX_CONCURRENT_EXECUTIONS = 16).
+    // NoOp effects don't carry a decision_hash, so the callback uses
+    // receipt_id as the decision_hash fallback.
     for i in 0..32 {
-        let hash = format!("hash-bp-{}", i);
         let effects = vec![KernelEffect::NoOp {
             reason: format!("backpressure-test-{}", i),
         }];
         callback(effects, format!("receipt-bp-{}", i));
-
-        // Cheat: the NoOp effects use receipt_id as decision_hash fallback
-        // since NoOp doesn't carry a decision_hash field.
-        let _ = hash; // hash unused — callback extracts from receipt_id
     }
 
     // Wait for all to complete (with backpressure, some will queue)
@@ -540,7 +583,7 @@ async fn test_backpressure_no_deadlock() {
     );
 }
 
-/// Test 8: Recovery after restart does not re-execute already confirmed decisions.
+/// Test 9: Recovery after restart does not re-execute already confirmed decisions.
 #[tokio::test]
 async fn test_recovery_does_not_re_execute_confirmed() {
     let (executor, exec_store) = make_executor();

--- a/icn/crates/icn-core/tests/escrow_release_integration.rs
+++ b/icn/crates/icn-core/tests/escrow_release_integration.rs
@@ -429,7 +429,7 @@ async fn test_crash_recovery_no_double_spend() {
 
     // Manually insert an Executing record (simulates mid-flight crash)
     let mut crashed_record =
-        ExecutionRecord::new_pending("hash-midcrash", "proposal-mid", "receipt-mid");
+        ExecutionRecord::new_pending("hash-midcrash", "proposal-mid", "receipt-mid", vec![]);
     crashed_record.mark_executing();
     exec_store3.put(&crashed_record).unwrap();
 

--- a/icn/crates/icn-kernel-api/src/execution.rs
+++ b/icn/crates/icn-kernel-api/src/execution.rs
@@ -245,4 +245,30 @@ mod tests {
         assert_eq!(parsed.status, ExecutionStatus::Confirmed);
         assert_eq!(parsed.ledger_entry_ids, vec!["e1"]);
     }
+
+    #[test]
+    fn test_execution_record_backward_compat_without_effects() {
+        // Pre-upgrade records serialized without the `effects` field
+        // must deserialize successfully with an empty effects vec.
+        let json = r#"{
+            "decision_hash": "old-hash",
+            "proposal_id": "old-proposal",
+            "decision_receipt_id": "old-receipt",
+            "status": "confirmed",
+            "started_at": 1700000000,
+            "finished_at": 1700000001,
+            "ledger_entry_ids": ["e1"],
+            "state_change_hashes": [],
+            "error": null,
+            "retries": 0
+        }"#;
+
+        let record: ExecutionRecord = serde_json::from_str(json).unwrap();
+        assert_eq!(record.decision_hash, "old-hash");
+        assert_eq!(record.status, ExecutionStatus::Confirmed);
+        assert!(
+            record.effects.is_empty(),
+            "effects should default to empty vec"
+        );
+    }
 }

--- a/icn/crates/icn-kernel-api/src/execution.rs
+++ b/icn/crates/icn-kernel-api/src/execution.rs
@@ -20,6 +20,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::effects::KernelEffect;
+
 /// Status of a governance decision's execution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -72,6 +74,11 @@ pub struct ExecutionRecord {
 
     /// Number of retry attempts.
     pub retries: u32,
+
+    /// The kernel effects to execute (stored for crash recovery).
+    /// Empty for pre-existing records that don't have effects stored.
+    #[serde(default)]
+    pub effects: Vec<KernelEffect>,
 }
 
 impl ExecutionRecord {
@@ -80,6 +87,7 @@ impl ExecutionRecord {
         decision_hash: impl Into<String>,
         proposal_id: impl Into<String>,
         decision_receipt_id: impl Into<String>,
+        effects: Vec<KernelEffect>,
     ) -> Self {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -97,6 +105,7 @@ impl ExecutionRecord {
             state_change_hashes: Vec::new(),
             error: None,
             retries: 0,
+            effects,
         }
     }
 
@@ -180,7 +189,8 @@ mod tests {
 
     #[test]
     fn test_execution_record_lifecycle() {
-        let mut record = ExecutionRecord::new_pending("abc123hash", "proposal-42", "receipt-42");
+        let mut record =
+            ExecutionRecord::new_pending("abc123hash", "proposal-42", "receipt-42", vec![]);
 
         assert_eq!(record.status, ExecutionStatus::Pending);
         assert!(!record.is_terminal());
@@ -197,7 +207,8 @@ mod tests {
 
     #[test]
     fn test_execution_record_failure_path() {
-        let mut record = ExecutionRecord::new_pending("abc123hash", "proposal-42", "receipt-42");
+        let mut record =
+            ExecutionRecord::new_pending("abc123hash", "proposal-42", "receipt-42", vec![]);
 
         record.mark_executing();
         record.mark_failed("Ledger unavailable");
@@ -223,7 +234,8 @@ mod tests {
 
     #[test]
     fn test_execution_record_serde_roundtrip() {
-        let mut record = ExecutionRecord::new_pending("deadbeef", "proposal-1", "receipt-1");
+        let mut record =
+            ExecutionRecord::new_pending("deadbeef", "proposal-1", "receipt-1", vec![]);
         record.mark_confirmed(vec!["e1".into()], vec!["h1".into()]);
 
         let json = serde_json::to_string(&record).unwrap();


### PR DESCRIPTION
## Summary

- **Store effects in ExecutionRecord** for crash recovery — `Vec<KernelEffect>` persisted alongside saga state, `#[serde(default)]` for backward compat
- **Startup recovery** via `recover_in_flight()` — scans for Executing/Pending/Failed records and re-executes them on daemon restart
- **Backpressure** via `tokio::sync::Semaphore` (16 concurrent max) — prevents unbounded task spawning from burst governance decisions
- **Wire BudgetStore** into `lifecycle.rs` — sled-backed, completes the budget enforcement pipeline from Step 4
- **8 integration tests** proving the runtime loop works end-to-end

## What this completes

**Step 5 of the Economics-First Architecture plan**: A running node automatically executes finalized governance decisions exactly once (or safely retries), using DecisionExecutor + ExecutionStore + saga stores.

The event-driven pipeline (EventBus → callback → DecisionExecutor) was already wired in Steps 2-4. This PR adds the three missing pieces:
1. **Crash recovery**: Effects stored in ExecutionRecord so the executor can re-run without re-querying governance
2. **Backpressure**: Semaphore-gated concurrency prevents overload
3. **BudgetStore wiring**: Budget enforcement now works in the daemon (not just tests)

## Test plan

8 new integration tests in `decision_executor_runtime_test.rs`:
- [x] `test_callback_auto_executes_decision` — callback fires, decision auto-confirms
- [x] `test_callback_idempotent_no_double_execute` — replay doesn't re-execute
- [x] `test_startup_recovery_completes_executing_decision` — crash recovery for Executing records
- [x] `test_startup_recovery_skips_records_without_effects` — pre-upgrade records skipped safely
- [x] `test_startup_recovery_retries_failed_decision` — Failed records get re-attempted
- [x] `test_callback_e2e_budget_create_and_spend` — full pipeline: create budget + spend via callback
- [x] `test_backpressure_no_deadlock` — 32 concurrent decisions (2x limit) all complete
- [x] `test_recovery_does_not_re_execute_confirmed` — confirmed records not re-run

All existing escrow (5) and budget (6) integration tests continue to pass.

## Invariants checklist

- [x] **Adversarial-by-default**: Idempotency key prevents double-execution; semaphore prevents resource exhaustion
- [x] **Determinism**: Effects stored deterministically; recovery replays in consistent order
- [x] **Canonical encodings**: serde(default) ensures backward-compatible deserialization
- [x] **No panics**: All error paths return Result; semaphore closure logged, not panicked
- [x] **Kernel/app boundary**: Effects are generic KernelEffect, not governance-specific types

🤖 Generated with [Claude Code](https://claude.com/claude-code)