### PR TITLE
fix(ci): move Test Coverage off homelab runner to ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,20 +424,40 @@ jobs:
     name: Test Coverage
     needs: [changes]
     if: needs.changes.outputs.docs_only != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-    timeout-minutes: 30
-    runs-on: [self-hosted, linux, x64, homelab]
+    # Gate is observational — job failure must never block CI or merges.
+    # Previously ran on [self-hosted, linux, x64, homelab] (ci-runner, 6GB RAM),
+    # which OOMed on instrumented workspace compilation. Moved to ubuntu-latest
+    # with rust-cache to remove homelab runner dependency for coverage entirely.
+    continue-on-error: true
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
+        with:
+          verbose: 'false'
+          aggressive: 'true'
+
+      - name: Install build tools
+        uses: ./.github/actions/install-build-tools
+
+      - uses: dtolnay/rust-toolchain@1.88.0
+        with:
+          components: llvm-tools-preview
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "icn -> target"
+          cache-on-failure: true
+          prefix-key: "v0-rust-coverage"
+
       - name: Install cargo-llvm-cov
-        run: |
-          source $HOME/.cargo/env
-          cargo install cargo-llvm-cov --locked
+        run: cargo install cargo-llvm-cov --locked
 
       - name: Generate coverage
-        run: |
-          source $HOME/.cargo/env
-          cargo llvm-cov --workspace --lcov --output-path ./lcov.info
+        run: cargo llvm-cov --workspace --lcov --output-path ./lcov.info
         working-directory: ./icn
         continue-on-error: ${{ env.GATE_RATCHET_PHASE_COVERAGE != 'blocking' }}
 


### PR DESCRIPTION
## Problem

The `coverage` job in `ci.yml` was targeting `[self-hosted, linux, x64, homelab]` — matched by `ci-runner` (VM 446, 8 vCPU, **6GB RAM**).

`cargo llvm-cov --workspace` on a 414K-LOC workspace with LLVM instrumentation requires substantially more than 6GB RAM. The runner OOMs mid-execution, which:
- Kills the runner process (not a normal step exit)
- Sets `Generate coverage` step conclusion to `null` (not `failure`)
- Marks the job `failed` regardless of step-level `continue-on-error`

The step-level `continue-on-error: ${{ env.GATE_RATCHET_PHASE_COVERAGE != 'blocking' }}` (which evaluates to `true`) does **not** protect against runner death — only process-level failures. The job-level `continue-on-error` was missing entirely.

## What Changed

- `runs-on`: `[self-hosted, linux, x64, homelab]` → `ubuntu-latest`  
  Removes homelab runner dependency for coverage entirely.
- `continue-on-error: true` at the **job** level (observational gate)  
  Runner death, OOM, or timeout can no longer mark CI red.
- Added proper Rust toolchain setup: `dtolnay/rust-toolchain@1.88.0` + `llvm-tools-preview` component (required by cargo-llvm-cov, was pre-installed on ci-runner)
- Added `Swatinem/rust-cache@v2` with `v0-rust-coverage` prefix (separate from test cache)
- Added `free-disk-space` + `install-build-tools` steps (matching test/clippy pattern)
- Timeout: 30min → 60min (instrumented compilation is slower; ubuntu-latest has more RAM)
- Removed `source $HOME/.cargo/env` (ci-runner-specific, not needed on ubuntu-latest)

## What Did NOT Change

- `GATE_RATCHET_PHASE_COVERAGE: observational` — unchanged in env block
- Coverage scope: still `--workspace` (same as before)
- Codecov upload logic: unchanged
- All other jobs: unchanged

## Note on Zentith

The MEMORY / handoff docs described a `zentith-coverage` runner (WSL2 nohup process, labels `self-hosted,linux,x64,coverage,zentith`). That runner is **not registered** in the repo runner list — only `ci-runner` is. The `zentith` label was never referenced in any workflow file. The coverage job was already migrated to `homelab`/ci-runner at some earlier point; this PR completes the migration to fully managed infrastructure.