### PR TITLE
PR-3: enforce ledger idempotency for treasury append by decision receipt

### DIFF
--- a/icn/crates/icn-core/src/services/ledger_service.rs
+++ b/icn/crates/icn-core/src/services/ledger_service.rs
@@ -135,6 +135,38 @@ impl LedgerServiceImpl {
             }
         }
     }
+
+    /// Find an existing journal entry by governance decision receipt id.
+    ///
+    /// This provides ledger-bound idempotency for treasury mutations:
+    /// a receipt id may map to at most one durable entry.
+    fn find_existing_entry_for_receipt(
+        ledger: &Ledger,
+        decision_receipt_id: &str,
+    ) -> Result<Option<(String, Option<String>)>, String> {
+        let entries = ledger
+            .get_all_entries()
+            .map_err(|e| format!("Failed to query ledger entries: {e}"))?;
+
+        for mut existing_entry in entries {
+            if existing_entry.decision_receipt_id.as_deref() != Some(decision_receipt_id) {
+                continue;
+            }
+
+            let entry_hash_hex = if let Some(existing_hash) = existing_entry.id.clone() {
+                existing_hash.to_hex()
+            } else {
+                existing_entry
+                    .get_hash()
+                    .map_err(|e| format!("Failed to compute existing entry hash: {e}"))?
+                    .to_hex()
+            };
+
+            return Ok(Some((entry_hash_hex, existing_entry.decision_hash.clone())));
+        }
+
+        Ok(None)
+    }
 }
 
 impl LedgerService for LedgerServiceImpl {
@@ -225,25 +257,52 @@ impl LedgerService for LedgerServiceImpl {
             .build()
             .map_err(|e| format!("Failed to build journal entry: {e}"))?;
 
-        // Append to ledger (async operation in sync context)
-        let entry_hash = tokio::task::block_in_place(|| {
+        // Idempotent append at ledger boundary:
+        // - If receipt_id already exists, return existing entry hash.
+        // - Otherwise append exactly once.
+        let (entry_hash_hex, was_idempotent_replay) = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
                 let mut ledger = self.ledger.write().await;
-                ledger
+
+                if let Some((existing_entry_hash, existing_decision_hash)) =
+                    Self::find_existing_entry_for_receipt(&ledger, &req.decision_receipt_id)?
+                {
+                    if let Some(existing_decision_hash) = existing_decision_hash {
+                        if existing_decision_hash != req.decision_hash {
+                            return Err(format!(
+                                "Decision hash mismatch for receipt {}: existing={}, requested={}",
+                                req.decision_receipt_id, existing_decision_hash, req.decision_hash
+                            ));
+                        }
+                    }
+
+                    return Ok((existing_entry_hash, true));
+                }
+
+                let entry_hash = ledger
                     .append_entry(entry)
                     .await
-                    .map_err(|e| format!("Failed to append ledger entry: {e}"))
+                    .map_err(|e| format!("Failed to append ledger entry: {e}"))?;
+
+                Ok((entry_hash.to_hex(), false))
             })
         })?;
 
-        let entry_hash_hex = entry_hash.to_hex();
-
-        info!(
-            entry_hash = %entry_hash_hex,
-            decision_receipt_id = %req.decision_receipt_id,
-            decision_hash = %req.decision_hash,
-            "Treasury entry submitted to ledger"
-        );
+        if was_idempotent_replay {
+            info!(
+                entry_hash = %entry_hash_hex,
+                decision_receipt_id = %req.decision_receipt_id,
+                decision_hash = %req.decision_hash,
+                "Treasury entry already exists for decision receipt (idempotent replay)"
+            );
+        } else {
+            info!(
+                entry_hash = %entry_hash_hex,
+                decision_receipt_id = %req.decision_receipt_id,
+                decision_hash = %req.decision_hash,
+                "Treasury entry submitted to ledger"
+            );
+        }
 
         Ok(TreasuryEntryResult {
             entry_hash: entry_hash_hex,
@@ -256,6 +315,10 @@ impl LedgerService for LedgerServiceImpl {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use icn_identity::KeyPair;
+    use icn_kernel_api::AllowAllOracle;
+    use icn_store::SledStore;
+    use tempfile::TempDir;
 
     // Note: Full integration tests require a real ledger instance.
     // These unit tests verify the basic structure.
@@ -277,5 +340,105 @@ mod tests {
         // These must be non-empty for pilot invariant
         assert!(!req.decision_receipt_id.is_empty());
         assert!(!req.decision_hash.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_submit_treasury_entry_is_idempotent_by_receipt_id() {
+        let treasury_did = KeyPair::generate().unwrap().did().clone();
+        let recipient_did = KeyPair::generate().unwrap().did().clone();
+
+        let ledger_store = Arc::new(SledStore::temporary().unwrap());
+        let ledger = Arc::new(RwLock::new(Ledger::new(ledger_store).unwrap()));
+        let service = LedgerServiceImpl::new(
+            ledger.clone(),
+            Arc::new(AllowAllOracle::wildcard()),
+            treasury_did.clone(),
+        );
+
+        let request = TreasuryEntryRequest {
+            treasury_id: "t1".to_string(),
+            operation_type: TreasuryOperationType::Spend,
+            amount: 50,
+            currency: "HOURS".to_string(),
+            recipient: Some(recipient_did.to_string()),
+            memo: "idempotency check".to_string(),
+            decision_receipt_id: "gov:proposal:pr3:idempotency:001".to_string(),
+            decision_hash: "decision-hash-pr3-001".to_string(),
+        };
+
+        let first = service.submit_treasury_entry(request.clone()).unwrap();
+        let count_after_first = ledger.read().await.count_entries().unwrap();
+        let treasury_balance_after_first = ledger.read().await.get_balance(&treasury_did, "HOURS");
+        assert_eq!(count_after_first, 1);
+
+        let second = service.submit_treasury_entry(request).unwrap();
+        let count_after_second = ledger.read().await.count_entries().unwrap();
+        let treasury_balance_after_second = ledger.read().await.get_balance(&treasury_did, "HOURS");
+
+        assert_eq!(
+            second.entry_hash, first.entry_hash,
+            "replayed decision receipt id must return existing entry hash"
+        );
+        assert_eq!(
+            count_after_second, 1,
+            "ledger must append at most one entry per decision receipt id"
+        );
+        assert_eq!(
+            treasury_balance_after_second, treasury_balance_after_first,
+            "idempotent replay must not mutate balances"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_submit_treasury_entry_idempotency_survives_restart() {
+        let treasury_did = KeyPair::generate().unwrap().did().clone();
+        let recipient_did = KeyPair::generate().unwrap().did().clone();
+        let tmp = TempDir::new().unwrap();
+        let ledger_path = tmp.path().join("ledger");
+        std::fs::create_dir_all(&ledger_path).unwrap();
+
+        let request = TreasuryEntryRequest {
+            treasury_id: "t1".to_string(),
+            operation_type: TreasuryOperationType::Spend,
+            amount: 75,
+            currency: "HOURS".to_string(),
+            recipient: Some(recipient_did.to_string()),
+            memo: "restart idempotency".to_string(),
+            decision_receipt_id: "gov:proposal:pr3:idempotency:restart".to_string(),
+            decision_hash: "decision-hash-pr3-restart".to_string(),
+        };
+
+        let first_hash = {
+            let ledger_store = Arc::new(SledStore::open(&ledger_path).unwrap());
+            let ledger = Arc::new(RwLock::new(Ledger::new(ledger_store).unwrap()));
+            let service = LedgerServiceImpl::new(
+                ledger.clone(),
+                Arc::new(AllowAllOracle::wildcard()),
+                treasury_did.clone(),
+            );
+
+            let first = service.submit_treasury_entry(request.clone()).unwrap();
+            assert_eq!(ledger.read().await.count_entries().unwrap(), 1);
+            first.entry_hash
+        };
+
+        let second_hash = {
+            let ledger_store = Arc::new(SledStore::open(&ledger_path).unwrap());
+            let ledger = Arc::new(RwLock::new(Ledger::new(ledger_store).unwrap()));
+            let service = LedgerServiceImpl::new(
+                ledger.clone(),
+                Arc::new(AllowAllOracle::wildcard()),
+                treasury_did,
+            );
+
+            let second = service.submit_treasury_entry(request).unwrap();
+            assert_eq!(ledger.read().await.count_entries().unwrap(), 1);
+            second.entry_hash
+        };
+
+        assert_eq!(
+            second_hash, first_hash,
+            "receipt-based idempotency must survive process restart"
+        );
     }
 }

--- a/icn/crates/icn-core/src/services/ledger_service.rs
+++ b/icn/crates/icn-core/src/services/ledger_service.rs
@@ -13,6 +13,7 @@
 //! This enables the provenance chain: governance decision → treasury effect → ledger entry.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use icn_kernel_api::services::{
     LedgerEvent, LedgerService, ResourceAccessInfo, RevokeResourceAccessRequest,
@@ -21,8 +22,20 @@ use icn_kernel_api::services::{
 use icn_kernel_api::types::Did;
 use icn_kernel_api::PolicyOracle;
 use icn_ledger::{entry::JournalEntryBuilder, AccountDelta, Ledger};
+use icn_store::SledStore;
 use tokio::sync::RwLock;
 use tracing::{debug, info};
+
+const RECEIPT_INDEX_PREFIX: &str = "ledger:receipt_index:";
+const RECEIPT_INDEX_PENDING: &[u8] = b"__pending__";
+const RECEIPT_INDEX_WAIT_ATTEMPTS: usize = 25;
+const RECEIPT_INDEX_WAIT_MS: u64 = 20;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct ReceiptIndexRecord {
+    entry_hash: String,
+    decision_hash: String,
+}
 
 /// Concrete implementation of `LedgerService` backed by the mutual credit ledger.
 ///
@@ -38,6 +51,12 @@ pub struct LedgerServiceImpl {
     /// Treasury DID (used as the source account for treasury operations)
     /// Format: "did:icn:<treasury-pubkey>"
     treasury_did: icn_identity::Did,
+
+    /// Optional receipt-id index store for O(1) treasury idempotency.
+    ///
+    /// Keys: `ledger:receipt_index:{decision_receipt_id}`
+    /// Values: `ReceiptIndexRecord` JSON or pending marker during in-flight append.
+    receipt_index: Option<Arc<SledStore>>,
 }
 
 impl LedgerServiceImpl {
@@ -56,6 +75,22 @@ impl LedgerServiceImpl {
             ledger,
             oracle,
             treasury_did,
+            receipt_index: None,
+        }
+    }
+
+    /// Create a LedgerService with a receipt-id index for idempotent append claims.
+    pub fn new_with_receipt_index(
+        ledger: Arc<RwLock<Ledger>>,
+        oracle: Arc<dyn PolicyOracle>,
+        treasury_did: icn_identity::Did,
+        receipt_index: Arc<SledStore>,
+    ) -> Self {
+        Self {
+            ledger,
+            oracle,
+            treasury_did,
+            receipt_index: Some(receipt_index),
         }
     }
 
@@ -137,9 +172,6 @@ impl LedgerServiceImpl {
     }
 
     /// Find an existing journal entry by governance decision receipt id.
-    ///
-    /// This provides ledger-bound idempotency for treasury mutations:
-    /// a receipt id may map to at most one durable entry.
     fn find_existing_entry_for_receipt(
         ledger: &Ledger,
         decision_receipt_id: &str,
@@ -166,6 +198,200 @@ impl LedgerServiceImpl {
         }
 
         Ok(None)
+    }
+
+    fn receipt_index_key(decision_receipt_id: &str) -> Vec<u8> {
+        format!("{RECEIPT_INDEX_PREFIX}{decision_receipt_id}").into_bytes()
+    }
+
+    /// Try to claim a decision receipt for append, or return an existing entry hash.
+    ///
+    /// Returns:
+    /// - `Ok(None)` when claim succeeds and caller should append.
+    /// - `Ok(Some(entry_hash))` when an existing finalized entry is found.
+    fn claim_or_get_existing_entry_hash(
+        &self,
+        decision_receipt_id: &str,
+        decision_hash: &str,
+    ) -> Result<Option<String>, String> {
+        let Some(index) = self.receipt_index.as_ref() else {
+            // Compatibility fallback when no index store is configured.
+            return tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(async {
+                    let ledger = self.ledger.write().await;
+                    if let Some((entry_hash, existing_decision_hash)) =
+                        Self::find_existing_entry_for_receipt(&ledger, decision_receipt_id)?
+                    {
+                        if let Some(existing_decision_hash) = existing_decision_hash {
+                            if existing_decision_hash != decision_hash {
+                                return Err(format!(
+                                    "Decision hash mismatch for receipt {}: existing={}, requested={}",
+                                    decision_receipt_id, existing_decision_hash, decision_hash
+                                ));
+                            }
+                        }
+                        Ok(Some(entry_hash))
+                    } else {
+                        Ok(None)
+                    }
+                })
+            });
+        };
+
+        let key = Self::receipt_index_key(decision_receipt_id);
+        let db = index.db();
+
+        for _ in 0..RECEIPT_INDEX_WAIT_ATTEMPTS {
+            match db
+                .compare_and_swap(key.as_slice(), None::<&[u8]>, Some(RECEIPT_INDEX_PENDING))
+                .map_err(|e| format!("Failed to claim receipt index: {e}"))?
+            {
+                Ok(()) => return Ok(None),
+                Err(cas_err) => {
+                    let Some(current) = cas_err.current else {
+                        // Key was concurrently removed; retry claim.
+                        continue;
+                    };
+
+                    if current.as_ref() == RECEIPT_INDEX_PENDING {
+                        // Another executor is finalizing this receipt; wait briefly.
+                        std::thread::sleep(Duration::from_millis(RECEIPT_INDEX_WAIT_MS));
+                        continue;
+                    }
+
+                    let record: ReceiptIndexRecord = serde_json::from_slice(current.as_ref())
+                        .map_err(|e| {
+                            format!("Failed to decode receipt index record for replay: {e}")
+                        })?;
+                    if record.decision_hash != decision_hash {
+                        return Err(format!(
+                            "Decision hash mismatch for receipt {}: existing={}, requested={}",
+                            decision_receipt_id, record.decision_hash, decision_hash
+                        ));
+                    }
+                    return Ok(Some(record.entry_hash));
+                }
+            }
+        }
+
+        // Pending marker exceeded wait budget. Attempt bounded recovery by scanning ledger
+        // once and finalizing the index if the entry already exists.
+        self.resolve_pending_claim_from_ledger(decision_receipt_id, decision_hash)
+    }
+
+    fn resolve_pending_claim_from_ledger(
+        &self,
+        decision_receipt_id: &str,
+        decision_hash: &str,
+    ) -> Result<Option<String>, String> {
+        let maybe_existing = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async {
+                let ledger = self.ledger.write().await;
+                Self::find_existing_entry_for_receipt(&ledger, decision_receipt_id)
+            })
+        })?;
+
+        let Some((entry_hash, existing_decision_hash)) = maybe_existing else {
+            return Err(format!(
+                "Receipt {} is currently in-flight (pending index claim), retry",
+                decision_receipt_id
+            ));
+        };
+
+        if let Some(existing_decision_hash) = existing_decision_hash {
+            if existing_decision_hash != decision_hash {
+                return Err(format!(
+                    "Decision hash mismatch for receipt {}: existing={}, requested={}",
+                    decision_receipt_id, existing_decision_hash, decision_hash
+                ));
+            }
+        }
+
+        self.finalize_receipt_claim(
+            decision_receipt_id,
+            &ReceiptIndexRecord {
+                entry_hash: entry_hash.clone(),
+                decision_hash: decision_hash.to_string(),
+            },
+        )?;
+        Ok(Some(entry_hash))
+    }
+
+    fn finalize_receipt_claim(
+        &self,
+        decision_receipt_id: &str,
+        record: &ReceiptIndexRecord,
+    ) -> Result<(), String> {
+        let Some(index) = self.receipt_index.as_ref() else {
+            return Ok(());
+        };
+
+        let key = Self::receipt_index_key(decision_receipt_id);
+        let encoded = serde_json::to_vec(record)
+            .map_err(|e| format!("Failed to encode receipt index record: {e}"))?;
+
+        match index
+            .db()
+            .compare_and_swap(
+                key.as_slice(),
+                Some(RECEIPT_INDEX_PENDING),
+                Some(encoded.as_slice()),
+            )
+            .map_err(|e| format!("Failed to finalize receipt index claim: {e}"))?
+        {
+            Ok(()) => Ok(()),
+            Err(cas_err) => {
+                if let Some(current) = cas_err.current {
+                    if current.as_ref() == encoded.as_slice() {
+                        return Ok(());
+                    }
+
+                    if current.as_ref() == RECEIPT_INDEX_PENDING {
+                        // Fall back to direct set if pending marker still present.
+                        index
+                            .db()
+                            .insert(key.as_slice(), encoded.as_slice())
+                            .map_err(|e| {
+                                format!("Failed to persist finalized receipt index: {e}")
+                            })?;
+                        return Ok(());
+                    }
+
+                    let existing: ReceiptIndexRecord = serde_json::from_slice(current.as_ref())
+                        .map_err(|e| {
+                            format!("Failed to decode existing finalized receipt index record: {e}")
+                        })?;
+                    if existing.entry_hash == record.entry_hash
+                        && existing.decision_hash == record.decision_hash
+                    {
+                        Ok(())
+                    } else {
+                        Err(format!(
+                            "Receipt index conflict for {}: existing hash {}, new hash {}",
+                            decision_receipt_id, existing.entry_hash, record.entry_hash
+                        ))
+                    }
+                } else {
+                    index
+                        .db()
+                        .insert(key.as_slice(), encoded.as_slice())
+                        .map_err(|e| format!("Failed to restore missing receipt index key: {e}"))?;
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn clear_pending_receipt_claim(&self, decision_receipt_id: &str) {
+        let Some(index) = self.receipt_index.as_ref() else {
+            return;
+        };
+
+        let key = Self::receipt_index_key(decision_receipt_id);
+        let _ =
+            index
+                .db()
+                .compare_and_swap(key.as_slice(), Some(RECEIPT_INDEX_PENDING), None::<&[u8]>);
     }
 }
 
@@ -238,6 +464,23 @@ impl LedgerService for LedgerServiceImpl {
             "Submitting treasury entry to ledger"
         );
 
+        // Claim receipt idempotency key (or return existing entry hash on replay).
+        if let Some(existing_entry_hash) =
+            self.claim_or_get_existing_entry_hash(&req.decision_receipt_id, &req.decision_hash)?
+        {
+            info!(
+                entry_hash = %existing_entry_hash,
+                decision_receipt_id = %req.decision_receipt_id,
+                decision_hash = %req.decision_hash,
+                "Treasury entry already exists for decision receipt (idempotent replay)"
+            );
+            return Ok(TreasuryEntryResult {
+                entry_hash: existing_entry_hash,
+                decision_receipt_id: req.decision_receipt_id,
+                decision_hash: req.decision_hash,
+            });
+        }
+
         // Build account deltas for double-entry bookkeeping
         let deltas = self.build_account_deltas(&req)?;
 
@@ -257,52 +500,40 @@ impl LedgerService for LedgerServiceImpl {
             .build()
             .map_err(|e| format!("Failed to build journal entry: {e}"))?;
 
-        // Idempotent append at ledger boundary:
-        // - If receipt_id already exists, return existing entry hash.
-        // - Otherwise append exactly once.
-        let (entry_hash_hex, was_idempotent_replay) = tokio::task::block_in_place(|| {
+        // Append to ledger (async operation in sync context)
+        let append_result = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
                 let mut ledger = self.ledger.write().await;
-
-                if let Some((existing_entry_hash, existing_decision_hash)) =
-                    Self::find_existing_entry_for_receipt(&ledger, &req.decision_receipt_id)?
-                {
-                    if let Some(existing_decision_hash) = existing_decision_hash {
-                        if existing_decision_hash != req.decision_hash {
-                            return Err(format!(
-                                "Decision hash mismatch for receipt {}: existing={}, requested={}",
-                                req.decision_receipt_id, existing_decision_hash, req.decision_hash
-                            ));
-                        }
-                    }
-
-                    return Ok((existing_entry_hash, true));
-                }
-
-                let entry_hash = ledger
+                ledger
                     .append_entry(entry)
                     .await
-                    .map_err(|e| format!("Failed to append ledger entry: {e}"))?;
-
-                Ok((entry_hash.to_hex(), false))
+                    .map_err(|e| format!("Failed to append ledger entry: {e}"))
             })
-        })?;
+        });
 
-        if was_idempotent_replay {
-            info!(
-                entry_hash = %entry_hash_hex,
-                decision_receipt_id = %req.decision_receipt_id,
-                decision_hash = %req.decision_hash,
-                "Treasury entry already exists for decision receipt (idempotent replay)"
-            );
-        } else {
-            info!(
-                entry_hash = %entry_hash_hex,
-                decision_receipt_id = %req.decision_receipt_id,
-                decision_hash = %req.decision_hash,
-                "Treasury entry submitted to ledger"
-            );
-        }
+        let entry_hash = match append_result {
+            Ok(hash) => hash,
+            Err(e) => {
+                self.clear_pending_receipt_claim(&req.decision_receipt_id);
+                return Err(e);
+            }
+        };
+        let entry_hash_hex = entry_hash.to_hex();
+
+        self.finalize_receipt_claim(
+            &req.decision_receipt_id,
+            &ReceiptIndexRecord {
+                entry_hash: entry_hash_hex.clone(),
+                decision_hash: req.decision_hash.clone(),
+            },
+        )?;
+
+        info!(
+            entry_hash = %entry_hash_hex,
+            decision_receipt_id = %req.decision_receipt_id,
+            decision_hash = %req.decision_hash,
+            "Treasury entry submitted to ledger"
+        );
 
         Ok(TreasuryEntryResult {
             entry_hash: entry_hash_hex,
@@ -348,11 +579,13 @@ mod tests {
         let recipient_did = KeyPair::generate().unwrap().did().clone();
 
         let ledger_store = Arc::new(SledStore::temporary().unwrap());
+        let receipt_index = Arc::new(SledStore::temporary().unwrap());
         let ledger = Arc::new(RwLock::new(Ledger::new(ledger_store).unwrap()));
-        let service = LedgerServiceImpl::new(
+        let service = LedgerServiceImpl::new_with_receipt_index(
             ledger.clone(),
             Arc::new(AllowAllOracle::wildcard()),
             treasury_did.clone(),
+            receipt_index,
         );
 
         let request = TreasuryEntryRequest {
@@ -395,7 +628,9 @@ mod tests {
         let recipient_did = KeyPair::generate().unwrap().did().clone();
         let tmp = TempDir::new().unwrap();
         let ledger_path = tmp.path().join("ledger");
+        let receipt_index_path = tmp.path().join("receipt-index");
         std::fs::create_dir_all(&ledger_path).unwrap();
+        std::fs::create_dir_all(&receipt_index_path).unwrap();
 
         let request = TreasuryEntryRequest {
             treasury_id: "t1".to_string(),
@@ -410,11 +645,13 @@ mod tests {
 
         let first_hash = {
             let ledger_store = Arc::new(SledStore::open(&ledger_path).unwrap());
+            let receipt_index = Arc::new(SledStore::open(&receipt_index_path).unwrap());
             let ledger = Arc::new(RwLock::new(Ledger::new(ledger_store).unwrap()));
-            let service = LedgerServiceImpl::new(
+            let service = LedgerServiceImpl::new_with_receipt_index(
                 ledger.clone(),
                 Arc::new(AllowAllOracle::wildcard()),
                 treasury_did.clone(),
+                receipt_index,
             );
 
             let first = service.submit_treasury_entry(request.clone()).unwrap();
@@ -424,11 +661,13 @@ mod tests {
 
         let second_hash = {
             let ledger_store = Arc::new(SledStore::open(&ledger_path).unwrap());
+            let receipt_index = Arc::new(SledStore::open(&receipt_index_path).unwrap());
             let ledger = Arc::new(RwLock::new(Ledger::new(ledger_store).unwrap()));
-            let service = LedgerServiceImpl::new(
+            let service = LedgerServiceImpl::new_with_receipt_index(
                 ledger.clone(),
                 Arc::new(AllowAllOracle::wildcard()),
                 treasury_did,
+                receipt_index,
             );
 
             let second = service.submit_treasury_entry(request).unwrap();
@@ -439,6 +678,54 @@ mod tests {
         assert_eq!(
             second_hash, first_hash,
             "receipt-based idempotency must survive process restart"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_submit_treasury_entry_concurrent_same_receipt_single_append() {
+        let treasury_did = KeyPair::generate().unwrap().did().clone();
+        let recipient_did = KeyPair::generate().unwrap().did().clone();
+
+        let ledger_store = Arc::new(SledStore::temporary().unwrap());
+        let receipt_index = Arc::new(SledStore::temporary().unwrap());
+        let ledger = Arc::new(RwLock::new(Ledger::new(ledger_store).unwrap()));
+        let service = Arc::new(LedgerServiceImpl::new_with_receipt_index(
+            ledger.clone(),
+            Arc::new(AllowAllOracle::wildcard()),
+            treasury_did,
+            receipt_index,
+        ));
+
+        let request = TreasuryEntryRequest {
+            treasury_id: "t1".to_string(),
+            operation_type: TreasuryOperationType::Spend,
+            amount: 25,
+            currency: "HOURS".to_string(),
+            recipient: Some(recipient_did.to_string()),
+            memo: "concurrency idempotency".to_string(),
+            decision_receipt_id: "gov:proposal:pr3:idempotency:concurrent".to_string(),
+            decision_hash: "decision-hash-pr3-concurrent".to_string(),
+        };
+
+        let req_a = request.clone();
+        let req_b = request;
+        let svc_a = service.clone();
+        let svc_b = service.clone();
+
+        let task_a = tokio::spawn(async move { svc_a.submit_treasury_entry(req_a) });
+        let task_b = tokio::spawn(async move { svc_b.submit_treasury_entry(req_b) });
+
+        let result_a = task_a.await.unwrap().unwrap();
+        let result_b = task_b.await.unwrap().unwrap();
+
+        assert_eq!(
+            result_a.entry_hash, result_b.entry_hash,
+            "concurrent same-receipt submissions must converge to one entry hash"
+        );
+        assert_eq!(
+            ledger.read().await.count_entries().unwrap(),
+            1,
+            "concurrent same-receipt submissions must append exactly one entry"
         );
     }
 }

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -599,10 +599,14 @@ async fn spawn_actors_with_identity(
         // Wire ledger service adapter
         let oracle: Arc<dyn icn_kernel_api::authz::PolicyOracle> =
             Arc::new(icn_kernel_api::authz::AllowAllOracle::wildcard());
-        let ledger_service = Arc::new(crate::services::LedgerServiceImpl::new(
+        let receipt_index_path = config.store_path().join("ledger-receipt-index");
+        let receipt_index_store: Arc<icn_store::SledStore> =
+            Arc::new(icn_store::SledStore::open(&receipt_index_path)?);
+        let ledger_service = Arc::new(crate::services::LedgerServiceImpl::new_with_receipt_index(
             ledger_handle.clone(),
             oracle,
             treasury_did.clone(),
+            receipt_index_store,
         ));
         kernel_executor = kernel_executor.with_ledger_service(ledger_service);
 


### PR DESCRIPTION
## Summary
- Enforce treasury append idempotency at the ledger boundary in `LedgerServiceImpl::submit_treasury_entry`.
- Idempotency key: `decision_receipt_id`.
- Behavior:
  - If an entry with the same `decision_receipt_id` already exists, return success with the existing `entry_hash` (no new append).
  - If an existing entry for the receipt has a different `decision_hash`, return an error.
  - Otherwise append once as before.
- Add focused tests for duplicate submit and restart durability.

## Why
This closes replay/double-apply risk at the ledger mutation boundary without changing proposal translation semantics.

## Changes
- `icn/crates/icn-core/src/services/ledger_service.rs`
  - Added `find_existing_entry_for_receipt(...)` to locate existing entry/hash by `decision_receipt_id`.
  - Wired idempotent logic into `submit_treasury_entry` under the ledger write lock.
  - Added tests:
    - `test_submit_treasury_entry_is_idempotent_by_receipt_id`
    - `test_submit_treasury_entry_idempotency_survives_restart`

## Verification
Commands run:

```bash
cd /home/ubuntu/projects/icn/icn && cargo fmt --all
cd /home/ubuntu/projects/icn/icn && cargo fmt --all --check
cd /home/ubuntu/projects/icn/icn && timeout 420 bash -lc 'RUSTC_WRAPPER= cargo test -p icn-core test_submit_treasury_entry_is_idempotent_by_receipt_id -- --nocapture'
cd /home/ubuntu/projects/icn/icn && timeout 420 bash -lc 'RUSTC_WRAPPER= cargo test -p icn-core test_submit_treasury_entry_idempotency_survives_restart -- --nocapture'
cd /home/ubuntu/projects/icn/icn && timeout 240 bash -lc 'RUSTC_WRAPPER= cargo test -p icn-core --test decision_executor_runtime_test test_treasury_entry_persisted_with_provenance -- --exact --nocapture'
cd /home/ubuntu/projects/icn/icn && timeout 420 bash -lc 'RUSTC_WRAPPER= cargo clippy -p icn-core --all-targets -- -D warnings'
```

Results:
- `test_submit_treasury_entry_is_idempotent_by_receipt_id ... ok`
- `test_submit_treasury_entry_idempotency_survives_restart ... ok`
- `test_treasury_entry_persisted_with_provenance ... ok`
- `cargo clippy -p icn-core --all-targets -- -D warnings` passed

## Out of Scope
- Treasury proposal translation changes.
- Treasury nonce enforcement.
- Cross-node lease/leader-execution coordination.
