### PR TITLE
fix(ci): make sync-stats push non-fatal on branch protection

### DIFF
--- a/.github/workflows/sync-stats.yml
+++ b/.github/workflows/sync-stats.yml
@@ -30,6 +30,11 @@ jobs:
         run: node website/scripts/gen-stats.mjs
 
       - name: Commit if changed
+        # stats.json is gitignored and regenerated at build time, so a failed push
+        # (e.g. branch protection requires PRs) is non-fatal — the file is always
+        # fresh at deploy time. continue-on-error prevents the daily cron from
+        # turning red when GITHUB_TOKEN cannot bypass protected-branch rules.
+        continue-on-error: true
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary

- `GITHUB_TOKEN` cannot push directly to `main` when branch protection requires PR status checks
- Daily cron was failing with `GH006: Protected branch update failed for refs/heads/main`
- `stats.json` is gitignored and regenerated fresh at every website deploy, so a failed cache-warming commit is non-fatal
- Added `continue-on-error: true` to the "Commit if changed" step

## Test plan

- [ ] Verify `Sync Website Stats` workflow no longer fails when push is rejected by branch protection
- [ ] Confirm website deploy still generates fresh `stats.json` at build time

🤖 Generated with [Claude Code](https://claude.com/claude-code)