### PR TITLE
feat(governance): wire BondIssuance proposal dispatch to real treasury mutation (Tranche 10)

### DIFF
--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -308,6 +308,26 @@ pub fn translate_payload_to_effects(
             Ok(effects)
         }
 
+        // Bond issuance: governance-approved capital raise via cooperative bond.
+        //
+        // The bond_id is derived from the issuer and decision receipt to ensure
+        // uniqueness across proposals. `maturity_date` encodes term duration as
+        // seconds (term_days × 86400) — deterministic given the payload, not wall-clock.
+        // `interest_rate_bps` and full `BondOffering` terms are preserved in the
+        // governance decision payload; only the financial effect is recorded in the ledger.
+        ProposalPayload::BondIssuance { bond_offering } => {
+            let bond_id = format!("bond-{}-{decision_receipt_id}", bond_offering.issuer_id);
+            Ok(vec![KernelEffect::Treasury(TreasuryEffect::IssueBond {
+                treasury_did: domain_id.to_string(),
+                bond_id,
+                principal: bond_offering.principal_requested,
+                interest_rate_bps: bond_offering.interest_rate_bps as u32,
+                maturity_date: bond_offering.term_days as u64 * 86400,
+                currency: bond_offering.currency.clone(),
+                decision_hash: decision_hash.to_string(),
+            })])
+        }
+
         // Fallback for unhandled types
         _ => Err(TranslationError::unsupported(
             "payload",
@@ -548,6 +568,57 @@ mod tests {
                 assert_eq!(*expected_nonce, 7);
             }
             other => panic!("expected treasury spend effect, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_translate_bond_issuance_produces_issue_bond_effect() {
+        let bond_offering = icn_ledger::BondOffering {
+            issuer_id: "test-coop".to_string(),
+            principal_requested: 500_000,
+            interest_rate_bps: 300,
+            term_days: 365,
+            purpose: "Equipment purchase".to_string(),
+            payment_schedule: icn_ledger::PaymentSchedule::InterestOnly { interval_days: 90 },
+            currency: "COOP".to_string(),
+            collateral: vec![],
+        };
+        let payload = icn_governance::ProposalPayload::BondIssuance { bond_offering };
+        let effects = translate_payload_to_effects(
+            &payload,
+            "receipt-bond-001",
+            "decision-hash-bond-001",
+            "did:icn:zTreasury",
+        )
+        .expect("BondIssuance must translate successfully");
+
+        assert_eq!(effects.len(), 1, "expected exactly one effect");
+        match &effects[0] {
+            KernelEffect::Treasury(TreasuryEffect::IssueBond {
+                treasury_did,
+                bond_id,
+                principal,
+                interest_rate_bps,
+                maturity_date,
+                currency,
+                decision_hash,
+            }) => {
+                assert_eq!(treasury_did, "did:icn:zTreasury");
+                assert!(
+                    bond_id.starts_with("bond-test-coop-"),
+                    "bond_id must include issuer: {bond_id}"
+                );
+                assert_eq!(*principal, 500_000);
+                assert_eq!(*interest_rate_bps, 300);
+                assert_eq!(
+                    *maturity_date,
+                    365 * 86400,
+                    "maturity encodes term_days as seconds"
+                );
+                assert_eq!(currency, "COOP");
+                assert_eq!(decision_hash, "decision-hash-bond-001");
+            }
+            other => panic!("expected IssueBond treasury effect, got {other:?}"),
         }
     }
 

--- a/icn/crates/icn-core/src/services/ledger_service.rs
+++ b/icn/crates/icn-core/src/services/ledger_service.rs
@@ -60,6 +60,24 @@ fn budget_liability_did(treasury_id: &str, budget_key: &str, currency: &str) -> 
     icn_identity::Did::from_public_key(&signing.verifying_key())
 }
 
+/// Derive a deterministic synthetic DID representing the bond-payable liability account.
+///
+/// When a cooperative issues a bond, the bond principal is received as capital
+/// and a corresponding liability is tracked under this synthetic DID.  The same
+/// inputs always produce the same DID so the account is stable across replays.
+fn bond_payable_did(treasury_id: &str, bond_id: &str, currency: &str) -> icn_identity::Did {
+    let mut hasher = Sha256::new();
+    hasher.update(b"icn:bond:payable:v1\0");
+    hasher.update(treasury_id.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(bond_id.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(currency.as_bytes());
+    let seed: [u8; 32] = hasher.finalize().into();
+    let signing = SigningKey::from_bytes(&seed);
+    icn_identity::Did::from_public_key(&signing.verifying_key())
+}
+
 /// Concrete implementation of `LedgerService` backed by the mutual credit ledger.
 ///
 /// This is the production adapter that translates kernel-safe treasury
@@ -260,6 +278,31 @@ impl LedgerServiceImpl {
                 }
                 Ok(deltas)
             }
+            TreasuryOperationType::IssueBond => {
+                // Bond issuance: cooperative receives principal (treasury incurs liability,
+                // bond-payable liability account is credited with the capital extended).
+                //
+                // In ICN mutual credit: credit(treasury) → treasury balance decreases
+                // (it is in debt to bond holders); debit(bond_payable) → liability account
+                // balance increases (it has distributed capital).
+                //
+                // The bond_payable DID is derived deterministically so the same bond always
+                // maps to the same synthetic liability account (idempotency-safe).
+                let bond_id = req
+                    .recipient
+                    .as_ref()
+                    .ok_or_else(|| "IssueBond requires bond_id in recipient field".to_string())?;
+                let bond_payable = bond_payable_did(&req.treasury_id, bond_id, &req.currency);
+                Ok(vec![
+                    AccountDelta::credit(
+                        self.treasury_did.clone(),
+                        req.currency.clone(),
+                        req.amount,
+                    ),
+                    AccountDelta::debit(bond_payable, req.currency.clone(), req.amount),
+                ])
+            }
+
             _ => {
                 // Other operation types can be added as needed
                 Err(format!(

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -328,10 +328,11 @@ impl KernelGovernanceExecutor {
                 ))
             }
 
-            // RedeemShares and IssueBond: not yet implemented in this executor.
+            // RedeemShares: not yet implemented in this executor (Tranche 11).
             // Return an honest non-deferred failure rather than falling through to
             // `treasury_effect_to_operation`'s `_ =>` placeholder which produces
             // zeroed-out operation data and a misleading "missing provenance" Deferred.
+            // IssueBond is wired (Tranche 10) and reaches Path 3 below.
             TreasuryEffect::RedeemShares { .. } => {
                 warn!("RedeemShares received: not yet implemented in the kernel treasury executor");
                 Ok(EffectResult {

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -344,19 +344,8 @@ impl KernelGovernanceExecutor {
                 })
             }
 
-            TreasuryEffect::IssueBond { .. } => {
-                warn!("IssueBond received: not yet implemented in the kernel treasury executor");
-                Ok(EffectResult {
-                    effect_id: decision_receipt_id.to_string(),
-                    success: false,
-                    message: "IssueBond: not yet implemented in the kernel treasury executor (no balances changed)".to_string(),
-                    state_change_hash: None,
-                    ledger_entry_id: None,
-                    not_executed: false,
-                })
-            }
-
             // Path 3: All other treasury effects → direct delegation
+            // Includes TreasuryEffect::IssueBond (wired in Tranche 10)
             _ => {
                 let operation = treasury_effect_to_operation(&treasury_effect);
                 let outcome = self
@@ -982,6 +971,7 @@ fn convert_operation_type(
         GovOp::Reserve => SvcOp::Allocate, // Map Reserve to Allocate
         GovOp::Release => SvcOp::Transfer, // Map Release to Transfer
         GovOp::DistributeSurplus => SvcOp::DistributeSurplus,
+        GovOp::IssueBond => SvcOp::IssueBond,
     }
 }
 

--- a/icn/crates/icn-core/tests/emitted_surface_contract.rs
+++ b/icn/crates/icn-core/tests/emitted_surface_contract.rs
@@ -36,6 +36,7 @@ fn approved_emitted_effects() -> BTreeSet<&'static str> {
         "Treasury::CreateBudget",
         "Treasury::Allocate",
         "Treasury::DistributeSurplus",
+        "Treasury::IssueBond",
         // Membership effects
         "Membership::AddMember",
         "Membership::RemoveMember",

--- a/icn/crates/icn-kernel-api/src/effects.rs
+++ b/icn/crates/icn-kernel-api/src/effects.rs
@@ -153,6 +153,8 @@ pub enum TreasuryEffect {
         interest_rate_bps: u32,
         maturity_date: u64,
         currency: String,
+        /// Governance decision hash for provenance tracking and idempotency.
+        decision_hash: String,
     },
     /// Release an escrow — governance decided, now move the money.
     ///
@@ -839,6 +841,7 @@ mod tests {
                 interest_rate_bps: 500,
                 maturity_date: 1750000000,
                 currency: "USD".into(),
+                decision_hash: "test-decision-hash".into(),
             },
             TreasuryEffect::ReleaseEscrow {
                 escrow_id: "esc-1".into(),

--- a/icn/crates/icn-kernel-api/src/governance.rs
+++ b/icn/crates/icn-kernel-api/src/governance.rs
@@ -76,6 +76,8 @@ pub enum TreasuryOperationType {
     /// Fan-out surplus settlement: N debits from treasury, N credits to member DIDs.
     /// The `distributions` field on `TreasuryOperation` carries the per-recipient amounts.
     DistributeSurplus,
+    /// Bond issuance: cooperative receives principal, incurs bond liability.
+    IssueBond,
 }
 
 /// Protocol parameter change request
@@ -455,6 +457,26 @@ pub fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperatio
                 .map(|(did, amt)| (did.clone(), *amt))
                 .collect(),
         },
+        TreasuryEffect::IssueBond {
+            treasury_did,
+            bond_id,
+            principal,
+            currency,
+            decision_hash,
+            ..
+        } => TreasuryOperation {
+            treasury_id: treasury_did.clone(),
+            operation_type: TreasuryOperationType::IssueBond,
+            amount: *principal,
+            currency: currency.clone(),
+            // bond_id carried in recipient field for bond-payable DID derivation in ledger_service
+            recipient: Some(bond_id.clone()),
+            memo: format!("Bond issuance: {bond_id}"),
+            expected_nonce: None,
+            decision_hash: Some(decision_hash.clone()),
+            distributions: Vec::new(),
+        },
+
         // Other treasury effects mapped to basic operations
         _ => TreasuryOperation {
             treasury_id: String::new(),


### PR DESCRIPTION
## Summary

- `ProposalPayload::BondIssuance` previously fell through to `_ => Err(unsupported)` in `translate_payload_to_effects`, producing `KernelEffect::NoOp` on proposal acceptance
- `TreasuryEffect::IssueBond` had an explicit warn stub in `governance_executor.rs` that returned `success:false` with no state change
- This PR closes the complete chain — translation → effect → executor → ledger double-entry mutation

## What Changed

**Translation** (`apps/governance/src/handlers/execution.rs`):
- Add `ProposalPayload::BondIssuance` arm → `KernelEffect::Treasury(TreasuryEffect::IssueBond)`
- `bond_id` derived from `issuer_id + decision_receipt_id` (unique per proposal)
- `maturity_date` encoded as `term_days × 86400` (deterministic, no wall-clock dependency)

**Kernel effect** (`icn-kernel-api/src/effects.rs`):
- Add `decision_hash: String` to `TreasuryEffect::IssueBond` (provenance field required by `execute_treasury_operation`; all other wired variants already carry it)

**Operation mapping** (`icn-kernel-api/src/governance.rs`):
- Add `IssueBond` variant to `governance::TreasuryOperationType`
- Add `TreasuryEffect::IssueBond` arm in `treasury_effect_to_operation`: maps `principal → amount`, `bond_id → recipient` (used for synthetic liability DID derivation in ledger service)

**Executor** (`icn-core/src/supervisor/governance_executor.rs`):
- Remove `TreasuryEffect::IssueBond` warn stub; effect now falls to Path 3 (`treasury_effect_to_operation → execute_treasury_operation`)
- Add `GovOp::IssueBond => SvcOp::IssueBond` to `convert_operation_type`

**Ledger service** (`icn-core/src/services/ledger_service.rs`):
- Add `bond_payable_did()` helper: deterministic synthetic DID for bond-payable liability account (same SHA256-from-seed pattern as `budget_liability_did`)
- Add `TreasuryOperationType::IssueBond` arm in `build_account_deltas`: `credit(treasury) + debit(bond_payable)` — in ICN mutual credit convention, treasury incurs liability (balance decreases), bond_payable account records capital extended (balance increases)

## Proof

- `test_translate_bond_issuance_produces_issue_bond_effect`: asserts `BondIssuance` payload produces `IssueBond` effect with correct field values (treasury_did, bond_id prefix, principal, interest_rate_bps, maturity_date encoding, currency, decision_hash)
- Existing regression guards (`ShareRedemption` still unsupported via `test_translate_unhandled_payload_returns_explicit_error`, `test_unsupported_accepted_payload_emits_classified_noop`) unchanged

## What This Does NOT Close

- `ProposalPayload::ShareRedemption` — needs `currency: String` added to payload schema first (Tranche 11)
- Bond payment/interest servicing lifecycle
- Bond registry or secondary market

## Test Plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p icn-kernel-api -p icn-core -p icn-governance-actor --all-targets -- -D warnings` clean
- [x] `cargo test -p icn-governance-actor --lib` — 49 passed
- [x] `cargo test -p icn-kernel-api --lib` — 303 passed
- [x] `cargo test -p icn-core --lib` — 363 passed
- [x] Meaning firewall ratchets (`strict_governance_import_violations`, `strict_gateway_governance_total_refs`) both pass — no gateway scope change

🤖 Generated with [Claude Code](https://claude.com/claude-code)