### PR TITLE
feat(treasury): add decision_hash to TreasuryEffect::Transfer; honest errors for RedeemShares/IssueBond

### DIFF
--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -318,6 +318,34 @@ impl KernelGovernanceExecutor {
                 })
             }
 
+            // RedeemShares and IssueBond: not yet implemented in this executor.
+            // Return an honest non-deferred failure rather than falling through to
+            // `treasury_effect_to_operation`'s `_ =>` placeholder which produces
+            // zeroed-out operation data and a misleading "missing provenance" Deferred.
+            TreasuryEffect::RedeemShares { .. } => {
+                warn!("RedeemShares received: not yet implemented in the kernel treasury executor");
+                Ok(EffectResult {
+                    effect_id: decision_receipt_id.to_string(),
+                    success: false,
+                    message: "RedeemShares: not yet implemented in the kernel treasury executor (no balances changed)".to_string(),
+                    state_change_hash: None,
+                    ledger_entry_id: None,
+                    not_executed: false,
+                })
+            }
+
+            TreasuryEffect::IssueBond { .. } => {
+                warn!("IssueBond received: not yet implemented in the kernel treasury executor");
+                Ok(EffectResult {
+                    effect_id: decision_receipt_id.to_string(),
+                    success: false,
+                    message: "IssueBond: not yet implemented in the kernel treasury executor (no balances changed)".to_string(),
+                    state_change_hash: None,
+                    ledger_entry_id: None,
+                    not_executed: false,
+                })
+            }
+
             // Path 3: All other treasury effects → direct delegation
             _ => {
                 let operation = treasury_effect_to_operation(&treasury_effect);

--- a/icn/crates/icn-kernel-api/src/effects.rs
+++ b/icn/crates/icn-kernel-api/src/effects.rs
@@ -107,6 +107,11 @@ pub enum TreasuryEffect {
         amount: i64,
         currency: String,
         memo: String,
+        /// Governance decision hash used as idempotency key by the treasury executor.
+        /// Empty string (default) causes the executor to defer this effect until a
+        /// decision hash is available — preserving backward compat with older serialized effects.
+        #[serde(default)]
+        decision_hash: String,
     },
     /// Surplus distribution to members
     DistributeSurplus {
@@ -752,6 +757,7 @@ mod tests {
                 amount: 200,
                 currency: "USD".into(),
                 memo: "xfer".into(),
+                decision_hash: String::new(),
             },
             TreasuryEffect::DistributeSurplus {
                 treasury_did: "did:icn:t1".into(),

--- a/icn/crates/icn-kernel-api/src/governance.rs
+++ b/icn/crates/icn-kernel-api/src/governance.rs
@@ -351,6 +351,7 @@ pub fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperatio
             amount,
             currency,
             memo,
+            decision_hash,
         } => TreasuryOperation {
             treasury_id: from_did.clone(),
             operation_type: TreasuryOperationType::Spend,
@@ -359,7 +360,11 @@ pub fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperatio
             recipient: Some(to_did.clone()),
             memo: memo.clone(),
             expected_nonce: None,
-            decision_hash: None,
+            decision_hash: if decision_hash.is_empty() {
+                None
+            } else {
+                Some(decision_hash.clone())
+            },
         },
         TreasuryEffect::ReleaseEscrow {
             treasury_did,


### PR DESCRIPTION
## What

- Adds `decision_hash: String` with `#[serde(default)]` to `TreasuryEffect::Transfer` — the last `TreasuryEffect` execution variant without governance provenance support
- Updates `treasury_effect_to_operation` Transfer arm to propagate the hash (`Some(hash)` when non-empty, `None` when empty → Deferred backward-compat path)
- Adds explicit `RedeemShares` and `IssueBond` arms in `KernelGovernanceExecutor::execute_treasury_with_budget` returning honest `success: false, not_executed: false` failures

## Why

`TreasuryEffect::Transfer` had no `decision_hash` field, so all Transfer effects were unconditionally Deferred by the executor (hardcoded `decision_hash: None` → `execute_treasury_operation` returns `Deferred { reason: "missing provenance" }`). This is a silent failure — callers get `not_executed: true` with no indication a field was missing.

`RedeemShares` and `IssueBond` fell through to the `_ =>` arm in `treasury_effect_to_operation` which produced a zeroed-out `TreasuryOperation { treasury_id: "", amount: 0, decision_hash: None }`. This always Deferred with a generic "missing provenance" message — wrong data AND misleading error. Honest failure (`not_executed: false`) is correct here since the variants were received and recognized, they're just not implemented yet.

## How

- `TreasuryEffect::Transfer`: new `decision_hash` field with `#[serde(default)]` preserves sled backward compat (old serialized Transfer records have no `decision_hash` key — `Default` fills in `String::new()` which maps to the existing Deferred path)
- `treasury_effect_to_operation` Transfer arm: `if decision_hash.is_empty() { None } else { Some(decision_hash.clone()) }`
- Two new explicit match arms in `execute_treasury_with_budget` before `_ =>`; return `success: false, not_executed: false` with a clear "not yet implemented" message

## Risk

Low. `#[serde(default)]` on a new field is a safe additive change for Sled-persisted structs. The executor behavior for Transfer with an empty `decision_hash` is unchanged (still Defers). The `RedeemShares`/`IssueBond` behavior changes from misleading-Deferred to honest-failure — both are non-success, so no callers treating success=false specially will change behavior.

## Test plan

- `cargo check --all-targets` ✅
- `cargo fmt --all -- --check` ✅
- `cargo clippy -p icn-kernel-api -p icn-core --all-targets -- -D warnings` ✅
- `cargo test -p icn-kernel-api` ✅ (9 passed)
- `cargo test -p icn-core --lib` ✅ (351 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)