### PR TITLE
fix(ci): add SSH setup step to K3s deploy workflow

### DIFF
--- a/.github/workflows/docker-build-deploy.yml
+++ b/.github/workflows/docker-build-deploy.yml
@@ -102,6 +102,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Setup SSH for K3s nodes
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          # Ensure K3s node host keys are in known_hosts
+          for NODE in ${K3S_CONTROL} 10.8.30.41 10.8.30.42; do
+            ssh-keyscan -t ed25519 "$NODE" >> ~/.ssh/known_hosts 2>/dev/null
+          done
+          chmod 600 ~/.ssh/known_hosts
+          # Verify connectivity to control node
+          ssh -o BatchMode=yes -o ConnectTimeout=5 ubuntu@${K3S_CONTROL} "echo 'SSH OK'" || {
+            echo "::error::Cannot SSH to K3s control node at ${K3S_CONTROL}"
+            echo "Ensure ci-runner has an SSH key authorized on the K3s nodes."
+            echo "See: docs/guides/operations/ for key setup instructions."
+            exit 1
+          }
+
       - name: Build Docker image
         run: |
           echo "Building image ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}"


### PR DESCRIPTION
## Summary
- Add SSH setup step to `docker-build-deploy.yml` that populates `known_hosts` and verifies connectivity before build/deploy
- Infrastructure fix already applied: ci-runner SSH key generated and authorized on all K3s nodes

## Root Cause
The Feb 2026 ci-runner rebuild (VM 446) created a fresh VM without:
1. An SSH keypair
2. K3s node fingerprints in `known_hosts`

The previous agent's commit (`c4cb39c0`) correctly rewrote all commands to use SSH, but didn't set up the trust path. Every subsequent deploy failed with `Host key verification failed`.

## Infrastructure Changes (already applied, not in this PR)
- Generated `~/.ssh/id_ed25519` on ci-runner (10.8.30.46)
- Authorized ci-runner's public key on k3s-control (.40), worker-1 (.41), worker-2 (.42)
- Populated `~/.ssh/known_hosts` on ci-runner with node fingerprints

## Workflow Changes (this PR)
- New step "Setup SSH for K3s nodes" before Docker build
- `ssh-keyscan` ensures known_hosts is current (survives node rebuilds)
- Connectivity check fails fast with `::error::` annotation and actionable message

## Test plan
- [ ] Merge to main → triggers deploy workflow → verify SSH step passes
- [ ] Verify Docker build + push to registry succeeds
- [ ] Verify kubectl commands via SSH succeed (deploy + rollout status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)