### PR TITLE
ci(pilot): deterministic provenance check + timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,6 +587,7 @@ jobs:
     name: Pilot Provenance Invariant
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [changes, test]
     steps:
       - uses: actions/checkout@v6
@@ -601,4 +602,6 @@ jobs:
           workspaces: "icn -> target"
 
       - name: Run pilot chain demo
+        env:
+          PILOT_DETERMINISTIC: "1"
         run: ./scripts/pilot_chain_demo.sh


### PR DESCRIPTION
## Summary
- add `timeout-minutes: 15` to `pilot-provenance` to prevent long-hanging CI jobs
- run pilot provenance smoke with `PILOT_DETERMINISTIC=1`

## Why
- deterministic mode is now supported by `scripts/pilot_chain_demo.sh` and should be exercised in CI
- explicit timeout reduces CI tail-risk and stuck-run cost

## Verification
- workflow config updated in `.github/workflows/ci.yml` under `pilot-provenance`
- change scope is CI-only (1 file)
