### PR TITLE
feat(audit): enforce canonical execution truth contract across gateway and icnctl

### DIFF
--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -10298,18 +10298,128 @@ fn verify_receipt_chain(
         },
     });
 
-    // Check 8: Chain completeness (server-computed)
+    // Check 8: Structural completeness
     checks.push(AuditCheck {
-        name: "Chain complete".to_string(),
-        passed: chain.chain_complete,
-        detail: if chain.chain_complete {
-            "All chain links present".to_string()
+        name: "Structural chain complete".to_string(),
+        passed: chain.structural_complete,
+        detail: if chain.structural_complete {
+            "All required receipt links present".to_string()
         } else {
-            "Chain has missing links".to_string()
+            "Missing receipt links in structural chain".to_string()
+        },
+    });
+
+    // Check 9: Execution summary arithmetic consistency.
+    let execution_counts_consistent = chain.execution.total_effects
+        == chain.execution.executed_effects
+            + chain.execution.not_executed_effects
+            + chain.execution.hard_failed_effects;
+    checks.push(AuditCheck {
+        name: "Execution counters consistent".to_string(),
+        passed: execution_counts_consistent,
+        detail: format!(
+            "total={} executed={} not_executed={} hard_failed={}",
+            chain.execution.total_effects,
+            chain.execution.executed_effects,
+            chain.execution.not_executed_effects,
+            chain.execution.hard_failed_effects
+        ),
+    });
+
+    // Check 10: Execution completeness (semantic truth gate)
+    checks.push(AuditCheck {
+        name: "Execution complete".to_string(),
+        passed: chain.execution_complete,
+        detail: if chain.execution.execution_record_present {
+            format!(
+                "status={:?}, complete={}, not_executed={}, hard_failed={}",
+                chain.execution.status,
+                chain.execution.execution_complete,
+                chain.execution.not_executed_effects,
+                chain.execution.hard_failed_effects
+            )
+        } else {
+            "No execution record present for decision".to_string()
+        },
+    });
+
+    // Check 11: Overall chain completeness contract.
+    checks.push(AuditCheck {
+        name: "Chain complete contract".to_string(),
+        passed: chain.chain_complete == (chain.structural_complete && chain.execution_complete),
+        detail: if chain.chain_complete {
+            "chain_complete=true (structural + execution complete)".to_string()
+        } else {
+            "chain_complete=false (structural and/or execution incomplete)".to_string()
         },
     });
 
     checks
+}
+
+#[cfg(test)]
+mod audit_verify_tests {
+    use super::verify_receipt_chain;
+    use icn_gateway::api::receipts::{
+        DecisionExecutionTruthResponse, GovernanceReceiptResponse, GovernanceVoteTallyResponse,
+        ReceiptChainResponse,
+    };
+
+    fn sample_chain(execution_complete: bool, not_executed: usize) -> ReceiptChainResponse {
+        ReceiptChainResponse {
+            decision_hash: "a".repeat(64),
+            governance: Some(GovernanceReceiptResponse {
+                decision_hash: "a".repeat(64),
+                proposal_id: "prop-1".to_string(),
+                domain_id: "domain-1".to_string(),
+                outcome: "Accepted".to_string(),
+                vote_tally: GovernanceVoteTallyResponse {
+                    for_votes: 3,
+                    against_votes: 0,
+                    abstain_votes: 0,
+                },
+                vote_hash: "b".repeat(64),
+            }),
+            allocations: vec![],
+            intents: vec![],
+            structural_complete: true,
+            execution_complete,
+            chain_complete: execution_complete,
+            execution: DecisionExecutionTruthResponse {
+                execution_record_present: true,
+                status: None,
+                total_effects: 1,
+                executed_effects: 1usize.saturating_sub(not_executed),
+                not_executed_effects: not_executed,
+                hard_failed_effects: 0,
+                execution_complete,
+            },
+        }
+    }
+
+    #[test]
+    fn partial_execution_fails_verification_checks() {
+        let chain = sample_chain(false, 1);
+        let checks = verify_receipt_chain(&chain, &"a".repeat(64));
+        assert!(
+            checks
+                .iter()
+                .any(|c| c.name == "Execution complete" && !c.passed),
+            "partial execution must fail execution-complete check"
+        );
+    }
+
+    #[test]
+    fn full_execution_passes_execution_check() {
+        let chain = sample_chain(true, 0);
+        let checks = verify_receipt_chain(&chain, &"a".repeat(64));
+        assert!(
+            checks
+                .iter()
+                .any(|c| c.name == "Execution complete" && c.passed),
+            "full execution must pass execution-complete check"
+        );
+    }
 }
 
 /// Handle audit commands — verify receipt chain integrity.

--- a/icn/bins/icnctl/tests/audit_verify_test.rs
+++ b/icn/bins/icnctl/tests/audit_verify_test.rs
@@ -6,8 +6,8 @@
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use icn_gateway::api::receipts::{
-    AllocationReceiptResponse, GovernanceReceiptResponse, GovernanceVoteTallyResponse,
-    ReceiptChainResponse, SettlementIntentResponse,
+    AllocationReceiptResponse, DecisionExecutionTruthResponse, GovernanceReceiptResponse,
+    GovernanceVoteTallyResponse, ReceiptChainResponse, SettlementIntentResponse,
 };
 
 const DECISION_HASH: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -61,7 +61,18 @@ fn make_complete_chain() -> ReceiptChainResponse {
         governance: Some(make_governance()),
         allocations: vec![make_allocation(vec![intent_hash.clone()])],
         intents: vec![make_intent(&intent_hash)],
+        structural_complete: true,
+        execution_complete: true,
         chain_complete: true,
+        execution: DecisionExecutionTruthResponse {
+            execution_record_present: true,
+            status: None,
+            total_effects: 1,
+            executed_effects: 1,
+            not_executed_effects: 0,
+            hard_failed_effects: 0,
+            execution_complete: true,
+        },
     }
 }
 
@@ -151,10 +162,35 @@ fn verify_receipt_chain(
         String::new(),
     ));
 
-    // 8: Chain complete
+    // 8: Structural complete
     checks.push((
-        "Chain complete".to_string(),
-        chain.chain_complete,
+        "Structural chain complete".to_string(),
+        chain.structural_complete,
+        String::new(),
+    ));
+
+    // 9: Execution counters consistent
+    let execution_counts_consistent = chain.execution.total_effects
+        == chain.execution.executed_effects
+            + chain.execution.not_executed_effects
+            + chain.execution.hard_failed_effects;
+    checks.push((
+        "Execution counters consistent".to_string(),
+        execution_counts_consistent,
+        String::new(),
+    ));
+
+    // 10: Execution complete
+    checks.push((
+        "Execution complete".to_string(),
+        chain.execution_complete,
+        String::new(),
+    ));
+
+    // 11: Chain complete contract
+    checks.push((
+        "Chain complete contract".to_string(),
+        chain.chain_complete == (chain.structural_complete && chain.execution_complete),
         String::new(),
     ));
 
@@ -166,7 +202,7 @@ fn test_complete_chain_passes_all_checks() {
     let chain = make_complete_chain();
     let checks = verify_receipt_chain(&chain, DECISION_HASH);
 
-    assert_eq!(checks.len(), 8);
+    assert_eq!(checks.len(), 11);
     for (name, passed, _) in &checks {
         assert!(passed, "Check '{}' should pass on complete chain", name);
     }
@@ -180,12 +216,23 @@ fn test_missing_governance_fails() {
         governance: None,
         allocations: vec![make_allocation(vec![intent_hash.clone()])],
         intents: vec![make_intent(&intent_hash)],
+        structural_complete: false,
+        execution_complete: false,
         chain_complete: false,
+        execution: DecisionExecutionTruthResponse {
+            execution_record_present: false,
+            status: None,
+            total_effects: 0,
+            executed_effects: 0,
+            not_executed_effects: 0,
+            hard_failed_effects: 0,
+            execution_complete: false,
+        },
     };
     let checks = verify_receipt_chain(&chain, DECISION_HASH);
 
     assert!(!checks[0].1, "Governance check should fail");
-    assert!(!checks[7].1, "Chain complete should fail");
+    assert!(checks[10].1, "Chain complete contract should hold");
 }
 
 #[test]
@@ -209,7 +256,18 @@ fn test_orphaned_intent_detected() {
         governance: Some(make_governance()),
         allocations: vec![make_allocation(vec![intent_hash.clone()])],
         intents: vec![make_intent(&intent_hash), make_intent(&orphan_hash)],
+        structural_complete: true,
+        execution_complete: true,
         chain_complete: true,
+        execution: DecisionExecutionTruthResponse {
+            execution_record_present: true,
+            status: None,
+            total_effects: 1,
+            executed_effects: 1,
+            not_executed_effects: 0,
+            hard_failed_effects: 0,
+            execution_complete: true,
+        },
     };
     let checks = verify_receipt_chain(&chain, DECISION_HASH);
 
@@ -223,7 +281,18 @@ fn test_empty_chain_reports_missing() {
         governance: None,
         allocations: vec![],
         intents: vec![],
+        structural_complete: false,
+        execution_complete: false,
         chain_complete: false,
+        execution: DecisionExecutionTruthResponse {
+            execution_record_present: false,
+            status: None,
+            total_effects: 0,
+            executed_effects: 0,
+            not_executed_effects: 0,
+            hard_failed_effects: 0,
+            execution_complete: false,
+        },
     };
     let checks = verify_receipt_chain(&chain, DECISION_HASH);
 
@@ -235,7 +304,7 @@ fn test_empty_chain_reports_missing() {
     assert!(!checks[4].1, "Intents should fail");
     assert!(checks[5].1, "Intent provenance vacuously passes");
     assert!(checks[6].1, "Orphan check vacuously passes");
-    assert!(!checks[7].1, "Chain complete should fail");
+    assert!(checks[10].1, "Chain complete contract should hold");
 }
 
 #[test]

--- a/icn/crates/icn-core/src/supervisor/decision_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/decision_executor.rs
@@ -52,7 +52,9 @@ use tracing::{debug, error, info, warn};
 
 use icn_kernel_api::effects::{EffectResult, KernelEffect};
 use icn_kernel_api::escrow::{EscrowStatus, EscrowStore};
-use icn_kernel_api::execution::{ExecutionRecord, ExecutionStatus, ExecutionStore};
+use icn_kernel_api::execution::{
+    ExecutionRecord, ExecutionStatus, ExecutionStore, ExecutionTruthSummary,
+};
 
 use super::effect_dispatcher::EffectDispatcher;
 
@@ -507,6 +509,22 @@ impl DecisionExecutor {
             .filter(|r| r.is_hard_failure())
             .map(|r| r.message.clone())
             .collect();
+
+        let total_effects = results.len();
+        let not_executed_effects = results.iter().filter(|r| r.not_executed).count();
+        let hard_failed_effects = results.iter().filter(|r| r.is_hard_failure()).count();
+        let executed_effects = total_effects
+            .saturating_sub(not_executed_effects)
+            .saturating_sub(hard_failed_effects);
+        let execution_complete =
+            total_effects > 0 && not_executed_effects == 0 && hard_failed_effects == 0;
+        record.truth_summary = Some(ExecutionTruthSummary {
+            total_effects,
+            executed_effects,
+            not_executed_effects,
+            hard_failed_effects,
+            execution_complete,
+        });
 
         let all_non_executable = !results.is_empty() && results.iter().all(|r| r.not_executed);
         let mixed_non_executable =

--- a/icn/crates/icn-gateway/src/api/execution.rs
+++ b/icn/crates/icn-gateway/src/api/execution.rs
@@ -19,6 +19,11 @@ pub struct ExecutionRecordResponse {
     pub decision_hash: String,
     pub proposal_id: String,
     pub status: ExecutionStatus,
+    pub total_effects: usize,
+    pub executed_effects: usize,
+    pub not_executed_effects: usize,
+    pub hard_failed_effects: usize,
+    pub execution_complete: bool,
     pub retries: u32,
     pub started_at: u64,
     pub finished_at: Option<u64>,
@@ -27,10 +32,16 @@ pub struct ExecutionRecordResponse {
 
 impl From<ExecutionRecord> for ExecutionRecordResponse {
     fn from(record: ExecutionRecord) -> Self {
+        let summary = record.truth_summary_or_fallback();
         Self {
             decision_hash: record.decision_hash,
             proposal_id: record.proposal_id,
             status: record.status,
+            total_effects: summary.total_effects,
+            executed_effects: summary.executed_effects,
+            not_executed_effects: summary.not_executed_effects,
+            hard_failed_effects: summary.hard_failed_effects,
+            execution_complete: summary.execution_complete,
             retries: record.retries,
             started_at: record.started_at,
             finished_at: record.finished_at,
@@ -147,6 +158,7 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
 mod tests {
     use super::*;
     use anyhow::Result;
+    use icn_kernel_api::execution::ExecutionTruthSummary;
 
     fn temp_store() -> Arc<dyn Store> {
         Arc::new(icn_store::SledStore::temporary().expect("temp store"))
@@ -203,5 +215,28 @@ mod tests {
         let store = temp_store();
         let result = get_execution_record(store.as_ref(), "missing").expect("query");
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn execution_response_exposes_truth_counters() {
+        let store = temp_store();
+        let mut record = ExecutionRecord::new_pending("h3", "p3", "r3", vec![]);
+        record.mark_confirmed(vec!["entry-1".to_string()], vec![]);
+        record.truth_summary = Some(ExecutionTruthSummary {
+            total_effects: 2,
+            executed_effects: 1,
+            not_executed_effects: 1,
+            hard_failed_effects: 0,
+            execution_complete: false,
+        });
+        put_record(store.as_ref(), &record).expect("put record");
+
+        let got = get_execution_record(store.as_ref(), "h3")
+            .expect("query")
+            .expect("record exists");
+        assert_eq!(got.total_effects, 2);
+        assert_eq!(got.executed_effects, 1);
+        assert_eq!(got.not_executed_effects, 1);
+        assert!(!got.execution_complete);
     }
 }

--- a/icn/crates/icn-gateway/src/api/receipts.rs
+++ b/icn/crates/icn-gateway/src/api/receipts.rs
@@ -8,9 +8,10 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::receipt_store::ReceiptStore;
-use icn_governance::GovernanceDecisionReceipt;
 use icn_kernel_api::economics::SettlementIntent;
+use icn_kernel_api::execution::{ExecutionRecord, ExecutionStatus};
 use icn_kernel_api::receipts::{AllocationReceipt, CanonicalReceipt, Hash};
+use icn_store::Store;
 
 /// Query parameters for listing by decision hash.
 ///
@@ -140,23 +141,6 @@ pub struct GovernanceVoteTallyResponse {
     pub abstain_votes: usize,
 }
 
-impl From<&GovernanceDecisionReceipt> for GovernanceReceiptResponse {
-    fn from(r: &GovernanceDecisionReceipt) -> Self {
-        Self {
-            decision_hash: hex::encode(r.decision_hash),
-            proposal_id: r.proposal_id.clone(),
-            domain_id: r.domain_id.clone(),
-            outcome: format!("{:?}", r.outcome),
-            vote_tally: GovernanceVoteTallyResponse {
-                for_votes: r.vote_tally.for_votes,
-                against_votes: r.vote_tally.against_votes,
-                abstain_votes: r.vote_tally.abstain_votes,
-            },
-            vote_hash: hex::encode(r.vote_hash),
-        }
-    }
-}
-
 /// Response for the full receipt chain (governance + economic artifacts).
 ///
 /// Returned by `GET /v1/receipts/chain/{decision_hash}`.
@@ -171,11 +155,26 @@ pub struct ReceiptChainResponse {
     pub allocations: Vec<AllocationReceiptResponse>,
     /// Settlement intents for this decision
     pub intents: Vec<SettlementIntentResponse>,
-    /// Whether all expected chain links are present.
-    ///
-    /// True when at least a governance receipt exists AND every allocation has
-    /// at least one intent.
+    /// Structural chain completeness (receipt-link integrity only).
+    pub structural_complete: bool,
+    /// Execution completeness for milestone scope.
+    pub execution_complete: bool,
+    /// Overall completeness: structural + execution truth.
     pub chain_complete: bool,
+    /// Canonical execution-truth counters for the decision.
+    pub execution: DecisionExecutionTruthResponse,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DecisionExecutionTruthResponse {
+    pub execution_record_present: bool,
+    pub status: Option<ExecutionStatus>,
+    pub total_effects: usize,
+    pub executed_effects: usize,
+    pub not_executed_effects: usize,
+    pub hard_failed_effects: usize,
+    pub execution_complete: bool,
 }
 
 /// Parse hex hash or return error response
@@ -193,6 +192,46 @@ fn parse_hash(hex_str: &str) -> Result<Hash, HttpResponse> {
     let mut hash = [0u8; 32];
     hash.copy_from_slice(&bytes);
     Ok(hash)
+}
+
+fn key_for_decision_hash(decision_hash: &str) -> Vec<u8> {
+    let mut key = b"exec:".to_vec();
+    key.extend_from_slice(decision_hash.as_bytes());
+    key
+}
+
+fn load_execution_truth(
+    execution_store: &dyn Store,
+    decision_hash: &str,
+) -> Result<DecisionExecutionTruthResponse, String> {
+    let value = execution_store
+        .get(&key_for_decision_hash(decision_hash))
+        .map_err(|e| format!("failed to read execution record: {e}"))?;
+
+    let Some(value) = value else {
+        return Ok(DecisionExecutionTruthResponse {
+            execution_record_present: false,
+            status: None,
+            total_effects: 0,
+            executed_effects: 0,
+            not_executed_effects: 0,
+            hard_failed_effects: 0,
+            execution_complete: false,
+        });
+    };
+
+    let record: ExecutionRecord = serde_json::from_slice(&value)
+        .map_err(|e| format!("failed to decode execution record: {e}"))?;
+    let summary = record.truth_summary_or_fallback();
+    Ok(DecisionExecutionTruthResponse {
+        execution_record_present: true,
+        status: Some(record.status),
+        total_effects: summary.total_effects,
+        executed_effects: summary.executed_effects,
+        not_executed_effects: summary.not_executed_effects,
+        hard_failed_effects: summary.hard_failed_effects,
+        execution_complete: summary.execution_complete,
+    })
 }
 
 /// GET /v1/receipts/allocations/{hash}
@@ -287,6 +326,7 @@ pub async fn get_chain(
 #[get("/chain/{decision_hash}")]
 pub async fn get_full_chain(
     receipt_store: web::Data<Arc<ReceiptStore>>,
+    execution_store: web::Data<Arc<dyn Store>>,
     path: web::Path<String>,
 ) -> HttpResponse {
     let hash_hex = path.into_inner();
@@ -315,19 +355,47 @@ pub async fn get_full_chain(
         }
     };
 
-    // Chain is complete when we have a governance receipt AND every allocation
-    // has at least one intent (or there are no allocations but intents exist).
-    let chain_complete = governance.is_some() && allocations.iter().all(|a| !a.intents.is_empty());
+    let normalized_decision_hash = hex::encode(hash);
+    let execution = match load_execution_truth(
+        execution_store.get_ref().as_ref(),
+        &normalized_decision_hash,
+    ) {
+        Ok(execution) => execution,
+        Err(e) => {
+            return HttpResponse::InternalServerError().json(serde_json::json!({
+                "error": e
+            }))
+        }
+    };
+
+    let structural_complete =
+        governance.is_some() && allocations.iter().all(|a| !a.intents.is_empty());
+    let execution_complete = execution.execution_complete;
+    let chain_complete = structural_complete && execution_complete;
 
     let response = ReceiptChainResponse {
         decision_hash: hash_hex,
-        governance: governance.as_ref().map(GovernanceReceiptResponse::from),
+        governance: governance.as_ref().map(|r| GovernanceReceiptResponse {
+            decision_hash: hex::encode(r.decision_hash),
+            proposal_id: r.proposal_id.clone(),
+            domain_id: r.domain_id.clone(),
+            outcome: format!("{:?}", r.outcome),
+            vote_tally: GovernanceVoteTallyResponse {
+                for_votes: r.vote_tally.for_votes,
+                against_votes: r.vote_tally.against_votes,
+                abstain_votes: r.vote_tally.abstain_votes,
+            },
+            vote_hash: hex::encode(r.vote_hash),
+        }),
         allocations: allocations
             .iter()
             .map(AllocationReceiptResponse::from)
             .collect(),
         intents: intents.iter().map(SettlementIntentResponse::from).collect(),
+        structural_complete,
+        execution_complete,
         chain_complete,
+        execution,
     };
     HttpResponse::Ok().json(response)
 }
@@ -395,4 +463,124 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
         .service(get_chain)
         .service(list_allocations)
         .service(list_intents);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::{test, App};
+    use icn_kernel_api::execution::{ExecutionRecord, ExecutionTruthSummary};
+    use icn_kernel_api::receipts::AllocationReceipt;
+    use icn_kernel_api::ScopeLevel;
+    use icn_store::{SledStore, Store};
+
+    #[actix_web::test]
+    async fn partial_execution_chain_is_not_complete() {
+        let db = sled::Config::new()
+            .temporary(true)
+            .open()
+            .expect("temp receipt db");
+        let receipt_store = Arc::new(ReceiptStore::new(db));
+        let execution_store: Arc<dyn Store> =
+            Arc::new(SledStore::temporary().expect("temp exec db"));
+
+        let decision_hash = receipt_store
+            .put_test_governance_receipt("prop-partial")
+            .expect("governance");
+
+        let intent = SettlementIntent::new("r1", decision_hash, "a", "b", 10, "HOURS");
+        let allocation = AllocationReceipt::new(decision_hash, ScopeLevel::Org).add_intent(intent);
+        receipt_store
+            .put_allocation_with_intents(&allocation)
+            .expect("allocation");
+
+        let mut record =
+            ExecutionRecord::new_pending(hex::encode(decision_hash), "prop-partial", "r1", vec![]);
+        record.mark_confirmed(vec!["ledger-1".to_string()], vec![]);
+        record.truth_summary = Some(ExecutionTruthSummary {
+            total_effects: 1,
+            executed_effects: 0,
+            not_executed_effects: 1,
+            hard_failed_effects: 0,
+            execution_complete: false,
+        });
+        execution_store
+            .put(
+                format!("exec:{}", hex::encode(decision_hash)).as_bytes(),
+                &serde_json::to_vec(&record).expect("serialize record"),
+            )
+            .expect("put execution");
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(receipt_store.clone()))
+                .app_data(web::Data::new(execution_store.clone()))
+                .service(web::scope("/v1/receipts").service(get_full_chain)),
+        )
+        .await;
+
+        let uri = format!("/v1/receipts/chain/{}", hex::encode(decision_hash));
+        let req = test::TestRequest::get().uri(&uri).to_request();
+        let resp: ReceiptChainResponse = test::call_and_read_body_json(&app, req).await;
+
+        assert!(resp.structural_complete);
+        assert!(!resp.execution_complete);
+        assert!(!resp.chain_complete);
+        assert_eq!(resp.execution.not_executed_effects, 1);
+    }
+
+    #[actix_web::test]
+    async fn full_execution_chain_is_complete() {
+        let db = sled::Config::new()
+            .temporary(true)
+            .open()
+            .expect("temp receipt db");
+        let receipt_store = Arc::new(ReceiptStore::new(db));
+        let execution_store: Arc<dyn Store> =
+            Arc::new(SledStore::temporary().expect("temp exec db"));
+
+        let decision_hash = receipt_store
+            .put_test_governance_receipt("prop-full")
+            .expect("governance");
+
+        let intent = SettlementIntent::new("r2", decision_hash, "a", "b", 10, "HOURS");
+        let allocation = AllocationReceipt::new(decision_hash, ScopeLevel::Org).add_intent(intent);
+        receipt_store
+            .put_allocation_with_intents(&allocation)
+            .expect("allocation");
+
+        let mut record =
+            ExecutionRecord::new_pending(hex::encode(decision_hash), "prop-full", "r2", vec![]);
+        record.mark_confirmed(vec!["ledger-1".to_string()], vec![]);
+        record.truth_summary = Some(ExecutionTruthSummary {
+            total_effects: 1,
+            executed_effects: 1,
+            not_executed_effects: 0,
+            hard_failed_effects: 0,
+            execution_complete: true,
+        });
+        execution_store
+            .put(
+                format!("exec:{}", hex::encode(decision_hash)).as_bytes(),
+                &serde_json::to_vec(&record).expect("serialize record"),
+            )
+            .expect("put execution");
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(receipt_store.clone()))
+                .app_data(web::Data::new(execution_store.clone()))
+                .service(web::scope("/v1/receipts").service(get_full_chain)),
+        )
+        .await;
+
+        let uri = format!("/v1/receipts/chain/{}", hex::encode(decision_hash));
+        let req = test::TestRequest::get().uri(&uri).to_request();
+        let resp: ReceiptChainResponse = test::call_and_read_body_json(&app, req).await;
+
+        assert!(resp.structural_complete);
+        assert!(resp.execution_complete);
+        assert!(resp.chain_complete);
+        assert_eq!(resp.execution.executed_effects, 1);
+    }
 }

--- a/icn/crates/icn-gateway/src/api/registry.rs
+++ b/icn/crates/icn-gateway/src/api/registry.rs
@@ -828,7 +828,18 @@ fn lookup_governance_receipt(
     };
 
     match store.get_governance(&hash) {
-        Ok(Some(receipt)) => Some(GovernanceReceiptResponse::from(&receipt)),
+        Ok(Some(receipt)) => Some(GovernanceReceiptResponse {
+            decision_hash: hex::encode(receipt.decision_hash),
+            proposal_id: receipt.proposal_id,
+            domain_id: receipt.domain_id,
+            outcome: format!("{:?}", receipt.outcome),
+            vote_tally: crate::api::receipts::GovernanceVoteTallyResponse {
+                for_votes: receipt.vote_tally.for_votes,
+                against_votes: receipt.vote_tally.against_votes,
+                abstain_votes: receipt.vote_tally.abstain_votes,
+            },
+            vote_hash: hex::encode(receipt.vote_hash),
+        }),
         Ok(None) => None,
         Err(e) => {
             tracing::warn!(

--- a/icn/crates/icn-kernel-api/src/execution.rs
+++ b/icn/crates/icn-kernel-api/src/execution.rs
@@ -44,6 +44,24 @@ pub enum ExecutionStatus {
     PermanentlyFailed,
 }
 
+/// Canonical execution-truth summary for boundary surfaces.
+///
+/// This is the tranche-2 contract for exposing whether execution was complete,
+/// independent of aggregate status labels like [`ExecutionStatus::Confirmed`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ExecutionTruthSummary {
+    /// Number of effect rows returned by dispatch.
+    pub total_effects: usize,
+    /// Number of effect rows that executed successfully.
+    pub executed_effects: usize,
+    /// Number of structurally non-executed rows (`not_executed = true`).
+    pub not_executed_effects: usize,
+    /// Number of hard-failure rows (`!success && !not_executed`).
+    pub hard_failed_effects: usize,
+    /// True only when all effect rows executed and none were skipped/failed.
+    pub execution_complete: bool,
+}
+
 /// Persistent record of a governance decision execution.
 ///
 /// Keyed by `decision_hash` in the execution store.
@@ -85,6 +103,13 @@ pub struct ExecutionRecord {
     /// Empty for pre-existing records that don't have effects stored.
     #[serde(default)]
     pub effects: Vec<KernelEffect>,
+
+    /// Canonical execution-truth summary for audit/API/CLI boundary surfaces.
+    ///
+    /// `None` means this record predates tranche-2 summary persistence and
+    /// consumers should use conservative fallback semantics.
+    #[serde(default)]
+    pub truth_summary: Option<ExecutionTruthSummary>,
 }
 
 impl ExecutionRecord {
@@ -112,6 +137,7 @@ impl ExecutionRecord {
             error: None,
             retries: 0,
             effects,
+            truth_summary: None,
         }
     }
 
@@ -184,6 +210,40 @@ impl ExecutionRecord {
                 | ExecutionStatus::NotExecuted
                 | ExecutionStatus::PermanentlyFailed
         )
+    }
+
+    /// Return execution-truth summary with a conservative fallback for legacy rows.
+    pub fn truth_summary_or_fallback(&self) -> ExecutionTruthSummary {
+        if let Some(summary) = &self.truth_summary {
+            return summary.clone();
+        }
+
+        // Legacy rows (pre-tranche-2) do not have canonical effect counters.
+        // Expose conservative values to avoid over-reporting completeness.
+        let total_effects = self.effects.len();
+        let not_executed_effects = if matches!(self.status, ExecutionStatus::NotExecuted) {
+            total_effects.max(1)
+        } else {
+            0
+        };
+        let hard_failed_effects = if matches!(
+            self.status,
+            ExecutionStatus::Failed | ExecutionStatus::PermanentlyFailed
+        ) {
+            1
+        } else {
+            0
+        };
+        let executed_effects = self.ledger_entry_ids.len().min(total_effects);
+        let execution_complete = false;
+
+        ExecutionTruthSummary {
+            total_effects,
+            executed_effects,
+            not_executed_effects,
+            hard_failed_effects,
+            execution_complete,
+        }
     }
 }
 


### PR DESCRIPTION
## Problem
Gateway and CLI audit surfaces could treat structurally valid receipt chains as effectively successful even when decision execution was partial. This allowed `chain_complete` and `audit verify` output to be read as full success without forcing effect-level execution truth into view.

## What this PR changes
- Defines canonical tranche-2 contract: `chain_complete = structural_complete && execution_complete`.
- Persists canonical execution truth counters on execution records via `ExecutionTruthSummary`.
- Exposes execution truth fields on gateway boundaries:
  - receipts chain response now includes `structural_complete`, `execution_complete`, and `execution.{total_effects,executed_effects,not_executed_effects,hard_failed_effects}`.
  - execution record response now includes effect counters plus `execution_complete`.
- Updates `icnctl audit verify` checks to separate structural validity from execution completeness and enforce chain-complete contract consistency.
- Adds regression tests for partial vs full execution visibility in gateway and CLI audit paths.

## What this PR does NOT do
- Does not redesign `ExecutionStatus` semantics globally (mixed rows may still aggregate to `Confirmed`).
- Does not implement full provenance/public verifier.
- Does not bind demo flows to this new contract yet.
- Does not redesign all UI/client surfaces.

## Why this approach is correct for Tranche 2
This is the smallest mergeable hardening step after Tranche 1: keep existing execution machinery intact while making boundary surfaces non-ambiguous for operators, scripts, and auditors. It prevents “structurally valid” from being misread as “fully executed” without a larger status-model refactor.

## Known limitations
- `ExecutionStatus::Confirmed` can still exist on mixed execution batches; boundary counters and `execution_complete=false` provide the truth signal.
- Legacy records without persisted summary use conservative fallback (`execution_complete=false`) until re-executed or rewritten.
- Full provenance verifier and demo truth wiring remain out of scope for this tranche.

## Compatibility / caller impact
This PR changes gateway response schemas for receipt-chain and execution endpoints by adding required execution-truth fields. Callers parsing these responses should adapt to:
- consume `structural_complete` and `execution_complete` distinctly,
- treat `chain_complete` as the combined contract signal,
- read effect counters for non-execution / hard-failure visibility.

## Validation
- `cargo fmt --all --check`
- `cargo test -p icn-gateway partial_execution_chain_is_not_complete`
- `cargo test -p icn-gateway full_execution_chain_is_complete`
- `cargo test -p icn-gateway execution_response_exposes_truth_counters`
- `cargo test -p icnctl partial_execution_fails_verification_checks`
- `cargo test -p icnctl full_execution_passes_execution_check`
- `cargo test -p icnctl --test audit_verify_test`
- `cargo check -p icn-kernel-api -p icn-core -p icn-gateway -p icnctl`

Made with [Cursor](https://cursor.com)