### PR TITLE
docs(ops): pilot runbook + one-command smoke verification (#1222)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -160,6 +160,7 @@ Deployment and operations documentation:
 - [operations-guide.md](guides/operations/operations-guide.md) - General operations
 - [backup-and-recovery.md](guides/operations/backup-and-recovery.md) - Backup procedures
 - [replication-operations.md](guides/operations/replication-operations.md) - Storage replication
+- [pilot-smoke.md](guides/operations/pilot-smoke.md) - Deterministic pilot linkage smoke runbook
 - [troubleshooting.md](guides/operations/troubleshooting.md) - Common issues and solutions
 
 ### Quick References

--- a/docs/guides/operations/README.md
+++ b/docs/guides/operations/README.md
@@ -8,6 +8,7 @@ This directory contains operational guides for running and maintaining ICN nodes
 - **troubleshooting.md** - Troubleshooting common issues
 - **operations-guide.md** - General operations guide
 - **replication-operations.md** - Storage replication operations
+- **pilot-smoke.md** - One-command pilot linkage smoke verification
 
 ## Related Documentation
 

--- a/docs/guides/operations/pilot-smoke.md
+++ b/docs/guides/operations/pilot-smoke.md
@@ -1,0 +1,98 @@
+# Pilot Smoke Runbook
+
+## Goal
+
+Provide a deterministic operator check for the pilot-critical linkage:
+
+`DecisionReceipt -> TreasuryEffect::Spend -> LedgerEntry`
+
+The smoke command fails fast with actionable output and exits non-zero on any broken link.
+
+## Preconditions
+
+- Run from repo root.
+- `cargo`, `rg`, and `tee` installed.
+- Rust dependencies already fetched.
+
+## Fresh Environment Setup
+
+1. Build the targeted test binary once:
+
+```bash
+cd icn
+RUSTC_WRAPPER= cargo test -p icn-core --test treasury_integration --no-run
+cd ..
+```
+
+2. Optional daemon startup check (not required for smoke test itself):
+
+```bash
+cd icn
+RUSTC_WRAPPER= cargo run --bin icnd > /tmp/icnd-pilot.log 2>&1 &
+ICN_DAEMON_PID=$!
+curl -sf http://localhost:8000/v1/healthz
+```
+
+## One-Command Smoke
+
+```bash
+bash scripts/pilot_smoke.sh
+```
+
+Expected successful tail:
+
+```text
+SMOKE PASS
+decision_receipt_id=...
+decision_hash=...
+ledger_entry_hash=...
+```
+
+## Runtime Contract
+
+- Default timeout per test command: `120s`
+- Override timeout: `ICN_SMOKE_TIMEOUT_SECS=180 bash scripts/pilot_smoke.sh`
+- Override logfile path: `ICN_SMOKE_LOGFILE=/tmp/pilot-smoke.log bash scripts/pilot_smoke.sh`
+- Exit code `0`: linkage verified
+- Exit code `1`: linkage/assertion failure
+- Exit code `2`: misconfiguration or missing local dependency
+
+## What The Script Asserts
+
+1. E2E provenance marker emitted (`ICN PILOT PROVENANCE CHAIN VERIFIED`)
+2. Decision markers present and non-empty:
+   - `PILOT_DECISION_RECEIPT_ID`
+   - `PILOT_DECISION_HASH`
+   - `PILOT_LEDGER_ENTRY_HASH`
+3. Spend execution log includes `expected_nonce=Some(...)`
+4. Field linkage assertions appear:
+   - `decision_receipt_id: MATCHES`
+   - `decision_hash: MATCHES`
+5. Both targeted tests report pass summaries
+
+## Failure Triage
+
+If the script fails:
+
+1. Open the emitted log file path from script output.
+2. Re-run failing test directly:
+
+```bash
+cd icn
+RUSTC_WRAPPER= cargo test -p icn-core --test treasury_integration test_decision_to_ledger_provenance_end_to_end -- --nocapture
+RUSTC_WRAPPER= cargo test -p icn-core --test treasury_integration test_ledger_entry_carries_decision_provenance -- --nocapture
+```
+
+3. Check for missing linkage fields in test output:
+   - `decision_receipt_id`
+   - `decision_hash`
+   - `expected_nonce`
+
+## Reset / Cleanup
+
+- Smoke script auto-removes its temporary logfile on success.
+- If daemon was started for optional health check:
+
+```bash
+kill "$ICN_DAEMON_PID"
+```

--- a/scripts/pilot_smoke.sh
+++ b/scripts/pilot_smoke.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Deterministic pilot smoke verification for decision -> effect -> ledger linkage.
+# Exits non-zero on any failed assertion.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ICN_DIR="$ROOT_DIR/icn"
+LOGFILE="${ICN_SMOKE_LOGFILE:-/tmp/icn_pilot_smoke_$$.log}"
+TIMEOUT_SECS="${ICN_SMOKE_TIMEOUT_SECS:-120}"
+
+if ! [[ "$TIMEOUT_SECS" =~ ^[0-9]+$ ]] || [ "$TIMEOUT_SECS" -le 0 ]; then
+    echo "ERROR: ICN_SMOKE_TIMEOUT_SECS must be a positive integer (got '$TIMEOUT_SECS')."
+    exit 2
+fi
+
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="gtimeout"
+else
+    TIMEOUT_BIN=""
+fi
+
+require_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "ERROR: required command '$1' is not available."
+        exit 2
+    fi
+}
+
+fail_with_hint() {
+    local reason="$1"
+    echo "SMOKE FAILED: $reason"
+    echo "Log file: $LOGFILE"
+    echo "Hint: rerun the failing test with '-- --nocapture' and inspect markers."
+    exit 1
+}
+
+assert_log_contains() {
+    local pattern="$1"
+    local reason="$2"
+    if ! rg -q "$pattern" "$LOGFILE"; then
+        fail_with_hint "$reason"
+    fi
+}
+
+run_test() {
+    local description="$1"
+    shift
+    local cmd=( "$@" )
+    echo "==> $description"
+    if [ -n "$TIMEOUT_BIN" ]; then
+        if ! "$TIMEOUT_BIN" "${TIMEOUT_SECS}s" "${cmd[@]}" 2>&1 | tee -a "$LOGFILE"; then
+            fail_with_hint "$description failed or exceeded ${TIMEOUT_SECS}s timeout"
+        fi
+    else
+        if ! "${cmd[@]}" 2>&1 | tee -a "$LOGFILE"; then
+            fail_with_hint "$description failed"
+        fi
+    fi
+}
+
+require_cmd cargo
+require_cmd rg
+require_cmd tee
+
+: > "$LOGFILE"
+
+cd "$ICN_DIR"
+
+run_test \
+    "Decision->Effect->Ledger E2E provenance test" \
+    env RUSTC_WRAPPER= cargo test -p icn-core --test treasury_integration \
+    test_decision_to_ledger_provenance_end_to_end -- --nocapture
+
+run_test \
+    "Ledger adapter provenance field test" \
+    env RUSTC_WRAPPER= cargo test -p icn-core --test treasury_integration \
+    test_ledger_entry_carries_decision_provenance -- --nocapture
+
+assert_log_contains "ICN PILOT PROVENANCE CHAIN VERIFIED" \
+    "provenance chain verification banner missing"
+assert_log_contains "PILOT_DECISION_RECEIPT_ID=" \
+    "decision_receipt_id marker missing"
+assert_log_contains "PILOT_DECISION_HASH=" \
+    "decision_hash marker missing"
+assert_log_contains "PILOT_LEDGER_ENTRY_HASH=" \
+    "ledger entry hash marker missing"
+assert_log_contains "expected_nonce=Some\\(" \
+    "expected_nonce was not observed in spend execution log"
+assert_log_contains "decision_receipt_id: ✅ MATCHES" \
+    "decision_receipt_id linkage assertion missing"
+assert_log_contains "decision_hash:[[:space:]]+✅ MATCHES" \
+    "decision_hash linkage assertion missing"
+assert_log_contains "test result: ok\\. 1 passed" \
+    "expected test pass summary missing"
+
+decision_receipt_id="$(rg -o "PILOT_DECISION_RECEIPT_ID=.*" "$LOGFILE" | tail -n1 | cut -d= -f2-)"
+decision_hash="$(rg -o "PILOT_DECISION_HASH=.*" "$LOGFILE" | tail -n1 | cut -d= -f2-)"
+ledger_entry_hash="$(rg -o "PILOT_LEDGER_ENTRY_HASH=.*" "$LOGFILE" | tail -n1 | cut -d= -f2-)"
+
+if [ -z "$decision_receipt_id" ] || [ -z "$decision_hash" ] || [ -z "$ledger_entry_hash" ]; then
+    fail_with_hint "one or more pilot markers were empty"
+fi
+
+echo ""
+echo "SMOKE PASS"
+echo "decision_receipt_id=$decision_receipt_id"
+echo "decision_hash=$decision_hash"
+echo "ledger_entry_hash=$ledger_entry_hash"
+
+rm -f "$LOGFILE"

--- a/scripts/pilot_smoke.sh
+++ b/scripts/pilot_smoke.sh
@@ -49,10 +49,17 @@ run_test() {
     local description="$1"
     shift
     local cmd=( "$@" )
+    local status=0
     echo "==> $description"
     if [ -n "$TIMEOUT_BIN" ]; then
-        if ! "$TIMEOUT_BIN" "${TIMEOUT_SECS}s" "${cmd[@]}" 2>&1 | tee -a "$LOGFILE"; then
-            fail_with_hint "$description failed or exceeded ${TIMEOUT_SECS}s timeout"
+        set +e
+        "$TIMEOUT_BIN" "${TIMEOUT_SECS}s" "${cmd[@]}" 2>&1 | tee -a "$LOGFILE"
+        status=${PIPESTATUS[0]}
+        set -e
+        if [ "$status" -eq 124 ] || [ "$status" -eq 137 ]; then
+            fail_with_hint "$description exceeded ${TIMEOUT_SECS}s timeout (try warm-cache: 'cd icn && RUSTC_WRAPPER= cargo test -p icn-core --test treasury_integration --no-run')"
+        elif [ "$status" -ne 0 ]; then
+            fail_with_hint "$description failed"
         fi
     else
         if ! "${cmd[@]}" 2>&1 | tee -a "$LOGFILE"; then


### PR DESCRIPTION
- [ ] **Blocked on #1228** (and implicitly #1227/#1225)

Implements #1222 deterministic operator verification for decision->effect->ledger linkage.

What this adds:
- scripts/pilot_smoke.sh (one-command smoke; non-zero on any failed linkage assertion)
- docs/guides/operations/pilot-smoke.md (env, startup, verification, reset, failure triage)
- docs index links in docs/guides/operations/README.md and docs/INDEX.md

Smoke contract:
- validates decision marker chain and ledger linkage markers
- validates spend execution log includes expected_nonce
- validates targeted provenance tests pass
- prints decision_receipt_id, decision_hash, ledger_entry_hash on success

Verification run:
- bash scripts/pilot_smoke.sh