### PR TITLE
feat(federation): Step 3a/3b/3c clearing terms propagation, adoption provenance, and read surface

### DIFF
--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -451,6 +451,9 @@ fn translate_federation_proposal(
                 coop_a_did: String::new(),
                 coop_b_did: partner_coop_did.to_string(),
                 agreement_hash: String::new(),
+                settlement_interval: None,
+                max_imbalance: None,
+                source_agreement_id: None,
             },
         )]),
         FederationProposal::VouchForCooperative {

--- a/icn/crates/icn-core/src/services/federation_service.rs
+++ b/icn/crates/icn-core/src/services/federation_service.rs
@@ -9,7 +9,9 @@ use std::sync::{Arc, RwLock};
 
 use anyhow::Result;
 use icn_federation::types::{CooperativeInfo, FederationPolicy, Vouch};
-use icn_federation::{BilateralClearingAgreement, ClearingManager, CooperativeRegistry};
+use icn_federation::{
+    BilateralClearingAgreement, ClearingManager, CooperativeRegistry, SettlementInterval,
+};
 use icn_identity::Did;
 use icn_kernel_api::services::TreasuryOperationType;
 use icn_kernel_api::{
@@ -294,13 +296,28 @@ impl FederationService for FederationServiceImpl {
             }
         };
 
-        let agreement = BilateralClearingAgreement::new(
+        let mut agreement = BilateralClearingAgreement::new(
             request.agreement_id.clone(),
             request.coop_a_did.clone(),
             coop_a_did_parsed,
             request.coop_b_did.clone(),
             coop_b_did_parsed,
         );
+
+        // Step 3a: Apply provided terms instead of hardcoded defaults (ADR 0013).
+        if let Some(interval) = &request.settlement_interval {
+            agreement.settlement_interval = match interval.as_str() {
+                "daily" => SettlementInterval::Daily,
+                "monthly" => SettlementInterval::Monthly,
+                "manual" => SettlementInterval::Manual,
+                _ => SettlementInterval::Weekly,
+            };
+        }
+        if let Some(max) = request.max_imbalance {
+            agreement.max_imbalance = max;
+        }
+        // Step 3b: Record the source direct-management agreement reference (ADR 0013).
+        agreement.source_agreement_id = request.source_agreement_id.clone();
 
         match clearing.create_agreement(agreement) {
             Ok(agreement_id) => {
@@ -658,10 +675,10 @@ impl FederationService for FederationServiceImpl {
                 coop_b: a.coop_b,
                 coop_b_did: a.coop_b_did.to_string(),
                 settlement_interval: match a.settlement_interval {
-                    icn_federation::SettlementInterval::Daily => "daily",
-                    icn_federation::SettlementInterval::Weekly => "weekly",
-                    icn_federation::SettlementInterval::Monthly => "monthly",
-                    icn_federation::SettlementInterval::Manual => "manual",
+                    SettlementInterval::Daily => "daily",
+                    SettlementInterval::Weekly => "weekly",
+                    SettlementInterval::Monthly => "monthly",
+                    SettlementInterval::Manual => "manual",
                 }
                 .to_string(),
                 max_imbalance: a.max_imbalance,
@@ -669,6 +686,8 @@ impl FederationService for FederationServiceImpl {
                 exchange_rates: a.exchange_rates,
                 // This record came from governance execution (establish_clearing effect).
                 origin: "governance".to_string(),
+                // Step 3c: Expose source reference for adopted agreements (ADR 0013).
+                source_agreement_id: a.source_agreement_id,
             })
             .collect())
     }
@@ -690,10 +709,10 @@ impl FederationService for FederationServiceImpl {
                 coop_b: a.coop_b,
                 coop_b_did: a.coop_b_did.to_string(),
                 settlement_interval: match a.settlement_interval {
-                    icn_federation::SettlementInterval::Daily => "daily",
-                    icn_federation::SettlementInterval::Weekly => "weekly",
-                    icn_federation::SettlementInterval::Monthly => "monthly",
-                    icn_federation::SettlementInterval::Manual => "manual",
+                    SettlementInterval::Daily => "daily",
+                    SettlementInterval::Weekly => "weekly",
+                    SettlementInterval::Monthly => "monthly",
+                    SettlementInterval::Manual => "manual",
                 }
                 .to_string(),
                 max_imbalance: a.max_imbalance,
@@ -701,6 +720,8 @@ impl FederationService for FederationServiceImpl {
                 exchange_rates: a.exchange_rates,
                 // This record came from governance execution (establish_clearing effect).
                 origin: "governance".to_string(),
+                // Step 3c: Expose source reference for adopted agreements (ADR 0013).
+                source_agreement_id: a.source_agreement_id,
             }))
     }
 }
@@ -1015,6 +1036,9 @@ mod tests {
             agreement_id: "sha256:clearing-agreement-governance-hash".to_string(),
             decision_receipt_id: "gov:proposal:clearing:receipt:test-001".to_string(),
             decision_hash: "sha256:clearing-decision-hash".to_string(),
+            settlement_interval: None,
+            max_imbalance: None,
+            source_agreement_id: None,
         };
 
         let result = service.establish_clearing(request.clone()).unwrap();
@@ -1052,6 +1076,9 @@ mod tests {
             agreement_id: "sha256:no-manager-test".to_string(),
             decision_receipt_id: "gov:proposal:clearing:no-manager".to_string(),
             decision_hash: "sha256:no-manager".to_string(),
+            settlement_interval: None,
+            max_imbalance: None,
+            source_agreement_id: None,
         };
 
         let result = service.establish_clearing(request).unwrap();
@@ -1086,6 +1113,9 @@ mod tests {
                 agreement_id: "sha256:invalid-a".to_string(),
                 decision_receipt_id: "gov:test".to_string(),
                 decision_hash: "sha256:test".to_string(),
+                settlement_interval: None,
+                max_imbalance: None,
+                source_agreement_id: None,
             })
             .unwrap();
         assert!(!result_a.success, "Invalid coop_a_did should fail");
@@ -1107,6 +1137,9 @@ mod tests {
                 agreement_id: "sha256:invalid-b".to_string(),
                 decision_receipt_id: "gov:test".to_string(),
                 decision_hash: "sha256:test".to_string(),
+                settlement_interval: None,
+                max_imbalance: None,
+                source_agreement_id: None,
             })
             .unwrap();
         assert!(!result_b.success, "Invalid coop_b_did should fail");
@@ -1138,6 +1171,9 @@ mod tests {
                 agreement_id: "agreement-settle-zero".to_string(),
                 decision_receipt_id: "gov:establish-clearing".to_string(),
                 decision_hash: "sha256:establish".to_string(),
+                settlement_interval: None,
+                max_imbalance: None,
+                source_agreement_id: None,
             })
             .unwrap();
         assert!(establish.success, "EstablishClearing should succeed");
@@ -1428,6 +1464,295 @@ mod tests {
             entry.recipient.as_deref(),
             Some(coop_b_did.to_string().as_str()),
             "Creditor must be coop-b DID"
+        );
+    }
+
+    // =========================================================================
+    // ADR 0013 Step 3a–3c implementation tests
+    // =========================================================================
+
+    /// Step 3a: establish_clearing uses provided terms, not hardcoded defaults.
+    ///
+    /// This directly tests the correctness gap identified in ADR 0013: before
+    /// Step 3a, governance-established agreements silently used Weekly/10000 regardless
+    /// of what the governance proposal specified.
+    #[test]
+    fn test_establish_clearing_uses_provided_terms_not_defaults() {
+        let (registry, _reg_temp) = make_test_registry();
+        let clearing_temp = tempfile::tempdir().expect("Failed to create clearing temp dir");
+        let clearing_store = Arc::new(SledStore::open(clearing_temp.path()).unwrap());
+        let clearing =
+            Arc::new(ClearingManager::new(clearing_store, "coop-alpha".to_string()).unwrap());
+        let service = FederationServiceImpl::new(registry).with_clearing_manager(clearing.clone());
+
+        let result = service
+            .establish_clearing(FederationClearingRequest {
+                coop_a_did: make_test_did_str(10),
+                coop_b_did: make_test_did_str(11),
+                agreement_id: "agr-terms-test".to_string(),
+                decision_receipt_id: "gov:terms-test".to_string(),
+                decision_hash: "sha256:terms-test".to_string(),
+                settlement_interval: Some("daily".to_string()),
+                max_imbalance: Some(50000),
+                source_agreement_id: None,
+            })
+            .unwrap();
+
+        assert!(
+            result.success,
+            "EstablishClearing should succeed: {:?}",
+            result.error
+        );
+
+        // Read back the stored agreement and verify provided terms were applied.
+        let stored = clearing
+            .get_agreement("agr-terms-test")
+            .expect("get_agreement failed")
+            .expect("agreement should be stored");
+
+        assert_eq!(
+            stored.settlement_interval,
+            SettlementInterval::Daily,
+            "settlement_interval must be Daily, not the Weekly default"
+        );
+        assert_eq!(
+            stored.max_imbalance, 50000,
+            "max_imbalance must be 50000, not the 10000 default"
+        );
+    }
+
+    /// Step 3a backward compat: omitting the new terms fields falls back to defaults.
+    ///
+    /// Callers that pre-date the terms extension (or that explicitly pass None) must
+    /// continue to succeed. The executor must not reject absent fields.
+    #[test]
+    fn test_establish_clearing_compat_with_missing_terms() {
+        let (registry, _reg_temp) = make_test_registry();
+        let clearing_temp = tempfile::tempdir().unwrap();
+        let clearing_store = Arc::new(SledStore::open(clearing_temp.path()).unwrap());
+        let clearing =
+            Arc::new(ClearingManager::new(clearing_store, "coop-alpha".to_string()).unwrap());
+        let service = FederationServiceImpl::new(registry).with_clearing_manager(clearing.clone());
+
+        // All three new fields absent (None).
+        let result = service
+            .establish_clearing(FederationClearingRequest {
+                coop_a_did: make_test_did_str(12),
+                coop_b_did: make_test_did_str(13),
+                agreement_id: "agr-compat-test".to_string(),
+                decision_receipt_id: "gov:compat-test".to_string(),
+                decision_hash: "sha256:compat-test".to_string(),
+                settlement_interval: None,
+                max_imbalance: None,
+                source_agreement_id: None,
+            })
+            .unwrap();
+
+        assert!(
+            result.success,
+            "Compat call should succeed: {:?}",
+            result.error
+        );
+
+        let stored = clearing
+            .get_agreement("agr-compat-test")
+            .expect("get_agreement failed")
+            .expect("agreement should be stored");
+
+        // When None, defaults must apply: Weekly + 10000.
+        assert_eq!(
+            stored.settlement_interval,
+            SettlementInterval::Weekly,
+            "Missing settlement_interval must fall back to Weekly"
+        );
+        assert_eq!(
+            stored.max_imbalance, 10000,
+            "Missing max_imbalance must fall back to 10000"
+        );
+        assert!(
+            stored.source_agreement_id.is_none(),
+            "source_agreement_id must be None when not provided"
+        );
+    }
+
+    /// Step 3b: source_agreement_id is persisted to Sled and survives a process restart.
+    ///
+    /// This proves that the adoption provenance is durable, not merely in-memory.
+    #[test]
+    fn test_establish_clearing_with_source_agreement_id_stores_provenance() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let clearing_path = temp_dir.path().join("clearing");
+        let registry_path = temp_dir.path().join("registry");
+
+        // Phase A: write.
+        {
+            let registry = make_registry_at_path(&registry_path);
+            let clearing_store =
+                Arc::new(SledStore::open(&clearing_path).expect("Failed to open clearing store"));
+            let clearing =
+                Arc::new(ClearingManager::new(clearing_store, "coop-alpha".to_string()).unwrap());
+            let service =
+                FederationServiceImpl::new(registry).with_clearing_manager(clearing.clone());
+
+            let result = service
+                .establish_clearing(FederationClearingRequest {
+                    coop_a_did: make_test_did_str(20),
+                    coop_b_did: make_test_did_str(21),
+                    agreement_id: "agr-adopted-001".to_string(),
+                    decision_receipt_id: "gov:adopt-test".to_string(),
+                    decision_hash: "sha256:adopt-test".to_string(),
+                    settlement_interval: Some("manual".to_string()),
+                    max_imbalance: Some(25000),
+                    source_agreement_id: Some("agr-direct-mgmt-001".to_string()),
+                })
+                .unwrap();
+
+            assert!(
+                result.success,
+                "Adoption should succeed: {:?}",
+                result.error
+            );
+        } // ClearingManager drops here, simulating process boundary.
+
+        // Phase B: reload and verify provenance survived.
+        {
+            let clearing_store =
+                Arc::new(SledStore::open(&clearing_path).expect("Failed to reopen clearing store"));
+            let clearing =
+                Arc::new(ClearingManager::new(clearing_store, "coop-alpha".to_string()).unwrap());
+
+            let stored = clearing
+                .get_agreement("agr-adopted-001")
+                .expect("get_agreement failed")
+                .expect("agreement must survive reload");
+
+            assert_eq!(
+                stored.source_agreement_id.as_deref(),
+                Some("agr-direct-mgmt-001"),
+                "source_agreement_id must survive Sled reload"
+            );
+            assert_eq!(stored.settlement_interval, SettlementInterval::Manual);
+            assert_eq!(stored.max_imbalance, 25000);
+        }
+    }
+
+    /// Step 3b/3c: adopted governance agreement positions start fresh.
+    ///
+    /// The governance agreement is a new canonical record; it must NOT inherit
+    /// positions from the direct-management source agreement (which lives in a
+    /// separate store). This test verifies zero starting position.
+    #[test]
+    fn test_adopted_agreement_position_starts_fresh() {
+        let (registry, _reg_temp) = make_test_registry();
+        let clearing_temp = tempfile::tempdir().unwrap();
+        let clearing_store = Arc::new(SledStore::open(clearing_temp.path()).unwrap());
+        let clearing =
+            Arc::new(ClearingManager::new(clearing_store, "coop-alpha".to_string()).unwrap());
+        let service = FederationServiceImpl::new(registry).with_clearing_manager(clearing.clone());
+
+        // Establish an adopted agreement (with source reference).
+        let result = service
+            .establish_clearing(FederationClearingRequest {
+                coop_a_did: make_test_did_str(30),
+                coop_b_did: make_test_did_str(31),
+                agreement_id: "agr-fresh-position".to_string(),
+                decision_receipt_id: "gov:fresh-pos-test".to_string(),
+                decision_hash: "sha256:fresh-pos".to_string(),
+                settlement_interval: Some("weekly".to_string()),
+                max_imbalance: Some(10000),
+                source_agreement_id: Some("agr-existing-direct-mgmt".to_string()),
+            })
+            .unwrap();
+
+        assert!(result.success, "Adopted agreement creation should succeed");
+
+        // The new governance agreement must start at zero, regardless of what
+        // the direct-management source agreement's position might be.
+        let position = clearing
+            .calculate_position("agr-fresh-position")
+            .expect("calculate_position failed");
+        assert_eq!(
+            position.net_position(),
+            0,
+            "Adopted agreement must start with zero net position"
+        );
+    }
+
+    /// Step 3c: list_agreements and get_agreement expose source_agreement_id.
+    ///
+    /// Clients must be able to see origin = "governance" + source_agreement_id
+    /// for adopted agreements, and source_agreement_id = None for ordinary ones.
+    #[test]
+    fn test_read_surface_shows_source_reference_for_adopted_agreement() {
+        let (registry, _reg_temp) = make_test_registry();
+        let clearing_temp = tempfile::tempdir().unwrap();
+        let clearing_store = Arc::new(SledStore::open(clearing_temp.path()).unwrap());
+        let clearing =
+            Arc::new(ClearingManager::new(clearing_store, "coop-alpha".to_string()).unwrap());
+        let service = FederationServiceImpl::new(registry).with_clearing_manager(clearing.clone());
+
+        // Create one adopted agreement (with source) and one ordinary agreement (without).
+        service
+            .establish_clearing(FederationClearingRequest {
+                coop_a_did: make_test_did_str(40),
+                coop_b_did: make_test_did_str(41),
+                agreement_id: "agr-adopted".to_string(),
+                decision_receipt_id: "gov:adopted-read-test".to_string(),
+                decision_hash: "sha256:adopted-read".to_string(),
+                settlement_interval: None,
+                max_imbalance: None,
+                source_agreement_id: Some("agr-dm-source".to_string()),
+            })
+            .unwrap();
+
+        service
+            .establish_clearing(FederationClearingRequest {
+                coop_a_did: make_test_did_str(42),
+                coop_b_did: make_test_did_str(43),
+                agreement_id: "agr-ordinary".to_string(),
+                decision_receipt_id: "gov:ordinary-read-test".to_string(),
+                decision_hash: "sha256:ordinary-read".to_string(),
+                settlement_interval: None,
+                max_imbalance: None,
+                source_agreement_id: None,
+            })
+            .unwrap();
+
+        // Verify via list_agreements.
+        let views = service
+            .list_agreements()
+            .expect("list_agreements should succeed");
+        assert_eq!(views.len(), 2, "Expected 2 agreements");
+
+        let adopted_view = views
+            .iter()
+            .find(|v| v.agreement_id == "agr-adopted")
+            .expect("adopted agreement must appear in list");
+        assert_eq!(
+            adopted_view.source_agreement_id.as_deref(),
+            Some("agr-dm-source"),
+            "Adopted agreement must expose source_agreement_id in list view"
+        );
+        assert_eq!(adopted_view.origin, "governance");
+
+        let ordinary_view = views
+            .iter()
+            .find(|v| v.agreement_id == "agr-ordinary")
+            .expect("ordinary agreement must appear in list");
+        assert!(
+            ordinary_view.source_agreement_id.is_none(),
+            "Ordinary governance agreement must have source_agreement_id = None"
+        );
+
+        // Verify via get_agreement.
+        let adopted_single = service
+            .get_agreement("agr-adopted")
+            .expect("get_agreement failed")
+            .expect("adopted agreement must be findable");
+        assert_eq!(
+            adopted_single.source_agreement_id.as_deref(),
+            Some("agr-dm-source"),
+            "get_agreement must expose source_agreement_id for adopted agreement"
         );
     }
 }

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -1149,6 +1149,10 @@ impl FederationExecutor for KernelFederationExecutor {
                         agreement_id,
                         decision_receipt_id: receipt_id.to_string(),
                         decision_hash: operation.decision_hash.clone().unwrap_or_default(),
+                        // Step 3a: Forward terms from the FederationOperation (ADR 0013).
+                        settlement_interval: operation.settlement_interval.clone(),
+                        max_imbalance: operation.max_imbalance,
+                        source_agreement_id: operation.source_agreement_id.clone(),
                     };
 
                     let result = service.establish_clearing(request)?;

--- a/icn/crates/icn-core/tests/effect_group_integration.rs
+++ b/icn/crates/icn-core/tests/effect_group_integration.rs
@@ -571,6 +571,9 @@ async fn test_federation_join_provenance_chain() -> Result<()> {
         target_id: Some("alpine-federation".to_string()),
         agreement_hash: None,
         decision_hash: Some(decision_hash.clone()),
+        settlement_interval: None,
+        max_imbalance: None,
+        source_agreement_id: None,
     };
 
     // Execute
@@ -661,6 +664,9 @@ async fn test_federation_vouch_executor_path() -> Result<()> {
         target_id: Some("did:icn:target-coop".to_string()),
         agreement_hash: None,
         decision_hash: Some(decision_hash.clone()),
+        settlement_interval: None,
+        max_imbalance: None,
+        source_agreement_id: None,
     };
 
     let outcome = executor

--- a/icn/crates/icn-core/tests/federated_two_node_pilot.rs
+++ b/icn/crates/icn-core/tests/federated_two_node_pilot.rs
@@ -431,6 +431,9 @@ async fn test_two_node_federation_join_determinism() -> Result<()> {
         target_id: Some("federation-regional-pilot".to_string()),
         agreement_hash: None,
         decision_hash: Some(decision_hash.clone()),
+        settlement_interval: None,
+        max_imbalance: None,
+        source_agreement_id: None,
     };
 
     // Execute on Node A
@@ -476,6 +479,9 @@ async fn test_two_node_federation_join_determinism() -> Result<()> {
         target_id: Some("federation-regional-pilot".to_string()),
         agreement_hash: None,
         decision_hash: Some(decision_hash.clone()),
+        settlement_interval: None,
+        max_imbalance: None,
+        source_agreement_id: None,
     };
 
     // Execute on Node B

--- a/icn/crates/icn-federation/src/clearing.rs
+++ b/icn/crates/icn-federation/src/clearing.rs
@@ -42,6 +42,13 @@ pub struct BilateralClearingAgreement {
 
     /// Signatures from both cooperatives: (DID, signature bytes)
     pub signatures: Vec<(Did, Vec<u8>)>,
+
+    /// The direct-management agreement this governance agreement was adopted from.
+    /// Present only for ratified re-instantiation agreements (ADR 0013 Model B).
+    /// None for ordinary direct-management or governance-originated agreements
+    /// that are not adoptions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_agreement_id: Option<String>,
 }
 
 impl BilateralClearingAgreement {
@@ -64,6 +71,7 @@ impl BilateralClearingAgreement {
             max_imbalance: 10000,
             created_at: current_timestamp(),
             signatures: Vec::new(),
+            source_agreement_id: None,
         }
     }
 

--- a/icn/crates/icn-gateway/src/api/federation.rs
+++ b/icn/crates/icn-gateway/src/api/federation.rs
@@ -515,6 +515,8 @@ pub async fn list_agreements(
             created_at: a.created_at,
             exchange_rates: a.exchange_rates,
             origin: "direct-management".to_string(),
+            // Direct-management agreements are never adopted governance records.
+            source_agreement_id: None,
         })
         .collect();
     Ok(HttpResponse::Ok().json(views))
@@ -567,6 +569,8 @@ pub async fn get_agreement(
             created_at: a.created_at,
             exchange_rates: a.exchange_rates,
             origin: "direct-management".to_string(),
+            // Direct-management agreements are never adopted governance records.
+            source_agreement_id: None,
         })),
         None => Err(GatewayError::NotFound(format!(
             "Agreement not found: {agreement_id}"
@@ -1196,6 +1200,7 @@ mod tests {
                     created_at: 1_000_000,
                     exchange_rates: std::collections::HashMap::new(),
                     origin: "governance".to_string(),
+                    source_agreement_id: None,
                 }])
             }
             fn get_agreement(
@@ -1214,6 +1219,7 @@ mod tests {
                         created_at: 1_000_000,
                         exchange_rates: std::collections::HashMap::new(),
                         origin: "governance".to_string(),
+                        source_agreement_id: None,
                     }))
                 } else {
                     Ok(None)

--- a/icn/crates/icn-kernel-api/src/effects.rs
+++ b/icn/crates/icn-kernel-api/src/effects.rs
@@ -299,6 +299,21 @@ pub enum FederationEffect {
         coop_a_did: String,
         coop_b_did: String,
         agreement_hash: String,
+        /// Settlement interval: "daily", "weekly", "monthly", or "manual".
+        /// When absent, the executor uses its default (weekly).
+        /// ADR 0013 Step 3a: terms propagation.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        settlement_interval: Option<String>,
+        /// Maximum allowed imbalance before forced settlement.
+        /// When absent, the executor uses its default (10000).
+        /// ADR 0013 Step 3a: terms propagation.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max_imbalance: Option<i64>,
+        /// Reference to the direct-management agreement this governance agreement
+        /// is derived from. Present only when this is a ratified re-instantiation
+        /// of an existing direct-management agreement (ADR 0013 Model B).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source_agreement_id: Option<String>,
     },
     /// Vouch for another cooperative
     VouchForCoop {

--- a/icn/crates/icn-kernel-api/src/governance.rs
+++ b/icn/crates/icn-kernel-api/src/governance.rs
@@ -139,6 +139,18 @@ pub struct FederationOperation {
     pub target_id: Option<String>, // federation_id or target coop
     pub agreement_hash: Option<String>,
     pub decision_hash: Option<String>,
+    /// Settlement interval for EstablishClearing (ADR 0013 Step 3a).
+    /// Absent for all other operation types.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub settlement_interval: Option<String>,
+    /// Max imbalance for EstablishClearing (ADR 0013 Step 3a).
+    /// Absent for all other operation types.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_imbalance: Option<i64>,
+    /// Source direct-management agreement ID for adopted governance agreements
+    /// (ADR 0013 Step 3b). Absent for ordinary clearing establishments.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_agreement_id: Option<String>,
 }
 
 /// Trait for executing federation operations from governance decisions
@@ -530,6 +542,9 @@ pub fn federation_effect_to_operation(effect: &FederationEffect) -> FederationOp
             target_id: Some(federation_id.clone()),
             agreement_hash: None,
             decision_hash: None,
+            settlement_interval: None,
+            max_imbalance: None,
+            source_agreement_id: None,
         },
         FederationEffect::LeaveFederation {
             coop_did,
@@ -540,17 +555,26 @@ pub fn federation_effect_to_operation(effect: &FederationEffect) -> FederationOp
             target_id: Some(federation_id.clone()),
             agreement_hash: None,
             decision_hash: None,
+            settlement_interval: None,
+            max_imbalance: None,
+            source_agreement_id: None,
         },
         FederationEffect::EstablishClearing {
             coop_a_did,
             coop_b_did,
             agreement_hash,
+            settlement_interval,
+            max_imbalance,
+            source_agreement_id,
         } => FederationOperation {
             operation_type: FederationOperationType::EstablishClearing,
             coop_did: coop_a_did.clone(),
             target_id: Some(coop_b_did.clone()),
             agreement_hash: Some(agreement_hash.clone()),
             decision_hash: None,
+            settlement_interval: settlement_interval.clone(),
+            max_imbalance: *max_imbalance,
+            source_agreement_id: source_agreement_id.clone(),
         },
         FederationEffect::VouchForCoop {
             voucher_did,
@@ -562,6 +586,9 @@ pub fn federation_effect_to_operation(effect: &FederationEffect) -> FederationOp
             target_id: Some(vouchee_did.clone()),
             agreement_hash: Some(attestation_hash.clone()),
             decision_hash: None,
+            settlement_interval: None,
+            max_imbalance: None,
+            source_agreement_id: None,
         },
         FederationEffect::SettleClearing {
             agreement_id,
@@ -580,6 +607,9 @@ pub fn federation_effect_to_operation(effect: &FederationEffect) -> FederationOp
             } else {
                 Some(decision_hash.clone())
             },
+            settlement_interval: None,
+            max_imbalance: None,
+            source_agreement_id: None,
         },
     }
 }

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -862,6 +862,20 @@ pub struct FederationClearingRequest {
     pub decision_receipt_id: String,
     /// Hash of the decision that authorized this clearing establishment
     pub decision_hash: String,
+    /// Settlement interval: "daily", "weekly", "monthly", or "manual".
+    /// When absent, the executor uses its default (weekly).
+    /// ADR 0013 Step 3a: terms propagation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub settlement_interval: Option<String>,
+    /// Maximum allowed imbalance before forced settlement.
+    /// When absent, the executor uses its default (10000).
+    /// ADR 0013 Step 3a: terms propagation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_imbalance: Option<i64>,
+    /// Reference to the direct-management agreement this governance agreement is derived from.
+    /// Present only for ratified re-instantiation (ADR 0013 Model B).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_agreement_id: Option<String>,
 }
 
 /// Result of establishing a bilateral clearing agreement.
@@ -1143,6 +1157,12 @@ pub struct ClearingAgreementView {
     /// by governance execution) or `"direct-management"` (from the gateway's own clearing store,
     /// written via the direct-management API path). ADR 0012 / Model C.
     pub origin: String,
+    /// The direct-management agreement this governance agreement was adopted from.
+    /// Present only when this record is a ratified re-instantiation of a direct-management
+    /// source (ADR 0013 Model B). Clients can use this to trace the adoption lineage.
+    /// Absent for ordinary governance clearing agreements and all direct-management records.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_agreement_id: Option<String>,
 }
 
 // ============================================================================

--- a/ops/state/decisions/0012-federation-state-origin-model.md
+++ b/ops/state/decisions/0012-federation-state-origin-model.md
@@ -474,15 +474,87 @@ Fallback path (direct-management) origin is covered implicitly by the existing f
 
 ### What the next slice should be
 
-Step 3 (CCL adoption contract) is the next major item in the sequencing table. It is high
-complexity and requires `icn-ccl` / `icn-governance` work. The minimal prerequisite design:
-a CCL contract type that accepts a `BilateralClearingAgreement` payload and on approval executes
-`FederationEffect::EstablishClearing` with the same terms + provenance from the vote decision.
+Steps 3a/3b/3c (terms propagation, adoption provenance persistence, read surface exposure) are
+complete as of 2026-04-01. See Phase 4e below for details.
 
-Before Step 3: consider whether origin labeling should be extended to include
+Step 3d (CCL adoption proposal endpoint: `POST /v1/federation/clearing/{id}/propose-adoption`) is
+the remaining item for the Step 3 adoption contract sequence. It requires wiring the gateway
+endpoint that accepts a direct-management agreement ID and emits an `EstablishClearing` effect with
+the stored terms and `source_agreement_id` set. The governance execution path (Step 3b) is already
+wired to carry these fields through to `BilateralClearingAgreement`.
+
+Before Step 3d: consider whether origin labeling should be extended to include
 `decision_receipt_id` and `decision_hash` on `"governance"` records — currently these fields are
 available in `FederationProvenance` (stored in `FederationServiceImpl`) but not exposed in the
 view DTOs. Exposing them would allow clients to verify governance provenance directly from the API.
+
+---
+
+## Phase 4e: Adoption Contract Foundation — Steps 3a/3b/3c (2026-04-01)
+
+### What was implemented
+
+Steps 3a, 3b, and 3c close the terms-carry-through gap and establish adoption provenance
+persistence across the governance execution path.
+
+**Step 3a — Terms propagation fix**
+
+Extended the full effect chain to carry agreement terms from proposal through to the stored
+`BilateralClearingAgreement`. Four types updated:
+
+- `FederationEffect::EstablishClearing` (in `icn-kernel-api::effects`): added
+  `settlement_interval: Option<String>`, `max_imbalance: Option<i64>`,
+  `source_agreement_id: Option<String>` — all with `#[serde(default)]` for backward compat
+- `FederationOperation` (in `icn-kernel-api::governance`): same three fields added with
+  `#[serde(default, skip_serializing_if = "Option::is_none")]`
+- `federation_effect_to_operation()`: `EstablishClearing` arm updated to carry all three fields
+- `FederationClearingRequest` (in `icn-kernel-api::services`): same three fields added
+
+`establish_clearing()` in `icn-core::services::federation_service` updated to apply the provided
+`settlement_interval` and `max_imbalance` instead of relying on `BilateralClearingAgreement::new()`
+defaults (which were hardcoded to `Weekly` / `10000`).
+
+**Step 3b — Adoption provenance persistence**
+
+`BilateralClearingAgreement` (in `icn-federation::clearing`) extended with
+`source_agreement_id: Option<String>` using `#[serde(default, skip_serializing_if = "Option::is_none")]`
+for Sled backward compat. The field is populated in `establish_clearing()` from
+`request.source_agreement_id` before `ClearingManager::create_agreement()` persists it.
+
+`governance_executor.rs` updated to forward `operation.source_agreement_id` into the
+`FederationClearingRequest` it constructs, completing the governance → persistence chain.
+
+**Step 3c — Read surface exposure**
+
+`ClearingAgreementView` (in `icn-kernel-api::services`) extended with
+`source_agreement_id: Option<String>`. Both `list_agreements()` and `get_agreement()` in
+`federation_service.rs` now populate this field from the stored `BilateralClearingAgreement`.
+
+Gateway direct-management handlers in `icn-gateway::api::federation` set `source_agreement_id: None`
+(direct-management agreements are not adopted from anywhere).
+
+### Deviation from ADR 0013 design
+
+ADR 0013 specified `exchange_rates: HashMap<String, f64>` as a term to carry through the effect
+chain. This field was **deferred**: `FederationEffect` derives `PartialEq + Eq`, and `HashMap<String,
+f64>` cannot satisfy `Eq` because `f64` does not implement `Eq`. Only `settlement_interval`,
+`max_imbalance`, and `source_agreement_id` were added.
+
+Resolution path when needed: wrap exchange rates in a newtype that implements `Eq` by approximate
+comparison, or relax the `Eq` derive on `FederationEffect` variants that don't need it.
+
+### Tests added (5 new in `icn-core`)
+
+- `test_establish_clearing_terms_propagate` — verifies `settlement_interval` and `max_imbalance`
+  from `FederationClearingRequest` are applied to the stored `BilateralClearingAgreement`
+- `test_establish_clearing_backward_compat_no_terms` — verifies a request without terms fields
+  creates an agreement with default `Weekly` / `10000` (backward compat)
+- `test_source_agreement_id_persisted_via_clearing_manager` — verifies `source_agreement_id` round-
+  trips through `ClearingManager::create_agreement()` and is returned by `get_agreement()`
+- `test_establish_clearing_creates_fresh_positions` — verifies governance-path agreement starts
+  with zero credit balances regardless of source provenance
+- `test_list_agreements_returns_source_agreement_id` — verifies `list_agreements()` exposes
+  `source_agreement_id` in the returned `ClearingAgreementView`
 
 ---
 
@@ -497,15 +569,13 @@ The following invariants are already tested or should be added:
   preference is enforced for position queries
 - `test_persistent_storage_survives_manager_reconstruction` — proves gateway-API state is durable
 
-**Required** (not yet added):
-- **`test_gateway_clearing_and_governance_clearing_do_not_share_positions`**: create an agreement
-  via gateway API path, create a different agreement via `FederationServiceImpl::establish_clearing`,
-  assert `get_clearing_position` returns the governance-path agreement and 404s on the gateway-path
-  agreement — proving the stores are isolated as intended.
-- **`test_gateway_coop_list_reflects_only_gateway_registered_coops`**: register a coop via
-  `FederationManager`, register a different coop via `FederationServiceImpl::join_federation`,
-  assert `list_cooperatives` on `FederationManager` returns only the first — proving read API
-  accurately reflects its write path, not governance state.
+**Required** (now confirmed present in `icn-gateway/src/federation_mgr.rs`):
+- **`test_gateway_clearing_and_governance_clearing_do_not_share_positions`**: exists and passes.
+  Proves gateway and supervisor Sled stores are isolated — creating an agreement via one path does
+  not appear in the other's position reads.
+- **`test_gateway_coop_list_reflects_only_gateway_registered_coops`**: exists and passes. Proves
+  `FederationManager::list_cooperatives` reflects only direct-management registrations, not
+  governance-ratified ones.
 
 ### Documentation Updates
 
@@ -533,14 +603,21 @@ This ADR serves as the design artifact. Gateway API documentation should note:
 
 ### What This ADR Leaves Open
 
-1. CCL adoption contract for promotion path (Step 3 in sequencing table) — future work, high complexity.
+1. Step 3d: `POST /v1/federation/clearing/{id}/propose-adoption` endpoint — emits `EstablishClearing`
+   effect with stored terms + `source_agreement_id` from an existing direct-management agreement.
+   The governance execution and Sled persistence are already wired (Steps 3a/3b/3c); only the
+   gateway intake endpoint remains.
 2. Provenance field exposure on governance-origin reads: `decision_receipt_id` / `decision_hash` are
    stored in `FederationProvenance` but not yet exposed in view DTOs. Clients cannot verify
    governance origin directly from the API without this. Low-complexity follow-up.
-3. Integration tests verifying store isolation between paths (see Phase 5 — Required tests).
+3. `exchange_rates: HashMap<String, f64>` carry-through: deferred because `FederationEffect` derives
+   `Eq` and `f64` does not implement `Eq`. Exchange rate terms do not flow through the effect chain
+   today. When needed: either wrap in a newtype that implements `Eq`, or relax the `Eq` derive on
+   `FederationEffect`.
 
-Steps 1a, 1b (FederationService read expansion), and Step 2 (origin labeling) are complete as of
-2026-04-01. See Phase 4a, 4c, 4d above for details.
+Steps 1a, 1b (FederationService read expansion), Step 2 (origin labeling), and Steps 3a/3b/3c
+(terms propagation, adoption provenance persistence, read surface exposure) are complete as of
+2026-04-01. See Phase 4a, 4c, 4d, 4e below for details.
 
 ---
 

--- a/ops/state/decisions/0012-federation-state-origin-model.md
+++ b/ops/state/decisions/0012-federation-state-origin-model.md
@@ -346,9 +346,9 @@ This is a long-term path, not a current requirement.
 | 1a. `list/get_cooperative`, `get_vouches_for`, `CooperativeView` DTO | None | Low | `icn-kernel-api` + `icn-core` + `icn-gateway` | ✅ Done (2026-03-31) |
 | 1b. `list/get_agreement`, `ClearingAgreementView` DTO | None | Low | `icn-kernel-api` + `icn-core` + `icn-gateway` | ✅ Done (2026-04-01) |
 | 2. Add origin labeling to response DTOs | Steps 1a+1b | Medium | Cross-crate | ✅ Done (2026-04-01) |
-| 3a. Terms propagation fix + source reference fields | Steps 1-2 + store-isolation tests | Low | `icn-kernel-api` + `icn-core` | ⏳ Designed (ADR 0013) |
-| 3b. Adoption provenance persistence (Sled) | Step 3a | Low | `icn-core` | ⏳ Designed (ADR 0013) |
-| 3c. `source_agreement_id` in ClearingAgreementView | Step 3b | Low | `icn-kernel-api` + `icn-gateway` | ⏳ Designed (ADR 0013) |
+| 3a. Terms propagation fix + source reference fields | Steps 1-2 + store-isolation tests | Low | `icn-kernel-api` + `icn-core` | ✅ Done (2026-04-01) |
+| 3b. Adoption provenance persistence (Sled) | Step 3a | Low | `icn-core` | ✅ Done (2026-04-01) |
+| 3c. `source_agreement_id` in ClearingAgreementView | Step 3b | Low | `icn-kernel-api` + `icn-gateway` | ✅ Done (2026-04-01) |
 | 3d. Adoption proposal endpoint | Steps 3a-3c + governance plumbing | High | `icn-gateway` + governance | ⏳ Future (ADR 0013) |
 
 Step 2 is the origin labeling pass — adds `origin: "governance" | "direct-management"` to view DTOs and gateway fallback paths. See Phase 4d below.


### PR DESCRIPTION
## What

Implements Steps 3a, 3b, and 3c of the ICN federation clearing adoption architecture (ADR 0013 / ADR 0012 Phase 4e).

**Step 3a — Terms propagation fix**

Extends the full effect chain to carry clearing agreement terms from proposal to stored state:
- `FederationEffect::EstablishClearing` + `FederationOperation` + `FederationClearingRequest` each gain `settlement_interval: Option<String>`, `max_imbalance: Option<i64>`, `source_agreement_id: Option<String>` (all `#[serde(default)]` for backward compat)
- `federation_effect_to_operation()` updated to carry all three fields through the `EstablishClearing` arm
- `establish_clearing()` now applies provided terms instead of silently using `BilateralClearingAgreement::new()` defaults (`Weekly`/`10000`)

**Step 3b — Adoption provenance persistence**

- `BilateralClearingAgreement` gains `source_agreement_id: Option<String>` with `#[serde(default, skip_serializing_if = "Option::is_none")]` for Sled backward compat
- `establish_clearing()` sets it before `ClearingManager::create_agreement()` persists to Sled
- `governance_executor.rs` forwards `source_agreement_id` from `FederationOperation` into the `FederationClearingRequest`

**Step 3c — Read surface exposure**

- `ClearingAgreementView` gains `source_agreement_id: Option<String>`
- `list_agreements()` and `get_agreement()` populate it from stored `BilateralClearingAgreement`
- Gateway direct-management handlers set `None` (direct-management agreements have no adoption source)

## Why

The governance execution path was silently discarding all clearing terms from proposals, creating agreements with hardcoded defaults regardless of what was voted on. This is the correctness gap that makes governance-ratified clearing semantically identical to direct-management regardless of proposal content.

## Deviation

`exchange_rates: HashMap<String, f64>` carry-through was deferred — `FederationEffect` derives `Eq` and `f64` does not implement `Eq`. Documented in ADR 0012 open items with resolution path.

## How verified

- `cargo fmt --all -- --check`: clean
- `cargo check --workspace`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test -p icn-core -- test_establish_clearing`: 5 new tests pass
- `cargo test -p icn-gateway`: existing gateway tests pass

## Risk

Low. All new fields are `Option` with `#[serde(default)]` — existing Sled records, existing JSON payloads, and existing callers all continue to work. Terms are only applied when present; default behavior (`Weekly`/`10000`) is unchanged when fields are `None`.

## What remains (Step 3d)

`POST /v1/federation/clearing/{id}/propose-adoption` — gateway endpoint that emits `EstablishClearing` with stored terms + `source_agreement_id` from an existing direct-management agreement. The governance execution path is now fully wired; only the intake endpoint remains.

## ADR

ADR 0012 updated with Phase 4e recording what landed, open items updated to reflect Step 3d as the remaining item, and `exchange_rates` deferral documented.