### PR TITLE
refactor(governance): extract GovernanceStateStore trait (Phase 3 kickoff)

### DIFF
--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -13,9 +13,9 @@ use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, RwLock};
 use tracing::{debug, info, warn};
 
+use crate::state_store::{GovernanceStateStore, SledGovernanceStateStore};
 use icn_gossip::GossipActor;
 use icn_identity::Did;
-use crate::state_store::{GovernanceStateStore, SledGovernanceStateStore};
 
 use icn_governance::{
     DecisionOutcome, Delegation, DelegationId, GovernanceConfig, GovernanceDomain,
@@ -2041,11 +2041,8 @@ impl GovernanceActor {
         let total = all_domains.len();
 
         // Skip to offset and take limit
-        let page: Vec<GovernanceDomain> = all_domains
-            .into_iter()
-            .skip(offset)
-            .take(limit)
-            .collect();
+        let page: Vec<GovernanceDomain> =
+            all_domains.into_iter().skip(offset).take(limit).collect();
 
         // Calculate next cursor
         let next_offset = offset + page.len();
@@ -2417,7 +2414,8 @@ impl GovernanceActor {
 
         delegation.revoked_at = Some(revoked_at);
 
-        self.store.save_revoked_delegation(&delegation, revoked_at)?;
+        self.store
+            .save_revoked_delegation(&delegation, revoked_at)?;
 
         info!("✓ Delegation revoked: {}", id.0);
 

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -15,7 +15,7 @@ use tracing::{debug, info, warn};
 
 use icn_gossip::GossipActor;
 use icn_identity::Did;
-use icn_store::Store;
+use crate::state_store::{GovernanceStateStore, SledGovernanceStateStore};
 
 use icn_governance::{
     DecisionOutcome, Delegation, DelegationId, GovernanceConfig, GovernanceDomain,
@@ -304,8 +304,7 @@ impl GovernanceHandle {
         proposal_id: &ProposalId,
     ) -> Result<Option<icn_governance::GovernanceProofV2>> {
         let actor = self.inner.read().await;
-        let proof_key = format!("governance:proof:{}", proposal_id.0);
-        match actor.store.get(proof_key.as_bytes())? {
+        match actor.store.get_proof_bytes(proposal_id)? {
             Some(bytes) => {
                 // Only return securely verifiable V2 proofs. Legacy proofs are not
                 // returned because they cannot carry canonical V2 attestations.
@@ -991,7 +990,7 @@ impl icn_governance::GovernanceOps for GovernanceHandle {
 /// The governance actor
 pub struct GovernanceActor {
     did: Did,
-    store: Arc<dyn Store>,
+    store: Arc<dyn GovernanceStateStore>,
     gossip: Arc<RwLock<GossipActor>>,
     resolver: Arc<dyn MembershipResolver + Send + Sync>,
     profile: GovernanceProfile,
@@ -1010,13 +1009,15 @@ impl GovernanceActor {
     /// Spawn a new governance actor
     pub async fn spawn(
         did: Did,
-        store: Arc<dyn Store>,
+        store: Arc<dyn icn_store::Store>,
         gossip: Arc<RwLock<GossipActor>>,
         resolver: Arc<dyn MembershipResolver + Send + Sync>,
         event_bus: Option<Arc<dyn EventEmitter>>,
         signing_key: Option<Arc<ed25519_dalek::SigningKey>>,
     ) -> Result<GovernanceHandle> {
         info!("Spawning GovernanceActor for DID: {}", did);
+        // Wrap raw store in typed state store abstraction
+        let store: Arc<dyn GovernanceStateStore> = Arc::new(SledGovernanceStateStore::new(store));
 
         // Subscribe to governance topic
         {
@@ -1271,8 +1272,7 @@ impl GovernanceActor {
                 );
 
                 // Persist locally
-                self.store
-                    .put(&domain_key(&domain_id), &serde_json::to_vec(&domain)?)?;
+                self.store.save_domain(&domain)?;
 
                 // Broadcast to network
                 self.publish(GovernanceMessage::domain_created(domain))
@@ -1304,8 +1304,7 @@ impl GovernanceActor {
                 proposal.id = proposal_id.clone();
 
                 // Persist locally
-                self.store
-                    .put(&proposal_key(&proposal_id), &serde_json::to_vec(&proposal)?)?;
+                self.store.save_proposal(&proposal)?;
 
                 // Broadcast to network
                 self.publish(GovernanceMessage::proposal_created(proposal.clone()))
@@ -1345,8 +1344,7 @@ impl GovernanceActor {
                 };
 
                 // Persist updated state
-                self.store
-                    .put(&proposal_key(&proposal_id), &serde_json::to_vec(&proposal)?)?;
+                self.store.save_proposal(&proposal)?;
 
                 // Load domain to get default voting period for auto-transition
                 // Use graceful fallback if domain load fails to avoid blocking deliberation
@@ -1425,8 +1423,7 @@ impl GovernanceActor {
                 };
 
                 // Persist updated state
-                self.store
-                    .put(&proposal_key(&proposal_id), &serde_json::to_vec(&proposal)?)?;
+                self.store.save_proposal(&proposal)?;
 
                 // Schedule auto-close for voting
                 let closes_at_instant = Instant::now() + Duration::from_secs(voting_period_seconds);
@@ -1492,8 +1489,7 @@ impl GovernanceActor {
                 };
 
                 // Persist updated state
-                self.store
-                    .put(&proposal_key(&proposal_id), &serde_json::to_vec(&proposal)?)?;
+                self.store.save_proposal(&proposal)?;
 
                 // Schedule auto-close
                 let closes_at_instant = Instant::now() + Duration::from_secs(voting_period_seconds);
@@ -1533,10 +1529,7 @@ impl GovernanceActor {
                 }
 
                 // Persist locally
-                self.store.put(
-                    &vote_key(&proposal_id, &self.did),
-                    &serde_json::to_vec(&vote)?,
-                )?;
+                self.store.save_vote(&proposal_id, &vote)?;
 
                 // Broadcast to network
                 let vote_msg = GovernanceMessage::vote_cast(vote, None);
@@ -1639,8 +1632,7 @@ impl GovernanceActor {
                 proposal.close(new_state)?;
 
                 // Persist updated state
-                self.store
-                    .put(&proposal_key(&proposal_id), &serde_json::to_vec(&proposal)?)?;
+                self.store.save_proposal(&proposal)?;
 
                 // Generate GovernanceProofV2 if signing key is available
                 let proof_bytes = if let Some(ref signing_key) = self.signing_key {
@@ -1671,8 +1663,7 @@ impl GovernanceActor {
                     let serialized = serde_json::to_vec(&proof)?;
 
                     // Persist proof for later retrieval
-                    let proof_key = format!("governance:proof:{}", proposal_id.0);
-                    self.store.put(proof_key.as_bytes(), &serialized)?;
+                    self.store.save_proof_bytes(&proposal_id, &serialized)?;
 
                     info!(
                         "GovernanceProofV2 signed for proposal {} (decision_hash: {})",
@@ -1785,8 +1776,7 @@ impl GovernanceActor {
                 proposal.veto(reason.clone())?;
 
                 // Persist updated state
-                self.store
-                    .put(&proposal_key(&proposal_id), &serde_json::to_vec(&proposal)?)?;
+                self.store.save_proposal(&proposal)?;
 
                 // Emit event for downstream processing
                 if let Some(ref event_bus) = self.event_bus {
@@ -1835,8 +1825,7 @@ impl GovernanceActor {
                 proposal.force_close(proposal_outcome.clone(), reason.clone())?;
 
                 // Persist updated state
-                self.store
-                    .put(&proposal_key(&proposal_id), &serde_json::to_vec(&proposal)?)?;
+                self.store.save_proposal(&proposal)?;
 
                 // Emit appropriate event
                 if let Some(ref event_bus) = self.event_bus {
@@ -1893,8 +1882,7 @@ impl GovernanceActor {
                 domain.update_config(new_config);
 
                 // Persist locally
-                self.store
-                    .put(&domain_key(&domain_id), &serde_json::to_vec(&domain)?)?;
+                self.store.save_domain(&domain)?;
 
                 // Broadcast to network
                 self.publish(GovernanceMessage::domain_updated(domain))
@@ -1972,8 +1960,7 @@ impl GovernanceActor {
                 domain.updated_at = icn_time::current_timestamp_secs();
 
                 // Persist locally
-                self.store
-                    .put(&domain_key(&domain_id), &serde_json::to_vec(&domain)?)?;
+                self.store.save_domain(&domain)?;
 
                 // Broadcast to network
                 self.publish(GovernanceMessage::domain_updated(domain))
@@ -2025,11 +2012,7 @@ impl GovernanceActor {
 
     /// List all domains
     fn list_domains(&self) -> Result<Vec<GovernanceDomain>> {
-        let prefix = domain_key_prefix();
-        let rows = self.store.scan(prefix)?;
-        rows.into_iter()
-            .map(|(_k, v)| Ok(serde_json::from_slice::<GovernanceDomain>(&v)?))
-            .collect()
+        self.store.list_domains()
     }
 
     /// List domains with pagination
@@ -2054,17 +2037,15 @@ impl GovernanceActor {
         };
 
         // Scan all domains (storage layer doesn't support native pagination)
-        let prefix = domain_key_prefix();
-        let all_rows = self.store.scan(prefix)?;
-        let total = all_rows.len();
+        let all_domains = self.store.list_domains()?;
+        let total = all_domains.len();
 
         // Skip to offset and take limit
-        let page: Vec<GovernanceDomain> = all_rows
+        let page: Vec<GovernanceDomain> = all_domains
             .into_iter()
             .skip(offset)
             .take(limit)
-            .map(|(_k, v)| serde_json::from_slice::<GovernanceDomain>(&v))
-            .collect::<std::result::Result<Vec<_>, _>>()?;
+            .collect();
 
         // Calculate next cursor
         let next_offset = offset + page.len();
@@ -2083,30 +2064,22 @@ impl GovernanceActor {
 
     /// List all proposals
     fn list_proposals(&self) -> Result<Vec<Proposal>> {
-        let prefix = proposal_key_prefix();
-        let rows = self.store.scan(prefix)?;
-        rows.into_iter()
-            .map(|(_k, v)| Ok(serde_json::from_slice::<Proposal>(&v)?))
-            .collect()
+        self.store.list_proposals()
     }
 
     /// Load a domain by ID
     fn load_domain(&self, id: &GovernanceDomainId) -> Result<Option<GovernanceDomain>> {
-        load_json(self.store.as_ref(), &domain_key(id))
+        self.store.get_domain(id)
     }
 
     /// Load a proposal by ID
     fn load_proposal(&self, id: &ProposalId) -> Result<Option<Proposal>> {
-        load_json(self.store.as_ref(), &proposal_key(id))
+        self.store.get_proposal(id)
     }
 
     /// Load all votes for a proposal
     fn load_votes(&self, id: &ProposalId) -> Result<Vec<Vote>> {
-        let prefix = vote_key_prefix(id);
-        let rows = self.store.scan(&prefix)?;
-        rows.into_iter()
-            .map(|(_k, v)| Ok(serde_json::from_slice::<Vote>(&v)?))
-            .collect()
+        self.store.list_votes(id)
     }
 
     /// Get vote tally for a proposal
@@ -2174,10 +2147,7 @@ impl GovernanceActor {
         }
 
         // Store the delegation
-        self.store.put(
-            &delegation_key(&delegation.id),
-            &serde_json::to_vec(&delegation)?,
-        )?;
+        self.store.save_delegation(&delegation)?;
 
         info!(
             "✓ Delegation created: {} -> {} (scope: {:?})",
@@ -2372,15 +2342,14 @@ impl GovernanceActor {
 
     /// Load a delegation by ID
     fn load_delegation(&self, id: &DelegationId) -> Result<Option<Delegation>> {
-        load_json(self.store.as_ref(), &delegation_key(id))
+        self.store.get_delegation(id)
     }
 
     /// List all delegations from a delegator
     ///
     /// Returns error on deserialization failures to surface data corruption issues.
     fn list_delegations_from(&self, delegator: &Did) -> Result<Vec<Delegation>> {
-        let prefix = delegation_key_prefix();
-        let rows = self.store.scan(prefix)?;
+        let rows = self.store.list_all_delegations()?;
         let mut delegations = Vec::new();
 
         for (k, v) in rows {
@@ -2412,8 +2381,7 @@ impl GovernanceActor {
     ///
     /// Returns error on deserialization failures to surface data corruption issues.
     fn list_delegations_to(&self, delegate: &Did) -> Result<Vec<Delegation>> {
-        let prefix = delegation_key_prefix();
-        let rows = self.store.scan(prefix)?;
+        let rows = self.store.list_all_delegations()?;
         let mut delegations = Vec::new();
 
         for (k, v) in rows {
@@ -2449,10 +2417,7 @@ impl GovernanceActor {
 
         delegation.revoked_at = Some(revoked_at);
 
-        self.store.put(
-            &delegation_key(&delegation.id),
-            &serde_json::to_vec(&delegation)?,
-        )?;
+        self.store.save_revoked_delegation(&delegation, revoked_at)?;
 
         info!("✓ Delegation revoked: {}", id.0);
 
@@ -2461,23 +2426,20 @@ impl GovernanceActor {
 }
 
 /// Handle incoming governance messages from gossip
-fn handle_incoming(store: &dyn Store, msg: GovernanceMessage) -> Result<()> {
+fn handle_incoming(store: &dyn GovernanceStateStore, msg: GovernanceMessage) -> Result<()> {
     match msg {
         GovernanceMessage::DomainCreated { domain } => {
-            // Use domain.id as the key
-            let id = GovernanceDomainId(domain.id.0.clone());
-            store.put(&domain_key(&id), &serde_json::to_vec(&domain)?)?;
+            store.save_domain(&domain)?;
         }
 
         GovernanceMessage::DomainUpdated { domain } => {
             // Update existing domain with new config
-            let id = GovernanceDomainId(domain.id.0.clone());
-            store.put(&domain_key(&id), &serde_json::to_vec(&domain)?)?;
-            info!("Domain config updated via gossip: {}", id.0);
+            store.save_domain(&domain)?;
+            info!("Domain config updated via gossip: {}", domain.id.0);
         }
 
         GovernanceMessage::ProposalCreated { proposal } => {
-            store.put(&proposal_key(&proposal.id), &serde_json::to_vec(&proposal)?)?;
+            store.save_proposal(&proposal)?;
         }
 
         GovernanceMessage::ProposalOpened {
@@ -2486,7 +2448,7 @@ fn handle_incoming(store: &dyn Store, msg: GovernanceMessage) -> Result<()> {
             closes_at,
         } => {
             // Load, update state, persist
-            if let Some(proposal) = load_json::<Proposal>(store, &proposal_key(&id))? {
+            if let Some(proposal) = store.get_proposal(&id)? {
                 // Force state to Open (idempotent for convergence)
                 let updated = Proposal {
                     state: ProposalState::Open {
@@ -2496,15 +2458,12 @@ fn handle_incoming(store: &dyn Store, msg: GovernanceMessage) -> Result<()> {
                     updated_at: now_seconds(),
                     ..proposal
                 };
-                store.put(&proposal_key(&id), &serde_json::to_vec(&updated)?)?;
+                store.save_proposal(&updated)?;
             }
         }
 
         GovernanceMessage::VoteCast { vote, .. } => {
-            store.put(
-                &vote_key(&vote.proposal_id, &vote.voter),
-                &serde_json::to_vec(&vote)?,
-            )?;
+            store.save_vote(&vote.proposal_id.clone(), &vote)?;
         }
 
         GovernanceMessage::ProposalClosed {
@@ -2514,19 +2473,17 @@ fn handle_incoming(store: &dyn Store, msg: GovernanceMessage) -> Result<()> {
             proof_bytes,
             ..
         } => {
-            if let Some(mut proposal) = load_json::<Proposal>(store, &proposal_key(&id))? {
+            if let Some(mut proposal) = store.get_proposal(&id)? {
                 let new_state = match outcome {
                     ProposalOutcome::Accepted => ProposalState::Accepted { closed_at },
                     ProposalOutcome::Rejected => ProposalState::Rejected { closed_at },
                     ProposalOutcome::NoQuorum => ProposalState::NoQuorum { closed_at },
                 };
                 proposal.close(new_state)?;
-                store.put(&proposal_key(&id), &serde_json::to_vec(&proposal)?)?;
+                store.save_proposal(&proposal)?;
             }
             // Persist proof from remote node (if included and valid)
             if let Some(bytes) = proof_bytes {
-                let proof_key = format!("governance:proof:{}", id.0);
-
                 // Validate remote proof before storing (untrusted gossip input)
                 let incoming_v2 = match serde_json::from_slice::<icn_governance::GovernanceProofV2>(
                     &bytes,
@@ -2580,7 +2537,7 @@ fn handle_incoming(store: &dyn Store, msg: GovernanceMessage) -> Result<()> {
                 };
 
                 if let Some(proof) = incoming_v2 {
-                    let should_store = match store.get(proof_key.as_bytes())? {
+                    let should_store = match store.get_proof_bytes(&id)? {
                         Some(existing_bytes) => {
                             match serde_json::from_slice::<icn_governance::GovernanceProofV2>(
                                 &existing_bytes,
@@ -2603,7 +2560,7 @@ fn handle_incoming(store: &dyn Store, msg: GovernanceMessage) -> Result<()> {
 
                     if should_store {
                         let canonical_bytes = serde_json::to_vec(&proof)?;
-                        store.put(proof_key.as_bytes(), &canonical_bytes)?;
+                        store.save_proof_bytes(&id, &canonical_bytes)?;
                         info!(
                             "Stored validated governance proof from remote for proposal {}",
                             id.0
@@ -2621,51 +2578,7 @@ fn handle_incoming(store: &dyn Store, msg: GovernanceMessage) -> Result<()> {
     Ok(())
 }
 
-// ---- Storage key helpers (aligned with icnctl) ----
-
-fn domain_key(id: &GovernanceDomainId) -> Vec<u8> {
-    format!("gov:domain:{}", id.0).into_bytes()
-}
-
-fn domain_key_prefix() -> &'static [u8] {
-    b"gov:domain:"
-}
-
-fn proposal_key(id: &ProposalId) -> Vec<u8> {
-    format!("gov:proposal:{}", id.0).into_bytes()
-}
-
-fn proposal_key_prefix() -> &'static [u8] {
-    b"gov:proposal:"
-}
-
-fn vote_key(proposal_id: &ProposalId, voter: &Did) -> Vec<u8> {
-    format!("gov:vote:{}:{}", proposal_id.0, voter).into_bytes()
-}
-
-fn vote_key_prefix(proposal_id: &ProposalId) -> Vec<u8> {
-    format!("gov:vote:{}:", proposal_id.0).into_bytes()
-}
-
-fn delegation_key(id: &DelegationId) -> Vec<u8> {
-    format!("gov:delegation:{}", id.0).into_bytes()
-}
-
-fn delegation_key_prefix() -> &'static [u8] {
-    b"gov:delegation:"
-}
-
 // ---- Utility functions ----
-
-fn load_json<T: for<'a> serde::Deserialize<'a>>(
-    store: &dyn Store,
-    key: &[u8],
-) -> Result<Option<T>> {
-    match store.get(key)? {
-        Some(v) => Ok(Some(serde_json::from_slice::<T>(&v)?)),
-        None => Ok(None),
-    }
-}
 
 fn now_seconds() -> u64 {
     icn_time::current_timestamp_secs()

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -29,8 +29,10 @@ pub mod executor;
 pub mod handlers;
 pub mod init;
 pub mod registry;
+pub mod state_store;
 
 pub use actor::{GovernanceActor, GovernanceCommand, GovernanceConfigLite, GovernanceHandle};
+pub use state_store::{GovernanceStateStore, SledGovernanceStateStore};
 pub use executor::{ExecutionCallback, GovernanceProposalExecutor};
 pub use handlers::translate_payload_to_effects;
 

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -32,9 +32,9 @@ pub mod registry;
 pub mod state_store;
 
 pub use actor::{GovernanceActor, GovernanceCommand, GovernanceConfigLite, GovernanceHandle};
-pub use state_store::{GovernanceStateStore, SledGovernanceStateStore};
 pub use executor::{ExecutionCallback, GovernanceProposalExecutor};
 pub use handlers::translate_payload_to_effects;
+pub use state_store::{GovernanceStateStore, SledGovernanceStateStore};
 
 // Re-export registry types for decision/meeting management
 pub use registry::{DecisionFilter, DecisionIndexEntry, DecisionRegistry, DecisionStatus, Meeting};

--- a/icn/apps/governance/src/state_store.rs
+++ b/icn/apps/governance/src/state_store.rs
@@ -1,0 +1,252 @@
+//! GovernanceStateStore — typed storage abstraction for the GovernanceActor.
+//!
+//! This module decouples the actor from raw `icn_store::Store` byte operations.
+//! The actor works entirely in domain terms; this module owns all key encoding
+//! and serialization details.
+
+use anyhow::Result;
+use std::sync::Arc;
+
+use icn_governance::{
+    Delegation, DelegationId, GovernanceDomain, GovernanceDomainId, Proposal, ProposalId,
+    Timestamp, Vote,
+};
+use icn_identity::Did;
+use icn_store::Store;
+
+// ---- Trait ----
+
+/// State storage abstraction for the GovernanceActor.
+///
+/// The actor works in domain terms; the implementor handles serialization
+/// and key encoding. This keeps raw byte-level concerns out of actor.rs.
+pub trait GovernanceStateStore: Send + Sync {
+    // --- Domains ---
+
+    /// Load a domain by ID.
+    fn get_domain(&self, id: &GovernanceDomainId) -> Result<Option<GovernanceDomain>>;
+
+    /// Persist a domain (insert or overwrite).
+    fn save_domain(&self, domain: &GovernanceDomain) -> Result<()>;
+
+    /// Return all domains in the store.
+    fn list_domains(&self) -> Result<Vec<GovernanceDomain>>;
+
+    // --- Proposals ---
+
+    /// Load a proposal by ID.
+    fn get_proposal(&self, id: &ProposalId) -> Result<Option<Proposal>>;
+
+    /// Persist a proposal (insert or overwrite).
+    fn save_proposal(&self, proposal: &Proposal) -> Result<()>;
+
+    /// Return all proposals in the store.
+    fn list_proposals(&self) -> Result<Vec<Proposal>>;
+
+    // --- Votes ---
+
+    /// Load a single vote cast by `voter` on `proposal_id`.
+    fn get_vote(&self, proposal_id: &ProposalId, voter: &Did) -> Result<Option<Vote>>;
+
+    /// Persist a vote (insert or overwrite).
+    fn save_vote(&self, proposal_id: &ProposalId, vote: &Vote) -> Result<()>;
+
+    /// Return all votes for a given proposal.
+    fn list_votes(&self, proposal_id: &ProposalId) -> Result<Vec<Vote>>;
+
+    // --- Delegations ---
+
+    /// Load a delegation by ID.
+    fn get_delegation(&self, id: &DelegationId) -> Result<Option<Delegation>>;
+
+    /// Persist a delegation (insert or overwrite).
+    fn save_delegation(&self, delegation: &Delegation) -> Result<()>;
+
+    /// Return all delegations in the store (unfiltered).
+    fn list_all_delegations(&self) -> Result<Vec<(Vec<u8>, Vec<u8>)>>;
+
+    /// Persist a delegation with an updated `revoked_at` field.
+    fn save_revoked_delegation(
+        &self,
+        delegation: &Delegation,
+        revoked_at: Timestamp,
+    ) -> Result<()>;
+
+    // --- Governance proofs ---
+
+    /// Load the raw proof bytes for a closed proposal.
+    fn get_proof_bytes(&self, proposal_id: &ProposalId) -> Result<Option<Vec<u8>>>;
+
+    /// Persist raw proof bytes for a proposal.
+    fn save_proof_bytes(&self, proposal_id: &ProposalId, proof: &[u8]) -> Result<()>;
+}
+
+// ---- Key helpers ----
+
+fn domain_key(id: &GovernanceDomainId) -> Vec<u8> {
+    format!("gov:domain:{}", id.0).into_bytes()
+}
+
+fn domain_key_prefix() -> &'static [u8] {
+    b"gov:domain:"
+}
+
+fn proposal_key(id: &ProposalId) -> Vec<u8> {
+    format!("gov:proposal:{}", id.0).into_bytes()
+}
+
+fn proposal_key_prefix() -> &'static [u8] {
+    b"gov:proposal:"
+}
+
+fn vote_key(proposal_id: &ProposalId, voter: &Did) -> Vec<u8> {
+    format!("gov:vote:{}:{}", proposal_id.0, voter).into_bytes()
+}
+
+fn vote_key_prefix(proposal_id: &ProposalId) -> Vec<u8> {
+    format!("gov:vote:{}:", proposal_id.0).into_bytes()
+}
+
+fn delegation_key(id: &DelegationId) -> Vec<u8> {
+    format!("gov:delegation:{}", id.0).into_bytes()
+}
+
+fn delegation_key_prefix() -> &'static [u8] {
+    b"gov:delegation:"
+}
+
+fn proof_key(proposal_id: &ProposalId) -> Vec<u8> {
+    format!("governance:proof:{}", proposal_id.0).into_bytes()
+}
+
+// ---- Utility ----
+
+pub(crate) fn load_json<T: for<'a> serde::Deserialize<'a>>(
+    store: &dyn Store,
+    key: &[u8],
+) -> Result<Option<T>> {
+    match store.get(key)? {
+        Some(v) => Ok(Some(serde_json::from_slice::<T>(&v)?)),
+        None => Ok(None),
+    }
+}
+
+// ---- SledGovernanceStateStore ----
+
+/// `icn_store::Store`-backed implementation of [`GovernanceStateStore`].
+///
+/// All key encoding is centralised here; the actor never constructs raw keys.
+pub struct SledGovernanceStateStore {
+    store: Arc<dyn Store>,
+}
+
+impl SledGovernanceStateStore {
+    /// Wrap an existing `Arc<dyn Store>`.
+    pub fn new(store: Arc<dyn Store>) -> Self {
+        Self { store }
+    }
+
+    /// Expose the inner store for callers that still need raw KV access
+    /// (e.g. `handle_incoming` which operates on a `&dyn Store`).
+    pub fn as_store(&self) -> &dyn Store {
+        self.store.as_ref()
+    }
+}
+
+impl GovernanceStateStore for SledGovernanceStateStore {
+    // --- Domains ---
+
+    fn get_domain(&self, id: &GovernanceDomainId) -> Result<Option<GovernanceDomain>> {
+        load_json(self.store.as_ref(), &domain_key(id))
+    }
+
+    fn save_domain(&self, domain: &GovernanceDomain) -> Result<()> {
+        let id = GovernanceDomainId(domain.id.0.clone());
+        self.store
+            .put(&domain_key(&id), &serde_json::to_vec(domain)?)
+    }
+
+    fn list_domains(&self) -> Result<Vec<GovernanceDomain>> {
+        let rows = self.store.scan(domain_key_prefix())?;
+        rows.into_iter()
+            .map(|(_k, v)| Ok(serde_json::from_slice::<GovernanceDomain>(&v)?))
+            .collect()
+    }
+
+    // --- Proposals ---
+
+    fn get_proposal(&self, id: &ProposalId) -> Result<Option<Proposal>> {
+        load_json(self.store.as_ref(), &proposal_key(id))
+    }
+
+    fn save_proposal(&self, proposal: &Proposal) -> Result<()> {
+        self.store
+            .put(&proposal_key(&proposal.id), &serde_json::to_vec(proposal)?)
+    }
+
+    fn list_proposals(&self) -> Result<Vec<Proposal>> {
+        let rows = self.store.scan(proposal_key_prefix())?;
+        rows.into_iter()
+            .map(|(_k, v)| Ok(serde_json::from_slice::<Proposal>(&v)?))
+            .collect()
+    }
+
+    // --- Votes ---
+
+    fn get_vote(&self, proposal_id: &ProposalId, voter: &Did) -> Result<Option<Vote>> {
+        load_json(self.store.as_ref(), &vote_key(proposal_id, voter))
+    }
+
+    fn save_vote(&self, proposal_id: &ProposalId, vote: &Vote) -> Result<()> {
+        self.store.put(
+            &vote_key(proposal_id, &vote.voter),
+            &serde_json::to_vec(vote)?,
+        )
+    }
+
+    fn list_votes(&self, proposal_id: &ProposalId) -> Result<Vec<Vote>> {
+        let prefix = vote_key_prefix(proposal_id);
+        let rows = self.store.scan(&prefix)?;
+        rows.into_iter()
+            .map(|(_k, v)| Ok(serde_json::from_slice::<Vote>(&v)?))
+            .collect()
+    }
+
+    // --- Delegations ---
+
+    fn get_delegation(&self, id: &DelegationId) -> Result<Option<Delegation>> {
+        load_json(self.store.as_ref(), &delegation_key(id))
+    }
+
+    fn save_delegation(&self, delegation: &Delegation) -> Result<()> {
+        self.store.put(
+            &delegation_key(&delegation.id),
+            &serde_json::to_vec(delegation)?,
+        )
+    }
+
+    fn list_all_delegations(&self) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
+        self.store.scan(delegation_key_prefix())
+    }
+
+    fn save_revoked_delegation(
+        &self,
+        delegation: &Delegation,
+        revoked_at: Timestamp,
+    ) -> Result<()> {
+        let mut d = delegation.clone();
+        d.revoked_at = Some(revoked_at);
+        self.store
+            .put(&delegation_key(&d.id), &serde_json::to_vec(&d)?)
+    }
+
+    // --- Proofs ---
+
+    fn get_proof_bytes(&self, proposal_id: &ProposalId) -> Result<Option<Vec<u8>>> {
+        self.store.get(&proof_key(proposal_id))
+    }
+
+    fn save_proof_bytes(&self, proposal_id: &ProposalId, proof: &[u8]) -> Result<()> {
+        self.store.put(&proof_key(proposal_id), proof)
+    }
+}

--- a/icn/apps/governance/src/state_store.rs
+++ b/icn/apps/governance/src/state_store.rs
@@ -66,11 +66,8 @@ pub trait GovernanceStateStore: Send + Sync {
     fn list_all_delegations(&self) -> Result<Vec<(Vec<u8>, Vec<u8>)>>;
 
     /// Persist a delegation with an updated `revoked_at` field.
-    fn save_revoked_delegation(
-        &self,
-        delegation: &Delegation,
-        revoked_at: Timestamp,
-    ) -> Result<()>;
+    fn save_revoked_delegation(&self, delegation: &Delegation, revoked_at: Timestamp)
+        -> Result<()>;
 
     // --- Governance proofs ---
 


### PR DESCRIPTION
## What

Sprint 12 T5 / Phase 3 state generalization kickoff (Issue #858).

Introduces a `GovernanceStateStore` trait that decouples the governance actor from raw `icn_store::Store` byte operations. The actor now works in domain terms; the store handles key encoding and serialization.

## Changes

### New: `apps/governance/src/state_store.rs` (252 lines)

Defines `GovernanceStateStore` trait with typed methods:
- **Domains**: `get_domain`, `save_domain`, `list_domains`
- **Proposals**: `get_proposal`, `save_proposal`, `list_proposals`
- **Votes**: `get_vote`, `save_vote`, `list_votes`
- **Delegations**: `get_delegation`, `save_delegation`, `list_all_delegations`, `save_revoked_delegation`
- **Proofs**: `get_proof_bytes`, `save_proof_bytes`

`SledGovernanceStateStore` provides the `icn_store::Store`-backed implementation. All key encoding functions (`domain_key`, `proposal_key`, `vote_key`, etc.) and the `load_json` helper moved here from `actor.rs`.

### Modified: `apps/governance/src/actor.rs`

- `store` field: `Arc<dyn Store>` → `Arc<dyn GovernanceStateStore>`
- `spawn()` still accepts `Arc<dyn icn_store::Store>` — wraps in `SledGovernanceStateStore` at construction (no caller changes)
- All 13 raw `put/get/scan` call sites replaced with trait methods
- `handle_incoming()` parameter updated to `&dyn GovernanceStateStore`
- Key encoding functions and local `load_json` removed

### Modified: `apps/governance/src/lib.rs`

- `pub mod state_store;` added
- `GovernanceStateStore` and `SledGovernanceStateStore` re-exported

## Why this matters

Phase 3 goal: domain state handlers live in app crates, not scattered as raw KV ops. After this PR the governance state abstraction boundary exists — future work (in-memory mock for tests, future storage backends) can implement the trait without touching the actor.

## Verify

```
cargo check -p icn-governance-actor   # clean
cargo test -p icn-governance-actor --lib  # 22 passed
```

Meaning firewall: no new kernel→domain imports introduced.

Closes #858