### PR TITLE
feat(governance): thread proposal scope through create API

### DIFF
--- a/docs/api/openapi.generated.yaml
+++ b/docs/api/openapi.generated.yaml
@@ -550,6 +550,11 @@ components:
           type: string
         payload:
           $ref: '#/components/schemas/ProposalPayloadRequest'
+        scope:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/ProposalScopeRequest'
+            description: Proposal scope — defaults to Local if omitted
         title:
           type: string
     CreateSessionRequest:
@@ -770,6 +775,10 @@ components:
       - status
       - version
       properties:
+        build_time:
+          type:
+          - string
+          - 'null'
         checks:
           type:
           - object
@@ -778,6 +787,10 @@ components:
             $ref: '#/components/schemas/ComponentHealth'
           propertyNames:
             type: string
+        git_sha:
+          type:
+          - string
+          - 'null'
         status:
           type: string
         version:
@@ -1152,6 +1165,31 @@ components:
           value:
             type: string
       description: Proposal payload types (matches icn_governance::ProposalPayload)
+    ProposalScopeRequest:
+      oneOf:
+      - type: object
+        description: Local to this node's governance domain (default)
+        required:
+        - type
+        properties:
+          type:
+            type: string
+            enum:
+            - local
+      - type: object
+        description: Visible across a federation — propagates via gossip
+        required:
+        - federation_id
+        - type
+        properties:
+          federation_id:
+            type: string
+            description: Federation identifier
+          type:
+            type: string
+            enum:
+            - federation
+      description: Scope for a proposal (local or federation-wide)
     RegisterDeviceRequest:
       type: object
       description: Register device request

--- a/docs/plans/2026-02-21-sprint-11-federated-governance-design.md
+++ b/docs/plans/2026-02-21-sprint-11-federated-governance-design.md
@@ -1,0 +1,684 @@
+# Sprint 11: Federated Governance Wiring — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Create a federation-scoped proposal on one coop node, have it propagate to all 4 coop nodes via gossip, collect votes from multiple nodes, and verify converged outcomes everywhere.
+
+**Architecture:** The federation gossip transport already exists (`icn-federation`). The governance actor already publishes to `federation:governance` topic when `ProposalScope::Federation`. The only code gap is that `CreateProposalRequest` has no `scope` field, so every proposal defaults to `Local`. We thread `scope` through the gateway → manager → actor → command chain, then deploy NodePorts + CORS to make each coop's gateway accessible externally. Scripts prove it works end-to-end.
+
+**Tech Stack:** Rust (actix-web gateway, governance actor), K8s YAML (NodePort services), Bash (demo scripts)
+
+---
+
+## PR A: Thread `scope` through proposal creation (T1)
+
+### Task 1: Add `ProposalScopeRequest` type to gateway models
+
+**Files:**
+- Modify: `icn/crates/icn-gateway/src/models.rs:296-301`
+
+**Step 1: Add the scope request type**
+
+After `CreateProposalRequest` (line 301), add:
+
+```rust
+/// Proposal scope — determines gossip routing
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ProposalScopeRequest {
+    /// Local to this cooperative (default)
+    Local,
+    /// Visible across a federation
+    Federation {
+        federation_id: String,
+    },
+}
+```
+
+**Step 2: Add `scope` field to `CreateProposalRequest`**
+
+Add to the struct at line 296:
+
+```rust
+pub struct CreateProposalRequest {
+    pub domain_id: String,
+    pub title: String,
+    pub description: String,
+    pub payload: ProposalPayloadRequest,
+    /// Proposal scope. Omit or set to "local" for local-only.
+    /// Set to {"type": "federation", "federation_id": "..."} for federation-wide.
+    #[serde(default)]
+    pub scope: Option<ProposalScopeRequest>,
+}
+```
+
+**Step 3: Run `cargo check -p icn-gateway`**
+
+Expected: compile errors in `governance_mgr.rs` because `create_proposal` doesn't accept scope yet.
+
+**Step 4: Commit**
+
+```bash
+git add icn/crates/icn-gateway/src/models.rs
+git commit -m "feat(gateway): add ProposalScopeRequest to CreateProposalRequest"
+```
+
+### Task 2: Thread scope through GovernanceManager
+
+**Files:**
+- Modify: `icn/crates/icn-gateway/src/governance_mgr.rs:525-540`
+
+**Step 1: Add scope parameter to `GovernanceManager::create_proposal`**
+
+Change signature at line 525:
+
+```rust
+pub async fn create_proposal(
+    &self,
+    proposal_id: ProposalId,
+    domain_id: GovernanceDomainId,
+    proposer: Did,
+    title: String,
+    description: String,
+    payload: ProposalPayload,
+    scope: icn_governance::ProposalScope,
+) -> Result<ProposalId> {
+```
+
+In actor-backed mode (line 534-540), pass scope:
+
+```rust
+if let Some(ref handle) = self.governance_handle {
+    let generated_id = handle
+        .create_proposal(domain_id, title, description, payload, scope)
+        .await?;
+    return Ok(generated_id);
+}
+```
+
+In standalone mode (line 556), apply scope:
+
+```rust
+let mut proposal = Proposal::new(domain_id, proposer, title, description, payload);
+proposal = proposal.with_scope(scope);
+proposal.id = proposal_id.clone();
+```
+
+**Step 2: Run `cargo check -p icn-gateway`**
+
+Expected: compile errors because `GovernanceHandle::create_proposal` doesn't accept scope yet, and the call site in `governance.rs` doesn't pass scope.
+
+**Step 3: Commit**
+
+```bash
+git add icn/crates/icn-gateway/src/governance_mgr.rs
+git commit -m "feat(gateway): thread scope through GovernanceManager::create_proposal"
+```
+
+### Task 3: Thread scope through GovernanceActor
+
+**Files:**
+- Modify: `icn/apps/governance/src/actor.rs` (lines 121-131, 697-703, 848-858, 1280-1298)
+
+**Step 1: Add scope to `GovernanceCommand::CreateProposal`**
+
+At line 121:
+
+```rust
+CreateProposal {
+    proposal_id: ProposalId,
+    domain_id: GovernanceDomainId,
+    title: String,
+    description: String,
+    payload: ProposalPayload,
+    scope: icn_governance::ProposalScope,
+},
+```
+
+**Step 2: Add scope to `GovernanceHandle::create_proposal`**
+
+At line 697:
+
+```rust
+async fn create_proposal(
+    &self,
+    domain_id: GovernanceDomainId,
+    title: String,
+    description: String,
+    payload: icn_governance::ProposalPayload,
+    scope: icn_governance::ProposalScope,
+) -> Result<ProposalId> {
+```
+
+At line 851 (submit call):
+
+```rust
+self.submit(GovernanceCommand::CreateProposal {
+    proposal_id: proposal_id.clone(),
+    domain_id,
+    title,
+    description,
+    payload,
+    scope,
+})
+.await?;
+```
+
+**Step 3: Apply scope in handler**
+
+At line 1289-1298:
+
+```rust
+GovernanceCommand::CreateProposal {
+    proposal_id,
+    domain_id,
+    title,
+    description,
+    payload,
+    scope,
+} => {
+    info!("Creating proposal: {} (scope: {:?})", title, scope);
+
+    let mut proposal = Proposal::new(
+        domain_id,
+        self.did.clone(),
+        title.clone(),
+        description,
+        payload,
+    );
+    proposal = proposal.with_scope(scope);
+    proposal.id = proposal_id.clone();
+    // ... rest unchanged
+```
+
+**Step 4: Run `cargo check -p icn-governance-actor`**
+
+Expected: should compile. May need to fix the trait definition if `create_proposal` is in a trait.
+
+**Step 5: Commit**
+
+```bash
+git add icn/apps/governance/src/actor.rs
+git commit -m "feat(governance): thread scope through GovernanceCommand::CreateProposal"
+```
+
+### Task 4: Wire scope in gateway API handler
+
+**Files:**
+- Modify: `icn/crates/icn-gateway/src/api/governance.rs:473-488`
+
+**Step 1: Map scope from request and pass to manager**
+
+After the payload conversion (line 471), add scope conversion:
+
+```rust
+// Convert scope (default to Local if not specified)
+let scope = match &req.scope {
+    Some(ProposalScopeRequest::Federation { federation_id }) => {
+        icn_governance::ProposalScope::Federation(federation_id.clone())
+    }
+    Some(ProposalScopeRequest::Local) | None => {
+        icn_governance::ProposalScope::Local
+    }
+};
+```
+
+At line 479, pass scope to `create_proposal`:
+
+```rust
+let proposal_id = gov_mgr
+    .create_proposal(
+        suggested_id,
+        domain_id,
+        proposer_did.clone(),
+        req.title.clone(),
+        req.description.clone(),
+        payload,
+        scope,
+    )
+    .await?;
+```
+
+Add the import at the top of the file:
+
+```rust
+use crate::models::ProposalScopeRequest;
+```
+
+**Step 2: Run full check**
+
+```bash
+cd icn/icn && cargo check --workspace
+```
+
+Expected: PASS
+
+**Step 3: Run gateway tests**
+
+```bash
+cd icn/icn && cargo test -p icn-gateway --lib
+```
+
+Expected: existing tests pass (they don't specify scope, so default=Local).
+
+**Step 4: Commit**
+
+```bash
+git add icn/crates/icn-gateway/src/api/governance.rs
+git commit -m "feat(gateway): map ProposalScopeRequest to ProposalScope in create_proposal"
+```
+
+### Task 5: Add scope to proposal response
+
+**Files:**
+- Modify: `icn/crates/icn-gateway/src/api/governance.rs` (proposal list/get responses)
+
+**Step 1: Check if proposal responses already include scope**
+
+The `Proposal` struct from `icn-governance` includes `scope: ProposalScope` (with `#[serde(default)]`). If responses serialize the full `Proposal`, scope is already visible. Verify by checking how proposals are returned in list/get endpoints.
+
+If proposals are returned directly as `Proposal` (not a DTO), no change needed — `scope` serializes automatically.
+
+**Step 2: Run `cargo test -p icn-gateway`**
+
+```bash
+cd icn/icn && cargo test -p icn-gateway
+```
+
+Expected: PASS
+
+**Step 3: Commit (only if changes needed)**
+
+### Task 6: Build, push, and verify
+
+**Step 1: Full workspace check**
+
+```bash
+cd icn/icn && cargo fmt --all --check && cargo clippy --workspace --all-targets -- -D warnings
+```
+
+**Step 2: Build Docker image**
+
+```bash
+cd /home/ubuntu/projects/icn && docker build -f deploy/Dockerfile.icnd -t icn:latest .
+```
+
+**Step 3: Push to registry**
+
+```bash
+docker tag icn:latest 10.8.10.40:30500/icn:latest
+docker push 10.8.10.40:30500/icn:latest
+```
+
+**Step 4: Create PR**
+
+```bash
+git push -u origin feat/proposal-scope
+gh pr create --title "feat(gateway): add scope field to proposal creation" --body "..."
+```
+
+---
+
+## PR B: Coop Gateway NodePorts + CORS (T2)
+
+### Task 7: Add gateway NodePort to deploy-coop.sh
+
+**Files:**
+- Modify: `deploy/k8s/multi-node/scripts/deploy-coop.sh:331-387`
+
+**Step 1: Add gateway NodePort to services section**
+
+After the existing NodePort service (line 387), add a gateway NodePort service. The port needs to be deterministic from coop name. Add a `NODEPORT_GATEWAY` variable:
+
+```bash
+# Add after line 71 (NODEPORT_RPC calculation)
+NODEPORT_GATEWAY=$((30081 + (BASE_PORT - 7777)))
+```
+
+Add to the services YAML (after the existing NodePort service, before the closing `EOF`):
+
+```yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: icn-${COOP_NAME}-gateway
+  namespace: $NAMESPACE
+  labels:
+    app: icn
+    coop: $COOP_NAME
+spec:
+  type: NodePort
+  selector:
+    app: icn
+    coop: $COOP_NAME
+  ports:
+  - name: gateway
+    port: 8080
+    protocol: TCP
+    targetPort: health
+    nodePort: ${NODEPORT_GATEWAY}
+```
+
+**Step 2: Add CORS env var to deployment template**
+
+In the deployment YAML (line 259-268), add after the HOME env var:
+
+```yaml
+        - name: ICN_CORS_ORIGINS
+          value: "http://10.8.10.40:30030"
+```
+
+**Step 3: Print gateway port in summary**
+
+After line 76 (`echo "  Metrics: $METRICS_PORT"`), add:
+
+```bash
+echo "  Gateway: 8080 (NodePort: $NODEPORT_GATEWAY)"
+```
+
+**Step 4: Commit**
+
+```bash
+git add deploy/k8s/multi-node/scripts/deploy-coop.sh
+git commit -m "feat(deploy): add gateway NodePort and CORS to coop deployments"
+```
+
+### Task 8: Apply NodePort services to existing coops
+
+**Step 1: Create gateway NodePort for each existing coop**
+
+Run `kubectl apply` for each coop to add gateway NodePort services. The port numbers for our existing coops are:
+
+Check the actual ports first:
+```bash
+# For each coop, check their QUIC port to derive gateway NodePort
+kubectl -n icn-coop-alpha get svc icn-alpha -o jsonpath='{.spec.ports[?(@.name=="quic")].port}'
+# Then: NODEPORT_GATEWAY = 30081 + (QUIC_PORT - 7777)
+```
+
+For the existing alpha/beta/gamma/delta coops, create gateway NodePort services:
+
+```bash
+# For each coop, apply a gateway NodePort service
+for COOP in alpha beta gamma delta; do
+    NS="icn-coop-${COOP}"
+    # Get the existing gateway port
+    NODEPORT=$(kubectl -n $NS get svc icn-${COOP}-nodeport -o jsonpath='{.spec.ports[0].nodePort}')
+    # Derive gateway nodeport: subtract 30777 base, add 30081 base
+    OFFSET=$((NODEPORT - 30777))
+    GW_PORT=$((30081 + OFFSET))
+
+    kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: icn-${COOP}-gateway
+  namespace: $NS
+  labels:
+    app: icn
+    coop: $COOP
+spec:
+  type: NodePort
+  selector:
+    app: icn
+    coop: $COOP
+  ports:
+  - name: gateway
+    port: 8080
+    protocol: TCP
+    targetPort: health
+    nodePort: $GW_PORT
+EOF
+    echo "Created gateway NodePort for $COOP at :$GW_PORT"
+done
+```
+
+**Step 2: Add CORS to existing coop deployments**
+
+For each coop, patch the deployment to add `ICN_CORS_ORIGINS`:
+
+```bash
+for COOP in alpha beta gamma delta; do
+    NS="icn-coop-${COOP}"
+    kubectl -n $NS set env deployment/icn-${COOP} ICN_CORS_ORIGINS="http://10.8.10.40:30030"
+done
+```
+
+**Step 3: Verify all 4 coop gateways respond**
+
+```bash
+NODE_IP=10.8.10.40
+for PORT in 30081 30082 30083 30084; do
+    echo -n "Port $PORT: "
+    curl -s "http://${NODE_IP}:${PORT}/v1/health" | jq -r '.status'
+done
+```
+
+Expected: all return `ok`
+
+**Step 4: Commit and create PR**
+
+```bash
+git push -u origin fix/coop-gateway-nodeports
+gh pr create --title "feat(deploy): add gateway NodePorts for coop instances" --body "..."
+```
+
+---
+
+## PR C: Federation Init + Demo Scripts (T3, T4, T5, T7)
+
+### Task 9: Create federation-init.sh
+
+**Files:**
+- Create: `scripts/federation-init.sh`
+
+**Step 1: Write the init script**
+
+```bash
+#!/usr/bin/env bash
+# Initialize federation on all coop instances.
+# Idempotent: re-running is safe.
+set -euo pipefail
+
+NODE_IP="${NODE_IP:-10.8.10.40}"
+COOPS=("alpha:30081" "beta:30082" "gamma:30083" "delta:30084")
+FED_ID="${FED_ID:-pilot-fed}"
+
+echo "Initializing federation '${FED_ID}' on ${#COOPS[@]} coops..."
+
+for entry in "${COOPS[@]}"; do
+    COOP="${entry%%:*}"
+    PORT="${entry##*:}"
+    URL="http://${NODE_IP}:${PORT}"
+
+    echo -n "  ${COOP} (${URL}): "
+
+    # Get the node's DID
+    DID=$(curl -sf "${URL}/v1/health" | jq -r '.version // "unknown"')
+
+    # Check if already initialized
+    STATUS=$(curl -sf "${URL}/v1/federation/status" 2>/dev/null || echo '{"initialized":false}')
+    INITIALIZED=$(echo "$STATUS" | jq -r '.initialized // false')
+
+    if [ "$INITIALIZED" = "true" ]; then
+        echo "already initialized"
+        continue
+    fi
+
+    # Initialize federation
+    RESULT=$(curl -sf -X POST "${URL}/v1/federation/init" \
+        -H "Content-Type: application/json" \
+        -d "{
+            \"coop_id\": \"${COOP}\",
+            \"name\": \"${COOP} cooperative\",
+            \"federation_id\": \"${FED_ID}\"
+        }" 2>&1) || true
+
+    echo "${RESULT}" | jq -r '.status // .error // "done"'
+done
+
+echo ""
+echo "Federation status:"
+for entry in "${COOPS[@]}"; do
+    COOP="${entry%%:*}"
+    PORT="${entry##*:}"
+    echo -n "  ${COOP}: "
+    curl -sf "http://${NODE_IP}:${PORT}/v1/federation/status" | jq -c '.' 2>/dev/null || echo "unreachable"
+done
+```
+
+**Step 2: Make executable and commit**
+
+```bash
+chmod +x scripts/federation-init.sh
+git add scripts/federation-init.sh
+git commit -m "feat(scripts): add federation-init.sh for multi-coop federation setup"
+```
+
+### Task 10: Create federated-governance-demo.sh (T7)
+
+**Files:**
+- Create: `scripts/federated-governance-demo.sh`
+
+**Step 1: Write the demo script**
+
+This script proves the full federation governance lifecycle. It:
+1. Health-checks all 4 coop gateways
+2. Obtains JWT tokens for each coop (via `kubectl exec`)
+3. Creates a governance domain on alpha
+4. Creates a federation-scoped proposal on alpha
+5. Verifies the proposal propagated to beta/gamma/delta
+6. Opens voting, casts votes from alpha + beta
+7. Verifies tally convergence on all coops
+8. Closes the proposal, verifies closed state everywhere
+
+Structure should follow `scripts/governance-demo.sh` as the template, but operate across all 4 coops with per-coop auth tokens and endpoints.
+
+Key differences from governance-demo.sh:
+- `NODE_IP` and per-coop ports (30081-30084) instead of single :30080
+- Per-coop JWT tokens obtained from each coop's pod
+- Proposal scope: `{"type": "federation", "federation_id": "pilot-fed"}`
+- Propagation verification: poll each coop's proposal list
+- Vote from multiple coops using their respective tokens
+- Tally convergence check: compare tallies across all coops
+
+**Step 2: Make executable and test**
+
+```bash
+chmod +x scripts/federated-governance-demo.sh
+./scripts/federated-governance-demo.sh
+```
+
+Expected: exits 0, all steps pass
+
+**Step 3: Commit**
+
+```bash
+git add scripts/federated-governance-demo.sh
+git commit -m "feat(scripts): add federated-governance-demo.sh proof-of-life"
+```
+
+### Task 11: Create PR
+
+```bash
+git push -u origin feat/federation-demo
+gh pr create --title "feat(scripts): federation init + federated governance demo" --body "..."
+```
+
+---
+
+## PR D: Pilot UI Federation View (T6)
+
+### Task 12: Add federation indicators to governance tab
+
+**Files:**
+- Modify: `web/pilot-ui/app.js` (governance tab section)
+
+**Step 1: Add origin coop badge to proposal cards**
+
+In the governance tab's proposal rendering, check if the proposal has `scope.federation` and display:
+- An origin badge: "Created on: alpha" (derive from proposal's proposer DID or scope metadata)
+- A federation indicator: small icon or text showing "Federation: pilot-fed"
+
+**Step 2: Add "seen on N coops" indicator**
+
+Add a function that checks the proposal exists on each coop gateway:
+
+```javascript
+async function checkProposalPropagation(proposalId) {
+    const coops = [
+        { name: 'alpha', port: 30081 },
+        { name: 'beta', port: 30082 },
+        { name: 'gamma', port: 30083 },
+        { name: 'delta', port: 30084 },
+    ];
+    let seen = 0;
+    for (const coop of coops) {
+        try {
+            const res = await fetch(`http://${NODE_IP}:${coop.port}/v1/gov/proposals/${proposalId}`);
+            if (res.ok) seen++;
+        } catch { /* unreachable */ }
+    }
+    return { seen, total: coops.length };
+}
+```
+
+Display as "Seen on 4/4 coops" badge in the proposal detail.
+
+**Step 3: Test in browser**
+
+Navigate to Pilot UI → Governance tab → verify federation badges appear on federation-scoped proposals.
+
+**Step 4: Commit and PR**
+
+```bash
+git add web/pilot-ui/app.js
+git commit -m "feat(pilot-ui): add federation indicators to governance tab"
+git push -u origin feat/pilot-ui-federation
+gh pr create --title "feat(pilot-ui): federation view indicators" --body "..."
+```
+
+---
+
+## Merge Order
+
+1. **PR A** (scope field) — independent Rust change
+2. **PR B** (NodePorts + CORS) — independent K8s/deploy change
+3. **PR C** (scripts) — depends on A + B being deployed
+4. **PR D** (Pilot UI) — depends on A + B being deployed
+
+A and B can merge in parallel. C and D wait for A + B to be deployed to the cluster.
+
+---
+
+## Acceptance Criteria
+
+1. `POST /v1/gov/proposals` with `"scope": {"type": "federation", "federation_id": "pilot-fed"}` returns 201 on alpha
+2. Proposal appears on beta/gamma/delta within 30 seconds
+3. Votes from alpha + beta produce identical tallies on all 4 coops
+4. Close on alpha → closed state on all 4 coops
+5. `federated-governance-demo.sh` exits 0 with clean transcript
+6. Pilot UI shows federation badge on federation-scoped proposals
+
+## Key File Map
+
+| File | Change | PR |
+|------|--------|-----|
+| `icn/crates/icn-gateway/src/models.rs` | Add `ProposalScopeRequest`, scope field | A |
+| `icn/crates/icn-gateway/src/api/governance.rs` | Map scope, pass to manager | A |
+| `icn/crates/icn-gateway/src/governance_mgr.rs` | Accept scope parameter | A |
+| `icn/apps/governance/src/actor.rs` | Scope in command, handle, handler | A |
+| `deploy/k8s/multi-node/scripts/deploy-coop.sh` | Gateway NodePort + CORS | B |
+| `scripts/federation-init.sh` | New: init federation on coops | C |
+| `scripts/federated-governance-demo.sh` | New: end-to-end proof script | C |
+| `web/pilot-ui/app.js` | Federation indicators | D |
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Gossip not connecting between coops | Check mDNS discovery, verify coops can see each other with `/v1/federation/status` |
+| Proposals don't propagate | Check governance actor logs for federation publish attempts, verify gossip topic subscription |
+| Port conflicts (NodePorts overlap) | Ports derived deterministically from coop name hash; verify no collision |
+| CORS issues on coop gateways | Same fix as Sprint 10: `ICN_CORS_ORIGINS` env var on each coop deployment |

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -22,8 +22,8 @@ use icn_governance::{
     GovernanceDomainId, GovernanceMessage, GovernanceParams, GovernanceProfile,
     GovernanceProfileId, MembershipAction, MembershipConfig, MembershipResolver, MembershipSource,
     PaginatedResult, ParameterChange, Proposal, ProposalId, ProposalOutcome, ProposalPayload,
-    ProposalState, ProtocolParameter, ProtocolParameterStore, TallySnapshot, Timestamp, Vote,
-    VoteChoice, VoteTally,
+    ProposalScope, ProposalState, ProtocolParameter, ProtocolParameterStore, TallySnapshot,
+    Timestamp, Vote, VoteChoice, VoteTally,
 };
 
 use icn_kernel_api::events::{EventEmitter, SystemEvent};
@@ -129,6 +129,8 @@ pub enum GovernanceCommand {
         description: String,
         /// Proposal action payload
         payload: ProposalPayload,
+        /// Scope — local or federation-wide
+        scope: ProposalScope,
     },
     /// Start deliberation period for a proposal
     ///
@@ -700,6 +702,7 @@ impl icn_governance::GovernanceOps for GovernanceHandle {
         title: String,
         description: String,
         payload: icn_governance::ProposalPayload,
+        scope: ProposalScope,
     ) -> Result<ProposalId> {
         // Pre-validate ProtocolChange proposals to catch invalid parameters early
         // This prevents wasted governance cycles on proposals that would fail at execution
@@ -854,6 +857,7 @@ impl icn_governance::GovernanceOps for GovernanceHandle {
             title,
             description,
             payload,
+            scope,
         })
         .await?;
 
@@ -1283,8 +1287,9 @@ impl GovernanceActor {
                 title,
                 description,
                 payload,
+                scope,
             } => {
-                info!("Creating proposal: {}", title);
+                info!("Creating proposal: {} (scope: {:?})", title, scope);
 
                 let mut proposal = Proposal::new(
                     domain_id,
@@ -1292,7 +1297,8 @@ impl GovernanceActor {
                     title.clone(),
                     description,
                     payload,
-                );
+                )
+                .with_scope(scope);
 
                 // Use the provided proposal ID instead of the generated one
                 proposal.id = proposal_id.clone();

--- a/icn/crates/icn-gateway/src/api/governance.rs
+++ b/icn/crates/icn-gateway/src/api/governance.rs
@@ -15,8 +15,8 @@ use crate::models::{
     CreateProposalRequest, DelegationListResponse, DelegationResponse,
     EstablishClearingProposalRequest, JoinFederationProposalRequest,
     LeaveFederationProposalRequest, OpenProposalRequest, ProposalPayloadRequest,
-    RevokeVouchProposalRequest, TerminateClearingProposalRequest, UpdateActionItemRequest,
-    UpdateFederationPolicyProposalRequest, VouchProposalRequest,
+    ProposalScopeRequest, RevokeVouchProposalRequest, TerminateClearingProposalRequest,
+    UpdateActionItemRequest, UpdateFederationPolicyProposalRequest, VouchProposalRequest,
 };
 use crate::pagination::{ListPagination, ListQuery, ListResponse};
 use crate::validation;
@@ -25,7 +25,7 @@ use icn_governance::{
     ActionItemFilter, ActionItemId, ActionItemPriority, ActionItemStatus, DataSharingLevel,
     Delegation, DelegationScope, DisputeResolutionMethod, FederationProposal, FederationTerms,
     GovernanceDomainId, GovernanceParams, MembershipConfig, ProposalId, ProposalPayload,
-    VoteChoice,
+    ProposalScope, VoteChoice,
 };
 use icn_identity::Did;
 use icn_obs::metrics::{action_items, gateway};
@@ -470,6 +470,14 @@ pub async fn create_proposal(
         }
     };
 
+    // Map scope request to governance ProposalScope
+    let scope = match req.scope {
+        Some(ProposalScopeRequest::Federation { ref federation_id }) => {
+            ProposalScope::Federation(federation_id.clone())
+        }
+        Some(ProposalScopeRequest::Local) | None => ProposalScope::Local,
+    };
+
     // Create proposal via governance manager
     // In actor-backed mode, the actor generates the proposal ID
     // In standalone mode, we provide one (but it may be overridden)
@@ -484,6 +492,7 @@ pub async fn create_proposal(
             req.title.clone(),
             req.description.clone(),
             payload,
+            scope,
         )
         .await?;
 
@@ -1113,6 +1122,7 @@ async fn create_federation_proposal_impl(
             common.title.clone(),
             common.description.clone(),
             payload,
+            ProposalScope::Local, // Federation join/leave is a local governance decision
         )
         .await?;
 
@@ -2863,7 +2873,7 @@ mod tests {
     use actix_web::{test, App, HttpMessage};
     use icn_governance::{
         GovernanceDomain, GovernanceDomainId, GovernanceParams, MembershipConfig, MembershipSource,
-        Proposal, ProposalState,
+        Proposal, ProposalScope, ProposalState,
     };
     use icn_identity::IdentityBundle;
 
@@ -3011,6 +3021,7 @@ mod tests {
             payload: ProposalPayloadRequest::Text {
                 body: "Detailed proposal text...".to_string(),
             },
+            scope: None,
         };
 
         let claims = create_test_claims(&alice.did().to_string(), vec!["governance:write"]);
@@ -3074,6 +3085,7 @@ mod tests {
             payload: ProposalPayloadRequest::Text {
                 body: "Test".to_string(),
             },
+            scope: None,
         };
 
         let claims = create_test_claims(&alice.did().to_string(), vec!["governance:write"]);
@@ -3188,6 +3200,7 @@ mod tests {
                 payload: ProposalPayloadRequest::Text {
                     body: "Test".to_string(),
                 },
+                scope: None,
             };
 
             let claims = create_test_claims(&alice.did().to_string(), vec!["governance:write"]);
@@ -3470,6 +3483,7 @@ mod tests {
                 ProposalPayload::Text {
                     body: "Should fail due to insufficient quorum".to_string(),
                 },
+                ProposalScope::Local,
             )
             .await
             .unwrap();
@@ -3556,6 +3570,7 @@ mod tests {
                 ProposalPayload::Text {
                     body: "Test".to_string(),
                 },
+                ProposalScope::Local,
             )
             .await
             .unwrap();
@@ -3618,6 +3633,7 @@ mod tests {
                 ProposalPayload::Text {
                     body: "Test".to_string(),
                 },
+                ProposalScope::Local,
             )
             .await
             .unwrap();
@@ -3663,6 +3679,7 @@ mod tests {
                 ProposalPayload::Text {
                     body: "Test".to_string(),
                 },
+                ProposalScope::Local,
             )
             .await
             .unwrap();
@@ -3715,6 +3732,7 @@ mod tests {
                 ProposalPayload::Text {
                     body: "Test".to_string(),
                 },
+                ProposalScope::Local,
             )
             .await
             .unwrap();
@@ -3749,6 +3767,7 @@ mod tests {
                 ProposalPayload::Text {
                     body: "Test".to_string(),
                 },
+                ProposalScope::Local,
             )
             .await;
 
@@ -3796,6 +3815,7 @@ mod tests {
                 ProposalPayload::Text {
                     body: "Test".to_string(),
                 },
+                ProposalScope::Local,
             )
             .await
             .unwrap();
@@ -3923,6 +3943,7 @@ mod tests {
                 ProposalPayload::Text {
                     body: "Original body".to_string(),
                 },
+                ProposalScope::Local,
             )
             .await
             .unwrap();
@@ -3938,6 +3959,7 @@ mod tests {
                 ProposalPayload::Text {
                     body: "Malicious content".to_string(),
                 },
+                ProposalScope::Local,
             )
             .await;
 
@@ -4062,6 +4084,7 @@ mod tests {
                 ProposalPayload::Text {
                     body: "Test".to_string(),
                 },
+                ProposalScope::Local,
             )
             .await
             .unwrap();

--- a/icn/crates/icn-gateway/src/api/treasury.rs
+++ b/icn/crates/icn-gateway/src/api/treasury.rs
@@ -669,6 +669,7 @@ pub async fn create_budget(
             title,
             description,
             payload,
+            icn_governance::ProposalScope::Local,
         )
         .await
         .map_err(|e| GatewayError::InternalError(format!("Failed to create proposal: {e}")))?;
@@ -1060,6 +1061,7 @@ pub(crate) async fn do_propose_spend(
             title,
             description,
             payload,
+            icn_governance::ProposalScope::Local,
         )
         .await
         .map_err(|e| GatewayError::InternalError(format!("Failed to create proposal: {e}")))?;

--- a/icn/crates/icn-gateway/src/governance_mgr.rs
+++ b/icn/crates/icn-gateway/src/governance_mgr.rs
@@ -24,7 +24,7 @@ use icn_governance::{
     GovernanceDomain, GovernanceDomainId, GovernanceError, GovernanceOps, GovernanceParams,
     GovernanceProfileId, InMemoryActionItemStore, InMemoryDiscussionStore, MembershipConfig,
     MembershipSource, PaginatedResult, ProofOutcome, Proposal, ProposalDomainLookup, ProposalId,
-    ProposalPayload, ProposalState, Timestamp, Vote, VoteChoice, VoteTally,
+    ProposalPayload, ProposalScope, ProposalState, Timestamp, Vote, VoteChoice, VoteTally,
     DEFAULT_MAX_DELEGATION_DEPTH,
 };
 use icn_identity::Did;
@@ -530,12 +530,13 @@ impl GovernanceManager {
         title: String,
         description: String,
         payload: ProposalPayload,
+        scope: ProposalScope,
     ) -> Result<ProposalId> {
         if let Some(ref handle) = self.governance_handle {
             // Actor-backed mode: delegate to GovernanceActor
             // Note: proposal_id and proposer are ignored - actor generates ID and uses own DID
             let generated_id = handle
-                .create_proposal(domain_id, title, description, payload)
+                .create_proposal(domain_id, title, description, payload, scope)
                 .await?;
             return Ok(generated_id);
         }
@@ -553,7 +554,8 @@ impl GovernanceManager {
         }
         drop(domains); // Release read lock before acquiring write lock
 
-        let mut proposal = Proposal::new(domain_id, proposer, title, description, payload);
+        let mut proposal =
+            Proposal::new(domain_id, proposer, title, description, payload).with_scope(scope);
         // Override the generated ID with the one provided
         proposal.id = proposal_id.clone();
 
@@ -1900,6 +1902,7 @@ mod tests {
             ProposalPayload::Text {
                 body: "test".to_string(),
             },
+            ProposalScope::Local,
         )
         .await
         .unwrap();
@@ -1959,6 +1962,7 @@ mod tests {
             ProposalPayload::Text {
                 body: "test".to_string(),
             },
+            ProposalScope::Local,
         )
         .await
         .unwrap();

--- a/icn/crates/icn-gateway/src/models.rs
+++ b/icn/crates/icn-gateway/src/models.rs
@@ -291,6 +291,19 @@ pub struct FederationConnectRequest {
     pub name: Option<String>,
 }
 
+/// Scope for a proposal (local or federation-wide)
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ProposalScopeRequest {
+    /// Local to this node's governance domain (default)
+    Local,
+    /// Visible across a federation — propagates via gossip
+    Federation {
+        /// Federation identifier
+        federation_id: String,
+    },
+}
+
 /// Create a new proposal
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct CreateProposalRequest {
@@ -298,6 +311,9 @@ pub struct CreateProposalRequest {
     pub title: String,       // Short title
     pub description: String, // Full description/rationale
     pub payload: ProposalPayloadRequest,
+    /// Proposal scope — defaults to Local if omitted
+    #[serde(default)]
+    pub scope: Option<ProposalScopeRequest>,
 }
 
 /// Proposal payload types (matches icn_governance::ProposalPayload)

--- a/icn/crates/icn-governance/src/handle.rs
+++ b/icn/crates/icn-governance/src/handle.rs
@@ -7,7 +7,7 @@ use icn_identity::Did;
 use crate::{
     Delegation, DelegationId, GovernanceDomain, GovernanceDomainId, GovernanceParams,
     MembershipAction, MembershipConfig, PaginatedResult, ParameterChange, Proposal, ProposalId,
-    ProposalPayload, ProtocolParameter, Timestamp, VoteChoice, VoteTally,
+    ProposalPayload, ProposalScope, ProtocolParameter, Timestamp, VoteChoice, VoteTally,
 };
 
 /// Trait for governance operations exposed to RPC layer
@@ -63,6 +63,7 @@ pub trait GovernanceOps: Send + Sync {
         title: String,
         description: String,
         payload: ProposalPayload,
+        scope: ProposalScope,
     ) -> Result<ProposalId>;
 
     /// Start deliberation period for a proposal

--- a/icn/crates/icn-rpc/src/handler/governance.rs
+++ b/icn/crates/icn-rpc/src/handler/governance.rs
@@ -508,7 +508,13 @@ pub async fn handle_governance_proposal_create(
     };
 
     match governance_handle
-        .create_proposal(domain_id, request.title, request.description, payload)
+        .create_proposal(
+            domain_id,
+            request.title,
+            request.description,
+            payload,
+            icn_governance::ProposalScope::Local,
+        )
         .await
     {
         Ok(proposal_id) => {


### PR DESCRIPTION
## Summary
- Adds `ProposalScopeRequest` enum to gateway models (`Local` / `Federation { federation_id }`)
- Threads scope through the full create-proposal chain: gateway API → `GovernanceManager` → `GovernanceOps` trait → `GovernanceCommand` → actor handler
- Federation-scoped proposals now trigger gossip propagation via the existing `publish_federation_if_scoped()` pathway
- Backward compatible: `scope` field defaults to `None` (= Local) in API requests
- Treasury and RPC callers default to `ProposalScope::Local`

## Context
Part of Sprint 11: Federated Governance. The federation gossip transport already exists (`federation:governance` topic subscribed at startup). The only gap was that `CreateProposalRequest` had no `scope` field, so every proposal defaulted to `ProposalScope::Local`. This PR closes that gap.

## Test plan
- [x] 511 gateway lib tests pass (including 52 governance tests)
- [x] clippy clean on icn-gateway, icn-rpc, icn-governance, icn-governance-actor
- [x] `cargo check --workspace` clean
- [ ] Integration test: create federation-scoped proposal via API, verify gossip propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)