### PR TITLE
fix(deploy): add CORS origin for Pilot UI

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -82,6 +82,9 @@ spec:
           value: "/data"
         - name: HOME
           value: "/data"
+        # CORS: allow Pilot UI origin for cross-origin API access
+        - name: ICN_CORS_ORIGINS
+          value: "http://10.8.10.40:30030"
         # Gateway base URL for QR login - set this to the external URL where the gateway is accessible
         # This is used in QR codes for mobile wallet login
         - name: GATEWAY_BASE_URL


### PR DESCRIPTION
## Summary
- Adds `ICN_CORS_ORIGINS=http://10.8.10.40:30030` to the icn-daemon deployment
- Without this, the Pilot UI PWA (served on NodePort 30030) gets blocked by the gateway's default CORS policy when making API calls to port 30080

## Test plan
- [x] Applied to live cluster, verified Pilot UI connects and loads governance tab
- [x] Gateway health endpoint still returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)