### PR TITLE
feat(deploy): identity initContainer for governance actor

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -19,6 +19,40 @@ spec:
         app: icn
         component: daemon
     spec:
+      initContainers:
+      - name: init-identity
+        image: 10.8.10.40:30500/icn:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            if [ -f /data/identity.age ]; then
+              echo "Identity keystore already exists, skipping init"
+            else
+              echo "Initializing identity keystore..."
+              icnctl id init
+              echo "Identity keystore created at /data/identity.age"
+            fi
+        env:
+        - name: ICN_KEYSTORE_PASSPHRASE
+          valueFrom:
+            secretKeyRef:
+              name: icn-secrets
+              key: passphrase
+        - name: ICN_DATA_DIR
+          value: "/data"
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        - name: tmp
+          mountPath: /tmp
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
       containers:
       - name: icnd
         image: 10.8.10.40:30500/icn:latest
@@ -27,6 +61,11 @@ spec:
           - --config
           - /etc/icn/icn.toml
         env:
+        - name: ICN_KEYSTORE_PASSPHRASE
+          valueFrom:
+            secretKeyRef:
+              name: icn-secrets
+              key: passphrase
         - name: ICN_PASSPHRASE
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## Summary
- Adds initContainer to `deployment.yaml` that runs `icnctl id init` before daemon starts
- Ensures identity keystore exists on PVC → daemon loads identity → governance actor spawns
- Idempotent: skips if `/data/identity.age` already exists (safe for pod restarts)
- Adds `ICN_KEYSTORE_PASSPHRASE` env var (preferred name) alongside legacy `ICN_PASSPHRASE`

## Context
Without identity, `icnd` falls back to `spawn_without_identity()` (supervisor/lifecycle.rs:103) which skips the governance actor entirely. This leaves `/v1/gov/*` endpoints in standalone in-memory mode — no gossip sync, no signed proposals.

## Test plan
- [ ] Build completes with updated Dockerfile (context = repo root)
- [ ] initContainer creates identity.age on first boot
- [ ] initContainer skips on subsequent pod restarts
- [ ] Daemon logs show "Identity loaded: did:icn:..." 
- [ ] Daemon logs show governance actor spawning
- [ ] `curl /v1/gov/domains` returns actor-backed response

🤖 Generated with [Claude Code](https://claude.com/claude-code)