### PR TITLE
feat(governance): Meeting management primitive (Phase 3)

### DIFF
--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -351,6 +351,40 @@ where
             web::resource("/activities/{activity_id}")
                 .route(web::get().to(handlers::get_activity::<E>)),
         )
+        // ── Meeting endpoints ────────────────────────────────────────────
+        .service(
+            web::resource("/domains/{domain_id}/meetings")
+                .route(web::post().to(handlers::create_meeting::<E>))
+                .route(web::get().to(handlers::list_meetings::<E>)),
+        )
+        .service(
+            web::resource("/meetings/{meeting_id}")
+                .route(web::get().to(handlers::get_meeting::<E>)),
+        )
+        .service(
+            web::resource("/meetings/{meeting_id}/start")
+                .route(web::post().to(handlers::start_meeting::<E>)),
+        )
+        .service(
+            web::resource("/meetings/{meeting_id}/end")
+                .route(web::post().to(handlers::end_meeting::<E>)),
+        )
+        .service(
+            web::resource("/meetings/{meeting_id}/attendees")
+                .route(web::post().to(handlers::add_attendee::<E>)),
+        )
+        .service(
+            web::resource("/meetings/{meeting_id}/attendance")
+                .route(web::put().to(handlers::mark_attendance::<E>)),
+        )
+        .service(
+            web::resource("/meetings/{meeting_id}/agenda")
+                .route(web::post().to(handlers::add_agenda_item::<E>)),
+        )
+        .service(
+            web::resource("/meetings/{meeting_id}/agenda/{item_id}")
+                .route(web::put().to(handlers::update_agenda_item::<E>)),
+        )
         // ── Federation proposal endpoints ────────────────────────────────
         .service(
             web::resource("/proposals/federation/join")

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -2917,7 +2917,12 @@ pub async fn create_meeting<E: GovernanceEventEmitter + Clone + 'static>(
     let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
     let domain = GovernanceDomainId(domain_id.into_inner());
 
-    check_domain_membership(&ctx.manager, &domain, &parse_did(&claims.sub, "Invalid DID in token")?).await?;
+    check_domain_membership(
+        &ctx.manager,
+        &domain,
+        &parse_did(&claims.sub, "Invalid DID in token")?,
+    )
+    .await?;
 
     let m = ctx
         .manager
@@ -2930,6 +2935,7 @@ pub async fn create_meeting<E: GovernanceEventEmitter + Clone + 'static>(
         )
         .map_err(anyhow_to_api)?;
 
+    // TODO: emit MeetingCreated event when GovernanceEventEmitter gains meeting methods
     Ok(HttpResponse::Created().json(meeting_to_response(&m)))
 }
 
@@ -2993,6 +2999,7 @@ pub async fn start_meeting<E: GovernanceEventEmitter + Clone + 'static>(
     m.started_at = Some(current_time_secs());
     ctx.manager.update_meeting(&m).map_err(anyhow_to_api)?;
 
+    // TODO: emit MeetingStarted event when GovernanceEventEmitter gains meeting methods
     Ok(HttpResponse::Ok().json(meeting_to_response(&m)))
 }
 
@@ -3024,6 +3031,7 @@ pub async fn end_meeting<E: GovernanceEventEmitter + Clone + 'static>(
     m.ended_at = Some(current_time_secs());
     ctx.manager.update_meeting(&m).map_err(anyhow_to_api)?;
 
+    // TODO: emit MeetingEnded event when GovernanceEventEmitter gains meeting methods
     Ok(HttpResponse::Ok().json(meeting_to_response(&m)))
 }
 
@@ -3034,7 +3042,7 @@ pub async fn add_attendee<E: GovernanceEventEmitter + Clone + 'static>(
     meeting_id: web::Path<String>,
     req: web::Json<AddAttendeeRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
     let id = MeetingId(meeting_id.into_inner());
     let role = parse_meeting_role(&req.meeting_role)?;
 
@@ -3043,6 +3051,23 @@ pub async fn add_attendee<E: GovernanceEventEmitter + Clone + 'static>(
         .get_meeting(&id)
         .map_err(anyhow_to_api)?
         .ok_or_else(|| err_not_found("Meeting not found"))?;
+
+    if matches!(
+        m.status,
+        MeetingStatus::Completed | MeetingStatus::Cancelled
+    ) {
+        return Ok(HttpResponse::UnprocessableEntity()
+            .json(serde_json::json!({"error": "Cannot modify a completed or cancelled meeting"})));
+    }
+
+    if let Some(ref checker) = ctx.member_checker {
+        let caller_did = parse_did(&claims.sub, "Invalid DID in token")?;
+        if !checker(caller_did, m.domain_id.clone()).await {
+            return Ok(
+                HttpResponse::Forbidden().json(serde_json::json!({"error": "Not a domain member"}))
+            );
+        }
+    }
 
     // Upsert: update existing entry or append
     if let Some(existing) = m.attendees.iter_mut().find(|a| a.did == req.did) {
@@ -3076,6 +3101,14 @@ pub async fn mark_attendance<E: GovernanceEventEmitter + Clone + 'static>(
         .map_err(anyhow_to_api)?
         .ok_or_else(|| err_not_found("Meeting not found"))?;
 
+    if matches!(
+        m.status,
+        MeetingStatus::Completed | MeetingStatus::Cancelled
+    ) {
+        return Ok(HttpResponse::UnprocessableEntity()
+            .json(serde_json::json!({"error": "Cannot modify a completed or cancelled meeting"})));
+    }
+
     let attendee = m
         .attendees
         .iter_mut()
@@ -3102,6 +3135,14 @@ pub async fn add_agenda_item<E: GovernanceEventEmitter + Clone + 'static>(
         .get_meeting(&id)
         .map_err(anyhow_to_api)?
         .ok_or_else(|| err_not_found("Meeting not found"))?;
+
+    if matches!(
+        m.status,
+        MeetingStatus::Completed | MeetingStatus::Cancelled
+    ) {
+        return Ok(HttpResponse::UnprocessableEntity()
+            .json(serde_json::json!({"error": "Cannot modify a completed or cancelled meeting"})));
+    }
 
     let mut item = icn_governance::AgendaItem::new(req.title.clone());
     item.description = req.description.clone();
@@ -3133,6 +3174,14 @@ pub async fn update_agenda_item<E: GovernanceEventEmitter + Clone + 'static>(
         .get_meeting(&meeting_id)
         .map_err(anyhow_to_api)?
         .ok_or_else(|| err_not_found("Meeting not found"))?;
+
+    if matches!(
+        m.status,
+        MeetingStatus::Completed | MeetingStatus::Cancelled
+    ) {
+        return Ok(HttpResponse::UnprocessableEntity()
+            .json(serde_json::json!({"error": "Cannot modify a completed or cancelled meeting"})));
+    }
 
     let item = m
         .get_agenda_item_mut(&item_id)

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -8,10 +8,11 @@ use actix_web::{web, HttpRequest, HttpResponse};
 use icn_federation::SettlementInterval;
 use icn_governance::{
     ActionItemFilter, ActionItemId, ActionItemPriority, ActionItemStatus, ActivityId, ActivityKind,
-    ActivityStatus, DataSharingLevel, Delegation, DelegationId, DelegationScope,
+    ActivityStatus, AttendanceStatus, DataSharingLevel, Delegation, DelegationId, DelegationScope,
     DisputeResolutionMethod, FederationProposal, FederationTerms, GovernanceDomainId,
-    GovernanceParams, MembershipAction, MembershipConfig, ProposalId, ProposalPayload,
-    ProposalScope, StructureId, StructureKind, StructureStatus, VoteChoice,
+    GovernanceParams, MeetingId, MeetingRole, MeetingStatus, MembershipAction, MembershipConfig,
+    ProposalId, ProposalPayload, ProposalScope, StructureId, StructureKind, StructureStatus,
+    VoteChoice,
 };
 use icn_http_kit::{
     auth::{require_scope, BasicClaims},
@@ -2810,6 +2811,342 @@ pub async fn get_activity<E: GovernanceEventEmitter + Clone + 'static>(
         .ok_or_else(|| err_not_found("Activity not found"))?;
 
     Ok(HttpResponse::Ok().json(activity_to_response(&a)))
+}
+
+// ── Meeting helpers ──────────────────────────────────────────────────────────
+
+fn attendance_status_str(s: &AttendanceStatus) -> &'static str {
+    match s {
+        AttendanceStatus::Invited => "invited",
+        AttendanceStatus::Present => "present",
+        AttendanceStatus::Absent => "absent",
+        AttendanceStatus::Remote => "remote",
+    }
+}
+
+fn meeting_role_str(r: &MeetingRole) -> &'static str {
+    match r {
+        MeetingRole::Facilitator => "facilitator",
+        MeetingRole::NoteTaker => "note_taker",
+        MeetingRole::Participant => "participant",
+        MeetingRole::Observer => "observer",
+    }
+}
+
+fn parse_attendance_status(s: &str) -> Result<AttendanceStatus, ApiError> {
+    match s {
+        "invited" => Ok(AttendanceStatus::Invited),
+        "present" => Ok(AttendanceStatus::Present),
+        "absent" => Ok(AttendanceStatus::Absent),
+        "remote" => Ok(AttendanceStatus::Remote),
+        _ => Err(err_bad(format!("Unknown attendance status: {s}"))),
+    }
+}
+
+fn parse_meeting_role(s: &str) -> Result<MeetingRole, ApiError> {
+    match s {
+        "facilitator" => Ok(MeetingRole::Facilitator),
+        "note_taker" | "notetaker" => Ok(MeetingRole::NoteTaker),
+        "participant" => Ok(MeetingRole::Participant),
+        "observer" => Ok(MeetingRole::Observer),
+        _ => Err(err_bad(format!("Unknown meeting role: {s}"))),
+    }
+}
+
+fn meeting_to_response(m: &icn_governance::Meeting) -> MeetingResponse {
+    MeetingResponse {
+        id: m.id.0.clone(),
+        domain_id: m.domain_id.clone(),
+        title: m.title.clone(),
+        description: m.description.clone(),
+        status: match m.status {
+            MeetingStatus::Scheduled => "scheduled",
+            MeetingStatus::InProgress => "in_progress",
+            MeetingStatus::Completed => "completed",
+            MeetingStatus::Cancelled => "cancelled",
+        }
+        .to_string(),
+        scheduled_at: m.scheduled_at,
+        started_at: m.started_at,
+        ended_at: m.ended_at,
+        attendees: m
+            .attendees
+            .iter()
+            .map(|a| MeetingAttendeeResponse {
+                did: a.did.clone(),
+                status: attendance_status_str(&a.status).to_string(),
+                meeting_role: meeting_role_str(&a.meeting_role).to_string(),
+            })
+            .collect(),
+        agenda: m
+            .agenda
+            .iter()
+            .map(|item| AgendaItemResponse {
+                id: item.id.to_string(),
+                title: item.title.clone(),
+                description: item.description.clone(),
+                presenter: item.presenter.clone(),
+                linked_proposal: item.linked_proposal.as_ref().map(|p| p.0.clone()),
+                discussion_notes: item.discussion_notes.clone(),
+                outcome: item.outcome.clone(),
+                generated_action_items: item
+                    .generated_action_items
+                    .iter()
+                    .map(|id| id.to_string())
+                    .collect(),
+            })
+            .collect(),
+        linked_structures: m.linked_structures.iter().map(|s| s.0.clone()).collect(),
+        linked_activities: m.linked_activities.iter().map(|a| a.0.clone()).collect(),
+        notes_doc_id: m.notes_doc_id.clone(),
+        created_by: m.created_by.clone(),
+        created_at: m.created_at,
+        present_count: m.present_count(),
+    }
+}
+
+// ── Meeting endpoints ────────────────────────────────────────────────────────
+
+/// POST /gov/domains/{domain_id}/meetings — Create a meeting.
+pub async fn create_meeting<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    domain_id: web::Path<String>,
+    req: web::Json<CreateMeetingRequest>,
+) -> Result<HttpResponse, ApiError> {
+    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let domain = GovernanceDomainId(domain_id.into_inner());
+
+    check_domain_membership(&ctx.manager, &domain, &parse_did(&claims.sub, "Invalid DID in token")?).await?;
+
+    let m = ctx
+        .manager
+        .create_meeting(
+            domain.0,
+            req.title.clone(),
+            req.description.clone(),
+            req.scheduled_at,
+            claims.sub.clone(),
+        )
+        .map_err(anyhow_to_api)?;
+
+    Ok(HttpResponse::Created().json(meeting_to_response(&m)))
+}
+
+/// GET /gov/domains/{domain_id}/meetings — List meetings in a domain.
+pub async fn list_meetings<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    domain_id: web::Path<String>,
+) -> Result<HttpResponse, ApiError> {
+    require_scope::<BasicClaims>(&http_req, "governance:read")?;
+    let domain = domain_id.into_inner();
+
+    let meetings = ctx.manager.list_meetings(&domain).map_err(anyhow_to_api)?;
+    let responses: Vec<MeetingResponse> = meetings.iter().map(meeting_to_response).collect();
+    Ok(HttpResponse::Ok().json(responses))
+}
+
+/// GET /gov/meetings/{meeting_id} — Get a specific meeting.
+pub async fn get_meeting<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    meeting_id: web::Path<String>,
+) -> Result<HttpResponse, ApiError> {
+    require_scope::<BasicClaims>(&http_req, "governance:read")?;
+    let id = MeetingId(meeting_id.into_inner());
+
+    let m = ctx
+        .manager
+        .get_meeting(&id)
+        .map_err(anyhow_to_api)?
+        .ok_or_else(|| err_not_found("Meeting not found"))?;
+
+    Ok(HttpResponse::Ok().json(meeting_to_response(&m)))
+}
+
+/// POST /gov/meetings/{meeting_id}/start — Transition meeting to InProgress.
+pub async fn start_meeting<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    meeting_id: web::Path<String>,
+) -> Result<HttpResponse, ApiError> {
+    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let id = MeetingId(meeting_id.into_inner());
+
+    let mut m = ctx
+        .manager
+        .get_meeting(&id)
+        .map_err(anyhow_to_api)?
+        .ok_or_else(|| err_not_found("Meeting not found"))?;
+
+    if m.created_by != claims.sub {
+        return Err(ApiError::Forbidden(
+            "Only the meeting creator can start it".into(),
+        ));
+    }
+    if !matches!(m.status, MeetingStatus::Scheduled) {
+        return Err(err_bad("Meeting is not in Scheduled status"));
+    }
+
+    m.status = MeetingStatus::InProgress;
+    m.started_at = Some(current_time_secs());
+    ctx.manager.update_meeting(&m).map_err(anyhow_to_api)?;
+
+    Ok(HttpResponse::Ok().json(meeting_to_response(&m)))
+}
+
+/// POST /gov/meetings/{meeting_id}/end — Transition meeting to Completed.
+pub async fn end_meeting<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    meeting_id: web::Path<String>,
+) -> Result<HttpResponse, ApiError> {
+    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let id = MeetingId(meeting_id.into_inner());
+
+    let mut m = ctx
+        .manager
+        .get_meeting(&id)
+        .map_err(anyhow_to_api)?
+        .ok_or_else(|| err_not_found("Meeting not found"))?;
+
+    if m.created_by != claims.sub {
+        return Err(ApiError::Forbidden(
+            "Only the meeting creator can end it".into(),
+        ));
+    }
+    if !matches!(m.status, MeetingStatus::InProgress) {
+        return Err(err_bad("Meeting is not InProgress"));
+    }
+
+    m.status = MeetingStatus::Completed;
+    m.ended_at = Some(current_time_secs());
+    ctx.manager.update_meeting(&m).map_err(anyhow_to_api)?;
+
+    Ok(HttpResponse::Ok().json(meeting_to_response(&m)))
+}
+
+/// POST /gov/meetings/{meeting_id}/attendees — Add or update an attendee.
+pub async fn add_attendee<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    meeting_id: web::Path<String>,
+    req: web::Json<AddAttendeeRequest>,
+) -> Result<HttpResponse, ApiError> {
+    require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let id = MeetingId(meeting_id.into_inner());
+    let role = parse_meeting_role(&req.meeting_role)?;
+
+    let mut m = ctx
+        .manager
+        .get_meeting(&id)
+        .map_err(anyhow_to_api)?
+        .ok_or_else(|| err_not_found("Meeting not found"))?;
+
+    // Upsert: update existing entry or append
+    if let Some(existing) = m.attendees.iter_mut().find(|a| a.did == req.did) {
+        existing.meeting_role = role;
+    } else {
+        m.attendees.push(icn_governance::MeetingAttendee {
+            did: req.did.clone(),
+            status: icn_governance::AttendanceStatus::Invited,
+            meeting_role: role,
+        });
+    }
+
+    ctx.manager.update_meeting(&m).map_err(anyhow_to_api)?;
+    Ok(HttpResponse::Ok().json(meeting_to_response(&m)))
+}
+
+/// PUT /gov/meetings/{meeting_id}/attendance — Mark attendance for a participant.
+pub async fn mark_attendance<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    meeting_id: web::Path<String>,
+    req: web::Json<MarkAttendanceRequest>,
+) -> Result<HttpResponse, ApiError> {
+    require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let id = MeetingId(meeting_id.into_inner());
+    let status = parse_attendance_status(&req.status)?;
+
+    let mut m = ctx
+        .manager
+        .get_meeting(&id)
+        .map_err(anyhow_to_api)?
+        .ok_or_else(|| err_not_found("Meeting not found"))?;
+
+    let attendee = m
+        .attendees
+        .iter_mut()
+        .find(|a| a.did == req.did)
+        .ok_or_else(|| err_not_found("Attendee not found in this meeting"))?;
+
+    attendee.status = status;
+    ctx.manager.update_meeting(&m).map_err(anyhow_to_api)?;
+    Ok(HttpResponse::Ok().json(meeting_to_response(&m)))
+}
+
+/// POST /gov/meetings/{meeting_id}/agenda — Add an agenda item.
+pub async fn add_agenda_item<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    meeting_id: web::Path<String>,
+    req: web::Json<AddAgendaItemRequest>,
+) -> Result<HttpResponse, ApiError> {
+    require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let id = MeetingId(meeting_id.into_inner());
+
+    let mut m = ctx
+        .manager
+        .get_meeting(&id)
+        .map_err(anyhow_to_api)?
+        .ok_or_else(|| err_not_found("Meeting not found"))?;
+
+    let mut item = icn_governance::AgendaItem::new(req.title.clone());
+    item.description = req.description.clone();
+    item.presenter = req.presenter.clone();
+    item.linked_proposal = req.linked_proposal.as_ref().map(|p| ProposalId(p.clone()));
+    m.agenda.push(item);
+
+    ctx.manager.update_meeting(&m).map_err(anyhow_to_api)?;
+    Ok(HttpResponse::Ok().json(meeting_to_response(&m)))
+}
+
+/// PUT /gov/meetings/{meeting_id}/agenda/{item_id} — Update an agenda item outcome.
+pub async fn update_agenda_item<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    path: web::Path<(String, String)>,
+    req: web::Json<UpdateAgendaItemRequest>,
+) -> Result<HttpResponse, ApiError> {
+    require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let (meeting_id_str, item_id_str) = path.into_inner();
+    let meeting_id = MeetingId(meeting_id_str);
+    let item_uuid = item_id_str
+        .parse::<uuid::Uuid>()
+        .map_err(|e| err_bad(format!("Invalid agenda item ID: {e}")))?;
+    let item_id = icn_governance::AgendaItemId(item_uuid);
+
+    let mut m = ctx
+        .manager
+        .get_meeting(&meeting_id)
+        .map_err(anyhow_to_api)?
+        .ok_or_else(|| err_not_found("Meeting not found"))?;
+
+    let item = m
+        .get_agenda_item_mut(&item_id)
+        .ok_or_else(|| err_not_found("Agenda item not found"))?;
+
+    if let Some(ref notes) = req.discussion_notes {
+        item.discussion_notes = Some(notes.clone());
+    }
+    if let Some(ref outcome) = req.outcome {
+        item.outcome = Some(outcome.clone());
+    }
+
+    ctx.manager.update_meeting(&m).map_err(anyhow_to_api)?;
+    Ok(HttpResponse::Ok().json(meeting_to_response(&m)))
 }
 
 // ============================================================================

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -2935,7 +2935,9 @@ pub async fn create_meeting<E: GovernanceEventEmitter + Clone + 'static>(
         )
         .map_err(anyhow_to_api)?;
 
-    // TODO: emit MeetingCreated event when GovernanceEventEmitter gains meeting methods
+    // MeetingCreated event emission is deferred to the notification-digest PR,
+    // where GovernanceEventEmitter will gain meeting methods and the variant
+    // will ship under the canonical Governance<Thing><Verb> naming convention.
     Ok(HttpResponse::Created().json(meeting_to_response(&m)))
 }
 
@@ -2972,6 +2974,15 @@ pub async fn get_meeting<E: GovernanceEventEmitter + Clone + 'static>(
 }
 
 /// POST /gov/meetings/{meeting_id}/start — Transition meeting to InProgress.
+///
+/// Authorization (Phase 3 scope):
+/// - Caller must hold the `governance:write` scope.
+/// - Caller must be a member of the meeting's governance domain.
+/// - Caller must be the `created_by` DID of the meeting.
+///
+/// Longer-term (Tranche 6, operational role delegation): authorization will
+/// derive from `RoleAssignment.authority_scope` capability strings plus a
+/// PolicyOracle rule — e.g., holders of `meeting-admin` on the linked structure.
 pub async fn start_meeting<E: GovernanceEventEmitter + Clone + 'static>(
     ctx: web::Data<GovernanceContext<E>>,
     http_req: HttpRequest,
@@ -2986,6 +2997,13 @@ pub async fn start_meeting<E: GovernanceEventEmitter + Clone + 'static>(
         .map_err(anyhow_to_api)?
         .ok_or_else(|| err_not_found("Meeting not found"))?;
 
+    check_domain_membership(
+        &ctx.manager,
+        &GovernanceDomainId(m.domain_id.clone()),
+        &parse_did(&claims.sub, "Invalid DID in token")?,
+    )
+    .await?;
+
     if m.created_by != claims.sub {
         return Err(ApiError::Forbidden(
             "Only the meeting creator can start it".into(),
@@ -2999,11 +3017,20 @@ pub async fn start_meeting<E: GovernanceEventEmitter + Clone + 'static>(
     m.started_at = Some(current_time_secs());
     ctx.manager.update_meeting(&m).map_err(anyhow_to_api)?;
 
-    // TODO: emit MeetingStarted event when GovernanceEventEmitter gains meeting methods
+    // Event emission deferred to the notification-digest PR (see create_meeting).
     Ok(HttpResponse::Ok().json(meeting_to_response(&m)))
 }
 
 /// POST /gov/meetings/{meeting_id}/end — Transition meeting to Completed.
+///
+/// Authorization: same as `start_meeting` (see docs there). Creator-only plus
+/// domain membership is the Phase 3 policy; richer role-based authorization
+/// lands with Tranche 6.
+///
+/// Note: this handler does not yet materialize action items from unresolved
+/// agenda items. `AgendaItem.generated_action_items` is supported in the
+/// schema but the closure trigger is a Tranche 1 follow-up — for now, action
+/// items are created separately via the action-item API with `meeting_id` set.
 pub async fn end_meeting<E: GovernanceEventEmitter + Clone + 'static>(
     ctx: web::Data<GovernanceContext<E>>,
     http_req: HttpRequest,
@@ -3018,6 +3045,13 @@ pub async fn end_meeting<E: GovernanceEventEmitter + Clone + 'static>(
         .map_err(anyhow_to_api)?
         .ok_or_else(|| err_not_found("Meeting not found"))?;
 
+    check_domain_membership(
+        &ctx.manager,
+        &GovernanceDomainId(m.domain_id.clone()),
+        &parse_did(&claims.sub, "Invalid DID in token")?,
+    )
+    .await?;
+
     if m.created_by != claims.sub {
         return Err(ApiError::Forbidden(
             "Only the meeting creator can end it".into(),
@@ -3031,7 +3065,7 @@ pub async fn end_meeting<E: GovernanceEventEmitter + Clone + 'static>(
     m.ended_at = Some(current_time_secs());
     ctx.manager.update_meeting(&m).map_err(anyhow_to_api)?;
 
-    // TODO: emit MeetingEnded event when GovernanceEventEmitter gains meeting methods
+    // Event emission deferred to the notification-digest PR (see create_meeting).
     Ok(HttpResponse::Ok().json(meeting_to_response(&m)))
 }
 
@@ -3091,7 +3125,7 @@ pub async fn mark_attendance<E: GovernanceEventEmitter + Clone + 'static>(
     meeting_id: web::Path<String>,
     req: web::Json<MarkAttendanceRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
     let id = MeetingId(meeting_id.into_inner());
     let status = parse_attendance_status(&req.status)?;
 
@@ -3100,6 +3134,15 @@ pub async fn mark_attendance<E: GovernanceEventEmitter + Clone + 'static>(
         .get_meeting(&id)
         .map_err(anyhow_to_api)?
         .ok_or_else(|| err_not_found("Meeting not found"))?;
+
+    // Domain-membership check: only members of the meeting's governance domain
+    // may mutate its state. `governance:write` alone is insufficient.
+    check_domain_membership(
+        &ctx.manager,
+        &GovernanceDomainId(m.domain_id.clone()),
+        &parse_did(&claims.sub, "Invalid DID in token")?,
+    )
+    .await?;
 
     if matches!(
         m.status,
@@ -3127,7 +3170,7 @@ pub async fn add_agenda_item<E: GovernanceEventEmitter + Clone + 'static>(
     meeting_id: web::Path<String>,
     req: web::Json<AddAgendaItemRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
     let id = MeetingId(meeting_id.into_inner());
 
     let mut m = ctx
@@ -3135,6 +3178,13 @@ pub async fn add_agenda_item<E: GovernanceEventEmitter + Clone + 'static>(
         .get_meeting(&id)
         .map_err(anyhow_to_api)?
         .ok_or_else(|| err_not_found("Meeting not found"))?;
+
+    check_domain_membership(
+        &ctx.manager,
+        &GovernanceDomainId(m.domain_id.clone()),
+        &parse_did(&claims.sub, "Invalid DID in token")?,
+    )
+    .await?;
 
     if matches!(
         m.status,
@@ -3161,7 +3211,7 @@ pub async fn update_agenda_item<E: GovernanceEventEmitter + Clone + 'static>(
     path: web::Path<(String, String)>,
     req: web::Json<UpdateAgendaItemRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
     let (meeting_id_str, item_id_str) = path.into_inner();
     let meeting_id = MeetingId(meeting_id_str);
     let item_uuid = item_id_str
@@ -3174,6 +3224,13 @@ pub async fn update_agenda_item<E: GovernanceEventEmitter + Clone + 'static>(
         .get_meeting(&meeting_id)
         .map_err(anyhow_to_api)?
         .ok_or_else(|| err_not_found("Meeting not found"))?;
+
+    check_domain_membership(
+        &ctx.manager,
+        &GovernanceDomainId(m.domain_id.clone()),
+        &parse_did(&claims.sub, "Invalid DID in token")?,
+    )
+    .await?;
 
     if matches!(
         m.status,

--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -626,3 +626,114 @@ pub struct ActivityResponse {
     pub linked_structures: Vec<String>,
     pub created_at: u64,
 }
+
+// ============================================================================
+// Meeting (deliberation trace objects)
+// ============================================================================
+
+/// Request to create a meeting
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct CreateMeetingRequest {
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Scheduled start time as Unix timestamp
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheduled_at: Option<u64>,
+}
+
+/// Request to add an attendee to a meeting
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AddAttendeeRequest {
+    pub did: String,
+    /// Coordination role: "facilitator", "note_taker", "participant", "observer"
+    #[serde(default = "default_meeting_role")]
+    pub meeting_role: String,
+}
+
+fn default_meeting_role() -> String {
+    "participant".to_string()
+}
+
+/// Request to mark attendance for a participant
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct MarkAttendanceRequest {
+    pub did: String,
+    /// Status: "present", "absent", "remote"
+    pub status: String,
+}
+
+/// Request to add an agenda item
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AddAgendaItemRequest {
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub presenter: Option<String>,
+    /// Proposal ID to discuss during this agenda item
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub linked_proposal: Option<String>,
+}
+
+/// Request to update an agenda item outcome
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct UpdateAgendaItemRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discussion_notes: Option<String>,
+    /// Outcome: "resolved", "tabled", "referred", "no_action"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<String>,
+}
+
+/// Attendee in a meeting response
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct MeetingAttendeeResponse {
+    pub did: String,
+    pub status: String,
+    pub meeting_role: String,
+}
+
+/// Agenda item in a meeting response
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AgendaItemResponse {
+    pub id: String,
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub presenter: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub linked_proposal: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discussion_notes: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<String>,
+    pub generated_action_items: Vec<String>,
+}
+
+/// Meeting response
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct MeetingResponse {
+    pub id: String,
+    pub domain_id: String,
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheduled_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ended_at: Option<u64>,
+    pub attendees: Vec<MeetingAttendeeResponse>,
+    pub agenda: Vec<AgendaItemResponse>,
+    pub linked_structures: Vec<String>,
+    pub linked_activities: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notes_doc_id: Option<String>,
+    pub created_by: String,
+    pub created_at: u64,
+    pub present_count: usize,
+}

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -39,7 +39,9 @@ pub use actor::{GovernanceActor, GovernanceCommand, GovernanceConfigLite, Govern
 pub use events::{GovernanceEventEmitter, NoopEventEmitter};
 pub use executor::{ExecutionCallback, GovernanceProposalExecutor};
 pub use handlers::translate_payload_to_effects;
-pub use manager::{GovernanceManager, SledActionItemStore, SledActivityStore, SledStructureStore};
+pub use manager::{
+    GovernanceManager, SledActionItemStore, SledActivityStore, SledMeetingStore, SledStructureStore,
+};
 pub use receipt_backend::GovernanceReceiptBackend;
 pub use state_store::{GovernanceStateStore, SledGovernanceStateStore};
 

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -597,10 +597,15 @@ impl icn_governance::ActivityStoreBackend for SledActivityStore {
 
 /// Sled-backed storage for meetings.
 ///
-/// Key scheme:
-/// - Meeting:  `meeting:{domain_id}:{meeting_id}`
+/// Key scheme (dual-key):
+/// - Primary:       `meeting:{meeting_id}`                     → postcard-encoded Meeting
+/// - Domain index:  `meeting_by_domain:{domain_id}:{meeting_id}` → empty (membership marker)
 ///
-/// All-meeting scan prefix: `meeting:` (for get-by-id when domain is unknown).
+/// This matches the `<thing>_by_<scope>:...` secondary-index convention used by
+/// `SledStructureStore` and `SledActivityStore`. Lookups by meeting ID are O(1)
+/// via the primary key; lookups by domain scan the index prefix. The scheme is
+/// unambiguous under domain IDs containing `:` because the meeting ID lives in
+/// its own primary key namespace, not embedded as a suffix of the domain key.
 pub struct SledMeetingStore {
     db: Arc<sled::Db>,
 }
@@ -611,56 +616,91 @@ impl SledMeetingStore {
         Self { db }
     }
 
-    fn meeting_key(domain_id: &str, id: &MeetingId) -> String {
-        format!("meeting:{}:{}", domain_id, id.0)
+    fn meeting_key(id: &MeetingId) -> String {
+        format!("meeting:{}", id.0)
     }
 
-    fn domain_prefix(domain_id: &str) -> String {
-        format!("meeting:{}:", domain_id)
+    fn index_key(domain_id: &str, id: &MeetingId) -> String {
+        format!("meeting_by_domain:{}:{}", domain_id, id.0)
     }
 
-    fn all_prefix() -> &'static str {
-        "meeting:"
+    fn domain_index_prefix(domain_id: &str) -> String {
+        format!("meeting_by_domain:{}:", domain_id)
     }
 }
 
 impl MeetingStoreBackend for SledMeetingStore {
     fn save(&self, m: &Meeting) -> std::result::Result<(), GovernanceError> {
-        let key = Self::meeting_key(&m.domain_id, &m.id);
+        let primary_key = Self::meeting_key(&m.id);
+        let index_key = Self::index_key(&m.domain_id, &m.id);
         let value = icn_encoding::encode_versioned(m)
             .map_err(|e| GovernanceError::Internal(format!("Failed to encode meeting: {e}")))?;
+
+        // Best-effort atomic: write primary, then index. If either fails, the
+        // caller sees an error and can retry. sled::Batch would be stronger but
+        // is not used elsewhere in this store for this pattern.
         self.db
-            .insert(key.as_bytes(), value)
-            .map_err(|e| GovernanceError::Internal(format!("Sled insert failed: {e}")))?;
+            .insert(primary_key.as_bytes(), value)
+            .map_err(|e| GovernanceError::Internal(format!("Sled insert (primary) failed: {e}")))?;
+        self.db
+            .insert(index_key.as_bytes(), &[] as &[u8])
+            .map_err(|e| GovernanceError::Internal(format!("Sled insert (index) failed: {e}")))?;
         Ok(())
     }
 
     fn get(&self, id: &MeetingId) -> std::result::Result<Option<Meeting>, GovernanceError> {
-        let suffix = format!(":{}", id.0);
-        for result in self.db.scan_prefix(Self::all_prefix().as_bytes()) {
-            let (key, value) =
-                result.map_err(|e| GovernanceError::Internal(format!("Sled scan failed: {e}")))?;
-            let key_str = std::str::from_utf8(&key)
-                .map_err(|e| GovernanceError::Internal(format!("Invalid UTF-8 key: {e}")))?;
-            if key_str.ends_with(&suffix) {
+        let key = Self::meeting_key(id);
+        match self
+            .db
+            .get(key.as_bytes())
+            .map_err(|e| GovernanceError::Internal(format!("Sled get failed: {e}")))?
+        {
+            Some(value) => {
                 let m: Meeting = icn_encoding::decode_versioned(&value).map_err(|e| {
                     GovernanceError::Internal(format!("Failed to decode meeting: {e}"))
                 })?;
-                return Ok(Some(m));
+                Ok(Some(m))
             }
+            None => Ok(None),
         }
-        Ok(None)
     }
 
     fn list_by_domain(
         &self,
         domain_id: &str,
     ) -> std::result::Result<Vec<Meeting>, GovernanceError> {
-        let prefix = Self::domain_prefix(domain_id);
+        let prefix = Self::domain_index_prefix(domain_id);
+        // The exact prefix the key's "domain portion" must match — i.e., the
+        // prefix minus its trailing ':'. This is necessary because sled's
+        // `scan_prefix` matches any byte-prefix, so `meeting_by_domain:coop:`
+        // also matches `meeting_by_domain:coop:nycn:{id}` (a different domain).
+        // We must reject index rows whose domain is not exactly `domain_id`.
+        let expected_domain_prefix = format!("meeting_by_domain:{}", domain_id);
         let mut out = Vec::new();
         for result in self.db.scan_prefix(prefix.as_bytes()) {
-            let (_, value) =
+            let (key, _) =
                 result.map_err(|e| GovernanceError::Internal(format!("Sled scan failed: {e}")))?;
+            let key_str = std::str::from_utf8(&key)
+                .map_err(|e| GovernanceError::Internal(format!("Invalid UTF-8 key: {e}")))?;
+            // Split at the last ':' to recover (domain-portion, meeting-id).
+            let Some((domain_portion, meeting_id_str)) = key_str.rsplit_once(':') else {
+                continue;
+            };
+            // Reject keys whose domain portion doesn't exactly match. This
+            // filters out keys from domains whose name happens to start with
+            // `{domain_id}` (e.g., scanning `coop:` must not pick up `coop:nycn`).
+            if domain_portion != expected_domain_prefix {
+                continue;
+            }
+            let primary_key = format!("meeting:{}", meeting_id_str);
+            let Some(value) = self
+                .db
+                .get(primary_key.as_bytes())
+                .map_err(|e| GovernanceError::Internal(format!("Sled get failed: {e}")))?
+            else {
+                // Index entry without primary — treat as dangling and skip.
+                continue;
+            };
             let m: Meeting = icn_encoding::decode_versioned(&value)
                 .map_err(|e| GovernanceError::Internal(format!("Failed to decode meeting: {e}")))?;
             out.push(m);
@@ -670,26 +710,171 @@ impl MeetingStoreBackend for SledMeetingStore {
     }
 
     fn delete(&self, id: &MeetingId) -> std::result::Result<bool, GovernanceError> {
-        let suffix = format!(":{}", id.0);
-        let mut found_key: Option<sled::IVec> = None;
-        for result in self.db.scan_prefix(Self::all_prefix().as_bytes()) {
-            let (key, _) =
-                result.map_err(|e| GovernanceError::Internal(format!("Sled scan failed: {e}")))?;
-            let key_str = std::str::from_utf8(&key)
-                .map_err(|e| GovernanceError::Internal(format!("Invalid UTF-8 key: {e}")))?;
-            if key_str.ends_with(&suffix) {
-                found_key = Some(key);
-                break;
-            }
-        }
-        match found_key {
-            Some(k) => self
-                .db
-                .remove(k)
-                .map(|opt| opt.is_some())
-                .map_err(|e| GovernanceError::Internal(format!("Sled delete failed: {e}"))),
-            None => Ok(false),
-        }
+        // Load the meeting to discover its domain_id so we can clean up the index.
+        let primary_key = Self::meeting_key(id);
+        let Some(value) = self
+            .db
+            .get(primary_key.as_bytes())
+            .map_err(|e| GovernanceError::Internal(format!("Sled get failed: {e}")))?
+        else {
+            return Ok(false);
+        };
+        let m: Meeting = icn_encoding::decode_versioned(&value)
+            .map_err(|e| GovernanceError::Internal(format!("Failed to decode meeting: {e}")))?;
+        let index_key = Self::index_key(&m.domain_id, id);
+
+        self.db
+            .remove(primary_key.as_bytes())
+            .map_err(|e| GovernanceError::Internal(format!("Sled delete (primary) failed: {e}")))?;
+        self.db
+            .remove(index_key.as_bytes())
+            .map_err(|e| GovernanceError::Internal(format!("Sled delete (index) failed: {e}")))?;
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod sled_meeting_store_tests {
+    use super::*;
+    use icn_governance::{Meeting, MeetingId};
+
+    fn open_temp_db() -> (Arc<sled::Db>, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = sled::Config::new()
+            .path(dir.path())
+            .temporary(true)
+            .open()
+            .expect("sled open");
+        (Arc::new(db), dir)
+    }
+
+    fn mk_meeting(domain: &str, title: &str) -> Meeting {
+        Meeting::new(
+            MeetingId::generate(),
+            domain.to_string(),
+            title.to_string(),
+            "did:icn:creator".to_string(),
+            1_700_000_000,
+        )
+    }
+
+    #[test]
+    fn save_and_get_roundtrip() {
+        let (db, _dir) = open_temp_db();
+        let store = SledMeetingStore::new(db);
+        let m = mk_meeting("dom-a", "Kickoff");
+        store.save(&m).unwrap();
+
+        let got = store.get(&m.id).unwrap().expect("meeting present");
+        assert_eq!(got.id, m.id);
+        assert_eq!(got.domain_id, "dom-a");
+        assert_eq!(got.title, "Kickoff");
+    }
+
+    #[test]
+    fn get_is_o1_and_does_not_scan() {
+        // Regression guard: the previous implementation full-scanned `meeting:`
+        // and could return the wrong meeting if two domains carried the same
+        // MeetingId. Primary keys are now meeting-id-only, so collisions are
+        // impossible within a single store.
+        let (db, _dir) = open_temp_db();
+        let store = SledMeetingStore::new(db);
+        let m1 = mk_meeting("dom-a", "alpha");
+        let m2 = mk_meeting("dom-b", "beta");
+        store.save(&m1).unwrap();
+        store.save(&m2).unwrap();
+
+        let got1 = store.get(&m1.id).unwrap().unwrap();
+        let got2 = store.get(&m2.id).unwrap().unwrap();
+        assert_eq!(got1.title, "alpha");
+        assert_eq!(got2.title, "beta");
+    }
+
+    #[test]
+    fn list_by_domain_isolates_domains() {
+        let (db, _dir) = open_temp_db();
+        let store = SledMeetingStore::new(db);
+        let m_a1 = mk_meeting("dom-a", "a1");
+        let m_a2 = mk_meeting("dom-a", "a2");
+        let m_b1 = mk_meeting("dom-b", "b1");
+        store.save(&m_a1).unwrap();
+        store.save(&m_a2).unwrap();
+        store.save(&m_b1).unwrap();
+
+        let a = store.list_by_domain("dom-a").unwrap();
+        let b = store.list_by_domain("dom-b").unwrap();
+        assert_eq!(a.len(), 2);
+        assert_eq!(b.len(), 1);
+        assert!(a.iter().all(|m| m.domain_id == "dom-a"));
+        assert!(b.iter().all(|m| m.domain_id == "dom-b"));
+    }
+
+    #[test]
+    fn domain_ids_with_colons_do_not_leak_across_domains() {
+        // Critical regression test: the previous `meeting:{domain}:{id}` scheme
+        // could confuse `meeting:foo:bar:baz` (domain `foo` / id `bar:baz` vs.
+        // domain `foo:bar` / id `baz`). The dual-key scheme is immune because
+        // domain IDs live only in the index prefix and meeting IDs live only in
+        // the primary key.
+        let (db, _dir) = open_temp_db();
+        let store = SledMeetingStore::new(db);
+        let m_colon = mk_meeting("coop:nycn", "colon-domain");
+        let m_plain = mk_meeting("coop", "plain-domain");
+        store.save(&m_colon).unwrap();
+        store.save(&m_plain).unwrap();
+
+        let colon_listing = store.list_by_domain("coop:nycn").unwrap();
+        let plain_listing = store.list_by_domain("coop").unwrap();
+        assert_eq!(colon_listing.len(), 1);
+        assert_eq!(plain_listing.len(), 1);
+        assert_eq!(colon_listing[0].title, "colon-domain");
+        assert_eq!(plain_listing[0].title, "plain-domain");
+    }
+
+    #[test]
+    fn delete_removes_primary_and_index() {
+        let (db, _dir) = open_temp_db();
+        let store = SledMeetingStore::new(db.clone());
+        let m = mk_meeting("dom-a", "to-delete");
+        store.save(&m).unwrap();
+
+        let removed = store.delete(&m.id).unwrap();
+        assert!(removed);
+
+        assert!(store.get(&m.id).unwrap().is_none());
+        assert!(store.list_by_domain("dom-a").unwrap().is_empty());
+
+        // Verify both keys physically removed (no dangling index).
+        let primary = format!("meeting:{}", m.id.0);
+        let index = format!("meeting_by_domain:dom-a:{}", m.id.0);
+        assert!(db.get(primary.as_bytes()).unwrap().is_none());
+        assert!(db.get(index.as_bytes()).unwrap().is_none());
+    }
+
+    #[test]
+    fn delete_missing_returns_false() {
+        let (db, _dir) = open_temp_db();
+        let store = SledMeetingStore::new(db);
+        let missing = MeetingId::from_raw("nope");
+        let removed = store.delete(&missing).unwrap();
+        assert!(!removed);
+    }
+
+    #[test]
+    fn list_by_domain_sorted_newest_first() {
+        let (db, _dir) = open_temp_db();
+        let store = SledMeetingStore::new(db);
+        let mut m_old = mk_meeting("dom-a", "old");
+        m_old.created_at = 1_700_000_000;
+        let mut m_new = mk_meeting("dom-a", "new");
+        m_new.created_at = 1_700_000_999;
+        store.save(&m_old).unwrap();
+        store.save(&m_new).unwrap();
+
+        let listing = store.list_by_domain("dom-a").unwrap();
+        assert_eq!(listing[0].title, "new");
+        assert_eq!(listing[1].title, "old");
     }
 }
 

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -15,12 +15,12 @@ use icn_governance::{
     ActivityStoreBackend, Comment, CommentId, Delegation, DelegationId, DelegationScope,
     Discussion, DiscussionStore, GovernanceConfig, GovernanceDecisionReceipt, GovernanceDomain,
     GovernanceDomainId, GovernanceError, GovernanceOps, GovernanceParams, GovernanceProfileId,
-    InMemoryActionItemStore, InMemoryActivityStore, InMemoryDiscussionStore,
-    InMemoryMeetingStore, InMemoryStructureStore, Meeting, MeetingId, MeetingStoreBackend,
-    MembershipConfig, MembershipSource, PaginatedResult, ProofOutcome, Proposal,
-    ProposalDomainLookup, ProposalId, ProposalPayload, ProposalScope, ProposalState, RoleAssignment,
-    Structure, StructureId, StructureKind, StructureStoreBackend, Timestamp, Vote, VoteChoice,
-    VoteTally, DEFAULT_MAX_DELEGATION_DEPTH,
+    InMemoryActionItemStore, InMemoryActivityStore, InMemoryDiscussionStore, InMemoryMeetingStore,
+    InMemoryStructureStore, Meeting, MeetingId, MeetingStoreBackend, MembershipConfig,
+    MembershipSource, PaginatedResult, ProofOutcome, Proposal, ProposalDomainLookup, ProposalId,
+    ProposalPayload, ProposalScope, ProposalState, RoleAssignment, Structure, StructureId,
+    StructureKind, StructureStoreBackend, Timestamp, Vote, VoteChoice, VoteTally,
+    DEFAULT_MAX_DELEGATION_DEPTH,
 };
 use icn_identity::Did;
 use icn_kernel_api::{AllocationReceipt, ScopeLevel, SettlementIntent};
@@ -661,9 +661,8 @@ impl MeetingStoreBackend for SledMeetingStore {
         for result in self.db.scan_prefix(prefix.as_bytes()) {
             let (_, value) =
                 result.map_err(|e| GovernanceError::Internal(format!("Sled scan failed: {e}")))?;
-            let m: Meeting = icn_encoding::decode_versioned(&value).map_err(|e| {
-                GovernanceError::Internal(format!("Failed to decode meeting: {e}"))
-            })?;
+            let m: Meeting = icn_encoding::decode_versioned(&value)
+                .map_err(|e| GovernanceError::Internal(format!("Failed to decode meeting: {e}")))?;
             out.push(m);
         }
         out.sort_by(|a, b| b.created_at.cmp(&a.created_at));

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -16,10 +16,11 @@ use icn_governance::{
     Discussion, DiscussionStore, GovernanceConfig, GovernanceDecisionReceipt, GovernanceDomain,
     GovernanceDomainId, GovernanceError, GovernanceOps, GovernanceParams, GovernanceProfileId,
     InMemoryActionItemStore, InMemoryActivityStore, InMemoryDiscussionStore,
-    InMemoryStructureStore, MembershipConfig, MembershipSource, PaginatedResult, ProofOutcome,
-    Proposal, ProposalDomainLookup, ProposalId, ProposalPayload, ProposalScope, ProposalState,
-    RoleAssignment, Structure, StructureId, StructureKind, StructureStoreBackend, Timestamp, Vote,
-    VoteChoice, VoteTally, DEFAULT_MAX_DELEGATION_DEPTH,
+    InMemoryMeetingStore, InMemoryStructureStore, Meeting, MeetingId, MeetingStoreBackend,
+    MembershipConfig, MembershipSource, PaginatedResult, ProofOutcome, Proposal,
+    ProposalDomainLookup, ProposalId, ProposalPayload, ProposalScope, ProposalState, RoleAssignment,
+    Structure, StructureId, StructureKind, StructureStoreBackend, Timestamp, Vote, VoteChoice,
+    VoteTally, DEFAULT_MAX_DELEGATION_DEPTH,
 };
 use icn_identity::Did;
 use icn_kernel_api::{AllocationReceipt, ScopeLevel, SettlementIntent};
@@ -590,6 +591,109 @@ impl icn_governance::ActivityStoreBackend for SledActivityStore {
     }
 }
 
+// ============================================================================
+// Sled-Backed Meeting Store
+// ============================================================================
+
+/// Sled-backed storage for meetings.
+///
+/// Key scheme:
+/// - Meeting:  `meeting:{domain_id}:{meeting_id}`
+///
+/// All-meeting scan prefix: `meeting:` (for get-by-id when domain is unknown).
+pub struct SledMeetingStore {
+    db: Arc<sled::Db>,
+}
+
+impl SledMeetingStore {
+    /// Create a new Sled-backed meeting store.
+    pub fn new(db: Arc<sled::Db>) -> Self {
+        Self { db }
+    }
+
+    fn meeting_key(domain_id: &str, id: &MeetingId) -> String {
+        format!("meeting:{}:{}", domain_id, id.0)
+    }
+
+    fn domain_prefix(domain_id: &str) -> String {
+        format!("meeting:{}:", domain_id)
+    }
+
+    fn all_prefix() -> &'static str {
+        "meeting:"
+    }
+}
+
+impl MeetingStoreBackend for SledMeetingStore {
+    fn save(&self, m: &Meeting) -> std::result::Result<(), GovernanceError> {
+        let key = Self::meeting_key(&m.domain_id, &m.id);
+        let value = icn_encoding::encode_versioned(m)
+            .map_err(|e| GovernanceError::Internal(format!("Failed to encode meeting: {e}")))?;
+        self.db
+            .insert(key.as_bytes(), value)
+            .map_err(|e| GovernanceError::Internal(format!("Sled insert failed: {e}")))?;
+        Ok(())
+    }
+
+    fn get(&self, id: &MeetingId) -> std::result::Result<Option<Meeting>, GovernanceError> {
+        let suffix = format!(":{}", id.0);
+        for result in self.db.scan_prefix(Self::all_prefix().as_bytes()) {
+            let (key, value) =
+                result.map_err(|e| GovernanceError::Internal(format!("Sled scan failed: {e}")))?;
+            let key_str = std::str::from_utf8(&key)
+                .map_err(|e| GovernanceError::Internal(format!("Invalid UTF-8 key: {e}")))?;
+            if key_str.ends_with(&suffix) {
+                let m: Meeting = icn_encoding::decode_versioned(&value).map_err(|e| {
+                    GovernanceError::Internal(format!("Failed to decode meeting: {e}"))
+                })?;
+                return Ok(Some(m));
+            }
+        }
+        Ok(None)
+    }
+
+    fn list_by_domain(
+        &self,
+        domain_id: &str,
+    ) -> std::result::Result<Vec<Meeting>, GovernanceError> {
+        let prefix = Self::domain_prefix(domain_id);
+        let mut out = Vec::new();
+        for result in self.db.scan_prefix(prefix.as_bytes()) {
+            let (_, value) =
+                result.map_err(|e| GovernanceError::Internal(format!("Sled scan failed: {e}")))?;
+            let m: Meeting = icn_encoding::decode_versioned(&value).map_err(|e| {
+                GovernanceError::Internal(format!("Failed to decode meeting: {e}"))
+            })?;
+            out.push(m);
+        }
+        out.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(out)
+    }
+
+    fn delete(&self, id: &MeetingId) -> std::result::Result<bool, GovernanceError> {
+        let suffix = format!(":{}", id.0);
+        let mut found_key: Option<sled::IVec> = None;
+        for result in self.db.scan_prefix(Self::all_prefix().as_bytes()) {
+            let (key, _) =
+                result.map_err(|e| GovernanceError::Internal(format!("Sled scan failed: {e}")))?;
+            let key_str = std::str::from_utf8(&key)
+                .map_err(|e| GovernanceError::Internal(format!("Invalid UTF-8 key: {e}")))?;
+            if key_str.ends_with(&suffix) {
+                found_key = Some(key);
+                break;
+            }
+        }
+        match found_key {
+            Some(k) => self
+                .db
+                .remove(k)
+                .map(|opt| opt.is_some())
+                .map_err(|e| GovernanceError::Internal(format!("Sled delete failed: {e}"))),
+            None => Ok(false),
+        }
+    }
+}
+
 /// Handle type for actor-backed governance
 ///
 /// This uses the `GovernanceOps` trait to avoid direct dependency on `icn-core`.
@@ -625,6 +729,8 @@ pub struct GovernanceManager {
     structure_store: Arc<dyn StructureStoreBackend>,
     /// Activity store backend (events, programs, projects)
     activity_store: Arc<dyn ActivityStoreBackend>,
+    /// Meeting store backend (deliberation trace objects)
+    meeting_store: Arc<dyn MeetingStoreBackend>,
     /// Optional handle to daemon's GovernanceActor (actor-backed mode)
     governance_handle: Option<GovernanceHandle>,
     /// Optional receipt store for persisting GovernanceDecisionReceipts
@@ -647,6 +753,7 @@ impl GovernanceManager {
             action_items: Box::new(InMemoryActionItemStore::new()),
             structure_store: Arc::new(InMemoryStructureStore::new()),
             activity_store: Arc::new(InMemoryActivityStore::new()),
+            meeting_store: Arc::new(InMemoryMeetingStore::new()),
             governance_handle: None,
             receipt_store: None,
         }
@@ -680,6 +787,7 @@ impl GovernanceManager {
             action_items: Box::new(InMemoryActionItemStore::new()),
             structure_store: Arc::new(InMemoryStructureStore::new()),
             activity_store: Arc::new(InMemoryActivityStore::new()),
+            meeting_store: Arc::new(InMemoryMeetingStore::new()),
             governance_handle: Some(handle),
             receipt_store: None,
         }
@@ -718,6 +826,14 @@ impl GovernanceManager {
         self
     }
 
+    /// Replace the meeting store backend.
+    ///
+    /// Use this to configure Sled-backed persistent storage for meetings.
+    pub fn with_meeting_store(mut self, store: Arc<dyn MeetingStoreBackend>) -> Self {
+        self.meeting_store = store;
+        self
+    }
+
     /// Create a governance manager with Sled-backed action item storage
     ///
     /// This is the recommended mode for production with persistent action items.
@@ -732,6 +848,7 @@ impl GovernanceManager {
             action_items: Box::new(SledActionItemStore::new(db)),
             structure_store: Arc::new(InMemoryStructureStore::new()),
             activity_store: Arc::new(InMemoryActivityStore::new()),
+            meeting_store: Arc::new(InMemoryMeetingStore::new()),
             governance_handle: Some(handle),
             receipt_store: None,
         }
@@ -751,6 +868,7 @@ impl GovernanceManager {
             action_items: Box::new(SledActionItemStore::new(db)),
             structure_store: Arc::new(InMemoryStructureStore::new()),
             activity_store: Arc::new(InMemoryActivityStore::new()),
+            meeting_store: Arc::new(InMemoryMeetingStore::new()),
             governance_handle: None,
             receipt_store: None,
         }
@@ -2353,6 +2471,58 @@ impl GovernanceManager {
         self.activity_store
             .list_by_entity(entity_id)
             .map_err(|e| anyhow::anyhow!("Failed to list activities: {e}"))
+    }
+
+    // ========================================================================
+    // Meeting management (deliberation trace objects)
+    // ========================================================================
+
+    /// Create a new meeting in a governance domain.
+    pub fn create_meeting(
+        &self,
+        domain_id: String,
+        title: String,
+        description: Option<String>,
+        scheduled_at: Option<u64>,
+        created_by: String,
+    ) -> Result<Meeting> {
+        let now = icn_time::current_timestamp_secs();
+        let id = MeetingId::generate();
+        let mut m = Meeting::new(id, domain_id, title, created_by, now);
+        m.description = description;
+        m.scheduled_at = scheduled_at;
+        self.meeting_store
+            .save(&m)
+            .map_err(|e| anyhow::anyhow!("Failed to save meeting: {e}"))?;
+        Ok(m)
+    }
+
+    /// Get a meeting by ID.
+    pub fn get_meeting(&self, id: &MeetingId) -> Result<Option<Meeting>> {
+        self.meeting_store
+            .get(id)
+            .map_err(|e| anyhow::anyhow!("Failed to get meeting: {e}"))
+    }
+
+    /// List all meetings in a governance domain, newest first.
+    pub fn list_meetings(&self, domain_id: &str) -> Result<Vec<Meeting>> {
+        self.meeting_store
+            .list_by_domain(domain_id)
+            .map_err(|e| anyhow::anyhow!("Failed to list meetings: {e}"))
+    }
+
+    /// Update a meeting record (full save — caller mutates then calls this).
+    pub fn update_meeting(&self, m: &Meeting) -> Result<()> {
+        self.meeting_store
+            .save(m)
+            .map_err(|e| anyhow::anyhow!("Failed to update meeting: {e}"))
+    }
+
+    /// Delete a meeting (hard delete).
+    pub fn delete_meeting(&self, id: &MeetingId) -> Result<bool> {
+        self.meeting_store
+            .delete(id)
+            .map_err(|e| anyhow::anyhow!("Failed to delete meeting: {e}"))
     }
 
     // ========================================================================

--- a/icn/crates/icn-gateway/src/events.rs
+++ b/icn/crates/icn-gateway/src/events.rs
@@ -270,31 +270,13 @@ pub enum GatewayEvent {
         transferred_at: u64,
     },
 
-    // === Institutional Events ===
-    /// A meeting was scheduled in a governance domain
-    MeetingCreated {
-        domain_id: String,
-        meeting_id: String,
-        title: String,
-        scheduled_at: u64,
-        created_by: String,
-    },
-
-    /// A meeting transitioned to in-progress
-    MeetingStarted {
-        domain_id: String,
-        meeting_id: String,
-    },
-
-    /// A meeting was completed or cancelled
-    MeetingEnded {
-        domain_id: String,
-        meeting_id: String,
-        /// "completed" or "cancelled"
-        outcome: String,
-    },
-
     // === Control Events ===
+    // Note: meeting-lifecycle events (GovernanceMeetingCreated/Started/Ended)
+    // will ship in the notification-digest PR alongside GovernanceActionItemCreated,
+    // under the canonical `Governance<Thing><Verb>` naming convention locked in
+    // docs/strategy/NYCN-Repo-Architecture-Spec.md §6. The variants were not
+    // emittable from this PR because `GovernanceEventEmitter` does not yet
+    // expose meeting methods, so shipping them here would be dead code.
     /// Server is shutting down gracefully
     ///
     /// Clients should:

--- a/icn/crates/icn-gateway/src/events.rs
+++ b/icn/crates/icn-gateway/src/events.rs
@@ -281,7 +281,10 @@ pub enum GatewayEvent {
     },
 
     /// A meeting transitioned to in-progress
-    MeetingStarted { domain_id: String, meeting_id: String },
+    MeetingStarted {
+        domain_id: String,
+        meeting_id: String,
+    },
 
     /// A meeting was completed or cancelled
     MeetingEnded {

--- a/icn/crates/icn-gateway/src/events.rs
+++ b/icn/crates/icn-gateway/src/events.rs
@@ -270,6 +270,27 @@ pub enum GatewayEvent {
         transferred_at: u64,
     },
 
+    // === Institutional Events ===
+    /// A meeting was scheduled in a governance domain
+    MeetingCreated {
+        domain_id: String,
+        meeting_id: String,
+        title: String,
+        scheduled_at: u64,
+        created_by: String,
+    },
+
+    /// A meeting transitioned to in-progress
+    MeetingStarted { domain_id: String, meeting_id: String },
+
+    /// A meeting was completed or cancelled
+    MeetingEnded {
+        domain_id: String,
+        meeting_id: String,
+        /// "completed" or "cancelled"
+        outcome: String,
+    },
+
     // === Control Events ===
     /// Server is shutting down gracefully
     ///

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -645,6 +645,9 @@ impl GatewayServer {
         let activity_store = Arc::new(icn_governance_actor::SledActivityStore::new(
             sled_db_arc.clone(),
         ));
+        let meeting_store = Arc::new(icn_governance_actor::SledMeetingStore::new(
+            sled_db_arc.clone(),
+        ));
         let governance_manager: Arc<GovernanceManager> =
             if let Some(handle) = self.governance_handle {
                 info!("Governance manager connected to daemon with persistent action items");
@@ -652,7 +655,8 @@ impl GatewayServer {
                     GovernanceManager::with_sled_action_items(handle, sled_db_arc)
                         .with_receipt_store(receipt_store.clone())
                         .with_structure_store(structure_store)
-                        .with_activity_store(activity_store),
+                        .with_activity_store(activity_store)
+                        .with_meeting_store(meeting_store),
                 )
             } else {
                 info!("Governance manager running standalone with persistent action items");
@@ -660,7 +664,8 @@ impl GatewayServer {
                     GovernanceManager::new_with_sled(sled_db_arc)
                         .with_receipt_store(receipt_store.clone())
                         .with_structure_store(structure_store)
-                        .with_activity_store(activity_store),
+                        .with_activity_store(activity_store)
+                        .with_meeting_store(meeting_store),
                 )
             };
         let ledger_service: Option<Arc<icn_api::LedgerService>> =

--- a/icn/crates/icn-governance/src/action_item.rs
+++ b/icn/crates/icn-governance/src/action_item.rs
@@ -197,7 +197,8 @@ pub struct ActionItem {
 
     /// Typed link to the meeting that generated this action item.
     ///
-    /// Set automatically when action items are created during meeting close.
+    /// Optional reference to the meeting in which this action item originated.
+    /// Set by callers when creating action items from a meeting context.
     /// Coexists with `meeting_context` (the free-text field remains for backward
     /// compatibility and manual entry).
     #[serde(default)]

--- a/icn/crates/icn-governance/src/action_item.rs
+++ b/icn/crates/icn-governance/src/action_item.rs
@@ -190,9 +190,18 @@ pub struct ActionItem {
     #[serde(default)]
     pub linked_proposal: Option<ProposalId>,
 
-    /// Meeting context (e.g., "2026-01-17 board meeting")
+    /// Meeting context (e.g., "2026-01-17 board meeting"). Free-text; kept for
+    /// backward compatibility. Prefer `meeting_id` for structured linkage.
     #[serde(default)]
     pub meeting_context: Option<String>,
+
+    /// Typed link to the meeting that generated this action item.
+    ///
+    /// Set automatically when action items are created during meeting close.
+    /// Coexists with `meeting_context` (the free-text field remains for backward
+    /// compatibility and manual entry).
+    #[serde(default)]
+    pub meeting_id: Option<crate::meeting::MeetingId>,
 
     /// Tags for categorization
     #[serde(default)]
@@ -230,6 +239,7 @@ impl ActionItem {
             updated_at: now,
             linked_proposal: None,
             meeting_context: None,
+            meeting_id: None,
             tags: Vec::new(),
             notes: Vec::new(),
             parent: None,

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -84,6 +84,7 @@ pub mod action_item;
 
 // Institutional structure + event model (Tranche 2)
 pub mod activity;
+pub mod meeting;
 pub mod parent;
 pub mod structure;
 
@@ -183,6 +184,10 @@ pub use action_item::{
 };
 pub use activity::{
     Activity, ActivityId, ActivityKind, ActivityStatus, ActivityStoreBackend, InMemoryActivityStore,
+};
+pub use meeting::{
+    AgendaItem, AgendaItemId, AttendanceStatus, InMemoryMeetingStore, Meeting, MeetingAttendee,
+    MeetingId, MeetingRole, MeetingStatus, MeetingStoreBackend,
 };
 pub use parent::InstitutionalParent;
 pub use structure::{

--- a/icn/crates/icn-governance/src/meeting.rs
+++ b/icn/crates/icn-governance/src/meeting.rs
@@ -209,9 +209,7 @@ impl AgendaItem {
 
     /// Whether this item has been resolved (outcome is set to "resolved").
     pub fn is_resolved(&self) -> bool {
-        self.outcome
-            .as_deref()
-            .is_some_and(|o| o == "resolved")
+        self.outcome.as_deref().is_some_and(|o| o == "resolved")
     }
 }
 
@@ -361,10 +359,8 @@ pub trait MeetingStoreBackend: Send + Sync {
     fn get(&self, id: &MeetingId) -> std::result::Result<Option<Meeting>, GovernanceError>;
 
     /// List all meetings in a governance domain, newest first.
-    fn list_by_domain(
-        &self,
-        domain_id: &str,
-    ) -> std::result::Result<Vec<Meeting>, GovernanceError>;
+    fn list_by_domain(&self, domain_id: &str)
+        -> std::result::Result<Vec<Meeting>, GovernanceError>;
 
     /// Delete a meeting (hard delete — prefer `Cancelled` status for soft-cancel).
     fn delete(&self, id: &MeetingId) -> std::result::Result<bool, GovernanceError>;

--- a/icn/crates/icn-governance/src/meeting.rs
+++ b/icn/crates/icn-governance/src/meeting.rs
@@ -1,0 +1,568 @@
+//! Meetings: institutional trace objects for deliberation and decision-making.
+//!
+//! A meeting exists because it produces deliberation context, witness context,
+//! and linked outputs — not as a generic calendar entry. Every meeting is
+//! scoped to a governance domain and may link to structures, activities,
+//! proposals, and action items.
+//!
+//! **Meaning-firewall note**: `MeetingRole` values (`Facilitator`, `NoteTaker`,
+//! etc.) are *coordination labels* on attendance records. They do NOT grant
+//! governance authority or voting rights. Authority requires an explicit
+//! `RoleAssignment` on a `Structure`.
+//!
+//! See `docs/design/institutional-structure-spec.md` for the full design.
+
+use crate::structure::StructureId;
+use crate::{ActivityId, GovernanceError, ProposalId, Timestamp};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::RwLock;
+use uuid::Uuid;
+
+// ========== Identifiers ==========
+
+/// Unique identifier for a meeting.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct MeetingId(pub String);
+
+impl MeetingId {
+    /// Create a new random meeting ID.
+    pub fn generate() -> Self {
+        Self(format!("meeting-{}", Uuid::new_v4()))
+    }
+
+    /// Create from a raw string (useful for deterministic IDs like "nycn-q1-2026-all-hands").
+    pub fn from_raw(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+}
+
+impl std::fmt::Display for MeetingId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Unique identifier for an agenda item within a meeting.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct AgendaItemId(pub Uuid);
+
+impl AgendaItemId {
+    /// Create a new random agenda item ID.
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+impl Default for AgendaItemId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for AgendaItemId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+// ========== Enums ==========
+
+/// Lifecycle status of a meeting.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MeetingStatus {
+    /// Scheduled but not yet started.
+    #[default]
+    Scheduled,
+    /// Currently in progress.
+    InProgress,
+    /// Finished and minutes finalized.
+    Completed,
+    /// Cancelled before it began.
+    Cancelled,
+}
+
+/// Attendance status of a participant in a meeting.
+///
+/// Richer than `(Did, bool)` — captures invitation, presence, and remote attendance
+/// for quorum and witness context.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttendanceStatus {
+    /// Invited but not yet confirmed.
+    #[default]
+    Invited,
+    /// Attended in person.
+    Present,
+    /// Did not attend.
+    Absent,
+    /// Attended remotely (e.g., video call).
+    Remote,
+}
+
+/// Coordination role a participant holds in this specific meeting.
+///
+/// **CRITICAL INVARIANT**: These are *coordination labels only*. A `Facilitator`
+/// role does NOT grant governance authority, voting weight, or decision power.
+/// Those require an explicit `RoleAssignment` on a `Structure` linked by charter.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MeetingRole {
+    /// Person running the meeting process.
+    Facilitator,
+    /// Person capturing notes and producing minutes.
+    NoteTaker,
+    /// Regular participant with full engagement.
+    #[default]
+    Participant,
+    /// Present but non-voting observer (e.g., guest, new member in onboarding).
+    Observer,
+}
+
+// ========== Core Types ==========
+
+/// A participant in a specific meeting with their attendance and coordination role.
+///
+/// `meeting_role` is a coordination label for this meeting instance only.
+/// It does not derive from or grant any persistent governance authority.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeetingAttendee {
+    /// DID of the participant. Using `String` to avoid cross-crate DID dependency
+    /// in the governance crate.
+    pub did: String,
+
+    /// Attendance status: invited, present, absent, or remote.
+    #[serde(default)]
+    pub status: AttendanceStatus,
+
+    /// Coordination role for this meeting. Defaults to `Participant`.
+    /// NOT a governance authority grant — see module docs.
+    #[serde(default)]
+    pub meeting_role: MeetingRole,
+}
+
+impl MeetingAttendee {
+    /// Create a new attendee with Invited status and Participant role.
+    pub fn new(did: impl Into<String>) -> Self {
+        Self {
+            did: did.into(),
+            status: AttendanceStatus::Invited,
+            meeting_role: MeetingRole::Participant,
+        }
+    }
+}
+
+/// A single item on a meeting agenda.
+///
+/// Each agenda item may be linked to an in-flight proposal (for discussion or
+/// ratification) and generates action items on meeting close for unresolved
+/// discussion outcomes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgendaItem {
+    /// Unique identifier within this meeting.
+    pub id: AgendaItemId,
+
+    /// Short title of the agenda item (e.g., "Q2 Budget Review", "Membership vote: Alice").
+    pub title: String,
+
+    /// Optional longer description.
+    #[serde(default)]
+    pub description: Option<String>,
+
+    /// DID of the person presenting this item.
+    #[serde(default)]
+    pub presenter: Option<String>,
+
+    /// A proposal being discussed or voted on during this agenda item.
+    #[serde(default)]
+    pub linked_proposal: Option<ProposalId>,
+
+    /// Free-text notes captured during discussion of this item.
+    #[serde(default)]
+    pub discussion_notes: Option<String>,
+
+    /// Outcome of discussion: "resolved", "tabled", "referred", "no_action", etc.
+    /// Free-form but bounded — used to determine whether action items are needed.
+    #[serde(default)]
+    pub outcome: Option<String>,
+
+    /// Action item IDs generated from this agenda item (populated at meeting close).
+    #[serde(default)]
+    pub generated_action_items: Vec<crate::ActionItemId>,
+}
+
+impl AgendaItem {
+    /// Create a new agenda item with a title.
+    pub fn new(title: impl Into<String>) -> Self {
+        Self {
+            id: AgendaItemId::new(),
+            title: title.into(),
+            description: None,
+            presenter: None,
+            linked_proposal: None,
+            discussion_notes: None,
+            outcome: None,
+            generated_action_items: Vec::new(),
+        }
+    }
+
+    /// Whether this item has been resolved (outcome is set to "resolved").
+    pub fn is_resolved(&self) -> bool {
+        self.outcome
+            .as_deref()
+            .is_some_and(|o| o == "resolved")
+    }
+}
+
+/// A meeting — the institutional trace object for deliberation.
+///
+/// Meetings link: agenda → proposals → attendance (witness context) →
+/// action items → records. They are scoped to a governance domain and may
+/// attach to structures (committees) and activities (events).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Meeting {
+    /// Unique identifier.
+    pub id: MeetingId,
+
+    /// Governance domain this meeting belongs to.
+    pub domain_id: String,
+
+    /// Display title (e.g., "NYCN Steering Committee – March 2026").
+    pub title: String,
+
+    /// Optional description or purpose statement.
+    #[serde(default)]
+    pub description: Option<String>,
+
+    /// Scheduled start time (Unix seconds). May differ from actual start.
+    #[serde(default)]
+    pub scheduled_at: Option<Timestamp>,
+
+    /// Actual start time (set when status transitions to InProgress).
+    #[serde(default)]
+    pub started_at: Option<Timestamp>,
+
+    /// Actual end time (set when status transitions to Completed or Cancelled).
+    #[serde(default)]
+    pub ended_at: Option<Timestamp>,
+
+    /// Current lifecycle status.
+    #[serde(default)]
+    pub status: MeetingStatus,
+
+    /// Invited/present participants with their attendance and coordination roles.
+    #[serde(default)]
+    pub attendees: Vec<MeetingAttendee>,
+
+    /// Ordered agenda items for this meeting.
+    #[serde(default)]
+    pub agenda: Vec<AgendaItem>,
+
+    /// Structures (committees, working groups) hosting or contributing to this meeting.
+    /// Informational linkage — does not grant authority from those structures.
+    #[serde(default)]
+    pub linked_structures: Vec<StructureId>,
+
+    /// Activities (events, programs) this meeting is part of.
+    #[serde(default)]
+    pub linked_activities: Vec<ActivityId>,
+
+    /// DocumentId for meeting notes/minutes (set after completion).
+    /// `String` to avoid forward dependency on the document type (added in Tranche 3).
+    #[serde(default)]
+    pub notes_doc_id: Option<String>,
+
+    /// DID of the person who created this meeting record.
+    pub created_by: String,
+
+    /// Unix timestamp when the meeting record was created.
+    pub created_at: Timestamp,
+}
+
+impl Meeting {
+    /// Create a new scheduled meeting with minimal required fields.
+    pub fn new(
+        id: MeetingId,
+        domain_id: impl Into<String>,
+        title: impl Into<String>,
+        created_by: impl Into<String>,
+        now: Timestamp,
+    ) -> Self {
+        Self {
+            id,
+            domain_id: domain_id.into(),
+            title: title.into(),
+            description: None,
+            scheduled_at: None,
+            started_at: None,
+            ended_at: None,
+            status: MeetingStatus::Scheduled,
+            attendees: Vec::new(),
+            agenda: Vec::new(),
+            linked_structures: Vec::new(),
+            linked_activities: Vec::new(),
+            notes_doc_id: None,
+            created_by: created_by.into(),
+            created_at: now,
+        }
+    }
+
+    /// Whether the meeting is currently active.
+    pub fn is_in_progress(&self) -> bool {
+        matches!(self.status, MeetingStatus::InProgress)
+    }
+
+    /// Whether the meeting has been completed.
+    pub fn is_completed(&self) -> bool {
+        matches!(self.status, MeetingStatus::Completed)
+    }
+
+    /// Count attendees with Present or Remote status.
+    pub fn present_count(&self) -> usize {
+        self.attendees
+            .iter()
+            .filter(|a| {
+                matches!(
+                    a.status,
+                    AttendanceStatus::Present | AttendanceStatus::Remote
+                )
+            })
+            .count()
+    }
+
+    /// Find the agenda item with the given ID.
+    pub fn get_agenda_item(&self, id: &AgendaItemId) -> Option<&AgendaItem> {
+        self.agenda.iter().find(|item| &item.id == id)
+    }
+
+    /// Find the agenda item with the given ID, mutably.
+    pub fn get_agenda_item_mut(&mut self, id: &AgendaItemId) -> Option<&mut AgendaItem> {
+        self.agenda.iter_mut().find(|item| &item.id == id)
+    }
+
+    /// Agenda items that have no outcome set (unresolved at meeting close).
+    pub fn unresolved_agenda_items(&self) -> Vec<&AgendaItem> {
+        self.agenda
+            .iter()
+            .filter(|item| item.outcome.is_none())
+            .collect()
+    }
+}
+
+// ========== Store Backend ==========
+
+/// Storage backend trait for meetings.
+pub trait MeetingStoreBackend: Send + Sync {
+    /// Save (create or update) a meeting.
+    fn save(&self, m: &Meeting) -> std::result::Result<(), GovernanceError>;
+
+    /// Retrieve a meeting by ID.
+    fn get(&self, id: &MeetingId) -> std::result::Result<Option<Meeting>, GovernanceError>;
+
+    /// List all meetings in a governance domain, newest first.
+    fn list_by_domain(
+        &self,
+        domain_id: &str,
+    ) -> std::result::Result<Vec<Meeting>, GovernanceError>;
+
+    /// Delete a meeting (hard delete — prefer `Cancelled` status for soft-cancel).
+    fn delete(&self, id: &MeetingId) -> std::result::Result<bool, GovernanceError>;
+}
+
+// ========== In-Memory Store ==========
+
+/// In-memory implementation of [`MeetingStoreBackend`]. Primarily for tests.
+#[derive(Default)]
+pub struct InMemoryMeetingStore {
+    meetings: RwLock<HashMap<MeetingId, Meeting>>,
+}
+
+impl InMemoryMeetingStore {
+    /// Create a new empty in-memory store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl MeetingStoreBackend for InMemoryMeetingStore {
+    fn save(&self, m: &Meeting) -> std::result::Result<(), GovernanceError> {
+        let mut guard = self
+            .meetings
+            .write()
+            .map_err(|e| GovernanceError::Internal(format!("meetings lock poisoned: {e}")))?;
+        guard.insert(m.id.clone(), m.clone());
+        Ok(())
+    }
+
+    fn get(&self, id: &MeetingId) -> std::result::Result<Option<Meeting>, GovernanceError> {
+        let guard = self
+            .meetings
+            .read()
+            .map_err(|e| GovernanceError::Internal(format!("meetings lock poisoned: {e}")))?;
+        Ok(guard.get(id).cloned())
+    }
+
+    fn list_by_domain(
+        &self,
+        domain_id: &str,
+    ) -> std::result::Result<Vec<Meeting>, GovernanceError> {
+        let guard = self
+            .meetings
+            .read()
+            .map_err(|e| GovernanceError::Internal(format!("meetings lock poisoned: {e}")))?;
+        let mut out: Vec<Meeting> = guard
+            .values()
+            .filter(|m| m.domain_id == domain_id)
+            .cloned()
+            .collect();
+        out.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(out)
+    }
+
+    fn delete(&self, id: &MeetingId) -> std::result::Result<bool, GovernanceError> {
+        let mut guard = self
+            .meetings
+            .write()
+            .map_err(|e| GovernanceError::Internal(format!("meetings lock poisoned: {e}")))?;
+        Ok(guard.remove(id).is_some())
+    }
+}
+
+// ========== Tests ==========
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_meeting(id: &str, domain: &str) -> Meeting {
+        Meeting::new(
+            MeetingId::from_raw(id),
+            domain,
+            "Test Meeting",
+            "did:icn:creator",
+            1000,
+        )
+    }
+
+    #[test]
+    fn test_meeting_lifecycle() {
+        let store = InMemoryMeetingStore::new();
+        let id = MeetingId::from_raw("nycn-march-2026");
+        let mut m = make_meeting("nycn-march-2026", "nycn-domain");
+        m.scheduled_at = Some(2000);
+        m.attendees = vec![
+            MeetingAttendee {
+                did: "did:icn:alice".to_string(),
+                status: AttendanceStatus::Present,
+                meeting_role: MeetingRole::Facilitator,
+            },
+            MeetingAttendee {
+                did: "did:icn:bob".to_string(),
+                status: AttendanceStatus::Remote,
+                meeting_role: MeetingRole::NoteTaker,
+            },
+            MeetingAttendee {
+                did: "did:icn:charlie".to_string(),
+                status: AttendanceStatus::Absent,
+                meeting_role: MeetingRole::Participant,
+            },
+        ];
+
+        store.save(&m).unwrap();
+        let retrieved = store.get(&id).unwrap().unwrap();
+        assert_eq!(retrieved.title, "Test Meeting");
+        assert_eq!(retrieved.attendees.len(), 3);
+        assert_eq!(retrieved.present_count(), 2); // alice + bob
+        assert_eq!(retrieved.status, MeetingStatus::Scheduled);
+    }
+
+    #[test]
+    fn test_meeting_status_transitions() {
+        let mut m = make_meeting("test", "domain");
+        assert!(!m.is_in_progress());
+        assert!(!m.is_completed());
+
+        m.status = MeetingStatus::InProgress;
+        m.started_at = Some(1100);
+        assert!(m.is_in_progress());
+
+        m.status = MeetingStatus::Completed;
+        m.ended_at = Some(1300);
+        assert!(m.is_completed());
+        assert!(!m.is_in_progress());
+    }
+
+    #[test]
+    fn test_agenda_items() {
+        let mut m = make_meeting("test", "domain");
+        let item1 = AgendaItem::new("Budget review");
+        let item2 = AgendaItem::new("Membership vote");
+        let id1 = item1.id.clone();
+        let id2 = item2.id.clone();
+        m.agenda.push(item1);
+        m.agenda.push(item2);
+
+        assert_eq!(m.unresolved_agenda_items().len(), 2);
+
+        // Resolve one
+        if let Some(item) = m.get_agenda_item_mut(&id1) {
+            item.outcome = Some("resolved".to_string());
+        }
+        assert_eq!(m.unresolved_agenda_items().len(), 1);
+        assert!(m.get_agenda_item(&id2).is_some());
+    }
+
+    #[test]
+    fn test_list_by_domain() {
+        let store = InMemoryMeetingStore::new();
+
+        store.save(&make_meeting("m1", "nycn")).unwrap();
+        store.save(&make_meeting("m2", "nycn")).unwrap();
+        store.save(&make_meeting("m3", "greenstar")).unwrap();
+
+        assert_eq!(store.list_by_domain("nycn").unwrap().len(), 2);
+        assert_eq!(store.list_by_domain("greenstar").unwrap().len(), 1);
+        assert!(store.list_by_domain("other").unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_delete() {
+        let store = InMemoryMeetingStore::new();
+        let id = MeetingId::from_raw("temp");
+        store.save(&make_meeting("temp", "domain")).unwrap();
+        assert!(store.delete(&id).unwrap());
+        assert!(store.get(&id).unwrap().is_none());
+        assert!(!store.delete(&id).unwrap()); // idempotent
+    }
+
+    #[test]
+    fn test_serde_defaults() {
+        let json = r#"{
+            "id": "m-abc",
+            "domain_id": "nycn",
+            "title": "Test",
+            "created_by": "did:icn:alice",
+            "created_at": 1000
+        }"#;
+        let m: Meeting = serde_json::from_str(json).unwrap();
+        assert_eq!(m.id.0, "m-abc");
+        assert_eq!(m.status, MeetingStatus::Scheduled);
+        assert!(m.attendees.is_empty());
+        assert!(m.agenda.is_empty());
+        assert!(m.linked_structures.is_empty());
+        assert!(m.notes_doc_id.is_none());
+    }
+
+    #[test]
+    fn test_meeting_role_is_not_authority() {
+        // Facilitator and NoteTaker roles are coordination labels.
+        // This test asserts they are distinct from governance roles.
+        let facilitator = MeetingRole::Facilitator;
+        let note_taker = MeetingRole::NoteTaker;
+        assert_ne!(facilitator, note_taker);
+        // They serialize to snake_case strings, not special authority tokens.
+        let s = serde_json::to_string(&facilitator).unwrap();
+        assert_eq!(s, "\"facilitator\"");
+    }
+}


### PR DESCRIPTION
## Summary

- **`meeting.rs`** (new) — `Meeting`, `MeetingAttendee`, `AgendaItem`, `MeetingId`, `AgendaItemId`, `MeetingStatus`, `AttendanceStatus`, `MeetingRole` (7 types, 7 unit tests)
- **Action item linkage** — `meeting_id: Option<MeetingId>` on `ActionItem` for provenance back-links to originating meeting
- **`SledMeetingStore`** — persistent backing via sled key `meeting:{domain_id}:{meeting_id}`
- **Gateway events** — `MeetingCreated`, `MeetingStarted`, `MeetingEnded` in `GatewayEvent`
- **9 HTTP endpoints** — full meeting lifecycle: create → start → agenda → attendance → end

## Invariant enforced

**Meaning-firewall**: `MeetingRole` values (Facilitator, NoteTaker, Participant, Observer) are coordination labels on attendance records only. They do NOT grant governance authority or voting weight.

## Routes

```
POST   /gov/domains/{id}/meetings
GET    /gov/domains/{id}/meetings
GET    /gov/meetings/{id}
POST   /gov/meetings/{id}/start
POST   /gov/meetings/{id}/end
POST   /gov/meetings/{id}/attendees
PUT    /gov/meetings/{id}/attendance
POST   /gov/meetings/{id}/agenda
PUT    /gov/meetings/{id}/agenda/{item_id}
```

## Authorization guards

- `add_attendee`: domain membership check (via `member_checker`) + lifecycle state guard
- `mark_attendance`, `add_agenda_item`, `update_agenda_item`: lifecycle state guard (reject if Completed/Cancelled)

## Test plan

- [x] 7 unit tests in `icn-governance::meeting` (lifecycle, status transitions, agenda, list/delete, serde defaults, role-not-authority invariant)
- [x] All action item tests pass (455 total in icn-governance)
- [x] `cargo clippy -p icn-governance -p icn-governance-actor -p icn-gateway` clean
- [x] Meaning-firewall ratchet at limit (16 `icn_governance::` refs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)