### PR TITLE
PR-2: Thread decision_hash into governance effect translation; explicitly guard unsupported Treasury Spend

### DIFF
--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -159,11 +159,12 @@ use icn_kernel_api::effects::{
 pub fn translate_payload_to_effects(
     payload: &ProposalPayload,
     decision_receipt_id: &str,
+    decision_hash: &str,
 ) -> Vec<KernelEffect> {
     match payload {
         // Treasury proposals
         ProposalPayload::Treasury { operation } => {
-            translate_treasury_operation(operation, decision_receipt_id)
+            translate_treasury_operation(operation, decision_receipt_id, decision_hash)
         }
 
         ProposalPayload::Budget {
@@ -180,7 +181,7 @@ pub fn translate_payload_to_effects(
             validity_start: 0,
             validity_end: u64::MAX,
             decision_receipt_id: decision_receipt_id.to_string(),
-            decision_hash: "pending".to_string(), // Wired when full context available
+            decision_hash: decision_hash.to_string(),
         })],
 
         // Membership proposals
@@ -277,8 +278,11 @@ pub fn translate_payload_to_effects(
 fn translate_treasury_operation(
     operation: &icn_governance::TreasuryProposalOperation,
     decision_receipt_id: &str,
+    decision_hash: &str,
 ) -> Vec<KernelEffect> {
     use icn_governance::TreasuryProposalOperation;
+    const TREASURY_SPEND_UNSUPPORTED_REASON: &str =
+        "Treasury Spend translation unsupported: missing treasury_did and currency in payload";
 
     match operation {
         TreasuryProposalOperation::Withdraw {
@@ -296,8 +300,12 @@ fn translate_treasury_operation(
             memo: purpose.clone(),
             budget_id: None, // TODO: wire budget_id from proposal payload
             decision_receipt_id: decision_receipt_id.to_string(),
-            decision_hash: "pending".to_string(), // Wired when full context available
+            decision_hash: decision_hash.to_string(),
         })],
+
+        TreasuryProposalOperation::Spend { .. } => vec![KernelEffect::NoOp {
+            reason: TREASURY_SPEND_UNSUPPORTED_REASON.to_string(),
+        }],
 
         TreasuryProposalOperation::CreateBudget {
             treasury_did,
@@ -314,7 +322,7 @@ fn translate_treasury_operation(
             validity_start: 0,
             validity_end: period_end.unwrap_or(u64::MAX),
             decision_receipt_id: decision_receipt_id.to_string(),
-            decision_hash: "pending".to_string(), // Wired when full context available
+            decision_hash: decision_hash.to_string(),
         })],
 
         // Fallback for other treasury operations

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -82,6 +82,14 @@ pub fn create_executor(
 /// The kernel's EffectDispatcher typically wraps this.
 pub type EffectExecutionCallback = std::sync::Arc<dyn Fn(Vec<KernelEffect>, String) + Send + Sync>;
 
+fn compute_decision_hash(decision_receipt_id: &str) -> String {
+    // Temporary deterministic bridge for effect routing; replace with
+    // canonical decision artifact hash when available at this boundary.
+    blake3::hash(decision_receipt_id.as_bytes())
+        .to_hex()
+        .to_string()
+}
+
 /// Create an event subscription that routes proposals through the effect system.
 ///
 /// This subscription:
@@ -117,13 +125,17 @@ where
         {
             // Generate decision_receipt_id from proposal_id and domain
             let decision_receipt_id = format!("gov:{domain_id}:{proposal_id}:receipt");
+            let decision_hash = compute_decision_hash(&decision_receipt_id);
 
             // Deserialize payload
             match serde_json::from_value::<ProposalPayload>(payload.clone()) {
                 Ok(proposal_payload) => {
                     // Translate to effects
-                    let effects =
-                        translate_payload_to_effects(&proposal_payload, &decision_receipt_id);
+                    let effects = translate_payload_to_effects(
+                        &proposal_payload,
+                        &decision_receipt_id,
+                        &decision_hash,
+                    );
 
                     if effects.is_empty() {
                         debug!(

--- a/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
+++ b/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
@@ -13,6 +13,8 @@ use std::sync::{Arc, RwLock};
 use anyhow::Result;
 use icn_core::services::LedgerServiceImpl;
 use icn_core::supervisor::execution_store::SledExecutionStore;
+use icn_governance::{ProposalPayload, TreasuryProposalOperation};
+use icn_governance_actor::translate_payload_to_effects;
 use icn_kernel_api::budget::{BudgetRecord, BudgetStore};
 use icn_kernel_api::effects::{KernelEffect, TreasuryEffect};
 use icn_kernel_api::execution::{ExecutionRecord, ExecutionStatus, ExecutionStore};
@@ -718,4 +720,40 @@ async fn test_treasury_entry_persisted_with_provenance() {
     let reopened_exec_store = SledExecutionStore::new(reopened_exec_backend);
     let reopened_record = reopened_exec_store.get(decision_hash).unwrap().unwrap();
     assert_eq!(reopened_record.ledger_entry_ids, vec![entry_hash]);
+}
+
+/// Test 11: Treasury Spend payload is explicitly unsupported at translation
+/// boundary until payload carries treasury identity + currency.
+#[test]
+fn test_treasury_spend_payload_translation_is_explicitly_unsupported() {
+    use icn_identity::Did;
+
+    let decision_receipt_id = "gov:test-domain:test-proposal:receipt";
+    let decision_hash = "test-decision-hash";
+    let recipient: Did = "did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9"
+        .parse()
+        .unwrap();
+
+    let payload = ProposalPayload::Treasury {
+        operation: TreasuryProposalOperation::Spend {
+            amount: 100,
+            recipient,
+            memo: "PR-2 treasury spend".to_string(),
+            nonce: 0,
+        },
+    };
+
+    let effects = translate_payload_to_effects(&payload, decision_receipt_id, decision_hash);
+    assert_eq!(effects.len(), 1);
+    match &effects[0] {
+        KernelEffect::NoOp { reason } => {
+            assert!(
+                reason.contains(
+                    "Treasury Spend translation unsupported: missing treasury_did and currency in payload"
+                ),
+                "NoOp reason must explain unsupported Spend translation boundary"
+            );
+        }
+        other => panic!("expected NoOp for unsupported Spend payload, got {other:?}"),
+    }
 }


### PR DESCRIPTION
## Summary
- Thread `decision_hash` through the production proposal->effects translation boundary in governance effect subscription.
- Keep treasury translation truthful by explicitly guarding `TreasuryProposalOperation::Spend` as unsupported (emits `KernelEffect::NoOp` with reason) instead of inventing missing fields.
- Add a regression test asserting Spend is explicitly unsupported at the translator boundary.

## Why
`TreasuryProposalOperation::Spend` currently carries `{ amount, recipient, memo, nonce }` and does not include `treasury_did` or `currency`, while `TreasuryEffect::Spend` requires both. This PR avoids semantic capture by refusing to fabricate those values.

## Evidence
Commands run:

```bash
cd /home/ubuntu/projects/icn/icn && cargo fmt --all
```
Result: success

```bash
cd /home/ubuntu/projects/icn/icn && timeout 180 bash -lc 'RUSTC_WRAPPER= cargo test -p icn-core --test decision_executor_runtime_test test_treasury_entry_persisted_with_provenance -- --exact --nocapture'
```
Result:
- `test test_treasury_entry_persisted_with_provenance ... ok`
- `test result: ok. 1 passed; 0 failed`

```bash
cd /home/ubuntu/projects/icn/icn && timeout 180 bash -lc 'RUSTC_WRAPPER= cargo test -p icn-core --test decision_executor_runtime_test test_treasury_spend_payload_translation_is_explicitly_unsupported -- --exact --nocapture'
```
Result:
- `test test_treasury_spend_payload_translation_is_explicitly_unsupported ... ok`
- `test result: ok. 1 passed; 0 failed`

## Out of Scope
- PR-3: treasury nonce enforcement in ledger mutation path.
- PR-4: replay/idempotency hardening and ledger dedup indexing.
- Implementing end-to-end treasury Spend translation/execution from payload (blocked on missing `treasury_did` + `currency` in payload schema).

## Operator Verification
Runtime operator verification via `icnd + icnctl` is not applicable for this PR because behavior change is constrained to translation boundary guard + unit/integration test assertions.
