### PR TITLE
feat(ledger): persistent journal append with governance provenance

### DIFF
--- a/icn/crates/icn-core/src/services/state_hash.rs
+++ b/icn/crates/icn-core/src/services/state_hash.rs
@@ -445,18 +445,21 @@ mod tests {
                 success: true,
                 message: "OK".into(),
                 state_change_hash: Some("hash_t".into()),
+                ledger_entry_id: None,
             },
             EffectResult {
                 effect_id: "membership_0".into(),
                 success: true,
                 message: "OK".into(),
                 state_change_hash: Some("hash_m".into()),
+                ledger_entry_id: None,
             },
             EffectResult {
                 effect_id: "no_hash".into(),
                 success: true,
                 message: "OK".into(),
                 state_change_hash: None,
+                ledger_entry_id: None,
             },
         ];
 
@@ -473,6 +476,7 @@ mod tests {
             success: true,
             message: "OK".into(),
             state_change_hash: Some("same_hash".into()),
+            ledger_entry_id: None,
         }];
 
         let results_b = vec![EffectResult {
@@ -480,6 +484,7 @@ mod tests {
             success: true,
             message: "Different message is OK".into(),
             state_change_hash: Some("same_hash".into()),
+            ledger_entry_id: None,
         }];
 
         assert!(verify_effect_results_match(&results_a, &results_b));
@@ -492,6 +497,7 @@ mod tests {
             success: true,
             message: "OK".into(),
             state_change_hash: Some("hash_a".into()),
+            ledger_entry_id: None,
         }];
 
         let results_b = vec![EffectResult {
@@ -499,6 +505,7 @@ mod tests {
             success: true,
             message: "OK".into(),
             state_change_hash: Some("hash_b".into()),
+            ledger_entry_id: None,
         }];
 
         let comparison = compare_effect_results(&results_a, &results_b);

--- a/icn/crates/icn-core/src/supervisor/decision_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/decision_executor.rs
@@ -337,7 +337,7 @@ impl DecisionExecutor {
         if all_success {
             let ledger_entry_ids: Vec<String> = results
                 .iter()
-                .filter_map(|r| extract_ledger_entry_id(&r.message))
+                .filter_map(|r| r.ledger_entry_id.clone())
                 .collect();
             let state_change_hashes: Vec<String> = results
                 .iter()
@@ -516,20 +516,6 @@ fn extract_decision_hash(effects: &[KernelEffect]) -> Option<String> {
     None
 }
 
-fn extract_ledger_entry_id(message: &str) -> Option<String> {
-    const MARKER: &str = "-> ledger entry ";
-
-    message.split(';').map(str::trim).find_map(|segment| {
-        let (_, hash) = segment.rsplit_once(MARKER)?;
-        let trimmed = hash.trim();
-        if trimmed.is_empty() {
-            None
-        } else {
-            Some(trimmed.to_string())
-        }
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -706,17 +692,6 @@ mod tests {
         let decision_executor = Arc::new(DecisionExecutor::new(dispatcher, exec_store.clone()));
 
         (decision_executor, exec_store)
-    }
-
-    #[test]
-    fn test_extract_ledger_entry_id_from_message() {
-        let message = "Spend 100 HOURS from treasury did:icn:treasury -> ledger entry abc123";
-        assert_eq!(extract_ledger_entry_id(message).as_deref(), Some("abc123"));
-    }
-
-    #[test]
-    fn test_extract_ledger_entry_id_missing_marker() {
-        assert!(extract_ledger_entry_id("No ledger append").is_none());
     }
 
     #[tokio::test]

--- a/icn/crates/icn-core/src/supervisor/decision_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/decision_executor.rs
@@ -335,13 +335,15 @@ impl DecisionExecutor {
         // 5. Check results and record outcome
         let all_success = results.iter().all(|r| r.success);
         if all_success {
+            let ledger_entry_ids: Vec<String> = results
+                .iter()
+                .filter_map(|r| extract_ledger_entry_id(&r.message))
+                .collect();
             let state_change_hashes: Vec<String> = results
                 .iter()
                 .filter_map(|r| r.state_change_hash.clone())
                 .collect();
-            // Note: ledger_entry_ids will be populated when treasury executor
-            // is wired to return entry IDs in EffectResult.
-            record.mark_confirmed(vec![], state_change_hashes);
+            record.mark_confirmed(ledger_entry_ids, state_change_hashes);
             self.store.put(&record)?;
 
             info!(
@@ -512,6 +514,20 @@ fn extract_decision_hash(effects: &[KernelEffect]) -> Option<String> {
         }
     }
     None
+}
+
+fn extract_ledger_entry_id(message: &str) -> Option<String> {
+    const MARKER: &str = "-> ledger entry ";
+
+    message.split(';').map(str::trim).find_map(|segment| {
+        let (_, hash) = segment.rsplit_once(MARKER)?;
+        let trimmed = hash.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
 }
 
 #[cfg(test)]
@@ -690,6 +706,17 @@ mod tests {
         let decision_executor = Arc::new(DecisionExecutor::new(dispatcher, exec_store.clone()));
 
         (decision_executor, exec_store)
+    }
+
+    #[test]
+    fn test_extract_ledger_entry_id_from_message() {
+        let message = "Spend 100 HOURS from treasury did:icn:treasury -> ledger entry abc123";
+        assert_eq!(extract_ledger_entry_id(message).as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn test_extract_ledger_entry_id_missing_marker() {
+        assert!(extract_ledger_entry_id("No ledger append").is_none());
     }
 
     #[tokio::test]

--- a/icn/crates/icn-core/src/supervisor/effect_dispatcher.rs
+++ b/icn/crates/icn-core/src/supervisor/effect_dispatcher.rs
@@ -115,6 +115,7 @@ impl EffectDispatcher {
                         success: false,
                         message: format!("Execution error: {}", e),
                         state_change_hash: None,
+                        ledger_entry_id: None,
                     });
                 }
             }

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -30,6 +30,8 @@ use icn_kernel_api::{ControlService, ForceCloseProposalRequest, VetoProposalRequ
 use sha2::{Digest, Sha256};
 use tracing::{info, warn};
 
+const LEDGER_ENTRY_MARKER: &str = "-> ledger entry ";
+
 /// Adapter that implements [`GovernanceExecutor`] by delegating to kernel services.
 ///
 /// This is the bridge between the governance app (domain logic) and the kernel's
@@ -144,6 +146,7 @@ impl KernelGovernanceExecutor {
                                     budget_id
                                 ),
                                 state_change_hash: None,
+                                ledger_entry_id: None,
                             });
                         }
                     }
@@ -201,6 +204,7 @@ impl KernelGovernanceExecutor {
                             success: false,
                             message: "Budget store not configured".to_string(),
                             state_change_hash: None,
+                            ledger_entry_id: None,
                         });
                     }
                 };
@@ -213,6 +217,7 @@ impl KernelGovernanceExecutor {
                             success: false,
                             message: format!("Budget {} not found", budget_id),
                             state_change_hash: None,
+                            ledger_entry_id: None,
                         });
                     }
                 };
@@ -234,6 +239,7 @@ impl KernelGovernanceExecutor {
                                 budget_id
                             ),
                             state_change_hash: None,
+                            ledger_entry_id: None,
                         });
                     }
                     Err(e) => {
@@ -247,6 +253,7 @@ impl KernelGovernanceExecutor {
                             success: false,
                             message: e.to_string(),
                             state_change_hash: None,
+                            ledger_entry_id: None,
                         });
                     }
                 }
@@ -344,6 +351,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                             success: false,
                             message: "Escrow store not configured".to_string(),
                             state_change_hash: None,
+                            ledger_entry_id: None,
                         });
                     }
                 };
@@ -361,6 +369,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                             success: false,
                             message: format!("Escrow not found: {}", escrow_id),
                             state_change_hash: None,
+                            ledger_entry_id: None,
                         });
                     }
                 };
@@ -401,6 +410,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                                 escrow_id
                             ),
                             state_change_hash: None,
+                            ledger_entry_id: None,
                         });
                     }
                     Err(EscrowReleaseError::AlreadyReleasedByOther {
@@ -420,6 +430,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                                 escrow_id, existing_decision_hash
                             ),
                             state_change_hash: None,
+                            ledger_entry_id: None,
                         });
                     }
                     Err(EscrowReleaseError::Cancelled) => {
@@ -432,6 +443,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                             success: false,
                             message: format!("Escrow {} was cancelled", escrow_id),
                             state_change_hash: None,
+                            ledger_entry_id: None,
                         });
                     }
                 }
@@ -523,6 +535,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                             protocol_effect
                         ),
                         state_change_hash: None,
+                        ledger_entry_id: None,
                     })
                 }
             }
@@ -543,6 +556,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                 success: true,
                 message: format!("NoOp: {}", reason),
                 state_change_hash: None,
+                ledger_entry_id: None,
             }),
             KernelEffect::Control(control_effect) => {
                 // Execute control effect (veto, force close)
@@ -643,11 +657,12 @@ impl TreasuryExecutor for KernelTreasuryExecutor {
                         return Ok(ExecutionOutcome::Success {
                             receipt_id: receipt_id.clone(),
                             effects: vec![format!(
-                                "{:?} {} {} from treasury {} -> ledger entry {}",
+                                "{:?} {} {} from treasury {} {}{}",
                                 operation.operation_type,
                                 operation.amount,
                                 operation.currency,
                                 operation.treasury_id,
+                                LEDGER_ENTRY_MARKER,
                                 result.entry_hash
                             )],
                         });
@@ -1134,12 +1149,22 @@ fn execution_outcome_to_effect_result(outcome: ExecutionOutcome, effect_id: &str
                     e[pos + 14..].to_string() // Skip "-> state_hash="
                 })
             });
+            let ledger_entry_id = effects.iter().find_map(|e| {
+                let (_, entry_id) = e.rsplit_once(LEDGER_ENTRY_MARKER)?;
+                let entry_id = entry_id.trim();
+                if entry_id.is_empty() {
+                    None
+                } else {
+                    Some(entry_id.to_string())
+                }
+            });
 
             EffectResult {
                 effect_id: effect_id.to_string(),
                 success: true,
                 message: effects.join("; "),
                 state_change_hash,
+                ledger_entry_id,
             }
         }
         ExecutionOutcome::Failed { reason, .. } => EffectResult {
@@ -1147,12 +1172,14 @@ fn execution_outcome_to_effect_result(outcome: ExecutionOutcome, effect_id: &str
             success: false,
             message: reason,
             state_change_hash: None,
+            ledger_entry_id: None,
         },
         ExecutionOutcome::Deferred { reason, .. } => EffectResult {
             effect_id: effect_id.to_string(),
             success: true,
             message: format!("Deferred: {}", reason),
             state_change_hash: None,
+            ledger_entry_id: None,
         },
     }
 }
@@ -1877,6 +1904,20 @@ mod tests {
         let result = executor.get_treasury_balance("treasury-1", "HOURS").await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 0); // Placeholder returns 0
+    }
+
+    #[test]
+    fn test_execution_outcome_maps_ledger_entry_id() {
+        let outcome = ExecutionOutcome::Success {
+            receipt_id: DecisionReceiptId::new("receipt-1"),
+            effects: vec![format!(
+                "Spend 10 HOURS from treasury did:icn:t1 {}abc123",
+                LEDGER_ENTRY_MARKER
+            )],
+        };
+
+        let result = execution_outcome_to_effect_result(outcome, "receipt-1");
+        assert_eq!(result.ledger_entry_id.as_deref(), Some("abc123"));
     }
 
     #[test]

--- a/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
+++ b/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
@@ -328,10 +328,12 @@ fn create_budget_effect(decision_hash: &str, budget_id: &str, limit: i64) -> Vec
     })]
 }
 
-fn content_hash_from_hex(hash_hex: &str) -> ContentHash {
-    let bytes = hex::decode(hash_hex).unwrap();
-    let bytes: [u8; 32] = bytes.try_into().unwrap();
-    ContentHash::from_bytes(bytes)
+fn content_hash_from_hex(hash_hex: &str) -> Result<ContentHash> {
+    let bytes = hex::decode(hash_hex).map_err(|e| anyhow::anyhow!("invalid hex: {e}"))?;
+    let bytes: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("expected 32-byte content hash"))?;
+    Ok(ContentHash::from_bytes(bytes))
 }
 
 // ---------------------------------------------------------------------------
@@ -688,6 +690,8 @@ async fn test_treasury_entry_persisted_with_provenance() {
         let entry_hash = record.ledger_entry_ids[0].clone();
 
         let hash = content_hash_from_hex(&entry_hash);
+        assert!(hash.is_ok(), "ledger entry id must parse as ContentHash");
+        let hash = hash.unwrap();
         let ledger_guard = ledger.read().await;
         let entry = ledger_guard.get_entry(&hash).unwrap().unwrap();
         assert_eq!(
@@ -702,7 +706,7 @@ async fn test_treasury_entry_persisted_with_provenance() {
 
     let reopened_ledger_store = Arc::new(SledStore::open(&ledger_store_path).unwrap());
     let reopened_ledger = Ledger::new(reopened_ledger_store).unwrap();
-    let reopened_hash = content_hash_from_hex(&entry_hash);
+    let reopened_hash = content_hash_from_hex(&entry_hash).unwrap();
     let reopened_entry = reopened_ledger.get_entry(&reopened_hash).unwrap().unwrap();
     assert_eq!(
         reopened_entry.decision_receipt_id.as_deref(),

--- a/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
+++ b/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
@@ -11,9 +11,16 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use anyhow::Result;
+use icn_core::services::LedgerServiceImpl;
+use icn_core::supervisor::execution_store::SledExecutionStore;
 use icn_kernel_api::budget::{BudgetRecord, BudgetStore};
 use icn_kernel_api::effects::{KernelEffect, TreasuryEffect};
 use icn_kernel_api::execution::{ExecutionRecord, ExecutionStatus, ExecutionStore};
+use icn_kernel_api::AllowAllOracle;
+use icn_ledger::types::ContentHash;
+use icn_ledger::Ledger;
+use icn_store::SledStore;
+use tempfile::TempDir;
 
 // ---------------------------------------------------------------------------
 // In-memory stores for testing
@@ -321,6 +328,12 @@ fn create_budget_effect(decision_hash: &str, budget_id: &str, limit: i64) -> Vec
     })]
 }
 
+fn content_hash_from_hex(hash_hex: &str) -> ContentHash {
+    let bytes = hex::decode(hash_hex).unwrap();
+    let bytes: [u8; 32] = bytes.try_into().unwrap();
+    ContentHash::from_bytes(bytes)
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -608,4 +621,97 @@ async fn test_recovery_does_not_re_execute_confirmed() {
     let after = exec_store.get("hash-confirmed-already").unwrap().unwrap();
     assert_eq!(after.status, ExecutionStatus::Confirmed);
     assert_eq!(after.ledger_entry_ids, vec!["entry-1"]);
+}
+
+/// Test 10: Treasury execution appends a real ledger entry with governance provenance,
+/// and the entry + execution record survive restart.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_treasury_entry_persisted_with_provenance() {
+    use icn_core::supervisor::decision_executor::DecisionExecutor;
+    use icn_core::supervisor::effect_dispatcher::EffectDispatcher;
+    use icn_core::supervisor::governance_executor::KernelGovernanceExecutor;
+
+    let tmp = TempDir::new().unwrap();
+    let ledger_store_path = tmp.path().join("ledger");
+    let exec_store_path = tmp.path().join("execution");
+    std::fs::create_dir_all(&ledger_store_path).unwrap();
+    std::fs::create_dir_all(&exec_store_path).unwrap();
+
+    let decision_hash = "hash-ledger-provenance-1";
+    let decision_receipt_id = "receipt-ledger-provenance-1";
+    let treasury_did = "did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9";
+
+    let entry_hash = {
+        let ledger_store = Arc::new(SledStore::open(&ledger_store_path).unwrap());
+        let ledger = Ledger::new(ledger_store).unwrap();
+        let ledger = Arc::new(tokio::sync::RwLock::new(ledger));
+
+        let ledger_service = Arc::new(LedgerServiceImpl::new(
+            ledger.clone(),
+            Arc::new(AllowAllOracle::wildcard()),
+            treasury_did.parse().unwrap(),
+        ));
+        let kernel_executor = KernelGovernanceExecutor::new(Arc::new(StubParamStore))
+            .with_ledger_service(ledger_service);
+
+        let dispatcher = Arc::new(EffectDispatcher::new(Arc::new(kernel_executor)));
+        let exec_backend = Arc::new(SledStore::open(&exec_store_path).unwrap());
+        let exec_store = Arc::new(SledExecutionStore::new(exec_backend));
+        let executor = DecisionExecutor::new(dispatcher, exec_store.clone());
+
+        let effects = vec![KernelEffect::Treasury(TreasuryEffect::Spend {
+            treasury_did: treasury_did.to_string(),
+            recipient_did: treasury_did.to_string(),
+            amount: 100,
+            currency: "HOURS".to_string(),
+            memo: "Provenance persistence test".to_string(),
+            budget_id: None,
+            decision_receipt_id: decision_receipt_id.to_string(),
+            decision_hash: decision_hash.to_string(),
+        })];
+
+        let results = executor
+            .execute(
+                effects,
+                decision_receipt_id,
+                decision_hash,
+                "proposal-ledger-provenance-1",
+            )
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].success);
+
+        let record = exec_store.get(decision_hash).unwrap().unwrap();
+        assert_eq!(record.status, ExecutionStatus::Confirmed);
+        assert_eq!(record.ledger_entry_ids.len(), 1);
+        let entry_hash = record.ledger_entry_ids[0].clone();
+
+        let hash = content_hash_from_hex(&entry_hash);
+        let ledger_guard = ledger.read().await;
+        let entry = ledger_guard.get_entry(&hash).unwrap().unwrap();
+        assert_eq!(
+            entry.decision_receipt_id.as_deref(),
+            Some(decision_receipt_id)
+        );
+        assert_eq!(entry.decision_hash.as_deref(), Some(decision_hash));
+        drop(ledger_guard);
+
+        entry_hash
+    };
+
+    let reopened_ledger_store = Arc::new(SledStore::open(&ledger_store_path).unwrap());
+    let reopened_ledger = Ledger::new(reopened_ledger_store).unwrap();
+    let reopened_hash = content_hash_from_hex(&entry_hash);
+    let reopened_entry = reopened_ledger.get_entry(&reopened_hash).unwrap().unwrap();
+    assert_eq!(
+        reopened_entry.decision_receipt_id.as_deref(),
+        Some(decision_receipt_id)
+    );
+    assert_eq!(reopened_entry.decision_hash.as_deref(), Some(decision_hash));
+
+    let reopened_exec_backend = Arc::new(SledStore::open(&exec_store_path).unwrap());
+    let reopened_exec_store = SledExecutionStore::new(reopened_exec_backend);
+    let reopened_record = reopened_exec_store.get(decision_hash).unwrap().unwrap();
+    assert_eq!(reopened_record.ledger_entry_ids, vec![entry_hash]);
 }

--- a/icn/crates/icn-core/tests/federated_two_node_pilot.rs
+++ b/icn/crates/icn-core/tests/federated_two_node_pilot.rs
@@ -715,6 +715,7 @@ async fn test_two_node_effect_batch_determinism() -> Result<()> {
                             success: true,
                             message: effects.join("; "),
                             state_change_hash: extract_state_hash_from_effects(&effects),
+                            ledger_entry_id: None,
                         }
                     }
                     _ => panic!("Batch effect failed on Node A"),
@@ -725,6 +726,7 @@ async fn test_two_node_effect_batch_determinism() -> Result<()> {
                 success: true,
                 message: reason.clone(),
                 state_change_hash: None,
+                ledger_entry_id: None,
             },
             _ => panic!("Unexpected effect type in batch"),
         };
@@ -760,6 +762,7 @@ async fn test_two_node_effect_batch_determinism() -> Result<()> {
                             success: true,
                             message: effects.join("; "),
                             state_change_hash: extract_state_hash_from_effects(&effects),
+                            ledger_entry_id: None,
                         }
                     }
                     _ => panic!("Batch effect failed on Node B"),
@@ -770,6 +773,7 @@ async fn test_two_node_effect_batch_determinism() -> Result<()> {
                 success: true,
                 message: reason.clone(),
                 state_change_hash: None,
+                ledger_entry_id: None,
             },
             _ => panic!("Unexpected effect type in batch"),
         };

--- a/icn/crates/icn-kernel-api/src/effects.rs
+++ b/icn/crates/icn-kernel-api/src/effects.rs
@@ -349,6 +349,11 @@ pub struct EffectResult {
     pub message: String,
     /// Optional hash of state change (for audit)
     pub state_change_hash: Option<String>,
+    /// Optional ledger entry id produced by this effect.
+    ///
+    /// Present for treasury effects that append a journal entry.
+    #[serde(default)]
+    pub ledger_entry_id: Option<String>,
 }
 
 // =============================================================================
@@ -560,12 +565,14 @@ mod tests {
                 success: true,
                 message: "Budget created successfully".into(),
                 state_change_hash: Some("statehash123".into()),
+                ledger_entry_id: Some("entry-123".into()),
             },
             EffectResult {
                 effect_id: "eff-2".into(),
                 success: false,
                 message: "Insufficient funds".into(),
                 state_change_hash: None,
+                ledger_entry_id: None,
             },
         ];
 

--- a/icn/crates/icn-kernel-api/src/governance.rs
+++ b/icn/crates/icn-kernel-api/src/governance.rs
@@ -248,6 +248,7 @@ impl EffectExecutor for DefaultEffectExecutor {
                         success: true,
                         message: "Protocol effect applied".to_string(),
                         state_change_hash: None,
+                        ledger_entry_id: None,
                     })
                 }
             }
@@ -256,6 +257,7 @@ impl EffectExecutor for DefaultEffectExecutor {
                 success: true,
                 message: format!("NoOp: {}", reason),
                 state_change_hash: None,
+                ledger_entry_id: None,
             }),
             // For other effect types, return success placeholder
             _ => Ok(EffectResult {
@@ -263,6 +265,7 @@ impl EffectExecutor for DefaultEffectExecutor {
                 success: true,
                 message: "Effect type not yet implemented".to_string(),
                 state_change_hash: None,
+                ledger_entry_id: None,
             }),
         }
     }
@@ -404,18 +407,21 @@ fn execution_outcome_to_effect_result(outcome: ExecutionOutcome, effect_id: &str
             success: true,
             message: effects.join("; "),
             state_change_hash: None,
+            ledger_entry_id: None,
         },
         ExecutionOutcome::Failed { reason, .. } => EffectResult {
             effect_id: effect_id.to_string(),
             success: false,
             message: reason,
             state_change_hash: None,
+            ledger_entry_id: None,
         },
         ExecutionOutcome::Deferred { reason, .. } => EffectResult {
             effect_id: effect_id.to_string(),
             success: true,
             message: format!("Deferred: {}", reason),
             state_change_hash: None,
+            ledger_entry_id: None,
         },
     }
 }


### PR DESCRIPTION
## Summary
- persist `ExecutionRecord.ledger_entry_ids` from real effect execution results via structured `EffectResult.ledger_entry_id` (DecisionExecutor no longer parses message text) (`icn/crates/icn-core/src/supervisor/decision_executor.rs`, `icn/crates/icn-kernel-api/src/effects.rs`)
- add a restart-durability integration test that executes the real path `DecisionExecutor -> EffectDispatcher -> KernelGovernanceExecutor(with_ledger_service) -> LedgerServiceImpl -> Ledger.append_entry` and verifies persisted provenance fields + persisted execution record linkage (`icn/crates/icn-core/tests/decision_executor_runtime_test.rs`)
- harden provenance boundary assertion: integration test explicitly verifies `ledger_entry_ids[0]` parses as `ContentHash` before ledger lookup (`icn/crates/icn-core/tests/decision_executor_runtime_test.rs`)
- interim bridge: treasury success output still carries a marker parsed in governance executor (`LEDGER_ENTRY_MARKER`) to populate `EffectResult.ledger_entry_id`; this remains temporary until treasury execution returns entry hash directly without marker parsing (`icn/crates/icn-core/src/supervisor/governance_executor.rs`)

## Scope Guard
- no ledger dedup/idempotency changes
- no treasury nonce wiring
- no payload->effect translation changes

## Tests
- `cd icn && RUSTC_WRAPPER= cargo check --workspace --all-targets`
- `cd icn && RUSTC_WRAPPER= cargo test -p icn-core --test decision_executor_runtime_test test_treasury_entry_persisted_with_provenance -- --exact --nocapture`
- `cd icn && RUSTC_WRAPPER= cargo test -p icn-core ledger_entry_id -- --nocapture`

## Operator Verification (icnd + icnctl)
1. Start daemon with persistent state dir:
   - `icnd --state-dir /tmp/icn-pr1-state`
2. Trigger a governance treasury effect path via normal submission/finalization flow (same path used by decision executor).
3. Restart daemon:
   - stop `icnd`
   - `icnd --state-dir /tmp/icn-pr1-state`
4. Verify ledger journal still contains the decision-linked entry and provenance metadata:
   - `icnctl ledger entries --state-dir /tmp/icn-pr1-state`
   - confirm entry includes `decision_receipt_id` and `decision_hash`
5. Verify execution record links to that entry hash:
   - `icnctl core execution get --decision-hash <decision_hash> --state-dir /tmp/icn-pr1-state`
   - confirm `ledger_entry_ids` contains the persisted entry hash
