### PR TITLE
feat(treasury): withdraw-first functional slice with restart-safe proof

### DIFF
--- a/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
+++ b/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
@@ -725,7 +725,157 @@ async fn test_treasury_entry_persisted_with_provenance() {
     assert_eq!(reopened_record.ledger_entry_ids, vec![entry_hash]);
 }
 
-/// Test 11: Treasury Spend payload is explicitly unsupported at translation
+/// Test 11: Withdraw proposal payload translates through the real boundary and
+/// executes as a single durable treasury mutation across restart/replay.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_withdraw_payload_restart_resume_single_mutation() {
+    use icn_core::supervisor::decision_executor::DecisionExecutor;
+    use icn_core::supervisor::effect_dispatcher::EffectDispatcher;
+    use icn_core::supervisor::governance_executor::KernelGovernanceExecutor;
+    use icn_identity::Did;
+
+    let tmp = TempDir::new().unwrap();
+    let ledger_store_path = tmp.path().join("ledger");
+    let exec_store_path = tmp.path().join("execution");
+    std::fs::create_dir_all(&ledger_store_path).unwrap();
+    std::fs::create_dir_all(&exec_store_path).unwrap();
+
+    let decision_hash = "hash-withdraw-restart-1";
+    let decision_receipt_id = "receipt-withdraw-restart-1";
+    let treasury_did_str = "did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9";
+    let treasury_did: Did = treasury_did_str.parse().unwrap();
+    let recipient_did: Did = treasury_did_str.parse().unwrap();
+
+    let payload = ProposalPayload::Treasury {
+        operation: TreasuryProposalOperation::Withdraw {
+            treasury_did: treasury_did.clone(),
+            recipient: recipient_did,
+            amount: 100,
+            currency: "HOURS".to_string(),
+            purpose: "Withdraw restart safety test".to_string(),
+            budget_id: None,
+            nonce: 0,
+        },
+    };
+
+    let effects = translate_payload_to_effects(&payload, decision_receipt_id, decision_hash);
+    assert_eq!(effects.len(), 1);
+    match &effects[0] {
+        KernelEffect::Treasury(TreasuryEffect::Spend {
+            decision_receipt_id: rid,
+            decision_hash: dh,
+            ..
+        }) => {
+            assert_eq!(rid, decision_receipt_id);
+            assert_eq!(dh, decision_hash);
+        }
+        other => panic!("expected translated treasury spend effect, got {other:?}"),
+    }
+
+    let entry_hash = {
+        let ledger_store = Arc::new(SledStore::open(&ledger_store_path).unwrap());
+        let ledger = Ledger::new(ledger_store).unwrap();
+        let ledger = Arc::new(tokio::sync::RwLock::new(ledger));
+
+        let ledger_service = Arc::new(LedgerServiceImpl::new(
+            ledger.clone(),
+            Arc::new(AllowAllOracle::wildcard()),
+            treasury_did_str.parse().unwrap(),
+        ));
+        let kernel_executor = KernelGovernanceExecutor::new(Arc::new(StubParamStore))
+            .with_ledger_service(ledger_service);
+        let dispatcher = Arc::new(EffectDispatcher::new(Arc::new(kernel_executor)));
+        let exec_backend = Arc::new(SledStore::open(&exec_store_path).unwrap());
+        let exec_store = Arc::new(SledExecutionStore::new(exec_backend));
+        let executor = DecisionExecutor::new(dispatcher, exec_store.clone());
+
+        let results = executor
+            .execute(
+                effects.clone(),
+                decision_receipt_id,
+                decision_hash,
+                "proposal-withdraw-restart-1",
+            )
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].success);
+
+        let record = exec_store.get(decision_hash).unwrap().unwrap();
+        assert_eq!(record.status, ExecutionStatus::Confirmed);
+        assert_eq!(record.ledger_entry_ids.len(), 1);
+        let entry_hash = record.ledger_entry_ids[0].clone();
+
+        let parsed = content_hash_from_hex(&entry_hash).unwrap();
+        let entry = ledger.read().await.get_entry(&parsed).unwrap().unwrap();
+        assert_eq!(
+            entry.decision_receipt_id.as_deref(),
+            Some(decision_receipt_id)
+        );
+        assert_eq!(entry.decision_hash.as_deref(), Some(decision_hash));
+        assert_eq!(ledger.read().await.count_entries().unwrap(), 1);
+
+        entry_hash
+    };
+
+    let replay_effects = translate_payload_to_effects(&payload, decision_receipt_id, decision_hash);
+    let reopened_ledger_store = Arc::new(SledStore::open(&ledger_store_path).unwrap());
+    let reopened_ledger = Ledger::new(reopened_ledger_store).unwrap();
+    let reopened_ledger = Arc::new(tokio::sync::RwLock::new(reopened_ledger));
+
+    let reopened_ledger_service = Arc::new(LedgerServiceImpl::new(
+        reopened_ledger.clone(),
+        Arc::new(AllowAllOracle::wildcard()),
+        treasury_did_str.parse().unwrap(),
+    ));
+    let reopened_kernel_executor = KernelGovernanceExecutor::new(Arc::new(StubParamStore))
+        .with_ledger_service(reopened_ledger_service);
+    let reopened_dispatcher = Arc::new(EffectDispatcher::new(Arc::new(reopened_kernel_executor)));
+    let reopened_exec_backend = Arc::new(SledStore::open(&exec_store_path).unwrap());
+    let reopened_exec_store = Arc::new(SledExecutionStore::new(reopened_exec_backend));
+    let reopened_executor = DecisionExecutor::new(reopened_dispatcher, reopened_exec_store.clone());
+
+    let report = reopened_executor.recover_in_flight().await.unwrap();
+    assert_eq!(
+        report.total(),
+        0,
+        "confirmed records should not be re-executed"
+    );
+
+    let replay_results = reopened_executor
+        .execute(
+            replay_effects,
+            decision_receipt_id,
+            decision_hash,
+            "proposal-withdraw-restart-1",
+        )
+        .await
+        .unwrap();
+    assert!(
+        replay_results.is_empty(),
+        "terminal decision replay should be skipped by idempotency gate"
+    );
+    assert_eq!(reopened_ledger.read().await.count_entries().unwrap(), 1);
+
+    let parsed = content_hash_from_hex(&entry_hash).unwrap();
+    let reopened_entry = reopened_ledger
+        .read()
+        .await
+        .get_entry(&parsed)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        reopened_entry.decision_receipt_id.as_deref(),
+        Some(decision_receipt_id)
+    );
+    assert_eq!(reopened_entry.decision_hash.as_deref(), Some(decision_hash));
+
+    let reopened_record = reopened_exec_store.get(decision_hash).unwrap().unwrap();
+    assert_eq!(reopened_record.status, ExecutionStatus::Confirmed);
+    assert_eq!(reopened_record.ledger_entry_ids, vec![entry_hash]);
+}
+
+/// Test 12: Treasury Spend payload is explicitly unsupported at translation
 /// boundary until payload carries treasury identity + currency.
 #[test]
 fn test_treasury_spend_payload_translation_is_explicitly_unsupported() {

--- a/icn/crates/icn-gateway/src/api/treasury.rs
+++ b/icn/crates/icn-gateway/src/api/treasury.rs
@@ -943,6 +943,11 @@ fn default_spend_currency() -> String {
 /// Creates a governance proposal for a direct treasury disbursement.
 /// The spend is charged against the treasury's unallocated balance.
 /// Requires governance approval before execution.
+///
+/// Implementation note:
+/// This route emits a `TreasuryProposalOperation::Withdraw` payload because
+/// that operation currently carries the full treasury identity/currency fields
+/// required by production effect translation/execution.
 #[post("/{coop_id}/spend")]
 pub async fn propose_spend(
     req: HttpRequest,
@@ -1014,10 +1019,13 @@ pub async fn propose_spend(
     let domain_id = GovernanceDomainId::new(&coop_id);
 
     let payload = ProposalPayload::Treasury {
-        operation: TreasuryProposalOperation::Spend {
+        operation: TreasuryProposalOperation::Withdraw {
+            treasury_did: treasury.treasury_did.clone(),
+            currency: body.currency.clone(),
             amount: body.amount,
             recipient: recipient_did,
-            memo: body.memo.clone(),
+            purpose: body.memo.clone(),
+            budget_id: None,
             nonce,
         },
     };
@@ -1049,6 +1057,7 @@ pub async fn propose_spend(
     let response = serde_json::json!({
         "status": "proposal_created",
         "message": "Treasury spend requires governance approval",
+        "operation": "withdraw",
         "proposal_id": created_proposal_id.to_string(),
         "coop_id": coop_id,
         "amount": body.amount,
@@ -1084,6 +1093,9 @@ mod tests {
     use super::*;
     use crate::auth::TokenClaims;
     use actix_web::{test, App, HttpMessage};
+    use icn_governance::{GovernanceParams, MembershipConfig};
+    use icn_identity::KeyPair;
+    use icn_ledger::TreasuryManager as LedgerTreasuryManager;
 
     fn test_claims(coop_id: &str) -> TokenClaims {
         TokenClaims {
@@ -1257,5 +1269,91 @@ mod tests {
         let resp: AuditTrailResponse = test::call_and_read_body_json(&app, req).await;
         assert_eq!(resp.limit, 50);
         assert_eq!(resp.offset, 10);
+    }
+
+    #[actix_web::test]
+    async fn test_propose_spend_creates_withdraw_operation_payload() {
+        let proposer = KeyPair::generate().unwrap();
+        let recipient = KeyPair::generate().unwrap();
+        let treasury_did = KeyPair::generate().unwrap().did().clone();
+
+        let treasury_handle = Arc::new(tokio::sync::RwLock::new(LedgerTreasuryManager::new()));
+        let treasury_mgr = Arc::new(GatewayTreasuryManager::with_handle(treasury_handle));
+        treasury_mgr
+            .register_treasury(
+                treasury_did.clone(),
+                "test-coop".to_string(),
+                "credits".to_string(),
+                proposer.did().clone(),
+                Some("test treasury".to_string()),
+            )
+            .await
+            .unwrap();
+
+        let governance_mgr = create_test_governance_manager();
+        governance_mgr
+            .create_domain(
+                GovernanceDomainId("test-coop".to_string()),
+                "Test Coop".to_string(),
+                "cooperative".to_string(),
+                GovernanceParams::new(50, 66, 7 * 86400),
+                MembershipConfig::static_list(vec![proposer.did().clone()]),
+            )
+            .await
+            .unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(treasury_mgr.clone()))
+                .app_data(web::Data::new(governance_mgr.clone()))
+                .service(web::scope("/treasury").configure(configure)),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri("/treasury/test-coop/spend")
+            .set_json(serde_json::json!({
+                "amount": 42,
+                "recipient": recipient.did().to_string(),
+                "memo": "Ops budget",
+                "currency": "credits",
+                "expected_nonce": 0
+            }))
+            .to_request();
+        req.extensions_mut().insert(TokenClaims {
+            sub: proposer.did().to_string(),
+            iat: 1_000_000_000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["treasury:write".to_string()],
+            exp: 9_999_999_999,
+        });
+
+        let _resp: serde_json::Value = test::call_and_read_body_json(&app, req).await;
+
+        let proposals = governance_mgr.list_proposals().await.unwrap();
+        assert_eq!(proposals.len(), 1);
+        match &proposals[0].payload {
+            ProposalPayload::Treasury { operation } => match operation {
+                TreasuryProposalOperation::Withdraw {
+                    treasury_did: op_treasury_did,
+                    recipient: op_recipient,
+                    amount,
+                    currency,
+                    purpose,
+                    budget_id,
+                    nonce,
+                } => {
+                    assert_eq!(op_treasury_did, &treasury_did);
+                    assert_eq!(op_recipient, recipient.did());
+                    assert_eq!(*amount, 42);
+                    assert_eq!(currency, "credits");
+                    assert_eq!(purpose, "Ops budget");
+                    assert_eq!(budget_id, &None);
+                    assert_eq!(*nonce, 0);
+                }
+                other => panic!("expected Withdraw payload, got {other:?}"),
+            },
+            other => panic!("expected Treasury payload, got {other:?}"),
+        }
     }
 }

--- a/icn/crates/icn-gateway/src/api/treasury.rs
+++ b/icn/crates/icn-gateway/src/api/treasury.rs
@@ -11,7 +11,11 @@
 //! proposal system.
 
 use actix_web::{get, post, web, HttpMessage, HttpRequest, HttpResponse};
-use icn_governance::{GovernanceDomainId, ProposalId, ProposalPayload, TreasuryProposalOperation};
+#[cfg_attr(not(test), allow(unused_imports))]
+use icn_governance::{
+    GovernanceDomainId, GovernanceParams, MembershipConfig, ProposalId, ProposalPayload,
+    TreasuryProposalOperation,
+};
 use icn_identity::Did;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -1093,7 +1097,6 @@ mod tests {
     use super::*;
     use crate::auth::TokenClaims;
     use actix_web::{test, App, HttpMessage};
-    use icn_governance::{GovernanceParams, MembershipConfig};
     use icn_identity::KeyPair;
     use icn_ledger::TreasuryManager as LedgerTreasuryManager;
 


### PR DESCRIPTION
## Summary
- Routes `POST /treasury/{coop_id}/spend` proposals through `TreasuryProposalOperation::Withdraw` so the proposal path uses the currently executable treasury translation boundary.
- Adds gateway test coverage proving `/spend` now creates a Withdraw payload (with treasury identity, currency, purpose, and nonce).
- Adds a core runtime acceptance test that goes through payload translation and proves:
  - durable ledger append with governance provenance,
  - restart/recovery does not re-apply mutation,
  - replay of same decision hash is skipped and ledger entry count remains 1.

## Why
`TreasuryProposalOperation::Spend` is currently intentionally guarded as unsupported in translation, while `Withdraw` is fully representable and executable. This PR delivers the first truthful end-to-end treasury governance slice without fabricating Spend semantics.

## Evidence
Commands run:

```bash
cd icn
cargo fmt --all --check

RUSTC_WRAPPER= cargo test -p icn-core --test decision_executor_runtime_test \
  test_withdraw_payload_restart_resume_single_mutation -- --exact --nocapture

RUSTC_WRAPPER= cargo test -p icn-core --test decision_executor_runtime_test \
  test_treasury_entry_persisted_with_provenance -- --exact --nocapture

RUSTC_WRAPPER= cargo test -p icn-gateway --features sled-storage --lib \
  api::treasury::tests::test_propose_spend_creates_withdraw_operation_payload \
  -- --exact --nocapture

RUSTC_WRAPPER= cargo clippy -p icn-core -p icn-gateway --all-targets -- -D warnings
```

Results:
- new withdraw restart/single-mutation test: **passed**
- provenance persistence regression test: **passed**
- new gateway payload-shape test: **passed**
- fmt/clippy: **passed**

## Out of scope
- Spend schema parity (`#1211`)
- Treasury `state_change_hash` parity (`#1213`)
- Shared `icn-api` ledger/governance service parity (`#1214`)

## Tracking
- Implements core of `#1212`
