### PR TITLE
fix(ccl): add provenance to CCL runtime ledger entries (fixes main)

### DIFF
--- a/icn/crates/icn-ccl/src/charter_validator.rs
+++ b/icn/crates/icn-ccl/src/charter_validator.rs
@@ -156,6 +156,7 @@ mod tests {
         JournalEntryBuilder::new(author.clone())
             .debit(author, "hours".to_string(), debit)
             .credit(receiver, "hours".to_string(), credit)
+            .with_system_provenance("test")
             .build()
             .unwrap()
     }

--- a/icn/crates/icn-ccl/src/runtime.rs
+++ b/icn/crates/icn-ccl/src/runtime.rs
@@ -154,6 +154,7 @@ impl ContractRuntime {
                     let entry = JournalEntryBuilder::new(from.clone())
                         .debit(to.clone(), currency.clone(), *amount)
                         .credit(from.clone(), currency.clone(), *amount)
+                        .with_system_provenance("ccl-contract-execution")
                         .build()?;
 
                     ledger.append_entry(entry).await?;


### PR DESCRIPTION
## Summary
- `runtime.rs`: `apply_ledger_operations` was creating `JournalEntry` via `.build()` without provenance — this is production code, not just tests. Added `.with_system_provenance("ccl-contract-execution")`.
- `charter_validator.rs`: `create_test_entry` test helper similarly missing provenance. Added `.with_system_provenance("test")`.

## Root cause
PR #1318 made `JournalEntryBuilder.build()` error if no provenance is set, but these two call sites in `icn-ccl` were missed, causing 5 tests to fail on main after #1318 merged.

## Tests
All 31 `icn-ccl` tests pass locally.

## Risk
Low — the runtime fix adds the correct provenance label to system-generated entries. The CCL runtime is the canonical source of these entries, so `SystemGenerated` provenance is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)