### PR TITLE
feat(governance): exclude suspended delegators from delegation expansion at close time

### DIFF
--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -184,6 +184,14 @@ pub enum GovernanceCommand {
         /// Votes from members who lost commons standing after casting are excluded.
         /// When `None`, all cast votes are counted (no eligibility filter applied).
         eligible_voters: Option<std::collections::HashSet<Did>>,
+        /// Optional set of member DIDs to exclude from close-time delegation expansion.
+        ///
+        /// When `Some`, members in this set will not have their vote weight flow via
+        /// any existing delegation at close time. Specifically: if a suspended member
+        /// did not vote directly, their absent weight is NOT applied via delegation,
+        /// preventing indirect governance influence after a FreezeMember proposal.
+        /// When `None`, all non-voter members may have delegation applied (default).
+        excluded_delegators: Option<std::collections::HashSet<Did>>,
     },
     /// Emergency veto - marks a proposal as vetoed
     VetoProposal {
@@ -343,6 +351,25 @@ impl GovernanceHandle {
         self.submit(GovernanceCommand::RevokeDelegation {
             id: id.clone(),
             revoked_at,
+        })
+        .await
+    }
+
+    /// Close a proposal with standing revalidation and suspension-based delegation exclusion.
+    ///
+    /// Members in `excluded_delegators` are excluded from the close-time delegation
+    /// expansion: their vote weight will not flow via any active delegation.
+    /// Pass `eligible_voters: None` and `excluded_delegators: None` for standard close behavior.
+    pub async fn close_proposal_with_suspension(
+        &self,
+        proposal_id: ProposalId,
+        eligible_voters: Option<std::collections::HashSet<Did>>,
+        excluded_delegators: Option<std::collections::HashSet<Did>>,
+    ) -> Result<()> {
+        self.submit(GovernanceCommand::CloseProposal {
+            proposal_id,
+            eligible_voters,
+            excluded_delegators,
         })
         .await
     }
@@ -970,6 +997,7 @@ impl icn_governance::GovernanceOps for GovernanceHandle {
         self.submit(GovernanceCommand::CloseProposal {
             proposal_id,
             eligible_voters: None,
+            excluded_delegators: None,
         })
         .await
     }
@@ -982,6 +1010,7 @@ impl icn_governance::GovernanceOps for GovernanceHandle {
         self.submit(GovernanceCommand::CloseProposal {
             proposal_id,
             eligible_voters: Some(eligible_voters.clone()),
+            excluded_delegators: None,
         })
         .await
     }
@@ -1211,6 +1240,7 @@ impl GovernanceActor {
                                     if let Err(e) = handle_clone.submit(GovernanceCommand::CloseProposal {
                                         proposal_id: proposal_id.clone(),
                                         eligible_voters: None,
+                                        excluded_delegators: None,
                                     }).await {
                                         // May fail if proposal was manually closed (race condition - expected)
                                         warn!("Scheduled close for proposal {} skipped: {}", proposal_id.0, e);
@@ -1644,6 +1674,7 @@ impl GovernanceActor {
             GovernanceCommand::CloseProposal {
                 proposal_id,
                 eligible_voters,
+                excluded_delegators,
             } => {
                 info!("Closing proposal: {}", proposal_id.0);
 
@@ -1717,6 +1748,7 @@ impl GovernanceActor {
                     &proposal.domain_id,
                     &proposal_id,
                     &mut tally,
+                    excluded_delegators.as_ref(),
                 );
 
                 // Get proposal-type-specific thresholds (Issue #477)
@@ -2733,6 +2765,7 @@ impl GovernanceActor {
         domain_id: &icn_governance::GovernanceDomainId,
         proposal_id: &ProposalId,
         tally: &mut VoteTally,
+        excluded_delegators: Option<&std::collections::HashSet<Did>>,
     ) {
         // Build a fast lookup of who voted directly
         let direct_voters: std::collections::HashSet<&Did> =
@@ -2744,6 +2777,14 @@ impl GovernanceActor {
         for member in eligible_members {
             if direct_voters.contains(member) {
                 continue; // voted directly — no delegation needed
+            }
+
+            // Suspension exclusion: a suspended member's weight must not flow
+            // via delegation. Their absence contributes to quorum pressure instead.
+            if let Some(excluded) = excluded_delegators {
+                if excluded.contains(member) {
+                    continue;
+                }
             }
 
             let delegate = self.resolve_delegate_from_store(member, domain_id, proposal_id);

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -1061,18 +1061,41 @@ pub async fn close_proposal<E: GovernanceEventEmitter + Clone + 'static>(
             None
         };
 
-    match eligible_voters {
-        Some(ref eligible) => ctx
-            .manager
-            .close_proposal_filtered(proposal_id.clone(), eligible)
-            .await
-            .map_err(anyhow_to_api)?,
-        None => ctx
-            .manager
-            .close_proposal(proposal_id.clone())
-            .await
-            .map_err(anyhow_to_api)?,
-    }
+    // Suspension-based delegation exclusion: if a suspension_checker is configured,
+    // identify suspended members across all domain members (not just voters) so their
+    // vote weight cannot flow via pre-existing delegations at close time. This closes
+    // the indirect-influence loophole: a suspended member cannot proxy their governance
+    // weight through a delegate they appointed before being frozen.
+    //
+    // Only StaticList membership domains can enumerate members here; TrustThreshold
+    // domains cannot, so their delegation suspension exclusion is a known gap.
+    let excluded_delegators: Option<std::collections::HashSet<Did>> =
+        if let Some(ref checker) = ctx.suspension_checker {
+            match &domain.config.membership.source {
+                icn_governance::MembershipSource::StaticList(members) => {
+                    let domain_id = proposal.domain_id.0.clone();
+                    let mut excluded = std::collections::HashSet::new();
+                    for member in members {
+                        if checker(member.clone(), domain_id.clone()).await {
+                            excluded.insert(member.clone());
+                        }
+                    }
+                    if excluded.is_empty() {
+                        None
+                    } else {
+                        Some(excluded)
+                    }
+                }
+                icn_governance::MembershipSource::TrustThreshold(_) => None,
+            }
+        } else {
+            None
+        };
+
+    ctx.manager
+        .close_proposal_with_suspension(proposal_id.clone(), eligible_voters, excluded_delegators)
+        .await
+        .map_err(anyhow_to_api)?;
 
     let proposal = ctx
         .manager

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -714,6 +714,29 @@ impl GovernanceManager {
         self.close_proposal_inner(proposal_id, Some(eligible_voters))
     }
 
+    /// Close a proposal with both standing revalidation and suspension-based
+    /// delegation exclusion. Passes both filters through to the actor when the
+    /// actor path is active. In the in-memory path, suspension exclusion is
+    /// a no-op (no delegation expansion occurs in-memory).
+    pub async fn close_proposal_with_suspension(
+        &self,
+        proposal_id: ProposalId,
+        eligible_voters: Option<HashSet<Did>>,
+        excluded_delegators: Option<HashSet<Did>>,
+    ) -> Result<()> {
+        if let Some(ref handle) = self.governance_handle {
+            return handle
+                .close_proposal_with_suspension(proposal_id, eligible_voters, excluded_delegators)
+                .await;
+        }
+        // In-memory path: no delegation expansion, so suspension exclusion is a no-op.
+        // Just apply the eligible_voters filter if present.
+        match eligible_voters.as_ref() {
+            Some(eligible) => self.close_proposal_inner(proposal_id, Some(eligible)),
+            None => self.close_proposal_inner(proposal_id, None),
+        }
+    }
+
     fn close_proposal_inner(
         &self,
         proposal_id: ProposalId,

--- a/icn/crates/icn-core/tests/delegation_tally_integration.rs
+++ b/icn/crates/icn-core/tests/delegation_tally_integration.rs
@@ -141,6 +141,7 @@ async fn lifecycle_proposal(
         .submit(GovernanceCommand::CloseProposal {
             proposal_id: proposal_id.clone(),
             eligible_voters: None,
+            excluded_delegators: None,
         })
         .await?;
 
@@ -346,6 +347,7 @@ async fn test_lost_standing_member_delegation_blocked() -> Result<()> {
         .submit(GovernanceCommand::CloseProposal {
             proposal_id: proposal_id.clone(),
             eligible_voters: Some(eligible),
+            excluded_delegators: None,
         })
         .await?;
 
@@ -356,6 +358,174 @@ async fn test_lost_standing_member_delegation_blocked() -> Result<()> {
         0,
         "Member who lost standing must not have delegation applied — their absence \
          should contribute to quorum failure, not be covered by a pre-existing delegation"
+    );
+
+    Ok(())
+}
+
+/// Prove that a suspended member's vote weight does not flow via delegation at close time.
+///
+/// Setup:
+/// - Alice, Bob, Carol in a 3-member domain (quorum=1%, approval=50%)
+/// - Bob delegates to Alice (created before Bob is "suspended")
+/// - Alice votes For, Carol votes Against
+/// - Bob does NOT vote (he is suspended)
+///
+/// Without the suspension exclusion: Bob is a non-voter with an active delegation
+/// to Alice. At close time, Bob's weight would flow to Alice's For vote.
+/// Result: 2 For (Alice + Bob via delegation) vs 1 Against (Carol).
+/// approval = for_votes > (total_votes * 50) / 100 → 2 > 1 → Accepted.
+///
+/// With `excluded_delegators: Some({bob})`: Bob is excluded from delegation scope.
+/// His weight does NOT flow. Only Alice's direct For + Carol's Against count.
+/// Result: 1 For vs 1 Against.
+/// approval = for_votes > (total_votes * 50) / 100 → 1 > 1 → false → Rejected.
+#[tokio::test]
+async fn test_suspended_delegator_weight_excluded_at_close_time() -> Result<()> {
+    let (actor, captured, _sub, alice_did, bob_did, carol_did, domain_id) =
+        make_three_member_actor(1, 50).await?;
+
+    let proposal_id = ProposalId::generate();
+
+    // Bob creates a delegation to Alice before "suspension"
+    actor
+        .submit(GovernanceCommand::CreateDelegation {
+            delegation: Delegation::new(
+                bob_did.clone(),
+                alice_did.clone(),
+                DelegationScope::Blanket,
+            ),
+        })
+        .await?;
+
+    actor
+        .submit(GovernanceCommand::CreateProposal {
+            proposal_id: proposal_id.clone(),
+            domain_id: domain_id.clone(),
+            title: "Suspension delegation gate proof".to_string(),
+            description: "Bob delegated before suspension; his weight must not flow.".to_string(),
+            payload: ProposalPayload::Text {
+                body: "Motion text.".to_string(),
+            },
+            scope: ProposalScope::Local,
+        })
+        .await?;
+
+    actor
+        .submit(GovernanceCommand::OpenProposal {
+            proposal_id: proposal_id.clone(),
+            voting_period_seconds: 3600,
+        })
+        .await?;
+
+    // Alice votes For; Carol votes Against; Bob is suspended and does not vote.
+    actor
+        .submit(GovernanceCommand::CastVote {
+            proposal_id: proposal_id.clone(),
+            voter: alice_did.clone(),
+            choice: VoteChoice::For,
+            comment: None,
+        })
+        .await?;
+
+    actor
+        .submit(GovernanceCommand::CastVote {
+            proposal_id: proposal_id.clone(),
+            voter: carol_did.clone(),
+            choice: VoteChoice::Against,
+            comment: None,
+        })
+        .await?;
+
+    // Close with Bob in excluded_delegators — his delegation must not apply.
+    let mut excluded = std::collections::HashSet::new();
+    excluded.insert(bob_did.clone());
+
+    actor
+        .submit(GovernanceCommand::CloseProposal {
+            proposal_id: proposal_id.clone(),
+            eligible_voters: None,
+            excluded_delegators: Some(excluded),
+        })
+        .await?;
+
+    // 1 For (Alice) vs 1 Against (Carol): for_votes > (2 * 50)/100 → 1 > 1 → false → Rejected.
+    // If Bob's delegation had applied: 2 For vs 1 Against → 2 > 1 → Accepted.
+    assert_eq!(
+        accepted_count(&captured),
+        0,
+        "Suspended delegator's weight must not flow via delegation — proposal must be \
+         Rejected (1 For vs 1 Against, strict majority fails) not Accepted"
+    );
+
+    // Sanity check: if Bob is NOT excluded, his delegation DOES flow and proposal passes.
+    let (actor2, captured2, _sub2, alice_did2, bob_did2, carol_did2, domain_id2) =
+        make_three_member_actor(1, 50).await?;
+
+    let proposal_id2 = ProposalId::generate();
+
+    actor2
+        .submit(GovernanceCommand::CreateDelegation {
+            delegation: Delegation::new(
+                bob_did2.clone(),
+                alice_did2.clone(),
+                DelegationScope::Blanket,
+            ),
+        })
+        .await?;
+
+    actor2
+        .submit(GovernanceCommand::CreateProposal {
+            proposal_id: proposal_id2.clone(),
+            domain_id: domain_id2.clone(),
+            title: "Baseline: non-excluded delegation flows".to_string(),
+            description: "Bob not excluded — delegation should apply normally.".to_string(),
+            payload: ProposalPayload::Text {
+                body: "Motion text.".to_string(),
+            },
+            scope: ProposalScope::Local,
+        })
+        .await?;
+
+    actor2
+        .submit(GovernanceCommand::OpenProposal {
+            proposal_id: proposal_id2.clone(),
+            voting_period_seconds: 3600,
+        })
+        .await?;
+
+    actor2
+        .submit(GovernanceCommand::CastVote {
+            proposal_id: proposal_id2.clone(),
+            voter: alice_did2.clone(),
+            choice: VoteChoice::For,
+            comment: None,
+        })
+        .await?;
+
+    // carol_did2 votes Against — same setup as primary test, but Bob is NOT excluded.
+    actor2
+        .submit(GovernanceCommand::CastVote {
+            proposal_id: proposal_id2.clone(),
+            voter: carol_did2.clone(),
+            choice: VoteChoice::Against,
+            comment: None,
+        })
+        .await?;
+
+    // Close WITHOUT exclusion — Bob's delegation flows: 2 For vs 1 Against → 2 > 1 → Accepted.
+    actor2
+        .submit(GovernanceCommand::CloseProposal {
+            proposal_id: proposal_id2.clone(),
+            eligible_voters: None,
+            excluded_delegators: None,
+        })
+        .await?;
+
+    assert_eq!(
+        accepted_count(&captured2),
+        1,
+        "Non-excluded delegation must still flow normally — 2 For vs 1 Against → Accepted"
     );
 
     Ok(())

--- a/icn/crates/icn-core/tests/execution_receipt_gate_integration.rs
+++ b/icn/crates/icn-core/tests/execution_receipt_gate_integration.rs
@@ -137,6 +137,7 @@ async fn run_proposal(
         .submit(GovernanceCommand::CloseProposal {
             proposal_id: proposal_id.clone(),
             eligible_voters: None,
+            excluded_delegators: None,
         })
         .await?;
 

--- a/icn/crates/icn-core/tests/receipt_chain_vertical_slice.rs
+++ b/icn/crates/icn-core/tests/receipt_chain_vertical_slice.rs
@@ -154,6 +154,7 @@ async fn test_allocation_receipt_chain_end_to_end() -> Result<()> {
         .submit(GovernanceCommand::CloseProposal {
             proposal_id: proposal_id.clone(),
             eligible_voters: None,
+            excluded_delegators: None,
         })
         .await?;
 

--- a/icn/crates/icn-core/tests/vertical_slice_integration.rs
+++ b/icn/crates/icn-core/tests/vertical_slice_integration.rs
@@ -367,6 +367,7 @@ async fn test_tool_library_cooperative_vertical_slice() -> Result<()> {
         .submit(GovernanceCommand::CloseProposal {
             proposal_id: membership_proposal_id.clone(),
             eligible_voters: None,
+            excluded_delegators: None,
         })
         .await?;
 
@@ -449,6 +450,7 @@ async fn test_tool_library_cooperative_vertical_slice() -> Result<()> {
         .submit(GovernanceCommand::CloseProposal {
             proposal_id: budget_proposal_id.clone(),
             eligible_voters: None,
+            excluded_delegators: None,
         })
         .await?;
 

--- a/icn/crates/icn-governance/src/handle.rs
+++ b/icn/crates/icn-governance/src/handle.rs
@@ -126,6 +126,31 @@ pub trait GovernanceOps: Send + Sync {
         self.close_proposal(proposal_id).await
     }
 
+    /// Close a proposal with both standing revalidation and suspension-based
+    /// delegation exclusion.
+    ///
+    /// `excluded_delegators` is the set of suspended members whose vote weight
+    /// must not flow via delegation at close time. Suspension prevents indirect
+    /// governance influence through pre-existing delegations after a FreezeMember
+    /// proposal is accepted.
+    ///
+    /// The default implementation ignores `excluded_delegators` and delegates to
+    /// `close_proposal_filtered` (or `close_proposal` if no eligible filter).
+    /// Backends that support delegation expansion (e.g., `GovernanceActor`) should
+    /// override this method.
+    async fn close_proposal_with_suspension(
+        &self,
+        proposal_id: ProposalId,
+        eligible_voters: Option<std::collections::HashSet<Did>>,
+        excluded_delegators: Option<std::collections::HashSet<Did>>,
+    ) -> Result<()> {
+        let _ = excluded_delegators;
+        match eligible_voters.as_ref() {
+            Some(eligible) => self.close_proposal_filtered(proposal_id, eligible).await,
+            None => self.close_proposal(proposal_id).await,
+        }
+    }
+
     /// Add or remove a member from a governance domain
     ///
     /// Only works for domains with static-list membership. For trust-based


### PR DESCRIPTION
## What

FreezeMember tranche 6: block suspended members from exercising governance influence via pre-existing delegations.

When a proposal is closed, members in `excluded_delegators` are skipped during delegation chain resolution — their vote weight does not flow to their delegate.

## Why

A FreezeMember proposal acceptance suspends a member. But if that member had previously delegated their vote, their weight would still flow via that delegation at close time. This tranche closes that gap: the HTTP close handler builds `excluded_delegators` from the suspension checker over all domain members, passing it through to the actor's `apply_delegation_to_tally`.

## Changes

- `GovernanceCommand::CloseProposal` — adds `excluded_delegators: Option<HashSet<Did>>`
- `apply_delegation_to_tally` — skips members in `excluded_delegators` during expansion
- `GovernanceHandle::close_proposal_with_suspension` — direct method on actor handle sending both filters
- `GovernanceOps` trait — default `close_proposal_with_suspension` (falls back to filtered/plain close)
- `GovernanceManager::close_proposal_with_suspension` — delegates to actor handle; in-memory path is a no-op (no delegation expansion)
- HTTP `close_proposal` handler — builds `excluded_delegators` from suspension checker + domain StaticList members

## Test

`test_suspended_delegator_weight_excluded_at_close_time` in `delegation_tally_integration.rs`:
- Alice For + Carol Against; Bob suspended (in `excluded_delegators`) with delegation to Alice
- **With exclusion:** 1 For vs 1 Against → `1 > 1` → false → Rejected ✓
- **Without exclusion (baseline):** Bob's delegation flows → 2 For vs 1 Against → `2 > 1` → Accepted ✓

## Risk

Low. The `excluded_delegators` field defaults to `None` at all existing call sites (no behavior change for non-suspension paths). The in-memory manager path has no delegation expansion so exclusion is a no-op there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)