### PR TITLE
feat(governance): close-time liquid democracy delegation tally

### DIFF
--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -1642,8 +1642,9 @@ impl GovernanceActor {
                     tally.add_vote(v);
                 }
 
-                // Resolve eligible membership
-                let eligible_count = self.resolver.member_count(&domain)?;
+                // Resolve eligible membership (list needed for delegation resolution)
+                let eligible_members = self.resolver.resolve_members(&domain)?;
+                let eligible_count = eligible_members.len();
 
                 // Edge case: cannot evaluate proposal with zero eligible voters
                 // This prevents division issues and ensures meaningful quorum calculation
@@ -1653,6 +1654,18 @@ impl GovernanceActor {
                         proposal.domain_id.0
                     ));
                 }
+
+                // Close-time liquid democracy: expand delegated votes for non-voters.
+                // For each eligible member who did NOT vote directly, resolve their
+                // delegation chain. If the terminal delegate voted, attribute their
+                // choice to the absent member. Direct votes always take precedence.
+                self.apply_delegation_to_tally(
+                    &votes,
+                    &eligible_members,
+                    &proposal.domain_id,
+                    &proposal_id,
+                    &mut tally,
+                );
 
                 // Get proposal-type-specific thresholds (Issue #477)
                 // Emergency proposals (freeze, veto, rollback) require higher quorum/approval
@@ -2547,6 +2560,122 @@ impl GovernanceActor {
         }
 
         Ok(delegations)
+    }
+
+    /// Resolve the delegation chain for a voter at a specific proposal, returning the
+    /// final effective voter DID.
+    ///
+    /// Follows active (non-expired, non-revoked) delegations matching the proposal's
+    /// domain or a blanket scope. Returns `voter` unchanged if no active delegation exists.
+    /// Stops at `MAX_DELEGATION_DEPTH` to prevent runaway chains (cycles are guaranteed
+    /// impossible by creation-time cycle detection, but the depth cap is a safety net).
+    ///
+    /// This mirrors `DelegationManager::resolve_delegate` but reads directly from the
+    /// Sled store instead of an in-memory manager.
+    fn resolve_delegate_from_store(
+        &self,
+        voter: &Did,
+        domain_id: &icn_governance::GovernanceDomainId,
+        proposal_id: &ProposalId,
+    ) -> Did {
+        let now = icn_time::current_timestamp_secs();
+        let mut current = voter.clone();
+        let mut visited = std::collections::HashSet::new();
+
+        for _ in 0..Self::MAX_DELEGATION_DEPTH {
+            visited.insert(current.clone());
+
+            // Load active delegations from current node, pick the most specific scope match
+            let delegations = match self.list_delegations_from(&current) {
+                Ok(d) => d,
+                Err(_) => break, // storage error → stop resolving, return best-so-far
+            };
+
+            let next = delegations
+                .into_iter()
+                .filter(|d| d.revoked_at.is_none() && d.is_active(now))
+                .filter_map(|d| {
+                    // Score by specificity: proposal-scope > domain-scope > blanket
+                    match &d.scope {
+                        icn_governance::DelegationScope::Proposal(pid) if pid == proposal_id => {
+                            Some((3u8, d.delegate))
+                        }
+                        icn_governance::DelegationScope::Domain(did) if did == domain_id => {
+                            Some((2, d.delegate))
+                        }
+                        icn_governance::DelegationScope::Blanket => Some((1, d.delegate)),
+                        _ => None,
+                    }
+                })
+                .max_by_key(|(score, _)| *score)
+                .map(|(_, delegate)| delegate);
+
+            match next {
+                Some(d) if !visited.contains(&d) => current = d,
+                _ => break,
+            }
+        }
+
+        current
+    }
+
+    /// Apply delegation to a raw vote tally, expanding delegated votes for non-voters.
+    ///
+    /// For each eligible member who did NOT vote directly, resolves their delegation
+    /// chain. If the final delegate DID voted, the non-voter's vote is attributed to
+    /// the delegate's choice (liquid democracy: absent members' weight flows to
+    /// whomever they trusted).
+    ///
+    /// Direct voters always override delegation — a member who voted directly is
+    /// never replaced by a delegated vote, regardless of what delegation records exist.
+    fn apply_delegation_to_tally(
+        &self,
+        votes: &[Vote],
+        eligible_members: &[Did],
+        domain_id: &icn_governance::GovernanceDomainId,
+        proposal_id: &ProposalId,
+        tally: &mut VoteTally,
+    ) {
+        // Build a fast lookup of who voted directly
+        let direct_voters: std::collections::HashSet<&Did> =
+            votes.iter().map(|v| &v.voter).collect();
+        let vote_by_did: std::collections::HashMap<&Did, &Vote> =
+            votes.iter().map(|v| (&v.voter, v)).collect();
+
+        let mut delegated = 0usize;
+        for member in eligible_members {
+            if direct_voters.contains(member) {
+                continue; // voted directly — no delegation needed
+            }
+
+            let delegate = self.resolve_delegate_from_store(member, domain_id, proposal_id);
+            if &delegate == member {
+                continue; // no active delegation
+            }
+
+            if let Some(delegate_vote) = vote_by_did.get(&delegate) {
+                // Create a synthetic vote for the delegating member using the delegate's choice.
+                let delegated_vote =
+                    Vote::new(proposal_id.clone(), member.clone(), delegate_vote.choice);
+                tally.add_vote(&delegated_vote);
+                delegated += 1;
+                tracing::debug!(
+                    member = %member,
+                    delegate = %delegate,
+                    choice = ?delegate_vote.choice,
+                    "Delegation applied: member's vote resolved through delegate"
+                );
+            }
+        }
+
+        if delegated > 0 {
+            tracing::info!(
+                proposal_id = %proposal_id.0,
+                delegated_votes = delegated,
+                "Close-time delegation resolution: {} votes applied via delegation",
+                delegated
+            );
+        }
     }
 
     /// Revoke a delegation

--- a/icn/crates/icn-core/tests/delegation_tally_integration.rs
+++ b/icn/crates/icn-core/tests/delegation_tally_integration.rs
@@ -1,0 +1,270 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! Integration tests proving close-time liquid democracy delegation resolution.
+//!
+//! Liquid democracy: eligible members who did NOT vote directly can delegate
+//! their vote to another member. At proposal close time, the actor resolves
+//! delegation chains and applies the delegate's vote choice on behalf of
+//! absent members.
+//!
+//! These tests prove:
+//! 1. **Delegation applies**: absent member's weight flows through their delegate
+//! 2. **Direct vote wins**: if both delegator and delegate vote, delegator is unaffected
+//! 3. **No-delegation baseline**: absent members without delegation produce no vote
+
+use anyhow::Result;
+use icn_core::{events::SubscriptionHandle, EventBus, SystemEvent};
+use icn_gossip::GossipActor;
+use icn_governance::{
+    Delegation, DelegationScope, GovernanceDomainId, GovernanceParams, MembershipConfig,
+    ProposalId, ProposalPayload, ProposalScope, StaticMembershipResolver, VoteChoice,
+};
+use icn_governance_actor::{GovernanceActor, GovernanceCommand, GovernanceConfigLite};
+use icn_identity::KeyPair;
+use icn_store::SledStore;
+use std::sync::{Arc, Mutex};
+
+/// Spawn a 3-member GovernanceActor with configurable quorum/approval thresholds.
+///
+/// Members: alice (passed in), bob, carol — all in "delegation-test-domain".
+/// Returns `(handle, captured_events, alice_did, bob_did, carol_did, domain_id)`.
+async fn make_three_member_actor(
+    quorum_pct: u8,
+    approval_pct: u8,
+) -> Result<(
+    icn_governance_actor::GovernanceHandle,
+    Arc<Mutex<Vec<SystemEvent>>>,
+    SubscriptionHandle,
+    icn_identity::Did,
+    icn_identity::Did,
+    icn_identity::Did,
+    GovernanceDomainId,
+)> {
+    let alice = KeyPair::generate()?;
+    let bob = KeyPair::generate()?;
+    let carol = KeyPair::generate()?;
+    let alice_did = alice.did().clone();
+    let bob_did = bob.did().clone();
+    let carol_did = carol.did().clone();
+
+    let store = Arc::new(SledStore::temporary()?);
+    let gossip = GossipActor::spawn(alice_did.clone(), None);
+    {
+        let mut g = gossip.write().await;
+        g.create_topic(icn_gossip::Topic::new(
+            "governance:proposal".to_string(),
+            icn_gossip::AccessControl::Public,
+        ));
+    }
+
+    let event_bus = Arc::new(EventBus::new());
+    let captured: Arc<Mutex<Vec<SystemEvent>>> = Arc::new(Mutex::new(vec![]));
+    let captured_clone = captured.clone();
+    let sub_handle = event_bus
+        .subscribe(Arc::new(move |event| {
+            captured_clone.lock().expect("lock").push(event);
+        }))
+        .await;
+
+    let resolver = Arc::new(StaticMembershipResolver::new());
+    let actor = GovernanceActor::spawn(
+        alice_did.clone(),
+        store,
+        gossip,
+        resolver,
+        Some(event_bus.clone()),
+        None,
+    )
+    .await?;
+
+    let domain_id = GovernanceDomainId::new("delegation-test-domain");
+    actor
+        .submit(GovernanceCommand::CreateDomain {
+            domain_id: domain_id.clone(),
+            name: "Delegation Test Domain".to_string(),
+            config: GovernanceConfigLite {
+                profile: "cooperative".to_string(),
+                params: GovernanceParams::new(quorum_pct, approval_pct, 604_800),
+                membership: MembershipConfig::static_list(vec![
+                    alice_did.clone(),
+                    bob_did.clone(),
+                    carol_did.clone(),
+                ]),
+            },
+        })
+        .await?;
+
+    Ok((
+        actor, captured, sub_handle, alice_did, bob_did, carol_did, domain_id,
+    ))
+}
+
+/// Create, open, and optionally vote on a proposal, then close it.
+async fn lifecycle_proposal(
+    actor: &icn_governance_actor::GovernanceHandle,
+    domain_id: &GovernanceDomainId,
+    voters: &[(icn_identity::Did, VoteChoice)],
+) -> Result<ProposalId> {
+    let proposal_id = ProposalId::generate();
+
+    actor
+        .submit(GovernanceCommand::CreateProposal {
+            proposal_id: proposal_id.clone(),
+            domain_id: domain_id.clone(),
+            title: "Delegation test proposal".to_string(),
+            description: "Tests liquid democracy at close time".to_string(),
+            payload: ProposalPayload::Text {
+                body: "Approve test motion".to_string(),
+            },
+            scope: ProposalScope::Local,
+        })
+        .await?;
+
+    actor
+        .submit(GovernanceCommand::OpenProposal {
+            proposal_id: proposal_id.clone(),
+            voting_period_seconds: 3600,
+        })
+        .await?;
+
+    for (voter, choice) in voters {
+        actor
+            .submit(GovernanceCommand::CastVote {
+                proposal_id: proposal_id.clone(),
+                choice: *choice,
+                voter: voter.clone(),
+                comment: None,
+            })
+            .await?;
+    }
+
+    actor
+        .submit(GovernanceCommand::CloseProposal {
+            proposal_id: proposal_id.clone(),
+        })
+        .await?;
+
+    Ok(proposal_id)
+}
+
+/// Count how many `ProposalAccepted` events have been captured.
+fn accepted_count(captured: &Arc<Mutex<Vec<SystemEvent>>>) -> usize {
+    captured
+        .lock()
+        .expect("lock")
+        .iter()
+        .filter(|e| matches!(e, SystemEvent::ProposalAccepted { .. }))
+        .count()
+}
+
+/// --- Test 1: Delegation raises quorum past threshold ---
+///
+/// Setup:
+/// - 3 members: Alice, Bob, Carol
+/// - Quorum = 67%, approval = 50%
+/// - Bob delegates to Alice (blanket scope)
+/// - Only Alice votes For; Bob and Carol do not vote
+///
+/// Quorum math (integer division, strictly-less check):
+///   quorum_required = (3 * 67) / 100 = 2
+///
+/// Without delegation:
+///   votes = 1/3, total_votes=1 < quorum_required=2 → NoQuorum (no ProposalAccepted)
+///
+/// With delegation (close-time resolution):
+///   Bob's absent vote is attributed to Alice's For choice
+///   effective votes = 2 (Alice direct + Bob delegated For)
+///   total_votes=2, quorum_required=2 → 2 < 2 is FALSE → quorum met
+///   for_votes=2, approval_required=(2*50)/100=1, 2>1 → Accepted
+#[tokio::test]
+async fn test_delegation_raises_participation_above_quorum() -> Result<()> {
+    let (actor, captured, _sub, alice_did, bob_did, _carol_did, domain_id) =
+        make_three_member_actor(67, 50).await?;
+
+    // Bob delegates to Alice (blanket scope)
+    let delegation = Delegation::new(bob_did.clone(), alice_did.clone(), DelegationScope::Blanket);
+    actor
+        .submit(GovernanceCommand::CreateDelegation {
+            delegation: delegation.clone(),
+        })
+        .await?;
+
+    // Only Alice votes; Bob (delegated) and Carol (no delegation) do not
+    lifecycle_proposal(&actor, &domain_id, &[(alice_did.clone(), VoteChoice::For)]).await?;
+
+    assert_eq!(
+        accepted_count(&captured),
+        1,
+        "Delegation should raise Bob's vote to Alice's For, reaching 2/3 = 66.7% ≥ 60% quorum"
+    );
+
+    Ok(())
+}
+
+/// --- Test 2: Without delegation, same setup fails quorum ---
+///
+/// Same as Test 1 but Bob has NO delegation. Only Alice votes.
+/// quorum_required = (3 * 67) / 100 = 2; total_votes=1 < 2 → NoQuorum
+/// ProposalAccepted NOT emitted.
+#[tokio::test]
+async fn test_no_delegation_fails_quorum() -> Result<()> {
+    let (actor, captured, _sub, alice_did, _bob_did, _carol_did, domain_id) =
+        make_three_member_actor(67, 50).await?;
+
+    // No delegations created — Alice votes alone
+    lifecycle_proposal(&actor, &domain_id, &[(alice_did.clone(), VoteChoice::For)]).await?;
+
+    assert_eq!(
+        accepted_count(&captured),
+        0,
+        "Without delegation, 1/3 votes = 33.3% < 60% quorum → no ProposalAccepted"
+    );
+
+    Ok(())
+}
+
+/// --- Test 3: Direct vote takes precedence over delegation ---
+///
+/// Bob delegates to Carol (Against), but Bob also votes For directly.
+/// Bob's direct For vote must NOT be replaced by Carol's Against choice.
+///
+/// Setup: 3 members, quorum=67%, approval=50%
+///   All 3 vote: Alice For, Bob For (direct), Carol Against
+///   quorum_required = (3*67)/100 = 2; total_votes=3 ≥ 2 → quorum met
+///   for_votes=2, approval_required=(3*50)/100=1; 2>1 → Accepted
+///
+/// If delegation INCORRECTLY replaced Bob's direct For with Carol's Against:
+///   for_votes=1 (only Alice), approval_required=1; 1>1 → FALSE → Rejected
+///   (observable behavior change proves direct-vote-wins logic is working)
+#[tokio::test]
+async fn test_direct_vote_overrides_delegation() -> Result<()> {
+    let (actor, captured, _sub, alice_did, bob_did, carol_did, domain_id) =
+        make_three_member_actor(67, 50).await?;
+
+    // Bob delegates to Carol (who will vote Against), but Bob will vote For directly
+    let delegation = Delegation::new(bob_did.clone(), carol_did.clone(), DelegationScope::Blanket);
+    actor
+        .submit(GovernanceCommand::CreateDelegation { delegation })
+        .await?;
+
+    // All three vote: Alice For, Bob For (direct overrides delegation), Carol Against
+    lifecycle_proposal(
+        &actor,
+        &domain_id,
+        &[
+            (alice_did.clone(), VoteChoice::For),
+            (bob_did.clone(), VoteChoice::For),
+            (carol_did.clone(), VoteChoice::Against),
+        ],
+    )
+    .await?;
+
+    // Correct: For=2 (Alice+Bob direct), Against=1 (Carol), 2>1 approval → Accepted
+    // Buggy (if delegation replaced Bob's For with Carol's Against): For=1, 1>1 → Rejected
+    assert_eq!(
+        accepted_count(&captured),
+        1,
+        "Bob's direct For vote should not be replaced by Carol's Against via delegation"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Wires liquid democracy delegation into the actor's close-proposal path
- At proposal close time, absent eligible members who delegated their vote have their weight attributed through the delegation chain
- Direct votes always take precedence over any active delegation records
- Sled-native implementation: reads delegation state from the persistent store, no in-memory manager required at close time

## Changes

**`apps/governance/src/actor.rs`**
- `GovernanceCommand::CloseProposal` handler: replaced `resolver.member_count()` with `resolver.resolve_members()` to get the full eligible member list (needed for per-member delegation resolution)
- Added `apply_delegation_to_tally()` call after the raw vote tally loop, before threshold evaluation
- Added `resolve_delegate_from_store()` private method: Sled-backed delegation chain resolution, mirrors `DelegationManager::resolve_delegate` but reads from persistent store; stops at `MAX_DELEGATION_DEPTH=3` hops
- Added `apply_delegation_to_tally()` private method: for each eligible non-voter, resolve delegation chain, attribute delegate's choice to absent member if delegate voted
- Fixed `filter_map` closure in `resolve_delegate_from_store` (removed spurious `let score =` binding that prevented the match from being returned)

**`crates/icn-core/tests/delegation_tally_integration.rs`** (new)
- `test_delegation_raises_participation_above_quorum`: 3 members, quorum=67%; Bob delegates to Alice; only Alice votes → 2 effective votes (Alice direct + Bob delegated) → Accepted
- `test_no_delegation_fails_quorum`: same setup without delegation → 1 vote < quorum → NoQuorum
- `test_direct_vote_overrides_delegation`: Bob delegates to Carol (Against), Bob votes For directly → direct For wins, outcome is Accepted (not Rejected as it would be if delegation incorrectly replaced Bob's direct vote)

## How delegation resolution works

```
CloseProposal handler:
  1. Load raw votes
  2. Build initial VoteTally from direct votes
  3. resolve_members() → full eligible member list
  4. apply_delegation_to_tally():
     for each eligible_member NOT in direct_voters:
       resolve_delegate_from_store(member) → traverse chain (Proposal > Domain > Blanket scope)
       if terminal delegate voted directly:
         attribute delegate's choice to absent member
  5. evaluate_with_thresholds(tally, thresholds, eligible_count)
```

## Test plan

- [x] `cargo check -p icn-governance-actor` — clean
- [x] `cargo test -p icn-core --test delegation_tally_integration` — 3/3 pass
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p icn-governance-actor -p icn-core --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)