### PR TITLE
feat(compute): cost-based commons credit enforcement (#1399)

### DIFF
--- a/icn/crates/icn-compute/src/actor/lifecycle.rs
+++ b/icn/crates/icn-compute/src/actor/lifecycle.rs
@@ -1224,7 +1224,8 @@ impl ComputeActor {
         // Applies only to Commons-scoped tasks; Local/Cell tasks are unaffected.
         // Enforcement is opt-in: if balance_callback is not configured, this gate
         // is skipped silently (e.g., during tests that only exercise scheduling logic).
-        // V1 floor: 1 credit. Dynamic per-task cost estimation is a future concern.
+        // Cost computed via cost::compute_credits_required(&task) — fuel_limit-based V1 formula.
+        // Governance-configurable divisor is a follow-on; see icn-compute/src/cost.rs.
         if task.scope == icn_kernel_api::ScopeLevel::Commons {
             if let Some(ref balance_cb) = self.balance_callback {
                 let balance = balance_cb(&task.submitter);

--- a/icn/crates/icn-compute/src/actor/lifecycle.rs
+++ b/icn/crates/icn-compute/src/actor/lifecycle.rs
@@ -1228,21 +1228,16 @@ impl ComputeActor {
         if task.scope == icn_kernel_api::ScopeLevel::Commons {
             if let Some(ref balance_cb) = self.balance_callback {
                 let balance = balance_cb(&task.submitter);
-                // V1 floor: 1 credit required to submit a Commons-scoped task.
-                // Dynamic per-task cost estimation is deferred (#1397).
-                const COMMONS_CREDIT_FLOOR: i64 = 1;
-                if balance < COMMONS_CREDIT_FLOOR {
+                let required = crate::cost::compute_credits_required(&task);
+                if balance < required {
                     tracing::warn!(
                         task_id = %task.id,
                         submitter = %task.submitter,
                         balance,
-                        required = COMMONS_CREDIT_FLOOR,
+                        required,
                         "Commons task rejected: insufficient credits"
                     );
-                    return Err(ComputeError::InsufficientCommonsCredits {
-                        balance,
-                        required: COMMONS_CREDIT_FLOOR,
-                    });
+                    return Err(ComputeError::InsufficientCommonsCredits { balance, required });
                 }
             }
         }

--- a/icn/crates/icn-compute/src/cost.rs
+++ b/icn/crates/icn-compute/src/cost.rs
@@ -1,0 +1,119 @@
+//! Compute cost calculation and credit enforcement.
+//!
+//! This module provides the cost gate for task submission, calculating the
+//! minimum credits required to execute a task based on fuel limits and payment rates.
+
+use crate::types::ComputeTask;
+
+/// Default fuel cost divisor (1_000 fuel units = 1 credit cost).
+///
+/// This divisor matches CommonsPoolPolicy's default and determines the base
+/// cost per fuel unit. The governance-configurable divisor is a planned
+/// follow-on enhancement (Phase TBD).
+const DEFAULT_FUEL_COST_DIVISOR: i64 = 1_000;
+
+/// Compute the minimum credits required for task submission.
+///
+/// This is the **V1 scheduling-time cost gate** formula. It determines whether
+/// a submitter has sufficient credit balance to submit a task, preventing
+/// resource exhaustion and enforcing economic discipline.
+///
+/// # Formula
+///
+/// - If `payment_rate` is set: `base = (fuel_limit * payment_rate) / DEFAULT_FUEL_COST_DIVISOR`
+/// - If `payment_rate` is None: `base = fuel_limit / DEFAULT_FUEL_COST_DIVISOR`
+/// - Final cost: `base.max(1)` — ensures even tiny tasks cost at least 1 credit
+///
+/// # Implementation Notes
+///
+/// - The `DEFAULT_FUEL_COST_DIVISOR` (1_000) is hardcoded to match CommonsPoolPolicy's default.
+///   A governance-configurable divisor is a planned follow-on.
+/// - The `.max(1)` floor covers task overhead (scheduling, gossip, verification) for very cheap tasks.
+///   Without it, free-tier tasks could exhaust resources via volume.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use icn_compute::types::{ComputeTask, FuelLimit};
+/// use icn_compute::cost::compute_credits_required;
+///
+/// let task = ComputeTask {
+///     fuel_limit: FuelLimit(10_000),
+///     payment_rate: None,
+///     ..Default::default()
+/// };
+/// assert_eq!(compute_credits_required(&task), 10);
+///
+/// let task_with_rate = ComputeTask {
+///     fuel_limit: FuelLimit(10_000),
+///     payment_rate: Some(2),
+///     ..Default::default()
+/// };
+/// assert_eq!(compute_credits_required(&task_with_rate), 20);
+///
+/// let tiny_task = ComputeTask {
+///     fuel_limit: FuelLimit(500),
+///     payment_rate: None,
+///     ..Default::default()
+/// };
+/// assert_eq!(compute_credits_required(&tiny_task), 1);  // floor applied
+/// ```
+pub fn compute_credits_required(task: &ComputeTask) -> i64 {
+    let base = match task.payment_rate {
+        Some(rate) => (task.fuel_limit.0 as i64 * rate as i64) / DEFAULT_FUEL_COST_DIVISOR,
+        None => task.fuel_limit.0 as i64 / DEFAULT_FUEL_COST_DIVISOR,
+    };
+
+    base.max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ComputeTask, FuelLimit, TaskId, TaskCode, TaskPriority};
+
+    /// Helper to construct a minimal test task.
+    fn test_task(fuel_limit: u64, payment_rate: Option<u64>) -> ComputeTask {
+        ComputeTask {
+            id: TaskId::from("test_task"),
+            submitter: "did:icn:test".to_string(),
+            coop_id: None,
+            code: TaskCode::Ccl(vec![]),
+            inputs: vec![],
+            fuel_limit: FuelLimit(fuel_limit),
+            required_capabilities: vec![],
+            priority: TaskPriority::default(),
+            created_at: 0,
+            deadline: None,
+            payment_rate,
+            payment_currency: None,
+            resource_profile: None,
+            actor_mode: None,
+            placement_constraints: None,
+            federation_constraints: None,
+            estimated_value: None,
+            verification: None,
+        }
+    }
+
+    #[test]
+    fn test_cost_no_rate_normal_fuel() {
+        // fuel_limit=10_000, no payment_rate → 10_000 / 1_000 = 10
+        let task = test_task(10_000, None);
+        assert_eq!(compute_credits_required(&task), 10);
+    }
+
+    #[test]
+    fn test_cost_no_rate_tiny_fuel() {
+        // fuel_limit=500, no payment_rate → 500 / 1_000 = 0, floored to 1
+        let task = test_task(500, None);
+        assert_eq!(compute_credits_required(&task), 1);
+    }
+
+    #[test]
+    fn test_cost_with_rate() {
+        // fuel_limit=10_000, payment_rate=2 → (10_000 * 2) / 1_000 = 20
+        let task = test_task(10_000, Some(2));
+        assert_eq!(compute_credits_required(&task), 20);
+    }
+}

--- a/icn/crates/icn-compute/src/cost.rs
+++ b/icn/crates/icn-compute/src/cost.rs
@@ -70,7 +70,9 @@ pub fn compute_credits_required(task: &ComputeTask) -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{ComputeTask, FuelLimit, TaskId, TaskCode, TaskPriority};
+    use crate::types::{
+        ComputeTask, DeterminismClass, FuelLimit, PrivacyClass, TaskCode, TaskId, TaskPriority,
+    };
 
     /// Helper to construct a minimal test task.
     fn test_task(fuel_limit: u64, payment_rate: Option<u64>) -> ComputeTask {
@@ -78,7 +80,7 @@ mod tests {
             id: TaskId::from("test_task"),
             submitter: "did:icn:test".to_string(),
             coop_id: None,
-            code: TaskCode::Ccl(vec![]),
+            code: TaskCode::Ccl(String::new()),
             inputs: vec![],
             fuel_limit: FuelLimit(fuel_limit),
             required_capabilities: vec![],
@@ -93,6 +95,13 @@ mod tests {
             federation_constraints: None,
             estimated_value: None,
             verification: None,
+            inputs_hash: None,
+            policy_hash: None,
+            determinism_class: DeterminismClass::default(),
+            privacy_class: PrivacyClass::default(),
+            storage_class: None,
+            data_locality: None,
+            scope: Default::default(),
         }
     }
 

--- a/icn/crates/icn-compute/src/lib.rs
+++ b/icn/crates/icn-compute/src/lib.rs
@@ -30,6 +30,7 @@ mod actor_model;
 mod actor_runtime;
 mod checkpoint_store;
 pub mod commons_pool;
+pub mod cost;
 mod dispute;
 mod error;
 mod executor;

--- a/icn/crates/icn-compute/tests/commons_integration.rs
+++ b/icn/crates/icn-compute/tests/commons_integration.rs
@@ -192,16 +192,16 @@ async fn test_scheduling_enforces_credits() {
             result,
             Err(ComputeError::InsufficientCommonsCredits {
                 balance: 0,
-                required: 1
+                required: 10
             })
         ),
         "expected InsufficientCommonsCredits, got: {result:?}"
     );
 
-    // --- Positive path: balance 1 → task accepted (Ok) ---
+    // --- Positive path: balance 10 → task accepted (Ok) ---
     // handle_submit() returns Ok(hash) once all gates pass. The task may not be
     // *executed* (no CCL executor configured in this test actor), but submission succeeds.
-    let sufficient_balance: BalanceCallback = Arc::new(|_| 1);
+    let sufficient_balance: BalanceCallback = Arc::new(|_| 10);
     let mut actor2 = ComputeActor::new("did:icn:scheduler".into(), trust_cb.clone());
     actor2.set_balance_callback(sufficient_balance);
     let handle2 = actor2.spawn();


### PR DESCRIPTION
## Summary

- Introduces `compute_credits_required(&task) -> i64` in `icn-compute/src/cost.rs` — V1 formula: `fuel_limit / 1_000` (floored at 1; `payment_rate` override supported)
- Replaces flat `COMMONS_CREDIT_FLOOR = 1` sentinel in `handle_submit()` with the cost-derived amount; `InsufficientCommonsCredits { balance, required }` now carries the actual task cost
- No new cross-crate dependency: `icn-ledger` stays in `[dev-dependencies]`; `icn-ledger` promotion scoped out per issue
- Updates `test_scheduling_enforces_credits` expectations: negative path asserts `required: 10`, positive path uses `balance: 10` (matches `FuelLimit(10_000) / 1_000`)

## Test Plan

- [x] `cargo test -p icn-compute --test commons_integration` — 9/9 pass
- [x] `cargo clippy -p icn-compute -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `COMMONS_CREDIT_FLOOR` constant removed; `crate::cost::compute_credits_required(&task)` wired at `lifecycle.rs:1231`

## Out of Scope

- Pre-execution credit reservation/escrow (separate issue)
- `icn-ledger` promotion from `[dev-dependencies]` to `[dependencies]` (file separately if needed)
- Governance-configurable divisor in `compute_credits_required()` (follow-on)

Closes #1399