### PR TITLE
fix(website): remove broken paths, tighten copy, and make onboarding honest

### DIFF
--- a/docs/deployment/ICN_ZONE_ROUTING.md
+++ b/docs/deployment/ICN_ZONE_ROUTING.md
@@ -1,11 +1,14 @@
 # icn.zone Domain Routing Plan
 
+**Status:** Plan — not yet implemented
+**Last Updated:** 2026-04-04
+
 ## Domain Distinction
 
 | Domain | Role | Status |
 |--------|------|--------|
 | `intercooperative.network` | Canonical public website | Live (GitHub Pages + CNAME) |
-| `icn.zone` | Utility / short-link domain | Subdomains active; root unresolved |
+| `icn.zone` | Utility / short-link domain | Subdomains active; root redirect planned (Phase 1) |
 | `api.icn.zone` | Gateway REST + WebSocket (K3s) | Active |
 | `pilot.icn.zone` | Pilot UI (K3s) | Active |
 | `metrics.icn.zone` | Prometheus / Grafana (K3s) | Active |
@@ -24,7 +27,7 @@ Root `icn.zone` (no subdomain, any path) redirects to `intercooperative.network`
 ```
 Zone:    icn.zone
 Match:   hostname eq "icn.zone"
-Action:  301 redirect → https://intercooperative.network${path}
+Action:  301 redirect → https://intercooperative.network${uri.path}
 ```
 
 Path-preserving: `icn.zone/docs` → `intercooperative.network/docs`.

--- a/docs/deployment/ICN_ZONE_ROUTING.md
+++ b/docs/deployment/ICN_ZONE_ROUTING.md
@@ -1,0 +1,91 @@
+# icn.zone Domain Routing Plan
+
+## Domain Distinction
+
+| Domain | Role | Status |
+|--------|------|--------|
+| `intercooperative.network` | Canonical public website | Live (GitHub Pages + CNAME) |
+| `icn.zone` | Utility / short-link domain | Subdomains active; root unresolved |
+| `api.icn.zone` | Gateway REST + WebSocket (K3s) | Active |
+| `pilot.icn.zone` | Pilot UI (K3s) | Active |
+| `metrics.icn.zone` | Prometheus / Grafana (K3s) | Active |
+
+`icn.zone` is **not** a second marketing website. The root redirects to `intercooperative.network`.
+Subdomains serve K3s cluster endpoints and future short-link utilities.
+
+---
+
+## Root Behavior
+
+Root `icn.zone` (no subdomain, any path) redirects to `intercooperative.network`.
+
+**Implementation: Cloudflare Redirect Rule**
+
+```
+Zone:    icn.zone
+Match:   hostname eq "icn.zone"
+Action:  301 redirect → https://intercooperative.network${path}
+```
+
+Path-preserving: `icn.zone/docs` → `intercooperative.network/docs`.
+
+Do **not** deploy a second static site at `icn.zone` root. The redirect is the entire root behavior.
+
+---
+
+## Short-Link Path Model
+
+Reserve the following path prefixes at `icn.zone` for future utility use.
+These paths will **not** fall through to the root redirect — they will be handled by a Cloudflare Worker.
+
+| Prefix | Purpose | Status |
+|--------|---------|--------|
+| `/j/<code>` | Cooperative join codes | Future (Worker) |
+| `/i/<code>` | Member invite links | Future (Worker) |
+| `/n/<name>` | Human-readable cooperative name shortcuts | Future (Worker) |
+
+All other paths → root redirect rule above.
+
+---
+
+## Implementation Order
+
+### Phase 1 — Root redirect (do now)
+Add a Cloudflare Redirect Rule in the `icn.zone` zone:
+
+1. Log into Cloudflare → `icn.zone` zone
+2. Rules → Redirect Rules → Create Rule
+3. Match: `hostname eq "icn.zone"`
+4. Action: Dynamic redirect, `https://intercooperative.network${uri.path}`, 301
+5. Save and verify: `curl -I https://icn.zone` should return `301 → https://intercooperative.network/`
+
+### Phase 2 — Short-link Worker (build when needed)
+Deploy a Cloudflare Worker to `icn.zone` that:
+1. Matches `/j/*`, `/i/*`, `/n/*` paths
+2. Looks up code in Cloudflare KV or queries the ICN gateway API
+3. Returns a 302 redirect to the resolved destination
+4. Falls through to the redirect rule for all unmatched paths
+
+Worker deployment does not require changes to the ICN Rust codebase.
+
+---
+
+## Implementation Layer
+
+| Component | Where | Not here |
+|-----------|-------|----------|
+| Root redirect | Cloudflare Redirect Rules | Not in K3s, not in Astro site |
+| Short-link handler | Cloudflare Worker + KV | Not in ICN daemon crate |
+| Subdomain DNS (`api.`, `pilot.`, `metrics.`) | Cloudflare DNS A/CNAME records | Unchanged |
+
+**K3s ingress is unaffected.** Cloudflare routes by full hostname — subdomain records take precedence over wildcard rules.
+
+---
+
+## Why Not a Second Website
+
+- Maintains single canonical public site at `intercooperative.network`
+- Zero build/deploy pipeline to maintain at `icn.zone`
+- Cloudflare Redirect Rules are instant, free-tier eligible, zero-latency
+- Short-link Workers are independently deployable and don't touch the Astro or Rust codebase
+- Preserves the subdomain pattern already in use for K3s services

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -8,7 +8,7 @@ export interface Props {
   activeNav?: string;
 }
 
-const { title, description = 'Democratic infrastructure for cooperatives, communities, and federations. Build your co-op on infrastructure no one owns but everyone runs.', activeNav = '' } = Astro.props;
+const { title, description = 'Institutional infrastructure for cooperative and federated organizations. Identity, governance, accounting, and coordination as auditable, member-owned infrastructure.', activeNav = '' } = Astro.props;
 const currentPath = Astro.url.pathname;
 
 const jsonLd = {
@@ -125,7 +125,7 @@ const jsonLd = {
             </svg>
             <span>InterCooperative Network</span>
           </a>
-          <p>Democratic infrastructure for cooperatives, communities, and federations. Infrastructure no one owns, but everyone runs.</p>
+          <p>Institutional infrastructure for cooperative and federated organizations. Identity, governance, accounting, and coordination — auditable and member-owned.</p>
         </div>
 
         <div class="footer-col">
@@ -160,8 +160,8 @@ const jsonLd = {
       </div>
 
       <div class="footer-bottom">
-        <span>AGPL-3.0 · InterCooperative Network · cooperative infrastructure, not extractive tech</span>
-        <span>Built with cooperation, not extraction</span>
+        <span>AGPL-3.0 · InterCooperative Network · open infrastructure for cooperative institutions</span>
+        <span>Open source. Open governance.</span>
       </div>
     </div>
   </footer>

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -91,7 +91,7 @@ const jsonLd = {
         <a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener" class="nav-github" aria-label="GitHub">
           <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
         </a>
-        <a href="/docs/GETTING_STARTED" class="btn btn-primary btn-sm">Get Started</a>
+        <a href="/docs/GETTING_STARTED" class="btn btn-primary btn-sm">Developer Setup</a>
       </div>
 
       <button class="nav-toggle" id="nav-toggle" aria-label="Toggle menu">

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -27,7 +27,7 @@ const jsonLd = {
       "@id": "https://intercooperative.network/#website",
       "url": "https://intercooperative.network",
       "name": "InterCooperative Network",
-      "description": "Democratic infrastructure for cooperatives, communities, and federations.",
+      "description": "Institutional infrastructure for cooperative and federated organizations. Identity, governance, accounting, and coordination as auditable, member-owned infrastructure.",
       "publisher": { "@id": "https://intercooperative.network/#organization" }
     }
   ]

--- a/website/src/pages/about.astro
+++ b/website/src/pages/about.astro
@@ -19,8 +19,8 @@ if (fs.existsSync(visionPath)) {
         <h1>InterCooperative Network</h1>
         <p class="about-lead">
           Cooperatives built on extractive platforms are still extractive at the infrastructure layer.
-          ICN fixes that — democratic governance, cooperative economics, and
-          member-owned identity, all running on peer-to-peer infrastructure that no one owns but everyone operates.
+          ICN is building the alternative: governance, accounting, and identity running as
+          member-owned infrastructure on a peer-to-peer daemon — no central host required.
         </p>
         <div class="about-ctas">
           <a href="/docs/GETTING_STARTED" class="btn btn-primary">Try it now →</a>
@@ -82,7 +82,7 @@ if (fs.existsSync(visionPath)) {
             <div class="comp-row">
               <span>Governance</span>
               <span class="comp-old">Bureaucratic / Centralized</span>
-              <span class="comp-new">Bylaws that enforce themselves</span>
+              <span class="comp-new">Governance rules the system enforces</span>
             </div>
             <div class="comp-row">
               <span>Economics</span>

--- a/website/src/pages/community.astro
+++ b/website/src/pages/community.astro
@@ -32,7 +32,7 @@ import stats from '../data/stats.json';
           <p>Join conversations about cooperative technology, governance patterns, and ICN development.</p>
         </a>
 
-        <a href="/docs/CONTRIBUTING" class="community-card">
+        <a href="https://github.com/InterCooperative-Network/icn/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer" class="community-card">
           <div class="card-icon">🤝</div>
           <h3>Contributing Guide</h3>
           <p>Read the guidelines for contributing code, documentation, and architectural proposals.</p>

--- a/website/src/pages/docs/demo.astro
+++ b/website/src/pages/docs/demo.astro
@@ -17,9 +17,9 @@ import Layout from '../../layouts/Layout.astro';
         <span class="badge badge-green">Live on K3s</span>
         <h1>ICN Demo: Five Cooperative Flows</h1>
         <p class="lead">
-          Five cooperatives running on a real Kubernetes cluster.
+          Five demonstration organizations on a live K3s cluster.
           Five end-to-end flows covering governance, economics, federation, reporting, and compute.
-          Each flow issues cryptographic receipts — not mocked, not simulated.
+          Each flow produces cryptographic receipts — running against real infrastructure, not a sandbox.
         </p>
       </div>
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -35,15 +35,16 @@ const commitUrl = 'https://github.com/InterCooperative-Network/icn/commits/main'
 
         <div class="hero-actions">
           <a href="/docs/GETTING_STARTED" class="btn btn-primary">
-            Get Started
+            Developer Docs
             <svg class="btn-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"/></svg>
           </a>
           <a href="https://github.com/InterCooperative-Network/icn" target="_blank" class="btn btn-secondary">
             <svg class="btn-icon" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
             View on GitHub
           </a>
-          <a href="/about" class="btn btn-ghost">Learn More</a>
+          <a href="/about" class="btn btn-ghost">About the Project</a>
         </div>
+        <p class="hero-qualifier">Requires building from source — no hosted instance yet.</p>
       </div>
     </div>
       </div>
@@ -321,6 +322,10 @@ const commitUrl = 'https://github.com/InterCooperative-Network/icn/commits/main'
 </Layout>﻿
 <style>
 /* Hero */
+.hero-qualifier {
+  font-size: .8125rem; color: var(--text-muted);
+  margin: var(--space-sm) 0 0; letter-spacing: .01em;
+}
 .relative { position: relative; }
 .overflow-hidden { overflow: hidden; }
 .absolute { position: absolute; }

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -229,7 +229,7 @@ const commitUrl = 'https://github.com/InterCooperative-Network/icn/commits/main'
           </div>
           <div class="dev-ctas">
             <a href="/docs/GETTING_STARTED" class="btn btn-teal">Quick Start →</a>
-            <a href="/docs/CONTRIBUTING" class="btn btn-ghost">Contributing →</a>
+            <a href="https://github.com/InterCooperative-Network/icn/blob/main/CONTRIBUTING.md" target="_blank" class="btn btn-ghost">Contributing →</a>
             <a href="https://github.com/InterCooperative-Network/icn" target="_blank" class="btn btn-ghost">
               ★ Star on GitHub
             </a>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -6,7 +6,7 @@ import NetworkGraph from '../components/NetworkGraph.astro';
 const commitUrl = 'https://github.com/InterCooperative-Network/icn/commits/main';
 ---
 
-<Layout title="Democratic Infrastructure for Cooperatives" activeNav="home">
+<Layout title="Institutional Infrastructure for Cooperative Organizations" activeNav="home">
 
   <!-- ═══ HERO ═══════════════════════════════════════════════════ -->
   <section class="hero relative overflow-hidden">
@@ -22,14 +22,15 @@ const commitUrl = 'https://github.com/InterCooperative-Network/icn/commits/main'
         </div>
 
         <h1>
-          Build cooperatives<br/>
-          <span class="gradient-text">that govern themselves.</span>
+          Institutional infrastructure<br/>
+          <span class="gradient-text">for cooperative organizations.</span>
         </h1>
 
         <p>
-          ICN is democratic infrastructure for cooperatives, communities, and federations.
-          Charter your org, run democratic votes, coordinate your finances, and federate with peers —
-          on infrastructure no one owns but everyone runs.
+          ICN provides identity, governance, accounting, and trust as shared infrastructure —
+          not a platform, not a hosted service.
+          Auditable decisions, provenance receipts, and member-owned coordination
+          for real organizations.
         </p>
 
         <div class="hero-actions">
@@ -55,10 +56,10 @@ const commitUrl = 'https://github.com/InterCooperative-Network/icn/commits/main'
     <div class="container">
       <div class="section-header">
         <span class="badge badge-amber">What You Can Build</span>
-        <h2>From charter to treasury,<br/><span class="shimmer-text">with one stack.</span></h2>
+        <h2>From governance to settlement,<br/><span class="shimmer-text">with a real audit trail.</span></h2>
         <p>
-          ICN gives cooperatives the full stack: identity, governance, economics, and federation.
-          No platform fees. No central admin. No extractive middleman.
+          ICN provides the core institutional primitives: identity, governance, accounting, and coordination.
+          Built for organizations that need auditable decisions and member-owned infrastructure.
         </p>
       </div>
 
@@ -66,7 +67,7 @@ const commitUrl = 'https://github.com/InterCooperative-Network/icn/commits/main'
         <div class="use-case-card card card-accent-teal animate-in">
           <div class="card-icon">🏛️</div>
           <h3>Form a Cooperative</h3>
-          <p>Three people. One charter. Five minutes. Each member gets a cryptographic identity they control. Submit your founding rules, open your treasury, and start governing. No platform account required. No landlord.</p>
+          <p>Members get cryptographic identities they own and control. Submit founding rules as a CCL document. Open a treasury ledger. Start running proposals. No platform account, no central admin required.</p>
           <div class="card-footer">
             <span class="tech-pill">Identity · Crypto</span>
             <span class="tech-pill">Charter · Bylaws</span>
@@ -86,7 +87,7 @@ const commitUrl = 'https://github.com/InterCooperative-Network/icn/commits/main'
         <div class="use-case-card card card-accent-green animate-in animate-delay-2">
           <div class="card-icon">🌐</div>
           <h3>Federate With Others</h3>
-          <p>Connect your co-op to a network through trust agreements and mutual credit. Inter-cooperative clearing without a bank. Shared resources without a landlord.</p>
+          <p>Connect organizations through formal trust agreements. Shared trust graphs, cross-coop governance receipts, and coordinated accounting. Federation is a native protocol — not a bolt-on integration.</p>
           <div class="card-footer">
             <span class="tech-pill">Trust Graph</span>
             <span class="tech-pill">Mutual Credit</span>
@@ -101,7 +102,7 @@ const commitUrl = 'https://github.com/InterCooperative-Network/icn/commits/main'
       <div class="demo-callout">
         <div class="demo-text">
           <span class="badge badge-green">Live on K3s</span>
-          <h2>Five cooperatives.<br/>Running now.</h2>
+          <h2>Five coordination flows.<br/>Running on live infrastructure.</h2>
           <p>
             Brightworks Collective governs by vote. Harbor Freight Workers settles patronage dividends.
             Rochester Cooperative Clearinghouse runs the treasury. New England Mesh files compliance reports.
@@ -243,10 +244,10 @@ const commitUrl = 'https://github.com/InterCooperative-Network/icn/commits/main'
     <div class="container">
       <div class="section-header">
         <span class="badge badge-purple">Digital Public Infrastructure</span>
-        <h2>Not a startup. Not a protocol.<br/><span class="gradient-text-warm">Infrastructure for the cooperative economy.</span></h2>
+        <h2>Four stages.<br/><span class="gradient-text-warm">Built in sequence.</span></h2>
         <p>
-          ICN replaces extractive platforms with cooperative ownership at every layer —
-          from the individual co-op to municipal governance. Four stages, built in sequence.
+          ICN is infrastructure-in-progress, built in traceable stages.
+          Each stage extends what real organizations can do with it.
         </p>
       </div>
 
@@ -287,8 +288,8 @@ const commitUrl = 'https://github.com/InterCooperative-Network/icn/commits/main'
         <div class="stage-card card animate-in animate-delay-3">
           <div class="stage-num stage-d">D</div>
           <div class="stage-body">
-            <h3>Civilization Tools</h3>
-            <p>Participatory budgeting at city scale. Municipal governance platforms. Public infrastructure coordination. The long-term vision: democratic technology governance beyond the co-op.</p>
+            <h3>Civic and Public Scale</h3>
+            <p>Participatory budgeting, municipal governance, and public infrastructure coordination. Long-term trajectory — the architecture is designed for it, but this work is not yet underway.</p>
           </div>
         </div>
       </div>
@@ -303,10 +304,11 @@ const commitUrl = 'https://github.com/InterCooperative-Network/icn/commits/main'
   <section class="section-alt">
     <div class="container">
       <div class="cta-box">
-        <h2>Build the cooperative internet.</h2>
+        <h2>Cooperative infrastructure, built in the open.</h2>
         <p>
-          Contribute to infrastructure that replaces extractive systems with cooperative ownership.
-          Your governance. Your economics. Your infrastructure. No permission required.
+          ICN is open source infrastructure for organizations that need auditable governance,
+          member-owned accounting, and coordinated federation.
+          Contributions welcome — code, documentation, governance patterns, or use cases.
         </p>
         <div class="hero-actions" style="justify-content: center;">
           <a href="/docs/GETTING_STARTED" class="btn btn-primary">Get Started →</a>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -230,8 +230,8 @@ const commitUrl = 'https://github.com/InterCooperative-Network/icn/commits/main'
           </div>
           <div class="dev-ctas">
             <a href="/docs/GETTING_STARTED" class="btn btn-teal">Quick Start →</a>
-            <a href="https://github.com/InterCooperative-Network/icn/blob/main/CONTRIBUTING.md" target="_blank" class="btn btn-ghost">Contributing →</a>
-            <a href="https://github.com/InterCooperative-Network/icn" target="_blank" class="btn btn-ghost">
+            <a href="https://github.com/InterCooperative-Network/icn/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer" class="btn btn-ghost">Contributing →</a>
+            <a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener noreferrer" class="btn btn-ghost">
               ★ Star on GitHub
             </a>
           </div>


### PR DESCRIPTION
## Summary

This PR improves website credibility and user experience by:
- removing broken or misleading links
- reducing manifesto-style copy
- aligning language with current ICN capabilities
- making onboarding expectations explicit

## What changed

- **Homepage copy:** reduced hype/overclaiming, improved clarity
- **Demo section:** no longer implies live production cooperatives
- **Fixed broken `/docs/CONTRIBUTING` links** → GitHub CONTRIBUTING.md
- **Onboarding:**
  - "Get Started" → "Developer Docs"
  - added "requires building from source" qualifier
  - clearer non-developer path ("About the Project")
- **Layout/meta:**
  - removed repeated "no one owns but everyone runs"
  - replaced with concrete institutional description
- **Added:** `docs/deployment/ICN_ZONE_ROUTING.md`
  - defines root redirect + short-link model for icn.zone

## Why

- Prevents trust damage from broken links and demo-like claims
- Aligns site messaging with actual system state
- Makes it clear ICN is infrastructure-in-progress, not a hosted product
- Establishes a clean plan for icn.zone as a utility domain

## Validation

- `npm run build` passed (no errors, 661 pages)
- Manual audit of all links and CTAs
- No layout changes introduced

## Known boundaries / not included

- No hosted demo added
- No new onboarding flow beyond labeling/clarity
- No visual redesign
- No proof artifact (e.g. GovernanceReceipt) added yet
- icn.zone routing not implemented yet (plan only)

## Follow-ups

- Add one concrete proof surface (e.g. receipt example from live demo run)
- Improve onboarding split for builders vs organizations
- Implement Cloudflare redirect rule for icn.zone root