### PR TITLE
docs(strategy): NYCN federation charter draft (CCL YAML)

### DIFF
--- a/docs/design/institutional-structure-spec.md
+++ b/docs/design/institutional-structure-spec.md
@@ -1,0 +1,246 @@
+# Institutional Structure + Event Model — Design Spec
+
+**Status**: DRAFT
+**Date**: 2026-04-14
+**Supersedes**: Committee-as-Community pattern in NYCN-Institutional-Design.md
+
+## Problem
+
+ICN models sovereign institutions (Cooperative, Community, Federation) but has no way to represent the internal operating structures that real institutions use daily — committees, working groups, roles — or the time-bounded activities they produce — events, projects, programs.
+
+NYCN exposed this gap: its 4 committees and annual summit were being modeled as Community entities, which is a category error. Committees are not sovereign. The summit is not an institution. Both need representation without polluting the entity graph.
+
+## Decision
+
+ICN's institutional model has three layers. Each layer has distinct sovereignty, lifecycle, and attachment rules.
+
+### Layer A: Sovereign Entities
+
+`Person | Cooperative | Community | Federation`
+
+Properties:
+- Hold identity (DID)
+- Own governance domains
+- Own treasury accounts
+- Join federations
+- Persist independently
+- Have charter/constitution
+
+These exist today in `icn-entity`. No changes needed to this layer.
+
+### Layer B: Internal Structures
+
+`Committee | WorkingGroup | Team | Office`
+
+Properties:
+- Exist only inside a parent entity
+- Authority is delegated, not sovereign
+- Cannot join federations independently
+- Cannot hold independent treasury (spend through parent's treasury with scoped authority)
+- Dissolving the parent dissolves them
+- Created and dissolved by governance decisions of the parent entity
+
+### Layer C: Activities
+
+`Event | Program | Project | Initiative`
+
+Properties:
+- Time-bounded or purpose-bounded
+- Owned by an entity (or co-owned by entity + structure)
+- Gather meetings, documents, budgets, tasks, registrations
+- Not sovereign — no independent governance or federation membership
+- Have lifecycle: Planned -> Active -> Completed/Cancelled
+
+## Object Definitions
+
+### Structure
+
+```rust
+pub struct Structure {
+    pub id: StructureId,
+    pub parent_entity_id: EntityId,
+    pub kind: StructureKind,
+    pub name: String,
+    pub mandate: Option<String>,       // what this structure is authorized to do
+    pub scope: Vec<String>,            // delegated authority scopes
+    pub status: StructureStatus,
+    pub created_at: Timestamp,
+    pub created_by_decision: Option<ProposalId>,  // provenance
+    pub updated_at: Timestamp,
+}
+
+pub enum StructureKind {
+    Committee,
+    WorkingGroup,
+    Team,
+    Office,
+}
+
+pub enum StructureStatus {
+    Active,
+    Suspended,
+    Dissolved,
+}
+```
+
+### RoleAssignment
+
+```rust
+pub struct RoleAssignment {
+    pub id: RoleAssignmentId,
+    pub structure_id: StructureId,
+    pub person_did: Did,
+    pub role: String,                  // e.g., "coordinator", "member", "secretary"
+    pub authority_scope: Vec<String>,  // what this role can do
+    pub start_date: Timestamp,
+    pub end_date: Option<Timestamp>,
+    pub assigned_by_decision: Option<ProposalId>,
+}
+```
+
+### Activity
+
+```rust
+pub struct Activity {
+    pub id: ActivityId,
+    pub parent_entity_id: EntityId,
+    pub kind: ActivityKind,
+    pub name: String,
+    pub description: Option<String>,
+    pub status: ActivityStatus,
+    pub start_date: Option<Timestamp>,
+    pub end_date: Option<Timestamp>,
+    pub linked_structures: Vec<StructureId>,  // committees contributing to this activity
+    pub created_at: Timestamp,
+    pub created_by_decision: Option<ProposalId>,
+}
+
+pub enum ActivityKind {
+    Event,
+    Program,
+    Project,
+    Initiative,
+}
+
+pub enum ActivityStatus {
+    Planned,
+    Active,
+    Completed,
+    Cancelled,
+}
+```
+
+### Parent-Aware Attachment
+
+All operational objects (Meeting, ActionItem, Document, Proposal) gain a polymorphic parent reference:
+
+```rust
+pub enum InstitutionalParent {
+    Entity(EntityId),
+    Structure(StructureId),
+    Activity(ActivityId),
+}
+```
+
+This replaces the current pattern where action items have `domain_id` as their only scope. A meeting can belong to a committee. A document can belong to a summit event. A proposal can be scoped to a federation.
+
+## Invariants
+
+1. **Sovereignty boundary**: Structures and Activities NEVER appear in federation membership lists. Only Entities join federations.
+2. **Delegation, not independence**: A Structure's authority derives entirely from its parent entity. Revoking the parent's charter dissolves all structures.
+3. **Provenance chain**: Structure creation, mandate changes, and role assignments are traceable to governance decisions when proposal-backed.
+4. **Treasury scoping**: Structures spend through the parent entity's treasury with scoped authority. They do not hold independent accounts.
+5. **Activity lifecycle**: Activities have bounded lifecycle. They transition to Completed or Cancelled, never persist as zombie entities.
+
+## NYCN Concrete Example
+
+### Sovereign layer
+- `entity:nycn` — Federation
+- `entity:nycn-organizers` — Cooperative (child of nycn)
+- `entity:greenstar` — Cooperative (federation member)
+- `entity:cooperation-buffalo` — Cooperative (federation member)
+
+### Internal structure layer
+- `structure:nycn-steering` — Committee in nycn-organizers
+- `structure:nycn-content` — Committee in nycn-organizers
+- `structure:nycn-logistics` — Committee in nycn-organizers
+- `structure:nycn-finance` — Committee in nycn-organizers
+
+### Activity layer
+- `activity:ny-cooperative-summit-2026` — Event owned by nycn-organizers
+
+### Artifact attachment
+- Finance committee meeting → parent: `structure:nycn-finance`
+- Summit venue contract → parent: `activity:ny-cooperative-summit-2026`
+- Federation membership proposal → parent: `entity:nycn`
+- Sponsor outreach task → parent: `structure:nycn-marketing`, linked to summit activity
+
+## API Shape (REST)
+
+### Structures
+
+```
+POST   /gov/entities/{entity_id}/structures
+GET    /gov/entities/{entity_id}/structures
+GET    /gov/structures/{structure_id}
+PUT    /gov/structures/{structure_id}
+DELETE /gov/structures/{structure_id}
+
+POST   /gov/structures/{structure_id}/roles
+GET    /gov/structures/{structure_id}/roles
+DELETE /gov/structures/{structure_id}/roles/{role_id}
+```
+
+### Activities
+
+```
+POST   /gov/entities/{entity_id}/activities
+GET    /gov/entities/{entity_id}/activities
+GET    /gov/activities/{activity_id}
+PUT    /gov/activities/{activity_id}
+```
+
+### Attachment
+
+Existing endpoints (meetings, action items, documents) gain optional query parameter or body field:
+
+```
+POST /gov/domains/{domain_id}/action-items
+  { ..., "parent": { "type": "structure", "id": "nycn-finance" } }
+
+GET /gov/structures/{structure_id}/meetings
+GET /gov/activities/{activity_id}/documents
+```
+
+## Where This Lives in the Codebase
+
+| Concern | Crate | Rationale |
+|---------|-------|-----------|
+| Structure, Activity types | `icn-governance` | Governance-scoped institutional objects |
+| StructureStore, ActivityStore | `icn-governance` + `apps/governance` | Same pattern as ActionItemStore |
+| REST endpoints | `apps/governance/src/http/` | Extends existing governance HTTP layer |
+| Entity↔Structure relationship | `icn-entity` (optional ref) | Entities may list their structures |
+| Gossip replication | `governance:{domain_id}:structures` topic | Same pattern as existing governance gossip |
+
+## Build Order
+
+1. **Types + store traits** in `icn-governance` (~200 lines)
+2. **Sled store backend** in `apps/governance/src/manager.rs`
+3. **HTTP endpoints** for structures and activities
+4. **Parent-aware attachment** on ActionItem, Meeting, Document
+5. **Governance hooks** — proposal-backed structure creation/dissolution
+6. **Charter update** — correct NYCN charter draft to use structures
+
+## What This Does NOT Include
+
+- UI rendering (separate tranche)
+- Notifications/digests for structures (Phase 4 from original plan)
+- Document storage (Phase 5 from original plan)
+- Trust thresholds for structure roles (future)
+- CCL enforcement of delegation scopes (future — currently advisory)
+
+## Relationship to Existing Plan
+
+This tranche **replaces** the Meeting Management phase (Phase 3) from the original sprint plan. Meetings still get built, but they attach to structures and activities rather than being standalone institutional objects. The meeting types themselves are unchanged — what changes is their parent scope.
+
+The Decision-to-Action bridge (Phase 1, PR #1532) and Consent mode (Phase 1, PR #1533) remain as-is. They are prerequisites — structures will eventually be created by accepted proposals through the action bridge.

--- a/docs/strategy/NYCN-Charter-Draft.yaml
+++ b/docs/strategy/NYCN-Charter-Draft.yaml
@@ -1,0 +1,325 @@
+# NYCN Charter — CCL YAML Draft
+#
+# New York Cooperative Network federation charter.
+# Based on Template 1 (Federation of Cooperatives) from ccl-charter-templates.md,
+# customized for NYCN's actual governance practices:
+#   - Consent-based decision-making (not majority vote)
+#   - 4 standing committees under an organizing cooperative
+#   - Annual summit as time-bounded community entity
+#   - 217+ member organizations across NY state
+#
+# This charter is ratified via a Charter governance proposal and deployed to
+# the CharterPolicyOracle. The kernel enforces it as a ConstraintSet.
+#
+# Status: DRAFT — requires community review before ratification proposal.
+
+charter:
+  name: "New York Cooperative Network"
+  version: 1
+  entity_type: federation
+  region: "New York State"
+
+  # ─── Federation Identity ──────────────────────────────
+  identity:
+    entity_id: "nycn"
+    display_name: "New York Cooperative Network"
+    description: >
+      A regional federation of cooperatives, communities, and aligned
+      organizations coordinating through shared governance, economic
+      solidarity, and the annual cooperative summit.
+
+  # ─── Federation Governance ────────────────────────────
+  # NYCN operates by consent: proposals pass unless objections exceed
+  # the threshold within the deliberation period. This reflects the
+  # cooperative tradition of consensus-seeking decision-making.
+  governance:
+    eligible_voters: federated_members
+    decision_mode: consent
+    default_max_objections: 0  # strict consensus — any objection blocks
+
+    decisions:
+      # Admitting new member organizations
+      membership_admission:
+        decision_mode: consent
+        max_objections: 0
+        quorum: 0.5
+        deliberation_period_hours: 168  # 7 days
+        voting_period_hours: 168        # 7 days
+
+      # Changing the charter itself — higher bar
+      charter_amendment:
+        decision_mode: consent
+        max_objections: 0
+        quorum: 0.5
+        deliberation_period_hours: 336  # 14 days
+        voting_period_hours: 336        # 14 days
+
+      # Removing a member organization — escalated
+      member_removal:
+        decision_mode: consent
+        max_objections: 0
+        quorum: 0.6
+        deliberation_period_hours: 336
+        voting_period_hours: 336
+
+      # Federation-wide initiatives and resolutions
+      initiative:
+        decision_mode: consent
+        max_objections: 1  # one objection tolerated for general initiatives
+        quorum: 0.4
+        deliberation_period_hours: 72
+        voting_period_hours: 168
+
+      # Annual budget approval
+      budget:
+        decision_mode: consent
+        max_objections: 0
+        quorum: 0.5
+        deliberation_period_hours: 168
+        voting_period_hours: 168
+
+  # ─── Organizing Cooperative ───────────────────────────
+  # The operational body that executes federation mandates.
+  # Holds the operational treasury and employs/coordinates staff.
+  operations:
+    entity_id: "nycn-organizers"
+    entity_type: cooperative
+    parent_id: "nycn"
+
+    governance:
+      eligible_voters: steering_members
+      decision_mode: consent
+      default_max_objections: 0
+
+      decisions:
+        budget_approval:
+          decision_mode: consent
+          max_objections: 0
+          quorum: 0.5
+          deliberation_period_hours: 72
+          voting_period_hours: 168
+
+        venue_selection:
+          decision_mode: consent
+          max_objections: 1
+          quorum: 0.5
+          voting_period_hours: 120
+
+        program_approval:
+          decision_mode: consent
+          max_objections: 1
+          quorum: 0.5
+          voting_period_hours: 120
+
+        spending_above_threshold:
+          decision_mode: consent
+          max_objections: 0
+          quorum: 0.5
+          voting_period_hours: 72
+
+        new_committee:
+          decision_mode: consent
+          max_objections: 0
+          quorum: 0.5
+          deliberation_period_hours: 48
+          voting_period_hours: 120
+
+        emergency_action:
+          decision_mode: consent
+          max_objections: 0
+          quorum: 0.3
+          voting_period_hours: 24
+
+  # ─── Committee Delegation ─────────────────────────────
+  # Each committee is a Community entity with its own governance domain.
+  # Committees operate by consent within their delegated scope.
+  # Decisions outside scope escalate to the organizing cooperative.
+  committees:
+    defaults:
+      decision_mode: consent
+      max_objections: 0
+      quorum: 0.5
+      voting_period_hours: 72
+
+    bodies:
+      - id: "nycn-steering"
+        name: "Steering Committee"
+        entity_type: community
+        parent_id: "nycn-organizers"
+        purpose: >
+          Overall strategic direction, inter-committee coordination,
+          and escalated decision authority for the organizing cooperative.
+        autonomous_scope:
+          - "Strategic direction within charter mandate"
+          - "Inter-committee coordination"
+          - "Approve committee membership changes"
+        escalation_required:
+          - "Charter amendments"
+          - "Federation-level membership changes"
+
+      - id: "nycn-content"
+        name: "Content Committee"
+        entity_type: community
+        parent_id: "nycn-organizers"
+        purpose: >
+          Summit programming, speaker curation, session design,
+          and year-round educational content.
+        autonomous_scope:
+          - "Approve individual sessions and speakers"
+          - "Assign speakers to sessions"
+          - "Set session schedule within approved structure"
+        escalation_required:
+          - "Overall program structure (tracks, keynote, session count)"
+          - "Speaker fees above $200"
+          - "Partnership with external orgs for content"
+
+      - id: "nycn-logistics"
+        name: "Logistics Committee"
+        entity_type: community
+        parent_id: "nycn-organizers"
+        purpose: >
+          Venue management, vendor coordination, day-of operations,
+          and physical infrastructure.
+        autonomous_scope:
+          - "Vendor selection within approved budget"
+          - "Day-of operational decisions"
+          - "Volunteer coordination"
+        escalation_required:
+          - "Venue selection or change"
+          - "Contracts above $1,000"
+          - "Changes affecting overall event structure"
+
+      - id: "nycn-finance"
+        name: "Finance Committee"
+        entity_type: community
+        parent_id: "nycn-organizers"
+        purpose: >
+          Budget management, sponsorship processing, financial reporting,
+          and fiscal accountability.
+        autonomous_scope:
+          - "Accept sponsorships up to $500"
+          - "Process routine expenses within committee allocations"
+          - "Generate and distribute financial reports"
+        escalation_required:
+          - "Sponsorships above $500"
+          - "Budget amendments or new expense categories"
+          - "End-of-year financial close decisions"
+
+  # ─── Summit Entity ────────────────────────────────────
+  # Time-bounded community for each annual summit.
+  # Created fresh each year, inheriting institutional records.
+  summit:
+    entity_template:
+      id_pattern: "nycn-summit-{year}"
+      entity_type: community
+      parent_id: "nycn-organizers"
+      lifecycle:
+        forming: "October (year-1)"
+        active: "January–summit date"
+        completed: "30 days post-summit"
+      governance:
+        decision_mode: consent
+        max_objections: 1
+        quorum: 0.5
+        voting_period_hours: 72
+
+  # ─── Trust Thresholds ─────────────────────────────────
+  trust:
+    thresholds:
+      propose_discussion: 0.0       # Anyone can start a discussion
+      vote_committee: 0.1           # Minimal participation required
+      propose_budget_change: 0.5    # Established contributor
+      committee_coordinator: 0.5    # Proven track record
+      steering_membership: 0.7     # Core leadership
+      charter_amendment: 0.7       # High trust for constitutional changes
+
+  # ─── Budget Authority ─────────────────────────────────
+  budget:
+    spending_threshold: 500  # USD — above requires steering approval
+    currency: USD
+
+    committee_allocations:
+      approval_required: steering
+      approval_method: consent
+      approval_max_objections: 0
+
+    expense_approval:
+      within_allocation: autonomous
+      above_allocation: steering
+
+  # ─── Membership ───────────────────────────────────────
+  membership:
+    tiers:
+      - name: full_member
+        entity_types: [cooperative]
+        role: federated_member
+        rights: [vote, propose, treasury_access, invite]
+        obligations:
+          - "Maintain active participation"
+          - "Adhere to federation charter"
+          - "Send delegate to annual meeting or summit"
+          - "Cooperative in good standing under NY law"
+
+      - name: affiliate
+        entity_types: [cooperative, community]
+        role: associate_member
+        rights: [vote_limited, propose_limited]
+        obligations:
+          - "Mission-aligned organization"
+          - "Annual affirmation of affiliation"
+
+      - name: emerging
+        entity_types: [community]
+        role: provisional_member
+        rights: [propose_community]
+        obligations:
+          - "Working toward cooperative formation"
+          - "Mentorship engagement"
+
+      - name: individual_organizer
+        entity_types: [individual]
+        role: organizer
+        rights: [vote_in_committees, propose]
+        obligations:
+          - "Active committee participation"
+          - "Attend steering meetings or send summary"
+
+      - name: observer
+        entity_types: [individual, cooperative]
+        role: observer_member
+        rights: [read_only]
+
+  # ─── Action Item Bridge ───────────────────────────────
+  # Accepted proposals auto-create institutional obligations.
+  # This section documents the default action specs for common decisions.
+  action_item_defaults:
+    budget_approval:
+      - title: "Distribute committee allocations"
+        assignee_role: finance_coordinator
+        due_offset_days: 7
+        priority: high
+        tags: [budget, finance]
+      - title: "Publish approved budget to federation members"
+        assignee_role: steering_coordinator
+        due_offset_days: 3
+        priority: medium
+        tags: [communication]
+
+    membership_admission:
+      - title: "Send welcome packet to new member"
+        assignee_role: steering_coordinator
+        due_offset_days: 7
+        priority: medium
+        tags: [onboarding]
+      - title: "Add member entity to federation roster"
+        assignee_role: steering_coordinator
+        due_offset_days: 3
+        priority: high
+        tags: [membership, admin]
+
+    initiative:
+      - title: "Draft implementation plan for initiative"
+        assignee_role: steering_coordinator
+        due_offset_days: 14
+        priority: medium
+        tags: [planning]

--- a/docs/strategy/NYCN-Charter-Draft.yaml
+++ b/docs/strategy/NYCN-Charter-Draft.yaml
@@ -131,8 +131,9 @@ charter:
           voting_period_hours: 24
 
   # ─── Committee Delegation ─────────────────────────────
-  # Each committee is a Community entity with its own governance domain.
-  # Committees operate by consent within their delegated scope.
+  # Committees are INTERNAL STRUCTURES of the organizing cooperative,
+  # NOT sovereign entities. They have delegated authority scopes but
+  # no independent governance domain, treasury, or federation membership.
   # Decisions outside scope escalate to the organizing cooperative.
   committees:
     defaults:
@@ -144,8 +145,8 @@ charter:
     bodies:
       - id: "nycn-steering"
         name: "Steering Committee"
-        entity_type: community
-        parent_id: "nycn-organizers"
+        structure_type: committee
+        parent_entity: "nycn-organizers"
         purpose: >
           Overall strategic direction, inter-committee coordination,
           and escalated decision authority for the organizing cooperative.
@@ -159,8 +160,8 @@ charter:
 
       - id: "nycn-content"
         name: "Content Committee"
-        entity_type: community
-        parent_id: "nycn-organizers"
+        structure_type: committee
+        parent_entity: "nycn-organizers"
         purpose: >
           Summit programming, speaker curation, session design,
           and year-round educational content.
@@ -175,8 +176,8 @@ charter:
 
       - id: "nycn-logistics"
         name: "Logistics Committee"
-        entity_type: community
-        parent_id: "nycn-organizers"
+        structure_type: committee
+        parent_entity: "nycn-organizers"
         purpose: >
           Venue management, vendor coordination, day-of operations,
           and physical infrastructure.
@@ -191,8 +192,8 @@ charter:
 
       - id: "nycn-finance"
         name: "Finance Committee"
-        entity_type: community
-        parent_id: "nycn-organizers"
+        structure_type: committee
+        parent_entity: "nycn-organizers"
         purpose: >
           Budget management, sponsorship processing, financial reporting,
           and fiscal accountability.
@@ -205,23 +206,24 @@ charter:
           - "Budget amendments or new expense categories"
           - "End-of-year financial close decisions"
 
-  # ─── Summit Entity ────────────────────────────────────
-  # Time-bounded community for each annual summit.
-  # Created fresh each year, inheriting institutional records.
+  # ─── Summit Activity ──────────────────────────────────
+  # The summit is an EVENT/ACTIVITY, not a sovereign entity.
+  # It is produced by the organizing cooperative and contributed to
+  # by committees. Created fresh each year.
   summit:
-    entity_template:
+    activity_template:
       id_pattern: "nycn-summit-{year}"
-      entity_type: community
-      parent_id: "nycn-organizers"
+      activity_type: event
+      parent_entity: "nycn-organizers"
+      linked_structures:
+        - "nycn-steering"
+        - "nycn-content"
+        - "nycn-logistics"
+        - "nycn-finance"
       lifecycle:
-        forming: "October (year-1)"
+        planned: "October (year-1)"
         active: "January–summit date"
         completed: "30 days post-summit"
-      governance:
-        decision_mode: consent
-        max_objections: 1
-        quorum: 0.5
-        voting_period_hours: 72
 
   # ─── Trust Thresholds ─────────────────────────────────
   trust:


### PR DESCRIPTION
## Summary

- NYCN federation charter in CCL YAML format, customized from Template 1
- Consent-based governance throughout (decision_mode: consent)
- 4 committees with delegated scope and escalation rules
- Annual summit entity template
- Membership tiers and action item defaults for common decisions

## Why

First concrete institutional charter for NYCN as an ICN-native federation. This is a platform exercise — the charter format and governance patterns apply to any future ICN institution.

## Test plan

- [x] Docs-only change, no code
- [ ] Community review of governance parameters before ratification proposal

🤖 Generated with [Claude Code](https://claude.com/claude-code)