### PR TITLE
feat(gateway): names API wiring + SDK surface (#1084)

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -3118,6 +3118,7 @@ dependencies = [
  "icn-kernel-api",
  "icn-ledger",
  "icn-ledger-app",
+ "icn-naming",
  "icn-net",
  "icn-obs",
  "icn-rpc",

--- a/icn/crates/icn-core/src/supervisor/actors.rs
+++ b/icn/crates/icn-core/src/supervisor/actors.rs
@@ -26,6 +26,7 @@ pub struct GatewayActorHandles {
     pub agreement_manager: Option<icn_federation::agreement::AgreementManagerHandle>,
     pub service_discovery_manager:
         Option<Arc<icn_gateway::service_discovery_mgr::ServiceDiscoveryManager>>,
+    pub naming_service: Option<Arc<dyn icn_kernel_api::naming::NamingService>>,
 }
 
 /// Core actor handles returned from initialization

--- a/icn/crates/icn-core/src/supervisor/init_gateway.rs
+++ b/icn/crates/icn-core/src/supervisor/init_gateway.rs
@@ -42,6 +42,8 @@ pub struct GatewayHandles {
     /// Service discovery manager with gossip wiring
     pub service_discovery_manager:
         Option<Arc<icn_gateway::service_discovery_mgr::ServiceDiscoveryManager>>,
+    /// Naming service for Flow B name resolution endpoints
+    pub naming_service: Option<Arc<dyn icn_kernel_api::naming::NamingService>>,
 }
 
 /// Spawn the Gateway API server if enabled
@@ -103,6 +105,7 @@ pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: Gateway
     let steward_handle = handles.steward;
     let agreement_manager_handle = handles.agreement_manager;
     let service_discovery_manager = handles.service_discovery_manager;
+    let naming_service = handles.naming_service;
     let default_trust_score = config.default_trust_score;
 
     // Spawn gateway in a dedicated thread (actix-web has its own runtime)
@@ -169,6 +172,10 @@ pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: Gateway
 
             if let Some(mgr) = service_discovery_manager {
                 gateway_server = gateway_server.with_service_discovery_manager(mgr);
+            }
+
+            if let Some(service) = naming_service {
+                gateway_server = gateway_server.with_naming_service(service);
             }
 
             if let Some(score) = default_trust_score {

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -121,6 +121,7 @@ pub async fn run_supervisor(
             steward: gateway_handles.steward,
             agreement_manager: gateway_handles.agreement_manager,
             service_discovery_manager: gateway_handles.service_discovery_manager,
+            naming_service: gateway_handles.naming_service,
         },
     );
 
@@ -395,6 +396,13 @@ async fn spawn_actors_with_identity(
     gateway_handles.trust_service = trust_service_from_registry.clone();
     gateway_handles.entity = Some(entity_services.entity_handle);
     gateway_handles.service_discovery_manager = service_discovery_mgr.clone();
+    gateway_handles.naming_service = match super::init_naming::init_naming_service(config) {
+        Ok(service) => Some(service),
+        Err(error) => {
+            warn!("Failed to initialize naming service: {}", error);
+            None
+        }
+    };
 
     // Spawn Identity actor (provides signing and trust service access)
     let identity_handle = crate::identity::IdentityActor::spawn(

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use tokio::select;
 use tokio::sync::RwLock;
 use tokio::task::JoinSet;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use icn_identity::IdentityBundle;
 use icn_kernel_api::services::ServiceRegistry;
@@ -399,7 +399,11 @@ async fn spawn_actors_with_identity(
     gateway_handles.naming_service = match super::init_naming::init_naming_service(config) {
         Ok(service) => Some(service),
         Err(error) => {
-            warn!("Failed to initialize naming service: {}", error);
+            // NOTE: When the supervisor-provided naming service fails to initialize,
+            // the gateway falls back to opening its own local store at the same path.
+            // This means the /names endpoint will serve from a potentially empty store
+            // rather than returning 503. Operators should monitor for this log.
+            error!("Failed to initialize naming service: {}", error);
             None
         }
     };

--- a/icn/crates/icn-gateway/Cargo.toml
+++ b/icn/crates/icn-gateway/Cargo.toml
@@ -69,6 +69,7 @@ sha2 = "0.10"
 icn-identity = { path = "../icn-identity", features = ["utoipa"] }
 icn-net = { path = "../icn-net" }
 icn-kernel-api = { path = "../icn-kernel-api" }
+icn-naming = { path = "../icn-naming" }
 icn-entity = { path = "../icn-entity" }
 icn-time = { path = "../icn-time" }
 icn-ledger = { path = "../icn-ledger" }

--- a/icn/crates/icn-gateway/src/api/mod.rs
+++ b/icn/crates/icn-gateway/src/api/mod.rs
@@ -25,6 +25,7 @@ pub mod ledger;
 pub mod listings;
 pub mod members;
 pub mod membership;
+pub mod names;
 pub mod notifications;
 pub mod oracle;
 pub mod receipts;

--- a/icn/crates/icn-gateway/src/api/names.rs
+++ b/icn/crates/icn-gateway/src/api/names.rs
@@ -1,0 +1,178 @@
+//! Name resolution API endpoints.
+//!
+//! Provides Flow B name lookup via the kernel `NamingService` trait.
+
+use actix_web::{get, web, HttpResponse};
+use icn_kernel_api::naming::{NameRecord, NamingError, NamingService, ResolveOptions, Target};
+use icn_kernel_api::types::{Endpoint, Name};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::error::GatewayError;
+
+#[derive(Debug, Deserialize)]
+pub struct ResolveNameQuery {
+    #[serde(default)]
+    pub verify_signatures: Option<bool>,
+    #[serde(default)]
+    pub max_depth: Option<u32>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ResolveNameResponse {
+    pub name: String,
+    pub resolved_name: String,
+    pub target: NameTargetResponse,
+    pub authority: String,
+    pub ttl_secs: u64,
+    pub created_at: u64,
+    pub updated_at: u64,
+    pub metadata: std::collections::HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum NameTargetResponse {
+    Service {
+        endpoint: EndpointResponse,
+    },
+    Blob {
+        hash: String,
+    },
+    Namespace {
+        org: String,
+        app: String,
+        sub: Option<String>,
+    },
+    Alias {
+        name: String,
+    },
+    MultiService {
+        endpoints: Vec<EndpointResponse>,
+    },
+}
+
+#[derive(Debug, Serialize)]
+pub struct EndpointResponse {
+    pub protocol: String,
+    pub host: String,
+    pub port: u16,
+    pub path: Option<String>,
+}
+
+fn map_endpoint(endpoint: &Endpoint) -> EndpointResponse {
+    EndpointResponse {
+        protocol: endpoint.protocol.clone(),
+        host: endpoint.host.clone(),
+        port: endpoint.port,
+        path: endpoint.path.clone(),
+    }
+}
+
+fn map_target(target: &Target) -> NameTargetResponse {
+    match target {
+        Target::Service { endpoint } => NameTargetResponse::Service {
+            endpoint: map_endpoint(endpoint),
+        },
+        Target::Blob { hash } => NameTargetResponse::Blob {
+            hash: hex::encode(hash),
+        },
+        Target::Namespace { ns } => NameTargetResponse::Namespace {
+            org: ns.org.clone(),
+            app: ns.app.clone(),
+            sub: ns.sub.clone(),
+        },
+        Target::Alias { name } => NameTargetResponse::Alias {
+            name: name.as_str().to_string(),
+        },
+        Target::MultiService { endpoints } => NameTargetResponse::MultiService {
+            endpoints: endpoints.iter().map(map_endpoint).collect(),
+        },
+    }
+}
+
+fn map_record_response(request_name: &Name, resolved: NameRecord) -> ResolveNameResponse {
+    ResolveNameResponse {
+        name: request_name.as_str().to_string(),
+        resolved_name: resolved.name.as_str().to_string(),
+        target: map_target(&resolved.target),
+        authority: resolved.authority,
+        ttl_secs: resolved.ttl.as_secs(),
+        created_at: resolved.created_at,
+        updated_at: resolved.updated_at,
+        metadata: resolved.metadata,
+    }
+}
+
+fn normalize_name_path(raw_path: &str) -> Result<Name, GatewayError> {
+    if raw_path.is_empty() {
+        return Err(GatewayError::BadRequest(
+            "name path must not be empty".to_string(),
+        ));
+    }
+    if raw_path.starts_with('/') {
+        Ok(Name::new(raw_path.to_string()))
+    } else {
+        Ok(Name::new(format!("/{raw_path}")))
+    }
+}
+
+fn map_naming_error(error: NamingError) -> GatewayError {
+    match error {
+        NamingError::NotFound(message) => GatewayError::NotFound(message),
+        NamingError::ServiceNotFound(message) => GatewayError::NotFound(message),
+        NamingError::InvalidName(message) => GatewayError::BadRequest(message),
+        NamingError::TooManyRedirects(depth) => {
+            GatewayError::BadRequest(format!("name resolution exceeded max depth: {depth}"))
+        }
+        NamingError::Unauthorized(message) => GatewayError::Forbidden(message),
+        NamingError::InvalidSignature(message) => GatewayError::BadRequest(message),
+        NamingError::AlreadyExists(message) => GatewayError::Conflict(message),
+        NamingError::RegistryFull(message) => GatewayError::ServiceUnavailable(message),
+        NamingError::Timeout => GatewayError::ServiceUnavailable("name resolution timeout".into()),
+        NamingError::Internal(message) => GatewayError::InternalError(message),
+    }
+}
+
+/// GET /names/{path} - Resolve a hierarchical name.
+#[get("/{path:.*}")]
+pub async fn resolve_name(
+    naming: web::Data<Arc<dyn NamingService>>,
+    path: web::Path<String>,
+    query: web::Query<ResolveNameQuery>,
+) -> crate::error::Result<HttpResponse> {
+    let name = normalize_name_path(&path.into_inner())?;
+    let mut options = ResolveOptions::new();
+    if let Some(max_depth) = query.max_depth {
+        options = options.with_max_depth(max_depth);
+    }
+    if matches!(query.verify_signatures, Some(false)) {
+        options = options.without_signature_verification();
+    }
+
+    let (_, record) = naming
+        .resolve_with_options(&name, options)
+        .map_err(map_naming_error)?;
+    Ok(HttpResponse::Ok().json(map_record_response(&name, record)))
+}
+
+pub fn configure(cfg: &mut web::ServiceConfig) {
+    cfg.service(resolve_name);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_path_adds_leading_slash() {
+        let normalized = normalize_name_path("org/demo/service").unwrap();
+        assert_eq!(normalized.as_str(), "/org/demo/service");
+    }
+
+    #[test]
+    fn normalize_path_rejects_empty() {
+        let err = normalize_name_path("").unwrap_err();
+        assert!(matches!(err, GatewayError::BadRequest(_)));
+    }
+}

--- a/icn/crates/icn-gateway/src/api/names.rs
+++ b/icn/crates/icn-gateway/src/api/names.rs
@@ -144,10 +144,16 @@ pub async fn resolve_name(
     let name = normalize_name_path(&path.into_inner())?;
     let mut options = ResolveOptions::new();
     if let Some(max_depth) = query.max_depth {
-        options = options.with_max_depth(max_depth);
+        // Cap to prevent unreasonably deep traversal via the REST API.
+        options = options.with_max_depth(max_depth.min(32));
     }
-    if matches!(query.verify_signatures, Some(false)) {
-        options = options.without_signature_verification();
+    match query.verify_signatures {
+        Some(false) => {
+            options = options.without_signature_verification();
+        }
+        Some(true) | None => {
+            // verify_signatures defaults to true; explicit true is a no-op.
+        }
     }
 
     let (_, record) = naming
@@ -163,16 +169,173 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use actix_web::{test, App};
+    use icn_kernel_api::naming::{NameRecord, ResolveOptions, Target};
+    use icn_kernel_api::types::{Endpoint, Name, Signature};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::time::Duration;
 
-    #[test]
-    fn normalize_path_adds_leading_slash() {
+    /// Minimal NamingService mock backed by a closure for full flexibility.
+    struct MockNaming<F>
+    where
+        F: Fn(&Name, ResolveOptions) -> Result<(Target, NameRecord), NamingError> + Send + Sync,
+    {
+        handler: F,
+    }
+
+    impl<F> NamingService for MockNaming<F>
+    where
+        F: Fn(&Name, ResolveOptions) -> Result<(Target, NameRecord), NamingError> + Send + Sync,
+    {
+        fn register(
+            &self,
+            _: &Name,
+            _: Target,
+            _: &icn_kernel_api::types::Did,
+            _: &Signature,
+            _: Duration,
+        ) -> Result<NameRecord, NamingError> {
+            unimplemented!()
+        }
+
+        fn resolve(&self, _: &Name) -> Result<Target, NamingError> {
+            unimplemented!()
+        }
+
+        fn resolve_with_options(
+            &self,
+            name: &Name,
+            options: ResolveOptions,
+        ) -> Result<(Target, NameRecord), NamingError> {
+            (self.handler)(name, options)
+        }
+
+        fn update(&self, _: &Name, _: Target, _: &Signature) -> Result<NameRecord, NamingError> {
+            unimplemented!()
+        }
+
+        fn delete(&self, _: &Name, _: &Signature) -> Result<(), NamingError> {
+            unimplemented!()
+        }
+
+        fn get_record(&self, _: &Name) -> Result<NameRecord, NamingError> {
+            unimplemented!()
+        }
+
+        fn list(&self, _: &Name) -> Result<Vec<Name>, NamingError> {
+            unimplemented!()
+        }
+
+        fn watch(&self, _: &Name) -> Result<icn_kernel_api::types::Subscription, NamingError> {
+            unimplemented!()
+        }
+
+        fn verify(&self, _: &NameRecord) -> Result<bool, NamingError> {
+            unimplemented!()
+        }
+    }
+
+    fn stub_record(name: &str) -> NameRecord {
+        NameRecord {
+            name: Name::new(name.to_string()),
+            target: Target::Service {
+                endpoint: Endpoint {
+                    protocol: "https".to_string(),
+                    host: "localhost".to_string(),
+                    port: 8080,
+                    path: None,
+                },
+            },
+            authority: "did:icn:testauthority".to_string(),
+            signature: Signature(vec![]),
+            ttl: Duration::from_secs(300),
+            created_at: 1000,
+            updated_at: 1000,
+            metadata: HashMap::new(),
+        }
+    }
+
+    #[actix_web::test]
+    async fn normalize_path_adds_leading_slash() {
         let normalized = normalize_name_path("org/demo/service").unwrap();
         assert_eq!(normalized.as_str(), "/org/demo/service");
     }
 
-    #[test]
-    fn normalize_path_rejects_empty() {
+    #[actix_web::test]
+    async fn normalize_path_rejects_empty() {
         let err = normalize_name_path("").unwrap_err();
         assert!(matches!(err, GatewayError::BadRequest(_)));
+    }
+
+    #[actix_web::test]
+    async fn test_resolve_name_success_returns_200() {
+        let svc: Arc<dyn NamingService> = Arc::new(MockNaming {
+            handler: |name, _opts| {
+                let rec = stub_record(name.as_str());
+                let target = rec.target.clone();
+                Ok((target, rec))
+            },
+        });
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(svc))
+                .service(web::scope("/names").configure(configure)),
+        )
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/names/org/demo/service")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), 200);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["target"]["kind"], "service");
+        assert_eq!(body["target"]["endpoint"]["host"], "localhost");
+        assert_eq!(body["authority"], "did:icn:testauthority");
+    }
+
+    #[actix_web::test]
+    async fn test_resolve_name_not_found_returns_404() {
+        let svc: Arc<dyn NamingService> = Arc::new(MockNaming {
+            handler: |_, _| Err(NamingError::NotFound("no such name".into())),
+        });
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(svc))
+                .service(web::scope("/names").configure(configure)),
+        )
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/names/missing/path")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), 404);
+    }
+
+    #[actix_web::test]
+    async fn test_resolve_name_unauthorized_returns_403() {
+        let svc: Arc<dyn NamingService> = Arc::new(MockNaming {
+            handler: |_, _| Err(NamingError::Unauthorized("not your name".into())),
+        });
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(svc))
+                .service(web::scope("/names").configure(configure)),
+        )
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/names/protected/path")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), 403);
     }
 }

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -39,6 +39,7 @@ use crate::security::{configure_cors, SecurityConfig, SecurityHeaders};
 use crate::treasury_mgr::{GatewayTreasuryManager, LedgerHandle, TreasuryHandle};
 use crate::trust_mgr::TrustManager;
 use icn_compute::ComputeHandle;
+use icn_kernel_api::naming::NamingService;
 use icn_store::SledStore;
 use tokio::sync::RwLock;
 
@@ -107,6 +108,8 @@ pub struct GatewayServer {
     /// Optional supervisor-initialized ServiceDiscoveryManager with gossip wiring.
     /// When provided, the gateway uses this instead of creating its own (gossip-less) instance.
     service_discovery_manager: Option<Arc<crate::service_discovery_mgr::ServiceDiscoveryManager>>,
+    /// Optional naming service for `/v1/names/*` resolution.
+    naming_service_handle: Option<Arc<dyn NamingService>>,
     /// Audit pruning configuration
     audit_prune_config: Option<AuditPruneConfig>,
     /// Default trust score for unknown peers (overrides DEFAULT_TRUST_SCORE)
@@ -137,6 +140,7 @@ impl GatewayServer {
             steward_handle: None,
             agreement_manager_handle: None,
             service_discovery_manager: None,
+            naming_service_handle: None,
             audit_prune_config: None,
             default_trust_score: None,
         }
@@ -177,6 +181,7 @@ impl GatewayServer {
             steward_handle: None,
             agreement_manager_handle: None,
             service_discovery_manager: None,
+            naming_service_handle: None,
             audit_prune_config: None,
             default_trust_score: None,
         }
@@ -218,6 +223,7 @@ impl GatewayServer {
             steward_handle: None,
             agreement_manager_handle: None,
             service_discovery_manager: None,
+            naming_service_handle: None,
             audit_prune_config: None,
             default_trust_score: None,
         }
@@ -366,6 +372,14 @@ impl GatewayServer {
         manager: Arc<crate::service_discovery_mgr::ServiceDiscoveryManager>,
     ) -> Self {
         self.service_discovery_manager = Some(manager);
+        self
+    }
+
+    /// Set naming service for daemon integration.
+    ///
+    /// When set, `/v1/names/*` resolution delegates to this shared service.
+    pub fn with_naming_service(mut self, service: Arc<dyn NamingService>) -> Self {
+        self.naming_service_handle = Some(service);
         self
     }
 
@@ -573,6 +587,29 @@ impl GatewayServer {
             info!("Service discovery manager initialized (local, no gossip)");
             Arc::new(crate::service_discovery_mgr::ServiceDiscoveryManager::new())
         };
+
+        // Use daemon-provided naming service or create a local sled-backed instance.
+        let naming_service: Arc<dyn NamingService> =
+            if let Some(service) = self.naming_service_handle {
+                info!("Naming service initialized (shared from supervisor)");
+                service
+            } else {
+                let store = if let Some(ref data_dir) = self.data_dir {
+                    let store_path = data_dir.join("store").join("naming");
+                    info!("Naming service initialized at {:?}", store_path);
+                    Arc::new(SledStore::open(&store_path).map_err(|e| {
+                        GatewayError::InternalError(format!("Failed to open naming store: {e}"))
+                    })?)
+                } else {
+                    info!("Naming service initialized with temporary storage");
+                    Arc::new(SledStore::temporary().map_err(|e| {
+                        GatewayError::InternalError(format!(
+                            "Failed to create temporary naming store: {e}"
+                        ))
+                    })?)
+                };
+                Arc::new(icn_naming::SledNamingService::new(store))
+            };
 
         // Start background expiry task for service endpoints (every 5 minutes)
         let _service_expiry_handle =
@@ -985,6 +1022,7 @@ impl GatewayServer {
                 .app_data(web::Data::new(agreement_manager.clone()))
                 // Service discovery manager
                 .app_data(web::Data::new(service_discovery_manager.clone()))
+                .app_data(web::Data::new(naming_service.clone()))
                 // Listings manager for cooperative exchange
                 .app_data(web::Data::new(listings_manager.clone()))
                 // Decision registry for governance meetings and decisions
@@ -1249,6 +1287,15 @@ impl GatewayServer {
                                 .wrap(auth.clone()),
                         )
                         // Service discovery endpoints (auth + rate limiting)
+                        .service(
+                            web::scope("/names")
+                                .configure(api::names::configure)
+                                .wrap(middleware::from_fn(
+                                    crate::rate_limit::trust_rate_limit_middleware,
+                                ))
+                                .wrap(auth.clone()),
+                        )
+                        // Protected services endpoints (auth + rate limiting)
                         .service(
                             web::scope("/services")
                                 .configure(api::services::configure)

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -596,10 +596,11 @@ impl GatewayServer {
             } else {
                 let store = if let Some(ref data_dir) = self.data_dir {
                     let store_path = data_dir.join("store").join("naming");
-                    info!("Naming service initialized at {:?}", store_path);
-                    Arc::new(SledStore::open(&store_path).map_err(|e| {
+                    let opened = SledStore::open(&store_path).map_err(|e| {
                         GatewayError::InternalError(format!("Failed to open naming store: {e}"))
-                    })?)
+                    })?;
+                    info!("Naming service initialized at {:?}", store_path);
+                    Arc::new(opened)
                 } else {
                     info!("Naming service initialized with temporary storage");
                     Arc::new(SledStore::temporary().map_err(|e| {

--- a/kernel_surface.toml
+++ b/kernel_surface.toml
@@ -14,9 +14,9 @@
 
 [metadata]
 version = "0.2.0"
-last_updated = "2026-02-10"
-total_crates = 28
-clean_crates = 8
+last_updated = "2026-02-20"
+total_crates = 29
+clean_crates = 9
 infected_crates = 11
 needs_review_crates = 9
 
@@ -271,6 +271,28 @@ notes = "Transaction support - kernel primitive"
 name = "StorageQuota"
 kind = "struct"
 notes = "Resource limits - kernel primitive"
+
+# -----------------------------------------------------------------------------
+
+[crates.icn-naming]
+description = "KV-backed hierarchical naming service"
+status = "clean"
+infection_notes = """
+Implements NamingService trait from icn-kernel-api. Provides generic
+hierarchical name resolution backed by icn-store (SledStore).
+
+No imports of icn-trust, icn-governance, icn-ledger, icn-ccl, icn-entity,
+icn-community, icn-federation, or icn-steward. Signature verification uses
+icn-identity primitives only.
+
+Added to icn-gateway in PR #1250 (Sprint 7 names API wiring).
+"""
+
+[[crates.icn-naming.exports]]
+name = "SledNamingService"
+kind = "struct"
+public_methods = ["new", "register", "resolve", "resolve_with_options", "update", "delete"]
+notes = "Concrete NamingService implementation - wraps SledStore"
 
 # -----------------------------------------------------------------------------
 

--- a/sdk/typescript/eslint.config.js
+++ b/sdk/typescript/eslint.config.js
@@ -1,0 +1,20 @@
+const tsParser = require("@typescript-eslint/parser");
+const tsPlugin = require("@typescript-eslint/eslint-plugin");
+
+module.exports = [
+  {
+    ignores: ["dist/**", "src/generated/**"],
+  },
+  {
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: "latest",
+      sourceType: "module",
+    },
+    plugins: {
+      "@typescript-eslint": tsPlugin,
+    },
+    rules: {},
+  },
+];

--- a/sdk/typescript/eslint.config.js
+++ b/sdk/typescript/eslint.config.js
@@ -15,6 +15,8 @@ module.exports = [
     plugins: {
       "@typescript-eslint": tsPlugin,
     },
-    rules: {},
+    rules: {
+      ...tsPlugin.configs["recommended"].rules,
+    },
   },
 ];

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -12,6 +12,9 @@
         "@types/jest": "^30.0.0",
         "@types/node": "^25.2.3",
         "@types/ws": "^8.5.10",
+        "@typescript-eslint/eslint-plugin": "^8.56.0",
+        "@typescript-eslint/parser": "^8.56.0",
+        "eslint": "^10.0.0",
         "jest": "^30.2.0",
         "openapi-typescript": "^7.13.0",
         "ts-jest": "^29.4.6",
@@ -574,6 +577,191 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.1.tgz",
+      "integrity": "sha512-uVSdg/V4dfQmTjJzR0szNczjOH/J+FyUMMjYtr07xFRXR7EDf9i1qdxrD0VusZH9knj1/ecxzCQQxyic5NzAiA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.1",
+        "debug": "^4.3.1",
+        "minimatch": "^10.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
+      "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.2.tgz",
+      "integrity": "sha512-a5MxrdDXEvqnIq+LisyCX6tQMPF/dSJpCfBgBauY+pNZ28yCtSsTvyTYrMhaI+LK26bVyCJfJkT0u8KIj2i1dQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.1.tgz",
+      "integrity": "sha512-P9cq2dpr+LU8j3qbLygLcSZrl2/ds/pUpfnHNNuk5HW7mnngHs+6WSq5C9mO3rqRX8A1poxqLTC9cu0KOyJlBg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.0.tgz",
+      "integrity": "sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1286,6 +1474,20 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -1323,6 +1525,13 @@
         "expect": "^30.0.0",
         "pretty-format": "^30.0.0"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.2.3",
@@ -1367,6 +1576,268 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.0.tgz",
+      "integrity": "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/type-utils": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.56.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.0.tgz",
+      "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.0.tgz",
+      "integrity": "sha512-M3rnyL1vIQOMeWxTWIW096/TtVP+8W3p/XnaFflhmcFp+U4zlxUxWj4XwNs6HbDeTtN4yun0GNTTDBw/SvufKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.56.0",
+        "@typescript-eslint/types": "^8.56.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.0.tgz",
+      "integrity": "sha512-7UiO/XwMHquH+ZzfVCfUNkIXlp/yQjjnlYUyYz7pfvlK3/EyyN6BK+emDmGNyQLBtLGaYrTAI6KOw8tFucWL2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.0.tgz",
+      "integrity": "sha512-bSJoIIt4o3lKXD3xmDh9chZcjCz5Lk8xS7Rxn+6l5/pKrDpkCwtQNQQwZ2qRPk7TkUYhrq3WPIHXOXlbXP0itg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.0.tgz",
+      "integrity": "sha512-qX2L3HWOU2nuDs6GzglBeuFXviDODreS58tLY/BALPC7iu3Fa+J7EOTwnX9PdNBxUI7Uh0ntP0YWGnxCkXzmfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.0.tgz",
+      "integrity": "sha512-DBsLPs3GsWhX5HylbP9HNG15U0bnwut55Lx12bHB9MpXxQ+R5GC8MwQe+N1UFXxAeQDvEsEDY6ZYwX03K7Z6HQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.0.tgz",
+      "integrity": "sha512-ex1nTUMWrseMltXUHmR2GAQ4d+WjkZCT4f+4bVsps8QEdh0vlBsaCokKTPlnqBFqqGaxilDNJG7b8dolW2m43Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.56.0",
+        "@typescript-eslint/tsconfig-utils": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
+        "debug": "^4.4.3",
+        "minimatch": "^9.0.5",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.0.tgz",
+      "integrity": "sha512-RZ3Qsmi2nFGsS+n+kjLAYDPVlrzf7UhTffrDIKr+h2yzAlYP/y5ZulU0yeDEPItos2Ph46JAL5P/On3pe7kDIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.0.tgz",
+      "integrity": "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
+      "integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -1657,6 +2128,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
@@ -1679,6 +2160,30 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -2282,6 +2787,13 @@
         }
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -2376,6 +2888,249 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.0.tgz",
+      "integrity": "sha512-O0piBKY36YSJhlFSG8p9VUdPV/SxxS4FYDWVpr/9GJuMaepzwlf4J8I4ov1b+ySQfDTPhc3DtLaxcT1fN0yqCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.0",
+        "@eslint/config-helpers": "^0.5.2",
+        "@eslint/core": "^1.1.0",
+        "@eslint/plugin-kit": "^0.6.0",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.12.4",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.0",
+        "eslint-visitor-keys": "^5.0.0",
+        "espree": "^11.1.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.1.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.0.tgz",
+      "integrity": "sha512-CkWE42hOJsNj9FJRaoMX9waUFYhqY4jmyLFdAdzZr6VaCg3ynLYx4WnOdkaIifGfH4gsUcBTn4OZbHXkpLD0FQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
+      "integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
+      "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.1.0.tgz",
+      "integrity": "sha512-WFWYhO1fV4iYkqOOvq8FbqIhr2pYfoDY0kCotMkDeNtGpiGGkZ1iov2u8ydjtgM8yF8rzK7oaTbw2NAzbAbehw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
+      "integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -2388,6 +3143,52 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/execa": {
@@ -2456,6 +3257,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -2481,6 +3289,19 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -2509,6 +3330,27 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -2626,6 +3468,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/glob/node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -2712,6 +3567,16 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -2781,6 +3646,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2799,6 +3674,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-number": {
@@ -3623,6 +4511,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -3634,6 +4529,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3650,6 +4552,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -3658,6 +4570,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -3928,6 +4854,24 @@
         "typescript": "^5.x"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -4115,6 +5059,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
@@ -4141,6 +5095,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/pure-rand": {
@@ -4565,6 +5529,54 @@
         "node": "*"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -4583,6 +5595,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-jest": {
@@ -4702,6 +5727,19 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -4827,6 +5865,16 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -4884,6 +5932,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wordwrap": {

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -32,11 +32,13 @@
     "url": "https://github.com/InterCooperative-Network/icn.git",
     "directory": "sdk/typescript"
   },
-  "dependencies": {},
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^25.2.3",
     "@types/ws": "^8.5.10",
+    "@typescript-eslint/eslint-plugin": "^8.56.0",
+    "@typescript-eslint/parser": "^8.56.0",
+    "eslint": "^10.0.0",
     "jest": "^30.2.0",
     "openapi-typescript": "^7.13.0",
     "ts-jest": "^29.4.6",

--- a/sdk/typescript/src/index.test.ts
+++ b/sdk/typescript/src/index.test.ts
@@ -1485,7 +1485,6 @@ describe('vote delegation', () => {
       await expect(
         client.createDelegation({
           delegate: 'did:icn:zValidKeyABCDEF',
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           scope: 'invalid-scope' as any, // Bypass type check for runtime validation test
         })
       ).rejects.toThrow("scope must be 'blanket'");
@@ -1495,7 +1494,6 @@ describe('vote delegation', () => {
       await expect(
         client.createDelegation({
           delegate: 'did:icn:zValidKeyABCDEF',
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           scope: 'domain:' as any, // Bypass type check for runtime validation test
         })
       ).rejects.toThrow('scope ID cannot be empty');

--- a/sdk/typescript/src/index.test.ts
+++ b/sdk/typescript/src/index.test.ts
@@ -2314,6 +2314,78 @@ describe('identity resolution', () => {
   });
 });
 
+describe('name resolution', () => {
+  it('should resolve a name path without leading slash', async () => {
+    const mockResponse = {
+      name: '/org/demo/ledger',
+      resolved_name: '/org/demo/ledger',
+      target: {
+        kind: 'service',
+        endpoint: { protocol: 'https', host: 'ledger.demo', port: 443 },
+      },
+      authority: 'did:icn:alice',
+      ttl_secs: 300,
+      created_at: 1700000000,
+      updated_at: 1700000000,
+      metadata: {},
+    };
+
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockResponse,
+    });
+
+    const client = new ICNClient({
+      baseUrl: 'http://localhost:8080',
+      token: 'test-token',
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    const result = await client.names.resolve('org/demo/ledger');
+
+    expect(result.resolved_name).toBe('/org/demo/ledger');
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:8080/v1/names/org/demo/ledger');
+  });
+
+  it('should resolve a name path with options', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        name: '/org/demo/alias',
+        resolved_name: '/org/demo/service',
+        target: {
+          kind: 'service',
+          endpoint: { protocol: 'https', host: 'service.demo', port: 443 },
+        },
+        authority: 'did:icn:bob',
+        ttl_secs: 300,
+        created_at: 1700000000,
+        updated_at: 1700000001,
+        metadata: {},
+      }),
+    });
+
+    const client = new ICNClient({
+      baseUrl: 'http://localhost:8080',
+      token: 'test-token',
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    await client.names.resolve('/org/demo/alias', {
+      verify_signatures: false,
+      max_depth: 4,
+    });
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe(
+      'http://localhost:8080/v1/names/org/demo/alias?verify_signatures=false&max_depth=4'
+    );
+  });
+});
+
 describe('device management', () => {
   it('should register a new device', async () => {
     const mockResponse = {

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -168,12 +168,15 @@ import {
   GovernanceReceiptResponse,
   TreasuryClient,
   GovernanceClient,
+  NamesClient,
   // Service discovery types
   ServiceEndpointInfo,
   AnnounceServiceRequest,
   AnnounceServiceResponse,
   DiscoverServicesRequest,
   DiscoverServicesResponse,
+  ResolveNameOptions,
+  ResolveNameResponse,
 } from './types';
 
 export * from './types';
@@ -323,6 +326,7 @@ export class ICNClient {
   private scopes?: string[];
   public readonly treasury: TreasuryClient;
   public readonly governance: GovernanceClient;
+  public readonly names: NamesClient;
 
   constructor(options: ICNClientOptions) {
     this.baseUrl = options.baseUrl.replace(/\/$/, '');
@@ -361,6 +365,38 @@ export class ICNClient {
         this.get<GovernanceReceiptResponse>(
           `/proposals/${encodeURIComponent(proposalId)}/proof`
         ),
+    };
+    this.names = {
+      resolve: async (
+        path: string,
+        options?: ResolveNameOptions
+      ): Promise<ResolveNameResponse> => {
+        const normalizedPath = path.replace(/^\/+/, '');
+        if (!normalizedPath) {
+          throw new ICNError('name path is required', 400, 'INVALID_NAME_PATH');
+        }
+
+        const encodedPath = normalizedPath
+          .split('/')
+          .filter((segment) => segment.length > 0)
+          .map((segment) => encodeURIComponent(segment))
+          .join('/');
+        if (!encodedPath) {
+          throw new ICNError('name path is required', 400, 'INVALID_NAME_PATH');
+        }
+
+        const params = new URLSearchParams();
+        if (options?.verify_signatures !== undefined) {
+          params.set('verify_signatures', String(options.verify_signatures));
+        }
+        if (options?.max_depth !== undefined) {
+          params.set('max_depth', String(options.max_depth));
+        }
+        const query = params.toString();
+        return this.get<ResolveNameResponse>(
+          `/names/${encodedPath}${query ? `?${query}` : ''}`
+        );
+      },
     };
   }
 

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -1898,6 +1898,11 @@ export interface GovernanceClient {
   getProof(proposalId: string): Promise<GovernanceReceiptResponse>;
 }
 
+/** Flow B names sub-client surface */
+export interface NamesClient {
+  resolve(path: string, options?: ResolveNameOptions): Promise<ResolveNameResponse>;
+}
+
 // ============================================================================
 // Service Discovery / Naming
 // ============================================================================
@@ -1983,4 +1988,46 @@ export interface DiscoverServicesResponse {
   services: ServiceEndpointInfo[];
   /** Total results */
   total: number;
+}
+
+/** Optional name resolution controls */
+export interface ResolveNameOptions {
+  /** Whether to verify signatures during resolution (default: true) */
+  verify_signatures?: boolean;
+  /** Maximum alias recursion depth */
+  max_depth?: number;
+}
+
+export interface ResolveNameEndpoint {
+  protocol: string;
+  host: string;
+  port: number;
+  path?: string;
+}
+
+export type ResolveNameTarget =
+  | { kind: 'service'; endpoint: ResolveNameEndpoint }
+  | { kind: 'blob'; hash: string }
+  | { kind: 'namespace'; org: string; app: string; sub?: string }
+  | { kind: 'alias'; name: string }
+  | { kind: 'multiService'; endpoints: ResolveNameEndpoint[] };
+
+/** Response from GET /v1/names/{path} */
+export interface ResolveNameResponse {
+  /** Requested name */
+  name: string;
+  /** Final resolved record name (after alias following) */
+  resolved_name: string;
+  /** Resolved target */
+  target: ResolveNameTarget;
+  /** Authority DID controlling the record */
+  authority: string;
+  /** Cache TTL in seconds */
+  ttl_secs: number;
+  /** Record creation timestamp */
+  created_at: number;
+  /** Record update timestamp */
+  updated_at: number;
+  /** Record metadata map */
+  metadata: Record<string, string>;
 }


### PR DESCRIPTION
## Summary
- Adds gateway names API wiring
- Updates TypeScript SDK surface/types for names
- Adds minimal ESLint tooling so `npm run lint` works in sdk/typescript (flat config)

## Validation
Rust:
- ✅ cargo fmt --check
- ✅ cargo clippy (icn-gateway + icn-naming, -D warnings)
- ✅ cargo test (icn-core + icn-gateway)

TypeScript SDK (sdk/typescript):
- ✅ npm run build
- ✅ npm test
- ✅ npm run lint

## Notes
- ESLint config is intentionally minimal and scoped to src/**/*.ts; dist/ and src/generated/ ignored.
