### PR TITLE
fix(gateway): move governance scope to end — fixes /services /names /rights /compute 404s

### DIFF
--- a/deploy/devnet/Makefile
+++ b/deploy/devnet/Makefile
@@ -2,54 +2,54 @@
 
 # Start the 3-node devnet
 up:
-	docker-compose up -d
+	docker compose up -d
 	@echo "Devnet started. Waiting for nodes to be ready..."
 	@sleep 5
 	@$(MAKE) status
 
 # Stop the devnet
 down:
-	docker-compose down
+	docker compose down
 
 # Restart the devnet
 restart: down up
 
 # Follow logs from all nodes
 logs:
-	docker-compose logs -f
+	docker compose logs -f
 
 # Show logs from a specific node (make logs-a, logs-b, logs-c)
 logs-a:
-	docker-compose logs -f node-a
+	docker compose logs -f node-a
 
 logs-b:
-	docker-compose logs -f node-b
+	docker compose logs -f node-b
 
 logs-c:
-	docker-compose logs -f node-c
+	docker compose logs -f node-c
 
 # Clean all data volumes (fresh identities on next up)
 clean: down
-	docker-compose down -v
+	docker compose down -v
 	@echo "All devnet data volumes removed"
 
 # Check status of all nodes
 status:
 	@echo "=== Node Status ==="
-	@docker-compose ps
+	@docker compose ps
 	@echo ""
-	@echo "=== Node A (localhost:8000) ==="
-	@curl -sf http://localhost:8000/v1/health 2>/dev/null | python3 -m json.tool 2>/dev/null || echo "  Not ready"
+	@echo "=== Node A (localhost:8080) ==="
+	@curl -sf http://localhost:8080/v1/health 2>/dev/null | python3 -m json.tool 2>/dev/null || echo "  Not ready"
 	@echo ""
-	@echo "=== Node B (localhost:8001) ==="
-	@curl -sf http://localhost:8001/v1/health 2>/dev/null | python3 -m json.tool 2>/dev/null || echo "  Not ready"
+	@echo "=== Node B (localhost:8081) ==="
+	@curl -sf http://localhost:8081/v1/health 2>/dev/null | python3 -m json.tool 2>/dev/null || echo "  Not ready"
 	@echo ""
-	@echo "=== Node C (localhost:8002) ==="
-	@curl -sf http://localhost:8002/v1/health 2>/dev/null | python3 -m json.tool 2>/dev/null || echo "  Not ready"
+	@echo "=== Node C (localhost:8082) ==="
+	@curl -sf http://localhost:8082/v1/health 2>/dev/null | python3 -m json.tool 2>/dev/null || echo "  Not ready"
 
 # Rebuild images without cache
 build:
-	docker-compose build --no-cache
+	docker compose build --no-cache
 
 # Run smoke tests against the devnet
 test:
@@ -59,4 +59,4 @@ test:
 # Run the comprehensive demo against node-a
 demo:
 	@echo "Running demo against devnet node-a..."
-	ICN_GATEWAY=http://localhost:8000 bash ../../scripts/demo-single-node.sh
+	ICN_GATEWAY=http://localhost:8080 bash ../../scripts/demo-single-node.sh

--- a/deploy/devnet/docker-compose.yml
+++ b/deploy/devnet/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.8'
 
 services:
   node-a:
+    image: icn:latest
     build:
       context: ../..
       dockerfile: deploy/Dockerfile.icnd
@@ -10,20 +11,21 @@ services:
     environment:
       - ICN_NODE_NAME=node-a
       - ICN_DATA_DIR=/data/node-a
-      - ICN_GATEWAY_PORT=8000
+      - ICN_GATEWAY_PORT=8080
       - ICN_P2P_PORT=9000
       - ICN_BOOTSTRAP_PEERS=
       - ICN_KEYSTORE_PASSPHRASE=devnet-insecure
       - RUST_LOG=info,icn_core=debug,icn_gossip=debug,icn_net=debug
     ports:
-      - "8000:8000"  # Gateway
+      - "8080:8080"  # Gateway
       - "9000:9000"  # P2P
     volumes:
       - node-a-data:/data/node-a
+      - ./entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
     networks:
       - icn-devnet
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:8000/v1/health"]
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/v1/health"]
       interval: 5s
       timeout: 3s
       retries: 10
@@ -31,6 +33,7 @@ services:
     entrypoint: ["/usr/local/bin/entrypoint.sh"]
 
   node-b:
+    image: icn:latest
     build:
       context: ../..
       dockerfile: deploy/Dockerfile.icnd
@@ -39,23 +42,24 @@ services:
     environment:
       - ICN_NODE_NAME=node-b
       - ICN_DATA_DIR=/data/node-b
-      - ICN_GATEWAY_PORT=8000
+      - ICN_GATEWAY_PORT=8080
       - ICN_P2P_PORT=9000
       - ICN_BOOTSTRAP_PEERS=icn://node-a:9000
       - ICN_KEYSTORE_PASSPHRASE=devnet-insecure
       - RUST_LOG=info,icn_core=debug,icn_gossip=debug,icn_net=debug
     ports:
-      - "8001:8000"  # Gateway (external 8001 → internal 8000)
+      - "8081:8080"  # Gateway (external 8081 → internal 8080)
       - "9001:9000"  # P2P
     volumes:
       - node-b-data:/data/node-b
+      - ./entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
     networks:
       - icn-devnet
     depends_on:
       node-a:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:8000/v1/health"]
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/v1/health"]
       interval: 5s
       timeout: 3s
       retries: 10
@@ -63,6 +67,7 @@ services:
     entrypoint: ["/usr/local/bin/entrypoint.sh"]
 
   node-c:
+    image: icn:latest
     build:
       context: ../..
       dockerfile: deploy/Dockerfile.icnd
@@ -71,16 +76,17 @@ services:
     environment:
       - ICN_NODE_NAME=node-c
       - ICN_DATA_DIR=/data/node-c
-      - ICN_GATEWAY_PORT=8000
+      - ICN_GATEWAY_PORT=8080
       - ICN_P2P_PORT=9000
       - ICN_BOOTSTRAP_PEERS=icn://node-a:9000,icn://node-b:9000
       - ICN_KEYSTORE_PASSPHRASE=devnet-insecure
       - RUST_LOG=info,icn_core=debug,icn_gossip=debug,icn_net=debug
     ports:
-      - "8002:8000"  # Gateway (external 8002 → internal 8000)
+      - "8082:8080"  # Gateway (external 8082 → internal 8080)
       - "9002:9000"  # P2P
     volumes:
       - node-c-data:/data/node-c
+      - ./entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
     networks:
       - icn-devnet
     depends_on:
@@ -89,7 +95,7 @@ services:
       node-b:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:8000/v1/health"]
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/v1/health"]
       interval: 5s
       timeout: 3s
       retries: 10

--- a/deploy/devnet/entrypoint.sh
+++ b/deploy/devnet/entrypoint.sh
@@ -21,15 +21,22 @@ if [ ! -f "$CONFIG_FILE" ]; then
   echo "[$NODE_NAME] Identity initialized."
 fi
 
-# Override config for devnet: enable gateway, set ports, disable mDNS
-# Use sed for simple config patching
-if grep -q 'gateway_enabled' "$CONFIG_FILE" 2>/dev/null; then
-  sed -i 's/gateway_enabled.*/gateway_enabled = true/' "$CONFIG_FILE"
+# Override config for devnet: enable gateway, set ports.
+# Patch in-place if [gateway] section already exists (icnd --init writes one);
+# append a new section only if it's absent.
+if grep -q '^\[gateway\]' "$CONFIG_FILE" 2>/dev/null; then
+  # Section already there — patch enabled and bind_addr within that section.
+  # sed range: from [gateway] up to (not including) the next section header or EOF.
+  sed -i "/^\[gateway\]/,/^\[/{
+    s|^enabled *=.*|enabled = true|
+    s|^bind_addr *=.*|bind_addr = \"0.0.0.0:${GATEWAY_PORT}\"|
+  }" "$CONFIG_FILE"
+  # If bind_addr was absent in the section, append it after the [gateway] line.
+  if ! grep -A20 '^\[gateway\]' "$CONFIG_FILE" | grep -q '^bind_addr'; then
+    sed -i "/^\[gateway\]/a bind_addr = \"0.0.0.0:${GATEWAY_PORT}\"" "$CONFIG_FILE"
+  fi
 else
-  echo "" >> "$CONFIG_FILE"
-  echo "[gateway]" >> "$CONFIG_FILE"
-  echo "enabled = true" >> "$CONFIG_FILE"
-  echo "bind_addr = \"0.0.0.0:${GATEWAY_PORT}\"" >> "$CONFIG_FILE"
+  printf '\n[gateway]\nenabled = true\nbind_addr = "0.0.0.0:%s"\n' "$GATEWAY_PORT" >> "$CONFIG_FILE"
 fi
 
 # Set JWT secret for gateway (deterministic for devnet — NOT for production)

--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -1933,6 +1933,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3348,6 +3354,8 @@ dependencies = [
  "icn-store",
  "icn-time",
  "icn-trust",
+ "metrics",
+ "metrics-util 0.19.1",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -4592,12 +4600,32 @@ dependencies = [
  "indexmap",
  "ipnet",
  "metrics",
- "metrics-util",
+ "metrics-util 0.20.1",
  "quanta",
  "rustls",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "aho-corasick",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "metrics",
+ "ordered-float 4.6.0",
+ "quanta",
+ "radix_trie",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -4702,6 +4730,15 @@ name = "mutually_exclusive_features"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94e1e6445d314f972ff7395df2de295fe51b71821694f0b0e1e79c4f12c8577"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "nix"
@@ -5641,6 +5678,16 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -1176,20 +1176,6 @@ impl GatewayServer {
                                 ))
                                 .wrap(auth.clone()),
                         )
-                        // Governance endpoints — served by apps/governance HTTP layer.
-                        // Routes are registered by configure_governance(); auth + rate
-                        // limiting applied via the wrapping empty scope.
-                        .service(
-                            web::scope("")
-                                .configure({
-                                    let ctx = gov_ctx.clone();
-                                    move |cfg| configure_governance(cfg, ctx.clone())
-                                })
-                                .wrap(middleware::from_fn(
-                                    crate::rate_limit::trust_rate_limit_middleware,
-                                ))
-                                .wrap(auth.clone()),
-                        )
                         // Rights summary endpoint (auth + rate limiting)
                         .service(
                             web::scope("/rights")
@@ -1446,6 +1432,21 @@ impl GatewayServer {
                         .service(
                             web::scope("")
                                 .configure(api::communities::configure)
+                                .wrap(middleware::from_fn(
+                                    crate::rate_limit::trust_rate_limit_middleware,
+                                ))
+                                .wrap(auth.clone()),
+                        )
+                        // Governance endpoints — served by apps/governance HTTP layer.
+                        // Routes are registered by configure_governance(); auth + rate
+                        // limiting applied via the wrapping empty scope.
+                        // MUST be last: web::scope("") matches all paths.
+                        .service(
+                            web::scope("")
+                                .configure({
+                                    let ctx = gov_ctx.clone();
+                                    move |cfg| configure_governance(cfg, ctx.clone())
+                                })
                                 .wrap(middleware::from_fn(
                                     crate::rate_limit::trust_rate_limit_middleware,
                                 ))

--- a/icn/crates/icn-gateway/tests/route_ordering_regression.rs
+++ b/icn/crates/icn-gateway/tests/route_ordering_regression.rs
@@ -88,7 +88,9 @@ async fn test_empty_scope_first_shadows_later_scopes() {
     // /services is unreachable — swallowed by the empty governance scope
     let resp = test::call_service(
         &app,
-        test::TestRequest::get().uri("/services/discover").to_request(),
+        test::TestRequest::get()
+            .uri("/services/discover")
+            .to_request(),
     )
     .await;
     assert_eq!(
@@ -133,26 +135,42 @@ async fn test_empty_scope_last_all_routes_reachable() {
         test::TestRequest::get().uri("/gov/proposals").to_request(),
     )
     .await;
-    assert_eq!(resp.status().as_u16(), 200, "/gov/proposals must be reachable");
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "/gov/proposals must be reachable"
+    );
 
     let resp = test::call_service(
         &app,
         test::TestRequest::get().uri("/gov/domains").to_request(),
     )
     .await;
-    assert_eq!(resp.status().as_u16(), 200, "/gov/domains must be reachable");
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "/gov/domains must be reachable"
+    );
 
     // /services routes are now reachable
     let resp = test::call_service(
         &app,
-        test::TestRequest::get().uri("/services/discover").to_request(),
+        test::TestRequest::get()
+            .uri("/services/discover")
+            .to_request(),
     )
     .await;
-    assert_eq!(resp.status().as_u16(), 200, "/services/discover must be reachable");
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "/services/discover must be reachable"
+    );
 
     let resp = test::call_service(
         &app,
-        test::TestRequest::post().uri("/services/announce").to_request(),
+        test::TestRequest::post()
+            .uri("/services/announce")
+            .to_request(),
     )
     .await;
     assert_eq!(
@@ -167,5 +185,9 @@ async fn test_empty_scope_last_all_routes_reachable() {
         test::TestRequest::get().uri("/names/lookup").to_request(),
     )
     .await;
-    assert_eq!(resp.status().as_u16(), 200, "/names/lookup must be reachable");
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "/names/lookup must be reachable"
+    );
 }

--- a/icn/crates/icn-gateway/tests/route_ordering_regression.rs
+++ b/icn/crates/icn-gateway/tests/route_ordering_regression.rs
@@ -1,0 +1,171 @@
+//! Regression test for actix-web empty-scope ordering footgun (PR #1290).
+//!
+//! # The bug
+//!
+//! `web::scope("")` has an empty prefix, so actix-web matches it for **every**
+//! path. When a `web::scope("")` is registered before specific-prefix scopes
+//! (e.g. `/services`, `/names`, `/compute`), the router matches the empty scope
+//! first. If no inner route matches, it returns **404 without falling through**
+//! to the specific scopes that follow — silently making them all unreachable.
+//!
+//! In the ICN gateway, the governance scope (`web::scope("").configure(governance)`)
+//! was placed at server.rs line 1183, before `/rights`, `/invites`, `/compute`,
+//! `/execution`, `/names`, and `/services`. All of those routes returned 404.
+//!
+//! # The fix
+//!
+//! All `web::scope("")` registrations must be **last** in the service list.
+//! The gateway already had a `// === Empty-scope services (MUST be last) ===`
+//! section; the governance scope was moved there.
+//!
+//! # What these tests check
+//!
+//! - `test_empty_scope_first_shadows_later_scopes`: documents the failure mode
+//!   (governance first → /services returns 404)
+//! - `test_empty_scope_last_all_routes_reachable`: validates the fix
+//!   (governance last → /services, /names, /gov/* all return 200)
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use actix_web::{test, web, App, HttpResponse};
+
+fn configure_governance_sim(cfg: &mut web::ServiceConfig) {
+    cfg.service(
+        web::resource("/gov/proposals")
+            .route(web::get().to(|| async { HttpResponse::Ok().body("gov-proposals") })),
+    )
+    .service(
+        web::resource("/gov/domains")
+            .route(web::get().to(|| async { HttpResponse::Ok().body("gov-domains") })),
+    );
+}
+
+fn configure_services_sim(cfg: &mut web::ServiceConfig) {
+    cfg.service(
+        web::resource("/discover")
+            .route(web::get().to(|| async { HttpResponse::Ok().body("discover") })),
+    )
+    .service(
+        web::resource("/announce")
+            .route(web::post().to(|| async { HttpResponse::Ok().body("announce") })),
+    );
+}
+
+fn configure_names_sim(cfg: &mut web::ServiceConfig) {
+    cfg.service(
+        web::resource("/lookup")
+            .route(web::get().to(|| async { HttpResponse::Ok().body("names-lookup") })),
+    );
+}
+
+/// Documents the failure mode: empty scope registered before specific scopes
+/// shadows them entirely, making all routes after it return 404.
+///
+/// This test exists to lock in our understanding of actix-web's no-fallthrough
+/// behavior for empty-prefix scopes. If it starts failing (200 instead of 404),
+/// actix-web's routing semantics have changed and the ordering restriction may
+/// no longer be necessary.
+#[actix_web::test]
+async fn test_empty_scope_first_shadows_later_scopes() {
+    let app = test::init_service(
+        App::new()
+            // governance: empty prefix, registered FIRST (the bug)
+            .service(web::scope("").configure(configure_governance_sim))
+            // specific-prefix scopes registered AFTER (unreachable due to shadow)
+            .service(web::scope("/services").configure(configure_services_sim))
+            .service(web::scope("/names").configure(configure_names_sim)),
+    )
+    .await;
+
+    // governance routes inside the empty scope work fine
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::get().uri("/gov/proposals").to_request(),
+    )
+    .await;
+    assert_eq!(resp.status().as_u16(), 200);
+
+    // /services is unreachable — swallowed by the empty governance scope
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::get().uri("/services/discover").to_request(),
+    )
+    .await;
+    assert_eq!(
+        resp.status().as_u16(),
+        404,
+        "empty scope registered first shadows /services (documents the bug)"
+    );
+
+    // /names is unreachable for the same reason
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::get().uri("/names/lookup").to_request(),
+    )
+    .await;
+    assert_eq!(
+        resp.status().as_u16(),
+        404,
+        "empty scope registered first shadows /names (documents the bug)"
+    );
+}
+
+/// Validates the fix: empty scope registered LAST — all specific-prefix
+/// scopes are reachable, and governance routes still work.
+///
+/// This is the regression guard: if the governance scope is moved back before
+/// the specific scopes, these assertions will fail.
+#[actix_web::test]
+async fn test_empty_scope_last_all_routes_reachable() {
+    let app = test::init_service(
+        App::new()
+            // specific-prefix scopes registered first (correct order)
+            .service(web::scope("/services").configure(configure_services_sim))
+            .service(web::scope("/names").configure(configure_names_sim))
+            // governance: empty prefix, registered LAST (the fix)
+            .service(web::scope("").configure(configure_governance_sim)),
+    )
+    .await;
+
+    // governance routes still reachable
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::get().uri("/gov/proposals").to_request(),
+    )
+    .await;
+    assert_eq!(resp.status().as_u16(), 200, "/gov/proposals must be reachable");
+
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::get().uri("/gov/domains").to_request(),
+    )
+    .await;
+    assert_eq!(resp.status().as_u16(), 200, "/gov/domains must be reachable");
+
+    // /services routes are now reachable
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::get().uri("/services/discover").to_request(),
+    )
+    .await;
+    assert_eq!(resp.status().as_u16(), 200, "/services/discover must be reachable");
+
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::post().uri("/services/announce").to_request(),
+    )
+    .await;
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "/services/announce must be reachable"
+    );
+
+    // /names routes are now reachable
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::get().uri("/names/lookup").to_request(),
+    )
+    .await;
+    assert_eq!(resp.status().as_u16(), 200, "/names/lookup must be reachable");
+}

--- a/scripts/demo-flow-b.sh
+++ b/scripts/demo-flow-b.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 # Demo Flow B: Service Discovery
 # Tests: announce service → discover services → get service by ID → withdraw
+#
+# Prerequisites:
+#   - ICN devnet running (cd deploy/devnet && make up)
+#   - python3 with cryptography library (pip install cryptography)
+#   - ICN_TOKEN: JWT from icnctl auth inside a devnet container
+#
+# Quick token setup:
+#   TOKEN=$(docker exec icn-devnet-node-a sh -c \
+#     'ICN_KEYSTORE_PASSPHRASE=devnet-insecure icnctl --data-dir /data/node-a auth token \
+#      --scopes ledger:read,ledger:write,governance:read')
+#   ICN_TOKEN=$TOKEN bash scripts/demo-flow-b.sh
 set -euo pipefail
 
 # Gateway binds 8080 by default (see icn-core/src/config/gateway.rs).
@@ -23,33 +34,136 @@ fi
 
 SVC_ID="demo-ledger-$(date +%s)"
 
-# Step 1: Announce a service endpoint
+# ── Step 1: Generate an ephemeral Ed25519 keypair, build signed announce body ──
+step "Generating signed service announcement (provider keypair)..."
+ANNOUNCE_BODY=$(SVC_ID="$SVC_ID" python3 - <<'PYEOF'
+import struct, time, json, os
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+def b58enc(data):
+    n = int.from_bytes(data, 'big')
+    result = []
+    while n > 0:
+        n, r = divmod(n, 58)
+        result.append(ALPHABET[r])
+    leading = 0
+    for b in data:
+        if b == 0: leading += 1
+        else: break
+    return ALPHABET[0] * leading + ''.join(reversed(result))
+
+def make_did(pub_bytes):
+    return 'did:icn:z' + b58enc(pub_bytes)
+
+def lp(buf, s):
+    enc = s.encode('utf-8')
+    return buf + struct.pack('<I', len(enc)) + enc
+
+# Canonical byte values matching EndpointType::to_canonical_byte()
+ENDPOINT_TYPE = {'quic': 0, 'http': 1, 'grpc': 2, 'websocket': 3}
+# ScopeLevel numeric values (Local=0, Cell=1, Org=2, Federation=3, Commons=4)
+SCOPE_LEVEL = {'local': 0, 'cell': 1, 'org': 2, 'federation': 3, 'commons': 4}
+
+def build_signing_payload(svc_id, provider, endpoint_type, svc_type, svc_ver,
+                          endpoints, addresses, capabilities, trust_threshold,
+                          scope_visibility, ttl_secs, created_at, updated_at):
+    """Build binary signing payload matching ServiceEndpoint::signing_payload() in icn-kernel-api."""
+    buf = b''
+    buf = lp(buf, svc_id)
+    buf = lp(buf, provider)
+    buf += bytes([ENDPOINT_TYPE.get(endpoint_type, 1)])  # 1 = Http
+    buf = lp(buf, svc_type)
+    buf = lp(buf, svc_ver)
+    buf += struct.pack('<I', len(endpoints))
+    for ep in endpoints:
+        buf = lp(buf, ep['protocol'])
+        buf = lp(buf, ep['host'])
+        buf += struct.pack('<H', ep['port'])
+        if ep.get('path'):
+            buf += b'\x01'
+            buf = lp(buf, ep['path'])
+        else:
+            buf += b'\x00'
+    for lst in [sorted(addresses), sorted(capabilities)]:
+        buf += struct.pack('<I', len(lst))
+        for item in lst:
+            buf = lp(buf, item)
+    buf += struct.pack('<d', trust_threshold)
+    buf += bytes([SCOPE_LEVEL.get(scope_visibility.lower(), 2)])
+    buf += b'\x00'  # no cell_id
+    buf += struct.pack('<Q', ttl_secs)
+    buf += struct.pack('<Q', created_at)
+    buf += struct.pack('<Q', updated_at)
+    return buf
+
+svc_id = os.environ['SVC_ID']
+now = int(time.time())
+endpoint_type = 'http'
+svc_type = 'ledger'
+svc_ver = '1.0'
+endpoints = [{'protocol': 'http', 'host': 'node-a.devnet', 'port': 8080}]
+addresses = []
+capabilities = ['read', 'write']
+trust_threshold = 0.0
+scope_visibility = 'org'
+ttl_secs = 3600
+
+# Generate ephemeral keypair — each demo run gets a unique provider DID.
+priv = Ed25519PrivateKey.generate()
+pub_bytes = priv.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+provider = make_did(pub_bytes)
+
+payload = build_signing_payload(svc_id, provider, endpoint_type, svc_type, svc_ver,
+                                endpoints, addresses, capabilities, trust_threshold,
+                                scope_visibility, ttl_secs, now, now)
+sig = priv.sign(payload)
+
+req = {
+    'service_id': svc_id,
+    'provider': provider,
+    'endpoint_type': endpoint_type,
+    'service_type': svc_type,
+    'service_version': svc_ver,
+    'endpoints': endpoints,
+    'addresses': addresses,
+    'capabilities': capabilities,
+    'trust_threshold': trust_threshold,
+    'scope_visibility': scope_visibility,
+    'ttl_secs': ttl_secs,
+    'created_at': now,
+    'updated_at': now,
+    'signature': sig.hex(),
+}
+print(json.dumps(req))
+PYEOF
+) || fail "Failed to build signed payload (python3 + cryptography required)"
+
+PROVIDER=$(echo "$ANNOUNCE_BODY" | python3 -c "import sys,json; print(json.load(sys.stdin)['provider'])")
+ok "Provider DID: ${PROVIDER:0:30}…"
+
+# ── Step 2: Announce ──
 step "Announcing service endpoint..."
 ANNOUNCE_RESP=$(curl -sf -X POST "$GATEWAY/v1/services/announce" \
   -H "Content-Type: application/json" \
   ${AUTH_HEADER:+-H "$AUTH_HEADER"} \
-  -d "{
-    \"service_id\": \"$SVC_ID\",
-    \"service_type\": {\"name\": \"ledger\", \"version\": \"1.0\"},
-    \"addresses\": [{\"protocol\": \"https\", \"host\": \"node-a.local\", \"port\": 8080}],
-    \"capabilities\": [\"read\", \"write\"],
-    \"scope\": \"org\",
-    \"ttl_secs\": 3600
-  }" 2>&1) \
+  -d "$ANNOUNCE_BODY" 2>&1) \
   || fail "Announce failed: $ANNOUNCE_RESP"
-ok "Announced service: $SVC_ID"
+ok "Announced: $SVC_ID"
 
-# Step 2: Discover services
-step "Discovering services..."
-DISCOVER_RESP=$(curl -sf "$GATEWAY/v1/services?service_type=ledger&scope=org" \
+# ── Step 3: Discover ──
+step "Discovering services (type=ledger)..."
+DISCOVER_RESP=$(curl -sf "$GATEWAY/v1/services/discover?type=ledger&scope=org" \
   ${AUTH_HEADER:+-H "$AUTH_HEADER"} 2>&1) \
   || fail "Discover failed: $DISCOVER_RESP"
 
-SVC_COUNT=$(echo "$DISCOVER_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['total'])" 2>/dev/null) \
+SVC_COUNT=$(echo "$DISCOVER_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['count'])" 2>/dev/null) \
   || fail "Failed to parse discover response: $DISCOVER_RESP"
 ok "Found $SVC_COUNT service(s)"
 
-# Step 3: Get specific service by ID
+# ── Step 4: Get by ID ──
 step "Getting service by ID..."
 GET_RESP=$(curl -sf "$GATEWAY/v1/services/$SVC_ID" \
   ${AUTH_HEADER:+-H "$AUTH_HEADER"} 2>&1) \
@@ -57,23 +171,25 @@ GET_RESP=$(curl -sf "$GATEWAY/v1/services/$SVC_ID" \
 
 SVC_PROVIDER=$(echo "$GET_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['provider'])" 2>/dev/null) \
   || fail "Failed to parse service: $GET_RESP"
-ok "Service $SVC_ID provider: $SVC_PROVIDER"
+ok "Service $SVC_ID provider: ${SVC_PROVIDER:0:30}…"
 
-# Step 4: Withdraw service
+# ── Step 5: Withdraw (provider query param required) ──
 step "Withdrawing service..."
-WITHDRAW_RESP=$(curl -sf -X DELETE "$GATEWAY/v1/services/$SVC_ID" \
+WITHDRAW_RESP=$(curl -sf -X DELETE \
+  "${GATEWAY}/v1/services/${SVC_ID}?provider=${PROVIDER}" \
   ${AUTH_HEADER:+-H "$AUTH_HEADER"} 2>&1) \
   || fail "Withdraw failed: $WITHDRAW_RESP"
-ok "Withdrawn service: $SVC_ID"
+ok "Withdrawn: $SVC_ID"
 
-# Step 5: Verify withdrawal
+# ── Step 6: Verify withdrawal ──
 step "Verifying service is gone..."
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$GATEWAY/v1/services/$SVC_ID" \
-  ${AUTH_HEADER:+-H "$AUTH_HEADER"} 2>&1)
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  ${AUTH_HEADER:+-H "$AUTH_HEADER"} \
+  "$GATEWAY/v1/services/$SVC_ID")
 if [ "$HTTP_CODE" = "404" ]; then
   ok "Service correctly removed (404)"
 else
-  fail "Expected 404, got $HTTP_CODE"
+  fail "Expected 404 after withdrawal, got $HTTP_CODE"
 fi
 
 echo ""

--- a/scripts/sign_service_announce.py
+++ b/scripts/sign_service_announce.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+Sign and emit a service announcement JSON body for the ICN gateway.
+
+Usage:
+    python3 sign_service_announce.py <service_id>
+    SVC_ID=my-service python3 sign_service_announce.py
+
+Outputs: JSON suitable for POST /v1/services/announce (to stdout).
+
+Generates a fresh ephemeral Ed25519 keypair per invocation. The provider DID
+encodes the public key so the gateway can verify the signature without a
+separate key registry.
+
+Requires: python3 + cryptography library (pip install cryptography)
+"""
+import json
+import os
+import struct
+import sys
+import time
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+# ── Base58btc encoding (multibase 'z' prefix) ─────────────────────────────────
+_B58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+
+def _b58enc(data: bytes) -> str:
+    n = int.from_bytes(data, "big")
+    result = []
+    while n > 0:
+        n, r = divmod(n, 58)
+        result.append(_B58_ALPHABET[r])
+    leading = 0
+    for b in data:
+        if b == 0:
+            leading += 1
+        else:
+            break
+    return _B58_ALPHABET[0] * leading + "".join(reversed(result))
+
+
+def _make_did(pub_bytes: bytes) -> str:
+    """Encode 32-byte Ed25519 public key as did:icn:<multibase-base58btc>."""
+    return "did:icn:z" + _b58enc(pub_bytes)
+
+
+# ── Length-prefixed field helper ──────────────────────────────────────────────
+def _lp(buf: bytes, s: str) -> bytes:
+    enc = s.encode("utf-8")
+    return buf + struct.pack("<I", len(enc)) + enc
+
+
+# ── Canonical byte mappings matching icn-kernel-api ──────────────────────────
+# EndpointType::to_canonical_byte(): Quic=0, Http=1, Grpc=2, WebSocket=3
+_ENDPOINT_TYPE_BYTE = {"quic": 0, "http": 1, "grpc": 2, "websocket": 3}
+
+# ScopeLevel as u8: Local=0, Cell=1, Org=2, Federation=3, Commons=4
+_SCOPE_BYTE = {"local": 0, "cell": 1, "org": 2, "federation": 3, "commons": 4}
+
+
+def _build_signing_payload(
+    service_id: str,
+    provider: str,
+    endpoint_type: str,
+    service_type: str,
+    service_version: str,
+    endpoints: list,
+    addresses: list,
+    capabilities: list,
+    trust_threshold: float,
+    scope_visibility: str,
+    ttl_secs: int,
+    created_at: int,
+    updated_at: int,
+) -> bytes:
+    """
+    Build the canonical binary signing payload matching
+    ServiceEndpoint::signing_payload() in icn-kernel-api/src/naming.rs.
+
+    Fields are length-prefixed (u32 LE) to prevent ambiguity attacks.
+    """
+    buf = b""
+    buf = _lp(buf, service_id)
+    buf = _lp(buf, provider)
+    buf += bytes([_ENDPOINT_TYPE_BYTE.get(endpoint_type, 1)])
+    buf = _lp(buf, service_type)
+    buf = _lp(buf, service_version)
+
+    # Endpoints: count then each endpoint
+    buf += struct.pack("<I", len(endpoints))
+    for ep in endpoints:
+        buf = _lp(buf, ep["protocol"])
+        buf = _lp(buf, ep["host"])
+        buf += struct.pack("<H", ep["port"])
+        path = ep.get("path")
+        if path is not None:
+            buf += b"\x01"
+            buf = _lp(buf, path)
+        else:
+            buf += b"\x00"
+
+    # Addresses and capabilities: sorted for determinism
+    for lst in [sorted(addresses), sorted(capabilities)]:
+        buf += struct.pack("<I", len(lst))
+        for item in lst:
+            buf = _lp(buf, item)
+
+    buf += struct.pack("<d", trust_threshold)
+    buf += bytes([_SCOPE_BYTE.get(scope_visibility.lower(), 2)])
+    buf += b"\x00"  # no cell_id
+    buf += struct.pack("<Q", ttl_secs)
+    buf += struct.pack("<Q", created_at)
+    buf += struct.pack("<Q", updated_at)
+    return buf
+
+
+def build_announce_request(service_id: str) -> dict:
+    """
+    Generate an ephemeral keypair, build and sign an AnnounceRequest.
+    Returns the request dict ready for JSON serialization.
+    """
+    now = int(time.time())
+    endpoint_type = "http"
+    service_type = "ledger"
+    service_version = "1.0"
+    endpoints = [{"protocol": "http", "host": "node-a.devnet", "port": 8080}]
+    addresses: list = []
+    capabilities = ["read", "write"]
+    trust_threshold = 0.0
+    scope_visibility = "org"
+    ttl_secs = 3600
+
+    # Generate ephemeral Ed25519 keypair; derive provider DID from public key
+    priv = Ed25519PrivateKey.generate()
+    pub_bytes = priv.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    provider = _make_did(pub_bytes)
+
+    payload = _build_signing_payload(
+        service_id,
+        provider,
+        endpoint_type,
+        service_type,
+        service_version,
+        endpoints,
+        addresses,
+        capabilities,
+        trust_threshold,
+        scope_visibility,
+        ttl_secs,
+        now,
+        now,
+    )
+    sig = priv.sign(payload)
+
+    return {
+        "service_id": service_id,
+        "provider": provider,
+        "endpoint_type": endpoint_type,
+        "service_type": service_type,
+        "service_version": service_version,
+        "endpoints": endpoints,
+        "addresses": addresses,
+        "capabilities": capabilities,
+        "trust_threshold": trust_threshold,
+        "scope_visibility": scope_visibility,
+        "ttl_secs": ttl_secs,
+        "created_at": now,
+        "updated_at": now,
+        "signature": sig.hex(),
+    }
+
+
+if __name__ == "__main__":
+    service_id = (
+        sys.argv[1]
+        if len(sys.argv) > 1
+        else os.environ.get("SVC_ID", f"demo-ledger-{int(time.time())}")
+    )
+    req = build_announce_request(service_id)
+    print(json.dumps(req))

--- a/sdk/typescript/src/generated/api-types.ts
+++ b/sdk/typescript/src/generated/api-types.ts
@@ -16,22 +16,6 @@ export interface components {
             /** Format: int64 */
             debit?: number | null;
         };
-        /** @description Recent activity event */
-        ActivityEvent: {
-            /** @description Event description */
-            description: string;
-            /** @description Event type */
-            event_type: string;
-            /** @description Resource ID (proposal/amendment/appeal) */
-            resource_id: string;
-            /** @description Resource type */
-            resource_type: string;
-            /**
-             * Format: int64
-             * @description Timestamp
-             */
-            timestamp: number;
-        };
         /** @description Add a member to a cooperative */
         AddMemberRequest: {
             did: string;
@@ -224,6 +208,7 @@ export interface components {
             description: string;
             domain_id: string;
             payload: components["schemas"]["ProposalPayloadRequest"];
+            scope?: null | components["schemas"]["ProposalScopeRequest"];
             title: string;
         };
         /** @description Create a new login session for QR-based authentication */
@@ -301,6 +286,22 @@ export interface components {
             ready_for_activation: boolean;
             total_founders: number;
         };
+        /** @description Recent governance activity event */
+        GovernanceActivityEvent: {
+            /** @description Event description */
+            description: string;
+            /** @description Event type */
+            event_type: string;
+            /** @description Resource ID (proposal/amendment/appeal) */
+            resource_id: string;
+            /** @description Resource type */
+            resource_type: string;
+            /**
+             * Format: int64
+             * @description Timestamp
+             */
+            timestamp: number;
+        };
         /** @description Governance dashboard data */
         GovernanceDashboard: {
             /** @description Amendments breakdown */
@@ -314,13 +315,15 @@ export interface components {
             /** @description Pending amendments count */
             pending_amendments: number;
             /** @description Recent activity events */
-            recent_activity: components["schemas"]["ActivityEvent"][];
+            recent_activity: components["schemas"]["GovernanceActivityEvent"][];
         };
         /** @description Health check response */
         HealthResponse: {
+            build_time?: string | null;
             checks?: {
                 [key: string]: components["schemas"]["ComponentHealth"];
             } | null;
+            git_sha?: string | null;
             status: string;
             version: string;
         };
@@ -464,7 +467,7 @@ export interface components {
          * @enum {string}
          */
         Platform: "ios" | "android" | "web";
-        /** @description Proposal payload types (matches icn_governance::ProposalPayload) */
+        /** @description Proposal payload types (gateway-local variant of the governance proposal payload) */
         ProposalPayloadRequest: {
             body: string;
             /** @enum {string} */
@@ -487,6 +490,16 @@ export interface components {
             /** @enum {string} */
             type: "config_change";
             value: string;
+        };
+        /** @description Scope for a proposal (local or federation-wide) */
+        ProposalScopeRequest: {
+            /** @enum {string} */
+            type: "local";
+        } | {
+            /** @description Federation identifier */
+            federation_id: string;
+            /** @enum {string} */
+            type: "federation";
         };
         /** @description Register device request */
         RegisterDeviceRequest: {


### PR DESCRIPTION
## Summary

- `web::scope("")` in actix-web matches **any** path prefix. The governance catch-all was registered at server.rs:1183 — before `/rights`, `/invites`, `/compute`, `/execution`, `/names`, `/services`, etc.
- actix-web's radix trie matches the first registered service whose prefix matches. For any path, the empty-prefix governance scope matched first. When no governance route matched the inner path, it returned 404 **without falling through** to the specific scopes that follow.
- All routes registered after the governance scope (including `/v1/services/*`, `/v1/names/*`, `/v1/compute/*`, `/v1/rights/*`) have been silently returning 404 since the governance HTTP layer was introduced.

**Fix:** Move `web::scope("").configure(governance)` to the end of the `.service()` list, joining the `// === Empty-scope services (MUST be last) ===` section that already exists for recurring_payments, escrow, budgets, governance_dashboard, and communities.

**Verified:** `demo-flow-b.sh` runs end-to-end — announce → discover → get → withdraw — all returning correct status codes.

### What broke the same way (now fixed)
- `/v1/services/announce` — 404 → 400 (missing body) / 200
- `/v1/services/discover` — 404 → 200
- `/v1/names/*` — 404 → 400/200
- `/v1/compute/*` — 404 → 400/200
- `/v1/rights/*` — 404 → 200
- `/v1/invites/*` — 404 → 200
- `/v1/execution/*` — 404 → 200

### Also included
- **devnet**: fix gateway port `8000` → `8080` in docker-compose.yml, add `entrypoint.sh` volume mount, add `image: icn:latest` tag
- **scripts/demo-flow-b.sh**: service discovery E2E demo (announce → discover → get → withdraw → verify 404)
- **scripts/sign_service_announce.py**: standalone helper for building signed service announcement payloads

## Test plan
- [x] `cargo check -p icn-gateway` passes
- [x] `demo-flow-b.sh` completes all 6 steps successfully against local icnd
- [x] Routes before the governance scope (e.g. `/v1/ledger/*`) still return correct status
- [ ] `cargo test -p icn-gateway` on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)