### PR TITLE
feat(gateway): add treasury:read and treasury:write to ALLOWED_SCOPES

### DIFF
--- a/icn/crates/icn-gateway/src/validation.rs
+++ b/icn/crates/icn-gateway/src/validation.rs
@@ -70,6 +70,9 @@ pub const ALLOWED_SCOPES: &[&str] = &[
     "entity:read",
     "entity:write",
     "entity:audit",
+    // Treasury operations
+    "treasury:read",
+    "treasury:write",
     // Admin operations
     "admin",
 ];


### PR DESCRIPTION
## Summary

Adds `treasury:read` and `treasury:write` to the gateway's scope allowlist, unblocking the gamma→alpha economic flow which was failing because treasury-scoped tokens were rejected at validation.

## Changes

- Add `treasury:read` and `treasury:write` to `ALLOWED_SCOPES` in `icn-gateway/src/validation.rs`

## Motivation

The gamma pod cannot initiate treasury flows because `validate_scope()` rejects any scope not in `ALLOWED_SCOPES`. Treasury API handlers already exist and are structurally complete — the scope whitelist was the only blocker. Noted in demo flow scripts as a known deployment gap (`flow-1-governance.sh` line 24, `flow-2-patronage.sh` line 16).

## Testing

- [x] `cargo fmt --all --check` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — pass
- [x] `cargo test --workspace` — pass (scope_validation_integration reads from ALLOWED_SCOPES directly, auto-covers new entries)
- [ ] Manual: verify gamma pod can request treasury-scoped token after rollout restart

## Invariants

- [x] No panics introduced in protocol paths
- [x] Determinism preserved
- [x] Canonical encodings unchanged (or N/A)
- [x] Trust gates not weakened (treasury endpoints have their own auth checks)
- [x] Kernel/app boundaries respected

## Verification

```
cargo fmt --all --check         ✓
cargo clippy --workspace        ✓ (no warnings)
cargo test --workspace          ✓ all pass
```

## Documentation

- [x] N/A — scope list is internal; no OpenAPI change required