### PR TITLE
ci: guard coverage upload on generated report file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,6 +425,10 @@ jobs:
         continue-on-error: ${{ env.GATE_RATCHET_PHASE_COVERAGE != 'blocking' }}  # Tarpaulin can have spurious failures even when tests pass
 
       - name: Upload coverage to Codecov
+        # Only upload if tarpaulin actually produced the report.
+        # When tarpaulin crashes (continue-on-error above), the XML may not exist;
+        # Codecov treating a missing file as a hard failure defeats the non-blocking intent.
+        if: hashFiles('./icn/coverage/cobertura.xml') != ''
         uses: codecov/codecov-action@v5
         with:
           files: ./icn/coverage/cobertura.xml


### PR DESCRIPTION
## What

Add `if: hashFiles('./icn/coverage/cobertura.xml') != ''` guard to the Codecov upload step in the coverage job.

## Why

When tarpaulin crashes spuriously, `continue-on-error: true` sets the step `conclusion=success` but the real `outcome=failure`. If tarpaulin exits before writing `cobertura.xml`, the Codecov upload step fails on the missing file — which causes the overall job to fail even though the gate is supposed to be non-blocking.

The `hashFiles()` expression is evaluated before the step runs, so it correctly detects whether the file exists on disk and skips the upload cleanly.

## Risk

Low. CI-only change. If tarpaulin succeeds, `cobertura.xml` exists and the upload runs exactly as before. If tarpaulin crashes, the upload is skipped (previously it errored).

## References

- Root cause documented in `docs/maintenance/spring-cleaning-2026-02-23.md` item A
- Unblocks #1282 spurious "Test Coverage" failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)