### PR TITLE
ops(pilot): deterministic smoke mode + summary artifact

### DIFF
--- a/docs/ops/runbooks/07-pilot-vertical-slice-smoke.md
+++ b/docs/ops/runbooks/07-pilot-vertical-slice-smoke.md
@@ -45,7 +45,9 @@ Confirm all of the following in output:
 2. `PILOT_LEDGER_ENTRY_HASH=...`
 3. `TRIPWIRE: Tests passed`
 4. Final banner: `PILOT INVARIANT PROVEN`
-5. In deterministic mode: `DETERMINISM VERIFIED`
+5. In deterministic mode:
+   - `DETERMINISM VERIFIED` when all compared fields match under active policy
+   - `DETERMINISM PARTIAL` when `decision_receipt_id` and `decision_hash` match but `ledger_entry_hash` differs (non-strict mode)
 
 The script exit code must be `0`.
 
@@ -57,6 +59,10 @@ Deterministic mode writes `tmp/pilot_chain_summary.json` with:
 - `decision_receipt_id`
 - `decision_hash`
 - `ledger_entry_hash`
+
+Strict toggle:
+
+- `PILOT_DETERMINISTIC_STRICT=1` makes `ledger_entry_hash` mismatch a hard failure.
 
 ## Failure Handling
 

--- a/docs/ops/runbooks/07-pilot-vertical-slice-smoke.md
+++ b/docs/ops/runbooks/07-pilot-vertical-slice-smoke.md
@@ -23,6 +23,14 @@ cd "$(git rev-parse --show-toplevel)"
 bash scripts/pilot_chain_demo.sh
 ```
 
+Deterministic mode (run-twice invariant comparison + JSON artifact):
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+PILOT_DETERMINISTIC=1 bash scripts/pilot_chain_demo.sh
+cat tmp/pilot_chain_summary.json
+```
+
 2. The script executes two tests:
    - `test_decision_to_ledger_provenance_end_to_end`
    - `test_ledger_entry_carries_decision_provenance`
@@ -37,8 +45,18 @@ Confirm all of the following in output:
 2. `PILOT_LEDGER_ENTRY_HASH=...`
 3. `TRIPWIRE: Tests passed`
 4. Final banner: `PILOT INVARIANT PROVEN`
+5. In deterministic mode: `DETERMINISM VERIFIED`
 
 The script exit code must be `0`.
+
+Deterministic mode writes `tmp/pilot_chain_summary.json` with:
+
+- `deterministic_mode`
+- `timestamp_utc`
+- `gateway_url`
+- `decision_receipt_id`
+- `decision_hash`
+- `ledger_entry_hash`
 
 ## Failure Handling
 

--- a/scripts/pilot_chain_demo.sh
+++ b/scripts/pilot_chain_demo.sh
@@ -189,11 +189,14 @@ if [ "$DETERMINISTIC_MODE" = "1" ]; then
     fi
 
     if [ "$DET_FAIL" -ne 0 ]; then
+        echo "Strict mode enabled; failing due to ledger_entry_hash drift."
         echo "Deterministic check failed."
         exit 1
     fi
     if [ "$LEDGER_HASH_MISMATCH" -eq 1 ] && [ "$DETERMINISTIC_STRICT" != "1" ]; then
-        echo "⚠️ DETERMINISM PARTIAL: decision ids/hashes match; ledger_entry_hash differs (set PILOT_DETERMINISTIC_STRICT=1 to enforce)"
+        echo "⚠️ DETERMINISM PARTIAL: decision ids/hashes match"
+        echo "ledger_entry_hash differs."
+        echo "set PILOT_DETERMINISTIC_STRICT=1 to enforce ledger hash stability."
     else
         echo "✅ DETERMINISM VERIFIED: run1 and run2 invariant identifiers match under active policy"
     fi

--- a/scripts/pilot_chain_demo.sh
+++ b/scripts/pilot_chain_demo.sh
@@ -160,6 +160,7 @@ if [ "$DETERMINISTIC_MODE" = "1" ]; then
     RUN2_LEDGER_ENTRY_HASH="$LEDGER_ENTRY_HASH"
 
     DET_FAIL=0
+    LEDGER_HASH_MISMATCH=0
     if [ "$RUN1_DECISION_RECEIPT_ID" != "$RUN2_DECISION_RECEIPT_ID" ]; then
         echo "❌ DETERMINISM FAILED: decision_receipt_id mismatch"
         echo "  run1: $RUN1_DECISION_RECEIPT_ID"
@@ -173,6 +174,7 @@ if [ "$DETERMINISTIC_MODE" = "1" ]; then
         DET_FAIL=1
     fi
     if [ "$RUN1_LEDGER_ENTRY_HASH" != "$RUN2_LEDGER_ENTRY_HASH" ]; then
+        LEDGER_HASH_MISMATCH=1
         if [ "$DETERMINISTIC_STRICT" = "1" ]; then
             echo "❌ DETERMINISM FAILED: ledger_entry_hash mismatch"
             echo "  run1: $RUN1_LEDGER_ENTRY_HASH"
@@ -190,7 +192,11 @@ if [ "$DETERMINISTIC_MODE" = "1" ]; then
         echo "Deterministic check failed."
         exit 1
     fi
-    echo "✅ DETERMINISM VERIFIED: run1 and run2 invariant identifiers match"
+    if [ "$LEDGER_HASH_MISMATCH" -eq 1 ] && [ "$DETERMINISTIC_STRICT" != "1" ]; then
+        echo "⚠️ DETERMINISM PARTIAL: decision ids/hashes match; ledger_entry_hash differs (set PILOT_DETERMINISTIC_STRICT=1 to enforce)"
+    else
+        echo "✅ DETERMINISM VERIFIED: run1 and run2 invariant identifiers match under active policy"
+    fi
     DECISION_RECEIPT_ID="$RUN1_DECISION_RECEIPT_ID"
     DECISION_HASH="$RUN1_DECISION_HASH"
     LEDGER_ENTRY_HASH="$RUN1_LEDGER_ENTRY_HASH"

--- a/scripts/pilot_chain_demo.sh
+++ b/scripts/pilot_chain_demo.sh
@@ -10,82 +10,190 @@
 
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+cd "$(git rev-parse --show-toplevel)"
 
-LOGFILE="/tmp/icn_pilot_demo_$$.log"
+DETERMINISTIC_MODE="${PILOT_DETERMINISTIC:-0}"
+DETERMINISTIC_STRICT="${PILOT_DETERMINISTIC_STRICT:-0}"
+GATEWAY_URL="${ICN_GATEWAY_URL:-http://127.0.0.1:7845}"
+SUMMARY_DIR="tmp"
+SUMMARY_FILE="${SUMMARY_DIR}/pilot_chain_summary.json"
 
-echo "╔══════════════════════════════════════════════════════════════════╗"
-echo "║         ICN PILOT: Decision → Effect → Ledger Demo               ║"
-echo "╚══════════════════════════════════════════════════════════════════╝"
-echo
+DECISION_RECEIPT_ID=""
+DECISION_HASH=""
+LEDGER_ENTRY_HASH=""
 
-# Move into the Rust workspace
-cd icn
+json_escape() {
+    local value="$1"
+    value="${value//\\/\\\\}"
+    value="${value//\"/\\\"}"
+    value="${value//$'\n'/\\n}"
+    printf '%s' "$value"
+}
 
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "[1/2] E2E Chain Test: Decision → Executor → Ledger"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo
-cargo test -p icn-core --test treasury_integration \
-    test_decision_to_ledger_provenance_end_to_end \
-    -- --nocapture 2>&1 | tee "$LOGFILE"
+write_summary_json() {
+    mkdir -p "$SUMMARY_DIR"
+    local timestamp_utc
+    timestamp_utc="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    cat >"$SUMMARY_FILE" <<EOF
+{
+  "deterministic_mode": $([ "$DETERMINISTIC_MODE" = "1" ] && echo "true" || echo "false"),
+  "timestamp_utc": "$(json_escape "$timestamp_utc")",
+  "gateway_url": "$(json_escape "$GATEWAY_URL")",
+  "decision_receipt_id": "$(json_escape "$DECISION_RECEIPT_ID")",
+  "decision_hash": "$(json_escape "$DECISION_HASH")",
+  "ledger_entry_hash": "$(json_escape "$LEDGER_ENTRY_HASH")"
+}
+EOF
+}
 
-echo
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "[2/2] Adapter Test: LedgerServiceImpl → JournalEntry"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo
-cargo test -p icn-core --test treasury_integration \
-    test_ledger_entry_carries_decision_provenance \
-    -- --nocapture 2>&1 | tee -a "$LOGFILE"
+run_demo_once() {
+    local run_label="$1"
+    local logfile="/tmp/icn_pilot_demo_${run_label}_$$.log"
+    local fail=0
 
-echo
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "TRIPWIRE VERIFICATION"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "╔══════════════════════════════════════════════════════════════════╗"
+    echo "║         ICN PILOT: Decision → Effect → Ledger Demo               ║"
+    echo "╚══════════════════════════════════════════════════════════════════╝"
+    echo
+    echo "Run label: ${run_label}"
+    echo "Gateway URL: ${GATEWAY_URL}"
+    echo
 
-# Machine-assertable tripwires
-FAIL=0
+    # Move into the Rust workspace
+    cd icn
 
-if grep -q "ICN PILOT PROVENANCE CHAIN VERIFIED" "$LOGFILE"; then
-    echo "✅ TRIPWIRE: 'ICN PILOT PROVENANCE CHAIN VERIFIED' found"
-else
-    echo "❌ TRIPWIRE FAILED: 'ICN PILOT PROVENANCE CHAIN VERIFIED' missing"
-    FAIL=1
-fi
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "[1/2] E2E Chain Test: Decision → Executor → Ledger"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo
+    cargo test -p icn-core --test treasury_integration \
+        test_decision_to_ledger_provenance_end_to_end \
+        -- --nocapture 2>&1 | tee "$logfile"
 
-if grep -q "PILOT_LEDGER_ENTRY_HASH=" "$LOGFILE"; then
-    HASH=$(grep "PILOT_LEDGER_ENTRY_HASH=" "$LOGFILE" | cut -d= -f2)
-    echo "✅ TRIPWIRE: Ledger entry hash = $HASH"
-else
-    echo "❌ TRIPWIRE FAILED: 'PILOT_LEDGER_ENTRY_HASH' missing"
-    FAIL=1
-fi
+    echo
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "[2/2] Adapter Test: LedgerServiceImpl → JournalEntry"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo
+    cargo test -p icn-core --test treasury_integration \
+        test_ledger_entry_carries_decision_provenance \
+        -- --nocapture 2>&1 | tee -a "$logfile"
 
-if grep -q "✅ MATCHES" "$LOGFILE"; then
-    echo "✅ TRIPWIRE: Provenance field assertions passed"
-else
-    echo "❌ TRIPWIRE FAILED: '✅ MATCHES' not found"
-    FAIL=1
-fi
+    echo
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "TRIPWIRE VERIFICATION"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-if grep -q "test.*ok" "$LOGFILE"; then
-    echo "✅ TRIPWIRE: Tests passed"
-else
-    echo "❌ TRIPWIRE FAILED: No 'test.*ok' found"
-    FAIL=1
-fi
+    if grep -q "ICN PILOT PROVENANCE CHAIN VERIFIED" "$logfile"; then
+        echo "✅ TRIPWIRE: 'ICN PILOT PROVENANCE CHAIN VERIFIED' found"
+    else
+        echo "❌ TRIPWIRE FAILED: 'ICN PILOT PROVENANCE CHAIN VERIFIED' missing"
+        fail=1
+    fi
 
-echo
-if [ $FAIL -eq 0 ]; then
+    if grep -q "PILOT_LEDGER_ENTRY_HASH=" "$logfile"; then
+        LEDGER_ENTRY_HASH=$(grep -m1 "^PILOT_LEDGER_ENTRY_HASH=" "$logfile" | cut -d= -f2-)
+        echo "✅ TRIPWIRE: Ledger entry hash = $LEDGER_ENTRY_HASH"
+    else
+        echo "❌ TRIPWIRE FAILED: 'PILOT_LEDGER_ENTRY_HASH' missing"
+        fail=1
+    fi
+
+    if grep -q "^PILOT_DECISION_RECEIPT_ID=" "$logfile"; then
+        DECISION_RECEIPT_ID=$(grep -m1 "^PILOT_DECISION_RECEIPT_ID=" "$logfile" | cut -d= -f2-)
+        echo "✅ TRIPWIRE: Decision receipt id = $DECISION_RECEIPT_ID"
+    else
+        echo "❌ TRIPWIRE FAILED: 'PILOT_DECISION_RECEIPT_ID' missing"
+        fail=1
+    fi
+
+    if grep -q "^PILOT_DECISION_HASH=" "$logfile"; then
+        DECISION_HASH=$(grep -m1 "^PILOT_DECISION_HASH=" "$logfile" | cut -d= -f2-)
+        echo "✅ TRIPWIRE: Decision hash = $DECISION_HASH"
+    else
+        echo "❌ TRIPWIRE FAILED: 'PILOT_DECISION_HASH' missing"
+        fail=1
+    fi
+
+    if grep -q "✅ MATCHES" "$logfile"; then
+        echo "✅ TRIPWIRE: Provenance field assertions passed"
+    else
+        echo "❌ TRIPWIRE FAILED: '✅ MATCHES' not found"
+        fail=1
+    fi
+
+    if grep -q "test.*ok" "$logfile"; then
+        echo "✅ TRIPWIRE: Tests passed"
+    else
+        echo "❌ TRIPWIRE FAILED: No 'test.*ok' found"
+        fail=1
+    fi
+
+    cd ..
+    if [ "$fail" -eq 0 ]; then
+        echo "════════════════════════════════════════════════════════════════════"
+        echo "  PILOT INVARIANT PROVEN: All tripwires passed"
+        echo "════════════════════════════════════════════════════════════════════"
+        rm -f "$logfile"
+        return 0
+    fi
+
     echo "════════════════════════════════════════════════════════════════════"
-    echo "  PILOT INVARIANT PROVEN: All tripwires passed"
+    echo "  PILOT INVARIANT FAILED: See $logfile for details"
     echo "════════════════════════════════════════════════════════════════════"
-    rm -f "$LOGFILE"
-    exit 0
-else
-    echo "════════════════════════════════════════════════════════════════════"
-    echo "  PILOT INVARIANT FAILED: See $LOGFILE for details"
-    echo "════════════════════════════════════════════════════════════════════"
-    exit 1
+    return 1
+}
+
+run_demo_once "run1"
+
+RUN1_DECISION_RECEIPT_ID="$DECISION_RECEIPT_ID"
+RUN1_DECISION_HASH="$DECISION_HASH"
+RUN1_LEDGER_ENTRY_HASH="$LEDGER_ENTRY_HASH"
+
+if [ "$DETERMINISTIC_MODE" = "1" ]; then
+    echo
+    echo "Deterministic mode enabled: running second pass for invariant comparison..."
+    run_demo_once "run2"
+
+    RUN2_DECISION_RECEIPT_ID="$DECISION_RECEIPT_ID"
+    RUN2_DECISION_HASH="$DECISION_HASH"
+    RUN2_LEDGER_ENTRY_HASH="$LEDGER_ENTRY_HASH"
+
+    DET_FAIL=0
+    if [ "$RUN1_DECISION_RECEIPT_ID" != "$RUN2_DECISION_RECEIPT_ID" ]; then
+        echo "❌ DETERMINISM FAILED: decision_receipt_id mismatch"
+        echo "  run1: $RUN1_DECISION_RECEIPT_ID"
+        echo "  run2: $RUN2_DECISION_RECEIPT_ID"
+        DET_FAIL=1
+    fi
+    if [ "$RUN1_DECISION_HASH" != "$RUN2_DECISION_HASH" ]; then
+        echo "❌ DETERMINISM FAILED: decision_hash mismatch"
+        echo "  run1: $RUN1_DECISION_HASH"
+        echo "  run2: $RUN2_DECISION_HASH"
+        DET_FAIL=1
+    fi
+    if [ "$RUN1_LEDGER_ENTRY_HASH" != "$RUN2_LEDGER_ENTRY_HASH" ]; then
+        if [ "$DETERMINISTIC_STRICT" = "1" ]; then
+            echo "❌ DETERMINISM FAILED: ledger_entry_hash mismatch"
+            echo "  run1: $RUN1_LEDGER_ENTRY_HASH"
+            echo "  run2: $RUN2_LEDGER_ENTRY_HASH"
+            DET_FAIL=1
+        else
+            echo "⚠️ DETERMINISM WARN: ledger_entry_hash mismatch"
+            echo "  run1: $RUN1_LEDGER_ENTRY_HASH"
+            echo "  run2: $RUN2_LEDGER_ENTRY_HASH"
+            echo "  continuing because PILOT_DETERMINISTIC_STRICT is not set"
+        fi
+    fi
+
+    if [ "$DET_FAIL" -ne 0 ]; then
+        echo "Deterministic check failed."
+        exit 1
+    fi
+    echo "✅ DETERMINISM VERIFIED: run1 and run2 invariant identifiers match"
+    DECISION_RECEIPT_ID="$RUN1_DECISION_RECEIPT_ID"
+    DECISION_HASH="$RUN1_DECISION_HASH"
+    LEDGER_ENTRY_HASH="$RUN1_LEDGER_ENTRY_HASH"
+    write_summary_json
+    echo "Summary artifact written to $SUMMARY_FILE"
 fi


### PR DESCRIPTION
## Summary
- update `scripts/pilot_chain_demo.sh` to run from repo root via `git rev-parse --show-toplevel`
- add `PILOT_DETERMINISTIC=1` mode with run-twice comparison for pilot provenance identifiers
- emit deterministic summary artifact at `tmp/pilot_chain_summary.json`
- document deterministic usage and artifact keys in `docs/ops/runbooks/07-pilot-vertical-slice-smoke.md`

## Deterministic behavior
- always enforces run-twice equality for:
  - `decision_receipt_id`
  - `decision_hash`
- compares `ledger_entry_hash` as well
  - default: warns on mismatch because current test harness uses fresh key material each run
  - strict mode (`PILOT_DETERMINISTIC_STRICT=1`): mismatch is a hard failure

## Verification
- `bash scripts/pilot_chain_demo.sh`
- `PILOT_DETERMINISTIC=1 bash scripts/pilot_chain_demo.sh`
- `cat tmp/pilot_chain_summary.json`
