### PR TITLE
fix(demo): correct list parsing and optional name in demo-flow-a.sh

### DIFF
--- a/scripts/demo-flow-a.sh
+++ b/scripts/demo-flow-a.sh
@@ -41,7 +41,7 @@ LIST_RESP=$(curl -sf "$GATEWAY/v1/compute/wasm?limit=10" \
   ${AUTH_HEADER:+-H "$AUTH_HEADER"} 2>&1) \
   || fail "List failed: $LIST_RESP"
 
-MODULE_COUNT=$(echo "$LIST_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['total'])" 2>/dev/null) \
+MODULE_COUNT=$(echo "$LIST_RESP" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))" 2>/dev/null) \
   || fail "Failed to parse list response: $LIST_RESP"
 ok "Found $MODULE_COUNT module(s)"
 
@@ -51,7 +51,7 @@ META_RESP=$(curl -sf "$GATEWAY/v1/compute/wasm/$WASM_HASH" \
   ${AUTH_HEADER:+-H "$AUTH_HEADER"} 2>&1) \
   || fail "Get metadata failed: $META_RESP"
 
-MODULE_NAME=$(echo "$META_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['name'])" 2>/dev/null) \
+MODULE_NAME=$(echo "$META_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('name', '(unnamed)'))" 2>/dev/null) \
   || fail "Failed to parse metadata: $META_RESP"
 ok "Module: $MODULE_NAME (hash: $WASM_HASH)"
 


### PR DESCRIPTION
## Summary
- Fix list endpoint parsing: bare array not `{total}` dict (#1078)
- Fix optional `name` field using `.get('name', '(unnamed)')`

## Test plan
- [ ] Run against devnet after PR #1253 merges: `ICN_GATEWAY=http://... bash scripts/demo-flow-a.sh`
- [ ] Verify MODULE_COUNT is a number, not a KeyError
- [ ] Verify unnamed modules show `(unnamed)` not crash

Closes #1078
🤖 Generated with [Claude Code](https://claude.com/claude-code)