### PR TITLE
feat(governance): add close-time suspension resolver seam for TrustThreshold domains

### DIFF
--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -14,6 +14,7 @@
 use std::sync::Arc;
 
 use actix_web::web;
+use icn_governance::MembershipResolver;
 use icn_identity::Did;
 
 use crate::events::GovernanceEventEmitter;
@@ -197,6 +198,17 @@ pub struct GovernanceContext<E> {
     /// proposal's domain — i.e., a `FreezeMember` proposal was accepted for them.
     /// A `true` result → 403 Forbidden. `None` disables the gate.
     pub suspension_checker: Option<SuspensionChecker>,
+    /// Optional resolver for enumerating eligible voters in `TrustThreshold` domains.
+    ///
+    /// `StaticList` domains enumerate members from the source directly at close time.
+    /// `TrustThreshold` domains cannot: membership is derived from a trust graph that
+    /// lives outside the governance layer. When this resolver is set, `close_proposal`
+    /// calls `resolve_members()` to obtain the current eligible set and checks each
+    /// against `suspension_checker` to build `excluded_delegators`.
+    ///
+    /// If `None`, `TrustThreshold` domains fall through with `excluded_delegators: None`
+    /// (fail-open — delegations from suspended members may still flow).
+    pub membership_resolver: Option<Arc<dyn MembershipResolver>>,
 }
 
 /// Register all governance routes on `cfg`.

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -1086,7 +1086,35 @@ pub async fn close_proposal<E: GovernanceEventEmitter + Clone + 'static>(
                         Some(excluded)
                     }
                 }
-                icn_governance::MembershipSource::TrustThreshold(_) => None,
+                icn_governance::MembershipSource::TrustThreshold(_) => {
+                    // TrustThreshold domains cannot enumerate members from the
+                    // MembershipSource directly. If a resolver is wired into the
+                    // context, ask it for the current eligible set and check each
+                    // member against the suspension gate. Fail-open on resolver
+                    // errors: a spurious 403 is worse than a missed exclusion, and
+                    // a production resolver must be reliable.
+                    if let Some(ref resolver) = ctx.membership_resolver {
+                        match resolver.resolve_members(&domain) {
+                            Ok(members) => {
+                                let domain_id = proposal.domain_id.0.clone();
+                                let mut excluded = std::collections::HashSet::new();
+                                for member in &members {
+                                    if checker(member.clone(), domain_id.clone()).await {
+                                        excluded.insert(member.clone());
+                                    }
+                                }
+                                if excluded.is_empty() {
+                                    None
+                                } else {
+                                    Some(excluded)
+                                }
+                            }
+                            Err(_) => None,
+                        }
+                    } else {
+                        None
+                    }
+                }
             }
         } else {
             None
@@ -2466,7 +2494,9 @@ mod tests {
 
     use super::*;
     use crate::events::NoopEventEmitter;
-    use crate::http::configure::{GovernanceContext, GovernanceEffect, ProposalAcceptedHook};
+    use crate::http::configure::{
+        GovernanceContext, GovernanceEffect, ProposalAcceptedHook, SuspensionChecker,
+    };
     use crate::manager::GovernanceManager;
 
     fn test_did(seed: u8) -> Did {
@@ -2579,6 +2609,7 @@ mod tests {
             member_checker: None,
             steward_checker: None,
             suspension_checker: None,
+            membership_resolver: None,
         };
 
         let app = test_app!(ctx, member_did);
@@ -2657,6 +2688,7 @@ mod tests {
             member_checker: None,
             steward_checker: None,
             suspension_checker: None,
+            membership_resolver: None,
         };
 
         let app = test_app!(ctx, member_did);
@@ -2670,6 +2702,130 @@ mod tests {
         assert!(
             !*fired.lock().unwrap(),
             "hook must NOT fire when proposal is rejected"
+        );
+    }
+
+    /// Proves: the `close_proposal` HTTP handler invokes `membership_resolver` for
+    /// `TrustThreshold` domains and uses the resolved member list to build
+    /// `excluded_delegators`. This exercises the code path added in Tranche 8.
+    ///
+    /// Note: the in-memory `GovernanceManager` does not expand delegations at close time
+    /// (delegation expansion requires the full `GovernanceActor`). The behavioral
+    /// proof that excluded members' weight does not flow is covered by
+    /// `test_suspended_delegator_weight_excluded_at_close_time` in
+    /// `crates/icn-core/tests/delegation_tally_integration.rs`. This test verifies
+    /// the HTTP-layer integration: that the resolver is invoked and the handler succeeds.
+    #[tokio::test]
+    async fn trust_threshold_membership_resolver_invoked_at_close_time() {
+        use icn_governance::{GovernanceDomain, MembershipResolver};
+        use icn_identity::KeyPair;
+
+        // Test-only resolver: tracks whether `resolve_members` was called.
+        struct TrackingResolver {
+            members: Vec<Did>,
+            called: Arc<Mutex<bool>>,
+        }
+        impl MembershipResolver for TrackingResolver {
+            fn resolve_members(&self, _domain: &GovernanceDomain) -> anyhow::Result<Vec<Did>> {
+                *self.called.lock().unwrap() = true;
+                Ok(self.members.clone())
+            }
+        }
+
+        // Use real KeyPairs so parse_did succeeds (test_did(N) with high N can produce
+        // 32-byte patterns that are not valid Ed25519 points).
+        let alice_kp = KeyPair::generate().unwrap();
+        let bob_kp = KeyPair::generate().unwrap();
+        let alice_did = alice_kp.did().clone();
+        let bob_did = bob_kp.did().clone();
+
+        let mgr = Arc::new(GovernanceManager::new());
+        let domain_id = GovernanceDomainId("tt-resolver-test".to_string());
+
+        // TrustThreshold domain: members cannot be enumerated without a resolver
+        mgr.create_domain(
+            domain_id.clone(),
+            "TrustThreshold Coop".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::new(0, 0, 86_400), // quorum=0, approval=0 → always Accepted
+            MembershipConfig {
+                source: MembershipSource::TrustThreshold(0.3),
+            },
+        )
+        .await
+        .unwrap();
+
+        let proposal_id = ProposalId("tt-resolver-proof-1".to_string());
+        mgr.create_proposal(
+            proposal_id.clone(),
+            domain_id.clone(),
+            alice_did.clone(),
+            "TrustThreshold resolver test".to_string(),
+            "Proves resolver is invoked for TrustThreshold domains".to_string(),
+            ProposalPayload::FreezeMember {
+                member: test_did(1), // target DID: use seed 1 which is a valid Ed25519 point
+                reason: "test".to_string(),
+                duration_seconds: Some(86_400),
+            },
+            ProposalScope::Local,
+        )
+        .await
+        .unwrap();
+
+        mgr.open_proposal(proposal_id.clone(), 86_400)
+            .await
+            .unwrap();
+
+        mgr.cast_vote(
+            proposal_id.clone(),
+            alice_did.clone(),
+            VoteChoice::For,
+            None,
+        )
+        .await
+        .unwrap();
+
+        // suspension_checker marks bob as suspended
+        let bob_did_for_checker = bob_did.clone();
+        let suspension_checker: SuspensionChecker = Arc::new(move |did, _domain_id| {
+            let bob = bob_did_for_checker.clone();
+            Box::pin(async move { did == bob })
+        });
+
+        let resolver_called = Arc::new(Mutex::new(false));
+        let resolver: Arc<dyn MembershipResolver> = Arc::new(TrackingResolver {
+            members: vec![alice_did.clone(), bob_did.clone()],
+            called: resolver_called.clone(),
+        });
+
+        let ctx = GovernanceContext {
+            manager: mgr.clone(),
+            emitter: NoopEventEmitter,
+            on_charter_accepted: None,
+            on_proposal_accepted: None,
+            member_checker: None,
+            steward_checker: None,
+            suspension_checker: Some(suspension_checker),
+            membership_resolver: Some(resolver),
+        };
+
+        let app = test_app!(ctx, alice_did);
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri(&format!("/proposals/{}/close", proposal_id.0))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(
+            resp.status().as_u16(),
+            200,
+            "close_proposal with TrustThreshold + resolver must succeed"
+        );
+        assert!(
+            *resolver_called.lock().unwrap(),
+            "membership_resolver.resolve_members() must be invoked for TrustThreshold domains"
         );
     }
 }

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -1319,6 +1319,11 @@ impl GatewayServer {
             member_checker: Some(member_checker),
             steward_checker: Some(steward_checker),
             suspension_checker: Some(suspension_checker),
+            // TrustThreshold membership resolution requires a trust graph that lives
+            // outside the governance layer. Until the gateway wires a resolver here,
+            // TrustThreshold domains fall through with excluded_delegators: None
+            // (fail-open). Wire a TrustMembershipResolver here to close that gap.
+            membership_resolver: None,
         };
 
         // Create rate limiter with configured or default config

--- a/icn/crates/icn-gateway/tests/e2e_close_time_revalidation.rs
+++ b/icn/crates/icn-gateway/tests/e2e_close_time_revalidation.rs
@@ -223,6 +223,7 @@ async fn build_app_with_proposal(
         member_checker: Some(make_checker(commons_mgr)),
         steward_checker: None,
         suspension_checker: None,
+        membership_resolver: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/e2e_create_delegation_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_create_delegation_gate.rs
@@ -193,6 +193,7 @@ async fn test_suspended_member_cannot_create_delegation() {
         member_checker: None,
         steward_checker: None,
         suspension_checker: Some(suspension_checker),
+        membership_resolver: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);
@@ -421,6 +422,7 @@ async fn test_suspended_member_cannot_create_blanket_delegation() {
         member_checker: None,
         steward_checker: None,
         suspension_checker: Some(suspension_checker),
+        membership_resolver: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
+++ b/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
@@ -233,6 +233,7 @@ async fn test_e2e_freeze_member_suspends_commons_affiliation() {
         member_checker: None,
         steward_checker: None,
         suspension_checker: None,
+        membership_resolver: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);
@@ -485,6 +486,7 @@ async fn test_e2e_unfreeze_member_reinstates_commons_affiliation() {
         member_checker: None,
         steward_checker: None,
         suspension_checker: None,
+        membership_resolver: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);
@@ -728,6 +730,7 @@ async fn test_e2e_appoint_steward_scoped_to_chartered_domain() {
         member_checker: None,
         steward_checker: None,
         suspension_checker: None,
+        membership_resolver: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/e2e_ledger_freeze_enforcement.rs
+++ b/icn/crates/icn-gateway/tests/e2e_ledger_freeze_enforcement.rs
@@ -149,6 +149,7 @@ async fn test_freeze_member_blocks_ledger_entries_after_governance_acceptance() 
         member_checker: None,
         steward_checker: None,
         suspension_checker: None,
+        membership_resolver: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/e2e_member_standing_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_member_standing_gate.rs
@@ -135,6 +135,7 @@ async fn build_app(
         member_checker: Some(make_checker(commons_mgr)),
         steward_checker: None,
         suspension_checker: None,
+        membership_resolver: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/e2e_open_proposal_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_open_proposal_gate.rs
@@ -134,6 +134,7 @@ async fn test_suspended_member_cannot_open_proposal() {
         member_checker: None,
         steward_checker: None,
         suspension_checker: Some(suspension_checker),
+        membership_resolver: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/e2e_proposal_submission_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_proposal_submission_gate.rs
@@ -168,6 +168,7 @@ async fn test_suspended_member_cannot_submit_proposals() {
         member_checker: None,
         steward_checker: None,
         suspension_checker: Some(suspension_checker),
+        membership_resolver: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/e2e_steward_standing_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_steward_standing_gate.rs
@@ -135,6 +135,7 @@ async fn build_app(
         member_checker: Some(make_member_checker(commons_mgr.clone())),
         steward_checker: Some(make_steward_checker(commons_mgr)),
         suspension_checker: None,
+        membership_resolver: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/e2e_vote_standing_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_vote_standing_gate.rs
@@ -158,6 +158,7 @@ async fn build_app_with_open_proposal(
         member_checker: Some(make_checker(commons_mgr)),
         steward_checker: None,
         suspension_checker: None,
+        membership_resolver: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);
@@ -407,6 +408,7 @@ async fn build_app_with_suspension_checker(
         member_checker: None, // omit commons gate — isolate suspension gate
         steward_checker: None,
         suspension_checker: Some(suspension_checker),
+        membership_resolver: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/governance_proof.rs
+++ b/icn/crates/icn-gateway/tests/governance_proof.rs
@@ -75,6 +75,7 @@ async fn test_governance_proposal_full_lifecycle_with_real_auth() {
         member_checker: None,
         steward_checker: None,
         suspension_checker: None,
+        membership_resolver: None,
     };
 
     // Build test app — mirrors the governance-relevant subset of server.rs:
@@ -390,6 +391,7 @@ async fn test_governance_endpoints_require_auth() {
         member_checker: None,
         steward_checker: None,
         suspension_checker: None,
+        membership_resolver: None,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);


### PR DESCRIPTION
## Summary
- Adds `membership_resolver: Option<Arc<dyn MembershipResolver>>` to `GovernanceContext`
- `close_proposal` handler now uses the resolver when present to enumerate TrustThreshold domain members at close time, building `excluded_delegators` the same way the StaticList path does
- Without a resolver wired (current gateway default), TrustThreshold domains preserve existing fail-open behavior (`excluded_delegators: None`)
- Updates all `GovernanceContext` construction sites with `membership_resolver: None`

## What this adds (seam, not closure)

This PR adds the **resolver injection point** for TrustThreshold close-time suspension exclusion. It does **not** fully close that gap in production.

The remaining gap: the gateway's `membership_resolver` is still `None`. Wiring a live resolver requires `get_dids_above_threshold()` to be exposed via the `TrustService` kernel interface, which does not currently exist. Until that is added and wired, TrustThreshold domains remain fail-open at close time.

The code and comments in `handlers.rs` (line ~1070) and `server.rs` document this explicitly.

## FreezeMember tranche progress (honest accounting)

| # | What | PR | Status |
|---|------|----|--------|
| 1 | Direct vote casting | #1490 | ✅ closed |
| 2 | Ledger-side restrictions | #1491 | ✅ closed |
| 3 | Proposal creation | #1492 | ✅ closed |
| 4 | Proposal opening | #1493 | ✅ closed |
| 5 | Domain + Proposal delegation creation | #1494 | ✅ closed |
| 6 | Close-time delegated weight — StaticList | #1495 | ✅ closed |
| 7 | Blanket delegation creation | #1496 | ✅ closed |
| 8 | Close-time delegated weight — TrustThreshold | **this PR** | ⚠️ seam added; live enforcement blocked until `TrustService::get_dids_above_threshold()` exists |

## Test plan
- [ ] `cargo test -p icn-governance-actor --lib` — all tests pass including `trust_threshold_membership_resolver_invoked_at_close_time`
- [ ] `cargo test -p icn-gateway --test e2e_create_delegation_gate` — 2/2 pass
- [ ] `cargo clippy -p icn-governance-actor -p icn-gateway --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --all -- --check` — clean

## Note on behavioral proof
The handler test `trust_threshold_membership_resolver_invoked_at_close_time` proves the resolver seam is invoked and safe. The behavioral contract (suspended delegators' weight does not flow) is covered by the existing actor-level test `test_suspended_delegator_weight_excluded_at_close_time` in `crates/icn-core/tests/delegation_tally_integration.rs` — the GovernanceActor's delegation expansion is domain-source-agnostic once `excluded_delegators` is set correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)