### PR TITLE
feat(governance): CCL governance safety spec — Phase A

### DIFF
--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -187,7 +187,9 @@ pub fn translate_payload_to_effects(
                     capabilities_hash: String::new(),
                 })]
             }
-            icn_governance::sdis::SdisProposal::RemoveSteward { steward, reason, .. } => {
+            icn_governance::sdis::SdisProposal::RemoveSteward {
+                steward, reason, ..
+            } => {
                 vec![KernelEffect::Sdis(SdisEffect::RevokeSteward {
                     steward_did: steward.to_string(),
                     reason: reason.clone(),

--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -447,14 +447,13 @@ mod tests {
 
     #[test]
     fn test_translate_unhandled_payload_to_noop() {
-        let payload = icn_governance::ProposalPayload::DisputeResolution {
-            dispute_entry_hash: "hash-001".to_string(),
-            filer: "did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9"
+        let payload = icn_governance::ProposalPayload::ShareRedemption {
+            member: "did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9"
                 .parse()
                 .expect("valid did"),
-            reason: "insufficient evidence".to_string(),
-            escalation_reason: "requires community vote".to_string(),
-            proposed_outcome: icn_governance::DisputeResolutionOutcome::Reject,
+            share_ids: vec![],
+            payout_schedule: vec![],
+            reason: "voluntary departure".to_string(),
         };
         let effects = translate_payload_to_effects(&payload, "receipt-abc", "decision-hash-abc");
         assert_eq!(effects.len(), 1);

--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -4,7 +4,8 @@
 
 use icn_governance::ProposalPayload;
 use icn_kernel_api::effects::{
-    ControlEffect, FederationEffect, KernelEffect, MembershipEffect, ProtocolEffect, TreasuryEffect,
+    ControlEffect, DisputeEffect, FederationEffect, KernelEffect, MembershipEffect, ProtocolEffect,
+    ResourceEffect, SdisEffect, TreasuryEffect,
 };
 
 /// Translate a governance proposal payload to kernel-safe effects.
@@ -46,6 +47,20 @@ pub fn translate_payload_to_effects(
             decision_receipt_id: decision_receipt_id.to_string(),
             decision_hash: decision_hash.to_string(),
         })],
+
+        ProposalPayload::SurplusAllocation { allocation } => {
+            let distributions = allocation
+                .allocations
+                .iter()
+                .map(|(share_id, amount)| (share_id.0.clone(), *amount))
+                .collect();
+            vec![KernelEffect::Treasury(TreasuryEffect::DistributeSurplus {
+                treasury_did: String::new(),
+                total_amount: allocation.total_surplus,
+                currency: allocation.currency.clone(),
+                distributions,
+            })]
+        }
 
         // Membership proposals
         ProposalPayload::Membership { action, member } => {
@@ -100,6 +115,15 @@ pub fn translate_payload_to_effects(
             })]
         }
 
+        ProposalPayload::ProtocolChange { proposal } => {
+            vec![KernelEffect::Protocol(ProtocolEffect::SetParameter {
+                parameter_name: proposal.parameter_id.clone(),
+                old_value_hash: String::new(), // Not carried by proposal payload
+                new_value_json: proposal.new_value.to_string(),
+                effective_at: proposal.effective_at.unwrap_or(0),
+            })]
+        }
+
         // Control proposals
         ProposalPayload::VetoProposal {
             target_proposal_id,
@@ -124,8 +148,85 @@ pub fn translate_payload_to_effects(
             })]
         }
 
+        // Dispute proposals
+        ProposalPayload::RollbackLedger {
+            target_hash,
+            reason,
+            affected_accounts: _,
+        } => vec![KernelEffect::Dispute(DisputeEffect::RollbackLedger {
+            entry_ids: vec![target_hash.clone()],
+            rollback_reason: reason.clone(),
+            authorized_by: decision_receipt_id.to_string(),
+        })],
+
+        ProposalPayload::DisputeResolution {
+            dispute_entry_hash,
+            reason,
+            proposed_outcome,
+            ..
+        } => {
+            let compensations = match proposed_outcome {
+                icn_governance::DisputeResolutionOutcome::Partial {
+                    adjustment,
+                    currency,
+                } => vec![(String::new(), *adjustment, currency.clone())],
+                _ => vec![],
+            };
+            vec![KernelEffect::Dispute(DisputeEffect::ResolveDispute {
+                dispute_id: dispute_entry_hash.clone(),
+                resolution_hash: blake3::hash(reason.as_bytes()).to_hex().to_string(),
+                compensations,
+            })]
+        }
+
+        // SDIS proposals
+        ProposalPayload::Sdis { proposal } => match proposal {
+            icn_governance::sdis::SdisProposal::AppointSteward { candidate, .. } => {
+                vec![KernelEffect::Sdis(SdisEffect::ApproveSteward {
+                    steward_did: candidate.to_string(),
+                    capabilities_hash: String::new(),
+                })]
+            }
+            icn_governance::sdis::SdisProposal::RemoveSteward { steward, reason, .. } => {
+                vec![KernelEffect::Sdis(SdisEffect::RevokeSteward {
+                    steward_did: steward.to_string(),
+                    reason: reason.clone(),
+                })]
+            }
+            _ => vec![KernelEffect::NoOp {
+                reason: format!(
+                    "SDIS proposal type not yet translated: {:?}",
+                    std::mem::discriminant(proposal)
+                ),
+            }],
+        },
+
         // Federation proposals
         ProposalPayload::Federation(fed_proposal) => translate_federation_proposal(fed_proposal),
+
+        // Resource access proposals
+        ProposalPayload::ResourceAccess {
+            action,
+            resource_id,
+            holder,
+            reason: _,
+        } => match action {
+            icn_governance::ResourceAccessAction::Grant { model } => {
+                vec![KernelEffect::Resource(ResourceEffect::GrantAccess {
+                    grantee_did: holder.to_string(),
+                    resource_type: resource_id.clone(),
+                    access_model_hash: blake3::hash(format!("{model:?}").as_bytes())
+                        .to_hex()
+                        .to_string(),
+                })]
+            }
+            icn_governance::ResourceAccessAction::Revoke => {
+                vec![KernelEffect::Resource(ResourceEffect::RevokeAccess {
+                    grantee_did: holder.to_string(),
+                    resource_type: resource_id.clone(),
+                })]
+            }
+        },
 
         // Fallback for unhandled types
         _ => vec![KernelEffect::NoOp {
@@ -153,14 +254,14 @@ fn translate_treasury_operation(
             currency,
             purpose,
             nonce,
-            ..
+            budget_id,
         } => vec![KernelEffect::Treasury(TreasuryEffect::Spend {
             treasury_did: treasury_did.to_string(),
             recipient_did: recipient.to_string(),
             amount: *amount,
             currency: currency.clone(),
             memo: purpose.clone(),
-            budget_id: None, // TODO: wire budget_id from proposal payload
+            budget_id: budget_id.clone(),
             expected_nonce: *nonce,
             decision_receipt_id: decision_receipt_id.to_string(),
             decision_hash: decision_hash.to_string(),
@@ -270,6 +371,15 @@ fn translate_federation_proposal(
                     agreement_hash: String::new(),
                 },
             )]
+        }
+        FederationProposal::VouchForCooperative {
+            target_coop_did, ..
+        } => {
+            vec![KernelEffect::Federation(FederationEffect::VouchForCoop {
+                voucher_did: String::new(),
+                vouchee_did: target_coop_did.to_string(),
+                attestation_hash: String::new(),
+            })]
         }
         // Fallback for other federation proposals
         _ => vec![KernelEffect::NoOp {

--- a/icn/crates/icn-core/Cargo.toml
+++ b/icn/crates/icn-core/Cargo.toml
@@ -73,7 +73,7 @@ tokio = { version = "1.49", features = ["test-util"] }
 
 [features]
 default = []
-wasm = ["icn-compute/wasm"]
+wasm = ["icn-compute/wasm", "icn-gateway/wasm"]
 
 [lints]
 workspace = true

--- a/icn/crates/icn-core/src/supervisor/effect_dispatcher.rs
+++ b/icn/crates/icn-core/src/supervisor/effect_dispatcher.rs
@@ -147,6 +147,9 @@ fn effect_type_label(effect: &KernelEffect) -> &'static str {
         KernelEffect::Membership(_) => "membership",
         KernelEffect::Control(_) => "control",
         KernelEffect::Federation(_) => "federation",
+        KernelEffect::Dispute(_) => "dispute",
+        KernelEffect::Resource(_) => "resource",
+        KernelEffect::Sdis(_) => "sdis",
         KernelEffect::NoOp { .. } => "noop",
     }
 }

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -593,49 +593,55 @@ impl EffectExecutor for KernelGovernanceExecutor {
             }
             KernelEffect::Membership(membership_effect) => {
                 // Execute membership effect (add, remove, update, freeze, unfreeze)
-                                    let outcome = self
-                                    .membership
-                                    .execute_membership_operation(&receipt_id, membership_effect)
-                                    .await?;
-                                Ok(execution_outcome_to_effect_result(
-                                    outcome,
-                                    decision_receipt_id,
-                                ))
-                            }
-                            KernelEffect::Dispute(dispute_effect) => {
-                                info!(?dispute_effect, "Executing dispute effect (placeholder)");
-                                Ok(EffectResult {
-                                    effect_id: decision_receipt_id.to_string(),
-                                    success: true,
-                                    message: format!("Dispute effect executed (placeholder): {:?}", dispute_effect),
-                                    state_change_hash: None,
-                                    ledger_entry_id: None,
-                                })
-                            }
-                            KernelEffect::Resource(resource_effect) => {
-                                info!(?resource_effect, "Executing resource effect (placeholder)");
-                                Ok(EffectResult {
-                                    effect_id: decision_receipt_id.to_string(),
-                                    success: true,
-                                    message: format!("Resource effect executed (placeholder): {:?}", resource_effect),
-                                    state_change_hash: None,
-                                    ledger_entry_id: None,
-                                })
-                            }
-                            KernelEffect::Sdis(sdis_effect) => {
-                                info!(?sdis_effect, "Executing SDIS effect (placeholder)");
-                                Ok(EffectResult {
-                                    effect_id: decision_receipt_id.to_string(),
-                                    success: true,
-                                    message: format!("SDIS effect executed (placeholder): {:?}", sdis_effect),
-                                    state_change_hash: None,
-                                    ledger_entry_id: None,
-                                })
-                            }
-                        }
-                    }
-                }
-                /// Treasury executor implementation.
+                let outcome = self
+                    .membership
+                    .execute_membership_operation(&receipt_id, membership_effect)
+                    .await?;
+                Ok(execution_outcome_to_effect_result(
+                    outcome,
+                    decision_receipt_id,
+                ))
+            }
+            KernelEffect::Dispute(dispute_effect) => {
+                info!(?dispute_effect, "Executing dispute effect (placeholder)");
+                Ok(EffectResult {
+                    effect_id: decision_receipt_id.to_string(),
+                    success: true,
+                    message: format!(
+                        "Dispute effect executed (placeholder): {:?}",
+                        dispute_effect
+                    ),
+                    state_change_hash: None,
+                    ledger_entry_id: None,
+                })
+            }
+            KernelEffect::Resource(resource_effect) => {
+                info!(?resource_effect, "Executing resource effect (placeholder)");
+                Ok(EffectResult {
+                    effect_id: decision_receipt_id.to_string(),
+                    success: true,
+                    message: format!(
+                        "Resource effect executed (placeholder): {:?}",
+                        resource_effect
+                    ),
+                    state_change_hash: None,
+                    ledger_entry_id: None,
+                })
+            }
+            KernelEffect::Sdis(sdis_effect) => {
+                info!(?sdis_effect, "Executing SDIS effect (placeholder)");
+                Ok(EffectResult {
+                    effect_id: decision_receipt_id.to_string(),
+                    success: true,
+                    message: format!("SDIS effect executed (placeholder): {:?}", sdis_effect),
+                    state_change_hash: None,
+                    ledger_entry_id: None,
+                })
+            }
+        }
+    }
+}
+/// Treasury executor implementation.
 ///
 /// Executes treasury operations (spend, allocate, reserve, release) by
 /// delegating to the kernel's ledger services.

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -593,20 +593,49 @@ impl EffectExecutor for KernelGovernanceExecutor {
             }
             KernelEffect::Membership(membership_effect) => {
                 // Execute membership effect (add, remove, update, freeze, unfreeze)
-                let outcome = self
-                    .membership
-                    .execute_membership_operation(&receipt_id, membership_effect)
-                    .await?;
-                Ok(execution_outcome_to_effect_result(
-                    outcome,
-                    decision_receipt_id,
-                ))
-            }
-        }
-    }
-}
-
-/// Treasury executor implementation.
+                                    let outcome = self
+                                    .membership
+                                    .execute_membership_operation(&receipt_id, membership_effect)
+                                    .await?;
+                                Ok(execution_outcome_to_effect_result(
+                                    outcome,
+                                    decision_receipt_id,
+                                ))
+                            }
+                            KernelEffect::Dispute(dispute_effect) => {
+                                info!(?dispute_effect, "Executing dispute effect (placeholder)");
+                                Ok(EffectResult {
+                                    effect_id: decision_receipt_id.to_string(),
+                                    success: true,
+                                    message: format!("Dispute effect executed (placeholder): {:?}", dispute_effect),
+                                    state_change_hash: None,
+                                    ledger_entry_id: None,
+                                })
+                            }
+                            KernelEffect::Resource(resource_effect) => {
+                                info!(?resource_effect, "Executing resource effect (placeholder)");
+                                Ok(EffectResult {
+                                    effect_id: decision_receipt_id.to_string(),
+                                    success: true,
+                                    message: format!("Resource effect executed (placeholder): {:?}", resource_effect),
+                                    state_change_hash: None,
+                                    ledger_entry_id: None,
+                                })
+                            }
+                            KernelEffect::Sdis(sdis_effect) => {
+                                info!(?sdis_effect, "Executing SDIS effect (placeholder)");
+                                Ok(EffectResult {
+                                    effect_id: decision_receipt_id.to_string(),
+                                    success: true,
+                                    message: format!("SDIS effect executed (placeholder): {:?}", sdis_effect),
+                                    state_change_hash: None,
+                                    ledger_entry_id: None,
+                                })
+                            }
+                        }
+                    }
+                }
+                /// Treasury executor implementation.
 ///
 /// Executes treasury operations (spend, allocate, reserve, release) by
 /// delegating to the kernel's ledger services.

--- a/icn/crates/icn-gateway/Cargo.toml
+++ b/icn/crates/icn-gateway/Cargo.toml
@@ -9,6 +9,8 @@ repository.workspace = true
 default = []
 # Enable sled storage backend tests
 sled-storage = []
+# Enable WASM compute support
+wasm = ["icn-compute/wasm"]
 
 
 [dependencies]

--- a/icn/crates/icn-gateway/src/api/constitutional/voting.rs
+++ b/icn/crates/icn-gateway/src/api/constitutional/voting.rs
@@ -157,7 +157,7 @@ fn ratification_to_vote(r: &Ratification) -> VoteResponse {
 
 fn format_status(status: &AmendmentStatus) -> String {
     match status {
-        AmendmentStatus::Draft => "draft".to_string(),
+        AmendmentStatus::Draft | AmendmentStatus::DraftWithArtifacts { .. } => "draft".to_string(),
         AmendmentStatus::Submitted { .. } => "submitted".to_string(),
         AmendmentStatus::UnderReview { .. } => "under_review".to_string(),
         AmendmentStatus::Voting { .. } => "voting".to_string(),

--- a/icn/crates/icn-gateway/src/compute_mgr.rs
+++ b/icn/crates/icn-gateway/src/compute_mgr.rs
@@ -38,6 +38,25 @@ impl ComputeManager {
         }
     }
 
+    /// Create a compute manager with daemon connection and WASM registry
+    pub fn with_service_and_registry(
+        service: Arc<icn_api::ComputeService>,
+        registry: Arc<icn_compute::WasmRegistry>,
+    ) -> Self {
+        ComputeManager {
+            compute_service: Some(service),
+            wasm_registry: Some(registry),
+        }
+    }
+
+    /// Create a compute manager with only a WASM registry (standalone mode)
+    pub fn with_registry(registry: Arc<icn_compute::WasmRegistry>) -> Self {
+        ComputeManager {
+            compute_service: None,
+            wasm_registry: Some(registry),
+        }
+    }
+
     /// Set compute service (for late binding)
     pub fn set_service(&mut self, service: Arc<icn_api::ComputeService>) {
         self.compute_service = Some(service);

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -113,6 +113,8 @@ pub struct GatewayServer {
     service_discovery_manager: Option<Arc<crate::service_discovery_mgr::ServiceDiscoveryManager>>,
     /// Optional naming service for `/v1/names/*` resolution.
     naming_service_handle: Option<Arc<dyn NamingService>>,
+    /// Optional WASM registry for module management.
+    wasm_registry_handle: Option<Arc<icn_compute::WasmRegistry>>,
     /// Audit pruning configuration
     audit_prune_config: Option<AuditPruneConfig>,
     /// Default trust score for unknown peers (overrides DEFAULT_TRUST_SCORE)
@@ -144,6 +146,7 @@ impl GatewayServer {
             agreement_manager_handle: None,
             service_discovery_manager: None,
             naming_service_handle: None,
+            wasm_registry_handle: None,
             audit_prune_config: None,
             default_trust_score: None,
         }
@@ -185,6 +188,7 @@ impl GatewayServer {
             agreement_manager_handle: None,
             service_discovery_manager: None,
             naming_service_handle: None,
+            wasm_registry_handle: None,
             audit_prune_config: None,
             default_trust_score: None,
         }
@@ -227,6 +231,7 @@ impl GatewayServer {
             agreement_manager_handle: None,
             service_discovery_manager: None,
             naming_service_handle: None,
+            wasm_registry_handle: None,
             audit_prune_config: None,
             default_trust_score: None,
         }
@@ -386,6 +391,14 @@ impl GatewayServer {
         self
     }
 
+    /// Set WASM registry for module management.
+    ///
+    /// When set, distributed compute can reference WASM modules by hash.
+    pub fn with_wasm_registry(mut self, registry: Arc<icn_compute::WasmRegistry>) -> Self {
+        self.wasm_registry_handle = Some(registry);
+        self
+    }
+
     /// Set custom rate limiting configuration
     pub fn with_rate_limit_config(mut self, config: RateLimitConfig) -> Self {
         self.rate_limit_config = Some(config);
@@ -518,6 +531,34 @@ impl GatewayServer {
 
         let ledger_handle_for_service = self.ledger_handle.clone();
 
+        // Initialize WASM registry for module management (Flow A)
+        let wasm_registry: Option<Arc<icn_compute::WasmRegistry>> = if let Some(registry) =
+            self.wasm_registry_handle
+        {
+            info!("WASM registry initialized (shared from supervisor)");
+            Some(registry)
+        } else {
+            if let Some(ref data_dir) = self.data_dir {
+                let wasm_path = data_dir.join("store").join("wasm");
+                match sled::open(&wasm_path) {
+                    Ok(db) => {
+                        info!("WASM registry store opened at {:?}", wasm_path);
+                        Some(Arc::new(icn_compute::WasmRegistry::with_store(db)))
+                    }
+                    Err(e) => {
+                        warn!(
+                            error = %e,
+                            "Failed to open WASM registry store; WASM registry will be unavailable"
+                        );
+                        None
+                    }
+                }
+            } else {
+                info!("WASM registry initialized with temporary storage");
+                Some(Arc::new(icn_compute::WasmRegistry::new()))
+            }
+        };
+
         // Create governance manager with Sled-backed action items
         // (uses GovernanceActor if handle available for proposals/votes/domains)
         let governance_manager: Arc<GovernanceManager> =
@@ -562,10 +603,18 @@ impl GatewayServer {
         let compute_manager = if let Some(handle) = self.compute_handle {
             info!("Compute manager connected to daemon");
             let service = Arc::new(icn_api::ComputeService::new(handle));
-            Arc::new(ComputeManager::with_service(service))
+            if let Some(registry) = wasm_registry {
+                Arc::new(ComputeManager::with_service_and_registry(service, registry))
+            } else {
+                Arc::new(ComputeManager::with_service(service))
+            }
         } else {
             info!("Compute manager running standalone (no daemon connection)");
-            Arc::new(ComputeManager::new())
+            if let Some(registry) = wasm_registry {
+                Arc::new(ComputeManager::with_registry(registry))
+            } else {
+                Arc::new(ComputeManager::new())
+            }
         };
 
         // Create contract registry handle for contract management API

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -538,25 +538,31 @@ impl GatewayServer {
             info!("WASM registry initialized (shared from supervisor)");
             Some(registry)
         } else {
-            if let Some(ref data_dir) = self.data_dir {
-                let wasm_path = data_dir.join("store").join("wasm");
-                match sled::open(&wasm_path) {
-                    Ok(db) => {
-                        info!("WASM registry store opened at {:?}", wasm_path);
-                        Some(Arc::new(icn_compute::WasmRegistry::with_store(db)))
+            #[cfg(feature = "wasm")]
+            {
+                if let Some(ref data_dir) = self.data_dir {
+                    let wasm_path = data_dir.join("store").join("wasm");
+                    match sled::open(&wasm_path) {
+                        Ok(db) => {
+                            info!("WASM registry store opened at {:?}", wasm_path);
+                            Some(Arc::new(icn_compute::WasmRegistry::with_store(db)))
+                        }
+                        Err(e) => {
+                            warn!(
+                                error = %e,
+                                "Failed to open WASM registry store at {:?}; falling back to temporary storage",
+                                wasm_path
+                            );
+                            Some(Arc::new(icn_compute::WasmRegistry::new()))
+                        }
                     }
-                    Err(e) => {
-                        warn!(
-                            error = %e,
-                            "Failed to open WASM registry store; WASM registry will be unavailable"
-                        );
-                        None
-                    }
+                } else {
+                    info!("WASM registry initialized with temporary storage");
+                    Some(Arc::new(icn_compute::WasmRegistry::new()))
                 }
-            } else {
-                info!("WASM registry initialized with temporary storage");
-                Some(Arc::new(icn_compute::WasmRegistry::new()))
             }
+            #[cfg(not(feature = "wasm"))]
+            None
         };
 
         // Create governance manager with Sled-backed action items

--- a/icn/crates/icn-governance/src/amendment.rs
+++ b/icn/crates/icn-governance/src/amendment.rs
@@ -115,6 +115,13 @@ impl fmt::Display for AmendmentScope {
 pub enum AmendmentStatus {
     /// Initial draft, not yet submitted
     Draft,
+    /// Draft with computed artifacts (manifest, diff, report).
+    /// Must pass invariant gate to reach this state.
+    DraftWithArtifacts {
+        manifest_hash: [u8; 32],
+        power_diff_hash: Option<[u8; 32]>,
+        report_hash: [u8; 32],
+    },
     /// Submitted for review
     Submitted { submitted_at: Timestamp },
     /// Under review period before voting
@@ -312,6 +319,15 @@ pub struct Amendment {
     pub created_at: Timestamp,
     /// When last updated
     pub updated_at: Timestamp,
+    /// Effect manifest (set when artifacts are attached).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effect_manifest: Option<crate::effect_manifest::EffectManifest>,
+    /// Power diff (set when artifacts are attached).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub power_diff: Option<crate::power_diff::PowerDiff>,
+    /// Invariant report (set when artifacts are attached).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invariant_report: Option<icn_kernel_api::invariants::InvariantReport>,
 }
 
 /// A specific change within an amendment
@@ -403,6 +419,9 @@ impl Amendment {
             supersedes: None,
             created_at: now,
             updated_at: now,
+            effect_manifest: None,
+            power_diff: None,
+            invariant_report: None,
         }
     }
 
@@ -677,6 +696,48 @@ impl Amendment {
 
     fn touch(&mut self) {
         self.updated_at = self.now();
+    }
+
+    /// Attach governance safety artifacts. Transitions Draft -> DraftWithArtifacts.
+    /// Rejects if invariant report has failures.
+    pub fn attach_artifacts(
+        &mut self,
+        manifest: crate::effect_manifest::EffectManifest,
+        power_diff: Option<crate::power_diff::PowerDiff>,
+        report: icn_kernel_api::invariants::InvariantReport,
+    ) -> Result<(), String> {
+        if !matches!(self.status, AmendmentStatus::Draft) {
+            return Err("Can only attach artifacts to Draft amendments".into());
+        }
+        if !report.passed {
+            return Err(format!(
+                "Invariant gate failed: {} violations",
+                report.violations.len()
+            ));
+        }
+
+        self.status = AmendmentStatus::DraftWithArtifacts {
+            manifest_hash: manifest.manifest_hash,
+            power_diff_hash: power_diff.as_ref().map(|pd| pd.diff_hash),
+            report_hash: report.report_hash,
+        };
+        self.effect_manifest = Some(manifest);
+        self.power_diff = power_diff;
+        self.invariant_report = Some(report);
+        self.updated_at = icn_time::current_timestamp_secs();
+        Ok(())
+    }
+
+    /// Submit for review. Only allowed from DraftWithArtifacts.
+    /// This enforces "no manifest, no activation."
+    pub fn submit_for_review(&mut self) -> Result<(), String> {
+        if !matches!(self.status, AmendmentStatus::DraftWithArtifacts { .. }) {
+            return Err("Must attach artifacts before submitting for review".into());
+        }
+        let now = icn_time::current_timestamp_secs();
+        self.status = AmendmentStatus::Submitted { submitted_at: now };
+        self.updated_at = now;
+        Ok(())
     }
 }
 
@@ -1088,5 +1149,129 @@ mod tests {
         });
 
         assert!(result.is_err());
+    }
+}
+
+#[cfg(test)]
+mod interceptor_tests {
+    use super::*;
+    use crate::effect_manifest::EffectManifest;
+    use icn_kernel_api::invariants::InvariantReport;
+
+    #[test]
+    fn test_amendment_attach_artifacts_passes_gate() {
+        let mut amendment = Amendment::new(
+            AmendmentType::Policy,
+            AmendmentScope::Jurisdiction {
+                domain_id: "test".into(),
+            },
+            "Test".into(),
+            "Test amendment".into(),
+            Did::from_anchor_id(&[42u8; 32]),
+        );
+        assert!(matches!(amendment.status, AmendmentStatus::Draft));
+
+        let manifest = EffectManifest::new(
+            [0u8; 32],
+            [0u8; 32],
+            "did:icn:proposer".into(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let report = InvariantReport::new(manifest.manifest_hash, None, vec![]);
+
+        let result = amendment.attach_artifacts(manifest, None, report);
+        assert!(result.is_ok());
+        assert!(matches!(
+            amendment.status,
+            AmendmentStatus::DraftWithArtifacts { .. }
+        ));
+    }
+
+    #[test]
+    fn test_amendment_attach_artifacts_rejects_failed_report() {
+        let mut amendment = Amendment::new(
+            AmendmentType::Policy,
+            AmendmentScope::Jurisdiction {
+                domain_id: "test".into(),
+            },
+            "Test".into(),
+            "Test amendment".into(),
+            Did::from_anchor_id(&[42u8; 32]),
+        );
+        let manifest = EffectManifest::new(
+            [0u8; 32],
+            [0u8; 32],
+            "did:icn:proposer".into(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let violation = icn_kernel_api::invariants::InvariantViolation {
+            id: icn_kernel_api::invariants::InvariantId::BoundedAuthority,
+            domain: icn_kernel_api::invariants::InvariantDomain::AntiCaptureCore,
+            message: "test failure".into(),
+            details: vec![],
+        };
+        let report = InvariantReport::new(manifest.manifest_hash, None, vec![violation]);
+
+        let result = amendment.attach_artifacts(manifest, None, report);
+        assert!(result.is_err());
+        assert!(matches!(amendment.status, AmendmentStatus::Draft));
+    }
+
+    #[test]
+    fn test_submit_requires_artifacts() {
+        let mut amendment = Amendment::new(
+            AmendmentType::Policy,
+            AmendmentScope::Jurisdiction {
+                domain_id: "test".into(),
+            },
+            "Test".into(),
+            "Test amendment".into(),
+            Did::from_anchor_id(&[42u8; 32]),
+        );
+        // Cannot submit directly from Draft -- must go through DraftWithArtifacts
+        let result = amendment.submit_for_review();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_full_artifact_then_submit_lifecycle() {
+        let mut amendment = Amendment::new(
+            AmendmentType::Policy,
+            AmendmentScope::Jurisdiction {
+                domain_id: "test".into(),
+            },
+            "Test".into(),
+            "Test amendment".into(),
+            Did::from_anchor_id(&[42u8; 32]),
+        );
+
+        let manifest = EffectManifest::new(
+            [0u8; 32],
+            [0u8; 32],
+            "did:icn:proposer".into(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let report = InvariantReport::new(manifest.manifest_hash, None, vec![]);
+
+        amendment.attach_artifacts(manifest, None, report).unwrap();
+        assert!(matches!(
+            amendment.status,
+            AmendmentStatus::DraftWithArtifacts { .. }
+        ));
+
+        amendment.submit_for_review().unwrap();
+        assert!(matches!(
+            amendment.status,
+            AmendmentStatus::Submitted { .. }
+        ));
     }
 }

--- a/icn/crates/icn-governance/src/effect_manifest.rs
+++ b/icn/crates/icn-governance/src/effect_manifest.rs
@@ -1,0 +1,346 @@
+//! Effect Manifest — normalized, hashable description of governance actions.
+//!
+//! Every governance mutation (proposal, amendment, parameter change) must
+//! produce an EffectManifest before the system applies it.
+//! The manifest is the input to the Invariant Gate and Power Diff.
+
+use icn_kernel_api::invariants::BlockHeight;
+use icn_kernel_api::Did;
+use serde::{Deserialize, Serialize};
+
+/// A normalized, deterministic description of what a governance action
+/// does to system state. This is the "effect vector" — typed, hashable,
+/// and exhaustive.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EffectManifest {
+    /// Version for deterministic replay.
+    pub manifest_version: u16,
+    /// Hash of the amendment/proposal this was derived from.
+    pub change_hash: [u8; 32],
+    /// Snapshot hash of the state this was diffed against.
+    pub baseline_snapshot_hash: [u8; 32],
+    /// DID of the manifest author.
+    pub author: Did,
+    /// Capability/authorization perimeter changes (if any).
+    pub capability_effects: Vec<CapabilityEffect>,
+    /// Economic policy changes (timelock-relevant).
+    pub economic_effects: Vec<EconomicEffect>,
+    /// Membership / identity-set changes (consent-relevant).
+    pub membership_effects: Vec<MembershipEffect>,
+    /// Protocol / governance parameter changes.
+    pub protocol_effects: Vec<ProtocolEffect>,
+    /// Block height when ratified (set after ratification).
+    pub ratification_block: Option<BlockHeight>,
+    /// Block height when activated (enforced by timelock invariant).
+    pub activation_block: Option<BlockHeight>,
+    /// Deterministic hash of this manifest.
+    pub manifest_hash: [u8; 32],
+}
+
+/// Capability/authorization perimeter change.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum CapabilityEffect {
+    Grant {
+        subject: Did,
+        capability: String,
+        scope: String,
+        resource: String,
+    },
+    Revoke {
+        subject: Did,
+        capability: String,
+        scope: String,
+        resource: String,
+    },
+}
+
+/// Economic policy change.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum EconomicEffect {
+    MutualCreditPolicyChange {
+        entity_id: String,
+        policy_key: String,
+        before_hash: [u8; 32],
+        after_hash: [u8; 32],
+    },
+    BudgetScopeChange {
+        entity_id: String,
+        envelope_id: String,
+        before_hash: [u8; 32],
+        after_hash: [u8; 32],
+    },
+    DemurrageChange {
+        entity_id: String,
+        old_rate_bps: u32,
+        new_rate_bps: u32,
+    },
+    DisputeHookChange {
+        entity_id: String,
+        hook_id: String,
+        before_hash: [u8; 32],
+        after_hash: [u8; 32],
+    },
+    SettlementRuleChange {
+        entity_id: String,
+        rule_id: String,
+        before_hash: [u8; 32],
+        after_hash: [u8; 32],
+    },
+}
+
+/// Membership/identity-set change.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum MembershipEffect {
+    AddToEntity {
+        entity_id: String,
+        identity: Did,
+        role: Option<String>,
+    },
+    RemoveFromEntity {
+        entity_id: String,
+        identity: Did,
+    },
+    AddObligation {
+        entity_id: String,
+        identity: Did,
+        obligation_hash: [u8; 32],
+    },
+}
+
+/// Protocol/governance parameter change.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ProtocolEffect {
+    ParameterChange {
+        param_id: String,
+        old_value: String,
+        new_value: String,
+        scope: String,
+    },
+    TimelockChange {
+        entity_id: String,
+        old_delay_secs: u64,
+        new_delay_secs: u64,
+    },
+    AuthzModelChange {
+        entity_id: String,
+        before_hash: [u8; 32],
+        after_hash: [u8; 32],
+    },
+    GovernanceExecutionChange {
+        entity_id: String,
+        before_hash: [u8; 32],
+        after_hash: [u8; 32],
+    },
+}
+
+impl EffectManifest {
+    /// Compute deterministic hash over manifest content.
+    pub fn compute_hash(
+        manifest_version: u16,
+        change_hash: [u8; 32],
+        baseline_snapshot_hash: [u8; 32],
+        author: &str,
+        capability_effects: &[CapabilityEffect],
+        economic_effects: &[EconomicEffect],
+        membership_effects: &[MembershipEffect],
+        protocol_effects: &[ProtocolEffect],
+        ratification_block: Option<BlockHeight>,
+        activation_block: Option<BlockHeight>,
+    ) -> [u8; 32] {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(&manifest_version.to_le_bytes());
+        hasher.update(&change_hash);
+        hasher.update(&baseline_snapshot_hash);
+        hasher.update(author.as_bytes());
+        // Hash each effect category deterministically via JSON
+        for effects in [
+            &serde_json::to_vec(capability_effects).unwrap_or_default(),
+            &serde_json::to_vec(economic_effects).unwrap_or_default(),
+            &serde_json::to_vec(membership_effects).unwrap_or_default(),
+            &serde_json::to_vec(protocol_effects).unwrap_or_default(),
+        ] {
+            hasher.update(&(effects.len() as u32).to_le_bytes());
+            hasher.update(effects);
+        }
+        if let Some(rb) = ratification_block {
+            hasher.update(&[1u8]);
+            hasher.update(&rb.to_le_bytes());
+        } else {
+            hasher.update(&[0u8]);
+        }
+        if let Some(ab) = activation_block {
+            hasher.update(&[1u8]);
+            hasher.update(&ab.to_le_bytes());
+        } else {
+            hasher.update(&[0u8]);
+        }
+        *hasher.finalize().as_bytes()
+    }
+
+    /// Build a manifest with computed hash.
+    pub fn new(
+        change_hash: [u8; 32],
+        baseline_snapshot_hash: [u8; 32],
+        author: Did,
+        capability_effects: Vec<CapabilityEffect>,
+        economic_effects: Vec<EconomicEffect>,
+        membership_effects: Vec<MembershipEffect>,
+        protocol_effects: Vec<ProtocolEffect>,
+    ) -> Self {
+        let manifest_hash = Self::compute_hash(
+            1,
+            change_hash,
+            baseline_snapshot_hash,
+            &author,
+            &capability_effects,
+            &economic_effects,
+            &membership_effects,
+            &protocol_effects,
+            None,
+            None,
+        );
+        Self {
+            manifest_version: 1,
+            change_hash,
+            baseline_snapshot_hash,
+            author,
+            capability_effects,
+            economic_effects,
+            membership_effects,
+            protocol_effects,
+            ratification_block: None,
+            activation_block: None,
+            manifest_hash,
+        }
+    }
+
+    /// Does this manifest touch the authorization perimeter?
+    pub fn touches_authz(&self) -> bool {
+        !self.capability_effects.is_empty()
+            || self
+                .protocol_effects
+                .iter()
+                .any(|e| matches!(e, ProtocolEffect::AuthzModelChange { .. }))
+    }
+
+    /// Does this manifest touch economic policy?
+    pub fn touches_economics(&self) -> bool {
+        !self.economic_effects.is_empty()
+    }
+
+    /// Is this manifest empty (no effects)?
+    pub fn is_empty(&self) -> bool {
+        self.capability_effects.is_empty()
+            && self.economic_effects.is_empty()
+            && self.membership_effects.is_empty()
+            && self.protocol_effects.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_manifest() {
+        let m = EffectManifest::new(
+            [0u8; 32],
+            [0u8; 32],
+            "did:icn:test".to_string(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+        assert!(m.is_empty());
+        assert!(!m.touches_authz());
+        assert!(!m.touches_economics());
+        assert_ne!(m.manifest_hash, [0u8; 32]);
+    }
+
+    #[test]
+    fn test_manifest_with_capability_effect() {
+        let m = EffectManifest::new(
+            [1u8; 32],
+            [0u8; 32],
+            "did:icn:author".to_string(),
+            vec![CapabilityEffect::Grant {
+                subject: "did:icn:bob".into(),
+                capability: "vote:operational".into(),
+                scope: "coop:sunrise".into(),
+                resource: "governance".into(),
+            }],
+            vec![],
+            vec![],
+            vec![],
+        );
+        assert!(m.touches_authz());
+        assert!(!m.touches_economics());
+    }
+
+    #[test]
+    fn test_manifest_hash_deterministic() {
+        let m1 = EffectManifest::new(
+            [1u8; 32],
+            [2u8; 32],
+            "did:icn:a".to_string(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let m2 = EffectManifest::new(
+            [1u8; 32],
+            [2u8; 32],
+            "did:icn:a".to_string(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+        assert_eq!(m1.manifest_hash, m2.manifest_hash);
+    }
+
+    #[test]
+    fn test_manifest_hash_changes_with_effects() {
+        let m1 = EffectManifest::new(
+            [1u8; 32],
+            [0u8; 32],
+            "did:icn:a".to_string(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let m2 = EffectManifest::new(
+            [1u8; 32],
+            [0u8; 32],
+            "did:icn:a".to_string(),
+            vec![],
+            vec![EconomicEffect::DemurrageChange {
+                entity_id: "coop:x".into(),
+                old_rate_bps: 100,
+                new_rate_bps: 200,
+            }],
+            vec![],
+            vec![],
+        );
+        assert_ne!(m1.manifest_hash, m2.manifest_hash);
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let m = EffectManifest::new(
+            [42u8; 32],
+            [0u8; 32],
+            "did:icn:test".to_string(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let json = serde_json::to_string(&m).unwrap();
+        let parsed: EffectManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.manifest_hash, m.manifest_hash);
+    }
+}

--- a/icn/crates/icn-governance/src/invariant_gate.rs
+++ b/icn/crates/icn-governance/src/invariant_gate.rs
@@ -1,0 +1,551 @@
+//! Invariant Gate — frozen-core predicate enforcement.
+//!
+//! Runs in two contexts with the same interface:
+//! 1. Governance interceptor (Draft → DraftWithArtifacts) — early rejection
+//! 2. Kernel write-path (Ratified → Activated) — final rejection
+//!
+//! Same code. Same hashes. Same deterministic outcome.
+
+use crate::effect_manifest::*;
+use crate::power_diff::PowerDiff;
+use icn_kernel_api::invariants::*;
+
+/// Read-only state view for invariant checking.
+/// Implemented by kernel state store (authoritative) and governance simulator (preview).
+pub trait InvariantStateView: Send + Sync {
+    /// Minimum timelock delay in blocks for an entity.
+    fn current_min_timelock_blocks(&self, entity_id: &str) -> u64;
+}
+
+/// Context passed to each invariant. Deterministic: no wall-clock, no network calls.
+pub struct InvariantContext<'a> {
+    pub current_block: BlockHeight,
+    pub manifest: &'a EffectManifest,
+    pub power_diff: Option<&'a PowerDiff>,
+    pub state: &'a dyn InvariantStateView,
+}
+
+/// Individual invariant predicate.
+pub trait Invariant: Send + Sync {
+    fn id(&self) -> InvariantId;
+    fn validate(&self, ctx: &InvariantContext) -> Result<(), InvariantViolation>;
+}
+
+/// The gate — runs all registered invariants, produces a report.
+pub struct InvariantGate {
+    invariants: Vec<Box<dyn Invariant>>,
+}
+
+impl InvariantGate {
+    pub fn new(invariants: Vec<Box<dyn Invariant>>) -> Self {
+        Self { invariants }
+    }
+
+    /// Build a gate with the default frozen-core invariants (#4, #5, #6).
+    /// More invariants will be added as they are implemented.
+    pub fn default_frozen_core() -> Self {
+        Self::new(vec![
+            Box::new(NoSilentPowerChanges),
+            Box::new(BoundedAuthority),
+            Box::new(MandatoryExecutionDelay),
+        ])
+    }
+
+    /// Run all invariants and produce a deterministic report.
+    pub fn evaluate(&self, ctx: &InvariantContext) -> InvariantReport {
+        let violations: Vec<InvariantViolation> = self
+            .invariants
+            .iter()
+            .filter_map(|inv| inv.validate(ctx).err())
+            .collect();
+        InvariantReport::new(
+            ctx.manifest.manifest_hash,
+            ctx.power_diff.map(|pd| pd.diff_hash),
+            violations,
+        )
+    }
+}
+
+// =============================================================================
+// Invariant #4: No Silent Power Changes
+// =============================================================================
+
+/// Any authz perimeter change must include a PowerDiff with a non-empty
+/// capability delta. If the manifest touches authz but the diff is missing
+/// or empty, reject.
+pub struct NoSilentPowerChanges;
+
+impl Invariant for NoSilentPowerChanges {
+    fn id(&self) -> InvariantId {
+        InvariantId::NoSilentPowerChanges
+    }
+
+    fn validate(&self, ctx: &InvariantContext) -> Result<(), InvariantViolation> {
+        if !ctx.manifest.touches_authz() {
+            return Ok(());
+        }
+
+        let pd = ctx.power_diff.ok_or_else(|| InvariantViolation {
+            id: self.id(),
+            domain: self.id().domain(),
+            message: "Authz perimeter change requires PowerDiff".into(),
+            details: vec![],
+        })?;
+
+        // Require at least one subject delta when authz is touched
+        if pd.subject_deltas.is_empty() {
+            return Err(InvariantViolation {
+                id: self.id(),
+                domain: self.id().domain(),
+                message: "PowerDiff present but has no subject deltas for authz change".into(),
+                details: vec![],
+            });
+        }
+
+        Ok(())
+    }
+}
+
+// =============================================================================
+// Invariant #5: Bounded Authority (No God Mode)
+// =============================================================================
+
+/// Rejects capability assignments with wildcard scope/resource.
+pub struct BoundedAuthority;
+
+impl Invariant for BoundedAuthority {
+    fn id(&self) -> InvariantId {
+        InvariantId::BoundedAuthority
+    }
+
+    fn validate(&self, ctx: &InvariantContext) -> Result<(), InvariantViolation> {
+        for effect in &ctx.manifest.capability_effects {
+            let (scope, resource) = match effect {
+                CapabilityEffect::Grant {
+                    scope, resource, ..
+                } => (scope, resource),
+                CapabilityEffect::Revoke {
+                    scope, resource, ..
+                } => (scope, resource),
+            };
+            if scope == "*" || resource == "*" {
+                return Err(InvariantViolation {
+                    id: self.id(),
+                    domain: self.id().domain(),
+                    message: "Wildcard '*' is not a valid scope/resource".into(),
+                    details: vec![
+                        ("scope".into(), scope.clone()),
+                        ("resource".into(), resource.clone()),
+                    ],
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+// =============================================================================
+// Invariant #6: Mandatory Execution Delay (Timelock)
+// =============================================================================
+
+/// Economic/capability changes require a minimum delay between ratification
+/// and activation. Prevents flash-governance attacks.
+pub struct MandatoryExecutionDelay;
+
+/// Minimum global timelock: 100 blocks. Entities can set higher.
+pub const MIN_GLOBAL_TIMELOCK_BLOCKS: u64 = 100;
+
+impl Invariant for MandatoryExecutionDelay {
+    fn id(&self) -> InvariantId {
+        InvariantId::MandatoryExecutionDelay
+    }
+
+    fn validate(&self, ctx: &InvariantContext) -> Result<(), InvariantViolation> {
+        let needs_timelock = ctx.manifest.touches_economics() || ctx.manifest.touches_authz();
+        if !needs_timelock {
+            return Ok(());
+        }
+
+        let rat_block = match ctx.manifest.ratification_block {
+            Some(b) => b,
+            None => {
+                // If no ratification block set yet, this is still in draft.
+                // We'll check again at activation time.
+                return Ok(());
+            }
+        };
+
+        let act_block = ctx
+            .manifest
+            .activation_block
+            .ok_or_else(|| InvariantViolation {
+                id: self.id(),
+                domain: self.id().domain(),
+                message: "activation_block must be set for amendments touching econ/caps".into(),
+                details: vec![],
+            })?;
+
+        // Use entity-specific delay or global minimum, whichever is higher
+        let entity_delay = ctx
+            .manifest
+            .economic_effects
+            .first()
+            .map(|e| match e {
+                EconomicEffect::MutualCreditPolicyChange { entity_id, .. }
+                | EconomicEffect::BudgetScopeChange { entity_id, .. }
+                | EconomicEffect::DemurrageChange { entity_id, .. }
+                | EconomicEffect::DisputeHookChange { entity_id, .. }
+                | EconomicEffect::SettlementRuleChange { entity_id, .. } => {
+                    ctx.state.current_min_timelock_blocks(entity_id)
+                }
+            })
+            .unwrap_or(0);
+
+        let min_delay = entity_delay.max(MIN_GLOBAL_TIMELOCK_BLOCKS);
+
+        if act_block < rat_block.saturating_add(min_delay) {
+            return Err(InvariantViolation {
+                id: self.id(),
+                domain: self.id().domain(),
+                message: "Activation block violates mandatory timelock".into(),
+                details: vec![
+                    ("ratification_block".into(), rat_block.to_string()),
+                    ("activation_block".into(), act_block.to_string()),
+                    ("min_delay_blocks".into(), min_delay.to_string()),
+                ],
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::power_diff::{DiffSummary, SubjectDelta};
+
+    /// Test state that returns a fixed timelock.
+    struct TestState {
+        timelock_blocks: u64,
+    }
+
+    impl InvariantStateView for TestState {
+        fn current_min_timelock_blocks(&self, _entity_id: &str) -> u64 {
+            self.timelock_blocks
+        }
+    }
+
+    fn make_ctx<'a>(
+        manifest: &'a EffectManifest,
+        power_diff: Option<&'a PowerDiff>,
+        state: &'a dyn InvariantStateView,
+    ) -> InvariantContext<'a> {
+        InvariantContext {
+            current_block: 1000,
+            manifest,
+            power_diff,
+            state,
+        }
+    }
+
+    // --- Invariant #4 tests ---
+
+    #[test]
+    fn test_no_silent_power_changes_passes_for_non_authz() {
+        let m = EffectManifest::new(
+            [0u8; 32],
+            [0u8; 32],
+            "did:icn:a".into(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let state = TestState { timelock_blocks: 0 };
+        let ctx = make_ctx(&m, None, &state);
+        assert!(NoSilentPowerChanges.validate(&ctx).is_ok());
+    }
+
+    #[test]
+    fn test_no_silent_power_changes_rejects_authz_without_diff() {
+        let m = EffectManifest::new(
+            [0u8; 32],
+            [0u8; 32],
+            "did:icn:a".into(),
+            vec![CapabilityEffect::Grant {
+                subject: "did:icn:b".into(),
+                capability: "vote".into(),
+                scope: "coop:x".into(),
+                resource: "governance".into(),
+            }],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let state = TestState { timelock_blocks: 0 };
+        let ctx = make_ctx(&m, None, &state);
+        let result = NoSilentPowerChanges.validate(&ctx);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().id, InvariantId::NoSilentPowerChanges);
+    }
+
+    #[test]
+    fn test_no_silent_power_changes_passes_with_diff() {
+        let m = EffectManifest::new(
+            [0u8; 32],
+            [0u8; 32],
+            "did:icn:a".into(),
+            vec![CapabilityEffect::Grant {
+                subject: "did:icn:b".into(),
+                capability: "vote".into(),
+                scope: "coop:x".into(),
+                resource: "governance".into(),
+            }],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let pd = PowerDiff::new(
+            m.manifest_hash,
+            [0u8; 32],
+            vec![SubjectDelta {
+                subject: "did:icn:b".into(),
+                capabilities_gained: vec![],
+                capabilities_lost: vec![],
+                scope_widened: vec![],
+                scope_narrowed: vec![],
+            }],
+            DiffSummary::default(),
+            vec![],
+        );
+        let state = TestState { timelock_blocks: 0 };
+        let ctx = make_ctx(&m, Some(&pd), &state);
+        assert!(NoSilentPowerChanges.validate(&ctx).is_ok());
+    }
+
+    // --- Invariant #5 tests ---
+
+    #[test]
+    fn test_bounded_authority_passes_for_scoped() {
+        let m = EffectManifest::new(
+            [0u8; 32],
+            [0u8; 32],
+            "did:icn:a".into(),
+            vec![CapabilityEffect::Grant {
+                subject: "did:icn:b".into(),
+                capability: "vote".into(),
+                scope: "coop:sunrise".into(),
+                resource: "governance".into(),
+            }],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let state = TestState { timelock_blocks: 0 };
+        let ctx = make_ctx(&m, None, &state);
+        assert!(BoundedAuthority.validate(&ctx).is_ok());
+    }
+
+    #[test]
+    fn test_bounded_authority_rejects_wildcard_scope() {
+        let m = EffectManifest::new(
+            [0u8; 32],
+            [0u8; 32],
+            "did:icn:a".into(),
+            vec![CapabilityEffect::Grant {
+                subject: "did:icn:b".into(),
+                capability: "admin".into(),
+                scope: "*".into(),
+                resource: "everything".into(),
+            }],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let state = TestState { timelock_blocks: 0 };
+        let ctx = make_ctx(&m, None, &state);
+        let result = BoundedAuthority.validate(&ctx);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().id, InvariantId::BoundedAuthority);
+    }
+
+    #[test]
+    fn test_bounded_authority_rejects_wildcard_resource() {
+        let m = EffectManifest::new(
+            [0u8; 32],
+            [0u8; 32],
+            "did:icn:a".into(),
+            vec![CapabilityEffect::Grant {
+                subject: "did:icn:b".into(),
+                capability: "admin".into(),
+                scope: "coop:x".into(),
+                resource: "*".into(),
+            }],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let state = TestState { timelock_blocks: 0 };
+        let ctx = make_ctx(&m, None, &state);
+        assert!(BoundedAuthority.validate(&ctx).is_err());
+    }
+
+    // --- Invariant #6 tests ---
+
+    #[test]
+    fn test_timelock_passes_for_non_econ() {
+        let m = EffectManifest::new(
+            [0u8; 32],
+            [0u8; 32],
+            "did:icn:a".into(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let state = TestState { timelock_blocks: 0 };
+        let ctx = make_ctx(&m, None, &state);
+        assert!(MandatoryExecutionDelay.validate(&ctx).is_ok());
+    }
+
+    #[test]
+    fn test_timelock_passes_for_draft_without_ratification() {
+        let m = EffectManifest::new(
+            [0u8; 32],
+            [0u8; 32],
+            "did:icn:a".into(),
+            vec![],
+            vec![EconomicEffect::DemurrageChange {
+                entity_id: "coop:x".into(),
+                old_rate_bps: 100,
+                new_rate_bps: 200,
+            }],
+            vec![],
+            vec![],
+        );
+        // ratification_block is None → skip check (still in draft)
+        let state = TestState { timelock_blocks: 0 };
+        let ctx = make_ctx(&m, None, &state);
+        assert!(MandatoryExecutionDelay.validate(&ctx).is_ok());
+    }
+
+    #[test]
+    fn test_timelock_rejects_too_short() {
+        let mut m = EffectManifest::new(
+            [0u8; 32],
+            [0u8; 32],
+            "did:icn:a".into(),
+            vec![],
+            vec![EconomicEffect::DemurrageChange {
+                entity_id: "coop:x".into(),
+                old_rate_bps: 100,
+                new_rate_bps: 200,
+            }],
+            vec![],
+            vec![],
+        );
+        m.ratification_block = Some(1000);
+        m.activation_block = Some(1050); // Only 50 blocks — below MIN_GLOBAL (100)
+        let state = TestState { timelock_blocks: 0 };
+        let ctx = make_ctx(&m, None, &state);
+        let result = MandatoryExecutionDelay.validate(&ctx);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().id, InvariantId::MandatoryExecutionDelay);
+    }
+
+    #[test]
+    fn test_timelock_passes_with_sufficient_delay() {
+        let mut m = EffectManifest::new(
+            [0u8; 32],
+            [0u8; 32],
+            "did:icn:a".into(),
+            vec![],
+            vec![EconomicEffect::DemurrageChange {
+                entity_id: "coop:x".into(),
+                old_rate_bps: 100,
+                new_rate_bps: 200,
+            }],
+            vec![],
+            vec![],
+        );
+        m.ratification_block = Some(1000);
+        m.activation_block = Some(1200); // 200 blocks — above MIN_GLOBAL (100)
+        let state = TestState { timelock_blocks: 0 };
+        let ctx = make_ctx(&m, None, &state);
+        assert!(MandatoryExecutionDelay.validate(&ctx).is_ok());
+    }
+
+    #[test]
+    fn test_timelock_uses_entity_override() {
+        let mut m = EffectManifest::new(
+            [0u8; 32],
+            [0u8; 32],
+            "did:icn:a".into(),
+            vec![],
+            vec![EconomicEffect::DemurrageChange {
+                entity_id: "coop:x".into(),
+                old_rate_bps: 100,
+                new_rate_bps: 200,
+            }],
+            vec![],
+            vec![],
+        );
+        m.ratification_block = Some(1000);
+        m.activation_block = Some(1200); // 200 blocks
+                                         // Entity requires 500 blocks
+        let state = TestState {
+            timelock_blocks: 500,
+        };
+        let ctx = make_ctx(&m, None, &state);
+        let result = MandatoryExecutionDelay.validate(&ctx);
+        assert!(result.is_err()); // 200 < 500
+    }
+
+    // --- Gate integration tests ---
+
+    #[test]
+    fn test_gate_all_pass() {
+        let m = EffectManifest::new(
+            [0u8; 32],
+            [0u8; 32],
+            "did:icn:a".into(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let state = TestState { timelock_blocks: 0 };
+        let ctx = make_ctx(&m, None, &state);
+        let gate = InvariantGate::default_frozen_core();
+        let report = gate.evaluate(&ctx);
+        assert!(report.passed);
+        assert!(report.violations.is_empty());
+    }
+
+    #[test]
+    fn test_gate_collects_multiple_violations() {
+        // Wildcard + missing diff = two violations
+        let m = EffectManifest::new(
+            [0u8; 32],
+            [0u8; 32],
+            "did:icn:a".into(),
+            vec![CapabilityEffect::Grant {
+                subject: "did:icn:b".into(),
+                capability: "admin".into(),
+                scope: "*".into(),
+                resource: "*".into(),
+            }],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let state = TestState { timelock_blocks: 0 };
+        let ctx = make_ctx(&m, None, &state);
+        let gate = InvariantGate::default_frozen_core();
+        let report = gate.evaluate(&ctx);
+        assert!(!report.passed);
+        // Should have violations from both #4 (no diff) and #5 (wildcard)
+        assert!(report.violations.len() >= 2);
+    }
+}

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -43,6 +43,8 @@ pub mod delegation;
 pub mod discussion;
 pub mod domain;
 #[allow(missing_docs)]
+pub mod effect_manifest;
+#[allow(missing_docs)]
 pub mod error;
 pub mod handle;
 pub mod membership;

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -47,6 +47,8 @@ pub mod effect_manifest;
 #[allow(missing_docs)]
 pub mod error;
 pub mod handle;
+#[allow(missing_docs)]
+pub mod invariant_gate;
 pub mod membership;
 #[allow(missing_docs)]
 pub mod message;

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -50,6 +50,8 @@ pub mod handle;
 pub mod membership;
 #[allow(missing_docs)]
 pub mod message;
+#[allow(missing_docs)]
+pub mod power_diff;
 pub mod profile;
 pub mod proof;
 #[allow(missing_docs)]

--- a/icn/crates/icn-governance/src/power_diff.rs
+++ b/icn/crates/icn-governance/src/power_diff.rs
@@ -1,0 +1,202 @@
+//! Power Diff — computed delta showing how an EffectManifest changes
+//! the authorization/capability landscape.
+//!
+//! Attached to every proposal so voters see power implications before voting.
+//! Three output layers: human-readable summary, structured data, cryptographic receipt.
+
+use icn_kernel_api::Did;
+use serde::{Deserialize, Serialize};
+
+/// Computed power delta for a governance action.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PowerDiff {
+    /// Version for deterministic replay.
+    pub diff_version: u16,
+    /// Hash of the manifest this diff was computed from.
+    pub manifest_hash: [u8; 32],
+    /// Hash of the baseline state snapshot.
+    pub baseline_snapshot_hash: [u8; 32],
+    /// Per-subject changes.
+    pub subject_deltas: Vec<SubjectDelta>,
+    /// Aggregate summary.
+    pub summary: DiffSummary,
+    /// Risk indicators.
+    pub warnings: Vec<PowerWarning>,
+    /// Deterministic hash of the full diff.
+    pub diff_hash: [u8; 32],
+}
+
+/// Change in capabilities for a single subject.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubjectDelta {
+    pub subject: Did,
+    pub capabilities_gained: Vec<CapabilityChange>,
+    pub capabilities_lost: Vec<CapabilityChange>,
+    pub scope_widened: Vec<ScopeChange>,
+    pub scope_narrowed: Vec<ScopeChange>,
+}
+
+/// A single capability change.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapabilityChange {
+    pub capability: String,
+    pub scope: String,
+    pub resource: String,
+}
+
+/// A scope change (widening or narrowing).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScopeChange {
+    pub capability: String,
+    pub old_scope: String,
+    pub new_scope: String,
+}
+
+/// Aggregate diff metrics.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DiffSummary {
+    pub total_grants: u32,
+    pub total_revocations: u32,
+    pub subjects_affected: u32,
+    /// Positive = more concentrated. Negative = more distributed.
+    pub concentration_delta: f64,
+    pub exit_rights_affected: bool,
+    pub appeal_rights_affected: bool,
+}
+
+/// Risk warnings that trigger tier escalation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum PowerWarning {
+    /// Power concentration spike for a single subject.
+    ConcentrationSpike {
+        subject: Did,
+        old_score: f64,
+        new_score: f64,
+    },
+    /// Exit rights narrowed for an entity.
+    ExitRightNarrowed { entity_id: String },
+    /// An appeal path was removed.
+    AppealPathRemoved { decision_type: String },
+    /// A subject gains unilateral capability (no quorum required).
+    UnilateralCapability { subject: Did, capability: String },
+    /// An irreversible change was detected.
+    IrreversibleChange { effect_index: usize, reason: String },
+}
+
+impl PowerWarning {
+    /// Minimum governance tier required when this warning is present.
+    pub fn min_tier(&self) -> u8 {
+        match self {
+            Self::ConcentrationSpike { .. } => 3,
+            Self::ExitRightNarrowed { .. } => 3,
+            Self::AppealPathRemoved { .. } => 4,
+            Self::UnilateralCapability { .. } => 4,
+            Self::IrreversibleChange { .. } => 3,
+        }
+    }
+}
+
+impl PowerDiff {
+    /// Compute deterministic hash of the diff.
+    pub fn compute_hash(
+        diff_version: u16,
+        manifest_hash: [u8; 32],
+        baseline_snapshot_hash: [u8; 32],
+        subject_deltas: &[SubjectDelta],
+        summary: &DiffSummary,
+        warnings: &[PowerWarning],
+    ) -> [u8; 32] {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(&diff_version.to_le_bytes());
+        hasher.update(&manifest_hash);
+        hasher.update(&baseline_snapshot_hash);
+        let deltas_json = serde_json::to_vec(subject_deltas).unwrap_or_default();
+        hasher.update(&(deltas_json.len() as u32).to_le_bytes());
+        hasher.update(&deltas_json);
+        let summary_json = serde_json::to_vec(summary).unwrap_or_default();
+        hasher.update(&summary_json);
+        let warnings_json = serde_json::to_vec(warnings).unwrap_or_default();
+        hasher.update(&warnings_json);
+        *hasher.finalize().as_bytes()
+    }
+
+    /// Build a diff with computed hash.
+    pub fn new(
+        manifest_hash: [u8; 32],
+        baseline_snapshot_hash: [u8; 32],
+        subject_deltas: Vec<SubjectDelta>,
+        summary: DiffSummary,
+        warnings: Vec<PowerWarning>,
+    ) -> Self {
+        let diff_hash = Self::compute_hash(
+            1,
+            manifest_hash,
+            baseline_snapshot_hash,
+            &subject_deltas,
+            &summary,
+            &warnings,
+        );
+        Self {
+            diff_version: 1,
+            manifest_hash,
+            baseline_snapshot_hash,
+            subject_deltas,
+            summary,
+            warnings,
+            diff_hash,
+        }
+    }
+
+    /// Maximum tier escalation required by warnings.
+    /// Returns 0 if no warnings.
+    pub fn max_escalation_tier(&self) -> u8 {
+        self.warnings
+            .iter()
+            .map(|w| w.min_tier())
+            .max()
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_diff() {
+        let d = PowerDiff::new([0u8; 32], [0u8; 32], vec![], DiffSummary::default(), vec![]);
+        assert_eq!(d.max_escalation_tier(), 0);
+        assert_ne!(d.diff_hash, [0u8; 32]);
+    }
+
+    #[test]
+    fn test_warning_escalation() {
+        let w = vec![
+            PowerWarning::ConcentrationSpike {
+                subject: "did:icn:alice".into(),
+                old_score: 0.1,
+                new_score: 0.5,
+            },
+            PowerWarning::AppealPathRemoved {
+                decision_type: "expulsion".into(),
+            },
+        ];
+        let d = PowerDiff::new([0u8; 32], [0u8; 32], vec![], DiffSummary::default(), w);
+        assert_eq!(d.max_escalation_tier(), 4);
+    }
+
+    #[test]
+    fn test_diff_hash_deterministic() {
+        let d1 = PowerDiff::new([1u8; 32], [2u8; 32], vec![], DiffSummary::default(), vec![]);
+        let d2 = PowerDiff::new([1u8; 32], [2u8; 32], vec![], DiffSummary::default(), vec![]);
+        assert_eq!(d1.diff_hash, d2.diff_hash);
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let d = PowerDiff::new([0u8; 32], [0u8; 32], vec![], DiffSummary::default(), vec![]);
+        let json = serde_json::to_string(&d).unwrap();
+        let parsed: PowerDiff = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.diff_hash, d.diff_hash);
+    }
+}

--- a/icn/crates/icn-governance/src/power_diff.rs
+++ b/icn/crates/icn-governance/src/power_diff.rs
@@ -158,6 +158,43 @@ impl PowerDiff {
     }
 }
 
+/// Self-authenticating cryptographic receipt for a Power Diff.
+/// Same pattern as GovernanceDecisionReceipt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PowerDiffReceipt {
+    pub diff_hash: [u8; 32],
+    pub manifest_hash: [u8; 32],
+    pub baseline_snapshot_hash: [u8; 32],
+    pub report_hash: [u8; 32],
+    pub computed_by: Did,
+    pub timestamp: u64,
+    /// Ed25519 signature over the receipt hash.
+    pub signature: Vec<u8>,
+    /// Deterministic hash of the receipt (signed content).
+    pub receipt_hash: [u8; 32],
+}
+
+impl PowerDiffReceipt {
+    /// Compute the receipt hash (the content that gets signed).
+    pub fn compute_receipt_hash(
+        diff_hash: [u8; 32],
+        manifest_hash: [u8; 32],
+        baseline_snapshot_hash: [u8; 32],
+        report_hash: [u8; 32],
+        computed_by: &str,
+        timestamp: u64,
+    ) -> [u8; 32] {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(&diff_hash);
+        hasher.update(&manifest_hash);
+        hasher.update(&baseline_snapshot_hash);
+        hasher.update(&report_hash);
+        hasher.update(computed_by.as_bytes());
+        hasher.update(&timestamp.to_le_bytes());
+        *hasher.finalize().as_bytes()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -198,5 +235,27 @@ mod tests {
         let json = serde_json::to_string(&d).unwrap();
         let parsed: PowerDiff = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.diff_hash, d.diff_hash);
+    }
+
+    #[test]
+    fn test_receipt_hash_deterministic() {
+        let h1 = PowerDiffReceipt::compute_receipt_hash(
+            [1u8; 32],
+            [2u8; 32],
+            [3u8; 32],
+            [4u8; 32],
+            "did:icn:a",
+            12345,
+        );
+        let h2 = PowerDiffReceipt::compute_receipt_hash(
+            [1u8; 32],
+            [2u8; 32],
+            [3u8; 32],
+            [4u8; 32],
+            "did:icn:a",
+            12345,
+        );
+        assert_eq!(h1, h2);
+        assert_ne!(h1, [0u8; 32]);
     }
 }

--- a/icn/crates/icn-governance/tests/governance_safety_integration.rs
+++ b/icn/crates/icn-governance/tests/governance_safety_integration.rs
@@ -1,0 +1,188 @@
+//! Integration test: governance safety pipeline
+//!
+//! Tests the full flow: Amendment -> EffectManifest -> InvariantGate -> PowerDiff
+//! -> DraftWithArtifacts
+
+use icn_governance::amendment::*;
+use icn_governance::effect_manifest::*;
+use icn_governance::invariant_gate::*;
+use icn_kernel_api::invariants::*;
+
+struct TestState;
+impl InvariantStateView for TestState {
+    fn current_min_timelock_blocks(&self, _: &str) -> u64 {
+        0
+    }
+}
+
+fn test_proposer() -> icn_identity::Did {
+    icn_identity::Did::from_anchor_id(&[42u8; 32])
+}
+
+#[test]
+fn test_full_pipeline_clean_amendment() {
+    // 1. Create amendment
+    let mut amendment = Amendment::new(
+        AmendmentType::Policy,
+        AmendmentScope::Jurisdiction {
+            domain_id: "sunrise-bakery".into(),
+        },
+        "Increase board seats".into(),
+        "Add 2 seats to the board".into(),
+        test_proposer(),
+    );
+
+    // 2. Generate manifest (no authz/econ effects for this simple case)
+    let manifest = EffectManifest::new(
+        amendment.document_hash.unwrap_or([0u8; 32]),
+        [0u8; 32], // baseline snapshot
+        "did:icn:proposer".into(),
+        vec![],
+        vec![],
+        vec![],
+        vec![],
+    );
+
+    // 3. Run invariant gate
+    let state = TestState;
+    let ctx = InvariantContext {
+        current_block: 1000,
+        manifest: &manifest,
+        power_diff: None,
+        state: &state,
+    };
+    let gate = InvariantGate::default_frozen_core();
+    let report = gate.evaluate(&ctx);
+    assert!(report.passed);
+
+    // 4. Attach artifacts
+    let result = amendment.attach_artifacts(manifest, None, report);
+    assert!(result.is_ok());
+    assert!(matches!(
+        amendment.status,
+        AmendmentStatus::DraftWithArtifacts { .. }
+    ));
+
+    // 5. Submit for review
+    let result = amendment.submit_for_review();
+    assert!(result.is_ok());
+    assert!(matches!(
+        amendment.status,
+        AmendmentStatus::Submitted { .. }
+    ));
+}
+
+#[test]
+fn test_pipeline_rejects_wildcard_capability() {
+    let mut amendment = Amendment::new(
+        AmendmentType::Governance,
+        AmendmentScope::Jurisdiction {
+            domain_id: "test".into(),
+        },
+        "Grant emergency powers".into(),
+        "Give founder all permissions".into(),
+        test_proposer(),
+    );
+
+    // Manifest with wildcard -- should be rejected by invariant #5
+    let manifest = EffectManifest::new(
+        [0u8; 32],
+        [0u8; 32],
+        "did:icn:proposer".into(),
+        vec![CapabilityEffect::Grant {
+            subject: "did:icn:founder".into(),
+            capability: "admin".into(),
+            scope: "*".into(),
+            resource: "*".into(),
+        }],
+        vec![],
+        vec![],
+        vec![],
+    );
+
+    let state = TestState;
+    let ctx = InvariantContext {
+        current_block: 1000,
+        manifest: &manifest,
+        power_diff: None,
+        state: &state,
+    };
+    let gate = InvariantGate::default_frozen_core();
+    let report = gate.evaluate(&ctx);
+    assert!(!report.passed);
+
+    // Attach should fail because report has violations
+    let result = amendment.attach_artifacts(manifest, None, report);
+    assert!(result.is_err());
+    assert!(matches!(amendment.status, AmendmentStatus::Draft));
+}
+
+#[test]
+fn test_pipeline_rejects_flash_governance() {
+    let mut amendment = Amendment::new(
+        AmendmentType::Economic,
+        AmendmentScope::Jurisdiction {
+            domain_id: "test".into(),
+        },
+        "Change credit limits".into(),
+        "Increase all limits 10x".into(),
+        test_proposer(),
+    );
+
+    // Manifest with economic effects but too-short timelock
+    let mut manifest = EffectManifest::new(
+        [0u8; 32],
+        [0u8; 32],
+        "did:icn:proposer".into(),
+        vec![],
+        vec![EconomicEffect::MutualCreditPolicyChange {
+            entity_id: "coop:x".into(),
+            policy_key: "credit_limit".into(),
+            before_hash: [0u8; 32],
+            after_hash: [1u8; 32],
+        }],
+        vec![],
+        vec![],
+    );
+    manifest.ratification_block = Some(1000);
+    manifest.activation_block = Some(1010); // Only 10 blocks -- way too short
+
+    let state = TestState;
+    let ctx = InvariantContext {
+        current_block: 1000,
+        manifest: &manifest,
+        power_diff: None,
+        state: &state,
+    };
+    let gate = InvariantGate::default_frozen_core();
+    let report = gate.evaluate(&ctx);
+    assert!(!report.passed);
+
+    // Verify the specific invariant that failed
+    let timelock_violation = report
+        .violations
+        .iter()
+        .find(|v| v.id == InvariantId::MandatoryExecutionDelay);
+    assert!(timelock_violation.is_some());
+
+    // Attach should fail
+    let result = amendment.attach_artifacts(manifest, None, report);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_cannot_submit_without_artifacts() {
+    let mut amendment = Amendment::new(
+        AmendmentType::Policy,
+        AmendmentScope::Jurisdiction {
+            domain_id: "test".into(),
+        },
+        "Test".into(),
+        "Test".into(),
+        test_proposer(),
+    );
+
+    // Try to submit directly -- should fail
+    let result = amendment.submit_for_review();
+    assert!(result.is_err());
+}

--- a/icn/crates/icn-kernel-api/src/effects.rs
+++ b/icn/crates/icn-kernel-api/src/effects.rs
@@ -37,6 +37,12 @@ pub enum KernelEffect {
     Control(ControlEffect),
     /// Federation effects
     Federation(FederationEffect),
+    /// Dispute resolution effects
+    Dispute(DisputeEffect),
+    /// Resource access effects
+    Resource(ResourceEffect),
+    /// SDIS effects
+    Sdis(SdisEffect),
     /// No-op effect (e.g., for text proposals)
     NoOp { reason: String },
 }

--- a/icn/crates/icn-kernel-api/src/invariants.rs
+++ b/icn/crates/icn-kernel-api/src/invariants.rs
@@ -1,0 +1,230 @@
+//! Frozen-core invariant types for governance safety.
+//!
+//! These types are kernel-safe: the kernel verifies attestation presence,
+//! format, and hash linkage. It never evaluates the predicates themselves.
+//! Predicate evaluation lives in the governance app layer.
+
+use serde::{Deserialize, Serialize};
+
+/// Block height for ordering governance transitions.
+pub type BlockHeight = u64;
+
+/// Identifies which frozen-core invariant was checked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InvariantId {
+    /// #1: No rule can prevent an identity from leaving an entity.
+    RightOfExit,
+    /// #2: Rules only apply to actions after activation block.
+    NoRetroactiveObligations,
+    /// #3: Adding an identity requires their cryptographic signature.
+    ExplicitCryptographicEntry,
+    /// #4: Authz changes must include a computable capability delta.
+    NoSilentPowerChanges,
+    /// #5: No wildcard capabilities across all resources.
+    BoundedAuthority,
+    /// #6: Economic/capability changes require timelock delay.
+    MandatoryExecutionDelay,
+    /// #7: Cannot delegate capabilities you don't possess.
+    CapabilityConservation,
+    /// #8: Mutual credit loops must net to zero.
+    MutualCreditConservation,
+    /// #9: Funds move only via owner signature or pre-consented dispute hook.
+    SovereignSignatureRequirement,
+    /// #10: Every state transition emits an immutable receipt.
+    UniversalReceiptGeneration,
+}
+
+/// Domain classification for invariants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InvariantDomain {
+    /// Consent & exit invariants (#1-#3).
+    SovereigntyCore,
+    /// Power & governance invariants (#4-#7).
+    AntiCaptureCore,
+    /// Economic invariants (#8-#10).
+    EconomicCore,
+}
+
+impl InvariantId {
+    /// Which domain does this invariant belong to?
+    pub fn domain(&self) -> InvariantDomain {
+        match self {
+            Self::RightOfExit
+            | Self::NoRetroactiveObligations
+            | Self::ExplicitCryptographicEntry => InvariantDomain::SovereigntyCore,
+            Self::NoSilentPowerChanges
+            | Self::BoundedAuthority
+            | Self::MandatoryExecutionDelay
+            | Self::CapabilityConservation => InvariantDomain::AntiCaptureCore,
+            Self::MutualCreditConservation
+            | Self::SovereignSignatureRequirement
+            | Self::UniversalReceiptGeneration => InvariantDomain::EconomicCore,
+        }
+    }
+
+    /// All frozen-core invariant IDs.
+    pub fn all() -> &'static [InvariantId] {
+        &[
+            Self::RightOfExit,
+            Self::NoRetroactiveObligations,
+            Self::ExplicitCryptographicEntry,
+            Self::NoSilentPowerChanges,
+            Self::BoundedAuthority,
+            Self::MandatoryExecutionDelay,
+            Self::CapabilityConservation,
+            Self::MutualCreditConservation,
+            Self::SovereignSignatureRequirement,
+            Self::UniversalReceiptGeneration,
+        ]
+    }
+}
+
+/// A single invariant violation with machine-readable details.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InvariantViolation {
+    pub id: InvariantId,
+    pub domain: InvariantDomain,
+    pub message: String,
+    /// Machine-readable key-value details for logging/UX.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub details: Vec<(String, String)>,
+}
+
+/// Report from running all invariants against a manifest.
+///
+/// The kernel checks `passed` and `report_hash` -- it never inspects
+/// individual violations (meaning firewall).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InvariantReport {
+    /// Gate version for deterministic replay.
+    pub report_version: u16,
+    /// Hash of the manifest that was checked.
+    pub manifest_hash: [u8; 32],
+    /// Hash of the power diff (if present).
+    pub power_diff_hash: Option<[u8; 32]>,
+    /// Did all invariants pass?
+    pub passed: bool,
+    /// Violations found (empty if passed).
+    pub violations: Vec<InvariantViolation>,
+    /// Deterministic hash over the full report content.
+    pub report_hash: [u8; 32],
+}
+
+impl InvariantReport {
+    /// Compute the deterministic report hash.
+    pub fn compute_hash(
+        report_version: u16,
+        manifest_hash: [u8; 32],
+        power_diff_hash: Option<[u8; 32]>,
+        passed: bool,
+        violations: &[InvariantViolation],
+    ) -> [u8; 32] {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(&report_version.to_le_bytes());
+        hasher.update(&manifest_hash);
+        if let Some(pdh) = power_diff_hash {
+            hasher.update(&[1u8]);
+            hasher.update(&pdh);
+        } else {
+            hasher.update(&[0u8]);
+        }
+        hasher.update(&[passed as u8]);
+        // Hash each violation deterministically
+        for v in violations {
+            let v_json = serde_json::to_vec(v).unwrap_or_default();
+            hasher.update(&(v_json.len() as u32).to_le_bytes());
+            hasher.update(&v_json);
+        }
+        *hasher.finalize().as_bytes()
+    }
+
+    /// Build a report with computed hash.
+    pub fn new(
+        manifest_hash: [u8; 32],
+        power_diff_hash: Option<[u8; 32]>,
+        violations: Vec<InvariantViolation>,
+    ) -> Self {
+        let passed = violations.is_empty();
+        let report_hash =
+            Self::compute_hash(1, manifest_hash, power_diff_hash, passed, &violations);
+        Self {
+            report_version: 1,
+            manifest_hash,
+            power_diff_hash,
+            passed,
+            violations,
+            report_hash,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_invariant_id_domain_mapping() {
+        assert_eq!(
+            InvariantId::RightOfExit.domain(),
+            InvariantDomain::SovereigntyCore
+        );
+        assert_eq!(
+            InvariantId::NoSilentPowerChanges.domain(),
+            InvariantDomain::AntiCaptureCore
+        );
+        assert_eq!(
+            InvariantId::MutualCreditConservation.domain(),
+            InvariantDomain::EconomicCore
+        );
+    }
+
+    #[test]
+    fn test_all_invariants_returns_10() {
+        assert_eq!(InvariantId::all().len(), 10);
+    }
+
+    #[test]
+    fn test_report_passing() {
+        let report = InvariantReport::new([0u8; 32], None, vec![]);
+        assert!(report.passed);
+        assert!(report.violations.is_empty());
+        assert_ne!(report.report_hash, [0u8; 32]);
+    }
+
+    #[test]
+    fn test_report_failing() {
+        let violation = InvariantViolation {
+            id: InvariantId::BoundedAuthority,
+            domain: InvariantDomain::AntiCaptureCore,
+            message: "Wildcard scope detected".into(),
+            details: vec![("scope".into(), "*".into())],
+        };
+        let report = InvariantReport::new([0u8; 32], None, vec![violation]);
+        assert!(!report.passed);
+        assert_eq!(report.violations.len(), 1);
+    }
+
+    #[test]
+    fn test_report_hash_deterministic() {
+        let v = InvariantViolation {
+            id: InvariantId::MandatoryExecutionDelay,
+            domain: InvariantDomain::AntiCaptureCore,
+            message: "Timelock too short".into(),
+            details: vec![],
+        };
+        let r1 = InvariantReport::new([1u8; 32], Some([2u8; 32]), vec![v.clone()]);
+        let r2 = InvariantReport::new([1u8; 32], Some([2u8; 32]), vec![v]);
+        assert_eq!(r1.report_hash, r2.report_hash);
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let report = InvariantReport::new([42u8; 32], None, vec![]);
+        let json = serde_json::to_string(&report).unwrap();
+        let parsed: InvariantReport = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.report_hash, report.report_hash);
+        assert!(parsed.passed);
+    }
+}

--- a/icn/crates/icn-kernel-api/src/lib.rs
+++ b/icn/crates/icn-kernel-api/src/lib.rs
@@ -46,6 +46,7 @@ pub mod events;
 pub mod execution;
 pub mod governance;
 pub mod identity;
+pub mod invariants;
 pub mod naming;
 pub mod proofs;
 pub mod protocol_params;
@@ -119,6 +120,10 @@ pub use state::{
 pub use storage::{DataLocality, StorageClass, StorageValidationError};
 pub use time::TimeService;
 pub use version::Version;
+
+pub use invariants::{
+    BlockHeight, InvariantDomain, InvariantId, InvariantReport, InvariantViolation,
+};
 
 // Re-export common types
 pub use types::*;

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -179,6 +179,8 @@ import {
   ResolveNameResponse,
 } from './types';
 
+import { WasmClient } from './wasm';
+
 export * from './types';
 export { WasmClient } from './wasm';
 export type { WasmModuleInfo, WasmDeployResult, WasmClientOptions } from './wasm';

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -329,6 +329,7 @@ export class ICNClient {
   public readonly treasury: TreasuryClient;
   public readonly governance: GovernanceClient;
   public readonly names: NamesClient;
+  public readonly wasm: WasmClient;
 
   constructor(options: ICNClientOptions) {
     this.baseUrl = options.baseUrl.replace(/\/$/, '');
@@ -339,6 +340,12 @@ export class ICNClient {
     this.retryOptions = { ...DEFAULT_RETRY, ...options.retry };
     this.autoRefresh = options.autoRefresh ?? false;
     this.refreshBeforeExpiry = options.refreshBeforeExpiry ?? 60;
+    this.wasm = new WasmClient({
+      baseUrl: this.baseUrl,
+      token: this.token,
+      timeout: this.timeout,
+      fetch: this.fetchImpl,
+    });
     this.treasury = {
       balance: async (coopId: string): Promise<TreasuryBalanceResponse> =>
         this.get<TreasuryBalanceResponse>(
@@ -408,6 +415,7 @@ export class ICNClient {
   setToken(token: string, expiresAt?: number): void {
     this.token = token;
     this.tokenExpiresAt = expiresAt;
+    this.wasm.setToken(token);
   }
 
   /**
@@ -420,6 +428,7 @@ export class ICNClient {
     this.did = undefined;
     this.coopId = undefined;
     this.scopes = undefined;
+    this.wasm.clearToken();
   }
 
   /**

--- a/sdk/typescript/src/wasm.ts
+++ b/sdk/typescript/src/wasm.ts
@@ -153,6 +153,37 @@ export class WasmClient {
     return modules;
   }
 
+  /**
+   * Submit a compute task referencing a previously deployed WASM module by hash.
+   *
+   * @param wasmHash - 64-char hex Blake3 hash of the module
+   * @param inputs - Optional input arguments for the task
+   * @param options - Optional execution parameters (fuelLimit, priority, etc.)
+   * @returns Task hash and ID
+   */
+  async submitCompute(
+    wasmHash: string,
+    inputs?: unknown,
+    options?: {
+      fuelLimit?: number;
+      priority?: string;
+      taskId?: string;
+    },
+  ): Promise<{ task_hash: string; task_id: string }> {
+    return this.request<{ task_hash: string; task_id: string }>(
+      'POST',
+      '/compute/submit',
+      {
+        code_type: 'wasm',
+        wasm_hash: wasmHash,
+        inputs: inputs ?? null,
+        fuel_limit: options?.fuelLimit,
+        priority: options?.priority,
+        task_id: options?.taskId,
+      },
+    );
+  }
+
   // --------------------------------------------------------------------------
   // Internal HTTP helper
   // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements Phase A (Interceptor + Artifacts) of the CCL Governance Safety Spec. Every governance mutation must now produce an `EffectManifest`, pass an `InvariantGate`, and generate a `PowerDiff` before the system applies it.

- **Frozen-core invariant types** in `icn-kernel-api` — 10 invariant IDs, 3 domains, `InvariantReport` with BLAKE3 hashing. Kernel-safe opaque proofs (meaning firewall preserved).
- **EffectManifest** — typed, hashable, exhaustive effect vector for governance mutations (capability, economic, membership, protocol effects).
- **PowerDiff** — per-subject capability deltas with tier escalation warnings (`ExitRightNarrowed` → Tier 3, `AppealPathRemoved` → Tier 4).
- **InvariantGate** with 3 frozen-core invariants:
  - **#4 NoSilentPowerChanges** — authz changes require a PowerDiff with subject deltas
  - **#5 BoundedAuthority** — rejects wildcard `*` scope/resource (no god mode)
  - **#6 MandatoryExecutionDelay** — economic/capability changes need timelock (min 100 blocks)
- **Amendment lifecycle wiring** — new `DraftWithArtifacts` status enforces "no manifest, no activation"
- **PowerDiffReceipt** — self-authenticating BLAKE3+Ed25519 cryptographic receipt

### Design documents
- `docs/plans/2026-02-23-ccl-governance-safety-spec-design.md` — full design
- `docs/plans/2026-02-23-ccl-governance-safety-impl-plan.md` — Phase A implementation plan

### Invariants checklist
- [x] No panics in protocol paths — all `Result<T, E>`
- [x] Kernel/app boundary — InvariantReport is kernel-api; predicate logic is governance
- [x] Determinism — BLAKE3 hashing with structured field-by-field input, no HashMaps
- [x] Canonical encodings — serde with explicit skip_serializing_if for backward compat
- [x] Adversarial-by-default — gate rejects by default, must prove invariants pass

## Test plan

- [x] `cargo test -p icn-kernel-api --lib invariants` — 6 tests (types, domains, hashing, serde)
- [x] `cargo test -p icn-governance --lib effect_manifest` — 5 tests
- [x] `cargo test -p icn-governance --lib power_diff` — 5 tests (includes receipt)
- [x] `cargo test -p icn-governance --lib invariant_gate` — 13 tests (3 invariants + gate integration)
- [x] `cargo test -p icn-governance --lib interceptor_tests` — 4 tests (lifecycle wiring)
- [x] `cargo test -p icn-governance --test governance_safety_integration` — 4 tests (full pipeline)
- [x] `cargo test -p icn-governance --lib` — 401 tests pass, 0 regressions
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p icn-kernel-api -p icn-governance --all-targets -- -D warnings` — clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>