### PR TITLE
chore(ci): route Test Coverage to homelab runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,7 +425,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.docs_only != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     timeout-minutes: 30
-    runs-on: [self-hosted, linux, x64, coverage]
+    runs-on: [self-hosted, linux, x64, homelab]
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

Routes the `Test Coverage` job from `[coverage]` label to `[homelab]` label.

**Why:** `zentith-coverage` was a temporary workaround while Hyperion's RAM was out for RMA. Hyperion is back. `ci-runner` (VM 446, 10.8.30.46) already has everything needed:
- `cargo-llvm-cov 0.8.5` installed
- `llvm-cov` + `llvm-profdata` bundled with rustup toolchain
- `sccache` for build caching

**Before:** `runs-on: [self-hosted, linux, x64, coverage]` → only `zentith-coverage` matches (currently offline)  
**After:** `runs-on: [self-hosted, linux, x64, homelab]` → `ci-runner` handles it

## Impact
- `Test Coverage` jobs will no longer queue indefinitely when zentith is offline
- PRs will show `CLEAN` instead of `UNSTABLE` once `Compare Against Base` completes
- No behavior change to other CI jobs

## Test plan
- [ ] Merge and verify `Test Coverage` runs on `ci-runner` in the next CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)