### PR TITLE
feat(devops): devnet compose + demo runner — one command for full local demo (#1098)

### DIFF
--- a/demo/run-all.sh
+++ b/demo/run-all.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# run-all.sh — Boot 3-node devnet and run the full demonstration suite
+#
+# Usage:
+#   bash demo/run-all.sh                 # Boot devnet + run all demos
+#   bash demo/run-all.sh --no-boot       # Skip docker compose up (devnet already running)
+#   bash demo/run-all.sh --presenter     # Interactive pause between phases
+#   bash demo/run-all.sh --no-boot --presenter
+#
+# What this runs:
+#   Phase 1-4: Cooperative Governance Demo on node-a (localhost:8080)
+#   Phase 1-4: Cooperative Governance Demo on node-b (localhost:8081)
+#   (Demonstrates that both nodes are independently operational)
+#
+# Requirements:
+#   - docker + docker compose (to boot the devnet)
+#   - python3 + cryptography package (for demo-governance.py)
+#   - Devnet image must be built: cd deploy/devnet && docker compose build
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEVNET_DIR="${REPO_ROOT}/deploy/devnet"
+DEMO_SCRIPTS="${SCRIPT_DIR}/scripts"
+
+# ── Parse args ───────────────────────────────────────────────────────────────
+BOOT=true
+PRESENT_FLAG=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-boot)   BOOT=false ;;
+    --presenter) PRESENT_FLAG="--presenter" ;;
+    --help|-h)
+      echo "Usage: $0 [--no-boot] [--presenter]"
+      echo ""
+      echo "Options:"
+      echo "  --no-boot    Skip 'docker compose up' (devnet already running)"
+      echo "  --presenter  Interactive pause between demo phases"
+      exit 0
+      ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+# ── Colors ───────────────────────────────────────────────────────────────────
+if [ -t 1 ]; then
+  BOLD='\033[1m'
+  GREEN='\033[0;32m'
+  RED='\033[0;31m'
+  YELLOW='\033[1;33m'
+  NC='\033[0m'
+else
+  BOLD=''; GREEN=''; RED=''; YELLOW=''; NC=''
+fi
+
+banner() { echo -e "\n${BOLD}=== $* ===${NC}"; }
+ok()     { echo -e "  ${GREEN}✓${NC} $*"; }
+fail()   { echo -e "  ${RED}✗${NC} $*"; }
+warn()   { echo -e "  ${YELLOW}⚠${NC} $*"; }
+
+# ── Pre-flight checks ─────────────────────────────────────────────────────────
+banner "Pre-flight"
+
+if ! command -v docker >/dev/null 2>&1; then
+  fail "docker not found — install Docker to run the devnet"
+  exit 1
+fi
+ok "docker available"
+
+if ! python3 -c "import cryptography" 2>/dev/null; then
+  warn "python3 'cryptography' package not found — installing..."
+  pip3 install cryptography --quiet
+fi
+ok "python3 cryptography available"
+
+# ── Step 1: Boot devnet ───────────────────────────────────────────────────────
+if [ "$BOOT" = true ]; then
+  banner "Booting 3-node devnet"
+  cd "$DEVNET_DIR"
+  docker compose up -d
+  cd "$REPO_ROOT"
+  ok "docker compose up"
+else
+  banner "Devnet boot skipped (--no-boot)"
+fi
+
+# ── Step 2: Wait for all 3 nodes ──────────────────────────────────────────────
+banner "Waiting for devnet nodes"
+for port in 8080 8081 8082; do
+  printf "  Waiting for localhost:%d " "$port"
+  retries=0
+  until curl -sf "http://localhost:${port}/v1/health" >/dev/null 2>&1; do
+    retries=$((retries + 1))
+    if [ "$retries" -gt 60 ]; then
+      echo ""
+      fail "localhost:${port} did not become healthy within 120s"
+      echo "  Check logs: cd deploy/devnet && docker compose logs"
+      exit 1
+    fi
+    printf "."
+    sleep 2
+  done
+  echo ""
+  ok "localhost:${port} healthy"
+done
+
+# ── Step 3: Run demo suite ────────────────────────────────────────────────────
+PASS=0
+FAIL=0
+
+run_demo() {
+  local label="$1"
+  local gateway="$2"
+
+  banner "$label"
+  set +e
+  python3 "${DEMO_SCRIPTS}/demo-governance.py" "$gateway" $PRESENT_FLAG
+  local rc=$?
+  set -e
+
+  if [ "$rc" -eq 0 ]; then
+    ok "$label passed"
+    PASS=$((PASS + 1))
+  else
+    fail "$label failed (exit $rc)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+run_demo "Governance Demo — node-a (localhost:8080)" "http://localhost:8080"
+run_demo "Governance Demo — node-b (localhost:8081)" "http://localhost:8081"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+if [ "$FAIL" -eq 0 ]; then
+  echo -e "${GREEN}${BOLD}┌──────────────────────────────────────────────────────┐${NC}"
+  echo -e "${GREEN}${BOLD}│  All demos passed (${PASS}/${PASS})                            │${NC}"
+  echo -e "${GREEN}${BOLD}└──────────────────────────────────────────────────────┘${NC}"
+else
+  echo -e "${RED}${BOLD}┌──────────────────────────────────────────────────────┐${NC}"
+  echo -e "${RED}${BOLD}│  ${FAIL} demo(s) failed, ${PASS} passed                          │${NC}"
+  echo -e "${RED}${BOLD}└──────────────────────────────────────────────────────┘${NC}"
+fi
+
+echo ""
+echo "  Devnet endpoints:"
+echo "    Node A (gateway):   http://localhost:8080"
+echo "    Node B (gateway):   http://localhost:8081"
+echo "    Node C (gateway):   http://localhost:8082"
+echo "    Prometheus:         http://localhost:9090"
+echo "    Grafana:            http://localhost:3000  (admin / devnet)"
+echo ""
+echo "  Manage devnet:  cd deploy/devnet && make [up|down|logs|status]"
+echo ""
+
+[ "$FAIL" -eq 0 ]

--- a/demo/scripts/lib-demo-ports.sh
+++ b/demo/scripts/lib-demo-ports.sh
@@ -567,3 +567,83 @@ demo_require_2xx() {
   fail "  Got HTTP $code"
   exit 1
 }
+
+# ===========================================================================
+# DEVNET MODE OVERRIDES
+# Set ICN_DEMO_TARGET=devnet to activate. Replaces kubectl-based functions
+# with direct Docker devnet equivalents (localhost:8080/8081/8082).
+# ===========================================================================
+if [ "${ICN_DEMO_TARGET:-}" = "devnet" ]; then
+
+  # Override gateway URLs to point at the local 3-node devnet
+  export BRIGHTWORKS_URL="http://localhost:8080"   # node-a
+  export RIVERCITY_URL="http://localhost:8081"      # node-b
+  export HARBOR_URL="http://localhost:8082"         # node-c
+  export FINGERLAKES_URL="http://localhost:8080"    # reuse node-a (devnet has 3 nodes)
+
+  # demo_ports_up: devnet is already running via docker compose; no port-forwards needed
+  demo_ports_up() {
+    aside "Devnet mode: gateway ports are localhost:8080/8081/8082 (no kubectl port-forward)"
+  }
+
+  # demo_ports_down: leave the devnet running; caller controls lifecycle
+  demo_ports_down() {
+    aside "Devnet mode: devnet left running (stop with: cd deploy/devnet && docker compose down)"
+    # Still clean up the token cache
+    rm -rf "${_DEMO_TOKEN_CACHE_DIR:-}" 2>/dev/null || true
+    rm -f "${_DEMO_LAST_RESP_FILE:-}" 2>/dev/null || true
+    _DEMO_LAST_RESP_FILE=""
+  }
+
+  # demo_get_token: use icnctl inside the devnet container (icnctl ships in the image)
+  demo_get_token() {
+    local _refresh=0
+    if [ "${1:-}" = "--refresh" ]; then
+      _refresh=1
+      shift
+    fi
+
+    local coop="${1:-}"
+    if [ -z "$coop" ]; then
+      fail "demo_get_token: coop name required (alpha/beta/gamma/delta)"
+      return 1
+    fi
+
+    local cache_file="${_DEMO_TOKEN_CACHE_DIR}/token-${coop}"
+    if [ "$_refresh" = "1" ]; then
+      rm -f "$cache_file"
+    fi
+    if [ -f "$cache_file" ] && [ -s "$cache_file" ]; then
+      cat "$cache_file"
+      return 0
+    fi
+
+    local container coop_id gateway_url
+    case "$coop" in
+      alpha) container="icn-devnet-node-a"; coop_id="$BRIGHTWORKS_COOP_ID"; gateway_url="$BRIGHTWORKS_URL" ;;
+      beta)  container="icn-devnet-node-b"; coop_id="$RIVERCITY_COOP_ID";   gateway_url="$RIVERCITY_URL" ;;
+      gamma) container="icn-devnet-node-c"; coop_id="$HARBOR_COOP_ID";      gateway_url="$HARBOR_URL" ;;
+      delta) container="icn-devnet-node-a"; coop_id="$FINGERLAKES_COOP_ID"; gateway_url="$FINGERLAKES_URL" ;;
+      *)     fail "demo_get_token: unknown coop '$coop' (must be alpha/beta/gamma/delta)"; return 1 ;;
+    esac
+
+    local token
+    token=$(docker exec "$container" \
+      env ICN_KEYSTORE_PASSPHRASE="devnet-insecure" \
+      icnctl auth token \
+      --gateway "$gateway_url" \
+      --coop-id "$coop_id" \
+      --scopes "$DEMO_DEFAULT_SCOPES" \
+      2>/dev/null | grep -oE 'eyJ[A-Za-z0-9_.-]+\.[A-Za-z0-9_.-]+\.[A-Za-z0-9_.-]+' | head -1 || true)
+
+    if [ -z "$token" ]; then
+      fail "demo_get_token: failed to get token for coop '$coop' (devnet mode)"
+      fail "  Tried: docker exec $container icnctl auth token --gateway $gateway_url --coop-id $coop_id"
+      return 1
+    fi
+
+    echo "$token" > "$cache_file"
+    echo "$token"
+  }
+
+fi  # end ICN_DEMO_TARGET=devnet overrides

--- a/deploy/devnet/Makefile
+++ b/deploy/devnet/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down restart logs clean status build demo test
+.PHONY: up down restart logs clean status build demo demo-all test
 
 # Start the 3-node devnet
 up:
@@ -60,3 +60,7 @@ test:
 demo:
 	@echo "Running demo against devnet node-a..."
 	ICN_GATEWAY=http://localhost:8080 bash ../../scripts/demo-single-node.sh
+
+# Boot the 3-node devnet and run all demo flows (one command end-to-end)
+demo-all:
+	bash ../../demo/run-all.sh

--- a/deploy/devnet/docker-compose.yml
+++ b/deploy/devnet/docker-compose.yml
@@ -13,15 +13,19 @@ services:
       - ICN_DATA_DIR=/data/node-a
       - ICN_GATEWAY_PORT=8080
       - ICN_P2P_PORT=9000
+      - ICN_METRICS_PORT=9100
       - ICN_BOOTSTRAP_PEERS=
       - ICN_KEYSTORE_PASSPHRASE=devnet-insecure
+      - ICN_GENESIS_FILE=/devnet/genesis.json
       - RUST_LOG=info,icn_core=debug,icn_gossip=debug,icn_net=debug
     ports:
-      - "8080:8080"  # Gateway
-      - "9000:9000"  # P2P
+      - "8080:8080"   # Gateway
+      - "9000:9000"   # P2P
+      - "9100:9100"   # Prometheus metrics
     volumes:
       - node-a-data:/data/node-a
       - ./entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./genesis.json:/devnet/genesis.json:ro
     networks:
       - icn-devnet
     healthcheck:
@@ -44,15 +48,19 @@ services:
       - ICN_DATA_DIR=/data/node-b
       - ICN_GATEWAY_PORT=8080
       - ICN_P2P_PORT=9000
+      - ICN_METRICS_PORT=9100
       - ICN_BOOTSTRAP_PEERS=icn://node-a:9000
       - ICN_KEYSTORE_PASSPHRASE=devnet-insecure
+      - ICN_GENESIS_FILE=/devnet/genesis.json
       - RUST_LOG=info,icn_core=debug,icn_gossip=debug,icn_net=debug
     ports:
-      - "8081:8080"  # Gateway (external 8081 → internal 8080)
-      - "9001:9000"  # P2P
+      - "8081:8080"   # Gateway (external 8081 → internal 8080)
+      - "9001:9000"   # P2P
+      - "9101:9100"   # Prometheus metrics
     volumes:
       - node-b-data:/data/node-b
       - ./entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./genesis.json:/devnet/genesis.json:ro
     networks:
       - icn-devnet
     depends_on:
@@ -78,15 +86,19 @@ services:
       - ICN_DATA_DIR=/data/node-c
       - ICN_GATEWAY_PORT=8080
       - ICN_P2P_PORT=9000
+      - ICN_METRICS_PORT=9100
       - ICN_BOOTSTRAP_PEERS=icn://node-a:9000,icn://node-b:9000
       - ICN_KEYSTORE_PASSPHRASE=devnet-insecure
+      - ICN_GENESIS_FILE=/devnet/genesis.json
       - RUST_LOG=info,icn_core=debug,icn_gossip=debug,icn_net=debug
     ports:
-      - "8082:8080"  # Gateway (external 8082 → internal 8080)
-      - "9002:9000"  # P2P
+      - "8082:8080"   # Gateway (external 8082 → internal 8080)
+      - "9002:9000"   # P2P
+      - "9102:9100"   # Prometheus metrics
     volumes:
       - node-c-data:/data/node-c
       - ./entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - ./genesis.json:/devnet/genesis.json:ro
     networks:
       - icn-devnet
     depends_on:
@@ -102,10 +114,55 @@ services:
       start_period: 15s
     entrypoint: ["/usr/local/bin/entrypoint.sh"]
 
+  prometheus:
+    image: prom/prometheus:v2.51.0
+    container_name: icn-devnet-prometheus
+    hostname: prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.enable-lifecycle'
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    networks:
+      - icn-devnet
+    depends_on:
+      node-a:
+        condition: service_healthy
+      node-b:
+        condition: service_healthy
+      node-c:
+        condition: service_healthy
+
+  grafana:
+    image: grafana/grafana:10.4.0
+    container_name: icn-devnet-grafana
+    hostname: grafana
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=devnet
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/dashboards:/etc/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    networks:
+      - icn-devnet
+    depends_on:
+      - prometheus
+
 volumes:
   node-a-data:
   node-b-data:
   node-c-data:
+  prometheus-data:
+  grafana-data:
 
 networks:
   icn-devnet:

--- a/deploy/devnet/entrypoint.sh
+++ b/deploy/devnet/entrypoint.sh
@@ -10,6 +10,17 @@ P2P_PORT="${ICN_P2P_PORT:-9000}"
 BOOTSTRAP_PEERS="${ICN_BOOTSTRAP_PEERS:-}"
 NODE_NAME="${ICN_NODE_NAME:-node}"
 KEYSTORE_PASSPHRASE="${ICN_KEYSTORE_PASSPHRASE:-devnet-insecure}"
+GENESIS_FILE="${ICN_GENESIS_FILE:-}"
+
+# Determine network_id: read from shared genesis file if present, else fall back to NODE_NAME
+NETWORK_ID="$NODE_NAME"
+if [ -n "$GENESIS_FILE" ] && [ -f "$GENESIS_FILE" ]; then
+  _gid=$(python3 -c "import json; d=json.load(open('$GENESIS_FILE')); print(d.get('network_id',''))" 2>/dev/null || echo "")
+  if [ -n "$_gid" ]; then
+    NETWORK_ID="$_gid"
+  fi
+  echo "[$NODE_NAME] Genesis file: $GENESIS_FILE (network_id=$NETWORK_ID)"
+fi
 
 # Create data dir
 mkdir -p "$DATA_DIR"
@@ -17,7 +28,7 @@ mkdir -p "$DATA_DIR"
 # Initialize identity + config if not already done
 if [ ! -f "$CONFIG_FILE" ]; then
   echo "[$NODE_NAME] First run — initializing identity and config..."
-  echo "$KEYSTORE_PASSPHRASE" | icnd --init --data-dir "$DATA_DIR"
+  echo "$KEYSTORE_PASSPHRASE" | icnd --init --data-dir "$DATA_DIR" --node-name "$NETWORK_ID"
   echo "[$NODE_NAME] Identity initialized."
 fi
 

--- a/deploy/devnet/genesis.json
+++ b/deploy/devnet/genesis.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": 1,
+  "network_id": "devnet-0",
+  "created_at": 1774051200,
+  "initial_dids": [],
+  "seed_peers": []
+}

--- a/deploy/devnet/monitoring/grafana/dashboards/icn-devnet.json
+++ b/deploy/devnet/monitoring/grafana/dashboards/icn-devnet.json
@@ -1,0 +1,389 @@
+{
+  "__inputs": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "description": "ICN devnet node metrics — HTTP requests, peer connections, gossip, and memory",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "req/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (node) (rate(icn_gateway_http_requests_total[1m]))",
+          "legendFormat": "{{node}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Request Rate per Node",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "connections",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "last"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "icn_net_active_connections",
+          "legendFormat": "{{node}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Active Peer Connections per Node",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "msg/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "mps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (node) (rate(icn_gossip_messages_received_total[1m]))",
+          "legendFormat": "{{node}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Gossip Messages Received per Node",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "bytes",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "process_resident_memory_bytes",
+          "legendFormat": "{{node}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Usage per Node (RSS)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "15s",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": ["icn", "devnet"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource",
+        "label": "Prometheus"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "ICN Devnet Overview",
+  "uid": "icn-devnet-overview",
+  "version": 1
+}

--- a/deploy/devnet/monitoring/grafana/provisioning/dashboards/default.yml
+++ b/deploy/devnet/monitoring/grafana/provisioning/dashboards/default.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: ICN Devnet
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/deploy/devnet/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/deploy/devnet/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    jsonData:
+      httpMethod: POST
+      timeInterval: 15s
+    editable: false

--- a/deploy/devnet/monitoring/prometheus.yml
+++ b/deploy/devnet/monitoring/prometheus.yml
@@ -1,0 +1,25 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    environment: devnet
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets:
+          - localhost:9090
+
+  - job_name: icn-nodes
+    static_configs:
+      - targets:
+          - node-a:9100
+          - node-b:9100
+          - node-c:9100
+        labels:
+          environment: devnet
+    relabel_configs:
+      - source_labels: [__address__]
+        regex: '([^:]+):.*'
+        target_label: node
+        replacement: '$1'


### PR DESCRIPTION
## Summary

- **docker-compose.yml**: adds Prometheus (port 9090) + Grafana (port 3000) services; adds `ICN_GENESIS_FILE` + `ICN_METRICS_PORT` env vars; exposes per-node metrics ports (9100/9101/9102); mounts `genesis.json` into each container
- **genesis.json**: new devnet seed bundle (`network_id: devnet-0`, unsigned — `verify_hash()` accepts unsigned bundles per spec)
- **entrypoint.sh**: reads `network_id` from `ICN_GENESIS_FILE` on first-run init; passes it as `--node-name` to `icnd --init` so all three devnet nodes share the same `network_id`
- **monitoring/**: Prometheus scrape config targeting `node-{a,b,c}:9100`; Grafana datasource + dashboard provisioning (HTTP rate, peer connections, gossip messages, memory)
- **demo/run-all.sh**: boots devnet, polls until all 3 nodes are healthy, runs the self-contained `demo-governance.py` (4-phase cooperative governance demo) on node-a and node-b
- **demo/scripts/lib-demo-ports.sh**: devnet mode overrides activated by `ICN_DEMO_TARGET=devnet` — replaces `kubectl port-forward` with no-op, replaces `kubectl exec` token fetching with `docker exec icn-devnet-node-{a,b,c} icnctl auth token`
- **deploy/devnet/Makefile**: adds `demo-all` target

## Usage

```bash
# One command — boots devnet and runs full demo suite
cd deploy/devnet && make demo-all

# Or directly
bash demo/run-all.sh

# Interactive presenter mode
bash demo/run-all.sh --presenter

# Skip docker compose up (devnet already running)
bash demo/run-all.sh --no-boot
```

## Test plan

- [ ] `cd deploy/devnet && docker compose build` — builds image successfully
- [ ] `make up` — all 3 nodes + prometheus + grafana healthy
- [ ] `make demo-all` — governance demo passes on node-a and node-b
- [ ] `make status` — all nodes show healthy
- [ ] Grafana at http://localhost:3000 shows ICN devnet dashboard
- [ ] `make down && make clean` — cleans up

Closes #1098 (PR13 in Epic #1099 critical path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)