### PR TITLE
chore(deps): bump utoipa v4→v5 to fix Security Audit (RUSTSEC-2024-0370)

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -2928,7 +2928,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "utoipa 5.4.0",
+ "utoipa",
  "uuid",
 ]
 
@@ -3077,7 +3077,7 @@ dependencies = [
  "tokio",
  "tracing",
  "urlencoding",
- "utoipa 5.4.0",
+ "utoipa",
  "uuid",
  "wiremock",
 ]
@@ -3150,7 +3150,7 @@ dependencies = [
  "tracing-actix-web",
  "tracing-subscriber",
  "url",
- "utoipa 5.4.0",
+ "utoipa",
  "utoipa-swagger-ui",
  "uuid",
 ]
@@ -3241,7 +3241,7 @@ dependencies = [
  "sled",
  "tokio",
  "tracing",
- "utoipa 4.2.3",
+ "utoipa",
  "uuid",
 ]
 
@@ -3302,7 +3302,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tss-esapi",
- "utoipa 5.4.0",
+ "utoipa",
  "x25519-dalek",
  "zeroize",
 ]
@@ -3389,7 +3389,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "utoipa 5.4.0",
+ "utoipa",
  "uuid",
 ]
 
@@ -3421,7 +3421,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "utoipa 5.4.0",
+ "utoipa",
  "uuid",
 ]
 
@@ -3765,7 +3765,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "utoipa 5.4.0",
+ "utoipa",
  "winter-air",
  "winter-math",
  "winter-utils",
@@ -3813,7 +3813,7 @@ dependencies = [
  "tokio",
  "toml 0.9.11+spec-1.1.0",
  "tracing",
- "utoipa 5.4.0",
+ "utoipa",
  "uuid",
  "walkdir",
  "x25519-dalek",
@@ -5405,30 +5405,6 @@ name = "pqcrypto-traits"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e851c7654eed9e68d7d27164c454961a616cf8c203d500607ef22c737b51bb"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro-error-attr2"
@@ -7693,18 +7669,6 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "4.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
-dependencies = [
- "indexmap",
- "serde",
- "serde_json",
- "utoipa-gen 4.3.1",
-]
-
-[[package]]
-name = "utoipa"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
@@ -7713,20 +7677,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_norway",
- "utoipa-gen 5.4.0",
-]
-
-[[package]]
-name = "utoipa-gen"
-version = "4.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.111",
+ "utoipa-gen",
 ]
 
 [[package]]
@@ -7755,7 +7706,7 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
- "utoipa 5.4.0",
+ "utoipa",
  "zip",
 ]
 

--- a/icn/apps/governance/Cargo.toml
+++ b/icn/apps/governance/Cargo.toml
@@ -42,7 +42,7 @@ icn-http-kit = { path = "../../crates/icn-http-kit" }
 
 # HTTP framework (for governance HTTP handlers)
 actix-web = "4"
-utoipa = { version = "4", features = ["actix_extras"] }
+utoipa = { version = "5", features = ["actix_extras"] }
 
 # Persistent storage for action items
 sled = "0.34"


### PR DESCRIPTION
## Summary
- `utoipa-gen v4` pulls in `proc-macro-error v1` which is unmaintained ([RUSTSEC-2024-0370](https://rustsec.org/advisories/RUSTSEC-2024-0370))
- `utoipa v5` uses `proc-macro-error2` instead — advisory gone
- Only `#[derive(ToSchema)]` is used in the governance actor; no API changes required
- `cargo audit` now exits clean (4 pre-existing allowed warnings, no errors)

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo audit` — 0 errors, 4 allowed warnings
- [ ] CI Security Audit job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)