### PR TITLE
feat(sdk): WASM module client + typed error mapping

### DIFF
--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -180,6 +180,8 @@ import {
 } from './types';
 
 export * from './types';
+export { WasmClient } from './wasm';
+export type { WasmModuleInfo, WasmDeployResult, WasmClientOptions } from './wasm';
 
 /** Default retry options */
 const DEFAULT_RETRY: Required<RetryOptions> = {

--- a/sdk/typescript/src/typed_error_mapping.test.ts
+++ b/sdk/typescript/src/typed_error_mapping.test.ts
@@ -1,0 +1,140 @@
+/**
+ * WasmClient typed error mapping tests
+ *
+ * Verifies that HTTP status codes from the gateway are translated into the
+ * correct typed exception subclasses (G0 ErrCode taxonomy).
+ */
+
+import { WasmClient } from './wasm';
+import {
+  AuthenticationError,
+  ConflictError,
+  NotFoundError,
+  NetworkError,
+  RateLimitError,
+  ServerError,
+  ValidationError,
+} from './types';
+
+const WASM_MAGIC = new Uint8Array([0x00, 0x61, 0x73, 0x6d]);
+const FAKE_HASH = 'a'.repeat(64);
+
+function mockFetch(status: number, body: unknown) {
+  return jest.fn().mockResolvedValue({
+    ok: status < 400,
+    status,
+    statusText: 'Error',
+    json: () => Promise.resolve(body),
+  });
+}
+
+function makeClient(fetchImpl: jest.Mock) {
+  return new WasmClient({
+    baseUrl: 'http://localhost:8080',
+    token: 'tok',
+    fetch: fetchImpl as unknown as typeof fetch,
+  });
+}
+
+describe('WasmClient typed error mapping', () => {
+  it('throws AuthenticationError (401) — invalid token', async () => {
+    const client = makeClient(
+      mockFetch(401, { error: 'Unauthorized', code: 'AUTHENTICATION_REQUIRED' }),
+    );
+    const err = await client.deploy(WASM_MAGIC).catch((e) => e);
+    expect(err).toBeInstanceOf(AuthenticationError);
+    expect(err.statusCode).toBe(401);
+  });
+
+  it('throws AuthenticationError immediately when token is absent', async () => {
+    const fetchImpl = mockFetch(200, {});
+    const client = new WasmClient({
+      baseUrl: 'http://localhost:8080',
+      fetch: fetchImpl as unknown as typeof fetch,
+    });
+    await expect(client.get(FAKE_HASH)).rejects.toBeInstanceOf(AuthenticationError);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('throws ValidationError (400 VALIDATION_FAILED)', async () => {
+    const client = makeClient(
+      mockFetch(400, { error: 'Bad WASM', code: 'VALIDATION_FAILED', details: { fields: {} } }),
+    );
+    const err = await client.deploy(WASM_MAGIC).catch((e) => e);
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err.statusCode).toBe(400);
+  });
+
+  it('throws NotFoundError (404) for get', async () => {
+    const client = makeClient(
+      mockFetch(404, { error: 'Not found', code: 'NOT_FOUND' }),
+    );
+    const err = await client.get(FAKE_HASH).catch((e) => e);
+    expect(err).toBeInstanceOf(NotFoundError);
+    expect(err.statusCode).toBe(404);
+  });
+
+  it('throws ConflictError (409) for duplicate deploy', async () => {
+    const client = makeClient(
+      mockFetch(409, { error: 'Already exists', code: 'CONFLICT' }),
+    );
+    const err = await client.deploy(WASM_MAGIC).catch((e) => e);
+    expect(err).toBeInstanceOf(ConflictError);
+    expect(err.statusCode).toBe(409);
+  });
+
+  it('throws RateLimitError (429)', async () => {
+    const client = makeClient(
+      mockFetch(429, { error: 'Too many requests', code: 'RATE_LIMITED', details: { retry_after: 30 } }),
+    );
+    const err = await client.list().catch((e) => e);
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err.statusCode).toBe(429);
+    expect(err.retryAfter).toBe(30);
+  });
+
+  it('throws ServerError (500)', async () => {
+    const client = makeClient(
+      mockFetch(500, { error: 'Internal error', code: 'INTERNAL_ERROR' }),
+    );
+    const err = await client.list().catch((e) => e);
+    expect(err).toBeInstanceOf(ServerError);
+    expect(err.statusCode).toBe(500);
+  });
+
+  it('throws NetworkError when fetch rejects', async () => {
+    const fetchImpl = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const client = new WasmClient({
+      baseUrl: 'http://localhost:8080',
+      token: 'tok',
+      fetch: fetchImpl as unknown as typeof fetch,
+    });
+    const err = await client.list().catch((e) => e);
+    expect(err).toBeInstanceOf(NetworkError);
+    expect(err.message).toContain('ECONNREFUSED');
+  });
+
+  it('error.code is propagated for client inspection', async () => {
+    const client = makeClient(
+      mockFetch(409, { error: 'WASM module already exists', code: 'CONFLICT' }),
+    );
+    const err = await client.deploy(WASM_MAGIC).catch((e) => e);
+    expect(err.code).toBe('CONFLICT');
+  });
+
+  it('setToken / clearToken gates requests', async () => {
+    const fetchImpl = mockFetch(200, []);
+    const client = new WasmClient({
+      baseUrl: 'http://localhost:8080',
+      fetch: fetchImpl as unknown as typeof fetch,
+    });
+
+    await expect(client.list()).rejects.toBeInstanceOf(AuthenticationError);
+
+    client.setToken('new-token');
+    await expect(client.list()).resolves.toEqual([]);
+
+    client.clearToken();
+    await expect(client.list()).rejects.toBeInstanceOf(AuthenticationError);
+  });
+});

--- a/sdk/typescript/src/wasm.deploy.test.ts
+++ b/sdk/typescript/src/wasm.deploy.test.ts
@@ -1,0 +1,109 @@
+/**
+ * WasmClient.deploy tests
+ */
+
+import { WasmClient, WasmDeployResult } from './wasm';
+import { ConflictError, ValidationError, AuthenticationError } from './types';
+
+const FAKE_HASH = 'a'.repeat(64);
+
+function mockFetch(status: number, body: unknown) {
+  return jest.fn().mockResolvedValue({
+    ok: status < 400,
+    status,
+    statusText: status < 400 ? 'OK' : 'Error',
+    json: () => Promise.resolve(body),
+  });
+}
+
+function makeClient(fetchImpl: jest.Mock, token = 'test-token') {
+  return new WasmClient({
+    baseUrl: 'http://localhost:8080',
+    token,
+    fetch: fetchImpl as unknown as typeof fetch,
+  });
+}
+
+const WASM_MAGIC = new Uint8Array([0x00, 0x61, 0x73, 0x6d]); // \0asm
+
+describe('WasmClient.deploy', () => {
+  it('uploads bytes and returns deploy result', async () => {
+    const deployResult: WasmDeployResult = { hash: FAKE_HASH, size: 4, name: 'test-mod' };
+    const fetchImpl = mockFetch(201, deployResult);
+    const client = makeClient(fetchImpl);
+
+    const result = await client.deploy(WASM_MAGIC, { name: 'test-mod' });
+
+    expect(result.hash).toBe(FAKE_HASH);
+    expect(result.size).toBe(4);
+    expect(result.name).toBe('test-mod');
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://localhost:8080/v1/compute/wasm/upload',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('sends name and description in request body', async () => {
+    const fetchImpl = mockFetch(201, { hash: FAKE_HASH, size: 4 });
+    const client = makeClient(fetchImpl);
+
+    await client.deploy(WASM_MAGIC, { name: 'my-mod', description: 'does things' });
+
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as {
+      wasm_bytes: string;
+      name?: string;
+      description?: string;
+    };
+    expect(body.name).toBe('my-mod');
+    expect(body.description).toBe('does things');
+    expect(typeof body.wasm_bytes).toBe('string');
+  });
+
+  it('accepts ArrayBuffer input', async () => {
+    const fetchImpl = mockFetch(201, { hash: FAKE_HASH, size: 4 });
+    const client = makeClient(fetchImpl);
+
+    const ab = WASM_MAGIC.buffer;
+    await expect(client.deploy(ab)).resolves.toBeDefined();
+  });
+
+  it('throws AuthenticationError when no token set', async () => {
+    const fetchImpl = mockFetch(201, {});
+    const client = new WasmClient({
+      baseUrl: 'http://localhost:8080',
+      fetch: fetchImpl as unknown as typeof fetch,
+    });
+
+    await expect(client.deploy(WASM_MAGIC)).rejects.toBeInstanceOf(AuthenticationError);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('throws ConflictError (409) when module already exists', async () => {
+    const fetchImpl = mockFetch(409, { error: 'Already exists', code: 'CONFLICT' });
+    const client = makeClient(fetchImpl);
+
+    await expect(client.deploy(WASM_MAGIC)).rejects.toBeInstanceOf(ConflictError);
+  });
+
+  it('throws ValidationError (400) for invalid WASM bytes', async () => {
+    const fetchImpl = mockFetch(400, {
+      error: 'Invalid WASM',
+      code: 'VALIDATION_FAILED',
+      details: { fields: {} },
+    });
+    const client = makeClient(fetchImpl);
+
+    await expect(client.deploy(new Uint8Array([0xff]))).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('passes Authorization header', async () => {
+    const fetchImpl = mockFetch(201, { hash: FAKE_HASH, size: 4 });
+    const client = makeClient(fetchImpl, 'my-secret-token');
+
+    await client.deploy(WASM_MAGIC);
+
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer my-secret-token');
+  });
+});

--- a/sdk/typescript/src/wasm.list.test.ts
+++ b/sdk/typescript/src/wasm.list.test.ts
@@ -1,0 +1,119 @@
+/**
+ * WasmClient.list and WasmClient.get tests
+ */
+
+import { WasmClient, WasmModuleInfo } from './wasm';
+import { NotFoundError } from './types';
+
+const MODULES: WasmModuleInfo[] = [
+  {
+    hash: 'a'.repeat(64),
+    name: 'mod-alice',
+    size_bytes: 100,
+    owner: 'did:icn:alice',
+    deployed_at: 1_000_000,
+  },
+  {
+    hash: 'b'.repeat(64),
+    name: 'mod-bob',
+    size_bytes: 200,
+    owner: 'did:icn:bob',
+    deployed_at: 2_000_000,
+  },
+  {
+    hash: 'c'.repeat(64),
+    name: 'mod-alice-2',
+    size_bytes: 300,
+    owner: 'did:icn:alice',
+    deployed_at: 3_000_000,
+  },
+];
+
+function mockFetch(status: number, body: unknown) {
+  return jest.fn().mockResolvedValue({
+    ok: status < 400,
+    status,
+    statusText: status < 400 ? 'OK' : 'Not Found',
+    json: () => Promise.resolve(body),
+  });
+}
+
+function makeClient(fetchImpl: jest.Mock) {
+  return new WasmClient({
+    baseUrl: 'http://localhost:8080',
+    token: 'tok',
+    fetch: fetchImpl as unknown as typeof fetch,
+  });
+}
+
+describe('WasmClient.list', () => {
+  it('returns all modules when owner is not specified', async () => {
+    const client = makeClient(mockFetch(200, MODULES));
+    const result = await client.list();
+    expect(result).toHaveLength(3);
+  });
+
+  it('filters by owner DID', async () => {
+    const client = makeClient(mockFetch(200, MODULES));
+    const result = await client.list('did:icn:alice');
+    expect(result).toHaveLength(2);
+    expect(result.every((m) => m.owner === 'did:icn:alice')).toBe(true);
+  });
+
+  it('returns empty array when no modules match owner', async () => {
+    const client = makeClient(mockFetch(200, MODULES));
+    const result = await client.list('did:icn:nobody');
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns empty array when registry is empty', async () => {
+    const client = makeClient(mockFetch(200, []));
+    const result = await client.list();
+    expect(result).toHaveLength(0);
+  });
+
+  it('calls GET /v1/compute/wasm', async () => {
+    const fetchImpl = mockFetch(200, MODULES);
+    const client = makeClient(fetchImpl);
+    await client.list();
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://localhost:8080/v1/compute/wasm',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+});
+
+describe('WasmClient.get', () => {
+  it('returns module metadata for a known hash', async () => {
+    const mod = MODULES[0];
+    const client = makeClient(mockFetch(200, mod));
+
+    const result = await client.get(mod.hash);
+    expect(result.hash).toBe(mod.hash);
+    expect(result.owner).toBe('did:icn:alice');
+    expect(result.size_bytes).toBe(100);
+  });
+
+  it('calls GET /v1/compute/wasm/{hash}', async () => {
+    const fetchImpl = mockFetch(200, MODULES[0]);
+    const client = makeClient(fetchImpl);
+    const hash = MODULES[0].hash;
+    await client.get(hash);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      `http://localhost:8080/v1/compute/wasm/${hash}`,
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('throws NotFoundError for unknown hash', async () => {
+    const client = makeClient(mockFetch(404, { error: 'Not found', code: 'NOT_FOUND' }));
+    await expect(client.get('0'.repeat(64))).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('preserves optional description field', async () => {
+    const mod: WasmModuleInfo = { ...MODULES[0], description: 'my desc' };
+    const client = makeClient(mockFetch(200, mod));
+    const result = await client.get(mod.hash);
+    expect(result.description).toBe('my desc');
+  });
+});

--- a/sdk/typescript/src/wasm.ts
+++ b/sdk/typescript/src/wasm.ts
@@ -1,0 +1,234 @@
+/**
+ * ICN WASM Module Client
+ *
+ * A focused client for deploying and querying WASM modules in the ICN
+ * compute registry. Errors are mapped to the typed exception hierarchy
+ * defined in types.ts (G0 ErrCode taxonomy).
+ *
+ * @example
+ * ```typescript
+ * const wasm = new WasmClient({ baseUrl: 'http://localhost:8080', token });
+ *
+ * const { hash } = await wasm.deploy(wasmBytes, { name: 'my-module' });
+ * const meta = await wasm.get(hash);
+ * const all = await wasm.list();
+ * const mine = await wasm.list('did:icn:alice');
+ * ```
+ */
+
+import {
+  ErrorCode,
+  AuthenticationError,
+  NetworkError,
+  TimeoutError,
+  createErrorFromResponse,
+} from './types';
+
+// ============================================================================
+// Response types — shape matches gateway WasmMetadataResponse
+// ============================================================================
+
+/** Metadata for a WASM module as returned by the gateway */
+export interface WasmModuleInfo {
+  /** Blake3 hash of the module bytes (64-char hex) */
+  hash: string;
+  /** Human-readable name, if set at upload time */
+  name?: string;
+  /** Size of the module in bytes */
+  size_bytes: number;
+  /** DID of the account that deployed this module */
+  owner: string;
+  /** Unix timestamp (seconds) when the module was deployed */
+  deployed_at: number;
+  /** Optional description set at upload time */
+  description?: string;
+}
+
+/** Result from a successful WASM deploy */
+export interface WasmDeployResult {
+  /** Blake3 hash of the deployed module (64-char hex) */
+  hash: string;
+  /** Size of the module in bytes */
+  size: number;
+  /** Name as stored, if provided */
+  name?: string;
+}
+
+// ============================================================================
+// Client options
+// ============================================================================
+
+export interface WasmClientOptions {
+  /** Gateway base URL without /v1 prefix (e.g. "http://localhost:8080") */
+  baseUrl: string;
+  /** JWT bearer token for authenticated requests */
+  token?: string;
+  /** Request timeout in milliseconds (default: 30 000) */
+  timeout?: number;
+  /** Custom fetch implementation (useful in tests) */
+  fetch?: typeof fetch;
+}
+
+// ============================================================================
+// WasmClient
+// ============================================================================
+
+export class WasmClient {
+  private readonly baseUrl: string;
+  private token: string | undefined;
+  private readonly timeout: number;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: WasmClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/$/, '');
+    this.token = options.token;
+    this.timeout = options.timeout ?? 30_000;
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+  }
+
+  /** Set or replace the bearer token */
+  setToken(token: string): void {
+    this.token = token;
+  }
+
+  /** Remove the current token (subsequent calls will throw AuthenticationError) */
+  clearToken(): void {
+    this.token = undefined;
+  }
+
+  /**
+   * Deploy a WASM module to the registry.
+   *
+   * Throws `ConflictError` (409) if the same module has already been deployed.
+   * Throws `ValidationError` (400) if the bytes are not valid WASM.
+   *
+   * @param bytes - Raw WASM module bytes
+   * @param options - Optional name and description metadata
+   * @returns Hash and size of the deployed module
+   */
+  async deploy(
+    bytes: Uint8Array | ArrayBuffer,
+    options?: { name?: string; description?: string },
+  ): Promise<WasmDeployResult> {
+    const arr = bytes instanceof ArrayBuffer ? new Uint8Array(bytes) : bytes;
+    const wasm_bytes = encodeBase64(arr);
+    return this.request<WasmDeployResult>('POST', '/compute/wasm/upload', {
+      wasm_bytes,
+      name: options?.name,
+      description: options?.description,
+    });
+  }
+
+  /**
+   * Fetch metadata for a WASM module by its hash.
+   *
+   * Throws `NotFoundError` (404) if no module with that hash exists.
+   *
+   * @param hash - 64-char hex Blake3 hash of the module
+   */
+  async get(hash: string): Promise<WasmModuleInfo> {
+    return this.request<WasmModuleInfo>(
+      'GET',
+      `/compute/wasm/${encodeURIComponent(hash)}`,
+    );
+  }
+
+  /**
+   * List deployed WASM modules.
+   *
+   * @param owner - Optional DID to filter by deployer. Filtering is applied
+   *   client-side because the gateway does not yet support server-side owner
+   *   filtering.
+   * @returns Array of matching module metadata
+   */
+  async list(owner?: string): Promise<WasmModuleInfo[]> {
+    const modules = await this.request<WasmModuleInfo[]>(
+      'GET',
+      '/compute/wasm',
+    );
+    if (owner !== undefined) {
+      return modules.filter((m) => m.owner === owner);
+    }
+    return modules;
+  }
+
+  // --------------------------------------------------------------------------
+  // Internal HTTP helper
+  // --------------------------------------------------------------------------
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<T> {
+    if (!this.token) {
+      throw new AuthenticationError(
+        'Authentication required',
+        ErrorCode.AUTHENTICATION_REQUIRED,
+      );
+    }
+
+    const url = `${this.baseUrl}/v1${path}`;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+
+    try {
+      const response = await this.fetchImpl(url, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.token}`,
+        },
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        const errorBody = (await response
+          .json()
+          .catch(() => ({}))) as { error?: string; code?: string; details?: unknown };
+        throw createErrorFromResponse(
+          response.status,
+          errorBody.error ?? response.statusText,
+          errorBody.code,
+          errorBody.details,
+        );
+      }
+
+      return (await response.json()) as T;
+    } catch (err) {
+      clearTimeout(timeoutId);
+      if ((err as { name?: string }).name === 'AbortError') {
+        throw new TimeoutError('Request timeout', this.timeout);
+      }
+      if (err instanceof Error && !(err as { statusCode?: number }).statusCode) {
+        throw new NetworkError(err.message);
+      }
+      throw err;
+    }
+  }
+}
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+/**
+ * Encode a Uint8Array as a base64 string.
+ * Uses Buffer in Node.js for efficiency; falls back to btoa in browsers.
+ */
+function encodeBase64(bytes: Uint8Array): string {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(bytes).toString('base64');
+  }
+  // Browser: process in 32 KB chunks to avoid call-stack limits for large modules
+  const CHUNK = 32_768;
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    const chunk = bytes.subarray(i, Math.min(i + CHUNK, bytes.length));
+    binary += String.fromCharCode.apply(null, chunk as unknown as number[]);
+  }
+  return btoa(binary);
+}

--- a/sdk/typescript/src/wasm.ts
+++ b/sdk/typescript/src/wasm.ts
@@ -18,6 +18,7 @@
 
 import {
   ErrorCode,
+  ICNError,
   AuthenticationError,
   NetworkError,
   TimeoutError,
@@ -83,7 +84,7 @@ export class WasmClient {
     this.baseUrl = options.baseUrl.replace(/\/$/, '');
     this.token = options.token;
     this.timeout = options.timeout ?? 30_000;
-    this.fetchImpl = options.fetch ?? globalThis.fetch;
+    this.fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis);
   }
 
   /** Set or replace the bearer token */
@@ -200,13 +201,13 @@ export class WasmClient {
       return (await response.json()) as T;
     } catch (err) {
       clearTimeout(timeoutId);
-      if ((err as { name?: string }).name === 'AbortError') {
+      if (err instanceof ICNError) {
+        throw err;
+      }
+      if ((err as Error).name === 'AbortError') {
         throw new TimeoutError('Request timeout', this.timeout);
       }
-      if (err instanceof Error && !(err as { statusCode?: number }).statusCode) {
-        throw new NetworkError(err.message);
-      }
-      throw err;
+      throw new NetworkError((err as Error).message);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds `WasmClient` to the TypeScript SDK (`sdk/typescript/src/wasm.ts`) for the WASM compute registry
- Exports `WasmClient`, `WasmModuleInfo`, `WasmDeployResult`, `WasmClientOptions` from `index.ts`
- Typed error mapping (G0 ErrCode taxonomy): `NotFoundError`, `ConflictError`, `ValidationError`, `AuthenticationError`, `RateLimitError`, `ServerError`, `NetworkError`

**Public surface:**
```typescript
wasm.deploy(bytes, { name?, description? }) → WasmDeployResult
wasm.get(hash)                              → WasmModuleInfo
wasm.list(owner?)                           → WasmModuleInfo[]
```

**Type correctness:** `WasmModuleInfo` matches the actual gateway `WasmMetadataResponse` shape (`size_bytes`, `owner`, `deployed_at`), correcting pre-existing drift in `types.ts`. `list(owner?)` filters client-side.

## Test plan

- [x] `wasm.deploy.test.ts` — upload bytes, auth guard, conflict/validation error cases
- [x] `wasm.list.test.ts` — list all, filter by owner, get by hash, 404
- [x] `typed_error_mapping.test.ts` — 401/400/404/409/429/500/ECONNREFUSED → typed exceptions
- [x] Full suite: 155 tests, 4 suites, all pass
- [x] `npm run build` — TypeScript compiles cleanly

Closes #1077

🤖 Generated with [Claude Code](https://claude.com/claude-code)