### PR TITLE
chore(ci): migrate coverage to llvm-cov on self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,11 +414,16 @@ jobs:
   coverage:
     name: Test Coverage
     needs: [changes]
-    if: needs.changes.outputs.docs_only != 'true'
+    if: needs.changes.outputs.docs_only != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     timeout-minutes: 30
     runs-on: [self-hosted, linux, x64, coverage]
     steps:
       - uses: actions/checkout@v6
+
+      - name: Install cargo-llvm-cov
+        run: |
+          source $HOME/.cargo/env
+          cargo install cargo-llvm-cov --locked
 
       - name: Generate coverage
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,54 +415,21 @@ jobs:
     name: Test Coverage
     needs: [changes]
     if: needs.changes.outputs.docs_only != 'true'
-    timeout-minutes: 45
-    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    runs-on: [self-hosted, linux, x64, coverage]
     steps:
       - uses: actions/checkout@v6
 
-      - name: Free disk space
-        uses: ./.github/actions/free-disk-space
-        with:
-          verbose: 'true'
-          aggressive: 'true'
-
-      - name: Install build tools
-        uses: ./.github/actions/install-build-tools
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      # NOTE: No rust-cache for coverage job - tarpaulin needs fresh instrumented
-      # builds anyway, and the cache just wastes disk space
-
-      - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin --locked
-
-      - name: Pre-tarpaulin cleanup
-        run: |
-          echo "Additional disk cleanup for coverage job..."
-          
-          # Remove cargo caches to free space (tarpaulin downloads what it needs)
-          # These are safe to remove - they're user-level caches, not system files
-          rm -rf ~/.cargo/registry/cache || true
-          rm -rf ~/.cargo/git/db || true
-          
-          # Show remaining space
-          echo "Disk space before tarpaulin:"
-          df -h /
-
       - name: Generate coverage
-        run: cargo tarpaulin --workspace --timeout 300 --out Xml --output-dir ./coverage
+        run: cargo llvm-cov --workspace --lcov --output-path ./lcov.info
         working-directory: ./icn
-        continue-on-error: ${{ env.GATE_RATCHET_PHASE_COVERAGE != 'blocking' }}  # Tarpaulin can have spurious failures even when tests pass
+        continue-on-error: ${{ env.GATE_RATCHET_PHASE_COVERAGE != 'blocking' }}
 
       - name: Upload coverage to Codecov
-        # Only upload if tarpaulin actually produced the report.
-        # When tarpaulin crashes (continue-on-error above), the XML may not exist;
-        # Codecov treating a missing file as a hard failure defeats the non-blocking intent.
-        if: hashFiles('./icn/coverage/cobertura.xml') != ''
+        if: hashFiles('./icn/lcov.info') != ''
         uses: codecov/codecov-action@v5
         with:
-          files: ./icn/coverage/cobertura.xml
+          files: ./icn/lcov.info
           fail_ci_if_error: false
 
   security:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,7 +421,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Generate coverage
-        run: cargo llvm-cov --workspace --lcov --output-path ./lcov.info
+        run: |
+          source $HOME/.cargo/env
+          cargo llvm-cov --workspace --lcov --output-path ./lcov.info
         working-directory: ./icn
         continue-on-error: ${{ env.GATE_RATCHET_PHASE_COVERAGE != 'blocking' }}
 


### PR DESCRIPTION
## Summary

- Replace tarpaulin on `ubuntu-latest` with `cargo-llvm-cov` on a self-hosted runner labeled `coverage`
- Coverage job now targets Zenith WSL2 (54GB RAM) instead of GitHub spot instances that never completed
- Reduced timeout from 45min to 30min — validated run completes in ~11 minutes

## What changed in ci.yml

- `runs-on: ubuntu-latest` → `[self-hosted, linux, x64, coverage]`
- `cargo tarpaulin` → `cargo llvm-cov --workspace --lcov`
- Output: `cobertura.xml` → `lcov.info` (Codecov accepts both)
- Removed 5 unnecessary steps (free-disk-space, install-build-tools, dtolnay/rust-toolchain, tarpaulin install, pre-tarpaulin cleanup)

## Evidence

**Problem:** Coverage job has never produced data — tarpaulin on ubuntu-latest was killed by spot preemption before completing. On ci-runner (3.8GB RAM), both tarpaulin and llvm-cov failed due to swap exhaustion after 45+ minutes.

**Validation on Zenith (54GB RAM):**
- `cargo llvm-cov --workspace --lcov` completed in ~11 minutes
- Produced 11MB / 288,731-line `lcov.info`
- Peak RAM: 7.2GB (no swap)

## Rollback

If Zenith is unavailable, the coverage job will simply queue until the runner comes back online. Other CI jobs are unaffected (they use different runner labels).

Coverage gate remains `observational` — this PR does not change pass/fail behavior.

## Test plan

- [ ] CI passes on this PR (all non-coverage jobs run on their existing runners)
- [ ] Coverage job dispatches to `zentith-coverage` runner
- [ ] `lcov.info` is produced and uploaded to Codecov

🤖 Generated with [Claude Code](https://claude.com/claude-code)