### PR TITLE
feat(economics): enforce treasury expected_nonce at ledger boundary

### DIFF
--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -291,6 +291,7 @@ fn translate_treasury_operation(
             amount,
             currency,
             purpose,
+            nonce,
             ..
         } => vec![KernelEffect::Treasury(TreasuryEffect::Spend {
             treasury_did: treasury_did.to_string(),
@@ -299,6 +300,7 @@ fn translate_treasury_operation(
             currency: currency.clone(),
             memo: purpose.clone(),
             budget_id: None, // TODO: wire budget_id from proposal payload
+            expected_nonce: *nonce,
             decision_receipt_id: decision_receipt_id.to_string(),
             decision_hash: decision_hash.to_string(),
         })],

--- a/icn/apps/governance/src/handlers/treasury.rs
+++ b/icn/apps/governance/src/handlers/treasury.rs
@@ -282,6 +282,7 @@ impl TreasuryHandler {
                 currency: currency.clone(),
                 recipient: Some(recipient.clone()),
                 memo: disburse_params.memo.clone(),
+                expected_nonce: Some(0),
                 decision_hash: Some(decision_hash_hex),
             };
 
@@ -418,6 +419,15 @@ fn to_kernel_operation(
         .and_then(|v| v.as_str())
         .unwrap_or(&ctx.domain_id)
         .to_string();
+    let expected_nonce = match operation_type {
+        TreasuryOperationType::Spend => Some(
+            ctx.payload
+                .get("nonce")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0),
+        ),
+        _ => None,
+    };
 
     KernelTreasuryOperation {
         treasury_id,
@@ -426,6 +436,7 @@ fn to_kernel_operation(
         currency,
         recipient,
         memo,
+        expected_nonce,
         decision_hash: None, // Set by caller with actual decision hash
     }
 }

--- a/icn/crates/icn-core/src/services/ledger_service.rs
+++ b/icn/crates/icn-core/src/services/ledger_service.rs
@@ -12,7 +12,8 @@
 //!
 //! This enables the provenance chain: governance decision → treasury effect → ledger entry.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use icn_kernel_api::services::{
@@ -27,6 +28,7 @@ use tokio::sync::RwLock;
 use tracing::{debug, info};
 
 const RECEIPT_INDEX_PREFIX: &str = "ledger:receipt_index:";
+const TREASURY_NONCE_PREFIX: &str = "ledger:treasury_nonce:";
 const RECEIPT_INDEX_PENDING: &[u8] = b"__pending__";
 const RECEIPT_INDEX_WAIT_ATTEMPTS: usize = 25;
 const RECEIPT_INDEX_WAIT_MS: u64 = 20;
@@ -57,6 +59,9 @@ pub struct LedgerServiceImpl {
     /// Keys: `ledger:receipt_index:{decision_receipt_id}`
     /// Values: `ReceiptIndexRecord` JSON or pending marker during in-flight append.
     receipt_index: Option<Arc<SledStore>>,
+
+    /// Fallback in-memory nonce state when no index store is configured.
+    treasury_nonce_cache: Mutex<HashMap<String, u64>>,
 }
 
 impl LedgerServiceImpl {
@@ -76,6 +81,7 @@ impl LedgerServiceImpl {
             oracle,
             treasury_did,
             receipt_index: None,
+            treasury_nonce_cache: Mutex::new(HashMap::new()),
         }
     }
 
@@ -91,6 +97,7 @@ impl LedgerServiceImpl {
             oracle,
             treasury_did,
             receipt_index: Some(receipt_index),
+            treasury_nonce_cache: Mutex::new(HashMap::new()),
         }
     }
 
@@ -202,6 +209,99 @@ impl LedgerServiceImpl {
 
     fn receipt_index_key(decision_receipt_id: &str) -> Vec<u8> {
         format!("{RECEIPT_INDEX_PREFIX}{decision_receipt_id}").into_bytes()
+    }
+
+    fn treasury_nonce_key(treasury_id: &str) -> Vec<u8> {
+        format!("{TREASURY_NONCE_PREFIX}{treasury_id}").into_bytes()
+    }
+
+    fn current_treasury_nonce(&self, treasury_id: &str) -> Result<u64, String> {
+        if let Some(index) = self.receipt_index.as_ref() {
+            let key = Self::treasury_nonce_key(treasury_id);
+            let raw = index
+                .db()
+                .get(key.as_slice())
+                .map_err(|e| format!("Failed to read treasury nonce from index: {e}"))?;
+            return match raw {
+                Some(bytes) => {
+                    if bytes.len() != 8 {
+                        Err(format!(
+                            "Corrupt treasury nonce for {}: expected 8 bytes, got {}",
+                            treasury_id,
+                            bytes.len()
+                        ))
+                    } else {
+                        let mut arr = [0u8; 8];
+                        arr.copy_from_slice(bytes.as_ref());
+                        Ok(u64::from_le_bytes(arr))
+                    }
+                }
+                None => Ok(0),
+            };
+        }
+
+        let cache = self
+            .treasury_nonce_cache
+            .lock()
+            .map_err(|_| "Treasury nonce cache lock poisoned".to_string())?;
+        Ok(*cache.get(treasury_id).unwrap_or(&0))
+    }
+
+    fn set_treasury_nonce(&self, treasury_id: &str, nonce: u64) -> Result<(), String> {
+        if let Some(index) = self.receipt_index.as_ref() {
+            let key = Self::treasury_nonce_key(treasury_id);
+            index
+                .db()
+                .insert(key.as_slice(), nonce.to_le_bytes().as_slice())
+                .map_err(|e| format!("Failed to persist treasury nonce: {e}"))?;
+            return Ok(());
+        }
+
+        let mut cache = self
+            .treasury_nonce_cache
+            .lock()
+            .map_err(|_| "Treasury nonce cache lock poisoned".to_string())?;
+        cache.insert(treasury_id.to_string(), nonce);
+        Ok(())
+    }
+
+    fn check_spend_nonce(&self, req: &TreasuryEntryRequest) -> Result<(), String> {
+        if req.operation_type != TreasuryOperationType::Spend {
+            return Ok(());
+        }
+        let expected_nonce = req.expected_nonce.ok_or_else(|| {
+            format!(
+                "Missing expected_nonce for treasury spend: receipt={}",
+                req.decision_receipt_id
+            )
+        })?;
+        let stored_nonce = self.current_treasury_nonce(&req.treasury_id)?;
+        if stored_nonce != expected_nonce {
+            return Err(format!(
+                "Treasury nonce mismatch for {}: expected {}, stored {}",
+                req.treasury_id, expected_nonce, stored_nonce
+            ));
+        }
+        Ok(())
+    }
+
+    fn advance_spend_nonce(&self, req: &TreasuryEntryRequest) -> Result<(), String> {
+        if req.operation_type != TreasuryOperationType::Spend {
+            return Ok(());
+        }
+        let expected_nonce = req.expected_nonce.ok_or_else(|| {
+            format!(
+                "Missing expected_nonce for treasury spend: receipt={}",
+                req.decision_receipt_id
+            )
+        })?;
+        let next_nonce = expected_nonce.checked_add(1).ok_or_else(|| {
+            format!(
+                "Treasury nonce overflow for {} at {}",
+                req.treasury_id, expected_nonce
+            )
+        })?;
+        self.set_treasury_nonce(&req.treasury_id, next_nonce)
     }
 
     /// Try to claim a decision receipt for append, or return an existing entry hash.
@@ -504,10 +604,13 @@ impl LedgerService for LedgerServiceImpl {
         let append_result = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
                 let mut ledger = self.ledger.write().await;
-                ledger
+                self.check_spend_nonce(&req)?;
+                let entry_hash = ledger
                     .append_entry(entry)
                     .await
-                    .map_err(|e| format!("Failed to append ledger entry: {e}"))
+                    .map_err(|e| format!("Failed to append ledger entry: {e}"))?;
+                self.advance_spend_nonce(&req)?;
+                Ok(entry_hash)
             })
         });
 
@@ -564,6 +667,7 @@ mod tests {
             currency: "USD".to_string(),
             recipient: Some("did:icn:recipient".to_string()),
             memo: "payment".to_string(),
+            expected_nonce: Some(0),
             decision_receipt_id: "gov:proposal:2024-001:receipt:abc".to_string(),
             decision_hash: "sha256:deadbeef".to_string(),
         };
@@ -595,6 +699,7 @@ mod tests {
             currency: "HOURS".to_string(),
             recipient: Some(recipient_did.to_string()),
             memo: "idempotency check".to_string(),
+            expected_nonce: Some(0),
             decision_receipt_id: "gov:proposal:pr3:idempotency:001".to_string(),
             decision_hash: "decision-hash-pr3-001".to_string(),
         };
@@ -639,6 +744,7 @@ mod tests {
             currency: "HOURS".to_string(),
             recipient: Some(recipient_did.to_string()),
             memo: "restart idempotency".to_string(),
+            expected_nonce: Some(0),
             decision_receipt_id: "gov:proposal:pr3:idempotency:restart".to_string(),
             decision_hash: "decision-hash-pr3-restart".to_string(),
         };
@@ -703,6 +809,7 @@ mod tests {
             currency: "HOURS".to_string(),
             recipient: Some(recipient_did.to_string()),
             memo: "concurrency idempotency".to_string(),
+            expected_nonce: Some(0),
             decision_receipt_id: "gov:proposal:pr3:idempotency:concurrent".to_string(),
             decision_hash: "decision-hash-pr3-concurrent".to_string(),
         };
@@ -726,6 +833,68 @@ mod tests {
             ledger.read().await.count_entries().unwrap(),
             1,
             "concurrent same-receipt submissions must append exactly one entry"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_submit_treasury_entry_rejects_stale_expected_nonce() {
+        let treasury_did = KeyPair::generate().unwrap().did().clone();
+        let recipient_did = KeyPair::generate().unwrap().did().clone();
+
+        let ledger_store = Arc::new(SledStore::temporary().unwrap());
+        let receipt_index = Arc::new(SledStore::temporary().unwrap());
+        let ledger = Arc::new(RwLock::new(Ledger::new(ledger_store).unwrap()));
+        let service = LedgerServiceImpl::new_with_receipt_index(
+            ledger.clone(),
+            Arc::new(AllowAllOracle::wildcard()),
+            treasury_did.clone(),
+            receipt_index,
+        );
+
+        let first = TreasuryEntryRequest {
+            treasury_id: "t1".to_string(),
+            operation_type: TreasuryOperationType::Spend,
+            amount: 40,
+            currency: "HOURS".to_string(),
+            recipient: Some(recipient_did.to_string()),
+            memo: "nonce baseline".to_string(),
+            expected_nonce: Some(0),
+            decision_receipt_id: "gov:proposal:pr4:nonce:first".to_string(),
+            decision_hash: "decision-hash-pr4-nonce-first".to_string(),
+        };
+        service.submit_treasury_entry(first).unwrap();
+
+        let count_after_first = ledger.read().await.count_entries().unwrap();
+        let balance_after_first = ledger.read().await.get_balance(&treasury_did, "HOURS");
+        assert_eq!(count_after_first, 1);
+
+        // Use a different receipt id so the idempotency short-circuit does not hide nonce checks.
+        let stale = TreasuryEntryRequest {
+            treasury_id: "t1".to_string(),
+            operation_type: TreasuryOperationType::Spend,
+            amount: 10,
+            currency: "HOURS".to_string(),
+            recipient: Some(recipient_did.to_string()),
+            memo: "stale nonce replay".to_string(),
+            expected_nonce: Some(0),
+            decision_receipt_id: "gov:proposal:pr4:nonce:stale".to_string(),
+            decision_hash: "decision-hash-pr4-nonce-stale".to_string(),
+        };
+        let err = service.submit_treasury_entry(stale).unwrap_err();
+        assert!(
+            err.contains("Treasury nonce mismatch"),
+            "expected nonce mismatch error, got: {err}"
+        );
+
+        let count_after_stale = ledger.read().await.count_entries().unwrap();
+        let balance_after_stale = ledger.read().await.get_balance(&treasury_did, "HOURS");
+        assert_eq!(
+            count_after_stale, count_after_first,
+            "stale nonce must not append a new ledger entry"
+        );
+        assert_eq!(
+            balance_after_stale, balance_after_first,
+            "stale nonce must not mutate balances"
         );
     }
 }

--- a/icn/crates/icn-core/src/supervisor/decision_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/decision_executor.rs
@@ -780,6 +780,7 @@ mod tests {
             currency: "HOURS".to_string(),
             memo: "Test".to_string(),
             budget_id: None,
+            expected_nonce: 0,
             decision_receipt_id: "receipt-t1".to_string(),
             decision_hash: "sha256:treasury-hash-1".to_string(),
         })];
@@ -814,6 +815,7 @@ mod tests {
                 currency: "ICN".to_string(),
                 memo: "m".to_string(),
                 budget_id: None,
+                expected_nonce: 0,
                 decision_receipt_id: "r1".to_string(),
                 decision_hash: "extracted-hash".to_string(),
             }),

--- a/icn/crates/icn-core/src/supervisor/effect_dispatcher.rs
+++ b/icn/crates/icn-core/src/supervisor/effect_dispatcher.rs
@@ -385,6 +385,7 @@ mod tests {
             currency: "ICN".to_string(),
             memo: "Test payment".to_string(),
             budget_id: None,
+            expected_nonce: 0,
             decision_receipt_id: "test-receipt-001".to_string(),
             decision_hash: "sha256:abc123".to_string(),
         })];
@@ -449,6 +450,7 @@ mod tests {
                     currency: "ICN".to_string(),
                     memo: "test".to_string(),
                     budget_id: None,
+                    expected_nonce: 0,
                     decision_receipt_id: "r1".to_string(),
                     decision_hash: "sha256:test".to_string(),
                 }
@@ -598,6 +600,7 @@ mod tests {
             currency: currency.to_string(),
             memo: "Development grant for Q1".to_string(),
             budget_id: None,
+            expected_nonce: 0,
             decision_receipt_id: decision_receipt_id.to_string(),
             decision_hash: "sha256:governance-decision-2024-001".to_string(),
         };

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -628,6 +628,7 @@ impl TreasuryExecutor for KernelTreasuryExecutor {
             currency = %operation.currency,
             recipient = ?operation.recipient,
             memo = %operation.memo,
+            expected_nonce = ?operation.expected_nonce,
             decision_hash = ?operation.decision_hash,
             "Executing treasury operation"
         );
@@ -642,6 +643,7 @@ impl TreasuryExecutor for KernelTreasuryExecutor {
                     currency: operation.currency.clone(),
                     recipient: operation.recipient.clone(),
                     memo: operation.memo.clone(),
+                    expected_nonce: operation.expected_nonce,
                     decision_receipt_id: receipt_id.to_string(),
                     decision_hash: decision_hash.clone(),
                 };
@@ -1781,6 +1783,7 @@ mod tests {
             currency: "HOURS".to_string(),
             recipient: Some("did:icn:recipient".to_string()),
             memo: "Test payment".to_string(),
+            expected_nonce: Some(0),
             decision_hash: Some("sha256:abc123".to_string()),
         };
 

--- a/icn/crates/icn-core/tests/budget_enforcement_integration.rs
+++ b/icn/crates/icn-core/tests/budget_enforcement_integration.rs
@@ -299,6 +299,7 @@ fn spend_from_budget_effect(
         currency: "HOURS".to_string(),
         memo: "Test spend".to_string(),
         budget_id: Some(budget_id.to_string()),
+        expected_nonce: 0,
         decision_receipt_id: format!("receipt:{}", decision_hash),
         decision_hash: decision_hash.to_string(),
     })
@@ -646,6 +647,7 @@ async fn test_spend_without_budget_passes_through() {
         currency: "HOURS".to_string(),
         memo: "No budget".to_string(),
         budget_id: None,
+        expected_nonce: 0,
         decision_receipt_id: "receipt:no-budget".to_string(),
         decision_hash: "hash:no-budget".to_string(),
     })];

--- a/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
+++ b/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
@@ -298,6 +298,7 @@ fn spend_effect(decision_hash: &str) -> Vec<KernelEffect> {
         currency: "HOURS".to_string(),
         memo: "Test spend".to_string(),
         budget_id: None,
+        expected_nonce: 0,
         decision_receipt_id: "receipt-1".to_string(),
         decision_hash: decision_hash.to_string(),
     })]
@@ -311,6 +312,7 @@ fn budget_spend_effect(decision_hash: &str, budget_id: &str, amount: i64) -> Vec
         currency: "HOURS".to_string(),
         memo: "Budget spend".to_string(),
         budget_id: Some(budget_id.to_string()),
+        expected_nonce: 0,
         decision_receipt_id: "receipt-budget".to_string(),
         decision_hash: decision_hash.to_string(),
     })]
@@ -670,6 +672,7 @@ async fn test_treasury_entry_persisted_with_provenance() {
             currency: "HOURS".to_string(),
             memo: "Provenance persistence test".to_string(),
             budget_id: None,
+            expected_nonce: 0,
             decision_receipt_id: decision_receipt_id.to_string(),
             decision_hash: decision_hash.to_string(),
         })];

--- a/icn/crates/icn-core/tests/effect_group_integration.rs
+++ b/icn/crates/icn-core/tests/effect_group_integration.rs
@@ -97,6 +97,7 @@ async fn test_treasury_create_budget_provenance_chain() -> Result<()> {
         currency: "HOURS".to_string(),
         recipient: Some(recipient_did.to_string()),
         memo: "2024 Operations Budget".to_string(),
+        expected_nonce: Some(0),
         decision_hash: Some(decision_hash.clone()),
     };
 

--- a/icn/crates/icn-core/tests/federated_two_node_pilot.rs
+++ b/icn/crates/icn-core/tests/federated_two_node_pilot.rs
@@ -130,6 +130,7 @@ async fn test_two_node_treasury_spend_determinism() -> Result<()> {
         currency: currency.clone(),
         memo: "Pilot equipment purchase".to_string(),
         budget_id: None,
+        expected_nonce: 0,
         decision_receipt_id: decision_receipt_id.to_string(),
         decision_hash: decision_hash.clone(),
     };
@@ -155,6 +156,7 @@ async fn test_two_node_treasury_spend_determinism() -> Result<()> {
         currency: currency.clone(),
         recipient: Some(recipient_did.to_string()),
         memo: "Pilot equipment purchase".to_string(),
+        expected_nonce: Some(0),
         decision_hash: Some(decision_hash.clone()),
     };
 
@@ -203,6 +205,7 @@ async fn test_two_node_treasury_spend_determinism() -> Result<()> {
         currency: currency.clone(),
         recipient: Some(recipient_did.to_string()),
         memo: "Pilot equipment purchase".to_string(),
+        expected_nonce: Some(0),
         decision_hash: Some(decision_hash.clone()),
     };
 

--- a/icn/crates/icn-core/tests/treasury_integration.rs
+++ b/icn/crates/icn-core/tests/treasury_integration.rs
@@ -1169,6 +1169,7 @@ async fn test_ledger_entry_carries_decision_provenance() -> Result<()> {
         currency: "HOURS".to_string(),
         recipient: Some(recipient_did.to_string()),
         memo: "Pilot test payment".to_string(),
+        expected_nonce: Some(0),
         decision_receipt_id: decision_receipt_id.clone(),
         decision_hash: decision_hash.clone(),
     };
@@ -1304,6 +1305,7 @@ async fn test_decision_to_ledger_provenance_end_to_end() -> Result<()> {
         currency: "HOURS".to_string(),
         recipient: Some(recipient_did.to_string()),
         memo: "E2E provenance test payment".to_string(),
+        expected_nonce: Some(0),
         decision_hash: Some(decision_hash.clone()),
     };
 

--- a/icn/crates/icn-governance/src/config.rs
+++ b/icn/crates/icn-governance/src/config.rs
@@ -887,6 +887,7 @@ mod tests {
                 currency: "COOP".to_string(),
                 purpose: "Equipment purchase".to_string(),
                 budget_id: None,
+                nonce: 0,
             },
         };
         let thresholds = config.thresholds_for_proposal(&payload);

--- a/icn/crates/icn-governance/src/proposal.rs
+++ b/icn/crates/icn-governance/src/proposal.rs
@@ -756,6 +756,12 @@ pub enum TreasuryProposalOperation {
         purpose: String,
         /// Optional budget to charge against
         budget_id: Option<String>,
+        /// Expected treasury nonce at execution time.
+        ///
+        /// Defaults to 0 for backwards-compatible deserialization of older
+        /// proposals that did not carry a nonce field.
+        #[serde(default)]
+        nonce: u64,
     },
 
     /// Transfer funds between budgets

--- a/icn/crates/icn-kernel-api/src/effects.rs
+++ b/icn/crates/icn-kernel-api/src/effects.rs
@@ -75,6 +75,12 @@ pub enum TreasuryEffect {
         /// before submitting the ledger entry.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         budget_id: Option<String>,
+        /// Expected treasury nonce at execution time for replay protection.
+        ///
+        /// The executor checks this against the current stored treasury nonce
+        /// before append. Mismatch rejects the spend.
+        #[serde(default)]
+        expected_nonce: u64,
         /// Links back to governance decision receipt
         decision_receipt_id: String,
         /// Canonical content hash for verification
@@ -373,6 +379,7 @@ mod tests {
             currency: "HOURS".into(),
             memo: "Tool purchase".into(),
             budget_id: None,
+            expected_nonce: 0,
             decision_receipt_id: "receipt-456".into(),
             decision_hash: "abc123".into(),
         };
@@ -397,6 +404,7 @@ mod tests {
             currency: "USD".into(),
             memo: "test".into(),
             budget_id: None,
+            expected_nonce: 0,
             decision_receipt_id: "r1".into(),
             decision_hash: "hash1".into(),
         });
@@ -431,6 +439,7 @@ mod tests {
             currency: String::new(),
             memo: String::new(),
             budget_id: None,
+            expected_nonce: 0,
             decision_receipt_id: String::new(),
             decision_hash: String::new(),
         };
@@ -477,6 +486,7 @@ mod tests {
                 currency: "HOURS".into(),
                 memo: "Tool purchase".into(),
                 budget_id: None,
+                expected_nonce: 0,
                 decision_receipt_id: "receipt-456".into(),
                 decision_hash: "abc123".into(),
             }),
@@ -604,6 +614,7 @@ mod tests {
                 currency: "USD".into(),
                 memo: "test".into(),
                 budget_id: None,
+                expected_nonce: 0,
                 decision_receipt_id: "r1".into(),
                 decision_hash: "h1".into(),
             },

--- a/icn/crates/icn-kernel-api/src/governance.rs
+++ b/icn/crates/icn-kernel-api/src/governance.rs
@@ -52,6 +52,9 @@ pub struct TreasuryOperation {
     pub currency: String,
     pub recipient: Option<String>,
     pub memo: String,
+    /// Expected treasury nonce (Spend only). `None` for operations without nonce checks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_nonce: Option<u64>,
     /// Canonical decision hash for provenance (cross-node anchor)
     pub decision_hash: Option<String>,
 }
@@ -282,6 +285,7 @@ pub fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperatio
             amount,
             currency,
             memo,
+            expected_nonce,
             decision_hash,
             ..
         } => TreasuryOperation {
@@ -291,6 +295,7 @@ pub fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperatio
             currency: currency.clone(),
             recipient: Some(recipient_did.clone()),
             memo: memo.clone(),
+            expected_nonce: Some(*expected_nonce),
             decision_hash: Some(decision_hash.clone()),
         },
         TreasuryEffect::CreateBudget {
@@ -308,6 +313,7 @@ pub fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperatio
             currency: currency.clone(),
             recipient: Some(budget_id.clone()),
             memo: name.clone(),
+            expected_nonce: None,
             decision_hash: Some(decision_hash.clone()),
         },
         TreasuryEffect::Allocate {
@@ -322,6 +328,7 @@ pub fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperatio
             currency: currency.clone(),
             recipient: Some(budget_id.clone()),
             memo: "Budget allocation".to_string(),
+            expected_nonce: None,
             decision_hash: None,
         },
         TreasuryEffect::Transfer {
@@ -337,6 +344,7 @@ pub fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperatio
             currency: currency.clone(),
             recipient: Some(to_did.clone()),
             memo: memo.clone(),
+            expected_nonce: None,
             decision_hash: None,
         },
         TreasuryEffect::ReleaseEscrow {
@@ -354,6 +362,7 @@ pub fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperatio
             currency: currency.clone(),
             recipient: Some(beneficiary_did.clone()),
             memo: format!("Escrow release: {}", escrow_id),
+            expected_nonce: None,
             decision_hash: Some(decision_hash.clone()),
         },
         // Other treasury effects mapped to basic operations
@@ -364,6 +373,7 @@ pub fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperatio
             currency: "UNKNOWN".to_string(),
             recipient: None,
             memo: "Unmapped treasury effect".to_string(),
+            expected_nonce: None,
             decision_hash: None,
         },
     }
@@ -493,11 +503,13 @@ mod tests {
             currency: "HOURS".to_string(),
             recipient: Some("did:icn:abc123".to_string()),
             memo: "Equipment purchase".to_string(),
+            expected_nonce: Some(7),
             decision_hash: Some("sha256:abc123".to_string()),
         };
         let json = serde_json::to_string(&op).unwrap();
         let parsed: TreasuryOperation = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.amount, 1000);
+        assert_eq!(parsed.expected_nonce, Some(7));
         assert_eq!(parsed.decision_hash, Some("sha256:abc123".to_string()));
     }
 

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -634,6 +634,11 @@ pub struct TreasuryEntryRequest {
     pub recipient: Option<String>,
     /// Human-readable memo
     pub memo: String,
+    /// Expected treasury nonce for spend replay protection.
+    ///
+    /// `Some(n)` is required for `Spend`; ignored for other operations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_nonce: Option<u64>,
 
     // Provenance fields (pilot-critical)
     /// Decision receipt ID that authorized this entry (node-local reference)
@@ -713,6 +718,7 @@ impl TreasuryEntryRequest {
             currency: intent.unit.clone(),
             recipient: Some(intent.to.clone()),
             memo: intent.memo.clone().unwrap_or_default(),
+            expected_nonce: None,
             decision_receipt_id: intent.decision_receipt_id.clone(),
             decision_hash: decision_hash_hex,
         })


### PR DESCRIPTION
## Summary
- Add `expected_nonce` to treasury spend effect input and thread it through governance translation and kernel operation/request DTOs.
- Enforce nonce check at the ledger boundary in `LedgerServiceImpl::submit_treasury_entry` before append; reject stale/mismatched nonce deterministically.
- Add stale-nonce replay coverage showing no append and no balance mutation.
- Keep existing provenance persistence regression green.

## Scope Lock (PR-4)
- Included: nonce threading + ledger-bound nonce enforcement + one stale-nonce replay test.
- Excluded: replay/idempotency redesign, ledger dedup redesign, translator ledger reads, and any PR-2/PR-3 scope changes.

## Key Files
- `icn/crates/icn-kernel-api/src/effects.rs`
- `icn/crates/icn-kernel-api/src/governance.rs`
- `icn/crates/icn-kernel-api/src/services.rs`
- `icn/crates/icn-governance/src/proposal.rs`
- `icn/apps/governance/src/handlers/execution.rs`
- `icn/crates/icn-core/src/supervisor/governance_executor.rs`
- `icn/crates/icn-core/src/services/ledger_service.rs`
- `icn/crates/icn-core/tests/decision_executor_runtime_test.rs`

## Acceptance Criteria Mapping
1. Treasury spend effect input carries nonce:
   - `TreasuryEffect::Spend.expected_nonce` in `icn/crates/icn-kernel-api/src/effects.rs`.
2. Governance translation populates nonce from payload boundary:
   - `TreasuryProposalOperation::Withdraw.nonce` in `icn/crates/icn-governance/src/proposal.rs`.
   - Mapped in `translate_treasury_operation` in `icn/apps/governance/src/handlers/execution.rs`.
3. Ledger rejects stale/mismatched nonce before append:
   - `check_spend_nonce()` called before `append_entry()` in `icn/crates/icn-core/src/services/ledger_service.rs`.
4. Replay test:
   - `test_submit_treasury_entry_rejects_stale_expected_nonce` in `icn/crates/icn-core/src/services/ledger_service.rs`.
5. Provenance regression remains green:
   - `test_treasury_entry_persisted_with_provenance` in `icn/crates/icn-core/tests/decision_executor_runtime_test.rs`.

## Verification
```bash
cd icn
cargo fmt --all --check
```
- pass

```bash
cd icn
timeout 300 bash -lc 'RUSTC_WRAPPER= cargo test -p icn-core --lib test_submit_treasury_entry_ -- --nocapture'
```
- `running 4 tests`
- `4 passed; 0 failed`

```bash
cd icn
timeout 300 bash -lc 'RUSTC_WRAPPER= cargo test -p icn-core services::ledger_service::tests::test_submit_treasury_entry_rejects_stale_expected_nonce -- --exact --nocapture'
```
- `running 1 test`
- `...rejects_stale_expected_nonce ... ok`

```bash
cd icn
timeout 240 bash -lc 'RUSTC_WRAPPER= cargo test -p icn-core --test decision_executor_runtime_test test_treasury_entry_persisted_with_provenance -- --exact --nocapture'
```
- `running 1 test`
- `...persisted_with_provenance ... ok`

```bash
cd icn
timeout 420 bash -lc 'RUSTC_WRAPPER= cargo clippy -p icn-core --all-targets -- -D warnings'
```
- pass

```bash
cd icn
timeout 420 bash -lc 'RUSTC_WRAPPER= cargo test -p icn-kernel-api --lib'
```
- `287 passed; 0 failed`

```bash
cd icn
timeout 420 bash -lc 'RUSTC_WRAPPER= cargo test -p icn-governance --lib'
```
- `374 passed; 0 failed`

