### PR TITLE
refactor(compute): extract reservation helpers + idempotence tests

### DIFF
--- a/icn/crates/icn-compute/src/actor/handle.rs
+++ b/icn/crates/icn-compute/src/actor/handle.rs
@@ -194,10 +194,10 @@ impl ComputeHandle {
 
     /// Trigger timeout sweep directly (test-only; production uses background timer).
     ///
-    /// # Note
-    /// This method exists solely to support integration tests. Do not call it in production.
+    /// Named with `_for_test` suffix to signal intent, consistent with other test-support
+    /// APIs in this crate (e.g., `commons_pool_for_test`). Do not call in production code.
     #[doc(hidden)]
-    pub async fn trigger_timeout_sweep(&self) -> Result<(), ComputeError> {
+    pub async fn trigger_timeout_sweep_for_test(&self) -> Result<(), ComputeError> {
         let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
         self.tx
             .send(ComputeCommand::TriggerTimeoutSweep { resp: resp_tx })

--- a/icn/crates/icn-compute/src/actor/lifecycle.rs
+++ b/icn/crates/icn-compute/src/actor/lifecycle.rs
@@ -49,6 +49,9 @@ async fn release_commons_reservation(
 /// Removes the hold from the kernel's ephemeral reservation index. The app-layer settlement
 /// callback (CommonsSettlementCallback) reconciles the reservation hold against the actual
 /// cost charged; this only removes the kernel's tracking entry.
+///
+/// Idempotent: if no reservation exists for `task_id`, this is a no-op (same guarantee
+/// as [`release_commons_reservation`]).
 async fn consume_commons_reservation(
     pending_reservations: &Arc<Mutex<HashMap<String, i64>>>,
     task_id: &str,
@@ -1299,7 +1302,11 @@ impl ComputeActor {
                             .await;
                         }
                         None => {
-                            // Task metadata unavailable; still purge the ephemeral reservation.
+                            // Theoretically unreachable: mgr.fail() guards this flow via `?`,
+                            // so if fail() returned Ok, mgr.get() could not have been None
+                            // under the same lock. Kept as a defensive purge-without-callback
+                            // fallback; the `remove` is idempotent if the reservation was
+                            // never created.
                             pending_reservations.lock().await.remove(&task_id);
                         }
                     }

--- a/icn/crates/icn-compute/src/actor/lifecycle.rs
+++ b/icn/crates/icn-compute/src/actor/lifecycle.rs
@@ -20,6 +20,42 @@ use crate::task::{TaskManager, TaskStatus};
 use crate::types::{ComputeMessage, ComputeResult, ComputeTask, TaskHash, TaskPriority};
 use crate::{MIN_TRUST_EXECUTE, MIN_TRUST_SUBMIT};
 
+/// Release a commons credit reservation on non-success task termination.
+///
+/// Removes the hold from the kernel's ephemeral reservation index and, if a release callback
+/// is configured, invokes it and emits a metric tagged with `reason`.
+///
+/// Idempotent: if no reservation exists for `task_id`, this is a no-op.
+async fn release_commons_reservation(
+    pending_reservations: &Arc<Mutex<HashMap<String, i64>>>,
+    release_cb: &Option<CommonsReleaseCallback>,
+    task_id: String,
+    consumer: String,
+    reason: &'static str,
+) {
+    let reserved = pending_reservations.lock().await.remove(&task_id);
+    if let (Some(reserved_amount), Some(ref cb)) = (reserved, release_cb) {
+        cb(CommonsReleaseRequest {
+            consumer,
+            task_id,
+            reserved_amount,
+        });
+        icn_obs::metrics::compute::commons_reservation_released_inc(reason);
+    }
+}
+
+/// Consume a commons credit reservation on successful task completion.
+///
+/// Removes the hold from the kernel's ephemeral reservation index. The app-layer settlement
+/// callback (CommonsSettlementCallback) reconciles the reservation hold against the actual
+/// cost charged; this only removes the kernel's tracking entry.
+async fn consume_commons_reservation(
+    pending_reservations: &Arc<Mutex<HashMap<String, i64>>>,
+    task_id: &str,
+) {
+    pending_reservations.lock().await.remove(task_id);
+}
+
 impl ComputeActor {
     /// Determine verification requirements for a task based on its estimated value
     /// or explicit verification configuration.
@@ -375,24 +411,21 @@ impl ComputeActor {
                 });
             }
 
-            // Release/consume commons reservation based on outcome (#1404)
+            // Settle commons reservation based on outcome (#1404)
             if let Some((task_id, icn_kernel_api::ScopeLevel::Commons, consumer)) =
                 task_reservation_info
             {
                 if matches!(&outcome, crate::types::ExecutionOutcome::Success(_)) {
-                    self.pending_reservations.lock().await.remove(&task_id);
+                    consume_commons_reservation(&self.pending_reservations, &task_id).await;
                 } else {
-                    let reserved = self.pending_reservations.lock().await.remove(&task_id);
-                    if let (Some(reserved_amount), Some(ref release_cb)) =
-                        (reserved, &self.commons_release_callback)
-                    {
-                        release_cb(CommonsReleaseRequest {
-                            consumer,
-                            task_id,
-                            reserved_amount,
-                        });
-                        icn_obs::metrics::compute::commons_reservation_released_inc("failure");
-                    }
+                    release_commons_reservation(
+                        &self.pending_reservations,
+                        &self.commons_release_callback,
+                        task_id,
+                        consumer,
+                        "failure",
+                    )
+                    .await;
                 }
             }
         }
@@ -444,24 +477,21 @@ impl ComputeActor {
             });
         }
 
-        // Release/consume commons reservation based on outcome (#1404)
+        // Settle commons reservation based on outcome (#1404)
         if let Some((task_id, icn_kernel_api::ScopeLevel::Commons, consumer)) =
             task_reservation_info
         {
             if matches!(&outcome, crate::types::ExecutionOutcome::Success(_)) {
-                self.pending_reservations.lock().await.remove(&task_id);
+                consume_commons_reservation(&self.pending_reservations, &task_id).await;
             } else {
-                let reserved = self.pending_reservations.lock().await.remove(&task_id);
-                if let (Some(reserved_amount), Some(ref release_cb)) =
-                    (reserved, &self.commons_release_callback)
-                {
-                    release_cb(CommonsReleaseRequest {
-                        consumer,
-                        task_id,
-                        reserved_amount,
-                    });
-                    icn_obs::metrics::compute::commons_reservation_released_inc("failure");
-                }
+                release_commons_reservation(
+                    &self.pending_reservations,
+                    &self.commons_release_callback,
+                    task_id,
+                    consumer,
+                    "failure",
+                )
+                .await;
             }
         }
 
@@ -635,17 +665,14 @@ impl ComputeActor {
         if let Some((task_id, icn_kernel_api::ScopeLevel::Commons, consumer)) =
             task_reservation_info
         {
-            let reserved = self.pending_reservations.lock().await.remove(&task_id);
-            if let (Some(reserved_amount), Some(ref release_cb)) =
-                (reserved, &self.commons_release_callback)
-            {
-                release_cb(CommonsReleaseRequest {
-                    consumer,
-                    task_id,
-                    reserved_amount,
-                });
-                icn_obs::metrics::compute::commons_reservation_released_inc("cancelled");
-            }
+            release_commons_reservation(
+                &self.pending_reservations,
+                &self.commons_release_callback,
+                task_id,
+                consumer,
+                "cancelled",
+            )
+            .await;
         }
 
         Ok(())
@@ -833,23 +860,14 @@ impl ComputeActor {
                             self.decrement_scope_queue(&hash).await;
                             // Release commons reservation on WasmRef resolution failure (#1404)
                             if claimed_task.scope == icn_kernel_api::ScopeLevel::Commons {
-                                let reserved = self
-                                    .pending_reservations
-                                    .lock()
-                                    .await
-                                    .remove(&claimed_task.id);
-                                if let (Some(reserved_amount), Some(ref release_cb)) =
-                                    (reserved, &self.commons_release_callback)
-                                {
-                                    release_cb(CommonsReleaseRequest {
-                                        consumer: claimed_task.submitter.clone(),
-                                        task_id: claimed_task.id.clone(),
-                                        reserved_amount,
-                                    });
-                                    icn_obs::metrics::compute::commons_reservation_released_inc(
-                                        "failure",
-                                    );
-                                }
+                                release_commons_reservation(
+                                    &self.pending_reservations,
+                                    &self.commons_release_callback,
+                                    claimed_task.id.clone(),
+                                    claimed_task.submitter.clone(),
+                                    "failure",
+                                )
+                                .await;
                             }
                             return Err(ComputeError::ModuleFetchFailed {
                                 hash: wasm_hash_hex,
@@ -878,21 +896,14 @@ impl ComputeActor {
                     self.decrement_scope_queue(&hash).await;
                     // Release commons reservation when WASM registry is missing (#1404)
                     if claimed_task.scope == icn_kernel_api::ScopeLevel::Commons {
-                        let reserved = self
-                            .pending_reservations
-                            .lock()
-                            .await
-                            .remove(&claimed_task.id);
-                        if let (Some(reserved_amount), Some(ref release_cb)) =
-                            (reserved, &self.commons_release_callback)
-                        {
-                            release_cb(CommonsReleaseRequest {
-                                consumer: claimed_task.submitter.clone(),
-                                task_id: claimed_task.id.clone(),
-                                reserved_amount,
-                            });
-                            icn_obs::metrics::compute::commons_reservation_released_inc("failure");
-                        }
+                        release_commons_reservation(
+                            &self.pending_reservations,
+                            &self.commons_release_callback,
+                            claimed_task.id.clone(),
+                            claimed_task.submitter.clone(),
+                            "failure",
+                        )
+                        .await;
                     }
                     return Err(ComputeError::ModuleFetchFailed {
                         hash: wasm_hash_hex,
@@ -1112,10 +1123,7 @@ impl ComputeActor {
                 // Phase 2a: consume the reservation on success (#1404).
                 // The reservation hold is released by settlement reconciliation in the
                 // app layer; here we just remove it from the kernel's ephemeral index.
-                self.pending_reservations
-                    .lock()
-                    .await
-                    .remove(&claimed_task.id);
+                consume_commons_reservation(&self.pending_reservations, &claimed_task.id).await;
             }
         }
 
@@ -1126,21 +1134,14 @@ impl ComputeActor {
         if !matches!(&result.outcome, crate::types::ExecutionOutcome::Success(_))
             && claimed_task.scope == icn_kernel_api::ScopeLevel::Commons
         {
-            let reserved = self
-                .pending_reservations
-                .lock()
-                .await
-                .remove(&claimed_task.id);
-            if let (Some(reserved_amount), Some(ref release_cb)) =
-                (reserved, &self.commons_release_callback)
-            {
-                release_cb(CommonsReleaseRequest {
-                    consumer: claimed_task.submitter.clone(),
-                    task_id: claimed_task.id.clone(),
-                    reserved_amount,
-                });
-                icn_obs::metrics::compute::commons_reservation_released_inc("failure");
-            }
+            release_commons_reservation(
+                &self.pending_reservations,
+                &self.commons_release_callback,
+                claimed_task.id.clone(),
+                claimed_task.submitter.clone(),
+                "failure",
+            )
+            .await;
         }
 
         // Broadcast result
@@ -1286,16 +1287,21 @@ impl ComputeActor {
                 let is_commons = scope == Some(icn_kernel_api::ScopeLevel::Commons)
                     || task_scope == Some(icn_kernel_api::ScopeLevel::Commons);
                 if is_commons {
-                    let reserved = pending_reservations.lock().await.remove(&task_id);
-                    if let (Some(reserved_amount), Some(ref release_cb), Some(consumer)) =
-                        (reserved, commons_release_callback, submitter)
-                    {
-                        release_cb(CommonsReleaseRequest {
-                            consumer,
-                            task_id: task_id.clone(),
-                            reserved_amount,
-                        });
-                        icn_obs::metrics::compute::commons_reservation_released_inc("timeout");
+                    match submitter {
+                        Some(consumer) => {
+                            release_commons_reservation(
+                                pending_reservations,
+                                commons_release_callback,
+                                task_id.clone(),
+                                consumer,
+                                "timeout",
+                            )
+                            .await;
+                        }
+                        None => {
+                            // Task metadata unavailable; still purge the ephemeral reservation.
+                            pending_reservations.lock().await.remove(&task_id);
+                        }
                     }
                 }
             }
@@ -1661,17 +1667,14 @@ impl ComputeActor {
         if let Some((task_id, icn_kernel_api::ScopeLevel::Commons, consumer)) =
             task_reservation_info
         {
-            let reserved = self.pending_reservations.lock().await.remove(&task_id);
-            if let (Some(reserved_amount), Some(ref release_cb)) =
-                (reserved, &self.commons_release_callback)
-            {
-                release_cb(CommonsReleaseRequest {
-                    consumer,
-                    task_id,
-                    reserved_amount,
-                });
-                icn_obs::metrics::compute::commons_reservation_released_inc("cancelled");
-            }
+            release_commons_reservation(
+                &self.pending_reservations,
+                &self.commons_release_callback,
+                task_id,
+                consumer,
+                "cancelled",
+            )
+            .await;
         }
 
         Ok(())

--- a/icn/crates/icn-compute/tests/commons_integration.rs
+++ b/icn/crates/icn-compute/tests/commons_integration.rs
@@ -719,9 +719,9 @@ async fn test_no_reserve_callback_is_backward_compatible() {
 
 /// Test: reservation is released when task times out via check_timeouts() sweep.
 ///
-/// Uses the test-only `trigger_timeout_sweep` command to avoid a 10-second background
-/// timer wait. The task is submitted with a near-future deadline; after sleeping past
-/// the deadline, the manual sweep marks the task failed and fires release_cb.
+/// Uses the test-only `trigger_timeout_sweep_for_test` command to avoid a 10-second
+/// background timer wait. The task is submitted with a near-future deadline; after
+/// sleeping past the deadline, the manual sweep marks the task failed and fires release_cb.
 #[tokio::test]
 async fn test_reservation_released_on_timeout() {
     use icn_compute::{BalanceCallback, CommonsReleaseCallback, CommonsReserveCallback};
@@ -764,7 +764,7 @@ async fn test_reservation_released_on_timeout() {
 
     // Phase 2c: trigger timeout sweep — should find the expired task and fire release_cb
     handle
-        .trigger_timeout_sweep()
+        .trigger_timeout_sweep_for_test()
         .await
         .expect("timeout sweep must not error");
 
@@ -789,5 +789,143 @@ async fn test_reservation_released_on_timeout() {
     assert!(
         captured[0].reserved_amount > 0,
         "release_cb reserved_amount must be positive"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sprint 26: Race / idempotence tests (#1405 follow-up)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Test: release_cb fires exactly once when a commons task is explicitly cancelled.
+///
+/// Flow: submit → reservation created → cancel_task → release_cb fires once.
+/// This covers the cancel_task() termination path that was added in PR #1405.
+#[tokio::test]
+async fn test_reservation_released_on_cancel() {
+    use icn_compute::{BalanceCallback, CommonsReleaseCallback, CommonsReserveCallback};
+    use std::sync::Mutex;
+
+    let releases: Arc<Mutex<Vec<icn_compute::CommonsReleaseRequest>>> =
+        Arc::new(Mutex::new(vec![]));
+    let releases_cb = Arc::clone(&releases);
+
+    let trust_cb: TrustCallback = Arc::new(|_| 1.0);
+    let balance_cb: BalanceCallback = Arc::new(|_| 1_000_000);
+    let reserve_cb: CommonsReserveCallback = Arc::new(|_| Ok(()));
+    let release_cb: CommonsReleaseCallback =
+        Arc::new(move |req| releases_cb.lock().unwrap().push(req));
+
+    let mut actor = ComputeActor::new(RES_EXECUTOR_DID.into(), trust_cb);
+    actor.set_balance_callback(balance_cb);
+    actor.set_commons_reserve_callback(reserve_cb);
+    actor.set_commons_release_callback(release_cb);
+    let handle = actor.spawn();
+
+    // Submit creates the reservation.
+    let task_hash = handle
+        .submit(make_reservation_task("res-cancel-1", "{}"))
+        .await
+        .expect("submit must succeed");
+
+    // Cancel the task before any executor claims it.
+    handle
+        .cancel_task(&task_hash, RES_SUBMITTER_DID, "test cancel".to_string())
+        .await
+        .expect("cancel must succeed");
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    let captured = releases.lock().unwrap();
+    assert_eq!(
+        captured.len(),
+        1,
+        "release_cb must fire exactly once on cancel; got {} calls",
+        captured.len()
+    );
+    assert_eq!(
+        captured[0].consumer, RES_SUBMITTER_DID,
+        "release consumer must be the submitter"
+    );
+    assert_eq!(
+        captured[0].task_id, "res-cancel-1",
+        "release task_id must match the submitted task"
+    );
+    assert!(
+        captured[0].reserved_amount > 0,
+        "released amount must be positive"
+    );
+}
+
+/// Test: release_cb fires exactly once even when cancel is called twice (idempotence).
+///
+/// The first cancel removes the reservation from `pending_reservations` and fires the
+/// callback. The second cancel finds no entry in `pending_reservations` (HashMap::remove
+/// returns None) and therefore cannot fire the callback again — even if the task record
+/// still exists in a cancelled state.
+///
+/// This proves the idempotence guarantee at the kernel level: the HashMap::remove
+/// is the authoritative gate; there is no double-debit risk from repeated cancellation
+/// calls (e.g., local cancel racing with a gossip-cancel from a peer).
+#[tokio::test]
+async fn test_double_cancel_is_idempotent() {
+    use icn_compute::{BalanceCallback, CommonsReleaseCallback, CommonsReserveCallback};
+    use std::sync::Mutex;
+
+    let releases: Arc<Mutex<Vec<icn_compute::CommonsReleaseRequest>>> =
+        Arc::new(Mutex::new(vec![]));
+    let releases_cb = Arc::clone(&releases);
+
+    let trust_cb: TrustCallback = Arc::new(|_| 1.0);
+    let balance_cb: BalanceCallback = Arc::new(|_| 1_000_000);
+    let reserve_cb: CommonsReserveCallback = Arc::new(|_| Ok(()));
+    let release_cb: CommonsReleaseCallback =
+        Arc::new(move |req| releases_cb.lock().unwrap().push(req));
+
+    let mut actor = ComputeActor::new(RES_EXECUTOR_DID.into(), trust_cb);
+    actor.set_balance_callback(balance_cb);
+    actor.set_commons_reserve_callback(reserve_cb);
+    actor.set_commons_release_callback(release_cb);
+    let handle = actor.spawn();
+
+    let task_hash = handle
+        .submit(make_reservation_task("res-idempotent-1", "{}"))
+        .await
+        .expect("submit must succeed");
+
+    // First cancel: reservation removed from pending_reservations, release_cb fires.
+    handle
+        .cancel_task(&task_hash, RES_SUBMITTER_DID, "first cancel".to_string())
+        .await
+        .expect("first cancel must succeed");
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    // Verify first cancel fired exactly once.
+    {
+        let count = releases.lock().unwrap().len();
+        assert_eq!(count, 1, "release_cb must fire once after first cancel");
+    }
+
+    // Second cancel on the same hash: task record is gone (or already cancelled),
+    // so cancel_task() will return Err. Regardless, release_cb must NOT fire again —
+    // pending_reservations has no entry for this task_id.
+    let _second_result = handle
+        .cancel_task(
+            &task_hash,
+            RES_SUBMITTER_DID,
+            "duplicate cancel".to_string(),
+        )
+        .await;
+    // We tolerate Err here — the important invariant is callback fire count.
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    let captured = releases.lock().unwrap();
+    assert_eq!(
+        captured.len(),
+        1,
+        "release_cb must fire exactly once even after double cancel; got {} calls — \
+         HashMap::remove is the authoritative idempotence gate",
+        captured.len()
     );
 }


### PR DESCRIPTION
## Summary

Sprint 26 follow-up to PR #1405 (commons credit reservation lifecycle fix).

- **Extract helpers**: The ~10-line `release_commons_reservation` pattern was copy-pasted across 9 sites in `lifecycle.rs`. Two free async functions (`release_commons_reservation`, `consume_commons_reservation`) now centralize this logic. Call sites are structurally identical — no behavior change.
- **Add idempotence tests**: Two new integration tests cover paths not previously tested individually:
  - `test_reservation_released_on_cancel`: cancellation path fires `release_cb` once with correct args
  - `test_double_cancel_is_idempotent`: second cancel finds nothing in `pending_reservations`, callback cannot fire twice — documents `HashMap::remove` as the authoritative idempotence gate
- **Rename `trigger_timeout_sweep` → `trigger_timeout_sweep_for_test`**: Consistent with `commons_pool_for_test` naming convention already in use.

## Test plan

- [x] All 17 `commons_integration` tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p icn-compute -- -D warnings` clean
- [x] No behavior changes — refactor only on the release/consume sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)