### PR TITLE
fix(ci): remove duplicate cargo test job from deploy workflow (#1401)

### DIFF
--- a/.github/workflows/docker-build-deploy.yml
+++ b/.github/workflows/docker-build-deploy.yml
@@ -42,59 +42,13 @@ env:
   CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
 
 jobs:
-  # Standard CI jobs run on GitHub-hosted runners
-  test:
-    name: Test
-    runs-on: [self-hosted, homelab, k3s]
-    timeout-minutes: 45
-    # Skip test on scheduled runs (cleanup only)
-    if: github.event_name != 'schedule'
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Free disk space
-        uses: ./.github/actions/free-disk-space
-        with:
-          verbose: 'true'
-          aggressive: 'true'
-
-      - name: Install build tools (clang + mold linker)
-        run: |
-          PACKAGES=""
-          if ! command -v clang &> /dev/null; then
-            PACKAGES="$PACKAGES clang"
-          fi
-          if ! command -v mold &> /dev/null; then
-            PACKAGES="$PACKAGES mold"
-          fi
-          if [ -n "$PACKAGES" ]; then
-            sudo apt-get update && sudo apt-get install -y $PACKAGES
-          fi
-          echo "Compiler: $(clang --version | head -1)"
-          echo "Linker: $(mold --version)"
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: Configure sccache
-        run: |
-          echo "RUSTC_WRAPPER=/usr/local/bin/sccache" >> $GITHUB_ENV
-          echo "SCCACHE_DIR=/home/ubuntu/.cache/sccache" >> $GITHUB_ENV
-          echo "SCCACHE_CACHE_SIZE=30G" >> $GITHUB_ENV
-          sccache --start-server || true
-          sccache --show-stats || true
-
-      - name: Run tests
-        run: cargo test --workspace
-        working-directory: ./icn
-
-      - name: sccache stats
-        if: always()
-        run: sccache --show-stats || true
-
-  # Build and deploy runs on self-hosted runner
+  # Build and deploy runs on self-hosted runner.
+  # Tests are not re-run here — ci.yml already runs cargo test --workspace as
+  # a required merge gate on ubuntu-latest. By the time code reaches main, the
+  # workspace tests are proven. This workflow's self-hosted lane is reserved
+  # for steps that actually require Docker/K3s/registry/SSH access.
   build-and-deploy:
     name: Build and Deploy
-    needs: test
     runs-on: [self-hosted, homelab, k3s]
     # Skip build/deploy on scheduled runs (cleanup only)
     if: github.event_name != 'schedule'


### PR DESCRIPTION
## Summary

- Removes the `test` job from `docker-build-deploy.yml` — it was an exact duplicate of the `cargo test --workspace` step that `ci.yml` already runs as a required merge gate on `ubuntu-latest`
- Removes `needs: test` from `build-and-deploy` job
- Adds explanatory comment clarifying that the self-hosted runner lane exists only for Docker/K3s/SSH steps

## Why

By the time any push reaches `main`, `ci.yml` has already passed `Test` (a required check). The `docker-build-deploy.yml` test job was re-running the full workspace test suite on the single `ci-runner` — occupying it for 30-60+ min and starving the required CI checks that PRs depend on (runner starvation, issue #1401).

## Risk

Low. No test coverage is lost — `ci.yml` already owns test gating. This only removes duplicate work from the deploy workflow.

## Test Plan

- [ ] Verify `ci.yml` still has `cargo test --workspace` in the `Test` job (it does)
- [ ] Confirm `docker-build-deploy.yml` no longer contains a `test` job
- [ ] Monitor next deploy run: should go straight to `build-and-deploy` without waiting for a test job

Closes #1401 (partial — runner queue visibility still tracked in the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)