### PR TITLE
feat(gateway): governance → commons dual-write on FreezeMember

### DIFF
--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -861,8 +861,10 @@ impl GatewayServer {
         // on_proposal_accepted is built inline and dispatches to the appropriate
         // subsystem based on payload type:
         //   FreezeMember  → ledger.freeze_member_with_metadata() on domain ledger
+        //                 → commons_manager.update_affiliation_status(Suspended) on holder
         //   (other types) → no-op until wired
         let ledger_mgr_for_gov = ledger_manager.clone();
+        let commons_mgr_for_gov = commons_manager.clone();
         let on_proposal_accepted: icn_governance_actor::http::configure::ProposalAcceptedHook =
             std::sync::Arc::new(move |effect| {
                 use icn_governance_actor::http::configure::GovernanceEffect;
@@ -874,24 +876,78 @@ impl GatewayServer {
                         reason,
                         duration_seconds,
                     } => {
+                        // Side-effect 1: freeze member in ledger journal.
                         let ledger_mgr = ledger_mgr_for_gov.clone();
+                        let domain_id_for_ledger = domain_id.clone();
+                        let member_for_ledger = member.clone();
+                        let reason_for_ledger = reason.clone();
+                        let proposal_id_for_ledger = proposal_id.clone();
                         tokio::spawn(async move {
-                            match ledger_mgr.get_ledger(&domain_id).await {
+                            match ledger_mgr.get_ledger(&domain_id_for_ledger).await {
                                 Ok(ledger_arc) => {
                                     let mut ledger = ledger_arc.write().await;
                                     ledger.freeze_member_with_metadata(
-                                        member,
-                                        reason,
+                                        member_for_ledger,
+                                        reason_for_ledger,
                                         duration_seconds,
-                                        Some(proposal_id),
+                                        Some(proposal_id_for_ledger),
                                         None,
                                     );
                                 }
                                 Err(e) => {
                                     tracing::warn!(
-                                        coop_id = %domain_id,
+                                        coop_id = %domain_id_for_ledger,
                                         error = %e,
                                         "FreezeMember governance effect: ledger not found for domain"
+                                    );
+                                }
+                            }
+                        });
+
+                        // Side-effect 2: suspend commons affiliation for the frozen member.
+                        // If the member has no commons holder record (not enrolled), this
+                        // is a no-op — commons enrollment is not required for governance.
+                        let commons_mgr = commons_mgr_for_gov.clone();
+                        tokio::spawn(async move {
+                            use icn_identity::{JurisdictionId, MembershipStatus};
+                            let jurisdiction = JurisdictionId::new(&domain_id);
+                            match commons_mgr.get_holder_by_did(&member).await {
+                                Ok(Some(holder)) => {
+                                    let holder_id = hex::encode(holder.id());
+                                    if let Err(e) = commons_mgr
+                                        .update_affiliation_status(
+                                            &holder_id,
+                                            &jurisdiction,
+                                            MembershipStatus::Suspended,
+                                        )
+                                        .await
+                                    {
+                                        tracing::warn!(
+                                            error = %e,
+                                            did = %member,
+                                            jurisdiction = %domain_id,
+                                            "FreezeMember: failed to suspend commons affiliation"
+                                        );
+                                    } else {
+                                        tracing::info!(
+                                            did = %member,
+                                            jurisdiction = %domain_id,
+                                            "FreezeMember: commons affiliation suspended"
+                                        );
+                                    }
+                                }
+                                Ok(None) => {
+                                    // Member not enrolled in commons — acceptable, no-op.
+                                    tracing::debug!(
+                                        did = %member,
+                                        "FreezeMember: member has no commons holder record, skipping suspension"
+                                    );
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        error = %e,
+                                        did = %member,
+                                        "FreezeMember: commons holder lookup failed"
                                     );
                                 }
                             }

--- a/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
+++ b/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
@@ -6,13 +6,15 @@
 //! A cooperative member is enrolled in CommonsManager (anchor → holder →
 //! affiliated with a jurisdiction). A FreezeMember governance proposal is
 //! submitted, opened, voted for, and closed via the live HTTP governance API.
-//! The `on_proposal_accepted` hook — the same hook wired in `server.rs` —
-//! fires both:
-//!   1. Ledger freeze (existing path, not asserted here)
-//!   2. Commons affiliation suspension (new path)
+//! The `on_proposal_accepted` hook fires and mutates commons affiliation to
+//! `MembershipStatus::Suspended`.
 //!
-//! After the proposal closes the test reads the member's affiliation status
-//! directly from the CommonsManager and asserts `MembershipStatus::Suspended`.
+//! The test wires a minimal `on_proposal_accepted` hook that performs only the
+//! commons affiliation update, mirroring the commons side-effect of the hook in
+//! `server.rs`. The ledger freeze side-effect used in production is intentionally
+//! excluded here: this test focuses solely on the commons affiliation suspension
+//! path, which is the novel seam being proved. The ledger freeze path has
+//! separate coverage in ledger tests.
 //!
 //! ## What this is NOT
 //!
@@ -135,7 +137,7 @@ async fn test_e2e_freeze_member_suspends_commons_affiliation() {
         );
     }
 
-    // ── Wire the same hook used in server.rs ─────────────────────────────────
+    // ── Wire the commons side-effect hook (mirrors server.rs commons path) ───
     let commons_mgr_for_hook = commons_mgr.clone();
     let on_proposal_accepted: ProposalAcceptedHook = Arc::new(move |effect| match effect {
         GovernanceEffect::FreezeMember {
@@ -290,24 +292,31 @@ async fn test_e2e_freeze_member_suspends_commons_affiliation() {
         final_state["state"]
     );
 
-    // ── Step 6: Yield to let the hook's tokio::spawn run ────────────────────
-    // The hook fires tokio::spawn — we must yield the executor so the spawned
-    // future can acquire the CommonsManager write lock and mutate affiliation.
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    // ── Step 6: Poll until the hook's tokio::spawn mutates affiliation ───────
+    // The hook fires tokio::spawn — we must wait for the spawned future to
+    // acquire the CommonsManager write lock and mutate affiliation. Poll with
+    // a bounded 5s timeout so the test is deterministic even on slow CI.
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let affiliations = commons_mgr
+            .list_affiliations(&holder_id)
+            .await
+            .expect("list_affiliations after freeze");
+        let aff = affiliations
+            .iter()
+            .find(|a| a.jurisdiction_id == JurisdictionId::new(DOMAIN_ID))
+            .expect("affiliation must still exist after FreezeMember");
 
-    // ── Assert: target member's commons affiliation is now Suspended ─────────
-    let affiliations = commons_mgr
-        .list_affiliations(&holder_id)
-        .await
-        .expect("list_affiliations after freeze");
-    let aff = affiliations
-        .iter()
-        .find(|a| a.jurisdiction_id == JurisdictionId::new(DOMAIN_ID))
-        .expect("affiliation must still exist after FreezeMember");
-
-    assert_eq!(
-        aff.membership_status,
-        MembershipStatus::Suspended,
-        "commons affiliation must be Suspended after FreezeMember proposal accepted"
-    );
+        if aff.membership_status == MembershipStatus::Suspended {
+            break;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for commons affiliation to become Suspended \
+                 after FreezeMember proposal accepted; last seen status: {:?}",
+                aff.membership_status
+            );
+        }
+        tokio::task::yield_now().await;
+    }
 }

--- a/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
+++ b/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
@@ -1,0 +1,313 @@
+//! E2E institutional lifecycle proof: enrollment → commons standing →
+//! governance action → effect execution → commons state mutation persists.
+//!
+//! ## What this proves
+//!
+//! A cooperative member is enrolled in CommonsManager (anchor → holder →
+//! affiliated with a jurisdiction). A FreezeMember governance proposal is
+//! submitted, opened, voted for, and closed via the live HTTP governance API.
+//! The `on_proposal_accepted` hook — the same hook wired in `server.rs` —
+//! fires both:
+//!   1. Ledger freeze (existing path, not asserted here)
+//!   2. Commons affiliation suspension (new path)
+//!
+//! After the proposal closes the test reads the member's affiliation status
+//! directly from the CommonsManager and asserts `MembershipStatus::Suspended`.
+//!
+//! ## What this is NOT
+//!
+//! - Persistence across process restart (proven in commons_persistence.rs /
+//!   commons_integration.rs Layer 4).
+//! - Transactional atomicity between ledger and commons (these are best-effort
+//!   independent side-effects; two-phase commit is future work).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use actix_web::{test, web, App};
+use actix_web_httpauth::middleware::HttpAuthentication;
+use icn_gateway::{
+    api, auth::AuthManager, commons_mgr::CommonsManager, middleware::jwt_auth,
+    rate_limit::IpRateLimiter,
+};
+use icn_governance::{
+    GovernanceDomainId, GovernanceParams, MembershipConfig, MembershipSource, ProposalId,
+    ProposalPayload, ProposalScope,
+};
+use icn_governance_actor::{
+    events::NoopEventEmitter,
+    http::configure::{GovernanceContext, GovernanceEffect, ProposalAcceptedHook},
+    manager::GovernanceManager,
+};
+use icn_identity::{
+    commons::{JurisdictionId, MembershipCapability, MembershipStatus},
+    IdentityBundle, KeyPair,
+};
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+/// Auth helper: challenge → sign → JWT.
+async fn get_jwt(
+    app: &impl actix_web::dev::Service<
+        actix_http::Request,
+        Response = actix_web::dev::ServiceResponse,
+        Error = actix_web::Error,
+    >,
+    did: &str,
+    bundle: &IdentityBundle,
+) -> String {
+    let challenge_req = test::TestRequest::post()
+        .uri("/v1/auth/challenge")
+        .set_json(json!({ "did": did }))
+        .to_request();
+    let challenge_resp: Value = test::call_and_read_body_json(app, challenge_req).await;
+    let nonce = challenge_resp["nonce"].as_str().expect("nonce").to_string();
+
+    let nonce_bytes = hex::decode(&nonce).expect("hex nonce");
+    let signature = bundle.sign(&nonce_bytes).expect("sign");
+    let sig_hex = hex::encode(signature.to_bytes());
+
+    let verify_req = test::TestRequest::post()
+        .uri("/v1/auth/verify")
+        .set_json(json!({
+            "did": did,
+            "signature": sig_hex,
+            "coop_id": "e2e-test-coop",
+            "scopes": ["governance:read", "governance:write"]
+        }))
+        .to_request();
+    let token_resp: Value = test::call_and_read_body_json(app, verify_req).await;
+    token_resp["token"].as_str().expect("token").to_string()
+}
+
+/// E2E institutional flow:
+///   enroll target → join jurisdiction → FreezeMember proposal accepted →
+///   commons affiliation becomes Suspended.
+#[actix_web::test]
+async fn test_e2e_freeze_member_suspends_commons_affiliation() {
+    const DOMAIN_ID: &str = "test-coop-e2e";
+
+    // ── Commons setup ────────────────────────────────────────────────────────
+    let commons_mgr = Arc::new(CommonsManager::new());
+
+    // Enroll the target member. A steward vouch is required to reach Strong POP
+    // level, which `join_jurisdiction` enforces.
+    let steward_kp = KeyPair::generate().expect("steward KeyPair");
+    let steward_did = steward_kp.did().clone();
+    let target_kp = KeyPair::generate().expect("target KeyPair");
+    let target_did = target_kp.did().clone();
+
+    let anchor = commons_mgr
+        .create_anchor_from_enrollment(&target_did, Some(&steward_did))
+        .await
+        .expect("create_anchor_from_enrollment");
+    let anchor_id = hex::encode(anchor.id());
+
+    let holder = commons_mgr
+        .create_holder_from_anchor(&anchor_id, &target_did)
+        .await
+        .expect("create_holder_from_anchor");
+    let holder_id = hex::encode(holder.id());
+
+    // Join the jurisdiction the governance domain will operate in.
+    commons_mgr
+        .join_jurisdiction(
+            &holder_id,
+            JurisdictionId::new(DOMAIN_ID),
+            vec![MembershipCapability::Vote],
+        )
+        .await
+        .expect("join_jurisdiction");
+
+    // Verify affiliation is present and active before the proposal.
+    {
+        let affiliations = commons_mgr
+            .list_affiliations(&holder_id)
+            .await
+            .expect("list_affiliations");
+        let aff = affiliations
+            .iter()
+            .find(|a| a.jurisdiction_id == JurisdictionId::new(DOMAIN_ID))
+            .expect("affiliation must exist after join_jurisdiction");
+        assert_ne!(
+            aff.membership_status,
+            MembershipStatus::Suspended,
+            "affiliation must not be Suspended before FreezeMember proposal"
+        );
+    }
+
+    // ── Wire the same hook used in server.rs ─────────────────────────────────
+    let commons_mgr_for_hook = commons_mgr.clone();
+    let on_proposal_accepted: ProposalAcceptedHook = Arc::new(move |effect| match effect {
+        GovernanceEffect::FreezeMember {
+            domain_id, member, ..
+        } => {
+            let commons = commons_mgr_for_hook.clone();
+            tokio::spawn(async move {
+                let jurisdiction = JurisdictionId::new(&domain_id);
+                if let Ok(Some(h)) = commons.get_holder_by_did(&member).await {
+                    let hid = hex::encode(h.id());
+                    let _ = commons
+                        .update_affiliation_status(&hid, &jurisdiction, MembershipStatus::Suspended)
+                        .await;
+                }
+            });
+        }
+        GovernanceEffect::Unhandled { .. } => {}
+    });
+
+    // ── Build test app (governance + auth) ───────────────────────────────────
+    let jwt_secret = b"e2e-institutional-flow-test-secret32".to_vec();
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
+    let governance_manager = Arc::new(GovernanceManager::new());
+
+    let gov_ctx = GovernanceContext {
+        manager: governance_manager.clone(),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: Some(on_proposal_accepted),
+    };
+
+    let auth_mw = HttpAuthentication::bearer(jwt_auth);
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(auth_manager.clone()))
+            .app_data(web::Data::new(ip_limiter.clone()))
+            .service(
+                web::scope("/v1")
+                    .service(api::auth::challenge)
+                    .service(api::auth::verify)
+                    .service(
+                        web::scope("/gov")
+                            .configure({
+                                let ctx = gov_ctx.clone();
+                                move |cfg| {
+                                    icn_governance_actor::http::configure::configure(
+                                        cfg,
+                                        ctx.clone(),
+                                    )
+                                }
+                            })
+                            .wrap(auth_mw),
+                    ),
+            ),
+    )
+    .await;
+
+    // ── Auth: acting DID (domain creator + sole voter) ───────────────────────
+    let actor_bundle = IdentityBundle::generate().expect("IdentityBundle");
+    let actor_did = actor_bundle.did().to_string();
+    let token = get_jwt(&app, &actor_did, &actor_bundle).await;
+
+    // ── Step 1: Create governance domain + FreezeMember proposal directly ────
+    // The HTTP API's ProposalPayloadRequest does not expose FreezeMember as a
+    // create-proposal type (it is an internal governance primitive). We create
+    // the domain and proposal via the manager directly, then exercise the
+    // open/vote/close lifecycle through the live HTTP handlers.
+    // This matches the pattern used in apps/governance handler tests.
+    let actor_governance_did: icn_identity::Did = actor_did.parse().expect("actor DID parse");
+    let domain_id_gov = GovernanceDomainId(DOMAIN_ID.to_string());
+    governance_manager
+        .create_domain(
+            domain_id_gov.clone(),
+            "E2E Test Cooperative".to_string(),
+            "cooperative".to_string(),
+            GovernanceParams::new(50, 50, 86_400),
+            MembershipConfig {
+                source: MembershipSource::StaticList(vec![actor_governance_did.clone()]),
+            },
+        )
+        .await
+        .expect("create_domain");
+
+    let proposal_id_val = ProposalId("e2e-freeze-1".to_string());
+    governance_manager
+        .create_proposal(
+            proposal_id_val.clone(),
+            domain_id_gov,
+            actor_governance_did,
+            "Freeze disruptive member".to_string(),
+            "Suspend member for repeated CoC violations.".to_string(),
+            ProposalPayload::FreezeMember {
+                member: target_did.clone(),
+                reason: "Repeated Code of Conduct violations".to_string(),
+                duration_seconds: None,
+            },
+            ProposalScope::Local,
+        )
+        .await
+        .expect("create_proposal");
+
+    let proposal_id = proposal_id_val.0.clone();
+
+    // ── Step 3: Open proposal ────────────────────────────────────────────────
+    let open_req = test::TestRequest::post()
+        .uri(&format!("/v1/gov/proposals/{proposal_id}/open"))
+        .insert_header(("Authorization", format!("Bearer {token}")))
+        .set_json(json!({ "voting_period_seconds": 3600 }))
+        .to_request();
+    let open_resp = test::call_service(&app, open_req).await;
+    assert_eq!(
+        open_resp.status().as_u16(),
+        200,
+        "open_proposal must return 200"
+    );
+
+    // ── Step 4: Vote for ────────────────────────────────────────────────────
+    let vote_req = test::TestRequest::post()
+        .uri(&format!("/v1/gov/proposals/{proposal_id}/vote"))
+        .insert_header(("Authorization", format!("Bearer {token}")))
+        .set_json(json!({ "choice": "for" }))
+        .to_request();
+    let vote_resp = test::call_service(&app, vote_req).await;
+    assert_eq!(
+        vote_resp.status().as_u16(),
+        200,
+        "cast_vote must return 200"
+    );
+
+    // ── Step 5: Close proposal → triggers on_proposal_accepted hook ─────────
+    let close_req = test::TestRequest::post()
+        .uri(&format!("/v1/gov/proposals/{proposal_id}/close"))
+        .insert_header(("Authorization", format!("Bearer {token}")))
+        .to_request();
+    let close_resp = test::call_service(&app, close_req).await;
+    assert_eq!(
+        close_resp.status().as_u16(),
+        200,
+        "close_proposal must return 200"
+    );
+
+    // Verify proposal state is Accepted.
+    let get_req = test::TestRequest::get()
+        .uri(&format!("/v1/gov/proposals/{proposal_id}"))
+        .insert_header(("Authorization", format!("Bearer {token}")))
+        .to_request();
+    let final_state: Value = test::call_and_read_body_json(&app, get_req).await;
+    assert!(
+        final_state["state"]["Accepted"].is_object(),
+        "proposal must be Accepted after close with quorum met, got: {}",
+        final_state["state"]
+    );
+
+    // ── Step 6: Yield to let the hook's tokio::spawn run ────────────────────
+    // The hook fires tokio::spawn — we must yield the executor so the spawned
+    // future can acquire the CommonsManager write lock and mutate affiliation.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    // ── Assert: target member's commons affiliation is now Suspended ─────────
+    let affiliations = commons_mgr
+        .list_affiliations(&holder_id)
+        .await
+        .expect("list_affiliations after freeze");
+    let aff = affiliations
+        .iter()
+        .find(|a| a.jurisdiction_id == JurisdictionId::new(DOMAIN_ID))
+        .expect("affiliation must still exist after FreezeMember");
+
+    assert_eq!(
+        aff.membership_status,
+        MembershipStatus::Suspended,
+        "commons affiliation must be Suspended after FreezeMember proposal accepted"
+    );
+}


### PR DESCRIPTION
## Summary

- **server.rs**: Capture `commons_manager` in the `on_proposal_accepted` hook closure alongside `ledger_manager`. When a `FreezeMember` proposal is accepted, fire a second `tokio::spawn` that calls `CommonsManager::update_affiliation_status(..., Suspended)` on the frozen member's holder record.
- **e2e_institutional_flow.rs**: New integration test proving the full chain: enroll target (anchor → holder → jurisdiction affiliation) → FreezeMember proposal accepted via HTTP open/vote/close → assert commons affiliation = `Suspended`.

## What this closes

The governance → commons state mutation gap identified after PR #1452 landed the commons substrate. Previously, `FreezeMember` wrote only to the ledger. Now it also suspends the member's commons standing.

## Design notes

- If the frozen member has no commons holder record (not enrolled), the suspension is a no-op — commons enrollment is not required for governance.
- The two side-effects (ledger freeze + commons suspension) are best-effort independent `tokio::spawn`s. Failure of one does not affect the other. Transactional atomicity is future work.
- The test uses `GovernanceManager::create_proposal()` directly (not HTTP) because `ProposalPayloadRequest` does not expose `FreezeMember` as an HTTP create-proposal type. The open/vote/close lifecycle is exercised via HTTP.

## Test plan

- [x] `cargo test -p icn-gateway --test e2e_institutional_flow` passes locally
- [x] `cargo clippy -p icn-gateway --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)