### PR TITLE
fix(compute): gossip-layer author validation for payer authorization (#1342)

### DIFF
--- a/icn/crates/icn-core/src/supervisor/init_notifications.rs
+++ b/icn/crates/icn-core/src/supervisor/init_notifications.rs
@@ -556,9 +556,31 @@ pub async fn handle_snapshot_coordination(
 }
 
 /// Handle compute topic messages
-pub async fn handle_compute_message(entry_data: Vec<u8>, compute_handle: ComputeHandleHolder) {
+///
+/// `entry_author` is the DID of the gossip entry author as authenticated by the gossip layer.
+/// For `TaskSubmitted`, we validate that it matches `task.submitter` to prevent payer spoofing
+/// (#1342): a malicious peer could publish a TaskSubmitted message naming a victim DID as payer.
+pub async fn handle_compute_message(
+    entry_data: Vec<u8>,
+    entry_author: Did,
+    compute_handle: ComputeHandleHolder,
+) {
     match icn_encoding::decode::<icn_compute::ComputeMessage>(&entry_data) {
         Ok(compute_msg) => {
+            // Security (#1342): validate gossip entry author matches declared task submitter.
+            // This prevents a malicious peer from spoofing victim DIDs as payers.
+            if let icn_compute::ComputeMessage::TaskSubmitted(ref task) = compute_msg {
+                if entry_author.as_str() != task.submitter.as_str() {
+                    warn!(
+                        entry_author = %entry_author,
+                        task_submitter = %task.submitter,
+                        task_id = %task.id,
+                        "Payer spoofing attempt: gossip entry author does not match task.submitter; rejecting"
+                    );
+                    return;
+                }
+            }
+
             if let Some(handle) = compute_handle.read().await.as_ref() {
                 if let Err(e) = handle.handle_gossip(compute_msg).await {
                     warn!("Failed to handle compute message: {}", e);
@@ -945,8 +967,9 @@ pub fn create_notification_callback(
         {
             if let Some(data) = entry_data {
                 let compute_handle = deps.compute_handle.clone();
+                let entry_author = entry.author.clone();
                 tokio::spawn(async move {
-                    handle_compute_message(data, compute_handle).await;
+                    handle_compute_message(data, entry_author, compute_handle).await;
                 });
             }
         } else if topic == icn_ccl::TOPIC_DISPUTES_FILE {
@@ -1044,5 +1067,82 @@ mod tests {
         // The actual construction requires many dependencies so we just verify the trait
         fn assert_clone<T: Clone>() {}
         assert_clone::<NotificationDeps>();
+    }
+
+    fn make_test_task(id: &str, submitter_did: &str) -> icn_compute::ComputeTask {
+        use icn_compute::{
+            DeterminismClass, ExecutorCapability, FuelLimit, PrivacyClass, TaskCode, TaskPriority,
+        };
+        icn_compute::ComputeTask {
+            id: id.to_string(),
+            submitter: submitter_did.to_string(),
+            coop_id: None,
+            code: TaskCode::Ccl("return 42".into()),
+            inputs: vec![],
+            fuel_limit: FuelLimit::default(),
+            required_capabilities: vec![ExecutorCapability::Ccl],
+            priority: TaskPriority::Normal,
+            created_at: 1000,
+            deadline: None,
+            payment_rate: None,
+            payment_currency: None,
+            resource_profile: None,
+            actor_mode: None,
+            placement_constraints: None,
+            federation_constraints: None,
+            estimated_value: None,
+            verification: None,
+            inputs_hash: None,
+            policy_hash: None,
+            determinism_class: DeterminismClass::default(),
+            privacy_class: PrivacyClass::default(),
+            storage_class: None,
+            data_locality: None,
+            scope: Default::default(),
+        }
+    }
+
+    /// Verify the payer-spoofing guard rejects mismatched author/submitter.
+    ///
+    /// A malicious peer could publish TaskSubmitted with a victim DID as `submitter`
+    /// (payer). The guard must drop such messages before they reach the compute actor.
+    #[tokio::test]
+    async fn test_compute_message_rejects_spoofed_author() {
+        use icn_compute::ComputeMessage;
+        use icn_identity::KeyPair;
+        use std::sync::Arc;
+        use tokio::sync::RwLock;
+
+        let attacker_did = KeyPair::generate().unwrap().did().clone();
+        let victim_did = KeyPair::generate().unwrap().did().clone();
+
+        // Build a TaskSubmitted message where submitter = victim (spoofed payer)
+        let task = make_test_task("spoofed-task", victim_did.as_str());
+        let msg = ComputeMessage::TaskSubmitted(Box::new(task));
+        let entry_data = icn_encoding::encode(&msg).unwrap();
+
+        // handle_compute_message with attacker as entry_author should silently drop the message
+        let compute_handle: ComputeHandleHolder = Arc::new(RwLock::new(None));
+        handle_compute_message(entry_data, attacker_did, compute_handle).await;
+        // If we reach here without panic, the rejection path executed correctly
+    }
+
+    /// Verify legitimate TaskSubmitted (author == submitter) passes the guard.
+    #[tokio::test]
+    async fn test_compute_message_accepts_matching_author() {
+        use icn_compute::ComputeMessage;
+        use icn_identity::KeyPair;
+        use std::sync::Arc;
+        use tokio::sync::RwLock;
+
+        let did = KeyPair::generate().unwrap().did().clone();
+
+        let task = make_test_task("legit-task", did.as_str());
+        let msg = ComputeMessage::TaskSubmitted(Box::new(task));
+        let entry_data = icn_encoding::encode(&msg).unwrap();
+
+        let compute_handle: ComputeHandleHolder = Arc::new(RwLock::new(None));
+        // Should not early-return — guard passes, then no-ops (handle is None)
+        handle_compute_message(entry_data, did, compute_handle).await;
     }
 }

--- a/icn/crates/icn-core/src/supervisor/init_notifications.rs
+++ b/icn/crates/icn-core/src/supervisor/init_notifications.rs
@@ -560,11 +560,14 @@ pub async fn handle_snapshot_coordination(
 /// `entry_author` is the DID of the gossip entry author as authenticated by the gossip layer.
 /// For `TaskSubmitted`, we validate that it matches `task.submitter` to prevent payer spoofing
 /// (#1342): a malicious peer could publish a TaskSubmitted message naming a victim DID as payer.
+///
+/// Returns `true` if the message passed the author guard and was forwarded (or would have been
+/// forwarded if the compute handle were present), `false` if rejected by the guard or malformed.
 pub async fn handle_compute_message(
     entry_data: Vec<u8>,
     entry_author: Did,
     compute_handle: ComputeHandleHolder,
-) {
+) -> bool {
     match icn_encoding::decode::<icn_compute::ComputeMessage>(&entry_data) {
         Ok(compute_msg) => {
             // Security (#1342): validate gossip entry author matches declared task submitter.
@@ -577,7 +580,7 @@ pub async fn handle_compute_message(
                         task_id = %task.id,
                         "Payer spoofing attempt: gossip entry author does not match task.submitter; rejecting"
                     );
-                    return;
+                    return false;
                 }
             }
 
@@ -586,9 +589,11 @@ pub async fn handle_compute_message(
                     warn!("Failed to handle compute message: {}", e);
                 }
             }
+            true
         }
         Err(e) => {
             warn!("Failed to deserialize compute message: {}", e);
+            false
         }
     }
 }
@@ -1121,10 +1126,12 @@ mod tests {
         let msg = ComputeMessage::TaskSubmitted(Box::new(task));
         let entry_data = icn_encoding::encode(&msg).unwrap();
 
-        // handle_compute_message with attacker as entry_author should silently drop the message
         let compute_handle: ComputeHandleHolder = Arc::new(RwLock::new(None));
-        handle_compute_message(entry_data, attacker_did, compute_handle).await;
-        // If we reach here without panic, the rejection path executed correctly
+        let forwarded = handle_compute_message(entry_data, attacker_did, compute_handle).await;
+        assert!(
+            !forwarded,
+            "spoofed TaskSubmitted (entry_author != task.submitter) must be rejected"
+        );
     }
 
     /// Verify legitimate TaskSubmitted (author == submitter) passes the guard.
@@ -1142,7 +1149,10 @@ mod tests {
         let entry_data = icn_encoding::encode(&msg).unwrap();
 
         let compute_handle: ComputeHandleHolder = Arc::new(RwLock::new(None));
-        // Should not early-return — guard passes, then no-ops (handle is None)
-        handle_compute_message(entry_data, did, compute_handle).await;
+        let forwarded = handle_compute_message(entry_data, did, compute_handle).await;
+        assert!(
+            forwarded,
+            "matching author/submitter must pass the guard (returns true even when handle is None)"
+        );
     }
 }

--- a/ops/state/decisions/0009-happy-eyeballs-ipv4-ipv6-connection-racing.md
+++ b/ops/state/decisions/0009-happy-eyeballs-ipv4-ipv6-connection-racing.md
@@ -1,0 +1,63 @@
+# ADR-0009: Happy Eyeballs — IPv4/IPv6 Connection Racing Within Endpoint Categories
+
+**Date**: 2026-03-21
+**Status**: accepted
+**Tags**: networking, ipv6, dual-stack, connectivity
+**Supersedes**: (none)
+
+## Context
+
+Sprint 18 completes the IPv6 connectivity track (epic #1295, phases 21-22). With
+`EndpointCandidate` / `EndpointKind` now available (PR #1358, ADR-0003), nodes can
+store and exchange multiple addresses per kind (local, public, relay).
+
+In dual-stack environments, a peer may have both an IPv4 and an IPv6 local address.
+Naively preferring IPv6 breaks nodes where the IPv6 path is degraded (e.g. NAT64
+tunnels, misconfigured 6to4, IPv6-only interfaces with no default route). Naively
+preferring IPv4 leaves IPv6-native networks underserved and slows connection setup
+for nodes where IPv6 is faster.
+
+The existing `dial_parallel()` in `nat_dial.rs` already races *endpoint categories*
+(local vs public). This ADR extends that to racing *IP versions within a category*
+following RFC 8305.
+
+## Decision
+
+Add `dial_happy_eyeballs(addrs: Vec<SocketAddr>, ...)` to `nat_dial.rs`:
+
+1. **Sort order**: IPv6 addresses first, IPv4 second (future-proof for IPv6-only networks).
+2. **Stagger**: Spawn the IPv6 dial immediately. If no success within `happy_eyeballs_delay_ms`
+   (default 250ms), spawn the IPv4 dial. This matches the delay specified in RFC 8305 §5
+   and used by all major browsers.
+3. **Winner takes all**: Return the first successful connection, cancel the other task.
+4. **Scope**: Races within a single `EndpointKind` (Local, Public, or Relay). The existing
+   `dial_parallel()` continues to race *across* kinds (local vs public). Happy Eyeballs
+   adds a second level of racing *within* a kind.
+5. **Config**: Add `happy_eyeballs_delay_ms: u64` to `NatDialConfig` with
+   `#[serde(default)]` so existing config files remain valid.
+
+## Consequences
+
+**Easier**:
+- Dual-stack nodes connect via whichever path (IPv4 or IPv6) responds first.
+- IPv6-native nodes get preference without harming dual-stack nodes with slow IPv6.
+- The 250ms stagger limits overhead: worst case is one extra dial attempt per connection.
+
+**Harder or riskier**:
+- Slightly more concurrent dials during connection setup (bounded to 2 per category).
+- `dial_parallel()` already handles the winner-takes-all pattern; extending it adds
+  complexity that must be tested carefully.
+
+**Out of scope (deferred)**:
+- Cross-category Happy Eyeballs (local-IPv6 vs public-IPv4) — not needed now.
+- Adaptive delay based on observed RTT — overkill for Sprint 18.
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|-------------|-------------|
+| Static IPv6 preference | Breaks dual-stack nodes with degraded IPv6 paths; no recovery mechanism |
+| Static IPv4 preference | Leaves IPv6-native networks underserved; wrong direction for the cooperative internet's long-term trajectory |
+| No racing, try IPv6 then IPv4 sequentially | Adds full `public_dial_timeout_ms` (10s) latency when IPv6 fails; unacceptable UX |
+| Race all addresses simultaneously with no stagger | More concurrent connections, wastes bandwidth, and doesn't give IPv6 preferential treatment as required by RFC 8305 |
+| Per-peer IP version learning / memory | Correct long-term, but premature for Sprint 18 scope; deferred to a future ADR |

--- a/ops/state/sprint/current.json
+++ b/ops/state/sprint/current.json
@@ -1,88 +1,67 @@
 {
-  "sprint": 17,
-  "name": "Sprint 17 — Security Hardening & IPv6 Foundation",
+  "sprint": 18,
+  "name": "Sprint 18 — IPv6 Connectivity: KnownPeer Endpoint Sets + Happy Eyeballs",
   "started": "2026-03-21",
   "goals": [
-    "Fix 4 security/correctness bugs flagged in S14-S16 code review (grant deadline: these undermine compliance claims)",
-    "IPv6 type refactor: EndpointCandidate + ConnectionCandidate (#1297) — gates all subsequent IPv6 work",
-    "Close PR #1338 (IPv6 dual-stack bind defaults) which has been in-review since S14"
+    "Close #1342 fully: gossip-layer author validation for compute payment settlement",
+    "KnownPeer endpoint field (#1300): replace Vec<String> with Vec<EndpointCandidate>",
+    "mDNS multi-address (#1298): advertise and collect all local addresses",
+    "Happy Eyeballs (#1299): race IPv4/IPv6 within address categories (RFC 8305)"
   ],
   "execution_order": [
-    "t1 (icnctl [::1]) — 1-line fix, unblocks IPv6 CLI usage immediately",
-    "t2 (delegation gossip validation) — adversarial-by-default, security bug",
-    "t3 (CharterPolicyOracle fail-closed) — meaning firewall integrity, security bug",
-    "t4 (payer authorization) — partial fix now, full fix requires PaymentRequest refactor (track in #1342)",
-    "t5 (PR #1338) — already merged in S16; icnctl default gap fixed in t1",
-    "t6 (EndpointCandidate type) — IPv6 type refactor, leads S17 networking track"
+    "t1 (#1342) — security gap, always first; gossip-layer entry.author == task.submitter guard",
+    "t2 (#1300) — KnownPeer type change; gates mDNS multi-address usefulness",
+    "t3 (#1298) — mDNS multi-address; needs #1300 for typed storage",
+    "t4 (#1299) — Happy Eyeballs dial racing; separate module, can overlap with t3"
   ],
   "tasks": [
     {
-      "id": "s17-t1",
-      "title": "fix(cli): icnctl RPC default [::1]:5601 after IPv6 bind change (#1339)",
-      "status": "done",
+      "id": "s18-t1",
+      "title": "fix(compute): gossip-layer author validation for payer authorization (#1342)",
+      "status": "pending",
       "pr": null,
-      "assignee": "claude",
-      "issue": 1339,
-      "epic": "1295",
-      "note": "1-line fix: default_value 127.0.0.1:5601 → [::1]:5601. Also fix healthcheck bind. Committed 88d091b0."
-    },
-    {
-      "id": "s17-t2",
-      "title": "fix(governance): validate delegation gossip sender before overwrite (#1340)",
-      "status": "done",
-      "pr": null,
-      "assignee": "claude",
-      "issue": 1340,
-      "epic": "1099",
-      "note": "Validate gossip sender DID == delegation.delegator before accept/revoke. 4 new security tests. Committed 88d091b0."
-    },
-    {
-      "id": "s17-t3",
-      "title": "fix(governance): CharterPolicyOracle fail-closed on translation error (#1341)",
-      "status": "done",
-      "pr": null,
-      "assignee": "claude",
-      "issue": 1341,
-      "epic": "1099",
-      "note": "Return Deny on charter_to_constraints() failure and unknown charter_id. Updated tests. Committed 88d091b0."
-    },
-    {
-      "id": "s17-t4",
-      "title": "fix(compute): payer authorization audit trail for compute settlements (#1342)",
-      "status": "done",
-      "pr": null,
-      "assignee": "claude",
+      "assignee": null,
       "issue": 1342,
       "epic": "1099",
-      "note": "Minimal fix: embed payer DID in provenance for auditability. Full fix (capability token in PaymentRequest) tracked in #1342. Committed 88d091b0."
+      "note": "Add entry.author == task.submitter guard in init_notifications.rs handle_compute_message(). Pass entry_author: Did through to the TaskSubmitted match arm. Closes the spoofing vector without needing PaymentRequest struct change."
     },
     {
-      "id": "s17-t5",
-      "title": "merge PR #1338: IPv6 dual-stack bind defaults ([::] and [::1])",
-      "status": "done",
-      "pr": 1338,
+      "id": "s18-t2",
+      "title": "refactor(net): KnownPeer endpoint field — Vec<String> → Vec<EndpointCandidate> (#1300)",
+      "status": "pending",
+      "pr": null,
       "assignee": null,
-      "issue": 1296,
+      "issue": 1300,
       "epic": "1295",
-      "note": "Already merged in S16 deploy work. icnctl default gap closed by t1."
+      "note": "Intentional wire format change. Update protocol.rs KnownPeer struct. Update peer_exchange.rs construction. Update init_network.rs .addresses accesses. Add serde compat notes."
     },
     {
-      "id": "s17-t6",
-      "title": "feat(net): EndpointCandidate type + ConnectionCandidate refactor (#1297)",
-      "status": "in_review",
-      "pr": 1358,
-      "assignee": "claude",
-      "issue": 1297,
+      "id": "s18-t3",
+      "title": "feat(net): mDNS multi-address — advertise all local addrs, collect Vec<SocketAddr> (#1298)",
+      "status": "pending",
+      "pr": null,
+      "assignee": null,
+      "issue": 1298,
       "epic": "1295",
-      "note": "EndpointKind + EndpointCandidate added. ConnectionCandidate refactored to Vec<EndpointCandidate>. Backward-compat new() + accessor methods. PR open. 250+308 tests pass."
+      "note": "Modify PeerInfo to store Vec<SocketAddr>. Update browse handler to collect all get_addresses(). Integrate with EndpointCandidate::local() for KnownPeer construction."
+    },
+    {
+      "id": "s18-t4",
+      "title": "feat(net): Happy Eyeballs — race IPv4/IPv6 in parallel with 250ms stagger (#1299)",
+      "status": "pending",
+      "pr": null,
+      "assignee": null,
+      "issue": 1299,
+      "epic": "1295",
+      "note": "RFC 8305 adaptation. Add dial_happy_eyeballs() to nat_dial.rs. IPv6 preferred, IPv4 fallback after 250ms. Add happy_eyeballs_delay_ms to NatDialConfig (serde default). Works per EndpointKind category."
     }
   ],
   "epics": {
     "1099": "[EPIC] ICN Pilot Completion — End-to-End Demos (P0)",
     "1295": "[EPIC] IPv6 dual-stack transport and endpoint sets (Phases 21-22)"
   },
-  "deferred_from_s14": {
-    "note": "Items deferred S14→S15→S16 that are now S17 targets",
-    "issues": [1297, 1298, 1299, 1300, 1301, 1120]
+  "deferred_from_s17": {
+    "note": "Issues deferred S14→S17 that are now S18 targets (after PR #1358 merge). #1301 (IPv6 federation transport) deferred to S19 — depends on #1298+#1299. #1120 has zero code references — flag for human review/closure.",
+    "issues": [1298, 1299, 1300, 1301, 1120]
   }
 }


### PR DESCRIPTION
## Summary

- Adds `entry_author: Did` parameter to `handle_compute_message()` in `init_notifications.rs`
- Validates `entry_author == task.submitter` for `TaskSubmitted` messages before forwarding to the compute actor
- Adds two security tests: one verifying spoofed messages are rejected, one verifying legitimate messages pass

## Problem

A malicious peer could publish a `TaskSubmitted` gossip message naming a victim DID as `task.submitter` (payer). The gossip layer verifies the entry author's signature, but the compute actor was not checking that the authenticated author matches the declared submitter. This allowed payer spoofing for compute payment settlement.

## Solution

In `create_notification_callback()`, `entry.author` is already available (it's the gossip-authenticated DID). We pass it to `handle_compute_message()` and add the guard before dispatching to the compute actor.

Only `TaskSubmitted` needs this check — other compute message types use different auth paths.

The S17 partial fix (`init_compute.rs` comment at line 182) noted this gap as needing a full fix. This PR closes it.

## Risk

Low. The guard is a strict equality check on a field that's always set correctly for legitimate messages. The compute actor receives one fewer call on spoofed messages; no state change in the compute actor itself.

## Test plan

- [x] `cargo test -p icn-core --lib test_compute_message` — 2/2 pass
- [x] `cargo check --workspace` — clean
- [x] `cargo clippy -p icn-core --all-targets -- -D warnings` — clean

Closes #1342.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)