### PR TITLE
ci(website): auto-deploy to gh-pages on main push touching website/ or docs/

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -1,0 +1,55 @@
+name: Deploy Website
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - 'docs/**'
+      - '.github/workflows/website-deploy.yml'
+  workflow_dispatch:
+
+# gh-pages deploys are force-pushes to a single branch; allow one at a time.
+concurrency:
+  group: website-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install dependencies
+        working-directory: website
+        run: npm ci
+
+      - name: Build site
+        working-directory: website
+        # prebuild script (gen-stats.mjs) runs automatically as part of `npm run build`.
+        # The build reads docs directly from repo-root /docs/ via import.meta.url-relative
+        # paths, which works because the runner checks out the full repo (not just website/).
+        run: npm run build
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: website/dist
+          publish_branch: gh-pages
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'deploy: ${{ github.event.head_commit.message }}'
+          force_orphan: false

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -57,5 +57,8 @@ Fonts: Inter (body), Outfit (headings), JetBrains Mono (code).
 
 ## Deployment
 
-For manual deploy: `npm run deploy` (builds and pushes to `gh-pages` branch).
-CI deployment workflow will be unified with monorepo CI in a future phase.
+**Automatic.** `.github/workflows/website-deploy.yml` builds and publishes to the `gh-pages` branch on every push to `main` that touches `website/**`, `docs/**`, or the workflow itself. Uses `peaceiris/actions-gh-pages@v4` to force-push the `website/dist/` build output to `gh-pages`. Site is served at `https://intercooperative.network` by GitHub Pages.
+
+**Manual fallback:** `npm run deploy` from `website/` still works (builds and pushes via the `gh-pages` npm package). Use this only when the workflow is broken or you need to push a one-off deploy without a main commit.
+
+**Triggering without content changes:** `gh workflow run website-deploy.yml` — useful for re-deploying after a docs/stats change that didn't modify `website/`.


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that auto-deploys the website on every push to \`main\` that touches \`website/\`, \`docs/\`, or the workflow itself. Ends a 21-day drift between main and the live site.

## Context

Today's session shipped 3 PRs to main with meaningful website changes:

- #1512: OVERVIEW manual + docs explorer title fix + roadmap refresh (+344 lines)
- #1513: sprint tracking truth-up to Sprint 28 (+40 lines)
- #1514: orphan worktree removal (-933K stale lines)

None of them were live until I just manually ran \`npm run deploy\` 5 minutes ago, which pushed \`d10100ec\` (2026-03-18) → \`96f06583\` (2026-04-08). 21 days of stale deploys.

The \`website/CLAUDE.md\` explicitly said "CI deployment workflow will be unified with monorepo CI in a future phase." This PR is that phase.

## Changes

**\`.github/workflows/website-deploy.yml\`** (new):
- Triggers: push to \`main\` with paths \`website/**\`, \`docs/**\`, or the workflow file; plus manual \`workflow_dispatch\`
- Steps: checkout → setup-node@v4 (Node 20 + npm cache) → \`npm ci\` → \`npm run build\` → \`peaceiris/actions-gh-pages@v4\`
- Concurrency group \`website-deploy\` with \`cancel-in-progress: false\` so overlapping deploys don't race the force-push
- \`docs/**\` is in the path filter because the website reads docs at build time via \`import.meta.url\`-relative paths (see \`website/CLAUDE.md\`)

**\`website/CLAUDE.md\`** (updated):
- Replaces the stale "future phase" note with current automated-deploy documentation
- Documents the manual \`npm run deploy\` fallback path for out-of-band deploys
- Adds \`gh workflow run website-deploy.yml\` as the trigger-without-content-change escape hatch

## Why \`peaceiris/actions-gh-pages\` vs \`actions/deploy-pages\`

The manual deploy uses the \`gh-pages\` npm package which force-pushes \`dist/\` to the \`gh-pages\` branch. GitHub Pages is already configured to serve from that branch. \`peaceiris/actions-gh-pages\` preserves that exact mechanism — same branch, same force-push semantics — so GitHub Pages serving continues unchanged. Switching to \`actions/deploy-pages\` would require migrating the Pages configuration to the "Deploy from Actions" mode, which is a separate change with its own risks. Additive, not a replacement.

## Test plan

- [x] \`cargo fmt --all -- --check\` clean (no Rust touched, verified anyway)
- [x] Workflow YAML syntax validated by passing through the editor
- [x] Manual deploy worked immediately before this PR (baseline proof the build + push path is healthy)
- [ ] CI will run the standard required checks on this PR
- [ ] First auto-deploy will fire when this PR merges (because it touches \`.github/workflows/website-deploy.yml\` which is in the new path filter)

## Out of scope

- Migrating to \`actions/deploy-pages\` / Pages "Deploy from Actions" mode
- Adding a staging environment or preview deploys for PR branches
- Parallelising docs generation (not currently a bottleneck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)