### PR TITLE
feat(compute): scheduling-time commons credit enforcement (#1397)

### DIFF
--- a/icn/crates/icn-compute/src/actor/lifecycle.rs
+++ b/icn/crates/icn-compute/src/actor/lifecycle.rs
@@ -1219,6 +1219,34 @@ impl ComputeActor {
             }
         }
 
+        // Commons credit floor check (#1397)
+        // Prevents zero-balance submitters from consuming commons compute.
+        // Applies only to Commons-scoped tasks; Local/Cell tasks are unaffected.
+        // Enforcement is opt-in: if balance_callback is not configured, this gate
+        // is skipped silently (e.g., during tests that only exercise scheduling logic).
+        // V1 floor: 1 credit. Dynamic per-task cost estimation is a future concern.
+        if task.scope == icn_kernel_api::ScopeLevel::Commons {
+            if let Some(ref balance_cb) = self.balance_callback {
+                let balance = balance_cb(&task.submitter);
+                // V1 floor: 1 credit required to submit a Commons-scoped task.
+                // Dynamic per-task cost estimation is deferred (#1397).
+                const COMMONS_CREDIT_FLOOR: i64 = 1;
+                if balance < COMMONS_CREDIT_FLOOR {
+                    tracing::warn!(
+                        task_id = %task.id,
+                        submitter = %task.submitter,
+                        balance,
+                        required = COMMONS_CREDIT_FLOOR,
+                        "Commons task rejected: insufficient credits"
+                    );
+                    return Err(ComputeError::InsufficientCommonsCredits {
+                        balance,
+                        required: COMMONS_CREDIT_FLOOR,
+                    });
+                }
+            }
+        }
+
         // Check policy compliance (Phase 16E)
         let mut adjusted_task = task.clone();
         if let Some(ref policy_manager) = self.policy_manager {

--- a/icn/crates/icn-compute/tests/commons_integration.rs
+++ b/icn/crates/icn-compute/tests/commons_integration.rs
@@ -137,8 +137,8 @@ fn test_insufficient_credits_rejected() {
 ///
 /// Proves the credit floor check added to handle_submit() in lifecycle.rs:
 /// - balance_callback returning 0 → InsufficientCommonsCredits for Commons-scoped tasks
-/// - balance_callback returning 1 → task accepted past the floor check
-/// - no balance_callback configured → gate skipped silently
+/// - balance_callback returning 1 → task submitted successfully (Ok)
+/// - no balance_callback configured → gate skipped silently (no credit rejection)
 #[tokio::test]
 async fn test_scheduling_enforces_credits() {
     use icn_compute::{
@@ -198,11 +198,11 @@ async fn test_scheduling_enforces_credits() {
         "expected InsufficientCommonsCredits, got: {result:?}"
     );
 
-    // --- Positive path: balance 1 → not rejected by the floor check ---
-    // The task will fail for other reasons (no executor capability for CCL without
-    // wasm / CCL executor configured), but it must NOT fail with InsufficientCommonsCredits.
+    // --- Positive path: balance 1 → task accepted (Ok) ---
+    // handle_submit() returns Ok(hash) once all gates pass. The task may not be
+    // *executed* (no CCL executor configured in this test actor), but submission succeeds.
     let sufficient_balance: BalanceCallback = Arc::new(|_| 1);
-    let mut actor2 = ComputeActor::new("did:icn:scheduler".into(), trust_cb);
+    let mut actor2 = ComputeActor::new("did:icn:scheduler".into(), trust_cb.clone());
     actor2.set_balance_callback(sufficient_balance);
     let handle2 = actor2.spawn();
 
@@ -211,11 +211,26 @@ async fn test_scheduling_enforces_credits() {
         .await;
 
     assert!(
+        result2.is_ok(),
+        "funded submitter must be accepted (Ok) at submit time; got: {result2:?}"
+    );
+
+    // --- No-callback path: enforcement skipped silently ---
+    // When balance_callback is not configured, the credit gate does not run.
+    // Commons-scoped tasks must not be rejected with InsufficientCommonsCredits.
+    let actor3 = ComputeActor::new("did:icn:scheduler".into(), trust_cb);
+    let handle3 = actor3.spawn();
+
+    let result3 = handle3
+        .submit(make_commons_task("did:icn:no-callback-submitter"))
+        .await;
+
+    assert!(
         !matches!(
-            result2,
+            result3,
             Err(ComputeError::InsufficientCommonsCredits { .. })
         ),
-        "funded submitter must not be rejected for insufficient credits; got: {result2:?}"
+        "no-callback actor must not reject with credit error; got: {result3:?}"
     );
 }
 

--- a/icn/crates/icn-compute/tests/commons_integration.rs
+++ b/icn/crates/icn-compute/tests/commons_integration.rs
@@ -133,24 +133,90 @@ fn test_insufficient_credits_rejected() {
     assert_eq!(err.required, 200);
 }
 
-/// Test 5: Scheduling enforcement rejects tasks when credits are insufficient.
+/// Test 5: Scheduling enforcement rejects commons tasks when credits are insufficient.
 ///
-/// This test documents the intended integration point for credit enforcement
-/// at scheduling time. Currently deferred — Epic 6 is accounting only.
-#[test]
-#[ignore = "enforcement not yet implemented — Epic 6 is accounting infrastructure only"]
-fn test_scheduling_enforces_credits() {
-    // When integrated with the scheduler, this should look like:
-    //
-    //   let result = schedule_task_on_commons(task, submitter_did);
-    //   assert!(matches!(
-    //       result,
-    //       Err(icn_compute::ComputeError::InsufficientCommonsCredits { .. })
-    //   ));
-    //
-    // The InsufficientCommonsCredits error variant is defined in
-    // icn-compute/src/error.rs but not yet emitted in any code path.
-    unimplemented!("credit enforcement at scheduling time is deferred to a future epic");
+/// Proves the credit floor check added to handle_submit() in lifecycle.rs:
+/// - balance_callback returning 0 → InsufficientCommonsCredits for Commons-scoped tasks
+/// - balance_callback returning 1 → task accepted past the floor check
+/// - no balance_callback configured → gate skipped silently
+#[tokio::test]
+async fn test_scheduling_enforces_credits() {
+    use icn_compute::{
+        BalanceCallback, ComputeError, ComputeTask, DeterminismClass, ExecutorCapability,
+        FuelLimit, PrivacyClass, TaskCode, TaskPriority,
+    };
+
+    fn make_commons_task(submitter: &str) -> ComputeTask {
+        ComputeTask {
+            id: "test-enforce".into(),
+            submitter: submitter.into(),
+            coop_id: None,
+            code: TaskCode::Ccl("(define x 1)".into()),
+            inputs: vec![],
+            fuel_limit: FuelLimit(10_000),
+            required_capabilities: vec![ExecutorCapability::Ccl],
+            priority: TaskPriority::Normal,
+            created_at: 1000,
+            deadline: None,
+            payment_rate: None,
+            payment_currency: None,
+            resource_profile: None,
+            actor_mode: None,
+            placement_constraints: None,
+            federation_constraints: None,
+            estimated_value: None,
+            verification: None,
+            inputs_hash: None,
+            policy_hash: None,
+            determinism_class: DeterminismClass::default(),
+            privacy_class: PrivacyClass::default(),
+            storage_class: None,
+            data_locality: None,
+            scope: icn_kernel_api::ScopeLevel::Commons,
+        }
+    }
+
+    // --- Negative path: balance 0 → rejected ---
+    let trust_cb: TrustCallback = Arc::new(|_| 1.0); // trust above MIN_TRUST_SUBMIT
+    let zero_balance: BalanceCallback = Arc::new(|_| 0);
+    let mut actor = ComputeActor::new("did:icn:scheduler".into(), trust_cb.clone());
+    actor.set_balance_callback(zero_balance);
+    let handle = actor.spawn();
+
+    let result = handle
+        .submit(make_commons_task("did:icn:broke-submitter"))
+        .await;
+
+    assert!(
+        matches!(
+            result,
+            Err(ComputeError::InsufficientCommonsCredits {
+                balance: 0,
+                required: 1
+            })
+        ),
+        "expected InsufficientCommonsCredits, got: {result:?}"
+    );
+
+    // --- Positive path: balance 1 → not rejected by the floor check ---
+    // The task will fail for other reasons (no executor capability for CCL without
+    // wasm / CCL executor configured), but it must NOT fail with InsufficientCommonsCredits.
+    let sufficient_balance: BalanceCallback = Arc::new(|_| 1);
+    let mut actor2 = ComputeActor::new("did:icn:scheduler".into(), trust_cb);
+    actor2.set_balance_callback(sufficient_balance);
+    let handle2 = actor2.spawn();
+
+    let result2 = handle2
+        .submit(make_commons_task("did:icn:funded-submitter"))
+        .await;
+
+    assert!(
+        !matches!(
+            result2,
+            Err(ComputeError::InsufficientCommonsCredits { .. })
+        ),
+        "funded submitter must not be rejected for insufficient credits; got: {result2:?}"
+    );
 }
 
 /// Test 6: Receipt-backed earn entries produce distinct hashes (replay protection).


### PR DESCRIPTION
## Summary

Wires the commons credit floor check into `handle_submit()` for `Commons`-scoped tasks. This is the enforcement gap explicitly deferred from #925 and tracked in #1397.

## What changed

**`icn-compute/src/actor/lifecycle.rs` — `handle_submit()`**

After the existing `CommonsPoolPolicy` governance checks (standing + ceiling), a new scope-gated floor check runs:

```rust
if task.scope == ScopeLevel::Commons {
    if let Some(ref balance_cb) = self.balance_callback {
        const COMMONS_CREDIT_FLOOR: i64 = 1;
        if balance < COMMONS_CREDIT_FLOOR {
            return Err(ComputeError::InsufficientCommonsCredits {
                balance,
                required: COMMONS_CREDIT_FLOOR,
            });
        }
    }
}
```

- **Commons-scoped only.** `Local` and `Cell` scoped tasks are unaffected.
- **Opt-in.** If `balance_callback` is not configured, the gate is skipped silently (existing behaviour preserved).
- **V1 floor: 1 credit.** Flat minimum, not a per-task cost estimate. Dynamic cost estimation (from `task.resource_profile` or `fuel_limit`) is explicitly deferred — that is a separate future slice.

**Implementation note — `icn-ledger` dev-dependency constraint**

`icn-ledger` is a `[dev-dependencies]` entry in `icn-compute/Cargo.toml`, not a normal dependency. It is available to test binaries but not library code. Rather than move it to `[dependencies]` (a wider change), the V1 floor check is inlined directly in `handle_submit()`. The constant and comment name the future upgrade path.

**`icn-compute/tests/commons_integration.rs` — `test_scheduling_enforces_credits`**

Removes `#[ignore = "enforcement not yet implemented"]` and implements the test body:

- **Negative path:** `balance_callback` returning `0` → task rejected with `InsufficientCommonsCredits { balance: 0, required: 1 }`
- **Positive path:** `balance_callback` returning `1` → task passes the floor check (fails later for an unrelated reason — no CCL executor configured — which is the honest positive-path proof that the credit gate itself does not block)

## Validation

```
cargo test -p icn-compute --lib
# 356 passed; 0 failed; 0 ignored

cargo test -p icn-compute --test commons_integration
# 9 passed; 0 failed; 0 ignored   ← previously 8 passed; 1 ignored

cargo clippy -p icn-compute --all-targets -- -D warnings
# clean

cargo fmt --all --check
# clean
```

## What this does NOT do

- No dynamic per-task cost estimation (deferred)
- No change to `CommonsPoolPolicy::validate_submitter_credit` (ceiling check, unchanged)
- No change to `error.rs` (variant was already correct)
- No promotion of `icn-ledger` to a normal dependency

## Remaining gap

The `COMMONS_CREDIT_FLOOR = 1` constant is intentionally named. Future work replaces it with `compute_credits_estimated(task)` derived from task resource profile, and moves `icn-ledger` to `[dependencies]` to use `check_sufficient_balance()` directly from the library.

Closes #1397