### PR TITLE
feat(gateway): ledger decision-read boundary via icn-api (#1221)

### DIFF
--- a/icn/crates/icn-api/src/ledger.rs
+++ b/icn/crates/icn-api/src/ledger.rs
@@ -17,6 +17,26 @@ pub struct AccountBalance {
     pub amount: i64,
 }
 
+/// Canonical account delta for ledger history/read endpoints.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct LedgerAccountDeltaView {
+    pub account_id: String,
+    pub currency: String,
+    pub debit: Option<i64>,
+    pub credit: Option<i64>,
+}
+
+/// Canonical ledger entry view used by shared ledger service consumers.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct LedgerEntryView {
+    pub id: String,
+    pub timestamp: u64,
+    pub author: String,
+    pub accounts: Vec<LedgerAccountDeltaView>,
+    pub decision_receipt_id: Option<String>,
+    pub decision_hash: Option<String>,
+}
+
 /// Shared ledger service used by both RPC and gateway layers.
 pub struct LedgerService {
     ledger: Arc<RwLock<Ledger>>,
@@ -62,5 +82,43 @@ impl LedgerService {
                 })
                 .collect())
         }
+    }
+
+    /// Get ledger entries authorized by a decision hash.
+    ///
+    /// This is intentionally scoped for current gateway boundary work:
+    /// it provides a stable DTO surface while keeping storage/query details internal.
+    pub async fn get_entries_by_decision(
+        &self,
+        decision_hash: &str,
+        limit: usize,
+    ) -> Result<Vec<LedgerEntryView>, ApiError> {
+        let ledger = self.ledger.read().await;
+        let (entries, _total) = ledger
+            .get_entries_paginated_asc(0, 1000)
+            .map_err(|e| ApiError::LedgerError(e.to_string()))?;
+
+        Ok(entries
+            .into_iter()
+            .filter(|entry| entry.decision_hash.as_deref() == Some(decision_hash))
+            .take(limit)
+            .map(|entry| LedgerEntryView {
+                id: entry.id.map(|h| h.to_hex()).unwrap_or_default(),
+                timestamp: entry.timestamp,
+                author: entry.author.to_string(),
+                accounts: entry
+                    .accounts
+                    .iter()
+                    .map(|delta| LedgerAccountDeltaView {
+                        account_id: delta.account_id.to_string(),
+                        currency: delta.currency.clone(),
+                        debit: delta.debit,
+                        credit: delta.credit,
+                    })
+                    .collect(),
+                decision_receipt_id: entry.decision_receipt_id.clone(),
+                decision_hash: entry.decision_hash.clone(),
+            })
+            .collect())
     }
 }

--- a/icn/crates/icn-api/src/lib.rs
+++ b/icn/crates/icn-api/src/lib.rs
@@ -47,7 +47,7 @@ pub mod scopes;
 pub use compute::{ComputeService, SubmitTaskParams};
 pub use error::ApiError;
 pub use governance::GovernanceService;
-pub use ledger::{AccountBalance, LedgerService};
+pub use ledger::{AccountBalance, LedgerAccountDeltaView, LedgerEntryView, LedgerService};
 
 /// API context passed to service methods
 #[derive(Debug, Clone)]

--- a/icn/crates/icn-gateway/src/api/ledger.rs
+++ b/icn/crates/icn-gateway/src/api/ledger.rs
@@ -356,6 +356,7 @@ pub async fn get_history(
 pub async fn get_entries_by_decision(
     req: HttpRequest,
     ledger_mgr: web::Data<Arc<LedgerManager>>,
+    ledger_service: Option<web::Data<Option<Arc<icn_api::LedgerService>>>>,
     coop_id: web::Path<String>,
     query: web::Query<std::collections::HashMap<String, String>>,
 ) -> Result<HttpResponse> {
@@ -385,6 +386,53 @@ pub async fn get_entries_by_decision(
         .and_then(|s| s.parse().ok())
         .unwrap_or(DEFAULT_PAGE_SIZE)
         .clamp(1, MAX_PAGE_SIZE);
+
+    if let Some(service) = ledger_service
+        .as_ref()
+        .and_then(|service| service.get_ref().clone())
+    {
+        let filtered = service
+            .get_entries_by_decision(decision_hash, limit)
+            .await
+            .map_err(|e| GatewayError::InternalError(e.to_string()))?
+            .into_iter()
+            .map(|entry| TransactionHistoryEntry {
+                id: entry.id,
+                timestamp: entry.timestamp,
+                author: entry.author,
+                accounts: entry
+                    .accounts
+                    .into_iter()
+                    .map(|delta| AccountDeltaResponse {
+                        account_id: delta.account_id,
+                        currency: delta.currency,
+                        debit: delta.debit,
+                        credit: delta.credit,
+                    })
+                    .collect(),
+                decision_receipt_id: entry.decision_receipt_id,
+                decision_hash: entry.decision_hash,
+            })
+            .collect::<Vec<_>>();
+
+        let count = filtered.len();
+        let pagination = PaginationInfo {
+            total: Some(count),
+            next_cursor: None,
+            prev_cursor: None,
+            count,
+            has_more: false,
+            offset: None,
+            limit,
+        };
+
+        let response = TransactionHistoryResponse {
+            transactions: filtered,
+            pagination,
+        };
+
+        return Ok(HttpResponse::Ok().json(response));
+    }
 
     // Get all history entries (bounded scan for pilot)
     // TODO: Add index for decision_hash in ledger for efficient queries
@@ -753,6 +801,62 @@ mod tests {
         let resp: TransactionHistoryResponse = test::call_and_read_body_json(&app, req).await;
         // With only 1 item, there should be no next_cursor
         assert!(resp.pagination.next_cursor.is_none());
+    }
+
+    #[actix_web::test]
+    async fn test_get_entries_by_decision_prefers_shared_service_boundary() {
+        use crate::models::TransactionHistoryResponse;
+        use icn_ledger::{entry::JournalEntryBuilder, Ledger};
+
+        let ledger_mgr = Arc::new(LedgerManager::new());
+        let alice = IdentityBundle::generate().unwrap();
+        let bob = IdentityBundle::generate().unwrap();
+        let decision_hash = "a".repeat(64);
+
+        let service_store = Arc::new(icn_store::SledStore::temporary().unwrap());
+        let mut service_ledger = Ledger::new(service_store).unwrap();
+        let service_entry = JournalEntryBuilder::new(alice.did().clone())
+            .debit(alice.did().clone(), "hours".to_string(), 10)
+            .credit(bob.did().clone(), "hours".to_string(), 10)
+            .with_decision_provenance("receipt-123", decision_hash.as_str())
+            .build()
+            .unwrap();
+        service_ledger.append_entry(service_entry).await.unwrap();
+
+        let ledger_service = Arc::new(icn_api::LedgerService::new(Arc::new(
+            tokio::sync::RwLock::new(service_ledger),
+        )));
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(ledger_mgr.clone()))
+                .app_data(web::Data::new(Some(ledger_service)))
+                .service(web::scope("/ledger").service(get_entries_by_decision)),
+        )
+        .await;
+
+        let claims = TokenClaims {
+            sub: alice.did().to_string(),
+            iat: 1000000000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["ledger:read".to_string()],
+            exp: 9999999999,
+        };
+
+        let uri = format!(
+            "/ledger/test-coop/entries/by-decision?decision_hash={}",
+            decision_hash
+        );
+        let req = test::TestRequest::get().uri(&uri).to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp: TransactionHistoryResponse = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(resp.transactions.len(), 1);
+        assert_eq!(
+            resp.transactions[0].decision_hash.as_deref(),
+            Some(decision_hash.as_str())
+        );
+        assert_eq!(resp.pagination.count, 1);
     }
 
     #[actix_web::test]

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -468,6 +468,7 @@ impl GatewayServer {
         info!("Receipt store initialized");
 
         let governance_handle_for_service = self.governance_handle.clone();
+        let ledger_handle_for_service = self.ledger_handle.clone();
 
         // Create governance manager with Sled-backed action items
         // (uses GovernanceActor if handle available for proposals/votes/domains)
@@ -488,6 +489,8 @@ impl GatewayServer {
         let governance_service: Option<Arc<icn_api::GovernanceService>> =
             governance_handle_for_service
                 .map(|handle| Arc::new(icn_api::GovernanceService::new(handle)));
+        let ledger_service: Option<Arc<icn_api::LedgerService>> =
+            ledger_handle_for_service.map(|handle| Arc::new(icn_api::LedgerService::new(handle)));
 
         let invite_manager = Arc::new(crate::invite::InviteManager::new());
         let session_manager = Arc::new(crate::session::SessionManager::new());
@@ -917,6 +920,7 @@ impl GatewayServer {
                 .app_data(web::Data::new(steward_manager.clone()))
                 .app_data(web::Data::new(governance_manager.clone()))
                 .app_data(web::Data::new(governance_service.clone()))
+                .app_data(web::Data::new(ledger_service.clone()))
                 .app_data(web::Data::new(invite_manager.clone()))
                 .app_data(web::Data::new(session_manager.clone()))
                 .app_data(web::Data::new(trust_manager.clone()))


### PR DESCRIPTION
- [ ] **Blocked on #1225** (must merge first)

Depends on #1225. Merge this after #1225.

- Adds LedgerEntryView + LedgerAccountDeltaView DTOs and LedgerService::get_entries_by_decision in icn-api
- Wires optional LedgerService into gateway server app state
- Updates GET /ledger/{coop_id}/entries/by-decision to prefer shared service boundary (fallback preserved)
- Adds focused test proving boundary path is used

Verification:
- cargo fmt --all
- RUSTC_WRAPPER= cargo test -p icn-api
- RUSTC_WRAPPER= cargo test -p icn-gateway --features sled-storage --lib
- RUSTC_WRAPPER= cargo clippy --workspace --all-targets --all-features -- -D warnings