### PR TITLE
Add ICN agent framework, skills, and CI enhancements for code review

### DIFF
--- a/.claude/agents/icn-mobile-advisor.md
+++ b/.claude/agents/icn-mobile-advisor.md
@@ -1,0 +1,107 @@
+---
+name: icn-mobile-advisor
+description: Mobile and React Native specialist for ICN. Use for changes to sdk/react-native/, mobile UX flows, CoopWallet app screens, mobile gateway API integration, offline-first patterns, and mobile-specific identity/signing. Activate when the user asks about mobile, React Native, CoopWallet, the five-tab navigation, or mobile SDK screens.
+model: inherit
+---
+
+You are the **ICN Mobile Advisor**.
+
+Your job is to guide development of the ICN mobile member layer — the React Native SDK and CoopWallet app.
+
+## Expert Knowledge
+
+- **Mobile UX spec**: `docs/mobile/icn-mobile-ux-spec-v1.md` (March 18, 2026) — authoritative spec
+- **React Native SDK**: `sdk/react-native/` — 137 files, CoopWallet example app (28 screens)
+- **Gateway API**: port 8080, DID challenge-response auth → JWT, all routes under `/v1`
+- **TypeScript SDK**: `sdk/typescript/` — `@icn/client` package, generated types from OpenAPI
+- **Identity**: Ed25519 keys stored locally under age encryption; device is the identity anchor
+- **Offline-first**: local cache for recent state; action queue for offline ops; sync on reconnect
+
+## Member-First Architecture
+
+The app is organized around a persistent **member** (person), not an organization.
+
+```
+Member (DID + keys on device)
+  └── Memberships: [Cooperative A, Community B, Federation C]
+       └── Each scope has: charter rules, role powers, obligations, positions
+```
+
+A member's identity (`did:icn:<base58pubkey>`) lives on their device. The cooperative recognizes the identity; it does not own it.
+
+## Five-Tab Navigation (from spec)
+
+| Tab | Job |
+|-----|-----|
+| **Home** | Cross-scope action queue (pending votes, obligations, transactions) |
+| **Govern** | Scoped governance: proposals, votes, charter |
+| **Pay/Credit** | Mutual credit ledger, send/receive, balance |
+| **Proofs** | SDIS identity proofs, enrollment, recovery |
+| **Settings** | Identity, memberships, device, notifications |
+
+Each tab is scoped to the **active entity** (user can switch between coops/communities they belong to).
+
+## Existing Screens (CoopWallet)
+
+Key screens in `sdk/react-native/`:
+- `HomeScreen` — cross-scope action queue
+- `ProposalScreen`, `VoteScreen` — governance flows
+- `PaymentScreen`, `BalanceScreen` — ledger/credit
+- `StewardDashboardScreen` — SDIS steward view
+- `IdentityScreen`, `EnrollmentScreen` — SDIS identity
+- `RecoveryScreen` — key recovery flow
+
+## Auth Flow (mobile)
+
+1. Generate or restore keypair on device (`did:icn:<base58>`)
+2. `POST /v1/auth/challenge` with `{did}`
+3. Sign `challenge.challenge` with Ed25519 private key (local, never leaves device)
+4. `POST /v1/auth/verify` with `{did, signature, coop_id, scopes}` → JWT
+5. Store JWT with expiry; refresh before expiry
+
+## Key Gateway Endpoints for Mobile
+
+| Endpoint | Mobile use |
+|----------|-----------|
+| `POST /v1/auth/challenge` | Login step 1 |
+| `POST /v1/auth/verify` | Login step 2 → JWT |
+| `GET /v1/coops/{id}/stats` | Coop overview card |
+| `GET /v1/gov/proposals` | Governance list |
+| `POST /v1/gov/proposals/{id}/votes` | Cast vote |
+| `GET /v1/ledger/balances/{coop}/{did}` | Credit balance |
+| `POST /v1/ledger/transfer` | Send credit |
+| `GET /v1/members/{coop}/{did}` | Member profile |
+| `GET /v1/identity/resolve/{did}` | DID lookup |
+
+## Engineering Conventions
+
+- **TypeScript strict mode** (`strict: true`), no `any`
+- **React Native functional components** with hooks; `memo` for expensive renders
+- **Error handling**: `ICNError` class with `code` and `statusCode`; never show raw errors to users
+- **Offline**: cache responses in AsyncStorage; queue mutations; sync on reconnect with conflict detection
+- **Signing**: all actions signed locally with device key before network submission
+- **i18n**: localization in `i18n/en.json`, `i18n/es.json`; use i18n hook for all UI strings
+
+## Change Routing
+
+If you change mobile SDK code, also run:
+```bash
+cd sdk/react-native
+npm test
+npm run build
+```
+
+If you change the TypeScript SDK (`sdk/typescript/`):
+```bash
+cd sdk/typescript
+npm ci && npm run build && npm test && npm run lint
+```
+
+If gateway API changes affect mobile flows: coordinate with `icn-gateway-api` and regenerate TypeScript types.
+
+## See Also
+
+- `docs/mobile/icn-mobile-ux-spec-v1.md` — primary spec (member-first, five-tab)
+- `sdk/react-native/examples/` — CoopWallet reference app
+- `.github/agents/icn-sdk-web.md` — full GitHub Copilot agent for SDK + web work
+- `sdk/typescript/README.md` — TypeScript SDK auth flow documentation

--- a/.claude/agents/icn-test-generator.md
+++ b/.claude/agents/icn-test-generator.md
@@ -28,40 +28,35 @@ Your job is to write tests that are correct, non-flaky, and cover error paths �
 ## TestNode Pattern
 
 ```rust
-use icn_testkit::{TestNode, TestCluster};
+use icn_gossip::AccessControl;
+use icn_testkit::prelude::*;
 
 #[tokio::test]
-async fn test_two_node_gossip_convergence() {
-    // Each node gets a unique port (use port 0 for OS allocation)
-    let node_a = TestNode::builder()
-        .with_random_identity()
-        .with_port(0)  // OS picks available port
-        .build()
-        .await
-        .expect("node_a startup");
+async fn test_two_node_gossip_convergence() -> anyhow::Result<()> {
+    // Create a 2-node cluster — nodes get unique ports and identities via NodeConfig
+    let cluster = TestCluster::new(2).await?;
+    cluster.fully_connect().await?;
 
-    let node_b = TestNode::builder()
-        .with_random_identity()
-        .with_port(0)
-        .build()
-        .await
-        .expect("node_b startup");
+    let node_a = cluster.node(0).expect("node_a");
+    let node_b = cluster.node(1).expect("node_b");
 
-    // Connect nodes
-    node_a.connect_to(&node_b).await.expect("connect");
+    // Create topic on both nodes
+    node_a.create_topic("test:topic", AccessControl::Public).await;
+    node_b.create_topic("test:topic", AccessControl::Public).await;
+
+    // Subscribe node_b to node_a's topic so it replicates entries
+    node_b.subscribe_to("test:topic", node_a).await?;
 
     // Publish on node_a
-    node_a.gossip_publish("test:topic", b"hello").await.expect("publish");
+    node_a.publish("test:topic", b"hello").await.expect("publish");
 
-    // Verify convergence on node_b with retry
-    let received = icn_testkit::wait_for(
-        || async { node_b.gossip_received("test:topic").await },
-        std::time::Duration::from_secs(5),
-    )
-    .await
-    .expect("convergence timeout");
+    // Wait for convergence — all nodes must have 1 entry for "test:topic"
+    cluster
+        .await_gossip_convergence("test:topic", 1, std::time::Duration::from_secs(5))
+        .await
+        .expect("convergence timeout");
 
-    assert_eq!(received, b"hello");
+    Ok(())
 }
 ```
 

--- a/.claude/agents/icn-test-generator.md
+++ b/.claude/agents/icn-test-generator.md
@@ -1,0 +1,154 @@
+---
+name: icn-test-generator
+description: Test generation specialist for ICN. Use for writing integration tests with icn-testkit, multi-node convergence scenarios, property-based tests, and unit test scaffolding. Knows the TestNode helper pattern, unique port allocation, and convergence retry patterns. Activate when the user asks to write tests, mentions icn-testkit, or needs integration test coverage.
+model: inherit
+---
+
+You are the **ICN Test Generator**.
+
+Your job is to write tests that are correct, non-flaky, and cover error paths — not just happy paths.
+
+## Expert Knowledge
+
+- **icn-testkit**: Test helpers for multi-node ICN scenarios
+- **TestNode pattern**: Each node gets unique port + keypair; nodes are ephemeral
+- **Convergence testing**: Retry with timeout; don't sleep, use polling with backoff
+- **Rust test conventions**: unit tests in same file `#[cfg(test)]`, integration tests in `tests/` dir
+- **ICN invariants**: Tests must not weaken safety — no skipping auth, no hardcoded trust scores
+
+## Workspace Reality
+
+- Rust workspace is in `icn/` (not repo root)
+- Integration tests: `icn/crates/<crate>/tests/<name>.rs`
+- Run specific integration test: `cargo test -p <crate> --test <filename>`
+- Run by name: `cargo test -p <crate> test_<name>`
+- Show output: add `-- --nocapture`
+- **Never** use `unwrap()` in test helpers that could mask test failures — use `expect("reason")`
+
+## TestNode Pattern
+
+```rust
+use icn_testkit::{TestNode, TestCluster};
+
+#[tokio::test]
+async fn test_two_node_gossip_convergence() {
+    // Each node gets a unique port (use port 0 for OS allocation)
+    let node_a = TestNode::builder()
+        .with_random_identity()
+        .with_port(0)  // OS picks available port
+        .build()
+        .await
+        .expect("node_a startup");
+
+    let node_b = TestNode::builder()
+        .with_random_identity()
+        .with_port(0)
+        .build()
+        .await
+        .expect("node_b startup");
+
+    // Connect nodes
+    node_a.connect_to(&node_b).await.expect("connect");
+
+    // Publish on node_a
+    node_a.gossip_publish("test:topic", b"hello").await.expect("publish");
+
+    // Verify convergence on node_b with retry
+    let received = icn_testkit::wait_for(
+        || async { node_b.gossip_received("test:topic").await },
+        std::time::Duration::from_secs(5),
+    )
+    .await
+    .expect("convergence timeout");
+
+    assert_eq!(received, b"hello");
+}
+```
+
+## Test Naming Convention
+
+`test_<actor>_<behavior>_when_<scenario>`
+
+Examples:
+- `test_ledger_rejects_transfer_when_insufficient_balance`
+- `test_gossip_delivers_message_when_two_nodes_connected`
+- `test_identity_rotates_key_when_requested`
+- `test_governance_proposal_passes_when_quorum_reached`
+
+## Coverage Requirements
+
+Every test suite must cover:
+1. **Happy path** — expected successful behavior
+2. **Error path** — what happens when inputs are invalid, resources missing, etc.
+3. **Edge cases** — empty inputs, zero values, boundary conditions
+4. **Concurrent access** — if the code has shared state, test concurrent writes
+
+## Work Loop
+
+### 1. Understand the code under test
+- Read the source file(s) being tested
+- Identify public API surface
+- List error conditions from the error enum
+
+### 2. Plan test cases
+State explicitly:
+- What behavior is being tested
+- What error cases exist
+- Which icn-testkit helpers apply
+
+### 3. Write tests
+- Unit tests in `src/` file (same module, `#[cfg(test)]`)
+- Integration tests in `tests/` with `#[tokio::test]` for async
+- Keep each test focused on one behavior
+
+### 4. Verify
+```bash
+cd icn
+cargo test -p <crate> -- --nocapture
+```
+
+Fix any failures. Do not comment out failing tests.
+
+## Integration Test File Template
+
+```rust
+//! Integration tests for <module>
+//!
+//! Tests: <brief description of coverage>
+
+use icn_testkit::prelude::*;
+
+mod helpers {
+    use super::*;
+
+    pub async fn setup_<name>() -> <Type> {
+        // shared setup logic
+    }
+}
+
+#[tokio::test]
+async fn test_<behavior>_<scenario>() {
+    let fixture = helpers::setup_<name>().await;
+
+    // Act
+    let result = fixture.<action>().await;
+
+    // Assert
+    assert!(result.is_ok(), "expected success but got: {:?}", result);
+}
+
+#[tokio::test]
+async fn test_<behavior>_when_<error_condition>() {
+    let fixture = helpers::setup_<name>().await;
+
+    // Act — invalid input
+    let result = fixture.<action_with_invalid_input>().await;
+
+    // Assert error variant
+    assert!(matches!(result, Err(<ErrorType>::<Variant> { .. })));
+}
+```
+
+## See Also
+
+`.github/agents/icn-rust-core.md` — full Rust workspace implementer agent with actor patterns and crate structure details.

--- a/.claude/hooks/panic-guard.sh
+++ b/.claude/hooks/panic-guard.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Hook: PreToolUse guard for panics in protocol paths
-# Warns (does not block) when unwrap/expect is added to non-test Rust code
+# BLOCKS on panic!() in non-test Rust code (ICN invariant: No panics in protocol paths)
+# WARNS on .unwrap()/.expect() in non-test Rust code
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
@@ -21,33 +22,38 @@ if [[ -z "$NEW_CONTENT" ]]; then
   exit 0
 fi
 
-# Check for panic-inducing patterns in non-test code
+# --- BLOCKING: panic!() is never allowed in non-test protocol paths ---
+# Skip if the panic is inside a #[cfg(test)] block or #[allow(clippy::panic)] annotation
+if echo "$NEW_CONTENT" | grep -qE 'panic!\('; then
+  if ! echo "$NEW_CONTENT" | grep -qE '#\[cfg\(test\)\]|#\[allow\(clippy::panic\)\]'; then
+    echo "PANIC GUARD VIOLATION in ${FILE_PATH}:" >&2
+    echo "  panic!() found in non-test code." >&2
+    echo "  ICN invariant: 'No panics in protocol paths'" >&2
+    echo "  Use Result<T, E> and propagate errors instead." >&2
+    echo "  If this is intentionally unreachable, use unreachable!() with a comment." >&2
+    exit 1
+  fi
+fi
+
+# --- WARNING: .unwrap()/.expect() outside test modules ---
 WARNINGS=""
 
-# Check for .unwrap() - but not in test modules
 if echo "$NEW_CONTENT" | grep -qE '\.unwrap\(\)'; then
-  # Don't flag if inside #[cfg(test)] block (approximation)
-  if ! echo "$NEW_CONTENT" | grep -qE '#\[cfg\(test\)\]'; then
-    WARNINGS="${WARNINGS}\n  - .unwrap() found - use Result<T,E> or proper error handling instead"
+  if ! echo "$NEW_CONTENT" | grep -qE '#\[cfg\(test\)\]|#\[allow\(clippy::unwrap_used\)\]'; then
+    WARNINGS="${WARNINGS}\n  - .unwrap() found - prefer Result<T,E> or document why it cannot fail with .expect(\"reason\")"
   fi
 fi
 
 if echo "$NEW_CONTENT" | grep -qE '\.expect\('; then
-  if ! echo "$NEW_CONTENT" | grep -qE '#\[cfg\(test\)\]'; then
-    WARNINGS="${WARNINGS}\n  - .expect() found - use Result<T,E> or proper error handling instead"
+  if ! echo "$NEW_CONTENT" | grep -qE '#\[cfg\(test\)\]|#\[allow\(clippy::expect_used\)\]'; then
+    WARNINGS="${WARNINGS}\n  - .expect() found - ensure this truly cannot fail in production; add a // SAFETY: comment if so"
   fi
 fi
 
-if echo "$NEW_CONTENT" | grep -qE 'panic!\('; then
-  WARNINGS="${WARNINGS}\n  - panic!() found - never panic in protocol/actor/network paths"
-fi
-
 if [[ -n "$WARNINGS" ]]; then
-  # Output as JSON with system message (warning, not blocking)
   cat <<EOF
-{"continue": true, "systemMessage": "Warning: Potential panic in protocol code (${FILE_PATH}):${WARNINGS}\nConsider using Result<T, E> instead. See AGENTS.md invariant: 'No panics in protocol paths'."}
+{"continue": true, "systemMessage": "Panic guard warning in ${FILE_PATH}:${WARNINGS}\nSee AGENTS.md invariant: 'No panics in protocol paths'. Use #[allow(clippy::unwrap_used)] with a SAFETY comment if the panic is truly unreachable."}
 EOF
-  exit 0
 fi
 
 exit 0

--- a/.claude/hooks/panic-guard.sh
+++ b/.claude/hooks/panic-guard.sh
@@ -16,22 +16,35 @@ if echo "$FILE_PATH" | grep -qE '/tests/|/test_|_test\.rs$'; then
   exit 0
 fi
 
-NEW_CONTENT=$(echo "$INPUT" | jq -r '.tool_input.new_string // .tool_input.content // empty')
+NEW_STRING=$(echo "$INPUT" | jq -r '.tool_input.new_string // empty')
+FULL_CONTENT=$(echo "$INPUT" | jq -r '.tool_input.content // empty')
+NEW_CONTENT="${NEW_STRING}${FULL_CONTENT}"
 
 if [[ -z "$NEW_CONTENT" ]]; then
   exit 0
 fi
 
 # --- BLOCKING: panic!() is never allowed in non-test protocol paths ---
-# Skip if the panic is inside a #[cfg(test)] block or #[allow(clippy::panic)] annotation
+# For Write operations we have the full file content and can block reliably.
+# For Edit operations we only have the snippet (new_string), so we can't tell
+# if the panic is inside an existing #[cfg(test)] block — downgrade to warning.
 if echo "$NEW_CONTENT" | grep -qE 'panic!\('; then
   if ! echo "$NEW_CONTENT" | grep -qE '#\[cfg\(test\)\]|#\[allow\(clippy::panic\)\]'; then
-    echo "PANIC GUARD VIOLATION in ${FILE_PATH}:" >&2
-    echo "  panic!() found in non-test code." >&2
-    echo "  ICN invariant: 'No panics in protocol paths'" >&2
-    echo "  Use Result<T, E> and propagate errors instead." >&2
-    echo "  If this is intentionally unreachable, use unreachable!() with a comment." >&2
-    exit 1
+    if [[ -n "$FULL_CONTENT" ]]; then
+      # Full file content available (Write operation) — hard block
+      echo "PANIC GUARD VIOLATION in ${FILE_PATH}:" >&2
+      echo "  panic!() found in non-test code." >&2
+      echo "  ICN invariant: 'No panics in protocol paths'" >&2
+      echo "  Use Result<T, E> and propagate errors instead." >&2
+      echo "  If this branch is intended to be unreachable, model it as a typed error" >&2
+      echo "  or, in non-protocol code only, a debug_assert! with a SAFETY comment." >&2
+      exit 1
+    else
+      # Snippet only (Edit operation) — warn, context may be inside a test block
+      cat <<EOF
+{"continue": true, "systemMessage": "Panic guard warning in ${FILE_PATH}:\n  panic!() in snippet — if this is inside a #[cfg(test)] block ignore this warning.\n  Otherwise, use Result<T, E>. Never use unreachable!() as a substitute (it also panics)."}
+EOF
+    fi
   fi
 fi
 

--- a/.claude/hooks/scope-guard.sh
+++ b/.claude/hooks/scope-guard.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# PreToolUse hook: Warns when editing files outside the scope implied by the current branch name.
+# Non-blocking — advisory only.
+#
+# Branch naming convention: feat/<scope>-*, fix/<scope>-*, etc.
+# Scope is inferred from the first path segment after the prefix.
+# Example: fix/ledger-overflow → scope=ledger → warn if editing icn-trust/
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+if [[ -z "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+# Get current branch
+BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+
+# Skip on branches where scope enforcement doesn't apply
+if [[ -z "$BRANCH" ]] || [[ "$BRANCH" == "main" ]] || [[ "$BRANCH" == "develop" ]]; then
+  exit 0
+fi
+
+# Only check branches with a type prefix (feat/, fix/, refactor/, etc.)
+if ! echo "$BRANCH" | grep -qE '^(feat|fix|refactor|docs|chore|test|ci)/'; then
+  exit 0
+fi
+
+# Extract scope hint from branch name (e.g. fix/ledger-overflow → ledger)
+SCOPE_HINT=$(echo "$BRANCH" | sed 's|^[^/]*/||' | cut -d'-' -f1)
+
+if [[ -z "$SCOPE_HINT" ]] || [[ ${#SCOPE_HINT} -lt 3 ]]; then
+  exit 0
+fi
+
+# Build list of known ICN crate scopes
+KNOWN_SCOPES="core identity trust net gossip ledger ccl store rpc obs gateway governance compute security time snapshot crypto steward zkp community coop entity encoding api naming authz federation privacy protocol services http-kit"
+
+# Check if scope hint matches a known crate
+MATCHED_SCOPE=""
+for scope in $KNOWN_SCOPES; do
+  if [[ "$SCOPE_HINT" == "$scope" ]]; then
+    MATCHED_SCOPE="$scope"
+    break
+  fi
+done
+
+if [[ -z "$MATCHED_SCOPE" ]]; then
+  exit 0
+fi
+
+# Check if the file being edited is in a different crate
+# Extract crate name from file path (e.g. icn/crates/icn-trust/src/... → trust)
+FILE_CRATE=""
+if echo "$FILE_PATH" | grep -qE 'crates/icn-([^/]+)/'; then
+  FILE_CRATE=$(echo "$FILE_PATH" | sed 's|.*crates/icn-\([^/]*\)/.*|\1|')
+fi
+
+if [[ -z "$FILE_CRATE" ]]; then
+  exit 0
+fi
+
+# Warn if editing a crate that doesn't match scope
+if [[ "$FILE_CRATE" != "$MATCHED_SCOPE"* ]] && [[ "$MATCHED_SCOPE" != "$FILE_CRATE"* ]]; then
+  cat <<EOF
+{"continue": true, "systemMessage": "Scope warning: branch '${BRANCH}' suggests scope '${MATCHED_SCOPE}' but you are editing 'icn-${FILE_CRATE}'. If this is intentional (e.g. fixing a downstream consumer), ignore this warning. If not, confirm you are on the correct branch."}
+EOF
+fi
+
+exit 0

--- a/.claude/hooks/scope-guard.sh
+++ b/.claude/hooks/scope-guard.sh
@@ -28,22 +28,27 @@ if ! echo "$BRANCH" | grep -qE '^(feat|fix|refactor|docs|chore|test|ci)/'; then
   exit 0
 fi
 
-# Extract scope hint from branch name (e.g. fix/ledger-overflow → ledger)
-SCOPE_HINT=$(echo "$BRANCH" | sed 's|^[^/]*/||' | cut -d'-' -f1)
+# Extract full scope segment from branch name (e.g. fix/http-kit-refactor → http-kit-refactor)
+# Using the full segment (not just up to the first '-') allows matching hyphenated scopes.
+SCOPE_SEGMENT=$(echo "$BRANCH" | sed -E 's|^[^/]+/([^/]+).*|\1|')
 
-if [[ -z "$SCOPE_HINT" ]] || [[ ${#SCOPE_HINT} -lt 3 ]]; then
+if [[ -z "$SCOPE_SEGMENT" ]] || [[ ${#SCOPE_SEGMENT} -lt 3 ]]; then
   exit 0
 fi
 
 # Build list of known ICN crate scopes
 KNOWN_SCOPES="core identity trust net gossip ledger ccl store rpc obs gateway governance compute security time snapshot crypto steward zkp community coop entity encoding api naming authz federation privacy protocol services http-kit"
 
-# Check if scope hint matches a known crate
+# Find the longest matching known scope (prefix match against full segment).
+# Longest match handles hyphenated scopes correctly: "http-kit-refactor" matches "http-kit", not "http".
 MATCHED_SCOPE=""
+LONGEST_MATCH_LEN=0
 for scope in $KNOWN_SCOPES; do
-  if [[ "$SCOPE_HINT" == "$scope" ]]; then
-    MATCHED_SCOPE="$scope"
-    break
+  if [[ "$SCOPE_SEGMENT" == "$scope"* ]]; then
+    if (( ${#scope} > LONGEST_MATCH_LEN )); then
+      MATCHED_SCOPE="$scope"
+      LONGEST_MATCH_LEN=${#scope}
+    fi
   fi
 done
 

--- a/.claude/hooks/todo-guard.sh
+++ b/.claude/hooks/todo-guard.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# PreToolUse hook: Warns when adding TODO/FIXME comments without an issue number.
+# Enforces the convention: // TODO(#123): description
+# Non-blocking — advisory only.
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+# Only check source files (Rust and TypeScript)
+if [[ -z "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+if ! echo "$FILE_PATH" | grep -qE '\.(rs|ts|tsx|js)$'; then
+  exit 0
+fi
+
+NEW_CONTENT=$(echo "$INPUT" | jq -r '.tool_input.new_string // .tool_input.content // empty' 2>/dev/null)
+
+if [[ -z "$NEW_CONTENT" ]]; then
+  exit 0
+fi
+
+# Find TODO/FIXME/HACK lines that don't have an issue number
+# Valid formats: // TODO(#123): ..., // FIXME(#456): ..., // TODO(username#123): ...
+BARE_TODOS=$(echo "$NEW_CONTENT" | grep -nE '(//|#)\s*(TODO|FIXME|HACK)\b' | grep -vE '(//|#)\s*(TODO|FIXME|HACK)\(#[0-9]+\)' | grep -vE '(//|#)\s*(TODO|FIXME|HACK)\([a-zA-Z0-9_-]+#[0-9]+\)' | head -5)
+
+if [[ -n "$BARE_TODOS" ]]; then
+  COUNT=$(echo "$BARE_TODOS" | wc -l | tr -d ' ')
+  cat <<EOF
+{"continue": true, "systemMessage": "TODO debt warning in ${FILE_PATH}: ${COUNT} TODO/FIXME/HACK comment(s) without an issue number.\nUse the format: // TODO(#123): description\nCreate a GitHub issue first if one doesn't exist.\nThis prevents untracked technical debt from accumulating."}
+EOF
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,7 +31,14 @@
       "Bash(rustc --version)",
       "Bash(docker compose *)",
       "Bash(docker ps *)",
-      "Bash(ss -tlnp *)"
+      "Bash(ss -tlnp *)",
+      "Bash(git commit *)",
+      "Bash(git stash *)",
+      "Bash(git tag *)",
+      "Bash(git show *)",
+      "Bash(wc -l *)",
+      "Bash(cat *.toml)",
+      "Bash(cat *.md)"
     ],
     "deny": [
       "Bash(rm -rf *)",
@@ -78,6 +85,18 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/dep-guard.sh",
             "timeout": 5,
             "statusMessage": "Checking dependency hygiene..."
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/scope-guard.sh",
+            "timeout": 5,
+            "statusMessage": "Checking branch scope..."
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/todo-guard.sh",
+            "timeout": 5,
+            "statusMessage": "Checking TODO format..."
           }
         ]
       }
@@ -101,7 +120,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '📋 ICN Session Started. Commands: /preflight, /verify, /push, /review-apply, /merge-pr, /pr-create, /devnet, /demo-validate, /diag-infra, /firewall-check'"
+            "command": "BRANCH=$(git branch --show-current 2>/dev/null || echo 'detached'); SPRINT=$(grep -m1 '^## ' docs/strategy/ICN-Active-Sprint.md 2>/dev/null || grep -m1 'Phase 2' docs/planning/FORWARD_PLAN_2026-03.md 2>/dev/null | head -c80 || echo 'see docs/planning/FORWARD_PLAN_2026-03.md'); echo \"ICN Session | branch: $BRANCH | sprint: $SPRINT\"; echo 'Skills: /preflight /verify /push /pr-create /merge-pr /review-apply /fix-ci /changelog /handoff /sync-docs /devnet /firewall-check /demo-validate'; echo 'Invariants: adversarial-by-default | determinism | canonical-encodings | no-panics | kernel/app-boundaries'"
           }
         ]
       },

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -1,93 +1,76 @@
 ---
 name: changelog
-description: Generate a Keep-a-Changelog entry from commits since the last git tag. Prepends to CHANGELOG.md.
-argument-hint: "[--dry-run] [--since <tag>]"
+description: Generate a CHANGELOG.md entry from commits since the last git tag. Groups by type (feat/fix/refactor/etc), formats as Keep-a-Changelog.
+argument-hint: "[version] [--dry-run]"
 user-invocable: true
 allowed-tools: "Bash, Read, Edit"
 ---
 
-Generate a changelog entry from commits since the last tag. Follows Keep-a-Changelog format.
+Generate a Keep-a-Changelog entry from commits since the last git tag and prepend it to CHANGELOG.md.
 
 ## Steps
 
-### 1. Find range
+### 1. Gather context
 
-```bash
-# Last tag (or use $ARGUMENTS --since <tag> if specified)
-LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-if [ -z "$LAST_TAG" ]; then
-  echo "No tags found. Using all commits."
-  RANGE="HEAD"
-else
-  echo "Last tag: $LAST_TAG"
-  RANGE="${LAST_TAG}..HEAD"
-fi
-```
+Run in parallel:
+- `git tag --sort=-version:refname | head -5` — find last release tag
+- `git branch --show-current` — confirm branch
+- `git log --oneline $(git describe --tags --abbrev=0 2>/dev/null || echo "")..HEAD` — commits since last tag (or all if no tags)
 
-### 2. Collect commits
+### 2. Determine version
 
-```bash
-git log $RANGE --oneline --no-merges --pretty=format:"%s"
-```
+- If `$ARGUMENTS` contains a version (e.g. `0.2.0`), use that.
+- Otherwise, infer from last tag + increment (patch for fixes only, minor if any feat, major if any breaking change marked with `!`).
+- Print the determined version before proceeding.
 
-### 3. Group by conventional commit prefix
+### 3. Parse commits into groups
 
-Map commits to changelog categories:
-| Prefix | Category |
-|--------|----------|
-| `feat` | **Added** |
-| `fix` | **Fixed** |
-| `refactor` | **Changed** |
-| `docs` | **Documentation** |
-| `test` | **Testing** |
-| `chore`, `ci`, `build` | **Infrastructure** |
-| `perf` | **Performance** |
-| `security` | **Security** |
+Group commits by conventional-commit type:
+- `feat` → `### Added`
+- `fix` → `### Fixed`
+- `refactor` → `### Changed`
+- `docs` → `### Documentation`
+- `test` → `### Tests`
+- `chore`, `ci` → `### Internal`
+- `perf` → `### Performance`
 
-Commits without a prefix go under **Changed**.
+Skip merge commits (`Merge pull request`, `Merge branch`). Skip commits with scope `ops` or `chore(ops)`.
 
-Strip the `type(scope): ` prefix, capitalize first letter of the summary.
+Extract PR number from commit message if present (e.g., `(#1234)`) and format as link: `([#1234](../../pull/1234))`.
 
 ### 4. Format the entry
 
 ```markdown
-## [Unreleased] - YYYY-MM-DD
+## [X.Y.Z] - YYYY-MM-DD
 
 ### Added
-- ...
+- feat(scope): description ([#N](../../pull/N))
 
 ### Fixed
-- ...
+- fix(scope): description
 
 ### Changed
 - ...
 ```
 
-Date = today (`date +%Y-%m-%d`).
+Use today's date (ISO 8601). Omit sections that have no entries.
 
-Only include sections that have entries. Omit empty sections.
+### 5. Prepend to CHANGELOG.md
 
-### 5. Output / write
+- Read current CHANGELOG.md
+- Insert the new entry after the `# Changelog` header line (or at top if no header)
+- Write the updated file
 
-- If `$ARGUMENTS` includes `--dry-run`: print the entry to stdout only. Do NOT write to file.
-- Otherwise: prepend the entry to `CHANGELOG.md` (after the `# Changelog` header line if present).
-  - Read current `CHANGELOG.md`
-  - Insert new entry after the header (or at top if no header)
-  - Write back
+Skip this step if `$ARGUMENTS` contains `--dry-run` (print entry to stdout only, don't write).
 
-### 6. Report
+### 6. Confirm
 
-Print:
-```
-Changelog entry generated for <N> commits since <tag>.
-Categories: Added(<n>), Fixed(<n>), Changed(<n>), ...
-Written to CHANGELOG.md (or --dry-run: printed only)
-Review and commit: git add CHANGELOG.md && git commit -m "chore(release): update changelog"
-```
+Print: "Changelog updated for vX.Y.Z with N entries."
+List the sections and entry counts.
 
 ## Important
 
-- Do NOT auto-commit the changelog. User reviews first.
-- If a commit message is unclear or too long (>80 chars), truncate at word boundary + "..."
-- Skip commits with `[skip changelog]` in the message.
-- If `CHANGELOG.md` doesn't exist, create it with a standard header first.
+- Do NOT create a git commit — leave that to the user.
+- If CHANGELOG.md doesn't exist, create it with the `# Changelog` header followed by the entry.
+- Keep entries concise: one line per commit.
+- Scope is law: do not rewrite or reformat existing CHANGELOG entries.

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: changelog
+description: Generate a Keep-a-Changelog entry from commits since the last git tag. Prepends to CHANGELOG.md.
+argument-hint: "[--dry-run] [--since <tag>]"
+user-invocable: true
+allowed-tools: "Bash, Read, Edit"
+---
+
+Generate a changelog entry from commits since the last tag. Follows Keep-a-Changelog format.
+
+## Steps
+
+### 1. Find range
+
+```bash
+# Last tag (or use $ARGUMENTS --since <tag> if specified)
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+if [ -z "$LAST_TAG" ]; then
+  echo "No tags found. Using all commits."
+  RANGE="HEAD"
+else
+  echo "Last tag: $LAST_TAG"
+  RANGE="${LAST_TAG}..HEAD"
+fi
+```
+
+### 2. Collect commits
+
+```bash
+git log $RANGE --oneline --no-merges --pretty=format:"%s"
+```
+
+### 3. Group by conventional commit prefix
+
+Map commits to changelog categories:
+| Prefix | Category |
+|--------|----------|
+| `feat` | **Added** |
+| `fix` | **Fixed** |
+| `refactor` | **Changed** |
+| `docs` | **Documentation** |
+| `test` | **Testing** |
+| `chore`, `ci`, `build` | **Infrastructure** |
+| `perf` | **Performance** |
+| `security` | **Security** |
+
+Commits without a prefix go under **Changed**.
+
+Strip the `type(scope): ` prefix, capitalize first letter of the summary.
+
+### 4. Format the entry
+
+```markdown
+## [Unreleased] - YYYY-MM-DD
+
+### Added
+- ...
+
+### Fixed
+- ...
+
+### Changed
+- ...
+```
+
+Date = today (`date +%Y-%m-%d`).
+
+Only include sections that have entries. Omit empty sections.
+
+### 5. Output / write
+
+- If `$ARGUMENTS` includes `--dry-run`: print the entry to stdout only. Do NOT write to file.
+- Otherwise: prepend the entry to `CHANGELOG.md` (after the `# Changelog` header line if present).
+  - Read current `CHANGELOG.md`
+  - Insert new entry after the header (or at top if no header)
+  - Write back
+
+### 6. Report
+
+Print:
+```
+Changelog entry generated for <N> commits since <tag>.
+Categories: Added(<n>), Fixed(<n>), Changed(<n>), ...
+Written to CHANGELOG.md (or --dry-run: printed only)
+Review and commit: git add CHANGELOG.md && git commit -m "chore(release): update changelog"
+```
+
+## Important
+
+- Do NOT auto-commit the changelog. User reviews first.
+- If a commit message is unclear or too long (>80 chars), truncate at word boundary + "..."
+- Skip commits with `[skip changelog]` in the message.
+- If `CHANGELOG.md` doesn't exist, create it with a standard header first.

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: handoff
+description: Write a session summary to docs/dev-journal/ capturing branch state, decisions, open threads, and next steps.
+argument-hint: "[--push]"
+user-invocable: true
+allowed-tools: "Bash, Read, Write, Grep"
+---
+
+Write a session handoff note so the next session (or next agent) can resume without context loss.
+
+## Steps
+
+### 1. Gather state
+
+Run in parallel:
+```bash
+git branch --show-current
+git log --oneline -10
+git status --short
+git stash list
+```
+
+Also:
+```bash
+# Open PRs on this branch (if gh available)
+gh pr list --head $(git branch --show-current) --json number,title,state 2>/dev/null || echo "gh not available"
+# Uncommitted TODOs added in this session
+git diff origin/main...HEAD 2>/dev/null | grep '^+.*// TODO' | head -20
+```
+
+### 2. Identify open threads
+
+- List any tests that are failing or skipped
+- Note any `// TODO`, `// FIXME`, or `// HACK` lines added on this branch
+- Note any files edited but not committed
+- Note any decisions made this session (summarize from recent tool use context)
+
+### 3. Write the handoff file
+
+Target: `docs/dev-journal/session-YYYY-MM-DD.md`
+
+Where `YYYY-MM-DD` = today's date (`date +%Y-%m-%d`).
+
+If a file for today already exists, append to it (don't overwrite).
+
+Format:
+```markdown
+# Session Handoff — YYYY-MM-DD
+
+## Branch
+`<branch-name>`
+
+## Commits this session
+- <sha> <message>
+- ...
+
+## Open PRs
+- #<N>: <title> (<state>)
+
+## Open threads
+- [ ] <description of unfinished work>
+- [ ] <decision that needs follow-up>
+
+## TODOs added
+- `<file>:<line>` — <todo text>
+
+## Uncommitted changes
+- <file> (<status>)
+
+## Next steps
+1. <first thing to do next session>
+2. ...
+
+## Notes
+<any decisions, trade-offs, or context worth preserving>
+```
+
+### 4. Clean up
+
+- Remind: `git stash list` should be empty — stash or commit before ending
+- If `$ARGUMENTS` includes `--push` AND working tree is clean: run `/push` to push the branch
+
+### 5. Report
+
+Print:
+```
+Handoff written to docs/dev-journal/session-YYYY-MM-DD.md
+Branch: <name> | Commits: <n> | Open PRs: <n> | Open threads: <n>
+```
+
+## Important
+
+- Do NOT commit the handoff file automatically. User decides.
+- If `docs/dev-journal/` doesn't exist, create it.
+- Keep notes concise — this is for the next session, not a full PR description.

--- a/.claude/skills/sync-docs/SKILL.md
+++ b/.claude/skills/sync-docs/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: sync-docs
+description: Check for documentation drift — crate inventory vs workspace, GOLDEN_PROMPT freshness, broken doc links.
+argument-hint: "[--fix-index]"
+user-invocable: true
+allowed-tools: "Bash, Read, Grep, Glob"
+---
+
+Audit documentation drift. Reports problems; does not auto-fix (unless --fix-index).
+
+## Checks
+
+### 1. Crate inventory drift
+
+Read workspace members:
+```bash
+grep -A999 '^\[workspace\]' icn/Cargo.toml | grep '"' | grep -v '#' | sed 's/.*"\(.*\)".*/\1/'
+```
+
+Compare against crate names mentioned in:
+- `docs/planning/icn-crate-reference.md`
+- `docs/ARCHITECTURE.md` (search for `icn-` patterns)
+
+Report:
+- Crates in workspace but NOT documented
+- Crates documented but NOT in workspace (may be removed/renamed)
+
+### 2. GOLDEN_PROMPT.md freshness
+
+```bash
+# Last modification date
+git log -1 --format="%ci" -- docs/GOLDEN_PROMPT.md
+
+# Last git tag date
+git log -1 --format="%ci" $(git describe --tags --abbrev=0 2>/dev/null) 2>/dev/null || echo "no tags"
+
+# Days since last update
+python3 -c "
+from datetime import datetime, timezone
+import subprocess
+result = subprocess.run(['git','log','-1','--format=%ct','--','docs/GOLDEN_PROMPT.md'], capture_output=True, text=True)
+if result.stdout.strip():
+    ts = int(result.stdout.strip())
+    days = (datetime.now(timezone.utc).timestamp() - ts) / 86400
+    print(f'GOLDEN_PROMPT.md last updated {days:.0f} days ago')
+else:
+    print('GOLDEN_PROMPT.md: unknown modification date')
+"
+```
+
+Warn if > 14 days since last update.
+
+### 3. KNOWLEDGE_INDEX.yaml freshness
+
+Check if `docs/dev-journal/KNOWLEDGE_INDEX.yaml` exists:
+- If not: report as missing, suggest creating it
+- If exists: check `last_updated` field vs today, warn if > 7 days stale
+
+### 4. Broken internal doc links (sampled)
+
+Search for markdown links in `docs/` that reference files starting with `../` or `./`:
+```bash
+grep -rn '\]\(\.\.' docs/ --include='*.md' | head -30
+```
+
+For a sample of 10 such links, verify the target file exists. Report missing targets.
+
+### 5. docs/INDEX.md completeness
+
+Count `.md` files in `docs/`:
+```bash
+find docs/ -name '*.md' | wc -l
+```
+
+Count entries in `docs/INDEX.md`:
+```bash
+grep -c '\.md' docs/INDEX.md 2>/dev/null || echo "INDEX.md missing"
+```
+
+Report gap (files not indexed).
+
+## Output
+
+```
+=== Docs Sync Report ===
+
+Crate drift:
+  In workspace, not documented: <list or "none">
+  Documented, not in workspace: <list or "none">
+
+GOLDEN_PROMPT.md: <N> days old <WARN if > 14>
+KNOWLEDGE_INDEX.yaml: <exists/missing> <staleness>
+
+Broken links: <N> checked, <N> broken
+  - <file>:<line> -> <target> (missing)
+
+INDEX.md: <N> .md files in docs/, <N> in INDEX.md, <gap> unindexed
+```
+
+## --fix-index
+
+If `$ARGUMENTS` includes `--fix-index`:
+- Append missing doc paths to `docs/INDEX.md` under an `## Unindexed` section
+- Print: "Added <N> entries to docs/INDEX.md — review and categorize"
+- Do NOT auto-commit
+
+## Important
+
+- Report only. No auto-fixes except `--fix-index`.
+- Do not modify any Rust files.
+- If a crate is in workspace but marked as deprecated/example, note that instead of flagging as undocumented.

--- a/.claude/skills/sync-docs/SKILL.md
+++ b/.claude/skills/sync-docs/SKILL.md
@@ -12,9 +12,9 @@ Audit documentation drift. Reports problems; does not auto-fix (unless --fix-ind
 
 ### 1. Crate inventory drift
 
-Read workspace members:
+Read workspace members (parse only the `members = [...]` array to avoid picking up dependency versions and paths):
 ```bash
-grep -A999 '^\[workspace\]' icn/Cargo.toml | grep '"' | grep -v '#' | sed 's/.*"\(.*\)".*/\1/'
+grep -A999 '^\[workspace\]' icn/Cargo.toml | awk '/members *= *\[/,/\]/' | grep '"' | grep -v '#' | sed 's/.*"\(.*\)".*/\1/'
 ```
 
 Compare against crate names mentioned in:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,8 +12,8 @@ concurrency:
 jobs:
   claude-review:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    # Advisory only — SDK crashes should not block PRs
+    timeout-minutes: 20
+    # Advisory only — never blocks merge
     continue-on-error: true
     permissions:
       contents: read
@@ -25,7 +25,91 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+
+      - name: Detect change scope
+        id: scope
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null | head -60 || echo "")
+
+          DOMAIN_HINTS=""
+
+          # Kernel / app boundary
+          if echo "$CHANGED" | grep -qE 'crates/icn-(core|net|gossip|store|kernel-api)/'; then
+            DOMAIN_HINTS="${DOMAIN_HINTS}
+          - KERNEL CRATE changed: verify no domain imports (icn-trust, icn-governance, icn-ledger, icn-ccl). Kernel must only see ConstraintSet and PolicyOracle. Check firewall-guard hook logic."
+          fi
+
+          # Trust / federation
+          if echo "$CHANGED" | grep -qE 'crates/icn-(trust|federation)/|apps/trust'; then
+            DOMAIN_HINTS="${DOMAIN_HINTS}
+          - TRUST/FEDERATION scope: verify trust score math is correct, TrustPolicyOracle boundary respected, no trust semantics leaking into kernel, federation settlement defined."
+          fi
+
+          # Ledger / economics
+          if echo "$CHANGED" | grep -qE 'crates/icn-ledger/|apps/ledger'; then
+            DOMAIN_HINTS="${DOMAIN_HINTS}
+          - LEDGER scope: verify double-entry invariant (debits == credits), no negative balances without explicit overdraft policy, commons credit accounting correct, settlement dedup in place."
+          fi
+
+          # Governance / CCL
+          if echo "$CHANGED" | grep -qE 'crates/icn-(governance|ccl|community|coop)/|apps/governance'; then
+            DOMAIN_HINTS="${DOMAIN_HINTS}
+          - GOVERNANCE/CCL scope: verify quorum math, proposal lifecycle state machine, CCL determinism (same inputs → same outputs), no panics in CCL interpreter, voting weight calculation."
+          fi
+
+          # Gateway / API
+          if echo "$CHANGED" | grep -qE 'crates/icn-(gateway|rpc|api|http-kit)/'; then
+            DOMAIN_HINTS="${DOMAIN_HINTS}
+          - GATEWAY scope: verify JWT scopes enforced on all protected routes, OpenAPI spec stays in sync (run: icnctl api export-openapi), TypeScript types regenerated if API changed, no sensitive data in error responses."
+          fi
+
+          # Identity / IAM
+          if echo "$CHANGED" | grep -qE 'crates/icn-(identity|naming|authz|entity)/'; then
+            DOMAIN_HINTS="${DOMAIN_HINTS}
+          - IDENTITY scope: verify Ed25519 key operations are correct, DID format unchanged, keystore encryption intact, no key material in logs or error messages, replay protection in place."
+          fi
+
+          # Network / gossip
+          if echo "$CHANGED" | grep -qE 'crates/icn-(net|gossip|protocol)/'; then
+            DOMAIN_HINTS="${DOMAIN_HINTS}
+          - NETWORK scope: verify SignedEnvelope verification, replay guard sequence tracking, QUIC session lifecycle, gossip vector clock causal ordering, no blocking operations in async network paths."
+          fi
+
+          # Compute
+          if echo "$CHANGED" | grep -qE 'crates/icn-compute/'; then
+            DOMAIN_HINTS="${DOMAIN_HINTS}
+          - COMPUTE scope: verify fuel metering prevents infinite loops, WASM sandbox isolation, task scheduling fairness, trust-gated execution correctly enforced."
+          fi
+
+          # Security / crypto
+          if echo "$CHANGED" | grep -qE 'crates/icn-(security|crypto|crypto-pq|privacy|zkp)/'; then
+            DOMAIN_HINTS="${DOMAIN_HINTS}
+          - SECURITY/CRYPTO scope: flag for icn-security-reviewer agent. Verify constant-time comparisons for secrets, no timing side-channels, post-quantum hybrid correctness."
+          fi
+
+          # SDK / mobile
+          if echo "$CHANGED" | grep -qE '^sdk/|^web/'; then
+            DOMAIN_HINTS="${DOMAIN_HINTS}
+          - SDK/WEB scope: verify TypeScript strict mode, no any types, ICNError codes stable, auth flow correct (challenge → sign → verify → JWT), offline patterns safe."
+          fi
+
+          # Deploy / infra
+          if echo "$CHANGED" | grep -qE '^deploy/|^\.github/workflows/'; then
+            DOMAIN_HINTS="${DOMAIN_HINTS}
+          - DEPLOY/CI scope: verify no secrets committed, placeholder values only in example files, workflow changes don't weaken security gates or ratchet phases."
+          fi
+
+          if [ -z "$DOMAIN_HINTS" ]; then
+            DOMAIN_HINTS="No specific domain detected. Apply general ICN review: check 5 invariants."
+          fi
+
+          # Write to output (escape newlines for GitHub Actions)
+          HINTS_ESCAPED="${DOMAIN_HINTS//$'\n'/%0A}"
+          echo "domain_hints=$HINTS_ESCAPED" >> "$GITHUB_OUTPUT"
+          echo "changed_files=$(echo "$CHANGED" | wc -l | tr -d ' ')" >> "$GITHUB_OUTPUT"
 
       - name: Run Claude Code Review
         id: claude-review
@@ -34,4 +118,18 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.event.pull_request.number }}'
+          prompt: |
+            /code-review:code-review ${{ github.event.pull_request.number }}
+
+            ICN-specific review context (${{ steps.scope.outputs.changed_files }} files changed):
+            ${{ steps.scope.outputs.domain_hints }}
+
+            ICN invariants to enforce in ALL reviews:
+            1. Adversarial-by-default: peers are untrusted until trust established
+            2. Determinism: same inputs → same outputs in protocol paths
+            3. Canonical encodings: wire/proof formats unchanged without versioning
+            4. No panics in protocol paths: use Result<T,E>, never unwrap() in network/actor code
+            5. Kernel/app boundaries: kernel crates must not import domain crates (icn-trust, icn-governance, icn-ledger, icn-ccl)
+
+            High signal-to-noise: only surface issues that genuinely matter (bugs, security, invariant violations).
+            Skip style nits. Skip issues already caught by clippy.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,7 +32,10 @@ jobs:
         run: |
           BASE="${{ github.event.pull_request.base.sha }}"
           HEAD="${{ github.event.pull_request.head.sha }}"
-          CHANGED=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null | head -60 || echo "")
+          ALL_CHANGED=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null || true)
+          # Truncate to 60 paths for domain-hint matching; track the real total separately.
+          CHANGED=$(printf '%s' "$ALL_CHANGED" | head -60)
+          TOTAL=$(printf '%s' "$ALL_CHANGED" | grep -c . || echo 0)
 
           DOMAIN_HINTS=""
 
@@ -109,7 +112,7 @@ jobs:
           # Write to output (escape newlines for GitHub Actions)
           HINTS_ESCAPED="${DOMAIN_HINTS//$'\n'/%0A}"
           echo "domain_hints=$HINTS_ESCAPED" >> "$GITHUB_OUTPUT"
-          echo "changed_files=$(echo "$CHANGED" | wc -l | tr -d ' ')" >> "$GITHUB_OUTPUT"
+          echo "changed_files=${TOTAL}" >> "$GITHUB_OUTPUT"
 
       - name: Run Claude Code Review
         id: claude-review

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,15 +36,33 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
+          # Allow Claude to read CI results on PRs
           additional_permissions: |
             actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
+          # ICN-specific system context injected into every @claude session
+          custom_instructions: |
+            You are working on ICN (InterCooperative Network) — a P2P coordination substrate for cooperatives.
+            Rust workspace is in icn/ (not repo root). All cargo commands run from icn/.
+            Port 8080 (gateway). Never assume 8000.
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+            5 non-negotiable invariants:
+            1. Adversarial-by-default — peers untrusted until trust established
+            2. Determinism — same inputs → same outputs in protocol paths
+            3. Canonical encodings — wire formats unchanged without versioning + docs
+            4. No panics in protocol paths — use Result<T,E>, never unwrap() in network/actor code
+            5. Kernel/app boundaries — kernel crates (icn-core, icn-net, icn-gossip) must NOT import domain crates (icn-trust, icn-governance, icn-ledger, icn-ccl)
+
+            Specialist agents available (invoke via Task tool):
+            - icn-rust-core: Rust workspace implementation
+            - icn-trust-federation-advisor: trust scores, TrustPolicyOracle, federation
+            - icn-economics-advisor: ledger, mutual credit, commons credits
+            - icn-governance-advisor: governance, CCL, proposals, voting
+            - icn-identity-iam-advisor: DIDs, keystore, capabilities
+            - icn-security-reviewer: security, crypto, threat modeling
+            - icn-invariants-guardian: safety gatekeeper — run before merging risky changes
+            - icn-architect: system design, crate boundaries, API design
+
+            Scope is law — only do what was asked. Note adjacent concerns but don't act on them.
+            Concise — no long narratives, no unrequested infrastructure.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,6 +271,48 @@ When running multiple agents in parallel, each agent gets its own Git worktree w
 
 ---
 
+## Agent handoff protocol
+
+When ending a session or passing work to another agent, write a handoff note using `/handoff`.
+
+**What to capture:**
+
+```markdown
+# Session Handoff — YYYY-MM-DD
+
+## Branch
+`feat/<slug>` — base: main
+
+## Commits this session
+- <sha> <message>
+
+## Open PRs
+- #<N>: <title> (state)
+
+## Open threads
+- [ ] <unfinished work or decision needed>
+
+## TODOs added this session
+- `<file>:<line>` — <text>
+
+## Next steps
+1. <first action for next session>
+```
+
+**Rules:**
+- Write to `docs/dev-journal/session-YYYY-MM-DD.md` (append if file exists today)
+- Stash must be empty before ending — commit or drop stashes
+- If pushing, use `/push` (runs fmt + clippy gates first)
+- The handoff file is for context continuity — do not auto-commit it
+
+**Resuming from a handoff:**
+1. Read `docs/dev-journal/session-YYYY-MM-DD.md` (most recent date)
+2. Run `/preflight` to verify environment
+3. Run `git fetch origin && git rebase origin/main` if branch is stale
+4. Check open threads from the handoff note before starting new work
+
+---
+
 ## Repo-provided agent rules (must follow)
 
 - **Copilot instructions**: `.github/copilot-instructions.md`


### PR DESCRIPTION
## Summary

This PR establishes the ICN agent framework and developer experience infrastructure:

1. **Three new specialized agents** for domain-specific guidance:
   - `icn-test-generator`: Test writing specialist (icn-testkit patterns, convergence testing, property-based tests)
   - `icn-mobile-advisor`: Mobile/React Native specialist (CoopWallet, gateway auth, offline-first patterns)
   - (Existing) `icn-rust-core`: Full Rust workspace implementer

2. **Three new user-invocable skills** for session management and documentation:
   - `sync-docs`: Audit documentation drift (crate inventory, GOLDEN_PROMPT freshness, broken links)
   - `handoff`: Write session summaries to `docs/dev-journal/` for context continuity
   - `changelog`: Generate Keep-a-Changelog entries from commits since last tag

3. **Enhanced CI/CD and guardrails**:
   - Claude code review workflow now detects change scope and injects domain-specific hints
   - New pre-tool-use hooks: `scope-guard.sh` (branch scope enforcement), `todo-guard.sh` (TODO format), `panic-guard.sh` (blocking on panics in protocol paths)
   - Updated `.claude/settings.json` with expanded allowed tools and hook configuration
   - Custom instructions injected into all Claude sessions with ICN's 5 non-negotiable invariants

4. **Agent handoff protocol** documented in AGENTS.md for multi-session continuity

## Related Issues

Implements foundational agent framework and developer experience improvements for ICN project.

## Risk

- **Scope guard hook**: Advisory only (non-blocking). May warn on legitimate cross-crate changes; users can ignore if intentional.
- **Panic guard hook**: **Blocking** on `panic!()` in non-test code (ICN invariant). Warns on `.unwrap()/.expect()` outside tests.
- **TODO guard hook**: Advisory only. Enforces `// TODO(#123):` format to prevent untracked debt.
- **CI timeout increase**: 15 → 20 minutes to accommodate domain hint detection and larger diffs.

No runtime code changes; all additions are developer tooling and CI configuration.

## How

**Agents**: Each agent is a `.md` file in `.claude/agents/` with:
- Expert knowledge section (crate structure, patterns, conventions)
- Work loop (understand → plan → write → verify)
- Workspace reality (paths, commands, testing)
- Activation criteria (when to use)

**Skills**: User-invocable tools in `.claude/skills/` that:
- Run bash/grep/read operations to audit or generate
- Write output to `docs/dev-journal/` or modify files
- Support `--dry-run` or `--fix-index` flags for safety

**Hooks**: Pre-tool-use bash scripts in `.claude/hooks/` that:
- Inspect file paths and content before writes
- Emit JSON warnings or block with exit code 1
- Integrate with Claude Code settings

**CI enhancement**: Workflow now:
1. Detects changed files (git diff)
2. Maps to domain hints (kernel, trust, ledger, governance, gateway, identity, network, compute, security, SDK, deploy)
3. Injects hints into Claude review prompt
4. Increased timeout to 20 min for larger diffs

## Type of Change

- [x] New feature (agent framework, skills, guardrails)
- [x] Documentation update (AGENTS.md, agent/skill docs)
- [x] CI/CD enhancement (code review workflow, hooks)

## Testing

- No automated tests required (configuration and documentation only)
- Agents and skills are invoked manually via `/agent-name` or `/skill-name` commands
- Hooks are tested by CI on next PR that modifies Rust/TypeScript files
- Panic guard blocking behavior verified by attempting `panic!()` in non-test code (should fail)

## Checklist

- [x] Code follows project conventions (agent/skill/hook structure documented)
- [x] Documentation complete (AGENTS.md updated, agent/skill docs self-contained)
- [x

https://claude.ai/code/session_01LiuSnjVcVtnznG3WWDdmN2