### PR TITLE
feat(treasury): expose coop-scoped nonce source endpoint

### DIFF
--- a/docs/api/openapi.generated.yaml
+++ b/docs/api/openapi.generated.yaml
@@ -259,6 +259,18 @@ components:
             format: int64
           propertyNames:
             type: string
+        credit_limits:
+          type:
+          - object
+          - 'null'
+          description: |-
+            Credit limits per currency (max negative balance allowed)
+            Absence of a key means no credit limit for that currency
+          additionalProperties:
+            type: integer
+            format: int64
+          propertyNames:
+            type: string
         did:
           type: string
     BanMemberRequest:

--- a/icn/crates/icn-core/src/services/ledger_service.rs
+++ b/icn/crates/icn-core/src/services/ledger_service.rs
@@ -549,6 +549,10 @@ impl LedgerService for LedgerServiceImpl {
         Err("Resource access revocation not supported by treasury ledger service".to_string())
     }
 
+    fn get_treasury_nonce(&self, treasury_id: &str) -> Result<u64, String> {
+        self.current_treasury_nonce(treasury_id)
+    }
+
     fn submit_treasury_entry(
         &self,
         req: TreasuryEntryRequest,
@@ -896,5 +900,41 @@ mod tests {
             balance_after_stale, balance_after_first,
             "stale nonce must not mutate balances"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_submit_treasury_entry_nonce_query_tracks_successful_spend() {
+        let treasury_did = KeyPair::generate().unwrap().did().clone();
+        let recipient_did = KeyPair::generate().unwrap().did().clone();
+
+        let ledger_store = Arc::new(SledStore::temporary().unwrap());
+        let receipt_index = Arc::new(SledStore::temporary().unwrap());
+        let ledger = Arc::new(RwLock::new(Ledger::new(ledger_store).unwrap()));
+        let service = LedgerServiceImpl::new_with_receipt_index(
+            ledger,
+            Arc::new(AllowAllOracle::wildcard()),
+            treasury_did,
+            receipt_index,
+        );
+
+        let treasury_id = "did:icn:treasury:nonce-test";
+        let baseline = service.get_treasury_nonce(treasury_id).unwrap();
+        assert_eq!(baseline, 0);
+
+        let request = TreasuryEntryRequest {
+            treasury_id: treasury_id.to_string(),
+            operation_type: TreasuryOperationType::Spend,
+            amount: 30,
+            currency: "HOURS".to_string(),
+            recipient: Some(recipient_did.to_string()),
+            memo: "nonce query coherence".to_string(),
+            expected_nonce: Some(baseline),
+            decision_receipt_id: "gov:proposal:pr5:nonce:coherence".to_string(),
+            decision_hash: "decision-hash-pr5-nonce-coherence".to_string(),
+        };
+        service.submit_treasury_entry(request).unwrap();
+
+        let after = service.get_treasury_nonce(treasury_id).unwrap();
+        assert_eq!(after, baseline + 1);
     }
 }

--- a/icn/crates/icn-core/src/services/ledger_service.rs
+++ b/icn/crates/icn-core/src/services/ledger_service.rs
@@ -265,6 +265,19 @@ impl LedgerServiceImpl {
         Ok(())
     }
 
+    // Treasury Spend enforcement contract:
+    //
+    // 1) Receipt idempotency (`decision_receipt_id`) prevents re-applying the same decision.
+    //    Same receipt returns an existing entry hash with no new append.
+    // 2) Nonce enforcement prevents stale/out-of-order spends.
+    //    It is evaluated only when receipt idempotency does not short-circuit.
+    // 3) Nonce check + append must run under the same ledger write lock in
+    //    `submit_treasury_entry`, so mismatch rejects without partial mutation.
+    //
+    // Meaning Firewall note:
+    // - `expected_nonce` is supplied at the policy boundary (wallet/proposal payload).
+    // - Translator/wiring does not read ledger state to derive nonce.
+    // - Ledger is the enforcement boundary and returns deterministic mismatch errors.
     fn check_spend_nonce(&self, req: &TreasuryEntryRequest) -> Result<(), String> {
         if req.operation_type != TreasuryOperationType::Spend {
             return Ok(());

--- a/icn/crates/icn-core/src/supervisor/actors.rs
+++ b/icn/crates/icn-core/src/supervisor/actors.rs
@@ -17,6 +17,7 @@ pub struct GatewayActorHandles {
     pub coop: Option<icn_coop::CoopHandle>,
     pub community: Option<icn_community::CommunityHandle>,
     pub trust_service: Option<Arc<dyn icn_kernel_api::services::TrustService>>,
+    pub ledger_service: Option<Arc<dyn icn_kernel_api::services::LedgerService>>,
     pub governance: Option<icn_gateway::governance_mgr::GovernanceHandle>,
     pub treasury: Option<icn_gateway::TreasuryHandle>,
     pub ledger: Option<icn_gateway::LedgerHandle>,

--- a/icn/crates/icn-core/src/supervisor/init_gateway.rs
+++ b/icn/crates/icn-core/src/supervisor/init_gateway.rs
@@ -25,6 +25,8 @@ pub struct GatewayHandles {
     pub community: Option<icn_community::CommunityHandle>,
     /// Trust service for trust queries (kernel/app separated)
     pub trust_service: Option<Arc<dyn icn_kernel_api::services::TrustService>>,
+    /// Ledger service for treasury nonce queries
+    pub ledger_service: Option<Arc<dyn icn_kernel_api::services::LedgerService>>,
     /// Governance handle for governance operations
     pub governance: Option<icn_gateway::governance_mgr::GovernanceHandle>,
     /// Treasury handle for treasury operations
@@ -93,6 +95,7 @@ pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: Gateway
     let coop_handle = handles.coop;
     let community_handle = handles.community;
     let trust_service_handle = handles.trust_service;
+    let ledger_service_handle = handles.ledger_service;
     let governance_handle = handles.governance;
     let treasury_handle = handles.treasury;
     let ledger_handle = handles.ledger;
@@ -134,6 +137,10 @@ pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: Gateway
 
             if let Some(service) = trust_service_handle {
                 gateway_server = gateway_server.with_trust_service(service);
+            }
+
+            if let Some(service) = ledger_service_handle {
+                gateway_server = gateway_server.with_ledger_service(service);
             }
 
             if let Some(handle) = governance_handle {

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -113,6 +113,7 @@ pub async fn run_supervisor(
             coop: gateway_handles.coop,
             community: gateway_handles.community,
             trust_service: gateway_handles.trust_service,
+            ledger_service: gateway_handles.ledger_service,
             governance: gateway_handles.governance,
             treasury: gateway_handles.treasury,
             ledger: gateway_handles.ledger,
@@ -602,12 +603,14 @@ async fn spawn_actors_with_identity(
         let receipt_index_path = config.store_path().join("ledger-receipt-index");
         let receipt_index_store: Arc<icn_store::SledStore> =
             Arc::new(icn_store::SledStore::open(&receipt_index_path)?);
-        let ledger_service = Arc::new(crate::services::LedgerServiceImpl::new_with_receipt_index(
-            ledger_handle.clone(),
-            oracle,
-            treasury_did.clone(),
-            receipt_index_store,
-        ));
+        let ledger_service: Arc<dyn icn_kernel_api::services::LedgerService> =
+            Arc::new(crate::services::LedgerServiceImpl::new_with_receipt_index(
+                ledger_handle.clone(),
+                oracle,
+                treasury_did.clone(),
+                receipt_index_store,
+            ));
+        gateway_handles.ledger_service = Some(ledger_service.clone());
         kernel_executor = kernel_executor.with_ledger_service(ledger_service);
 
         // Wire federation service adapter if available

--- a/icn/crates/icn-gateway/src/api/treasury.rs
+++ b/icn/crates/icn-gateway/src/api/treasury.rs
@@ -110,6 +110,17 @@ pub struct TreasuryBalanceResponse {
     pub balances: HashMap<String, i64>,
 }
 
+/// Response for treasury nonce
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TreasuryNonceResponse {
+    /// Cooperative ID
+    pub coop_id: String,
+    /// Treasury DID
+    pub treasury_did: String,
+    /// Current spend nonce for this treasury
+    pub nonce: u64,
+}
+
 /// Budget summary for list response
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BudgetSummary {
@@ -383,6 +394,50 @@ pub async fn get_treasury_balance(
     };
 
     Ok(HttpResponse::Ok().json(response))
+}
+
+/// GET /treasury/{coop_id}/nonce - Get treasury spend nonce
+///
+/// Returns the current nonce used for treasury spend ordering.
+#[get("/{coop_id}/nonce")]
+pub async fn get_treasury_nonce(
+    req: HttpRequest,
+    path: web::Path<String>,
+    treasury_mgr: web::Data<Arc<GatewayTreasuryManager>>,
+) -> Result<HttpResponse> {
+    require_scope(&req, "treasury:read")?;
+
+    let coop_id = path.into_inner();
+    require_coop_access(&req, &coop_id)?;
+
+    let treasury = treasury_mgr
+        .get_treasury_by_coop(&coop_id)
+        .await
+        .map_err(|e| GatewayError::InternalError(e.to_string()))?;
+
+    let Some(treasury) = treasury else {
+        return Err(GatewayError::NotFound(format!(
+            "Treasury not configured for cooperative '{coop_id}'"
+        )));
+    };
+
+    let treasury_did = treasury.treasury_did.to_string();
+    let nonce = treasury_mgr
+        .get_treasury_nonce(&treasury_did)
+        .await
+        .map_err(|e| GatewayError::InternalError(e.to_string()))?
+        .ok_or_else(|| {
+            GatewayError::ServiceUnavailable(
+                "Treasury nonce lookup requires daemon integration with ledger service."
+                    .to_string(),
+            )
+        })?;
+
+    Ok(HttpResponse::Ok().json(TreasuryNonceResponse {
+        coop_id,
+        treasury_did,
+        nonce,
+    }))
 }
 
 /// GET /treasury/{coop_id}/budgets - List budgets
@@ -874,6 +929,9 @@ pub struct SpendRequest {
     /// Currency (defaults to "credits")
     #[serde(default = "default_spend_currency")]
     pub currency: String,
+    /// Optional expected treasury nonce. If omitted, gateway resolves current nonce.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_nonce: Option<u64>,
 }
 
 fn default_spend_currency() -> String {
@@ -924,15 +982,25 @@ pub async fn propose_spend(
         .get_treasury_by_coop(&coop_id)
         .await
         .map_err(|e| GatewayError::InternalError(e.to_string()))?;
-    let _treasury = treasury.ok_or_else(|| {
+    let treasury = treasury.ok_or_else(|| {
         GatewayError::NotFound(format!(
             "Treasury not configured for cooperative '{coop_id}'"
         ))
     })?;
 
-    // Nonce is checked at execution time by the TreasuryManager.
-    // For the proposal, we use 0 — the executor reads the current nonce atomically.
-    let nonce = 0u64;
+    let nonce = match body.expected_nonce {
+        Some(n) => n,
+        None => treasury_mgr
+            .get_treasury_nonce(&treasury.treasury_did.to_string())
+            .await
+            .map_err(|e| GatewayError::InternalError(e.to_string()))?
+            .ok_or_else(|| {
+                GatewayError::ServiceUnavailable(
+                    "Treasury nonce lookup requires daemon integration with ledger service."
+                        .to_string(),
+                )
+            })?,
+    };
 
     info!(
         coop_id = %coop_id,
@@ -1001,6 +1069,7 @@ pub async fn propose_spend(
 pub fn configure(cfg: &mut web::ServiceConfig) {
     cfg.service(get_treasury_status)
         .service(get_treasury_balance)
+        .service(get_treasury_nonce)
         .service(list_budgets)
         .service(get_budget)
         .service(create_budget)
@@ -1046,6 +1115,25 @@ mod tests {
 
         let req = test::TestRequest::get()
             .uri("/treasury/test-coop")
+            .to_request();
+        req.extensions_mut().insert(test_claims("test-coop"));
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::NOT_FOUND);
+    }
+
+    #[actix_web::test]
+    async fn test_get_treasury_nonce_not_found() {
+        let treasury_mgr = create_test_treasury_manager();
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(treasury_mgr))
+                .service(web::scope("/treasury").configure(configure)),
+        )
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/treasury/test-coop/nonce")
             .to_request();
         req.extensions_mut().insert(test_claims("test-coop"));
 

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -86,6 +86,8 @@ pub struct GatewayServer {
     coop_handle: Option<icn_coop::CoopHandle>,
     /// Optional TrustService for kernel/app separation
     trust_service_handle: Option<Arc<dyn icn_kernel_api::services::TrustService>>,
+    /// Optional LedgerService for treasury nonce queries
+    ledger_service_handle: Option<Arc<dyn icn_kernel_api::services::LedgerService>>,
     /// Optional handle to daemon's GovernanceActor (for actor-backed mode)
     governance_handle: Option<GovernanceHandle>,
     /// Optional handle to daemon's ContractRegistryActor (for contract management)
@@ -125,6 +127,7 @@ impl GatewayServer {
             compute_handle: None,
             coop_handle: None,
             trust_service_handle: None,
+            ledger_service_handle: None,
             governance_handle: None,
             contract_registry_handle: None,
             treasury_handle: None,
@@ -164,6 +167,7 @@ impl GatewayServer {
             compute_handle: None,
             coop_handle: None,
             trust_service_handle: None,
+            ledger_service_handle: None,
             governance_handle: None,
             contract_registry_handle: None,
             treasury_handle: None,
@@ -204,6 +208,7 @@ impl GatewayServer {
             compute_handle: None,
             coop_handle: None,
             trust_service_handle: None,
+            ledger_service_handle: None,
             governance_handle: None,
             contract_registry_handle: None,
             treasury_handle: None,
@@ -276,6 +281,18 @@ impl GatewayServer {
         service: Arc<dyn icn_kernel_api::services::TrustService>,
     ) -> Self {
         self.trust_service_handle = Some(service);
+        self
+    }
+
+    /// Set ledger service for treasury nonce queries.
+    ///
+    /// When set, treasury nonce endpoints query the same nonce source-of-truth
+    /// used by ledger spend enforcement.
+    pub fn with_ledger_service(
+        mut self,
+        service: Arc<dyn icn_kernel_api::services::LedgerService>,
+    ) -> Self {
+        self.ledger_service_handle = Some(service);
         self
     }
 
@@ -553,6 +570,9 @@ impl GatewayServer {
                 info!("Treasury manager connected to daemon (TreasuryManager + Ledger handles)");
             } else {
                 info!("Treasury manager connected to daemon (TreasuryManager handle only)");
+            }
+            if let Some(ledger_service) = self.ledger_service_handle.clone() {
+                mgr.set_ledger_service_handle(ledger_service);
             }
             Arc::new(mgr)
         } else {

--- a/icn/crates/icn-gateway/src/treasury_mgr.rs
+++ b/icn/crates/icn-gateway/src/treasury_mgr.rs
@@ -53,6 +53,8 @@ pub struct GatewayTreasuryManager {
     treasury_handle: Option<TreasuryHandle>,
     /// Optional handle to daemon's Ledger (for balance queries)
     ledger_handle: Option<LedgerHandle>,
+    /// Optional ledger service handle for treasury nonce queries.
+    ledger_service_handle: Option<Arc<dyn icn_kernel_api::services::LedgerService>>,
 }
 
 impl GatewayTreasuryManager {
@@ -66,6 +68,7 @@ impl GatewayTreasuryManager {
             standalone: Some(LedgerTreasuryManager::new()),
             treasury_handle: None,
             ledger_handle: None,
+            ledger_service_handle: None,
         }
     }
 
@@ -82,6 +85,7 @@ impl GatewayTreasuryManager {
             standalone: None,
             treasury_handle: Some(handle),
             ledger_handle: None,
+            ledger_service_handle: None,
         }
     }
 
@@ -92,6 +96,15 @@ impl GatewayTreasuryManager {
     pub fn set_ledger_handle(&mut self, handle: LedgerHandle) {
         debug!("GatewayTreasuryManager wired to daemon Ledger for balance queries");
         self.ledger_handle = Some(handle);
+    }
+
+    /// Set ledger service handle for nonce queries.
+    pub fn set_ledger_service_handle(
+        &mut self,
+        handle: Arc<dyn icn_kernel_api::services::LedgerService>,
+    ) {
+        debug!("GatewayTreasuryManager wired to daemon LedgerService for nonce queries");
+        self.ledger_service_handle = Some(handle);
     }
 
     /// Check if running in actor-backed mode
@@ -388,6 +401,19 @@ impl GatewayTreasuryManager {
             return Ok(account_balances.balances);
         }
         Ok(HashMap::new()) // Ledger not wired
+    }
+
+    /// Get current nonce for a treasury identity from the ledger service.
+    ///
+    /// Returns `None` when no ledger service is wired.
+    pub async fn get_treasury_nonce(&self, treasury_id: &str) -> Result<Option<u64>> {
+        if let Some(ref service) = self.ledger_service_handle {
+            let nonce = service
+                .get_treasury_nonce(treasury_id)
+                .map_err(anyhow::Error::msg)?;
+            return Ok(Some(nonce));
+        }
+        Ok(None)
     }
 
     // ============================================================================

--- a/icn/crates/icn-gateway/tests/listings_integration.rs
+++ b/icn/crates/icn-gateway/tests/listings_integration.rs
@@ -694,11 +694,25 @@ async fn test_interest_persists_across_manager_instances() {
         // releases its file lock before we re-open in the next block.
         drop(mgr);
         db.flush().unwrap();
+        drop(db);
     }
 
     // Open new manager instance and verify interest exists
     {
-        let db = sled::open(db_path.path()).unwrap();
+        let mut db = None;
+        for _ in 0..20 {
+            match sled::open(db_path.path()) {
+                Ok(opened) => {
+                    db = Some(opened);
+                    break;
+                }
+                Err(err) if err.to_string().contains("Resource temporarily unavailable") => {
+                    std::thread::sleep(std::time::Duration::from_millis(25));
+                }
+                Err(err) => panic!("failed to re-open persisted sled db: {err}"),
+            }
+        }
+        let db = db.expect("failed to re-open persisted sled db after retries");
         let mgr = ListingsManager::with_sled(Arc::new(db));
 
         let interests = mgr.get_interests(&listing_id).unwrap();

--- a/icn/crates/icn-kernel-api/src/effects.rs
+++ b/icn/crates/icn-kernel-api/src/effects.rs
@@ -75,10 +75,11 @@ pub enum TreasuryEffect {
         /// before submitting the ledger entry.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         budget_id: Option<String>,
-        /// Expected treasury nonce at execution time for replay protection.
+        /// Expected treasury nonce provided by the policy layer for spend ordering.
         ///
-        /// The executor checks this against the current stored treasury nonce
-        /// before append. Mismatch rejects the spend.
+        /// The translator/wiring passes this value through without reading ledger
+        /// state. The ledger boundary enforces it against stored nonce before append.
+        /// Mismatch rejects stale/out-of-order spends deterministically.
         #[serde(default)]
         expected_nonce: u64,
         /// Links back to governance decision receipt

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -569,6 +569,14 @@ pub trait LedgerService: Send + Sync {
     ) -> Result<TreasuryEntryResult, String> {
         Err("Treasury entry submission not supported".to_string())
     }
+
+    /// Get the current treasury nonce used for spend ordering enforcement.
+    ///
+    /// The returned value must come from the same source-of-truth used by
+    /// `submit_treasury_entry` nonce checks.
+    fn get_treasury_nonce(&self, _treasury_id: &str) -> Result<u64, String> {
+        Err("Treasury nonce query not supported".to_string())
+    }
 }
 
 // ============================================================================

--- a/sdk/typescript/src/generated/api-types.ts
+++ b/sdk/typescript/src/generated/api-types.ts
@@ -35,6 +35,8 @@ export interface components {
         /** @description Add a member to a cooperative */
         AddMemberRequest: {
             did: string;
+            /** @description Optional display name to set when adding the member */
+            display_name?: string | null;
             /**
              * @description Role for the new member: "steward", "facilitator", or "participant"
              *     Legacy names "owner", "admin", "member" are also accepted for backwards compatibility
@@ -103,6 +105,13 @@ export interface components {
             balances: {
                 [key: string]: number;
             };
+            /**
+             * @description Credit limits per currency (max negative balance allowed)
+             *     Absence of a key means no credit limit for that currency
+             */
+            credit_limits?: {
+                [key: string]: number;
+            } | null;
             did: string;
         };
         /** @description Ban member request */


### PR DESCRIPTION
## Summary
- Add a treasury nonce query to the kernel ledger service interface and implement it in `LedgerServiceImpl` using the same nonce source used by spend enforcement.
- Plumb a ledger-service handle from supervisor lifecycle into gateway treasury manager, so gateway nonce reads come from ledger-service source-of-truth.
- Add `GET /treasury/{coop_id}/nonce` returning `{ coop_id, treasury_did, nonce }`.
- Remove hardcoded `nonce=0` in treasury spend proposal API. `propose_spend` now uses client-provided `expected_nonce` when present, otherwise resolves current nonce via ledger service.
- Add tests for nonce coherence and route behavior.

## Evidence
- `cd icn && cargo fmt --all --check` ✅
- `cd icn && timeout 180 bash -lc 'RUSTC_WRAPPER= cargo test -p icn-core --lib services::ledger_service::tests::test_submit_treasury_entry_nonce_query_tracks_successful_spend -- --exact --nocapture'` ✅ (`1 passed`)
- `cd icn && timeout 180 bash -lc 'RUSTC_WRAPPER= cargo test -p icn-gateway --lib api::treasury::tests::test_get_treasury_nonce_not_found -- --exact --nocapture'` ✅ (`1 passed`)
- `cd icn && timeout 240 bash -lc 'RUSTC_WRAPPER= cargo test -p icn-core --test decision_executor_runtime_test test_treasury_entry_persisted_with_provenance -- --exact --nocapture'` ✅ (`1 passed`)
- `cd icn && timeout 600 bash -lc 'RUSTC_WRAPPER= cargo clippy -p icn-core -p icn-gateway --all-targets -- -D warnings'` ✅

## Out Of Scope
- No replay/idempotency redesign (already handled in prior PR).
- No treasury spend payload schema expansion.
- No execution lease/leader-election work.

## Operator Verification
1. Start daemon with gateway enabled.
2. Query nonce:
   - `GET /treasury/{coop_id}/nonce`
3. Submit treasury spend proposal with `expected_nonce` set to the returned value.
4. Query nonce again and verify increment by 1 after successful execution path.
