### PR TITLE
feat(compute): make commons pool thresholds config-driven (#1370 partial)

### DIFF
--- a/icn/crates/icn-compute/src/actor/mod.rs
+++ b/icn/crates/icn-compute/src/actor/mod.rs
@@ -198,6 +198,16 @@ impl ComputeActor {
         self.commons_pool_policy = Some(policy);
     }
 
+    /// Set the sybil resistance policy for commons pool participation.
+    ///
+    /// Replaces the commons pool with a fresh instance configured with the given
+    /// sybil policy. Must be called at startup before any participants join.
+    pub fn set_commons_sybil_policy(&mut self, policy: crate::commons_pool::SybilPolicy) {
+        self.commons_pool = Arc::new(RwLock::new(crate::commons_pool::CommonsPool::with_policy(
+            policy,
+        )));
+    }
+
     /// Set balance callback for commons credit ceiling enforcement (E7 - #1134).
     ///
     /// The callback receives a submitter DID string and returns their current credit balance.

--- a/icn/crates/icn-compute/src/actor/tests.rs
+++ b/icn/crates/icn-compute/src/actor/tests.rs
@@ -1753,6 +1753,7 @@ fn commons_policy(
         max_concurrent_per_submitter: 5,
         preemption_enabled: false,
         credit_ceiling,
+        fuel_cost_divisor: 1000,
     }
 }
 

--- a/icn/crates/icn-compute/src/policy.rs
+++ b/icn/crates/icn-compute/src/policy.rs
@@ -90,6 +90,16 @@ pub struct CommonsPoolPolicy {
     /// Tasks whose estimated cost exceeds available credits are rejected.
     #[serde(default)]
     pub credit_ceiling: Option<i64>,
+
+    /// Fuel units per commons credit for cost estimation.
+    /// A divisor of 1000 means 1 credit per 1000 fuel units consumed.
+    /// Governance decision: set via config, not compiled constant.
+    #[serde(default = "default_fuel_cost_divisor")]
+    pub fuel_cost_divisor: u64,
+}
+
+fn default_fuel_cost_divisor() -> u64 {
+    1000
 }
 
 impl Default for CommonsPoolPolicy {
@@ -100,6 +110,7 @@ impl Default for CommonsPoolPolicy {
             max_concurrent_per_submitter: 5,
             preemption_enabled: false,
             credit_ceiling: None,
+            fuel_cost_divisor: default_fuel_cost_divisor(),
         }
     }
 }
@@ -122,7 +133,7 @@ impl CommonsPoolPolicy {
         };
 
         // Estimate task cost from fuel limit and payment rate
-        let estimated_cost = Self::estimate_task_cost(task);
+        let estimated_cost = self.estimate_task_cost(task);
 
         // Check if submitter has room under their ceiling
         let available = ceiling.saturating_sub(submitter_balance);
@@ -138,15 +149,17 @@ impl CommonsPoolPolicy {
 
     /// Estimate the credit cost of a task.
     ///
-    /// Uses payment_rate if specified, otherwise derives from fuel limit.
-    fn estimate_task_cost(task: &ComputeTask) -> i64 {
+    /// Uses payment_rate if specified, otherwise derives from fuel limit using
+    /// `fuel_cost_divisor` (governance-configured, default 1000 fuel per credit).
+    pub fn estimate_task_cost(&self, task: &ComputeTask) -> i64 {
+        let divisor = self.fuel_cost_divisor.max(1) as i64;
         if let Some(rate) = task.payment_rate {
-            // payment_rate is credits per 1000 fuel units
+            // payment_rate is credits per fuel_cost_divisor fuel units
             let fuel = task.fuel_limit.0 as i64;
-            (fuel * rate as i64) / 1000
+            (fuel * rate as i64) / divisor
         } else {
-            // Default: 1 credit per 1000 fuel units
-            (task.fuel_limit.0 as i64) / 1000
+            // Default: 1 credit per fuel_cost_divisor fuel units
+            (task.fuel_limit.0 as i64) / divisor
         }
     }
 
@@ -1606,6 +1619,7 @@ mod tests {
             max_concurrent_per_submitter: 10,
             preemption_enabled: true,
             credit_ceiling: Some(1000),
+            fuel_cost_divisor: 1000,
         };
 
         let json = serde_json::to_string(&policy).unwrap();
@@ -1789,5 +1803,119 @@ mod tests {
         } else {
             panic!("Expected InsufficientTrust error");
         }
+    }
+
+    // ========== Sprint 21: config-driven policy threshold tests ==========
+
+    #[test]
+    fn test_commonspool_policy_uses_configured_min_standing() {
+        // Cooperative configured a higher bar — 0.7 instead of default 0.3
+        let policy = CommonsPoolPolicy {
+            min_standing: 0.7,
+            ..CommonsPoolPolicy::default()
+        };
+        assert!(
+            policy.check_standing(0.6).is_err(),
+            "0.6 should fail 0.7 threshold"
+        );
+        assert!(
+            policy.check_standing(0.8).is_ok(),
+            "0.8 should pass 0.7 threshold"
+        );
+    }
+
+    #[test]
+    fn test_commonspool_policy_fuel_cost_divisor_configurable() {
+        // Default divisor (1000): 10000 fuel = 10 credits
+        let policy_default = CommonsPoolPolicy::default();
+        let task = make_test_task(TaskPriority::Normal); // fuel_limit = 10000
+        assert_eq!(policy_default.estimate_task_cost(&task), 10);
+
+        // Custom divisor (500): 10000 fuel = 20 credits
+        let policy_custom = CommonsPoolPolicy {
+            fuel_cost_divisor: 500,
+            ..CommonsPoolPolicy::default()
+        };
+        assert_eq!(policy_custom.estimate_task_cost(&task), 20);
+
+        // Custom divisor (2000): 10000 fuel = 5 credits
+        let policy_cheap = CommonsPoolPolicy {
+            fuel_cost_divisor: 2000,
+            ..CommonsPoolPolicy::default()
+        };
+        assert_eq!(policy_cheap.estimate_task_cost(&task), 5);
+    }
+
+    #[test]
+    fn test_sybil_policy_uses_configured_min_trust() {
+        use crate::commons_pool::{CommonsParticipant, CommonsPool, SybilPolicy};
+        use crate::scheduler::{CapacityBudget, NodeCapacity};
+        use std::time::Instant;
+
+        fn zero_capacity() -> NodeCapacity {
+            NodeCapacity {
+                cpu_cores_total: 1.0,
+                cpu_cores_available: 1.0,
+                memory_mb_total: 256,
+                memory_mb_available: 256,
+                storage_mb_available: 1024,
+                network_mbps: 100.0,
+                gpu_devices: vec![],
+                updated_at: 0,
+            }
+        }
+
+        // Cooperative configured a higher sybil threshold — 0.5 instead of default 0.1
+        let policy = SybilPolicy {
+            min_trust_score: 0.5,
+            ..SybilPolicy::default()
+        };
+        let mut pool = CommonsPool::with_policy(policy);
+
+        let low_trust = CommonsParticipant {
+            did: "did:icn:low".to_string(),
+            trust_score: 0.3, // below 0.5 threshold
+            capacity: zero_capacity(),
+            budget: CapacityBudget::default(),
+            last_announce: Instant::now(),
+        };
+        assert!(
+            pool.try_add_participant(low_trust).is_err(),
+            "trust 0.3 should be rejected by 0.5 threshold"
+        );
+
+        let high_trust = CommonsParticipant {
+            did: "did:icn:high".to_string(),
+            trust_score: 0.7, // above 0.5 threshold
+            capacity: zero_capacity(),
+            budget: CapacityBudget::default(),
+            last_announce: Instant::now(),
+        };
+        assert!(
+            pool.try_add_participant(high_trust).is_ok(),
+            "trust 0.7 should be accepted by 0.5 threshold"
+        );
+    }
+
+    #[test]
+    fn test_compute_policy_config_defaults_match_hardcoded() {
+        // Verify the config defaults exactly match the original hardcoded values.
+        // If these drift, production behavior would change for unconfigured nodes.
+        let policy = CommonsPoolPolicy::default();
+        assert!(
+            (policy.min_standing - 0.3).abs() < f64::EPSILON,
+            "default min_standing must remain 0.3"
+        );
+        assert_eq!(
+            policy.fuel_cost_divisor, 1000,
+            "default fuel_cost_divisor must remain 1000"
+        );
+
+        use crate::commons_pool::SybilPolicy;
+        let sybil = SybilPolicy::default();
+        assert!(
+            (sybil.min_trust_score - 0.1).abs() < f64::EPSILON,
+            "default min_trust_score must remain 0.1"
+        );
     }
 }

--- a/icn/crates/icn-core/src/config/compute.rs
+++ b/icn/crates/icn-core/src/config/compute.rs
@@ -8,6 +8,12 @@
 //! actor_model_enabled = false  # Enable stateful compute actors
 //! max_actors = 100             # Maximum hosted actors
 //!
+//! # Governance policy thresholds (defaults are cooperative-neutral starting points)
+//! [compute.policy]
+//! min_standing = 0.3           # Min trust standing to submit to commons pool
+//! min_trust_score = 0.1        # Min trust score for sybil admission
+//! fuel_cost_divisor = 1000     # Fuel units per credit (1 credit per N fuel)
+//!
 //! # Task result verification settings
 //! [compute.verification]
 //! low_value_threshold = 100    # Credits below this: single executor
@@ -20,12 +26,66 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Governance policy thresholds for the compute subsystem.
+///
+/// These values encode cooperative-level governance decisions. Different cooperatives
+/// running different risk profiles should be able to set them via config without
+/// recompiling. Default values preserve the original hardcoded behavior.
+///
+/// Config section: `[compute.policy]`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComputePolicyConfig {
+    /// Minimum trust standing required to submit tasks to the commons pool (0.0–1.0).
+    /// Members below this threshold are rejected at the gate.
+    /// Original hardcoded value: 0.3
+    #[serde(default = "default_min_standing")]
+    pub min_standing: f64,
+
+    /// Minimum trust score required for sybil-resistance admission to the commons pool (0.0–1.0).
+    /// Nodes below this threshold cannot join as commons participants.
+    /// Original hardcoded value: 0.1
+    #[serde(default = "default_min_trust_score")]
+    pub min_trust_score: f64,
+
+    /// Fuel units per commons credit for cost estimation.
+    /// A divisor of 1000 means 1 credit per 1000 fuel units consumed.
+    /// Original hardcoded value: 1000
+    #[serde(default = "default_fuel_cost_divisor")]
+    pub fuel_cost_divisor: u64,
+}
+
+fn default_min_standing() -> f64 {
+    0.3
+}
+
+fn default_min_trust_score() -> f64 {
+    0.1
+}
+
+fn default_fuel_cost_divisor() -> u64 {
+    1000
+}
+
+impl Default for ComputePolicyConfig {
+    fn default() -> Self {
+        Self {
+            min_standing: default_min_standing(),
+            min_trust_score: default_min_trust_score(),
+            fuel_cost_divisor: default_fuel_cost_divisor(),
+        }
+    }
+}
+
 /// Distributed compute configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ComputeConfig {
     /// Maximum concurrent tasks this node will execute
     #[serde(default = "default_max_concurrent_tasks")]
     pub max_concurrent_tasks: usize,
+
+    /// Governance policy thresholds for commons pool and cost estimation
+    #[serde(default)]
+    pub policy: ComputePolicyConfig,
 
     /// Task result verification settings
     #[serde(default)]
@@ -44,6 +104,7 @@ impl Default for ComputeConfig {
     fn default() -> Self {
         Self {
             max_concurrent_tasks: default_max_concurrent_tasks(),
+            policy: ComputePolicyConfig::default(),
             verification: VerificationConfig::default(),
             actor_model_enabled: default_false(),
             max_actors: default_max_actors(),
@@ -179,6 +240,7 @@ mod tests {
     fn test_compute_config_toml_serialization() {
         let config = ComputeConfig {
             max_concurrent_tasks: 20,
+            policy: ComputePolicyConfig::default(),
             verification: VerificationConfig {
                 low_value_threshold: 200,
                 medium_value_threshold: 2000,

--- a/icn/crates/icn-core/src/supervisor/init_compute.rs
+++ b/icn/crates/icn-core/src/supervisor/init_compute.rs
@@ -40,6 +40,8 @@ pub struct ComputeDeps {
     pub store_path: std::path::PathBuf,
     /// Contract registry for CclRef resolution (optional)
     pub contract_registry: Option<icn_ccl::ContractRegistryHandle>,
+    /// Governance policy thresholds for commons pool admission and cost estimation
+    pub policy_config: crate::config::ComputePolicyConfig,
 }
 
 /// Services returned from compute initialization
@@ -360,7 +362,29 @@ pub async fn init_compute_services(deps: ComputeDeps) -> anyhow::Result<ComputeS
     let usage_tracker = Arc::new(icn_compute::UsageTracker::new());
     let policy_manager = Arc::new(icn_compute::PolicyManager::new(usage_tracker.clone()));
     compute_actor.set_policy_manager(policy_manager.clone());
-    info!("Policy manager initialized for cooperative scheduling");
+
+    // Apply governance policy thresholds from config.
+    // min_standing and fuel_cost_divisor go into CommonsPoolPolicy (submission gate).
+    // min_trust_score goes into SybilPolicy (pool admission gate).
+    let commons_pool_policy = icn_compute::CommonsPoolPolicy {
+        min_standing: deps.policy_config.min_standing,
+        fuel_cost_divisor: deps.policy_config.fuel_cost_divisor,
+        ..icn_compute::CommonsPoolPolicy::default()
+    };
+    compute_actor.set_commons_pool_policy(commons_pool_policy);
+
+    let sybil_policy = icn_compute::SybilPolicy {
+        min_trust_score: deps.policy_config.min_trust_score,
+        ..icn_compute::SybilPolicy::default()
+    };
+    compute_actor.set_commons_sybil_policy(sybil_policy);
+
+    info!(
+        "Policy manager initialized (min_standing={}, min_trust_score={}, fuel_cost_divisor={})",
+        deps.policy_config.min_standing,
+        deps.policy_config.min_trust_score,
+        deps.policy_config.fuel_cost_divisor
+    );
 
     // Spawn DisputeActor with shared system
     let dispute_store_path = deps.store_path.join("disputes");

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -819,6 +819,7 @@ async fn spawn_actors_with_identity(
             identity_bundle: identity_bundle.clone(),
             store_path: config.store_path(),
             contract_registry: Some(contract_registry_handle.clone()),
+            policy_config: config.compute.policy.clone(),
         })
         .await?;
 


### PR DESCRIPTION
## Summary

- Extracts three hardcoded governance constants in `icn-compute` into a new `[compute.policy]` config section
- `min_standing` (0.3): minimum trust standing to submit to commons pool — a cooperative governance decision, not a compiled constant
- `min_trust_score` (0.1): sybil-resistance threshold for commons pool admission
- `fuel_cost_divisor` (1000): fuel units per credit in cost estimation
- All defaults match original hardcoded values — zero behavioral change for unconfigured deployments

## Why

These values are governance decisions. A cooperative running high-stakes distributed compute should be able to set `min_standing: 0.7`. A development coop should be able to set `min_trust_score: 0.0`. None of that was possible without recompiling. Identified as HIGH-severity violations in the Meaning Firewall Phase 2 audit (PR #1383).

## How

- `ComputePolicyConfig` added to `icn-core/src/config/compute.rs` as `[compute.policy]` sub-section
- `fuel_cost_divisor` added to `CommonsPoolPolicy`; `estimate_task_cost` made `&self` to read it
- `set_commons_sybil_policy()` added to `ComputeActor` to configure pool admission threshold
- `ComputeDeps.policy_config` threaded from `lifecycle.rs` → `init_compute_services()` → both setters
- 4 new tests verify config-driven behavior and that defaults preserve original semantics

## Risk

Config fields are `#[serde(default)]` — existing deployments without `[compute.policy]` in config get identical behavior to before. The only code path change is that `estimate_task_cost` is now an instance method.

## Test plan

- [x] `cargo test -p icn-compute` — 351 tests pass
- [x] `cargo check -p icn-core` — clean
- [x] `cargo clippy -p icn-compute -p icn-core -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] 4 new tests: configurable min_standing, configurable fuel_cost_divisor, configurable sybil threshold, defaults-match-hardcoded invariant

Closes partial: #1370 (compute violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)