### PR TITLE
docs(sprints): add 2026-02-18 sprint tracker

### DIFF
--- a/docs/development/sprints/README.md
+++ b/docs/development/sprints/README.md
@@ -8,6 +8,10 @@ Sprint documents should follow the naming convention:
 - `sprint-YYYY-MM-DD.md` - Sprint planning and goals
 - `sprint-YYYY-MM-DD-retro.md` - Sprint retrospective
 
+## Active Tracker
+
+- [Sprint 2026-02-18](./sprint-2026-02-18.md) - Sprint 5 Flow C execution tracker and milestones
+
 ## Related Documentation
 
 - [Development Documentation](../)

--- a/docs/development/sprints/sprint-2026-02-18.md
+++ b/docs/development/sprints/sprint-2026-02-18.md
@@ -1,0 +1,121 @@
+# Sprint Plan - 2026-02-18
+
+## Scope
+Sprint 5 execution tracker focused on closing Flow C (treasury governance demo path) after Sprint 4 hardening landed.
+
+## Grounded Start State (2026-02-18)
+- Open PRs: `#1240` only (`feat(sdk): add Flow C treasury/governance methods`)
+- Main head: `114342fc` (`feat(gateway): add Flow C route aliases for proposals and treasury (#1239)`)
+- Landed in sequence: `#1235`, `#1236`, `#1237`, `#1238`, `#1239`
+- Flow C issue chain status:
+  - `#1092` Gateway endpoints: done (closed after `#1239`)
+  - `#1093` TypeScript SDK methods: in review (`#1240`)
+  - `#1094` Flow C demo script: not started
+
+## Sprint Goal
+Ship a repeatable Flow C operator path end-to-end:
+`balance -> proposeSpend -> vote -> getProof`
+
+## Milestones and Exit Criteria
+
+### M1 - Merge SDK Flow C Surface
+Owner lane: SDK
+
+Tasks:
+- [ ] Required checks green for `#1240`
+- [ ] Merge `#1240` (squash + delete branch)
+- [ ] Confirm `#1093` auto-closed from PR body (`Closes #1093`)
+
+Verification commands:
+```bash
+cd /home/ubuntu/projects/icn
+gh pr checks 1240 --repo InterCooperative-Network/icn --required
+gh pr merge 1240 --repo InterCooperative-Network/icn --squash --delete-branch
+gh issue view 1093 --repo InterCooperative-Network/icn
+```
+
+Exit criteria:
+- `#1240` merged
+- `#1093` closed
+
+---
+
+### M2 - Flow C Demo Script (`#1094`)
+Owner lane: Demo/Ops
+
+Branch:
+- `feat/sprint5-flow-c-demo-1094`
+
+Tasks:
+- [ ] Create script (recommended path: `scripts/flow_c_treasury_governance_demo.sh`)
+- [ ] Use Flow C endpoints/SDK sequence:
+  1. `GET /v1/coops/{id}/treasury/balance`
+  2. `POST /v1/coops/{id}/proposals`
+  3. `POST /v1/proposals/{id}/vote`
+  4. `GET /v1/proposals/{id}/proof`
+- [ ] Add clear success markers and non-zero exits on failure
+- [ ] Document required env vars, token scopes, and expected outputs
+- [ ] Add or update runbook references
+
+Verification commands (minimum):
+```bash
+cd /home/ubuntu/projects/icn
+bash scripts/flow_c_treasury_governance_demo.sh
+# if script requires env:
+# ICN_BASE_URL=... ICN_TOKEN=... COOP_ID=... bash scripts/flow_c_treasury_governance_demo.sh
+```
+
+Exit criteria:
+- PR for `#1094` merged
+- Script reproducibly completes sequence and returns proof payload
+
+---
+
+### M3 - Sprint Hygiene and Closure
+Owner lane: Repo hygiene
+
+Tasks:
+- [ ] Close any completed-but-open sprint issues with merge evidence comments
+- [ ] Refresh state docs if sprint outcome changes active priorities (`docs/STATE.md`, `docs/TODO.md`)
+- [ ] Capture a short sprint closeout note in this file
+
+Verification commands:
+```bash
+cd /home/ubuntu/projects/icn
+gh issue list --repo InterCooperative-Network/icn --state open --limit 100
+gh pr list --repo InterCooperative-Network/icn --state open --limit 20
+```
+
+Exit criteria:
+- No stale completed issues in the sprint path
+- Open PR queue reflects actual active work only
+
+## Work Queue (Ordered)
+1. `#1240` merge readiness and merge
+2. `#1094` implementation PR
+3. Sprint hygiene pass
+4. Re-plan next sprint with updated backlog state
+
+## Non-Goals (This Sprint)
+- No broad SDK refactor beyond Flow C additions
+- No new dependencies/tooling for SDK or demo scripts
+- No expansion into Flow A/Flow B unless Flow C closes early
+
+## Risk Register
+- CI lag on `#1240` blocks start of `#1094`
+  - Mitigation: start only after merge or branch off updated `main` and rebase once
+- Endpoint/shape drift between SDK types and gateway responses
+  - Mitigation: keep tests asserting URL + payload + response shape for all 4 Flow C methods
+- Demo script environment variance
+  - Mitigation: explicit prerequisites + deterministic success markers in script output
+
+## Update Cadence
+- Update this file at each state transition:
+  - PR opened
+  - checks green
+  - PR merged
+  - issue closed
+- Keep checkboxes as source of truth for milestone completion.
+
+## Change Log
+- 2026-02-18: Initial Sprint 5 tracker created from grounded repo/PR/issue state.


### PR DESCRIPTION
## Summary
- add Sprint 5 execution tracker at `docs/development/sprints/sprint-2026-02-18.md`
- track milestones, exit criteria, verification commands, risks, and update cadence
- link the active sprint tracker from `docs/development/sprints/README.md`

## Why
We need a durable, in-repo plan document to track progress and milestone completion across PRs/issues.

## Scope
Docs-only.
