### PR TITLE
fix(ci): add has_rust dual-signal guard to 4 skippable CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,7 +378,7 @@ jobs:
   backup-validation:
     name: Backup Validation
     needs: [changes]
-    if: needs.changes.outputs.docs_only != 'true'
+    if: needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.has_rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -471,7 +471,7 @@ jobs:
   security:
     name: Security Audit
     needs: [changes]
-    if: needs.changes.outputs.docs_only != 'true'
+    if: needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.has_rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -588,7 +588,7 @@ jobs:
   web-ui:
     name: Web UI
     needs: [changes]
-    if: needs.changes.outputs.docs_only != 'true'
+    if: needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.has_rust == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -656,7 +656,7 @@ jobs:
 
   pilot-provenance:
     name: Pilot Provenance Invariant
-    if: needs.changes.outputs.docs_only != 'true'
+    if: needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.has_rust == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [changes, test]

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -6,15 +6,16 @@ Last Reviewed: 2026-04-10
 
 # ICN State (living doc)
 
-## Current status (2026-04-10 snapshot)
-- **PR #1520** (website cleanup: logo, homepage condensation, light theme, NetworkGraph/d3 removal) merged to main
-- **PR #1522** (`fix/coop-store-sled-lock`) merged — resolves two main CI blockers:
+## Current status (2026-04-11 snapshot)
+- **PR #1520** (website cleanup: logo, homepage condensation, light theme, NetworkGraph/d3 removal) merged 2026-04-10
+- **PR #1522** (`fix/coop-store-sled-lock`) merged 2026-04-11T00:21Z — resolves two main CI blockers:
   - Security Audit gate: wasmtime bumped 24.0.6 → 36.0.7 (RUSTSEC-2026-0095, critical sandbox escape)
   - Test gate: `icn_coop::store::tests::test_treasury_nonce_survives_reopen` sled lock contention fixed via explicit `drop(store)` before reopen
 - **PR #1521** (`fix/wasmtime-security-audit`) closed as superseded by #1522 (strict superset)
 - **Pilot Vertical Slice Hardening sprint complete**: #1214, #1221, #1220, #1222 all closed
-- **Issue #862** (naming primitive) closed as superseded — implemented as `icn-naming` crate (`SledNamingService` with authority signature enforcement, alias chain resolution, sled persistence)
-- Main CI post-merge: Clippy ✅, Format ✅, Test (in progress), Build Release (in progress), Security Audit skipping (not failing — skip pattern matches PR CI behavior; wasmtime 36.0.7 is in Cargo.lock)
+- **Issue #862** (naming primitive) closed as superseded — implemented as `icn-naming` crate
+- **Issue #1401** (hung docker-build-deploy CI) closed — root cause (Test job) already removed in PR #1403
+- Main CI post-merge: all real gates green. Security Audit was skipping due to missing `has_rust` dual-signal guard in CI workflow (fix: PR #1524)
 
 
 ## Architecture notes

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14,19 +14,19 @@ Last reviewed: 2026-04-10
    - #1220 ✅ closed
    - #1222 ✅ closed
 
-2) Docs reality-sync (active, non-archive/session scope)
+3) Docs reality-sync (active, non-archive/session scope)
    - Fix broken links and stale absolute paths under `docs/`
    - Normalize present-tense status claims to dated snapshot language where not re-verified
    - Keep canonical current pointers in `docs/INDEX.md`, `docs/README.md`, `docs/STATE.md`
    Acceptance: `.codex/skills/icn-docs-reality-sync/scripts/doc_reality_scan.sh` reports no broken links in scanned docs.
 
-3) Verification routing discipline
+4) Verification routing discipline
    - Rust changes: run `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and targeted `cargo test` scopes
    - Gateway API changes: run `cargo test -p icn-gateway --features sled-storage`
    - If API schema changes: regenerate OpenAPI + TypeScript generated types
    Acceptance: verification output recorded in PR and matches touched subsystems.
 
-4) Track remaining pilot-completion backlog separately
+5) Track remaining pilot-completion backlog separately
    - Milestone `Pilot Completion` retains open items (for example #1099 epic and child issues)
    - Keep this backlog distinct from active hardening sprint to avoid scope mixing
    Acceptance: sprint PRs link explicitly to milestone scope.


### PR DESCRIPTION
## What

Adds the `has_rust` counter-signal to 4 jobs that were missing it:
- Security Audit
- Backup Validation
- Web UI
- Pilot Provenance Invariant

## Why

`dorny/paths-filter` `docs_only` output means "docs paths matched" — not "only docs changed." When a commit touches both `docs/**` and `icn/Cargo.lock`, both `docs_only` and `has_rust` are true. Jobs using only `docs_only != 'true'` skip incorrectly.

This was observed during the #1522 merge: Security Audit skipped on main even though `Cargo.lock` changed (wasmtime 24→36 security fix). The audit should have run to confirm the advisory was resolved.

Other jobs (Clippy, Test, Build Release) already use the dual-signal guard. This PR makes the 4 remaining jobs consistent.

## Risk

CI-only change. No code changes. Worst case: these jobs run slightly more often (when a PR touches both docs and Rust files — which is the correct behavior).

## Test plan

- CI should pass on this PR itself
- On next main push that includes both docs and Rust changes, Security Audit should run instead of skipping

Closes the "Security Audit skip on push CI" investigation from the 2026-04-10 handoff.