### PR TITLE
feat(website): design-language tranche — new pages, components, and civic design system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,9 @@ icn-wt/
 # Claude Code agent worktrees (per-session, never tracked — commit dcc7baeb
 # accidentally added 2192 files / 934K insertions from an orphan worktree)
 .claude/worktrees/
+
+# Local Preview MCP launch config — per-developer, not project state
+.claude/launch.json
+
+# Playwright MCP debug artifacts (screenshots, console logs, snapshots)
+.playwright-mcp/

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -36,10 +36,19 @@ Welcome to the ICN (Intercooperative Network) documentation! This index provides
 
 - **New to ICN?** → Start with [Getting Started Guide](GETTING_STARTED.md)
 - **Understanding the system?** → Read [Architecture Overview](ARCHITECTURE.md)
+- **Building the public site?** → Start with [Design Language Brief v0](design-language/brief-v0.md)
 - **Building features?** → Check [Developer Guides](#developer-guides)
 - **Deploying ICN?** → See [Operations Guides](#operations-guides)
 - **Looking for APIs?** → Browse [API Reference](#api-reference)
 - **Historical context?** → Explore [Archives](#archives)
+
+### Design language (canonical)
+
+The ICN public website is the first implementation surface of the universal civic design language. These docs are the source of truth for every public-facing design decision:
+
+- **[design-language/brief-v0.md](design-language/brief-v0.md)** — the canonical design language brief (principles, semantic layers, visual primitives, anti-patterns)
+- **[design-language/concept-map.md](design-language/concept-map.md)** — canonical → public plain-language label → localization notes for every ICN concept
+- **[design-language/accessibility.md](design-language/accessibility.md)** — WCAG rules, contrast requirements, the review checklist every PR must pass
 
 ---
 

--- a/docs/design-language/accessibility.md
+++ b/docs/design-language/accessibility.md
@@ -1,0 +1,279 @@
+# ICN Accessibility Rules
+
+**Status:** v0 — canonical accessibility requirements for the ICN design language.
+**Parent doc:** [brief-v0.md](./brief-v0.md)
+**WCAG target:** WCAG 2.2 Level AA minimum, AAA where practical.
+
+---
+
+## 1. Why this matters
+
+ICN is institutional infrastructure for collective self-rule. Accessibility is not polish. It is part of institutional legitimacy.
+
+If the system is only legible to people with good eyesight, fast bandwidth, native English, high literacy, big screens, and insider vocabulary, then it is not infrastructure for collective self-rule. It is infrastructure for a class of insiders.
+
+This document defines the rules every public surface must meet.
+
+---
+
+## 2. Five layers of accessibility
+
+### 2.1 Sensory
+
+- Strong contrast
+- Scalable typography
+- Touch-friendly controls
+- Reduced motion where possible
+- Non-color-only meaning
+- Readable diagrams
+- Adequate spacing
+- Screen-reader-compatible semantics
+
+### 2.2 Cognitive
+
+- Plain language first
+- Stable layout patterns
+- Chunked information
+- Limited jargon in public-facing contexts
+- Consistent labels
+- Visible next steps
+- Predictable status indicators
+
+### 2.3 Linguistic
+
+- Avoid idioms
+- Avoid unexplained abstractions
+- Use short labels
+- Use helper text
+- Support translation and local overrides cleanly
+- Assume the reader's first language may not be English
+
+### 2.4 Institutional
+
+- Users should not need preexisting expertise in law, cooperative governance, cryptography, or systems theory to orient themselves.
+- Formal terms are allowed but must be paired with plain-language explanations on first use.
+
+### 2.5 Social
+
+- The system should feel learnable without insider status.
+- No implied hierarchy of technical sophistication between users.
+
+---
+
+## 3. Core rules (WCAG-grounded)
+
+### 3.1 Color is never the only cue
+
+**Rule:** Meaning must never depend on color alone. Every color-coded meaning must also be conveyed by text, icon, pattern, position, or structure.
+
+**WCAG:** 1.4.1 Use of Color (Level A)
+
+**Examples:**
+- ✅ Maturity bands: the band carries a text label ("Strong today", "Advancing now") *and* a color. A colorblind reader loses the color cue but retains full meaning.
+- ✅ ClosureLoop station 09: uses an amber gradient to signal convergence *and* spans both columns of the grid *and* is the last numbered station in the sequence.
+- ❌ Six `.inst-card` variants distinguished only by accent bar color, with identical eyebrow structure. Fix: each variant also carries its category in the eyebrow text.
+
+**Enforcement:** when reviewing a design, run a grayscale preview. If two things are now indistinguishable, meaning is leaking into color.
+
+### 3.2 Contrast ratios meet WCAG AA
+
+**Rule:**
+- Normal text (under 18pt regular / 14pt bold): **4.5:1** minimum
+- Large text (18pt regular / 14pt bold and above): **3:1** minimum
+- Interactive components and meaningful graphics: **3:1** minimum against adjacent colors
+
+**WCAG:** 1.4.3 Contrast (Minimum) (Level AA), 1.4.11 Non-text Contrast (Level AA)
+
+**Current tokens to verify:**
+- `--text-primary` (`#e8edf5`) on `--bg-primary` (`#06090f`) — ~17:1, passes AAA
+- `--text-secondary` (`#94a3b8`) on `--bg-primary` — ~7.1:1, passes AAA
+- `--text-muted` (`#64748b`) on `--bg-primary` — ~4.7:1, passes AA
+- `--text-muted` on `--bg-card` (`#111827`) — ~3.7:1, **fails AA for small text**
+
+**Action:** any muted-on-card text must be at least 14pt/bold to qualify as large text, or the token pair must be swapped. Eyebrow labels and station-number pills sit in this zone and need review.
+
+### 3.3 Focus states are always visible
+
+**Rule:** Every interactive element must show a visible focus indicator when reached by keyboard. The indicator must be distinguishable from the default state.
+
+**WCAG:** 2.4.7 Focus Visible (Level AA), 2.4.11 Focus Not Obscured (Level AA)
+
+**Current state:** the site has no `:focus-visible` rules. Keyboard users cannot see where they are as they tab through.
+
+**Required fix:** add a global `:focus-visible` rule with a visible ring (outline or box-shadow), applied to links, buttons, form controls, and interactive cards.
+
+### 3.4 Motion respects user preferences
+
+**Rule:** Any non-essential motion (parallax, auto-animations, reveal-on-scroll, hover transitions over 200ms) must be disabled when the user prefers reduced motion.
+
+**WCAG:** 2.3.3 Animation from Interactions (Level AAA)
+
+**Current state:** the `.reveal` IntersectionObserver fade-up animation in `Layout.astro` ignores reduced-motion preferences.
+
+**Required fix:** wrap motion rules in `@media (prefers-reduced-motion: no-preference)` or add a `@media (prefers-reduced-motion: reduce)` override that sets `transition: none` and `animation: none`.
+
+### 3.5 Keyboard navigation works everywhere
+
+**Rule:** Every page must be fully usable with a keyboard alone. No interaction should require a mouse or touch.
+
+**WCAG:** 2.1.1 Keyboard (Level A), 2.1.2 No Keyboard Trap (Level A)
+
+**Specific checks:**
+- Tab order follows visual order
+- The mobile menu opens with keyboard (Enter/Space on the hamburger button)
+- All CTAs are reachable
+- `:focus-visible` shows the current element
+- No keyboard traps in modals or menus
+- A skip-to-main-content link is the first tabbable element on every page
+
+### 3.6 Screen reader semantics are correct
+
+**Rule:** Interactive state, landmark regions, and meaningful structure must be exposed to assistive technology.
+
+**WCAG:** 4.1.2 Name, Role, Value (Level A), 1.3.1 Info and Relationships (Level A)
+
+**Specific requirements:**
+- The `<main>` element wraps page content (exists)
+- The hamburger button has `aria-expanded` reflecting menu state
+- Decorative SVGs use `aria-hidden="true"`
+- Meaningful SVGs use `role="img"` and `aria-label`
+- Headings form a logical outline (h1 → h2 → h3, no skips)
+- `aria-current="page"` on the active nav link
+- Diagram components (`ClosureLoop`, future `ScopeMap`) expose their structure via `aria-label` or inline `<figcaption>`
+
+### 3.7 Touch targets are big enough
+
+**Rule:** Interactive elements must be at least **44×44 CSS pixels** on mobile, or spaced so adjacent touch targets do not overlap.
+
+**WCAG:** 2.5.5 Target Size (Enhanced) (Level AAA), 2.5.8 Target Size (Minimum) (Level AA)
+
+**Current state:** mobile nav links, hero CTAs, and footer links are large enough. Some secondary ghost buttons and the station-number pills may be borderline. Audit required.
+
+### 3.8 Text can scale without breaking
+
+**Rule:** The page must remain usable when text is zoomed to 200% without horizontal scrolling or content loss.
+
+**WCAG:** 1.4.4 Resize Text (Level AA), 1.4.10 Reflow (Level AA)
+
+**Current state:** headings use `clamp()`, body text uses rem. Should be fine but untested.
+
+### 3.9 Small text is not smaller than necessary
+
+**Rule:** Default body text should be at least 16 CSS pixels. Mono labels and eyebrows should be at least 11 CSS pixels and ideally 12+.
+
+**Current state:** `.station-number` uses `0.6875rem` (~11px) and `.eyebrow` uses the same. At the lower bound of the rule.
+
+**Action:** keep as-is for now but verify with real users. Do not go smaller.
+
+### 3.10 Alt text is meaningful or absent
+
+**Rule:**
+- Decorative images: `alt=""` and/or `aria-hidden="true"`
+- Meaningful images: alt text that conveys the same information the image provides
+- SVG icons used as UI affordances: `aria-label` describing the action
+- SVG icons paired with visible text labels: `aria-hidden="true"`
+
+### 3.11 Icons follow the Icon component rules
+
+**Rule:** All canonical ICN icons flow through `website/src/components/Icon.astro`, which enforces:
+- `focusable="false"` always (icons never trap tab focus)
+- `aria-hidden="true"` when no `label` prop is provided (decorative, paired with text)
+- `role="img"` + `aria-label` when a `label` prop is provided (standalone, meaningful)
+- `stroke="currentColor"` so the icon inherits color from its parent rather than baking it in
+
+When integrating an icon:
+- ✅ Pass no `label` if the icon sits next to visible text that already names it. The `Icon.astro` component will mark it decorative.
+- ✅ Pass `label="Identity"` if the icon is standalone and must be named by the screen reader.
+- ✅ Run the grayscale test (`filter: grayscale(1)` on `<html>`) after adding a new icon integration. Every card and every labeled context must remain distinguishable.
+- ❌ Never bake color into icon path `stroke` or `fill` attributes. Use `currentColor` and set color on the parent.
+- ❌ Never use an emoji as a substitute for an icon in a canonical component. Emojis do not have stable silhouettes across fonts and platforms.
+
+See `docs/design-language/brief-v0.md §7a` for the full icon system rules.
+
+---
+
+## 4. Concrete do-and-don't examples
+
+### Color and meaning
+
+- ✅ Status card: `<div class="status-card status-strong">` → green left border + `<div class="status-label">Strong today</div>` text label inside. Both channels.
+- ❌ Status card: `<div class="status-strong">` → green background only. No label. Relies on color.
+
+### Typography and size
+
+- ✅ Hero headline: `font-size: clamp(1.75rem, 7vw, 2.5rem)` → scales with viewport.
+- ❌ Hero headline: `font-size: 48px` → fixed, breaks mobile and screen-reader zoom.
+
+### Interactive state
+
+- ✅ Button: `:hover` + `:focus-visible` share the same treatment, so mouse and keyboard users both see it.
+- ❌ Button: only `:hover` styled. Keyboard users see nothing.
+
+### Language
+
+- ✅ Public page copy: "Every decision produces a receipt that can be traced back to the rule that authorized it."
+- ❌ Public page copy: "The governance dispatch bridge wires payloads into executor slots via the trust policy oracle." (Accurate, but unreadable without expertise. Belongs on `/for-developers`.)
+
+### Diagrams
+
+- ✅ ClosureLoop: numbered stations with both canonical label and description, visible labels at every breakpoint, `aria-label` on the figure.
+- ❌ NetworkGraph (homepage hero): decorative force-directed SVG with floating text labels, no description, no semantic structure.
+
+---
+
+## 5. Current known failures
+
+These are the accessibility failures identified in the latest assessment. Each should be addressed in the accessibility foundation pass.
+
+1. **No `:focus-visible` styles anywhere.** Keyboard users cannot see where they are. Fails 2.4.7.
+2. **No skip-to-main-content link.** Screen reader users tab through the full nav on every page load. Fails 2.4.1.
+3. **Hamburger menu lacks `aria-expanded`.** Screen reader users cannot tell if the menu is open. Fails 4.1.2.
+4. **No `prefers-reduced-motion` handling.** The `.reveal` animation and theme toggle ignore user preferences. Fails 2.3.3.
+5. **Decorative SVGs not marked `aria-hidden`.** The nav logo, footer logo, and several button icons are exposed to screen readers as meaningless SVG content.
+6. **`NetworkGraph` has no accessible description.** Decorative but rendered into the tree without `aria-hidden`.
+7. **`--text-muted` on `--bg-card`** passes large-text AA but fails small-text AA. Audit required for `.eyebrow` and `.station-number` uses.
+8. **No `aria-current` on nav links.** The active nav item is styled but not announced as current.
+
+---
+
+## 6. Review checklist
+
+Before any public-facing PR ships, run this checklist:
+
+- [ ] Every color-coded meaning has a non-color cue
+- [ ] All interactive elements have `:focus-visible` styles
+- [ ] Motion respects `prefers-reduced-motion`
+- [ ] Touch targets are ≥44px on mobile
+- [ ] Headings form a logical outline
+- [ ] New SVGs are marked `aria-hidden="true"` (decorative) or have `role="img"` + `aria-label` (meaningful)
+- [ ] New interactive elements have accessible names (button text, `aria-label`, or `aria-labelledby`)
+- [ ] Text can scale to 200% without breaking layout
+- [ ] New mono or eyebrow text is ≥11px and audited against its background
+- [ ] Keyboard can reach and operate every interactive element
+- [ ] No keyboard traps
+- [ ] The page passes a grayscale preview (no meaning lost)
+
+---
+
+## 7. Tools
+
+**Manual:**
+- Browser devtools Accessibility panel (axe-core)
+- Keyboard-only navigation test
+- Screen reader test (VoiceOver / NVDA / Orca)
+- Grayscale preview (`filter: grayscale(1)` on `html`)
+- 200% zoom test
+
+**Automated:**
+- `axe-core` via Playwright (recommended for CI)
+- Lighthouse accessibility audit
+- WCAG contrast checkers (WebAIM)
+
+---
+
+## 8. Related artifacts
+
+- [brief-v0.md](./brief-v0.md) — the design language brief
+- [concept-map.md](./concept-map.md) — canonical → public term mapping
+- `website/src/layouts/Layout.astro` — site shell, nav, skip link, focus handling
+- `website/src/styles/global.css` — token definitions, focus-visible rules, motion handling

--- a/docs/design-language/brief-v0.md
+++ b/docs/design-language/brief-v0.md
@@ -1,0 +1,330 @@
+# ICN Universal Civic Design Language — Brief v0
+
+**Status:** v0 — canonical source of truth for the ICN design language.
+**Scope:** website today; product UI, diagrams, docs, and onboarding over time.
+**Last updated:** current refactor session.
+
+---
+
+## 1. Purpose
+
+ICN needs a design language that makes institutional life **legible**.
+
+Not attractive. Not modern. Not technically impressive.
+
+It needs a system of symbols, language, structure, and visual patterns that helps people understand:
+
+- who is acting
+- in what scope
+- with what standing
+- under what authority
+- according to what rules
+- affecting what resources
+- producing what record
+- in relation to which other institutions
+
+The design language must make ICN understandable across regions, organizations, cultures, and levels of expertise without flattening the meaning of the system.
+
+**Core principle:** *same system grammar, locally expressed*
+
+---
+
+## 2. North star
+
+ICN should feel like:
+
+- institutional
+- civic
+- calm
+- legible
+- federated
+- auditable
+- serious
+- structured
+- human-centered but not soft
+- accessible by design
+
+It should feel like **public infrastructure for collective self-rule**.
+
+It should not feel like:
+
+- crypto
+- startup SaaS
+- enterprise dashboard sludge
+- generic govtech
+- hacker terminal aesthetic
+- cyberpunk network maps
+- AI vapor
+- futuristic spectacle
+- obscure priest-language software
+
+---
+
+## 3. What the design language must do
+
+- make complex institutional systems easier to understand
+- teach users the system through repetition
+- support mobile-first real-world use
+- support plain language and local translation
+- preserve semantic consistency across different institutions
+- distinguish public meaning, truth-state, and technical depth
+- remain readable under stress, low attention, or low expertise
+- allow local adaptation without semantic collapse
+
+This is not branding alone. It is part of the institutional interface.
+
+---
+
+## 4. Core design principles
+
+### 4.1 Structure over spectacle
+
+Every visual element should clarify relation, authority, state, scope, proof, or consequence. No decorative futurism.
+
+### 4.2 One system, many surfaces
+
+The website, product, docs, onboarding, and diagrams should all teach the same grammar.
+
+### 4.3 Stable meaning, flexible expression
+
+Core concepts remain stable. Visible wording, examples, and helper text can vary by institution, region, or language.
+
+### 4.4 Accessibility is foundational
+
+Meaning must survive low vision, colorblindness, stress, mobile use, translation, and low familiarity. Accessibility is not an add-on. It is part of institutional legitimacy.
+
+### 4.5 Repetition builds literacy
+
+Symbols, card structures, scope markers, status bands, and relationship patterns should recur consistently. Users should start learning the system just by seeing the same visual patterns recur.
+
+### 4.6 Human-centered, not infantilized
+
+The system should be easy to understand without being dumbed down.
+
+### 4.7 Institutional seriousness without bureaucratic deadness
+
+Alive and usable, but durable, formal, and trustworthy.
+
+---
+
+## 5. Three layers of meaning
+
+Every public-facing surface must operate across three layers simultaneously:
+
+### Layer 1 — Canonical semantic layer
+
+Stable system concepts. Used internally and for technical precision. Never changes.
+
+Examples: Identity, Standing, Authority, Governance, Policy, Accounting, Execution, Provenance, Federation, Commons, Scope, Agreement, Allocation, Obligation, Settlement, Attestation, Role, Membership, Resource, Member experience.
+
+### Layer 2 — Default public vocabulary
+
+Plain-language English. The default user-facing layer for unlocalized public surfaces.
+
+Examples:
+- Standing → "your recognized status"
+- Authority → "what you are allowed to do"
+- Provenance → "history and proof"
+- Federation → "how groups work together"
+
+### Layer 3 — Local institutional vocabulary
+
+Overridable by organization, federation, language, or region. A local co-op, an agricultural federation, a mutual-aid network, and an indigenous governance body may all prefer different visible labels for the same underlying concept.
+
+The site should default to Layer 2 on public-facing surfaces. Formal Layer 1 terms are allowed when precision requires them, but must be paired with Layer 2 explanations. Layer 3 is not yet implemented; it is the architecture target for localization.
+
+---
+
+## 6. Visual primitives
+
+These are the recurring forms the system uses. Each should be a reusable component, not per-page CSS.
+
+- **Institutional card** (`.inst-card`) — exists today with 6 semantic accent variants
+- **Closure station marker** — exists today as ClosureLoop + station-number pills
+- **Scope container** — not yet built
+- **Agreement connector** — not yet built
+- **Provenance trail / receipt strip** — not yet built
+- **Truth-state band** — exists as custom CSS on three pages; not yet a reusable component
+- **Resource / commons field** — not yet built
+- **Federation relation line** — not yet built
+- **Role / authority badge** — not yet built
+- **Action block** — not yet built
+- **Eyebrow** (`.eyebrow`) — exists today
+- **System divider** (`.system-divider`) — defined, unused
+- **Section frame** (`.section-frame`) — defined, unused
+
+---
+
+## 7. Current maturity of the design language
+
+As of the latest assessment:
+
+**Built and working:**
+- Token system (74 custom properties)
+- Dark theme with reasonable contrast (AA+ verified)
+- Mobile layout verified
+- ClosureLoop component (first canonical diagram)
+- `.inst-card` with six semantic accent variants
+- `.station-number` pill
+- `.eyebrow` mono label pattern
+- Maturity bands with text + color (not color alone)
+- Public reading order + cross-page flow
+- **Icon component + initial symbol family** (`Icon.astro` + `src/data/icons.ts`)
+  - First 10 icons: identity, standing, authority, governance, policy,
+    accounting, execution, provenance, federation, commons
+  - Silhouette-distinct at 16–22px
+  - Stroke-based line art (1.5px, round caps), monochrome via currentColor
+  - Grayscale-safe: integrated into ClosureLoop and `.inst-card` eyebrows;
+    each card remains distinguishable under `filter: grayscale(1)`
+- Accessibility foundations: skip-link, focus-visible, reduced-motion
+  support, `aria-expanded` hamburger, `aria-current` on nav, `aria-hidden`
+  on decorative SVGs
+
+**Not yet built:**
+- Scope model diagram
+- Federation relation map
+- Provenance trail visual
+- Commons / resource governance visual
+- Reusable truth-state band component (blocked by semantic divergence
+  across three current call sites — see Phase 2 notes in session log)
+- Full institutional object card grammar (icon ✓, scope, status, action ✗)
+- Icon for station 09 Member Experience (convergence station — still
+  unresolved; the amber gradient + column span currently carries it)
+- Canonical concept map as a runtime data artifact (exists as markdown,
+  not yet imported by components)
+- Localization scaffold (i18n)
+- Real logo
+- Light theme maintenance discipline
+
+---
+
+## 7a. Icon system rules
+
+The first implementation of the ICN symbol system lives in:
+
+- `website/src/data/icons.ts` — the sprite definitions (SVG paths per concept)
+- `website/src/components/Icon.astro` — the renderer
+- `website/src/components/ClosureLoop.astro` — the first integration
+- `website/src/pages/index.astro` (inst-card eyebrows) — the second integration
+
+### Style rules (enforced by review)
+
+- **One concept, one icon.** Icon ids match canonical concept ids in
+  `concept-map.md`. No parallel icon systems, no per-page icon reinterpretation.
+- **Stroke-based line art.** 1.5px stroke, round line caps, round joins,
+  `fill="none"` on the parent `<svg>`. No filled shapes unless absolutely
+  required for silhouette distinction.
+- **24×24 viewBox, designed for 16–22px display.** Silhouettes must remain
+  distinct at 16px. If an icon becomes illegible at that size, simplify it.
+- **Monochrome via `currentColor`.** Icons inherit their stroke color from the
+  parent element. Never bake color into path attributes.
+- **Silhouette-distinct.** Each icon must be recognizable without relying on
+  its label. At 20px, you should be able to identify the concept from shape
+  alone.
+- **Civic, not decorative.** No fantasy insignia, no crypto aesthetics, no
+  cartoon flourishes, no product-UI doodles. Closer to transit signage or
+  constitutional stamps than to consumer app icons.
+- **Culturally careful.** Avoid metaphors that only make sense in English or
+  Western institutional traditions. When a concept is culturally loaded
+  (e.g. "standing", "commons"), lean on abstract structural forms over
+  narrative scenes.
+
+### Accessibility rules
+
+- **Paired with text on first use.** When an icon is introduced on a page,
+  it must appear alongside its visible label. Icons never carry first-time
+  meaning alone.
+- **`aria-hidden="true"` when decorative.** When the icon sits next to a
+  visible text label, it is decorative from the screen-reader's perspective
+  and must be hidden. The `Icon.astro` component does this automatically
+  when the `label` prop is omitted.
+- **`role="img"` + `aria-label` when standalone.** When an icon must carry
+  meaning by itself (rare, discouraged), pass a `label` prop and the
+  component will set both attributes.
+- **`focusable="false"` always.** Icons never trap tab focus.
+- **Grayscale-safe.** Every icon + card combination must remain
+  distinguishable under `filter: grayscale(1)`. Run the grayscale check
+  before shipping a new integration.
+
+### Adding a new icon
+
+1. Add an `IconDef` entry to `ICONS` in `src/data/icons.ts` keyed by the
+   canonical concept id from `concept-map.md`.
+2. Draw the paths in a 24×24 viewBox using round-cap strokes.
+3. Review the silhouette at 16px, 20px, and 22px against the existing set.
+   If it is confusable with another icon at those sizes, refine.
+4. Add the icon slug to the concept entry in `concept-map.md` once the
+   concept map grows an `iconSlug` field (currently tracked informally).
+5. Integrate into the relevant page by importing `Icon.astro` and using
+   `<Icon name="..." size={...} label="..." />` or decorative form.
+6. Run the grayscale test on every page that uses it.
+
+### Open questions (v1 targets)
+
+- **Additional concepts** beyond the initial 10 — scope, agreement,
+  allocation, obligation, settlement, attestation, role, membership,
+  resource — still need icons.
+- **Runtime concept-map consumption.** Currently `concept-map.md` is a
+  human-readable markdown table and icons are separately defined in
+  `icons.ts`. These should eventually be unified so a single source of
+  truth drives both human docs and runtime rendering.
+- **Icon for the NetworkGraph replacement.** The placeholder decorative
+  graph on the homepage hero could become a motion/composition built from
+  the real icon system once the full set exists.
+
+---
+
+## 8. Anti-patterns
+
+ICN should not look or sound like:
+
+- a crypto protocol explainer
+- a venture-funded SaaS homepage
+- a generic enterprise dashboard
+- a government PDF portal
+- a cyberpunk network map
+- a developer docs site pretending to be a public institution
+- a symbolic system so abstract that only insiders can read it
+- icon chaos
+- color overloading
+- long unbroken prose everywhere
+- diagrams that require prior expertise
+- centralizing federation imagery
+- soft consumer polish that undermines seriousness
+
+---
+
+## 9. Open questions for v1
+
+- exact icon family style
+- exact palette spec with WCAG-verified contrast pairs
+- logo/mark direction
+- degree of local institutional theming allowed
+- how much terminology override is safe before semantic drift
+- whether some concepts need two-level display everywhere
+- how to formalize design tokens across site and product
+
+---
+
+## 10. Working definition
+
+> ICN should use a universal civic design language: a stable system of symbols, structures, colors, and plain-language labels that makes institutional life legible across regions, organizations, and languages. The underlying semantic model should remain consistent, while visible wording and examples can be localized by each institution or federation. The system should be understandable on mobile, under stress, across literacy levels, and without insider knowledge. It should feel like public infrastructure for collective self-rule.
+
+---
+
+## 11. Related artifacts
+
+- `docs/design-language/concept-map.md` — canonical → public → local term mapping
+- `docs/design-language/accessibility.md` — accessibility rules and WCAG requirements
+- `website/src/styles/global.css` — token definitions and shared component classes
+- `website/src/components/ClosureLoop.astro` — the first canonical diagram primitive
+
+---
+
+## 12. How to use this document
+
+This is the canonical source of truth for the ICN design language. Every public-facing page, component, copy change, and visual decision should be checkable against it.
+
+**Rule for contributors:** if an edit introduces something this brief does not describe, either the brief needs to evolve (v0 → v1) or the edit is out of scope for the design language. Do not let ad-hoc decisions silently drift the system.
+
+**Rule for future agents:** this brief supersedes any earlier design direction scattered across chat history, README snippets, or informal notes. Start here.

--- a/docs/design-language/concept-map.md
+++ b/docs/design-language/concept-map.md
@@ -1,0 +1,232 @@
+# ICN Concept Map
+
+**Status:** v0 — canonical source for concept terminology.
+**Parent doc:** [brief-v0.md](./brief-v0.md)
+
+This document maps every canonical ICN system concept to:
+
+1. **Canonical** — the stable internal term used in architecture, code, and technical writing.
+2. **Public (English default)** — the plain-language label used on public-facing surfaces by default.
+3. **Short description** — a one-line gloss suitable for tooltips, subtitles, and helper text.
+4. **Localization notes** — guidance for organizations, federations, and translators building local terminology packs.
+
+The rule: the canonical term is the system's semantic anchor. The public label is what shows on default English surfaces. Local institutions may override the visible label as long as the underlying canonical meaning is preserved.
+
+---
+
+## Closure-loop stations (ordered)
+
+These nine concepts constitute the ICN institutional closure loop. They are rendered visually by the `ClosureLoop` component and referenced by number across pages.
+
+### 01. Identity
+
+- **Canonical:** `identity`
+- **Public:** *Who you are*
+- **Short:** Cryptographic identity held by the member — not a platform account.
+- **Localization notes:** The word "identity" is loaded across cultures and legal systems. Local packs may prefer "recognized person," "named participant," or a term rooted in the local institutional tradition. The underlying meaning is *a self-held cryptographic anchor distinct from platform accounts*.
+- **Color token:** `--accent-teal`
+- **Loop position:** 01
+
+### 02. Standing
+
+- **Canonical:** `standing`
+- **Public:** *Your recognized status*
+- **Short:** Provable participation inside a scope. The institution can verify it directly.
+- **Localization notes:** "Standing" has institutional weight in English but no universal equivalent. Local packs often prefer "recognized status," "member in good standing," "active steward," "confirmed participant," or role-specific terms. Avoid "rank" and "reputation" — both distort the meaning.
+- **Color token:** `--accent-teal`
+- **Loop position:** 02
+
+### 03. Authority
+
+- **Canonical:** `authority`
+- **Public:** *What you are allowed to do*
+- **Short:** Derived from scope rules and the decisions members have made under them.
+- **Localization notes:** Do not translate "authority" as "power" or "permission." The meaning is *the action-space granted by the scope's rules and the decisions its members have made*. Local packs often prefer "mandate," "authorization," or scope-specific language like "charter permissions."
+- **Color token:** `--accent-teal`
+- **Loop position:** 03
+
+### 04. Governance
+
+- **Canonical:** `governance`
+- **Public:** *How group decisions are made*
+- **Short:** Proposals, deliberation, and decisions the institution will honor.
+- **Localization notes:** "Governance" has strong institutional resonance in English but can translate as "administration" or "management" in other languages, which distorts the meaning. The underlying meaning is *the collective process by which members decide*. Local packs may prefer "decision-making," "assembly process," or culturally specific terms for collective deliberation.
+- **Color token:** `--accent-amber`
+- **Loop position:** 04
+
+### 05. Policy
+
+- **Canonical:** `policy`
+- **Public:** *The rules this follows*
+- **Short:** Shared rules produced by decisions, shaping what can happen next.
+- **Localization notes:** "Policy" in English can read as bureaucratic. The meaning is *the binding rules an institution has adopted through its governance*. Local packs may prefer "rules," "bylaws," "charter provisions," or "operating rules."
+- **Color token:** `--accent-amber`
+- **Loop position:** 05
+
+### 06. Accounting
+
+- **Canonical:** `accounting`
+- **Public:** *How resources and obligations are tracked*
+- **Short:** Obligations, treasury, patronage, mutual-credit positions — governed social accounting.
+- **Localization notes:** Do not translate as "finance" or "bookkeeping" on public surfaces. The meaning is *relational social accounting of obligations and resources between named parties*, not commercial finance. Local packs may prefer "resource ledger," "collective books," "mutual obligations."
+- **Color token:** `--accent-blue`
+- **Loop position:** 06
+
+### 07. Execution
+
+- **Canonical:** `execution`
+- **Public:** *What actually happens*
+- **Short:** Where accepted decisions translate into real operational effect.
+- **Localization notes:** "Execution" can read as cold or bureaucratic. The meaning is *the step where an accepted decision becomes an operational fact*. Local packs may prefer "action," "effect," "carrying out," "implementation."
+- **Color token:** `--accent-amber`
+- **Loop position:** 07
+
+### 08. Receipts and Provenance
+
+- **Canonical:** `provenance`
+- **Public:** *History and proof*
+- **Short:** The chain from authority to outcome — durable, auditable institutional memory.
+- **Localization notes:** "Provenance" is precise but rare outside English. The meaning is *the verifiable chain from decision to outcome that an institution can show its members*. Local packs may prefer "history and proof," "institutional memory," "audit trail," or "the record."
+- **Color token:** `--accent-green`
+- **Loop position:** 08
+
+### 09. Member Experience
+
+- **Canonical:** `member_experience`
+- **Public:** *What people can do and see*
+- **Short:** Where all of the above becomes something a person can see, use, and live in.
+- **Localization notes:** "Member experience" sounds product-y in English. The meaning is *the surface through which an ordinary participant interacts with the institution*. Local packs may prefer "what members see," "the member-facing layer," or simply "the interface."
+- **Color token:** `--accent-amber`
+- **Icon slug:** `member_experience` — a rounded surface frame with a simplified person silhouette inside. Communicates "the member inhabits the context of the surface" without reading as a phone mockup or duplicating the standalone `identity` person icon.
+- **Loop position:** 09 (convergence)
+
+---
+
+## Scope concepts
+
+Concepts describing where and on behalf of whom action is taken.
+
+### Scope
+
+- **Canonical:** `scope`
+- **Public:** *Where you are acting*
+- **Short:** A distinct institutional entity the system recognizes — a member, a cooperative, a community, a federation, or a commons.
+- **Localization notes:** "Scope" is a technical term in English but can be translated as "context" or "institutional frame." Some cultures may not distinguish between "self" and "group" scopes the same way; helper text matters.
+
+### Cooperative
+
+- **Canonical:** `cooperative`
+- **Public:** *A cooperative*
+- **Short:** A scoped institution owned and governed by its members.
+- **Localization notes:** The word "cooperative" has strong legal-structural meaning in some jurisdictions and cultural meaning in others. Local packs should use the local legal term when relevant (e.g., *cooperativa*, *Genossenschaft*, *协同社*).
+
+### Community
+
+- **Canonical:** `community`
+- **Public:** *A community*
+- **Short:** A scoped institution of people organized around shared rules and purpose, not necessarily an economic coop.
+- **Localization notes:** "Community" is broad in English; local packs should narrow it to the institutional form being described (neighborhood association, civic body, mutual aid network, etc.).
+
+### Federation
+
+- **Canonical:** `federation`
+- **Public:** *How groups work together*
+- **Short:** A coordinating scope that connects distinct cooperatives and communities without dissolving them.
+- **Localization notes:** "Federation" has different meanings in different legal traditions. The ICN meaning is *a voluntary coordinating scope with its own governance that does not subsume its member institutions*. Local packs should be careful not to translate it as "union," "alliance," or "merger" unless those words carry the same meaning locally.
+
+### Commons
+
+- **Canonical:** `commons`
+- **Public:** *Shared resources*
+- **Short:** A scoped domain of shared resources governed by the institutions that participate in it.
+- **Localization notes:** "Commons" is a specific English-language tradition (Hardin, Ostrom). Local packs should use equivalent local traditions where they exist — *ejido*, *agora*, *公共资源*, *allmenning*. Avoid translations that sound like "public goods" in a government-provision sense.
+
+---
+
+## Economic concepts
+
+### Agreement
+
+- **Canonical:** `agreement`
+- **Public:** *A formal relationship*
+- **Short:** A recorded understanding between scopes or members, with standing inside the system.
+- **Localization notes:** Translate carefully — "agreement" should not collapse into "contract" in the commercial sense unless that is what is meant.
+
+### Allocation
+
+- **Canonical:** `allocation`
+- **Public:** *What has been assigned*
+- **Short:** A decision to direct resources, obligations, or authority to a specific party.
+- **Localization notes:** "Allocation" is technical. Local packs may prefer "assignment," "grant," or "distribution."
+
+### Obligation
+
+- **Canonical:** `obligation`
+- **Public:** *What is owed or required*
+- **Short:** A structured claim one party has on another within the system's rules.
+- **Localization notes:** Avoid "debt" as a default translation — it loads commercial connotations. Local packs may prefer "duty," "commitment," "owing."
+
+### Settlement
+
+- **Canonical:** `settlement`
+- **Public:** *How accounts are resolved*
+- **Short:** The process of discharging obligations between parties.
+- **Localization notes:** "Settlement" is a precise accounting term in English and a loaded colonial term in other contexts. Local packs should strongly consider alternatives — "resolution," "clearing," "balancing."
+
+### Attestation
+
+- **Canonical:** `attestation`
+- **Public:** *A verified claim*
+- **Short:** A signed statement by one party that another party can rely on.
+- **Localization notes:** "Attestation" is formal. Local packs may prefer "witnessed statement," "verified claim," "confirmation."
+
+---
+
+## Membership concepts
+
+### Role
+
+- **Canonical:** `role`
+- **Public:** *Your function in this context*
+- **Short:** A named bundle of authority and responsibility within a scope.
+- **Localization notes:** Local packs typically have strong culturally specific role names (steward, elder, facilitator, delegate). Use them.
+
+### Membership
+
+- **Canonical:** `membership`
+- **Public:** *Your place in the group*
+- **Short:** Recognized participation in a scope.
+- **Localization notes:** "Membership" is institutionally loaded. Local packs may prefer "belonging," "participation," "standing" (careful — distinct from the canonical `standing`).
+
+### Resource
+
+- **Canonical:** `resource`
+- **Public:** *Something shared, used, or governed*
+- **Short:** A tangible or intangible asset the institution tracks and allocates.
+- **Localization notes:** Broad term; local packs should specify the resource type when possible (compute, storage, capital, labor-time, etc.).
+
+---
+
+## How this map is used
+
+1. **Public pages default to the Public label.** Helper text draws from the Short description.
+2. **Canonical terms appear when precision matters** — technical docs, developer surfaces, the architecture page. Always paired with the Public label on first use.
+3. **Future localization packs override the Public label** per scope or region. The canonical term is the stable anchor; the visible label is the render.
+4. **Color tokens are reinforcement, not meaning.** The label is the source of truth. Color is a hint.
+
+---
+
+## v1 expansion targets
+
+- Icon slug for each concept (once the symbol family exists)
+- Locale file path and translation status
+- Example local labels for at least three real organizational traditions (worker co-op, agricultural federation, mutual aid network)
+- Semantic relationship graph between concepts (e.g., `standing` depends on `identity`, `authority` derives from `governance` operating on `policy`)
+- Machine-readable version as `website/src/data/concepts.ts` for runtime consumption
+
+---
+
+## Related artifacts
+
+- [brief-v0.md](./brief-v0.md) — the full design language brief
+- [accessibility.md](./accessibility.md) — accessibility rules that apply to every concept's visual treatment

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -11,9 +11,9 @@
 schema_version = 1
 allowlisted_docs_subdirs = [
   "adr", "ai", "api", "architecture", "archive", "ci", "crate-manifests", "demo", "deployment",
-  "design", "dev", "development", "examples", "features", "guides", "internal", "maintenance",
-  "manual", "migration-guides", "mobile", "observability", "onboarding", "operations", "ops",
-  "performance", "phases", "pilots", "planning", "plans", "reference", "scripts", "sdis",
+  "design", "design-language", "dev", "development", "examples", "features", "guides", "internal",
+  "maintenance", "manual", "migration-guides", "mobile", "observability", "onboarding", "operations",
+  "ops", "performance", "phases", "pilots", "planning", "plans", "reference", "scripts", "sdis",
   "security", "spec", "sprints", "state", "status", "strategy", "summit", "superpowers",
   "templates", "testing", "vision",
 ]
@@ -150,6 +150,16 @@ freshness = "unknown"
 domain_tags = ["design"]
 recommended_action = "keep"
 last_reviewed = "unknown"
+
+[[doc_path_defaults]]
+prefix = "docs/design-language/"
+truth_class = "normative"
+role = "design"
+canonical = "no"
+freshness = "current"
+domain_tags = ["design-language", "website"]
+recommended_action = "keep"
+last_reviewed = "2026-04-09"
 
 [[doc_path_defaults]]
 prefix = "docs/guides/"

--- a/website/README.md
+++ b/website/README.md
@@ -1,14 +1,16 @@
 # ICN Website
 
-The official website for the InterCooperative Network (ICN) - a federated compute, resource, and governance protocol designed for cooperatives, communities, and federations.
+The public-facing website for the InterCooperative Network (ICN) — institutional infrastructure for cooperatives, communities, and federations.
 
-## 🌟 Features
+## Design language (read this first)
 
-- **Modern Design**: Clean, responsive design with dark theme and vibrant accents
-- **Comprehensive Documentation**: Integrated documentation with clear navigation and search
-- **Performance Optimized**: Built with Astro for fast loading and excellent SEO
-- **Accessibility**: WCAG compliant with proper semantic markup and keyboard navigation
-- **Mobile First**: Responsive design that works beautifully on all devices
+The website is the first implementation surface of ICN's universal civic design language. Every public-facing edit should be checkable against the canonical design-language docs:
+
+- **[brief-v0](../docs/design-language/brief-v0.md)** — the canonical source of truth for the design language (principles, semantic layers, visual primitives, anti-patterns)
+- **[concept-map](../docs/design-language/concept-map.md)** — canonical term → public plain-language label → localization notes, for every ICN concept
+- **[accessibility](../docs/design-language/accessibility.md)** — WCAG rules, contrast requirements, keyboard and screen-reader expectations, and the review checklist every PR must pass
+
+If an edit introduces something these docs do not describe, either the docs evolve or the edit is out of scope for the design language. Do not let ad-hoc decisions silently drift the system.
 
 ## 🚀 Quick Start
 

--- a/website/src/components/ClosureLoop.astro
+++ b/website/src/components/ClosureLoop.astro
@@ -1,0 +1,365 @@
+---
+// ClosureLoop.astro — The nine-station institutional closure.
+// Visual representation of ICN's core thesis: identity → standing → authority →
+// governance → policy → accounting → execution → receipts/provenance → member
+// experience, with the loop closing back to the next round of standing.
+//
+// Variants:
+//   full    — complete with station notes (default, primary pages)
+//   compact — station chips only, for homepage / inline use
+//
+// Responsive: horizontal two-column stagger on desktop (full variant),
+// stacked vertical flow with connectors on mobile. Compact variant is a
+// horizontal chip row that wraps.
+
+import Icon from './Icon.astro';
+import type { IconName } from '../data/icons';
+
+export interface Props {
+  variant?: 'full' | 'compact';
+  title?: string;
+  showReturn?: boolean;
+}
+
+const { variant = 'full', title, showReturn = true } = Astro.props;
+
+interface Station {
+  n: string;
+  label: string;
+  note: string;
+  icon?: IconName;
+}
+
+const stations: Station[] = [
+  {
+    n: '01',
+    label: 'Identity',
+    note: 'Cryptographic identity held by the member — not a platform account.',
+    icon: 'identity',
+  },
+  {
+    n: '02',
+    label: 'Standing',
+    note: 'Provable participation inside a scope. The institution can verify it directly.',
+    icon: 'standing',
+  },
+  {
+    n: '03',
+    label: 'Authority',
+    note: 'Derived from scope rules and the decisions members have made under them.',
+    icon: 'authority',
+  },
+  {
+    n: '04',
+    label: 'Governance',
+    note: 'Proposals, deliberation, and decisions the institution will honor.',
+    icon: 'governance',
+  },
+  {
+    n: '05',
+    label: 'Policy',
+    note: 'Shared rules produced by decisions, shaping what can happen next.',
+    icon: 'policy',
+  },
+  {
+    n: '06',
+    label: 'Accounting',
+    note: 'Obligations, treasury, patronage, mutual-credit positions — governed social accounting.',
+    icon: 'accounting',
+  },
+  {
+    n: '07',
+    label: 'Execution',
+    note: 'Where accepted decisions translate into real operational effect.',
+    icon: 'execution',
+  },
+  {
+    n: '08',
+    label: 'Receipts & Provenance',
+    note: 'The chain from authority to outcome — durable, auditable institutional memory.',
+    icon: 'provenance',
+  },
+  {
+    n: '09',
+    label: 'Member Experience',
+    note: 'Where all of the above becomes something a person can see, use, and live in.',
+    icon: 'member_experience',
+  },
+];
+---
+
+<figure class="closure-loop" data-variant={variant} aria-label="ICN's nine-station institutional closure loop">
+  {title && <figcaption class="loop-title">{title}</figcaption>}
+
+  <ol class="loop-list">
+    {stations.map((s, i) => (
+      <li class="loop-station">
+        <div class="loop-station-inner">
+          <span class="loop-number" aria-hidden="true">{s.n}</span>
+          {s.icon && (
+            <span class="loop-icon" aria-hidden="true">
+              <Icon name={s.icon} size={22} />
+            </span>
+          )}
+          <div class="loop-body">
+            <span class="loop-label">{s.label}</span>
+            {variant === 'full' && <span class="loop-note">{s.note}</span>}
+          </div>
+        </div>
+        {i < stations.length - 1 && (
+          <span class="loop-connector" aria-hidden="true">
+            <span class="loop-connector-line"></span>
+            <span class="loop-connector-arrow">↓</span>
+          </span>
+        )}
+      </li>
+    ))}
+  </ol>
+
+  {showReturn && (
+    <div class="loop-return" aria-hidden="true">
+      <span class="loop-return-mark">↻</span>
+      <span class="loop-return-text">
+        <span class="loop-return-eyebrow">The loop closes</span>
+        Every round of standing starts the next. Identity does not begin at 01 again —
+        it is reinforced by the provenance that station 08 produces and the member experience at 09.
+      </span>
+    </div>
+  )}
+</figure>
+
+<style>
+  .closure-loop {
+    --loop-accent: var(--accent-teal);
+    --loop-accent-dim: var(--accent-teal-dim);
+    --loop-rail: var(--border-default);
+    --loop-text: var(--text-heading);
+    --loop-muted: var(--text-muted);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+    margin: 0;
+    padding: 0;
+  }
+
+  .loop-title {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--loop-muted);
+    text-align: left;
+  }
+
+  .loop-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .loop-station {
+    position: relative;
+    padding: 0;
+  }
+
+  .loop-station-inner {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-md);
+    padding: var(--space-md) var(--space-lg);
+    background: var(--bg-card);
+    border: 1px solid var(--border-subtle);
+    border-left: 3px solid var(--loop-accent);
+    border-radius: var(--radius-md);
+    transition:
+      border-color var(--duration-fast) var(--ease-out),
+      background var(--duration-fast) var(--ease-out),
+      transform var(--duration-fast) var(--ease-out);
+  }
+
+  .loop-station-inner:hover {
+    border-color: var(--loop-accent);
+    background: var(--bg-card-hover);
+  }
+
+  .loop-number {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    font-weight: 500;
+    letter-spacing: 0.1em;
+    color: var(--loop-accent);
+    flex-shrink: 0;
+    padding-top: 0.25em;
+    min-width: 1.75em;
+  }
+
+  .loop-icon {
+    flex-shrink: 0;
+    color: var(--loop-accent);
+    display: inline-flex;
+    align-items: flex-start;
+    padding-top: 0.1em;
+  }
+
+  .loop-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    flex: 1;
+    min-width: 0;
+  }
+
+  .loop-label {
+    font-family: var(--font-heading);
+    font-weight: 700;
+    font-size: 1rem;
+    color: var(--loop-text);
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+  }
+
+  .loop-note {
+    font-size: 0.875rem;
+    color: var(--loop-muted);
+    line-height: 1.55;
+  }
+
+  /* Connector between stations — vertical on mobile/narrow */
+  .loop-connector {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: var(--space-lg);
+    position: relative;
+    padding-left: calc(var(--space-lg) + 1.75em + var(--space-md));
+  }
+
+  .loop-connector-line {
+    position: absolute;
+    left: calc(var(--space-lg) + 0.875em + var(--space-md) / 2 - 0.5px);
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: var(--loop-rail);
+  }
+
+  .loop-connector-arrow {
+    position: absolute;
+    left: calc(var(--space-lg) + 0.875em + var(--space-md) / 2);
+    top: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 0.75rem;
+    color: var(--loop-muted);
+    background: var(--bg-primary);
+    width: 1.25em;
+    text-align: center;
+    line-height: 1;
+  }
+
+  /* Return-arrow card — the loop closing */
+  .loop-return {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-md);
+    padding: var(--space-md) var(--space-lg);
+    background: var(--bg-surface);
+    border: 1px dashed var(--border-default);
+    border-radius: var(--radius-md);
+    color: var(--loop-muted);
+  }
+
+  .loop-return-mark {
+    font-size: 1.25rem;
+    color: var(--loop-accent);
+    flex-shrink: 0;
+    line-height: 1.3;
+  }
+
+  .loop-return-text {
+    font-size: 0.875rem;
+    line-height: 1.6;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+  }
+
+  .loop-return-eyebrow {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--loop-accent);
+  }
+
+  /* Compact variant: chips that wrap */
+  .closure-loop[data-variant='compact'] .loop-list {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+  }
+
+  .closure-loop[data-variant='compact'] .loop-station-inner {
+    padding: var(--space-sm) var(--space-md);
+    border-left-width: 2px;
+    border-radius: var(--radius-sm);
+  }
+
+  .closure-loop[data-variant='compact'] .loop-note {
+    display: none;
+  }
+
+  .closure-loop[data-variant='compact'] .loop-connector {
+    display: none;
+  }
+
+  .closure-loop[data-variant='compact'] .loop-label {
+    font-size: 0.875rem;
+  }
+
+  .closure-loop[data-variant='compact'] .loop-number {
+    padding-top: 0.15em;
+    min-width: 1.5em;
+  }
+
+  .closure-loop[data-variant='compact'] .loop-return {
+    margin-top: var(--space-md);
+  }
+
+  /* Wide viewports (full variant): two-column stagger, converging on last row */
+  @media (min-width: 900px) {
+    .closure-loop[data-variant='full'] .loop-list {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      column-gap: var(--space-lg);
+      row-gap: var(--space-md);
+    }
+
+    .closure-loop[data-variant='full'] .loop-connector {
+      display: none;
+    }
+
+    /* Last station spans both columns to feel like the loop converging */
+    .closure-loop[data-variant='full'] .loop-station:last-child {
+      grid-column: 1 / -1;
+    }
+
+    .closure-loop[data-variant='full'] .loop-station:last-child .loop-station-inner {
+      border-left-width: 3px;
+      border-left-color: var(--accent-amber);
+      background: linear-gradient(
+        to right,
+        var(--bg-card) 0%,
+        var(--accent-amber-glow) 100%
+      );
+    }
+
+    .closure-loop[data-variant='full'] .loop-station:last-child .loop-number {
+      color: var(--accent-amber);
+    }
+  }
+</style>

--- a/website/src/components/Icon.astro
+++ b/website/src/components/Icon.astro
@@ -1,0 +1,98 @@
+---
+// Icon.astro — the canonical ICN icon renderer.
+//
+// Usage:
+//   <Icon name="identity" />                                decorative, paired with text
+//   <Icon name="identity" label="Identity" />               standalone, labeled
+//   <Icon name="identity" size={24} />                      custom size
+//   <Icon name="identity" class="some-modifier" />          class passthrough
+//
+// Rules:
+//   - When `label` is provided, the SVG is treated as meaningful
+//     (role="img", aria-label set).
+//   - When `label` is absent, the SVG is treated as decorative
+//     (aria-hidden="true"), which is correct when the icon sits
+//     next to visible text that already names it.
+//   - `focusable="false"` is always set so the icon never traps tab focus.
+//   - Colors come from the parent element via currentColor — never baked in.
+//
+// See docs/design-language/brief-v0.md and
+// docs/design-language/accessibility.md for the rules this component enforces.
+
+import { ICONS, type IconName } from '../data/icons';
+
+export interface Props {
+  /** Canonical concept id. Must exist in ICONS. */
+  name: IconName;
+  /** Pixel size (width and height). Defaults to 20. */
+  size?: number;
+  /** Accessible label. If omitted, the icon is marked decorative. */
+  label?: string;
+  /** Extra class names for the <svg>. */
+  class?: string;
+  /** Stroke width override. Defaults to 1.5. */
+  strokeWidth?: number;
+}
+
+const {
+  name,
+  size = 20,
+  label,
+  class: className,
+  strokeWidth = 1.5,
+} = Astro.props;
+
+const icon = ICONS[name];
+if (!icon) {
+  throw new Error(
+    `Icon "${name}" not found. Add it to src/data/icons.ts and docs/design-language/concept-map.md.`
+  );
+}
+
+const isDecorative = !label;
+const accessibilityAttrs = isDecorative
+  ? { 'aria-hidden': 'true' }
+  : { role: 'img', 'aria-label': label };
+---
+
+<svg
+  class:list={['icon', `icon-${name}`, className]}
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width={strokeWidth}
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  focusable="false"
+  {...accessibilityAttrs}
+>
+  {icon.paths.map((d) => <path d={d} />)}
+  {
+    icon.extras?.map((shape) => {
+      if (shape.type === 'circle') {
+        return (
+          <circle
+            cx={shape.cx}
+            cy={shape.cy}
+            r={shape.r}
+            fill={shape.fill ?? 'none'}
+          />
+        );
+      }
+      if (shape.type === 'line') {
+        return <line x1={shape.x1} y1={shape.y1} x2={shape.x2} y2={shape.y2} />;
+      }
+      return null;
+    })
+  }
+</svg>
+
+<style>
+  .icon {
+    display: inline-block;
+    vertical-align: middle;
+    flex-shrink: 0;
+  }
+</style>

--- a/website/src/components/MaturityBadge.astro
+++ b/website/src/components/MaturityBadge.astro
@@ -1,0 +1,74 @@
+---
+// MaturityBadge.astro — the inline "truth-state" pill used on headings
+// to mark which maturity band a subsystem or claim sits in.
+//
+// Canonical bands (see docs/design-language/concept-map.md):
+//   strong    — implemented, integrated, load-bearing
+//   advancing — actively being built, real progress, not yet reliable
+//   maturing  — real implementation, but surfaces/integrations still lag
+//   notyet    — scoped but not currently active
+//   behind    — capability exists underneath, interface still catching up
+//
+// Every band has a color (reinforcement only) and a text label (the source
+// of truth). Meaning never depends on color alone.
+//
+// Usage:
+//   <MaturityBadge band="strong" />                        uses default label
+//   <MaturityBadge band="behind" label="behind the system" /> custom label
+
+export type Band = 'strong' | 'advancing' | 'maturing' | 'notyet' | 'behind';
+
+export interface Props {
+  band: Band;
+  /** Override the default label. Defaults are the canonical forms. */
+  label?: string;
+}
+
+const DEFAULT_LABELS: Record<Band, string> = {
+  strong: 'strong today',
+  advancing: 'advancing now',
+  maturing: 'real but maturing',
+  notyet: 'not yet',
+  behind: 'behind the system',
+};
+
+const { band, label } = Astro.props;
+const displayLabel = label ?? DEFAULT_LABELS[band];
+---
+
+<span class:list={['maturity-badge', `band-${band}`]}>{displayLabel}</span>
+
+<style>
+  .maturity-badge {
+    display: inline-block;
+    font-size: 0.6875rem;
+    font-family: var(--font-mono);
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 0.2em 0.65em;
+    border-radius: 999px;
+    border: 1px solid var(--border-default);
+    color: var(--text-muted);
+    background: var(--bg-surface);
+    vertical-align: middle;
+    white-space: nowrap;
+  }
+  .maturity-badge.band-strong {
+    color: var(--accent-green);
+    border-color: rgba(74, 222, 128, 0.35);
+  }
+  .maturity-badge.band-advancing {
+    color: var(--accent-teal);
+    border-color: rgba(45, 212, 191, 0.35);
+  }
+  .maturity-badge.band-maturing {
+    color: var(--accent-amber);
+    border-color: rgba(251, 146, 60, 0.35);
+  }
+  .maturity-badge.band-notyet,
+  .maturity-badge.band-behind {
+    color: var(--text-muted);
+    border-color: var(--border-default);
+  }
+</style>

--- a/website/src/components/MaturityCard.astro
+++ b/website/src/components/MaturityCard.astro
@@ -1,0 +1,79 @@
+---
+// MaturityCard.astro — a single card in the maturity band grid.
+// Shows a band label and a description of which capabilities currently
+// sit in that band. Meant to be used inside <MaturityGrid> on pages like
+// the homepage "what's real now" strip and the full /whats-real-now page.
+//
+// Description content is passed as a slot so each page can write its
+// own prose for each band.
+
+import type { Band } from './MaturityBadge.astro';
+
+export interface Props {
+  band: Band;
+  /** Visible label. Defaults to the canonical form. */
+  label?: string;
+}
+
+const DEFAULT_LABELS: Record<Band, string> = {
+  strong: 'Strong today',
+  advancing: 'Advancing now',
+  maturing: 'Real but maturing',
+  notyet: 'Not yet',
+  behind: 'Behind the system',
+};
+
+const { band, label } = Astro.props;
+const displayLabel = label ?? DEFAULT_LABELS[band];
+---
+
+<div class:list={['maturity-card', `mc-${band}`]}>
+  <div class="maturity-card-label">{displayLabel}</div>
+  <div class="maturity-card-body">
+    <slot />
+  </div>
+</div>
+
+<style>
+  .maturity-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-default);
+    border-left: 3px solid var(--border-default);
+    border-radius: var(--radius-lg);
+    padding: var(--space-lg);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+  }
+  .maturity-card-label {
+    font-family: var(--font-heading);
+    font-weight: 700;
+    font-size: 0.9375rem;
+    color: var(--text-heading);
+  }
+  .maturity-card-body {
+    font-size: 0.9375rem;
+    color: var(--text-muted);
+    line-height: 1.65;
+  }
+  .maturity-card-body :global(p) {
+    margin: 0;
+  }
+
+  /* Accent color cascades to the left border only. Card background,
+     label color, and body color stay constant across all bands so the
+     band is distinguished by its label first, color second. */
+  .maturity-card.mc-strong {
+    border-left-color: var(--accent-green);
+  }
+  .maturity-card.mc-advancing {
+    border-left-color: var(--accent-teal);
+  }
+  .maturity-card.mc-maturing {
+    border-left-color: var(--accent-amber);
+  }
+  .maturity-card.mc-notyet,
+  .maturity-card.mc-behind {
+    border-left-color: var(--text-muted);
+  }
+</style>

--- a/website/src/components/MaturityGrid.astro
+++ b/website/src/components/MaturityGrid.astro
@@ -1,0 +1,25 @@
+---
+// MaturityGrid.astro — the wrapper grid for a maturity band summary.
+// Used on the homepage "what's real now" strip and on the full
+// /whats-real-now page. Accepts MaturityCard children as a slot.
+//
+// Responsive: single column on narrow viewports, 2-up at ≥720px.
+---
+
+<div class="maturity-grid">
+  <slot />
+</div>
+
+<style>
+  .maturity-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-md);
+    margin: var(--space-xl) 0;
+  }
+  @media (min-width: 720px) {
+    .maturity-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+</style>

--- a/website/src/components/MemberSurface.astro
+++ b/website/src/components/MemberSurface.astro
@@ -1,0 +1,474 @@
+---
+// MemberSurface.astro — illustrative member-facing surface.
+//
+// The closure model is walkable. Scope is visible. Provenance has a shape.
+// What this primitive shows is the last missing piece: what it would feel
+// like to inhabit ICN as a member on an actual device surface.
+//
+// CRITICAL: this is NOT a product mockup and NOT a claim to a shipped
+// member app. The ICN member-facing surface is currently the part of
+// the system most visibly trailing the substrate underneath (see
+// /whats-real-now, "behind the system" band). This component exists
+// specifically to make that gap inspectable rather than abstract.
+//
+// Rules this component must preserve:
+//   - clearly labeled as illustrative ("MEMBER SURFACE · ILLUSTRATIVE")
+//   - no payment-app vocabulary (no balance, no wallet, no currency symbol)
+//   - economics rendered as governed social accounting: contributions,
+//     obligations, allocations, patronage, mutual-credit position
+//   - sample entity names are fictional and read as examples
+//   - uses existing icons from the canonical family
+//   - reuses existing visual grammar: eyebrow → intro → blocks → footer
+//   - grayscale-safe: every cue is carried by structure + label, not color
+//   - mobile-first, stacks cleanly
+//
+// See docs/design-language/brief-v0.md §7a (icon rules) and
+// docs/design-language/accessibility.md §3.11.
+
+import Icon from './Icon.astro';
+---
+
+<figure
+  class="member-surface"
+  aria-label="An illustrative member-facing surface showing what it could look like to inhabit ICN on a personal device. This is a design illustration, not a claim to a shipped app."
+>
+  <figcaption class="ms-title">An illustrative member surface</figcaption>
+
+  <p class="ms-intro">
+    What would it feel like to inhabit ICN as a member, on your own device?
+    Below is an illustration — not a product — of how the closure loop resolves
+    into something a person can see, read, and act on. The capabilities
+    underneath each panel are real; the interface on top is still being built.
+  </p>
+
+  <div class="ms-device" role="group" aria-labelledby="ms-device-label">
+    <div class="ms-device-bar">
+      <span class="ms-device-label" id="ms-device-label">Member surface · illustrative</span>
+      <span class="ms-device-dots" aria-hidden="true">
+        <span class="ms-dot"></span>
+        <span class="ms-dot"></span>
+        <span class="ms-dot"></span>
+      </span>
+    </div>
+
+    <div class="ms-device-body">
+      <!-- Acting as / inside — the scope context a member is currently acting within -->
+      <section class="ms-panel">
+        <header class="ms-panel-head">
+          <span class="ms-panel-icon" aria-hidden="true">
+            <Icon name="identity" size={18} />
+          </span>
+          <span class="ms-panel-eyebrow">Acting as</span>
+        </header>
+        <div class="ms-panel-body">
+          <p class="ms-primary"><strong>Self</strong> — your cryptographic identity</p>
+          <p class="ms-secondary">
+            Inside <strong>Brightworks Collective</strong>
+            <span class="ms-scope-type">(cooperative)</span>
+          </p>
+          <p class="ms-secondary">
+            Inside <strong>Northeast Worker Federation</strong>
+            <span class="ms-scope-type">(federation)</span>
+          </p>
+        </div>
+      </section>
+
+      <!-- Standing — provable participation inside those scopes -->
+      <section class="ms-panel">
+        <header class="ms-panel-head">
+          <span class="ms-panel-icon" aria-hidden="true">
+            <Icon name="authority" size={18} />
+          </span>
+          <span class="ms-panel-eyebrow">Standing</span>
+        </header>
+        <div class="ms-panel-body">
+          <p class="ms-primary"><strong>Recognized member</strong> · Brightworks Collective</p>
+          <p class="ms-meta">
+            <span class="ms-chip">Recognized since 2024-11</span>
+            <span class="ms-chip">Role: Member</span>
+          </p>
+        </div>
+      </section>
+
+      <!-- Governed social accounting — explicitly not a wallet, not a balance -->
+      <section class="ms-panel">
+        <header class="ms-panel-head">
+          <span class="ms-panel-icon" aria-hidden="true">
+            <Icon name="accounting" size={18} />
+          </span>
+          <span class="ms-panel-eyebrow">Position</span>
+        </header>
+        <div class="ms-panel-body">
+          <p class="ms-primary">Mutual-credit position inside Brightworks</p>
+          <dl class="ms-stat-list">
+            <div class="ms-stat">
+              <dt>Contributions recorded</dt>
+              <dd>142 hours</dd>
+            </div>
+            <div class="ms-stat">
+              <dt>Allocations drawn</dt>
+              <dd>38 hours</dd>
+            </div>
+            <div class="ms-stat">
+              <dt>Open obligations</dt>
+              <dd>2 outstanding</dd>
+            </div>
+            <div class="ms-stat">
+              <dt>Patronage (Q3)</dt>
+              <dd>pending approval</dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+
+      <!-- Active governance — a pending decision inside your scope -->
+      <section class="ms-panel">
+        <header class="ms-panel-head">
+          <span class="ms-panel-icon" aria-hidden="true">
+            <Icon name="governance" size={18} />
+          </span>
+          <span class="ms-panel-eyebrow">Open decision</span>
+        </header>
+        <div class="ms-panel-body">
+          <p class="ms-primary">
+            <strong>Proposal:</strong> Extend the commons compute pool cap
+            for the next quarter
+          </p>
+          <p class="ms-meta">
+            <span class="ms-chip">Your vote: pending</span>
+            <span class="ms-chip">Closes in 3 days</span>
+            <span class="ms-chip">Scope: Federation</span>
+          </p>
+        </div>
+      </section>
+
+      <!-- Recent receipts — provenance as lived record -->
+      <section class="ms-panel">
+        <header class="ms-panel-head">
+          <span class="ms-panel-icon" aria-hidden="true">
+            <Icon name="provenance" size={18} />
+          </span>
+          <span class="ms-panel-eyebrow">Recent receipts</span>
+        </header>
+        <div class="ms-panel-body">
+          <ul class="ms-receipt-list" role="list">
+            <li>
+              <span class="ms-receipt-id">#482</span>
+              <span class="ms-receipt-text">Patronage settlement Q3 — scope: Cooperative</span>
+              <span class="ms-receipt-stamp">stamped 2024-10-31</span>
+            </li>
+            <li>
+              <span class="ms-receipt-id">#481</span>
+              <span class="ms-receipt-text">Shared room booking approved — scope: Community</span>
+              <span class="ms-receipt-stamp">stamped 2024-10-28</span>
+            </li>
+            <li>
+              <span class="ms-receipt-id">#479</span>
+              <span class="ms-receipt-text">Federation cross-clearing complete — scope: Federation</span>
+              <span class="ms-receipt-stamp">stamped 2024-10-24</span>
+            </li>
+          </ul>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <p class="ms-foot">
+    <span class="ms-foot-eyebrow">Illustrative, not shipped</span>
+    ICN's member-facing surface is the part of the system most visibly
+    trailing the substrate underneath. The panels above are a design
+    illustration of how governance, economics, scope, and provenance could
+    resolve into a coherent member surface — what a person would read and
+    act on. The capabilities beneath each panel are real today; the
+    interface on top is still being built. This illustration is how we
+    keep the gap visible instead of abstract.
+  </p>
+</figure>
+
+<style>
+  .member-surface {
+    --ms-accent: var(--accent-teal);
+    --ms-rail: var(--border-default);
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+
+  .ms-title {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--text-muted);
+    text-align: left;
+  }
+
+  .ms-intro {
+    margin: 0;
+    font-size: 0.9375rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+  }
+
+  /* The device: a bordered panel with a top bar labeled 'illustrative'.
+     Not a phone bezel — a civic "screen frame" that stays in the
+     institutional register rather than product-mockup territory. */
+  .ms-device {
+    background: var(--bg-card);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    margin-top: var(--space-sm);
+    box-shadow: var(--shadow-md);
+  }
+
+  .ms-device-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-md);
+    padding: var(--space-sm) var(--space-md);
+    background: var(--bg-surface);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .ms-device-label {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--ms-accent);
+  }
+
+  .ms-device-dots {
+    display: inline-flex;
+    gap: 4px;
+  }
+  .ms-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--border-default);
+  }
+
+  .ms-device-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+
+  /* Each panel is a "section" of the surface. No left accent color —
+     the icons + labels carry the meaning. Subtle hairlines between
+     panels make them read as stacked regions of the same screen. */
+  .ms-panel {
+    padding: var(--space-md) var(--space-lg);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+  .ms-panel:last-child {
+    border-bottom: none;
+  }
+
+  .ms-panel-head {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    margin-bottom: var(--space-sm);
+  }
+
+  .ms-panel-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    flex-shrink: 0;
+    color: var(--ms-accent);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: var(--bg-surface);
+  }
+
+  .ms-panel-eyebrow {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-muted);
+  }
+
+  .ms-panel-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+  }
+
+  .ms-panel-body p {
+    margin: 0;
+  }
+
+  .ms-primary {
+    font-size: 0.9375rem;
+    color: var(--text-primary);
+    line-height: 1.5;
+  }
+
+  .ms-primary strong {
+    color: var(--text-heading);
+    font-weight: 600;
+  }
+
+  .ms-secondary {
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+    line-height: 1.5;
+  }
+
+  .ms-secondary strong {
+    color: var(--text-heading);
+    font-weight: 600;
+  }
+
+  .ms-scope-type {
+    color: var(--text-muted);
+    font-size: 0.8125rem;
+  }
+
+  .ms-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+    margin-top: var(--space-xs);
+  }
+
+  .ms-chip {
+    display: inline-block;
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 0.25em 0.65em;
+    border-radius: 999px;
+    border: 1px solid var(--border-default);
+    background: var(--bg-surface);
+    color: var(--text-muted);
+    white-space: nowrap;
+  }
+
+  /* Governed social accounting stat list.
+     NEVER a "balance" row. Each stat labels its nature explicitly. */
+  .ms-stat-list {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-sm);
+    margin: var(--space-xs) 0 0;
+    padding: 0;
+  }
+
+  @media (min-width: 520px) {
+    .ms-stat-list {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+
+  .ms-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .ms-stat dt {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-muted);
+  }
+
+  .ms-stat dd {
+    margin: 0;
+    font-family: var(--font-heading);
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-heading);
+    line-height: 1.3;
+  }
+
+  .ms-receipt-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
+
+  .ms-receipt-list li {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto auto;
+    column-gap: var(--space-sm);
+    row-gap: 2px;
+    padding: var(--space-xs) 0;
+  }
+
+  .ms-receipt-id {
+    grid-column: 1;
+    grid-row: 1 / span 2;
+    align-self: start;
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--ms-accent);
+    padding-top: 0.15em;
+    min-width: 2.75em;
+  }
+
+  .ms-receipt-text {
+    grid-column: 2;
+    grid-row: 1;
+    font-size: 0.875rem;
+    color: var(--text-primary);
+    line-height: 1.4;
+  }
+
+  .ms-receipt-stamp {
+    grid-column: 2;
+    grid-row: 2;
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+  }
+
+  /* Dashed "illustrative, not shipped" footer — same grammar as the
+     ClosureLoop return card and the ScopeModel footer caption, so
+     pages carrying multiple primitives share visual language. */
+  .ms-foot {
+    margin: var(--space-md) 0 0;
+    padding: var(--space-md) var(--space-lg);
+    background: var(--bg-surface);
+    border: 1px dashed var(--border-default);
+    border-radius: var(--radius-md);
+    font-size: 0.875rem;
+    line-height: 1.6;
+    color: var(--text-muted);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+  }
+
+  .ms-foot-eyebrow {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--accent-amber);
+  }
+</style>

--- a/website/src/components/ProvenanceTrail.astro
+++ b/website/src/components/ProvenanceTrail.astro
@@ -1,0 +1,279 @@
+---
+// ProvenanceTrail.astro — the flow from a proposal to its durable receipt.
+//
+// ICN's strongest real capability is institutional memory: the chain that
+// carries a decision forward through its effects and produces a receipt
+// that can be walked back to the authority that produced it. This
+// component makes that chain visible.
+//
+// Flow:
+//   proposal → decision → execution → effect → receipt
+//
+// Each step maps to a canonical icon from the ICN symbol family:
+//   proposal  → governance (the assembly proposes)
+//   decision  → authority  (the decision grants authorization)
+//   execution → execution  (the action takes operational effect)
+//   effect    → accounting (the effect is recorded in state)
+//   receipt   → provenance (the receipt makes the chain durable)
+//
+// Responsive: horizontal row on desktop with → connectors, vertical
+// stack on mobile with ↓ connectors. Same component, same data.
+//
+// Meaning never depends on color alone: icon silhouettes + labels +
+// numeric order + directional arrows carry the signal. Verified in
+// grayscale.
+
+import Icon from './Icon.astro';
+import type { IconName } from '../data/icons';
+
+export interface Props {
+  title?: string;
+}
+
+const { title = 'How a decision becomes a receipt' } = Astro.props;
+
+interface Step {
+  n: string;
+  label: string;
+  gloss: string;
+  icon: IconName;
+}
+
+const steps: Step[] = [
+  {
+    n: '01',
+    label: 'Proposal',
+    gloss: 'A member or scope proposes an action.',
+    icon: 'governance',
+  },
+  {
+    n: '02',
+    label: 'Decision',
+    gloss: 'The scope decides under its rules. The decision grants authorization.',
+    icon: 'authority',
+  },
+  {
+    n: '03',
+    label: 'Execution',
+    gloss: 'The authorized action becomes operational effect.',
+    icon: 'execution',
+  },
+  {
+    n: '04',
+    label: 'Effect',
+    gloss: 'The effect is recorded — obligations, allocations, state.',
+    icon: 'accounting',
+  },
+  {
+    n: '05',
+    label: 'Receipt',
+    gloss: 'A durable receipt ties the effect back to the authority that produced it.',
+    icon: 'provenance',
+  },
+];
+---
+
+<figure
+  class="provenance-trail"
+  aria-label="The provenance trail: how a proposal in ICN becomes a durable institutional receipt"
+>
+  <figcaption class="trail-title">{title}</figcaption>
+
+  <p class="trail-intro">
+    Every ICN action leaves a trail. The trail is not a log file —
+    it is the chain by which a decision becomes an institutional fact
+    that can be walked back to the authority that produced it.
+  </p>
+
+  <ol class="trail-steps" role="list">
+    {steps.map((s, i) => (
+      <>
+        <li class="trail-step" id={`trail-${s.n}`}>
+          <div class="trail-step-inner">
+            <div class="trail-head">
+              <span class="trail-number" aria-hidden="true">{s.n}</span>
+              <span class="trail-icon" aria-hidden="true">
+                <Icon name={s.icon} size={22} />
+              </span>
+            </div>
+            <div class="trail-body">
+              <span class="trail-label">{s.label}</span>
+              <span class="trail-gloss">{s.gloss}</span>
+            </div>
+          </div>
+        </li>
+        {i < steps.length - 1 && (
+          <li class="trail-connector" aria-hidden="true" role="presentation">
+            <span class="trail-arrow-down">↓</span>
+          </li>
+        )}
+      </>
+    ))}
+  </ol>
+
+  <p class="trail-foot">
+    <span class="trail-foot-eyebrow">Proof flows forward</span>
+    The receipt at step 05 is not the end. It becomes part of the record
+    that confers standing and authority for the next round of decisions.
+    Institutional memory is how ICN ties one action to the next.
+  </p>
+</figure>
+
+<style>
+  .provenance-trail {
+    --trail-accent: var(--accent-teal);
+    --trail-dim: var(--border-default);
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+
+  .trail-title {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--text-muted);
+    text-align: left;
+  }
+
+  .trail-intro {
+    margin: 0;
+    font-size: 0.9375rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+  }
+
+  /* Mobile-first: vertical stack with down arrows between steps. */
+  .trail-steps {
+    list-style: none;
+    padding: 0;
+    margin: var(--space-sm) 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .trail-step {
+    position: relative;
+  }
+
+  .trail-step-inner {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+    padding: var(--space-md) var(--space-lg);
+    background: var(--bg-card);
+    border: 1px solid var(--border-subtle);
+    border-left: 3px solid var(--trail-accent);
+    border-radius: var(--radius-md);
+    transition:
+      border-color var(--duration-fast) var(--ease-out),
+      background var(--duration-fast) var(--ease-out);
+  }
+
+  .trail-step-inner:hover {
+    border-color: var(--trail-accent);
+    background: var(--bg-card-hover);
+  }
+
+  .trail-head {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+  }
+
+  .trail-number {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    font-weight: 500;
+    letter-spacing: 0.1em;
+    color: var(--trail-accent);
+    flex-shrink: 0;
+  }
+
+  .trail-icon {
+    flex-shrink: 0;
+    color: var(--trail-accent);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: var(--bg-surface);
+  }
+
+  .trail-body {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .trail-label {
+    font-family: var(--font-heading);
+    font-weight: 700;
+    font-size: 1rem;
+    color: var(--text-heading);
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+  }
+
+  .trail-gloss {
+    font-size: 0.875rem;
+    color: var(--text-muted);
+    line-height: 1.55;
+  }
+
+  /* Connector between steps. Mobile default = down arrow in a centered
+     column. Desktop flips to a right arrow (see min-width breakpoint). */
+  .trail-connector {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-sm) 0;
+    color: var(--text-muted);
+    font-size: 1.125rem;
+    line-height: 1;
+  }
+
+  .trail-arrow-down {
+    display: inline;
+  }
+
+  /* Proof-flow footer — dashed card mirroring the ClosureLoop return card
+     so pages carrying both primitives share grammar. */
+  .trail-foot {
+    margin: var(--space-md) 0 0;
+    padding: var(--space-md) var(--space-lg);
+    background: var(--bg-surface);
+    border: 1px dashed var(--border-default);
+    border-radius: var(--radius-md);
+    font-size: 0.875rem;
+    line-height: 1.6;
+    color: var(--text-muted);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+  }
+
+  .trail-foot-eyebrow {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--trail-accent);
+  }
+
+  /* ProvenanceTrail stacks vertically at every viewport width. Pages
+     that host the component use narrow prose containers (~780px) so a
+     horizontal 5-card layout would be cramped regardless of viewport.
+     Vertical stacking also matches the ClosureLoop grammar — both
+     primitives flow top-to-bottom, reinforcing the "reading as walking"
+     metaphor the design language uses. */
+</style>

--- a/website/src/components/ReadingLadder.astro
+++ b/website/src/components/ReadingLadder.astro
@@ -1,0 +1,465 @@
+---
+// ReadingLadder.astro — the public-narrative reading-order indicator.
+//
+// Renders the canonical 5-step ladder defined in src/data/readingOrder.ts
+// at the bottom of every public narrative page, marking the reader's
+// current position and showing previous/next destinations.
+//
+// Design rules:
+//   - shows the full ladder, not just the immediate neighbors,
+//     so the reader sees the whole sequence at a glance
+//   - uses the existing station-number mono pill grammar from ClosureLoop
+//   - "current" state carries a teal accent + dot marker AND a label
+//     ("you are here") so meaning never depends on color alone
+//   - works on mobile with a single-column stack
+//   - works in grayscale: current step is distinguishable by its dot
+//     marker, its border, and its label
+//   - the homepage, /about, /architecture, /community, /blog are NOT
+//     part of the ladder and should not render this component
+//   - step 5 is a fork (For Cooperatives | For Developers); rendered as
+//     a parallel pair under a shared "05" number
+//
+// Usage:
+//   <ReadingLadder current="what-is-icn" />
+//   <ReadingLadder current="for-cooperatives" />
+//
+// Optional slot for page-specific alt CTAs that are not part of the
+// ladder (e.g. "GitHub ↗" or "Back to How It Works"):
+//   <ReadingLadder current="how-it-works">
+//     <a slot="extras" href="...">...</a>
+//   </ReadingLadder>
+
+import {
+  LADDER_STEPS,
+  LADDER_FORK,
+  getNeighbors,
+  type LadderSlug,
+} from '../data/readingOrder';
+
+export interface Props {
+  current: LadderSlug;
+}
+
+const { current } = Astro.props;
+
+const neighbors = getNeighbors(current);
+
+// Helper: is this step the current one?
+const isCurrent = (slug: string) => slug === current;
+
+// Helper: type guard for the fork's "next"
+function isFork(
+  next: ReturnType<typeof getNeighbors>['next']
+): next is typeof LADDER_FORK {
+  return next !== null && 'options' in next;
+}
+---
+
+<nav class="reading-ladder" aria-label="Public reading order">
+  <div class="ladder-eyebrow">Reading order</div>
+
+  <ol class="ladder-rail" role="list">
+    {LADDER_STEPS.map((step) => (
+      <li class:list={['ladder-step', { 'is-current': isCurrent(step.slug) }]}>
+        {isCurrent(step.slug) ? (
+          <div class="ladder-step-inner">
+            <span class="ladder-marker" aria-hidden="true"></span>
+            <span class="ladder-num">{step.n}</span>
+            <span class="ladder-label">{step.label}</span>
+            <span class="ladder-here">you are here</span>
+          </div>
+        ) : (
+          <a href={step.href} class="ladder-step-inner ladder-link">
+            <span class="ladder-num">{step.n}</span>
+            <span class="ladder-label">{step.label}</span>
+          </a>
+        )}
+      </li>
+    ))}
+
+    <li class:list={[
+      'ladder-step',
+      'ladder-step-fork',
+      { 'is-current': LADDER_FORK.options.some((o) => isCurrent(o.slug)) },
+    ]}>
+      <div class="ladder-fork">
+        <span class="ladder-fork-num">{LADDER_FORK.n}</span>
+        <div class="ladder-fork-options">
+          {LADDER_FORK.options.map((opt) => (
+            isCurrent(opt.slug) ? (
+              <div class="ladder-fork-opt is-current">
+                <span class="ladder-marker" aria-hidden="true"></span>
+                <span class="ladder-label">{opt.label}</span>
+                <span class="ladder-here">you are here</span>
+              </div>
+            ) : (
+              <a href={opt.href} class="ladder-fork-opt ladder-link">
+                <span class="ladder-label">{opt.label}</span>
+              </a>
+            )
+          ))}
+        </div>
+      </div>
+    </li>
+  </ol>
+
+  <div class="ladder-navigation">
+    {neighbors.prev && (
+      <a href={neighbors.prev.href} class="ladder-nav ladder-nav-prev">
+        <span class="ladder-nav-eyebrow">← Previous</span>
+        <span class="ladder-nav-label">{neighbors.prev.label}</span>
+      </a>
+    )}
+    {neighbors.next && (
+      <div class="ladder-nav-next-wrap">
+        {isFork(neighbors.next) ? (
+          <>
+            <span class="ladder-nav-eyebrow">Next — pick one →</span>
+            <div class="ladder-nav-fork">
+              {neighbors.next.options.map((opt) => (
+                <a href={opt.href} class="ladder-nav ladder-nav-next">
+                  <span class="ladder-nav-label">{opt.label}</span>
+                </a>
+              ))}
+            </div>
+          </>
+        ) : (
+          <a href={neighbors.next.href} class="ladder-nav ladder-nav-next">
+            <span class="ladder-nav-eyebrow">Next →</span>
+            <span class="ladder-nav-label">{neighbors.next.label}</span>
+          </a>
+        )}
+      </div>
+    )}
+  </div>
+
+  {Astro.slots.has('extras') && (
+    <div class="ladder-extras">
+      <slot name="extras" />
+    </div>
+  )}
+</nav>
+
+<style>
+  .reading-ladder {
+    --ladder-accent: var(--accent-teal);
+    --ladder-rail: var(--border-default);
+    margin: 0;
+    padding: var(--space-xl) 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+  }
+
+  .ladder-eyebrow {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--text-muted);
+    text-align: center;
+  }
+
+  /* The rail: shows ALL five steps so the reader sees the sequence
+     as a whole, not just the immediate neighbors. Mobile-first stack. */
+  .ladder-rail {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
+
+  .ladder-step {
+    position: relative;
+  }
+
+  .ladder-step-inner {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+    padding: var(--space-sm) var(--space-md);
+    background: var(--bg-card);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    text-decoration: none;
+    color: inherit;
+    transition:
+      border-color var(--duration-fast) var(--ease-out),
+      background var(--duration-fast) var(--ease-out);
+  }
+
+  .ladder-link:hover {
+    border-color: var(--ladder-accent);
+    background: var(--bg-card-hover);
+  }
+
+  .ladder-num {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    font-weight: 500;
+    letter-spacing: 0.1em;
+    color: var(--text-muted);
+    flex-shrink: 0;
+    min-width: 1.75em;
+  }
+
+  .ladder-label {
+    font-family: var(--font-heading);
+    font-weight: 600;
+    font-size: 0.9375rem;
+    color: var(--text-primary);
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+    flex: 1;
+    min-width: 0;
+  }
+
+  /* Current step: teal-bordered, with a dot marker AND a "you are here"
+     label. Color is reinforcement; the marker dot and the label carry the
+     meaning. Grayscale-safe. */
+  .ladder-step.is-current .ladder-step-inner,
+  .ladder-step.is-current .ladder-fork-opt.is-current {
+    border-color: var(--ladder-accent);
+    background: var(--bg-card-hover);
+  }
+
+  .ladder-step.is-current .ladder-num {
+    color: var(--ladder-accent);
+  }
+
+  .ladder-marker {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--ladder-accent);
+    flex-shrink: 0;
+  }
+
+  .ladder-here {
+    font-family: var(--font-mono);
+    font-size: 0.625rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--ladder-accent);
+    padding: 0.2em 0.6em;
+    border: 1px solid var(--ladder-accent);
+    border-radius: 999px;
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
+
+  /* Fork step: parallel pair under a shared "05" number. */
+  .ladder-fork {
+    display: flex;
+    align-items: stretch;
+    gap: var(--space-sm);
+    padding: var(--space-sm) var(--space-md);
+    background: var(--bg-card);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+  }
+
+  .ladder-step.is-current .ladder-fork {
+    border-color: var(--ladder-accent);
+    background: var(--bg-card-hover);
+  }
+
+  .ladder-fork-num {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    font-weight: 500;
+    letter-spacing: 0.1em;
+    color: var(--text-muted);
+    flex-shrink: 0;
+    min-width: 1.75em;
+    align-self: center;
+  }
+
+  .ladder-step.is-current .ladder-fork-num {
+    color: var(--ladder-accent);
+  }
+
+  .ladder-fork-options {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    flex: 1;
+    min-width: 0;
+  }
+
+  .ladder-fork-opt {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: var(--space-xs) var(--space-sm);
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    text-decoration: none;
+    color: inherit;
+    transition:
+      border-color var(--duration-fast) var(--ease-out),
+      background var(--duration-fast) var(--ease-out);
+  }
+
+  .ladder-fork-opt.ladder-link:hover {
+    border-color: var(--ladder-accent);
+    background: var(--bg-surface);
+  }
+
+  .ladder-fork-opt.is-current {
+    border-color: var(--ladder-accent);
+    background: var(--bg-surface);
+  }
+
+  /* Wider viewports: render the rail horizontally so the sequence is
+     scannable in a single line. Each step takes equal width. */
+  @media (min-width: 720px) {
+    .ladder-rail {
+      flex-direction: row;
+      align-items: stretch;
+      gap: var(--space-sm);
+    }
+    .ladder-step {
+      flex: 1 1 0;
+      min-width: 0;
+    }
+    .ladder-step-inner {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: var(--space-xs);
+      padding: var(--space-md);
+      height: 100%;
+    }
+    .ladder-num {
+      min-width: 0;
+    }
+    .ladder-label {
+      flex: none;
+    }
+    .ladder-here {
+      align-self: flex-start;
+    }
+    .ladder-step-fork .ladder-fork {
+      flex-direction: column;
+      align-items: stretch;
+      padding: var(--space-md);
+      height: 100%;
+    }
+    .ladder-fork-num {
+      min-width: 0;
+      align-self: flex-start;
+    }
+  }
+
+  /* Previous / next navigation block — explicit reading direction. */
+  .ladder-navigation {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+    padding-top: var(--space-md);
+    border-top: 1px solid var(--border-subtle);
+  }
+
+  .ladder-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: var(--space-sm) var(--space-md);
+    background: var(--bg-card);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    text-decoration: none;
+    color: inherit;
+    transition:
+      border-color var(--duration-fast) var(--ease-out),
+      background var(--duration-fast) var(--ease-out);
+  }
+
+  .ladder-nav:hover {
+    border-color: var(--ladder-accent);
+    background: var(--bg-card-hover);
+  }
+
+  .ladder-nav-eyebrow {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-muted);
+  }
+
+  .ladder-nav-label {
+    font-family: var(--font-heading);
+    font-weight: 600;
+    font-size: 1rem;
+    color: var(--text-heading);
+    line-height: 1.3;
+  }
+
+  .ladder-nav-next-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
+
+  .ladder-nav-next-wrap > .ladder-nav-eyebrow {
+    padding: 0 var(--space-md);
+  }
+
+  .ladder-nav-fork {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
+
+  @media (min-width: 720px) {
+    .ladder-navigation {
+      flex-direction: row;
+      align-items: stretch;
+      justify-content: space-between;
+      gap: var(--space-md);
+    }
+    .ladder-nav {
+      flex: 1 1 0;
+      min-width: 0;
+    }
+    .ladder-nav-prev {
+      text-align: left;
+    }
+    .ladder-nav-next {
+      text-align: right;
+    }
+    .ladder-nav-next-wrap {
+      flex: 1 1 0;
+      min-width: 0;
+    }
+    .ladder-nav-next-wrap > .ladder-nav-eyebrow {
+      padding: 0;
+      text-align: right;
+    }
+    .ladder-nav-fork {
+      flex-direction: row;
+      gap: var(--space-sm);
+    }
+    .ladder-nav-fork .ladder-nav {
+      flex: 1 1 0;
+    }
+  }
+
+  /* Optional extras row — for page-specific alt CTAs that are not
+     part of the ladder (e.g. "GitHub ↗"). Rendered only when a slot
+     named "extras" is provided. */
+  .ladder-extras {
+    display: flex;
+    gap: var(--space-sm);
+    flex-wrap: wrap;
+    justify-content: center;
+    padding-top: var(--space-md);
+    border-top: 1px solid var(--border-subtle);
+  }
+</style>

--- a/website/src/components/ScopeModel.astro
+++ b/website/src/components/ScopeModel.astro
@@ -1,0 +1,252 @@
+---
+// ScopeModel.astro — The five scopes of institutional action in ICN.
+//
+// Scopes are contexts of action, not levels of hierarchy. When a member
+// acts inside ICN, they are always acting inside one or more scopes at
+// once: self, cooperative, community, federation, commons. Each scope
+// has its own rules, its own accounting, and its own receipts. An
+// action, a decision, a rule, or a proof belongs to one or more scopes
+// at once — that's the point.
+//
+// This component makes that visible. It is the second canonical
+// diagram primitive of the ICN civic design language, alongside
+// ClosureLoop. It uses the Icon component and the shared token system.
+// Meaning never depends on color alone — structure + icon silhouette +
+// text label carry the signal.
+//
+// Usage:
+//   <ScopeModel />                     default title
+//   <ScopeModel title="Where you act" /> custom title
+//
+// See docs/design-language/brief-v0.md and concept-map.md.
+
+import Icon from './Icon.astro';
+import type { IconName } from '../data/icons';
+
+export interface Props {
+  title?: string;
+}
+
+const { title = 'Five scopes of action' } = Astro.props;
+
+interface Scope {
+  id: string;
+  label: string;
+  gloss: string;
+  icon: IconName;
+}
+
+// Ordered from widest shared context to most personal.
+// This ordering is explicit and documented in the figcaption: it is
+// NOT a hierarchy. It is "walk down from the most shared to the most
+// personal — a single action often touches several at once."
+const scopes: Scope[] = [
+  {
+    id: 'commons',
+    label: 'Commons',
+    gloss: 'Shared resources governed by the institutions that use them.',
+    icon: 'commons',
+  },
+  {
+    id: 'federation',
+    label: 'Federation',
+    gloss: 'How distinct institutions coordinate without merging.',
+    icon: 'federation',
+  },
+  {
+    id: 'community',
+    label: 'Community',
+    gloss: 'A group of members with shared rules, purpose, and standing.',
+    icon: 'governance',
+  },
+  {
+    id: 'cooperative',
+    label: 'Cooperative',
+    gloss: 'A scoped institution owned and governed by its members.',
+    icon: 'authority',
+  },
+  {
+    id: 'self',
+    label: 'Self',
+    gloss: 'The individual member — the identity that holds standing in each scope above.',
+    icon: 'identity',
+  },
+];
+---
+
+<figure
+  class="scope-model"
+  aria-label="ICN's five scopes of institutional action, from the most shared context to the most personal"
+>
+  <figcaption class="scope-title">{title}</figcaption>
+
+  <p class="scope-intro">
+    Scope is <strong>context of action</strong>, not hierarchy.
+    Every ICN action belongs to one or more scopes at once.
+  </p>
+
+  <ol class="scope-rail" role="list">
+    {scopes.map((s) => (
+      <li class="scope-row" id={`scope-${s.id}`}>
+        <span class="scope-rail-node" aria-hidden="true"></span>
+        <div class="scope-card">
+          <span class="scope-icon" aria-hidden="true">
+            <Icon name={s.icon} size={22} />
+          </span>
+          <div class="scope-body">
+            <span class="scope-label">{s.label}</span>
+            <span class="scope-gloss">{s.gloss}</span>
+          </div>
+        </div>
+      </li>
+    ))}
+  </ol>
+
+  <p class="scope-foot">
+    Read top to bottom: widest shared context down to the most personal.
+    A single decision can touch several scopes at once — that is the point.
+    The receipt it produces is tagged with every scope it passed through.
+  </p>
+</figure>
+
+<style>
+  .scope-model {
+    --rail-color: var(--accent-teal);
+    --rail-dim: var(--border-default);
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+
+  .scope-title {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--text-muted);
+    text-align: left;
+  }
+
+  .scope-intro {
+    margin: 0;
+    font-size: 0.9375rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+  }
+
+  .scope-intro strong {
+    color: var(--text-heading);
+    font-weight: 600;
+  }
+
+  /* The rail: a single vertical line connecting all five scopes so the
+     visual communicates "you are always inside all of these at once."
+     The rail runs the full height of the list; each row has a node
+     where it touches the rail. */
+  .scope-rail {
+    list-style: none;
+    padding: 0;
+    margin: var(--space-sm) 0 0;
+    position: relative;
+  }
+
+  .scope-rail::before {
+    content: '';
+    position: absolute;
+    left: 0.75rem;
+    top: 1.1rem;
+    bottom: 1.1rem;
+    width: 2px;
+    background: var(--rail-color);
+    border-radius: 1px;
+  }
+
+  .scope-row {
+    position: relative;
+    padding-left: 2rem;
+    padding-bottom: var(--space-md);
+  }
+
+  .scope-row:last-child {
+    padding-bottom: 0;
+  }
+
+  .scope-rail-node {
+    position: absolute;
+    left: calc(0.75rem - 5px);
+    top: 1.05rem;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--bg-primary);
+    border: 2px solid var(--rail-color);
+  }
+
+  .scope-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    padding: var(--space-md) var(--space-lg);
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-md);
+    transition:
+      border-color var(--duration-fast) var(--ease-out),
+      background var(--duration-fast) var(--ease-out);
+  }
+
+  .scope-card:hover {
+    border-color: var(--rail-color);
+    background: var(--bg-card-hover);
+  }
+
+  .scope-icon {
+    flex-shrink: 0;
+    color: var(--rail-color);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: var(--bg-surface);
+  }
+
+  .scope-body {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .scope-label {
+    font-family: var(--font-heading);
+    font-weight: 700;
+    font-size: 1rem;
+    color: var(--text-heading);
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+  }
+
+  .scope-gloss {
+    font-size: 0.875rem;
+    color: var(--text-muted);
+    line-height: 1.55;
+  }
+
+  .scope-foot {
+    margin: var(--space-md) 0 0;
+    padding: var(--space-md) var(--space-lg);
+    background: var(--bg-surface);
+    border: 1px dashed var(--border-default);
+    border-radius: var(--radius-md);
+    font-size: 0.875rem;
+    line-height: 1.6;
+    color: var(--text-muted);
+  }
+</style>

--- a/website/src/data/icons.ts
+++ b/website/src/data/icons.ts
@@ -1,0 +1,248 @@
+// ICN Icon Sprite — canonical institutional icons for the design language.
+//
+// Each icon maps to a canonical concept id from
+// docs/design-language/concept-map.md. The paths use currentColor for stroke
+// and are designed for a 24x24 viewBox with 1.5px strokes and round caps.
+//
+// Style rules (enforced by review, not runtime):
+//   - stroke-width: 1.5 (inherited from the Icon component)
+//   - stroke-linecap: round
+//   - stroke-linejoin: round
+//   - no fills (fill="none" on the parent svg)
+//   - no color baked into paths — parent inherits via currentColor
+//   - designed to read cleanly at 16-20px
+//   - silhouettes distinct from each other at small sizes
+//   - institutional line-art: calm, precise, not decorative
+//
+// Adding an icon:
+//   1. Add an entry to the ICONS map keyed by concept id.
+//   2. Provide { label, description, paths } — paths is an array of
+//      JSX-ready path strings (just the "d" attribute value).
+//   3. Pair with a canonical concept in docs/design-language/concept-map.md
+//      so the concept map can reference the icon slug.
+//   4. Review at 16px, 20px, and 24px. Silhouette should remain distinct.
+
+export interface IconDef {
+  /** Canonical concept id (matches concept-map.md). */
+  id: string;
+  /** Default accessible label when the icon is used standalone. */
+  label: string;
+  /** Short description — what this icon represents. */
+  description: string;
+  /** Array of SVG path "d" values rendered as <path d={...} /> */
+  paths: string[];
+  /** Optional circles, rects, or other primitive shapes. */
+  extras?: Array<
+    | { type: 'circle'; cx: number; cy: number; r: number; fill?: string }
+    | { type: 'line'; x1: number; y1: number; x2: number; y2: number }
+  >;
+}
+
+export const ICONS: Record<string, IconDef> = {
+  // ─── Closure loop stations ───────────────────────────────────
+  identity: {
+    id: 'identity',
+    label: 'Identity',
+    description: 'Cryptographic identity held by the member.',
+    // A person silhouette with a small key mark — identity as held, not issued.
+    paths: [
+      // head
+      'M12 3.75a3.25 3.25 0 1 0 0 6.5 3.25 3.25 0 0 0 0-6.5Z',
+      // shoulders / body
+      'M5.5 20.25c0-3.25 2.9-5.75 6.5-5.75s6.5 2.5 6.5 5.75',
+    ],
+  },
+
+  standing: {
+    id: 'standing',
+    label: 'Standing',
+    description: 'Provable participation inside a scope.',
+    // A badge/seal with a check: recognized status as verifiable claim.
+    paths: [
+      // shield/badge outline
+      'M12 3.25 5.5 6v5.5c0 4.25 2.75 7.75 6.5 9.25 3.75-1.5 6.5-5 6.5-9.25V6L12 3.25Z',
+      // check mark inside
+      'm9 11.75 2.25 2.25L15.25 10',
+    ],
+  },
+
+  authority: {
+    id: 'authority',
+    label: 'Authority',
+    description: 'What you are allowed to do, derived from scope rules.',
+    // A rounded rectangular seal-stamp: institutional mandate, not "power."
+    paths: [
+      // outer seal
+      'M5 7.5A2.5 2.5 0 0 1 7.5 5h9A2.5 2.5 0 0 1 19 7.5v9a2.5 2.5 0 0 1-2.5 2.5h-9A2.5 2.5 0 0 1 5 16.5v-9Z',
+      // inner ring
+      'M12 9.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5Z',
+      // stamp base line
+      'M8 19.25h8',
+    ],
+  },
+
+  governance: {
+    id: 'governance',
+    label: 'Governance',
+    description: 'How group decisions are made.',
+    // Three nodes arranged around a center point — an assembly / council
+    // meeting around a shared decision. Simpler silhouette than three full
+    // figures, reads cleanly at 16-22px.
+    paths: [
+      // top node
+      'M12 4.5a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z',
+      // bottom-left node
+      'M5.5 15a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z',
+      // bottom-right node
+      'M18.5 15a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z',
+      // center dot — the shared matter being decided
+      'M12 13.25a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z',
+      // connecting lines from each node to center
+      'M12 8.5 12 11.5',
+      'm7 14.5 4-2',
+      'm17 14.5-4-2',
+    ],
+  },
+
+  policy: {
+    id: 'policy',
+    label: 'Policy',
+    description: 'The shared rules that bind practice.',
+    // A document with horizontal rule-lines: policy as written, binding rules.
+    paths: [
+      // document frame
+      'M6.75 4.25h8.5l3 3v11.5a1.5 1.5 0 0 1-1.5 1.5H6.75a1.5 1.5 0 0 1-1.5-1.5V5.75a1.5 1.5 0 0 1 1.5-1.5Z',
+      // fold corner
+      'M15.25 4.25v3h3',
+      // rule lines
+      'M8.5 12h7',
+      'M8.5 15h7',
+      'M8.5 9.5h3.5',
+    ],
+  },
+
+  accounting: {
+    id: 'accounting',
+    label: 'Accounting',
+    description: 'Obligations, allocations, and mutual-credit positions.',
+    // A two-pan balance: relational accounting, not commerce.
+    paths: [
+      // vertical staff
+      'M12 4.25v15.5',
+      // horizontal beam
+      'M5.25 8.25h13.5',
+      // left pan + chains
+      'M5.25 8.25 3 13.5h4.5L5.25 8.25Z',
+      // right pan + chains
+      'M18.75 8.25 16.5 13.5H21l-2.25-5.25Z',
+      // base
+      'M8.5 19.75h7',
+    ],
+  },
+
+  execution: {
+    id: 'execution',
+    label: 'Execution',
+    description: 'Where accepted decisions become operational effect.',
+    // An arrow passing through a threshold: decision becoming action.
+    paths: [
+      // threshold/gate lines
+      'M5.25 8.5v7',
+      'M18.75 8.5v7',
+      // arrow shaft
+      'M5.25 12h13.5',
+      // arrowhead
+      'm15 8.5 3.75 3.5L15 15.5',
+    ],
+  },
+
+  provenance: {
+    id: 'provenance',
+    label: 'Receipts & Provenance',
+    description: 'The chain from authority to outcome.',
+    // Three linked rectangular records — institutional memory as a chain.
+    paths: [
+      // record 1
+      'M3.25 7.75h5v8.5h-5z',
+      // record 2
+      'M9.5 7.75h5v8.5h-5z',
+      // record 3
+      'M15.75 7.75h5v8.5h-5z',
+      // link between 1 and 2
+      'M8.25 12h1.25',
+      // link between 2 and 3
+      'M14.5 12h1.25',
+    ],
+  },
+
+  federation: {
+    id: 'federation',
+    label: 'Federation',
+    description: 'How distinct institutions coordinate without merging.',
+    // Three circles connected by lines, no central hub — plurality, not control.
+    paths: [
+      // circle 1 (top)
+      'M12 3.25a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5Z',
+      // circle 2 (bottom left)
+      'M5.5 14.25a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5Z',
+      // circle 3 (bottom right)
+      'M18.5 14.25a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5Z',
+      // connecting lines
+      'M10.5 7 7 13',
+      'M13.5 7 17 13',
+      'M8 16.75h8',
+    ],
+  },
+
+  commons: {
+    id: 'commons',
+    label: 'Commons',
+    description: 'Shared resources governed by participating institutions.',
+    // A shared field/grid with four corners — common ground.
+    paths: [
+      // outer frame
+      'M4.25 4.25h15.5v15.5H4.25z',
+      // cross-hatch field
+      'M4.25 9.5h15.5',
+      'M4.25 14.5h15.5',
+      'M9.5 4.25v15.5',
+      'M14.5 4.25v15.5',
+    ],
+  },
+
+  member_experience: {
+    id: 'member_experience',
+    label: 'Member Experience',
+    description: 'Where the member inhabits the system through a surface they can see and act on.',
+    // A rounded surface frame with a simplified person silhouette inside.
+    // The frame = the member-facing layer; the person = the member inhabiting
+    // it. Distinct from `identity` (person without frame) and from
+    // `authority` (rounded seal with a small centered circle inside):
+    // here the inner element is a head + shoulders, not a ring, so the
+    // silhouette reads as "person in context" even at 16px.
+    paths: [
+      // outer rounded-rect frame — the surface the member inhabits
+      'M5.25 5A2.25 2.25 0 0 1 7.5 2.75h9A2.25 2.25 0 0 1 18.75 5v14A2.25 2.25 0 0 1 16.5 21.25h-9A2.25 2.25 0 0 1 5.25 19V5Z',
+      // small person head inside the frame
+      'M12 8.25a1.75 1.75 0 1 0 0 3.5 1.75 1.75 0 0 0 0-3.5Z',
+      // small person shoulders inside the frame
+      'M8.75 17.25c0-1.75 1.45-3 3.25-3s3.25 1.25 3.25 3',
+    ],
+  },
+};
+
+/** Ordered list of the nine closure-loop stations for use in ClosureLoop.
+    All nine stations now have canonical icons. */
+export const CLOSURE_STATION_ICONS: Array<keyof typeof ICONS> = [
+  'identity',
+  'standing',
+  'authority',
+  'governance',
+  'policy',
+  'accounting',
+  'execution',
+  'provenance',
+  'member_experience',
+];
+
+export type IconName = keyof typeof ICONS;

--- a/website/src/data/readingOrder.ts
+++ b/website/src/data/readingOrder.ts
@@ -1,0 +1,117 @@
+// readingOrder.ts — the canonical public reading-order ladder.
+//
+// This is the sequence the homepage's "Reading order" list points to and
+// the sequence the ReadingLadder component renders at the bottom of every
+// narrative page.
+//
+// IMPORTANT: this is *only* the public narrative ladder. Not every page
+// is on the ladder. The homepage (/) is the entry point, not a step.
+// /about and /architecture are intentionally outside the ladder. The
+// ladder must not pretend they belong to it.
+//
+// Step 5 forks: For Cooperatives and For Developers are alternate
+// endpoints, not sequential. A reader picks one based on who they are.
+// The component renders this fork explicitly.
+
+export interface LadderStep {
+  /** Sequence number, "01" through "05". */
+  n: string;
+  /** Page slug (matches activeNav prop on each page). */
+  slug: string;
+  /** Public-facing label. */
+  label: string;
+  /** href the step links to. */
+  href: string;
+}
+
+export interface LadderFork {
+  /** Sequence number for the forked endpoint. */
+  n: string;
+  /** Two parallel options. */
+  options: LadderStep[];
+}
+
+/** The five steps of the public narrative ladder.
+    Step 5 is a fork — see LADDER_FORK below. */
+export const LADDER_STEPS: LadderStep[] = [
+  {
+    n: '01',
+    slug: 'what-is-icn',
+    label: 'What is ICN',
+    href: '/what-is-icn',
+  },
+  {
+    n: '02',
+    slug: 'why-icn',
+    label: 'Why ICN',
+    href: '/why-icn',
+  },
+  {
+    n: '03',
+    slug: 'how-it-works',
+    label: 'How It Works',
+    href: '/how-it-works',
+  },
+  {
+    n: '04',
+    slug: 'whats-real-now',
+    label: "What's Real Now",
+    href: '/whats-real-now',
+  },
+];
+
+/** Step 5 is a fork: a reader picks an audience, not a sequence. */
+export const LADDER_FORK: LadderFork = {
+  n: '05',
+  options: [
+    {
+      n: '05',
+      slug: 'for-cooperatives',
+      label: 'For Cooperatives',
+      href: '/for-cooperatives',
+    },
+    {
+      n: '05',
+      slug: 'for-developers',
+      label: 'For Developers',
+      href: '/for-developers',
+    },
+  ],
+};
+
+/** Slugs that are valid `current` values for the ReadingLadder.
+    Anything else gets rejected at the component level so the ladder
+    can't be misused on a page that isn't part of the sequence. */
+export const LADDER_SLUGS = [
+  ...LADDER_STEPS.map((s) => s.slug),
+  ...LADDER_FORK.options.map((o) => o.slug),
+] as const;
+
+export type LadderSlug = (typeof LADDER_SLUGS)[number];
+
+/** Get the previous and next steps for a given slug. Used to render
+    the "←" and "→" navigation hints around the current position.
+    For the forked endpoint slugs, prev = step 04 and next = null. */
+export function getNeighbors(slug: LadderSlug): {
+  prev: LadderStep | null;
+  next: LadderStep | LadderFork | null;
+} {
+  const linearIdx = LADDER_STEPS.findIndex((s) => s.slug === slug);
+  if (linearIdx >= 0) {
+    const prev = linearIdx > 0 ? LADDER_STEPS[linearIdx - 1] : null;
+    const next =
+      linearIdx === LADDER_STEPS.length - 1
+        ? LADDER_FORK
+        : LADDER_STEPS[linearIdx + 1];
+    return { prev, next };
+  }
+  // Slug must be one of the fork endpoints.
+  const isFork = LADDER_FORK.options.some((o) => o.slug === slug);
+  if (isFork) {
+    return {
+      prev: LADDER_STEPS[LADDER_STEPS.length - 1],
+      next: null,
+    };
+  }
+  return { prev: null, next: null };
+}

--- a/website/src/data/roadmap.json
+++ b/website/src/data/roadmap.json
@@ -1,46 +1,53 @@
 {
-  "currentSprint": {
-    "number": 28,
-    "name": "Governance Dispatch Tranches",
-    "status": "active",
-    "detail": "Sprints 24–28 shipped (commons-compute spine, Flow 5 demo, gossip fan-out fix). Current workstream: post-Sprint-28 governance dispatch tranches wiring real executors for every accepted proposal payload. Tranches 9–16 merged (TrustThreshold, BondIssuance, ShareRedemption, LeaveFederation, SdisService executor, ReconfirmSteward, ReinstateSteward, SuspendSteward). Tranche 17 (UpdateJurisdictionTier) complete locally, pending push. Tranche 18 (TerminateClearing + RevokeVouch) up next."
+  "currentEmphasis": {
+    "title": "What the project is concentrating on right now",
+    "detail": "The active frontier is expanding execution coverage — the breadth with which accepted decisions carry into concrete operational effect. Governance-backed provenance and receipts are the load-bearing parts of the system today; work is ongoing to connect more of the decisions the substrate records to the actions those decisions are supposed to authorize."
   },
   "stages": [
     {
       "id": "A",
-      "label": "Stage A — Now",
-      "badge": "badge-teal",
-      "markerColor": "var(--accent-teal)",
-      "title": "Institution-in-a-Box",
-      "description": "Charter templates, guided cooperative formation, membership onboarding, treasury ledger, and proposal-to-vote loop. The minimum viable institution. Live on K3s with five cooperatives running governance, patronage settlement, and financial reporting.",
-      "status": "active"
+      "label": "Current emphasis",
+      "badge": "badge-green",
+      "markerColor": "var(--accent-green)",
+      "title": "Institution-in-a-box",
+      "description": "The core loop of cooperative life — identity, membership, proposals, decisions, and durable receipts — is the most mature part of the system. Governance-backed provenance and auditable coordination are load-bearing today. This is the part of ICN we are most willing to stand behind in public.",
+      "band": "strong"
     },
     {
       "id": "B",
-      "label": "Stage B — In Development",
-      "badge": "badge-blue",
-      "markerColor": "var(--accent-blue)",
-      "title": "Federation Layer",
-      "description": "Inter-cooperative trust and federated coordination live on K3s. Multiple cooperatives operate simultaneously with shared trust graphs, cross-coop governance receipts, and ledger integration. Formal treaty-based clearing and mutual credit settlement across organizations follow.",
-      "status": "in-progress"
+      "label": "Direction of work",
+      "badge": "badge-teal",
+      "markerColor": "var(--accent-teal)",
+      "title": "Execution coverage and shared rules",
+      "description": "Expanding the range of accepted decisions that translate cleanly into real operational effect, and the mechanisms that let shared rules bind practice rather than just describe it. This is the active frontier of the project. Real progress, real incompleteness — the direction is clear and the pace is real.",
+      "band": "advancing"
     },
     {
       "id": "C",
-      "label": "Stage C — In Development",
-      "badge": "badge-purple",
-      "markerColor": "var(--accent-purple)",
-      "title": "Compute Commons",
-      "description": "Trust-gated compute task admission is live: trust score enforcement, compute:write scope authorization, and ledger position integration are proven on K3s. Task execution by registered executor nodes and settlement receipt generation follow in the next sprint.",
-      "status": "in-progress"
+      "label": "Direction of work",
+      "badge": "badge-amber",
+      "markerColor": "var(--accent-amber)",
+      "title": "Federation and commons",
+      "description": "Inter-institutional coordination and shared resources across the network. Both are real, active subsystems with serious implementation behind them, and both are still maturing. In some places the implementation is ahead of the public-facing story, and the surfaces that would let outsiders see and evaluate this work are still being built.",
+      "band": "maturing"
     },
     {
       "id": "D",
-      "label": "Stage D",
+      "label": "Direction of work",
       "badge": "badge-amber",
       "markerColor": "var(--accent-amber)",
-      "title": "Civilization Tools",
-      "description": "Participatory budgeting at city scale. Municipal governance platforms. Public infrastructure coordination. The long-term vision: democratic technology governance beyond the co-op.",
-      "status": "vision"
+      "title": "Member-facing experience",
+      "description": "The surface through which ordinary members would interact with identity, governance, rules, accounting, receipts, and federation as one coherent environment. The capabilities underneath are real and in places strong. The interface on top is still catching up, and closing that gap is active work — not a finished capability.",
+      "band": "maturing"
+    },
+    {
+      "id": "E",
+      "label": "Long-term direction",
+      "badge": "badge-purple",
+      "markerColor": "var(--accent-purple)",
+      "title": "Public and civic-scale coordination",
+      "description": "Participatory budgeting, municipal governance, and public infrastructure coordination. The architecture is designed with this horizon in mind, but it is not where active work is concentrated today. When outsiders ask whether ICN does this, the honest answer is not yet — and we would rather say so than imply a schedule.",
+      "band": "notyet"
     }
   ]
 }

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -57,10 +57,11 @@ const jsonLd = {
   </script>
 </head>
 <body>
-  <nav class="nav" id="main-nav">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <nav class="nav" id="main-nav" aria-label="Primary">
     <div class="nav-inner">
-      <a href="/" class="nav-logo">
-        <svg class="nav-logo-svg" width="28" height="28" viewBox="0 0 128 128" fill="none">
+      <a href="/" class="nav-logo" aria-label="InterCooperative Network — home">
+        <svg class="nav-logo-svg" width="28" height="28" viewBox="0 0 128 128" fill="none" aria-hidden="true" focusable="false">
           <rect width="128" height="128" rx="28" fill="url(#nav-bg)"/>
           <line x1="64" y1="30" x2="34" y2="82" stroke="url(#nav-warm)" stroke-width="4" stroke-linecap="round" opacity="0.7"/>
           <line x1="64" y1="30" x2="94" y2="82" stroke="url(#nav-warm)" stroke-width="4" stroke-linecap="round" opacity="0.7"/>
@@ -78,29 +79,29 @@ const jsonLd = {
       </a>
 
       <ul class="nav-links" id="nav-links">
-        <li><a href="/about" class:list={[{ active: activeNav === 'about' || currentPath.startsWith('/about') }]}>About</a></li>
-        <li><a href="/docs" class:list={[{ active: activeNav === 'docs' || currentPath.startsWith('/docs') }]}>Docs</a></li>
-        <li><a href="/architecture" class:list={[{ active: activeNav === 'architecture' || currentPath.startsWith('/architecture') }]}>Architecture</a></li>
-        <li><a href="/roadmap" class:list={[{ active: activeNav === 'roadmap' || currentPath.startsWith('/roadmap') }]}>Roadmap</a></li>
-        <li><a href="/community" class:list={[{ active: activeNav === 'community' || currentPath.startsWith('/community') }]}>Community</a></li>
-        <li><a href="/blog" class:list={[{ active: activeNav === 'blog' || currentPath.startsWith('/blog') }]}>Blog</a></li>
+        <li><a href="/what-is-icn" class:list={[{ active: activeNav === 'what-is-icn' || currentPath.startsWith('/what-is-icn') }]} aria-current={activeNav === 'what-is-icn' || currentPath.startsWith('/what-is-icn') ? 'page' : undefined}>What is ICN</a></li>
+        <li><a href="/why-icn" class:list={[{ active: activeNav === 'why-icn' || currentPath.startsWith('/why-icn') }]} aria-current={activeNav === 'why-icn' || currentPath.startsWith('/why-icn') ? 'page' : undefined}>Why ICN</a></li>
+        <li><a href="/how-it-works" class:list={[{ active: activeNav === 'how-it-works' || currentPath.startsWith('/how-it-works') }]} aria-current={activeNav === 'how-it-works' || currentPath.startsWith('/how-it-works') ? 'page' : undefined}>How It Works</a></li>
+        <li><a href="/whats-real-now" class:list={[{ active: activeNav === 'whats-real-now' || currentPath.startsWith('/whats-real-now') }]} aria-current={activeNav === 'whats-real-now' || currentPath.startsWith('/whats-real-now') ? 'page' : undefined}>What's Real Now</a></li>
+        <li><a href="/for-cooperatives" class:list={[{ active: activeNav === 'for-cooperatives' || currentPath.startsWith('/for-cooperatives') }]} aria-current={activeNav === 'for-cooperatives' || currentPath.startsWith('/for-cooperatives') ? 'page' : undefined}>For Cooperatives</a></li>
+        <li><a href="/for-developers" class:list={[{ active: activeNav === 'for-developers' || currentPath.startsWith('/for-developers') }]} aria-current={activeNav === 'for-developers' || currentPath.startsWith('/for-developers') ? 'page' : undefined}>For Developers</a></li>
+        <li><a href="/docs" class:list={[{ active: activeNav === 'docs' || currentPath.startsWith('/docs') || currentPath.startsWith('/architecture') }]} aria-current={activeNav === 'docs' || currentPath.startsWith('/docs') || currentPath.startsWith('/architecture') ? 'page' : undefined}>Explore</a></li>
       </ul>
 
       <div class="nav-cta">
         <ThemeToggle />
-        <a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener" class="nav-github" aria-label="GitHub">
-          <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+        <a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener" class="nav-github" aria-label="InterCooperative Network on GitHub">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
         </a>
-        <a href="/docs/GETTING_STARTED" class="btn btn-primary btn-sm">Developer Setup</a>
       </div>
 
-      <button class="nav-toggle" id="nav-toggle" aria-label="Toggle menu">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12h18M3 6h18M3 18h18"/></svg>
+      <button class="nav-toggle" id="nav-toggle" aria-label="Open menu" aria-expanded="false" aria-controls="nav-links">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true" focusable="false"><path d="M3 12h18M3 6h18M3 18h18"/></svg>
       </button>
     </div>
   </nav>
 
-  <main>
+  <main id="main-content" tabindex="-1">
     <slot />
   </main>
 
@@ -108,8 +109,8 @@ const jsonLd = {
     <div class="container">
       <div class="footer-inner">
         <div class="footer-brand">
-          <a href="/" class="nav-logo">
-            <svg class="nav-logo-svg" width="28" height="28" viewBox="0 0 128 128" fill="none">
+          <a href="/" class="nav-logo" aria-label="InterCooperative Network — home">
+            <svg class="nav-logo-svg" width="28" height="28" viewBox="0 0 128 128" fill="none" aria-hidden="true" focusable="false">
               <rect width="128" height="128" rx="28" fill="url(#ft-bg)"/>
               <line x1="64" y1="30" x2="34" y2="82" stroke="url(#ft-warm)" stroke-width="4" stroke-linecap="round" opacity="0.7"/>
               <line x1="64" y1="30" x2="94" y2="82" stroke="url(#ft-warm)" stroke-width="4" stroke-linecap="round" opacity="0.7"/>
@@ -129,30 +130,35 @@ const jsonLd = {
         </div>
 
         <div class="footer-col">
-          <h4>Project</h4>
+          <h4>Public</h4>
           <ul>
-            <li><a href="/about">About</a></li>
-            <li><a href="/docs">Documentation</a></li>
-            <li><a href="/architecture">Architecture</a></li>
-            <li><a href="/roadmap">Roadmap</a></li>
+            <li><a href="/what-is-icn">What is ICN</a></li>
+            <li><a href="/why-icn">Why ICN</a></li>
+            <li><a href="/how-it-works">How It Works</a></li>
+            <li><a href="/whats-real-now">What's Real Now</a></li>
+            <li><a href="/for-cooperatives">For Cooperatives</a></li>
+            <li><a href="/for-developers">For Developers</a></li>
           </ul>
         </div>
 
         <div class="footer-col">
-          <h4>Resources</h4>
+          <h4>Technical</h4>
           <ul>
-            <li><a href="/docs/GETTING_STARTED">Getting Started</a></li>
+            <li><a href="/docs">Documentation</a></li>
+            <li><a href="/architecture">Architecture</a></li>
+            <li><a href="/roadmap">Roadmap</a></li>
+            <li><a href="/about">About the Project</a></li>
             <li><a href="/docs/glossary">Glossary</a></li>
             <li><a href="https://github.com/InterCooperative-Network/icn/blob/main/CONTRIBUTING.md">Contributing</a></li>
-            <li><a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank">Discussions</a></li>
           </ul>
         </div>
 
         <div class="footer-col">
           <h4>Community</h4>
           <ul>
-            <li><a href="https://github.com/InterCooperative-Network/icn" target="_blank">GitHub</a></li>
-            <li><a href="https://github.com/InterCooperative-Network/icn/issues" target="_blank">Issues</a></li>
+            <li><a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener">GitHub</a></li>
+            <li><a href="https://github.com/InterCooperative-Network/icn/issues" target="_blank" rel="noopener">Issues</a></li>
+            <li><a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank" rel="noopener">Discussions</a></li>
             <li><a href="/community">Community</a></li>
             <li><a href="/blog">Blog</a></li>
           </ul>
@@ -167,30 +173,64 @@ const jsonLd = {
   </footer>
 
   <script is:inline>
-    document.getElementById('nav-toggle')?.addEventListener('click', () => {
-      document.getElementById('nav-links')?.classList.toggle('open');
+    const navToggle = document.getElementById('nav-toggle');
+    const navLinks = document.getElementById('nav-links');
+
+    function setMenuState(open) {
+      if (!navLinks || !navToggle) return;
+      navLinks.classList.toggle('open', open);
+      navToggle.setAttribute('aria-expanded', String(open));
+      navToggle.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
+    }
+
+    navToggle?.addEventListener('click', () => {
+      const isOpen = navLinks?.classList.contains('open') ?? false;
+      setMenuState(!isOpen);
     });
 
     // Close mobile nav when a link is tapped
     document.querySelectorAll('#nav-links a').forEach(link => {
-      link.addEventListener('click', () => {
-        document.getElementById('nav-links')?.classList.remove('open');
-      });
+      link.addEventListener('click', () => setMenuState(false));
     });
 
-    const revealObserver = new IntersectionObserver((entries) => {
-      entries.forEach(entry => {
-        if (entry.isIntersecting) {
-          entry.target.classList.add('revealed');
-          revealObserver.unobserve(entry.target);
-        }
-      });
-    }, { threshold: 0.1, rootMargin: '0px 0px -40px 0px' });
-
-    document.querySelectorAll('.card, .section-header, .arch-box, .stage-item, .docs-section-card, .primitive, .use-case-card, .demo-step').forEach(el => {
-      el.classList.add('reveal');
-      revealObserver.observe(el);
+    // Close mobile nav on Escape
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && navLinks?.classList.contains('open')) {
+        setMenuState(false);
+        navToggle?.focus();
+      }
     });
+
+    // Respect reduced-motion preferences: if the user has asked for less
+    // motion, skip the reveal animation entirely and mark everything
+    // revealed immediately so no content is hidden behind a transition.
+    const prefersReducedMotion =
+      window.matchMedia &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    const revealTargets = document.querySelectorAll(
+      '.card, .inst-card, .section-header, .arch-box, .stage-item, .docs-section-card, .primitive, .use-case-card, .demo-step'
+    );
+
+    if (prefersReducedMotion) {
+      revealTargets.forEach(el => {
+        el.classList.add('reveal', 'revealed');
+      });
+    } else {
+      const revealObserver = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('revealed');
+            revealObserver.unobserve(entry.target);
+          }
+        });
+      }, { threshold: 0.1, rootMargin: '0px 0px -40px 0px' });
+
+      revealTargets.forEach(el => {
+        el.classList.add('reveal');
+        revealObserver.observe(el);
+      });
+    }
   </script>
 </body>
 </html>

--- a/website/src/pages/about.astro
+++ b/website/src/pages/about.astro
@@ -1,146 +1,144 @@
-﻿---
+---
 import Layout from '../layouts/Layout.astro';
-import fs from 'node:fs';
-import { renderMarkdown } from '../lib/markdown';
-import { resolveRepoDoc } from '../lib/paths';
-
-const visionPath = resolveRepoDoc('VISION.md');
-let visionHtml = '';
-if (fs.existsSync(visionPath)) {
-  visionHtml = renderMarkdown(fs.readFileSync(visionPath, 'utf-8'));
-}
 ---
 
-<Layout title="About" activeNav="about">
-  <section class="section" style="padding-top: calc(64px + var(--space-3xl));">
-    <div class="container">
-      <div class="about-hero">
+<Layout title="About the Project" activeNav="about" description="What ICN is as a project, who builds it, the principles guiding it, and how to continue reading.">
+
+  <section class="section page-intro">
+    <div class="container narrow">
+      <div class="page-hero">
         <span class="badge badge-amber">About the Project</span>
-        <h1>InterCooperative Network</h1>
-        <p class="about-lead">
-          Cooperatives built on extractive platforms are still extractive at the infrastructure layer.
-          ICN is building the alternative: governance, accounting, and identity running as
-          member-owned infrastructure on a peer-to-peer daemon — no central host required.
+        <h1>ICN is an open-source attempt to build institutional infrastructure.</h1>
+        <p class="lead">
+          Not a product, not a platform, not a blockchain, not a DAO framework.
+          A coherent substrate where identity, standing, authority, governance, policy,
+          economics, federation, execution, and provenance belong to the same system —
+          and where the humans inside cooperatives, communities, and federations can actually live in it.
         </p>
-        <div class="about-ctas">
-          <a href="/docs/GETTING_STARTED" class="btn btn-primary">Try it now →</a>
-          <a href="/roadmap" class="btn btn-ghost">See the roadmap</a>
-        </div>
       </div>
     </div>
   </section>
 
   <section class="section-alt">
-    <div class="container">
-      <div class="grid grid-2" style="gap: var(--space-2xl);">
-        <div>
-          <h2>What is ICN?</h2>
-          <p style="margin-top: var(--space-md);">
-            ICN is a P2P coordination daemon — a background service that connects with other ICN nodes
-            to form cooperative networks. It provides four foundational institution primitives:
-          </p>
-          <div class="primitive-list">
-            <div class="primitive">
-              <div class="primitive-icon">🔑</div>
-              <div>
-                <strong>Identity & Membership</strong>
-                <p>Cryptographic identities that members own and control. No platform accounts. Trust built from actual participation, not reputation scores.</p>
-              </div>
-            </div>
-            <div class="primitive">
-              <div class="primitive-icon">📜</div>
-              <div>
-                <strong>Rules & Governance</strong>
-                <p>Your bylaws become enforceable rules the system follows automatically. Proposals, votes, delegation, receipts — democratic decisions that work at any scale.</p>
-              </div>
-            </div>
-            <div class="primitive">
-              <div class="primitive-icon">💰</div>
-              <div>
-                <strong>Economics</strong>
-                <p>Mutual credit between cooperatives with cryptographic accounting. Dynamic credit limits. A cooperative treasury that does not require a bank.</p>
-              </div>
-            </div>
-            <div class="primitive">
-              <div class="primitive-icon">🌐</div>
-              <div>
-                <strong>Interoperation</strong>
-                <p>Formal agreements between cooperatives. Cross-group trust. Shared resources. Inter-cooperative coordination as a built-in feature, not an afterthought.</p>
-              </div>
-            </div>
-          </div>
-        </div>
+    <div class="container narrow prose">
+      <h2>What kind of project this is</h2>
+      <p>
+        ICN is an open-source software project in active construction, organized around a specific
+        institutional thesis: that cooperatives, communities, and federations need infrastructure
+        that takes their form seriously, and that the layer underneath institutional life
+        — identity, rules, decisions, obligations, execution, proof — should be one coherent substrate
+        rather than seven tools held together by staff discipline.
+      </p>
+      <p>
+        It is licensed under <strong>AGPL-3.0</strong>, developed in the open on GitHub,
+        and built by a small group of contributors with institutional knowledge alongside technical depth.
+        It is not a startup. It is not venture-backed. It is not a managed service.
+        The code and the documents that describe it are the work, and the website is part of how we keep them honest.
+      </p>
 
-        <div>
-          <h2>How is it different?</h2>
-          <div class="comparison-table">
-            <div class="comp-row comp-header">
-              <span></span>
-              <span>Traditional</span>
-              <span>ICN</span>
-            </div>
-            <div class="comp-row">
-              <span>Governance</span>
-              <span class="comp-old">Bureaucratic / Centralized</span>
-              <span class="comp-new">Governance rules the system enforces</span>
-            </div>
-            <div class="comp-row">
-              <span>Economics</span>
-              <span class="comp-old">Extractive finance</span>
-              <span class="comp-new">Mutual credit + cooperative treasury</span>
-            </div>
-            <div class="comp-row">
-              <span>Identity</span>
-              <span class="comp-old">Platform accounts</span>
-              <span class="comp-new">Identities you own and control</span>
-            </div>
-            <div class="comp-row">
-              <span>Trust</span>
-              <span class="comp-old">Reputation scores</span>
-              <span class="comp-new">Trust built from real participation</span>
-            </div>
-            <div class="comp-row">
-              <span>Infrastructure</span>
-              <span class="comp-old">Central servers / blockchain</span>
-              <span class="comp-new">P2P daemon — no mining, no landlord</span>
-            </div>
-          </div>
-        </div>
-      </div>
+      <h2>Principles that guide it</h2>
+      <ul>
+        <li><strong>Institutions, not user groups.</strong> A cooperative is not a set of logins. Scopes — members, cooperatives, communities, federations, commons — are first-class entities with their own rules, history, and authority.</li>
+        <li><strong>Trust-native, not trustless.</strong> Trust is a first-class, measurable, auditable property of the system, not something we try to design away.</li>
+        <li><strong>Meaning firewall.</strong> Kernel enforcement is structurally separated from domain meaning. Apps interpret institutional concepts; the kernel enforces the constraints that result — and never the other way around.</li>
+        <li><strong>Provenance as institutional memory.</strong> Every outcome traces back through the rule that shaped it, the decision that authorized it, and the members who held standing. Not an audit log bolted on after.</li>
+        <li><strong>Economics as governed social accounting.</strong> Obligations, treasury with budgets and approvals, mutual-credit positions, patronage settlement, usage-rights. Relational accounting between real parties — not a payment rail.</li>
+        <li><strong>Federation strengthens rather than dissolves.</strong> Cooperatives coordinate across boundaries through formal agreements and cross-institutional clearing without being merged into a single organization.</li>
+        <li><strong>Augment human institutions, do not replace them.</strong> Deliberation, judgment, care, politics, and revision stay with people. ICN reduces the fragility of the glue; it does not automate away the work.</li>
+        <li><strong>Honest about maturity.</strong> The project would rather be trusted than impressive. Every capability on the public site is placed in a bounded maturity band.</li>
+      </ul>
+
+      <h2>How to continue reading</h2>
+      <p>
+        This page is orientation. The public narrative layer is organized as a sequence,
+        and reading it in order is the intended path:
+      </p>
+      <ol>
+        <li><a href="/what-is-icn">What is ICN</a> — the canonical definition, the loop, and what ICN is not.</li>
+        <li><a href="/why-icn">Why ICN</a> — the institutional diagnosis this project exists to address.</li>
+        <li><a href="/how-it-works">How it Works</a> — the subsystems, in plain language, with maturity banding.</li>
+        <li><a href="/whats-real-now">What's Real Now</a> — the direct account of which parts of the system are strongest, advancing, or still behind.</li>
+        <li><a href="/for-cooperatives">For Cooperatives</a> or <a href="/for-developers">For Developers</a> — depending on who you are and what you need.</li>
+      </ol>
+      <p>
+        The technical reference layer lives beneath that. <a href="/architecture">Architecture</a>,
+        <a href="/docs">documentation</a>, and the <a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener">source on GitHub</a>
+        are there for readers who want implementation detail.
+      </p>
+
+      <h2>How to engage with the project</h2>
+      <p>
+        If you are a cooperative, community, or federation evaluating ICN as institutional infrastructure,
+        the most honest path right now is <em>observation and early collaboration</em>, not adoption.
+        <a href="/for-cooperatives">For Cooperatives</a> describes the three realistic relationships in detail.
+      </p>
+      <p>
+        If you are a developer or technical reader, <a href="/for-developers">For Developers</a>
+        describes the architecture, the meaning firewall, and which parts of the system are worth reading first.
+        The code is at <a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener">github.com/InterCooperative-Network/icn</a>;
+        contribution paths are linked from there.
+      </p>
+      <p>
+        If you want to follow the work or talk to the people building it,
+        the <a href="/community">community page</a>, <a href="/blog">blog</a>,
+        and <a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank" rel="noopener">GitHub discussions</a>
+        are the right places.
+      </p>
     </div>
   </section>
 
-  {visionHtml && (
-    <section class="section">
-      <div class="container-narrow">
-        <span class="badge badge-teal mb-lg">From VISION.md</span>
-        <article class="prose" set:html={visionHtml} />
+  <section class="section">
+    <div class="container narrow">
+      <div class="next-step">
+        <span class="next-label">Start here →</span>
+        <a href="/what-is-icn" class="btn btn-primary btn-lg">What is ICN</a>
       </div>
-    </section>
-  )}
+      <div class="cta-row">
+        <a href="/why-icn" class="btn btn-secondary">Why ICN</a>
+        <a href="/whats-real-now" class="btn btn-ghost">What's Real Now</a>
+        <a href="/for-cooperatives" class="btn btn-ghost">For Cooperatives</a>
+        <a href="/for-developers" class="btn btn-ghost">For Developers</a>
+      </div>
+    </div>
+  </section>
 </Layout>
 
 <style>
-  .about-hero { max-width: 720px; }
-  .about-hero h1 { margin: var(--space-md) 0; }
-  .about-lead { font-size: 1.25rem; line-height: 1.8; margin-bottom: var(--space-lg); }
-  .about-ctas { display: flex; gap: var(--space-sm); flex-wrap: wrap; }
+.page-intro { padding-top: calc(64px + var(--space-3xl)); }
+.narrow { max-width: 760px; }
+.page-hero { display: flex; flex-direction: column; gap: var(--space-md); align-items: flex-start; }
+.page-hero .badge { align-self: flex-start; }
+.page-hero h1 {
+  margin: 0;
+  font-size: clamp(1.625rem, 3.8vw, 2.25rem);
+  line-height: 1.22;
+}
+.lead { font-size: 1.125rem; color: var(--text-body); line-height: 1.6; margin: 0; }
 
-  .comparison-table {
-    margin-top: var(--space-xl);
-    border: 1px solid var(--border-default);
-    border-radius: var(--radius-lg); overflow: hidden;
-  }
-  .comp-row {
-    display: grid; grid-template-columns: 100px 1fr 1fr;
-    border-bottom: 1px solid var(--border-subtle); font-size: .8125rem;
-  }
-  .comp-row:last-child { border-bottom: none; }
-  .comp-row span { padding: var(--space-sm) var(--space-md); color: var(--text-secondary); }
-  .comp-header span {
-    font-weight: 600; color: var(--text-muted); text-transform: uppercase;
-    font-size: .6875rem; letter-spacing: .1em; background: var(--bg-card);
-  }
-  .comp-old { color: var(--text-muted) !important; text-decoration: line-through; opacity: .7; }
-  .comp-new { color: var(--accent-teal) !important; }
+.prose h2 { margin-top: var(--space-2xl); margin-bottom: var(--space-md); }
+.prose p { margin: 0 0 var(--space-md); line-height: 1.7; }
+.prose ul, .prose ol { margin: var(--space-md) 0; padding-left: var(--space-lg); }
+.prose li { margin-bottom: var(--space-sm); line-height: 1.7; }
+
+.next-step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-lg);
+}
+.next-label {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+}
+.btn-lg { font-size: 1rem; padding: 0.75rem 1.5rem; }
+.cta-row {
+  display: flex;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+  justify-content: center;
+}
 </style>

--- a/website/src/pages/architecture.astro
+++ b/website/src/pages/architecture.astro
@@ -12,16 +12,29 @@ if (fs.existsSync(archPath)) {
 }
 ---
 
-<Layout title="Architecture" activeNav="architecture">
-  <section class="section" style="padding-top: calc(64px + var(--space-3xl));">
-    <div class="container">
-      <div class="section-header" style="text-align: left; max-width: none;">
+<Layout title="Architecture reference" activeNav="architecture" description="The technical architecture reference for ICN — kernel/app separation, the meaning firewall, and the subsystems that make the substrate work. Synced from docs/ARCHITECTURE.md.">
+  <section class="section arch-intro">
+    <div class="container narrow">
+      <div class="ref-banner">
+        <span class="ref-label">Technical reference layer</span>
+        <p class="ref-text">
+          This page is the deep technical architecture of ICN, synced directly from
+          <code>docs/ARCHITECTURE.md</code> in the main repository. It is written for developers,
+          architects, and technical evaluators.
+        </p>
+        <p class="ref-text">
+          If you are trying to understand ICN as an institution rather than as a codebase, start with
+          <a href="/what-is-icn">What is ICN</a> or <a href="/how-it-works">How it Works</a>.
+          Those pages describe the same system in plain language, without the crate map.
+        </p>
+      </div>
+
+      <div class="page-hero">
         <span class="badge badge-blue">System Design</span>
         <h1>Architecture</h1>
-        <p>
-          A deep dive into the Constraint Engine Model, kernel/app separation, 
-          and the subsystems that make ICN work. This document is synced from 
-          <code>docs/ARCHITECTURE.md</code> in the main repository.
+        <p class="lead">
+          Kernel/app separation, the meaning firewall, the actor runtime, and the subsystems that make ICN work —
+          at the level of detail serious readers want.
         </p>
       </div>
     </div>
@@ -55,19 +68,82 @@ if (fs.existsSync(archPath)) {
   <section class="section">
     <div class="container-narrow">
       <article class="prose" set:html={archHtml} />
-      
-      <div class="doc-footer" style="margin-top: var(--space-3xl); padding-top: var(--space-xl); border-top: 1px solid var(--border-subtle);">
-        <a href="https://github.com/InterCooperative-Network/icn/blob/main/docs/ARCHITECTURE.md" target="_blank" class="btn btn-ghost">View source on GitHub →</a>
+
+      <div class="doc-footer">
+        <a href="https://github.com/InterCooperative-Network/icn/blob/main/docs/ARCHITECTURE.md" target="_blank" rel="noopener" class="btn btn-ghost">View source on GitHub →</a>
+        <a href="/how-it-works" class="btn btn-ghost">Public explanation →</a>
+        <a href="/for-developers" class="btn btn-ghost">For Developers</a>
       </div>
     </div>
   </section>
 </Layout>
 
 <style>
+  .arch-intro {
+    padding-top: calc(64px + var(--space-3xl));
+  }
+  .narrow { max-width: 760px; margin: 0 auto; }
+
+  .ref-banner {
+    background: var(--bg-card);
+    border: 1px solid var(--border-default);
+    border-left: 3px solid var(--accent-blue);
+    border-radius: var(--radius-lg);
+    padding: var(--space-lg) var(--space-xl);
+    margin-bottom: var(--space-2xl);
+  }
+  .ref-label {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--accent-blue);
+    margin-bottom: var(--space-sm);
+  }
+  .ref-text {
+    margin: 0 0 var(--space-sm);
+    color: var(--text-muted);
+    line-height: 1.65;
+    font-size: 0.9375rem;
+  }
+  .ref-text:last-child { margin-bottom: 0; }
+  .ref-text code {
+    font-size: 0.85em;
+    background: var(--bg-surface);
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+  }
+
+  .page-hero {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+    align-items: flex-start;
+  }
+  .page-hero .badge { align-self: flex-start; }
+  .page-hero h1 { margin: 0; }
+  .lead {
+    font-size: 1.0625rem;
+    color: var(--text-body);
+    line-height: 1.6;
+    margin: 0;
+    max-width: 40em;
+  }
+
   .arch-overview-grid {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
     gap: var(--space-lg);
+  }
+
+  .doc-footer {
+    margin-top: var(--space-3xl);
+    padding-top: var(--space-xl);
+    border-top: 1px solid var(--border-subtle);
+    display: flex;
+    gap: var(--space-sm);
+    flex-wrap: wrap;
   }
 
   @media (max-width: 1100px) {

--- a/website/src/pages/for-cooperatives.astro
+++ b/website/src/pages/for-cooperatives.astro
@@ -1,0 +1,169 @@
+---
+import Layout from '../layouts/Layout.astro';
+import ScopeModel from '../components/ScopeModel.astro';
+import ReadingLadder from '../components/ReadingLadder.astro';
+---
+
+<Layout title="For Cooperatives" activeNav="for-cooperatives" description="What ICN is trying to do for cooperatives, communities, and federations — and what it is not yet ready to do.">
+
+  <section class="section" style="padding-top: calc(64px + var(--space-3xl));">
+    <div class="container narrow">
+      <div class="page-hero">
+        <span class="badge badge-amber">For Cooperatives</span>
+        <h1>ICN is being built for the kind of institution that has to hold itself together with people, memory, and care.</h1>
+        <p class="lead">
+          If you run a cooperative, a community organization, or a federation,
+          you already know the shape of the problem. This page is not here to explain cooperatives to you.
+          It is here to explain what ICN is trying to do for you — and what it is not yet ready to do.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section-alt">
+    <div class="container narrow prose">
+      <h2>The institutional problem you actually face</h2>
+      <p>
+        Most cooperatives operate across a stack of tools that were built for firms, platforms,
+        or administrative convenience, and then stretched to cover democratic life.
+        Membership sits in a CRM or spreadsheet. Governance happens in meetings whose minutes
+        live somewhere separate from the decisions they produced.
+        Rules live in documents that are read inconsistently and interpreted differently depending on who is in the room.
+        Accounting lives in a system that has no idea what was decided.
+        Execution depends on whoever remembered what they were supposed to do.
+      </p>
+      <p>
+        Each of these tools, in isolation, can be made to work. Together, they produce drift.
+        Decisions do not reliably become action. Rules do not reliably bind practice.
+        Accountability decays into trust in the specific people holding the pieces together in their heads.
+        And when those people leave, burn out, or disagree about what happened,
+        the institution can lose what it knew.
+      </p>
+
+      <h2>Why generic software is not enough</h2>
+      <p>
+        The underlying problem is that none of those tools model the institution itself.
+        They do not know what a member is, in the sense that matters to a cooperative.
+        They do not know what a rule is, in the sense that should bind practice.
+        They do not know what it means for a decision to authorize an action.
+        Integrating them only spreads the gap more evenly.
+      </p>
+
+      <h2>What changes when the institutional loop is closed</h2>
+      <p>
+        ICN is built on the claim that the pieces of institutional life should not be scattered
+        across unrelated systems. When the loop closes, a cooperative gets things that are genuinely hard to get today:
+      </p>
+      <ul>
+        <li>A member's <strong>standing</strong> is provable — not a row in a CRM, but a cryptographic fact the institution can verify directly.</li>
+        <li>A decision made in a meeting has a <strong>durable, pointable existence</strong> — not as minutes someone wrote up afterward, but as an artifact of the institution itself, tied to the members who held standing in it.</li>
+        <li>A rule the membership agreed to is <strong>visible at the point where it matters</strong>, not buried in a document that gets read once a year.</li>
+        <li>Obligations between members or between cooperatives are carried as <strong>institutional facts</strong> — with treasury, budgets and approvals, patronage settlement, and mutual-credit positions — not entries in a private spreadsheet.</li>
+        <li>The chain from <em>what we decided</em> to <em>what actually happened</em> stays intact, so the institution can answer its own members honestly about its own actions.</li>
+        <li>Federation with other cooperatives is a first-class mechanism — <strong>formal agreements, attestations, and cross-institutional clearing</strong> — not something two organizations have to hold together by email and trust in specific staff.</li>
+        <li>Shared infrastructure — compute, storage, coordinated work — can be held as a <strong>commons</strong> with governance, placement, clearing, and dispute resolution built into the same loop, not bolted on after the fact.</li>
+      </ul>
+      <p>
+        None of this replaces the work of running a cooperative.
+        It changes what the work is resting on.
+      </p>
+
+      <ScopeModel title="The contexts your members would actually act inside" />
+
+      <h2>What is real today</h2>
+      <p>
+        Some of this is already load-bearing. The strongest parts of ICN today are
+        <strong>provenance and institutional memory</strong> — the chain that carries an outcome
+        back through the rule that shaped it, the decision that authorized it, and the members who held standing.
+        Cryptographic identity and membership primitives are in place. The structural discipline that separates
+        kernel enforcement from domain meaning (the "meaning firewall") is real and enforced in the codebase itself.
+      </p>
+      <p>
+        <strong>Execution coverage</strong> — how broadly an accepted decision translates into operational effect —
+        is the active frontier. A kernel-dispatch bridge exists; widening the set of proposal types it handles cleanly
+        is where current work is concentrated.
+      </p>
+      <p>
+        <strong>Federation</strong> (treaties, attestations, cross-institutional clearing) and
+        <strong>commons/compute</strong> (shared infrastructure with placement, clearing, checkpointing, and dispute resolution)
+        have serious implementation behind them, and are in places ahead of what the public site describes.
+        <strong>Economic semantics</strong> — treasury, budgets, patronage settlement, usage-rights accounting —
+        are real but their cross-scope integration story is still being completed.
+      </p>
+      <p>
+        The <strong>member-facing experience</strong> is the piece most visibly trailing the underlying system.
+        The capabilities beneath it are real; the interface through which ordinary members would interact with them is still being built.
+        This is the gap you would feel most directly if you tried to adopt ICN this month.
+      </p>
+      <p>
+        The full account, with bounded maturity language for every subsystem, is at <a href="/whats-real-now">What's Real Now</a>.
+      </p>
+
+      <h2>What is not ready to overclaim</h2>
+      <p>We want to be direct about what ICN is not, today:</p>
+      <ul>
+        <li><strong>It is not a product you can buy, install, and hand to your membership this week.</strong> A cooperative adopting ICN right now is working with engineering help, not clicking through a polished onboarding flow.</li>
+        <li><strong>It is not a managed platform with a vendor behind a support contract.</strong> ICN is open, cooperative infrastructure, with the usual tradeoffs of early-stage open infrastructure.</li>
+        <li><strong>It is not a complete federation fabric.</strong> Federation is real, but not everything a federation would want to do across its members is finished.</li>
+        <li><strong>It is not a replacement for the governance your cooperative already does.</strong> It is the layer underneath — the layer that can remember, carry, and make legible what your governance decides.</li>
+      </ul>
+
+      <h2>How to think about timing and adoption</h2>
+      <p>If you are running a cooperative today, there are a few honest ways to relate to ICN.</p>
+      <p>
+        The first is <strong>observation</strong>: following the work, understanding the direction,
+        being in a position to evaluate it as the surfaces mature. This is the right relationship for most cooperatives right now.
+      </p>
+      <p>
+        The second is <strong>early collaboration</strong>: working with the project in depth,
+        with real engineering involvement, as a cooperative or federation willing to be part of how the substrate gets shaped.
+        This is the right relationship for institutions that have the capacity and the interest,
+        and who understand they are helping build the thing, not buying it finished.
+      </p>
+      <p>
+        The third is <strong>contribution of expertise</strong>: bringing the institutional knowledge
+        of how real cooperatives actually run into the design of the substrate.
+        ICN needs to be informed by the institutions it is meant to serve.
+      </p>
+      <p>
+        What we would ask you not to do is treat ICN as a SaaS product to pilot next quarter.
+        That is not the current shape of the project.
+      </p>
+
+      <h2>This is about enhancing human institutions, not automating them away</h2>
+      <p>
+        The work of running a cooperative — deliberation, interpretation, care, negotiation, political judgment,
+        the mediation of disagreement, the responsibility for what the institution does in the world —
+        is human work. It is hard, and the hardness is not a defect.
+      </p>
+      <p>
+        What ICN is trying to change is the <em>fragility of the glue</em> that holds institutional coherence together.
+        Better memory. Better continuity. Better accountability. Better legibility. Better collective capacity across organizations.
+        So that the attention of members and staff can go to the work that actually requires human judgment.
+      </p>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="container narrow">
+      <ReadingLadder current="for-cooperatives">
+        <Fragment slot="extras">
+          <a href="/community" class="btn btn-ghost">Community</a>
+          <a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener" class="btn btn-ghost">GitHub ↗</a>
+        </Fragment>
+      </ReadingLadder>
+    </div>
+  </section>
+</Layout>
+
+<style>
+.narrow { max-width: 760px; }
+.page-hero { display: flex; flex-direction: column; gap: var(--space-md); align-items: flex-start; }
+.page-hero .badge { align-self: flex-start; }
+.page-hero h1 { margin: 0; font-size: clamp(1.625rem, 3.6vw, 2.25rem); line-height: 1.25; }
+.lead { font-size: 1.125rem; color: var(--text-body); line-height: 1.6; margin: 0; }
+.prose h2 { margin-top: var(--space-2xl); margin-bottom: var(--space-md); }
+.prose p { margin: 0 0 var(--space-md); line-height: 1.7; }
+.prose ul { margin: var(--space-md) 0; padding-left: var(--space-lg); }
+.prose li { margin-bottom: var(--space-sm); line-height: 1.7; }
+</style>

--- a/website/src/pages/for-developers.astro
+++ b/website/src/pages/for-developers.astro
@@ -1,0 +1,169 @@
+---
+import Layout from '../layouts/Layout.astro';
+import ClosureLoop from '../components/ClosureLoop.astro';
+import ReadingLadder from '../components/ReadingLadder.astro';
+---
+
+<Layout title="For Developers" activeNav="for-developers" description="ICN as a technical system: kernel/app separation, trust-native architecture, mutual-credit accounting, and where the current implementation is strongest.">
+
+  <section class="section" style="padding-top: calc(64px + var(--space-3xl));">
+    <div class="container narrow">
+      <div class="page-hero">
+        <span class="badge badge-teal">For Developers</span>
+        <h1>ICN is institutional infrastructure with a real codebase behind it.</h1>
+        <p class="lead">
+          If you are reading this, you probably already know that most "infrastructure for cooperatives" projects
+          turn out to be either a thin SaaS layer or a crypto protocol wearing institutional language.
+          ICN is neither. This page is where the public narrative meets the implementation.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section-alt">
+    <div class="container narrow prose">
+      <h2>Why ICN may be interesting to technical readers</h2>
+      <ul>
+        <li><strong>Kernel/app separation with a strict meaning firewall.</strong> The kernel enforces generic constraints without understanding their domain semantics. Apps translate domain meaning into those constraints. The boundary is enforced in the crate graph.</li>
+        <li><strong>Trust-native, not trustless.</strong> ICN is built around trust as a first-class, measurable, auditable property — not around the assumption that trust can be eliminated.</li>
+        <li><strong>Mutual-credit accounting rather than token economics.</strong> The economic layer is relational: obligations between named parties, settled institutionally, not a market instrument.</li>
+        <li><strong>Actor-based runtime over Tokio</strong>, with explicit supervision, shutdown, and message-passing between subsystems.</li>
+        <li><strong>Cryptographic identity for members, cooperatives, communities, and federations</strong>, with an Age-encrypted keystore and explicit key rotation paths.</li>
+        <li><strong>An honest repository.</strong> The project is unusually direct about what is real, what is being built, and what is still unfinished.</li>
+      </ul>
+
+      <h2>What kind of system this is, technically</h2>
+      <p>
+        ICN is a daemon (<code>icnd</code>) implemented in Rust, running as a peer in a network of other ICN nodes.
+        It is not a blockchain. There is no global consensus layer, no token, no mining.
+        It is not a client-server application. There is no central service that nodes report to.
+      </p>
+      <p>
+        Nodes communicate over QUIC/TLS with cryptographic identity bound to the transport layer.
+        Between nodes, the main coordination primitives are topic-based gossip with causal ordering,
+        signed envelopes with replay protection, a mutual-credit ledger of obligations between parties,
+        and <strong>policy oracles</strong> — app-level components that translate domain decisions
+        (governance, trust, membership) into generic constraints the kernel can enforce without understanding the domain.
+      </p>
+      <p>
+        Inside a node, the runtime is an actor system: the supervisor spawns long-lived actors
+        for the network, gossip, ledger, and related subsystems, and wires them together
+        through message passing and typed callbacks.
+        State is persisted through sled-backed storage; cryptographic material lives in an Age-encrypted keystore.
+      </p>
+
+      <h2>Core architectural ideas worth knowing before reading the code</h2>
+      <ul>
+        <li><strong>The meaning firewall.</strong> Kernel crates enforce constraints; app crates supply meaning. The kernel is not allowed to understand what a "trust score" or a "cooperative" is. The boundary is enforced in the crate graph itself, not as a design aspiration.</li>
+        <li><strong>Policy oracles.</strong> An app that implements the <code>PolicyOracle</code> interface is the bridge between domain semantics and kernel enforcement. The trust oracle is the canonical example.</li>
+        <li><strong>The governance executor.</strong> A kernel-dispatch bridge between accepted governance payloads and the subsystems that carry them into operational effect. Widening the set of payload types it dispatches is the active frontier of the project.</li>
+        <li><strong>Scopes as first-class institutions.</strong> A member, a cooperative, a community, a federation, and a commons are each modeled as a distinct scope. Each has its own crate in the workspace.</li>
+        <li><strong>Actors and supervision.</strong> The runtime is built around long-lived actors managed by a supervisor, communicating through message passing.</li>
+        <li><strong>Trust-gated rate limiting and placement.</strong> Trust class affects message rate limits, credit relationships, and task placement. Trust is native, not trustless.</li>
+        <li><strong>Signed envelopes and replay guards.</strong> All messages between nodes are signed and replay-protected; verification happens in the network actor before messages reach the rest of the system.</li>
+        <li><strong>Federation as treaty.</strong> The federation crate carries formal agreements, attestations, typed inter-institutional channels, and cross-scope clearing — not just message relay.</li>
+        <li><strong>Commons and compute.</strong> Shared infrastructure with trust-aware placement, checkpointing, cross-participant clearing, and dispute resolution — participating in the same institutional loop as governance and accounting.</li>
+      </ul>
+
+      <ClosureLoop variant="full" title="The institutional loop you'll be reading code against" showReturn={false} />
+
+      <h2>Subsystems that exist but are not yet publicly described</h2>
+      <p>
+        Some parts of the codebase are real but we are not yet willing to carry them on the public narrative pages —
+        either because their public surfaces are thin, or because we are not ready to describe them in a way we can stand behind.
+        Technical readers looking at the workspace will see them, so we name them here honestly:
+      </p>
+      <ul>
+        <li><strong><code>icn-privacy</code></strong> — privacy primitives as a dedicated crate. Real code, no polished public framing yet.</li>
+        <li><strong><code>icn-zkp</code></strong> — zero-knowledge proof components. Real code, limited public narrative.</li>
+        <li><strong><code>icn-steward</code></strong> — a steward network for trust distribution and integrity. Real implementation, deliberately absent from public pages until we can describe it without overclaim.</li>
+      </ul>
+      <p>
+        If you are evaluating ICN as a system and any of these matter to your work, read the crates directly rather than waiting for the public story to catch up.
+      </p>
+
+      <h2>Where the current implementation is strongest</h2>
+      <p>
+        ICN's strongest technical through-line today is the part of the system that connects governance
+        to durable, auditable records. The primitives for cryptographic identity, signed messages,
+        provenance, and receipts are mature and load-bearing. The paths from decision to recorded outcome
+        are where the most implementation work has gone.
+      </p>
+      <p>
+        Core kernel subsystems — the actor runtime, network transport, gossip, identity primitives,
+        storage, and the meaning-firewall boundary between kernel and apps — are in place and integrated.
+        The trust policy oracle is a working example of the kernel/app pattern and is the reference
+        implementation to read first if you want to understand how the separation is meant to work.
+      </p>
+
+      <h2>Where active work is happening</h2>
+      <ul>
+        <li><strong>Execution coverage.</strong> Expanding the range of decisions that translate cleanly into concrete operational effect.</li>
+        <li><strong>Policy mechanisms.</strong> The breadth of governance patterns an app can express, and the fidelity with which policy oracles can translate them into kernel-enforceable constraints.</li>
+        <li><strong>Federation.</strong> The federation crate and the coordination protocols between scopes are real, but integrations across adjacent subsystems are still being completed.</li>
+        <li><strong>Commons and compute.</strong> The distributed compute layer with trust-gated task placement exists and is serious, but the surfaces that would let external readers evaluate it are underdeveloped.</li>
+        <li><strong>The gateway and member-facing APIs.</strong> The REST and WebSocket surfaces that would let ordinary members interact with a scope are the part of the system most visibly trailing the substrate underneath.</li>
+      </ul>
+
+      <h2>How to explore the codebase and docs</h2>
+      <p>
+        The main monorepo is at
+        <a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener">InterCooperative-Network/icn</a>.
+        It is a Cargo workspace with crates in <code>icn/crates/</code> and apps in <code>icn/apps/</code>,
+        binaries in <code>icn/bins/</code>.
+      </p>
+      <p>A reasonable reading order for someone new:</p>
+      <ol>
+        <li>Start with the <a href="/architecture">architecture reference</a> for the structural model.</li>
+        <li>Read the trust policy oracle as the canonical example of how an app translates domain semantics into generic constraints.</li>
+        <li>Read the supervisor and runtime (<code>icn-core</code>) to see how actors are spawned, wired, and shut down.</li>
+        <li>Read the network actor (<code>icn-net</code>) and the gossip actor (<code>icn-gossip</code>) to see how inter-node communication works.</li>
+        <li>Read the ledger (<code>icn-ledger</code>) to see how mutual-credit accounting is carried as a replicated journal.</li>
+        <li>Read the governance app to see how proposals, decisions, and the transition from governance to policy are handled today.</li>
+      </ol>
+
+      <h2>How to contribute without misunderstanding the project</h2>
+      <ul>
+        <li><strong>ICN is institutional infrastructure, not a protocol in search of a use case.</strong> Contributions that treat it as a generic substrate for arbitrary coordination tend to miss the point.</li>
+        <li><strong>The kernel/app separation is load-bearing.</strong> Contributions that erode the meaning firewall will be reverted.</li>
+        <li><strong>Trust is native, not trustless.</strong> Designs that assume trust can be eliminated will not fit.</li>
+        <li><strong>Honesty about maturity is a project value.</strong> Contributions that overclaim — PRs whose descriptions suggest a feature is complete when it is only partially wired — will not land.</li>
+        <li><strong>Scope discipline matters.</strong> Small, focused contributions against a clearly scoped issue are the path of least resistance.</li>
+      </ul>
+
+      <h2>What ICN is not, technically</h2>
+      <ul>
+        <li><strong>Not a blockchain.</strong> No global consensus, no token, no mining.</li>
+        <li><strong>Not a DAO framework.</strong> Governance is one part of a larger substrate, not voting over a treasury.</li>
+        <li><strong>Not a federated social platform.</strong> Federation is about institutional coordination, not content distribution.</li>
+        <li><strong>Not a general-purpose smart contract platform.</strong> CCL is domain-scoped, deterministic, fuel-metered, and not Turing-complete.</li>
+        <li><strong>Not finished.</strong> ICN is real and active, but not mature. See <a href="/whats-real-now">What's Real Now</a>.</li>
+      </ul>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="container narrow">
+      <ReadingLadder current="for-developers">
+        <Fragment slot="extras">
+          <a href="/architecture" class="btn btn-ghost">Architecture reference →</a>
+          <a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener" class="btn btn-ghost">GitHub ↗</a>
+          <a href="/docs" class="btn btn-ghost">Docs</a>
+        </Fragment>
+      </ReadingLadder>
+    </div>
+  </section>
+</Layout>
+
+<style>
+.narrow { max-width: 780px; }
+.page-hero { display: flex; flex-direction: column; gap: var(--space-md); align-items: flex-start; }
+.page-hero .badge { align-self: flex-start; }
+.page-hero h1 { margin: 0; font-size: clamp(1.625rem, 3.6vw, 2.25rem); line-height: 1.25; }
+.lead { font-size: 1.125rem; color: var(--text-body); line-height: 1.6; margin: 0; }
+.prose h2 { margin-top: var(--space-2xl); margin-bottom: var(--space-md); }
+.prose p { margin: 0 0 var(--space-md); line-height: 1.7; }
+.prose ul, .prose ol { margin: var(--space-md) 0; padding-left: var(--space-lg); }
+.prose li { margin-bottom: var(--space-sm); line-height: 1.7; }
+.prose code { font-size: 0.85em; background: var(--bg-surface); padding: 0.15em 0.4em; border-radius: 4px; }
+</style>

--- a/website/src/pages/how-it-works.astro
+++ b/website/src/pages/how-it-works.astro
@@ -1,0 +1,260 @@
+---
+import Layout from '../layouts/Layout.astro';
+import MaturityBadge from '../components/MaturityBadge.astro';
+import ScopeModel from '../components/ScopeModel.astro';
+import ProvenanceTrail from '../components/ProvenanceTrail.astro';
+import MemberSurface from '../components/MemberSurface.astro';
+import ReadingLadder from '../components/ReadingLadder.astro';
+---
+
+<Layout title="How it Works" activeNav="how-it-works" description="A plain-language explanation of how ICN connects identity, membership, governance, rules, accounting, execution, provenance, federation, and the member experience into one coherent substrate.">
+
+  <section class="section" style="padding-top: calc(64px + var(--space-3xl));">
+    <div class="container narrow">
+      <div class="page-hero">
+        <span class="badge badge-teal">How it Works</span>
+        <h1>ICN works by connecting the parts of institutional life that are usually split apart.</h1>
+        <p class="lead">
+          In most cooperatives, communities, and federations today,
+          the pieces of institutional life live in different systems that don't know about each other.
+          ICN is built on the premise that this fragmentation is not a fact of nature.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section-alt">
+    <div class="container narrow prose">
+      <p>
+        The same institution can hold membership, governance, shared rules, economic coordination,
+        execution, provenance, and federation as <em>one coherent substrate</em> —
+        a single underlying layer on which institutional life runs —
+        rather than as seven disconnected systems that staff have to reconcile by hand.
+      </p>
+      <p>
+        This page walks through the pieces of that substrate one at a time,
+        and then shows how they close a single loop.
+      </p>
+
+      <h2><span class="station-number">01 · 02</span>Identity and membership <MaturityBadge band="strong" /></h2>
+      <p>
+        Every person, cooperative, community, and federation in ICN has a cryptographic identity they control directly.
+        A member is not an account on a platform. They are a participant with their own keys and their own history,
+        recognized by the institutions they belong to because those institutions can verify their standing directly.
+      </p>
+      <p>
+        This is what "self-sovereign identity" means in the ICN sense: not independence
+        <em>from</em> institutions, but the ability to be a provable participant <em>inside</em> them.
+      </p>
+
+      <h2><span class="station-number">Scope</span>Scopes and institutions <MaturityBadge band="strong" /></h2>
+      <p>
+        ICN models cooperatives, communities, and federations as <strong>scopes</strong>:
+        real institutional entities with their own rules, their own members, their own history, and their own boundaries.
+        A scope is not a tenant on someone else's platform. It is a distinct institution the substrate knows about directly.
+      </p>
+      <p>
+        Scopes are <em>contexts of action</em>, not levels of hierarchy.
+        When a member acts, they are always acting inside one or more scopes at once.
+        Every decision, every rule, every obligation, and every receipt belongs to its scopes.
+      </p>
+
+      <ScopeModel title="The five scopes a member acts inside" />
+
+      <h2><span class="station-number">03 · 04</span>Authority and governance <MaturityBadge band="strong" /></h2>
+      <p>
+        Governance in ICN is the process by which members of a scope make decisions that the institution will honor.
+        Proposals are created, deliberated on, decided, and recorded.
+        The decisions produce durable artifacts: not just vote tallies, but records that can be pointed to later.
+      </p>
+      <p>
+        ICN does not govern. Members govern. ICN is the layer that makes the record of their governance durable —
+        that holds the proposal, the deliberation, the decision, and the link between the decision and what happens afterward.
+      </p>
+
+      <h2><span class="station-number">05</span>Policy — rules that bind practice <MaturityBadge band="advancing" /></h2>
+      <p>
+        Decisions, once made, produce rules. Rules are what govern practice afterward:
+        who can do what, under what conditions, within what limits, with what approvals.
+      </p>
+      <p>
+        ICN's ambition is that a rule produced by a decision should actually bind the practice that follows —
+        not by removing human interpretation, but by making the rule legible at the point where it matters.
+        Policy mechanisms are the active frontier of the system right now.
+        Real work is happening here, and it is not yet complete.
+      </p>
+
+      <h2><span class="station-number">06</span>Accounting — governed social accounting <MaturityBadge band="advancing" /></h2>
+      <p>
+        Economics in ICN is not commerce. It is not primarily about exchange, pricing, or markets.
+        It is about how institutions carry <em>obligations between real parties</em> — who has contributed what,
+        who owes what to whom, how resources are allocated, how budgets are approved,
+        how surpluses are stewarded, and how reciprocity is recorded.
+      </p>
+      <p>
+        The vocabulary is concrete: obligations, treasury with budgets and approvals,
+        patronage settlement, mutual-credit positions, progressive credit limits, and usage-rights accounting.
+        The accounting is relational, denominated in obligations between named parties,
+        not in a tradable asset. That choice is deliberate — it keeps the economic layer
+        tied to institutional rules rather than drifting into speculation or payment-rail framing.
+      </p>
+
+      <h2><span class="station-number">07</span>Execution and operational effect <MaturityBadge band="advancing" /></h2>
+      <p>
+        A decision that never touches practice is not really a decision.
+        The hardest problem in institutional software — the one most systems quietly punt on —
+        is <strong>execution</strong>: the step where an accepted decision turns into a concrete operational effect.
+      </p>
+      <p>
+        ICN has a kernel-dispatch bridge between accepted governance payloads and the subsystems
+        that carry them into effect. Some payload types are wired through and load-bearing today;
+        others are being added. Widening the set of decisions that dispatch cleanly is the active frontier of the project.
+        <a href="/whats-real-now">What's Real Now</a> carries the precise current state.
+      </p>
+
+      <h2><span class="station-number">08</span>Receipts, provenance, and auditability <MaturityBadge band="strong" /></h2>
+      <p>
+        When something happens in ICN — a proposal accepted, a rule applied, an obligation settled,
+        an action taken under authorization — the substrate produces a durable record of it.
+        Those records are receipts in the strict sense: evidence that a specific thing happened
+        under specific rules with specific standing.
+      </p>
+      <p>
+        Provenance is the chain those receipts form. You can follow a particular outcome back to the decision
+        that authorized it, to the rule that shaped it, to the members who had standing in the decision.
+        This is where the substrate is strongest, and it is the anchor the rest of the system is built around.
+      </p>
+
+      <ProvenanceTrail title="How the chain is built" />
+
+      <h2><span class="station-number">Cross-scope</span>Federation <MaturityBadge band="maturing" /></h2>
+      <p>
+        No cooperative is an island. Federation in ICN is the layer that lets scopes
+        recognize each other, enter formal agreements, exchange attestations, and settle obligations
+        across their boundaries — without being collapsed into a single organization.
+      </p>
+      <p>
+        The principle is that federation strengthens its member institutions rather than dissolving them.
+        A cooperative in a federation is still a cooperative: its own governance, rules, members, and history.
+        The federation is an additional scope that its member institutions participate in,
+        with its own governance and its own agreements — not a merger that erases what it contains.
+      </p>
+      <p>
+        Federation is real. Serious implementation exists: treaty-grade agreements, attestations,
+        typed inter-institutional channels, and cross-scope clearing. At the same time, the public-facing surfaces
+        that would let an outside reader see federation clearly are still being completed,
+        and some integrations remain partial.
+      </p>
+
+      <h2><span class="station-number">Shared scope</span>Commons and compute <MaturityBadge band="maturing" /></h2>
+      <p>
+        Some things institutions need to do cannot be held by a single organization.
+        Shared resources — compute capacity, storage, coordinated work, infrastructure — need
+        to be held in common across members of a network, with rules that are accountable to all of them.
+        <strong>Commons and compute</strong> is the name ICN uses for this part of the substrate:
+        shared infrastructure participating in the same institutional loop as governance and accounting.
+      </p>
+      <p>
+        In concrete terms, the implementation includes trust-aware task placement,
+        cross-participant clearing, checkpointing, and dispute resolution — federation-aware where it needs to be.
+        This is one of the areas where ICN's implementation is meaningfully ahead of its public-facing explanation.
+        The work is serious; the surfaces that would let an outsider see and evaluate it are still being built.
+      </p>
+
+      <h2><span class="station-number">09</span>Member-facing experience <MaturityBadge band="behind" /></h2>
+      <p>
+        All of the pieces above are useless if a member cannot actually experience the institution through them.
+        The member-facing surface of ICN is where identity, membership, governance, rules, accounting,
+        receipts, and federation come together into something a person can see and use.
+      </p>
+      <p>
+        This is an area where the substrate is ahead of the surface.
+        The capabilities underneath are real and in many places strong.
+        The interface through which ordinary members interact with those capabilities is still being built out.
+      </p>
+
+      <MemberSurface />
+
+      <h2>Closing the loop</h2>
+      <p>
+        The point of describing the pieces one at a time is that they are not actually separate.
+        ICN is built on the claim that institutional life breaks down when its pieces are scattered,
+        and works when they are held together.
+      </p>
+      <ul>
+        <li><strong>Identity</strong> belongs to the member — cryptographic, self-held, verifiable.</li>
+        <li><strong>Standing</strong> inside a scope is not administrative metadata; it is a provable fact about who the member is in this institution.</li>
+        <li><strong>Authority</strong> flows from the scope's rules and the decisions its members have made under them — not from a platform owner.</li>
+        <li><strong>Governance</strong> is how members make decisions that the institution will honor.</li>
+        <li><strong>Policy</strong> is what those decisions produce: rules that shape what can happen next.</li>
+        <li><strong>Execution</strong> is where accepted decisions translate into operational effect — through obligations, allocations, settlements, commons actions, or federation clearing.</li>
+        <li><strong>Receipts and provenance</strong> carry the chain from authority to outcome, and feed back into the record the institution runs on.</li>
+        <li><strong>Federation</strong> lets scopes coordinate across their boundaries without dissolving into each other.</li>
+        <li><strong>The member-facing experience</strong> is where all of this becomes something a person can actually see, use, and live inside — one institution, not seven tools.</li>
+      </ul>
+      <p>
+        That is the loop ICN is trying to close. Parts of it are already closed today.
+        Other parts are still being filled in.
+      </p>
+
+      <h2>Why this enhances human institutions rather than replacing them</h2>
+      <p>
+        Everything above is easy to misread as a claim that software can run an institution.
+        It cannot, and ICN is not designed to pretend otherwise.
+      </p>
+      <p>
+        People still deliberate. People still govern. People still interpret rules,
+        negotiate edge cases, and make calls about what the institution should do
+        when reality does not match what was written down. People still do the work of caring about each other,
+        mediating disputes, and holding each other accountable.
+      </p>
+      <p>
+        What ICN changes is the <em>fragility of the glue</em>.
+        Most institutions today hold themselves together through individual memory, staff discretion,
+        informal trust, and scattered tools that only a few people fully understand.
+        That glue works until the people holding it burn out, leave, or disagree about what happened.
+      </p>
+      <p>
+        ICN is built to reduce how much institutional coherence depends on that kind of fragile glue.
+        Better memory. Better continuity. Better accountability. Better legibility.
+        Better collective capacity across organizations.
+        The system holds what the institution has written down so that the people inside it
+        can spend their attention on the work that actually requires human judgment.
+      </p>
+
+      <h3>What this page does not mean</h3>
+      <ul>
+        <li><strong>ICN does not replace people with software.</strong> Deliberation, interpretation, and care remain human.</li>
+        <li><strong>ICN does not eliminate politics.</strong> Disagreement, negotiation, and contested judgment are still human work.</li>
+        <li><strong>ICN does not make institutions automatically fair.</strong> A legible rule can still be a bad rule.</li>
+        <li><strong>ICN does not collapse all institutions into one model.</strong> Scopes are distinct; federations do not erase their members.</li>
+        <li><strong>ICN does not require blind faith in external authorities.</strong> Sovereignty in the ICN sense is operational — a member can verify their own standing.</li>
+      </ul>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="container narrow">
+      <ReadingLadder current="how-it-works" />
+    </div>
+  </section>
+</Layout>
+
+<style>
+.narrow { max-width: 780px; }
+.page-hero { display: flex; flex-direction: column; gap: var(--space-md); align-items: flex-start; }
+.page-hero .badge { align-self: flex-start; }
+.page-hero h1 { margin: 0; font-size: clamp(1.625rem, 3.6vw, 2.25rem); line-height: 1.25; }
+.lead { font-size: 1.125rem; color: var(--text-body); line-height: 1.6; margin: 0; }
+
+.prose h2 {
+  margin-top: var(--space-2xl); margin-bottom: var(--space-md);
+  display: flex; align-items: baseline; gap: var(--space-md); flex-wrap: wrap;
+}
+.prose h3 { margin-top: var(--space-xl); margin-bottom: var(--space-md); }
+.prose p { margin: 0 0 var(--space-md); line-height: 1.7; }
+.prose ul { margin: var(--space-md) 0; padding-left: var(--space-lg); }
+.prose li { margin-bottom: var(--space-sm); line-height: 1.7; }
+
+/* .maturity-badge styles moved to MaturityBadge component (scoped). */
+</style>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,339 +1,375 @@
-﻿---
+---
 import Layout from '../layouts/Layout.astro';
 import NetworkGraph from '../components/NetworkGraph.astro';
-
-
-const commitUrl = 'https://github.com/InterCooperative-Network/icn/commits/main';
+import ClosureLoop from '../components/ClosureLoop.astro';
+import Icon from '../components/Icon.astro';
+import MaturityGrid from '../components/MaturityGrid.astro';
+import MaturityCard from '../components/MaturityCard.astro';
 ---
 
-<Layout title="Institutional Infrastructure for Cooperative Organizations" activeNav="home">
+<Layout title="Institutional infrastructure for cooperatives, communities, and federations" activeNav="home">
 
   <!-- ═══ HERO ═══════════════════════════════════════════════════ -->
-  <section class="hero relative overflow-hidden">
-    <div class="absolute inset-0 z-0 opacity-40 pointer-events-auto">
+  <section class="hero hero-home">
+    <div class="hero-graph" aria-hidden="true">
       <NetworkGraph />
     </div>
 
-    <div class="container relative z-10">
+    <div class="container narrow hero-container">
       <div class="hero-content animate-in">
         <div class="badge badge-teal mb-lg">
           <span class="badge-dot"></span>
-          Active Development · Stage A: Institution-in-a-Box
+          Active project · open infrastructure
         </div>
 
         <h1>
-          Institutional infrastructure<br/>
-          <span class="gradient-text">for cooperative organizations.</span>
+          Digital infrastructure for<br/>
+          <span class="gradient-text">cooperatives, communities, and federations.</span>
         </h1>
 
         <p>
-          ICN provides identity, governance, accounting, and trust as shared infrastructure —
-          not a platform, not a hosted service.
-          Auditable decisions, provenance receipts, and member-owned coordination
-          for real organizations.
+          ICN makes membership, governance, shared rules, economic coordination,
+          and institutional accountability native to the system itself —
+          so decisions, action, and proof do not have to live in separate worlds.
         </p>
 
         <div class="hero-actions">
-          <a href="/docs/GETTING_STARTED" class="btn btn-primary">
-            Developer Docs
+          <a href="/what-is-icn" class="btn btn-primary">
+            What is ICN
             <svg class="btn-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"/></svg>
           </a>
-          <a href="https://github.com/InterCooperative-Network/icn" target="_blank" class="btn btn-secondary">
-            <svg class="btn-icon" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
-            View on GitHub
-          </a>
-          <a href="/about" class="btn btn-ghost">About the Project</a>
+          <a href="/how-it-works" class="btn btn-secondary">How It Works</a>
+          <a href="/whats-real-now" class="btn btn-ghost">What's Real Now</a>
         </div>
-        <p class="hero-qualifier">Requires building from source — no hosted instance yet.</p>
-      </div>
-    </div>
+        <p class="hero-qualifier">Under active construction. This site is explicit about what is proven, what is advancing, and what is not yet built.</p>
       </div>
     </div>
     <div class="hero-bg-grid" aria-hidden="true"></div>
   </section>
 
-  <!-- ═══ USE CASES ══════════════════════════════════════════════ -->
-  <section class="section">
-    <div class="container">
-      <div class="section-header">
-        <span class="badge badge-amber">What You Can Build</span>
-        <h2>From governance to settlement,<br/><span class="shimmer-text">with a real audit trail.</span></h2>
+  <!-- ═══ PROBLEM ═══════════════════════════════════════════════ -->
+  <section class="section section-tight">
+    <div class="container narrow">
+      <div class="section-header section-header-left">
+        <span class="badge badge-amber">The Problem</span>
+        <h2>Most institutions run across tools that were never designed for them.</h2>
+      </div>
+      <div class="prose-block">
         <p>
-          ICN provides the core institutional primitives: identity, governance, accounting, and coordination.
-          Built for organizations that need auditable decisions and member-owned infrastructure.
+          Governance happens in meetings and minutes. Policy lives in documents that are read inconsistently.
+          Membership sits in a CRM built for a sales team. Accounting lives in a system that has no idea
+          what was decided. Execution depends on whoever remembered what they were supposed to do.
+        </p>
+        <p>
+          Each tool is fine in isolation. Together, they produce drift.
+          Decisions do not reliably become action. Rules do not reliably bind practice.
+          Accountability decays into trust in individual people instead of trust in the institution.
+        </p>
+        <p>
+          Underneath all of this sits a deeper problem: most of the systems we depend on
+          do not answer to the people who live inside them. They answer to ownership, management,
+          capital, or centralized administration. Democratic institutions are forced to operate
+          through software that fights the way they are supposed to work.
         </p>
       </div>
-
-      <div class="grid grid-3">
-        <div class="use-case-card card card-accent-teal animate-in">
-          <div class="card-icon">🏛️</div>
-          <h3>Form a Cooperative</h3>
-          <p>Members get cryptographic identities they own and control. Submit founding rules as a CCL document. Open a treasury ledger. Start running proposals. No platform account, no central admin required.</p>
-          <div class="card-footer">
-            <span class="tech-pill">Identity · Crypto</span>
-            <span class="tech-pill">Charter · Bylaws</span>
-          </div>
-        </div>
-
-        <div class="use-case-card card card-accent-amber animate-in animate-delay-1">
-          <div class="card-icon">🗳️</div>
-          <h3>Run Democratic Votes</h3>
-          <p>Any member proposes. Any member votes. Every decision produces a verifiable receipt — not a spreadsheet in someone's inbox. Six months later, you can prove exactly what was decided and who voted.</p>
-          <div class="card-footer">
-            <span class="tech-pill">Proposals · Tally</span>
-            <span class="tech-pill">Receipts · Proofs</span>
-          </div>
-        </div>
-
-        <div class="use-case-card card card-accent-green animate-in animate-delay-2">
-          <div class="card-icon">🌐</div>
-          <h3>Federate With Others</h3>
-          <p>Connect organizations through formal trust agreements. Shared trust graphs, cross-coop governance receipts, and coordinated accounting. Federation is a native protocol — not a bolt-on integration.</p>
-          <div class="card-footer">
-            <span class="tech-pill">Trust Graph</span>
-            <span class="tech-pill">Mutual Credit</span>
-          </div>
-        </div>
-      </div>
     </div>
-  </section>﻿
-  <!-- ═══ DEMO CALLOUT ══════════════════════════════════════════ -->
+  </section>
+
+  <!-- ═══ WHAT ICN DOES — INSTITUTIONAL PRIMITIVES ═════════════ -->
   <section class="section-alt">
     <div class="container">
-      <div class="demo-callout">
-        <div class="demo-text">
-          <span class="badge badge-green">Live on K3s</span>
-          <h2>Five coordination flows.<br/>Running on live infrastructure.</h2>
-          <p>
-            Brightworks Collective governs by vote. Harbor Freight Workers settles patronage dividends.
-            Rochester Cooperative Clearinghouse runs the treasury. New England Mesh files compliance reports.
-            Finger Lakes CDN submits compute tasks to the commons pool.
-            Five flows. Five cryptographic receipts. No central server.
-          </p>
-          <div class="demo-actions">
-            <a href="/docs/demo" class="btn btn-primary">
-              Demo Walkthrough →
-            </a>
-            <a href="https://github.com/InterCooperative-Network/icn/tree/main/demo" target="_blank" class="btn btn-ghost">
-              View Scripts on GitHub
-              <svg class="btn-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
-            </a>
+      <div class="section-header">
+        <span class="badge badge-teal">What ICN Does</span>
+        <h2>Closes the institutional loop.</h2>
+        <p>
+          ICN is not a management tool layered on top of a generic platform.
+          It is a substrate where the pieces of institutional life hold together
+          as stations of one coherent loop.
+        </p>
+      </div>
+
+      <div class="grid grid-3 inst-grid">
+        <article class="inst-card acc-teal">
+          <div class="inst-card-eyebrow">
+            <span class="inst-card-icon" aria-hidden="true"><Icon name="identity" size={18} /></span>
+            <div class="inst-card-eyebrow-labels">
+              <span class="inst-card-num">01 · 02 · 03</span>
+              <span>Identity · Standing · Authority</span>
+            </div>
           </div>
-          <p class="demo-note">
-            Requires kubectl access to the K3s cluster. Run any flow:
-            <code>bash demo/scripts/flow-1-governance.sh [--present | --narrated]</code>
-          </p>
-        </div>
-        <div class="demo-terminal">
-          <div class="terminal-header">
-            <span class="terminal-dot red"></span>
-            <span class="terminal-dot yellow"></span>
-            <span class="terminal-dot green"></span>
-            <span class="terminal-title">flow-1-governance.sh · flow-5-compute.sh</span>
+          <h3>Scopes as first-class institutions</h3>
+          <p>A member, a cooperative, a community, a federation, and a commons are each a scope the system knows about directly — with their own rules, members, and history. Not user groups layered on a platform.</p>
+        </article>
+        <article class="inst-card acc-amber">
+          <div class="inst-card-eyebrow">
+            <span class="inst-card-icon" aria-hidden="true"><Icon name="governance" size={18} /></span>
+            <div class="inst-card-eyebrow-labels">
+              <span class="inst-card-num">04 · 05 · 07</span>
+              <span>Governance · Policy · Execution</span>
+            </div>
           </div>
-          <pre class="terminal-body"><code><span class="t-dim">✓</span> Brightworks: <span class="t-teal">did:icn:zH4PkcBG8jyyQ18wsFKJZ...</span>
-<span class="t-dim">✓</span> Harbor:      <span class="t-teal">did:icn:zM9jxVQaTpzfh2wPishDw...</span>
-<span class="t-dim">✓</span> Finger Lakes: <span class="t-teal">did:icn:zE5E8bz7XrJGr6WozTbUN...</span>
-
-<span class="t-dim">✓</span> Governance: <span class="t-heading">"Expand to Digital Services"</span>
-<span class="t-dim">✓</span> Alice: <span class="t-green">FOR</span>  · Bob: <span class="t-green">FOR</span>  · Carol: <span class="t-green">FOR</span>
-<span class="t-dim">✓</span> Accepted — decision_hash: <span class="t-purple">9a717129bb8c70a0...</span>
-
-<span class="t-dim">✓</span> Patronage round: 3 members · <span class="t-amber">$4,200 allocated</span>
-<span class="t-dim">✓</span> Harbor compliance report: <span class="t-amber">127 transactions signed</span>
-
-<span class="t-dim">✓</span> Compute trust gate: <span class="t-green">0.85 ≥ 0.1 PASS</span>
-<span class="t-dim">✓</span> Task admitted: <span class="t-heading">fl-route-opt-847291</span>
-<span class="t-dim">✓</span> hash: <span class="t-purple">a8f2d4e9c1b7...</span>  status: <span class="t-amber">Pending</span></code></pre>
-        </div>
+          <h3>Governance that carries into action</h3>
+          <p>Proposals, deliberation, and accepted decisions produce durable records. A kernel-dispatch bridge translates accepted payloads into operational effect — widening that coverage is the active frontier.</p>
+        </article>
+        <article class="inst-card acc-green">
+          <div class="inst-card-eyebrow">
+            <span class="inst-card-icon" aria-hidden="true"><Icon name="provenance" size={18} /></span>
+            <div class="inst-card-eyebrow-labels">
+              <span class="inst-card-num">08</span>
+              <span>Receipts · Provenance</span>
+            </div>
+          </div>
+          <h3>Provenance as institutional memory</h3>
+          <p>Every outcome traces back through the rule that shaped it, the decision that authorized it, and the members who held standing. The chain is the record the institution runs on — not an audit log bolted on after.</p>
+        </article>
+        <article class="inst-card acc-blue">
+          <div class="inst-card-eyebrow">
+            <span class="inst-card-icon" aria-hidden="true"><Icon name="accounting" size={18} /></span>
+            <div class="inst-card-eyebrow-labels">
+              <span class="inst-card-num">06</span>
+              <span>Accounting</span>
+            </div>
+          </div>
+          <h3>Economics as governed social accounting</h3>
+          <p>Obligations, treasury with budgets and approvals, patronage settlement, mutual-credit positions, and usage-rights accounting. Relational, denominated in obligations between real parties — not a payment rail.</p>
+        </article>
+        <article class="inst-card acc-purple">
+          <div class="inst-card-eyebrow">
+            <span class="inst-card-icon" aria-hidden="true"><Icon name="federation" size={18} /></span>
+            <div class="inst-card-eyebrow-labels">
+              <span class="inst-card-num">Cross-scope</span>
+              <span>Federation</span>
+            </div>
+          </div>
+          <h3>Federation as treaty, not merger</h3>
+          <p>Cooperatives enter formal agreements, exchange attestations, and settle obligations across their boundaries through cross-institutional clearing — without being dissolved into a single organization.</p>
+        </article>
+        <article class="inst-card acc-rose">
+          <div class="inst-card-eyebrow">
+            <span class="inst-card-icon" aria-hidden="true"><Icon name="commons" size={18} /></span>
+            <div class="inst-card-eyebrow-labels">
+              <span class="inst-card-num">Shared scope</span>
+              <span>Commons · Compute</span>
+            </div>
+          </div>
+          <h3>Commons and compute as shared infrastructure</h3>
+          <p>Shared resources and coordinated work across the network — with clearing, trust-aware placement, and dispute resolution — participate in the same loop as governance and accounting, not a separate system.</p>
+        </article>
       </div>
     </div>
   </section>
 
-  <!-- ═══ THE MEANING FIREWALL ═══════════════════════════════════ -->
-  <section class="section">
-    <div class="container">
-      <div class="section-header">
-        <span class="badge badge-teal">The Architecture</span>
-        <h2>Not a blockchain. Not a server.<br/><span class="shimmer-text">A coordination engine.</span></h2>
+  <!-- ═══ THE CLOSURE LOOP ═════════════════════════════════════ -->
+  <section class="section section-closure">
+    <div class="container narrow">
+      <div class="section-header section-header-left">
+        <span class="badge badge-teal">The Closure Loop</span>
+        <h2>Nine stations, one institution.</h2>
         <p>
-          ICN runs as a peer-to-peer service. Your co-op's rules get translated into enforceable constraints.
-          The engine enforces them mechanically — it doesn't interpret what they mean, it just makes sure they're followed.
-          This is the <strong style="color: var(--text-heading)">Meaning Firewall</strong>.
+          Every serious institution runs on a chain: a member has standing,
+          standing confers authority, authority produces decisions, decisions bind action,
+          and the record of what happened becomes the basis for the next round of standing.
+          ICN carries that chain as one substrate, station by station.
         </p>
       </div>
 
-      <div class="firewall-diagram">
-        <div class="fw-layer">
-          <div class="fw-box fw-app">
-            <span class="fw-label">CCL Document</span>
-            <span class="fw-desc">constitution · bylaws · treaty · budget</span>
-          </div>
-        </div>
-        <div class="fw-arrow">↓</div>
-        <div class="fw-layer fw-row">
-          <div class="fw-box fw-oracle">
-            <span class="fw-label">Governance</span>
-            <span class="fw-desc">proposals · votes · delegation</span>
-          </div>
-          <div class="fw-box fw-oracle">
-            <span class="fw-label">Trust Graph</span>
-            <span class="fw-desc">attestations · scores · propagation</span>
-          </div>
-          <div class="fw-box fw-oracle">
-            <span class="fw-label">Ledger</span>
-            <span class="fw-desc">mutual credit · treasury · clearing</span>
-          </div>
-        </div>
-        <div class="fw-arrow">↓ <span class="fw-firewall-label">MEANING FIREWALL</span></div>
-        <div class="fw-layer">
-          <div class="fw-box fw-kernel">
-            <span class="fw-label">Kernel</span>
-            <span class="fw-desc">enforces constraints mechanically — no domain semantics</span>
-          </div>
-        </div>
+      <ClosureLoop variant="full" title="Read top to bottom — the loop closes at 09" />
+
+      <p class="closure-footnote">
+        The <a href="/what-is-icn">What is ICN</a> page walks through each station in plain language.
+        <a href="/how-it-works">How It Works</a> carries the same loop as a subsystem-by-subsystem account,
+        with explicit maturity banding on each station.
+      </p>
+    </div>
+  </section>
+
+  <!-- ═══ WHAT'S REAL NOW ═══════════════════════════════════════ -->
+  <section class="section">
+    <div class="container narrow">
+      <div class="section-header section-header-left">
+        <span class="badge badge-green">What's Real Now</span>
+        <h2>Uneven, but real.</h2>
+        <p>
+          ICN is an active infrastructure project with different parts at different levels of maturity.
+          We would rather be trusted than impressive.
+        </p>
       </div>
 
+      <MaturityGrid>
+        <MaturityCard band="strong">
+          <p>Provenance and auditable coordination — receipts, decision-to-outcome chains, and the institutional memory the rest of the system depends on. Cryptographic identity and membership primitives are in place.</p>
+        </MaturityCard>
+        <MaturityCard band="advancing">
+          <p>Execution coverage: a kernel-dispatch bridge exists and widening the set of accepted governance payloads it translates into operational effect is the active frontier. Policy binding practice is the adjacent frontier.</p>
+        </MaturityCard>
+        <MaturityCard band="maturing">
+          <p>Federation (treaties, attestations, cross-institutional clearing) and commons/compute (shared infrastructure with clearing, placement, and dispute resolution) have serious implementation. Their public-facing surfaces still lag.</p>
+        </MaturityCard>
+        <MaturityCard band="behind">
+          <p>The member-facing experience — where identity, standing, governance, accounting, and receipts converge into something a person can actually see and use — is the part most visibly trailing the substrate underneath.</p>
+        </MaturityCard>
+      </MaturityGrid>
+
       <div class="text-center mt-xl">
-        <a href="/architecture" class="btn btn-secondary">Full Architecture →</a>
+        <a href="/whats-real-now" class="btn btn-secondary">Read the full account →</a>
       </div>
     </div>
-  </section>﻿
-  <!-- ═══ FOR DEVELOPERS ════════════════════════════════════════ -->
+  </section>
+
+  <!-- ═══ WHO IT'S FOR ══════════════════════════════════════════ -->
   <section class="section-alt">
     <div class="container">
-      <div class="dev-grid">
-        <div class="dev-text">
-          <span class="badge badge-teal">For Developers</span>
-          <h2>Pure Rust.<br/>Zero central servers.</h2>
+      <div class="section-header">
+        <span class="badge badge-purple">Who It's For</span>
+        <h2>Institutions, not user groups.</h2>
+      </div>
+
+      <div class="grid grid-2">
+        <div class="card">
+          <h3>Cooperatives, communities, and federations</h3>
           <p>
-            ICN is built entirely in Rust. No central servers, no runtime dependencies on anyone else's infrastructure.
-            Three binaries: <code>icnd</code> (daemon), <code>icn-cli</code> (tooling), and a gateway.
-            Core subsystems organized around the Meaning Firewall.
+            Organizations that already know how hard running a real institution is,
+            and are tired of doing it through software that was never designed for the job.
+            ICN is being built for you — and we try to be honest about what is usable today
+            versus what is still being built.
           </p>
-          <div class="crate-table">
-            <div class="crate-section">
-              <div class="crate-section-label teal">Kernel (Domain-Agnostic)</div>
-              <div class="crate-row"><code>icn-core</code><span>Tokio runtime, supervisor, actor lifecycle</span></div>
-              <div class="crate-row"><code>icn-net</code><span>QUIC/TLS sessions, mDNS discovery</span></div>
-              <div class="crate-row"><code>icn-gossip</code><span>Topic-based replication, causal ordering</span></div>
-              <div class="crate-row"><code>icn-identity</code><span>DIDs, Ed25519 keypairs, Age keystore</span></div>
-              <div class="crate-row"><code>icn-gateway</code><span>REST + WebSocket API, static demo UI</span></div>
-            </div>
-            <div class="crate-section">
-              <div class="crate-section-label amber">Apps (Policy Oracles)</div>
-              <div class="crate-row"><code>apps/governance</code><span>Proposals, voting, delegation, receipts</span></div>
-              <div class="crate-row"><code>apps/trust</code><span>Trust graph → rate limits, credit multipliers</span></div>
-              <div class="crate-row"><code>apps/ledger</code><span>Mutual credit, settlement, fork resolution</span></div>
-              <div class="crate-row"><code>icn-ccl</code><span>Contract language, fuel-metered interpreter, governance</span></div>
-            </div>
-          </div>
-          <div class="dev-ctas">
-            <a href="/docs/GETTING_STARTED" class="btn btn-teal">Quick Start →</a>
-            <a href="https://github.com/InterCooperative-Network/icn/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer" class="btn btn-ghost">Contributing →</a>
-            <a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener noreferrer" class="btn btn-ghost">
-              ★ Star on GitHub
-            </a>
-          </div>
+          <a href="/for-cooperatives" class="link-arrow">For Cooperatives →</a>
+        </div>
+        <div class="card">
+          <h3>Developers, architects, and researchers</h3>
+          <p>
+            Technical readers evaluating ICN as a system. Kernel/app separation with a strict meaning firewall,
+            trust-native architecture, mutual-credit accounting, and an honest account of current implementation state.
+          </p>
+          <a href="/for-developers" class="link-arrow">For Developers →</a>
         </div>
       </div>
     </div>
   </section>
 
-  <!-- ═══ STAGES (FOR FUNDERS + CO-OPS) ════════════════════════ -->
+  <!-- ═══ WHY IT MATTERS ════════════════════════════════════════ -->
   <section class="section">
-    <div class="container">
-      <div class="section-header">
-        <span class="badge badge-purple">Digital Public Infrastructure</span>
-        <h2>Four stages.<br/><span class="gradient-text-warm">Built in sequence.</span></h2>
+    <div class="container narrow">
+      <div class="section-header section-header-left">
+        <span class="badge badge-amber">Why It Matters</span>
+        <h2>Advanced technology, primitive institutional forms.</h2>
+      </div>
+      <div class="prose-block">
         <p>
-          ICN is infrastructure-in-progress, built in traceable stages.
-          Each stage extends what real organizations can do with it.
+          We have built extraordinary software over the last forty years and used almost none of it
+          to make our institutions more legible, more accountable, or more co-authored by the people inside them.
+          Most of our collective life still runs on tools built for firms, platforms, and administrative convenience.
+        </p>
+        <p>
+          ICN is one attempt to close that gap. Not by replacing deliberation, judgment, politics,
+          or human responsibility — those stay with people — but by giving institutions better memory,
+          better continuity, better accountability, better legibility, and better collective capacity.
+          So that the work of running a cooperative, a community, or a federation rests on something
+          more durable than whoever happens to be holding the pieces together today.
+        </p>
+        <p>
+          That is a narrower claim than "ICN fixes democratic institutions," and a more honest one.
         </p>
       </div>
-
-      <div class="stages-grid">
-        <div class="stage-card stage-active card animate-in">
-          <div class="stage-num stage-a">A</div>
-          <div class="stage-body">
-            <div class="stage-status">
-              <span class="badge badge-green">Active Now</span>
-            </div>
-            <h3>Institution-in-a-Box</h3>
-            <p>Charter templates and guided cooperative formation. Membership onboarding. Treasury ledger. Proposal-to-vote loop. The minimum viable institution.</p>
-          </div>
-        </div>
-
-        <div class="stage-card card animate-in animate-delay-1">
-          <div class="stage-num stage-b">B</div>
-          <div class="stage-body">
-            <div class="stage-status">
-              <span class="badge badge-blue">In Development</span>
-            </div>
-            <h3>Federation Layer</h3>
-            <p>Inter-cooperative trust and federated coordination live on K3s. Shared trust graphs, cross-coop governance receipts, and ledger integration proven. Treaty-based clearing follows.</p>
-          </div>
-        </div>
-
-        <div class="stage-card card animate-in animate-delay-2">
-          <div class="stage-num stage-c">C</div>
-          <div class="stage-body">
-            <div class="stage-status">
-              <span class="badge badge-purple">In Development</span>
-            </div>
-            <h3>Compute Commons</h3>
-            <p>Trust-gated compute task admission is live on K3s: scope enforcement, trust score gate, and ledger integration proven. Task execution and settlement receipts follow.</p>
-          </div>
-        </div>
-
-        <div class="stage-card card animate-in animate-delay-3">
-          <div class="stage-num stage-d">D</div>
-          <div class="stage-body">
-            <h3>Civic and Public Scale</h3>
-            <p>Participatory budgeting, municipal governance, and public infrastructure coordination. Long-term trajectory — the architecture is designed for it, but this work is not yet underway.</p>
-          </div>
-        </div>
-      </div>
-
-      <div class="text-center mt-xl">
-        <a href="/roadmap" class="btn btn-secondary">Full Roadmap →</a>
-      </div>
     </div>
   </section>
 
-  <!-- ═══ CTA ═══════════════════════════════════════════════════ -->
+  <!-- ═══ EXPLORE ═══════════════════════════════════════════════ -->
   <section class="section-alt">
     <div class="container">
       <div class="cta-box">
-        <h2>Cooperative infrastructure, built in the open.</h2>
+        <h2>Where to go next</h2>
         <p>
-          ICN is open source infrastructure for organizations that need auditable governance,
-          member-owned accounting, and coordinated federation.
-          Contributions welcome — code, documentation, governance patterns, or use cases.
+          ICN is being built as one coherent institutional substrate, not a pile of features.
+          The public narrative pages are written to be read in order.
+          If any claim on this site does not match what you see in the code,
+          that is a bug in the site and we want to know.
         </p>
-        <div class="hero-actions" style="justify-content: center;">
-          <a href="/docs/GETTING_STARTED" class="btn btn-primary">Get Started →</a>
-          <a href="/docs/CONTRIBUTING" class="btn btn-secondary">Contribute →</a>
-          <a href="https://github.com/InterCooperative-Network/icn" target="_blank" class="btn btn-ghost">Star on GitHub ☆</a>
+        <div class="next-step">
+          <span class="next-label">Start here →</span>
+          <a href="/what-is-icn" class="btn btn-primary btn-lg">What is ICN</a>
+        </div>
+        <div class="reading-order">
+          <span class="reading-order-label">Reading order</span>
+          <ol class="reading-order-list">
+            <li><a href="/what-is-icn">What is ICN</a></li>
+            <li><a href="/why-icn">Why ICN</a></li>
+            <li><a href="/how-it-works">How It Works</a></li>
+            <li><a href="/whats-real-now">What's Real Now</a></li>
+            <li><a href="/for-cooperatives">For Cooperatives</a> <span class="or">or</span> <a href="/for-developers">For Developers</a></li>
+          </ol>
         </div>
       </div>
     </div>
   </section>
-</Layout>﻿
+
+</Layout>
+
 <style>
-/* Hero */
+/* Homepage hero — override the global .hero to a more reasonable shape */
+.hero-home {
+  position: relative;
+  overflow: hidden;
+  min-height: 0;
+  height: auto;
+  display: block;
+  padding-top: calc(64px + var(--space-3xl));
+  padding-bottom: var(--space-3xl);
+}
+.hero-container {
+  position: relative;
+  z-index: 2;
+}
+.hero-home .hero-content {
+  max-width: 760px;
+}
+.hero-home .hero-content h1 {
+  font-size: clamp(2.25rem, 5.5vw, 3.75rem);
+  line-height: 1.08;
+}
+.hero-home .hero-content > p {
+  max-width: 40em;
+  font-size: 1.0625rem;
+  line-height: 1.6;
+}
+
+/* NetworkGraph wrapper: anchored right, masked so it never touches the headline.
+   Labels are hidden on the homepage — the graph reads as abstract background texture. */
+.hero-graph {
+  position: absolute;
+  top: 0;
+  right: -8%;
+  bottom: 0;
+  width: 50%;
+  opacity: 0.18;
+  pointer-events: none;
+  z-index: 0;
+  mask-image: linear-gradient(
+    to right,
+    transparent 0%,
+    transparent 15%,
+    rgba(0,0,0,0.6) 50%,
+    black 90%
+  );
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent 0%,
+    transparent 15%,
+    rgba(0,0,0,0.6) 50%,
+    black 90%
+  );
+}
+.hero-graph :global(svg text) {
+  display: none;
+}
+@media (max-width: 1100px) {
+  .hero-graph { display: none; }
+}
+
 .hero-qualifier {
   font-size: .8125rem; color: var(--text-muted);
-  margin: var(--space-sm) 0 0; letter-spacing: .01em;
+  margin: var(--space-sm) 0 0; letter-spacing: .01em; max-width: 42em;
 }
-.relative { position: relative; }
-.overflow-hidden { overflow: hidden; }
-.absolute { position: absolute; }
-.inset-0 { inset: 0; }
-.z-0 { z-index: 0; }
-.z-10 { z-index: 10; }
-.pointer-events-auto { pointer-events: auto; }
-.pointer-events-none { pointer-events: none; }
 .badge-dot {
   width: 6px; height: 6px; border-radius: 50%;
   background: var(--accent-teal); display: inline-block;
@@ -352,126 +388,137 @@ const commitUrl = 'https://github.com/InterCooperative-Network/icn/commits/main'
   pointer-events: none;
 }
 
-/* Use cases */
-.card-icon { font-size: 2rem; margin-bottom: var(--space-md); }
-.card-footer { margin-top: var(--space-md); display: flex; gap: var(--space-xs); flex-wrap: wrap; }
-.tech-pill {
-  font-size: .6875rem; font-family: var(--font-mono);
-  background: var(--bg-surface); border: 1px solid var(--border-subtle);
-  border-radius: 999px; padding: .2em .6em; color: var(--text-muted);
+/* Tighten the section right after the hero so the fold is not empty */
+.hero-home + .section-tight {
+  padding-top: var(--space-xl);
 }
 
-/* Demo callout */
-.demo-callout {
-  display: grid; grid-template-columns: 1fr 1fr;
-  gap: var(--space-3xl); align-items: center;
+/* Left-aligned section headers inside narrow containers */
+.section-header-left {
+  text-align: left !important;
+  max-width: none !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+  align-items: flex-start;
 }
-.demo-text { display: flex; flex-direction: column; gap: var(--space-lg); }
-.demo-text h2 { margin: 0; }
-.demo-text > p { margin: 0; }
-.demo-actions { display: flex; gap: var(--space-sm); flex-wrap: wrap; }
-.demo-note { font-size: .875rem; color: var(--text-muted); margin: 0; }
+.section-header-left h2,
+.section-header-left p {
+  text-align: left;
+  margin-left: 0;
+  margin-right: 0;
+}
 
-.demo-terminal {
-  background: var(--bg-code); border: 1px solid var(--border-default);
-  border-radius: var(--radius-xl); overflow: hidden;
-  box-shadow: var(--shadow-lg), 0 0 40px rgba(45,212,191,.06);
+/* Narrow container for prose sections */
+.narrow { max-width: 760px; margin-left: auto; margin-right: auto; }
+.prose-block p {
+  margin: 0 0 var(--space-md); line-height: 1.7;
+  font-size: 1.0625rem; color: var(--text-body);
 }
-.terminal-header {
-  display: flex; align-items: center; gap: var(--space-xs);
-  padding: var(--space-sm) var(--space-md);
-  background: rgba(255,255,255,.04); border-bottom: 1px solid var(--border-subtle);
-}
-.terminal-dot {
-  width: 12px; height: 12px; border-radius: 50%;
-}
-.terminal-dot.red { background: #ff5f57; }
-.terminal-dot.yellow { background: #ffbd2e; }
-.terminal-dot.green { background: #28ca41; }
-.terminal-title { font-size: .75rem; color: var(--text-muted); margin-left: auto; font-family: var(--font-mono); }
-.terminal-body {
-  margin: 0; padding: var(--space-lg); border: none; border-radius: 0;
-  font-size: .8rem; line-height: 1.9; overflow-x: auto;
-}
-.t-dim { color: var(--text-muted); }
-.t-teal { color: var(--accent-teal); }
-.t-amber { color: var(--accent-amber); }
-.t-green { color: var(--accent-green); }
-.t-purple { color: var(--accent-purple); }
-.t-heading { color: var(--text-heading); }
+.prose-block p:last-child { margin-bottom: 0; }
 
-/* Meaning Firewall */
-.firewall-diagram { max-width: 700px; margin: 0 auto; display: flex; flex-direction: column; gap: 0; }
-.fw-layer { display: flex; justify-content: center; }
-.fw-row { gap: var(--space-md); }
-.fw-box {
-  background: var(--bg-card); border: 1px solid var(--border-default);
-  border-radius: var(--radius-lg); padding: var(--space-lg) var(--space-xl);
-  text-align: center; flex: 1;
-  transition: all var(--duration-normal) var(--ease-out);
+/* Institutional card grid — paired with .inst-card class in global.css.
+   Adds a tighter gap than the default .grid gap for a denser system feel. */
+.inst-grid { gap: var(--space-md); }
+
+/* Closure loop section — slightly tighter padding than default, with
+   a quieter footnote link row. */
+.section-closure { padding-top: var(--space-3xl); padding-bottom: var(--space-3xl); }
+.closure-footnote {
+  margin-top: var(--space-xl);
+  font-size: 0.9375rem;
+  color: var(--text-muted);
+  line-height: 1.6;
 }
-.fw-box:hover { transform: translateY(-2px); }
-.fw-app { border-left: 3px solid var(--accent-purple); }
-.fw-oracle { border-left: 3px solid var(--accent-amber); }
-.fw-kernel { border-left: 3px solid var(--accent-teal); }
-.fw-label { display: block; font-family: var(--font-heading); font-weight: 700; font-size: 1.0625rem; color: var(--text-heading); }
-.fw-desc { display: block; font-size: .75rem; color: var(--text-muted); margin-top: var(--space-xs); }
-.fw-arrow { text-align: center; font-size: 1.5rem; color: var(--text-muted); padding: var(--space-sm) 0; display: flex; align-items: center; justify-content: center; gap: var(--space-md); }
-.fw-firewall-label { font-size: .6875rem; font-family: var(--font-mono); letter-spacing: .15em; color: var(--accent-amber); text-transform: uppercase; }
+.closure-footnote a { color: var(--accent-teal); border-bottom: 1px solid transparent; }
+.closure-footnote a:hover { border-bottom-color: var(--accent-teal); }
 
-/* Developer section */
-.dev-grid { max-width: 800px; }
-.crate-table { margin-top: var(--space-xl); display: flex; flex-direction: column; gap: var(--space-xl); }
-.crate-section { display: flex; flex-direction: column; gap: var(--space-sm); }
-.crate-section-label { font-size: .6875rem; text-transform: uppercase; letter-spacing: .1em; font-weight: 700; margin-bottom: var(--space-xs); }
-.crate-section-label.teal { color: var(--accent-teal); }
-.crate-section-label.amber { color: var(--accent-amber); }
-.crate-row { display: flex; gap: var(--space-md); align-items: baseline; font-size: .875rem; }
-.crate-row code { font-size: .8125rem; white-space: nowrap; flex-shrink: 0; }
-.crate-row span { color: var(--text-muted); }
-.dev-ctas { display: flex; gap: var(--space-sm); flex-wrap: wrap; margin-top: var(--space-xl); }
+/* Status grid styles moved to MaturityGrid/MaturityCard components. */
 
-/* Stages */
-.stages-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: var(--space-lg); }
-.stage-card { display: flex; gap: var(--space-md); align-items: flex-start; }
-.stage-active { border-color: rgba(74,222,128,0.3); background: linear-gradient(135deg, var(--bg-card), rgba(74,222,128,0.04)); }
-.stage-num {
-  width: 44px; height: 44px; border-radius: var(--radius-md);
-  display: flex; align-items: center; justify-content: center;
-  font-family: var(--font-heading); font-weight: 800; font-size: 1.25rem; flex-shrink: 0;
+/* Link-arrow style for card CTAs */
+.link-arrow {
+  display: inline-block; margin-top: var(--space-md);
+  font-weight: 600; color: var(--accent-teal);
+  text-decoration: none;
 }
-.stage-a { background: var(--accent-green-glow); color: var(--accent-green); }
-.stage-b { background: rgba(56,189,248,.12); color: var(--accent-blue); }
-.stage-c { background: rgba(167,139,250,.12); color: var(--accent-purple); }
-.stage-d { background: var(--accent-amber-glow); color: var(--accent-amber); }
-.stage-body { display: flex; flex-direction: column; gap: var(--space-xs); }
-.stage-status { margin-bottom: var(--space-xs); }
-.stage-body h3 { font-size: 1.0625rem; margin: 0; }
-.stage-body p { font-size: .875rem; margin: 0; }
+.link-arrow:hover { text-decoration: underline; }
 
-/* CTA */
-.cta-box { text-align: center; max-width: 700px; margin: 0 auto; }
+/* CTA box */
+.cta-box { text-align: center; max-width: 760px; margin: 0 auto; }
 .cta-box h2 { margin-bottom: var(--space-md); }
-.cta-box > p { margin: 0 auto var(--space-xl); font-size: 1.125rem; }
+.cta-box > p { margin: 0 auto var(--space-xl); font-size: 1.0625rem; color: var(--text-muted); }
 
-@media (max-width: 1000px) {
-  .stages-grid { grid-template-columns: repeat(2, 1fr); }
+.next-step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-xl);
 }
+.next-label {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+}
+.btn-lg { font-size: 1rem; padding: 0.75rem 1.5rem; }
+
+.reading-order {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-top: var(--space-lg);
+  padding-top: var(--space-lg);
+  border-top: 1px solid var(--border-subtle);
+}
+.reading-order-label {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+}
+.reading-order-list {
+  list-style: decimal;
+  padding-left: var(--space-lg);
+  margin: 0;
+  text-align: left;
+  font-size: 0.9375rem;
+  color: var(--text-body);
+  line-height: 1.9;
+}
+.reading-order-list a {
+  color: var(--text-body);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color var(--duration-fast) var(--ease-out);
+}
+.reading-order-list a:hover { border-bottom-color: var(--accent-teal); }
+.or { color: var(--text-muted); font-size: 0.875em; }
+
 @media (max-width: 768px) {
-  .demo-callout { grid-template-columns: 1fr; }
-  .stages-grid { grid-template-columns: 1fr; }
-  .stage-card { flex-direction: row; gap: var(--space-sm); }
-  .stage-num { width: 36px; height: 36px; font-size: 1rem; }
-  .stage-body p { font-size: .8125rem; line-height: 1.5; }
-  .hero-content h1 { font-size: clamp(2rem, 8vw, 3rem); }
-  .hero-content > p { font-size: 1rem; }
-  .crate-table { gap: var(--space-lg); }
-  .crate-row { flex-direction: column; gap: 2px; }
-  .crate-row code { font-size: .75rem; }
-  .crate-row span { font-size: .8125rem; }
-  .fw-grid { grid-template-columns: 1fr !important; }
+  .hero-home {
+    padding-top: calc(64px + var(--space-xl));
+    padding-bottom: var(--space-xl);
+  }
+  .hero-home .hero-content h1 {
+    font-size: clamp(1.75rem, 7vw, 2.5rem);
+    line-height: 1.15;
+  }
+  .hero-home .hero-content > p {
+    font-size: 0.9375rem;
+  }
+  .hero-actions .btn {
+    flex: 1 1 auto;
+    min-width: 140px;
+  }
 }
 @media (max-width: 480px) {
+  .hero-home {
+    padding-top: calc(56px + var(--space-lg));
+  }
   .badge { font-size: .625rem; padding: .2rem .5rem; }
+  .hero-actions .btn { width: 100%; min-width: 0; }
 }
 </style>

--- a/website/src/pages/roadmap.astro
+++ b/website/src/pages/roadmap.astro
@@ -1,43 +1,49 @@
 ---
-// src/pages/roadmap.astro — Project Roadmap
+// src/pages/roadmap.astro — Direction of work, public status
 import Layout from '../layouts/Layout.astro';
-import fs from 'node:fs';
-import { renderMarkdown } from '../lib/markdown';
-import { resolveRepoDoc } from '../lib/paths';
 import roadmap from '../data/roadmap.json';
-
-// Phase history from repo root docs/
-const phaseHistoryPath = resolveRepoDoc('PHASE_HISTORY.md');
-let phaseHtml = '';
-if (fs.existsSync(phaseHistoryPath)) {
-  phaseHtml = renderMarkdown(fs.readFileSync(phaseHistoryPath, 'utf-8'));
-}
 ---
 
-<Layout title="Roadmap" activeNav="roadmap">
-  <section class="section" style="padding-top: calc(64px + var(--space-3xl));">
-    <div class="container">
-      <div class="section-header" style="text-align: left; max-width: none;">
-        <span class="badge badge-amber">Project Roadmap</span>
-        <h1>Development Roadmap</h1>
-        <p>ICN is developed in phases, each building on the last. The project has completed 18+ development milestones across identity, networking, governance, economics, and federation.</p>
-        {roadmap.currentSprint && (
-          <p class="sprint-indicator">
-            Active: <strong>Sprint {roadmap.currentSprint.number}</strong> — {roadmap.currentSprint.name}
-          </p>
-        )}
+<Layout title="Direction of work" activeNav="roadmap" description="Where ICN is concentrating effort right now, the broad areas of work, and honest maturity framing — aligned with What's Real Now.">
+  <section class="hero-section">
+    <div class="container narrow">
+      <div class="page-hero">
+        <span class="badge badge-amber">Direction of work</span>
+        <h1>Where the project is concentrating effort.</h1>
+        <p class="lead">
+          ICN is under active construction. This page describes the broad areas of work and the
+          current emphasis, in language that matches <a href="/whats-real-now">What's Real Now</a>.
+          It is not a schedule. It is not a release plan. It is a public-facing account of where effort is going.
+        </p>
       </div>
     </div>
   </section>
 
-  <!-- Vision roadmap stages (data-driven from src/data/roadmap.json) -->
-  <section class="section-alt">
-    <div class="container">
-      <h2 style="margin-bottom: var(--space-xl);">Product Vision Stages</h2>
-      <div class="roadmap-timeline">
+  {roadmap.currentEmphasis && (
+    <section class="section-alt">
+      <div class="container narrow">
+        <div class="emphasis-card">
+          <div class="emphasis-header">
+            <span class="badge badge-teal">Current emphasis</span>
+            <h2>{roadmap.currentEmphasis.title}</h2>
+          </div>
+          <p>{roadmap.currentEmphasis.detail}</p>
+        </div>
+      </div>
+    </section>
+  )}
+
+  <section class="section">
+    <div class="container narrow">
+      <h2 class="section-title">Broad areas of work</h2>
+      <p class="section-intro">
+        Each area below is at a different level of maturity. The maturity band is stated directly,
+        and every description is reconcilable with <a href="/whats-real-now">What's Real Now</a>.
+      </p>
+      <div class="work-timeline">
         {roadmap.stages.map((stage) => (
-          <div class="timeline-item">
-            <div class="timeline-marker" style={`background: ${stage.markerColor};`}></div>
+          <div class={`timeline-item band-${stage.band}`}>
+            <div class="timeline-marker"></div>
             <div class="timeline-content">
               <span class={`badge ${stage.badge}`}>{stage.label}</span>
               <h3>{stage.title}</h3>
@@ -49,41 +55,121 @@ if (fs.existsSync(phaseHistoryPath)) {
     </div>
   </section>
 
-  <!-- Phase history from repo -->
-  {phaseHtml && (
-    <section class="section">
-      <div class="container-narrow">
-        <span class="badge badge-teal mb-lg">From PHASE_HISTORY.md</span>
-        <article class="prose" set:html={phaseHtml} />
+  <section class="section-alt">
+    <div class="container narrow">
+      <div class="footnote">
+        <h3>A note on what this page is not</h3>
+        <p>
+          This page does not commit the project to dates, releases, or feature schedules.
+          It does not claim percentage progress. It does not report internal sprint or milestone state.
+          When the project's public account needs to move — because implementation has advanced,
+          or because a direction has changed — this page and <a href="/whats-real-now">What's Real Now</a>
+          move together.
+        </p>
+        <p>
+          If any claim here does not match what you see in the code, that is a bug in the site and we want to know.
+        </p>
       </div>
-    </section>
-  )}
+
+      <div class="cta-row">
+        <a href="/whats-real-now" class="btn btn-primary">What's Real Now →</a>
+        <a href="/how-it-works" class="btn btn-secondary">How It Works</a>
+        <a href="/for-developers" class="btn btn-ghost">For Developers</a>
+      </div>
+    </div>
+  </section>
 </Layout>
 
 <style>
-  .roadmap-timeline {
+  .hero-section {
+    padding-top: calc(64px + var(--space-3xl));
+    padding-bottom: var(--space-2xl);
+  }
+  .narrow {
+    max-width: 760px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .page-hero {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+    align-items: flex-start;
+  }
+  .page-hero .badge { align-self: flex-start; }
+  .page-hero h1 {
+    margin: 0;
+    font-size: clamp(1.625rem, 3.8vw, 2.25rem);
+    line-height: 1.25;
+  }
+  .lead {
+    font-size: 1.125rem;
+    color: var(--text-body);
+    line-height: 1.6;
+    margin: 0;
+  }
+
+  .emphasis-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-default);
+    border-left: 3px solid var(--accent-teal);
+    border-radius: var(--radius-lg);
+    padding: var(--space-xl);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+  .emphasis-header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
+  .emphasis-header h2 {
+    margin: 0;
+    font-size: 1.25rem;
+  }
+  .emphasis-card p {
+    margin: 0;
+    line-height: 1.7;
+    color: var(--text-body);
+  }
+
+  .section-title {
+    margin: 0 0 var(--space-md);
+  }
+  .section-intro {
+    margin: 0 0 var(--space-xl);
+    color: var(--text-muted);
+    line-height: 1.6;
+  }
+
+  .work-timeline {
     position: relative;
     padding-left: var(--space-2xl);
   }
-
-  .roadmap-timeline::before {
+  .work-timeline::before {
     content: '';
     position: absolute;
     left: 11px;
     top: 8px;
     bottom: 8px;
     width: 2px;
-    background: linear-gradient(to bottom, var(--accent-teal), var(--accent-blue), var(--accent-purple), var(--accent-amber));
+    background: linear-gradient(
+      to bottom,
+      var(--accent-green),
+      var(--accent-teal),
+      var(--accent-amber),
+      var(--accent-purple)
+    );
     border-radius: 1px;
   }
-
   .timeline-item {
     position: relative;
     padding-bottom: var(--space-2xl);
   }
-
-  .timeline-item:last-child { padding-bottom: 0; }
-
+  .timeline-item:last-child {
+    padding-bottom: 0;
+  }
   .timeline-marker {
     position: absolute;
     left: calc(var(--space-2xl) * -1);
@@ -92,7 +178,12 @@ if (fs.existsSync(phaseHistoryPath)) {
     height: 24px;
     border-radius: 50%;
     border: 3px solid var(--bg-primary);
+    background: var(--text-muted);
   }
+  .band-strong .timeline-marker { background: var(--accent-green); }
+  .band-advancing .timeline-marker { background: var(--accent-teal); }
+  .band-maturing .timeline-marker { background: var(--accent-amber); }
+  .band-notyet .timeline-marker { background: var(--text-muted); }
 
   .timeline-content {
     background: var(--bg-card);
@@ -100,22 +191,39 @@ if (fs.existsSync(phaseHistoryPath)) {
     border-radius: var(--radius-xl);
     padding: var(--space-xl);
   }
-
   .timeline-content h3 {
     margin: var(--space-sm) 0 var(--space-sm);
   }
-
   .timeline-content p {
     margin: 0;
+    line-height: 1.7;
   }
 
-  .sprint-indicator {
-    margin-top: var(--space-md);
-    color: var(--text-secondary);
-    font-size: 0.9rem;
+  .footnote {
+    background: var(--bg-card);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    padding: var(--space-xl);
+    margin-bottom: var(--space-2xl);
+  }
+  .footnote h3 {
+    margin: 0 0 var(--space-md);
+    font-size: 1rem;
+  }
+  .footnote p {
+    margin: 0 0 var(--space-md);
+    line-height: 1.65;
+    color: var(--text-muted);
+    font-size: 0.9375rem;
+  }
+  .footnote p:last-child {
+    margin-bottom: 0;
   }
 
-  .sprint-indicator strong {
-    color: var(--accent-teal);
+  .cta-row {
+    display: flex;
+    gap: var(--space-sm);
+    flex-wrap: wrap;
+    justify-content: center;
   }
 </style>

--- a/website/src/pages/what-is-icn.astro
+++ b/website/src/pages/what-is-icn.astro
@@ -1,0 +1,116 @@
+---
+import Layout from '../layouts/Layout.astro';
+import ClosureLoop from '../components/ClosureLoop.astro';
+import ScopeModel from '../components/ScopeModel.astro';
+import ReadingLadder from '../components/ReadingLadder.astro';
+---
+
+<Layout title="What is ICN" activeNav="what-is-icn" description="ICN is digital infrastructure for cooperatives, communities, and federations — a substrate where membership, governance, rules, and accountability are native rather than layered on.">
+
+  <section class="section" style="padding-top: calc(64px + var(--space-3xl));">
+    <div class="container narrow">
+      <div class="page-hero">
+        <span class="badge badge-teal">What is ICN</span>
+        <h1>ICN is digital infrastructure for cooperatives, communities, and federations.</h1>
+        <p class="lead">
+          It gives institutions a coherent substrate where membership, governance, shared rules, economic coordination, and accountability are native —
+          so decisions, action, and proof do not have to live in separate worlds.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section-alt">
+    <div class="container narrow prose">
+      <h2>A different kind of system</h2>
+      <p>
+        ICN is not an app. It is not a management SaaS. It is not a blockchain,
+        and it is not a DAO platform.
+      </p>
+      <p>
+        It is infrastructure — the layer underneath institutional life that most democratic organizations
+        have never had. The layer that says <em>who is a member</em>, <em>what the rules are</em>,
+        <em>what was decided</em>, <em>what happened</em>, <em>what is owed</em>,
+        and <em>what can be proven later</em>.
+      </p>
+      <p>
+        Today that layer is improvised. It lives in spreadsheets, chat threads, documents,
+        staff memory, and disconnected tools that were never designed to carry institutional weight.
+        ICN is an attempt to give it a real home.
+      </p>
+
+      <h2>What ICN models directly</h2>
+      <p>Most software models users and accounts. ICN models institutions.</p>
+      <ul>
+        <li><strong>Members</strong> — people with cryptographic identity and real, provable standing inside the institutions they belong to.</li>
+        <li><strong>Scopes</strong> — cooperatives, communities, federations, and commons, each modeled as a first-class institutional entity with its own rules, members, and history.</li>
+        <li><strong>Authority</strong> — not handed down from a platform owner, but derived from the scope's rules and the decisions its members have made under them.</li>
+        <li><strong>Governance and policy</strong> — proposals, deliberation, and the rules those decisions produce — rules that shape what can happen next.</li>
+        <li><strong>Economic life</strong> — obligations, treasury with budgets and approvals, mutual-credit positions, patronage settlement, usage-rights. Social accounting denominated in obligations between real parties, not payment rails.</li>
+        <li><strong>Execution</strong> — the step where an accepted decision turns into a concrete operational effect, so decisions do not die in meeting minutes.</li>
+        <li><strong>Receipts and provenance</strong> — durable records that trace every outcome back through the rule that shaped it, the decision that authorized it, and the members who held standing.</li>
+        <li><strong>Federation</strong> — formal agreements, attestations, and cross-institutional clearing between distinct scopes. Coordination without merger.</li>
+      </ul>
+      <p>
+        These are not features layered on top of a generic platform.
+        They are the primitives of the system.
+      </p>
+
+      <ScopeModel title="The five scopes of institutional action" />
+
+      <h2>Closing the institutional loop</h2>
+      <p>
+        The defining idea behind ICN is that institutional life should not be scattered
+        across unrelated tools. The loop that matters is specific, and the system is built
+        to carry every station of it. Read the nine stations in order:
+      </p>
+
+      <ClosureLoop variant="full" title="The nine-station closure" />
+
+      <p class="after-loop">
+        That is the loop. ICN exists to close it.
+        Parts of it are already closed today; other parts are still being filled in.
+        See <a href="/whats-real-now">What's Real Now</a> for the direct account
+        of which stations are strongest, which are the active frontier, and which are still behind.
+      </p>
+
+      <h2>What ICN is not</h2>
+      <ul>
+        <li><strong>Not a blockchain.</strong> ICN is not oriented around tokens, speculation, or trustless global consensus. It is oriented around institutions and their accountability to themselves and each other.</li>
+        <li><strong>Not a DAO framework.</strong> DAOs typically treat governance as voting over a treasury. ICN treats governance as one part of a much larger institutional substrate.</li>
+        <li><strong>Not a SaaS suite.</strong> ICN is not a bundle of management tools. It is the layer those tools should sit on top of.</li>
+        <li><strong>Not finished.</strong> ICN is a real, active project with uneven maturity. See <a href="/whats-real-now">What's Real Now</a> for a direct account.</li>
+      </ul>
+
+      <h2>Why this framing matters</h2>
+      <p>
+        If you treat institutions as user groups on generic software, you get what we already have:
+        governance that cannot bind practice, decisions that do not become action,
+        and accountability that depends on individuals remembering what happened.
+      </p>
+      <p>
+        If you treat institutions as first-class entities with their own identity, rules, and history,
+        something different becomes possible. That is the bet ICN is making.
+      </p>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="container narrow">
+      <ReadingLadder current="what-is-icn" />
+    </div>
+  </section>
+</Layout>
+
+<style>
+.narrow { max-width: 760px; }
+.page-hero { display: flex; flex-direction: column; gap: var(--space-md); align-items: flex-start; }
+.page-hero .badge { align-self: flex-start; }
+.page-hero h1 { margin: 0; }
+.lead { font-size: 1.125rem; color: var(--text-body); line-height: 1.6; margin: 0; }
+.prose h2 { margin-top: var(--space-2xl); margin-bottom: var(--space-md); }
+.prose p { margin: 0 0 var(--space-md); line-height: 1.7; }
+.prose ul { margin: var(--space-md) 0; padding-left: var(--space-lg); }
+.prose li { margin-bottom: var(--space-sm); line-height: 1.7; }
+.after-loop { margin-top: var(--space-xl) !important; }
+</style>

--- a/website/src/pages/whats-real-now.astro
+++ b/website/src/pages/whats-real-now.astro
@@ -1,0 +1,188 @@
+---
+import Layout from '../layouts/Layout.astro';
+import MaturityGrid from '../components/MaturityGrid.astro';
+import MaturityCard from '../components/MaturityCard.astro';
+import ProvenanceTrail from '../components/ProvenanceTrail.astro';
+import ScopeModel from '../components/ScopeModel.astro';
+import ReadingLadder from '../components/ReadingLadder.astro';
+---
+
+<Layout title="What's Real Now" activeNav="whats-real-now" description="An honest account of which parts of ICN are strongest today, which are advancing, which are still maturing, and which are not yet built.">
+
+  <section class="section" style="padding-top: calc(64px + var(--space-3xl));">
+    <div class="container narrow">
+      <div class="page-hero">
+        <span class="badge badge-amber">Maturity Anchor</span>
+        <h1>What's Real Now</h1>
+        <p class="lead">
+          ICN is a real, active infrastructure project with uneven maturity.
+          This page is where we say what is proven, what is advancing, and what is not yet finished.
+          Every other page on this site should be readable against what is here without contradiction.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section-alt">
+    <div class="container narrow prose">
+      <h2>How to read this page</h2>
+      <p>
+        ICN is large, and different parts of the system are at different levels of maturity.
+        The public-facing site has historically lagged the actual implementation,
+        and this page is part of closing that gap. We describe maturity in four bands,
+        and every capability claim elsewhere on this site is placed in one of them.
+      </p>
+
+      <MaturityGrid>
+        <MaturityCard band="strong">
+          <p>Implemented, integrated, and load-bearing. The project is willing to stand behind these capabilities in public.</p>
+        </MaturityCard>
+        <MaturityCard band="advancing">
+          <p>Actively under development with visible progress. Real work, real incompleteness. Not yet something to rely on.</p>
+        </MaturityCard>
+        <MaturityCard band="maturing">
+          <p>Serious implementation exists. Surfaces and integrations are still being finished. Implementation is often ahead of the public-facing story.</p>
+        </MaturityCard>
+        <MaturityCard band="notyet">
+          <p>Scoped and intended, but not where real work is concentrated right now. We would rather say that directly than imply a schedule.</p>
+        </MaturityCard>
+      </MaturityGrid>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="container narrow prose">
+      <h2>Strong today</h2>
+      <p>
+        <strong>Provenance and institutional memory.</strong>
+        The deepest mature part of ICN is the chain that carries an outcome back through the rule that shaped it,
+        the decision that authorized it, and the members who held standing. Proposals, votes, receipts,
+        and the decision-to-outcome chain are the strongest through-line in the current system.
+      </p>
+      <p>
+        <strong>Auditable coordination.</strong>
+        The paths that carry a decision into a recorded outcome are where the most implementation effort and
+        the most hardening have gone. These are the capabilities we are most willing to stand behind today.
+      </p>
+      <p>
+        <strong>Cryptographic identity and membership primitives.</strong>
+        Self-held identity for members and institutions is in place, and is the foundation the rest of the system builds on.
+      </p>
+      <p>
+        <strong>The meaning-firewall discipline.</strong>
+        The structural separation between the kernel (which enforces constraints blindly) and the app layer
+        (which interprets domain meaning) is enforced in the crate graph itself. It is not aspirational;
+        it is how the system stays coherent as it grows.
+      </p>
+
+      <ProvenanceTrail title="What 'strongest today' means, concretely" />
+
+      <h2>Advancing now</h2>
+      <p>
+        <strong>Execution coverage.</strong>
+        A kernel-dispatch bridge between accepted governance payloads and the subsystems that carry them
+        into operational effect already exists. Widening the set of payload types that dispatch cleanly —
+        so that more of what a scope decides actually becomes operationally real — is the active frontier.
+        Real work, real incompleteness.
+      </p>
+      <p>
+        <strong>Policy binding practice.</strong>
+        The mechanisms that let shared rules bind what happens, rather than just describe what is supposed to happen,
+        are advancing alongside execution coverage. This is one of the most consequential active fronts in the project.
+      </p>
+
+      <h2>Real but maturing</h2>
+      <p>
+        <strong>Federation.</strong>
+        Inter-institutional coordination is a serious, active subsystem with real implementation behind it:
+        formal agreements, attestations, typed inter-institutional channels, and cross-scope clearing.
+        It is not yet at the level where its public-facing story is complete, and some integrations remain partial.
+        We would rather say that directly than paper over it.
+      </p>
+      <p>
+        <strong>Commons and compute.</strong>
+        Shared infrastructure participating in the same institutional loop as governance and accounting.
+        Implementation includes trust-aware task placement, cross-participant clearing, checkpointing, and dispute resolution.
+        This is the area where implementation is most meaningfully ahead of the public narrative,
+        and the surfaces that would let outsiders evaluate it are still being built.
+      </p>
+      <p>
+        <strong>Economic semantics.</strong>
+        Obligations, treasury with budgets and approvals, patronage settlement, mutual-credit positions,
+        progressive credit limits, and usage-rights accounting all have implementation behind them.
+        The governed-social-accounting framing is real; the cross-scope integration story is still being completed.
+      </p>
+      <p>
+        <strong>Member-facing experience.</strong>
+        Identity, participation, and institutional interaction are converging toward a coherent member surface,
+        but that surface is not yet where the underlying system is. This is the gap a cooperative adopting ICN today
+        will feel most directly.
+      </p>
+
+      <h2>Not yet, or not yet publicly surfaced</h2>
+      <p>
+        Some parts of the system are real but not yet worth highlighting to outsiders because their
+        public-facing story is thin. <strong>Privacy primitives</strong> and <strong>zero-knowledge proof components</strong>
+        exist as dedicated subsystems, and a <strong>steward network</strong> for trust distribution is implemented —
+        but none of them are ready to be described in public without risking overclaim. We would rather wait
+        than paint pictures we cannot yet stand behind.
+      </p>
+      <p>
+        Other parts of the system are scoped and intended but not where active work is concentrated right now.
+        When outsiders ask "does ICN do X," the honest answer is sometimes <em>not yet, and we are not pretending otherwise</em>.
+      </p>
+
+      <h2>Where the site and the system diverge</h2>
+      <p>
+        One honest caveat: the public-facing site has historically lagged the actual implementation, sometimes significantly.
+        Parts of ICN that are real and working are not yet well represented in the public narrative.
+        Parts that are still maturing have sometimes been described as if they were further along than they are.
+        This page — and the refactor it belongs to — is how we are closing that gap.
+      </p>
+      <p>
+        If you find a claim elsewhere on the site that does not match what you see in the code, that is a bug in the site and we want to know.
+      </p>
+
+      <h2>The scopes the bands above apply across</h2>
+      <p>
+        The maturity bands above describe <em>capabilities</em>. ICN runs those capabilities
+        across five distinct contexts of action — five scopes. The substrate is at <strong>different
+        levels of maturity inside each scope</strong>. Provenance and identity are strongest at the
+        cooperative scope today; federation and commons are real but maturing; the
+        member-facing surface trails the substrate underneath. The scopes diagram below is the
+        map the bands apply across — not a claim that ICN is uniformly strong everywhere on it.
+      </p>
+
+      <ScopeModel title="The contexts the maturity bands apply across" />
+
+      <h2>Where to look directly</h2>
+      <ul>
+        <li><a href="/architecture">Architecture reference</a> — the technical deep-dive synced from the repo</li>
+        <li><a href="/docs">Documentation</a> — current developer and operator docs</li>
+        <li><a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener">Source on GitHub</a> — the ground truth</li>
+      </ul>
+    </div>
+  </section>
+
+  <section class="section-alt">
+    <div class="container narrow">
+      <ReadingLadder current="whats-real-now" />
+    </div>
+  </section>
+</Layout>
+
+<style>
+.narrow { max-width: 760px; }
+.page-hero { display: flex; flex-direction: column; gap: var(--space-md); align-items: flex-start; }
+.page-hero .badge { align-self: flex-start; }
+.page-hero h1 { margin: 0; }
+.lead { font-size: 1.125rem; color: var(--text-body); line-height: 1.6; margin: 0; }
+
+.prose h2 { margin-top: var(--space-2xl); margin-bottom: var(--space-md); }
+.prose p { margin: 0 0 var(--space-md); line-height: 1.7; }
+.prose ul { margin: var(--space-md) 0; padding-left: var(--space-lg); }
+.prose li { margin-bottom: var(--space-xs); line-height: 1.6; }
+
+/* Band grid styles moved to MaturityGrid/MaturityCard components. */
+/* Bottom CTA styles moved to ReadingLadder component. */
+</style>

--- a/website/src/pages/why-icn.astro
+++ b/website/src/pages/why-icn.astro
@@ -1,0 +1,140 @@
+---
+import Layout from '../layouts/Layout.astro';
+import ClosureLoop from '../components/ClosureLoop.astro';
+import ReadingLadder from '../components/ReadingLadder.astro';
+---
+
+<Layout title="Why ICN" activeNav="why-icn" description="Why cooperatives and democratic institutions need infrastructure that takes their form seriously — and why generic software does not solve the problem.">
+
+  <section class="section" style="padding-top: calc(64px + var(--space-3xl));">
+    <div class="container narrow">
+      <div class="page-hero">
+        <span class="badge badge-amber">Why ICN</span>
+        <h1>Cooperatives and democratic institutions should not have to govern themselves through toolchains built for firms, platforms, and administrative convenience.</h1>
+        <p class="lead">
+          ICN exists because the software stack available to collective institutions
+          actively fights the way those institutions are supposed to work.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section-alt">
+    <div class="container narrow prose">
+      <h2>The fracture</h2>
+      <p>
+        Run any cooperative, community organization, or federation long enough and the same pattern appears.
+      </p>
+      <p>
+        Governance happens in meetings and minutes. Policy lives in documents nobody reads the same way twice.
+        Membership lives in a spreadsheet or a CRM that was built for a sales team.
+        Accounting lives in a system that has no idea what a decision was.
+        Execution happens because a specific person remembers what they were supposed to do.
+      </p>
+      <p>
+        Each of these tools is fine in isolation. Together, they produce drift.
+      </p>
+      <p>
+        Decisions do not reliably become action. Rules do not reliably bind practice.
+        Accountability decays into <em>trust in individual people</em>
+        instead of <em>trust in the institution</em>.
+        And when something goes wrong, there is no path back from the outcome to the decision that was supposed to govern it.
+      </p>
+      <p>
+        This is not a failure of any one tool. It is the shape of the gap between institutional life
+        and the software stack it has been forced to use.
+      </p>
+
+      <h2>Most of the tools we depend on do not answer to us</h2>
+      <p>
+        The deeper problem is that most of the systems we depend on —
+        platforms, employers, infrastructure providers, administrative backends —
+        do not answer to the people who live inside them. They answer to ownership, to management,
+        to capital, or to centralized administration.
+      </p>
+      <p>
+        This is not a conspiracy. It is just the default shape of software built for firms and platforms.
+        Democratic institutions are forced to operate inside it, and they pay the translation cost every day,
+        in staff time, in lost history, in weakened accountability, in the quiet conversion of institutional trust into individual trust.
+      </p>
+
+      <h2>Why generic tools do not fix this</h2>
+      <p>
+        It is tempting to believe the answer is a better project management tool,
+        a better voting app, a better accounting package, or tighter integration between them.
+      </p>
+      <p>
+        It is not.
+      </p>
+      <p>
+        The problem is not that the tools are individually bad. The problem is that none of them
+        model the institution itself. None of them know what a member is.
+        None of them know what a rule is.
+        None of them know what it means for a decision to bind action.
+        Integrating them only spreads the gap more evenly.
+      </p>
+      <p>
+        A cooperative running on a stack of generic tools is not running on infrastructure built for cooperatives.
+        It is running on infrastructure built for firms and platforms.
+      </p>
+
+      <h2>Why this matters beyond convenience</h2>
+      <p>
+        The cost of the fracture is not just operational overhead. It is legitimacy.
+      </p>
+      <p>
+        Every serious institution runs on a chain that looks something like this:
+        a member has <em>standing</em>, standing confers <em>authority</em> to participate in decisions,
+        decisions produce <em>policy</em>, policy binds <em>action</em>, and the record of what happened
+        becomes the basis for the next round of standing and authority.
+        When that chain is broken — when the rules live in one place, the decision in another,
+        the action in a third, and the record in none of them —
+        the institution is running on trust in individuals, not trust in itself.
+      </p>
+      <p>
+        That works until it doesn't. It does not scale, it does not federate,
+        and it does not survive the departure of the people who held the loop together in their heads.
+        A democratic institution's authority comes from its ability to show that chain intact.
+        Losing the chain means losing the authority, even if nothing visibly breaks.
+      </p>
+
+      <h2>What ICN proposes</h2>
+      <p>
+        ICN proposes that the institutional substrate itself should be the software.
+      </p>
+      <p>
+        Identity, standing, authority, governance, policy, economic life, execution, provenance, and federation
+        should not be scattered across a stack of tools held together by staff discipline.
+        They should be stations in one coherent loop — where members can be recognized,
+        decisions carry into real operational effect, obligations are carried as institutional facts,
+        and the whole history remains legible to the people who live inside it.
+      </p>
+
+      <ClosureLoop variant="compact" title="The chain ICN is built to keep intact" showReturn={false} />
+
+      <p>
+        That is not a small claim, and ICN does not pretend the work is done.
+        But the direction is clear, and the gap it addresses is real.
+        <a href="/how-it-works">How It Works</a> walks each station in plain language;
+        <a href="/whats-real-now">What's Real Now</a> says which stations are strongest today
+        and which are still being built.
+      </p>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="container narrow">
+      <ReadingLadder current="why-icn" />
+    </div>
+  </section>
+</Layout>
+
+<style>
+.narrow { max-width: 760px; }
+.page-hero { display: flex; flex-direction: column; gap: var(--space-md); align-items: flex-start; }
+.page-hero .badge { align-self: flex-start; }
+.page-hero h1 { margin: 0; font-size: clamp(1.625rem, 3.8vw, 2.25rem); line-height: 1.2; }
+.lead { font-size: 1.125rem; color: var(--text-body); line-height: 1.6; margin: 0; }
+.prose h2 { margin-top: var(--space-2xl); margin-bottom: var(--space-md); }
+.prose p { margin: 0 0 var(--space-md); line-height: 1.7; }
+</style>

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -8,8 +8,8 @@
   --bg-surface: #0f1620;
   --bg-code: #0d1117;
   --text-primary: #e8edf5;
-  --text-secondary: #94a3b8;
-  --text-muted: #64748b;
+  --text-secondary: #a3b0c2; /* raised from #94a3b8 for AA on card bgs */
+  --text-muted: #8b99ad; /* raised from #64748b for AA on card bgs */
   --text-heading: #f1f5f9;
   --accent-teal: #2dd4bf;
   --accent-teal-dim: #14b8a6;
@@ -87,6 +87,82 @@
   margin: 0;
   padding: 0;
 }
+
+/* ─── Accessibility foundations ─────────────────────────────
+   Skip link, focus-visible rings, and reduced-motion rules.
+   See docs/design-language/accessibility.md for the full ruleset. */
+
+.skip-link {
+  position: absolute;
+  top: -9999px;
+  left: 0;
+  z-index: 200;
+  background: var(--bg-primary);
+  color: var(--text-heading);
+  padding: var(--space-sm) var(--space-lg);
+  border: 2px solid var(--accent-teal);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  text-decoration: none;
+  transition: none;
+}
+.skip-link:focus,
+.skip-link:focus-visible {
+  top: var(--space-sm);
+  left: var(--space-sm);
+  outline: none;
+}
+
+/* Global focus-visible ring — applied to every interactive element
+   that doesn't define its own focus style. Keyboard users need to
+   see where they are; mouse users are not affected. */
+*:focus {
+  outline: none;
+}
+*:focus-visible {
+  outline: 2px solid var(--accent-teal);
+  outline-offset: 3px;
+  border-radius: var(--radius-sm);
+}
+a:focus-visible,
+button:focus-visible,
+[role="button"]:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+summary:focus-visible {
+  outline: 2px solid var(--accent-teal);
+  outline-offset: 3px;
+}
+
+/* Main content target — hidden tabindex anchor for skip link.
+   Visible :focus would be distracting, so we suppress its outline. */
+#main-content:focus,
+#main-content:focus-visible {
+  outline: none;
+}
+
+/* Reduced-motion override: honor user preference. The reveal
+   IntersectionObserver also detects this and skips animation,
+   but this catches any stray transitions and animations. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+  .reveal,
+  .reveal.revealed {
+    opacity: 1 !important;
+    transform: none !important;
+    transition: none !important;
+  }
+}
+
 html {
   font-size: 16px;
   scroll-behavior: smooth;
@@ -212,6 +288,193 @@ pre code {
     grid-template-columns: 1fr;
   }
 }
+
+/* ─────────────────────────────────────────────────────────────
+   System grammar — institutional interface primitives.
+   These are the shared "institutional object" visual treatments
+   used across public pages to make the site feel like a system
+   rather than a set of documents.
+   ───────────────────────────────────────────────────────────── */
+
+/* Eyebrow — mono uppercase section marker. Use above h2 when a
+   section is a "stage" or "component" of the system rather than
+   a standalone topic. */
+.eyebrow {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--text-muted);
+}
+.eyebrow-accent {
+  color: var(--accent-teal);
+}
+
+/* Station number — mono numeric marker for stations of the
+   institutional closure loop. Use inline with prose headings.
+   Fixed size (not em-relative) so it stays small regardless of
+   heading scale. On narrow viewports, wraps naturally above h2. */
+.station-number {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  color: var(--accent-teal);
+  padding: 0.3em 0.65em;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  vertical-align: middle;
+  margin-right: 0.8em;
+  line-height: 1;
+  position: relative;
+  top: -0.2em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+/* System divider — thin horizontal rule with a centered mono
+   label. Used between major movements of a long page. */
+.system-divider {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  margin: var(--space-3xl) 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+.system-divider::before,
+.system-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border-default);
+}
+
+/* Institutional card — the shared "object" treatment for
+   capability/primitive cards. Uses a left accent bar, a mono
+   eyebrow label, a heading, and prose. Distinct from the
+   generic .card class which is a plain container. */
+.inst-card {
+  position: relative;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-left: 3px solid var(--accent-teal);
+  border-radius: var(--radius-md);
+  padding: var(--space-lg) var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  transition:
+    border-color var(--duration-fast) var(--ease-out),
+    background var(--duration-fast) var(--ease-out);
+}
+.inst-card:hover {
+  border-color: var(--accent-teal);
+  background: var(--bg-card-hover);
+}
+.inst-card-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--text-muted);
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-sm);
+  line-height: 1.4;
+}
+.inst-card-eyebrow .inst-card-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  flex-shrink: 0;
+  color: var(--accent-teal);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+}
+.inst-card-eyebrow .inst-card-eyebrow-labels {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-top: 0.2em;
+  min-width: 0;
+}
+.inst-card-eyebrow .inst-card-num {
+  color: var(--accent-teal);
+  white-space: nowrap;
+}
+.inst-card h3 {
+  margin: 0;
+  font-size: 1.0625rem;
+  line-height: 1.3;
+}
+.inst-card p {
+  margin: 0;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+/* Accent variants for inst-card — tie card color to semantic
+   category (governance=amber, provenance=green, economics=blue,
+   federation=purple, commons=rose). The accent cascades to the left
+   border, hover border, station number, and icon chip. Meaning never
+   depends on color alone — every card also carries a text category
+   label and a concept icon with its own silhouette. Color is
+   reinforcement, not source of truth. */
+.inst-card.acc-teal { border-left-color: var(--accent-teal); }
+.inst-card.acc-teal:hover { border-color: var(--accent-teal); }
+.inst-card.acc-teal .inst-card-num,
+.inst-card.acc-teal .inst-card-icon { color: var(--accent-teal); }
+
+.inst-card.acc-amber { border-left-color: var(--accent-amber); }
+.inst-card.acc-amber:hover { border-color: var(--accent-amber); }
+.inst-card.acc-amber .inst-card-num,
+.inst-card.acc-amber .inst-card-icon { color: var(--accent-amber); }
+
+.inst-card.acc-green { border-left-color: var(--accent-green); }
+.inst-card.acc-green:hover { border-color: var(--accent-green); }
+.inst-card.acc-green .inst-card-num,
+.inst-card.acc-green .inst-card-icon { color: var(--accent-green); }
+
+.inst-card.acc-blue { border-left-color: var(--accent-blue); }
+.inst-card.acc-blue:hover { border-color: var(--accent-blue); }
+.inst-card.acc-blue .inst-card-num,
+.inst-card.acc-blue .inst-card-icon { color: var(--accent-blue); }
+
+.inst-card.acc-purple { border-left-color: var(--accent-purple); }
+.inst-card.acc-purple:hover { border-color: var(--accent-purple); }
+.inst-card.acc-purple .inst-card-num,
+.inst-card.acc-purple .inst-card-icon { color: var(--accent-purple); }
+
+.inst-card.acc-rose { border-left-color: var(--accent-rose); }
+.inst-card.acc-rose:hover { border-color: var(--accent-rose); }
+.inst-card.acc-rose .inst-card-num,
+.inst-card.acc-rose .inst-card-icon { color: var(--accent-rose); }
+
+/* Section frame — container that gives a section an institutional
+   "panel" feel with a subtle top hairline and eyebrow label. Used
+   sparingly for sections that are system components. */
+.section-frame {
+  position: relative;
+  padding-top: var(--space-xl);
+  border-top: 1px solid var(--border-subtle);
+}
+.section-frame > .eyebrow {
+  display: block;
+  margin-bottom: var(--space-md);
+}
+
 ﻿.nav {
   position: fixed;
   top: 0;


### PR DESCRIPTION
Adds the first implementation surface of ICN's civic design language. 6 new pages, 9 components, expanded CSS design system, canonical design-language docs. Build verified locally (672 pages, 0 errors).