### PR TITLE
feat(website): blog posts, community cards, data-driven roadmap, stats pipeline

### DIFF
--- a/.github/workflows/sync-stats.yml
+++ b/.github/workflows/sync-stats.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   sync-stats:
@@ -16,6 +17,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Full history needed for git log --merges fallback in gen-stats.mjs
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -30,8 +33,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git diff --quiet website/src/data/stats.json 2>/dev/null || {
-            git add website/src/data/stats.json
+          # stats.json is gitignored (generated at build time) so force-add is required
+          git add -f website/src/data/stats.json
+          git diff --quiet --cached website/src/data/stats.json || {
             git commit -m "chore(website): update stats.json [skip ci]"
             git push
           }

--- a/.github/workflows/sync-stats.yml
+++ b/.github/workflows/sync-stats.yml
@@ -1,0 +1,37 @@
+name: Sync Website Stats
+
+on:
+  schedule:
+    # Run daily at 02:00 UTC
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync-stats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate stats.json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node website/scripts/gen-stats.mjs
+
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git diff --quiet website/src/data/stats.json 2>/dev/null || {
+            git add website/src/data/stats.json
+            git commit -m "chore(website): update stats.json [skip ci]"
+            git push
+          }

--- a/website/scripts/gen-stats.mjs
+++ b/website/scripts/gen-stats.mjs
@@ -51,8 +51,13 @@ function countTests() {
   }
 }
 
-// Count merged PRs from git log (merge commits)
+// Count merged PRs: gh API (accurate), fallback to git merge commits
 function countMergedPRs() {
+  const ghOut = run(
+    `gh pr list --state merged --limit 1000 --json number --jq 'length' -R InterCooperative-Network/icn 2>/dev/null`,
+    { cwd: repoRoot }
+  );
+  if (ghOut && /^\d+$/.test(ghOut)) return parseInt(ghOut, 10);
   try {
     const out = run(
       `git log --oneline --merges --format="%h" 2>/dev/null | wc -l`,
@@ -64,18 +69,41 @@ function countMergedPRs() {
   }
 }
 
+// Active branches: gh API first, fallback to git branch -r
+function countActiveBranches() {
+  const ghOut = run(
+    `gh api "repos/InterCooperative-Network/icn/branches?per_page=100" --paginate --jq 'length' 2>/dev/null | awk '{s+=$1} END{print s}'`,
+    { cwd: repoRoot }
+  );
+  if (ghOut && /^\d+$/.test(ghOut)) return parseInt(ghOut, 10);
+  const gitOut = run(`git branch -r 2>/dev/null | grep -v HEAD | wc -l`, { cwd: repoRoot });
+  return parseInt(gitOut.trim(), 10) || 0;
+}
+
+// Doc files: count all .md files under docs/ at repo root
+function countDocFiles() {
+  const docsDir = path.join(repoRoot, "docs");
+  if (!fs.existsSync(docsDir)) return 0;
+  const out = run(`find "${docsDir}" -name "*.md" | wc -l`);
+  return parseInt(out.trim(), 10) || 0;
+}
+
 const latestCommit = run("git rev-parse --short HEAD", { cwd: repoRoot }) || "unknown";
 const latestCommitFull = run("git rev-parse HEAD", { cwd: repoRoot }) || "";
 
 const rustLinesOfCode = countRustLoc();
 const testCount = countTests();
 const mergedPRs = countMergedPRs();
+const activeBranches = countActiveBranches();
+const docFiles = countDocFiles();
 
 const stats = {
   crates,
   rustLinesOfCode,
   testCount,
   mergedPRs,
+  activeBranches,
+  docFiles,
   latestCommit,
   latestCommitFull,
   syncedAt: new Date().toISOString(),
@@ -91,5 +119,5 @@ const outPath = path.join(
 fs.mkdirSync(path.dirname(outPath), { recursive: true });
 fs.writeFileSync(outPath, JSON.stringify(stats, null, 2) + "\n");
 console.log(
-  `[gen-stats] ${crates} crates · ${rustLinesOfCode.toLocaleString()} LoC · ${testCount} tests · ${mergedPRs} PRs → ${outPath}`
+  `[gen-stats] ${crates} crates · ${rustLinesOfCode.toLocaleString()} LoC · ${testCount} tests · ${mergedPRs} PRs · ${activeBranches} branches · ${docFiles} docs → ${outPath}`
 );

--- a/website/src/content/blog/institution-in-a-box.md
+++ b/website/src/content/blog/institution-in-a-box.md
@@ -1,0 +1,65 @@
+---
+title: "Institution-in-a-Box: A Live Demo"
+description: "What it looks like when a cooperative actually runs on ICN. A walk-through of the four governance flows that make up our demo."
+pubDate: 2026-03-21
+tags: ["demo", "governance", "cooperative", "summit"]
+---
+
+The most common question we get is: "What does it actually do?"
+
+Fair question. Coordination infrastructure is abstract until it isn't. So here is what it actually does, in the form of a demo you can run yourself.
+
+## The Setup
+
+Three nodes. Three cooperatives. One federation.
+
+Each node runs `icnd`, the ICN daemon. Each has a DID generated from a local keypair. The nodes discover each other over the local network via mDNS, establish encrypted QUIC connections, and begin gossiping governance state.
+
+Start time to three connected nodes: about thirty seconds. No configuration server. No cloud account. No "sign up for a developer key." The network builds itself from the cryptographic identities.
+
+## Flow 1: Governance Proposal
+
+A member of Cooperative A submits a governance proposal: allocate 500 commons credits to a shared infrastructure fund.
+
+The proposal goes to `icnd` via the RPC API. The governance engine encodes it as a signed artifact, gossips it to all members, and opens a voting period. Members vote by signing a vote transaction with their keypair. The vote is counted. The proposal is accepted.
+
+What makes this different from a voting app: the accepted proposal produces a `GovernanceReceipt` with a hash. That hash follows the proposal into every downstream action. If someone later tries to execute an allocation without that receipt in the chain, the protocol rejects it. The decision and the consequence are cryptographically linked.
+
+## Flow 2: Patronage Distribution
+
+Cooperative B runs `icnctl coop distribute-patronage`. The PatronageTracker computes each member's contribution share for the period, generates a distribution receipt, and posts it to the ledger.
+
+The member who contributed the most doesn't get to decide they contributed the most. The tracker computes it from the signed work records accumulated during the period. The math is public. The inputs are auditable. The output is a signed artifact.
+
+If your cooperative operates in New York and is required to distribute surplus based on patronage, this is the flow that does it correctly, in a way that can be audited and verified by members and, if necessary, by regulators.
+
+## Flow 3: Federated Resource Allocation
+
+Cooperative A has compute capacity. Cooperative C needs compute. They have a federation agreement.
+
+Cooperative C submits a compute task. The federation protocol routes it to Cooperative A's available nodes. The task executes. An `ExecutionReceipt` comes back. The receipt is linked to the federation agreement that authorized the allocation. Commons credits move between the two cooperatives' accounts, recorded on both sides as signed journal entries.
+
+No platform in the middle. No third-party routing compute marketplace. Two organizations that agreed to work together, doing so directly, with a verifiable record on both sides.
+
+## Flow 4: Audit Report
+
+After the demo's governance, patronage, and compute flows run, `icnctl audit verify` generates a report. Every decision links to its execution. Every execution links to its authorization. Every allocation links to the receipt that proves it happened.
+
+The audit report is not a dashboard that someone generated. It is a traversal of the cryptographic receipt chain. If the chain is valid, the report is valid. If anyone tampered with a record, the chain breaks and the report says so.
+
+This is what cooperative accountability looks like when the infrastructure takes it seriously.
+
+## Run It Yourself
+
+```bash
+git clone https://github.com/InterCooperative-Network/icn
+cd icn && just devnet-up
+# Three nodes start, form a network, ready for demo flows
+bash demo/scripts/present-governance.sh --port 9080
+```
+
+The demo runs on your laptop. No cloud required. No account required. The cryptographic infrastructure is local, real, and auditable.
+
+The summit is in October. The demo will run there. If you want to be part of building what it demonstrates, the issues are labeled, the codebase is open, and we have a Matrix room.
+
+The infrastructure is not theoretical anymore.

--- a/website/src/content/blog/regulatory-safety-by-architecture.md
+++ b/website/src/content/blog/regulatory-safety-by-architecture.md
@@ -1,0 +1,46 @@
+---
+title: "Regulatory Safety by Architecture"
+description: "ICN's seven invariants aren't a compliance checklist. They're load-bearing walls. Here's why that distinction matters."
+pubDate: 2026-03-21
+tags: ["architecture", "regulatory", "design", "cooperative"]
+---
+
+When people say a system is "compliant," they usually mean someone audited it and wrote a report. The report says the right things. The auditor signed it. The regulator accepted it. Everyone goes home.
+
+This is not how ICN approaches regulatory safety. The difference is worth explaining carefully, because it is the difference between a system that is safe and a system that can be argued to be safe.
+
+## The Seven Invariants
+
+ICN is built around seven architectural invariants. These are not policies enforced by administrators. They are structural properties of the protocol. Violating them requires changing the code, not bypassing a rule.
+
+**1. User-signed transitions only.** Every state change is signed by the key of the entity that authorized it. There is no privileged path through which an operator can modify state without user authorization. An operator cannot redirect your credits. They cannot revoke your membership. They cannot reassign your vote.
+
+**2. No hosted balances.** ICN tracks obligations and receipts. It does not hold assets. There is no "ICN wallet" that holds value on your behalf. The protocol records that you have a claim on something. The claim is exercised through your governance, not by ICN moving anything.
+
+**3. No operator routing of value.** ICN nodes relay gossip messages. They do not route value. The distinction matters legally. A system that routes value needs money transmission licenses. A system that gossips signed commitments does not.
+
+**4. Derived views are not authoritative.** Your dashboard shows you what your node has computed from the receipt chain. The receipt chain is the authoritative record. If your dashboard says one thing and the chain says another, the chain is right. There is no database that can be corrected without correcting the chain.
+
+**5. No embedded convertibility.** ICN does not convert anything to anything. Commons credits are not redeemable for dollars through the protocol. There is no exchange rate. There is no "cash out" endpoint. What your cooperative decides to honor is your governance's decision, not the protocol's.
+
+**6. Matching and market features are opt-in, scoped, and governance-authorized.** If you want ICN to help match compute tasks to available nodes, you opt into that. The matching happens under your governance's policies. The scope is what you define. Nothing happens by default that you didn't authorize.
+
+**7. Execution receipts close the governance loop.** Governance decisions produce receipts. Execution is authorized by receipts. The two are linked by hash. There is no authorized action without a governance decision. There is no governance decision without evidence of execution.
+
+## Why This Is Different From Compliance
+
+A compliance approach would say: we will not route value without the proper licenses. A policy document says this. Auditors verify adherence. The policy can be changed. The audit can be gamed.
+
+An architectural approach says: the code cannot route value. Not because we chose not to. Because there is no code path that does it. The invariant is enforced by the structure of the system, not by the intentions of its operators.
+
+This matters most under adversarial conditions. A regulatory finding against a compliant-by-policy system means rewriting policies. A regulatory finding against an architecturally safe system means proving the architecture doesn't do what the finding claims. The architecture is the argument.
+
+## What This Is Not
+
+Architectural safety is not a guarantee against all regulatory risk. It is a specific claim: ICN's architecture does not create the risk profile of a payment intermediary, a custodian, or a money transmitter. Other risk profiles exist and require other analysis.
+
+It is also not finished. The compliance sprint (epic #1302) is closed. The seven invariants are in the code. The CI linter blocks custodial patterns from the public API. But the work of demonstrating architectural safety is ongoing. Every sprint adds receipts to the chain.
+
+The architecture is the argument. The receipts are the evidence. Both are in the open, on GitHub, for anyone who wants to read them.
+
+That is not a compliance posture. That is a design philosophy.

--- a/website/src/content/blog/sprint-14-closing-the-economic-loop.md
+++ b/website/src/content/blog/sprint-14-closing-the-economic-loop.md
@@ -1,0 +1,52 @@
+---
+title: "Sprint 14: Closing the Economic Loop"
+description: "PatronageTracker, ExecutionReceiptGate, and why linking governance decisions to execution outputs is harder than it sounds."
+pubDate: 2026-03-21
+tags: ["development", "sprint", "economics", "governance"]
+---
+
+Every sprint has a theme. Sprint 14's theme was: prove that decisions and their consequences are actually connected.
+
+This sounds obvious. In practice, it is one of the hardest things to build correctly. Most software systems treat governance and execution as separate layers that communicate by convention. Someone decides something. Someone else executes it. The link between the two is a handshake agreement, not a verifiable chain.
+
+ICN is trying to do something different. Sprint 14 is where that ambition became code.
+
+## PatronageTracker: NY Corp Law §93 in Rust
+
+New York's cooperative corporation law requires that worker-owned businesses track member contributions over time. The law exists to make surplus allocation transparent: members should be able to see what they contributed and verify that distribution reflects those contributions.
+
+Nobody had implemented this as software that actually runs.
+
+`PatronageTracker` is now in the codebase. It accumulates per-member contribution history, ties each entry to a governance period, and produces cryptographic artifacts that can be audited. If your cooperative is incorporated in New York and operates on ICN, the accounting your members are legally entitled to see is automatically generated and signed.
+
+This is what "cooperative-native infrastructure" means. Not a generic accounting tool adapted for cooperatives. Software that knows what cooperatives need because it was built for that context from the start.
+
+## ExecutionReceiptGate: Invariant Seven
+
+ICN has seven core architecture invariants. Invariant seven is the most important one for economic integrity:
+
+**Execution receipts close the governance loop.**
+
+A governance decision without an execution receipt is a promise. An execution receipt without a linked governance decision is an unauthorized action. The protocol must enforce that these two things are always connected.
+
+`ExecutionReceiptGate` is the enforcement mechanism. Before compute results are accepted and settlement proceeds, the gate checks that the task execution was authorized by a governance decision in the receipt chain. No decision hash, no settlement. No shortcuts.
+
+The adversarial model here is important. ICN assumes peers are untrusted. A malicious compute operator could attempt to claim payment for work that was never authorized. The gate rejects this by construction. The receipt chain is the proof of authorization, and the proof is checked cryptographically, not by policy enforcement after the fact.
+
+## DelegationManager: Persistence Across Restarts
+
+Governance doesn't stop when a node restarts. If a member has delegated their voting power to a coordinator for a six-month governance period, that delegation needs to survive node crashes, network outages, and software updates.
+
+`DelegationManager` now persists delegation state with gossip sync. When a node comes back online, its delegation graph is restored from local storage and reconciled with what peers have seen. The gossip layer ensures that delegation changes propagate without requiring all nodes to be online simultaneously.
+
+This is table stakes for a production governance system. Sprint 14 made it real.
+
+## What Closing the Loop Actually Costs
+
+None of these features are simple. `PatronageTracker` required designing a contribution accounting model from scratch. `ExecutionReceiptGate` required threading receipt hashes through the entire compute pipeline and making the gate rejection a hard failure rather than a warning. `DelegationManager` persistence required careful conflict resolution for concurrent delegation changes.
+
+The work is unglamorous. It is not the kind of thing that generates a press release. But it is the kind of thing that makes the difference between a demo and a system someone can actually run their cooperative on.
+
+Sprint 14 closed the economic loop. Sprint 18 is hardening the network beneath it. The receipt chain is real. The governance is real. The only thing left is deployment.
+
+We are closer than we have ever been.

--- a/website/src/content/blog/what-icn-is-and-isnt.md
+++ b/website/src/content/blog/what-icn-is-and-isnt.md
@@ -1,0 +1,54 @@
+---
+title: "What ICN Is (And What It Isn't)"
+description: "A blunt framing for the technically skeptical. ICN is coordination infrastructure, not a blockchain, not a payment rail, not a DAO."
+pubDate: 2026-03-21
+tags: ["architecture", "framing", "cooperative"]
+---
+
+Let's get the disclaimers out of the way first.
+
+ICN is not a blockchain. It has no token. There is no "ICN coin." If you are here because someone told you this was a crypto project, they were wrong and you should demand a refund of your time.
+
+What ICN actually is: a peer-to-peer coordination substrate for cooperatives, communities, and federations. Think less "decentralized finance" and more "group infrastructure that doesn't require trusting a single company." The distinction matters enormously and we will return to it.
+
+## The Problem ICN Solves
+
+Cooperatives are organizationally democratic but technically dependent. A worker-owned grocery collective uses Square for payments, Slack for communication, and QuickBooks for accounting. The cooperative controls the governance. The infrastructure is owned by someone else, and that someone has different incentives, different politics, and a different idea of what your data is worth.
+
+This is not a fringe concern. It is a structural problem. Every cooperative that relies on extractive infrastructure is one pricing change, one acquisition, one "we're sunsetting this product" away from crisis. The democratic governance the members voted for is fully dependent on infrastructure they didn't vote for and can't control.
+
+ICN is the technical answer to that dependency.
+
+## What "Coordination Substrate" Actually Means
+
+A substrate is what sits under everything else. ICN provides:
+
+- **Identity** without a central authority. Every member, every cooperative, every federation gets a decentralized identifier (DID) backed by a cryptographic key they hold. No username-password database. No account recovery email. No "sign in with Google."
+
+- **Governance** that actually governs. Proposals, votes, and delegation chains are cryptographic artifacts, not rows in a database someone else owns. When your cooperative votes to allocate surplus, that decision is linked by hash to the execution that follows it. There is no gap between "we decided" and "it happened."
+
+- **Economic coordination** without payment rails. ICN tracks obligations, receipts, and contributions. It doesn't move money. It records who did what, who agreed to what, and what the evidence trail looks like. What you do with that evidence is your governance's business.
+
+- **Federation** without a hub. Two cooperatives can transact, share resources, and govern their relationship without routing through a platform that extracts rent from both.
+
+The substrate metaphor is intentional. You build on top of it. ICN does not tell you how to run your cooperative. It gives you the infrastructure to run it without asking permission.
+
+## What ICN Is Not
+
+ICN is not a payment system. This is not a hedge or a legal technicality. It is a design decision backed by architecture. ICN has no hosted balances. No operator routes value on your behalf. Every state transition is signed by the member who authorized it.
+
+The implication: ICN cannot be a payment intermediary because the protocol physically cannot hold money. There is nothing to seize, freeze, or comply-away. This is what "regulatory safety by architecture" means, and it is not a marketing line.
+
+ICN is not a DAO. DAOs are governance experiments on top of financial infrastructure. ICN is governance infrastructure that financial tools can be built on top of. The direction matters. Finance-first systems bolt governance on as an afterthought. ICN is governance-first; economic coordination is a consequence of that.
+
+ICN is not finished. We are building in public, on GitHub, under an open license. Sprint 18 is running right now. If you want to watch sausage get made with Rust and strong opinions, the commit log is public.
+
+## Why This Matters Now
+
+The cooperative sector is large, growing, and technically underserved. There are tens of thousands of worker cooperatives, housing cooperatives, credit unions, and mutual aid organizations in the United States alone. Almost none of them have technical infrastructure that reflects their values.
+
+ICN is the attempt to fix that. Not by disrupting the cooperative sector with technology, but by building the tools the sector has always needed and never had time or money to build itself.
+
+The summit is in October. The demo is getting sharper every sprint. The infrastructure is real.
+
+Come build with us.

--- a/website/src/data/roadmap.json
+++ b/website/src/data/roadmap.json
@@ -1,0 +1,45 @@
+{
+  "currentSprint": {
+    "number": 18,
+    "name": "IPv6 Connectivity: KnownPeer Endpoint Sets + Happy Eyeballs",
+    "status": "active"
+  },
+  "stages": [
+    {
+      "id": "A",
+      "label": "Stage A — Now",
+      "badge": "badge-teal",
+      "markerColor": "var(--accent-teal)",
+      "title": "Institution-in-a-Box",
+      "description": "Charter templates, guided cooperative formation, membership onboarding, treasury ledger, and proposal-to-vote loop. The minimum viable institution.",
+      "status": "active"
+    },
+    {
+      "id": "B",
+      "label": "Stage B",
+      "badge": "badge-blue",
+      "markerColor": "var(--accent-blue)",
+      "title": "Federation Layer",
+      "description": "Inter-cooperative agreements with treaty-based governance, cross-group trust propagation, and federation clearing for mutual credit networks.",
+      "status": "planned"
+    },
+    {
+      "id": "C",
+      "label": "Stage C",
+      "badge": "badge-purple",
+      "markerColor": "var(--accent-purple)",
+      "title": "Compute Commons",
+      "description": "Shared compute resources contributed to a commons and allocated via cooperative fuel metering. Members contribute hardware; the network rewards them with cooperative capacity.",
+      "status": "planned"
+    },
+    {
+      "id": "D",
+      "label": "Stage D",
+      "badge": "badge-amber",
+      "markerColor": "var(--accent-amber)",
+      "title": "Civilization Tools",
+      "description": "Participatory budgeting at city scale. Municipal governance platforms. Public infrastructure coordination. The long-term vision: democratic technology governance beyond the co-op.",
+      "status": "vision"
+    }
+  ]
+}

--- a/website/src/pages/community.astro
+++ b/website/src/pages/community.astro
@@ -49,6 +49,24 @@ import stats from '../data/stats.json';
           <h3>Documentation</h3>
           <p>{stats.docFiles}+ documents covering architecture, APIs, guides, economics, and governance.</p>
         </a>
+
+        <a href="https://matrix.to/#/#icn:matrix.org" target="_blank" class="community-card">
+          <div class="card-icon">💬</div>
+          <h3>Matrix Room</h3>
+          <p>Real-time chat with ICN developers and cooperative technologists. Join <code>#icn:matrix.org</code> — no account required to read.</p>
+        </a>
+
+        <a href="https://github.com/InterCooperative-Network/icn/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue" target="_blank" class="community-card">
+          <div class="card-icon">🌱</div>
+          <h3>Good First Issues</h3>
+          <p>Labeled, scoped, and documented. If you want to contribute code but don't know where to start, start here.</p>
+        </a>
+
+        <a href="https://github.com/InterCooperative-Network/icn/discussions/categories/announcements" target="_blank" class="community-card">
+          <div class="card-icon">📬</div>
+          <h3>Announcements</h3>
+          <p>Sprint summaries, release notes, and major milestones. Subscribe to the Announcements discussion category on GitHub.</p>
+        </a>
       </div>
     </div>
   </section>

--- a/website/src/pages/community.astro
+++ b/website/src/pages/community.astro
@@ -14,19 +14,19 @@ import stats from '../data/stats.json';
       </div>
 
       <div class="grid grid-3">
-        <a href="https://github.com/InterCooperative-Network/icn" target="_blank" class="community-card">
+        <a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener noreferrer" class="community-card">
           <div class="card-icon">⭐</div>
           <h3>Star on GitHub</h3>
           <p>Show your support and stay updated. {stats.activeBranches} branches, {stats.mergedPRs} merged PRs.</p>
         </a>
 
-        <a href="https://github.com/InterCooperative-Network/icn/issues" target="_blank" class="community-card">
+        <a href="https://github.com/InterCooperative-Network/icn/issues" target="_blank" rel="noopener noreferrer" class="community-card">
           <div class="card-icon">🐛</div>
           <h3>Report Issues</h3>
           <p>Found a bug or have a feature idea? Open an issue and help us improve.</p>
         </a>
 
-        <a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank" class="community-card">
+        <a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank" rel="noopener noreferrer" class="community-card">
           <div class="card-icon">💬</div>
           <h3>Discussions</h3>
           <p>Join conversations about cooperative technology, governance patterns, and ICN development.</p>
@@ -50,19 +50,19 @@ import stats from '../data/stats.json';
           <p>{stats.docFiles}+ documents covering architecture, APIs, guides, economics, and governance.</p>
         </a>
 
-        <a href="https://matrix.to/#/#icn:matrix.org" target="_blank" class="community-card">
+        <a href="https://matrix.to/#/#icn:matrix.org" target="_blank" rel="noopener noreferrer" class="community-card">
           <div class="card-icon">💬</div>
           <h3>Matrix Room</h3>
           <p>Real-time chat with ICN developers and cooperative technologists. Join <code>#icn:matrix.org</code> — no account required to read.</p>
         </a>
 
-        <a href="https://github.com/InterCooperative-Network/icn/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue" target="_blank" class="community-card">
+        <a href="https://github.com/InterCooperative-Network/icn/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue" target="_blank" rel="noopener noreferrer" class="community-card">
           <div class="card-icon">🌱</div>
           <h3>Good First Issues</h3>
           <p>Labeled, scoped, and documented. If you want to contribute code but don't know where to start, start here.</p>
         </a>
 
-        <a href="https://github.com/InterCooperative-Network/icn/discussions/categories/announcements" target="_blank" class="community-card">
+        <a href="https://github.com/InterCooperative-Network/icn/discussions/categories/announcements" target="_blank" rel="noopener noreferrer" class="community-card">
           <div class="card-icon">📬</div>
           <h3>Announcements</h3>
           <p>Sprint summaries, release notes, and major milestones. Subscribe to the Announcements discussion category on GitHub.</p>

--- a/website/src/pages/roadmap.astro
+++ b/website/src/pages/roadmap.astro
@@ -4,6 +4,7 @@ import Layout from '../layouts/Layout.astro';
 import fs from 'node:fs';
 import { renderMarkdown } from '../lib/markdown';
 import { resolveRepoDoc } from '../lib/paths';
+import roadmap from '../data/roadmap.json';
 
 // Phase history from repo root docs/
 const phaseHistoryPath = resolveRepoDoc('PHASE_HISTORY.md');
@@ -20,47 +21,30 @@ if (fs.existsSync(phaseHistoryPath)) {
         <span class="badge badge-amber">Project Roadmap</span>
         <h1>Development Roadmap</h1>
         <p>ICN is developed in phases, each building on the last. The project has completed 18+ development milestones across identity, networking, governance, economics, and federation.</p>
+        {roadmap.currentSprint && (
+          <p class="sprint-indicator">
+            Active: <strong>Sprint {roadmap.currentSprint.number}</strong> — {roadmap.currentSprint.name}
+          </p>
+        )}
       </div>
     </div>
   </section>
 
-  <!-- Vision roadmap stages -->
+  <!-- Vision roadmap stages (data-driven from src/data/roadmap.json) -->
   <section class="section-alt">
     <div class="container">
       <h2 style="margin-bottom: var(--space-xl);">Product Vision Stages</h2>
       <div class="roadmap-timeline">
-        <div class="timeline-item">
-          <div class="timeline-marker" style="background: var(--accent-teal);"></div>
-          <div class="timeline-content">
-            <span class="badge badge-teal">Stage A — Now</span>
-            <h3>Institution-in-a-Box</h3>
-            <p>Charter templates, guided cooperative formation, membership onboarding, treasury ledger, and proposal-to-vote loop. The minimum viable institution.</p>
+        {roadmap.stages.map((stage) => (
+          <div class="timeline-item">
+            <div class="timeline-marker" style={`background: ${stage.markerColor};`}></div>
+            <div class="timeline-content">
+              <span class={`badge ${stage.badge}`}>{stage.label}</span>
+              <h3>{stage.title}</h3>
+              <p>{stage.description}</p>
+            </div>
           </div>
-        </div>
-        <div class="timeline-item">
-          <div class="timeline-marker" style="background: var(--accent-blue);"></div>
-          <div class="timeline-content">
-            <span class="badge badge-blue">Stage B</span>
-            <h3>Federation Layer</h3>
-            <p>Inter-cooperative agreements with treaty-based governance, cross-group trust propagation, and federation clearing for mutual credit networks.</p>
-          </div>
-        </div>
-        <div class="timeline-item">
-          <div class="timeline-marker" style="background: var(--accent-purple);"></div>
-          <div class="timeline-content">
-            <span class="badge badge-purple">Stage C</span>
-            <h3>Compute Commons</h3>
-            <p>Shared compute resources contributed to a commons and allocated via cooperative fuel metering. Members contribute hardware; the network rewards them with cooperative capacity.</p>
-          </div>
-        </div>
-        <div class="timeline-item">
-          <div class="timeline-marker" style="background: var(--accent-amber);"></div>
-          <div class="timeline-content">
-            <span class="badge" style="background: rgba(251, 191, 36, 0.12); color: var(--accent-amber); border: 1px solid rgba(251, 191, 36, 0.25);">Stage D</span>
-            <h3>Civilization Tools</h3>
-            <p>Participatory budgeting at city scale. Municipal governance platforms. Public infrastructure coordination. The long-term vision: democratic technology governance beyond the co-op.</p>
-          </div>
-        </div>
+        ))}
       </div>
     </div>
   </section>
@@ -123,5 +107,15 @@ if (fs.existsSync(phaseHistoryPath)) {
 
   .timeline-content p {
     margin: 0;
+  }
+
+  .sprint-indicator {
+    margin-top: var(--space-md);
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+  }
+
+  .sprint-indicator strong {
+    color: var(--accent-teal);
   }
 </style>


### PR DESCRIPTION
## Summary

- **4 blog posts** (Phase 3.2a-d): ICN framing, Sprint 14 retrospective, institution-in-a-box demo walk-through, regulatory safety by architecture
- **Community page** (#1368): adds Matrix room card (`#icn:matrix.org`), Good First Issues card, and Announcements card to the community grid
- **Roadmap page** (#1369): vision stages extracted to `src/data/roadmap.json`; rendered via `map()` instead of hardcoded HTML; active sprint name shown in header
- **Stats pipeline** (#1367): `gen-stats.mjs` now computes `activeBranches` and `docFiles` (via `gh` API with git fallback); new `sync-stats.yml` cron runs daily at 02:00 UTC to commit fresh stats

## Test plan

- [ ] `cd website && npm run build` — should complete without errors (pre-existing TS type errors in `blog/index.astro` are unrelated to these changes)
- [ ] Verify 4 new blog posts appear at `/blog`
- [ ] Verify community page shows Matrix, Good First Issues, and Announcements cards
- [ ] Verify roadmap page renders stages from JSON (Stage A–D still visible)
- [ ] Verify `sync-stats.yml` workflow appears in GitHub Actions

Closes #1367, #1368, #1369

🤖 Generated with [Claude Code](https://claude.com/claude-code)