### PR TITLE
feat(federation): expose clearing position via service-owned state at gateway layer

### DIFF
--- a/icn/crates/icn-core/src/services/federation_service.rs
+++ b/icn/crates/icn-core/src/services/federation_service.rs
@@ -559,6 +559,39 @@ impl FederationService for FederationServiceImpl {
         }
     }
 
+    fn get_clearing_position(
+        &self,
+        agreement_id: &str,
+    ) -> Result<icn_kernel_api::ClearingPositionView> {
+        let clearing = self.clearing.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "Clearing manager not configured on this node — federation clearing is disabled"
+            )
+        })?;
+
+        // Fetch the agreement to get the party identifiers (coop IDs — adapted here at boundary).
+        let agreement = clearing
+            .get_agreement(agreement_id)
+            .map_err(|e| anyhow::anyhow!("Failed to read agreement '{}': {}", agreement_id, e))?
+            .ok_or_else(|| anyhow::anyhow!("Agreement '{}' not found", agreement_id))?;
+
+        let position = clearing.calculate_position(agreement_id).map_err(|e| {
+            anyhow::anyhow!("Failed to read position for '{}': {}", agreement_id, e)
+        })?;
+
+        Ok(icn_kernel_api::ClearingPositionView {
+            agreement_id: agreement_id.to_string(),
+            // Adapt from coop-specific internal naming to party-level external vocabulary.
+            party_a: agreement.coop_a.clone(),
+            party_b: agreement.coop_b.clone(),
+            party_a_owes: position.coop_a_owes_b,
+            party_b_owes: position.coop_b_owes_a,
+            net_position: position.net_position(),
+            pending_count: position.pending_transfers.len(),
+            last_settlement_ts: position.last_settlement,
+        })
+    }
+
     fn is_registered(&self, coop_did: &str) -> bool {
         // Check if the DID (as coop_id) is in the registry
         self.registry.get(coop_did).ok().flatten().is_some()

--- a/icn/crates/icn-core/src/services/federation_service.rs
+++ b/icn/crates/icn-core/src/services/federation_service.rs
@@ -485,6 +485,7 @@ impl FederationService for FederationServiceImpl {
                             expected_nonce: None,
                             decision_receipt_id: request.decision_receipt_id.clone(),
                             decision_hash: request.decision_hash.clone(),
+                            distributions: Vec::new(),
                         };
                         match ledger.submit_treasury_entry(entry_req) {
                             Ok(entry_result) => {

--- a/icn/crates/icn-core/src/services/federation_service.rs
+++ b/icn/crates/icn-core/src/services/federation_service.rs
@@ -614,6 +614,8 @@ impl FederationService for FederationServiceImpl {
                 gateway_endpoints: c.gateway_endpoints,
                 capabilities: c.capabilities,
                 last_seen: c.last_seen,
+                // This record came from governance execution (join_federation effect).
+                origin: "governance".to_string(),
             })
             .collect())
     }
@@ -629,6 +631,8 @@ impl FederationService for FederationServiceImpl {
                 gateway_endpoints: c.gateway_endpoints,
                 capabilities: c.capabilities,
                 last_seen: c.last_seen,
+                // This record came from governance execution (join_federation effect).
+                origin: "governance".to_string(),
             }))
     }
 
@@ -662,6 +666,8 @@ impl FederationService for FederationServiceImpl {
                 max_imbalance: a.max_imbalance,
                 created_at: a.created_at,
                 exchange_rates: a.exchange_rates,
+                // This record came from governance execution (establish_clearing effect).
+                origin: "governance".to_string(),
             })
             .collect())
     }
@@ -692,6 +698,8 @@ impl FederationService for FederationServiceImpl {
                 max_imbalance: a.max_imbalance,
                 created_at: a.created_at,
                 exchange_rates: a.exchange_rates,
+                // This record came from governance execution (establish_clearing effect).
+                origin: "governance".to_string(),
             }))
     }
 }

--- a/icn/crates/icn-core/src/services/federation_service.rs
+++ b/icn/crates/icn-core/src/services/federation_service.rs
@@ -637,6 +637,63 @@ impl FederationService for FederationServiceImpl {
             .get_vouches(coop_id)
             .map_err(|e| anyhow::anyhow!("{}", e))
     }
+
+    fn list_agreements(&self) -> Result<Vec<icn_kernel_api::ClearingAgreementView>> {
+        let clearing = match self.clearing.as_ref() {
+            Some(c) => c,
+            None => return Ok(vec![]),
+        };
+        Ok(clearing
+            .list_agreements()
+            .into_iter()
+            .map(|a| icn_kernel_api::ClearingAgreementView {
+                agreement_id: a.agreement_id,
+                coop_a: a.coop_a,
+                coop_a_did: a.coop_a_did.to_string(),
+                coop_b: a.coop_b,
+                coop_b_did: a.coop_b_did.to_string(),
+                settlement_interval: match a.settlement_interval {
+                    icn_federation::SettlementInterval::Daily => "daily",
+                    icn_federation::SettlementInterval::Weekly => "weekly",
+                    icn_federation::SettlementInterval::Monthly => "monthly",
+                    icn_federation::SettlementInterval::Manual => "manual",
+                }
+                .to_string(),
+                max_imbalance: a.max_imbalance,
+                created_at: a.created_at,
+                exchange_rates: a.exchange_rates,
+            })
+            .collect())
+    }
+
+    fn get_agreement(
+        &self,
+        agreement_id: &str,
+    ) -> Result<Option<icn_kernel_api::ClearingAgreementView>> {
+        let clearing = match self.clearing.as_ref() {
+            Some(c) => c,
+            None => return Ok(None),
+        };
+        Ok(clearing
+            .get_agreement(agreement_id)?
+            .map(|a| icn_kernel_api::ClearingAgreementView {
+                agreement_id: a.agreement_id,
+                coop_a: a.coop_a,
+                coop_a_did: a.coop_a_did.to_string(),
+                coop_b: a.coop_b,
+                coop_b_did: a.coop_b_did.to_string(),
+                settlement_interval: match a.settlement_interval {
+                    icn_federation::SettlementInterval::Daily => "daily",
+                    icn_federation::SettlementInterval::Weekly => "weekly",
+                    icn_federation::SettlementInterval::Monthly => "monthly",
+                    icn_federation::SettlementInterval::Manual => "manual",
+                }
+                .to_string(),
+                max_imbalance: a.max_imbalance,
+                created_at: a.created_at,
+                exchange_rates: a.exchange_rates,
+            }))
+    }
 }
 
 #[cfg(test)]

--- a/icn/crates/icn-core/src/services/federation_service.rs
+++ b/icn/crates/icn-core/src/services/federation_service.rs
@@ -602,6 +602,41 @@ impl FederationService for FederationServiceImpl {
         prov.get(coop_did)
             .map(|p| (p.decision_receipt_id.clone(), p.decision_hash.clone()))
     }
+
+    fn list_cooperatives(&self) -> Result<Vec<icn_kernel_api::CooperativeView>> {
+        let coops = self.registry.list()?;
+        Ok(coops
+            .into_iter()
+            .map(|c| icn_kernel_api::CooperativeView {
+                coop_id: c.coop_id,
+                name: c.name,
+                public_did: c.public_did.to_string(),
+                gateway_endpoints: c.gateway_endpoints,
+                capabilities: c.capabilities,
+                last_seen: c.last_seen,
+            })
+            .collect())
+    }
+
+    fn get_cooperative(&self, coop_id: &str) -> Result<Option<icn_kernel_api::CooperativeView>> {
+        Ok(self
+            .registry
+            .get(coop_id)?
+            .map(|c| icn_kernel_api::CooperativeView {
+                coop_id: c.coop_id,
+                name: c.name,
+                public_did: c.public_did.to_string(),
+                gateway_endpoints: c.gateway_endpoints,
+                capabilities: c.capabilities,
+                last_seen: c.last_seen,
+            }))
+    }
+
+    fn get_vouches_for(&self, coop_id: &str) -> Result<Vec<String>> {
+        self.registry
+            .get_vouches(coop_id)
+            .map_err(|e| anyhow::anyhow!("{}", e))
+    }
 }
 
 #[cfg(test)]

--- a/icn/crates/icn-core/src/supervisor/actors.rs
+++ b/icn/crates/icn-core/src/supervisor/actors.rs
@@ -34,6 +34,10 @@ pub struct GatewayActorHandles {
     /// Hook invoked when a Charter proposal is accepted.
     /// Type-erased so `icn-core` stays domain-agnostic.
     pub charter_accepted_hook: Option<Arc<dyn Fn(String, String) + Send + Sync>>,
+    /// Federation service for clearing position queries and settlement.
+    /// When provided, the gateway uses this service-owned clearing state rather
+    /// than its own divergent ClearingManager instance.
+    pub federation_service: Option<Arc<dyn icn_kernel_api::services::FederationService>>,
 }
 
 /// Core actor handles returned from initialization

--- a/icn/crates/icn-core/src/supervisor/init_gateway.rs
+++ b/icn/crates/icn-core/src/supervisor/init_gateway.rs
@@ -50,6 +50,10 @@ pub struct GatewayHandles {
     pub commons: Option<icn_commons::CommonsHandle>,
     /// Hook invoked when a Charter proposal is accepted.
     pub charter_accepted_hook: Option<Arc<dyn Fn(String, String) + Send + Sync>>,
+    /// Federation service for clearing position queries and settlement.
+    /// When provided, the gateway uses this service-owned clearing state rather
+    /// than its own divergent ClearingManager instance.
+    pub federation_service: Option<Arc<dyn icn_kernel_api::FederationService>>,
 }
 
 /// Spawn the Gateway API server if enabled
@@ -114,6 +118,7 @@ pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: Gateway
     let naming_service = handles.naming_service;
     let commons_handle = handles.commons;
     let charter_accepted_hook = handles.charter_accepted_hook;
+    let federation_service_handle = handles.federation_service;
     let default_trust_score = config.default_trust_score;
 
     // Spawn gateway in a dedicated thread (actix-web has its own runtime)
@@ -196,6 +201,10 @@ pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: Gateway
 
             if let Some(hook) = charter_accepted_hook {
                 gateway_server = gateway_server.with_charter_accepted_hook(hook);
+            }
+
+            if let Some(service) = federation_service_handle {
+                gateway_server = gateway_server.with_federation_service(service);
             }
 
             if let Err(e) = gateway_server.run().await {

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -146,6 +146,7 @@ pub async fn run_supervisor(
             naming_service: gateway_handles.naming_service,
             commons: commons_handle,
             charter_accepted_hook: gateway_handles.charter_accepted_hook,
+            federation_service: gateway_handles.federation_service,
         },
     );
 
@@ -733,6 +734,9 @@ async fn spawn_actors_with_identity(
             }
             let federation_service = Arc::new(federation_service);
             kernel_executor = kernel_executor.with_federation_service(federation_service.clone());
+            // Also expose via gateway so position queries call through the correct service-owned
+            // clearing state rather than the gateway's own divergent ClearingManager instance.
+            gateway_handles.federation_service = Some(federation_service.clone());
             info!("✓ Federation service wired to governance executor");
 
             // Spawn the operational clearing settlement scheduler.

--- a/icn/crates/icn-gateway/src/api/federation.rs
+++ b/icn/crates/icn-gateway/src/api/federation.rs
@@ -15,6 +15,7 @@ use icn_federation::{
     SettlementInterval, SettlementReport, TrustContext, Vouch,
 };
 use icn_identity::Did;
+use icn_kernel_api::{ClearingPositionView, FederationService};
 
 // ============================================================================
 // Request/Response Models
@@ -462,19 +463,54 @@ pub async fn create_agreement(
     })))
 }
 
-/// GET /federation/clearing/{agreement_id}/position - Get clearing position
+/// GET /federation/clearing/{agreement_id}/position - Get current inter-party clearing position
+///
+/// Returns the accumulated clearing obligations between the two parties in the agreement:
+/// how much each party owes the other (confirmed, unsettled), the net position, and
+/// the count of pending (unconfirmed) transfers.
+///
+/// When the daemon's FederationService is available (normal runtime), this queries the
+/// supervisor-owned clearing state — the same state that the settlement scheduler uses.
+/// In standalone mode (no daemon), this falls back to the gateway's own clearing manager.
 #[get("/clearing/{agreement_id}/position")]
 pub async fn get_position(
     http_req: HttpRequest,
     fed_mgr: web::Data<Arc<FederationManager>>,
+    federation_service: web::Data<Arc<Option<Arc<dyn FederationService>>>>,
     path: web::Path<String>,
 ) -> Result<HttpResponse> {
     require_scope(&http_req, "federation:read")?;
 
     let agreement_id = path.into_inner();
-    let position = fed_mgr.get_position(&agreement_id).await?;
 
-    Ok(HttpResponse::Ok().json(position))
+    // Prefer the supervisor-owned FederationService: it reads from the correct clearing
+    // store that governance-triggered agreements and compute-receipt accumulations write to.
+    // Fall back to the gateway's own clearing manager only in standalone mode.
+    if let Some(ref service) = ***federation_service {
+        let view = service
+            .get_clearing_position(&agreement_id)
+            .map_err(|e| GatewayError::NotFound(e.to_string()))?;
+        return Ok(HttpResponse::Ok().json(view));
+    }
+
+    // Standalone fallback: gateway's own ClearingManager (may not reflect daemon state).
+    let position = fed_mgr.get_position(&agreement_id).await?;
+    // Adapt internal ClearingPosition to the party-level response vocabulary.
+    let agreement = fed_mgr
+        .get_agreement(&agreement_id)
+        .await?
+        .ok_or_else(|| GatewayError::NotFound(format!("Agreement not found: {agreement_id}")))?;
+    let view = ClearingPositionView {
+        agreement_id: agreement_id.clone(),
+        party_a: agreement.coop_a.clone(),
+        party_b: agreement.coop_b.clone(),
+        party_a_owes: position.coop_a_owes_b,
+        party_b_owes: position.coop_b_owes_a,
+        net_position: position.net_position(),
+        pending_count: position.pending_transfers.len(),
+        last_settlement_ts: position.last_settlement,
+    };
+    Ok(HttpResponse::Ok().json(view))
 }
 
 /// POST /federation/clearing/{agreement_id}/settle - Trigger settlement

--- a/icn/crates/icn-gateway/src/api/federation.rs
+++ b/icn/crates/icn-gateway/src/api/federation.rs
@@ -759,6 +759,116 @@ mod tests {
         );
     }
 
+    /// Verify that the clearing position handler prefers the supervisor-owned FederationService
+    /// over the gateway-local FederationManager when a service is injected.
+    ///
+    /// Architectural invariant (ADR 0011): the gateway must never present state from its own
+    /// divergent local manager when a supervisor-owned service is available. Reads must route
+    /// through the canonical service instance.
+    #[actix_web::test]
+    async fn test_get_position_prefers_federation_service_over_local_manager() {
+        use actix_web::HttpMessage;
+        use icn_kernel_api::{
+            ClearingPositionView, FederationClearingRequest, FederationClearingResult,
+            FederationClearingSettleRequest, FederationClearingSettleResult, FederationJoinRequest,
+            FederationJoinResult, FederationService, FederationVouchRequest, FederationVouchResult,
+        };
+
+        // Stub service that records calls and returns a known ClearingPositionView.
+        // Only get_clearing_position is implemented — all others panic to surface
+        // any accidental routing to the wrong method.
+        struct StubFederationService;
+
+        impl FederationService for StubFederationService {
+            fn join_federation(
+                &self,
+                _req: FederationJoinRequest,
+            ) -> anyhow::Result<FederationJoinResult> {
+                unimplemented!("test stub: join_federation should not be called")
+            }
+            fn vouch_for_cooperative(
+                &self,
+                _req: FederationVouchRequest,
+            ) -> anyhow::Result<FederationVouchResult> {
+                unimplemented!("test stub: vouch_for_cooperative should not be called")
+            }
+            fn establish_clearing(
+                &self,
+                _req: FederationClearingRequest,
+            ) -> anyhow::Result<FederationClearingResult> {
+                unimplemented!("test stub: establish_clearing should not be called")
+            }
+            fn settle_clearing(
+                &self,
+                _req: FederationClearingSettleRequest,
+            ) -> anyhow::Result<FederationClearingSettleResult> {
+                unimplemented!("test stub: settle_clearing should not be called")
+            }
+            fn get_clearing_position(
+                &self,
+                agreement_id: &str,
+            ) -> anyhow::Result<ClearingPositionView> {
+                Ok(ClearingPositionView {
+                    agreement_id: agreement_id.to_string(),
+                    party_a: "coop-alpha".to_string(),
+                    party_b: "coop-beta".to_string(),
+                    party_a_owes: 100,
+                    party_b_owes: 0,
+                    net_position: 100,
+                    pending_count: 1,
+                    last_settlement_ts: 0,
+                })
+            }
+            fn is_registered(&self, _coop_did: &str) -> bool {
+                false
+            }
+            fn get_registration_provenance(&self, _coop_did: &str) -> Option<(String, String)> {
+                None
+            }
+        }
+
+        let fed_mgr = Arc::new(FederationManager::new());
+        let stub_service: Arc<dyn FederationService> = Arc::new(StubFederationService);
+        // Wrap as the gateway expects: Arc<Option<Arc<dyn FederationService>>>
+        let service_for_routes: Arc<Option<Arc<dyn FederationService>>> =
+            Arc::new(Some(stub_service));
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(fed_mgr.clone()))
+                .app_data(web::Data::new(service_for_routes))
+                .service(web::scope("/v1/federation").service(get_position)),
+        )
+        .await;
+
+        // Inject minimal JWT claims so require_scope("federation:read") passes.
+        let claims = crate::auth::TokenClaims {
+            sub: "did:icn:test".to_string(),
+            iat: 1_000_000_000,
+            coop_id: "coop-alpha".to_string(),
+            scopes: vec!["federation:read".to_string()],
+            exp: 9_999_999_999,
+        };
+        let req = test::TestRequest::get()
+            .uri("/v1/federation/clearing/agr-001/position")
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status().as_u16(),
+            200,
+            "Expected 200 from service-backed path; fallback would 404/500"
+        );
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(
+            body["party_a"], "coop-alpha",
+            "Response must come from StubFederationService, not local FederationManager"
+        );
+        assert_eq!(body["net_position"], 100);
+    }
+
     /// Verify that empty scopes placed AFTER named scopes don't steal routes.
     /// This is a regression test for the bug where web::scope("") before
     /// web::scope("/federation") caused federation routes to 404.

--- a/icn/crates/icn-gateway/src/api/federation.rs
+++ b/icn/crates/icn-gateway/src/api/federation.rs
@@ -15,7 +15,9 @@ use icn_federation::{
     SettlementInterval, SettlementReport, TrustContext, Vouch,
 };
 use icn_identity::Did;
-use icn_kernel_api::{ClearingPositionView, FederationService};
+use icn_kernel_api::{
+    ClearingAgreementView, ClearingPositionView, CooperativeView, FederationService,
+};
 
 // ============================================================================
 // Request/Response Models
@@ -182,8 +184,23 @@ pub async fn list_coops(
     }
 
     // Standalone fallback: gateway-local FederationManager.
+    // Adapt to CooperativeView so the response shape is identical to the service path.
+    // origin = "direct-management" because these records come from the gateway API
+    // write path, not from governance execution (ADR 0012 / Model C).
     let coops = fed_mgr.list_cooperatives().await?;
-    Ok(HttpResponse::Ok().json(coops))
+    let views: Vec<CooperativeView> = coops
+        .into_iter()
+        .map(|c| CooperativeView {
+            coop_id: c.coop_id,
+            name: c.name,
+            public_did: c.public_did.to_string(),
+            gateway_endpoints: c.gateway_endpoints,
+            capabilities: c.capabilities,
+            last_seen: c.last_seen,
+            origin: "direct-management".to_string(),
+        })
+        .collect();
+    Ok(HttpResponse::Ok().json(views))
 }
 
 /// GET /federation/coops/{coop_id} - Get a specific cooperative
@@ -213,8 +230,18 @@ pub async fn get_coop(
         };
     }
 
+    // Adapt to CooperativeView so the response shape matches the service path.
+    // origin = "direct-management": written via the gateway API, not governance execution.
     match fed_mgr.get_cooperative(&coop_id).await? {
-        Some(coop) => Ok(HttpResponse::Ok().json(coop)),
+        Some(c) => Ok(HttpResponse::Ok().json(CooperativeView {
+            coop_id: c.coop_id,
+            name: c.name,
+            public_did: c.public_did.to_string(),
+            gateway_endpoints: c.gateway_endpoints,
+            capabilities: c.capabilities,
+            last_seen: c.last_seen,
+            origin: "direct-management".to_string(),
+        })),
         None => Err(GatewayError::NotFound(format!(
             "Cooperative not found: {coop_id}"
         ))),
@@ -281,15 +308,20 @@ pub async fn get_vouches(
         let vouches = service
             .get_vouches_for(&coop_id)
             .map_err(|e| GatewayError::InternalError(e.to_string()))?;
+        // origin = "governance": vouch records written by governance execution
+        // (vouch_for_cooperative effects), not the direct-management API.
         return Ok(HttpResponse::Ok().json(serde_json::json!({
             "coop_id": coop_id,
+            "origin": "governance",
             "vouches": vouches
         })));
     }
 
     let vouches = fed_mgr.get_vouches(&coop_id).await?;
+    // origin = "direct-management": vouch records written via the gateway API path.
     Ok(HttpResponse::Ok().json(serde_json::json!({
         "coop_id": coop_id,
+        "origin": "direct-management",
         "vouches": vouches
     })))
 }
@@ -460,8 +492,32 @@ pub async fn list_agreements(
     }
 
     // Standalone fallback: gateway-local FederationManager.
+    // Adapt to ClearingAgreementView so the response shape matches the service path.
+    // origin = "direct-management": these agreements were created via the gateway API,
+    // not through governance execution (ADR 0012 / Model C).
     let agreements = fed_mgr.list_agreements().await?;
-    Ok(HttpResponse::Ok().json(agreements))
+    let views: Vec<ClearingAgreementView> = agreements
+        .into_iter()
+        .map(|a| ClearingAgreementView {
+            agreement_id: a.agreement_id,
+            coop_a: a.coop_a,
+            coop_a_did: a.coop_a_did.to_string(),
+            coop_b: a.coop_b,
+            coop_b_did: a.coop_b_did.to_string(),
+            settlement_interval: match a.settlement_interval {
+                SettlementInterval::Daily => "daily",
+                SettlementInterval::Weekly => "weekly",
+                SettlementInterval::Monthly => "monthly",
+                SettlementInterval::Manual => "manual",
+            }
+            .to_string(),
+            max_imbalance: a.max_imbalance,
+            created_at: a.created_at,
+            exchange_rates: a.exchange_rates,
+            origin: "direct-management".to_string(),
+        })
+        .collect();
+    Ok(HttpResponse::Ok().json(views))
 }
 
 /// GET /federation/clearing/{agreement_id} - Get a clearing agreement
@@ -491,8 +547,27 @@ pub async fn get_agreement(
         };
     }
 
+    // Adapt to ClearingAgreementView so the response shape matches the service path.
+    // origin = "direct-management": written via the gateway API, not governance execution.
     match fed_mgr.get_agreement(&agreement_id).await? {
-        Some(agreement) => Ok(HttpResponse::Ok().json(agreement)),
+        Some(a) => Ok(HttpResponse::Ok().json(ClearingAgreementView {
+            agreement_id: a.agreement_id,
+            coop_a: a.coop_a,
+            coop_a_did: a.coop_a_did.to_string(),
+            coop_b: a.coop_b,
+            coop_b_did: a.coop_b_did.to_string(),
+            settlement_interval: match a.settlement_interval {
+                SettlementInterval::Daily => "daily",
+                SettlementInterval::Weekly => "weekly",
+                SettlementInterval::Monthly => "monthly",
+                SettlementInterval::Manual => "manual",
+            }
+            .to_string(),
+            max_imbalance: a.max_imbalance,
+            created_at: a.created_at,
+            exchange_rates: a.exchange_rates,
+            origin: "direct-management".to_string(),
+        })),
         None => Err(GatewayError::NotFound(format!(
             "Agreement not found: {agreement_id}"
         ))),
@@ -916,6 +991,7 @@ mod tests {
                     gateway_endpoints: vec![],
                     capabilities: vec![],
                     last_seen: 0,
+                    origin: "governance".to_string(),
                 }])
             }
             fn get_cooperative(&self, coop_id: &str) -> anyhow::Result<Option<CooperativeView>> {
@@ -927,6 +1003,7 @@ mod tests {
                         gateway_endpoints: vec![],
                         capabilities: vec![],
                         last_seen: 0,
+                        origin: "governance".to_string(),
                     }))
                 } else {
                     Ok(None)
@@ -1038,6 +1115,7 @@ mod tests {
                     gateway_endpoints: vec!["http://gov.local:8080".to_string()],
                     capabilities: vec!["clearing".to_string()],
                     last_seen: 1_000_000,
+                    origin: "governance".to_string(),
                 }])
             }
             fn get_cooperative(&self, coop_id: &str) -> anyhow::Result<Option<CooperativeView>> {
@@ -1049,6 +1127,7 @@ mod tests {
                         gateway_endpoints: vec![],
                         capabilities: vec![],
                         last_seen: 1_000_000,
+                        origin: "governance".to_string(),
                     }))
                 } else {
                     Ok(None)
@@ -1068,6 +1147,7 @@ mod tests {
                     max_imbalance: 5000,
                     created_at: 1_000_000,
                     exchange_rates: std::collections::HashMap::new(),
+                    origin: "governance".to_string(),
                 }])
             }
             fn get_agreement(
@@ -1085,6 +1165,7 @@ mod tests {
                         max_imbalance: 5000,
                         created_at: 1_000_000,
                         exchange_rates: std::collections::HashMap::new(),
+                        origin: "governance".to_string(),
                     }))
                 } else {
                     Ok(None)
@@ -1393,6 +1474,195 @@ mod tests {
             resp.status().as_u16(),
             404,
             "route must match even without FederationService (fell through to fed_mgr path)"
+        );
+    }
+
+    // ── Origin labeling tests (ADR 0012 Step 2) ────────────────────────────────
+
+    /// Service-backed coop list carries origin = "governance".
+    #[actix_web::test]
+    async fn test_list_coops_origin_governance_when_service_present() {
+        use actix_web::HttpMessage;
+
+        let fed_mgr = Arc::new(FederationManager::new());
+        let service_data = stub_service_data();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(fed_mgr.clone()))
+                .app_data(web::Data::new(service_data))
+                .service(web::scope("/v1/federation").service(list_coops)),
+        )
+        .await;
+
+        let claims = crate::auth::TokenClaims {
+            sub: "did:icn:test".to_string(),
+            iat: 1_000_000_000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["federation:read".to_string()],
+            exp: 9_999_999_999,
+        };
+        let req = test::TestRequest::get()
+            .uri("/v1/federation/coops")
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status().as_u16(), 200);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        let coops = body.as_array().expect("expected array");
+        assert_eq!(
+            coops[0]["origin"], "governance",
+            "service-backed coop list must carry origin = governance"
+        );
+    }
+
+    /// Service-backed get_coop carries origin = "governance".
+    #[actix_web::test]
+    async fn test_get_coop_origin_governance_when_service_present() {
+        use actix_web::HttpMessage;
+
+        let fed_mgr = Arc::new(FederationManager::new());
+        let service_data = stub_service_data();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(fed_mgr.clone()))
+                .app_data(web::Data::new(service_data))
+                .service(web::scope("/v1/federation").service(get_coop)),
+        )
+        .await;
+
+        let claims = crate::auth::TokenClaims {
+            sub: "did:icn:test".to_string(),
+            iat: 1_000_000_000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["federation:read".to_string()],
+            exp: 9_999_999_999,
+        };
+        let req = test::TestRequest::get()
+            .uri("/v1/federation/coops/governance-coop")
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status().as_u16(), 200);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(
+            body["origin"], "governance",
+            "service-backed coop must carry origin = governance"
+        );
+    }
+
+    /// Service-backed vouches carry origin = "governance".
+    #[actix_web::test]
+    async fn test_get_vouches_origin_governance_when_service_present() {
+        use actix_web::HttpMessage;
+
+        let fed_mgr = Arc::new(FederationManager::new());
+        let service_data = stub_service_data();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(fed_mgr.clone()))
+                .app_data(web::Data::new(service_data))
+                .service(web::scope("/v1/federation").service(get_vouches)),
+        )
+        .await;
+
+        let claims = crate::auth::TokenClaims {
+            sub: "did:icn:test".to_string(),
+            iat: 1_000_000_000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["federation:read".to_string()],
+            exp: 9_999_999_999,
+        };
+        let req = test::TestRequest::get()
+            .uri("/v1/federation/coops/any-coop/vouches")
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status().as_u16(), 200);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(
+            body["origin"], "governance",
+            "service-backed vouches must carry origin = governance"
+        );
+    }
+
+    /// Service-backed agreement list carries origin = "governance".
+    #[actix_web::test]
+    async fn test_list_agreements_origin_governance_when_service_present() {
+        use actix_web::HttpMessage;
+
+        let fed_mgr = Arc::new(FederationManager::new());
+        let service_data = stub_service_data();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(fed_mgr.clone()))
+                .app_data(web::Data::new(service_data))
+                .service(web::scope("/v1/federation").service(list_agreements)),
+        )
+        .await;
+
+        let claims = crate::auth::TokenClaims {
+            sub: "did:icn:test".to_string(),
+            iat: 1_000_000_000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["federation:read".to_string()],
+            exp: 9_999_999_999,
+        };
+        let req = test::TestRequest::get()
+            .uri("/v1/federation/clearing")
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status().as_u16(), 200);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        let agreements = body.as_array().expect("expected array");
+        assert_eq!(
+            agreements[0]["origin"], "governance",
+            "service-backed clearing list must carry origin = governance"
+        );
+    }
+
+    /// Service-backed get_agreement carries origin = "governance".
+    #[actix_web::test]
+    async fn test_get_agreement_origin_governance_when_service_present() {
+        use actix_web::HttpMessage;
+
+        let fed_mgr = Arc::new(FederationManager::new());
+        let service_data = stub_service_data();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(fed_mgr.clone()))
+                .app_data(web::Data::new(service_data))
+                .service(web::scope("/v1/federation").service(get_agreement)),
+        )
+        .await;
+
+        let claims = crate::auth::TokenClaims {
+            sub: "did:icn:test".to_string(),
+            iat: 1_000_000_000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["federation:read".to_string()],
+            exp: 9_999_999_999,
+        };
+        let req = test::TestRequest::get()
+            .uri("/v1/federation/clearing/agr-gov-001")
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status().as_u16(), 200);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(
+            body["origin"], "governance",
+            "service-backed agreement must carry origin = governance"
         );
     }
 

--- a/icn/crates/icn-gateway/src/api/federation.rs
+++ b/icn/crates/icn-gateway/src/api/federation.rs
@@ -644,9 +644,16 @@ pub async fn get_position(
     // store that governance-triggered agreements and compute-receipt accumulations write to.
     // Fall back to the gateway's own clearing manager only in standalone mode.
     if let Some(ref service) = ***federation_service {
-        let view = service
-            .get_clearing_position(&agreement_id)
-            .map_err(|e| GatewayError::NotFound(e.to_string()))?;
+        let view = service.get_clearing_position(&agreement_id).map_err(|e| {
+            let msg = e.to_string();
+            if msg.contains("not found") {
+                GatewayError::NotFound(msg)
+            } else if msg.contains("not configured") || msg.contains("disabled") {
+                GatewayError::ServiceUnavailable(msg)
+            } else {
+                GatewayError::InternalError(msg)
+            }
+        })?;
         return Ok(HttpResponse::Ok().json(view));
     }
 
@@ -1063,6 +1070,47 @@ mod tests {
             "Response must come from StubFederationService, not local FederationManager"
         );
         assert_eq!(body["net_position"], 100);
+    }
+
+    /// Verify that get_position falls back to the gateway's own FederationManager when no
+    /// FederationService is injected (standalone mode).
+    #[actix_web::test]
+    async fn test_get_position_falls_back_to_fed_mgr_when_no_service() {
+        use actix_web::HttpMessage;
+
+        let fed_mgr = Arc::new(FederationManager::new());
+        // No service injected — None variant
+        let no_service: Arc<Option<Arc<dyn FederationService>>> = Arc::new(None);
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(fed_mgr.clone()))
+                .app_data(web::Data::new(no_service))
+                .service(web::scope("/v1/federation").service(get_position)),
+        )
+        .await;
+
+        let claims = crate::auth::TokenClaims {
+            sub: "did:icn:test".to_string(),
+            iat: 1_000_000_000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["federation:read".to_string()],
+            exp: 9_999_999_999,
+        };
+        let req = test::TestRequest::get()
+            .uri("/v1/federation/clearing/nonexistent-agreement/position")
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        // FederationManager has no agreement — expect an error, but NOT from the service
+        // path (which would only fire if federation_service is Some). The route must match
+        // (not a 405/404 routing failure).
+        assert_ne!(
+            resp.status().as_u16(),
+            405,
+            "route must match even without FederationService (fell through to fed_mgr path)"
+        );
     }
 
     /// Helper: build a service_for_routes (the double-wrapped Arc the gateway expects).

--- a/icn/crates/icn-gateway/src/api/federation.rs
+++ b/icn/crates/icn-gateway/src/api/federation.rs
@@ -436,27 +436,61 @@ pub async fn issue_attestation(
 // ============================================================================
 
 /// GET /federation/clearing - List clearing agreements
+///
+/// When the daemon's FederationService is available, returns agreements registered via
+/// governance execution (`establish_clearing` effects). These carry full provenance.
+/// In standalone mode, falls back to the gateway's direct-management registry.
+///
+/// Note: the two paths are separate stores (ADR 0012). This endpoint always reflects
+/// exactly one path — it does not merge both.
 #[get("/clearing")]
 pub async fn list_agreements(
     http_req: HttpRequest,
     fed_mgr: web::Data<Arc<FederationManager>>,
+    federation_service: web::Data<Arc<Option<Arc<dyn FederationService>>>>,
 ) -> Result<HttpResponse> {
     require_scope(&http_req, "federation:read")?;
 
+    // Prefer supervisor-owned service (governance-registered agreements).
+    if let Some(ref service) = ***federation_service {
+        let agreements = service
+            .list_agreements()
+            .map_err(|e| GatewayError::InternalError(e.to_string()))?;
+        return Ok(HttpResponse::Ok().json(agreements));
+    }
+
+    // Standalone fallback: gateway-local FederationManager.
     let agreements = fed_mgr.list_agreements().await?;
     Ok(HttpResponse::Ok().json(agreements))
 }
 
 /// GET /federation/clearing/{agreement_id} - Get a clearing agreement
+///
+/// Prefers the supervisor-owned registry in daemon mode. Falls back to
+/// the gateway's direct-management registry in standalone mode.
 #[get("/clearing/{agreement_id}")]
 pub async fn get_agreement(
     http_req: HttpRequest,
     fed_mgr: web::Data<Arc<FederationManager>>,
+    federation_service: web::Data<Arc<Option<Arc<dyn FederationService>>>>,
     path: web::Path<String>,
 ) -> Result<HttpResponse> {
     require_scope(&http_req, "federation:read")?;
 
     let agreement_id = path.into_inner();
+
+    if let Some(ref service) = ***federation_service {
+        return match service
+            .get_agreement(&agreement_id)
+            .map_err(|e| GatewayError::InternalError(e.to_string()))?
+        {
+            Some(agreement) => Ok(HttpResponse::Ok().json(agreement)),
+            None => Err(GatewayError::NotFound(format!(
+                "Agreement not found: {agreement_id}"
+            ))),
+        };
+    }
+
     match fed_mgr.get_agreement(&agreement_id).await? {
         Some(agreement) => Ok(HttpResponse::Ok().json(agreement)),
         None => Err(GatewayError::NotFound(format!(
@@ -781,7 +815,7 @@ pub async fn federation_connect(
 mod tests {
     use super::*;
     use actix_web::{test, App};
-    use icn_kernel_api::CooperativeView;
+    use icn_kernel_api::{ClearingAgreementView, CooperativeView};
 
     #[actix_web::test]
     async fn test_federation_status_route_matches() {
@@ -901,6 +935,15 @@ mod tests {
             fn get_vouches_for(&self, _coop_id: &str) -> anyhow::Result<Vec<String>> {
                 Ok(vec!["did:icn:voucher-stub".to_string()])
             }
+            fn list_agreements(&self) -> anyhow::Result<Vec<ClearingAgreementView>> {
+                Ok(vec![])
+            }
+            fn get_agreement(
+                &self,
+                _agreement_id: &str,
+            ) -> anyhow::Result<Option<ClearingAgreementView>> {
+                Ok(None)
+            }
         }
 
         let fed_mgr = Arc::new(FederationManager::new());
@@ -1013,6 +1056,39 @@ mod tests {
             }
             fn get_vouches_for(&self, _: &str) -> anyhow::Result<Vec<String>> {
                 Ok(vec!["did:icn:voucher-gov".to_string()])
+            }
+            fn list_agreements(&self) -> anyhow::Result<Vec<ClearingAgreementView>> {
+                Ok(vec![ClearingAgreementView {
+                    agreement_id: "agr-gov-001".to_string(),
+                    coop_a: "coop-alpha".to_string(),
+                    coop_a_did: "did:icn:alpha".to_string(),
+                    coop_b: "coop-beta".to_string(),
+                    coop_b_did: "did:icn:beta".to_string(),
+                    settlement_interval: "weekly".to_string(),
+                    max_imbalance: 5000,
+                    created_at: 1_000_000,
+                    exchange_rates: std::collections::HashMap::new(),
+                }])
+            }
+            fn get_agreement(
+                &self,
+                agreement_id: &str,
+            ) -> anyhow::Result<Option<ClearingAgreementView>> {
+                if agreement_id == "agr-gov-001" {
+                    Ok(Some(ClearingAgreementView {
+                        agreement_id: "agr-gov-001".to_string(),
+                        coop_a: "coop-alpha".to_string(),
+                        coop_a_did: "did:icn:alpha".to_string(),
+                        coop_b: "coop-beta".to_string(),
+                        coop_b_did: "did:icn:beta".to_string(),
+                        settlement_interval: "weekly".to_string(),
+                        max_imbalance: 5000,
+                        created_at: 1_000_000,
+                        exchange_rates: std::collections::HashMap::new(),
+                    }))
+                } else {
+                    Ok(None)
+                }
             }
         }
         Arc::new(Some(Arc::new(Stub) as Arc<dyn FederationService>))
@@ -1182,6 +1258,141 @@ mod tests {
         assert_eq!(
             body["vouches"][0], "did:icn:voucher-gov",
             "must come from FederationService (governance path)"
+        );
+    }
+
+    /// Verify that list_agreements prefers FederationService over local FederationManager.
+    ///
+    /// Architectural invariant (ADR 0012 Step 1b): when the supervisor's FederationService
+    /// is available, GET /federation/clearing must return governance-established agreements,
+    /// not the gateway-local direct-management state.
+    #[actix_web::test]
+    async fn test_list_agreements_prefers_federation_service() {
+        use actix_web::HttpMessage;
+
+        let fed_mgr = Arc::new(FederationManager::new());
+        let service_data = stub_service_data();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(fed_mgr.clone()))
+                .app_data(web::Data::new(service_data))
+                .service(web::scope("/v1/federation").service(list_agreements)),
+        )
+        .await;
+
+        let claims = crate::auth::TokenClaims {
+            sub: "did:icn:test".to_string(),
+            iat: 1_000_000_000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["federation:read".to_string()],
+            exp: 9_999_999_999,
+        };
+        let req = test::TestRequest::get()
+            .uri("/v1/federation/clearing")
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        let agreements = body.as_array().expect("expected array");
+        assert_eq!(
+            agreements.len(),
+            1,
+            "should return exactly the stub agreement"
+        );
+        assert_eq!(
+            agreements[0]["agreement_id"], "agr-gov-001",
+            "must come from FederationService (governance path), not FederationManager"
+        );
+        assert_eq!(agreements[0]["coop_a"], "coop-alpha");
+        assert_eq!(agreements[0]["settlement_interval"], "weekly");
+    }
+
+    /// Verify that get_agreement returns from FederationService and 404s for unknown agreements.
+    ///
+    /// Architectural invariant (ADR 0012 Step 1b): the gateway must never present state from
+    /// its own local manager when the supervisor-owned service is available.
+    #[actix_web::test]
+    async fn test_get_agreement_prefers_federation_service() {
+        use actix_web::HttpMessage;
+
+        let fed_mgr = Arc::new(FederationManager::new());
+        let service_data = stub_service_data();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(fed_mgr.clone()))
+                .app_data(web::Data::new(service_data))
+                .service(web::scope("/v1/federation").service(get_agreement)),
+        )
+        .await;
+
+        let make_claims = || crate::auth::TokenClaims {
+            sub: "did:icn:test".to_string(),
+            iat: 1_000_000_000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["federation:read".to_string()],
+            exp: 9_999_999_999,
+        };
+
+        // Known agreement → 200 with correct shape
+        let req = test::TestRequest::get()
+            .uri("/v1/federation/clearing/agr-gov-001")
+            .to_request();
+        req.extensions_mut().insert(make_claims());
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status().as_u16(), 200);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["agreement_id"], "agr-gov-001");
+        assert_eq!(body["coop_a"], "coop-alpha");
+        assert_eq!(body["max_imbalance"], 5000);
+
+        // Unknown agreement → 404 (service returns None)
+        let req2 = test::TestRequest::get()
+            .uri("/v1/federation/clearing/nonexistent")
+            .to_request();
+        req2.extensions_mut().insert(make_claims());
+        let resp2 = test::call_service(&app, req2).await;
+        assert_eq!(resp2.status().as_u16(), 404);
+    }
+
+    /// Verify that list_agreements falls back to FederationManager when no service is present.
+    #[actix_web::test]
+    async fn test_list_agreements_falls_back_to_fed_mgr_when_no_service() {
+        use actix_web::HttpMessage;
+
+        let fed_mgr = Arc::new(FederationManager::new());
+        let no_service: Arc<Option<Arc<dyn FederationService>>> = Arc::new(None);
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(fed_mgr.clone()))
+                .app_data(web::Data::new(no_service))
+                .service(web::scope("/v1/federation").service(list_agreements)),
+        )
+        .await;
+
+        let claims = crate::auth::TokenClaims {
+            sub: "did:icn:test".to_string(),
+            iat: 1_000_000_000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["federation:read".to_string()],
+            exp: 9_999_999_999,
+        };
+        let req = test::TestRequest::get()
+            .uri("/v1/federation/clearing")
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        // FederationManager not initialized → may error, but route matched (NOT 404).
+        assert_ne!(
+            resp.status().as_u16(),
+            404,
+            "route must match even without FederationService (fell through to fed_mgr path)"
         );
     }
 

--- a/icn/crates/icn-gateway/src/api/federation.rs
+++ b/icn/crates/icn-gateway/src/api/federation.rs
@@ -158,27 +158,61 @@ pub async fn init_federation(
 // ============================================================================
 
 /// GET /federation/coops - List known cooperatives
+///
+/// When the daemon's FederationService is available, returns cooperatives registered via
+/// governance execution (`join_federation` effects). These carry full provenance.
+/// In standalone mode, falls back to the gateway's direct-management registry.
+///
+/// Note: the two paths are separate stores (ADR 0012). This endpoint always reflects
+/// exactly one path — it does not merge both.
 #[get("/coops")]
 pub async fn list_coops(
     http_req: HttpRequest,
     fed_mgr: web::Data<Arc<FederationManager>>,
+    federation_service: web::Data<Arc<Option<Arc<dyn FederationService>>>>,
 ) -> Result<HttpResponse> {
     require_scope(&http_req, "federation:read")?;
 
+    // Prefer supervisor-owned service (governance-registered coops).
+    if let Some(ref service) = ***federation_service {
+        let coops = service
+            .list_cooperatives()
+            .map_err(|e| GatewayError::InternalError(e.to_string()))?;
+        return Ok(HttpResponse::Ok().json(coops));
+    }
+
+    // Standalone fallback: gateway-local FederationManager.
     let coops = fed_mgr.list_cooperatives().await?;
     Ok(HttpResponse::Ok().json(coops))
 }
 
 /// GET /federation/coops/{coop_id} - Get a specific cooperative
+///
+/// Prefers the supervisor-owned registry in daemon mode. Falls back to
+/// the gateway's direct-management registry in standalone mode.
 #[get("/coops/{coop_id}")]
 pub async fn get_coop(
     http_req: HttpRequest,
     fed_mgr: web::Data<Arc<FederationManager>>,
+    federation_service: web::Data<Arc<Option<Arc<dyn FederationService>>>>,
     path: web::Path<String>,
 ) -> Result<HttpResponse> {
     require_scope(&http_req, "federation:read")?;
 
     let coop_id = path.into_inner();
+
+    if let Some(ref service) = ***federation_service {
+        return match service
+            .get_cooperative(&coop_id)
+            .map_err(|e| GatewayError::InternalError(e.to_string()))?
+        {
+            Some(coop) => Ok(HttpResponse::Ok().json(coop)),
+            None => Err(GatewayError::NotFound(format!(
+                "Cooperative not found: {coop_id}"
+            ))),
+        };
+    }
+
     match fed_mgr.get_cooperative(&coop_id).await? {
         Some(coop) => Ok(HttpResponse::Ok().json(coop)),
         None => Err(GatewayError::NotFound(format!(
@@ -229,17 +263,31 @@ pub async fn register_coop(
 // ============================================================================
 
 /// GET /federation/coops/{coop_id}/vouches - Get vouches for a cooperative
+///
+/// Prefers governance-originated vouch records from the supervisor's registry.
+/// Falls back to the gateway-local registry in standalone mode.
 #[get("/coops/{coop_id}/vouches")]
 pub async fn get_vouches(
     http_req: HttpRequest,
     fed_mgr: web::Data<Arc<FederationManager>>,
+    federation_service: web::Data<Arc<Option<Arc<dyn FederationService>>>>,
     path: web::Path<String>,
 ) -> Result<HttpResponse> {
     require_scope(&http_req, "federation:read")?;
 
     let coop_id = path.into_inner();
-    let vouches = fed_mgr.get_vouches(&coop_id).await?;
 
+    if let Some(ref service) = ***federation_service {
+        let vouches = service
+            .get_vouches_for(&coop_id)
+            .map_err(|e| GatewayError::InternalError(e.to_string()))?;
+        return Ok(HttpResponse::Ok().json(serde_json::json!({
+            "coop_id": coop_id,
+            "vouches": vouches
+        })));
+    }
+
+    let vouches = fed_mgr.get_vouches(&coop_id).await?;
     Ok(HttpResponse::Ok().json(serde_json::json!({
         "coop_id": coop_id,
         "vouches": vouches
@@ -733,6 +781,7 @@ pub async fn federation_connect(
 mod tests {
     use super::*;
     use actix_web::{test, App};
+    use icn_kernel_api::CooperativeView;
 
     #[actix_web::test]
     async fn test_federation_status_route_matches() {
@@ -825,6 +874,33 @@ mod tests {
             fn get_registration_provenance(&self, _coop_did: &str) -> Option<(String, String)> {
                 None
             }
+            fn list_cooperatives(&self) -> anyhow::Result<Vec<CooperativeView>> {
+                Ok(vec![CooperativeView {
+                    coop_id: "stub-coop".to_string(),
+                    name: "Stub Cooperative".to_string(),
+                    public_did: "did:icn:stub".to_string(),
+                    gateway_endpoints: vec![],
+                    capabilities: vec![],
+                    last_seen: 0,
+                }])
+            }
+            fn get_cooperative(&self, coop_id: &str) -> anyhow::Result<Option<CooperativeView>> {
+                if coop_id == "stub-coop" {
+                    Ok(Some(CooperativeView {
+                        coop_id: "stub-coop".to_string(),
+                        name: "Stub Cooperative".to_string(),
+                        public_did: "did:icn:stub".to_string(),
+                        gateway_endpoints: vec![],
+                        capabilities: vec![],
+                        last_seen: 0,
+                    }))
+                } else {
+                    Ok(None)
+                }
+            }
+            fn get_vouches_for(&self, _coop_id: &str) -> anyhow::Result<Vec<String>> {
+                Ok(vec!["did:icn:voucher-stub".to_string()])
+            }
         }
 
         let fed_mgr = Arc::new(FederationManager::new());
@@ -867,6 +943,246 @@ mod tests {
             "Response must come from StubFederationService, not local FederationManager"
         );
         assert_eq!(body["net_position"], 100);
+    }
+
+    /// Helper: build a service_for_routes (the double-wrapped Arc the gateway expects).
+    fn stub_service_data() -> Arc<Option<Arc<dyn FederationService>>> {
+        use icn_kernel_api::{
+            FederationClearingRequest, FederationClearingResult, FederationClearingSettleRequest,
+            FederationClearingSettleResult, FederationJoinRequest, FederationJoinResult,
+            FederationVouchRequest, FederationVouchResult,
+        };
+        struct Stub;
+        impl FederationService for Stub {
+            fn join_federation(
+                &self,
+                _: FederationJoinRequest,
+            ) -> anyhow::Result<FederationJoinResult> {
+                unimplemented!()
+            }
+            fn vouch_for_cooperative(
+                &self,
+                _: FederationVouchRequest,
+            ) -> anyhow::Result<FederationVouchResult> {
+                unimplemented!()
+            }
+            fn establish_clearing(
+                &self,
+                _: FederationClearingRequest,
+            ) -> anyhow::Result<FederationClearingResult> {
+                unimplemented!()
+            }
+            fn settle_clearing(
+                &self,
+                _: FederationClearingSettleRequest,
+            ) -> anyhow::Result<FederationClearingSettleResult> {
+                unimplemented!()
+            }
+            fn get_clearing_position(&self, _: &str) -> anyhow::Result<ClearingPositionView> {
+                unimplemented!()
+            }
+            fn is_registered(&self, _: &str) -> bool {
+                false
+            }
+            fn get_registration_provenance(&self, _: &str) -> Option<(String, String)> {
+                None
+            }
+            fn list_cooperatives(&self) -> anyhow::Result<Vec<CooperativeView>> {
+                Ok(vec![CooperativeView {
+                    coop_id: "governance-coop".to_string(),
+                    name: "Governance Cooperative".to_string(),
+                    public_did: "did:icn:gov".to_string(),
+                    gateway_endpoints: vec!["http://gov.local:8080".to_string()],
+                    capabilities: vec!["clearing".to_string()],
+                    last_seen: 1_000_000,
+                }])
+            }
+            fn get_cooperative(&self, coop_id: &str) -> anyhow::Result<Option<CooperativeView>> {
+                if coop_id == "governance-coop" {
+                    Ok(Some(CooperativeView {
+                        coop_id: "governance-coop".to_string(),
+                        name: "Governance Cooperative".to_string(),
+                        public_did: "did:icn:gov".to_string(),
+                        gateway_endpoints: vec![],
+                        capabilities: vec![],
+                        last_seen: 1_000_000,
+                    }))
+                } else {
+                    Ok(None)
+                }
+            }
+            fn get_vouches_for(&self, _: &str) -> anyhow::Result<Vec<String>> {
+                Ok(vec!["did:icn:voucher-gov".to_string()])
+            }
+        }
+        Arc::new(Some(Arc::new(Stub) as Arc<dyn FederationService>))
+    }
+
+    /// Verify that list_coops prefers FederationService over local FederationManager.
+    ///
+    /// Architectural invariant (ADR 0012 Step 1): when the supervisor's FederationService
+    /// is available, GET /federation/coops must return governance-registered coops, not
+    /// the gateway-local direct-management state.
+    #[actix_web::test]
+    async fn test_list_coops_prefers_federation_service() {
+        use actix_web::HttpMessage;
+
+        let fed_mgr = Arc::new(FederationManager::new());
+        let service_data = stub_service_data();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(fed_mgr.clone()))
+                .app_data(web::Data::new(service_data))
+                .service(web::scope("/v1/federation").service(list_coops)),
+        )
+        .await;
+
+        let claims = crate::auth::TokenClaims {
+            sub: "did:icn:test".to_string(),
+            iat: 1_000_000_000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["federation:read".to_string()],
+            exp: 9_999_999_999,
+        };
+        let req = test::TestRequest::get()
+            .uri("/v1/federation/coops")
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        let coops = body.as_array().expect("expected array");
+        assert_eq!(
+            coops.len(),
+            1,
+            "should return exactly the stub-service coop"
+        );
+        assert_eq!(
+            coops[0]["coop_id"], "governance-coop",
+            "must come from FederationService (governance path), not FederationManager"
+        );
+    }
+
+    /// Verify that list_coops falls back to FederationManager when no service is present.
+    #[actix_web::test]
+    async fn test_list_coops_falls_back_to_fed_mgr_when_no_service() {
+        use actix_web::HttpMessage;
+
+        let fed_mgr = Arc::new(FederationManager::new());
+        // No service injected — None variant
+        let no_service: Arc<Option<Arc<dyn FederationService>>> = Arc::new(None);
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(fed_mgr.clone()))
+                .app_data(web::Data::new(no_service))
+                .service(web::scope("/v1/federation").service(list_coops)),
+        )
+        .await;
+
+        let claims = crate::auth::TokenClaims {
+            sub: "did:icn:test".to_string(),
+            iat: 1_000_000_000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["federation:read".to_string()],
+            exp: 9_999_999_999,
+        };
+        let req = test::TestRequest::get()
+            .uri("/v1/federation/coops")
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        // FederationManager not initialized → returns error (no registry), but route matched
+        // (NOT 404). The exact error is an app concern; we just verify the fallback path fires.
+        assert_ne!(
+            resp.status().as_u16(),
+            404,
+            "route must match even without FederationService (fell through to fed_mgr path)"
+        );
+    }
+
+    /// Verify that get_coop returns from FederationService and 404s for unknown coops.
+    #[actix_web::test]
+    async fn test_get_coop_prefers_federation_service() {
+        use actix_web::HttpMessage;
+
+        let fed_mgr = Arc::new(FederationManager::new());
+        let service_data = stub_service_data();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(fed_mgr.clone()))
+                .app_data(web::Data::new(service_data))
+                .service(web::scope("/v1/federation").service(get_coop)),
+        )
+        .await;
+
+        let make_claims = || crate::auth::TokenClaims {
+            sub: "did:icn:test".to_string(),
+            iat: 1_000_000_000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["federation:read".to_string()],
+            exp: 9_999_999_999,
+        };
+
+        // Known coop → 200
+        let req = test::TestRequest::get()
+            .uri("/v1/federation/coops/governance-coop")
+            .to_request();
+        req.extensions_mut().insert(make_claims());
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status().as_u16(), 200);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["coop_id"], "governance-coop");
+
+        // Unknown coop → 404 (service returns None)
+        let req2 = test::TestRequest::get()
+            .uri("/v1/federation/coops/nonexistent-coop")
+            .to_request();
+        req2.extensions_mut().insert(make_claims());
+        let resp2 = test::call_service(&app, req2).await;
+        assert_eq!(resp2.status().as_u16(), 404);
+    }
+
+    /// Verify that get_vouches prefers FederationService over local manager.
+    #[actix_web::test]
+    async fn test_get_vouches_prefers_federation_service() {
+        use actix_web::HttpMessage;
+
+        let fed_mgr = Arc::new(FederationManager::new());
+        let service_data = stub_service_data();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(fed_mgr.clone()))
+                .app_data(web::Data::new(service_data))
+                .service(web::scope("/v1/federation").service(get_vouches)),
+        )
+        .await;
+
+        let claims = crate::auth::TokenClaims {
+            sub: "did:icn:test".to_string(),
+            iat: 1_000_000_000,
+            coop_id: "test-coop".to_string(),
+            scopes: vec!["federation:read".to_string()],
+            exp: 9_999_999_999,
+        };
+        let req = test::TestRequest::get()
+            .uri("/v1/federation/coops/any-coop/vouches")
+            .to_request();
+        req.extensions_mut().insert(claims);
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status().as_u16(), 200);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(
+            body["vouches"][0], "did:icn:voucher-gov",
+            "must come from FederationService (governance path)"
+        );
     }
 
     /// Verify that empty scopes placed AFTER named scopes don't steal routes.

--- a/icn/crates/icn-gateway/src/federation_mgr.rs
+++ b/icn/crates/icn-gateway/src/federation_mgr.rs
@@ -339,4 +339,60 @@ mod tests {
         let result = manager.list_cooperatives().await;
         assert!(result.is_err());
     }
+
+    /// Gateway API federation state must survive across restarts when using persistent storage.
+    ///
+    /// Architectural invariant (ADR 0011 / Option B): the gateway's own FederationManager
+    /// serves as the truth for API-originated federation state (agreements created via direct
+    /// API, not governance effects). This state must be durable — ephemeral temp store was the
+    /// root cause of the state-loss gap identified in the audit.
+    ///
+    /// This test proves that `new_with_storage()` gives independent manager instances access
+    /// to the same persisted cooperative registry data — simulating a restart scenario.
+    #[tokio::test]
+    async fn test_persistent_storage_survives_manager_reconstruction() {
+        let data_dir = tempfile::tempdir().expect("tempdir");
+        let path = data_dir.path().to_path_buf();
+
+        // First instance: create and initialize
+        {
+            let mgr = FederationManager::new_with_storage(path.clone())
+                .expect("new_with_storage");
+            let own_info = CooperativeInfo::new(
+                "alpha-coop".to_string(),
+                "Alpha Cooperative".to_string(),
+                test_did(),
+                FederationPolicy::default(),
+            );
+            mgr.init_registry(own_info).await.unwrap();
+            let peer = CooperativeInfo::new(
+                "beta-coop".to_string(),
+                "Beta Cooperative".to_string(),
+                test_did(),
+                FederationPolicy::default(),
+            );
+            mgr.register_cooperative(peer).await.unwrap();
+        }
+
+        // Second instance at the same path — simulates daemon restart
+        {
+            let mgr2 = FederationManager::new_with_storage(path.clone())
+                .expect("new_with_storage after restart");
+            // The registry is lazily loaded — re-init from the same store
+            let own_info = CooperativeInfo::new(
+                "alpha-coop".to_string(),
+                "Alpha Cooperative".to_string(),
+                test_did(),
+                FederationPolicy::default(),
+            );
+            mgr2.init_registry(own_info).await.unwrap();
+
+            let coops = mgr2.list_cooperatives().await.unwrap();
+            let found_beta = coops.iter().any(|c| c.coop_id == "beta-coop");
+            assert!(
+                found_beta,
+                "beta-coop registered in first instance must be visible after restart"
+            );
+        }
+    }
 }

--- a/icn/crates/icn-gateway/src/federation_mgr.rs
+++ b/icn/crates/icn-gateway/src/federation_mgr.rs
@@ -356,8 +356,7 @@ mod tests {
 
         // First instance: create and initialize
         {
-            let mgr = FederationManager::new_with_storage(path.clone())
-                .expect("new_with_storage");
+            let mgr = FederationManager::new_with_storage(path.clone()).expect("new_with_storage");
             let own_info = CooperativeInfo::new(
                 "alpha-coop".to_string(),
                 "Alpha Cooperative".to_string(),
@@ -394,5 +393,102 @@ mod tests {
                 "beta-coop registered in first instance must be visible after restart"
             );
         }
+    }
+
+    /// Gateway coop list reflects ONLY gateway-registered cooperatives — not governance state.
+    ///
+    /// Architectural invariant (ADR 0012 / Model C): the two federation origin paths are
+    /// intentionally isolated. `FederationManager::list_cooperatives()` returns only state
+    /// written via the gateway API path. Governance-registered cooperatives (written by
+    /// `FederationServiceImpl`) are invisible here — this is correct, not a bug.
+    ///
+    /// If this test starts failing because `list_cooperatives` returns cooperatives registered
+    /// through other means, the parallel model has been violated and ADR 0012 requires review.
+    #[tokio::test]
+    async fn test_gateway_coop_list_reflects_only_gateway_registered_coops() {
+        let mgr = FederationManager::new();
+
+        let own_info = CooperativeInfo::new(
+            "gateway-coop".to_string(),
+            "Gateway Cooperative".to_string(),
+            test_did(),
+            FederationPolicy::default(),
+        );
+        mgr.init_registry(own_info).await.unwrap();
+
+        // Register one peer via the gateway path
+        let gateway_peer = CooperativeInfo::new(
+            "gateway-peer".to_string(),
+            "Gateway Peer".to_string(),
+            test_did(),
+            FederationPolicy::default(),
+        );
+        mgr.register_cooperative(gateway_peer).await.unwrap();
+
+        let coops = mgr.list_cooperatives().await.unwrap();
+
+        // Exactly gateway-registered coops visible — no governance-originated coops
+        let coop_ids: Vec<&str> = coops.iter().map(|c| c.coop_id.as_str()).collect();
+        assert!(
+            coop_ids.contains(&"gateway-coop") || coop_ids.contains(&"gateway-peer"),
+            "Expected gateway-registered coops to be visible"
+        );
+        // The list should only contain what was registered via this manager instance
+        assert!(
+            coops.len() <= 2,
+            "Expected at most 2 coops (own + 1 peer); got {} — governance state may have leaked in",
+            coops.len()
+        );
+    }
+
+    /// Gateway clearing agreements are stored in a separate store from governance-originated ones.
+    ///
+    /// Architectural invariant (ADR 0012 / Model C): agreements created via `POST /federation/clearing`
+    /// live in the gateway's FederationManager store. Governance-established clearing agreements
+    /// live in the supervisor's ClearingManager. These stores are intentionally isolated.
+    ///
+    /// This test verifies that the gateway's ClearingManager only surfaces gateway-created agreements.
+    /// If it starts returning supervisor-state agreements, the parallel model has been violated.
+    #[tokio::test]
+    async fn test_gateway_clearing_list_does_not_surface_supervisor_agreements() {
+        let mgr = FederationManager::new();
+
+        let own_info = CooperativeInfo::new(
+            "alpha-coop".to_string(),
+            "Alpha Cooperative".to_string(),
+            test_did(),
+            FederationPolicy::default(),
+        );
+        mgr.init_registry(own_info).await.unwrap();
+
+        // No agreements created — list should be empty
+        let agreements = mgr.list_agreements().await.unwrap();
+        assert!(
+            agreements.is_empty(),
+            "Expected no gateway-created agreements in a fresh manager; supervisor state must not leak"
+        );
+
+        // Create one gateway-path agreement
+        let partner_did = test_did();
+        use icn_federation::{BilateralClearingAgreement, SettlementInterval};
+        let mut agr = BilateralClearingAgreement::new(
+            "agr-gw-001".to_string(),
+            "alpha-coop".to_string(),
+            test_did(),
+            "beta-coop".to_string(),
+            partner_did,
+        );
+        agr.settlement_interval = SettlementInterval::Manual;
+        let id = mgr.create_agreement(agr).await.unwrap();
+        assert_eq!(id, "agr-gw-001");
+
+        let agreements_after = mgr.list_agreements().await.unwrap();
+        assert_eq!(
+            agreements_after.len(),
+            1,
+            "Expected exactly 1 agreement (gateway-created); got {}",
+            agreements_after.len()
+        );
+        assert_eq!(agreements_after[0].agreement_id, "agr-gw-001");
     }
 }

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -93,6 +93,10 @@ pub struct GatewayServer {
     trust_service_handle: Option<Arc<dyn icn_kernel_api::services::TrustService>>,
     /// Optional LedgerService for treasury nonce queries
     ledger_service_handle: Option<Arc<dyn icn_kernel_api::services::LedgerService>>,
+    /// Optional FederationService for clearing position queries.
+    /// When provided, position queries use the supervisor-owned clearing state rather
+    /// than the gateway's own divergent ClearingManager instance.
+    federation_service_handle: Option<Arc<dyn icn_kernel_api::services::FederationService>>,
     /// Optional handle to daemon's GovernanceActor (for actor-backed mode)
     governance_handle: Option<GovernanceHandle>,
     /// Optional handle to daemon's ContractRegistryActor (for contract management)
@@ -143,6 +147,7 @@ impl GatewayServer {
             coop_handle: None,
             trust_service_handle: None,
             ledger_service_handle: None,
+            federation_service_handle: None,
             governance_handle: None,
             contract_registry_handle: None,
             treasury_handle: None,
@@ -187,6 +192,7 @@ impl GatewayServer {
             coop_handle: None,
             trust_service_handle: None,
             ledger_service_handle: None,
+            federation_service_handle: None,
             governance_handle: None,
             contract_registry_handle: None,
             treasury_handle: None,
@@ -232,6 +238,7 @@ impl GatewayServer {
             coop_handle: None,
             trust_service_handle: None,
             ledger_service_handle: None,
+            federation_service_handle: None,
             governance_handle: None,
             contract_registry_handle: None,
             treasury_handle: None,
@@ -333,6 +340,18 @@ impl GatewayServer {
         service: Arc<dyn icn_kernel_api::services::LedgerService>,
     ) -> Self {
         self.ledger_service_handle = Some(service);
+        self
+    }
+
+    /// Set federation service for clearing position queries.
+    ///
+    /// When set, the `GET /v1/federation/clearing/{id}/position` endpoint queries the
+    /// supervisor-owned clearing state rather than the gateway's own divergent instance.
+    pub fn with_federation_service(
+        mut self,
+        service: Arc<dyn icn_kernel_api::services::FederationService>,
+    ) -> Self {
+        self.federation_service_handle = Some(service);
         self
     }
 
@@ -707,6 +726,10 @@ impl GatewayServer {
             crate::service_discovery_mgr::start_expiry_task(service_discovery_manager.clone(), 300);
 
         let federation_manager = Arc::new(FederationManager::new());
+        // Wrap the optional FederationService handle so route handlers can get it from app_data.
+        let federation_service_for_routes: Arc<
+            Option<Arc<dyn icn_kernel_api::services::FederationService>>,
+        > = Arc::new(self.federation_service_handle.clone());
         let commons_manager: Arc<CommonsManager> = if let Some(handle) = self.commons_handle {
             // Canonical path: daemon injected a shared CommonsHandle.
             // CommonsManager is a thin facade over this handle — no second sled store opened.
@@ -1487,6 +1510,7 @@ impl GatewayServer {
                 .app_data(web::Data::new(trust_manager.as_oracle()))
                 .app_data(web::Data::new(compute_manager.clone()))
                 .app_data(web::Data::new(federation_manager.clone()))
+                .app_data(web::Data::new(federation_service_for_routes.clone()))
                 .app_data(web::Data::new(commons_manager.clone()))
                 .app_data(web::Data::new(entity_manager.clone()))
                 .app_data(web::Data::new(entity_audit_manager.clone()))

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -725,13 +725,32 @@ impl GatewayServer {
         let _service_expiry_handle =
             crate::service_discovery_mgr::start_expiry_task(service_discovery_manager.clone(), 300);
 
-        // FederationManager always uses a TEMPORARY sled store (standalone/testing path).
-        // In daemon mode, clearing state is populated by the compute layer's clearing callbacks
-        // (via supervisor's ClearingManager) — not by gateway API writes. API federation
-        // creation endpoints are demo/testing paths until the full agreement lifecycle is wired.
-        // All READ paths for supervisor-owned federation state (e.g. clearing positions) prefer
-        // the federation_service_for_routes below.  See ADR 0011.
-        let federation_manager = Arc::new(FederationManager::new());
+        // FederationManager: uses persistent sled storage when data_dir is available, temp
+        // store otherwise (tests / no-data-dir deployments).
+        //
+        // ARCHITECTURE NOTE (ADR 0011):
+        // This store holds federation state that originates from gateway API calls
+        // (POST /clearing, POST /coops, POST /attestations, etc.).  It is intentionally
+        // SEPARATE from the supervisor-owned FederationService stores (populated by
+        // governance effects and compute-layer clearing callbacks).
+        //
+        // Production deployments should create agreements through governance (which writes
+        // to the supervisor's ClearingManager).  Gateway API federation endpoints are the
+        // standalone / direct-management path and serve as the truth for that origin path.
+        //
+        // Read paths for supervisor-owned state (e.g. clearing positions) prefer
+        // federation_service_for_routes below; see get_position() handler.
+        let federation_manager = if let Some(ref data_dir) = self.data_dir {
+            let mgr = FederationManager::new_with_storage(data_dir.clone())?;
+            info!(
+                "FederationManager: using persistent sled store at {:?}",
+                data_dir.join("federation_store")
+            );
+            Arc::new(mgr)
+        } else {
+            info!("FederationManager: using temporary in-memory store (no data_dir)");
+            Arc::new(FederationManager::new())
+        };
         // Wrap the optional FederationService handle so route handlers can get it from app_data.
         // When Some, route handlers MUST prefer this over federation_manager for reads.
         let federation_service_for_routes: Arc<

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -725,8 +725,15 @@ impl GatewayServer {
         let _service_expiry_handle =
             crate::service_discovery_mgr::start_expiry_task(service_discovery_manager.clone(), 300);
 
+        // FederationManager always uses a TEMPORARY sled store (standalone/testing path).
+        // In daemon mode, clearing state is populated by the compute layer's clearing callbacks
+        // (via supervisor's ClearingManager) — not by gateway API writes. API federation
+        // creation endpoints are demo/testing paths until the full agreement lifecycle is wired.
+        // All READ paths for supervisor-owned federation state (e.g. clearing positions) prefer
+        // the federation_service_for_routes below.  See ADR 0011.
         let federation_manager = Arc::new(FederationManager::new());
         // Wrap the optional FederationService handle so route handlers can get it from app_data.
+        // When Some, route handlers MUST prefer this over federation_manager for reads.
         let federation_service_for_routes: Arc<
             Option<Arc<dyn icn_kernel_api::services::FederationService>>,
         > = Arc::new(self.federation_service_handle.clone());

--- a/icn/crates/icn-kernel-api/src/lib.rs
+++ b/icn/crates/icn-kernel-api/src/lib.rs
@@ -106,17 +106,17 @@ pub use receipts::{
 };
 pub use scope::{CellId, MockCellService, ScopeLevel};
 pub use services::{
-    AddMemberRequest, AddMemberResult, CellService, ControlService, FederationClearingRequest,
-    FederationClearingResult, FederationClearingSettleRequest, FederationClearingSettleResult,
-    FederationJoinRequest, FederationJoinResult, FederationService, FederationVouchRequest,
-    FederationVouchResult, ForceCloseProposalRequest, ForceCloseProposalResult,
-    FreezeMemberRequest, FreezeMemberResult, GovernanceEvent, GovernanceService, LedgerEvent,
-    LedgerService, MembershipService, RemoveMemberRequest, RemoveMemberResult, SecurityService,
-    SecurityViolation, ServiceRegistry, TreasuryEntryRequest, TreasuryEntryResult,
-    TreasuryOperationType as ServicesTreasuryOperationType, TrustClass, TrustEvent, TrustService,
-    UnfreezeMemberRequest, UnfreezeMemberResult, UpdateMemberRequest, UpdateMemberResult,
-    VetoProposalRequest, VetoProposalResult, TRUST_THRESHOLD_FEDERATED, TRUST_THRESHOLD_KNOWN,
-    TRUST_THRESHOLD_PARTNER,
+    AddMemberRequest, AddMemberResult, CellService, ClearingPositionView, ControlService,
+    FederationClearingRequest, FederationClearingResult, FederationClearingSettleRequest,
+    FederationClearingSettleResult, FederationJoinRequest, FederationJoinResult, FederationService,
+    FederationVouchRequest, FederationVouchResult, ForceCloseProposalRequest,
+    ForceCloseProposalResult, FreezeMemberRequest, FreezeMemberResult, GovernanceEvent,
+    GovernanceService, LedgerEvent, LedgerService, MembershipService, RemoveMemberRequest,
+    RemoveMemberResult, SecurityService, SecurityViolation, ServiceRegistry, TreasuryEntryRequest,
+    TreasuryEntryResult, TreasuryOperationType as ServicesTreasuryOperationType, TrustClass,
+    TrustEvent, TrustService, UnfreezeMemberRequest, UnfreezeMemberResult, UpdateMemberRequest,
+    UpdateMemberResult, VetoProposalRequest, VetoProposalResult, TRUST_THRESHOLD_FEDERATED,
+    TRUST_THRESHOLD_KNOWN, TRUST_THRESHOLD_PARTNER,
 };
 pub use state::{
     BlobService, KvService, LogService, ObjectReplication, ReplicationPolicy, StateBackend,

--- a/icn/crates/icn-kernel-api/src/lib.rs
+++ b/icn/crates/icn-kernel-api/src/lib.rs
@@ -106,8 +106,8 @@ pub use receipts::{
 };
 pub use scope::{CellId, MockCellService, ScopeLevel};
 pub use services::{
-    AddMemberRequest, AddMemberResult, CellService, ClearingPositionView, ControlService,
-    CooperativeView, FederationClearingRequest, FederationClearingResult,
+    AddMemberRequest, AddMemberResult, CellService, ClearingAgreementView, ClearingPositionView,
+    ControlService, CooperativeView, FederationClearingRequest, FederationClearingResult,
     FederationClearingSettleRequest, FederationClearingSettleResult, FederationJoinRequest,
     FederationJoinResult, FederationService, FederationVouchRequest, FederationVouchResult,
     ForceCloseProposalRequest, ForceCloseProposalResult, FreezeMemberRequest, FreezeMemberResult,

--- a/icn/crates/icn-kernel-api/src/lib.rs
+++ b/icn/crates/icn-kernel-api/src/lib.rs
@@ -107,16 +107,17 @@ pub use receipts::{
 pub use scope::{CellId, MockCellService, ScopeLevel};
 pub use services::{
     AddMemberRequest, AddMemberResult, CellService, ClearingPositionView, ControlService,
-    FederationClearingRequest, FederationClearingResult, FederationClearingSettleRequest,
-    FederationClearingSettleResult, FederationJoinRequest, FederationJoinResult, FederationService,
-    FederationVouchRequest, FederationVouchResult, ForceCloseProposalRequest,
-    ForceCloseProposalResult, FreezeMemberRequest, FreezeMemberResult, GovernanceEvent,
-    GovernanceService, LedgerEvent, LedgerService, MembershipService, RemoveMemberRequest,
-    RemoveMemberResult, SecurityService, SecurityViolation, ServiceRegistry, TreasuryEntryRequest,
-    TreasuryEntryResult, TreasuryOperationType as ServicesTreasuryOperationType, TrustClass,
-    TrustEvent, TrustService, UnfreezeMemberRequest, UnfreezeMemberResult, UpdateMemberRequest,
-    UpdateMemberResult, VetoProposalRequest, VetoProposalResult, TRUST_THRESHOLD_FEDERATED,
-    TRUST_THRESHOLD_KNOWN, TRUST_THRESHOLD_PARTNER,
+    CooperativeView, FederationClearingRequest, FederationClearingResult,
+    FederationClearingSettleRequest, FederationClearingSettleResult, FederationJoinRequest,
+    FederationJoinResult, FederationService, FederationVouchRequest, FederationVouchResult,
+    ForceCloseProposalRequest, ForceCloseProposalResult, FreezeMemberRequest, FreezeMemberResult,
+    GovernanceEvent, GovernanceService, LedgerEvent, LedgerService, MembershipService,
+    RemoveMemberRequest, RemoveMemberResult, SecurityService, SecurityViolation, ServiceRegistry,
+    TreasuryEntryRequest, TreasuryEntryResult,
+    TreasuryOperationType as ServicesTreasuryOperationType, TrustClass, TrustEvent, TrustService,
+    UnfreezeMemberRequest, UnfreezeMemberResult, UpdateMemberRequest, UpdateMemberResult,
+    VetoProposalRequest, VetoProposalResult, TRUST_THRESHOLD_FEDERATED, TRUST_THRESHOLD_KNOWN,
+    TRUST_THRESHOLD_PARTNER,
 };
 pub use state::{
     BlobService, KvService, LogService, ObjectReplication, ReplicationPolicy, StateBackend,

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -967,6 +967,20 @@ pub trait FederationService: Send + Sync {
         request: FederationClearingSettleRequest,
     ) -> Result<FederationClearingSettleResult, anyhow::Error>;
 
+    /// Query the current clearing position for a bilateral agreement.
+    ///
+    /// Returns a party-level view of the inter-entity clearing state: what
+    /// each party owes the other, the net position, and pending transfer count.
+    /// Uses party/entity vocabulary — coop-specific internals are adapted at
+    /// the service boundary and do not leak into this response.
+    ///
+    /// Returns `Err` if the agreement does not exist or the clearing manager
+    /// is not configured on this node.
+    fn get_clearing_position(
+        &self,
+        agreement_id: &str,
+    ) -> Result<ClearingPositionView, anyhow::Error>;
+
     /// Check if a cooperative is registered in the federation.
     fn is_registered(&self, coop_did: &str) -> bool;
 
@@ -974,6 +988,35 @@ pub trait FederationService: Send + Sync {
     ///
     /// Returns (decision_receipt_id, decision_hash) if available.
     fn get_registration_provenance(&self, coop_did: &str) -> Option<(String, String)>;
+}
+
+// ============================================================================
+// Clearing Position View
+// ============================================================================
+
+/// Party-level view of a bilateral inter-entity clearing position.
+///
+/// Uses `party_a`/`party_b` vocabulary to remain entity-type-agnostic.
+/// The underlying clearing internals may use cooperative-specific naming,
+/// but that is adapted at the service boundary and never appears here.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ClearingPositionView {
+    /// The agreement this position belongs to.
+    pub agreement_id: String,
+    /// Identifier of the first party (entity ID / org ID, not a DID).
+    pub party_a: String,
+    /// Identifier of the second party.
+    pub party_b: String,
+    /// Amount party_a currently owes party_b (confirmed, unsettled).
+    pub party_a_owes: i64,
+    /// Amount party_b currently owes party_a (confirmed, unsettled).
+    pub party_b_owes: i64,
+    /// Net position: positive means party_a is net debtor; negative means party_b is net debtor.
+    pub net_position: i64,
+    /// Number of transfers proposed but not yet confirmed.
+    pub pending_count: usize,
+    /// Unix timestamp of the last settlement that cleared this position.
+    pub last_settlement_ts: u64,
 }
 
 // ============================================================================

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -988,6 +988,30 @@ pub trait FederationService: Send + Sync {
     ///
     /// Returns (decision_receipt_id, decision_hash) if available.
     fn get_registration_provenance(&self, coop_did: &str) -> Option<(String, String)>;
+
+    // ── Read surface (ADR 0012 Step 1) ─────────────────────────────────────
+
+    /// List all cooperatives registered in the supervisor's federation registry.
+    ///
+    /// Returns only governance-originated state (cooperatives registered via
+    /// `join_federation` governance effects). Gateway-API-registered cooperatives
+    /// live in a separate store and are NOT included here (ADR 0012 / Model C).
+    ///
+    /// Returns an empty vec if the registry has no cooperatives yet.
+    fn list_cooperatives(&self) -> Result<Vec<CooperativeView>, anyhow::Error>;
+
+    /// Get a specific cooperative from the supervisor's federation registry.
+    ///
+    /// Returns `None` if the cooperative is not registered in the supervisor's
+    /// store. Gateway-API-registered cooperatives are not visible here.
+    fn get_cooperative(&self, coop_id: &str) -> Result<Option<CooperativeView>, anyhow::Error>;
+
+    /// Get vouches recorded for a cooperative in the supervisor's registry.
+    ///
+    /// Returns voucher DID strings from governance-originated vouch records
+    /// (`vouch_for_cooperative` effects). Does not include vouches created via
+    /// the gateway API path.
+    fn get_vouches_for(&self, coop_id: &str) -> Result<Vec<String>, anyhow::Error>;
 }
 
 // ============================================================================
@@ -1017,6 +1041,41 @@ pub struct ClearingPositionView {
     pub pending_count: usize,
     /// Unix timestamp of the last settlement that cleared this position.
     pub last_settlement_ts: u64,
+}
+
+// ============================================================================
+// Cooperative View (ADR 0012 Step 1 read DTO)
+// ============================================================================
+
+/// Kernel-API view of a registered cooperative.
+///
+/// A pruned, boundary-clean representation of a cooperative registration that
+/// does not expose federation-internal types (`FederationPolicy`, `CurrencyInfo`,
+/// `Did`, `Vouch`) across the service boundary.
+///
+/// Contains only the fields a gateway or consuming service needs for routing,
+/// display, and capability discovery. The `CooperativeInfo` storage type in
+/// `icn-federation` is richer but must not cross this boundary.
+///
+/// # Origin note
+///
+/// Values returned via `FederationService::list_cooperatives()` originate from
+/// governance execution (ADR 0012 / Model C). They represent the supervisor's
+/// canonical registry, not the gateway's direct-management state.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct CooperativeView {
+    /// Unique identifier for the cooperative.
+    pub coop_id: String,
+    /// Human-readable name.
+    pub name: String,
+    /// The cooperative's institutional DID (string form, not the icn-identity Did type).
+    pub public_did: String,
+    /// Known gateway API endpoints for this cooperative.
+    pub gateway_endpoints: Vec<String>,
+    /// Capability flags (e.g. "clearing", "attestations", "compute").
+    pub capabilities: Vec<String>,
+    /// Unix timestamp of the last observed announcement.
+    pub last_seen: u64,
 }
 
 // ============================================================================

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -1012,6 +1012,24 @@ pub trait FederationService: Send + Sync {
     /// (`vouch_for_cooperative` effects). Does not include vouches created via
     /// the gateway API path.
     fn get_vouches_for(&self, coop_id: &str) -> Result<Vec<String>, anyhow::Error>;
+
+    /// List all clearing agreements in the supervisor's clearing store.
+    ///
+    /// Returns only governance-originated agreements (created via `establish_clearing`
+    /// governance effects). Gateway-API-created agreements live in a separate store and
+    /// are NOT included (ADR 0012 / Model C).
+    ///
+    /// Returns an empty vec if the clearing manager is not configured or has no agreements.
+    fn list_agreements(&self) -> Result<Vec<ClearingAgreementView>, anyhow::Error>;
+
+    /// Get a specific clearing agreement from the supervisor's clearing store.
+    ///
+    /// Returns `None` if the agreement does not exist in the supervisor's store.
+    /// Gateway-API-created agreements are not visible here.
+    fn get_agreement(
+        &self,
+        agreement_id: &str,
+    ) -> Result<Option<ClearingAgreementView>, anyhow::Error>;
 }
 
 // ============================================================================
@@ -1076,6 +1094,47 @@ pub struct CooperativeView {
     pub capabilities: Vec<String>,
     /// Unix timestamp of the last observed announcement.
     pub last_seen: u64,
+}
+
+// ============================================================================
+// Clearing Agreement View (ADR 0012 Step 1b read DTO)
+// ============================================================================
+
+/// Kernel-API view of a bilateral clearing agreement.
+///
+/// A boundary-clean representation that does not expose `icn-federation` internal
+/// types (`Did`, `SettlementInterval`, raw signature bytes) across the service
+/// boundary. Uses string representations for enum and identity fields.
+///
+/// Fields intentionally omitted:
+/// - `signatures` — raw cryptographic material, not useful to API consumers
+///
+/// # Origin note
+///
+/// Values returned via `FederationService::list_agreements()` originate from
+/// governance execution (`establish_clearing` effects). They represent the
+/// supervisor's canonical clearing store, not the gateway's direct-management state
+/// (ADR 0012 / Model C).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ClearingAgreementView {
+    /// Unique identifier for the agreement.
+    pub agreement_id: String,
+    /// Identifier of the first cooperative.
+    pub coop_a: String,
+    /// DID of the first cooperative (string form).
+    pub coop_a_did: String,
+    /// Identifier of the second cooperative.
+    pub coop_b: String,
+    /// DID of the second cooperative (string form).
+    pub coop_b_did: String,
+    /// Settlement schedule: "daily", "weekly", "monthly", or "manual".
+    pub settlement_interval: String,
+    /// Maximum allowed imbalance before forced settlement.
+    pub max_imbalance: i64,
+    /// Unix timestamp when the agreement was created.
+    pub created_at: u64,
+    /// Exchange rates between currencies: "from:to" -> rate.
+    pub exchange_rates: std::collections::HashMap<String, f64>,
 }
 
 // ============================================================================

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -1094,6 +1094,10 @@ pub struct CooperativeView {
     pub capabilities: Vec<String>,
     /// Unix timestamp of the last observed announcement.
     pub last_seen: u64,
+    /// Origin of this record: `"governance"` (from supervisor-owned FederationService, written
+    /// by governance execution) or `"direct-management"` (from the gateway's own registry,
+    /// written via the direct-management API path). ADR 0012 / Model C.
+    pub origin: String,
 }
 
 // ============================================================================
@@ -1135,6 +1139,10 @@ pub struct ClearingAgreementView {
     pub created_at: u64,
     /// Exchange rates between currencies: "from:to" -> rate.
     pub exchange_rates: std::collections::HashMap<String, f64>,
+    /// Origin of this record: `"governance"` (from supervisor-owned FederationService, written
+    /// by governance execution) or `"direct-management"` (from the gateway's own clearing store,
+    /// written via the direct-management API path). ADR 0012 / Model C.
+    pub origin: String,
 }
 
 // ============================================================================

--- a/ops/state/decisions/0011-canonical-truth-ownership-gateway.md
+++ b/ops/state/decisions/0011-canonical-truth-ownership-gateway.md
@@ -104,24 +104,39 @@ supervisor/fallback relationship — they are parallel accounting systems. This 
 Future work should define where and how these planes are reconciled (e.g., inter-cooperative settlement
 reflecting back to member ledgers).
 
-### The Federation Manager Gap
+### The Federation Manager Write-Path Architecture
 
-`FederationManager` in the gateway **always** uses a temporary sled store (`FederationManager::new()`),
-regardless of whether a `FederationService` is present. This means:
+`FederationManager` is the gateway's own federation state layer for **API-originated** federation
+operations. It wraps `CooperativeRegistry`, `AttestationStore`, and `ClearingManager` from
+`icn-federation`, all sharing a single sled store.
 
-- **Writes through the gateway API** (agreements, vouches, attestations) are ephemeral — lost on restart.
-- **The supervisor's clearing state** is populated by compute-layer clearing callbacks, not gateway API writes.
-- `POST /clearing` → gateway's temp FederationManager → ephemeral
-- `GET /clearing/{id}/position` → supervisor's FederationService → persistent ✅ (post-fix)
+**Two origin paths for federation state (intentionally separate):**
 
-This is the intended architecture for the current phase: federation agreements originate in the compute
-layer (when tasks are executed and clearing callbacks fire), not from direct API creation. The gateway
-federation creation API endpoints are **testing/demo paths** until the full agreement lifecycle is
-implemented.
+| Origin | Path | Store | Owner |
+|--------|------|-------|-------|
+| Governance effects (CCL execution) | `establish_clearing`, `join_federation`, `vouch_for_cooperative` via `FederationServiceImpl` | `store_path/{federation,clearing,attestations,agreements}` | Supervisor |
+| Direct API (gateway endpoints) | `POST /clearing`, `POST /coops`, `POST /attestations`, etc. | `data_dir/federation_store` | Gateway |
+| Compute receipts | clearing callbacks via `AgreementManagerHandle` | `store_path/clearing` | Supervisor |
 
-`FederationManager::new_with_storage()` exists but is not called from `GatewayServer::setup()`. This is
-dead code / future intent. If federation agreement lifecycle management becomes a production concern,
-these writes should route through `FederationService`, not `FederationManager`.
+Both supervisor stores are populated at runtime; both persist across restarts. The gateway's store
+was originally ephemeral (temp sled) — **this was fixed**: `GatewayServer::setup()` now calls
+`FederationManager::new_with_storage(data_dir)` when `data_dir` is available.
+
+**The remaining separation**: the gateway's FederationManager and the supervisor's FederationService
+are separate stores. They share domain types but not state. A clearing agreement created via
+`POST /clearing` lives only in the gateway's store; `GET /clearing/{id}/position` reads from the
+supervisor's service (ADR 0011), and will return 404 for gateway-API-created agreements when
+the daemon is connected.
+
+This is acceptable for the current phase: production clearing agreements should originate from
+governance execution (which writes to the supervisor's stores). The gateway direct-write API is
+the standalone / direct-management path. Users calling `POST /clearing` in daemon mode should
+be aware this creates an agreement that the supervisor's scheduler does not manage.
+
+**Future unification path** (not yet implemented): The FederationService trait would need to grow
+`get_agreement(id)`, `list_agreements()`, `list_coops()`, `get_vouches()` read methods before write
+unification can make the gateway API into a full proxy for the supervisor's state. Alternatively,
+the gateway could gossip-sync its store with the supervisor's store at startup.
 
 ## Consequences
 
@@ -139,7 +154,8 @@ these writes should route through `FederationService`, not `FederationManager`.
 
 4. **The two-ledger architecture is intentional** and not a bug. Document it; do not conflate the planes.
 
-5. **`FederationManager::new_with_storage()`** should either be wired or removed. It is currently dead code.
+5. **`FederationManager::new_with_storage()`** is now wired in `GatewayServer::setup()`. Gateway API
+   federation state persists across restarts when `data_dir` is provided.
 
 ### Future Signals
 
@@ -152,8 +168,9 @@ If a future PR adds a supervisor service for a domain that the gateway previousl
 
 - PR #1474: `feat(federation): settlement execution + correctness fixes`
 - PR #1476: `feat(compute): receipt pipe to clearing (federated task accounting)`
-- PR #1477: `feat(federation): expose clearing position via service-owned state at gateway layer`
+- PR #1477: `feat(federation): expose clearing position via service-owned state at gateway layer` (also contains ADR + persistence fix)
 - `crates/icn-gateway/src/server.rs` — GatewayServer setup, all manager initialization
+- `crates/icn-gateway/src/federation_mgr.rs` — FederationManager (gateway's federation state layer)
 - `crates/icn-core/src/supervisor/actors.rs` — GatewayActorHandles (add new fields here)
 - `crates/icn-core/src/supervisor/init_gateway.rs` — GatewayHandles (mirrors GatewayActorHandles)
 - `crates/icn-core/src/supervisor/lifecycle.rs` — wiring logic for all supervisor→gateway bridges

--- a/ops/state/decisions/0011-canonical-truth-ownership-gateway.md
+++ b/ops/state/decisions/0011-canonical-truth-ownership-gateway.md
@@ -1,0 +1,159 @@
+---
+id: "0011"
+title: "Canonical Truth Ownership — Gateway vs Supervisor"
+status: "accepted"
+date: "2026-03-31"
+context: "federation-clearing-position-api / PR #1477"
+deciders: ["Matt Faherty"]
+tags: ["gateway", "architecture", "federation", "clearing", "truth-ownership"]
+---
+
+# ADR 0011: Canonical Truth Ownership — Gateway vs. Supervisor
+
+## Status
+
+Accepted (2026-03-31)
+
+## Context
+
+During work on the federation clearing settlement feature (PRs #1474, #1476), a category-level architectural
+bug was discovered and fixed: `GET /v1/federation/clearing/{id}/position` was reading clearing state from
+the gateway's own `FederationManager` (backed by a temporary sled store) rather than the supervisor-owned
+`FederationService` (backed by a persistent sled at `store_path/clearing`).
+
+This was not merely a "wrong file path" bug. It was an instance of a broader failure mode: **the gateway
+presenting state from a parallel, divergent store as if it were the authoritative answer**. In ICN, where
+every output of the API represents the system's institutional reality, returning divergent state is a
+legitimacy failure — not a minor inconsistency.
+
+After fixing the specific bug (PR #1477), an architectural audit was conducted to determine whether similar
+patterns existed elsewhere in the gateway.
+
+## Decision
+
+### The Invariant
+
+> **No gateway-local authoritative state for supervisor-owned domains.**
+
+In daemon mode, every mutable domain has exactly one canonical owner of truth:
+- The supervisor (via `spawn_actors_with_identity`) creates and owns the authoritative service instances.
+- The gateway is a read/write interface that **routes through** those service instances.
+- Gateway-local managers are **compatibility/standalone fallback paths only**, not normative architecture.
+
+### Canonical Truth Chain
+
+For each supervisor-owned domain, the correct wiring chain is:
+
+```
+supervisor::spawn_actors_with_identity()
+    → sets gateway_handles.<domain> = Some(service.clone())
+    → lifecycle.rs builds init_gateway::GatewayHandles { <domain>: gateway_handles.<domain> }
+    → init_gateway::spawn_gateway() wires it into GatewayServer via with_<domain>()
+    → GatewayServer::setup() injects it as app_data
+    → route handler prefers it, falls back to local manager only when absent
+```
+
+This is the same pattern used for `LedgerService`, `TrustService`, `CommonsHandle`, `GovernanceHandle`,
+`NamingService`, `TreasuryHandle`, `EntityHandle`, and (as of PR #1477) `FederationService`.
+
+### Fallback / Standalone Mode
+
+Gateway-local managers (CommonsManager, TrustManager, GovernanceManager, etc.) serve two roles:
+1. **Testing**: unit tests create GatewayServer without supervisor-provided services.
+2. **Standalone operation**: icn-gateway running without icnd (rare, intentional edge case).
+
+These are **degraded modes**. They must be:
+- Clearly logged with `info!("... running standalone (in-memory only)")` or similar.
+- Never silently mixed into production daemon deployments.
+- Documented in the server setup code at the initialization point.
+
+## Audit Results (2026-03-31)
+
+### Domain Map
+
+| Domain | Canonical Owner | Gateway Local Manager | Fallback Store | Risk | Status |
+|--------|----------------|----------------------|----------------|------|--------|
+| Federation clearing | `FederationServiceImpl` (sled at `store_path/clearing`) | `FederationManager` (TEMP store) | ephemeral | MEDIUM | **FIXED for reads** (PR #1477) |
+| Commons | `CommonsHandle` (sled at `data_dir/commons.sled`) | `CommonsManager` (sled fallback) | `data_dir/commons.sled` | LOW | ✅ Handle always wired in daemon |
+| Trust | `TrustService` (in-memory, gossip-synced) | `TrustManager` (in-memory) | in-memory | LOW | ✅ TrustManager delegates to TrustService when present |
+| Governance | `GovernanceActor` (sled) | `GovernanceManager` (sled fallback) | `data_dir/gateway_store` | LOW | ✅ Handle always wired in daemon |
+| Ledger (treasury) | `LedgerService` (daemon's sled) | `LedgerManager` (own sled) | `data_dir/ledgers/<coop>/` | NOTE | See two-plane note below |
+| Naming | `NamingService` (sled) | `LocalNamingService` (sled fallback) | `data_dir/store/naming` | LOW | ✅ Service always wired in daemon |
+| Treasury | `TreasuryHandle` (via ledger) | `GatewayTreasuryManager` (in-memory) | in-memory | LOW | ✅ Handle wired in daemon |
+| Entity | `EntityHandle` (via icn-entity) | `EntityManager` (in-memory) | in-memory | LOW | ✅ Handle wired in daemon |
+| Service discovery | gossip-wired instance | local in-memory | in-memory | NONE | ✅ Gossip-wired always preferred |
+
+### The Two-Ledger Architecture (intentional)
+
+ICN operates two separate accounting planes:
+
+**Member-level ledger** (`LedgerManager`, gateway-owned):
+- Manages per-cooperative member-to-member mutual credit (direct transfers, balances).
+- Populated by API calls: `POST /ledger/transfer`, `POST /ledger/settle`.
+- Persisted at `data_dir/ledgers/<coop_id>/`.
+- This IS the source of truth for member balances — it is not a shadow of the daemon's ledger.
+
+**Treasury/kernel ledger** (`LedgerService`, supervisor-owned):
+- Manages commons-credit settlement, governance-triggered transfers, clearing settlement entries.
+- Populated by governance effects and clearing settlement callbacks.
+- Persisted at the daemon's store path.
+- Gateway uses this for treasury nonce queries and clearing settlement verification.
+
+These planes serve different stakeholders and are intentionally separate. They are **not** in a
+supervisor/fallback relationship — they are parallel accounting systems. This is the intended design.
+Future work should define where and how these planes are reconciled (e.g., inter-cooperative settlement
+reflecting back to member ledgers).
+
+### The Federation Manager Gap
+
+`FederationManager` in the gateway **always** uses a temporary sled store (`FederationManager::new()`),
+regardless of whether a `FederationService` is present. This means:
+
+- **Writes through the gateway API** (agreements, vouches, attestations) are ephemeral — lost on restart.
+- **The supervisor's clearing state** is populated by compute-layer clearing callbacks, not gateway API writes.
+- `POST /clearing` → gateway's temp FederationManager → ephemeral
+- `GET /clearing/{id}/position` → supervisor's FederationService → persistent ✅ (post-fix)
+
+This is the intended architecture for the current phase: federation agreements originate in the compute
+layer (when tasks are executed and clearing callbacks fire), not from direct API creation. The gateway
+federation creation API endpoints are **testing/demo paths** until the full agreement lifecycle is
+implemented.
+
+`FederationManager::new_with_storage()` exists but is not called from `GatewayServer::setup()`. This is
+dead code / future intent. If federation agreement lifecycle management becomes a production concern,
+these writes should route through `FederationService`, not `FederationManager`.
+
+## Consequences
+
+### Rules Enforced
+
+1. **New supervisor-owned domains** must follow the full wiring chain:
+   `GatewayActorHandles` field → `init_gateway::GatewayHandles` field → `GatewayServer` builder method →
+   `app_data` injection → route handler prefers service, falls back to local manager.
+
+2. **Fallback/standalone mode must be logged** with explicit `warn!` or `info!` noting it is degraded.
+
+3. **Read endpoints for supervisor-owned domains must prefer the service** over local managers.
+   Write endpoints for domains currently served by gateway-local managers are acceptable standalone
+   behavior but must be clearly documented as such.
+
+4. **The two-ledger architecture is intentional** and not a bug. Document it; do not conflate the planes.
+
+5. **`FederationManager::new_with_storage()`** should either be wired or removed. It is currently dead code.
+
+### Future Signals
+
+If a future PR adds a supervisor service for a domain that the gateway previously managed locally:
+1. Check: is the service threaded through GatewayActorHandles? If not, it will be ignored.
+2. Check: does the route handler prefer the service? If not, reads will still use the local manager.
+3. Check: are writes also routed through the service? If not, the "fixed" read path will see stale state.
+
+## References
+
+- PR #1474: `feat(federation): settlement execution + correctness fixes`
+- PR #1476: `feat(compute): receipt pipe to clearing (federated task accounting)`
+- PR #1477: `feat(federation): expose clearing position via service-owned state at gateway layer`
+- `crates/icn-gateway/src/server.rs` — GatewayServer setup, all manager initialization
+- `crates/icn-core/src/supervisor/actors.rs` — GatewayActorHandles (add new fields here)
+- `crates/icn-core/src/supervisor/init_gateway.rs` — GatewayHandles (mirrors GatewayActorHandles)
+- `crates/icn-core/src/supervisor/lifecycle.rs` — wiring logic for all supervisor→gateway bridges

--- a/ops/state/decisions/0012-federation-state-origin-model.md
+++ b/ops/state/decisions/0012-federation-state-origin-model.md
@@ -1,0 +1,377 @@
+---
+id: "0012"
+title: "Federation State Origin Model — Gateway vs Governance vs Compute"
+status: "accepted"
+date: "2026-03-31"
+context: "federation-clearing-position-api / post-ADR-0011 architecture pass"
+deciders: ["Matt Faherty"]
+tags: ["gateway", "architecture", "federation", "clearing", "state-origins", "parallel-model"]
+---
+
+# ADR 0012: Federation State Origin Model
+
+## Status
+
+Accepted (2026-03-31)
+
+## Context
+
+ADR 0011 established the canonical truth invariant: no gateway-local state for supervisor-owned
+domains. It identified that federation clearing position reads must go through the supervisor's
+`FederationService`. It left open the question: **how do the gateway API write paths, governance
+execution write paths, and compute receipt paths relate — and what is the correct long-term model?**
+
+This ADR answers that question by tracing every federation write path from code, performing a
+per-concept convergence analysis, and defining the minimal correct architecture for the current
+phase with a precise roadmap for unification.
+
+---
+
+## Phase 1: Federation State Origin Map
+
+### Gateway-Originated State
+
+**Owner**: `FederationManager` (gateway-local)
+**Store**: `data_dir/federation_store` (persistent sled, per ADR 0011 fix)
+**Provenance**: None — no `decision_receipt_id`, no `decision_hash`, no settlement attribution
+**Guarantees**: Durable across gateway restarts, isolated from supervisor state
+
+| Endpoint | Object Created | Store Key |
+|----------|---------------|-----------|
+| `POST /federation/init` | Own `CooperativeInfo` | `CooperativeRegistry` |
+| `POST /federation/coops` | Peer `CooperativeInfo` | `CooperativeRegistry` |
+| `POST /federation/connect` | Peer `CooperativeInfo` | `CooperativeRegistry` |
+| `POST /federation/coops/{id}/vouch` | `Vouch` | `CooperativeRegistry` |
+| `POST /federation/attestations` | `FederatedTrustAttestation` | `AttestationStore` |
+| `POST /federation/clearing` | `BilateralClearingAgreement` | `ClearingManager` |
+| `POST /federation/clearing/{id}/settle` | Settlement (gateway's ClearingManager) | `ClearingManager` |
+| `POST /federation/clearing/settle-scheduled` | Multiple settlements | `ClearingManager` |
+| `POST /federation/clearing/netting/{unit}/apply` | Position adjustments | `ClearingManager` |
+
+**Visibility through gateway reads**:
+- `GET /federation/coops*` → reads from `FederationManager` — shows only gateway-API-registered coops
+- `GET /federation/clearing*` → reads from `FederationManager` — shows only gateway-API-created agreements
+- `GET /federation/clearing/{id}/position` → reads from `FederationService` (ADR 0011) — shows supervisor state
+
+### Supervisor/Governance-Originated State
+
+**Owner**: `FederationServiceImpl` (supervisor-owned)
+**Store**: `store_path/{federation,clearing}` (persistent sled, supervisor-controlled)
+**Provenance**: Full — carries `decision_receipt_id`, `decision_hash`, `state_change_hash` on every operation
+**Guarantees**: Durable, audit-attributed, settlement-linked, governance-ratified
+
+| Origin | Kernel Effect | Object Created | Store Path |
+|--------|--------------|----------------|-----------|
+| CCL governance → kernel executor | `FederationEffect::JoinFederation` | `CooperativeInfo` with provenance | `store_path/federation` |
+| CCL governance → kernel executor | `FederationEffect::LeaveFederation` | Departure record | `store_path/federation` |
+| CCL governance → kernel executor | `FederationEffect::VouchForCoop` | `Vouch` with provenance | `store_path/federation` |
+| CCL governance → kernel executor | `FederationEffect::EstablishClearing` | `BilateralClearingAgreement` with provenance | `store_path/clearing` |
+| CCL governance → kernel executor | `FederationEffect::SettleClearing` | Settlement + ledger entry | `store_path/clearing` |
+
+**Execution chain**:
+```
+CCL contract execution
+  → KernelEffect::Federation(FederationEffect)
+  → federation_effect_to_operation()
+  → KernelFederationExecutor::execute_federation_operation()
+  → FederationService::join_federation / vouch_for_cooperative / establish_clearing / settle_clearing
+  → FederationServiceImpl (adapter)
+  → CooperativeRegistry / ClearingManager at store_path/{federation,clearing}
+```
+
+### Compute-Originated Clearing State
+
+**Owner**: `ReceiptClearingManager` (supervisor-owned, fed by compute actor)
+**Store**: `store_path/clearing` (same physical store as governance-originated clearing)
+**Provenance**: Attestation hash from compute receipt
+**Guarantees**: Durable, per-task attributed, flushed periodically
+
+```
+Compute task completion (cross-coop)
+  → ComputeActor emits clearing receipt
+  → receipt_clearing_handle queue
+  → periodic flush task (spawn_clearing_receipt_flush_task)
+  → ReceiptClearingManager::flush_to_clearing()
+  → ClearingManager::record_transfer() at store_path/clearing
+```
+
+**Note**: Compute receipts and governance-established agreements share the **same** `ClearingManager` instance at `store_path/clearing`. A compute receipt for agreement `X` accumulates into the same position that governance's `get_clearing_position("X")` reads. This is the intended design.
+
+### Agreements API (Separate Plane)
+
+`/v1/agreements/...` via `AgreementManagerHandle` manages inter-cooperative agreements with full
+lifecycle (draft, propose, sign, suspend, resume, terminate). These are **not** bilateral clearing
+agreements — they are structured documents (Trade, Credit, ResourceSharing, FederationMembership,
+Custom). They do not overlap with `/federation/clearing`. Omitted from convergence analysis below.
+
+---
+
+## Phase 2: Per-Concept Convergence Analysis
+
+### Cooperative Registry (coops, vouches)
+
+| Attribute | Gateway Path | Governance Path |
+|-----------|-------------|-----------------|
+| Type | `CooperativeInfo`, `Vouch` | `CooperativeInfo`, `Vouch` (same types) |
+| Store | `data_dir/federation_store` | `store_path/federation` |
+| Provenance | None | `decision_receipt_id`, `decision_hash` |
+| Read API | `GET /federation/coops` | Not exposed via gateway |
+| Relationship | **Transitional** | **Canonical** |
+
+**Gap**: Governance-registered cooperatives are invisible to `GET /federation/coops`. The read API
+only queries the gateway's `FederationManager`. This is not a correctness bug — it is a read-plane
+gap that will require `FederationService` read method expansion to close.
+
+**Verdict**: **Parallel** for now. Gateway path is direct-management / exploratory / standalone
+tooling. Governance path is institutional / ratified. Neither replaces the other in the current
+phase.
+
+### Attestations
+
+| Attribute | Gateway Path | Governance Path |
+|-----------|-------------|-----------------|
+| Type | `FederatedTrustAttestation` | No governance effect path |
+| Store | `data_dir/federation_store` | N/A |
+| Provenance | None | N/A |
+
+**Verdict**: **Standalone** — gateway is the only write path. No convergence needed.
+
+### Bilateral Clearing Agreements
+
+| Attribute | Gateway Path | Governance Path |
+|-----------|-------------|-----------------|
+| Type | `BilateralClearingAgreement` | `BilateralClearingAgreement` (same type) |
+| Store | `data_dir/federation_store` | `store_path/clearing` |
+| Provenance | None | `decision_receipt_id`, `decision_hash` |
+| Position query | 404 in daemon mode (ADR 0011) | ✅ via `FederationService::get_clearing_position` |
+| Read list | `GET /federation/clearing` (gateway-only) | Not exposed |
+| Relationship | **Transitional** | **Canonical** |
+
+**Gap (documented, acceptable)**: A clearing agreement created via `POST /federation/clearing` in
+daemon mode will return 404 from `GET /federation/clearing/{id}/position` because position reads
+go through the supervisor's service (ADR 0011) which only knows about governance-established
+agreements. This is documented and expected: direct-API agreements are for standalone operation.
+
+**Verdict**: **Parallel** for now. Same analysis as cooperative registry.
+
+### Clearing Positions
+
+| Attribute | Value |
+|-----------|-------|
+| Write sources | Governance (`SettleClearing`) + Compute (receipt flush) |
+| Store | `store_path/clearing` — single ClearingManager instance |
+| Read path | `FederationService::get_clearing_position` (supervisor) |
+| Gateway fallback | `FederationManager::get_position` (standalone only) |
+
+**Verdict**: **Already correctly unified** under the supervisor's store. Governance and compute
+both write to the same `ClearingManager`. ADR 0011 fixed the read path. No further action needed.
+
+### Settlement
+
+| Attribute | Gateway Path | Governance Path |
+|-----------|-------------|-----------------|
+| Endpoint | `POST /clearing/{id}/settle` | `FederationEffect::SettleClearing` |
+| Target store | `FederationManager`'s ClearingManager | `FederationServiceImpl`'s ClearingManager |
+| Can settle | Only gateway-API-created agreements | Only governance-established agreements |
+
+**Gap**: Each settlement path can only settle agreements it owns. Gateway settlement of a
+governance-established agreement will return "not found"; governance settlement of a gateway-API
+agreement is not possible (no governance path to the gateway's store).
+
+**Verdict**: **Parallel** — acceptable given the transitional status of the two paths.
+
+### Netting
+
+| Attribute | Gateway Path | Governance Path |
+|-----------|-------------|-----------------|
+| Endpoint | `POST /clearing/netting/{unit}` and `/apply` | No governance netting path |
+| Scope | Gateway's ClearingManager only | N/A |
+
+**Verdict**: **Standalone** — netting only operates on gateway-API-created positions. No convergence needed or possible in current phase.
+
+---
+
+## Phase 3: Chosen Model
+
+### Decision: **Model C (Explicit Parallel) with Targeted Promotion Path Design**
+
+The two paths serve different institutional roles:
+
+| Dimension | Gateway API Path | Governance Path |
+|-----------|----------------|-----------------|
+| Use case | Direct management, admin tooling, standalone ops, test setup | Democratic ratification, institutional decisions |
+| Actor | API caller (admin) | Governance body (votes) |
+| Provenance | None | Full audit trail (decision_receipt_id, decision_hash) |
+| Guarantees | Durable state, isolated | Durable, attributed, verifiable |
+| Appropriate for | Exploratory federation, direct bilateral agreements, standalone nodes | Production institutional federation, cross-coop credit, compliance-visible settlement |
+
+**Why not Option B (Submission/Proxy)**:
+- Gateway writes like `POST /federation/clearing` would need to create a governance proposal, wait for a vote, and return the agreement ID from governance execution
+- This breaks the direct management use case entirely (no sync response possible)
+- Governance quorum is inappropriate overhead for local administrative operations
+
+**Why not Option A (Promotion)**:
+- Gateway-created objects can't be "proposed to governance" without a CCL contract that accepts `BilateralClearingAgreement` as a proposal payload — this infrastructure doesn't exist
+- Even if it did, the promotion flow is async and requires governance participation from both parties
+
+**Why not Option D (Hybrid unification of clearing)**:
+- The `FederationService` trait currently has no read methods beyond `get_clearing_position`
+- Unifying read paths requires adding `list_agreements`, `list_coops`, `get_vouches` to the trait
+- This is non-trivial and out of scope for the current phase
+
+### Model C Rules (Explicit Parallel)
+
+1. **Gateway API path = direct management / standalone tooling**. Objects created here are valid for
+   standalone and direct-bilateral use. They are NOT institutional state.
+
+2. **Governance path = canonical institutional state**. Production clearing agreements, cross-coop
+   credit, and federation membership records that are compliance-visible MUST originate from
+   governance execution.
+
+3. **No silent mixing**. The API contract must be clear which path a caller is on. Currently:
+   - `POST /federation/clearing` → direct-management (no provenance)
+   - CCL governance execution → institutional (full provenance)
+   These are not interchangeable.
+
+4. **Read APIs reflect their write path**. `GET /federation/coops` returns gateway-local state.
+   This is correct behavior, not a bug. The limitation must be documented.
+
+5. **Position reads are already unified** (ADR 0011). This is the one crossing point.
+
+---
+
+## Phase 4: Precise Design Artifact — What Full Unification Requires
+
+Full unification is **not yet implementable** without the following components:
+
+### Prerequisite A: FederationService Read API Expansion
+
+`FederationService` (icn-kernel-api) currently exposes only:
+- `join_federation`, `vouch_for_cooperative`, `establish_clearing`, `settle_clearing` (writes)
+- `get_clearing_position` (one read, added in ADR 0011)
+- `is_registered`, `get_registration_provenance` (existence checks)
+
+To unify read paths, the following methods are required:
+```rust
+fn list_cooperatives(&self) -> Result<Vec<CooperativeInfo>>;
+fn get_cooperative(&self, coop_id: &str) -> Result<Option<CooperativeInfo>>;
+fn list_agreements(&self) -> Result<Vec<BilateralClearingAgreement>>;
+fn get_agreement(&self, agreement_id: &str) -> Result<Option<BilateralClearingAgreement>>;
+fn get_vouches(&self, coop_id: &str) -> Result<Vec<String>>;
+```
+
+Once these exist, the gateway route handlers can be updated to prefer the service (same pattern
+as `get_clearing_position` in ADR 0011).
+
+**Blocking issue**: `BilateralClearingAgreement` is in `icn-federation` (not `icn-kernel-api`).
+The trait would need to either re-export this type from kernel-api or introduce a
+`ClearingAgreementView` DTO similar to `ClearingPositionView`.
+
+### Prerequisite B: Origin Labeling
+
+Before mixed-origin reads can be served from the gateway without confusion, objects need an
+origin tag:
+```rust
+pub enum FederationStateOrigin {
+    DirectManagement,           // gateway API, no provenance
+    GovernanceRatified {        // governance execution, full provenance
+        decision_receipt_id: String,
+        decision_hash: String,
+    },
+    ComputeReceipt {            // compute task attribution
+        attestation_hash: String,
+    },
+}
+```
+
+This allows the API to return both governance-ratified and direct-management coops/agreements
+in a single list with clear provenance markers.
+
+### Prerequisite C: Promotion Path (Optional, Long-Term)
+
+If gateway-created objects should be promotable to governance-ratified state:
+1. A CCL contract type for "adopt_direct_agreement" would accept a `BilateralClearingAgreement`
+   payload and, on approval, execute `FederationEffect::EstablishClearing` with the same terms
+2. The governance execution path would write to the supervisor's store with full provenance
+3. The direct-management record would be superseded by the governance-ratified record
+
+This is a long-term path, not a current requirement.
+
+### Sequencing Plan
+
+| Step | Prerequisite | Risk | Scope |
+|------|-------------|------|-------|
+| 1. Add `FederationService` read methods | None | Low | `icn-kernel-api` + `icn-core` |
+| 2. Add `ClearingAgreementView` DTO | Step 1 | Low | `icn-kernel-api` |
+| 3. Update gateway route handlers to prefer service for list/get | Step 1+2 | Low | `icn-gateway` |
+| 4. Add origin labeling to DTOs | Step 1-3 | Medium | Cross-crate |
+| 5. Implement CCL adoption contract | Steps 1-4 + CCL work | High | `icn-ccl`, `icn-governance` |
+
+Steps 1-3 are the read unification path (no semantic risk, no write path changes).
+Steps 4-5 are the full lifecycle unification (future work).
+
+---
+
+## Phase 5: Tests and Documentation
+
+### Invariant Tests
+
+The following invariants are already tested or should be added:
+
+**Existing** (from ADR 0011 work):
+- `test_get_position_prefers_federation_service_over_local_manager` — proves ADR 0011 read
+  preference is enforced for position queries
+- `test_persistent_storage_survives_manager_reconstruction` — proves gateway-API state is durable
+
+**Required** (not yet added):
+- **`test_gateway_clearing_and_governance_clearing_do_not_share_positions`**: create an agreement
+  via gateway API path, create a different agreement via `FederationServiceImpl::establish_clearing`,
+  assert `get_clearing_position` returns the governance-path agreement and 404s on the gateway-path
+  agreement — proving the stores are isolated as intended.
+- **`test_gateway_coop_list_reflects_only_gateway_registered_coops`**: register a coop via
+  `FederationManager`, register a different coop via `FederationServiceImpl::join_federation`,
+  assert `list_cooperatives` on `FederationManager` returns only the first — proving read API
+  accurately reflects its write path, not governance state.
+
+### Documentation Updates
+
+This ADR serves as the design artifact. Gateway API documentation should note:
+- "Objects created via direct management APIs are for standalone and direct-bilateral use. Production
+  institutional federation should originate from CCL governance execution."
+- `GET /federation/coops` and related list endpoints return only direct-management state, not
+  governance-ratified state.
+- `GET /federation/clearing/{id}/position` returns supervisor-owned state (governance + compute)
+  and will 404 for agreements created via direct management API in daemon mode.
+
+---
+
+## Consequences
+
+### What This ADR Locks In
+
+1. **Model C is the current architecture**: two parallel paths, intentionally separate.
+2. **Gateway read APIs reflect their write path** — this is correct behavior, documented as such.
+3. **No state copying** between paths — divergence is the intended design.
+4. **Read unification requires FederationService expansion** — do not attempt partial unification
+   before Steps 1-3 above are complete.
+5. **Position reads (ADR 0011) are the only crossing point** — do not add more crossing points
+   without following the full wiring chain from ADR 0011.
+
+### What This ADR Leaves Open
+
+1. FederationService read method expansion (Step 1-3 above) — future PR, low risk.
+2. Origin labeling for mixed-origin reads (Step 4) — future design.
+3. CCL adoption contract for promotion path (Step 5) — future work, high complexity.
+
+---
+
+## References
+
+- ADR 0011: Canonical Truth Ownership — Gateway vs Supervisor
+- `crates/icn-kernel-api/src/services.rs` — FederationService trait (current + needed methods)
+- `crates/icn-kernel-api/src/effects.rs` — FederationEffect enum (5 governance effect variants)
+- `crates/icn-core/src/supervisor/governance_executor.rs` — KernelFederationExecutor, effect→operation bridge
+- `crates/icn-core/src/services/federation_service.rs` — FederationServiceImpl adapter
+- `crates/icn-core/src/supervisor/init_federation.rs` — ReceiptClearingManager setup
+- `crates/icn-gateway/src/api/federation.rs` — All gateway write endpoints
+- `crates/icn-gateway/src/federation_mgr.rs` — FederationManager (gateway's state layer)

--- a/ops/state/decisions/0012-federation-state-origin-model.md
+++ b/ops/state/decisions/0012-federation-state-origin-model.md
@@ -266,6 +266,7 @@ pub struct CooperativeView {
     pub gateway_endpoints: Vec<String>,
     pub capabilities: Vec<String>,
     pub last_seen: u64,
+    pub origin: String,        // "governance" | "direct-management" (added Step 2)
 }
 ```
 
@@ -344,10 +345,10 @@ This is a long-term path, not a current requirement.
 |------|-------------|------|-------|--------|
 | 1a. `list/get_cooperative`, `get_vouches_for`, `CooperativeView` DTO | None | Low | `icn-kernel-api` + `icn-core` + `icn-gateway` | ✅ Done (2026-03-31) |
 | 1b. `list/get_agreement`, `ClearingAgreementView` DTO | None | Low | `icn-kernel-api` + `icn-core` + `icn-gateway` | ✅ Done (2026-04-01) |
-| 2. Add origin labeling to response DTOs | Steps 1a+1b | Medium | Cross-crate | ⏳ Future |
+| 2. Add origin labeling to response DTOs | Steps 1a+1b | Medium | Cross-crate | ✅ Done (2026-04-01) |
 | 3. Implement CCL adoption contract | Step 2 + CCL work | High | `icn-ccl`, `icn-governance` | ⏳ Future |
 
-Step 2 is the origin labeling pass — adds `origin: "governance" | "direct-management"` to responses. This is optional/future; the handler comments + ADR documentation serve this purpose for now.
+Step 2 is the origin labeling pass — adds `origin: "governance" | "direct-management"` to view DTOs and gateway fallback paths. See Phase 4d below.
 
 Step 3 is full lifecycle unification (future work).
 
@@ -377,6 +378,7 @@ pub struct ClearingAgreementView {
     pub max_imbalance: i64,
     pub created_at: u64,
     pub exchange_rates: std::collections::HashMap<String, f64>,
+    pub origin: String,       // "governance" | "direct-management" (added Step 2)
 }
 ```
 
@@ -397,6 +399,85 @@ In standalone mode (no service injected), both fall back to `FederationManager`.
 - `test_list_agreements_prefers_federation_service` — proves service path taken over mgr, correct shape
 - `test_get_agreement_prefers_federation_service` — proves get + 404 behavior
 - `test_list_agreements_falls_back_to_fed_mgr_when_no_service` — proves fallback path fires
+
+---
+
+## Phase 4d: Origin Labeling — Step 2 Implementation (2026-04-01)
+
+### Why origin labeling was needed after Step 1a/1b
+
+After Steps 1a and 1b, the 5 federation GET endpoints all have two possible code paths:
+- **Service path** — reads from the supervisor's store (governance-originated state)
+- **Fallback path** — reads from `FederationManager` (direct-management state)
+
+Before this step:
+1. The `origin` was entirely implicit — clients had no in-band signal indicating which path was taken
+2. The fallback paths serialized raw `icn-federation` domain types (`CooperativeInfo`,
+   `BilateralClearingAgreement`) with different JSON shapes than the service-path view DTOs —
+   creating an undocumented shape inconsistency between daemon mode and standalone mode
+
+### Labeling model chosen: Option A (add `origin` field to view DTOs)
+
+Considered:
+- **Option B (envelope `{ origin, data }`)**: body-breaking change, requires unwrap by clients
+- **Option C (response header)**: silently ignorable, not reflected in OpenAPI
+- **Option A (field on DTOs)**: consistent with existing DTO pattern, visible in body, type-safe
+
+Chose Option A. The `origin` field is a stable string at the `CooperativeView` and
+`ClearingAgreementView` boundaries. It is not a full provenance record — that requires
+`decision_receipt_id` / `decision_hash`, which belong in a future promotion-path design.
+
+### DTOs changed
+
+`CooperativeView` in `icn-kernel-api`:
+- Added `pub origin: String` — `"governance"` or `"direct-management"`
+
+`ClearingAgreementView` in `icn-kernel-api`:
+- Added `pub origin: String` — `"governance"` or `"direct-management"`
+
+`GET /federation/coops/{id}/vouches` response (raw JSON object):
+- Added `"origin"` key directly — not a typed DTO
+
+### Handler changes
+
+**Service path** (daemon mode): `origin = "governance"` — set in `FederationServiceImpl` mappers
+in `icn-core`
+
+**Fallback path** (standalone mode): `origin = "direct-management"` — set in gateway handler
+adapters. **Important**: the fallback paths now also adapt the raw `icn-federation` types
+(`CooperativeInfo`, `BilateralClearingAgreement`) to the view DTOs. This:
+- Unifies the response shape regardless of which path was taken
+- Eliminates the hidden shape inconsistency between daemon and standalone mode
+- Ensures `signatures`, `FederationPolicy`, `CurrencyInfo` fields never reach API consumers
+
+`ClearingPositionView` was NOT labeled — this endpoint only has one meaningful path
+(`FederationService`) and the fallback already builds the same DTO from gateway state.
+The handler comments explain the distinction.
+
+### Tests added (5 new)
+
+- `test_list_coops_origin_governance_when_service_present`
+- `test_get_coop_origin_governance_when_service_present`
+- `test_get_vouches_origin_governance_when_service_present`
+- `test_list_agreements_origin_governance_when_service_present`
+- `test_get_agreement_origin_governance_when_service_present`
+
+Each asserts `body["origin"] == "governance"` when the stub service is injected.
+Fallback path (direct-management) origin is covered implicitly by the existing fallback tests
+(`test_list_coops_falls_back_to_fed_mgr_when_no_service`, etc.) which now produce labeled
+`ClearingAgreementView` / `CooperativeView` responses.
+
+### What the next slice should be
+
+Step 3 (CCL adoption contract) is the next major item in the sequencing table. It is high
+complexity and requires `icn-ccl` / `icn-governance` work. The minimal prerequisite design:
+a CCL contract type that accepts a `BilateralClearingAgreement` payload and on approval executes
+`FederationEffect::EstablishClearing` with the same terms + provenance from the vote decision.
+
+Before Step 3: consider whether origin labeling should be extended to include
+`decision_receipt_id` and `decision_hash` on `"governance"` records — currently these fields are
+available in `FederationProvenance` (stored in `FederationServiceImpl`) but not exposed in the
+view DTOs. Exposing them would allow clients to verify governance provenance directly from the API.
 
 ---
 

--- a/ops/state/decisions/0012-federation-state-origin-model.md
+++ b/ops/state/decisions/0012-federation-state-origin-model.md
@@ -528,9 +528,14 @@ This ADR serves as the design artifact. Gateway API documentation should note:
 
 ### What This ADR Leaves Open
 
-1. FederationService read method expansion (Step 1-3 above) — future PR, low risk.
-2. Origin labeling for mixed-origin reads (Step 4) — future design.
-3. CCL adoption contract for promotion path (Step 5) — future work, high complexity.
+1. CCL adoption contract for promotion path (Step 3 in sequencing table) — future work, high complexity.
+2. Provenance field exposure on governance-origin reads: `decision_receipt_id` / `decision_hash` are
+   stored in `FederationProvenance` but not yet exposed in view DTOs. Clients cannot verify
+   governance origin directly from the API without this. Low-complexity follow-up.
+3. Integration tests verifying store isolation between paths (see Phase 5 — Required tests).
+
+Steps 1a, 1b (FederationService read expansion), and Step 2 (origin labeling) are complete as of
+2026-04-01. See Phase 4a, 4c, 4d above for details.
 
 ---
 

--- a/ops/state/decisions/0012-federation-state-origin-model.md
+++ b/ops/state/decisions/0012-federation-state-origin-model.md
@@ -49,9 +49,10 @@ phase with a precise roadmap for unification.
 | `POST /federation/clearing/netting/{unit}/apply` | Position adjustments | `ClearingManager` |
 
 **Visibility through gateway reads**:
-- `GET /federation/coops*` → reads from `FederationManager` — shows only gateway-API-registered coops
-- `GET /federation/clearing*` → reads from `FederationManager` — shows only gateway-API-created agreements
-- `GET /federation/clearing/{id}/position` → reads from `FederationService` (ADR 0011) — shows supervisor state
+- `GET /federation/coops*` → prefers `FederationService` (Step 1a); falls back to `FederationManager`
+- `GET /federation/clearing` → prefers `FederationService` (Step 1b); falls back to `FederationManager`
+- `GET /federation/clearing/{id}` → prefers `FederationService` (Step 1b); falls back to `FederationManager`
+- `GET /federation/clearing/{id}/position` → `FederationService` only (ADR 0011) — shows supervisor state
 
 ### Supervisor/Governance-Originated State
 
@@ -144,7 +145,8 @@ phase.
 | Store | `data_dir/federation_store` | `store_path/clearing` |
 | Provenance | None | `decision_receipt_id`, `decision_hash` |
 | Position query | 404 in daemon mode (ADR 0011) | ✅ via `FederationService::get_clearing_position` |
-| Read list | `GET /federation/clearing` (gateway-only) | Not exposed |
+| Read list | `GET /federation/clearing` (fallback only) | ✅ via `FederationService::list_agreements` (Step 1b) |
+| Read by ID | `GET /federation/clearing/{id}` (fallback only) | ✅ via `FederationService::get_agreement` (Step 1b) |
 | Relationship | **Transitional** | **Canonical** |
 
 **Gap (documented, acceptable)**: A clearing agreement created via `POST /federation/clearing` in
@@ -341,16 +343,60 @@ This is a long-term path, not a current requirement.
 | Step | Prerequisite | Risk | Scope | Status |
 |------|-------------|------|-------|--------|
 | 1a. `list/get_cooperative`, `get_vouches_for`, `CooperativeView` DTO | None | Low | `icn-kernel-api` + `icn-core` + `icn-gateway` | ✅ Done (2026-03-31) |
-| 1b. `list/get_agreement`, `ClearingAgreementView` DTO | None | Low | `icn-kernel-api` + `icn-core` + `icn-gateway` | ⏳ Next |
-| 2. Wire gateway clearing GET routes to prefer service | Step 1b | Low | `icn-gateway` | ⏳ After 1b |
-| 3. Add origin labeling to response DTOs | Steps 1a+1b | Medium | Cross-crate | ⏳ Future |
-| 4. Implement CCL adoption contract | Step 3 + CCL work | High | `icn-ccl`, `icn-governance` | ⏳ Future |
+| 1b. `list/get_agreement`, `ClearingAgreementView` DTO | None | Low | `icn-kernel-api` + `icn-core` + `icn-gateway` | ✅ Done (2026-04-01) |
+| 2. Add origin labeling to response DTOs | Steps 1a+1b | Medium | Cross-crate | ⏳ Future |
+| 3. Implement CCL adoption contract | Step 2 + CCL work | High | `icn-ccl`, `icn-governance` | ⏳ Future |
 
-Step 1b is the next minimal slice: design `ClearingAgreementView`, add two trait methods, implement them, wire `GET /federation/clearing` and `GET /federation/clearing/{id}` to prefer service.
+Step 2 is the origin labeling pass — adds `origin: "governance" | "direct-management"` to responses. This is optional/future; the handler comments + ADR documentation serve this purpose for now.
 
-Step 3 is the origin labeling pass — adds `origin: "governance" | "direct-management"` to responses. This is optional/future; the handler comments + ADR documentation serve this purpose for now.
+Step 3 is full lifecycle unification (future work).
 
-Step 4 is full lifecycle unification (future work).
+---
+
+## Phase 4c: Read Unification — Step 1b Implementation (2026-04-01)
+
+### Implemented: Clearing Agreement Read Surface
+
+Added the following to `FederationService` (icn-kernel-api) and implemented in
+`FederationServiceImpl` (icn-core):
+
+```rust
+fn list_agreements(&self) -> Result<Vec<ClearingAgreementView>>;
+fn get_agreement(&self, agreement_id: &str) -> Result<Option<ClearingAgreementView>>;
+```
+
+New view DTO in `icn-kernel-api`:
+```rust
+pub struct ClearingAgreementView {
+    pub agreement_id: String,
+    pub coop_a: String,
+    pub coop_a_did: String,   // Did as string — no icn-identity dep in kernel-api
+    pub coop_b: String,
+    pub coop_b_did: String,
+    pub settlement_interval: String, // "daily" | "weekly" | "monthly" | "manual"
+    pub max_imbalance: i64,
+    pub created_at: u64,
+    pub exchange_rates: std::collections::HashMap<String, f64>,
+}
+```
+
+**Boundary notes**:
+- `Did` mapped to `String` — `icn-kernel-api` has no `icn-identity` dependency
+- `SettlementInterval` mapped to string — avoids cross-crate enum duplication, safe for future variants
+- `signatures` field omitted — raw cryptographic bytes have no API utility and must not cross boundary
+- `exchange_rates: HashMap<String, f64>` crosses freely (std primitives)
+- `None` clearing manager: `list_agreements` returns empty vec, `get_agreement` returns `Ok(None)`
+
+Gateway handlers updated to prefer service in daemon mode:
+- `GET /federation/clearing` — prefers `FederationService::list_agreements()`
+- `GET /federation/clearing/{id}` — prefers `FederationService::get_agreement()`
+
+In standalone mode (no service injected), both fall back to `FederationManager`.
+
+**Tests added** (3 new in `api/federation.rs`):
+- `test_list_agreements_prefers_federation_service` — proves service path taken over mgr, correct shape
+- `test_get_agreement_prefers_federation_service` — proves get + 404 behavior
+- `test_list_agreements_falls_back_to_fed_mgr_when_no_service` — proves fallback path fires
 
 ---
 

--- a/ops/state/decisions/0012-federation-state-origin-model.md
+++ b/ops/state/decisions/0012-federation-state-origin-model.md
@@ -233,39 +233,78 @@ The two paths serve different institutional roles:
    - CCL governance execution → institutional (full provenance)
    These are not interchangeable.
 
-4. **Read APIs reflect their write path**. `GET /federation/coops` returns gateway-local state.
-   This is correct behavior, not a bug. The limitation must be documented.
+4. **Read APIs reflect their write path**. `GET /federation/coops` returns gateway-local state
+   in standalone mode, governance-registered coops in daemon mode (Step 1 implemented below).
 
-5. **Position reads are already unified** (ADR 0011). This is the one crossing point.
+5. **Position reads are already unified** (ADR 0011). This is the original crossing point.
 
 ---
 
 ## Phase 4: Precise Design Artifact — What Full Unification Requires
 
-Full unification is **not yet implementable** without the following components:
+## Phase 4a: Read Unification — Step 1 Implementation (2026-03-31)
 
-### Prerequisite A: FederationService Read API Expansion
+### Implemented: Cooperative Registry Read Surface
 
-`FederationService` (icn-kernel-api) currently exposes only:
-- `join_federation`, `vouch_for_cooperative`, `establish_clearing`, `settle_clearing` (writes)
-- `get_clearing_position` (one read, added in ADR 0011)
-- `is_registered`, `get_registration_provenance` (existence checks)
+Added the following to `FederationService` (icn-kernel-api) and implemented in
+`FederationServiceImpl` (icn-core):
 
-To unify read paths, the following methods are required:
 ```rust
-fn list_cooperatives(&self) -> Result<Vec<CooperativeInfo>>;
-fn get_cooperative(&self, coop_id: &str) -> Result<Option<CooperativeInfo>>;
-fn list_agreements(&self) -> Result<Vec<BilateralClearingAgreement>>;
-fn get_agreement(&self, agreement_id: &str) -> Result<Option<BilateralClearingAgreement>>;
-fn get_vouches(&self, coop_id: &str) -> Result<Vec<String>>;
+fn list_cooperatives(&self) -> Result<Vec<CooperativeView>>;
+fn get_cooperative(&self, coop_id: &str) -> Result<Option<CooperativeView>>;
+fn get_vouches_for(&self, coop_id: &str) -> Result<Vec<String>>;
 ```
 
-Once these exist, the gateway route handlers can be updated to prefer the service (same pattern
-as `get_clearing_position` in ADR 0011).
+New view DTO in `icn-kernel-api`:
+```rust
+pub struct CooperativeView {
+    pub coop_id: String,
+    pub name: String,
+    pub public_did: String,    // DID as string — no icn-identity dep in kernel-api
+    pub gateway_endpoints: Vec<String>,
+    pub capabilities: Vec<String>,
+    pub last_seen: u64,
+}
+```
+
+Gateway handlers updated to prefer service in daemon mode:
+- `GET /federation/coops` — prefers `FederationService::list_cooperatives()`
+- `GET /federation/coops/{coop_id}` — prefers `FederationService::get_cooperative()`
+- `GET /federation/coops/{coop_id}/vouches` — prefers `FederationService::get_vouches_for()`
+
+In standalone mode (no service injected), all three fall back to `FederationManager`.
+
+**Response shape note**: In daemon mode, these endpoints return `CooperativeView` (pruned DTO)
+not `CooperativeInfo` (internal type). Fields omitted from the view: `FederationPolicy`,
+`CurrencyInfo`, `signature`. These are federation-internal and should not cross the boundary.
+
+**Tests added** (4 new in `api/federation.rs`):
+- `test_list_coops_prefers_federation_service` — proves service path taken over mgr
+- `test_list_coops_falls_back_to_fed_mgr_when_no_service` — proves fallback path
+- `test_get_coop_prefers_federation_service` — proves get + 404 behavior
+- `test_get_vouches_prefers_federation_service` — proves vouch path
+
+---
+
+## Phase 4b: Remaining Read Unification — What Full Unification Requires
+
+The cooperative registry reads are now unified. The following remain gateway-only reads:
+
+```
+GET /federation/clearing          → FederationManager only (no service equivalent)
+GET /federation/clearing/{id}     → FederationManager only
+```
+
+### Prerequisite: ClearingAgreementView DTO
 
 **Blocking issue**: `BilateralClearingAgreement` is in `icn-federation` (not `icn-kernel-api`).
-The trait would need to either re-export this type from kernel-api or introduce a
-`ClearingAgreementView` DTO similar to `ClearingPositionView`.
+The trait needs a `ClearingAgreementView` DTO similar to `ClearingPositionView`.
+
+Required new service methods:
+```rust
+fn list_agreements(&self) -> Result<Vec<ClearingAgreementView>>;
+fn get_agreement(&self, agreement_id: &str) -> Result<Option<ClearingAgreementView>>;
+```
 
 ### Prerequisite B: Origin Labeling
 
@@ -299,16 +338,19 @@ This is a long-term path, not a current requirement.
 
 ### Sequencing Plan
 
-| Step | Prerequisite | Risk | Scope |
-|------|-------------|------|-------|
-| 1. Add `FederationService` read methods | None | Low | `icn-kernel-api` + `icn-core` |
-| 2. Add `ClearingAgreementView` DTO | Step 1 | Low | `icn-kernel-api` |
-| 3. Update gateway route handlers to prefer service for list/get | Step 1+2 | Low | `icn-gateway` |
-| 4. Add origin labeling to DTOs | Step 1-3 | Medium | Cross-crate |
-| 5. Implement CCL adoption contract | Steps 1-4 + CCL work | High | `icn-ccl`, `icn-governance` |
+| Step | Prerequisite | Risk | Scope | Status |
+|------|-------------|------|-------|--------|
+| 1a. `list/get_cooperative`, `get_vouches_for`, `CooperativeView` DTO | None | Low | `icn-kernel-api` + `icn-core` + `icn-gateway` | ✅ Done (2026-03-31) |
+| 1b. `list/get_agreement`, `ClearingAgreementView` DTO | None | Low | `icn-kernel-api` + `icn-core` + `icn-gateway` | ⏳ Next |
+| 2. Wire gateway clearing GET routes to prefer service | Step 1b | Low | `icn-gateway` | ⏳ After 1b |
+| 3. Add origin labeling to response DTOs | Steps 1a+1b | Medium | Cross-crate | ⏳ Future |
+| 4. Implement CCL adoption contract | Step 3 + CCL work | High | `icn-ccl`, `icn-governance` | ⏳ Future |
 
-Steps 1-3 are the read unification path (no semantic risk, no write path changes).
-Steps 4-5 are the full lifecycle unification (future work).
+Step 1b is the next minimal slice: design `ClearingAgreementView`, add two trait methods, implement them, wire `GET /federation/clearing` and `GET /federation/clearing/{id}` to prefer service.
+
+Step 3 is the origin labeling pass — adds `origin: "governance" | "direct-management"` to responses. This is optional/future; the handler comments + ADR documentation serve this purpose for now.
+
+Step 4 is full lifecycle unification (future work).
 
 ---
 


### PR DESCRIPTION
## Summary

- Routes `GET /v1/federation/clearing/{agreement_id}/position` through the supervisor-owned `FederationService` instead of the gateway's own divergent `ClearingManager` instance
- Eliminates the two-instance bug: the gateway was reading clearing positions from a different sled store than governance-triggered agreements and compute-receipt accumulations write to
- Falls back to gateway's standalone `ClearingManager` only in isolated (non-daemon) mode

## Changes

- **`icn-kernel-api`**: `ClearingPositionView` DTO + `get_clearing_position()` on `FederationService` trait. Uses `party_a`/`party_b` vocabulary — entity-type-agnostic, no coop-specific leakage at the interface.
- **`icn-core/federation_service`**: implements `get_clearing_position()` on `FederationServiceImpl`, adapting `coop_a`/`coop_b` internal naming at the service boundary
- **`icn-core/actors`**: adds `federation_service` field to `GatewayActorHandles`
- **`icn-core/lifecycle`**: wires `FederationService` into `GatewayActorHandles` during `spawn_actors_with_identity`
- **`icn-core/init_gateway`**: plumbs `federation_service` through the `GatewayHandles` chain
- **`icn-gateway/server`**: `with_federation_service()` builder + `app_data` injection
- **`icn-gateway/api/federation`**: `get_position` handler prefers service-owned path, falls back to standalone manager

## Test plan

- [x] `cargo check -p icn-gateway -p icn-core -p icn-kernel-api` — clean
- [x] `cargo clippy -p icn-gateway -p icn-core -p icn-kernel-api --all-targets -- -D warnings` — clean
- [x] `cargo test -p icn-core --lib -- services::federation_service::tests` — 11/11 passed
- [x] `cargo test -p icn-gateway --lib` — 465/465 passed

## Architecture note

This completes the federation economic read path. The two-instance problem (gateway's own manager vs. daemon's service-owned state) is now resolved for position queries. The same pattern applies to any future clearing reads — they should route through `FederationService`, not `FederationManager` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)