### PR TITLE
fix(ci): add timeout-minutes to docker-build-deploy jobs

### DIFF
--- a/.github/workflows/docker-build-deploy.yml
+++ b/.github/workflows/docker-build-deploy.yml
@@ -50,6 +50,7 @@ jobs:
   build-and-deploy:
     name: Build and Deploy
     runs-on: [self-hosted, homelab, k3s]
+    timeout-minutes: 30
     # Skip build/deploy on scheduled runs (cleanup only)
     if: github.event_name != 'schedule'
 
@@ -187,6 +188,7 @@ jobs:
   cleanup:
     name: Cleanup Old Images
     runs-on: [self-hosted, homelab, k3s]
+    timeout-minutes: 15
     if: github.event_name == 'schedule'
     steps:
       - name: Remove old images on all nodes


### PR DESCRIPTION
## What

Adds `timeout-minutes` to both jobs in `docker-build-deploy.yml`:
- `build-and-deploy`: 30 minutes
- `cleanup`: 15 minutes

## Why

The Test job that caused #1401 (runner starvation) was removed in PR #1403, but the remaining Docker build/deploy/cleanup jobs still have no timeout. A hung Docker build or SSH connection could still hold the self-hosted runner indefinitely (up to GitHub's 6-hour default).

## Risk

CI-only. No code changes. 30 minutes is generous for the build+deploy cycle (typically ~10-15 min).

## Test plan

CI passes on this PR. Next `docker-build-deploy` run on main will enforce the timeout.