### PR TITLE
docs(sprints): add sprint 7 tracker and sprint 6 closeout

### DIFF
--- a/docs/development/sprints/README.md
+++ b/docs/development/sprints/README.md
@@ -10,7 +10,11 @@ Sprint documents should follow the naming convention:
 
 ## Active Tracker
 
-- [Sprint 2026-02-18](./sprint-2026-02-18.md) - Sprint 5 Flow C execution tracker and milestones
+- [Sprint 2026-02-19](./sprint-2026-02-19.md) - Sprint 7 Flow B execution tracker and milestones
+
+## Previous Tracker
+
+- [Sprint 2026-02-18](./sprint-2026-02-18.md) - Sprint 5/6 closeout tracker (Flow C + core ops safety net)
 
 ## Related Documentation
 

--- a/docs/development/sprints/sprint-2026-02-18.md
+++ b/docs/development/sprints/sprint-2026-02-18.md
@@ -119,3 +119,18 @@ Exit criteria:
 
 ## Change Log
 - 2026-02-18: Initial Sprint 5 tracker created from grounded repo/PR/issue state.
+- 2026-02-19: Sprint closeout recorded.
+
+## Sprint Closeout (2026-02-19)
+
+Completed milestones:
+- `#1093` merged via `#1240`
+- `#1094` merged via `#1242`
+- `#1200` merged via `#1243`
+- `#1201` merged via `#1245`
+- `#1202` merged via `#1244`
+- `#1195` merged via `#1246`
+
+Final state:
+- Open PRs: `0`
+- `main` head at closeout: `3ea518c2`

--- a/docs/development/sprints/sprint-2026-02-19.md
+++ b/docs/development/sprints/sprint-2026-02-19.md
@@ -1,0 +1,137 @@
+# Sprint Plan - 2026-02-19
+
+## Scope
+Sprint 7 plan focused on Pilot Completion follow-through after Sprint 6 closed Flow C and core ops safety net items.
+
+## Grounded Start State (2026-02-19)
+- Open PRs: none
+- Main head: `3ea518c2` (`feat(core): terminally fail stuck releasing escrows (#1195) (#1246)`)
+- Recently closed issues: `#1093`, `#1094`, `#1195`, `#1200`, `#1201`, `#1202`
+- Pilot Completion flow status:
+  - Flow C (`#1090/#1093/#1094`): largely closed, with `#1090` still open
+  - Flow B (`#1083/#1084/#1085`): not started
+  - Flow A (`#1076/#1077/#1078`): not started
+
+## Sprint Goal
+Advance Pilot Completion with the next demo-capable chain:
+`Flow B (naming/discovery) end-to-end`, then prep Flow A kickoff.
+
+## Milestones and Exit Criteria
+
+### M1 - Flow B backend primitive (`#1083`)
+Owner lane: Core/API
+
+Tasks:
+- [ ] Implement `icn-naming` crate + KV storage wiring per issue scope
+- [ ] Add minimal persistence tests for create/read/update semantics
+- [ ] Ensure crate topology stays under `icn/` runtime boundaries
+
+Verification commands:
+```bash
+cd icn
+cargo fmt --all --check
+cargo clippy -p icn-naming --all-targets -- -D warnings
+cargo test -p icn-naming -- --nocapture
+```
+
+Exit criteria:
+- PR merged with `Closes #1083`
+- naming state survives restart in test coverage
+
+---
+
+### M2 - Flow B gateway + SDK surface (`#1084`)
+Owner lane: Gateway/SDK
+
+Tasks:
+- [ ] Add gateway names endpoint(s) required by issue `#1084`
+- [ ] Update TypeScript SDK methods/types for new names API
+- [ ] Keep OpenAPI/types in sync if endpoint shape changes
+
+Verification commands:
+```bash
+cd icn
+cargo fmt --all --check
+cargo clippy -p icn-gateway --all-targets -- -D warnings
+cargo test -p icn-gateway --features sled-storage
+
+cd ../sdk/typescript
+npm ci
+npm run build
+npm test
+npm run lint
+```
+
+Exit criteria:
+- PR merged with `Closes #1084`
+- Gateway + SDK paths proven by tests
+
+---
+
+### M3 - Flow B demo script (`#1085`)
+Owner lane: Demo/Ops
+
+Tasks:
+- [ ] Add/extend script for service discovery demo flow
+- [ ] Include deterministic success markers and non-zero exits on failure
+- [ ] Document prerequisites and expected output in runbook/docs
+
+Verification commands:
+```bash
+cd /home/ubuntu/projects/icn
+bash scripts/demo-flow-b.sh
+```
+
+Exit criteria:
+- PR merged with `Closes #1085`
+- Script runs end-to-end on a clean checkout with documented prerequisites
+
+---
+
+### M4 - Flow A readiness spike (carry-in prep)
+Owner lane: Planning/Architecture
+
+Tasks:
+- [ ] Confirm exact API/SDK gaps for `#1076`, `#1077`, `#1078`
+- [ ] Capture implementation order and acceptance tests in a short handoff note
+
+Verification commands:
+```bash
+cd /home/ubuntu/projects/icn
+gh issue view 1076 --repo InterCooperative-Network/icn
+gh issue view 1077 --repo InterCooperative-Network/icn
+gh issue view 1078 --repo InterCooperative-Network/icn
+```
+
+Exit criteria:
+- Written execution order for Flow A with explicit PR sequencing
+
+## Work Queue (Ordered)
+1. `#1083` (Flow B primitive)
+2. `#1084` (gateway + SDK)
+3. `#1085` (demo script)
+4. Flow A readiness spike (`#1076/#1077/#1078`)
+5. Re-evaluate `#1090` (fallback atomicity) for scope or closure based on current invariants
+
+## Non-Goals (This Sprint)
+- No tier:3 performance backlog (`#1047`, `#1053`, `#1054`)
+- No post-demo infra track (`#1095` to `#1098`)
+- No broad architecture-wave docs (`#1009` to `#1012`) unless directly blocking Flow B
+
+## Risk Register
+- Endpoint/type drift between gateway and SDK for Flow B
+  - Mitigation: update OpenAPI + generated SDK types if API shape changes
+- Discovery demo flakiness due to environment assumptions
+  - Mitigation: script preflight checks + explicit fail-fast messages
+- Worktree drift during parallel lanes
+  - Mitigation: run `bash scripts/worktree_sanity.sh` before starting each PR lane
+
+## Update Cadence
+- Update this tracker at each state transition:
+  - PR opened
+  - checks green
+  - PR merged
+  - issue closed
+
+## Change Log
+- 2026-02-19: Sprint 7 tracker created after Sprint 6 completion and #1246 merge.


### PR DESCRIPTION
## Summary
- add a new Sprint 7 tracker at `docs/development/sprints/sprint-2026-02-19.md`
- update sprint index to mark 2026-02-19 as active and 2026-02-18 as previous
- add Sprint 6 closeout section to `sprint-2026-02-18.md` with merged PR/issue outcomes

## Why
We needed the next-step plan documented on disk with milestone checklists, ordered work queue, and verification commands.

## Verification
- `rg -n "sprint-2026-02-19.md|sprint-2026-02-18.md" docs/development/sprints/README.md`
- docs-only change scope: `docs/development/sprints/**`
