### PR TITLE
chore(skills): add repo-aware operational skill layer

### DIFF
--- a/.claude/skills/fix-rust-lints/SKILL.md
+++ b/.claude/skills/fix-rust-lints/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: fix-rust-lints
+description: Classify clippy/compiler failures by lint family and apply canonical idiomatic fixes.
+argument-hint: "[lint output | --scan]"
+user-invocable: true
+allowed-tools: "Bash, Read, Edit, Grep"
+---
+
+Turn recurring Rust lint failures into known remediation classes. Never debug clippy from scratch.
+
+## The Problem This Solves
+
+The transcript discovered two lint patterns mid-run and fixed them ad hoc. Those same patterns
+will recur. This skill pre-encodes them as named classes with canonical fix shapes so the model
+stops relearning under pressure.
+
+## Steps
+
+1. **Collect failures**: If `$ARGUMENTS` is empty, run:
+   ```bash
+   cargo clippy --workspace --all-targets -- -D warnings 2>&1 | grep "^error"
+   ```
+   Or read from provided output.
+
+2. **Classify each error** by lint name (appears in brackets after `error:`):
+   ```bash
+   cargo clippy ... 2>&1 | grep -E "^error\[|^\s+-->"
+   ```
+
+3. **Apply canonical fix** from the playbook below.
+
+4. **Scan for recurrences** of the same anti-pattern in nearby code:
+   ```bash
+   grep -rn "<pattern>" crates/ apps/ bins/
+   ```
+
+5. **Verify**: Re-run the scoped clippy command to confirm the fix.
+
+---
+
+## Lint Remediation Playbook
+
+### `field_reassign_with_default`
+
+**Trigger**: `let mut x = T::default(); x.field = value;`
+
+**Canonical fix**: Struct update syntax
+```rust
+// BEFORE
+let mut cfg = FooConfig::default();
+cfg.some_field = new_value;
+
+// AFTER
+let cfg = FooConfig {
+    some_field: new_value,
+    ..Default::default()
+};
+```
+
+**Why**: Removes the `mut` binding, signals intent at construction, eliminates post-init mutation.
+
+**Scan for recurrences**:
+```bash
+grep -rn "let mut .* = .*::default();" crates/ apps/ bins/ --include="*.rs"
+```
+
+---
+
+### Deprecated item in `--all-targets` (test code)
+
+**Trigger**: `use of deprecated ...` in test modules when compiling with `--all-targets -D warnings`
+
+**Root cause**: `#[deprecated]` is transitive. CI uses `--all-targets`, which compiles test code.
+A deprecated constant marked in a library still fires as an error wherever test code references it,
+even if the non-test code is clean.
+
+**Canonical fix**: Replace deprecated references with the recommended replacement, even in tests.
+Do NOT use `#[allow(deprecated)]` unless the replacement doesn't exist yet.
+
+```rust
+// BEFORE (in test)
+membership_age_secs: MIN_MEMBERSHIP_AGE_SECS + 1,
+
+// AFTER
+membership_age_secs: AttestationThresholds::default().min_membership_age_secs + 1,
+```
+
+**Scan for recurrences**:
+```bash
+# Find uses of deprecated constants in test modules
+grep -rn "MIN_MEMBERSHIP_AGE_SECS\|MAX_ATTESTATIONS_PER_PERIOD\|MIN_TRUST_TO_ATTEST" \
+  crates/ apps/ --include="*.rs" | grep -v "pub const\|#\[deprecated"
+```
+
+**Re-export workaround**: When a module re-exports deprecated items for backward compat,
+add `#[allow(deprecated)]` on the `pub use` block only, not on callers:
+```rust
+#[allow(deprecated)]
+pub use attestation::{LEGACY_CONST, old_function};
+```
+
+---
+
+### `clippy::unwrap_used` / `clippy::expect_used` in tests
+
+**Trigger**: `error: used unwrap() on a Result value` in test code
+
+**Canonical fix**: Add workspace-level test allowance or use `#![cfg_attr(test, allow(...))]`
+in the crate root. Do NOT sprinkle `#[allow]` throughout test functions.
+
+```rust
+// In lib.rs crate root:
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+```
+
+---
+
+### `clippy::too_many_arguments`
+
+**Trigger**: Function has 8+ parameters.
+
+**Canonical fix**: Either group related params into a config struct, or accept the lint suppression
+if the function is a one-off constructor:
+```rust
+// Group into struct when params are logically related
+pub fn build_policy(config: PolicyConfig) -> Policy { ... }
+
+// Or suppress if it's an internal constructor unlikely to be called repeatedly
+#[allow(clippy::too_many_arguments)]
+pub fn new_internal(a: T, b: U, ...) -> Self { ... }
+```
+
+**ICN note**: Prefer the config struct approach for any function that appears in lifecycle.rs,
+since those wire multiple values from config objects.
+
+---
+
+### `clippy::missing_errors_doc` / `clippy::missing_panics_doc`
+
+**Trigger**: Public function lacks `# Errors` / `# Panics` doc section.
+
+**Canonical fix**: Add the section, or suppress at crate level with `#![allow(missing_docs)]`
+if the crate already has that allowance:
+```rust
+/// Does the thing.
+///
+/// # Errors
+/// Returns `Err` if the configuration is invalid.
+pub fn do_thing(&self) -> Result<(), String> { ... }
+```
+
+---
+
+### Overflow / underflow in time arithmetic
+
+**Trigger**: `SystemTime` subtraction that can underflow, or `u64::checked_mul` missing.
+
+**Canonical fix**:
+```rust
+// BEFORE (panics on underflow in debug mode)
+let cutoff = now - duration;
+
+// AFTER
+let cutoff = now.checked_sub(duration).unwrap_or(SystemTime::UNIX_EPOCH);
+
+// For u64 multiplication that might overflow:
+let secs = days.checked_mul(SECONDS_PER_DAY).unwrap_or(u64::MAX);
+```
+
+---
+
+## Guardrails
+
+- Never suppress a lint without understanding its class. Find the canonical fix first.
+- Prefer fixing the anti-pattern to suppressing the warning.
+- After fixing, scan for the same pattern in nearby code before committing.
+- A fix that passes local `cargo clippy -p <crate>` may still fail CI `--workspace --all-targets`.
+  Always scope-check with `--all-targets` before declaring victory.

--- a/.claude/skills/integrate-pr-stack/SKILL.md
+++ b/.claude/skills/integrate-pr-stack/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: integrate-pr-stack
+description: Full sprint-batch or stacked-PR integration pipeline. Owns merge order, rebases, local gates, and main sync.
+argument-hint: "[PR numbers...] [--admin] [--dry-run]"
+user-invocable: true
+allowed-tools: "Bash, Read"
+---
+
+Own the full lifecycle of safely integrating a batch of PRs into `main`. This is not a thin wrapper
+around `gh pr merge`. It is the standard integration pipeline for ICN sprint closes.
+
+## The Problem This Solves
+
+The transcript improvised rebase sequencing, rediscovered branch names mid-flight, and had to
+manually orchestrate the merge order. This skill makes that the default path, not a recovery.
+
+## Steps
+
+### Phase 1: Resolve and classify
+
+For each PR in `$ARGUMENTS` (or all open PRs if none given):
+
+```bash
+# Resolve head branches from GitHub — never trust plan docs
+gh pr list --json number,title,headRefName,baseRefName,mergeable,mergeStateStatus \
+  --jq '.[] | {pr:.number, title:.title, head:.headRefName, base:.baseRefName, mergeable:.mergeable, state:.mergeStateStatus}'
+```
+
+For each PR, fetch required check status:
+```bash
+gh api repos/InterCooperative-Network/icn/branches/main/protection \
+  --jq '.required_status_checks.contexts'
+```
+
+Then for each PR:
+```bash
+gh pr checks <N> --json name,state,conclusion \
+  | python3 -c "
+import sys, json
+required = {'Build Release','Test','Clippy','Format Check'}
+checks = json.load(sys.stdin)
+req = [(c['name'],c['state'],c['conclusion']) for c in checks if c['name'] in required]
+opt = [(c['name'],c['state'],c['conclusion']) for c in checks if c['name'] not in required and c['conclusion']=='failure']
+print('REQUIRED:', req)
+print('NON-BLOCKING FAILURES:', opt)
+"
+```
+
+Classify each PR:
+- **GREEN**: all required checks pass, `mergeable=MERGEABLE`
+- **PENDING**: required checks still running
+- **BLOCKED**: a required check failed
+- **UNSTABLE**: only non-blocking checks failed — treat as GREEN for merge purposes
+- **STACKED**: base ≠ main — must be merged after its base PR
+
+### Phase 2: Determine merge order
+
+1. Identify stacked PRs (base ≠ main) and sort them after their dependencies.
+2. Among independent PRs, merge smallest/least-risky first.
+3. If `--dry-run`, print the plan and stop.
+
+Suggested ICN ordering heuristic (from sprint patterns):
+- Security/obs (isolated, small) → compute (isolated) → ledger (medium) → docs/meta (last)
+
+### Phase 3: Integrate loop
+
+For each PR in merge order:
+
+**a. Pre-merge checks**
+```bash
+gh pr view <N> --json mergeable,mergeStateStatus \
+  --jq '"mergeable=\(.mergeable) state=\(.mergeStateStatus)"'
+```
+Stop if `mergeable != MERGEABLE`.
+
+**b. Merge**
+```bash
+# Green required checks → direct merge
+gh pr merge <N> --merge          # or --merge --admin if $ARGUMENTS includes --admin
+
+# Pending required checks → auto-merge (prefer --auto over waiting in a loop)
+gh pr merge <N> --auto --merge
+```
+
+**c. Pull main**
+```bash
+git checkout main && git pull
+```
+
+**d. Rebase remaining PR branches**
+For each remaining PR branch:
+```bash
+git checkout <branch> && git rebase origin/main
+```
+
+After rebase, run scoped local verification before force-pushing:
+```bash
+# Use resolve-rust-targets to find the right scope
+cargo clippy -p <affected-packages> --all-targets -- -D warnings
+```
+
+Only force-push if verification passes:
+```bash
+git push --force-with-lease
+```
+
+**e. Log progress**: `#<N> merged · rebased [branch1, branch2]`
+
+### Phase 4: Finalize
+
+```bash
+# Confirm main state
+git checkout main && git log --oneline -5
+
+# Check for main CI fallout
+gh run list --branch main --limit 3 --json status,conclusion,name,databaseId \
+  --jq '.[] | "\(.databaseId) \(.name) \(.status) \(.conclusion)"'
+```
+
+Print batch summary:
+```
+Merged:   #1389, #1391, #1392, #1390
+Rebased:  feat/s22-compute-policy-config (after #1389), feat/s22-obs-attestation-config (after #1391)
+Main CI:  in_progress (non-blocking only)
+Lessons:  none new
+```
+
+## Guardrails
+
+- **Never trust branch names from plan docs.** Always resolve from `gh pr view <N> --json headRefName`.
+- **UNSTABLE ≠ blocked.** If required checks are green and `mergeable=MERGEABLE`, merge.
+- **After every rebase, run scoped local verification before force-pushing.** The rebase may have
+  introduced new base-crate changes that affect the branch's compilation.
+- **Never skip `git pull` after each merge.** Subsequent rebases need an updated local main.
+- **Stacked PRs must merge in dependency order.** If PR B has base = PR A's branch, merge A first,
+  then update B's base to main before merging B.
+- **`--admin` is for queue-stalled runners only**, not for bypassing genuine failures.
+  Confirm required gates are actually green before using `--admin`.
+
+## ICN-specific notes
+
+- Required gates: `Build Release`, `Test`, `Clippy`, `Format Check` (from branch protection API).
+- Non-blocking: `Test Coverage`, `Compare Against Base`, `Benchmarks`, `claude-review`.
+- Single self-hosted runner (`ci-runner` at 10.8.30.46) means parallel PRs queue up. A PR
+  showing `pending / 0s` for >30 min is likely queue-stalled, not failing.
+- `mergeStateStatus=UNSTABLE` with `mergeable=MERGEABLE` means only non-blocking checks failed.
+  Safe to merge with `--admin`.
+- After merging multiple PRs in sequence, expect CI on main to run the full workspace build.
+  That's normal — not a sign of regression.

--- a/.claude/skills/merge-prs/SKILL.md
+++ b/.claude/skills/merge-prs/SKILL.md
@@ -1,32 +1,87 @@
 ---
 name: merge-prs
-description: Merge one or more PRs. No polling loops. Uses gh --json. Prefer --auto, use --admin when told.
-argument-hint: "[PR numbers...] [--admin]"
+description: Merge one or more PRs with full stack-integration pipeline. Resolves branches, rebases, gates, pulls main.
+argument-hint: "[PR numbers...] [--admin] [--dry-run]"
 user-invocable: true
 allowed-tools: "Bash"
 ---
 
-Merge PRs. No polling. No tabular parsing. One line per PR.
+Stack-integration merge pipeline. Not a thin `gh pr merge` wrapper. Owns branch resolution,
+merge ordering, post-merge rebases, local verification, and main sync.
+
+For single quick merges when you already know the state is clean, this still works. For sprint
+batch closes, use `/integrate-pr-stack` instead (same logic, more verbose output).
 
 ## Steps
 
-1. List target PRs:
-   - If `$ARGUMENTS` specifies PR numbers, use those.
-   - Otherwise: `gh pr list --json number,title,headRefName,statusCheckRollup --limit 20`
-   - If zero open PRs, print "0 open PRs" and stop.
+1. **Resolve PRs to merge**:
+   - If `$ARGUMENTS` specifies numbers, use those.
+   - Otherwise list open PRs: `gh pr list --json number,title,headRefName,mergeable,mergeStateStatus`
+   - If zero open PRs, stop.
 
-2. For each PR, in order:
-   a. Get status: `gh pr view <N> --json number,title,mergeable,statusCheckRollup`
-   b. If checks are green → `gh pr merge <N> --merge`
-   c. If checks are pending/running → `gh pr merge <N> --auto --merge` (let GitHub merge when green)
-   d. If `$ARGUMENTS` includes `--admin` → use `gh pr merge <N> --merge --admin`
-   e. If merge fails, print one-line error and continue to next PR.
+2. **For each PR, resolve head branch from GitHub** (never trust plan names):
+   ```bash
+   gh pr view <N> --json number,title,headRefName,baseRefName,mergeable,mergeStateStatus \
+     --jq '{pr:.number, head:.headRefName, base:.baseRefName, mergeable:.mergeable, state:.mergeStateStatus}'
+   ```
 
-3. After all PRs: `git checkout main && git pull`
+3. **Classify check state** (required gates only):
+   ```bash
+   gh pr checks <N> --json name,state,conclusion \
+     | python3 -c "
+   import sys, json
+   required = {'Build Release','Test','Clippy','Format Check'}
+   checks = json.load(sys.stdin)
+   req_states = {c['name']:c['conclusion'] or c['state'] for c in checks if c['name'] in required}
+   all_pass = all(v in ('SUCCESS','success') for v in req_states.values())
+   print('required:', req_states, '→', 'GREEN' if all_pass else 'NOT READY')
+   " 2>/dev/null || echo "checks unavailable"
+   ```
+
+   - `UNSTABLE` + required all pass → treat as GREEN, safe to merge
+   - `MERGEABLE` + required pending → use `--auto` or wait
+
+4. **Merge** (in order provided; smallest/safest first for batch):
+   ```bash
+   gh pr merge <N> --merge              # green required checks
+   gh pr merge <N> --merge --admin      # if $ARGUMENTS includes --admin (queue-stalled)
+   gh pr merge <N> --auto --merge       # pending required checks
+   ```
+
+5. **After each merge**:
+   ```bash
+   git checkout main && git pull
+   ```
+
+6. **Rebase remaining PR branches** after each merge to keep them current:
+   ```bash
+   gh pr view <remaining-N> --json headRefName --jq '.headRefName'   # resolve branch
+   git checkout <branch> && git rebase origin/main
+   # Run scoped clippy before force-pushing
+   cargo clippy -p <affected-packages> --all-targets -- -D warnings
+   git push --force-with-lease
+   ```
+
+7. **Final**: confirm main state, print one-line summary per PR.
+
+## Output format
+
+```
+#1389 merged · rebased [feat/s22-compute-policy-config, feat/s22-obs-attestation-config]
+#1391 merged · rebased [feat/s22-obs-attestation-config]
+#1390 merged · rebased []
+```
 
 ## Rules
 
-- **No polling loops.** Never `while true; sleep; done`. Use `--auto` for pending checks.
-- **No tabular parsing.** Always `--json` flag, parse with `jq` or python3.
-- **One line per PR**: `#123 merged` or `#123 failed: <reason>` or `#123 --auto set`.
-- Max 20 lines total output.
+- **No polling loops.** Use `--auto` for pending checks; use `--admin` for queue-stalled (not failing).
+- **No tabular parsing.** Always `--json` with `jq` or `python3`.
+- **UNSTABLE ≠ blocked.** Required checks green + `mergeable=MERGEABLE` → merge.
+- **Always resolve head branch from GitHub.** Never use plan-doc branch names directly.
+- **After each merge, rebase remaining branches.** Verify locally before force-push.
+
+## Required checks (from branch protection)
+
+`Build Release`, `Test`, `Clippy`, `Format Check`
+
+Non-blocking (don't block merge): `Test Coverage`, `Compare Against Base`, `Benchmarks`, `claude-review`

--- a/.claude/skills/push/SKILL.md
+++ b/.claude/skills/push/SKILL.md
@@ -1,33 +1,97 @@
 ---
 name: push
-description: Run fmt + clippy gates, then push. The only sanctioned path for pushing Rust changes.
+description: Resolve targets, run scoped local gates, then push. The only sanctioned path for pushing Rust changes.
 argument-hint: "[--skip-test] [--force-with-lease]"
 user-invocable: true
 allowed-tools: "Bash"
 ---
 
-Gated push: runs fmt and clippy before allowing push. This is the sanctioned path for pushing Rust workspace changes.
+Gated push with scoped verification. Resolves affected packages first, runs the minimum sufficient
+gate set, classifies any lint failures by known remediation class, then pushes.
 
 ## Steps
 
-1. Confirm current branch and remote tracking:
-   - `git branch --show-current`
-   - `git status --short`
-2. Run gates (all must pass):
-   - `cd icn && cargo fmt --all --check`
-   - `cd icn && cargo clippy --workspace --all-targets -- -D warnings`
-3. If `$ARGUMENTS` does NOT include `--skip-test`:
-   - `cd icn && cargo test --workspace`
-4. If any gate fails:
-   - Report which gate failed and the output
-   - Do NOT push
-   - Suggest fix commands
-5. If all gates pass:
-   - `git push` (or `git push --force-with-lease` if `$ARGUMENTS` includes `--force-with-lease`)
-6. Report: pushed branch, commit SHA, gate results.
+1. **Confirm branch and status**:
+   ```bash
+   git branch --show-current
+   git status --short
+   ```
+
+2. **Resolve touched packages** to determine verification scope:
+   ```bash
+   # Files changed on this branch
+   git diff --name-only $(git merge-base HEAD origin/main)..HEAD
+
+   # Map to workspace package names (never guess)
+   cargo metadata --no-deps --format-version 1 \
+     | python3 -c "
+   import sys, json
+   md = json.load(sys.stdin)
+   for p in md['packages']:
+       root = p['manifest_path'].replace('/Cargo.toml','')
+       print(f\"{p['name']:40s}  {root}\")
+   " | sort
+   ```
+
+   Scope decision:
+   - Changes in 1–3 packages → scoped commands (faster)
+   - Changes include `icnd/src/main.rs`, `lifecycle.rs`, or cross multiple crate boundaries → workspace-wide
+
+3. **Run format check** (always workspace-wide, fast):
+   ```bash
+   cargo fmt --all --check
+   ```
+
+4. **Run clippy** (scoped if possible):
+   ```bash
+   # Scoped (preferred — must use --all-targets to match CI):
+   cargo clippy -p <pkg1> -p <pkg2> --all-targets -- -D warnings
+
+   # Workspace (when cross-cutting):
+   cargo clippy --workspace --all-targets -- -D warnings
+   ```
+
+   On failure, classify before fixing (see `fix-rust-lints` for canonical patterns):
+   - `field_reassign_with_default` → struct update syntax
+   - `use of deprecated` in tests → replace with recommended API
+   - Overflow/underflow in time math → use `checked_sub` / `checked_mul`
+
+5. **Run tests** (unless `$ARGUMENTS` includes `--skip-test`):
+   ```bash
+   cargo test -p <pkg1> -p <pkg2>   # scoped
+   cargo test --workspace            # workspace
+   ```
+
+6. **If any gate fails**: report lint class and canonical fix, do NOT push.
+
+7. **If all gates pass**:
+   ```bash
+   git push                         # normal push
+   git push -u origin <branch>      # first push (no upstream)
+   git push --force-with-lease      # after rebase (if $ARGUMENTS includes --force-with-lease)
+   ```
+
+8. **Report**: pushed branch, commit SHA, scope used, gate results.
 
 ## Important
 
 - Never push if fmt or clippy fails.
-- `--skip-test` skips the test suite (for speed when tests were already run). fmt + clippy always run.
-- If the branch has no upstream, use `git push -u origin <branch>`.
+- `--skip-test` skips the test suite. fmt + clippy always run.
+- A local `cargo clippy -p <crate>` pass does NOT guarantee `--workspace --all-targets` passes.
+  Use `--all-targets` to match CI behavior.
+- After a rebase, always re-run at minimum scoped clippy before force-pushing.
+- Never guess package IDs. Use `cargo metadata` to confirm. See known confusions below.
+
+## Known ICN package name confusions
+
+| Human label | Correct `-p` argument |
+|-------------|----------------------|
+| "ledger" (crate) | `icn-ledger` |
+| "ledger app" / "icn-ledger-app" | `icn-ledger-actor` (apps/ledger) |
+| "obs" | `icn-obs` |
+| "security" | `icn-security` |
+| "compute" | `icn-compute` |
+| "core" | `icn-core` |
+| "daemon" / "icnd" | `icnd` (bin — triggers workspace-wide) |
+| "governance app" | `icn-governance-actor` |
+| "membership app" | `icn-membership-app` |

--- a/.claude/skills/repair-gh-workflow/SKILL.md
+++ b/.claude/skills/repair-gh-workflow/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: repair-gh-workflow
+description: Diagnose and fix GitHub Actions failures with branch protection, token permissions, and repo policy in mind.
+argument-hint: "[workflow name | run ID | --main]"
+user-invocable: true
+allowed-tools: "Bash, Read, Edit"
+---
+
+Diagnose GitHub Actions failures that involve branch protection, token permissions, or workflow design.
+Start with the protection model, not with the error message alone.
+
+## The Problem This Solves
+
+The transcript's `Sync Website Stats` cron workflow failed daily with `GH006: Protected branch update
+failed`. The fix was clear once branch protection was checked: `GITHUB_TOKEN` cannot push to protected
+`main` regardless of `permissions: contents: write`. That constraint should be known upfront, not
+discovered after a failure has been running for days.
+
+## Steps
+
+### Phase 1: Identify failure context
+
+```bash
+# Find recent failures on main
+gh run list --branch main --limit 10 --json status,conclusion,name,databaseId,createdAt \
+  --jq '.[] | select(.conclusion == "failure") | "\(.databaseId) \(.name) \(.createdAt)"'
+
+# Get failed job and step
+gh api repos/InterCooperative-Network/icn/actions/runs/<RUN_ID>/jobs \
+  --jq '.jobs[] | select(.conclusion == "failure") | {name:.name, steps:[.steps[] | select(.conclusion=="failure") | .name]}'
+```
+
+### Phase 2: Classify failure type
+
+| Error pattern | Class | Fix direction |
+|---------------|-------|---------------|
+| `GH006: Protected branch update failed` | Permission | Don't push to main directly; use PAT or make non-fatal |
+| `remote: Repository not found` | Auth | Token scope or GITHUB_TOKEN missing repo access |
+| `Resource not accessible by integration` | Token scope | Add `permissions:` block to workflow |
+| Exit code 1 on `git push` | Permission or protection | Check branch protection + token capability |
+| Timeout / no logs | Runner contention | Self-hosted runner busy; not a code failure |
+| Missing step output | Upstream step skipped | Check `if:` conditions in prior steps |
+
+### Phase 3: Check branch protection before patching
+
+Always verify the actual protection model before deciding on a fix:
+
+```bash
+gh api repos/InterCooperative-Network/icn/branches/main/protection \
+  --jq '{
+    required_checks: .required_status_checks.contexts,
+    strict: .required_status_checks.strict,
+    enforce_admins: .enforce_admins.enabled,
+    required_approvals: .required_pull_request_reviews.required_approving_review_count
+  }'
+```
+
+**The critical invariant for ICN main**:
+- `GITHUB_TOKEN` (even with `contents: write`) cannot push directly to `main` when `required_status_checks`
+  are set, because the push bypasses the check gates.
+- Only a PAT from an account with admin bypass (and `enforce_admins: false`) can push directly.
+
+### Phase 4: Apply fix by class
+
+**Class: write-back is essential** (data must land in the repo)
+→ Use a PR-based flow:
+```yaml
+- name: Create PR with updated stats
+  run: |
+    git checkout -b chore/update-stats-$(date +%Y%m%d)
+    git commit -m "chore: update stats.json [skip ci]"
+    git push -u origin HEAD
+    gh pr create --title "chore: update stats.json" --body "Automated." --base main
+```
+
+**Class: write-back is a cache warm** (artifact regenerated elsewhere)
+→ Make the push step non-fatal:
+```yaml
+- name: Commit if changed
+  continue-on-error: true   # ← push may be rejected by branch protection; that's OK
+  run: |
+    git add -f path/to/generated-file
+    git diff --quiet --cached || git commit -m "chore: update [skip ci]" && git push
+```
+
+**Class: write-back requires admin**
+→ Add a PAT secret and use it in checkout:
+```yaml
+- uses: actions/checkout@v4
+  with:
+    token: ${{ secrets.ADMIN_PAT }}
+```
+Then document the secret requirement in the workflow comment. Do not add PAT secrets without user approval.
+
+### Phase 5: Verify fix
+
+After patching:
+```bash
+# Trigger a manual run to confirm
+gh workflow run <workflow-name>
+
+# Watch the run
+gh run list --workflow <workflow-file> --limit 3 --json status,conclusion,databaseId \
+  --jq '.[] | "\(.databaseId) \(.status) \(.conclusion // "running")"'
+```
+
+## ICN-specific workflow inventory
+
+| Workflow | File | Failure pattern | Fix class |
+|----------|------|----------------|-----------|
+| `Sync Website Stats` | `sync-stats.yml` | Push to protected main | Cache warm → `continue-on-error: true` (applied PR #1393) |
+| `CI` | `ci.yml` | Various; required gates | Fix code, not workflow |
+| `Build and Deploy to K3s` | `deploy.yml` | Registry push / K3s apply | Infra issue; check cluster |
+| `Benchmarks` | `benchmarks.yml` | Compare fails on base delta | Non-blocking; ignore unless spike |
+
+## Guardrails
+
+- **Never design a workflow that depends on `GITHUB_TOKEN` pushing to protected `main`.** It will fail.
+- **Non-essential write-backs should always have `continue-on-error: true`.** A failed cache warm
+  should never turn a cron workflow red.
+- **Do not add PAT secrets without explicit user approval.** Propose it, wait for confirmation.
+- **Check `enforce_admins` before assuming `--admin` works.** If `enforce_admins: true`, even admin
+  merges require passing checks.
+- **Workflow security**: Never interpolate untrusted GitHub event data (PR titles, issue bodies,
+  commit messages) directly into `run:` commands. Always use `env:` variables with proper quoting.

--- a/.claude/skills/resolve-pr-branch/SKILL.md
+++ b/.claude/skills/resolve-pr-branch/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: resolve-pr-branch
+description: Resolve PR↔branch identity from GitHub. Never trust plan docs or memory for branch names.
+argument-hint: "[PR number | branch name]"
+user-invocable: true
+allowed-tools: "Bash"
+---
+
+Resolve PR and branch identity from GitHub as the authoritative source. Use this before any
+checkout, rebase, force-push, or when a plan references a branch by name.
+
+## The Problem This Solves
+
+Branch names in plans, notes, and memory drift. The transcript showed a `git checkout feat/s22-compute-config`
+failing because the true head ref was `feat/s22-compute-policy-config`. That lookup took an extra round-trip
+to recover. This skill makes the lookup the first step, not a recovery.
+
+## Steps
+
+1. **Determine lookup direction from `$ARGUMENTS`**:
+   - If argument looks like a number → PR lookup
+   - If argument looks like a branch name → branch lookup
+   - If empty → show all open PRs with their head branches
+
+2. **PR → head branch**:
+   ```bash
+   gh pr view <N> --json number,title,headRefName,baseRefName,state \
+     --jq '{pr: .number, title: .title, head: .headRefName, base: .baseRefName, state: .state}'
+   ```
+
+3. **Branch → PR**:
+   ```bash
+   gh pr list --json number,title,headRefName,state \
+     --jq '.[] | select(.headRefName == "<branch>") | {pr: .number, title: .title, state: .state}'
+   ```
+
+4. **Check local branch existence**:
+   ```bash
+   git branch --list <branch>          # local
+   git ls-remote --heads origin <branch> | grep -q . && echo "exists remotely"
+   ```
+
+5. **Fetch if missing locally but present remotely**:
+   ```bash
+   git fetch origin <branch>
+   ```
+
+6. **Detect stacked PRs** (base ≠ main):
+   ```bash
+   gh pr list --json number,headRefName,baseRefName \
+     --jq '.[] | select(.baseRefName != "main") | "PR #\(.number) \(.headRefName) → \(.baseRefName)"'
+   ```
+
+## Output format
+
+```
+PR #1391 · feat/s22-compute-policy-config → main  [OPEN]
+  local branch: present
+  remote:       present
+  stacked:      no
+```
+
+## Guardrails
+
+- Never proceed with a branch name that hasn't been confirmed against GitHub.
+- When a local checkout fails with "pathspec did not match", immediately run this skill instead of
+  trying other branch name guesses.
+- Treat stacked PRs (base ≠ main) as requiring ordered integration.
+
+## ICN-specific notes
+
+- Sprint plan docs (`ops/state/sprint/current.json`) store branch names that can drift between
+  plan-time and execution-time. Always verify against `gh pr view`.
+- Worktrees in `icn-wt/` hold their own branch refs; a branch that appears absent may just be
+  checked out in a worktree.

--- a/.claude/skills/resolve-rust-targets/SKILL.md
+++ b/.claude/skills/resolve-rust-targets/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: resolve-rust-targets
+description: Resolve Rust package names and verification scope from cargo metadata. Never guess package IDs.
+argument-hint: "[file-path | package-name | --touched]"
+user-invocable: true
+allowed-tools: "Bash"
+---
+
+Use `cargo metadata` as the authoritative source for package names, manifests, and verification scope.
+Run before clippy, test, or build commands when the target package is even slightly uncertain.
+
+## The Problem This Solves
+
+The transcript hit `ledger` → `icn-ledger-app` → `icn-ledger-actor` before landing on the right package.
+That cost two dead-end compile attempts. `cargo metadata` answers this in one call.
+
+## Steps
+
+### Mode 1: Resolve from changed files (`$ARGUMENTS` is `--touched` or empty)
+
+```bash
+# Get files changed on this branch
+git diff --name-only $(git merge-base HEAD origin/main)..HEAD
+
+# Get all workspace package names and their root dirs
+cargo metadata --no-deps --format-version 1 \
+  | python3 -c "
+import sys, json
+md = json.load(sys.stdin)
+for p in md['packages']:
+    root = p['manifest_path'].replace('/Cargo.toml','')
+    print(f\"{p['name']:40s}  {root}\")
+" | sort
+```
+
+Then for each changed file, find its containing package by matching path prefix to manifest root.
+
+### Mode 2: Resolve a human label (`$ARGUMENTS` is a name like "ledger")
+
+```bash
+cargo metadata --no-deps --format-version 1 \
+  | python3 -c "
+import sys, json, difflib
+name = '$ARGUMENTS'
+md = json.load(sys.stdin)
+packages = [(p['name'], p['manifest_path']) for p in md['packages']]
+# Exact match first
+exact = [p for p in packages if p[0] == name]
+if exact:
+    print('EXACT:', exact[0][0])
+else:
+    # Near-match suggestions
+    names = [p[0] for p in packages]
+    close = difflib.get_close_matches(name, names, n=5, cutoff=0.4)
+    for c in close:
+        m = next(p for p in packages if p[0] == c)
+        print(f'NEAR:  {m[0]:40s}  {m[1]}')
+"
+```
+
+### Mode 3: Generate verification commands for a set of packages
+
+Given a list of resolved package names, produce the minimal cargo command set:
+
+```bash
+# For scoped verification (preferred — faster):
+cargo clippy -p <pkg1> -p <pkg2> --all-targets -- -D warnings
+cargo test -p <pkg1> -p <pkg2>
+
+# For cross-cutting changes (bins, icnd, core):
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+## Package taxonomy (ICN workspace)
+
+| Location | Pattern | Example |
+|----------|---------|---------|
+| `icn/crates/<name>/` | `icn-<name>` | `icn-ledger`, `icn-obs`, `icn-security` |
+| `icn/apps/<name>/` | `icn-<name>-actor` or `icn-<name>-app` | `icn-ledger-actor`, `icn-governance-actor` |
+| `icn/bins/<name>/` | `<name>` | `icnd`, `icnctl`, `icn-console` |
+
+Common confusions from the transcript:
+- `"ledger"` → `icn-ledger` (crate) or `icn-ledger-actor` (app) — both exist
+- `"ledger app"` → `icn-ledger-actor`
+- `"icn-ledger-app"` → does not exist; nearest is `icn-ledger-actor`
+- `"obs"` → `icn-obs`
+- `"security"` → `icn-security`
+- `"compute"` → `icn-compute`
+
+## Output
+
+```
+Changed files → packages:
+  icn/crates/icn-obs/src/attestation.rs     icn-obs
+  icn/crates/icn-core/src/config/obs.rs     icn-core
+
+Suggested scoped command:
+  cargo clippy -p icn-obs -p icn-core --all-targets -- -D warnings
+  cargo test -p icn-obs -p icn-core
+```
+
+## Guardrails
+
+- Never run `cargo clippy --workspace` when scoped commands are sufficient.
+- When a package name yields "error: package ID specification did not match", immediately run
+  this skill with the human label to find the correct name before retrying.
+- Bins (`icnd`) depend on everything; touching `icnd/src/main.rs` requires workspace-wide verify.

--- a/.claude/skills/watch-ci-and-advance/SKILL.md
+++ b/.claude/skills/watch-ci-and-advance/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: watch-ci-and-advance
+description: Monitor CI as a queue system. Advance other ready work while waiting. Report gate deltas, not polls.
+argument-hint: "[PR number | run ID]"
+user-invocable: true
+allowed-tools: "Bash"
+---
+
+Treat CI as a queue system. While the runner is busy, do useful work. Report only meaningful
+state changes, not repetitive status dumps.
+
+## The Problem This Solves
+
+The transcript spent significant time in a passive poll cycle: check → still pending → wait → check.
+Meanwhile, other PRs could have been rebased, verified, and readied. This skill turns waiting time
+into advance work.
+
+## Steps
+
+### Phase 1: Assess current queue state
+
+```bash
+# Check if runner is actively processing or just queued
+gh run list --limit 5 --json databaseId,status,name,conclusion,createdAt \
+  --jq '.[] | "\(.databaseId) \(.name) \(.status) \(.conclusion // "running")"'
+```
+
+Classify:
+- `in_progress`: runner is actively working — productive wait
+- `queued` + age > 5 min: runner contention likely
+- `queued` + age > 30 min: definitely queue-stalled, likely safe to `--admin` merge after manual local verify
+
+```bash
+# Check runner health
+gh api repos/InterCooperative-Network/icn/actions/runners \
+  --jq '.runners[] | {name:.name, status:.status, busy:.busy}'
+```
+
+### Phase 2: Identify useful advance work
+
+While CI runs, prioritize in this order:
+
+1. **Rebase other PR branches onto latest main** (no runner needed)
+2. **Run scoped local verification on rebased branches**
+3. **Check main for workflow failures** (may reveal pre-existing breakage)
+4. **Inspect non-running PRs for review comments that can be addressed**
+
+```bash
+# Find PRs not currently in CI queue
+gh pr list --json number,headRefName,statusCheckRollup \
+  --jq '.[] | select(.statusCheckRollup | length == 0 or all(.[]; .state != "IN_PROGRESS")) | .number'
+```
+
+### Phase 3: Report gate deltas, not full dumps
+
+Instead of printing the full check table every poll, track which gates changed:
+
+```bash
+# Snapshot required gates only
+gh pr checks <N> --json name,state,conclusion \
+  | python3 -c "
+import sys, json
+required = {'Build Release','Test','Clippy','Format Check'}
+checks = {c['name']:c for c in json.load(sys.stdin) if c['name'] in required}
+for name, c in sorted(checks.items()):
+    status = c['conclusion'] if c['state'] == 'COMPLETED' else c['state']
+    print(f'{name:20s} {status}')
+"
+```
+
+Output format — only report changes, not repeats:
+```
+[CI delta] Clippy: pass (was pending)
+[CI delta] Build Release: pass (was pending)
+[CI delta] Test: still running
+```
+
+### Phase 4: Merge decision
+
+When required gates resolve:
+- All pass → proceed with merge (use `integrate-pr-stack` for sequencing)
+- A required gate fails → run `fix-ci` or `fix-rust-lints` to address
+- Non-blocking fails → explicitly note "non-blocking only, safe to merge"
+
+## Distinguishing queue stall from genuine failure
+
+| Signal | Meaning |
+|--------|---------|
+| `pending / 0s` for < 5 min | Normal startup delay |
+| `pending / 0s` for 5–30 min | Likely queue contention |
+| `pending / 0s` for > 30 min | Queue-stalled; local verify + `--admin` is valid |
+| `in_progress` for > 20 min | Likely running (full workspace test suite takes ~14 min) |
+| Check disappears after push | Normal: new commit resets CI identity |
+
+## ICN-specific notes
+
+- ICN has one self-hosted runner (`ci-runner`, 10.8.30.46). Parallel PR merges cause queue.
+- Full workspace test suite runs ~14 min on the self-hosted runner.
+- Build Release + Clippy + Test tend to run sequentially on the same runner job.
+- `Test Coverage` and `Compare Against Base` often tail the required gates — ignore them for merge decisions.
+- After rebasing a PR branch and force-pushing, GitHub resets its CI run. The old pass result is
+  gone. New run must complete before the PR regains green status. Use `--admin` after local verify
+  if the queue is stalled.
+
+## Guardrails
+
+- Do NOT poll blindly in a loop. Check, do advance work, check again.
+- Do NOT conflate non-blocking failures with merge blockers.
+- Do NOT report the full check table unchanged on every check — that adds noise without signal.
+- When the runner has been busy for > 30 min and local gates pass, inform the user that `--admin`
+  is viable rather than waiting indefinitely.


### PR DESCRIPTION
## Summary

- 6 new skills encoding Sprint 22 failure modes as permanent operational memory
- 2 existing skills (`push`, `merge-prs`) rewritten with scoped verification and stack-integration logic
- Skills table in root CLAUDE.md reorganized by function

## New skills

| Skill | Encodes |
|-------|---------|
| `resolve-pr-branch` | Branch name drift, stale plan docs, missing local refs |
| `resolve-rust-targets` | Package name confusion (`icn-ledger-actor` vs `icn-ledger-app`) |
| `fix-rust-lints` | `field_reassign_with_default`, deprecated constants in `--all-targets`, time overflow |
| `integrate-pr-stack` | Full merge pipeline: branch resolution, ordering, rebases, local gates, main sync |
| `watch-ci-and-advance` | CI as queue system; advance other work while runner is busy |
| `repair-gh-workflow` | `GITHUB_TOKEN` cannot push to protected `main`; fix classes for write-back automation |

## Updated skills

- `push`: Adds package resolution step, scoped clippy/test commands, known package name table
- `merge-prs`: Rewritten as stack-integration pipeline with required-vs-non-blocking classification

## Philosophy

> A good skill does not just tell the agent what to do. It remembers how this repo fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)