### PR TITLE
fix(ci): clean stale Cargo test binaries before test run on self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,18 +311,22 @@ jobs:
         run: |
           # Test executables accumulate in target/debug/ across CI runs on self-hosted
           # runners. Remove them before building so the linker can't run out of disk.
-          # .rlib/.rmeta files are preserved — sccache can repopulate them if missing,
-          # but keeping them avoids the extra sccache round-trip on relink.
+          # lib*.rlib / lib*.rmeta / lib*.d are preserved — sccache can repopulate
+          # them if missing, but keeping them avoids an extra sccache round-trip.
+          # NOTE: We must also delete .d files for test executables (non-lib*.d).
+          # Keeping a .d file for a deleted binary causes Cargo to skip relinking
+          # (fingerprint says "up-to-date") but then fail with ENOENT at runtime.
           if [ -d icn/target/debug ]; then
             echo "=== Disk before Cargo cleanup ==="
             df -h / | tail -1
             # Remove top-level test executables (cargo places copies here)
             find icn/target/debug -maxdepth 1 -type f -delete 2>/dev/null || true
-            # Remove test executables from deps/ but keep compiled rlib/rmeta/d files
+            # Remove test executables + their .d dep-files from deps/.
+            # Keep only lib-prefixed files: lib*.rlib, lib*.rmeta, lib*.d, *.so
             find icn/target/debug/deps -maxdepth 1 -type f \
-              ! -name "*.rlib" \
-              ! -name "*.rmeta" \
-              ! -name "*.d" \
+              ! -name "lib*.rlib" \
+              ! -name "lib*.rmeta" \
+              ! -name "lib*.d" \
               ! -name "*.so" \
               -delete 2>/dev/null || true
             echo "=== Disk after Cargo cleanup ==="

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,29 @@ jobs:
         with:
           verbose: 'true'
 
+      - name: Clean stale Cargo test binaries
+        if: needs.changes.outputs.docs_only != 'true'
+        run: |
+          # Test executables accumulate in target/debug/ across CI runs on self-hosted
+          # runners. Remove them before building so the linker can't run out of disk.
+          # .rlib/.rmeta files are preserved — sccache can repopulate them if missing,
+          # but keeping them avoids the extra sccache round-trip on relink.
+          if [ -d icn/target/debug ]; then
+            echo "=== Disk before Cargo cleanup ==="
+            df -h / | tail -1
+            # Remove top-level test executables (cargo places copies here)
+            find icn/target/debug -maxdepth 1 -type f -delete 2>/dev/null || true
+            # Remove test executables from deps/ but keep compiled rlib/rmeta/d files
+            find icn/target/debug/deps -maxdepth 1 -type f \
+              ! -name "*.rlib" \
+              ! -name "*.rmeta" \
+              ! -name "*.d" \
+              ! -name "*.so" \
+              -delete 2>/dev/null || true
+            echo "=== Disk after Cargo cleanup ==="
+            df -h / | tail -1
+          fi
+
       - name: Install build tools
         if: needs.changes.outputs.docs_only != 'true'
         uses: ./.github/actions/install-build-tools


### PR DESCRIPTION
## Summary

- Adds a "Clean stale Cargo test binaries" step to the \`test\` CI job, between \`Free disk space\` and \`Install build tools\`
- Removes previously-linked test executables **and their \`.d\` dep-files** from \`target/debug/\` and \`target/debug/deps/\` before each run, while preserving library files (\`lib*.rlib\`, \`lib*.rmeta\`, \`lib*.d\`)
- Prevents \`No space left on device\` linker failures that occur when test binary accumulation from prior runs fills the runner disk

## Root Cause

The \`free-disk-space\` action removes pre-installed OS tooling (dotnet, Android SDK, CodeQL, etc.) designed for GitHub-hosted runners. On the self-hosted k3s workers those paths don't exist — the only meaningful cleanup it does is \`docker system prune -af\`.

The Cargo \`target/debug/\` directory is never cleaned between CI runs (that would defeat sccache). With a 39-crate workspace running three test passes (unit + integration + sled-storage), each CI run generates **15–30 GB** of test executables. These accumulate across runs until the linker can't write new binaries:

```
/usr/bin/ld: final link failed: No space left on device
```

Observed failure: run [22190713144](https://github.com/InterCooperative-Network/icn/actions/runs/22190713144), job 64177406114, step "Run sled storage tests", commit f2732365, runner \`homelab-k3s-worker-41\`.

## Second Bug Found and Fixed

The initial version of this PR preserved **all** \`.d\` files, including those for test executables. This exposed a Cargo fingerprinting edge case:

1. Previous run: \`icn_gateway-{hash}\` compiled and \`icn_gateway-{hash}.d\` written
2. Our cleanup: deleted \`icn_gateway-{hash}\` but preserved \`icn_gateway-{hash}.d\`
3. Next run: Cargo sees \`.d\` file, checks inputs — sccache 100% hit — concludes "up-to-date", **skips relinking**
4. Cargo tries to exec \`icn_gateway-{hash}\` → \`No such file or directory (os error 2)\`

Observed failure: run [22210185860](https://github.com/InterCooperative-Network/icn/actions/runs/22210185860), PR #1251 Test job, 12-minute runtime (fast fail, not disk exhaustion).

Fix: use \`lib*\` prefix matching — only library outputs have this prefix (\`lib*.rlib\`, \`lib*.rmeta\`, \`lib*.d\`). Test binary artifacts (\`icn_gateway-{hash}\`, \`icn_gateway-{hash}.d\`) don't have the \`lib\` prefix and are deleted.

## How It Works

```bash
# Remove top-level test executables (cargo places copies here)
find icn/target/debug -maxdepth 1 -type f -delete

# Remove test executables + their .d dep-files from deps/.
# Keep only lib-prefixed files: lib*.rlib, lib*.rmeta, lib*.d, *.so
find icn/target/debug/deps -maxdepth 1 -type f \
  ! -name "lib*.rlib" ! -name "lib*.rmeta" ! -name "lib*.d" ! -name "*.so" \
  -delete
```

sccache still provides full benefit: \`lib*.rlib\`/\`lib*.rmeta\` are preserved so compilation is cache-hot, and the test binary relink (always fast) happens fresh every run.

## Risk

Infra-only change. Only affects the self-hosted \`[self-hosted, linux, x64, homelab, k3s]\` runner. The \`if: needs.changes.outputs.docs_only != 'true'\` guard means docs-only PRs skip it entirely.

## Test Plan

- [ ] Test job passes on self-hosted runner (two consecutive green runs)
- [ ] Disk usage stays flat across back-to-back CI runs