### PR TITLE
fix(deps): update aws-lc-sys + rustls-webpki to clear RUSTSEC advisories

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -619,9 +619,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.2"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88aab2464f1f25453baa7a07c84c5b7684e274054ba06817f382357f77a288"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -629,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.35.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45afffdee1e7c9126814751f88dddc747f41d91da16c9551a0f1e8a11e788a1"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",
@@ -6351,9 +6351,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

- `aws-lc-rs` 1.15.2 → 1.16.2 (pulls `aws-lc-sys` 0.35.0 → 0.39.0) — clears RUSTSEC-2026-0044, 0045, 0046, 0047, 0048
- `rustls-webpki` 0.103.8 → 0.103.10 — clears RUSTSEC-2026-0049

Remaining audit warnings (`atomic-polyfill` unmaintained, `bincode` unmaintained, `keccak` yanked) are pre-existing and treated as allowed warnings by CI — not vulnerabilities.

## Test plan

- [x] `cargo audit` — 0 vulnerabilities, 4 allowed warnings (pre-existing)
- [x] `cargo check -p icnd` — compiles clean
- [ ] CI: Security Audit, Build Release, Test, Clippy

🤖 Generated with [Claude Code](https://claude.com/claude-code)