### PR TITLE
test(governance): lock pilot treasury routing to effect path

### DIFF
--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -399,7 +399,9 @@ mod tests {
         for payload in pilot_cases {
             let effects = translate_payload_to_effects(&payload, "receipt-pilot", "hash-pilot");
             assert!(
-                !effects.iter().any(|e| matches!(e, KernelEffect::NoOp { .. })),
+                !effects
+                    .iter()
+                    .any(|e| matches!(e, KernelEffect::NoOp { .. })),
                 "pilot treasury operation must not translate to NoOp: {payload:?}"
             );
         }

--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -284,6 +284,8 @@ fn translate_federation_proposal(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use icn_governance::TreasuryProposalOperation;
+    use icn_identity::Did;
 
     #[test]
     fn test_translate_treasury_spend_preserves_decision_provenance() {
@@ -341,5 +343,63 @@ mod tests {
         let effects = translate_payload_to_effects(&payload, "receipt-abc", "decision-hash-abc");
         assert_eq!(effects.len(), 1);
         assert!(matches!(effects[0], KernelEffect::NoOp { .. }));
+    }
+
+    #[test]
+    fn test_pilot_treasury_ops_do_not_fall_back_to_noop_with_legacy_env_flag() {
+        // Legacy env gating was removed from runtime; keep this regression test to
+        // ensure pilot treasury operations remain effect-path translated even when
+        // old env flags are present.
+        std::env::set_var("ICN_USE_EFFECT_PATH", "0");
+
+        let treasury_did: Did = "did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9"
+            .parse()
+            .expect("valid did");
+        let recipient: Did = "did:icn:z8eQZfY3RY75YwQ6MrFCHt9phbi3HGx1caFXE3291ow8t"
+            .parse()
+            .expect("valid did");
+
+        let pilot_cases = vec![
+            ProposalPayload::Treasury {
+                operation: TreasuryProposalOperation::Spend {
+                    treasury_did: treasury_did.clone(),
+                    amount: 10,
+                    currency: "hours".to_string(),
+                    recipient: recipient.clone(),
+                    memo: "pilot spend".to_string(),
+                    nonce: 1,
+                },
+            },
+            ProposalPayload::Treasury {
+                operation: TreasuryProposalOperation::Withdraw {
+                    treasury_did: treasury_did.clone(),
+                    recipient: recipient.clone(),
+                    amount: 11,
+                    currency: "hours".to_string(),
+                    purpose: "pilot withdraw".to_string(),
+                    nonce: 2,
+                    budget_id: None,
+                },
+            },
+            ProposalPayload::Treasury {
+                operation: TreasuryProposalOperation::CreateBudget {
+                    treasury_did,
+                    purpose: "pilot-budget".to_string(),
+                    amount: 12,
+                    currency: "hours".to_string(),
+                    period_end: Some(42),
+                },
+            },
+        ];
+
+        for payload in pilot_cases {
+            let effects = translate_payload_to_effects(&payload, "receipt-pilot", "hash-pilot");
+            assert!(
+                !effects.iter().any(|e| matches!(e, KernelEffect::NoOp { .. })),
+                "pilot treasury operation must not translate to NoOp: {payload:?}"
+            );
+        }
+
+        std::env::remove_var("ICN_USE_EFFECT_PATH");
     }
 }

--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -286,6 +286,9 @@ mod tests {
     use super::*;
     use icn_governance::TreasuryProposalOperation;
     use icn_identity::Did;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_translate_treasury_spend_preserves_decision_provenance() {
@@ -347,6 +350,7 @@ mod tests {
 
     #[test]
     fn test_pilot_treasury_ops_do_not_fall_back_to_noop_with_legacy_env_flag() {
+        let _env_guard = ENV_LOCK.lock().expect("env lock");
         // Legacy env gating was removed from runtime; keep this regression test to
         // ensure pilot treasury operations remain effect-path translated even when
         // old env flags are present.

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -164,6 +164,8 @@ mod tests {
     use icn_kernel_api::events::SystemEvent;
     use std::sync::{Arc, Mutex};
 
+    type CapturedEffects = Arc<Mutex<Vec<(Vec<KernelEffect>, String)>>>;
+
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
@@ -173,7 +175,7 @@ mod tests {
         // still route through the effect-path subscription callback.
         std::env::set_var("ICN_USE_EFFECT_PATH", "0");
 
-        let captured: Arc<Mutex<Vec<(Vec<KernelEffect>, String)>>> = Arc::new(Mutex::new(vec![]));
+        let captured: CapturedEffects = Arc::new(Mutex::new(vec![]));
         let sink = captured.clone();
         let subscription = create_effect_subscription(move |effects, decision_receipt_id| {
             sink.lock()
@@ -212,7 +214,10 @@ mod tests {
         assert_eq!(got.len(), 1, "effect callback should fire exactly once");
         assert_eq!(got[0].1, "gov:domain-pilot:pr-pilot-1:receipt");
         assert!(
-            matches!(got[0].0.first(), Some(KernelEffect::Treasury(TreasuryEffect::Spend { .. }))),
+            matches!(
+                got[0].0.first(),
+                Some(KernelEffect::Treasury(TreasuryEffect::Spend { .. }))
+            ),
             "pilot treasury proposal should route to TreasuryEffect::Spend via effect path"
         );
 

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -155,3 +155,64 @@ where
         }
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use icn_governance::{ProposalPayload, TreasuryProposalOperation};
+    use icn_identity::Did;
+    use icn_kernel_api::events::SystemEvent;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn test_pilot_proposal_uses_effect_subscription_even_with_legacy_env_flag() {
+        // Legacy env switch was removed; this test proves pilot treasury proposals
+        // still route through the effect-path subscription callback.
+        std::env::set_var("ICN_USE_EFFECT_PATH", "0");
+
+        let captured: Arc<Mutex<Vec<(Vec<KernelEffect>, String)>>> = Arc::new(Mutex::new(vec![]));
+        let sink = captured.clone();
+        let subscription = create_effect_subscription(move |effects, decision_receipt_id| {
+            sink.lock()
+                .expect("capture lock")
+                .push((effects, decision_receipt_id));
+        });
+
+        let treasury_did: Did = "did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9"
+            .parse()
+            .expect("valid did");
+        let recipient: Did = "did:icn:z8eQZfY3RY75YwQ6MrFCHt9phbi3HGx1caFXE3291ow8t"
+            .parse()
+            .expect("valid did");
+
+        let payload = ProposalPayload::Treasury {
+            operation: TreasuryProposalOperation::Spend {
+                treasury_did,
+                amount: 5,
+                currency: "hours".to_string(),
+                recipient,
+                memo: "pilot".to_string(),
+                nonce: 7,
+            },
+        };
+
+        let event = SystemEvent::ProposalAccepted {
+            proposal_id: "pr-pilot-1".to_string(),
+            domain_id: "domain-pilot".to_string(),
+            payload: serde_json::to_value(payload).expect("serialize payload"),
+            decided_at: 1_700_000_000,
+        };
+
+        subscription(event);
+
+        let got = captured.lock().expect("capture lock");
+        assert_eq!(got.len(), 1, "effect callback should fire exactly once");
+        assert_eq!(got[0].1, "gov:domain-pilot:pr-pilot-1:receipt");
+        assert!(
+            matches!(got[0].0.first(), Some(KernelEffect::Treasury(TreasuryEffect::Spend { .. }))),
+            "pilot treasury proposal should route to TreasuryEffect::Spend via effect path"
+        );
+
+        std::env::remove_var("ICN_USE_EFFECT_PATH");
+    }
+}

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -164,8 +164,11 @@ mod tests {
     use icn_kernel_api::events::SystemEvent;
     use std::sync::{Arc, Mutex};
 
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
     #[test]
     fn test_pilot_proposal_uses_effect_subscription_even_with_legacy_env_flag() {
+        let _env_guard = ENV_LOCK.lock().expect("env lock");
         // Legacy env switch was removed; this test proves pilot treasury proposals
         // still route through the effect-path subscription callback.
         std::env::set_var("ICN_USE_EFFECT_PATH", "0");


### PR DESCRIPTION
## Summary
- add regression tests that lock pilot-required treasury proposal types to effect-path translation
- prove pilot treasury proposal routing stays on effect subscription path even if legacy env flags are set
- prevent silent NoOp fallback for pilot treasury cases used by pilot proof flow

## Scope
Pilot-required set is intentionally minimal and tied to the current proof path:
- types exercised by `scripts/pilot_chain_demo.sh`
- types exercised in `icn-core/tests/treasury_integration.rs`

## Why
Sprint P0-C requires that pilot types cannot regress to legacy execution paths under misconfiguration. These tests ensure env-flag drift cannot silently reroute pilot treasury execution semantics.

## Verification
- `cd icn && cargo test -p icn-governance-actor test_pilot_treasury_ops_do_not_fall_back_to_noop_with_legacy_env_flag -- --nocapture`
- `cd icn && cargo test -p icn-governance-actor test_pilot_proposal_uses_effect_subscription_even_with_legacy_env_flag -- --nocapture`
- `cd icn && cargo test -p icn-core --test effect_path_tripwire`
- `cd icn && cargo test -p icn-core --test treasury_integration`
