### PR TITLE
fix(demo): update Flow 2 for renamed ledger routes + open Sprint 16

### DIFF
--- a/demo/scripts/flow-2-patronage.sh
+++ b/demo/scripts/flow-2-patronage.sh
@@ -403,19 +403,17 @@ echo "  The approved governance decision authorizes the ledger settlement."
 echo "  Each allocation is posted as a ledger entry. The memo records provenance."
 echo "  (Programmatic decision-linkage via decision_id is a future capability.)"
 echo ""
-aside "Attempting settlement via POST /v1/ledger/${BRIGHTWORKS_COOP_ID}/payment"
+aside "Attempting settlement via POST /v1/ledger/${BRIGHTWORKS_COOP_ID}/settle"
 echo ""
 
 # Settlement payload: from cooperative fund to member DID
-# Deployed binary (2bc85f83, 2026-02-23) uses /payment route and currency field.
-# Route renamed to /settle + field renamed to unit in source commit 439a8a2c (2026-03-01).
 # Demo: settlement from BrightWorks node DID to Harbor Homes node DID as member proxy.
 # (One DID per coop in demo — self-payments rejected, Harbor DID is a real cluster identity.)
 # NOTE: decision_id intentionally omitted — not in RecordTransferRequest schema.
 # The memo field carries human-readable provenance. The receipt chain (step 11) is the
 # future enforcement path; narrating decision_id as enforced here would be dishonest.
-_do_curl "${BRIGHTWORKS_URL}/v1/ledger/${BRIGHTWORKS_COOP_ID}/payment" POST \
-  "{\"from\":\"${BRIGHTWORKS_NODE_DID}\",\"to\":\"${HARBOR_NODE_DID}\",\"amount\":880,\"currency\":\"patronage_credits\",\"memo\":\"Q1 2026 patronage — Yusuf Okafor (120 labor hours, (120/524)*3840=880) — decision:${PROPOSAL_ID}\"}" \
+_do_curl "${BRIGHTWORKS_URL}/v1/ledger/${BRIGHTWORKS_COOP_ID}/settle" POST \
+  "{\"from\":\"${BRIGHTWORKS_NODE_DID}\",\"to\":\"${HARBOR_NODE_DID}\",\"amount\":880,\"unit\":\"patronage_credits\",\"memo\":\"Q1 2026 patronage — Yusuf Okafor (120 labor hours, (120/524)*3840=880) — decision:${PROPOSAL_ID}\"}" \
   "$BRIGHTWORKS_TOKEN"
 
 if [[ "$DEMO_LAST_HTTP_CODE" =~ ^2 ]]; then
@@ -442,30 +440,29 @@ fi
 echo ""
 
 # ---------------------------------------------------------------------------
-# STEP 9: Ledger position — member balance visible
+# STEP 9: Ledger position — member position visible
 # ---------------------------------------------------------------------------
-narrate "Step 9: Ledger balance — cooperative account shows allocation"
-_beat "The balance is live. Any member can query their own balance at any time — the coop doesn't have to send a statement."
+narrate "Step 9: Ledger position — cooperative account shows allocation"
+_beat "The position is live. Any member can query their own position at any time — the coop doesn't have to send a statement."
 echo ""
-aside "GET /v1/ledger/${BRIGHTWORKS_COOP_ID}/balance/${BRIGHTWORKS_NODE_DID}"
+aside "GET /v1/ledger/${BRIGHTWORKS_COOP_ID}/position/${BRIGHTWORKS_NODE_DID}"
 echo ""
-# Route was /balance/{did} in deployed binary (2bc85f83). Renamed to /position/{did} in 439a8a2c.
 
-_do_curl "${BRIGHTWORKS_URL}/v1/ledger/${BRIGHTWORKS_COOP_ID}/balance/${BRIGHTWORKS_NODE_DID}" \
+_do_curl "${BRIGHTWORKS_URL}/v1/ledger/${BRIGHTWORKS_COOP_ID}/position/${BRIGHTWORKS_NODE_DID}" \
   GET "" "$BRIGHTWORKS_TOKEN"
 
 if [[ "$DEMO_LAST_HTTP_CODE" =~ ^2 ]]; then
-  result "Ledger balance (HTTP ${DEMO_LAST_HTTP_CODE}):"
+  result "Ledger position (HTTP ${DEMO_LAST_HTTP_CODE}):"
   _pretty
-  aside "Cooperative account shows outgoing allocation (debit side of the double-entry record)"
+  aside "Cooperative account position shows outgoing allocation (debit side of the double-entry record)"
 elif [ "$DEMO_LAST_HTTP_CODE" = "403" ] || [ "$DEMO_LAST_HTTP_CODE" = "401" ]; then
-  warn "Balance query returned HTTP ${DEMO_LAST_HTTP_CODE} — ledger:read scope constraint"
+  warn "Position query returned HTTP ${DEMO_LAST_HTTP_CODE} — ledger:read scope constraint"
   echo ""
-  echo "  What the cooperative account balance would show:"
+  echo "  What the cooperative account position would show:"
   echo "    did:      ${BRIGHTWORKS_NODE_DID:0:45}..."
-  echo "    balances: {\"patronage_credits\": -880}"
+  echo "    positions: {\"patronage_credits\": -880}"
   echo ""
-  aside "In a production deployment, each member would see their personal balance here."
+  aside "In a production deployment, each member would see their personal position here."
 else
   warn "Unexpected response (HTTP ${DEMO_LAST_HTTP_CODE}):"
   _pretty
@@ -551,15 +548,15 @@ else
   warn "They show what would happen if the vote had met quorum and been accepted."
   echo ""
   echo "  STEP 8 (settlement) — what authorized settlement looks like:"
-  echo "    POST /v1/ledger/${BRIGHTWORKS_COOP_ID}/payment"
+  echo "    POST /v1/ledger/${BRIGHTWORKS_COOP_ID}/settle"
   echo "    { from: <coop-did>, to: <member-did>, amount: 880,"
-  echo "      currency: patronage_credits,"
+  echo "      unit: patronage_credits,"
   echo "      memo: 'Q1 2026 patronage — Yusuf Okafor — decision:<id>' }"
   echo "    (decision_id is in memo, not a schema field — enforced via receipt chain later)"
   echo ""
-  echo "  STEP 9 (balance) — what a member's balance would show:"
-  echo "    GET /v1/ledger/${BRIGHTWORKS_COOP_ID}/balance/<member-did>"
-  echo "    { did: <member-did>, balances: { patronage_credits: 880 } }"
+  echo "  STEP 9 (position) — what a member's position would show:"
+  echo "    GET /v1/ledger/${BRIGHTWORKS_COOP_ID}/position/<member-did>"
+  echo "    { did: <member-did>, positions: { patronage_credits: 880 } }"
   echo ""
   echo "  STEP 10 (history) — what the allocation trail looks like:"
   echo "    GET /v1/ledger/${BRIGHTWORKS_COOP_ID}/history"
@@ -589,13 +586,13 @@ echo "   - Allocation table: each member's share derived transparently"
 echo "   - Governance: allocation ratified by member vote, not just declared"
 echo "   - Record: governance decision persisted on the cooperative's node"
 echo "   - Ledger: settlement posts credits with provenance (decision_id)"
-echo "   - Audit: any member can query balance and trace back to the vote"
+echo "   - Audit: any member can query position and trace back to the vote"
 echo ""
 echo " The cooperator question answered:"
 echo "   'Why did this member get this distribution?'"
 echo "   Because: (their hours / total hours) × Q1 surplus"
 echo "   Verified: the formula is in the proposal, the vote is on-chain"
-echo "   Traceable: balance → settlement entry → approved decision → vote"
+echo "   Traceable: position → settlement entry → approved decision → vote"
 echo ""
 if [ "$FINAL_STATE" = "Accepted" ]; then
   echo " Governance outcome: ACCEPTED — distribution officially ratified"

--- a/ops/state/sprint/current.json
+++ b/ops/state/sprint/current.json
@@ -1,103 +1,68 @@
 {
-  "sprint": 15,
-  "name": "Sprint 15 — Receipt Chain & Demo Truth",
-  "started": "2026-03-20",
+  "sprint": 16,
+  "name": "Sprint 16 — Grant-Ready Demo & K3s Pipeline",
+  "started": "2026-03-19",
   "goals": [
-    "Audit all 4 demo flows on K3s — classify PROVEN/FRAGILE/BROKEN with evidence",
-    "Complete 6-link receipt chain: AllocationProposal → Execution gate wiring → vertical slice test",
-    "Close epic #1302 (regulatory-safe architecture): CCL formula extraction + CI linter",
-    "Support March 31 grant applications with credible demo proof"
+    "Make all 4 demo flows PROVEN on K3s (fix stale route names in demo scripts)",
+    "Fix K3s deploy pipeline (ci-runner → control node SSH)",
+    "Terminology rename: ledger → state change journal in user-facing docs (#1303)",
+    "Package grant-ready artifacts for March 31 deadline (Outta Excuses, Verizon Digital Ready)"
   ],
   "tasks": [
     {
-      "id": "s15-t1",
-      "title": "K3s demo audit: run all 4 flows, classify with evidence, write report",
-      "status": "done",
-      "pr": null,
-      "assignee": "claude",
-      "epic": "1099",
-      "evidence": "docs/status/demo-audit-2026-03-19.md — F1 PROVEN, F2 FRAGILE, F3 PROVEN (post-fix), F4 FRAGILE"
-    },
-    {
-      "id": "s15-t2",
-      "title": "fix(gateway): make decision_hash optional in /v1/receipts/allocations (#1334)",
-      "status": "done",
-      "pr": 1343,
-      "assignee": "claude",
-      "epic": "1302",
-      "evidence": "Merged 2026-03-19. 449 tests pass. Awaiting K3s deploy to verify flows 2/4."
-    },
-    {
-      "id": "s15-t3",
-      "title": "fix(demo): Flow 3 clearing agreement ID extraction (#1335)",
-      "status": "done",
-      "pr": 1344,
-      "assignee": "claude",
-      "epic": "1099",
-      "evidence": "Merged 2026-03-19. Steps 5/6/7 verified 2xx on live K3s. docs/status/demo-audit-2026-03-19-flow3-verified.md"
-    },
-    {
-      "id": "s15-t4",
-      "title": "feat(governance): AllocationProposal for participatory budgeting (#1311)",
-      "status": "done",
-      "pr": 1345,
-      "assignee": "claude",
-      "epic": "1302",
-      "evidence": "PR #1345. AllocationOption struct + Allocation variant in ProposalPayload, gateway, RPC. 3 new tests, 468 total pass. Clippy clean."
-    },
-    {
-      "id": "s15-t5",
-      "title": "feat(governance): wire AllocationProposal acceptance to ExecutionReceiptGate",
-      "status": "done",
-      "pr": 1350,
-      "assignee": "claude",
-      "epic": "1147",
-      "evidence": "PR #1350. Allocation match arm in translate_payload_to_effects() produces CreateBudget + Allocate effects. 1 new test, clippy clean."
-    },
-    {
-      "id": "s15-t6",
-      "title": "test(core): vertical slice integration test — full receipt chain in CI (#1147)",
-      "status": "done",
-      "pr": 1351,
-      "assignee": "claude",
-      "epic": "1147",
-      "evidence": "PR #1351. End-to-end test: Allocation proposal → vote → gate → effect translation → treasury effects → audit provenance. All 6 links proven."
-    },
-    {
-      "id": "s15-t7",
-      "title": "refactor(economics): extract commons credit formula to CommonsResourcePolicy (#1308)",
-      "status": "done",
-      "pr": 1348,
-      "assignee": "claude",
-      "epic": "1302",
-      "evidence": "PR #1348. CommonsResourcePolicy struct with Serialize/Deserialize. 3 new tests + all 41 existing pass. Clippy clean."
-    },
-    {
-      "id": "s15-t8",
-      "title": "chore(ci): regulatory compliance linter (#1312)",
-      "status": "done",
-      "pr": 1349,
-      "assignee": "claude",
-      "epic": "1302",
-      "evidence": "PR #1349. Python linter + CI job at warning phase. 33 pre-existing violations cataloged. Ratchet to blocking after cleanup."
-    },
-    {
-      "id": "s15-t9",
-      "title": "Close epic #1302 with verified evidence for all 10 sub-items",
-      "status": "done",
-      "pr": null,
-      "assignee": "claude",
-      "epic": "1302",
-      "evidence": "All 10 sub-issues checked off. 8 success criteria verified: no payment terms in API, ProvenanceRef required, ExecutionReceipt proven (vertical slice test PR #1351), PatronageTracker (PR #1325), CommonsResourcePolicy extracted (PR #1348), DelegationManager persisted (PR #1326), 7 invariants in CONTRIBUTING.md, meaning firewall CI passing, compliance linter CI (PR #1349)."
-    },
-    {
-      "id": "s15-t10",
-      "title": "feat(cli): icnctl audit verify — receipt chain verification command (Tier 2)",
+      "id": "s16-t1",
+      "title": "Merge PR #1354 + close Sprint 15",
       "status": "done",
       "pr": 1354,
       "assignee": "claude",
       "epic": "1147",
-      "evidence": "PR #1354. icnctl audit verify command with 7 integrity checks, --json output, non-zero exit on failure. All workspace tests pass."
+      "evidence": "PR #1354 merged. Sprint 15 archived to history/sprint-15.json."
+    },
+    {
+      "id": "s16-t2",
+      "title": "fix(demo): update Flow 2/4 scripts for renamed ledger routes (payment→settle, balance→position)",
+      "status": "todo",
+      "pr": null,
+      "assignee": "claude",
+      "epic": "1099",
+      "evidence": null
+    },
+    {
+      "id": "s16-t3",
+      "title": "fix(ci): K3s deploy pipeline — SSH to control node instead of local k3s CLI",
+      "status": "in-progress",
+      "pr": null,
+      "assignee": "other-agent",
+      "epic": "1099",
+      "evidence": "Root cause: ci-runner (10.8.30.46) lacks k3s CLI and kubeconfig. Another agent working on fix."
+    },
+    {
+      "id": "s16-t4",
+      "title": "K3s redeploy + live demo verification (all 4 flows PROVEN)",
+      "status": "blocked",
+      "pr": null,
+      "assignee": "claude",
+      "epic": "1099",
+      "evidence": null,
+      "blocked_by": ["s16-t2", "s16-t3"]
+    },
+    {
+      "id": "s16-t5",
+      "title": "docs(terminology): rename ledger → state change journal in user-facing text (#1303)",
+      "status": "todo",
+      "pr": null,
+      "assignee": "claude",
+      "epic": "1302",
+      "evidence": null
+    },
+    {
+      "id": "s16-t6",
+      "title": "docs(grants): package grant-ready artifacts for March 31 deadline",
+      "status": "todo",
+      "pr": null,
+      "assignee": "claude",
+      "epic": "1099",
+      "evidence": null
     }
   ],
   "epics": {

--- a/ops/state/sprint/current.json
+++ b/ops/state/sprint/current.json
@@ -21,11 +21,11 @@
     {
       "id": "s16-t2",
       "title": "fix(demo): update Flow 2/4 scripts for renamed ledger routes (payment→settle, balance→position)",
-      "status": "todo",
-      "pr": null,
+      "status": "done",
+      "pr": 1355,
       "assignee": "claude",
       "epic": "1099",
-      "evidence": null
+      "evidence": "PR #1355. Routes updated: payment→settle, balance→position, currency→unit. All narration text updated."
     },
     {
       "id": "s16-t3",

--- a/ops/state/sprint/history/sprint-15.json
+++ b/ops/state/sprint/history/sprint-15.json
@@ -1,0 +1,108 @@
+{
+  "sprint": 15,
+  "name": "Sprint 15 — Receipt Chain & Demo Truth",
+  "started": "2026-03-20",
+  "goals": [
+    "Audit all 4 demo flows on K3s — classify PROVEN/FRAGILE/BROKEN with evidence",
+    "Complete 6-link receipt chain: AllocationProposal → Execution gate wiring → vertical slice test",
+    "Close epic #1302 (regulatory-safe architecture): CCL formula extraction + CI linter",
+    "Support March 31 grant applications with credible demo proof"
+  ],
+  "tasks": [
+    {
+      "id": "s15-t1",
+      "title": "K3s demo audit: run all 4 flows, classify with evidence, write report",
+      "status": "done",
+      "pr": null,
+      "assignee": "claude",
+      "epic": "1099",
+      "evidence": "docs/status/demo-audit-2026-03-19.md — F1 PROVEN, F2 FRAGILE, F3 PROVEN (post-fix), F4 FRAGILE"
+    },
+    {
+      "id": "s15-t2",
+      "title": "fix(gateway): make decision_hash optional in /v1/receipts/allocations (#1334)",
+      "status": "done",
+      "pr": 1343,
+      "assignee": "claude",
+      "epic": "1302",
+      "evidence": "Merged 2026-03-19. 449 tests pass. Awaiting K3s deploy to verify flows 2/4."
+    },
+    {
+      "id": "s15-t3",
+      "title": "fix(demo): Flow 3 clearing agreement ID extraction (#1335)",
+      "status": "done",
+      "pr": 1344,
+      "assignee": "claude",
+      "epic": "1099",
+      "evidence": "Merged 2026-03-19. Steps 5/6/7 verified 2xx on live K3s. docs/status/demo-audit-2026-03-19-flow3-verified.md"
+    },
+    {
+      "id": "s15-t4",
+      "title": "feat(governance): AllocationProposal for participatory budgeting (#1311)",
+      "status": "done",
+      "pr": 1345,
+      "assignee": "claude",
+      "epic": "1302",
+      "evidence": "PR #1345. AllocationOption struct + Allocation variant in ProposalPayload, gateway, RPC. 3 new tests, 468 total pass. Clippy clean."
+    },
+    {
+      "id": "s15-t5",
+      "title": "feat(governance): wire AllocationProposal acceptance to ExecutionReceiptGate",
+      "status": "done",
+      "pr": 1350,
+      "assignee": "claude",
+      "epic": "1147",
+      "evidence": "PR #1350. Allocation match arm in translate_payload_to_effects() produces CreateBudget + Allocate effects. 1 new test, clippy clean."
+    },
+    {
+      "id": "s15-t6",
+      "title": "test(core): vertical slice integration test — full receipt chain in CI (#1147)",
+      "status": "done",
+      "pr": 1351,
+      "assignee": "claude",
+      "epic": "1147",
+      "evidence": "PR #1351. End-to-end test: Allocation proposal → vote → gate → effect translation → treasury effects → audit provenance. All 6 links proven."
+    },
+    {
+      "id": "s15-t7",
+      "title": "refactor(economics): extract commons credit formula to CommonsResourcePolicy (#1308)",
+      "status": "done",
+      "pr": 1348,
+      "assignee": "claude",
+      "epic": "1302",
+      "evidence": "PR #1348. CommonsResourcePolicy struct with Serialize/Deserialize. 3 new tests + all 41 existing pass. Clippy clean."
+    },
+    {
+      "id": "s15-t8",
+      "title": "chore(ci): regulatory compliance linter (#1312)",
+      "status": "done",
+      "pr": 1349,
+      "assignee": "claude",
+      "epic": "1302",
+      "evidence": "PR #1349. Python linter + CI job at warning phase. 33 pre-existing violations cataloged. Ratchet to blocking after cleanup."
+    },
+    {
+      "id": "s15-t9",
+      "title": "Close epic #1302 with verified evidence for all 10 sub-items",
+      "status": "done",
+      "pr": null,
+      "assignee": "claude",
+      "epic": "1302",
+      "evidence": "All 10 sub-issues checked off. 8 success criteria verified: no payment terms in API, ProvenanceRef required, ExecutionReceipt proven (vertical slice test PR #1351), PatronageTracker (PR #1325), CommonsResourcePolicy extracted (PR #1348), DelegationManager persisted (PR #1326), 7 invariants in CONTRIBUTING.md, meaning firewall CI passing, compliance linter CI (PR #1349)."
+    },
+    {
+      "id": "s15-t10",
+      "title": "feat(cli): icnctl audit verify — receipt chain verification command (Tier 2)",
+      "status": "done",
+      "pr": 1354,
+      "assignee": "claude",
+      "epic": "1147",
+      "evidence": "PR #1354. icnctl audit verify command with 7 integrity checks, --json output, non-zero exit on failure. All workspace tests pass."
+    }
+  ],
+  "epics": {
+    "1099": "[EPIC] Pilot Completion (P0) — Flows A/B/C",
+    "1147": "[EPIC] Vertical Slice (P0) — Identity→Governance→Compute→Receipts→Audit",
+    "1302": "[EPIC] Regulatory-safe verifiable state architecture"
+  }
+}


### PR DESCRIPTION
## Summary
- Update Flow 2 demo script (`flow-2-patronage.sh`) to use current gateway ledger routes:
  - `POST /v1/ledger/{coop_id}/payment` → `POST /v1/ledger/{coop_id}/settle`
  - `GET /v1/ledger/{coop_id}/balance/{did}` → `GET /v1/ledger/{coop_id}/position/{did}`
  - Request field `currency` → `unit`
  - Response field `balances` → `positions`
- Remove stale comments referencing pre-439a8a2c route names
- Archive Sprint 15 (10/10 tasks done) to `ops/state/sprint/history/sprint-15.json`
- Open Sprint 16 targeting March 31 grant deadline

## Why
Flow 2 was classified FRAGILE in the Sprint 15 demo audit because commit `439a8a2c` renamed ledger routes but didn't update the demo scripts. This PR makes Flow 2 match the current API surface.

## Test plan
- [ ] `cargo fmt/clippy/test` — all pass (no Rust changes, shell + JSON only)
- [ ] After K3s redeploy, run `./demo/scripts/flow-2-patronage.sh` and verify steps 8-9 return 2xx
- [ ] Flow 4 unaffected (uses only `/history` and governance routes, both unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)