### PR TITLE
feat(gateway): wire CommonsManager to sled-backed storage

### DIFF
--- a/icn/crates/icn-gateway/src/commons_mgr.rs
+++ b/icn/crates/icn-gateway/src/commons_mgr.rs
@@ -6,7 +6,7 @@
 //! - Charter management (Layer 2)
 //! - Affiliation/membership management
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use icn_governance::{
     Amendment, AmendmentChange, AmendmentId, AmendmentStatus, Appeal, AppealEvidence, AppealId,
     AppealOutcome, AppealResponse, AppealStatus, Charter, CharterStatus, OrgType, Ratification,
@@ -22,7 +22,9 @@ use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use tracing::{info, warn};
 
-use crate::commons_store::{CommonsStore, CommonsStoreBackend, InMemoryCommonsStore};
+use crate::commons_store::{
+    CommonsStore, CommonsStoreBackend, InMemoryCommonsStore, SledCommonsStore,
+};
 use crate::models::{
     AmendmentsBreakdown, AppealsBreakdown, GovernanceActivityEvent, GovernanceDashboard,
     StewardDetailResponse, StewardSummaryResponse,
@@ -37,7 +39,7 @@ use crate::models::{
 /// - StewardRecords, Amendments, Appeals
 ///
 /// RevocationRegistry is kept separate for now.
-pub struct CommonsManager<S: CommonsStoreBackend = InMemoryCommonsStore> {
+pub struct CommonsManager<S: CommonsStoreBackend = Arc<dyn CommonsStoreBackend>> {
     /// Storage backend
     store: CommonsStore<S>,
 
@@ -45,31 +47,31 @@ pub struct CommonsManager<S: CommonsStoreBackend = InMemoryCommonsStore> {
     revocations: RevocationRegistry,
 }
 
-impl CommonsManager<InMemoryCommonsStore> {
-    /// Create a new commons manager with in-memory storage
+impl CommonsManager<Arc<dyn CommonsStoreBackend>> {
+    /// Create a new commons manager with in-memory storage (testing / no data_dir configured)
     pub fn new() -> Self {
-        let backend = Arc::new(InMemoryCommonsStore::new());
-        Self::with_store(backend)
+        let backend: Arc<dyn CommonsStoreBackend> = Arc::new(InMemoryCommonsStore::new());
+        Self::with_store(Arc::new(backend))
     }
-}
 
-use crate::commons_store::SledCommonsStore;
-
-impl CommonsManager<SledCommonsStore> {
     /// Create a new commons manager with persistent Sled storage
     ///
     /// Data will persist across gateway restarts at the given path.
     pub fn with_sled_path(path: impl AsRef<std::path::Path>) -> Result<Self> {
-        let backend = Arc::new(SledCommonsStore::open(path)?);
-        Ok(Self::with_store(backend))
+        let backend: Arc<dyn CommonsStoreBackend> =
+            Arc::new(SledCommonsStore::open(path).context("Failed to open commons sled store")?);
+        Ok(Self::with_store(Arc::new(backend)))
     }
 
     /// Create a new commons manager with a temporary Sled database
     ///
     /// Useful for testing persistent storage behavior without leaving files.
     pub fn with_sled_temporary() -> Result<Self> {
-        let backend = Arc::new(SledCommonsStore::temporary()?);
-        Ok(Self::with_store(backend))
+        let backend: Arc<dyn CommonsStoreBackend> = Arc::new(
+            SledCommonsStore::temporary()
+                .context("Failed to create temporary commons sled store")?,
+        );
+        Ok(Self::with_store(Arc::new(backend)))
     }
 
     /// Flush all pending writes to disk
@@ -2219,7 +2221,7 @@ impl<S: CommonsStoreBackend> CommonsManager<S> {
     }
 }
 
-impl Default for CommonsManager<InMemoryCommonsStore> {
+impl Default for CommonsManager<Arc<dyn CommonsStoreBackend>> {
     fn default() -> Self {
         Self::new()
     }

--- a/icn/crates/icn-gateway/src/commons_store.rs
+++ b/icn/crates/icn-gateway/src/commons_store.rs
@@ -70,6 +70,31 @@ pub trait CommonsStoreBackend: Send + Sync {
     fn exists(&self, key: &[u8]) -> Result<bool> {
         Ok(self.get(key)?.is_some())
     }
+
+    /// Flush pending writes to durable storage. Default is a no-op for in-memory backends.
+    fn flush(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Allow `Arc<dyn CommonsStoreBackend>` to be used as a backend directly.
+/// This enables type-erased `CommonsManager` construction without changing handler signatures.
+impl CommonsStoreBackend for Arc<dyn CommonsStoreBackend> {
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        self.as_ref().get(key)
+    }
+    fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        self.as_ref().put(key, value)
+    }
+    fn delete(&self, key: &[u8]) -> Result<()> {
+        self.as_ref().delete(key)
+    }
+    fn scan(&self, prefix: &[u8]) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
+        self.as_ref().scan(prefix)
+    }
+    fn flush(&self) -> Result<()> {
+        self.as_ref().flush()
+    }
 }
 
 // ============================================================================
@@ -230,6 +255,11 @@ impl CommonsStoreBackend for SledCommonsStore {
             results.push((k.to_vec(), v.to_vec()));
         }
         Ok(results)
+    }
+
+    fn flush(&self) -> Result<()> {
+        self.db.flush().context("Failed to flush Sled database")?;
+        Ok(())
     }
 }
 

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -39,6 +39,7 @@ use crate::rate_limit::{
 use crate::security::{configure_cors, SecurityConfig, SecurityHeaders};
 use crate::treasury_mgr::{GatewayTreasuryManager, LedgerHandle, TreasuryHandle};
 use crate::trust_mgr::TrustManager;
+use anyhow::Context;
 use icn_compute::ComputeHandle;
 use icn_governance_actor::http::configure as configure_governance;
 use icn_governance_actor::http::configure::GovernanceContext;
@@ -689,16 +690,20 @@ impl GatewayServer {
             crate::service_discovery_mgr::start_expiry_task(service_discovery_manager.clone(), 300);
 
         let federation_manager = Arc::new(FederationManager::new());
-        // TODO: wire CommonsManager to a daemon handle (CommonsHandle) for cross-restart
-        // persistence. Currently all commons/personhood/charter/enrollment state is
-        // in-memory only and will be lost on process restart.
-        // See GovernanceManager::with_handle() for the pattern to follow.
-        warn!(
-            "CommonsManager running in-memory-only mode: \
-             commons/personhood/charter/enrollment state will NOT survive process restart. \
-             Wire a CommonsHandle for production use."
-        );
-        let commons_manager = Arc::new(CommonsManager::new());
+        let commons_manager: Arc<CommonsManager> = if let Some(ref data_dir) = self.data_dir {
+            let commons_path = data_dir.join("commons.sled");
+            info!("CommonsManager: opening sled store at {:?}", commons_path);
+            Arc::new(
+                CommonsManager::with_sled_path(&commons_path)
+                    .context("Failed to open commons sled store")?,
+            )
+        } else {
+            warn!(
+                "CommonsManager: no data_dir configured, running in-memory only — \
+                 commons/personhood/charter/enrollment state will NOT survive process restart"
+            );
+            Arc::new(CommonsManager::new())
+        };
 
         // Setup agreement manager if provided (for inter-cooperative agreements)
         let agreement_manager: Option<icn_federation::agreement::AgreementManagerHandle> =

--- a/icn/crates/icn-gateway/tests/commons_integration.rs
+++ b/icn/crates/icn-gateway/tests/commons_integration.rs
@@ -406,3 +406,111 @@ async fn test_anchor_status_updates() {
     let found = commons_mgr.get_anchor(&anchor_id).await.unwrap().unwrap();
     assert!(matches!(found.status, AnchorStatus::Active));
 }
+
+// ============================================================================
+// Layer 1 — Sled persistence proof tests (drop-and-reopen)
+// ============================================================================
+
+/// Prove that PersonhoodAnchor survives a CommonsManager drop-and-reopen boundary.
+#[actix_web::test]
+async fn test_commons_anchor_survives_sled_drop_and_reopen() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sled_path = tmp.path().join("commons.sled");
+
+    let keypair = icn_identity::KeyPair::generate().unwrap();
+    let did = keypair.did().clone();
+
+    // Phase 1: write
+    let anchor_id = {
+        let mgr = CommonsManager::with_sled_path(&sled_path).expect("open sled");
+        let anchor = mgr.create_anchor_from_enrollment(&did, None).await.unwrap();
+        hex::encode(anchor.id())
+        // mgr drops here — sled lock released
+    };
+
+    // Phase 2: reopen fresh instance
+    let mgr2 = CommonsManager::with_sled_path(&sled_path).expect("reopen sled");
+    let found = mgr2.get_anchor(&anchor_id).await.unwrap();
+    assert!(
+        found.is_some(),
+        "PersonhoodAnchor must survive sled drop-and-reopen"
+    );
+    // Verify the DID-to-anchor index also survived
+    let by_did = mgr2.get_anchor_by_did(&did).await.unwrap();
+    assert!(
+        by_did.is_some(),
+        "DID index must survive sled drop-and-reopen"
+    );
+}
+
+/// Prove that Charter survives a CommonsManager drop-and-reopen boundary.
+#[actix_web::test]
+async fn test_commons_charter_survives_sled_drop_and_reopen() {
+    use icn_governance::{Charter, DisputePolicy, GovernanceConfig, MembershipPolicy, OrgType};
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sled_path = tmp.path().join("commons.sled");
+
+    // Phase 1: write
+    let charter_id = {
+        let mgr = CommonsManager::with_sled_path(&sled_path).expect("open sled");
+        let charter = Charter::new(
+            OrgType::Cooperative,
+            "coop:persist-test".to_string(),
+            "Persistence Test Coop".to_string(),
+            GovernanceConfig::cooperative_default(),
+            MembershipPolicy::default(),
+            DisputePolicy::default(),
+        );
+        let id = charter.charter_id.to_hex();
+        mgr.store_charter(charter).await.unwrap();
+        id
+        // mgr drops here
+    };
+
+    // Phase 2: reopen fresh instance
+    let mgr2 = CommonsManager::with_sled_path(&sled_path).expect("reopen sled");
+    let found = mgr2.get_charter(&charter_id).await.unwrap();
+    assert!(found.is_some(), "Charter must survive sled drop-and-reopen");
+    assert_eq!(
+        found.unwrap().name,
+        "Persistence Test Coop",
+        "name must survive round-trip"
+    );
+}
+
+/// Prove that CommonsHolderRecord survives a CommonsManager drop-and-reopen boundary.
+#[actix_web::test]
+async fn test_commons_holder_survives_sled_drop_and_reopen() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sled_path = tmp.path().join("commons.sled");
+
+    let keypair = icn_identity::KeyPair::generate().unwrap();
+    let did = keypair.did().clone();
+
+    // Phase 1: write anchor + holder
+    let holder_id = {
+        let mgr = CommonsManager::with_sled_path(&sled_path).expect("open sled");
+        let anchor = mgr.create_anchor_from_enrollment(&did, None).await.unwrap();
+        let anchor_id = hex::encode(anchor.id());
+        let holder = mgr
+            .create_holder_from_anchor(&anchor_id, &did)
+            .await
+            .unwrap();
+        hex::encode(holder.id())
+        // mgr drops here
+    };
+
+    // Phase 2: reopen fresh instance
+    let mgr2 = CommonsManager::with_sled_path(&sled_path).expect("reopen sled");
+    let found = mgr2.get_holder(&holder_id).await.unwrap();
+    assert!(
+        found.is_some(),
+        "CommonsHolderRecord must survive sled drop-and-reopen"
+    );
+    let found_holder = found.unwrap();
+    assert_eq!(
+        found_holder.holder_did, did,
+        "holder_did must survive round-trip"
+    );
+}


### PR DESCRIPTION
## Summary

- Replace `CommonsManager<InMemoryCommonsStore>` default with type-erased `Arc<dyn CommonsStoreBackend>` backend — zero handler-file changes (13 handlers unchanged)
- `server.rs` opens `commons.sled` when `data_dir` is configured; falls back to in-memory with warning when not set
- Add drop-and-reopen persistence proof tests for anchor, charter, and holder state (Layer 1)

## What was lost on restart before this PR

`PersonhoodAnchor`, `CommonsHolderRecord`, `Charter`, `StewardRecord`, `Amendment`, `Appeal`, and `EnrollmentSession` records — all of it gone on every gateway restart.

## Implementation notes

- Blanket `impl CommonsStoreBackend for Arc<dyn CommonsStoreBackend>` enables the type erasure without touching handler signatures
- `flush()` added as default no-op to the trait; `SledCommonsStore` overrides with real sled flush
- `commons.sled` path is distinct from `gateway_store`, `entity_audit_store`, `oracle_store` (no lock collision)
- `Default for CommonsManager` updated to match new default type parameter

## Out of scope

- `RevocationRegistry` persistence (in-memory by design)
- `CommonsHandle` actor pattern (daemon-owned canonical truth) — next tranche
- Cross-node gossip sync of commons state

## Test plan

- [x] `cargo test -p icn-gateway --lib -- commons_store` — 4 inline tests pass
- [x] `cargo test -p icn-gateway` — all integration tests pass including 3 new drop-and-reopen proofs
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p icn-gateway --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)