### PR TITLE
feat(governance): gate blanket delegations on suspension status

### DIFF
--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -1645,28 +1645,62 @@ pub async fn create_delegation<E: GovernanceEventEmitter + Clone + 'static>(
     // Scope resolution:
     // - Domain(id)   → domain is known directly; checked below.
     // - Proposal(id) → domain is resolved via manager lookup; checked below.
-    // - Blanket       → spans all domains; no single domain to check against
-    //                   the per-(did, domain) suspension index. Known gap:
-    //                   blanket delegations by suspended members are not blocked
-    //                   in this tranche.
+    // - Blanket       → spans all StaticList domains; check each one the delegator
+    //                   belongs to. TrustThreshold domains are skipped (member set
+    //                   is not enumerable without the trust graph at this layer).
     if let Some(ref checker) = ctx.suspension_checker {
-        let domain_id_opt: Option<String> = match &scope {
-            DelegationScope::Domain(d) => Some(d.0.clone()),
-            DelegationScope::Proposal(p) => ctx
-                .manager
-                .get_proposal(p)
-                .await
-                .unwrap_or(None)
-                .map(|prop| prop.domain_id.0.clone()),
-            DelegationScope::Blanket => None,
-        };
-        if let Some(domain_id) = domain_id_opt {
-            if checker(delegator_did.clone(), domain_id.clone()).await {
-                return Err(err_forbidden(format!(
-                    "delegator {} is suspended in domain {}; \
-                     suspended members may not create delegations",
-                    delegator_did, domain_id
-                )));
+        match &scope {
+            DelegationScope::Blanket => {
+                // A blanket delegation affects all domains. Enumerate every
+                // StaticList domain the delegator belongs to and deny if suspended
+                // in any of them. Errors from list_domains are non-fatal: if we
+                // cannot enumerate, we do not deny (fail-open preserves existing
+                // non-suspended behaviour and prevents spurious 403s).
+                if let Ok(all_domains) = ctx.manager.list_domains().await {
+                    for domain in &all_domains {
+                        let is_member = match &domain.config.membership.source {
+                            icn_governance::MembershipSource::StaticList(members) => {
+                                members.contains(&delegator_did)
+                            }
+                            icn_governance::MembershipSource::TrustThreshold(_) => {
+                                // Cannot enumerate dynamic membership here; skip.
+                                false
+                            }
+                        };
+                        if is_member {
+                            let domain_id = domain.id.0.clone();
+                            if checker(delegator_did.clone(), domain_id.clone()).await {
+                                return Err(err_forbidden(format!(
+                                    "delegator {} is suspended in domain {}; \
+                                     suspended members may not create blanket delegations",
+                                    delegator_did, domain_id
+                                )));
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {
+                // Domain and Proposal scopes: check the single resolved domain.
+                let domain_id_opt: Option<String> = match &scope {
+                    DelegationScope::Domain(d) => Some(d.0.clone()),
+                    DelegationScope::Proposal(p) => ctx
+                        .manager
+                        .get_proposal(p)
+                        .await
+                        .unwrap_or(None)
+                        .map(|prop| prop.domain_id.0.clone()),
+                    DelegationScope::Blanket => unreachable!("handled above"),
+                };
+                if let Some(domain_id) = domain_id_opt {
+                    if checker(delegator_did.clone(), domain_id.clone()).await {
+                        return Err(err_forbidden(format!(
+                            "delegator {} is suspended in domain {}; \
+                             suspended members may not create delegations",
+                            delegator_did, domain_id
+                        )));
+                    }
+                }
             }
         }
     }

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -1643,31 +1643,29 @@ pub async fn create_delegation<E: GovernanceEventEmitter + Clone + 'static>(
     // by creating delegations in domains where they are frozen.
     //
     // Scope resolution:
-    // - Domain(id)   → domain is known directly; checked below.
-    // - Proposal(id) → domain is resolved via manager lookup; checked below.
-    // - Blanket       → spans all StaticList domains; check each one the delegator
-    //                   belongs to. TrustThreshold domains are skipped (member set
-    //                   is not enumerable without the trust graph at this layer).
+    // - Domain(id)   → domain is known directly; suspension checked against it.
+    // - Proposal(id) → domain resolved via manager lookup; suspension checked.
+    // - Blanket       → applies to all domains globally; the gate enumerates
+    //                   every StaticList domain the delegator belongs to and
+    //                   denies if suspended in any. TrustThreshold domains are
+    //                   intentionally skipped (member set is not enumerable
+    //                   without the trust graph at this layer).
     if let Some(ref checker) = ctx.suspension_checker {
         match &scope {
             DelegationScope::Blanket => {
-                // A blanket delegation affects all domains. Enumerate every
-                // StaticList domain the delegator belongs to and deny if suspended
-                // in any of them. Errors from list_domains are non-fatal: if we
-                // cannot enumerate, we do not deny (fail-open preserves existing
-                // non-suspended behaviour and prevents spurious 403s).
+                // A blanket delegation affects all domains globally. Enumerate
+                // every domain the delegator belongs to via StaticList and deny
+                // if suspended in any. Errors from list_domains are fail-open:
+                // if enumeration fails, we do not deny (prevents spurious 403s
+                // and preserves behaviour for non-suspended callers).
                 if let Ok(all_domains) = ctx.manager.list_domains().await {
                     for domain in &all_domains {
-                        let is_member = match &domain.config.membership.source {
-                            icn_governance::MembershipSource::StaticList(members) => {
-                                members.contains(&delegator_did)
-                            }
-                            icn_governance::MembershipSource::TrustThreshold(_) => {
-                                // Cannot enumerate dynamic membership here; skip.
-                                false
-                            }
-                        };
-                        if is_member {
+                        if domain
+                            .config
+                            .membership
+                            .source
+                            .contains_static(&delegator_did)
+                        {
                             let domain_id = domain.id.0.clone();
                             if checker(delegator_did.clone(), domain_id.clone()).await {
                                 return Err(err_forbidden(format!(
@@ -1680,19 +1678,24 @@ pub async fn create_delegation<E: GovernanceEventEmitter + Clone + 'static>(
                     }
                 }
             }
-            _ => {
-                // Domain and Proposal scopes: check the single resolved domain.
-                let domain_id_opt: Option<String> = match &scope {
-                    DelegationScope::Domain(d) => Some(d.0.clone()),
-                    DelegationScope::Proposal(p) => ctx
-                        .manager
-                        .get_proposal(p)
-                        .await
-                        .unwrap_or(None)
-                        .map(|prop| prop.domain_id.0.clone()),
-                    DelegationScope::Blanket => unreachable!("handled above"),
-                };
-                if let Some(domain_id) = domain_id_opt {
+            DelegationScope::Domain(d) => {
+                let domain_id = d.0.clone();
+                if checker(delegator_did.clone(), domain_id.clone()).await {
+                    return Err(err_forbidden(format!(
+                        "delegator {} is suspended in domain {}; \
+                         suspended members may not create delegations",
+                        delegator_did, domain_id
+                    )));
+                }
+            }
+            DelegationScope::Proposal(p) => {
+                if let Some(domain_id) = ctx
+                    .manager
+                    .get_proposal(p)
+                    .await
+                    .unwrap_or(None)
+                    .map(|prop| prop.domain_id.0.clone())
+                {
                     if checker(delegator_did.clone(), domain_id.clone()).await {
                         return Err(err_forbidden(format!(
                             "delegator {} is suspended in domain {}; \

--- a/icn/crates/icn-gateway/tests/e2e_create_delegation_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_create_delegation_gate.rs
@@ -27,7 +27,6 @@
 //! - Ledger enforcement (covered in e2e_ledger_freeze_enforcement.rs).
 //! - Proposal-creation enforcement (covered in e2e_proposal_submission_gate.rs).
 //! - Open-proposal enforcement (covered in e2e_open_proposal_gate.rs).
-//! - Blanket-scope delegation gating (known gap: no single domain to check against).
 //! - Full atomic suspension (best-effort hook, not transactional).
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
@@ -104,6 +103,32 @@ async fn try_create_delegation(
             .set_json(json!({
                 "delegate": delegate_did,
                 "scope": format!("domain:{domain_id}")
+            }))
+            .to_request(),
+    )
+    .await
+    .status()
+    .as_u16()
+}
+
+/// Helper: attempt to create a Blanket-scoped delegation via HTTP; return status.
+async fn try_create_blanket_delegation(
+    app: &impl actix_web::dev::Service<
+        actix_http::Request,
+        Response = actix_web::dev::ServiceResponse,
+        Error = actix_web::Error,
+    >,
+    token: &str,
+    delegate_did: &str,
+) -> u16 {
+    test::call_service(
+        app,
+        test::TestRequest::post()
+            .uri("/v1/gov/delegations")
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .set_json(json!({
+                "delegate": delegate_did,
+                "scope": "blanket"
             }))
             .to_request(),
     )
@@ -331,4 +356,242 @@ async fn test_suspended_member_cannot_create_delegation() {
         bystander_status, 201,
         "non-suspended bystander must be able to create delegations (got {bystander_status})"
     );
+}
+
+/// E2E Blanket-scope delegation suspension gate:
+///   member is suspended in a StaticList domain →
+///   subsequent Blanket create_delegation is denied 403,
+///   non-suspended member's Blanket delegation succeeds,
+///   unrelated member (not in any domain) is not denied.
+///
+/// This proves that the `list_domains()` → `contains_static()` walk correctly
+/// identifies the delegator's member domains and denies the Blanket creation.
+#[actix_web::test]
+async fn test_suspended_member_cannot_create_blanket_delegation() {
+    const DOMAIN_ID: &str = "blanket-gate-test-coop";
+
+    // ── In-memory suspension store ───────────────────────────────────────────
+    let suspended: Arc<RwLock<HashSet<(String, String)>>> = Arc::new(RwLock::new(HashSet::new()));
+
+    // ── Member identities ────────────────────────────────────────────────────
+    let target_kp = KeyPair::generate().expect("target KeyPair");
+    let target_did: Did = target_kp.did().clone();
+
+    let bystander_kp = KeyPair::generate().expect("bystander KeyPair");
+    let bystander_did: Did = bystander_kp.did().clone();
+
+    let proxy_kp = KeyPair::generate().expect("proxy KeyPair");
+    let proxy_did: Did = proxy_kp.did().clone();
+
+    // outsider is NOT in any domain — Blanket delegation must still succeed.
+    let outsider_kp = KeyPair::generate().expect("outsider KeyPair");
+    let outsider_did: Did = outsider_kp.did().clone();
+
+    // ── Wire hook + checker ──────────────────────────────────────────────────
+    let suspended_for_hook = suspended.clone();
+    let on_proposal_accepted: ProposalAcceptedHook = Arc::new(move |effect| {
+        if let GovernanceEffect::FreezeMember {
+            member, domain_id, ..
+        } = effect
+        {
+            let s = suspended_for_hook.clone();
+            tokio::spawn(async move {
+                s.write().await.insert((member.to_string(), domain_id));
+            });
+        }
+    });
+
+    let suspended_for_checker = suspended.clone();
+    let suspension_checker: SuspensionChecker = Arc::new(move |did: Did, domain_id: String| {
+        let s = suspended_for_checker.clone();
+        Box::pin(async move { s.read().await.contains(&(did.to_string(), domain_id)) })
+    });
+
+    // ── Build test app ────────────────────────────────────────────────────────
+    let jwt_secret = b"blanket-gate-enforcement-sec--32".to_vec();
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
+    let governance_manager = Arc::new(GovernanceManager::new());
+
+    let gov_ctx = GovernanceContext {
+        manager: governance_manager.clone(),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: Some(on_proposal_accepted),
+        member_checker: None,
+        steward_checker: None,
+        suspension_checker: Some(suspension_checker),
+    };
+
+    let auth_mw = HttpAuthentication::bearer(jwt_auth);
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(auth_manager.clone()))
+            .app_data(web::Data::new(ip_limiter.clone()))
+            .service(
+                web::scope("/v1")
+                    .service(api::auth::challenge)
+                    .service(api::auth::verify)
+                    .service(
+                        web::scope("/gov")
+                            .configure({
+                                let ctx = gov_ctx.clone();
+                                move |cfg| {
+                                    icn_governance_actor::http::configure::configure(
+                                        cfg,
+                                        ctx.clone(),
+                                    )
+                                }
+                            })
+                            .wrap(auth_mw),
+                    ),
+            ),
+    )
+    .await;
+
+    // ── Auth ─────────────────────────────────────────────────────────────────
+    let actor_bundle = IdentityBundle::generate().expect("actor IdentityBundle");
+    let actor_did_str = actor_bundle.did().to_string();
+    let actor_token = get_jwt(&app, &actor_did_str, &actor_bundle).await;
+
+    let target_bundle = IdentityBundle::from_keypair(target_kp).expect("target IdentityBundle");
+    let target_did_str = target_did.to_string();
+    let target_token = get_jwt(&app, &target_did_str, &target_bundle).await;
+
+    let bystander_bundle =
+        IdentityBundle::from_keypair(bystander_kp).expect("bystander IdentityBundle");
+    let bystander_did_str = bystander_did.to_string();
+    let bystander_token = get_jwt(&app, &bystander_did_str, &bystander_bundle).await;
+
+    let outsider_bundle =
+        IdentityBundle::from_keypair(outsider_kp).expect("outsider IdentityBundle");
+    let outsider_did_str = outsider_did.to_string();
+    let outsider_token = get_jwt(&app, &outsider_did_str, &outsider_bundle).await;
+
+    let proxy_bundle = IdentityBundle::from_keypair(proxy_kp).expect("proxy IdentityBundle");
+    let proxy_did_str = proxy_did.to_string();
+    let _ = get_jwt(&app, &proxy_did_str, &proxy_bundle).await;
+
+    // ── Create governance domain (StaticList: actor + target + bystander) ────
+    let actor_governance_did: Did = actor_did_str.parse().expect("actor DID parse");
+    let target_governance_did: Did = target_did_str.parse().expect("target DID parse");
+    let bystander_governance_did: Did = bystander_did_str.parse().expect("bystander DID parse");
+    let domain_id_gov = GovernanceDomainId(DOMAIN_ID.to_string());
+
+    governance_manager
+        .create_domain(
+            domain_id_gov.clone(),
+            "Blanket Gate Test Cooperative".to_string(),
+            "cooperative".to_string(),
+            GovernanceParams::new(1, 1, 86_400),
+            MembershipConfig {
+                source: MembershipSource::StaticList(vec![
+                    actor_governance_did.clone(),
+                    target_governance_did,
+                    bystander_governance_did,
+                ]),
+            },
+        )
+        .await
+        .expect("create_domain");
+
+    // ── Precondition: target (not yet suspended) can create a Blanket delegation
+    let pre_freeze_status =
+        try_create_blanket_delegation(&app, &target_token, &proxy_did_str).await;
+    assert_eq!(
+        pre_freeze_status, 201,
+        "pre-condition: unsuspended target must be able to create blanket delegations (got {pre_freeze_status})"
+    );
+
+    // ── Suspend target via FreezeMember proposal ─────────────────────────────
+    let freeze_proposal_id = ProposalId("blanket-gate-freeze-prop".to_string());
+    governance_manager
+        .create_proposal(
+            freeze_proposal_id.clone(),
+            domain_id_gov,
+            actor_governance_did,
+            "Freeze target member".to_string(),
+            "Suspend target from all governance actions.".to_string(),
+            ProposalPayload::FreezeMember {
+                member: target_did.clone(),
+                reason: "governance abuse".to_string(),
+                duration_seconds: None,
+            },
+            ProposalScope::Local,
+        )
+        .await
+        .expect("create FreezeMember proposal");
+
+    let freeze_id = freeze_proposal_id.0.clone();
+
+    let open_resp = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/v1/gov/proposals/{freeze_id}/open"))
+            .insert_header(("Authorization", format!("Bearer {actor_token}")))
+            .set_json(json!({ "voting_period_seconds": 3600 }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(open_resp.status().as_u16(), 200, "open freeze proposal");
+
+    let vote_resp = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/v1/gov/proposals/{freeze_id}/vote"))
+            .insert_header(("Authorization", format!("Bearer {actor_token}")))
+            .set_json(json!({ "choice": "for" }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(vote_resp.status().as_u16(), 200, "vote on freeze proposal");
+
+    let close_resp = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/v1/gov/proposals/{freeze_id}/close"))
+            .insert_header(("Authorization", format!("Bearer {actor_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(close_resp.status().as_u16(), 200, "close freeze proposal");
+
+    // ── Wait for hook ─────────────────────────────────────────────────────────
+    let expected_suspension = (target_did_str.clone(), DOMAIN_ID.to_string());
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if suspended.read().await.contains(&expected_suspension) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for FreezeMember acceptance hook");
+
+    // ── Assert: suspended member cannot create a Blanket delegation ───────────
+    let post_freeze_status =
+        try_create_blanket_delegation(&app, &target_token, &proxy_did_str).await;
+    assert_eq!(
+        post_freeze_status, 403,
+        "suspended member must be denied blanket delegation creation (got {post_freeze_status})"
+    );
+
+    // ── Assert: non-suspended bystander can still create Blanket delegations ──
+    let bystander_status =
+        try_create_blanket_delegation(&app, &bystander_token, &proxy_did_str).await;
+    assert_eq!(
+        bystander_status, 201,
+        "non-suspended bystander must be able to create blanket delegations (got {bystander_status})"
+    );
+
+    // ── Assert: outsider (not in any domain) is not falsely denied ────────────
+    let outsider_status =
+        try_create_blanket_delegation(&app, &outsider_token, &proxy_did_str).await;
+    assert_eq!(
+        outsider_status, 201,
+        "outsider not in any domain must not be falsely denied (got {outsider_status})"
+    );
+
+    let _ = outsider_did_str;
 }


### PR DESCRIPTION
## What

FreezeMember tranche 7: block suspended members from creating Blanket-scope delegations.

Prior tranche (#1494) gated Domain- and Proposal-scoped delegation creation but skipped Blanket scope because there is no single domain ID available at creation time. This tranche closes that gap.

## Why

A suspended member could still call `POST /delegations` with `scope: "blanket"`. While the close-time exclusion from #1495 mitigates the downstream tally impact, the semantic policy was incomplete: suspended members should not create new delegations of any scope.

## How

The `create_delegation` handler now has an explicit `Blanket` match arm that:
1. Calls `ctx.manager.list_domains()` to enumerate all known domains
2. For each `StaticList` domain, checks `contains_static(&delegator_did)`
3. If the delegator is a member, calls `suspension_checker(delegator_did, domain_id)`
4. Denies with 403 on first suspended-domain match

**TrustThreshold domains** are skipped — member sets are not enumerable without the trust graph at this layer. This is consistent with the close-time handler's existing TrustThreshold gap.

**Fail-open on `list_domains()` errors** — if domain enumeration fails, the request proceeds rather than returning a spurious 403. Non-suspended and out-of-domain members are never falsely denied.

## Test

`test_suspended_member_cannot_create_blanket_delegation` in `e2e_create_delegation_gate.rs`:
- Pre-suspension: target can create Blanket delegation → 201 ✓
- After FreezeMember accepted: target → 403 ✓
- Non-suspended bystander → 201 ✓
- Outsider (not in any domain) → 201 (no false denial) ✓

## Risk

Low. The Blanket arm is new code; existing Domain/Proposal arm behavior is unchanged. Fail-open semantics prevent accidental lockout if domain enumeration is unavailable.

## What This Closes

FreezeMember now blocks:
1. Direct vote casting (#1490)
2. Ledger submission (#1491)
3. Proposal creation (#1492)
4. Proposal opening (#1493)
5. All new delegation creation — Domain, Proposal, and now Blanket scope (#1494 + this PR)
6. Delegated vote-weight flow at close time (#1495)

## Remaining Known Gaps (out of scope)

- TrustThreshold domains: close-time suspension exclusion is a no-op
- Pre-suspension direct votes are not retroactively invalidated
- Freeze auto-expiration / storage cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)