### PR TITLE
feat(kernel-api): add decision_hash to TreasuryEffect::Allocate to unblock execution

### DIFF
--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -298,6 +298,7 @@ pub fn translate_payload_to_effects(
                     recipient_did: opt.recipient.to_string(),
                     amount: opt.requested_amount,
                     currency: unit.clone(),
+                    decision_hash: decision_hash.to_string(),
                 }));
             }
             Ok(effects)

--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -683,11 +683,16 @@ mod tests {
                 budget_id,
                 amount,
                 currency,
+                decision_hash,
                 ..
             }) => {
                 assert_eq!(budget_id, "alloc-q1-budget-receipt-alloc-1");
                 assert_eq!(*amount, 6_000);
                 assert_eq!(currency, "compute-hours");
+                assert_eq!(
+                    decision_hash, "decision-hash-alloc-1",
+                    "Allocate must carry decision_hash from proposal context (empty → Deferred)"
+                );
             }
             other => panic!("expected Allocate for Infrastructure, got {other:?}"),
         }
@@ -698,11 +703,16 @@ mod tests {
                 budget_id,
                 amount,
                 currency,
+                decision_hash,
                 ..
             }) => {
                 assert_eq!(budget_id, "alloc-q1-budget-receipt-alloc-1");
                 assert_eq!(*amount, 4_000);
                 assert_eq!(currency, "compute-hours");
+                assert_eq!(
+                    decision_hash, "decision-hash-alloc-1",
+                    "Allocate must carry decision_hash from proposal context (empty → Deferred)"
+                );
             }
             other => panic!("expected Allocate for Education, got {other:?}"),
         }

--- a/icn/crates/icn-core/src/supervisor/decision_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/decision_executor.rs
@@ -1375,6 +1375,9 @@ mod tests {
             recipient_did: "did:icn:member-test".to_string(),
             amount: 100,
             currency: "HOURS".to_string(),
+            // Empty decision_hash → None in TreasuryOperation → Deferred path.
+            // This test verifies that effects without provenance defer correctly.
+            decision_hash: String::new(),
         })];
 
         let results = executor

--- a/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
+++ b/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
@@ -594,6 +594,140 @@ async fn test_recovery_does_not_re_execute_confirmed() {
     assert_eq!(after.ledger_entry_ids, vec!["entry-1"]);
 }
 
+/// Test: TreasuryEffect::Allocate with a populated decision_hash executes and produces a
+/// real ledger entry (debit treasury → credit budget liability account).
+///
+/// This test proves "governance allocation → actual economic state change":
+/// - `decision_hash` on the effect flows through `treasury_effect_to_operation`
+/// - `execute_treasury_operation` does NOT hit the Deferred path
+/// - A ledger entry is committed with Governance provenance
+/// - The execution record reaches `Confirmed`
+#[tokio::test(flavor = "multi_thread")]
+async fn test_allocate_with_decision_hash_executes_and_produces_ledger_entry() {
+    use icn_core::supervisor::decision_executor::DecisionExecutor;
+    use icn_core::supervisor::effect_dispatcher::EffectDispatcher;
+    use icn_core::supervisor::governance_executor::KernelGovernanceExecutor;
+
+    let tmp = TempDir::new().unwrap();
+    let ledger_store_path = tmp.path().join("ledger");
+    let exec_store_path = tmp.path().join("execution");
+    std::fs::create_dir_all(&ledger_store_path).unwrap();
+    std::fs::create_dir_all(&exec_store_path).unwrap();
+
+    let decision_hash = "hash-allocate-executes-1";
+    let decision_receipt_id = "receipt-allocate-executes-1";
+    let treasury_did = RT_TEST_TREASURY;
+    let budget_id = "alloc-member-services-receipt-allocate-executes-1";
+    let recipient_did = "did:icn:zGyGKxMyg1p9SsHfm15MkNUu1u9TN2JtTspcdmrtGUdse";
+
+    let ledger_store = Arc::new(SledStore::open(&ledger_store_path).unwrap());
+    let ledger = Arc::new(TokioRwLock::new(
+        icn_ledger::Ledger::new(ledger_store).unwrap(),
+    ));
+
+    let ledger_service = Arc::new(LedgerServiceImpl::new(
+        ledger.clone(),
+        Arc::new(AllowAllOracle::wildcard()),
+        treasury_did.parse().unwrap(),
+    ));
+    let kernel_executor =
+        KernelGovernanceExecutor::new(Arc::new(StubParamStore)).with_ledger_service(ledger_service);
+
+    let dispatcher = Arc::new(EffectDispatcher::new(Arc::new(kernel_executor)));
+    let exec_backend = Arc::new(SledStore::open(&exec_store_path).unwrap());
+    let exec_store = Arc::new(SledExecutionStore::new(exec_backend));
+    let executor = DecisionExecutor::new(dispatcher, exec_store.clone());
+
+    let effects = vec![KernelEffect::Treasury(TreasuryEffect::Allocate {
+        treasury_did: treasury_did.to_string(),
+        budget_id: budget_id.to_string(),
+        recipient_did: recipient_did.to_string(),
+        amount: 1_000,
+        currency: "HOURS".to_string(),
+        decision_hash: decision_hash.to_string(),
+    })];
+
+    let results = executor
+        .execute(
+            effects,
+            decision_receipt_id,
+            decision_hash,
+            "proposal-alloc-1",
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 1, "expected one EffectResult");
+    assert!(
+        results[0].success,
+        "Allocate with decision_hash must succeed (not deferred), got: {:?}",
+        results[0].message
+    );
+    assert!(
+        !results[0].not_executed,
+        "Allocate must not be marked not_executed when decision_hash is present"
+    );
+    assert!(
+        !results[0].message.contains("Deferred"),
+        "expected no Deferred message, got: {:?}",
+        results[0].message
+    );
+
+    let record = exec_store.get(decision_hash).unwrap().unwrap();
+    assert_eq!(
+        record.status,
+        ExecutionStatus::Confirmed,
+        "execution record must be Confirmed after successful Allocate"
+    );
+    assert_eq!(
+        record.ledger_entry_ids.len(),
+        1,
+        "exactly one ledger entry expected for Allocate"
+    );
+
+    let entry_hash = content_hash_from_hex(&record.ledger_entry_ids[0]).unwrap();
+    let ledger_guard = ledger.read().await;
+    let entry = ledger_guard.get_entry(&entry_hash).unwrap().unwrap();
+    assert!(
+        matches!(
+            &entry.provenance,
+            ProvenanceRef::Governance { receipt_id, decision_hash: dh }
+                if receipt_id == decision_receipt_id && dh == decision_hash
+        ),
+        "ledger entry provenance must carry governance receipt_id and decision_hash"
+    );
+    // Verify account deltas: treasury debit + budget liability credit
+    assert_eq!(
+        entry.accounts.len(),
+        2,
+        "Allocate must produce exactly 2 account deltas"
+    );
+    let debit = entry
+        .accounts
+        .iter()
+        .find(|a| a.debit.is_some())
+        .expect("must have a debit delta");
+    let credit = entry
+        .accounts
+        .iter()
+        .find(|a| a.credit.is_some())
+        .expect("must have a credit delta");
+    assert_eq!(
+        debit.account_id.as_str(),
+        treasury_did,
+        "debit must be from treasury"
+    );
+    assert_eq!(debit.debit, Some(1_000));
+    assert_eq!(credit.credit, Some(1_000));
+    // Budget liability DID is a synthetic hash-derived DID — verify it's NOT the recipient_did
+    // (which would be wrong: recipient_did is audit metadata, not the ledger routing key)
+    assert_ne!(
+        credit.account_id.as_str(),
+        recipient_did,
+        "credit must go to budget liability account (budget_id), not directly to recipient_did"
+    );
+}
+
 /// Test 10: Treasury execution appends a real ledger entry with governance provenance,
 /// and the entry + execution record survive restart.
 #[tokio::test(flavor = "multi_thread")]
@@ -966,6 +1100,9 @@ async fn test_deferred_outcome_sled_persists_not_executed() {
         recipient_did: "did:icn:member-test".to_string(),
         amount: 50,
         currency: "HOURS".to_string(),
+        // Deliberately empty: empty decision_hash → None in TreasuryOperation → Deferred path.
+        // Tests backward compat for effects persisted before decision_hash was added to Allocate.
+        decision_hash: String::new(),
     })];
 
     {

--- a/icn/crates/icn-kernel-api/src/effects.rs
+++ b/icn/crates/icn-kernel-api/src/effects.rs
@@ -104,6 +104,11 @@ pub enum TreasuryEffect {
         recipient_did: String,
         amount: i64,
         currency: String,
+        /// Governance decision hash used as idempotency key by the treasury executor.
+        /// Empty string (default) causes the executor to defer this effect until a
+        /// decision hash is available — preserving backward compat with older serialized effects.
+        #[serde(default)]
+        decision_hash: String,
     },
     /// Transfer between accounts
     Transfer {
@@ -751,6 +756,7 @@ mod tests {
                 recipient_did: "did:icn:member1".into(),
                 amount: 500,
                 currency: "USD".into(),
+                decision_hash: "h-alloc-1".into(),
             },
             TreasuryEffect::Transfer {
                 from_did: "did:icn:a".into(),
@@ -891,6 +897,7 @@ mod tests {
             recipient_did: "did:icn:alice".into(),
             amount: 100,
             currency: "HOURS".into(),
+            decision_hash: "hash-q1-alloc".into(),
         };
         let op = treasury_effect_to_operation(&effect);
         assert_eq!(

--- a/icn/crates/icn-kernel-api/src/effects.rs
+++ b/icn/crates/icn-kernel-api/src/effects.rs
@@ -909,5 +909,24 @@ mod tests {
             op.memo.contains("did:icn:alice"),
             "recipient_did should appear in memo for audit provenance"
         );
+        assert_eq!(
+            op.decision_hash,
+            Some("hash-q1-alloc".to_string()),
+            "non-empty decision_hash must propagate to TreasuryOperation.decision_hash as Some(...)"
+        );
+        // Verify empty decision_hash maps to None (preserves Deferred for legacy effects)
+        let legacy_effect = TreasuryEffect::Allocate {
+            treasury_did: "did:icn:treasury".into(),
+            budget_id: "budget-q1".into(),
+            recipient_did: String::new(),
+            amount: 100,
+            currency: "HOURS".into(),
+            decision_hash: String::new(),
+        };
+        let legacy_op = treasury_effect_to_operation(&legacy_effect);
+        assert_eq!(
+            legacy_op.decision_hash, None,
+            "empty decision_hash must map to None to preserve Deferred behavior for legacy effects"
+        );
     }
 }

--- a/icn/crates/icn-kernel-api/src/governance.rs
+++ b/icn/crates/icn-kernel-api/src/governance.rs
@@ -336,6 +336,7 @@ pub fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperatio
             recipient_did,
             amount,
             currency,
+            decision_hash,
         } => TreasuryOperation {
             treasury_id: treasury_did.clone(),
             operation_type: TreasuryOperationType::Allocate,
@@ -352,7 +353,11 @@ pub fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperatio
                 format!("Budget allocation from {budget_id} → {recipient_did}")
             },
             expected_nonce: None,
-            decision_hash: None,
+            decision_hash: if decision_hash.is_empty() {
+                None
+            } else {
+                Some(decision_hash.clone())
+            },
         },
         TreasuryEffect::Transfer {
             from_did,


### PR DESCRIPTION
## Summary

- `TreasuryEffect::Allocate` had no `decision_hash` field, causing `execute_treasury_operation` to return `ExecutionOutcome::Deferred` on every allocation — making `ProposalPayload::Allocation` effectively inert
- Adds `decision_hash: String` with `#[serde(default)]` for backward compatibility with Sled-persisted effects
- Propagates `decision_hash` through `treasury_effect_to_operation` → `TreasuryOperation::decision_hash: Some(...)`
- Populates it from the governance decision context in `translate_payload_to_effects`

## Behavior

| `decision_hash` | Before | After |
|---|---|---|
| Empty (legacy effects) | Deferred | Deferred (backward compat preserved) |
| Populated (new effects) | Deferred | Executes → ledger entry |

## Test Plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test -p icn-kernel-api --lib` — 302 passed
- [x] `cargo test -p icn-core --test decision_executor_runtime_test` — 14 passed (including new test)
- [x] **New test**: `test_allocate_with_decision_hash_executes_and_produces_ledger_entry` — proves governance allocation → real ledger entry (treasury debit + budget liability credit, with governance provenance)

## Stacking

Depends on #1464 (`feat(kernel-api): add recipient_did to TreasuryEffect::Allocate`). Base branch will be retargeted to `main` after #1464 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)