### PR TITLE
feat(authz): Capability Graph scaffold + deterministic hashing (Phase B0)

### DIFF
--- a/docs/plans/2026-02-23-authz-capability-graph-design.md
+++ b/docs/plans/2026-02-23-authz-capability-graph-design.md
@@ -1,0 +1,494 @@
+# Authz Capability Graph Design (Phase B)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Unify ICN's four disconnected authorization systems into a single canonical capability graph model with deterministic hashing, computed-on-demand evaluation, and adapter traits.
+
+**Architecture:** App-layer crate (`icn-authz`) with a domain-agnostic model subset (`icn-authz::model`) designed to be liftable to `icn-kernel-api` in a future phase. No persistence — graph is computed on demand from adapter sources. Deterministic hashing uses BLAKE3 with length-prefixed fields and explicit tag bytes.
+
+**Tech Stack:** Rust, BLAKE3, `icn-kernel-api` (types only), `icn-identity` (DID types)
+
+---
+
+## 1. Motivation
+
+ICN currently has four independent authorization systems that don't talk to each other:
+
+1. **CCL Capabilities** (`icn-ccl/src/types.rs`): 12-variant `Capability` enum. The governance-related variants (`ProposeAmendment`, `VoteOnProposal`, etc.) are dead code — governance doesn't actually check them.
+
+2. **Trust Classes** (`icn-trust/src/types.rs`): `TrustGraphType` enum maps to hardcoded rate limits. Trust score → rate limit conversion is buried in `TrustPolicyOracle` with no way for governance or CCL to query it.
+
+3. **Kernel ConstraintSet** (`icn-kernel-api/src/authz.rs`): `HashMap<String, ConstraintValue>` custom bag. Powerful but untyped — anyone can stuff anything in, no schema, no auditing.
+
+4. **JWT Scopes** (`icn-gateway/src/auth.rs`): `scopes: Vec<String>` in `TokenClaims`. Static strings like `"governance:read"`, completely disconnected from CCL capabilities.
+
+**Problems this causes:**
+- An amendment can grant `ProposeAmendment` capability in CCL but governance never checks it
+- Trust-gated rate limits are invisible to the governance safety pipeline (Phase A)
+- No way to compute "what changed" across a governance action that touches multiple systems
+- PowerDiff (Phase A) can detect *that* power changed but not *what capabilities* changed
+
+## 2. Goals and Non-Goals
+
+### Goals (B0 scope)
+- Canonical types for subjects, actions, resources, constraints, and edges
+- Deterministic BLAKE3 hashing of capability edges and edge sets
+- `GraphBuilder` trait for constructing graphs from heterogeneous sources
+- `CapabilityQuery` trait for evaluating "can subject X do action Y on resource Z?"
+- Test suite proving ordering invariants and hash determinism
+
+### Non-Goals (deferred)
+- Persistence (no sled, no storage)
+- Live adapters for CCL/Trust/JWT (Phase B1)
+- PowerDiff integration (Phase B2)
+- Full pipeline wiring (Phase B3)
+- Kernel promotion (future phase, post-pilot)
+
+## 3. Boundary and Meaning Firewall Stance
+
+`icn-authz` is an **app-layer crate**. It lives alongside `icn-governance`, `icn-trust`, etc.
+
+**Why not kernel?** The capability graph interprets domain semantics — it knows what "governance:propose" means, what trust classes map to. This is meaning. The kernel must not understand meaning.
+
+**Promotion path:** The `icn-authz::model` module contains only domain-agnostic types (`SubjectId`, `Action`, `ResourceId`, `Constraint`, `CapabilityEdge`). These types are designed to be copy-pasted into `icn-kernel-api` when the time comes. The `icn-authz::adapters` module imports domain crates and will never move to kernel.
+
+**Dependency direction:**
+```
+icn-authz::model     → icn-kernel-api (types only: BlockHeight, InvariantId)
+icn-authz::adapters  → icn-ccl, icn-trust, icn-gateway (future, B1)
+icn-authz::graph     → icn-authz::model (only)
+```
+
+## 4. Canonical Model
+
+### 4.1 SubjectId
+
+```rust
+/// An actor in the capability graph. Always a DID.
+///
+/// Validated on construction: must start with "did:" prefix.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct SubjectId(String);
+
+impl SubjectId {
+    pub fn new(did: impl Into<String>) -> Result<Self, AuthzError> {
+        let s = did.into();
+        if !s.starts_with("did:") {
+            return Err(AuthzError::InvalidSubjectId(s));
+        }
+        Ok(Self(s))
+    }
+    pub fn as_str(&self) -> &str { &self.0 }
+}
+```
+
+**Hashing:** `hash_subject(s)` = BLAKE3(TAG_SUBJECT ++ len_u32_le(s.as_bytes()) ++ s.as_bytes())
+
+### 4.2 Action
+
+Validated canonical string newtype. Format: `domain:verb[:subverb]`.
+
+```rust
+/// A capability action. Lowercased, trimmed, colon-separated segments.
+///
+/// Examples: "governance:propose", "ledger:transfer:credit", "compute:submit"
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct Action(String);
+
+impl Action {
+    pub fn new(raw: impl Into<String>) -> Result<Self, AuthzError> {
+        let s = raw.into().trim().to_ascii_lowercase();
+        // Must have at least domain:verb
+        let segments: Vec<&str> = s.split(':').collect();
+        if segments.len() < 2 || segments.iter().any(|seg| seg.is_empty()) {
+            return Err(AuthzError::InvalidAction(s));
+        }
+        // Only ASCII alphanumeric + colon + hyphen
+        if !s.chars().all(|c| c.is_ascii_alphanumeric() || c == ':' || c == '-') {
+            return Err(AuthzError::InvalidAction(s));
+        }
+        Ok(Self(s))
+    }
+    pub fn as_str(&self) -> &str { &self.0 }
+    pub fn domain(&self) -> &str { self.0.split(':').next().unwrap() }
+    pub fn verb(&self) -> &str { self.0.splitn(3, ':').nth(1).unwrap() }
+}
+```
+
+**Normalization:** Soft — `Action::new()` lowercases and trims, then validates. No rejection on case mismatch, just normalization.
+
+**Hashing:** `hash_action(a)` = BLAKE3(TAG_ACTION ++ len_u32_le(a.as_bytes()) ++ a.as_bytes())
+
+### 4.3 ResourceId
+
+```rust
+/// Variant order is FROZEN. Do not reorder. Append only.
+/// Tag bytes: Entity=0x01, Scope=0x02, Asset=0x03, Contract=0x04, System=0x05
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum ResourceKind {
+    Entity,    // tag 0x01 — cooperatives, communities, federations, individuals
+    Scope,     // tag 0x02 — cells, namespaces, governance scopes
+    Asset,     // tag 0x03 — ledger accounts, credit lines, treasury
+    Contract,  // tag 0x04 — CCL contracts, amendments
+    System,    // tag 0x05 — protocol parameters, invariant config
+}
+
+/// A typed resource identifier.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ResourceId {
+    pub kind: ResourceKind,
+    pub id: String,
+}
+```
+
+**Hashing:** `hash_resource(r)` = BLAKE3(TAG_RESOURCE ++ resource_kind_tag_byte(r.kind) ++ len_u32_le(r.id.as_bytes()) ++ r.id.as_bytes())
+
+Where `resource_kind_tag_byte` uses the explicit tag byte constants (0x01..0x05), NOT enum-as-integer casting.
+
+### 4.4 Constraint
+
+```rust
+/// Variant order is FROZEN. Do not reorder. Append only.
+/// Tag bytes: RateLimit=0x01, CreditMultiplier=0x02, MaxTopics=0x03,
+///            TimeLock=0x04, RequiresQuorum=0x05, Tag=0x06
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum Constraint {
+    RateLimit(u32),          // tag 0x01 — messages per second
+    CreditMultiplier(u32),   // tag 0x02 — basis points (10000 = 1.0x)
+    MaxTopics(u32),          // tag 0x03 — topic subscription limit
+    TimeLock(u64),           // tag 0x04 — block height before which action is locked
+    RequiresQuorum(u32),     // tag 0x05 — minimum votes (absolute count)
+    Tag(String),             // tag 0x06 — escape hatch for domain-specific labels
+}
+```
+
+**Design note:** `CreditMultiplier` uses basis points (u32) instead of f64 for determinism. 10000 = 1.0x, 15000 = 1.5x.
+
+**Hashing:** `hash_constraint(c)` = BLAKE3(TAG_CONSTRAINT ++ constraint_tag_byte ++ value_bytes)
+- For `u32` values: 4 bytes LE
+- For `u64` values: 8 bytes LE
+- For `Tag(s)`: len_u32_le(s.as_bytes()) ++ s.as_bytes()
+
+### 4.5 EdgeSource
+
+```rust
+/// Variant order is FROZEN. Do not reorder. Append only.
+/// Tag bytes: CclContract=0x01, TrustScore=0x02, GovernanceVote=0x03, Static=0x04
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum EdgeSource {
+    CclContract(String),     // tag 0x01 — contract hash or ID
+    TrustScore(String),      // tag 0x02 — trust graph identifier
+    GovernanceVote(String),  // tag 0x03 — proposal ID
+    Static(String),          // tag 0x04 — hardcoded/bootstrap grants
+}
+```
+
+**Hashing:** `hash_edge_source(es)` = BLAKE3(TAG_EDGE_SOURCE ++ source_tag_byte ++ len_u32_le(inner.as_bytes()) ++ inner.as_bytes())
+
+### 4.6 CapabilityEdge
+
+The fundamental unit of the graph: "subject S can do action A on resource R, with constraints C, granted by source E, valid at height H."
+
+```rust
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct CapabilityEdge {
+    pub subject: SubjectId,
+    pub action: Action,
+    pub resource: ResourceId,
+    pub constraints: Vec<Constraint>,  // sorted, deduped
+    pub source: EdgeSource,
+    pub valid_at: Option<BlockHeight>,
+}
+```
+
+**Invariant:** `constraints` is always sorted and deduped. The constructor enforces this.
+
+**Hashing:** `hash_edge(e)` = BLAKE3 of field-by-field update:
+```
+hasher.update(TAG_EDGE)
+hasher.update(hash_subject(e.subject))
+hasher.update(hash_action(e.action))
+hasher.update(hash_resource(e.resource))
+hasher.update(len_u32_le(e.constraints.len()))
+for c in &e.constraints { hasher.update(hash_constraint(c)) }
+hasher.update(hash_edge_source(e.source))
+hasher.update(hash_option_height(e.valid_at))
+```
+
+## 5. Canonicalization Rules
+
+All types implement `Ord`. Canonical ordering is the foundation of deterministic hashing.
+
+### 5.1 Edge Set Canonicalization
+
+Given a `Vec<CapabilityEdge>`:
+1. Sort by `Ord` (subject → action → resource → constraints → source → valid_at)
+2. Dedup consecutive equal edges
+3. Hash: BLAKE3(TAG_EDGE_SET ++ len_u32_le(edges.len()) ++ hash(edge_0) ++ hash(edge_1) ++ ...)
+
+### 5.2 Constraint Canonicalization
+
+Within a single edge, constraints are:
+1. Sorted by `Ord` (variant discriminant first, then inner value)
+2. Deduped — exact duplicates removed
+
+This is enforced at construction time by `CapabilityEdge::new()`.
+
+### 5.3 No HashMap Anywhere
+
+The canonical model uses only `Vec`, `String`, and fixed-size types. No `HashMap`, no `BTreeMap`, no `HashSet`. All collections are sorted `Vec`s. This eliminates iteration-order nondeterminism.
+
+## 6. Deterministic Hashing Specification
+
+### 6.1 Core Principles
+
+1. **Length-prefix all variable-length fields.** Every `String`, `&[u8]`, or `Vec<T>` is preceded by its length as `u32` little-endian. This prevents ambiguous concatenations (e.g., `"ab" ++ "cd"` vs `"a" ++ "bcd"`).
+
+2. **Explicit tag bytes for all enums.** Every enum variant has a hardcoded tag byte constant. We NEVER cast `variant as u8` or rely on discriminant values. Tag byte constants are defined as named constants with comments noting they are frozen.
+
+3. **Variant order is frozen.** Every enum has a comment: "Variant order is FROZEN. Do not reorder. Append only." New variants get the next sequential tag byte.
+
+4. **Option encoding.** `None` = single byte 0x00. `Some(v)` = byte 0x01 ++ encoded(v). For `Option<BlockHeight>`, `encoded(v)` = `v.0 as u64` as 8 bytes LE.
+
+5. **BLAKE3 only.** All hashing uses BLAKE3. Output is 32 bytes.
+
+### 6.2 Tag Byte Constants
+
+```rust
+// Top-level type tags
+const TAG_SUBJECT: u8       = 0x10;
+const TAG_ACTION: u8        = 0x11;
+const TAG_RESOURCE: u8      = 0x12;
+const TAG_CONSTRAINT: u8    = 0x13;
+const TAG_EDGE_SOURCE: u8   = 0x14;
+const TAG_EDGE: u8          = 0x15;
+const TAG_EDGE_SET: u8      = 0x16;
+
+// ResourceKind tags — FROZEN, append only
+const RESOURCE_ENTITY: u8   = 0x01;
+const RESOURCE_SCOPE: u8    = 0x02;
+const RESOURCE_ASSET: u8    = 0x03;
+const RESOURCE_CONTRACT: u8 = 0x04;
+const RESOURCE_SYSTEM: u8   = 0x05;
+
+// Constraint tags — FROZEN, append only
+const CONSTRAINT_RATE_LIMIT: u8         = 0x01;
+const CONSTRAINT_CREDIT_MULTIPLIER: u8  = 0x02;
+const CONSTRAINT_MAX_TOPICS: u8         = 0x03;
+const CONSTRAINT_TIME_LOCK: u8          = 0x04;
+const CONSTRAINT_REQUIRES_QUORUM: u8    = 0x05;
+const CONSTRAINT_TAG: u8               = 0x06;
+
+// EdgeSource tags — FROZEN, append only
+const SOURCE_CCL_CONTRACT: u8     = 0x01;
+const SOURCE_TRUST_SCORE: u8      = 0x02;
+const SOURCE_GOVERNANCE_VOTE: u8  = 0x03;
+const SOURCE_STATIC: u8           = 0x04;
+```
+
+### 6.3 Length-Prefix Helper
+
+```rust
+fn hash_bytes(hasher: &mut blake3::Hasher, data: &[u8]) {
+    hasher.update(&(data.len() as u32).to_le_bytes());
+    hasher.update(data);
+}
+
+fn hash_option_height(hasher: &mut blake3::Hasher, h: Option<BlockHeight>) {
+    match h {
+        None => hasher.update(&[0x00]),
+        Some(height) => {
+            hasher.update(&[0x01]);
+            hasher.update(&(height.0 as u64).to_le_bytes());
+        }
+    }
+}
+```
+
+## 7. Builder and Query Interfaces
+
+### 7.1 CapabilitySource Trait
+
+```rust
+/// An adapter that can produce capability edges from a domain-specific source.
+///
+/// Implementations live in `icn-authz::adapters` (Phase B1).
+/// The trait is defined here so B0 can write tests with mock sources.
+pub trait CapabilitySource: Send + Sync {
+    /// Return all capability edges this source knows about for the given subject.
+    fn edges_for_subject(&self, subject: &SubjectId) -> Vec<CapabilityEdge>;
+
+    /// Return all capability edges this source can produce.
+    fn all_edges(&self) -> Vec<CapabilityEdge>;
+}
+```
+
+### 7.2 GraphBuilder
+
+```rust
+/// Constructs a CapabilityGraph from one or more CapabilitySource adapters.
+pub struct GraphBuilder {
+    sources: Vec<Box<dyn CapabilitySource>>,
+}
+
+impl GraphBuilder {
+    pub fn new() -> Self { Self { sources: vec![] } }
+
+    pub fn add_source(mut self, source: Box<dyn CapabilitySource>) -> Self {
+        self.sources.push(source);
+        self
+    }
+
+    /// Build the graph by polling all sources and canonicalizing.
+    pub fn build(&self) -> CapabilityGraph {
+        let mut edges: Vec<CapabilityEdge> = self.sources
+            .iter()
+            .flat_map(|s| s.all_edges())
+            .collect();
+        edges.sort();
+        edges.dedup();
+        CapabilityGraph { edges }
+    }
+
+    /// Build a subject-scoped graph (cheaper than full build).
+    pub fn build_for_subject(&self, subject: &SubjectId) -> CapabilityGraph {
+        let mut edges: Vec<CapabilityEdge> = self.sources
+            .iter()
+            .flat_map(|s| s.edges_for_subject(subject))
+            .collect();
+        edges.sort();
+        edges.dedup();
+        CapabilityGraph { edges }
+    }
+}
+```
+
+### 7.3 CapabilityGraph and Query
+
+```rust
+pub struct CapabilityGraph {
+    edges: Vec<CapabilityEdge>,  // sorted, deduped
+}
+
+impl CapabilityGraph {
+    pub fn edges(&self) -> &[CapabilityEdge] { &self.edges }
+
+    /// Deterministic hash of the entire edge set.
+    pub fn hash(&self) -> [u8; 32] { hash_edge_set(&self.edges) }
+
+    /// Query: can subject do action on resource?
+    pub fn query(&self, subject: &SubjectId, action: &Action, resource: &ResourceId) -> Decision {
+        let matching: Vec<usize> = self.edges.iter()
+            .enumerate()
+            .filter(|(_, e)| e.subject == *subject && e.action == *action && e.resource == *resource)
+            .map(|(i, _)| i)
+            .collect();
+
+        Decision {
+            allowed: !matching.is_empty(),
+            matching_edges: matching,
+        }
+    }
+}
+
+/// B0 decision: just allowed + matching edge indices. No string reasons.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Decision {
+    pub allowed: bool,
+    pub matching_edges: Vec<usize>,
+}
+```
+
+## 8. Error Type
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum AuthzError {
+    #[error("invalid subject ID (must start with 'did:'): {0}")]
+    InvalidSubjectId(String),
+
+    #[error("invalid action format (expected 'domain:verb[:subverb]'): {0}")]
+    InvalidAction(String),
+}
+```
+
+Minimal for B0. No `anyhow`, no error chains. Grows as adapters land in B1.
+
+## 9. Crate Structure (B0)
+
+```
+icn/crates/icn-authz/
+  Cargo.toml
+  src/
+    lib.rs              # pub mod model; pub mod graph; pub mod error;
+    error.rs            # AuthzError
+    model/
+      mod.rs            # pub mod ids; pub mod edge; pub mod hash;
+      ids.rs            # SubjectId, Action, ResourceKind, ResourceId, Constraint, EdgeSource
+      edge.rs           # CapabilityEdge, CapabilityGraph, Decision
+      hash.rs           # All hashing: tag constants, hash_*, hash_edge_set
+    graph/
+      mod.rs            # pub mod builder; pub mod query;
+      builder.rs        # CapabilitySource trait, GraphBuilder
+      query.rs          # Query logic (may be inlined into CapabilityGraph for B0)
+```
+
+**Cargo.toml dependencies (B0):**
+```toml
+[dependencies]
+blake3 = "1.8"
+serde = { workspace = true, features = ["derive"] }
+thiserror.workspace = true
+icn-kernel-api = { path = "../icn-kernel-api" }  # BlockHeight only
+
+[dev-dependencies]
+serde_json = "1.0"
+```
+
+## 10. Testing Requirements
+
+### 10.1 Ordering Invariant Tests
+- Create 100 random edges, sort, verify sorted
+- Serialize to JSON, deserialize, verify still sorted
+- Two graphs built from same edges in different insertion order → same `Ord` result
+
+### 10.2 Hash Determinism Tests
+- Same edge set → same hash (trivial)
+- Same edges, different insertion order → same hash after canonicalization
+- Add one edge → hash changes
+- Remove one edge → hash changes
+- Change one constraint → hash changes
+
+### 10.3 Action Normalization Tests
+- `"GOVERNANCE:PROPOSE"` normalizes to `"governance:propose"`
+- `"  ledger:transfer  "` normalizes to `"ledger:transfer"`
+- `""` → error
+- `"single"` → error (no colon)
+- `"a::b"` → error (empty segment)
+- `"a:b:c"` → ok (3 segments)
+
+### 10.4 SubjectId Validation Tests
+- `"did:icn:abc123"` → ok
+- `"not-a-did"` → error
+- `""` → error
+
+### 10.5 GraphBuilder Tests
+- Empty graph → empty edges, query returns `allowed: false`
+- Two sources with overlapping edges → deduped
+- `build_for_subject` returns subset
+
+## 11. Follow-On Phases
+
+### B1: Adapters (after B0 merges)
+- `CclCapabilitySource`: reads CCL contracts, emits edges
+- `TrustCapabilitySource`: reads trust scores, emits rate-limit edges
+- `JwtCapabilitySource`: reads token claims, emits edges
+
+### B2: PowerDiff Integration
+- `PowerDiff::from_graphs(before: &CapabilityGraph, after: &CapabilityGraph)`
+- Replaces the current `PowerDiff` stub with real edge-level diff
+
+### B3: Pipeline Wiring
+- Amendment lifecycle calls `GraphBuilder` before/after
+- `InvariantGate` receives `PowerDiff` from graph comparison
+- Full safety pipeline: CCL change → graph diff → invariant check → receipt

--- a/docs/plans/2026-02-23-authz-capability-graph-impl-plan.md
+++ b/docs/plans/2026-02-23-authz-capability-graph-impl-plan.md
@@ -1,0 +1,1736 @@
+# Authz Capability Graph (Phase B0) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Scaffold the `icn-authz` crate with canonical model types, deterministic BLAKE3 hashing (length-prefixed, explicit tag bytes), `CapabilitySource` trait, `GraphBuilder`, and `CapabilityGraph` with query — the foundation for unifying ICN's four authorization systems.
+
+**Architecture:** New app-layer crate `icn-authz` in `icn/crates/`. Domain-agnostic model in `icn-authz::model` (promotable to kernel later). Graph builder/query in `icn-authz::graph`. No persistence, no domain adapters (those are Phase B1). All hashing uses BLAKE3 with length-prefixed variable-length fields and explicit frozen tag byte constants.
+
+**Tech Stack:** Rust (1.88.0), BLAKE3, serde, thiserror, icn-kernel-api (BlockHeight type alias = u64)
+
+**Design doc:** `docs/plans/2026-02-23-authz-capability-graph-design.md`
+
+---
+
+## Landmines & Gotchas
+
+1. **`BlockHeight` is `pub type BlockHeight = u64;`** (a type alias, NOT a newtype). The design doc says `height.0 as u64` — this is WRONG. Use `height` directly since it IS u64. Defined in `icn-kernel-api/src/invariants.rs:10`.
+
+2. **`blake3` is NOT a workspace dependency.** Declare it directly: `blake3 = "1.8"` (same as `icn-governance`).
+
+3. **`serde_json` is NOT a workspace dependency for dev-deps.** Use `serde_json = "1.0"` directly in `[dev-dependencies]`.
+
+4. **Workspace members list is NOT alphabetical.** Insert `"crates/icn-authz"` after `"crates/icn-naming"` (line 36) to keep app-layer crates grouped near the end.
+
+5. **Workspace lints say `unwrap_used = "warn"`.** Tests that call `.unwrap()` will emit warnings. Use `#[allow(clippy::unwrap_used)]` on test modules, or use `expect("reason")` (also warned but with context).
+
+6. **No `icn-identity` dependency needed for B0.** `SubjectId` is just a validated String newtype — no DID resolution or crypto needed yet.
+
+7. **`Ord` derive on enums** uses variant declaration order as discriminant. Our "frozen variant order" comments + explicit tag bytes in hashing mean the `Ord` derive is safe for sorting, but hashing MUST use the explicit constants, never rely on derived discriminants.
+
+---
+
+### Task 1: Scaffold crate and workspace registration
+
+**Files:**
+- Create: `icn/crates/icn-authz/Cargo.toml`
+- Create: `icn/crates/icn-authz/src/lib.rs`
+- Create: `icn/crates/icn-authz/src/error.rs`
+- Modify: `icn/Cargo.toml:3-41` (workspace members)
+- Modify: `icn/Cargo.toml:117-147` (workspace dependencies)
+
+**Step 1: Create directory structure**
+
+```bash
+mkdir -p icn/crates/icn-authz/src/model
+mkdir -p icn/crates/icn-authz/src/graph
+```
+
+**Step 2: Write `icn/crates/icn-authz/Cargo.toml`**
+
+```toml
+[package]
+name = "icn-authz"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+blake3 = "1.8"
+serde = { workspace = true, features = ["derive"] }
+thiserror.workspace = true
+icn-kernel-api = { path = "../icn-kernel-api" }
+
+[dev-dependencies]
+serde_json = "1.0"
+
+[lints]
+workspace = true
+```
+
+**Step 3: Write `icn/crates/icn-authz/src/error.rs`**
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum AuthzError {
+    #[error("invalid subject ID (must start with 'did:'): {0}")]
+    InvalidSubjectId(String),
+
+    #[error("invalid action format (expected 'domain:verb[:subverb]'): {0}")]
+    InvalidAction(String),
+}
+```
+
+**Step 4: Write `icn/crates/icn-authz/src/lib.rs`**
+
+```rust
+//! # ICN Authorization
+//!
+//! Canonical capability graph model for unifying ICN's authorization systems.
+//!
+//! ## Architecture
+//!
+//! - `model` — Domain-agnostic types: subjects, actions, resources, constraints, edges.
+//!   Designed to be liftable to `icn-kernel-api` in a future phase.
+//! - `graph` — Builder and query: `CapabilitySource` trait, `GraphBuilder`, `CapabilityGraph`.
+//! - `error` — Error types for validation failures.
+//!
+//! ## Meaning Firewall
+//!
+//! This is an **app-layer** crate. It interprets domain semantics (what capabilities mean).
+//! The kernel sees only hashes produced by this crate, never the capability model itself.
+
+pub mod error;
+pub mod graph;
+pub mod model;
+
+pub use error::AuthzError;
+```
+
+**Step 5: Write placeholder `icn/crates/icn-authz/src/model/mod.rs`**
+
+```rust
+pub mod hash;
+pub mod ids;
+pub mod edge;
+```
+
+**Step 6: Write placeholder `icn/crates/icn-authz/src/graph/mod.rs`**
+
+```rust
+pub mod builder;
+```
+
+**Step 7: Write placeholder `icn/crates/icn-authz/src/model/ids.rs`**
+
+```rust
+// Canonical identity and resource types — Task 2
+```
+
+**Step 8: Write placeholder `icn/crates/icn-authz/src/model/edge.rs`**
+
+```rust
+// CapabilityEdge and CapabilityGraph — Task 4
+```
+
+**Step 9: Write placeholder `icn/crates/icn-authz/src/model/hash.rs`**
+
+```rust
+// Deterministic BLAKE3 hashing — Task 3
+```
+
+**Step 10: Write placeholder `icn/crates/icn-authz/src/graph/builder.rs`**
+
+```rust
+// CapabilitySource trait and GraphBuilder — Task 5
+```
+
+**Step 11: Add to workspace members in `icn/Cargo.toml`**
+
+In the `members` array, after `"crates/icn-naming",` (line 36), add:
+
+```toml
+    "crates/icn-authz",
+```
+
+**Step 12: Add to workspace dependencies in `icn/Cargo.toml`**
+
+In the `[workspace.dependencies]` section, after `icn-naming = { path = "crates/icn-naming" }` (line 147), add:
+
+```toml
+icn-authz = { path = "crates/icn-authz" }
+```
+
+**Step 13: Verify the crate compiles**
+
+Run: `cd icn/icn && cargo check -p icn-authz`
+Expected: Compiles with 0 errors (warnings about empty files are OK)
+
+**Step 14: Run clippy**
+
+Run: `cd icn/icn && cargo clippy -p icn-authz --all-targets -- -D warnings`
+Expected: PASS
+
+**Step 15: Commit**
+
+```bash
+git add icn/crates/icn-authz/ icn/Cargo.toml
+git commit -m "feat(authz): scaffold icn-authz crate with workspace registration"
+```
+
+---
+
+### Task 2: Canonical identity types (SubjectId, Action, ResourceKind, ResourceId, Constraint, EdgeSource)
+
+**Files:**
+- Create: `icn/crates/icn-authz/src/model/ids.rs` (overwrite placeholder)
+
+**Step 1: Write the failing tests**
+
+Add the following test module at the bottom of `ids.rs`:
+
+```rust
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    // --- SubjectId ---
+
+    #[test]
+    fn subject_id_valid_did() {
+        let s = SubjectId::new("did:icn:abc123").unwrap();
+        assert_eq!(s.as_str(), "did:icn:abc123");
+    }
+
+    #[test]
+    fn subject_id_rejects_non_did() {
+        assert!(SubjectId::new("not-a-did").is_err());
+    }
+
+    #[test]
+    fn subject_id_rejects_empty() {
+        assert!(SubjectId::new("").is_err());
+    }
+
+    // --- Action ---
+
+    #[test]
+    fn action_normalizes_uppercase() {
+        let a = Action::new("GOVERNANCE:PROPOSE").unwrap();
+        assert_eq!(a.as_str(), "governance:propose");
+    }
+
+    #[test]
+    fn action_trims_whitespace() {
+        let a = Action::new("  ledger:transfer  ").unwrap();
+        assert_eq!(a.as_str(), "ledger:transfer");
+    }
+
+    #[test]
+    fn action_three_segments_ok() {
+        let a = Action::new("ledger:transfer:credit").unwrap();
+        assert_eq!(a.as_str(), "ledger:transfer:credit");
+        assert_eq!(a.domain(), "ledger");
+        assert_eq!(a.verb(), "transfer");
+    }
+
+    #[test]
+    fn action_rejects_empty() {
+        assert!(Action::new("").is_err());
+    }
+
+    #[test]
+    fn action_rejects_no_colon() {
+        assert!(Action::new("single").is_err());
+    }
+
+    #[test]
+    fn action_rejects_empty_segment() {
+        assert!(Action::new("a::b").is_err());
+    }
+
+    #[test]
+    fn action_rejects_non_ascii() {
+        assert!(Action::new("gov:propos\u{00e9}").is_err());
+    }
+
+    #[test]
+    fn action_allows_hyphens() {
+        let a = Action::new("compute:long-running").unwrap();
+        assert_eq!(a.as_str(), "compute:long-running");
+    }
+
+    // --- ResourceKind ordering ---
+
+    #[test]
+    fn resource_kind_ordering_is_declaration_order() {
+        assert!(ResourceKind::Entity < ResourceKind::Scope);
+        assert!(ResourceKind::Scope < ResourceKind::Asset);
+        assert!(ResourceKind::Asset < ResourceKind::Contract);
+        assert!(ResourceKind::Contract < ResourceKind::System);
+    }
+
+    // --- Constraint ordering ---
+
+    #[test]
+    fn constraint_variants_ordered_by_discriminant() {
+        let rate = Constraint::RateLimit(100);
+        let credit = Constraint::CreditMultiplier(10000);
+        let topics = Constraint::MaxTopics(50);
+        let timelock = Constraint::TimeLock(1000);
+        let quorum = Constraint::RequiresQuorum(3);
+        let tag = Constraint::Tag("x".into());
+        assert!(rate < credit);
+        assert!(credit < topics);
+        assert!(topics < timelock);
+        assert!(timelock < quorum);
+        assert!(quorum < tag);
+    }
+
+    #[test]
+    fn constraint_same_variant_orders_by_value() {
+        assert!(Constraint::RateLimit(10) < Constraint::RateLimit(20));
+        assert!(Constraint::Tag("a".into()) < Constraint::Tag("b".into()));
+    }
+
+    // --- EdgeSource ordering ---
+
+    #[test]
+    fn edge_source_ordering_is_declaration_order() {
+        assert!(EdgeSource::CclContract("a".into()) < EdgeSource::TrustScore("a".into()));
+        assert!(EdgeSource::TrustScore("a".into()) < EdgeSource::GovernanceVote("a".into()));
+        assert!(EdgeSource::GovernanceVote("a".into()) < EdgeSource::Static("a".into()));
+    }
+
+    // --- Serde round-trip ---
+
+    #[test]
+    fn subject_id_serde_roundtrip() {
+        let s = SubjectId::new("did:icn:test").unwrap();
+        let json = serde_json::to_string(&s).unwrap();
+        let back: SubjectId = serde_json::from_str(&json).unwrap();
+        assert_eq!(s, back);
+    }
+
+    #[test]
+    fn action_serde_roundtrip() {
+        let a = Action::new("governance:propose").unwrap();
+        let json = serde_json::to_string(&a).unwrap();
+        let back: Action = serde_json::from_str(&json).unwrap();
+        assert_eq!(a, back);
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd icn/icn && cargo test -p icn-authz --lib`
+Expected: FAIL — `SubjectId`, `Action`, etc. not defined yet
+
+**Step 3: Write the implementation**
+
+Write the full `ids.rs` with types + the test module from Step 1:
+
+```rust
+use serde::{Deserialize, Serialize};
+
+use crate::AuthzError;
+
+/// An actor in the capability graph. Always a DID.
+///
+/// Validated on construction: must start with "did:" prefix.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct SubjectId(String);
+
+impl SubjectId {
+    pub fn new(did: impl Into<String>) -> Result<Self, AuthzError> {
+        let s = did.into();
+        if !s.starts_with("did:") {
+            return Err(AuthzError::InvalidSubjectId(s));
+        }
+        Ok(Self(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A capability action. Lowercased, trimmed, colon-separated segments.
+///
+/// Format: `domain:verb[:subverb]`. Only ASCII alphanumeric, colon, and hyphen.
+/// Soft normalization: lowercases and trims on construction.
+///
+/// Examples: "governance:propose", "ledger:transfer:credit", "compute:submit"
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct Action(String);
+
+impl Action {
+    pub fn new(raw: impl Into<String>) -> Result<Self, AuthzError> {
+        let s = raw.into().trim().to_ascii_lowercase();
+        let segments: Vec<&str> = s.split(':').collect();
+        if segments.len() < 2 || segments.iter().any(|seg| seg.is_empty()) {
+            return Err(AuthzError::InvalidAction(s));
+        }
+        if !s
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == ':' || c == '-')
+        {
+            return Err(AuthzError::InvalidAction(s));
+        }
+        Ok(Self(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn domain(&self) -> &str {
+        self.0.split(':').next().expect("validated in new()")
+    }
+
+    pub fn verb(&self) -> &str {
+        self.0.splitn(3, ':').nth(1).expect("validated in new()")
+    }
+}
+
+/// Variant order is FROZEN. Do not reorder. Append only.
+/// Tag bytes: Entity=0x01, Scope=0x02, Asset=0x03, Contract=0x04, System=0x05
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum ResourceKind {
+    /// tag 0x01 — cooperatives, communities, federations, individuals
+    Entity,
+    /// tag 0x02 — cells, namespaces, governance scopes
+    Scope,
+    /// tag 0x03 — ledger accounts, credit lines, treasury
+    Asset,
+    /// tag 0x04 — CCL contracts, amendments
+    Contract,
+    /// tag 0x05 — protocol parameters, invariant config
+    System,
+}
+
+/// A typed resource identifier.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ResourceId {
+    pub kind: ResourceKind,
+    pub id: String,
+}
+
+impl ResourceId {
+    pub fn new(kind: ResourceKind, id: impl Into<String>) -> Self {
+        Self {
+            kind,
+            id: id.into(),
+        }
+    }
+}
+
+/// Variant order is FROZEN. Do not reorder. Append only.
+/// Tag bytes: RateLimit=0x01, CreditMultiplier=0x02, MaxTopics=0x03,
+///            TimeLock=0x04, RequiresQuorum=0x05, Tag=0x06
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum Constraint {
+    /// tag 0x01 — messages per second
+    RateLimit(u32),
+    /// tag 0x02 — basis points (10000 = 1.0x)
+    CreditMultiplier(u32),
+    /// tag 0x03 — topic subscription limit
+    MaxTopics(u32),
+    /// tag 0x04 — block height before which action is locked
+    TimeLock(u64),
+    /// tag 0x05 — minimum votes (absolute count)
+    RequiresQuorum(u32),
+    /// tag 0x06 — escape hatch for domain-specific labels
+    Tag(String),
+}
+
+/// Variant order is FROZEN. Do not reorder. Append only.
+/// Tag bytes: CclContract=0x01, TrustScore=0x02, GovernanceVote=0x03, Static=0x04
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum EdgeSource {
+    /// tag 0x01 — contract hash or ID
+    CclContract(String),
+    /// tag 0x02 — trust graph identifier
+    TrustScore(String),
+    /// tag 0x03 — proposal ID
+    GovernanceVote(String),
+    /// tag 0x04 — hardcoded/bootstrap grants
+    Static(String),
+}
+
+// --- tests at bottom (see Step 1) ---
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd icn/icn && cargo test -p icn-authz --lib`
+Expected: 17 tests PASS
+
+**Step 5: Run clippy**
+
+Run: `cd icn/icn && cargo clippy -p icn-authz --all-targets -- -D warnings`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add icn/crates/icn-authz/src/model/ids.rs
+git commit -m "feat(authz): canonical identity types with validation and ordering"
+```
+
+---
+
+### Task 3: Deterministic hashing (tag constants, hash functions, length-prefixing)
+
+**Files:**
+- Create: `icn/crates/icn-authz/src/model/hash.rs` (overwrite placeholder)
+
+**Step 1: Write the failing tests**
+
+Add the following test module at the bottom of `hash.rs`:
+
+```rust
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::model::ids::*;
+
+    fn test_subject() -> SubjectId {
+        SubjectId::new("did:icn:alice").unwrap()
+    }
+
+    fn test_action() -> Action {
+        Action::new("governance:propose").unwrap()
+    }
+
+    fn test_resource() -> ResourceId {
+        ResourceId::new(ResourceKind::Entity, "coop-1")
+    }
+
+    // --- Determinism ---
+
+    #[test]
+    fn hash_subject_deterministic() {
+        let a = hash_subject(&test_subject());
+        let b = hash_subject(&test_subject());
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn hash_action_deterministic() {
+        let a = hash_action(&test_action());
+        let b = hash_action(&test_action());
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn hash_resource_deterministic() {
+        let a = hash_resource(&test_resource());
+        let b = hash_resource(&test_resource());
+        assert_eq!(a, b);
+    }
+
+    // --- Different inputs → different hashes ---
+
+    #[test]
+    fn hash_subject_differs_for_different_dids() {
+        let a = hash_subject(&SubjectId::new("did:icn:alice").unwrap());
+        let b = hash_subject(&SubjectId::new("did:icn:bob").unwrap());
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn hash_action_differs_for_different_actions() {
+        let a = hash_action(&Action::new("governance:propose").unwrap());
+        let b = hash_action(&Action::new("governance:vote").unwrap());
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn hash_resource_differs_for_different_kinds() {
+        let a = hash_resource(&ResourceId::new(ResourceKind::Entity, "x"));
+        let b = hash_resource(&ResourceId::new(ResourceKind::Asset, "x"));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn hash_resource_differs_for_different_ids() {
+        let a = hash_resource(&ResourceId::new(ResourceKind::Entity, "x"));
+        let b = hash_resource(&ResourceId::new(ResourceKind::Entity, "y"));
+        assert_ne!(a, b);
+    }
+
+    // --- Constraint hashing ---
+
+    #[test]
+    fn hash_constraint_deterministic() {
+        let c = Constraint::RateLimit(100);
+        assert_eq!(hash_constraint(&c), hash_constraint(&c));
+    }
+
+    #[test]
+    fn hash_constraint_differs_across_variants() {
+        let a = hash_constraint(&Constraint::RateLimit(100));
+        let b = hash_constraint(&Constraint::MaxTopics(100));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn hash_constraint_tag_differs_by_string() {
+        let a = hash_constraint(&Constraint::Tag("foo".into()));
+        let b = hash_constraint(&Constraint::Tag("bar".into()));
+        assert_ne!(a, b);
+    }
+
+    // --- EdgeSource hashing ---
+
+    #[test]
+    fn hash_edge_source_deterministic() {
+        let s = EdgeSource::Static("bootstrap".into());
+        assert_eq!(hash_edge_source(&s), hash_edge_source(&s));
+    }
+
+    #[test]
+    fn hash_edge_source_differs_across_variants() {
+        let a = hash_edge_source(&EdgeSource::CclContract("x".into()));
+        let b = hash_edge_source(&EdgeSource::Static("x".into()));
+        assert_ne!(a, b);
+    }
+
+    // --- Option<BlockHeight> hashing ---
+
+    #[test]
+    fn hash_option_height_none_vs_some_differ() {
+        let mut h1 = blake3::Hasher::new();
+        hash_option_height(&mut h1, None);
+        let mut h2 = blake3::Hasher::new();
+        hash_option_height(&mut h2, Some(0));
+        assert_ne!(h1.finalize().as_bytes(), h2.finalize().as_bytes());
+    }
+
+    #[test]
+    fn hash_option_height_different_values_differ() {
+        let mut h1 = blake3::Hasher::new();
+        hash_option_height(&mut h1, Some(100));
+        let mut h2 = blake3::Hasher::new();
+        hash_option_height(&mut h2, Some(200));
+        assert_ne!(h1.finalize().as_bytes(), h2.finalize().as_bytes());
+    }
+
+    // --- Length-prefix prevents ambiguity ---
+
+    #[test]
+    fn length_prefix_prevents_concatenation_ambiguity() {
+        // "ab" ++ "cd" must differ from "a" ++ "bcd"
+        let mut h1 = blake3::Hasher::new();
+        hash_bytes(&mut h1, b"ab");
+        hash_bytes(&mut h1, b"cd");
+
+        let mut h2 = blake3::Hasher::new();
+        hash_bytes(&mut h2, b"a");
+        hash_bytes(&mut h2, b"bcd");
+
+        assert_ne!(h1.finalize().as_bytes(), h2.finalize().as_bytes());
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd icn/icn && cargo test -p icn-authz --lib`
+Expected: FAIL — hash functions not defined
+
+**Step 3: Write the implementation**
+
+Write the full `hash.rs` with constants + functions + test module:
+
+```rust
+use icn_kernel_api::BlockHeight;
+
+use crate::model::ids::*;
+
+// ─── Top-level type tags ───────────────────────────────────────────
+// These tag bytes are FROZEN. Do not change values. Append only.
+pub(crate) const TAG_SUBJECT: u8 = 0x10;
+pub(crate) const TAG_ACTION: u8 = 0x11;
+pub(crate) const TAG_RESOURCE: u8 = 0x12;
+pub(crate) const TAG_CONSTRAINT: u8 = 0x13;
+pub(crate) const TAG_EDGE_SOURCE: u8 = 0x14;
+pub(crate) const TAG_EDGE: u8 = 0x15;
+pub(crate) const TAG_EDGE_SET: u8 = 0x16;
+
+// ─── ResourceKind tag bytes ────────────────────────────────────────
+// FROZEN. Do not reorder. Append only. Must match ResourceKind variant order.
+pub(crate) const RESOURCE_ENTITY: u8 = 0x01;
+pub(crate) const RESOURCE_SCOPE: u8 = 0x02;
+pub(crate) const RESOURCE_ASSET: u8 = 0x03;
+pub(crate) const RESOURCE_CONTRACT: u8 = 0x04;
+pub(crate) const RESOURCE_SYSTEM: u8 = 0x05;
+
+// ─── Constraint tag bytes ──────────────────────────────────────────
+// FROZEN. Do not reorder. Append only. Must match Constraint variant order.
+pub(crate) const CONSTRAINT_RATE_LIMIT: u8 = 0x01;
+pub(crate) const CONSTRAINT_CREDIT_MULTIPLIER: u8 = 0x02;
+pub(crate) const CONSTRAINT_MAX_TOPICS: u8 = 0x03;
+pub(crate) const CONSTRAINT_TIME_LOCK: u8 = 0x04;
+pub(crate) const CONSTRAINT_REQUIRES_QUORUM: u8 = 0x05;
+pub(crate) const CONSTRAINT_TAG: u8 = 0x06;
+
+// ─── EdgeSource tag bytes ──────────────────────────────────────────
+// FROZEN. Do not reorder. Append only. Must match EdgeSource variant order.
+pub(crate) const SOURCE_CCL_CONTRACT: u8 = 0x01;
+pub(crate) const SOURCE_TRUST_SCORE: u8 = 0x02;
+pub(crate) const SOURCE_GOVERNANCE_VOTE: u8 = 0x03;
+pub(crate) const SOURCE_STATIC: u8 = 0x04;
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+/// Length-prefix then append bytes. Prevents concatenation ambiguity.
+pub(crate) fn hash_bytes(hasher: &mut blake3::Hasher, data: &[u8]) {
+    hasher.update(&(data.len() as u32).to_le_bytes());
+    hasher.update(data);
+}
+
+/// Hash an Option<BlockHeight>. None = 0x00. Some(h) = 0x01 ++ h as u64 LE.
+/// BlockHeight is a type alias for u64, so no .0 accessor needed.
+pub(crate) fn hash_option_height(hasher: &mut blake3::Hasher, h: Option<BlockHeight>) {
+    match h {
+        None => hasher.update(&[0x00]),
+        Some(height) => {
+            hasher.update(&[0x01]);
+            hasher.update(&height.to_le_bytes());
+        }
+    }
+}
+
+// ─── Per-type hash functions ───────────────────────────────────────
+
+pub fn hash_subject(s: &SubjectId) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&[TAG_SUBJECT]);
+    hash_bytes(&mut hasher, s.as_str().as_bytes());
+    *hasher.finalize().as_bytes()
+}
+
+pub fn hash_action(a: &Action) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&[TAG_ACTION]);
+    hash_bytes(&mut hasher, a.as_str().as_bytes());
+    *hasher.finalize().as_bytes()
+}
+
+fn resource_kind_tag(kind: &ResourceKind) -> u8 {
+    match kind {
+        ResourceKind::Entity => RESOURCE_ENTITY,
+        ResourceKind::Scope => RESOURCE_SCOPE,
+        ResourceKind::Asset => RESOURCE_ASSET,
+        ResourceKind::Contract => RESOURCE_CONTRACT,
+        ResourceKind::System => RESOURCE_SYSTEM,
+    }
+}
+
+pub fn hash_resource(r: &ResourceId) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&[TAG_RESOURCE]);
+    hasher.update(&[resource_kind_tag(&r.kind)]);
+    hash_bytes(&mut hasher, r.id.as_bytes());
+    *hasher.finalize().as_bytes()
+}
+
+fn constraint_tag(c: &Constraint) -> u8 {
+    match c {
+        Constraint::RateLimit(_) => CONSTRAINT_RATE_LIMIT,
+        Constraint::CreditMultiplier(_) => CONSTRAINT_CREDIT_MULTIPLIER,
+        Constraint::MaxTopics(_) => CONSTRAINT_MAX_TOPICS,
+        Constraint::TimeLock(_) => CONSTRAINT_TIME_LOCK,
+        Constraint::RequiresQuorum(_) => CONSTRAINT_REQUIRES_QUORUM,
+        Constraint::Tag(_) => CONSTRAINT_TAG,
+    }
+}
+
+pub fn hash_constraint(c: &Constraint) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&[TAG_CONSTRAINT]);
+    hasher.update(&[constraint_tag(c)]);
+    match c {
+        Constraint::RateLimit(v) => hasher.update(&v.to_le_bytes()),
+        Constraint::CreditMultiplier(v) => hasher.update(&v.to_le_bytes()),
+        Constraint::MaxTopics(v) => hasher.update(&v.to_le_bytes()),
+        Constraint::TimeLock(v) => hasher.update(&v.to_le_bytes()),
+        Constraint::RequiresQuorum(v) => hasher.update(&v.to_le_bytes()),
+        Constraint::Tag(s) => {
+            hash_bytes(&mut hasher, s.as_bytes());
+            return *hasher.finalize().as_bytes();
+        }
+    };
+    *hasher.finalize().as_bytes()
+}
+
+fn edge_source_tag(es: &EdgeSource) -> u8 {
+    match es {
+        EdgeSource::CclContract(_) => SOURCE_CCL_CONTRACT,
+        EdgeSource::TrustScore(_) => SOURCE_TRUST_SCORE,
+        EdgeSource::GovernanceVote(_) => SOURCE_GOVERNANCE_VOTE,
+        EdgeSource::Static(_) => SOURCE_STATIC,
+    }
+}
+
+fn edge_source_inner(es: &EdgeSource) -> &str {
+    match es {
+        EdgeSource::CclContract(s)
+        | EdgeSource::TrustScore(s)
+        | EdgeSource::GovernanceVote(s)
+        | EdgeSource::Static(s) => s,
+    }
+}
+
+pub fn hash_edge_source(es: &EdgeSource) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&[TAG_EDGE_SOURCE]);
+    hasher.update(&[edge_source_tag(es)]);
+    hash_bytes(&mut hasher, edge_source_inner(es).as_bytes());
+    *hasher.finalize().as_bytes()
+}
+
+/// Hash a sorted, deduped slice of edges into a single edge-set hash.
+pub fn hash_edge_set(edges: &[crate::model::edge::CapabilityEdge]) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&[TAG_EDGE_SET]);
+    hasher.update(&(edges.len() as u32).to_le_bytes());
+    for edge in edges {
+        hasher.update(&crate::model::edge::hash_edge(edge));
+    }
+    *hasher.finalize().as_bytes()
+}
+
+// --- tests at bottom (see Step 1) ---
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd icn/icn && cargo test -p icn-authz --lib`
+Expected: All hash tests PASS (edge tests may fail if edge.rs is still placeholder — that's expected)
+
+**Step 5: Run clippy**
+
+Run: `cd icn/icn && cargo clippy -p icn-authz --all-targets -- -D warnings`
+Expected: PASS (or warn about unused hash_edge_set if edge module is still placeholder — acceptable)
+
+**Step 6: Commit**
+
+```bash
+git add icn/crates/icn-authz/src/model/hash.rs
+git commit -m "feat(authz): deterministic BLAKE3 hashing with length-prefixed fields and explicit tags"
+```
+
+---
+
+### Task 4: CapabilityEdge, CapabilityGraph, Decision, and edge hashing
+
+**Files:**
+- Create: `icn/crates/icn-authz/src/model/edge.rs` (overwrite placeholder)
+
+**Step 1: Write the failing tests**
+
+Add the following test module at the bottom of `edge.rs`:
+
+```rust
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::model::ids::*;
+
+    fn alice() -> SubjectId {
+        SubjectId::new("did:icn:alice").unwrap()
+    }
+
+    fn bob() -> SubjectId {
+        SubjectId::new("did:icn:bob").unwrap()
+    }
+
+    fn propose() -> Action {
+        Action::new("governance:propose").unwrap()
+    }
+
+    fn vote() -> Action {
+        Action::new("governance:vote").unwrap()
+    }
+
+    fn coop_resource() -> ResourceId {
+        ResourceId::new(ResourceKind::Entity, "coop-1")
+    }
+
+    fn make_edge(subject: SubjectId, action: Action) -> CapabilityEdge {
+        CapabilityEdge::new(
+            subject,
+            action,
+            coop_resource(),
+            vec![Constraint::RateLimit(10)],
+            EdgeSource::Static("bootstrap".into()),
+            None,
+        )
+    }
+
+    // --- Constructor sorts and dedupes constraints ---
+
+    #[test]
+    fn constructor_sorts_constraints() {
+        let edge = CapabilityEdge::new(
+            alice(),
+            propose(),
+            coop_resource(),
+            vec![
+                Constraint::Tag("z".into()),
+                Constraint::RateLimit(10),
+                Constraint::MaxTopics(5),
+            ],
+            EdgeSource::Static("test".into()),
+            None,
+        );
+        let kinds: Vec<&str> = edge
+            .constraints
+            .iter()
+            .map(|c| match c {
+                Constraint::RateLimit(_) => "RateLimit",
+                Constraint::MaxTopics(_) => "MaxTopics",
+                Constraint::Tag(_) => "Tag",
+                _ => "other",
+            })
+            .collect();
+        assert_eq!(kinds, vec!["RateLimit", "MaxTopics", "Tag"]);
+    }
+
+    #[test]
+    fn constructor_dedupes_constraints() {
+        let edge = CapabilityEdge::new(
+            alice(),
+            propose(),
+            coop_resource(),
+            vec![Constraint::RateLimit(10), Constraint::RateLimit(10)],
+            EdgeSource::Static("test".into()),
+            None,
+        );
+        assert_eq!(edge.constraints.len(), 1);
+    }
+
+    // --- Edge hashing ---
+
+    #[test]
+    fn hash_edge_deterministic() {
+        let e = make_edge(alice(), propose());
+        assert_eq!(hash_edge(&e), hash_edge(&e));
+    }
+
+    #[test]
+    fn hash_edge_differs_by_subject() {
+        let a = hash_edge(&make_edge(alice(), propose()));
+        let b = hash_edge(&make_edge(bob(), propose()));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn hash_edge_differs_by_action() {
+        let a = hash_edge(&make_edge(alice(), propose()));
+        let b = hash_edge(&make_edge(alice(), vote()));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn hash_edge_differs_by_valid_at() {
+        let mut e1 = make_edge(alice(), propose());
+        e1.valid_at = None;
+        let mut e2 = make_edge(alice(), propose());
+        e2.valid_at = Some(100);
+        assert_ne!(hash_edge(&e1), hash_edge(&e2));
+    }
+
+    // --- Graph hashing ---
+
+    #[test]
+    fn graph_hash_deterministic() {
+        let edges = vec![make_edge(alice(), propose()), make_edge(bob(), vote())];
+        let g = CapabilityGraph::from_edges(edges.clone());
+        let g2 = CapabilityGraph::from_edges(edges);
+        assert_eq!(g.hash(), g2.hash());
+    }
+
+    #[test]
+    fn graph_hash_order_independent() {
+        let e1 = make_edge(alice(), propose());
+        let e2 = make_edge(bob(), vote());
+        let g1 = CapabilityGraph::from_edges(vec![e1.clone(), e2.clone()]);
+        let g2 = CapabilityGraph::from_edges(vec![e2, e1]);
+        assert_eq!(g1.hash(), g2.hash());
+    }
+
+    #[test]
+    fn graph_hash_changes_when_edge_added() {
+        let e1 = make_edge(alice(), propose());
+        let e2 = make_edge(bob(), vote());
+        let g1 = CapabilityGraph::from_edges(vec![e1.clone()]);
+        let g2 = CapabilityGraph::from_edges(vec![e1, e2]);
+        assert_ne!(g1.hash(), g2.hash());
+    }
+
+    #[test]
+    fn graph_hash_changes_when_constraint_changes() {
+        let mut e1 = make_edge(alice(), propose());
+        e1.constraints = vec![Constraint::RateLimit(10)];
+        let mut e2 = make_edge(alice(), propose());
+        e2.constraints = vec![Constraint::RateLimit(20)];
+        // These are different edges so graphs differ
+        let g1 = CapabilityGraph::from_edges(vec![e1]);
+        let g2 = CapabilityGraph::from_edges(vec![e2]);
+        assert_ne!(g1.hash(), g2.hash());
+    }
+
+    // --- Query ---
+
+    #[test]
+    fn query_allowed_when_edge_exists() {
+        let g = CapabilityGraph::from_edges(vec![make_edge(alice(), propose())]);
+        let d = g.query(&alice(), &propose(), &coop_resource());
+        assert!(d.allowed);
+        assert_eq!(d.matching_edges, vec![0]);
+    }
+
+    #[test]
+    fn query_denied_when_no_edge() {
+        let g = CapabilityGraph::from_edges(vec![make_edge(alice(), propose())]);
+        let d = g.query(&bob(), &propose(), &coop_resource());
+        assert!(!d.allowed);
+        assert!(d.matching_edges.is_empty());
+    }
+
+    #[test]
+    fn query_denied_on_empty_graph() {
+        let g = CapabilityGraph::from_edges(vec![]);
+        let d = g.query(&alice(), &propose(), &coop_resource());
+        assert!(!d.allowed);
+    }
+
+    // --- Serde roundtrip ---
+
+    #[test]
+    fn edge_serde_roundtrip() {
+        let e = make_edge(alice(), propose());
+        let json = serde_json::to_string(&e).unwrap();
+        let back: CapabilityEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(e, back);
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd icn/icn && cargo test -p icn-authz --lib`
+Expected: FAIL — `CapabilityEdge`, `CapabilityGraph` not defined
+
+**Step 3: Write the implementation**
+
+Write the full `edge.rs`:
+
+```rust
+use icn_kernel_api::BlockHeight;
+use serde::{Deserialize, Serialize};
+
+use crate::model::hash::*;
+use crate::model::ids::*;
+
+/// A capability edge: "subject can do action on resource, with constraints, from source, at height."
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct CapabilityEdge {
+    pub subject: SubjectId,
+    pub action: Action,
+    pub resource: ResourceId,
+    pub constraints: Vec<Constraint>,
+    pub source: EdgeSource,
+    pub valid_at: Option<BlockHeight>,
+}
+
+impl CapabilityEdge {
+    /// Create an edge. Constraints are sorted and deduped automatically.
+    pub fn new(
+        subject: SubjectId,
+        action: Action,
+        resource: ResourceId,
+        mut constraints: Vec<Constraint>,
+        source: EdgeSource,
+        valid_at: Option<BlockHeight>,
+    ) -> Self {
+        constraints.sort();
+        constraints.dedup();
+        Self {
+            subject,
+            action,
+            resource,
+            constraints,
+            source,
+            valid_at,
+        }
+    }
+}
+
+/// Hash a single edge field-by-field using BLAKE3.
+pub fn hash_edge(e: &CapabilityEdge) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&[TAG_EDGE]);
+    hasher.update(&hash_subject(&e.subject));
+    hasher.update(&hash_action(&e.action));
+    hasher.update(&hash_resource(&e.resource));
+    hasher.update(&(e.constraints.len() as u32).to_le_bytes());
+    for c in &e.constraints {
+        hasher.update(&hash_constraint(c));
+    }
+    hasher.update(&hash_edge_source(&e.source));
+    hash_option_height(&mut hasher, e.valid_at);
+    *hasher.finalize().as_bytes()
+}
+
+/// B0 decision: allowed + matching edge indices. No string reasons.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Decision {
+    pub allowed: bool,
+    pub matching_edges: Vec<usize>,
+}
+
+/// A computed capability graph: sorted, deduped edges.
+#[derive(Clone, Debug)]
+pub struct CapabilityGraph {
+    edges: Vec<CapabilityEdge>,
+}
+
+impl CapabilityGraph {
+    /// Create a graph from edges. Sorts and dedupes.
+    pub fn from_edges(mut edges: Vec<CapabilityEdge>) -> Self {
+        edges.sort();
+        edges.dedup();
+        Self { edges }
+    }
+
+    pub fn edges(&self) -> &[CapabilityEdge] {
+        &self.edges
+    }
+
+    /// Deterministic hash of the entire edge set.
+    pub fn hash(&self) -> [u8; 32] {
+        hash_edge_set(&self.edges)
+    }
+
+    /// Query: can subject do action on resource?
+    pub fn query(
+        &self,
+        subject: &SubjectId,
+        action: &Action,
+        resource: &ResourceId,
+    ) -> Decision {
+        let matching: Vec<usize> = self
+            .edges
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| {
+                e.subject == *subject && e.action == *action && e.resource == *resource
+            })
+            .map(|(i, _)| i)
+            .collect();
+
+        Decision {
+            allowed: !matching.is_empty(),
+            matching_edges: matching,
+        }
+    }
+}
+
+// --- tests at bottom (see Step 1) ---
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd icn/icn && cargo test -p icn-authz --lib`
+Expected: All tests PASS (hash tests from Task 3 + edge/graph tests from Task 4)
+
+**Step 5: Run clippy**
+
+Run: `cd icn/icn && cargo clippy -p icn-authz --all-targets -- -D warnings`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add icn/crates/icn-authz/src/model/edge.rs
+git commit -m "feat(authz): CapabilityEdge, CapabilityGraph, Decision with deterministic hashing"
+```
+
+---
+
+### Task 5: GraphBuilder and CapabilitySource trait
+
+**Files:**
+- Create: `icn/crates/icn-authz/src/graph/builder.rs` (overwrite placeholder)
+
+**Step 1: Write the failing tests**
+
+Add the following test module at the bottom of `builder.rs`:
+
+```rust
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::model::edge::CapabilityGraph;
+    use crate::model::ids::*;
+
+    fn alice() -> SubjectId {
+        SubjectId::new("did:icn:alice").unwrap()
+    }
+
+    fn bob() -> SubjectId {
+        SubjectId::new("did:icn:bob").unwrap()
+    }
+
+    fn propose() -> Action {
+        Action::new("governance:propose").unwrap()
+    }
+
+    fn coop_resource() -> ResourceId {
+        ResourceId::new(ResourceKind::Entity, "coop-1")
+    }
+
+    fn make_edge(subject: SubjectId, action: Action) -> CapabilityEdge {
+        CapabilityEdge::new(
+            subject,
+            action,
+            coop_resource(),
+            vec![Constraint::RateLimit(10)],
+            EdgeSource::Static("bootstrap".into()),
+            None,
+        )
+    }
+
+    /// Mock source that returns a fixed set of edges.
+    struct MockSource {
+        edges: Vec<CapabilityEdge>,
+    }
+
+    impl CapabilitySource for MockSource {
+        fn edges_for_subject(&self, subject: &SubjectId) -> Vec<CapabilityEdge> {
+            self.edges
+                .iter()
+                .filter(|e| e.subject == *subject)
+                .cloned()
+                .collect()
+        }
+
+        fn all_edges(&self) -> Vec<CapabilityEdge> {
+            self.edges.clone()
+        }
+    }
+
+    #[test]
+    fn empty_builder_produces_empty_graph() {
+        let g = GraphBuilder::new().build();
+        assert!(g.edges().is_empty());
+        let d = g.query(&alice(), &propose(), &coop_resource());
+        assert!(!d.allowed);
+    }
+
+    #[test]
+    fn single_source_produces_edges() {
+        let source = MockSource {
+            edges: vec![make_edge(alice(), propose())],
+        };
+        let g = GraphBuilder::new()
+            .add_source(Box::new(source))
+            .build();
+        assert_eq!(g.edges().len(), 1);
+    }
+
+    #[test]
+    fn two_sources_with_overlapping_edges_deduped() {
+        let edge = make_edge(alice(), propose());
+        let s1 = MockSource {
+            edges: vec![edge.clone()],
+        };
+        let s2 = MockSource {
+            edges: vec![edge],
+        };
+        let g = GraphBuilder::new()
+            .add_source(Box::new(s1))
+            .add_source(Box::new(s2))
+            .build();
+        assert_eq!(g.edges().len(), 1);
+    }
+
+    #[test]
+    fn two_sources_with_different_edges_merged() {
+        let s1 = MockSource {
+            edges: vec![make_edge(alice(), propose())],
+        };
+        let s2 = MockSource {
+            edges: vec![make_edge(bob(), propose())],
+        };
+        let g = GraphBuilder::new()
+            .add_source(Box::new(s1))
+            .add_source(Box::new(s2))
+            .build();
+        assert_eq!(g.edges().len(), 2);
+    }
+
+    #[test]
+    fn build_for_subject_returns_subset() {
+        let s1 = MockSource {
+            edges: vec![make_edge(alice(), propose()), make_edge(bob(), propose())],
+        };
+        let g = GraphBuilder::new()
+            .add_source(Box::new(s1))
+            .build_for_subject(&alice());
+        assert_eq!(g.edges().len(), 1);
+        assert_eq!(g.edges()[0].subject, alice());
+    }
+
+    #[test]
+    fn build_same_edges_different_order_same_hash() {
+        let e1 = make_edge(alice(), propose());
+        let e2 = make_edge(bob(), propose());
+        let s1 = MockSource {
+            edges: vec![e1.clone(), e2.clone()],
+        };
+        let s2 = MockSource {
+            edges: vec![e2, e1],
+        };
+        let g1 = GraphBuilder::new().add_source(Box::new(s1)).build();
+        let g2 = GraphBuilder::new().add_source(Box::new(s2)).build();
+        assert_eq!(g1.hash(), g2.hash());
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd icn/icn && cargo test -p icn-authz --lib`
+Expected: FAIL — `CapabilitySource`, `GraphBuilder` not defined
+
+**Step 3: Write the implementation**
+
+Write the full `builder.rs`:
+
+```rust
+use crate::model::edge::{CapabilityEdge, CapabilityGraph};
+use crate::model::ids::SubjectId;
+
+/// An adapter that produces capability edges from a domain-specific source.
+///
+/// Implementations live in `icn-authz::adapters` (Phase B1).
+/// The trait is defined here so B0 can write tests with mock sources.
+pub trait CapabilitySource: Send + Sync {
+    /// Return all capability edges this source knows about for the given subject.
+    fn edges_for_subject(&self, subject: &SubjectId) -> Vec<CapabilityEdge>;
+
+    /// Return all capability edges this source can produce.
+    fn all_edges(&self) -> Vec<CapabilityEdge>;
+}
+
+/// Constructs a CapabilityGraph from one or more CapabilitySource adapters.
+pub struct GraphBuilder {
+    sources: Vec<Box<dyn CapabilitySource>>,
+}
+
+impl GraphBuilder {
+    pub fn new() -> Self {
+        Self {
+            sources: Vec::new(),
+        }
+    }
+
+    pub fn add_source(mut self, source: Box<dyn CapabilitySource>) -> Self {
+        self.sources.push(source);
+        self
+    }
+
+    /// Build the graph by polling all sources and canonicalizing.
+    pub fn build(&self) -> CapabilityGraph {
+        let edges: Vec<CapabilityEdge> = self
+            .sources
+            .iter()
+            .flat_map(|s| s.all_edges())
+            .collect();
+        CapabilityGraph::from_edges(edges)
+    }
+
+    /// Build a subject-scoped graph (cheaper than full build).
+    pub fn build_for_subject(&self, subject: &SubjectId) -> CapabilityGraph {
+        let edges: Vec<CapabilityEdge> = self
+            .sources
+            .iter()
+            .flat_map(|s| s.edges_for_subject(subject))
+            .collect();
+        CapabilityGraph::from_edges(edges)
+    }
+}
+
+impl Default for GraphBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// --- tests at bottom (see Step 1) ---
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd icn/icn && cargo test -p icn-authz --lib`
+Expected: All tests PASS
+
+**Step 5: Run clippy**
+
+Run: `cd icn/icn && cargo clippy -p icn-authz --all-targets -- -D warnings`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add icn/crates/icn-authz/src/graph/builder.rs
+git commit -m "feat(authz): CapabilitySource trait and GraphBuilder with dedup and canonicalization"
+```
+
+---
+
+### Task 6: Wire up re-exports in lib.rs and model/mod.rs
+
+**Files:**
+- Modify: `icn/crates/icn-authz/src/lib.rs`
+- Modify: `icn/crates/icn-authz/src/model/mod.rs`
+- Modify: `icn/crates/icn-authz/src/graph/mod.rs`
+
+**Step 1: Update `model/mod.rs` with re-exports**
+
+```rust
+pub mod edge;
+pub mod hash;
+pub mod ids;
+
+pub use edge::{CapabilityEdge, CapabilityGraph, Decision};
+pub use ids::{Action, Constraint, EdgeSource, ResourceId, ResourceKind, SubjectId};
+```
+
+**Step 2: Update `graph/mod.rs` with re-exports**
+
+```rust
+pub mod builder;
+
+pub use builder::{CapabilitySource, GraphBuilder};
+```
+
+**Step 3: Update `lib.rs` with re-exports**
+
+```rust
+//! # ICN Authorization
+//!
+//! Canonical capability graph model for unifying ICN's authorization systems.
+//!
+//! ## Architecture
+//!
+//! - `model` — Domain-agnostic types: subjects, actions, resources, constraints, edges.
+//!   Designed to be liftable to `icn-kernel-api` in a future phase.
+//! - `graph` — Builder and query: `CapabilitySource` trait, `GraphBuilder`, `CapabilityGraph`.
+//! - `error` — Error types for validation failures.
+//!
+//! ## Meaning Firewall
+//!
+//! This is an **app-layer** crate. It interprets domain semantics (what capabilities mean).
+//! The kernel sees only hashes produced by this crate, never the capability model itself.
+
+pub mod error;
+pub mod graph;
+pub mod model;
+
+pub use error::AuthzError;
+pub use graph::{CapabilitySource, GraphBuilder};
+pub use model::{
+    Action, CapabilityEdge, CapabilityGraph, Constraint, Decision, EdgeSource, ResourceId,
+    ResourceKind, SubjectId,
+};
+```
+
+**Step 4: Run full test suite**
+
+Run: `cd icn/icn && cargo test -p icn-authz --lib`
+Expected: All tests PASS
+
+**Step 5: Run clippy**
+
+Run: `cd icn/icn && cargo clippy -p icn-authz --all-targets -- -D warnings`
+Expected: PASS
+
+**Step 6: Run fmt**
+
+Run: `cd icn/icn && cargo fmt -p icn-authz --check`
+Expected: PASS
+
+**Step 7: Commit**
+
+```bash
+git add icn/crates/icn-authz/src/lib.rs icn/crates/icn-authz/src/model/mod.rs icn/crates/icn-authz/src/graph/mod.rs
+git commit -m "feat(authz): wire up re-exports for public API surface"
+```
+
+---
+
+### Task 7: Integration tests (ordering invariants, hash determinism across boundaries)
+
+**Files:**
+- Create: `icn/crates/icn-authz/tests/capability_graph_integration.rs`
+
+**Step 1: Write integration tests**
+
+```rust
+//! Integration tests for the icn-authz capability graph.
+//!
+//! These test cross-module properties: ordering invariants hold after
+//! serialization round-trips, hash determinism across graph boundaries,
+//! and the full build→query→hash pipeline.
+
+#[allow(clippy::unwrap_used)]
+mod capability_graph_integration {
+    use icn_authz::*;
+
+    fn alice() -> SubjectId {
+        SubjectId::new("did:icn:alice").unwrap()
+    }
+
+    fn bob() -> SubjectId {
+        SubjectId::new("did:icn:bob").unwrap()
+    }
+
+    fn carol() -> SubjectId {
+        SubjectId::new("did:icn:carol").unwrap()
+    }
+
+    fn propose() -> Action {
+        Action::new("governance:propose").unwrap()
+    }
+
+    fn vote() -> Action {
+        Action::new("governance:vote").unwrap()
+    }
+
+    fn transfer() -> Action {
+        Action::new("ledger:transfer").unwrap()
+    }
+
+    fn coop() -> ResourceId {
+        ResourceId::new(ResourceKind::Entity, "coop-1")
+    }
+
+    fn make_edge(
+        subject: SubjectId,
+        action: Action,
+        resource: ResourceId,
+        source: EdgeSource,
+    ) -> CapabilityEdge {
+        CapabilityEdge::new(
+            subject,
+            action,
+            resource,
+            vec![Constraint::RateLimit(10)],
+            source,
+            None,
+        )
+    }
+
+    struct FixedSource(Vec<CapabilityEdge>);
+
+    impl CapabilitySource for FixedSource {
+        fn edges_for_subject(&self, subject: &SubjectId) -> Vec<CapabilityEdge> {
+            self.0
+                .iter()
+                .filter(|e| e.subject == *subject)
+                .cloned()
+                .collect()
+        }
+        fn all_edges(&self) -> Vec<CapabilityEdge> {
+            self.0.clone()
+        }
+    }
+
+    // --- Ordering invariant: sort survives serde round-trip ---
+
+    #[test]
+    fn edges_sorted_after_serde_roundtrip() {
+        let edges = vec![
+            make_edge(carol(), vote(), coop(), EdgeSource::Static("s".into())),
+            make_edge(alice(), propose(), coop(), EdgeSource::Static("s".into())),
+            make_edge(bob(), transfer(), coop(), EdgeSource::Static("s".into())),
+        ];
+        let g = CapabilityGraph::from_edges(edges);
+
+        let json = serde_json::to_string(g.edges()).unwrap();
+        let deserialized: Vec<CapabilityEdge> = serde_json::from_str(&json).unwrap();
+        let g2 = CapabilityGraph::from_edges(deserialized);
+
+        assert_eq!(g.hash(), g2.hash());
+    }
+
+    // --- Full pipeline: two sources → build → query → hash ---
+
+    #[test]
+    fn full_pipeline_two_sources() {
+        let s1 = FixedSource(vec![
+            make_edge(
+                alice(),
+                propose(),
+                coop(),
+                EdgeSource::CclContract("contract-1".into()),
+            ),
+            make_edge(
+                bob(),
+                vote(),
+                coop(),
+                EdgeSource::TrustScore("trust-main".into()),
+            ),
+        ]);
+        let s2 = FixedSource(vec![make_edge(
+            carol(),
+            transfer(),
+            ResourceId::new(ResourceKind::Asset, "treasury"),
+            EdgeSource::GovernanceVote("prop-42".into()),
+        )]);
+
+        let g = GraphBuilder::new()
+            .add_source(Box::new(s1))
+            .add_source(Box::new(s2))
+            .build();
+
+        assert_eq!(g.edges().len(), 3);
+
+        // Alice can propose
+        let d = g.query(&alice(), &propose(), &coop());
+        assert!(d.allowed);
+
+        // Bob can vote
+        let d = g.query(&bob(), &vote(), &coop());
+        assert!(d.allowed);
+
+        // Carol can transfer on treasury
+        let d = g.query(
+            &carol(),
+            &transfer(),
+            &ResourceId::new(ResourceKind::Asset, "treasury"),
+        );
+        assert!(d.allowed);
+
+        // Alice cannot vote
+        let d = g.query(&alice(), &vote(), &coop());
+        assert!(!d.allowed);
+    }
+
+    // --- Hash stability: same edges from different source configs → same hash ---
+
+    #[test]
+    fn hash_stable_across_source_configurations() {
+        let e1 = make_edge(alice(), propose(), coop(), EdgeSource::Static("s".into()));
+        let e2 = make_edge(bob(), vote(), coop(), EdgeSource::Static("s".into()));
+
+        // Config A: one source with both edges
+        let g1 = GraphBuilder::new()
+            .add_source(Box::new(FixedSource(vec![e1.clone(), e2.clone()])))
+            .build();
+
+        // Config B: two sources, one edge each
+        let g2 = GraphBuilder::new()
+            .add_source(Box::new(FixedSource(vec![e1])))
+            .add_source(Box::new(FixedSource(vec![e2])))
+            .build();
+
+        assert_eq!(g1.hash(), g2.hash());
+    }
+
+    // --- Subject-scoped build produces correct subset ---
+
+    #[test]
+    fn build_for_subject_correct_subset() {
+        let source = FixedSource(vec![
+            make_edge(alice(), propose(), coop(), EdgeSource::Static("s".into())),
+            make_edge(alice(), vote(), coop(), EdgeSource::Static("s".into())),
+            make_edge(bob(), propose(), coop(), EdgeSource::Static("s".into())),
+        ]);
+
+        let g = GraphBuilder::new()
+            .add_source(Box::new(source))
+            .build_for_subject(&alice());
+
+        assert_eq!(g.edges().len(), 2);
+        assert!(g.edges().iter().all(|e| e.subject == alice()));
+    }
+
+    // --- Multiple matching edges for same subject+action+resource ---
+
+    #[test]
+    fn query_returns_multiple_matching_edges() {
+        let e1 = CapabilityEdge::new(
+            alice(),
+            propose(),
+            coop(),
+            vec![Constraint::RateLimit(10)],
+            EdgeSource::CclContract("c1".into()),
+            None,
+        );
+        let e2 = CapabilityEdge::new(
+            alice(),
+            propose(),
+            coop(),
+            vec![Constraint::RateLimit(20)],
+            EdgeSource::TrustScore("t1".into()),
+            None,
+        );
+        let g = CapabilityGraph::from_edges(vec![e1, e2]);
+        let d = g.query(&alice(), &propose(), &coop());
+        assert!(d.allowed);
+        assert_eq!(d.matching_edges.len(), 2);
+    }
+}
+```
+
+**Step 2: Run integration tests**
+
+Run: `cd icn/icn && cargo test -p icn-authz --test capability_graph_integration`
+Expected: All 6 tests PASS
+
+**Step 3: Run full crate test suite one final time**
+
+Run: `cd icn/icn && cargo test -p icn-authz`
+Expected: All unit + integration tests PASS
+
+**Step 4: Run fmt + clippy on the entire crate**
+
+Run: `cd icn/icn && cargo fmt -p icn-authz --check && cargo clippy -p icn-authz --all-targets -- -D warnings`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add icn/crates/icn-authz/tests/
+git commit -m "test(authz): integration tests for ordering, hash determinism, and full pipeline"
+```
+
+---
+
+## Final Verification
+
+After all 7 tasks, run:
+
+```bash
+cd icn/icn && cargo fmt --all --check
+cd icn/icn && cargo clippy -p icn-authz --all-targets -- -D warnings
+cd icn/icn && cargo test -p icn-authz
+```
+
+Expected: fmt clean, clippy clean, all tests pass.
+
+**Test count target:** ~50 tests total (17 ids + 15 hash + 13 edge/graph + 6 builder + 6 integration = ~57).

--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -1933,6 +1933,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2806,6 +2812,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "icn-authz"
+version = "0.1.0"
+dependencies = [
+ "blake3",
+ "icn-kernel-api",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "icn-ccl"
 version = "0.1.0"
 dependencies = [
@@ -3348,6 +3365,8 @@ dependencies = [
  "icn-store",
  "icn-time",
  "icn-trust",
+ "metrics",
+ "metrics-util 0.19.1",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -4592,12 +4611,32 @@ dependencies = [
  "indexmap",
  "ipnet",
  "metrics",
- "metrics-util",
+ "metrics-util 0.20.1",
  "quanta",
  "rustls",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "aho-corasick",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "metrics",
+ "ordered-float 4.6.0",
+ "quanta",
+ "radix_trie",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -4702,6 +4741,15 @@ name = "mutually_exclusive_features"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94e1e6445d314f972ff7395df2de295fe51b71821694f0b0e1e79c4f12c8577"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "nix"
@@ -5641,6 +5689,16 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"

--- a/icn/Cargo.toml
+++ b/icn/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "crates/icn-encoding",
     "crates/icn-api",
     "crates/icn-naming",
+    "crates/icn-authz",
     "apps/governance",
     "apps/membership",
     "apps/ledger",
@@ -145,6 +146,7 @@ icn-encoding = { path = "crates/icn-encoding" }
 icn-coop = { path = "crates/icn-coop" }
 icn-api = { path = "crates/icn-api" }
 icn-naming = { path = "crates/icn-naming" }
+icn-authz = { path = "crates/icn-authz" }
 
 [workspace.lints.clippy]
 # Error handling - warn for now, will be upgraded to deny after cleanup

--- a/icn/crates/icn-authz/Cargo.toml
+++ b/icn/crates/icn-authz/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "icn-authz"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+blake3 = "1.8"
+serde = { workspace = true, features = ["derive"] }
+thiserror.workspace = true
+icn-kernel-api = { path = "../icn-kernel-api" }
+
+[dev-dependencies]
+serde_json = "1.0"
+
+[lints]
+workspace = true

--- a/icn/crates/icn-authz/src/adapters/mod.rs
+++ b/icn/crates/icn-authz/src/adapters/mod.rs
@@ -1,0 +1,1 @@
+// Domain-specific adapters (CCL, Trust, JWT) -- implemented in Phase B1

--- a/icn/crates/icn-authz/src/error.rs
+++ b/icn/crates/icn-authz/src/error.rs
@@ -1,0 +1,8 @@
+#[derive(Debug, thiserror::Error)]
+pub enum AuthzError {
+    #[error("invalid subject ID (must start with 'did:'): {0}")]
+    InvalidSubjectId(String),
+
+    #[error("invalid action format (expected 'domain:verb[:subverb]'): {0}")]
+    InvalidAction(String),
+}

--- a/icn/crates/icn-authz/src/graph/builder.rs
+++ b/icn/crates/icn-authz/src/graph/builder.rs
@@ -1,0 +1,1 @@
+// CapabilitySource trait and GraphBuilder -- implemented in Task 4

--- a/icn/crates/icn-authz/src/graph/builder.rs
+++ b/icn/crates/icn-authz/src/graph/builder.rs
@@ -1,1 +1,217 @@
-// CapabilitySource trait and GraphBuilder -- implemented in Task 4
+//! [`CapabilitySource`] trait and [`GraphBuilder`] for assembling capability graphs
+//! from one or more domain-specific sources.
+//!
+//! Implementations of `CapabilitySource` will live in `icn-authz::adapters` (Phase B1).
+//! The trait is defined here so B0 can write tests with mock sources.
+
+use crate::model::edge::{CapabilityEdge, CapabilityGraph};
+use crate::model::ids::SubjectId;
+
+// ---------------------------------------------------------------------------
+// CapabilitySource trait
+// ---------------------------------------------------------------------------
+
+/// An adapter that produces capability edges from a domain-specific source.
+///
+/// Implementations live in `icn-authz::adapters` (Phase B1).
+/// The trait is defined here so B0 can write tests with mock sources.
+pub trait CapabilitySource: Send + Sync {
+    /// Return all capability edges this source knows about for the given subject.
+    fn edges_for_subject(&self, subject: &SubjectId) -> Vec<CapabilityEdge>;
+
+    /// Return all capability edges this source can produce.
+    fn all_edges(&self) -> Vec<CapabilityEdge>;
+}
+
+// ---------------------------------------------------------------------------
+// GraphBuilder
+// ---------------------------------------------------------------------------
+
+/// Assembles a [`CapabilityGraph`] from zero or more [`CapabilitySource`]s.
+///
+/// Builder pattern: create with `new()`, add sources, then `build()`.
+/// The resulting graph is sorted and deduplicated (canonical).
+pub struct GraphBuilder {
+    sources: Vec<Box<dyn CapabilitySource>>,
+}
+
+impl GraphBuilder {
+    /// Create a new builder with no sources.
+    pub fn new() -> Self {
+        Self {
+            sources: Vec::new(),
+        }
+    }
+
+    /// Add a capability source. Builder pattern -- returns self.
+    pub fn add_source(mut self, source: Box<dyn CapabilitySource>) -> Self {
+        self.sources.push(source);
+        self
+    }
+
+    /// Poll all sources via `all_edges()` and build a canonical graph.
+    ///
+    /// The resulting [`CapabilityGraph`] is sorted and deduplicated.
+    pub fn build(&self) -> CapabilityGraph {
+        let edges: Vec<CapabilityEdge> = self.sources.iter().flat_map(|s| s.all_edges()).collect();
+        CapabilityGraph::from_edges(edges)
+    }
+
+    /// Poll all sources for edges matching `subject` and build a canonical graph.
+    ///
+    /// The resulting [`CapabilityGraph`] is sorted and deduplicated.
+    pub fn build_for_subject(&self, subject: &SubjectId) -> CapabilityGraph {
+        let edges: Vec<CapabilityEdge> = self
+            .sources
+            .iter()
+            .flat_map(|s| s.edges_for_subject(subject))
+            .collect();
+        CapabilityGraph::from_edges(edges)
+    }
+}
+
+impl Default for GraphBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::model::ids::{Action, Constraint, EdgeSource, ResourceId, ResourceKind};
+
+    // -- Mock source --------------------------------------------------------
+
+    struct MockSource {
+        edges: Vec<CapabilityEdge>,
+    }
+
+    impl CapabilitySource for MockSource {
+        fn edges_for_subject(&self, subject: &SubjectId) -> Vec<CapabilityEdge> {
+            self.edges
+                .iter()
+                .filter(|e| e.subject == *subject)
+                .cloned()
+                .collect()
+        }
+
+        fn all_edges(&self) -> Vec<CapabilityEdge> {
+            self.edges.clone()
+        }
+    }
+
+    // -- Test helpers -------------------------------------------------------
+
+    fn alice() -> SubjectId {
+        SubjectId::new("did:icn:alice").unwrap()
+    }
+
+    fn bob() -> SubjectId {
+        SubjectId::new("did:icn:bob").unwrap()
+    }
+
+    fn propose() -> Action {
+        Action::new("governance:propose").unwrap()
+    }
+
+    fn coop_resource() -> ResourceId {
+        ResourceId::new(ResourceKind::Entity, "coop-1")
+    }
+
+    fn make_edge(subject: SubjectId, action: Action) -> CapabilityEdge {
+        CapabilityEdge::new(
+            subject,
+            action,
+            coop_resource(),
+            vec![Constraint::RateLimit(10)],
+            EdgeSource::Static("bootstrap".into()),
+            None,
+        )
+    }
+
+    // -- Tests --------------------------------------------------------------
+
+    #[test]
+    fn empty_builder_produces_empty_graph() {
+        let graph = GraphBuilder::new().build();
+        assert!(graph.edges().is_empty());
+        let decision = graph.query(&alice(), &propose(), &coop_resource());
+        assert!(!decision.allowed);
+    }
+
+    #[test]
+    fn single_source_produces_edges() {
+        let source = MockSource {
+            edges: vec![make_edge(alice(), propose())],
+        };
+        let graph = GraphBuilder::new().add_source(Box::new(source)).build();
+        assert_eq!(graph.edges().len(), 1);
+        let decision = graph.query(&alice(), &propose(), &coop_resource());
+        assert!(decision.allowed);
+    }
+
+    #[test]
+    fn two_sources_with_overlapping_edges_deduped() {
+        let edge = make_edge(alice(), propose());
+        let source_a = MockSource {
+            edges: vec![edge.clone()],
+        };
+        let source_b = MockSource { edges: vec![edge] };
+        let graph = GraphBuilder::new()
+            .add_source(Box::new(source_a))
+            .add_source(Box::new(source_b))
+            .build();
+        assert_eq!(graph.edges().len(), 1);
+    }
+
+    #[test]
+    fn two_sources_with_different_edges_merged() {
+        let source_a = MockSource {
+            edges: vec![make_edge(alice(), propose())],
+        };
+        let source_b = MockSource {
+            edges: vec![make_edge(bob(), propose())],
+        };
+        let graph = GraphBuilder::new()
+            .add_source(Box::new(source_a))
+            .add_source(Box::new(source_b))
+            .build();
+        assert_eq!(graph.edges().len(), 2);
+    }
+
+    #[test]
+    fn build_for_subject_returns_subset() {
+        let source = MockSource {
+            edges: vec![make_edge(alice(), propose()), make_edge(bob(), propose())],
+        };
+        let graph = GraphBuilder::new()
+            .add_source(Box::new(source))
+            .build_for_subject(&alice());
+        assert_eq!(graph.edges().len(), 1);
+        assert_eq!(graph.edges()[0].subject, alice());
+    }
+
+    #[test]
+    fn build_same_edges_different_order_same_hash() {
+        let edge_a = make_edge(alice(), propose());
+        let edge_b = make_edge(bob(), propose());
+
+        let source_ab = MockSource {
+            edges: vec![edge_a.clone(), edge_b.clone()],
+        };
+        let source_ba = MockSource {
+            edges: vec![edge_b, edge_a],
+        };
+
+        let graph_ab = GraphBuilder::new().add_source(Box::new(source_ab)).build();
+        let graph_ba = GraphBuilder::new().add_source(Box::new(source_ba)).build();
+
+        assert_eq!(graph_ab.hash(), graph_ba.hash());
+    }
+}

--- a/icn/crates/icn-authz/src/graph/mod.rs
+++ b/icn/crates/icn-authz/src/graph/mod.rs
@@ -1,0 +1,1 @@
+pub mod builder;

--- a/icn/crates/icn-authz/src/graph/mod.rs
+++ b/icn/crates/icn-authz/src/graph/mod.rs
@@ -1,1 +1,3 @@
 pub mod builder;
+
+pub use builder::{CapabilitySource, GraphBuilder};

--- a/icn/crates/icn-authz/src/lib.rs
+++ b/icn/crates/icn-authz/src/lib.rs
@@ -19,3 +19,8 @@ pub mod graph;
 pub mod model;
 
 pub use error::AuthzError;
+pub use graph::{CapabilitySource, GraphBuilder};
+pub use model::{
+    Action, CapabilityEdge, CapabilityGraph, Constraint, Decision, EdgeSource, ResourceId,
+    ResourceKind, SubjectId,
+};

--- a/icn/crates/icn-authz/src/lib.rs
+++ b/icn/crates/icn-authz/src/lib.rs
@@ -1,0 +1,21 @@
+//! # ICN Authorization
+//!
+//! Canonical capability graph model for unifying ICN's authorization systems.
+//!
+//! ## Architecture
+//!
+//! - `model` -- Domain-agnostic types: subjects, actions, resources, constraints, edges.
+//!   Designed to be liftable to `icn-kernel-api` in a future phase.
+//! - `graph` -- Builder and query: `CapabilitySource` trait, `GraphBuilder`, `CapabilityGraph`.
+//! - `error` -- Error types for validation failures.
+//!
+//! ## Meaning Firewall
+//!
+//! This is an **app-layer** crate. It interprets domain semantics (what capabilities mean).
+//! The kernel sees only hashes produced by this crate, never the capability model itself.
+
+pub mod error;
+pub mod graph;
+pub mod model;
+
+pub use error::AuthzError;

--- a/icn/crates/icn-authz/src/model/edge.rs
+++ b/icn/crates/icn-authz/src/model/edge.rs
@@ -1,0 +1,1 @@
+// CapabilityEdge and CapabilityGraph -- implemented in Task 4

--- a/icn/crates/icn-authz/src/model/edge.rs
+++ b/icn/crates/icn-authz/src/model/edge.rs
@@ -1,1 +1,208 @@
-// CapabilityEdge and CapabilityGraph -- implemented in Task 4
+//! Capability edges and the computed capability graph.
+//!
+//! A [`CapabilityEdge`] is the fundamental unit: subject S may perform action A
+//! on resource R, subject to constraints C, granted by source E, valid at block H.
+//!
+//! A [`CapabilityGraph`] is a sorted, deduplicated collection of edges with
+//! a simple query interface.
+
+use serde::{Deserialize, Serialize};
+
+use super::ids::{Action, BlockHeight, Constraint, EdgeSource, ResourceId, SubjectId};
+
+// ---------------------------------------------------------------------------
+// CapabilityEdge
+// ---------------------------------------------------------------------------
+
+/// A single capability grant: subject may perform action on resource.
+///
+/// Constraints are always sorted and deduplicated (canonicalized in constructor).
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct CapabilityEdge {
+    pub subject: SubjectId,
+    pub action: Action,
+    pub resource: ResourceId,
+    /// INVARIANT: always sorted and deduplicated.
+    pub constraints: Vec<Constraint>,
+    pub source: EdgeSource,
+    pub valid_at: Option<BlockHeight>,
+}
+
+impl CapabilityEdge {
+    /// Create a new edge, sorting and deduplicating constraints.
+    pub fn new(
+        subject: SubjectId,
+        action: Action,
+        resource: ResourceId,
+        mut constraints: Vec<Constraint>,
+        source: EdgeSource,
+        valid_at: Option<BlockHeight>,
+    ) -> Self {
+        constraints.sort();
+        constraints.dedup();
+        Self {
+            subject,
+            action,
+            resource,
+            constraints,
+            source,
+            valid_at,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decision
+// ---------------------------------------------------------------------------
+
+/// The result of a capability graph query (B0 minimal).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Decision {
+    /// Whether the action is allowed.
+    pub allowed: bool,
+    /// Indices into `CapabilityGraph::edges()` that matched the query.
+    pub matching_edges: Vec<usize>,
+}
+
+// ---------------------------------------------------------------------------
+// CapabilityGraph
+// ---------------------------------------------------------------------------
+
+/// A computed, canonical capability graph.
+///
+/// Edges are sorted and deduplicated. Not serializable -- use edges directly
+/// if you need to persist.
+#[derive(Clone, Debug)]
+pub struct CapabilityGraph {
+    edges: Vec<CapabilityEdge>,
+}
+
+impl CapabilityGraph {
+    /// Build a graph from a collection of edges, sorting and deduplicating.
+    pub fn from_edges(mut edges: Vec<CapabilityEdge>) -> Self {
+        edges.sort();
+        edges.dedup();
+        Self { edges }
+    }
+
+    /// Borrow the canonical edge list.
+    pub fn edges(&self) -> &[CapabilityEdge] {
+        &self.edges
+    }
+
+    /// Query whether `subject` may perform `action` on `resource`.
+    ///
+    /// Returns a [`Decision`] with matching edge indices. In B0, a match
+    /// requires exact equality on subject, action, and resource.
+    pub fn query(&self, subject: &SubjectId, action: &Action, resource: &ResourceId) -> Decision {
+        let matching_edges: Vec<usize> = self
+            .edges
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| {
+                e.subject == *subject && e.action == *action && e.resource == *resource
+            })
+            .map(|(i, _)| i)
+            .collect();
+
+        Decision {
+            allowed: !matching_edges.is_empty(),
+            matching_edges,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::model::ids::{EdgeSource, ResourceKind};
+
+    fn make_subject() -> SubjectId {
+        SubjectId::new("did:icn:alice").unwrap()
+    }
+
+    fn make_action() -> Action {
+        Action::new("ledger:transfer").unwrap()
+    }
+
+    fn make_resource() -> ResourceId {
+        ResourceId::new(ResourceKind::Asset, "credit-line-1")
+    }
+
+    fn make_edge(constraints: Vec<Constraint>) -> CapabilityEdge {
+        CapabilityEdge::new(
+            make_subject(),
+            make_action(),
+            make_resource(),
+            constraints,
+            EdgeSource::Static("test".into()),
+            None,
+        )
+    }
+
+    // -- CapabilityEdge -----------------------------------------------------
+
+    #[test]
+    fn constructor_sorts_constraints() {
+        let edge = make_edge(vec![Constraint::MaxTopics(5), Constraint::RateLimit(100)]);
+        assert_eq!(
+            edge.constraints,
+            vec![Constraint::RateLimit(100), Constraint::MaxTopics(5)]
+        );
+    }
+
+    #[test]
+    fn constructor_dedupes_constraints() {
+        let edge = make_edge(vec![
+            Constraint::RateLimit(100),
+            Constraint::MaxTopics(5),
+            Constraint::RateLimit(100),
+        ]);
+        assert_eq!(
+            edge.constraints,
+            vec![Constraint::RateLimit(100), Constraint::MaxTopics(5)]
+        );
+    }
+
+    // -- CapabilityGraph query ----------------------------------------------
+
+    #[test]
+    fn query_allowed_when_edge_exists() {
+        let graph = CapabilityGraph::from_edges(vec![make_edge(vec![])]);
+        let decision = graph.query(&make_subject(), &make_action(), &make_resource());
+        assert!(decision.allowed);
+        assert_eq!(decision.matching_edges, vec![0]);
+    }
+
+    #[test]
+    fn query_denied_when_no_matching_edge() {
+        let graph = CapabilityGraph::from_edges(vec![make_edge(vec![])]);
+        let other_subject = SubjectId::new("did:icn:bob").unwrap();
+        let decision = graph.query(&other_subject, &make_action(), &make_resource());
+        assert!(!decision.allowed);
+        assert!(decision.matching_edges.is_empty());
+    }
+
+    #[test]
+    fn query_denied_on_empty_graph() {
+        let graph = CapabilityGraph::from_edges(vec![]);
+        let decision = graph.query(&make_subject(), &make_action(), &make_resource());
+        assert!(!decision.allowed);
+        assert!(decision.matching_edges.is_empty());
+    }
+
+    // -- Serde roundtrip ----------------------------------------------------
+
+    #[test]
+    fn capability_edge_serde_roundtrip() {
+        let edge = make_edge(vec![Constraint::RateLimit(50), Constraint::MaxTopics(3)]);
+        let json = serde_json::to_string(&edge).unwrap();
+        let back: CapabilityEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(edge, back);
+    }
+}

--- a/icn/crates/icn-authz/src/model/edge.rs
+++ b/icn/crates/icn-authz/src/model/edge.rs
@@ -8,6 +8,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use super::hash::hash_edge_set;
 use super::ids::{Action, BlockHeight, Constraint, EdgeSource, ResourceId, SubjectId};
 
 // ---------------------------------------------------------------------------
@@ -88,6 +89,11 @@ impl CapabilityGraph {
     /// Borrow the canonical edge list.
     pub fn edges(&self) -> &[CapabilityEdge] {
         &self.edges
+    }
+
+    /// Deterministic hash of the entire edge set.
+    pub fn hash(&self) -> [u8; 32] {
+        hash_edge_set(&self.edges)
     }
 
     /// Query whether `subject` may perform `action` on `resource`.

--- a/icn/crates/icn-authz/src/model/hash.rs
+++ b/icn/crates/icn-authz/src/model/hash.rs
@@ -1,0 +1,1 @@
+// Deterministic BLAKE3 hashing -- implemented in Task 3

--- a/icn/crates/icn-authz/src/model/hash.rs
+++ b/icn/crates/icn-authz/src/model/hash.rs
@@ -1,1 +1,426 @@
-// Deterministic BLAKE3 hashing -- implemented in Task 3
+//! Deterministic BLAKE3 hashing for capability graph types.
+//!
+//! Every type gets a unique tag byte prefix to prevent cross-type collisions.
+//! Strings are length-prefixed to prevent concatenation ambiguity.
+//! All tag bytes are FROZEN -- append only, never change values.
+
+use super::edge::CapabilityEdge;
+use super::ids::{
+    Action, BlockHeight, Constraint, EdgeSource, ResourceId, ResourceKind, SubjectId,
+};
+
+// ---------------------------------------------------------------------------
+// Top-level type tags -- FROZEN
+// ---------------------------------------------------------------------------
+
+pub(crate) const TAG_SUBJECT: u8 = 0x10;
+pub(crate) const TAG_ACTION: u8 = 0x11;
+pub(crate) const TAG_RESOURCE: u8 = 0x12;
+pub(crate) const TAG_CONSTRAINT: u8 = 0x13;
+pub(crate) const TAG_EDGE_SOURCE: u8 = 0x14;
+pub(crate) const TAG_EDGE: u8 = 0x15;
+pub(crate) const TAG_EDGE_SET: u8 = 0x16;
+
+// ---------------------------------------------------------------------------
+// ResourceKind tags -- FROZEN, must match variant declaration order
+// ---------------------------------------------------------------------------
+
+pub(crate) const RESOURCE_ENTITY: u8 = 0x01;
+pub(crate) const RESOURCE_SCOPE: u8 = 0x02;
+pub(crate) const RESOURCE_ASSET: u8 = 0x03;
+pub(crate) const RESOURCE_CONTRACT: u8 = 0x04;
+pub(crate) const RESOURCE_SYSTEM: u8 = 0x05;
+
+// ---------------------------------------------------------------------------
+// Constraint tags -- FROZEN
+// ---------------------------------------------------------------------------
+
+pub(crate) const CONSTRAINT_RATE_LIMIT: u8 = 0x01;
+pub(crate) const CONSTRAINT_CREDIT_MULTIPLIER: u8 = 0x02;
+pub(crate) const CONSTRAINT_MAX_TOPICS: u8 = 0x03;
+pub(crate) const CONSTRAINT_TIME_LOCK: u8 = 0x04;
+pub(crate) const CONSTRAINT_REQUIRES_QUORUM: u8 = 0x05;
+pub(crate) const CONSTRAINT_TAG: u8 = 0x06;
+
+// ---------------------------------------------------------------------------
+// EdgeSource tags -- FROZEN
+// ---------------------------------------------------------------------------
+
+pub(crate) const SOURCE_CCL_CONTRACT: u8 = 0x01;
+pub(crate) const SOURCE_TRUST_SCORE: u8 = 0x02;
+pub(crate) const SOURCE_GOVERNANCE_VOTE: u8 = 0x03;
+pub(crate) const SOURCE_STATIC: u8 = 0x04;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Length-prefix then append bytes. Prevents concatenation ambiguity.
+pub(crate) fn hash_bytes(hasher: &mut blake3::Hasher, data: &[u8]) {
+    hasher.update(&(data.len() as u32).to_le_bytes());
+    hasher.update(data);
+}
+
+/// Hash an `Option<BlockHeight>`. `None` = `0x00`. `Some(h)` = `0x01 ++ h as u64 LE`.
+pub(crate) fn hash_option_height(hasher: &mut blake3::Hasher, h: Option<BlockHeight>) {
+    match h {
+        None => {
+            hasher.update(&[0x00]);
+        }
+        Some(height) => {
+            hasher.update(&[0x01]);
+            hasher.update(&height.to_le_bytes());
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Private tag mappers -- explicit match arms, no casting
+// ---------------------------------------------------------------------------
+
+fn resource_kind_tag(kind: &ResourceKind) -> u8 {
+    match kind {
+        ResourceKind::Entity => RESOURCE_ENTITY,
+        ResourceKind::Scope => RESOURCE_SCOPE,
+        ResourceKind::Asset => RESOURCE_ASSET,
+        ResourceKind::Contract => RESOURCE_CONTRACT,
+        ResourceKind::System => RESOURCE_SYSTEM,
+    }
+}
+
+fn constraint_tag(c: &Constraint) -> u8 {
+    match c {
+        Constraint::RateLimit(_) => CONSTRAINT_RATE_LIMIT,
+        Constraint::CreditMultiplier(_) => CONSTRAINT_CREDIT_MULTIPLIER,
+        Constraint::MaxTopics(_) => CONSTRAINT_MAX_TOPICS,
+        Constraint::TimeLock(_) => CONSTRAINT_TIME_LOCK,
+        Constraint::RequiresQuorum(_) => CONSTRAINT_REQUIRES_QUORUM,
+        Constraint::Tag(_) => CONSTRAINT_TAG,
+    }
+}
+
+fn edge_source_tag(es: &EdgeSource) -> u8 {
+    match es {
+        EdgeSource::CclContract(_) => SOURCE_CCL_CONTRACT,
+        EdgeSource::TrustScore(_) => SOURCE_TRUST_SCORE,
+        EdgeSource::GovernanceVote(_) => SOURCE_GOVERNANCE_VOTE,
+        EdgeSource::Static(_) => SOURCE_STATIC,
+    }
+}
+
+fn edge_source_inner(es: &EdgeSource) -> &str {
+    match es {
+        EdgeSource::CclContract(s)
+        | EdgeSource::TrustScore(s)
+        | EdgeSource::GovernanceVote(s)
+        | EdgeSource::Static(s) => s,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-type hash functions
+// ---------------------------------------------------------------------------
+
+/// Deterministic BLAKE3 hash of a [`SubjectId`].
+pub fn hash_subject(s: &SubjectId) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&[TAG_SUBJECT]);
+    hash_bytes(&mut hasher, s.as_str().as_bytes());
+    *hasher.finalize().as_bytes()
+}
+
+/// Deterministic BLAKE3 hash of an [`Action`].
+pub fn hash_action(a: &Action) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&[TAG_ACTION]);
+    hash_bytes(&mut hasher, a.as_str().as_bytes());
+    *hasher.finalize().as_bytes()
+}
+
+/// Deterministic BLAKE3 hash of a [`ResourceId`].
+pub fn hash_resource(r: &ResourceId) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&[TAG_RESOURCE]);
+    hasher.update(&[resource_kind_tag(&r.kind)]);
+    hash_bytes(&mut hasher, r.id.as_bytes());
+    *hasher.finalize().as_bytes()
+}
+
+/// Deterministic BLAKE3 hash of a [`Constraint`].
+pub fn hash_constraint(c: &Constraint) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&[TAG_CONSTRAINT]);
+    hasher.update(&[constraint_tag(c)]);
+    match c {
+        Constraint::RateLimit(v) => hasher.update(&v.to_le_bytes()),
+        Constraint::CreditMultiplier(v) => hasher.update(&v.to_le_bytes()),
+        Constraint::MaxTopics(v) => hasher.update(&v.to_le_bytes()),
+        Constraint::TimeLock(v) => hasher.update(&v.to_le_bytes()),
+        Constraint::RequiresQuorum(v) => hasher.update(&v.to_le_bytes()),
+        Constraint::Tag(s) => {
+            hash_bytes(&mut hasher, s.as_bytes());
+            return *hasher.finalize().as_bytes();
+        }
+    };
+    *hasher.finalize().as_bytes()
+}
+
+/// Deterministic BLAKE3 hash of an [`EdgeSource`].
+pub fn hash_edge_source(es: &EdgeSource) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&[TAG_EDGE_SOURCE]);
+    hasher.update(&[edge_source_tag(es)]);
+    hash_bytes(&mut hasher, edge_source_inner(es).as_bytes());
+    *hasher.finalize().as_bytes()
+}
+
+/// Deterministic BLAKE3 hash of a [`CapabilityEdge`].
+pub fn hash_edge(e: &CapabilityEdge) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&[TAG_EDGE]);
+    hasher.update(&hash_subject(&e.subject));
+    hasher.update(&hash_action(&e.action));
+    hasher.update(&hash_resource(&e.resource));
+    hasher.update(&(e.constraints.len() as u32).to_le_bytes());
+    for c in &e.constraints {
+        hasher.update(&hash_constraint(c));
+    }
+    hasher.update(&hash_edge_source(&e.source));
+    hash_option_height(&mut hasher, e.valid_at);
+    *hasher.finalize().as_bytes()
+}
+
+/// Deterministic BLAKE3 hash of an edge set (used by [`CapabilityGraph::hash`]).
+pub fn hash_edge_set(edges: &[CapabilityEdge]) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&[TAG_EDGE_SET]);
+    hasher.update(&(edges.len() as u32).to_le_bytes());
+    for e in edges {
+        hasher.update(&hash_edge(e));
+    }
+    *hasher.finalize().as_bytes()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn alice() -> SubjectId {
+        SubjectId::new("did:icn:alice").unwrap()
+    }
+
+    fn bob() -> SubjectId {
+        SubjectId::new("did:icn:bob").unwrap()
+    }
+
+    fn transfer() -> Action {
+        Action::new("ledger:transfer").unwrap()
+    }
+
+    fn propose() -> Action {
+        Action::new("governance:propose").unwrap()
+    }
+
+    fn vote() -> Action {
+        Action::new("governance:vote").unwrap()
+    }
+
+    fn asset_x() -> ResourceId {
+        ResourceId::new(ResourceKind::Asset, "x")
+    }
+
+    fn entity_x() -> ResourceId {
+        ResourceId::new(ResourceKind::Entity, "x")
+    }
+
+    fn entity_y() -> ResourceId {
+        ResourceId::new(ResourceKind::Entity, "y")
+    }
+
+    fn make_edge(
+        subject: SubjectId,
+        action: Action,
+        valid_at: Option<BlockHeight>,
+    ) -> CapabilityEdge {
+        CapabilityEdge::new(
+            subject,
+            action,
+            asset_x(),
+            vec![Constraint::RateLimit(100)],
+            EdgeSource::Static("test".into()),
+            valid_at,
+        )
+    }
+
+    // -- SubjectId hashing --------------------------------------------------
+
+    #[test]
+    fn hash_subject_deterministic() {
+        let h1 = hash_subject(&alice());
+        let h2 = hash_subject(&alice());
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn hash_subject_differs_for_different_dids() {
+        assert_ne!(hash_subject(&alice()), hash_subject(&bob()));
+    }
+
+    // -- Action hashing -----------------------------------------------------
+
+    #[test]
+    fn hash_action_deterministic() {
+        let h1 = hash_action(&transfer());
+        let h2 = hash_action(&transfer());
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn hash_action_differs_for_different_actions() {
+        assert_ne!(hash_action(&propose()), hash_action(&vote()));
+    }
+
+    // -- Resource hashing ---------------------------------------------------
+
+    #[test]
+    fn hash_resource_deterministic() {
+        let h1 = hash_resource(&asset_x());
+        let h2 = hash_resource(&asset_x());
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn hash_resource_differs_for_different_kinds() {
+        assert_ne!(hash_resource(&entity_x()), hash_resource(&asset_x()));
+    }
+
+    #[test]
+    fn hash_resource_differs_for_different_ids() {
+        assert_ne!(hash_resource(&entity_x()), hash_resource(&entity_y()));
+    }
+
+    // -- Constraint hashing -------------------------------------------------
+
+    #[test]
+    fn hash_constraint_deterministic() {
+        let h1 = hash_constraint(&Constraint::RateLimit(100));
+        let h2 = hash_constraint(&Constraint::RateLimit(100));
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn hash_constraint_differs_across_variants() {
+        // Same inner value (100), different variant tags.
+        assert_ne!(
+            hash_constraint(&Constraint::RateLimit(100)),
+            hash_constraint(&Constraint::MaxTopics(100)),
+        );
+    }
+
+    #[test]
+    fn hash_constraint_tag_differs_by_string() {
+        assert_ne!(
+            hash_constraint(&Constraint::Tag("foo".into())),
+            hash_constraint(&Constraint::Tag("bar".into())),
+        );
+    }
+
+    // -- EdgeSource hashing -------------------------------------------------
+
+    #[test]
+    fn hash_edge_source_deterministic() {
+        let es = EdgeSource::CclContract("contract-1".into());
+        let h1 = hash_edge_source(&es);
+        let h2 = hash_edge_source(&es);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn hash_edge_source_differs_across_variants() {
+        // Same inner string, different variant tags.
+        assert_ne!(
+            hash_edge_source(&EdgeSource::CclContract("x".into())),
+            hash_edge_source(&EdgeSource::Static("x".into())),
+        );
+    }
+
+    // -- Option<BlockHeight> hashing ----------------------------------------
+
+    #[test]
+    fn hash_option_height_none_vs_some_differ() {
+        let mut h_none = blake3::Hasher::new();
+        hash_option_height(&mut h_none, None);
+        let digest_none = *h_none.finalize().as_bytes();
+
+        let mut h_some = blake3::Hasher::new();
+        hash_option_height(&mut h_some, Some(100));
+        let digest_some = *h_some.finalize().as_bytes();
+
+        assert_ne!(digest_none, digest_some);
+    }
+
+    #[test]
+    fn hash_option_height_different_values_differ() {
+        let mut h1 = blake3::Hasher::new();
+        hash_option_height(&mut h1, Some(100));
+        let d1 = *h1.finalize().as_bytes();
+
+        let mut h2 = blake3::Hasher::new();
+        hash_option_height(&mut h2, Some(200));
+        let d2 = *h2.finalize().as_bytes();
+
+        assert_ne!(d1, d2);
+    }
+
+    // -- Length-prefix ambiguity --------------------------------------------
+
+    #[test]
+    fn length_prefix_prevents_concatenation_ambiguity() {
+        // ("ab", "cd") vs ("a", "bcd") must differ when length-prefixed.
+        let mut h1 = blake3::Hasher::new();
+        hash_bytes(&mut h1, b"ab");
+        hash_bytes(&mut h1, b"cd");
+        let d1 = *h1.finalize().as_bytes();
+
+        let mut h2 = blake3::Hasher::new();
+        hash_bytes(&mut h2, b"a");
+        hash_bytes(&mut h2, b"bcd");
+        let d2 = *h2.finalize().as_bytes();
+
+        assert_ne!(d1, d2);
+    }
+
+    // -- Edge hashing -------------------------------------------------------
+
+    #[test]
+    fn hash_edge_deterministic() {
+        let e = make_edge(alice(), transfer(), None);
+        assert_eq!(hash_edge(&e), hash_edge(&e));
+    }
+
+    #[test]
+    fn hash_edge_differs_by_subject() {
+        let e1 = make_edge(alice(), transfer(), None);
+        let e2 = make_edge(bob(), transfer(), None);
+        assert_ne!(hash_edge(&e1), hash_edge(&e2));
+    }
+
+    #[test]
+    fn hash_edge_differs_by_action() {
+        let e1 = make_edge(alice(), propose(), None);
+        let e2 = make_edge(alice(), vote(), None);
+        assert_ne!(hash_edge(&e1), hash_edge(&e2));
+    }
+
+    #[test]
+    fn hash_edge_differs_by_valid_at() {
+        let e1 = make_edge(alice(), transfer(), None);
+        let e2 = make_edge(alice(), transfer(), Some(100));
+        assert_ne!(hash_edge(&e1), hash_edge(&e2));
+    }
+}

--- a/icn/crates/icn-authz/src/model/ids.rs
+++ b/icn/crates/icn-authz/src/model/ids.rs
@@ -1,0 +1,1 @@
+// Canonical identity and resource types -- implemented in Task 2

--- a/icn/crates/icn-authz/src/model/ids.rs
+++ b/icn/crates/icn-authz/src/model/ids.rs
@@ -191,6 +191,9 @@ pub enum EdgeSource {
 // ---------------------------------------------------------------------------
 
 /// Block height for temporal validity. Alias for `u64`.
+///
+/// Defined locally until `icn-kernel-api::BlockHeight` (Phase A, PR #1282) merges
+/// to main. Switch to re-export at that point.
 pub type BlockHeight = u64;
 
 // ---------------------------------------------------------------------------

--- a/icn/crates/icn-authz/src/model/ids.rs
+++ b/icn/crates/icn-authz/src/model/ids.rs
@@ -1,1 +1,328 @@
-// Canonical identity and resource types -- implemented in Task 2
+//! Canonical identity and resource types for the capability graph.
+//!
+//! All types implement full ordering and serde round-tripping.
+//! Enum variant order is FROZEN -- append only, never reorder.
+
+use serde::{Deserialize, Serialize};
+
+use crate::AuthzError;
+
+// ---------------------------------------------------------------------------
+// SubjectId
+// ---------------------------------------------------------------------------
+
+/// A validated DID identifying a capability subject.
+///
+/// Must start with `"did:"`. Empty strings are rejected.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SubjectId(String);
+
+impl SubjectId {
+    /// Create a new `SubjectId`, rejecting values that do not start with `"did:"`.
+    pub fn new(did: impl Into<String>) -> Result<Self, AuthzError> {
+        let s = did.into();
+        if !s.starts_with("did:") {
+            return Err(AuthzError::InvalidSubjectId(s));
+        }
+        Ok(Self(s))
+    }
+
+    /// Borrow the inner DID string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Action
+// ---------------------------------------------------------------------------
+
+/// A validated, canonicalized action string in `domain:verb[:subverb...]` form.
+///
+/// Construction normalizes the input:
+/// - Trims whitespace
+/// - Lowercases to ASCII
+/// - Validates at least two colon-separated segments, no empty segments,
+///   and only ASCII alphanumeric, colon, or hyphen characters.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Action(String);
+
+impl Action {
+    /// Create a new `Action` with soft normalization (trim + lowercase).
+    ///
+    /// Returns `Err` if the result doesn't match `domain:verb[:subverb...]`
+    /// with only ASCII alphanumeric, colon, and hyphen characters.
+    pub fn new(raw: impl Into<String>) -> Result<Self, AuthzError> {
+        let s: String = raw.into().trim().to_ascii_lowercase();
+
+        if s.is_empty() {
+            return Err(AuthzError::InvalidAction(s));
+        }
+
+        // Only ASCII alphanumeric + colon + hyphen allowed
+        if !s
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b':' || b == b'-')
+        {
+            return Err(AuthzError::InvalidAction(s));
+        }
+
+        let segments: Vec<&str> = s.split(':').collect();
+
+        // Must have >= 2 segments, no empty segments
+        if segments.len() < 2 || segments.iter().any(|seg| seg.is_empty()) {
+            return Err(AuthzError::InvalidAction(s));
+        }
+
+        Ok(Self(s))
+    }
+
+    /// Borrow the canonical action string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// The first colon-delimited segment (e.g. `"ledger"` in `"ledger:transfer"`).
+    pub fn domain(&self) -> &str {
+        // SAFETY: constructor validated at least two segments separated by ':'.
+        // split(':').next() always returns Some on a non-empty string.
+        self.0.split(':').next().unwrap_or("")
+    }
+
+    /// The second colon-delimited segment (e.g. `"transfer"` in `"ledger:transfer"`).
+    pub fn verb(&self) -> &str {
+        // SAFETY: constructor validated at least two segments separated by ':'.
+        self.0.split(':').nth(1).unwrap_or("")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ResourceKind
+// ---------------------------------------------------------------------------
+
+/// The kind of resource a capability applies to.
+///
+/// Variant order is FROZEN. Do not reorder. Append only.
+/// Tag bytes: Entity=0x01, Scope=0x02, Asset=0x03, Contract=0x04, System=0x05
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum ResourceKind {
+    /// A cooperative entity (individual, coop, federation).
+    Entity,
+    /// A scope/namespace boundary.
+    Scope,
+    /// A tracked asset (credit line, token, etc.).
+    Asset,
+    /// A CCL contract instance.
+    Contract,
+    /// A system-level resource (metrics, config, etc.).
+    System,
+}
+
+// ---------------------------------------------------------------------------
+// ResourceId
+// ---------------------------------------------------------------------------
+
+/// Identifies a specific resource by kind and ID.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ResourceId {
+    pub kind: ResourceKind,
+    pub id: String,
+}
+
+impl ResourceId {
+    /// Create a new resource identifier.
+    pub fn new(kind: ResourceKind, id: impl Into<String>) -> Self {
+        Self {
+            kind,
+            id: id.into(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Constraint
+// ---------------------------------------------------------------------------
+
+/// A constraint attached to a capability edge.
+///
+/// Variant order is FROZEN. Do not reorder. Append only.
+/// Tag bytes: RateLimit=0x01, CreditMultiplier=0x02, MaxTopics=0x03,
+///            TimeLock=0x04, RequiresQuorum=0x05, Tag=0x06
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum Constraint {
+    /// Maximum messages per second.
+    RateLimit(u32),
+    /// Credit multiplier in basis points (10000 = 1.0x).
+    CreditMultiplier(u32),
+    /// Maximum gossip topic subscriptions.
+    MaxTopics(u32),
+    /// Unix timestamp before which the capability is locked.
+    TimeLock(u64),
+    /// Minimum quorum size required to exercise the capability.
+    RequiresQuorum(u32),
+    /// Opaque tag for domain-specific constraints.
+    Tag(String),
+}
+
+// ---------------------------------------------------------------------------
+// EdgeSource
+// ---------------------------------------------------------------------------
+
+/// The provenance of a capability edge -- what granted it.
+///
+/// Variant order is FROZEN. Do not reorder. Append only.
+/// Tag bytes: CclContract=0x01, TrustScore=0x02, GovernanceVote=0x03, Static=0x04
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum EdgeSource {
+    /// Granted by a CCL contract (contract ID).
+    CclContract(String),
+    /// Derived from a trust score computation (score label).
+    TrustScore(String),
+    /// Granted by a governance vote (proposal ID).
+    GovernanceVote(String),
+    /// Statically configured (description).
+    Static(String),
+}
+
+// ---------------------------------------------------------------------------
+// BlockHeight type alias
+// ---------------------------------------------------------------------------
+
+/// Block height for temporal validity. Alias for `u64`.
+pub type BlockHeight = u64;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    // -- SubjectId ----------------------------------------------------------
+
+    #[test]
+    fn subject_id_valid_did() {
+        let sid = SubjectId::new("did:icn:abc123").unwrap();
+        assert_eq!(sid.as_str(), "did:icn:abc123");
+    }
+
+    #[test]
+    fn subject_id_rejects_non_did() {
+        assert!(SubjectId::new("not-a-did").is_err());
+    }
+
+    #[test]
+    fn subject_id_rejects_empty() {
+        assert!(SubjectId::new("").is_err());
+    }
+
+    // -- Action -------------------------------------------------------------
+
+    #[test]
+    fn action_normalizes_uppercase() {
+        let a = Action::new("LEDGER:TRANSFER").unwrap();
+        assert_eq!(a.as_str(), "ledger:transfer");
+        assert_eq!(a.domain(), "ledger");
+        assert_eq!(a.verb(), "transfer");
+    }
+
+    #[test]
+    fn action_trims_whitespace() {
+        let a = Action::new("  gossip:subscribe  ").unwrap();
+        assert_eq!(a.as_str(), "gossip:subscribe");
+    }
+
+    #[test]
+    fn action_three_segments_ok() {
+        let a = Action::new("ledger:transfer:credit").unwrap();
+        assert_eq!(a.domain(), "ledger");
+        assert_eq!(a.verb(), "transfer");
+    }
+
+    #[test]
+    fn action_rejects_empty() {
+        assert!(Action::new("").is_err());
+    }
+
+    #[test]
+    fn action_rejects_no_colon() {
+        assert!(Action::new("ledger").is_err());
+    }
+
+    #[test]
+    fn action_rejects_empty_segment() {
+        assert!(Action::new("ledger:").is_err());
+        assert!(Action::new(":verb").is_err());
+        assert!(Action::new("a::b").is_err());
+    }
+
+    #[test]
+    fn action_rejects_non_ascii() {
+        assert!(Action::new("ledger:tr\u{00e4}nsfer").is_err());
+    }
+
+    #[test]
+    fn action_allows_hyphens() {
+        let a = Action::new("my-domain:my-verb").unwrap();
+        assert_eq!(a.as_str(), "my-domain:my-verb");
+    }
+
+    // -- ResourceKind ordering ----------------------------------------------
+
+    #[test]
+    fn resource_kind_ordering_is_declaration_order() {
+        assert!(ResourceKind::Entity < ResourceKind::Scope);
+        assert!(ResourceKind::Scope < ResourceKind::Asset);
+        assert!(ResourceKind::Asset < ResourceKind::Contract);
+        assert!(ResourceKind::Contract < ResourceKind::System);
+    }
+
+    // -- Constraint ordering ------------------------------------------------
+
+    #[test]
+    fn constraint_variant_ordering() {
+        // Cross-variant: declaration order
+        assert!(Constraint::RateLimit(100) < Constraint::CreditMultiplier(100));
+        assert!(Constraint::CreditMultiplier(100) < Constraint::MaxTopics(100));
+        assert!(Constraint::MaxTopics(100) < Constraint::TimeLock(100));
+        assert!(Constraint::TimeLock(100) < Constraint::RequiresQuorum(100));
+        assert!(Constraint::RequiresQuorum(100) < Constraint::Tag("a".into()));
+    }
+
+    #[test]
+    fn constraint_same_variant_orders_by_value() {
+        assert!(Constraint::RateLimit(10) < Constraint::RateLimit(20));
+        assert!(Constraint::Tag("a".into()) < Constraint::Tag("b".into()));
+    }
+
+    // -- EdgeSource ordering ------------------------------------------------
+
+    #[test]
+    fn edge_source_ordering_is_declaration_order() {
+        assert!(EdgeSource::CclContract("a".into()) < EdgeSource::TrustScore("a".into()));
+        assert!(EdgeSource::TrustScore("a".into()) < EdgeSource::GovernanceVote("a".into()));
+        assert!(EdgeSource::GovernanceVote("a".into()) < EdgeSource::Static("a".into()));
+    }
+
+    // -- Serde roundtrips ---------------------------------------------------
+
+    #[test]
+    fn subject_id_serde_roundtrip() {
+        let sid = SubjectId::new("did:icn:abc").unwrap();
+        let json = serde_json::to_string(&sid).unwrap();
+        let back: SubjectId = serde_json::from_str(&json).unwrap();
+        assert_eq!(sid, back);
+    }
+
+    #[test]
+    fn action_serde_roundtrip() {
+        let a = Action::new("ledger:transfer").unwrap();
+        let json = serde_json::to_string(&a).unwrap();
+        let back: Action = serde_json::from_str(&json).unwrap();
+        assert_eq!(a, back);
+    }
+}

--- a/icn/crates/icn-authz/src/model/mod.rs
+++ b/icn/crates/icn-authz/src/model/mod.rs
@@ -1,3 +1,6 @@
 pub mod edge;
 pub mod hash;
 pub mod ids;
+
+pub use edge::{CapabilityEdge, CapabilityGraph, Decision};
+pub use ids::{Action, BlockHeight, Constraint, EdgeSource, ResourceId, ResourceKind, SubjectId};

--- a/icn/crates/icn-authz/src/model/mod.rs
+++ b/icn/crates/icn-authz/src/model/mod.rs
@@ -1,0 +1,3 @@
+pub mod edge;
+pub mod hash;
+pub mod ids;

--- a/icn/crates/icn-authz/tests/capability_graph_integration.rs
+++ b/icn/crates/icn-authz/tests/capability_graph_integration.rs
@@ -1,0 +1,261 @@
+//! Cross-module integration tests for icn-authz capability graph.
+//!
+//! These tests exercise the full pipeline: construct edges from multiple
+//! `CapabilitySource` implementations, build graphs via `GraphBuilder`,
+//! query decisions, and verify deterministic hashing across configurations.
+
+#![allow(clippy::unwrap_used)]
+
+use icn_authz::*;
+
+// ---------------------------------------------------------------------------
+// FixedSource -- a trivial CapabilitySource for integration testing
+// ---------------------------------------------------------------------------
+
+struct FixedSource(Vec<CapabilityEdge>);
+
+impl CapabilitySource for FixedSource {
+    fn edges_for_subject(&self, subject: &SubjectId) -> Vec<CapabilityEdge> {
+        self.0
+            .iter()
+            .filter(|e| e.subject == *subject)
+            .cloned()
+            .collect()
+    }
+
+    fn all_edges(&self) -> Vec<CapabilityEdge> {
+        self.0.clone()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn alice() -> SubjectId {
+    SubjectId::new("did:icn:alice").unwrap()
+}
+fn bob() -> SubjectId {
+    SubjectId::new("did:icn:bob").unwrap()
+}
+fn carol() -> SubjectId {
+    SubjectId::new("did:icn:carol").unwrap()
+}
+fn propose() -> Action {
+    Action::new("governance:propose").unwrap()
+}
+fn vote() -> Action {
+    Action::new("governance:vote").unwrap()
+}
+fn transfer() -> Action {
+    Action::new("ledger:transfer").unwrap()
+}
+fn coop() -> ResourceId {
+    ResourceId::new(ResourceKind::Entity, "coop-1")
+}
+
+fn make_edge(
+    subject: SubjectId,
+    action: Action,
+    resource: ResourceId,
+    source: EdgeSource,
+) -> CapabilityEdge {
+    CapabilityEdge::new(
+        subject,
+        action,
+        resource,
+        vec![Constraint::RateLimit(10)],
+        source,
+        None,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Build a graph, serialize its edges to JSON, deserialize, rebuild.
+/// The two graphs must have identical hashes (canonical ordering survives serde).
+#[test]
+fn edges_sorted_after_serde_roundtrip() {
+    // Intentionally insert in non-sorted order: carol, alice, bob
+    let edges = vec![
+        make_edge(carol(), vote(), coop(), EdgeSource::Static("c".into())),
+        make_edge(
+            alice(),
+            propose(),
+            coop(),
+            EdgeSource::CclContract("contract-1".into()),
+        ),
+        make_edge(
+            bob(),
+            transfer(),
+            coop(),
+            EdgeSource::TrustScore("high".into()),
+        ),
+    ];
+
+    let graph_a = CapabilityGraph::from_edges(edges.clone());
+    let hash_a = graph_a.hash();
+
+    // Round-trip through JSON
+    let json = serde_json::to_string(graph_a.edges()).unwrap();
+    let deserialized: Vec<CapabilityEdge> = serde_json::from_str(&json).unwrap();
+    let graph_b = CapabilityGraph::from_edges(deserialized);
+
+    assert_eq!(hash_a, graph_b.hash());
+    assert_eq!(graph_a.edges(), graph_b.edges());
+}
+
+/// Two independent sources feed edges into a single graph via GraphBuilder.
+/// Verify edge count, and query results for each subject.
+#[test]
+fn full_pipeline_two_sources() {
+    let source_1 = FixedSource(vec![
+        make_edge(
+            alice(),
+            propose(),
+            coop(),
+            EdgeSource::CclContract("contract-1".into()),
+        ),
+        make_edge(
+            bob(),
+            vote(),
+            coop(),
+            EdgeSource::TrustScore("medium".into()),
+        ),
+    ]);
+
+    let treasury = ResourceId::new(ResourceKind::Asset, "treasury");
+    let source_2 = FixedSource(vec![make_edge(
+        carol(),
+        transfer(),
+        treasury.clone(),
+        EdgeSource::GovernanceVote("proposal-42".into()),
+    )]);
+
+    let graph = GraphBuilder::new()
+        .add_source(Box::new(source_1))
+        .add_source(Box::new(source_2))
+        .build();
+
+    assert_eq!(graph.edges().len(), 3);
+
+    // Alice can propose on coop
+    let d = graph.query(&alice(), &propose(), &coop());
+    assert!(d.allowed);
+
+    // Bob can vote on coop
+    let d = graph.query(&bob(), &vote(), &coop());
+    assert!(d.allowed);
+
+    // Carol can transfer on treasury
+    let d = graph.query(&carol(), &transfer(), &treasury);
+    assert!(d.allowed);
+
+    // Alice cannot vote on coop (no such edge)
+    let d = graph.query(&alice(), &vote(), &coop());
+    assert!(!d.allowed);
+    assert!(d.matching_edges.is_empty());
+}
+
+/// Same set of edges, different source configurations (one source vs two).
+/// The resulting graph hash must be identical.
+#[test]
+fn hash_stable_across_source_configurations() {
+    let edge_a = make_edge(
+        alice(),
+        propose(),
+        coop(),
+        EdgeSource::CclContract("c-1".into()),
+    );
+    let edge_b = make_edge(bob(), vote(), coop(), EdgeSource::TrustScore("high".into()));
+
+    // Config A: one source with both edges
+    let source_both = FixedSource(vec![edge_a.clone(), edge_b.clone()]);
+    let graph_a = GraphBuilder::new()
+        .add_source(Box::new(source_both))
+        .build();
+
+    // Config B: two sources, one edge each
+    let source_a = FixedSource(vec![edge_a]);
+    let source_b = FixedSource(vec![edge_b]);
+    let graph_b = GraphBuilder::new()
+        .add_source(Box::new(source_a))
+        .add_source(Box::new(source_b))
+        .build();
+
+    assert_eq!(graph_a.hash(), graph_b.hash());
+    assert_eq!(graph_a.edges(), graph_b.edges());
+}
+
+/// `build_for_subject` returns only edges matching the requested subject.
+#[test]
+fn build_for_subject_correct_subset() {
+    let source = FixedSource(vec![
+        make_edge(
+            alice(),
+            propose(),
+            coop(),
+            EdgeSource::CclContract("c-1".into()),
+        ),
+        make_edge(
+            alice(),
+            vote(),
+            coop(),
+            EdgeSource::TrustScore("high".into()),
+        ),
+        make_edge(
+            bob(),
+            propose(),
+            coop(),
+            EdgeSource::Static("bootstrap".into()),
+        ),
+    ]);
+
+    let graph = GraphBuilder::new()
+        .add_source(Box::new(source))
+        .build_for_subject(&alice());
+
+    assert_eq!(graph.edges().len(), 2);
+    for edge in graph.edges() {
+        assert_eq!(edge.subject, alice());
+    }
+}
+
+/// When two edges match the same (subject, action, resource) but differ in
+/// constraints or source, query returns both matching edge indices.
+#[test]
+fn query_returns_multiple_matching_edges() {
+    let edge_a = CapabilityEdge::new(
+        alice(),
+        propose(),
+        coop(),
+        vec![Constraint::RateLimit(10)],
+        EdgeSource::CclContract("contract-1".into()),
+        None,
+    );
+    let edge_b = CapabilityEdge::new(
+        alice(),
+        propose(),
+        coop(),
+        vec![Constraint::MaxTopics(5)],
+        EdgeSource::GovernanceVote("proposal-7".into()),
+        None,
+    );
+
+    let graph = CapabilityGraph::from_edges(vec![edge_a, edge_b]);
+
+    let d = graph.query(&alice(), &propose(), &coop());
+    assert!(d.allowed);
+    assert_eq!(d.matching_edges.len(), 2);
+}
+
+/// An empty graph denies every query.
+#[test]
+fn query_denied_on_empty_graph() {
+    let graph = CapabilityGraph::from_edges(vec![]);
+    let d = graph.query(&alice(), &propose(), &coop());
+    assert!(!d.allowed);
+    assert!(d.matching_edges.is_empty());
+}


### PR DESCRIPTION
## Summary

Phase B0 of the Authz Capability Graph — unifies ICN's four disconnected authorization systems (CCL caps, trust classes, kernel ConstraintSet, JWT scopes) into a single canonical model.

- New app-layer crate `icn-authz` with workspace registration
- Canonical model types: `SubjectId`, `Action`, `ResourceKind`, `ResourceId`, `Constraint`, `EdgeSource`
- `CapabilityEdge` with sorted+deduped constraint invariant
- Deterministic BLAKE3 hashing with length-prefixed variable-length fields and explicit frozen tag bytes
- `CapabilitySource` trait + `GraphBuilder` (computed-on-demand, no persistence)
- `CapabilityGraph` with `query()` returning `Decision { allowed, matching_edges }`
- 54 tests (48 unit + 6 integration)

## Design doc

`docs/plans/2026-02-23-authz-capability-graph-design.md`

## Key decisions

- **App-layer now, promote later**: `icn-authz::model` is domain-agnostic and designed to be liftable to `icn-kernel-api` in a future phase
- **No persistence**: Graph is computed on demand from adapter sources (Phase B1)
- **Explicit tag bytes**: All enum hashing uses frozen named constants, never `as u8` casting
- **Length-prefixed hashing**: All variable-length fields prefixed with u32 LE length to prevent concatenation ambiguity
- **Local `BlockHeight` alias**: `pub type BlockHeight = u64` until Phase A (PR #1282) merges and `icn-kernel-api::BlockHeight` becomes available

## Depends on

- Independent of PR #1282 (Phase A) — no code overlap, parallel reviewable

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p icn-authz --all-targets -- -D warnings`
- [x] `cargo test -p icn-authz` (54 tests pass)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)