### PR TITLE
fix(website): remove LLM-in-progress voice from public copy

### DIFF
--- a/website/src/components/MemberSurface.astro
+++ b/website/src/components/MemberSurface.astro
@@ -32,18 +32,17 @@ import Icon from './Icon.astro';
   class="member-surface"
   aria-label="An illustrative member-facing surface showing what it could look like to inhabit ICN on a personal device. This is a design illustration, not a claim to a shipped app."
 >
-  <figcaption class="ms-title">An illustrative member surface</figcaption>
+  <figcaption class="ms-title">What a member would see</figcaption>
 
   <p class="ms-intro">
-    What would it feel like to inhabit ICN as a member, on your own device?
-    Below is an illustration — not a product — of how the closure loop resolves
-    into something a person can see, read, and act on. The capabilities
-    underneath each panel are real; the interface on top is still being built.
+    What does it look like to inhabit ICN as a member? This concept shows how
+    identity, governance, accounting, and provenance come together as a single
+    coherent surface — the kind of experience ICN is designed to produce.
   </p>
 
   <div class="ms-device" role="group" aria-labelledby="ms-device-label">
     <div class="ms-device-bar">
-      <span class="ms-device-label" id="ms-device-label">Member surface · illustrative</span>
+      <span class="ms-device-label" id="ms-device-label">Member surface · concept</span>
       <span class="ms-device-dots" aria-hidden="true">
         <span class="ms-dot"></span>
         <span class="ms-dot"></span>
@@ -174,14 +173,11 @@ import Icon from './Icon.astro';
   </div>
 
   <p class="ms-foot">
-    <span class="ms-foot-eyebrow">Illustrative, not shipped</span>
-    ICN's member-facing surface is the part of the system most visibly
-    trailing the substrate underneath. The panels above are a design
-    illustration of how governance, economics, scope, and provenance could
-    resolve into a coherent member surface — what a person would read and
-    act on. The capabilities beneath each panel are real today; the
-    interface on top is still being built. This illustration is how we
-    keep the gap visible instead of abstract.
+    <span class="ms-foot-eyebrow">What we are building toward</span>
+    This is an illustration of how governance, economics, scope, and provenance
+    could come together as a coherent member surface. The capabilities beneath
+    each panel are real; the unified interface that ties them together is still
+    being built.
   </p>
 </figure>
 

--- a/website/src/pages/about.astro
+++ b/website/src/pages/about.astro
@@ -50,7 +50,7 @@ import Layout from '../layouts/Layout.astro';
 
       <h2>How to continue reading</h2>
       <p>
-        This page is orientation. The public narrative layer is organized as a sequence,
+        This page is orientation. The site is organized as a sequence,
         and reading it in order is the intended path:
       </p>
       <ol>

--- a/website/src/pages/for-cooperatives.astro
+++ b/website/src/pages/for-cooperatives.astro
@@ -72,28 +72,28 @@ import ReadingLadder from '../components/ReadingLadder.astro';
 
       <h2>What is real today</h2>
       <p>
-        Some of this is already load-bearing. The strongest parts of ICN today are
+        Some of this is already working. The strongest parts of ICN today are
         <strong>provenance and institutional memory</strong> — the chain that carries an outcome
         back through the rule that shaped it, the decision that authorized it, and the members who held standing.
-        Cryptographic identity and membership primitives are in place. The structural discipline that separates
-        kernel enforcement from domain meaning (the "meaning firewall") is real and enforced in the codebase itself.
+        Cryptographic identity and membership primitives are in place. The architectural discipline
+        that keeps enforcement and institutional meaning cleanly separated is real and enforced in the codebase.
       </p>
       <p>
         <strong>Execution coverage</strong> — how broadly an accepted decision translates into operational effect —
-        is the active frontier. A kernel-dispatch bridge exists; widening the set of proposal types it handles cleanly
-        is where current work is concentrated.
+        is where active development is concentrated. The mechanism exists; the range of decisions
+        it handles is expanding.
       </p>
       <p>
         <strong>Federation</strong> (treaties, attestations, cross-institutional clearing) and
-        <strong>commons/compute</strong> (shared infrastructure with placement, clearing, checkpointing, and dispute resolution)
-        have serious implementation behind them, and are in places ahead of what the public site describes.
+        <strong>commons/compute</strong> (shared infrastructure with placement, clearing, and dispute resolution)
+        have serious implementation behind them.
         <strong>Economic semantics</strong> — treasury, budgets, patronage settlement, usage-rights accounting —
-        are real but their cross-scope integration story is still being completed.
+        are real, with cross-scope integration still being completed.
       </p>
       <p>
-        The <strong>member-facing experience</strong> is the piece most visibly trailing the underlying system.
-        The capabilities beneath it are real; the interface through which ordinary members would interact with them is still being built.
-        This is the gap you would feel most directly if you tried to adopt ICN this month.
+        The <strong>member-facing experience</strong> is the part of the system still furthest from what
+        it will eventually be. The capabilities underneath are real; the unified interface for ordinary
+        members is still being built. If you tried to adopt ICN this month, that gap is what you would feel most.
       </p>
       <p>
         The full account, with bounded maturity language for every subsystem, is at <a href="/whats-real-now">What's Real Now</a>.

--- a/website/src/pages/how-it-works.astro
+++ b/website/src/pages/how-it-works.astro
@@ -80,8 +80,8 @@ import ReadingLadder from '../components/ReadingLadder.astro';
       <p>
         ICN's ambition is that a rule produced by a decision should actually bind the practice that follows —
         not by removing human interpretation, but by making the rule legible at the point where it matters.
-        Policy mechanisms are the active frontier of the system right now.
-        Real work is happening here, and it is not yet complete.
+        The mechanisms that let rules bind practice are under active development
+        and are not yet complete.
       </p>
 
       <h2><span class="station-number">06</span>Accounting — governed social accounting <MaturityBadge band="advancing" /></h2>
@@ -106,10 +106,10 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         is <strong>execution</strong>: the step where an accepted decision turns into a concrete operational effect.
       </p>
       <p>
-        ICN has a kernel-dispatch bridge between accepted governance payloads and the subsystems
-        that carry them into effect. Some payload types are wired through and load-bearing today;
-        others are being added. Widening the set of decisions that dispatch cleanly is the active frontier of the project.
-        <a href="/whats-real-now">What's Real Now</a> carries the precise current state.
+        ICN has a mechanism that carries accepted decisions into operational effect.
+        Some types of decisions are already fully wired; others are being added.
+        Expanding that coverage is where active work is concentrated.
+        <a href="/whats-real-now">What's Real Now</a> describes the current state in detail.
       </p>
 
       <h2><span class="station-number">08</span>Receipts, provenance, and auditability <MaturityBadge band="strong" /></h2>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -109,7 +109,7 @@ import MaturityCard from '../components/MaturityCard.astro';
             </div>
           </div>
           <h3>Governance that carries into action</h3>
-          <p>Proposals, deliberation, and accepted decisions produce durable records. A kernel-dispatch bridge translates accepted payloads into operational effect — widening that coverage is the active frontier.</p>
+          <p>Proposals, deliberation, and accepted decisions produce durable records and carry into real operational effect — where the system's execution coverage reaches.</p>
         </article>
         <article class="inst-card acc-green">
           <div class="inst-card-eyebrow">
@@ -173,12 +173,11 @@ import MaturityCard from '../components/MaturityCard.astro';
         </p>
       </div>
 
-      <ClosureLoop variant="full" title="Read top to bottom — the loop closes at 09" />
+      <ClosureLoop variant="full" title="The institutional closure" />
 
       <p class="closure-footnote">
-        The <a href="/what-is-icn">What is ICN</a> page walks through each station in plain language.
-        <a href="/how-it-works">How It Works</a> carries the same loop as a subsystem-by-subsystem account,
-        with explicit maturity banding on each station.
+        <a href="/what-is-icn">What is ICN</a> walks through each station in plain language.
+        <a href="/how-it-works">How It Works</a> goes deeper into each subsystem.
       </p>
     </div>
   </section>
@@ -190,8 +189,8 @@ import MaturityCard from '../components/MaturityCard.astro';
         <span class="badge badge-green">What's Real Now</span>
         <h2>Uneven, but real.</h2>
         <p>
-          ICN is an active infrastructure project with different parts at different levels of maturity.
-          We would rather be trusted than impressive.
+          ICN is an active infrastructure project. Different parts of the system are at different
+          levels of maturity, and this section says so plainly.
         </p>
       </div>
 
@@ -200,10 +199,10 @@ import MaturityCard from '../components/MaturityCard.astro';
           <p>Provenance and auditable coordination — receipts, decision-to-outcome chains, and the institutional memory the rest of the system depends on. Cryptographic identity and membership primitives are in place.</p>
         </MaturityCard>
         <MaturityCard band="advancing">
-          <p>Execution coverage: a kernel-dispatch bridge exists and widening the set of accepted governance payloads it translates into operational effect is the active frontier. Policy binding practice is the adjacent frontier.</p>
+          <p>Execution coverage — the breadth of decisions that translate into real operational effect — is where active work is concentrated. The mechanism exists; the range of decisions it handles is expanding.</p>
         </MaturityCard>
         <MaturityCard band="maturing">
-          <p>Federation (treaties, attestations, cross-institutional clearing) and commons/compute (shared infrastructure with clearing, placement, and dispute resolution) have serious implementation. Their public-facing surfaces still lag.</p>
+          <p>Federation and commons/compute have serious implementation behind them — treaties, attestations, cross-institutional clearing, shared resource governance. These subsystems are real and advancing.</p>
         </MaturityCard>
         <MaturityCard band="behind">
           <p>The member-facing experience — where identity, standing, governance, accounting, and receipts converge into something a person can actually see and use — is the part most visibly trailing the substrate underneath.</p>
@@ -280,10 +279,8 @@ import MaturityCard from '../components/MaturityCard.astro';
       <div class="cta-box">
         <h2>Where to go next</h2>
         <p>
-          ICN is being built as one coherent institutional substrate, not a pile of features.
-          The public narrative pages are written to be read in order.
-          If any claim on this site does not match what you see in the code,
-          that is a bug in the site and we want to know.
+          ICN is one coherent institutional substrate, not a pile of features.
+          These pages are designed to be read in order.
         </p>
         <div class="next-step">
           <span class="next-label">Start here →</span>

--- a/website/src/pages/roadmap.astro
+++ b/website/src/pages/roadmap.astro
@@ -67,7 +67,7 @@ import roadmap from '../data/roadmap.json';
           move together.
         </p>
         <p>
-          If any claim here does not match what you see in the code, that is a bug in the site and we want to know.
+          If any claim here does not match the current project state, let us know.
         </p>
       </div>
 

--- a/website/src/pages/whats-real-now.astro
+++ b/website/src/pages/whats-real-now.astro
@@ -28,9 +28,8 @@ import ReadingLadder from '../components/ReadingLadder.astro';
       <h2>How to read this page</h2>
       <p>
         ICN is large, and different parts of the system are at different levels of maturity.
-        The public-facing site has historically lagged the actual implementation,
-        and this page is part of closing that gap. We describe maturity in four bands,
-        and every capability claim elsewhere on this site is placed in one of them.
+        We describe maturity in four bands. Every capability claim on this site
+        is placed in one of them.
       </p>
 
       <MaturityGrid>
@@ -38,7 +37,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
           <p>Implemented, integrated, and load-bearing. The project is willing to stand behind these capabilities in public.</p>
         </MaturityCard>
         <MaturityCard band="advancing">
-          <p>Actively under development with visible progress. Real work, real incompleteness. Not yet something to rely on.</p>
+          <p>Actively under development with visible progress. Not yet something to rely on, but moving.</p>
         </MaturityCard>
         <MaturityCard band="maturing">
           <p>Serious implementation exists. Surfaces and integrations are still being finished. Implementation is often ahead of the public-facing story.</p>
@@ -69,10 +68,10 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         Self-held identity for members and institutions is in place, and is the foundation the rest of the system builds on.
       </p>
       <p>
-        <strong>The meaning-firewall discipline.</strong>
-        The structural separation between the kernel (which enforces constraints blindly) and the app layer
-        (which interprets domain meaning) is enforced in the crate graph itself. It is not aspirational;
-        it is how the system stays coherent as it grows.
+        <strong>Structural discipline.</strong>
+        The separation between the enforcement layer (which enforces constraints without understanding
+        their domain meaning) and the application layer (which interprets institutional concepts)
+        is enforced in the codebase architecture. This is how the system stays coherent as it grows.
       </p>
 
       <ProvenanceTrail title="What 'strongest today' means, concretely" />
@@ -80,10 +79,9 @@ import ReadingLadder from '../components/ReadingLadder.astro';
       <h2>Advancing now</h2>
       <p>
         <strong>Execution coverage.</strong>
-        A kernel-dispatch bridge between accepted governance payloads and the subsystems that carry them
-        into operational effect already exists. Widening the set of payload types that dispatch cleanly —
-        so that more of what a scope decides actually becomes operationally real — is the active frontier.
-        Real work, real incompleteness.
+        The mechanism that carries accepted decisions into operational effect already exists.
+        Expanding the range of decision types it handles — so that more of what an institution
+        decides actually becomes operationally real — is where active development is concentrated.
       </p>
       <p>
         <strong>Policy binding practice.</strong>
@@ -103,8 +101,8 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         <strong>Commons and compute.</strong>
         Shared infrastructure participating in the same institutional loop as governance and accounting.
         Implementation includes trust-aware task placement, cross-participant clearing, checkpointing, and dispute resolution.
-        This is the area where implementation is most meaningfully ahead of the public narrative,
-        and the surfaces that would let outsiders evaluate it are still being built.
+        This is one of the areas where the implementation is ahead of what the documentation
+        and public surfaces currently convey.
       </p>
       <p>
         <strong>Economic semantics.</strong>
@@ -132,15 +130,12 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         When outsiders ask "does ICN do X," the honest answer is sometimes <em>not yet, and we are not pretending otherwise</em>.
       </p>
 
-      <h2>Where the site and the system diverge</h2>
+      <h2>What this page commits to</h2>
       <p>
-        One honest caveat: the public-facing site has historically lagged the actual implementation, sometimes significantly.
-        Parts of ICN that are real and working are not yet well represented in the public narrative.
-        Parts that are still maturing have sometimes been described as if they were further along than they are.
-        This page — and the refactor it belongs to — is how we are closing that gap.
-      </p>
-      <p>
-        If you find a claim elsewhere on the site that does not match what you see in the code, that is a bug in the site and we want to know.
+        Every capability claim on this site is grounded in the maturity bands above.
+        If something is described as "strong today," it is implemented and in use.
+        If something is described as "advancing," it is under active development but not finished.
+        If you find a claim elsewhere on this site that contradicts what is here, please let us know.
       </p>
 
       <h2>The scopes the bands above apply across</h2>


### PR DESCRIPTION
## Summary

Strip meta-commentary, internal dev jargon, and self-referential process language from the public-facing website pages. The previous design-language tranche shipped strong primitives and page structure but left behind agent-process voice artifacts in the public copy.

## What changed

**Meta-commentary removed** — phrases like "the refactor it belongs to," "the public narrative layer," "Real work, real incompleteness," and "if you find a claim that does not match what you see in the code, that is a bug in the site" were the voice of an AI agent explaining its own work process, not a finished institutional website.

**Dev jargon replaced on non-developer pages** — "kernel-dispatch bridge," "payload types," "crate graph," "active frontier," and "meaning-firewall discipline" have been replaced with plain-language equivalents on pages aimed at cooperative organizers and general readers. Developer-facing pages (/for-developers) retain this vocabulary because that IS the correct audience.

**MemberSurface component cleaned** — "ILLUSTRATIVE, NOT SHIPPED" label changed to "What we are building toward" / "concept." The verbose disclaimer about keeping "the gap visible instead of abstract" has been shortened to focus on what matters: the capabilities are real, the unified interface is being built.

## Pages touched

-  — homepage maturity strip, closure loop title, explore CTA
-  — execution section, policy section
-  — maturity band descriptions, divergence section reframed
-  — "what is real today" section
-  — one meta-phrase
-  — one meta-phrase
-  — title, intro, device label, footer

## Test plan

- [x]  passes (672 pages)
- [x] No new pages or components — purely copy edits
- [x] Developer-facing pages retain technical vocabulary unchanged
- [x] No structural or CSS changes

## Risk

Low. Copy-only changes. No component, layout, or style modifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)