### PR TITLE
feat(governance): decision-to-action bridge — accepted proposals create linked action items

### DIFF
--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -2025,37 +2025,11 @@ impl GovernanceActor {
                 }
 
                 // Decision-to-Action bridge: materialize action items from accepted proposals.
-                // Idempotent: uses proposal_id in dedup check to prevent duplicates on replay.
                 if matches!(outcome_result, DecisionOutcome::Accepted)
                     && !proposal.action_items_on_accept.is_empty()
                 {
                     if let Some(ref store) = self.action_item_store {
-                        let specs = &proposal.action_items_on_accept;
-                        let mut created = 0usize;
-                        for spec in specs {
-                            let item = spec.materialize(
-                                proposal.domain_id.clone(),
-                                proposal_id.clone(),
-                                proposal.proposer.clone(),
-                                now,
-                            );
-                            match store.save(&item) {
-                                Ok(()) => created += 1,
-                                Err(e) => {
-                                    warn!(
-                                        "Failed to create action item '{}' from proposal {}: {e}",
-                                        spec.title, proposal_id.0
-                                    );
-                                }
-                            }
-                        }
-                        if created > 0 {
-                            info!(
-                                "📋 Created {created}/{} action items from accepted proposal {}",
-                                specs.len(),
-                                proposal_id.0
-                            );
-                        }
+                        Self::materialize_action_items(store, &proposal, &proposal_id, now);
                     }
                 }
 
@@ -2203,20 +2177,7 @@ impl GovernanceActor {
                 {
                     if let Some(ref store) = self.action_item_store {
                         let now = now_seconds();
-                        for spec in &proposal.action_items_on_accept {
-                            let item = spec.materialize(
-                                proposal.domain_id.clone(),
-                                proposal_id.clone(),
-                                proposal.proposer.clone(),
-                                now,
-                            );
-                            if let Err(e) = store.save(&item) {
-                                warn!(
-                                    "Failed to create action item '{}' from force-accepted proposal {}: {e}",
-                                    spec.title, proposal_id.0
-                                );
-                            }
-                        }
+                        Self::materialize_action_items(store, &proposal, &proposal_id, now);
                     }
                 }
 
@@ -2456,6 +2417,67 @@ impl GovernanceActor {
     /// Load a domain by ID
     fn load_domain(&self, id: &GovernanceDomainId) -> Result<Option<GovernanceDomain>> {
         self.store.get_domain(id)
+    }
+
+    /// Materialize action items from an accepted proposal's specs.
+    ///
+    /// Idempotent: checks for existing linked items before creating new ones.
+    fn materialize_action_items(
+        store: &Arc<dyn icn_governance::ActionItemStoreBackend>,
+        proposal: &Proposal,
+        proposal_id: &ProposalId,
+        now: u64,
+    ) {
+        // Dedup check: skip if action items already exist for this proposal
+        let filter = icn_governance::ActionItemFilter {
+            linked_proposal: Some(proposal_id.clone()),
+            ..Default::default()
+        };
+        match store.list(&proposal.domain_id, &filter) {
+            Ok(existing) if !existing.is_empty() => {
+                info!(
+                    "📋 Skipping action item creation for proposal {} — {} linked item(s) already exist",
+                    proposal_id.0,
+                    existing.len()
+                );
+                return;
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to check existing action items for proposal {}: {e}",
+                    proposal_id.0
+                );
+                // Continue anyway — better to risk duplicates than lose items
+            }
+            _ => {}
+        }
+
+        let specs = &proposal.action_items_on_accept;
+        let mut created = 0usize;
+        for spec in specs {
+            let item = spec.materialize(
+                proposal.domain_id.clone(),
+                proposal_id.clone(),
+                proposal.proposer.clone(),
+                now,
+            );
+            match store.save(&item) {
+                Ok(()) => created += 1,
+                Err(e) => {
+                    warn!(
+                        "Failed to create action item '{}' from proposal {}: {e}",
+                        spec.title, proposal_id.0
+                    );
+                }
+            }
+        }
+        if created > 0 {
+            info!(
+                "📋 Created {created}/{} action items from accepted proposal {}",
+                specs.len(),
+                proposal_id.0
+            );
+        }
     }
 
     /// Load a proposal by ID

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -131,6 +131,8 @@ pub enum GovernanceCommand {
         payload: ProposalPayload,
         /// Scope — local or federation-wide
         scope: ProposalScope,
+        /// Action items to create on acceptance (decision-to-action bridge)
+        action_items_on_accept: Vec<icn_governance::ActionItemSpec>,
     },
     /// Start deliberation period for a proposal
     ///
@@ -520,6 +522,22 @@ impl GovernanceHandle {
         self.executor.as_ref()
     }
 
+    /// Set the action item store for the decision-to-action bridge.
+    ///
+    /// When configured, proposals with `action_items_on_accept` specs will
+    /// auto-create linked action items on acceptance. Call during initialization
+    /// before cloning the handle.
+    pub fn with_action_item_store(
+        self,
+        store: Arc<dyn icn_governance::ActionItemStoreBackend>,
+    ) -> Self {
+        // Set on inner actor for use during proposal close
+        if let Ok(mut actor) = self.inner.try_write() {
+            actor.action_item_store = Some(store);
+        }
+        self
+    }
+
     /// List all protocol parameters
     pub fn list_protocol_parameters(&self) -> Result<Vec<ProtocolParameter>> {
         match &self.protocol_params {
@@ -789,6 +807,20 @@ impl icn_governance::GovernanceOps for GovernanceHandle {
         payload: icn_governance::ProposalPayload,
         scope: ProposalScope,
     ) -> Result<ProposalId> {
+        self.create_proposal_with_actions(domain_id, title, description, payload, scope, Vec::new())
+            .await
+    }
+
+    /// Create a proposal with action item specs that will materialize on acceptance.
+    async fn create_proposal_with_actions(
+        &self,
+        domain_id: GovernanceDomainId,
+        title: String,
+        description: String,
+        payload: icn_governance::ProposalPayload,
+        scope: ProposalScope,
+        action_items_on_accept: Vec<icn_governance::ActionItemSpec>,
+    ) -> Result<ProposalId> {
         // Pre-validate ProtocolChange proposals to catch invalid parameters early
         // This prevents wasted governance cycles on proposals that would fail at execution
         if let ProposalPayload::ProtocolChange { ref proposal } = payload {
@@ -943,6 +975,7 @@ impl icn_governance::GovernanceOps for GovernanceHandle {
             description,
             payload,
             scope,
+            action_items_on_accept,
         })
         .await?;
 
@@ -1108,6 +1141,10 @@ pub struct GovernanceActor {
     signing_key: Option<Arc<ed25519_dalek::SigningKey>>,
     /// Optional kernel governance executor for delegated proposal execution
     executor: Option<Arc<dyn icn_kernel_api::governance::GovernanceExecutor>>,
+    /// Optional action item store for materializing action items from accepted proposals.
+    /// When present, proposals with `action_items_on_accept` specs will auto-create
+    /// linked action items on acceptance (decision-to-action bridge).
+    action_item_store: Option<Arc<dyn icn_governance::ActionItemStoreBackend>>,
 }
 
 impl GovernanceActor {
@@ -1183,6 +1220,7 @@ impl GovernanceActor {
             protocol_params: None,
             signing_key,
             executor: None,
+            action_item_store: None,
         };
 
         // Slot for the scheduler task JoinHandle; filled in after spawn.
@@ -1415,6 +1453,7 @@ impl GovernanceActor {
                 description,
                 payload,
                 scope,
+                action_items_on_accept,
             } => {
                 info!("Creating proposal: {} (scope: {:?})", title, scope);
 
@@ -1425,7 +1464,8 @@ impl GovernanceActor {
                     description,
                     payload,
                 )
-                .with_scope(scope);
+                .with_scope(scope)
+                .with_action_items(action_items_on_accept);
 
                 // Use the provided proposal ID instead of the generated one
                 proposal.id = proposal_id.clone();
@@ -1984,6 +2024,41 @@ impl GovernanceActor {
                     event_bus.emit(event).await;
                 }
 
+                // Decision-to-Action bridge: materialize action items from accepted proposals.
+                // Idempotent: uses proposal_id in dedup check to prevent duplicates on replay.
+                if matches!(outcome_result, DecisionOutcome::Accepted)
+                    && !proposal.action_items_on_accept.is_empty()
+                {
+                    if let Some(ref store) = self.action_item_store {
+                        let specs = &proposal.action_items_on_accept;
+                        let mut created = 0usize;
+                        for spec in specs {
+                            let item = spec.materialize(
+                                proposal.domain_id.clone(),
+                                proposal_id.clone(),
+                                proposal.proposer.clone(),
+                                now,
+                            );
+                            match store.save(&item) {
+                                Ok(()) => created += 1,
+                                Err(e) => {
+                                    warn!(
+                                        "Failed to create action item '{}' from proposal {}: {e}",
+                                        spec.title, proposal_id.0
+                                    );
+                                }
+                            }
+                        }
+                        if created > 0 {
+                            info!(
+                                "📋 Created {created}/{} action items from accepted proposal {}",
+                                specs.len(),
+                                proposal_id.0
+                            );
+                        }
+                    }
+                }
+
                 info!(
                     "✓ Proposal closed: {} ({:?})",
                     proposal_id.0, outcome_result
@@ -2120,6 +2195,29 @@ impl GovernanceActor {
                         },
                     };
                     event_bus.emit(event).await;
+                }
+
+                // Decision-to-Action bridge for force-accepted proposals
+                if matches!(forced_outcome, ForcedOutcome::Accept)
+                    && !proposal.action_items_on_accept.is_empty()
+                {
+                    if let Some(ref store) = self.action_item_store {
+                        let now = now_seconds();
+                        for spec in &proposal.action_items_on_accept {
+                            let item = spec.materialize(
+                                proposal.domain_id.clone(),
+                                proposal_id.clone(),
+                                proposal.proposer.clone(),
+                                now,
+                            );
+                            if let Err(e) = store.save(&item) {
+                                warn!(
+                                    "Failed to create action item '{}' from force-accepted proposal {}: {e}",
+                                    spec.title, proposal_id.0
+                                );
+                            }
+                        }
+                    }
                 }
 
                 icn_obs::metrics::governance::proposals_force_closed_inc();

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -755,9 +755,28 @@ pub async fn create_proposal<E: GovernanceEventEmitter + Clone + 'static>(
     let domain_id = GovernanceDomainId(req.domain_id.clone());
     let suggested_id = ProposalId(format!("prop-{}", uuid::Uuid::new_v4()));
 
+    // Convert action item specs from API model to domain model
+    let action_specs: Vec<icn_governance::ActionItemSpec> = req
+        .action_items_on_accept
+        .iter()
+        .map(|s| icn_governance::ActionItemSpec {
+            title: s.title.clone(),
+            description: s.description.clone(),
+            assignee: s.assignee.as_ref().and_then(|d| icn_identity::Did::from_str(d).ok()),
+            due_offset_seconds: s.due_offset_seconds,
+            priority: match s.priority.as_deref() {
+                Some("low") => icn_governance::ActionItemPriority::Low,
+                Some("high") => icn_governance::ActionItemPriority::High,
+                Some("critical") => icn_governance::ActionItemPriority::Critical,
+                _ => icn_governance::ActionItemPriority::Medium,
+            },
+            tags: s.tags.clone(),
+        })
+        .collect();
+
     let proposal_id = ctx
         .manager
-        .create_proposal(
+        .create_proposal_with_actions(
             suggested_id,
             domain_id,
             proposer_did.clone(),
@@ -765,6 +784,7 @@ pub async fn create_proposal<E: GovernanceEventEmitter + Clone + 'static>(
             req.description.clone(),
             payload,
             scope,
+            action_specs,
         )
         .await
         .map_err(anyhow_to_api)?;

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -755,24 +755,36 @@ pub async fn create_proposal<E: GovernanceEventEmitter + Clone + 'static>(
     let domain_id = GovernanceDomainId(req.domain_id.clone());
     let suggested_id = ProposalId(format!("prop-{}", uuid::Uuid::new_v4()));
 
-    // Convert action item specs from API model to domain model
+    // Convert action item specs from API model to domain model, applying the
+    // same validation as the action-item endpoints.
     let action_specs: Vec<icn_governance::ActionItemSpec> = req
         .action_items_on_accept
         .iter()
-        .map(|s| icn_governance::ActionItemSpec {
-            title: s.title.clone(),
-            description: s.description.clone(),
-            assignee: s.assignee.as_ref().and_then(|d| icn_identity::Did::from_str(d).ok()),
-            due_offset_seconds: s.due_offset_seconds,
-            priority: match s.priority.as_deref() {
-                Some("low") => icn_governance::ActionItemPriority::Low,
-                Some("high") => icn_governance::ActionItemPriority::High,
-                Some("critical") => icn_governance::ActionItemPriority::Critical,
-                _ => icn_governance::ActionItemPriority::Medium,
-            },
-            tags: s.tags.clone(),
+        .map(|s| -> Result<icn_governance::ActionItemSpec, ApiError> {
+            val::validate_action_item_title(&s.title)?;
+            val::validate_action_item_description(&s.description)?;
+            val::validate_tags(&s.tags)?;
+
+            let priority = match s.priority.as_deref() {
+                Some(p) => parse_priority(p)?,
+                None => icn_governance::ActionItemPriority::Medium,
+            };
+
+            let assignee = match s.assignee.as_deref() {
+                Some(d) => Some(parse_did(d, "action_items_on_accept[].assignee")?),
+                None => None,
+            };
+
+            Ok(icn_governance::ActionItemSpec {
+                title: s.title.clone(),
+                description: s.description.clone(),
+                assignee,
+                due_offset_seconds: s.due_offset_seconds,
+                priority,
+                tags: s.tags.clone(),
+            })
         })
-        .collect();
+        .collect::<Result<Vec<_>, _>>()?;
 
     let proposal_id = ctx
         .manager

--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -74,6 +74,29 @@ pub struct CreateProposalRequest {
     pub payload: ProposalPayloadRequest,
     #[serde(default)]
     pub scope: Option<ProposalScopeRequest>,
+    /// Action items to create when this proposal is accepted.
+    /// Each spec becomes a linked ActionItem with provenance to this proposal.
+    #[serde(default)]
+    pub action_items_on_accept: Vec<ActionItemSpecRequest>,
+}
+
+/// Template for creating action items from accepted proposals (API model).
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ActionItemSpecRequest {
+    pub title: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Assignee DID (optional)
+    #[serde(default)]
+    pub assignee: Option<String>,
+    /// Seconds after acceptance before this item is due
+    #[serde(default)]
+    pub due_offset_seconds: Option<u64>,
+    /// Priority: low, medium (default), high, critical
+    #[serde(default)]
+    pub priority: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
 }
 
 /// Proposal payload types

--- a/icn/apps/governance/src/init.rs
+++ b/icn/apps/governance/src/init.rs
@@ -108,8 +108,9 @@ pub async fn init_governance_actor(
     let action_item_path = store_path.join("governance_action_items");
     let action_item_db = sled::open(&action_item_path)
         .map_err(|e| anyhow::anyhow!("Failed to open action item store: {e}"))?;
-    let action_store: Arc<dyn icn_governance::ActionItemStoreBackend> =
-        Arc::new(crate::manager::SledActionItemStore::new(Arc::new(action_item_db)));
+    let action_store: Arc<dyn icn_governance::ActionItemStoreBackend> = Arc::new(
+        crate::manager::SledActionItemStore::new(Arc::new(action_item_db)),
+    );
     let governance_handle = governance_handle.with_action_item_store(action_store);
 
     info!("Governance actor spawned at {}", gov_store_path.display());

--- a/icn/apps/governance/src/init.rs
+++ b/icn/apps/governance/src/init.rs
@@ -103,6 +103,15 @@ pub async fn init_governance_actor(
     )
     .await?;
 
+    // Wire action item store for the decision-to-action bridge.
+    // Opens a dedicated sled DB alongside the governance state store.
+    let action_item_path = store_path.join("governance_action_items");
+    let action_item_db = sled::open(&action_item_path)
+        .map_err(|e| anyhow::anyhow!("Failed to open action item store: {e}"))?;
+    let action_store: Arc<dyn icn_governance::ActionItemStoreBackend> =
+        Arc::new(crate::manager::SledActionItemStore::new(Arc::new(action_item_db)));
+    let governance_handle = governance_handle.with_action_item_store(action_store);
+
     info!("Governance actor spawned at {}", gov_store_path.display());
 
     Ok(GovernanceActorServices {

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -503,9 +503,41 @@ impl GovernanceManager {
         payload: ProposalPayload,
         scope: ProposalScope,
     ) -> Result<ProposalId> {
+        self.create_proposal_with_actions(
+            proposal_id,
+            domain_id,
+            proposer,
+            title,
+            description,
+            payload,
+            scope,
+            Vec::new(),
+        )
+        .await
+    }
+
+    /// Create a proposal with action item specs that will be materialized on acceptance.
+    pub async fn create_proposal_with_actions(
+        &self,
+        proposal_id: ProposalId,
+        domain_id: GovernanceDomainId,
+        proposer: Did,
+        title: String,
+        description: String,
+        payload: ProposalPayload,
+        scope: ProposalScope,
+        action_items_on_accept: Vec<icn_governance::ActionItemSpec>,
+    ) -> Result<ProposalId> {
         if let Some(ref handle) = self.governance_handle {
             let generated_id = handle
-                .create_proposal(domain_id, title, description, payload, scope)
+                .create_proposal_with_actions(
+                    domain_id,
+                    title,
+                    description,
+                    payload,
+                    scope,
+                    action_items_on_accept,
+                )
                 .await?;
             return Ok(generated_id);
         }
@@ -521,8 +553,9 @@ impl GovernanceManager {
         }
         drop(domains);
 
-        let mut proposal =
-            Proposal::new(domain_id, proposer, title, description, payload).with_scope(scope);
+        let mut proposal = Proposal::new(domain_id, proposer, title, description, payload)
+            .with_scope(scope)
+            .with_action_items(action_items_on_accept);
         proposal.id = proposal_id.clone();
 
         let mut proposals = self.proposals.write().map_err(|e| {

--- a/icn/crates/icn-core/tests/delegation_tally_integration.rs
+++ b/icn/crates/icn-core/tests/delegation_tally_integration.rs
@@ -116,6 +116,7 @@ async fn lifecycle_proposal(
                 body: "Approve test motion".to_string(),
             },
             scope: ProposalScope::Local,
+            action_items_on_accept: Vec::new(),
         })
         .await?;
 
@@ -320,6 +321,7 @@ async fn test_lost_standing_member_delegation_blocked() -> Result<()> {
                 body: "Test motion".to_string(),
             },
             scope: ProposalScope::Local,
+            action_items_on_accept: Vec::new(),
         })
         .await?;
     actor
@@ -410,6 +412,7 @@ async fn test_suspended_delegator_weight_excluded_at_close_time() -> Result<()> 
                 body: "Motion text.".to_string(),
             },
             scope: ProposalScope::Local,
+            action_items_on_accept: Vec::new(),
         })
         .await?;
 
@@ -486,6 +489,7 @@ async fn test_suspended_delegator_weight_excluded_at_close_time() -> Result<()> 
                 body: "Motion text.".to_string(),
             },
             scope: ProposalScope::Local,
+            action_items_on_accept: Vec::new(),
         })
         .await?;
 

--- a/icn/crates/icn-core/tests/execution_receipt_gate_integration.rs
+++ b/icn/crates/icn-core/tests/execution_receipt_gate_integration.rs
@@ -112,6 +112,7 @@ async fn run_proposal(
                 body: "Nothing to allocate".to_string(),
             },
             scope: ProposalScope::Local,
+            action_items_on_accept: Vec::new(),
         })
         .await?;
 

--- a/icn/crates/icn-core/tests/governance_integration.rs
+++ b/icn/crates/icn-core/tests/governance_integration.rs
@@ -139,7 +139,7 @@ impl TestNode {
                         }
                         GovernanceMessage::ProposalCreated { proposal } => {
                             let proposal_id = proposal.id.clone();
-                            proposals_clone.write().await.insert(proposal_id, proposal);
+                            proposals_clone.write().await.insert(proposal_id, *proposal);
                         }
                         GovernanceMessage::ProposalOpened {
                             id,

--- a/icn/crates/icn-core/tests/receipt_chain_vertical_slice.rs
+++ b/icn/crates/icn-core/tests/receipt_chain_vertical_slice.rs
@@ -129,6 +129,7 @@ async fn test_allocation_receipt_chain_end_to_end() -> Result<()> {
                 purpose: "q1-compute".to_string(),
             },
             scope: ProposalScope::Local,
+            action_items_on_accept: Vec::new(),
         })
         .await?;
 

--- a/icn/crates/icn-core/tests/vertical_slice_integration.rs
+++ b/icn/crates/icn-core/tests/vertical_slice_integration.rs
@@ -337,6 +337,7 @@ async fn test_tool_library_cooperative_vertical_slice() -> Result<()> {
                 member: dave.did(),
             },
             scope: ProposalScope::Local,
+            action_items_on_accept: Vec::new(),
         })
         .await?;
 
@@ -428,6 +429,7 @@ async fn test_tool_library_cooperative_vertical_slice() -> Result<()> {
                 purpose: "Purchase drill press for tool library".to_string(),
             },
             scope: ProposalScope::Local,
+            action_items_on_accept: Vec::new(),
         })
         .await?;
 

--- a/icn/crates/icn-gateway/tests/entity_dissolution_integration.rs
+++ b/icn/crates/icn-gateway/tests/entity_dissolution_integration.rs
@@ -62,6 +62,7 @@ fn create_test_proposal(proposal_id: &str) -> Proposal {
         created_at: now - 3600,
         updated_at: now,
         scope: icn_governance::ProposalScope::Local,
+        action_items_on_accept: Vec::new(),
     }
 }
 

--- a/icn/crates/icn-governance/src/action_item.rs
+++ b/icn/crates/icn-governance/src/action_item.rs
@@ -998,4 +998,159 @@ mod tests {
             1
         );
     }
+
+    #[test]
+    fn test_action_item_spec_materialize() {
+        let spec = ActionItemSpec {
+            title: "Draft committee report".to_string(),
+            description: Some("Prepare Q1 report for the board".to_string()),
+            assignee: Some(test_did()),
+            due_offset_seconds: Some(7 * 24 * 3600), // 1 week
+            priority: ActionItemPriority::High,
+            tags: vec!["committee".to_string(), "report".to_string()],
+        };
+
+        let domain = test_domain();
+        let proposal_id = crate::ProposalId("prop-123".to_string());
+        let proposer = test_did();
+        let now = 1_000_000u64;
+
+        let item = spec.materialize(domain.clone(), proposal_id.clone(), proposer.clone(), now);
+
+        assert_eq!(item.domain_id, domain);
+        assert_eq!(item.title, "Draft committee report");
+        assert_eq!(
+            item.description,
+            Some("Prepare Q1 report for the board".to_string())
+        );
+        assert_eq!(item.assignee, Some(test_did()));
+        assert_eq!(item.due_date, Some(now + 7 * 24 * 3600));
+        assert_eq!(item.priority, ActionItemPriority::High);
+        assert_eq!(item.tags, vec!["committee", "report"]);
+        assert_eq!(item.linked_proposal, Some(proposal_id));
+        assert_eq!(item.status, ActionItemStatus::Pending);
+        assert_eq!(item.created_at, now);
+    }
+
+    #[test]
+    fn test_action_item_spec_materialize_minimal() {
+        let spec = ActionItemSpec {
+            title: "Follow up".to_string(),
+            description: None,
+            assignee: None,
+            due_offset_seconds: None,
+            priority: ActionItemPriority::Medium,
+            tags: Vec::new(),
+        };
+
+        let item = spec.materialize(
+            test_domain(),
+            crate::ProposalId("prop-456".to_string()),
+            test_did(),
+            500,
+        );
+
+        assert_eq!(item.title, "Follow up");
+        assert!(item.description.is_none());
+        assert!(item.assignee.is_none());
+        assert!(item.due_date.is_none());
+        assert_eq!(item.priority, ActionItemPriority::Medium);
+        assert!(item.tags.is_empty());
+        assert!(item.linked_proposal.is_some());
+    }
+
+    #[test]
+    fn test_action_item_spec_materialize_saturating_due_date() {
+        let spec = ActionItemSpec {
+            title: "Overflow test".to_string(),
+            description: None,
+            assignee: None,
+            due_offset_seconds: Some(u64::MAX),
+            priority: ActionItemPriority::Medium,
+            tags: Vec::new(),
+        };
+
+        let item = spec.materialize(
+            test_domain(),
+            crate::ProposalId("prop-overflow".to_string()),
+            test_did(),
+            1_000_000,
+        );
+
+        // Should saturate to u64::MAX, not panic or wrap
+        assert_eq!(item.due_date, Some(u64::MAX));
+    }
+
+    #[test]
+    fn test_materialize_creates_linked_items_in_store() {
+        let store = ActionItemStore::in_memory();
+        let domain = test_domain();
+        let proposal_id = crate::ProposalId("prop-accepted".to_string());
+
+        let specs = vec![
+            ActionItemSpec {
+                title: "Task A".to_string(),
+                description: None,
+                assignee: None,
+                due_offset_seconds: Some(3600),
+                priority: ActionItemPriority::High,
+                tags: vec!["urgent".to_string()],
+            },
+            ActionItemSpec {
+                title: "Task B".to_string(),
+                description: Some("Second task".to_string()),
+                assignee: Some(test_did()),
+                due_offset_seconds: None,
+                priority: ActionItemPriority::Low,
+                tags: Vec::new(),
+            },
+        ];
+
+        let now = 1_000_000u64;
+        for spec in &specs {
+            let item = spec.materialize(domain.clone(), proposal_id.clone(), test_did(), now);
+            store.save(&item).unwrap();
+        }
+
+        // All items linked to the proposal
+        let linked = store
+            .list(
+                &domain,
+                &ActionItemFilter {
+                    linked_proposal: Some(proposal_id.clone()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(linked.len(), 2);
+        assert!(linked
+            .iter()
+            .all(|i| i.linked_proposal.as_ref() == Some(&proposal_id)));
+
+        // Idempotency check: if items already exist, a second pass would find them
+        let existing = store
+            .list(
+                &domain,
+                &ActionItemFilter {
+                    linked_proposal: Some(proposal_id),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(existing.len(), 2, "dedup check should find existing items");
+    }
+
+    #[test]
+    fn test_action_item_spec_serde_defaults() {
+        // Minimal JSON — all optional fields omitted
+        let json = r#"{"title":"Minimal task"}"#;
+        let spec: ActionItemSpec = serde_json::from_str(json).unwrap();
+
+        assert_eq!(spec.title, "Minimal task");
+        assert!(spec.description.is_none());
+        assert!(spec.assignee.is_none());
+        assert!(spec.due_offset_seconds.is_none());
+        assert_eq!(spec.priority, ActionItemPriority::Medium);
+        assert!(spec.tags.is_empty());
+    }
 }

--- a/icn/crates/icn-governance/src/action_item.rs
+++ b/icn/crates/icn-governance/src/action_item.rs
@@ -90,7 +90,7 @@ pub enum ActionItemPriority {
 ///
 /// Attached to proposals via `Proposal::action_items_on_accept`. When the proposal
 /// is accepted, each spec produces an `ActionItem` linked to the originating proposal
-/// with its provenance hash. This is the first bridge pattern for obligation-producing
+/// via `linked_proposal`. This is the first bridge pattern for obligation-producing
 /// proposals — other proposal types (Budget→ledger, Charter→oracle) keep their own
 /// execution hooks.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -134,7 +134,9 @@ impl ActionItemSpec {
         let mut item = ActionItem::new(domain_id, self.title.clone(), created_by, now);
         item.description = self.description.clone();
         item.assignee = self.assignee.clone();
-        item.due_date = self.due_offset_seconds.map(|offset| now + offset);
+        item.due_date = self
+            .due_offset_seconds
+            .map(|offset| now.saturating_add(offset));
         item.priority = self.priority;
         item.tags = self.tags.clone();
         item.linked_proposal = Some(proposal_id);

--- a/icn/crates/icn-governance/src/action_item.rs
+++ b/icn/crates/icn-governance/src/action_item.rs
@@ -86,6 +86,62 @@ pub enum ActionItemPriority {
     Critical,
 }
 
+/// A template for creating action items when a proposal is accepted.
+///
+/// Attached to proposals via `Proposal::action_items_on_accept`. When the proposal
+/// is accepted, each spec produces an `ActionItem` linked to the originating proposal
+/// with its provenance hash. This is the first bridge pattern for obligation-producing
+/// proposals — other proposal types (Budget→ledger, Charter→oracle) keep their own
+/// execution hooks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActionItemSpec {
+    /// Short title describing the action
+    pub title: String,
+
+    /// Detailed description (optional)
+    #[serde(default)]
+    pub description: Option<String>,
+
+    /// Member responsible for this item (optional DID)
+    #[serde(default)]
+    pub assignee: Option<Did>,
+
+    /// Seconds after proposal acceptance before this item is due (optional).
+    /// Converted to absolute timestamp at creation time.
+    #[serde(default)]
+    pub due_offset_seconds: Option<u64>,
+
+    /// Priority level
+    #[serde(default)]
+    pub priority: ActionItemPriority,
+
+    /// Tags for categorization
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+impl ActionItemSpec {
+    /// Materialize this spec into a concrete ActionItem linked to the given proposal.
+    ///
+    /// The `now` timestamp is used for created_at and to compute due_date from the offset.
+    pub fn materialize(
+        &self,
+        domain_id: GovernanceDomainId,
+        proposal_id: ProposalId,
+        created_by: Did,
+        now: u64,
+    ) -> ActionItem {
+        let mut item = ActionItem::new(domain_id, self.title.clone(), created_by, now);
+        item.description = self.description.clone();
+        item.assignee = self.assignee.clone();
+        item.due_date = self.due_offset_seconds.map(|offset| now + offset);
+        item.priority = self.priority;
+        item.tags = self.tags.clone();
+        item.linked_proposal = Some(proposal_id);
+        item
+    }
+}
+
 /// An action item tracked within a governance domain
 ///
 /// Note: Option fields use `#[serde(default)]` for binary serialization compatibility

--- a/icn/crates/icn-governance/src/handle.rs
+++ b/icn/crates/icn-governance/src/handle.rs
@@ -66,6 +66,23 @@ pub trait GovernanceOps: Send + Sync {
         scope: ProposalScope,
     ) -> Result<ProposalId>;
 
+    /// Create a proposal with action item specs that materialize on acceptance.
+    ///
+    /// Default impl delegates to `create_proposal` (ignoring action items).
+    /// Implementations that support the decision-to-action bridge should override.
+    async fn create_proposal_with_actions(
+        &self,
+        domain_id: GovernanceDomainId,
+        title: String,
+        description: String,
+        payload: ProposalPayload,
+        scope: ProposalScope,
+        _action_items_on_accept: Vec<crate::action_item::ActionItemSpec>,
+    ) -> Result<ProposalId> {
+        self.create_proposal(domain_id, title, description, payload, scope)
+            .await
+    }
+
     /// Start deliberation period for a proposal
     ///
     /// Transitions the proposal from Draft to Deliberation state.

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -174,7 +174,8 @@ pub use proposal_cleanup::{CleanupStats, ProposalArchive, ProposalCleanupTask, P
 // Action item types
 pub use action_item::{
     ActionItem, ActionItemFilter, ActionItemId, ActionItemNote, ActionItemPriority,
-    ActionItemStatus, ActionItemStore, ActionItemStoreBackend, InMemoryActionItemStore,
+    ActionItemSpec, ActionItemStatus, ActionItemStore, ActionItemStoreBackend,
+    InMemoryActionItemStore,
 };
 
 /// Unix timestamp in seconds

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -173,9 +173,8 @@ pub use proposal_cleanup::{CleanupStats, ProposalArchive, ProposalCleanupTask, P
 
 // Action item types
 pub use action_item::{
-    ActionItem, ActionItemFilter, ActionItemId, ActionItemNote, ActionItemPriority,
-    ActionItemSpec, ActionItemStatus, ActionItemStore, ActionItemStoreBackend,
-    InMemoryActionItemStore,
+    ActionItem, ActionItemFilter, ActionItemId, ActionItemNote, ActionItemPriority, ActionItemSpec,
+    ActionItemStatus, ActionItemStore, ActionItemStoreBackend, InMemoryActionItemStore,
 };
 
 /// Unix timestamp in seconds

--- a/icn/crates/icn-governance/src/message.rs
+++ b/icn/crates/icn-governance/src/message.rs
@@ -231,7 +231,9 @@ impl GovernanceMessage {
 
     /// Create a ProposalCreated message
     pub fn proposal_created(proposal: Proposal) -> Self {
-        Self::ProposalCreated { proposal: Box::new(proposal) }
+        Self::ProposalCreated {
+            proposal: Box::new(proposal),
+        }
     }
 
     /// Create a ProposalOpened message

--- a/icn/crates/icn-governance/src/message.rs
+++ b/icn/crates/icn-governance/src/message.rs
@@ -26,8 +26,8 @@ pub enum GovernanceMessage {
 
     /// A new proposal has been created
     ProposalCreated {
-        /// The proposal
-        proposal: Proposal,
+        /// The proposal (boxed to reduce enum size — Proposal is the largest variant)
+        proposal: Box<Proposal>,
     },
 
     /// A proposal has been opened for voting
@@ -231,7 +231,7 @@ impl GovernanceMessage {
 
     /// Create a ProposalCreated message
     pub fn proposal_created(proposal: Proposal) -> Self {
-        Self::ProposalCreated { proposal }
+        Self::ProposalCreated { proposal: Box::new(proposal) }
     }
 
     /// Create a ProposalOpened message

--- a/icn/crates/icn-governance/src/proposal.rs
+++ b/icn/crates/icn-governance/src/proposal.rs
@@ -1325,7 +1325,7 @@ pub struct Proposal {
     /// Action items to create when this proposal is accepted.
     ///
     /// Each spec is materialized into a concrete `ActionItem` linked to this
-    /// proposal's ID and provenance hash. This is the decision-to-action bridge:
+    /// proposal's ID via `linked_proposal`. This is the decision-to-action bridge:
     /// accepted proposals produce institutional obligations, not just status changes.
     ///
     /// Empty by default (backward compatible). Only obligation-producing proposals

--- a/icn/crates/icn-governance/src/proposal.rs
+++ b/icn/crates/icn-governance/src/proposal.rs
@@ -1321,6 +1321,18 @@ pub struct Proposal {
     /// Scope (local or federation). Defaults to Local for backward compat.
     #[serde(default)]
     pub scope: ProposalScope,
+
+    /// Action items to create when this proposal is accepted.
+    ///
+    /// Each spec is materialized into a concrete `ActionItem` linked to this
+    /// proposal's ID and provenance hash. This is the decision-to-action bridge:
+    /// accepted proposals produce institutional obligations, not just status changes.
+    ///
+    /// Empty by default (backward compatible). Only obligation-producing proposals
+    /// use this field; other proposal types (Budget, Charter, Membership) have their
+    /// own execution hooks.
+    #[serde(default)]
+    pub action_items_on_accept: Vec<crate::action_item::ActionItemSpec>,
 }
 
 impl Proposal {
@@ -1345,7 +1357,15 @@ impl Proposal {
             created_at: now,
             updated_at: now,
             scope: ProposalScope::Local,
+            action_items_on_accept: Vec::new(),
         }
+    }
+
+    /// Attach action item specs to be created on acceptance.
+    #[must_use]
+    pub fn with_action_items(mut self, specs: Vec<crate::action_item::ActionItemSpec>) -> Self {
+        self.action_items_on_accept = specs;
+        self
     }
 
     /// Set the proposal scope.


### PR DESCRIPTION
## Summary
- Adds `ActionItemSpec` type and `action_items_on_accept` field to `Proposal`
- When a proposal is accepted, the governance actor materializes specs into linked `ActionItem` records
- Works for both voted acceptance and force-acceptance paths
- HTTP API accepts action item specs in `CreateProposalRequest`

This is the institutional execution bridge (Tranche 1A of the NYCN sprint plan): governance decisions produce downstream obligations with provenance linkage, not just status changes.

**Platform feature** — works for any governance domain on any ICN node.

## What changed
- `icn-governance`: `ActionItemSpec` with `materialize()`, `Proposal.action_items_on_accept`, `GovernanceOps::create_proposal_with_actions` trait method with default impl
- `governance-actor`: Hook after `ProposalAccepted` and `ForceCloseProposal(Accept)` to create linked items via `ActionItemStoreBackend`
- HTTP models: `ActionItemSpecRequest` in `CreateProposalRequest`
- Fix: `Box<Proposal>` in `GovernanceMessage::ProposalCreated` (clippy `large_enum_variant`)

## Risk
- Low — additive change. Existing proposals without `action_items_on_accept` (all current proposals) behave identically due to `#[serde(default)]`
- The actor's `action_item_store` is `Option` — nodes without it configured skip materialization silently

## Test plan
- `cargo clippy -p icn-governance -p icn-governance-actor --all-targets -- -D warnings` ✅
- `cargo test -p icn-governance` ✅ (7 passed, 6 ignored)
- `cargo test -p icn-governance-actor` ✅ (2 passed, 2 ignored)
- `cargo check` full workspace ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)