### PR TITLE
feat(net): Happy Eyeballs — race IPv4/IPv6 within endpoint categories (#1299)

### DIFF
--- a/icn/crates/icn-core/src/config/network.rs
+++ b/icn/crates/icn-core/src/config/network.rs
@@ -204,7 +204,8 @@ pub struct NatDialConfig {
     /// spawning an IPv4 dial task. The first successful connection wins.
     ///
     /// 250ms matches RFC 8305 §5 and the value used by all major browsers.
-    /// Set to 0 to disable IPv6 preference and dial all addresses simultaneously.
+    /// Set to 0 to start the IPv4 task immediately alongside IPv6 (no stagger delay).
+    /// IPv6 is still preferred — this only removes the delay before IPv4 is spawned.
     ///
     /// Default: 250 (milliseconds)
     #[serde(default = "default_happy_eyeballs_delay_ms")]

--- a/icn/crates/icn-core/src/config/network.rs
+++ b/icn/crates/icn-core/src/config/network.rs
@@ -196,6 +196,19 @@ pub struct NatDialConfig {
     /// Default: 150 (2.5 minutes)
     #[serde(default = "default_candidate_announce_interval_secs")]
     pub candidate_announce_interval_secs: u64,
+
+    /// Delay before attempting the IPv4 fallback in Happy Eyeballs dialing (RFC 8305), in milliseconds
+    ///
+    /// When multiple addresses of different IP versions are available within one endpoint
+    /// category (Local or Public), ICN dials IPv6 first and waits this long before also
+    /// spawning an IPv4 dial task. The first successful connection wins.
+    ///
+    /// 250ms matches RFC 8305 §5 and the value used by all major browsers.
+    /// Set to 0 to disable IPv6 preference and dial all addresses simultaneously.
+    ///
+    /// Default: 250 (milliseconds)
+    #[serde(default = "default_happy_eyeballs_delay_ms")]
+    pub happy_eyeballs_delay_ms: u64,
 }
 
 impl Default for NatDialConfig {
@@ -206,6 +219,7 @@ impl Default for NatDialConfig {
             public_dial_timeout_ms: default_public_dial_timeout_ms(),
             relay_dial_timeout_ms: default_relay_dial_timeout_ms(),
             candidate_announce_interval_secs: default_candidate_announce_interval_secs(),
+            happy_eyeballs_delay_ms: default_happy_eyeballs_delay_ms(),
         }
     }
 }
@@ -224,6 +238,10 @@ fn default_relay_dial_timeout_ms() -> u64 {
 
 fn default_candidate_announce_interval_secs() -> u64 {
     150
+}
+
+fn default_happy_eyeballs_delay_ms() -> u64 {
+    250
 }
 
 fn default_circuit_breaker_threshold() -> u32 {

--- a/icn/crates/icn-core/src/supervisor/nat_dial.rs
+++ b/icn/crates/icn-core/src/supervisor/nat_dial.rs
@@ -416,75 +416,89 @@ pub async fn dial_happy_eyeballs(
 
     let delay = Duration::from_millis(config.happy_eyeballs_delay_ms);
 
-    // Fast path: only one IP version present — dial it directly, no stagger needed
+    // Fast path: only one IP version present — try all addresses in order, no stagger needed
     let has_ipv6 = sorted.iter().any(|a| a.is_ipv6());
     let has_ipv4 = sorted.iter().any(|a| a.is_ipv4());
     if !has_ipv6 || !has_ipv4 {
-        let addr = sorted[0];
-        debug!(%did, %addr, "happy_eyeballs: single IP version, dialing directly");
-        return tokio::time::timeout(dial_timeout, network_handle.dial(addr, did.clone()))
-            .await
-            .ok()
-            .and_then(|r| r.ok())
-            .map(|_| addr);
+        icn_obs::metrics::nat::dial_attempt_inc("happy_eyeballs");
+        debug!(%did, candidates = sorted.len(), "happy_eyeballs: single IP version, dialing sequentially");
+        for addr in &sorted {
+            if let Ok(Ok(_)) =
+                tokio::time::timeout(dial_timeout, network_handle.dial(*addr, did.clone())).await
+            {
+                icn_obs::metrics::nat::dial_success_inc(
+                    if addr.is_ipv6() { "ipv6" } else { "ipv4" },
+                );
+                info!(%did, %addr, "happy_eyeballs: connected");
+                return Some(*addr);
+            }
+        }
+        icn_obs::metrics::nat::dial_failure_inc();
+        return None;
     }
 
-    // Dual-stack path: IPv6 first, IPv4 after stagger
+    // Dual-stack path: IPv6 first (immediate), IPv4 after stagger (RFC 8305 §5)
     let ipv6_addrs: Vec<SocketAddr> = sorted.iter().filter(|a| a.is_ipv6()).copied().collect();
     let ipv4_addrs: Vec<SocketAddr> = sorted.iter().filter(|a| a.is_ipv4()).copied().collect();
 
-    let ipv6_addr = ipv6_addrs[0];
-    let ipv4_addr = ipv4_addrs[0];
-
     debug!(
         %did,
-        ipv6 = %ipv6_addr,
-        ipv4 = %ipv4_addr,
+        ipv6_candidates = ipv6_addrs.len(),
+        ipv4_candidates = ipv4_addrs.len(),
         stagger_ms = config.happy_eyeballs_delay_ms,
         "happy_eyeballs: racing IPv6 (preferred) and IPv4 (staggered)"
     );
+    icn_obs::metrics::nat::dial_attempt_inc("happy_eyeballs");
 
     let (result_tx, mut result_rx) = tokio::sync::mpsc::channel::<SocketAddr>(1);
 
-    // Spawn IPv6 task (immediate)
-    let ipv6_handle_clone = network_handle.clone();
+    // Spawn IPv6 task: try all IPv6 addresses in order, send first success
+    let ipv6_handle = network_handle.clone();
     let ipv6_did = did.clone();
     let ipv6_tx = result_tx.clone();
     let ipv6_task = tokio::spawn(async move {
-        if let Ok(Ok(_)) =
-            tokio::time::timeout(dial_timeout, ipv6_handle_clone.dial(ipv6_addr, ipv6_did)).await
-        {
-            let _ = ipv6_tx.send(ipv6_addr).await;
+        for addr in ipv6_addrs {
+            if let Ok(Ok(_)) =
+                tokio::time::timeout(dial_timeout, ipv6_handle.dial(addr, ipv6_did.clone())).await
+            {
+                let _ = ipv6_tx.send(addr).await;
+                break;
+            }
         }
     });
 
-    // Spawn IPv4 task (staggered)
-    let ipv4_handle_clone = network_handle.clone();
+    // Spawn IPv4 task: sleep stagger, then try all IPv4 addresses in order
+    let ipv4_handle = network_handle.clone();
     let ipv4_did = did.clone();
     let ipv4_tx = result_tx.clone();
     let ipv4_task = tokio::spawn(async move {
         tokio::time::sleep(delay).await;
-        if let Ok(Ok(_)) =
-            tokio::time::timeout(dial_timeout, ipv4_handle_clone.dial(ipv4_addr, ipv4_did)).await
-        {
-            let _ = ipv4_tx.send(ipv4_addr).await;
+        for addr in ipv4_addrs {
+            if let Ok(Ok(_)) =
+                tokio::time::timeout(dial_timeout, ipv4_handle.dial(addr, ipv4_did.clone())).await
+            {
+                let _ = ipv4_tx.send(addr).await;
+                break;
+            }
         }
     });
 
     // Drop the original sender so the channel closes when both tasks finish
     drop(result_tx);
 
-    // Wait for first success or both tasks finishing
+    // Wait for first success or both tasks exhausted
     let winner = result_rx.recv().await;
 
-    // Cancel the other task (best-effort; the task is already detached but the result is ignored)
+    // Cancel the other task (best-effort)
     ipv6_task.abort();
     ipv4_task.abort();
 
     if let Some(addr) = winner {
+        icn_obs::metrics::nat::dial_success_inc(if addr.is_ipv6() { "ipv6" } else { "ipv4" });
         info!(%did, %addr, "happy_eyeballs: connected");
     } else {
-        debug!(%did, "happy_eyeballs: both IPv4 and IPv6 failed");
+        icn_obs::metrics::nat::dial_failure_inc();
+        debug!(%did, "happy_eyeballs: all candidates exhausted");
     }
 
     winner

--- a/icn/crates/icn-core/src/supervisor/nat_dial.rs
+++ b/icn/crates/icn-core/src/supervisor/nat_dial.rs
@@ -384,6 +384,112 @@ async fn dial_sequential(
     None
 }
 
+/// Race IPv4 and IPv6 addresses within a single endpoint category (RFC 8305 Happy Eyeballs).
+///
+/// IPv6 is preferred: it is dialed immediately. If the IPv6 dial does not succeed within
+/// `config.happy_eyeballs_delay_ms` (default 250ms), an IPv4 dial is spawned in parallel.
+/// The first successful connection wins; all other tasks are cancelled.
+///
+/// If `addrs` contains only one IP version, that address is dialed directly with no stagger.
+/// If `addrs` is empty, returns `None`.
+///
+/// # Design (ADR-0009)
+///
+/// This function races addresses **within** a single `EndpointKind`. The existing
+/// `dial_parallel()` continues to race **across** kinds (Local vs Public). These two
+/// levels of racing compose: for each category of addresses that has both IPv4 and IPv6,
+/// Happy Eyeballs finds the faster path automatically.
+pub async fn dial_happy_eyeballs(
+    addrs: Vec<SocketAddr>,
+    did: &icn_identity::Did,
+    network_handle: &NetworkHandle,
+    dial_timeout: Duration,
+    config: &NatDialConfig,
+) -> Option<SocketAddr> {
+    if addrs.is_empty() {
+        return None;
+    }
+
+    // Sort: IPv6 first, IPv4 second (RFC 8305 §5 preference order)
+    let mut sorted = addrs;
+    sorted.sort_by_key(|a| !a.is_ipv6());
+
+    let delay = Duration::from_millis(config.happy_eyeballs_delay_ms);
+
+    // Fast path: only one IP version present — dial it directly, no stagger needed
+    let has_ipv6 = sorted.iter().any(|a| a.is_ipv6());
+    let has_ipv4 = sorted.iter().any(|a| a.is_ipv4());
+    if !has_ipv6 || !has_ipv4 {
+        let addr = sorted[0];
+        debug!(%did, %addr, "happy_eyeballs: single IP version, dialing directly");
+        return tokio::time::timeout(dial_timeout, network_handle.dial(addr, did.clone()))
+            .await
+            .ok()
+            .and_then(|r| r.ok())
+            .map(|_| addr);
+    }
+
+    // Dual-stack path: IPv6 first, IPv4 after stagger
+    let ipv6_addrs: Vec<SocketAddr> = sorted.iter().filter(|a| a.is_ipv6()).copied().collect();
+    let ipv4_addrs: Vec<SocketAddr> = sorted.iter().filter(|a| a.is_ipv4()).copied().collect();
+
+    let ipv6_addr = ipv6_addrs[0];
+    let ipv4_addr = ipv4_addrs[0];
+
+    debug!(
+        %did,
+        ipv6 = %ipv6_addr,
+        ipv4 = %ipv4_addr,
+        stagger_ms = config.happy_eyeballs_delay_ms,
+        "happy_eyeballs: racing IPv6 (preferred) and IPv4 (staggered)"
+    );
+
+    let (result_tx, mut result_rx) = tokio::sync::mpsc::channel::<SocketAddr>(1);
+
+    // Spawn IPv6 task (immediate)
+    let ipv6_handle_clone = network_handle.clone();
+    let ipv6_did = did.clone();
+    let ipv6_tx = result_tx.clone();
+    let ipv6_task = tokio::spawn(async move {
+        if let Ok(Ok(_)) =
+            tokio::time::timeout(dial_timeout, ipv6_handle_clone.dial(ipv6_addr, ipv6_did)).await
+        {
+            let _ = ipv6_tx.send(ipv6_addr).await;
+        }
+    });
+
+    // Spawn IPv4 task (staggered)
+    let ipv4_handle_clone = network_handle.clone();
+    let ipv4_did = did.clone();
+    let ipv4_tx = result_tx.clone();
+    let ipv4_task = tokio::spawn(async move {
+        tokio::time::sleep(delay).await;
+        if let Ok(Ok(_)) =
+            tokio::time::timeout(dial_timeout, ipv4_handle_clone.dial(ipv4_addr, ipv4_did)).await
+        {
+            let _ = ipv4_tx.send(ipv4_addr).await;
+        }
+    });
+
+    // Drop the original sender so the channel closes when both tasks finish
+    drop(result_tx);
+
+    // Wait for first success or both tasks finishing
+    let winner = result_rx.recv().await;
+
+    // Cancel the other task (best-effort; the task is already detached but the result is ignored)
+    ipv6_task.abort();
+    ipv4_task.abort();
+
+    if let Some(addr) = winner {
+        info!(%did, %addr, "happy_eyeballs: connected");
+    } else {
+        debug!(%did, "happy_eyeballs: both IPv4 and IPv6 failed");
+    }
+
+    winner
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -403,5 +509,32 @@ mod tests {
         assert_eq!(config.public_dial_timeout_ms, 10000);
         assert_eq!(config.relay_dial_timeout_ms, 30000);
         assert_eq!(config.candidate_announce_interval_secs, 150);
+        assert_eq!(config.happy_eyeballs_delay_ms, 250);
+    }
+
+    #[test]
+    fn test_happy_eyeballs_delay_default() {
+        let config = NatDialConfig::default();
+        assert_eq!(
+            config.happy_eyeballs_delay_ms, 250,
+            "RFC 8305 §5 mandates 250ms stagger"
+        );
+    }
+
+    #[test]
+    fn test_ipv6_sort_order() {
+        // Verify that our sort puts IPv6 first
+        let mut addrs: Vec<SocketAddr> = vec![
+            "192.168.1.1:7777".parse().unwrap(), // IPv4
+            "[::1]:7777".parse().unwrap(),       // IPv6
+            "10.0.0.1:7777".parse().unwrap(),    // IPv4
+            "[fe80::1]:7777".parse().unwrap(),   // IPv6
+        ];
+        addrs.sort_by_key(|a| !a.is_ipv6());
+
+        assert!(addrs[0].is_ipv6(), "first address must be IPv6");
+        assert!(addrs[1].is_ipv6(), "second address must be IPv6");
+        assert!(addrs[2].is_ipv4(), "third address must be IPv4");
+        assert!(addrs[3].is_ipv4(), "fourth address must be IPv4");
     }
 }

--- a/icn/crates/icn-core/src/supervisor/nat_dial.rs
+++ b/icn/crates/icn-core/src/supervisor/nat_dial.rs
@@ -426,9 +426,11 @@ pub async fn dial_happy_eyeballs(
             if let Ok(Ok(_)) =
                 tokio::time::timeout(dial_timeout, network_handle.dial(*addr, did.clone())).await
             {
-                icn_obs::metrics::nat::dial_success_inc(
-                    if addr.is_ipv6() { "ipv6" } else { "ipv4" },
-                );
+                icn_obs::metrics::nat::dial_success_inc(if addr.is_ipv6() {
+                    "ipv6"
+                } else {
+                    "ipv4"
+                });
                 info!(%did, %addr, "happy_eyeballs: connected");
                 return Some(*addr);
             }


### PR DESCRIPTION
## Summary

- Adds `dial_happy_eyeballs()` to `nat_dial.rs` — RFC 8305 connection racing within a single `EndpointKind`
- Adds `happy_eyeballs_delay_ms: u64` to `NatDialConfig` (default 250ms, `#[serde(default)]`)
- 3 new unit tests: default config value, RFC 8305 delay, IPv6-first sort order

## Algorithm (RFC 8305 §5 adaptation)

1. Sort addresses: IPv6 first, IPv4 second
2. Spawn IPv6 dial task immediately (preferred for IPv6-native networks)
3. After `happy_eyeballs_delay_ms` (default 250ms), spawn IPv4 dial task (fallback)
4. Return first successful connection, abort the other task

**Fast path**: if only one IP version is present, dial directly (no stagger, no overhead).

## Scope

`dial_happy_eyeballs()` races **within** a single `EndpointKind`. The existing `dial_parallel()` races **across** kinds (Local vs Public). These two levels compose — each category of addresses races both IP versions independently.

The function is added but not yet wired into `dial_parallel()` / `dial_with_fallback()`. Wiring happens when `#1298` and `#1300` land (they provide the typed multi-address inputs). The function is ready to call from those integration points.

## Config backward compatibility

`happy_eyeballs_delay_ms` uses `#[serde(default)]` — existing config files (TOML/JSON) that don't include this field will default to 250ms automatically.

## Risk

Low. New function, not yet wired. Config field has safe default and doesn't break existing configs.

See ADR-0009 for design decisions and alternatives considered.

Closes #1299.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)