### PR TITLE
feat(compute): extract CharterPriority preemption + credit ceiling to ComputePolicyConfig (s22-t2)

### DIFF
--- a/icn/crates/icn-compute/src/actor/tests.rs
+++ b/icn/crates/icn-compute/src/actor/tests.rs
@@ -1754,6 +1754,7 @@ fn commons_policy(
         preemption_enabled: false,
         credit_ceiling,
         fuel_cost_divisor: 1000,
+        ..Default::default()
     }
 }
 

--- a/icn/crates/icn-compute/src/policy.rs
+++ b/icn/crates/icn-compute/src/policy.rs
@@ -86,8 +86,18 @@ pub struct CommonsPoolPolicy {
     /// If true, higher-priority tasks can interrupt lower-priority ones.
     pub preemption_enabled: bool,
 
+    /// Charter priority modes that support task preemption.
+    ///
+    /// When `preemption_enabled` is true and the active `priority` mode is in this
+    /// list, higher-priority tasks may interrupt running lower-priority tasks.
+    /// Governance decision: cooperatives choose which modes support preemption.
+    /// Default: `[UbsFirst, EmergencyFirst]` (matches previous hardcoded behavior).
+    #[serde(default = "default_preemptable_priorities")]
+    pub preemptable_priorities: Vec<CharterPriority>,
+
     /// Credit ceiling for cost validation.
     /// Tasks whose estimated cost exceeds available credits are rejected.
+    /// `None` disables ceiling enforcement. Set via governance config.
     #[serde(default)]
     pub credit_ceiling: Option<i64>,
 
@@ -102,6 +112,10 @@ fn default_fuel_cost_divisor() -> u64 {
     1000
 }
 
+fn default_preemptable_priorities() -> Vec<CharterPriority> {
+    vec![CharterPriority::UbsFirst, CharterPriority::EmergencyFirst]
+}
+
 impl Default for CommonsPoolPolicy {
     fn default() -> Self {
         Self {
@@ -109,6 +123,7 @@ impl Default for CommonsPoolPolicy {
             priority: CharterPriority::default(),
             max_concurrent_per_submitter: 5,
             preemption_enabled: false,
+            preemptable_priorities: default_preemptable_priorities(),
             credit_ceiling: None,
             fuel_cost_divisor: default_fuel_cost_divisor(),
         }
@@ -165,16 +180,17 @@ impl CommonsPoolPolicy {
 
     /// Check if a new task can preempt a running task.
     ///
-    /// Returns `true` if preemption is enabled and the new task has
-    /// sufficiently higher priority to justify interrupting the running task.
+    /// Returns `true` if preemption is enabled, the active priority mode is in
+    /// the governance-configured `preemptable_priorities` list, and the new task
+    /// has strictly higher priority than the running task.
     pub fn can_preempt(&self, new_task: &ComputeTask, running_task: &ComputeTask) -> bool {
         // Preemption must be enabled
         if !self.preemption_enabled {
             return false;
         }
 
-        // Priority policy must allow preemption
-        if !self.priority.allows_preemption() {
+        // Priority policy must be in the governance-configured preemptable set
+        if !self.preemptable_priorities.contains(&self.priority) {
             return false;
         }
 
@@ -1620,6 +1636,7 @@ mod tests {
             preemption_enabled: true,
             credit_ceiling: Some(1000),
             fuel_cost_divisor: 1000,
+            ..Default::default()
         };
 
         let json = serde_json::to_string(&policy).unwrap();

--- a/icn/crates/icn-core/src/config/compute.rs
+++ b/icn/crates/icn-core/src/config/compute.rs
@@ -13,6 +13,8 @@
 //! min_standing = 0.3           # Min trust standing to submit to commons pool
 //! min_trust_score = 0.1        # Min trust score for sybil admission
 //! fuel_cost_divisor = 1000     # Fuel units per credit (1 credit per N fuel)
+//! credit_ceiling = 5000        # Optional: max credits a submitter may spend (omit to disable)
+//! preemptable_priorities = ["ubs_first", "emergency_first"]  # Modes that allow preemption
 //!
 //! # Task result verification settings
 //! [compute.verification]
@@ -52,6 +54,20 @@ pub struct ComputePolicyConfig {
     /// Original hardcoded value: 1000
     #[serde(default = "default_fuel_cost_divisor")]
     pub fuel_cost_divisor: u64,
+
+    /// Credit ceiling for cost validation (in credit units).
+    /// Tasks whose estimated cost exceeds available credits are rejected.
+    /// `None` (default) disables ceiling enforcement.
+    #[serde(default)]
+    pub credit_ceiling: Option<i64>,
+
+    /// Charter priority modes that allow task preemption.
+    ///
+    /// When preemption is enabled and the active charter priority is in this list,
+    /// higher-priority tasks may interrupt running lower-priority tasks.
+    /// Default: `[ubs_first, emergency_first]` (previous hardcoded behavior).
+    #[serde(default = "default_preemptable_priorities")]
+    pub preemptable_priorities: Vec<icn_compute::CharterPriority>,
 }
 
 fn default_min_standing() -> f64 {
@@ -66,12 +82,21 @@ fn default_fuel_cost_divisor() -> u64 {
     1000
 }
 
+fn default_preemptable_priorities() -> Vec<icn_compute::CharterPriority> {
+    vec![
+        icn_compute::CharterPriority::UbsFirst,
+        icn_compute::CharterPriority::EmergencyFirst,
+    ]
+}
+
 impl Default for ComputePolicyConfig {
     fn default() -> Self {
         Self {
             min_standing: default_min_standing(),
             min_trust_score: default_min_trust_score(),
             fuel_cost_divisor: default_fuel_cost_divisor(),
+            credit_ceiling: None,
+            preemptable_priorities: default_preemptable_priorities(),
         }
     }
 }
@@ -327,5 +352,52 @@ low_value_threshold = 150
         // Consensus threshold should be between 0 and 1
         assert!(config.consensus_threshold > 0.0);
         assert!(config.consensus_threshold <= 1.0);
+    }
+
+    #[test]
+    fn test_compute_policy_config_defaults() {
+        let config = ComputePolicyConfig::default();
+        assert!((config.min_standing - 0.3).abs() < f64::EPSILON);
+        assert!((config.min_trust_score - 0.1).abs() < f64::EPSILON);
+        assert_eq!(config.fuel_cost_divisor, 1000);
+        assert!(config.credit_ceiling.is_none());
+        assert_eq!(config.preemptable_priorities.len(), 2);
+        assert!(config
+            .preemptable_priorities
+            .contains(&icn_compute::CharterPriority::UbsFirst));
+        assert!(config
+            .preemptable_priorities
+            .contains(&icn_compute::CharterPriority::EmergencyFirst));
+    }
+
+    #[test]
+    fn test_compute_policy_config_credit_ceiling_toml() {
+        let toml_str = r#"
+[policy]
+credit_ceiling = 5000
+"#;
+        let config: ComputeConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.policy.credit_ceiling, Some(5000));
+        // Other fields use defaults
+        assert!((config.policy.min_standing - 0.3).abs() < f64::EPSILON);
+        assert_eq!(config.policy.fuel_cost_divisor, 1000);
+    }
+
+    #[test]
+    fn test_compute_policy_config_preemptable_priorities_toml() {
+        let toml_str = r#"
+[policy]
+preemptable_priorities = ["emergency_first"]
+"#;
+        let config: ComputeConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.policy.preemptable_priorities.len(), 1);
+        assert!(config
+            .policy
+            .preemptable_priorities
+            .contains(&icn_compute::CharterPriority::EmergencyFirst));
+        assert!(!config
+            .policy
+            .preemptable_priorities
+            .contains(&icn_compute::CharterPriority::UbsFirst));
     }
 }

--- a/icn/crates/icn-core/src/supervisor/init_compute.rs
+++ b/icn/crates/icn-core/src/supervisor/init_compute.rs
@@ -364,11 +364,14 @@ pub async fn init_compute_services(deps: ComputeDeps) -> anyhow::Result<ComputeS
     compute_actor.set_policy_manager(policy_manager.clone());
 
     // Apply governance policy thresholds from config.
-    // min_standing and fuel_cost_divisor go into CommonsPoolPolicy (submission gate).
+    // min_standing, fuel_cost_divisor, credit_ceiling, and preemptable_priorities
+    // go into CommonsPoolPolicy (submission gate + preemption control).
     // min_trust_score goes into SybilPolicy (pool admission gate).
     let commons_pool_policy = icn_compute::CommonsPoolPolicy {
         min_standing: deps.policy_config.min_standing,
         fuel_cost_divisor: deps.policy_config.fuel_cost_divisor,
+        credit_ceiling: deps.policy_config.credit_ceiling,
+        preemptable_priorities: deps.policy_config.preemptable_priorities.clone(),
         ..icn_compute::CommonsPoolPolicy::default()
     };
     compute_actor.set_commons_pool_policy(commons_pool_policy);
@@ -380,10 +383,12 @@ pub async fn init_compute_services(deps: ComputeDeps) -> anyhow::Result<ComputeS
     compute_actor.set_commons_sybil_policy(sybil_policy);
 
     info!(
-        "Policy manager initialized (min_standing={}, min_trust_score={}, fuel_cost_divisor={})",
+        "Policy manager initialized (min_standing={}, min_trust_score={}, fuel_cost_divisor={}, credit_ceiling={:?}, preemptable_priorities={:?})",
         deps.policy_config.min_standing,
         deps.policy_config.min_trust_score,
-        deps.policy_config.fuel_cost_divisor
+        deps.policy_config.fuel_cost_divisor,
+        deps.policy_config.credit_ceiling,
+        deps.policy_config.preemptable_priorities
     );
 
     // Spawn DisputeActor with shared system


### PR DESCRIPTION
## Summary
- Adds `preemptable_priorities: Vec<CharterPriority>` to `CommonsPoolPolicy` replacing hardcoded `allows_preemption()` logic
- Adds `credit_ceiling: Option<i64>` to `ComputePolicyConfig` and wires through `init_compute.rs`
- Extends `can_preempt()` to use config-driven preemptable set
- 3 new tests in `config::compute` covering both new fields

## Why
Meaning Firewall Sprint 22 (s22-t2): two violations remained in `icn-compute`:
1. `CharterPriority::allows_preemption()` hardcoded `UbsFirst | EmergencyFirst` as kernel policy — preemption eligibility is a governance decision
2. `credit_ceiling` in `CommonsPoolPolicy` had no path from `ComputePolicyConfig`, so operators couldn't set it via config

## Risk
Low. All defaults match previous hardcoded behavior. Legacy `CharterPriority::allows_preemption()` method is still present for external callers.

## Test plan
- `cargo test -p icn-compute --lib` — 351 tests pass
- `cargo test -p icn-core --lib config::compute` — 10 tests pass (3 new)
- `cargo check --workspace` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)