### PR TITLE
fix(membership): correct doctest import path

### DIFF
--- a/icn/apps/membership/src/entity_core/membership.rs
+++ b/icn/apps/membership/src/entity_core/membership.rs
@@ -523,7 +523,7 @@ impl fmt::Display for MembershipStatus {
 /// # Example
 ///
 /// ```rust
-/// use icn_entity::membership::UnifiedMembershipStatus;
+/// use icn_membership_app::UnifiedMembershipStatus;
 ///
 /// let status = UnifiedMembershipStatus::Applicant;
 /// assert!(!status.is_active());


### PR DESCRIPTION
## Summary

- Fix broken doctest in `UnifiedMembershipStatus`: `icn_entity::membership::UnifiedMembershipStatus` → `icn_membership_app::UnifiedMembershipStatus`

The doctest referenced `icn_entity` which isn't a dependency of `icn-membership-app`. The type is defined in this crate and re-exported from the root, so the self-referencing path is correct.

## Test plan

- [x] `cargo test -p icn-membership-app --doc` passes (was FAILED, now ok)

🤖 Generated with [Claude Code](https://claude.com/claude-code)