### PR TITLE
feat(governance): close resource-access dispatch gap

### DIFF
--- a/icn/apps/ledger/src/init.rs
+++ b/icn/apps/ledger/src/init.rs
@@ -1,7 +1,8 @@
 //! Initialization helper for ledger stores.
 //!
 //! Mirrors `apps/governance/src/init.rs` — the caller provides a store path
-//! and receives ready-to-use `Arc<dyn EscrowStore>` and `Arc<dyn BudgetStore>`.
+//! and receives ready-to-use `Arc<dyn EscrowStore>`, `Arc<dyn BudgetStore>`,
+//! and `Arc<dyn ResourceAccessStore>`.
 
 use std::path::Path;
 use std::sync::Arc;
@@ -9,10 +10,12 @@ use std::sync::Arc;
 use anyhow::Result;
 use icn_kernel_api::budget::BudgetStore;
 use icn_kernel_api::escrow::EscrowStore;
+use icn_kernel_api::resource::ResourceAccessStore;
 use icn_store::SledStore;
 
 use crate::budget::SledBudgetStore;
 use crate::escrow::SledEscrowStore;
+use crate::resource_access::SledResourceAccessStore;
 
 /// Stores returned from ledger initialization.
 pub struct LedgerStores {
@@ -20,13 +23,16 @@ pub struct LedgerStores {
     pub escrow_store: Arc<dyn EscrowStore>,
     /// Budget store for budget enforcement.
     pub budget_store: Arc<dyn BudgetStore>,
+    /// Resource access store for governance-authorized grants.
+    pub resource_access_store: Arc<dyn ResourceAccessStore>,
 }
 
-/// Create the ledger stores (escrow + budget) rooted at `store_path`.
+/// Create the ledger stores (escrow + budget + resource_access) rooted at `store_path`.
 ///
 /// Opens:
 /// - `<store_path>/escrow/` — Sled KV store via `icn_store::SledStore`
 /// - `<store_path>/budget/` — Sled DB with a named tree
+/// - `<store_path>/resource_access/` — Sled DB with a named tree
 pub fn create_stores(store_path: &Path) -> Result<LedgerStores> {
     let escrow_store_path = store_path.join("escrow");
     let escrow_sled_store: Arc<SledStore> = Arc::new(SledStore::open(&escrow_store_path)?);
@@ -36,8 +42,14 @@ pub fn create_stores(store_path: &Path) -> Result<LedgerStores> {
     let budget_sled_db = sled::open(&budget_store_path)?;
     let budget_store: Arc<dyn BudgetStore> = Arc::new(SledBudgetStore::new(&budget_sled_db)?);
 
+    let resource_access_path = store_path.join("resource_access");
+    let resource_access_db = sled::open(&resource_access_path)?;
+    let resource_access_store: Arc<dyn ResourceAccessStore> =
+        Arc::new(SledResourceAccessStore::new(&resource_access_db)?);
+
     Ok(LedgerStores {
         escrow_store,
         budget_store,
+        resource_access_store,
     })
 }

--- a/icn/apps/ledger/src/lib.rs
+++ b/icn/apps/ledger/src/lib.rs
@@ -6,3 +6,4 @@
 pub mod budget;
 pub mod escrow;
 pub mod init;
+pub mod resource_access;

--- a/icn/apps/ledger/src/resource_access.rs
+++ b/icn/apps/ledger/src/resource_access.rs
@@ -1,0 +1,219 @@
+//! Sled-backed resource access grant store.
+//!
+//! Stores governance-authorized resource access records keyed by
+//! `access:{resource_type}:{grantee_did}` under the `exec:resource` sled tree.
+//!
+//! Records carry the governance `decision_hash` for a complete audit trail
+//! from proposal → effect → persisted grant.
+
+use anyhow::Result;
+use icn_kernel_api::resource::{ResourceAccessRecord, ResourceAccessStore};
+
+/// Sled-backed implementation of [`ResourceAccessStore`].
+pub struct SledResourceAccessStore {
+    tree: sled::Tree,
+}
+
+impl SledResourceAccessStore {
+    /// Open or create the resource access store in the given sled DB.
+    pub fn new(db: &sled::Db) -> Result<Self> {
+        let tree = db.open_tree("exec:resource")?;
+        Ok(Self { tree })
+    }
+
+    fn key(resource_type: &str, grantee_did: &str) -> Vec<u8> {
+        format!("access:{}:{}", resource_type, grantee_did).into_bytes()
+    }
+
+    fn active_prefix() -> &'static str {
+        "access:"
+    }
+}
+
+impl ResourceAccessStore for SledResourceAccessStore {
+    fn grant(&self, record: &ResourceAccessRecord) -> Result<()> {
+        let key = Self::key(&record.resource_type, &record.grantee_did);
+
+        // Idempotency: if the exact same decision_hash is already stored, skip.
+        if let Some(bytes) = self.tree.get(&key)? {
+            let existing: ResourceAccessRecord = serde_json::from_slice(&bytes)?;
+            if existing.decision_hash == record.decision_hash {
+                return Ok(());
+            }
+        }
+
+        let bytes = serde_json::to_vec(record)?;
+        self.tree.insert(key, bytes)?;
+        self.tree.flush()?;
+        Ok(())
+    }
+
+    fn revoke(
+        &self,
+        resource_type: &str,
+        grantee_did: &str,
+        revoked_at: u64,
+        reason: &str,
+    ) -> Result<()> {
+        let key = Self::key(resource_type, grantee_did);
+        if let Some(bytes) = self.tree.get(&key)? {
+            let mut record: ResourceAccessRecord = serde_json::from_slice(&bytes)?;
+            if record.is_revoked {
+                return Ok(()); // Already revoked — no-op.
+            }
+            record.is_revoked = true;
+            record.revoked_at = Some(revoked_at);
+            record.revocation_reason = Some(reason.to_string());
+            let updated = serde_json::to_vec(&record)?;
+            self.tree.insert(key, updated)?;
+            self.tree.flush()?;
+        }
+        Ok(())
+    }
+
+    fn get(&self, resource_type: &str, grantee_did: &str) -> Result<Option<ResourceAccessRecord>> {
+        let key = Self::key(resource_type, grantee_did);
+        match self.tree.get(key)? {
+            Some(bytes) => {
+                let record: ResourceAccessRecord = serde_json::from_slice(&bytes)?;
+                Ok(Some(record))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn list_active(&self) -> Result<Vec<ResourceAccessRecord>> {
+        let prefix = Self::active_prefix();
+        let mut records = Vec::new();
+
+        for entry in self.tree.scan_prefix(prefix.as_bytes()) {
+            let (_, bytes) = entry?;
+            let record: ResourceAccessRecord = serde_json::from_slice(&bytes)?;
+            if !record.is_revoked {
+                records.push(record);
+            }
+        }
+
+        Ok(records)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn temp_db() -> sled::Db {
+        sled::Config::new().temporary(true).open().unwrap()
+    }
+
+    fn make_record(
+        resource_type: &str,
+        grantee_did: &str,
+        decision_hash: &str,
+    ) -> ResourceAccessRecord {
+        ResourceAccessRecord {
+            resource_type: resource_type.to_string(),
+            grantee_did: grantee_did.to_string(),
+            access_model_hash: "hash-abc".to_string(),
+            granted_at: 1_000_000,
+            decision_hash: decision_hash.to_string(),
+            is_revoked: false,
+            revoked_at: None,
+            revocation_reason: None,
+        }
+    }
+
+    #[test]
+    fn test_grant_and_get() {
+        let db = temp_db();
+        let store = SledResourceAccessStore::new(&db).unwrap();
+        let rec = make_record("compute-cluster-alpha", "did:icn:alice", "decision-1");
+        store.grant(&rec).unwrap();
+        let got = store
+            .get("compute-cluster-alpha", "did:icn:alice")
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.decision_hash, "decision-1");
+        assert!(!got.is_revoked);
+    }
+
+    #[test]
+    fn test_grant_is_idempotent_on_same_decision_hash() {
+        let db = temp_db();
+        let store = SledResourceAccessStore::new(&db).unwrap();
+        let rec = make_record("resource-x", "did:icn:bob", "decision-2");
+        store.grant(&rec).unwrap();
+        store.grant(&rec).unwrap(); // Second call with same hash is no-op
+        let got = store.get("resource-x", "did:icn:bob").unwrap().unwrap();
+        assert_eq!(got.granted_at, 1_000_000);
+    }
+
+    #[test]
+    fn test_revoke_sets_is_revoked() {
+        let db = temp_db();
+        let store = SledResourceAccessStore::new(&db).unwrap();
+        let rec = make_record("storage-vol-1", "did:icn:carol", "decision-3");
+        store.grant(&rec).unwrap();
+        store
+            .revoke(
+                "storage-vol-1",
+                "did:icn:carol",
+                2_000_000,
+                "governance revoked",
+            )
+            .unwrap();
+        let got = store
+            .get("storage-vol-1", "did:icn:carol")
+            .unwrap()
+            .unwrap();
+        assert!(got.is_revoked);
+        assert_eq!(got.revoked_at, Some(2_000_000));
+        assert_eq!(got.revocation_reason.as_deref(), Some("governance revoked"));
+    }
+
+    #[test]
+    fn test_revoke_is_idempotent() {
+        let db = temp_db();
+        let store = SledResourceAccessStore::new(&db).unwrap();
+        let rec = make_record("resource-y", "did:icn:dave", "decision-4");
+        store.grant(&rec).unwrap();
+        store
+            .revoke("resource-y", "did:icn:dave", 2_000_000, "first")
+            .unwrap();
+        store
+            .revoke("resource-y", "did:icn:dave", 3_000_000, "second")
+            .unwrap();
+        let got = store.get("resource-y", "did:icn:dave").unwrap().unwrap();
+        // Second revoke is a no-op; revoked_at stays at first value
+        assert_eq!(got.revoked_at, Some(2_000_000));
+    }
+
+    #[test]
+    fn test_list_active_excludes_revoked() {
+        let db = temp_db();
+        let store = SledResourceAccessStore::new(&db).unwrap();
+        store
+            .grant(&make_record("res-a", "did:icn:alice", "d-a"))
+            .unwrap();
+        store
+            .grant(&make_record("res-b", "did:icn:alice", "d-b"))
+            .unwrap();
+        store
+            .revoke("res-a", "did:icn:alice", 9_000, "test")
+            .unwrap();
+        let active = store.list_active().unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].resource_type, "res-b");
+    }
+
+    #[test]
+    fn test_revoke_nonexistent_is_noop() {
+        let db = temp_db();
+        let store = SledResourceAccessStore::new(&db).unwrap();
+        // Should not error even if grant doesn't exist
+        store
+            .revoke("no-such-resource", "did:icn:nobody", 1_000, "reason")
+            .unwrap();
+    }
+}

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -17,7 +17,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use icn_kernel_api::budget::{BeginSpendOutcome, BudgetRecord, BudgetSpendError, BudgetStore};
 use icn_kernel_api::effects::{
-    ControlEffect, EffectResult, KernelEffect, MembershipEffect, TreasuryEffect,
+    ControlEffect, EffectResult, KernelEffect, MembershipEffect, ResourceEffect, TreasuryEffect,
 };
 use icn_kernel_api::escrow::{BeginReleaseOutcome, EscrowReleaseError, EscrowStore};
 use icn_kernel_api::governance::{
@@ -26,6 +26,7 @@ use icn_kernel_api::governance::{
     ProtocolChange, ProtocolExecutor, TreasuryExecutor, TreasuryOperation,
 };
 use icn_kernel_api::protocol_params::ProtocolParameterStore;
+use icn_kernel_api::resource::{ResourceAccessRecord, ResourceAccessStore};
 use icn_kernel_api::{ControlService, ForceCloseProposalRequest, VetoProposalRequest};
 use sha2::{Digest, Sha256};
 use tracing::{info, warn};
@@ -47,6 +48,8 @@ pub struct KernelGovernanceExecutor {
     escrow_store: Option<Arc<dyn EscrowStore>>,
     /// Budget store for budget enforcement.
     budget_store: Option<Arc<dyn BudgetStore>>,
+    /// Resource access store for governance-authorized grants and revocations.
+    resource_store: Option<Arc<dyn ResourceAccessStore>>,
 }
 
 impl KernelGovernanceExecutor {
@@ -64,6 +67,7 @@ impl KernelGovernanceExecutor {
             membership: Arc::new(KernelMembershipExecutor::new()),
             escrow_store: None,
             budget_store: None,
+            resource_store: None,
         }
     }
 
@@ -108,6 +112,12 @@ impl KernelGovernanceExecutor {
     /// Set the budget store for budget enforcement.
     pub fn with_budget_store(mut self, store: Arc<dyn BudgetStore>) -> Self {
         self.budget_store = Some(store);
+        self
+    }
+
+    /// Set the resource access store for governance-authorized grant/revocation.
+    pub fn with_resource_access_store(mut self, store: Arc<dyn ResourceAccessStore>) -> Self {
+        self.resource_store = Some(store);
         self
     }
 
@@ -692,21 +702,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                 })
             }
             KernelEffect::Resource(resource_effect) => {
-                info!(
-                    ?resource_effect,
-                    "Executing resource effect (not implemented in kernel executor)"
-                );
-                Ok(EffectResult {
-                    effect_id: decision_receipt_id.to_string(),
-                    success: false,
-                    message: format!(
-                        "Resource effect not implemented in kernel executor: {:?}",
-                        resource_effect
-                    ),
-                    state_change_hash: None,
-                    ledger_entry_id: None,
-                    not_executed: false,
-                })
+                self.execute_resource_effect(&resource_effect, decision_receipt_id)
             }
             KernelEffect::Sdis(sdis_effect) => {
                 info!(
@@ -724,6 +720,117 @@ impl EffectExecutor for KernelGovernanceExecutor {
                     ledger_entry_id: None,
                     not_executed: false,
                 })
+            }
+        }
+    }
+}
+
+impl KernelGovernanceExecutor {
+    /// Execute a resource access effect: grant or revoke access in the resource store.
+    ///
+    /// If no `resource_store` is wired, the effect is rejected with an explicit failure
+    /// (not `not_executed`) so the decision executor can log it as a hard failure and
+    /// surface it in monitoring rather than silently dropping it.
+    fn execute_resource_effect(
+        &self,
+        effect: &ResourceEffect,
+        decision_receipt_id: &str,
+    ) -> Result<EffectResult> {
+        let store = match &self.resource_store {
+            Some(s) => s,
+            None => {
+                return Ok(EffectResult {
+                    effect_id: decision_receipt_id.to_string(),
+                    success: false,
+                    message: "Resource access store not wired — cannot persist grant/revoke"
+                        .to_string(),
+                    state_change_hash: None,
+                    ledger_entry_id: None,
+                    not_executed: false,
+                });
+            }
+        };
+
+        // Use wall-clock time for `granted_at` / `revoked_at`.
+        // The kernel does not own authoritative time; this is advisory metadata.
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        match effect {
+            ResourceEffect::GrantAccess {
+                grantee_did,
+                resource_type,
+                access_model_hash,
+            } => {
+                info!(
+                    grantee_did = %grantee_did,
+                    resource_type = %resource_type,
+                    "Granting resource access via governance decision"
+                );
+                let record = ResourceAccessRecord {
+                    resource_type: resource_type.clone(),
+                    grantee_did: grantee_did.clone(),
+                    access_model_hash: access_model_hash.clone(),
+                    granted_at: now_secs,
+                    decision_hash: decision_receipt_id.to_string(),
+                    is_revoked: false,
+                    revoked_at: None,
+                    revocation_reason: None,
+                };
+                match store.grant(&record) {
+                    Ok(()) => Ok(EffectResult {
+                        effect_id: decision_receipt_id.to_string(),
+                        success: true,
+                        message: format!(
+                            "Resource access granted: {} → {}",
+                            grantee_did, resource_type
+                        ),
+                        state_change_hash: Some(access_model_hash.clone()),
+                        ledger_entry_id: None,
+                        not_executed: false,
+                    }),
+                    Err(e) => Ok(EffectResult {
+                        effect_id: decision_receipt_id.to_string(),
+                        success: false,
+                        message: format!("Failed to persist resource grant: {}", e),
+                        state_change_hash: None,
+                        ledger_entry_id: None,
+                        not_executed: false,
+                    }),
+                }
+            }
+            ResourceEffect::RevokeAccess {
+                grantee_did,
+                resource_type,
+            } => {
+                info!(
+                    grantee_did = %grantee_did,
+                    resource_type = %resource_type,
+                    "Revoking resource access via governance decision"
+                );
+                match store.revoke(resource_type, grantee_did, now_secs, "governance decision") {
+                    Ok(()) => Ok(EffectResult {
+                        effect_id: decision_receipt_id.to_string(),
+                        success: true,
+                        message: format!(
+                            "Resource access revoked: {} → {}",
+                            grantee_did, resource_type
+                        ),
+                        state_change_hash: None,
+                        ledger_entry_id: None,
+                        not_executed: false,
+                    }),
+                    Err(e) => Ok(EffectResult {
+                        effect_id: decision_receipt_id.to_string(),
+                        success: false,
+                        message: format!("Failed to persist resource revocation: {}", e),
+                        state_change_hash: None,
+                        ledger_entry_id: None,
+                        not_executed: false,
+                    }),
+                }
             }
         }
     }

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -2653,8 +2653,8 @@ mod tests {
         assert!(
             effect_result
                 .message
-                .contains("Resource effect not implemented in kernel executor"),
-            "Failure message should explain missing kernel implementation: {}",
+                .contains("Resource access store not wired"),
+            "Failure message should explain missing resource store: {}",
             effect_result.message
         );
     }

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -829,7 +829,9 @@ async fn spawn_actors_with_identity(
         let escrow_store = ledger_stores.escrow_store;
         kernel_executor = kernel_executor.with_escrow_store(escrow_store.clone());
         kernel_executor = kernel_executor.with_budget_store(ledger_stores.budget_store);
-        info!("✓ Escrow and budget stores wired to governance executor");
+        kernel_executor =
+            kernel_executor.with_resource_access_store(ledger_stores.resource_access_store);
+        info!("✓ Escrow, budget, and resource access stores wired to governance executor");
 
         // Create effect dispatcher
         let effect_dispatcher = Arc::new(super::effect_dispatcher::EffectDispatcher::new(

--- a/icn/crates/icn-core/tests/resource_access_governance_integration.rs
+++ b/icn/crates/icn-core/tests/resource_access_governance_integration.rs
@@ -1,0 +1,242 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! Integration test: governance-authorized resource access.
+//!
+//! Proves that:
+//! 1. An accepted `GrantAccess` effect writes a persisted record with decision provenance.
+//! 2. A subsequent `RevokeAccess` effect marks that record revoked.
+//! 3. Replaying the same `GrantAccess` is idempotent (same decision_hash → no-op).
+//! 4. Without a wired store the executor returns an explicit hard failure (not a silent pass).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use icn_core::supervisor::governance_executor::KernelGovernanceExecutor;
+use icn_governance::InMemoryParameterStore;
+use icn_kernel_api::effects::{KernelEffect, ResourceEffect};
+use icn_kernel_api::governance::EffectExecutor;
+use icn_kernel_api::resource::{ResourceAccessRecord, ResourceAccessStore};
+
+// ─── In-memory store (test-only) ────────────────────────────────────────────
+
+#[derive(Default)]
+struct MemoryResourceAccessStore {
+    records: Mutex<HashMap<(String, String), ResourceAccessRecord>>,
+}
+
+impl ResourceAccessStore for MemoryResourceAccessStore {
+    fn grant(&self, record: &ResourceAccessRecord) -> Result<()> {
+        let key = (record.resource_type.clone(), record.grantee_did.clone());
+        let mut map = self.records.lock().unwrap();
+        if let Some(existing) = map.get(&key) {
+            if existing.decision_hash == record.decision_hash {
+                return Ok(()); // Idempotent
+            }
+        }
+        map.insert(key, record.clone());
+        Ok(())
+    }
+
+    fn revoke(
+        &self,
+        resource_type: &str,
+        grantee_did: &str,
+        revoked_at: u64,
+        reason: &str,
+    ) -> Result<()> {
+        let key = (resource_type.to_string(), grantee_did.to_string());
+        let mut map = self.records.lock().unwrap();
+        if let Some(rec) = map.get_mut(&key) {
+            if !rec.is_revoked {
+                rec.is_revoked = true;
+                rec.revoked_at = Some(revoked_at);
+                rec.revocation_reason = Some(reason.to_string());
+            }
+        }
+        Ok(())
+    }
+
+    fn get(&self, resource_type: &str, grantee_did: &str) -> Result<Option<ResourceAccessRecord>> {
+        let key = (resource_type.to_string(), grantee_did.to_string());
+        Ok(self.records.lock().unwrap().get(&key).cloned())
+    }
+
+    fn list_active(&self) -> Result<Vec<ResourceAccessRecord>> {
+        Ok(self
+            .records
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|r| !r.is_revoked)
+            .cloned()
+            .collect())
+    }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+fn executor_with_store(store: Arc<MemoryResourceAccessStore>) -> KernelGovernanceExecutor {
+    let param_store = Arc::new(InMemoryParameterStore::new());
+    KernelGovernanceExecutor::new(param_store)
+        .with_resource_access_store(store as Arc<dyn ResourceAccessStore>)
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+/// An accepted GrantAccess effect persists a record with the decision hash.
+#[tokio::test]
+async fn grant_access_persists_record_with_decision_provenance() {
+    let store = Arc::new(MemoryResourceAccessStore::default());
+    let executor = executor_with_store(store.clone());
+
+    let effect = KernelEffect::Resource(ResourceEffect::GrantAccess {
+        grantee_did: "did:icn:alice".to_string(),
+        resource_type: "compute-cluster-alpha".to_string(),
+        access_model_hash: "hash-model-read-only".to_string(),
+    });
+
+    let result = executor
+        .execute_effect(effect, "receipt-grant-001")
+        .await
+        .unwrap();
+
+    assert!(
+        result.success,
+        "GrantAccess must succeed; got: {}",
+        result.message
+    );
+    assert!(!result.not_executed, "GrantAccess must not be not_executed");
+
+    let record = store
+        .get("compute-cluster-alpha", "did:icn:alice")
+        .unwrap()
+        .expect("record must be persisted after GrantAccess");
+
+    assert_eq!(record.grantee_did, "did:icn:alice");
+    assert_eq!(record.resource_type, "compute-cluster-alpha");
+    assert_eq!(record.access_model_hash, "hash-model-read-only");
+    // The decision_hash stored in the record must match the receipt ID passed to execute_effect.
+    assert_eq!(record.decision_hash, "receipt-grant-001");
+    assert!(!record.is_revoked);
+}
+
+/// A subsequent RevokeAccess effect marks the record revoked.
+#[tokio::test]
+async fn revoke_access_marks_record_revoked() {
+    let store = Arc::new(MemoryResourceAccessStore::default());
+    let executor = executor_with_store(store.clone());
+
+    let grant = KernelEffect::Resource(ResourceEffect::GrantAccess {
+        grantee_did: "did:icn:bob".to_string(),
+        resource_type: "storage-vol-1".to_string(),
+        access_model_hash: "hash-rw".to_string(),
+    });
+    executor
+        .execute_effect(grant, "receipt-grant-002")
+        .await
+        .unwrap();
+
+    let revoke = KernelEffect::Resource(ResourceEffect::RevokeAccess {
+        grantee_did: "did:icn:bob".to_string(),
+        resource_type: "storage-vol-1".to_string(),
+    });
+    let result = executor
+        .execute_effect(revoke, "receipt-revoke-002")
+        .await
+        .unwrap();
+
+    assert!(
+        result.success,
+        "RevokeAccess must succeed; got: {}",
+        result.message
+    );
+
+    let record = store
+        .get("storage-vol-1", "did:icn:bob")
+        .unwrap()
+        .expect("record must still exist after revocation");
+
+    assert!(record.is_revoked, "record must be marked revoked");
+    assert!(record.revoked_at.is_some(), "revoked_at must be set");
+    assert_eq!(
+        record.revocation_reason.as_deref(),
+        Some("governance decision")
+    );
+
+    let active = store.list_active().unwrap();
+    assert!(
+        active
+            .iter()
+            .all(|r| !(r.resource_type == "storage-vol-1" && r.grantee_did == "did:icn:bob")),
+        "revoked record must not appear in list_active"
+    );
+}
+
+/// Replaying a GrantAccess with the same decision hash is idempotent.
+#[tokio::test]
+async fn grant_access_replay_is_idempotent() {
+    let store = Arc::new(MemoryResourceAccessStore::default());
+    let executor = executor_with_store(store.clone());
+
+    let make_effect = || {
+        KernelEffect::Resource(ResourceEffect::GrantAccess {
+            grantee_did: "did:icn:carol".to_string(),
+            resource_type: "network-segment-3".to_string(),
+            access_model_hash: "hash-net".to_string(),
+        })
+    };
+
+    let r1 = executor
+        .execute_effect(make_effect(), "receipt-idempotent-003")
+        .await
+        .unwrap();
+    assert!(r1.success);
+    let after_first = store
+        .get("network-segment-3", "did:icn:carol")
+        .unwrap()
+        .unwrap();
+
+    let r2 = executor
+        .execute_effect(make_effect(), "receipt-idempotent-003")
+        .await
+        .unwrap();
+    assert!(r2.success, "replay must succeed");
+    let after_replay = store
+        .get("network-segment-3", "did:icn:carol")
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        after_first.granted_at, after_replay.granted_at,
+        "idempotent replay must not change granted_at"
+    );
+}
+
+/// Without a wired store, GrantAccess returns an explicit hard failure.
+#[tokio::test]
+async fn grant_access_without_store_is_explicit_failure() {
+    let param_store = Arc::new(InMemoryParameterStore::new());
+    let executor = KernelGovernanceExecutor::new(param_store);
+
+    let effect = KernelEffect::Resource(ResourceEffect::GrantAccess {
+        grantee_did: "did:icn:dave".to_string(),
+        resource_type: "resource-unwired".to_string(),
+        access_model_hash: "hash-x".to_string(),
+    });
+
+    let result = executor
+        .execute_effect(effect, "receipt-no-store")
+        .await
+        .unwrap();
+
+    assert!(!result.success, "must fail without wired store");
+    assert!(
+        !result.not_executed,
+        "must be hard failure, not not_executed"
+    );
+    assert!(
+        result.message.contains("not wired"),
+        "error message must mention missing store; got: {}",
+        result.message
+    );
+}

--- a/icn/crates/icn-kernel-api/src/lib.rs
+++ b/icn/crates/icn-kernel-api/src/lib.rs
@@ -52,6 +52,7 @@ pub mod naming;
 pub mod proofs;
 pub mod protocol_params;
 pub mod receipts;
+pub mod resource;
 pub mod scope;
 pub mod services;
 pub mod state;
@@ -104,6 +105,7 @@ pub use proofs::ArtifactReceipt;
 pub use receipts::{
     compute_canonical_hash, AllocationReceipt, CanonicalReceipt, Hash, ProvenanceAnchors, ReceiptId,
 };
+pub use resource::{ResourceAccessRecord, ResourceAccessStore};
 pub use scope::{CellId, MockCellService, ScopeLevel};
 pub use services::{
     AddMemberRequest, AddMemberResult, CellService, ClearingAgreementView, ClearingPositionView,

--- a/icn/crates/icn-kernel-api/src/resource.rs
+++ b/icn/crates/icn-kernel-api/src/resource.rs
@@ -1,0 +1,74 @@
+//! Kernel-safe resource access grant store trait.
+//!
+//! The kernel records governance-authorized resource access grants here so that:
+//! 1. The governance effect path persists grants with decision provenance.
+//! 2. The `ResourceAccessEnforcerActor` can later query grants for idle-revocation.
+//!
+//! # Pattern
+//!
+//! Follows the same pattern as [`crate::budget::BudgetStore`]:
+//! - Trait defined here (kernel API boundary).
+//! - Sled-backed implementation lives in `apps/ledger`.
+//! - Injected into `KernelGovernanceExecutor` via `with_resource_access_store()`.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+/// A persisted resource access grant record.
+///
+/// Carries the governance decision hash for a complete audit trail from
+/// proposal → effect → persisted grant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceAccessRecord {
+    /// The resource type (opaque string; domain-defined by the app layer).
+    pub resource_type: String,
+    /// DID of the entity that was granted access.
+    pub grantee_did: String,
+    /// Blake3 hash of the access model (for verifiable audit without importing domain types).
+    pub access_model_hash: String,
+    /// When access was granted (seconds since epoch).
+    pub granted_at: u64,
+    /// Governance decision hash — links this grant to the proposal that authorized it.
+    pub decision_hash: String,
+    /// Whether this grant has been revoked.
+    pub is_revoked: bool,
+    /// When the grant was revoked (seconds since epoch), if applicable.
+    pub revoked_at: Option<u64>,
+    /// Reason for revocation, if revoked.
+    pub revocation_reason: Option<String>,
+}
+
+/// Store for governance-authorized resource access grants.
+///
+/// # Idempotency
+///
+/// `grant()` is idempotent on `(resource_type, grantee_did, decision_hash)`:
+/// if a record with the same key already exists with the same decision hash,
+/// implementations MUST return `Ok(())` without modifying the record.
+pub trait ResourceAccessStore: Send + Sync {
+    /// Persist a new access grant.
+    ///
+    /// Idempotent: if a record already exists for `(resource_type, grantee_did)`
+    /// with the same `decision_hash`, this is a no-op and returns `Ok(())`.
+    fn grant(&self, record: &ResourceAccessRecord) -> Result<()>;
+
+    /// Mark an existing grant as revoked.
+    ///
+    /// No-op if the grant does not exist or is already revoked.
+    fn revoke(
+        &self,
+        resource_type: &str,
+        grantee_did: &str,
+        revoked_at: u64,
+        reason: &str,
+    ) -> Result<()>;
+
+    /// Get the current record for a specific `(resource_type, grantee_did)` pair.
+    fn get(&self, resource_type: &str, grantee_did: &str) -> Result<Option<ResourceAccessRecord>>;
+
+    /// List all active (non-revoked) grants.
+    ///
+    /// Used by `LedgerService::list_enforceable_resources()` to feed the
+    /// `ResourceAccessEnforcerActor` with governance-granted resources.
+    fn list_active(&self) -> Result<Vec<ResourceAccessRecord>>;
+}


### PR DESCRIPTION
## Summary

- `KernelEffect::Resource(GrantAccess/RevokeAccess)` was a hard stub returning `success: false`. Accepted `ResourceAccess` proposals had no operational effect.
- Adds `ResourceAccessStore` trait (kernel-api) + `SledResourceAccessStore` impl (apps/ledger) following the `BudgetStore` pattern exactly.
- Fills the stub in `governance_executor.rs`: GrantAccess persists a sled record with `decision_hash`, `access_model_hash`, `grantee_did`, `granted_at`. RevokeAccess marks it revoked. Both are idempotent.
- Wires the store in `lifecycle.rs` alongside the existing escrow/budget stores.
- Missing store = explicit hard failure (surfaced in monitoring, not silently swallowed).

## What is real now

An accepted `ResourceAccess` governance proposal now:
1. Persists a `ResourceAccessRecord` in sled (`exec:resource` tree)
2. Carries the `decision_hash` for full provenance linkage
3. Is queryable via `list_active()` for idle-revocation enforcement (enforcer wiring is the natural next step)

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p icn-core --test resource_access_governance_integration` — 4/4 pass:
  - `grant_access_persists_record_with_decision_provenance`
  - `revoke_access_marks_record_revoked`
  - `grant_access_replay_is_idempotent`
  - `grant_access_without_store_is_explicit_failure`
- [x] `cargo test -p icn-ledger-actor` — 15/15 pass (includes 6 new sled store unit tests)

## Next best task

Wire `LedgerServiceImpl::list_enforceable_resources()` to `ResourceAccessStore::list_active()` so the `ResourceAccessEnforcerActor` picks up governance-granted resources for idle-revocation enforcement. That closes the full governance → grant → auto-revocation loop.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)