### PR TITLE
feat(governance): implement TreasuryEffect::DistributeSurplus execution end-to-end

### DIFF
--- a/icn/crates/icn-core/src/bin/ledger_restart_helper.rs
+++ b/icn/crates/icn-core/src/bin/ledger_restart_helper.rs
@@ -135,6 +135,7 @@ fn run_write(sled_path: PathBuf) -> i32 {
         expected_nonce: Some(0),
         decision_receipt_id: RECEIPT_ID.to_string(),
         decision_hash: "proof-decision-hash-layer4".to_string(),
+        distributions: Vec::new(),
     };
 
     let result = match service.submit_treasury_entry(request) {

--- a/icn/crates/icn-core/src/services/ledger_service.rs
+++ b/icn/crates/icn-core/src/services/ledger_service.rs
@@ -200,8 +200,26 @@ impl LedgerServiceImpl {
                             .to_string(),
                     );
                 }
+
+                // Validate: sum of individual amounts must equal req.amount to prevent
+                // the logged total from diverging from actual ledger mutations.
+                let distribution_sum: i64 = req.distributions.iter().map(|(_, amt)| amt).sum();
+                if distribution_sum != req.amount {
+                    return Err(format!(
+                        "DistributeSurplus: distribution sum ({distribution_sum}) \
+                         does not equal total amount ({})",
+                        req.amount
+                    ));
+                }
+
+                // Sort by recipient DID string to canonicalize delta ordering.
+                // The ledger entry hash covers the AccountDelta sequence, so ordering
+                // must be deterministic across all nodes processing the same decision.
+                let mut sorted: Vec<&(String, i64)> = req.distributions.iter().collect();
+                sorted.sort_by(|(a, _), (b, _)| a.cmp(b));
+
                 let mut deltas = Vec::with_capacity(req.distributions.len() * 2);
-                for (member_did_str, amount) in &req.distributions {
+                for (member_did_str, amount) in sorted {
                     let member_did: icn_identity::Did = member_did_str
                         .parse()
                         .map_err(|e| format!("Invalid member DID in distribution: {e}"))?;

--- a/icn/crates/icn-core/src/services/ledger_service.rs
+++ b/icn/crates/icn-core/src/services/ledger_service.rs
@@ -190,6 +190,34 @@ impl LedgerServiceImpl {
                     AccountDelta::credit(recipient_did, req.currency.clone(), req.amount),
                 ])
             }
+            TreasuryOperationType::DistributeSurplus => {
+                // Fan-out: one debit per distribution, one credit per member.
+                // All deltas land in a single JournalEntry so the one-receipt-one-entry
+                // idempotency invariant is preserved across retries.
+                if req.distributions.is_empty() {
+                    return Err(
+                        "DistributeSurplus requires at least one distribution (empty list)"
+                            .to_string(),
+                    );
+                }
+                let mut deltas = Vec::with_capacity(req.distributions.len() * 2);
+                for (member_did_str, amount) in &req.distributions {
+                    let member_did: icn_identity::Did = member_did_str
+                        .parse()
+                        .map_err(|e| format!("Invalid member DID in distribution: {e}"))?;
+                    deltas.push(AccountDelta::debit(
+                        self.treasury_did.clone(),
+                        req.currency.clone(),
+                        *amount,
+                    ));
+                    deltas.push(AccountDelta::credit(
+                        member_did,
+                        req.currency.clone(),
+                        *amount,
+                    ));
+                }
+                Ok(deltas)
+            }
             _ => {
                 // Other operation types can be added as needed
                 Err(format!(
@@ -717,6 +745,7 @@ mod tests {
             expected_nonce: Some(0),
             decision_receipt_id: "gov:proposal:2024-001:receipt:abc".to_string(),
             decision_hash: "sha256:deadbeef".to_string(),
+            distributions: Vec::new(),
         };
 
         // These must be non-empty for pilot invariant
@@ -749,6 +778,7 @@ mod tests {
             expected_nonce: Some(0),
             decision_receipt_id: "gov:proposal:pr3:idempotency:001".to_string(),
             decision_hash: "decision-hash-pr3-001".to_string(),
+            distributions: Vec::new(),
         };
 
         let first = service.submit_treasury_entry(request.clone()).unwrap();
@@ -794,6 +824,7 @@ mod tests {
             expected_nonce: Some(0),
             decision_receipt_id: "gov:proposal:pr3:idempotency:restart".to_string(),
             decision_hash: "decision-hash-pr3-restart".to_string(),
+            distributions: Vec::new(),
         };
 
         let first_hash = {
@@ -859,6 +890,7 @@ mod tests {
             expected_nonce: Some(0),
             decision_receipt_id: "gov:proposal:pr3:idempotency:concurrent".to_string(),
             decision_hash: "decision-hash-pr3-concurrent".to_string(),
+            distributions: Vec::new(),
         };
 
         let req_a = request.clone();
@@ -908,6 +940,7 @@ mod tests {
             expected_nonce: Some(0),
             decision_receipt_id: "gov:proposal:pr4:nonce:first".to_string(),
             decision_hash: "decision-hash-pr4-nonce-first".to_string(),
+            distributions: Vec::new(),
         };
         service.submit_treasury_entry(first).unwrap();
 
@@ -926,6 +959,7 @@ mod tests {
             expected_nonce: Some(0),
             decision_receipt_id: "gov:proposal:pr4:nonce:stale".to_string(),
             decision_hash: "decision-hash-pr4-nonce-stale".to_string(),
+            distributions: Vec::new(),
         };
         let err = service.submit_treasury_entry(stale).unwrap_err();
         assert!(
@@ -974,6 +1008,7 @@ mod tests {
             expected_nonce: Some(baseline),
             decision_receipt_id: "gov:proposal:pr5:nonce:coherence".to_string(),
             decision_hash: "decision-hash-pr5-nonce-coherence".to_string(),
+            distributions: Vec::new(),
         };
         service.submit_treasury_entry(request).unwrap();
 

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -2521,11 +2521,12 @@ mod tests {
         );
         assert!(
             effect_result.not_executed,
-            "DistributeSurplus should be structurally not executed until ledger support exists"
+            "DistributeSurplus without ledger service must defer (not_executed=true): {}",
+            effect_result.message
         );
         assert!(
-            effect_result.message.contains("DistributeSurplus"),
-            "message should name the effect: {}",
+            effect_result.message.starts_with("Deferred:"),
+            "message must be a Deferred reason when ledger service is not configured: {}",
             effect_result.message
         );
     }

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -300,22 +300,22 @@ impl KernelGovernanceExecutor {
                 }
             }
 
-            // Surplus distribution: multi-recipient settlement is not implemented in the kernel
-            // treasury → ledger bridge (single `TreasuryEntryRequest` per operation). Do not map
-            // through `treasury_effect_to_operation` placeholder (that path could report success
-            // with no ledger mutation when `decision_hash` is absent).
+            // Surplus distribution: fan-out payment to N members in a single journal entry.
+            //
+            // Routes through treasury_effect_to_operation → TreasuryOperation::DistributeSurplus
+            // → execute_treasury_operation → submit_treasury_entry (DistributeSurplus arm).
+            // All N debit/credit deltas land in one JournalEntry so the one-receipt-one-entry
+            // idempotency invariant is preserved across retries.
             TreasuryEffect::DistributeSurplus { .. } => {
-                warn!(
-                    "DistributeSurplus received: multi-recipient surplus settlement is not implemented in the kernel executor; no ledger mutation"
-                );
-                Ok(EffectResult {
-                    effect_id: decision_receipt_id.to_string(),
-                    success: false,
-                    message: "DistributeSurplus: multi-recipient surplus distribution is not implemented in the kernel treasury executor (no balances changed)".to_string(),
-                    state_change_hash: None,
-                    ledger_entry_id: None,
-                    not_executed: true,
-                })
+                let operation = treasury_effect_to_operation(&treasury_effect);
+                let outcome = self
+                    .treasury
+                    .execute_treasury_operation(receipt_id, operation)
+                    .await?;
+                Ok(execution_outcome_to_effect_result(
+                    outcome,
+                    decision_receipt_id,
+                ))
             }
 
             // RedeemShares and IssueBond: not yet implemented in this executor.
@@ -797,6 +797,7 @@ impl TreasuryExecutor for KernelTreasuryExecutor {
                 recipient: operation.recipient.clone(),
                 memo: operation.memo.clone(),
                 expected_nonce: operation.expected_nonce,
+                distributions: operation.distributions.clone(),
                 decision_receipt_id: receipt_id.to_string(),
                 decision_hash: decision_hash.clone(),
             };
@@ -873,6 +874,7 @@ fn convert_operation_type(
         GovOp::Allocate => SvcOp::Allocate,
         GovOp::Reserve => SvcOp::Allocate, // Map Reserve to Allocate
         GovOp::Release => SvcOp::Transfer, // Map Release to Transfer
+        GovOp::DistributeSurplus => SvcOp::DistributeSurplus,
     }
 }
 
@@ -2005,6 +2007,7 @@ mod tests {
             memo: "Test payment".to_string(),
             expected_nonce: Some(0),
             decision_hash: Some("sha256:abc123".to_string()),
+            distributions: Vec::new(),
         };
 
         let result = executor
@@ -2065,6 +2068,7 @@ mod tests {
             memo: "Test payment".to_string(),
             expected_nonce: Some(0),
             decision_hash: None,
+            distributions: Vec::new(),
         };
 
         let result = executor

--- a/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
+++ b/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
@@ -1146,3 +1146,154 @@ async fn test_deferred_outcome_sled_persists_not_executed() {
     assert_eq!(reread.retries, 0);
     assert!(reread.error.as_deref().unwrap_or("").contains("Deferred:"));
 }
+
+/// Test 15: DistributeSurplus execution produces a single ledger entry with 2*N account deltas.
+///
+/// This proves:
+/// 1. TreasuryEffect::DistributeSurplus no longer hits the `not_executed: true` wall
+/// 2. N-recipient fan-out is a single JournalEntry (one-receipt-one-entry invariant)
+/// 3. Each recipient gets a debit-from-treasury + credit-to-member pair
+/// 4. Governance provenance is recorded on the entry
+#[tokio::test(flavor = "multi_thread")]
+async fn test_distribute_surplus_executes_single_entry_with_n_deltas() {
+    use icn_core::supervisor::decision_executor::DecisionExecutor;
+    use icn_core::supervisor::effect_dispatcher::EffectDispatcher;
+    use icn_core::supervisor::governance_executor::KernelGovernanceExecutor;
+
+    let tmp = TempDir::new().unwrap();
+    let ledger_store_path = tmp.path().join("ledger");
+    let exec_store_path = tmp.path().join("execution");
+    std::fs::create_dir_all(&ledger_store_path).unwrap();
+    std::fs::create_dir_all(&exec_store_path).unwrap();
+
+    let decision_hash = "hash-distribute-surplus-executes-1";
+    let decision_receipt_id = "receipt-distribute-surplus-executes-1";
+    let treasury_did = RT_TEST_TREASURY;
+
+    // Two recipients with known valid multibase DIDs
+    let member_a = "did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9";
+    let member_b = "did:icn:zGyGKxMyg1p9SsHfm15MkNUu1u9TN2JtTspcdmrtGUdse";
+    let distributions = vec![
+        (member_a.to_string(), 300_i64),
+        (member_b.to_string(), 200_i64),
+    ];
+    let total_amount = 500_i64;
+
+    let ledger_store = Arc::new(SledStore::open(&ledger_store_path).unwrap());
+    let ledger = Arc::new(TokioRwLock::new(
+        icn_ledger::Ledger::new(ledger_store).unwrap(),
+    ));
+
+    let ledger_service = Arc::new(LedgerServiceImpl::new(
+        ledger.clone(),
+        Arc::new(AllowAllOracle::wildcard()),
+        treasury_did.parse().unwrap(),
+    ));
+    let kernel_executor =
+        KernelGovernanceExecutor::new(Arc::new(StubParamStore)).with_ledger_service(ledger_service);
+
+    let dispatcher = Arc::new(EffectDispatcher::new(Arc::new(kernel_executor)));
+    let exec_backend = Arc::new(SledStore::open(&exec_store_path).unwrap());
+    let exec_store = Arc::new(SledExecutionStore::new(exec_backend));
+    let executor = DecisionExecutor::new(dispatcher, exec_store.clone());
+
+    let effects = vec![KernelEffect::Treasury(TreasuryEffect::DistributeSurplus {
+        treasury_did: treasury_did.to_string(),
+        total_amount,
+        currency: "HOURS".to_string(),
+        distributions: distributions.clone(),
+        decision_receipt_id: decision_receipt_id.to_string(),
+        decision_hash: decision_hash.to_string(),
+    })];
+
+    let results = executor
+        .execute(
+            effects,
+            decision_receipt_id,
+            decision_hash,
+            "proposal-distribute-surplus-1",
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 1, "expected one EffectResult");
+    assert!(
+        results[0].success,
+        "DistributeSurplus must succeed (not hit not_executed wall), got: {:?}",
+        results[0].message
+    );
+    assert!(
+        !results[0].not_executed,
+        "DistributeSurplus must not be marked not_executed when decision_hash is present"
+    );
+    assert!(
+        !results[0].message.contains("Deferred"),
+        "expected no Deferred message, got: {:?}",
+        results[0].message
+    );
+
+    // One-receipt-one-entry invariant: N recipients → 1 JournalEntry
+    let record = exec_store.get(decision_hash).unwrap().unwrap();
+    assert_eq!(
+        record.status,
+        ExecutionStatus::Confirmed,
+        "execution record must be Confirmed after DistributeSurplus"
+    );
+    assert_eq!(
+        record.ledger_entry_ids.len(),
+        1,
+        "exactly one ledger entry expected for DistributeSurplus regardless of recipient count"
+    );
+
+    // Verify the single entry has 2*N account deltas
+    let entry_hash = content_hash_from_hex(&record.ledger_entry_ids[0]).unwrap();
+    let ledger_guard = ledger.read().await;
+    let entry = ledger_guard.get_entry(&entry_hash).unwrap().unwrap();
+
+    assert!(
+        matches!(
+            &entry.provenance,
+            ProvenanceRef::Governance { receipt_id, decision_hash: dh }
+                if receipt_id == decision_receipt_id && dh == decision_hash
+        ),
+        "ledger entry provenance must carry governance receipt_id and decision_hash"
+    );
+
+    // 2 recipients × 2 deltas (debit treasury + credit member) = 4 account deltas
+    assert_eq!(
+        entry.accounts.len(),
+        4,
+        "DistributeSurplus with 2 recipients must produce 4 account deltas (debit+credit per member)"
+    );
+
+    let debits: Vec<_> = entry.accounts.iter().filter(|a| a.debit.is_some()).collect();
+    let credits: Vec<_> = entry.accounts.iter().filter(|a| a.credit.is_some()).collect();
+    assert_eq!(debits.len(), 2, "must have 2 treasury debits");
+    assert_eq!(credits.len(), 2, "must have 2 member credits");
+
+    // All debits from treasury
+    for debit in &debits {
+        assert_eq!(
+            debit.account_id.as_str(),
+            treasury_did,
+            "all debits must come from treasury"
+        );
+    }
+
+    // Credits go to member DIDs, total = total_amount
+    let credit_total: i64 = credits.iter().filter_map(|a| a.credit).sum();
+    assert_eq!(
+        credit_total, total_amount,
+        "total credits must equal total_amount"
+    );
+    let credit_dids: std::collections::HashSet<&str> =
+        credits.iter().map(|a| a.account_id.as_str()).collect();
+    assert!(
+        credit_dids.contains(member_a),
+        "member_a must appear in credits"
+    );
+    assert!(
+        credit_dids.contains(member_b),
+        "member_b must appear in credits"
+    );
+}

--- a/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
+++ b/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
@@ -1266,8 +1266,16 @@ async fn test_distribute_surplus_executes_single_entry_with_n_deltas() {
         "DistributeSurplus with 2 recipients must produce 4 account deltas (debit+credit per member)"
     );
 
-    let debits: Vec<_> = entry.accounts.iter().filter(|a| a.debit.is_some()).collect();
-    let credits: Vec<_> = entry.accounts.iter().filter(|a| a.credit.is_some()).collect();
+    let debits: Vec<_> = entry
+        .accounts
+        .iter()
+        .filter(|a| a.debit.is_some())
+        .collect();
+    let credits: Vec<_> = entry
+        .accounts
+        .iter()
+        .filter(|a| a.credit.is_some())
+        .collect();
     assert_eq!(debits.len(), 2, "must have 2 treasury debits");
     assert_eq!(credits.len(), 2, "must have 2 member credits");
 

--- a/icn/crates/icn-core/tests/effect_group_integration.rs
+++ b/icn/crates/icn-core/tests/effect_group_integration.rs
@@ -99,6 +99,7 @@ async fn test_treasury_create_budget_provenance_chain() -> Result<()> {
         memo: "2024 Operations Budget".to_string(),
         expected_nonce: Some(0),
         decision_hash: Some(decision_hash.clone()),
+        distributions: Vec::new(),
     };
 
     let outcome = executor

--- a/icn/crates/icn-core/tests/federated_two_node_pilot.rs
+++ b/icn/crates/icn-core/tests/federated_two_node_pilot.rs
@@ -158,6 +158,7 @@ async fn test_two_node_treasury_spend_determinism() -> Result<()> {
         memo: "Pilot equipment purchase".to_string(),
         expected_nonce: Some(0),
         decision_hash: Some(decision_hash.clone()),
+        distributions: Vec::new(),
     };
 
     let outcome_a = executor_a
@@ -207,6 +208,7 @@ async fn test_two_node_treasury_spend_determinism() -> Result<()> {
         memo: "Pilot equipment purchase".to_string(),
         expected_nonce: Some(0),
         decision_hash: Some(decision_hash.clone()),
+        distributions: Vec::new(),
     };
 
     let outcome_b = executor_b

--- a/icn/crates/icn-core/tests/ledger_service_persistence.rs
+++ b/icn/crates/icn-core/tests/ledger_service_persistence.rs
@@ -84,6 +84,7 @@ async fn test_ledger_service_entry_survives_drop_and_reopen() {
             expected_nonce: Some(0),
             decision_receipt_id: "proof:receipt:layer3:001".to_string(),
             decision_hash: "proof-decision-hash-layer3".to_string(),
+            distributions: Vec::new(),
         };
 
         let result = service

--- a/icn/crates/icn-core/tests/treasury_integration.rs
+++ b/icn/crates/icn-core/tests/treasury_integration.rs
@@ -1176,6 +1176,7 @@ async fn test_ledger_entry_carries_decision_provenance() -> Result<()> {
         expected_nonce: Some(0),
         decision_receipt_id: decision_receipt_id.clone(),
         decision_hash: decision_hash.clone(),
+        distributions: Vec::new(),
     };
 
     // Execute the treasury operation
@@ -1309,6 +1310,7 @@ async fn test_decision_to_ledger_provenance_end_to_end() -> Result<()> {
         memo: "E2E provenance test payment".to_string(),
         expected_nonce: Some(0),
         decision_hash: Some(decision_hash.clone()),
+        distributions: Vec::new(),
     };
 
     // Execute via the executor trait (this is the real kernel path)

--- a/icn/crates/icn-kernel-api/src/governance.rs
+++ b/icn/crates/icn-kernel-api/src/governance.rs
@@ -57,6 +57,13 @@ pub struct TreasuryOperation {
     pub expected_nonce: Option<u64>,
     /// Canonical decision hash for provenance (cross-node anchor)
     pub decision_hash: Option<String>,
+    /// Per-recipient distribution amounts (DistributeSurplus only).
+    ///
+    /// Each entry is `(member_did, amount)`. All distributions land in a single journal entry
+    /// to preserve the one-receipt-one-entry idempotency invariant.
+    /// Empty for all other operation types.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub distributions: Vec<(String, i64)>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -66,6 +73,9 @@ pub enum TreasuryOperationType {
     Allocate,
     Reserve,
     Release,
+    /// Fan-out surplus settlement: N debits from treasury, N credits to member DIDs.
+    /// The `distributions` field on `TreasuryOperation` carries the per-recipient amounts.
+    DistributeSurplus,
 }
 
 /// Protocol parameter change request
@@ -311,6 +321,7 @@ pub fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperatio
             memo: memo.clone(),
             expected_nonce: Some(*expected_nonce),
             decision_hash: Some(decision_hash.clone()),
+            distributions: Vec::new(),
         },
         TreasuryEffect::CreateBudget {
             treasury_did,
@@ -329,6 +340,7 @@ pub fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperatio
             memo: name.clone(),
             expected_nonce: None,
             decision_hash: Some(decision_hash.clone()),
+            distributions: Vec::new(),
         },
         TreasuryEffect::Allocate {
             treasury_did,
@@ -358,6 +370,7 @@ pub fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperatio
             } else {
                 Some(decision_hash.clone())
             },
+            distributions: Vec::new(),
         },
         TreasuryEffect::Transfer {
             from_did,
@@ -379,6 +392,7 @@ pub fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperatio
             } else {
                 Some(decision_hash.clone())
             },
+            distributions: Vec::new(),
         },
         TreasuryEffect::ReleaseEscrow {
             treasury_did,
@@ -397,18 +411,32 @@ pub fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperatio
             memo: format!("Escrow release: {}", escrow_id),
             expected_nonce: None,
             decision_hash: Some(decision_hash.clone()),
+            distributions: Vec::new(),
         },
-        // Not executed via `TreasuryOperation` / `submit_treasury_entry` today (multi-recipient).
-        // `KernelGovernanceExecutor::execute_treasury_with_budget` handles this explicitly.
-        TreasuryEffect::DistributeSurplus { .. } => TreasuryOperation {
-            treasury_id: String::new(),
-            operation_type: TreasuryOperationType::Reserve,
-            amount: 0,
-            currency: "UNKNOWN".to_string(),
+        TreasuryEffect::DistributeSurplus {
+            treasury_did,
+            total_amount,
+            currency,
+            distributions,
+            decision_receipt_id: _,
+            decision_hash,
+        } => TreasuryOperation {
+            treasury_id: treasury_did.clone(),
+            operation_type: TreasuryOperationType::DistributeSurplus,
+            amount: *total_amount,
+            currency: currency.clone(),
             recipient: None,
-            memo: "DistributeSurplus: unmapped to single TreasuryOperation".to_string(),
+            memo: format!("Surplus distribution: {} recipients", distributions.len()),
             expected_nonce: None,
-            decision_hash: None,
+            decision_hash: if decision_hash.is_empty() {
+                None
+            } else {
+                Some(decision_hash.clone())
+            },
+            distributions: distributions
+                .iter()
+                .map(|(did, amt)| (did.clone(), *amt))
+                .collect(),
         },
         // Other treasury effects mapped to basic operations
         _ => TreasuryOperation {
@@ -420,6 +448,7 @@ pub fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperatio
             memo: "Unmapped treasury effect".to_string(),
             expected_nonce: None,
             decision_hash: None,
+            distributions: Vec::new(),
         },
     }
 }
@@ -553,6 +582,7 @@ mod tests {
             memo: "Equipment purchase".to_string(),
             expected_nonce: Some(7),
             decision_hash: Some("sha256:abc123".to_string()),
+            distributions: Vec::new(),
         };
         let json = serde_json::to_string(&op).unwrap();
         let parsed: TreasuryOperation = serde_json::from_str(&json).unwrap();

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -648,6 +648,16 @@ pub struct TreasuryEntryRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expected_nonce: Option<u64>,
 
+    /// Per-recipient distribution amounts for `DistributeSurplus` operations.
+    ///
+    /// Each entry is `(member_did, amount)`. All amounts are debited from the treasury
+    /// and credited to the respective member DIDs in a single journal entry.
+    /// Ignored for all other operation types.
+    ///
+    /// Default is empty (backward-compatible with existing requests).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub distributions: Vec<(String, i64)>,
+
     // Provenance fields (pilot-critical)
     /// Decision receipt ID that authorized this entry (node-local reference)
     pub decision_receipt_id: String,
@@ -727,6 +737,7 @@ impl TreasuryEntryRequest {
             recipient: Some(intent.to.clone()),
             memo: intent.memo.clone().unwrap_or_default(),
             expected_nonce: None,
+            distributions: Vec::new(),
             decision_receipt_id: intent.decision_receipt_id.clone(),
             decision_hash: decision_hash_hex,
         })


### PR DESCRIPTION
## What

Removes the `not_executed: true` wall that was blocking surplus settlement execution in the participatory budgeting flow. `TreasuryEffect::DistributeSurplus` now executes end-to-end through the kernel treasury executor.

## Why

Every governance decision carrying `DistributeSurplus` was silently deferred with `not_executed: true` — surplus settlement was completely inert. This is the execution path for patronage dividend payouts.

## How

- Added `DistributeSurplus` variant to `governance::TreasuryOperationType`
- Added `distributions: Vec<(String, i64)>` (serde default) to `TreasuryOperation` and `TreasuryEntryRequest`
- Wired `treasury_effect_to_operation` DistributeSurplus arm with real mapping
- Added `build_account_deltas` arm in `LedgerServiceImpl` producing 2×N deltas (debit-treasury + credit-member per recipient)
- Replaced `not_executed: true` hardcode in `governance_executor.rs` with path-3 routing through `self.treasury.execute_treasury_operation`
- Added `distributions: Vec::new()` to all 12 construction sites affected by the new struct fields

## Key invariant preserved

N recipients → 1 `JournalEntry` with 2N account deltas. The `decision_receipt_id` CAS key ensures idempotency regardless of recipient count. Proven by new integration test.

## Risk

- `#[serde(default)]` on both new fields ensures backward compat with Sled-persisted effects written before this PR
- Stacked on #1466 (Allocate decision_hash) — should be merged after #1464 and #1466

## Test plan

- `test_distribute_surplus_executes_single_entry_with_n_deltas`: 2-recipient fan-out → 1 entry, 4 deltas, governance provenance
- All 15 `decision_executor_runtime_test` tests pass
- `cargo check --all-targets --workspace` clean
- `cargo clippy --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)