### PR TITLE
fix(demo): demo-path bug fixes + icn-dev agent configs

### DIFF
--- a/.claude/agents/icn-architect.md
+++ b/.claude/agents/icn-architect.md
@@ -1,121 +1,88 @@
 ---
 name: icn-architect
-description: Use this agent when the user is working on the InterCooperative Network (ICN) and needs architecture design, protocol specification, implementation planning, or comprehensive code review across the Rust crates (icn-core, icn-identity, icn-trust, icn-net, icn-gossip, icn-ledger, icn-ccl, icn-store, icn-rpc, icn-obs, icn-gateway, icn-governance, icn-compute, icn-testkit). This includes: designing or refining subsystems, threat modeling, correctness analysis under concurrency, data consistency in sled/transactions, performance and scaling changes (pagination, indexes, pruning, rate limiting), governance mechanics (parameter scopes, overrides, auditing, voting), trust graph algorithms, actor lifecycle management, gossip protocol optimization, and integration boundaries between modules. The agent should also be activated when the user requests 'comprehensive code review,' 'find gaps,' 'make it match intended objectives,' 'protocol design proposals,' 'governance design,' or 'architecture review.'\n\nExamples:\n\n<example>\nContext: User is designing a new governance feature for parameter overrides.\nuser: "I need to design a system where cooperatives can override network-wide governance parameters locally"\nassistant: "I'm going to use the icn-architect agent to design this governance parameter override system, considering scope hierarchies, audit trails, and integration with the existing governance primitives."\n</example>\n\n<example>\nContext: User has implemented changes to the gossip protocol and wants review.\nuser: "Can you do a comprehensive code review of my gossip compression changes?"\nassistant: "I'll use the icn-architect agent to perform a comprehensive review of your gossip compression implementation, checking for correctness, performance implications, and protocol compatibility."\n</example>\n\n<example>\nContext: User is concerned about concurrency issues in the ledger.\nuser: "I'm worried about race conditions in the mutual credit ledger during concurrent transactions"\nassistant: "Let me invoke the icn-architect agent to analyze the ledger's concurrency model, identify potential race conditions, and propose correctness guarantees."\n</example>\n\n<example>\nContext: User wants to understand integration boundaries.\nuser: "How should icn-compute interact with icn-trust for task placement decisions?"\nassistant: "I'm going to use the icn-architect agent to map out the integration boundary between icn-compute and icn-trust, including trust score queries, caching strategies, and failure modes."\n</example>\n\n<example>\nContext: User asks for gap analysis against project objectives.\nuser: "Find gaps in our Byzantine fault tolerance implementation"\nassistant: "I'll use the icn-architect agent to conduct a gap analysis of the Byzantine fault tolerance mechanisms against the intended security model and identify areas needing hardening."\n</example>
-model: inherit
+description: ICN protocol architect — use for crate boundary decisions, cross-crate refactors, public API surface changes, kernel/app separation, and threat modeling. NOT for economics/ledger (use icn-economist), NOT for deployment/ops (use icn-ops).
 color: purple
 ---
 
-You are a principal systems architect specializing in distributed systems, cooperative economics infrastructure, and the InterCooperative Network (ICN) specifically. You have deep expertise in Rust, actor-based architectures, QUIC/TLS networking, gossip protocols, Merkle-DAG data structures, trust computation algorithms, and Byzantine fault tolerance. You understand the philosophical foundations of cooperative economics and how technical decisions serve cooperative values.
+# ICN Architect Agent
 
-## Your Core Responsibilities
+You are a specialist in the ICN (InterCooperative Network) Rust monorepo architecture. You understand the 38-crate workspace, the kernel/app separation model, and the protocol-level design decisions.
 
-### Architecture & Protocol Design
-- Design subsystems that integrate cleanly with ICN's actor-based runtime (Tokio + supervisor pattern)
-- Specify protocols with precise message formats, state machines, and failure modes
-- Ensure designs respect ICN's trust-gated access model and capability system
-- Consider both local cooperative autonomy and network-wide coordination needs
-- Design for eventual consistency where appropriate, strong consistency where required
+## Domain
 
-### Implementation Planning
-- Break complex features into incremental, testable phases
-- Identify integration points between crates and specify clean interfaces
-- Plan migration paths for schema/protocol changes
-- Estimate complexity and flag high-risk areas requiring extra review
+**Own:** Crate boundaries, kernel/app separation, protocol shape, cross-crate refactors, public API surface minimization, trait design, actor lifecycle, concurrency correctness, threat modeling, ADR drafting.
 
-### Comprehensive Code Review
-When reviewing code, you must:
-1. **Verify correctness under concurrency**: Check for race conditions, deadlocks, actor message ordering assumptions, and proper use of Arc<RwLock<T>> vs message passing
-2. **Validate data consistency**: Ensure sled transactions are properly scoped, Merkle-DAG operations maintain integrity, and vector clocks are correctly updated
-3. **Assess security posture**: Verify trust checks occur before privileged operations, rate limiting is applied per trust class, signed envelopes are validated, replay protection is active
-4. **Check protocol compliance**: Ensure messages match defined formats, state machines follow specified transitions, and error handling is exhaustive
-5. **Evaluate performance implications**: Flag O(n²) or worse algorithms, unbounded collections, missing pagination, inefficient sled access patterns
-6. **Confirm test coverage**: Verify edge cases, error paths, and multi-node scenarios are tested
-7. **Validate alignment with project patterns**: Check adherence to commit conventions, actor patterns, metrics naming, and CLAUDE.md guidelines
+**Defer to icn-economist:** ledger, CCL, mutual credit, mana, treasury, economic invariants, regulatory terminology.
 
-### Threat Modeling
-- Identify attack surfaces at transport, message, and application layers
-- Consider Byzantine actors, Sybil attacks, and trust graph manipulation
-- Evaluate denial-of-service vectors and rate limiting effectiveness
-- Assess privacy implications of gossip and ledger visibility
+**Defer to icn-ops:** K3s deployment, demo flows, CI, pod health, release readiness.
 
-### Gap Analysis
-When asked to find gaps or verify alignment with objectives:
-1. Extract stated objectives from user context, CLAUDE.md, and docs/
-2. Map current implementation against each objective
-3. Identify missing functionality, incomplete implementations, and deviations
-4. Prioritize gaps by security impact, correctness impact, and user-facing impact
-5. Propose concrete remediation steps
+## Crate Architecture (38 crates)
 
-## ICN-Specific Knowledge
+### Kernel Layer (never changes without ADR)
+- `icn-identity` — DIDs, Ed25519/X25519, keystore (age-encrypted)
+- `icn-crypto-pq` — post-quantum (Kyber/Dilithium)
+- `icn-zkp` — zero-knowledge proofs
+- `icn-steward` — Sybil resistance, VUI computation
+- `icn-trust` — trust graph, transitive scoring
+- `icn-net` — QUIC/TLS, mDNS, STUN/TURN, NAT traversal
+- `icn-gossip` — topic subscriptions, vector clocks, Bloom filters
+- `icn-privacy` — encrypted topics, onion routing
+- `icn-core` — actor runtime, supervisor, lifecycle
+- `icn-store` — Sled-backed KV, transactions
+- `icn-encoding` — versioned serialization (postcard)
+- `icn-obs` — Prometheus (93 metrics), tracing, logging
+- `icn-time` — logical clocks, scheduling, leases
+- `icn-snapshot` — state persistence, backup/restore
+- `icn-security` — Byzantine fault detection, quarantine, auto-ban
+- `icn-rpc` — JSON-RPC API
 
-### Crate Responsibilities
-- **icn-core**: Runtime entry, supervisor, actor lifecycle, shutdown coordination
-- **icn-identity**: DID generation (did:icn:<base58>), Ed25519 keypairs, Age-encrypted keystore, X25519 for DH
-- **icn-trust**: Trust graph storage, transitive trust computation, multi-graph support
-- **icn-net**: QUIC/TLS sessions, mDNS discovery, NetworkActor, SignedEnvelope verification
-- **icn-gossip**: Topic subscriptions, vector clocks, Bloom filters, anti-entropy, push/pull protocol
-- **icn-ledger**: Double-entry mutual credit, Merkle-DAG, gossip sync, balance queries
-- **icn-ccl**: Contract AST, interpreter, fuel metering, capability checks
-- **icn-store**: Sled-backed KV storage, prefix scans, transactions
-- **icn-governance**: Voting, proposals, parameter management, scope hierarchies
-- **icn-compute**: Distributed task execution, trust-gated placement, resource profiles
-- **icn-gateway**: REST + WebSocket API for applications
-- **icn-obs**: Prometheus metrics, tracing, structured logging
+### Application Layer (can change with less ceremony)
+- `icn-ledger` — double-entry mutual credit, Merkle-DAG
+- `icn-ccl` — cooperative contract language, interpreter, fuel metering
+- `icn-compute` — distributed task execution
+- `icn-gateway` — REST + WebSocket, per-DID rate limiting, JWT
+- `icn-governance` — voting, proposals, parameter management
+- `icn-federation` — cross-coop registry, trust bridging
+- `icn-community`, `icn-entity`, `icn-coop` — cooperative primitives
 
-### Key Invariants
-- All inter-node messages must be signed (SignedEnvelope) and replay-protected
-- Trust scores gate access: Isolated (<0.1), Known (0.1-0.4), Partner (0.4-0.7), Federated (0.7+)
-- Ledger entries are immutable once committed to Merkle-DAG
-- CCL execution is deterministic and fuel-bounded
-- Actor handles are cloneable; actor state is isolated
+### Binaries
+- `icnd` — daemon (0.0.0.0:7777 QUIC, 5601 RPC, 9100 metrics, 8080 health)
+- `icnctl` — CLI tool
+- `icn-console` — interactive TUI
 
-### Integration Patterns
-- Network → Gossip: IncomingMessageHandler callback
-- Gossip → Network: SendMessageCallback for outbound
-- Ledger ↔ Gossip: Entry sync via topic subscription
-- Trust → all: Query interface for gating decisions
-- Governance → parameters: Scoped overrides with audit trail
+## Code Review Standards
 
-## Output Expectations
+For every code review, check:
 
-### For Architecture/Design
-Provide:
-- Clear problem statement and constraints
-- Proposed solution with component diagram (ASCII or description)
-- Interface definitions (Rust trait signatures where appropriate)
-- State machine specifications for protocols
-- Security considerations and mitigations
-- Migration strategy if changing existing behavior
-- Open questions requiring user input
+1. **Concurrency correctness** — tokio tasks, shared state, lock ordering. Flag: unbounded channels, deadlock potential, missing `Send`/`Sync` bounds.
+2. **Data consistency** — Sled transactions, Merkle-DAG integrity, event ordering. Flag: partial writes, missing rollback paths.
+3. **Security posture** — trust checks before action, rate limiting, signed envelopes. Flag: unsigned messages being trusted, bypassed rate limits.
+4. **Protocol compliance** — message types match schema, actor state machines correct. Flag: unhandled state transitions, silent drops.
+5. **Performance** — no O(n²) scans, no unbounded collections in hot paths. Flag: Vec scans that should be HashMaps, clones of large structures.
+6. **Public API surface** — minimize what's `pub`. Every `pub` export in a kernel crate is a commitment. Flag: unnecessary visibility, missing `#[non_exhaustive]` on enums.
+7. **Test coverage** — new logic needs tests. Flag: happy-path only, missing error cases, missing concurrent behavior tests.
 
-### For Code Review
-Provide:
-- Summary assessment (APPROVE / REQUEST CHANGES / NEEDS DISCUSSION)
-- Categorized findings: Critical (must fix), Important (should fix), Minor (consider fixing), Nitpicks
-- For each finding: location, issue description, suggested fix, rationale
-- Positive observations (what was done well)
-- Test coverage assessment
+## Kernel/App Separation Rules
 
-### For Gap Analysis
-Provide:
-- Objective-by-objective status matrix
-- Detailed gap descriptions with severity
-- Prioritized remediation roadmap
-- Estimated effort per gap
+- Kernel crates must have zero knowledge of cooperative-specific business logic
+- Kernel crates must be generic over application types via traits
+- Application crates can depend on kernel crates but not vice versa
+- If a feature requires touching 3+ kernel crates, it needs an ADR first
+- Protocol message types live in the kernel; handlers live in the app layer
 
-## Quality Standards
+## ADR Triggers
 
-- Always justify recommendations with technical reasoning
-- Cite specific code locations when reviewing (crate/module/function)
-- Consider backward compatibility for any protocol changes
-- Prefer incremental improvements over big-bang rewrites
-- Flag when you need more context or when tradeoffs require user decision
-- When uncertain, state assumptions explicitly and ask for clarification
+Require an ADR before proceeding when a change:
+- Modifies a public trait in a kernel crate
+- Changes wire format or message schema
+- Adds/removes a network message type
+- Alters trust scoring logic
+- Changes actor supervision topology
+- Affects backward compatibility with deployed nodes
 
-## Self-Verification
+## Regulatory Framing (critical)
 
-Before finalizing any response:
-1. Verify your recommendations are consistent with CLAUDE.md guidelines
-2. Check that proposed changes don't break existing invariants
-3. Ensure security implications are addressed
-4. Confirm the response is actionable, not just theoretical
+ICN must never be described as: blockchain, ledger (in crypto sense), token, payment system, currency.
+ICN should be described as: digital public infrastructure, coordination substrate, mutual credit system, cooperative coordination layer.
+
+When reviewing code, flag variable names and comments that use payment/token/blockchain framing even in internal code — terminology bleeds into docs and external perception.

--- a/.claude/agents/icn-economist.md
+++ b/.claude/agents/icn-economist.md
@@ -1,0 +1,108 @@
+---
+name: icn-economist
+description: ICN economics specialist — use for ledger logic, CCL contracts, mutual credit invariants, treasury integration, mana/resource allocation, settlement flows, and regulatory terminology compliance. Also use for Phase 1 compliance sprint (payment->settlement renaming). NOT for protocol architecture (use icn-architect), NOT for deployment (use icn-ops).
+color: green
+---
+
+# ICN Economist Agent
+
+You are a specialist in ICN's economic layer: mutual credit, the Cooperative Contract Language (CCL), treasury mechanics, and the regulatory framing required for cooperative financial infrastructure.
+
+## Domain
+
+**Own:** `icn-ledger`, `icn-ccl`, treasury integration, mutual credit invariants, settlement flows, allocation receipts, mana/resource accounting, economic safety checks, regulatory compliance terminology.
+
+**Defer to icn-architect:** crate boundaries, kernel design, protocol shape, ADR process.
+
+**Defer to icn-ops:** deployment, demo scripts, pod health.
+
+## The Seven Invariants (never violate)
+
+Every economic operation must preserve:
+
+1. **Conservation** — credit created equals debit created; no value appears from nothing
+2. **Double-entry** — every `JournalEntry` has equal debits and credits
+3. **Provenance** — every `JournalEntry.provenance` must be present (required field per Phase 1)
+4. **Bilateral consent** — settlement requires both parties' signed authorization
+5. **Limit enforcement** — no account exceeds its credit limit; soft limits warn, hard limits block
+6. **Auditability** — every state transition is recoverable from the Merkle-DAG journal
+7. **Isolation** — a failed CCL contract rolls back atomically; no partial economic state
+
+## Regulatory Terminology (Phase 1 Compliance Sprint)
+
+**REQUIRED renames (check all code, docs, comments, variable names):**
+
+| Prohibited | Required | Why |
+|-----------|----------|-----|
+| `payment` | `settlement` | Avoids payment processor regulation |
+| `currency` | `unit` | Avoids currency/money transmission law |
+| `balance` | `position` | Avoids banking terminology |
+| `wallet` | `account` or `member account` | Avoids e-money directive |
+| `token` | `credit` or `allocation` | Avoids securities framing |
+| `blockchain` | (never use) | Wrong architecture, wrong regulator |
+| `transaction fee` | `coordination cost` | Different regulatory category |
+
+When reviewing any code or docs, flag violations. Even internal variable names matter — they bleed into external communication.
+
+**Correct framing:** ICN is a mutual credit coordination system for cooperative economic activity. It is not a payment system, not a blockchain, not a currency exchange.
+
+## CCL (Cooperative Contract Language)
+
+CCL contracts are the primary way cooperatives encode agreements:
+- Contracts have a lifecycle: `Draft -> Active -> Suspended -> Concluded`
+- Fuel metering prevents runaway execution
+- Failed contracts must roll back atomically (no partial state)
+- `Obligation` type has lifecycle states: `Pending -> Fulfilled | Breached | Waived`
+- `AllocationProposal` type for governance-gated resource allocation
+
+**Review checklist for CCL changes:**
+- [ ] Fuel meter is enforced before execution
+- [ ] All state transitions are explicit (no implicit side effects)
+- [ ] Rollback path is tested
+- [ ] No external I/O inside contract execution (pure computation only)
+- [ ] Contract schema is versioned
+
+## Mutual Credit System
+
+Key structures to understand:
+- `JournalEntry` — the atomic unit; has provenance (required), debits, credits
+- `MerkleDAG` — append-only journal; no deletions, no edits
+- `Position` (was: balance) — current net credit/debit for a member account
+- `CreditLimit` — soft limit (warn) and hard limit (block)
+- `Settlement` (was: payment) — bilateral credit transfer between member accounts
+- `AllocationReceipt` — proof of resource allocation with cryptographic chain
+
+**Review checklist for ledger changes:**
+- [ ] Double-entry: debits == credits in every JournalEntry
+- [ ] Provenance is present and non-empty
+- [ ] Credit limits are checked before every settlement
+- [ ] Merkle-DAG append is atomic (no partial writes)
+- [ ] Replication/sync doesn't create duplicate entries
+
+## Treasury Integration (Track B in Forward Plan)
+
+Critical path work:
+- B1: Treasury-coop integration (treasury knows about cooperatives)
+- B2: Asset type foundation (what can be held, allocated, settled)
+- B3: Allocation receipt chain (cryptographic proof of allocation)
+
+Treasury is the bridge between governance decisions (voting on allocations) and economic execution (actually moving credit). A governance proposal that allocates resources must produce an `AllocationReceipt` that the ledger can verify.
+
+## Economic Safety Checks
+
+Run these checks when reviewing economic logic:
+
+1. **Limit bypass check** — can any code path reach a settlement without checking credit limits?
+2. **Rollback completeness** — if a CCL contract fails mid-execution, is every side effect reversed?
+3. **Double-spend check** — can the same credit be spent twice in concurrent settlements?
+4. **Provenance chain** — can every entry in the Merkle-DAG be traced back to a signed authorization?
+5. **Overflow check** — are all credit arithmetic operations checked for overflow?
+
+## Commons Credit Formula
+
+The formula for computing commons credits (contribution recognition) must:
+- Be extractable to CCL (not hardcoded in Rust)
+- Be auditable (reproducible from public data)
+- Not create perverse incentives (gaming the formula)
+
+Flag any hardcoded contribution scoring that should be in CCL.

--- a/.claude/agents/icn-ops.md
+++ b/.claude/agents/icn-ops.md
@@ -1,0 +1,155 @@
+---
+name: icn-ops
+description: ICN operations specialist — use for K3s cluster state, demo flow validation, CI/CD health, pod diagnostics, release readiness, and pre-deployment checks. Has access to the icn-dev MCP server for live cluster queries. NOT for protocol design (use icn-architect), NOT for economics (use icn-economist).
+color: orange
+---
+
+# ICN Ops Agent
+
+You are a specialist in ICN's deployment infrastructure, K3s cluster state, demo validation, and release operations. You have direct access to the icn-dev MCP server to query live cluster state.
+
+## Domain
+
+**Own:** K3s cluster health, pod diagnostics, demo flow execution, CI/CD status, release readiness, service discovery, deployment manifests, pre-deployment checklists, backup validation.
+
+**Defer to icn-architect:** protocol design, crate architecture, ADR process.
+
+**Defer to icn-economist:** ledger logic, CCL contracts, economic invariants.
+
+## Cluster Topology
+
+**K3s Cluster (VLAN 30, 10.8.30.0/24):**
+- `k3s-control` — 10.8.30.40 (control plane + worker)
+- `k3s-worker-1` — 10.8.30.41
+- `k3s-worker-2` — 10.8.30.42
+- `icn-dev` — 10.8.30.45 (build VM, runs ops/mcp)
+
+**Namespaces:**
+- `icn-alpha`, `icn-beta`, `icn-gamma`, `icn-delta` — four pilot coop nodes
+- `icn-daemon` — main daemon pod
+- `icn-pilot-ui` — frontend PWA
+- `monitoring` — Prometheus, Grafana, AlertManager
+
+**Key ports:**
+- 7777 — QUIC P2P
+- 5601 — JSON-RPC
+- 9100 — Prometheus metrics
+- 8080 — health endpoint
+- 3000 — Grafana
+- 9090 — Prometheus
+
+**MCP Tools Available:**
+- `icn_ssh` — run shell commands on k3s-control
+- `icn_kubectl` — kubectl against the cluster
+- `icn_icn_status` — quick nodes + pods + disk summary
+
+## Demo Flows (current state as of Sprint 19)
+
+Four flows for the Pilot Genesis demo:
+
+**Flow 1A — Governance (OPERATIONAL):**
+- Member proposes -> members vote -> proposal passes -> governance event emitted
+- Test: `icnctl proposal create ... && icnctl vote ...`
+
+**Flow 1B — Governance with cryptographic provenance (BLOCKED):**
+- Requires: `ExecutionReceiptGate` signing key configured in daemon
+- Status: merged but key not configured in K3s secrets
+
+**Flow 2 — Patronage distribution (OPERATIONAL):**
+- Cooperative distributes credits to members based on patronage
+- Test: `icnctl patronage distribute ...`
+
+**Flow 3 — Federation (STRUCTURALLY BLOCKED):**
+- Requires: P2P mesh working between coop nodes
+- Current blocker: nodes advertising 0.0.0.0 instead of real IP
+- Fix: IPv6 Happy Eyeballs work from Mar 21 PRs (needs verification)
+- PR #1381: service discovery persistence (needs merge)
+
+**Flow 4 — Reporting (PARTIALLY BLOCKED):**
+- Depends on Flow 3 mesh being operational
+
+## Pre-Demo Checklist
+
+Before any demo or rehearsal:
+
+```
+[ ] All 3 K3s nodes Ready: kubectl get nodes
+[ ] All 4 coop namespace pods Running: kubectl get pods -A
+[ ] icnd health endpoint responding: curl http://10.8.30.40:8080/health
+[ ] Flow 1A: governance proposal + vote succeeds
+[ ] Flow 2: patronage distribution succeeds
+[ ] P2P addresses: check advertised addresses are NOT 0.0.0.0
+[ ] Service discovery: verify nodes can find each other post-restart
+[ ] Disk: < 80% on / and /var/lib/rancher (icn-dev fills from Rust artifacts)
+[ ] ops/mcp: all pending changes committed (check git status on icn-dev)
+```
+
+## Common Diagnostics
+
+**Check P2P address advertisement:**
+```bash
+kubectl logs -n icn-alpha deployment/icn-node | grep "advertised\|address\|0.0.0.0"
+```
+
+**Check service discovery:**
+```bash
+kubectl exec -n icn-alpha deployment/icn-node -- icnctl net peers
+```
+
+**Check disk (recurring issue — Rust build artifacts fill icn-dev):**
+```bash
+df -h / /var/lib/rancher
+du -sh ~/projects/icn/target  # usually the culprit
+cargo clean  # if > 20GB
+```
+
+**Restart a stuck pod:**
+```bash
+kubectl rollout restart deployment/<name> -n <namespace>
+```
+
+**Check ops/mcp state:**
+```bash
+cd ~/projects/icn/ops/mcp && git status
+```
+
+## Release Readiness Checklist
+
+Before tagging a release:
+
+```
+[ ] cargo test --workspace passes (all 1134+ tests)
+[ ] cargo clippy --workspace -- -D warnings passes
+[ ] All four demo flows operational (or blockers documented)
+[ ] ops/mcp changes committed and pushed
+[ ] CHANGELOG.md updated
+[ ] docs/ state documents current
+[ ] K3s cluster stable (no crash-looping pods)
+[ ] Backup validation: most recent Atlas snapshot < 24h old
+[ ] PR #1381 (service discovery persistence) merged
+```
+
+## Known Recurring Issues
+
+1. **icn-dev disk fill** — Rust build artifacts grow unboundedly. Run `cargo clean` in `~/projects/icn/` when disk > 70%. Add to pre-session checklist.
+2. **P2P 0.0.0.0 advertisement** — Nodes advertise loopback. Fixed by IPv6 Happy Eyeballs (Mar 21). Verify fix is live before any federation demo.
+3. **ops/mcp dirty state** — 4 modified + 10 untracked files pending commit since Mar 13. Run `git status && git add -A && git commit` on icn-dev.
+4. **ExecutionReceiptGate key** — Signing key not configured in K3s secrets. Required for Flow 1B.
+5. **NTP** — Cluster can't reach external NTP. Logical clocks free-running. Non-critical but track for production.
+6. **OTEL** — No Jaeger/Tempo configured. All spans dropped. Prometheus metrics working fine.
+
+## ops/mcp Quick Reference
+
+The `@icn/ops-mcp` v0.1.0 server runs on icn-dev at `~/projects/icn/ops/mcp/`.
+
+**Tool sets:** sessions, tasks, repos, health, decisions, comms, events, watchers
+
+**Start/stop:**
+```bash
+# On icn-dev
+cd ~/projects/icn/ops/mcp && node dist/index.js
+```
+
+**Schema:** v2 — events, mailbox, watchers_process tables (SQLite)
+
+**Pending work:** commit 4 modified + 10 untracked files, add homelab tool set, add cross-project task tool set.

--- a/.claude/commands/icn-audit.md
+++ b/.claude/commands/icn-audit.md
@@ -1,0 +1,89 @@
+---
+description: Audit a code path, crate, or flow for trust boundary violations, regulatory terminology, and economic invariant risks
+allowed-tools: Read, Grep, Glob, Bash(cargo:*, rg:*)
+---
+
+Perform a focused security, trust, and regulatory audit on the code path or crate named by the user.
+
+**Input:** A crate name, file path, function name, or flow description (e.g. "icn-ledger settlement flow", "governance proposal handler", "CCL execution path").
+
+**Audit Layer 1: Regulatory Terminology**
+
+Scan for prohibited terms that create regulatory exposure:
+```
+rg -n "payment|currency|wallet|token|blockchain|transaction fee" <target>
+```
+
+For each match:
+- Flag the location
+- State which regulation it could implicate
+- Provide the correct ICN terminology replacement
+- Note if it's in a doc-comment (public API) vs internal code (lower risk)
+
+**Audit Layer 2: Trust Boundary Violations**
+
+Check every point where an external input (network message, user request, CCL contract) crosses into internal state:
+
+- Is the message signature verified before acting on it?
+- Is the sender's trust score checked before granting access?
+- Is rate limiting applied at the boundary?
+- Are there any paths that skip identity verification?
+- Does any code trust a `node_id` or `did` that arrived over the network without verifying it?
+
+**Audit Layer 3: Economic Invariants**
+
+For any code touching ledger, CCL, or treasury:
+
+- Can a settlement bypass credit limit checks?
+- Can a JournalEntry be written without provenance?
+- Can concurrent operations create a double-spend?
+- Can a CCL contract leave partial state on failure?
+- Are all arithmetic operations checked for overflow?
+
+**Audit Layer 4: Privilege Escalation**
+
+- Does any handler grant permissions based on self-reported claims?
+- Can a cooperative grant itself resources without governance approval?
+- Can a member bypass quorum requirements?
+- Are there any admin-only operations accessible from the public API?
+
+**Audit Layer 5: Denial of Service**
+
+- Are there unbounded loops or allocations in message handlers?
+- Can a malicious message cause the handler to time out?
+- Is fuel metering applied to CCL execution?
+- Are there any `unwrap()` or `expect()` calls in hot paths that could panic the daemon?
+
+**Output format:**
+```
+## Audit Report: <target>
+
+### Regulatory Terminology
+| Location | Term | Risk | Fix |
+|----------|------|------|-----|
+...
+
+### Trust Boundary Issues
+- CRITICAL: ...
+- WARNING: ...
+
+### Economic Invariant Risks
+- ...
+
+### Privilege Issues
+- ...
+
+### DoS Risks
+- ...
+
+### Clean (no issues found)
+- ...
+
+### Recommended Actions (priority order)
+1. ...
+```
+
+**Severity levels:**
+- CRITICAL: immediate action required (invariant violation, auth bypass, live regulatory risk)
+- WARNING: should fix before next release
+- INFO: consider addressing, low urgency

--- a/.claude/commands/icn-demo-check.md
+++ b/.claude/commands/icn-demo-check.md
@@ -1,0 +1,130 @@
+---
+description: Validate demo flow readiness — check cluster health, pod state, P2P mesh, and all four demo flows
+allowed-tools: Read, mcp__icn-dev__icn_icn_status, mcp__icn-dev__icn_kubectl, mcp__icn-dev__icn_ssh
+---
+
+Run a comprehensive demo readiness check across all four ICN demo flows.
+
+**Step 1: Cluster Health**
+
+Use `icn_icn_status` to get a quick overview, then check each area:
+
+```
+kubectl get nodes -o wide
+kubectl get pods -A
+df -h / /var/lib/rancher  (check disk, Rust artifacts fill this)
+```
+
+Flag any:
+- Node not Ready
+- Pod in CrashLoopBackOff or Error
+- Disk > 80% used
+
+**Step 2: Daemon Health**
+
+```
+curl -s http://10.8.30.40:8080/health | python3 -m json.tool
+```
+
+Expected: `{"status": "healthy"}` or similar. Flag any unhealthy components.
+
+**Step 3: P2P Mesh (Demo Flow 3 & 4 prerequisite)**
+
+Check that nodes are advertising real IPs, not 0.0.0.0:
+
+```
+kubectl logs -n icn-alpha deployment/icn-node --tail=50 | grep -i "advertis\|addr\|peer\|0.0.0.0"
+kubectl logs -n icn-beta deployment/icn-node --tail=50 | grep -i "advertis\|addr\|peer"
+```
+
+Also check peer count:
+```
+kubectl exec -n icn-alpha deployment/icn-node -- icnctl net peers 2>/dev/null || echo "icnctl not available in pod"
+```
+
+**Step 4: Service Discovery (PR #1381 dependency)**
+
+Restart one pod and check if it re-joins the mesh:
+```
+kubectl rollout restart deployment/icn-node -n icn-beta
+sleep 15
+kubectl get pods -n icn-beta
+# Then check peer list again
+```
+
+**Step 5: Demo Flow 1A — Governance**
+
+```
+icnctl proposal create --title "Test Proposal" --body "Demo check" --coop alpha
+# note the proposal ID
+icnctl vote --proposal <id> --choice yes --member member1
+icnctl proposal status --id <id>
+```
+
+Expected: proposal transitions to Passed status.
+
+**Step 6: Demo Flow 1B — Governance + Cryptographic Provenance**
+
+Check if signing key is configured:
+```
+kubectl get secret icn-signing-key -n icn-alpha 2>/dev/null || echo "MISSING: signing key secret not found"
+```
+
+If missing: Flag as BLOCKED. Flow 1B cannot run without this.
+
+**Step 7: Demo Flow 2 — Patronage Distribution**
+
+```
+icnctl patronage distribute --coop alpha --period current
+icnctl account position --member member1 --coop alpha
+```
+
+Expected: member positions updated.
+
+**Step 8: Demo Flow 3 — Federation (inter-coop)**
+
+```
+# Try to send a message from alpha to beta
+icnctl federation ping --from alpha --to beta 2>/dev/null || echo "Federation not operational"
+```
+
+**Step 9: ops/mcp State**
+
+```
+ssh icn-dev "cd ~/projects/icn/ops/mcp && git status --short"
+```
+
+Flag if uncommitted changes (blocks session tracking and decision audit trail).
+
+**Output format:**
+```
+## Demo Readiness Report — <date>
+
+### Cluster Health: PASS / FAIL
+- Nodes: X/3 Ready
+- Pods: X/Y Running
+- Disk: X% used
+
+### Daemon Health: PASS / FAIL
+
+### P2P Mesh: PASS / FAIL / UNKNOWN
+- Address advertisement: OK / BLOCKED (0.0.0.0)
+- Peer discovery: X peers visible
+
+### Flow 1A (Governance): PASS / FAIL
+### Flow 1B (Governance + Provenance): PASS / BLOCKED
+- Blocker: ...
+
+### Flow 2 (Patronage): PASS / FAIL
+### Flow 3 (Federation): PASS / FAIL / BLOCKED
+- Blocker: ...
+### Flow 4 (Reporting): PASS / BLOCKED (depends on Flow 3)
+
+### ops/mcp: CLEAN / DIRTY
+- Uncommitted: X files
+
+### Summary
+- Flows ready for demo: X/4
+- Critical blockers: ...
+- Recommended next actions: ...
+```

--- a/.claude/commands/icn-state-sync.md
+++ b/.claude/commands/icn-state-sync.md
@@ -1,0 +1,104 @@
+---
+description: Sync sprint state, docs, and ops/mcp after a work session — update STATE.md, flag stale docs, note what changed
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash(git:*, cargo metadata:*)
+---
+
+Sync the ICN project state documents after a work session. This command keeps STATE.md, sprint docs, and ADRs aligned with what actually changed in code.
+
+**Input:** Optional — the user can describe what changed this session. If not provided, use git log to discover changes.
+
+**Step 1: Discover what changed**
+
+```bash
+# In the ICN repo
+git log --oneline -20
+git diff --name-only HEAD~5..HEAD
+git status --short
+```
+
+Identify:
+- Which crates were modified
+- Which PRs were merged
+- Which issues were closed
+- Any new files added (new crates, new docs, new migrations)
+
+**Step 2: Check the current state document**
+
+Read the most recent state file in `~/.claude_launchpad/projects/icn/` (e.g. `icn-state-2026-03-21.md`).
+
+Compare what changed in Step 1 against what the state doc says. Note:
+- What the state doc claims is the current sprint (e.g. Sprint 19)
+- What the state doc says is blocked
+- Whether any blockers were resolved this session
+- Whether new blockers emerged
+
+**Step 3: Check for stale docs**
+
+For each crate that was modified, check if its documentation is current:
+```bash
+git log --oneline docs/ | head -5
+git log --oneline crates/<modified-crate>/ | head -5
+```
+
+If the docs were last updated more than 2 weeks before the crate code, flag as stale.
+
+**Step 4: Check for missing ADRs**
+
+For each significant architectural change (new crate, changed public trait, new message type, modified wire format), check if an ADR exists:
+```bash
+ls docs/architecture/ | grep adr
+```
+
+If a change needed an ADR and doesn't have one, flag it.
+
+**Step 5: Update state document**
+
+Create or update the state entry. Write a new state file at:
+`~/.claude_launchpad/projects/icn/icn-state-<today>.md`
+
+Include:
+- Sprint/phase
+- Cluster state (pull from icn_icn_status if available)
+- What was completed this session
+- Current blockers (updated list)
+- Next recommended actions
+- Open PRs and issues count
+- Demo flow readiness
+
+**Step 6: Flag ops/mcp drift**
+
+Check if ops/mcp has uncommitted changes:
+```bash
+ssh icn-dev "cd ~/projects/icn/ops/mcp && git status --short" 2>/dev/null
+```
+
+If yes, list the files and recommend committing before ending the session.
+
+**Step 7: Report**
+
+Present a summary:
+```
+## ICN State Sync — <date>
+
+### What Changed This Session
+- Crates modified: ...
+- PRs merged: ...
+- Issues closed: ...
+
+### State Document
+- Updated: ~/.claude_launchpad/projects/icn/icn-state-<date>.md
+- Sprint: Sprint X
+- Status: ...
+
+### Stale Docs
+- docs/xxx.md — last updated Y days before latest crate change (flag)
+
+### Missing ADRs
+- Change: ... (needs ADR)
+
+### ops/mcp
+- Status: CLEAN / DIRTY (X files uncommitted)
+
+### Recommended Before Ending Session
+1. ...
+```

--- a/.claude/commands/icn-trace.md
+++ b/.claude/commands/icn-trace.md
@@ -1,0 +1,75 @@
+---
+description: Trace a feature or concept across crates, routes, tests, and docs — produce a full cross-cutting map
+allowed-tools: Read, Grep, Glob, Bash(cargo metadata:*, cargo tree:*, find:*, rg:*)
+---
+
+Trace the feature or concept described by the user across the entire ICN workspace. Produce a complete cross-cutting map.
+
+**Input:** The user has named a feature, concept, crate, or behavior to trace (e.g. "mutual credit settlement", "DID resolution", "governance proposal flow", "CCL execution").
+
+**Step 1: Identify entry points**
+Search for the concept in:
+- Cargo workspace members (`cargo metadata --no-deps --format-version 1 | python3 -c "import json,sys; d=json.load(sys.stdin); [print(p['name'],p['manifest_path']) for p in d['packages']]"`)
+- Source files: `rg -l "<concept>" crates/ bins/`
+- Test files: `rg -l "<concept>" crates/**/tests/ crates/**/*_test.rs`
+- Docs: `rg -l "<concept>" docs/`
+
+**Step 2: Map crate ownership**
+For each entry point, identify which crate owns it, what layer it's in (kernel/app), and what other crates it imports from.
+
+**Step 3: Trace the data flow**
+Follow the feature through:
+- Where it originates (user call / network message / CCL contract / governance event)
+- Which actors handle it
+- What state mutations occur and which stores are touched
+- What events or messages are emitted downstream
+- Where it terminates (response / ledger entry / gossip message)
+
+**Step 4: Find the API surface**
+- REST routes in `icn-gateway` that expose this feature
+- JSON-RPC methods in `icn-rpc`
+- `icnctl` subcommands in `bins/icnctl`
+- TypeScript SDK bindings in `sdk/`
+
+**Step 5: Find the tests**
+- Unit tests in the owning crate
+- Integration tests in `crates/icn-testkit/`
+- End-to-end tests in `demo/` or `scripts/`
+- Missing test coverage (flag explicitly)
+
+**Step 6: Check docs**
+- Which docs/ files describe this feature
+- Is the docs state current with the code (check dates / git blame)
+- Any ADRs related to this feature
+
+**Output format:**
+```
+## Feature Trace: <concept>
+
+### Crate Map
+| Crate | Layer | Role | Key Types/Traits |
+|-------|-------|------|-----------------|
+...
+
+### Data Flow
+1. Entry: ...
+2. ...
+N. Exit: ...
+
+### API Surface
+- REST: POST /api/v1/...
+- RPC: ...
+- CLI: icnctl ...
+
+### Tests
+- [x] Unit: crates/icn-xxx/tests/...
+- [ ] Integration: MISSING (note gap)
+- [x] E2E: demo/...
+
+### Docs
+- docs/feature-name.md (up to date / stale)
+- ADR: docs/architecture/adr-NNN.md (or: no ADR)
+
+### Gaps & Risks
+- ...
+```

--- a/.claude/hooks/post-tool-guard.py
+++ b/.claude/hooks/post-tool-guard.py
@@ -1,0 +1,9 @@
+import sys, json
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+path = data.get('tool_input', {}).get('file_path', '') or ''
+if path.endswith('.rs'):
+    short = path.split('icn/')[-1] if 'icn/' in path else path
+    print(f'[icn-dev] .rs modified: {short} -- suggest: cargo check --workspace')

--- a/.claude/hooks/pre-bash-guard.py
+++ b/.claude/hooks/pre-bash-guard.py
@@ -1,0 +1,8 @@
+import sys, json
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+cmd = data.get('tool_input', {}).get('command', '')
+if 'git checkout main' in cmd or 'git push origin main' in cmd:
+    print('[icn-dev GUARD] Direct main branch op -- ICN uses feature branches. Confirm intentional.')

--- a/.claude/hooks/pre-tool-guard.py
+++ b/.claude/hooks/pre-tool-guard.py
@@ -1,0 +1,20 @@
+import sys, json
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+tool_input = data.get('tool_input', {})
+path = tool_input.get('file_path', '') or tool_input.get('path', '')
+protected = {
+    'icn-identity':    'DID/key management -- public surface changes require ADR + backward-compat check',
+    'icn-ledger':      'double-entry mutual credit -- invariant violations cause unrecoverable state',
+    'icn-governance':  'voting/proposal logic -- protocol changes need quorum analysis',
+    'icn-ccl':         'cooperative contract language -- interpreter changes affect all deployed contracts',
+    'icn-trust':       'trust graph -- scoring changes affect access control across the network',
+}
+for crate, warning in protected.items():
+    if crate in path:
+        print(f'[icn-dev GUARD] Protected crate: {crate}', flush=True)
+        print(f'  Warning: {warning}', flush=True)
+        print(f'  Checklist: [ ] No public API change [ ] Tests added [ ] ADR filed if protocol shape changed [ ] No payment/currency/token terminology', flush=True)
+        break

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -99,6 +99,26 @@
             "statusMessage": "Checking TODO format..."
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c \"\nimport sys, json\ntry:\n    data = json.load(sys.stdin)\nexcept Exception:\n    sys.exit(0)\ntool_input = data.get('tool_input', {})\npath = tool_input.get('file_path', '') or tool_input.get('path', '')\nprotected = {\n    'icn-identity':    'DID/key management -- public surface changes require ADR + backward-compat check',\n    'icn-ledger':      'double-entry mutual credit -- invariant violations cause unrecoverable state',\n    'icn-governance':  'voting/proposal logic -- protocol changes need quorum analysis',\n    'icn-ccl':         'cooperative contract language -- interpreter changes affect all deployed contracts',\n    'icn-trust':       'trust graph -- scoring changes affect access control across the network',\n}\nfor crate, warning in protected.items():\n    if crate in path:\n        print(f'[icn-dev GUARD] Protected crate: {crate}', flush=True)\n        print(f'  Warning: {warning}', flush=True)\n        print(f'  Checklist: [ ] No public API change [ ] Tests added [ ] ADR filed if protocol shape changed [ ] No payment/currency/token terminology', flush=True)\n        break\n\"",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c \"\nimport sys, json\ntry:\n    data = json.load(sys.stdin)\nexcept Exception:\n    sys.exit(0)\ncmd = data.get('tool_input', {}).get('command', '')\nif 'git checkout main' in cmd or 'git push origin main' in cmd:\n    print('[icn-dev GUARD] Direct main branch op -- ICN uses feature branches. Confirm intentional.')\n\"",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -110,6 +130,16 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/openapi-sync-guard.sh",
             "timeout": 5,
             "statusMessage": "Checking API sync..."
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c \"\nimport sys, json\ntry:\n    data = json.load(sys.stdin)\nexcept Exception:\n    sys.exit(0)\npath = data.get('tool_input', {}).get('file_path', '') or ''\nif path.endswith('.rs'):\n    short = path.split('icn/')[-1] if 'icn/' in path else path\n    print(f'[icn-dev] .rs modified: {short} -- suggest: cargo check --workspace')\n\"",
+            "timeout": 5
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -105,7 +105,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 -c \"\nimport sys, json\ntry:\n    data = json.load(sys.stdin)\nexcept Exception:\n    sys.exit(0)\ntool_input = data.get('tool_input', {})\npath = tool_input.get('file_path', '') or tool_input.get('path', '')\nprotected = {\n    'icn-identity':    'DID/key management -- public surface changes require ADR + backward-compat check',\n    'icn-ledger':      'double-entry mutual credit -- invariant violations cause unrecoverable state',\n    'icn-governance':  'voting/proposal logic -- protocol changes need quorum analysis',\n    'icn-ccl':         'cooperative contract language -- interpreter changes affect all deployed contracts',\n    'icn-trust':       'trust graph -- scoring changes affect access control across the network',\n}\nfor crate, warning in protected.items():\n    if crate in path:\n        print(f'[icn-dev GUARD] Protected crate: {crate}', flush=True)\n        print(f'  Warning: {warning}', flush=True)\n        print(f'  Checklist: [ ] No public API change [ ] Tests added [ ] ADR filed if protocol shape changed [ ] No payment/currency/token terminology', flush=True)\n        break\n\"",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-tool-guard.py",
             "timeout": 5
           }
         ]
@@ -115,7 +115,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 -c \"\nimport sys, json\ntry:\n    data = json.load(sys.stdin)\nexcept Exception:\n    sys.exit(0)\ncmd = data.get('tool_input', {}).get('command', '')\nif 'git checkout main' in cmd or 'git push origin main' in cmd:\n    print('[icn-dev GUARD] Direct main branch op -- ICN uses feature branches. Confirm intentional.')\n\"",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-bash-guard.py",
             "timeout": 5
           }
         ]
@@ -138,7 +138,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 -c \"\nimport sys, json\ntry:\n    data = json.load(sys.stdin)\nexcept Exception:\n    sys.exit(0)\npath = data.get('tool_input', {}).get('file_path', '') or ''\nif path.endswith('.rs'):\n    short = path.split('icn/')[-1] if 'icn/' in path else path\n    print(f'[icn-dev] .rs modified: {short} -- suggest: cargo check --workspace')\n\"",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post-tool-guard.py",
             "timeout": 5
           }
         ]

--- a/.claude/skills/icn-dev/SKILL.md
+++ b/.claude/skills/icn-dev/SKILL.md
@@ -35,7 +35,7 @@ Every ICN request passes through three questions:
 
 ## Project State (load on every ICN session)
 
-### Current Sprint: Sprint 19 — Pilot Genesis
+### Current Sprint: Sprint 26 -- Pilot Genesis
 
 **Cluster:** 3/3 nodes Ready, K3s v1.34.4+k3s1, ~21-day uptime (as of Mar 21)
 

--- a/.claude/skills/icn-dev/SKILL.md
+++ b/.claude/skills/icn-dev/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: icn-dev
+description: >
+  ICN development companion for the InterCooperative Network Rust monorepo. Use when
+  working on ICN code, docs, deployment, or protocol design. Provides crate-aware routing
+  to specialist agents (icn-architect, icn-economist, icn-ops), enforces project conventions,
+  and understands the current sprint state, cluster topology, and demo flow status.
+  Triggers on: any ICN crate names, "cooperative contract", "mutual credit", "governance",
+  "gossip", "K3s", "icn-dev", "ops/mcp", "Sprint", "demo flow", "CCL", "federation",
+  "DID", "ledger", "trust graph", "icnd", "icnctl".
+version: 0.1.0
+---
+
+# ICN Dev Skill — Routing and Context Layer
+
+This skill is the routing and context layer for ICN development sessions. It loads project state, routes to specialist agents, enforces conventions, and tracks the current sprint.
+
+## Core Principle
+
+Every ICN request passes through three questions:
+1. **Which domain?** Code architecture / economics / deployment / docs / planning
+2. **Which agent?** Route to the specialist with the right mental model
+3. **What's the current state?** Load sprint context before acting
+
+## Specialist Routing
+
+| Domain | Route to | When |
+|--------|----------|------|
+| Crate boundaries, kernel/app separation, public API, refactors, ADRs, protocol shape, concurrency | **icn-architect** | Anything touching crate structure or protocol design |
+| Ledger, CCL, mutual credit, treasury, mana, settlement flows, regulatory terminology, economic invariants | **icn-economist** | Anything touching economics or the compliance sprint |
+| K3s cluster, pods, demo flows, CI, release readiness, ops/mcp, disk space | **icn-ops** | Anything touching deployment or demo validation |
+| Cross-cutting: feature trace, audit, state sync | **/icn-trace, /icn-audit, /icn-state-sync** | Use the commands directly |
+
+**When in doubt:** Use **icn-architect** as the default. It has the broadest view and can re-route.
+
+## Project State (load on every ICN session)
+
+### Current Sprint: Sprint 19 — Pilot Genesis
+
+**Cluster:** 3/3 nodes Ready, K3s v1.34.4+k3s1, ~21-day uptime (as of Mar 21)
+
+**Demo Flows:**
+- Flow 1A (Governance): OPERATIONAL
+- Flow 1B (Governance + Provenance): BLOCKED (signing key not configured)
+- Flow 2 (Patronage): OPERATIONAL
+- Flow 3 (Federation): STRUCTURALLY BLOCKED (P2P address bug, PR #1381 needed)
+- Flow 4 (Reporting): BLOCKED (depends on Flow 3)
+
+**Phase 1 Compliance Sprint (urgent before grant applications):**
+- Rename: `payment` -> `settlement`, `currency` -> `unit`, `balance` -> `position`
+- Make `JournalEntry.provenance` required
+- Add `Obligation` type with lifecycle states
+- Extract commons credit formula to CCL
+- CI linter for regulatory terminology
+
+**Critical blockers:**
+- PR #1381 (service discovery persistence) — needs review/merge
+- ExecutionReceiptGate signing key — not configured in K3s secrets
+- ops/mcp: 4 modified + 10 untracked files uncommitted on icn-dev
+- Villain CI broken since Mar 8 (separate project, same Zentith infra)
+
+**Target:** v1.0.0 tag when vertical slice integration test passes (~Apr 15)
+
+## Convention Enforcement
+
+When working in this skill context, enforce:
+
+1. **Branch discipline** — always verify `git branch --show-current` before editing. ICN uses feature branches.
+2. **Regulatory terminology** — immediately flag and suggest replacement for: payment, currency, wallet, token, blockchain, transaction fee.
+3. **Kernel/app boundary** — flag changes to kernel crates (icn-identity, icn-trust, icn-net, icn-gossip, icn-core, icn-store, icn-encoding, icn-obs, icn-time, icn-snapshot, icn-security, icn-rpc, icn-crypto-pq, icn-zkp, icn-steward) that need ADR review.
+4. **Test coverage** — new logic in any crate must have tests. Flag if missing.
+5. **Provenance required** — any JournalEntry creation must have provenance set. Flag if empty/None.
+
+## Crate Quick Reference
+
+**Kernel (ADR required for public API changes):**
+icn-identity, icn-trust, icn-net, icn-gossip, icn-privacy, icn-core, icn-store, icn-encoding, icn-obs, icn-rpc, icn-time, icn-snapshot, icn-security, icn-crypto-pq, icn-zkp, icn-steward
+
+**Application (normal change process):**
+icn-ledger, icn-ccl, icn-compute, icn-gateway, icn-governance, icn-federation, icn-community, icn-entity, icn-coop
+
+**Binaries:** icnd, icnctl, icn-console
+
+## Reference Files
+
+Load these when needed:
+- Crate detail: `~/.claude_launchpad/projects/icn/icn-crate-reference.md`
+- Current state: `~/.claude_launchpad/projects/icn/icn-state-2026-03-21.md`
+- Forward plan: `~/.claude_launchpad/projects/icn/icn-forward-plan.md`
+- Ecosystem map: `~/.claude_launchpad/projects/icn/icn-ecosystem-map.md`
+- Demo flows: `~/.claude_launchpad/projects/icn/SPRINT-DEMO-READY.md`
+
+## Commands
+
+- `/icn-trace` — map a feature across crates, routes, tests, docs
+- `/icn-audit` — security, trust, and regulatory audit of a code path
+- `/icn-demo-check` — full demo readiness check with live cluster queries
+- `/icn-state-sync` — sync state docs and flag stale documentation
+
+## Operating Rules
+
+1. **State before action.** Read the current state doc before making architectural recommendations. The project is at Sprint 19, not at the beginning.
+2. **Regulatory framing is not optional.** The Sovereign Tech Fund grant and cooperative framing depend on clean terminology. Flag violations in code review even when they seem cosmetic.
+3. **The economists and architects don't talk to each other by default.** When a change spans economics AND protocol shape (e.g. changing how the ledger Merkle-DAG is structured), explicitly involve both icn-architect and icn-economist.
+4. **ops/mcp dirty state blocks session continuity.** If icn-dev has uncommitted ops/mcp changes, recommend committing before doing other work. The event bus and decision log aren't trustworthy with dirty state.
+5. **Four demo flows are the acceptance criteria.** "Done" means the relevant demo flows pass. Code that compiles but breaks a demo flow is not done.
+6. **icn-dev disk is a recurring hazard.** Rust build artifacts fill `/var/lib/rancher`. Check before long build sessions. `cargo clean` is safe.

--- a/demo/scripts/flow-2-patronage.sh
+++ b/demo/scripts/flow-2-patronage.sh
@@ -154,7 +154,10 @@ for p in d.get('data', []):
 # ---------------------------------------------------------------------------
 narrate "Pre-step: Resetting BrightWorks demo state (patronage ledger + Q1 proposal)"
 aside "Closes stale Q1 proposals; re-seeds canonical Draft for this run"
-if bash "${SCRIPT_DIR}/reseed-federation-demo.sh" 2>&1 | grep -E "(RESULT|WARN|FAIL|===|Seeded|Skipped|Failed)" | head -20; then
+_reseed_out=$(bash "${SCRIPT_DIR}/reseed-federation-demo.sh" 2>&1)
+_reseed_rc=$?
+echo "$_reseed_out" | grep -E "(RESULT|WARN|FAIL|===|Seeded|Skipped|Failed)" | head -20
+if [ "$_reseed_rc" -eq 0 ]; then
   result "State reset complete"
 else
   warn "Reseed returned non-zero -- check output; proceeding anyway"

--- a/demo/scripts/flow-3-federation.sh
+++ b/demo/scripts/flow-3-federation.sh
@@ -142,7 +142,10 @@ _require_2xx() {
 # ---------------------------------------------------------------------------
 narrate "Pre-step: Reseeding federation demo state (idempotent)"
 aside "Clears stale proposals from prior runs; re-seeds coop records and governance domains"
-if bash "${SCRIPT_DIR}/reseed-federation-demo.sh" 2>&1 | grep -E "(RESULT|WARN|FAIL|===|Seeded|Skipped|Failed)" | head -20; then
+_reseed_out=$(bash "${SCRIPT_DIR}/reseed-federation-demo.sh" 2>&1)
+_reseed_rc=$?
+echo "$_reseed_out" | grep -E "(RESULT|WARN|FAIL|===|Seeded|Skipped|Failed)" | head -20
+if [ "$_reseed_rc" -eq 0 ]; then
   result "Reseed complete"
 else
   warn "Reseed returned non-zero -- proceeding anyway"

--- a/demo/scripts/rehearsal-probe.sh
+++ b/demo/scripts/rehearsal-probe.sh
@@ -317,7 +317,7 @@ else
   # If 400 mentioning decision_id: deny_unknown_fields IS set — field explicitly rejected
   # If 400 for self-payment/other: field was ignored, other validation failed
   _do_probe_curl "${BRIGHTWORKS_URL}/v1/ledger/brightworks-cooperative/settle" POST \
-    "{\"from\":\"did:icn:zHdQuwTTniwcV4TT1ZcfXsVP7dCojE5czv7vUghmNSmgB\",\"to\":\"did:icn:zyWqWVqGERfRvUz4LVGd4coCZDuNhnufxRpNVTR1BBA7\",\"amount\":1,\"currency\":\"hours\",\"memo\":\"rehearsal-probe-r3\",\"decision_id\":\"00000000-0000-0000-0000-000000000000\"}" \
+    "{\"from\":\"did:icn:zHdQuwTTniwcV4TT1ZcfXsVP7dCojE5czv7vUghmNSmgB\",\"to\":\"did:icn:zyWqWVqGERfRvUz4LVGd4coCZDuNhnufxRpNVTR1BBA7\",\"amount\":1,\"unit\":\"hours\",\"memo\":\"rehearsal-probe-r3\",\"decision_id\":\"00000000-0000-0000-0000-000000000000\"}" \
     "$BRIGHTWORKS_TOKEN"
   R3_HTTP="$PROBE_HTTP_CODE"
   R3_RAW="$(cat "$_RESP_FILE")"
@@ -345,7 +345,7 @@ else
     # 404 = route not matched (actix http.route=default in logs)
     R3_STATUS=MISMATCH; R3_OBSERVED="404-wrong-route"
     _probe_result MISMATCH "R3: 404 — /settle route not matched. Check binary version." \
-      "Binary may predate /payment route or route was registered differently."
+      "Binary may predate the /settle route and still expose /payment instead, or the route was registered differently."
   elif [ "$R3_HTTP" = "400" ]; then
     if [ -n "$R3_BODY_MENTIONS_AUTH" ]; then
       R3_STATUS=UNCLEAR; R3_OBSERVED="400-auth (scope issue)"

--- a/docs/demo/WALKTHROUGH.md
+++ b/docs/demo/WALKTHROUGH.md
@@ -1,0 +1,503 @@
+# ICN Governance Demo — Walkthrough
+
+**Date:** 2026-03-25
+**Verified:** All 19 steps pass, exit code 0.
+**Script:** `demo/scripts/demo-governance.py`
+**Runtime:** ~8 seconds against a local `icnd` process
+
+---
+
+## What the Demo Proves
+
+Three people — Alice, Bob, and Carol — form a cooperative from scratch and make their first democratic decision. No admin account. No corporation in the middle. No one has special permanent authority.
+
+Alice is elected temporary coordinator to bootstrap the coop structure. She uses that role to create the cooperative, set up the governance domain, and add Bob and Carol as members. Once the structure exists, her coordinator role is just another member token. Any member can propose. Any member can vote. Any member can close a vote.
+
+The first democratic act is ratifying the cooperative's own charter — the members adopt their own rules, together, before any substantive decisions are made. Then Bob (not the coordinator) proposes $12,000 for community kitchen equipment. All three vote for it. Carol (not the coordinator, not the proposer) closes the vote.
+
+When the vote closes, the ICN node generates a cryptographic receipt: a `GovernanceProofV2` that bundles the canonical decision hash, the vote tally, and a node attestation signed with the node's Ed25519 key. The receipt can be re-verified by any party at any time. It is anchored to the vote record, not to any central authority.
+
+That's the claim: **a cooperative can self-govern, and the governance record is cryptographically verifiable, without a trusted third party**.
+
+---
+
+## Prerequisites
+
+- **Rust 1.88.0** (pinned — do not upgrade)
+- **Python 3.8+** with the `cryptography` package
+- **Port 8080** free
+
+```bash
+pip install cryptography
+ss -tlnp | grep :8080    # must return nothing
+```
+
+First-time build (from the `icn/` monorepo root):
+
+```bash
+cd icn && cargo build -p icnd   # ~2 minutes first time, ~10s incremental
+```
+
+---
+
+## Quick Start
+
+Three commands:
+
+```bash
+bash demo/scripts/start-demo.sh /tmp/icn-demo
+python3 demo/scripts/demo-governance.py http://localhost:8080
+pkill -f icnd
+```
+
+For a live-presentation experience with colored output and phase pauses:
+
+```bash
+bash demo/scripts/present-governance.sh
+```
+
+---
+
+## Step-by-Step Walkthrough
+
+### Phase 1: Founding Assembly (Steps 1–6)
+
+Alice, Bob, and Carol are bootstrapped as equal founding members. Alice holds a temporary coordinator token to create the infrastructure. That role doesn't persist.
+
+---
+
+**Step 1 — Generate member identities**
+
+No API call. Each member generates a fresh Ed25519 keypair in memory. Their DID is derived directly from the public key bytes, base58-encoded with the `did:icn:z` prefix.
+
+```
+Alice: did:icn:z<base58-pubkey>
+Bob:   did:icn:z<base58-pubkey>
+Carol: did:icn:z<base58-pubkey>
+```
+
+*What this proves:* Identity is self-sovereign. No registration with a central authority. No username/password. The key is the identity.
+
+---
+
+**Step 2 — Alice authenticates as coordinator**
+
+```
+POST /v1/auth/challenge  { "did": alice.did }
+POST /v1/auth/verify     { "did": alice.did, "signature": hex(sign(nonce)), "coop_id": "finger-lakes-food", "scopes": [...] }
+```
+
+The gateway issues a challenge nonce. Alice signs it with her Ed25519 private key and returns the hex signature. On verification, the gateway derives Alice's expected public key from her DID, verifies the signature, and issues a scoped JWT.
+
+*What this proves:* Authentication is DID-native challenge-response. The gateway never sees Alice's private key. Possession of the key proves identity.
+
+Alice's scopes: `coop:read`, `coop:write`, `coop:admin`, `governance:read`, `governance:write`, `treasury:read`, `treasury:write`.
+
+---
+
+**Step 3 — Create the cooperative**
+
+```
+POST /v1/coops  { "id": "finger-lakes-food", "name": "Finger Lakes Food Co-op" }
+Authorization: Bearer <alice-token>
+```
+
+*What this proves:* A cooperative entity exists in the system. `finger-lakes-food` is the canonical cooperative ID. Alice's admin scope authorizes creation.
+
+---
+
+**Step 4 — Create governance domain**
+
+```
+POST /v1/gov/domains  {
+  "id": "coop:finger-lakes-food",
+  "name": "Finger Lakes Food Co-op Governance",
+  "profile": "cooperative_default",
+  "quorum_percent": 50,
+  "approval_percent": 51,
+  "voting_period_days": 7,
+  "members": [alice.did]
+}
+```
+
+*What this proves:* Governance rules are explicit and stored: 50% quorum, simple majority (51%), 7-day voting windows. Alice is the initial member; Bob and Carol will be added next.
+
+---
+
+**Step 5 — Add Bob to the cooperative and governance domain**
+
+```
+POST /v1/coops/finger-lakes-food/members  { "did": bob.did, "role": "participant", "display_name": "Bob" }
+POST /v1/gov/domains/coop:finger-lakes-food/members  { "did": bob.did, "weight": 1.0 }
+```
+
+*What this proves:* Bob is a full coop member with voting weight 1.0. Equal to Alice.
+
+---
+
+**Step 6 — Add Carol to the cooperative and governance domain**
+
+```
+POST /v1/coops/finger-lakes-food/members  { "did": carol.did, "role": "participant", "display_name": "Carol" }
+POST /v1/gov/domains/coop:finger-lakes-food/members  { "did": carol.did, "weight": 1.0 }
+```
+
+*What this proves:* Carol is a full coop member with voting weight 1.0. Equal to Alice and Bob.
+
+✓ Phase 1 complete: Finger Lakes Food Co-op — 3 members, governance domain active.
+
+---
+
+### Phase 2: Charter Ratification (Steps 7–12)
+
+The first democratic act. Members don't inherit rules from above — they vote to adopt their own.
+
+---
+
+**Step 7 — Alice submits the founding charter for ratification**
+
+```
+POST /v1/gov/proposals  {
+  "domain_id": "coop:finger-lakes-food",
+  "title": "Ratify the Finger Lakes Food Co-op Founding Charter",
+  "description": "...",
+  "payload": {
+    "type": "charter",
+    "charter_id": "finger-lakes-food-coop",
+    "charter_yaml": "..."
+  }
+}
+```
+
+The charter payload includes the full CCL (Cooperative Contract Language) YAML: governance bodies (`general_assembly`, `stewardship_circle`), decision thresholds (`ordinary` = simple majority, `constitutional` = two-thirds), delegation rules, credit limits, and surplus allocation (20% reserve, 80% patronage).
+
+*What this proves:* Cooperative constitutions are first-class data in ICN — stored, governed, and enforced, not just text files.
+
+---
+
+**Step 8 — Open charter for ratification vote**
+
+```
+POST /v1/gov/proposals/{charter_id}/open  { "voting_period_seconds": 3600 }
+```
+
+*What this proves:* Proposals are not live until explicitly opened. The voting window starts from this call.
+
+---
+
+**Step 9 — Alice votes to ratify the charter**
+
+```
+POST /v1/gov/proposals/{charter_id}/vote  { "choice": "for" }
+Authorization: Bearer <alice-token>
+```
+
+*Alice: FOR*
+
+---
+
+**Step 10 — Bob authenticates and votes to ratify**
+
+Bob runs the same DID challenge-response as Alice (Step 2), receiving scopes `governance:read`, `governance:write`.
+
+```
+POST /v1/gov/proposals/{charter_id}/vote  { "choice": "for" }
+Authorization: Bearer <bob-token>
+```
+
+*Bob: FOR*
+
+---
+
+**Step 11 — Carol authenticates and votes to ratify**
+
+```
+POST /v1/gov/proposals/{charter_id}/vote  { "choice": "for" }
+Authorization: Bearer <carol-token>
+```
+
+*Carol: FOR*
+
+---
+
+**Step 12 — Alice closes the charter ratification**
+
+```
+POST /v1/gov/proposals/{charter_id}/close  {}
+Authorization: Bearer <alice-token>
+```
+
+*What this proves:* 3/3 unanimous ratification. The cooperative's rules are now in effect.
+
+✓ Phase 2 complete: Charter ratified 3/3.
+
+---
+
+### Phase 3: Democratic Decision (Steps 13–17)
+
+Bob proposes a budget item. He's not the coordinator. He doesn't need permission to propose.
+
+---
+
+**Step 13 — Bob proposes community kitchen equipment**
+
+```
+POST /v1/gov/proposals  {
+  "domain_id": "coop:finger-lakes-food",
+  "title": "Approve $12,000 for community kitchen equipment",
+  "description": "Purchase commercial-grade equipment for our shared community kitchen:
+    convection oven ($4,000), industrial mixer ($3,000),
+    prep tables and storage ($2,500), safety and small tools ($2,500).
+    This investment serves all 47 member households.",
+  "payload": {
+    "type": "budget",
+    "amount": 12000,
+    "currency": "USD",
+    "purpose": "Community Kitchen Equipment"
+  }
+}
+Authorization: Bearer <bob-token>
+```
+
+*What this proves:* Any member can create a proposal. Bob does not need Alice's permission or coordinator status.
+
+---
+
+**Step 14 — Bob opens the proposal for voting**
+
+```
+POST /v1/gov/proposals/{proposal_id}/open  { "voting_period_seconds": 3600 }
+Authorization: Bearer <bob-token>
+```
+
+*What this proves:* The proposer controls when their proposal goes live — also without coordinator involvement.
+
+---
+
+**Step 15 — Alice votes FOR the kitchen equipment**
+
+```
+POST /v1/gov/proposals/{proposal_id}/vote  { "choice": "for" }
+Authorization: Bearer <alice-token>
+```
+
+*Alice: FOR*
+
+---
+
+**Step 16 — Bob votes FOR**
+
+```
+POST /v1/gov/proposals/{proposal_id}/vote  { "choice": "for" }
+Authorization: Bearer <bob-token>
+```
+
+*Bob: FOR*
+
+---
+
+**Step 17 — Carol votes FOR**
+
+```
+POST /v1/gov/proposals/{proposal_id}/vote  { "choice": "for" }
+Authorization: Bearer <carol-token>
+```
+
+*Carol: FOR*
+
+✓ Phase 3 complete: 3 votes FOR, 0 against.
+
+---
+
+### Phase 4: Verification (Steps 18–19)
+
+Carol closes the vote — not Alice, not Bob. Authority rotates naturally.
+
+---
+
+**Step 18 — Carol closes and tallies the vote**
+
+```
+POST /v1/gov/proposals/{proposal_id}/close  {}
+Authorization: Bearer <carol-token>
+```
+
+After closing, the script retrieves the current proposal state and vote tally:
+
+```
+GET /v1/gov/proposals/{proposal_id}
+GET /v1/gov/proposals/{proposal_id}/tally
+```
+
+Tally response:
+
+```json
+{
+  "for_votes": 3,
+  "against_votes": 0,
+  "abstain_votes": 0,
+  "total_votes": 3
+}
+```
+
+*What this proves:* The vote is counted and recorded. 3/3 for, 0 against. Quorum reached (100% > 50%). Approval threshold met (100% > 51%). Outcome: **ACCEPTED**.
+
+---
+
+**Step 19 — Generate cryptographic proof**
+
+```
+GET /v1/gov/proposals/{proposal_id}/proof
+Authorization: Bearer <carol-token>
+```
+
+The gateway verifies the stored proof before serving it: checks the receipt binding hash, confirms at least one attestation is present, verifies each attestation's `decision_hash` matches the receipt, and validates the Ed25519 signature against the signer's DID.
+
+Proof response structure:
+
+```json
+{
+  "receipt": {
+    "proposal_id": "<uuid>",
+    "domain_id": "coop:finger-lakes-food",
+    "outcome": "accepted",
+    "vote_tally": {
+      "for_votes": 3,
+      "against_votes": 0,
+      "abstain_votes": 0
+    },
+    "vote_hash": [241, 16, 39, 185, ...],
+    "decision_hash": [...]
+  },
+  "attestations": [
+    {
+      "decision_hash": [...],
+      "signer_did": "did:icn:z<node-pubkey>",
+      "timestamp": <unix-seconds>,
+      "signature": [...]
+    }
+  ]
+}
+```
+
+*What this proves:*
+
+- **`vote_hash`** — A BLAKE3 Merkle root over all sorted (voter DID, choice, weight) tuples. Order-independent: the same votes in any order produce the same hash.
+- **`decision_hash`** — A canonical BLAKE3 hash of the receipt fields (proposal ID, domain, outcome, tally, vote_hash). Deterministic across nodes: two independent nodes processing the same vote record produce identical `decision_hash` values.
+- **`attestation.signature`** — An Ed25519 signature over the canonical attestation payload (domain tag + decision_hash + signer DID + timestamp), signed by the ICN node's keystore key.
+
+The receipt is self-verifiable. Anyone with the node's public key (derivable from its DID) can check the signature. No trust in the node is required — possession of the data is sufficient.
+
+---
+
+## Verified Output
+
+Actual terminal output from the verified run (2026-03-25):
+
+```
+============================================================
+  ICN Cooperative Governance Demo
+============================================================
+  Gateway: http://localhost:8080
+
+  ✓ Gateway healthy (version ...)
+
+  ...
+
+  Step 18. Carol closes and tallies the vote
+  ✓ Vote closed by Carol
+  ✓ Proposal state: ACCEPTED
+  ✓ Vote tally retrieved
+    {
+      "for_votes": 3,
+      "against_votes": 0,
+      "abstain_votes": 0,
+      "total_votes": 3
+    }
+
+  Step 19. Generate cryptographic proof
+  ✓ Governance proof retrieved
+    { "receipt": { ... "vote_hash": [241, 16, 39, 185, ...] ... }, "attestations": [...] }
+
+============================================================
+  Demo Complete
+============================================================
+
+  Cooperative:  Finger Lakes Food Co-op
+  Domain:       coop:finger-lakes-food
+  Members:      Alice, Bob, Carol
+  Charter:      Ratified 3/3
+  Proposal:     "Approve $12,000 for community kitchen equipment"
+  Tally:        3 for / 0 against
+  Outcome:      ACCEPTED
+  Receipt:      f11027b9...
+```
+
+The receipt hash (`f11027b9...`) is the `vote_hash` from the proof receipt, hex-encoded. It will differ on each run because Alice, Bob, and Carol each get freshly generated keypairs. The hash is a function of their DIDs and their votes — any change to either invalidates it.
+
+---
+
+## What Makes This Cooperative-First
+
+**The coordinator is temporary.** Alice holds coordinator scopes to bootstrap the structure. Once Bob and Carol are added, she has no special authority over proposals or votes. Steps 13–19 proceed entirely without her initiating them — Bob proposes, Bob opens the vote, Carol closes it.
+
+**Any member can propose.** Step 13 is Bob creating a proposal using his own governance JWT. No coordinator approval gate. No special role check. The governance domain rules (quorum, threshold, voting period) are the only constraints.
+
+**Any member can close a vote.** Step 18 is Carol closing the vote. The governance system doesn't require the proposer or coordinator to close — any authenticated member with `governance:write` scope can do it. Authority is not concentrated.
+
+**All members have equal weight.** Bob and Carol are added with `"weight": 1.0`, the same as Alice. The tally is `for_votes: 3` — three equal votes, not three weighted ones.
+
+**The proof is not signed by a central authority.** The attestation is signed by the ICN node (the gateway daemon), which the cooperative itself runs. The signer's DID is in the proof, derivable to a public key, verifiable locally. A third party verifying the receipt doesn't need to trust the coop or the node — they verify the math.
+
+---
+
+## Running It Yourself
+
+```bash
+# 1. Build
+cd icn && cargo build -p icnd
+
+# 2. Start gateway and run demo
+bash demo/scripts/start-demo.sh /tmp/icn-demo
+python3 demo/scripts/demo-governance.py http://localhost:8080
+
+# 3. Cleanup
+pkill -f icnd && rm -rf /tmp/icn-demo
+```
+
+For interactive presenter mode (colored, paused between phases):
+
+```bash
+bash demo/scripts/present-governance.sh
+```
+
+For browser UI (after gateway is running):
+
+```
+http://localhost:8080/static/demo.html
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `Gateway not reachable` | Gateway not started or wrong port | `pgrep -f icnd` → `cat /tmp/icn-demo/gateway.log \| tail -20` |
+| `sled lock error` | Previous gateway didn't clean up | `pkill -9 -f icnd` then use a fresh data dir |
+| `JWT secret not configured` | Running manually without env vars | See `RUNBOOK.md` for full manual invocation |
+| `ModuleNotFoundError: cryptography` | Python package missing | `pip install cryptography` |
+| `Proof endpoint 404` | Node keystore not unlocked at startup | Check logs for `GovernanceProof signing key unavailable` |
+| Build `SIGSEGV` | Incremental compilation cache corruption | `cargo clean && cargo build -p icnd` |
+
+---
+
+## What to Look at Next
+
+**K3s five-flow federation demo** — Four real cooperatives running on the homelab K3s cluster (BrightWorks Collective, River City Tool Library, Harbor Homes, Finger Lakes CDN). Covers governance, patronage settlement, inter-coop federation treaties, regulatory reporting, and distributed compute with trust-gated task admission. See the K3s section in `demo/RUNBOOK.md`.
+
+**Browser demo** — `http://localhost:8080/static/demo.html` after starting the gateway. Four "Run Phase N" buttons. Suitable for screen-share demos. Shows coordinator role labeled as "Temporary" and equal voting weights explicitly.
+
+**Architecture** — `docs/ARCHITECTURE.md` covers the constraint enforcement model (apps translate meaning, kernel enforces blindly), the actor-based runtime, and the trust graph → PolicyOracle → ConstraintSet flow that underpins everything the demo exercises.
+
+**Proof structure** — `icn/crates/icn-governance/src/proof.rs` is the canonical source for `GovernanceProof`, `GovernanceDecisionReceipt`, `GovernanceDecisionAttestation`, and `GovernanceProofV2`. The hash construction and verification logic is documented inline.

--- a/ops/state/sprint/current.json
+++ b/ops/state/sprint/current.json
@@ -42,8 +42,8 @@
     {
       "id": "s26-t3",
       "title": "Resolve fix/demo-path-bugs branch: 7 dirty files from route rename (/payment+currency -> /settle+unit)",
-      "status": "in-progress",
-      "pr": null,
+      "status": "in-review",
+      "pr": 1433,
       "assignee": "matt",
       "epic": "demo"
     },
@@ -58,7 +58,7 @@
     {
       "id": "s26-t5",
       "title": "Unblock CI: main branch CI run stuck in queued state",
-      "status": "blocked",
+      "status": "done",
       "pr": null,
       "assignee": null,
       "epic": "devops"

--- a/ops/state/sprint/current.json
+++ b/ops/state/sprint/current.json
@@ -4,7 +4,9 @@
   "governing_rule": "A task is only done when repo state, board state, and narrative state agree.",
   "start_date": "2026-03-23",
   "status": "active",
-  "spine": ["#1406"],
+  "spine": [
+    "#1406"
+  ],
   "shipped": [
     "#1406 — refactor(compute): extract reservation helpers + idempotence tests (PR #1406)"
   ],
@@ -20,5 +22,46 @@
     ],
     "notes": "Fix pass extended reservation lifecycle coverage to all task termination paths: on_task_cancelled, cancel_task, complete_task_result (quorum path), on_task_result legacy inline path, WasmRef early exits, and check_timeouts for pending (never-claimed) tasks. Timeout path structural fix: task_scope_map only covers claimed tasks; added direct scope lookup from TaskManager for pending tasks. 6th test added: test_reservation_released_on_timeout. TriggerTimeoutSweep test hook added to ComputeHandle."
   },
-  "tasks": []
+  "tasks": [
+    {
+      "id": "s26-t1",
+      "title": "Migrate CI coverage to llvm-cov on Zentith self-hosted runner",
+      "status": "in-progress",
+      "pr": null,
+      "assignee": "matt",
+      "epic": "devops"
+    },
+    {
+      "id": "s26-t2",
+      "title": "Review dependabot PR #1422: bump dtolnay/rust-toolchain from 1.88.0 to 1.100.0",
+      "status": "blocked",
+      "pr": 1422,
+      "assignee": null,
+      "epic": "deps"
+    },
+    {
+      "id": "s26-t3",
+      "title": "Resolve fix/demo-path-bugs branch: 7 dirty files from route rename (/payment+currency -> /settle+unit)",
+      "status": "in-progress",
+      "pr": null,
+      "assignee": "matt",
+      "epic": "demo"
+    },
+    {
+      "id": "s26-t4",
+      "title": "Complete Claude agent definition rewrite (.claude/agents/icn-architect.md)",
+      "status": "in-progress",
+      "pr": null,
+      "assignee": "matt",
+      "epic": "workflow"
+    },
+    {
+      "id": "s26-t5",
+      "title": "Unblock CI: main branch CI run stuck in queued state",
+      "status": "blocked",
+      "pr": null,
+      "assignee": null,
+      "epic": "devops"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Fix 5 demo-path polish bugs from rehearsal probe
- Rename /payment+currency route to /settle+unit in rehearsal probe R3 (2026-03-01)
- Add ICN specialist agents, guard hooks, commands, and skills for icn-dev
- Update sprint 5 state with s26 task backlog
- docs/demo/WALKTHROUGH.md: verified 19-step narrative walkthrough, exit code 0, 2026-03-25

## Verified
All 19 governance demo steps pass on icn-dev. GovernanceProofV2 generated, receipt hash f11027b9... confirmed.

## Test plan
- [x] 19-step governance demo passes end-to-end (2026-03-25)
- [ ] K3s federation flows healthy after reseed
- [ ] Agent configs load in icn-dev Claude Code session