### PR TITLE
feat(core): treasury state_change_hash parity

### DIFF
--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -659,13 +659,13 @@ impl TreasuryExecutor for KernelTreasuryExecutor {
                         return Ok(ExecutionOutcome::Success {
                             receipt_id: receipt_id.clone(),
                             effects: vec![format!(
-                                "{:?} {} {} from treasury {} {}{} -> state_hash={}",
+                                "{:?} {} {} from treasury {} -> state_hash={} {}{}",
                                 operation.operation_type,
                                 operation.amount,
                                 operation.currency,
                                 operation.treasury_id,
-                                LEDGER_ENTRY_MARKER,
                                 result.entry_hash,
+                                LEDGER_ENTRY_MARKER,
                                 result.entry_hash
                             )],
                         });
@@ -1149,7 +1149,11 @@ fn execution_outcome_to_effect_result(outcome: ExecutionOutcome, effect_id: &str
             // Format: "... -> state_hash=<hash>"
             let state_change_hash = effects.iter().find_map(|e| {
                 e.find("-> state_hash=").map(|pos| {
-                    e[pos + 14..].to_string() // Skip "-> state_hash="
+                    e[pos + 14..]
+                        .split_whitespace()
+                        .next()
+                        .unwrap_or_default()
+                        .to_string() // Skip "-> state_hash="
                 })
             });
             let ledger_entry_id = effects.iter().find_map(|e| {

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -1158,7 +1158,7 @@ fn execution_outcome_to_effect_result(outcome: ExecutionOutcome, effect_id: &str
             });
             let ledger_entry_id = effects.iter().find_map(|e| {
                 let (_, entry_id) = e.rsplit_once(LEDGER_ENTRY_MARKER)?;
-                let entry_id = entry_id.split_whitespace().next()?.trim();
+                let entry_id = entry_id.split_whitespace().next()?;
                 if entry_id.is_empty() {
                     None
                 } else {

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -659,12 +659,13 @@ impl TreasuryExecutor for KernelTreasuryExecutor {
                         return Ok(ExecutionOutcome::Success {
                             receipt_id: receipt_id.clone(),
                             effects: vec![format!(
-                                "{:?} {} {} from treasury {} {}{}",
+                                "{:?} {} {} from treasury {} {}{} -> state_hash={}",
                                 operation.operation_type,
                                 operation.amount,
                                 operation.currency,
                                 operation.treasury_id,
                                 LEDGER_ENTRY_MARKER,
+                                result.entry_hash,
                                 result.entry_hash
                             )],
                         });
@@ -1153,7 +1154,7 @@ fn execution_outcome_to_effect_result(outcome: ExecutionOutcome, effect_id: &str
             });
             let ledger_entry_id = effects.iter().find_map(|e| {
                 let (_, entry_id) = e.rsplit_once(LEDGER_ENTRY_MARKER)?;
-                let entry_id = entry_id.trim();
+                let entry_id = entry_id.split_whitespace().next()?.trim();
                 if entry_id.is_empty() {
                     None
                 } else {

--- a/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
+++ b/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
@@ -692,7 +692,9 @@ async fn test_treasury_entry_persisted_with_provenance() {
         let record = exec_store.get(decision_hash).unwrap().unwrap();
         assert_eq!(record.status, ExecutionStatus::Confirmed);
         assert_eq!(record.ledger_entry_ids.len(), 1);
+        assert_eq!(record.state_change_hashes.len(), 1);
         let entry_hash = record.ledger_entry_ids[0].clone();
+        assert_eq!(record.state_change_hashes[0], entry_hash);
 
         let hash = content_hash_from_hex(&entry_hash);
         assert!(hash.is_ok(), "ledger entry id must parse as ContentHash");
@@ -873,6 +875,10 @@ async fn test_withdraw_payload_restart_resume_single_mutation() {
     let reopened_record = reopened_exec_store.get(decision_hash).unwrap().unwrap();
     assert_eq!(reopened_record.status, ExecutionStatus::Confirmed);
     assert_eq!(reopened_record.ledger_entry_ids, vec![entry_hash]);
+    assert_eq!(
+        reopened_record.state_change_hashes,
+        reopened_record.ledger_entry_ids
+    );
 }
 
 /// Test 12: Treasury Spend payload translates to a treasury spend effect.


### PR DESCRIPTION
## Summary
- emit `-> state_hash=<entry_hash>` marker for successful ledger-backed treasury execution effects
- keep `ledger_entry_id` extraction stable by parsing only the first token after `LEDGER_ENTRY_MARKER`
- extend withdraw restart/replay runtime test to assert `ExecutionRecord.state_change_hashes` is populated and stable

Closes #1213.

## Invariants
- Determinism: treasury state hash is derived from durable `entry_hash` (stable for same receipt idempotency result)
- Adversarial safety: no trust/validation gates relaxed
- Meaning Firewall ratchet: no new gateway governance import edges

## Verification
```bash
cd icn
cargo fmt --all --check
RUSTC_WRAPPER= cargo test -p icn-core --test decision_executor_runtime_test test_withdraw_payload_restart_resume_single_mutation -- --exact --nocapture
RUSTC_WRAPPER= cargo test -p icn-core --lib meaning_firewall::tests::strict_governance_import_violations -- --exact --nocapture
RUSTC_WRAPPER= cargo test -p icn-core --lib meaning_firewall::tests::strict_gateway_governance_total_refs -- --exact --nocapture
RUSTC_WRAPPER= cargo clippy -p icn-core --all-targets -- -D warnings
```
