### PR TITLE
fix(cli): update RPC references from 127.0.0.1 to [::1] after IPv6 bind change (#1339)

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -202,7 +202,7 @@ demo/
 **Demo configuration for:**
 - Rochester Tool Library cooperative
 - Network: 127.0.0.1:7777
-- API: 127.0.0.1:5601
+- API: [::1]:5601
 - Gateway: 127.0.0.1:8080
 - Metrics: 127.0.0.1:9100
 - Timebank ledger type

--- a/demo/configs/tool-library.toml
+++ b/demo/configs/tool-library.toml
@@ -9,7 +9,7 @@ listen_addr = "127.0.0.1:7777"
 mdns_enabled = true
 
 [api]
-listen_addr = "127.0.0.1:5601"
+listen_addr = "[::1]:5601"
 
 [gateway]
 listen_addr = "127.0.0.1:8080"

--- a/docs/guides/operations/nat-traversal-pilot-test.md
+++ b/docs/guides/operations/nat-traversal-pilot-test.md
@@ -21,8 +21,8 @@ sed -i 's/min_trust_threshold = 0.1/min_trust_threshold = 0.0/' $BASE/node-a/con
 ICN_KEYSTORE_PASSPHRASE=test $ICND --config $BASE/node-a/config.toml &
 sleep 5
 
-ICN_KEYSTORE_PASSPHRASE=test $ICNCTL --data-dir $BASE/node-a -e 127.0.0.1:5601 network status
-ICN_KEYSTORE_PASSPHRASE=test $ICNCTL --data-dir $BASE/node-a -e 127.0.0.1:5601 ledger head
+ICN_KEYSTORE_PASSPHRASE=test $ICNCTL --data-dir $BASE/node-a -e '[::1]:5601' network status
+ICN_KEYSTORE_PASSPHRASE=test $ICNCTL --data-dir $BASE/node-a -e '[::1]:5601' ledger head
 ```
 
 **Expected output:**
@@ -30,7 +30,7 @@ ICN_KEYSTORE_PASSPHRASE=test $ICNCTL --data-dir $BASE/node-a -e 127.0.0.1:5601 l
 ```
 Network Actor Status:
   Running:               true
-  Listening on:      127.0.0.1:5601
+  Listening on:      [::1]:5601
   NAT Traversal:
     Public endpoint:  <your-public-IP>:<port>
     TURN relay:       none
@@ -120,10 +120,10 @@ The gateway starts automatically (enabled by default in the generated config).
 
 ```bash
 # Node A
-ICN_KEYSTORE_PASSPHRASE=test $ICNCTL --data-dir $BASE/node-a -e 127.0.0.1:5601 network status
+ICN_KEYSTORE_PASSPHRASE=test $ICNCTL --data-dir $BASE/node-a -e '[::1]:5601' network status
 
 # Node B
-ICN_KEYSTORE_PASSPHRASE=test $ICNCTL --data-dir $BASE/node-b -e 127.0.0.1:5602 network status
+ICN_KEYSTORE_PASSPHRASE=test $ICNCTL --data-dir $BASE/node-b -e '[::1]:5602' network status
 ```
 
 Both should show:
@@ -144,7 +144,7 @@ curl -s http://127.0.0.1:8001/v1/health
 **Ledger (confirms RPC null-result handling):**
 
 ```bash
-ICN_KEYSTORE_PASSPHRASE=test $ICNCTL --data-dir $BASE/node-a -e 127.0.0.1:5601 ledger head
+ICN_KEYSTORE_PASSPHRASE=test $ICNCTL --data-dir $BASE/node-a -e '[::1]:5601' ledger head
 # Ledger is empty
 ```
 

--- a/docs/planning/icn-crate-reference.md
+++ b/docs/planning/icn-crate-reference.md
@@ -444,7 +444,7 @@ icnctl
 
 **Notable flags:**
 - `-d <dir>` — data directory (default `~/.icn`)
-- `-e <addr>` — RPC endpoint (default `127.0.0.1:5601`)
+- `-e <addr>` — RPC endpoint (default `[::1]:5601`)
 - `--features post-quantum` — PQ identity support
 
 **i18n support:** `rust-i18n` + `sys-locale` — CLI messages in local language

--- a/examples/contracts/test-contracts.sh
+++ b/examples/contracts/test-contracts.sh
@@ -5,7 +5,7 @@
 set -e
 
 ICNCTL="../../icn/target/debug/icnctl"
-ENDPOINT="127.0.0.1:5601"
+ENDPOINT="[::1]:5601"
 
 # Colors for output
 GREEN='\033[0;32m'

--- a/icn/crates/icn-core/src/supervisor/init_rpc.rs
+++ b/icn/crates/icn-core/src/supervisor/init_rpc.rs
@@ -40,7 +40,7 @@ pub struct RpcDeps {
 
 /// Configuration for RPC server
 pub struct RpcConfig {
-    /// RPC server address (usually [::1]:rpc_port after IPv6 bind change in PR #1338)
+    /// RPC server address (typically [::1]:rpc_port — IPv6 loopback)
     pub addr: SocketAddr,
     /// JWT secret for authentication (optional, enables auth if provided)
     pub jwt_secret: Option<Vec<u8>>,

--- a/icn/crates/icn-core/src/supervisor/init_rpc.rs
+++ b/icn/crates/icn-core/src/supervisor/init_rpc.rs
@@ -40,7 +40,7 @@ pub struct RpcDeps {
 
 /// Configuration for RPC server
 pub struct RpcConfig {
-    /// RPC server address (usually 127.0.0.1:rpc_port)
+    /// RPC server address (usually [::1]:rpc_port after IPv6 bind change in PR #1338)
     pub addr: SocketAddr,
     /// JWT secret for authentication (optional, enables auth if provided)
     pub jwt_secret: Option<Vec<u8>>,


### PR DESCRIPTION
## Summary

PR #1338 changed the RPC bind address to `[::1]:5601` (IPv6 loopback). This PR updates all remaining `127.0.0.1:5601` references in demo configs, docs, and the example test script.

- `demo/configs/tool-library.toml` — `listen_addr` updated
- `demo/README.md` — config summary updated  
- `examples/contracts/test-contracts.sh` — `ENDPOINT` variable updated
- `docs/planning/icn-crate-reference.md` — default flag documentation updated
- `docs/guides/operations/nat-traversal-pilot-test.md` — all CLI examples and expected output updated
- `icn/crates/icn-core/src/supervisor/init_rpc.rs` — stale doc comment updated

Note: `icnctl` itself already had `[::1]:5601` as the default (line 39 of `bins/icnctl/src/main.rs`).

## Test plan

- [x] `cargo check -p icnctl` passes
- [ ] `icnctl` without `-e` flag connects to daemon bound on `[::1]:5601`

Closes #1339

🤖 Generated with [Claude Code](https://claude.com/claude-code)