### PR TITLE
feat(treasury): spend schema parity

### DIFF
--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -281,8 +281,6 @@ fn translate_treasury_operation(
     decision_hash: &str,
 ) -> Vec<KernelEffect> {
     use icn_governance::TreasuryProposalOperation;
-    const TREASURY_SPEND_UNSUPPORTED_REASON: &str =
-        "Treasury Spend translation unsupported: missing treasury_did and currency in payload";
 
     match operation {
         TreasuryProposalOperation::Withdraw {
@@ -305,9 +303,24 @@ fn translate_treasury_operation(
             decision_hash: decision_hash.to_string(),
         })],
 
-        TreasuryProposalOperation::Spend { .. } => vec![KernelEffect::NoOp {
-            reason: TREASURY_SPEND_UNSUPPORTED_REASON.to_string(),
-        }],
+        TreasuryProposalOperation::Spend {
+            treasury_did,
+            recipient,
+            amount,
+            currency,
+            memo,
+            nonce,
+        } => vec![KernelEffect::Treasury(TreasuryEffect::Spend {
+            treasury_did: treasury_did.to_string(),
+            recipient_did: recipient.to_string(),
+            amount: *amount,
+            currency: currency.clone(),
+            memo: memo.clone(),
+            budget_id: None,
+            expected_nonce: *nonce,
+            decision_receipt_id: decision_receipt_id.to_string(),
+            decision_hash: decision_hash.to_string(),
+        })],
 
         TreasuryProposalOperation::CreateBudget {
             treasury_did,

--- a/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
+++ b/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
@@ -875,21 +875,25 @@ async fn test_withdraw_payload_restart_resume_single_mutation() {
     assert_eq!(reopened_record.ledger_entry_ids, vec![entry_hash]);
 }
 
-/// Test 12: Treasury Spend payload is explicitly unsupported at translation
-/// boundary until payload carries treasury identity + currency.
+/// Test 12: Treasury Spend payload translates to a treasury spend effect.
 #[test]
-fn test_treasury_spend_payload_translation_is_explicitly_unsupported() {
+fn test_treasury_spend_payload_translation_produces_treasury_spend_effect() {
     use icn_identity::Did;
 
     let decision_receipt_id = "gov:test-domain:test-proposal:receipt";
     let decision_hash = "test-decision-hash";
+    let treasury_did: Did = "did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9"
+        .parse()
+        .unwrap();
     let recipient: Did = "did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9"
         .parse()
         .unwrap();
 
     let payload = ProposalPayload::Treasury {
         operation: TreasuryProposalOperation::Spend {
+            treasury_did: treasury_did.clone(),
             amount: 100,
+            currency: "HOURS".to_string(),
             recipient,
             memo: "PR-2 treasury spend".to_string(),
             nonce: 0,
@@ -899,14 +903,18 @@ fn test_treasury_spend_payload_translation_is_explicitly_unsupported() {
     let effects = translate_payload_to_effects(&payload, decision_receipt_id, decision_hash);
     assert_eq!(effects.len(), 1);
     match &effects[0] {
-        KernelEffect::NoOp { reason } => {
-            assert!(
-                reason.contains(
-                    "Treasury Spend translation unsupported: missing treasury_did and currency in payload"
-                ),
-                "NoOp reason must explain unsupported Spend translation boundary"
-            );
+        KernelEffect::Treasury(TreasuryEffect::Spend {
+            treasury_did: effect_treasury_did,
+            currency,
+            decision_receipt_id: rid,
+            decision_hash: dh,
+            ..
+        }) => {
+            assert_eq!(effect_treasury_did, &treasury_did.to_string());
+            assert_eq!(currency, "HOURS");
+            assert_eq!(rid, decision_receipt_id);
+            assert_eq!(dh, decision_hash);
         }
-        other => panic!("expected NoOp for unsupported Spend payload, got {other:?}"),
+        other => panic!("expected Treasury Spend effect, got {other:?}"),
     }
 }

--- a/icn/crates/icn-gateway/src/api/treasury.rs
+++ b/icn/crates/icn-gateway/src/api/treasury.rs
@@ -947,11 +947,6 @@ fn default_spend_currency() -> String {
 /// Creates a governance proposal for a direct treasury disbursement.
 /// The spend is charged against the treasury's unallocated balance.
 /// Requires governance approval before execution.
-///
-/// Implementation note:
-/// This route emits a `TreasuryProposalOperation::Withdraw` payload because
-/// that operation currently carries the full treasury identity/currency fields
-/// required by production effect translation/execution.
 #[post("/{coop_id}/spend")]
 pub async fn propose_spend(
     req: HttpRequest,
@@ -1023,13 +1018,12 @@ pub async fn propose_spend(
     let domain_id = GovernanceDomainId::new(&coop_id);
 
     let payload = ProposalPayload::Treasury {
-        operation: TreasuryProposalOperation::Withdraw {
+        operation: TreasuryProposalOperation::Spend {
             treasury_did: treasury.treasury_did.clone(),
-            currency: body.currency.clone(),
             amount: body.amount,
+            currency: body.currency.clone(),
             recipient: recipient_did,
-            purpose: body.memo.clone(),
-            budget_id: None,
+            memo: body.memo.clone(),
             nonce,
         },
     };
@@ -1061,7 +1055,7 @@ pub async fn propose_spend(
     let response = serde_json::json!({
         "status": "proposal_created",
         "message": "Treasury spend requires governance approval",
-        "operation": "withdraw",
+        "operation": "spend",
         "proposal_id": created_proposal_id.to_string(),
         "coop_id": coop_id,
         "amount": body.amount,
@@ -1275,7 +1269,7 @@ mod tests {
     }
 
     #[actix_web::test]
-    async fn test_propose_spend_creates_withdraw_operation_payload() {
+    async fn test_propose_spend_creates_spend_operation_payload() {
         let proposer = KeyPair::generate().unwrap();
         let recipient = KeyPair::generate().unwrap();
         let treasury_did = KeyPair::generate().unwrap().did().clone();
@@ -1337,24 +1331,22 @@ mod tests {
         assert_eq!(proposals.len(), 1);
         match &proposals[0].payload {
             ProposalPayload::Treasury { operation } => match operation {
-                TreasuryProposalOperation::Withdraw {
+                TreasuryProposalOperation::Spend {
                     treasury_did: op_treasury_did,
                     recipient: op_recipient,
                     amount,
                     currency,
-                    purpose,
-                    budget_id,
+                    memo,
                     nonce,
                 } => {
                     assert_eq!(op_treasury_did, &treasury_did);
                     assert_eq!(op_recipient, recipient.did());
                     assert_eq!(*amount, 42);
                     assert_eq!(currency, "credits");
-                    assert_eq!(purpose, "Ops budget");
-                    assert_eq!(budget_id, &None);
+                    assert_eq!(memo, "Ops budget");
                     assert_eq!(*nonce, 0);
                 }
-                other => panic!("expected Withdraw payload, got {other:?}"),
+                other => panic!("expected Spend payload, got {other:?}"),
             },
             other => panic!("expected Treasury payload, got {other:?}"),
         }

--- a/icn/crates/icn-governance/src/proposal.rs
+++ b/icn/crates/icn-governance/src/proposal.rs
@@ -811,8 +811,12 @@ pub enum TreasuryProposalOperation {
     ///
     /// Requires governance approval (same thresholds as `Withdraw`).
     Spend {
+        /// Treasury DID
+        treasury_did: Did,
         /// Amount to spend (must be positive)
         amount: i64,
+        /// Currency
+        currency: String,
         /// Recipient DID (must be a valid `did:icn:` identifier)
         recipient: Did,
         /// Human-readable description of the spend (must be non-empty)
@@ -2361,10 +2365,13 @@ mod tests {
 
     #[test]
     fn test_treasury_spend_serialization_roundtrip() {
+        let treasury_did = KeyPair::generate().unwrap().did().clone();
         let recipient = KeyPair::generate().unwrap().did().clone();
 
         let operation = TreasuryProposalOperation::Spend {
+            treasury_did: treasury_did.clone(),
             amount: 5000,
+            currency: "credits".to_string(),
             recipient: recipient.clone(),
             memo: "Office supplies reimbursement".to_string(),
             nonce: 0,
@@ -2375,12 +2382,16 @@ mod tests {
 
         match deserialized {
             TreasuryProposalOperation::Spend {
+                treasury_did: parsed_treasury_did,
                 amount,
+                currency,
                 recipient: r,
                 memo,
                 nonce,
             } => {
+                assert_eq!(parsed_treasury_did, treasury_did);
                 assert_eq!(amount, 5000);
+                assert_eq!(currency, "credits");
                 assert_eq!(r, recipient);
                 assert_eq!(memo, "Office supplies reimbursement");
                 assert_eq!(nonce, 0);
@@ -2394,6 +2405,7 @@ mod tests {
         let kp = KeyPair::generate().unwrap();
         let did = kp.did().clone();
         let domain_id = GovernanceDomainId::new("test-coop");
+        let treasury_did = KeyPair::generate().unwrap().did().clone();
         let recipient = KeyPair::generate().unwrap().did().clone();
 
         let proposal = Proposal::new(
@@ -2403,7 +2415,9 @@ mod tests {
             "Purchase supplies for the community garden project".to_string(),
             ProposalPayload::Treasury {
                 operation: TreasuryProposalOperation::Spend {
+                    treasury_did,
                     amount: 2500,
+                    currency: "credits".to_string(),
                     recipient: recipient.clone(),
                     memo: "Garden tools and seeds".to_string(),
                     nonce: 0,
@@ -2425,10 +2439,13 @@ mod tests {
     fn test_treasury_spend_zero_amount_is_representable() {
         // Zero amount is structurally valid at the type level; validation
         // happens at the handler level (handler rejects amount <= 0).
+        let treasury_did = KeyPair::generate().unwrap().did().clone();
         let recipient = KeyPair::generate().unwrap().did().clone();
 
         let operation = TreasuryProposalOperation::Spend {
+            treasury_did,
             amount: 0,
+            currency: "credits".to_string(),
             recipient,
             memo: "Should be rejected by handler".to_string(),
             nonce: 0,
@@ -2442,10 +2459,13 @@ mod tests {
     #[test]
     fn test_treasury_spend_empty_memo_is_representable() {
         // Empty memo is structurally valid; handler-level validation rejects it.
+        let treasury_did = KeyPair::generate().unwrap().did().clone();
         let recipient = KeyPair::generate().unwrap().did().clone();
 
         let operation = TreasuryProposalOperation::Spend {
+            treasury_did,
             amount: 100,
+            currency: "credits".to_string(),
             recipient,
             memo: String::new(),
             nonce: 0,
@@ -2460,6 +2480,7 @@ mod tests {
         let kp = KeyPair::generate().unwrap();
         let did = kp.did().clone();
         let domain_id = GovernanceDomainId::new("test-coop");
+        let treasury_did = KeyPair::generate().unwrap().did().clone();
         let recipient = KeyPair::generate().unwrap().did().clone();
 
         let mut proposal = Proposal::new(
@@ -2469,7 +2490,9 @@ mod tests {
             "Approve spend for emergency roof repair".to_string(),
             ProposalPayload::Treasury {
                 operation: TreasuryProposalOperation::Spend {
+                    treasury_did,
                     amount: 15000,
+                    currency: "credits".to_string(),
                     recipient,
                     memo: "Roof repair after storm damage".to_string(),
                     nonce: 0,


### PR DESCRIPTION
## Summary
- Switch `/treasury/{coop_id}/spend` proposal payload construction from `TreasuryProposalOperation::Withdraw` to `TreasuryProposalOperation::Spend`.
- Extend `TreasuryProposalOperation::Spend` schema with `treasury_did` and `currency` so translation has complete spend semantics.
- Replace governance translator `Spend -> NoOp` bridge with direct `Spend -> TreasuryEffect::Spend` mapping.
- Update spend-focused tests to assert `Spend` payload/effect parity.

## Scope Lock
- Includes only spend schema + translator parity and one end-to-end gateway proof update.
- No ledger execution semantics changes.
- No decision receipt/provenance model changes.
- No meaning-firewall ratchet relaxations.

## Verification
```bash
cd icn
RUSTC_WRAPPER= cargo test -p icn-core --lib meaning_firewall::tests::strict_governance_import_violations -- --exact --nocapture
RUSTC_WRAPPER= cargo test -p icn-core --lib meaning_firewall::tests::strict_gateway_governance_total_refs -- --exact --nocapture
RUSTC_WRAPPER= cargo test -p icn-gateway --features sled-storage --lib api::treasury::tests::test_propose_spend_creates_spend_operation_payload -- --exact --nocapture
RUSTC_WRAPPER= cargo test -p icn-core --test decision_executor_runtime_test test_treasury_spend_payload_translation_produces_treasury_spend_effect -- --exact --nocapture
cargo fmt --all --check
RUSTC_WRAPPER= cargo clippy -p icn-core -p icn-gateway --all-targets -- -D warnings
```

## Out of Scope
- Replay/idempotency work (already covered by prior PRs)
- Treasury nonce policy changes
- Additional gateway/governance refactors
