### PR TITLE
feat(governance): wire AllocationProposal acceptance to ExecutionReceiptGate (s15-t5)

### DIFF
--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -29,6 +29,26 @@ use super::handlers;
 /// should log warnings internally rather than panicking.
 pub type CharterAcceptedHook = Arc<dyn Fn(String, String) + Send + Sync>;
 
+/// Callback invoked when an `AllocationProposal` is accepted.
+///
+/// Arguments: `(decision_receipt, recipients, unit, total_amount, domain_id)`.
+///
+/// The gateway wires this to build an `AllocationReceipt` (with one
+/// `SettlementIntent` per recipient), run it through `check_execution_gate`,
+/// and persist it to the `ReceiptStore`.
+///
+/// Errors are non-fatal — implementations should log warnings.
+pub type AllocationAcceptedHook = Arc<
+    dyn Fn(
+            icn_governance::GovernanceDecisionReceipt,
+            Vec<icn_governance::AllocationEntry>,
+            String,
+            u64,
+            String,
+        ) + Send
+        + Sync,
+>;
+
 /// Shared application context for governance HTTP handlers.
 ///
 /// Stored as `web::Data<GovernanceContext<E>>`. Using a single struct keeps
@@ -39,6 +59,8 @@ pub struct GovernanceContext<E> {
     pub emitter: E,
     /// Optional hook called when a `Charter` proposal is accepted.
     pub on_charter_accepted: Option<CharterAcceptedHook>,
+    /// Optional hook called when an `AllocationProposal` is accepted.
+    pub on_allocation_accepted: Option<AllocationAcceptedHook>,
 }
 
 /// Register all governance routes on `cfg`.

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -1025,6 +1025,44 @@ pub async fn close_proposal<E: GovernanceEventEmitter + Clone + 'static>(
                 hook(charter_id.clone(), charter_yaml.clone());
             }
         }
+
+        // On allocation acceptance: produce AllocationReceipt via ExecutionReceiptGate.
+        if let icn_governance::ProposalPayload::AllocationProposal {
+            ref recipients,
+            ref unit,
+            total_amount,
+            ..
+        } = proposal.payload
+        {
+            if let Some(hook) = &ctx.on_allocation_accepted {
+                match ctx.manager.get_proof(&proposal_id).await {
+                    Ok(Some(proof)) => {
+                        hook(
+                            proof.receipt,
+                            recipients.clone(),
+                            unit.clone(),
+                            total_amount,
+                            proposal.domain_id.0.clone(),
+                        );
+                    }
+                    Ok(None) => {
+                        tracing::warn!(
+                            proposal_id = %proposal_id.0,
+                            "AllocationProposal accepted but no GovernanceDecisionReceipt found \
+                             — AllocationReceipt not written"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            proposal_id = %proposal_id.0,
+                            error = %e,
+                            "Failed to retrieve proof for AllocationProposal — AllocationReceipt \
+                             not written"
+                        );
+                    }
+                }
+            }
+        }
     }
 
     ctx.emitter

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -848,15 +848,19 @@ impl GatewayServer {
                     let intents: Vec<SettlementIntent> = recipients
                         .iter()
                         .map(|entry| {
-                            SettlementIntent::new(
-                                entry.recipient.to_string(),
+                            let intent = SettlementIntent::new(
+                                receipt.proposal_id.clone(),
                                 decision_hash,
                                 domain_id.clone(),
                                 entry.recipient.as_str(),
                                 entry.amount,
                                 unit.clone(),
                             )
-                            .with_timestamp(now)
+                            .with_timestamp(now);
+                            match &entry.memo {
+                                Some(m) => intent.with_memo(m.clone()),
+                                None => intent,
+                            }
                         })
                         .collect();
 
@@ -865,7 +869,7 @@ impl GatewayServer {
                         .with_timestamp(now)
                         .with_receipt_id(uuid::Uuid::new_v4().to_string());
 
-                    match receipt_store_hook.put_allocation(&allocation_receipt) {
+                    match receipt_store_hook.put_allocation_with_intents(&allocation_receipt) {
                         Ok(hash) => {
                             tracing::info!(
                                 decision_hash = ?decision_hash,

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -812,6 +812,79 @@ impl GatewayServer {
             Arc::new(EventBroadcaster::new())
         });
 
+        // Build AllocationProposal acceptance hook.
+        //
+        // When an AllocationProposal is accepted, this closure:
+        //   1. Runs the GovernanceDecisionReceipt through check_execution_gate
+        //   2. Builds one SettlementIntent per recipient
+        //   3. Writes an AllocationReceipt to the ReceiptStore
+        //
+        // This closes the provenance chain:
+        //   GovernanceDecisionReceipt → AllocationReceipt → SettlementIntent(s)
+        let receipt_store_hook = receipt_store.clone();
+        let on_allocation_accepted = {
+            use icn_governance::{check_execution_gate, GovernanceDecisionReceipt};
+            use icn_kernel_api::{
+                economics::SettlementIntent, receipts::AllocationReceipt, ScopeLevel,
+            };
+            std::sync::Arc::new(
+                move |receipt: GovernanceDecisionReceipt,
+                      recipients: Vec<icn_governance::AllocationEntry>,
+                      unit: String,
+                      _total_amount: u64,
+                      domain_id: String| {
+                    if let Err(e) = check_execution_gate(&receipt) {
+                        tracing::warn!(
+                            decision_hash = ?receipt.decision_hash,
+                            error = %e,
+                            "ExecutionReceiptGate rejected AllocationProposal — receipt not written"
+                        );
+                        return;
+                    }
+
+                    let now = icn_time::current_timestamp_secs();
+                    let decision_hash = receipt.decision_hash;
+
+                    let intents: Vec<SettlementIntent> = recipients
+                        .iter()
+                        .map(|entry| {
+                            SettlementIntent::new(
+                                entry.recipient.to_string(),
+                                decision_hash,
+                                domain_id.clone(),
+                                entry.recipient.as_str(),
+                                entry.amount,
+                                unit.clone(),
+                            )
+                            .with_timestamp(now)
+                        })
+                        .collect();
+
+                    let allocation_receipt = AllocationReceipt::new(decision_hash, ScopeLevel::Org)
+                        .with_intents(intents)
+                        .with_timestamp(now)
+                        .with_receipt_id(uuid::Uuid::new_v4().to_string());
+
+                    match receipt_store_hook.put_allocation(&allocation_receipt) {
+                        Ok(hash) => {
+                            tracing::info!(
+                                decision_hash = ?decision_hash,
+                                receipt_hash = ?hash,
+                                "AllocationReceipt stored (receipt chain complete)"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                decision_hash = ?decision_hash,
+                                error = %e,
+                                "Failed to store AllocationReceipt (non-fatal)"
+                            );
+                        }
+                    }
+                },
+            )
+        };
+
         // Create governance context for apps/governance HTTP handlers.
         // GatewayEventAdapter wires the domain emitter to the WebSocket broadcaster.
         //
@@ -821,6 +894,7 @@ impl GatewayServer {
             manager: governance_manager.clone(),
             emitter: GatewayEventAdapter::new(event_broadcaster.clone()),
             on_charter_accepted: self.charter_accepted_hook,
+            on_allocation_accepted: Some(on_allocation_accepted),
         };
 
         // Create rate limiter with configured or default config

--- a/icn/crates/icn-governance/src/config.rs
+++ b/icn/crates/icn-governance/src/config.rs
@@ -140,7 +140,8 @@ impl GovernanceConfig {
             | ProposalPayload::BondIssuance { .. }
             | ProposalPayload::Federation(_)
             | ProposalPayload::ResourceAccess { .. }
-            | ProposalPayload::Charter { .. } => ProposalThresholds::new(
+            | ProposalPayload::Charter { .. }
+            | ProposalPayload::AllocationProposal { .. } => ProposalThresholds::new(
                 self.params.quorum_percentage,
                 self.params.approval_threshold_percentage,
             ),

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -126,9 +126,9 @@ pub use proof::{
     ProofOutcome,
 };
 pub use proposal::{
-    DataSharingLevel, DisputeResolutionMethod, DisputeResolutionOutcome, FederationProposal,
-    FederationTerms, ForcedOutcome, MembershipAction, Proposal, ProposalId, ProposalPayload,
-    ProposalScope, ProposalState, ResourceAccessAction, TreasuryApprovalType,
+    AllocationEntry, DataSharingLevel, DisputeResolutionMethod, DisputeResolutionOutcome,
+    FederationProposal, FederationTerms, ForcedOutcome, MembershipAction, Proposal, ProposalId,
+    ProposalPayload, ProposalScope, ProposalState, ResourceAccessAction, TreasuryApprovalType,
     TreasuryProposalOperation, Version,
 };
 pub use resolver::{MembershipResolver, StaticMembershipResolver};

--- a/icn/crates/icn-governance/src/proposal.rs
+++ b/icn/crates/icn-governance/src/proposal.rs
@@ -668,6 +668,31 @@ pub enum ProposalPayload {
         /// Complete YAML charter document (CCL format, schema_version: v0).
         charter_yaml: String,
     },
+
+    // === Participatory Budgeting (Receipt Chain) ===
+    /// Multi-recipient allocation proposal for participatory budgeting.
+    ///
+    /// When accepted, produces an `AllocationReceipt` containing one
+    /// `SettlementIntent` per recipient. The receipt is anchored to the
+    /// governance `decision_hash`, closing the provenance chain:
+    ///
+    /// `AllocationProposal` → vote → `GovernanceDecisionReceipt`
+    ///   → `AllocationReceipt` → `SettlementIntent`(s) → ledger entry
+    ///
+    /// This is the structurally-typed alternative to `ProposalPayload::Text`
+    /// for budget distributions. Unlike `SurplusAllocation` (which is coupled
+    /// to `icn_ledger::SurplusAllocation`), this payload is self-contained and
+    /// can be produced by any governance domain.
+    AllocationProposal {
+        /// Total amount being distributed (must equal sum of recipient amounts)
+        total_amount: u64,
+        /// Currency or unit symbol (e.g. "credits", "ICN", "USD")
+        unit: String,
+        /// Human-readable formula or basis for this allocation (included in audit trail)
+        formula: String,
+        /// Recipient allocations (one SettlementIntent per entry on acceptance)
+        recipients: Vec<AllocationEntry>,
+    },
 }
 
 impl ProposalPayload {
@@ -695,6 +720,7 @@ impl ProposalPayload {
             ProposalPayload::Federation(_) => "federation",
             ProposalPayload::ResourceAccess { .. } => "resource_access",
             ProposalPayload::Charter { .. } => "charter",
+            ProposalPayload::AllocationProposal { .. } => "allocation_proposal",
         }
     }
 
@@ -718,6 +744,21 @@ impl ProposalPayload {
     pub fn is_emergency(&self) -> bool {
         self.emergency_type().is_some()
     }
+}
+
+/// A single recipient entry in an `AllocationProposal`.
+///
+/// Each entry produces one `SettlementIntent` when the proposal is accepted.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AllocationEntry {
+    /// Recipient DID
+    pub recipient: Did,
+    /// Amount to allocate in the proposal's unit
+    pub amount: u64,
+    /// Optional labor hours or participation basis for audit provenance
+    pub basis_hours: Option<u64>,
+    /// Optional human-readable memo (included in receipt provenance)
+    pub memo: Option<String>,
 }
 
 /// Treasury operations that require governance approval
@@ -2598,5 +2639,62 @@ mod tests {
             proposal.scope,
             ProposalScope::Federation("my-fed".to_string())
         );
+    }
+
+    #[test]
+    fn test_allocation_proposal() {
+        let kp = KeyPair::generate().unwrap();
+        let did = kp.did().clone();
+        let domain_id = GovernanceDomainId::new("brightworks-governance");
+
+        let recipient_a = KeyPair::generate().unwrap();
+        let recipient_b = KeyPair::generate().unwrap();
+
+        let payload = ProposalPayload::AllocationProposal {
+            total_amount: 3_840,
+            unit: "credits".to_string(),
+            formula: "(member_hours / 524) * 3840".to_string(),
+            recipients: vec![
+                AllocationEntry {
+                    recipient: recipient_a.did().clone(),
+                    amount: 2_000,
+                    basis_hours: Some(274),
+                    memo: Some("Q1 labor contribution".to_string()),
+                },
+                AllocationEntry {
+                    recipient: recipient_b.did().clone(),
+                    amount: 1_840,
+                    basis_hours: Some(250),
+                    memo: None,
+                },
+            ],
+        };
+
+        let proposal = Proposal::new(
+            domain_id,
+            did,
+            "Q1 2026 Patronage Distribution".to_string(),
+            "Distribute Q1 surplus proportionally to labor hours".to_string(),
+            payload,
+        );
+
+        assert_eq!(proposal.payload.type_name(), "allocation_proposal");
+        assert!(!proposal.payload.is_emergency());
+
+        let ProposalPayload::AllocationProposal {
+            total_amount,
+            unit,
+            recipients,
+            ..
+        } = &proposal.payload
+        else {
+            panic!("expected AllocationProposal");
+        };
+        assert_eq!(*total_amount, 3_840);
+        assert_eq!(unit, "credits");
+        assert_eq!(recipients.len(), 2);
+        assert_eq!(recipients[0].amount + recipients[1].amount, 3_840);
+        assert_eq!(recipients[0].basis_hours, Some(274));
+        assert!(recipients[1].memo.is_none());
     }
 }


### PR DESCRIPTION
## What

Wires `AllocationProposal` acceptance to the `ExecutionReceiptGate`, producing an `AllocationReceipt` with `SettlementIntent`s stored in the `ReceiptStore`.

## Why

This closes the provenance chain started in s15-t4 (#1345):

```
AllocationProposal vote
  → GovernanceDecisionReceipt (governance store)
  → AllocationReceipt (receipt store) ← this PR
  → SettlementIntent(s) (inside receipt)
```

After this PR, `GET /v1/receipts/allocations` returns populated results when an `AllocationProposal` has been accepted — not an empty list.

## Changes

**`configure.rs`** — adds `AllocationAcceptedHook` type and `on_allocation_accepted` field to `GovernanceContext`

**`handlers.rs`** — in `close_proposal`, after the charter hook block:
- If `outcome == accepted` and payload is `AllocationProposal`
- Retrieves `GovernanceDecisionReceipt` via `manager.get_proof()`
- Calls the hook with `(receipt, recipients, unit, total_amount, domain_id)`

**`server.rs`** — wires the hook as a closure that:
1. Calls `check_execution_gate(&receipt)` — gate enforces Invariant 7
2. Builds one `SettlementIntent` per `AllocationEntry` recipient
3. Writes `AllocationReceipt` to `ReceiptStore`

## Risk

Additive. Non-acceptance paths (Rejected, NoQuorum) are unaffected. Gate errors are logged as warnings (non-fatal to the proposal-close response). `receipt_store` is already shared with the governance manager.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo clippy -p icn-governance-actor` clean
- [x] `cargo clippy -p icn-gateway` clean
- [ ] s15-t6 integration test will verify end-to-end in CI

Depends on: #1345 (s15-t4 — AllocationProposal type)
Part of Sprint 15 / Epic #1147 (receipt chain vertical slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)