### PR TITLE
feat(core): execution retention + startup cleanup

### DIFF
--- a/icn/crates/icn-core/src/supervisor/decision_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/decision_executor.rs
@@ -43,6 +43,10 @@ use super::effect_dispatcher::EffectDispatcher;
 
 /// Maximum number of automatic retries before marking permanently failed.
 const MAX_RETRIES: u32 = 3;
+/// Maximum age of terminal records (seconds) to retain on startup.
+pub const MAX_CONFIRMED_AGE_SECS: u64 = 30 * 24 * 60 * 60;
+/// Maximum number of terminal records to retain after startup cleanup.
+pub const MAX_CONFIRMED_COUNT: usize = 10_000;
 
 /// Maximum number of concurrent decision executions (backpressure).
 const MAX_CONCURRENT_EXECUTIONS: usize = 16;
@@ -200,6 +204,60 @@ impl DecisionExecutor {
             skipped_max_retries = report.skipped_max_retries,
             "Decision recovery complete"
         );
+
+        Ok(report)
+    }
+
+    /// Best-effort startup cleanup of old terminal records.
+    ///
+    /// Deletes `Confirmed` and `PermanentlyFailed` records older than
+    /// `MAX_CONFIRMED_AGE_SECS`. Then enforces `MAX_CONFIRMED_COUNT` cap by
+    /// deleting oldest remaining terminal records.
+    ///
+    /// This method intentionally returns `Result` so callers can log and
+    /// continue startup without aborting.
+    pub fn cleanup_old_records(&self) -> Result<CleanupReport> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let cutoff = now.saturating_sub(MAX_CONFIRMED_AGE_SECS);
+
+        let mut terminal = Vec::new();
+        terminal.extend(self.store.list_by_status(ExecutionStatus::Confirmed)?);
+        terminal.extend(
+            self.store
+                .list_by_status(ExecutionStatus::PermanentlyFailed)?,
+        );
+
+        terminal.sort_by_key(|r| r.finished_at.unwrap_or(r.started_at));
+
+        let mut report = CleanupReport::default();
+
+        for record in &terminal {
+            let finished = record.finished_at.unwrap_or(record.started_at);
+            if finished < cutoff {
+                self.store.delete(&record.decision_hash)?;
+                report.deleted_old += 1;
+            }
+        }
+
+        // Re-query after age-based pruning and enforce count cap.
+        let mut terminal_after = Vec::new();
+        terminal_after.extend(self.store.list_by_status(ExecutionStatus::Confirmed)?);
+        terminal_after.extend(
+            self.store
+                .list_by_status(ExecutionStatus::PermanentlyFailed)?,
+        );
+        terminal_after.sort_by_key(|r| r.finished_at.unwrap_or(r.started_at));
+
+        if terminal_after.len() > MAX_CONFIRMED_COUNT {
+            let excess = terminal_after.len() - MAX_CONFIRMED_COUNT;
+            for record in terminal_after.iter().take(excess) {
+                self.store.delete(&record.decision_hash)?;
+                report.deleted_excess += 1;
+            }
+        }
 
         Ok(report)
     }
@@ -414,6 +472,15 @@ impl RecoveryReport {
     }
 }
 
+/// Report from startup retention cleanup.
+#[derive(Debug, Default)]
+pub struct CleanupReport {
+    /// Number of terminal records deleted for exceeding age threshold.
+    pub deleted_old: usize,
+    /// Number of terminal records deleted to enforce count threshold.
+    pub deleted_excess: usize,
+}
+
 /// Create an effect executor callback that routes through the DecisionExecutor.
 ///
 /// The callback acquires a semaphore permit (backpressure) before spawning
@@ -552,6 +619,14 @@ mod tests {
                 .write()
                 .map_err(|e| anyhow::anyhow!("lock: {e}"))?
                 .insert(record.decision_hash.clone(), record.clone());
+            Ok(())
+        }
+
+        fn delete(&self, decision_hash: &str) -> Result<()> {
+            self.records
+                .write()
+                .map_err(|e| anyhow::anyhow!("lock: {e}"))?
+                .remove(decision_hash);
             Ok(())
         }
 
@@ -865,5 +940,31 @@ mod tests {
         assert_eq!(a.status, ExecutionStatus::Confirmed);
         assert_eq!(b.status, ExecutionStatus::Confirmed);
         assert_ne!(a.proposal_id, b.proposal_id);
+    }
+
+    #[tokio::test]
+    async fn test_exec_record_retention_cleanup_old_records_but_keeps_recent() {
+        let (executor, store) = make_test_executor();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let mut old_confirmed = ExecutionRecord::new_pending("old-c", "p-old", "r-old", vec![]);
+        old_confirmed.status = ExecutionStatus::Confirmed;
+        old_confirmed.started_at = now.saturating_sub(MAX_CONFIRMED_AGE_SECS + 100);
+        old_confirmed.finished_at = Some(now.saturating_sub(MAX_CONFIRMED_AGE_SECS + 100));
+        store.put(&old_confirmed).unwrap();
+
+        let mut recent_confirmed = ExecutionRecord::new_pending("new-c", "p-new", "r-new", vec![]);
+        recent_confirmed.status = ExecutionStatus::Confirmed;
+        recent_confirmed.started_at = now.saturating_sub(60);
+        recent_confirmed.finished_at = Some(now.saturating_sub(60));
+        store.put(&recent_confirmed).unwrap();
+
+        let report = executor.cleanup_old_records().unwrap();
+        assert_eq!(report.deleted_old, 1);
+        assert!(store.get("old-c").unwrap().is_none());
+        assert!(store.get("new-c").unwrap().is_some());
     }
 }

--- a/icn/crates/icn-core/src/supervisor/execution_store.rs
+++ b/icn/crates/icn-core/src/supervisor/execution_store.rs
@@ -53,6 +53,14 @@ impl<S: icn_store::Store> ExecutionStore for SledExecutionStore<S> {
         Ok(())
     }
 
+    fn delete(&self, decision_hash: &str) -> Result<()> {
+        let key = Self::entry_key(decision_hash);
+        self.store
+            .delete(&key)
+            .context("Failed to delete execution record")?;
+        Ok(())
+    }
+
     fn list_by_status(&self, status: ExecutionStatus) -> Result<Vec<ExecutionRecord>> {
         let entries = self.store.scan(Self::PREFIX)?;
         let mut result = Vec::new();
@@ -131,6 +139,19 @@ mod tests {
         let retrieved = exec_store.get("hash456").unwrap().unwrap();
         assert_eq!(retrieved.status, ExecutionStatus::Confirmed);
         assert_eq!(retrieved.ledger_entry_ids, vec!["entry-1"]);
+    }
+
+    #[test]
+    fn test_delete() {
+        let store = test_store();
+        let exec_store = SledExecutionStore::new(store);
+
+        let record = ExecutionRecord::new_pending("hash-delete", "proposal-1", "receipt-1", vec![]);
+        exec_store.put(&record).unwrap();
+        assert!(exec_store.get("hash-delete").unwrap().is_some());
+
+        exec_store.delete("hash-delete").unwrap();
+        assert!(exec_store.get("hash-delete").unwrap().is_none());
     }
 
     #[test]

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -699,6 +699,28 @@ async fn spawn_actors_with_identity(
             }
         }
 
+        // Best-effort startup retention cleanup (non-fatal).
+        // Must run after recovery so pending/in-flight records are not pruned.
+        match decision_executor.cleanup_old_records() {
+            Ok(report) => {
+                if report.deleted_old > 0 || report.deleted_excess > 0 {
+                    info!(
+                        deleted_old = report.deleted_old,
+                        deleted_excess = report.deleted_excess,
+                        "Startup cleanup pruned terminal execution records"
+                    );
+                } else {
+                    debug!("Startup cleanup: no terminal execution records pruned");
+                }
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "Startup cleanup failed (non-fatal, continuing startup)"
+                );
+            }
+        }
+
         // Create callback that routes effects through DecisionExecutor
         let effect_callback =
             super::decision_executor::create_decision_executor_callback(decision_executor);

--- a/icn/crates/icn-core/tests/budget_enforcement_integration.rs
+++ b/icn/crates/icn-core/tests/budget_enforcement_integration.rs
@@ -49,6 +49,11 @@ impl ExecutionStore for MemoryExecutionStore {
         Ok(())
     }
 
+    fn delete(&self, decision_hash: &str) -> Result<()> {
+        self.records.write().unwrap().remove(decision_hash);
+        Ok(())
+    }
+
     fn list_by_status(&self, status: ExecutionStatus) -> Result<Vec<ExecutionRecord>> {
         Ok(self
             .records

--- a/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
+++ b/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
@@ -58,6 +58,14 @@ impl ExecutionStore for MemoryExecutionStore {
         Ok(())
     }
 
+    fn delete(&self, decision_hash: &str) -> Result<()> {
+        self.records
+            .write()
+            .map_err(|e| anyhow::anyhow!("lock: {e}"))?
+            .remove(decision_hash);
+        Ok(())
+    }
+
     fn list_by_status(&self, status: ExecutionStatus) -> Result<Vec<ExecutionRecord>> {
         Ok(self
             .records

--- a/icn/crates/icn-core/tests/escrow_release_integration.rs
+++ b/icn/crates/icn-core/tests/escrow_release_integration.rs
@@ -102,6 +102,11 @@ impl ExecutionStore for MemoryExecutionStore {
         Ok(())
     }
 
+    fn delete(&self, decision_hash: &str) -> anyhow::Result<()> {
+        self.records.write().unwrap().remove(decision_hash);
+        Ok(())
+    }
+
     fn list_by_status(&self, status: ExecutionStatus) -> anyhow::Result<Vec<ExecutionRecord>> {
         Ok(self
             .records

--- a/icn/crates/icn-kernel-api/src/execution.rs
+++ b/icn/crates/icn-kernel-api/src/execution.rs
@@ -176,6 +176,9 @@ pub trait ExecutionStore: Send + Sync {
     /// Insert or update an execution record.
     fn put(&self, record: &ExecutionRecord) -> anyhow::Result<()>;
 
+    /// Delete an execution record by decision hash.
+    fn delete(&self, decision_hash: &str) -> anyhow::Result<()>;
+
     /// List records by status.
     fn list_by_status(&self, status: ExecutionStatus) -> anyhow::Result<Vec<ExecutionRecord>>;
 


### PR DESCRIPTION
## Summary
- add `ExecutionStore::delete` and sled-backed delete support for execution records
- add `DecisionExecutor::cleanup_old_records()` to prune terminal records by age and cap total count
- invoke startup cleanup after `recover_in_flight()` as a non-fatal best-effort step

## Retention policy
- `MAX_CONFIRMED_AGE_SECS = 2_592_000` (30 days)
- `MAX_CONFIRMED_COUNT = 10_000`
- cleanup only targets terminal records (`Confirmed`, `PermanentlyFailed`)
- cleanup errors are logged and never abort startup

## Verification
- `cd icn && cargo fmt --all --check`
- `cd icn && CARGO_TARGET_DIR=/tmp/icn-target-1200 RUSTC_WRAPPER= cargo test -p icn-core supervisor::decision_executor::tests::test_exec_record_retention_cleanup_old_records_but_keeps_recent -- --exact --nocapture`
- `cd icn && CARGO_TARGET_DIR=/tmp/icn-target-1200 RUSTC_WRAPPER= cargo clippy -p icn-core --all-targets -- -D warnings`

Closes #1200
