### PR TITLE
feat(governance): wire ShareRedemption proposal dispatch to real treasury mutation (Tranche 11)

### DIFF
--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -328,6 +328,29 @@ pub fn translate_payload_to_effects(
             })])
         }
 
+        // Share redemption: member exchanges shares for payout from treasury.
+        //
+        // `payout_amount` is the sum of all approved installments. The payout
+        // schedule is governance-approved; only the financial effect lands in
+        // the ledger here. Installment tracking is out of scope for this tranche.
+        ProposalPayload::ShareRedemption {
+            member,
+            share_ids,
+            payout_schedule,
+            currency,
+            ..
+        } => {
+            let payout_amount: i64 = payout_schedule.iter().map(|s| s.amount).sum();
+            Ok(vec![KernelEffect::Treasury(TreasuryEffect::RedeemShares {
+                treasury_did: domain_id.to_string(),
+                member_did: member.to_string(),
+                share_count: share_ids.len() as u64,
+                payout_amount,
+                currency: currency.clone(),
+                decision_hash: decision_hash.to_string(),
+            })])
+        }
+
         // Fallback for unhandled types
         _ => Err(TranslationError::unsupported(
             "payload",
@@ -624,13 +647,11 @@ mod tests {
 
     #[test]
     fn test_translate_unhandled_payload_returns_explicit_error() {
-        let payload = icn_governance::ProposalPayload::ShareRedemption {
-            member: "did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9"
-                .parse()
-                .expect("valid did"),
-            share_ids: vec![],
-            payout_schedule: vec![],
-            reason: "voluntary departure".to_string(),
+        // Charter is an example of a still-unsupported payload (falls to `_ => Err(...)`).
+        // ShareRedemption was previously used here but is now wired (Tranche 11).
+        let payload = icn_governance::ProposalPayload::Charter {
+            charter_id: "test-coop-charter".to_string(),
+            charter_yaml: "schema_version: v0\nentity: coop\n".to_string(),
         };
         let effects = translate_payload_to_effects(
             &payload,
@@ -640,6 +661,57 @@ mod tests {
         );
         let err = effects.expect_err("unsupported payload must be explicit");
         assert_eq!(err.kind, "payload");
+    }
+
+    #[test]
+    fn test_translate_share_redemption_produces_redeem_shares_effect() {
+        let member_did = "did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9";
+        let payout_schedule = vec![
+            icn_ledger::ScheduledPayout::new(30 * 86400, 5_000),
+            icn_ledger::ScheduledPayout::new(60 * 86400, 5_000),
+        ];
+        let payload = icn_governance::ProposalPayload::ShareRedemption {
+            member: member_did.parse().expect("valid did"),
+            share_ids: vec![
+                icn_ledger::ShareId::new("share-001"),
+                icn_ledger::ShareId::new("share-002"),
+                icn_ledger::ShareId::new("share-003"),
+            ],
+            payout_schedule,
+            reason: "Voluntary departure".to_string(),
+            currency: "COOP".to_string(),
+        };
+
+        let effects = translate_payload_to_effects(
+            &payload,
+            "receipt-redeem-001",
+            "decision-hash-redeem-001",
+            "did:icn:zTreasury",
+        )
+        .expect("ShareRedemption must translate successfully");
+
+        assert_eq!(effects.len(), 1, "expected exactly one effect");
+        match &effects[0] {
+            KernelEffect::Treasury(TreasuryEffect::RedeemShares {
+                treasury_did,
+                member_did: effect_member_did,
+                share_count,
+                payout_amount,
+                currency,
+                decision_hash,
+            }) => {
+                assert_eq!(treasury_did, "did:icn:zTreasury");
+                assert_eq!(effect_member_did, member_did);
+                assert_eq!(*share_count, 3, "share_count from share_ids.len()");
+                assert_eq!(
+                    *payout_amount, 10_000,
+                    "payout_amount is sum of schedule: 5000+5000"
+                );
+                assert_eq!(currency, "COOP");
+                assert_eq!(decision_hash, "decision-hash-redeem-001");
+            }
+            other => panic!("expected RedeemShares treasury effect, got {other:?}"),
+        }
     }
 
     #[test]

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -277,13 +277,10 @@ mod tests {
                 .push((effects, decision_receipt_id));
         });
 
-        let payload = ProposalPayload::ShareRedemption {
-            member: "did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9"
-                .parse()
-                .expect("valid did"),
-            share_ids: vec![],
-            payout_schedule: vec![],
-            reason: "unsupported in pilot path".to_string(),
+        // Charter is a still-unsupported payload; ShareRedemption is wired as of Tranche 11.
+        let payload = ProposalPayload::Charter {
+            charter_id: "test-coop-charter".to_string(),
+            charter_yaml: "schema_version: v0\nentity: coop\n".to_string(),
         };
 
         let event = SystemEvent::ProposalAccepted {

--- a/icn/crates/icn-core/src/services/ledger_service.rs
+++ b/icn/crates/icn-core/src/services/ledger_service.rs
@@ -303,6 +303,30 @@ impl LedgerServiceImpl {
                 ])
             }
 
+            TreasuryOperationType::RedeemShares => {
+                // Share redemption: treasury pays out to departing member.
+                //
+                // In ICN mutual credit: debit(treasury) → treasury balance increases
+                // (same direction as Spend — treasury is the sending side);
+                // credit(member) → member receives payout (balance changes reflect settlement).
+                //
+                // `recipient` carries the member DID passed through from the governance effect.
+                let member = req.recipient.as_ref().ok_or_else(|| {
+                    "RedeemShares requires member DID in recipient field".to_string()
+                })?;
+                let member_did: icn_identity::Did = member
+                    .parse()
+                    .map_err(|e| format!("Invalid member DID in RedeemShares: {e}"))?;
+                Ok(vec![
+                    AccountDelta::debit(
+                        self.treasury_did.clone(),
+                        req.currency.clone(),
+                        req.amount,
+                    ),
+                    AccountDelta::credit(member_did, req.currency.clone(), req.amount),
+                ])
+            }
+
             _ => {
                 // Other operation types can be added as needed
                 Err(format!(

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -328,25 +328,8 @@ impl KernelGovernanceExecutor {
                 ))
             }
 
-            // RedeemShares: not yet implemented in this executor (Tranche 11).
-            // Return an honest non-deferred failure rather than falling through to
-            // `treasury_effect_to_operation`'s `_ =>` placeholder which produces
-            // zeroed-out operation data and a misleading "missing provenance" Deferred.
-            // IssueBond is wired (Tranche 10) and reaches Path 3 below.
-            TreasuryEffect::RedeemShares { .. } => {
-                warn!("RedeemShares received: not yet implemented in the kernel treasury executor");
-                Ok(EffectResult {
-                    effect_id: decision_receipt_id.to_string(),
-                    success: false,
-                    message: "RedeemShares: not yet implemented in the kernel treasury executor (no balances changed)".to_string(),
-                    state_change_hash: None,
-                    ledger_entry_id: None,
-                    not_executed: false,
-                })
-            }
-
             // Path 3: All other treasury effects → direct delegation
-            // Includes TreasuryEffect::IssueBond (wired in Tranche 10)
+            // Includes TreasuryEffect::IssueBond (Tranche 10) and TreasuryEffect::RedeemShares (Tranche 11)
             _ => {
                 let operation = treasury_effect_to_operation(&treasury_effect);
                 let outcome = self
@@ -973,6 +956,7 @@ fn convert_operation_type(
         GovOp::Release => SvcOp::Transfer, // Map Release to Transfer
         GovOp::DistributeSurplus => SvcOp::DistributeSurplus,
         GovOp::IssueBond => SvcOp::IssueBond,
+        GovOp::RedeemShares => SvcOp::RedeemShares,
     }
 }
 

--- a/icn/crates/icn-core/tests/emitted_surface_contract.rs
+++ b/icn/crates/icn-core/tests/emitted_surface_contract.rs
@@ -37,6 +37,7 @@ fn approved_emitted_effects() -> BTreeSet<&'static str> {
         "Treasury::Allocate",
         "Treasury::DistributeSurplus",
         "Treasury::IssueBond",
+        "Treasury::RedeemShares",
         // Membership effects
         "Membership::AddMember",
         "Membership::RemoveMember",

--- a/icn/crates/icn-governance/src/proposal.rs
+++ b/icn/crates/icn-governance/src/proposal.rs
@@ -643,6 +643,8 @@ pub enum ProposalPayload {
         payout_schedule: Vec<icn_ledger::ScheduledPayout>,
         /// Reason for redemption (voluntary departure, retirement, etc.)
         reason: String,
+        /// Currency for the payout (e.g., "COOP", "hours")
+        currency: String,
     },
 
     /// Approve bond issuance for cooperative financing
@@ -1807,6 +1809,7 @@ mod tests {
                 ],
                 payout_schedule,
                 reason: "Voluntary departure".to_string(),
+                currency: "COOP".to_string(),
             },
         );
 

--- a/icn/crates/icn-kernel-api/src/effects.rs
+++ b/icn/crates/icn-kernel-api/src/effects.rs
@@ -144,6 +144,8 @@ pub enum TreasuryEffect {
         share_count: u64,
         payout_amount: i64,
         currency: String,
+        /// Governance decision hash for provenance tracking and idempotency.
+        decision_hash: String,
     },
     /// Bond issuance
     IssueBond {
@@ -833,6 +835,7 @@ mod tests {
                 share_count: 10,
                 payout_amount: 1000,
                 currency: "USD".into(),
+                decision_hash: "test-decision-hash".into(),
             },
             TreasuryEffect::IssueBond {
                 treasury_did: "did:icn:t1".into(),

--- a/icn/crates/icn-kernel-api/src/governance.rs
+++ b/icn/crates/icn-kernel-api/src/governance.rs
@@ -78,6 +78,8 @@ pub enum TreasuryOperationType {
     DistributeSurplus,
     /// Bond issuance: cooperative receives principal, incurs bond liability.
     IssueBond,
+    /// Share redemption: member exchanges shares for payout from treasury.
+    RedeemShares,
 }
 
 /// Protocol parameter change request
@@ -477,16 +479,23 @@ pub fn treasury_effect_to_operation(effect: &TreasuryEffect) -> TreasuryOperatio
             distributions: Vec::new(),
         },
 
-        // Other treasury effects mapped to basic operations
-        _ => TreasuryOperation {
-            treasury_id: String::new(),
-            operation_type: TreasuryOperationType::Reserve,
-            amount: 0,
-            currency: "UNKNOWN".to_string(),
-            recipient: None,
-            memo: "Unmapped treasury effect".to_string(),
+        TreasuryEffect::RedeemShares {
+            treasury_did,
+            member_did,
+            payout_amount,
+            currency,
+            decision_hash,
+            share_count,
+        } => TreasuryOperation {
+            treasury_id: treasury_did.clone(),
+            operation_type: TreasuryOperationType::RedeemShares,
+            amount: *payout_amount,
+            currency: currency.clone(),
+            // member_did carried in recipient for ledger credit entry
+            recipient: Some(member_did.clone()),
+            memo: format!("Share redemption: {share_count} shares"),
             expected_nonce: None,
-            decision_hash: None,
+            decision_hash: Some(decision_hash.clone()),
             distributions: Vec::new(),
         },
     }


### PR DESCRIPTION
## Summary

- `ProposalPayload::ShareRedemption` was missing `currency: String` — the first broken point in the chain, blocking all downstream translation
- `TreasuryEffect::RedeemShares` was missing `decision_hash: String` — required by `execute_treasury_operation` to avoid `Deferred` outcome
- This PR closes the complete chain: schema fix → translation → effect → executor → ledger double-entry mutation

## What Changed

**Schema** (`crates/icn-governance/src/proposal.rs`):
- Add `currency: String` to `ProposalPayload::ShareRedemption`

**Kernel effect** (`crates/icn-kernel-api/src/effects.rs`):
- Add `decision_hash: String` to `TreasuryEffect::RedeemShares`

**Operation mapping** (`crates/icn-kernel-api/src/governance.rs`):
- Add `RedeemShares` variant to `governance::TreasuryOperationType`
- Add `TreasuryEffect::RedeemShares` arm in `treasury_effect_to_operation`
- Remove now-exhausted `_ =>` fallthrough (all 8 TreasuryEffect variants now have explicit arms)

**Executor** (`crates/icn-core/src/supervisor/governance_executor.rs`):
- Remove `TreasuryEffect::RedeemShares` warn stub; effect falls to Path 3
- Add `GovOp::RedeemShares => SvcOp::RedeemShares` to `convert_operation_type`

**Ledger service** (`crates/icn-core/src/services/ledger_service.rs`):
- Add `TreasuryOperationType::RedeemShares` arm in `build_account_deltas`:
  `debit(treasury) + credit(member_did)` — same direction as Spend

**Translation** (`apps/governance/src/handlers/execution.rs`):
- Add `ProposalPayload::ShareRedemption` translation arm: sums `payout_schedule` amounts into `payout_amount`
- Switch regression tests from ShareRedemption (now supported) to Charter (still unsupported)

**Surface contract** (`crates/icn-core/tests/emitted_surface_contract.rs`):
- Register `Treasury::RedeemShares` in approved emitted effects

## Proof

- `test_translate_share_redemption_produces_redeem_shares_effect`: asserts `ShareRedemption` payload produces `RedeemShares` effect with correct `member_did`, `share_count = 3`, `payout_amount = 10_000` (sum of two 5000 installments), `currency = "COOP"`, `decision_hash`
- `test_translate_unhandled_payload_returns_explicit_error` and `test_unsupported_accepted_payload_emits_classified_noop` both now use `Charter` as the still-unsupported payload regression guard

## What This Does NOT Close

- Payout installment scheduling / lifecycle tracking
- Share registry or secondary market
- Bond payment / interest servicing lifecycle

## Test Plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p icn-kernel-api -p icn-core -p icn-governance-actor -p icn-governance --all-targets -- -D warnings` clean
- [x] `cargo test -p icn-governance-actor --lib` — 50 passed
- [x] `cargo test -p icn-kernel-api --lib` — 303 passed
- [x] `cargo test -p icn-core --lib` — 363 passed
- [x] `cargo test -p icn-core --test emitted_surface_contract` — 5 passed
- [x] Meaning firewall ratchets (`strict_governance_import_violations`, `strict_gateway_governance_total_refs`) both pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)