### PR TITLE
fix(ci): benchmark baseline job timeout and cache reuse

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -51,14 +51,15 @@ jobs:
         with:
           workspaces: "icn -> target"
           cache-on-failure: true
-          # Add unique suffix to avoid cache key conflicts when multiple runs occur simultaneously
+          # Stable key across main commits so builds reuse target/; lockfile hash still invalidates on dep changes.
           prefix-key: "v0-rust-benchmark"
-          shared-key: "${{ github.sha }}"
+          shared-key: "main-baseline"
 
       - name: Run benchmarks
-        run: cargo bench $BENCH_TARGETS -- --noplot --save-baseline main
+        # Match PR compare job sample size so baseline runs finish reliably after compile.
+        run: cargo bench $BENCH_TARGETS -- --noplot --save-baseline main --sample-size 20
         working-directory: ./icn
-        timeout-minutes: 45
+        timeout-minutes: 90
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## What
The **Benchmarks** workflow was failing on `main` with `Run benchmarks` hitting the **45-minute step timeout**. Logs showed most of the window spent on a cold `cargo` build.

## Why
`rust-cache` used `shared-key: ${{ github.sha }}`, which forces a **new cache key on every push**, so `target/` was rarely restored and each run rebuilt from scratch.

## How
- `shared-key: main-baseline` so restores reuse the previous main build; lockfile-derived key still invalidates when dependencies change.
- `--sample-size 20` on the baseline `cargo bench` line to match the PR compare job (faster, consistent methodology).
- Step timeout **45 → 90** minutes as margin after the above.

## Risk
Low. Baseline artifact sampling is slightly noisier (same as PR path already).

## Test plan
Merge and confirm the next `main` **Save Benchmark Baseline** run completes green.

Made with [Cursor](https://cursor.com)