### PR TITLE
feat(governance): block suspended members from casting votes

### DIFF
--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -152,6 +152,23 @@ pub type MemberStandingChecker = Arc<
         + Sync,
 >;
 
+/// Async predicate: is `did` currently suspended in cooperative `domain_id`?
+///
+/// Called by `cast_vote` before recording a vote. Returns `true` if the member
+/// holds `MemberStatus::Suspended` (set by an accepted `FreezeMember` proposal).
+/// A `true` result causes `403 Forbidden` — suspended members may not vote.
+///
+/// `None` disables the gate (useful in tests that do not wire a coop store).
+///
+/// The gateway wires this against `CoopManager::is_member_suspended()`.
+/// The governance app never imports `icn-coop` types — the closure is the
+/// only crossing point, preserving the kernel/app boundary.
+pub type SuspensionChecker = Arc<
+    dyn Fn(Did, String) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send>>
+        + Send
+        + Sync,
+>;
+
 /// Shared application context for governance HTTP handlers.
 ///
 /// Stored as `web::Data<GovernanceContext<E>>`. Using a single struct keeps
@@ -175,6 +192,11 @@ pub struct GovernanceContext<E> {
     /// Returns `true` if the caller is an active steward; `false` → 403 Forbidden.
     /// Steward standing is a strictly higher bar than Member standing.
     pub steward_checker: Option<StewardStandingChecker>,
+    /// Optional gate: if set, `cast_vote` calls this before recording the vote.
+    /// Returns `true` if the voter is suspended (`MemberStatus::Suspended`) in the
+    /// proposal's domain — i.e., a `FreezeMember` proposal was accepted for them.
+    /// A `true` result → 403 Forbidden. `None` disables the gate.
+    pub suspension_checker: Option<SuspensionChecker>,
 }
 
 /// Register all governance routes on `cfg`.

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -1190,6 +1190,19 @@ pub async fn cast_vote<E: GovernanceEventEmitter + Clone + 'static>(
         }
     }
 
+    // Suspension gate: voter must not be suspended (MemberStatus::Suspended) in
+    // the proposal's domain. Suspension is set by an accepted FreezeMember proposal.
+    // A suspended member may not influence governance decisions until unfrozen.
+    if let Some(ref checker) = ctx.suspension_checker {
+        if checker(voter_did.clone(), proposal.domain_id.0.clone()).await {
+            return Err(err_forbidden(format!(
+                "voter {} is suspended in domain {}; \
+                 suspended members may not cast votes",
+                voter_did, proposal.domain_id.0
+            )));
+        }
+    }
+
     ctx.manager
         .cast_vote(
             proposal_id.clone(),
@@ -2446,6 +2459,7 @@ mod tests {
             on_proposal_accepted: Some(hook),
             member_checker: None,
             steward_checker: None,
+            suspension_checker: None,
         };
 
         let app = test_app!(ctx, member_did);
@@ -2523,6 +2537,7 @@ mod tests {
             on_proposal_accepted: Some(hook),
             member_checker: None,
             steward_checker: None,
+            suspension_checker: None,
         };
 
         let app = test_app!(ctx, member_did);

--- a/icn/crates/icn-gateway/src/coop.rs
+++ b/icn/crates/icn-gateway/src/coop.rs
@@ -355,6 +355,28 @@ impl CoopManager {
         Ok(coops.values().cloned().collect())
     }
 
+    /// Returns `true` if `did` is currently suspended (`MemberStatus::Suspended`)
+    /// in cooperative `coop_id`.
+    ///
+    /// Queries the `CoopActor` (sled-backed) when a daemon handle is present.
+    /// Returns `false` in standalone (no-handle) mode — suspension is never set
+    /// without a live `MembershipService`, so failing open is correct.
+    ///
+    /// Fails open on store errors to avoid blocking all governance operations
+    /// due to a transient read failure.
+    pub async fn is_member_suspended(&self, coop_id: &str, did: &icn_identity::Did) -> bool {
+        use icn_coop::MemberStatus;
+        let Some(ref handle) = self.coop_handle else {
+            return false;
+        };
+        match handle.list_members(coop_id.to_string()).await {
+            Ok(members) => members
+                .iter()
+                .any(|m| &m.did == did && m.status == MemberStatus::Suspended),
+            Err(_) => false,
+        }
+    }
+
     /// List all cooperative IDs (for cleanup tasks)
     pub fn list_all_coop_ids(&self) -> Result<Vec<CoopId>> {
         let coops = self

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -1293,6 +1293,17 @@ impl GatewayServer {
                 Box::pin(async move { commons.is_active_steward(&did).await.unwrap_or(false) })
             });
 
+        // Suspension gate: voters with MemberStatus::Suspended (set by an accepted
+        // FreezeMember proposal) are blocked from casting votes. Wired here so the
+        // governance app never imports icn-coop types — the closure is the only
+        // crossing point, same pattern as member_checker and steward_checker.
+        let coop_manager_for_suspension = coop_manager.clone();
+        let suspension_checker: icn_governance_actor::http::configure::SuspensionChecker =
+            std::sync::Arc::new(move |did, domain_id| {
+                let mgr = coop_manager_for_suspension.clone();
+                Box::pin(async move { mgr.is_member_suspended(&domain_id, &did).await })
+            });
+
         let gov_ctx = GovernanceContext {
             manager: governance_manager.clone(),
             emitter: GatewayEventAdapter::new(event_broadcaster.clone()),
@@ -1300,6 +1311,7 @@ impl GatewayServer {
             on_proposal_accepted: Some(on_proposal_accepted),
             member_checker: Some(member_checker),
             steward_checker: Some(steward_checker),
+            suspension_checker: Some(suspension_checker),
         };
 
         // Create rate limiter with configured or default config

--- a/icn/crates/icn-gateway/tests/e2e_close_time_revalidation.rs
+++ b/icn/crates/icn-gateway/tests/e2e_close_time_revalidation.rs
@@ -222,6 +222,7 @@ async fn build_app_with_proposal(
         on_proposal_accepted: None,
         member_checker: Some(make_checker(commons_mgr)),
         steward_checker: None,
+        suspension_checker: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
+++ b/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
@@ -232,6 +232,7 @@ async fn test_e2e_freeze_member_suspends_commons_affiliation() {
         on_proposal_accepted: Some(on_proposal_accepted),
         member_checker: None,
         steward_checker: None,
+        suspension_checker: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);
@@ -483,6 +484,7 @@ async fn test_e2e_unfreeze_member_reinstates_commons_affiliation() {
         on_proposal_accepted: Some(on_proposal_accepted),
         member_checker: None,
         steward_checker: None,
+        suspension_checker: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);
@@ -725,6 +727,7 @@ async fn test_e2e_appoint_steward_scoped_to_chartered_domain() {
         on_proposal_accepted: Some(on_proposal_accepted),
         member_checker: None,
         steward_checker: None,
+        suspension_checker: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/e2e_member_standing_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_member_standing_gate.rs
@@ -134,6 +134,7 @@ async fn build_app(
         on_proposal_accepted: None,
         member_checker: Some(make_checker(commons_mgr)),
         steward_checker: None,
+        suspension_checker: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/e2e_steward_standing_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_steward_standing_gate.rs
@@ -134,6 +134,7 @@ async fn build_app(
         on_proposal_accepted: None,
         member_checker: Some(make_member_checker(commons_mgr.clone())),
         steward_checker: Some(make_steward_checker(commons_mgr)),
+        suspension_checker: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/e2e_vote_standing_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_vote_standing_gate.rs
@@ -29,7 +29,7 @@ use icn_governance::{
 };
 use icn_governance_actor::{
     events::NoopEventEmitter,
-    http::configure::{GovernanceContext, MemberStandingChecker},
+    http::configure::{GovernanceContext, MemberStandingChecker, SuspensionChecker},
     manager::GovernanceManager,
 };
 use icn_identity::{
@@ -157,6 +157,7 @@ async fn build_app_with_open_proposal(
         on_proposal_accepted: None,
         member_checker: Some(make_checker(commons_mgr)),
         steward_checker: None,
+        suspension_checker: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);
@@ -337,5 +338,160 @@ async fn test_suspended_member_cannot_vote() {
         resp.status().as_u16(),
         403,
         "Suspended member must be rejected with 403"
+    );
+}
+
+/// Build an app with no commons member_checker but with a custom suspension_checker.
+///
+/// Used to isolate the suspension gate from the commons affiliation gate.
+/// The member_checker is omitted so only the suspension_checker is exercised.
+async fn build_app_with_suspension_checker(
+    actor_did: &Did,
+    is_suspended: bool,
+) -> (
+    impl actix_web::dev::Service<
+        actix_http::Request,
+        Response = actix_web::dev::ServiceResponse,
+        Error = actix_web::Error,
+    >,
+    String,
+) {
+    let governance_manager = Arc::new(GovernanceManager::new());
+
+    governance_manager
+        .create_domain(
+            GovernanceDomainId(DOMAIN_ID.to_string()),
+            "Suspension Gate Test Coop".to_string(),
+            "cooperative".to_string(),
+            GovernanceParams::new(50, 50, 86_400),
+            MembershipConfig {
+                source: MembershipSource::StaticList(vec![actor_did.clone()]),
+            },
+        )
+        .await
+        .expect("create_domain");
+
+    let proposal_id_val = ProposalId("suspension-gate-prop-1".to_string());
+    governance_manager
+        .create_proposal(
+            proposal_id_val.clone(),
+            GovernanceDomainId(DOMAIN_ID.to_string()),
+            actor_did.clone(),
+            "Suspension gate test proposal".to_string(),
+            "Testing that suspension blocks voting.".to_string(),
+            ProposalPayload::Text {
+                body: "Suspension gate test body.".to_string(),
+            },
+            ProposalScope::Local,
+        )
+        .await
+        .expect("create_proposal");
+
+    governance_manager
+        .open_proposal(proposal_id_val.clone(), 3600)
+        .await
+        .expect("open_proposal");
+
+    let suspension_checker: SuspensionChecker =
+        Arc::new(move |_did, _domain| Box::pin(async move { is_suspended }));
+
+    let jwt_secret = b"suspension-gate-test-jwt-secret32".to_vec();
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
+
+    let gov_ctx = GovernanceContext {
+        manager: governance_manager,
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: None,
+        member_checker: None, // omit commons gate — isolate suspension gate
+        steward_checker: None,
+        suspension_checker: Some(suspension_checker),
+    };
+
+    let auth_mw = HttpAuthentication::bearer(jwt_auth);
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(auth_manager))
+            .app_data(web::Data::new(ip_limiter))
+            .service(
+                web::scope("/v1")
+                    .service(api::auth::challenge)
+                    .service(api::auth::verify)
+                    .service(
+                        web::scope("/gov")
+                            .configure({
+                                let ctx = gov_ctx.clone();
+                                move |cfg| {
+                                    icn_governance_actor::http::configure::configure(
+                                        cfg,
+                                        ctx.clone(),
+                                    )
+                                }
+                            })
+                            .wrap(auth_mw),
+                    ),
+            ),
+    )
+    .await;
+
+    (app, proposal_id_val.0)
+}
+
+/// Proves: when suspension_checker returns true (member is suspended in coop store),
+/// cast_vote is rejected with 403 Forbidden.
+///
+/// This gate is distinct from the commons member_checker: it reflects
+/// MemberStatus::Suspended set by an accepted FreezeMember governance proposal,
+/// not a commons affiliation status. A frozen member may not cast votes.
+#[actix_web::test]
+async fn test_coopstore_suspended_member_blocked_by_suspension_checker() {
+    let actor_bundle = IdentityBundle::generate().expect("IdentityBundle");
+    let actor_did = actor_bundle.did().clone();
+
+    let (app, proposal_id) = build_app_with_suspension_checker(&actor_did, true).await;
+    let token = get_jwt(&app, &actor_did.to_string(), &actor_bundle).await;
+
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/v1/gov/proposals/{proposal_id}/vote"))
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .set_json(json!({ "choice": "for" }))
+            .to_request(),
+    )
+    .await;
+
+    assert_eq!(
+        resp.status().as_u16(),
+        403,
+        "suspension_checker=true must block vote with 403"
+    );
+}
+
+/// Proves backward compatibility: when suspension_checker returns false
+/// (member is not suspended), votes proceed normally.
+#[actix_web::test]
+async fn test_non_suspended_member_passes_suspension_checker() {
+    let actor_bundle = IdentityBundle::generate().expect("IdentityBundle");
+    let actor_did = actor_bundle.did().clone();
+
+    let (app, proposal_id) = build_app_with_suspension_checker(&actor_did, false).await;
+    let token = get_jwt(&app, &actor_did.to_string(), &actor_bundle).await;
+
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/v1/gov/proposals/{proposal_id}/vote"))
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .set_json(json!({ "choice": "for" }))
+            .to_request(),
+    )
+    .await;
+
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "non-suspended member must pass suspension_checker and vote successfully"
     );
 }

--- a/icn/crates/icn-gateway/tests/governance_proof.rs
+++ b/icn/crates/icn-gateway/tests/governance_proof.rs
@@ -74,6 +74,7 @@ async fn test_governance_proposal_full_lifecycle_with_real_auth() {
         on_proposal_accepted: None,
         member_checker: None,
         steward_checker: None,
+        suspension_checker: None,
     };
 
     // Build test app — mirrors the governance-relevant subset of server.rs:
@@ -388,6 +389,7 @@ async fn test_governance_endpoints_require_auth() {
         on_proposal_accepted: None,
         member_checker: None,
         steward_checker: None,
+        suspension_checker: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);


### PR DESCRIPTION
## Summary

Accepted `FreezeMember` proposals now have a real governance consequence: the frozen member cannot cast votes until unfrozen.

Before this PR, `FreezeMember` execution set `MemberStatus::Suspended` in the CoopStore but that status had no runtime behavioral effect. A frozen member could still influence every governance vote in the domain. The freeze label existed without enforcement.

## Changes

| File | Change |
|------|--------|
| `apps/governance/src/http/configure.rs` | Add `SuspensionChecker` type alias + `suspension_checker` field to `GovernanceContext` |
| `apps/governance/src/http/handlers.rs` | `cast_vote` checks `suspension_checker` after commons standing gate; suspended voter → 403 |
| `crates/icn-gateway/src/coop.rs` | `CoopManager::is_member_suspended()` — queries CoopActor → CoopStore via `list_members`, fails open on error |
| `crates/icn-gateway/src/server.rs` | Wire `suspension_checker` from `coop_manager` into `GovernanceContext` |
| `crates/icn-gateway/tests/e2e_vote_standing_gate.rs` | Two new gate-specific tests (see below) |
| 5 other gateway test files | Add `suspension_checker: None` to `GovernanceContext` construction sites |

## Architecture

Follows the existing **closure-injection pattern** (`member_checker`, `steward_checker`): the governance app never imports `icn-coop` types. The `SuspensionChecker` closure is the only crossing point between coop-store suspension state and governance vote logic. Kernel/app boundary preserved.

The two gates are orthogonal:
- `member_checker` — commons affiliation (`MembershipStatus::Member`)
- `suspension_checker` — coop-store status (`MemberStatus::Suspended`, set by `FreezeMember` effect)

Both must pass for a vote to land.

## Tests

Two new tests in `crates/icn-gateway/tests/e2e_vote_standing_gate.rs`:
- `test_coopstore_suspended_member_blocked_by_suspension_checker` — `suspension_checker` returning `true` → 403
- `test_non_suspended_member_passes_suspension_checker` — `suspension_checker` returning `false` → 200 (backward compat when gate is wired but member is not suspended)

All 5 vote standing gate tests pass.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p icn-governance-actor -p icn-gateway -- -D warnings` — clean
- `cargo test -p icn-gateway --test e2e_vote_standing_gate --features sled-storage` — 5/5 pass

## Truth Boundary / Non-Goals

This closes **one bounded enforcement lane**: vote casting. It does NOT:
- Enforce suspension at the ledger (transaction) layer — `FreezeManager` wiring is separate work
- Auto-expire suspensions — `freeze_expires_at` metadata exists but is not yet acted on
- Implement general governance execution dispatch — `FreezeMember` execution already existed before this branch

This PR does not claim to solve governance enforcement broadly. It makes freeze have one concrete, observable consequence: the frozen member cannot vote.