### PR TITLE
feat(gateway): add git_sha and build_time to /v1/health

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,16 @@ COPY apps ./apps
 
 WORKDIR /app/icn
 
+# Build-time provenance args
+ARG GIT_SHA=unknown
+ARG BUILD_TIME=unknown
+
 # Build release binaries
 # RUST_MIN_STACK: Increase rustc stack size to prevent SIGSEGV on complex crates
 # -j 2: Limit parallelism to reduce peak memory usage
 ENV RUST_MIN_STACK=33554432
+ENV GIT_SHA=${GIT_SHA}
+ENV BUILD_TIME=${BUILD_TIME}
 RUN cargo build --release --bins -j 2
 
 # Stage 2: Runtime (must match builder's glibc version)

--- a/deploy/Dockerfile.icnd
+++ b/deploy/Dockerfile.icnd
@@ -14,6 +14,10 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /build
 
+# Build-time provenance args
+ARG GIT_SHA=unknown
+ARG BUILD_TIME=unknown
+
 # Copy workspace (context is already ../icn)
 COPY . .
 
@@ -21,6 +25,8 @@ COPY . .
 # RUST_MIN_STACK: Increase rustc stack size to prevent SIGSEGV on complex crates
 # -j 2: Limit parallelism to reduce peak memory usage
 ENV RUST_MIN_STACK=33554432
+ENV GIT_SHA=${GIT_SHA}
+ENV BUILD_TIME=${BUILD_TIME}
 RUN cargo build --release --bin icnd --bin icnctl --features wasm -j 2
 
 # Runtime image

--- a/deploy/k8s/scripts/build-image.sh
+++ b/deploy/k8s/scripts/build-image.sh
@@ -40,11 +40,20 @@ echo ""
 
 cd "$REPO_ROOT"
 
+# Build-time provenance
+GIT_SHA="$(git -C "$REPO_ROOT" rev-parse --short=12 HEAD 2>/dev/null || echo unknown)"
+BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+echo "  Git SHA: $GIT_SHA"
+echo "  Build time: $BUILD_TIME"
+
 # Build the image
 # Use Dockerfile.icnd which expects context to be icn/ directory
 # This matches the docker-compose setup
 docker build \
   $NO_CACHE \
+  --build-arg GIT_SHA="$GIT_SHA" \
+  --build-arg BUILD_TIME="$BUILD_TIME" \
   -f deploy/Dockerfile.icnd \
   -t "$FULL_IMAGE" \
   -t "${IMAGE_NAME}:latest" \

--- a/icn/crates/icn-gateway/src/api/health.rs
+++ b/icn/crates/icn-gateway/src/api/health.rs
@@ -80,6 +80,8 @@ pub async fn readiness(coop_manager: web::Data<Arc<CoopManager>>) -> HttpRespons
             "not_ready".to_string()
         },
         version: env!("CARGO_PKG_VERSION").to_string(),
+        git_sha: option_env!("GIT_SHA").map(|s| s.to_string()),
+        build_time: option_env!("BUILD_TIME").map(|s| s.to_string()),
         checks: Some(checks),
     };
 
@@ -168,6 +170,8 @@ pub async fn health() -> HttpResponse {
     let response = HealthResponse {
         status: "ok".to_string(),
         version: env!("CARGO_PKG_VERSION").to_string(),
+        git_sha: option_env!("GIT_SHA").map(|s| s.to_string()),
+        build_time: option_env!("BUILD_TIME").map(|s| s.to_string()),
         checks: None,
     };
     HttpResponse::Ok().json(response)

--- a/icn/crates/icn-gateway/src/models.rs
+++ b/icn/crates/icn-gateway/src/models.rs
@@ -9,6 +9,10 @@ pub struct HealthResponse {
     pub status: String,
     pub version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_sha: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_time: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub checks: Option<std::collections::HashMap<String, ComponentHealth>>,
 }
 


### PR DESCRIPTION
## Summary
- Add `git_sha` and `build_time` fields to the `/v1/health` response
- Both Dockerfiles inject `GIT_SHA` and `BUILD_TIME` as build args via `option_env!()`
- `build-image.sh` passes git rev-parse and UTC timestamp at build time

Sprint 10, T1: provenance proof for deployed binaries.

## Test plan
- [x] `cargo check -p icn-gateway` passes
- [ ] Fresh image build includes SHA in `/v1/health`
- [ ] Deployed daemon shows SHA matching `main` HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)