### PR TITLE
feat(core): terminally fail stuck releasing escrows

### DIFF
--- a/icn/crates/icn-core/src/supervisor/decision_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/decision_executor.rs
@@ -37,6 +37,7 @@ use tokio::sync::Semaphore;
 use tracing::{debug, error, info, warn};
 
 use icn_kernel_api::effects::{EffectResult, KernelEffect};
+use icn_kernel_api::escrow::{EscrowStatus, EscrowStore};
 use icn_kernel_api::execution::{ExecutionRecord, ExecutionStatus, ExecutionStore};
 
 use super::effect_dispatcher::EffectDispatcher;
@@ -55,6 +56,7 @@ const MAX_CONCURRENT_EXECUTIONS: usize = 16;
 pub struct DecisionExecutor {
     dispatcher: Arc<EffectDispatcher>,
     store: Arc<dyn ExecutionStore>,
+    escrow_store: Option<Arc<dyn EscrowStore>>,
     /// Bounded semaphore for backpressure on concurrent executions.
     concurrency_limit: Arc<Semaphore>,
 }
@@ -65,8 +67,15 @@ impl DecisionExecutor {
         Self {
             dispatcher,
             store,
+            escrow_store: None,
             concurrency_limit: Arc::new(Semaphore::new(MAX_CONCURRENT_EXECUTIONS)),
         }
+    }
+
+    /// Attach escrow store for terminal remediation of stuck Releasing escrows.
+    pub fn with_escrow_store(mut self, escrow_store: Arc<dyn EscrowStore>) -> Self {
+        self.escrow_store = Some(escrow_store);
+        self
     }
 
     /// Get a reference to the execution store.
@@ -141,6 +150,8 @@ impl DecisionExecutor {
                             error = %e,
                             "Failed to mark exhausted decision as PermanentlyFailed"
                         );
+                    } else {
+                        self.mark_related_escrows_failed(&rec, "max retries exceeded (recovery)");
                     }
                     report.skipped_max_retries += 1;
                     continue;
@@ -262,6 +273,72 @@ impl DecisionExecutor {
         Ok(report)
     }
 
+    /// Best-effort remediation for escrows stuck in `Releasing` when a decision
+    /// reaches terminal `PermanentlyFailed`.
+    fn mark_related_escrows_failed(&self, record: &ExecutionRecord, reason: &str) {
+        let Some(escrow_store) = &self.escrow_store else {
+            return;
+        };
+
+        use icn_kernel_api::effects::TreasuryEffect;
+
+        for effect in &record.effects {
+            let KernelEffect::Treasury(TreasuryEffect::ReleaseEscrow {
+                escrow_id,
+                decision_hash,
+                ..
+            }) = effect
+            else {
+                continue;
+            };
+
+            if decision_hash != &record.decision_hash {
+                continue;
+            }
+
+            match escrow_store.get(escrow_id) {
+                Ok(Some(mut escrow)) => {
+                    let is_stuck_for_decision = escrow.status == EscrowStatus::Releasing
+                        && escrow.release_decision_hash.as_deref() == Some(decision_hash);
+                    if !is_stuck_for_decision {
+                        continue;
+                    }
+
+                    escrow.mark_failed(decision_hash, reason.to_string());
+                    if let Err(e) = escrow_store.put(&escrow) {
+                        warn!(
+                            escrow_id = %escrow_id,
+                            decision_hash = %decision_hash,
+                            error = %e,
+                            "Failed to persist terminal escrow failure state"
+                        );
+                    } else {
+                        warn!(
+                            escrow_id = %escrow_id,
+                            decision_hash = %decision_hash,
+                            "Escrow transitioned Releasing → Failed due to permanent decision failure"
+                        );
+                    }
+                }
+                Ok(None) => {
+                    warn!(
+                        escrow_id = %escrow_id,
+                        decision_hash = %decision_hash,
+                        "Escrow referenced by failed decision was not found"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        escrow_id = %escrow_id,
+                        decision_hash = %decision_hash,
+                        error = %e,
+                        "Failed to read escrow for terminal remediation"
+                    );
+                }
+            }
+        }
+    }
+
     /// Execute effects for a governance decision, with idempotency.
     ///
     /// # Arguments
@@ -312,6 +389,7 @@ impl DecisionExecutor {
                 let mut record = existing;
                 record.mark_permanently_failed("Max retries exceeded");
                 self.store.put(&record)?;
+                self.mark_related_escrows_failed(&record, "max retries exceeded");
                 return Ok(vec![]);
             }
         }
@@ -587,6 +665,7 @@ fn extract_decision_hash(effects: &[KernelEffect]) -> Option<String> {
 mod tests {
     use super::*;
     use icn_kernel_api::effects::TreasuryEffect;
+    use icn_kernel_api::escrow::{EscrowRecord, EscrowStatus, EscrowStore};
     use icn_kernel_api::execution::ExecutionRecord;
     use std::collections::HashMap;
     use std::sync::RwLock;
@@ -655,6 +734,49 @@ mod tests {
         }
     }
 
+    /// In-memory escrow store for testing terminal remediation behavior.
+    struct MemoryEscrowStore {
+        records: RwLock<HashMap<String, EscrowRecord>>,
+    }
+
+    impl MemoryEscrowStore {
+        fn new() -> Self {
+            Self {
+                records: RwLock::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl EscrowStore for MemoryEscrowStore {
+        fn get(&self, escrow_id: &str) -> Result<Option<EscrowRecord>> {
+            Ok(self
+                .records
+                .read()
+                .map_err(|e| anyhow::anyhow!("lock: {e}"))?
+                .get(escrow_id)
+                .cloned())
+        }
+
+        fn put(&self, record: &EscrowRecord) -> Result<()> {
+            self.records
+                .write()
+                .map_err(|e| anyhow::anyhow!("lock: {e}"))?
+                .insert(record.escrow_id.clone(), record.clone());
+            Ok(())
+        }
+
+        fn list_by_scope(&self, scope_id: &str) -> Result<Vec<EscrowRecord>> {
+            Ok(self
+                .records
+                .read()
+                .map_err(|e| anyhow::anyhow!("lock: {e}"))?
+                .values()
+                .filter(|r| r.scope_id == scope_id)
+                .cloned()
+                .collect())
+        }
+    }
+
     /// Helper: create a DecisionExecutor with in-memory stores and no ledger.
     fn make_test_executor() -> (Arc<DecisionExecutor>, Arc<MemoryExecutionStore>) {
         use icn_kernel_api::protocol_params::*;
@@ -668,6 +790,28 @@ mod tests {
         let decision_executor = Arc::new(DecisionExecutor::new(dispatcher, exec_store.clone()));
 
         (decision_executor, exec_store)
+    }
+
+    fn make_test_executor_with_escrow() -> (
+        Arc<DecisionExecutor>,
+        Arc<MemoryExecutionStore>,
+        Arc<MemoryEscrowStore>,
+    ) {
+        use icn_kernel_api::protocol_params::*;
+
+        let param_store = Arc::new(StubParamStore);
+        let kernel_executor =
+            Arc::new(super::super::governance_executor::KernelGovernanceExecutor::new(param_store));
+        let dispatcher = Arc::new(EffectDispatcher::new(kernel_executor));
+        let exec_store = Arc::new(MemoryExecutionStore::new());
+        let escrow_store = Arc::new(MemoryEscrowStore::new());
+
+        let decision_executor = Arc::new(
+            DecisionExecutor::new(dispatcher, exec_store.clone())
+                .with_escrow_store(escrow_store.clone()),
+        );
+
+        (decision_executor, exec_store, escrow_store)
     }
 
     #[tokio::test]
@@ -867,5 +1011,71 @@ mod tests {
         assert_eq!(report.deleted_old, 1);
         assert!(store.get("old-c").unwrap().is_none());
         assert!(store.get("new-c").unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_permanent_failure_marks_releasing_escrow_failed() {
+        let (executor, exec_store, escrow_store) = make_test_executor_with_escrow();
+
+        let decision_hash = "sha256:escrow-fail-hash";
+        let escrow_id = "escrow-fail-1";
+
+        let mut escrow = EscrowRecord::new_locked(
+            escrow_id,
+            "coop-alpha",
+            "did:treasury",
+            "did:beneficiary",
+            1000,
+            "HOURS",
+        );
+        escrow.begin_release(decision_hash).unwrap();
+        escrow_store.put(&escrow).unwrap();
+
+        let mut failed_record = ExecutionRecord::new_pending(
+            decision_hash,
+            "proposal-escrow-fail",
+            "receipt-escrow-fail",
+            vec![KernelEffect::Treasury(TreasuryEffect::ReleaseEscrow {
+                escrow_id: escrow_id.to_string(),
+                treasury_did: "did:treasury".to_string(),
+                beneficiary_did: "did:beneficiary".to_string(),
+                amount: 1000,
+                currency: "HOURS".to_string(),
+                decision_receipt_id: "receipt-escrow-fail".to_string(),
+                decision_hash: decision_hash.to_string(),
+            })],
+        );
+        failed_record.status = ExecutionStatus::Failed;
+        failed_record.retries = MAX_RETRIES;
+        failed_record.error = Some("insufficient funds".to_string());
+        exec_store.put(&failed_record).unwrap();
+
+        let results = executor
+            .execute(
+                vec![KernelEffect::NoOp {
+                    reason: "ignored".to_string(),
+                }],
+                "receipt-escrow-fail",
+                decision_hash,
+                "proposal-escrow-fail",
+            )
+            .await
+            .unwrap();
+        assert!(results.is_empty());
+
+        let updated_record = exec_store.get(decision_hash).unwrap().unwrap();
+        assert_eq!(updated_record.status, ExecutionStatus::PermanentlyFailed);
+
+        let updated_escrow = escrow_store.get(escrow_id).unwrap().unwrap();
+        assert_eq!(updated_escrow.status, EscrowStatus::Failed);
+        assert_eq!(
+            updated_escrow.failed_decision_hash.as_deref(),
+            Some(decision_hash)
+        );
+        assert!(updated_escrow
+            .failed_reason
+            .as_deref()
+            .unwrap_or_default()
+            .contains("max retries exceeded"));
     }
 }

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -446,6 +446,28 @@ impl EffectExecutor for KernelGovernanceExecutor {
                             ledger_entry_id: None,
                         });
                     }
+                    Err(EscrowReleaseError::Failed {
+                        existing_decision_hash,
+                        reason,
+                    }) => {
+                        warn!(
+                            escrow_id = %escrow_id,
+                            decision_hash = %decision_hash,
+                            existing_decision_hash = %existing_decision_hash,
+                            reason = %reason,
+                            "Cannot release terminally failed escrow"
+                        );
+                        return Ok(EffectResult {
+                            effect_id: decision_receipt_id.to_string(),
+                            success: false,
+                            message: format!(
+                                "Escrow {} terminally failed by decision {}: {}",
+                                escrow_id, existing_decision_hash, reason
+                            ),
+                            state_change_hash: None,
+                            ledger_entry_id: None,
+                        });
+                    }
                 }
 
                 // Phase 2: Execute ledger mutation (escrow is now in Releasing state).

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -640,7 +640,7 @@ async fn spawn_actors_with_identity(
             Arc::new(icn_store::SledStore::open(&escrow_store_path)?);
         let escrow_store: Arc<dyn icn_kernel_api::escrow::EscrowStore> =
             Arc::new(super::escrow_store::SledEscrowStore::new(escrow_sled_store));
-        kernel_executor = kernel_executor.with_escrow_store(escrow_store);
+        kernel_executor = kernel_executor.with_escrow_store(escrow_store.clone());
         info!("✓ Escrow store wired to governance executor");
 
         // Create budget store for budget enforcement
@@ -669,10 +669,10 @@ async fn spawn_actors_with_identity(
         );
 
         // Wrap dispatcher with DecisionExecutor for idempotent execution
-        let decision_executor = Arc::new(super::decision_executor::DecisionExecutor::new(
-            effect_dispatcher,
-            execution_store,
-        ));
+        let decision_executor = Arc::new(
+            super::decision_executor::DecisionExecutor::new(effect_dispatcher, execution_store)
+                .with_escrow_store(escrow_store),
+        );
 
         // Recover in-flight decisions from prior crash
         // This must run BEFORE the event subscription is established

--- a/icn/crates/icn-kernel-api/src/escrow.rs
+++ b/icn/crates/icn-kernel-api/src/escrow.rs
@@ -30,7 +30,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Status of an escrow allocation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EscrowStatus {
     /// Funds are locked, awaiting governance decision.
@@ -40,6 +40,8 @@ pub enum EscrowStatus {
     Releasing,
     /// Funds have been released to the beneficiary (ledger mutation confirmed).
     Released,
+    /// Terminal failure after retries are exhausted.
+    Failed,
     /// Escrow was cancelled, funds returned to funder.
     Cancelled,
 }
@@ -76,6 +78,12 @@ pub struct EscrowRecord {
 
     /// Unix timestamp (seconds) when escrow was released (if any).
     pub released_at: Option<u64>,
+
+    /// Decision hash that terminally failed this escrow (if any).
+    pub failed_decision_hash: Option<String>,
+
+    /// Terminal failure reason (if any).
+    pub failed_reason: Option<String>,
 }
 
 impl EscrowRecord {
@@ -104,6 +112,8 @@ impl EscrowRecord {
             created_at: now,
             release_decision_hash: None,
             released_at: None,
+            failed_decision_hash: None,
+            failed_reason: None,
         }
     }
 
@@ -131,6 +141,8 @@ impl EscrowRecord {
             EscrowStatus::Locked => {
                 self.status = EscrowStatus::Releasing;
                 self.release_decision_hash = Some(decision_hash.to_string());
+                self.failed_decision_hash = None;
+                self.failed_reason = None;
                 Ok(BeginReleaseOutcome::Proceed)
             }
             EscrowStatus::Releasing => {
@@ -156,6 +168,16 @@ impl EscrowRecord {
                     })
                 }
             }
+            EscrowStatus::Failed => Err(EscrowReleaseError::Failed {
+                existing_decision_hash: self
+                    .failed_decision_hash
+                    .clone()
+                    .unwrap_or_else(|| "unknown".to_string()),
+                reason: self
+                    .failed_reason
+                    .clone()
+                    .unwrap_or_else(|| "terminal failure".to_string()),
+            }),
             EscrowStatus::Cancelled => Err(EscrowReleaseError::Cancelled),
         }
     }
@@ -177,6 +199,15 @@ impl EscrowRecord {
                 .map(|d| d.as_secs())
                 .unwrap_or(0),
         );
+        self.failed_decision_hash = None;
+        self.failed_reason = None;
+    }
+
+    /// Transition escrow to a terminal failed state.
+    pub fn mark_failed(&mut self, decision_hash: &str, reason: impl Into<String>) {
+        self.status = EscrowStatus::Failed;
+        self.failed_decision_hash = Some(decision_hash.to_string());
+        self.failed_reason = Some(reason.into());
     }
 }
 
@@ -199,6 +230,11 @@ pub enum EscrowReleaseError {
     AlreadyReleasedByOther { existing_decision_hash: String },
     /// Escrow was cancelled.
     Cancelled,
+    /// Escrow is terminally failed.
+    Failed {
+        existing_decision_hash: String,
+        reason: String,
+    },
 }
 
 impl std::fmt::Display for EscrowReleaseError {
@@ -217,6 +253,14 @@ impl std::fmt::Display for EscrowReleaseError {
                 )
             }
             Self::Cancelled => write!(f, "escrow was cancelled"),
+            Self::Failed {
+                existing_decision_hash,
+                reason,
+            } => write!(
+                f,
+                "escrow terminally failed by decision {}: {}",
+                existing_decision_hash, reason
+            ),
         }
     }
 }
@@ -253,6 +297,8 @@ mod tests {
         assert!(escrow.is_locked());
         assert_eq!(escrow.status, EscrowStatus::Locked);
         assert!(escrow.release_decision_hash.is_none());
+        assert!(escrow.failed_decision_hash.is_none());
+        assert!(escrow.failed_reason.is_none());
     }
 
     #[test]
@@ -409,5 +455,33 @@ mod tests {
         assert_eq!(parsed.status, EscrowStatus::Releasing);
         assert_eq!(parsed.release_decision_hash.as_deref(), Some("hash-y"));
         assert!(parsed.released_at.is_none());
+    }
+
+    #[test]
+    fn test_terminal_failed_blocks_release() {
+        let mut escrow = EscrowRecord::new_locked(
+            "esc-f",
+            "coop-alpha",
+            "did:treasury",
+            "did:alice",
+            5000,
+            "HOURS",
+        );
+
+        escrow.begin_release("hash-f").unwrap();
+        escrow.mark_failed("hash-f", "insufficient funds");
+
+        assert_eq!(escrow.status, EscrowStatus::Failed);
+        assert_eq!(escrow.failed_decision_hash.as_deref(), Some("hash-f"));
+        assert_eq!(escrow.failed_reason.as_deref(), Some("insufficient funds"));
+
+        let err = escrow.begin_release("hash-f").unwrap_err();
+        assert_eq!(
+            err,
+            EscrowReleaseError::Failed {
+                existing_decision_hash: "hash-f".to_string(),
+                reason: "insufficient funds".to_string(),
+            }
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add terminal escrow failure support (`EscrowStatus::Failed`) with persisted failure metadata
- wire `DecisionExecutor` to mark matching `Releasing` escrows as `Failed` when a decision reaches `PermanentlyFailed`
- keep saga semantics intact (`Locked -> Releasing -> Released`) while preventing infinite `Releasing` limbo on terminal failure
- pass escrow store into `DecisionExecutor` at supervisor startup for remediation

## Why
Issue #1195 identified that escrows can remain `Releasing` forever when treasury effects fail logically and the decision exhausts retries. This patch introduces a terminal escrow state and applies it only when the decision itself is terminal (`PermanentlyFailed`).

## Invariants
- does not weaken adversarial/trust boundaries
- does not alter canonical effect encoding
- preserves crash-recovery saga behavior for non-terminal retries
- no panic paths added; remediation is best-effort and warning-only on store errors

## Verification
- `cd icn && cargo fmt --all --check`
- `cd icn && cargo test -p icn-kernel-api escrow -- --nocapture`
- `cd icn && CARGO_TARGET_DIR=/tmp/icn-target-1195 cargo test -p icn-core --lib permanent_failure_marks_releasing_escrow_failed -- --nocapture`
- `cd icn && CARGO_TARGET_DIR=/tmp/icn-target-1195 RUSTC_WRAPPER= cargo clippy -p icn-core --all-targets -- -D warnings`

Closes #1195
