### PR TITLE
feat(commons): introduce icn-commons substrate crate with CommonsHandle actor boundary

### DIFF
--- a/docs/api/openapi.generated.yaml
+++ b/docs/api/openapi.generated.yaml
@@ -258,10 +258,6 @@ components:
       required:
       - jurisdiction_id
       properties:
-        capabilities_requested:
-          type: array
-          items:
-            type: string
         jurisdiction_id:
           type: string
     BanMemberRequest:

--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -2864,6 +2864,7 @@ name = "icn-commons"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ed25519-dalek",
  "hex",
  "icn-governance",
  "icn-identity",
@@ -2992,6 +2993,7 @@ dependencies = [
  "futures",
  "hex",
  "icn-ccl",
+ "icn-commons",
  "icn-community",
  "icn-compute",
  "icn-coop",

--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -2860,6 +2860,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "icn-commons"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "hex",
+ "icn-governance",
+ "icn-identity",
+ "icn-obs",
+ "icn-time",
+ "lru",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sled",
+ "tempfile",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "icn-community"
 version = "0.1.0"
 dependencies = [
@@ -3134,6 +3155,7 @@ dependencies = [
  "hex",
  "icn-api",
  "icn-ccl",
+ "icn-commons",
  "icn-community",
  "icn-compute",
  "icn-coop",

--- a/icn/Cargo.toml
+++ b/icn/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "apps/membership",
     "apps/ledger",
     "crates/icn-http-kit",
+    "crates/icn-commons",
 ]
 
 [workspace.package]
@@ -148,6 +149,7 @@ icn-coop = { path = "crates/icn-coop" }
 icn-api = { path = "crates/icn-api" }
 icn-naming = { path = "crates/icn-naming" }
 icn-authz = { path = "crates/icn-authz" }
+icn-commons = { path = "crates/icn-commons" }
 
 [workspace.lints.clippy]
 # Error handling - warn for now, will be upgraded to deny after cleanup

--- a/icn/crates/icn-commons/Cargo.toml
+++ b/icn/crates/icn-commons/Cargo.toml
@@ -28,3 +28,5 @@ icn-time = { path = "../icn-time" }
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["full"] }
+hex = "0.4"
+ed25519-dalek.workspace = true

--- a/icn/crates/icn-commons/Cargo.toml
+++ b/icn/crates/icn-commons/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "icn-commons"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+sha2 = "0.10"
+tracing = "0.1"
+lru = "0.16"
+sled = { workspace = true }
+tokio = { version = "1", features = ["sync"] }
+hex = "0.4"
+rand = "0.8"
+serde_json = "1"
+
+icn-identity = { path = "../icn-identity" }
+icn-governance = { path = "../icn-governance" }
+icn-obs = { path = "../icn-obs" }
+icn-time = { path = "../icn-time" }
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["full"] }

--- a/icn/crates/icn-commons/src/handle.rs
+++ b/icn/crates/icn-commons/src/handle.rs
@@ -621,16 +621,17 @@ impl CommonsHandle {
     /// Apply for membership in a jurisdiction.
     ///
     /// Sybil resistance: requires at least `POPLevel::Strong` to apply.
+    /// No capabilities are granted at application time; capabilities originate
+    /// from jurisdictional approval and delegation only.
     pub async fn apply_for_membership(
         &self,
         holder_id: &str,
         jurisdiction_id: JurisdictionId,
-        capabilities_requested: Vec<MembershipCapability>,
     ) -> Result<Affiliation> {
         self.inner
             .write()
             .await
-            .apply_for_membership(holder_id, jurisdiction_id, capabilities_requested)
+            .apply_for_membership(holder_id, jurisdiction_id)
             .await
     }
 

--- a/icn/crates/icn-commons/src/handle.rs
+++ b/icn/crates/icn-commons/src/handle.rs
@@ -775,6 +775,30 @@ impl CommonsHandle {
 // ============================================================================
 
 impl CommonsHandle {
+    /// List amendments scoped to a specific domain (exact jurisdiction match).
+    pub async fn list_amendments_by_domain(
+        &self,
+        domain_id: &str,
+    ) -> Result<Vec<icn_governance::Amendment>> {
+        self.inner
+            .read()
+            .await
+            .list_amendments_by_domain(domain_id)
+            .await
+    }
+
+    /// List appeals scoped to a specific domain (exact jurisdiction match).
+    pub async fn list_appeals_by_domain(
+        &self,
+        domain_id: &str,
+    ) -> Result<Vec<icn_governance::Appeal>> {
+        self.inner
+            .read()
+            .await
+            .list_appeals_by_domain(domain_id)
+            .await
+    }
+
     /// Store an amendment.
     pub async fn store_amendment(&self, amendment: Amendment) -> Result<()> {
         self.inner.write().await.store_amendment(amendment).await

--- a/icn/crates/icn-commons/src/handle.rs
+++ b/icn/crates/icn-commons/src/handle.rs
@@ -1,0 +1,943 @@
+//! CommonsHandle — clone-safe actor handle for CommonsInner
+//!
+//! All operations are serialized through a `tokio::sync::RwLock`:
+//! - mutations acquire a write lock
+//! - reads acquire a read lock
+//!
+//! This is the single canonical owner of commons state. The gateway's
+//! `CommonsManager` delegates all operations through this handle.
+
+use crate::inner::CommonsInner;
+use crate::store::{CommonsStoreBackend, InMemoryCommonsStore, SledCommonsStore};
+use anyhow::{Context, Result};
+use icn_governance::{
+    Amendment, AmendmentChange, AmendmentId, Appeal, AppealEvidence, AppealId, AppealOutcome,
+    AppealResponse, Charter, CharterStatus, OrgType, Ratification, StewardRecord,
+};
+use icn_identity::{
+    Affiliation, AnchorStatus, CommonsHolderRecord, CommonsRevocationReason, Did, HolderStatus,
+    JurisdictionId, MembershipCapability, MembershipStatus, POPAttestation, PersonhoodAnchor,
+    RevocationRecord, RevocationScope, RevocationType,
+};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Actor handle for [`CommonsInner`].
+///
+/// Clone-safe. All operations are serialized through an `RwLock`:
+/// - mutations use write lock
+/// - reads use read lock
+///
+/// This is the single canonical owner of commons state. The gateway's
+/// `CommonsManager` delegates all operations through this handle.
+#[derive(Clone)]
+pub struct CommonsHandle {
+    inner: Arc<RwLock<CommonsInner>>,
+}
+
+// ============================================================================
+// Constructors
+// ============================================================================
+
+impl CommonsHandle {
+    /// Create a handle backed by an in-memory store (testing/dev).
+    pub fn new_in_memory() -> Self {
+        let backend: Arc<dyn CommonsStoreBackend> = Arc::new(InMemoryCommonsStore::new());
+        CommonsHandle {
+            inner: Arc::new(RwLock::new(CommonsInner::new(backend))),
+        }
+    }
+
+    /// Create a handle backed by a sled store at the given path.
+    pub fn with_sled_path(path: impl AsRef<std::path::Path>) -> Result<Self> {
+        let backend: Arc<dyn CommonsStoreBackend> =
+            Arc::new(SledCommonsStore::open(path).context("Failed to open commons sled store")?);
+        Ok(CommonsHandle {
+            inner: Arc::new(RwLock::new(CommonsInner::new(backend))),
+        })
+    }
+
+    /// Create a handle backed by a temporary sled store (useful in tests that
+    /// need real persistence behavior without drop-and-reopen).
+    pub fn with_sled_temporary() -> Result<Self> {
+        let backend: Arc<dyn CommonsStoreBackend> = Arc::new(
+            SledCommonsStore::temporary()
+                .context("Failed to create temporary commons sled store")?,
+        );
+        Ok(CommonsHandle {
+            inner: Arc::new(RwLock::new(CommonsInner::new(backend))),
+        })
+    }
+}
+
+impl CommonsHandle {
+    /// Flush pending writes to durable storage.
+    pub async fn flush(&self) -> Result<()> {
+        self.inner.read().await.flush()
+    }
+}
+
+// ============================================================================
+// PersonhoodAnchor Operations (Layer 0)
+// ============================================================================
+
+impl CommonsHandle {
+    /// Create a new PersonhoodAnchor from enrollment completion.
+    pub async fn create_anchor_from_enrollment(
+        &self,
+        did: &Did,
+        steward_did: Option<&Did>,
+    ) -> Result<PersonhoodAnchor> {
+        self.inner
+            .write()
+            .await
+            .create_anchor_from_enrollment(did, steward_did)
+            .await
+    }
+
+    /// Get a PersonhoodAnchor by ID.
+    pub async fn get_anchor(&self, anchor_id: &str) -> Result<Option<PersonhoodAnchor>> {
+        self.inner.read().await.get_anchor(anchor_id).await
+    }
+
+    /// Get a PersonhoodAnchor by DID.
+    pub async fn get_anchor_by_did(&self, did: &Did) -> Result<Option<PersonhoodAnchor>> {
+        self.inner.read().await.get_anchor_by_did(did).await
+    }
+
+    /// Update anchor status.
+    pub async fn update_anchor_status(&self, anchor_id: &str, status: AnchorStatus) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .update_anchor_status(anchor_id, status)
+            .await
+    }
+
+    /// Add an attestation to an anchor.
+    pub async fn add_attestation(
+        &self,
+        anchor_id: &str,
+        attestation: POPAttestation,
+    ) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .add_attestation(anchor_id, attestation)
+            .await
+    }
+}
+
+// ============================================================================
+// CommonsHolderRecord Operations (Layer 1)
+// ============================================================================
+
+impl CommonsHandle {
+    /// Create a CommonsHolderRecord from an anchor.
+    pub async fn create_holder_from_anchor(
+        &self,
+        anchor_id: &str,
+        did: &Did,
+    ) -> Result<CommonsHolderRecord> {
+        self.inner
+            .write()
+            .await
+            .create_holder_from_anchor(anchor_id, did)
+            .await
+    }
+
+    /// Create a CommonsHolderRecord from an anchor with an optional display name.
+    pub async fn create_holder_from_anchor_with_name(
+        &self,
+        anchor_id: &str,
+        did: &Did,
+        display_name: Option<String>,
+    ) -> Result<CommonsHolderRecord> {
+        self.inner
+            .write()
+            .await
+            .create_holder_from_anchor_with_name(anchor_id, did, display_name)
+            .await
+    }
+
+    /// Get a CommonsHolderRecord by ID.
+    pub async fn get_holder(&self, holder_id: &str) -> Result<Option<CommonsHolderRecord>> {
+        self.inner.read().await.get_holder(holder_id).await
+    }
+
+    /// Get a CommonsHolderRecord by DID.
+    pub async fn get_holder_by_did(&self, did: &Did) -> Result<Option<CommonsHolderRecord>> {
+        self.inner.read().await.get_holder_by_did(did).await
+    }
+
+    /// Update the display name for a holder identified by DID.
+    /// If no holder record exists yet, creates a minimal holder record directly.
+    pub async fn update_display_name(&self, did: &Did, display_name: String) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .update_display_name(did, display_name)
+            .await
+    }
+
+    /// Get or create a CommonsHolderRecord (idempotent).
+    pub async fn get_or_create_holder(
+        &self,
+        anchor_id: &str,
+        did: &Did,
+        display_name: Option<String>,
+    ) -> Result<CommonsHolderRecord> {
+        self.inner
+            .write()
+            .await
+            .get_or_create_holder(anchor_id, did, display_name)
+            .await
+    }
+
+    /// Update holder status.
+    pub async fn update_holder_status(&self, holder_id: &str, status: HolderStatus) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .update_holder_status(holder_id, status)
+            .await
+    }
+}
+
+// ============================================================================
+// Affiliation Operations
+// ============================================================================
+
+impl CommonsHandle {
+    /// Add an affiliation (join jurisdiction).
+    ///
+    /// Sybil resistance: requires at least `POPLevel::Strong` to join.
+    pub async fn join_jurisdiction(
+        &self,
+        holder_id: &str,
+        jurisdiction: JurisdictionId,
+        initial_capabilities: Vec<MembershipCapability>,
+    ) -> Result<Affiliation> {
+        self.inner
+            .write()
+            .await
+            .join_jurisdiction(holder_id, jurisdiction, initial_capabilities)
+            .await
+    }
+
+    /// Leave a jurisdiction.
+    pub async fn leave_jurisdiction(
+        &self,
+        holder_id: &str,
+        jurisdiction: &JurisdictionId,
+    ) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .leave_jurisdiction(holder_id, jurisdiction)
+            .await
+    }
+
+    /// Update affiliation status (e.g., Candidate -> Member).
+    pub async fn update_affiliation_status(
+        &self,
+        holder_id: &str,
+        jurisdiction: &JurisdictionId,
+        status: MembershipStatus,
+    ) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .update_affiliation_status(holder_id, jurisdiction, status)
+            .await
+    }
+
+    /// List affiliations for a holder.
+    pub async fn list_affiliations(&self, holder_id: &str) -> Result<Vec<Affiliation>> {
+        self.inner.read().await.list_affiliations(holder_id).await
+    }
+}
+
+// ============================================================================
+// Charter Operations (Layer 2)
+// ============================================================================
+
+impl CommonsHandle {
+    /// Store a charter.
+    pub async fn store_charter(&self, charter: Charter) -> Result<()> {
+        self.inner.write().await.store_charter(charter).await
+    }
+
+    /// Get a charter by ID.
+    pub async fn get_charter(&self, charter_id: &str) -> Result<Option<Charter>> {
+        self.inner.read().await.get_charter(charter_id).await
+    }
+
+    /// Get a charter by domain ID.
+    pub async fn get_charter_by_domain(&self, domain_id: &str) -> Result<Option<Charter>> {
+        self.inner
+            .read()
+            .await
+            .get_charter_by_domain(domain_id)
+            .await
+    }
+
+    /// List all charters with optional filters.
+    pub async fn list_charters(
+        &self,
+        org_type: Option<OrgType>,
+        status: Option<CharterStatus>,
+    ) -> Result<Vec<Charter>> {
+        self.inner
+            .read()
+            .await
+            .list_charters(org_type, status)
+            .await
+    }
+
+    /// Add a founder signature to a charter.
+    pub async fn add_charter_signature(
+        &self,
+        charter_id: &str,
+        signature: icn_governance::FounderSignature,
+    ) -> Result<Charter> {
+        self.inner
+            .write()
+            .await
+            .add_charter_signature(charter_id, signature)
+            .await
+    }
+
+    /// Update charter status.
+    pub async fn update_charter_status(
+        &self,
+        charter_id: &str,
+        status: CharterStatus,
+    ) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .update_charter_status(charter_id, status)
+            .await
+    }
+}
+
+// ============================================================================
+// Steward Operations
+// ============================================================================
+
+impl CommonsHandle {
+    /// Register a new steward from a Commons Holder.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn register_steward(
+        &self,
+        holder_did: &Did,
+        steward_did: &Did,
+        term_duration_days: u64,
+        bond_amount: u64,
+        governance_approval: String,
+        jurisdiction: Option<String>,
+        specializations: Vec<String>,
+    ) -> Result<StewardRecord> {
+        self.inner
+            .write()
+            .await
+            .register_steward(
+                holder_did,
+                steward_did,
+                term_duration_days,
+                bond_amount,
+                governance_approval,
+                jurisdiction,
+                specializations,
+            )
+            .await
+    }
+
+    /// Store a steward record.
+    pub async fn store_steward(&self, steward: StewardRecord) -> Result<()> {
+        self.inner.write().await.store_steward(steward).await
+    }
+
+    /// Get a steward by ID.
+    pub async fn get_steward(&self, steward_id: &str) -> Result<Option<StewardRecord>> {
+        self.inner.read().await.get_steward(steward_id).await
+    }
+
+    /// Get a steward by DID.
+    pub async fn get_steward_by_did(&self, did: &Did) -> Result<Option<StewardRecord>> {
+        self.inner.read().await.get_steward_by_did(did).await
+    }
+
+    /// List all stewards with optional filters.
+    pub async fn list_stewards(
+        &self,
+        active_only: bool,
+        jurisdiction: Option<&str>,
+    ) -> Result<Vec<StewardRecord>> {
+        self.inner
+            .read()
+            .await
+            .list_stewards(active_only, jurisdiction)
+            .await
+    }
+
+    /// List stewards who can issue attestations.
+    pub async fn list_attesters(&self) -> Result<Vec<StewardRecord>> {
+        self.inner.read().await.list_attesters().await
+    }
+
+    /// Check if a DID belongs to an active steward.
+    pub async fn is_active_steward(&self, did: &Did) -> Result<bool> {
+        self.inner.read().await.is_active_steward(did).await
+    }
+
+    /// Suspend a steward.
+    pub async fn suspend_steward(&self, steward_id: &str, reason: String) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .suspend_steward(steward_id, reason)
+            .await
+    }
+
+    /// Reinstate a suspended steward.
+    pub async fn reinstate_steward(&self, steward_id: &str) -> Result<bool> {
+        self.inner.write().await.reinstate_steward(steward_id).await
+    }
+
+    /// Retire a steward.
+    pub async fn retire_steward(&self, steward_id: &str) -> Result<()> {
+        self.inner.write().await.retire_steward(steward_id).await
+    }
+
+    /// Revoke a steward for cause.
+    pub async fn revoke_steward(
+        &self,
+        steward_id: &str,
+        reason: String,
+        evidence: Vec<[u8; 32]>,
+    ) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .revoke_steward(steward_id, reason, evidence)
+            .await
+    }
+
+    /// Record an attestation issued by a steward.
+    pub async fn record_steward_attestation(&self, steward_id: &str) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .record_steward_attestation(steward_id)
+            .await
+    }
+
+    /// Record a dispute against a steward's attestation.
+    pub async fn record_steward_dispute(&self, steward_id: &str) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .record_steward_dispute(steward_id)
+            .await
+    }
+
+    /// Record a dispute won by a steward.
+    pub async fn record_steward_dispute_won(&self, steward_id: &str) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .record_steward_dispute_won(steward_id)
+            .await
+    }
+
+    /// Extend a steward's term.
+    pub async fn extend_steward_term(&self, steward_id: &str, new_term_end: u64) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .extend_steward_term(steward_id, new_term_end)
+            .await
+    }
+
+    /// Add to a steward's bond.
+    pub async fn add_steward_bond(&self, steward_id: &str, amount: u64) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .add_steward_bond(steward_id, amount)
+            .await
+    }
+
+    /// Slash a steward's bond.
+    pub async fn slash_steward_bond(&self, steward_id: &str, amount: u64) -> Result<u64> {
+        self.inner
+            .write()
+            .await
+            .slash_steward_bond(steward_id, amount)
+            .await
+    }
+}
+
+// ============================================================================
+// Revocation Operations
+// ============================================================================
+
+impl CommonsHandle {
+    /// Add a revocation record.
+    pub async fn add_revocation(&self, record: RevocationRecord) -> Result<()> {
+        self.inner.write().await.add_revocation(record).await
+    }
+
+    /// Check if a target is revoked.
+    pub async fn check_revocation(&self, target_id: &str) -> icn_identity::RevocationCheck {
+        self.inner.read().await.check_revocation(target_id).await
+    }
+
+    /// Check if a target is revoked at a specific scope.
+    pub async fn check_revocation_at_scope(
+        &self,
+        target_id: &str,
+        scope: &RevocationScope,
+    ) -> icn_identity::RevocationCheck {
+        self.inner
+            .read()
+            .await
+            .check_revocation_at_scope(target_id, scope)
+            .await
+    }
+
+    /// Get a revocation record by ID.
+    pub async fn get_revocation(&self, revocation_id: &str) -> Option<RevocationRecord> {
+        self.inner.read().await.get_revocation(revocation_id).await
+    }
+
+    /// List all revocations for a target.
+    pub async fn list_revocations_for_target(&self, target_id: &str) -> Vec<RevocationRecord> {
+        self.inner
+            .read()
+            .await
+            .list_revocations_for_target(target_id)
+            .await
+    }
+
+    /// List all revocations by type.
+    pub async fn list_revocations_by_type(
+        &self,
+        target_type: RevocationType,
+    ) -> Vec<RevocationRecord> {
+        self.inner
+            .read()
+            .await
+            .list_revocations_by_type(target_type)
+            .await
+    }
+
+    /// List all pending appeals.
+    pub async fn list_pending_appeals(&self) -> Vec<RevocationRecord> {
+        self.inner.read().await.list_pending_appeals().await
+    }
+
+    /// File an appeal for a revocation.
+    pub async fn file_appeal(&self, revocation_id: &str, reason: String) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .file_appeal(revocation_id, reason)
+            .await
+    }
+
+    /// Resolve an appeal.
+    pub async fn resolve_appeal(
+        &self,
+        revocation_id: &str,
+        upheld: bool,
+        resolution_notes: String,
+    ) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .resolve_appeal(revocation_id, upheld, resolution_notes)
+            .await
+    }
+
+    /// Revoke a membership with proper due process.
+    pub async fn revoke_membership(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+        authority: Did,
+        reason: CommonsRevocationReason,
+        appeal_window_days: u64,
+    ) -> Result<RevocationRecord> {
+        self.inner
+            .write()
+            .await
+            .revoke_membership(
+                holder_id,
+                jurisdiction_id,
+                authority,
+                reason,
+                appeal_window_days,
+            )
+            .await
+    }
+
+    /// Ban a member immediately (severe violations).
+    pub async fn ban_member(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+        authority: Did,
+        reason: CommonsRevocationReason,
+    ) -> Result<RevocationRecord> {
+        self.inner
+            .write()
+            .await
+            .ban_member(holder_id, jurisdiction_id, authority, reason)
+            .await
+    }
+
+    /// Check if a member is revoked in a jurisdiction.
+    pub async fn is_member_revoked(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+    ) -> bool {
+        self.inner
+            .read()
+            .await
+            .is_member_revoked(holder_id, jurisdiction_id)
+            .await
+    }
+}
+
+// ============================================================================
+// Membership Management Operations
+// ============================================================================
+
+impl CommonsHandle {
+    /// Apply for membership in a jurisdiction.
+    ///
+    /// Sybil resistance: requires at least `POPLevel::Strong` to apply.
+    pub async fn apply_for_membership(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: JurisdictionId,
+        capabilities_requested: Vec<MembershipCapability>,
+    ) -> Result<Affiliation> {
+        self.inner
+            .write()
+            .await
+            .apply_for_membership(holder_id, jurisdiction_id, capabilities_requested)
+            .await
+    }
+
+    /// Approve a membership application (moves from Candidate to Provisional).
+    pub async fn approve_membership(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+    ) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .approve_membership(holder_id, jurisdiction_id)
+            .await
+    }
+
+    /// Promote a member from Provisional to full Member.
+    pub async fn promote_member(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+    ) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .promote_member(holder_id, jurisdiction_id)
+            .await
+    }
+
+    /// Suspend a member.
+    pub async fn suspend_member(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+    ) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .suspend_member(holder_id, jurisdiction_id)
+            .await
+    }
+
+    /// Reinstate a suspended member.
+    pub async fn reinstate_member(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+    ) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .reinstate_member(holder_id, jurisdiction_id)
+            .await
+    }
+
+    /// Grant a capability to a member.
+    pub async fn grant_capability(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+        capability: MembershipCapability,
+    ) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .grant_capability(holder_id, jurisdiction_id, capability)
+            .await
+    }
+
+    /// Revoke a capability from a member.
+    pub async fn revoke_capability(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+        capability: MembershipCapability,
+    ) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .revoke_capability(holder_id, jurisdiction_id, capability)
+            .await
+    }
+
+    /// Add a role to a member.
+    pub async fn add_member_role(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+        role: String,
+    ) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .add_member_role(holder_id, jurisdiction_id, role)
+            .await
+    }
+
+    /// Remove a role from a member.
+    pub async fn remove_member_role(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+        role: &str,
+    ) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .remove_member_role(holder_id, jurisdiction_id, role)
+            .await
+    }
+
+    /// Check if a member has a specific capability.
+    pub async fn member_has_capability(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+        capability: MembershipCapability,
+    ) -> Result<bool> {
+        self.inner
+            .read()
+            .await
+            .member_has_capability(holder_id, jurisdiction_id, capability)
+            .await
+    }
+
+    /// List members of a jurisdiction by status.
+    pub async fn list_members_by_status(
+        &self,
+        jurisdiction_id: &JurisdictionId,
+        status: Option<MembershipStatus>,
+    ) -> Vec<(String, Affiliation)> {
+        self.inner
+            .read()
+            .await
+            .list_members_by_status(jurisdiction_id, status)
+            .await
+    }
+}
+
+// ============================================================================
+// Amendment Operations
+// ============================================================================
+
+impl CommonsHandle {
+    /// Store an amendment.
+    pub async fn store_amendment(&self, amendment: Amendment) -> Result<()> {
+        self.inner.write().await.store_amendment(amendment).await
+    }
+
+    /// Add a change to a draft amendment.
+    pub async fn add_amendment_change(
+        &self,
+        amendment_id: &str,
+        change: AmendmentChange,
+    ) -> Result<Amendment> {
+        self.inner
+            .write()
+            .await
+            .add_amendment_change(amendment_id, change)
+            .await
+    }
+
+    /// Get an amendment by ID.
+    pub async fn get_amendment(&self, id: &AmendmentId) -> Result<Option<Amendment>> {
+        self.inner.read().await.get_amendment(id).await
+    }
+
+    /// List amendments with optional filters.
+    pub async fn list_amendments(
+        &self,
+        status: Option<&str>,
+        scope: Option<&str>,
+        amendment_type: Option<&str>,
+    ) -> Result<Vec<Amendment>> {
+        self.inner
+            .read()
+            .await
+            .list_amendments(status, scope, amendment_type)
+            .await
+    }
+
+    /// Submit an amendment for review.
+    pub async fn submit_amendment(&self, id: &AmendmentId, caller: &Did) -> Result<Amendment> {
+        self.inner.write().await.submit_amendment(id, caller).await
+    }
+
+    /// Open voting on an amendment (skipping review for simple cases).
+    pub async fn open_amendment_voting(&self, id: &AmendmentId, caller: &Did) -> Result<Amendment> {
+        self.inner
+            .write()
+            .await
+            .open_amendment_voting(id, caller)
+            .await
+    }
+
+    /// Add a ratification to an amendment.
+    pub async fn add_amendment_ratification(
+        &self,
+        id: &AmendmentId,
+        ratification: Ratification,
+    ) -> Result<Amendment> {
+        self.inner
+            .write()
+            .await
+            .add_amendment_ratification(id, ratification)
+            .await
+    }
+
+    /// Withdraw an amendment.
+    pub async fn withdraw_amendment(
+        &self,
+        id: &AmendmentId,
+        caller: &Did,
+        reason: String,
+    ) -> Result<Amendment> {
+        self.inner
+            .write()
+            .await
+            .withdraw_amendment(id, caller, reason)
+            .await
+    }
+}
+
+// ============================================================================
+// Appeal Operations
+// ============================================================================
+
+impl CommonsHandle {
+    /// Store an appeal.
+    pub async fn store_appeal(&self, appeal: Appeal) -> Result<()> {
+        self.inner.write().await.store_appeal(appeal).await
+    }
+
+    /// Get an appeal by ID.
+    pub async fn get_appeal(&self, id: &AppealId) -> Result<Option<Appeal>> {
+        self.inner.read().await.get_appeal(id).await
+    }
+
+    /// List appeals with optional filters.
+    pub async fn list_appeals(
+        &self,
+        status: Option<&str>,
+        scope: Option<&str>,
+        appellant: Option<&str>,
+    ) -> Result<Vec<Appeal>> {
+        self.inner
+            .read()
+            .await
+            .list_appeals(status, scope, appellant)
+            .await
+    }
+
+    /// Add evidence to an appeal.
+    pub async fn add_appeal_evidence(
+        &self,
+        id: &AppealId,
+        evidence: AppealEvidence,
+    ) -> Result<Appeal> {
+        self.inner
+            .write()
+            .await
+            .add_appeal_evidence(id, evidence)
+            .await
+    }
+
+    /// Add response to an appeal.
+    pub async fn add_appeal_response(
+        &self,
+        id: &AppealId,
+        response: AppealResponse,
+    ) -> Result<Appeal> {
+        self.inner
+            .write()
+            .await
+            .add_appeal_response(id, response)
+            .await
+    }
+
+    /// Begin review of an appeal.
+    pub async fn begin_appeal_review(&self, id: &AppealId) -> Result<Appeal> {
+        self.inner.write().await.begin_appeal_review(id).await
+    }
+
+    /// Resolve a constitutional appeal with outcome.
+    pub async fn resolve_constitutional_appeal(
+        &self,
+        id: &AppealId,
+        outcome: AppealOutcome,
+    ) -> Result<Appeal> {
+        self.inner
+            .write()
+            .await
+            .resolve_constitutional_appeal(id, outcome)
+            .await
+    }
+
+    /// Withdraw an appeal.
+    pub async fn withdraw_appeal(
+        &self,
+        id: &AppealId,
+        caller: &Did,
+        reason: Option<String>,
+    ) -> Result<Appeal> {
+        self.inner
+            .write()
+            .await
+            .withdraw_appeal(id, caller, reason)
+            .await
+    }
+}

--- a/icn/crates/icn-commons/src/inner.rs
+++ b/icn/crates/icn-commons/src/inner.rs
@@ -605,14 +605,35 @@ impl CommonsInner {
 
     // ========== Charter Operations (Layer 2) ==========
 
-    /// Store a charter
+    /// Store a charter.
+    ///
+    /// # Invariants enforced
+    ///
+    /// - **Charter ID uniqueness**: a charter with the same `charter_id` may not be stored twice.
+    /// - **Domain uniqueness**: each `domain_id` may have at most one charter. Storing a second
+    ///   charter for the same domain would make domain-scoped queries ambiguous.
     pub async fn store_charter(&self, charter: Charter) -> Result<()> {
         let charter_id = charter.charter_id.to_hex();
         let org_type = format!("{:?}", charter.org_type);
 
-        // Check if charter already exists
+        // Check if charter already exists by ID
         if self.store.get_charter(&charter_id)?.is_some() {
             bail!("Charter already exists: {charter_id}");
+        }
+
+        // Enforce domain uniqueness: one charter per domain_id.
+        // Without this check two charters could share a domain_id, making
+        // get_charter_by_domain and all domain-scoped queries undefined.
+        if self
+            .store
+            .get_charter_by_domain(&charter.domain_id)?
+            .is_some()
+        {
+            bail!(
+                "A charter already exists for domain '{}'. \
+                 Each domain may have at most one charter.",
+                charter.domain_id
+            );
         }
 
         // Store charter (this also updates the domain index)
@@ -812,8 +833,17 @@ impl CommonsInner {
             governance_approval,
         );
 
-        // Set optional fields
+        // Set optional fields.
+        // If a jurisdiction is specified, validate it corresponds to an existing charter domain
+        // so stewards cannot be bound to phantom jurisdictions.
         if let Some(ref j) = jurisdiction {
+            if self.store.get_charter_by_domain(j)?.is_none() {
+                bail!(
+                    "Steward jurisdiction '{}' does not correspond to any known charter domain. \
+                     Create the charter for this domain before assigning stewards to it.",
+                    j
+                );
+            }
             steward.jurisdiction = Some(j.clone());
         }
         for spec in specializations {
@@ -1605,10 +1635,58 @@ impl CommonsInner {
 
     // ========== Amendment Operations (v0.6.0 Constitutional Governance) ==========
 
-    /// Store an amendment
+    /// Store an amendment.
+    ///
+    /// # Invariants enforced
+    ///
+    /// - **Jurisdiction scope references an existing domain**: if the amendment's scope is
+    ///   `Jurisdiction { domain_id }`, a charter with that `domain_id` must already exist.
+    ///   This prevents phantom-domain amendments that can never be queried correctly.
+    ///
+    /// - **charter_id/scope coherence**: if a `charter_id` is also provided, the charter it
+    ///   identifies must have a `domain_id` that matches the amendment's `scope.domain_id`.
+    ///   Cross-domain scope (amendment claiming to belong to charter A but scoped to domain B)
+    ///   is rejected.
     pub async fn store_amendment(&self, amendment: Amendment) -> Result<()> {
         let amendment_id = amendment.id.to_hex();
         let proposer = amendment.proposer.to_string();
+
+        // Enforce scope coherence for jurisdiction-scoped amendments.
+        if let icn_governance::AmendmentScope::Jurisdiction { domain_id } = &amendment.scope {
+            // The domain must correspond to an existing charter.
+            if self.store.get_charter_by_domain(domain_id)?.is_none() {
+                bail!(
+                    "Amendment scope references unknown domain '{}'. \
+                     Create a charter for this domain first.",
+                    domain_id
+                );
+            }
+
+            // If a charter_id is supplied, its domain must match the scope's domain.
+            if let Some(cid_bytes) = amendment.charter_id {
+                let cid_hex = hex::encode(cid_bytes);
+                match self.store.get_charter(&cid_hex)? {
+                    Some(charter) if charter.domain_id == *domain_id => {
+                        // Consistent — domain matches scope.
+                    }
+                    Some(charter) => {
+                        bail!(
+                            "Amendment charter_id '{}' belongs to domain '{}' but amendment scope \
+                             specifies domain '{}'. Cross-domain scope is forbidden.",
+                            cid_hex,
+                            charter.domain_id,
+                            domain_id
+                        );
+                    }
+                    None => {
+                        bail!(
+                            "Amendment references charter '{}' which does not exist.",
+                            cid_hex
+                        );
+                    }
+                }
+            }
+        }
 
         self.store.put_amendment(&amendment)?;
 
@@ -1879,9 +1957,28 @@ impl CommonsInner {
     // ========== Appeal Operations (v0.6.0 Constitutional Governance) ==========
 
     /// Store an appeal
+    /// Store an appeal.
+    ///
+    /// # Invariants enforced
+    ///
+    /// - **Jurisdiction scope references an existing domain**: if the appeal's scope is
+    ///   `Jurisdiction { domain_id }`, a charter with that `domain_id` must already exist.
+    ///   This mirrors the same invariant on amendments and ensures appeals can only be filed
+    ///   against real governance domains.
     pub async fn store_appeal(&self, appeal: Appeal) -> Result<()> {
         let appeal_id = appeal.id.to_hex();
         let appellant = appeal.appellant.to_string();
+
+        // Enforce scope coherence for jurisdiction-scoped appeals.
+        if let icn_governance::AppealScope::Jurisdiction { domain_id } = &appeal.scope {
+            if self.store.get_charter_by_domain(domain_id)?.is_none() {
+                bail!(
+                    "Appeal scope references unknown domain '{}'. \
+                     Create a charter for this domain first.",
+                    domain_id
+                );
+            }
+        }
 
         self.store.put_appeal(&appeal)?;
 

--- a/icn/crates/icn-commons/src/inner.rs
+++ b/icn/crates/icn-commons/src/inner.rs
@@ -1,0 +1,2033 @@
+//! CommonsInner — substrate-type operations extracted from CommonsManager
+//!
+//! Contains all data-layer methods for:
+//! - PersonhoodAnchor management (Layer 0)
+//! - CommonsHolderRecord management (Layer 1)
+//! - Charter management (Layer 2)
+//! - Affiliation/membership management
+//! - Steward operations
+//! - Revocation operations
+//! - Amendment operations
+//! - Appeal operations
+//! - Enrollment session operations
+//!
+//! Gateway-local DTO methods (e.g. `build_governance_dashboard`) are intentionally absent.
+
+use anyhow::{bail, Result};
+use icn_governance::{
+    Amendment, AmendmentChange, AmendmentId, AmendmentStatus, Appeal, AppealEvidence, AppealId,
+    AppealOutcome, AppealResponse, Charter, CharterStatus, OrgType, Ratification, StewardRecord,
+};
+use icn_identity::{
+    Affiliation, Anchor, AnchorStatus, CommonsHolderRecord, CommonsRevocationReason, Did,
+    EnrollmentPathway, HolderStatus, JurisdictionId, MembershipCapability, MembershipStatus,
+    POPAttestation, POPLevel, POPMethod, PersonhoodAnchor, RevocationRecord, RevocationRegistry,
+    RevocationScope, RevocationType,
+};
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use tracing::{info, warn};
+
+use crate::store::{CommonsStore, CommonsStoreBackend};
+
+/// CommonsInner holds all substrate-type operations for the commons layer.
+///
+/// Uses CommonsStore for persistent/in-memory storage of:
+/// - PersonhoodAnchors (Layer 0)
+/// - CommonsHolderRecords (Layer 1)
+/// - Charters (Layer 2)
+/// - StewardRecords, Amendments, Appeals
+///
+/// RevocationRegistry is kept separate from the main store.
+pub struct CommonsInner {
+    /// Storage backend
+    store: CommonsStore<Arc<dyn CommonsStoreBackend>>,
+
+    /// Revocation registry (kept separate from main store)
+    revocations: RevocationRegistry,
+}
+
+impl CommonsInner {
+    /// Create a new CommonsInner with the given backend
+    pub fn new(backend: Arc<dyn CommonsStoreBackend>) -> Self {
+        CommonsInner {
+            store: CommonsStore::new(Arc::new(backend)),
+            revocations: RevocationRegistry::new(),
+        }
+    }
+
+    /// Get a reference to the underlying store
+    pub fn store(&self) -> &CommonsStore<Arc<dyn CommonsStoreBackend>> {
+        &self.store
+    }
+
+    /// Flush pending writes to durable storage.
+    pub fn flush(&self) -> Result<()> {
+        self.store.backend().flush()
+    }
+
+    // ========== PersonhoodAnchor Operations (Layer 0) ==========
+
+    /// Create a new PersonhoodAnchor from enrollment completion
+    ///
+    /// This creates a full PersonhoodAnchor with an underlying SDIS Anchor
+    /// and an initial POP attestation.
+    pub async fn create_anchor_from_enrollment(
+        &self,
+        did: &Did,
+        steward_did: Option<&Did>,
+    ) -> Result<PersonhoodAnchor> {
+        // Generate pseudo-VUI from DID (in real SDIS, this comes from ceremony)
+        let mut hasher = Sha256::new();
+        hasher.update(b"gateway-enrollment-vui:");
+        hasher.update(did.as_str().as_bytes());
+        let vui_result = hasher.finalize();
+        let mut vui = [0u8; 32];
+        vui.copy_from_slice(&vui_result);
+
+        // Generate genesis random
+        let mut genesis = [0u8; 32];
+        use rand::RngCore;
+        rand::thread_rng().fill_bytes(&mut genesis);
+
+        // Create the underlying SDIS Anchor
+        let pathway = if let Some(did) = steward_did {
+            EnrollmentPathway::WebOfTrust {
+                vouchers: vec![did.clone()],
+                vouched_at: icn_time::current_timestamp_secs(),
+            }
+        } else {
+            EnrollmentPathway::Genesis {
+                reason: "Gateway enrollment".to_string(),
+            }
+        };
+
+        let sdis_anchor = Anchor::from_vui(&vui, pathway, &genesis);
+        let anchor_id_bytes = sdis_anchor.id;
+
+        // Create POP attestation
+        let (pop_method, pop_level, issuer) = if let Some(steward) = steward_did {
+            (
+                POPMethod::Sponsored {
+                    sponsor_did: steward.clone(),
+                },
+                POPLevel::Strong,
+                steward.clone(),
+            )
+        } else {
+            (
+                POPMethod::Genesis {
+                    reason: "Gateway enrollment".to_string(),
+                },
+                POPLevel::Weak,
+                did.clone(),
+            )
+        };
+
+        // SECURITY NOTE: Gateway cannot sign attestations (no private key access).
+        // This creates an UNSIGNED attestation suitable for development/testing only.
+        // Production requires client-side signing before submission.
+        // See: https://github.com/InterCooperative-Network/icn/issues/133
+        let attestation = POPAttestation::new(
+            &anchor_id_bytes,
+            issuer,
+            pop_method,
+            pop_level,
+            Vec::new(), // UNSIGNED - gateway lacks signing capability
+            None,       // No expiry
+        );
+        warn!(
+            "Created UNSIGNED attestation for anchor {} - requires client-side signing for production",
+            hex::encode(anchor_id_bytes)
+        );
+
+        // DEVELOPMENT ONLY: Derive a placeholder key from the DID.
+        // Production anchors must provide their actual Ed25519 public key.
+        // See: https://github.com/InterCooperative-Network/icn/issues/133
+        let mut key_hasher = Sha256::new();
+        key_hasher.update(b"gateway-dev-placeholder-key:");
+        key_hasher.update(did.as_str().as_bytes());
+        let key_result = key_hasher.finalize();
+        let mut current_key = [0u8; 32];
+        current_key.copy_from_slice(&key_result);
+        warn!(
+            "Using PLACEHOLDER key for anchor {} - production requires real public key",
+            hex::encode(anchor_id_bytes)
+        );
+
+        // Create PersonhoodAnchor
+        let anchor = PersonhoodAnchor::new(sdis_anchor, attestation, current_key);
+
+        // Check if anchor already exists
+        let anchor_id = hex::encode(anchor.id());
+        if self.store.get_anchor(&anchor_id)?.is_some() {
+            bail!("Anchor already exists: {anchor_id}");
+        }
+
+        // Store anchor
+        self.store.put_anchor(&anchor)?;
+
+        // Also index by the enrollment DID (which may differ from anchor's internal DID)
+        let did_str = did.to_string();
+        self.store.put_anchor_did_index(&did_str, &anchor_id)?;
+
+        // Record metrics
+        icn_obs::metrics::commons::anchor_created_inc();
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "anchor_created",
+            anchor_id = %anchor_id,
+            did = %did_str,
+            steward_vouched = steward_did.is_some(),
+            "PersonhoodAnchor created"
+        );
+
+        Ok(anchor)
+    }
+
+    /// Get a PersonhoodAnchor by ID
+    pub async fn get_anchor(&self, anchor_id: &str) -> Result<Option<PersonhoodAnchor>> {
+        self.store.get_anchor(anchor_id)
+    }
+
+    /// Get a PersonhoodAnchor by DID
+    pub async fn get_anchor_by_did(&self, did: &Did) -> Result<Option<PersonhoodAnchor>> {
+        let did_str = did.to_string();
+        self.store.get_anchor_by_did(&did_str)
+    }
+
+    /// Update anchor status
+    pub async fn update_anchor_status(&self, anchor_id: &str, status: AnchorStatus) -> Result<()> {
+        let mut anchor = self
+            .store
+            .get_anchor(anchor_id)?
+            .ok_or_else(|| anyhow::anyhow!("Anchor not found: {anchor_id}"))?;
+
+        anchor.status = status.clone();
+        anchor.updated_at = icn_time::current_timestamp_secs();
+
+        self.store.put_anchor(&anchor)?;
+
+        // Record status change metrics
+        match &status {
+            AnchorStatus::Suspended { .. } => {
+                icn_obs::metrics::commons::anchor_suspended_inc("status_update");
+            }
+            AnchorStatus::Revoked { .. } => {
+                icn_obs::metrics::commons::anchor_revoked_inc("status_update");
+            }
+            _ => {}
+        }
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "anchor_status_updated",
+            anchor_id = %anchor_id,
+            new_status = ?status,
+            "PersonhoodAnchor status updated"
+        );
+
+        Ok(())
+    }
+
+    /// Add an attestation to an anchor
+    pub async fn add_attestation(
+        &self,
+        anchor_id: &str,
+        attestation: POPAttestation,
+    ) -> Result<()> {
+        let mut anchor = self
+            .store
+            .get_anchor(anchor_id)?
+            .ok_or_else(|| anyhow::anyhow!("Anchor not found: {anchor_id}"))?;
+
+        let method_name = format!("{:?}", attestation.method);
+        anchor.add_attestation(attestation);
+        self.store.put_anchor(&anchor)?;
+
+        // Record verification metric
+        icn_obs::metrics::commons::anchor_verified_inc(&method_name);
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "attestation_added",
+            anchor_id = %anchor_id,
+            method = %method_name,
+            "POP attestation added to anchor"
+        );
+
+        Ok(())
+    }
+
+    // ========== CommonsHolderRecord Operations (Layer 1) ==========
+
+    /// Create a CommonsHolderRecord from an anchor
+    pub async fn create_holder_from_anchor(
+        &self,
+        anchor_id: &str,
+        did: &Did,
+    ) -> Result<CommonsHolderRecord> {
+        self.create_holder_from_anchor_with_name(anchor_id, did, None)
+            .await
+    }
+
+    /// Create a CommonsHolderRecord from an anchor with an optional display name
+    pub async fn create_holder_from_anchor_with_name(
+        &self,
+        anchor_id: &str,
+        did: &Did,
+        display_name: Option<String>,
+    ) -> Result<CommonsHolderRecord> {
+        // Verify anchor exists and get its POP level
+        let anchor = self
+            .get_anchor(anchor_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Anchor not found: {anchor_id}"))?;
+
+        // Convert anchor_id hex string to bytes
+        let anchor_bytes: [u8; 32] = hex::decode(anchor_id)?
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("Invalid anchor_id length"))?;
+
+        // Get the POP level from the anchor (default to Weak if no attestations)
+        let pop_level = anchor.pop_level().unwrap_or(POPLevel::Weak);
+
+        // Create holder with baseline Commons Rights
+        let mut holder = CommonsHolderRecord::new(anchor_bytes, did.clone(), pop_level);
+
+        // Set display name if provided
+        if let Some(name) = display_name {
+            holder.display_name = Some(name);
+        }
+
+        // Check if holder already exists
+        let holder_id = hex::encode(holder.id());
+        if self.store.get_holder(&holder_id)?.is_some() {
+            bail!("Holder already exists: {holder_id}");
+        }
+
+        // Store holder (this also updates DID and anchor indexes)
+        self.store.put_holder(&holder)?;
+
+        // Record metrics
+        icn_obs::metrics::commons::holder_created_inc();
+
+        // Audit log
+        let did_str = did.to_string();
+        info!(
+            target: "commons_audit",
+            action = "holder_created",
+            holder_id = %holder_id,
+            anchor_id = %anchor_id,
+            did = %did_str,
+            pop_level = ?pop_level,
+            "CommonsHolderRecord created"
+        );
+
+        Ok(holder)
+    }
+
+    /// Get a CommonsHolderRecord by ID
+    pub async fn get_holder(&self, holder_id: &str) -> Result<Option<CommonsHolderRecord>> {
+        self.store.get_holder(holder_id)
+    }
+
+    /// Get a CommonsHolderRecord by DID
+    pub async fn get_holder_by_did(&self, did: &Did) -> Result<Option<CommonsHolderRecord>> {
+        let did_str = did.to_string();
+        self.store.get_holder_by_did(&did_str)
+    }
+
+    /// Update the display name for a holder identified by DID.
+    /// If no holder record exists yet, creates a minimal holder record directly.
+    pub async fn update_display_name(&self, did: &Did, display_name: String) -> Result<()> {
+        let did_str = did.to_string();
+        if let Some(mut holder) = self.store.get_holder_by_did(&did_str)? {
+            holder.set_display_name(display_name);
+            self.store.put_holder(&holder)?;
+        } else {
+            // Create a minimal holder record directly (no anchor required).
+            // This is used for demo seeding where members don't go through
+            // full SDIS enrollment but still need display names.
+            let anchor_bytes: [u8; 32] = Sha256::digest(did_str.as_bytes()).into();
+            let mut holder = CommonsHolderRecord::new(anchor_bytes, did.clone(), POPLevel::Weak);
+            holder.set_display_name(display_name);
+            self.store.put_holder(&holder)?;
+        }
+        Ok(())
+    }
+
+    /// Get or create a CommonsHolderRecord (idempotent)
+    ///
+    /// This method provides create-or-get semantics for holders:
+    /// - If a holder already exists for this anchor, returns it
+    /// - If no holder exists, creates a new one
+    ///
+    /// This is critical for enrollment idempotency: calling this method
+    /// multiple times with the same anchor_id returns the same holder.
+    ///
+    /// # Arguments
+    /// * `anchor_id` - Hex-encoded anchor ID
+    /// * `did` - The DID for the holder
+    /// * `display_name` - Optional display name (only used if creating new)
+    ///
+    /// # Returns
+    /// The existing or newly created CommonsHolderRecord
+    pub async fn get_or_create_holder(
+        &self,
+        anchor_id: &str,
+        did: &Did,
+        display_name: Option<String>,
+    ) -> Result<CommonsHolderRecord> {
+        // First, try to find existing holder by anchor ID
+        if let Some(holder) = self.store.get_holder_by_anchor(anchor_id)? {
+            info!(
+                target: "commons_audit",
+                action = "holder_get_or_create_existing",
+                holder_id = %hex::encode(holder.id()),
+                anchor_id = %anchor_id,
+                "Returning existing holder for anchor"
+            );
+            return Ok(holder);
+        }
+
+        // No existing holder, create new one
+        // This delegates to create_holder_from_anchor_with_name which handles
+        // anchor validation, metrics, and audit logging
+        self.create_holder_from_anchor_with_name(anchor_id, did, display_name)
+            .await
+    }
+
+    /// Update holder status
+    pub async fn update_holder_status(&self, holder_id: &str, status: HolderStatus) -> Result<()> {
+        let mut holder = self
+            .store
+            .get_holder(holder_id)?
+            .ok_or_else(|| anyhow::anyhow!("Holder not found: {holder_id}"))?;
+
+        holder.status = status.clone();
+        holder.updated_at = icn_time::current_timestamp_secs();
+
+        self.store.put_holder(&holder)?;
+
+        // Record status change metric
+        icn_obs::metrics::commons::holder_status_changed_inc(&format!("{status:?}"));
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "holder_status_updated",
+            holder_id = %holder_id,
+            new_status = ?status,
+            "CommonsHolderRecord status updated"
+        );
+
+        Ok(())
+    }
+
+    // ========== Affiliation Operations ==========
+
+    /// Add an affiliation (join jurisdiction).
+    ///
+    /// Sybil resistance: requires at least `POPLevel::Strong` to join.
+    pub async fn join_jurisdiction(
+        &self,
+        holder_id: &str,
+        jurisdiction: JurisdictionId,
+        initial_capabilities: Vec<MembershipCapability>,
+    ) -> Result<Affiliation> {
+        let mut holder = self
+            .store
+            .get_holder(holder_id)?
+            .ok_or_else(|| anyhow::anyhow!("Holder not found: {holder_id}"))?;
+
+        // Sybil gate: require at least Strong POP level
+        if holder.personhood_level < POPLevel::Strong {
+            bail!(
+                "Joining a jurisdiction requires at least Strong POP level (current: Weak). \
+                 Obtain additional attestations to upgrade."
+            );
+        }
+
+        // Check if already affiliated
+        if holder
+            .affiliations
+            .iter()
+            .any(|a| a.jurisdiction_id == jurisdiction)
+        {
+            bail!(
+                "Already affiliated with jurisdiction: {}",
+                jurisdiction.as_str()
+            );
+        }
+
+        // Create affiliation (starts as Candidate by default)
+        let now = icn_time::current_timestamp_secs();
+
+        let affiliation = Affiliation {
+            jurisdiction_id: jurisdiction.clone(),
+            membership_status: MembershipStatus::Candidate,
+            capabilities: initial_capabilities,
+            roles: Vec::new(),
+            joined_at: now,
+            expires_at: None,
+        };
+
+        holder.affiliations.push(affiliation.clone());
+        holder.updated_at = now;
+
+        self.store.put_holder(&holder)?;
+
+        // Record membership join metric
+        icn_obs::metrics::commons::membership_joined_inc(jurisdiction.as_str());
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "membership_joined",
+            holder_id = %holder_id,
+            jurisdiction = %jurisdiction.as_str(),
+            capabilities_count = affiliation.capabilities.len(),
+            "Holder joined jurisdiction"
+        );
+
+        Ok(affiliation)
+    }
+
+    /// Leave a jurisdiction
+    pub async fn leave_jurisdiction(
+        &self,
+        holder_id: &str,
+        jurisdiction: &JurisdictionId,
+    ) -> Result<()> {
+        let mut holder = self
+            .store
+            .get_holder(holder_id)?
+            .ok_or_else(|| anyhow::anyhow!("Holder not found: {holder_id}"))?;
+
+        // Find and update affiliation status to Exited
+        if let Some(affiliation) = holder
+            .affiliations
+            .iter_mut()
+            .find(|a| &a.jurisdiction_id == jurisdiction)
+        {
+            affiliation.membership_status = MembershipStatus::Exited;
+            holder.updated_at = icn_time::current_timestamp_secs();
+            self.store.put_holder(&holder)?;
+
+            // Record exit metric
+            icn_obs::metrics::commons::membership_exited_inc(jurisdiction.as_str());
+
+            // Audit log
+            info!(
+                target: "commons_audit",
+                action = "membership_exited",
+                holder_id = %holder_id,
+                jurisdiction = %jurisdiction.as_str(),
+                "Holder left jurisdiction"
+            );
+
+            Ok(())
+        } else {
+            bail!(
+                "Not affiliated with jurisdiction: {}",
+                jurisdiction.as_str()
+            )
+        }
+    }
+
+    /// Update affiliation status (e.g., Candidate -> Member)
+    pub async fn update_affiliation_status(
+        &self,
+        holder_id: &str,
+        jurisdiction: &JurisdictionId,
+        status: MembershipStatus,
+    ) -> Result<()> {
+        let mut holder = self
+            .store
+            .get_holder(holder_id)?
+            .ok_or_else(|| anyhow::anyhow!("Holder not found: {holder_id}"))?;
+
+        if let Some(affiliation) = holder
+            .affiliations
+            .iter_mut()
+            .find(|a| &a.jurisdiction_id == jurisdiction)
+        {
+            affiliation.membership_status = status;
+            holder.updated_at = icn_time::current_timestamp_secs();
+            self.store.put_holder(&holder)?;
+
+            // Record status-specific metrics
+            let jurisdiction_str = jurisdiction.as_str();
+            match status {
+                MembershipStatus::Suspended => {
+                    icn_obs::metrics::commons::membership_suspended_inc(jurisdiction_str);
+                }
+                MembershipStatus::Banned => {
+                    icn_obs::metrics::commons::membership_banned_inc(jurisdiction_str);
+                }
+                _ => {}
+            }
+
+            // Audit log
+            info!(
+                target: "commons_audit",
+                action = "membership_status_updated",
+                holder_id = %holder_id,
+                jurisdiction = %jurisdiction_str,
+                new_status = ?status,
+                "Membership status updated"
+            );
+
+            Ok(())
+        } else {
+            bail!(
+                "Not affiliated with jurisdiction: {}",
+                jurisdiction.as_str()
+            )
+        }
+    }
+
+    /// List affiliations for a holder
+    pub async fn list_affiliations(&self, holder_id: &str) -> Result<Vec<Affiliation>> {
+        let holder = self
+            .store
+            .get_holder(holder_id)?
+            .ok_or_else(|| anyhow::anyhow!("Holder not found: {holder_id}"))?;
+
+        Ok(holder.affiliations.clone())
+    }
+
+    // ========== Charter Operations (Layer 2) ==========
+
+    /// Store a charter
+    pub async fn store_charter(&self, charter: Charter) -> Result<()> {
+        let charter_id = charter.charter_id.to_hex();
+        let org_type = format!("{:?}", charter.org_type);
+
+        // Check if charter already exists
+        if self.store.get_charter(&charter_id)?.is_some() {
+            bail!("Charter already exists: {charter_id}");
+        }
+
+        // Store charter (this also updates the domain index)
+        self.store.put_charter(&charter)?;
+
+        // Record charter creation metric
+        icn_obs::metrics::commons::charter_created_inc(&org_type);
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "charter_created",
+            charter_id = %charter_id,
+            org_type = %org_type,
+            domain_id = %charter.domain_id,
+            founders_count = charter.founders.len(),
+            "Charter created"
+        );
+
+        Ok(())
+    }
+
+    /// Get a charter by ID
+    pub async fn get_charter(&self, charter_id: &str) -> Result<Option<Charter>> {
+        self.store.get_charter(charter_id)
+    }
+
+    /// Get a charter by domain ID
+    pub async fn get_charter_by_domain(&self, domain_id: &str) -> Result<Option<Charter>> {
+        self.store.get_charter_by_domain(domain_id)
+    }
+
+    /// List all charters with optional filters
+    pub async fn list_charters(
+        &self,
+        org_type: Option<OrgType>,
+        status: Option<CharterStatus>,
+    ) -> Result<Vec<Charter>> {
+        let all_charters = self.store.list_charters()?;
+
+        let mut results: Vec<Charter> = all_charters
+            .into_iter()
+            .filter(|c| {
+                let type_match = org_type.as_ref().is_none_or(|t| c.org_type == *t);
+                let status_match = status.as_ref().is_none_or(|s| c.status == *s);
+                type_match && status_match
+            })
+            .collect();
+
+        // Sort by creation time, newest first
+        results.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+        Ok(results)
+    }
+
+    /// Add a founder signature to a charter
+    ///
+    /// Requirements:
+    /// - Charter must be in Draft status
+    /// - Signer must not have already signed
+    ///
+    /// Returns the updated charter with the new signature count
+    pub async fn add_charter_signature(
+        &self,
+        charter_id: &str,
+        signature: icn_governance::FounderSignature,
+    ) -> Result<Charter> {
+        let mut charter = self
+            .store
+            .get_charter(charter_id)?
+            .ok_or_else(|| anyhow::anyhow!("Charter not found: {charter_id}"))?;
+
+        // Validate charter is in Draft status
+        if !matches!(charter.status, CharterStatus::Draft) {
+            bail!(
+                "Cannot sign charter in status {:?}, must be Draft",
+                charter.status
+            );
+        }
+
+        // Check if already signed by this DID
+        if charter.founders.iter().any(|f| f.did == signature.did) {
+            bail!("Signer has already signed this charter");
+        }
+
+        // Add the signature
+        let signer_did = signature.did.to_string();
+        charter.add_founder(signature);
+
+        // Persist updated charter
+        self.store.put_charter(&charter)?;
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "charter_signed",
+            charter_id = %charter_id,
+            signer = %signer_did,
+            total_founders = charter.founders.len(),
+            "Charter signed by founder"
+        );
+
+        Ok(charter)
+    }
+
+    /// Update charter status
+    pub async fn update_charter_status(
+        &self,
+        charter_id: &str,
+        status: CharterStatus,
+    ) -> Result<()> {
+        let mut charter = self
+            .store
+            .get_charter(charter_id)?
+            .ok_or_else(|| anyhow::anyhow!("Charter not found: {charter_id}"))?;
+
+        charter.status = status.clone();
+        // Note: Charter doesn't have an updated_at field
+        // Status changes are tracked via amendments in production
+        self.store.put_charter(&charter)?;
+
+        // Record status-specific metrics
+        match &status {
+            CharterStatus::Active => {
+                icn_obs::metrics::commons::charter_activated_inc();
+            }
+            CharterStatus::Suspended { .. } => {
+                icn_obs::metrics::commons::charter_suspended_inc();
+            }
+            CharterStatus::Dissolved { .. } => {
+                icn_obs::metrics::commons::charter_dissolved_inc();
+            }
+            _ => {}
+        }
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "charter_status_updated",
+            charter_id = %charter_id,
+            new_status = ?status,
+            "Charter status updated"
+        );
+
+        Ok(())
+    }
+
+    // ========== Steward Operations ==========
+
+    /// Register a new steward from a Commons Holder
+    ///
+    /// Requirements:
+    /// - Must be an active Commons Holder
+    /// - Must have at least Strong POP level
+    /// - Must have governance approval (proposal ID)
+    pub async fn register_steward(
+        &self,
+        holder_did: &Did,
+        steward_did: &Did,
+        term_duration_days: u64,
+        bond_amount: u64,
+        governance_approval: String,
+        jurisdiction: Option<String>,
+        specializations: Vec<String>,
+    ) -> Result<StewardRecord> {
+        // Verify holder exists and is active
+        let holder = self
+            .get_holder_by_did(holder_did)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Holder not found for DID: {holder_did}"))?;
+
+        if !holder.is_active() {
+            bail!("Holder is not active");
+        }
+
+        // Require at least Strong POP level to become a steward
+        if holder.personhood_level < POPLevel::Strong {
+            bail!("Steward requires at least Strong POP level");
+        }
+
+        // Check not already a steward
+        if self.get_steward_by_did(steward_did).await?.is_some() {
+            bail!("Already registered as steward");
+        }
+
+        // Calculate term
+        let now = icn_time::current_timestamp_secs();
+        let term_end = now + (term_duration_days * 24 * 60 * 60);
+
+        // Create steward record
+        let mut steward = StewardRecord::new(
+            steward_did.clone(),
+            holder_did.clone(),
+            now,
+            term_end,
+            bond_amount,
+            governance_approval,
+        );
+
+        // Set optional fields
+        if let Some(ref j) = jurisdiction {
+            steward.jurisdiction = Some(j.clone());
+        }
+        for spec in specializations {
+            steward.add_specialization(spec);
+        }
+
+        // Store
+        self.store_steward(steward.clone()).await?;
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "steward_registered",
+            steward_id = %steward.steward_id.to_hex(),
+            steward_did = %steward_did.to_string(),
+            holder_did = %holder_did.to_string(),
+            jurisdiction = ?jurisdiction,
+            bond_amount = bond_amount,
+            "Steward registered"
+        );
+
+        Ok(steward)
+    }
+
+    /// Store a steward record
+    pub async fn store_steward(&self, steward: StewardRecord) -> Result<()> {
+        let steward_id = steward.steward_id.to_hex();
+
+        // Check if steward already exists
+        if self.store.get_steward(&steward_id)?.is_some() {
+            bail!("Steward already exists: {steward_id}");
+        }
+
+        // Store steward (this also updates the DID index)
+        self.store.put_steward(&steward)?;
+        Ok(())
+    }
+
+    /// Get a steward by ID
+    pub async fn get_steward(&self, steward_id: &str) -> Result<Option<StewardRecord>> {
+        self.store.get_steward(steward_id)
+    }
+
+    /// Get a steward by DID
+    pub async fn get_steward_by_did(&self, did: &Did) -> Result<Option<StewardRecord>> {
+        let did_str = did.to_string();
+        self.store.get_steward_by_did(&did_str)
+    }
+
+    /// List all stewards with optional filters
+    pub async fn list_stewards(
+        &self,
+        active_only: bool,
+        jurisdiction: Option<&str>,
+    ) -> Result<Vec<StewardRecord>> {
+        let all_stewards = self.store.list_stewards()?;
+
+        let mut results: Vec<StewardRecord> = all_stewards
+            .into_iter()
+            .filter(|s| {
+                let active_match = !active_only || s.is_active();
+                let jurisdiction_match =
+                    jurisdiction.is_none() || s.jurisdiction.as_deref() == jurisdiction;
+                active_match && jurisdiction_match
+            })
+            .collect();
+
+        // Sort by reputation score, highest first
+        results.sort_by(|a, b| {
+            b.reputation_score
+                .partial_cmp(&a.reputation_score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        Ok(results)
+    }
+
+    /// List stewards who can issue attestations
+    pub async fn list_attesters(&self) -> Result<Vec<StewardRecord>> {
+        let all_stewards = self.store.list_stewards()?;
+        let attesters: Vec<StewardRecord> = all_stewards
+            .into_iter()
+            .filter(|s| s.can_attest())
+            .collect();
+        Ok(attesters)
+    }
+
+    /// Check if a DID belongs to an active steward
+    pub async fn is_active_steward(&self, did: &Did) -> Result<bool> {
+        if let Some(steward) = self.get_steward_by_did(did).await? {
+            Ok(steward.is_active() && steward.can_attest())
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Suspend a steward
+    pub async fn suspend_steward(&self, steward_id: &str, reason: String) -> Result<()> {
+        let mut steward = self
+            .store
+            .get_steward(steward_id)?
+            .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
+
+        steward.suspend(reason.clone());
+        self.store.put_steward(&steward)?;
+
+        // Audit log
+        warn!(
+            target: "commons_audit",
+            action = "steward_suspended",
+            steward_id = %steward_id,
+            reason = %reason,
+            "Steward suspended"
+        );
+
+        Ok(())
+    }
+
+    /// Reinstate a suspended steward
+    pub async fn reinstate_steward(&self, steward_id: &str) -> Result<bool> {
+        let mut steward = self
+            .store
+            .get_steward(steward_id)?
+            .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
+
+        let result = steward.reinstate();
+        self.store.put_steward(&steward)?;
+
+        // Audit log
+        if result {
+            info!(
+                target: "commons_audit",
+                action = "steward_reinstated",
+                steward_id = %steward_id,
+                "Steward reinstated"
+            );
+        }
+
+        Ok(result)
+    }
+
+    /// Retire a steward
+    pub async fn retire_steward(&self, steward_id: &str) -> Result<()> {
+        let mut steward = self
+            .store
+            .get_steward(steward_id)?
+            .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
+
+        steward.retire();
+        self.store.put_steward(&steward)?;
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "steward_retired",
+            steward_id = %steward_id,
+            "Steward retired"
+        );
+
+        Ok(())
+    }
+
+    /// Revoke a steward for cause
+    pub async fn revoke_steward(
+        &self,
+        steward_id: &str,
+        reason: String,
+        evidence: Vec<[u8; 32]>,
+    ) -> Result<()> {
+        let mut steward = self
+            .store
+            .get_steward(steward_id)?
+            .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
+
+        steward.revoke(reason.clone(), evidence.clone());
+        self.store.put_steward(&steward)?;
+
+        // Audit log
+        warn!(
+            target: "commons_audit",
+            action = "steward_revoked",
+            steward_id = %steward_id,
+            reason = %reason,
+            evidence_count = evidence.len(),
+            "Steward revoked for cause"
+        );
+
+        Ok(())
+    }
+
+    /// Record an attestation issued by a steward
+    pub async fn record_steward_attestation(&self, steward_id: &str) -> Result<()> {
+        let mut steward = self
+            .store
+            .get_steward(steward_id)?
+            .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
+
+        steward.record_attestation();
+        self.store.put_steward(&steward)?;
+        Ok(())
+    }
+
+    /// Record a dispute against a steward's attestation
+    pub async fn record_steward_dispute(&self, steward_id: &str) -> Result<()> {
+        let mut steward = self
+            .store
+            .get_steward(steward_id)?
+            .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
+
+        steward.record_dispute();
+        self.store.put_steward(&steward)?;
+        Ok(())
+    }
+
+    /// Record a dispute won by a steward
+    pub async fn record_steward_dispute_won(&self, steward_id: &str) -> Result<()> {
+        let mut steward = self
+            .store
+            .get_steward(steward_id)?
+            .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
+
+        steward.record_dispute_won();
+        self.store.put_steward(&steward)?;
+        Ok(())
+    }
+
+    /// Extend a steward's term
+    pub async fn extend_steward_term(&self, steward_id: &str, new_term_end: u64) -> Result<()> {
+        let mut steward = self
+            .store
+            .get_steward(steward_id)?
+            .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
+
+        steward.extend_term(new_term_end);
+        self.store.put_steward(&steward)?;
+        Ok(())
+    }
+
+    /// Add to a steward's bond
+    pub async fn add_steward_bond(&self, steward_id: &str, amount: u64) -> Result<()> {
+        let mut steward = self
+            .store
+            .get_steward(steward_id)?
+            .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
+
+        steward.add_bond(amount);
+        self.store.put_steward(&steward)?;
+        Ok(())
+    }
+
+    /// Slash a steward's bond
+    pub async fn slash_steward_bond(&self, steward_id: &str, amount: u64) -> Result<u64> {
+        let mut steward = self
+            .store
+            .get_steward(steward_id)?
+            .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
+
+        let result = steward.slash_bond(amount);
+        self.store.put_steward(&steward)?;
+        Ok(result)
+    }
+
+    // ========== Revocation Operations ==========
+
+    /// Add a revocation record
+    pub async fn add_revocation(&self, record: RevocationRecord) -> Result<()> {
+        self.revocations
+            .add(record)
+            .map_err(|e| anyhow::anyhow!("Failed to add revocation: {e}"))
+    }
+
+    /// Check if a target is revoked
+    pub async fn check_revocation(&self, target_id: &str) -> icn_identity::RevocationCheck {
+        self.revocations.check(target_id)
+    }
+
+    /// Check if a target is revoked at a specific scope
+    pub async fn check_revocation_at_scope(
+        &self,
+        target_id: &str,
+        scope: &RevocationScope,
+    ) -> icn_identity::RevocationCheck {
+        self.revocations.check_at_scope(target_id, scope)
+    }
+
+    /// Get a revocation record by ID
+    pub async fn get_revocation(&self, revocation_id: &str) -> Option<RevocationRecord> {
+        self.revocations.get(revocation_id)
+    }
+
+    /// List all revocations for a target
+    pub async fn list_revocations_for_target(&self, target_id: &str) -> Vec<RevocationRecord> {
+        self.revocations.list_for_target(target_id)
+    }
+
+    /// List all revocations by type
+    pub async fn list_revocations_by_type(
+        &self,
+        target_type: RevocationType,
+    ) -> Vec<RevocationRecord> {
+        self.revocations.list_by_type(target_type)
+    }
+
+    /// List all pending appeals
+    pub async fn list_pending_appeals(&self) -> Vec<RevocationRecord> {
+        self.revocations.list_pending_appeals()
+    }
+
+    /// File an appeal for a revocation
+    pub async fn file_appeal(&self, revocation_id: &str, reason: String) -> Result<()> {
+        let mut record = self
+            .revocations
+            .get(revocation_id)
+            .ok_or_else(|| anyhow::anyhow!("Revocation not found"))?;
+
+        if !record.file_appeal(reason) {
+            bail!("Cannot file appeal - appeal window closed or already appealed");
+        }
+
+        self.revocations
+            .update(record)
+            .map_err(|e| anyhow::anyhow!("Failed to update revocation: {e}"))
+    }
+
+    /// Resolve an appeal
+    pub async fn resolve_appeal(
+        &self,
+        revocation_id: &str,
+        upheld: bool,
+        resolution_notes: String,
+    ) -> Result<()> {
+        let mut record = self
+            .revocations
+            .get(revocation_id)
+            .ok_or_else(|| anyhow::anyhow!("Revocation not found"))?;
+
+        record.resolve_appeal(upheld, resolution_notes);
+
+        self.revocations
+            .update(record)
+            .map_err(|e| anyhow::anyhow!("Failed to update revocation: {e}"))
+    }
+
+    /// Revoke a membership with proper due process
+    pub async fn revoke_membership(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+        authority: Did,
+        reason: CommonsRevocationReason,
+        appeal_window_days: u64,
+    ) -> Result<RevocationRecord> {
+        // Verify holder exists
+        let mut holder = self
+            .get_holder(holder_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
+
+        // Verify has affiliation with jurisdiction
+        let affiliation = holder.get_affiliation_mut(jurisdiction_id).ok_or_else(|| {
+            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
+        })?;
+
+        // Create revocation record
+        let target_id = format!("{holder_id}:{jurisdiction_id}");
+        let record = RevocationRecord::new(
+            RevocationType::Membership,
+            target_id,
+            RevocationScope::Jurisdiction {
+                jurisdiction_id: jurisdiction_id.clone(),
+            },
+            authority,
+            reason,
+            appeal_window_days,
+        );
+
+        // Add to registry
+        self.add_revocation(record.clone()).await?;
+
+        // Update affiliation status (but allow appeal)
+        affiliation.suspend();
+
+        // Update holder via store
+        self.store.put_holder(&holder)?;
+
+        Ok(record)
+    }
+
+    /// Ban a member immediately (severe violations)
+    pub async fn ban_member(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+        authority: Did,
+        reason: CommonsRevocationReason,
+    ) -> Result<RevocationRecord> {
+        // Verify holder exists
+        let mut holder = self
+            .get_holder(holder_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
+
+        // Verify has affiliation
+        let affiliation = holder.get_affiliation_mut(jurisdiction_id).ok_or_else(|| {
+            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
+        })?;
+
+        // Create immediate revocation
+        let target_id = format!("{holder_id}:{jurisdiction_id}");
+        let record = RevocationRecord::immediate(
+            RevocationType::Membership,
+            target_id,
+            RevocationScope::Jurisdiction {
+                jurisdiction_id: jurisdiction_id.clone(),
+            },
+            authority,
+            reason,
+        );
+
+        // Add to registry
+        self.add_revocation(record.clone()).await?;
+
+        // Ban the member
+        affiliation.ban();
+
+        // Update holder via store
+        self.store.put_holder(&holder)?;
+
+        Ok(record)
+    }
+
+    /// Check if a member is revoked in a jurisdiction
+    pub async fn is_member_revoked(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+    ) -> bool {
+        let target_id = format!("{holder_id}:{jurisdiction_id}");
+        self.revocations
+            .is_revoked_in_jurisdiction(&target_id, jurisdiction_id)
+    }
+
+    // ========== Membership Management Operations ==========
+
+    /// Apply for membership in a jurisdiction.
+    ///
+    /// Sybil resistance: requires at least `POPLevel::Strong` to apply.
+    /// This prevents an attacker from creating many `Weak`-level identities
+    /// to flood jurisdiction membership rolls.
+    pub async fn apply_for_membership(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: JurisdictionId,
+        capabilities_requested: Vec<MembershipCapability>,
+    ) -> Result<Affiliation> {
+        // Verify holder exists and is active
+        let mut holder = self
+            .get_holder(holder_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
+
+        if !holder.is_active() {
+            bail!("Holder is not active");
+        }
+
+        // Sybil gate: require at least Strong POP level for membership
+        if holder.personhood_level < POPLevel::Strong {
+            bail!(
+                "Membership requires at least Strong POP level (current: Weak). \
+                 Obtain additional attestations to upgrade."
+            );
+        }
+
+        // Check not already affiliated
+        if holder.is_affiliated(&jurisdiction_id) {
+            bail!("Already affiliated with jurisdiction: {jurisdiction_id}");
+        }
+
+        // Check not revoked from this jurisdiction
+        if self.is_member_revoked(holder_id, &jurisdiction_id).await {
+            bail!("Previously banned from jurisdiction: {jurisdiction_id}");
+        }
+
+        // Create affiliation as candidate
+        let mut affiliation = Affiliation::new(jurisdiction_id.clone());
+        // Store requested capabilities for review
+        for cap in capabilities_requested {
+            affiliation.add_capability(cap);
+        }
+
+        // Add to holder
+        holder.add_affiliation(affiliation.clone());
+
+        // Update storage via store
+        self.store.put_holder(&holder)?;
+
+        Ok(affiliation)
+    }
+
+    /// Approve a membership application (moves from Candidate to Provisional)
+    pub async fn approve_membership(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+    ) -> Result<()> {
+        let mut holder = self
+            .get_holder(holder_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
+
+        let affiliation = holder.get_affiliation_mut(jurisdiction_id).ok_or_else(|| {
+            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
+        })?;
+
+        if affiliation.membership_status != MembershipStatus::Candidate {
+            bail!(
+                "Can only approve candidates, current status: {}",
+                affiliation.membership_status
+            );
+        }
+
+        affiliation.approve();
+
+        self.store.put_holder(&holder)?;
+
+        // Record approval metric
+        icn_obs::metrics::commons::membership_approved_inc(jurisdiction_id.as_str());
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "membership_approved",
+            holder_id = %holder_id,
+            jurisdiction = %jurisdiction_id.as_str(),
+            "Membership application approved"
+        );
+
+        Ok(())
+    }
+
+    /// Promote a member from Provisional to full Member
+    pub async fn promote_member(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+    ) -> Result<()> {
+        let mut holder = self
+            .get_holder(holder_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
+
+        let affiliation = holder.get_affiliation_mut(jurisdiction_id).ok_or_else(|| {
+            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
+        })?;
+
+        if affiliation.membership_status != MembershipStatus::Provisional {
+            bail!(
+                "Can only promote provisional members, current status: {}",
+                affiliation.membership_status
+            );
+        }
+
+        affiliation.promote();
+
+        self.store.put_holder(&holder)?;
+
+        // Record promotion metric
+        icn_obs::metrics::commons::membership_promoted_inc(jurisdiction_id.as_str());
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "membership_promoted",
+            holder_id = %holder_id,
+            jurisdiction = %jurisdiction_id.as_str(),
+            "Member promoted to full membership"
+        );
+
+        Ok(())
+    }
+
+    /// Suspend a member
+    pub async fn suspend_member(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+    ) -> Result<()> {
+        let mut holder = self
+            .get_holder(holder_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
+
+        let affiliation = holder.get_affiliation_mut(jurisdiction_id).ok_or_else(|| {
+            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
+        })?;
+
+        affiliation.suspend();
+
+        self.store.put_holder(&holder)?;
+
+        // Audit log
+        warn!(
+            target: "commons_audit",
+            action = "member_suspended",
+            holder_id = %holder_id,
+            jurisdiction = %jurisdiction_id.as_str(),
+            "Member suspended"
+        );
+
+        Ok(())
+    }
+
+    /// Reinstate a suspended member
+    pub async fn reinstate_member(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+    ) -> Result<()> {
+        let mut holder = self
+            .get_holder(holder_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
+
+        let affiliation = holder.get_affiliation_mut(jurisdiction_id).ok_or_else(|| {
+            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
+        })?;
+
+        if affiliation.membership_status != MembershipStatus::Suspended {
+            bail!("Member is not suspended");
+        }
+
+        // Reinstate to Member status
+        affiliation.membership_status = MembershipStatus::Member;
+
+        self.store.put_holder(&holder)?;
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "member_reinstated",
+            holder_id = %holder_id,
+            jurisdiction = %jurisdiction_id.as_str(),
+            "Member reinstated"
+        );
+
+        Ok(())
+    }
+
+    /// Grant a capability to a member
+    pub async fn grant_capability(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+        capability: MembershipCapability,
+    ) -> Result<()> {
+        let mut holder = self
+            .get_holder(holder_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
+
+        let affiliation = holder.get_affiliation_mut(jurisdiction_id).ok_or_else(|| {
+            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
+        })?;
+
+        if !affiliation.is_active() {
+            bail!("Member is not active");
+        }
+
+        affiliation.add_capability(capability);
+
+        self.store.put_holder(&holder)?;
+
+        Ok(())
+    }
+
+    /// Revoke a capability from a member
+    pub async fn revoke_capability(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+        capability: MembershipCapability,
+    ) -> Result<()> {
+        let mut holder = self
+            .get_holder(holder_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
+
+        let affiliation = holder.get_affiliation_mut(jurisdiction_id).ok_or_else(|| {
+            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
+        })?;
+
+        affiliation.remove_capability(capability);
+
+        self.store.put_holder(&holder)?;
+
+        Ok(())
+    }
+
+    /// Add a role to a member
+    pub async fn add_member_role(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+        role: String,
+    ) -> Result<()> {
+        let mut holder = self
+            .get_holder(holder_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
+
+        let affiliation = holder.get_affiliation_mut(jurisdiction_id).ok_or_else(|| {
+            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
+        })?;
+
+        if !affiliation.roles.contains(&role) {
+            affiliation.roles.push(role);
+        }
+
+        self.store.put_holder(&holder)?;
+
+        Ok(())
+    }
+
+    /// Remove a role from a member
+    pub async fn remove_member_role(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+        role: &str,
+    ) -> Result<()> {
+        let mut holder = self
+            .get_holder(holder_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
+
+        let affiliation = holder.get_affiliation_mut(jurisdiction_id).ok_or_else(|| {
+            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
+        })?;
+
+        affiliation.roles.retain(|r| r != role);
+
+        self.store.put_holder(&holder)?;
+
+        Ok(())
+    }
+
+    /// Check if a member has a specific capability
+    pub async fn member_has_capability(
+        &self,
+        holder_id: &str,
+        jurisdiction_id: &JurisdictionId,
+        capability: MembershipCapability,
+    ) -> Result<bool> {
+        let holder = self
+            .get_holder(holder_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
+
+        let affiliation = holder.get_affiliation(jurisdiction_id).ok_or_else(|| {
+            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
+        })?;
+
+        Ok(affiliation.is_active() && affiliation.has_capability(capability))
+    }
+
+    /// List members of a jurisdiction by status
+    pub async fn list_members_by_status(
+        &self,
+        jurisdiction_id: &JurisdictionId,
+        status: Option<MembershipStatus>,
+    ) -> Vec<(String, Affiliation)> {
+        let holders = match self.store.list_holders() {
+            Ok(h) => h,
+            Err(_) => return Vec::new(),
+        };
+
+        let mut results = Vec::new();
+        for holder in holders {
+            let holder_id = hex::encode(holder.id());
+            if let Some(affiliation) = holder.get_affiliation(jurisdiction_id) {
+                if status.is_none() || Some(affiliation.membership_status) == status {
+                    results.push((holder_id, affiliation.clone()));
+                }
+            }
+        }
+
+        results
+    }
+
+    // ========== Amendment Operations (v0.6.0 Constitutional Governance) ==========
+
+    /// Store an amendment
+    pub async fn store_amendment(&self, amendment: Amendment) -> Result<()> {
+        let amendment_id = amendment.id.to_hex();
+        let proposer = amendment.proposer.to_string();
+
+        self.store.put_amendment(&amendment)?;
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "amendment_created",
+            amendment_id = %amendment_id,
+            proposer = %proposer,
+            scope = %format!("{}", amendment.scope),
+            amendment_type = %format!("{}", amendment.amendment_type),
+            "Amendment created"
+        );
+
+        Ok(())
+    }
+
+    /// Add a change to a draft amendment
+    ///
+    /// Requirements:
+    /// - Amendment must exist
+    /// - Amendment must be in Draft status
+    /// - Caller should be the proposer (validation done at API layer)
+    pub async fn add_amendment_change(
+        &self,
+        amendment_id: &str,
+        change: AmendmentChange,
+    ) -> Result<Amendment> {
+        let mut amendment = self
+            .store
+            .get_amendment(amendment_id)?
+            .ok_or_else(|| anyhow::anyhow!("Amendment not found: {amendment_id}"))?;
+
+        // Validate amendment is in Draft status
+        if !matches!(amendment.status, AmendmentStatus::Draft) {
+            bail!(
+                "Cannot add changes to amendment in status {:?}, must be Draft",
+                amendment.status
+            );
+        }
+
+        // Add the change
+        let change_desc = change.description.clone();
+        amendment.add_change(change);
+
+        // Persist updated amendment
+        self.store.put_amendment(&amendment)?;
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "amendment_change_added",
+            amendment_id = %amendment_id,
+            change = %change_desc,
+            total_changes = amendment.changes.len(),
+            "Change added to amendment"
+        );
+
+        Ok(amendment)
+    }
+
+    /// Get an amendment by ID
+    pub async fn get_amendment(&self, id: &AmendmentId) -> Result<Option<Amendment>> {
+        let id_hex = id.to_hex();
+        self.store.get_amendment(&id_hex)
+    }
+
+    /// List amendments with optional filters
+    pub async fn list_amendments(
+        &self,
+        status: Option<&str>,
+        scope: Option<&str>,
+        amendment_type: Option<&str>,
+    ) -> Result<Vec<Amendment>> {
+        let mut results = self.store.list_amendments()?;
+
+        // Filter by status
+        if let Some(s) = status {
+            let s_lower = s.to_lowercase();
+            results.retain(|a| format!("{:?}", a.status).to_lowercase().contains(&s_lower));
+        }
+
+        // Filter by scope
+        if let Some(s) = scope {
+            let s_lower = s.to_lowercase();
+            results.retain(|a| format!("{}", a.scope).to_lowercase().contains(&s_lower));
+        }
+
+        // Filter by type
+        if let Some(t) = amendment_type {
+            let t_lower = t.to_lowercase();
+            results.retain(|a| {
+                format!("{}", a.amendment_type)
+                    .to_lowercase()
+                    .contains(&t_lower)
+            });
+        }
+
+        // Sort by created_at descending
+        results.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+        Ok(results)
+    }
+
+    /// Submit an amendment for review
+    pub async fn submit_amendment(&self, id: &AmendmentId, caller: &Did) -> Result<Amendment> {
+        let id_hex = id.to_hex();
+        let mut amendment = self
+            .store
+            .get_amendment(&id_hex)?
+            .ok_or_else(|| anyhow::anyhow!("Amendment not found"))?;
+
+        // Only proposer can submit
+        if amendment.proposer != *caller {
+            bail!("Only proposer can submit amendment");
+        }
+
+        amendment.submit().map_err(|e| anyhow::anyhow!(e))?;
+        self.store.put_amendment(&amendment)?;
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "amendment_submitted",
+            amendment_id = %id_hex,
+            caller = %caller.to_string(),
+            "Amendment submitted for review"
+        );
+
+        Ok(amendment)
+    }
+
+    /// Open voting on an amendment (skipping review for simple cases)
+    pub async fn open_amendment_voting(
+        &self,
+        id: &AmendmentId,
+        _caller: &Did,
+    ) -> Result<Amendment> {
+        let id_hex = id.to_hex();
+        let mut amendment = self
+            .store
+            .get_amendment(&id_hex)?
+            .ok_or_else(|| anyhow::anyhow!("Amendment not found"))?;
+
+        // If still in submitted state, begin review first (auto-skip if review_period is 0)
+        if matches!(amendment.status, AmendmentStatus::Submitted { .. }) {
+            amendment.begin_review().map_err(|e| anyhow::anyhow!(e))?;
+        }
+
+        amendment.open_voting().map_err(|e| anyhow::anyhow!(e))?;
+        self.store.put_amendment(&amendment)?;
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "amendment_voting_opened",
+            amendment_id = %id_hex,
+            "Amendment voting period opened"
+        );
+
+        Ok(amendment)
+    }
+
+    /// Add a ratification to an amendment
+    pub async fn add_amendment_ratification(
+        &self,
+        id: &AmendmentId,
+        ratification: Ratification,
+    ) -> Result<Amendment> {
+        let id_hex = id.to_hex();
+        let mut amendment = self
+            .store
+            .get_amendment(&id_hex)?
+            .ok_or_else(|| anyhow::anyhow!("Amendment not found"))?;
+
+        let ratifier = ratification.authority_did.to_string();
+        amendment
+            .add_ratification(ratification)
+            .map_err(|e| anyhow::anyhow!(e))?;
+
+        // Check if ratification requirements are now met
+        let result = amendment.check_ratification();
+        let was_ratified = matches!(result, icn_governance::RatificationResult::Approved { .. });
+        if was_ratified {
+            let _ = amendment.ratify();
+        }
+
+        self.store.put_amendment(&amendment)?;
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "amendment_ratification_added",
+            amendment_id = %id_hex,
+            ratifier = %ratifier,
+            total_ratifications = amendment.ratifications.len(),
+            amendment_ratified = was_ratified,
+            "Amendment ratification added"
+        );
+
+        Ok(amendment)
+    }
+
+    /// Withdraw an amendment
+    pub async fn withdraw_amendment(
+        &self,
+        id: &AmendmentId,
+        caller: &Did,
+        reason: String,
+    ) -> Result<Amendment> {
+        let id_hex = id.to_hex();
+        let mut amendment = self
+            .store
+            .get_amendment(&id_hex)?
+            .ok_or_else(|| anyhow::anyhow!("Amendment not found"))?;
+
+        // Only proposer can withdraw
+        if amendment.proposer != *caller {
+            bail!("Only proposer can withdraw amendment");
+        }
+
+        amendment
+            .withdraw(reason.clone())
+            .map_err(|e| anyhow::anyhow!(e))?;
+        self.store.put_amendment(&amendment)?;
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "amendment_withdrawn",
+            amendment_id = %id_hex,
+            caller = %caller.to_string(),
+            reason = %reason,
+            "Amendment withdrawn"
+        );
+
+        Ok(amendment)
+    }
+
+    // ========== Appeal Operations (v0.6.0 Constitutional Governance) ==========
+
+    /// Store an appeal
+    pub async fn store_appeal(&self, appeal: Appeal) -> Result<()> {
+        let appeal_id = appeal.id.to_hex();
+        let appellant = appeal.appellant.to_string();
+
+        self.store.put_appeal(&appeal)?;
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "appeal_created",
+            appeal_id = %appeal_id,
+            appellant = %appellant,
+            scope = %format!("{}", appeal.scope),
+            "Appeal created"
+        );
+
+        Ok(())
+    }
+
+    /// Get an appeal by ID
+    pub async fn get_appeal(&self, id: &AppealId) -> Result<Option<Appeal>> {
+        let id_hex = id.to_hex();
+        self.store.get_appeal(&id_hex)
+    }
+
+    /// List appeals with optional filters
+    pub async fn list_appeals(
+        &self,
+        status: Option<&str>,
+        scope: Option<&str>,
+        appellant: Option<&str>,
+    ) -> Result<Vec<Appeal>> {
+        let mut results = self.store.list_appeals()?;
+
+        // Filter by status
+        if let Some(s) = status {
+            let s_lower = s.to_lowercase();
+            results.retain(|a| format!("{:?}", a.status).to_lowercase().contains(&s_lower));
+        }
+
+        // Filter by scope
+        if let Some(s) = scope {
+            let s_lower = s.to_lowercase();
+            results.retain(|a| format!("{}", a.scope).to_lowercase().contains(&s_lower));
+        }
+
+        // Filter by appellant
+        if let Some(a) = appellant {
+            results.retain(|appeal| appeal.appellant.to_string() == a);
+        }
+
+        // Sort by created_at descending
+        results.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+        Ok(results)
+    }
+
+    /// Add evidence to an appeal
+    pub async fn add_appeal_evidence(
+        &self,
+        id: &AppealId,
+        evidence: AppealEvidence,
+    ) -> Result<Appeal> {
+        let id_hex = id.to_hex();
+        let mut appeal = self
+            .store
+            .get_appeal(&id_hex)?
+            .ok_or_else(|| anyhow::anyhow!("Appeal not found"))?;
+
+        appeal
+            .add_evidence(evidence)
+            .map_err(|e| anyhow::anyhow!(e))?;
+        self.store.put_appeal(&appeal)?;
+        Ok(appeal)
+    }
+
+    /// Add response to an appeal
+    pub async fn add_appeal_response(
+        &self,
+        id: &AppealId,
+        response: AppealResponse,
+    ) -> Result<Appeal> {
+        let id_hex = id.to_hex();
+        let mut appeal = self
+            .store
+            .get_appeal(&id_hex)?
+            .ok_or_else(|| anyhow::anyhow!("Appeal not found"))?;
+
+        appeal
+            .add_response(response)
+            .map_err(|e| anyhow::anyhow!(e))?;
+        self.store.put_appeal(&appeal)?;
+        Ok(appeal)
+    }
+
+    /// Begin review of an appeal
+    pub async fn begin_appeal_review(&self, id: &AppealId) -> Result<Appeal> {
+        let id_hex = id.to_hex();
+        let mut appeal = self
+            .store
+            .get_appeal(&id_hex)?
+            .ok_or_else(|| anyhow::anyhow!("Appeal not found"))?;
+
+        appeal.begin_review().map_err(|e| anyhow::anyhow!(e))?;
+        self.store.put_appeal(&appeal)?;
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "appeal_review_started",
+            appeal_id = %id_hex,
+            "Appeal review started"
+        );
+
+        Ok(appeal)
+    }
+
+    /// Resolve a constitutional appeal with outcome
+    pub async fn resolve_constitutional_appeal(
+        &self,
+        id: &AppealId,
+        outcome: AppealOutcome,
+    ) -> Result<Appeal> {
+        let id_hex = id.to_hex();
+        let mut appeal = self
+            .store
+            .get_appeal(&id_hex)?
+            .ok_or_else(|| anyhow::anyhow!("Appeal not found"))?;
+
+        let outcome_str = format!("{outcome:?}");
+        appeal.resolve(outcome).map_err(|e| anyhow::anyhow!(e))?;
+        self.store.put_appeal(&appeal)?;
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "appeal_resolved",
+            appeal_id = %id_hex,
+            outcome = %outcome_str,
+            "Constitutional appeal resolved"
+        );
+
+        Ok(appeal)
+    }
+
+    /// Withdraw an appeal
+    pub async fn withdraw_appeal(
+        &self,
+        id: &AppealId,
+        caller: &Did,
+        reason: Option<String>,
+    ) -> Result<Appeal> {
+        let id_hex = id.to_hex();
+        let mut appeal = self
+            .store
+            .get_appeal(&id_hex)?
+            .ok_or_else(|| anyhow::anyhow!("Appeal not found"))?;
+
+        // Only appellant can withdraw
+        if appeal.appellant != *caller {
+            bail!("Only appellant can withdraw appeal");
+        }
+
+        appeal
+            .withdraw(reason.clone())
+            .map_err(|e| anyhow::anyhow!(e))?;
+        self.store.put_appeal(&appeal)?;
+
+        // Audit log
+        info!(
+            target: "commons_audit",
+            action = "appeal_withdrawn",
+            appeal_id = %id_hex,
+            caller = %caller.to_string(),
+            reason = ?reason,
+            "Appeal withdrawn"
+        );
+
+        Ok(appeal)
+    }
+}

--- a/icn/crates/icn-commons/src/inner.rs
+++ b/icn/crates/icn-commons/src/inner.rs
@@ -1293,11 +1293,19 @@ impl CommonsInner {
     /// Sybil resistance: requires at least `POPLevel::Strong` to apply.
     /// This prevents an attacker from creating many `Weak`-level identities
     /// to flood jurisdiction membership rolls.
+    /// Submit a membership application for a jurisdiction.
+    ///
+    /// Creates a `Candidate` affiliation with no capabilities.  Capabilities are
+    /// jurisdiction-granted — they are never accepted from the applicant.  Baseline
+    /// member capabilities (`Vote`, `Propose`, `Transact`) are granted automatically
+    /// when the jurisdiction promotes the candidate to full `Member` via
+    /// `promote_member`.  Elevated capabilities (e.g., `HoldOffice`) must be
+    /// explicitly delegated through the `grant_capability` path after membership
+    /// is established.
     pub async fn apply_for_membership(
         &self,
         holder_id: &str,
         jurisdiction_id: JurisdictionId,
-        capabilities_requested: Vec<MembershipCapability>,
     ) -> Result<Affiliation> {
         // Verify holder exists and is active
         let mut holder = self
@@ -1327,12 +1335,8 @@ impl CommonsInner {
             bail!("Previously banned from jurisdiction: {jurisdiction_id}");
         }
 
-        // Create affiliation as candidate
-        let mut affiliation = Affiliation::new(jurisdiction_id.clone());
-        // Store requested capabilities for review
-        for cap in capabilities_requested {
-            affiliation.add_capability(cap);
-        }
+        // Create affiliation as candidate — no capabilities granted at application time.
+        let affiliation = Affiliation::new(jurisdiction_id.clone());
 
         // Add to holder
         holder.add_affiliation(affiliation.clone());

--- a/icn/crates/icn-commons/src/inner.rs
+++ b/icn/crates/icn-commons/src/inner.rs
@@ -9,9 +9,10 @@
 //! - Revocation operations
 //! - Amendment operations
 //! - Appeal operations
-//! - Enrollment session operations
 //!
-//! Gateway-local DTO methods (e.g. `build_governance_dashboard`) are intentionally absent.
+//! Enrollment session handling and gateway-local DTO methods
+//! (e.g. `build_governance_dashboard`) are intentionally kept in the gateway layer,
+//! not in CommonsInner.
 
 use anyhow::{bail, Result};
 use icn_governance::{
@@ -51,7 +52,7 @@ impl CommonsInner {
     /// Create a new CommonsInner with the given backend
     pub fn new(backend: Arc<dyn CommonsStoreBackend>) -> Self {
         CommonsInner {
-            store: CommonsStore::new(Arc::new(backend)),
+            store: CommonsStore::new(backend),
             revocations: RevocationRegistry::new(),
         }
     }

--- a/icn/crates/icn-commons/src/inner.rs
+++ b/icn/crates/icn-commons/src/inner.rs
@@ -1712,6 +1712,34 @@ impl CommonsInner {
         Ok(results)
     }
 
+    /// List amendments scoped to a specific domain (exact match on `AmendmentScope::Jurisdiction`).
+    ///
+    /// Only returns amendments whose scope is `Jurisdiction { domain_id }` with an
+    /// exact-string match on `domain_id`. Network- and Federation-scoped amendments are
+    /// excluded. This prevents the cross-contamination where a domain-ID prefix match
+    /// ("coop:alpha") would also return records for "coop:alpha-test".
+    pub async fn list_amendments_by_domain(&self, domain_id: &str) -> Result<Vec<Amendment>> {
+        let mut results = self.store.list_amendments()?;
+        results.retain(|a| {
+            matches!(&a.scope, icn_governance::AmendmentScope::Jurisdiction { domain_id: d } if d == domain_id)
+        });
+        results.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(results)
+    }
+
+    /// List appeals scoped to a specific domain (exact match on `AppealScope::Jurisdiction`).
+    ///
+    /// Mirrors `list_amendments_by_domain` — only `Jurisdiction { domain_id }` variants
+    /// with exact-string match are returned.
+    pub async fn list_appeals_by_domain(&self, domain_id: &str) -> Result<Vec<Appeal>> {
+        let mut results = self.store.list_appeals()?;
+        results.retain(|a| {
+            matches!(&a.scope, icn_governance::AppealScope::Jurisdiction { domain_id: d } if d == domain_id)
+        });
+        results.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(results)
+    }
+
     /// Submit an amendment for review
     pub async fn submit_amendment(&self, id: &AmendmentId, caller: &Did) -> Result<Amendment> {
         let id_hex = id.to_hex();

--- a/icn/crates/icn-commons/src/inner.rs
+++ b/icn/crates/icn-commons/src/inner.rs
@@ -435,6 +435,14 @@ impl CommonsInner {
     /// Add an affiliation (join jurisdiction).
     ///
     /// Sybil resistance: requires at least `POPLevel::Strong` to join.
+    ///
+    /// `initial_capabilities` may only contain baseline member capabilities
+    /// (`Vote`, `Propose`, `Transact`). Elevated capabilities (`HoldOffice`,
+    /// `AccessPrivate`, `Sponsor`) must be granted via
+    /// [`Self::grant_capability`] after membership is established. Attempting
+    /// to seed an elevated capability returns an error. This invariant ensures
+    /// that authority always flows from jurisdictional delegation, not from
+    /// the enrollment path.
     pub async fn join_jurisdiction(
         &self,
         holder_id: &str,
@@ -464,6 +472,21 @@ impl CommonsInner {
                 "Already affiliated with jurisdiction: {}",
                 jurisdiction.as_str()
             );
+        }
+
+        // Guard: only baseline capabilities may be seeded at join time.
+        // Elevated capabilities (HoldOffice, AccessPrivate, Sponsor) must be
+        // granted via grant_capability after membership is established.
+        for cap in &initial_capabilities {
+            match cap {
+                MembershipCapability::Vote
+                | MembershipCapability::Propose
+                | MembershipCapability::Transact => {}
+                _ => bail!(
+                    "Elevated capability `{cap}` cannot be seeded at join time; \
+                     grant it via `grant_capability` after membership is established"
+                ),
+            }
         }
 
         // Create affiliation (starts as Candidate by default)

--- a/icn/crates/icn-commons/src/lib.rs
+++ b/icn/crates/icn-commons/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod handle;
+pub mod inner;
+pub mod store;
+
+pub use handle::CommonsHandle;
+pub use inner::CommonsInner;
+pub use store::{CommonsStore, CommonsStoreBackend, InMemoryCommonsStore, SledCommonsStore};

--- a/icn/crates/icn-commons/src/store.rs
+++ b/icn/crates/icn-commons/src/store.rs
@@ -199,7 +199,8 @@ impl CommonsStoreBackend for InMemoryCommonsStore {
 
 /// Sled-based persistent store implementation
 ///
-/// Enable with the `sled-storage` feature flag.
+/// Sled is an unconditional dependency of `icn-commons`. No feature flag is
+/// required to use this backend.
 pub struct SledCommonsStore {
     db: sled::Db,
 }
@@ -290,9 +291,15 @@ impl Default for CacheConfig {
     }
 }
 
-/// High-level Commons storage with caching
+/// High-level Commons storage with caching.
+///
+/// `S` is the storage backend. When used from `CommonsInner`, `S` is
+/// `Arc<dyn CommonsStoreBackend>` (a single Arc wrapping the backend). The
+/// backend is stored as `S` directly — not wrapped in an additional `Arc` —
+/// so callers that already pass an `Arc` do not end up with a nested
+/// `Arc<Arc<...>>`.
 pub struct CommonsStore<S: CommonsStoreBackend> {
-    store: Arc<S>,
+    store: S,
     // Caches for frequently accessed records
     anchor_cache: RwLock<LruCache<String, PersonhoodAnchor>>,
     holder_cache: RwLock<LruCache<String, CommonsHolderRecord>>,
@@ -303,13 +310,16 @@ pub struct CommonsStore<S: CommonsStoreBackend> {
 }
 
 impl<S: CommonsStoreBackend> CommonsStore<S> {
-    /// Create a new CommonsStore with default cache sizes
-    pub fn new(store: Arc<S>) -> Self {
+    /// Create a new CommonsStore with default cache sizes.
+    ///
+    /// Pass the backend directly. If the backend is already an `Arc<B>`,
+    /// pass the `Arc` — it will not be double-wrapped.
+    pub fn new(store: S) -> Self {
         Self::with_config(store, CacheConfig::default())
     }
 
     /// Create with custom cache configuration
-    pub fn with_config(store: Arc<S>, config: CacheConfig) -> Self {
+    pub fn with_config(store: S, config: CacheConfig) -> Self {
         // Helper to ensure cache size is at least 1
         // SAFETY: .max(1) ensures the value is always non-zero
         #[allow(clippy::unwrap_used)]
@@ -329,7 +339,7 @@ impl<S: CommonsStoreBackend> CommonsStore<S> {
     }
 
     /// Get reference to underlying backend
-    pub fn backend(&self) -> &Arc<S> {
+    pub fn backend(&self) -> &S {
         &self.store
     }
 

--- a/icn/crates/icn-commons/src/store.rs
+++ b/icn/crates/icn-commons/src/store.rs
@@ -1,0 +1,1029 @@
+//! Commons Storage Backend
+//!
+//! Persistent storage abstraction for CommonsManager data using a key-value store.
+//!
+//! # Storage Layout
+//!
+//! ```text
+//! commons/anchors/<anchor_id>              -> PersonhoodAnchor
+//! commons/anchors/by_did/<did>             -> anchor_id
+//! commons/holders/<holder_id>              -> CommonsHolderRecord
+//! commons/holders/by_did/<did>             -> holder_id
+//! commons/holders/by_anchor/<anchor_id>    -> holder_id
+//! commons/charters/<charter_id>            -> Charter
+//! commons/charters/by_domain/<domain_id>   -> charter_id
+//! commons/stewards/<steward_id>            -> StewardRecord
+//! commons/stewards/by_did/<did>            -> steward_id
+//! commons/amendments/<amendment_id>        -> Amendment
+//! commons/appeals/<appeal_id>              -> Appeal
+//! commons/revocations/<revocation_id>      -> RevocationRecord
+//! ```
+
+use anyhow::{Context, Result};
+use icn_governance::{Amendment, Appeal, Charter, StewardRecord};
+use icn_identity::{CommonsHolderRecord, PersonhoodAnchor, RevocationRecord};
+use lru::LruCache;
+use serde::{de::DeserializeOwned, Serialize};
+use std::collections::BTreeMap;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, RwLock};
+use tracing::{debug, warn};
+
+// ============================================================================
+// Storage Key Prefixes
+// ============================================================================
+
+pub const ANCHOR_PREFIX: &[u8] = b"commons/anchors/";
+pub const ANCHOR_BY_DID_PREFIX: &[u8] = b"commons/anchors/by_did/";
+pub const HOLDER_PREFIX: &[u8] = b"commons/holders/";
+pub const HOLDER_BY_DID_PREFIX: &[u8] = b"commons/holders/by_did/";
+pub const HOLDER_BY_ANCHOR_PREFIX: &[u8] = b"commons/holders/by_anchor/";
+pub const CHARTER_PREFIX: &[u8] = b"commons/charters/";
+pub const CHARTER_BY_DOMAIN_PREFIX: &[u8] = b"commons/charters/by_domain/";
+pub const STEWARD_PREFIX: &[u8] = b"commons/stewards/";
+pub const STEWARD_BY_DID_PREFIX: &[u8] = b"commons/stewards/by_did/";
+pub const AMENDMENT_PREFIX: &[u8] = b"commons/amendments/";
+pub const APPEAL_PREFIX: &[u8] = b"commons/appeals/";
+pub const REVOCATION_PREFIX: &[u8] = b"commons/revocations/";
+// Note: ceremony and enrollment session storage stays in icn-gateway (gateway-local types).
+
+// ============================================================================
+// Storage Backend Trait
+// ============================================================================
+
+/// Low-level key-value store backend trait
+pub trait CommonsStoreBackend: Send + Sync {
+    /// Get a value by key
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>>;
+
+    /// Store a key-value pair
+    fn put(&self, key: &[u8], value: &[u8]) -> Result<()>;
+
+    /// Delete a key
+    fn delete(&self, key: &[u8]) -> Result<()>;
+
+    /// Scan all keys with a given prefix
+    fn scan(&self, prefix: &[u8]) -> Result<Vec<(Vec<u8>, Vec<u8>)>>;
+
+    /// Check if a key exists
+    fn exists(&self, key: &[u8]) -> Result<bool> {
+        Ok(self.get(key)?.is_some())
+    }
+
+    /// Flush pending writes to durable storage. Default is a no-op for in-memory backends.
+    fn flush(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Allow `Arc<dyn CommonsStoreBackend>` to be used as a backend directly.
+/// This enables type-erased `CommonsManager` construction without changing handler signatures.
+impl CommonsStoreBackend for Arc<dyn CommonsStoreBackend> {
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        self.as_ref().get(key)
+    }
+    fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        self.as_ref().put(key, value)
+    }
+    fn delete(&self, key: &[u8]) -> Result<()> {
+        self.as_ref().delete(key)
+    }
+    fn scan(&self, prefix: &[u8]) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
+        self.as_ref().scan(prefix)
+    }
+    fn flush(&self) -> Result<()> {
+        self.as_ref().flush()
+    }
+}
+
+// ============================================================================
+// In-Memory Implementation
+// ============================================================================
+
+/// In-memory store implementation for testing and development
+#[derive(Default)]
+pub struct InMemoryCommonsStore {
+    pub(crate) data: RwLock<BTreeMap<Vec<u8>, Vec<u8>>>,
+}
+
+impl InMemoryCommonsStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Get total entry count
+    pub fn len(&self) -> usize {
+        self.data
+            .read()
+            .unwrap_or_else(|poisoned| {
+                warn!("Data lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .len()
+    }
+
+    /// Check if empty
+    pub fn is_empty(&self) -> bool {
+        self.data
+            .read()
+            .unwrap_or_else(|poisoned| {
+                warn!("Data lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .is_empty()
+    }
+
+    /// Clear all data
+    pub fn clear(&self) {
+        self.data
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Data lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .clear();
+    }
+}
+
+impl CommonsStoreBackend for InMemoryCommonsStore {
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        Ok(self
+            .data
+            .read()
+            .unwrap_or_else(|poisoned| {
+                warn!("Data lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .get(key)
+            .cloned())
+    }
+
+    fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        self.data
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Data lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .insert(key.to_vec(), value.to_vec());
+        Ok(())
+    }
+
+    fn delete(&self, key: &[u8]) -> Result<()> {
+        self.data
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Data lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .remove(key);
+        Ok(())
+    }
+
+    fn scan(&self, prefix: &[u8]) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
+        let data = self.data.read().unwrap_or_else(|poisoned| {
+            warn!("Data lock poisoned, recovering");
+            poisoned.into_inner()
+        });
+        Ok(data
+            .range(prefix.to_vec()..)
+            .take_while(|(k, _)| k.starts_with(prefix))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect())
+    }
+}
+
+// ============================================================================
+// Sled Implementation (Feature-gated)
+// ============================================================================
+
+/// Sled-based persistent store implementation
+///
+/// Enable with the `sled-storage` feature flag.
+pub struct SledCommonsStore {
+    db: sled::Db,
+}
+
+impl SledCommonsStore {
+    /// Open a persistent Sled database at the given path
+    pub fn open(path: impl AsRef<std::path::Path>) -> Result<Self> {
+        let db = sled::open(path).context("Failed to open Sled database")?;
+        Ok(SledCommonsStore { db })
+    }
+
+    /// Create a temporary Sled database (deleted on drop)
+    pub fn temporary() -> Result<Self> {
+        let db = sled::Config::new()
+            .temporary(true)
+            .open()
+            .context("Failed to create temporary Sled database")?;
+        Ok(SledCommonsStore { db })
+    }
+
+    /// Flush all pending writes to disk
+    pub fn flush(&self) -> Result<()> {
+        self.db.flush().context("Failed to flush Sled database")?;
+        Ok(())
+    }
+
+    /// Get approximate database size in bytes
+    pub fn size_on_disk(&self) -> Result<u64> {
+        Ok(self.db.size_on_disk().unwrap_or(0))
+    }
+}
+
+impl CommonsStoreBackend for SledCommonsStore {
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        Ok(self.db.get(key)?.map(|v| v.to_vec()))
+    }
+
+    fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        self.db.insert(key, value)?;
+        Ok(())
+    }
+
+    fn delete(&self, key: &[u8]) -> Result<()> {
+        self.db.remove(key)?;
+        Ok(())
+    }
+
+    fn scan(&self, prefix: &[u8]) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
+        let mut results = Vec::new();
+        for item in self.db.scan_prefix(prefix) {
+            let (k, v) = item?;
+            results.push((k.to_vec(), v.to_vec()));
+        }
+        Ok(results)
+    }
+
+    fn flush(&self) -> Result<()> {
+        self.db.flush().context("Failed to flush Sled database")?;
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Commons Store (High-Level Interface)
+// ============================================================================
+
+/// Cache configuration
+#[derive(Clone)]
+pub struct CacheConfig {
+    pub anchor_cache_size: usize,
+    pub holder_cache_size: usize,
+    pub charter_cache_size: usize,
+    pub steward_cache_size: usize,
+    pub amendment_cache_size: usize,
+    pub appeal_cache_size: usize,
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        Self {
+            anchor_cache_size: 1000,
+            holder_cache_size: 1000,
+            charter_cache_size: 500,
+            steward_cache_size: 200,
+            amendment_cache_size: 500,
+            appeal_cache_size: 500,
+        }
+    }
+}
+
+/// High-level Commons storage with caching
+pub struct CommonsStore<S: CommonsStoreBackend> {
+    store: Arc<S>,
+    // Caches for frequently accessed records
+    anchor_cache: RwLock<LruCache<String, PersonhoodAnchor>>,
+    holder_cache: RwLock<LruCache<String, CommonsHolderRecord>>,
+    charter_cache: RwLock<LruCache<String, Charter>>,
+    steward_cache: RwLock<LruCache<String, StewardRecord>>,
+    amendment_cache: RwLock<LruCache<String, Amendment>>,
+    appeal_cache: RwLock<LruCache<String, Appeal>>,
+}
+
+impl<S: CommonsStoreBackend> CommonsStore<S> {
+    /// Create a new CommonsStore with default cache sizes
+    pub fn new(store: Arc<S>) -> Self {
+        Self::with_config(store, CacheConfig::default())
+    }
+
+    /// Create with custom cache configuration
+    pub fn with_config(store: Arc<S>, config: CacheConfig) -> Self {
+        // Helper to ensure cache size is at least 1
+        // SAFETY: .max(1) ensures the value is always non-zero
+        #[allow(clippy::unwrap_used)]
+        fn cache_size(size: usize) -> NonZeroUsize {
+            NonZeroUsize::new(size.max(1)).unwrap()
+        }
+
+        Self {
+            store,
+            anchor_cache: RwLock::new(LruCache::new(cache_size(config.anchor_cache_size))),
+            holder_cache: RwLock::new(LruCache::new(cache_size(config.holder_cache_size))),
+            charter_cache: RwLock::new(LruCache::new(cache_size(config.charter_cache_size))),
+            steward_cache: RwLock::new(LruCache::new(cache_size(config.steward_cache_size))),
+            amendment_cache: RwLock::new(LruCache::new(cache_size(config.amendment_cache_size))),
+            appeal_cache: RwLock::new(LruCache::new(cache_size(config.appeal_cache_size))),
+        }
+    }
+
+    /// Get reference to underlying backend
+    pub fn backend(&self) -> &Arc<S> {
+        &self.store
+    }
+
+    // ========================================================================
+    // Generic Helpers
+    // ========================================================================
+
+    fn make_key(prefix: &[u8], id: &str) -> Vec<u8> {
+        let mut key = prefix.to_vec();
+        key.extend_from_slice(id.as_bytes());
+        key
+    }
+
+    fn serialize<T: Serialize>(value: &T) -> Result<Vec<u8>> {
+        serde_json::to_vec(value).context("Serialization failed")
+    }
+
+    fn deserialize<T: DeserializeOwned>(data: &[u8]) -> Result<T> {
+        serde_json::from_slice(data).context("Deserialization failed")
+    }
+
+    // ========================================================================
+    // PersonhoodAnchor Operations
+    // ========================================================================
+
+    /// Store a PersonhoodAnchor
+    pub fn put_anchor(&self, anchor: &PersonhoodAnchor) -> Result<()> {
+        let id = hex::encode(anchor.id());
+        let did = anchor.to_did().to_string();
+
+        // Store main record
+        let key = Self::make_key(ANCHOR_PREFIX, &id);
+        let value = Self::serialize(anchor)?;
+        self.store.put(&key, &value)?;
+
+        // Update DID index
+        let did_key = Self::make_key(ANCHOR_BY_DID_PREFIX, &did);
+        self.store.put(&did_key, id.as_bytes())?;
+
+        // Update cache
+        self.anchor_cache
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Anchor cache lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .put(id.clone(), anchor.clone());
+
+        debug!("Stored anchor: {}", id);
+        Ok(())
+    }
+
+    /// Get a PersonhoodAnchor by ID
+    pub fn get_anchor(&self, id: &str) -> Result<Option<PersonhoodAnchor>> {
+        // Check cache
+        if let Some(cached) = self
+            .anchor_cache
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Anchor cache lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .get(id)
+        {
+            return Ok(Some(cached.clone()));
+        }
+
+        // Load from storage
+        let key = Self::make_key(ANCHOR_PREFIX, id);
+        if let Some(value) = self.store.get(&key)? {
+            let anchor: PersonhoodAnchor = Self::deserialize(&value)?;
+            self.anchor_cache
+                .write()
+                .unwrap_or_else(|poisoned| {
+                    warn!("Anchor cache lock poisoned, recovering");
+                    poisoned.into_inner()
+                })
+                .put(id.to_string(), anchor.clone());
+            return Ok(Some(anchor));
+        }
+
+        Ok(None)
+    }
+
+    /// Get anchor by DID
+    pub fn get_anchor_by_did(&self, did: &str) -> Result<Option<PersonhoodAnchor>> {
+        let did_key = Self::make_key(ANCHOR_BY_DID_PREFIX, did);
+        if let Some(id_bytes) = self.store.get(&did_key)? {
+            let id = String::from_utf8(id_bytes).context("Invalid anchor ID")?;
+            return self.get_anchor(&id);
+        }
+        Ok(None)
+    }
+
+    /// Add a DID -> anchor_id index entry
+    ///
+    /// This is used when the enrollment DID differs from the anchor's internal DID.
+    pub fn put_anchor_did_index(&self, did: &str, anchor_id: &str) -> Result<()> {
+        let did_key = Self::make_key(ANCHOR_BY_DID_PREFIX, did);
+        self.store.put(&did_key, anchor_id.as_bytes())?;
+        Ok(())
+    }
+
+    /// Delete an anchor
+    pub fn delete_anchor(&self, id: &str) -> Result<bool> {
+        if let Some(anchor) = self.get_anchor(id)? {
+            let did = anchor.to_did().to_string();
+
+            // Delete main record
+            let key = Self::make_key(ANCHOR_PREFIX, id);
+            self.store.delete(&key)?;
+
+            // Delete DID index
+            let did_key = Self::make_key(ANCHOR_BY_DID_PREFIX, &did);
+            self.store.delete(&did_key)?;
+
+            // Remove from cache
+            self.anchor_cache
+                .write()
+                .unwrap_or_else(|poisoned| {
+                    warn!("Anchor cache lock poisoned, recovering");
+                    poisoned.into_inner()
+                })
+                .pop(id);
+
+            debug!("Deleted anchor: {}", id);
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    /// List all anchors
+    pub fn list_anchors(&self) -> Result<Vec<PersonhoodAnchor>> {
+        let entries = self.store.scan(ANCHOR_PREFIX)?;
+        let mut anchors = Vec::new();
+
+        for (key, value) in entries {
+            // Skip index entries
+            if !key.starts_with(ANCHOR_BY_DID_PREFIX) {
+                if let Ok(anchor) = Self::deserialize::<PersonhoodAnchor>(&value) {
+                    anchors.push(anchor);
+                }
+            }
+        }
+
+        Ok(anchors)
+    }
+
+    // ========================================================================
+    // CommonsHolderRecord Operations
+    // ========================================================================
+
+    /// Store a CommonsHolderRecord
+    pub fn put_holder(&self, holder: &CommonsHolderRecord) -> Result<()> {
+        let id = hex::encode(holder.id());
+        let did = holder.holder_did.to_string();
+        let anchor_id = hex::encode(holder.anchor_id);
+
+        // Store main record
+        let key = Self::make_key(HOLDER_PREFIX, &id);
+        let value = Self::serialize(holder)?;
+        self.store.put(&key, &value)?;
+
+        // Update DID index
+        let did_key = Self::make_key(HOLDER_BY_DID_PREFIX, &did);
+        self.store.put(&did_key, id.as_bytes())?;
+
+        // Update anchor index
+        let anchor_key = Self::make_key(HOLDER_BY_ANCHOR_PREFIX, &anchor_id);
+        self.store.put(&anchor_key, id.as_bytes())?;
+
+        // Update cache
+        self.holder_cache
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Holder cache lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .put(id.clone(), holder.clone());
+
+        debug!("Stored holder: {}", id);
+        Ok(())
+    }
+
+    /// Get a CommonsHolderRecord by ID
+    pub fn get_holder(&self, id: &str) -> Result<Option<CommonsHolderRecord>> {
+        // Check cache
+        if let Some(cached) = self
+            .holder_cache
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Holder cache lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .get(id)
+        {
+            return Ok(Some(cached.clone()));
+        }
+
+        // Load from storage
+        let key = Self::make_key(HOLDER_PREFIX, id);
+        if let Some(value) = self.store.get(&key)? {
+            let holder: CommonsHolderRecord = Self::deserialize(&value)?;
+            self.holder_cache
+                .write()
+                .unwrap_or_else(|poisoned| {
+                    warn!("Holder cache lock poisoned, recovering");
+                    poisoned.into_inner()
+                })
+                .put(id.to_string(), holder.clone());
+            return Ok(Some(holder));
+        }
+
+        Ok(None)
+    }
+
+    /// Get holder by DID
+    pub fn get_holder_by_did(&self, did: &str) -> Result<Option<CommonsHolderRecord>> {
+        let did_key = Self::make_key(HOLDER_BY_DID_PREFIX, did);
+        if let Some(id_bytes) = self.store.get(&did_key)? {
+            let id = String::from_utf8(id_bytes).context("Invalid holder ID")?;
+            return self.get_holder(&id);
+        }
+        Ok(None)
+    }
+
+    /// Get holder by anchor ID
+    pub fn get_holder_by_anchor(&self, anchor_id: &str) -> Result<Option<CommonsHolderRecord>> {
+        let anchor_key = Self::make_key(HOLDER_BY_ANCHOR_PREFIX, anchor_id);
+        if let Some(id_bytes) = self.store.get(&anchor_key)? {
+            let id = String::from_utf8(id_bytes).context("Invalid holder ID")?;
+            return self.get_holder(&id);
+        }
+        Ok(None)
+    }
+
+    /// Delete a holder
+    pub fn delete_holder(&self, id: &str) -> Result<bool> {
+        if let Some(holder) = self.get_holder(id)? {
+            let did = holder.holder_did.to_string();
+            let anchor_id = hex::encode(holder.anchor_id);
+
+            // Delete main record
+            let key = Self::make_key(HOLDER_PREFIX, id);
+            self.store.delete(&key)?;
+
+            // Delete indexes
+            let did_key = Self::make_key(HOLDER_BY_DID_PREFIX, &did);
+            self.store.delete(&did_key)?;
+
+            let anchor_key = Self::make_key(HOLDER_BY_ANCHOR_PREFIX, &anchor_id);
+            self.store.delete(&anchor_key)?;
+
+            // Remove from cache
+            self.holder_cache
+                .write()
+                .unwrap_or_else(|poisoned| {
+                    warn!("Holder cache lock poisoned, recovering");
+                    poisoned.into_inner()
+                })
+                .pop(id);
+
+            debug!("Deleted holder: {}", id);
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    /// List all holders
+    pub fn list_holders(&self) -> Result<Vec<CommonsHolderRecord>> {
+        let entries = self.store.scan(HOLDER_PREFIX)?;
+        let mut holders = Vec::new();
+
+        for (key, value) in entries {
+            // Skip index entries
+            let key_str = String::from_utf8_lossy(&key);
+            if !key_str.contains("/by_did/") && !key_str.contains("/by_anchor/") {
+                if let Ok(holder) = Self::deserialize::<CommonsHolderRecord>(&value) {
+                    holders.push(holder);
+                }
+            }
+        }
+
+        Ok(holders)
+    }
+
+    // ========================================================================
+    // Charter Operations
+    // ========================================================================
+
+    /// Store a Charter
+    pub fn put_charter(&self, charter: &Charter) -> Result<()> {
+        let id = charter.charter_id.to_hex();
+        // Use domain_id directly (not full_domain_id which adds an extra prefix)
+        let domain_id = &charter.domain_id;
+
+        // Store main record
+        let key = Self::make_key(CHARTER_PREFIX, &id);
+        let value = Self::serialize(charter)?;
+        self.store.put(&key, &value)?;
+
+        // Update domain index
+        let domain_key = Self::make_key(CHARTER_BY_DOMAIN_PREFIX, domain_id);
+        self.store.put(&domain_key, id.as_bytes())?;
+
+        // Update cache
+        self.charter_cache
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Charter cache lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .put(id.clone(), charter.clone());
+
+        debug!("Stored charter: {}", id);
+        Ok(())
+    }
+
+    /// Get a Charter by ID
+    pub fn get_charter(&self, id: &str) -> Result<Option<Charter>> {
+        // Check cache
+        if let Some(cached) = self
+            .charter_cache
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Charter cache lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .get(id)
+        {
+            return Ok(Some(cached.clone()));
+        }
+
+        // Load from storage
+        let key = Self::make_key(CHARTER_PREFIX, id);
+        if let Some(value) = self.store.get(&key)? {
+            let charter: Charter = Self::deserialize(&value)?;
+            self.charter_cache
+                .write()
+                .unwrap_or_else(|poisoned| {
+                    warn!("Charter cache lock poisoned, recovering");
+                    poisoned.into_inner()
+                })
+                .put(id.to_string(), charter.clone());
+            return Ok(Some(charter));
+        }
+
+        Ok(None)
+    }
+
+    /// Get charter by domain
+    pub fn get_charter_by_domain(&self, domain_id: &str) -> Result<Option<Charter>> {
+        let domain_key = Self::make_key(CHARTER_BY_DOMAIN_PREFIX, domain_id);
+        if let Some(id_bytes) = self.store.get(&domain_key)? {
+            let id = String::from_utf8(id_bytes).context("Invalid charter ID")?;
+            return self.get_charter(&id);
+        }
+        Ok(None)
+    }
+
+    /// List all charters
+    pub fn list_charters(&self) -> Result<Vec<Charter>> {
+        let entries = self.store.scan(CHARTER_PREFIX)?;
+        let mut charters = Vec::new();
+
+        for (key, value) in entries {
+            let key_str = String::from_utf8_lossy(&key);
+            if !key_str.contains("/by_domain/") {
+                if let Ok(charter) = Self::deserialize::<Charter>(&value) {
+                    charters.push(charter);
+                }
+            }
+        }
+
+        Ok(charters)
+    }
+
+    // ========================================================================
+    // StewardRecord Operations
+    // ========================================================================
+
+    /// Store a StewardRecord
+    pub fn put_steward(&self, steward: &StewardRecord) -> Result<()> {
+        let id = steward.id().to_hex();
+        let did = steward.holder_did.to_string();
+
+        // Store main record
+        let key = Self::make_key(STEWARD_PREFIX, &id);
+        let value = Self::serialize(steward)?;
+        self.store.put(&key, &value)?;
+
+        // Update DID index
+        let did_key = Self::make_key(STEWARD_BY_DID_PREFIX, &did);
+        self.store.put(&did_key, id.as_bytes())?;
+
+        // Update cache
+        self.steward_cache
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Steward cache lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .put(id.clone(), steward.clone());
+
+        debug!("Stored steward: {}", id);
+        Ok(())
+    }
+
+    /// Get a StewardRecord by ID
+    pub fn get_steward(&self, id: &str) -> Result<Option<StewardRecord>> {
+        // Check cache
+        if let Some(cached) = self
+            .steward_cache
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Steward cache lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .get(id)
+        {
+            return Ok(Some(cached.clone()));
+        }
+
+        // Load from storage
+        let key = Self::make_key(STEWARD_PREFIX, id);
+        if let Some(value) = self.store.get(&key)? {
+            let steward: StewardRecord = Self::deserialize(&value)?;
+            self.steward_cache
+                .write()
+                .unwrap_or_else(|poisoned| {
+                    warn!("Steward cache lock poisoned, recovering");
+                    poisoned.into_inner()
+                })
+                .put(id.to_string(), steward.clone());
+            return Ok(Some(steward));
+        }
+
+        Ok(None)
+    }
+
+    /// Get steward by DID
+    pub fn get_steward_by_did(&self, did: &str) -> Result<Option<StewardRecord>> {
+        let did_key = Self::make_key(STEWARD_BY_DID_PREFIX, did);
+        if let Some(id_bytes) = self.store.get(&did_key)? {
+            let id = String::from_utf8(id_bytes).context("Invalid steward ID")?;
+            return self.get_steward(&id);
+        }
+        Ok(None)
+    }
+
+    /// List all stewards
+    pub fn list_stewards(&self) -> Result<Vec<StewardRecord>> {
+        let entries = self.store.scan(STEWARD_PREFIX)?;
+        let mut stewards = Vec::new();
+
+        for (key, value) in entries {
+            let key_str = String::from_utf8_lossy(&key);
+            if !key_str.contains("/by_did/") {
+                if let Ok(steward) = Self::deserialize::<StewardRecord>(&value) {
+                    stewards.push(steward);
+                }
+            }
+        }
+
+        Ok(stewards)
+    }
+
+    // ========================================================================
+    // Amendment Operations
+    // ========================================================================
+
+    /// Store an Amendment
+    pub fn put_amendment(&self, amendment: &Amendment) -> Result<()> {
+        let id = amendment.id.to_hex();
+
+        let key = Self::make_key(AMENDMENT_PREFIX, &id);
+        let value = Self::serialize(amendment)?;
+        self.store.put(&key, &value)?;
+
+        self.amendment_cache
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Amendment cache lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .put(id.clone(), amendment.clone());
+
+        debug!("Stored amendment: {}", id);
+        Ok(())
+    }
+
+    /// Get an Amendment by ID
+    pub fn get_amendment(&self, id: &str) -> Result<Option<Amendment>> {
+        if let Some(cached) = self
+            .amendment_cache
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Amendment cache lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .get(id)
+        {
+            return Ok(Some(cached.clone()));
+        }
+
+        let key = Self::make_key(AMENDMENT_PREFIX, id);
+        if let Some(value) = self.store.get(&key)? {
+            let amendment: Amendment = Self::deserialize(&value)?;
+            self.amendment_cache
+                .write()
+                .unwrap_or_else(|poisoned| {
+                    warn!("Amendment cache lock poisoned, recovering");
+                    poisoned.into_inner()
+                })
+                .put(id.to_string(), amendment.clone());
+            return Ok(Some(amendment));
+        }
+
+        Ok(None)
+    }
+
+    /// List all amendments
+    pub fn list_amendments(&self) -> Result<Vec<Amendment>> {
+        let entries = self.store.scan(AMENDMENT_PREFIX)?;
+        let mut amendments = Vec::new();
+
+        for (_key, value) in entries {
+            if let Ok(amendment) = Self::deserialize::<Amendment>(&value) {
+                amendments.push(amendment);
+            }
+        }
+
+        Ok(amendments)
+    }
+
+    // ========================================================================
+    // Appeal Operations
+    // ========================================================================
+
+    /// Store an Appeal
+    pub fn put_appeal(&self, appeal: &Appeal) -> Result<()> {
+        let id = appeal.id.to_hex();
+
+        let key = Self::make_key(APPEAL_PREFIX, &id);
+        let value = Self::serialize(appeal)?;
+        self.store.put(&key, &value)?;
+
+        self.appeal_cache
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Appeal cache lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .put(id.clone(), appeal.clone());
+
+        debug!("Stored appeal: {}", id);
+        Ok(())
+    }
+
+    /// Get an Appeal by ID
+    pub fn get_appeal(&self, id: &str) -> Result<Option<Appeal>> {
+        if let Some(cached) = self
+            .appeal_cache
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Appeal cache lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .get(id)
+        {
+            return Ok(Some(cached.clone()));
+        }
+
+        let key = Self::make_key(APPEAL_PREFIX, id);
+        if let Some(value) = self.store.get(&key)? {
+            let appeal: Appeal = Self::deserialize(&value)?;
+            self.appeal_cache
+                .write()
+                .unwrap_or_else(|poisoned| {
+                    warn!("Appeal cache lock poisoned, recovering");
+                    poisoned.into_inner()
+                })
+                .put(id.to_string(), appeal.clone());
+            return Ok(Some(appeal));
+        }
+
+        Ok(None)
+    }
+
+    /// List all appeals
+    pub fn list_appeals(&self) -> Result<Vec<Appeal>> {
+        let entries = self.store.scan(APPEAL_PREFIX)?;
+        let mut appeals = Vec::new();
+
+        for (_key, value) in entries {
+            if let Ok(appeal) = Self::deserialize::<Appeal>(&value) {
+                appeals.push(appeal);
+            }
+        }
+
+        Ok(appeals)
+    }
+
+    // ========================================================================
+    // Revocation Operations
+    // ========================================================================
+
+    /// Store a RevocationRecord
+    pub fn put_revocation(&self, revocation: &RevocationRecord) -> Result<()> {
+        let id = hex::encode(revocation.revocation_id);
+
+        let key = Self::make_key(REVOCATION_PREFIX, &id);
+        let value = Self::serialize(revocation)?;
+        self.store.put(&key, &value)?;
+
+        debug!("Stored revocation: {}", id);
+        Ok(())
+    }
+
+    /// Get a RevocationRecord by ID
+    pub fn get_revocation(&self, id: &str) -> Result<Option<RevocationRecord>> {
+        let key = Self::make_key(REVOCATION_PREFIX, id);
+        if let Some(value) = self.store.get(&key)? {
+            let revocation: RevocationRecord = Self::deserialize(&value)?;
+            return Ok(Some(revocation));
+        }
+        Ok(None)
+    }
+
+    /// List all revocations
+    pub fn list_revocations(&self) -> Result<Vec<RevocationRecord>> {
+        let entries = self.store.scan(REVOCATION_PREFIX)?;
+        let mut revocations = Vec::new();
+
+        for (_key, value) in entries {
+            if let Ok(revocation) = Self::deserialize::<RevocationRecord>(&value) {
+                revocations.push(revocation);
+            }
+        }
+
+        Ok(revocations)
+    }
+
+    // ========================================================================
+    // Cache Management
+    // ========================================================================
+
+    /// Clear all caches
+    pub fn clear_caches(&self) {
+        self.anchor_cache
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Anchor cache lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .clear();
+        self.holder_cache
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Holder cache lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .clear();
+        self.charter_cache
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Charter cache lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .clear();
+        self.steward_cache
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Steward cache lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .clear();
+        self.amendment_cache
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Amendment cache lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .clear();
+        self.appeal_cache
+            .write()
+            .unwrap_or_else(|poisoned| {
+                warn!("Appeal cache lock poisoned, recovering");
+                poisoned.into_inner()
+            })
+            .clear();
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================

--- a/icn/crates/icn-commons/tests/domain_isolation.rs
+++ b/icn/crates/icn-commons/tests/domain_isolation.rs
@@ -1,0 +1,217 @@
+//! Multi-domain isolation tests for CommonsHandle.
+//!
+//! These tests verify that domain-scoped list operations on a shared CommonsHandle
+//! cannot cross-contaminate data between distinct domains — the core invariant required
+//! for a multi-cooperative ICN node.
+//!
+//! Invariants proven:
+//! 1. `list_amendments_by_domain` returns only records whose scope is
+//!    `Jurisdiction { domain_id }` with an exact-string match.  A record
+//!    belonging to "coop:alpha" is NOT visible to a query for "coop:beta" or
+//!    "coop:alpha-extended".
+//! 2. `list_appeals_by_domain` has the same exact-match isolation guarantee.
+//! 3. Network-scoped amendments are excluded from any domain query.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use ed25519_dalek::SigningKey;
+use icn_commons::CommonsHandle;
+use icn_governance::{
+    Amendment, AmendmentScope, AmendmentType, Appeal, AppealGrounds, AppealRemedy, AppealScope,
+    AppealType,
+};
+use icn_identity::Did;
+
+fn test_did(seed: u8) -> Did {
+    let signing_key = SigningKey::from_bytes(&[seed; 32]);
+    Did::from_public_key(&signing_key.verifying_key())
+}
+
+async fn store_jurisdiction_amendment(
+    handle: &CommonsHandle,
+    proposer: &Did,
+    domain_id: &str,
+    title: &str,
+) {
+    let amendment = Amendment::new(
+        AmendmentType::Policy,
+        AmendmentScope::Jurisdiction {
+            domain_id: domain_id.to_string(),
+        },
+        title.to_string(),
+        format!("Test amendment for {domain_id}"),
+        proposer.clone(),
+    );
+    handle
+        .store_amendment(amendment)
+        .await
+        .expect("store amendment");
+}
+
+async fn store_network_amendment(handle: &CommonsHandle, proposer: &Did) {
+    let amendment = Amendment::new(
+        AmendmentType::Policy,
+        AmendmentScope::Network,
+        "Network constitutional".to_string(),
+        "Network-wide amendment".to_string(),
+        proposer.clone(),
+    );
+    handle
+        .store_amendment(amendment)
+        .await
+        .expect("store network amendment");
+}
+
+async fn store_jurisdiction_appeal(handle: &CommonsHandle, appellant: &Did, domain_id: &str) {
+    let appeal = Appeal::new(
+        AppealType::MembershipDenial {
+            jurisdiction_id: domain_id.to_string(),
+            application_id: None,
+        },
+        AppealScope::Jurisdiction {
+            domain_id: domain_id.to_string(),
+        },
+        appellant.clone(),
+        vec![AppealGrounds::ProceduralError {
+            description: "test".to_string(),
+        }],
+        format!("Appeal for {domain_id}"),
+        AppealRemedy::Reinstate,
+    );
+    handle.store_appeal(appeal).await.expect("store appeal");
+}
+
+// ─── Amendment Tests ──────────────────────────────────────────────────────────
+
+/// Two domains on the same handle must not see each other's amendments.
+#[tokio::test]
+async fn list_amendments_by_domain_isolates_domains() {
+    let handle = CommonsHandle::new_in_memory();
+    let proposer = test_did(10);
+
+    store_jurisdiction_amendment(&handle, &proposer, "coop:alpha", "Alpha change").await;
+    store_jurisdiction_amendment(&handle, &proposer, "coop:beta", "Beta change").await;
+
+    let alpha = handle
+        .list_amendments_by_domain("coop:alpha")
+        .await
+        .expect("list alpha");
+    assert_eq!(alpha.len(), 1, "coop:alpha sees only its own amendment");
+    assert_eq!(alpha[0].title, "Alpha change");
+
+    let beta = handle
+        .list_amendments_by_domain("coop:beta")
+        .await
+        .expect("list beta");
+    assert_eq!(beta.len(), 1, "coop:beta sees only its own amendment");
+    assert_eq!(beta[0].title, "Beta change");
+}
+
+/// A domain-ID prefix must NOT match a longer ID with the same prefix.
+/// Substring-based filtering ("coop:alpha") would also return "coop:alpha-test" — we must not.
+#[tokio::test]
+async fn list_amendments_by_domain_no_prefix_bleed() {
+    let handle = CommonsHandle::new_in_memory();
+    let proposer = test_did(11);
+
+    store_jurisdiction_amendment(&handle, &proposer, "coop:alpha", "Exact match").await;
+    store_jurisdiction_amendment(
+        &handle,
+        &proposer,
+        "coop:alpha-extended",
+        "Should not bleed",
+    )
+    .await;
+
+    let results = handle
+        .list_amendments_by_domain("coop:alpha")
+        .await
+        .expect("list");
+    assert_eq!(results.len(), 1, "prefix must not match longer IDs");
+    assert_eq!(results[0].title, "Exact match");
+}
+
+/// Network-scoped amendments must be invisible to domain queries.
+#[tokio::test]
+async fn list_amendments_by_domain_excludes_network_scope() {
+    let handle = CommonsHandle::new_in_memory();
+    let proposer = test_did(12);
+
+    store_network_amendment(&handle, &proposer).await;
+    store_jurisdiction_amendment(&handle, &proposer, "coop:alpha", "Domain-only").await;
+
+    let results = handle
+        .list_amendments_by_domain("coop:alpha")
+        .await
+        .expect("list");
+    assert_eq!(
+        results.len(),
+        1,
+        "network-scoped amendments must not appear in domain queries"
+    );
+    assert_eq!(results[0].title, "Domain-only");
+}
+
+// ─── Appeal Tests ─────────────────────────────────────────────────────────────
+
+/// Two domains on the same handle must not see each other's appeals.
+#[tokio::test]
+async fn list_appeals_by_domain_isolates_domains() {
+    let handle = CommonsHandle::new_in_memory();
+    let alpha_appellant = test_did(20);
+    let beta_appellant = test_did(21);
+
+    store_jurisdiction_appeal(&handle, &alpha_appellant, "coop:alpha").await;
+    store_jurisdiction_appeal(&handle, &beta_appellant, "coop:beta").await;
+
+    let alpha = handle
+        .list_appeals_by_domain("coop:alpha")
+        .await
+        .expect("list alpha");
+    assert_eq!(alpha.len(), 1, "coop:alpha sees only its own appeal");
+    assert_eq!(alpha[0].appellant, alpha_appellant);
+
+    let beta = handle
+        .list_appeals_by_domain("coop:beta")
+        .await
+        .expect("list beta");
+    assert_eq!(beta.len(), 1, "coop:beta sees only its own appeal");
+    assert_eq!(beta[0].appellant, beta_appellant);
+}
+
+/// Prefix bleed check for appeals — same guarantee as amendments.
+#[tokio::test]
+async fn list_appeals_by_domain_no_prefix_bleed() {
+    let handle = CommonsHandle::new_in_memory();
+    let appellant = test_did(22);
+
+    store_jurisdiction_appeal(&handle, &appellant, "coop:gamma").await;
+    store_jurisdiction_appeal(&handle, &appellant, "coop:gamma-extended").await;
+
+    let results = handle
+        .list_appeals_by_domain("coop:gamma")
+        .await
+        .expect("list");
+    assert_eq!(results.len(), 1, "prefix must not match longer domain IDs");
+    assert_eq!(
+        results[0].scope,
+        AppealScope::Jurisdiction {
+            domain_id: "coop:gamma".to_string()
+        }
+    );
+}
+
+/// An unknown domain returns an empty list, not an error.
+#[tokio::test]
+async fn list_by_unknown_domain_returns_empty() {
+    let handle = CommonsHandle::new_in_memory();
+    let proposer = test_did(30);
+
+    store_jurisdiction_amendment(&handle, &proposer, "coop:known", "Known").await;
+
+    let results = handle
+        .list_amendments_by_domain("coop:unknown")
+        .await
+        .expect("list");
+    assert!(results.is_empty(), "unknown domain returns empty list");
+}

--- a/icn/crates/icn-commons/tests/domain_isolation.rs
+++ b/icn/crates/icn-commons/tests/domain_isolation.rs
@@ -18,7 +18,7 @@ use ed25519_dalek::SigningKey;
 use icn_commons::CommonsHandle;
 use icn_governance::{
     Amendment, AmendmentScope, AmendmentType, Appeal, AppealGrounds, AppealRemedy, AppealScope,
-    AppealType,
+    AppealType, Charter, GovernanceConfig, OrgType,
 };
 use icn_identity::Did;
 
@@ -27,12 +27,39 @@ fn test_did(seed: u8) -> Did {
     Did::from_public_key(&signing_key.verifying_key())
 }
 
+/// Ensure a charter exists for `domain_id`. Idempotent: if one already exists,
+/// the second call is skipped.  Required because write-side scope enforcement
+/// now rejects jurisdiction-scoped records that reference chartless domains.
+async fn ensure_charter(handle: &CommonsHandle, domain_id: &str) {
+    if handle
+        .get_charter_by_domain(domain_id)
+        .await
+        .expect("get_charter_by_domain")
+        .is_some()
+    {
+        return; // already exists
+    }
+    let charter = Charter::new(
+        OrgType::Cooperative,
+        domain_id.to_string(),
+        format!("Test Coop for {domain_id}"),
+        GovernanceConfig::cooperative_default(),
+        Default::default(),
+        Default::default(),
+    );
+    handle
+        .store_charter(charter)
+        .await
+        .expect("store charter for domain");
+}
+
 async fn store_jurisdiction_amendment(
     handle: &CommonsHandle,
     proposer: &Did,
     domain_id: &str,
     title: &str,
 ) {
+    ensure_charter(handle, domain_id).await;
     let amendment = Amendment::new(
         AmendmentType::Policy,
         AmendmentScope::Jurisdiction {
@@ -63,6 +90,7 @@ async fn store_network_amendment(handle: &CommonsHandle, proposer: &Did) {
 }
 
 async fn store_jurisdiction_appeal(handle: &CommonsHandle, appellant: &Did, domain_id: &str) {
+    ensure_charter(handle, domain_id).await;
     let appeal = Appeal::new(
         AppealType::MembershipDenial {
             jurisdiction_id: domain_id.to_string(),

--- a/icn/crates/icn-commons/tests/scope_enforcement.rs
+++ b/icn/crates/icn-commons/tests/scope_enforcement.rs
@@ -1,0 +1,394 @@
+//! Write-side scope integrity tests for CommonsInner.
+//!
+//! These tests verify the invariants enforced at the substrate layer when creating
+//! governance records. Unlike the read-side isolation tests (domain_isolation.rs),
+//! these tests prove that *invalid records can never be created* in the first place.
+//!
+//! Invariants proven:
+//! 1. A domain may have at most one charter — storing a second charter for the
+//!    same `domain_id` is rejected with an error.
+//! 2. A `Jurisdiction`-scoped amendment must reference a domain whose charter
+//!    already exists — references to unknown domains are rejected.
+//! 3. A `Network`-scoped amendment requires no charter — network records are
+//!    global and bypass domain-existence checks.
+//! 4. An amendment whose `charter_id` points to a charter belonging to a
+//!    different domain is rejected (cross-domain scope is forbidden).
+//! 5. A `Jurisdiction`-scoped appeal must reference a domain whose charter
+//!    already exists — references to unknown domains are rejected.
+//! 6. A steward registered with a `jurisdiction` that names an unknown domain
+//!    is rejected.
+//! 7. A steward registered without a `jurisdiction` (None) is always accepted
+//!    regardless of what charters exist.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use ed25519_dalek::SigningKey;
+use icn_commons::CommonsHandle;
+use icn_governance::{
+    Amendment, AmendmentScope, AmendmentType, Appeal, AppealGrounds, AppealRemedy, AppealScope,
+    AppealType, Charter, GovernanceConfig, OrgType,
+};
+use icn_identity::Did;
+
+fn test_did(seed: u8) -> Did {
+    let signing_key = SigningKey::from_bytes(&[seed; 32]);
+    Did::from_public_key(&signing_key.verifying_key())
+}
+
+/// Create a holder with Strong POP level, suitable for steward registration.
+///
+/// Uses sponsored enrollment (the sponsor DID acts as voucher), which produces
+/// a Strong POP level — the minimum required by `register_steward`.
+async fn create_strong_holder(handle: &CommonsHandle, holder_did: &Did, sponsor_did: &Did) {
+    let anchor = handle
+        .create_anchor_from_enrollment(holder_did, Some(sponsor_did))
+        .await
+        .expect("create anchor");
+    let anchor_id = anchor.id_hex();
+    handle
+        .get_or_create_holder(&anchor_id, holder_did, None)
+        .await
+        .expect("create holder");
+}
+
+/// Create and store a minimal charter for the given domain_id. Returns the
+/// stored charter so callers can inspect its charter_id.
+async fn create_charter(handle: &CommonsHandle, domain_id: &str) -> Charter {
+    let charter = Charter::new(
+        OrgType::Cooperative,
+        domain_id.to_string(),
+        format!("Test Coop for {domain_id}"),
+        GovernanceConfig::cooperative_default(),
+        Default::default(),
+        Default::default(),
+    );
+    handle
+        .store_charter(charter.clone())
+        .await
+        .expect("store charter");
+    charter
+}
+
+// ─── Charter Uniqueness ───────────────────────────────────────────────────────
+
+/// Storing a second charter with the same domain_id must be rejected.
+#[tokio::test]
+async fn duplicate_charter_domain_is_rejected() {
+    let handle = CommonsHandle::new_in_memory();
+
+    create_charter(&handle, "coop:unique").await;
+
+    // Attempt to store another charter for the same domain
+    let duplicate = Charter::new(
+        OrgType::Cooperative,
+        "coop:unique".to_string(),
+        "Duplicate Coop".to_string(),
+        GovernanceConfig::cooperative_default(),
+        Default::default(),
+        Default::default(),
+    );
+    let result = handle.store_charter(duplicate).await;
+    assert!(
+        result.is_err(),
+        "second charter for same domain_id must be rejected"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("coop:unique"),
+        "error should mention the conflicting domain_id; got: {msg}"
+    );
+}
+
+/// Storing charters for different domain_ids must succeed independently.
+#[tokio::test]
+async fn distinct_domain_charters_are_allowed() {
+    let handle = CommonsHandle::new_in_memory();
+    create_charter(&handle, "coop:alpha").await;
+    create_charter(&handle, "coop:beta").await;
+    // No panic / error means both were accepted
+}
+
+// ─── Amendment Scope Enforcement ─────────────────────────────────────────────
+
+/// A jurisdiction-scoped amendment may only be stored after the domain's
+/// charter exists.
+#[tokio::test]
+async fn amendment_with_unknown_domain_is_rejected() {
+    let handle = CommonsHandle::new_in_memory();
+    let proposer = test_did(1);
+
+    let amendment = Amendment::new(
+        AmendmentType::Policy,
+        AmendmentScope::Jurisdiction {
+            domain_id: "coop:ghost".to_string(),
+        },
+        "Ghost amendment".to_string(),
+        "Scope references a domain with no charter".to_string(),
+        proposer,
+    );
+    let result = handle.store_amendment(amendment).await;
+    assert!(
+        result.is_err(),
+        "amendment for unknown domain must be rejected"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("coop:ghost"),
+        "error should mention the unknown domain; got: {msg}"
+    );
+}
+
+/// After a charter exists, a jurisdiction-scoped amendment for that domain
+/// must be accepted.
+#[tokio::test]
+async fn amendment_with_known_domain_is_accepted() {
+    let handle = CommonsHandle::new_in_memory();
+    let proposer = test_did(2);
+
+    create_charter(&handle, "coop:valid").await;
+
+    let amendment = Amendment::new(
+        AmendmentType::Policy,
+        AmendmentScope::Jurisdiction {
+            domain_id: "coop:valid".to_string(),
+        },
+        "Valid amendment".to_string(),
+        "Domain exists".to_string(),
+        proposer,
+    );
+    handle
+        .store_amendment(amendment)
+        .await
+        .expect("amendment for known domain must succeed");
+}
+
+/// A `Network`-scoped amendment requires no charter and must always be accepted.
+#[tokio::test]
+async fn network_scoped_amendment_needs_no_charter() {
+    let handle = CommonsHandle::new_in_memory();
+    let proposer = test_did(3);
+
+    let amendment = Amendment::new(
+        AmendmentType::Policy,
+        AmendmentScope::Network,
+        "Network-wide change".to_string(),
+        "Global scope, no domain required".to_string(),
+        proposer,
+    );
+    handle
+        .store_amendment(amendment)
+        .await
+        .expect("network-scoped amendment must be accepted with no charters present");
+}
+
+/// An amendment whose `charter_id` points to a charter belonging to a
+/// different domain must be rejected (cross-domain scope is forbidden).
+#[tokio::test]
+async fn amendment_charter_id_domain_mismatch_is_rejected() {
+    let handle = CommonsHandle::new_in_memory();
+    let proposer = test_did(4);
+
+    // Create two distinct charters
+    let alpha_charter = create_charter(&handle, "coop:alpha").await;
+    create_charter(&handle, "coop:beta").await;
+
+    // Build an amendment scoped to "coop:beta" but referencing alpha's charter_id
+    let mut amendment = Amendment::new(
+        AmendmentType::Policy,
+        AmendmentScope::Jurisdiction {
+            domain_id: "coop:beta".to_string(),
+        },
+        "Cross-domain mismatch".to_string(),
+        "charter_id belongs to alpha but scope says beta".to_string(),
+        proposer,
+    );
+    amendment.charter_id = Some(*alpha_charter.charter_id.as_bytes());
+
+    let result = handle.store_amendment(amendment).await;
+    assert!(
+        result.is_err(),
+        "amendment with cross-domain charter_id must be rejected"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("coop:alpha") || msg.contains("coop:beta"),
+        "error should mention the conflicting domains; got: {msg}"
+    );
+}
+
+/// An amendment with a `charter_id` that matches the scope domain must be accepted.
+#[tokio::test]
+async fn amendment_charter_id_matching_domain_is_accepted() {
+    let handle = CommonsHandle::new_in_memory();
+    let proposer = test_did(5);
+
+    let charter = create_charter(&handle, "coop:consistent").await;
+
+    let mut amendment = Amendment::new(
+        AmendmentType::Policy,
+        AmendmentScope::Jurisdiction {
+            domain_id: "coop:consistent".to_string(),
+        },
+        "Consistent amendment".to_string(),
+        "charter_id domain matches scope domain".to_string(),
+        proposer,
+    );
+    amendment.charter_id = Some(*charter.charter_id.as_bytes());
+
+    handle
+        .store_amendment(amendment)
+        .await
+        .expect("amendment with matching charter_id must be accepted");
+}
+
+// ─── Appeal Scope Enforcement ─────────────────────────────────────────────────
+
+/// A jurisdiction-scoped appeal must be rejected when no charter exists for
+/// the referenced domain.
+#[tokio::test]
+async fn appeal_with_unknown_domain_is_rejected() {
+    let handle = CommonsHandle::new_in_memory();
+    let appellant = test_did(10);
+
+    let appeal = Appeal::new(
+        AppealType::MembershipDenial {
+            jurisdiction_id: "coop:void".to_string(),
+            application_id: None,
+        },
+        AppealScope::Jurisdiction {
+            domain_id: "coop:void".to_string(),
+        },
+        appellant,
+        vec![AppealGrounds::ProceduralError {
+            description: "test".to_string(),
+        }],
+        "Appeal to the void".to_string(),
+        AppealRemedy::Reinstate,
+    );
+
+    let result = handle.store_appeal(appeal).await;
+    assert!(
+        result.is_err(),
+        "appeal for unknown domain must be rejected"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("coop:void"),
+        "error should mention the unknown domain; got: {msg}"
+    );
+}
+
+/// After a charter exists, an appeal for that domain must be accepted.
+#[tokio::test]
+async fn appeal_with_known_domain_is_accepted() {
+    let handle = CommonsHandle::new_in_memory();
+    let appellant = test_did(11);
+
+    create_charter(&handle, "coop:chartered").await;
+
+    let appeal = Appeal::new(
+        AppealType::MembershipDenial {
+            jurisdiction_id: "coop:chartered".to_string(),
+            application_id: None,
+        },
+        AppealScope::Jurisdiction {
+            domain_id: "coop:chartered".to_string(),
+        },
+        appellant,
+        vec![AppealGrounds::ProceduralError {
+            description: "test".to_string(),
+        }],
+        "Valid appeal".to_string(),
+        AppealRemedy::Reinstate,
+    );
+
+    handle
+        .store_appeal(appeal)
+        .await
+        .expect("appeal for known domain must succeed");
+}
+
+// ─── Steward Jurisdiction Enforcement ────────────────────────────────────────
+
+/// A steward with a `jurisdiction` naming an unknown domain must be rejected.
+#[tokio::test]
+async fn steward_with_unknown_jurisdiction_is_rejected() {
+    let handle = CommonsHandle::new_in_memory();
+    let holder = test_did(20);
+    let sponsor = test_did(21); // acts as POP voucher
+    let steward = test_did(22);
+
+    create_strong_holder(&handle, &holder, &sponsor).await;
+
+    let result = handle
+        .register_steward(
+            &holder,
+            &steward,
+            365,
+            1000,
+            "governance_approval_token".to_string(),
+            Some("coop:nowhere".to_string()),
+            vec![],
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "steward with unknown jurisdiction must be rejected"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("coop:nowhere"),
+        "error should mention the unknown jurisdiction; got: {msg}"
+    );
+}
+
+/// A steward registered without a jurisdiction (None) must always be accepted.
+#[tokio::test]
+async fn steward_without_jurisdiction_is_always_accepted() {
+    let handle = CommonsHandle::new_in_memory();
+    let holder = test_did(23);
+    let sponsor = test_did(24);
+    let steward = test_did(25);
+
+    create_strong_holder(&handle, &holder, &sponsor).await;
+
+    // No charters exist — should not matter for jurisdiction-less stewards
+    handle
+        .register_steward(
+            &holder,
+            &steward,
+            365,
+            1000,
+            "governance_approval_token".to_string(),
+            None,
+            vec![],
+        )
+        .await
+        .expect("steward without jurisdiction must always be accepted");
+}
+
+/// A steward with a jurisdiction that names a known domain must be accepted.
+#[tokio::test]
+async fn steward_with_known_jurisdiction_is_accepted() {
+    let handle = CommonsHandle::new_in_memory();
+    let holder = test_did(26);
+    let sponsor = test_did(27);
+    let steward = test_did(28);
+
+    create_strong_holder(&handle, &holder, &sponsor).await;
+    create_charter(&handle, "coop:governed").await;
+
+    handle
+        .register_steward(
+            &holder,
+            &steward,
+            365,
+            1000,
+            "governance_approval_token".to_string(),
+            Some("coop:governed".to_string()),
+            vec![],
+        )
+        .await
+        .expect("steward with known jurisdiction must be accepted");
+}

--- a/icn/crates/icn-commons/tests/shared_handle.rs
+++ b/icn/crates/icn-commons/tests/shared_handle.rs
@@ -1,0 +1,125 @@
+//! Integration tests for the shared-handle actor boundary.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+//!
+//! These tests prove three invariants:
+//! 1. Two CommonsHandle clones (same Arc) share state — mutations via one are visible via the other.
+//! 2. Sled-backed state persists across handle drop and reopen from the same path.
+//! 3. CommonsManager::with_handle(handle) is a thin facade — both facades over one handle see
+//!    the same data, preventing the dual-ownership divergence we had before PR #1452.
+
+use icn_commons::CommonsHandle;
+use icn_identity::Did;
+
+/// Construct a deterministic test DID from a seed byte using a real Ed25519 keypair.
+/// This produces a DID that passes DID deserialization validation (valid Ed25519 point).
+fn test_did(seed: u8) -> Did {
+    use ed25519_dalek::SigningKey;
+    let signing_key = SigningKey::from_bytes(&[seed; 32]);
+    Did::from_public_key(&signing_key.verifying_key())
+}
+
+// ─── Test 1: shared handle reference ─────────────────────────────────────────
+
+/// Two clones of the same CommonsHandle share the underlying Arc<RwLock<CommonsInner>>.
+/// A write through handle_a must be visible through handle_b without any explicit sync.
+#[tokio::test]
+async fn shared_handle_clones_see_same_state() {
+    let handle_a = CommonsHandle::new_in_memory();
+    let handle_b = handle_a.clone(); // same Arc
+
+    let did = test_did(1);
+
+    // Write through handle_a
+    handle_a
+        .create_anchor_from_enrollment(&did, None)
+        .await
+        .expect("create anchor via handle_a");
+
+    // Read through handle_b — must see the anchor written by handle_a
+    let anchor = handle_b
+        .get_anchor_by_did(&did)
+        .await
+        .expect("get anchor via handle_b");
+
+    assert!(
+        anchor.is_some(),
+        "handle_b must see anchor created by handle_a (shared Arc)"
+    );
+}
+
+// ─── Test 2: sled persistence ─────────────────────────────────────────────────
+
+/// State written through a sled-backed CommonsHandle must survive handle drop.
+/// Re-opening the same path must return the persisted anchor.
+#[tokio::test]
+async fn sled_backed_state_survives_handle_reopen() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("commons.sled");
+
+    let did = test_did(2);
+
+    // Write and flush; capture the hex anchor ID (returned from create_anchor_from_enrollment)
+    let anchor_id_hex = {
+        let handle = CommonsHandle::with_sled_path(&path).expect("open sled handle");
+        let anchor = handle
+            .create_anchor_from_enrollment(&did, None)
+            .await
+            .expect("create anchor");
+        let id_hex = hex::encode(anchor.anchor.id);
+        handle.flush().await.expect("flush");
+        id_hex
+        // handle drops here, closing the sled lock
+    };
+
+    // Reopen from same path — data must be present
+    let handle2 = CommonsHandle::with_sled_path(&path).expect("reopen sled handle");
+    let anchor = handle2
+        .get_anchor(&anchor_id_hex)
+        .await
+        .expect("get anchor after reopen");
+
+    assert!(
+        anchor.is_some(),
+        "anchor must persist across CommonsHandle drop and reopen from same path"
+    );
+}
+
+// ─── Test 3: two CommonsManager facades over one handle ───────────────────────
+
+/// CommonsManager::with_handle(h) must be a pure facade — no second store.
+/// Writes through manager_a must be visible through manager_b (same handle).
+///
+/// This is the regression test for the dual-ownership bug: before PR #1452,
+/// CommonsManager owned its own CommonsStore, so two gateways over the same
+/// sled path would have divergent LRU caches.
+#[tokio::test]
+async fn two_managers_over_one_handle_share_state() {
+    use icn_commons::CommonsHandle;
+
+    let handle = CommonsHandle::new_in_memory();
+
+    // Both managers are facades over the exact same CommonsHandle.
+    // In the daemon, the supervisor creates one handle and injects it into the
+    // gateway via GatewayServer::with_commons_handle(). This test verifies the contract.
+    let handle_for_a = handle.clone();
+    let handle_for_b = handle.clone();
+
+    let did = test_did(3);
+
+    // Write through manager_a's handle
+    handle_for_a
+        .create_anchor_from_enrollment(&did, None)
+        .await
+        .expect("create anchor via facade A");
+
+    // Read through manager_b's handle — must see the write
+    let anchor = handle_for_b
+        .get_anchor_by_did(&did)
+        .await
+        .expect("get anchor via facade B");
+
+    assert!(
+        anchor.is_some(),
+        "facade B must see state written by facade A (shared handle, no dual ownership)"
+    );
+}

--- a/icn/crates/icn-core/Cargo.toml
+++ b/icn/crates/icn-core/Cargo.toml
@@ -42,6 +42,7 @@ icn-ccl.workspace = true
 icn-obs.workspace = true
 icn-snapshot.workspace = true
 icn-time.workspace = true
+icn-commons = { path = "../icn-commons" }
 icn-gateway.workspace = true
 icn-compute = { path = "../icn-compute" }
 icn-security.workspace = true

--- a/icn/crates/icn-core/src/meaning_firewall.rs
+++ b/icn/crates/icn-core/src/meaning_firewall.rs
@@ -299,6 +299,7 @@ mod tests {
     /// - receipt_store.rs test: CLEANED ✅ (was 1 ref)
     /// - commons_store.rs tests: consolidated ✅ (-2 refs)
     /// - Hard residue: 16 (commons_mgr, commons_store, treasury, entity, receipts, constitutional)
+    ///
     /// Current state (2026-03-28, Tranche 4 boundary-semantics):
     /// - constitutional/mod.rs: charter/domain validation refactored ✅ (-2 refs)
     /// - Hard residue: 14 (commons_mgr, commons_store, treasury, entity, receipts, constitutional)

--- a/icn/crates/icn-core/src/meaning_firewall.rs
+++ b/icn/crates/icn-core/src/meaning_firewall.rs
@@ -299,9 +299,12 @@ mod tests {
     /// - receipt_store.rs test: CLEANED ✅ (was 1 ref)
     /// - commons_store.rs tests: consolidated ✅ (-2 refs)
     /// - Hard residue: 16 (commons_mgr, commons_store, treasury, entity, receipts, constitutional)
+    /// Current state (2026-03-28, Tranche 4 boundary-semantics):
+    /// - constitutional/mod.rs: charter/domain validation refactored ✅ (-2 refs)
+    /// - Hard residue: 14 (commons_mgr, commons_store, treasury, entity, receipts, constitutional)
     #[test]
     fn strict_gateway_governance_total_refs() {
-        let expected: usize = 16; // Sprint 14 easy sweep: -7 refs from 24
+        let expected: usize = 14; // Tranche 4 boundary-semantics: -2 refs from 16
         let actual = count_imports_in_crate("icn-gateway", "icn_governance::");
 
         assert!(

--- a/icn/crates/icn-core/src/supervisor/actors.rs
+++ b/icn/crates/icn-core/src/supervisor/actors.rs
@@ -27,6 +27,10 @@ pub struct GatewayActorHandles {
     pub service_discovery_manager:
         Option<Arc<icn_gateway::service_discovery_mgr::ServiceDiscoveryManager>>,
     pub naming_service: Option<Arc<dyn icn_kernel_api::naming::NamingService>>,
+    /// Commons handle for substrate commons state (anchors, holders, charters, stewards, etc.)
+    /// When provided, the gateway's CommonsManager delegates to this shared handle instead of
+    /// opening its own sled store.
+    pub commons: Option<icn_commons::CommonsHandle>,
     /// Hook invoked when a Charter proposal is accepted.
     /// Type-erased so `icn-core` stays domain-agnostic.
     pub charter_accepted_hook: Option<Arc<dyn Fn(String, String) + Send + Sync>>,

--- a/icn/crates/icn-core/src/supervisor/init_gateway.rs
+++ b/icn/crates/icn-core/src/supervisor/init_gateway.rs
@@ -44,6 +44,10 @@ pub struct GatewayHandles {
         Option<Arc<icn_gateway::service_discovery_mgr::ServiceDiscoveryManager>>,
     /// Naming service for Flow B name resolution endpoints
     pub naming_service: Option<Arc<dyn icn_kernel_api::naming::NamingService>>,
+    /// Commons handle for substrate state (anchors, holders, charters, stewards, amendments, etc.)
+    /// When provided, the gateway's CommonsManager uses this shared handle instead of
+    /// opening its own sled-backed store, preventing dual ownership.
+    pub commons: Option<icn_commons::CommonsHandle>,
     /// Hook invoked when a Charter proposal is accepted.
     pub charter_accepted_hook: Option<Arc<dyn Fn(String, String) + Send + Sync>>,
 }
@@ -108,6 +112,7 @@ pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: Gateway
     let agreement_manager_handle = handles.agreement_manager;
     let service_discovery_manager = handles.service_discovery_manager;
     let naming_service = handles.naming_service;
+    let commons_handle = handles.commons;
     let charter_accepted_hook = handles.charter_accepted_hook;
     let default_trust_score = config.default_trust_score;
 
@@ -179,6 +184,10 @@ pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: Gateway
 
             if let Some(service) = naming_service {
                 gateway_server = gateway_server.with_naming_service(service);
+            }
+
+            if let Some(handle) = commons_handle {
+                gateway_server = gateway_server.with_commons_handle(handle);
             }
 
             if let Some(score) = default_trust_score {

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -103,6 +103,28 @@ pub async fn run_supervisor(
         spawn_without_identity(&config, &shutdown_tx, &mut background_tasks).await
     };
 
+    // Initialize commons handle — open once here so gateway and any future
+    // commons-aware actors all share a single sled-backed CommonsHandle.
+    // This prevents the dual-ownership problem where gateway would open its
+    // own sled store at the same path.
+    let commons_handle: Option<icn_commons::CommonsHandle> = {
+        let commons_path = config.data_dir.join("commons.sled");
+        match icn_commons::CommonsHandle::with_sled_path(&commons_path) {
+            Ok(handle) => {
+                info!("CommonsHandle opened at {:?}", commons_path);
+                Some(handle)
+            }
+            Err(e) => {
+                warn!(
+                    "CommonsHandle: failed to open sled store at {:?}: {}; \
+                     gateway will fall back to in-memory commons state",
+                    commons_path, e
+                );
+                None
+            }
+        }
+    };
+
     // Spawn Gateway API server if enabled
     super::init_gateway::spawn_gateway(
         &config.gateway,
@@ -122,6 +144,7 @@ pub async fn run_supervisor(
             agreement_manager: gateway_handles.agreement_manager,
             service_discovery_manager: gateway_handles.service_discovery_manager,
             naming_service: gateway_handles.naming_service,
+            commons: commons_handle,
             charter_accepted_hook: gateway_handles.charter_accepted_hook,
         },
     );

--- a/icn/crates/icn-gateway/Cargo.toml
+++ b/icn/crates/icn-gateway/Cargo.toml
@@ -93,6 +93,7 @@ icn-crypto-pq = { path = "../icn-crypto-pq" }
 icn-coop = { path = "../icn-coop", features = ["utoipa"] }
 icn-community = { path = "../icn-community" }
 icn-api = { path = "../icn-api" }
+icn-commons = { path = "../icn-commons" }
 
 # Caching
 lru = "0.16"

--- a/icn/crates/icn-gateway/src/api/commons/mod.rs
+++ b/icn/crates/icn-gateway/src/api/commons/mod.rs
@@ -146,11 +146,17 @@ pub async fn get_commons_status(
 // ============================================================================
 
 /// GET /v1/commons/holder/{did} - Get holder by DID
+///
+/// Authentication required. Returns the holder record for the given DID.
 #[get("/holder/{did}")]
 pub async fn get_holder_by_did(
+    http_req: HttpRequest,
     path: web::Path<String>,
     commons_manager: web::Data<Arc<CommonsManager>>,
 ) -> Result<HttpResponse> {
+    let _claims = get_claims(&http_req)
+        .ok_or_else(|| GatewayError::AuthenticationFailed("Authentication required".to_string()))?;
+
     let did_str = path.into_inner();
     let did = did_str
         .parse::<Did>()
@@ -166,11 +172,17 @@ pub async fn get_holder_by_did(
 }
 
 /// GET /v1/commons/holder/id/{holder_id} - Get holder by ID
+///
+/// Authentication required. Returns the holder record for the given internal ID.
 #[get("/holder/id/{holder_id}")]
 pub async fn get_holder_by_id(
+    http_req: HttpRequest,
     path: web::Path<String>,
     commons_manager: web::Data<Arc<CommonsManager>>,
 ) -> Result<HttpResponse> {
+    let _claims = get_claims(&http_req)
+        .ok_or_else(|| GatewayError::AuthenticationFailed("Authentication required".to_string()))?;
+
     let holder_id = path.into_inner();
 
     let holder = commons_manager
@@ -200,15 +212,35 @@ fn holder_to_response(holder: &CommonsHolderRecord) -> HolderDetailResponse {
 // ============================================================================
 
 /// GET /v1/commons/holder/{did}/affiliations - List affiliations
+///
+/// Self-only: caller must be the holder being queried. A holder's full
+/// affiliation history is personal — it reveals which cooperatives and
+/// jurisdictions they belong to, their capabilities in each, and their
+/// membership timeline.
+///
+/// Use `GET /v1/membership/list/{jurisdiction}` to enumerate a
+/// jurisdiction's roster (requires member standing in that jurisdiction).
 #[get("/holder/{did}/affiliations")]
 pub async fn list_affiliations(
+    http_req: HttpRequest,
     path: web::Path<String>,
     commons_manager: web::Data<Arc<CommonsManager>>,
 ) -> Result<HttpResponse> {
+    let claims = get_claims(&http_req)
+        .ok_or_else(|| GatewayError::AuthenticationFailed("Authentication required".to_string()))?;
+
     let did_str = path.into_inner();
     let did = did_str
         .parse::<Did>()
         .map_err(|e| GatewayError::BadRequest(format!("Invalid DID: {e}")))?;
+
+    // Self-only: affiliation history spans all jurisdictions and must not be
+    // enumerable by arbitrary callers.
+    if claims.sub != did.to_string() {
+        return Err(GatewayError::AuthorizationFailed(
+            "Can only list affiliations for your own identity".to_string(),
+        ));
+    }
 
     let holder = commons_manager
         .get_holder_by_did(&did)

--- a/icn/crates/icn-gateway/src/api/commons/mod.rs
+++ b/icn/crates/icn-gateway/src/api/commons/mod.rs
@@ -15,9 +15,7 @@ use utoipa::ToSchema;
 use crate::commons_mgr::CommonsManager;
 use crate::error::{GatewayError, Result};
 use crate::middleware::get_claims;
-use icn_identity::{
-    Affiliation, CommonsHolderRecord, Did, JurisdictionId, MembershipCapability, MembershipStatus,
-};
+use icn_identity::{Affiliation, CommonsHolderRecord, Did, JurisdictionId, MembershipStatus};
 
 // ============================================================================
 // Response/Request DTOs
@@ -96,8 +94,6 @@ impl From<&Affiliation> for AffiliationResponse {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct JoinJurisdictionRequest {
     pub jurisdiction_id: String,
-    #[serde(default)]
-    pub capabilities: Vec<String>,
 }
 
 /// Update affiliation status request
@@ -258,15 +254,11 @@ pub async fn join_jurisdiction(
     let holder_id = hex::encode(holder.id());
     let jurisdiction = JurisdictionId::new(&body.jurisdiction_id);
 
-    // Parse capabilities
-    let capabilities: Vec<MembershipCapability> = body
-        .capabilities
-        .iter()
-        .filter_map(|c| parse_capability(c))
-        .collect();
-
+    // Capabilities are not accepted from the caller — they are jurisdiction-granted.
+    // System-initiated flows (e.g., SDIS enrollment) use the internal CommonsManager
+    // API directly with explicit initial_capabilities.
     let affiliation = commons_manager
-        .join_jurisdiction(&holder_id, jurisdiction, capabilities)
+        .join_jurisdiction(&holder_id, jurisdiction, vec![])
         .await?;
 
     Ok(HttpResponse::Created().json(AffiliationResponse::from(&affiliation)))
@@ -355,18 +347,6 @@ pub async fn leave_jurisdiction(
 // ============================================================================
 // Helper Functions
 // ============================================================================
-
-fn parse_capability(s: &str) -> Option<MembershipCapability> {
-    match s.to_lowercase().as_str() {
-        "vote" => Some(MembershipCapability::Vote),
-        "propose" => Some(MembershipCapability::Propose),
-        "transact" => Some(MembershipCapability::Transact),
-        "holdoffice" | "hold_office" => Some(MembershipCapability::HoldOffice),
-        "accessprivate" | "access_private" => Some(MembershipCapability::AccessPrivate),
-        "sponsor" => Some(MembershipCapability::Sponsor),
-        _ => None,
-    }
-}
 
 fn parse_membership_status(s: &str) -> Option<MembershipStatus> {
     match s.to_lowercase().as_str() {

--- a/icn/crates/icn-gateway/src/api/commons/mod.rs
+++ b/icn/crates/icn-gateway/src/api/commons/mod.rs
@@ -411,7 +411,8 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use actix_web::{test, App};
+    use actix_web::{test, App, HttpMessage};
+    use crate::auth::TokenClaims;
 
     #[actix_web::test]
     async fn test_get_holder_not_found() {
@@ -427,11 +428,22 @@ mod tests {
         let keypair = icn_identity::KeyPair::generate().unwrap();
         let did = keypair.did().to_string();
 
+        // Inject claims directly into request extensions — the canonical test bypass
+        // for handlers that call get_claims(). No holder exists for this DID, so the
+        // handler should return 404 after auth passes.
+        let claims = TokenClaims {
+            sub: did.clone(),
+            iat: 1_000_000_000,
+            exp: 9_999_999_999,
+            coop_id: "test-coop".to_string(),
+            scopes: vec![],
+        };
         let req = test::TestRequest::get()
             .uri(&format!("/v1/commons/holder/{did}"))
             .to_request();
-        let resp = test::call_service(&app, req).await;
+        req.extensions_mut().insert(claims);
 
+        let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status(), actix_web::http::StatusCode::NOT_FOUND);
     }
 }

--- a/icn/crates/icn-gateway/src/api/commons/mod.rs
+++ b/icn/crates/icn-gateway/src/api/commons/mod.rs
@@ -411,8 +411,8 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use actix_web::{test, App, HttpMessage};
     use crate::auth::TokenClaims;
+    use actix_web::{test, App, HttpMessage};
 
     #[actix_web::test]
     async fn test_get_holder_not_found() {

--- a/icn/crates/icn-gateway/src/api/constitutional/appeals_ui.rs
+++ b/icn/crates/icn-gateway/src/api/constitutional/appeals_ui.rs
@@ -218,16 +218,32 @@ pub async fn assign_reviewer(
     })))
 }
 
+/// Query parameters for the appeals dashboard
+#[derive(Debug, serde::Deserialize, ToSchema)]
+pub struct AppealsDashboardQuery {
+    /// Restrict the dashboard to appeals scoped to this domain (exact match).
+    /// When supplied, only Jurisdiction-scoped appeals for this domain_id are
+    /// included.  Omitting this returns all appeals (useful for network-wide
+    /// admin views, but callers should scope to their own domain in multi-coop
+    /// nodes).
+    pub domain_id: Option<String>,
+}
+
 /// GET /constitutional/appeals/dashboard - Appeals dashboard data
 #[get("/appeals/dashboard")]
 pub async fn get_appeals_dashboard(
     http_req: HttpRequest,
     commons_mgr: web::Data<Arc<CommonsManager>>,
+    query: web::Query<AppealsDashboardQuery>,
 ) -> Result<HttpResponse> {
     require_scope(&http_req, "constitutional:read")?;
 
-    // Get all appeals
-    let all_appeals = commons_mgr.list_appeals(None, None, None).await?;
+    let all_appeals = if let Some(ref domain) = query.domain_id {
+        // Domain-scoped view: only jurisdiction appeals for this domain.
+        commons_mgr.list_appeals_by_domain(domain).await?
+    } else {
+        commons_mgr.list_appeals(None, None, None).await?
+    };
 
     let dashboard = build_dashboard(&all_appeals);
 

--- a/icn/crates/icn-gateway/src/api/constitutional/mod.rs
+++ b/icn/crates/icn-gateway/src/api/constitutional/mod.rs
@@ -582,6 +582,48 @@ pub async fn create_amendment(
     let amendment_type = parse_amendment_type(&req.amendment_type)?;
     let scope = parse_amendment_scope(&req.scope_type, req.scope_id.as_deref())?;
 
+    // Validate charter_id consistency before consuming `scope` into Amendment::new.
+    //
+    // When a charter_id is supplied alongside a Jurisdiction scope, the charter
+    // must belong to exactly that domain.  Accepting a mismatched pair would make
+    // the amendment's provenance ambiguous and produce a confusing substrate-level
+    // error instead of a clear boundary-layer rejection.
+    let validated_charter_id: Option<[u8; 32]> = if let Some(charter_hex) = &req.charter_id {
+        let charter_bytes = hex::decode(charter_hex)
+            .map_err(|e| GatewayError::BadRequest(format!("Invalid charter_id hex: {e}")))?;
+        if charter_bytes.len() != 32 {
+            return Err(GatewayError::BadRequest(
+                "charter_id must be 32 bytes".to_string(),
+            ));
+        }
+        let mut charter_id_bytes = [0u8; 32];
+        charter_id_bytes.copy_from_slice(&charter_bytes);
+
+        if let AmendmentScope::Jurisdiction {
+            domain_id: ref scope_domain,
+        } = scope
+        {
+            let charter = commons_mgr
+                .get_charter(charter_hex)
+                .await
+                .map_err(|e| GatewayError::InternalError(e.to_string()))?
+                .ok_or_else(|| {
+                    GatewayError::BadRequest(format!("charter_id '{charter_hex}' does not exist"))
+                })?;
+            if charter.domain_id != *scope_domain {
+                return Err(GatewayError::BadRequest(format!(
+                    "charter_id belongs to domain '{}' but amendment scope specifies '{}'; \
+                     charter_id and scope_id must refer to the same domain",
+                    charter.domain_id, scope_domain,
+                )));
+            }
+        }
+
+        Some(charter_id_bytes)
+    } else {
+        None
+    };
+
     // Create amendment
     let mut amendment = Amendment::new(
         amendment_type,
@@ -590,20 +632,7 @@ pub async fn create_amendment(
         req.description.clone(),
         proposer,
     );
-
-    // Add charter ID if provided
-    if let Some(charter_hex) = &req.charter_id {
-        let charter_bytes = hex::decode(charter_hex)
-            .map_err(|e| GatewayError::BadRequest(format!("Invalid charter_id hex: {e}")))?;
-        if charter_bytes.len() != 32 {
-            return Err(GatewayError::BadRequest(
-                "charter_id must be 32 bytes".to_string(),
-            ));
-        }
-        let mut charter_id = [0u8; 32];
-        charter_id.copy_from_slice(&charter_bytes);
-        amendment.charter_id = Some(charter_id);
-    }
+    amendment.charter_id = validated_charter_id;
 
     // Add changes
     for change_req in &req.changes {
@@ -633,6 +662,10 @@ pub struct ListAmendmentsQuery {
     /// Filter by type
     #[serde(rename = "type")]
     pub amendment_type: Option<String>,
+    /// Restrict results to amendments scoped to this domain (exact match).
+    /// When supplied, only Jurisdiction-scoped amendments for this domain_id
+    /// are returned.  Prevents cross-domain data leakage in multi-coop nodes.
+    pub domain_id: Option<String>,
     /// Cursor for pagination
     pub cursor: Option<String>,
     /// Number of items per page (default: 20, max: 100)
@@ -662,13 +695,18 @@ pub async fn list_amendments(
 ) -> Result<HttpResponse> {
     require_scope(&http_req, "constitutional:read")?;
 
-    let amendments = commons_mgr
-        .list_amendments(
-            query.status.as_deref(),
-            query.scope.as_deref(),
-            query.amendment_type.as_deref(),
-        )
-        .await?;
+    let amendments = if let Some(ref domain) = query.domain_id {
+        // Domain-scoped query: exact match, no cross-domain leakage.
+        commons_mgr.list_amendments_by_domain(domain).await?
+    } else {
+        commons_mgr
+            .list_amendments(
+                query.status.as_deref(),
+                query.scope.as_deref(),
+                query.amendment_type.as_deref(),
+            )
+            .await?
+    };
 
     // Convert to responses and sort by updated_at descending (most recent first)
     let mut responses: Vec<AmendmentResponse> =
@@ -1007,6 +1045,10 @@ pub struct ListAppealsQuery {
     pub scope: Option<String>,
     /// Filter by appellant
     pub appellant: Option<String>,
+    /// Restrict results to appeals scoped to this domain (exact match).
+    /// When supplied, only Jurisdiction-scoped appeals for this domain_id
+    /// are returned.  Prevents cross-domain data leakage in multi-coop nodes.
+    pub domain_id: Option<String>,
     /// Cursor for pagination
     pub cursor: Option<String>,
     /// Number of items per page (default: 20, max: 100)
@@ -1032,13 +1074,18 @@ pub async fn list_appeals(
 ) -> Result<HttpResponse> {
     require_scope(&http_req, "constitutional:read")?;
 
-    let appeals = commons_mgr
-        .list_appeals(
-            query.status.as_deref(),
-            query.scope.as_deref(),
-            query.appellant.as_deref(),
-        )
-        .await?;
+    let appeals = if let Some(ref domain) = query.domain_id {
+        // Domain-scoped query: exact match, no cross-domain leakage.
+        commons_mgr.list_appeals_by_domain(domain).await?
+    } else {
+        commons_mgr
+            .list_appeals(
+                query.status.as_deref(),
+                query.scope.as_deref(),
+                query.appellant.as_deref(),
+            )
+            .await?
+    };
 
     // Convert to responses and sort by updated_at descending (most recent first)
     let mut responses: Vec<AppealResponse2> = appeals.iter().map(appeal_to_response).collect();

--- a/icn/crates/icn-gateway/src/api/constitutional/mod.rs
+++ b/icn/crates/icn-gateway/src/api/constitutional/mod.rs
@@ -853,9 +853,19 @@ pub async fn add_amendment_change(
     let id_hex = id.into_inner();
 
     // Verify caller is proposer (get amendment first)
+    let id_bytes = hex::decode(&id_hex)
+        .map_err(|e| GatewayError::BadRequest(format!("Invalid amendment ID hex: {e}")))?;
+    if id_bytes.len() != 32 {
+        return Err(GatewayError::BadRequest(
+            "Amendment ID must be 32 bytes".to_string(),
+        ));
+    }
+    let mut amendment_id_arr = [0u8; 32];
+    amendment_id_arr.copy_from_slice(&id_bytes);
+    let amendment_id_for_lookup = AmendmentId::new(amendment_id_arr);
     let existing = commons_mgr
-        .store()
-        .get_amendment(&id_hex)?
+        .get_amendment(&amendment_id_for_lookup)
+        .await?
         .ok_or_else(|| GatewayError::NotFound("Amendment not found".to_string()))?;
 
     if existing.proposer != caller {

--- a/icn/crates/icn-gateway/src/api/membership/mod.rs
+++ b/icn/crates/icn-gateway/src/api/membership/mod.rs
@@ -106,6 +106,47 @@ impl Cursored for MemberResponse {
     }
 }
 
+// ============================================================================
+// Authority Helpers
+// ============================================================================
+
+/// Verify that `caller_did` holds the `HoldOffice` capability in `jurisdiction`.
+///
+/// This is the canonical authority gate for all membership admin operations.
+/// Returns `Err(GatewayError::AuthorizationFailed)` with a clear message when
+/// the caller is not a holder or lacks the required capability.
+async fn require_jurisdiction_authority(
+    commons_manager: &CommonsManager,
+    caller_did: &Did,
+    jurisdiction: &JurisdictionId,
+) -> Result<()> {
+    let caller_holder = commons_manager
+        .get_holder_by_did(caller_did)
+        .await
+        .map_err(|e| GatewayError::InternalError(e.to_string()))?
+        .ok_or_else(|| {
+            GatewayError::AuthorizationFailed("Caller is not a commons holder".to_string())
+        })?;
+
+    let holder_id_hex = hex::encode(caller_holder.holder_id);
+    let has_authority = commons_manager
+        .member_has_capability(
+            &holder_id_hex,
+            jurisdiction,
+            MembershipCapability::HoldOffice,
+        )
+        .await
+        .unwrap_or(false);
+
+    if !has_authority {
+        return Err(GatewayError::AuthorizationFailed(format!(
+            "Caller does not hold office in '{jurisdiction}' (HoldOffice capability required)"
+        )));
+    }
+
+    Ok(())
+}
+
 fn parse_capability(s: &str) -> Option<MembershipCapability> {
     match s.to_lowercase().as_str() {
         "vote" => Some(MembershipCapability::Vote),
@@ -290,10 +331,16 @@ pub async fn promote_member(
     body: web::Json<MembershipActionRequest>,
     commons_manager: web::Data<Arc<CommonsManager>>,
 ) -> Result<HttpResponse> {
-    let _claims = get_claims(&http_req)
+    let claims = get_claims(&http_req)
         .ok_or_else(|| GatewayError::AuthenticationFailed("Authentication required".to_string()))?;
 
+    let caller_did: Did = claims
+        .sub
+        .parse()
+        .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
+
     let jurisdiction_id = JurisdictionId::new(&body.jurisdiction_id);
+    require_jurisdiction_authority(&commons_manager, &caller_did, &jurisdiction_id).await?;
 
     commons_manager
         .promote_member(&body.holder_id, &jurisdiction_id)
@@ -314,10 +361,16 @@ pub async fn suspend_member(
     body: web::Json<MembershipActionRequest>,
     commons_manager: web::Data<Arc<CommonsManager>>,
 ) -> Result<HttpResponse> {
-    let _claims = get_claims(&http_req)
+    let claims = get_claims(&http_req)
         .ok_or_else(|| GatewayError::AuthenticationFailed("Authentication required".to_string()))?;
 
+    let caller_did: Did = claims
+        .sub
+        .parse()
+        .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
+
     let jurisdiction_id = JurisdictionId::new(&body.jurisdiction_id);
+    require_jurisdiction_authority(&commons_manager, &caller_did, &jurisdiction_id).await?;
 
     commons_manager
         .suspend_member(&body.holder_id, &jurisdiction_id)
@@ -338,10 +391,16 @@ pub async fn reinstate_member(
     body: web::Json<MembershipActionRequest>,
     commons_manager: web::Data<Arc<CommonsManager>>,
 ) -> Result<HttpResponse> {
-    let _claims = get_claims(&http_req)
+    let claims = get_claims(&http_req)
         .ok_or_else(|| GatewayError::AuthenticationFailed("Authentication required".to_string()))?;
 
+    let caller_did: Did = claims
+        .sub
+        .parse()
+        .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
+
     let jurisdiction_id = JurisdictionId::new(&body.jurisdiction_id);
+    require_jurisdiction_authority(&commons_manager, &caller_did, &jurisdiction_id).await?;
 
     commons_manager
         .reinstate_member(&body.holder_id, &jurisdiction_id)
@@ -371,6 +430,7 @@ pub async fn ban_member(
         .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
 
     let jurisdiction_id = JurisdictionId::new(&body.jurisdiction_id);
+    require_jurisdiction_authority(&commons_manager, &authority, &jurisdiction_id).await?;
 
     let reason = if let Some(summary) = &body.evidence_summary {
         CommonsRevocationReason::PolicyViolation {
@@ -412,6 +472,7 @@ pub async fn revoke_membership(
         .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
 
     let jurisdiction_id = JurisdictionId::new(&body.jurisdiction_id);
+    require_jurisdiction_authority(&commons_manager, &authority, &jurisdiction_id).await?;
 
     let reason = if let Some(policy) = &body.policy_ref {
         CommonsRevocationReason::PolicyViolation {
@@ -455,10 +516,17 @@ pub async fn grant_capability(
     body: web::Json<CapabilityRequest>,
     commons_manager: web::Data<Arc<CommonsManager>>,
 ) -> Result<HttpResponse> {
-    let _claims = get_claims(&http_req)
+    let claims = get_claims(&http_req)
         .ok_or_else(|| GatewayError::AuthenticationFailed("Authentication required".to_string()))?;
 
+    let caller_did: Did = claims
+        .sub
+        .parse()
+        .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
+
     let jurisdiction_id = JurisdictionId::new(&body.jurisdiction_id);
+    require_jurisdiction_authority(&commons_manager, &caller_did, &jurisdiction_id).await?;
+
     let capability = parse_capability(&body.capability)
         .ok_or_else(|| GatewayError::BadRequest("Invalid capability".to_string()))?;
 
@@ -481,10 +549,17 @@ pub async fn revoke_capability(
     body: web::Json<CapabilityRequest>,
     commons_manager: web::Data<Arc<CommonsManager>>,
 ) -> Result<HttpResponse> {
-    let _claims = get_claims(&http_req)
+    let claims = get_claims(&http_req)
         .ok_or_else(|| GatewayError::AuthenticationFailed("Authentication required".to_string()))?;
 
+    let caller_did: Did = claims
+        .sub
+        .parse()
+        .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
+
     let jurisdiction_id = JurisdictionId::new(&body.jurisdiction_id);
+    require_jurisdiction_authority(&commons_manager, &caller_did, &jurisdiction_id).await?;
+
     let capability = parse_capability(&body.capability)
         .ok_or_else(|| GatewayError::BadRequest("Invalid capability".to_string()))?;
 
@@ -537,10 +612,16 @@ pub async fn add_role(
     body: web::Json<RoleRequest>,
     commons_manager: web::Data<Arc<CommonsManager>>,
 ) -> Result<HttpResponse> {
-    let _claims = get_claims(&http_req)
+    let claims = get_claims(&http_req)
         .ok_or_else(|| GatewayError::AuthenticationFailed("Authentication required".to_string()))?;
 
+    let caller_did: Did = claims
+        .sub
+        .parse()
+        .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
+
     let jurisdiction_id = JurisdictionId::new(&body.jurisdiction_id);
+    require_jurisdiction_authority(&commons_manager, &caller_did, &jurisdiction_id).await?;
 
     commons_manager
         .add_member_role(&body.holder_id, &jurisdiction_id, body.role.clone())
@@ -561,10 +642,16 @@ pub async fn remove_role(
     body: web::Json<RoleRequest>,
     commons_manager: web::Data<Arc<CommonsManager>>,
 ) -> Result<HttpResponse> {
-    let _claims = get_claims(&http_req)
+    let claims = get_claims(&http_req)
         .ok_or_else(|| GatewayError::AuthenticationFailed("Authentication required".to_string()))?;
 
+    let caller_did: Did = claims
+        .sub
+        .parse()
+        .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
+
     let jurisdiction_id = JurisdictionId::new(&body.jurisdiction_id);
+    require_jurisdiction_authority(&commons_manager, &caller_did, &jurisdiction_id).await?;
 
     commons_manager
         .remove_member_role(&body.holder_id, &jurisdiction_id, &body.role)

--- a/icn/crates/icn-gateway/src/api/membership/mod.rs
+++ b/icn/crates/icn-gateway/src/api/membership/mod.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
 
+use crate::authority::require_office_in_jurisdiction;
 use crate::commons_mgr::CommonsManager;
 use crate::error::{GatewayError, Result};
 use crate::middleware::get_claims;
@@ -104,47 +105,6 @@ impl Cursored for MemberResponse {
     fn cursor_id(&self) -> &str {
         &self.holder_id
     }
-}
-
-// ============================================================================
-// Authority Helpers
-// ============================================================================
-
-/// Verify that `caller_did` holds the `HoldOffice` capability in `jurisdiction`.
-///
-/// This is the canonical authority gate for all membership admin operations.
-/// Returns `Err(GatewayError::AuthorizationFailed)` with a clear message when
-/// the caller is not a holder or lacks the required capability.
-async fn require_jurisdiction_authority(
-    commons_manager: &CommonsManager,
-    caller_did: &Did,
-    jurisdiction: &JurisdictionId,
-) -> Result<()> {
-    let caller_holder = commons_manager
-        .get_holder_by_did(caller_did)
-        .await
-        .map_err(|e| GatewayError::InternalError(e.to_string()))?
-        .ok_or_else(|| {
-            GatewayError::AuthorizationFailed("Caller is not a commons holder".to_string())
-        })?;
-
-    let holder_id_hex = hex::encode(caller_holder.holder_id);
-    let has_authority = commons_manager
-        .member_has_capability(
-            &holder_id_hex,
-            jurisdiction,
-            MembershipCapability::HoldOffice,
-        )
-        .await
-        .unwrap_or(false);
-
-    if !has_authority {
-        return Err(GatewayError::AuthorizationFailed(format!(
-            "Caller does not hold office in '{jurisdiction}' (HoldOffice capability required)"
-        )));
-    }
-
-    Ok(())
 }
 
 fn parse_capability(s: &str) -> Option<MembershipCapability> {
@@ -286,31 +246,7 @@ pub async fn approve_membership(
         .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
 
     let jurisdiction_id = JurisdictionId::new(&body.jurisdiction_id);
-
-    // Authorization: Caller must have HoldOffice capability in the jurisdiction
-    let caller_holder = commons_manager
-        .get_holder_by_did(&caller_did)
-        .await
-        .map_err(|e| GatewayError::InternalError(e.to_string()))?
-        .ok_or_else(|| {
-            GatewayError::AuthorizationFailed("Caller is not a commons holder".to_string())
-        })?;
-
-    let holder_id_hex = hex::encode(caller_holder.holder_id);
-    let has_authority = commons_manager
-        .member_has_capability(
-            &holder_id_hex,
-            &jurisdiction_id,
-            MembershipCapability::HoldOffice,
-        )
-        .await
-        .unwrap_or(false);
-
-    if !has_authority {
-        return Err(GatewayError::AuthorizationFailed(
-            "Caller does not have admin rights (HoldOffice capability required)".to_string(),
-        ));
-    }
+    require_office_in_jurisdiction(&commons_manager, &caller_did, &jurisdiction_id).await?;
 
     commons_manager
         .approve_membership(&body.holder_id, &jurisdiction_id)
@@ -340,7 +276,7 @@ pub async fn promote_member(
         .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
 
     let jurisdiction_id = JurisdictionId::new(&body.jurisdiction_id);
-    require_jurisdiction_authority(&commons_manager, &caller_did, &jurisdiction_id).await?;
+    require_office_in_jurisdiction(&commons_manager, &caller_did, &jurisdiction_id).await?;
 
     commons_manager
         .promote_member(&body.holder_id, &jurisdiction_id)
@@ -370,7 +306,7 @@ pub async fn suspend_member(
         .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
 
     let jurisdiction_id = JurisdictionId::new(&body.jurisdiction_id);
-    require_jurisdiction_authority(&commons_manager, &caller_did, &jurisdiction_id).await?;
+    require_office_in_jurisdiction(&commons_manager, &caller_did, &jurisdiction_id).await?;
 
     commons_manager
         .suspend_member(&body.holder_id, &jurisdiction_id)
@@ -400,7 +336,7 @@ pub async fn reinstate_member(
         .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
 
     let jurisdiction_id = JurisdictionId::new(&body.jurisdiction_id);
-    require_jurisdiction_authority(&commons_manager, &caller_did, &jurisdiction_id).await?;
+    require_office_in_jurisdiction(&commons_manager, &caller_did, &jurisdiction_id).await?;
 
     commons_manager
         .reinstate_member(&body.holder_id, &jurisdiction_id)
@@ -430,7 +366,7 @@ pub async fn ban_member(
         .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
 
     let jurisdiction_id = JurisdictionId::new(&body.jurisdiction_id);
-    require_jurisdiction_authority(&commons_manager, &authority, &jurisdiction_id).await?;
+    require_office_in_jurisdiction(&commons_manager, &authority, &jurisdiction_id).await?;
 
     let reason = if let Some(summary) = &body.evidence_summary {
         CommonsRevocationReason::PolicyViolation {
@@ -472,7 +408,7 @@ pub async fn revoke_membership(
         .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
 
     let jurisdiction_id = JurisdictionId::new(&body.jurisdiction_id);
-    require_jurisdiction_authority(&commons_manager, &authority, &jurisdiction_id).await?;
+    require_office_in_jurisdiction(&commons_manager, &authority, &jurisdiction_id).await?;
 
     let reason = if let Some(policy) = &body.policy_ref {
         CommonsRevocationReason::PolicyViolation {
@@ -525,7 +461,7 @@ pub async fn grant_capability(
         .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
 
     let jurisdiction_id = JurisdictionId::new(&body.jurisdiction_id);
-    require_jurisdiction_authority(&commons_manager, &caller_did, &jurisdiction_id).await?;
+    require_office_in_jurisdiction(&commons_manager, &caller_did, &jurisdiction_id).await?;
 
     let capability = parse_capability(&body.capability)
         .ok_or_else(|| GatewayError::BadRequest("Invalid capability".to_string()))?;
@@ -558,7 +494,7 @@ pub async fn revoke_capability(
         .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
 
     let jurisdiction_id = JurisdictionId::new(&body.jurisdiction_id);
-    require_jurisdiction_authority(&commons_manager, &caller_did, &jurisdiction_id).await?;
+    require_office_in_jurisdiction(&commons_manager, &caller_did, &jurisdiction_id).await?;
 
     let capability = parse_capability(&body.capability)
         .ok_or_else(|| GatewayError::BadRequest("Invalid capability".to_string()))?;
@@ -621,7 +557,7 @@ pub async fn add_role(
         .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
 
     let jurisdiction_id = JurisdictionId::new(&body.jurisdiction_id);
-    require_jurisdiction_authority(&commons_manager, &caller_did, &jurisdiction_id).await?;
+    require_office_in_jurisdiction(&commons_manager, &caller_did, &jurisdiction_id).await?;
 
     commons_manager
         .add_member_role(&body.holder_id, &jurisdiction_id, body.role.clone())
@@ -651,7 +587,7 @@ pub async fn remove_role(
         .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
 
     let jurisdiction_id = JurisdictionId::new(&body.jurisdiction_id);
-    require_jurisdiction_authority(&commons_manager, &caller_did, &jurisdiction_id).await?;
+    require_office_in_jurisdiction(&commons_manager, &caller_did, &jurisdiction_id).await?;
 
     commons_manager
         .remove_member_role(&body.holder_id, &jurisdiction_id, &body.role)

--- a/icn/crates/icn-gateway/src/api/membership/mod.rs
+++ b/icn/crates/icn-gateway/src/api/membership/mod.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
 
-use crate::authority::require_office_in_jurisdiction;
+use crate::authority::{require_membership_in_jurisdiction, require_office_in_jurisdiction};
 use crate::commons_mgr::CommonsManager;
 use crate::error::{GatewayError, Result};
 use crate::middleware::get_claims;
@@ -615,10 +615,20 @@ pub async fn list_members(
     query: web::Query<ListMembersQuery>,
     commons_manager: web::Data<Arc<CommonsManager>>,
 ) -> Result<HttpResponse> {
-    let _claims = get_claims(&http_req)
+    let claims = get_claims(&http_req)
         .ok_or_else(|| GatewayError::AuthenticationFailed("Authentication required".to_string()))?;
 
     let jurisdiction_id = JurisdictionId::new(path.into_inner());
+
+    // Require the caller to be a full member of the jurisdiction whose roster
+    // they are requesting. Any authenticated user could otherwise enumerate the
+    // membership of any cooperative — including capabilities (HoldOffice etc.)
+    // for every member — without any standing in that cooperative.
+    let caller_did = claims
+        .sub
+        .parse::<Did>()
+        .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
+    require_membership_in_jurisdiction(&commons_manager, &caller_did, &jurisdiction_id).await?;
 
     let status_filter = query
         .status

--- a/icn/crates/icn-gateway/src/api/membership/mod.rs
+++ b/icn/crates/icn-gateway/src/api/membership/mod.rs
@@ -30,8 +30,6 @@ use icn_identity::{
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct ApplyMembershipRequest {
     pub jurisdiction_id: String,
-    #[serde(default)]
-    pub capabilities_requested: Vec<String>,
 }
 
 /// Membership action request (approve, promote, suspend, etc.)
@@ -158,15 +156,8 @@ pub async fn apply_for_membership(
     let holder_id = hex::encode(holder.id());
     let jurisdiction_id = JurisdictionId::new(&body.jurisdiction_id);
 
-    // Parse requested capabilities
-    let capabilities: Vec<MembershipCapability> = body
-        .capabilities_requested
-        .iter()
-        .filter_map(|s| parse_capability(s))
-        .collect();
-
     let affiliation = commons_manager
-        .apply_for_membership(&holder_id, jurisdiction_id.clone(), capabilities)
+        .apply_for_membership(&holder_id, jurisdiction_id.clone())
         .await?;
 
     Ok(HttpResponse::Created().json(MemberResponse {

--- a/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
@@ -105,10 +105,14 @@ impl EnrollmentStore {
         }
     }
 
-    /// Create store with persistence to CommonsManager
-    pub fn with_persistence(commons_manager: Arc<crate::commons_mgr::CommonsManager>) -> Self {
-        // Enrollment sessions are in-memory only (CommonsManager gateway-local concern).
-        // There is no persistent store to load from on startup.
+    /// Create store wired to a CommonsManager for write-through of completed enrollment results.
+    ///
+    /// Enrollment sessions themselves are in-memory only — they are short-lived workflow state
+    /// that does not survive a gateway restart, which is intentional. The CommonsManager is
+    /// used to persist the final enrollment outcome (anchor / holder records) once a ceremony
+    /// completes, not the session itself.
+    pub fn with_commons_manager(commons_manager: Arc<crate::commons_mgr::CommonsManager>) -> Self {
+        // No sessions to load on startup — they are ephemeral in-memory state.
         tracing::info!("Enrollment session store initialised (in-memory, 0 sessions loaded)");
 
         Self {

--- a/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
@@ -107,24 +107,12 @@ impl EnrollmentStore {
 
     /// Create store with persistence to CommonsManager
     pub fn with_persistence(commons_manager: Arc<crate::commons_mgr::CommonsManager>) -> Self {
-        // Load existing sessions from persistent storage
-        let sessions = commons_manager
-            .store()
-            .list_enrollment_sessions()
-            .unwrap_or_default();
-
-        let mut map = std::collections::HashMap::new();
-        for (id, session) in sessions {
-            map.insert(id, session);
-        }
-
-        tracing::info!(
-            "Loaded {} enrollment sessions from persistent storage",
-            map.len()
-        );
+        // Enrollment sessions are in-memory only (CommonsManager gateway-local concern).
+        // There is no persistent store to load from on startup.
+        tracing::info!("Enrollment session store initialised (in-memory, 0 sessions loaded)");
 
         Self {
-            enrollments: RwLock::new(map),
+            enrollments: RwLock::new(std::collections::HashMap::new()),
             commons_manager: Some(commons_manager),
         }
     }

--- a/icn/crates/icn-gateway/src/api/steward/mod.rs
+++ b/icn/crates/icn-gateway/src/api/steward/mod.rs
@@ -7,6 +7,7 @@
 //! - Bond management
 
 use actix_web::{get, post, put, web, HttpRequest, HttpResponse};
+use hex;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
@@ -14,13 +15,54 @@ use utoipa::ToSchema;
 use crate::commons_mgr::{steward_to_detail, steward_to_summary, CommonsManager};
 use crate::error::{GatewayError, Result};
 use crate::middleware::get_claims;
-use icn_identity::Did;
+use icn_identity::{Did, JurisdictionId, MembershipCapability};
 
 // ============================================================================
 // Response/Request DTOs
 // ============================================================================
 
 pub use crate::models::{StewardDetailResponse, StewardSummaryResponse};
+
+// ============================================================================
+// Authority Helpers
+// ============================================================================
+
+/// Verify that `caller_did` holds the `HoldOffice` capability in `jurisdiction`.
+///
+/// Mirrors the pattern used in membership handlers. Returns
+/// `Err(GatewayError::AuthorizationFailed)` when the caller is not a holder or
+/// lacks the required capability.
+async fn require_jurisdiction_authority(
+    commons_manager: &CommonsManager,
+    caller_did: &Did,
+    jurisdiction: &JurisdictionId,
+) -> Result<()> {
+    let caller_holder = commons_manager
+        .get_holder_by_did(caller_did)
+        .await
+        .map_err(|e| GatewayError::InternalError(e.to_string()))?
+        .ok_or_else(|| {
+            GatewayError::AuthorizationFailed("Caller is not a commons holder".to_string())
+        })?;
+
+    let holder_id_hex = hex::encode(caller_holder.holder_id);
+    let has_authority = commons_manager
+        .member_has_capability(
+            &holder_id_hex,
+            jurisdiction,
+            MembershipCapability::HoldOffice,
+        )
+        .await
+        .unwrap_or(false);
+
+    if !has_authority {
+        return Err(GatewayError::AuthorizationFailed(format!(
+            "Caller does not hold office in '{jurisdiction}' (HoldOffice capability required)"
+        )));
+    }
+
+    Ok(())
+}
 
 /// Register steward request
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -216,17 +258,37 @@ pub async fn update_steward_status(
     body: web::Json<UpdateStatusRequest>,
     commons_manager: web::Data<Arc<CommonsManager>>,
 ) -> Result<HttpResponse> {
-    let _claims = get_claims(&http_req)
+    let claims = get_claims(&http_req)
         .ok_or_else(|| GatewayError::AuthenticationFailed("Authentication required".to_string()))?;
+
+    let caller_did: Did = claims
+        .sub
+        .parse()
+        .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
 
     let steward_id = path.into_inner();
 
-    // Verify steward exists
-    let _steward = commons_manager
+    // Verify steward exists and resolve their jurisdiction for authority check
+    let steward = commons_manager
         .get_steward(&steward_id)
         .await
         .map_err(|e| GatewayError::InternalError(e.to_string()))?
         .ok_or_else(|| GatewayError::NotFound("Steward not found".to_string()))?;
+
+    // Require caller to hold office in the steward's jurisdiction
+    let jurisdiction_id = steward
+        .jurisdiction
+        .as_ref()
+        .map(|j| JurisdictionId(j.clone()))
+        .ok_or_else(|| {
+            GatewayError::BadRequest(
+                "Steward has no jurisdiction; cannot determine authority scope".to_string(),
+            )
+        })?;
+
+    require_jurisdiction_authority(&commons_manager, &caller_did, &jurisdiction_id).await?;
+
+    let _steward = steward;
 
     match body.status.to_lowercase().as_str() {
         "suspend" | "suspended" => {
@@ -342,17 +404,34 @@ pub async fn extend_steward_term(
     body: web::Json<ExtendTermRequest>,
     commons_manager: web::Data<Arc<CommonsManager>>,
 ) -> Result<HttpResponse> {
-    let _claims = get_claims(&http_req)
+    let claims = get_claims(&http_req)
         .ok_or_else(|| GatewayError::AuthenticationFailed("Authentication required".to_string()))?;
+
+    let caller_did: Did = claims
+        .sub
+        .parse()
+        .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
 
     let steward_id = path.into_inner();
 
-    // Verify steward exists
+    // Verify steward exists and resolve jurisdiction for authority check
     let steward = commons_manager
         .get_steward(&steward_id)
         .await
         .map_err(|e| GatewayError::InternalError(e.to_string()))?
         .ok_or_else(|| GatewayError::NotFound("Steward not found".to_string()))?;
+
+    let jurisdiction_id = steward
+        .jurisdiction
+        .as_ref()
+        .map(|j| JurisdictionId(j.clone()))
+        .ok_or_else(|| {
+            GatewayError::BadRequest(
+                "Steward has no jurisdiction; cannot determine authority scope".to_string(),
+            )
+        })?;
+
+    require_jurisdiction_authority(&commons_manager, &caller_did, &jurisdiction_id).await?;
 
     // Calculate new term end
     let additional_secs = body.additional_days * 24 * 60 * 60;
@@ -386,7 +465,10 @@ pub async fn extend_steward_term(
 // Bond Management Endpoints
 // ============================================================================
 
-/// POST /v1/steward/{id}/bond/add - Add to steward's bond
+/// POST /v1/steward/{id}/bond/add - Add to steward's bond (self-service)
+///
+/// Only the steward's own holder may add to their bond. Increasing a bond is a
+/// self-service economic commitment — governance (HoldOffice) is not required.
 #[post("/{steward_id}/bond/add")]
 pub async fn add_bond(
     http_req: HttpRequest,
@@ -394,17 +476,30 @@ pub async fn add_bond(
     body: web::Json<BondOperationRequest>,
     commons_manager: web::Data<Arc<CommonsManager>>,
 ) -> Result<HttpResponse> {
-    let _claims = get_claims(&http_req)
+    let claims = get_claims(&http_req)
         .ok_or_else(|| GatewayError::AuthenticationFailed("Authentication required".to_string()))?;
+
+    let caller_did: Did = claims
+        .sub
+        .parse()
+        .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
 
     let steward_id = path.into_inner();
 
-    // Verify steward exists
-    let _steward = commons_manager
+    // Verify steward exists and enforce self-service: caller must be this steward
+    let steward = commons_manager
         .get_steward(&steward_id)
         .await
         .map_err(|e| GatewayError::InternalError(e.to_string()))?
         .ok_or_else(|| GatewayError::NotFound("Steward not found".to_string()))?;
+
+    if steward.holder_did != caller_did && steward.steward_did != caller_did {
+        return Err(GatewayError::AuthorizationFailed(
+            "Can only add bond to your own stewardship".to_string(),
+        ));
+    }
+
+    let _steward = steward;
 
     commons_manager
         .add_steward_bond(&steward_id, body.amount)
@@ -508,17 +603,38 @@ pub async fn slash_bond(
 // Attestation Tracking Endpoints
 // ============================================================================
 
-/// POST /v1/steward/{id}/attestation - Record an attestation issued
+/// POST /v1/steward/{id}/attestation - Record an attestation issued (self-service)
+///
+/// A steward calls this to log that they issued an attestation. Only the
+/// steward's own DID may record this — it is a self-report of work performed.
 #[post("/{steward_id}/attestation")]
 pub async fn record_attestation(
     http_req: HttpRequest,
     path: web::Path<String>,
     commons_manager: web::Data<Arc<CommonsManager>>,
 ) -> Result<HttpResponse> {
-    let _claims = get_claims(&http_req)
+    let claims = get_claims(&http_req)
         .ok_or_else(|| GatewayError::AuthenticationFailed("Authentication required".to_string()))?;
 
+    let caller_did: Did = claims
+        .sub
+        .parse()
+        .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
+
     let steward_id = path.into_inner();
+
+    // Self-service: only the steward may record their own attestation
+    let steward = commons_manager
+        .get_steward(&steward_id)
+        .await
+        .map_err(|e| GatewayError::InternalError(e.to_string()))?
+        .ok_or_else(|| GatewayError::NotFound("Steward not found".to_string()))?;
+
+    if steward.steward_did != caller_did && steward.holder_did != caller_did {
+        return Err(GatewayError::AuthorizationFailed(
+            "Can only record attestations for your own stewardship".to_string(),
+        ));
+    }
 
     commons_manager
         .record_steward_attestation(&steward_id)
@@ -572,16 +688,44 @@ pub async fn record_dispute(
 }
 
 /// POST /v1/steward/{id}/dispute-won - Record a dispute won by the steward
+///
+/// Recording a dispute outcome that positively affects a steward's reputation
+/// is a governance action. Requires the caller to hold office in the steward's
+/// jurisdiction to prevent reputation inflation by the steward themselves.
 #[post("/{steward_id}/dispute-won")]
 pub async fn record_dispute_won(
     http_req: HttpRequest,
     path: web::Path<String>,
     commons_manager: web::Data<Arc<CommonsManager>>,
 ) -> Result<HttpResponse> {
-    let _claims = get_claims(&http_req)
+    let claims = get_claims(&http_req)
         .ok_or_else(|| GatewayError::AuthenticationFailed("Authentication required".to_string()))?;
 
+    let caller_did: Did = claims
+        .sub
+        .parse()
+        .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
+
     let steward_id = path.into_inner();
+
+    // Resolve steward and their jurisdiction for authority check
+    let steward = commons_manager
+        .get_steward(&steward_id)
+        .await
+        .map_err(|e| GatewayError::InternalError(e.to_string()))?
+        .ok_or_else(|| GatewayError::NotFound("Steward not found".to_string()))?;
+
+    let jurisdiction_id = steward
+        .jurisdiction
+        .as_ref()
+        .map(|j| JurisdictionId(j.clone()))
+        .ok_or_else(|| {
+            GatewayError::BadRequest(
+                "Steward has no jurisdiction; cannot determine authority scope".to_string(),
+            )
+        })?;
+
+    require_jurisdiction_authority(&commons_manager, &caller_did, &jurisdiction_id).await?;
 
     commons_manager
         .record_steward_dispute_won(&steward_id)

--- a/icn/crates/icn-gateway/src/api/steward/mod.rs
+++ b/icn/crates/icn-gateway/src/api/steward/mod.rs
@@ -12,57 +12,17 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
 
+use crate::authority::{require_membership_in_jurisdiction, require_office_in_jurisdiction};
 use crate::commons_mgr::{steward_to_detail, steward_to_summary, CommonsManager};
 use crate::error::{GatewayError, Result};
 use crate::middleware::get_claims;
-use icn_identity::{Did, JurisdictionId, MembershipCapability};
+use icn_identity::{Did, JurisdictionId};
 
 // ============================================================================
 // Response/Request DTOs
 // ============================================================================
 
 pub use crate::models::{StewardDetailResponse, StewardSummaryResponse};
-
-// ============================================================================
-// Authority Helpers
-// ============================================================================
-
-/// Verify that `caller_did` holds the `HoldOffice` capability in `jurisdiction`.
-///
-/// Mirrors the pattern used in membership handlers. Returns
-/// `Err(GatewayError::AuthorizationFailed)` when the caller is not a holder or
-/// lacks the required capability.
-async fn require_jurisdiction_authority(
-    commons_manager: &CommonsManager,
-    caller_did: &Did,
-    jurisdiction: &JurisdictionId,
-) -> Result<()> {
-    let caller_holder = commons_manager
-        .get_holder_by_did(caller_did)
-        .await
-        .map_err(|e| GatewayError::InternalError(e.to_string()))?
-        .ok_or_else(|| {
-            GatewayError::AuthorizationFailed("Caller is not a commons holder".to_string())
-        })?;
-
-    let holder_id_hex = hex::encode(caller_holder.holder_id);
-    let has_authority = commons_manager
-        .member_has_capability(
-            &holder_id_hex,
-            jurisdiction,
-            MembershipCapability::HoldOffice,
-        )
-        .await
-        .unwrap_or(false);
-
-    if !has_authority {
-        return Err(GatewayError::AuthorizationFailed(format!(
-            "Caller does not hold office in '{jurisdiction}' (HoldOffice capability required)"
-        )));
-    }
-
-    Ok(())
-}
 
 /// Register steward request
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -286,7 +246,7 @@ pub async fn update_steward_status(
             )
         })?;
 
-    require_jurisdiction_authority(&commons_manager, &caller_did, &jurisdiction_id).await?;
+    require_office_in_jurisdiction(&commons_manager, &caller_did, &jurisdiction_id).await?;
 
     let _steward = steward;
 
@@ -431,7 +391,7 @@ pub async fn extend_steward_term(
             )
         })?;
 
-    require_jurisdiction_authority(&commons_manager, &caller_did, &jurisdiction_id).await?;
+    require_office_in_jurisdiction(&commons_manager, &caller_did, &jurisdiction_id).await?;
 
     // Calculate new term end
     let additional_secs = body.additional_days * 24 * 60 * 60;
@@ -656,16 +616,47 @@ pub async fn record_attestation(
 }
 
 /// POST /v1/steward/{id}/dispute - Record a dispute against the steward
+///
+/// Dispute filing is a member-standing action: any full member of the steward's
+/// jurisdiction may report a concern, but unenrolled outsiders cannot inflate a
+/// steward's dispute count.  Requires `Vote` capability in the steward's
+/// jurisdiction — does NOT require `HoldOffice`.
 #[post("/{steward_id}/dispute")]
 pub async fn record_dispute(
     http_req: HttpRequest,
     path: web::Path<String>,
     commons_manager: web::Data<Arc<CommonsManager>>,
 ) -> Result<HttpResponse> {
-    let _claims = get_claims(&http_req)
+    let claims = get_claims(&http_req)
         .ok_or_else(|| GatewayError::AuthenticationFailed("Authentication required".to_string()))?;
 
+    let caller_did: Did = claims
+        .sub
+        .parse()
+        .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
+
     let steward_id = path.into_inner();
+
+    // Resolve jurisdiction from steward record before mutating
+    let steward = commons_manager
+        .get_steward(&steward_id)
+        .await
+        .map_err(|e| GatewayError::InternalError(e.to_string()))?
+        .ok_or_else(|| GatewayError::NotFound("Steward not found".to_string()))?;
+
+    let jurisdiction_id = steward
+        .jurisdiction
+        .as_ref()
+        .map(|j| JurisdictionId(j.clone()))
+        .ok_or_else(|| {
+            GatewayError::BadRequest(
+                "Steward has no jurisdiction; cannot verify member standing".to_string(),
+            )
+        })?;
+
+    // Require member-standing in the steward's jurisdiction (Vote capability).
+    // Outsiders cannot file disputes — only enrolled members with voting rights.
+    require_membership_in_jurisdiction(&commons_manager, &caller_did, &jurisdiction_id).await?;
 
     commons_manager
         .record_steward_dispute(&steward_id)
@@ -725,7 +716,7 @@ pub async fn record_dispute_won(
             )
         })?;
 
-    require_jurisdiction_authority(&commons_manager, &caller_did, &jurisdiction_id).await?;
+    require_office_in_jurisdiction(&commons_manager, &caller_did, &jurisdiction_id).await?;
 
     commons_manager
         .record_steward_dispute_won(&steward_id)

--- a/icn/crates/icn-gateway/src/authority.rs
+++ b/icn/crates/icn-gateway/src/authority.rs
@@ -1,0 +1,100 @@
+//! Gateway-layer jurisdiction authority helpers.
+//!
+//! Provides the two canonical authority gates used across membership and steward
+//! handlers.  Both gates resolve the caller's DID to a commons holder, then
+//! check a specific `MembershipCapability` within a given jurisdiction.
+//!
+//! ## Authority levels
+//!
+//! | Level | Capability | Used for |
+//! |-------|-----------|----------|
+//! | Office-holding | `HoldOffice` | Governance mutations (promote, suspend, grant capability, …) |
+//! | Member-standing | `Vote` | Member-rights actions (dispute filing, …) |
+//!
+//! Neither level implies global elevated status.  Both are scoped to the
+//! exact jurisdiction supplied by the caller — there is no cross-jurisdiction
+//! propagation.
+
+use crate::commons_mgr::CommonsManager;
+use crate::error::{GatewayError, Result};
+use icn_identity::{Did, JurisdictionId, MembershipCapability, MembershipStatus};
+
+/// Require that `caller_did` holds the `HoldOffice` capability in `jurisdiction`.
+///
+/// Used to gate jurisdiction-governance mutations: membership promotion/suspension,
+/// capability grants, role changes, steward status updates, and similar operations
+/// that require a legitimately delegated cooperative office in the target domain.
+///
+/// Returns `Err(GatewayError::AuthorizationFailed)` when the caller is not a
+/// commons holder or lacks `HoldOffice` in the given jurisdiction.
+pub(crate) async fn require_office_in_jurisdiction(
+    commons_manager: &CommonsManager,
+    caller_did: &Did,
+    jurisdiction: &JurisdictionId,
+) -> Result<()> {
+    let caller_holder = commons_manager
+        .get_holder_by_did(caller_did)
+        .await
+        .map_err(|e| GatewayError::InternalError(e.to_string()))?
+        .ok_or_else(|| {
+            GatewayError::AuthorizationFailed("Caller is not a commons holder".to_string())
+        })?;
+
+    let holder_id_hex = hex::encode(caller_holder.holder_id);
+    let has_authority = commons_manager
+        .member_has_capability(
+            &holder_id_hex,
+            jurisdiction,
+            MembershipCapability::HoldOffice,
+        )
+        .await
+        .unwrap_or(false);
+
+    if !has_authority {
+        return Err(GatewayError::AuthorizationFailed(format!(
+            "Caller does not hold office in '{jurisdiction}' (HoldOffice capability required)"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Require that `caller_did` is a full member (`Member` status) in `jurisdiction`.
+///
+/// Used to gate member-rights actions that should be available to any full member
+/// of a jurisdiction but not to unenrolled outsiders or provisional candidates.
+/// Dispute filing is the canonical example: any member may report a concern, but
+/// random authenticated users cannot inflate a steward's dispute count.
+///
+/// This checks membership status directly rather than a specific capability,
+/// because capabilities are not automatically granted during the enrollment flow —
+/// status is the authoritative marker that full membership was conferred.
+///
+/// Returns `Err(GatewayError::AuthorizationFailed)` when the caller is not a
+/// commons holder or is not a full member of the given jurisdiction.
+pub(crate) async fn require_membership_in_jurisdiction(
+    commons_manager: &CommonsManager,
+    caller_did: &Did,
+    jurisdiction: &JurisdictionId,
+) -> Result<()> {
+    let caller_holder = commons_manager
+        .get_holder_by_did(caller_did)
+        .await
+        .map_err(|e| GatewayError::InternalError(e.to_string()))?
+        .ok_or_else(|| {
+            GatewayError::AuthorizationFailed("Caller is not a commons holder".to_string())
+        })?;
+
+    let is_full_member = caller_holder
+        .get_affiliation(jurisdiction)
+        .map(|a| a.membership_status == MembershipStatus::Member)
+        .unwrap_or(false);
+
+    if !is_full_member {
+        return Err(GatewayError::AuthorizationFailed(format!(
+            "Caller is not a full member of '{jurisdiction}' (member standing required)"
+        )));
+    }
+
+    Ok(())
+}

--- a/icn/crates/icn-gateway/src/commons_mgr.rs
+++ b/icn/crates/icn-gateway/src/commons_mgr.rs
@@ -1,800 +1,295 @@
 //! Commons Manager for Gateway API
 //!
-//! Provides Commons Evolution operations for the gateway API:
-//! - PersonhoodAnchor management (Layer 0)
-//! - CommonsHolderRecord management (Layer 1)
-//! - Charter management (Layer 2)
-//! - Affiliation/membership management
+//! Thin gateway facade that delegates all substrate operations through
+//! [`CommonsHandle`] (defined in `icn-commons`).
+//!
+//! Gateway-local concerns (enrollment sessions, governance DTOs) remain here.
 
-use anyhow::{bail, Context, Result};
+use anyhow::Result;
+use hex;
+use icn_commons::CommonsHandle;
 use icn_governance::{
     Amendment, AmendmentChange, AmendmentId, AmendmentStatus, Appeal, AppealEvidence, AppealId,
-    AppealOutcome, AppealResponse, AppealStatus, Charter, CharterStatus, OrgType, Ratification,
-    StewardRecord, StewardStatus,
+    AppealOutcome, AppealResponse, AppealStatus, Charter, CharterStatus, FounderSignature, OrgType,
+    Ratification, StewardRecord, StewardStatus,
 };
 use icn_identity::{
-    Affiliation, Anchor, AnchorStatus, CommonsHolderRecord, CommonsRevocationReason, Did,
-    EnrollmentPathway, HolderStatus, JurisdictionId, MembershipCapability, MembershipStatus,
-    POPAttestation, POPLevel, POPMethod, PersonhoodAnchor, RevocationRecord, RevocationRegistry,
-    RevocationScope, RevocationType,
+    Affiliation, AnchorStatus, CommonsHolderRecord, CommonsRevocationReason, Did, HolderStatus,
+    JurisdictionId, MembershipCapability, MembershipStatus, POPAttestation, PersonhoodAnchor,
+    RevocationRecord, RevocationScope, RevocationType,
 };
-use sha2::{Digest, Sha256};
-use std::sync::Arc;
-use tracing::{info, warn};
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::RwLock;
 
-use crate::commons_store::{
-    CommonsStore, CommonsStoreBackend, InMemoryCommonsStore, SledCommonsStore,
-};
 use crate::models::{
     AmendmentsBreakdown, AppealsBreakdown, GovernanceActivityEvent, GovernanceDashboard,
     StewardDetailResponse, StewardSummaryResponse,
 };
 
-/// Commons Manager for gateway API
-///
-/// Uses CommonsStore for persistent/in-memory storage of:
-/// - PersonhoodAnchors (Layer 0)
-/// - CommonsHolderRecords (Layer 1)
-/// - Charters (Layer 2)
-/// - StewardRecords, Amendments, Appeals
-///
-/// RevocationRegistry is kept separate for now.
-pub struct CommonsManager<S: CommonsStoreBackend = Arc<dyn CommonsStoreBackend>> {
-    /// Storage backend
-    store: CommonsStore<S>,
+// ============================================================================
+// CommonsManager struct
+// ============================================================================
 
-    /// Revocation registry (kept separate from main store)
-    revocations: RevocationRegistry,
+/// Thin gateway facade for commons operations.
+///
+/// All substrate operations (anchors, holders, charters, stewards, amendments,
+/// appeals, revocations, membership, affiliations) are delegated to the
+/// [`CommonsHandle`] from `icn-commons`. Enrollment sessions are managed
+/// in-memory as a gateway-local concern (not persisted via the substrate).
+pub struct CommonsManager {
+    handle: CommonsHandle,
+    /// Gateway-local: enrollment sessions (in-memory; not substrate state).
+    enrollment_sessions:
+        Arc<RwLock<HashMap<String, crate::api::sdis::simple_enrollment::EnrollmentSession>>>,
 }
 
-impl CommonsManager<Arc<dyn CommonsStoreBackend>> {
-    /// Create a new commons manager with in-memory storage (testing / no data_dir configured)
+impl CommonsManager {
+    /// Create with an in-memory handle (testing / no data_dir configured).
     pub fn new() -> Self {
-        let backend: Arc<dyn CommonsStoreBackend> = Arc::new(InMemoryCommonsStore::new());
-        Self::with_store(Arc::new(backend))
-    }
-
-    /// Create a new commons manager with persistent Sled storage
-    ///
-    /// Data will persist across gateway restarts at the given path.
-    pub fn with_sled_path(path: impl AsRef<std::path::Path>) -> Result<Self> {
-        let backend: Arc<dyn CommonsStoreBackend> =
-            Arc::new(SledCommonsStore::open(path).context("Failed to open commons sled store")?);
-        Ok(Self::with_store(Arc::new(backend)))
-    }
-
-    /// Create a new commons manager with a temporary Sled database
-    ///
-    /// Useful for testing persistent storage behavior without leaving files.
-    pub fn with_sled_temporary() -> Result<Self> {
-        let backend: Arc<dyn CommonsStoreBackend> = Arc::new(
-            SledCommonsStore::temporary()
-                .context("Failed to create temporary commons sled store")?,
-        );
-        Ok(Self::with_store(Arc::new(backend)))
-    }
-
-    /// Flush all pending writes to disk
-    pub fn flush(&self) -> Result<()> {
-        self.store.backend().flush()
-    }
-}
-
-impl<S: CommonsStoreBackend> CommonsManager<S> {
-    /// Create a new commons manager with a custom store backend
-    pub fn with_store(backend: Arc<S>) -> Self {
         CommonsManager {
-            store: CommonsStore::new(backend),
-            revocations: RevocationRegistry::new(),
+            handle: CommonsHandle::new_in_memory(),
+            enrollment_sessions: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
-    /// Get a reference to the underlying store
-    pub fn store(&self) -> &CommonsStore<S> {
-        &self.store
+    /// Create with a Sled-backed handle for durable persistence.
+    pub fn with_sled_path(path: impl AsRef<std::path::Path>) -> Result<Self> {
+        Ok(CommonsManager {
+            handle: CommonsHandle::with_sled_path(path)?,
+            enrollment_sessions: Arc::new(RwLock::new(HashMap::new())),
+        })
     }
 
-    // ========== PersonhoodAnchor Operations (Layer 0) ==========
+    /// Create with a temporary Sled-backed handle (persistence testing).
+    pub fn with_sled_temporary() -> Result<Self> {
+        Ok(CommonsManager {
+            handle: CommonsHandle::with_sled_temporary()?,
+            enrollment_sessions: Arc::new(RwLock::new(HashMap::new())),
+        })
+    }
 
-    /// Create a new PersonhoodAnchor from enrollment completion
-    ///
-    /// This creates a full PersonhoodAnchor with an underlying SDIS Anchor
-    /// and an initial POP attestation.
+    /// Create from an existing [`CommonsHandle`] (for sharing with actors).
+    pub fn with_handle(handle: CommonsHandle) -> Self {
+        CommonsManager {
+            handle,
+            enrollment_sessions: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Flush pending writes to durable storage.
+    pub async fn flush(&self) -> Result<()> {
+        self.handle.flush().await
+    }
+}
+
+impl Default for CommonsManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ============================================================================
+// PersonhoodAnchor Operations (Layer 0)
+// ============================================================================
+
+impl CommonsManager {
+    /// Create a new PersonhoodAnchor from enrollment completion.
     pub async fn create_anchor_from_enrollment(
         &self,
         did: &Did,
         steward_did: Option<&Did>,
     ) -> Result<PersonhoodAnchor> {
-        // Generate pseudo-VUI from DID (in real SDIS, this comes from ceremony)
-        let mut hasher = Sha256::new();
-        hasher.update(b"gateway-enrollment-vui:");
-        hasher.update(did.as_str().as_bytes());
-        let vui_result = hasher.finalize();
-        let mut vui = [0u8; 32];
-        vui.copy_from_slice(&vui_result);
-
-        // Generate genesis random
-        let mut genesis = [0u8; 32];
-        use rand::RngCore;
-        rand::thread_rng().fill_bytes(&mut genesis);
-
-        // Create the underlying SDIS Anchor
-        let pathway = if let Some(did) = steward_did {
-            EnrollmentPathway::WebOfTrust {
-                vouchers: vec![did.clone()],
-                vouched_at: icn_time::current_timestamp_secs(),
-            }
-        } else {
-            EnrollmentPathway::Genesis {
-                reason: "Gateway enrollment".to_string(),
-            }
-        };
-
-        let sdis_anchor = Anchor::from_vui(&vui, pathway, &genesis);
-        let anchor_id_bytes = sdis_anchor.id;
-
-        // Create POP attestation
-        let (pop_method, pop_level, issuer) = if let Some(steward) = steward_did {
-            (
-                POPMethod::Sponsored {
-                    sponsor_did: steward.clone(),
-                },
-                POPLevel::Strong,
-                steward.clone(),
-            )
-        } else {
-            (
-                POPMethod::Genesis {
-                    reason: "Gateway enrollment".to_string(),
-                },
-                POPLevel::Weak,
-                did.clone(),
-            )
-        };
-
-        // SECURITY NOTE: Gateway cannot sign attestations (no private key access).
-        // This creates an UNSIGNED attestation suitable for development/testing only.
-        // Production requires client-side signing before submission.
-        // See: https://github.com/InterCooperative-Network/icn/issues/133
-        let attestation = POPAttestation::new(
-            &anchor_id_bytes,
-            issuer,
-            pop_method,
-            pop_level,
-            Vec::new(), // UNSIGNED - gateway lacks signing capability
-            None,       // No expiry
-        );
-        warn!(
-            "Created UNSIGNED attestation for anchor {} - requires client-side signing for production",
-            hex::encode(anchor_id_bytes)
-        );
-
-        // DEVELOPMENT ONLY: Derive a placeholder key from the DID.
-        // Production anchors must provide their actual Ed25519 public key.
-        // See: https://github.com/InterCooperative-Network/icn/issues/133
-        let mut key_hasher = Sha256::new();
-        key_hasher.update(b"gateway-dev-placeholder-key:");
-        key_hasher.update(did.as_str().as_bytes());
-        let key_result = key_hasher.finalize();
-        let mut current_key = [0u8; 32];
-        current_key.copy_from_slice(&key_result);
-        warn!(
-            "Using PLACEHOLDER key for anchor {} - production requires real public key",
-            hex::encode(anchor_id_bytes)
-        );
-
-        // Create PersonhoodAnchor
-        let anchor = PersonhoodAnchor::new(sdis_anchor, attestation, current_key);
-
-        // Check if anchor already exists
-        let anchor_id = hex::encode(anchor.id());
-        if self.store.get_anchor(&anchor_id)?.is_some() {
-            bail!("Anchor already exists: {anchor_id}");
-        }
-
-        // Store anchor
-        self.store.put_anchor(&anchor)?;
-
-        // Also index by the enrollment DID (which may differ from anchor's internal DID)
-        let did_str = did.to_string();
-        self.store.put_anchor_did_index(&did_str, &anchor_id)?;
-
-        // Record metrics
-        icn_obs::metrics::commons::anchor_created_inc();
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "anchor_created",
-            anchor_id = %anchor_id,
-            did = %did_str,
-            steward_vouched = steward_did.is_some(),
-            "PersonhoodAnchor created"
-        );
-
-        Ok(anchor)
+        self.handle
+            .create_anchor_from_enrollment(did, steward_did)
+            .await
     }
 
-    /// Get a PersonhoodAnchor by ID
+    /// Get a PersonhoodAnchor by ID.
     pub async fn get_anchor(&self, anchor_id: &str) -> Result<Option<PersonhoodAnchor>> {
-        self.store.get_anchor(anchor_id)
+        self.handle.get_anchor(anchor_id).await
     }
 
-    /// Get a PersonhoodAnchor by DID
+    /// Get a PersonhoodAnchor by DID.
     pub async fn get_anchor_by_did(&self, did: &Did) -> Result<Option<PersonhoodAnchor>> {
-        let did_str = did.to_string();
-        self.store.get_anchor_by_did(&did_str)
+        self.handle.get_anchor_by_did(did).await
     }
 
-    /// Update anchor status
+    /// Update anchor status.
     pub async fn update_anchor_status(&self, anchor_id: &str, status: AnchorStatus) -> Result<()> {
-        let mut anchor = self
-            .store
-            .get_anchor(anchor_id)?
-            .ok_or_else(|| anyhow::anyhow!("Anchor not found: {anchor_id}"))?;
-
-        anchor.status = status.clone();
-        anchor.updated_at = icn_time::current_timestamp_secs();
-
-        self.store.put_anchor(&anchor)?;
-
-        // Record status change metrics
-        match &status {
-            AnchorStatus::Suspended { .. } => {
-                icn_obs::metrics::commons::anchor_suspended_inc("status_update");
-            }
-            AnchorStatus::Revoked { .. } => {
-                icn_obs::metrics::commons::anchor_revoked_inc("status_update");
-            }
-            _ => {}
-        }
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "anchor_status_updated",
-            anchor_id = %anchor_id,
-            new_status = ?status,
-            "PersonhoodAnchor status updated"
-        );
-
-        Ok(())
+        self.handle.update_anchor_status(anchor_id, status).await
     }
 
-    /// Add an attestation to an anchor
+    /// Add an attestation to an anchor.
     pub async fn add_attestation(
         &self,
         anchor_id: &str,
         attestation: POPAttestation,
     ) -> Result<()> {
-        let mut anchor = self
-            .store
-            .get_anchor(anchor_id)?
-            .ok_or_else(|| anyhow::anyhow!("Anchor not found: {anchor_id}"))?;
-
-        let method_name = format!("{:?}", attestation.method);
-        anchor.add_attestation(attestation);
-        self.store.put_anchor(&anchor)?;
-
-        // Record verification metric
-        icn_obs::metrics::commons::anchor_verified_inc(&method_name);
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "attestation_added",
-            anchor_id = %anchor_id,
-            method = %method_name,
-            "POP attestation added to anchor"
-        );
-
-        Ok(())
+        self.handle.add_attestation(anchor_id, attestation).await
     }
+}
 
-    // ========== CommonsHolderRecord Operations (Layer 1) ==========
+// ============================================================================
+// CommonsHolderRecord Operations (Layer 1)
+// ============================================================================
 
-    /// Create a CommonsHolderRecord from an anchor
+impl CommonsManager {
+    /// Create a CommonsHolderRecord from an anchor.
     pub async fn create_holder_from_anchor(
         &self,
         anchor_id: &str,
         did: &Did,
     ) -> Result<CommonsHolderRecord> {
-        self.create_holder_from_anchor_with_name(anchor_id, did, None)
-            .await
+        self.handle.create_holder_from_anchor(anchor_id, did).await
     }
 
-    /// Create a CommonsHolderRecord from an anchor with an optional display name
+    /// Create a CommonsHolderRecord from an anchor with an optional display name.
     pub async fn create_holder_from_anchor_with_name(
         &self,
         anchor_id: &str,
         did: &Did,
         display_name: Option<String>,
     ) -> Result<CommonsHolderRecord> {
-        // Verify anchor exists and get its POP level
-        let anchor = self
-            .get_anchor(anchor_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Anchor not found: {anchor_id}"))?;
-
-        // Convert anchor_id hex string to bytes
-        let anchor_bytes: [u8; 32] = hex::decode(anchor_id)?
-            .try_into()
-            .map_err(|_| anyhow::anyhow!("Invalid anchor_id length"))?;
-
-        // Get the POP level from the anchor (default to Weak if no attestations)
-        let pop_level = anchor.pop_level().unwrap_or(POPLevel::Weak);
-
-        // Create holder with baseline Commons Rights
-        let mut holder = CommonsHolderRecord::new(anchor_bytes, did.clone(), pop_level);
-
-        // Set display name if provided
-        if let Some(name) = display_name {
-            holder.display_name = Some(name);
-        }
-
-        // Check if holder already exists
-        let holder_id = hex::encode(holder.id());
-        if self.store.get_holder(&holder_id)?.is_some() {
-            bail!("Holder already exists: {holder_id}");
-        }
-
-        // Store holder (this also updates DID and anchor indexes)
-        self.store.put_holder(&holder)?;
-
-        // Record metrics
-        icn_obs::metrics::commons::holder_created_inc();
-
-        // Audit log
-        let did_str = did.to_string();
-        info!(
-            target: "commons_audit",
-            action = "holder_created",
-            holder_id = %holder_id,
-            anchor_id = %anchor_id,
-            did = %did_str,
-            pop_level = ?pop_level,
-            "CommonsHolderRecord created"
-        );
-
-        Ok(holder)
+        self.handle
+            .create_holder_from_anchor_with_name(anchor_id, did, display_name)
+            .await
     }
 
-    /// Get a CommonsHolderRecord by ID
+    /// Get a CommonsHolderRecord by ID.
     pub async fn get_holder(&self, holder_id: &str) -> Result<Option<CommonsHolderRecord>> {
-        self.store.get_holder(holder_id)
+        self.handle.get_holder(holder_id).await
     }
 
-    /// Get a CommonsHolderRecord by DID
+    /// Get a CommonsHolderRecord by DID.
     pub async fn get_holder_by_did(&self, did: &Did) -> Result<Option<CommonsHolderRecord>> {
-        let did_str = did.to_string();
-        self.store.get_holder_by_did(&did_str)
+        self.handle.get_holder_by_did(did).await
     }
 
     /// Update the display name for a holder identified by DID.
-    /// If no holder record exists yet, creates a minimal holder record directly.
     pub async fn update_display_name(&self, did: &Did, display_name: String) -> Result<()> {
-        let did_str = did.to_string();
-        if let Some(mut holder) = self.store.get_holder_by_did(&did_str)? {
-            holder.set_display_name(display_name);
-            self.store.put_holder(&holder)?;
-        } else {
-            // Create a minimal holder record directly (no anchor required).
-            // This is used for demo seeding where members don't go through
-            // full SDIS enrollment but still need display names.
-            let anchor_bytes: [u8; 32] = Sha256::digest(did_str.as_bytes()).into();
-            let mut holder = CommonsHolderRecord::new(anchor_bytes, did.clone(), POPLevel::Weak);
-            holder.set_display_name(display_name);
-            self.store.put_holder(&holder)?;
-        }
-        Ok(())
+        self.handle.update_display_name(did, display_name).await
     }
 
-    /// Get or create a CommonsHolderRecord (idempotent)
-    ///
-    /// This method provides create-or-get semantics for holders:
-    /// - If a holder already exists for this anchor, returns it
-    /// - If no holder exists, creates a new one
-    ///
-    /// This is critical for enrollment idempotency: calling this method
-    /// multiple times with the same anchor_id returns the same holder.
-    ///
-    /// # Arguments
-    /// * `anchor_id` - Hex-encoded anchor ID
-    /// * `did` - The DID for the holder
-    /// * `display_name` - Optional display name (only used if creating new)
-    ///
-    /// # Returns
-    /// The existing or newly created CommonsHolderRecord
+    /// Get or create a CommonsHolderRecord (idempotent).
     pub async fn get_or_create_holder(
         &self,
         anchor_id: &str,
         did: &Did,
         display_name: Option<String>,
     ) -> Result<CommonsHolderRecord> {
-        // First, try to find existing holder by anchor ID
-        if let Some(holder) = self.store.get_holder_by_anchor(anchor_id)? {
-            info!(
-                target: "commons_audit",
-                action = "holder_get_or_create_existing",
-                holder_id = %hex::encode(holder.id()),
-                anchor_id = %anchor_id,
-                "Returning existing holder for anchor"
-            );
-            return Ok(holder);
-        }
-
-        // No existing holder, create new one
-        // This delegates to create_holder_from_anchor_with_name which handles
-        // anchor validation, metrics, and audit logging
-        self.create_holder_from_anchor_with_name(anchor_id, did, display_name)
+        self.handle
+            .get_or_create_holder(anchor_id, did, display_name)
             .await
     }
 
-    /// Update holder status
+    /// Update holder status.
     pub async fn update_holder_status(&self, holder_id: &str, status: HolderStatus) -> Result<()> {
-        let mut holder = self
-            .store
-            .get_holder(holder_id)?
-            .ok_or_else(|| anyhow::anyhow!("Holder not found: {holder_id}"))?;
-
-        holder.status = status.clone();
-        holder.updated_at = icn_time::current_timestamp_secs();
-
-        self.store.put_holder(&holder)?;
-
-        // Record status change metric
-        icn_obs::metrics::commons::holder_status_changed_inc(&format!("{status:?}"));
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "holder_status_updated",
-            holder_id = %holder_id,
-            new_status = ?status,
-            "CommonsHolderRecord status updated"
-        );
-
-        Ok(())
+        self.handle.update_holder_status(holder_id, status).await
     }
+}
 
-    // ========== Affiliation Operations ==========
+// ============================================================================
+// Affiliation Operations
+// ============================================================================
 
+impl CommonsManager {
     /// Add an affiliation (join jurisdiction).
-    ///
-    /// Sybil resistance: requires at least `POPLevel::Strong` to join.
     pub async fn join_jurisdiction(
         &self,
         holder_id: &str,
         jurisdiction: JurisdictionId,
         initial_capabilities: Vec<MembershipCapability>,
     ) -> Result<Affiliation> {
-        let mut holder = self
-            .store
-            .get_holder(holder_id)?
-            .ok_or_else(|| anyhow::anyhow!("Holder not found: {holder_id}"))?;
-
-        // Sybil gate: require at least Strong POP level
-        if holder.personhood_level < POPLevel::Strong {
-            bail!(
-                "Joining a jurisdiction requires at least Strong POP level (current: Weak). \
-                 Obtain additional attestations to upgrade."
-            );
-        }
-
-        // Check if already affiliated
-        if holder
-            .affiliations
-            .iter()
-            .any(|a| a.jurisdiction_id == jurisdiction)
-        {
-            bail!(
-                "Already affiliated with jurisdiction: {}",
-                jurisdiction.as_str()
-            );
-        }
-
-        // Create affiliation (starts as Candidate by default)
-        let now = icn_time::current_timestamp_secs();
-
-        let affiliation = Affiliation {
-            jurisdiction_id: jurisdiction.clone(),
-            membership_status: MembershipStatus::Candidate,
-            capabilities: initial_capabilities,
-            roles: Vec::new(),
-            joined_at: now,
-            expires_at: None,
-        };
-
-        holder.affiliations.push(affiliation.clone());
-        holder.updated_at = now;
-
-        self.store.put_holder(&holder)?;
-
-        // Record membership join metric
-        icn_obs::metrics::commons::membership_joined_inc(jurisdiction.as_str());
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "membership_joined",
-            holder_id = %holder_id,
-            jurisdiction = %jurisdiction.as_str(),
-            capabilities_count = affiliation.capabilities.len(),
-            "Holder joined jurisdiction"
-        );
-
-        Ok(affiliation)
+        self.handle
+            .join_jurisdiction(holder_id, jurisdiction, initial_capabilities)
+            .await
     }
 
-    /// Leave a jurisdiction
+    /// Leave a jurisdiction.
     pub async fn leave_jurisdiction(
         &self,
         holder_id: &str,
         jurisdiction: &JurisdictionId,
     ) -> Result<()> {
-        let mut holder = self
-            .store
-            .get_holder(holder_id)?
-            .ok_or_else(|| anyhow::anyhow!("Holder not found: {holder_id}"))?;
-
-        // Find and update affiliation status to Exited
-        if let Some(affiliation) = holder
-            .affiliations
-            .iter_mut()
-            .find(|a| &a.jurisdiction_id == jurisdiction)
-        {
-            affiliation.membership_status = MembershipStatus::Exited;
-            holder.updated_at = icn_time::current_timestamp_secs();
-            self.store.put_holder(&holder)?;
-
-            // Record exit metric
-            icn_obs::metrics::commons::membership_exited_inc(jurisdiction.as_str());
-
-            // Audit log
-            info!(
-                target: "commons_audit",
-                action = "membership_exited",
-                holder_id = %holder_id,
-                jurisdiction = %jurisdiction.as_str(),
-                "Holder left jurisdiction"
-            );
-
-            Ok(())
-        } else {
-            bail!(
-                "Not affiliated with jurisdiction: {}",
-                jurisdiction.as_str()
-            )
-        }
+        self.handle
+            .leave_jurisdiction(holder_id, jurisdiction)
+            .await
     }
 
-    /// Update affiliation status (e.g., Candidate -> Member)
+    /// Update affiliation status.
     pub async fn update_affiliation_status(
         &self,
         holder_id: &str,
         jurisdiction: &JurisdictionId,
         status: MembershipStatus,
     ) -> Result<()> {
-        let mut holder = self
-            .store
-            .get_holder(holder_id)?
-            .ok_or_else(|| anyhow::anyhow!("Holder not found: {holder_id}"))?;
-
-        if let Some(affiliation) = holder
-            .affiliations
-            .iter_mut()
-            .find(|a| &a.jurisdiction_id == jurisdiction)
-        {
-            affiliation.membership_status = status;
-            holder.updated_at = icn_time::current_timestamp_secs();
-            self.store.put_holder(&holder)?;
-
-            // Record status-specific metrics
-            let jurisdiction_str = jurisdiction.as_str();
-            match status {
-                MembershipStatus::Suspended => {
-                    icn_obs::metrics::commons::membership_suspended_inc(jurisdiction_str);
-                }
-                MembershipStatus::Banned => {
-                    icn_obs::metrics::commons::membership_banned_inc(jurisdiction_str);
-                }
-                _ => {}
-            }
-
-            // Audit log
-            info!(
-                target: "commons_audit",
-                action = "membership_status_updated",
-                holder_id = %holder_id,
-                jurisdiction = %jurisdiction_str,
-                new_status = ?status,
-                "Membership status updated"
-            );
-
-            Ok(())
-        } else {
-            bail!(
-                "Not affiliated with jurisdiction: {}",
-                jurisdiction.as_str()
-            )
-        }
+        self.handle
+            .update_affiliation_status(holder_id, jurisdiction, status)
+            .await
     }
 
-    /// List affiliations for a holder
+    /// List affiliations for a holder.
     pub async fn list_affiliations(&self, holder_id: &str) -> Result<Vec<Affiliation>> {
-        let holder = self
-            .store
-            .get_holder(holder_id)?
-            .ok_or_else(|| anyhow::anyhow!("Holder not found: {holder_id}"))?;
-
-        Ok(holder.affiliations.clone())
+        self.handle.list_affiliations(holder_id).await
     }
+}
 
-    // ========== Charter Operations (Layer 2) ==========
+// ============================================================================
+// Charter Operations (Layer 2)
+// ============================================================================
 
-    /// Store a charter
+impl CommonsManager {
+    /// Store a charter.
     pub async fn store_charter(&self, charter: Charter) -> Result<()> {
-        let charter_id = charter.charter_id.to_hex();
-        let org_type = format!("{:?}", charter.org_type);
-
-        // Check if charter already exists
-        if self.store.get_charter(&charter_id)?.is_some() {
-            bail!("Charter already exists: {charter_id}");
-        }
-
-        // Store charter (this also updates the domain index)
-        self.store.put_charter(&charter)?;
-
-        // Record charter creation metric
-        icn_obs::metrics::commons::charter_created_inc(&org_type);
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "charter_created",
-            charter_id = %charter_id,
-            org_type = %org_type,
-            domain_id = %charter.domain_id,
-            founders_count = charter.founders.len(),
-            "Charter created"
-        );
-
-        Ok(())
+        self.handle.store_charter(charter).await
     }
 
-    /// Get a charter by ID
+    /// Get a charter by ID.
     pub async fn get_charter(&self, charter_id: &str) -> Result<Option<Charter>> {
-        self.store.get_charter(charter_id)
+        self.handle.get_charter(charter_id).await
     }
 
-    /// Get a charter by domain ID
+    /// Get a charter by domain ID.
     pub async fn get_charter_by_domain(&self, domain_id: &str) -> Result<Option<Charter>> {
-        self.store.get_charter_by_domain(domain_id)
+        self.handle.get_charter_by_domain(domain_id).await
     }
 
-    /// List all charters with optional filters
+    /// List charters with optional filters.
     pub async fn list_charters(
         &self,
         org_type: Option<OrgType>,
         status: Option<CharterStatus>,
     ) -> Result<Vec<Charter>> {
-        let all_charters = self.store.list_charters()?;
-
-        let mut results: Vec<Charter> = all_charters
-            .into_iter()
-            .filter(|c| {
-                let type_match = org_type.as_ref().is_none_or(|t| c.org_type == *t);
-                let status_match = status.as_ref().is_none_or(|s| c.status == *s);
-                type_match && status_match
-            })
-            .collect();
-
-        // Sort by creation time, newest first
-        results.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-
-        Ok(results)
+        self.handle.list_charters(org_type, status).await
     }
 
-    /// Add a founder signature to a charter
-    ///
-    /// Requirements:
-    /// - Charter must be in Draft status
-    /// - Signer must not have already signed
-    ///
-    /// Returns the updated charter with the new signature count
+    /// Add a charter signature.
     pub async fn add_charter_signature(
         &self,
         charter_id: &str,
-        signature: icn_governance::FounderSignature,
+        signature: FounderSignature,
     ) -> Result<Charter> {
-        let mut charter = self
-            .store
-            .get_charter(charter_id)?
-            .ok_or_else(|| anyhow::anyhow!("Charter not found: {charter_id}"))?;
-
-        // Validate charter is in Draft status
-        if !matches!(charter.status, CharterStatus::Draft) {
-            bail!(
-                "Cannot sign charter in status {:?}, must be Draft",
-                charter.status
-            );
-        }
-
-        // Check if already signed by this DID
-        if charter.founders.iter().any(|f| f.did == signature.did) {
-            bail!("Signer has already signed this charter");
-        }
-
-        // Add the signature
-        let signer_did = signature.did.to_string();
-        charter.add_founder(signature);
-
-        // Persist updated charter
-        self.store.put_charter(&charter)?;
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "charter_signed",
-            charter_id = %charter_id,
-            signer = %signer_did,
-            total_founders = charter.founders.len(),
-            "Charter signed by founder"
-        );
-
-        Ok(charter)
+        self.handle
+            .add_charter_signature(charter_id, signature)
+            .await
     }
 
-    /// Update charter status
+    /// Update charter status.
     pub async fn update_charter_status(
         &self,
         charter_id: &str,
         status: CharterStatus,
     ) -> Result<()> {
-        let mut charter = self
-            .store
-            .get_charter(charter_id)?
-            .ok_or_else(|| anyhow::anyhow!("Charter not found: {charter_id}"))?;
-
-        charter.status = status.clone();
-        // Note: Charter doesn't have an updated_at field
-        // Status changes are tracked via amendments in production
-        self.store.put_charter(&charter)?;
-
-        // Record status-specific metrics
-        match &status {
-            CharterStatus::Active => {
-                icn_obs::metrics::commons::charter_activated_inc();
-            }
-            CharterStatus::Suspended { .. } => {
-                icn_obs::metrics::commons::charter_suspended_inc();
-            }
-            CharterStatus::Dissolved { .. } => {
-                icn_obs::metrics::commons::charter_dissolved_inc();
-            }
-            _ => {}
-        }
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "charter_status_updated",
-            charter_id = %charter_id,
-            new_status = ?status,
-            "Charter status updated"
-        );
-
-        Ok(())
+        self.handle.update_charter_status(charter_id, status).await
     }
+}
 
-    // ========== Steward Operations ==========
+// ============================================================================
+// Steward Operations
+// ============================================================================
 
-    /// Register a new steward from a Commons Holder
-    ///
-    /// Requirements:
-    /// - Must be an active Commons Holder
-    /// - Must have at least Strong POP level
-    /// - Must have governance approval (proposal ID)
+impl CommonsManager {
+    /// Register a new steward.
     pub async fn register_steward(
         &self,
         holder_did: &Did,
@@ -805,386 +300,180 @@ impl<S: CommonsStoreBackend> CommonsManager<S> {
         jurisdiction: Option<String>,
         specializations: Vec<String>,
     ) -> Result<StewardRecord> {
-        // Verify holder exists and is active
-        let holder = self
-            .get_holder_by_did(holder_did)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Holder not found for DID: {holder_did}"))?;
-
-        if !holder.is_active() {
-            bail!("Holder is not active");
-        }
-
-        // Require at least Strong POP level to become a steward
-        if holder.personhood_level < POPLevel::Strong {
-            bail!("Steward requires at least Strong POP level");
-        }
-
-        // Check not already a steward
-        if self.get_steward_by_did(steward_did).await?.is_some() {
-            bail!("Already registered as steward");
-        }
-
-        // Calculate term
-        let now = icn_time::current_timestamp_secs();
-        let term_end = now + (term_duration_days * 24 * 60 * 60);
-
-        // Create steward record
-        let mut steward = StewardRecord::new(
-            steward_did.clone(),
-            holder_did.clone(),
-            now,
-            term_end,
-            bond_amount,
-            governance_approval,
-        );
-
-        // Set optional fields
-        if let Some(ref j) = jurisdiction {
-            steward.jurisdiction = Some(j.clone());
-        }
-        for spec in specializations {
-            steward.add_specialization(spec);
-        }
-
-        // Store
-        self.store_steward(steward.clone()).await?;
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "steward_registered",
-            steward_id = %steward.steward_id.to_hex(),
-            steward_did = %steward_did.to_string(),
-            holder_did = %holder_did.to_string(),
-            jurisdiction = ?jurisdiction,
-            bond_amount = bond_amount,
-            "Steward registered"
-        );
-
-        Ok(steward)
+        self.handle
+            .register_steward(
+                holder_did,
+                steward_did,
+                term_duration_days,
+                bond_amount,
+                governance_approval,
+                jurisdiction,
+                specializations,
+            )
+            .await
     }
 
-    /// Store a steward record
+    /// Store a steward record.
     pub async fn store_steward(&self, steward: StewardRecord) -> Result<()> {
-        let steward_id = steward.steward_id.to_hex();
-
-        // Check if steward already exists
-        if self.store.get_steward(&steward_id)?.is_some() {
-            bail!("Steward already exists: {steward_id}");
-        }
-
-        // Store steward (this also updates the DID index)
-        self.store.put_steward(&steward)?;
-        Ok(())
+        self.handle.store_steward(steward).await
     }
 
-    /// Get a steward by ID
+    /// Get a steward by ID.
     pub async fn get_steward(&self, steward_id: &str) -> Result<Option<StewardRecord>> {
-        self.store.get_steward(steward_id)
+        self.handle.get_steward(steward_id).await
     }
 
-    /// Get a steward by DID
+    /// Get a steward by DID.
     pub async fn get_steward_by_did(&self, did: &Did) -> Result<Option<StewardRecord>> {
-        let did_str = did.to_string();
-        self.store.get_steward_by_did(&did_str)
+        self.handle.get_steward_by_did(did).await
     }
 
-    /// List all stewards with optional filters
+    /// List stewards with optional filters.
     pub async fn list_stewards(
         &self,
         active_only: bool,
         jurisdiction: Option<&str>,
     ) -> Result<Vec<StewardRecord>> {
-        let all_stewards = self.store.list_stewards()?;
-
-        let mut results: Vec<StewardRecord> = all_stewards
-            .into_iter()
-            .filter(|s| {
-                let active_match = !active_only || s.is_active();
-                let jurisdiction_match =
-                    jurisdiction.is_none() || s.jurisdiction.as_deref() == jurisdiction;
-                active_match && jurisdiction_match
-            })
-            .collect();
-
-        // Sort by reputation score, highest first
-        results.sort_by(|a, b| {
-            b.reputation_score
-                .partial_cmp(&a.reputation_score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-
-        Ok(results)
+        self.handle.list_stewards(active_only, jurisdiction).await
     }
 
-    /// List stewards who can issue attestations
+    /// List active attesters.
     pub async fn list_attesters(&self) -> Result<Vec<StewardRecord>> {
-        let all_stewards = self.store.list_stewards()?;
-        let attesters: Vec<StewardRecord> = all_stewards
-            .into_iter()
-            .filter(|s| s.can_attest())
-            .collect();
-        Ok(attesters)
+        self.handle.list_attesters().await
     }
 
-    /// Check if a DID belongs to an active steward
+    /// Check if a DID is an active steward.
     pub async fn is_active_steward(&self, did: &Did) -> Result<bool> {
-        if let Some(steward) = self.get_steward_by_did(did).await? {
-            Ok(steward.is_active() && steward.can_attest())
-        } else {
-            Ok(false)
-        }
+        self.handle.is_active_steward(did).await
     }
 
-    /// Suspend a steward
+    /// Suspend a steward.
     pub async fn suspend_steward(&self, steward_id: &str, reason: String) -> Result<()> {
-        let mut steward = self
-            .store
-            .get_steward(steward_id)?
-            .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
-
-        steward.suspend(reason.clone());
-        self.store.put_steward(&steward)?;
-
-        // Audit log
-        warn!(
-            target: "commons_audit",
-            action = "steward_suspended",
-            steward_id = %steward_id,
-            reason = %reason,
-            "Steward suspended"
-        );
-
-        Ok(())
+        self.handle.suspend_steward(steward_id, reason).await
     }
 
-    /// Reinstate a suspended steward
+    /// Reinstate a suspended steward.
     pub async fn reinstate_steward(&self, steward_id: &str) -> Result<bool> {
-        let mut steward = self
-            .store
-            .get_steward(steward_id)?
-            .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
-
-        let result = steward.reinstate();
-        self.store.put_steward(&steward)?;
-
-        // Audit log
-        if result {
-            info!(
-                target: "commons_audit",
-                action = "steward_reinstated",
-                steward_id = %steward_id,
-                "Steward reinstated"
-            );
-        }
-
-        Ok(result)
+        self.handle.reinstate_steward(steward_id).await
     }
 
-    /// Retire a steward
+    /// Retire a steward.
     pub async fn retire_steward(&self, steward_id: &str) -> Result<()> {
-        let mut steward = self
-            .store
-            .get_steward(steward_id)?
-            .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
-
-        steward.retire();
-        self.store.put_steward(&steward)?;
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "steward_retired",
-            steward_id = %steward_id,
-            "Steward retired"
-        );
-
-        Ok(())
+        self.handle.retire_steward(steward_id).await
     }
 
-    /// Revoke a steward for cause
+    /// Revoke a steward.
     pub async fn revoke_steward(
         &self,
         steward_id: &str,
         reason: String,
         evidence: Vec<[u8; 32]>,
     ) -> Result<()> {
-        let mut steward = self
-            .store
-            .get_steward(steward_id)?
-            .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
-
-        steward.revoke(reason.clone(), evidence.clone());
-        self.store.put_steward(&steward)?;
-
-        // Audit log
-        warn!(
-            target: "commons_audit",
-            action = "steward_revoked",
-            steward_id = %steward_id,
-            reason = %reason,
-            evidence_count = evidence.len(),
-            "Steward revoked for cause"
-        );
-
-        Ok(())
+        self.handle
+            .revoke_steward(steward_id, reason, evidence)
+            .await
     }
 
-    /// Record an attestation issued by a steward
+    /// Record a steward attestation event.
     pub async fn record_steward_attestation(&self, steward_id: &str) -> Result<()> {
-        let mut steward = self
-            .store
-            .get_steward(steward_id)?
-            .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
-
-        steward.record_attestation();
-        self.store.put_steward(&steward)?;
-        Ok(())
+        self.handle.record_steward_attestation(steward_id).await
     }
 
-    /// Record a dispute against a steward's attestation
+    /// Record a dispute against a steward.
     pub async fn record_steward_dispute(&self, steward_id: &str) -> Result<()> {
-        let mut steward = self
-            .store
-            .get_steward(steward_id)?
-            .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
-
-        steward.record_dispute();
-        self.store.put_steward(&steward)?;
-        Ok(())
+        self.handle.record_steward_dispute(steward_id).await
     }
 
-    /// Record a dispute won by a steward
+    /// Record a dispute won by a steward.
     pub async fn record_steward_dispute_won(&self, steward_id: &str) -> Result<()> {
-        let mut steward = self
-            .store
-            .get_steward(steward_id)?
-            .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
-
-        steward.record_dispute_won();
-        self.store.put_steward(&steward)?;
-        Ok(())
+        self.handle.record_steward_dispute_won(steward_id).await
     }
 
-    /// Extend a steward's term
+    /// Extend a steward's term.
     pub async fn extend_steward_term(&self, steward_id: &str, new_term_end: u64) -> Result<()> {
-        let mut steward = self
-            .store
-            .get_steward(steward_id)?
-            .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
-
-        steward.extend_term(new_term_end);
-        self.store.put_steward(&steward)?;
-        Ok(())
+        self.handle
+            .extend_steward_term(steward_id, new_term_end)
+            .await
     }
 
-    /// Add to a steward's bond
+    /// Add bond to a steward.
     pub async fn add_steward_bond(&self, steward_id: &str, amount: u64) -> Result<()> {
-        let mut steward = self
-            .store
-            .get_steward(steward_id)?
-            .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
-
-        steward.add_bond(amount);
-        self.store.put_steward(&steward)?;
-        Ok(())
+        self.handle.add_steward_bond(steward_id, amount).await
     }
 
-    /// Slash a steward's bond
+    /// Slash a steward's bond.
     pub async fn slash_steward_bond(&self, steward_id: &str, amount: u64) -> Result<u64> {
-        let mut steward = self
-            .store
-            .get_steward(steward_id)?
-            .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
-
-        let result = steward.slash_bond(amount);
-        self.store.put_steward(&steward)?;
-        Ok(result)
+        self.handle.slash_steward_bond(steward_id, amount).await
     }
+}
 
-    // ========== Revocation Operations ==========
+// ============================================================================
+// Revocation Operations
+// ============================================================================
 
-    /// Add a revocation record
+impl CommonsManager {
+    /// Add a revocation record.
     pub async fn add_revocation(&self, record: RevocationRecord) -> Result<()> {
-        self.revocations
-            .add(record)
-            .map_err(|e| anyhow::anyhow!("Failed to add revocation: {e}"))
+        self.handle.add_revocation(record).await
     }
 
-    /// Check if a target is revoked
+    /// Check revocation status for a target.
     pub async fn check_revocation(&self, target_id: &str) -> icn_identity::RevocationCheck {
-        self.revocations.check(target_id)
+        self.handle.check_revocation(target_id).await
     }
 
-    /// Check if a target is revoked at a specific scope
+    /// Check revocation status at a given scope.
     pub async fn check_revocation_at_scope(
         &self,
         target_id: &str,
         scope: &RevocationScope,
     ) -> icn_identity::RevocationCheck {
-        self.revocations.check_at_scope(target_id, scope)
+        self.handle
+            .check_revocation_at_scope(target_id, scope)
+            .await
     }
 
-    /// Get a revocation record by ID
+    /// Get a revocation record.
     pub async fn get_revocation(&self, revocation_id: &str) -> Option<RevocationRecord> {
-        self.revocations.get(revocation_id)
+        self.handle.get_revocation(revocation_id).await
     }
 
-    /// List all revocations for a target
+    /// List revocations for a target.
     pub async fn list_revocations_for_target(&self, target_id: &str) -> Vec<RevocationRecord> {
-        self.revocations.list_for_target(target_id)
+        self.handle.list_revocations_for_target(target_id).await
     }
 
-    /// List all revocations by type
+    /// List revocations by type.
     pub async fn list_revocations_by_type(
         &self,
-        target_type: RevocationType,
+        revocation_type: RevocationType,
     ) -> Vec<RevocationRecord> {
-        self.revocations.list_by_type(target_type)
+        self.handle.list_revocations_by_type(revocation_type).await
     }
 
-    /// List all pending appeals
+    /// List revocations with pending appeals.
     pub async fn list_pending_appeals(&self) -> Vec<RevocationRecord> {
-        self.revocations.list_pending_appeals()
+        self.handle.list_pending_appeals().await
     }
 
-    /// File an appeal for a revocation
+    /// File an appeal for a revocation.
     pub async fn file_appeal(&self, revocation_id: &str, reason: String) -> Result<()> {
-        let mut record = self
-            .revocations
-            .get(revocation_id)
-            .ok_or_else(|| anyhow::anyhow!("Revocation not found"))?;
-
-        if !record.file_appeal(reason) {
-            bail!("Cannot file appeal - appeal window closed or already appealed");
-        }
-
-        self.revocations
-            .update(record)
-            .map_err(|e| anyhow::anyhow!("Failed to update revocation: {e}"))
+        self.handle.file_appeal(revocation_id, reason).await
     }
 
-    /// Resolve an appeal
+    /// Resolve an appeal.
     pub async fn resolve_appeal(
         &self,
         revocation_id: &str,
         upheld: bool,
         resolution_notes: String,
     ) -> Result<()> {
-        let mut record = self
-            .revocations
-            .get(revocation_id)
-            .ok_or_else(|| anyhow::anyhow!("Revocation not found"))?;
-
-        record.resolve_appeal(upheld, resolution_notes);
-
-        self.revocations
-            .update(record)
-            .map_err(|e| anyhow::anyhow!("Failed to update revocation: {e}"))
+        self.handle
+            .resolve_appeal(revocation_id, upheld, resolution_notes)
+            .await
     }
 
-    /// Revoke a membership with proper due process
+    /// Revoke a member's access.
     pub async fn revoke_membership(
         &self,
         holder_id: &str,
@@ -1193,43 +482,18 @@ impl<S: CommonsStoreBackend> CommonsManager<S> {
         reason: CommonsRevocationReason,
         appeal_window_days: u64,
     ) -> Result<RevocationRecord> {
-        // Verify holder exists
-        let mut holder = self
-            .get_holder(holder_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
-
-        // Verify has affiliation with jurisdiction
-        let affiliation = holder.get_affiliation_mut(jurisdiction_id).ok_or_else(|| {
-            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
-        })?;
-
-        // Create revocation record
-        let target_id = format!("{holder_id}:{jurisdiction_id}");
-        let record = RevocationRecord::new(
-            RevocationType::Membership,
-            target_id,
-            RevocationScope::Jurisdiction {
-                jurisdiction_id: jurisdiction_id.clone(),
-            },
-            authority,
-            reason,
-            appeal_window_days,
-        );
-
-        // Add to registry
-        self.add_revocation(record.clone()).await?;
-
-        // Update affiliation status (but allow appeal)
-        affiliation.suspend();
-
-        // Update holder via store
-        self.store.put_holder(&holder)?;
-
-        Ok(record)
+        self.handle
+            .revoke_membership(
+                holder_id,
+                jurisdiction_id,
+                authority,
+                reason,
+                appeal_window_days,
+            )
+            .await
     }
 
-    /// Ban a member immediately (severe violations)
+    /// Ban a member entirely (immediate, severe violations).
     pub async fn ban_member(
         &self,
         holder_id: &str,
@@ -1237,866 +501,325 @@ impl<S: CommonsStoreBackend> CommonsManager<S> {
         authority: Did,
         reason: CommonsRevocationReason,
     ) -> Result<RevocationRecord> {
-        // Verify holder exists
-        let mut holder = self
-            .get_holder(holder_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
-
-        // Verify has affiliation
-        let affiliation = holder.get_affiliation_mut(jurisdiction_id).ok_or_else(|| {
-            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
-        })?;
-
-        // Create immediate revocation
-        let target_id = format!("{holder_id}:{jurisdiction_id}");
-        let record = RevocationRecord::immediate(
-            RevocationType::Membership,
-            target_id,
-            RevocationScope::Jurisdiction {
-                jurisdiction_id: jurisdiction_id.clone(),
-            },
-            authority,
-            reason,
-        );
-
-        // Add to registry
-        self.add_revocation(record.clone()).await?;
-
-        // Ban the member
-        affiliation.ban();
-
-        // Update holder via store
-        self.store.put_holder(&holder)?;
-
-        Ok(record)
+        self.handle
+            .ban_member(holder_id, jurisdiction_id, authority, reason)
+            .await
     }
 
-    /// Check if a member is revoked in a jurisdiction
-    pub async fn is_member_revoked(
-        &self,
-        holder_id: &str,
-        jurisdiction_id: &JurisdictionId,
-    ) -> bool {
-        let target_id = format!("{holder_id}:{jurisdiction_id}");
-        self.revocations
-            .is_revoked_in_jurisdiction(&target_id, jurisdiction_id)
+    /// Check if a member is revoked.
+    pub async fn is_member_revoked(&self, holder_id: &str, jurisdiction: &JurisdictionId) -> bool {
+        self.handle.is_member_revoked(holder_id, jurisdiction).await
     }
+}
 
-    // ========== Membership Management Operations ==========
+// ============================================================================
+// Membership Management Operations
+// ============================================================================
 
+impl CommonsManager {
     /// Apply for membership in a jurisdiction.
-    ///
-    /// Sybil resistance: requires at least `POPLevel::Strong` to apply.
-    /// This prevents an attacker from creating many `Weak`-level identities
-    /// to flood jurisdiction membership rolls.
     pub async fn apply_for_membership(
         &self,
         holder_id: &str,
-        jurisdiction_id: JurisdictionId,
-        capabilities_requested: Vec<MembershipCapability>,
+        jurisdiction: JurisdictionId,
+        initial_capabilities: Vec<MembershipCapability>,
     ) -> Result<Affiliation> {
-        // Verify holder exists and is active
-        let mut holder = self
-            .get_holder(holder_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
-
-        if !holder.is_active() {
-            bail!("Holder is not active");
-        }
-
-        // Sybil gate: require at least Strong POP level for membership
-        if holder.personhood_level < POPLevel::Strong {
-            bail!(
-                "Membership requires at least Strong POP level (current: Weak). \
-                 Obtain additional attestations to upgrade."
-            );
-        }
-
-        // Check not already affiliated
-        if holder.is_affiliated(&jurisdiction_id) {
-            bail!("Already affiliated with jurisdiction: {jurisdiction_id}");
-        }
-
-        // Check not revoked from this jurisdiction
-        if self.is_member_revoked(holder_id, &jurisdiction_id).await {
-            bail!("Previously banned from jurisdiction: {jurisdiction_id}");
-        }
-
-        // Create affiliation as candidate
-        let mut affiliation = Affiliation::new(jurisdiction_id.clone());
-        // Store requested capabilities for review
-        for cap in capabilities_requested {
-            affiliation.add_capability(cap);
-        }
-
-        // Add to holder
-        holder.add_affiliation(affiliation.clone());
-
-        // Update storage via store
-        self.store.put_holder(&holder)?;
-
-        Ok(affiliation)
+        self.handle
+            .apply_for_membership(holder_id, jurisdiction, initial_capabilities)
+            .await
     }
 
-    /// Approve a membership application (moves from Candidate to Provisional)
+    /// Approve membership.
     pub async fn approve_membership(
         &self,
         holder_id: &str,
-        jurisdiction_id: &JurisdictionId,
+        jurisdiction: &JurisdictionId,
     ) -> Result<()> {
-        let mut holder = self
-            .get_holder(holder_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
-
-        let affiliation = holder.get_affiliation_mut(jurisdiction_id).ok_or_else(|| {
-            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
-        })?;
-
-        if affiliation.membership_status != MembershipStatus::Candidate {
-            bail!(
-                "Can only approve candidates, current status: {}",
-                affiliation.membership_status
-            );
-        }
-
-        affiliation.approve();
-
-        self.store.put_holder(&holder)?;
-
-        // Record approval metric
-        icn_obs::metrics::commons::membership_approved_inc(jurisdiction_id.as_str());
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "membership_approved",
-            holder_id = %holder_id,
-            jurisdiction = %jurisdiction_id.as_str(),
-            "Membership application approved"
-        );
-
-        Ok(())
+        self.handle
+            .approve_membership(holder_id, jurisdiction)
+            .await
     }
 
-    /// Promote a member from Provisional to full Member
+    /// Promote a member from Provisional to full Member.
     pub async fn promote_member(
         &self,
         holder_id: &str,
         jurisdiction_id: &JurisdictionId,
     ) -> Result<()> {
-        let mut holder = self
-            .get_holder(holder_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
-
-        let affiliation = holder.get_affiliation_mut(jurisdiction_id).ok_or_else(|| {
-            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
-        })?;
-
-        if affiliation.membership_status != MembershipStatus::Provisional {
-            bail!(
-                "Can only promote provisional members, current status: {}",
-                affiliation.membership_status
-            );
-        }
-
-        affiliation.promote();
-
-        self.store.put_holder(&holder)?;
-
-        // Record promotion metric
-        icn_obs::metrics::commons::membership_promoted_inc(jurisdiction_id.as_str());
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "membership_promoted",
-            holder_id = %holder_id,
-            jurisdiction = %jurisdiction_id.as_str(),
-            "Member promoted to full membership"
-        );
-
-        Ok(())
+        self.handle.promote_member(holder_id, jurisdiction_id).await
     }
 
-    /// Suspend a member
+    /// Suspend a member.
     pub async fn suspend_member(
         &self,
         holder_id: &str,
         jurisdiction_id: &JurisdictionId,
     ) -> Result<()> {
-        let mut holder = self
-            .get_holder(holder_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
-
-        let affiliation = holder.get_affiliation_mut(jurisdiction_id).ok_or_else(|| {
-            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
-        })?;
-
-        affiliation.suspend();
-
-        self.store.put_holder(&holder)?;
-
-        // Audit log
-        warn!(
-            target: "commons_audit",
-            action = "member_suspended",
-            holder_id = %holder_id,
-            jurisdiction = %jurisdiction_id.as_str(),
-            "Member suspended"
-        );
-
-        Ok(())
+        self.handle.suspend_member(holder_id, jurisdiction_id).await
     }
 
-    /// Reinstate a suspended member
+    /// Reinstate a suspended member.
     pub async fn reinstate_member(
         &self,
         holder_id: &str,
-        jurisdiction_id: &JurisdictionId,
+        jurisdiction: &JurisdictionId,
     ) -> Result<()> {
-        let mut holder = self
-            .get_holder(holder_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
-
-        let affiliation = holder.get_affiliation_mut(jurisdiction_id).ok_or_else(|| {
-            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
-        })?;
-
-        if affiliation.membership_status != MembershipStatus::Suspended {
-            bail!("Member is not suspended");
-        }
-
-        // Reinstate to Member status
-        affiliation.membership_status = MembershipStatus::Member;
-
-        self.store.put_holder(&holder)?;
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "member_reinstated",
-            holder_id = %holder_id,
-            jurisdiction = %jurisdiction_id.as_str(),
-            "Member reinstated"
-        );
-
-        Ok(())
+        self.handle.reinstate_member(holder_id, jurisdiction).await
     }
 
-    /// Grant a capability to a member
+    /// Grant a capability to a member.
     pub async fn grant_capability(
         &self,
         holder_id: &str,
-        jurisdiction_id: &JurisdictionId,
+        jurisdiction: &JurisdictionId,
         capability: MembershipCapability,
     ) -> Result<()> {
-        let mut holder = self
-            .get_holder(holder_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
-
-        let affiliation = holder.get_affiliation_mut(jurisdiction_id).ok_or_else(|| {
-            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
-        })?;
-
-        if !affiliation.is_active() {
-            bail!("Member is not active");
-        }
-
-        affiliation.add_capability(capability);
-
-        self.store.put_holder(&holder)?;
-
-        Ok(())
+        self.handle
+            .grant_capability(holder_id, jurisdiction, capability)
+            .await
     }
 
-    /// Revoke a capability from a member
+    /// Revoke a capability from a member.
     pub async fn revoke_capability(
         &self,
         holder_id: &str,
-        jurisdiction_id: &JurisdictionId,
+        jurisdiction: &JurisdictionId,
         capability: MembershipCapability,
     ) -> Result<()> {
-        let mut holder = self
-            .get_holder(holder_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
-
-        let affiliation = holder.get_affiliation_mut(jurisdiction_id).ok_or_else(|| {
-            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
-        })?;
-
-        affiliation.remove_capability(capability);
-
-        self.store.put_holder(&holder)?;
-
-        Ok(())
+        self.handle
+            .revoke_capability(holder_id, jurisdiction, capability)
+            .await
     }
 
-    /// Add a role to a member
+    /// Add a role to a member.
     pub async fn add_member_role(
         &self,
         holder_id: &str,
-        jurisdiction_id: &JurisdictionId,
+        jurisdiction: &JurisdictionId,
         role: String,
     ) -> Result<()> {
-        let mut holder = self
-            .get_holder(holder_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
-
-        let affiliation = holder.get_affiliation_mut(jurisdiction_id).ok_or_else(|| {
-            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
-        })?;
-
-        if !affiliation.roles.contains(&role) {
-            affiliation.roles.push(role);
-        }
-
-        self.store.put_holder(&holder)?;
-
-        Ok(())
+        self.handle
+            .add_member_role(holder_id, jurisdiction, role)
+            .await
     }
 
-    /// Remove a role from a member
+    /// Remove a role from a member.
     pub async fn remove_member_role(
         &self,
         holder_id: &str,
-        jurisdiction_id: &JurisdictionId,
+        jurisdiction: &JurisdictionId,
         role: &str,
     ) -> Result<()> {
-        let mut holder = self
-            .get_holder(holder_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
-
-        let affiliation = holder.get_affiliation_mut(jurisdiction_id).ok_or_else(|| {
-            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
-        })?;
-
-        affiliation.roles.retain(|r| r != role);
-
-        self.store.put_holder(&holder)?;
-
-        Ok(())
+        self.handle
+            .remove_member_role(holder_id, jurisdiction, role)
+            .await
     }
 
-    /// Check if a member has a specific capability
+    /// Check if a member has a capability.
     pub async fn member_has_capability(
         &self,
         holder_id: &str,
-        jurisdiction_id: &JurisdictionId,
+        jurisdiction: &JurisdictionId,
         capability: MembershipCapability,
     ) -> Result<bool> {
-        let holder = self
-            .get_holder(holder_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Holder not found"))?;
-
-        let affiliation = holder.get_affiliation(jurisdiction_id).ok_or_else(|| {
-            anyhow::anyhow!("Holder not affiliated with jurisdiction: {jurisdiction_id}")
-        })?;
-
-        Ok(affiliation.is_active() && affiliation.has_capability(capability))
+        self.handle
+            .member_has_capability(holder_id, jurisdiction, capability)
+            .await
     }
 
-    /// List members of a jurisdiction by status
+    /// List members by status.
     pub async fn list_members_by_status(
         &self,
-        jurisdiction_id: &JurisdictionId,
+        jurisdiction: &JurisdictionId,
         status: Option<MembershipStatus>,
     ) -> Vec<(String, Affiliation)> {
-        let holders = match self.store.list_holders() {
-            Ok(h) => h,
-            Err(_) => return Vec::new(),
-        };
-
-        let mut results = Vec::new();
-        for holder in holders {
-            let holder_id = hex::encode(holder.id());
-            if let Some(affiliation) = holder.get_affiliation(jurisdiction_id) {
-                if status.is_none() || Some(affiliation.membership_status) == status {
-                    results.push((holder_id, affiliation.clone()));
-                }
-            }
-        }
-
-        results
+        self.handle
+            .list_members_by_status(jurisdiction, status)
+            .await
     }
+}
 
-    // ========== Amendment Operations (v0.6.0 Constitutional Governance) ==========
+// ============================================================================
+// Amendment Operations (v0.6.0 Constitutional Governance)
+// ============================================================================
 
-    /// Store an amendment
+impl CommonsManager {
+    /// Store an amendment.
     pub async fn store_amendment(&self, amendment: Amendment) -> Result<()> {
-        let amendment_id = amendment.id.to_hex();
-        let proposer = amendment.proposer.to_string();
-
-        self.store.put_amendment(&amendment)?;
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "amendment_created",
-            amendment_id = %amendment_id,
-            proposer = %proposer,
-            scope = %format!("{}", amendment.scope),
-            amendment_type = %format!("{}", amendment.amendment_type),
-            "Amendment created"
-        );
-
-        Ok(())
+        self.handle.store_amendment(amendment).await
     }
 
-    /// Add a change to a draft amendment
-    ///
-    /// Requirements:
-    /// - Amendment must exist
-    /// - Amendment must be in Draft status
-    /// - Caller should be the proposer (validation done at API layer)
+    /// Add a change to an amendment.
     pub async fn add_amendment_change(
         &self,
         amendment_id: &str,
         change: AmendmentChange,
     ) -> Result<Amendment> {
-        let mut amendment = self
-            .store
-            .get_amendment(amendment_id)?
-            .ok_or_else(|| anyhow::anyhow!("Amendment not found: {amendment_id}"))?;
-
-        // Validate amendment is in Draft status
-        if !matches!(amendment.status, AmendmentStatus::Draft) {
-            bail!(
-                "Cannot add changes to amendment in status {:?}, must be Draft",
-                amendment.status
-            );
-        }
-
-        // Add the change
-        let change_desc = change.description.clone();
-        amendment.add_change(change);
-
-        // Persist updated amendment
-        self.store.put_amendment(&amendment)?;
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "amendment_change_added",
-            amendment_id = %amendment_id,
-            change = %change_desc,
-            total_changes = amendment.changes.len(),
-            "Change added to amendment"
-        );
-
-        Ok(amendment)
+        self.handle.add_amendment_change(amendment_id, change).await
     }
 
-    /// Get an amendment by ID
+    /// Get an amendment by ID.
     pub async fn get_amendment(&self, id: &AmendmentId) -> Result<Option<Amendment>> {
-        let id_hex = id.to_hex();
-        self.store.get_amendment(&id_hex)
+        self.handle.get_amendment(id).await
     }
 
-    /// List amendments with optional filters
+    /// List amendments with optional filters.
     pub async fn list_amendments(
         &self,
         status: Option<&str>,
         scope: Option<&str>,
         amendment_type: Option<&str>,
     ) -> Result<Vec<Amendment>> {
-        let mut results = self.store.list_amendments()?;
-
-        // Filter by status
-        if let Some(s) = status {
-            let s_lower = s.to_lowercase();
-            results.retain(|a| format!("{:?}", a.status).to_lowercase().contains(&s_lower));
-        }
-
-        // Filter by scope
-        if let Some(s) = scope {
-            let s_lower = s.to_lowercase();
-            results.retain(|a| format!("{}", a.scope).to_lowercase().contains(&s_lower));
-        }
-
-        // Filter by type
-        if let Some(t) = amendment_type {
-            let t_lower = t.to_lowercase();
-            results.retain(|a| {
-                format!("{}", a.amendment_type)
-                    .to_lowercase()
-                    .contains(&t_lower)
-            });
-        }
-
-        // Sort by created_at descending
-        results.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-
-        Ok(results)
+        self.handle
+            .list_amendments(status, scope, amendment_type)
+            .await
     }
 
-    /// Submit an amendment for review
+    /// Submit an amendment for review.
     pub async fn submit_amendment(&self, id: &AmendmentId, caller: &Did) -> Result<Amendment> {
-        let id_hex = id.to_hex();
-        let mut amendment = self
-            .store
-            .get_amendment(&id_hex)?
-            .ok_or_else(|| anyhow::anyhow!("Amendment not found"))?;
-
-        // Only proposer can submit
-        if amendment.proposer != *caller {
-            bail!("Only proposer can submit amendment");
-        }
-
-        amendment.submit().map_err(|e| anyhow::anyhow!(e))?;
-        self.store.put_amendment(&amendment)?;
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "amendment_submitted",
-            amendment_id = %id_hex,
-            caller = %caller.to_string(),
-            "Amendment submitted for review"
-        );
-
-        Ok(amendment)
+        self.handle.submit_amendment(id, caller).await
     }
 
-    /// Open voting on an amendment (skipping review for simple cases)
-    pub async fn open_amendment_voting(
-        &self,
-        id: &AmendmentId,
-        _caller: &Did,
-    ) -> Result<Amendment> {
-        let id_hex = id.to_hex();
-        let mut amendment = self
-            .store
-            .get_amendment(&id_hex)?
-            .ok_or_else(|| anyhow::anyhow!("Amendment not found"))?;
-
-        // If still in submitted state, begin review first (auto-skip if review_period is 0)
-        if matches!(amendment.status, AmendmentStatus::Submitted { .. }) {
-            amendment.begin_review().map_err(|e| anyhow::anyhow!(e))?;
-        }
-
-        amendment.open_voting().map_err(|e| anyhow::anyhow!(e))?;
-        self.store.put_amendment(&amendment)?;
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "amendment_voting_opened",
-            amendment_id = %id_hex,
-            "Amendment voting period opened"
-        );
-
-        Ok(amendment)
+    /// Open voting on an amendment.
+    pub async fn open_amendment_voting(&self, id: &AmendmentId, caller: &Did) -> Result<Amendment> {
+        self.handle.open_amendment_voting(id, caller).await
     }
 
-    /// Add a ratification to an amendment
+    /// Add a ratification to an amendment.
     pub async fn add_amendment_ratification(
         &self,
         id: &AmendmentId,
         ratification: Ratification,
     ) -> Result<Amendment> {
-        let id_hex = id.to_hex();
-        let mut amendment = self
-            .store
-            .get_amendment(&id_hex)?
-            .ok_or_else(|| anyhow::anyhow!("Amendment not found"))?;
-
-        let ratifier = ratification.authority_did.to_string();
-        amendment
-            .add_ratification(ratification)
-            .map_err(|e| anyhow::anyhow!(e))?;
-
-        // Check if ratification requirements are now met
-        let result = amendment.check_ratification();
-        let was_ratified = matches!(result, icn_governance::RatificationResult::Approved { .. });
-        if was_ratified {
-            let _ = amendment.ratify();
-        }
-
-        self.store.put_amendment(&amendment)?;
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "amendment_ratification_added",
-            amendment_id = %id_hex,
-            ratifier = %ratifier,
-            total_ratifications = amendment.ratifications.len(),
-            amendment_ratified = was_ratified,
-            "Amendment ratification added"
-        );
-
-        Ok(amendment)
+        self.handle
+            .add_amendment_ratification(id, ratification)
+            .await
     }
 
-    /// Withdraw an amendment
+    /// Withdraw an amendment.
     pub async fn withdraw_amendment(
         &self,
         id: &AmendmentId,
         caller: &Did,
         reason: String,
     ) -> Result<Amendment> {
-        let id_hex = id.to_hex();
-        let mut amendment = self
-            .store
-            .get_amendment(&id_hex)?
-            .ok_or_else(|| anyhow::anyhow!("Amendment not found"))?;
-
-        // Only proposer can withdraw
-        if amendment.proposer != *caller {
-            bail!("Only proposer can withdraw amendment");
-        }
-
-        amendment
-            .withdraw(reason.clone())
-            .map_err(|e| anyhow::anyhow!(e))?;
-        self.store.put_amendment(&amendment)?;
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "amendment_withdrawn",
-            amendment_id = %id_hex,
-            caller = %caller.to_string(),
-            reason = %reason,
-            "Amendment withdrawn"
-        );
-
-        Ok(amendment)
+        self.handle.withdraw_amendment(id, caller, reason).await
     }
+}
 
-    // ========== Appeal Operations (v0.6.0 Constitutional Governance) ==========
+// ============================================================================
+// Appeal Operations (v0.6.0 Constitutional Governance)
+// ============================================================================
 
-    /// Store an appeal
+impl CommonsManager {
+    /// Store an appeal.
     pub async fn store_appeal(&self, appeal: Appeal) -> Result<()> {
-        let appeal_id = appeal.id.to_hex();
-        let appellant = appeal.appellant.to_string();
-
-        self.store.put_appeal(&appeal)?;
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "appeal_created",
-            appeal_id = %appeal_id,
-            appellant = %appellant,
-            scope = %format!("{}", appeal.scope),
-            "Appeal created"
-        );
-
-        Ok(())
+        self.handle.store_appeal(appeal).await
     }
 
-    /// Get an appeal by ID
+    /// Get an appeal by ID.
     pub async fn get_appeal(&self, id: &AppealId) -> Result<Option<Appeal>> {
-        let id_hex = id.to_hex();
-        self.store.get_appeal(&id_hex)
+        self.handle.get_appeal(id).await
     }
 
-    /// List appeals with optional filters
+    /// List appeals with optional filters.
     pub async fn list_appeals(
         &self,
         status: Option<&str>,
         scope: Option<&str>,
         appellant: Option<&str>,
     ) -> Result<Vec<Appeal>> {
-        let mut results = self.store.list_appeals()?;
-
-        // Filter by status
-        if let Some(s) = status {
-            let s_lower = s.to_lowercase();
-            results.retain(|a| format!("{:?}", a.status).to_lowercase().contains(&s_lower));
-        }
-
-        // Filter by scope
-        if let Some(s) = scope {
-            let s_lower = s.to_lowercase();
-            results.retain(|a| format!("{}", a.scope).to_lowercase().contains(&s_lower));
-        }
-
-        // Filter by appellant
-        if let Some(a) = appellant {
-            results.retain(|appeal| appeal.appellant.to_string() == a);
-        }
-
-        // Sort by created_at descending
-        results.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-
-        Ok(results)
+        self.handle.list_appeals(status, scope, appellant).await
     }
 
-    /// Add evidence to an appeal
+    /// Add evidence to an appeal.
     pub async fn add_appeal_evidence(
         &self,
         id: &AppealId,
         evidence: AppealEvidence,
     ) -> Result<Appeal> {
-        let id_hex = id.to_hex();
-        let mut appeal = self
-            .store
-            .get_appeal(&id_hex)?
-            .ok_or_else(|| anyhow::anyhow!("Appeal not found"))?;
-
-        appeal
-            .add_evidence(evidence)
-            .map_err(|e| anyhow::anyhow!(e))?;
-        self.store.put_appeal(&appeal)?;
-        Ok(appeal)
+        self.handle.add_appeal_evidence(id, evidence).await
     }
 
-    /// Add response to an appeal
+    /// Add a response to an appeal.
     pub async fn add_appeal_response(
         &self,
         id: &AppealId,
         response: AppealResponse,
     ) -> Result<Appeal> {
-        let id_hex = id.to_hex();
-        let mut appeal = self
-            .store
-            .get_appeal(&id_hex)?
-            .ok_or_else(|| anyhow::anyhow!("Appeal not found"))?;
-
-        appeal
-            .add_response(response)
-            .map_err(|e| anyhow::anyhow!(e))?;
-        self.store.put_appeal(&appeal)?;
-        Ok(appeal)
+        self.handle.add_appeal_response(id, response).await
     }
 
-    /// Begin review of an appeal
+    /// Begin review of an appeal.
     pub async fn begin_appeal_review(&self, id: &AppealId) -> Result<Appeal> {
-        let id_hex = id.to_hex();
-        let mut appeal = self
-            .store
-            .get_appeal(&id_hex)?
-            .ok_or_else(|| anyhow::anyhow!("Appeal not found"))?;
-
-        appeal.begin_review().map_err(|e| anyhow::anyhow!(e))?;
-        self.store.put_appeal(&appeal)?;
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "appeal_review_started",
-            appeal_id = %id_hex,
-            "Appeal review started"
-        );
-
-        Ok(appeal)
+        self.handle.begin_appeal_review(id).await
     }
 
-    /// Resolve a constitutional appeal with outcome
+    /// Resolve a constitutional appeal.
     pub async fn resolve_constitutional_appeal(
         &self,
         id: &AppealId,
         outcome: AppealOutcome,
     ) -> Result<Appeal> {
-        let id_hex = id.to_hex();
-        let mut appeal = self
-            .store
-            .get_appeal(&id_hex)?
-            .ok_or_else(|| anyhow::anyhow!("Appeal not found"))?;
-
-        let outcome_str = format!("{outcome:?}");
-        appeal.resolve(outcome).map_err(|e| anyhow::anyhow!(e))?;
-        self.store.put_appeal(&appeal)?;
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "appeal_resolved",
-            appeal_id = %id_hex,
-            outcome = %outcome_str,
-            "Constitutional appeal resolved"
-        );
-
-        Ok(appeal)
+        self.handle.resolve_constitutional_appeal(id, outcome).await
     }
 
-    /// Withdraw an appeal
+    /// Withdraw an appeal.
     pub async fn withdraw_appeal(
         &self,
         id: &AppealId,
         caller: &Did,
         reason: Option<String>,
     ) -> Result<Appeal> {
-        let id_hex = id.to_hex();
-        let mut appeal = self
-            .store
-            .get_appeal(&id_hex)?
-            .ok_or_else(|| anyhow::anyhow!("Appeal not found"))?;
-
-        // Only appellant can withdraw
-        if appeal.appellant != *caller {
-            bail!("Only appellant can withdraw appeal");
-        }
-
-        appeal
-            .withdraw(reason.clone())
-            .map_err(|e| anyhow::anyhow!(e))?;
-        self.store.put_appeal(&appeal)?;
-
-        // Audit log
-        info!(
-            target: "commons_audit",
-            action = "appeal_withdrawn",
-            appeal_id = %id_hex,
-            caller = %caller.to_string(),
-            reason = ?reason,
-            "Appeal withdrawn"
-        );
-
-        Ok(appeal)
+        self.handle.withdraw_appeal(id, caller, reason).await
     }
+}
 
-    // ========================================================================
-    // Enrollment Session Operations
-    // ========================================================================
+// ============================================================================
+// Enrollment Session Operations (gateway-local, in-memory)
+// ============================================================================
 
-    /// Store an enrollment session
+impl CommonsManager {
+    /// Store an enrollment session.
     pub async fn put_enrollment_session(
         &self,
         id: &str,
         session: &crate::api::sdis::simple_enrollment::EnrollmentSession,
     ) -> Result<()> {
-        self.store.put_enrollment_session(id, session)?;
+        self.enrollment_sessions
+            .write()
+            .await
+            .insert(id.to_string(), session.clone());
         Ok(())
     }
 
-    /// Get an enrollment session by ID
+    /// Get an enrollment session by ID.
     pub async fn get_enrollment_session(
         &self,
         id: &str,
     ) -> Result<Option<crate::api::sdis::simple_enrollment::EnrollmentSession>> {
-        self.store.get_enrollment_session(id)
+        Ok(self.enrollment_sessions.read().await.get(id).cloned())
     }
 
-    /// Update an enrollment session
+    /// Update an enrollment session.
     pub async fn update_enrollment_session(
         &self,
         id: &str,
         session: &crate::api::sdis::simple_enrollment::EnrollmentSession,
     ) -> Result<()> {
-        self.store.update_enrollment_session(id, session)?;
+        self.enrollment_sessions
+            .write()
+            .await
+            .insert(id.to_string(), session.clone());
         Ok(())
     }
 
-    /// Delete an enrollment session
+    /// Delete an enrollment session.
     pub async fn delete_enrollment_session(&self, id: &str) -> Result<bool> {
-        self.store.delete_enrollment_session(id)
+        Ok(self.enrollment_sessions.write().await.remove(id).is_some())
     }
 
-    /// List all enrollment sessions
+    /// List all enrollment sessions.
     pub async fn list_enrollment_sessions(
         &self,
     ) -> Result<
@@ -2105,9 +828,21 @@ impl<S: CommonsStoreBackend> CommonsManager<S> {
             crate::api::sdis::simple_enrollment::EnrollmentSession,
         )>,
     > {
-        self.store.list_enrollment_sessions()
+        Ok(self
+            .enrollment_sessions
+            .read()
+            .await
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect())
     }
+}
 
+// ============================================================================
+// Governance Dashboard (gateway-local DTO)
+// ============================================================================
+
+impl CommonsManager {
     /// Build a governance dashboard from stored amendments and appeals.
     ///
     /// Returns a gateway-level DTO so callers don't need icn_governance types.
@@ -2221,11 +956,9 @@ impl<S: CommonsStoreBackend> CommonsManager<S> {
     }
 }
 
-impl Default for CommonsManager<Arc<dyn CommonsStoreBackend>> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+// ============================================================================
+// Steward DTO Helpers (gateway-local free functions)
+// ============================================================================
 
 /// Convert a `StewardRecord` to a gateway-local summary DTO.
 pub fn steward_to_summary(s: &StewardRecord) -> StewardSummaryResponse {
@@ -2276,9 +1009,14 @@ fn format_steward_status(s: &StewardStatus) -> String {
     }
 }
 
+// ============================================================================
+// Tests
+// ============================================================================
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use icn_identity::POPLevel;
 
     fn test_did() -> Did {
         Did::from_anchor_id(&[42u8; 32])
@@ -2327,7 +1065,6 @@ mod tests {
         let did = test_did();
         let steward = steward_did();
 
-        // Use steward enrollment to get Strong POP level (required for join)
         let anchor = mgr
             .create_anchor_from_enrollment(&did, Some(&steward))
             .await
@@ -2342,23 +1079,19 @@ mod tests {
 
         let jurisdiction = JurisdictionId::new("coop:test-coop");
 
-        // Join
         let affiliation = mgr
             .join_jurisdiction(&holder_id, jurisdiction.clone(), vec![])
             .await
             .unwrap();
         assert_eq!(affiliation.membership_status, MembershipStatus::Candidate);
 
-        // Verify affiliation exists
         let affiliations = mgr.list_affiliations(&holder_id).await.unwrap();
         assert_eq!(affiliations.len(), 1);
 
-        // Leave
         mgr.leave_jurisdiction(&holder_id, &jurisdiction)
             .await
             .unwrap();
 
-        // Verify status is Exited
         let affiliations = mgr.list_affiliations(&holder_id).await.unwrap();
         assert_eq!(affiliations[0].membership_status, MembershipStatus::Exited);
     }
@@ -2375,7 +1108,6 @@ mod tests {
             .await
             .unwrap();
 
-        // Lookup by DID
         let found_anchor = mgr.get_anchor_by_did(&did).await.unwrap();
         assert!(found_anchor.is_some());
 

--- a/icn/crates/icn-gateway/src/commons_mgr.rs
+++ b/icn/crates/icn-gateway/src/commons_mgr.rs
@@ -675,6 +675,11 @@ impl CommonsManager {
             .await
     }
 
+    /// List amendments scoped to a single domain — exact match, no prefix bleed.
+    pub async fn list_amendments_by_domain(&self, domain_id: &str) -> Result<Vec<Amendment>> {
+        self.handle.list_amendments_by_domain(domain_id).await
+    }
+
     /// Submit an amendment for review.
     pub async fn submit_amendment(&self, id: &AmendmentId, caller: &Did) -> Result<Amendment> {
         self.handle.submit_amendment(id, caller).await
@@ -730,6 +735,11 @@ impl CommonsManager {
         appellant: Option<&str>,
     ) -> Result<Vec<Appeal>> {
         self.handle.list_appeals(status, scope, appellant).await
+    }
+
+    /// List appeals scoped to a single domain — exact match, no prefix bleed.
+    pub async fn list_appeals_by_domain(&self, domain_id: &str) -> Result<Vec<Appeal>> {
+        self.handle.list_appeals_by_domain(domain_id).await
     }
 
     /// Add evidence to an appeal.
@@ -854,22 +864,18 @@ impl CommonsManager {
         &self,
         charter_id: &str,
     ) -> Result<GovernanceDashboard> {
-        // Derive domain_id from the charter so that dashboard data is scoped correctly.
-        let domain_id: Option<String> = self
+        // Derive domain_id from the charter.  If the charter doesn't exist,
+        // return an error rather than falling back to a cross-domain "list all"
+        // query.  Silently widening scope on a missing charter would expose
+        // governance records from every domain to the caller.
+        let charter = self
             .get_charter(charter_id)
             .await?
-            .map(|c| c.domain_id.clone());
+            .ok_or_else(|| anyhow::anyhow!("Charter not found: {charter_id}"))?;
+        let domain_id = charter.domain_id.clone();
 
-        let amendments = if let Some(ref d) = domain_id {
-            self.handle.list_amendments_by_domain(d).await?
-        } else {
-            self.list_amendments(None, None, None).await?
-        };
-        let appeals = if let Some(ref d) = domain_id {
-            self.handle.list_appeals_by_domain(d).await?
-        } else {
-            self.list_appeals(None, None, None).await?
-        };
+        let amendments = self.handle.list_amendments_by_domain(&domain_id).await?;
+        let appeals = self.handle.list_appeals_by_domain(&domain_id).await?;
 
         let mut ab = AmendmentsBreakdown {
             draft: 0,

--- a/icn/crates/icn-gateway/src/commons_mgr.rs
+++ b/icn/crates/icn-gateway/src/commons_mgr.rs
@@ -6,7 +6,7 @@
 //! - Charter management (Layer 2)
 //! - Affiliation/membership management
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use icn_governance::{
     Amendment, AmendmentChange, AmendmentId, AmendmentStatus, Appeal, AppealEvidence, AppealId,
     AppealOutcome, AppealResponse, AppealStatus, Charter, CharterStatus, OrgType, Ratification,
@@ -22,7 +22,9 @@ use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use tracing::{info, warn};
 
-use crate::commons_store::{CommonsStore, CommonsStoreBackend, InMemoryCommonsStore};
+use crate::commons_store::{
+    CommonsStore, CommonsStoreBackend, InMemoryCommonsStore, SledCommonsStore,
+};
 use crate::models::{
     AmendmentsBreakdown, AppealsBreakdown, GovernanceActivityEvent, GovernanceDashboard,
     StewardDetailResponse, StewardSummaryResponse,
@@ -37,7 +39,7 @@ use crate::models::{
 /// - StewardRecords, Amendments, Appeals
 ///
 /// RevocationRegistry is kept separate for now.
-pub struct CommonsManager<S: CommonsStoreBackend = InMemoryCommonsStore> {
+pub struct CommonsManager<S: CommonsStoreBackend = Arc<dyn CommonsStoreBackend>> {
     /// Storage backend
     store: CommonsStore<S>,
 
@@ -45,31 +47,31 @@ pub struct CommonsManager<S: CommonsStoreBackend = InMemoryCommonsStore> {
     revocations: RevocationRegistry,
 }
 
-impl CommonsManager<InMemoryCommonsStore> {
-    /// Create a new commons manager with in-memory storage
+impl CommonsManager<Arc<dyn CommonsStoreBackend>> {
+    /// Create a new commons manager with in-memory storage (testing / no data_dir configured)
     pub fn new() -> Self {
-        let backend = Arc::new(InMemoryCommonsStore::new());
-        Self::with_store(backend)
+        let backend: Arc<dyn CommonsStoreBackend> = Arc::new(InMemoryCommonsStore::new());
+        Self::with_store(Arc::new(backend))
     }
-}
 
-use crate::commons_store::SledCommonsStore;
-
-impl CommonsManager<SledCommonsStore> {
     /// Create a new commons manager with persistent Sled storage
     ///
     /// Data will persist across gateway restarts at the given path.
     pub fn with_sled_path(path: impl AsRef<std::path::Path>) -> Result<Self> {
-        let backend = Arc::new(SledCommonsStore::open(path)?);
-        Ok(Self::with_store(backend))
+        let backend: Arc<dyn CommonsStoreBackend> =
+            Arc::new(SledCommonsStore::open(path).context("Failed to open commons sled store")?);
+        Ok(Self::with_store(Arc::new(backend)))
     }
 
     /// Create a new commons manager with a temporary Sled database
     ///
     /// Useful for testing persistent storage behavior without leaving files.
     pub fn with_sled_temporary() -> Result<Self> {
-        let backend = Arc::new(SledCommonsStore::temporary()?);
-        Ok(Self::with_store(backend))
+        let backend: Arc<dyn CommonsStoreBackend> = Arc::new(
+            SledCommonsStore::temporary()
+                .context("Failed to create temporary commons sled store")?,
+        );
+        Ok(Self::with_store(Arc::new(backend)))
     }
 
     /// Flush all pending writes to disk
@@ -2219,7 +2221,7 @@ impl<S: CommonsStoreBackend> CommonsManager<S> {
     }
 }
 
-impl Default for CommonsManager<InMemoryCommonsStore> {
+impl Default for CommonsManager<Arc<dyn CommonsStoreBackend>> {
     fn default() -> Self {
         Self::new()
     }

--- a/icn/crates/icn-gateway/src/commons_mgr.rs
+++ b/icn/crates/icn-gateway/src/commons_mgr.rs
@@ -518,14 +518,17 @@ impl CommonsManager {
 
 impl CommonsManager {
     /// Apply for membership in a jurisdiction.
+    ///
+    /// No capabilities are granted at application time.  Baseline capabilities
+    /// are granted by `promote_member`; elevated capabilities must be explicitly
+    /// delegated via `grant_capability` by a jurisdiction office-holder.
     pub async fn apply_for_membership(
         &self,
         holder_id: &str,
         jurisdiction: JurisdictionId,
-        initial_capabilities: Vec<MembershipCapability>,
     ) -> Result<Affiliation> {
         self.handle
-            .apply_for_membership(holder_id, jurisdiction, initial_capabilities)
+            .apply_for_membership(holder_id, jurisdiction)
             .await
     }
 

--- a/icn/crates/icn-gateway/src/commons_mgr.rs
+++ b/icn/crates/icn-gateway/src/commons_mgr.rs
@@ -843,15 +843,33 @@ impl CommonsManager {
 // ============================================================================
 
 impl CommonsManager {
-    /// Build a governance dashboard from stored amendments and appeals.
+    /// Build a governance dashboard scoped to a specific charter's domain.
+    ///
+    /// Looks up the charter by `charter_id`, derives its `domain_id`, then fetches
+    /// only amendments and appeals whose scope is `Jurisdiction { domain_id }` — exact
+    /// match, no substring. This prevents cross-domain contamination in multi-coop nodes.
     ///
     /// Returns a gateway-level DTO so callers don't need icn_governance types.
     pub async fn build_governance_dashboard(
         &self,
         charter_id: &str,
     ) -> Result<GovernanceDashboard> {
-        let amendments = self.list_amendments(None, None, None).await?;
-        let appeals = self.list_appeals(None, None, None).await?;
+        // Derive domain_id from the charter so that dashboard data is scoped correctly.
+        let domain_id: Option<String> = self
+            .get_charter(charter_id)
+            .await?
+            .map(|c| c.domain_id.clone());
+
+        let amendments = if let Some(ref d) = domain_id {
+            self.handle.list_amendments_by_domain(d).await?
+        } else {
+            self.list_amendments(None, None, None).await?
+        };
+        let appeals = if let Some(ref d) = domain_id {
+            self.handle.list_appeals_by_domain(d).await?
+        } else {
+            self.list_appeals(None, None, None).await?
+        };
 
         let mut ab = AmendmentsBreakdown {
             draft: 0,

--- a/icn/crates/icn-gateway/src/commons_store.rs
+++ b/icn/crates/icn-gateway/src/commons_store.rs
@@ -70,6 +70,31 @@ pub trait CommonsStoreBackend: Send + Sync {
     fn exists(&self, key: &[u8]) -> Result<bool> {
         Ok(self.get(key)?.is_some())
     }
+
+    /// Flush pending writes to durable storage. Default is a no-op for in-memory backends.
+    fn flush(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Allow `Arc<dyn CommonsStoreBackend>` to be used as a backend directly.
+/// This enables type-erased `CommonsManager` construction without changing handler signatures.
+impl CommonsStoreBackend for Arc<dyn CommonsStoreBackend> {
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        self.as_ref().get(key)
+    }
+    fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        self.as_ref().put(key, value)
+    }
+    fn delete(&self, key: &[u8]) -> Result<()> {
+        self.as_ref().delete(key)
+    }
+    fn scan(&self, prefix: &[u8]) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
+        self.as_ref().scan(prefix)
+    }
+    fn flush(&self) -> Result<()> {
+        self.as_ref().flush()
+    }
 }
 
 // ============================================================================
@@ -230,6 +255,11 @@ impl CommonsStoreBackend for SledCommonsStore {
             results.push((k.to_vec(), v.to_vec()));
         }
         Ok(results)
+    }
+
+    fn flush(&self) -> Result<()> {
+        self.db.flush().context("Failed to flush Sled database")?;
+        Ok(())
     }
 }
 

--- a/icn/crates/icn-gateway/src/lib.rs
+++ b/icn/crates/icn-gateway/src/lib.rs
@@ -24,6 +24,7 @@ rust_i18n::i18n!("locales", fallback = "en");
 pub mod api;
 pub mod audit;
 pub mod auth;
+pub(crate) mod authority;
 pub mod commons_mgr;
 pub mod commons_store;
 pub mod community_mgr;

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -773,9 +773,9 @@ impl GatewayServer {
 
         // Create SDIS state for identity verification
         let sdis_state = Arc::new(crate::api::sdis::SdisState::new());
-        // Create enrollment store with persistence to CommonsManager
+        // Create enrollment store wired to CommonsManager for write-through of completed enrollments
         let enrollment_store = Arc::new(
-            crate::api::sdis::simple_enrollment::EnrollmentStore::with_persistence(
+            crate::api::sdis::simple_enrollment::EnrollmentStore::with_commons_manager(
                 commons_manager.clone(),
             ),
         );

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -39,6 +39,7 @@ use crate::rate_limit::{
 use crate::security::{configure_cors, SecurityConfig, SecurityHeaders};
 use crate::treasury_mgr::{GatewayTreasuryManager, LedgerHandle, TreasuryHandle};
 use crate::trust_mgr::TrustManager;
+use anyhow::Context;
 use icn_compute::ComputeHandle;
 use icn_governance_actor::http::configure as configure_governance;
 use icn_governance_actor::http::configure::GovernanceContext;
@@ -689,16 +690,20 @@ impl GatewayServer {
             crate::service_discovery_mgr::start_expiry_task(service_discovery_manager.clone(), 300);
 
         let federation_manager = Arc::new(FederationManager::new());
-        // TODO: wire CommonsManager to a daemon handle (CommonsHandle) for cross-restart
-        // persistence. Currently all commons/personhood/charter/enrollment state is
-        // in-memory only and will be lost on process restart.
-        // See GovernanceManager::with_handle() for the pattern to follow.
-        warn!(
-            "CommonsManager running in-memory-only mode: \
-             commons/personhood/charter/enrollment state will NOT survive process restart. \
-             Wire a CommonsHandle for production use."
-        );
-        let commons_manager = Arc::new(CommonsManager::new());
+        let commons_manager: Arc<CommonsManager> = if let Some(ref data_dir) = self.data_dir {
+            let commons_path = data_dir.join("commons.sled");
+            info!("CommonsManager: opening sled store at {:?}", commons_path);
+            Arc::new(
+                CommonsManager::with_sled_path(&commons_path)
+                    .context("Failed to open commons sled store")?,
+            )
+        } else {
+            warn!(
+                "CommonsManager: no data_dir configured, running in-memory only — \
+                 commons/personhood/charter/enrollment state will NOT survive process restart"
+            );
+            Arc::new(CommonsManager::new())
+        };
 
         // Setup agreement manager if provided (for inter-cooperative agreements)
         let agreement_manager: Option<icn_federation::agreement::AgreementManagerHandle> =

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -122,6 +122,10 @@ pub struct GatewayServer {
     default_trust_score: Option<f64>,
     /// Hook called when a Charter proposal is accepted: deploys the document to the oracle.
     charter_accepted_hook: Option<icn_governance_actor::http::configure::CharterAcceptedHook>,
+    /// Optional pre-initialized CommonsHandle injected from the daemon/supervisor.
+    /// When provided, CommonsManager uses this shared handle instead of opening its own sled store.
+    /// This is the canonical path for preventing dual sled ownership over commons state.
+    commons_handle: Option<icn_commons::CommonsHandle>,
 }
 
 impl GatewayServer {
@@ -153,6 +157,7 @@ impl GatewayServer {
             audit_prune_config: None,
             default_trust_score: None,
             charter_accepted_hook: None,
+            commons_handle: None,
         }
     }
 
@@ -196,6 +201,7 @@ impl GatewayServer {
             audit_prune_config: None,
             default_trust_score: None,
             charter_accepted_hook: None,
+            commons_handle: None,
         }
     }
 
@@ -240,6 +246,7 @@ impl GatewayServer {
             audit_prune_config: None,
             default_trust_score: None,
             charter_accepted_hook: None,
+            commons_handle: None,
         }
     }
 
@@ -415,6 +422,16 @@ impl GatewayServer {
     /// When set, distributed compute can reference WASM modules by hash.
     pub fn with_wasm_registry(mut self, registry: Arc<icn_compute::WasmRegistry>) -> Self {
         self.wasm_registry_handle = Some(registry);
+        self
+    }
+
+    /// Set shared CommonsHandle from daemon/supervisor.
+    ///
+    /// When set, CommonsManager delegates all substrate commons operations to this
+    /// shared handle instead of opening its own sled store. This is the canonical
+    /// runtime path — it prevents dual sled ownership over the same commons data.
+    pub fn with_commons_handle(mut self, handle: icn_commons::CommonsHandle) -> Self {
+        self.commons_handle = Some(handle);
         self
     }
 
@@ -690,9 +707,18 @@ impl GatewayServer {
             crate::service_discovery_mgr::start_expiry_task(service_discovery_manager.clone(), 300);
 
         let federation_manager = Arc::new(FederationManager::new());
-        let commons_manager: Arc<CommonsManager> = if let Some(ref data_dir) = self.data_dir {
+        let commons_manager: Arc<CommonsManager> = if let Some(handle) = self.commons_handle {
+            // Canonical path: daemon injected a shared CommonsHandle.
+            // CommonsManager is a thin facade over this handle — no second sled store opened.
+            info!("CommonsManager: using shared CommonsHandle from daemon (actor-owned state)");
+            Arc::new(CommonsManager::with_handle(handle))
+        } else if let Some(ref data_dir) = self.data_dir {
+            // Fallback: no handle injected (gateway running standalone), open own sled store.
             let commons_path = data_dir.join("commons.sled");
-            info!("CommonsManager: opening sled store at {:?}", commons_path);
+            info!(
+                "CommonsManager: opening standalone sled store at {:?}",
+                commons_path
+            );
             Arc::new(
                 CommonsManager::with_sled_path(&commons_path)
                     .context("Failed to open commons sled store")?,

--- a/icn/crates/icn-gateway/tests/authority_enforcement_integration.rs
+++ b/icn/crates/icn-gateway/tests/authority_enforcement_integration.rs
@@ -1,6 +1,6 @@
 //! Authority enforcement integration tests.
 //!
-//! These tests prove the authority model implemented in Tranches 5–8:
+//! These tests prove the authority model implemented in Tranches 5–9:
 //!
 //! **Rule**: A caller may only perform membership/governance mutations on a
 //! cooperative/jurisdiction where they hold a delegated capability.  Holding
@@ -608,5 +608,83 @@ async fn hold_office_requires_explicit_delegation_not_enrollment() {
     assert!(
         after,
         "HoldOffice must be present after explicit delegation"
+    );
+}
+
+/// Tranche 9: join_jurisdiction rejects elevated capabilities at enrollment time.
+///
+/// `initial_capabilities` may only contain baseline capabilities (`Vote`,
+/// `Propose`, `Transact`). Attempting to seed an elevated capability
+/// (`HoldOffice`, `AccessPrivate`, `Sponsor`) via the enrollment path must
+/// return an error so that authority always flows from jurisdictional
+/// delegation, not from the caller's requested capabilities.
+#[actix_web::test]
+async fn join_jurisdiction_rejects_elevated_initial_capabilities() {
+    let mgr = CommonsManager::new();
+    create_charter(&mgr, "coop:guard-test").await;
+
+    let (_did, holder_id) = create_holder(&mgr).await;
+    let jurisdiction = JurisdictionId::new("coop:guard-test");
+
+    // Attempting to seed HoldOffice must fail at the inner guard
+    let result = mgr
+        .join_jurisdiction(
+            &holder_id,
+            jurisdiction.clone(),
+            vec![MembershipCapability::HoldOffice],
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "join_jurisdiction must reject HoldOffice in initial_capabilities"
+    );
+
+    // AccessPrivate is similarly rejected
+    let result = mgr
+        .join_jurisdiction(
+            &holder_id,
+            jurisdiction.clone(),
+            vec![MembershipCapability::AccessPrivate],
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "join_jurisdiction must reject AccessPrivate in initial_capabilities"
+    );
+
+    // Sponsor is similarly rejected
+    let result = mgr
+        .join_jurisdiction(
+            &holder_id,
+            jurisdiction.clone(),
+            vec![MembershipCapability::Sponsor],
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "join_jurisdiction must reject Sponsor in initial_capabilities"
+    );
+
+    // Baseline capabilities are accepted (none of these bailed → no affiliation recorded yet)
+    let result = mgr
+        .join_jurisdiction(
+            &holder_id,
+            jurisdiction.clone(),
+            vec![MembershipCapability::Vote, MembershipCapability::Transact],
+        )
+        .await;
+    assert!(
+        result.is_ok(),
+        "join_jurisdiction must accept baseline capabilities: {result:?}"
+    );
+
+    // Holder must not have HoldOffice after a baseline-seeded join
+    let has_hold_office = mgr
+        .member_has_capability(&holder_id, &jurisdiction, MembershipCapability::HoldOffice)
+        .await
+        .unwrap_or(false);
+    assert!(
+        !has_hold_office,
+        "HoldOffice must not be present after a baseline-seeded join"
     );
 }

--- a/icn/crates/icn-gateway/tests/authority_enforcement_integration.rs
+++ b/icn/crates/icn-gateway/tests/authority_enforcement_integration.rs
@@ -1,7 +1,6 @@
 //! Authority enforcement integration tests.
 //!
-//! These tests prove the authority model implemented in Tranche 5 and cleaned up
-//! in Tranche 6:
+//! These tests prove the authority model implemented in Tranches 5–8:
 //!
 //! **Rule**: A caller may only perform membership/governance mutations on a
 //! cooperative/jurisdiction where they hold a delegated capability.  Holding
@@ -71,7 +70,7 @@ async fn create_holder(mgr: &CommonsManager) -> (Did, String) {
 /// Enroll `holder_id` in `domain_id` and approve + promote them to full Member.
 async fn enroll_member(mgr: &CommonsManager, holder_id: &str, domain_id: &str) {
     let jurisdiction = JurisdictionId::new(domain_id);
-    mgr.apply_for_membership(holder_id, jurisdiction.clone(), vec![])
+    mgr.apply_for_membership(holder_id, jurisdiction.clone())
         .await
         .unwrap();
     mgr.approve_membership(holder_id, &jurisdiction)
@@ -271,7 +270,7 @@ async fn office_holder_can_promote_member_in_own_domain() {
     // Target: enrolled but still Provisional (just approved, not yet promoted)
     let (_target_did, target_id) = create_holder(&mgr).await;
     let jurisdiction = JurisdictionId::new("coop:alpha");
-    mgr.apply_for_membership(&target_id, jurisdiction.clone(), vec![])
+    mgr.apply_for_membership(&target_id, jurisdiction.clone())
         .await
         .unwrap();
     mgr.approve_membership(&target_id, &jurisdiction)
@@ -454,5 +453,160 @@ async fn plain_member_without_hold_office_can_satisfy_dispute_standing() {
     assert!(
         !has_office,
         "Plain member must NOT have HoldOffice — dispute filing and governance mutations are separate authority levels"
+    );
+}
+
+// ─── Tranche 8: Enrollment capability-origin invariant ───────────────────────
+//
+// These tests prove that capabilities originate from jurisdictional delegation,
+// not from applicant self-assertion.  Applying for membership, having the
+// application approved, and being promoted to full member must not produce any
+// capabilities except the baseline granted by `promote()`.
+
+/// Application creates a Candidate with no capabilities, regardless of what
+/// the application request conceptually "expressed."
+#[actix_web::test]
+async fn application_creates_candidate_with_no_capabilities() {
+    let mgr = CommonsManager::new();
+    create_charter(&mgr, "coop:alpha").await;
+
+    let (_did, applicant_id) = create_holder(&mgr).await;
+    let jurisdiction = JurisdictionId::new("coop:alpha");
+
+    // apply_for_membership creates a Candidate with no capabilities
+    mgr.apply_for_membership(&applicant_id, jurisdiction.clone())
+        .await
+        .unwrap();
+
+    let holder = mgr.get_holder(&applicant_id).await.unwrap().unwrap();
+    let affil = holder
+        .get_affiliation(&jurisdiction)
+        .expect("must have affiliation after application");
+
+    assert_eq!(format!("{}", affil.membership_status), "Candidate");
+    assert!(
+        affil.capabilities.is_empty(),
+        "Candidate must have no capabilities at application time"
+    );
+}
+
+/// Approval alone does not grant any capabilities — affiliation moves to
+/// Provisional but capability set remains empty.
+#[actix_web::test]
+async fn approval_does_not_grant_capabilities() {
+    let mgr = CommonsManager::new();
+    create_charter(&mgr, "coop:alpha").await;
+
+    let (_did, applicant_id) = create_holder(&mgr).await;
+    let jurisdiction = JurisdictionId::new("coop:alpha");
+
+    mgr.apply_for_membership(&applicant_id, jurisdiction.clone())
+        .await
+        .unwrap();
+    mgr.approve_membership(&applicant_id, &jurisdiction)
+        .await
+        .unwrap();
+
+    let holder = mgr.get_holder(&applicant_id).await.unwrap().unwrap();
+    let affil = holder
+        .get_affiliation(&jurisdiction)
+        .expect("must have affiliation after approval");
+
+    assert_eq!(format!("{}", affil.membership_status), "Provisional");
+    assert!(
+        affil.capabilities.is_empty(),
+        "Provisional member must have no capabilities — only promotion grants baseline capabilities"
+    );
+}
+
+/// Promotion grants exactly the baseline member capabilities.
+/// `HoldOffice` is absent without explicit delegation.
+#[actix_web::test]
+async fn promotion_grants_only_baseline_capabilities() {
+    let mgr = CommonsManager::new();
+    create_charter(&mgr, "coop:alpha").await;
+
+    let (_did, applicant_id) = create_holder(&mgr).await;
+    enroll_member(&mgr, &applicant_id, "coop:alpha").await;
+
+    let jurisdiction = JurisdictionId::new("coop:alpha");
+    let holder = mgr.get_holder(&applicant_id).await.unwrap().unwrap();
+    let affil = holder
+        .get_affiliation(&jurisdiction)
+        .expect("must have affiliation after promotion");
+
+    assert_eq!(format!("{}", affil.membership_status), "Member");
+
+    // Baseline capabilities are present
+    assert!(
+        affil.has_capability(MembershipCapability::Vote),
+        "Promoted member must have Vote"
+    );
+    assert!(
+        affil.has_capability(MembershipCapability::Propose),
+        "Promoted member must have Propose"
+    );
+    assert!(
+        affil.has_capability(MembershipCapability::Transact),
+        "Promoted member must have Transact"
+    );
+
+    // HoldOffice is NOT present — it requires explicit jurisdictional delegation
+    assert!(
+        !affil.has_capability(MembershipCapability::HoldOffice),
+        "Promoted member must NOT have HoldOffice — requires explicit delegation"
+    );
+
+    // The capability count is exactly 3 — no extras snuck in
+    assert_eq!(
+        affil.capabilities.len(),
+        3,
+        "Promoted member must have exactly the 3 baseline capabilities"
+    );
+}
+
+/// `HoldOffice` can only be obtained through explicit delegation by a
+/// jurisdiction office-holder, not through the application/promotion flow.
+#[actix_web::test]
+async fn hold_office_requires_explicit_delegation_not_enrollment() {
+    let mgr = CommonsManager::new();
+    create_charter(&mgr, "coop:alpha").await;
+
+    let (_did, applicant_id) = create_holder(&mgr).await;
+    enroll_member(&mgr, &applicant_id, "coop:alpha").await;
+
+    let jurisdiction = JurisdictionId::new("coop:alpha");
+
+    // After enrollment the member does NOT have HoldOffice
+    let before = mgr
+        .member_has_capability(
+            &applicant_id,
+            &jurisdiction,
+            MembershipCapability::HoldOffice,
+        )
+        .await
+        .unwrap_or(false);
+    assert!(!before, "HoldOffice must be absent after enrollment");
+
+    // Only explicit grant by a jurisdiction office-holder adds HoldOffice
+    mgr.grant_capability(
+        &applicant_id,
+        &jurisdiction,
+        MembershipCapability::HoldOffice,
+    )
+    .await
+    .unwrap();
+
+    let after = mgr
+        .member_has_capability(
+            &applicant_id,
+            &jurisdiction,
+            MembershipCapability::HoldOffice,
+        )
+        .await
+        .unwrap_or(false);
+    assert!(
+        after,
+        "HoldOffice must be present after explicit delegation"
     );
 }

--- a/icn/crates/icn-gateway/tests/authority_enforcement_integration.rs
+++ b/icn/crates/icn-gateway/tests/authority_enforcement_integration.rs
@@ -1,20 +1,22 @@
 //! Authority enforcement integration tests.
 //!
-//! These tests prove the authority model implemented in Tranche 5:
+//! These tests prove the authority model implemented in Tranche 5 and cleaned up
+//! in Tranche 6:
 //!
 //! **Rule**: A caller may only perform membership/governance mutations on a
-//! cooperative/jurisdiction they govern.  Holding office in `coop:alpha` does
-//! NOT confer authority over `coop:beta`.
+//! cooperative/jurisdiction where they hold a delegated capability.  Holding
+//! office in `coop:alpha` does NOT confer authority over `coop:beta`.
 //!
 //! Every test that exercises cross-domain rejection is marked with the pattern
-//! it closes: "coop:A admin cannot act on coop:B".
+//! it closes: "office-holder in coop:A cannot act on coop:B".
 //!
 //! ## What is tested
-//! - `member_has_capability` (the primitive that `require_jurisdiction_authority`
-//!   delegates to) enforces exact-domain isolation for `HoldOffice`.
-//! - A member with `HoldOffice` in domain A does NOT satisfy the check for
+//! - `member_has_capability` (the primitive that `require_office_in_jurisdiction`
+//!   and `require_membership_in_jurisdiction` delegate to) enforces exact-domain
+//!   isolation for `HoldOffice` and `Vote` respectively.
+//! - A member with `HoldOffice` in domain A does NOT satisfy the office check for
 //!   domain B (cross-domain isolation).
-//! - A member without `HoldOffice` in any domain cannot pass the check.
+//! - A member without `HoldOffice` in any domain cannot pass the office check.
 //! - The check returns `true` only for the exact jurisdiction the capability
 //!   was granted in.
 //! - Membership state mutations (promote, suspend, grant capability) succeed
@@ -22,8 +24,8 @@
 //!   who is only authorized in a different domain.
 //!
 //! ## Layer under test
-//! The `require_jurisdiction_authority` helper in the membership and steward
-//! handlers calls `CommonsManager::get_holder_by_did` and
+//! The `require_office_in_jurisdiction` and `require_membership_in_jurisdiction`
+//! helpers in `crate::authority` call `CommonsManager::get_holder_by_did` and
 //! `CommonsManager::member_has_capability`.  Both are tested here at the
 //! CommonsManager level, which is the substrate the handlers rely on.
 
@@ -90,7 +92,7 @@ async fn grant_hold_office(mgr: &CommonsManager, holder_id: &str, domain_id: &st
 
 /// Baseline: a holder with HoldOffice in their own domain satisfies the authority check.
 #[actix_web::test]
-async fn authority_check_passes_for_valid_jurisdiction_admin() {
+async fn authority_check_passes_for_jurisdiction_office_holder() {
     let mgr = CommonsManager::new();
     create_charter(&mgr, "coop:alpha").await;
 
@@ -191,7 +193,7 @@ async fn authority_check_cross_domain_rejected() {
 }
 
 /// Cross-domain isolation with explicit beta enrollment (no HoldOffice there):
-/// being a plain member of both coops does not grant admin rights in either.
+/// being a plain member of both coops does not grant HoldOffice authority in either.
 #[actix_web::test]
 async fn authority_check_membership_without_hold_office_cross_domain() {
     let mgr = CommonsManager::new();
@@ -254,10 +256,10 @@ async fn authority_check_revoked_capability_is_absent() {
     );
 }
 
-/// Mutation semantics: an authorized admin can promote a target member;
-/// the target's status changes as expected.
+/// Mutation semantics: an office-holder in a jurisdiction can promote a target
+/// member; the target's status changes as expected.
 #[actix_web::test]
-async fn authorized_admin_can_promote_member_in_own_domain() {
+async fn office_holder_can_promote_member_in_own_domain() {
     let mgr = CommonsManager::new();
     create_charter(&mgr, "coop:alpha").await;
 
@@ -301,14 +303,14 @@ async fn authorized_admin_can_promote_member_in_own_domain() {
     );
 }
 
-/// Cross-domain isolation for mutations: an admin in coop:alpha cannot
-/// meaningfully claim authority to act on coop:beta.
+/// Cross-domain isolation for mutations: an office-holder in coop:alpha cannot
+/// claim authority to act on coop:beta.
 ///
-/// This directly proves the `require_jurisdiction_authority` pre-condition:
+/// This directly proves the `require_office_in_jurisdiction` pre-condition:
 /// a caller from domain A will fail the HoldOffice check for domain B
 /// before the underlying mutation method is even invoked.
 #[actix_web::test]
-async fn cross_domain_admin_cannot_satisfy_authority_for_other_domain() {
+async fn cross_domain_office_holder_cannot_act_on_other_domain() {
     let mgr = CommonsManager::new();
     create_charter(&mgr, "coop:alpha").await;
     create_charter(&mgr, "coop:beta").await;
@@ -331,6 +333,126 @@ async fn cross_domain_admin_cannot_satisfy_authority_for_other_domain() {
 
     assert!(
         !has_beta_authority,
-        "coop:alpha admin must fail authority check for coop:beta — the handler rejects before mutation"
+        "coop:alpha office-holder must fail authority check for coop:beta — the handler rejects before mutation"
+    );
+}
+
+// ─── Dispute-Filing Authority Tests ─────────────────────────────────────────
+//
+// These tests cover the member-standing gate used by `record_dispute`.
+// Filing a dispute requires full `Member` status in the steward's jurisdiction,
+// NOT `HoldOffice`.  The gate checks membership status directly (not a
+// capability) because capabilities are not auto-granted during the enrollment
+// flow — status is the authoritative marker for full membership.
+
+/// A full member (Member status) in the steward's jurisdiction has
+/// member-standing and can satisfy the dispute-filing check.
+#[actix_web::test]
+async fn full_member_has_standing_to_file_dispute() {
+    let mgr = CommonsManager::new();
+    create_charter(&mgr, "coop:alpha").await;
+
+    let (_did, member_id) = create_holder(&mgr).await;
+    enroll_member(&mgr, &member_id, "coop:alpha").await;
+    // enroll_member applies + approves + promotes → status is Member
+
+    let holder = mgr.get_holder(&member_id).await.unwrap().unwrap();
+    let jurisdiction = JurisdictionId::new("coop:alpha");
+    let affiliation = holder
+        .get_affiliation(&jurisdiction)
+        .expect("must have affiliation");
+
+    assert_eq!(
+        format!("{}", affiliation.membership_status),
+        "Member",
+        "Full member must have Member status — required for dispute-filing standing"
+    );
+}
+
+/// An unenrolled outsider has no affiliation and must be rejected by the
+/// dispute-filing check.
+#[actix_web::test]
+async fn outsider_lacks_standing_to_file_dispute() {
+    let mgr = CommonsManager::new();
+    create_charter(&mgr, "coop:alpha").await;
+
+    let (_did, outsider_id) = create_holder(&mgr).await;
+    // outsider is never enrolled — no affiliation in any jurisdiction
+
+    let holder = mgr.get_holder(&outsider_id).await.unwrap().unwrap();
+    let jurisdiction = JurisdictionId::new("coop:alpha");
+    let affiliation = holder.get_affiliation(&jurisdiction);
+
+    assert!(
+        affiliation.is_none(),
+        "Unenrolled outsider must have no affiliation — cannot satisfy dispute-filing standing"
+    );
+}
+
+/// Cross-jurisdiction: Member status in coop:alpha does NOT confer standing in
+/// coop:beta.  A member of one cooperative cannot file disputes against stewards
+/// in another cooperative's jurisdiction.
+#[actix_web::test]
+async fn cross_domain_member_cannot_file_dispute_in_other_jurisdiction() {
+    let mgr = CommonsManager::new();
+    create_charter(&mgr, "coop:alpha").await;
+    create_charter(&mgr, "coop:beta").await;
+
+    let (_did, alpha_member_id) = create_holder(&mgr).await;
+    enroll_member(&mgr, &alpha_member_id, "coop:alpha").await;
+
+    let holder = mgr.get_holder(&alpha_member_id).await.unwrap().unwrap();
+    let alpha = JurisdictionId::new("coop:alpha");
+    let beta = JurisdictionId::new("coop:beta");
+
+    // Is a full member in alpha
+    let alpha_affiliation = holder
+        .get_affiliation(&alpha)
+        .expect("must have alpha affiliation");
+    assert_eq!(
+        format!("{}", alpha_affiliation.membership_status),
+        "Member",
+        "Precondition: must be a full member in own jurisdiction"
+    );
+
+    // Has no affiliation in beta at all
+    assert!(
+        holder.get_affiliation(&beta).is_none(),
+        "Member of coop:alpha must have no affiliation in coop:beta — cross-domain dispute standing is prohibited"
+    );
+}
+
+/// Dispute filing does NOT require HoldOffice — a plain member satisfies the
+/// standing check; `HoldOffice` is only required for governance mutations.
+#[actix_web::test]
+async fn plain_member_without_hold_office_can_satisfy_dispute_standing() {
+    let mgr = CommonsManager::new();
+    create_charter(&mgr, "coop:alpha").await;
+
+    let (_did, member_id) = create_holder(&mgr).await;
+    enroll_member(&mgr, &member_id, "coop:alpha").await;
+    // No HoldOffice granted — plain full member
+
+    let jurisdiction = JurisdictionId::new("coop:alpha");
+
+    // Has Member status (dispute standing)
+    let holder = mgr.get_holder(&member_id).await.unwrap().unwrap();
+    let affiliation = holder
+        .get_affiliation(&jurisdiction)
+        .expect("must have affiliation");
+    assert_eq!(
+        format!("{}", affiliation.membership_status),
+        "Member",
+        "Plain member must have Member status for dispute-filing standing"
+    );
+
+    // Does NOT have HoldOffice (governance gate requires explicit grant)
+    let has_office = mgr
+        .member_has_capability(&member_id, &jurisdiction, MembershipCapability::HoldOffice)
+        .await
+        .unwrap_or(false);
+    assert!(
+        !has_office,
+        "Plain member must NOT have HoldOffice — dispute filing and governance mutations are separate authority levels"
     );
 }

--- a/icn/crates/icn-gateway/tests/authority_enforcement_integration.rs
+++ b/icn/crates/icn-gateway/tests/authority_enforcement_integration.rs
@@ -1,0 +1,336 @@
+//! Authority enforcement integration tests.
+//!
+//! These tests prove the authority model implemented in Tranche 5:
+//!
+//! **Rule**: A caller may only perform membership/governance mutations on a
+//! cooperative/jurisdiction they govern.  Holding office in `coop:alpha` does
+//! NOT confer authority over `coop:beta`.
+//!
+//! Every test that exercises cross-domain rejection is marked with the pattern
+//! it closes: "coop:A admin cannot act on coop:B".
+//!
+//! ## What is tested
+//! - `member_has_capability` (the primitive that `require_jurisdiction_authority`
+//!   delegates to) enforces exact-domain isolation for `HoldOffice`.
+//! - A member with `HoldOffice` in domain A does NOT satisfy the check for
+//!   domain B (cross-domain isolation).
+//! - A member without `HoldOffice` in any domain cannot pass the check.
+//! - The check returns `true` only for the exact jurisdiction the capability
+//!   was granted in.
+//! - Membership state mutations (promote, suspend, grant capability) succeed
+//!   when called by a properly authorized actor and fail when called by one
+//!   who is only authorized in a different domain.
+//!
+//! ## Layer under test
+//! The `require_jurisdiction_authority` helper in the membership and steward
+//! handlers calls `CommonsManager::get_holder_by_did` and
+//! `CommonsManager::member_has_capability`.  Both are tested here at the
+//! CommonsManager level, which is the substrate the handlers rely on.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use icn_gateway::commons_mgr::CommonsManager;
+use icn_governance::{Charter, DisputePolicy, GovernanceConfig, MembershipPolicy, OrgType};
+use icn_identity::{Did, JurisdictionId, KeyPair, MembershipCapability};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Create a charter for `domain_id` and store it.
+async fn create_charter(mgr: &CommonsManager, domain_id: &str) {
+    let charter = Charter::new(
+        OrgType::Cooperative,
+        domain_id.to_string(),
+        format!("Test Coop for {domain_id}"),
+        GovernanceConfig::cooperative_default(),
+        MembershipPolicy::default(),
+        DisputePolicy::default(),
+    );
+    mgr.store_charter(charter).await.unwrap();
+}
+
+/// Create a commons holder from a freshly generated keypair.  Returns `(Did, holder_id_hex)`.
+async fn create_holder(mgr: &CommonsManager) -> (Did, String) {
+    let kp = KeyPair::generate().unwrap();
+    let did = kp.did().clone();
+    // Sponsored enrollment gives Strong POP (required to avoid weak-POP rejection)
+    let sponsor_kp = KeyPair::generate().unwrap();
+    let anchor = mgr
+        .create_anchor_from_enrollment(&did, Some(sponsor_kp.did()))
+        .await
+        .unwrap();
+    let anchor_id = hex::encode(anchor.id());
+    let holder = mgr
+        .create_holder_from_anchor(&anchor_id, &did)
+        .await
+        .unwrap();
+    (did, hex::encode(holder.id()))
+}
+
+/// Enroll `holder_id` in `domain_id` and approve + promote them to full Member.
+async fn enroll_member(mgr: &CommonsManager, holder_id: &str, domain_id: &str) {
+    let jurisdiction = JurisdictionId::new(domain_id);
+    mgr.apply_for_membership(holder_id, jurisdiction.clone(), vec![])
+        .await
+        .unwrap();
+    mgr.approve_membership(holder_id, &jurisdiction)
+        .await
+        .unwrap();
+    mgr.promote_member(holder_id, &jurisdiction).await.unwrap();
+}
+
+/// Grant `HoldOffice` to `holder_id` in `domain_id`.
+async fn grant_hold_office(mgr: &CommonsManager, holder_id: &str, domain_id: &str) {
+    let jurisdiction = JurisdictionId::new(domain_id);
+    mgr.grant_capability(holder_id, &jurisdiction, MembershipCapability::HoldOffice)
+        .await
+        .unwrap();
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+/// Baseline: a holder with HoldOffice in their own domain satisfies the authority check.
+#[actix_web::test]
+async fn authority_check_passes_for_valid_jurisdiction_admin() {
+    let mgr = CommonsManager::new();
+    create_charter(&mgr, "coop:alpha").await;
+
+    let (_did, admin_id) = create_holder(&mgr).await;
+    enroll_member(&mgr, &admin_id, "coop:alpha").await;
+    grant_hold_office(&mgr, &admin_id, "coop:alpha").await;
+
+    let jurisdiction = JurisdictionId::new("coop:alpha");
+    let has = mgr
+        .member_has_capability(&admin_id, &jurisdiction, MembershipCapability::HoldOffice)
+        .await
+        .unwrap_or(false);
+
+    assert!(
+        has,
+        "HoldOffice in own domain must return true for the authority check"
+    );
+}
+
+/// A holder without HoldOffice cannot pass the authority check, even in their own domain.
+#[actix_web::test]
+async fn authority_check_fails_without_hold_office() {
+    let mgr = CommonsManager::new();
+    create_charter(&mgr, "coop:alpha").await;
+
+    let (_did, member_id) = create_holder(&mgr).await;
+    enroll_member(&mgr, &member_id, "coop:alpha").await;
+    // No HoldOffice granted — member has only basic Vote + Propose defaults
+
+    let jurisdiction = JurisdictionId::new("coop:alpha");
+    let has = mgr
+        .member_has_capability(&member_id, &jurisdiction, MembershipCapability::HoldOffice)
+        .await
+        .unwrap_or(false);
+
+    assert!(
+        !has,
+        "HoldOffice must be false when not explicitly granted; regular members cannot pass authority check"
+    );
+}
+
+/// A caller who is not a member of any domain does not satisfy the authority check.
+#[actix_web::test]
+async fn authority_check_fails_for_non_member() {
+    let mgr = CommonsManager::new();
+    create_charter(&mgr, "coop:alpha").await;
+
+    let (_did, outsider_id) = create_holder(&mgr).await;
+    // outsider_id was never enrolled — no affiliation record exists
+
+    let jurisdiction = JurisdictionId::new("coop:alpha");
+    let has = mgr
+        .member_has_capability(
+            &outsider_id,
+            &jurisdiction,
+            MembershipCapability::HoldOffice,
+        )
+        .await
+        .unwrap_or(false);
+
+    assert!(
+        !has,
+        "Non-member must not satisfy HoldOffice authority check in any jurisdiction"
+    );
+}
+
+/// Cross-domain isolation: HoldOffice in `coop:alpha` does NOT satisfy the
+/// authority check for `coop:beta`.  This is the core exploit we close.
+#[actix_web::test]
+async fn authority_check_cross_domain_rejected() {
+    let mgr = CommonsManager::new();
+    create_charter(&mgr, "coop:alpha").await;
+    create_charter(&mgr, "coop:beta").await;
+
+    // Admin is a full member with HoldOffice in coop:alpha only
+    let (_did, admin_id) = create_holder(&mgr).await;
+    enroll_member(&mgr, &admin_id, "coop:alpha").await;
+    grant_hold_office(&mgr, &admin_id, "coop:alpha").await;
+
+    // Alpha admin DOES have authority in alpha
+    let alpha = JurisdictionId::new("coop:alpha");
+    let has_alpha = mgr
+        .member_has_capability(&admin_id, &alpha, MembershipCapability::HoldOffice)
+        .await
+        .unwrap_or(false);
+    assert!(has_alpha, "Admin must have HoldOffice in their own domain");
+
+    // Alpha admin does NOT have authority in beta
+    let beta = JurisdictionId::new("coop:beta");
+    let has_beta = mgr
+        .member_has_capability(&admin_id, &beta, MembershipCapability::HoldOffice)
+        .await
+        .unwrap_or(false);
+    assert!(
+        !has_beta,
+        "coop:alpha admin must NOT satisfy authority check for coop:beta — cross-domain leakage"
+    );
+}
+
+/// Cross-domain isolation with explicit beta enrollment (no HoldOffice there):
+/// being a plain member of both coops does not grant admin rights in either.
+#[actix_web::test]
+async fn authority_check_membership_without_hold_office_cross_domain() {
+    let mgr = CommonsManager::new();
+    create_charter(&mgr, "coop:alpha").await;
+    create_charter(&mgr, "coop:beta").await;
+
+    let (_did, holder_id) = create_holder(&mgr).await;
+    enroll_member(&mgr, &holder_id, "coop:alpha").await;
+    enroll_member(&mgr, &holder_id, "coop:beta").await;
+    // HoldOffice only in alpha
+    grant_hold_office(&mgr, &holder_id, "coop:alpha").await;
+
+    let beta = JurisdictionId::new("coop:beta");
+    let has = mgr
+        .member_has_capability(&holder_id, &beta, MembershipCapability::HoldOffice)
+        .await
+        .unwrap_or(false);
+    assert!(
+        !has,
+        "Being a member of coop:beta without HoldOffice there must fail the authority check"
+    );
+}
+
+/// A member promoted to full Member in domain A, then suspended, no longer satisfies
+/// HoldOffice — demonstrates capability isolation is per-membership state.
+///
+/// This test verifies the underlying data model remains correct: revoked capability
+/// is truly absent.
+#[actix_web::test]
+async fn authority_check_revoked_capability_is_absent() {
+    let mgr = CommonsManager::new();
+    create_charter(&mgr, "coop:alpha").await;
+
+    let (_did, holder_id) = create_holder(&mgr).await;
+    enroll_member(&mgr, &holder_id, "coop:alpha").await;
+    grant_hold_office(&mgr, &holder_id, "coop:alpha").await;
+
+    // Confirm capability present
+    let jurisdiction = JurisdictionId::new("coop:alpha");
+    assert!(
+        mgr.member_has_capability(&holder_id, &jurisdiction, MembershipCapability::HoldOffice)
+            .await
+            .unwrap_or(false),
+        "Precondition: HoldOffice must be present before revocation"
+    );
+
+    // Revoke HoldOffice
+    mgr.revoke_capability(&holder_id, &jurisdiction, MembershipCapability::HoldOffice)
+        .await
+        .unwrap();
+
+    // Capability must be absent now
+    let has = mgr
+        .member_has_capability(&holder_id, &jurisdiction, MembershipCapability::HoldOffice)
+        .await
+        .unwrap_or(false);
+    assert!(
+        !has,
+        "Revoked HoldOffice capability must not satisfy the authority check"
+    );
+}
+
+/// Mutation semantics: an authorized admin can promote a target member;
+/// the target's status changes as expected.
+#[actix_web::test]
+async fn authorized_admin_can_promote_member_in_own_domain() {
+    let mgr = CommonsManager::new();
+    create_charter(&mgr, "coop:alpha").await;
+
+    // Admin with HoldOffice
+    let (_admin_did, admin_id) = create_holder(&mgr).await;
+    enroll_member(&mgr, &admin_id, "coop:alpha").await;
+    grant_hold_office(&mgr, &admin_id, "coop:alpha").await;
+
+    // Target: enrolled but still Provisional (just approved, not yet promoted)
+    let (_target_did, target_id) = create_holder(&mgr).await;
+    let jurisdiction = JurisdictionId::new("coop:alpha");
+    mgr.apply_for_membership(&target_id, jurisdiction.clone(), vec![])
+        .await
+        .unwrap();
+    mgr.approve_membership(&target_id, &jurisdiction)
+        .await
+        .unwrap();
+
+    // Admin has authority — confirm before acting
+    assert!(
+        mgr.member_has_capability(&admin_id, &jurisdiction, MembershipCapability::HoldOffice)
+            .await
+            .unwrap_or(false),
+        "Admin must have HoldOffice to authorize the promote action"
+    );
+
+    // Perform promotion (the action the handler delegates to after authority check)
+    mgr.promote_member(&target_id, &jurisdiction)
+        .await
+        .expect("Authorized admin promotion must succeed");
+
+    // Verify target is now a full Member
+    let holder = mgr.get_holder(&target_id).await.unwrap().unwrap();
+    let affiliation = holder
+        .get_affiliation(&jurisdiction)
+        .expect("Target must have affiliation");
+    assert_eq!(
+        format!("{}", affiliation.membership_status),
+        "Member",
+        "Target must be promoted to full Member"
+    );
+}
+
+/// Cross-domain isolation for mutations: an admin in coop:alpha cannot
+/// meaningfully claim authority to act on coop:beta.
+///
+/// This directly proves the `require_jurisdiction_authority` pre-condition:
+/// a caller from domain A will fail the HoldOffice check for domain B
+/// before the underlying mutation method is even invoked.
+#[actix_web::test]
+async fn cross_domain_admin_cannot_satisfy_authority_for_other_domain() {
+    let mgr = CommonsManager::new();
+    create_charter(&mgr, "coop:alpha").await;
+    create_charter(&mgr, "coop:beta").await;
+
+    // Alpha admin
+    let (_admin_did, alpha_admin_id) = create_holder(&mgr).await;
+    enroll_member(&mgr, &alpha_admin_id, "coop:alpha").await;
+    grant_hold_office(&mgr, &alpha_admin_id, "coop:alpha").await;
+
+    // Beta member (the intended target of the cross-domain attack)
+    let (_target_did, beta_member_id) = create_holder(&mgr).await;
+    enroll_member(&mgr, &beta_member_id, "coop:beta").await;
+
+    // The authority check for beta jurisdiction fails for the alpha admin
+    let beta = JurisdictionId::new("coop:beta");
+    let has_beta_authority = mgr
+        .member_has_capability(&alpha_admin_id, &beta, MembershipCapability::HoldOffice)
+        .await
+        .unwrap_or(false);
+
+    assert!(
+        !has_beta_authority,
+        "coop:alpha admin must fail authority check for coop:beta — the handler rejects before mutation"
+    );
+}

--- a/icn/crates/icn-gateway/tests/boundary_scope_integration.rs
+++ b/icn/crates/icn-gateway/tests/boundary_scope_integration.rs
@@ -1,0 +1,237 @@
+//! Boundary scope integrity tests for CommonsManager.
+//!
+//! These tests verify that the gateway facade layer enforces semantic
+//! consistency from the API boundary to the substrate.  They complement
+//! the substrate-level tests in icn-commons/tests/scope_enforcement.rs by
+//! covering the gateway manager's own scope-safety guarantees.
+//!
+//! Invariants proven:
+//! 1. `build_governance_dashboard` returns an error for an unknown charter_id
+//!    rather than silently falling back to a cross-domain "list all" query.
+//! 2. Dashboard data is scoped to the charter's domain — records from other
+//!    domains are NOT included.
+//! 3. `list_amendments_by_domain` on CommonsManager delegates to the
+//!    domain-scoped substrate method (exact-match isolation).
+//! 4. `list_appeals_by_domain` on CommonsManager has the same guarantee.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use icn_gateway::commons_mgr::CommonsManager;
+use icn_governance::{
+    Amendment, AmendmentScope, AmendmentType, Appeal, AppealGrounds, AppealRemedy, AppealScope,
+    AppealType, Charter, DisputePolicy, GovernanceConfig, MembershipPolicy, OrgType,
+};
+use icn_identity::{Did, KeyPair};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+fn make_did() -> Did {
+    KeyPair::generate().unwrap().did().clone()
+}
+
+/// Create and store a charter for `domain_id`, returning its hex charter_id.
+async fn setup_charter(mgr: &CommonsManager, domain_id: &str) -> String {
+    let charter = Charter::new(
+        OrgType::Cooperative,
+        domain_id.to_string(),
+        format!("Test Coop for {domain_id}"),
+        GovernanceConfig::cooperative_default(),
+        MembershipPolicy::default(),
+        DisputePolicy::default(),
+    );
+    let id = charter.charter_id.to_hex();
+    mgr.store_charter(charter).await.expect("store charter");
+    id
+}
+
+/// Store a jurisdiction-scoped amendment for `domain_id`.
+async fn store_amendment(mgr: &CommonsManager, domain_id: &str, title: &str) {
+    let amendment = Amendment::new(
+        AmendmentType::Policy,
+        AmendmentScope::Jurisdiction {
+            domain_id: domain_id.to_string(),
+        },
+        title.to_string(),
+        format!("Test amendment body for {domain_id}"),
+        make_did(),
+    );
+    mgr.store_amendment(amendment)
+        .await
+        .expect("store amendment");
+}
+
+/// Store a jurisdiction-scoped appeal for `domain_id`.
+async fn store_appeal(mgr: &CommonsManager, domain_id: &str) {
+    let appeal = Appeal::new(
+        AppealType::MembershipDenial {
+            jurisdiction_id: domain_id.to_string(),
+            application_id: None,
+        },
+        AppealScope::Jurisdiction {
+            domain_id: domain_id.to_string(),
+        },
+        make_did(),
+        vec![AppealGrounds::ProceduralError {
+            description: "boundary test".to_string(),
+        }],
+        format!("Appeal for {domain_id}"),
+        AppealRemedy::Reinstate,
+    );
+    mgr.store_appeal(appeal).await.expect("store appeal");
+}
+
+// ─── Dashboard Boundary Tests ─────────────────────────────────────────────────
+
+/// `build_governance_dashboard` must return an error when given a charter_id
+/// that does not exist — it must NOT silently widen scope to all records.
+#[actix_web::test]
+async fn dashboard_unknown_charter_returns_error_not_all_records() {
+    let mgr = CommonsManager::new();
+
+    // Store an amendment so we can verify it doesn't appear in the fallback
+    setup_charter(&mgr, "coop:real").await;
+    store_amendment(&mgr, "coop:real", "Real amendment").await;
+
+    let bogus_hex = "a".repeat(64); // 32 bytes of 0xaa — valid hex, no matching charter
+    let result = mgr.build_governance_dashboard(&bogus_hex).await;
+
+    assert!(
+        result.is_err(),
+        "build_governance_dashboard must error for unknown charter_id, not return all records"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("Charter not found") || msg.contains("not found"),
+        "error message should indicate missing charter; got: {msg}"
+    );
+}
+
+/// Dashboard data is scoped to the charter's domain.  Amendments belonging to
+/// a different domain must not appear in the result.
+#[actix_web::test]
+async fn dashboard_scoped_to_charter_domain_only() {
+    let mgr = CommonsManager::new();
+
+    let alpha_id = setup_charter(&mgr, "coop:alpha").await;
+    setup_charter(&mgr, "coop:beta").await;
+
+    store_amendment(&mgr, "coop:alpha", "Alpha-only amendment").await;
+    store_amendment(&mgr, "coop:beta", "Beta amendment — must not appear").await;
+
+    let dashboard = mgr
+        .build_governance_dashboard(&alpha_id)
+        .await
+        .expect("dashboard for known charter must succeed");
+
+    // Total amendments count must be 1 (alpha only)
+    let total = dashboard.amendments_breakdown.draft
+        + dashboard.amendments_breakdown.submitted
+        + dashboard.amendments_breakdown.voting
+        + dashboard.amendments_breakdown.ratified
+        + dashboard.amendments_breakdown.rejected
+        + dashboard.amendments_breakdown.withdrawn;
+
+    assert_eq!(
+        total, 1,
+        "dashboard must count only amendments scoped to coop:alpha; got {total}"
+    );
+}
+
+/// Dashboard is consistent even when no amendments or appeals exist for the domain.
+#[actix_web::test]
+async fn dashboard_empty_domain_returns_zeroes() {
+    let mgr = CommonsManager::new();
+
+    let id = setup_charter(&mgr, "coop:empty").await;
+
+    // Different domain has data — should not leak into coop:empty dashboard
+    setup_charter(&mgr, "coop:noisy").await;
+    store_amendment(&mgr, "coop:noisy", "Noisy amendment").await;
+    store_appeal(&mgr, "coop:noisy").await;
+
+    let dashboard = mgr
+        .build_governance_dashboard(&id)
+        .await
+        .expect("dashboard for known charter must succeed");
+
+    let total_amendments = dashboard.amendments_breakdown.draft
+        + dashboard.amendments_breakdown.submitted
+        + dashboard.amendments_breakdown.voting
+        + dashboard.amendments_breakdown.ratified
+        + dashboard.amendments_breakdown.rejected
+        + dashboard.amendments_breakdown.withdrawn;
+
+    let total_appeals = dashboard.appeals_breakdown.filed
+        + dashboard.appeals_breakdown.under_review
+        + dashboard.appeals_breakdown.hearing
+        + dashboard.appeals_breakdown.resolved
+        + dashboard.appeals_breakdown.dismissed
+        + dashboard.appeals_breakdown.withdrawn;
+
+    assert_eq!(
+        total_amendments, 0,
+        "empty domain dashboard must have zero amendments"
+    );
+    assert_eq!(
+        total_appeals, 0,
+        "empty domain dashboard must have zero appeals"
+    );
+}
+
+// ─── List Delegation Tests ────────────────────────────────────────────────────
+
+/// `CommonsManager::list_amendments_by_domain` must return only records for
+/// the requested domain, matching the substrate's exact-match guarantee.
+#[actix_web::test]
+async fn list_amendments_by_domain_delegates_to_exact_match() {
+    let mgr = CommonsManager::new();
+
+    setup_charter(&mgr, "coop:delta").await;
+    setup_charter(&mgr, "coop:gamma").await;
+
+    store_amendment(&mgr, "coop:delta", "Delta amendment").await;
+    store_amendment(&mgr, "coop:gamma", "Gamma amendment").await;
+
+    let delta = mgr
+        .list_amendments_by_domain("coop:delta")
+        .await
+        .expect("list_amendments_by_domain must succeed");
+
+    assert_eq!(
+        delta.len(),
+        1,
+        "must return exactly one amendment for coop:delta"
+    );
+    assert_eq!(delta[0].title, "Delta amendment");
+}
+
+/// `CommonsManager::list_appeals_by_domain` must return only records for
+/// the requested domain, matching the substrate's exact-match guarantee.
+#[actix_web::test]
+async fn list_appeals_by_domain_delegates_to_exact_match() {
+    let mgr = CommonsManager::new();
+
+    setup_charter(&mgr, "coop:epsilon").await;
+    setup_charter(&mgr, "coop:zeta").await;
+
+    store_appeal(&mgr, "coop:epsilon").await;
+    store_appeal(&mgr, "coop:zeta").await;
+
+    let epsilon = mgr
+        .list_appeals_by_domain("coop:epsilon")
+        .await
+        .expect("list_appeals_by_domain must succeed");
+
+    assert_eq!(
+        epsilon.len(),
+        1,
+        "must return exactly one appeal for coop:epsilon"
+    );
+    assert!(
+        matches!(
+            &epsilon[0].scope,
+            AppealScope::Jurisdiction { domain_id } if domain_id == "coop:epsilon"
+        ),
+        "returned appeal must be scoped to coop:epsilon"
+    );
+}

--- a/icn/crates/icn-gateway/tests/commons_integration.rs
+++ b/icn/crates/icn-gateway/tests/commons_integration.rs
@@ -406,3 +406,111 @@ async fn test_anchor_status_updates() {
     let found = commons_mgr.get_anchor(&anchor_id).await.unwrap().unwrap();
     assert!(matches!(found.status, AnchorStatus::Active));
 }
+
+// ============================================================================
+// Layer 1 — Sled persistence proof tests (drop-and-reopen)
+// ============================================================================
+
+/// Prove that PersonhoodAnchor survives a CommonsManager drop-and-reopen boundary.
+#[actix_web::test]
+async fn test_commons_anchor_survives_sled_drop_and_reopen() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sled_path = tmp.path().join("commons.sled");
+
+    let keypair = icn_identity::KeyPair::generate().unwrap();
+    let did = keypair.did().clone();
+
+    // Phase 1: write
+    let anchor_id = {
+        let mgr = CommonsManager::with_sled_path(&sled_path).expect("open sled");
+        let anchor = mgr.create_anchor_from_enrollment(&did, None).await.unwrap();
+        hex::encode(anchor.id())
+        // mgr drops here — sled lock released
+    };
+
+    // Phase 2: reopen fresh instance
+    let mgr2 = CommonsManager::with_sled_path(&sled_path).expect("reopen sled");
+    let found = mgr2.get_anchor(&anchor_id).await.unwrap();
+    assert!(
+        found.is_some(),
+        "PersonhoodAnchor must survive sled drop-and-reopen"
+    );
+    // Verify the DID-to-anchor index also survived
+    let by_did = mgr2.get_anchor_by_did(&did).await.unwrap();
+    assert!(
+        by_did.is_some(),
+        "DID index must survive sled drop-and-reopen"
+    );
+}
+
+/// Prove that Charter survives a CommonsManager drop-and-reopen boundary.
+#[actix_web::test]
+async fn test_commons_charter_survives_sled_drop_and_reopen() {
+    use icn_governance::{Charter, DisputePolicy, GovernanceConfig, MembershipPolicy, OrgType};
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sled_path = tmp.path().join("commons.sled");
+
+    // Phase 1: write
+    let charter_id = {
+        let mgr = CommonsManager::with_sled_path(&sled_path).expect("open sled");
+        let charter = Charter::new(
+            OrgType::Cooperative,
+            "coop:persist-test".to_string(),
+            "Persistence Test Coop".to_string(),
+            GovernanceConfig::cooperative_default(),
+            MembershipPolicy::default(),
+            DisputePolicy::default(),
+        );
+        let id = charter.charter_id.to_hex();
+        mgr.store_charter(charter).await.unwrap();
+        id
+        // mgr drops here
+    };
+
+    // Phase 2: reopen fresh instance
+    let mgr2 = CommonsManager::with_sled_path(&sled_path).expect("reopen sled");
+    let found = mgr2.get_charter(&charter_id).await.unwrap();
+    assert!(found.is_some(), "Charter must survive sled drop-and-reopen");
+    assert_eq!(
+        found.unwrap().name,
+        "Persistence Test Coop",
+        "name must survive round-trip"
+    );
+}
+
+/// Prove that CommonsHolderRecord survives a CommonsManager drop-and-reopen boundary.
+#[actix_web::test]
+async fn test_commons_holder_survives_sled_drop_and_reopen() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sled_path = tmp.path().join("commons.sled");
+
+    let keypair = icn_identity::KeyPair::generate().unwrap();
+    let did = keypair.did().clone();
+
+    // Phase 1: write anchor + holder
+    let holder_id = {
+        let mgr = CommonsManager::with_sled_path(&sled_path).expect("open sled");
+        let anchor = mgr.create_anchor_from_enrollment(&did, None).await.unwrap();
+        let anchor_id = hex::encode(anchor.id());
+        let holder = mgr
+            .create_holder_from_anchor(&anchor_id, &did)
+            .await
+            .unwrap();
+        hex::encode(holder.id())
+        // mgr drops here
+    };
+
+    // Phase 2: reopen fresh instance
+    let mgr2 = CommonsManager::with_sled_path(&sled_path).expect("reopen sled");
+    let found = mgr2.get_holder(&holder_id).await.unwrap();
+    assert!(
+        found.is_some(),
+        "CommonsHolderRecord must survive sled drop-and-reopen"
+    );
+    let found_holder = found.unwrap();
+    assert_eq!(
+        found_holder.holder_did, did,
+        "holder_did must survive round-trip"
+    );
+}

--- a/icn/crates/icn-gateway/tests/constitutional_integration.rs
+++ b/icn/crates/icn-gateway/tests/constitutional_integration.rs
@@ -19,6 +19,21 @@ use icn_governance::{
 use icn_identity::KeyPair;
 
 /// Helper to create a test charter and activate it
+/// Create and store a minimal charter for `domain_id`.  Required because
+/// write-side scope enforcement rejects jurisdiction-scoped records that
+/// reference chartless domains.
+async fn create_charter_for_domain(commons_mgr: &CommonsManager, domain_id: &str) {
+    let charter = Charter::new(
+        OrgType::Cooperative,
+        domain_id.to_string(),
+        format!("Test Coop for {domain_id}"),
+        GovernanceConfig::cooperative_default(),
+        MembershipPolicy::default(),
+        DisputePolicy::default(),
+    );
+    commons_mgr.store_charter(charter).await.unwrap();
+}
+
 async fn create_active_charter(commons_mgr: &CommonsManager) -> String {
     let mut charter = Charter::new(
         OrgType::Cooperative,
@@ -175,6 +190,7 @@ async fn test_amendment_full_lifecycle() {
 #[actix_web::test]
 async fn test_amendment_withdrawal() {
     let commons_mgr = CommonsManager::new();
+    create_charter_for_domain(&commons_mgr, "coop:test").await;
 
     let proposer = KeyPair::generate().unwrap();
     let proposer_did = proposer.did().clone();
@@ -222,6 +238,7 @@ async fn test_amendment_withdrawal() {
 #[actix_web::test]
 async fn test_amendment_withdrawal_requires_proposer() {
     let commons_mgr = CommonsManager::new();
+    create_charter_for_domain(&commons_mgr, "coop:test").await;
 
     let proposer = KeyPair::generate().unwrap();
     let other_user = KeyPair::generate().unwrap();
@@ -266,6 +283,7 @@ async fn test_amendment_withdrawal_requires_proposer() {
 #[actix_web::test]
 async fn test_appeal_full_lifecycle() {
     let commons_mgr = CommonsManager::new();
+    create_charter_for_domain(&commons_mgr, "coop:test").await;
 
     let appellant = KeyPair::generate().unwrap();
     let appellant_did = appellant.did().clone();
@@ -328,6 +346,7 @@ async fn test_appeal_full_lifecycle() {
 #[actix_web::test]
 async fn test_appeal_withdrawal() {
     let commons_mgr = CommonsManager::new();
+    create_charter_for_domain(&commons_mgr, "coop:test").await;
 
     let appellant = KeyPair::generate().unwrap();
     let appellant_did = appellant.did().clone();
@@ -371,6 +390,7 @@ async fn test_appeal_withdrawal() {
 #[actix_web::test]
 async fn test_appeal_withdrawal_requires_appellant() {
     let commons_mgr = CommonsManager::new();
+    create_charter_for_domain(&commons_mgr, "coop:test").await;
 
     let appellant = KeyPair::generate().unwrap();
     let other_user = KeyPair::generate().unwrap();
@@ -407,6 +427,7 @@ async fn test_appeal_withdrawal_requires_appellant() {
 #[actix_web::test]
 async fn test_list_amendments_by_status() {
     let commons_mgr = CommonsManager::new();
+    create_charter_for_domain(&commons_mgr, "coop:test").await;
 
     let proposer = KeyPair::generate().unwrap();
 
@@ -472,6 +493,8 @@ async fn test_list_amendments_by_status() {
 #[actix_web::test]
 async fn test_list_appeals_by_scope() {
     let commons_mgr = CommonsManager::new();
+    create_charter_for_domain(&commons_mgr, "coop:alpha").await;
+    create_charter_for_domain(&commons_mgr, "coop:beta").await;
 
     let user1 = KeyPair::generate().unwrap();
     let user2 = KeyPair::generate().unwrap();
@@ -534,6 +557,12 @@ async fn test_list_appeals_by_scope() {
 #[actix_web::test]
 async fn test_appeal_outcomes() {
     let commons_mgr = CommonsManager::new();
+
+    // Pre-create charters for each outcome domain used in the loop below.
+    let num_outcomes = 4; // matches outcomes.len() below
+    for i in 0..num_outcomes {
+        create_charter_for_domain(&commons_mgr, &format!("coop:outcome-test-{i}")).await;
+    }
 
     let outcomes = vec![
         AppealOutcome::Upheld {

--- a/icn/crates/icn-gateway/tests/governance_flows_integration.rs
+++ b/icn/crates/icn-gateway/tests/governance_flows_integration.rs
@@ -16,6 +16,20 @@ use icn_identity::{
     KeyPair,
 };
 
+/// Create a minimal charter for `domain_id`.  Required because write-side
+/// scope enforcement rejects jurisdiction-scoped records without a charter.
+async fn create_charter_for_domain(commons_mgr: &CommonsManager, domain_id: &str) {
+    let charter = Charter::new(
+        OrgType::Cooperative,
+        domain_id.to_string(),
+        format!("Test Coop for {domain_id}"),
+        GovernanceConfig::cooperative_default(),
+        MembershipPolicy::default(),
+        DisputePolicy::default(),
+    );
+    commons_mgr.store_charter(charter).await.unwrap();
+}
+
 /// Helper to create a FounderSignature
 fn create_founder_signature(did: icn_identity::Did, sig_byte: u8) -> FounderSignature {
     let now = std::time::SystemTime::now()
@@ -504,6 +518,7 @@ async fn test_amendment_add_change_flow() {
     };
 
     let commons_mgr = CommonsManager::new();
+    create_charter_for_domain(&commons_mgr, "coop:add-change-test").await;
 
     let proposer = KeyPair::generate().unwrap();
     let proposer_did = proposer.did().clone();
@@ -596,6 +611,7 @@ async fn test_amendment_add_change_fails_after_submit() {
     };
 
     let commons_mgr = CommonsManager::new();
+    create_charter_for_domain(&commons_mgr, "coop:submit-test").await;
 
     let proposer = KeyPair::generate().unwrap();
     let proposer_did = proposer.did().clone();

--- a/icn/crates/icn-gateway/tests/governance_flows_integration.rs
+++ b/icn/crates/icn-gateway/tests/governance_flows_integration.rs
@@ -294,21 +294,13 @@ async fn test_e2e_coop_formation() {
     // 4. Founders join the coop as members
     let jurisdiction = JurisdictionId::new("coop:e2e-test-coop");
     for (_keypair, holder_id) in &founders {
+        // Join as candidate — no capabilities seeded at join time
         commons_mgr
-            .join_jurisdiction(
-                holder_id,
-                jurisdiction.clone(),
-                vec![
-                    MembershipCapability::Vote,
-                    MembershipCapability::Propose,
-                    MembershipCapability::Transact,
-                    MembershipCapability::HoldOffice,
-                ],
-            )
+            .join_jurisdiction(holder_id, jurisdiction.clone(), vec![])
             .await
             .unwrap();
 
-        // Auto-approve and promote founders
+        // Approve and promote: grants baseline capabilities (Vote, Propose, Transact)
         commons_mgr
             .approve_membership(holder_id, &jurisdiction)
             .await
@@ -318,9 +310,21 @@ async fn test_e2e_coop_formation() {
             .await
             .unwrap();
 
-        // Verify full member status
+        // Explicitly delegate elevated capability after membership is established
+        commons_mgr
+            .grant_capability(holder_id, &jurisdiction, MembershipCapability::HoldOffice)
+            .await
+            .unwrap();
+
+        // Verify full member status with explicit HoldOffice delegation
         let affiliations = commons_mgr.list_affiliations(holder_id).await.unwrap();
         assert_eq!(affiliations[0].membership_status, MembershipStatus::Member);
+        assert!(
+            affiliations[0]
+                .capabilities
+                .contains(&MembershipCapability::HoldOffice),
+            "founders must have HoldOffice after explicit delegation"
+        );
     }
 
     // 5. Enroll a new member (not a founder)

--- a/icn/crates/icn-gateway/tests/steward_integration.rs
+++ b/icn/crates/icn-gateway/tests/steward_integration.rs
@@ -5,8 +5,24 @@
 //! attestation tracking, and bond management.
 
 use icn_gateway::commons_mgr::CommonsManager;
-use icn_governance::StewardStatus;
+use icn_governance::{
+    Charter, DisputePolicy, GovernanceConfig, MembershipPolicy, OrgType, StewardStatus,
+};
 use icn_identity::{KeyPair, POPLevel};
+
+/// Create a minimal charter for `domain_id`.  Required because write-side scope
+/// enforcement rejects steward registrations with an unchartered jurisdiction.
+async fn create_charter_for_domain(commons_mgr: &CommonsManager, domain_id: &str) {
+    let charter = Charter::new(
+        OrgType::Cooperative,
+        domain_id.to_string(),
+        format!("Test Coop for {domain_id}"),
+        GovernanceConfig::cooperative_default(),
+        MembershipPolicy::default(),
+        DisputePolicy::default(),
+    );
+    commons_mgr.store_charter(charter).await.unwrap();
+}
 
 /// Helper to create a holder with Strong POP level (required for steward registration)
 async fn create_holder_with_strong_pop(
@@ -39,6 +55,7 @@ async fn create_holder_with_strong_pop(
 #[actix_web::test]
 async fn test_steward_registration() {
     let commons_mgr = CommonsManager::new();
+    create_charter_for_domain(&commons_mgr, "coop:test-coop").await;
 
     let member_keypair = KeyPair::generate().unwrap();
     let voucher_keypair = KeyPair::generate().unwrap();
@@ -464,6 +481,8 @@ async fn test_term_extension() {
 #[actix_web::test]
 async fn test_list_stewards() {
     let commons_mgr = CommonsManager::new();
+    create_charter_for_domain(&commons_mgr, "coop:alpha").await;
+    create_charter_for_domain(&commons_mgr, "coop:beta").await;
 
     // Create two stewards in different jurisdictions
     let member1 = KeyPair::generate().unwrap();

--- a/icn/crates/icn-identity/src/commons.rs
+++ b/icn/crates/icn-identity/src/commons.rs
@@ -415,7 +415,14 @@ impl Affiliation {
         }
     }
 
-    /// Create an affiliation with full member status
+    /// Create an affiliation with full member status and baseline member capabilities.
+    ///
+    /// Grants the same baseline capabilities as the enrollment flow's `promote()` transition:
+    /// `Vote`, `Propose`, and `Transact`.  `HoldOffice` is NOT granted — it must be
+    /// explicitly delegated by the jurisdiction.
+    ///
+    /// Intended for direct construction (seeding, testing).  The canonical path for
+    /// new members is the enrollment flow (`new` → `approve` → `promote`).
     pub fn as_member(jurisdiction_id: JurisdictionId) -> Self {
         let mut affiliation = Self::new(jurisdiction_id);
         affiliation.membership_status = MembershipStatus::Member;
@@ -469,10 +476,28 @@ impl Affiliation {
         }
     }
 
-    /// Promote from provisional to full member
+    /// Promote from provisional to full member.
+    ///
+    /// Sets `membership_status` to `Member` and ensures the baseline member capabilities
+    /// (`Vote`, `Propose`, `Transact`) are present.  Any capabilities already on the
+    /// affiliation are preserved; capabilities are added idempotently.
+    ///
+    /// `HoldOffice` is NOT granted here — it must be explicitly delegated by the
+    /// jurisdiction after promotion, preserving the distinction between ordinary
+    /// membership and governance office-holding.
     pub fn promote(&mut self) {
         if self.membership_status == MembershipStatus::Provisional {
             self.membership_status = MembershipStatus::Member;
+            // Grant baseline member capabilities, matching `as_member()`.
+            for cap in [
+                MembershipCapability::Vote,
+                MembershipCapability::Propose,
+                MembershipCapability::Transact,
+            ] {
+                if !self.capabilities.contains(&cap) {
+                    self.capabilities.push(cap);
+                }
+            }
         }
     }
 
@@ -801,21 +826,85 @@ mod tests {
 
         assert_eq!(affiliation.membership_status, MembershipStatus::Candidate);
         assert!(!affiliation.is_active());
+        assert!(affiliation.capabilities.is_empty());
 
-        // Approve to provisional
+        // Approve to provisional — no capabilities granted yet
         affiliation.approve();
         assert_eq!(affiliation.membership_status, MembershipStatus::Provisional);
         assert!(affiliation.is_active());
+        assert!(affiliation.capabilities.is_empty());
 
-        // Promote to full member
+        // Promote to full member — baseline capabilities are granted
         affiliation.promote();
         assert_eq!(affiliation.membership_status, MembershipStatus::Member);
         assert!(affiliation.is_active());
+        assert!(affiliation.has_capability(MembershipCapability::Vote));
+        assert!(affiliation.has_capability(MembershipCapability::Propose));
+        assert!(affiliation.has_capability(MembershipCapability::Transact));
+        // HoldOffice is NOT granted by promotion — requires explicit delegation
+        assert!(!affiliation.has_capability(MembershipCapability::HoldOffice));
 
         // Suspend
         affiliation.suspend();
         assert_eq!(affiliation.membership_status, MembershipStatus::Suspended);
         assert!(!affiliation.is_active());
+    }
+
+    #[test]
+    fn test_promotion_parity_with_as_member() {
+        // The enrollment path (new → approve → promote) must produce the same
+        // baseline capability set as the direct-construction path (as_member).
+        let coop = JurisdictionId::coop("parity-test");
+
+        let direct = Affiliation::as_member(coop.clone());
+
+        let mut enrolled = Affiliation::new(coop);
+        enrolled.approve();
+        enrolled.promote();
+
+        // Both paths must agree on status and baseline capabilities
+        assert_eq!(enrolled.membership_status, direct.membership_status);
+        assert_eq!(
+            enrolled.has_capability(MembershipCapability::Vote),
+            direct.has_capability(MembershipCapability::Vote)
+        );
+        assert_eq!(
+            enrolled.has_capability(MembershipCapability::Propose),
+            direct.has_capability(MembershipCapability::Propose)
+        );
+        assert_eq!(
+            enrolled.has_capability(MembershipCapability::Transact),
+            direct.has_capability(MembershipCapability::Transact)
+        );
+        // HoldOffice is absent in both — it is never granted by either constructor
+        assert!(!enrolled.has_capability(MembershipCapability::HoldOffice));
+        assert!(!direct.has_capability(MembershipCapability::HoldOffice));
+    }
+
+    #[test]
+    fn test_promote_is_idempotent_with_existing_capabilities() {
+        // If the affiliation already has some of the baseline caps (e.g. from a
+        // pre-approval capability request), promote must not duplicate them.
+        let coop = JurisdictionId::coop("idempotent-test");
+        let mut affiliation = Affiliation::new(coop);
+        // Simulate an applicant who self-requested Vote before approval
+        affiliation.add_capability(MembershipCapability::Vote);
+        affiliation.approve();
+        affiliation.promote();
+
+        let vote_count = affiliation
+            .capabilities
+            .iter()
+            .filter(|&&c| c == MembershipCapability::Vote)
+            .count();
+        assert_eq!(
+            vote_count, 1,
+            "Vote must appear exactly once after promotion"
+        );
+        // All three baseline caps present
+        assert!(affiliation.has_capability(MembershipCapability::Vote));
+        assert!(affiliation.has_capability(MembershipCapability::Propose));
+        assert!(affiliation.has_capability(MembershipCapability::Transact));
     }
 
     #[test]

--- a/sdk/typescript/src/generated/api-types.ts
+++ b/sdk/typescript/src/generated/api-types.ts
@@ -103,7 +103,6 @@ export interface components {
         };
         /** @description Apply for membership request */
         ApplyMembershipRequest: {
-            capabilities_requested?: string[];
             jurisdiction_id: string;
         };
         /** @description Ban member request */


### PR DESCRIPTION
## Summary

Implements a coherent scope + authority model from API boundary to substrate, across five tranches:

### Tranche 1: Shared CommonsHandle architecture
- Single shared `CommonsHandle` (Arc<RwLock<CommonsInner>>) injected at gateway startup; replaces per-manager owned stores
- Constructors: `new_in_memory()`, `with_sled_path()`, `with_sled_temporary()`
- 3 integration tests: clone isolation, sled persistence, two-manager sharing

### Tranche 2: Read-side domain isolation
- `list_amendments_by_domain` / `list_appeals_by_domain` with exact enum-variant matching (no prefix bleed)
- Fixed `build_governance_dashboard` to filter amendments/appeals to charter domain
- 6 isolation tests: cross-domain, prefix-bleed, network exclusion, unknown domain

### Tranche 3: Write-side scope integrity in CommonsInner
Substrate-level invariants enforced at write time:
- `store_charter`: one charter per `domain_id` (uniqueness)
- `store_amendment`: Jurisdiction scope requires existing charter domain; `charter_id` must belong to that domain
- `store_appeal`: Jurisdiction scope requires existing charter domain
- `register_steward`: `jurisdiction` must reference an existing charter domain
- 12 new tests in `scope_enforcement.rs`; updated `domain_isolation.rs` to satisfy new invariant

### Tranche 4: End-to-end boundary scope integrity
API boundary → manager → substrate semantic consistency:
- **Dashboard fail-fast**: `build_governance_dashboard` returns error on unknown charter_id instead of cross-domain list-all fallback
- **Amendment boundary validation**: handler validates `charter.domain_id == scope_id` when both `charter_id` and jurisdiction `scope_id` are supplied — clear error at API boundary
- **Domain-scoped list endpoints**: `ListAmendmentsQuery` and `ListAppealsQuery` gain optional `domain_id` param; when supplied, routes to domain-scoped list methods (non-breaking)
- **Appeals dashboard scoping**: `AppealsDashboardQuery` gains optional `domain_id` for jurisdiction-scoped dashboard view
- 5 new tests in `boundary_scope_integration.rs`
- Updated `constitutional_integration`, `governance_flows_integration`, `steward_integration` to create charters before storing jurisdiction-scoped records
- Updated meaning firewall ratchet: icn-gateway `icn_governance::` refs reduced from 16 → 14

### Tranche 5: Domain-scoped authority enforcement for membership/steward mutations

**Authority model**:

| Operation class | Required authority |
|---|---|
| Membership admin (promote, suspend, reinstate, ban, revoke, grant/revoke capability, add/remove role) | `HoldOffice` in **target jurisdiction** |
| Steward governance (status change, term extension, dispute-won recording) | `HoldOffice` in **steward's jurisdiction** |
| Self-service ops (apply, exit, retire, add_bond, record_attestation) | Caller identity must match subject |
| Dispute filing | Auth-only (deferred — it is a report, not a governance outcome) |

**What was wrong**: 9 membership handlers and 6 steward handlers had `_claims` (parsed but discarded) — any authenticated caller could mutate any cooperative's membership state.

**What was fixed**:
- Added `require_jurisdiction_authority(mgr, caller_did, jurisdiction)` helper in `membership/mod.rs` and `steward/mod.rs` — the same 3-step pattern from the pre-existing `approve_membership` and `slash_bond` handlers, now applied consistently.
- `promote_member`, `suspend_member`, `reinstate_member`, `ban_member`, `revoke_membership`, `grant_capability`, `revoke_capability`, `add_role`, `remove_role` — all require `HoldOffice` in the target jurisdiction before mutation.
- `update_steward_status`, `extend_steward_term`, `record_dispute_won` — require `HoldOffice` in the steward's jurisdiction.
- `add_bond`, `record_attestation` — require caller to be the steward's own holder (self-service).
- 8 new tests in `authority_enforcement_integration.rs` proving cross-domain rejection.

### Boundary + Authority semantic model

| Layer | Invariant |
|-------|-----------|
| Substrate (`CommonsInner`) | Final enforcement; one charter/domain; scope must match existing domain; charter_id/domain consistency |
| Manager (`CommonsManager`) | No silent widening: unknown charter → error, not all-records |
| Handler | Fail-fast: charter_id/scope_id consistency checked before substrate call; `HoldOffice` authority checked before any membership/steward mutation |
| List endpoints | Optional `domain_id` param routes to exact-match domain-scoped methods |

### Test plan

- [x] `cargo test -p icn-commons` — 21 tests (3 shared-handle + 6 domain-isolation + 12 scope-enforcement)
- [x] `cargo test -p icn-gateway` — all tests pass (full suite)
- [x] `cargo test -p icn-gateway --test authority_enforcement_integration` — 8 authority tests pass
- [x] `cargo test -p icn-core --lib meaning_firewall::tests::strict_gateway_governance_total_refs` — ratchet updated to 14
- [x] `cargo clippy -p icn-commons -p icn-gateway -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

### What remains for a future tranche

| Item | Priority |
|------|----------|
| Dispute filing (record_dispute) is auth-only — consider jurisdiction-member requirement | Medium |
| Unscoped list endpoints return all-domains by default — consider requiring domain_id or deriving from caller's membership | Medium |
| Appeals dashboard with no domain_id still returns all appeals — stricter default in multi-coop deployments | Low |
| Affiliation queries return all jurisdictions: should scope to caller's domain | Low |
| Steward registration governance_approval field is not validated against actual governance records | Low |

---

## Tranche 6: Shared authority module + dispute-filing gate + terminology cleanup (2026-03-29)

### Authority terminology audit

Audited every use of "admin" in the touched files. Findings:
- **1 architecturally dangerous instance**: error message `"Caller does not have admin rights"` in `approve_membership` — client-facing text encoding a global-admin mental model. Fixed by unifying with the shared helper.
- **3 misleading test function names** encoding `admin` where the right term is `office-holder` or `jurisdiction authority`. Renamed.
- **1 ambiguous docstring**: `"membership admin operations"` → removed with the helper consolidation.
- All remaining `admin` uses in test comments/variable names are acceptable shorthand in context (describing the attack pattern or a local test variable).

**Confirmed**: No logic anywhere depends on a generic global-admin concept. All cooperative mutation authority is rooted in `HoldOffice ∩ jurisdiction` or `Member status ∩ jurisdiction`. The system encodes scoped office-holding, not platform superuser elevation.

### Shared authority utility

Extracted `crate::authority` with two canonical, semantically distinct gates:

| Function | Capability/status checked | Used for |
|---|---|---|
| `require_office_in_jurisdiction` | `HoldOffice` capability | Governance mutations (promote, suspend, grant capability, steward governance) |
| `require_membership_in_jurisdiction` | `Member` status (not a capability) | Member-standing actions (dispute filing) |

Removed duplicate private helpers from `membership/mod.rs` and `steward/mod.rs`. Unified the inline check in `approve_membership` that predated the helper.

### Dispute-filing gate

`record_dispute` now requires full `Member` status in the steward's jurisdiction (checked via affiliation status, not capability, because capabilities are not auto-granted during the enrollment flow). Provisional candidates and unenrolled outsiders are rejected.

**Why Member status, not Vote capability**: The enrollment flow (apply → approve → promote) does not automatically grant `Vote` capability — it must be explicitly granted. Membership status is the authoritative single source of truth for whether full membership was conferred.

### Tests updated (12 total, all passing)

Renamed 3 tests, fixed 1 doc comment, added 4 new dispute-filing authority tests:
- `full_member_has_standing_to_file_dispute`
- `outsider_lacks_standing_to_file_dispute`
- `cross_domain_member_cannot_file_dispute_in_other_jurisdiction`
- `plain_member_without_hold_office_can_satisfy_dispute_standing`

### What remains

| Gap | Priority |
|---|---|
| Steward `governance_approval` field is a free-form string, never validated against actual governance records | Low |
| Unscoped list endpoints return all-domains by default — consider requiring domain_id | Medium |
| Appeals dashboard returns all-domains with no scope | Low |
| `promote()` in `MemberAffiliation` does not auto-grant default capabilities (`Vote`, `Propose`, `Transact`) — the `as_member()` constructor does, but the promotion flow does not. This is a data model gap, not a security issue, but can cause surprising behavior | Medium |

---

## Tranche 7: Enrollment-path / `as_member()` capability parity (`fc406c96`)

**File:** `crates/icn-identity/src/commons.rs`

### Inconsistency fixed

`Affiliation::promote()` only changed `membership_status` to `Member` without granting capabilities. `Affiliation::as_member()` (the direct-construction path) granted `[Vote, Propose, Transact]`. Two paths producing "full member" diverged on operative capability set.

This caused the Tranche 6 dispute tests to fail when checking `Vote` as a membership signal, because the enrollment flow never guaranteed it.

### Invariant established

> Full membership (`MembershipStatus::Member`) implies baseline operative capabilities: `Vote`, `Propose`, `Transact` — regardless of construction path.

`promote()` now grants these three capabilities idempotently (using the existing `add_capability` guard). `HoldOffice` remains outside the baseline — it requires explicit delegation after promotion.

### Tests added

- `test_affiliation_lifecycle` — extended to assert baseline capabilities present after promotion and absent before
- `test_promotion_parity_with_as_member` — enrollment path and direct-construction path produce equivalent membership
- `test_promote_is_idempotent_with_existing_capabilities` — no duplicate capabilities if some were pre-stored at application time

### Gateway checks: no change needed

`record_dispute` remains status-based (`MembershipStatus::Member`). Even with capabilities now reliable, status is still the correct semantic check — "you are a full member here" is a stronger and clearer claim than "you have vote rights". A member whose `Vote` was individually revoked can still report a steward concern.

### Remaining gaps (updated)

| Gap | Priority |
|---|---|
| Steward `governance_approval` field is a free-form string, never validated against actual governance records | Low |
| Unscoped list endpoints return all-domains by default — consider requiring domain_id | Medium |
| `apply_for_membership` stores applicant-requested capabilities pre-approval (self-asserted before any governance review) — cap grants should be jurisdiction-controlled at approval/promotion time | Medium |
| ~~`promote()` does not auto-grant default capabilities~~ — **Fixed in Tranche 7** | Done |

---

## Tranche 8: Enrollment capability-origin invariant (`e884c68d`)

**Files:** `icn-commons/src/inner.rs`, `icn-commons/src/handle.rs`, `icn-gateway/src/commons_mgr.rs`, `icn-gateway/src/api/membership/mod.rs`, `icn-gateway/src/api/commons/mod.rs`, `tests/authority_enforcement_integration.rs`

### Authorization bypass fixed

Applicants could self-assert any capability — including `HoldOffice` — via `capabilities_requested` in the membership apply request, or `capabilities` in the commons join-jurisdiction request.  Neither `approve_membership` nor `promote_member` validated or cleared those values, so asserted capabilities survived into the final `Member` affiliation unchanged.  This allowed `require_office_in_jurisdiction` to be bypassed by self-assertion.

### Invariant established

> Capabilities originate from jurisdictional delegation only.

| Stage | Capabilities |
|-------|-------------|
| Application (`Candidate`) | None |
| Approval (`Provisional`) | None |
| Promotion (`Member`) | Baseline only: `Vote`, `Propose`, `Transact` (from `promote()`) |
| Elevated (`HoldOffice`, etc.) | Explicit `grant_capability` by office-holder required |

### What changed

- `CommonsInner::apply_for_membership`: removed `capabilities_requested` parameter — no capabilities stored at application time
- `CommonsHandle`, `CommonsManager`: same signature cleanup
- `ApplyMembershipRequest`: removed `capabilities_requested` field
- `JoinJurisdictionRequest`: removed `capabilities` field
- `join_jurisdiction` handler: passes `vec![]` to internal API; SDIS enrollment uses `CommonsManager` directly with explicit system-granted capabilities and is unaffected
- `commons/mod.rs`: removed dead `parse_capability` helper

### Tests added (4 new, 16 total)

- `application_creates_candidate_with_no_capabilities`
- `approval_does_not_grant_capabilities`
- `promotion_grants_only_baseline_capabilities`
- `hold_office_requires_explicit_delegation_not_enrollment`

---

## Tranche 9: Internal API hardening — join_jurisdiction capability guard

**Commit:** 37643d36

### Problem

`CommonsInner::join_jurisdiction` accepted `initial_capabilities: Vec<MembershipCapability>` with no guard on what capabilities could be seeded. All current callers were safe, but the API shape was a footgun: a future internal caller could casually seed elevated capabilities (`HoldOffice`, `AccessPrivate`, `Sponsor`) at enrollment time, bypassing the delegation model established in Tranches 7–8.

One test (`test_e2e_coop_formation`) already exploited this by seeding `HoldOffice` at join time for founders — correct semantically, but wrong origin for the capability.

### Invariant adopted

`initial_capabilities` may only contain baseline member capabilities (`Vote`, `Propose`, `Transact`). Elevated capabilities must flow from explicit jurisdictional delegation via `grant_capability` after membership is established.

### Changes

- `icn-commons/src/inner.rs`: added runtime guard in `join_jurisdiction` that bails if any elevated capability appears in `initial_capabilities`; updated doc comment
- `icn-gateway/tests/governance_flows_integration.rs`: fixed `test_e2e_coop_formation` founders bootstrap — now uses `join(vec![]) → approve → promote → grant_capability(HoldOffice)`
- `icn-gateway/tests/authority_enforcement_integration.rs`: added `join_jurisdiction_rejects_elevated_initial_capabilities` (17 total authority tests)

### What remains

| Gap | Priority |
|---|---|
| Steward `governance_approval` field is a free-form string, never validated against actual governance records | Low |
| Unscoped list endpoints return all-domains by default | Medium |