### PR TITLE
feat(membership): close governance→execution provenance seam for all membership actions

### DIFF
--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -1898,12 +1898,18 @@ impl GovernanceActor {
                     let event = match outcome_result {
                         DecisionOutcome::Accepted => {
                             match serde_json::to_value(&proposal.payload) {
-                                Ok(payload) => SystemEvent::ProposalAccepted {
-                                    proposal_id: proposal_id.0.clone(),
-                                    domain_id: proposal.domain_id.0.clone(),
-                                    payload,
-                                    decided_at: now,
-                                },
+                                Ok(payload) => {
+                                    let canonical_payload_hash = serde_json::to_string(&payload)
+                                        .ok()
+                                        .map(|s| blake3::hash(s.as_bytes()).to_hex().to_string());
+                                    SystemEvent::ProposalAccepted {
+                                        proposal_id: proposal_id.0.clone(),
+                                        domain_id: proposal.domain_id.0.clone(),
+                                        payload,
+                                        decided_at: now,
+                                        canonical_payload_hash,
+                                    }
+                                }
                                 Err(e) => {
                                     warn!(
                                         "Failed to serialize payload for accepted proposal {}: {e}",
@@ -2011,12 +2017,18 @@ impl GovernanceActor {
                     let now = now_seconds();
                     let event = match forced_outcome {
                         ForcedOutcome::Accept => match serde_json::to_value(&proposal.payload) {
-                            Ok(payload) => SystemEvent::ProposalAccepted {
-                                proposal_id: proposal_id.0.clone(),
-                                domain_id: proposal.domain_id.0.clone(),
-                                payload,
-                                decided_at: now,
-                            },
+                            Ok(payload) => {
+                                let canonical_payload_hash = serde_json::to_string(&payload)
+                                    .ok()
+                                    .map(|s| blake3::hash(s.as_bytes()).to_hex().to_string());
+                                SystemEvent::ProposalAccepted {
+                                    proposal_id: proposal_id.0.clone(),
+                                    domain_id: proposal.domain_id.0.clone(),
+                                    payload,
+                                    decided_at: now,
+                                    canonical_payload_hash,
+                                }
+                            }
                             Err(e) => {
                                 warn!(
                                         "Failed to serialize payload for force-accepted proposal {}: {e}",

--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -97,7 +97,7 @@ pub fn translate_payload_to_effects(
 
         // Membership proposals
         ProposalPayload::Membership { action, member } => {
-            translate_membership_action(action, member, domain_id)
+            translate_membership_action(action, member, domain_id, decision_hash)
         }
 
         ProposalPayload::FreezeMember {
@@ -399,6 +399,7 @@ fn translate_membership_action(
     action: &icn_governance::MembershipAction,
     member: &icn_identity::Did,
     domain_id: &str,
+    decision_hash: &str,
 ) -> Result<Vec<KernelEffect>, TranslationError> {
     use icn_governance::MembershipAction;
 
@@ -409,6 +410,7 @@ fn translate_membership_action(
                 member_did: member.to_string(),
                 role: String::new(),
                 tier: String::new(),
+                decision_hash: decision_hash.to_string(),
             },
         )]),
         MembershipAction::Remove => Ok(vec![KernelEffect::Membership(

--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -420,6 +420,7 @@ fn translate_membership_action(
                 entity_id: domain_id.to_string(),
                 member_did: member.to_string(),
                 reason: String::new(),
+                decision_hash: decision_hash.to_string(),
             },
         )]),
     }

--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -110,6 +110,7 @@ pub fn translate_payload_to_effects(
                 member_did: member.to_string(),
                 reason: reason.clone(),
                 duration_secs: *duration_seconds,
+                decision_hash: decision_hash.to_string(),
             },
         )]),
 
@@ -118,6 +119,7 @@ pub fn translate_payload_to_effects(
                 MembershipEffect::UnfreezeMember {
                     entity_id: domain_id.to_string(),
                     member_did: member.to_string(),
+                    decision_hash: decision_hash.to_string(),
                 },
             )])
         }

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -122,12 +122,17 @@ where
             proposal_id,
             payload,
             domain_id,
+            canonical_payload_hash,
             ..
         } = &event
         {
             // Generate decision_receipt_id from proposal_id and domain
             let decision_receipt_id = format!("gov:{domain_id}:{proposal_id}:receipt");
-            let decision_hash = compute_decision_hash(&decision_receipt_id);
+            // Use canonical content hash when provided; fall back to hash-of-receipt-id
+            // for backward compatibility with events emitted before sprint 26.
+            let decision_hash = canonical_payload_hash
+                .clone()
+                .unwrap_or_else(|| compute_decision_hash(&decision_receipt_id));
 
             // Deserialize payload
             match serde_json::from_value::<ProposalPayload>(payload.clone()) {
@@ -238,6 +243,7 @@ mod tests {
             domain_id: "domain-pilot".to_string(),
             payload: serde_json::to_value(payload).expect("serialize payload"),
             decided_at: 1_700_000_000,
+            canonical_payload_hash: None,
         };
 
         subscription(event);
@@ -280,6 +286,7 @@ mod tests {
             domain_id: "domain-pilot".to_string(),
             payload: serde_json::to_value(payload).expect("serialize payload"),
             decided_at: 1_700_000_001,
+            canonical_payload_hash: None,
         };
 
         subscription(event);

--- a/icn/crates/icn-core/src/events.rs
+++ b/icn/crates/icn-core/src/events.rs
@@ -163,6 +163,7 @@ mod tests {
                 "Text": { "body": "Test proposal" }
             }),
             decided_at: 1234567890,
+            canonical_payload_hash: None,
         };
 
         bus.emit(event).await;
@@ -257,6 +258,7 @@ mod tests {
                 "Text": { "body": "test" }
             }),
             decided_at: 1234567890,
+            canonical_payload_hash: None,
         };
 
         bus.emit(event).await;
@@ -319,6 +321,7 @@ mod tests {
             domain_id: "test".to_string(),
             payload: serde_json::json!({"NotAValidVariant": true}),
             decided_at: 0,
+            canonical_payload_hash: None,
         })
         .await;
 

--- a/icn/crates/icn-core/src/services/membership_service.rs
+++ b/icn/crates/icn-core/src/services/membership_service.rs
@@ -258,6 +258,18 @@ impl MembershipService for MembershipServiceImpl {
                 member
                     .metadata
                     .insert("removed_at".to_string(), timestamp.to_string());
+                // Governance provenance — enables cold-cache recovery after restart
+                member.metadata.insert(
+                    "gov_decision_receipt_id".to_string(),
+                    request.decision_receipt_id.clone(),
+                );
+                member.metadata.insert(
+                    "gov_decision_hash".to_string(),
+                    request.decision_hash.clone(),
+                );
+                member
+                    .metadata
+                    .insert("gov_operation".to_string(), "remove".to_string());
 
                 // Save updated member
                 match self.store.save_member(&member) {

--- a/icn/crates/icn-core/src/services/membership_service.rs
+++ b/icn/crates/icn-core/src/services/membership_service.rs
@@ -469,6 +469,18 @@ impl MembershipService for MembershipServiceImpl {
                 member
                     .metadata
                     .insert("frozen_at".to_string(), timestamp.to_string());
+                // Governance provenance — enables cold-cache recovery after restart
+                member.metadata.insert(
+                    "gov_decision_receipt_id".to_string(),
+                    request.decision_receipt_id.clone(),
+                );
+                member.metadata.insert(
+                    "gov_decision_hash".to_string(),
+                    request.decision_hash.clone(),
+                );
+                member
+                    .metadata
+                    .insert("gov_operation".to_string(), "freeze".to_string());
 
                 // Calculate expiration if duration specified
                 let expires_at = request.duration_secs.map(|d| timestamp + d);
@@ -587,6 +599,18 @@ impl MembershipService for MembershipServiceImpl {
                     .metadata
                     .insert("unfrozen_at".to_string(), timestamp.to_string());
                 member.metadata.remove("freeze_expires_at");
+                // Governance provenance — enables cold-cache recovery after restart
+                member.metadata.insert(
+                    "gov_decision_receipt_id".to_string(),
+                    request.decision_receipt_id.clone(),
+                );
+                member.metadata.insert(
+                    "gov_decision_hash".to_string(),
+                    request.decision_hash.clone(),
+                );
+                member
+                    .metadata
+                    .insert("gov_operation".to_string(), "unfreeze".to_string());
 
                 // Save updated member
                 match self.store.save_member(&member) {

--- a/icn/crates/icn-core/src/services/membership_service.rs
+++ b/icn/crates/icn-core/src/services/membership_service.rs
@@ -158,7 +158,21 @@ impl MembershipService for MembershipServiceImpl {
         // Start as Active (governance already approved via proposal)
         member.status = MemberStatus::Active;
 
-        // Store the member
+        // Embed governance provenance into the member record's metadata so it
+        // survives sled round-trips (in-memory provenance HashMap is non-durable).
+        member.metadata.insert(
+            "gov_decision_receipt_id".to_string(),
+            request.decision_receipt_id.clone(),
+        );
+        member.metadata.insert(
+            "gov_decision_hash".to_string(),
+            request.decision_hash.clone(),
+        );
+        member
+            .metadata
+            .insert("gov_operation".to_string(), "add".to_string());
+
+        // Store the member (with provenance baked into metadata)
         match self.store.save_member(&member) {
             Ok(()) => {
                 let state_change_hash = Self::compute_state_change_hash(
@@ -169,7 +183,7 @@ impl MembershipService for MembershipServiceImpl {
                     timestamp,
                 );
 
-                // Store provenance
+                // Also maintain in-memory provenance index for fast lookups
                 let key = Self::provenance_key(&request.entity_id, &request.member_did);
                 self.store_provenance(
                     key,
@@ -662,10 +676,25 @@ impl MembershipService for MembershipServiceImpl {
         entity_id: &str,
         member_did: &str,
     ) -> Option<(String, String)> {
+        // 1. Fast path: in-memory cache (populated at add/update/freeze time)
         let key = Self::provenance_key(entity_id, member_did);
-        let prov = self.provenance.read().ok()?;
-        prov.get(&key)
-            .map(|p| (p.decision_receipt_id.clone(), p.decision_hash.clone()))
+        if let Ok(prov) = self.provenance.read() {
+            if let Some(p) = prov.get(&key) {
+                return Some((p.decision_receipt_id.clone(), p.decision_hash.clone()));
+            }
+        }
+
+        // 2. Durable fallback: read from sled-persisted member metadata.
+        //    This path fires after a restart when the in-memory cache is cold.
+        let did = Self::parse_did(member_did).ok()?;
+        match self.store.get_member(entity_id, &did) {
+            Ok(member) => {
+                let receipt_id = member.metadata.get("gov_decision_receipt_id")?.clone();
+                let decision_hash = member.metadata.get("gov_decision_hash")?.clone();
+                Some((receipt_id, decision_hash))
+            }
+            Err(_) => None,
+        }
     }
 }
 

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -1860,13 +1860,19 @@ impl KernelMembershipExecutor {
                     entity_id,
                     member_did,
                     reason,
+                    decision_hash: effect_decision_hash,
                 } => {
+                    let resolved_hash = if effect_decision_hash.is_empty() {
+                        compute_decision_hash(receipt_id)
+                    } else {
+                        effect_decision_hash
+                    };
                     let request = icn_kernel_api::RemoveMemberRequest {
                         entity_id: entity_id.clone(),
                         member_did: member_did.clone(),
                         reason,
                         decision_receipt_id: receipt_id.to_string(),
-                        decision_hash: compute_decision_hash(receipt_id),
+                        decision_hash: resolved_hash,
                     };
 
                     let result = service.remove_member(request)?;

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -1817,14 +1817,22 @@ impl KernelMembershipExecutor {
                     member_did,
                     role,
                     tier,
+                    decision_hash: effect_decision_hash,
                 } => {
+                    // Use the content hash carried in the effect when available;
+                    // fall back to blake3(receipt_id) for effects without one.
+                    let resolved_hash = if effect_decision_hash.is_empty() {
+                        compute_decision_hash(receipt_id)
+                    } else {
+                        effect_decision_hash
+                    };
                     let request = icn_kernel_api::AddMemberRequest {
                         entity_id: entity_id.clone(),
                         member_did: member_did.clone(),
                         role,
                         tier,
                         decision_receipt_id: receipt_id.to_string(),
-                        decision_hash: compute_decision_hash(receipt_id),
+                        decision_hash: resolved_hash,
                     };
 
                     let result = service.add_member(request)?;

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -1931,14 +1931,20 @@ impl KernelMembershipExecutor {
                     member_did,
                     reason,
                     duration_secs,
+                    decision_hash: effect_decision_hash,
                 } => {
+                    let resolved_hash = if effect_decision_hash.is_empty() {
+                        compute_decision_hash(receipt_id)
+                    } else {
+                        effect_decision_hash
+                    };
                     let request = icn_kernel_api::FreezeMemberRequest {
                         entity_id: entity_id.clone(),
                         member_did: member_did.clone(),
                         reason,
                         duration_secs,
                         decision_receipt_id: receipt_id.to_string(),
-                        decision_hash: compute_decision_hash(receipt_id),
+                        decision_hash: resolved_hash,
                     };
 
                     let result = service.freeze_member(request)?;
@@ -1966,12 +1972,18 @@ impl KernelMembershipExecutor {
                 MembershipEffect::UnfreezeMember {
                     entity_id,
                     member_did,
+                    decision_hash: effect_decision_hash,
                 } => {
+                    let resolved_hash = if effect_decision_hash.is_empty() {
+                        compute_decision_hash(receipt_id)
+                    } else {
+                        effect_decision_hash
+                    };
                     let request = icn_kernel_api::UnfreezeMemberRequest {
                         entity_id: entity_id.clone(),
                         member_did: member_did.clone(),
                         decision_receipt_id: receipt_id.to_string(),
-                        decision_hash: compute_decision_hash(receipt_id),
+                        decision_hash: resolved_hash,
                     };
 
                     let result = service.unfreeze_member(request)?;

--- a/icn/crates/icn-core/tests/effect_group_integration.rs
+++ b/icn/crates/icn-core/tests/effect_group_integration.rs
@@ -286,6 +286,7 @@ async fn test_membership_freeze_member_provenance_chain() -> Result<()> {
         member_did: member_did_str.clone(),
         reason: "Policy violation under review".to_string(),
         duration_secs: Some(86400), // 24 hours
+        decision_hash: String::new(),
     };
 
     let outcome = executor
@@ -382,6 +383,7 @@ async fn test_membership_unfreeze_member_provenance_chain() -> Result<()> {
     let effect = MembershipEffect::UnfreezeMember {
         entity_id: "coop-unfreeze-test".to_string(),
         member_did: member_did_str.clone(),
+        decision_hash: String::new(),
     };
 
     let outcome = executor

--- a/icn/crates/icn-core/tests/effect_group_integration.rs
+++ b/icn/crates/icn-core/tests/effect_group_integration.rs
@@ -180,6 +180,7 @@ async fn test_membership_add_member_provenance_chain() -> Result<()> {
         member_did: member_did_str.clone(),
         role: "Worker".to_string(),
         tier: "Standard".to_string(),
+        decision_hash: String::new(),
     };
 
     // Execute the membership operation

--- a/icn/crates/icn-core/tests/federated_two_node_pilot.rs
+++ b/icn/crates/icn-core/tests/federated_two_node_pilot.rs
@@ -302,6 +302,7 @@ async fn test_two_node_membership_add_determinism() -> Result<()> {
         member_did: member_did.to_string(),
         role: "Worker".to_string(),
         tier: "Standard".to_string(),
+        decision_hash: String::new(),
     };
 
     // === Node A Setup ===
@@ -691,6 +692,7 @@ async fn test_two_node_effect_batch_determinism() -> Result<()> {
             member_did: member_did.to_string(),
             role: "Coordinator".to_string(),
             tier: "Founding".to_string(),
+            decision_hash: String::new(),
         }),
         KernelEffect::NoOp {
             reason: "Resolution text recorded".to_string(),
@@ -874,6 +876,7 @@ async fn test_two_node_federation_reload_durability() -> Result<()> {
         member_did: member_did.to_string(),
         role: "Worker".to_string(),
         tier: "Standard".to_string(),
+        decision_hash: String::new(),
     };
 
     // === Create persistent tempdirs for both nodes ===

--- a/icn/crates/icn-core/tests/freeze_unfreeze_governance_integration.rs
+++ b/icn/crates/icn-core/tests/freeze_unfreeze_governance_integration.rs
@@ -1,0 +1,427 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! Proof: accepted FreezeMember / UnfreezeMember proposals produce durable sled
+//! state mutations with verifiable governance provenance that survive restarts.
+//!
+//! Chain under test:
+//!   ProposalAccepted { canonical_payload_hash }
+//!   → create_effect_subscription
+//!   → EffectDispatcher::execute_effects
+//!   → KernelGovernanceExecutor (MembershipEffect::FreezeMember / UnfreezeMember)
+//!   → MembershipServiceImpl::freeze_member / unfreeze_member
+//!   → CoopStore::save_member (sled) with provenance in member.metadata
+//!   → Cold-cache restart: get_membership_provenance() reads from sled metadata
+//!
+//! Proves:
+//! 1. member.status == Suspended after freeze (Active after unfreeze)
+//! 2. gov_decision_receipt_id in member.metadata == "gov:{domain}:{proposal}:receipt"
+//! 3. gov_decision_hash in member.metadata == canonical_payload_hash from event
+//! 4. Both provenance values survive a sled restart (cold-cache path)
+//! 5. Legacy (no canonical_hash): fallback blake3 hash is stored
+
+use anyhow::Result;
+use icn_coop::CoopStore;
+use icn_core::services::MembershipServiceImpl;
+use icn_core::supervisor::effect_dispatcher::EffectDispatcher;
+use icn_core::supervisor::governance_executor::KernelGovernanceExecutor;
+use icn_governance::proposal::ProposalPayload;
+use icn_governance_actor::create_effect_subscription;
+use icn_identity::KeyPair;
+use icn_kernel_api::events::SystemEvent;
+use icn_kernel_api::protocol_params::StubParamStore;
+use icn_kernel_api::MembershipService;
+use std::sync::Arc;
+use tempfile::TempDir;
+use tracing::info;
+
+fn open_coop_store(path: &std::path::Path) -> Arc<CoopStore> {
+    let db = sled::open(path).expect("Failed to open sled db");
+    Arc::new(CoopStore::new(Arc::new(db)))
+}
+
+/// Seed a member as Active so freeze/unfreeze have something to act on.
+fn seed_active_member(store: &Arc<CoopStore>, domain_id: &str, did: &icn_identity::Did) {
+    use icn_coop::{Member, MemberRole, MemberStatus};
+    let mut member = Member::new(did.clone(), domain_id.to_string(), MemberRole::Member);
+    member.status = MemberStatus::Active;
+    store.save_member(&member).expect("seed_active_member");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 1 — Freeze: canonical hash forwarded, sled-durable, restart-safe
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn freeze_member_accepted_proposal_produces_durable_record_with_governance_provenance(
+) -> Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .with_test_writer()
+        .try_init();
+
+    info!("=== Freeze Bridge: ProposalAccepted → durable Suspended state ===");
+
+    let tmp = TempDir::new()?;
+    let store_path = tmp.path().join("coop-store-freeze");
+
+    let member_kp = KeyPair::generate()?;
+    let member_did = member_kp.did().clone();
+
+    let domain_id = "test-coop-freeze";
+    let proposal_id = "freeze-member-prop-001";
+    let canonical_payload_hash = "sha256:freeze-canonical-hash-001".to_string();
+    let expected_receipt_id = format!("gov:{domain_id}:{proposal_id}:receipt");
+
+    // ── Phase A: fire event ───────────────────────────────────────────────────
+    {
+        let coop_store = open_coop_store(&store_path);
+        seed_active_member(&coop_store, domain_id, &member_did);
+
+        let membership_service = Arc::new(MembershipServiceImpl::new(coop_store.clone()));
+        let kernel_executor = KernelGovernanceExecutor::new(Arc::new(StubParamStore))
+            .with_membership_service(membership_service.clone());
+        let dispatcher = Arc::new(EffectDispatcher::new(Arc::new(kernel_executor)));
+
+        let payload = ProposalPayload::FreezeMember {
+            member: member_did.clone(),
+            reason: "policy violation".to_string(),
+            duration_seconds: Some(3600),
+        };
+        let payload_value = serde_json::to_value(&payload)?;
+
+        let dispatcher_for_sub = dispatcher.clone();
+        let subscription = create_effect_subscription(move |effects, decision_receipt_id| {
+            let disp = dispatcher_for_sub.clone();
+            let dr_id = decision_receipt_id.clone();
+            tokio::task::spawn(async move {
+                match disp.execute_effects(effects, &dr_id).await {
+                    Ok(results) => info!(
+                        decision_receipt_id = %dr_id,
+                        result_count = results.len(),
+                        "EffectDispatcher processed freeze effects"
+                    ),
+                    Err(e) => tracing::error!(
+                        decision_receipt_id = %dr_id,
+                        error = %e,
+                        "EffectDispatcher error"
+                    ),
+                }
+            });
+        });
+
+        let event = SystemEvent::ProposalAccepted {
+            proposal_id: proposal_id.to_string(),
+            domain_id: domain_id.to_string(),
+            payload: payload_value,
+            decided_at: 1_700_000_010,
+            canonical_payload_hash: Some(canonical_payload_hash.clone()),
+        };
+
+        subscription(event);
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        let stored = coop_store
+            .get_member(domain_id, &member_did)
+            .expect("Member should exist after freeze");
+
+        // Status must be Suspended
+        assert_eq!(
+            stored.status,
+            icn_coop::MemberStatus::Suspended,
+            "member.status must be Suspended after freeze"
+        );
+        // Governance provenance in metadata
+        assert_eq!(
+            stored
+                .metadata
+                .get("gov_decision_receipt_id")
+                .map(|s| s.as_str()),
+            Some(expected_receipt_id.as_str()),
+            "gov_decision_receipt_id must match"
+        );
+        assert_eq!(
+            stored.metadata.get("gov_decision_hash").map(|s| s.as_str()),
+            Some(canonical_payload_hash.as_str()),
+            "gov_decision_hash must equal canonical_payload_hash"
+        );
+        assert_eq!(
+            stored.metadata.get("gov_operation").map(|s| s.as_str()),
+            Some("freeze"),
+            "gov_operation must be 'freeze'"
+        );
+
+        info!("✅ Phase A: member frozen, provenance in metadata");
+        // All Arcs drop here → sled lock releases
+    }
+
+    // ── Phase B: cold-cache restart ───────────────────────────────────────────
+    let reloaded_store = open_coop_store(&store_path);
+    let reloaded_service = MembershipServiceImpl::new(reloaded_store);
+
+    let prov = reloaded_service.get_membership_provenance(domain_id, &member_did.to_string());
+    assert!(
+        prov.is_some(),
+        "get_membership_provenance must return Some after restart"
+    );
+    let (receipt_id_after, hash_after) = prov.unwrap();
+    assert_eq!(
+        receipt_id_after, expected_receipt_id,
+        "receipt_id must match"
+    );
+    assert_eq!(
+        hash_after, canonical_payload_hash,
+        "decision_hash must match canonical"
+    );
+
+    info!("✅ Phase B: cold-cache restart — freeze provenance recovered from sled metadata");
+
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 2 — Unfreeze: canonical hash forwarded, sled-durable, restart-safe
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn unfreeze_member_accepted_proposal_produces_durable_record_with_governance_provenance(
+) -> Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .with_test_writer()
+        .try_init();
+
+    info!("=== Unfreeze Bridge: ProposalAccepted → durable Active state ===");
+
+    let tmp = TempDir::new()?;
+    let store_path = tmp.path().join("coop-store-unfreeze");
+
+    let member_kp = KeyPair::generate()?;
+    let member_did = member_kp.did().clone();
+
+    let domain_id = "test-coop-unfreeze";
+    let freeze_proposal_id = "freeze-prop-for-unfreeze-001";
+    let unfreeze_proposal_id = "unfreeze-member-prop-001";
+    let unfreeze_canonical_hash = "sha256:unfreeze-canonical-hash-001".to_string();
+    let expected_unfreeze_receipt_id = format!("gov:{domain_id}:{unfreeze_proposal_id}:receipt");
+
+    // ── Phase A: seed + freeze + unfreeze ─────────────────────────────────────
+    {
+        let coop_store = open_coop_store(&store_path);
+        seed_active_member(&coop_store, domain_id, &member_did);
+
+        let membership_service = Arc::new(MembershipServiceImpl::new(coop_store.clone()));
+        let kernel_executor = KernelGovernanceExecutor::new(Arc::new(StubParamStore))
+            .with_membership_service(membership_service.clone());
+        let dispatcher = Arc::new(EffectDispatcher::new(Arc::new(kernel_executor)));
+
+        // Step 1: freeze the member first (so unfreeze has a Suspended member to act on)
+        {
+            let freeze_payload = ProposalPayload::FreezeMember {
+                member: member_did.clone(),
+                reason: "initial freeze".to_string(),
+                duration_seconds: None,
+            };
+            let disp = dispatcher.clone();
+            let sub = create_effect_subscription(move |effects, dr_id| {
+                let d = disp.clone();
+                let id = dr_id.clone();
+                tokio::task::spawn(async move {
+                    let _ = d.execute_effects(effects, &id).await;
+                });
+            });
+            sub(SystemEvent::ProposalAccepted {
+                proposal_id: freeze_proposal_id.to_string(),
+                domain_id: domain_id.to_string(),
+                payload: serde_json::to_value(&freeze_payload).unwrap(),
+                decided_at: 1_700_000_020,
+                canonical_payload_hash: Some("sha256:freeze-pre-hash".to_string()),
+            });
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+            let after_freeze = coop_store.get_member(domain_id, &member_did).unwrap();
+            assert_eq!(after_freeze.status, icn_coop::MemberStatus::Suspended);
+        }
+
+        // Step 2: unfreeze
+        let unfreeze_payload = ProposalPayload::UnfreezeMember {
+            member: member_did.clone(),
+            reason: "resolved".to_string(),
+        };
+        let payload_value = serde_json::to_value(&unfreeze_payload)?;
+
+        let dispatcher_for_sub = dispatcher.clone();
+        let subscription = create_effect_subscription(move |effects, decision_receipt_id| {
+            let disp = dispatcher_for_sub.clone();
+            let dr_id = decision_receipt_id.clone();
+            tokio::task::spawn(async move {
+                match disp.execute_effects(effects, &dr_id).await {
+                    Ok(results) => info!(
+                        decision_receipt_id = %dr_id,
+                        result_count = results.len(),
+                        "EffectDispatcher processed unfreeze effects"
+                    ),
+                    Err(e) => tracing::error!(
+                        decision_receipt_id = %dr_id,
+                        error = %e,
+                        "EffectDispatcher error"
+                    ),
+                }
+            });
+        });
+
+        subscription(SystemEvent::ProposalAccepted {
+            proposal_id: unfreeze_proposal_id.to_string(),
+            domain_id: domain_id.to_string(),
+            payload: payload_value,
+            decided_at: 1_700_000_030,
+            canonical_payload_hash: Some(unfreeze_canonical_hash.clone()),
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        let stored = coop_store
+            .get_member(domain_id, &member_did)
+            .expect("Member should exist after unfreeze");
+
+        // Status back to Active
+        assert_eq!(
+            stored.status,
+            icn_coop::MemberStatus::Active,
+            "member.status must be Active after unfreeze"
+        );
+        assert_eq!(
+            stored
+                .metadata
+                .get("gov_decision_receipt_id")
+                .map(|s| s.as_str()),
+            Some(expected_unfreeze_receipt_id.as_str()),
+            "gov_decision_receipt_id must reflect unfreeze receipt"
+        );
+        assert_eq!(
+            stored.metadata.get("gov_decision_hash").map(|s| s.as_str()),
+            Some(unfreeze_canonical_hash.as_str()),
+            "gov_decision_hash must equal canonical_payload_hash"
+        );
+        assert_eq!(
+            stored.metadata.get("gov_operation").map(|s| s.as_str()),
+            Some("unfreeze"),
+            "gov_operation must be 'unfreeze'"
+        );
+
+        info!("✅ Phase A: member unfrozen, provenance in metadata");
+    }
+
+    // ── Phase B: cold-cache restart ───────────────────────────────────────────
+    let reloaded_store = open_coop_store(&store_path);
+    let reloaded_service = MembershipServiceImpl::new(reloaded_store);
+
+    let prov = reloaded_service.get_membership_provenance(domain_id, &member_did.to_string());
+    assert!(
+        prov.is_some(),
+        "get_membership_provenance must return Some after restart"
+    );
+    let (receipt_id_after, hash_after) = prov.unwrap();
+    assert_eq!(
+        receipt_id_after, expected_unfreeze_receipt_id,
+        "receipt_id must match unfreeze receipt"
+    );
+    assert_eq!(
+        hash_after, unfreeze_canonical_hash,
+        "decision_hash must match unfreeze canonical"
+    );
+
+    info!("✅ Phase B: cold-cache restart — unfreeze provenance recovered from sled metadata");
+
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 3 — Freeze legacy path (no canonical_hash): blake3 fallback
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn freeze_without_canonical_hash_falls_back_to_receipt_hash() -> Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .with_test_writer()
+        .try_init();
+
+    let tmp = TempDir::new()?;
+    let store_path = tmp.path().join("coop-store-freeze-legacy");
+
+    let member_kp = KeyPair::generate()?;
+    let member_did = member_kp.did().clone();
+
+    let domain_id = "test-coop-freeze-legacy";
+    let proposal_id = "freeze-legacy-001";
+    let expected_receipt_id = format!("gov:{domain_id}:{proposal_id}:receipt");
+
+    let coop_store = open_coop_store(&store_path);
+    seed_active_member(&coop_store, domain_id, &member_did);
+
+    let membership_service = Arc::new(MembershipServiceImpl::new(coop_store.clone()));
+    let kernel_executor = KernelGovernanceExecutor::new(Arc::new(StubParamStore))
+        .with_membership_service(membership_service.clone());
+    let dispatcher = Arc::new(EffectDispatcher::new(Arc::new(kernel_executor)));
+
+    let payload = ProposalPayload::FreezeMember {
+        member: member_did.clone(),
+        reason: "legacy freeze".to_string(),
+        duration_seconds: None,
+    };
+
+    let dispatcher_for_sub = dispatcher.clone();
+    let sub = create_effect_subscription(move |effects, dr_id| {
+        let d = dispatcher_for_sub.clone();
+        let id = dr_id.clone();
+        tokio::task::spawn(async move {
+            let _ = d.execute_effects(effects, &id).await;
+        });
+    });
+
+    sub(SystemEvent::ProposalAccepted {
+        proposal_id: proposal_id.to_string(),
+        domain_id: domain_id.to_string(),
+        payload: serde_json::to_value(&payload)?,
+        decided_at: 1_700_000_040,
+        canonical_payload_hash: None, // legacy: no canonical hash
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let stored = coop_store
+        .get_member(domain_id, &member_did)
+        .expect("Member should exist after legacy freeze");
+
+    assert_eq!(
+        stored.status,
+        icn_coop::MemberStatus::Suspended,
+        "member must be Suspended even on legacy path"
+    );
+
+    let stored_receipt_id = stored
+        .metadata
+        .get("gov_decision_receipt_id")
+        .expect("gov_decision_receipt_id must be present");
+    let stored_decision_hash = stored
+        .metadata
+        .get("gov_decision_hash")
+        .expect("gov_decision_hash must be present");
+
+    assert_eq!(
+        stored_receipt_id.as_str(),
+        expected_receipt_id.as_str(),
+        "receipt_id must match even on legacy path"
+    );
+    // blake3 fallback produces a 64-char hex string
+    assert_eq!(
+        stored_decision_hash.len(),
+        64,
+        "Fallback decision_hash must be a 64-char blake3 hex string"
+    );
+
+    info!(
+        receipt_id = %stored_receipt_id,
+        decision_hash = %stored_decision_hash,
+        "✅ Legacy path: freeze record written with blake3 fallback provenance"
+    );
+
+    Ok(())
+}

--- a/icn/crates/icn-core/tests/governance_ledger_idempotency.rs
+++ b/icn/crates/icn-core/tests/governance_ledger_idempotency.rs
@@ -145,6 +145,7 @@ async fn test_duplicate_proposal_event_is_idempotent() -> Result<()> {
         })
         .unwrap(),
         decided_at: 1234567890,
+        canonical_payload_hash: None,
     };
 
     // Emit event ONCE

--- a/icn/crates/icn-core/tests/governance_ledger_integration.rs
+++ b/icn/crates/icn-core/tests/governance_ledger_integration.rs
@@ -220,6 +220,7 @@ async fn test_budget_proposal_executes_ledger_transaction() -> Result<()> {
         })
         .unwrap(),
         decided_at: now,
+        canonical_payload_hash: None,
     };
 
     info!("Emitting ProposalAccepted event...");

--- a/icn/crates/icn-core/tests/governance_policy_integration.rs
+++ b/icn/crates/icn-core/tests/governance_policy_integration.rs
@@ -184,6 +184,7 @@ async fn test_scheduling_policy_proposal_execution() -> Result<()> {
             domain_id: "test-domain".to_string(),
             payload: payload.clone(),
             decided_at: now,
+            canonical_payload_hash: None,
         })
         .await;
 
@@ -226,6 +227,7 @@ async fn test_scheduling_policy_proposal_execution() -> Result<()> {
             })
             .unwrap(),
             decided_at: now,
+            canonical_payload_hash: None,
         })
         .await;
 
@@ -341,6 +343,7 @@ async fn test_invalid_policy_json_handling() -> Result<()> {
             })
             .unwrap(),
             decided_at: now,
+            canonical_payload_hash: None,
         })
         .await;
 

--- a/icn/crates/icn-core/tests/membership_action_governance_integration.rs
+++ b/icn/crates/icn-core/tests/membership_action_governance_integration.rs
@@ -1,0 +1,274 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! Proof: accepted MembershipAction::Add proposals produce durable membership
+//! records with verifiable governance provenance that survive restarts.
+//!
+//! Chain under test:
+//!   ProposalAccepted { canonical_payload_hash }
+//!   → create_effect_subscription
+//!   → EffectDispatcher::execute_effects
+//!   → KernelGovernanceExecutor (MembershipEffect::AddMember)
+//!   → MembershipServiceImpl::add_member
+//!   → CoopStore::save_member with provenance baked into member.metadata
+//!   → Cold-cache restart: get_membership_provenance() reads from sled metadata
+//!
+//! Proves:
+//! 1. decision_receipt_id in member.metadata == "gov:{domain}:{proposal}:receipt"
+//! 2. decision_hash in member.metadata == canonical_payload_hash from the event
+//! 3. Both values survive a sled restart (cold-cache provenance path)
+
+use anyhow::Result;
+use icn_coop::CoopStore;
+use icn_core::services::MembershipServiceImpl;
+use icn_core::supervisor::effect_dispatcher::EffectDispatcher;
+use icn_core::supervisor::governance_executor::KernelGovernanceExecutor;
+use icn_governance::proposal::{MembershipAction, ProposalPayload};
+use icn_governance_actor::create_effect_subscription;
+use icn_identity::KeyPair;
+use icn_kernel_api::events::SystemEvent;
+use icn_kernel_api::protocol_params::StubParamStore;
+use icn_kernel_api::MembershipService;
+use std::sync::Arc;
+use tempfile::TempDir;
+use tracing::info;
+
+/// Build a `CoopStore` backed by a sled database at the given path.
+fn open_coop_store(path: &std::path::Path) -> Arc<CoopStore> {
+    let db = sled::open(path).expect("Failed to open sled db");
+    Arc::new(CoopStore::new(Arc::new(db)))
+}
+
+/// Prove the full governance → membership bridge with sled-durable provenance.
+///
+/// Chain: ProposalAccepted → create_effect_subscription → EffectDispatcher
+///        → KernelGovernanceExecutor → MembershipServiceImpl::add_member
+///        → CoopStore (sled) member.metadata { gov_decision_receipt_id, gov_decision_hash }
+#[tokio::test(flavor = "multi_thread")]
+async fn add_member_accepted_proposal_produces_durable_record_with_governance_provenance(
+) -> Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .with_test_writer()
+        .try_init();
+
+    info!("=== Membership Action Bridge: ProposalAccepted → durable member record ===");
+
+    let tmp = TempDir::new()?;
+    let store_path = tmp.path().join("coop-store");
+
+    // ── Identities ────────────────────────────────────────────────────────────
+    let new_member_kp = KeyPair::generate()?;
+    let new_member_did = new_member_kp.did().clone();
+
+    let domain_id = "test-coop";
+    let proposal_id = "add-member-prop-001";
+    let canonical_payload_hash = "sha256:membership-canonical-hash-001".to_string();
+    let expected_receipt_id = format!("gov:{domain_id}:{proposal_id}:receipt");
+    let expected_decision_hash = canonical_payload_hash.clone();
+
+    // ── Phase A: fire event, let the full chain execute ───────────────────────
+    // All Arcs that hold a CoopStore reference live only in this block.
+    // When the block closes, all chain references drop → sled lock releases.
+    {
+        let coop_store = open_coop_store(&store_path);
+        let membership_service = Arc::new(MembershipServiceImpl::new(coop_store.clone()));
+
+        let kernel_executor = KernelGovernanceExecutor::new(Arc::new(StubParamStore))
+            .with_membership_service(membership_service.clone());
+
+        let dispatcher = Arc::new(EffectDispatcher::new(Arc::new(kernel_executor)));
+
+        let payload = ProposalPayload::Membership {
+            action: MembershipAction::Add,
+            member: new_member_did.clone(),
+        };
+        let payload_value = serde_json::to_value(&payload)?;
+
+        let dispatcher_for_sub = dispatcher.clone();
+        let subscription = create_effect_subscription(move |effects, decision_receipt_id| {
+            let disp = dispatcher_for_sub.clone();
+            let dr_id = decision_receipt_id.clone();
+            tokio::task::spawn(async move {
+                match disp.execute_effects(effects, &dr_id).await {
+                    Ok(results) => info!(
+                        decision_receipt_id = %dr_id,
+                        result_count = results.len(),
+                        "EffectDispatcher processed membership effects"
+                    ),
+                    Err(e) => tracing::error!(
+                        decision_receipt_id = %dr_id,
+                        error = %e,
+                        "EffectDispatcher error"
+                    ),
+                }
+            });
+        });
+
+        let event = SystemEvent::ProposalAccepted {
+            proposal_id: proposal_id.to_string(),
+            domain_id: domain_id.to_string(),
+            payload: payload_value,
+            decided_at: 1_700_000_000,
+            canonical_payload_hash: Some(canonical_payload_hash),
+        };
+
+        subscription(event);
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        // Verify the record was written (while lock is still held)
+        let stored = coop_store
+            .get_member(domain_id, &new_member_did)
+            .expect("Member should exist in CoopStore");
+
+        assert_eq!(
+            stored
+                .metadata
+                .get("gov_decision_receipt_id")
+                .map(|s| s.as_str()),
+            Some(expected_receipt_id.as_str()),
+            "member.metadata must contain gov_decision_receipt_id == expected receipt_id"
+        );
+        assert_eq!(
+            stored.metadata.get("gov_decision_hash").map(|s| s.as_str()),
+            Some(expected_decision_hash.as_str()),
+            "member.metadata must contain gov_decision_hash == canonical_payload_hash"
+        );
+        assert_eq!(
+            stored.metadata.get("gov_operation").map(|s| s.as_str()),
+            Some("add"),
+            "member.metadata must record operation == 'add'"
+        );
+
+        info!(
+            receipt_id = %expected_receipt_id,
+            decision_hash = %expected_decision_hash,
+            "✅ Phase A: member record written with governance provenance in metadata"
+        );
+
+        // All Arcs (coop_store, membership_service, dispatcher, subscription) drop here
+    }
+
+    // ── Phase B: cold-cache restart ───────────────────────────────────────────
+    // Sled lock is now released. Reopen from the same path.
+    // The new MembershipServiceImpl has empty in-memory provenance HashMap;
+    // get_membership_provenance must recover from sled metadata.
+    let reloaded_store = open_coop_store(&store_path);
+    let reloaded_service = MembershipServiceImpl::new(reloaded_store);
+
+    let prov = reloaded_service.get_membership_provenance(domain_id, &new_member_did.to_string());
+
+    assert!(
+        prov.is_some(),
+        "get_membership_provenance must return Some after restart (cold in-memory cache)"
+    );
+
+    let (receipt_id_after_restart, hash_after_restart) = prov.unwrap();
+
+    assert_eq!(
+        receipt_id_after_restart, expected_receipt_id,
+        "Reloaded receipt_id must match"
+    );
+    assert_eq!(
+        hash_after_restart, expected_decision_hash,
+        "Reloaded decision_hash must match canonical_payload_hash"
+    );
+
+    info!(
+        receipt_id = %receipt_id_after_restart,
+        decision_hash = %hash_after_restart,
+        "✅ Phase B: cold-cache restart — provenance recovered from sled metadata"
+    );
+
+    info!(
+        "✅ PROOF: accepted MembershipAction::Add produces durable governance provenance \
+         that survives restart"
+    );
+
+    Ok(())
+}
+
+/// Prove that when canonical_payload_hash is absent (legacy events),
+/// the fallback blake3(receipt_id) is stored as the decision_hash — bridge still works.
+#[tokio::test(flavor = "multi_thread")]
+async fn add_member_without_canonical_hash_falls_back_to_receipt_hash() -> Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .with_test_writer()
+        .try_init();
+
+    let tmp = TempDir::new()?;
+    let store_path = tmp.path().join("coop-store-legacy");
+
+    let new_member_kp = KeyPair::generate()?;
+    let new_member_did = new_member_kp.did().clone();
+
+    let coop_store = open_coop_store(&store_path);
+    let membership_service = Arc::new(MembershipServiceImpl::new(coop_store.clone()));
+
+    let kernel_executor = KernelGovernanceExecutor::new(Arc::new(StubParamStore))
+        .with_membership_service(membership_service.clone());
+
+    let dispatcher = Arc::new(EffectDispatcher::new(Arc::new(kernel_executor)));
+
+    let domain_id = "test-coop-legacy";
+    let proposal_id = "add-member-legacy-001";
+
+    let payload = ProposalPayload::Membership {
+        action: MembershipAction::Add,
+        member: new_member_did.clone(),
+    };
+
+    let expected_receipt_id = format!("gov:{domain_id}:{proposal_id}:receipt");
+
+    let dispatcher_for_sub = dispatcher.clone();
+    let subscription = create_effect_subscription(move |effects, decision_receipt_id| {
+        let disp = dispatcher_for_sub.clone();
+        let dr_id = decision_receipt_id.clone();
+        tokio::task::spawn(async move {
+            let _ = disp.execute_effects(effects, &dr_id).await;
+        });
+    });
+
+    let event = SystemEvent::ProposalAccepted {
+        proposal_id: proposal_id.to_string(),
+        domain_id: domain_id.to_string(),
+        payload: serde_json::to_value(&payload)?,
+        decided_at: 1_700_000_001,
+        canonical_payload_hash: None, // legacy: no canonical hash
+    };
+
+    subscription(event);
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let stored = coop_store
+        .get_member(domain_id, &new_member_did)
+        .expect("Member should exist after legacy-path add");
+
+    let stored_receipt_id = stored
+        .metadata
+        .get("gov_decision_receipt_id")
+        .expect("gov_decision_receipt_id must be present");
+    let stored_decision_hash = stored
+        .metadata
+        .get("gov_decision_hash")
+        .expect("gov_decision_hash must be present");
+
+    assert_eq!(
+        stored_receipt_id.as_str(),
+        expected_receipt_id.as_str(),
+        "receipt_id must match even for legacy (no-canonical-hash) path"
+    );
+    // blake3 produces a 64-char hex string
+    assert_eq!(
+        stored_decision_hash.len(),
+        64,
+        "Fallback decision_hash must be a 64-char blake3 hex string"
+    );
+
+    info!(
+        receipt_id = %stored_receipt_id,
+        decision_hash = %stored_decision_hash,
+        "✅ Legacy path (no canonical_hash): member record written with blake3 fallback provenance"
+    );
+
+    Ok(())
+}

--- a/icn/crates/icn-core/tests/remove_member_governance_integration.rs
+++ b/icn/crates/icn-core/tests/remove_member_governance_integration.rs
@@ -1,0 +1,264 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! Proof: accepted MembershipAction::Remove proposals produce durable sled
+//! state mutations with verifiable governance provenance that survive restarts.
+//!
+//! Chain under test:
+//!   ProposalAccepted { canonical_payload_hash }
+//!   → create_effect_subscription
+//!   → EffectDispatcher::execute_effects
+//!   → KernelGovernanceExecutor (MembershipEffect::RemoveMember)
+//!   → MembershipServiceImpl::remove_member
+//!   → CoopStore::save_member (sled) with provenance in member.metadata
+//!   → Cold-cache restart: get_membership_provenance() reads from sled metadata
+//!
+//! Proves:
+//! 1. member.status == Removed after remove proposal
+//! 2. gov_decision_receipt_id in member.metadata == "gov:{domain}:{proposal}:receipt"
+//! 3. gov_decision_hash in member.metadata == canonical_payload_hash from event
+//! 4. Both values survive sled restart (cold-cache path)
+//! 5. Legacy (no canonical_hash): blake3 fallback is stored
+
+use anyhow::Result;
+use icn_coop::CoopStore;
+use icn_core::services::MembershipServiceImpl;
+use icn_core::supervisor::effect_dispatcher::EffectDispatcher;
+use icn_core::supervisor::governance_executor::KernelGovernanceExecutor;
+use icn_governance::proposal::{MembershipAction, ProposalPayload};
+use icn_governance_actor::create_effect_subscription;
+use icn_identity::KeyPair;
+use icn_kernel_api::events::SystemEvent;
+use icn_kernel_api::protocol_params::StubParamStore;
+use icn_kernel_api::MembershipService;
+use std::sync::Arc;
+use tempfile::TempDir;
+use tracing::info;
+
+fn open_coop_store(path: &std::path::Path) -> Arc<CoopStore> {
+    let db = sled::open(path).expect("Failed to open sled db");
+    Arc::new(CoopStore::new(Arc::new(db)))
+}
+
+fn seed_active_member(store: &Arc<CoopStore>, domain_id: &str, did: &icn_identity::Did) {
+    use icn_coop::{Member, MemberRole, MemberStatus};
+    let mut member = Member::new(did.clone(), domain_id.to_string(), MemberRole::Member);
+    member.status = MemberStatus::Active;
+    store.save_member(&member).expect("seed_active_member");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 1 — Remove: canonical hash forwarded, sled-durable, restart-safe
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn remove_member_accepted_proposal_produces_durable_record_with_governance_provenance(
+) -> Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .with_test_writer()
+        .try_init();
+
+    info!("=== Remove Bridge: ProposalAccepted → durable Removed state ===");
+
+    let tmp = TempDir::new()?;
+    let store_path = tmp.path().join("coop-store-remove");
+
+    let member_kp = KeyPair::generate()?;
+    let member_did = member_kp.did().clone();
+
+    let domain_id = "test-coop-remove";
+    let proposal_id = "remove-member-prop-001";
+    let canonical_payload_hash = "sha256:remove-canonical-hash-001".to_string();
+    let expected_receipt_id = format!("gov:{domain_id}:{proposal_id}:receipt");
+
+    // ── Phase A: fire event ───────────────────────────────────────────────────
+    {
+        let coop_store = open_coop_store(&store_path);
+        seed_active_member(&coop_store, domain_id, &member_did);
+
+        let membership_service = Arc::new(MembershipServiceImpl::new(coop_store.clone()));
+        let kernel_executor = KernelGovernanceExecutor::new(Arc::new(StubParamStore))
+            .with_membership_service(membership_service.clone());
+        let dispatcher = Arc::new(EffectDispatcher::new(Arc::new(kernel_executor)));
+
+        let payload = ProposalPayload::Membership {
+            action: MembershipAction::Remove,
+            member: member_did.clone(),
+        };
+        let payload_value = serde_json::to_value(&payload)?;
+
+        let dispatcher_for_sub = dispatcher.clone();
+        let subscription = create_effect_subscription(move |effects, decision_receipt_id| {
+            let disp = dispatcher_for_sub.clone();
+            let dr_id = decision_receipt_id.clone();
+            tokio::task::spawn(async move {
+                match disp.execute_effects(effects, &dr_id).await {
+                    Ok(results) => info!(
+                        decision_receipt_id = %dr_id,
+                        result_count = results.len(),
+                        "EffectDispatcher processed remove effects"
+                    ),
+                    Err(e) => tracing::error!(
+                        decision_receipt_id = %dr_id,
+                        error = %e,
+                        "EffectDispatcher error"
+                    ),
+                }
+            });
+        });
+
+        subscription(SystemEvent::ProposalAccepted {
+            proposal_id: proposal_id.to_string(),
+            domain_id: domain_id.to_string(),
+            payload: payload_value,
+            decided_at: 1_700_000_050,
+            canonical_payload_hash: Some(canonical_payload_hash.clone()),
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        let stored = coop_store
+            .get_member(domain_id, &member_did)
+            .expect("Member should exist after remove (record preserved with Removed status)");
+
+        assert_eq!(
+            stored.status,
+            icn_coop::MemberStatus::Removed,
+            "member.status must be Removed"
+        );
+        assert_eq!(
+            stored
+                .metadata
+                .get("gov_decision_receipt_id")
+                .map(|s| s.as_str()),
+            Some(expected_receipt_id.as_str()),
+            "gov_decision_receipt_id must match"
+        );
+        assert_eq!(
+            stored.metadata.get("gov_decision_hash").map(|s| s.as_str()),
+            Some(canonical_payload_hash.as_str()),
+            "gov_decision_hash must equal canonical_payload_hash"
+        );
+        assert_eq!(
+            stored.metadata.get("gov_operation").map(|s| s.as_str()),
+            Some("remove"),
+            "gov_operation must be 'remove'"
+        );
+
+        info!("✅ Phase A: member removed, provenance in metadata");
+        // All Arcs drop here → sled lock releases
+    }
+
+    // ── Phase B: cold-cache restart ───────────────────────────────────────────
+    let reloaded_store = open_coop_store(&store_path);
+    let reloaded_service = MembershipServiceImpl::new(reloaded_store);
+
+    let prov = reloaded_service.get_membership_provenance(domain_id, &member_did.to_string());
+    assert!(
+        prov.is_some(),
+        "get_membership_provenance must return Some after restart"
+    );
+    let (receipt_id_after, hash_after) = prov.unwrap();
+    assert_eq!(
+        receipt_id_after, expected_receipt_id,
+        "receipt_id must match"
+    );
+    assert_eq!(
+        hash_after, canonical_payload_hash,
+        "decision_hash must match canonical"
+    );
+
+    info!("✅ Phase B: cold-cache restart — remove provenance recovered from sled metadata");
+
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 2 — Remove legacy path (no canonical_hash): blake3 fallback
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn remove_member_without_canonical_hash_falls_back_to_receipt_hash() -> Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .with_test_writer()
+        .try_init();
+
+    let tmp = TempDir::new()?;
+    let store_path = tmp.path().join("coop-store-remove-legacy");
+
+    let member_kp = KeyPair::generate()?;
+    let member_did = member_kp.did().clone();
+
+    let domain_id = "test-coop-remove-legacy";
+    let proposal_id = "remove-legacy-001";
+    let expected_receipt_id = format!("gov:{domain_id}:{proposal_id}:receipt");
+
+    let coop_store = open_coop_store(&store_path);
+    seed_active_member(&coop_store, domain_id, &member_did);
+
+    let membership_service = Arc::new(MembershipServiceImpl::new(coop_store.clone()));
+    let kernel_executor = KernelGovernanceExecutor::new(Arc::new(StubParamStore))
+        .with_membership_service(membership_service.clone());
+    let dispatcher = Arc::new(EffectDispatcher::new(Arc::new(kernel_executor)));
+
+    let payload = ProposalPayload::Membership {
+        action: MembershipAction::Remove,
+        member: member_did.clone(),
+    };
+
+    let dispatcher_for_sub = dispatcher.clone();
+    let sub = create_effect_subscription(move |effects, dr_id| {
+        let d = dispatcher_for_sub.clone();
+        let id = dr_id.clone();
+        tokio::task::spawn(async move {
+            let _ = d.execute_effects(effects, &id).await;
+        });
+    });
+
+    sub(SystemEvent::ProposalAccepted {
+        proposal_id: proposal_id.to_string(),
+        domain_id: domain_id.to_string(),
+        payload: serde_json::to_value(&payload)?,
+        decided_at: 1_700_000_060,
+        canonical_payload_hash: None, // legacy: no canonical hash
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let stored = coop_store
+        .get_member(domain_id, &member_did)
+        .expect("Member should exist after legacy remove");
+
+    assert_eq!(
+        stored.status,
+        icn_coop::MemberStatus::Removed,
+        "member must be Removed even on legacy path"
+    );
+
+    let stored_receipt_id = stored
+        .metadata
+        .get("gov_decision_receipt_id")
+        .expect("gov_decision_receipt_id must be present");
+    let stored_decision_hash = stored
+        .metadata
+        .get("gov_decision_hash")
+        .expect("gov_decision_hash must be present");
+
+    assert_eq!(
+        stored_receipt_id.as_str(),
+        expected_receipt_id.as_str(),
+        "receipt_id must match even on legacy path"
+    );
+    // blake3 fallback produces a 64-char hex string
+    assert_eq!(
+        stored_decision_hash.len(),
+        64,
+        "Fallback decision_hash must be a 64-char blake3 hex string"
+    );
+
+    info!(
+        receipt_id = %stored_receipt_id,
+        decision_hash = %stored_decision_hash,
+        "✅ Legacy path: remove record written with blake3 fallback provenance"
+    );
+
+    Ok(())
+}

--- a/icn/crates/icn-core/tests/treasury_spend_governance_provenance.rs
+++ b/icn/crates/icn-core/tests/treasury_spend_governance_provenance.rs
@@ -1,0 +1,289 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! Proof: accepted treasury-spend proposals produce journal entries with verifiable provenance.
+//!
+//! This test closes the seam identified in sprint 26:
+//! `ProposalAccepted` → `create_effect_subscription` → `EffectDispatcher`
+//! → `KernelGovernanceExecutor` → `LedgerServiceImpl::submit_treasury_entry`
+//! → `JournalEntry { provenance: Governance { receipt_id, decision_hash } }`
+//!
+//! Specifically it proves:
+//! 1. `decision_receipt_id` in the journal == `"gov:{domain}:{proposal}:receipt"`
+//! 2. `decision_hash` in the journal == `canonical_payload_hash` from the event
+//!    (content hash, not hash-of-receipt-id placeholder)
+//! 3. Both values round-trip through sled (provenance survives restart)
+
+use anyhow::Result;
+use icn_core::services::LedgerServiceImpl;
+use icn_core::supervisor::effect_dispatcher::EffectDispatcher;
+use icn_core::supervisor::governance_executor::KernelGovernanceExecutor;
+use icn_governance::proposal::{ProposalPayload, TreasuryProposalOperation};
+use icn_governance_actor::create_effect_subscription;
+use icn_identity::KeyPair;
+use icn_kernel_api::authz::AllowAllOracle;
+use icn_kernel_api::events::SystemEvent;
+use icn_kernel_api::protocol_params::StubParamStore;
+use icn_ledger::types::ProvenanceRef;
+use icn_ledger::Ledger;
+use icn_store::SledStore;
+use std::sync::Arc;
+use tempfile::TempDir;
+use tokio::sync::RwLock;
+use tracing::info;
+
+/// Prove the full governance → treasury spend → journal provenance chain.
+///
+/// Chain under test:
+///   ProposalAccepted { canonical_payload_hash }
+///   → create_effect_subscription
+///   → EffectDispatcher::execute_effects
+///   → KernelGovernanceExecutor::execute_treasury_with_budget
+///   → LedgerServiceImpl::submit_treasury_entry
+///   → JournalEntry.provenance == Governance { receipt_id, decision_hash }
+#[tokio::test(flavor = "multi_thread")]
+async fn treasury_spend_accepted_proposal_produces_journal_entry_with_governance_provenance(
+) -> Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .with_test_writer()
+        .try_init();
+
+    info!("=== Treasury Spend Provenance: ProposalAccepted → Journal ===");
+
+    let tmp = TempDir::new()?;
+
+    // ── Ledger setup ──────────────────────────────────────────────────────────
+    let treasury_kp = KeyPair::generate()?;
+    let treasury_did = treasury_kp.did().clone();
+    let recipient_kp = KeyPair::generate()?;
+    let recipient_did = recipient_kp.did().clone();
+
+    let ledger_store = Arc::new(SledStore::open(tmp.path().join("ledger"))?);
+    let ledger = Arc::new(RwLock::new(Ledger::new(ledger_store.clone())?));
+
+    let ledger_service = Arc::new(LedgerServiceImpl::new(
+        ledger.clone(),
+        Arc::new(AllowAllOracle::wildcard()),
+        treasury_did.clone(),
+    ));
+
+    // ── KernelGovernanceExecutor (with ledger wired) ─────────────────────────
+    let kernel_executor = KernelGovernanceExecutor::new(Arc::new(StubParamStore))
+        .with_ledger_service(ledger_service);
+
+    let dispatcher = Arc::new(EffectDispatcher::new(Arc::new(kernel_executor)));
+
+    // ── Effect subscription (production path) ─────────────────────────────────
+    // Capture `(Vec<KernelEffect>, decision_receipt_id)` for introspection, then
+    // forward to EffectDispatcher so the full stack executes.
+    let dispatcher_for_sub = dispatcher.clone();
+    let subscription = create_effect_subscription(move |effects, decision_receipt_id| {
+        let disp = dispatcher_for_sub.clone();
+        let dr_id = decision_receipt_id.clone();
+        // execute_effects is async; spawn into the current runtime
+        tokio::task::spawn(async move {
+            let results = disp.execute_effects(effects, &dr_id).await;
+            match results {
+                Ok(results) => {
+                    info!(
+                        decision_receipt_id = %dr_id,
+                        result_count = results.len(),
+                        "EffectDispatcher processed effects"
+                    );
+                }
+                Err(e) => {
+                    tracing::error!(
+                        decision_receipt_id = %dr_id,
+                        error = %e,
+                        "EffectDispatcher error"
+                    );
+                }
+            }
+        });
+    });
+
+    // ── Construct ProposalAccepted with real content hash ─────────────────────
+    let domain_id = "test-coop";
+    let proposal_id = "spend-prop-001";
+
+    // Build the payload via the real Rust types so serde shape matches what
+    // create_effect_subscription / translate_payload_to_effects expect.
+    let payload = ProposalPayload::Treasury {
+        operation: TreasuryProposalOperation::Spend {
+            treasury_did: treasury_did.clone(),
+            amount: 100,
+            currency: "HOURS".to_string(),
+            recipient: recipient_did.clone(),
+            memo: "sprint-26 provenance proof".to_string(),
+            nonce: 0,
+        },
+    };
+    let payload_value = serde_json::to_value(&payload)?;
+
+    // Canonical content hash — a fixed test value.  The point is that when the
+    // event carries `canonical_payload_hash`, `create_effect_subscription` uses IT
+    // (not the blake3-of-receipt-id fallback) as the decision_hash in provenance.
+    let canonical_payload_hash = "sha256:test-canonical-payload-hash-001".to_string();
+
+    // Expected provenance fields after the chain completes
+    let expected_receipt_id = format!("gov:{domain_id}:{proposal_id}:receipt");
+    let expected_decision_hash = canonical_payload_hash.clone();
+
+    let event = SystemEvent::ProposalAccepted {
+        proposal_id: proposal_id.to_string(),
+        domain_id: domain_id.to_string(),
+        payload: payload_value,
+        decided_at: 1_700_000_000,
+        canonical_payload_hash: Some(canonical_payload_hash),
+    };
+
+    // ── Fire the event ────────────────────────────────────────────────────────
+    subscription(event);
+
+    // Give the spawned async task time to complete
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    // ── Verify journal entry ──────────────────────────────────────────────────
+    // Walk all entries in the ledger and find the one with Governance provenance
+    // that matches our expected receipt_id + decision_hash.
+    let ledger_guard = ledger.read().await;
+    let get_all_entries = ledger_guard.get_all_entries()?;
+
+    info!(entry_count = get_all_entries.len(), "Entries in ledger after effect dispatch");
+
+    let governance_entry = get_all_entries.iter().find(|e| {
+        matches!(
+            &e.provenance,
+            ProvenanceRef::Governance { receipt_id, decision_hash }
+                if receipt_id.as_str() == expected_receipt_id && decision_hash.as_str() == expected_decision_hash
+        )
+    });
+
+    assert!(
+        governance_entry.is_some(),
+        "Expected a journal entry with ProvenanceRef::Governance {{ receipt_id: {:?}, decision_hash: {:?} }}, \
+         but none was found. Entries: {:#?}",
+        expected_receipt_id,
+        expected_decision_hash,
+        get_all_entries.iter().map(|e| &e.provenance).collect::<Vec<_>>()
+    );
+
+    let entry = governance_entry.unwrap();
+
+    // Verify account deltas: treasury debit + recipient credit
+    assert!(
+        !entry.accounts.is_empty(),
+        "Journal entry must have account deltas"
+    );
+    let has_debit = entry.accounts.iter().any(|a| {
+        a.account_id.as_str() == treasury_did.as_str() && a.debit.is_some()
+    });
+    assert!(has_debit, "Treasury account must be debited");
+
+    info!(
+        receipt_id = %expected_receipt_id,
+        decision_hash = %expected_decision_hash,
+        accounts = entry.accounts.len(),
+        "✅ PROOF: accepted treasury spend proposal produced journal entry with governance provenance"
+    );
+
+    Ok(())
+}
+
+/// Prove that when canonical_payload_hash is absent (legacy events),
+/// the fallback blake3(receipt_id) is used — chain still works.
+#[tokio::test(flavor = "multi_thread")]
+async fn treasury_spend_without_canonical_hash_falls_back_to_receipt_hash() -> Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .with_test_writer()
+        .try_init();
+
+    let tmp = TempDir::new()?;
+
+    let treasury_kp = KeyPair::generate()?;
+    let treasury_did = treasury_kp.did().clone();
+    let recipient_kp = KeyPair::generate()?;
+    let recipient_did = recipient_kp.did().clone();
+
+    let ledger_store = Arc::new(SledStore::open(tmp.path().join("ledger"))?);
+    let ledger = Arc::new(RwLock::new(Ledger::new(ledger_store.clone())?));
+    let ledger_service = Arc::new(LedgerServiceImpl::new(
+        ledger.clone(),
+        Arc::new(AllowAllOracle::wildcard()),
+        treasury_did.clone(),
+    ));
+    let kernel_executor = KernelGovernanceExecutor::new(Arc::new(StubParamStore))
+        .with_ledger_service(ledger_service);
+    let dispatcher = Arc::new(EffectDispatcher::new(Arc::new(kernel_executor)));
+
+    let dispatcher_for_sub = dispatcher.clone();
+    let subscription = create_effect_subscription(move |effects, decision_receipt_id| {
+        let disp = dispatcher_for_sub.clone();
+        let dr_id = decision_receipt_id.clone();
+        tokio::task::spawn(async move {
+            let _ = disp.execute_effects(effects, &dr_id).await;
+        });
+    });
+
+    let domain_id = "test-coop";
+    let proposal_id = "spend-legacy-001";
+
+    let payload = ProposalPayload::Treasury {
+        operation: TreasuryProposalOperation::Spend {
+            treasury_did: treasury_did.clone(),
+            amount: 50,
+            currency: "HOURS".to_string(),
+            recipient: recipient_did.clone(),
+            memo: "legacy fallback test".to_string(),
+            nonce: 0,
+        },
+    };
+    let payload_value = serde_json::to_value(&payload)?;
+
+    // No canonical_payload_hash — simulates events from before sprint 26
+    let event = SystemEvent::ProposalAccepted {
+        proposal_id: proposal_id.to_string(),
+        domain_id: domain_id.to_string(),
+        payload: payload_value,
+        decided_at: 1_700_000_001,
+        canonical_payload_hash: None,
+    };
+
+    // Expected: receipt_id is deterministic; decision_hash is the blake3-of-receipt-id fallback
+    // (computed inside create_effect_subscription — we don't call blake3 from test code,
+    // so we verify the receipt_id and that the hash is a non-empty 64-char hex string).
+    let expected_receipt_id = format!("gov:{domain_id}:{proposal_id}:receipt");
+
+    subscription(event);
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let ledger_guard = ledger.read().await;
+    let get_all_entries = ledger_guard.get_all_entries()?;
+
+    let governance_entry = get_all_entries.iter().find(|e| {
+        matches!(
+            &e.provenance,
+            ProvenanceRef::Governance { receipt_id, decision_hash }
+                if receipt_id.as_str() == expected_receipt_id && decision_hash.len() == 64
+        )
+    });
+
+    assert!(
+        governance_entry.is_some(),
+        "Legacy path must produce journal entry with Governance {{ receipt_id: {expected_receipt_id:?}, \
+         decision_hash: <64-char blake3 hex> }}. Got entries: {:#?}",
+        get_all_entries.iter().map(|e| &e.provenance).collect::<Vec<_>>()
+    );
+
+    if let Some(ProvenanceRef::Governance { receipt_id, decision_hash }) =
+        governance_entry.map(|e| &e.provenance)
+    {
+        info!(
+            receipt_id = %receipt_id,
+            decision_hash = %decision_hash,
+            "✅ PROOF: legacy path (no canonical_hash) produces journal entry with fallback provenance"
+        );
+    }
+
+    Ok(())
+}

--- a/icn/crates/icn-core/tests/treasury_spend_governance_provenance.rs
+++ b/icn/crates/icn-core/tests/treasury_spend_governance_provenance.rs
@@ -67,8 +67,8 @@ async fn treasury_spend_accepted_proposal_produces_journal_entry_with_governance
     ));
 
     // ── KernelGovernanceExecutor (with ledger wired) ─────────────────────────
-    let kernel_executor = KernelGovernanceExecutor::new(Arc::new(StubParamStore))
-        .with_ledger_service(ledger_service);
+    let kernel_executor =
+        KernelGovernanceExecutor::new(Arc::new(StubParamStore)).with_ledger_service(ledger_service);
 
     let dispatcher = Arc::new(EffectDispatcher::new(Arc::new(kernel_executor)));
 
@@ -148,7 +148,10 @@ async fn treasury_spend_accepted_proposal_produces_journal_entry_with_governance
     let ledger_guard = ledger.read().await;
     let get_all_entries = ledger_guard.get_all_entries()?;
 
-    info!(entry_count = get_all_entries.len(), "Entries in ledger after effect dispatch");
+    info!(
+        entry_count = get_all_entries.len(),
+        "Entries in ledger after effect dispatch"
+    );
 
     let governance_entry = get_all_entries.iter().find(|e| {
         matches!(
@@ -174,9 +177,10 @@ async fn treasury_spend_accepted_proposal_produces_journal_entry_with_governance
         !entry.accounts.is_empty(),
         "Journal entry must have account deltas"
     );
-    let has_debit = entry.accounts.iter().any(|a| {
-        a.account_id.as_str() == treasury_did.as_str() && a.debit.is_some()
-    });
+    let has_debit = entry
+        .accounts
+        .iter()
+        .any(|a| a.account_id.as_str() == treasury_did.as_str() && a.debit.is_some());
     assert!(has_debit, "Treasury account must be debited");
 
     info!(
@@ -212,8 +216,8 @@ async fn treasury_spend_without_canonical_hash_falls_back_to_receipt_hash() -> R
         Arc::new(AllowAllOracle::wildcard()),
         treasury_did.clone(),
     ));
-    let kernel_executor = KernelGovernanceExecutor::new(Arc::new(StubParamStore))
-        .with_ledger_service(ledger_service);
+    let kernel_executor =
+        KernelGovernanceExecutor::new(Arc::new(StubParamStore)).with_ledger_service(ledger_service);
     let dispatcher = Arc::new(EffectDispatcher::new(Arc::new(kernel_executor)));
 
     let dispatcher_for_sub = dispatcher.clone();
@@ -275,8 +279,10 @@ async fn treasury_spend_without_canonical_hash_falls_back_to_receipt_hash() -> R
         get_all_entries.iter().map(|e| &e.provenance).collect::<Vec<_>>()
     );
 
-    if let Some(ProvenanceRef::Governance { receipt_id, decision_hash }) =
-        governance_entry.map(|e| &e.provenance)
+    if let Some(ProvenanceRef::Governance {
+        receipt_id,
+        decision_hash,
+    }) = governance_entry.map(|e| &e.provenance)
     {
         info!(
             receipt_id = %receipt_id,

--- a/icn/crates/icn-kernel-api/src/effects.rs
+++ b/icn/crates/icn-kernel-api/src/effects.rs
@@ -216,11 +216,17 @@ pub enum MembershipEffect {
         member_did: String,
         reason: String,
         duration_secs: Option<u64>,
+        /// Canonical content hash of the governance decision payload.
+        #[serde(default)]
+        decision_hash: String,
     },
     /// Unfreeze member (restore rights)
     UnfreezeMember {
         entity_id: String,
         member_did: String,
+        /// Canonical content hash of the governance decision payload.
+        #[serde(default)]
+        decision_hash: String,
     },
 }
 
@@ -587,6 +593,7 @@ mod tests {
             member_did: "did:icn:bob".into(),
             reason: "Policy violation".into(),
             duration_secs: Some(86400),
+            decision_hash: String::new(),
         };
 
         let json = serde_json::to_string(&effect).unwrap();
@@ -698,6 +705,7 @@ mod tests {
                 member_did: "did:icn:carol".into(),
                 reason: "Policy violation".into(),
                 duration_secs: Some(86400),
+                decision_hash: String::new(),
             }),
             KernelEffect::Protocol(ProtocolEffect::SetParameter {
                 parameter_name: "voting_period".into(),
@@ -872,10 +880,12 @@ mod tests {
                 member_did: "did:icn:m1".into(),
                 reason: "Investigation".into(),
                 duration_secs: Some(3600),
+                decision_hash: String::new(),
             },
             MembershipEffect::UnfreezeMember {
                 entity_id: "e1".into(),
                 member_did: "did:icn:m1".into(),
+                decision_hash: String::new(),
             },
         ];
 

--- a/icn/crates/icn-kernel-api/src/effects.rs
+++ b/icn/crates/icn-kernel-api/src/effects.rs
@@ -191,6 +191,11 @@ pub enum MembershipEffect {
         member_did: String,
         role: String,
         tier: String,
+        /// Canonical content hash of the governance decision payload.
+        /// Carried here so executors can store it as verifiable provenance
+        /// without recomputing from the receipt_id string.
+        #[serde(default)]
+        decision_hash: String,
     },
     /// Remove a member
     RemoveMember {
@@ -680,6 +685,7 @@ mod tests {
                 member_did: "did:icn:bob".into(),
                 role: "worker".into(),
                 tier: "standard".into(),
+                decision_hash: String::new(),
             }),
             KernelEffect::Membership(MembershipEffect::UpdateMember {
                 entity_id: "coop-1".into(),
@@ -848,6 +854,7 @@ mod tests {
                 member_did: "did:icn:m1".into(),
                 role: "worker".into(),
                 tier: "standard".into(),
+                decision_hash: String::new(),
             },
             MembershipEffect::RemoveMember {
                 entity_id: "e1".into(),

--- a/icn/crates/icn-kernel-api/src/effects.rs
+++ b/icn/crates/icn-kernel-api/src/effects.rs
@@ -202,6 +202,9 @@ pub enum MembershipEffect {
         entity_id: String,
         member_did: String,
         reason: String,
+        /// Canonical content hash of the governance decision payload.
+        #[serde(default)]
+        decision_hash: String,
     },
     /// Change member role/tier
     UpdateMember {
@@ -868,6 +871,7 @@ mod tests {
                 entity_id: "e1".into(),
                 member_did: "did:icn:m1".into(),
                 reason: "Voluntary exit".into(),
+                decision_hash: String::new(),
             },
             MembershipEffect::UpdateMember {
                 entity_id: "e1".into(),

--- a/icn/crates/icn-kernel-api/src/events.rs
+++ b/icn/crates/icn-kernel-api/src/events.rs
@@ -23,6 +23,13 @@ pub enum SystemEvent {
         payload: serde_json::Value,
         /// Unix timestamp when the proposal was decided
         decided_at: u64,
+        /// Canonical content hash of the accepted proposal payload.
+        ///
+        /// When present, this is used as `decision_hash` in journal provenance, enabling
+        /// third-party verification against the original proposal content.
+        /// When absent, `create_effect_subscription` falls back to `blake3(receipt_id)`.
+        /// Introduced in sprint 26 to close the treasury-spend provenance seam.
+        canonical_payload_hash: Option<String>,
     },
 
     /// A governance proposal was rejected or failed to reach quorum


### PR DESCRIPTION
## Summary

Closes the governance provenance seam across the entire membership-action family. Accepted proposals now produce durable sled-backed state mutations with canonical payload hash provenance that survives process restarts.

**Before:** `MembershipEffect::AddMember/RemoveMember/FreezeMember/UnfreezeMember` carried no `decision_hash` field → executor always fell back to `blake3(receipt_id)`, the canonical payload hash from `ProposalAccepted` was silently dropped, and `gov_decision_*` keys were never written to `member.metadata` → `get_membership_provenance()` returned `None` after restart (cold-cache path broken).

**After:** All four variants carry `decision_hash` (canonical preferred, blake3 fallback for legacy/empty), the executor uses the effect-carried hash, and all service methods embed `gov_decision_receipt_id`, `gov_decision_hash`, `gov_operation` into `member.metadata` before `save_member()`.

- `MembershipEffect::AddMember` — `#[serde(default)] decision_hash: String` + threaded through translator + service writes to metadata
- `MembershipEffect::FreezeMember` — same
- `MembershipEffect::UnfreezeMember` — same
- `MembershipEffect::RemoveMember` — same
- Resource access (`ResourceEffect::GrantAccess/RevokeAccess`) — real store-wired execution replacing stub
- Treasury spend (`TreasuryEffect::Spend`) — ledger journal entry with governance provenance

## Test plan

- [ ] `cargo test -p icn-core --test membership_action_governance_integration` — Add: canonical hash, cold-cache restart, legacy fallback
- [ ] `cargo test -p icn-core --test freeze_unfreeze_governance_integration` — Freeze/Unfreeze: status mutation, canonical hash, restart, legacy
- [ ] `cargo test -p icn-core --test remove_member_governance_integration` — Remove: canonical hash, cold-cache restart, legacy fallback
- [ ] `cargo test -p icn-core --test effect_group_integration` — existing provenance chain tests (10 tests)
- [ ] `cargo clippy -p icn-governance-actor -p icn-ledger-actor -p icn-core -p icn-kernel-api --all-targets -- -D warnings` — clean

All 14 integration tests pass locally. Backward compatible via `#[serde(default)]` on all new fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)