### PR TITLE
feat(ledger): replace optional provenance fields with required ProvenanceRef enum (closes #1305)

### DIFF
--- a/icn/crates/icn-api/src/ledger.rs
+++ b/icn/crates/icn-api/src/ledger.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use icn_identity::Did;
-use icn_ledger::Ledger;
+use icn_ledger::{types::ProvenanceRef, Ledger};
 
 use crate::error::ApiError;
 
@@ -114,7 +114,16 @@ impl LedgerService {
         let mut page_entries = Vec::new();
 
         for entry in entries {
-            if entry.decision_hash.as_deref() != Some(decision_hash) {
+            // Extract governance provenance fields for filtering and view projection
+            let (view_receipt_id, view_decision_hash) = match &entry.provenance {
+                ProvenanceRef::Governance {
+                    receipt_id,
+                    decision_hash: dh,
+                } => (Some(receipt_id.clone()), Some(dh.clone())),
+                _ => (None, None),
+            };
+
+            if view_decision_hash.as_deref() != Some(decision_hash) {
                 continue;
             }
 
@@ -137,8 +146,8 @@ impl LedgerService {
                         credit: delta.credit,
                     })
                     .collect(),
-                decision_receipt_id: entry.decision_receipt_id.clone(),
-                decision_hash: entry.decision_hash.clone(),
+                decision_receipt_id: view_receipt_id,
+                decision_hash: view_decision_hash,
             });
         }
 

--- a/icn/crates/icn-core/src/services/ledger_service.rs
+++ b/icn/crates/icn-core/src/services/ledger_service.rs
@@ -22,7 +22,7 @@ use icn_kernel_api::services::{
 };
 use icn_kernel_api::types::Did;
 use icn_kernel_api::PolicyOracle;
-use icn_ledger::{entry::JournalEntryBuilder, AccountDelta, Ledger};
+use icn_ledger::{entry::JournalEntryBuilder, types::ProvenanceRef, AccountDelta, Ledger};
 use icn_store::SledStore;
 use tokio::sync::RwLock;
 use tracing::{debug, info};
@@ -188,7 +188,15 @@ impl LedgerServiceImpl {
             .map_err(|e| format!("Failed to query ledger entries: {e}"))?;
 
         for mut existing_entry in entries {
-            if existing_entry.decision_receipt_id.as_deref() != Some(decision_receipt_id) {
+            let (entry_receipt_id, entry_decision_hash) = match &existing_entry.provenance {
+                ProvenanceRef::Governance {
+                    receipt_id,
+                    decision_hash,
+                } => (Some(receipt_id.as_str()), Some(decision_hash.clone())),
+                _ => (None, None),
+            };
+
+            if entry_receipt_id != Some(decision_receipt_id) {
                 continue;
             }
 
@@ -201,7 +209,7 @@ impl LedgerServiceImpl {
                     .to_hex()
             };
 
-            return Ok(Some((entry_hash_hex, existing_entry.decision_hash.clone())));
+            return Ok(Some((entry_hash_hex, entry_decision_hash)));
         }
 
         Ok(None)

--- a/icn/crates/icn-core/src/services/ledger_service.rs
+++ b/icn/crates/icn-core/src/services/ledger_service.rs
@@ -613,7 +613,7 @@ impl LedgerService for LedgerServiceImpl {
         let mut builder = JournalEntryBuilder::new(self.treasury_did.clone());
 
         // Add decision provenance (PILOT-CRITICAL INVARIANT)
-        builder = builder.with_decision_provenance(&req.decision_receipt_id, &req.decision_hash);
+        builder = builder.with_governance_provenance(&req.decision_receipt_id, &req.decision_hash);
 
         // Add account deltas
         for delta in deltas {

--- a/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
+++ b/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
@@ -20,7 +20,7 @@ use icn_kernel_api::effects::{KernelEffect, TreasuryEffect};
 use icn_kernel_api::execution::{ExecutionRecord, ExecutionStatus, ExecutionStore};
 use icn_kernel_api::protocol_params::StubParamStore;
 use icn_kernel_api::AllowAllOracle;
-use icn_ledger::types::ContentHash;
+use icn_ledger::types::{ContentHash, ProvenanceRef};
 use icn_ledger::Ledger;
 use icn_store::SledStore;
 use tempfile::TempDir;
@@ -584,11 +584,14 @@ async fn test_treasury_entry_persisted_with_provenance() {
         let hash = hash.unwrap();
         let ledger_guard = ledger.read().await;
         let entry = ledger_guard.get_entry(&hash).unwrap().unwrap();
-        assert_eq!(
-            entry.decision_receipt_id.as_deref(),
-            Some(decision_receipt_id)
+        assert!(
+            matches!(
+                &entry.provenance,
+                ProvenanceRef::Governance { receipt_id, decision_hash: dh }
+                    if receipt_id == decision_receipt_id && dh == decision_hash
+            ),
+            "entry provenance must be Governance with matching receipt_id and decision_hash"
         );
-        assert_eq!(entry.decision_hash.as_deref(), Some(decision_hash));
         drop(ledger_guard);
 
         entry_hash
@@ -598,11 +601,14 @@ async fn test_treasury_entry_persisted_with_provenance() {
     let reopened_ledger = Ledger::new(reopened_ledger_store).unwrap();
     let reopened_hash = content_hash_from_hex(&entry_hash).unwrap();
     let reopened_entry = reopened_ledger.get_entry(&reopened_hash).unwrap().unwrap();
-    assert_eq!(
-        reopened_entry.decision_receipt_id.as_deref(),
-        Some(decision_receipt_id)
+    assert!(
+        matches!(
+            &reopened_entry.provenance,
+            ProvenanceRef::Governance { receipt_id, decision_hash: dh }
+                if receipt_id == decision_receipt_id && dh == decision_hash
+        ),
+        "reopened entry provenance must be Governance with matching receipt_id and decision_hash"
     );
-    assert_eq!(reopened_entry.decision_hash.as_deref(), Some(decision_hash));
 
     let reopened_exec_backend = Arc::new(SledStore::open(&exec_store_path).unwrap());
     let reopened_exec_store = SledExecutionStore::new(reopened_exec_backend);
@@ -693,11 +699,14 @@ async fn test_withdraw_payload_restart_resume_single_mutation() {
 
         let parsed = content_hash_from_hex(&entry_hash).unwrap();
         let entry = ledger.read().await.get_entry(&parsed).unwrap().unwrap();
-        assert_eq!(
-            entry.decision_receipt_id.as_deref(),
-            Some(decision_receipt_id)
+        assert!(
+            matches!(
+                &entry.provenance,
+                ProvenanceRef::Governance { receipt_id, decision_hash: dh }
+                    if receipt_id == decision_receipt_id && dh == decision_hash
+            ),
+            "entry provenance must be Governance with matching receipt_id and decision_hash"
         );
-        assert_eq!(entry.decision_hash.as_deref(), Some(decision_hash));
         assert_eq!(ledger.read().await.count_entries().unwrap(), 1);
 
         entry_hash
@@ -749,11 +758,14 @@ async fn test_withdraw_payload_restart_resume_single_mutation() {
         .get_entry(&parsed)
         .unwrap()
         .unwrap();
-    assert_eq!(
-        reopened_entry.decision_receipt_id.as_deref(),
-        Some(decision_receipt_id)
+    assert!(
+        matches!(
+            &reopened_entry.provenance,
+            ProvenanceRef::Governance { receipt_id, decision_hash: dh }
+                if receipt_id == decision_receipt_id && dh == decision_hash
+        ),
+        "reopened entry provenance must be Governance with matching receipt_id and decision_hash"
     );
-    assert_eq!(reopened_entry.decision_hash.as_deref(), Some(decision_hash));
 
     let reopened_record = reopened_exec_store.get(decision_hash).unwrap().unwrap();
     assert_eq!(reopened_record.status, ExecutionStatus::Confirmed);

--- a/icn/crates/icn-core/tests/treasury_integration.rs
+++ b/icn/crates/icn-core/tests/treasury_integration.rs
@@ -15,6 +15,7 @@ use icn_identity::Did;
 use icn_ledger::treasury::{
     ApprovalType, BudgetStatus, SpendingRule, TreasuryManager, TreasuryOperation, VelocityLimit,
 };
+use icn_ledger::types::ProvenanceRef;
 use icn_ledger::{AccountDelta, ContentHash, JournalEntry};
 use icn_store::SledStore;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -243,8 +244,9 @@ async fn test_spending_rule_enforcement() -> Result<()> {
             parents: vec![],
             signature: None,
             nonce: None,
-            decision_receipt_id: None,
-            decision_hash: None,
+            provenance: ProvenanceRef::SystemGenerated {
+                reason: "test".to_string(),
+            },
         };
 
         let result = guard.validate_entry(&entry);
@@ -279,8 +281,9 @@ async fn test_spending_rule_enforcement() -> Result<()> {
             parents: vec![],
             signature: None,
             nonce: None,
-            decision_receipt_id: None,
-            decision_hash: None,
+            provenance: ProvenanceRef::SystemGenerated {
+                reason: "test".to_string(),
+            },
         };
 
         let result = guard.validate_entry(&entry);
@@ -338,8 +341,9 @@ async fn test_spending_below_threshold_allowed() -> Result<()> {
             parents: vec![],
             signature: None,
             nonce: None,
-            decision_receipt_id: None,
-            decision_hash: None,
+            provenance: ProvenanceRef::SystemGenerated {
+                reason: "test".to_string(),
+            },
         };
 
         let result = guard.validate_entry(&entry);
@@ -1218,15 +1222,13 @@ async fn test_ledger_entry_carries_decision_provenance() -> Result<()> {
             .ok_or_else(|| anyhow::anyhow!("Entry not found in ledger"))?;
 
         // THE PILOT-CRITICAL ASSERTIONS:
-        assert_eq!(
-            entry.decision_receipt_id.as_ref(),
-            Some(&decision_receipt_id),
-            "Ledger entry must carry decision_receipt_id"
-        );
-        assert_eq!(
-            entry.decision_hash.as_ref(),
-            Some(&decision_hash),
-            "Ledger entry must carry decision_hash (canonical cross-node anchor)"
+        assert!(
+            matches!(
+                &entry.provenance,
+                ProvenanceRef::Governance { receipt_id, decision_hash: dh }
+                    if receipt_id == &decision_receipt_id && dh == &decision_hash
+            ),
+            "Ledger entry must carry Governance provenance with matching receipt_id and decision_hash"
         );
 
         info!(
@@ -1359,15 +1361,13 @@ async fn test_decision_to_ledger_provenance_end_to_end() -> Result<()> {
             .ok_or_else(|| anyhow::anyhow!("Entry not found in ledger"))?;
 
         // THE E2E PILOT-CRITICAL ASSERTIONS:
-        assert_eq!(
-            entry.decision_receipt_id.as_ref(),
-            Some(&decision_receipt_id.to_string()),
-            "Ledger entry must carry decision_receipt_id from executor path"
-        );
-        assert_eq!(
-            entry.decision_hash.as_ref(),
-            Some(&decision_hash),
-            "Ledger entry must carry decision_hash from executor path"
+        assert!(
+            matches!(
+                &entry.provenance,
+                ProvenanceRef::Governance { receipt_id, decision_hash: dh }
+                    if receipt_id == &decision_receipt_id.to_string() && dh == &decision_hash
+            ),
+            "Ledger entry must carry Governance provenance with matching receipt_id and decision_hash from executor path"
         );
 
         // Print the pilot chain for demo visibility (machine-parseable + human-readable)

--- a/icn/crates/icn-gateway/src/api/ledger.rs
+++ b/icn/crates/icn-gateway/src/api/ledger.rs
@@ -15,6 +15,7 @@ use crate::models::{
 use crate::rate_limit::VelocityLimiter;
 use crate::trust_mgr::TrustManager;
 use crate::validation;
+use icn_ledger::types::ProvenanceRef;
 use icn_obs::metrics::gateway;
 
 /// GET /ledger/:coop_id/position/:did - Get account position
@@ -310,13 +311,21 @@ pub async fn get_history(
                 })
                 .collect();
 
+            let (decision_receipt_id, decision_hash) = match &entry.provenance {
+                ProvenanceRef::Governance {
+                    receipt_id,
+                    decision_hash: dh,
+                } => (Some(receipt_id.clone()), Some(dh.clone())),
+                _ => (None, None),
+            };
+
             TransactionHistoryEntry {
                 id: entry.id.map(|h| h.to_hex()).unwrap_or_default(),
                 timestamp: entry.timestamp,
                 author: entry.author.to_string(),
                 accounts,
-                decision_receipt_id: entry.decision_receipt_id.clone(),
-                decision_hash: entry.decision_hash.clone(),
+                decision_receipt_id,
+                decision_hash,
             }
         })
         .collect();
@@ -443,7 +452,12 @@ pub async fn get_entries_by_decision(
     // Filter entries by decision_hash
     let matching_entries: Vec<_> = entries
         .into_iter()
-        .filter(|entry| entry.decision_hash.as_deref() == Some(decision_hash.as_str()))
+        .filter(|entry| {
+            matches!(
+                &entry.provenance,
+                ProvenanceRef::Governance { decision_hash: dh, .. } if dh == decision_hash
+            )
+        })
         .collect();
     let has_more = matching_entries.len() > limit;
 
@@ -462,13 +476,21 @@ pub async fn get_entries_by_decision(
                 })
                 .collect();
 
+            let (decision_receipt_id, decision_hash) = match &entry.provenance {
+                ProvenanceRef::Governance {
+                    receipt_id,
+                    decision_hash: dh,
+                } => (Some(receipt_id.clone()), Some(dh.clone())),
+                _ => (None, None),
+            };
+
             TransactionHistoryEntry {
                 id: entry.id.map(|h| h.to_hex()).unwrap_or_default(),
                 timestamp: entry.timestamp,
                 author: entry.author.to_string(),
                 accounts,
-                decision_receipt_id: entry.decision_receipt_id.clone(),
-                decision_hash: entry.decision_hash.clone(),
+                decision_receipt_id,
+                decision_hash,
             }
         })
         .collect();

--- a/icn/crates/icn-gateway/src/api/ledger.rs
+++ b/icn/crates/icn-gateway/src/api/ledger.rs
@@ -847,7 +847,7 @@ mod tests {
         let service_entry = JournalEntryBuilder::new(alice.did().clone())
             .debit(alice.did().clone(), "hours".to_string(), 10)
             .credit(bob.did().clone(), "hours".to_string(), 10)
-            .with_decision_provenance("receipt-123", decision_hash.as_str())
+            .with_governance_provenance("receipt-123", decision_hash.as_str())
             .build()
             .unwrap();
         service_ledger.append_entry(service_entry).await.unwrap();

--- a/icn/crates/icn-gateway/src/api/registry.rs
+++ b/icn/crates/icn-gateway/src/api/registry.rs
@@ -1176,7 +1176,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(from.clone())
             .debit(from, "credits".to_string(), 25)
             .credit(to, "credits".to_string(), 25)
-            .with_decision_provenance(&decision_receipt_id, &decision_hash_hex)
+            .with_governance_provenance(&decision_receipt_id, &decision_hash_hex)
             .build()
             .unwrap();
         ledger.write().await.append_entry(entry).await.unwrap();

--- a/icn/crates/icn-gateway/src/ledger_mgr.rs
+++ b/icn/crates/icn-gateway/src/ledger_mgr.rs
@@ -149,6 +149,7 @@ impl LedgerManager {
         let entry = JournalEntryBuilder::new(from.clone())
             .debit(from.clone(), currency.clone(), amount)
             .credit(to.clone(), currency.clone(), amount)
+            .with_system_provenance("direct settlement")
             .build()
             .map_err(GatewayError::SubstrateError)?;
 

--- a/icn/crates/icn-gateway/src/treasury_mgr.rs
+++ b/icn/crates/icn-gateway/src/treasury_mgr.rs
@@ -454,6 +454,7 @@ impl GatewayTreasuryManager {
         let mut entry = icn_ledger::entry::JournalEntryBuilder::new(from_did.clone())
             .credit(from_did.clone(), currency.clone(), amount) // Depositor gives funds
             .debit(treasury_did.clone(), currency.clone(), amount) // Treasury receives funds
+            .with_system_provenance("treasury deposit")
             .build()?;
 
         // Compute the hash

--- a/icn/crates/icn-ledger/src/balance.rs
+++ b/icn/crates/icn-ledger/src/balance.rs
@@ -120,6 +120,7 @@ mod tests {
         let entry1 = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -127,6 +128,7 @@ mod tests {
         let entry2 = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 5)
             .credit(bob.clone(), "hours".to_string(), 5)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -152,6 +154,7 @@ mod tests {
             .credit(bob.clone(), "hours".to_string(), 10)
             .debit(alice.clone(), "USD".to_string(), 100)
             .credit(bob.clone(), "USD".to_string(), 100)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -173,12 +176,14 @@ mod tests {
         let entry1 = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
         let entry2 = JournalEntryBuilder::new(bob.clone())
             .debit(bob.clone(), "hours".to_string(), 5)
             .credit(charlie.clone(), "hours".to_string(), 5)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -212,6 +217,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 60)
             .credit(bob.clone(), "hours".to_string(), 60)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -238,6 +244,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 50)
             .credit(bob.clone(), "hours".to_string(), 50)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -302,12 +309,14 @@ mod tests {
         let entry1 = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), i64::MAX / 2)
             .credit(bob.clone(), "hours".to_string(), i64::MAX / 2)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
         let entry2 = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), i64::MAX / 2 + 100)
             .credit(bob.clone(), "hours".to_string(), i64::MAX / 2 + 100)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 

--- a/icn/crates/icn-ledger/src/commons_credits.rs
+++ b/icn/crates/icn-ledger/src/commons_credits.rs
@@ -226,7 +226,8 @@ fn build_earn_entry_inner(
             contributor.clone(),
             COMMONS_CREDIT_CURRENCY.to_string(),
             amount,
-        );
+        )
+        .with_system_provenance("commons-mint");
 
     if let Some(n) = nonce {
         builder = builder.nonce(n);
@@ -280,7 +281,8 @@ fn build_spend_entry_inner(
             COMMONS_CREDIT_CURRENCY.to_string(),
             amount,
         )
-        .credit(mint_did, COMMONS_CREDIT_CURRENCY.to_string(), amount);
+        .credit(mint_did, COMMONS_CREDIT_CURRENCY.to_string(), amount)
+        .with_system_provenance("commons-spend");
 
     if let Some(n) = nonce {
         builder = builder.nonce(n);

--- a/icn/crates/icn-ledger/src/entry.rs
+++ b/icn/crates/icn-ledger/src/entry.rs
@@ -1,6 +1,6 @@
 //! Journal entry creation and validation
 
-use crate::types::{AccountDelta, ContentHash, JournalEntry};
+use crate::types::{AccountDelta, ContentHash, JournalEntry, ProvenanceRef};
 use anyhow::{bail, Result};
 use icn_identity::Did;
 use std::collections::HashMap;
@@ -12,8 +12,7 @@ pub struct JournalEntryBuilder {
     accounts: Vec<AccountDelta>,
     parents: Vec<ContentHash>,
     nonce: Option<[u8; 32]>,
-    decision_receipt_id: Option<String>,
-    decision_hash: Option<String>,
+    provenance: Option<ProvenanceRef>,
 }
 
 impl JournalEntryBuilder {
@@ -25,8 +24,7 @@ impl JournalEntryBuilder {
             accounts: Vec::new(),
             parents: Vec::new(),
             nonce: None,
-            decision_receipt_id: None,
-            decision_hash: None,
+            provenance: None,
         }
     }
 
@@ -72,31 +70,62 @@ impl JournalEntryBuilder {
         self
     }
 
-    /// Set the governance decision provenance.
+    /// Set governance decision provenance.
     ///
-    /// Links this ledger entry to the governance decision that authorized it.
-    /// Both fields should be set together for complete provenance.
+    /// Use when this entry was authorized by a governance proposal/vote.
     ///
     /// # Arguments
-    /// * `receipt_id` - Node-local decision receipt ID (e.g., "gov:proposal:2024-001:receipt:abc")
-    /// * `hash` - Canonical decision hash (cross-node anchor, e.g., "sha256:abc123...")
-    pub fn with_decision_provenance(
+    /// * `receipt_id` - Node-local decision receipt ID
+    /// * `decision_hash` - Canonical cross-node hash anchor
+    pub fn with_governance_provenance(
         mut self,
         receipt_id: impl Into<String>,
-        hash: impl Into<String>,
+        decision_hash: impl Into<String>,
     ) -> Self {
-        self.decision_receipt_id = Some(receipt_id.into());
-        self.decision_hash = Some(hash.into());
+        self.provenance = Some(ProvenanceRef::Governance {
+            receipt_id: receipt_id.into(),
+            decision_hash: decision_hash.into(),
+        });
         self
     }
 
-    /// Build and validate the journal entry
+    /// Set governance decision provenance (legacy name, same as `with_governance_provenance`).
+    pub fn with_decision_provenance(
+        self,
+        receipt_id: impl Into<String>,
+        decision_hash: impl Into<String>,
+    ) -> Self {
+        self.with_governance_provenance(receipt_id, decision_hash)
+    }
+
+    /// Set system-generated provenance.
+    ///
+    /// Use for internal operations: FX transfers, DID migration, mint/burn.
+    pub fn with_system_provenance(mut self, reason: impl Into<String>) -> Self {
+        self.provenance = Some(ProvenanceRef::SystemGenerated {
+            reason: reason.into(),
+        });
+        self
+    }
+
+    /// Build and validate the journal entry.
+    ///
+    /// Returns `Err` if:
+    /// - Double-entry invariant is violated (Σ debits ≠ Σ credits per currency)
+    /// - Any amount is negative
+    /// - No provenance was set (use `with_governance_provenance` or `with_system_provenance`)
+    /// - The system clock is unavailable
     pub fn build(self) -> Result<JournalEntry> {
         // Validate double-entry invariant: Σ debits == Σ credits per currency
         validate_double_entry(&self.accounts)?;
 
         // Validate that amounts are positive
         validate_positive_amounts(&self.accounts)?;
+
+        // Require provenance — every entry must be traceable
+        let provenance = self
+            .provenance
+            .ok_or_else(|| anyhow::anyhow!("JournalEntry requires provenance; call with_governance_provenance() or with_system_provenance()"))?;
 
         // Get current timestamp in milliseconds (security-critical: reject if clock is invalid)
         let timestamp = icn_time::try_current_timestamp_millis()
@@ -111,8 +140,7 @@ impl JournalEntryBuilder {
             parents: self.parents,
             signature: None, // Will be set by caller
             nonce: self.nonce,
-            decision_receipt_id: self.decision_receipt_id,
-            decision_hash: self.decision_hash,
+            provenance,
         };
 
         // Compute the content hash
@@ -190,6 +218,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build();
 
         assert!(entry.is_ok(), "Valid entry should build successfully");
@@ -208,6 +237,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 5) // Unbalanced!
+            .with_system_provenance("test")
             .build();
 
         assert!(entry.is_err(), "Unbalanced entry should fail validation");
@@ -226,6 +256,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), -10) // Negative!
             .credit(bob.clone(), "hours".to_string(), -10) // Negative!
+            .with_system_provenance("test")
             .build();
 
         assert!(entry.is_err(), "Negative amounts should fail validation");
@@ -246,6 +277,7 @@ mod tests {
             .credit(bob.clone(), "hours".to_string(), 10)
             .debit(alice.clone(), "USD".to_string(), 100)
             .credit(bob.clone(), "USD".to_string(), 100)
+            .with_system_provenance("test")
             .build();
 
         assert!(
@@ -268,6 +300,7 @@ mod tests {
             .credit(bob.clone(), "hours".to_string(), 10)
             .debit(alice.clone(), "USD".to_string(), 100)
             .credit(bob.clone(), "USD".to_string(), 50) // Unbalanced USD!
+            .with_system_provenance("test")
             .build();
 
         assert!(
@@ -277,63 +310,92 @@ mod tests {
         assert!(entry.unwrap_err().to_string().contains("USD"));
     }
 
-    /// Golden-path test: JournalEntry with decision provenance
+    /// Golden-path test: JournalEntry with governance provenance
     ///
-    /// This test verifies the pilot invariant:
-    /// - Ledger entries carry decision_receipt_id and decision_hash
-    /// - These fields are preserved through serialization
-    /// - The entry can be traced back to its authorizing decision
+    /// Verifies:
+    /// - `ProvenanceRef::Governance` is preserved through build
+    /// - Provenance round-trips through JSON serialization
     #[test]
-    fn test_entry_with_decision_provenance() {
+    fn test_entry_with_governance_provenance() {
         let keypair = KeyPair::generate().unwrap();
         let treasury = keypair.did().clone();
         let recipient = KeyPair::generate().unwrap().did().clone();
 
-        let decision_receipt_id = "gov:proposal:2024-001:receipt:abc123";
+        let receipt_id = "gov:proposal:2024-001:receipt:abc123";
         let decision_hash = "sha256:def456789...";
 
         let entry = JournalEntryBuilder::new(treasury.clone())
             .debit(treasury.clone(), "HOURS".to_string(), 2500)
             .credit(recipient.clone(), "HOURS".to_string(), 2500)
-            .with_decision_provenance(decision_receipt_id, decision_hash)
+            .with_governance_provenance(receipt_id, decision_hash)
             .build()
-            .expect("Entry with provenance should build successfully");
+            .expect("Entry with governance provenance should build successfully");
 
-        // Verify provenance fields are set
-        assert_eq!(
-            entry.decision_receipt_id.as_deref(),
-            Some(decision_receipt_id),
-            "decision_receipt_id must be preserved"
-        );
-        assert_eq!(
-            entry.decision_hash.as_deref(),
-            Some(decision_hash),
-            "decision_hash must be preserved"
-        );
+        // Verify provenance variant
+        match &entry.provenance {
+            ProvenanceRef::Governance {
+                receipt_id: r,
+                decision_hash: h,
+            } => {
+                assert_eq!(r, receipt_id);
+                assert_eq!(h, decision_hash);
+            }
+            other => panic!("Expected Governance provenance, got {other:?}"),
+        }
 
-        // Verify entry is valid
         assert!(entry.id.is_some(), "Entry should have computed hash");
 
-        // Verify serialization preserves provenance
+        // Round-trip through JSON
         let json = serde_json::to_string(&entry).expect("should serialize");
-        assert!(
-            json.contains(decision_receipt_id),
-            "JSON should contain decision_receipt_id"
-        );
+        assert!(json.contains(receipt_id), "JSON should contain receipt_id");
         assert!(
             json.contains(decision_hash),
             "JSON should contain decision_hash"
         );
-
-        // Verify deserialization preserves provenance
         let deserialized: JournalEntry = serde_json::from_str(&json).expect("should deserialize");
-        assert_eq!(
-            deserialized.decision_receipt_id, entry.decision_receipt_id,
-            "decision_receipt_id must survive round-trip"
+        assert_eq!(deserialized.provenance, entry.provenance);
+    }
+
+    /// Test that build() fails when no provenance is set.
+    #[test]
+    fn test_missing_provenance_fails() {
+        let keypair = KeyPair::generate().unwrap();
+        let alice = keypair.did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        let result = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 5)
+            .credit(bob.clone(), "hours".to_string(), 5)
+            .build();
+
+        assert!(result.is_err(), "build() without provenance must fail");
+        assert!(
+            result.unwrap_err().to_string().contains("provenance"),
+            "error message should mention provenance"
         );
-        assert_eq!(
-            deserialized.decision_hash, entry.decision_hash,
-            "decision_hash must survive round-trip"
-        );
+    }
+
+    /// Test that SystemGenerated provenance round-trips correctly.
+    #[test]
+    fn test_system_provenance_roundtrip() {
+        let keypair = KeyPair::generate().unwrap();
+        let alice = keypair.did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        let entry = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 5)
+            .credit(bob.clone(), "hours".to_string(), 5)
+            .with_system_provenance("fx-transfer")
+            .build()
+            .expect("system provenance entry should build");
+
+        match &entry.provenance {
+            ProvenanceRef::SystemGenerated { reason } => assert_eq!(reason, "fx-transfer"),
+            other => panic!("Expected SystemGenerated, got {other:?}"),
+        }
+
+        let json = serde_json::to_string(&entry).unwrap();
+        let de: JournalEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(de.provenance, entry.provenance);
     }
 }

--- a/icn/crates/icn-ledger/src/entry.rs
+++ b/icn/crates/icn-ledger/src/entry.rs
@@ -89,13 +89,22 @@ impl JournalEntryBuilder {
         self
     }
 
-    /// Set governance decision provenance (legacy name, same as `with_governance_provenance`).
-    pub fn with_decision_provenance(
-        self,
-        receipt_id: impl Into<String>,
-        decision_hash: impl Into<String>,
-    ) -> Self {
-        self.with_governance_provenance(receipt_id, decision_hash)
+    /// Set member-direct provenance.
+    ///
+    /// Use when a cooperative member directly authorizes a transfer without a
+    /// formal governance proposal — e.g., a member-to-member credit grant.
+    ///
+    /// # Arguments
+    /// * `did`       - DID of the authorizing member
+    /// * `signature` - Ed25519 signature of the entry by the member's key.
+    ///   A `DirectMember` entry without a signature has no verifiable
+    ///   authorization, so the signature is required.
+    pub fn with_direct_member_provenance(mut self, did: Did, signature: impl Into<String>) -> Self {
+        self.provenance = Some(ProvenanceRef::DirectMember {
+            did,
+            signature: signature.into(),
+        });
+        self
     }
 
     /// Set system-generated provenance.
@@ -113,7 +122,7 @@ impl JournalEntryBuilder {
     /// Returns `Err` if:
     /// - Double-entry invariant is violated (Σ debits ≠ Σ credits per currency)
     /// - Any amount is negative
-    /// - No provenance was set (use `with_governance_provenance` or `with_system_provenance`)
+    /// - No provenance was set (use `with_governance_provenance`, `with_direct_member_provenance`, or `with_system_provenance`)
     /// - The system clock is unavailable
     pub fn build(self) -> Result<JournalEntry> {
         // Validate double-entry invariant: Σ debits == Σ credits per currency
@@ -123,9 +132,12 @@ impl JournalEntryBuilder {
         validate_positive_amounts(&self.accounts)?;
 
         // Require provenance — every entry must be traceable
-        let provenance = self
-            .provenance
-            .ok_or_else(|| anyhow::anyhow!("JournalEntry requires provenance; call with_governance_provenance() or with_system_provenance()"))?;
+        let provenance = self.provenance.ok_or_else(|| {
+            anyhow::anyhow!(
+                "JournalEntry requires provenance; call with_governance_provenance(), \
+                 with_direct_member_provenance(), or with_system_provenance()"
+            )
+        })?;
 
         // Get current timestamp in milliseconds (security-critical: reject if clock is invalid)
         let timestamp = icn_time::try_current_timestamp_millis()
@@ -395,6 +407,36 @@ mod tests {
         }
 
         let json = serde_json::to_string(&entry).unwrap();
+        let de: JournalEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(de.provenance, entry.provenance);
+    }
+
+    /// Test that DirectMember provenance round-trips correctly.
+    #[test]
+    fn test_direct_member_provenance_roundtrip() {
+        let keypair = KeyPair::generate().unwrap();
+        let alice = keypair.did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        let sig = "ed25519:abcdef1234567890";
+
+        let entry = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 3)
+            .credit(bob.clone(), "hours".to_string(), 3)
+            .with_direct_member_provenance(alice.clone(), sig)
+            .build()
+            .expect("direct member provenance entry should build");
+
+        match &entry.provenance {
+            ProvenanceRef::DirectMember { did, signature } => {
+                assert_eq!(did, &alice);
+                assert_eq!(signature, sig);
+            }
+            other => panic!("Expected DirectMember, got {other:?}"),
+        }
+
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(json.contains(sig), "JSON should contain signature");
         let de: JournalEntry = serde_json::from_str(&json).unwrap();
         assert_eq!(de.provenance, entry.provenance);
     }

--- a/icn/crates/icn-ledger/src/fork_resolution.rs
+++ b/icn/crates/icn-ledger/src/fork_resolution.rs
@@ -412,7 +412,7 @@ impl Default for ForkDetector {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::AccountDelta;
+    use crate::types::{AccountDelta, ProvenanceRef};
     use icn_identity::{Did, KeyPair};
 
     fn make_test_did() -> Did {
@@ -439,8 +439,9 @@ mod tests {
             parents,
             signature: None,
             nonce: None,
-            decision_receipt_id: None,
-            decision_hash: None,
+            provenance: ProvenanceRef::SystemGenerated {
+                reason: "test".to_string(),
+            },
         }
     }
 

--- a/icn/crates/icn-ledger/src/fx.rs
+++ b/icn/crates/icn-ledger/src/fx.rs
@@ -813,7 +813,7 @@ mod tests {
     }
 
     fn create_test_prepared_transfer(valid_until: u64) -> PreparedFxTransfer {
-        use crate::types::JournalEntry;
+        use crate::types::{JournalEntry, ProvenanceRef};
         let sender = Did::from_anchor_id(&[3u8; 32]);
         let entry = JournalEntry {
             id: None,
@@ -824,8 +824,9 @@ mod tests {
             parents: vec![],
             signature: None,
             nonce: None,
-            decision_receipt_id: None,
-            decision_hash: None,
+            provenance: ProvenanceRef::SystemGenerated {
+                reason: "test".to_string(),
+            },
         };
 
         PreparedFxTransfer {

--- a/icn/crates/icn-ledger/src/hash.rs
+++ b/icn/crates/icn-ledger/src/hash.rs
@@ -64,7 +64,7 @@ impl JournalEntry {
 
 #[cfg(test)]
 mod tests {
-    use crate::types::{AccountDelta, JournalEntry};
+    use crate::types::{AccountDelta, JournalEntry, ProvenanceRef};
     use icn_identity::KeyPair;
 
     #[test]
@@ -84,8 +84,9 @@ mod tests {
             parents: vec![],
             signature: None,
             nonce: None,
-            decision_receipt_id: None,
-            decision_hash: None,
+            provenance: ProvenanceRef::SystemGenerated {
+                reason: "test".to_string(),
+            },
         };
 
         let mut entry2 = entry1.clone();
@@ -113,8 +114,9 @@ mod tests {
             parents: vec![],
             signature: None,
             nonce: None,
-            decision_receipt_id: None,
-            decision_hash: None,
+            provenance: ProvenanceRef::SystemGenerated {
+                reason: "test".to_string(),
+            },
         };
 
         let mut entry2 = entry1.clone();
@@ -146,8 +148,9 @@ mod tests {
             parents: vec![],
             signature: None,
             nonce: Some([0xAA; 32]),
-            decision_receipt_id: None,
-            decision_hash: None,
+            provenance: ProvenanceRef::SystemGenerated {
+                reason: "test".to_string(),
+            },
         };
 
         let mut entry2 = entry1.clone();
@@ -179,8 +182,9 @@ mod tests {
             parents: vec![],
             signature: None,
             nonce: Some([0xAA; 32]),
-            decision_receipt_id: None,
-            decision_hash: None,
+            provenance: ProvenanceRef::SystemGenerated {
+                reason: "test".to_string(),
+            },
         };
 
         let mut entry_without = entry_with.clone();

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -891,6 +891,7 @@ impl Ledger {
         }
 
         let entry = builder
+            .with_system_provenance("fx-transfer")
             .build()
             .map_err(|e| FxError::InvalidAmount(format!("Failed to build journal entry: {e}")))?;
 
@@ -1070,6 +1071,7 @@ impl Ledger {
         }
 
         let entry = builder
+            .with_system_provenance("fx-transfer")
             .build()
             .map_err(|e| FxError::InvalidAmount(format!("Failed to build journal entry: {e}")))?;
 
@@ -2451,6 +2453,7 @@ impl Ledger {
                 JournalEntryBuilder::new(new_did.clone())
                     .credit(old_did.clone(), currency.clone(), *balance) // Reduce old_did's balance
                     .debit(new_did.clone(), currency.clone(), *balance) // Increase new_did's balance
+                    .with_system_provenance("did-migration")
                     .build()?
             } else {
                 // old_did has negative balance (-100 means they owe credit)
@@ -2459,6 +2462,7 @@ impl Ledger {
                 JournalEntryBuilder::new(new_did.clone())
                     .debit(old_did.clone(), currency.clone(), debt_amount) // Reduce old_did's debt
                     .credit(new_did.clone(), currency.clone(), debt_amount) // Increase new_did's debt
+                    .with_system_provenance("did-migration")
                     .build()?
             };
 
@@ -3043,6 +3047,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3067,12 +3072,14 @@ mod tests {
         let entry1 = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
         let entry2 = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 5)
             .credit(bob.clone(), "hours".to_string(), 5)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3094,6 +3101,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3113,6 +3121,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3140,12 +3149,14 @@ mod tests {
         let entry1 = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
         let entry2 = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 5)
             .credit(bob.clone(), "hours".to_string(), 5)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3176,6 +3187,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3206,6 +3218,7 @@ mod tests {
         let mut entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3239,6 +3252,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3267,6 +3281,7 @@ mod tests {
         let entry1 = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3281,6 +3296,7 @@ mod tests {
         let entry2 = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 5)
             .credit(bob.clone(), "hours".to_string(), 5)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3305,6 +3321,7 @@ mod tests {
         let entry1 = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3318,6 +3335,7 @@ mod tests {
         let entry2 = JournalEntryBuilder::new(charlie.clone())
             .debit(charlie.clone(), "hours".to_string(), 5)
             .credit(bob.clone(), "hours".to_string(), 5)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3345,6 +3363,7 @@ mod tests {
         let entry1 = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3360,6 +3379,7 @@ mod tests {
         let entry2 = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3430,6 +3450,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 50)
             .credit(bob.clone(), "hours".to_string(), 50)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3489,6 +3510,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 600)
             .credit(bob.clone(), "hours".to_string(), 600)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3513,6 +3535,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 40)
             .credit(bob.clone(), "hours".to_string(), 40)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3563,6 +3586,7 @@ mod tests {
             let entry = JournalEntryBuilder::new(alice.clone())
                 .debit(alice.clone(), "hours".to_string(), 50)
                 .credit(funder.clone(), "hours".to_string(), 50)
+                .with_system_provenance("test")
                 .build()
                 .unwrap();
 
@@ -3582,6 +3606,7 @@ mod tests {
         let entry_over = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(funders[10].clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3607,6 +3632,7 @@ mod tests {
         let entry1 = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 40)
             .credit(bob.clone(), "hours".to_string(), 40)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3620,6 +3646,7 @@ mod tests {
         let entry2 = JournalEntryBuilder::new(alice.clone())
             .debit(charlie.clone(), "hours".to_string(), 30)
             .credit(alice.clone(), "hours".to_string(), 30)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3647,6 +3674,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(bob.clone())
             .debit(bob.clone(), "hours".to_string(), 100)
             .credit(alice.clone(), "hours".to_string(), 100)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3678,6 +3706,7 @@ mod tests {
             let entry = JournalEntryBuilder::new(sender.clone())
                 .debit(sender.clone(), "hours".to_string(), (i + 1) as i64)
                 .credit(receiver.clone(), "hours".to_string(), (i + 1) as i64)
+                .with_system_provenance("test")
                 .build()
                 .unwrap();
 
@@ -3773,6 +3802,7 @@ mod tests {
             let entry = JournalEntryBuilder::new(alice.clone())
                 .debit(alice.clone(), "hours".to_string(), (i + 1) as i64)
                 .credit(bob.clone(), "hours".to_string(), (i + 1) as i64)
+                .with_system_provenance("test")
                 .build()
                 .unwrap();
             ledger.append_entry(entry).await.unwrap();
@@ -3784,6 +3814,7 @@ mod tests {
             let entry = JournalEntryBuilder::new(charlie.clone())
                 .debit(charlie.clone(), "hours".to_string(), (i + 1) as i64)
                 .credit(bob.clone(), "hours".to_string(), (i + 1) as i64)
+                .with_system_provenance("test")
                 .build()
                 .unwrap();
             ledger.append_entry(entry).await.unwrap();
@@ -3906,6 +3937,7 @@ mod tests {
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
             .add_parent(fake_parent)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3933,6 +3965,7 @@ mod tests {
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
             .add_parent(fake_parent)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -3958,6 +3991,7 @@ mod tests {
         let entry1 = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
         let hash1 = entry1.id.clone().unwrap();
@@ -3968,6 +4002,7 @@ mod tests {
             .debit(alice.clone(), "hours".to_string(), 5)
             .credit(bob.clone(), "hours".to_string(), 5)
             .add_parent(hash1.clone())
+            .with_system_provenance("test")
             .build()
             .unwrap();
         let hash2 = entry2.id.clone().unwrap();
@@ -3992,6 +4027,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -4016,6 +4052,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -4060,6 +4097,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -4104,6 +4142,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -4145,6 +4184,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -4186,6 +4226,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -4227,6 +4268,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -4268,6 +4310,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -4314,6 +4357,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -4367,6 +4411,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -4397,6 +4442,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -4438,6 +4484,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -4495,8 +4542,9 @@ mod tests {
             parents: vec![],
             signature: None,
             nonce: None,
-            decision_receipt_id: None,
-            decision_hash: None,
+            provenance: crate::types::ProvenanceRef::SystemGenerated {
+                reason: "test".to_string(),
+            },
         };
 
         let current_time = icn_time::current_timestamp_secs();
@@ -4531,6 +4579,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -4578,6 +4627,7 @@ mod tests {
             .debit(alice.clone(), "hours".to_string(), 20)
             .credit(bob.clone(), "hours".to_string(), 10)
             .credit(charlie.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 

--- a/icn/crates/icn-ledger/src/quarantine.rs
+++ b/icn/crates/icn-ledger/src/quarantine.rs
@@ -376,6 +376,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -408,6 +409,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -441,6 +443,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -479,6 +482,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 
@@ -520,6 +524,7 @@ mod tests {
             let entry = JournalEntryBuilder::new(alice.clone())
                 .debit(alice.clone(), "hours".to_string(), 10 + i)
                 .credit(bob.clone(), "hours".to_string(), 10 + i)
+                .with_system_provenance("test")
                 .build()
                 .unwrap();
 
@@ -552,6 +557,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 

--- a/icn/crates/icn-ledger/src/settlement.rs
+++ b/icn/crates/icn-ledger/src/settlement.rs
@@ -171,6 +171,7 @@ impl SettlementEngine {
                 request.currency.clone(),
                 request.amount,
             )
+            .with_system_provenance("compute-settlement")
             .build()
             .map_err(|e| LedgerError::InvalidEntry(e.to_string()))?;
 

--- a/icn/crates/icn-ledger/src/sync.rs
+++ b/icn/crates/icn-ledger/src/sync.rs
@@ -83,6 +83,7 @@ mod tests {
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 10)
             .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test")
             .build()
             .unwrap();
 

--- a/icn/crates/icn-ledger/src/types.rs
+++ b/icn/crates/icn-ledger/src/types.rs
@@ -36,6 +36,34 @@ impl std::fmt::Display for ContentHash {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Signature(pub Vec<u8>);
 
+/// Provenance of a journal entry — who or what authorized this ledger change.
+///
+/// Every entry must carry exactly one provenance ref. This is a pilot-grade
+/// invariant: the ledger must be able to answer "why was this entry created?"
+/// for every record it holds.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProvenanceRef {
+    /// Entry was authorized by a governance decision (proposal + vote).
+    ///
+    /// `receipt_id` is the node-local decision receipt identifier.
+    /// `decision_hash` is the canonical cross-node equality anchor.
+    Governance {
+        receipt_id: String,
+        decision_hash: String,
+    },
+
+    /// Entry was created directly by a member (not via governance).
+    ///
+    /// `did` identifies the authorizing member.
+    /// `signature` is their Ed25519 signature over the entry content.
+    DirectMember { did: Did, signature: String },
+
+    /// Entry was created by the system (FX transfer, DID migration, mint, etc.).
+    ///
+    /// `reason` is a short human-readable label for audit logs.
+    SystemGenerated { reason: String },
+}
+
 /// Journal entry in the ledger's Merkle-DAG
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JournalEntry {
@@ -79,24 +107,15 @@ pub struct JournalEntry {
     pub nonce: Option<[u8; 32]>,
 
     // =========================================================================
-    // PROVENANCE FIELDS (Pilot-grade invariant: governance → ledger traceability)
+    // PROVENANCE (Pilot-grade invariant: every entry must be traceable)
     // =========================================================================
-    /// Governance decision receipt ID that authorized this entry.
+    /// Who or what authorized this ledger entry.
     ///
-    /// Links this ledger entry back to the governance decision that caused it.
-    /// This is the node-local identifier for the decision receipt.
-    ///
-    /// Example: `"gov:proposal:2024-001:receipt:abc123"`
-    pub decision_receipt_id: Option<String>,
-
-    /// Canonical decision hash (cross-node equality anchor).
-    ///
-    /// This is the cryptographic hash of the canonical decision content,
-    /// ensuring that any node can verify this ledger entry was authorized
-    /// by the same decision, regardless of receipt ID format.
-    ///
-    /// Example: `"sha256:abc123def456..."`
-    pub decision_hash: Option<String>,
+    /// Required on every entry. Use [`ProvenanceRef::Governance`] for
+    /// governance-authorized changes, [`ProvenanceRef::DirectMember`] for
+    /// member-direct changes, and [`ProvenanceRef::SystemGenerated`] for
+    /// internal system operations (FX, migration, mint/burn).
+    pub provenance: ProvenanceRef,
 }
 
 /// Delta for a single account in a journal entry

--- a/icn/crates/icn-ledger/tests/dynamic_limits_integration.rs
+++ b/icn/crates/icn-ledger/tests/dynamic_limits_integration.rs
@@ -51,6 +51,7 @@ async fn test_dynamic_limits_integration_basic() {
     let entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 10)
         .credit(bob.clone(), "hours".to_string(), 10)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -112,6 +113,7 @@ async fn test_activity_updates_dynamic_state() {
     let entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 5)
         .credit(bob.clone(), "hours".to_string(), 5)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -169,6 +171,7 @@ async fn test_credit_limit_enforcement_with_dynamic_manager() {
     let entry1 = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 50)
         .credit(bob.clone(), "hours".to_string(), 50)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -181,6 +184,7 @@ async fn test_credit_limit_enforcement_with_dynamic_manager() {
     let entry2 = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 60)
         .credit(bob.clone(), "hours".to_string(), 60)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -218,6 +222,7 @@ async fn test_fallback_to_static_limits_on_error() {
     let entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 10)
         .credit(bob.clone(), "hours".to_string(), 10)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -262,6 +267,7 @@ async fn test_multiple_currencies_tracked_separately() {
     let hours_entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 50)
         .credit(bob.clone(), "hours".to_string(), 50)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -272,6 +278,7 @@ async fn test_multiple_currencies_tracked_separately() {
     let kwh_entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "kwh".to_string(), 80)
         .credit(bob.clone(), "kwh".to_string(), 80)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -295,6 +302,7 @@ async fn test_multiple_currencies_tracked_separately() {
     let hours_exceed = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 60)
         .credit(bob.clone(), "hours".to_string(), 60)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -309,6 +317,7 @@ async fn test_multiple_currencies_tracked_separately() {
     let kwh_ok = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "kwh".to_string(), 15)
         .credit(bob.clone(), "kwh".to_string(), 15)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 

--- a/icn/crates/icn-ledger/tests/gossip_sync.rs
+++ b/icn/crates/icn-ledger/tests/gossip_sync.rs
@@ -88,6 +88,7 @@ async fn test_direct_sync_message() {
     let entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 10)
         .credit(bob.clone(), "hours".to_string(), 10)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -126,6 +127,7 @@ async fn test_ledger_publishes_to_gossip() {
     let entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 10)
         .credit(bob.clone(), "hours".to_string(), 10)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -172,12 +174,14 @@ async fn test_multiple_entries_to_gossip() {
     let entry1 = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 10)
         .credit(bob.clone(), "hours".to_string(), 10)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
     let entry2 = JournalEntryBuilder::new(bob.clone())
         .debit(bob.clone(), "hours".to_string(), 5)
         .credit(charlie.clone(), "hours".to_string(), 5)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -211,6 +215,7 @@ async fn test_duplicate_entry_handling() {
     let entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 10)
         .credit(bob.clone(), "hours".to_string(), 10)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -256,6 +261,7 @@ async fn test_witnessed_entry_with_valid_signature() {
     let entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 10)
         .credit(bob.clone(), "hours".to_string(), 10)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -300,6 +306,7 @@ async fn test_witnessed_entry_with_invalid_signature() {
     let entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 10)
         .credit(bob.clone(), "hours".to_string(), 10)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -348,6 +355,7 @@ async fn test_witnessed_entry_insufficient_signatures() {
     let entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 10)
         .credit(bob.clone(), "hours".to_string(), 10)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -386,6 +394,7 @@ async fn test_witnessed_entry_sync_message() {
     let entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 10)
         .credit(bob.clone(), "hours".to_string(), 10)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -437,6 +446,7 @@ async fn test_witness_policy_threshold() {
     let small_entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 10)
         .credit(bob.clone(), "hours".to_string(), 10)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -446,6 +456,7 @@ async fn test_witness_policy_threshold() {
     let large_entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 200)
         .credit(bob.clone(), "hours".to_string(), 200)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -473,6 +484,7 @@ async fn test_witnessed_entry_invalid_signature_quarantined_via_sync() {
     let entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 10)
         .credit(bob.clone(), "hours".to_string(), 10)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -543,6 +555,7 @@ async fn test_witnessed_entry_insufficient_signatures_quarantined_via_sync() {
     let entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 10)
         .credit(bob.clone(), "hours".to_string(), 10)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 

--- a/icn/crates/icn-ledger/tests/witness_trust.rs
+++ b/icn/crates/icn-ledger/tests/witness_trust.rs
@@ -101,6 +101,7 @@ async fn test_witness_trust_validation_sufficient_trust() {
     let entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 10)
         .credit(bob.clone(), "hours".to_string(), 10)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -154,6 +155,7 @@ async fn test_witness_trust_validation_insufficient_trust() {
     let entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 10)
         .credit(bob.clone(), "hours".to_string(), 10)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -211,6 +213,7 @@ async fn test_witness_trust_validation_unknown_witness() {
     let entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 10)
         .credit(bob.clone(), "hours".to_string(), 10)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -266,6 +269,7 @@ async fn test_witness_trust_validation_backward_compatible() {
     let entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 10)
         .credit(bob.clone(), "hours".to_string(), 10)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -315,6 +319,7 @@ async fn test_witness_trust_validation_no_trust_graph() {
     let entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 10)
         .credit(bob.clone(), "hours".to_string(), 10)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -397,6 +402,7 @@ async fn test_witness_trust_validation_quorum_with_trust() {
     let entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 100)
         .credit(bob.clone(), "hours".to_string(), 100)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 
@@ -494,6 +500,7 @@ async fn test_witness_trust_validation_quorum_insufficient_trusted_witnesses() {
     let entry = JournalEntryBuilder::new(alice.clone())
         .debit(alice.clone(), "hours".to_string(), 100)
         .credit(bob.clone(), "hours".to_string(), 100)
+        .with_system_provenance("test")
         .build()
         .unwrap();
 


### PR DESCRIPTION
## Summary

Replaces `JournalEntry.decision_receipt_id: Option<String>` and `decision_hash: Option<String>` with a single required `provenance: ProvenanceRef` field. Every journal entry must now declare *how* it was authorized at construction time.

- **`ProvenanceRef::Governance { receipt_id, decision_hash }`** — authorized by a governance proposal/vote
- **`ProvenanceRef::DirectMember { did, signature }`** — authorized by a member's Ed25519 signature
- **`ProvenanceRef::SystemGenerated { reason }`** — internal operations (FX, migration, mint/burn)

## What changed

- `icn-ledger/src/types.rs` — `ProvenanceRef` enum + `JournalEntry.provenance` field (required, not `Option`)
- `icn-ledger/src/entry.rs` — `JournalEntryBuilder` gains `.with_governance_provenance()`, `.with_direct_member_provenance()`, `.with_system_provenance()`; `build()` returns `Err` if provenance not set
- All `icn-ledger` internal call sites updated (balance, commons_credits, fx, settlement, sync, etc.)
- `icn-gateway` and `icn-core` call sites updated (ledger_mgr, treasury_mgr, registry, ledger api, ledger service)
- `icn-api` DTO updated; `icn-core` integration tests updated

## Why

Closes #1305 (epic #1302 — regulatory-safe verifiable state architecture). The old dual-`Option` design allowed entries to be created with no traceable authorization, a compliance and auditability gap. The new `ProvenanceRef` type makes authorization mandatory and machine-readable.

## Risk

**Breaking change** for any code constructing `JournalEntry` struct literals directly — all known call sites within the workspace have been updated. External crates consuming `icn-ledger` will need to add `.with_*_provenance()` calls before `.build()`.

## Test plan

- [x] `cargo test -p icn-ledger --lib` — 378 unit tests passing (includes new `test_direct_member_provenance_roundtrip`, `test_entry_with_governance_provenance`, `test_missing_provenance_fails`, `test_system_provenance_roundtrip`)
- [x] `cargo check --workspace --tests` — clean compile across all 39 crates + integration tests
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)