### PR TITLE
feat(compute): wire CommonsPoolPolicy into submission flow (E7 #1134)

### DIFF
--- a/icn/crates/icn-compute/src/actor/lifecycle.rs
+++ b/icn/crates/icn-compute/src/actor/lifecycle.rs
@@ -1154,17 +1154,15 @@ impl ComputeActor {
         if let Some(ref policy) = self.commons_pool_policy {
             // Standing check: member must meet minimum participation threshold.
             // Uses the same trust score already computed above.
-            policy
-                .check_standing(trust)
-                .inspect_err(|_| {
-                    tracing::warn!(
-                        task_id = %task.id,
-                        submitter = %task.submitter,
-                        trust_score = trust,
-                        required = policy.min_standing,
-                        "Commons task rejected: insufficient member standing"
-                    );
-                })?;
+            policy.check_standing(trust).inspect_err(|_| {
+                tracing::warn!(
+                    task_id = %task.id,
+                    submitter = %task.submitter,
+                    trust_score = trust,
+                    required = policy.min_standing,
+                    "Commons task rejected: insufficient member standing"
+                );
+            })?;
 
             // Credit ceiling check: submitter must have headroom under their ceiling.
             if let Some(ref balance_cb) = self.balance_callback {

--- a/icn/crates/icn-compute/src/actor/lifecycle.rs
+++ b/icn/crates/icn-compute/src/actor/lifecycle.rs
@@ -11,9 +11,10 @@ use super::types::{ComputeEvent, ExecutorInfo, PaymentRequest, ResultConsensus, 
 use super::ComputeActor;
 use crate::error::ComputeError;
 use crate::executor::Executor;
+use crate::policy::CharterPriority;
 use crate::result_quorum::{QuorumStatus, TaskVerification};
 use crate::task::{TaskManager, TaskStatus};
-use crate::types::{ComputeMessage, ComputeResult, ComputeTask, TaskHash};
+use crate::types::{ComputeMessage, ComputeResult, ComputeTask, TaskHash, TaskPriority};
 use crate::{MIN_TRUST_EXECUTE, MIN_TRUST_SUBMIT};
 
 impl ComputeActor {
@@ -1148,6 +1149,39 @@ impl ComputeActor {
             });
         }
 
+        // Commons pool governance checks (E7 - #1134)
+        // Standing and credit ceiling validation gate access to shared compute resources.
+        if let Some(ref policy) = self.commons_pool_policy {
+            // Standing check: member must meet minimum participation threshold.
+            // Uses the same trust score already computed above.
+            policy
+                .check_standing(trust)
+                .inspect_err(|_| {
+                    tracing::warn!(
+                        task_id = %task.id,
+                        submitter = %task.submitter,
+                        trust_score = trust,
+                        required = policy.min_standing,
+                        "Commons task rejected: insufficient member standing"
+                    );
+                })?;
+
+            // Credit ceiling check: submitter must have headroom under their ceiling.
+            if let Some(ref balance_cb) = self.balance_callback {
+                let balance = balance_cb(&task.submitter);
+                policy
+                    .validate_submitter_credit(&task, balance)
+                    .inspect_err(|_| {
+                        tracing::warn!(
+                            task_id = %task.id,
+                            submitter = %task.submitter,
+                            balance = balance,
+                            "Commons task rejected: credit ceiling exceeded"
+                        );
+                    })?;
+            }
+        }
+
         // Check policy compliance (Phase 16E)
         let mut adjusted_task = task.clone();
         if let Some(ref policy_manager) = self.policy_manager {
@@ -1188,6 +1222,23 @@ impl ComputeActor {
                         "Policy check passed with adjustments"
                     );
                 }
+            }
+        }
+
+        // Apply charter-defined priority ordering (E7 - #1134).
+        // Charter priority may cap or reorder priorities relative to member standing.
+        // This runs after `CoopSchedulingPolicy` adjustments so both layers compose.
+        if let Some(ref policy) = self.commons_pool_policy {
+            let original = adjusted_task.priority;
+            adjusted_task.priority = apply_commons_charter_priority(policy, &adjusted_task, trust);
+            if adjusted_task.priority != original {
+                tracing::debug!(
+                    task_id = %task.id,
+                    original_priority = ?original,
+                    charter_priority = ?adjusted_task.priority,
+                    charter_policy = ?policy.priority,
+                    "Charter priority applied"
+                );
             }
         }
 
@@ -1339,6 +1390,50 @@ impl ComputeActor {
             let mut depths = self.scope_queue_depths.lock().await;
             if let Some(count) = depths.get_mut(&scope) {
                 *count = count.saturating_sub(1);
+            }
+        }
+    }
+}
+
+/// Apply charter-defined priority ordering for commons compute (E7 - #1134).
+///
+/// Charter policies express cooperative values as scheduling constraints:
+/// - `Fifo`: Pure arrival order. Equal treatment, minimal overhead.
+/// - `EmergencyFirst`: Critical tasks preempt; cooperative constitution declares emergencies.
+/// - `UbsFirst`: Essential services (health, energy, comms) hold Critical priority;
+///   commercial tasks are capped at Normal to preserve headroom.
+/// - `FairShare`: Member standing gates maximum priority. High contributors get
+///   full priority access; low-standing members are throttled proportionally.
+///
+/// This runs after `CoopSchedulingPolicy` adjustments so both layers compose.
+pub(super) fn apply_commons_charter_priority(
+    policy: &crate::policy::CommonsPoolPolicy,
+    task: &ComputeTask,
+    standing: f64,
+) -> TaskPriority {
+    match policy.priority {
+        // Arrival order: no priority modification.
+        CharterPriority::Fifo => task.priority,
+        // Emergency policy: preserve priority as-is; Critical tasks already sort highest.
+        CharterPriority::EmergencyFirst => task.priority,
+        // UBS-first: UBS infrastructure submits as Critical.
+        // Non-essential commercial work is capped at Normal.
+        CharterPriority::UbsFirst => {
+            if task.priority < TaskPriority::Critical {
+                task.priority.min(TaskPriority::Normal)
+            } else {
+                TaskPriority::Critical
+            }
+        }
+        // Fair share: standing proportionally gates maximum allowed priority.
+        // Ensures high-participation members aren't crowded out by low-standing submitters.
+        CharterPriority::FairShare => {
+            if standing >= 0.7 {
+                task.priority // High standing: full priority access
+            } else if standing >= 0.4 {
+                task.priority.min(TaskPriority::Normal) // Medium: cap at Normal
+            } else {
+                task.priority.min(TaskPriority::Low) // Low standing: cap at Low
             }
         }
     }

--- a/icn/crates/icn-compute/src/actor/mod.rs
+++ b/icn/crates/icn-compute/src/actor/mod.rs
@@ -14,8 +14,8 @@ mod types;
 // Re-export public types
 pub use handle::ComputeHandle;
 pub use types::{
-    ComputeEvent, EventCallback, LocalityCallback, PaymentCallback, PaymentRequest, SendCallback,
-    TrustCallback,
+    BalanceCallback, ComputeEvent, EventCallback, LocalityCallback, PaymentCallback,
+    PaymentRequest, SendCallback, TrustCallback,
 };
 
 // Internal imports from submodules
@@ -107,6 +107,13 @@ pub struct ComputeActor {
     /// Commons resource pool for tracking nodes contributing to the commons (Epic 6 #946).
     /// Advisory scheduling state only — ledger is authoritative economic state.
     commons_pool: Arc<RwLock<crate::commons_pool::CommonsPool>>,
+    /// Commons pool governance policy (E7 - #1134).
+    /// When set, all task submissions are validated against this policy:
+    /// standing checks, credit ceiling enforcement, and charter priority ordering.
+    commons_pool_policy: Option<crate::policy::CommonsPoolPolicy>,
+    /// Callback for querying submitter ledger balances (E7 - #1134).
+    /// Required for credit ceiling enforcement via `CommonsPoolPolicy::validate_submitter_credit`.
+    balance_callback: Option<BalanceCallback>,
     /// WASM registry for execute-by-hash (Issue #1074)
     wasm_registry: Option<Arc<WasmRegistry>>,
     /// Resource refresh configuration
@@ -153,6 +160,8 @@ impl ComputeActor {
             capacity_budget: Arc::new(RwLock::new(crate::scheduler::CapacityBudget::default())),
             demand_adjustment_config: crate::scheduler::DemandAdjustmentConfig::default(),
             commons_pool: Arc::new(RwLock::new(crate::commons_pool::CommonsPool::new())),
+            commons_pool_policy: None,
+            balance_callback: None,
             wasm_registry: None,
             resource_refresh_config: crate::scheduler::ResourceRefreshConfig::default(),
             cached_capacity: Arc::new(Mutex::new(None)),
@@ -173,6 +182,24 @@ impl ComputeActor {
     /// Set policy manager for cooperative scheduling policies
     pub fn set_policy_manager(&mut self, manager: Arc<crate::policy::PolicyManager>) {
         self.policy_manager = Some(manager);
+    }
+
+    /// Set commons pool governance policy (E7 - #1134).
+    ///
+    /// When set, task submissions are validated against this policy:
+    /// - Minimum standing check (`CommonsPoolPolicy::check_standing`)
+    /// - Credit ceiling check (`CommonsPoolPolicy::validate_submitter_credit`, requires balance callback)
+    /// - Charter priority ordering applied to the adjusted task priority
+    pub fn set_commons_pool_policy(&mut self, policy: crate::policy::CommonsPoolPolicy) {
+        self.commons_pool_policy = Some(policy);
+    }
+
+    /// Set balance callback for commons credit ceiling enforcement (E7 - #1134).
+    ///
+    /// The callback receives a submitter DID string and returns their current credit balance.
+    /// Must be set alongside `set_commons_pool_policy` for credit validation to activate.
+    pub fn set_balance_callback(&mut self, cb: BalanceCallback) {
+        self.balance_callback = Some(cb);
     }
 
     /// Set dispute resolution system (Phase 18 Week 4)

--- a/icn/crates/icn-compute/src/actor/tests.rs
+++ b/icn/crates/icn-compute/src/actor/tests.rs
@@ -1,9 +1,11 @@
 use super::consensus::{outcome_to_value, results_match};
+use super::lifecycle::apply_commons_charter_priority;
 use super::*;
+use crate::policy::{CharterPriority, CommonsPoolPolicy};
 use crate::task::TaskStatus;
 use crate::types::{
     ComputeResult, ComputeTask, DeterminismClass, ExecutorCapability, FuelLimit, PrivacyClass,
-    TaskCode,
+    TaskCode, TaskPriority,
 };
 
 fn simple_ccl() -> String {
@@ -1732,4 +1734,176 @@ async fn test_execute_by_hash_authz_before_fetch() {
         !fetch_attempted.load(Ordering::SeqCst),
         "Fetch should NOT be attempted when executor trust is too low"
     );
+}
+
+// ============================================================================
+// E7: Commons Compute Governance Hardening (#1134)
+// ============================================================================
+
+fn commons_policy(
+    min_standing: f64,
+    priority: CharterPriority,
+    credit_ceiling: Option<i64>,
+) -> CommonsPoolPolicy {
+    CommonsPoolPolicy {
+        min_standing,
+        priority,
+        max_concurrent_per_submitter: 5,
+        preemption_enabled: false,
+        credit_ceiling,
+    }
+}
+
+#[tokio::test]
+async fn test_commons_standing_rejected() {
+    // Trust = 0.2, min_standing = 0.3 → rejected
+    let trust_cb: TrustCallback = Arc::new(|_| 0.2);
+    let mut actor = ComputeActor::new("did:icn:executor".into(), trust_cb);
+    actor.set_commons_pool_policy(commons_policy(0.3, CharterPriority::Fifo, None));
+    let handle = actor.spawn();
+
+    let task = make_task("commons-standing-fail", "did:icn:low-standing");
+    let result = handle.submit(task).await;
+
+    assert!(
+        matches!(result, Err(ComputeError::InsufficientTrust { required, actual }) if (required - 0.3).abs() < 0.001 && (actual - 0.2).abs() < 0.001),
+        "Expected InsufficientTrust rejection, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_commons_standing_passes() {
+    // Trust = 0.5, min_standing = 0.3 → allowed
+    let trust_cb: TrustCallback = Arc::new(|_| 0.5);
+    let mut actor = ComputeActor::new("did:icn:executor".into(), trust_cb);
+    actor.set_commons_pool_policy(commons_policy(0.3, CharterPriority::Fifo, None));
+    let handle = actor.spawn();
+
+    let task = make_task("commons-standing-pass", "did:icn:good-standing");
+    let result = handle.submit(task).await;
+
+    assert!(
+        result.is_ok(),
+        "Expected submission to succeed, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_commons_credit_ceiling_rejected() {
+    // Balance 91, ceiling 100, estimated_cost = FuelLimit(10_000) / 1000 = 10.
+    // available = 100 - 91 = 9 < 10 → rejected.
+    let trust_cb: TrustCallback = Arc::new(|_| 0.8);
+    let mut actor = ComputeActor::new("did:icn:executor".into(), trust_cb);
+    actor.set_commons_pool_policy(commons_policy(0.3, CharterPriority::Fifo, Some(100)));
+    // Balance callback: returns 91 (9 credits below ceiling, but task costs 10)
+    let balance_cb: BalanceCallback = Arc::new(|_| 91);
+    actor.set_balance_callback(balance_cb);
+    let handle = actor.spawn();
+
+    let task = make_task("commons-credit-fail", "did:icn:alice");
+    let result = handle.submit(task).await;
+
+    assert!(
+        matches!(result, Err(ComputeError::InsufficientCommonsCredits { .. })),
+        "Expected InsufficientCommonsCredits rejection, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_commons_credit_ceiling_passes() {
+    // Balance 85, ceiling 100, cost 10. available = 15 >= 10 → allowed.
+    let trust_cb: TrustCallback = Arc::new(|_| 0.8);
+    let mut actor = ComputeActor::new("did:icn:executor".into(), trust_cb);
+    actor.set_commons_pool_policy(commons_policy(0.3, CharterPriority::Fifo, Some(100)));
+    let balance_cb: BalanceCallback = Arc::new(|_| 85);
+    actor.set_balance_callback(balance_cb);
+    let handle = actor.spawn();
+
+    let task = make_task("commons-credit-pass", "did:icn:alice");
+    let result = handle.submit(task).await;
+
+    assert!(
+        result.is_ok(),
+        "Expected submission to succeed, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_commons_charter_priority_fair_share_caps_low_standing() {
+    // FairShare policy: standing 0.2 → capped at Low regardless of submitted priority.
+    let policy = commons_policy(0.0, CharterPriority::FairShare, None);
+    let task = ComputeTask {
+        priority: TaskPriority::High,
+        ..make_task("test", "did:icn:member")
+    };
+    let result = apply_commons_charter_priority(&policy, &task, 0.2);
+    assert_eq!(result, TaskPriority::Low);
+}
+
+#[tokio::test]
+async fn test_commons_charter_priority_fair_share_medium_standing() {
+    // FairShare: standing 0.5 → capped at Normal.
+    let policy = commons_policy(0.0, CharterPriority::FairShare, None);
+    let task = ComputeTask {
+        priority: TaskPriority::High,
+        ..make_task("test", "did:icn:member")
+    };
+    let result = apply_commons_charter_priority(&policy, &task, 0.5);
+    assert_eq!(result, TaskPriority::Normal);
+}
+
+#[tokio::test]
+async fn test_commons_charter_priority_fair_share_high_standing() {
+    // FairShare: standing 0.8 → full priority access.
+    let policy = commons_policy(0.0, CharterPriority::FairShare, None);
+    let task = ComputeTask {
+        priority: TaskPriority::High,
+        ..make_task("test", "did:icn:member")
+    };
+    let result = apply_commons_charter_priority(&policy, &task, 0.8);
+    assert_eq!(result, TaskPriority::High);
+}
+
+#[tokio::test]
+async fn test_commons_charter_priority_ubs_first_caps_non_critical() {
+    // UbsFirst: non-critical tasks capped at Normal; Critical UBS tasks preserved.
+    let policy = commons_policy(0.0, CharterPriority::UbsFirst, None);
+
+    let commercial = ComputeTask {
+        priority: TaskPriority::High,
+        ..make_task("commercial", "did:icn:member")
+    };
+    assert_eq!(
+        apply_commons_charter_priority(&policy, &commercial, 0.9),
+        TaskPriority::Normal,
+        "Commercial High → Normal under UbsFirst"
+    );
+
+    let ubs = ComputeTask {
+        priority: TaskPriority::Critical,
+        ..make_task("ubs-infra", "did:icn:member")
+    };
+    assert_eq!(
+        apply_commons_charter_priority(&policy, &ubs, 0.9),
+        TaskPriority::Critical,
+        "UBS Critical stays Critical"
+    );
+}
+
+#[tokio::test]
+async fn test_commons_charter_priority_fifo_no_change() {
+    // Fifo: no priority modification.
+    let policy = commons_policy(0.0, CharterPriority::Fifo, None);
+    for &prio in &[
+        TaskPriority::Low,
+        TaskPriority::Normal,
+        TaskPriority::High,
+        TaskPriority::Critical,
+    ] {
+        let task = ComputeTask {
+            priority: prio,
+            ..make_task("fifo", "did:icn:member")
+        };
+        assert_eq!(apply_commons_charter_priority(&policy, &task, 0.3), prio);
+    }
 }

--- a/icn/crates/icn-compute/src/actor/types.rs
+++ b/icn/crates/icn-compute/src/actor/types.rs
@@ -116,3 +116,9 @@ pub type EventCallback = Arc<dyn Fn(ComputeEvent) + Send + Sync>;
 /// - Blob locality information
 /// - Region information
 pub type LocalityCallback = Arc<dyn Fn(&str) -> crate::scheduler::LocalityContext + Send + Sync>;
+
+/// Callback for querying a submitter's ledger balance (E7 - commons credit ceiling checks).
+///
+/// Takes a submitter DID string and returns their current credit balance as a signed integer.
+/// Negative balances indicate debt. Used by `CommonsPoolPolicy::validate_submitter_credit`.
+pub type BalanceCallback = Arc<dyn Fn(&str) -> i64 + Send + Sync>;


### PR DESCRIPTION
## Summary

Wires `CommonsPoolPolicy` into the compute actor's task submission flow. The policy was fully implemented in `policy.rs` (standing checks, credit ceiling, charter priority, preemption logic) but was never stored on `ComputeActor` or called anywhere.

## Changes

- Add `BalanceCallback` type alias for ledger balance lookup (`actor/types.rs`)
- Add `commons_pool_policy: Option<CommonsPoolPolicy>` and `balance_callback: Option<BalanceCallback>` fields to `ComputeActor`
- Add `set_commons_pool_policy()` and `set_balance_callback()` setters
- Wire standing check and credit ceiling check in `handle_submit` — runs after the trust gate, before `CoopSchedulingPolicy` (so both layers compose)
- Wire `apply_commons_charter_priority()` after policy adjustments to apply charter-defined ordering: `Fifo` (no-op), `EmergencyFirst` (preserve), `UbsFirst` (cap non-Critical at Normal), `FairShare` (standing-proportional caps)
- 8 new tests covering rejection paths and all charter priority variants

## Motivation

Commons compute is shared infrastructure governed by the cooperative's charter. Without this wiring, any member with sufficient trust could submit arbitrarily high-priority tasks or exhaust the commons credit pool — violating the cooperative's mutual accountability commitments. E7 completes the submission-time enforcement chain: trust → standing → credit ceiling → charter priority ordering.

## Testing

- [x] Unit tests: `test_commons_standing_rejected`, `test_commons_standing_passes`
- [x] Unit tests: `test_commons_credit_ceiling_rejected`, `test_commons_credit_ceiling_passes`
- [x] Unit tests: `test_commons_charter_priority_fair_share_caps_low_standing` (standing 0.2 → Low)
- [x] Unit tests: `test_commons_charter_priority_fair_share_medium_standing` (standing 0.5 → Normal)
- [x] Unit tests: `test_commons_charter_priority_fair_share_high_standing` (standing 0.8 → full)
- [x] Unit tests: `test_commons_charter_priority_ubs_first_caps_non_critical`
- [x] Unit tests: `test_commons_charter_priority_fifo_no_change`
- [x] 343/343 existing tests pass

## Invariants

- [x] No panics introduced in protocol paths
- [x] Determinism preserved
- [x] Canonical encodings unchanged
- [x] Trust gates not weakened (commons policy is additive on top of existing trust gate)
- [x] Kernel/app boundaries respected

## Verification

```
cargo check -p icn-compute   ✅
cargo fmt --all --check       ✅
cargo clippy -- -D warnings   ✅
cargo test -p icn-compute --lib  ✅ 343 passed
```

## Documentation

- [x] N/A — implementation of existing E7 spec in `policy.rs` comments