### PR TITLE
feat(compute): pre-execution commons credit reservation (#1404)

### DIFF
--- a/icn/crates/icn-compute/src/actor/command.rs
+++ b/icn/crates/icn-compute/src/actor/command.rs
@@ -60,4 +60,8 @@ pub(crate) enum ComputeCommand {
         dispute_id: icn_ccl::DisputeId,
         resp: tokio::sync::oneshot::Sender<Option<icn_ccl::DisputeStatus>>,
     },
+    /// Trigger timeout sweep directly (test-only; production uses background timer).
+    TriggerTimeoutSweep {
+        resp: tokio::sync::oneshot::Sender<Result<(), crate::error::ComputeError>>,
+    },
 }

--- a/icn/crates/icn-compute/src/actor/handle.rs
+++ b/icn/crates/icn-compute/src/actor/handle.rs
@@ -192,6 +192,22 @@ impl ComputeHandle {
             .map_err(|_| ComputeError::Internal("no response".into()))?
     }
 
+    /// Trigger timeout sweep directly (test-only; production uses background timer).
+    ///
+    /// # Note
+    /// This method exists solely to support integration tests. Do not call it in production.
+    #[doc(hidden)]
+    pub async fn trigger_timeout_sweep(&self) -> Result<(), ComputeError> {
+        let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
+        self.tx
+            .send(ComputeCommand::TriggerTimeoutSweep { resp: resp_tx })
+            .await
+            .map_err(|_| ComputeError::Internal("actor closed".into()))?;
+        resp_rx
+            .await
+            .map_err(|_| ComputeError::Internal("no response".into()))?
+    }
+
     /// Get dispute status by ID
     pub async fn get_dispute_status(
         &self,

--- a/icn/crates/icn-compute/src/actor/lifecycle.rs
+++ b/icn/crates/icn-compute/src/actor/lifecycle.rs
@@ -8,8 +8,8 @@ use tokio::sync::Mutex;
 
 use super::consensus::{outcome_to_value, results_match};
 use super::types::{
-    CommonsPaymentRequest, ComputeEvent, ExecutorInfo, PaymentRequest, ResultConsensus,
-    SendCallback,
+    CommonsPaymentRequest, CommonsReleaseCallback, CommonsReleaseRequest, CommonsReserveRequest,
+    ComputeEvent, ExecutorInfo, PaymentRequest, ResultConsensus, SendCallback,
 };
 use super::ComputeActor;
 use crate::error::ComputeError;
@@ -971,6 +971,10 @@ impl ComputeActor {
         //
         // Belt + suspenders: settle_commons_receipt() hard-rejects any scope != Commons,
         // so even if this check is bypassed, the ledger invariant holds.
+        //
+        // Settlement semantics change with reservation (#1404): once CommonsReserveCallback
+        // is configured, the app-layer implementation of this callback must reconcile against
+        // the hold established for task_id rather than performing an unrelated free-pool debit.
         if let crate::types::ExecutionOutcome::Success(_) = &result.outcome {
             if claimed_task.scope == icn_kernel_api::ScopeLevel::Commons {
                 if let Some(ref commons_cb) = self.commons_settlement_callback {
@@ -996,6 +1000,37 @@ impl ComputeActor {
                         task_id: claimed_task.id.clone(),
                     });
                 }
+                // Phase 2a: consume the reservation on success (#1404).
+                // The reservation hold is released by settlement reconciliation in the
+                // app layer; here we just remove it from the kernel's ephemeral index.
+                self.pending_reservations
+                    .lock()
+                    .await
+                    .remove(&claimed_task.id);
+            }
+        }
+
+        // Phase 2b: release reservation on non-success outcomes (#1404).
+        //
+        // On failure/out-of-fuel, credits were not consumed — return the hold to
+        // the submitter via the release callback (idempotent; no-op if no reservation).
+        if !matches!(&result.outcome, crate::types::ExecutionOutcome::Success(_))
+            && claimed_task.scope == icn_kernel_api::ScopeLevel::Commons
+        {
+            let reserved = self
+                .pending_reservations
+                .lock()
+                .await
+                .remove(&claimed_task.id);
+            if let (Some(reserved_amount), Some(ref release_cb)) =
+                (reserved, &self.commons_release_callback)
+            {
+                release_cb(CommonsReleaseRequest {
+                    consumer: claimed_task.submitter.clone(),
+                    task_id: claimed_task.id.clone(),
+                    reserved_amount,
+                });
+                icn_obs::metrics::compute::commons_reservation_released_inc("failure");
             }
         }
 
@@ -1075,6 +1110,8 @@ impl ComputeActor {
         send_callback: &Option<SendCallback>,
         scope_queue_depths: &Arc<Mutex<HashMap<icn_kernel_api::ScopeLevel, usize>>>,
         task_scope_map: &Arc<Mutex<HashMap<TaskHash, icn_kernel_api::ScopeLevel>>>,
+        pending_reservations: &Arc<Mutex<HashMap<String, i64>>>,
+        commons_release_callback: &Option<CommonsReleaseCallback>,
     ) -> Result<(), ComputeError> {
         let now = icn_time::current_timestamp_millis();
 
@@ -1098,12 +1135,13 @@ impl ComputeActor {
                 "Task exceeded deadline, marking as failed"
             );
 
-            // Get task info for broadcasting
+            // Get task info for broadcasting and reservation release
             let mut mgr = task_manager.lock().await;
             let task_id = mgr
                 .get(&hash)
                 .map(|t| t.id.clone())
                 .unwrap_or_else(|| "unknown".to_string());
+            let submitter = mgr.get(&hash).map(|t| t.submitter.clone());
 
             // Mark as failed
             mgr.fail(&hash, "Deadline exceeded".to_string())?;
@@ -1121,13 +1159,28 @@ impl ComputeActor {
                     }
                 }
             }
-            // Decrement scope queue depth
+            // Decrement scope queue depth and release commons reservation on timeout
             {
                 let scope = task_scope_map.lock().await.remove(&hash);
-                if let Some(scope) = scope {
+                if let Some(ref scope) = scope {
                     let mut depths = scope_queue_depths.lock().await;
-                    if let Some(count) = depths.get_mut(&scope) {
+                    if let Some(count) = depths.get_mut(scope) {
                         *count = count.saturating_sub(1);
+                    }
+                }
+                // Phase 2c: release commons credit reservation on timeout (#1404).
+                // Idempotent: no-op if no reservation exists for task_id.
+                if scope == Some(icn_kernel_api::ScopeLevel::Commons) {
+                    let reserved = pending_reservations.lock().await.remove(&task_id);
+                    if let (Some(reserved_amount), Some(ref release_cb), Some(consumer)) =
+                        (reserved, commons_release_callback, submitter)
+                    {
+                        release_cb(CommonsReleaseRequest {
+                            consumer,
+                            task_id: task_id.clone(),
+                            reserved_amount,
+                        });
+                        icn_obs::metrics::compute::commons_reservation_released_inc("timeout");
                     }
                 }
             }
@@ -1239,6 +1292,51 @@ impl ComputeActor {
                         "Commons task rejected: insufficient credits"
                     );
                     return Err(ComputeError::InsufficientCommonsCredits { balance, required });
+                }
+            }
+        }
+
+        // Phase 1: pre-execution commons credit reservation (#1404)
+        //
+        // The balance check above is an ADVISORY fast-fail only — it does not hold credits
+        // and cannot prevent a concurrent submission from consuming the same balance.
+        // This callback is the AUTHORITATIVE, race-free admission gate: it must atomically
+        // read-and-hold `amount` credits against `task_id`. On Err (race lost), reject.
+        //
+        // Backward compatibility: no reserve callback configured = advisory-check-only mode.
+        // This is not race-free correctness mode — configure the callback for correct enforcement.
+        if task.scope == icn_kernel_api::ScopeLevel::Commons {
+            if let Some(ref reserve_cb) = self.commons_reserve_callback {
+                let required = crate::cost::compute_credits_required(&task);
+                match reserve_cb(CommonsReserveRequest {
+                    consumer: task.submitter.clone(),
+                    amount: required,
+                    task_id: task.id.clone(),
+                }) {
+                    Ok(()) => {
+                        self.pending_reservations
+                            .lock()
+                            .await
+                            .insert(task.id.clone(), required);
+                        icn_obs::metrics::compute::commons_reservation_created_inc();
+                        tracing::debug!(
+                            task_id = %task.id,
+                            consumer = %task.submitter,
+                            amount = required,
+                            "Commons credit reservation created"
+                        );
+                    }
+                    Err(reason) => {
+                        tracing::warn!(
+                            task_id = %task.id,
+                            reason = %reason,
+                            "Commons reservation race: insufficient credits at atomic check"
+                        );
+                        return Err(ComputeError::InsufficientCommonsCredits {
+                            balance: 0,
+                            required,
+                        });
+                    }
                 }
             }
         }

--- a/icn/crates/icn-compute/src/actor/lifecycle.rs
+++ b/icn/crates/icn-compute/src/actor/lifecycle.rs
@@ -340,7 +340,10 @@ impl ComputeActor {
             let duration_ms = accepted_result.duration_ms;
 
             let mut mgr = self.task_manager.lock().await;
-            if mgr.get(&accepted_result.task_hash).is_some() {
+            let task_reservation_info = mgr
+                .get(&accepted_result.task_hash)
+                .map(|t| (t.id.clone(), t.scope, t.submitter.clone()));
+            if task_reservation_info.is_some() {
                 mgr.complete(accepted_result)?;
             }
             drop(mgr);
@@ -371,6 +374,27 @@ impl ComputeActor {
                     duration_ms,
                 });
             }
+
+            // Release/consume commons reservation based on outcome (#1404)
+            if let Some((task_id, icn_kernel_api::ScopeLevel::Commons, consumer)) =
+                task_reservation_info
+            {
+                if matches!(&outcome, crate::types::ExecutionOutcome::Success(_)) {
+                    self.pending_reservations.lock().await.remove(&task_id);
+                } else {
+                    let reserved = self.pending_reservations.lock().await.remove(&task_id);
+                    if let (Some(reserved_amount), Some(ref release_cb)) =
+                        (reserved, &self.commons_release_callback)
+                    {
+                        release_cb(CommonsReleaseRequest {
+                            consumer,
+                            task_id,
+                            reserved_amount,
+                        });
+                        icn_obs::metrics::compute::commons_reservation_released_inc("failure");
+                    }
+                }
+            }
         }
 
         Ok(())
@@ -385,7 +409,10 @@ impl ComputeActor {
         let duration_ms = result.duration_ms;
 
         let mut mgr = self.task_manager.lock().await;
-        if mgr.get(&task_hash).is_some() {
+        let task_reservation_info = mgr
+            .get(&task_hash)
+            .map(|t| (t.id.clone(), t.scope, t.submitter.clone()));
+        if task_reservation_info.is_some() {
             mgr.complete(result)?;
         }
         drop(mgr);
@@ -415,6 +442,27 @@ impl ComputeActor {
                 fuel_used,
                 duration_ms,
             });
+        }
+
+        // Release/consume commons reservation based on outcome (#1404)
+        if let Some((task_id, icn_kernel_api::ScopeLevel::Commons, consumer)) =
+            task_reservation_info
+        {
+            if matches!(&outcome, crate::types::ExecutionOutcome::Success(_)) {
+                self.pending_reservations.lock().await.remove(&task_id);
+            } else {
+                let reserved = self.pending_reservations.lock().await.remove(&task_id);
+                if let (Some(reserved_amount), Some(ref release_cb)) =
+                    (reserved, &self.commons_release_callback)
+                {
+                    release_cb(CommonsReleaseRequest {
+                        consumer,
+                        task_id,
+                        reserved_amount,
+                    });
+                    icn_obs::metrics::compute::commons_reservation_released_inc("failure");
+                }
+            }
         }
 
         Ok(())
@@ -527,14 +575,19 @@ impl ComputeActor {
             "Received task cancellation"
         );
 
-        // Get the executor if task was claimed
-        let executor_did = {
+        // Get executor and reservation info before cancellation
+        let (executor_did, task_reservation_info) = {
             let mgr = self.task_manager.lock().await;
-            if let Some(TaskStatus::Claimed { executor, .. }) = mgr.status(&task_hash) {
-                Some(executor.clone())
-            } else {
-                None
-            }
+            let executor_did =
+                if let Some(TaskStatus::Claimed { executor, .. }) = mgr.status(&task_hash) {
+                    Some(executor.clone())
+                } else {
+                    None
+                };
+            let task_reservation_info = mgr
+                .get(&task_hash)
+                .map(|t| (t.id.clone(), t.scope, t.submitter.clone()));
+            (executor_did, task_reservation_info)
         };
 
         // Cancel the task in our local manager
@@ -576,6 +629,24 @@ impl ComputeActor {
             task_hash = %task_hash_str,
             "Task cancelled successfully"
         );
+
+        // Release commons reservation on network-level cancellation (#1404).
+        // Idempotent: no-op if no reservation exists for this task_id.
+        if let Some((task_id, icn_kernel_api::ScopeLevel::Commons, consumer)) =
+            task_reservation_info
+        {
+            let reserved = self.pending_reservations.lock().await.remove(&task_id);
+            if let (Some(reserved_amount), Some(ref release_cb)) =
+                (reserved, &self.commons_release_callback)
+            {
+                release_cb(CommonsReleaseRequest {
+                    consumer,
+                    task_id,
+                    reserved_amount,
+                });
+                icn_obs::metrics::compute::commons_reservation_released_inc("cancelled");
+            }
+        }
 
         Ok(())
     }
@@ -760,6 +831,26 @@ impl ComputeActor {
                             }
                             drop(registry);
                             self.decrement_scope_queue(&hash).await;
+                            // Release commons reservation on WasmRef resolution failure (#1404)
+                            if claimed_task.scope == icn_kernel_api::ScopeLevel::Commons {
+                                let reserved = self
+                                    .pending_reservations
+                                    .lock()
+                                    .await
+                                    .remove(&claimed_task.id);
+                                if let (Some(reserved_amount), Some(ref release_cb)) =
+                                    (reserved, &self.commons_release_callback)
+                                {
+                                    release_cb(CommonsReleaseRequest {
+                                        consumer: claimed_task.submitter.clone(),
+                                        task_id: claimed_task.id.clone(),
+                                        reserved_amount,
+                                    });
+                                    icn_obs::metrics::compute::commons_reservation_released_inc(
+                                        "failure",
+                                    );
+                                }
+                            }
                             return Err(ComputeError::ModuleFetchFailed {
                                 hash: wasm_hash_hex,
                                 reason: e.to_string(),
@@ -785,6 +876,24 @@ impl ComputeActor {
                     }
                     drop(registry);
                     self.decrement_scope_queue(&hash).await;
+                    // Release commons reservation when WASM registry is missing (#1404)
+                    if claimed_task.scope == icn_kernel_api::ScopeLevel::Commons {
+                        let reserved = self
+                            .pending_reservations
+                            .lock()
+                            .await
+                            .remove(&claimed_task.id);
+                        if let (Some(reserved_amount), Some(ref release_cb)) =
+                            (reserved, &self.commons_release_callback)
+                        {
+                            release_cb(CommonsReleaseRequest {
+                                consumer: claimed_task.submitter.clone(),
+                                task_id: claimed_task.id.clone(),
+                                reserved_amount,
+                            });
+                            icn_obs::metrics::compute::commons_reservation_released_inc("failure");
+                        }
+                    }
                     return Err(ComputeError::ModuleFetchFailed {
                         hash: wasm_hash_hex,
                         reason: "WASM registry not configured".to_string(),
@@ -1142,6 +1251,8 @@ impl ComputeActor {
                 .map(|t| t.id.clone())
                 .unwrap_or_else(|| "unknown".to_string());
             let submitter = mgr.get(&hash).map(|t| t.submitter.clone());
+            // task_scope covers Pending tasks that were never claimed (no task_scope_map entry)
+            let task_scope = mgr.get(&hash).map(|t| t.scope);
 
             // Mark as failed
             mgr.fail(&hash, "Deadline exceeded".to_string())?;
@@ -1170,7 +1281,11 @@ impl ComputeActor {
                 }
                 // Phase 2c: release commons credit reservation on timeout (#1404).
                 // Idempotent: no-op if no reservation exists for task_id.
-                if scope == Some(icn_kernel_api::ScopeLevel::Commons) {
+                // scope covers claimed tasks (task_scope_map entry); task_scope covers
+                // Pending tasks that timed out before any executor claimed them.
+                let is_commons = scope == Some(icn_kernel_api::ScopeLevel::Commons)
+                    || task_scope == Some(icn_kernel_api::ScopeLevel::Commons);
+                if is_commons {
                     let reserved = pending_reservations.lock().await.remove(&task_id);
                     if let (Some(reserved_amount), Some(ref release_cb), Some(consumer)) =
                         (reserved, commons_release_callback, submitter)
@@ -1513,6 +1628,13 @@ impl ComputeActor {
         // Cancel in local manager (validates authorization)
         let now = icn_time::current_timestamp_millis();
 
+        // Capture reservation info before cancellation
+        let task_reservation_info = {
+            let mgr = self.task_manager.lock().await;
+            mgr.get(task_hash)
+                .map(|t| (t.id.clone(), t.scope, t.submitter.clone()))
+        };
+
         let mut mgr = self.task_manager.lock().await;
         mgr.cancel(task_hash, requester, reason.clone())?;
         drop(mgr);
@@ -1532,6 +1654,24 @@ impl ComputeActor {
                 reason,
                 cancelled_at: now,
             });
+        }
+
+        // Release commons reservation on local cancellation (#1404).
+        // Idempotent: no-op if no reservation exists for this task_id.
+        if let Some((task_id, icn_kernel_api::ScopeLevel::Commons, consumer)) =
+            task_reservation_info
+        {
+            let reserved = self.pending_reservations.lock().await.remove(&task_id);
+            if let (Some(reserved_amount), Some(ref release_cb)) =
+                (reserved, &self.commons_release_callback)
+            {
+                release_cb(CommonsReleaseRequest {
+                    consumer,
+                    task_id,
+                    reserved_amount,
+                });
+                icn_obs::metrics::compute::commons_reservation_released_inc("cancelled");
+            }
         }
 
         Ok(())

--- a/icn/crates/icn-compute/src/actor/mod.rs
+++ b/icn/crates/icn-compute/src/actor/mod.rs
@@ -14,8 +14,9 @@ mod types;
 // Re-export public types
 pub use handle::ComputeHandle;
 pub use types::{
-    BalanceCallback, CommonsPaymentRequest, CommonsSettlementCallback, ComputeEvent, EventCallback,
-    LocalityCallback, PaymentCallback, PaymentRequest, SendCallback, TrustCallback,
+    BalanceCallback, CommonsPaymentRequest, CommonsReleaseCallback, CommonsReleaseRequest,
+    CommonsReserveCallback, CommonsReserveRequest, CommonsSettlementCallback, ComputeEvent,
+    EventCallback, LocalityCallback, PaymentCallback, PaymentRequest, SendCallback, TrustCallback,
 };
 
 // Internal imports from submodules
@@ -119,7 +120,22 @@ pub struct ComputeActor {
     balance_callback: Option<BalanceCallback>,
     /// Callback for settling commons credits on task completion (E7 - #948).
     /// Fires when a commons-scope task completes successfully.
+    /// App-layer implementation must reconcile against the reservation established
+    /// by `commons_reserve_callback` rather than performing a free-pool debit (#1404).
     commons_settlement_callback: Option<CommonsSettlementCallback>,
+    /// Authoritative race-free admission gate for commons tasks (#1404).
+    /// When set, `handle_submit()` calls this after the advisory balance check.
+    /// The callee atomically holds `amount` credits; on Err the task is rejected.
+    /// Not set = rollout compatibility mode (advisory check only, no hold).
+    commons_reserve_callback: Option<CommonsReserveCallback>,
+    /// Callback to release a commons credit hold on non-success outcomes (#1404).
+    /// Fires on task failure, out-of-fuel, or timeout. Must be idempotent.
+    commons_release_callback: Option<CommonsReleaseCallback>,
+    /// Ephemeral index of outstanding commons credit reservations (#1404).
+    /// Maps task_id → reserved_amount. Populated on successful reserve_cb call;
+    /// cleared on settlement (Success) or release (non-Success / timeout).
+    /// Not persisted — consistent with task state loss on process crash (V1 limitation).
+    pending_reservations: Arc<Mutex<HashMap<String, i64>>>,
     /// WASM registry for execute-by-hash (Issue #1074)
     wasm_registry: Option<Arc<WasmRegistry>>,
     /// Resource refresh configuration
@@ -170,6 +186,9 @@ impl ComputeActor {
             commons_pool_policy: None,
             balance_callback: None,
             commons_settlement_callback: None,
+            commons_reserve_callback: None,
+            commons_release_callback: None,
+            pending_reservations: Arc::new(Mutex::new(HashMap::new())),
             wasm_registry: None,
             resource_refresh_config: crate::scheduler::ResourceRefreshConfig::default(),
             cached_capacity: Arc::new(Mutex::new(None)),
@@ -230,6 +249,30 @@ impl ComputeActor {
     /// Must be set alongside `set_commons_pool_policy` for credit validation to activate.
     pub fn set_balance_callback(&mut self, cb: BalanceCallback) {
         self.balance_callback = Some(cb);
+    }
+
+    /// Set the authoritative commons credit reservation callback (#1404).
+    ///
+    /// When set, `handle_submit()` calls this after the advisory balance floor check
+    /// to atomically hold `compute_credits_required(&task)` credits. If the callee
+    /// returns `Err`, the task is rejected with `InsufficientCommonsCredits`.
+    ///
+    /// **Must be set alongside `set_commons_release_callback`** for complete two-phase
+    /// commit semantics. Without both, reservation is silently skipped.
+    ///
+    /// Without this callback: advisory check only — rollout compatibility mode, not
+    /// race-free. Configure to enable correct concurrent-submission enforcement.
+    pub fn set_commons_reserve_callback(&mut self, cb: CommonsReserveCallback) {
+        self.commons_reserve_callback = Some(cb);
+    }
+
+    /// Set the commons credit release callback (#1404).
+    ///
+    /// Fires when a commons-scope task fails, runs out of fuel, or times out.
+    /// The callee must release the hold established by `CommonsReserveCallback`
+    /// for the given `task_id`. Must be idempotent (no-op if task_id not found).
+    pub fn set_commons_release_callback(&mut self, cb: CommonsReleaseCallback) {
+        self.commons_release_callback = Some(cb);
     }
 
     /// Set dispute resolution system (Phase 18 Week 4)
@@ -459,6 +502,8 @@ impl ComputeActor {
         let send_callback_clone = self.send_callback.clone();
         let scope_depths_clone = Arc::clone(&self.scope_queue_depths);
         let task_scope_map_clone = Arc::clone(&self.task_scope_map);
+        let pending_reservations_clone = Arc::clone(&self.pending_reservations);
+        let commons_release_cb_clone = self.commons_release_callback.clone();
 
         // Spawn timeout checker task
         tokio::spawn(async move {
@@ -471,6 +516,8 @@ impl ComputeActor {
                     &send_callback_clone,
                     &scope_depths_clone,
                     &task_scope_map_clone,
+                    &pending_reservations_clone,
+                    &commons_release_cb_clone,
                 )
                 .await
                 {

--- a/icn/crates/icn-compute/src/actor/mod.rs
+++ b/icn/crates/icn-compute/src/actor/mod.rs
@@ -263,6 +263,13 @@ impl ComputeActor {
     /// Without this callback: advisory check only — rollout compatibility mode, not
     /// race-free. Configure to enable correct concurrent-submission enforcement.
     pub fn set_commons_reserve_callback(&mut self, cb: CommonsReserveCallback) {
+        if self.commons_release_callback.is_none() {
+            tracing::warn!(
+                "setting commons_reserve_callback without commons_release_callback; \
+                 reservations will not be released on failure/timeout — \
+                 call set_commons_release_callback before first submit"
+            );
+        }
         self.commons_reserve_callback = Some(cb);
     }
 
@@ -896,6 +903,19 @@ impl ComputeActor {
                         } else {
                             let _ = resp.send(None);
                         }
+                    }
+                    ComputeCommand::TriggerTimeoutSweep { resp } => {
+                        let result = Self::check_timeouts(
+                            &self.task_manager,
+                            &self.executor_registry,
+                            &self.send_callback,
+                            &self.scope_queue_depths,
+                            &self.task_scope_map,
+                            &self.pending_reservations,
+                            &self.commons_release_callback,
+                        )
+                        .await;
+                        let _ = resp.send(result);
                     }
                 }
             }

--- a/icn/crates/icn-compute/src/actor/types.rs
+++ b/icn/crates/icn-compute/src/actor/types.rs
@@ -150,4 +150,61 @@ pub struct CommonsPaymentRequest {
 /// 1. Fetching the consumer's current commons credit balance.
 /// 2. Constructing a `CommonsSettlementRequest` and calling `settle_commons_receipt()`.
 /// 3. Appending the resulting earn/spend entries to the ledger.
+///
+/// **Settlement semantics change with reservation (#1404):** once `CommonsReserveCallback`
+/// is configured, the app-layer implementation of this callback must reconcile against
+/// the hold established for `task_id` rather than performing an unrelated free-pool debit.
+/// The callback interface is unchanged; the contract is not.
 pub type CommonsSettlementCallback = Arc<dyn Fn(CommonsPaymentRequest) + Send + Sync>;
+
+/// Request to reserve commons credits at task submission time (#1404).
+///
+/// Fired by `handle_submit()` for Commons-scoped tasks after the advisory balance
+/// floor check passes. The callee MUST atomically read the submitter's balance and
+/// hold `amount` credits against `task_id`. If the balance is insufficient after
+/// the atomic read (race condition — another task consumed credits between the
+/// advisory check and this call), return `Err(reason)`.
+#[derive(Debug, Clone)]
+pub struct CommonsReserveRequest {
+    /// DID of the consumer (submitter — credits are held from their balance).
+    pub consumer: String,
+    /// Credits to reserve. Computed by `cost::compute_credits_required(&task)`.
+    pub amount: i64,
+    /// Task ID used as the reservation key. Unique per submission.
+    pub task_id: String,
+}
+
+/// Authoritative race-free admission gate for commons tasks (#1404).
+///
+/// The advisory balance check in `handle_submit()` is a fast-fail hint only.
+/// This callback is the **authoritative** gate: it must atomically read-and-hold,
+/// making it safe against concurrent submissions from the same submitter.
+///
+/// Returns `Ok(())` if successfully reserved; `Err(reason)` if the balance is
+/// insufficient (race condition). On `Err`, `handle_submit()` rejects the task.
+///
+/// **Backward compatibility:** if this callback is not configured, the reservation
+/// gate is skipped silently. This is **rollout compatibility mode**, not race-free
+/// correctness mode. Configure this callback to enable correct enforcement.
+pub type CommonsReserveCallback =
+    Arc<dyn Fn(CommonsReserveRequest) -> Result<(), String> + Send + Sync>;
+
+/// Request to release a previously reserved commons credit hold (#1404).
+///
+/// Fired by `on_task_completed()` when outcome is not Success, and by
+/// `check_timeouts()` when a task exceeds its deadline.
+#[derive(Debug, Clone)]
+pub struct CommonsReleaseRequest {
+    /// DID of the consumer (submitter).
+    pub consumer: String,
+    /// Task ID used as the reservation key.
+    pub task_id: String,
+    /// Originally reserved amount (for audit). The callee keys on `task_id`, not this.
+    pub reserved_amount: i64,
+}
+
+/// Callback to release a pending commons credit reservation (#1404).
+///
+/// Must be idempotent: if no reservation exists for `task_id`, the callee
+/// must succeed silently (no-op). This handles double-release races gracefully.
+pub type CommonsReleaseCallback = Arc<dyn Fn(CommonsReleaseRequest) + Send + Sync>;

--- a/icn/crates/icn-compute/src/lib.rs
+++ b/icn/crates/icn-compute/src/lib.rs
@@ -47,9 +47,10 @@ mod wasm_executor;
 mod wasm_registry;
 
 pub use actor::{
-    BalanceCallback, CommonsPaymentRequest, CommonsSettlementCallback, ComputeActor, ComputeEvent,
-    ComputeHandle, EventCallback, LocalityCallback, PaymentCallback, PaymentRequest, SendCallback,
-    TrustCallback,
+    BalanceCallback, CommonsPaymentRequest, CommonsReleaseCallback, CommonsReleaseRequest,
+    CommonsReserveCallback, CommonsReserveRequest, CommonsSettlementCallback, ComputeActor,
+    ComputeEvent, ComputeHandle, EventCallback, LocalityCallback, PaymentCallback, PaymentRequest,
+    SendCallback, TrustCallback,
 };
 pub use actor_model::{
     ActorCheckpoint, ActorEvent, ActorId, ActorMode, ActorRuntimeState, MigrationDecision,

--- a/icn/crates/icn-compute/tests/commons_integration.rs
+++ b/icn/crates/icn-compute/tests/commons_integration.rs
@@ -400,3 +400,319 @@ async fn test_affiliated_zero_trust_rejected_via_capacity_announce() {
     );
     assert_eq!(pool.participant_count(), 0);
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sprint 25: Pre-execution commons credit reservation tests (#1404)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// DIDs reused across reservation tests.
+const RES_EXECUTOR_DID: &str = "did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9";
+const RES_SUBMITTER_DID: &str = "did:icn:z9hSR6S7WPtxmTojgo6GG3k4yDPecgJY292j7xrsUGWBu";
+
+/// Build a commons task with the given `id` and CCL `code`.
+fn make_reservation_task(id: &str, code: &str) -> icn_compute::ComputeTask {
+    use icn_compute::{
+        DeterminismClass, ExecutorCapability, FuelLimit, PrivacyClass, TaskCode, TaskPriority,
+    };
+    icn_compute::ComputeTask {
+        id: id.to_string(),
+        submitter: RES_SUBMITTER_DID.to_string(),
+        coop_id: None,
+        code: TaskCode::Ccl(code.to_string()),
+        inputs: vec![],
+        fuel_limit: FuelLimit(10_000), // cost::compute_credits_required → 10 credits
+        required_capabilities: vec![ExecutorCapability::Ccl],
+        priority: TaskPriority::Normal,
+        created_at: 1_000,
+        deadline: None,
+        payment_rate: None,
+        payment_currency: None,
+        resource_profile: None,
+        actor_mode: None,
+        placement_constraints: None,
+        federation_constraints: None,
+        estimated_value: None,
+        verification: None,
+        inputs_hash: None,
+        policy_hash: None,
+        determinism_class: DeterminismClass::default(),
+        privacy_class: PrivacyClass::default(),
+        storage_class: None,
+        data_locality: None,
+        scope: icn_kernel_api::ScopeLevel::Commons,
+    }
+}
+
+/// Valid CCL contract that executes successfully (returns Int 1).
+fn valid_ccl() -> String {
+    format!(
+        r#"{{
+            "name": "ReservationTest",
+            "participants": ["{RES_EXECUTOR_DID}"],
+            "currency": null,
+            "state_vars": [],
+            "rules": [{{
+                "name": "run",
+                "params": [],
+                "requires": [],
+                "body": [{{ "Return": {{ "value": {{ "Literal": {{ "Int": 1 }} }} }} }}]
+            }}],
+            "triggers": []
+        }}"#
+    )
+}
+
+/// Invalid CCL (not JSON) that produces ExecutionOutcome::Failed.
+fn failing_ccl() -> &'static str {
+    "NOT_VALID_JSON"
+}
+
+/// Test: reserve_cb is called at submit time with the correct consumer / amount / task_id.
+///
+/// The advisory balance check passes (balance 1_000_000 >> required 10).
+/// The reserve_cb must be called exactly once before submit returns Ok.
+#[tokio::test]
+async fn test_reservation_created_at_submit() {
+    use icn_compute::{BalanceCallback, CommonsReserveCallback, CommonsReserveRequest};
+    use std::sync::Mutex;
+
+    let reserves: Arc<Mutex<Vec<CommonsReserveRequest>>> = Arc::new(Mutex::new(vec![]));
+    let reserves_cb = Arc::clone(&reserves);
+
+    let trust_cb: TrustCallback = Arc::new(|_| 1.0);
+    let balance_cb: BalanceCallback = Arc::new(|_| 1_000_000);
+    let reserve_cb: CommonsReserveCallback = Arc::new(move |req| {
+        reserves_cb.lock().unwrap().push(req);
+        Ok(())
+    });
+
+    let mut actor = ComputeActor::new(RES_EXECUTOR_DID.into(), trust_cb);
+    actor.set_balance_callback(balance_cb);
+    actor.set_commons_reserve_callback(reserve_cb);
+    let handle = actor.spawn();
+
+    let result = handle
+        .submit(make_reservation_task("res-submit-1", "{}"))
+        .await;
+    assert!(
+        result.is_ok(),
+        "submit must succeed with sufficient balance; got {result:?}"
+    );
+
+    let captured = reserves.lock().unwrap();
+    assert_eq!(
+        captured.len(),
+        1,
+        "reserve_cb must fire exactly once at submit"
+    );
+    assert_eq!(
+        captured[0].consumer, RES_SUBMITTER_DID,
+        "consumer must be the submitter DID"
+    );
+    assert_eq!(
+        captured[0].task_id, "res-submit-1",
+        "task_id must match the submitted task"
+    );
+    assert!(
+        captured[0].amount > 0,
+        "reserved amount must be positive (fuel=10000 → 10 credits)"
+    );
+}
+
+/// Test: release_cb is called (and pending map is empty) when a task fails execution.
+///
+/// Flow: submit creates reservation → gossip path triggers execution with invalid CCL
+/// → Failed outcome → release_cb fires with the reserved amount.
+#[tokio::test]
+async fn test_reservation_released_on_failure() {
+    use icn_compute::{
+        BalanceCallback, CommonsReleaseCallback, CommonsReleaseRequest, CommonsReserveCallback,
+    };
+    use std::sync::Mutex;
+
+    let releases: Arc<Mutex<Vec<CommonsReleaseRequest>>> = Arc::new(Mutex::new(vec![]));
+    let releases_cb = Arc::clone(&releases);
+    let reserve_calls: Arc<Mutex<Vec<i64>>> = Arc::new(Mutex::new(vec![]));
+    let reserve_calls_cb = Arc::clone(&reserve_calls);
+
+    let trust_cb: TrustCallback = Arc::new(|_| 1.0);
+    let balance_cb: BalanceCallback = Arc::new(|_| 1_000_000);
+    let reserve_cb: CommonsReserveCallback = Arc::new(move |req| {
+        reserve_calls_cb.lock().unwrap().push(req.amount);
+        Ok(())
+    });
+    let release_cb: CommonsReleaseCallback = Arc::new(move |req| {
+        releases_cb.lock().unwrap().push(req);
+    });
+
+    let mut actor = ComputeActor::new(RES_EXECUTOR_DID.into(), trust_cb);
+    actor.set_signing_key(vec![1u8; 32]);
+    actor.set_balance_callback(balance_cb);
+    actor.set_commons_reserve_callback(reserve_cb);
+    actor.set_commons_release_callback(release_cb);
+    let handle = actor.spawn();
+
+    let task = make_reservation_task("res-fail-1", failing_ccl());
+
+    // Phase 1: submit creates reservation
+    handle
+        .submit(task.clone())
+        .await
+        .expect("submit must succeed");
+
+    // Phase 2: gossip path triggers execution (invalid CCL → Failed)
+    handle
+        .handle_gossip(ComputeMessage::TaskSubmitted(Box::new(task)))
+        .await
+        .expect("gossip delivery must succeed");
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+    // release_cb must have fired once
+    let captured = releases.lock().unwrap();
+    assert_eq!(
+        captured.len(),
+        1,
+        "release_cb must fire exactly once on failure"
+    );
+    assert_eq!(
+        captured[0].consumer, RES_SUBMITTER_DID,
+        "release consumer must be the submitter"
+    );
+    assert_eq!(
+        captured[0].task_id, "res-fail-1",
+        "release task_id must match"
+    );
+    assert!(
+        captured[0].reserved_amount > 0,
+        "released amount must be positive"
+    );
+
+    // reserve_cb fired → reserved_amount == released_amount
+    let reserved = *reserve_calls.lock().unwrap().first().unwrap();
+    assert_eq!(
+        captured[0].reserved_amount, reserved,
+        "released amount must match what was reserved"
+    );
+}
+
+/// Test: release_cb is NOT called (reservation consumed) when a task succeeds; settlement_cb IS called.
+///
+/// Flow: submit creates reservation → gossip path triggers execution with valid CCL
+/// → Success outcome → settlement_cb fires, release_cb silent.
+#[tokio::test]
+async fn test_reservation_consumed_on_success() {
+    use icn_compute::{
+        BalanceCallback, CommonsPaymentRequest, CommonsReleaseCallback, CommonsReserveCallback,
+        CommonsSettlementCallback,
+    };
+    use std::sync::Mutex;
+
+    let releases: Arc<Mutex<Vec<icn_compute::CommonsReleaseRequest>>> =
+        Arc::new(Mutex::new(vec![]));
+    let releases_cb = Arc::clone(&releases);
+    let settlements: Arc<Mutex<Vec<CommonsPaymentRequest>>> = Arc::new(Mutex::new(vec![]));
+    let settlements_cb = Arc::clone(&settlements);
+
+    let trust_cb: TrustCallback = Arc::new(|_| 1.0);
+    let balance_cb: BalanceCallback = Arc::new(|_| 1_000_000);
+    let reserve_cb: CommonsReserveCallback = Arc::new(|_| Ok(()));
+    let release_cb: CommonsReleaseCallback =
+        Arc::new(move |req| releases_cb.lock().unwrap().push(req));
+    let settlement_cb: CommonsSettlementCallback =
+        Arc::new(move |req| settlements_cb.lock().unwrap().push(req));
+
+    let mut actor = ComputeActor::new(RES_EXECUTOR_DID.into(), trust_cb);
+    actor.set_signing_key(vec![1u8; 32]);
+    actor.set_balance_callback(balance_cb);
+    actor.set_commons_reserve_callback(reserve_cb);
+    actor.set_commons_release_callback(release_cb);
+    actor.set_commons_settlement_callback(settlement_cb);
+    let handle = actor.spawn();
+
+    let task = make_reservation_task("res-success-1", &valid_ccl());
+
+    // Phase 1: submit creates reservation
+    handle
+        .submit(task.clone())
+        .await
+        .expect("submit must succeed");
+
+    // Phase 2: gossip path triggers execution (valid CCL → Success)
+    handle
+        .handle_gossip(ComputeMessage::TaskSubmitted(Box::new(task)))
+        .await
+        .expect("gossip delivery must succeed");
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+    // release_cb must NOT fire on success (reservation consumed, not released)
+    let release_count = releases.lock().unwrap().len();
+    assert_eq!(
+        release_count, 0,
+        "release_cb must NOT fire on success; reservation is consumed"
+    );
+
+    // settlement_cb must fire (existing settlement path unaffected)
+    let settle_count = settlements.lock().unwrap().len();
+    assert_eq!(
+        settle_count, 1,
+        "settlement_cb must fire exactly once on success"
+    );
+}
+
+/// Test: reserve_cb returning Err causes handle_submit() to return InsufficientCommonsCredits.
+///
+/// Models a TOCTOU race where the balance was consumed between the advisory check and the
+/// atomic reserve. The task must be rejected.
+#[tokio::test]
+async fn test_reservation_race_rejection() {
+    use icn_compute::{BalanceCallback, CommonsReserveCallback, ComputeError};
+
+    let trust_cb: TrustCallback = Arc::new(|_| 1.0);
+    let balance_cb: BalanceCallback = Arc::new(|_| 1_000_000); // advisory check passes
+    let reserve_cb: CommonsReserveCallback =
+        Arc::new(|_| Err("balance consumed by concurrent submission".into()));
+
+    let mut actor = ComputeActor::new(RES_EXECUTOR_DID.into(), trust_cb);
+    actor.set_balance_callback(balance_cb);
+    actor.set_commons_reserve_callback(reserve_cb);
+    let handle = actor.spawn();
+
+    let result = handle
+        .submit(make_reservation_task("res-race-1", "{}"))
+        .await;
+
+    assert!(
+        matches!(result, Err(ComputeError::InsufficientCommonsCredits { .. })),
+        "race rejection must return InsufficientCommonsCredits; got {result:?}"
+    );
+}
+
+/// Test: actor without CommonsReserveCallback accepts Commons tasks without error.
+///
+/// This is ROLLOUT COMPATIBILITY MODE — advisory balance check only, not race-free.
+/// Document the trade-off: tasks without a reserve callback can still race to exhaust credits.
+#[tokio::test]
+async fn test_no_reserve_callback_is_backward_compatible() {
+    use icn_compute::{BalanceCallback, ComputeError};
+
+    let trust_cb: TrustCallback = Arc::new(|_| 1.0);
+    let balance_cb: BalanceCallback = Arc::new(|_| 1_000_000);
+
+    // No reserve callback configured — rollout compatibility mode
+    let mut actor = ComputeActor::new(RES_EXECUTOR_DID.into(), trust_cb);
+    actor.set_balance_callback(balance_cb);
+    let handle = actor.spawn();
+
+    let result = handle
+        .submit(make_reservation_task("res-compat-1", "{}"))
+        .await;
+
+    assert!(
+        !matches!(result, Err(ComputeError::InsufficientCommonsCredits { .. })),
+        "actor without reserve_cb must NOT reject with InsufficientCommonsCredits; got {result:?}"
+    );
+    // NOTE: This is advisory-only mode. The task is accepted, but no atomic hold is created.
+    // Configure CommonsReserveCallback for race-free correctness.
+}

--- a/icn/crates/icn-compute/tests/commons_integration.rs
+++ b/icn/crates/icn-compute/tests/commons_integration.rs
@@ -716,3 +716,78 @@ async fn test_no_reserve_callback_is_backward_compatible() {
     // NOTE: This is advisory-only mode. The task is accepted, but no atomic hold is created.
     // Configure CommonsReserveCallback for race-free correctness.
 }
+
+/// Test: reservation is released when task times out via check_timeouts() sweep.
+///
+/// Uses the test-only `trigger_timeout_sweep` command to avoid a 10-second background
+/// timer wait. The task is submitted with a near-future deadline; after sleeping past
+/// the deadline, the manual sweep marks the task failed and fires release_cb.
+#[tokio::test]
+async fn test_reservation_released_on_timeout() {
+    use icn_compute::{BalanceCallback, CommonsReleaseCallback, CommonsReserveCallback};
+    use std::sync::Mutex;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let releases: Arc<Mutex<Vec<icn_compute::CommonsReleaseRequest>>> =
+        Arc::new(Mutex::new(vec![]));
+    let releases_cb = Arc::clone(&releases);
+
+    let trust_cb: TrustCallback = Arc::new(|_| 1.0);
+    let balance_cb: BalanceCallback = Arc::new(|_| 1_000_000);
+    let reserve_cb: CommonsReserveCallback = Arc::new(|_| Ok(()));
+    let release_cb: CommonsReleaseCallback =
+        Arc::new(move |req| releases_cb.lock().unwrap().push(req));
+
+    let mut actor = ComputeActor::new(RES_EXECUTOR_DID.into(), trust_cb);
+    actor.set_balance_callback(balance_cb);
+    actor.set_commons_reserve_callback(reserve_cb);
+    actor.set_commons_release_callback(release_cb);
+    let handle = actor.spawn();
+
+    // Set a deadline 150ms in the future so validation passes but expires quickly.
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    let mut task = make_reservation_task("res-timeout-1", "{}");
+    task.deadline = Some(now_ms + 150);
+    task.created_at = now_ms;
+
+    // Phase 1: submit creates the reservation
+    handle
+        .submit(task)
+        .await
+        .expect("submit must succeed when deadline is in the future");
+
+    // Wait for the deadline to pass
+    tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
+
+    // Phase 2c: trigger timeout sweep — should find the expired task and fire release_cb
+    handle
+        .trigger_timeout_sweep()
+        .await
+        .expect("timeout sweep must not error");
+
+    // Give the async release a moment to propagate
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    let captured = releases.lock().unwrap();
+    assert_eq!(
+        captured.len(),
+        1,
+        "release_cb must fire exactly once on timeout; got {} calls",
+        captured.len()
+    );
+    assert_eq!(
+        captured[0].consumer, RES_SUBMITTER_DID,
+        "release_cb consumer must match submitter"
+    );
+    assert_eq!(
+        captured[0].task_id, "res-timeout-1",
+        "release_cb task_id must match submitted task"
+    );
+    assert!(
+        captured[0].reserved_amount > 0,
+        "release_cb reserved_amount must be positive"
+    );
+}

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -3928,6 +3928,21 @@ pub mod compute {
     pub fn receipt_settlement_inc(scope: &'static str) {
         counter!("icn_compute_receipt_settlement_total", "scope" => scope).increment(1);
     }
+
+    // === Commons Credit Reservation Metrics (Sprint 25 #1404) ===
+
+    /// Increment counter when a commons credit reservation is created at submit time.
+    pub fn commons_reservation_created_inc() {
+        counter!("icn_compute_commons_reservation_created_total").increment(1);
+    }
+
+    /// Increment counter when a commons credit reservation is released.
+    ///
+    /// `reason` must be `"failure"` (non-success outcome) or `"timeout"` (deadline exceeded).
+    /// Low-cardinality label — no heap allocation on the hot path.
+    pub fn commons_reservation_released_inc(reason: &'static str) {
+        counter!("icn_compute_commons_reservation_released_total", "reason" => reason).increment(1);
+    }
 }
 
 /// Misbehavior detection metrics (Phase 18)

--- a/ops/state/sprint/current.json
+++ b/ops/state/sprint/current.json
@@ -68,9 +68,10 @@
     {
       "id": "s25-t6",
       "title": "PR → CI → merge",
-      "status": "waiting",
+      "status": "in_progress",
       "depends_on": ["s25-t4", "s25-t5"],
-      "notes": "Run /push skill. Verify fmt + clippy + test. Merge when green."
+      "pr": 1405,
+      "notes": "PR #1405 open. Waiting for CI. Merge when green."
     }
   ]
 }

--- a/ops/state/sprint/current.json
+++ b/ops/state/sprint/current.json
@@ -1,69 +1,76 @@
 {
-  "sprint": 24,
-  "theme": "Commons Compute Spine",
+  "sprint": 25,
+  "theme": "Pre-Execution Commons Credit Reservation",
   "governing_rule": "A task is only done when repo state, board state, and narrative state agree.",
-  "start_date": "2026-03-22",
+  "start_date": "2026-03-24",
   "status": "active",
   "spine": [
-    "#925",
-    "#947",
-    "#964"
+    "#1404"
   ],
+  "closed_sprint": {
+    "sprint": 24,
+    "theme": "Commons Compute Spine",
+    "start_date": "2026-03-22",
+    "closed_date": "2026-03-23",
+    "status": "done",
+    "shipped": [
+      "#947 — two-tier trust thresholds for unaffiliated pool admission (PR #1396)",
+      "#964 — stale commons pool participant expiry (PR #1396)",
+      "#925 — parent epic: commons resource pool + credit accounting substrate (closed as delivered)",
+      "#1397 — V1 scheduling-time credit enforcement floor at handle_submit() (PR #1398)",
+      "#1399 — cost-based commons credit enforcement: compute_credits_required() (PR #1400)"
+    ],
+    "ci_fixes": ["#1401 — hung docker-build-deploy Test job (PR #1402, #1403)"]
+  },
   "tasks": [
     {
-      "id": "s24-t1",
-      "title": "#947 Trust bootstrap for unaffiliated commons pool nodes",
-      "track": "A",
-      "status": "ready",
-      "github_issue": 947,
-      "branch": "feat/947-unaffiliated-trust-bootstrap",
-      "scope": "icn-compute/src/commons_pool.rs + actor/placement.rs",
-      "notes": "Add commons_admission_min_trust:0.0 to SybilPolicy, is_affiliated:bool to CommonsParticipant, branch in try_add_participant(). ~40 lines."
+      "id": "s25-t1",
+      "title": "Filed GitHub issue #1404 for pre-execution commons credit reservation",
+      "status": "done",
+      "github_issue": 1404
     },
     {
-      "id": "s24-t2",
-      "title": "#947 Integration test: unaffiliated node full path (announce\u2192pool\u2192task\u2192settlement)",
-      "track": "A",
-      "status": "ready",
-      "github_issue": 947,
-      "depends_on": [
-        "s24-t1"
-      ],
+      "id": "s25-t2",
+      "title": "New callback types + actor fields",
+      "status": "done",
+      "github_issue": 1404,
+      "branch": "feat/1404-commons-credit-reservation",
+      "scope": "icn-compute/src/actor/types.rs + mod.rs",
+      "notes": "Add CommonsReserveRequest, CommonsReleaseRequest, CommonsReserveCallback, CommonsReleaseCallback. Add pending_reservations field + setters. Extend check_timeouts() signature. ~60 lines."
+    },
+    {
+      "id": "s25-t3",
+      "title": "Two-phase commit in lifecycle.rs",
+      "status": "done",
+      "github_issue": 1404,
+      "depends_on": ["s25-t2"],
+      "scope": "icn-compute/src/actor/lifecycle.rs",
+      "notes": "Phase 1: reserve_cb call in handle_submit() after floor check. Phase 2a: remove from pending on success. Phase 2b: release_cb on non-success. Phase 2c: release_cb in check_timeouts() timeout sweep. ~65 lines."
+    },
+    {
+      "id": "s25-t4",
+      "title": "Tests: 5 functions covering all reservation paths",
+      "status": "done",
+      "github_issue": 1404,
+      "depends_on": ["s25-t3"],
       "scope": "icn-compute/tests/commons_integration.rs",
-      "notes": "Test through on_capacity_announce with trust_callback returning 0.0. Verify pool admission, task routing, credit settlement."
+      "notes": "reservation_created_at_submit, reservation_released_on_failure, reservation_consumed_on_success, reservation_race_rejection, no_reserve_callback_backward_compat. All backed by Arc<Mutex<Vec>> recorders. ~90 lines."
     },
     {
-      "id": "s24-t3",
-      "title": "#964 Stale commons pool participant expiry",
-      "track": "A",
-      "status": "ready",
-      "github_issue": 964,
-      "depends_on": [
-        "s24-t1"
-      ],
-      "scope": "icn-compute/src/commons_pool.rs + actor/placement.rs",
-      "notes": "Add expire_stale(max_age) method, StaleParticipantConfig, call on each announce, emit commons_pool_expired_total metric. ~30 lines."
+      "id": "s25-t5",
+      "title": "Metrics: 2 counters",
+      "status": "done",
+      "github_issue": 1404,
+      "depends_on": ["s25-t3"],
+      "scope": "icn-obs/src/metrics_legacy.rs",
+      "notes": "commons_reservation_created_total, commons_reservation_released_total{reason=failure|timeout}. ~12 lines."
     },
     {
-      "id": "s24-t4",
-      "title": "Close #947 and #925 after t1+t2 pass CI",
-      "track": "A",
+      "id": "s25-t6",
+      "title": "PR → CI → merge",
       "status": "waiting",
-      "depends_on": [
-        "s24-t1",
-        "s24-t2"
-      ],
-      "notes": "Merge branch, close #947, verify #946+#947+#948+#949 all closed, then close parent #925."
-    },
-    {
-      "id": "s24-t5",
-      "title": "Close #964 after t3 passes CI",
-      "track": "A",
-      "status": "waiting",
-      "depends_on": [
-        "s24-t3"
-      ],
-      "notes": "Merge stale expiry PR, close #964."
+      "depends_on": ["s25-t4", "s25-t5"],
+      "notes": "Run /push skill. Verify fmt + clippy + test. Merge when green."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Closes the TOCTOU race between `handle_submit()` balance check and settlement in the commons compute path
- Introduces two-phase commit: `CommonsReserveCallback` reserves credits at submit (authoritative gate); `CommonsReleaseCallback` releases on failure/timeout; existing settlement path unchanged on success
- Adds `pending_reservations: HashMap<task_id → amount>` as an ephemeral scheduling index in the compute actor

## Contract invariants

| Invariant | Behavior |
|-----------|----------|
| **Advisory vs. authoritative** | Existing `balance >= required` check is a fast-fail hint only. `CommonsReserveCallback` is the race-free gate: it must atomically read-and-hold |
| **Settlement semantics** | On success, `CommonsSettlementCallback` must reconcile against the reservation hold (not a free-pool debit). Interface unchanged; app-layer contract is not |
| **Crash semantics** | `pending_reservations` is ephemeral. Lost on crash, consistent with task state loss. V1 accepted trade-off |
| **Rollout compat** | No `CommonsReserveCallback` configured = advisory-check-only mode. Not race-free correctness mode — configure the callback for correct enforcement |
| **Meaning Firewall** | Compute actor holds only a mechanical `task_id → amount` index. No economic semantics in kernel |

## Changes

- `icn-compute/src/actor/types.rs` — `CommonsReserveRequest`, `CommonsReserveCallback`, `CommonsReleaseRequest`, `CommonsReleaseCallback`
- `icn-compute/src/actor/mod.rs` — 3 new fields, 2 setters, updated `check_timeouts()` call site
- `icn-compute/src/actor/lifecycle.rs` — Phase 1 (reserve at submit), Phase 2a (consume on success), Phase 2b (release on failure), Phase 2c (release on timeout)
- `icn-obs/src/metrics_legacy.rs` — `commons_reservation_created_total`, `commons_reservation_released_total{reason=failure|timeout}`
- `icn-compute/tests/commons_integration.rs` — 5 new tests: created_at_submit, released_on_failure, consumed_on_success, race_rejection, no_callback_backward_compat

## Test plan

- [x] `cargo test -p icn-compute --test commons_integration` — 14/14 pass
- [x] `cargo test -p icn-compute --test commons_settlement_integration` — 4/4 pass
- [x] `cargo clippy -p icn-compute -p icn-obs --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

Closes #1404

🤖 Generated with [Claude Code](https://claude.com/claude-code)