### PR TITLE
fix(ci): concurrency cancellation + timeouts + remove broken benchmark cache

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -91,12 +91,6 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "baseline/icn -> baseline/icn/target"
-          prefix-key: "bench-baseline-${{ github.run_id }}-${{ github.event.pull_request.base.sha }}"
-          cache-on-failure: true
-
       - name: Run baseline benchmarks
         run: cargo bench $BENCH_TARGETS -- --noplot --save-baseline base --sample-size 20
         working-directory: ./baseline/icn
@@ -122,12 +116,6 @@ jobs:
             echo "::error::Baseline benchmarks missing or empty - cannot perform valid comparison"
             exit 1
           fi
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "pr/icn -> pr/icn/target"
-          prefix-key: "bench-pr-${{ github.run_id }}-${{ github.event.pull_request.head.sha }}"
-          cache-on-failure: true
 
       - name: Run PR benchmarks and compare
         id: bench_compare

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -249,6 +253,7 @@ jobs:
   clippy:
     name: Clippy
     needs: [changes]
+    timeout-minutes: 30
     runs-on: [self-hosted, linux, x64, homelab, k3s]
     steps:
       - uses: actions/checkout@v6
@@ -292,6 +297,7 @@ jobs:
   test:
     name: Test
     needs: [changes]
+    timeout-minutes: 90
     runs-on: [self-hosted, linux, x64, homelab, k3s]
     steps:
       - uses: actions/checkout@v6
@@ -398,6 +404,7 @@ jobs:
     name: Test Coverage
     needs: [changes]
     if: needs.changes.outputs.docs_only != 'true'
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -476,6 +483,7 @@ jobs:
   build:
     name: Build Release
     needs: [changes]
+    timeout-minutes: 45
     runs-on: [self-hosted, linux, x64, homelab, k3s]
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Three zero-cost CI performance improvements identified from Sprint 8 runner friction:

- **Concurrency cancellation**: Cancel in-progress runs when a new commit pushes to the same PR branch. Immediately frees the self-hosted runner queue — biggest single win when 6 PRs are active simultaneously.
- **Job timeouts**: Prevent zombie runs from blocking the runner for hours. `clippy=30m`, `test=90m`, `coverage=45m`, `build=45m`.
- **Remove broken benchmark rust-cache**: Both `Swatinem/rust-cache` steps in `Compare Against Base` used `run_id` in the cache key (so they *never* hit a cached artifact), and the baseline step caused a consistent `cargo not in PATH` failure in the cache save hook. Removed both — benchmarks still run and compare correctly, just without useless caching overhead.

## Test plan
- [ ] Push a commit to an active PR, verify old CI run is cancelled
- [ ] Verify `Compare Against Base` no longer fails with `cargo not in PATH`
- [ ] Verify Test job is cancelled after 90 min if stuck (rather than running 172+ min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)