### PR TITLE
fix(net): advertise dialable local address instead of 0.0.0.0

### DIFF
--- a/icn/crates/icn-core/src/config/mod.rs
+++ b/icn/crates/icn-core/src/config/mod.rs
@@ -131,6 +131,7 @@ impl Default for Config {
                 encryption_cleanup_circuit_breaker_threshold: 3,
                 nat_dial: NatDialConfig::default(),
                 blob_registry: BlobRegistryConfig::default(),
+                advertised_addr: None,
             },
             observability: ObservabilityConfig {
                 metrics_port: 9100,

--- a/icn/crates/icn-core/src/config/network.rs
+++ b/icn/crates/icn-core/src/config/network.rs
@@ -92,6 +92,20 @@ pub struct NetworkConfig {
     /// Blob registry configuration for distributed data tracking
     #[serde(default)]
     pub blob_registry: BlobRegistryConfig,
+
+    /// Explicit advertised address for connection candidates (format: "IP:PORT").
+    ///
+    /// When set, this address is announced to peers as the local dialable address,
+    /// overriding both the auto-detected address and `endpoint.local_addr()`.
+    ///
+    /// Required in containerized environments (Docker/K8s) where the node binds
+    /// to `0.0.0.0` but must advertise the container/pod IP so other nodes can
+    /// dial back. If not set, the node auto-detects its routing IP via the
+    /// routing-socket trick (usually correct for containers).
+    ///
+    /// Example: `advertised_addr = "10.42.2.101:7827"`
+    #[serde(default)]
+    pub advertised_addr: Option<String>,
 }
 
 /// Blob registry configuration for distributed data tracking

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -1030,6 +1030,20 @@ async fn spawn_network_actor(
 
     let turn_config = config.network.turn_config();
 
+    // Parse optional explicit advertised address (for containerized deployments)
+    let advertised_addr = config.network.advertised_addr.as_deref().and_then(|s| {
+        match s.parse::<std::net::SocketAddr>() {
+            Ok(addr) => {
+                info!("Using explicit advertised address: {}", addr);
+                Some(addr)
+            }
+            Err(e) => {
+                warn!("Failed to parse advertised_addr '{}': {} — falling back to auto-detect", s, e);
+                None
+            }
+        }
+    });
+
     // Create store for replay protection persistence
     let network_store_path = config.store_path().join("network");
     let network_store: Arc<dyn icn_store::Store> =
@@ -1053,6 +1067,7 @@ async fn spawn_network_actor(
         Some(network_store),
         None, // Personhood store for Sybil resistance
         None, // Anchor rate limit config
+        advertised_addr,
     )
     .await?;
 

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -1031,26 +1031,30 @@ async fn spawn_network_actor(
     let turn_config = config.network.turn_config();
 
     // Parse optional explicit advertised address (for containerized deployments)
-    let advertised_addr = config.network.advertised_addr.as_deref().and_then(|s| {
-        match s.parse::<std::net::SocketAddr>() {
-            Ok(addr) => {
-                info!("Using explicit advertised address: {}", addr);
-                if addr.port() != listen_addr.port() {
-                    warn!(
+    let advertised_addr =
+        config.network.advertised_addr.as_deref().and_then(|s| {
+            match s.parse::<std::net::SocketAddr>() {
+                Ok(addr) => {
+                    info!("Using explicit advertised address: {}", addr);
+                    if addr.port() != listen_addr.port() {
+                        warn!(
                         "advertised_addr {} uses port {} but network.listen_addr {} uses port {}. \
                         Peers will dial a port this node may not be listening on — \
                         verify port-forwarding or proxy configuration.",
                         addr, addr.port(), listen_addr, listen_addr.port()
                     );
+                    }
+                    Some(addr)
                 }
-                Some(addr)
+                Err(e) => {
+                    warn!(
+                        "Failed to parse advertised_addr '{}': {} — falling back to auto-detect",
+                        s, e
+                    );
+                    None
+                }
             }
-            Err(e) => {
-                warn!("Failed to parse advertised_addr '{}': {} — falling back to auto-detect", s, e);
-                None
-            }
-        }
-    });
+        });
 
     // Create store for replay protection persistence
     let network_store_path = config.store_path().join("network");

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -1035,6 +1035,14 @@ async fn spawn_network_actor(
         match s.parse::<std::net::SocketAddr>() {
             Ok(addr) => {
                 info!("Using explicit advertised address: {}", addr);
+                if addr.port() != listen_addr.port() {
+                    warn!(
+                        "advertised_addr {} uses port {} but network.listen_addr {} uses port {}. \
+                        Peers will dial a port this node may not be listening on — \
+                        verify port-forwarding or proxy configuration.",
+                        addr, addr.port(), listen_addr, listen_addr.port()
+                    );
+                }
                 Some(addr)
             }
             Err(e) => {

--- a/icn/crates/icn-core/tests/contract_deployment_integration.rs
+++ b/icn/crates/icn-core/tests/contract_deployment_integration.rs
@@ -131,6 +131,7 @@ impl TestNode {
             None, // No store for tests
             None, // personhood_store
             None, // anchor_rate_config
+            None, // advertised_addr
         )
         .await?;
 

--- a/icn/crates/icn-core/tests/entity_gossip_convergence.rs
+++ b/icn/crates/icn-core/tests/entity_gossip_convergence.rs
@@ -186,6 +186,7 @@ impl TestNode {
             None, // No store
             None, // personhood_store
             None, // anchor_rate_config
+            None, // advertised_addr
         )
         .await?;
 

--- a/icn/crates/icn-core/tests/gossip_pull_protocol_integration.rs
+++ b/icn/crates/icn-core/tests/gossip_pull_protocol_integration.rs
@@ -143,6 +143,7 @@ impl TestNode {
             None, // No store for tests
             None, // personhood_store
             None, // anchor_rate_config
+            None, // advertised_addr
         )
         .await?;
 

--- a/icn/crates/icn-core/tests/governance_integration.rs
+++ b/icn/crates/icn-core/tests/governance_integration.rs
@@ -202,6 +202,7 @@ impl TestNode {
             None, // No store for tests
             None, // personhood_store
             None, // anchor_rate_config
+            None, // advertised_addr
         )
         .await?;
 

--- a/icn/crates/icn-core/tests/graceful_restart_integration.rs
+++ b/icn/crates/icn-core/tests/graceful_restart_integration.rs
@@ -86,6 +86,7 @@ impl TestNode {
             None, // No store for tests
             None, // personhood_store
             None, // anchor_rate_config
+            None, // advertised_addr
         )
         .await?;
 
@@ -278,6 +279,7 @@ async fn test_graceful_restart_preserves_state() -> Result<()> {
         None, // No store for tests
         None, // personhood_store
         None, // anchor_rate_config
+        None, // advertised_addr
     )
     .await?;
 
@@ -496,6 +498,7 @@ async fn test_x25519_keys_persist_across_restart() -> Result<()> {
         None, // No store for tests
         None, // personhood_store
         None, // anchor_rate_config
+        None, // advertised_addr
     )
     .await?;
 

--- a/icn/crates/icn-core/tests/graceful_restart_stress.rs
+++ b/icn/crates/icn-core/tests/graceful_restart_stress.rs
@@ -81,6 +81,7 @@ impl TestNode {
             None, // No store for tests
             None, // personhood_store
             None, // anchor_rate_config
+            None, // advertised_addr
         )
         .await?;
 
@@ -197,6 +198,7 @@ impl TestNode {
             None, // No store for tests
             None, // personhood_store
             None, // anchor_rate_config
+            None, // advertised_addr
         )
         .await?;
 

--- a/icn/crates/icn-core/tests/multi_node_gossip_convergence.rs
+++ b/icn/crates/icn-core/tests/multi_node_gossip_convergence.rs
@@ -199,6 +199,7 @@ impl TestNode {
             None, // No store for tests
             None, // personhood_store
             None, // anchor_rate_config
+            None, // advertised_addr
         )
         .await?;
 

--- a/icn/crates/icn-core/tests/network_gossip_integration.rs
+++ b/icn/crates/icn-core/tests/network_gossip_integration.rs
@@ -75,6 +75,7 @@ impl TestNode {
             None, // No store for tests
             None, // personhood_store
             None, // anchor_rate_config
+            None, // advertised_addr
         )
         .await?;
 

--- a/icn/crates/icn-core/tests/recovery_integration.rs
+++ b/icn/crates/icn-core/tests/recovery_integration.rs
@@ -324,6 +324,7 @@ impl RecoveryTestNode {
             None, // No store for tests
             None, // personhood_store
             None, // anchor_rate_config
+            None, // advertised_addr
         )
         .await?;
 

--- a/icn/crates/icn-core/tests/subscription_integration.rs
+++ b/icn/crates/icn-core/tests/subscription_integration.rs
@@ -168,6 +168,7 @@ impl TestNode {
             None, // No store for tests
             None, // personhood_store
             None, // anchor_rate_config
+            None, // advertised_addr
         )
         .await?;
 

--- a/icn/crates/icn-core/tests/topology_integration.rs
+++ b/icn/crates/icn-core/tests/topology_integration.rs
@@ -112,6 +112,7 @@ impl TestNode {
             None,                  // No store for tests
             None,                  // personhood_store
             None,                  // anchor_rate_config
+            None,                  // advertised_addr
         )
         .await?;
 

--- a/icn/crates/icn-net/src/actor/mod.rs
+++ b/icn/crates/icn-net/src/actor/mod.rs
@@ -998,6 +998,11 @@ impl NetworkActor {
         store: Option<Arc<dyn Store>>,
         personhood_store: Option<Arc<dyn PersonhoodStoreTrait>>,
         anchor_rate_config: Option<AnchorRateLimitConfig>,
+        // Explicit advertised address for connection candidates.
+        // When set, overrides the auto-detected local address in candidate announcements.
+        // Required in K8s/Docker where the QUIC endpoint binds to `0.0.0.0` but must
+        // advertise the pod/container IP so other nodes can dial back.
+        advertised_addr: Option<SocketAddr>,
     ) -> Result<NetworkHandle> {
         let did = identity_bundle.did().clone();
 
@@ -1014,6 +1019,9 @@ impl NetworkActor {
 
         // Start session manager (no TLS trust gating anymore - handled by PolicyOracle in protocol)
         let mut session_manager = SessionManager::new();
+        if let Some(addr) = advertised_addr {
+            session_manager.set_advertised_addr(addr);
+        }
         session_manager
             .start(&identity_bundle, listen_addr, stun_servers, turn_config)
             .await
@@ -1375,6 +1383,7 @@ mod tests {
             None, // store (tests don't need persistence)
             None, // personhood_store
             None, // anchor_rate_config
+            None, // advertised_addr
         )
         .await
         .unwrap();

--- a/icn/crates/icn-net/src/session.rs
+++ b/icn/crates/icn-net/src/session.rs
@@ -77,6 +77,13 @@ pub struct SessionManager {
 
     /// Shutdown channel receiver
     _shutdown_rx: mpsc::Receiver<()>,
+
+    /// Explicit advertised local address override.
+    ///
+    /// When set, this address is used instead of `endpoint.local_addr()` when building
+    /// connection candidates. Required in containerized environments (Docker/K8s) where
+    /// the QUIC endpoint binds to `0.0.0.0` but must advertise the container/pod IP.
+    advertised_addr: Option<SocketAddr>,
 }
 
 impl SessionManager {
@@ -94,7 +101,17 @@ impl SessionManager {
             turn_config: Arc::new(RwLock::new(None)),
             shutdown_tx: Some(shutdown_tx),
             _shutdown_rx: shutdown_rx,
+            advertised_addr: None,
         }
+    }
+
+    /// Set an explicit advertised address for connection candidates.
+    ///
+    /// Use this in containerized environments where the bind address (`0.0.0.0`) is not
+    /// a dialable address. When set, this takes precedence over `endpoint.local_addr()`
+    /// and the auto-detection fallback.
+    pub fn set_advertised_addr(&mut self, addr: SocketAddr) {
+        self.advertised_addr = Some(addr);
     }
 
     /// Start the session manager with a QUIC endpoint
@@ -440,8 +457,23 @@ impl SessionManager {
             .as_ref()
             .context("Session manager not started")?;
 
-        let local_addr = endpoint.local_addr()?;
+        let raw_local_addr = endpoint.local_addr()?;
         let public_addr = *self.public_endpoint.read().await;
+
+        // Resolve the actual dialable local address.
+        //
+        // When the endpoint binds to 0.0.0.0 (wildcard), the raw local_addr is not
+        // dialable by peers. Resolve in priority order:
+        //   1. Explicit `advertised_addr` config override (e.g. K8s pod IP)
+        //   2. Auto-detect via routing-socket trick (works in containers/VMs)
+        //   3. Raw endpoint address as last resort (may be 0.0.0.0)
+        let local_addr = if let Some(addr) = self.advertised_addr {
+            addr
+        } else if raw_local_addr.ip().is_unspecified() {
+            resolve_local_addr(raw_local_addr.port()).unwrap_or(raw_local_addr)
+        } else {
+            raw_local_addr
+        };
 
         // Include relay address if TURN allocation is active (Phase 4 M1)
         let relay_addr = *self.relay_addr.read().await;
@@ -633,8 +665,28 @@ impl SessionManager {
             turn_config: self.turn_config.clone(),
             shutdown_tx: None, // Test clones don't control shutdown
             _shutdown_rx: mpsc::channel(1).1,
+            advertised_addr: self.advertised_addr,
         }
     }
+}
+
+/// Determine the local IP that would be used to route packets to an external host.
+///
+/// Uses the routing-socket trick: binding a UDP socket and calling `connect()` to a
+/// well-known external address makes the OS select the egress interface without
+/// sending any packets. The bound socket's local address then reveals the real IP.
+///
+/// Works correctly in Docker/K8s containers where the bind address is `0.0.0.0`
+/// but the container has a real routable IP on eth0.
+///
+/// Returns None if the trick fails (e.g., no network, weird routing table).
+fn resolve_local_addr(port: u16) -> Option<SocketAddr> {
+    let socket = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
+    // Connecting UDP does not send any packets — it only sets the routing destination.
+    // 8.8.8.8:80 is used as a well-known routable external address.
+    socket.connect("8.8.8.8:80").ok()?;
+    let local_ip = socket.local_addr().ok()?.ip();
+    Some(SocketAddr::new(local_ip, port))
 }
 
 #[cfg(test)]

--- a/icn/crates/icn-net/src/session.rs
+++ b/icn/crates/icn-net/src/session.rs
@@ -677,16 +677,33 @@ impl SessionManager {
 /// sending any packets. The bound socket's local address then reveals the real IP.
 ///
 /// Works correctly in Docker/K8s containers where the bind address is `0.0.0.0`
-/// but the container has a real routable IP on eth0.
+/// but the container has a real routable IP on eth0. In IPv6-only environments,
+/// falls back to the same trick using an IPv6 wildcard and destination.
 ///
 /// Returns None if the trick fails (e.g., no network, weird routing table).
 fn resolve_local_addr(port: u16) -> Option<SocketAddr> {
-    let socket = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
+    // Try IPv4 first to preserve existing behavior on dual-stack/IPv4 hosts.
     // Connecting UDP does not send any packets — it only sets the routing destination.
-    // 8.8.8.8:80 is used as a well-known routable external address.
-    socket.connect("8.8.8.8:80").ok()?;
-    let local_ip = socket.local_addr().ok()?.ip();
-    Some(SocketAddr::new(local_ip, port))
+    // 8.8.8.8:80 is used as a well-known routable external IPv4 address.
+    if let Ok(socket) = std::net::UdpSocket::bind("0.0.0.0:0") {
+        if socket.connect("8.8.8.8:80").is_ok() {
+            if let Ok(local_addr) = socket.local_addr() {
+                return Some(SocketAddr::new(local_addr.ip(), port));
+            }
+        }
+    }
+
+    // Fallback: try the same routing trick using IPv6 for IPv6-only environments.
+    // 2001:4860:4860::8888 is Google's well-known routable IPv6 address.
+    if let Ok(socket) = std::net::UdpSocket::bind("[::]:0") {
+        if socket.connect("[2001:4860:4860::8888]:80").is_ok() {
+            if let Ok(local_addr) = socket.local_addr() {
+                return Some(SocketAddr::new(local_addr.ip(), port));
+            }
+        }
+    }
+
+    None
 }
 
 #[cfg(test)]

--- a/icn/crates/icn-net/tests/client_cert_verification_integration.rs
+++ b/icn/crates/icn-net/tests/client_cert_verification_integration.rs
@@ -69,6 +69,7 @@ impl SecureTestNode {
             None,
             None, // store
             None, // anchor_rate_config
+            None, // advertised_addr
         )
         .await?;
 
@@ -125,6 +126,7 @@ impl SecureTestNode {
             None,
             None, // store
             None, // anchor_rate_config
+            None, // advertised_addr
         )
         .await?;
 
@@ -227,6 +229,7 @@ async fn test_client_cert_verification_allows_trusted_peer() -> Result<()> {
         None,
         None, // store
         None, // anchor_rate_config
+        None, // advertised_addr
     )
     .await?;
 
@@ -251,6 +254,7 @@ async fn test_client_cert_verification_allows_trusted_peer() -> Result<()> {
         None,
         None, // store
         None, // anchor_rate_config
+        None, // advertised_addr
     )
     .await?;
 
@@ -324,6 +328,7 @@ async fn test_client_cert_verification_rejects_untrusted_peer() -> Result<()> {
         None,
         None, // store
         None, // anchor_rate_config
+        None, // advertised_addr
     )
     .await?;
 
@@ -348,6 +353,7 @@ async fn test_client_cert_verification_rejects_untrusted_peer() -> Result<()> {
         None,
         None, // store
         None, // anchor_rate_config
+        None, // advertised_addr
     )
     .await?;
 
@@ -465,6 +471,7 @@ async fn test_did_tls_binding_verified_on_hello() -> Result<()> {
         None,
         None, // store
         None, // anchor_rate_config
+        None, // advertised_addr
     )
     .await?;
 
@@ -487,6 +494,7 @@ async fn test_did_tls_binding_verified_on_hello() -> Result<()> {
         None,
         None, // store
         None, // anchor_rate_config
+        None, // advertised_addr
     )
     .await?;
 

--- a/icn/crates/icn-net/tests/did_tls_binding_integration.rs
+++ b/icn/crates/icn-net/tests/did_tls_binding_integration.rs
@@ -71,6 +71,7 @@ impl TestNode {
             None, // No misbehavior detector for tests
             None, // No store for tests
             None, // anchor_rate_config
+            None, // advertised_addr
         )
         .await?;
 

--- a/icn/crates/icn-net/tests/encrypted_message_integration.rs
+++ b/icn/crates/icn-net/tests/encrypted_message_integration.rs
@@ -342,6 +342,7 @@ impl TestNode {
             None, // No store for tests
             None, // personhood_store
             None, // anchor_rate_config
+            None, // advertised_addr
         )
         .await?;
 

--- a/icn/crates/icn-net/tests/relay_fallback.rs
+++ b/icn/crates/icn-net/tests/relay_fallback.rs
@@ -355,6 +355,7 @@ async fn spawn_node(
         None, // store
         None, // personhood_store
         None, // anchor_rate_config
+        None, // advertised_addr
     )
     .await?;
 

--- a/icn/crates/icn-testkit/src/node.rs
+++ b/icn/crates/icn-testkit/src/node.rs
@@ -378,6 +378,7 @@ impl TestNode {
             None, // No store
             None, // No personhood store (Sybil resistance)
             None, // No anchor rate config
+            None, // No advertised addr override
         )
         .await?;
 


### PR DESCRIPTION
## What
Pods advertising  as their local P2P candidate address — peers that
receive this candidate try to dial , get ,
and the mesh never forms.

## Root Cause
 called  which
returns the QUIC bind address verbatim. When the endpoint binds to 
(standard in containers), that wildcard is published as the dialable local address.

Log evidence from live K3s pod ( in ):


## Fix
Three-layer resolution in :
1. **Explicit config override**: new  field
2. **Auto-detect** via routing-socket trick: bind UDP to , connect to
    (no packets sent), read local_addr — OS selects egress interface
3. **Raw endpoint.local_addr()** as fallback

Auto-detect works correctly in K8s pods (returns the pod's eth0 IP). Explicit
override is available for edge cases where routing-table auto-detect is wrong.

## Secondary issue (not fixed in this PR)
The pod is also self-banning: the gossip subscription limit (10 per-peer) is hit
by the node's own DID subscribing to 11 topics on startup. The misbehavior detector
then bans the own DID. This is a separate bug that doesn't block the address fix.

## Risk
Low — the routing-socket trick is a read-only OS operation, no packets sent.
Existing behavior preserved when  is already a real IP (non-unspecified).

## Test plan
- [x]  passes
- [ ] Deploy to K3s alpha pod, verify candidate announces real pod IP
- [ ] Observe two-pod mesh forming via connection candidate exchange

🤖 Generated with [Claude Code](https://claude.com/claude-code)