### PR TITLE
refactor(ledger): extract escrow and budget stores into apps/ledger

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -2956,6 +2956,7 @@ dependencies = [
  "icn-identity",
  "icn-kernel-api",
  "icn-ledger",
+ "icn-ledger-actor",
  "icn-membership-app",
  "icn-naming",
  "icn-net",
@@ -3333,6 +3334,17 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "icn-ledger-actor"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "icn-kernel-api",
+ "icn-store",
+ "serde_json",
+ "sled",
 ]
 
 [[package]]

--- a/icn/Cargo.toml
+++ b/icn/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "crates/icn-naming",
     "apps/governance",
     "apps/membership",
+    "apps/ledger",
 ]
 
 [workspace.package]

--- a/icn/apps/ledger/Cargo.toml
+++ b/icn/apps/ledger/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "icn-ledger-actor"
+version = "0.1.0"
+edition = "2021"
+description = "ICN Ledger App — escrow and budget stores for the cooperative ledger"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+# Kernel API for EscrowStore and BudgetStore traits
+icn-kernel-api = { path = "../../crates/icn-kernel-api" }
+
+# Storage trait and Sled implementation
+icn-store = { path = "../../crates/icn-store" }
+
+# Direct sled access for budget tree
+sled.workspace = true
+
+# Serialization
+serde_json.workspace = true
+
+# Error handling
+anyhow.workspace = true
+
+[lints]
+workspace = true

--- a/icn/apps/ledger/src/budget.rs
+++ b/icn/apps/ledger/src/budget.rs
@@ -73,6 +73,7 @@ impl BudgetStore for SledBudgetStore {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use icn_kernel_api::budget::BudgetStatus;

--- a/icn/apps/ledger/src/escrow.rs
+++ b/icn/apps/ledger/src/escrow.rs
@@ -70,6 +70,7 @@ impl<S: icn_store::Store> EscrowStore for SledEscrowStore<S> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use icn_kernel_api::escrow::EscrowStatus;

--- a/icn/apps/ledger/src/init.rs
+++ b/icn/apps/ledger/src/init.rs
@@ -1,0 +1,43 @@
+//! Initialization helper for ledger stores.
+//!
+//! Mirrors `apps/governance/src/init.rs` — the caller provides a store path
+//! and receives ready-to-use `Arc<dyn EscrowStore>` and `Arc<dyn BudgetStore>`.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Result;
+use icn_kernel_api::budget::BudgetStore;
+use icn_kernel_api::escrow::EscrowStore;
+use icn_store::SledStore;
+
+use crate::budget::SledBudgetStore;
+use crate::escrow::SledEscrowStore;
+
+/// Stores returned from ledger initialization.
+pub struct LedgerStores {
+    /// Escrow store for domain-level idempotency on escrow releases.
+    pub escrow_store: Arc<dyn EscrowStore>,
+    /// Budget store for budget enforcement.
+    pub budget_store: Arc<dyn BudgetStore>,
+}
+
+/// Create the ledger stores (escrow + budget) rooted at `store_path`.
+///
+/// Opens:
+/// - `<store_path>/escrow/` — Sled KV store via `icn_store::SledStore`
+/// - `<store_path>/budget/` — Sled DB with a named tree
+pub fn create_stores(store_path: &Path) -> Result<LedgerStores> {
+    let escrow_store_path = store_path.join("escrow");
+    let escrow_sled_store: Arc<SledStore> = Arc::new(SledStore::open(&escrow_store_path)?);
+    let escrow_store: Arc<dyn EscrowStore> = Arc::new(SledEscrowStore::new(escrow_sled_store));
+
+    let budget_store_path = store_path.join("budget");
+    let budget_sled_db = sled::open(&budget_store_path)?;
+    let budget_store: Arc<dyn BudgetStore> = Arc::new(SledBudgetStore::new(&budget_sled_db)?);
+
+    Ok(LedgerStores {
+        escrow_store,
+        budget_store,
+    })
+}

--- a/icn/apps/ledger/src/lib.rs
+++ b/icn/apps/ledger/src/lib.rs
@@ -1,0 +1,8 @@
+//! Ledger app — escrow and budget state stores.
+//!
+//! This crate moves domain-specific ledger storage out of the kernel supervisor
+//! and into the app layer, following the same pattern as `apps/governance`.
+
+pub mod budget;
+pub mod escrow;
+pub mod init;

--- a/icn/crates/icn-core/Cargo.toml
+++ b/icn/crates/icn-core/Cargo.toml
@@ -51,6 +51,7 @@ icn-steward.workspace = true
 # App crates for initialization
 icn-trust-app = { path = "../../../apps/trust" }
 icn-governance-actor = { path = "../../apps/governance" }
+icn-ledger-actor = { path = "../../apps/ledger" }
 icn-coop = { path = "../icn-coop" }
 icn-community = { path = "../icn-community" }
 icn-naming.workspace = true

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -646,22 +646,12 @@ async fn spawn_actors_with_identity(
         kernel_executor = kernel_executor.with_membership_service(membership_service);
         info!("✓ Membership service wired to governance executor");
 
-        // Create escrow store for domain-level idempotency
-        let escrow_store_path = config.store_path().join("escrow");
-        let escrow_sled_store: Arc<icn_store::SledStore> =
-            Arc::new(icn_store::SledStore::open(&escrow_store_path)?);
-        let escrow_store: Arc<dyn icn_kernel_api::escrow::EscrowStore> =
-            Arc::new(super::escrow_store::SledEscrowStore::new(escrow_sled_store));
+        // Create escrow and budget stores via the ledger app crate
+        let ledger_stores = icn_ledger_actor::init::create_stores(&config.store_path())?;
+        let escrow_store = ledger_stores.escrow_store;
         kernel_executor = kernel_executor.with_escrow_store(escrow_store.clone());
-        info!("✓ Escrow store wired to governance executor");
-
-        // Create budget store for budget enforcement
-        let budget_store_path = config.store_path().join("budget");
-        let budget_sled_db = sled::open(&budget_store_path)?;
-        let budget_store: Arc<dyn icn_kernel_api::budget::BudgetStore> =
-            Arc::new(super::budget_store::SledBudgetStore::new(&budget_sled_db)?);
-        kernel_executor = kernel_executor.with_budget_store(budget_store);
-        info!("✓ Budget store wired to governance executor");
+        kernel_executor = kernel_executor.with_budget_store(ledger_stores.budget_store);
+        info!("✓ Escrow and budget stores wired to governance executor");
 
         // Create effect dispatcher
         let effect_dispatcher = Arc::new(super::effect_dispatcher::EffectDispatcher::new(

--- a/icn/crates/icn-core/src/supervisor/mod.rs
+++ b/icn/crates/icn-core/src/supervisor/mod.rs
@@ -12,10 +12,8 @@
 pub mod actors;
 pub mod background_tasks;
 pub mod bridge;
-pub mod budget_store;
 pub mod decision_executor;
 pub mod effect_dispatcher;
-pub mod escrow_store;
 pub mod execution_store;
 pub mod governance_executor;
 pub mod init_bootstrap;


### PR DESCRIPTION
## Summary

Phase 3 of kernel/app separation (#858): moves `SledEscrowStore` and `SledBudgetStore` out of `icn-core/src/supervisor/` (kernel layer) and into a new `apps/ledger/` crate (`icn-ledger-actor`).

## Changes

- New crate `apps/ledger/` (`icn-ledger-actor`) with `escrow.rs`, `budget.rs`, `init.rs`, `lib.rs`
- `init::create_stores(store_path)` returns `LedgerStores { escrow_store, budget_store }` — same init pattern as `apps/governance`
- Supervisor `lifecycle.rs` replaces direct `SledEscrowStore`/`SledBudgetStore` construction with `icn_ledger_actor::init::create_stores()`
- `icn-core/src/supervisor/budget_store.rs` and `escrow_store.rs` deleted
- `mod.rs` entries for the deleted modules removed
- Root `Cargo.toml` adds `apps/ledger` workspace member
- `icn-core/Cargo.toml` adds `icn-ledger-actor` dependency

## Motivation

Domain-specific storage logic (escrow sagas, budget enforcement) was living in the kernel supervisor. This extracts it to the app layer, matching the pattern established by `apps/governance` in T5 (#1272). After this PR, the kernel supervisor holds no domain-aware store implementations.

## Testing

- [x] Unit tests added: 8 tests in `icn-ledger-actor` (4 escrow, 4 budget) — all pass
- [x] `cargo test -p icn-core --lib`: 308/308 pass (no regressions)
- [x] `cargo test -p icn-governance-actor --lib`: 22/22 pass
- [x] `cargo test --workspace`: all pass

## Invariants

- [x] No panics introduced in protocol paths
- [x] Determinism preserved
- [x] Canonical encodings unchanged
- [x] Trust gates not weakened
- [x] Kernel/app boundaries respected — kernel supervisor no longer directly constructs domain stores

## Verification

```
cargo fmt --all --check         ✓
cargo clippy --workspace -- -D warnings  ✓
cargo test --workspace          ✓
meaning firewall: gateway stays at 83 (Phase 3 doesn't touch gateway)
```

## Documentation

- [x] N/A — internal refactor, no API surface changes