### PR TITLE
fix(gateway): update scope integration test for settlements rename

### DIFF
--- a/icn/crates/icn-gateway/tests/scope_validation_integration.rs
+++ b/icn/crates/icn-gateway/tests/scope_validation_integration.rs
@@ -13,7 +13,7 @@ fn test_scope_allowlist_validation() {
     assert!(validation::validate_scopes(&["ledger:write".to_string()]).is_ok());
     assert!(validation::validate_scopes(&["coop:admin".to_string()]).is_ok());
     assert!(validation::validate_scopes(&["governance:read".to_string()]).is_ok());
-    assert!(validation::validate_scopes(&["payments:write".to_string()]).is_ok());
+    assert!(validation::validate_scopes(&["settlements:write".to_string()]).is_ok());
 
     // Multiple valid scopes
     assert!(validation::validate_scopes(&[


### PR DESCRIPTION
## Summary
- The `refactor/1303-api-rename` PR renamed `payments:write` → `settlements:write` in `validation.rs` but missed updating the scope integration test
- This caused the required `Test` CI check to fail on main
- One-line fix: `scope_validation_integration.rs:16`

## Test plan
- [x] `cargo test -p icn-gateway --test scope_validation_integration` → 11/11 pass
- [x] `cargo fmt --all --check` pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)