### PR TITLE
fix(deploy): set HOME and --data-dir for initContainer

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -31,7 +31,7 @@ spec:
               echo "Identity keystore already exists, skipping init"
             else
               echo "Initializing identity keystore..."
-              icnctl id init
+              icnctl --data-dir /data id init
               echo "Identity keystore created at /data/identity.age"
             fi
         env:
@@ -41,6 +41,8 @@ spec:
               name: icn-secrets
               key: passphrase
         - name: ICN_DATA_DIR
+          value: "/data"
+        - name: HOME
           value: "/data"
         volumeMounts:
         - name: data


### PR DESCRIPTION
## Summary
- initContainer was crash-looping with `Read-only file system (os error 30)` because `icnctl id init` defaults to `~/.icn` when `--data-dir` isn't passed
- With `readOnlyRootFilesystem: true`, creating dirs on the root FS fails
- Fix: pass `--data-dir /data` explicitly and set `HOME=/data` so `dirs::home_dir()` resolves to the PVC mount

Already deployed and verified — identity keystore created successfully at `/data/identity.age`.

## Test plan
- [x] Deployed to K3s cluster, initContainer passes
- [x] Identity created: `did:icn:z5dTCBUuKPTVntv7X7vK2nWiqwYjLbvD8dTUWvXjrNicr`
- [x] Daemon starts with identity loaded, all actors spawned

🤖 Generated with [Claude Code](https://claude.com/claude-code)