### PR TITLE
test(governance): update emitted effects surface contract approved list

### DIFF
--- a/icn/crates/icn-core/tests/emitted_surface_contract.rs
+++ b/icn/crates/icn-core/tests/emitted_surface_contract.rs
@@ -34,6 +34,7 @@ fn approved_emitted_effects() -> BTreeSet<&'static str> {
         // Treasury effects
         "Treasury::Spend",
         "Treasury::CreateBudget",
+        "Treasury::DistributeSurplus",
         // Membership effects
         "Membership::AddMember",
         "Membership::RemoveMember",
@@ -42,6 +43,7 @@ fn approved_emitted_effects() -> BTreeSet<&'static str> {
         // Protocol effects
         "Protocol::SetGovernanceConfig",
         "Protocol::SetSchedulingPolicy",
+        "Protocol::SetParameter",
         "Protocol::Upgrade",
         // Control effects
         "Control::VetoProposal",
@@ -51,6 +53,16 @@ fn approved_emitted_effects() -> BTreeSet<&'static str> {
         "Federation::JoinFederation",
         "Federation::LeaveFederation",
         "Federation::EstablishClearing",
+        "Federation::VouchForCoop",
+        // Dispute effects
+        "Dispute::ResolveDispute",
+        "Dispute::RollbackLedger",
+        // Resource effects
+        "Resource::GrantAccess",
+        "Resource::RevokeAccess",
+        // SDIS effects
+        "Sdis::ApproveSteward",
+        "Sdis::RevokeSteward",
         // Fallback (always allowed)
         "NoOp",
     ]


### PR DESCRIPTION
## Summary

- Updates `approved_emitted_effects()` in `crates/icn-core/tests/emitted_surface_contract.rs` to include 9 effects that the governance translator already emits but were never added to the approved list
- Unblocks Dependabot PR #1314 (TypeScript dev-dep bump) which was failing `Test` CI due to this pre-existing main branch failure

## Effects added

All have confirmed `KernelEffect` definitions in `icn-kernel-api/src/effects.rs`:

| Effect | Kernel type |
|--------|------------|
| `Treasury::DistributeSurplus` | `TreasuryEffect` |
| `Protocol::SetParameter` | `ProtocolEffect` |
| `Federation::VouchForCoop` | `FederationEffect` |
| `Dispute::ResolveDispute` | `DisputeEffect` |
| `Dispute::RollbackLedger` | `DisputeEffect` |
| `Resource::GrantAccess` | `ResourceEffect` |
| `Resource::RevokeAccess` | `ResourceEffect` |
| `Sdis::ApproveSteward` | `SdisEffect` |
| `Sdis::RevokeSteward` | `SdisEffect` |

## Test plan

- `cargo test -p icn-core --test emitted_surface_contract` — 5 passed, 0 failed ✅
- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)