### PR TITLE
fix(ledger): add member_payments to SurplusAllocation; fix DistributeSurplus DID translation

### DIFF
--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -76,10 +76,12 @@ pub fn translate_payload_to_effects(
         })]),
 
         ProposalPayload::SurplusAllocation { allocation } => {
+            // Use member_payments (resolved holder DIDs) not allocations (ShareId keys).
+            // ShareId strings are not valid DIDs; the ledger executor parses distributions as DIDs.
             let distributions = allocation
-                .allocations
+                .member_payments
                 .iter()
-                .map(|(share_id, amount)| (share_id.0.clone(), *amount))
+                .map(|(did, amount)| (did.to_string(), *amount))
                 .collect();
             Ok(vec![KernelEffect::Treasury(
                 TreasuryEffect::DistributeSurplus {
@@ -718,6 +720,14 @@ mod tests {
 
     #[test]
     fn test_translate_surplus_allocation_carries_decision_provenance() {
+        let member_a_did: icn_identity::Did =
+            "did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9"
+                .parse()
+                .unwrap();
+        let member_b_did: icn_identity::Did =
+            "did:icn:zGyGKxMyg1p9SsHfm15MkNUu1u9TN2JtTspcdmrtGUdse"
+                .parse()
+                .unwrap();
         let allocation = icn_ledger::SurplusAllocation {
             id: "alloc-q1".to_string(),
             cooperative_id: "coop-x".to_string(),
@@ -729,6 +739,8 @@ mod tests {
                 (icn_ledger::ShareId::new("share-a"), 300),
                 (icn_ledger::ShareId::new("share-b"), 200),
             ],
+            // member_payments carries the resolved holder DIDs used by the execution path.
+            member_payments: vec![(member_a_did.clone(), 300), (member_b_did.clone(), 200)],
             proposal_id: "prop-1".to_string(),
             allocated_at: 0,
             currency: "HOURS".to_string(),
@@ -754,9 +766,13 @@ mod tests {
                 assert_eq!(treasury_did, "domain-coop-x");
                 assert_eq!(*total_amount, 500);
                 assert_eq!(currency, "HOURS");
+                // distributions must carry member DIDs (not ShareId strings).
                 assert_eq!(
                     distributions,
-                    &vec![("share-a".to_string(), 300), ("share-b".to_string(), 200)]
+                    &vec![
+                        (member_a_did.to_string(), 300),
+                        (member_b_did.to_string(), 200)
+                    ]
                 );
                 assert_eq!(decision_receipt_id, "receipt-surplus-1");
                 assert_eq!(decision_hash, "hash-surplus-1");

--- a/icn/crates/icn-governance/src/proposal.rs
+++ b/icn/crates/icn-governance/src/proposal.rs
@@ -1742,8 +1742,9 @@ mod tests {
                 (icn_ledger::ShareId::new("share-001"), 50_000),
                 (icn_ledger::ShareId::new("share-002"), 50_000),
             ],
+            member_payments: vec![], // Not needed for this structural proposal test
             proposal_id: String::new(), // Will be set after proposal creation
-            allocated_at: 0,            // Will be set on execution
+            allocated_at: 0,         // Will be set on execution
             currency: "COOP".to_string(),
         };
 

--- a/icn/crates/icn-ledger/src/labor_shares.rs
+++ b/icn/crates/icn-ledger/src/labor_shares.rs
@@ -574,7 +574,18 @@ pub struct SurplusAllocation {
     pub total_labor_days: u64,
 
     /// Individual allocations: (share_id, amount)
+    /// Used by the treasury's internal accounting to update `LaborShare.accumulated_surplus`.
     pub allocations: Vec<(ShareId, i64)>,
+
+    /// Member DID → amount pairs derived from `allocations` at construction time.
+    /// Populated by `SurplusAllocation::new` from each share's `holder` field.
+    /// Used by the governance execution path to build `TreasuryEffect::DistributeSurplus.distributions`.
+    ///
+    /// `#[serde(default)]` preserves backward compat: records persisted before this field was
+    /// added deserialize with an empty Vec, which the execution path treats as a not-yet-resolved
+    /// allocation (and declines to execute rather than silently using wrong IDs).
+    #[serde(default)]
+    pub member_payments: Vec<(Did, i64)>,
 
     /// Governance proposal that approved this allocation
     pub proposal_id: String,
@@ -685,6 +696,25 @@ impl SurplusAllocation {
                 .collect()
         };
 
+        // Build member_payments from share holder DIDs.
+        // Keyed by the same ShareId values in `allocations` so the two lists stay in sync.
+        let holder_map: std::collections::HashMap<&ShareId, &Did> =
+            active_shares.iter().map(|s| (&s.id, &s.holder)).collect();
+        let member_payments: Vec<(Did, i64)> = allocations
+            .iter()
+            .map(|(share_id, amount)| {
+                holder_map
+                    .get(share_id)
+                    .map(|holder| ((*holder).clone(), *amount))
+                    .ok_or_else(|| {
+                        format!(
+                            "allocation share_id {} not found in active_shares",
+                            share_id
+                        )
+                    })
+            })
+            .collect::<Result<_, _>>()?;
+
         Ok(SurplusAllocation {
             id,
             cooperative_id,
@@ -693,6 +723,7 @@ impl SurplusAllocation {
             share_unit_value,
             total_labor_days,
             allocations,
+            member_payments,
             proposal_id,
             allocated_at,
             currency,


### PR DESCRIPTION
## What

- Adds `member_payments: Vec<(Did, i64)>` field to `SurplusAllocation` (with `#[serde(default)]`), populated by `::new` from each `LaborShare.holder` DID
- Fixes `ProposalPayload::SurplusAllocation` handler in `execution.rs` to use `allocation.member_payments` instead of `allocation.allocations` for building `TreasuryEffect::DistributeSurplus.distributions`
- Updates the `execution.rs` translation test to assert distributions carry valid DIDs, not ShareId strings

## Why

`DistributeSurplus` was built correctly in the kernel (PR #1467), but the governance app translation was silently passing `share_id.0` strings (format: `share-<timestamp>-<uuid>`) as member DIDs. `LedgerServiceImpl::build_account_deltas` calls `member_did_str.parse::<icn_identity::Did>()` — which fails for any real ShareId string with "Invalid member DID in distribution".

This meant every production `SurplusAllocation` governance proposal would fail with a parse error at execution time, even though the kernel mechanism was correct.

`SurplusAllocation.allocations: Vec<(ShareId, i64)>` carries share-keyed amounts needed for treasury internal accounting (updating `LaborShare.accumulated_surplus` per share record in `treasury.rs::execute_surplus_allocation`). Those usages are unchanged.

## How

- `SurplusAllocation::new` already has access to `active_shares[].holder: Did`. After computing `allocations`, build `holder_map: HashMap<&ShareId, &Did>` from the same `active_shares`, then derive `member_payments` by mapping each `(share_id, amount)` → `(holder_did, amount)`. Returns `Err` if a share_id is somehow not in the active_shares (invariant violation — belt+suspenders, this can't happen in practice).
- `#[serde(default)]` on `member_payments`: old persisted `SurplusAllocation` records (before this field) deserialize with `[]`. The execution path treats an empty `distributions` list as a rejection ("requires at least one distribution"), which is correct — better to fail loudly than silently use wrong IDs.

## Risk

Low. `allocations` field is unchanged, preserving all treasury.rs internal accounting. The only consumers that need updating are literal struct constructions (two test sites in `proposal.rs` and the test in `execution.rs`). All updated. `407 icn-ledger + 409 icn-governance + 46 icn-governance-actor` tests pass.

## Test plan

- `cargo check --all-targets` ✅
- `cargo fmt --all -- --check` ✅
- `cargo clippy -p icn-ledger -p icn-governance --all-targets -- -D warnings` ✅
- `cargo test -p icn-ledger --lib` ✅ (407 passed)
- `cargo test -p icn-governance --lib` ✅ (409 passed)
- `cargo test -p icn-governance-actor --lib` ✅ (46 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)