### PR TITLE
fix(ci): add timeout-minutes: 45 to deploy Test job (#1401)

### DIFF
--- a/.github/workflows/docker-build-deploy.yml
+++ b/.github/workflows/docker-build-deploy.yml
@@ -46,6 +46,7 @@ jobs:
   test:
     name: Test
     runs-on: [self-hosted, homelab, k3s]
+    timeout-minutes: 45
     # Skip test on scheduled runs (cleanup only)
     if: github.event_name != 'schedule'
     steps:


### PR DESCRIPTION
## Summary

- Adds `timeout-minutes: 45` to the `Test` job in `docker-build-deploy.yml`
- One line change, no logic change

## Evidence

Run `23415464374` (`Build and Deploy to K3s`, triggered 2026-03-22T23:49Z) held `ci-runner` for ~2.5h. The `Test` job ran `cargo test --workspace` with no job-level timeout. When manually cancelled at 02:18Z, the cleanup log showed orphan processes being killed: `sccache`, `cargo`, `rustc`, `clang` — all mid-compilation.

During that window, required checks on PR #1400 (`Build Release`, `Test`) stalled at `pending / 0s`, forcing an `--admin` merge bypass.

## Test Plan

- [x] Diff is exactly one line: `timeout-minutes: 45` on the `Test` job
- [x] No other jobs, steps, or workflows touched
- [ ] Observe next deploy run — should complete or fail within 45 minutes, never hold runner indefinitely

## Out of Scope

Deeper fixes (splitting cluster-integration tests, moving unit tests to GitHub-hosted runners) are tracked in #1401 as follow-on work.

Closes #1401