### PR TITLE
chore(deploy): rebuild K3s on Hyperion, registry-first images

### DIFF
--- a/deploy/k8s/Makefile
+++ b/deploy/k8s/Makefile
@@ -225,12 +225,23 @@ image-count: ## Show container image count on all nodes
 
 REGISTRY ?= 10.8.10.40:30500
 
-push-registry: ## Push image to local in-cluster registry (fast path, no scp)
-	@echo "Pushing $(IMAGE_NAME):$(IMAGE_TAG) to local registry $(REGISTRY)..."
+push-registry: ## Push image to local in-cluster registry
+	@echo "Pushing $(IMAGE_NAME):$(IMAGE_TAG) to registry $(REGISTRY)..."
 	docker tag $(IMAGE_NAME):$(IMAGE_TAG) $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
 	docker push $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
 
-fast-deploy: build push-registry ## Build + registry push + rolling deploy (fast iteration)
-	@echo "Deploying $(IMAGE_NAME):$(IMAGE_TAG) from local registry..."
-	# Use localhost on k3s-control because this command runs remotely over SSH.
-	ssh $(K3S_HOST) "sudo kubectl -n $(NAMESPACE) set image deployment/icn-daemon icnd=localhost:30500/$(IMAGE_NAME):$(IMAGE_TAG) && sudo kubectl -n $(NAMESPACE) rollout status deployment/icn-daemon --timeout=120s"
+push-ui-registry: ## Push Pilot UI image to local in-cluster registry
+	@echo "Pushing $(UI_IMAGE_NAME):$(IMAGE_TAG) to registry $(REGISTRY)..."
+	docker tag $(UI_IMAGE_NAME):$(IMAGE_TAG) $(REGISTRY)/$(UI_IMAGE_NAME):$(IMAGE_TAG)
+	docker push $(REGISTRY)/$(UI_IMAGE_NAME):$(IMAGE_TAG)
+
+fast-deploy: build push-registry ## Build + registry push + rolling restart (DEFAULT deploy path)
+	@echo "Deploying $(IMAGE_NAME):$(IMAGE_TAG) via registry..."
+	ssh $(K3S_HOST) "sudo kubectl -n $(NAMESPACE) rollout restart deployment/icn-daemon && sudo kubectl -n $(NAMESPACE) rollout status deployment/icn-daemon --timeout=120s"
+
+fast-deploy-ui: build-ui-image push-ui-registry ## Build + push + restart Pilot UI via registry
+	@echo "Deploying $(UI_IMAGE_NAME):$(IMAGE_TAG) via registry..."
+	ssh $(K3S_HOST) "sudo kubectl -n $(NAMESPACE) rollout restart deployment/pilot-ui && sudo kubectl -n $(NAMESPACE) rollout status deployment/pilot-ui --timeout=60s"
+
+fast-deploy-all: fast-deploy fast-deploy-ui ## Build + push + deploy both via registry
+	@echo "✓ All deployments updated via registry"

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -21,8 +21,8 @@ spec:
     spec:
       containers:
       - name: icnd
-        image: icn:latest
-        imagePullPolicy: Never
+        image: 10.8.10.40:30500/icn:latest
+        imagePullPolicy: Always
         args:
           - --config
           - /etc/icn/icn.toml

--- a/deploy/k8s/multi-node/scripts/deploy-coop.sh
+++ b/deploy/k8s/multi-node/scripts/deploy-coop.sh
@@ -251,8 +251,8 @@ spec:
     spec:
       containers:
       - name: icnd
-        image: icn:latest
-        imagePullPolicy: Never
+        image: 10.8.10.40:30500/icn:latest
+        imagePullPolicy: Always
         args:
           - --config
           - /etc/icn/icn.toml

--- a/deploy/k8s/pilot-ui-deployment.yaml
+++ b/deploy/k8s/pilot-ui-deployment.yaml
@@ -20,8 +20,8 @@ spec:
     spec:
       containers:
       - name: pilot-ui
-        image: icn-pilot-ui:latest
-        imagePullPolicy: Never
+        image: 10.8.10.40:30500/icn-pilot-ui:latest
+        imagePullPolicy: Always
         ports:
         - name: http
           containerPort: 3000

--- a/docs/operations/deployment/HOMELAB_DEPLOYMENT.md
+++ b/docs/operations/deployment/HOMELAB_DEPLOYMENT.md
@@ -1,22 +1,37 @@
 # ICN Homelab Deployment
 
-**Status**: ICN daemon running on K3s cluster (deployed 2025-12-03, automated 2025-12-04).
+**Status**: ICN daemon running on K3s cluster. Rebuilt 2026-02-21 with registry-first architecture on Hyperion.
 
 ## Cluster Overview
 
 | Component | Details |
 |-----------|---------|
-| **Node Identity** | `did:icn:z3TE1ei6B4L5j6Jp29RmJKt1FYonGaQAXQoYHJL3GULR3` |
-| **K3s Control** | `k3s-control` (10.8.10.40) |
-| **Workers** | `k3s-worker-1` (10.8.10.41), `k3s-worker-2` (10.8.10.42) |
-| **Storage** | NFS from Atlas (10.8.10.25) via `atlas-nfs` StorageClass |
-| **Ports** | 7777/UDP (QUIC), 5601/TCP (RPC), 9100/TCP (Prometheus) |
+| **K3s Version** | v1.34.4+k3s1 |
+| **K3s Control** | `k3s-control` (10.8.10.40) — 4 vCPU, 8GB RAM on Hyperion, tainted `NoSchedule` |
+| **Worker 1** | `k3s-worker-1` (10.8.10.41) — 4 vCPU, 16GB RAM on node-2 |
+| **Worker 2** | `k3s-worker-2` (10.8.10.42) — 4 vCPU, 16GB RAM on node-3 |
+| **CI Runner** | `ci-runner` (10.8.10.46) — 8 vCPU, 6GB RAM on Hyperion (standalone, not in K3s) |
+| **Storage** | NFS from Atlas (10.8.10.25) via `atlas-nfs` StorageClass (csi-driver-nfs v4.9.0) |
+| **Registry** | In-cluster at `10.8.10.40:30500` (NFS-backed PVC) |
+| **Ports** | 7777/UDP (QUIC), 5601/TCP (RPC), 9100/TCP (Prometheus), 8080/TCP (Gateway) |
+
+### Image Strategy
+
+All images use `imagePullPolicy: Always` and pull from the in-cluster registry at `10.8.10.40:30500`. SCP-based image sync is deprecated.
+
+```bash
+# Default deploy path (build + push to registry + rolling restart)
+cd deploy/k8s && make fast-deploy
+```
 
 ## Quick Commands
 
 ```bash
-# Deploy new version (from repo root)
-cd deploy/k8s && make full-deploy-dev
+# Deploy new version (registry-first, default path)
+cd deploy/k8s && make fast-deploy
+
+# Deploy both daemon and UI
+cd deploy/k8s && make fast-deploy-all
 
 # Check status
 make status
@@ -25,77 +40,45 @@ make status
 # View logs
 make logs
 # OR: ssh ubuntu@10.8.10.40 "sudo kubectl -n icn logs -f deployment/icn-daemon"
-
-# Show identity
-ssh ubuntu@10.8.10.40 "sudo kubectl -n icn exec deploy/icn-daemon -- /usr/local/bin/icnctl id show"
 ```
 
-## Automated Deployment
+## Deployment Paths
 
-Full deployment automation available via `deploy/k8s/`:
+| Target | What it does |
+|--------|-------------|
+| `make fast-deploy` | Build + push to registry + rolling restart (default) |
+| `make fast-deploy-ui` | Build + push UI + restart |
+| `make fast-deploy-all` | Both daemon and UI |
+| `make full-deploy` | Legacy: build + SCP sync + deploy (deprecated) |
 
-```bash
-# From repo root
-cd deploy/k8s
-make full-deploy-dev  # Build, sync, and deploy in one command
-```
+## Monitoring Stack (rebuilt 2026-02-21)
 
-See [deploy/k8s/README.md](../../../deploy/k8s/README.md) for complete documentation.
-
-**Features**:
-- Version-controlled Kubernetes manifests
-- Automated Docker image building
-- Image sync to all cluster nodes
-- One-command deployment
-- Git hash tagging for tracking
-
-## Monitoring Stack (deployed 2025-12-04)
+Deployed via `kube-prometheus-stack` Helm chart in `monitoring` namespace.
 
 | Component | Access | Notes |
 |-----------|--------|-------|
-| **Grafana** | http://10.8.10.40:30300 | ICN Node Dashboard |
-| **Prometheus** | K3s internal only | Scrapes ICN metrics every 15s |
-| **AlertManager** | K3s internal only | 15 ICN-specific alerts configured |
+| **Grafana** | http://10.8.10.40:30300 | Default admin/prom-operator |
+| **Prometheus** | http://10.8.10.40:30090 | Scrapes ICN metrics |
+| **AlertManager** | K3s internal only | Via kube-prometheus-stack |
 
-## CI/CD Pipeline (deployed 2025-12-05)
+## CI/CD Pipeline (rebuilt 2026-02-21)
 
-**Self-Hosted GitHub Actions Runner** on K3s control plane.
+**Self-Hosted GitHub Actions Runner** on dedicated VM (not inside K3s).
 
 | Component | Details |
 |-----------|---------|
-| **Runner Name** | `homelab-runner` |
-| **Runner Host** | `k3s-control` (10.8.10.40) |
+| **Runner Name** | `ci-runner` |
+| **Runner Host** | `ci-runner` VM (10.8.10.46) on Hyperion |
+| **Specs** | 8 vCPU, 6GB RAM, 80GB disk |
 | **Labels** | `self-hosted, linux, x64, homelab, k3s` |
-| **Workflow** | `.github/workflows/docker-build-deploy.yml` |
-
-**How It Works**:
-1. Push to `main` triggers workflow
-2. Tests run on GitHub-hosted runners
-3. Build & deploy runs on self-hosted runner
-
-**Manual Trigger**:
-```bash
-gh workflow run docker-build-deploy.yml
-```
+| **Rust** | 1.88.0 with sccache |
+| **Docker** | Configured with insecure registry (10.8.10.40:30500) |
+| **kubectl** | Has kubeconfig for cluster access |
 
 **Runner Management**:
 ```bash
-ssh ubuntu@10.8.10.40 "cd ~/actions-runner && sudo ./svc.sh status"
-ssh ubuntu@10.8.10.40 "journalctl -u actions.runner.* -f"
-```
-
-**Disk Cleanup** (automated):
-- Script: `~/docker-cleanup.sh` runs every 6 hours via cron
-- Removes dangling images, stopped containers
-- Aggressive cleanup when disk > 80% full
-- Logs: `/var/log/docker-cleanup.log`
-
-```bash
-# Manual cleanup
-ssh ubuntu@10.8.10.40 "~/docker-cleanup.sh"
-
-# Check disk usage
-ssh ubuntu@10.8.10.40 "df -h / && sudo docker system df"
+ssh ubuntu@10.8.10.46 "sudo systemctl status actions.runner.InterCooperative-Network-icn.ci-runner"
+ssh ubuntu@10.8.10.46 "journalctl -u actions.runner.InterCooperative-Network-icn.ci-runner -f"
 ```
 
 ## Pilot Testing Status (2025-12-05)
@@ -173,6 +156,16 @@ curl -X POST http://10.8.10.40:30080/v1/sdis/enrollment/start \
 ---
 
 ## Deployment History
+
+### Infrastructure Rebuild (2026-02-21)
+Full tear-down and rebuild:
+- Moved control plane from node-1 (undersized 2 vCPU/8GB) to Hyperion (4 vCPU/8GB)
+- Workers: 16GB RAM each (up from 8GB)
+- Dedicated CI runner VM on Hyperion (8 vCPU, not inside K3s)
+- Registry-first image strategy (`imagePullPolicy: Always`)
+- NFS CSI driver v4.9.0 (replaces broken csi-nfs-controller)
+- Prometheus + Grafana via kube-prometheus-stack Helm chart
+- 4 coop instances (alpha, beta, gamma, delta)
 
 ### Initial Deployment (2025-12-03)
 Manual deployment with fixes for:


### PR DESCRIPTION
## Summary
- Moved K3s control plane to Hyperion (4 vCPU, 8GB RAM)
- All images now pull from in-cluster registry at `10.8.10.40:30500` (`imagePullPolicy: Always`)
- Dedicated CI runner VM (10.8.10.46, 8 vCPU, not inside K3s)
- Updated Makefile with `fast-deploy` registry-first targets
- Updated HOMELAB_DEPLOYMENT.md with new architecture

## Test plan
- [x] 3 K3s nodes Ready
- [x] 23/23 pods Running
- [x] Gateway, Pilot UI, Prometheus, Grafana, Registry all reachable
- [x] CI runner online on GitHub
- [x] 4 coop instances deployed with identities

🤖 Generated with [Claude Code](https://claude.com/claude-code)