### PR TITLE
feat(provenance): harden governance decision hash threading and forced-accept audit reads

### DIFF
--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -2034,13 +2034,33 @@ impl GovernanceActor {
                                 let canonical_payload_hash = serde_json::to_string(&payload)
                                     .ok()
                                     .map(|s| blake3::hash(s.as_bytes()).to_hex().to_string());
+                                // Compute a canonical governance decision hash for the forced
+                                // accept using the same GovernanceDecisionReceipt encoding as
+                                // voted accepts.  VoteTally{0,0,0} accurately represents
+                                // "forced by authority — no votes were cast."
+                                //
+                                // NOTE: no GovernanceDecisionReceipt is stored in the receipt
+                                // backend for forced accepts (the actor has no receipt_store).
+                                // Audit verify will find journal entries via this hash but will
+                                // report "No governance receipt present" — which is honest.
+                                use icn_governance::proof::ProofOutcome;
+                                let forced_decision_hash = {
+                                    let receipt = GovernanceDecisionReceipt::new(
+                                        proposal_id.0.clone(),
+                                        proposal.domain_id.0.clone(),
+                                        ProofOutcome::Accepted,
+                                        VoteTally::empty(),
+                                        &[],
+                                    );
+                                    Some(hex::encode(receipt.decision_hash))
+                                };
                                 SystemEvent::ProposalAccepted {
                                     proposal_id: proposal_id.0.clone(),
                                     domain_id: proposal.domain_id.0.clone(),
                                     payload,
                                     decided_at: now,
                                     canonical_payload_hash,
-                                    governance_decision_hash: None,
+                                    governance_decision_hash: forced_decision_hash,
                                 }
                             }
                             Err(e) => {

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -1782,7 +1782,15 @@ impl GovernanceActor {
                 // ProposalAccepted event fires without a receipt that is (a) Accepted and
                 // (b) internally consistent (verify() passes). Non-Accepted outcomes skip
                 // the gate entirely; they never produce resource-allocation effects.
-                if matches!(outcome_result, DecisionOutcome::Accepted) {
+                //
+                // The canonical governance decision hash (gate_receipt.decision_hash) is
+                // propagated to the ProposalAccepted event so that journal entries created
+                // by create_effect_subscription carry the same hash that keys the
+                // governance receipt chain — enabling hash-level audit verification.
+                let governance_decision_hash: Option<String> = if matches!(
+                    outcome_result,
+                    DecisionOutcome::Accepted
+                ) {
                     use icn_governance::proof::ProofOutcome;
                     let gate_receipt = GovernanceDecisionReceipt::new(
                         proposal_id.0.clone(),
@@ -1802,12 +1810,16 @@ impl GovernanceActor {
                             proposal_id.0
                         );
                     }
+                    let decision_hash_hex = hex::encode(gate_receipt.decision_hash);
                     info!(
                         proposal_id = %proposal_id.0,
-                        decision_hash = %hex::encode(gate_receipt.decision_hash),
+                        decision_hash = %decision_hash_hex,
                         "Invariant 7 gate passed"
                     );
-                }
+                    Some(decision_hash_hex)
+                } else {
+                    None
+                };
 
                 // Generate GovernanceProofV2 if signing key is available
                 let proof_bytes = if let Some(ref signing_key) = self.signing_key {
@@ -1908,6 +1920,7 @@ impl GovernanceActor {
                                         payload,
                                         decided_at: now,
                                         canonical_payload_hash,
+                                        governance_decision_hash: governance_decision_hash.clone(),
                                     }
                                 }
                                 Err(e) => {
@@ -2027,6 +2040,7 @@ impl GovernanceActor {
                                     payload,
                                     decided_at: now,
                                     canonical_payload_hash,
+                                    governance_decision_hash: None,
                                 }
                             }
                             Err(e) => {

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -319,4 +319,126 @@ mod tests {
             other => panic!("expected classified NoOp fallback, got {other:?}"),
         }
     }
+
+    /// Prove forced-accept provenance: the governance_decision_hash produced by the
+    /// forced-accept path is a canonical GovernanceDecisionReceipt hash (not a content
+    /// hash), is deterministic, and is distinct from canonical_payload_hash.
+    ///
+    /// This validates the actor.rs forced-accept fix without requiring the full actor
+    /// to be spawned: we construct the event exactly as the actor would and verify that
+    /// create_effect_subscription forwards the governance_decision_hash (not the content
+    /// hash fallback) as the decision_hash in the captured effect receipt_id.
+    #[test]
+    fn forced_accept_emits_canonical_governance_decision_hash_not_content_hash() {
+        use icn_governance::proof::{GovernanceDecisionReceipt, ProofOutcome};
+        use icn_governance::tally::VoteTally;
+
+        let domain_id = "test-forced-domain";
+        let proposal_id = "forced-prop-001";
+
+        // Replicate the exact hash computation from the actor's forced-accept path.
+        let forced_decision_hash = {
+            let receipt = GovernanceDecisionReceipt::new(
+                proposal_id.to_string(),
+                domain_id.to_string(),
+                ProofOutcome::Accepted,
+                VoteTally::empty(),
+                &[],
+            );
+            hex::encode(receipt.decision_hash)
+        };
+
+        // The content hash is different — compute it so we can prove non-equality.
+        let payload = ProposalPayload::Treasury {
+            operation: TreasuryProposalOperation::Spend {
+                treasury_did: "did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9"
+                    .parse::<Did>()
+                    .expect("valid did"),
+                amount: 10,
+                currency: "HOURS".to_string(),
+                recipient: "did:icn:z8eQZfY3RY75YwQ6MrFCHt9phbi3HGx1caFXE3291ow8t"
+                    .parse::<Did>()
+                    .expect("valid did"),
+                memo: "forced-accept test".to_string(),
+                nonce: 0,
+            },
+        };
+        let payload_value = serde_json::to_value(&payload).expect("serialize payload");
+        let canonical_payload_hash = serde_json::to_string(&payload_value)
+            .ok()
+            .map(|s| blake3::hash(s.as_bytes()).to_hex().to_string())
+            .expect("content hash");
+
+        // Invariant: forced_decision_hash must differ from canonical_payload_hash.
+        assert_ne!(
+            forced_decision_hash, canonical_payload_hash,
+            "governance decision hash must not equal content hash — they encode different things"
+        );
+
+        // Invariant: forced_decision_hash is 64 hex chars (canonical receipt hash format).
+        assert_eq!(
+            forced_decision_hash.len(),
+            64,
+            "forced decision hash must be 64 hex chars"
+        );
+        assert!(
+            forced_decision_hash.chars().all(|c| c.is_ascii_hexdigit()),
+            "forced decision hash must be valid hex"
+        );
+
+        // Invariant: deterministic — same inputs produce the same hash.
+        let second_hash = {
+            let receipt = GovernanceDecisionReceipt::new(
+                proposal_id.to_string(),
+                domain_id.to_string(),
+                ProofOutcome::Accepted,
+                VoteTally::empty(),
+                &[],
+            );
+            hex::encode(receipt.decision_hash)
+        };
+        assert_eq!(
+            forced_decision_hash, second_hash,
+            "forced decision hash must be deterministic"
+        );
+
+        // Prove create_effect_subscription uses governance_decision_hash (not content hash)
+        // when governance_decision_hash is present — which is what the fixed actor now sets.
+        let captured: CapturedEffects = Arc::new(Mutex::new(vec![]));
+        let sink = captured.clone();
+        let subscription = create_effect_subscription(move |effects, receipt_id| {
+            sink.lock().expect("lock").push((effects, receipt_id));
+        });
+
+        let expected_receipt_id = format!("gov:{domain_id}:{proposal_id}:receipt");
+
+        subscription(SystemEvent::ProposalAccepted {
+            proposal_id: proposal_id.to_string(),
+            domain_id: domain_id.to_string(),
+            payload: payload_value,
+            decided_at: 1_700_000_099,
+            canonical_payload_hash: Some(canonical_payload_hash.clone()),
+            governance_decision_hash: Some(forced_decision_hash.clone()),
+        });
+
+        let got = captured.lock().expect("lock");
+        assert_eq!(got.len(), 1, "subscription must fire exactly once");
+        assert_eq!(
+            got[0].1, expected_receipt_id,
+            "receipt_id must use standard gov:domain:proposal:receipt format"
+        );
+
+        // The effect carries the forced_decision_hash as its provenance reference.
+        // For treasury spend, this means TreasuryEffect::Spend.decision_hash == forced_hash.
+        assert!(
+            matches!(
+                got[0].0.first(),
+                Some(KernelEffect::Treasury(TreasuryEffect::Spend { decision_hash, .. }))
+                    if decision_hash == &forced_decision_hash
+            ),
+            "TreasuryEffect::Spend must carry forced decision hash, not content hash. \
+             Got effect: {:?}",
+            got[0].0.first()
+        );
+    }
 }

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -123,15 +123,19 @@ where
             payload,
             domain_id,
             canonical_payload_hash,
+            governance_decision_hash,
             ..
         } = &event
         {
             // Generate decision_receipt_id from proposal_id and domain
             let decision_receipt_id = format!("gov:{domain_id}:{proposal_id}:receipt");
-            // Use canonical content hash when provided; fall back to hash-of-receipt-id
-            // for backward compatibility with events emitted before sprint 26.
-            let decision_hash = canonical_payload_hash
+            // Prefer governance_decision_hash (canonical GovernanceDecisionReceipt hash,
+            // includes votes + tally + outcome) when provided by actor.rs Invariant 7 gate.
+            // Fall back to canonical_payload_hash (content hash) for sprint 26 compatibility,
+            // then to blake3(receipt_id) for legacy events with no hash at all.
+            let decision_hash = governance_decision_hash
                 .clone()
+                .or_else(|| canonical_payload_hash.clone())
                 .unwrap_or_else(|| compute_decision_hash(&decision_receipt_id));
 
             // Deserialize payload
@@ -244,6 +248,7 @@ mod tests {
             payload: serde_json::to_value(payload).expect("serialize payload"),
             decided_at: 1_700_000_000,
             canonical_payload_hash: None,
+            governance_decision_hash: None,
         };
 
         subscription(event);
@@ -287,6 +292,7 @@ mod tests {
             payload: serde_json::to_value(payload).expect("serialize payload"),
             decided_at: 1_700_000_001,
             canonical_payload_hash: None,
+            governance_decision_hash: None,
         };
 
         subscription(event);

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -11036,7 +11036,7 @@ mod audit_verify_tests {
         let decision_hash = "a".repeat(64);
         let journal_entries = vec![JournalEntryProvenanceResponse {
             entry_id: "entry-1".to_string(),
-            decision_receipt_id: format!("gov:domain-1:prop-1:receipt"),
+            decision_receipt_id: "gov:domain-1:prop-1:receipt".to_string(),
             decision_hash: decision_hash.clone(),
             account_count: 2,
             timestamp: 1_700_000_000,

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -10418,6 +10418,42 @@ fn verify_receipt_chain(
         },
     });
 
+    // Check 12: Journal entries present for this decision.
+    // An accepted treasury spend must produce at least one ledger journal entry.
+    // Absence here means the economic effect was either not executed or the ledger
+    // manager was unavailable at query time (informational when empty, not a hard failure).
+    let has_journal = !chain.journal_entries.is_empty();
+    checks.push(AuditCheck {
+        name: "Journal entries present".to_string(),
+        passed: has_journal,
+        detail: format!(
+            "{} journal entry/entries found",
+            chain.journal_entries.len()
+        ),
+    });
+
+    // Check 13: All journal entries carry governance provenance matching this decision.
+    // This proves the economic artifact was created by THIS decision, not coincidentally
+    // referencing the same hash.
+    let all_journal_linked = chain
+        .journal_entries
+        .iter()
+        .all(|j| j.decision_hash == decision_hash);
+    checks.push(AuditCheck {
+        name: "Journal provenance matches decision".to_string(),
+        passed: !has_journal || all_journal_linked,
+        detail: if !has_journal {
+            "No journal entries to verify".to_string()
+        } else if all_journal_linked {
+            format!(
+                "All {} journal entries carry matching governance provenance",
+                chain.journal_entries.len()
+            )
+        } else {
+            "Some journal entries carry mismatched decision hash".to_string()
+        },
+    });
+
     checks
 }
 
@@ -10896,10 +10932,18 @@ mod audit_verify_tests {
     use super::verify_receipt_chain;
     use icn_gateway::api::receipts::{
         DecisionExecutionTruthResponse, GovernanceReceiptResponse, GovernanceVoteTallyResponse,
-        ReceiptChainResponse,
+        JournalEntryProvenanceResponse, ReceiptChainResponse,
     };
 
     fn sample_chain(execution_complete: bool, not_executed: usize) -> ReceiptChainResponse {
+        sample_chain_with_journal(execution_complete, not_executed, vec![])
+    }
+
+    fn sample_chain_with_journal(
+        execution_complete: bool,
+        not_executed: usize,
+        journal_entries: Vec<JournalEntryProvenanceResponse>,
+    ) -> ReceiptChainResponse {
         ReceiptChainResponse {
             decision_hash: "a".repeat(64),
             governance: Some(GovernanceReceiptResponse {
@@ -10916,6 +10960,7 @@ mod audit_verify_tests {
             }),
             allocations: vec![],
             intents: vec![],
+            journal_entries,
             structural_complete: true,
             execution_complete,
             chain_complete: execution_complete,
@@ -10952,6 +10997,66 @@ mod audit_verify_tests {
                 .iter()
                 .any(|c| c.name == "Execution complete" && c.passed),
             "full execution must pass execution-complete check"
+        );
+    }
+
+    #[test]
+    fn missing_journal_entries_fails_journal_present_check() {
+        // journal_entries is empty → check 12 must fail
+        let chain = sample_chain_with_journal(true, 0, vec![]);
+        let checks = verify_receipt_chain(&chain, &"a".repeat(64));
+        assert!(
+            checks
+                .iter()
+                .any(|c| c.name == "Journal entries present" && !c.passed),
+            "empty journal_entries must fail check 12"
+        );
+    }
+
+    #[test]
+    fn journal_entries_with_matching_hash_passes_both_journal_checks() {
+        let decision_hash = "a".repeat(64);
+        let journal_entries = vec![JournalEntryProvenanceResponse {
+            entry_id: "entry-1".to_string(),
+            decision_receipt_id: format!("gov:domain-1:prop-1:receipt"),
+            decision_hash: decision_hash.clone(),
+            account_count: 2,
+            timestamp: 1_700_000_000,
+        }];
+        let chain = sample_chain_with_journal(true, 0, journal_entries);
+        let checks = verify_receipt_chain(&chain, &decision_hash);
+        assert!(
+            checks
+                .iter()
+                .any(|c| c.name == "Journal entries present" && c.passed),
+            "present journal entry must pass check 12"
+        );
+        assert!(
+            checks
+                .iter()
+                .any(|c| c.name == "Journal provenance matches decision" && c.passed),
+            "matching decision_hash must pass check 13"
+        );
+    }
+
+    #[test]
+    fn journal_entry_with_wrong_hash_fails_provenance_check() {
+        let decision_hash = "a".repeat(64);
+        let wrong_hash = "b".repeat(64);
+        let journal_entries = vec![JournalEntryProvenanceResponse {
+            entry_id: "entry-bad".to_string(),
+            decision_receipt_id: "gov:domain-1:prop-1:receipt".to_string(),
+            decision_hash: wrong_hash, // mismatched — provenance check must fail
+            account_count: 2,
+            timestamp: 1_700_000_001,
+        }];
+        let chain = sample_chain_with_journal(true, 0, journal_entries);
+        let checks = verify_receipt_chain(&chain, &decision_hash);
+        assert!(
+            checks
+                .iter()
+                .any(|c| c.name == "Journal provenance matches decision" && !c.passed),
+            "mismatched decision_hash must fail check 13"
         );
     }
 }

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -285,6 +285,17 @@ enum AuditCommands {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+
+        /// Cooperative/domain ID hint for forced-accept decisions.
+        ///
+        /// For normal voted decisions the domain_id is stored in the governance receipt
+        /// and this flag is unnecessary. For forced-accept decisions (no stored receipt),
+        /// supplying this allows journal cross-reference to succeed.
+        ///
+        /// Does not imply a governance receipt exists. Check 1 will still report FAIL
+        /// for forced accepts even when journal entries are successfully found.
+        #[arg(long, value_name = "ID")]
+        domain_id: Option<String>,
     },
 }
 
@@ -10469,13 +10480,20 @@ async fn handle_audit_command(cmd: AuditCommands) -> Result<()> {
             decision_hash,
             gateway,
             json,
+            domain_id,
         } => {
             if decision_hash.len() != 64 || !decision_hash.chars().all(|c| c.is_ascii_hexdigit()) {
                 bail!("Invalid decision hash: expected 64 hex characters");
             }
 
             let client = reqwest::Client::new();
-            let url = format!("{}/v1/receipts/chain/{}", gateway, decision_hash);
+            let url = match &domain_id {
+                Some(id) => format!(
+                    "{}/v1/receipts/chain/{}?domain_id={}",
+                    gateway, decision_hash, id
+                ),
+                None => format!("{}/v1/receipts/chain/{}", gateway, decision_hash),
+            };
             let resp = client
                 .get(&url)
                 .send()

--- a/icn/bins/icnctl/tests/audit_verify_test.rs
+++ b/icn/bins/icnctl/tests/audit_verify_test.rs
@@ -396,3 +396,70 @@ fn test_journal_entry_with_wrong_hash_fails_provenance_check() {
         "Journal provenance check must fail on hash mismatch"
     );
 }
+
+/// Forced-accept honesty: governance=None (no stored receipt), but journal
+/// cross-reference succeeded because the caller supplied domain_id.
+///
+/// This is the expected state after `icnctl audit verify --domain-id <id>` is
+/// used for a forced-accept decision where the gateway found journal entries
+/// but has no stored governance receipt.
+///
+/// Check 1 (governance present) must FAIL — the absence of a receipt is truth.
+/// Checks 12+13 (journal present + provenance matched) must PASS.
+///
+/// This proves the CLI output is honest about the forced-accept distinction:
+/// economic execution is visible and verifiable, but no voted receipt exists.
+#[test]
+fn test_forced_accept_audit_output_is_honest() {
+    // Simulate a chain returned when the gateway found journal entries via
+    // ?domain_id= but had no stored governance receipt (forced-accept path).
+    let chain = ReceiptChainResponse {
+        decision_hash: DECISION_HASH.to_string(),
+        governance: None, // No stored voted governance receipt — forced accept
+        allocations: vec![],
+        intents: vec![],
+        journal_entries: vec![make_journal_entry(DECISION_HASH)],
+        structural_complete: false, // no governance receipt → structural incomplete
+        execution_complete: true,
+        chain_complete: false,
+        execution: DecisionExecutionTruthResponse {
+            execution_record_present: true,
+            status: None,
+            total_effects: 1,
+            executed_effects: 1,
+            not_executed_effects: 0,
+            hard_failed_effects: 0,
+            execution_complete: true,
+        },
+    };
+    let checks = verify_receipt_chain(&chain, DECISION_HASH);
+
+    // Check 1: governance absent → FAIL (truthful — no stored receipt)
+    assert!(
+        !checks[0].1,
+        "Governance check must FAIL for forced-accept (no stored receipt)"
+    );
+    assert_eq!(
+        checks[0].2, "No governance decision receipt found",
+        "Detail must state absence, not a misleading message"
+    );
+
+    // Check 11 (chain complete contract): structural_complete=false,
+    // execution_complete=true → chain_complete=false → contract holds
+    assert!(
+        checks[10].1,
+        "Chain complete contract must still hold for forced-accept"
+    );
+
+    // Check 12: journal entries present → PASS
+    assert!(
+        checks[11].1,
+        "Journal entries check must PASS when domain_id hint surfaced entries"
+    );
+
+    // Check 13: provenance matches → PASS
+    assert!(
+        checks[12].1,
+        "Journal provenance check must PASS when entries carry the correct decision hash"
+    );
+}

--- a/icn/bins/icnctl/tests/audit_verify_test.rs
+++ b/icn/bins/icnctl/tests/audit_verify_test.rs
@@ -7,7 +7,8 @@
 
 use icn_gateway::api::receipts::{
     AllocationReceiptResponse, DecisionExecutionTruthResponse, GovernanceReceiptResponse,
-    GovernanceVoteTallyResponse, ReceiptChainResponse, SettlementIntentResponse,
+    GovernanceVoteTallyResponse, JournalEntryProvenanceResponse, ReceiptChainResponse,
+    SettlementIntentResponse,
 };
 
 const DECISION_HASH: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -54,6 +55,16 @@ fn make_allocation(intent_hashes: Vec<String>) -> AllocationReceiptResponse {
     }
 }
 
+fn make_journal_entry(decision_hash: &str) -> JournalEntryProvenanceResponse {
+    JournalEntryProvenanceResponse {
+        entry_id: "entry-1".to_string(),
+        decision_receipt_id: "gov:test-domain:prop-1:receipt".to_string(),
+        decision_hash: decision_hash.to_string(),
+        account_count: 2,
+        timestamp: 1_700_000_000,
+    }
+}
+
 fn make_complete_chain() -> ReceiptChainResponse {
     let intent_hash = "dd".repeat(32);
     ReceiptChainResponse {
@@ -61,6 +72,7 @@ fn make_complete_chain() -> ReceiptChainResponse {
         governance: Some(make_governance()),
         allocations: vec![make_allocation(vec![intent_hash.clone()])],
         intents: vec![make_intent(&intent_hash)],
+        journal_entries: vec![make_journal_entry(DECISION_HASH)],
         structural_complete: true,
         execution_complete: true,
         chain_complete: true,
@@ -194,6 +206,28 @@ fn verify_receipt_chain(
         String::new(),
     ));
 
+    // 12: Journal entries present
+    let has_journal = !chain.journal_entries.is_empty();
+    checks.push((
+        "Journal entries present".to_string(),
+        has_journal,
+        format!(
+            "{} journal entry/entries found",
+            chain.journal_entries.len()
+        ),
+    ));
+
+    // 13: Journal provenance matches decision
+    let all_journal_linked = chain
+        .journal_entries
+        .iter()
+        .all(|j| j.decision_hash == decision_hash);
+    checks.push((
+        "Journal provenance matches decision".to_string(),
+        !has_journal || all_journal_linked,
+        String::new(),
+    ));
+
     checks
 }
 
@@ -202,7 +236,7 @@ fn test_complete_chain_passes_all_checks() {
     let chain = make_complete_chain();
     let checks = verify_receipt_chain(&chain, DECISION_HASH);
 
-    assert_eq!(checks.len(), 11);
+    assert_eq!(checks.len(), 13);
     for (name, passed, _) in &checks {
         assert!(passed, "Check '{}' should pass on complete chain", name);
     }
@@ -216,6 +250,7 @@ fn test_missing_governance_fails() {
         governance: None,
         allocations: vec![make_allocation(vec![intent_hash.clone()])],
         intents: vec![make_intent(&intent_hash)],
+        journal_entries: vec![],
         structural_complete: false,
         execution_complete: false,
         chain_complete: false,
@@ -256,6 +291,7 @@ fn test_orphaned_intent_detected() {
         governance: Some(make_governance()),
         allocations: vec![make_allocation(vec![intent_hash.clone()])],
         intents: vec![make_intent(&intent_hash), make_intent(&orphan_hash)],
+        journal_entries: vec![make_journal_entry(DECISION_HASH)],
         structural_complete: true,
         execution_complete: true,
         chain_complete: true,
@@ -281,6 +317,7 @@ fn test_empty_chain_reports_missing() {
         governance: None,
         allocations: vec![],
         intents: vec![],
+        journal_entries: vec![],
         structural_complete: false,
         execution_complete: false,
         chain_complete: false,
@@ -305,6 +342,12 @@ fn test_empty_chain_reports_missing() {
     assert!(checks[5].1, "Intent provenance vacuously passes");
     assert!(checks[6].1, "Orphan check vacuously passes");
     assert!(checks[10].1, "Chain complete contract should hold");
+    // Journal checks: empty journal fails present check, provenance passes vacuously
+    assert!(!checks[11].1, "Journal entries should fail when absent");
+    assert!(
+        checks[12].1,
+        "Journal provenance vacuously passes when empty"
+    );
 }
 
 #[test]
@@ -316,5 +359,40 @@ fn test_serde_roundtrip_of_chain_response() {
     assert_eq!(chain.chain_complete, deserialized.chain_complete);
     assert_eq!(chain.allocations.len(), deserialized.allocations.len());
     assert_eq!(chain.intents.len(), deserialized.intents.len());
+    assert_eq!(
+        chain.journal_entries.len(),
+        deserialized.journal_entries.len()
+    );
     assert!(deserialized.governance.is_some());
+}
+
+#[test]
+fn test_journal_entry_with_wrong_hash_fails_provenance_check() {
+    let wrong_hash = "bb".repeat(32);
+    let chain = ReceiptChainResponse {
+        decision_hash: DECISION_HASH.to_string(),
+        governance: Some(make_governance()),
+        allocations: vec![],
+        intents: vec![],
+        journal_entries: vec![make_journal_entry(&wrong_hash)], // wrong decision hash
+        structural_complete: false,
+        execution_complete: true,
+        chain_complete: false,
+        execution: DecisionExecutionTruthResponse {
+            execution_record_present: true,
+            status: None,
+            total_effects: 1,
+            executed_effects: 1,
+            not_executed_effects: 0,
+            hard_failed_effects: 0,
+            execution_complete: true,
+        },
+    };
+    let checks = verify_receipt_chain(&chain, DECISION_HASH);
+
+    assert!(checks[11].1, "Journal entry present check should pass");
+    assert!(
+        !checks[12].1,
+        "Journal provenance check must fail on hash mismatch"
+    );
 }

--- a/icn/crates/icn-core/src/events.rs
+++ b/icn/crates/icn-core/src/events.rs
@@ -164,6 +164,7 @@ mod tests {
             }),
             decided_at: 1234567890,
             canonical_payload_hash: None,
+            governance_decision_hash: None,
         };
 
         bus.emit(event).await;
@@ -259,6 +260,7 @@ mod tests {
             }),
             decided_at: 1234567890,
             canonical_payload_hash: None,
+            governance_decision_hash: None,
         };
 
         bus.emit(event).await;
@@ -322,6 +324,7 @@ mod tests {
             payload: serde_json::json!({"NotAValidVariant": true}),
             decided_at: 0,
             canonical_payload_hash: None,
+            governance_decision_hash: None,
         })
         .await;
 

--- a/icn/crates/icn-core/tests/freeze_unfreeze_governance_integration.rs
+++ b/icn/crates/icn-core/tests/freeze_unfreeze_governance_integration.rs
@@ -114,6 +114,7 @@ async fn freeze_member_accepted_proposal_produces_durable_record_with_governance
             payload: payload_value,
             decided_at: 1_700_000_010,
             canonical_payload_hash: Some(canonical_payload_hash.clone()),
+            governance_decision_hash: None,
         };
 
         subscription(event);
@@ -234,6 +235,7 @@ async fn unfreeze_member_accepted_proposal_produces_durable_record_with_governan
                 payload: serde_json::to_value(&freeze_payload).unwrap(),
                 decided_at: 1_700_000_020,
                 canonical_payload_hash: Some("sha256:freeze-pre-hash".to_string()),
+                governance_decision_hash: None,
             });
             tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
@@ -274,6 +276,7 @@ async fn unfreeze_member_accepted_proposal_produces_durable_record_with_governan
             payload: payload_value,
             decided_at: 1_700_000_030,
             canonical_payload_hash: Some(unfreeze_canonical_hash.clone()),
+            governance_decision_hash: None,
         });
         tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
@@ -383,6 +386,7 @@ async fn freeze_without_canonical_hash_falls_back_to_receipt_hash() -> Result<()
         payload: serde_json::to_value(&payload)?,
         decided_at: 1_700_000_040,
         canonical_payload_hash: None, // legacy: no canonical hash
+        governance_decision_hash: None,
     });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 

--- a/icn/crates/icn-core/tests/governance_ledger_idempotency.rs
+++ b/icn/crates/icn-core/tests/governance_ledger_idempotency.rs
@@ -146,6 +146,7 @@ async fn test_duplicate_proposal_event_is_idempotent() -> Result<()> {
         .unwrap(),
         decided_at: 1234567890,
         canonical_payload_hash: None,
+        governance_decision_hash: None,
     };
 
     // Emit event ONCE

--- a/icn/crates/icn-core/tests/governance_ledger_integration.rs
+++ b/icn/crates/icn-core/tests/governance_ledger_integration.rs
@@ -221,6 +221,7 @@ async fn test_budget_proposal_executes_ledger_transaction() -> Result<()> {
         .unwrap(),
         decided_at: now,
         canonical_payload_hash: None,
+        governance_decision_hash: None,
     };
 
     info!("Emitting ProposalAccepted event...");

--- a/icn/crates/icn-core/tests/governance_policy_integration.rs
+++ b/icn/crates/icn-core/tests/governance_policy_integration.rs
@@ -185,6 +185,7 @@ async fn test_scheduling_policy_proposal_execution() -> Result<()> {
             payload: payload.clone(),
             decided_at: now,
             canonical_payload_hash: None,
+            governance_decision_hash: None,
         })
         .await;
 
@@ -228,6 +229,7 @@ async fn test_scheduling_policy_proposal_execution() -> Result<()> {
             .unwrap(),
             decided_at: now,
             canonical_payload_hash: None,
+            governance_decision_hash: None,
         })
         .await;
 
@@ -344,6 +346,7 @@ async fn test_invalid_policy_json_handling() -> Result<()> {
             .unwrap(),
             decided_at: now,
             canonical_payload_hash: None,
+            governance_decision_hash: None,
         })
         .await;
 

--- a/icn/crates/icn-core/tests/membership_action_governance_integration.rs
+++ b/icn/crates/icn-core/tests/membership_action_governance_integration.rs
@@ -109,6 +109,7 @@ async fn add_member_accepted_proposal_produces_durable_record_with_governance_pr
             payload: payload_value,
             decided_at: 1_700_000_000,
             canonical_payload_hash: Some(canonical_payload_hash),
+            governance_decision_hash: None,
         };
 
         subscription(event);

--- a/icn/crates/icn-core/tests/membership_action_governance_integration.rs
+++ b/icn/crates/icn-core/tests/membership_action_governance_integration.rs
@@ -234,6 +234,7 @@ async fn add_member_without_canonical_hash_falls_back_to_receipt_hash() -> Resul
         payload: serde_json::to_value(&payload)?,
         decided_at: 1_700_000_001,
         canonical_payload_hash: None, // legacy: no canonical hash
+        governance_decision_hash: None,
     };
 
     subscription(event);

--- a/icn/crates/icn-core/tests/remove_member_governance_integration.rs
+++ b/icn/crates/icn-core/tests/remove_member_governance_integration.rs
@@ -112,6 +112,7 @@ async fn remove_member_accepted_proposal_produces_durable_record_with_governance
             payload: payload_value,
             decided_at: 1_700_000_050,
             canonical_payload_hash: Some(canonical_payload_hash.clone()),
+            governance_decision_hash: None,
         });
         tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
@@ -220,6 +221,7 @@ async fn remove_member_without_canonical_hash_falls_back_to_receipt_hash() -> Re
         payload: serde_json::to_value(&payload)?,
         decided_at: 1_700_000_060,
         canonical_payload_hash: None, // legacy: no canonical hash
+        governance_decision_hash: None,
     });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 

--- a/icn/crates/icn-core/tests/treasury_spend_governance_provenance.rs
+++ b/icn/crates/icn-core/tests/treasury_spend_governance_provenance.rs
@@ -134,6 +134,7 @@ async fn treasury_spend_accepted_proposal_produces_journal_entry_with_governance
         payload: payload_value,
         decided_at: 1_700_000_000,
         canonical_payload_hash: Some(canonical_payload_hash),
+        governance_decision_hash: None,
     };
 
     // ── Fire the event ────────────────────────────────────────────────────────
@@ -251,6 +252,7 @@ async fn treasury_spend_without_canonical_hash_falls_back_to_receipt_hash() -> R
         payload: payload_value,
         decided_at: 1_700_000_001,
         canonical_payload_hash: None,
+        governance_decision_hash: None,
     };
 
     // Expected: receipt_id is deterministic; decision_hash is the blake3-of-receipt-id fallback
@@ -290,6 +292,121 @@ async fn treasury_spend_without_canonical_hash_falls_back_to_receipt_hash() -> R
             "✅ PROOF: legacy path (no canonical_hash) produces journal entry with fallback provenance"
         );
     }
+
+    Ok(())
+}
+
+/// Prove that `governance_decision_hash` (canonical GovernanceDecisionReceipt hash)
+/// takes priority over `canonical_payload_hash` (content hash) when both are present.
+///
+/// This is the end-to-end proof that the sprint 26 seam is fully closed:
+/// the journal entry now carries the SAME hash that keys the governance receipt chain,
+/// enabling `icnctl audit verify <decision_hash>` to cross-reference ledger entries.
+#[tokio::test(flavor = "multi_thread")]
+async fn governance_decision_hash_takes_priority_over_canonical_payload_hash() -> Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .with_test_writer()
+        .try_init();
+
+    info!("=== PROOF: governance_decision_hash > canonical_payload_hash ===");
+
+    let tmp = TempDir::new()?;
+
+    let treasury_kp = KeyPair::generate()?;
+    let treasury_did = treasury_kp.did().clone();
+    let recipient_kp = KeyPair::generate()?;
+    let recipient_did = recipient_kp.did().clone();
+
+    let ledger_store = Arc::new(SledStore::open(tmp.path().join("ledger"))?);
+    let ledger = Arc::new(RwLock::new(Ledger::new(ledger_store.clone())?));
+    let ledger_service = Arc::new(LedgerServiceImpl::new(
+        ledger.clone(),
+        Arc::new(AllowAllOracle::wildcard()),
+        treasury_did.clone(),
+    ));
+    let kernel_executor =
+        KernelGovernanceExecutor::new(Arc::new(StubParamStore)).with_ledger_service(ledger_service);
+    let dispatcher = Arc::new(EffectDispatcher::new(Arc::new(kernel_executor)));
+
+    let dispatcher_for_sub = dispatcher.clone();
+    let subscription = create_effect_subscription(move |effects, decision_receipt_id| {
+        let disp = dispatcher_for_sub.clone();
+        let dr_id = decision_receipt_id.clone();
+        tokio::task::spawn(async move {
+            let _ = disp.execute_effects(effects, &dr_id).await;
+        });
+    });
+
+    let domain_id = "test-coop-priority";
+    let proposal_id = "priority-prop-001";
+
+    let payload = ProposalPayload::Treasury {
+        operation: TreasuryProposalOperation::Spend {
+            treasury_did: treasury_did.clone(),
+            amount: 75,
+            currency: "HOURS".to_string(),
+            recipient: recipient_did.clone(),
+            memo: "priority hash proof".to_string(),
+            nonce: 0,
+        },
+    };
+    let payload_value = serde_json::to_value(&payload)?;
+
+    // Both hashes present — governance_decision_hash must win.
+    let canonical_payload_hash = "sha256:payload-hash-should-be-ignored".to_string();
+    let governance_decision_hash = "sha256:governance-receipt-hash-should-win".to_string();
+    let expected_receipt_id = format!("gov:{domain_id}:{proposal_id}:receipt");
+
+    subscription(SystemEvent::ProposalAccepted {
+        proposal_id: proposal_id.to_string(),
+        domain_id: domain_id.to_string(),
+        payload: payload_value,
+        decided_at: 1_700_000_002,
+        canonical_payload_hash: Some(canonical_payload_hash.clone()),
+        governance_decision_hash: Some(governance_decision_hash.clone()),
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let ledger_guard = ledger.read().await;
+    let entries = ledger_guard.get_all_entries()?;
+
+    let governance_entry = entries.iter().find(|e| {
+        matches!(
+            &e.provenance,
+            ProvenanceRef::Governance { receipt_id, decision_hash }
+                if receipt_id.as_str() == expected_receipt_id
+                    && decision_hash.as_str() == governance_decision_hash.as_str()
+        )
+    });
+
+    assert!(
+        governance_entry.is_some(),
+        "Expected journal entry with governance_decision_hash {:?} as decision_hash, \
+         but got: {:#?}",
+        governance_decision_hash,
+        entries.iter().map(|e| &e.provenance).collect::<Vec<_>>()
+    );
+
+    // Also prove canonical_payload_hash is NOT used when governance_decision_hash is present.
+    let payload_hash_entry = entries.iter().find(|e| {
+        matches!(
+            &e.provenance,
+            ProvenanceRef::Governance { decision_hash, .. }
+                if decision_hash.as_str() == canonical_payload_hash.as_str()
+        )
+    });
+    assert!(
+        payload_hash_entry.is_none(),
+        "canonical_payload_hash must NOT appear in journal when governance_decision_hash is set"
+    );
+
+    info!(
+        receipt_id = %expected_receipt_id,
+        winning_hash = %governance_decision_hash,
+        suppressed_hash = %canonical_payload_hash,
+        "✅ PROOF: governance_decision_hash wins; canonical_payload_hash correctly suppressed"
+    );
 
     Ok(())
 }

--- a/icn/crates/icn-gateway/src/api/receipts.rs
+++ b/icn/crates/icn-gateway/src/api/receipts.rs
@@ -424,11 +424,11 @@ pub async fn get_full_chain(
     // Query journal entries whose ProvenanceRef::Governance.decision_hash matches.
     // domain_id is derived from the governance receipt when present; for forced-accept
     // decisions (no stored receipt) the caller may supply it as a query parameter.
+    let receipt_domain_id = governance.as_ref().map(|g| g.domain_id.as_str());
     let journal_entries = query_journal_entries_for_decision(
         &ledger_mgr,
-        &governance,
+        receipt_domain_id.or(query.domain_id.as_deref()),
         &normalized_decision_hash,
-        query.domain_id.as_deref(),
     )
     .await;
 
@@ -468,22 +468,15 @@ pub async fn get_full_chain(
 /// Query ledger journal entries whose `ProvenanceRef::Governance.decision_hash` matches
 /// the supplied hex-encoded decision hash.
 ///
-/// `domain_id_hint` is used when no governance receipt is stored (forced-accept path).
-/// When a governance receipt is present, its `domain_id` takes precedence.
-/// Returns an empty vec when neither source provides a domain_id, or when the
-/// LedgerManager is unavailable.
+/// `domain_id` is the resolved cooperative domain — governance receipt domain_id
+/// takes precedence over any query parameter hint; callers resolve this before calling.
+/// Returns an empty vec when no domain_id is available or LedgerManager is unavailable.
 async fn query_journal_entries_for_decision(
     ledger_mgr: &Option<web::Data<Arc<LedgerManager>>>,
-    governance: &Option<icn_governance::GovernanceDecisionReceipt>,
+    domain_id: Option<&str>,
     decision_hash_hex: &str,
-    domain_id_hint: Option<&str>,
 ) -> Vec<JournalEntryProvenanceResponse> {
-    // Governance receipt domain_id takes precedence; hint only used when receipt absent.
-    let domain_id = governance
-        .as_ref()
-        .map(|g| g.domain_id.as_str())
-        .or(domain_id_hint)
-        .map(str::to_owned);
+    let domain_id = domain_id.map(str::to_owned);
 
     let (mgr, domain_id) = match (ledger_mgr, domain_id) {
         (Some(m), Some(d)) => (m, d),

--- a/icn/crates/icn-gateway/src/api/receipts.rs
+++ b/icn/crates/icn-gateway/src/api/receipts.rs
@@ -24,6 +24,23 @@ pub struct ByDecisionQuery {
     pub decision_hash: Option<String>,
 }
 
+/// Query parameters for `GET /v1/receipts/chain/{decision_hash}`.
+#[derive(Debug, Deserialize, Default)]
+pub struct ChainQuery {
+    /// Optional cooperative/domain ID for forced-accept chains where no governance
+    /// receipt is stored in the backend.
+    ///
+    /// For normal voted decisions, `domain_id` is derived from the stored governance
+    /// receipt and this parameter is ignored.
+    ///
+    /// For forced-accept decisions (no stored receipt), providing this parameter
+    /// enables journal cross-reference. Without it, `journal_entries` is empty.
+    ///
+    /// The caller always knows the domain_id (it is part of the proposal record).
+    /// This parameter does not imply that a governance receipt exists.
+    pub domain_id: Option<String>,
+}
+
 /// Response for allocation receipt
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -344,19 +361,26 @@ pub async fn get_chain(
     }
 }
 
-/// GET /v1/receipts/chain/{decision_hash}
+/// GET /v1/receipts/chain/{decision_hash}[?domain_id=<coop-id>]
 ///
 /// Returns the full receipt chain for a decision: governance receipt,
 /// allocation receipts, settlement intents, and journal entry provenance refs.
 ///
 /// Journal entries are populated when a `LedgerManager` is registered in app data
-/// and the governance receipt carries a `domain_id` that resolves to a coop ledger.
+/// and a domain_id can be resolved. For normal voted decisions the domain_id comes
+/// from the stored governance receipt. For forced-accept decisions (no stored
+/// governance receipt), the caller may supply `?domain_id=<id>` as a hint;
+/// without it `journal_entries` remains empty.
+///
+/// Providing `domain_id` never implies a governance receipt is present — the
+/// `governance` field reflects actual receipt-store state.
 #[get("/chain/{decision_hash}")]
 pub async fn get_full_chain(
     receipt_store: web::Data<Arc<ReceiptStore>>,
     execution_store: web::Data<Arc<dyn Store>>,
     ledger_mgr: Option<web::Data<Arc<LedgerManager>>>,
     path: web::Path<String>,
+    query: web::Query<ChainQuery>,
 ) -> HttpResponse {
     let hash_hex = path.into_inner();
     let hash = match parse_hash(&hash_hex) {
@@ -398,10 +422,15 @@ pub async fn get_full_chain(
     };
 
     // Query journal entries whose ProvenanceRef::Governance.decision_hash matches.
-    // Requires both a LedgerManager and a domain_id from the governance receipt.
-    let journal_entries =
-        query_journal_entries_for_decision(&ledger_mgr, &governance, &normalized_decision_hash)
-            .await;
+    // domain_id is derived from the governance receipt when present; for forced-accept
+    // decisions (no stored receipt) the caller may supply it as a query parameter.
+    let journal_entries = query_journal_entries_for_decision(
+        &ledger_mgr,
+        &governance,
+        &normalized_decision_hash,
+        query.domain_id.as_deref(),
+    )
+    .await;
 
     let structural_complete =
         governance.is_some() && allocations.iter().all(|a| !a.intents.is_empty());
@@ -439,15 +468,25 @@ pub async fn get_full_chain(
 /// Query ledger journal entries whose `ProvenanceRef::Governance.decision_hash` matches
 /// the supplied hex-encoded decision hash.
 ///
-/// Returns an empty vec when the LedgerManager is unavailable or the governance
-/// receipt carries no domain_id (standalone / test mode).
+/// `domain_id_hint` is used when no governance receipt is stored (forced-accept path).
+/// When a governance receipt is present, its `domain_id` takes precedence.
+/// Returns an empty vec when neither source provides a domain_id, or when the
+/// LedgerManager is unavailable.
 async fn query_journal_entries_for_decision(
     ledger_mgr: &Option<web::Data<Arc<LedgerManager>>>,
     governance: &Option<icn_governance::GovernanceDecisionReceipt>,
     decision_hash_hex: &str,
+    domain_id_hint: Option<&str>,
 ) -> Vec<JournalEntryProvenanceResponse> {
-    let (mgr, domain_id) = match (ledger_mgr, governance.as_ref()) {
-        (Some(m), Some(g)) => (m, g.domain_id.clone()),
+    // Governance receipt domain_id takes precedence; hint only used when receipt absent.
+    let domain_id = governance
+        .as_ref()
+        .map(|g| g.domain_id.as_str())
+        .or(domain_id_hint)
+        .map(str::to_owned);
+
+    let (mgr, domain_id) = match (ledger_mgr, domain_id) {
+        (Some(m), Some(d)) => (m, d),
         _ => return Vec::new(),
     };
 
@@ -656,5 +695,201 @@ mod tests {
         assert!(resp.execution_complete);
         assert!(resp.chain_complete);
         assert_eq!(resp.execution.executed_effects, 1);
+    }
+
+    // --- domain_id query param tests (forced-accept read path) ---
+
+    /// Helper: build a minimal actix App with the given stores and optional LedgerManager.
+    async fn build_chain_app(
+        receipt_store: Arc<ReceiptStore>,
+        execution_store: Arc<dyn Store>,
+        ledger_mgr: Option<Arc<LedgerManager>>,
+    ) -> impl actix_web::dev::Service<
+        actix_http::Request,
+        Response = actix_web::dev::ServiceResponse,
+        Error = actix_web::Error,
+    > {
+        let mut app = App::new()
+            .app_data(web::Data::new(receipt_store))
+            .app_data(web::Data::new(execution_store))
+            .service(web::scope("/v1/receipts").service(get_full_chain));
+
+        if let Some(mgr) = ledger_mgr {
+            app = app.app_data(web::Data::new(mgr));
+        }
+
+        test::init_service(app).await
+    }
+
+    /// Forced-accept chain without domain_id hint: journal_entries stays empty.
+    /// governance is None (no stored receipt), no domain_id query param.
+    #[actix_web::test]
+    async fn forced_accept_without_domain_id_hint_returns_empty_journal() {
+        let db = sled::Config::new().temporary(true).open().expect("temp db");
+        let receipt_store = Arc::new(ReceiptStore::new(db));
+        let execution_store: Arc<dyn Store> =
+            Arc::new(SledStore::temporary().expect("temp exec db"));
+
+        // Use a well-formed 32-byte hash for a forced-accept with no stored receipt.
+        let decision_hash_hex = "a1".repeat(32);
+        let decision_hash_bytes = hex::decode(&decision_hash_hex).expect("valid hex");
+        let mut hash_arr = [0u8; 32];
+        hash_arr.copy_from_slice(&decision_hash_bytes);
+
+        // Register a LedgerManager with an entry in "test-domain" carrying this hash.
+        let mgr = Arc::new(LedgerManager::new());
+        {
+            use icn_identity::KeyPair;
+            use icn_ledger::entry::JournalEntryBuilder;
+            let ledger_arc = mgr
+                .get_ledger(&"test-domain".to_string())
+                .await
+                .expect("get ledger");
+            let author = KeyPair::generate().expect("keypair").did().clone();
+            let entry = JournalEntryBuilder::new(author.clone())
+                .debit(author.clone(), "credits".to_string(), 10)
+                .credit(
+                    KeyPair::generate().expect("keypair").did().clone(),
+                    "credits".to_string(),
+                    10,
+                )
+                .with_governance_provenance(
+                    "gov:test-domain:forced-001:receipt",
+                    &decision_hash_hex,
+                )
+                .build()
+                .expect("entry");
+            ledger_arc
+                .write()
+                .await
+                .append_entry(entry)
+                .await
+                .expect("append");
+        }
+
+        // No ?domain_id= query param supplied.
+        let app = build_chain_app(receipt_store, execution_store, Some(mgr)).await;
+        let uri = format!("/v1/receipts/chain/{decision_hash_hex}");
+        let req = test::TestRequest::get().uri(&uri).to_request();
+        let resp: ReceiptChainResponse = test::call_and_read_body_json(&app, req).await;
+
+        assert!(
+            resp.governance.is_none(),
+            "forced accept must not invent a governance receipt"
+        );
+        assert!(
+            resp.journal_entries.is_empty(),
+            "without domain_id hint, journal cross-reference must return empty"
+        );
+    }
+
+    /// Forced-accept chain with correct domain_id hint: journal_entries populated.
+    /// governance is None, but ?domain_id=test-domain resolves the ledger.
+    #[actix_web::test]
+    async fn forced_accept_with_domain_id_hint_finds_journal_entries() {
+        let db = sled::Config::new().temporary(true).open().expect("temp db");
+        let receipt_store = Arc::new(ReceiptStore::new(db));
+        let execution_store: Arc<dyn Store> =
+            Arc::new(SledStore::temporary().expect("temp exec db"));
+
+        let decision_hash_hex = "b2".repeat(32);
+        let mgr = Arc::new(LedgerManager::new());
+        {
+            use icn_identity::KeyPair;
+            use icn_ledger::entry::JournalEntryBuilder;
+            let ledger_arc = mgr
+                .get_ledger(&"test-domain".to_string())
+                .await
+                .expect("get ledger");
+            let author = KeyPair::generate().expect("keypair").did().clone();
+            let entry = JournalEntryBuilder::new(author.clone())
+                .debit(author.clone(), "credits".to_string(), 5)
+                .credit(
+                    KeyPair::generate().expect("keypair").did().clone(),
+                    "credits".to_string(),
+                    5,
+                )
+                .with_governance_provenance(
+                    "gov:test-domain:forced-002:receipt",
+                    &decision_hash_hex,
+                )
+                .build()
+                .expect("entry");
+            ledger_arc
+                .write()
+                .await
+                .append_entry(entry)
+                .await
+                .expect("append");
+        }
+
+        let app = build_chain_app(receipt_store, execution_store, Some(mgr)).await;
+        // Provide the correct domain_id hint.
+        let uri = format!("/v1/receipts/chain/{decision_hash_hex}?domain_id=test-domain");
+        let req = test::TestRequest::get().uri(&uri).to_request();
+        let resp: ReceiptChainResponse = test::call_and_read_body_json(&app, req).await;
+
+        assert!(
+            resp.governance.is_none(),
+            "domain_id hint must not invent a governance receipt"
+        );
+        assert_eq!(
+            resp.journal_entries.len(),
+            1,
+            "correct domain_id hint must surface the journal entry"
+        );
+        assert_eq!(resp.journal_entries[0].decision_hash, decision_hash_hex);
+    }
+
+    /// Forced-accept chain with wrong domain_id hint: journal_entries remains empty.
+    /// No match should be returned for an unrelated domain.
+    #[actix_web::test]
+    async fn wrong_domain_id_hint_returns_empty_journal() {
+        let db = sled::Config::new().temporary(true).open().expect("temp db");
+        let receipt_store = Arc::new(ReceiptStore::new(db));
+        let execution_store: Arc<dyn Store> =
+            Arc::new(SledStore::temporary().expect("temp exec db"));
+
+        let decision_hash_hex = "c3".repeat(32);
+        let mgr = Arc::new(LedgerManager::new());
+        {
+            use icn_identity::KeyPair;
+            use icn_ledger::entry::JournalEntryBuilder;
+            let ledger_arc = mgr
+                .get_ledger(&"correct-domain".to_string())
+                .await
+                .expect("get ledger");
+            let author = KeyPair::generate().expect("keypair").did().clone();
+            let entry = JournalEntryBuilder::new(author.clone())
+                .debit(author.clone(), "credits".to_string(), 3)
+                .credit(
+                    KeyPair::generate().expect("keypair").did().clone(),
+                    "credits".to_string(),
+                    3,
+                )
+                .with_governance_provenance(
+                    "gov:correct-domain:forced-003:receipt",
+                    &decision_hash_hex,
+                )
+                .build()
+                .expect("entry");
+            ledger_arc
+                .write()
+                .await
+                .append_entry(entry)
+                .await
+                .expect("append");
+        }
+
+        // Provide the WRONG domain_id hint — entry lives in "correct-domain".
+        let app = build_chain_app(receipt_store, execution_store, Some(mgr)).await;
+        let uri = format!("/v1/receipts/chain/{decision_hash_hex}?domain_id=wrong-domain");
+        let req = test::TestRequest::get().uri(&uri).to_request();
+        let resp: ReceiptChainResponse = test::call_and_read_body_json(&app, req).await;
+
+        assert!(
+            resp.journal_entries.is_empty(),
+            "wrong domain_id hint must not produce false matches"
+        );
     }
 }

--- a/icn/crates/icn-gateway/src/api/receipts.rs
+++ b/icn/crates/icn-gateway/src/api/receipts.rs
@@ -7,10 +7,12 @@ use actix_web::{get, web, HttpResponse};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+use crate::ledger_mgr::LedgerManager;
 use crate::receipt_store::ReceiptStore;
 use icn_kernel_api::economics::SettlementIntent;
 use icn_kernel_api::execution::{ExecutionRecord, ExecutionStatus};
 use icn_kernel_api::receipts::{AllocationReceipt, CanonicalReceipt, Hash};
+use icn_ledger::types::ProvenanceRef;
 use icn_store::Store;
 
 /// Query parameters for listing by decision hash.
@@ -141,6 +143,26 @@ pub struct GovernanceVoteTallyResponse {
     pub abstain_votes: usize,
 }
 
+/// Minimal journal entry provenance reference for audit cross-check.
+///
+/// Carries only the fields needed to verify that a ledger journal entry
+/// was authorized by the originating governance decision: the receipt_id
+/// and the decision_hash stored in `ProvenanceRef::Governance`.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JournalEntryProvenanceResponse {
+    /// Ledger-assigned entry ID (blake3 hex or empty if not yet assigned)
+    pub entry_id: String,
+    /// Governance receipt ID stored in the journal entry's provenance
+    pub decision_receipt_id: String,
+    /// Decision hash stored in the journal entry's provenance
+    pub decision_hash: String,
+    /// Number of account deltas in this entry
+    pub account_count: usize,
+    /// Entry timestamp (Unix seconds)
+    pub timestamp: u64,
+}
+
 /// Response for the full receipt chain (governance + economic artifacts).
 ///
 /// Returned by `GET /v1/receipts/chain/{decision_hash}`.
@@ -155,6 +177,9 @@ pub struct ReceiptChainResponse {
     pub allocations: Vec<AllocationReceiptResponse>,
     /// Settlement intents for this decision
     pub intents: Vec<SettlementIntentResponse>,
+    /// Journal entries whose ProvenanceRef::Governance.decision_hash matches.
+    /// Populated when a LedgerManager is available and governance.domain_id resolves a ledger.
+    pub journal_entries: Vec<JournalEntryProvenanceResponse>,
     /// Structural chain completeness (receipt-link integrity only).
     pub structural_complete: bool,
     /// Execution completeness for milestone scope.
@@ -322,11 +347,15 @@ pub async fn get_chain(
 /// GET /v1/receipts/chain/{decision_hash}
 ///
 /// Returns the full receipt chain for a decision: governance receipt,
-/// allocation receipts, and settlement intents.
+/// allocation receipts, settlement intents, and journal entry provenance refs.
+///
+/// Journal entries are populated when a `LedgerManager` is registered in app data
+/// and the governance receipt carries a `domain_id` that resolves to a coop ledger.
 #[get("/chain/{decision_hash}")]
 pub async fn get_full_chain(
     receipt_store: web::Data<Arc<ReceiptStore>>,
     execution_store: web::Data<Arc<dyn Store>>,
+    ledger_mgr: Option<web::Data<Arc<LedgerManager>>>,
     path: web::Path<String>,
 ) -> HttpResponse {
     let hash_hex = path.into_inner();
@@ -368,6 +397,12 @@ pub async fn get_full_chain(
         }
     };
 
+    // Query journal entries whose ProvenanceRef::Governance.decision_hash matches.
+    // Requires both a LedgerManager and a domain_id from the governance receipt.
+    let journal_entries =
+        query_journal_entries_for_decision(&ledger_mgr, &governance, &normalized_decision_hash)
+            .await;
+
     let structural_complete =
         governance.is_some() && allocations.iter().all(|a| !a.intents.is_empty());
     let execution_complete = execution.execution_complete;
@@ -392,12 +427,51 @@ pub async fn get_full_chain(
             .map(AllocationReceiptResponse::from)
             .collect(),
         intents: intents.iter().map(SettlementIntentResponse::from).collect(),
+        journal_entries,
         structural_complete,
         execution_complete,
         chain_complete,
         execution,
     };
     HttpResponse::Ok().json(response)
+}
+
+/// Query ledger journal entries whose `ProvenanceRef::Governance.decision_hash` matches
+/// the supplied hex-encoded decision hash.
+///
+/// Returns an empty vec when the LedgerManager is unavailable or the governance
+/// receipt carries no domain_id (standalone / test mode).
+async fn query_journal_entries_for_decision(
+    ledger_mgr: &Option<web::Data<Arc<LedgerManager>>>,
+    governance: &Option<icn_governance::GovernanceDecisionReceipt>,
+    decision_hash_hex: &str,
+) -> Vec<JournalEntryProvenanceResponse> {
+    let (mgr, domain_id) = match (ledger_mgr, governance.as_ref()) {
+        (Some(m), Some(g)) => (m, g.domain_id.clone()),
+        _ => return Vec::new(),
+    };
+
+    let entries = match mgr.get_history(&domain_id, None, 0, 100).await {
+        Ok(e) => e,
+        Err(_) => return Vec::new(),
+    };
+
+    entries
+        .into_iter()
+        .filter_map(|entry| match &entry.provenance {
+            ProvenanceRef::Governance {
+                receipt_id,
+                decision_hash: dh,
+            } if dh.as_str() == decision_hash_hex => Some(JournalEntryProvenanceResponse {
+                entry_id: entry.id.map(|h| h.to_hex()).unwrap_or_default(),
+                decision_receipt_id: receipt_id.clone(),
+                decision_hash: dh.clone(),
+                account_count: entry.accounts.len(),
+                timestamp: entry.timestamp,
+            }),
+            _ => None,
+        })
+        .collect()
 }
 
 /// GET /v1/receipts/allocations[?decision_hash=<hex>]

--- a/icn/crates/icn-kernel-api/src/events.rs
+++ b/icn/crates/icn-kernel-api/src/events.rs
@@ -25,11 +25,26 @@ pub enum SystemEvent {
         decided_at: u64,
         /// Canonical content hash of the accepted proposal payload.
         ///
-        /// When present, this is used as `decision_hash` in journal provenance, enabling
+        /// A BLAKE3 hash of the serialized proposal payload JSON. Allows
         /// third-party verification against the original proposal content.
-        /// When absent, `create_effect_subscription` falls back to `blake3(receipt_id)`.
-        /// Introduced in sprint 26 to close the treasury-spend provenance seam.
+        /// Superseded by `governance_decision_hash` when present.
+        /// When both are absent, `create_effect_subscription` falls back to `blake3(receipt_id)`.
         canonical_payload_hash: Option<String>,
+        /// Canonical governance decision hash.
+        ///
+        /// Hex-encoded SHA3/BLAKE3 hash computed by `GovernanceDecisionReceipt` from
+        /// (proposal_id + domain_id + outcome + vote_tally + vote_hash). This is the
+        /// same hash that keys the governance receipt, allocation receipts, execution
+        /// record, and GovernanceProofV2 — making it the authoritative cross-reference
+        /// for `icnctl audit verify`.
+        ///
+        /// When present, `create_effect_subscription` uses this as `decision_hash` in
+        /// journal entry provenance, enabling hash-level verification of the journal
+        /// entry against the governance receipt chain without trusting the operator.
+        ///
+        /// Introduced in sprint 27 to close the treasury-spend provenance seam at the
+        /// canonical hash level (superseding `canonical_payload_hash` for provenance).
+        governance_decision_hash: Option<String>,
     },
 
     /// A governance proposal was rejected or failed to reach quorum


### PR DESCRIPTION
## Summary

- Thread `governance_decision_hash` (canonical `GovernanceDecisionReceipt` hash — includes votes, tally, outcome) through `SystemEvent::ProposalAccepted` so downstream journal entries are keyed by the governance receipt hash, not just the proposal content hash.
- Extend `icnctl audit verify` with journal cross-reference: checks 12 + 13 verify that ledger journal entries carry matching provenance back to the governance decision.
- Fix forced-accept path: `ForcedOutcome::Accept` previously set `governance_decision_hash = None`, causing fallback to content-hash semantics. Now computes a deterministic hash via `GovernanceDecisionReceipt::new(..., VoteTally::empty(), &[])`.
- Add optional `?domain_id=` to `GET /v1/receipts/chain/{decision_hash}` so the gateway can cross-reference journal entries for forced-accept decisions (which have no stored governance receipt).
- Add `--domain-id <id>` to `icnctl audit verify` wired to the gateway query param.

## Why

Receipt chain audit (`icnctl audit verify`) was incomplete for two scenarios:

1. **Normal voted decisions**: Journal entries created by treasury effects were keyed by content hash (`blake3(payload_json)`), not by the governance receipt hash. Auditors querying a decision hash would see a chain with no journal entries even when execution had occurred — a silent provenance gap.

2. **Forced-accept decisions** (`ForcedOutcome::Accept`): These bypass vote collection, so no `GovernanceDecisionReceipt` is stored. The gateway had no way to cross-reference journal entries for these decisions without a domain hint, and the CLI had no way to supply that hint.

## Truth Boundary

**A forced-accept artifact is NOT a voted governance receipt.**

Forced-accept decisions produce a deterministic hash from `GovernanceDecisionReceipt::new(..., VoteTally::empty(), &[])` — the same struct and hash function, but with empty votes. This hash enables provenance threading (journal entries, treasury effects, and audit tools can all refer to the same canonical identifier) but it does NOT imply:
- A quorum was met
- Any member voted For/Against/Abstain
- A governance receipt is stored in the receipt chain

In `icnctl audit verify` output, check 1 ("Governance receipt present") **always fails** for forced-accept decisions, even when `--domain-id` successfully surfaces journal entries in checks 12–13. That distinction is enforced in tests (`test_forced_accept_audit_output_is_honest`) and is non-negotiable.

## Exact Changes

| File | Change |
|------|--------|
| `crates/icn-kernel-api/src/events.rs` | Add `governance_decision_hash: Option<String>` to `SystemEvent::ProposalAccepted` |
| `apps/governance/src/actor.rs` | Compute and emit `governance_decision_hash` after Invariant 7 gate; forced-accept path emits deterministic hash instead of `None` |
| `apps/governance/src/lib.rs` | `create_effect_subscription` three-tier fallback: prefer `governance_decision_hash` → `canonical_payload_hash` → `blake3(receipt_id)` |
| `crates/icn-gateway/src/api/receipts.rs` | `ChainQuery { domain_id }` extractor; `query_journal_entries_for_decision` gains `domain_id_hint` param; governance receipt's domain takes precedence over hint |
| `bins/icnctl/src/main.rs` | `AuditCommands::Verify` gains `--domain-id`; URL builder appends `?domain_id=` when present; checks 12+13 added to `verify_receipt_chain` |
| `bins/icnctl/tests/audit_verify_test.rs` | 7 tests total; `test_forced_accept_audit_output_is_honest` proves honesty boundary |
| `crates/icn-core/tests/treasury_spend_governance_provenance.rs` | Provenance proof: `governance_decision_hash` forwarded through subscription to journal entries |

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p icn-gateway -p icn-kernel-api -p icn-core -p icnctl -- -D warnings` — clean
- `cargo test -p icnctl` — 8/8 audit verify tests pass
- `cargo test -p icn-core --test treasury_spend_governance_provenance` — 3/3 pass
- `cargo test -p icn-gateway --features sled-storage` — pass
- `cargo test -p icn-core --test freeze_unfreeze_governance_integration` — 3/3 pass (existing, unaffected)

## Non-Goals

- This PR does NOT implement general governance execution dispatch
- This PR does NOT add FreezeMember execution (already exists in prior work)
- This PR does NOT add vote-gate enforcement for suspended members
- This PR does NOT modify ledger freeze enforcement