### PR TITLE
feat(federation): clearing settlement with service-owned ledger emission and operational scheduler

### DIFF
--- a/icn/crates/icn-core/src/services/federation_service.rs
+++ b/icn/crates/icn-core/src/services/federation_service.rs
@@ -12,8 +12,9 @@ use icn_federation::types::{CooperativeInfo, FederationPolicy, Vouch};
 use icn_federation::{BilateralClearingAgreement, ClearingManager, CooperativeRegistry};
 use icn_identity::Did;
 use icn_kernel_api::{
-    FederationClearingRequest, FederationClearingResult, FederationJoinRequest,
-    FederationJoinResult, FederationService, FederationVouchRequest, FederationVouchResult,
+    FederationClearingRequest, FederationClearingResult, FederationClearingSettleRequest,
+    FederationClearingSettleResult, FederationJoinRequest, FederationJoinResult, FederationService,
+    FederationVouchRequest, FederationVouchResult,
 };
 use sha2::{Digest, Sha256};
 use tracing::info;
@@ -310,6 +311,107 @@ impl FederationService for FederationServiceImpl {
                 );
                 Ok(FederationClearingResult {
                     success: false,
+                    state_change_hash: String::new(),
+                    error: Some(e.to_string()),
+                })
+            }
+        }
+    }
+
+    fn settle_clearing(
+        &self,
+        request: FederationClearingSettleRequest,
+    ) -> Result<FederationClearingSettleResult> {
+        let clearing = match &self.clearing {
+            Some(c) => c,
+            None => {
+                return Ok(FederationClearingSettleResult {
+                    success: false,
+                    net_settlement: 0,
+                    coop_a: String::new(),
+                    coop_b: String::new(),
+                    transfers_settled: 0,
+                    state_change_hash: String::new(),
+                    error: Some(
+                        "Clearing manager not configured — wire FederationServiceImpl::with_clearing_manager in supervisor"
+                            .to_string(),
+                    ),
+                });
+            }
+        };
+
+        // Look up the agreement to get coop identifiers for the ledger transfer
+        let agreement = match clearing.get_agreement(&request.agreement_id)? {
+            Some(a) => a,
+            None => {
+                return Ok(FederationClearingSettleResult {
+                    success: false,
+                    net_settlement: 0,
+                    coop_a: String::new(),
+                    coop_b: String::new(),
+                    transfers_settled: 0,
+                    state_change_hash: String::new(),
+                    error: Some(format!(
+                        "Clearing agreement '{}' not found",
+                        request.agreement_id
+                    )),
+                });
+            }
+        };
+
+        let coop_a = agreement.coop_a.clone();
+        let coop_b = agreement.coop_b.clone();
+
+        info!(
+            agreement_id = %request.agreement_id,
+            currency = %request.currency,
+            coop_a = %coop_a,
+            coop_b = %coop_b,
+            decision_receipt_id = %request.decision_receipt_id,
+            "Triggering clearing settlement"
+        );
+
+        match clearing.trigger_settlement(&request.agreement_id) {
+            Ok(report) => {
+                let mut hasher = Sha256::new();
+                hasher.update(b"federation:settle:");
+                hasher.update(request.agreement_id.as_bytes());
+                hasher.update(b":");
+                hasher.update(request.decision_receipt_id.as_bytes());
+                hasher.update(b":");
+                hasher.update(report.net_settlement.to_le_bytes());
+                let state_change_hash = format!("{:x}", hasher.finalize());
+
+                info!(
+                    agreement_id = %report.agreement_id,
+                    net_settlement = %report.net_settlement,
+                    transfers_settled = %report.transfers_settled,
+                    state_change_hash = %state_change_hash,
+                    "Clearing settlement completed"
+                );
+
+                Ok(FederationClearingSettleResult {
+                    success: true,
+                    net_settlement: report.net_settlement,
+                    coop_a,
+                    coop_b,
+                    transfers_settled: report.transfers_settled,
+                    state_change_hash,
+                    error: None,
+                })
+            }
+            Err(e) => {
+                tracing::warn!(
+                    agreement_id = %request.agreement_id,
+                    error = %e,
+                    "Clearing settlement failed"
+                );
+                Ok(FederationClearingSettleResult {
+                    success: false,
+                    net_settlement: 0,
+                    coop_a,
+                    coop_b,
+                    transfers_settled: 0,
                     state_change_hash: String::new(),
                     error: Some(e.to_string()),
                 })
@@ -742,6 +844,144 @@ mod tests {
                 .contains("coop_b_did"),
             "Error should mention coop_b_did: {:?}",
             result_b.error
+        );
+    }
+
+    #[test]
+    fn test_settle_clearing_zero_net_position() {
+        let (registry, _reg_temp) = make_test_registry();
+        let clearing_temp = tempfile::tempdir().unwrap();
+        let clearing_store = Arc::new(SledStore::open(clearing_temp.path()).unwrap());
+        let clearing =
+            Arc::new(ClearingManager::new(clearing_store, "coop-a".to_string()).unwrap());
+
+        // First establish the agreement
+        let service = FederationServiceImpl::new(registry).with_clearing_manager(clearing.clone());
+        let establish = service
+            .establish_clearing(FederationClearingRequest {
+                coop_a_did: make_test_did_str(2),
+                coop_b_did: make_test_did_str(3),
+                agreement_id: "agreement-settle-zero".to_string(),
+                decision_receipt_id: "gov:establish-clearing".to_string(),
+                decision_hash: "sha256:establish".to_string(),
+            })
+            .unwrap();
+        assert!(establish.success, "EstablishClearing should succeed");
+
+        // Settle with no transfers — net position is zero
+        let result = service
+            .settle_clearing(FederationClearingSettleRequest {
+                agreement_id: "agreement-settle-zero".to_string(),
+                currency: "HOURS".to_string(),
+                decision_receipt_id: "gov:settle-clearing".to_string(),
+                decision_hash: "sha256:settle".to_string(),
+            })
+            .unwrap();
+
+        assert!(
+            result.success,
+            "Settlement should succeed: {:?}",
+            result.error
+        );
+        assert_eq!(result.net_settlement, 0, "No transfers → zero net position");
+        assert_eq!(result.transfers_settled, 0);
+        assert!(!result.state_change_hash.is_empty());
+    }
+
+    #[test]
+    fn test_settle_clearing_nonzero_net_position() {
+        use icn_federation::clearing::CrossCoopTransfer;
+
+        let (registry, _reg_temp) = make_test_registry();
+        let clearing_temp = tempfile::tempdir().unwrap();
+        let clearing_store = Arc::new(SledStore::open(clearing_temp.path()).unwrap());
+        let clearing =
+            Arc::new(ClearingManager::new(clearing_store, "coop-a".to_string()).unwrap());
+
+        let coop_a_did = Did::from_public_key(
+            &ed25519_dalek::SigningKey::from_bytes(&[2u8; 32]).verifying_key(),
+        );
+        let coop_b_did = Did::from_public_key(
+            &ed25519_dalek::SigningKey::from_bytes(&[3u8; 32]).verifying_key(),
+        );
+        let agreement_id = "agreement-settle-nonzero".to_string();
+
+        // Establish the agreement with an HOURS→HOURS exchange rate
+        clearing
+            .create_agreement(
+                BilateralClearingAgreement::new(
+                    agreement_id.clone(),
+                    "coop-a".to_string(),
+                    coop_a_did.clone(),
+                    "coop-b".to_string(),
+                    coop_b_did.clone(),
+                )
+                .with_rate("HOURS", "HOURS", 1.0),
+            )
+            .unwrap();
+
+        // Propose and confirm a transfer: coop-a sends 100 HOURS to coop-b
+        let transfer = CrossCoopTransfer::new(
+            "transfer-001".to_string(),
+            "coop-a".to_string(),
+            coop_a_did.clone(),
+            "coop-b".to_string(),
+            coop_b_did.clone(),
+            100,
+            "HOURS".to_string(),
+            100,
+            "HOURS".to_string(),
+        );
+        let transfer_id = clearing.propose_transfer(transfer).unwrap();
+        clearing.confirm_transfer(&transfer_id).unwrap();
+
+        let service = FederationServiceImpl::new(registry).with_clearing_manager(clearing.clone());
+
+        let result = service
+            .settle_clearing(FederationClearingSettleRequest {
+                agreement_id: agreement_id.clone(),
+                currency: "HOURS".to_string(),
+                decision_receipt_id: "gov:settle-nonzero".to_string(),
+                decision_hash: "sha256:settle-nonzero".to_string(),
+            })
+            .unwrap();
+
+        assert!(
+            result.success,
+            "Settlement should succeed: {:?}",
+            result.error
+        );
+        // coop-a owes coop-b 100 HOURS → net_settlement = +100 (positive: a owes b)
+        assert_eq!(result.net_settlement, 100, "net_settlement should be 100");
+        assert_eq!(result.coop_a, "coop-a");
+        assert_eq!(result.coop_b, "coop-b");
+        assert_eq!(result.transfers_settled, 1);
+        assert!(!result.state_change_hash.is_empty());
+    }
+
+    #[test]
+    fn test_settle_clearing_agreement_not_found() {
+        let (registry, _reg_temp) = make_test_registry();
+        let clearing_temp = tempfile::tempdir().unwrap();
+        let clearing_store = Arc::new(SledStore::open(clearing_temp.path()).unwrap());
+        let clearing =
+            Arc::new(ClearingManager::new(clearing_store, "coop-a".to_string()).unwrap());
+        let service = FederationServiceImpl::new(registry).with_clearing_manager(clearing);
+
+        let result = service
+            .settle_clearing(FederationClearingSettleRequest {
+                agreement_id: "no-such-agreement".to_string(),
+                currency: "HOURS".to_string(),
+                decision_receipt_id: "gov:settle-missing".to_string(),
+                decision_hash: "sha256:missing".to_string(),
+            })
+            .unwrap();
+
+        assert!(!result.success, "Should fail for unknown agreement");
+        assert!(
+            result.error.as_deref().unwrap_or("").contains("not found"),
+            "Error should mention not found: {:?}",
+            result.error
         );
     }
 }

--- a/icn/crates/icn-core/src/services/federation_service.rs
+++ b/icn/crates/icn-core/src/services/federation_service.rs
@@ -378,6 +378,36 @@ impl FederationService for FederationServiceImpl {
 
         let coop_a = agreement.coop_a.clone();
         let coop_b = agreement.coop_b.clone();
+        // Store DIDs as strings for the ledger transfer — the ledger's Transfer path
+        // parses recipient via Did::from_str(), so we must pass the DID, not the coop ID.
+        let coop_a_did_str = agreement.coop_a_did.to_string();
+        let coop_b_did_str = agreement.coop_b_did.to_string();
+
+        // Idempotency guard: if net is non-zero and no ledger is configured, fail BEFORE
+        // mutating clearing positions.  Otherwise trigger_settlement() would clear positions
+        // leaving no accounting trace (partial-settlement state).
+        if self.ledger.is_none() {
+            let preview_net = clearing
+                .calculate_position(&request.agreement_id)
+                .map(|p| p.net_position())
+                .unwrap_or(0);
+            if preview_net != 0 {
+                return Ok(FederationClearingSettleResult {
+                    success: false,
+                    net_settlement: 0,
+                    coop_a,
+                    coop_b,
+                    transfers_settled: 0,
+                    state_change_hash: String::new(),
+                    ledger_entry_hash: None,
+                    error: Some(format!(
+                        "Cannot settle agreement '{}': net position is {} but no ledger configured — wire with_ledger()",
+                        request.agreement_id,
+                        preview_net
+                    )),
+                });
+            }
+        }
 
         info!(
             agreement_id = %request.agreement_id,
@@ -410,22 +440,37 @@ impl FederationService for FederationServiceImpl {
                 // Emit ledger transfer for non-zero net positions.
                 // net_settlement > 0: coop_a owes coop_b
                 // net_settlement < 0: coop_b owes coop_a
+                // We use DID strings (not coop ID strings) because the ledger's Transfer
+                // path parses treasury_id and recipient via Did::from_str().
                 let ledger_entry_hash = if report.net_settlement != 0 {
                     if let Some(ledger) = &self.ledger {
-                        let (debtor, creditor, amount) = if report.net_settlement > 0 {
-                            (coop_a.clone(), coop_b.clone(), report.net_settlement)
-                        } else {
-                            (coop_b.clone(), coop_a.clone(), -report.net_settlement)
-                        };
+                        let (debtor_did, creditor_did, debtor_label, creditor_label, amount) =
+                            if report.net_settlement > 0 {
+                                (
+                                    coop_a_did_str.clone(),
+                                    coop_b_did_str.clone(),
+                                    coop_a.clone(),
+                                    coop_b.clone(),
+                                    report.net_settlement,
+                                )
+                            } else {
+                                (
+                                    coop_b_did_str.clone(),
+                                    coop_a_did_str.clone(),
+                                    coop_b.clone(),
+                                    coop_a.clone(),
+                                    -report.net_settlement,
+                                )
+                            };
                         let entry_req = TreasuryEntryRequest {
-                            treasury_id: debtor.clone(),
+                            treasury_id: debtor_did.clone(),
                             operation_type: TreasuryOperationType::Transfer,
                             amount,
                             currency: request.currency.clone(),
-                            recipient: Some(creditor.clone()),
+                            recipient: Some(creditor_did.clone()),
                             memo: format!(
                                 "Clearing settlement for {}: {} -> {}",
-                                request.agreement_id, debtor, creditor
+                                request.agreement_id, debtor_label, creditor_label
                             ),
                             expected_nonce: None,
                             decision_receipt_id: request.decision_receipt_id.clone(),
@@ -973,8 +1018,11 @@ mod tests {
         assert!(!result.state_change_hash.is_empty());
     }
 
+    /// Non-zero net settlement without a ledger service must fail BEFORE mutating
+    /// clearing positions (idempotency guard).  The clearing positions should be
+    /// unchanged after the call so a retry with a ledger wired will work correctly.
     #[test]
-    fn test_settle_clearing_nonzero_net_position() {
+    fn test_settle_clearing_nonzero_net_requires_ledger() {
         use icn_federation::clearing::CrossCoopTransfer;
 
         let (registry, _reg_temp) = make_test_registry();
@@ -1020,6 +1068,7 @@ mod tests {
         let transfer_id = clearing.propose_transfer(transfer).unwrap();
         clearing.confirm_transfer(&transfer_id).unwrap();
 
+        // Service without ledger — must fail on non-zero net to prevent partial settlement
         let service = FederationServiceImpl::new(registry).with_clearing_manager(clearing.clone());
 
         let result = service
@@ -1031,17 +1080,24 @@ mod tests {
             })
             .unwrap();
 
+        assert!(!result.success, "Non-zero net without ledger must fail");
         assert!(
-            result.success,
-            "Settlement should succeed: {:?}",
+            result
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("no ledger configured"),
+            "Error should mention ledger requirement: {:?}",
             result.error
         );
-        // coop-a owes coop-b 100 HOURS → net_settlement = +100 (positive: a owes b)
-        assert_eq!(result.net_settlement, 100, "net_settlement should be 100");
-        assert_eq!(result.coop_a, "coop-a");
-        assert_eq!(result.coop_b, "coop-b");
-        assert_eq!(result.transfers_settled, 1);
-        assert!(!result.state_change_hash.is_empty());
+
+        // Verify positions were NOT mutated (idempotency guard fired before trigger_settlement)
+        let position = clearing.calculate_position(&agreement_id).unwrap();
+        assert_eq!(
+            position.net_position(),
+            100,
+            "Positions must be unchanged after guard fires"
+        );
     }
 
     #[test]

--- a/icn/crates/icn-core/src/services/federation_service.rs
+++ b/icn/crates/icn-core/src/services/federation_service.rs
@@ -386,11 +386,21 @@ impl FederationService for FederationServiceImpl {
         // Idempotency guard: if net is non-zero and no ledger is configured, fail BEFORE
         // mutating clearing positions.  Otherwise trigger_settlement() would clear positions
         // leaving no accounting trace (partial-settlement state).
+        //
+        // We must propagate position-read errors rather than treating them as zero:
+        // a store error cannot be distinguished from a true zero balance, and silently
+        // allowing settlement would corrupt the audit trail.
         if self.ledger.is_none() {
             let preview_net = clearing
                 .calculate_position(&request.agreement_id)
-                .map(|p| p.net_position())
-                .unwrap_or(0);
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "Cannot read clearing position for '{}': {} — retry after store recovery",
+                        request.agreement_id,
+                        e
+                    )
+                })?
+                .net_position();
             if preview_net != 0 {
                 return Ok(FederationClearingSettleResult {
                     success: false,
@@ -1123,6 +1133,167 @@ mod tests {
             result.error.as_deref().unwrap_or("").contains("not found"),
             "Error should mention not found: {:?}",
             result.error
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Stub ledger for settlement tests
+    // -------------------------------------------------------------------------
+
+    use std::sync::Mutex;
+
+    struct StubLedger {
+        captured: Mutex<Vec<TreasuryEntryRequest>>,
+        result: Result<String, String>,
+    }
+
+    impl StubLedger {
+        fn succeeding(entry_hash: &str) -> Arc<Self> {
+            Arc::new(Self {
+                captured: Mutex::new(Vec::new()),
+                result: Ok(entry_hash.to_string()),
+            })
+        }
+
+        fn captured_entries(&self) -> Vec<TreasuryEntryRequest> {
+            self.captured.lock().unwrap().clone()
+        }
+    }
+
+    impl icn_kernel_api::LedgerService for StubLedger {
+        fn oracle(&self) -> Arc<dyn icn_kernel_api::PolicyOracle> {
+            Arc::new(icn_kernel_api::AllowAllOracle::wildcard())
+        }
+
+        fn balance(&self, _account: &String, _currency: &str) -> i64 {
+            0
+        }
+
+        fn credit_limit(&self, _account: &String, _currency: &str) -> i64 {
+            0
+        }
+
+        fn record_event(&self, _event: icn_kernel_api::LedgerEvent) {}
+
+        fn submit_treasury_entry(
+            &self,
+            entry: TreasuryEntryRequest,
+        ) -> Result<icn_kernel_api::TreasuryEntryResult, String> {
+            let decision_hash = entry.decision_hash.clone();
+            let decision_receipt_id = entry.decision_receipt_id.clone();
+            self.captured.lock().unwrap().push(entry);
+            self.result
+                .clone()
+                .map(|h| icn_kernel_api::TreasuryEntryResult {
+                    entry_hash: h,
+                    decision_hash,
+                    decision_receipt_id,
+                })
+        }
+    }
+
+    /// Happy path: non-zero net settlement with a wired ledger.
+    /// Proves that:
+    /// - `settle_clearing` succeeds when ledger is wired and net is non-zero
+    /// - the correct decision_hash flows into the ledger transfer entry
+    /// - debtor/creditor DIDs are set correctly based on net direction
+    /// - transfers_settled > 0 and ledger_entry_hash is Some
+    #[test]
+    fn test_settle_clearing_with_ledger_emits_correct_entry() {
+        use icn_federation::clearing::CrossCoopTransfer;
+
+        let (registry, _reg_temp) = make_test_registry();
+        let clearing_temp = tempfile::tempdir().unwrap();
+        let clearing_store = Arc::new(SledStore::open(clearing_temp.path()).unwrap());
+        let clearing =
+            Arc::new(ClearingManager::new(clearing_store, "coop-a".to_string()).unwrap());
+
+        let coop_a_did = Did::from_public_key(&SigningKey::from_bytes(&[4u8; 32]).verifying_key());
+        let coop_b_did = Did::from_public_key(&SigningKey::from_bytes(&[5u8; 32]).verifying_key());
+        let agreement_id = "agreement-ledger-test".to_string();
+
+        // Establish agreement with HOURS→HOURS rate
+        clearing
+            .create_agreement(
+                BilateralClearingAgreement::new(
+                    agreement_id.clone(),
+                    "coop-a".to_string(),
+                    coop_a_did.clone(),
+                    "coop-b".to_string(),
+                    coop_b_did.clone(),
+                )
+                .with_rate("HOURS", "HOURS", 1.0),
+            )
+            .unwrap();
+
+        // coop-a sends 200 HOURS to coop-b — net: coop-a owes coop-b 200
+        let transfer = CrossCoopTransfer::new(
+            "transfer-ledger-001".to_string(),
+            "coop-a".to_string(),
+            coop_a_did.clone(),
+            "coop-b".to_string(),
+            coop_b_did.clone(),
+            200,
+            "HOURS".to_string(),
+            200,
+            "HOURS".to_string(),
+        );
+        let transfer_id = clearing.propose_transfer(transfer).unwrap();
+        clearing.confirm_transfer(&transfer_id).unwrap();
+
+        let stub = StubLedger::succeeding("sha256:settlement-entry-001");
+        let service = FederationServiceImpl::new(registry)
+            .with_clearing_manager(clearing)
+            .with_ledger(stub.clone() as Arc<dyn icn_kernel_api::LedgerService>);
+
+        let decision_hash = "sha256:governance-settle-decision-abc123".to_string();
+        let result = service
+            .settle_clearing(FederationClearingSettleRequest {
+                agreement_id: agreement_id.clone(),
+                currency: "HOURS".to_string(),
+                decision_receipt_id: "gov:settle-001".to_string(),
+                decision_hash: decision_hash.clone(),
+            })
+            .unwrap();
+
+        assert!(
+            result.success,
+            "Settlement should succeed: {:?}",
+            result.error
+        );
+        assert_eq!(result.net_settlement, 200, "coop-a owes coop-b 200");
+        assert_eq!(result.transfers_settled, 1);
+        assert!(!result.state_change_hash.is_empty());
+        assert_eq!(
+            result.ledger_entry_hash.as_deref(),
+            Some("sha256:settlement-entry-001"),
+            "Ledger entry hash must come from stub"
+        );
+
+        // Verify the entry submitted to the ledger carries correct provenance
+        let entries = stub.captured_entries();
+        assert_eq!(
+            entries.len(),
+            1,
+            "Exactly one ledger entry should be emitted"
+        );
+        let entry = &entries[0];
+        assert_eq!(
+            entry.decision_hash, decision_hash,
+            "decision_hash must flow through to the ledger entry unchanged"
+        );
+        assert_eq!(entry.amount, 200);
+        assert_eq!(entry.currency, "HOURS");
+        // coop-a is the debtor (net_settlement > 0 means coop-a owes coop-b)
+        assert_eq!(
+            entry.treasury_id,
+            coop_a_did.to_string(),
+            "Debtor must be coop-a DID"
+        );
+        assert_eq!(
+            entry.recipient.as_deref(),
+            Some(coop_b_did.to_string().as_str()),
+            "Creditor must be coop-b DID"
         );
     }
 }

--- a/icn/crates/icn-core/src/services/federation_service.rs
+++ b/icn/crates/icn-core/src/services/federation_service.rs
@@ -11,10 +11,11 @@ use anyhow::Result;
 use icn_federation::types::{CooperativeInfo, FederationPolicy, Vouch};
 use icn_federation::{BilateralClearingAgreement, ClearingManager, CooperativeRegistry};
 use icn_identity::Did;
+use icn_kernel_api::services::TreasuryOperationType;
 use icn_kernel_api::{
     FederationClearingRequest, FederationClearingResult, FederationClearingSettleRequest,
     FederationClearingSettleResult, FederationJoinRequest, FederationJoinResult, FederationService,
-    FederationVouchRequest, FederationVouchResult,
+    FederationVouchRequest, FederationVouchResult, LedgerService, TreasuryEntryRequest,
 };
 use sha2::{Digest, Sha256};
 use tracing::info;
@@ -35,6 +36,10 @@ pub struct FederationServiceImpl {
     /// federation clearing is configured in the supervisor)
     clearing: Option<Arc<ClearingManager>>,
 
+    /// Ledger service for emitting settlement transfers (optional — required for non-zero
+    /// net settlement to produce ledger entries)
+    ledger: Option<Arc<dyn LedgerService>>,
+
     /// Provenance tracking for registered cooperatives
     /// Maps coop_did -> (decision_receipt_id, decision_hash)
     provenance: RwLock<HashMap<String, FederationProvenance>>,
@@ -46,6 +51,7 @@ impl FederationServiceImpl {
         Self {
             registry,
             clearing: None,
+            ledger: None,
             provenance: RwLock::new(HashMap::new()),
         }
     }
@@ -53,6 +59,15 @@ impl FederationServiceImpl {
     /// Attach a clearing manager, enabling governance-driven clearing establishment.
     pub fn with_clearing_manager(mut self, clearing: Arc<ClearingManager>) -> Self {
         self.clearing = Some(clearing);
+        self
+    }
+
+    /// Attach a ledger service so that non-zero clearing settlements produce ledger entries.
+    ///
+    /// Required for the operational clearing scheduler and governance force-settle paths
+    /// to write net obligations into the ledger.
+    pub fn with_ledger(mut self, ledger: Arc<dyn LedgerService>) -> Self {
+        self.ledger = Some(ledger);
         self
     }
 
@@ -332,6 +347,7 @@ impl FederationService for FederationServiceImpl {
                     coop_b: String::new(),
                     transfers_settled: 0,
                     state_change_hash: String::new(),
+                    ledger_entry_hash: None,
                     error: Some(
                         "Clearing manager not configured — wire FederationServiceImpl::with_clearing_manager in supervisor"
                             .to_string(),
@@ -351,6 +367,7 @@ impl FederationService for FederationServiceImpl {
                     coop_b: String::new(),
                     transfers_settled: 0,
                     state_change_hash: String::new(),
+                    ledger_entry_hash: None,
                     error: Some(format!(
                         "Clearing agreement '{}' not found",
                         request.agreement_id
@@ -390,6 +407,72 @@ impl FederationService for FederationServiceImpl {
                     "Clearing settlement completed"
                 );
 
+                // Emit ledger transfer for non-zero net positions.
+                // net_settlement > 0: coop_a owes coop_b
+                // net_settlement < 0: coop_b owes coop_a
+                let ledger_entry_hash = if report.net_settlement != 0 {
+                    if let Some(ledger) = &self.ledger {
+                        let (debtor, creditor, amount) = if report.net_settlement > 0 {
+                            (coop_a.clone(), coop_b.clone(), report.net_settlement)
+                        } else {
+                            (coop_b.clone(), coop_a.clone(), -report.net_settlement)
+                        };
+                        let entry_req = TreasuryEntryRequest {
+                            treasury_id: debtor.clone(),
+                            operation_type: TreasuryOperationType::Transfer,
+                            amount,
+                            currency: request.currency.clone(),
+                            recipient: Some(creditor.clone()),
+                            memo: format!(
+                                "Clearing settlement for {}: {} -> {}",
+                                request.agreement_id, debtor, creditor
+                            ),
+                            expected_nonce: None,
+                            decision_receipt_id: request.decision_receipt_id.clone(),
+                            decision_hash: request.decision_hash.clone(),
+                        };
+                        match ledger.submit_treasury_entry(entry_req) {
+                            Ok(entry_result) => {
+                                info!(
+                                    agreement_id = %request.agreement_id,
+                                    net_settlement = report.net_settlement,
+                                    entry_hash = %entry_result.entry_hash,
+                                    "Clearing settlement produced ledger transfer entry"
+                                );
+                                Some(entry_result.entry_hash)
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    agreement_id = %request.agreement_id,
+                                    error = %e,
+                                    "Clearing settlement succeeded but ledger transfer failed"
+                                );
+                                return Ok(FederationClearingSettleResult {
+                                    success: false,
+                                    net_settlement: report.net_settlement,
+                                    coop_a,
+                                    coop_b,
+                                    transfers_settled: report.transfers_settled,
+                                    state_change_hash,
+                                    ledger_entry_hash: None,
+                                    error: Some(format!(
+                                        "Settlement positions cleared but ledger transfer failed: {e}"
+                                    )),
+                                });
+                            }
+                        }
+                    } else {
+                        tracing::warn!(
+                            agreement_id = %request.agreement_id,
+                            net_settlement = report.net_settlement,
+                            "Non-zero net settlement but no ledger configured — wire with_ledger()"
+                        );
+                        None
+                    }
+                } else {
+                    None
+                };
+
                 Ok(FederationClearingSettleResult {
                     success: true,
                     net_settlement: report.net_settlement,
@@ -397,6 +480,7 @@ impl FederationService for FederationServiceImpl {
                     coop_b,
                     transfers_settled: report.transfers_settled,
                     state_change_hash,
+                    ledger_entry_hash,
                     error: None,
                 })
             }
@@ -413,6 +497,7 @@ impl FederationService for FederationServiceImpl {
                     coop_b,
                     transfers_settled: 0,
                     state_change_hash: String::new(),
+                    ledger_entry_hash: None,
                     error: Some(e.to_string()),
                 })
             }

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -90,6 +90,25 @@ impl KernelGovernanceExecutor {
         self
     }
 
+    /// Set the ledger service for clearing settlement entries.
+    ///
+    /// Must be called after `with_federation_service()` to attach the ledger
+    /// service to the federation executor (so SettleClearing can emit transfers).
+    pub fn with_settlement_ledger(
+        mut self,
+        ledger: Arc<dyn icn_kernel_api::LedgerService>,
+    ) -> Self {
+        // Rebuild the federation executor with ledger attached.
+        // Preserve any existing service by extracting it from the current executor.
+        let existing_service = self.federation.service.clone();
+        let mut new_fed = KernelFederationExecutor::new();
+        if let Some(svc) = existing_service {
+            new_fed = KernelFederationExecutor::with_service(svc);
+        }
+        self.federation = Arc::new(new_fed.with_ledger(ledger));
+        self
+    }
+
     /// Set the membership service for membership operations.
     pub fn with_membership_service(
         mut self,
@@ -1000,19 +1019,32 @@ impl ProtocolExecutor for KernelProtocolExecutor {
 pub struct KernelFederationExecutor {
     /// Federation service for durable state operations
     service: Option<Arc<dyn icn_kernel_api::FederationService>>,
+    /// Ledger service for emitting settlement transfer entries.
+    /// Required only for SettleClearing operations.
+    ledger: Option<Arc<dyn icn_kernel_api::LedgerService>>,
 }
 
 impl KernelFederationExecutor {
     /// Create a new federation executor (placeholder mode - no durable state).
     pub fn new() -> Self {
-        Self { service: None }
+        Self {
+            service: None,
+            ledger: None,
+        }
     }
 
     /// Create a new federation executor with a real service.
     pub fn with_service(service: Arc<dyn icn_kernel_api::FederationService>) -> Self {
         Self {
             service: Some(service),
+            ledger: None,
         }
+    }
+
+    /// Attach a ledger service for settlement transfer entries.
+    pub fn with_ledger(mut self, ledger: Arc<dyn icn_kernel_api::LedgerService>) -> Self {
+        self.ledger = Some(ledger);
+        self
     }
 
     /// Set the federation service after construction.
@@ -1166,6 +1198,146 @@ impl FederationExecutor for KernelFederationExecutor {
                         Ok(ExecutionOutcome::Failed {
                             receipt_id: receipt_id.clone(),
                             reason: result.error.unwrap_or_else(|| "Unknown error".to_string()),
+                        })
+                    }
+                }
+                FederationOperationType::SettleClearing => {
+                    let agreement_id = match operation
+                        .agreement_hash
+                        .as_deref()
+                        .filter(|s| !s.is_empty())
+                    {
+                        Some(id) => id.to_string(),
+                        None => {
+                            return Ok(ExecutionOutcome::Failed {
+                                receipt_id: receipt_id.clone(),
+                                reason: "SettleClearing: missing or empty agreement_hash"
+                                    .to_string(),
+                            });
+                        }
+                    };
+                    let currency = operation
+                        .target_id
+                        .clone()
+                        .filter(|s| !s.is_empty())
+                        .unwrap_or_else(|| "HOURS".to_string());
+
+                    let settle_req = icn_kernel_api::FederationClearingSettleRequest {
+                        agreement_id: agreement_id.clone(),
+                        currency: currency.clone(),
+                        decision_receipt_id: receipt_id.to_string(),
+                        decision_hash: operation.decision_hash.clone().unwrap_or_default(),
+                    };
+
+                    let settle_result = service.settle_clearing(settle_req)?;
+
+                    if !settle_result.success {
+                        return Ok(ExecutionOutcome::Failed {
+                            receipt_id: receipt_id.clone(),
+                            reason: settle_result
+                                .error
+                                .unwrap_or_else(|| "Settlement failed".to_string()),
+                        });
+                    }
+
+                    // If net position is zero, positions cancelled — no ledger entry needed.
+                    if settle_result.net_settlement == 0 {
+                        tracing::info!(
+                            agreement_id = %agreement_id,
+                            transfers_settled = settle_result.transfers_settled,
+                            "Clearing settlement: zero net position, no transfer needed"
+                        );
+                        return Ok(ExecutionOutcome::Success {
+                            receipt_id: receipt_id.clone(),
+                            effects: vec![format!(
+                                "Clearing settled: {} transfers, net=0 (positions cancelled)",
+                                settle_result.transfers_settled
+                            )],
+                        });
+                    }
+
+                    // Non-zero net: emit a ledger transfer for the net settlement.
+                    // net_settlement > 0: coop_a owes coop_b
+                    // net_settlement < 0: coop_b owes coop_a
+                    let (debtor, creditor, amount) = if settle_result.net_settlement > 0 {
+                        (
+                            settle_result.coop_a.clone(),
+                            settle_result.coop_b.clone(),
+                            settle_result.net_settlement,
+                        )
+                    } else {
+                        (
+                            settle_result.coop_b.clone(),
+                            settle_result.coop_a.clone(),
+                            -settle_result.net_settlement,
+                        )
+                    };
+
+                    if let Some(ledger) = &self.ledger {
+                        let entry_req = icn_kernel_api::TreasuryEntryRequest {
+                            treasury_id: debtor.clone(),
+                            operation_type:
+                                icn_kernel_api::services::TreasuryOperationType::Transfer,
+                            amount,
+                            currency: currency.clone(),
+                            recipient: Some(creditor.clone()),
+                            memo: format!(
+                                "Clearing settlement for {agreement_id}: {debtor} -> {creditor}"
+                            ),
+                            expected_nonce: None,
+                            decision_receipt_id: receipt_id.to_string(),
+                            decision_hash: operation.decision_hash.clone().unwrap_or_default(),
+                        };
+
+                        match ledger.submit_treasury_entry(entry_req) {
+                            Ok(entry_result) => {
+                                tracing::info!(
+                                    agreement_id = %agreement_id,
+                                    net_settlement = settle_result.net_settlement,
+                                    entry_hash = %entry_result.entry_hash,
+                                    "Clearing settlement produced ledger transfer entry"
+                                );
+                                Ok(ExecutionOutcome::Success {
+                                    receipt_id: receipt_id.clone(),
+                                    effects: vec![format!(
+                                        "Clearing settled: {} {} {} -> {} -> ledger entry {}",
+                                        settle_result.transfers_settled,
+                                        amount,
+                                        currency,
+                                        creditor,
+                                        entry_result.entry_hash
+                                    )],
+                                })
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    agreement_id = %agreement_id,
+                                    error = %e,
+                                    "Clearing settlement succeeded but ledger transfer failed"
+                                );
+                                Ok(ExecutionOutcome::Failed {
+                                    receipt_id: receipt_id.clone(),
+                                    reason: format!(
+                                        "Settlement positions cleared but ledger transfer failed: {e}"
+                                    ),
+                                })
+                            }
+                        }
+                    } else {
+                        // Ledger not configured — report net position but can't produce entry.
+                        tracing::warn!(
+                            agreement_id = %agreement_id,
+                            net_settlement = settle_result.net_settlement,
+                            "SettleClearing: no ledger service configured, settlement positions cleared but no ledger transfer emitted"
+                        );
+                        Ok(ExecutionOutcome::Failed {
+                            receipt_id: receipt_id.clone(),
+                            reason: format!(
+                                "Settlement cleared ({} transfers, net={} {}) but ledger service not configured — wire with_settlement_ledger()",
+                                settle_result.transfers_settled,
+                                settle_result.net_settlement,
+                                currency
+                            ),
                         })
                     }
                 }

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -90,25 +90,6 @@ impl KernelGovernanceExecutor {
         self
     }
 
-    /// Set the ledger service for clearing settlement entries.
-    ///
-    /// Must be called after `with_federation_service()` to attach the ledger
-    /// service to the federation executor (so SettleClearing can emit transfers).
-    pub fn with_settlement_ledger(
-        mut self,
-        ledger: Arc<dyn icn_kernel_api::LedgerService>,
-    ) -> Self {
-        // Rebuild the federation executor with ledger attached.
-        // Preserve any existing service by extracting it from the current executor.
-        let existing_service = self.federation.service.clone();
-        let mut new_fed = KernelFederationExecutor::new();
-        if let Some(svc) = existing_service {
-            new_fed = KernelFederationExecutor::with_service(svc);
-        }
-        self.federation = Arc::new(new_fed.with_ledger(ledger));
-        self
-    }
-
     /// Set the membership service for membership operations.
     pub fn with_membership_service(
         mut self,
@@ -1017,34 +998,22 @@ impl ProtocolExecutor for KernelProtocolExecutor {
 /// Executes federation operations (join, leave, vouch, clearing) by
 /// delegating to the FederationService for durable state mutations.
 pub struct KernelFederationExecutor {
-    /// Federation service for durable state operations
+    /// Federation service for durable state operations.
+    /// The service holds all required resources including ledger access for settlements.
     service: Option<Arc<dyn icn_kernel_api::FederationService>>,
-    /// Ledger service for emitting settlement transfer entries.
-    /// Required only for SettleClearing operations.
-    ledger: Option<Arc<dyn icn_kernel_api::LedgerService>>,
 }
 
 impl KernelFederationExecutor {
     /// Create a new federation executor (placeholder mode - no durable state).
     pub fn new() -> Self {
-        Self {
-            service: None,
-            ledger: None,
-        }
+        Self { service: None }
     }
 
     /// Create a new federation executor with a real service.
     pub fn with_service(service: Arc<dyn icn_kernel_api::FederationService>) -> Self {
         Self {
             service: Some(service),
-            ledger: None,
         }
-    }
-
-    /// Attach a ledger service for settlement transfer entries.
-    pub fn with_ledger(mut self, ledger: Arc<dyn icn_kernel_api::LedgerService>) -> Self {
-        self.ledger = Some(ledger);
-        self
     }
 
     /// Set the federation service after construction.
@@ -1229,6 +1198,7 @@ impl FederationExecutor for KernelFederationExecutor {
                         decision_hash: operation.decision_hash.clone().unwrap_or_default(),
                     };
 
+                    // Delegate fully to the service — ledger emission happens there.
                     let settle_result = service.settle_clearing(settle_req)?;
 
                     if !settle_result.success {
@@ -1240,106 +1210,33 @@ impl FederationExecutor for KernelFederationExecutor {
                         });
                     }
 
-                    // If net position is zero, positions cancelled — no ledger entry needed.
-                    if settle_result.net_settlement == 0 {
-                        tracing::info!(
-                            agreement_id = %agreement_id,
-                            transfers_settled = settle_result.transfers_settled,
-                            "Clearing settlement: zero net position, no transfer needed"
-                        );
-                        return Ok(ExecutionOutcome::Success {
-                            receipt_id: receipt_id.clone(),
-                            effects: vec![format!(
-                                "Clearing settled: {} transfers, net=0 (positions cancelled)",
-                                settle_result.transfers_settled
-                            )],
-                        });
-                    }
-
-                    // Non-zero net: emit a ledger transfer for the net settlement.
-                    // net_settlement > 0: coop_a owes coop_b
-                    // net_settlement < 0: coop_b owes coop_a
-                    let (debtor, creditor, amount) = if settle_result.net_settlement > 0 {
-                        (
-                            settle_result.coop_a.clone(),
-                            settle_result.coop_b.clone(),
+                    let effects = if settle_result.net_settlement == 0 {
+                        vec![format!(
+                            "Clearing settled: {} transfers, net=0 (positions cancelled)",
+                            settle_result.transfers_settled
+                        )]
+                    } else if let Some(ref entry_hash) = settle_result.ledger_entry_hash {
+                        vec![format!(
+                            "Clearing settled: {} transfers, net={} {} -> ledger entry {}",
+                            settle_result.transfers_settled,
                             settle_result.net_settlement,
-                        )
+                            currency,
+                            entry_hash
+                        )]
                     } else {
-                        (
-                            settle_result.coop_b.clone(),
-                            settle_result.coop_a.clone(),
-                            -settle_result.net_settlement,
-                        )
+                        // Non-zero net but no ledger entry — service warned; treat as partial success.
+                        vec![format!(
+                            "Clearing settled: {} transfers, net={} {} (no ledger — wire with_ledger() on FederationServiceImpl)",
+                            settle_result.transfers_settled,
+                            settle_result.net_settlement,
+                            currency
+                        )]
                     };
 
-                    if let Some(ledger) = &self.ledger {
-                        let entry_req = icn_kernel_api::TreasuryEntryRequest {
-                            treasury_id: debtor.clone(),
-                            operation_type:
-                                icn_kernel_api::services::TreasuryOperationType::Transfer,
-                            amount,
-                            currency: currency.clone(),
-                            recipient: Some(creditor.clone()),
-                            memo: format!(
-                                "Clearing settlement for {agreement_id}: {debtor} -> {creditor}"
-                            ),
-                            expected_nonce: None,
-                            decision_receipt_id: receipt_id.to_string(),
-                            decision_hash: operation.decision_hash.clone().unwrap_or_default(),
-                        };
-
-                        match ledger.submit_treasury_entry(entry_req) {
-                            Ok(entry_result) => {
-                                tracing::info!(
-                                    agreement_id = %agreement_id,
-                                    net_settlement = settle_result.net_settlement,
-                                    entry_hash = %entry_result.entry_hash,
-                                    "Clearing settlement produced ledger transfer entry"
-                                );
-                                Ok(ExecutionOutcome::Success {
-                                    receipt_id: receipt_id.clone(),
-                                    effects: vec![format!(
-                                        "Clearing settled: {} {} {} -> {} -> ledger entry {}",
-                                        settle_result.transfers_settled,
-                                        amount,
-                                        currency,
-                                        creditor,
-                                        entry_result.entry_hash
-                                    )],
-                                })
-                            }
-                            Err(e) => {
-                                tracing::warn!(
-                                    agreement_id = %agreement_id,
-                                    error = %e,
-                                    "Clearing settlement succeeded but ledger transfer failed"
-                                );
-                                Ok(ExecutionOutcome::Failed {
-                                    receipt_id: receipt_id.clone(),
-                                    reason: format!(
-                                        "Settlement positions cleared but ledger transfer failed: {e}"
-                                    ),
-                                })
-                            }
-                        }
-                    } else {
-                        // Ledger not configured — report net position but can't produce entry.
-                        tracing::warn!(
-                            agreement_id = %agreement_id,
-                            net_settlement = settle_result.net_settlement,
-                            "SettleClearing: no ledger service configured, settlement positions cleared but no ledger transfer emitted"
-                        );
-                        Ok(ExecutionOutcome::Failed {
-                            receipt_id: receipt_id.clone(),
-                            reason: format!(
-                                "Settlement cleared ({} transfers, net={} {}) but ledger service not configured — wire with_settlement_ledger()",
-                                settle_result.transfers_settled,
-                                settle_result.net_settlement,
-                                currency
-                            ),
-                        })
-                    }
+                    Ok(ExecutionOutcome::Success {
+                        receipt_id: receipt_id.clone(),
+                        effects,
+                    })
                 }
                 // LeaveFederation not yet wired to service
                 FederationOperationType::LeaveFederation => {

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -1191,11 +1191,28 @@ impl FederationExecutor for KernelFederationExecutor {
                         .filter(|s| !s.is_empty())
                         .unwrap_or_else(|| "HOURS".to_string());
 
+                    // decision_hash is required: settlement may emit a ledger transfer entry,
+                    // which must carry non-empty decision_hash for provenance.  Reject early
+                    // rather than letting an empty hash propagate to the ledger layer.
+                    let decision_hash = match operation
+                        .decision_hash
+                        .as_deref()
+                        .filter(|s| !s.is_empty())
+                    {
+                        Some(h) => h.to_string(),
+                        None => {
+                            return Ok(ExecutionOutcome::Failed {
+                                receipt_id: receipt_id.clone(),
+                                reason: "SettleClearing: missing or empty decision_hash — required for ledger provenance".to_string(),
+                            });
+                        }
+                    };
+
                     let settle_req = icn_kernel_api::FederationClearingSettleRequest {
                         agreement_id: agreement_id.clone(),
                         currency: currency.clone(),
                         decision_receipt_id: receipt_id.to_string(),
-                        decision_hash: operation.decision_hash.clone().unwrap_or_default(),
+                        decision_hash,
                     };
 
                     // Delegate fully to the service — ledger emission happens there.

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -726,16 +726,80 @@ async fn spawn_actors_with_identity(
                 federation_service = federation_service.with_clearing_manager(clearing);
                 info!("✓ Federation clearing manager wired to federation service");
             }
-            kernel_executor = kernel_executor.with_federation_service(Arc::new(federation_service));
+            // Wire ledger so settle_clearing() can emit transfer entries for non-zero net positions.
+            if let Some(ref ledger) = gateway_handles.ledger_service {
+                federation_service = federation_service.with_ledger(ledger.clone());
+                info!("✓ Settlement ledger wired to federation service");
+            }
+            let federation_service = Arc::new(federation_service);
+            kernel_executor = kernel_executor.with_federation_service(federation_service.clone());
             info!("✓ Federation service wired to governance executor");
-        }
 
-        // Wire settlement ledger so SettleClearing effects can produce ledger entries.
-        // Reuses the same LedgerService Arc already wired to the treasury executor;
-        // the service is stateless (no mutable fields), so sharing is safe.
-        if let Some(settlement_ledger) = gateway_handles.ledger_service.clone() {
-            kernel_executor = kernel_executor.with_settlement_ledger(settlement_ledger);
-            info!("✓ Settlement ledger wired to federation executor");
+            // Spawn the operational clearing settlement scheduler.
+            // This is the PRIMARY settlement path: agreements settle on their own terms
+            // without requiring governance proposals. Governance SettleClearing effects
+            // serve as an escape hatch for force-settle scenarios only.
+            if let Some(clearing) = clearing_manager_for_governance.clone() {
+                let sched_svc: Arc<dyn icn_kernel_api::FederationService> =
+                    federation_service.clone();
+                let mut sched_shutdown = shutdown_tx.subscribe();
+                // Default 60-second interval; TODO: expose via FederationConfig::settlement_interval_secs
+                let sched_interval = std::time::Duration::from_secs(60);
+                background_tasks.spawn(async move {
+                    let mut interval = tokio::time::interval(sched_interval);
+                    loop {
+                        tokio::select! {
+                            _ = interval.tick() => {
+                                let due = clearing.get_due_settlements();
+                                for agreement_id in due {
+                                    // Default to HOURS; exchange_rates keys are "from:to" pairs
+                                    // TODO: derive currency from agreement exchange_rates when multi-currency support needed
+                                    let currency = "HOURS".to_string();
+                                    let req = icn_kernel_api::FederationClearingSettleRequest {
+                                        agreement_id: agreement_id.clone(),
+                                        currency,
+                                        decision_receipt_id: "scheduler:auto".to_string(),
+                                        decision_hash: String::new(),
+                                    };
+                                    match sched_svc.settle_clearing(req) {
+                                        Ok(result) if result.success => {
+                                            tracing::info!(
+                                                agreement_id = %agreement_id,
+                                                transfers_settled = result.transfers_settled,
+                                                net_settlement = result.net_settlement,
+                                                ledger_entry = ?result.ledger_entry_hash,
+                                                "Scheduled clearing settlement completed"
+                                            );
+                                        }
+                                        Ok(result) => {
+                                            tracing::warn!(
+                                                agreement_id = %agreement_id,
+                                                error = ?result.error,
+                                                "Scheduled clearing settlement failed"
+                                            );
+                                        }
+                                        Err(e) => {
+                                            tracing::warn!(
+                                                agreement_id = %agreement_id,
+                                                error = %e,
+                                                "Clearing settlement scheduler error"
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                            _ = sched_shutdown.recv() => {
+                                tracing::debug!("Clearing settlement scheduler shutting down");
+                                break;
+                            }
+                        }
+                    }
+                });
+                info!(
+                    "✓ Clearing settlement scheduler started (interval: {}s)",
+                    sched_interval.as_secs()
+                );
+            }
         }
 
         // Wire control service adapter

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -730,6 +730,14 @@ async fn spawn_actors_with_identity(
             info!("✓ Federation service wired to governance executor");
         }
 
+        // Wire settlement ledger so SettleClearing effects can produce ledger entries.
+        // Reuses the same LedgerService Arc already wired to the treasury executor;
+        // the service is stateless (no mutable fields), so sharing is safe.
+        if let Some(settlement_ledger) = gateway_handles.ledger_service.clone() {
+            kernel_executor = kernel_executor.with_settlement_ledger(settlement_ledger);
+            info!("✓ Settlement ledger wired to federation executor");
+        }
+
         // Wire control service adapter
         let control_service = Arc::new(crate::services::ControlServiceImpl::new(
             governance_handle.clone(),

--- a/icn/crates/icn-kernel-api/src/effects.rs
+++ b/icn/crates/icn-kernel-api/src/effects.rs
@@ -306,6 +306,20 @@ pub enum FederationEffect {
         vouchee_did: String,
         attestation_hash: String,
     },
+    /// Trigger settlement for an established bilateral clearing agreement.
+    /// Nets all confirmed cross-coop transfers and emits a ledger transfer
+    /// entry for the net position.  The agreement_id references an agreement
+    /// previously established via EstablishClearing.
+    SettleClearing {
+        agreement_id: String,
+        currency: String,
+        /// Governance provenance — empty string for legacy/backwards compat.
+        #[serde(default)]
+        decision_receipt_id: String,
+        /// Canonical decision hash for audit trail.
+        #[serde(default)]
+        decision_hash: String,
+    },
 }
 
 // =============================================================================

--- a/icn/crates/icn-kernel-api/src/governance.rs
+++ b/icn/crates/icn-kernel-api/src/governance.rs
@@ -116,6 +116,9 @@ pub enum FederationOperationType {
     LeaveFederation,
     EstablishClearing,
     VouchForCoop,
+    /// Settle net positions for a bilateral clearing agreement and emit a
+    /// ledger transfer entry for the net amount.
+    SettleClearing,
 }
 
 /// Federation operation request from governance
@@ -528,6 +531,24 @@ pub fn federation_effect_to_operation(effect: &FederationEffect) -> FederationOp
             target_id: Some(vouchee_did.clone()),
             agreement_hash: Some(attestation_hash.clone()),
             decision_hash: None,
+        },
+        FederationEffect::SettleClearing {
+            agreement_id,
+            currency,
+            decision_receipt_id: _,
+            decision_hash,
+        } => FederationOperation {
+            operation_type: FederationOperationType::SettleClearing,
+            // coop_did is not meaningful for SettleClearing; use agreement_id as key
+            coop_did: agreement_id.clone(),
+            // target_id carries the currency
+            target_id: Some(currency.clone()),
+            agreement_hash: Some(agreement_id.clone()),
+            decision_hash: if decision_hash.is_empty() {
+                None
+            } else {
+                Some(decision_hash.clone())
+            },
         },
     }
 }

--- a/icn/crates/icn-kernel-api/src/lib.rs
+++ b/icn/crates/icn-kernel-api/src/lib.rs
@@ -107,15 +107,16 @@ pub use receipts::{
 pub use scope::{CellId, MockCellService, ScopeLevel};
 pub use services::{
     AddMemberRequest, AddMemberResult, CellService, ControlService, FederationClearingRequest,
-    FederationClearingResult, FederationJoinRequest, FederationJoinResult, FederationService,
-    FederationVouchRequest, FederationVouchResult, ForceCloseProposalRequest,
-    ForceCloseProposalResult, FreezeMemberRequest, FreezeMemberResult, GovernanceEvent,
-    GovernanceService, LedgerEvent, LedgerService, MembershipService, RemoveMemberRequest,
-    RemoveMemberResult, SecurityService, SecurityViolation, ServiceRegistry, TreasuryEntryRequest,
-    TreasuryEntryResult, TreasuryOperationType as ServicesTreasuryOperationType, TrustClass,
-    TrustEvent, TrustService, UnfreezeMemberRequest, UnfreezeMemberResult, UpdateMemberRequest,
-    UpdateMemberResult, VetoProposalRequest, VetoProposalResult, TRUST_THRESHOLD_FEDERATED,
-    TRUST_THRESHOLD_KNOWN, TRUST_THRESHOLD_PARTNER,
+    FederationClearingResult, FederationClearingSettleRequest, FederationClearingSettleResult,
+    FederationJoinRequest, FederationJoinResult, FederationService, FederationVouchRequest,
+    FederationVouchResult, ForceCloseProposalRequest, ForceCloseProposalResult,
+    FreezeMemberRequest, FreezeMemberResult, GovernanceEvent, GovernanceService, LedgerEvent,
+    LedgerService, MembershipService, RemoveMemberRequest, RemoveMemberResult, SecurityService,
+    SecurityViolation, ServiceRegistry, TreasuryEntryRequest, TreasuryEntryResult,
+    TreasuryOperationType as ServicesTreasuryOperationType, TrustClass, TrustEvent, TrustService,
+    UnfreezeMemberRequest, UnfreezeMemberResult, UpdateMemberRequest, UpdateMemberResult,
+    VetoProposalRequest, VetoProposalResult, TRUST_THRESHOLD_FEDERATED, TRUST_THRESHOLD_KNOWN,
+    TRUST_THRESHOLD_PARTNER,
 };
 pub use state::{
     BlobService, KvService, LogService, ObjectReplication, ReplicationPolicy, StateBackend,

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -864,6 +864,41 @@ pub struct FederationClearingResult {
     pub error: Option<String>,
 }
 
+/// Request to settle net positions for a bilateral clearing agreement.
+///
+/// Causes `ClearingManager::trigger_settlement()` to run, which nets all
+/// confirmed transfers and resets the running position.  The resulting net
+/// amount is returned so the caller can emit a corresponding ledger entry.
+pub struct FederationClearingSettleRequest {
+    /// ID of the clearing agreement to settle
+    pub agreement_id: String,
+    /// Currency for the net settlement transfer
+    pub currency: String,
+    /// Governance decision receipt for audit linkage
+    pub decision_receipt_id: String,
+    /// Canonical decision hash
+    pub decision_hash: String,
+}
+
+/// Result of a clearing settlement operation.
+pub struct FederationClearingSettleResult {
+    /// Whether the settlement succeeded
+    pub success: bool,
+    /// Net settlement amount.  Positive: coop_a owes coop_b.  Negative: coop_b owes coop_a.
+    /// Zero: positions cancelled, no transfer needed.
+    pub net_settlement: i64,
+    /// coop_a identifier (from the agreement) — debtor when net_settlement > 0
+    pub coop_a: String,
+    /// coop_b identifier (from the agreement) — debtor when net_settlement < 0
+    pub coop_b: String,
+    /// Number of transfers that were settled
+    pub transfers_settled: usize,
+    /// State change hash for verification
+    pub state_change_hash: String,
+    /// Error message if failed
+    pub error: Option<String>,
+}
+
 /// Abstract federation management service.
 ///
 /// The kernel uses this to register cooperatives, record vouches, and
@@ -903,6 +938,19 @@ pub trait FederationService: Send + Sync {
         &self,
         request: FederationClearingRequest,
     ) -> Result<FederationClearingResult, anyhow::Error>;
+
+    /// Settle net positions for a bilateral clearing agreement.
+    ///
+    /// Triggers `ClearingManager::trigger_settlement()` which nets all confirmed
+    /// cross-coop transfers and returns the resulting net position.  The caller
+    /// is responsible for submitting a ledger transfer entry for the net amount.
+    ///
+    /// Returns the net position and coop identifiers so the executor can
+    /// produce the correct ledger debit/credit entries.
+    fn settle_clearing(
+        &self,
+        request: FederationClearingSettleRequest,
+    ) -> Result<FederationClearingSettleResult, anyhow::Error>;
 
     /// Check if a cooperative is registered in the federation.
     fn is_registered(&self, coop_did: &str) -> bool;

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -895,6 +895,8 @@ pub struct FederationClearingSettleResult {
     pub transfers_settled: usize,
     /// State change hash for verification
     pub state_change_hash: String,
+    /// Ledger entry hash if a transfer entry was emitted (non-zero net settlement with ledger configured)
+    pub ledger_entry_hash: Option<String>,
     /// Error message if failed
     pub error: Option<String>,
 }

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -869,6 +869,7 @@ pub struct FederationClearingResult {
 /// Causes `ClearingManager::trigger_settlement()` to run, which nets all
 /// confirmed transfers and resets the running position.  The resulting net
 /// amount is returned so the caller can emit a corresponding ledger entry.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct FederationClearingSettleRequest {
     /// ID of the clearing agreement to settle
     pub agreement_id: String,
@@ -881,6 +882,7 @@ pub struct FederationClearingSettleRequest {
 }
 
 /// Result of a clearing settlement operation.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct FederationClearingSettleResult {
     /// Whether the settlement succeeded
     pub success: bool,


### PR DESCRIPTION
## Summary

- Adds `FederationEffect::SettleClearing` — a governance-triggerable force-settle effect that nets all confirmed cross-coop transfers and emits a ledger transfer entry for the net position
- Closes the execution chain: `EstablishClearing` (governance) → operational transfers → `SettleClearing` (governance escape hatch) → ledger journal entry
- Implements `FederationService::settle_clearing()` backed by `ClearingManager::trigger_settlement()`
- Primary settlement path: operational scheduler (`get_due_settlements()` loop in `lifecycle.rs`) — not governance-triggered
- `FederationServiceImpl` gains optional `with_ledger()` builder; non-zero net settlements submitted as `TreasuryOperationType::Transfer` entries using `coop_a_did`/`coop_b_did` (not human-readable coop IDs)
- Idempotency guard: previews position before `trigger_settlement()` — fails fast if non-zero net and no ledger configured
- Background settlement scheduler wired into `lifecycle.rs` shutdown-safe task group

## Architecture note

`SettleClearing` via governance is an **escape hatch**, not the normal path. Routine settlement runs operationally on a timer. Governance-triggered settlement is for disputes and early settlement only.

## Test Plan

- [x] `cargo check -p icn-core -p icn-kernel-api -p icn-federation` — clean
- [x] `cargo test -p icn-core --lib` — 14/14 passed (including `test_settle_clearing_nonzero_net_requires_ledger`)
- [x] Rebased onto main after #1471 squash-merge

Replaces closed #1472 (auto-closed when #1471's base branch was deleted on merge).
Depends on #1471 — now merged to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)