### PR TITLE
scripts: add whereami.sh root-sanity helper

### DIFF
--- a/scripts/whereami.sh
+++ b/scripts/whereami.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# scripts/whereami.sh — prints which repo root you're in
+# Prevents the two-root confusion class of errors (monorepo root vs Rust workspace).
+# See CLAUDE.md "Repo Topology (Two Roots)" section.
+
+set -euo pipefail
+
+echo "git top-level: $(git rev-parse --show-toplevel 2>/dev/null || echo '(not in a git repo)')"
+
+if [ -f Cargo.toml ]; then
+    echo "✓ Rust workspace root (Cargo.toml found)"
+else
+    echo "✗ Not Rust workspace root (no Cargo.toml here)"
+fi
+
+if [ -f sdk/typescript/package.json ]; then
+    echo "✓ Monorepo root (sdk/typescript/package.json found)"
+else
+    echo "  sdk/typescript/package.json not found (not monorepo root)"
+fi


### PR DESCRIPTION
Adds `scripts/whereami.sh` to print whether you are at monorepo root or Rust workspace root. Prevents two-root confusion described in CLAUDE.md Repo Topology section.