### PR TITLE
fix(ci): restore green main (icnctl + meaning firewall ratchets)

### DIFF
--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -10357,71 +10357,6 @@ fn verify_receipt_chain(
     checks
 }
 
-#[cfg(test)]
-mod audit_verify_tests {
-    use super::verify_receipt_chain;
-    use icn_gateway::api::receipts::{
-        DecisionExecutionTruthResponse, GovernanceReceiptResponse, GovernanceVoteTallyResponse,
-        ReceiptChainResponse,
-    };
-
-    fn sample_chain(execution_complete: bool, not_executed: usize) -> ReceiptChainResponse {
-        ReceiptChainResponse {
-            decision_hash: "a".repeat(64),
-            governance: Some(GovernanceReceiptResponse {
-                decision_hash: "a".repeat(64),
-                proposal_id: "prop-1".to_string(),
-                domain_id: "domain-1".to_string(),
-                outcome: "Accepted".to_string(),
-                vote_tally: GovernanceVoteTallyResponse {
-                    for_votes: 3,
-                    against_votes: 0,
-                    abstain_votes: 0,
-                },
-                vote_hash: "b".repeat(64),
-            }),
-            allocations: vec![],
-            intents: vec![],
-            structural_complete: true,
-            execution_complete,
-            chain_complete: execution_complete,
-            execution: DecisionExecutionTruthResponse {
-                execution_record_present: true,
-                status: None,
-                total_effects: 1,
-                executed_effects: 1usize.saturating_sub(not_executed),
-                not_executed_effects: not_executed,
-                hard_failed_effects: 0,
-                execution_complete,
-            },
-        }
-    }
-
-    #[test]
-    fn partial_execution_fails_verification_checks() {
-        let chain = sample_chain(false, 1);
-        let checks = verify_receipt_chain(&chain, &"a".repeat(64));
-        assert!(
-            checks
-                .iter()
-                .any(|c| c.name == "Execution complete" && !c.passed),
-            "partial execution must fail execution-complete check"
-        );
-    }
-
-    #[test]
-    fn full_execution_passes_execution_check() {
-        let chain = sample_chain(true, 0);
-        let checks = verify_receipt_chain(&chain, &"a".repeat(64));
-        assert!(
-            checks
-                .iter()
-                .any(|c| c.name == "Execution complete" && c.passed),
-            "full execution must pass execution-complete check"
-        );
-    }
-}
-
 /// Handle audit commands — verify receipt chain integrity.
 ///
 /// Fetches the full receipt chain from the gateway and runs typed verification
@@ -10695,5 +10630,70 @@ async fn handle_preflight_command(
     } else {
         println!("\n✗ Some preflight checks failed. Please address issues above.");
         bail!("Preflight checks failed");
+    }
+}
+
+#[cfg(test)]
+mod audit_verify_tests {
+    use super::verify_receipt_chain;
+    use icn_gateway::api::receipts::{
+        DecisionExecutionTruthResponse, GovernanceReceiptResponse, GovernanceVoteTallyResponse,
+        ReceiptChainResponse,
+    };
+
+    fn sample_chain(execution_complete: bool, not_executed: usize) -> ReceiptChainResponse {
+        ReceiptChainResponse {
+            decision_hash: "a".repeat(64),
+            governance: Some(GovernanceReceiptResponse {
+                decision_hash: "a".repeat(64),
+                proposal_id: "prop-1".to_string(),
+                domain_id: "domain-1".to_string(),
+                outcome: "Accepted".to_string(),
+                vote_tally: GovernanceVoteTallyResponse {
+                    for_votes: 3,
+                    against_votes: 0,
+                    abstain_votes: 0,
+                },
+                vote_hash: "b".repeat(64),
+            }),
+            allocations: vec![],
+            intents: vec![],
+            structural_complete: true,
+            execution_complete,
+            chain_complete: execution_complete,
+            execution: DecisionExecutionTruthResponse {
+                execution_record_present: true,
+                status: None,
+                total_effects: 1,
+                executed_effects: 1usize.saturating_sub(not_executed),
+                not_executed_effects: not_executed,
+                hard_failed_effects: 0,
+                execution_complete,
+            },
+        }
+    }
+
+    #[test]
+    fn partial_execution_fails_verification_checks() {
+        let chain = sample_chain(false, 1);
+        let checks = verify_receipt_chain(&chain, &"a".repeat(64));
+        assert!(
+            checks
+                .iter()
+                .any(|c| c.name == "Execution complete" && !c.passed),
+            "partial execution must fail execution-complete check"
+        );
+    }
+
+    #[test]
+    fn full_execution_passes_execution_check() {
+        let chain = sample_chain(true, 0);
+        let checks = verify_receipt_chain(&chain, &"a".repeat(64));
+        assert!(
+            checks
+                .iter()
+                .any(|c| c.name == "Execution complete" && c.passed),
+            "full execution must pass execution-complete check"
+        );
     }
 }

--- a/icn/crates/icn-core/src/meaning_firewall.rs
+++ b/icn/crates/icn-core/src/meaning_firewall.rs
@@ -250,14 +250,14 @@ mod tests {
     /// - icn-net: CLEAN ✅
     /// - icn-gossip: CLEAN ✅
     /// - icn-ledger: CLEAN ✅
-    /// - icn-gateway: 11 (governance_dashboard, flow_c, steward extracted; commons/treasury/entity residue)
+    /// - icn-gateway: 10 (governance_dashboard, flow_c, steward extracted; commons/treasury/entity residue)
     #[test]
     fn strict_governance_import_violations() {
         let expected: &[(&str, usize)] = &[
             ("icn-net", 0),      // CLEAN ✅
             ("icn-gossip", 0),   // CLEAN ✅
             ("icn-ledger", 0),   // CLEAN ✅
-            ("icn-gateway", 11), // Sprint 14 easy sweep: governance_dashboard, flow_c, steward extracted
+            ("icn-gateway", 10), // Sprint 14 easy sweep: governance_dashboard, flow_c, steward extracted
         ];
 
         for &(crate_name, expected_count) in expected {
@@ -298,10 +298,10 @@ mod tests {
     /// - models.rs comment: CLEANED ✅ (was 1 ref)
     /// - receipt_store.rs test: CLEANED ✅ (was 1 ref)
     /// - commons_store.rs tests: consolidated ✅ (-2 refs)
-    /// - Hard residue: 17 (commons_mgr, commons_store, treasury, entity, receipts, constitutional)
+    /// - Hard residue: 16 (commons_mgr, commons_store, treasury, entity, receipts, constitutional)
     #[test]
     fn strict_gateway_governance_total_refs() {
-        let expected: usize = 17; // Sprint 14 easy sweep: -7 refs from 24
+        let expected: usize = 16; // Sprint 14 easy sweep: -7 refs from 24
         let actual = count_imports_in_crate("icn-gateway", "icn_governance::");
 
         assert!(


### PR DESCRIPTION
## Cause
`main` CI was failing on:
1. **Clippy** — `clippy::items_after_test_module` in `icnctl`: `mod audit_verify_tests` was placed **before** `handle_audit_command` / `handle_preflight_command`, so non-test items followed a test module.
2. **icn-core tests** — `strict_governance_import_violations` and `strict_gateway_governance_total_refs` intentionally panic when counts drop below pins (progress signal). Gateway now has **10** `use icn_governance::` imports and **16** total `icn_governance::` refs.

## Fix
- Move `audit_verify_tests` to **end of file** after `handle_preflight_command`.
- Update ratchet pins: **11→10**, **17→16**.

## Proof (local)
- `cargo fmt --all --check`
- `cargo clippy -p icnctl --all-targets -- -D warnings`
- `cargo test -p icn-core strict_governance --lib` and `strict_gateway_governance --lib`

## Note
**Benchmarks** timeout on `main` is separate; **[#1447](https://github.com/InterCooperative-Network/icn/pull/1447)** addresses that. Merge both to clear all red checks.

Made with [Cursor](https://cursor.com)