### PR TITLE
feat(provenance): governance→economics chain binding + JWT auth proof in direct-member entries

### DIFF
--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -96,6 +96,10 @@ where
             web::resource("/proposals/{proposal_id}/proof")
                 .route(web::get().to(handlers::get_proof::<E>)),
         )
+        .service(
+            web::resource("/proposals/{proposal_id}/chain")
+                .route(web::get().to(handlers::get_chain::<E>)),
+        )
         // ── Discussion endpoints ─────────────────────────────────────────
         .service(
             web::resource("/proposals/{proposal_id}/discussion")

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -1118,6 +1118,31 @@ pub async fn get_vote_tally<E: GovernanceEventEmitter + Clone + 'static>(
     }))
 }
 
+/// GET /gov/proposals/{proposal_id}/chain — Get the full provenance chain for a proposal.
+///
+/// Returns the governance decision receipt and any linked allocation receipts,
+/// enabling independent verification of the governance→economics binding (INV-5).
+///
+/// Response includes:
+/// - `governance_receipt`: The decision receipt (present if proposal is closed)
+/// - `allocations`: AllocationReceipts created when the proposal was accepted
+/// - `chain_complete`: Whether the chain is complete for this proposal type
+///
+/// A `chain_complete: false` response means the system cannot answer
+/// "what economic effect did this decision have?" — a provenance gap.
+pub async fn get_chain<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    proposal_id: web::Path<String>,
+) -> Result<HttpResponse, ApiError> {
+    require_scope::<BasicClaims>(&http_req, "governance:read")?;
+
+    let id = ProposalId(proposal_id.into_inner());
+    let chain = ctx.manager.get_chain(&id).await.map_err(anyhow_to_api)?;
+
+    Ok(HttpResponse::Ok().json(chain))
+}
+
 /// GET /gov/proposals/{proposal_id}/proof — Get cryptographic proof of proposal outcome.
 pub async fn get_proof<E: GovernanceEventEmitter + Clone + 'static>(
     ctx: web::Data<GovernanceContext<E>>,

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -19,9 +19,23 @@ use icn_governance::{
     DEFAULT_MAX_DELEGATION_DEPTH,
 };
 use icn_identity::Did;
+use icn_kernel_api::{AllocationReceipt, ScopeLevel, SettlementIntent};
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 use tracing::debug;
+
+/// Full provenance chain for a governance proposal (INV-5).
+///
+/// Links governance decision → allocation receipts for independent verification.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ProvenanceChain {
+    /// Governance decision receipt (present if proposal was closed)
+    pub governance_receipt: Option<icn_governance::GovernanceDecisionReceipt>,
+    /// Allocation receipts linking decision to economic intents
+    pub allocations: Vec<AllocationReceipt>,
+    /// True if the chain is complete for this proposal type
+    pub chain_complete: bool,
+}
 
 // ============================================================================
 // Sled-Backed Action Item Store
@@ -687,11 +701,40 @@ impl GovernanceManager {
                     &proposal_votes,
                 );
                 if let Err(e) = store.put_governance(&receipt) {
-                    tracing::warn!(
+                    tracing::error!(
                         proposal_id = %proposal_id.0,
                         error = %e,
-                        "Failed to store governance decision receipt (non-fatal)"
+                        "Failed to store governance decision receipt — provenance chain broken"
                     );
+                    // Escalated from warn to error: receipt store failure means
+                    // the governance→economics provenance chain is broken (PS-3).
+                }
+
+                // Wire governance→economics binding (INV-2: Allocation Completeness)
+                // When a budget/treasury/allocation proposal is accepted, create an
+                // AllocationReceipt linking the decision to economic intents.
+                if matches!(outcome, ProofOutcome::Accepted) {
+                    let decision_hash = receipt.decision_hash;
+                    if let Some(allocation_receipt) = self.create_allocation_receipt(
+                        &proposal.payload,
+                        decision_hash,
+                        &proposal_id,
+                        &proposal.domain_id,
+                    ) {
+                        if let Err(e) = store.put_allocation(&allocation_receipt) {
+                            tracing::error!(
+                                proposal_id = %proposal_id.0,
+                                error = %e,
+                                "Failed to store allocation receipt — economics binding broken"
+                            );
+                        } else {
+                            tracing::info!(
+                                proposal_id = %proposal_id.0,
+                                intent_count = allocation_receipt.intents.len(),
+                                "Allocation receipt created: governance→economics chain bound"
+                            );
+                        }
+                    }
                 }
             }
 
@@ -701,6 +744,224 @@ impl GovernanceManager {
                 "Proposal '{}' not found. It may not exist or was already deleted.",
                 proposal_id.0
             )
+        }
+    }
+
+    /// Get the full provenance chain for a proposal (INV-5: Chain Walkability).
+    ///
+    /// Returns:
+    /// - `governance_receipt`: The decision receipt for the proposal (if closed)
+    /// - `allocations`: AllocationReceipts linked to this decision (if any)
+    /// - `chain_complete`: true if governance receipt AND at least one allocation exist for economic proposals
+    ///
+    /// This endpoint makes the governance→economics link independently verifiable
+    /// without SSH access to the node.
+    pub async fn get_chain(&self, proposal_id: &ProposalId) -> Result<ProvenanceChain> {
+        let governance_receipt = if let Some(ref store) = self.receipt_store {
+            match store.get_governance_by_proposal(&proposal_id.0) {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::warn!(proposal_id = %proposal_id.0, error = %e, "Receipt store error in get_chain");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        let allocations = if let Some(ref receipt) = governance_receipt {
+            if let Some(ref store) = self.receipt_store {
+                let decision_hash = receipt.decision_hash;
+                match store.list_allocations_by_decision(&decision_hash) {
+                    Ok(a) => a,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "Failed to query allocations in get_chain");
+                        vec![]
+                    }
+                }
+            } else {
+                vec![]
+            }
+        } else {
+            vec![]
+        };
+
+        // Chain is complete when:
+        // - governance receipt exists AND
+        // - either there are allocations (economic proposal) OR
+        //   the proposal is non-economic (Text/Membership/etc — no allocation expected)
+        let has_governance = governance_receipt.is_some();
+        let has_allocations = !allocations.is_empty();
+
+        // Determine if this is an economic proposal by checking the stored receipt or proposal payload
+        let is_economic = has_allocations; // If allocations were created, it was economic
+        let chain_complete = has_governance && (is_economic == has_allocations);
+
+        Ok(ProvenanceChain {
+            governance_receipt,
+            allocations,
+            chain_complete,
+        })
+    }
+
+    /// Create an AllocationReceipt from an accepted proposal's payload.
+    ///
+    /// Returns `None` for proposal types that don't produce economic effects
+    /// (e.g., Text, Membership, ConfigChange).
+    ///
+    /// This is the governance→economics binding point (INV-2).
+    fn create_allocation_receipt(
+        &self,
+        payload: &ProposalPayload,
+        decision_hash: icn_kernel_api::Hash,
+        proposal_id: &ProposalId,
+        domain_id: &GovernanceDomainId,
+    ) -> Option<AllocationReceipt> {
+        let now = icn_time::current_timestamp_secs();
+
+        match payload {
+            ProposalPayload::Budget {
+                amount,
+                currency,
+                recipient,
+                purpose,
+            } => {
+                let intent = SettlementIntent::new(
+                    &proposal_id.0,
+                    decision_hash,
+                    &domain_id.0,           // from: domain treasury
+                    recipient.to_string(), // to: recipient
+                    *amount as u64,
+                    currency,
+                )
+                .with_memo(purpose.clone())
+                .with_timestamp(now);
+
+                let receipt =
+                    AllocationReceipt::new(decision_hash, ScopeLevel::Org).add_intent(intent);
+                // Set timestamp
+                let mut receipt = receipt;
+                receipt.created_at = now;
+                Some(receipt)
+            }
+
+            ProposalPayload::Treasury { operation } => {
+                // Treasury operations that produce economic effects
+                match operation {
+                    icn_governance::TreasuryProposalOperation::CreateBudget {
+                        treasury_did,
+                        amount,
+                        currency,
+                        purpose,
+                        ..
+                    } => {
+                        let intent = SettlementIntent::new(
+                            &proposal_id.0,
+                            decision_hash,
+                            treasury_did.to_string(),
+                            format!("budget:{}", proposal_id.0),
+                            *amount as u64,
+                            currency,
+                        )
+                        .with_memo(purpose.clone())
+                        .with_timestamp(now);
+
+                        let mut receipt = AllocationReceipt::new(decision_hash, ScopeLevel::Org)
+                            .add_intent(intent);
+                        receipt.created_at = now;
+                        Some(receipt)
+                    }
+                    icn_governance::TreasuryProposalOperation::Spend {
+                        treasury_did,
+                        recipient,
+                        amount,
+                        currency,
+                        memo,
+                        ..
+                    } => {
+                        let intent = SettlementIntent::new(
+                            &proposal_id.0,
+                            decision_hash,
+                            treasury_did.to_string(),
+                            recipient.to_string(),
+                            *amount as u64,
+                            currency,
+                        )
+                        .with_memo(memo.clone())
+                        .with_timestamp(now);
+
+                        let mut receipt = AllocationReceipt::new(decision_hash, ScopeLevel::Org)
+                            .add_intent(intent);
+                        receipt.created_at = now;
+                        Some(receipt)
+                    }
+                    _ => {
+                        tracing::debug!(
+                            proposal_id = %proposal_id.0,
+                            "Treasury operation does not produce allocation receipt"
+                        );
+                        None
+                    }
+                }
+            }
+
+            ProposalPayload::Allocation {
+                pool_amount: _,
+                unit,
+                options,
+                purpose: _,
+            } => {
+                // Participatory budget: create one intent per option
+                let intents: Vec<SettlementIntent> = options
+                    .iter()
+                    .map(|opt| {
+                        SettlementIntent::new(
+                            &proposal_id.0,
+                            decision_hash,
+                            &domain_id.0,
+                            opt.recipient.to_string(),
+                            opt.requested_amount as u64,
+                            unit,
+                        )
+                        .with_memo(opt.label.clone())
+                        .with_timestamp(now)
+                    })
+                    .collect();
+
+                let mut receipt =
+                    AllocationReceipt::new(decision_hash, ScopeLevel::Org).with_intents(intents);
+                receipt.created_at = now;
+                Some(receipt)
+            }
+
+            ProposalPayload::SurplusAllocation { .. } => {
+                // Surplus allocation produces economic effects
+                // For now, create a placeholder receipt — the actual distribution
+                // is handled by the ledger's patronage module
+                let mut receipt = AllocationReceipt::new(decision_hash, ScopeLevel::Org);
+                receipt.created_at = now;
+                Some(receipt)
+            }
+
+            // Non-economic proposal types
+            ProposalPayload::Text { .. }
+            | ProposalPayload::Membership { .. }
+            | ProposalPayload::ConfigChange { .. }
+            | ProposalPayload::SchedulingPolicy { .. }
+            | ProposalPayload::FreezeMember { .. }
+            | ProposalPayload::UnfreezeMember { .. }
+            | ProposalPayload::VetoProposal { .. }
+            | ProposalPayload::ForceCloseProposal { .. }
+            | ProposalPayload::DisputeResolution { .. }
+            | ProposalPayload::Sdis { .. }
+            | ProposalPayload::ProtocolUpgrade { .. }
+            | ProposalPayload::ProtocolChange { .. }
+            | ProposalPayload::ResourceAccess { .. }
+            | ProposalPayload::Charter { .. }
+            | ProposalPayload::RollbackLedger { .. }
+            | ProposalPayload::ShareRedemption { .. }
+            | ProposalPayload::BondIssuance { .. }
+            | ProposalPayload::Federation(_) => None,
         }
     }
 
@@ -1674,5 +1935,327 @@ mod tests {
             ))
             .await;
         assert!(result.is_ok());
+    }
+
+    // ============================================================================
+    // Stage 4 Regression Tests — Hardening Pass 2026-03-25
+    // ============================================================================
+
+    /// In-memory receipt backend for tests (no sled dependency required).
+    struct InMemoryReceiptBackend {
+        governance: std::sync::Mutex<Vec<icn_governance::GovernanceDecisionReceipt>>,
+        allocations: std::sync::Mutex<Vec<AllocationReceipt>>,
+    }
+
+    impl InMemoryReceiptBackend {
+        fn new() -> Self {
+            Self {
+                governance: std::sync::Mutex::new(vec![]),
+                allocations: std::sync::Mutex::new(vec![]),
+            }
+        }
+    }
+
+    impl crate::receipt_backend::GovernanceReceiptBackend for InMemoryReceiptBackend {
+        fn put_governance(
+            &self,
+            receipt: &icn_governance::GovernanceDecisionReceipt,
+        ) -> Result<(), String> {
+            self.governance.lock().unwrap().push(receipt.clone());
+            Ok(())
+        }
+        fn get_governance_by_proposal(
+            &self,
+            proposal_id: &str,
+        ) -> Result<Option<icn_governance::GovernanceDecisionReceipt>, String> {
+            Ok(self
+                .governance
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|r| r.proposal_id == proposal_id)
+                .cloned())
+        }
+        fn put_allocation(
+            &self,
+            receipt: &AllocationReceipt,
+        ) -> Result<icn_kernel_api::Hash, String> {
+            let hash = [1u8; 32]; // deterministic test hash
+            self.allocations.lock().unwrap().push(receipt.clone());
+            Ok(hash)
+        }
+        fn get_governance_by_decision(
+            &self,
+            decision_hash: &icn_kernel_api::Hash,
+        ) -> Result<Option<icn_governance::GovernanceDecisionReceipt>, String> {
+            Ok(self
+                .governance
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|r| r.decision_hash == *decision_hash)
+                .cloned())
+        }
+        fn list_allocations_by_decision(
+            &self,
+            decision_hash: &icn_kernel_api::Hash,
+        ) -> Result<Vec<AllocationReceipt>, String> {
+            Ok(self
+                .allocations
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|a| a.decision_hash == *decision_hash)
+                .cloned()
+                .collect())
+        }
+    }
+
+    /// Build a minimal manager with a single domain and single member.
+    async fn make_manager_with_domain() -> (GovernanceManager, GovernanceDomainId, Did) {
+        let kp = icn_identity::KeyPair::generate().unwrap();
+        let member_did = kp.did().clone();
+        let domain_id = GovernanceDomainId::new("test-coop");
+
+        let mgr = GovernanceManager::new();
+        mgr.create_domain(
+            domain_id.clone(),
+            "Test Coop".to_string(),
+            "default".to_string(),
+            GovernanceParams {
+                quorum_percentage: 1,
+                approval_threshold_percentage: 51,
+                voting_period_seconds: 86400,
+                require_deliberation: false,
+                ..GovernanceParams::default()
+            },
+            MembershipConfig {
+                source: MembershipSource::StaticList(vec![member_did.clone()]),
+            },
+        )
+        .await
+        .unwrap();
+
+        (mgr, domain_id, member_did)
+    }
+
+    /// INV-2 TEST: Accepted Budget proposal creates AllocationReceipt.
+    #[tokio::test]
+    async fn test_inv2_allocation_receipt_created_on_budget_acceptance() {
+        let (mgr, domain_id, member_did) = make_manager_with_domain().await;
+
+        // Attach in-memory receipt backend
+        let backend = Arc::new(InMemoryReceiptBackend::new());
+        let mgr = mgr.with_receipt_store(backend.clone());
+
+        // Create and open a Budget proposal
+        let proposal_id = mgr
+            .create_proposal(
+                ProposalId(format!("prop-{}", uuid::Uuid::new_v4())),
+                domain_id.clone(),
+                member_did.clone(),
+                "Fund server".to_string(),
+                "Buy a server".to_string(),
+                ProposalPayload::Budget {
+                    amount: 1000,
+                    currency: "HOURS".to_string(),
+                    recipient: member_did.clone(),
+                    purpose: "Infrastructure".to_string(),
+                },
+                ProposalScope::Local,
+            )
+            .await
+            .unwrap();
+
+        mgr.open_proposal(proposal_id.clone(), 86400).await.unwrap();
+        mgr.cast_vote(
+            proposal_id.clone(),
+            member_did.clone(),
+            VoteChoice::For,
+            None,
+        )
+        .await
+        .unwrap();
+        mgr.close_proposal(proposal_id.clone()).await.unwrap();
+
+        // Verify governance receipt created
+        let gov_receipt = backend.get_governance_by_proposal(&proposal_id.0).unwrap();
+        assert!(
+            gov_receipt.is_some(),
+            "INV-2: governance receipt must be created on close"
+        );
+        let gov_receipt = gov_receipt.unwrap();
+        assert_eq!(
+            gov_receipt.outcome,
+            icn_governance::ProofOutcome::Accepted,
+            "INV-2: outcome must be Accepted"
+        );
+
+        // Verify allocation receipt created (INV-2)
+        let allocations = backend
+            .list_allocations_by_decision(&gov_receipt.decision_hash)
+            .unwrap();
+        assert!(
+            !allocations.is_empty(),
+            "INV-2: AllocationReceipt must be created for accepted Budget proposal"
+        );
+        assert_eq!(
+            allocations[0].decision_hash, gov_receipt.decision_hash,
+            "INV-2: AllocationReceipt decision_hash must match GovernanceDecisionReceipt"
+        );
+        assert!(
+            !allocations[0].intents.is_empty(),
+            "INV-2: AllocationReceipt must have at least one SettlementIntent"
+        );
+    }
+
+    /// INV-2 TEST: Non-economic proposals (Text) do NOT create AllocationReceipt.
+    #[tokio::test]
+    async fn test_inv2_no_allocation_receipt_for_text_proposal() {
+        let (mgr, domain_id, member_did) = make_manager_with_domain().await;
+        let backend = Arc::new(InMemoryReceiptBackend::new());
+        let mgr = mgr.with_receipt_store(backend.clone());
+
+        let proposal_id = mgr
+            .create_proposal(
+                ProposalId(format!("prop-{}", uuid::Uuid::new_v4())),
+                domain_id.clone(),
+                member_did.clone(),
+                "Policy change".to_string(),
+                "Update meeting schedule".to_string(),
+                ProposalPayload::Text {
+                    body: "Meet bi-weekly".to_string(),
+                },
+                ProposalScope::Local,
+            )
+            .await
+            .unwrap();
+
+        mgr.open_proposal(proposal_id.clone(), 86400).await.unwrap();
+        mgr.cast_vote(
+            proposal_id.clone(),
+            member_did.clone(),
+            VoteChoice::For,
+            None,
+        )
+        .await
+        .unwrap();
+        mgr.close_proposal(proposal_id.clone()).await.unwrap();
+
+        let gov_receipt = backend
+            .get_governance_by_proposal(&proposal_id.0)
+            .unwrap()
+            .unwrap();
+        let allocations = backend
+            .list_allocations_by_decision(&gov_receipt.decision_hash)
+            .unwrap();
+        assert!(
+            allocations.is_empty(),
+            "INV-2: Text proposal must NOT create AllocationReceipt"
+        );
+    }
+
+    /// INV-6 TEST: Duplicate vote is rejected.
+    #[tokio::test]
+    async fn test_inv6_duplicate_vote_rejected() {
+        let (mgr, domain_id, member_did) = make_manager_with_domain().await;
+
+        let proposal_id = mgr
+            .create_proposal(
+                ProposalId(format!("prop-{}", uuid::Uuid::new_v4())),
+                domain_id.clone(),
+                member_did.clone(),
+                "Test".to_string(),
+                "Test proposal".to_string(),
+                ProposalPayload::Text {
+                    body: "test".to_string(),
+                },
+                ProposalScope::Local,
+            )
+            .await
+            .unwrap();
+
+        mgr.open_proposal(proposal_id.clone(), 86400).await.unwrap();
+
+        // First vote succeeds
+        mgr.cast_vote(
+            proposal_id.clone(),
+            member_did.clone(),
+            VoteChoice::For,
+            None,
+        )
+        .await
+        .expect("First vote must succeed");
+
+        // Second vote from same DID must fail (INV-6)
+        let result = mgr
+            .cast_vote(
+                proposal_id.clone(),
+                member_did.clone(),
+                VoteChoice::Against,
+                None,
+            )
+            .await;
+        assert!(result.is_err(), "INV-6: Duplicate vote must be rejected");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("already voted"),
+            "INV-6: Error must mention 'already voted', got: {err}"
+        );
+    }
+
+    /// INV-5 TEST: get_chain returns chain after accepted proposal.
+    #[tokio::test]
+    async fn test_inv5_chain_walkable_after_close() {
+        let (mgr, domain_id, member_did) = make_manager_with_domain().await;
+        let backend = Arc::new(InMemoryReceiptBackend::new());
+        let mgr = mgr.with_receipt_store(backend.clone());
+
+        let proposal_id = mgr
+            .create_proposal(
+                ProposalId(format!("prop-{}", uuid::Uuid::new_v4())),
+                domain_id.clone(),
+                member_did.clone(),
+                "Fund server".to_string(),
+                "Buy a server".to_string(),
+                ProposalPayload::Budget {
+                    amount: 500,
+                    currency: "CREDITS".to_string(),
+                    recipient: member_did.clone(),
+                    purpose: "Server".to_string(),
+                },
+                ProposalScope::Local,
+            )
+            .await
+            .unwrap();
+
+        mgr.open_proposal(proposal_id.clone(), 86400).await.unwrap();
+        mgr.cast_vote(
+            proposal_id.clone(),
+            member_did.clone(),
+            VoteChoice::For,
+            None,
+        )
+        .await
+        .unwrap();
+        mgr.close_proposal(proposal_id.clone()).await.unwrap();
+
+        // INV-5: chain must be walkable
+        let chain = mgr.get_chain(&proposal_id).await.unwrap();
+        assert!(
+            chain.governance_receipt.is_some(),
+            "INV-5: governance_receipt must be present"
+        );
+        assert!(
+            !chain.allocations.is_empty(),
+            "INV-5: allocations must be present for Budget proposal"
+        );
+
+        // Verify decision_hash binds governance to allocation
+        let gov_hash = chain.governance_receipt.unwrap().decision_hash;
+        assert_eq!(
+            chain.allocations[0].decision_hash, gov_hash,
+            "INV-5: allocation.decision_hash must equal governance.decision_hash"
+        );
     }
 }

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -786,16 +786,49 @@ impl GovernanceManager {
             vec![]
         };
 
-        // Chain is complete when:
-        // - governance receipt exists AND
-        // - either there are allocations (economic proposal) OR
-        //   the proposal is non-economic (Text/Membership/etc — no allocation expected)
         let has_governance = governance_receipt.is_some();
         let has_allocations = !allocations.is_empty();
 
-        // Determine if this is an economic proposal by checking the stored receipt or proposal payload
-        let is_economic = has_allocations; // If allocations were created, it was economic
-        let chain_complete = has_governance && (is_economic == has_allocations);
+        // chain_complete requires correctly determining if this proposal type
+        // was expected to produce allocation receipts.
+        //
+        // Logic:
+        // - No governance receipt: always incomplete.
+        // - Rejected/NoQuorum: complete with just the governance receipt (no allocations expected).
+        // - Accepted + economic payload: complete iff allocations were stored.
+        // - Accepted + non-economic payload: complete (no allocations needed).
+        // - Accepted + unknown proposal (actor mode, no local state): conservative false.
+        let chain_complete = if let Some(ref receipt) = governance_receipt {
+            match receipt.outcome {
+                icn_governance::ProofOutcome::Rejected | icn_governance::ProofOutcome::NoQuorum => {
+                    true
+                }
+                icn_governance::ProofOutcome::Accepted => {
+                    // Look up the proposal to determine if it requires allocations.
+                    match self.get_proposal(proposal_id).await.ok().flatten() {
+                        Some(p) => {
+                            let is_economic_payload = matches!(
+                                p.payload,
+                                ProposalPayload::Budget { .. }
+                                    | ProposalPayload::Treasury { .. }
+                                    | ProposalPayload::Allocation { .. }
+                                    | ProposalPayload::SurplusAllocation { .. }
+                            );
+                            if is_economic_payload {
+                                has_allocations
+                            } else {
+                                true // non-economic proposals complete without allocations
+                            }
+                        }
+                        // Proposal not found (actor-backed mode, no local state):
+                        // fall back to presence of allocations as the completeness signal.
+                        None => has_governance && has_allocations,
+                    }
+                }
+            }
+        } else {
+            false
+        };
 
         Ok(ProvenanceChain {
             governance_receipt,
@@ -829,7 +862,7 @@ impl GovernanceManager {
                 let intent = SettlementIntent::new(
                     &proposal_id.0,
                     decision_hash,
-                    &domain_id.0,           // from: domain treasury
+                    &domain_id.0,          // from: domain treasury
                     recipient.to_string(), // to: recipient
                     *amount as u64,
                     currency,
@@ -2251,11 +2284,65 @@ mod tests {
             "INV-5: allocations must be present for Budget proposal"
         );
 
+        // Verify chain_complete is true for accepted Budget with allocations stored
+        assert!(
+            chain.chain_complete,
+            "INV-5: chain_complete must be true for accepted Budget with stored allocations"
+        );
+
         // Verify decision_hash binds governance to allocation
         let gov_hash = chain.governance_receipt.unwrap().decision_hash;
         assert_eq!(
             chain.allocations[0].decision_hash, gov_hash,
             "INV-5: allocation.decision_hash must equal governance.decision_hash"
+        );
+    }
+
+    /// INV-5 TEST: chain_complete is correct for accepted Text proposal (no allocations expected).
+    #[tokio::test]
+    async fn test_inv5_chain_complete_text_proposal() {
+        let (mgr, domain_id, member_did) = make_manager_with_domain().await;
+        let backend = Arc::new(InMemoryReceiptBackend::new());
+        let mgr = mgr.with_receipt_store(backend.clone());
+
+        let proposal_id = mgr
+            .create_proposal(
+                ProposalId(format!("prop-{}", uuid::Uuid::new_v4())),
+                domain_id.clone(),
+                member_did.clone(),
+                "Text proposal".to_string(),
+                "No economic effect".to_string(),
+                ProposalPayload::Text {
+                    body: "Just a decision".to_string(),
+                },
+                ProposalScope::Local,
+            )
+            .await
+            .unwrap();
+
+        mgr.open_proposal(proposal_id.clone(), 86400).await.unwrap();
+        mgr.cast_vote(
+            proposal_id.clone(),
+            member_did.clone(),
+            VoteChoice::For,
+            None,
+        )
+        .await
+        .unwrap();
+        mgr.close_proposal(proposal_id.clone()).await.unwrap();
+
+        let chain = mgr.get_chain(&proposal_id).await.unwrap();
+        assert!(
+            chain.governance_receipt.is_some(),
+            "INV-5: governance_receipt must exist"
+        );
+        assert!(
+            chain.allocations.is_empty(),
+            "INV-5: Text proposal has no allocations"
+        );
+        assert!(
+            chain.chain_complete,
+            "INV-5: chain_complete must be true for accepted Text proposal (no allocations needed)"
         );
     }
 }

--- a/icn/apps/governance/src/receipt_backend.rs
+++ b/icn/apps/governance/src/receipt_backend.rs
@@ -2,6 +2,7 @@
 //! in this crate without a circular dependency on icn-gateway.
 
 use icn_governance::GovernanceDecisionReceipt;
+use icn_kernel_api::{AllocationReceipt, Hash};
 
 /// Minimal receipt-storage interface required by [`GovernanceManager`].
 ///
@@ -19,4 +20,22 @@ pub trait GovernanceReceiptBackend: Send + Sync {
         &self,
         proposal_id: &str,
     ) -> Result<Option<GovernanceDecisionReceipt>, String>;
+
+    /// Persist an allocation receipt linked to a governance decision.
+    ///
+    /// Called by the governance manager when a budget/treasury proposal
+    /// is accepted, creating the governance→economics binding.
+    fn put_allocation(&self, receipt: &AllocationReceipt) -> Result<Hash, String>;
+
+    /// Retrieve a governance decision receipt by decision hash (cross-node canonical).
+    fn get_governance_by_decision(
+        &self,
+        decision_hash: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String>;
+
+    /// Retrieve all allocation receipts linked to a governance decision.
+    fn list_allocations_by_decision(
+        &self,
+        decision_hash: &Hash,
+    ) -> Result<Vec<AllocationReceipt>, String>;
 }

--- a/icn/crates/icn-gateway/src/api/escrow.rs
+++ b/icn/crates/icn-gateway/src/api/escrow.rs
@@ -207,6 +207,7 @@ pub async fn release_escrow(
                 &from_did, // Payer (credited/loses credits)
                 escrow.amount,
                 escrow.currency.clone(),
+                None, // system-executed path: no per-request JWT proof
             )
             .await
         {

--- a/icn/crates/icn-gateway/src/api/health.rs
+++ b/icn/crates/icn-gateway/src/api/health.rs
@@ -7,6 +7,7 @@ use crate::models::{
     ComponentHealth, DetailedComponentHealth, DetailedHealthResponse, HealthResponse, HealthStatus,
 };
 use crate::notification_queue::NotificationQueue;
+use crate::receipt_store::ReceiptStore;
 use actix_web::{get, web, HttpResponse};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -270,6 +271,176 @@ pub async fn health_detailed(
     };
 
     HttpResponse::Ok().json(response)
+}
+
+/// GET /health/full — Composite health check with real subsystem probes.
+///
+/// Unlike `/health/detailed` (which has static placeholder responses for some
+/// components), this endpoint performs actual I/O probes on every subsystem.
+/// Used by operator tooling and pre-flight scripts to verify system integrity.
+///
+/// Returns HTTP 200 if all critical components are healthy.
+/// Returns HTTP 503 if any critical component is unhealthy.
+#[get("/health/full")]
+pub async fn health_full(
+    coop_manager: web::Data<Arc<CoopManager>>,
+    ledger_manager: web::Data<Arc<LedgerManager>>,
+    identity_manager: web::Data<Arc<IdentityManager>>,
+    notification_queue: web::Data<Arc<NotificationQueue>>,
+    receipt_store: web::Data<Arc<ReceiptStore>>,
+) -> HttpResponse {
+    let mut components = HashMap::new();
+    let mut any_critical_unhealthy = false;
+
+    // --- Coop Manager (real probe) ---
+    let start = Instant::now();
+    let coop_probe = match coop_manager.list_all_coop_ids() {
+        Ok(coops) => DetailedComponentHealth {
+            status: HealthStatus::Ok,
+            message: Some(format!("{} cooperatives active", coops.len())),
+            latency_ms: Some(start.elapsed().as_millis() as u64),
+        },
+        Err(e) => {
+            any_critical_unhealthy = true;
+            DetailedComponentHealth {
+                status: HealthStatus::Unhealthy,
+                message: Some(format!("PROBE FAILED: {e}")),
+                latency_ms: Some(start.elapsed().as_millis() as u64),
+            }
+        }
+    };
+    components.insert("coop_manager".to_string(), coop_probe);
+
+    // --- Ledger Manager (real probe: count loaded ledger namespaces) ---
+    let start = Instant::now();
+    let ledger_probe = {
+        // get_ledger requires a coop_id; probe by listing cooperatives and checking first
+        match coop_manager.list_all_coop_ids() {
+            Ok(coops) if !coops.is_empty() => {
+                // Probe the first coop's ledger
+                match ledger_manager.get_ledger(&coops[0]).await {
+                    Ok(_) => DetailedComponentHealth {
+                        status: HealthStatus::Ok,
+                        message: Some(format!(
+                            "Ledger accessible for {} cooperatives",
+                            coops.len()
+                        )),
+                        latency_ms: Some(start.elapsed().as_millis() as u64),
+                    },
+                    Err(e) => {
+                        any_critical_unhealthy = true;
+                        DetailedComponentHealth {
+                            status: HealthStatus::Unhealthy,
+                            message: Some(format!("PROBE FAILED: ledger unavailable: {e}")),
+                            latency_ms: Some(start.elapsed().as_millis() as u64),
+                        }
+                    }
+                }
+            }
+            Ok(_) => DetailedComponentHealth {
+                status: HealthStatus::Ok,
+                message: Some("No cooperatives registered yet (empty state)".to_string()),
+                latency_ms: Some(start.elapsed().as_millis() as u64),
+            },
+            Err(e) => {
+                any_critical_unhealthy = true;
+                DetailedComponentHealth {
+                    status: HealthStatus::Unhealthy,
+                    message: Some(format!(
+                        "PROBE FAILED: cannot enumerate coops for ledger probe: {e}"
+                    )),
+                    latency_ms: Some(start.elapsed().as_millis() as u64),
+                }
+            }
+        }
+    };
+    components.insert("ledger".to_string(), ledger_probe);
+
+    // --- Identity Manager (real probe: attempt document lookup on probe DID) ---
+    let start = Instant::now();
+    // Parse a syntactically valid but non-existent DID as a liveness probe.
+    // Success (Ok(None)) proves the storage backend is reachable.
+    let probe_did_str = "did:icn:z11111111111111111111111111111111";
+    let identity_probe = match probe_did_str.parse::<icn_identity::Did>() {
+        Ok(probe_did) => match identity_manager.get_document(&probe_did).await {
+            Ok(_) => DetailedComponentHealth {
+                status: HealthStatus::Ok,
+                message: Some("Identity store reachable (DID lookup successful)".to_string()),
+                latency_ms: Some(start.elapsed().as_millis() as u64),
+            },
+            Err(e) => DetailedComponentHealth {
+                status: HealthStatus::Degraded,
+                message: Some(format!("Identity store probe degraded: {e}")),
+                latency_ms: Some(start.elapsed().as_millis() as u64),
+            },
+        },
+        Err(_) => DetailedComponentHealth {
+            status: HealthStatus::Ok,
+            message: Some("Identity manager available".to_string()),
+            latency_ms: Some(start.elapsed().as_millis() as u64),
+        },
+    };
+    components.insert("identity".to_string(), identity_probe);
+
+    // --- Notification Queue (real probe: get stats) ---
+    let start = Instant::now();
+    let queue_stats = notification_queue.get_stats();
+    let queue_probe = DetailedComponentHealth {
+        status: HealthStatus::Ok,
+        message: Some(format!(
+            "queued={} delivered={} failed={} pending={}",
+            queue_stats.queued,
+            queue_stats.delivered,
+            queue_stats.failed,
+            queue_stats.pending_count,
+        )),
+        latency_ms: Some(start.elapsed().as_millis() as u64),
+    };
+    components.insert("notification_queue".to_string(), queue_probe);
+
+    // --- Receipt Store (real probe: count allocations) ---
+    let start = Instant::now();
+    let receipt_probe = match receipt_store.list_all_allocations() {
+        Ok(allocations) => DetailedComponentHealth {
+            status: HealthStatus::Ok,
+            message: Some(format!("{} allocation receipts indexed", allocations.len())),
+            latency_ms: Some(start.elapsed().as_millis() as u64),
+        },
+        Err(e) => {
+            // Receipt store unavailable breaks provenance chain (critical)
+            any_critical_unhealthy = true;
+            DetailedComponentHealth {
+                status: HealthStatus::Unhealthy,
+                message: Some(format!("PROBE FAILED: receipt store unavailable: {e}")),
+                latency_ms: Some(start.elapsed().as_millis() as u64),
+            }
+        }
+    };
+    components.insert("receipt_store".to_string(), receipt_probe);
+
+    let overall_status = if any_critical_unhealthy {
+        HealthStatus::Unhealthy
+    } else if components
+        .values()
+        .any(|c| c.status == HealthStatus::Degraded)
+    {
+        HealthStatus::Degraded
+    } else {
+        HealthStatus::Ok
+    };
+
+    let response = DetailedHealthResponse {
+        status: overall_status,
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        uptime_seconds: get_uptime_seconds(),
+        components,
+    };
+
+    if overall_status == HealthStatus::Unhealthy {
+        HttpResponse::ServiceUnavailable().json(response)
+    } else {
+        HttpResponse::Ok().json(response)
+    }
 }
 
 #[cfg(test)]

--- a/icn/crates/icn-gateway/src/api/ledger.rs
+++ b/icn/crates/icn-gateway/src/api/ledger.rs
@@ -118,8 +118,27 @@ pub async fn create_settlement(
     let trust_score = trust_mgr.compute_trust_score_for_velocity(&from).await;
     velocity_limiter.check_and_record(&req.from, trust_score)?;
 
+    // INV-1: Extract the JWT signature segment from the Authorization header.
+    // The third JWT segment is HMAC-SHA256("{header}.{payload}", jwt_secret) —
+    // a node-verifiable fingerprint that ties this journal entry to the specific
+    // auth token that authorized the action.
+    let auth_proof = http_req
+        .headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .and_then(|token| token.splitn(3, '.').nth(2))
+        .map(|sig| format!("jwt-sig:{sig}"));
+
     let hash = ledger_mgr
-        .create_settlement(&coop_id, &from, &to, req.amount, req.unit.clone())
+        .create_settlement(
+            &coop_id,
+            &from,
+            &to,
+            req.amount,
+            req.unit.clone(),
+            auth_proof,
+        )
         .await?;
 
     // Record spending in budget tracker
@@ -765,6 +784,7 @@ mod tests {
                 bob.did(),
                 10,
                 "hours".to_string(),
+                None,
             )
             .await
             .unwrap();
@@ -1045,6 +1065,7 @@ mod tests {
                 bob.did(),
                 50,
                 "hours".to_string(),
+                None,
             )
             .await
             .unwrap();

--- a/icn/crates/icn-gateway/src/api/ledger.rs
+++ b/icn/crates/icn-gateway/src/api/ledger.rs
@@ -1561,4 +1561,180 @@ mod tests {
             "Error code should be FX_NOT_CONFIGURED"
         );
     }
+
+    // INV-1 HTTP-level proof: the actix handler must extract the JWT third segment
+    // from the Authorization header and store it as "jwt-sig:<seg>" in the journal
+    // entry's DirectMember provenance.
+    //
+    // This is the proof boundary above the manager-level test in ledger_mgr.rs:
+    // it exercises the actual header extraction path in the HTTP handler, not just
+    // the manager's storage semantics.
+    //
+    // Auth bypass: TokenClaims injected directly into request extensions (the
+    // middleware reads from extensions, not from the Authorization header). The
+    // Authorization header is present only for the INV-1 extraction path.
+    #[actix_web::test]
+    async fn test_inv1_http_settlement_stores_jwt_sig_in_provenance() {
+        use icn_ledger::types::ProvenanceRef;
+
+        let ledger_mgr = Arc::new(LedgerManager::new());
+        let db = sled::Config::new().temporary(true).open().unwrap();
+        let budget_store = BudgetStore::new(db);
+        let velocity_limiter = VelocityLimiter::default();
+        let trust_mgr = Arc::new(TrustManager::new());
+        let store = Arc::new(crate::notifications::NotificationStore::new(
+            sled::Config::new().temporary(true).open().unwrap(),
+        ));
+        let notification_service =
+            Arc::new(crate::notifications::NotificationService::new(store, None));
+        let event_broadcaster = Arc::new(EventBroadcaster::new());
+        let alice = IdentityBundle::generate().unwrap();
+        let bob = IdentityBundle::generate().unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(ledger_mgr.clone()))
+                .app_data(web::Data::new(budget_store.clone()))
+                .app_data(web::Data::new(velocity_limiter.clone()))
+                .app_data(web::Data::new(trust_mgr.clone()))
+                .app_data(web::Data::new(notification_service.clone()))
+                .app_data(web::Data::new(event_broadcaster.clone()))
+                .service(web::scope("/ledger").service(create_settlement)),
+        )
+        .await;
+
+        let req_body = RecordTransferRequest {
+            from: alice.did().to_string(),
+            to: bob.did().to_string(),
+            amount: 10,
+            unit: "hours".to_string(),
+            memo: None,
+        };
+
+        // Inject claims for auth bypass; include Authorization header with a synthetic
+        // JWT-shaped token so the extraction path fires.
+        // The third segment ("fakesig") is what must appear in stored provenance.
+        let claims = TokenClaims {
+            sub: alice.did().to_string(),
+            iat: 1_000_000_000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["ledger:write".to_string()],
+            exp: 9_999_999_999,
+        };
+
+        let req = test::TestRequest::post()
+            .uri("/ledger/test-coop/settle")
+            .insert_header(("Authorization", "Bearer hdr.payload.fakesig"))
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        assert!(
+            resp.status().is_success(),
+            "settlement must succeed: {:?}",
+            resp.status()
+        );
+
+        // Storage-truth check: read back via get_history and inspect the provenance field.
+        let entries = ledger_mgr
+            .get_history(&"test-coop".to_string(), None, 0, 100)
+            .await
+            .unwrap();
+
+        assert_eq!(entries.len(), 1, "exactly one journal entry must exist");
+        match &entries[0].provenance {
+            ProvenanceRef::DirectMember { did, signature } => {
+                assert_eq!(did, alice.did(), "provenance DID must be the sender");
+                assert_eq!(
+                    signature, "jwt-sig:fakesig",
+                    "INV-1: HTTP handler must carry JWT third segment into stored provenance"
+                );
+            }
+            other => panic!("expected DirectMember provenance, got: {other:?}"),
+        }
+    }
+
+    // INV-1 boundary: a request without a usable Authorization header must NOT
+    // produce a "jwt-sig:*" provenance entry.  The handler must degrade honestly
+    // to "system-executed" rather than storing a false verified-auth claim.
+    #[actix_web::test]
+    async fn test_inv1_missing_bearer_sig_stores_system_executed_not_jwt_sig() {
+        use icn_ledger::types::ProvenanceRef;
+
+        let ledger_mgr = Arc::new(LedgerManager::new());
+        let db = sled::Config::new().temporary(true).open().unwrap();
+        let budget_store = BudgetStore::new(db);
+        let velocity_limiter = VelocityLimiter::default();
+        let trust_mgr = Arc::new(TrustManager::new());
+        let store = Arc::new(crate::notifications::NotificationStore::new(
+            sled::Config::new().temporary(true).open().unwrap(),
+        ));
+        let notification_service =
+            Arc::new(crate::notifications::NotificationService::new(store, None));
+        let event_broadcaster = Arc::new(EventBroadcaster::new());
+        let alice = IdentityBundle::generate().unwrap();
+        let bob = IdentityBundle::generate().unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(ledger_mgr.clone()))
+                .app_data(web::Data::new(budget_store.clone()))
+                .app_data(web::Data::new(velocity_limiter.clone()))
+                .app_data(web::Data::new(trust_mgr.clone()))
+                .app_data(web::Data::new(notification_service.clone()))
+                .app_data(web::Data::new(event_broadcaster.clone()))
+                .service(web::scope("/ledger").service(create_settlement)),
+        )
+        .await;
+
+        let req_body = RecordTransferRequest {
+            from: alice.did().to_string(),
+            to: bob.did().to_string(),
+            amount: 10,
+            unit: "hours".to_string(),
+            memo: None,
+        };
+
+        let claims = TokenClaims {
+            sub: alice.did().to_string(),
+            iat: 1_000_000_000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["ledger:write".to_string()],
+            exp: 9_999_999_999,
+        };
+
+        // No Authorization header — the extraction path must return None → "system-executed".
+        let req = test::TestRequest::post()
+            .uri("/ledger/test-coop/settle")
+            .set_json(&req_body)
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        assert!(
+            resp.status().is_success(),
+            "settlement must succeed even without Authorization header"
+        );
+
+        let entries = ledger_mgr
+            .get_history(&"test-coop".to_string(), None, 0, 100)
+            .await
+            .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        match &entries[0].provenance {
+            ProvenanceRef::DirectMember { signature, .. } => {
+                assert_eq!(
+                    signature, "system-executed",
+                    "INV-1: missing Authorization must not produce jwt-sig provenance"
+                );
+                assert!(
+                    !signature.starts_with("jwt-sig:"),
+                    "INV-1: no Authorization header must never produce jwt-sig:* provenance"
+                );
+            }
+            other => panic!("expected DirectMember provenance, got: {other:?}"),
+        }
+    }
 }

--- a/icn/crates/icn-gateway/src/api/ledger.rs
+++ b/icn/crates/icn-gateway/src/api/ledger.rs
@@ -1644,10 +1644,10 @@ mod tests {
 
         assert_eq!(entries.len(), 1, "exactly one journal entry must exist");
         match &entries[0].provenance {
-            ProvenanceRef::DirectMember { did, signature } => {
+            ProvenanceRef::DirectMember { did, auth_proof } => {
                 assert_eq!(did, alice.did(), "provenance DID must be the sender");
                 assert_eq!(
-                    signature, "jwt-sig:fakesig",
+                    auth_proof, "jwt-sig:fakesig",
                     "INV-1: HTTP handler must carry JWT third segment into stored provenance"
                 );
             }
@@ -1724,13 +1724,13 @@ mod tests {
 
         assert_eq!(entries.len(), 1);
         match &entries[0].provenance {
-            ProvenanceRef::DirectMember { signature, .. } => {
+            ProvenanceRef::DirectMember { auth_proof, .. } => {
                 assert_eq!(
-                    signature, "system-executed",
+                    auth_proof, "system-executed",
                     "INV-1: missing Authorization must not produce jwt-sig provenance"
                 );
                 assert!(
-                    !signature.starts_with("jwt-sig:"),
+                    !auth_proof.starts_with("jwt-sig:"),
                     "INV-1: no Authorization header must never produce jwt-sig:* provenance"
                 );
             }

--- a/icn/crates/icn-gateway/src/api/ledger.rs
+++ b/icn/crates/icn-gateway/src/api/ledger.rs
@@ -122,13 +122,19 @@ pub async fn create_settlement(
     // The third JWT segment is HMAC-SHA256("{header}.{payload}", jwt_secret) —
     // a node-verifiable fingerprint that ties this journal entry to the specific
     // auth token that authorized the action.
+    //
+    // We always pass Some(...) from the HTTP path so that create_settlement can
+    // distinguish "HTTP request with usable proof" from "true system-executed path".
+    // When the header is absent or unparseable, we store "http-auth-missing" rather
+    // than "system-executed", preserving the semantic distinction for auditors.
     let auth_proof = http_req
         .headers()
         .get("authorization")
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.strip_prefix("Bearer "))
         .and_then(|token| token.splitn(3, '.').nth(2))
-        .map(|sig| format!("jwt-sig:{sig}"));
+        .map(|sig| format!("jwt-sig:{sig}"))
+        .unwrap_or_else(|| "http-auth-missing".to_string());
 
     let hash = ledger_mgr
         .create_settlement(
@@ -137,7 +143,7 @@ pub async fn create_settlement(
             &to,
             req.amount,
             req.unit.clone(),
-            auth_proof,
+            Some(auth_proof),
         )
         .await?;
 
@@ -1657,9 +1663,10 @@ mod tests {
 
     // INV-1 boundary: a request without a usable Authorization header must NOT
     // produce a "jwt-sig:*" provenance entry.  The handler must degrade honestly
-    // to "system-executed" rather than storing a false verified-auth claim.
+    // to "http-auth-missing" — distinct from "system-executed" (which is reserved
+    // for non-HTTP/system callers that never had an auth context).
     #[actix_web::test]
-    async fn test_inv1_missing_bearer_sig_stores_system_executed_not_jwt_sig() {
+    async fn test_inv1_missing_bearer_sig_stores_http_auth_missing() {
         use icn_ledger::types::ProvenanceRef;
 
         let ledger_mgr = Arc::new(LedgerManager::new());
@@ -1704,7 +1711,8 @@ mod tests {
             exp: 9_999_999_999,
         };
 
-        // No Authorization header — the extraction path must return None → "system-executed".
+        // No Authorization header — the extraction path must store "http-auth-missing",
+        // NOT "system-executed" (which is reserved for true non-HTTP system paths).
         let req = test::TestRequest::post()
             .uri("/ledger/test-coop/settle")
             .set_json(&req_body)
@@ -1726,12 +1734,16 @@ mod tests {
         match &entries[0].provenance {
             ProvenanceRef::DirectMember { auth_proof, .. } => {
                 assert_eq!(
-                    auth_proof, "system-executed",
-                    "INV-1: missing Authorization must not produce jwt-sig provenance"
+                    auth_proof, "http-auth-missing",
+                    "INV-1: missing Authorization on HTTP path must store http-auth-missing, not system-executed"
                 );
                 assert!(
                     !auth_proof.starts_with("jwt-sig:"),
                     "INV-1: no Authorization header must never produce jwt-sig:* provenance"
+                );
+                assert_ne!(
+                    auth_proof, "system-executed",
+                    "INV-1: http-auth-missing must not collapse into system-executed"
                 );
             }
             other => panic!("expected DirectMember provenance, got: {other:?}"),

--- a/icn/crates/icn-gateway/src/api/recurring_settlements.rs
+++ b/icn/crates/icn-gateway/src/api/recurring_settlements.rs
@@ -328,6 +328,7 @@ pub async fn execute_due_settlements(
                 &from_did,
                 payment.amount,
                 payment.currency.clone(),
+                None, // system-executed path: no per-request JWT proof
             )
             .await
         {

--- a/icn/crates/icn-gateway/src/ledger_mgr.rs
+++ b/icn/crates/icn-gateway/src/ledger_mgr.rs
@@ -121,15 +121,17 @@ impl LedgerManager {
 
     /// Create a settlement transaction.
     ///
-    /// `auth_proof` should be supplied by direct-member HTTP paths.
-    /// It is the HMAC-SHA256 JWT signature segment from the Authorization header,
-    /// formatted as `"jwt-sig:<base64url-segment>"`.  This creates a durable,
-    /// node-verifiable cryptographic reference that links the journal entry to
-    /// the specific auth token that authorized the action (INV-1).
+    /// `auth_proof` encodes the authorization context for the stored `DirectMember`
+    /// provenance entry.  Three values are meaningful:
     ///
-    /// Callers without an HTTP context (escrow release, recurring settlements)
-    /// pass `None`; the entry is still recorded as `DirectMember` with an
-    /// explicit `"system-executed"` marker that signals no per-request proof.
+    /// - `Some("jwt-sig:<seg>")` — HTTP direct-member path, usable Authorization header.
+    ///   The third JWT segment is HMAC-SHA256("{header}.{payload}", jwt_secret), a
+    ///   node-verifiable fingerprint tying this entry to a specific auth token (INV-1).
+    /// - `Some("http-auth-missing")` — HTTP direct-member path, Authorization header
+    ///   absent or unparseable.  Distinguishes "proof was expected but unavailable"
+    ///   from true system execution for audit/compliance purposes.
+    /// - `None` — non-HTTP/system paths (escrow release, recurring settlements).
+    ///   Stored as `"system-executed"` to signal no per-request proof was ever expected.
     pub async fn create_settlement(
         &self,
         coop_id: &CoopId,
@@ -158,13 +160,10 @@ impl LedgerManager {
 
         // Build the journal entry with INV-1 provenance.
         //
-        // When auth_proof is Some("jwt-sig:<seg>"): the third JWT segment is the
-        // HMAC-SHA256 of "{header}.{payload}" — a real cryptographic authorization
-        // fingerprint that ties this entry to a specific, verified auth token.
-        //
-        // When auth_proof is None (escrow, recurring, system paths): record
-        // "system-executed" to make clear this entry has no per-request proof,
-        // rather than falsely claiming "jwt-authenticated".
+        // Three stored values (see create_settlement doc):
+        //   "jwt-sig:<seg>"     — HTTP path, usable Authorization header
+        //   "http-auth-missing" — HTTP path, Authorization header absent/unparseable
+        //   "system-executed"   — non-HTTP system paths (escrow, recurring)
         let proof = auth_proof.unwrap_or_else(|| "system-executed".to_string());
         let entry = JournalEntryBuilder::new(from.clone())
             .debit(from.clone(), currency.clone(), amount)

--- a/icn/crates/icn-gateway/src/ledger_mgr.rs
+++ b/icn/crates/icn-gateway/src/ledger_mgr.rs
@@ -748,10 +748,10 @@ mod tests {
 
         assert_eq!(entries.len(), 1);
         match &entries[0].provenance {
-            ProvenanceRef::DirectMember { did, signature } => {
+            ProvenanceRef::DirectMember { did, auth_proof } => {
                 assert_eq!(did, alice.did(), "provenance DID must be the sender");
                 assert_eq!(
-                    signature, &fake_jwt_sig,
+                    auth_proof, &fake_jwt_sig,
                     "INV-1: journal entry must store the JWT sig segment verbatim"
                 );
             }
@@ -788,13 +788,13 @@ mod tests {
 
         assert_eq!(entries.len(), 1);
         match &entries[0].provenance {
-            ProvenanceRef::DirectMember { signature, .. } => {
+            ProvenanceRef::DirectMember { auth_proof, .. } => {
                 assert_eq!(
-                    signature, "system-executed",
+                    auth_proof, "system-executed",
                     "INV-1: system paths must not falsely claim jwt-authenticated"
                 );
                 assert_ne!(
-                    signature, "jwt-authenticated",
+                    auth_proof, "jwt-authenticated",
                     "INV-1: the old static placeholder must never appear"
                 );
             }

--- a/icn/crates/icn-gateway/src/ledger_mgr.rs
+++ b/icn/crates/icn-gateway/src/ledger_mgr.rs
@@ -146,10 +146,14 @@ impl LedgerManager {
         let ledger_arc = self.get_ledger(coop_id).await?;
 
         // Build the journal entry
+        // INV-1: Use DirectMember provenance for member-authorized settlements.
+        // The from DID is verified via JWT authentication before this point.
+        // The signature field records the authorization method.
+        // TODO(hardening): wire actual Ed25519 signature from client request body.
         let entry = JournalEntryBuilder::new(from.clone())
             .debit(from.clone(), currency.clone(), amount)
             .credit(to.clone(), currency.clone(), amount)
-            .with_system_provenance("direct settlement")
+            .with_direct_member_provenance(from.clone(), "jwt-authenticated")
             .build()
             .map_err(GatewayError::SubstrateError)?;
 

--- a/icn/crates/icn-gateway/src/ledger_mgr.rs
+++ b/icn/crates/icn-gateway/src/ledger_mgr.rs
@@ -119,7 +119,17 @@ impl LedgerManager {
         self.budget_store = Some(budget_store);
     }
 
-    /// Create a settlement transaction
+    /// Create a settlement transaction.
+    ///
+    /// `auth_proof` should be supplied by direct-member HTTP paths.
+    /// It is the HMAC-SHA256 JWT signature segment from the Authorization header,
+    /// formatted as `"jwt-sig:<base64url-segment>"`.  This creates a durable,
+    /// node-verifiable cryptographic reference that links the journal entry to
+    /// the specific auth token that authorized the action (INV-1).
+    ///
+    /// Callers without an HTTP context (escrow release, recurring settlements)
+    /// pass `None`; the entry is still recorded as `DirectMember` with an
+    /// explicit `"system-executed"` marker that signals no per-request proof.
     pub async fn create_settlement(
         &self,
         coop_id: &CoopId,
@@ -127,6 +137,7 @@ impl LedgerManager {
         to: &Did,
         amount: i64,
         currency: String,
+        auth_proof: Option<String>,
     ) -> Result<String> {
         // Enforce budget limits if store is available
         if let Some(store) = &self.budget_store {
@@ -145,15 +156,20 @@ impl LedgerManager {
 
         let ledger_arc = self.get_ledger(coop_id).await?;
 
-        // Build the journal entry
-        // INV-1: Use DirectMember provenance for member-authorized settlements.
-        // The from DID is verified via JWT authentication before this point.
-        // The signature field records the authorization method.
-        // TODO(hardening): wire actual Ed25519 signature from client request body.
+        // Build the journal entry with INV-1 provenance.
+        //
+        // When auth_proof is Some("jwt-sig:<seg>"): the third JWT segment is the
+        // HMAC-SHA256 of "{header}.{payload}" — a real cryptographic authorization
+        // fingerprint that ties this entry to a specific, verified auth token.
+        //
+        // When auth_proof is None (escrow, recurring, system paths): record
+        // "system-executed" to make clear this entry has no per-request proof,
+        // rather than falsely claiming "jwt-authenticated".
+        let proof = auth_proof.unwrap_or_else(|| "system-executed".to_string());
         let entry = JournalEntryBuilder::new(from.clone())
             .debit(from.clone(), currency.clone(), amount)
             .credit(to.clone(), currency.clone(), amount)
-            .with_direct_member_provenance(from.clone(), "jwt-authenticated")
+            .with_direct_member_provenance(from.clone(), proof)
             .build()
             .map_err(GatewayError::SubstrateError)?;
 
@@ -608,6 +624,7 @@ mod tests {
                 bob.did(),
                 10,
                 "hours".to_string(),
+                None,
             )
             .await
             .unwrap();
@@ -640,6 +657,7 @@ mod tests {
             bob.did(),
             10,
             "hours".to_string(),
+            None,
         )
         .await
         .unwrap();
@@ -663,6 +681,7 @@ mod tests {
             bob.did(),
             10,
             "hours".to_string(),
+            None,
         )
         .await
         .unwrap();
@@ -695,5 +714,91 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(empty_page.len(), 0); // Offset beyond available entries
+    }
+
+    // INV-1: Journal entries must carry the JWT signature segment when the
+    // settlement is created via an HTTP request path.
+    #[tokio::test]
+    async fn test_inv1_direct_member_provenance_carries_jwt_sig() {
+        use icn_ledger::types::ProvenanceRef;
+
+        let mgr = LedgerManager::new();
+        let alice = IdentityBundle::generate().unwrap();
+        let bob = IdentityBundle::generate().unwrap();
+
+        // Simulate what the HTTP handler passes: the third JWT segment formatted
+        // as "jwt-sig:<base64url-segment>".
+        let fake_jwt_sig = "jwt-sig:aHR0cHM6Ly9leGFtcGxlLmNvbQ".to_string();
+
+        mgr.create_settlement(
+            &"test-coop".to_string(),
+            alice.did(),
+            bob.did(),
+            10,
+            "hours".to_string(),
+            Some(fake_jwt_sig.clone()),
+        )
+        .await
+        .unwrap();
+
+        let entries = mgr
+            .get_history(&"test-coop".to_string(), None, 0, 100)
+            .await
+            .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        match &entries[0].provenance {
+            ProvenanceRef::DirectMember { did, signature } => {
+                assert_eq!(did, alice.did(), "provenance DID must be the sender");
+                assert_eq!(
+                    signature, &fake_jwt_sig,
+                    "INV-1: journal entry must store the JWT sig segment verbatim"
+                );
+            }
+            other => panic!("Expected DirectMember provenance, got: {other:?}"),
+        }
+    }
+
+    // INV-1 (negative): System-executed paths must record "system-executed",
+    // never the misleading "jwt-authenticated" string.
+    #[tokio::test]
+    async fn test_inv1_system_path_records_system_executed_not_jwt_authenticated() {
+        use icn_ledger::types::ProvenanceRef;
+
+        let mgr = LedgerManager::new();
+        let alice = IdentityBundle::generate().unwrap();
+        let bob = IdentityBundle::generate().unwrap();
+
+        // Escrow and recurring settlement callers pass None.
+        mgr.create_settlement(
+            &"test-coop".to_string(),
+            alice.did(),
+            bob.did(),
+            10,
+            "hours".to_string(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let entries = mgr
+            .get_history(&"test-coop".to_string(), None, 0, 100)
+            .await
+            .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        match &entries[0].provenance {
+            ProvenanceRef::DirectMember { signature, .. } => {
+                assert_eq!(
+                    signature, "system-executed",
+                    "INV-1: system paths must not falsely claim jwt-authenticated"
+                );
+                assert_ne!(
+                    signature, "jwt-authenticated",
+                    "INV-1: the old static placeholder must never appear"
+                );
+            }
+            other => panic!("Expected DirectMember provenance, got: {other:?}"),
+        }
     }
 }

--- a/icn/crates/icn-gateway/src/receipt_store.rs
+++ b/icn/crates/icn-gateway/src/receipt_store.rs
@@ -374,6 +374,25 @@ impl GovernanceReceiptBackend for ReceiptStore {
     ) -> Result<Option<GovernanceDecisionReceipt>, String> {
         self.get_governance_by_proposal(proposal_id)
     }
+
+    fn put_allocation(&self, receipt: &AllocationReceipt) -> Result<Hash, String> {
+        self.put_allocation(receipt)
+    }
+
+    fn get_governance_by_decision(
+        &self,
+        decision_hash: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        let results = self.list_governance_by_decision(decision_hash)?;
+        Ok(results.into_iter().next())
+    }
+
+    fn list_allocations_by_decision(
+        &self,
+        decision_hash: &Hash,
+    ) -> Result<Vec<AllocationReceipt>, String> {
+        self.list_allocations_by_decision(decision_hash)
+    }
 }
 
 #[cfg(test)]

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -1134,6 +1134,7 @@ impl GatewayServer {
                         .service(api::health::ready)
                         .service(api::health::health)
                         .service(api::health::health_detailed)
+                        .service(api::health::health_full)
                         .service(api::auth::challenge)
                         .service(api::auth::verify)
                         .service(api::websocket::websocket)

--- a/icn/crates/icn-gateway/tests/budget_integration.rs
+++ b/icn/crates/icn-gateway/tests/budget_integration.rs
@@ -51,7 +51,7 @@ async fn test_budget_enforcement() {
 
     // 2. Make Payment (50) -> Success
     let res = ledger_mgr
-        .create_settlement(&coop_id, alice.did(), bob.did(), 50, currency.clone())
+        .create_settlement(&coop_id, alice.did(), bob.did(), 50, currency.clone(), None)
         .await;
     assert!(res.is_ok());
 
@@ -61,7 +61,7 @@ async fn test_budget_enforcement() {
 
     // 3. Make Payment (60) -> Fail (Total 110 > 100)
     let res_fail = ledger_mgr
-        .create_settlement(&coop_id, alice.did(), bob.did(), 60, currency.clone())
+        .create_settlement(&coop_id, alice.did(), bob.did(), 60, currency.clone(), None)
         .await;
 
     assert!(res_fail.is_err());
@@ -76,7 +76,7 @@ async fn test_budget_enforcement() {
 
     // 4. Make Payment (50) -> Success (Total 100 == 100)
     let res_success = ledger_mgr
-        .create_settlement(&coop_id, alice.did(), bob.did(), 50, currency.clone())
+        .create_settlement(&coop_id, alice.did(), bob.did(), 50, currency.clone(), None)
         .await;
     assert!(res_success.is_ok());
 
@@ -91,7 +91,7 @@ async fn test_budget_enforcement() {
 
     // 5. Make Payment (1) -> Fail (Status is Exceeded or Limit hit)
     let res_fail_2 = ledger_mgr
-        .create_settlement(&coop_id, alice.did(), bob.did(), 1, currency.clone())
+        .create_settlement(&coop_id, alice.did(), bob.did(), 1, currency.clone(), None)
         .await;
     assert!(res_fail_2.is_err());
 }

--- a/icn/crates/icn-gateway/tests/escrow_integration.rs
+++ b/icn/crates/icn-gateway/tests/escrow_integration.rs
@@ -89,6 +89,7 @@ async fn test_escrow_lifecycle() {
                 alice.did(), // Payer
                 escrow.amount,
                 escrow.currency.clone(),
+                None,
             )
             .await;
         assert!(res.is_ok());

--- a/icn/crates/icn-ledger/src/entry.rs
+++ b/icn/crates/icn-ledger/src/entry.rs
@@ -95,14 +95,21 @@ impl JournalEntryBuilder {
     /// formal governance proposal — e.g., a member-to-member credit grant.
     ///
     /// # Arguments
-    /// * `did`       - DID of the authorizing member
-    /// * `signature` - Ed25519 signature of the entry by the member's key.
-    ///   A `DirectMember` entry without a signature has no verifiable
-    ///   authorization, so the signature is required.
-    pub fn with_direct_member_provenance(mut self, did: Did, signature: impl Into<String>) -> Self {
+    /// * `did`        - DID of the authorizing member
+    /// * `auth_proof` - Stored authorization evidence for this action.
+    ///   On the HTTP direct-member path, pass `"jwt-sig:<segment>"` where
+    ///   `<segment>` is the HMAC-SHA256 third segment of the JWT from the
+    ///   `Authorization` header.  For system-executed paths (escrow, recurring
+    ///   settlements), pass `"system-executed"`.
+    ///   This is NOT an Ed25519 signature over entry content (see issue #1435).
+    pub fn with_direct_member_provenance(
+        mut self,
+        did: Did,
+        auth_proof: impl Into<String>,
+    ) -> Self {
         self.provenance = Some(ProvenanceRef::DirectMember {
             did,
-            signature: signature.into(),
+            auth_proof: auth_proof.into(),
         });
         self
     }
@@ -411,33 +418,76 @@ mod tests {
         assert_eq!(de.provenance, entry.provenance);
     }
 
-    /// Test that DirectMember provenance round-trips correctly.
+    /// Test that DirectMember provenance round-trips correctly with the new
+    /// `auth_proof` field name.
     #[test]
     fn test_direct_member_provenance_roundtrip() {
         let keypair = KeyPair::generate().unwrap();
         let alice = keypair.did().clone();
         let bob = KeyPair::generate().unwrap().did().clone();
 
-        let sig = "ed25519:abcdef1234567890";
+        let proof = "jwt-sig:aHR0cHM6Ly9leGFtcGxlLmNvbQ";
 
         let entry = JournalEntryBuilder::new(alice.clone())
             .debit(alice.clone(), "hours".to_string(), 3)
             .credit(bob.clone(), "hours".to_string(), 3)
-            .with_direct_member_provenance(alice.clone(), sig)
+            .with_direct_member_provenance(alice.clone(), proof)
             .build()
             .expect("direct member provenance entry should build");
 
         match &entry.provenance {
-            ProvenanceRef::DirectMember { did, signature } => {
+            ProvenanceRef::DirectMember { did, auth_proof } => {
                 assert_eq!(did, &alice);
-                assert_eq!(signature, sig);
+                assert_eq!(auth_proof, proof);
             }
             other => panic!("Expected DirectMember, got {other:?}"),
         }
 
+        // New entries serialize with "auth_proof" key.
         let json = serde_json::to_string(&entry).unwrap();
-        assert!(json.contains(sig), "JSON should contain signature");
+        assert!(
+            json.contains("\"auth_proof\""),
+            "new entries must serialize with auth_proof key, got: {json}"
+        );
+        assert!(json.contains(proof), "JSON must contain the proof value");
         let de: JournalEntry = serde_json::from_str(&json).unwrap();
         assert_eq!(de.provenance, entry.provenance);
+    }
+
+    /// Backward-compatibility: on-disk Sled data written before the rename
+    /// used `"signature"` as the JSON key.  The serde alias must still
+    /// deserialize those entries without error.
+    #[test]
+    fn test_direct_member_provenance_backward_compat_signature_alias() {
+        let keypair = KeyPair::generate().unwrap();
+        let alice = keypair.did().clone();
+
+        // Simulate a pre-rename journal entry where the field was `"signature"`.
+        let old_json = format!(
+            r#"{{
+                "timestamp": 1000000000,
+                "author": {did_json},
+                "contract_ref": null,
+                "accounts": [],
+                "parents": [],
+                "signature": null,
+                "nonce": null,
+                "provenance": {{"DirectMember": {{"did": {did_json}, "signature": "jwt-sig:oldsig"}}}}
+            }}"#,
+            did_json = serde_json::to_string(&alice).unwrap()
+        );
+
+        let entry: JournalEntry =
+            serde_json::from_str(&old_json).expect("old signature key must deserialize via alias");
+
+        match &entry.provenance {
+            ProvenanceRef::DirectMember { auth_proof, .. } => {
+                assert_eq!(
+                    auth_proof, "jwt-sig:oldsig",
+                    "backward-compat alias must preserve the stored value"
+                );
+            }
+            other => panic!("Expected DirectMember, got {other:?}"),
+        }
     }
 }

--- a/icn/crates/icn-ledger/src/entry.rs
+++ b/icn/crates/icn-ledger/src/entry.rs
@@ -1,9 +1,78 @@
 //! Journal entry creation and validation
 
-use crate::types::{AccountDelta, ContentHash, JournalEntry, ProvenanceRef};
+use crate::types::{AccountDelta, ContentHash, JournalEntry, ProvenanceRef, Signature};
 use anyhow::{bail, Result};
-use icn_identity::Did;
+use icn_identity::{Did, KeyPair};
 use std::collections::HashMap;
+
+/// Sign a journal entry's content hash using the author's Ed25519 keypair.
+///
+/// Signs `entry.id` (the 32-byte SHA-256 content hash) and stores the 64-byte
+/// Ed25519 signature in `entry.signature`.  The signed bytes are identical to
+/// the bytes used by witness signatures, so verification is consistent.
+///
+/// # Prerequisites
+///
+/// - The entry must have a computed content hash (`entry.id` must be `Some`).
+///   Call `JournalEntryBuilder::build()` before calling this function.
+/// - `keypair.did()` should equal `entry.author` for the signature to be
+///   verifiable via `verify_entry_signature()`.
+///
+/// # Key access gap (issue #1435)
+///
+/// The gateway's direct-member settlement path does not currently have access to
+/// the author's private key — JWT auth proves identity but the key never reaches
+/// the server.  This function is the substrate enabling step: once a signing
+/// capability is threaded into `LedgerManager::create_settlement`, this is the
+/// call that produces the content signature.
+pub fn sign_entry(entry: &mut JournalEntry, keypair: &KeyPair) -> Result<()> {
+    let hash = entry.id.as_ref().ok_or_else(|| {
+        anyhow::anyhow!("Entry must have a computed hash before signing; call build() first")
+    })?;
+
+    let sig = keypair.sign(hash.as_bytes());
+    entry.signature = Some(Signature(sig.to_bytes().to_vec()));
+    Ok(())
+}
+
+/// Verify the Ed25519 content signature on a journal entry.
+///
+/// Extracts the verifying key from `entry.author` (the DID's embedded Ed25519
+/// public key) and verifies the stored signature against `entry.id` (the
+/// content hash).
+///
+/// This is publicly verifiable: any party with the author's DID can verify
+/// without any shared secret.
+///
+/// Returns:
+/// - `Ok(true)` — signature is present and verifies against author's public key
+/// - `Ok(false)` — no signature stored (`entry.signature` is `None`)
+/// - `Err(...)` — DID is malformed, signature bytes are wrong length,
+///   or content hash is missing
+pub fn verify_entry_signature(entry: &JournalEntry) -> Result<bool> {
+    let Some(ref stored_sig) = entry.signature else {
+        return Ok(false);
+    };
+
+    let hash = entry
+        .id
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("Entry has no content hash; cannot verify signature"))?;
+
+    let verifying_key = entry.author.to_verifying_key()?;
+
+    let sig_bytes: [u8; 64] = stored_sig.0.as_slice().try_into().map_err(|_| {
+        anyhow::anyhow!(
+            "Invalid signature length: {} bytes (expected 64)",
+            stored_sig.0.len()
+        )
+    })?;
+
+    let signature = ed25519_dalek::Signature::from_bytes(&sig_bytes);
+
+    use ed25519_dalek::Verifier;
+    Ok(verifying_key.verify(hash.as_bytes(), &signature).is_ok())
+}
 
 /// Builder for creating valid journal entries
 pub struct JournalEntryBuilder {
@@ -489,5 +558,124 @@ mod tests {
             }
             other => panic!("Expected DirectMember, got {other:?}"),
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // sign_entry / verify_entry_signature tests
+    // -------------------------------------------------------------------------
+
+    /// Golden path: sign → verify with the same keypair returns true.
+    ///
+    /// Proves that `sign_entry` + `verify_entry_signature` form a valid
+    /// round-trip using only the author's DID (public info) for verification.
+    #[test]
+    fn test_sign_and_verify_entry() {
+        let keypair = KeyPair::generate().unwrap();
+        let alice = keypair.did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        let mut entry = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 5)
+            .credit(bob.clone(), "hours".to_string(), 5)
+            .with_direct_member_provenance(alice.clone(), "jwt-sig:testsig")
+            .build()
+            .expect("entry should build");
+
+        // Entry has a hash but no signature yet.
+        assert!(entry.id.is_some(), "build() must compute the content hash");
+        assert!(
+            entry.signature.is_none(),
+            "signature not set before sign_entry"
+        );
+
+        sign_entry(&mut entry, &keypair).expect("sign_entry must succeed");
+
+        assert!(
+            entry.signature.is_some(),
+            "signature must be set after sign_entry"
+        );
+
+        // Verification uses only the author DID (public key embedded in the DID string).
+        let result = verify_entry_signature(&entry).expect("verify must not error");
+        assert!(result, "signature from correct keypair must verify");
+    }
+
+    /// Verify returns false for an entry with no signature.
+    #[test]
+    fn test_verify_unsigned_entry_returns_false() {
+        let keypair = KeyPair::generate().unwrap();
+        let alice = keypair.did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        let entry = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 3)
+            .credit(bob.clone(), "hours".to_string(), 3)
+            .with_system_provenance("test")
+            .build()
+            .expect("entry should build");
+
+        let result = verify_entry_signature(&entry).expect("verify must not error");
+        assert!(!result, "unsigned entry must return false, not error");
+    }
+
+    /// Verify fails when a different keypair signed the entry.
+    ///
+    /// Proves that the signature is bound to the specific keypair / DID:
+    /// signing with a key that doesn't match `entry.author` is detected.
+    #[test]
+    fn test_verify_wrong_key_fails() {
+        // alice is the entry author
+        let alice_kp = KeyPair::generate().unwrap();
+        let alice = alice_kp.did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        let mut entry = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 5)
+            .credit(bob.clone(), "hours".to_string(), 5)
+            .with_direct_member_provenance(alice.clone(), "jwt-sig:test")
+            .build()
+            .expect("entry should build");
+
+        // Sign with a DIFFERENT keypair (not alice's).
+        let wrong_kp = KeyPair::generate().unwrap();
+        sign_entry(&mut entry, &wrong_kp).expect("sign_entry with wrong key must not panic");
+
+        // Verification checks against entry.author (alice's DID), so must fail.
+        let result = verify_entry_signature(&entry).expect("verify must not error");
+        assert!(
+            !result,
+            "signature from wrong keypair must not verify against author's DID"
+        );
+    }
+
+    /// Verify fails after content mutation (hash changes).
+    ///
+    /// Proves that `sign_entry` binds to the content hash at signing time.
+    /// Any change to content-hashed fields invalidates the signature.
+    #[test]
+    fn test_verify_fails_after_content_mutation() {
+        let keypair = KeyPair::generate().unwrap();
+        let alice = keypair.did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        let mut entry = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 10)
+            .credit(bob.clone(), "hours".to_string(), 10)
+            .with_direct_member_provenance(alice.clone(), "jwt-sig:test")
+            .build()
+            .expect("entry should build");
+
+        sign_entry(&mut entry, &keypair).expect("sign must succeed");
+
+        // Mutate the content hash to simulate tampered data.
+        // (In a real attack, the attacker would modify accounts and then re-hash,
+        // but here we directly corrupt the id to prove signature coverage.)
+        entry.id = Some(crate::types::ContentHash::from_bytes([0xde; 32]));
+
+        let result = verify_entry_signature(&entry).expect("verify must not error");
+        assert!(
+            !result,
+            "mutated content hash must break signature verification"
+        );
     }
 }

--- a/icn/crates/icn-ledger/src/types.rs
+++ b/icn/crates/icn-ledger/src/types.rs
@@ -55,8 +55,26 @@ pub enum ProvenanceRef {
     /// Entry was created directly by a member (not via governance).
     ///
     /// `did` identifies the authorizing member.
-    /// `signature` is their Ed25519 signature over the entry content.
-    DirectMember { did: Did, signature: String },
+    ///
+    /// `auth_proof` carries stored authorization evidence for this action.
+    /// The format depends on the call path:
+    /// - `"jwt-sig:<base64url-segment>"` — the HMAC-SHA256 third segment of
+    ///   the JWT that authorized the HTTP request (verifiable by the issuing
+    ///   node using `jwt_secret`; not publicly verifiable without the secret)
+    /// - `"system-executed"` — entry created by a system path (escrow release,
+    ///   recurring settlement) with no per-request HTTP auth context
+    ///
+    /// This field is NOT an Ed25519 signature over the entry content.
+    /// For content-bound asymmetric signing, see issue #1435.
+    DirectMember {
+        did: Did,
+        /// Stored authorization evidence. See variant doc for format variants.
+        ///
+        /// Serde alias `"signature"` preserves backward compatibility with
+        /// existing on-disk Sled data written before this field was renamed.
+        #[serde(alias = "signature")]
+        auth_proof: String,
+    },
 
     /// Entry was created by the system (FX transfer, DID migration, mint, etc.).
     ///

--- a/ops/state/sprint/current.json
+++ b/ops/state/sprint/current.json
@@ -42,7 +42,7 @@
     {
       "id": "s26-t3",
       "title": "Resolve fix/demo-path-bugs branch: 7 dirty files from route rename (/payment+currency -> /settle+unit)",
-      "status": "in-review",
+      "status": "done",
       "pr": 1433,
       "assignee": "matt",
       "epic": "demo"
@@ -62,6 +62,14 @@
       "pr": null,
       "assignee": null,
       "epic": "devops"
+    },
+    {
+      "id": "s26-t6",
+      "title": "Governance→economics provenance hardening (INV-2/5/6): chain endpoint, allocation receipts, /health/full, 4 regression tests",
+      "status": "in-progress",
+      "pr": null,
+      "assignee": "matt",
+      "epic": "arch-invariants"
     }
   ]
 }

--- a/ops/state/sprint/current.json
+++ b/ops/state/sprint/current.json
@@ -66,8 +66,8 @@
     {
       "id": "s26-t6",
       "title": "Governance→economics provenance hardening (INV-2/5/6): chain endpoint, allocation receipts, /health/full, 4 regression tests",
-      "status": "in-progress",
-      "pr": null,
+      "status": "in-review",
+      "pr": 1434,
       "assignee": "matt",
       "epic": "arch-invariants"
     }


### PR DESCRIPTION
## Summary

Three provenance-hardening commits: INV-1 (direct-member auth evidence), INV-2 (allocation completeness), INV-5 (chain walkability), INV-6 (duplicate vote rejection), and a correction of a pre-existing `chain_complete` logic defect.

Addresses sprint task s26-t6.

## Problem

1. **INV-2:** Accepted economic proposals (`Budget`, `Treasury`, `Allocation`, `SurplusAllocation`) created a `GovernanceDecisionReceipt` but no downstream `AllocationReceipt`. The governance→economics chain was incomplete and unqueryable.

2. **INV-5:** No HTTP endpoint existed to query the provenance chain. Inspection required direct node access.

3. **`chain_complete` defect:** The chain completeness flag reduced to `has_governance` under all conditions due to the tautological expression `has_governance && (is_economic == has_allocations)`. An accepted Budget proposal with a missing allocation receipt would report `chain_complete: true` — a silent false guarantee.

4. **INV-1:** Every `DirectMember` journal entry stored the static string `"jwt-authenticated"` regardless of actual caller context — including escrow release and recurring settlements which have no JWT. No inspectable authorization evidence, no link to any specific request.

## Changes

**`apps/governance/`**
- `GovernanceReceiptBackend` trait: adds `put_allocation`, `get_governance_by_decision`, `list_allocations_by_decision`
- `GovernanceManager::create_allocation_receipt`: creates `AllocationReceipt` for economic payloads on `ProofOutcome::Accepted`; wired into `close_proposal`
- `GovernanceManager::get_chain`: returns `ProvenanceChain { governance_receipt, allocations, chain_complete }` with corrected completeness logic
- `GET /gov/proposals/{id}/chain` registered
- 5 invariant regression tests (INV-2×2, INV-5×2, INV-6)

**`crates/icn-gateway/`**
- `LedgerManager::create_settlement` takes `auth_proof: Option<String>`
- HTTP handler (`POST /ledger/{coop_id}/settle`) extracts JWT third segment from `Authorization: Bearer <h>.<p>.<sig>`, passes `Some("jwt-sig:<sig>")`
- Missing/malformed Authorization header falls through to `None` → stored `"system-executed"` (no false proof claim)
- Escrow release and recurring settlement callers pass `None`
- `GET /health/full` composite health endpoint with per-subsystem probes and latency
- 2 INV-1 provenance-readback regression tests via `get_history()` at `ProvenanceRef::DirectMember.signature`

## Verification

- `cargo check -p icn-gateway`: clean
- `cargo fmt --all --check`: clean
- `cargo clippy -p icn-gateway --all-targets -- -D warnings`: clean
- `cargo test -p icn-gateway --lib`: 458/458 pass
- INV-1 tests verify storage truth via `get_history()` readback — not just call-site threading

## Semantics

The stored `"jwt-sig:<segment>"` is the HMAC-SHA256 fingerprint of the JWT that authorized the HTTP action. It ties the journal entry to a specific, verified auth token. It is **not** a public-key signature over entry content. Nodes holding `jwt_secret` can verify by recomputing `HMAC-SHA256(secret, "{header}.{payload}")`.

System-executed paths store `"system-executed"` — an honest marker that no per-request proof exists.

## Limitations

- HMAC verification requires `jwt_secret`. Federation replicas and external auditors without the secret cannot verify stored fingerprints.
- The `signature` field name in `ProvenanceRef::DirectMember` implies Ed25519; the stored value is an auth-token fingerprint, not a signature over entry content.
- No HTTP-level actix integration test covering the full extraction→storage path; proof is at the manager/storage boundary.
- Missing/malformed Authorization header degrades silently to `"system-executed"`. Indistinguishable from a system-executed entry at the storage layer.

## Follow-ups

- HTTP-level actix integration test: verify `api/ledger.rs` correctly extracts and threads the JWT third segment end-to-end
- Asymmetric per-entry signing over entry content using the node's Ed25519 key — publicly verifiable without secret sharing
- Disambiguate `ProvenanceRef::DirectMember.signature` field name from Ed25519 semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)