### PR TITLE
docs(roadmap): truth-up sprint tracking to post-Sprint-28 Governance Dispatch Tranches

### DIFF
--- a/docs/strategy/ICN-Roadmap-Live.md
+++ b/docs/strategy/ICN-Roadmap-Live.md
@@ -1,9 +1,44 @@
 # ICN Roadmap — Live
 
-*Last updated: 2026-03-22 (Sprint 23 — Baseline Lock + Narrative Surface)*
+*Last updated: 2026-04-08 (Post-Sprint 28 — Governance Dispatch Tranches)*
 
 > This document tracks sprint-level progress against the ICN development roadmap.
 > For architecture and phase history, see `docs/ARCHITECTURE.md` and `docs/PHASE_HISTORY.md`.
+
+---
+
+## Current state (2026-04-08)
+
+**Active workstream:** Post-Sprint-28 governance dispatch tranches. The sprint-numbered planning cadence ended with Sprint 28; active work is now organized as sequential "Tranches" against the executor-wiring and ADR-0016 closure epics.
+
+**What landed between Sprint 23 and the current work (summarized; see git log for detail):**
+
+- **Sprint 24** — Commons-compute spine. Two-tier trust threshold for pool admission, stale participant expiry, V1 scheduling-time credit enforcement floor. Closed 2026-03-23. See `docs/strategy/sprint-24-close.md`.
+- **Sprint 25** — ADR-0016 Phase 2 work. Closed via `chore(ops): close sprint 25, open sprint 26` (commit `92de849e`).
+- **Sprint 26** — Interim tranche; see commits between `92de849e` and Sprint 27 opening.
+- **Sprint 27** — Demo-Ready + Compute Story. Flow 5 commons compute trust-gated admission, demo polish, website five-flow update, summit proposal. Key commits: `1600a1fb`, `b1ba40c7`, `cb22e1e5`, `8ab59cff`.
+- **Sprint 28** — Gossip fan-out fix (compute task delivery restored). Commit `4ae8401f` (PR #1419).
+
+**Governance Dispatch Tranches (post-Sprint 28, active):**
+
+The canonical source of truth for tranche status is `docs/architecture/agent-handoff-current.md` and git commit messages tagged `Tranche N`. At time of writing:
+
+| Tranche | Scope | Status |
+|---|---|---|
+| 9 | TrustThreshold suspension enforcement | ✅ Merged |
+| 10 | BondIssuance treasury mutation | ✅ Merged |
+| 11 | ShareRedemption treasury mutation | ✅ Merged |
+| 12 | LeaveFederation dispatch | ✅ Merged (#1506) |
+| 13 | Real `SdisService` executor, dual-path closure | ✅ Merged |
+| 14 | ReconfirmSteward + firewall fixes | ✅ Merged |
+| 15 | ReinstateSteward governance dispatch | ✅ Merged (#1509) |
+| 16 | SuspendSteward governance dispatch | ✅ Merged (#1510) |
+| 17 | UpdateJurisdictionTier executor | 🚧 Local on `fix/steward-bond-semantics` (icn-dev) |
+| 18 | TerminateClearing + RevokeVouch executors | ⏳ Next |
+
+An overlaid "Agent Handoff Tranche" track (`I`, `II`, `III`, ...) in `docs/architecture/agent-handoff-current.md` covers ADR-0016 closures (surplus reserves consumption, charter view persistence, etc.) and advances on its own cadence. Tranches I, II, and III all closed 2026-04-08.
+
+> **Rule:** Do not treat the per-sprint sections below as current status. They are historical only. For current state, read this block, git log, and `docs/architecture/agent-handoff-current.md`.
 
 ---
 

--- a/website/src/data/roadmap.json
+++ b/website/src/data/roadmap.json
@@ -1,8 +1,9 @@
 {
   "currentSprint": {
-    "number": 23,
-    "name": "Baseline Lock + Narrative Surface",
-    "status": "active"
+    "number": 28,
+    "name": "Governance Dispatch Tranches",
+    "status": "active",
+    "detail": "Sprints 24–28 shipped (commons-compute spine, Flow 5 demo, gossip fan-out fix). Current workstream: post-Sprint-28 governance dispatch tranches wiring real executors for every accepted proposal payload. Tranches 9–16 merged (TrustThreshold, BondIssuance, ShareRedemption, LeaveFederation, SdisService executor, ReconfirmSteward, ReinstateSteward, SuspendSteward). Tranche 17 (UpdateJurisdictionTier) complete locally, pending push. Tranche 18 (TerminateClearing + RevokeVouch) up next."
   },
   "stages": [
     {


### PR DESCRIPTION
## Summary

`ICN-Roadmap-Live.md` was frozen at Sprint 23 (2026-03-22). Actual repo state has since shipped Sprints 24, 25, 26, 27, 28 plus post-Sprint-28 Governance Dispatch Tranches 9-16 (merged) with T17 in flight on icn-dev. My own previous PR (#1512) set the website's sprint to 23, which was my best guess from the stale doc. This PR corrects both.

## Changes

**`website/src/data/roadmap.json`**
- `currentSprint.number`: 23 → **28**
- `currentSprint.name`: "Baseline Lock + Narrative Surface" → **"Governance Dispatch Tranches"**
- Added `currentSprint.detail` with the full tranche status summary

**`docs/strategy/ICN-Roadmap-Live.md`**
- Prepended a **"Current state (2026-04-08)"** block that:
  - Summarises Sprints 24-28 from git log (not reinventing detail)
  - Shows the real tranche status table (9-16 merged, 17 in flight, 18 next)
  - Flags that per-sprint sections below are historical, not current
  - Points readers to git log and `docs/architecture/agent-handoff-current.md` as canonical

## What this does NOT do

- Does **not** rewrite Sprint 24-27 history into this file (I wasn't present for that work; source of truth is git)
- Does **not** touch `icn-ops/state/sprint/current.json` on icn-dev (separate repo, separate owner)
- Does **not** add or remove sprint sections — keeps the "Completed Sprints" listing as-is for historical reference

## Test plan

- [x] `npm run build` clean (662 pages, 0 errors)
- [x] Rendered HTML verified to contain "Sprint 28" and "Governance Dispatch"
- [x] `cargo fmt --all -- --check` clean (no Rust touched, verified anyway)
- [x] Drift check PASS (previous session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)