### PR TITLE
docs(ops): pilot runbook + one-command smoke-test.sh

### DIFF
--- a/docs/guides/operations/PILOT_RUNBOOK.md
+++ b/docs/guides/operations/PILOT_RUNBOOK.md
@@ -1,0 +1,467 @@
+# ICN Pilot Cluster Operator Runbook
+
+**Audience**: Operators running the ICN pilot on the K3s homelab cluster.  
+**Last updated**: 2026-02-22
+
+---
+
+## Table of Contents
+
+1. [Prerequisites](#1-prerequisites)
+2. [Environment Setup](#2-environment-setup)
+3. [Cluster Health Check](#3-cluster-health-check)
+4. [Authentication — Getting a JWT](#4-authentication--getting-a-jwt)
+5. [Governance Lifecycle](#5-governance-lifecycle)
+6. [Ledger Verification](#6-ledger-verification)
+7. [Smoke Test](#7-smoke-test)
+8. [Reset Test Data](#8-reset-test-data)
+9. [Troubleshooting](#9-troubleshooting)
+
+---
+
+## 1. Prerequisites
+
+### What must be running
+
+| Component | Where | How to verify |
+|-----------|-------|---------------|
+| K3s control plane | `k3s-control` (10.8.10.40) | `kubectl get nodes` |
+| ICN gateway pods | `icn` namespace | `kubectl get pods -n icn` |
+| Atlas NFS | 10.8.10.25 | `kubectl get pvc -n icn` — must be `Bound` |
+
+### Tools required on your workstation
+
+```
+curl       >= 7.68
+jq         >= 1.6
+kubectl    >= 1.28   (optional — for pod inspection)
+icnctl              (optional — for DID operations)
+```
+
+Check:
+
+```bash
+curl --version | head -1
+jq --version
+```
+
+### Gateway NodePorts
+
+| Port  | Instance        | URL |
+|-------|----------------|-----|
+| 30080 | Default gateway | http://10.8.10.40:30080 |
+| 30081 | Coop instance 1 | http://10.8.10.40:30081 |
+| 30082 | Coop instance 2 | http://10.8.10.40:30082 |
+| 30083 | Coop instance 3 | http://10.8.10.40:30083 |
+| 30084 | Coop instance 4 | http://10.8.10.40:30084 |
+
+---
+
+## 2. Environment Setup
+
+Set these in your shell before running any commands:
+
+```bash
+export HOST="http://10.8.10.40:30080"   # default gateway
+export COOP_ID="pilot-coop-1"           # your cooperative ID
+export TOKEN=""                         # filled in after auth (§4)
+```
+
+All `curl` examples below assume these are set.
+
+---
+
+## 3. Cluster Health Check
+
+### Single gateway
+
+```bash
+curl -sf "$HOST/v1/health" | jq .
+```
+
+Expected response:
+
+```json
+{"status": "ok"}
+```
+
+HTTP 200 means the gateway is up and accepting requests.
+
+### All five gateway ports
+
+```bash
+for port in 30080 30081 30082 30083 30084; do
+    code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "http://10.8.10.40:${port}/v1/health")
+    echo "port $port → $code"
+done
+```
+
+All should return `200`. A `000` means the port is not listening — check the pod:
+
+```bash
+kubectl get pods -n icn -l app=icnd
+kubectl logs -n icn -l app=icnd --tail=50
+```
+
+### Quick K3s node check (if you have kubectl)
+
+```bash
+kubectl get nodes -o wide
+kubectl get pods -n icn
+kubectl get pvc -n icn
+```
+
+All nodes `Ready`, all pods `Running`, all PVCs `Bound`.
+
+---
+
+## 4. Authentication — Getting a JWT
+
+The gateway uses DID-based challenge–response auth. You need an Ed25519 DID keypair.
+
+### Option A: Use icnctl (recommended)
+
+```bash
+# Generate a DID keypair if you don't have one
+icnctl id init
+
+# Show your DID
+icnctl id show
+
+# Get a token (icnctl handles challenge + sign + verify internally)
+TOKEN=$(icnctl auth login --gateway "$HOST" --output token)
+export TOKEN
+```
+
+### Option B: Manual curl flow
+
+**Step 1 — Request a challenge**
+
+```bash
+DID="did:icn:<your-base58-pubkey>"
+
+CHALLENGE=$(curl -s -X POST "$HOST/v1/auth/challenge" \
+    -H "Content-Type: application/json" \
+    -d "{\"did\": \"$DID\"}" | jq -r '.challenge')
+
+echo "Challenge: $CHALLENGE"
+```
+
+**Step 2 — Sign the challenge**
+
+Sign the raw challenge string with your Ed25519 private key. The signature must be base64-encoded (standard, no padding).
+
+With icnctl:
+
+```bash
+SIG=$(icnctl id sign "$CHALLENGE" --base64)
+```
+
+**Step 3 — Verify and get JWT**
+
+```bash
+TOKEN=$(curl -s -X POST "$HOST/v1/auth/verify" \
+    -H "Content-Type: application/json" \
+    -d "{\"did\": \"$DID\", \"challenge\": \"$CHALLENGE\", \"signature\": \"$SIG\"}" \
+    | jq -r '.token')
+
+export TOKEN
+echo "Token: ${TOKEN:0:40}..."
+```
+
+A token is a signed JWT valid for the session. Pass it as `Authorization: Bearer $TOKEN` on all authenticated requests.
+
+---
+
+## 5. Governance Lifecycle
+
+These steps exercise the full governance flow: domain creation → proposal → vote → close.
+
+### 5.1 Create a governance domain
+
+A domain is the container for proposals and membership.
+
+```bash
+DOMAIN_ID="ops-test-$(date +%s)"
+
+curl -s -X POST "$HOST/v1/gov/domains" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{
+        \"id\": \"$DOMAIN_ID\",
+        \"name\": \"Ops Test Domain\",
+        \"profile\": \"cooperative_default\",
+        \"quorum_percent\": 1,
+        \"approval_percent\": 51,
+        \"voting_period_days\": 1,
+        \"members\": []
+    }" | jq .
+```
+
+Expected: HTTP 201 with domain object. A 400 with "already exists" is safe to ignore if the domain was created earlier.
+
+### 5.2 Submit a text proposal
+
+```bash
+PROPOSAL_TITLE="Test Proposal $(date +%s)"
+
+PROPOSAL_ID=$(curl -s -X POST "$HOST/v1/gov/proposals" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{
+        \"domain_id\": \"$DOMAIN_ID\",
+        \"title\": \"$PROPOSAL_TITLE\",
+        \"description\": \"Manual ops test proposal.\",
+        \"payload\": {
+            \"type\": \"text\",
+            \"body\": \"Approve routine maintenance window.\"
+        }
+    }" | jq -r '.id')
+
+echo "Proposal ID: $PROPOSAL_ID"
+```
+
+### 5.3 Open the proposal for voting
+
+```bash
+curl -s -X POST "$HOST/v1/gov/proposals/$PROPOSAL_ID/open" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"voting_period_seconds": 3600}' | jq '.state'
+```
+
+Expected: proposal state transitions to `open`.
+
+### 5.4 Cast a vote
+
+```bash
+curl -s -X POST "$HOST/v1/gov/proposals/$PROPOSAL_ID/vote" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"choice": "for", "comment": "Approved by ops."}' | jq .
+```
+
+Valid choices: `"for"`, `"against"`, `"abstain"`.
+
+### 5.5 Close the proposal
+
+```bash
+curl -s -X POST "$HOST/v1/gov/proposals/$PROPOSAL_ID/close" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{}' | jq '{state, outcome: .outcome}'
+```
+
+Expected: state is one of `accepted`, `rejected`, or `no_quorum`.
+
+### 5.6 Read the result
+
+```bash
+curl -s "$HOST/v1/gov/proposals/$PROPOSAL_ID" \
+    -H "Authorization: Bearer $TOKEN" | jq '{id, title, state}'
+```
+
+---
+
+## 6. Ledger Verification
+
+### Check a balance
+
+```bash
+DID="did:icn:<member-did>"
+
+curl -s "$HOST/v1/ledger/$COOP_ID/balance/$DID" \
+    -H "Authorization: Bearer $TOKEN" | jq .
+```
+
+### Ledger entries linked to a decision
+
+After governance closes a proposal that triggers economic effects, the decision hash links to ledger entries.
+
+```bash
+DECISION_HASH="<hex-hash-from-governance-receipt>"
+
+curl -s "$HOST/v1/ledger/$COOP_ID/entries/by-decision?decision_hash=$DECISION_HASH" \
+    -H "Authorization: Bearer $TOKEN" | jq .
+```
+
+An empty result is normal for text proposals (no economic effect). Budget proposals should produce entries.
+
+### Decision registry trace
+
+The registry tracks the full provenance chain:
+
+```bash
+# List decisions for a coop
+curl -s "$HOST/v1/registry/decisions?coop_id=$COOP_ID" \
+    -H "Authorization: Bearer $TOKEN" | jq '.[].decision_receipt_id'
+
+# Get a specific decision with trace
+RECEIPT_ID="<receipt-id-from-above>"
+
+curl -s "$HOST/v1/registry/decisions/$RECEIPT_ID" \
+    -H "Authorization: Bearer $TOKEN" | jq .
+
+curl -s "$HOST/v1/registry/decisions/$RECEIPT_ID/trace" \
+    -H "Authorization: Bearer $TOKEN" | jq .
+```
+
+The `/trace` endpoint shows the linkage: `DecisionReceipt → AllocationReceipt → LedgerEntry`.
+
+---
+
+## 7. Smoke Test
+
+The smoke test script runs the full governance lifecycle in one command and exits non-zero on any failure. It is safe to run against the live pilot cluster — it creates unique IDs per run and does not modify persistent state beyond the in-memory governance store.
+
+```bash
+HOST=$HOST TOKEN=$TOKEN COOP_ID=$COOP_ID ./scripts/smoke-test.sh
+```
+
+### What it tests
+
+| Step | Endpoint | Success criteria |
+|------|----------|-----------------|
+| 1 | `GET /v1/health` | 200 |
+| 2 | `GET /v1/gov/domains` (no auth) | 401 |
+| 3 | `POST /v1/gov/domains` | 201 or 200 |
+| 4 | `POST /v1/gov/proposals` | 201 or 200, `id` field present |
+| 5 | `POST /v1/gov/proposals/{id}/open` | 200 |
+| 6 | `POST /v1/gov/proposals/{id}/vote` | 200 or 201 |
+| 7 | `POST /v1/gov/proposals/{id}/close` | 200 |
+| 8 | `GET /v1/gov/proposals/{id}` | 200 |
+| 9 | `GET /v1/registry/decisions` | 200 |
+| 10 | `GET /v1/ledger/{coop}/entries/by-decision` | 200 or 404 |
+| 11 | `GET /v1/gov/proposals` | 200 |
+
+### Interpreting output
+
+```
+PASS Gateway health check (200)
+PASS Unauthenticated request rejected (401)
+PASS Create governance domain (201)
+PASS Create proposal (201) → id=prop-abc123
+PASS Open proposal (200) state=open
+PASS Cast vote (200)
+PASS Close proposal (200) outcome=accepted
+PASS Get closed proposal (200) state=accepted
+PASS List registry decisions (200) count=0
+PASS Ledger entries-by-decision endpoint reachable (200)
+PASS List proposals (200)
+
+Results: 11 passed, 0 failed, 0 skipped (11 total)
+SMOKE PASS
+```
+
+A `FAIL` line means that specific HTTP call returned an unexpected status. The body is printed below the FAIL line for diagnosis. The script exits `1`.
+
+A `WARN` line is non-fatal (e.g., domain already exists from a previous run).
+
+---
+
+## 8. Reset Test Data
+
+The governance store is in-memory per pod restart. To reset all governance state:
+
+```bash
+# Rolling restart of ICN pods (drops in-memory state, PVC data is preserved)
+kubectl rollout restart deployment/icnd -n icn
+
+# Wait for pods to come back
+kubectl rollout status deployment/icnd -n icn
+```
+
+Ledger entries on NFS-backed PVCs survive restarts. To clear ledger data for a specific coop, there is no REST endpoint — this requires direct Sled store access (see ops team).
+
+---
+
+## 9. Troubleshooting
+
+### Gateway returns 000 (connection refused)
+
+The pod is not running or the NodePort is not bound.
+
+```bash
+kubectl get pods -n icn
+kubectl describe pod <pod-name> -n icn
+kubectl logs <pod-name> -n icn --tail=100
+```
+
+Common causes:
+- PVC not bound (NFS unreachable) — check `kubectl get pvc -n icn`
+- OOMKilled — check `kubectl describe pod` for exit code 137
+- CrashLoopBackOff — check logs for keystore unlock failure
+
+### 401 Unauthorized on authenticated requests
+
+Your JWT has expired or the wrong secret was used.
+
+```bash
+# Decode the JWT payload (no verification, just inspect)
+echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq '{sub, exp}'
+```
+
+`exp` is a Unix timestamp. Re-authenticate if expired (§4).
+
+### 403 Forbidden on domain/proposal operations
+
+The DID in your JWT is not a member of the target domain. Either:
+1. Add your DID to the domain: `POST /v1/gov/domains/{id}/members`
+2. Create a new domain with your DID in the `members` array
+
+### 400 on create domain — "already exists"
+
+Safe to ignore. The domain with that ID was created in a previous run. Use a different `DOMAIN_ID` or proceed with the existing domain.
+
+### Proposal stuck in `draft` state
+
+A proposal must be explicitly opened before votes can be cast:
+
+```bash
+curl -s -X POST "$HOST/v1/gov/proposals/$PROPOSAL_ID/open" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"voting_period_seconds": 3600}'
+```
+
+### Close returns 404
+
+The proposal ID is wrong or the gateway was restarted (in-memory state lost). Re-create via §5.
+
+### Ledger entries/by-decision returns empty
+
+Text proposals do not generate ledger entries — this is correct. Only budget proposals (payload type `budget`) trigger ledger writes. Verify the proposal payload type:
+
+```bash
+curl -s "$HOST/v1/gov/proposals/$PROPOSAL_ID" \
+    -H "Authorization: Bearer $TOKEN" | jq '.payload.type'
+```
+
+### Checking metrics
+
+Prometheus scrapes on port 30090:
+
+```bash
+curl -s http://10.8.10.40:30090/metrics | grep gateway_governance
+```
+
+Key metrics:
+- `gateway_governance_proposals_created_total`
+- `gateway_governance_proposals_opened_total`
+- `gateway_governance_proposals_closed_total`
+- `gateway_governance_votes_cast_total`
+
+### Pod logs for a specific operation
+
+Enable debug logging for a single pod:
+
+```bash
+kubectl exec -n icn <pod-name> -- sh -c 'kill -USR1 1'  # toggles log level if supported
+kubectl logs -n icn <pod-name> -f --tail=200
+```
+
+Or filter for a specific proposal ID:
+
+```bash
+kubectl logs -n icn <pod-name> --tail=500 | grep "$PROPOSAL_ID"
+```

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+# ICN Pilot Cluster — Live REST Smoke Test
+#
+# Exercises the governance lifecycle end-to-end against a running gateway:
+#   health → create domain → create proposal → open → vote → close → ledger linkage
+#
+# Usage:
+#   HOST=http://10.8.10.40:30080 TOKEN=<jwt> ./scripts/smoke-test.sh
+#   HOST=http://10.8.10.40:30080 TOKEN=<jwt> COOP_ID=my-coop ./scripts/smoke-test.sh
+#
+# Environment:
+#   HOST     Gateway base URL (default: http://10.8.10.40:30080)
+#   TOKEN    Pre-issued JWT (required for authenticated steps)
+#   COOP_ID  Cooperative identifier (default: pilot-coop-1)
+#
+# Exit codes:
+#   0  All steps passed
+#   1  One or more steps failed
+#   2  Dependency missing (curl, jq)
+
+set -euo pipefail
+
+HOST="${HOST:-http://10.8.10.40:30080}"
+TOKEN="${TOKEN:-}"
+COOP_ID="${COOP_ID:-pilot-coop-1}"
+
+# Unique suffix so repeated runs don't collide
+RUN_ID="smoke-$(date +%s)-${RANDOM}"
+DOMAIN_ID="smoke-domain-${RUN_ID}"
+PROPOSAL_TITLE="Smoke Test Proposal ${RUN_ID}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+
+pass() { echo -e "${GREEN}PASS${NC} $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo -e "${RED}FAIL${NC} $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+warn() { echo -e "${YELLOW}WARN${NC} $1"; }
+skip() { echo -e "${YELLOW}SKIP${NC} $1"; SKIP_COUNT=$((SKIP_COUNT + 1)); }
+step() { echo -e "${CYAN}--->${NC} $1"; }
+
+require_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "ERROR: required command '$1' not found." >&2
+        exit 2
+    fi
+}
+
+require_cmd curl
+require_cmd jq
+
+# Returns: body\nHTTP_CODE
+http_get() {
+    local url="$1"
+    local auth_header="${2:-}"
+    if [ -n "$auth_header" ]; then
+        curl -s -w "\n%{http_code}" --max-time 15 -H "$auth_header" "$url"
+    else
+        curl -s -w "\n%{http_code}" --max-time 15 "$url"
+    fi
+}
+
+http_post() {
+    local url="$1"
+    local body="$2"
+    local auth_header="${3:-}"
+    if [ -n "$auth_header" ]; then
+        curl -s -w "\n%{http_code}" --max-time 15 \
+            -X POST -H "Content-Type: application/json" -H "$auth_header" \
+            -d "$body" "$url"
+    else
+        curl -s -w "\n%{http_code}" --max-time 15 \
+            -X POST -H "Content-Type: application/json" \
+            -d "$body" "$url"
+    fi
+}
+
+# Split response into body + code
+split_response() {
+    local raw="$1"
+    RESP_BODY=$(printf '%s' "$raw" | head -n -1)
+    RESP_CODE=$(printf '%s' "$raw" | tail -n1)
+}
+
+AUTH=""
+[ -n "$TOKEN" ] && AUTH="Authorization: Bearer $TOKEN"
+
+echo "=================================="
+echo "ICN Pilot Cluster Smoke Test"
+echo "Host:    $HOST"
+echo "CoopID:  $COOP_ID"
+echo "Run ID:  $RUN_ID"
+echo "Auth:    $([ -n "$TOKEN" ] && echo "provided" || echo "none (unauthenticated steps only)")"
+echo "=================================="
+echo ""
+
+# ---------------------------------------------------------------------------
+# Step 1: Health check
+# ---------------------------------------------------------------------------
+step "GET /v1/health"
+RAW=$(http_get "$HOST/v1/health")
+split_response "$RAW"
+if [ "$RESP_CODE" = "200" ]; then
+    pass "Gateway health check (200)"
+else
+    fail "Gateway health check returned $RESP_CODE (expected 200)"
+    echo "  Body: $RESP_BODY"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: Unauthenticated endpoints return 401
+# ---------------------------------------------------------------------------
+step "GET /v1/gov/domains (no auth, expect 401)"
+RAW=$(http_get "$HOST/v1/gov/domains")
+split_response "$RAW"
+if [ "$RESP_CODE" = "401" ]; then
+    pass "Unauthenticated request rejected (401)"
+else
+    warn "Expected 401 without auth, got $RESP_CODE"
+fi
+
+# ---------------------------------------------------------------------------
+# Authenticated steps — skip if no token
+# ---------------------------------------------------------------------------
+if [ -z "$TOKEN" ]; then
+    echo ""
+    skip "All authenticated steps (no TOKEN provided)"
+    echo ""
+    echo "To run the full suite:"
+    echo "  1. Obtain a challenge:  curl -s -X POST $HOST/v1/auth/challenge \\"
+    echo "       -H 'Content-Type: application/json' \\"
+    echo "       -d '{\"did\":\"<your-did>\"}'"
+    echo "  2. Sign the challenge with your DID key"
+    echo "  3. Verify:              curl -s -X POST $HOST/v1/auth/verify \\"
+    echo "       -H 'Content-Type: application/json' \\"
+    echo "       -d '{\"did\":\"<did>\",\"challenge\":\"<c>\",\"signature\":\"<sig>\"}'"
+    echo "  4. Re-run:              HOST=$HOST TOKEN=<jwt> $0"
+    echo ""
+    echo "=================================="
+    echo "Results: ${PASS_COUNT} passed, ${FAIL_COUNT} failed, ${SKIP_COUNT} skipped"
+    echo "=================================="
+    [ "$FAIL_COUNT" -eq 0 ] && exit 0 || exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3: Create governance domain
+# ---------------------------------------------------------------------------
+step "POST /v1/gov/domains (create smoke domain)"
+DOMAIN_BODY=$(jq -n \
+    --arg id "$DOMAIN_ID" \
+    --arg name "Smoke Test Domain ${RUN_ID}" \
+    '{
+        id: $id,
+        name: $name,
+        profile: "cooperative_default",
+        quorum_percent: 1,
+        approval_percent: 51,
+        voting_period_days: 1,
+        members: []
+    }')
+RAW=$(http_post "$HOST/v1/gov/domains" "$DOMAIN_BODY" "$AUTH")
+split_response "$RAW"
+if [ "$RESP_CODE" = "201" ] || [ "$RESP_CODE" = "200" ]; then
+    pass "Create governance domain ($RESP_CODE)"
+elif [ "$RESP_CODE" = "400" ] && echo "$RESP_BODY" | jq -e '.error' 2>/dev/null | grep -qi "already"; then
+    warn "Domain already exists (400) — continuing"
+else
+    fail "Create domain returned $RESP_CODE"
+    echo "  Body: $(echo "$RESP_BODY" | jq -c . 2>/dev/null || echo "$RESP_BODY")"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4: Create a text proposal
+# ---------------------------------------------------------------------------
+step "POST /v1/gov/proposals (text proposal)"
+PROPOSAL_BODY=$(jq -n \
+    --arg domain_id "$DOMAIN_ID" \
+    --arg title "$PROPOSAL_TITLE" \
+    '{
+        domain_id: $domain_id,
+        title: $title,
+        description: "Automated smoke test proposal. Safe to ignore.",
+        payload: {
+            type: "text",
+            body: "This proposal was created by the ICN pilot smoke test script."
+        }
+    }')
+RAW=$(http_post "$HOST/v1/gov/proposals" "$PROPOSAL_BODY" "$AUTH")
+split_response "$RAW"
+if [ "$RESP_CODE" = "201" ] || [ "$RESP_CODE" = "200" ]; then
+    PROPOSAL_ID=$(echo "$RESP_BODY" | jq -r '.id // .proposal_id // empty' 2>/dev/null)
+    if [ -n "$PROPOSAL_ID" ] && [ "$PROPOSAL_ID" != "null" ]; then
+        pass "Create proposal ($RESP_CODE) → id=$PROPOSAL_ID"
+    else
+        fail "Create proposal returned $RESP_CODE but no id in response"
+        echo "  Body: $(echo "$RESP_BODY" | jq -c . 2>/dev/null || echo "$RESP_BODY")"
+        PROPOSAL_ID=""
+    fi
+else
+    fail "Create proposal returned $RESP_CODE"
+    echo "  Body: $(echo "$RESP_BODY" | jq -c . 2>/dev/null || echo "$RESP_BODY")"
+    PROPOSAL_ID=""
+fi
+
+if [ -z "$PROPOSAL_ID" ]; then
+    echo ""
+    echo "Cannot proceed without proposal ID. Aborting remaining steps."
+    echo ""
+    echo "=================================="
+    echo "Results: ${PASS_COUNT} passed, ${FAIL_COUNT} failed, ${SKIP_COUNT} skipped"
+    echo "=================================="
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Step 5: Open the proposal for voting
+# ---------------------------------------------------------------------------
+step "POST /v1/gov/proposals/$PROPOSAL_ID/open"
+OPEN_BODY='{"voting_period_seconds": 3600}'
+RAW=$(http_post "$HOST/v1/gov/proposals/$PROPOSAL_ID/open" "$OPEN_BODY" "$AUTH")
+split_response "$RAW"
+if [ "$RESP_CODE" = "200" ]; then
+    PROPOSAL_STATE=$(echo "$RESP_BODY" | jq -r '.state // .status // empty' 2>/dev/null)
+    pass "Open proposal (200) state=${PROPOSAL_STATE:-unknown}"
+else
+    fail "Open proposal returned $RESP_CODE"
+    echo "  Body: $(echo "$RESP_BODY" | jq -c . 2>/dev/null || echo "$RESP_BODY")"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 6: Cast a vote
+# ---------------------------------------------------------------------------
+step "POST /v1/gov/proposals/$PROPOSAL_ID/vote"
+VOTE_BODY='{"choice": "for", "comment": "Smoke test vote"}'
+RAW=$(http_post "$HOST/v1/gov/proposals/$PROPOSAL_ID/vote" "$VOTE_BODY" "$AUTH")
+split_response "$RAW"
+if [ "$RESP_CODE" = "200" ] || [ "$RESP_CODE" = "201" ]; then
+    pass "Cast vote ($RESP_CODE)"
+else
+    fail "Cast vote returned $RESP_CODE"
+    echo "  Body: $(echo "$RESP_BODY" | jq -c . 2>/dev/null || echo "$RESP_BODY")"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 7: Close the proposal
+# ---------------------------------------------------------------------------
+step "POST /v1/gov/proposals/$PROPOSAL_ID/close"
+RAW=$(http_post "$HOST/v1/gov/proposals/$PROPOSAL_ID/close" '{}' "$AUTH")
+split_response "$RAW"
+if [ "$RESP_CODE" = "200" ]; then
+    OUTCOME=$(echo "$RESP_BODY" | jq -r '.outcome // .state // empty' 2>/dev/null)
+    pass "Close proposal (200) outcome=${OUTCOME:-unknown}"
+else
+    fail "Close proposal returned $RESP_CODE"
+    echo "  Body: $(echo "$RESP_BODY" | jq -c . 2>/dev/null || echo "$RESP_BODY")"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 8: Verify proposal is readable after close
+# ---------------------------------------------------------------------------
+step "GET /v1/gov/proposals/$PROPOSAL_ID"
+RAW=$(http_get "$HOST/v1/gov/proposals/$PROPOSAL_ID" "$AUTH")
+split_response "$RAW"
+if [ "$RESP_CODE" = "200" ]; then
+    FINAL_STATE=$(echo "$RESP_BODY" | jq -r '.state // empty' 2>/dev/null)
+    pass "Get closed proposal (200) state=${FINAL_STATE:-unknown}"
+else
+    fail "Get proposal post-close returned $RESP_CODE"
+    echo "  Body: $(echo "$RESP_BODY" | jq -c . 2>/dev/null || echo "$RESP_BODY")"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 9: Registry — list decisions (expect 200, may be empty)
+# ---------------------------------------------------------------------------
+step "GET /v1/registry/decisions?coop_id=$COOP_ID"
+RAW=$(http_get "$HOST/v1/registry/decisions?coop_id=$COOP_ID" "$AUTH")
+split_response "$RAW"
+if [ "$RESP_CODE" = "200" ]; then
+    DECISION_COUNT=$(echo "$RESP_BODY" | jq 'if type == "array" then length else (.decisions // [] | length) end' 2>/dev/null || echo "?")
+    pass "List registry decisions (200) count=${DECISION_COUNT}"
+else
+    fail "List registry decisions returned $RESP_CODE"
+    echo "  Body: $(echo "$RESP_BODY" | jq -c . 2>/dev/null || echo "$RESP_BODY")"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 10: Ledger entries by decision (uses a stable fixture hash; 200 + empty is fine)
+# ---------------------------------------------------------------------------
+step "GET /v1/ledger/$COOP_ID/entries/by-decision (fixture hash)"
+# A known-zero hash — expect 200 with empty or 404; both indicate the endpoint is live
+FIXTURE_HASH="0000000000000000000000000000000000000000000000000000000000000000"
+RAW=$(http_get "$HOST/v1/ledger/$COOP_ID/entries/by-decision?decision_hash=$FIXTURE_HASH" "$AUTH")
+split_response "$RAW"
+if [ "$RESP_CODE" = "200" ] || [ "$RESP_CODE" = "404" ]; then
+    pass "Ledger entries-by-decision endpoint reachable ($RESP_CODE)"
+else
+    fail "Ledger entries-by-decision returned $RESP_CODE"
+    echo "  Body: $(echo "$RESP_BODY" | jq -c . 2>/dev/null || echo "$RESP_BODY")"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 11: List governance proposals (smoke check list endpoint)
+# ---------------------------------------------------------------------------
+step "GET /v1/gov/proposals"
+RAW=$(http_get "$HOST/v1/gov/proposals" "$AUTH")
+split_response "$RAW"
+if [ "$RESP_CODE" = "200" ]; then
+    pass "List proposals (200)"
+else
+    fail "List proposals returned $RESP_CODE"
+    echo "  Body: $(echo "$RESP_BODY" | jq -c . 2>/dev/null || echo "$RESP_BODY")"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=================================="
+TOTAL=$((PASS_COUNT + FAIL_COUNT + SKIP_COUNT))
+echo "Results: ${PASS_COUNT} passed, ${FAIL_COUNT} failed, ${SKIP_COUNT} skipped (${TOTAL} total)"
+if [ "$FAIL_COUNT" -eq 0 ]; then
+    echo -e "${GREEN}SMOKE PASS${NC}"
+    echo "=================================="
+    exit 0
+else
+    echo -e "${RED}SMOKE FAIL${NC}"
+    echo "=================================="
+    exit 1
+fi


### PR DESCRIPTION
## What

Adds two new operational artifacts for Sprint 12 T4 (Issue #1222):

- `scripts/smoke-test.sh` — 11-step live REST smoke test against the K3s cluster gateway
- `docs/guides/operations/PILOT_RUNBOOK.md` — complete operator runbook

## Smoke test steps

1. Dependency check (curl, jq)
2. Health check `GET /v1/health`
3. Auth rejection smoke (401 without token)
4. Create governance domain (idempotent — skips on 400)
5. Create text proposal
6. Open proposal for voting
7. Cast vote
8. Close proposal
9. Registry: read back decision record
10. Ledger: verify entries-by-decision endpoint is live
11. Summary: PASS/FAIL counts, exit 1 on any failure

Runs against `HOST` (default `http://10.8.10.40:30080`), accepts pre-provided `TOKEN`.
Without a token, steps 4–11 are skipped with auth instructions.

## Runbook sections

Prerequisites · Environment setup · Cluster health · Governance lifecycle · Ledger verification · Smoke test · Reset · Troubleshooting (6 failure modes)

## Verify

```
bash scripts/smoke-test.sh                     # no token → health + 401 check only
bash scripts/smoke-test.sh $HOST $TOKEN        # full run against live cluster
```

## Risk

None — new files only, no existing code changed.

Closes #1222