### PR TITLE
test(commons): add Layers 2-4 persistence proof tranche

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -2869,6 +2869,7 @@ dependencies = [
  "icn-governance",
  "icn-identity",
  "icn-obs",
+ "icn-testkit",
  "icn-time",
  "lru",
  "rand 0.8.5",

--- a/icn/crates/icn-commons/Cargo.toml
+++ b/icn/crates/icn-commons/Cargo.toml
@@ -30,3 +30,8 @@ tempfile = "3"
 tokio = { version = "1", features = ["full"] }
 hex = "0.4"
 ed25519-dalek.workspace = true
+icn-testkit.workspace = true
+
+[[bin]]
+name = "commons_restart_helper"
+path = "src/bin/commons_restart_helper.rs"

--- a/icn/crates/icn-commons/src/bin/commons_restart_helper.rs
+++ b/icn/crates/icn-commons/src/bin/commons_restart_helper.rs
@@ -1,0 +1,150 @@
+//! Cross-process commons persistence proof helper binary.
+//!
+//! Used exclusively by the Layer 3 integration test in
+//! `crates/icn-commons/tests/commons_persistence.rs` to prove that commons
+//! state written through `CommonsHandle` survives a true OS process boundary.
+//!
+//! ## Usage
+//!
+//! ```text
+//! commons_restart_helper write <sled_path>
+//!     Opens a CommonsHandle at <sled_path>, creates a PersonhoodAnchor,
+//!     flushes to sled, prints "anchor_id_hex,did_str" to stdout, exits 0.
+//!
+//! commons_restart_helper read <sled_path> <anchor_id_hex> <did_str>
+//!     Opens fresh CommonsHandle, verifies the anchor exists by ID and by
+//!     DID index lookup. Exits 0 on success, 1 on failure.
+//! ```
+//!
+//! ## Architecture note
+//!
+//! CommonsHandle uses `tokio::sync::RwLock`. All operations are async.
+//! A current-thread runtime is sufficient — no blocking I/O bypass needed.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use icn_commons::CommonsHandle;
+use icn_identity::{Did, KeyPair};
+use std::{path::PathBuf, process};
+
+fn main() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+
+    let args: Vec<String> = std::env::args().collect();
+    let exit_code = match args.get(1).map(String::as_str) {
+        Some("write") => {
+            let sled_path = PathBuf::from(args.get(2).expect("write: missing sled_path"));
+            rt.block_on(run_write(sled_path))
+        }
+        Some("read") => {
+            let sled_path = PathBuf::from(args.get(2).expect("read: missing sled_path"));
+            let anchor_id = args.get(3).expect("read: missing anchor_id_hex").clone();
+            let did_str = args.get(4).expect("read: missing did_str").clone();
+            rt.block_on(run_read(sled_path, anchor_id, did_str))
+        }
+        _ => {
+            eprintln!(
+                "usage: commons_restart_helper <write|read> <sled_path> [anchor_id_hex did_str]"
+            );
+            1
+        }
+    };
+
+    process::exit(exit_code);
+}
+
+/// Write phase: create a PersonhoodAnchor through CommonsHandle, flush to sled,
+/// print "anchor_id_hex,did_str" to stdout.
+async fn run_write(sled_path: PathBuf) -> i32 {
+    let keypair = match KeyPair::generate() {
+        Ok(kp) => kp,
+        Err(e) => {
+            eprintln!("write: KeyPair::generate failed: {e}");
+            return 1;
+        }
+    };
+    let did = keypair.did().clone();
+
+    let handle = match CommonsHandle::with_sled_path(&sled_path) {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("write: CommonsHandle::with_sled_path failed: {e}");
+            return 1;
+        }
+    };
+
+    let anchor = match handle.create_anchor_from_enrollment(&did, None).await {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("write: create_anchor_from_enrollment failed: {e}");
+            return 1;
+        }
+    };
+
+    if let Err(e) = handle.flush().await {
+        eprintln!("write: flush failed: {e}");
+        return 1;
+    }
+
+    let anchor_id_hex = hex::encode(anchor.id());
+    println!("{},{}", anchor_id_hex, did);
+    0
+}
+
+/// Read phase: open fresh CommonsHandle, verify anchor exists by ID and by
+/// DID index.
+async fn run_read(sled_path: PathBuf, anchor_id_hex: String, did_str: String) -> i32 {
+    let did: Did = match did_str.parse() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("read: invalid did_str {did_str:?}: {e}");
+            return 1;
+        }
+    };
+
+    let handle = match CommonsHandle::with_sled_path(&sled_path) {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("read: CommonsHandle::with_sled_path failed: {e}");
+            return 1;
+        }
+    };
+
+    // Assert 1: anchor present by ID.
+    let anchor = match handle.get_anchor(&anchor_id_hex).await {
+        Ok(Some(a)) => a,
+        Ok(None) => {
+            eprintln!("read: anchor {anchor_id_hex} not found after cross-process restart");
+            return 1;
+        }
+        Err(e) => {
+            eprintln!("read: get_anchor failed: {e}");
+            return 1;
+        }
+    };
+
+    // Assert 2: anchor ID survives exact round-trip.
+    let stored_id = hex::encode(anchor.id());
+    if stored_id != anchor_id_hex {
+        eprintln!("read: anchor ID mismatch: expected {anchor_id_hex}, got {stored_id}");
+        return 1;
+    }
+
+    // Assert 3: DID index survives cross-process boundary.
+    match handle.get_anchor_by_did(&did).await {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            eprintln!("read: DID index not found for {did_str} after cross-process restart");
+            return 1;
+        }
+        Err(e) => {
+            eprintln!("read: get_anchor_by_did failed: {e}");
+            return 1;
+        }
+    }
+
+    0
+}

--- a/icn/crates/icn-commons/tests/commons_persistence.rs
+++ b/icn/crates/icn-commons/tests/commons_persistence.rs
@@ -1,0 +1,238 @@
+//! Commons substrate persistence proofs — Layers 2 and 3.
+//!
+//! ## Layer 2 — what it proves
+//!
+//! Commons state (anchor, charter, holder) written through `CommonsHandle`
+//! — the substrate boundary directly below `CommonsManager` — survives a
+//! same-runtime drop-and-reopen boundary.
+//!
+//! Layer 1 (in `icn-gateway/tests/commons_integration.rs`) proved that
+//! `CommonsManager::with_sled_path()` round-trips through sled. Layer 2
+//! descends one level: it exercises `CommonsHandle` itself, proving the
+//! `CommonsHandle → CommonsInner → CommonsStore` path reaches the sled file
+//! without any in-memory-only bypass.
+//!
+//! All Arc refs are dropped in a scoped block before Phase 2 opens the fresh
+//! handle. The sled file is the only bridge.
+//!
+//! ## Layer 3 — what it proves
+//!
+//! Commons state written through `CommonsHandle` in one OS process is
+//! readable by a completely fresh OS process. No shared memory, no shared
+//! sled handle, no Arc continuity across the process boundary.
+//!
+//! Uses `crates/icn-commons/src/bin/commons_restart_helper.rs` and
+//! `icn_testkit::subprocess::run_subprocess` for the subprocess invocations.
+//!
+//! ## What is NOT proven
+//!
+//! - Layer 4 (daemon restart simulation via CommonsManager + CommonsHandle):
+//!   that proof lives in `icn-gateway/tests/commons_integration.rs` because
+//!   it requires `CommonsManager` from the gateway crate.
+//! - Charter and steward round-trips in Layer 3 (scoped to anchor to keep
+//!   the cross-process helper minimal).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use icn_commons::CommonsHandle;
+use icn_identity::KeyPair;
+use icn_testkit::subprocess::run_subprocess;
+
+// ============================================================================
+// Layer 2 — CommonsHandle substrate drop + reopen (same-runtime)
+// ============================================================================
+
+/// Layer 2a — PersonhoodAnchor survives CommonsHandle drop + reopen.
+///
+/// Writes via `CommonsHandle::with_sled_path()`, drops all Arc refs in a
+/// scoped block, reopens a fresh handle from the same path, and asserts:
+/// 1. Anchor is retrievable by ID.
+/// 2. DID reverse-index survives the boundary (anchor retrievable by DID).
+#[tokio::test]
+async fn test_l2_anchor_survives_handle_drop_and_reopen() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sled_path = tmp.path().join("l2-anchor.sled");
+
+    let keypair = KeyPair::generate().expect("KeyPair::generate");
+    let did = keypair.did().clone();
+
+    // ── Phase 1: write through CommonsHandle, then DROP all Arc refs ─────────
+    let anchor_id = {
+        let handle = CommonsHandle::with_sled_path(&sled_path).expect("open CommonsHandle");
+        let anchor = handle
+            .create_anchor_from_enrollment(&did, None)
+            .await
+            .expect("create_anchor_from_enrollment");
+        handle.flush().await.expect("flush");
+        hex::encode(anchor.id())
+        // handle (Arc<RwLock<CommonsInner>>) drops here — sled lock released
+    };
+
+    // ── Boundary: disk is the only bridge ────────────────────────────────────
+
+    // ── Phase 2: fresh CommonsHandle, no shared memory ───────────────────────
+    let handle2 = CommonsHandle::with_sled_path(&sled_path).expect("reopen CommonsHandle");
+
+    // 1. Anchor present by ID.
+    let found = handle2
+        .get_anchor(&anchor_id)
+        .await
+        .expect("get_anchor after reopen");
+    assert!(
+        found.is_some(),
+        "PersonhoodAnchor must survive CommonsHandle drop + reopen (Layer 2)"
+    );
+
+    // 2. DID index survives.
+    let by_did = handle2
+        .get_anchor_by_did(&did)
+        .await
+        .expect("get_anchor_by_did after reopen");
+    assert!(
+        by_did.is_some(),
+        "DID reverse-index must survive CommonsHandle drop + reopen (Layer 2)"
+    );
+}
+
+/// Layer 2b — Charter survives CommonsHandle drop + reopen.
+///
+/// Proves that the charter write path (`CommonsHandle::store_charter`) and
+/// read path (`CommonsHandle::get_charter`) are both sled-backed and survive
+/// the handle drop-and-reopen boundary with exact field values.
+#[tokio::test]
+async fn test_l2_charter_survives_handle_drop_and_reopen() {
+    use icn_governance::{Charter, DisputePolicy, GovernanceConfig, MembershipPolicy, OrgType};
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sled_path = tmp.path().join("l2-charter.sled");
+
+    // ── Phase 1: write charter, drop all Arc refs ─────────────────────────────
+    let charter_id = {
+        let handle = CommonsHandle::with_sled_path(&sled_path).expect("open CommonsHandle");
+        let charter = Charter::new(
+            OrgType::Cooperative,
+            "coop:l2-persist-test".to_string(),
+            "Layer 2 Persistence Coop".to_string(),
+            GovernanceConfig::cooperative_default(),
+            MembershipPolicy::default(),
+            DisputePolicy::default(),
+        );
+        let id = charter.charter_id.to_hex();
+        handle.store_charter(charter).await.expect("store_charter");
+        handle.flush().await.expect("flush");
+        id
+        // handle drops here
+    };
+
+    // ── Phase 2: fresh CommonsHandle ─────────────────────────────────────────
+    let handle2 = CommonsHandle::with_sled_path(&sled_path).expect("reopen CommonsHandle");
+    let found = handle2
+        .get_charter(&charter_id)
+        .await
+        .expect("get_charter after reopen");
+
+    assert!(
+        found.is_some(),
+        "Charter must survive CommonsHandle drop + reopen (Layer 2)"
+    );
+    assert_eq!(
+        found.unwrap().name,
+        "Layer 2 Persistence Coop",
+        "charter name must survive round-trip"
+    );
+}
+
+/// Layer 2c — CommonsHolderRecord survives CommonsHandle drop + reopen.
+///
+/// Proves that the full enrollment path (anchor → holder) survives the
+/// CommonsHandle drop-and-reopen boundary. The holder DID must match exactly.
+#[tokio::test]
+async fn test_l2_holder_survives_handle_drop_and_reopen() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sled_path = tmp.path().join("l2-holder.sled");
+
+    let keypair = KeyPair::generate().expect("KeyPair::generate");
+    let did = keypair.did().clone();
+
+    // ── Phase 1: enroll anchor + holder, drop ─────────────────────────────────
+    let holder_id = {
+        let handle = CommonsHandle::with_sled_path(&sled_path).expect("open CommonsHandle");
+        let anchor = handle
+            .create_anchor_from_enrollment(&did, None)
+            .await
+            .expect("create_anchor_from_enrollment");
+        let anchor_id = hex::encode(anchor.id());
+        let holder = handle
+            .create_holder_from_anchor(&anchor_id, &did)
+            .await
+            .expect("create_holder_from_anchor");
+        handle.flush().await.expect("flush");
+        hex::encode(holder.id())
+        // handle drops here
+    };
+
+    // ── Phase 2: fresh CommonsHandle ─────────────────────────────────────────
+    let handle2 = CommonsHandle::with_sled_path(&sled_path).expect("reopen CommonsHandle");
+    let found = handle2
+        .get_holder(&holder_id)
+        .await
+        .expect("get_holder after reopen");
+
+    assert!(
+        found.is_some(),
+        "CommonsHolderRecord must survive CommonsHandle drop + reopen (Layer 2)"
+    );
+    assert_eq!(
+        found.unwrap().holder_did,
+        did,
+        "holder_did must survive round-trip"
+    );
+}
+
+// ============================================================================
+// Layer 3 — Cross-process persistence proof (OS process boundary)
+// ============================================================================
+
+/// Layer 3 — PersonhoodAnchor survives a true OS process restart.
+///
+/// A `CommonsHandle` in one OS process writes a `PersonhoodAnchor` to sled
+/// and exits. A completely fresh OS process opens the same sled path and
+/// verifies the anchor is present — no shared memory, no Arc continuity.
+///
+/// Uses `commons_restart_helper write/read` subprocesses via
+/// `icn_testkit::subprocess::run_subprocess`.
+///
+/// Invariants asserted across the process boundary:
+/// 1. Anchor is present by ID after process restart.
+/// 2. DID reverse-index survives (anchor retrievable by DID).
+#[test]
+fn test_l3_anchor_survives_cross_process_restart() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sled_path = tmp.path().to_str().expect("sled_path to str");
+    let helper = env!("CARGO_BIN_EXE_commons_restart_helper");
+
+    // ── Write subprocess: create anchor, flush, print "anchor_id,did" ────────
+    let write_stdout = run_subprocess(helper, &["write", sled_path]);
+
+    // stdout format: "anchor_id_hex,did_str"
+    let parts: Vec<&str> = write_stdout.splitn(2, ',').collect();
+    assert_eq!(
+        parts.len(),
+        2,
+        "write stdout must be 'anchor_id_hex,did_str', got: {write_stdout:?}"
+    );
+    let (anchor_id_hex, did_str) = (parts[0], parts[1]);
+
+    assert!(
+        !anchor_id_hex.is_empty(),
+        "anchor_id_hex must be non-empty, got: {anchor_id_hex:?}"
+    );
+    assert!(
+        did_str.starts_with("did:icn:"),
+        "did_str must be a valid ICN DID, got: {did_str:?}"
+    );
+
+    // ── Read subprocess: fresh process, no shared memory ─────────────────────
+    // run_subprocess asserts exit 0; panics with full stdout+stderr otherwise.
+    run_subprocess(helper, &["read", sled_path, anchor_id_hex, did_str]);
+}

--- a/icn/crates/icn-gateway/tests/commons_integration.rs
+++ b/icn/crates/icn-gateway/tests/commons_integration.rs
@@ -408,7 +408,7 @@ async fn test_anchor_status_updates() {
 }
 
 // ============================================================================
-// Layer 1 — Sled persistence proof tests (drop-and-reopen)
+// Layer 1 — Sled persistence proof tests (CommonsManager drop-and-reopen)
 // ============================================================================
 
 /// Prove that PersonhoodAnchor survives a CommonsManager drop-and-reopen boundary.
@@ -512,5 +512,105 @@ async fn test_commons_holder_survives_sled_drop_and_reopen() {
     assert_eq!(
         found_holder.holder_did, did,
         "holder_did must survive round-trip"
+    );
+}
+
+// ============================================================================
+// Layer 4 — Daemon restart simulation
+//
+// Proves that commons state written through the production daemon wiring
+// (`CommonsManager::with_handle(CommonsHandle::with_sled_path(...))`)
+// survives a full daemon shutdown + restart simulation: all manager and
+// handle references drop, then a fresh daemon path reopens the same data dir.
+//
+// This is the highest-fidelity same-process proof. It exercises the exact
+// code path that `icn-core/src/supervisor/lifecycle.rs` uses:
+//   CommonsHandle::with_sled_path(data_dir/commons.sled) → CommonsManager::with_handle(handle)
+//
+// What it proves:
+// - CommonsManager::with_handle() is a thin facade — writes go through to sled
+// - Dropping both CommonsManager and CommonsHandle releases the sled lock
+// - A fresh handle + manager pair recovers exactly the persisted state
+//
+// What it does NOT prove:
+// - Cross-process durability (see Layer 3 in icn-commons/tests/commons_persistence.rs)
+// ============================================================================
+
+/// Layer 4 — Daemon restart simulation: anchor + holder survive full production
+/// CommonsManager+CommonsHandle lifecycle boundary.
+#[actix_web::test]
+async fn test_l4_daemon_restart_simulation_anchor_and_holder() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let data_dir = tmp.path();
+    let commons_path = data_dir.join("commons.sled");
+
+    let keypair = KeyPair::generate().expect("KeyPair::generate");
+    let did = keypair.did().clone();
+
+    // ── Daemon startup + write ────────────────────────────────────────────────
+    // Mirrors lifecycle.rs: open CommonsHandle, inject into CommonsManager.
+    let (anchor_id, holder_id) = {
+        let handle =
+            icn_commons::CommonsHandle::with_sled_path(&commons_path).expect("open CommonsHandle");
+        let mgr = CommonsManager::with_handle(handle);
+        // Write anchor
+        let anchor = mgr
+            .create_anchor_from_enrollment(&did, None)
+            .await
+            .expect("create_anchor_from_enrollment");
+        let anchor_id = hex::encode(anchor.id());
+        // Write holder
+        let holder = mgr
+            .create_holder_from_anchor(&anchor_id, &did)
+            .await
+            .expect("create_holder_from_anchor");
+        let holder_id = hex::encode(holder.id());
+        // Flush before drop — simulates clean daemon shutdown
+        mgr.flush().await.expect("flush");
+        (anchor_id, holder_id)
+        // mgr drops here, then handle drops — sled lock released.
+        // This simulates the daemon exiting: all Arc refs go to zero.
+    };
+
+    // ── Daemon restart ────────────────────────────────────────────────────────
+    // Fresh CommonsHandle + CommonsManager from the same data_dir.
+    // No shared memory with the "previous daemon" — disk is the only bridge.
+    let handle2 =
+        icn_commons::CommonsHandle::with_sled_path(&commons_path).expect("reopen CommonsHandle");
+    let mgr2 = CommonsManager::with_handle(handle2);
+
+    // Assert 1: anchor present by ID after restart.
+    let found_anchor = mgr2
+        .get_anchor(&anchor_id)
+        .await
+        .expect("get_anchor after daemon restart");
+    assert!(
+        found_anchor.is_some(),
+        "PersonhoodAnchor must survive daemon restart simulation (Layer 4)"
+    );
+
+    // Assert 2: DID reverse-index survives restart.
+    let by_did = mgr2
+        .get_anchor_by_did(&did)
+        .await
+        .expect("get_anchor_by_did after daemon restart");
+    assert!(
+        by_did.is_some(),
+        "DID reverse-index must survive daemon restart simulation (Layer 4)"
+    );
+
+    // Assert 3: holder present by ID after restart.
+    let found_holder = mgr2
+        .get_holder(&holder_id)
+        .await
+        .expect("get_holder after daemon restart");
+    assert!(
+        found_holder.is_some(),
+        "CommonsHolderRecord must survive daemon restart simulation (Layer 4)"
+    );
+    assert_eq!(
+        found_holder.unwrap().holder_did,
+        did,
+        "holder_did must survive daemon restart round-trip (Layer 4)"
     );
 }


### PR DESCRIPTION
## Summary

- **Layer 2** (`icn-commons/tests/commons_persistence.rs`): 3 tests proving anchor, charter, and holder survive `CommonsHandle` substrate drop + reopen — directly exercises `CommonsHandle → CommonsInner → CommonsStore`, one level below the `CommonsManager` gateway facade
- **Layer 3** (`icn-commons/tests/commons_persistence.rs` + `src/bin/commons_restart_helper.rs`): 1 test proving anchor survives a true OS process boundary via write/read subprocesses — no shared memory, disk-only bridge
- **Layer 4** (`icn-gateway/tests/commons_integration.rs`): 1 test proving anchor + holder survive the production daemon wiring (`CommonsManager::with_handle(CommonsHandle::with_sled_path(...))`) after a full drop + reopen simulation

## What each layer proves vs doesn't prove

| Layer | What it proves | What it doesn't prove |
|---|---|---|
| 1 (existing) | `CommonsManager::with_sled_path()` round-trips through sled | Whether the substrate handle layer itself is sled-backed |
| 2 (new) | `CommonsHandle` substrate writes reach sled; all 3 entity types persist | Cross-process durability |
| 3 (new) | OS process boundary — no in-memory survival possible | Daemon-path wiring specifically |
| 4 (new) | Production wiring `CommonsManager::with_handle(CommonsHandle)` persists through restart | Cross-process durability (see Layer 3) |

## Test plan

All tests passing locally:
- `cargo test -p icn-commons --test commons_persistence` — 4 passed (Layer 2 × 3, Layer 3 × 1)
- `cargo test -p icn-gateway --test commons_integration -- test_l4` — 1 passed (Layer 4)
- `cargo fmt --all --check` — clean
- `cargo clippy -p icn-commons --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)