### PR TITLE
feat(sdk): add Flow C treasury/governance methods

### DIFF
--- a/sdk/typescript/src/index.test.ts
+++ b/sdk/typescript/src/index.test.ts
@@ -589,6 +589,157 @@ describe('compute task cancellation', () => {
   });
 });
 
+describe('flow c sdk methods', () => {
+  it('should get treasury balance via flow c alias route', async () => {
+    const mockResponse = {
+      treasury_did: 'did:icn:treasury123',
+      balances: { credits: 4200 },
+    };
+
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockResponse,
+    });
+
+    const client = new ICNClient({
+      baseUrl: 'http://localhost:8080',
+      token: 'test-token',
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    const result = await client.treasury.balance('coop-alpha');
+
+    expect(result).toEqual(mockResponse);
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:8080/v1/coops/coop-alpha/treasury/balance');
+    expect(options.method).toBe('GET');
+  });
+
+  it('should propose treasury spend via flow c alias route', async () => {
+    const mockResponse = {
+      status: 'proposal_created',
+      message: 'Treasury spend requires governance approval',
+      operation: 'spend',
+      proposal_id: 'prop-abc',
+      coop_id: 'coop-alpha',
+      amount: 150,
+      currency: 'credits',
+      recipient: 'did:icn:bob',
+      memo: 'equipment',
+      nonce: 7,
+    };
+
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 202,
+      json: async () => mockResponse,
+    });
+
+    const client = new ICNClient({
+      baseUrl: 'http://localhost:8080',
+      token: 'test-token',
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    const req = {
+      amount: 150,
+      recipient: 'did:icn:bob',
+      memo: 'equipment',
+      currency: 'credits',
+    };
+    const result = await client.governance.proposeSpend('coop-alpha', req);
+
+    expect(result).toEqual(mockResponse);
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:8080/v1/coops/coop-alpha/proposals');
+    expect(options.method).toBe('POST');
+    expect(JSON.parse(options.body)).toEqual(req);
+  });
+
+  it('should vote via flow c alias route with choice and comment', async () => {
+    const mockResponse = {
+      id: 'prop-abc',
+      domain_id: 'coop-alpha',
+      proposer: 'did:icn:alice',
+      title: 'Treasury Spend: 150 credits',
+      description: 'Proposal to spend 150 credits',
+      payload: { type: 'treasury' },
+      state: { open: { opened_at: 1700000000, closes_at: 1700003600 } },
+      created_at: 1700000000,
+      updated_at: 1700000100,
+      scope: 'local',
+    };
+
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockResponse,
+    });
+
+    const client = new ICNClient({
+      baseUrl: 'http://localhost:8080',
+      token: 'test-token',
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    const result = await client.governance.vote('prop-abc', 'for', 'looks good');
+
+    expect(result).toEqual(mockResponse);
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:8080/v1/proposals/prop-abc/vote');
+    expect(options.method).toBe('POST');
+    expect(JSON.parse(options.body)).toEqual({
+      choice: 'for',
+      comment: 'looks good',
+    });
+  });
+
+  it('should fetch governance proof via flow c alias route', async () => {
+    const mockResponse = {
+      receipt: {
+        proposal_id: 'prop-abc',
+        domain_id: 'coop-alpha',
+        outcome: 'accepted',
+        vote_tally: {
+          for_votes: 3,
+          against_votes: 1,
+          abstain_votes: 0,
+        },
+        vote_hash: Array(32).fill(1),
+        decision_hash: Array(32).fill(2),
+      },
+      attestations: [
+        {
+          decision_hash: Array(32).fill(2),
+          signer_did: 'did:icn:validator1',
+          timestamp: 1700000200,
+          signature: Array(64).fill(3),
+        },
+      ],
+    };
+
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockResponse,
+    });
+
+    const client = new ICNClient({
+      baseUrl: 'http://localhost:8080',
+      token: 'test-token',
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    const result = await client.governance.getProof('prop-abc');
+
+    expect(result).toEqual(mockResponse);
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:8080/v1/proposals/prop-abc/proof');
+    expect(options.method).toBe('GET');
+  });
+});
+
 describe('compute task status', () => {
   it('should get task status', async () => {
     const mockResponse = {

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -159,8 +159,15 @@ import {
   // Treasury types
   TreasuryStatus,
   TreasuryBalance,
+  TreasuryBalanceResponse,
   ProposeTreasurySpendRequest,
   ProposeTreasurySpendResponse,
+  ProposeSpendRequest,
+  ProposeSpendResponse,
+  ProposalResponse,
+  GovernanceReceiptResponse,
+  TreasuryClient,
+  GovernanceClient,
   // Service discovery types
   ServiceEndpointInfo,
   AnnounceServiceRequest,
@@ -314,6 +321,8 @@ export class ICNClient {
   private did?: string;
   private coopId?: string;
   private scopes?: string[];
+  public readonly treasury: TreasuryClient;
+  public readonly governance: GovernanceClient;
 
   constructor(options: ICNClientOptions) {
     this.baseUrl = options.baseUrl.replace(/\/$/, '');
@@ -324,6 +333,35 @@ export class ICNClient {
     this.retryOptions = { ...DEFAULT_RETRY, ...options.retry };
     this.autoRefresh = options.autoRefresh ?? false;
     this.refreshBeforeExpiry = options.refreshBeforeExpiry ?? 60;
+    this.treasury = {
+      balance: async (coopId: string): Promise<TreasuryBalanceResponse> =>
+        this.get<TreasuryBalanceResponse>(
+          `/coops/${encodeURIComponent(coopId)}/treasury/balance`
+        ),
+    };
+    this.governance = {
+      proposeSpend: async (
+        coopId: string,
+        req: ProposeSpendRequest
+      ): Promise<ProposeSpendResponse> =>
+        this.post<ProposeSpendResponse>(
+          `/coops/${encodeURIComponent(coopId)}/proposals`,
+          req
+        ),
+      vote: async (
+        proposalId: string,
+        choice: 'for' | 'against' | 'abstain',
+        comment?: string
+      ): Promise<ProposalResponse> =>
+        this.post<ProposalResponse>(`/proposals/${encodeURIComponent(proposalId)}/vote`, {
+          choice,
+          ...(comment !== undefined ? { comment } : {}),
+        }),
+      getProof: async (proposalId: string): Promise<GovernanceReceiptResponse> =>
+        this.get<GovernanceReceiptResponse>(
+          `/proposals/${encodeURIComponent(proposalId)}/proof`
+        ),
+    };
   }
 
   /**

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -335,6 +335,7 @@ export interface VoteTally {
 
 export interface CastVoteRequest {
   choice: VoteChoice;
+  comment?: string;
 }
 
 export interface ProposalOutcome {
@@ -1786,6 +1787,14 @@ export interface TreasuryBalance {
   currency: string;
 }
 
+/** Flow C treasury balance response */
+export interface TreasuryBalanceResponse {
+  /** Treasury DID */
+  treasury_did: string;
+  /** Balances by currency code */
+  balances: Record<string, number>;
+}
+
 /** Request to propose a treasury spend */
 export interface ProposeTreasurySpendRequest {
   /** Amount to spend */
@@ -1798,6 +1807,20 @@ export interface ProposeTreasurySpendRequest {
   memo: string;
 }
 
+/** Flow C request to propose a treasury spend */
+export interface ProposeSpendRequest {
+  /** Amount to spend */
+  amount: number;
+  /** Recipient DID */
+  recipient: string;
+  /** Memo/reason for the spend */
+  memo: string;
+  /** Currency (defaults to credits in gateway) */
+  currency?: string;
+  /** Optional nonce to enforce expected treasury ordering */
+  expected_nonce?: number;
+}
+
 /** Response from proposing a treasury spend */
 export interface ProposeTreasurySpendResponse {
   /** ID of the created governance proposal */
@@ -1806,6 +1829,73 @@ export interface ProposeTreasurySpendResponse {
   domain_id: string;
   /** Status message */
   status: string;
+}
+
+/** Flow C response from proposing a treasury spend */
+export interface ProposeSpendResponse {
+  status: string;
+  message: string;
+  operation: string;
+  proposal_id: string;
+  coop_id: string;
+  amount: number;
+  currency: string;
+  recipient: string;
+  memo: string;
+  nonce: number;
+}
+
+/** Flow C proposal response returned by vote endpoint */
+export interface ProposalResponse {
+  id: string;
+  domain_id: string;
+  proposer: string;
+  title: string;
+  description: string;
+  payload: unknown;
+  state: unknown;
+  created_at: number;
+  updated_at: number;
+  scope?: unknown;
+}
+
+/** Flow C governance decision receipt and attestation types */
+export interface GovernanceDecisionReceipt {
+  proposal_id: string;
+  domain_id: string;
+  outcome: 'accepted' | 'rejected' | 'no_quorum';
+  vote_tally: {
+    for_votes: number;
+    against_votes: number;
+    abstain_votes: number;
+  };
+  vote_hash: number[];
+  decision_hash: number[];
+}
+
+export interface GovernanceDecisionAttestation {
+  decision_hash: number[];
+  signer_did: string;
+  timestamp: number;
+  signature: number[];
+}
+
+/** Flow C proof response from /v1/proposals/{id}/proof */
+export interface GovernanceReceiptResponse {
+  receipt: GovernanceDecisionReceipt;
+  attestations: GovernanceDecisionAttestation[];
+}
+
+/** Flow C treasury sub-client surface */
+export interface TreasuryClient {
+  balance(coopId: string): Promise<TreasuryBalanceResponse>;
+}
+
+/** Flow C governance sub-client surface */
+export interface GovernanceClient {
+  proposeSpend(coopId: string, req: ProposeSpendRequest): Promise<ProposeSpendResponse>;
+  vote(proposalId: string, choice: VoteChoice, comment?: string): Promise<ProposalResponse>;
+  getProof(proposalId: string): Promise<GovernanceReceiptResponse>;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- add Flow C SDK sub-clients: `treasury.balance`, `governance.proposeSpend`, `governance.vote`, `governance.getProof`
- add typed request/response models for Flow C gateway routes
- add focused SDK tests (one per method) validating URL, payload, and response parsing
- compatibility: this adds Flow C sub-clients without removing existing flat/legacy SDK methods

## Flow C Endpoints
- `GET /v1/coops/{coop_id}/treasury/balance`
- `POST /v1/coops/{coop_id}/proposals`
- `POST /v1/proposals/{id}/vote`
- `GET /v1/proposals/{id}/proof`

## Flow C Sequence
```ts
const balance = await client.treasury.balance(coopId);
const proposal = await client.governance.proposeSpend(coopId, {
  amount: 150,
  recipient: "did:icn:bob",
  memo: "equipment",
  currency: "credits",
});
await client.governance.vote(proposal.proposal_id, "for", "looks good");
const proof = await client.governance.getProof(proposal.proposal_id);
```

## Local Verification
```bash
cd sdk/typescript
npm test -- src/index.test.ts
npx tsc --noEmit
```

Closes #1093.
