### PR TITLE
docs(grants): modular grant application artifacts for March 31 deadline

### DIFF
--- a/docs/strategy/grants/README.md
+++ b/docs/strategy/grants/README.md
@@ -1,0 +1,58 @@
+# Grant Application Artifacts
+
+**Modular, reusable materials for ICN grant applications. March 2026.**
+
+## How to Use These Files
+
+Each file is a self-contained module. Compose them per funder:
+
+| File | What It Is | Word Count |
+|------|-----------|------------|
+| [grant-one-pager.md](grant-one-pager.md) | Executive summary for any funder | ~600 |
+| [grant-narrative-core.md](grant-narrative-core.md) | Problem/solution/evidence narrative | ~1,500 |
+| [budget-skeleton.md](budget-skeleton.md) | Budget template with 3 tier examples | ~400 |
+| [milestones.md](milestones.md) | Timeline from current state through pilot | ~500 |
+| [compliance-architecture.md](compliance-architecture.md) | Regulatory-safe architecture explanation | ~800 |
+| [pilot-readiness.md](pilot-readiness.md) | What works, what's close, pilot requirements | ~800 |
+
+## Per-Funder Assembly
+
+### Outta Excuses Foundation ($500-3,000, due Mar 31)
+- One-pager (full)
+- Narrative core (Problem + Solution sections)
+- Budget skeleton (micro-grant tier)
+- Pilot readiness (ideal partner section)
+
+### Verizon Digital Ready ($10,000, due Mar 31)
+- One-pager (full)
+- Narrative core (full)
+- Budget skeleton (small grant tier)
+- Milestones (near-term section)
+- Pilot readiness (full)
+
+### Sovereign Tech Fund (€50,000+, target Apr 2026)
+- Narrative core (full)
+- Compliance architecture (full)
+- Budget skeleton (medium grant tier)
+- Milestones (full)
+- Pilot readiness (full)
+- Technical whitepaper: `../ICN-Technical-Whitepaper.md`
+
+## Placeholders
+
+Items marked `[PLACEHOLDER]` require external inputs:
+- Exact compensation rates (SSDI-compliant)
+- Named pilot partners
+- Fiscal sponsor fee structure (Alchemical)
+- ACCES-VR plan status
+- Contract developer rates
+
+## Source Documents
+
+These artifacts draw from:
+- `../ICN-Pitch.md` — Full narrative pitch
+- `../ICN-Definition.md` — Problem/solution definition
+- `../ICN-Gap-Analysis-March-2026.md` — System-by-system reality check
+- `../ICN-Technical-Whitepaper.md` — Technical architecture
+- `../../status/icn-status-march-2026.md` — Current project status
+- `../../status/demo-audit-2026-03-19.md` — Demo flow audit results

--- a/docs/strategy/grants/budget-skeleton.md
+++ b/docs/strategy/grants/budget-skeleton.md
@@ -1,0 +1,103 @@
+# ICN Budget Skeleton
+
+**Adapt amounts and line items per funder. This is the structural template.**
+
+---
+
+## Budget Categories
+
+### 1. Development Labor
+
+| Item | Monthly Cost | Duration | Total |
+|------|-------------|----------|-------|
+| Lead developer (Matt Faherty) | [PLACEHOLDER: $X,XXX] | 6 months | [PLACEHOLDER] |
+| Contract developer (mobile UX) | [PLACEHOLDER: $X,XXX] | 3 months | [PLACEHOLDER] |
+| **Subtotal** | | | **[PLACEHOLDER]** |
+
+**Notes:**
+- Lead developer rate should reflect disability-adjusted capacity (~20-25 hrs/week productive) and SSDI income limits ($1,210/month TWP, $1,690 SGA)
+- ACCES-VR self-employment plan may cover up to $11K of startup costs separately (application pending)
+- Contract developer needed for React Native mobile UX (voting, receipt verification)
+
+### 2. Infrastructure
+
+| Item | Monthly Cost | Duration | Total |
+|------|-------------|----------|-------|
+| Cloud hosting (pilot nodes) | $50-100 | 6 months | $300-600 |
+| Domain + DNS | $15/yr | 1 year | $15 |
+| SSL certificates | $0 (Let's Encrypt) | — | $0 |
+| **Subtotal** | | | **$315-615** |
+
+**Notes:**
+- Current development runs on homelab infrastructure (no recurring cloud cost)
+- Pilot cooperatives will need hosted nodes until they run their own hardware
+- 2-3 pilot nodes at $20-50/month each covers the deployment phase
+
+### 3. Pilot Program
+
+| Item | Cost | Notes |
+|------|------|-------|
+| Cooperative onboarding (travel, meetings) | [PLACEHOLDER: $500-1,500] | Upstate NY, within driving distance |
+| Workshop materials | $200-500 | Printed guides, demo devices |
+| Pilot support (3 months) | [PLACEHOLDER] | Included in dev labor |
+| **Subtotal** | | **[PLACEHOLDER]** |
+
+### 4. Community & Outreach
+
+| Item | Cost | Notes |
+|------|------|-------|
+| NY Cooperative Summit participation | $0 (organizer) | Matt is core organizer |
+| Conference travel (1-2 events) | [PLACEHOLDER: $500-1,500] | NCBA CLUSA, Eastern Conference |
+| Documentation and guides | $0 | Included in dev labor |
+| **Subtotal** | | **[PLACEHOLDER]** |
+
+### 5. Legal & Administrative
+
+| Item | Cost | Notes |
+|------|------|-------|
+| Fiscal sponsor fees | [PLACEHOLDER: 5-10% of total] | Current sponsor: Alchemical |
+| Legal review (cooperative formation) | [PLACEHOLDER: $500-2,000] | BCL Corp → Article 5-A conversion |
+| **Subtotal** | | **[PLACEHOLDER]** |
+
+---
+
+## Budget Tiers by Funder
+
+### Micro-grant ($500-3,000)
+*e.g., Outta Excuses Foundation*
+
+Focus: pilot onboarding costs only
+- Cooperative partner meetings and travel: $500-1,000
+- Workshop materials: $200-500
+- Cloud hosting for pilot nodes (3 months): $150-300
+
+### Small grant ($5,000-10,000)
+*e.g., Verizon Digital Ready*
+
+Focus: pilot deployment + mobile UX
+- Development labor (2 months): $3,000-5,000
+- Infrastructure: $300-600
+- Pilot onboarding: $1,000-1,500
+- Workshop materials: $500
+
+### Medium grant (€50,000+)
+*e.g., Sovereign Tech Fund*
+
+Focus: full pilot cycle through federation deployment
+- Development labor (6 months): $25,000-35,000
+- Contract mobile developer (3 months): $8,000-12,000
+- Infrastructure: $600
+- Pilot program (3 cooperatives): $3,000-5,000
+- Community outreach: $1,500
+- Legal/admin: $2,000-3,000
+- Fiscal sponsor fees: $2,500-5,000
+
+---
+
+## Missing Inputs
+
+- [ ] Exact SSDI-compliant compensation rate (must stay under TWP/SGA thresholds)
+- [ ] ACCES-VR plan status — if approved, $11K offsets startup costs
+- [ ] Named pilot partner(s) and their specific needs
+- [ ] Fiscal sponsor fee structure (Alchemical — confirm percentage)
+- [ ] Contract mobile developer rate (market: $50-100/hr, need estimate for grant)

--- a/docs/strategy/grants/compliance-architecture.md
+++ b/docs/strategy/grants/compliance-architecture.md
@@ -1,0 +1,83 @@
+# ICN Compliance Architecture
+
+**How ICN stays regulatory-safe by design, not by disclaimer.**
+
+---
+
+## The Regulatory Context
+
+Any system that handles economic coordination between organizations triggers regulatory scrutiny. Payment systems, money transmission, securities, lending. The cooperative economy needs economic coordination. ICN provides it without becoming a regulated financial technology.
+
+This is not a legal argument. It is an architectural fact.
+
+## The Meaning Firewall
+
+ICN's core architectural principle is a strict separation between domain semantics and constraint enforcement:
+
+```
+┌─────────────────────────────────────────────────┐
+│                  APPLICATIONS                     │
+│  Governance  │  Mutual Credit  │  Membership      │
+│  "votes"     │  "obligations"  │  "members"       │
+│  "proposals" │  "settlements"  │  "cooperatives"  │
+├─────────────── MEANING FIREWALL ─────────────────┤
+│                    KERNEL                          │
+│  "state transitions"  │  "constraints"             │
+│  "signed envelopes"   │  "capability tokens"       │
+│  "hash chains"        │  "rate limits"             │
+└─────────────────────────────────────────────────┘
+```
+
+**Above the firewall:** Applications understand what a "vote" means, what an "obligation" is, what a "cooperative" does. They translate these concepts into generic constraints.
+
+**Below the firewall:** The kernel enforces constraints mechanically. It processes signed state transitions with quorum thresholds, position constraints, and capability checks. It does not know what any of it means.
+
+## Why This Matters for Regulation
+
+1. **No payment processing.** The kernel does not process payments. It enforces position constraints on state transitions. Applications interpret position changes as economic activity (mutual credit, patronage distribution, resource sharing). The kernel sees numbers.
+
+2. **No currency issuance.** ICN does not create, issue, or manage currency. Cooperatives track mutual obligations using unit-denominated positions. The units are defined by governance policy, not by the system. "Hours," "patronage credits," and "commons capacity" are application-layer concepts.
+
+3. **No money transmission.** ICN does not move money between parties. It records signed state transitions that applications interpret as settlements of mutual obligations. The actual movement of value happens through existing cooperative financial channels (credit unions, cooperative banks).
+
+4. **No securities.** Cooperative membership shares are not securities under most US state cooperative statutes (see NY Cooperative Corporations Law Article 5-A, Section 81). ICN tracks membership and governance participation, not investment returns.
+
+## Terminology Discipline
+
+ICN enforces regulatory-safe terminology through automated CI checks:
+
+| Forbidden Term | Required Alternative | Why |
+|---------------|---------------------|-----|
+| payment | settlement | Settlements of mutual obligations, not payments |
+| currency | unit | Units of account, not currencies |
+| balance | position | Net position in obligation graph, not account balance |
+| transaction | state transition | Generic state change, not financial transaction |
+| ledger | state change journal | Journal of state transitions, not financial ledger |
+| wallet | keystore | Cryptographic key storage, not money storage |
+| token (monetary) | capability | Authorization tokens, not value tokens |
+
+A **regulatory compliance linter** runs in CI (PR #1349) and flags any new introduction of forbidden terms in the API surface.
+
+## Enforcement Mechanisms
+
+| Mechanism | What It Checks | Status |
+|-----------|---------------|--------|
+| Meaning Firewall CI gate | No domain imports in kernel crates | Active, blocking |
+| Kernel Forbidden Dependencies | No `icn-trust`, `icn-governance` in kernel | Active, blocking |
+| Firewall Contract Enforcement | No semantic types cross the boundary | Active, blocking |
+| Regulatory Compliance Linter | Forbidden financial terms in API surface | Active, warning (ratcheting to blocking) |
+| Seven Invariants checklist | PR review checklist in CONTRIBUTING.md | Active, manual |
+
+## Evidence
+
+- **PR #1349:** Compliance linter CI job — catalogs 33 pre-existing violations, prevents new ones
+- **PR #1348:** CommonsResourcePolicy — extracted formula from kernel to governance-configurable policy
+- **PR #1351:** Vertical slice test — proves the complete receipt chain from governance to audit
+- **PR #1354:** `icnctl audit verify` — CLI command for machine-verifiable receipt chain integrity
+- **Epic #1302:** All 10 sub-issues closed with verified evidence (8 success criteria met)
+
+## What This Means for Funders
+
+ICN is **digital public infrastructure** for democratic coordination. It is architecturally equivalent to TCP/IP, not to Venmo. A grant funding ICN is funding infrastructure development, not financial technology development.
+
+The regulatory-safe architecture is not a surface-level framing exercise. It is enforced by automated CI gates that reject code violating the boundary. Every PR to ICN is checked against these constraints before it can merge.

--- a/docs/strategy/grants/grant-narrative-core.md
+++ b/docs/strategy/grants/grant-narrative-core.md
@@ -1,0 +1,81 @@
+# ICN Grant Narrative Core
+
+**Reusable narrative sections for grant applications. Adapt framing per funder.**
+
+---
+
+## Problem Statement
+
+The cooperative economy has a proof problem.
+
+When a worker cooperative votes on a wage proposal, the result is a line in a meeting minutes document. When a community land trust allocates funds from a community benefit agreement, the authorization is an email chain. When a federation of cooperatives makes a joint purchasing decision affecting dozens of member organizations, the evidence that governance happened is whatever someone remembers to write down.
+
+This matters because the cooperative movement is entering a period of unprecedented growth and scrutiny simultaneously. State and municipal governments are creating cooperative development programs. Foundations are funding cooperative ecosystem development. Federal agencies are exploring cooperative models for broadband, housing, and healthcare delivery. Every one of these institutional relationships requires accountability. And accountability without proof is just trust.
+
+The cooperative movement has no digital infrastructure it owns. Every tool in the cooperative technology stack is rented from a company that doesn't share cooperative values. Google Workspace for documents. Loomio for governance. QuickBooks for accounting. Slack for coordination. When a platform changes its pricing, cooperatives absorb the cost. When a platform changes its terms, cooperatives comply or migrate. When a platform shuts down, cooperatives lose their institutional records.
+
+For a movement built on the principle of democratic ownership, this is a structural contradiction. The solidarity economy runs on infrastructure designed for extraction.
+
+## Solution
+
+The InterCooperative Network (ICN) is peer-to-peer coordination software that lets democratic organizations prove their decisions, own their infrastructure, and coordinate with each other without trusting a platform.
+
+**Provable decisions.** When a governance action happens through ICN, it produces a cryptographic receipt. The receipt contains a hash of the decision, signed attestations from voters, and a verifiable chain linking the decision to the proposal that triggered it, the allocation it authorized, and the execution that followed. Anyone with the receipt can verify it independently. No platform operator, no certificate authority, no trust required. The mathematics proves it happened.
+
+This is not a feature of a voting app. It is a property of the infrastructure. Every state transition in ICN is deterministic, content-addressed, and signed. The system cannot produce a valid receipt for a decision that didn't happen. It cannot alter a receipt after the fact without breaking the hash chain.
+
+**Sovereign infrastructure.** ICN runs on hardware the organization controls. The daemon runs on a server, a cloud instance, or a Raspberry Pi. Identity lives in a local encrypted keystore. Organizational records live in local storage. Governance rules live in a machine-readable charter. No platform holds the data. No company operates the network.
+
+**Federation without surrender.** ICN lets organizations discover each other, verify claims, and settle obligations across boundaries without a common platform. Each organization runs its own node. Nodes communicate over encrypted peer-to-peer connections. Trust is established through verifiable participation, not through mutual membership in a vendor's ecosystem.
+
+## Why Now
+
+Three convergent factors make this the right moment:
+
+1. **The cooperative movement is scaling.** The number of worker cooperatives in the US has grown 30% in the past decade. State-level cooperative development legislation is active in New York, California, Colorado, and Maine. The movement needs infrastructure that scales with it.
+
+2. **Institutional funders want accountability.** Foundations funding cooperative development increasingly require governance evidence. "Show us your minutes" is becoming "show us your decision trail." ICN provides machine-verifiable proof, not self-reported documents.
+
+3. **The technology is ready.** Peer-to-peer cryptographic systems have matured. QUIC transport, Ed25519 signatures, content-addressed storage, and capability-based authorization are production-ready. ICN is not speculative technology. It is an integration of proven components for a specific institutional need.
+
+## Why ICN and Not Existing Tools
+
+| Tool | What It Does | What It Can't Do |
+|------|-------------|-----------------|
+| Loomio | Records votes | Prove votes to someone who wasn't there |
+| Google Workspace | Stores documents | Let you own the infrastructure |
+| Blockchain | Global consensus | Local-first governance without mining costs |
+| ActivityPub | Federates social posts | Federate institutional decisions with proof |
+| Open Collective | Financial transparency | Cryptographic governance receipts |
+
+ICN is the only system that combines provable governance, sovereign infrastructure, and cross-organization federation in a single coherent stack. It is not a blockchain (no global consensus, no tokens, no mining). It is not a SaaS platform (no vendor, no subscription, no lock-in). It is infrastructure, like TCP/IP is infrastructure.
+
+## Innovation
+
+ICN's core architectural innovation is the **Meaning Firewall** — a strict separation between domain semantics and constraint enforcement.
+
+Applications (governance, mutual credit, membership) translate human-meaningful concepts into generic constraints. The kernel enforces constraints mechanically without understanding what they mean. A "vote" becomes a signed state transition with a quorum threshold. A "budget allocation" becomes a constraint on account positions. The kernel doesn't know what a vote is. It knows what a valid state transition is.
+
+This separation has three consequences:
+
+1. **Regulatory safety.** Because the kernel never handles "payments," "currencies," or "financial instruments," ICN operates as coordination infrastructure, not a financial technology. This is not wordplay. The architecture genuinely does not process financial transactions. It enforces constraints on state transitions that applications interpret as economic activity.
+
+2. **Governance flexibility.** Different cooperatives can implement radically different governance models (simple majority, sociocracy, liquid democracy) on the same infrastructure. The kernel doesn't care. It enforces the constraints each governance model produces.
+
+3. **Auditability.** Because every state transition is deterministic, the entire decision chain is machine-verifiable. A grant funder can audit a cooperative's governance without trusting anyone. They check the cryptographic proofs.
+
+## Evidence of Progress
+
+ICN is not a whitepaper project. It is a working system:
+
+- **451,000 lines of Rust** across 34 crates in a single workspace
+- **5,933 passing tests** including integration tests and a full vertical slice test
+- **70+ REST API endpoints** for governance, mutual credit, federation, and receipts
+- **4 demo flows** demonstrating governance, patronage distribution, federation agreements, and institutional reporting
+- **TypeScript and React Native SDKs** for web and mobile integration
+- **Live deployment** on a 4-node K3s cluster running federated cooperative nodes
+- **Complete receipt chain** proven end-to-end in CI: proposal -> vote -> decision -> allocation -> execution -> audit provenance
+- **CI-enforced architecture** with automated gates for the Meaning Firewall, forbidden kernel dependencies, and regulatory compliance linting
+- **~75% complete** to first external pilot deployment
+
+This is not a prototype. It is infrastructure in late-stage development.

--- a/docs/strategy/grants/grant-one-pager.md
+++ b/docs/strategy/grants/grant-one-pager.md
@@ -1,0 +1,75 @@
+# ICN: Digital Public Infrastructure for the Cooperative Economy
+
+**InterCooperative Network** | Matt Faherty | intercooperative.network | March 2026
+
+---
+
+## The Problem
+
+Democratic organizations cannot prove their decisions happened. A cooperative votes on a budget. Someone writes it down. A grant funder, a federation partner, or a regulator has to take their word for it. Meeting minutes are a document someone typed. For seven people in a room, this works. For a federation of fifty organizations coordinating across a state, it doesn't.
+
+Meanwhile, the cooperative movement runs on infrastructure it doesn't own. Google Workspace, Loomio, Slack, QuickBooks. Every tool is rented from a company that can change terms, raise prices, or disappear. Democratic organizations built on the principle of ownership run on platforms they'll never control.
+
+## The Solution
+
+ICN is a peer-to-peer coordination substrate that lets cooperatives and community organizations:
+
+1. **Prove decisions.** Every governance action produces a cryptographic receipt. A vote, a budget allocation, a federation agreement. Anyone with the receipt can verify it independently. No platform required.
+
+2. **Own infrastructure.** ICN runs on hardware you control. Your identity, your records, your governance rules. No vendor holds your data.
+
+3. **Coordinate without surrendering.** Organizations discover each other, verify claims, and settle obligations across boundaries without a common platform. Exit is free.
+
+## What Exists Today
+
+| Metric | Value |
+|--------|-------|
+| Rust codebase | 451K lines, 34 crates |
+| Test suite | 5,933 passing tests |
+| API surface | 70+ REST endpoints |
+| Demo flows | 4 (governance, patronage, federation, reporting) |
+| SDKs | TypeScript + React Native |
+| Deployment | 4-node K3s cluster running federated demo |
+| Completion | ~75% to first external deployment |
+
+**Proven in CI:** Complete 6-link receipt chain (proposal -> vote -> decision -> allocation -> execution -> audit) verified end-to-end in automated tests.
+
+**Proven on K3s:** Governance flow (Flow 1) and federation flow (Flow 3) run clean against live cluster. Patronage and reporting flows updated and pending redeploy verification.
+
+## Architecture
+
+ICN implements a **constraint enforcement architecture** with a Meaning Firewall:
+
+- **Apps** (governance, mutual credit, membership) translate domain semantics into generic constraints
+- **Kernel** enforces constraints mechanically without understanding what they mean
+- This separation makes ICN infrastructure, not a product. Like TCP/IP doesn't know whether your packets are email or video, ICN doesn't know whether your state transitions are votes or payments
+
+This architecture is not theoretical. It is enforced by CI gates that reject code violating the boundary.
+
+## Who It's For
+
+Worker cooperatives, housing cooperatives, community land trusts, mutual aid networks, cooperative federations, and any organization that governs itself democratically and needs to prove it.
+
+**First pilot target:** Upstate New York cooperative ecosystem, supported by the NY Cooperative Summit network (3rd annual summit planned October 2026).
+
+## What Funding Enables
+
+| Phase | Timeline | Deliverable |
+|-------|----------|-------------|
+| Demo polish + grant prep | Now - Mar 31 | Recorded demo, grant submissions |
+| Pilot deployment | Apr - Jun 2026 | First external cooperative running ICN |
+| Mobile member UX | May - Jul 2026 | Phone-based voting and receipt verification |
+| Summit workshop | Oct 2026 | Live demonstration at NY Cooperative Summit |
+| Federation pilot | Q4 2026 | 3-5 cooperatives federated on ICN |
+
+## The Team
+
+**Matt Faherty** — Sole architect and developer. Background in cooperative organizing (NY Cooperative Summit co-organizer, 2 years running), software architecture, and sports science pedagogy. 12 years of coaching experience translating complex systems into accessible practice. CompTIA A+ certified. Building ICN full-time with AI-augmented development.
+
+**Advisory network:** Joe Marraffino (Cooperative Fund of New England), Frank Cetera (Institute for the Cooperative Digital Economy), Rochester Cooperative Collective, ACCES-VR vocational rehabilitation program.
+
+## Contact
+
+Matt Faherty | matt.faherty@gmail.com | 585-506-8579
+GitHub: github.com/InterCooperative-Network/icn
+Web: intercooperative.network

--- a/docs/strategy/grants/milestones.md
+++ b/docs/strategy/grants/milestones.md
@@ -1,0 +1,62 @@
+# ICN Milestones
+
+**Project timeline from current state through pilot deployment.**
+
+---
+
+## Completed Milestones
+
+| Milestone | Date | Evidence |
+|-----------|------|----------|
+| Phase 0: Foundation | Dec 2025 | 34-crate Rust workspace, actor-based runtime, all core subsystems |
+| Phase 1: Federation Demo | Mar 13, 2026 | 4 demo flows merged, K3s deployment, TypeScript SDK |
+| K3s Cluster Deployment | Dec 3, 2025 | 4-node federated demo running on dedicated hardware |
+| Epic #1302: Regulatory-Safe Architecture | Mar 19, 2026 | 10/10 sub-issues closed, 8 success criteria verified (PR #1348, #1349, #1351) |
+| 6-Link Receipt Chain | Mar 19, 2026 | Vertical slice integration test (PR #1351) proves complete chain in CI |
+| Sprint 15: Receipt Chain & Demo Truth | Mar 20, 2026 | 10/10 tasks done. Flows 1+3 PROVEN on K3s. Compliance linter in CI. |
+
+## Current Phase: Grant Prep & Stabilization (Mar 20 - Mar 31, 2026)
+
+| Task | Status | Target |
+|------|--------|--------|
+| Fix demo scripts for renamed API routes | Done (PR #1355) | Mar 20 |
+| Fix K3s deploy pipeline | In progress | Mar 22 |
+| Redeploy to K3s + verify all 4 flows | Blocked on pipeline | Mar 23 |
+| Package grant artifacts | In progress | Mar 25 |
+| Submit Outta Excuses application | Pending | Mar 31 |
+| Submit Verizon Digital Ready application | Pending | Mar 31 |
+
+## Near-Term Milestones (Apr - Jun 2026)
+
+| Milestone | Target | Deliverable | Dependencies |
+|-----------|--------|-------------|--------------|
+| Sovereign Tech Fund application | Apr 2026 | Full application + recorded demo | K3s flows verified |
+| First pilot partner identified | Apr 2026 | Named cooperative + needs assessment | NY coop network contacts |
+| Mobile member UX v1 | May 2026 | Phone-based voting + receipt verification | React Native SDK |
+| Pilot onboarding (1 cooperative) | Jun 2026 | External org running ICN node | Pilot partner, mobile UX |
+
+## Medium-Term Milestones (Jul - Dec 2026)
+
+| Milestone | Target | Deliverable |
+|-----------|--------|-------------|
+| NY Cooperative Summit workshop | Oct 2026 | Live demo + hands-on session |
+| Federation pilot (3-5 coops) | Q4 2026 | Multiple organizations federated on ICN |
+| Phase 2 completion (~90%) | Dec 2026 | Production-ready for small-scale deployment |
+
+## Long-Term Vision (2027+)
+
+| Milestone | Target | Deliverable |
+|-----------|--------|-------------|
+| Article 5-A Worker Cooperative formation | Q1 2027 | ICN development governed cooperatively |
+| First non-NY deployment | Q2 2027 | Geographic expansion beyond Finger Lakes |
+| v1.0 release | Q3 2027 | Stable API, migration guarantees, documentation |
+
+---
+
+## Key Decision Points
+
+1. **Pilot partner selection (Apr 2026):** Which cooperative or community organization becomes the first external user? Criteria: governance complexity, geographic proximity, willingness to provide feedback.
+
+2. **Mobile-first vs. desktop-first (May 2026):** The mobile UX spec exists (docs/mobile/icn-mobile-ux-spec-v1.md). Decision: invest in React Native native app, or PWA-first with native later?
+
+3. **Legal structure timing (Q1 2027):** When does ICN transition from sole proprietorship to worker cooperative? Depends on: funding secured, pilot partners engaged, at least one additional developer.

--- a/docs/strategy/grants/pilot-readiness.md
+++ b/docs/strategy/grants/pilot-readiness.md
@@ -1,0 +1,104 @@
+# ICN Pilot Readiness Assessment
+
+**What works, what's close, and what a pilot cooperative needs.**
+
+---
+
+## Current Demo Flow Status (as of Sprint 16, March 2026)
+
+| Flow | Name | Status | Evidence |
+|------|------|--------|----------|
+| Flow 1 | Governance (proposal → vote → decision → proof) | **PROVEN** | Runs clean on K3s. 14-step demo verified 2xx on all calls. |
+| Flow 2 | Patronage (surplus distribution with formula transparency) | **Updated** | Demo script fixed (PR #1355). Pending K3s redeploy verification. |
+| Flow 3 | Federation (cross-coop agreement ratification) | **PROVEN** | Runs clean on K3s after fix (PR #1344). Steps 5/6/7 verified 2xx. |
+| Flow 4 | Institutional Reporting (federation-wide audit view) | **Updated** | No route changes needed. Depends on Flows 1-3 data. |
+
+## What a Pilot Cooperative Gets
+
+### Day 1: Core Governance
+
+A cooperative installs ICN and immediately has:
+
+- **Democratic proposal system.** Create proposals with structured payloads (text, budget, allocation). Members vote. Quorum is enforced. Decisions are recorded.
+- **Cryptographic receipts.** Every governance action produces a verifiable receipt. The receipt chain links proposals to votes to decisions to allocations.
+- **Audit trail.** Any member can query the full governance history. Any authorized external party (funder, federation, auditor) can verify specific decisions.
+- **CLI tools.** `icnctl` provides command-line management for all governance operations, including `icnctl audit verify` for receipt chain integrity checks.
+
+### Month 1: Economic Coordination
+
+With governance established, a cooperative can use:
+
+- **Mutual credit.** Track obligations between members or between cooperatives. Double-entry accounting with Merkle-DAG integrity.
+- **Patronage distribution.** Governance-approved formulas distribute surplus proportionally to contribution. Every step is transparent and auditable.
+- **Settlement tracking.** Record and verify settlements of mutual obligations. Cross-unit settlements with configurable exchange policies.
+
+### Month 3: Federation
+
+Once comfortable with single-node operation:
+
+- **Peer discovery.** Find other ICN nodes on the network via mDNS or manual connection.
+- **Federation agreements.** Ratify cross-organization agreements with governance on both sides.
+- **Cross-coop visibility.** Read-only access to partner governance records for accountability without control.
+- **Resource sharing.** Equipment lending, service exchanges, and joint procurement tracked with provenance.
+
+## What's Not Ready Yet
+
+| Capability | Status | Timeline |
+|-----------|--------|----------|
+| Mobile member app | UX spec complete, implementation not started | May-Jun 2026 |
+| Multi-member identity | Single node DID per coop in demo; multi-member requires key management | Apr 2026 |
+| Automated governance execution | Gate wired (PR #1350), full automation in progress | Apr 2026 |
+| Production hardening | Security audit, rate limiting, backup/restore tested | Q3 2026 |
+
+## Pilot Requirements
+
+### What the cooperative needs:
+
+- A server, cloud instance, or even a Raspberry Pi (minimum: 2 CPU, 4GB RAM, 10GB storage)
+- A technical contact willing to run `icnd` and use `icnctl` (or a managed deployment)
+- At least 3 members willing to participate in governance actions during the pilot
+- A governance decision they actually need to make (not a toy scenario)
+
+### What ICN provides:
+
+- Installation and configuration support
+- Onboarding documentation and guided walkthrough
+- Weekly check-ins during the pilot period
+- Bug fixes prioritized for pilot-blocking issues
+
+### Ideal pilot partner characteristics:
+
+- **Active governance need.** A cooperative that makes regular collective decisions (budgets, policy, elections)
+- **Geographic proximity.** Upstate New York preferred for in-person onboarding support
+- **Federation interest.** A cooperative that coordinates with other cooperatives or community organizations
+- **Feedback willingness.** Willing to report what works, what breaks, and what's confusing
+
+## Candidate Ecosystem
+
+The NY Cooperative Summit network provides the primary pilot recruitment channel:
+
+| Organization Type | Examples in Network | Governance Complexity |
+|-------------------|--------------------|-----------------------|
+| Worker cooperatives | Rochester-area coops | High (labor hours, surplus distribution, elections) |
+| Housing cooperatives | Regional housing co-ops | Medium (maintenance budgets, capital reserves) |
+| Tool libraries | Community tool lending orgs | Low-medium (lending policies, membership) |
+| Food cooperatives | Finger Lakes food co-ops | Medium (member dividends, supplier decisions) |
+| Cooperative federations | Regional CDNs | High (cross-org coordination, shared services) |
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Pilot cooperative lacks technical capacity | Medium | High | Provide managed deployment option |
+| Multi-member identity complexity | Medium | Medium | Start with single-node governance, add members incrementally |
+| Mobile UX not ready for non-technical members | High | Medium | Desktop/CLI pilot first; mobile follows |
+| Pilot org loses interest | Low | High | Choose org with active governance need, not theoretical interest |
+
+---
+
+## Missing Inputs for Pilot Launch
+
+- [ ] Named pilot partner (1-3 cooperatives from NY network)
+- [ ] Specific governance use case for each partner
+- [ ] Managed deployment option (hosted nodes for non-technical coops)
+- [ ] Pilot timeline commitment (minimum 3 months)

--- a/ops/state/sprint/current.json
+++ b/ops/state/sprint/current.json
@@ -58,11 +58,11 @@
     {
       "id": "s16-t6",
       "title": "docs(grants): package grant-ready artifacts for March 31 deadline",
-      "status": "todo",
-      "pr": null,
+      "status": "done",
+      "pr": 1356,
       "assignee": "claude",
       "epic": "1099",
-      "evidence": null
+      "evidence": "6 modular grant files in docs/strategy/grants/. One-pager, narrative, budget, milestones, compliance, pilot readiness. Assembly guide per funder."
     }
   ],
   "epics": {


### PR DESCRIPTION
## Summary
- Add 6 reusable grant application artifacts in `docs/strategy/grants/`
- Modular design: compose per funder from independent files
- Covers: one-pager, narrative core, budget skeleton (3 tiers), milestones, compliance architecture, pilot readiness
- Assembly instructions per funder in README (Outta Excuses, Verizon Digital Ready, Sovereign Tech Fund)
- Sprint board updated: s16-t6 marked done

## Files
| File | Purpose |
|------|---------|
| `grant-one-pager.md` | Executive summary (~600 words) |
| `grant-narrative-core.md` | Problem/solution/evidence (~1,500 words) |
| `budget-skeleton.md` | Budget template with micro/small/medium tiers |
| `milestones.md` | Timeline: completed → current → near-term → long-term |
| `compliance-architecture.md` | Meaning Firewall + regulatory framing |
| `pilot-readiness.md` | Demo status, requirements, candidate ecosystem |
| `README.md` | Assembly guide per funder |

## Placeholders remaining
- Exact SSDI-compliant compensation rates
- Named pilot partners
- Fiscal sponsor fee structure (Alchemical)
- ACCES-VR plan status
- Contract mobile developer rates

## Test plan
- [ ] No Rust changes — docs + JSON only
- [ ] Verify all internal links resolve
- [ ] Review narrative accuracy against current project state

🤖 Generated with [Claude Code](https://claude.com/claude-code)