### PR TITLE
fix(governance): block delegation for members who lost standing at close time

### DIFF
--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -1677,7 +1677,10 @@ impl GovernanceActor {
                     tally.add_vote(v);
                 }
 
-                // Resolve eligible membership (list needed for delegation resolution)
+                // Resolve eligible membership (list needed for delegation resolution).
+                // eligible_count uses the FULL member list as the quorum denominator —
+                // standing revalidation filters whose votes count but does not shrink
+                // the community for quorum purposes.
                 let eligible_members = self.resolver.resolve_members(&domain)?;
                 let eligible_count = eligible_members.len();
 
@@ -1691,12 +1694,26 @@ impl GovernanceActor {
                 }
 
                 // Close-time liquid democracy: expand delegated votes for non-voters.
-                // For each eligible member who did NOT vote directly, resolve their
-                // delegation chain. If the terminal delegate voted, attribute their
-                // choice to the absent member. Direct votes always take precedence.
+                //
+                // Delegation scope: when standing revalidation is active (`eligible_voters`
+                // is Some), only members with CURRENT standing can have delegation applied.
+                // A member who lost standing cannot have their absent weight flow through
+                // their delegation record — their absence must contribute to quorum failure,
+                // not be silently covered by a pre-existing delegation.
+                //
+                // Without a standing filter (eligible_voters=None), the full member list
+                // is used and any active delegation is honoured.
+                let delegation_scope: Vec<Did> = match &eligible_voters {
+                    Some(filter) => eligible_members
+                        .iter()
+                        .filter(|m| filter.contains(m))
+                        .cloned()
+                        .collect(),
+                    None => eligible_members.clone(),
+                };
                 self.apply_delegation_to_tally(
                     &votes,
-                    &eligible_members,
+                    &delegation_scope,
                     &proposal.domain_id,
                     &proposal_id,
                     &mut tally,

--- a/icn/crates/icn-core/tests/delegation_tally_integration.rs
+++ b/icn/crates/icn-core/tests/delegation_tally_integration.rs
@@ -140,6 +140,7 @@ async fn lifecycle_proposal(
     actor
         .submit(GovernanceCommand::CloseProposal {
             proposal_id: proposal_id.clone(),
+            eligible_voters: None,
         })
         .await?;
 
@@ -264,6 +265,97 @@ async fn test_direct_vote_overrides_delegation() -> Result<()> {
         accepted_count(&captured),
         1,
         "Bob's direct For vote should not be replaced by Carol's Against via delegation"
+    );
+
+    Ok(())
+}
+
+/// --- Test 4: Standing revalidation blocks delegation for ineligible members ---
+///
+/// A member who LOST standing AND delegated their vote should NOT have their
+/// absent weight flow through delegation when standing revalidation is active.
+///
+/// This tests the interaction between PR #1461 (standing revalidation) and
+/// PR #1462 (delegation resolution).
+///
+/// Setup: 3 members, quorum=67%, approval=50%
+///   Bob loses standing before close (simulated via eligible_voters filter)
+///   Bob delegated to Alice (who votes For)
+///   Only Alice votes directly
+///
+/// With correct interaction:
+///   eligible_voters = {Alice, Carol} (Bob excluded — lost standing)
+///   delegation_scope = intersection of eligible_members ∩ eligible_voters = {Alice, Carol}
+///   Bob is NOT in delegation_scope → delegation NOT applied for Bob
+///   effective votes = 1 (Alice direct For only)
+///   quorum_required = (3*67)/100 = 2; 1 < 2 → NoQuorum → no ProposalAccepted
+///
+/// Without the fix (buggy):
+///   delegation_scope = all eligible_members including Bob
+///   Bob's delegation to Alice fires → For=2 (Alice direct + Bob delegated)
+///   2 >= 2 quorum → Accepted (wrong!)
+#[tokio::test]
+async fn test_lost_standing_member_delegation_blocked() -> Result<()> {
+    let (actor, captured, _sub, alice_did, bob_did, carol_did, domain_id) =
+        make_three_member_actor(67, 50).await?;
+
+    // Bob delegates to Alice before losing standing
+    let delegation = Delegation::new(bob_did.clone(), alice_did.clone(), DelegationScope::Blanket);
+    actor
+        .submit(GovernanceCommand::CreateDelegation { delegation })
+        .await?;
+
+    // Create and open proposal
+    let proposal_id = ProposalId::generate();
+    actor
+        .submit(GovernanceCommand::CreateProposal {
+            proposal_id: proposal_id.clone(),
+            domain_id: domain_id.clone(),
+            title: "Standing-delegation interaction test".to_string(),
+            description: "Bob lost standing; should not delegate".to_string(),
+            payload: ProposalPayload::Text {
+                body: "Test motion".to_string(),
+            },
+            scope: ProposalScope::Local,
+        })
+        .await?;
+    actor
+        .submit(GovernanceCommand::OpenProposal {
+            proposal_id: proposal_id.clone(),
+            voting_period_seconds: 3600,
+        })
+        .await?;
+
+    // Only Alice votes
+    actor
+        .submit(GovernanceCommand::CastVote {
+            proposal_id: proposal_id.clone(),
+            choice: VoteChoice::For,
+            voter: alice_did.clone(),
+            comment: None,
+        })
+        .await?;
+
+    // Simulate standing revalidation: Bob lost standing before close.
+    // Only Alice and Carol are currently eligible (Bob excluded).
+    let mut eligible = std::collections::HashSet::new();
+    eligible.insert(alice_did.clone());
+    eligible.insert(carol_did.clone());
+
+    actor
+        .submit(GovernanceCommand::CloseProposal {
+            proposal_id: proposal_id.clone(),
+            eligible_voters: Some(eligible),
+        })
+        .await?;
+
+    // With correct behavior: Bob's delegation is blocked (he lost standing).
+    // Only Alice's direct For vote counts. 1 < quorum_required(2) → NoQuorum.
+    assert_eq!(
+        accepted_count(&captured),
+        0,
+        "Member who lost standing must not have delegation applied — their absence \
+         should contribute to quorum failure, not be covered by a pre-existing delegation"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

- Fixes a correctness bug in the interaction between close-time standing revalidation (#1461) and close-time delegation resolution (#1462)
- A member who lost commons standing AND had an active delegation record was incorrectly having their absent weight flow through delegation, defeating the point of standing revalidation
- Their absence must contribute to quorum failure, not be silently covered by a pre-existing delegation

## The Bug

When `close_proposal_filtered` is called (standing revalidation active), `apply_delegation_to_tally` still iterated the full `eligible_members` list. A member excluded from `eligible_voters` (lost standing) would:
1. Not appear in `direct_voters` (their vote was filtered)
2. Still appear in `eligible_members` (full member list)
3. Trigger delegation chain resolution — attributing a synthetic vote on their behalf

This means a suspended member with an active delegation could still influence the outcome.

## Fix

When `eligible_voters` is Some, restrict the `delegation_scope` to `eligible_members ∩ eligible_voters`. Only members who currently hold standing can contribute via delegation.

The quorum **denominator** (`eligible_count`) remains the full member list — standing revalidation filters who contributes, not the size of the community.

```rust
let delegation_scope: Vec<Did> = match &eligible_voters {
    Some(filter) => eligible_members.iter().filter(|m| filter.contains(m)).cloned().collect(),
    None => eligible_members.clone(),
};
```

## Test

`test_lost_standing_member_delegation_blocked`:
- 3 members, quorum=67% (requires 2 votes from 3 members)
- Bob delegates to Alice, then loses standing before close
- Alice votes For; eligible_voters = {Alice, Carol} (Bob excluded)
- **Expected**: Bob's delegation blocked → 1 vote < 2 required → NoQuorum
- **Without fix**: Bob's delegation fires → 2 votes ≥ 2 required → Accepted (wrong)

## Validation

- [x] `cargo test -p icn-core --test delegation_tally_integration` — 4/4 pass
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p icn-governance-actor -p icn-core --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)