### PR TITLE
docs(strategy): NYCN repo-shaped architecture spec + implementation matrix + execution tranches

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -383,9 +383,12 @@ Strategic direction and gap analysis (March 2026):
 - [ICN-Scenarios.md](strategy/ICN-Scenarios.md) - Six working scenarios with API calls
 - [ICN-Evolution-Arc.md](strategy/ICN-Evolution-Arc.md) - Two-year project history
 - [NYCN-Institutional-Strategy.md](strategy/NYCN-Institutional-Strategy.md) - NYCN as first real ICN institution (2026-04-13)
-- [NYCN-Institutional-Design.md](strategy/NYCN-Institutional-Design.md) - NYCN entity tree, governance model, and ICN primitive mapping (2026-04-13)
+- [NYCN-Institutional-Design.md](strategy/NYCN-Institutional-Design.md) - NYCN entity tree, governance model, and ICN primitive mapping (2026-04-13; partially superseded by Repo-Architecture-Spec §0.3 — committees are Structures, not Communities)
 - [NYCN-Implementation-Plan.md](strategy/NYCN-Implementation-Plan.md) - 5-phase platform feature plan: decision→action bridge, consent mode, meetings, digests, documents (2026-04-13)
 - [NYCN-Sprint-Plan.md](strategy/NYCN-Sprint-Plan.md) - 3-lane sprint plan: platform closure, institutional model, migration prep (2026-04-13)
+- [NYCN-Repo-Architecture-Spec.md](strategy/NYCN-Repo-Architecture-Spec.md) - Repo-shaped architectural map grounded in current code: bounded domains, canonical objects, authority model, Program/cycle design (2026-04-14)
+- [NYCN-Implementation-Matrix.md](strategy/NYCN-Implementation-Matrix.md) - Execution ledger: per-object status (main/open_pr/branch_only/spec_only), touch points, bootstrap seed, ny-coop-net import crosswalk, phase-gated open questions (2026-04-14)
+- [NYCN-Execution-Tranches.md](strategy/NYCN-Execution-Tranches.md) - Merge-order + dependency plan across 7 tranches, rollback strategy, agent assignments (2026-04-14)
 
 ### Current Status Reports (`status/`)
 

--- a/docs/strategy/NYCN-Execution-Tranches.md
+++ b/docs/strategy/NYCN-Execution-Tranches.md
@@ -1,0 +1,419 @@
+# NYCN × ICN Execution Tranches
+
+**Status**: Merge-order + dependency plan, grounded against `main` at `37ec91e0` (2026-04-14)
+**Companions**: `NYCN-Repo-Architecture-Spec.md`, `NYCN-Implementation-Matrix.md`
+
+This document sequences the NYCN integration into concrete tranches. Each tranche is one or two PRs with explicit entry conditions, exit conditions, and dependencies. Agents and humans should read this before opening any NYCN-related branch.
+
+---
+
+## 0. Dependency graph (high-level)
+
+```
+Tranche 0: Land open work
+  ├── 0a: Merge PR #1543 (meetings)
+  └── 0b: PR the notification-digest branch (rebased on #1543)
+         │
+         ▼
+Tranche 1: Program + Milestones + scope-aware digests
+         │
+         ├──► Tranche 2: Sponsor + BudgetItem
+         └──► Tranche 3: Session + Registration + Accessibility
+                  │
+                  ▼
+Tranche 4: SourceRef + ny-coop-net importer
+         │
+         ▼
+Tranche 5: InstitutionalDocument + provenance surfacing
+         │
+         ▼
+Tranche 6: RoleDelegation + Organizer Onboarding
+```
+
+Tranches 2 and 3 parallelize once 1 lands. Tranche 4 can start research/scripting in parallel with 2 and 3 (docs-only / scripts-only), but its code changes inside `icn-governance` should wait for SourceRef to be reviewable without conflicting with 2/3.
+
+---
+
+## 1. Tranche 0 — Land open work
+
+**Entry condition**: `main` at `37ec91e0`. No other tranche should start until 0 is clear.
+
+### 0a. Merge PR #1543 (Meeting management)
+
+- **Status**: OPEN, mergeable, CI green except non-blocking benchmark regression.
+- **Actions**:
+  1. Request human review (one reviewer with meaning-firewall + governance context).
+  2. Address any human review comments.
+  3. If benchmark regression is deemed acceptable, add `perf-regression-ok` label; otherwise profile and mitigate the 18% postcard serialization regression flagged by the bench bot.
+  4. Merge via `/push`-gated workflow → `gh pr merge 1543 --squash --delete-branch`.
+- **Exit condition**: `main` contains `meeting.rs`, `SledMeetingStore`, meeting HTTP endpoints, `ActionItem.meeting_id`, and `MeetingCreated/Started/Ended` gateway events.
+
+### 0b. PR + ship the notification-digest branch
+
+- **Status**: `feat/notification-digests` exists local+remote, 1 commit ahead of main, no PR yet.
+- **Required rework before opening the PR**:
+  1. **Rebase on post-#1543 main**. Old base (`37ec91e0`) is before meetings land.
+  2. **Unstub `upcoming_meetings`** in `GovernanceManager::generate_digest`. Use `SledMeetingStore::list_for_scope` (or equivalent) filtered to `scheduled_at` within the next 48h, where scope is derived from the requesting DID's role assignments.
+  3. **Add assignee-index backfill** to `SledActionItemStore::open` (or equivalent init path). Write a `_meta:idx_version:assignee` marker; if missing or below current version, walk all action items once and populate the secondary index. Add a unit test for the backfill on a pre-populated store.
+  4. **Keep scope partitioning out of scope for this PR** — it's a v1.1 concern; PR scope is "correct DID-level digest".
+  5. Add a scenario test: create proposals, action items, and a meeting; call digest; verify all three sections populate correctly.
+- **PR body must call out**:
+  - Depends on #1543 (meeting store).
+  - Notes that `SledActionItemStore` assignee index is being introduced — CI must pass on both empty and pre-populated stores.
+- **Exit condition**: PR open, CI green, review approved, merged.
+
+### Tranche 0 risks
+
+- **If #1543 does not merge within a week**, consider whether to base the digest rework on the #1543 branch directly and merge them as a stack — but prefer clean sequential merging.
+- **If #1543 hits unexpected review blockers**, the digest work still cannot ship without its meeting-store dependency.
+
+---
+
+## 2. Tranche 1 — Program + Milestones + scope-aware digest partitioning
+
+**Entry condition**: Tranche 0 complete.
+**Scope**: Large (Opus-grade design on Program/Milestone; Sonnet-executable rest).
+**Branch**: `feat/program-container`.
+
+### 1.1 Add `icn-governance::program`
+
+- Types: `ProgramId`, `ProgramKind`, `ProgramStatus`, `Program`, `Milestone`, `MilestoneId`, `MilestoneType`, `MilestoneStatus`, `CheckRef`, `InMemoryProgramStore`.
+- `Program.activity_id` as an optional link; do not require it. Program is the first-class container; Activity is kept for lighter cases.
+
+### 1.2 Add `SledProgramStore` in `apps/governance/src/manager.rs`
+
+- Key prefix `program:<id>`.
+- Secondary indexes: `program_idx:parent_entity:<eid>:<pid>`, `program_idx:status:<status>:<pid>`, `program_idx:kind:<kind>:<pid>`.
+- Backfill pattern with `_meta:idx_version:program:<name>` markers.
+
+### 1.3 HTTP surface
+
+- `POST/GET /gov/programs`
+- `GET /gov/programs/{id}`
+- `POST /gov/programs/{id}/milestones`
+- `PATCH /gov/programs/{id}/milestones/{mid}`
+- `POST /gov/programs/{id}/close`
+- `GET /gov/programs/{id}/dashboard` — composes program + milestones + action-item counts by parent + open-decision count
+
+### 1.4 Gateway events
+
+- `ProgramOpened`, `ProgramClosed`, `MilestoneCompleted`, `MilestoneBlocked`.
+
+### 1.5 Scope-partitioned digest (v1.1 of digest)
+
+- Extend `generate_digest(did, scope: Option<DigestScope>)`.
+- `DigestScope::Structure(sid) | Program(pid) | Entity(eid) | All`.
+- Handler: `GET /gov/digest?scope=structure:nycn-finance`.
+
+### 1.6 MyScope view
+
+- `GET /gov/me/scopes` — enumerate current user's `RoleAssignment`s grouped by scope, with authority type and time-bounds. Trivial but unblocks UI.
+
+### 1.7 Scenario tests
+
+- S1 (backbone → full-team transition) with Program/Milestone.
+- Milestone transition gated on required checks.
+- Scope-partitioned digest returns disjoint results for two scopes the same user is in.
+
+### 1.8 Exit condition
+
+PR merged; NYCN charter bootstrap can create `summit-2026` as a `Program { kind: AnnualSummit, parent_entity_id: "nycn-organizers" }` with `StrategyLocked`, `VenueLocked`, `BudgetLocked`, `PublicLaunchReady`, `EventReady`, `ClosureComplete` milestones.
+
+---
+
+## 3. Tranche 2 — Sponsor + BudgetItem (funding closure)
+
+**Entry condition**: Tranche 1 merged.
+**Scope**: Medium. Parallelizable with Tranche 3.
+**Branch**: `feat/sponsor-budget`.
+
+### 2.1 Add `icn-governance::sponsor`
+
+- `Sponsor { id, entity_ref: Option<String>, program_id, relationship_owner_did, status, tier, amount, follow_up_at, benefits_status, source_refs, notes }`.
+- `SponsorStatus { Prospect, Warm, Asked, Negotiating, Confirmed, Declined, Fulfilled }`.
+- Lifecycle validation: disallow illegal transitions (e.g., Declined → Confirmed is only via a new Sponsor record).
+
+### 2.2 Add `icn-governance::budget_item`
+
+- `BudgetItem { id, program_id, category, amount, direction: Income|Expense|Commitment|Forecast, status, owner_did, linked_party, due_at, source_refs }`.
+- No double-entry bookkeeping here. Budget items are **program-level operational planning records**; treasury remains in `icn-ledger`. If/when a budget item is realized financially, it references a ledger journal entry by ID — but BudgetItem itself does not post ledger entries.
+
+### 2.3 Sled stores + HTTP
+
+- `SledSponsorStore`, `SledBudgetItemStore` in `apps/governance/src/manager.rs`.
+- Endpoints per §13 of the architecture spec.
+
+### 2.4 Sponsor → Budget + Action auto-materialization
+
+- On `Sponsor.status → Confirmed`: emit `SponsorStatusChanged`, auto-create a `BudgetItem { direction: Income, status: Forecast, amount: sponsor.amount, linked_party: sponsor.entity_ref }`, and auto-create a recognition `ActionItem` with `parent = InstitutionalParent::Activity(program_activity_id)` assigned to the marketing-committee lead role holder.
+- Use a deterministic materialization pattern (keyed by sponsor ID + event) so retries are idempotent.
+
+### 2.5 Gateway events
+
+- `SponsorStatusChanged`, `BudgetItemCreated`, `BudgetItemUpdated`.
+
+### 2.6 Scenario tests
+
+- S5 (sponsor pipeline → budget → action).
+- Idempotence: re-emitting `SponsorStatusChanged(Confirmed)` does not duplicate the budget item or action item.
+
+### 2.7 Exit condition
+
+PR merged; NYCN can track sponsor prospects and confirmed funders with automatic budget and recognition follow-ups.
+
+---
+
+## 4. Tranche 3 — Session + Registration + Accessibility
+
+**Entry condition**: Tranche 1 merged. Parallelizable with Tranche 2.
+**Scope**: Large.
+**Branch**: `feat/session-registration`.
+
+### 3.1 Add `icn-governance::session`
+
+- `Session { id, program_id, title, track, format, speaker_dids, status, language_needs, publication_state, representation: RepresentationMetadata, source_refs }`.
+- `SessionStatus { Idea, Invited, Confirmed, Published, Cancelled }`.
+- `RepresentationMetadata { sector, geography, language, cooperative_type }` — all `Option<String>`, used for representation dashboards.
+
+### 3.2 Add `icn-governance::registration`
+
+- `Registration { id, program_id, actor_did, ticket_type, payment_state, dietary_needs, childcare_needs, language_needs, accessibility_notes, volunteer_interest, organizer_interest, checkin_state, source_refs }`.
+- `ChildcareNeed { None, RequestedOnSite, RequestedNearSite, PartialCoverage }`.
+
+### 3.3 Add `icn-governance::accessibility`
+
+- `VenueAccessibility { transit_score, hotel_walkability_score, childcare_fit, interpretation_supported, sobriety_friendly, navigation_clarity_score, restroom_inclusion_notes, family_support_notes, environmental_quality_notes }`.
+- `AccessibilityScore { Poor, Fair, Good, Excellent, Unknown }`.
+- Embed on `Program.metadata.venue_accessibility` (serde passthrough) or as a first-class optional field on Program — prefer first-class.
+
+### 3.4 Sled stores + HTTP
+
+- `SledSessionStore`, `SledRegistrationStore`.
+- Endpoints per §13 of architecture spec.
+- `GET /gov/programs/{id}/accessibility-status` — composes venue accessibility + aggregated registration accessibility needs into a single status struct.
+- `GET /gov/programs/{id}/representation` — aggregates `Session.representation` fields into buckets.
+
+### 3.5 Gateway events
+
+- `SessionPublished`, `SessionStatusChanged`, `RegistrationConfirmed`, `RegistrationCheckedIn`.
+
+### 3.6 Scenario tests
+
+- S4 (registration accessibility feedback).
+- Representation bucket aggregation returns stable counts under rapid session status changes.
+
+### 3.7 Exit condition
+
+PR merged; attendee and content dashboards populate; logistics committee can query accessibility status.
+
+---
+
+## 5. Tranche 4 — SourceRef + ny-coop-net importer
+
+**Entry condition**: Tranches 2 + 3 merged (SourceRef is attached to sponsor/budget/session/registration records from day 1 going forward, but the importer populates historical data).
+**Scope**: Medium Rust + scripts.
+**Branches**: `feat/source-ref` (docs-touching Rust), `chore/nycn-importer` (binary/script).
+
+### 4.1 Add `icn-governance::source_ref`
+
+- `SourceSystem { GoogleDoc, GoogleSheet, DriveFile, LegacyRepo, MailingList, NyCoopNetRow, ManualEntry, Other(String) }`.
+- `ProvenanceType { Linked, Mirrored, Imported, Derived }`.
+- `SourceRef` struct as specified.
+- Attach `source_refs: Vec<SourceRef>` field (`#[serde(default)]`) to: `Program`, `Sponsor`, `BudgetItem`, `Session`, `Registration`, `InstitutionalDocument` (when Tranche 5 lands), and any entity/participation records created via import.
+
+### 4.2 `bins/icn-nycn-import` (or `scripts/nycn-importer/`)
+
+- Reads ny-coop-net Postgres (connection string via env).
+- Maps tables → canonical ICN objects:
+  - `organizations` → `Entity { type: Cooperative | Community }` or `Participation { type: MemberOrg }` depending on relation
+  - `members` → `Participation { type: Member }` linked to entities
+  - `events` / `summits` → `Activity` or `Program` (summit years as Program, misc events as Activity)
+  - `sponsors` → `Sponsor` with status mapped from legacy state
+  - `registrations` → `Registration`
+- **All imported records carry `SourceRef { source_system: NyCoopNetRow, external_identifier: "<table>:<pk>", provenance_type: Imported }`.**
+- Writes via the gateway HTTP API — never directly to sled — so validation is exercised identically to normal create flows.
+- Idempotent: re-running must not duplicate. Dedup by (source_system, external_identifier).
+
+### 4.3 Scenario tests
+
+- Import + re-import does not duplicate.
+- Random-sample verification: pick 10 ny-coop-net rows, assert each maps to an ICN record with matching `SourceRef`.
+- Provenance round-trip: `GET /gov/provenance/<id>` returns the source ref.
+
+### 4.4 Exit condition
+
+- NYCN can be bootstrapped on a fresh ICN node by running the importer. Historical sponsor pipeline, summit attendees, and member orgs are present with provenance links to ny-coop-net.
+
+---
+
+## 6. Tranche 5 — InstitutionalDocument + cross-object provenance
+
+**Entry condition**: Tranche 4 merged.
+**Scope**: Large. Design-Opus, implementation-Sonnet.
+**Branch**: `feat/institutional-documents`.
+
+### 6.1 Add `icn-governance::document`
+
+- Content-addressed (`id = blake3(body)`).
+- `DocumentType { MeetingAgenda, MeetingMinutes, CommitteeReport, Policy, Evaluation, General }`.
+- Linked-to-scope via `InstitutionalParent` OR linked to a specific meeting/proposal instance.
+- Version lineage via `parent_doc`.
+- `attachments: Vec<AttachmentRef>` (each attachment is content-addressed separately).
+
+### 6.2 Gossip integration
+
+- Topic: `governance:{domain_id}:documents`.
+- Published as gossip entries; content-addressed so replication is automatic via existing protocol.
+- Sled indexes: `doc:<domain>:<doc_id>`, `doc_idx:<domain>:<type>:<timestamp>`, `doc_link:<scope_tag>:<scope_id>:<doc_id>`.
+
+### 6.3 HTTP surface
+
+- `POST /gov/documents`, `GET /gov/documents/{id}`, version-history list, search.
+
+### 6.4 Meeting notes linkage
+
+- `Meeting.notes_doc: Option<DocumentId>` (add field now, defaulting to `None`, on the meeting model so post-meeting summaries can attach the minutes document).
+
+### 6.5 Provenance surfacing
+
+- `GET /gov/history/{ref}` — walks the provenance chain. Given an `ActionItem`, returns: action → meeting → agenda item → decision (proposal) → accepted tally → originating documents.
+- `GET /gov/provenance/{ref}` — raw provenance edges only.
+
+### 6.6 Scenario tests
+
+- S7 (provenance chain).
+- Cross-node gossip: document created on node A is retrievable and hash-verifiable on node B.
+- Version lineage: v1 → v2 → v3 queryable by parent_doc chain.
+
+### 6.7 Exit condition
+
+- A new organizer can walk from their action item inbox back through meetings, decisions, and supporting documents to understand the full lineage of any obligation.
+
+---
+
+## 7. Tranche 6 — RoleDelegation + Organizer Onboarding
+
+**Entry condition**: Tranche 5 merged.
+**Scope**: Medium.
+**Branch**: `feat/role-delegation-onboarding`.
+
+### 7.1 Add `icn-governance::role_delegation`
+
+- Distinct from vote-delegation (`icn-governance::delegation`).
+- `RoleDelegation { id, grantor_did, grantee_did, scope_ref, capabilities, starts_at, ends_at, reason, revoked_at }`.
+- Sled store + HTTP (`POST /gov/role-delegations`, `POST /gov/role-delegations/{id}/revoke`, `GET /gov/me/delegations`).
+- Active-scope resolution in the gateway includes active delegations within time window.
+
+### 7.2 Add `icn-governance::onboarding`
+
+- `OnboardingPipelineEntry { id, actor_did, pipeline_type (interest | orientation | role-assigned | first-task | continuity), status, created_at, promoted_at, structure_interest: Option<StructureId>, notes }`.
+- HTTP: `POST /gov/onboarding`, `PATCH /gov/onboarding/{id}/advance`, `GET /gov/onboarding`.
+- View: `OrganizerOnboardingView` — pipeline state + next actions per entry.
+
+### 7.3 Scenario tests
+
+- Delegation grant → grantee acts in scope → revocation → grantee loses capability.
+- Onboarding pipeline traversal: interest → role-assigned → first-task completion.
+- S6 (cycle closure + handoff): closed program's role assignments do not block new organizers onboarding to the next cycle's program.
+
+### 7.4 Exit condition
+
+- Organizers can be onboarded and delegated to with full auditability; annual cycle handoff leaves clean state.
+
+---
+
+## 8. Docs and charter work (parallel / continuous)
+
+These are **not** code tranches but must progress alongside:
+
+### 8.1 After Tranche 0 lands
+
+- Update `docs/strategy/NYCN-Implementation-Plan.md`: Phase 3 (meetings) → ✅, Phase 4 (digests) → ✅ for v1; add v1.1 (scope partitioning) as a note.
+- Update `docs/INDEX.md` to reference this architecture spec and matrix docs.
+
+### 8.2 After Tranche 1 lands
+
+- Revise `docs/strategy/NYCN-Institutional-Design.md`:
+  - Replace the committee-as-Community entity-tree diagram with the Structure-based topology.
+  - Add Program wrapping.
+  - Note that the older entity tree is superseded.
+- Add `docs/strategy/NYCN-Bootstrap-Runbook.md` (does not currently exist despite prior-session claim).
+
+### 8.3 After Tranche 4 lands
+
+- Add `docs/strategy/NYCN-Schema-Mapping.md` documenting the ny-coop-net → ICN mapping actually implemented by the importer.
+
+### 8.4 NYCN Charter YAML
+
+- `docs/strategy/NYCN-Charter-Draft.yaml` exists. When Tranche 1 lands, update the charter YAML to declare programs and milestones if the CCL schema supports them. If not, open a CCL extension proposal.
+
+---
+
+## 9. Rollback and risk mitigation
+
+### 9.1 Tranche rollback rule
+
+Each tranche is independently revertable via `gh pr revert`. Specifically:
+
+- Reverting Tranche 0 restores digest-less, meeting-less state — no data loss.
+- Reverting Tranche 1 requires first reverting all later tranches that reference Program. Phase gate: if Tranche 1 has problems, no later tranche should have merged.
+- Tranches 2 and 3 are independently revertable from each other.
+- Tranche 4 importer bugs do not require code revert — `SourceRef`-tagged records can be bulk-deleted by source-system filter.
+- Tranche 5 documents are content-addressed; reverting the code still leaves gossiped documents on peer nodes. Plan a clean-shutdown migration if this becomes a live concern.
+
+### 9.2 Load-bearing risks
+
+| Risk | Mitigation |
+|------|------------|
+| Program/Activity overlap confusion | Clear docstring separation; both primitives kept but linter/docs explain when to use which |
+| Authority ambiguity (backbone vs full group) | Model via `RoleAssignment.authority_type` + PolicyOracle rules, not hardcoded logic |
+| Endpoint sprawl | No sponsor/budget/session/registration endpoints before Tranche 1 lands |
+| Spreadsheet-shaped architecture | All imported data carries `SourceRef`; canonical shape is ICN-native, not sheet-derived |
+| Meaning firewall breach | No NYCN-specific strings in kernel crates; only in seed data and test fixtures |
+| Digest staleness / index drift | Every new secondary index includes backfill-on-init with version marker |
+| Migration double-import | Idempotent import keyed on (source_system, external_identifier) |
+
+---
+
+## 10. Agent assignments
+
+| Tranche | Suggested agent(s) | Reason |
+|---------|-------------------|--------|
+| 0a (merge #1543) | human review + `icn-rust-core` for any review fixes | meaning-firewall sensitive |
+| 0b (digest rework) | `icn-rust-core` | index backfill + store composition |
+| 1 (Program + Milestones) | `icn-governance-advisor` design + `icn-rust-core` impl | governance state machine correctness |
+| 2 (Sponsor + Budget) | `icn-governance-advisor` + `icn-economics-advisor` on the budget/ledger boundary | ledger boundary risk |
+| 3 (Session + Registration + Accessibility) | `icn-rust-core` with `icn-governance-advisor` review | operational domains |
+| 4 (SourceRef + importer) | `icn-rust-core` + human operator for the importer binary | touches external DB |
+| 5 (Documents + gossip) | `icn-gossip-net` + `icn-rust-core` + `icn-governance-advisor` | gossip integration |
+| 6 (RoleDelegation + Onboarding) | `icn-identity-iam-advisor` + `icn-governance-advisor` | IAM + governance crossover |
+
+Every tranche also gets one pass by `icn-invariants-guardian` before merge.
+
+---
+
+## 11. Success criteria (the decisive test)
+
+> Can a new organizer enter the system mid-cycle, switch into the right scope, see the summit's current phase, understand what was decided, know what is blocked, receive their obligations, trace why they exist, and continue the work without needing private oral history?
+
+| Tranche | What this enables toward the decisive test |
+|---------|-------------------------------------------|
+| 0 | Meetings recorded; overdue work surfaces in digest |
+| 1 | New organizer can see summit's current phase (milestones) + their scope |
+| 2 | New organizer can see funding state and follow-ups without asking |
+| 3 | New organizer can see content + attendees + accessibility status |
+| 4 | Historical context from ny-coop-net is present with provenance |
+| 5 | New organizer can walk back from any obligation to the document that originated it |
+| 6 | New organizer can be onboarded with delegated scope without oral handoff |
+
+When Tranche 6 is merged and a migration has happened, the decisive test returns "yes" for the first time.
+
+---
+
+## 12. Start line
+
+- **Immediate next action**: Push `feat/notification-digests` rework is blocked until #1543 is reviewed + merged. So **the very next action is: request human review on PR #1543**.
+- Second action: once #1543 is merged, rebase `feat/notification-digests` on main, apply the digest-rework list in §2.0b, push, open PR.
+- Third action: design review for Tranche 1 (`Program` module) with `icn-governance-advisor` and `icn-invariants-guardian` on the proposed module shape before opening a branch.
+
+Do not start Tranche 2+ branches until Tranche 1 is under review.

--- a/docs/strategy/NYCN-Execution-Tranches.md
+++ b/docs/strategy/NYCN-Execution-Tranches.md
@@ -54,12 +54,15 @@ Tranches 2 and 3 parallelize once 1 lands. Tranche 4 can start research/scriptin
 - **Required rework before opening the PR**:
   1. **Rebase on post-#1543 main**. Old base (`37ec91e0`) is before meetings land.
   2. **Unstub `upcoming_meetings`** in `GovernanceManager::generate_digest`. Use `SledMeetingStore::list_for_scope` (or equivalent) filtered to `scheduled_at` within the next 48h, where scope is derived from the requesting DID's role assignments.
-  3. **Add assignee-index backfill** to `SledActionItemStore::open` (or equivalent init path). Write a `_meta:idx_version:assignee` marker; if missing or below current version, walk all action items once and populate the secondary index. Add a unit test for the backfill on a pre-populated store.
-  4. **Keep scope partitioning out of scope for this PR** — it's a v1.1 concern; PR scope is "correct DID-level digest".
-  5. Add a scenario test: create proposals, action items, and a meeting; call digest; verify all three sections populate correctly.
+  3. **Rename the assignee index** to follow the existing `<thing>_by_<scope>` convention: `action_item_by_assignee:{did}:{domain_id}:{item_id}` (not `ai_idx:assignee:*`). Match how `SledStructureStore` / `SledActivityStore` name their secondary keys on `main`.
+  4. **Add assignee-index backfill** to `SledActionItemStore::open` (or equivalent init path). Write a `_meta:idx_version:assignee` marker; if missing or below current version, walk all action items once and populate the secondary index. Add a unit test for the backfill on a pre-populated store.
+  5. **Add `GovernanceActionItemCreated` gateway event** — emit from `apps/governance/src/actor.rs` where the decision→action bridge materializes items. This is ~20 LOC and lets the digest architecture (and every future consumer) be event-driven from the start instead of store-polling. Variant fields: `{ item_id, domain_id, linked_proposal, assignee }`. Follow the existing `Governance<Thing><Verb>` naming pattern.
+  6. **Keep scope partitioning out of scope for this PR** — it's a v1.1 concern; PR scope is "correct DID-level digest".
+  7. Add a scenario test: create proposals with `action_items_on_accept`, close them, verify `GovernanceActionItemCreated` fires, and that the digest reflects the materialized items plus upcoming meetings.
 - **PR body must call out**:
   - Depends on #1543 (meeting store).
-  - Notes that `SledActionItemStore` assignee index is being introduced — CI must pass on both empty and pre-populated stores.
+  - Notes that `SledActionItemStore` assignee index is being introduced under the `<thing>_by_<scope>` naming convention — CI must pass on both empty and pre-populated stores.
+  - Introduces `GovernanceActionItemCreated` gateway event (first non-proposal governance-event variant).
 - **Exit condition**: PR open, CI green, review approved, merged.
 
 ### Tranche 0 risks
@@ -97,7 +100,8 @@ Tranches 2 and 3 parallelize once 1 lands. Tranche 4 can start research/scriptin
 
 ### 1.4 Gateway events
 
-- `ProgramOpened`, `ProgramClosed`, `MilestoneCompleted`, `MilestoneBlocked`.
+- `GovernanceProgramOpened`, `GovernanceProgramClosed`, `GovernanceMilestoneCompleted`, `GovernanceMilestoneBlocked`. Follow the existing `Governance<Thing><Verb>` naming pattern on `GatewayEvent`.
+- Also emit `GovernanceStructureCreated`, `GovernanceRoleAssigned`, `GovernanceActivityCreated`, `GovernanceActivityStatusChanged` here if Tranche 0b has not already added them — these were assumed present in earlier planning but are **not** on `main`.
 
 ### 1.5 Scope-partitioned digest (v1.1 of digest)
 

--- a/docs/strategy/NYCN-Implementation-Matrix.md
+++ b/docs/strategy/NYCN-Implementation-Matrix.md
@@ -1,0 +1,331 @@
+# NYCN × ICN Implementation Matrix
+
+**Status**: Execution ledger, grounded against `main` at `37ec91e0` (2026-04-14)
+**Companions**: `NYCN-Repo-Architecture-Spec.md` (architectural map), `NYCN-Execution-Tranches.md` (merge-order plan)
+**Working instruction**: Treat the architecture spec as the map and this matrix as the execution ledger. Before writing code, reconcile any disagreement between them and current repo state — reality wins.
+
+---
+
+## Legend
+
+**Lifecycle**
+- ✅ **exists** — canonical state lives on `main`, tests passing
+- 🚧 **partial** — work exists but not on `main` (see `Source` column)
+- ⚠️ **adjacent** — something close exists but does not fully cover the need
+- ❌ **missing** — no code, no branch
+
+**Source** (mechanical state)
+- `main` — merged into `main`, covered by CI on `main`
+- `open_pr` — on an open pull request targeting `main`
+- `branch_only` — local/remote branch with no PR yet opened
+- `spec_only` — described in docs, no code
+- `external` — lives in a non-governance crate (e.g., `icn-entity`, `icn-ledger`)
+
+**Touch points** (expected implementation surfaces per row)
+- `D` domain module in `icn-governance::<name>`
+- `S` sled store in `apps/governance/src/manager.rs`
+- `M` `GovernanceManager` wiring
+- `Hm` HTTP models in `apps/governance/src/http/models.rs`
+- `Hh` HTTP handlers/routes in `apps/governance/src/http/{handlers,configure}.rs`
+- `E` gateway event variant(s) in `icn-gateway::events`
+- `T` unit + scenario tests
+- `SDK` regenerate `sdk/typescript/src/generated/api-types.ts`
+
+---
+
+## 1. Canonical objects
+
+| Object | Status | Source | Code location (existing or proposed) | Touch points (remaining) | Next move | Blockers / deps |
+|--------|--------|--------|--------------------------------------|-------------------------|-----------|-----------------|
+| Entity (Federation / Cooperative / Community / Individual) | ✅ | `external` | `icn-entity` | — | Use as-is for NYCN, nycn-organizers, member co-ops | — |
+| Did / Actor | ✅ | `external` | `icn-identity` | — | — | — |
+| Governance domain | ✅ | `main` | `icn-governance::domain` | — | One domain per entity + optionally per structure | — |
+| Proposal + Vote + Tally + Profile | ✅ | `main` | `icn-governance::{proposal,vote,tally,profile}` | — | — | — |
+| Consent mode (`DecisionMode::Consent`, `max_objections`) | ✅ | `main` | `icn-governance::{config,profile}` | — | — | #1533 merged |
+| ActionItem **core** (type, sled store, HTTP) | ✅ | `main` | `icn-governance::action_item`, `apps/governance/src/manager.rs::SledActionItemStore` | — | — | — |
+| ActionItem `parent: InstitutionalParent` field | ✅ | `main` | `icn-governance::action_item::ActionItem.parent` | — | — | #1540 merged |
+| ActionItem `linked_proposal` + decision→action bridge | ✅ | `main` | `icn-governance::proposal::ActionItemSpec`, `apps/governance/src/actor.rs` | — | — | #1532 merged |
+| ActionItem `meeting_id: Option<MeetingId>` field | 🚧 | `open_pr` (#1543) | `icn-governance::action_item` (on meeting branch) | T (on land) | Merge #1543 | — |
+| ActionItem **assignee secondary index** (`ai_idx:assignee:<did>:<id>`) | 🚧 | `branch_only` | `apps/governance/src/manager.rs::SledActionItemStore` (on `feat/notification-digests`) | S, T (backfill test) | Open PR; add backfill-on-init with `_meta:idx_version:assignee` marker | #1543 merge first |
+| ActionItem **assignee-index backfill** for pre-existing items | ❌ | `spec_only` | same file | S, T | Add on same PR as above | — |
+| ActionItem secondary indexes (`ai_idx:parent:*`, `ai_idx:status:*`) | ❌ | `spec_only` | same file | S, T | Add alongside parent-scoped / status-scoped queries (Phase 1 views) | Program views |
+| ActionItemSpec (proposal materialization) | ✅ | `main` | `icn-governance::proposal::ActionItemSpec` | — | — | #1532 |
+| Structure (Committee / WorkingGroup / Team / Office) | ✅ | `main` | `icn-governance::structure`, `apps/governance/src/manager.rs::SledStructureStore` | — | Seed NYCN committees via charter bootstrap | #1540 |
+| RoleAssignment | ✅ | `main` | `icn-governance::structure::RoleAssignment` | Hh (`GET /me/scopes` handler missing) | Add `GET /me/scopes` in Tranche 1 | — |
+| Activity (Event / Program / Project / Initiative) | ✅ | `main` | `icn-governance::activity`, `apps/governance/src/manager.rs::SledActivityStore` | — | Keep; wrap into Program for stage-gated cycles | #1540 |
+| InstitutionalParent (polymorphic attachment) | ✅ | `main` | `icn-governance::parent` | — | Use for every new operational object | #1540 |
+| Charter + CharterStore | ✅ | `main` | `icn-governance::{charter,charter_store}` | — | Use NYCN charter YAML draft | — |
+| Steward (SDIS) | ✅ | `main` | `icn-governance::{steward,steward_store}` | — | — | — |
+| Delegation (vote-level) | ✅ | `main` | `icn-governance::delegation` | — | Distinct from operational RoleDelegation (Phase 6) | — |
+| Gateway events (proposal / action / structure / activity) | ✅ | `main` | `icn-gateway::events` | — | Extend per-object | — |
+| **Meeting** + AgendaItem + attendance + SledMeetingStore + 9 HTTP endpoints | 🚧 | `open_pr` (#1543) | `icn-governance::meeting`, `apps/governance/src/manager.rs::SledMeetingStore`, handlers | T (on land) | Human review + merge #1543 | Benchmark regression tag; no blocking human review yet |
+| Meeting-lifecycle events (`MeetingCreated/Started/Ended`) | 🚧 | `open_pr` (#1543) | `icn-gateway::events` | — | Lands with #1543 | — |
+| **DigestSummary** + `GET /digest` + `list_by_assignee` | 🚧 | `branch_only` | `apps/governance/src/manager.rs`, handlers | Hh, T | PR it after #1543 merges; unstub `upcoming_meetings` against meeting store | #1543 |
+| **Program** + ProgramStatus + ProgramKind | ❌ | `spec_only` | proposed `icn-governance::program` | D, S, M, Hm, Hh, E, T, SDK | Tranche 1 | — |
+| **Milestone** + MilestoneType + required_checks | ❌ | `spec_only` | proposed `icn-governance::program::Milestone` | D, Hm, Hh, E, T | Same PR as Program | — |
+| **CheckRef** (milestone predicates) | ❌ | `spec_only` | proposed `icn-governance::program::checks` | D, T | Same PR as Program; enum + evaluator | — |
+| Scope-partitioned digest (`DigestScope::{Structure,Program,Entity,All}`) | ❌ | `spec_only` | `apps/governance/src/manager.rs` | Hm, Hh, T | Tranche 1 (after base digest lands) | — |
+| MyScope view (`GET /me/scopes`) | ❌ | `spec_only` | `apps/governance/src/http/handlers.rs` | Hh, T, SDK | Tranche 1 (trivial) | — |
+| MyWork view (`GET /me/work`) | ❌ | `spec_only` | `apps/governance/src/http/handlers.rs` | Hh, T, SDK | Tranche 1 | — |
+| ProgramDashboardView | ❌ | `spec_only` | `apps/governance/src/http/views.rs` (new file) | Hh, T, SDK | Tranche 1 | Program |
+| **Participation** (non-authority: sponsor-contact / speaker / attendee / volunteer) | ❌ | `spec_only` | proposed `icn-governance::participation` OR `icn-entity` extension | D, S, M, Hm, Hh, T, SDK | Decide location before Tranche 2 | — |
+| **Sponsor** | ❌ | `spec_only` | proposed `icn-governance::sponsor` | D, S, M, Hm, Hh, E, T, SDK | Tranche 2 | Program |
+| **BudgetItem** | ❌ | `spec_only` | proposed `icn-governance::budget_item` | D, S, M, Hm, Hh, E, T, SDK | Tranche 2 | Program |
+| **Session** | ❌ | `spec_only` | proposed `icn-governance::session` | D, S, M, Hm, Hh, E, T, SDK | Tranche 3 | Program |
+| **Registration** | ❌ | `spec_only` | proposed `icn-governance::registration` | D, S, M, Hm, Hh, E, T, SDK | Tranche 3 | Program |
+| **VenueAccessibility + AccessibilityScore** | ❌ | `spec_only` | proposed `icn-governance::accessibility` | D, Hm, T, SDK | Tranche 3 (ship with Registration) | — |
+| RepresentationMetadata | ❌ | `spec_only` | field on `Session` | D, T, SDK | Tranche 3 | Session |
+| **SourceRef** (Linked/Mirrored/Imported/Derived) | ❌ | `spec_only` | proposed `icn-governance::source_ref` | D, Hm, T, SDK (field on Program/Sponsor/etc.) | Tranche 4 | Target objects must exist |
+| **ny-coop-net importer** | ❌ | `spec_only` | proposed `bins/icn-nycn-import` or `scripts/nycn-importer/` | binary/script, T | Tranche 4 | SourceRef + target objects |
+| **InstitutionalDocument** (content-addressed, versioned) | ❌ | `spec_only` | proposed `icn-governance::document` | D, S, M, Hm, Hh, E, T, SDK; gossip topic | Tranche 5 | — |
+| AttachmentRef | ❌ | `spec_only` | inside `document` module | D, T | Ships with Document | — |
+| Meeting.notes_doc field | ❌ | `spec_only` | `icn-governance::meeting` | D, Hm, T | Ships with Document (Tranche 5), add field now as `Option<DocumentId>` default None when #1543 lands OR as part of Tranche 5 | #1543 first |
+| **RoleDelegation** (operational, distinct from vote delegation) | ❌ | `spec_only` | proposed `icn-governance::role_delegation` | D, S, M, Hm, Hh, T, SDK | Tranche 6 | — |
+| **OrganizerOnboardingPipeline** | ❌ | `spec_only` | proposed `icn-governance::onboarding` | D, S, M, Hm, Hh, T, SDK | Tranche 6 | — |
+| CycleComparisonView | ❌ | `spec_only` | `apps/governance/src/http/views.rs` | Hh, T, SDK | Tranche 6 or later | Program.parent_program_id |
+| DigestPacket (persisted digest for delivery history) | ❌ | `spec_only` | later | — | Defer | — |
+
+---
+
+## 2. Bounded domains → module map
+
+| Domain | Module (existing/proposed) | Status | Source |
+|--------|---------------------------|--------|--------|
+| Identity & participation (authority) | `icn-identity`, `icn-entity`, `icn-governance::{membership, structure::RoleAssignment}` | ✅ | `main` / `external` |
+| Identity & participation (non-authority) | proposed `icn-governance::participation` OR `icn-entity::participation` | ❌ | `spec_only` |
+| Institutional structure | `icn-governance::structure` | ✅ | `main` |
+| Governance | `icn-governance::{proposal,vote,tally,profile,config,discussion,appeal,amendment}` + `apps/governance/src/actor.rs` | ✅ | `main` |
+| Program / cycle | proposed `icn-governance::program` | ❌ | `spec_only` |
+| Meeting | `icn-governance::meeting` | 🚧 | `open_pr` #1543 |
+| Work execution | `icn-governance::action_item` + bridge | ✅ | `main` |
+| Communications / digests (DID-level) | `apps/governance::manager::DigestSummary` | 🚧 | `branch_only` |
+| Communications / digests (scope-partitioned, pre-/post-meeting packets) | proposed extensions | ❌ | `spec_only` |
+| Funding / treasury | `icn-ledger` | ✅ | `external` |
+| Funding / sponsor pipeline | proposed `icn-governance::sponsor` | ❌ | `spec_only` |
+| Funding / program budget | proposed `icn-governance::budget_item` | ❌ | `spec_only` |
+| Content / session | proposed `icn-governance::session` | ❌ | `spec_only` |
+| Registration / attendee | proposed `icn-governance::registration` | ❌ | `spec_only` |
+| Archive / provenance (decisions) | `icn-governance::proof` | ✅ | `main` |
+| Archive / provenance (source refs) | proposed `icn-governance::source_ref` | ❌ | `spec_only` |
+| Archive / provenance (documents) | proposed `icn-governance::document` | ❌ | `spec_only` |
+
+---
+
+## 3. Authority & scope gaps
+
+| Gap | Proposal | Status | Source |
+|-----|----------|--------|--------|
+| No API to enumerate current user's scopes | `GET /me/scopes` handler | ❌ | `spec_only` |
+| Gateway JWT does not carry explicit active-scope | `X-ICN-Active-Scope` header or JWT claim; server-side resolution against `RoleAssignment` | ❌ | `spec_only` |
+| Operational role-delegation record (distinct from vote delegation) | New `icn-governance::role_delegation` | ❌ | `spec_only` (Tranche 6) |
+| Backbone-group authority (political debt) | `Structure { kind: Committee }` on `nycn-organizers` + PolicyOracle rule requiring parent-domain ratification for certain proposal types | ⚠️ | Structure exists (`main`); oracle rule `spec_only` |
+| Ratification flow (committee → network) | Proposal-type metadata + companion proposal auto-opened in parent domain | ❌ | `spec_only` |
+
+---
+
+## 4. Storage indexes
+
+| Store | Index | Status | Source | Required for |
+|-------|-------|--------|--------|--------------|
+| `SledActionItemStore` | `ai_idx:assignee:<did>:<id>` | 🚧 | `branch_only` | Digest performance |
+| `SledActionItemStore` | assignee-index backfill on init | ❌ | `spec_only` | Correctness for pre-existing items |
+| `SledActionItemStore` | `ai_idx:parent:<parent_tag>:<parent_id>:<id>` | ❌ | `spec_only` | Scope-scoped queries |
+| `SledActionItemStore` | `ai_idx:status:<status>:<id>` | ❌ | `spec_only` | Dashboard counts |
+| `SledStructureStore` | `structure_idx:parent_entity:<id>:<sid>` | ⚠️ | verify on `main` | Committee listing |
+| `SledActivityStore` | `activity_idx:parent_entity:<id>:<aid>` | ⚠️ | verify on `main` | Activity listing |
+| `SledMeetingStore` | `meeting_idx:scope:<tag>:<id>:<scheduled_at>:<mid>` | ⚠️ | verify on #1543 | Upcoming meetings within 48h for digest |
+| `SledProgramStore` | primary + parent-entity + status + kind indexes | ❌ | `spec_only` | All program views |
+| `SledSponsorStore` | `sponsor_idx:program:<pid>:<sid>` + `...:status:...` | ❌ | `spec_only` | Sponsor pipeline view |
+| `SledBudgetItemStore` | `budget_idx:program:<pid>:<bid>` | ❌ | `spec_only` | Program budget view |
+| `SledSessionStore` | `session_idx:program:<pid>:<sid>` + `...:status:...` | ❌ | `spec_only` | Program content view |
+| `SledRegistrationStore` | `registration_idx:program:<pid>:<rid>` + `...:actor:<did>:...` | ❌ | `spec_only` | Attendee counts, user's registrations |
+| `SledDocumentStore` | `doc_idx:<domain>:<type>:<timestamp>` + `doc_link:<scope>:<id>:<doc_id>` | ❌ | `spec_only` | Phase 5 document queries |
+
+**Migration-safe index rule**: every new index gets a `_meta:idx_version:<name>` marker. On store init, if absent or below current version, walk rows and populate. Test coverage must include both "empty store" and "pre-populated store".
+
+---
+
+## 5. Gateway events
+
+| Event | Status | Source |
+|-------|--------|--------|
+| `ProposalOpened/Accepted/Rejected` | ✅ | `main` |
+| `ActionItemCreated/Updated/Completed` | ⚠️ | verify coverage in `events.rs` on `main` |
+| `StructureCreated`, `RoleAssigned` | ⚠️ | verify on `main` (via #1540) |
+| `ActivityCreated`, `ActivityStatusChanged` | ⚠️ | verify on `main` (via #1540) |
+| `MeetingCreated/Started/Ended` | 🚧 | `open_pr` #1543 |
+| `ProgramOpened/Closed`, `MilestoneCompleted/Blocked` | ❌ | `spec_only` (Tranche 1) |
+| `SponsorStatusChanged` | ❌ | `spec_only` (Tranche 2) |
+| `BudgetItemCreated/Updated` | ❌ | `spec_only` (Tranche 2) |
+| `SessionPublished`, `SessionStatusChanged` | ❌ | `spec_only` (Tranche 3) |
+| `RegistrationConfirmed`, `RegistrationCheckedIn` | ❌ | `spec_only` (Tranche 3) |
+| `DocumentCreated`, `DocumentUpdated` | ❌ | `spec_only` (Tranche 5) |
+
+---
+
+## 6. HTTP API surface
+
+### 6.1 On `main`
+
+- `POST/GET /gov/domains/...`, `POST /gov/proposals`, vote/close
+- `POST/GET /gov/action-items`, `PATCH /gov/action-items/{id}`
+- `POST/GET /gov/structures`, `POST /gov/structures/{id}/roles`
+- `POST/GET /gov/activities`
+
+### 6.2 On PR #1543
+
+- `POST /gov/meetings`, `GET`, `GET /{id}`, `PATCH /{id}`
+- `POST /gov/meetings/{id}/agenda-items`, `PATCH .../{aid}`
+- `POST /gov/meetings/{id}/start`, `POST .../end`
+- Attendance endpoint (verify exact shape against impl)
+
+### 6.3 On `feat/notification-digests`
+
+- `GET /gov/digest?did=...`
+
+### 6.4 Proposed per tranche
+
+- **Tranche 1 (Program)**: `/gov/programs` CRUD, `/{id}/milestones` CRUD, `/{id}/close`, `/{id}/dashboard`; `/me/scopes`, `/me/work`; scope-partitioned `/gov/digest?scope=...`
+- **Tranche 2 (Funding)**: `/gov/sponsors` CRUD, `/gov/programs/{id}/sponsors`, `/gov/budget-items` CRUD, `/gov/programs/{id}/budget`
+- **Tranche 3 (Content/Attendees)**: `/gov/sessions` CRUD, `/gov/programs/{id}/sessions`, `/gov/registrations` CRUD, `/gov/programs/{id}/registrations`, `/gov/programs/{id}/accessibility-status`, `/gov/programs/{id}/representation`
+- **Tranche 4 (Migration)**: provenance reads `/gov/history/{ref}`, `/gov/provenance/{ref}` (if not deferred to Tranche 5)
+- **Tranche 5 (Documents)**: `/gov/documents` CRUD, version history, search
+- **Tranche 6 (IAM/Onboarding)**: `/gov/role-delegations` CRUD, `/gov/onboarding` CRUD
+
+### 6.5 SDK drift
+
+Every added model in `apps/governance/src/http/models.rs` → regenerate `sdk/typescript/src/generated/api-types.ts` → commit as `chore(sdk): regenerate TypeScript API types` (no mixed commits).
+
+---
+
+## 7. Derived views
+
+| View | Data available? | Implementable today? | Tranche |
+|------|----------------|---------------------|---------|
+| MyActionQueueView | ✅ | 🚧 partial (digest branch) | 0 |
+| MyScopeView | ✅ | ❌ (no handler) | 1 |
+| MyWorkView | ✅ | ❌ | 1 |
+| ProgramDashboardView | ❌ | ❌ | 1 |
+| CommitteeOperationalView | ⚠️ | ⚠️ needs composition handler | 1 |
+| SponsorPipelineView | ❌ | ❌ | 2 |
+| AccessibilityStatusView | ❌ | ❌ | 3 |
+| RepresentationDashboardView | ❌ | ❌ | 3 |
+| PostMeetingSummaryView | 🚧 | 🚧 (lands with #1543) | 0 |
+| CycleComparisonView | ❌ | ❌ | 1+6 |
+| OrganizerOnboardingView | ❌ | ❌ | 6 |
+
+---
+
+## 8. External integration status
+
+| Source | Today | Target | Tranche |
+|--------|-------|--------|---------|
+| Google Docs planning notes | none | `SourceRef { system: GoogleDoc, provenance: Linked }` | 4 |
+| Google Sheets planning workbook | none | Linked + selective Imported rows (sponsor, budget) | 4 |
+| Summit website / CMS | none | Linked; Session publication state later mirrored | 3 / 4 |
+| ny-coop-net (Postgres) | live separate app | Imported: entities, participations, programs, sponsors, registrations | 4 |
+| Mailing lists | none | Linked only | 4 |
+| Legacy NYCN repos | none | Linked or Mirrored | 4 |
+
+**Rule**: no external-source data enters ICN canonical state without a `SourceRef` attached.
+
+---
+
+## 9. ny-coop-net → ICN import crosswalk
+
+Concrete per-domain migration mapping the importer must implement (Tranche 4). Every row carries `SourceRef { source_system: NyCoopNetRow, external_identifier: "<table>:<pk>", provenance_type: Imported }`.
+
+| ny-coop-net (conceptual) | ICN target object | Notes |
+|--------------------------|-------------------|-------|
+| `organizations` (co-ops, partner orgs) | `Entity { type: Cooperative | Community }` for independent orgs; or `Participation { type: MemberOrg, object_ref: "nycn" }` for federation-only relationships | Some orgs will need both: Entity for their own identity + Participation to NYCN |
+| `members` (individuals associated with orgs) | `Participation { type: Member }` linked to their org entity, plus possibly `RoleAssignment` if they have an organizer role | Only those with organizer authority get `RoleAssignment` |
+| `summits` / `events` (annual summit rows) | `Program { kind: AnnualSummit, year: <n>, parent_entity_id: "nycn-organizers" }` for cycles; `Activity { kind: Event }` for smaller events | Historical summits imported as `Closed` programs |
+| `sponsors` (summit sponsor rows) | `Sponsor` with status mapped from legacy state; linked to the appropriate Program | Dedup by (sponsor_org_entity, program_id) |
+| `sponsorship_commitments` / amount rows | `BudgetItem { direction: Income, status: Confirmed|Forecast, amount, linked_party }` | If legacy has confirmed amount, mark `Confirmed`; else `Forecast` |
+| `registrations` / `attendees` (summit registration rows) | `Registration` with accessibility fields mapped from free-text where possible (else preserved in `accessibility_notes`) | Accept partial mapping; do not require perfect structured translation |
+| `sessions` / `speakers` (summit program rows) | `Session` + speaker `Participation` records | Speaker DIDs may not exist for historical speakers — store as stub Entity if needed, or leave speaker_dids empty with `source_refs` carrying original name |
+| Notes / meeting minutes rows | `SourceRef { system: GoogleDoc, provenance: Linked }` attached to the relevant program/meeting | Full `InstitutionalDocument` lift is Tranche 5 |
+| Email threads / mailing-list archives | `SourceRef { system: MailingList, provenance: Linked }` only | No import; reference only |
+
+**Idempotence rule**: every importer write is keyed on `(source_system, external_identifier)`. Re-running the importer must not create duplicates. The importer writes via the gateway HTTP API (not directly to sled) so validation is exercised identically to normal create flows.
+
+---
+
+## 10. Bootstrap & seed data (missing operational artifact)
+
+Bootstrapping NYCN on a running ICN node requires seed data. This is not currently scripted. It is part of making the institution reproducible and belongs in Tranche 1 / Tranche 4 scope.
+
+| Seed object | Source | Required fields | Owning tranche | Status |
+|-------------|--------|-----------------|----------------|--------|
+| NYCN federation entity | `icn-entity` create | `EntityId: "nycn"`, `type: Federation`, `FederationProfile { member_entities: [...] }` | 0 (pre-merge) or 1 | ❌ no seed script |
+| `nycn-organizers` co-op entity | `icn-entity` create | `EntityId: "nycn-organizers"`, `parent_id: "nycn"`, `type: Cooperative`, treasury account | 0 or 1 | ❌ |
+| Committee structures (backbone, finance, content, logistics, marketing) | `POST /gov/structures` | `StructureId::from_raw("nycn-{name}")`, `kind: Committee`, `parent_entity_id: "nycn-organizers"` | 1 | ❌ |
+| Accessibility working group | `POST /gov/structures` | `kind: WorkingGroup` | 1 | ❌ |
+| Summit-year program | `POST /gov/programs` | `ProgramId::from_raw("summit-2026")`, `kind: AnnualSummit`, `parent_entity_id: "nycn-organizers"`, milestone set | 1 | ❌ (needs Program impl) |
+| Default milestones for summit cycle | `POST /gov/programs/{id}/milestones` | `StrategyLocked`, `VenueLocked`, `BudgetLocked`, `PublicLaunchReady`, `EventReady`, `ClosureComplete` | 1 | ❌ |
+| Initial RoleAssignments for core organizers | `POST /gov/structures/{id}/roles` | one per committee lead | 1 | ❌ |
+| NYCN charter registration | `CharterStore` via governance actor | CCL body from `NYCN-Charter-Draft.yaml` | 1 | ⚠️ YAML exists, not seeded |
+| PolicyOracle config for backbone ratification rules | oracle registration via governance actor | type-to-rule mapping | 1 or 2 | ❌ |
+
+**Deliverable**: `docs/strategy/NYCN-Bootstrap-Runbook.md` + a reproducible seed script (shell or Rust binary under `bins/`). Create alongside Tranche 1 merge.
+
+---
+
+## 11. Docs-update triggers
+
+| When | Update |
+|------|--------|
+| #1543 merges | `docs/INDEX.md` (meeting module), `docs/ARCHITECTURE.md` if meeting-level subsystem mentioned |
+| Digest PR merges | `NYCN-Implementation-Plan.md` Phase 4 → ✅, add note on v1.1 scope partitioning |
+| Tranche 1 lands | `NYCN-Institutional-Design.md` needs correction pass (committees are Structures, summit is Activity wrapped by Program); architecture spec status table; add `NYCN-Bootstrap-Runbook.md` |
+| Tranche 2 lands | Update charter YAML if budget authority is encoded |
+| Tranche 4 lands | Add `NYCN-Schema-Mapping.md` documenting actual importer mapping |
+| Tranche 5 lands | Close out Phase 5 of `NYCN-Implementation-Plan.md` |
+
+---
+
+## 12. Open questions — phase-gated
+
+Each must be resolved **before** the named phase begins. Do not let these float.
+
+| # | Question | Must decide before | Current recommendation |
+|---|----------|-------------------|-----------------------|
+| Q1 | Does `Activity` stay a separate primitive, or does `Program` subsume it? | **Tranche 1 branch opens** | Keep both. Activity for lightweight time-bounded things; Program for stage-gated cycles. Document the distinction in Program module docstring. |
+| Q2 | Does `Participation` (non-authority) belong in `icn-governance` or `icn-entity`? | **Tranche 2 branch opens** | Lean `icn-governance::participation` to keep governance-adjacent relationships colocated. Reconfirm by reading `icn-entity::membership` first. |
+| Q3 | Does `Sponsor + BudgetItem` justify its own `apps/programs` app, or live in `apps/governance`? | **Tranche 2 branch opens** | Start in `apps/governance`. Split to a separate app only when combined LOC exceeds ~5k or oracle logic diverges. |
+| Q4 | Is operational `RoleDelegation` distinct from `icn-governance::delegation` (1717 LOC), or should we extend the existing module? | **Tranche 6 branch opens** | Read `delegation.rs` fully first. Spec currently assumes distinct. Extend only if the semantics genuinely overlap without overload. |
+| Q5 | Does `InstitutionalDocument` gossip from day 1, or sled-only initially? | **Tranche 5 design review** | Gossip from day 1 (cleaner design; replication is the whole point of institutional memory). Sled-only is a Plan B if review surface is too large. |
+| Q6 | How are authority-ratification rules expressed? Hardcoded match arms, oracle config, or CCL? | **Tranche 1 before policy-oracle rule is written** | CCL-expressed rules loaded into oracle config. Keeps meaning firewall intact. |
+| Q7 | Meeting.notes_doc: add as `Option<DocumentId>` now during #1543 review, or defer to Tranche 5? | **before #1543 merges** | Add now as `Option<DocumentId>` with `#[serde(default)]`. Cheap to add pre-merge; avoids a later migration. |
+
+---
+
+## 13. Tests required per tranche
+
+| Tranche | Scenario tests (minimum) |
+|---------|-------------------------|
+| 0 | S2 (consent → action → digest), S3 (meeting closure continuity), assignee-index backfill correctness |
+| 1 | S1 (backbone → full-team), Program lifecycle + milestone transitions, scope-partitioned digest disjointness |
+| 2 | S5 (sponsor pipeline → budget → action), sponsor-confirm idempotence |
+| 3 | S4 (registration accessibility feedback), representation bucket stability |
+| 4 | Importer idempotence, random-sample spot-check, provenance round-trip |
+| 5 | S7 (provenance chain), cross-node gossip replication, version lineage |
+| 6 | Delegation grant → act → revoke, onboarding pipeline traversal, S6 (cycle closure + handoff) |
+| Cross-cutting | S8 (replay idempotence) maintained as regression guard throughout |
+
+---
+
+## 14. Agent assignments
+
+| Tranche | Suggested agent | Reason |
+|---------|----------------|--------|
+| 0a (merge #1543) | human review + `icn-rust-core` for fixes | meaning-firewall sensitive |
+| 0b (digest rework) | `icn-rust-core` | index backfill + store composition |
+| 1 (Program + Milestones) | `icn-governance-advisor` design + `icn-rust-core` impl | state machine correctness |
+| 2 (Sponsor + Budget) | `icn-governance-advisor` + `icn-economics-advisor` on budget/ledger boundary | ledger boundary risk |
+| 3 (Session + Registration + Accessibility) | `icn-rust-core` with `icn-governance-advisor` review | operational domains |
+| 4 (SourceRef + importer) | `icn-rust-core` + human operator for importer binary | touches external DB |
+| 5 (Documents + gossip) | `icn-gossip-net` + `icn-rust-core` + `icn-governance-advisor` | gossip integration |
+| 6 (RoleDelegation + Onboarding) | `icn-identity-iam-advisor` + `icn-governance-advisor` | IAM + governance crossover |
+
+Every tranche gets one pass by `icn-invariants-guardian` before merge.

--- a/docs/strategy/NYCN-Implementation-Matrix.md
+++ b/docs/strategy/NYCN-Implementation-Matrix.md
@@ -46,18 +46,19 @@
 | ActionItem `parent: InstitutionalParent` field | ✅ | `main` | `icn-governance::action_item::ActionItem.parent` | — | — | #1540 merged |
 | ActionItem `linked_proposal` + decision→action bridge | ✅ | `main` | `icn-governance::proposal::ActionItemSpec`, `apps/governance/src/actor.rs` | — | — | #1532 merged |
 | ActionItem `meeting_id: Option<MeetingId>` field | 🚧 | `open_pr` (#1543) | `icn-governance::action_item` (on meeting branch) | T (on land) | Merge #1543 | — |
-| ActionItem **assignee secondary index** (`ai_idx:assignee:<did>:<id>`) | 🚧 | `branch_only` | `apps/governance/src/manager.rs::SledActionItemStore` (on `feat/notification-digests`) | S, T (backfill test) | Open PR; add backfill-on-init with `_meta:idx_version:assignee` marker | #1543 merge first |
+| ActionItem **assignee secondary index** (proposed key: `action_item_by_assignee:{did}:{domain_id}:{item_id}`) | 🚧 | `branch_only` | `apps/governance/src/manager.rs::SledActionItemStore` (on `feat/notification-digests`) | S, T (backfill test) | Open PR; align key name to existing `_by_` convention; add backfill-on-init with `_meta:idx_version:assignee` marker | #1543 merge first |
 | ActionItem **assignee-index backfill** for pre-existing items | ❌ | `spec_only` | same file | S, T | Add on same PR as above | — |
-| ActionItem secondary indexes (`ai_idx:parent:*`, `ai_idx:status:*`) | ❌ | `spec_only` | same file | S, T | Add alongside parent-scoped / status-scoped queries (Phase 1 views) | Program views |
+| ActionItem secondary indexes (`action_item_by_parent:*`, `action_item_by_status:*`) | ❌ | `spec_only` | same file | S, T | Add alongside parent-scoped / status-scoped queries (Tranche 1 views) | Program views |
 | ActionItemSpec (proposal materialization) | ✅ | `main` | `icn-governance::proposal::ActionItemSpec` | — | — | #1532 |
 | Structure (Committee / WorkingGroup / Team / Office) | ✅ | `main` | `icn-governance::structure`, `apps/governance/src/manager.rs::SledStructureStore` | — | Seed NYCN committees via charter bootstrap | #1540 |
-| RoleAssignment | ✅ | `main` | `icn-governance::structure::RoleAssignment` | Hh (`GET /me/scopes` handler missing) | Add `GET /me/scopes` in Tranche 1 | — |
+| RoleAssignment (`structure_id`, `person_did`, `role: String`, `authority_scope: Vec<String>`, start/end, `assigned_by_decision`) | ✅ | `main` | `icn-governance::structure::RoleAssignment` | Hh (`GET /me/scopes` handler missing) | Add `GET /me/scopes` in Tranche 1. Authority is capability-string based (`authority_scope`), not a typed enum. | — |
 | Activity (Event / Program / Project / Initiative) | ✅ | `main` | `icn-governance::activity`, `apps/governance/src/manager.rs::SledActivityStore` | — | Keep; wrap into Program for stage-gated cycles | #1540 |
 | InstitutionalParent (polymorphic attachment) | ✅ | `main` | `icn-governance::parent` | — | Use for every new operational object | #1540 |
 | Charter + CharterStore | ✅ | `main` | `icn-governance::{charter,charter_store}` | — | Use NYCN charter YAML draft | — |
 | Steward (SDIS) | ✅ | `main` | `icn-governance::{steward,steward_store}` | — | — | — |
 | Delegation (vote-level) | ✅ | `main` | `icn-governance::delegation` | — | Distinct from operational RoleDelegation (Phase 6) | — |
-| Gateway events (proposal / action / structure / activity) | ✅ | `main` | `icn-gateway::events` | — | Extend per-object | — |
+| Gateway events — governance subset (`GovernanceDomainCreated`, `GovernanceProposalCreated`, `GovernanceProposalOpened`, `GovernanceProposalClosed { outcome, ... }`, `GovernanceVoteCast`) | ✅ | `main` | `icn-gateway::events` (verified) | — | — | — |
+| Gateway events for action-item / structure / activity lifecycle | ❌ | `spec_only` | `icn-gateway::events` | E, wire emission in `apps/governance/src/actor.rs` | Add at least `GovernanceActionItemCreated` in Tranche 0b so digest architecture is event-driven; others per tranche | — |
 | **Meeting** + AgendaItem + attendance + SledMeetingStore + 9 HTTP endpoints | 🚧 | `open_pr` (#1543) | `icn-governance::meeting`, `apps/governance/src/manager.rs::SledMeetingStore`, handlers | T (on land) | Human review + merge #1543 | Benchmark regression tag; no blocking human review yet |
 | Meeting-lifecycle events (`MeetingCreated/Started/Ended`) | 🚧 | `open_pr` (#1543) | `icn-gateway::events` | — | Lands with #1543 | — |
 | **DigestSummary** + `GET /digest` + `list_by_assignee` | 🚧 | `branch_only` | `apps/governance/src/manager.rs`, handlers | Hh, T | PR it after #1543 merges; unstub `upcoming_meetings` against meeting store | #1543 |
@@ -127,19 +128,29 @@
 
 | Store | Index | Status | Source | Required for |
 |-------|-------|--------|--------|--------------|
-| `SledActionItemStore` | `ai_idx:assignee:<did>:<id>` | 🚧 | `branch_only` | Digest performance |
+**On `main`** (verified in `apps/governance/src/manager.rs`):
+
+| Store | Keys | Status | Source |
+|-------|------|--------|--------|
+| `SledActionItemStore` | `action_item:{domain_id}:{item_id}` | ✅ | `main` |
+| `SledStructureStore` | `structure:{structure_id}`, `structure_by_entity:{entity_id}:{structure_id}`, `role:{role_id}`, `role_by_structure:{structure_id}:{role_id}` | ✅ | `main` |
+| `SledActivityStore` | `activity:{activity_id}`, `activity_by_entity:{entity_id}:{activity_id}` | ✅ | `main` |
+
+**Needed** (new keys follow the existing `<thing>_by_<scope>:...` convention, not a fabricated `_idx:` prefix):
+
+| Store | Key | Status | Source | Required for |
+|-------|-----|--------|--------|--------------|
+| `SledActionItemStore` | `action_item_by_assignee:{did}:{domain_id}:{item_id}` | 🚧 | `branch_only` | Digest performance |
 | `SledActionItemStore` | assignee-index backfill on init | ❌ | `spec_only` | Correctness for pre-existing items |
-| `SledActionItemStore` | `ai_idx:parent:<parent_tag>:<parent_id>:<id>` | ❌ | `spec_only` | Scope-scoped queries |
-| `SledActionItemStore` | `ai_idx:status:<status>:<id>` | ❌ | `spec_only` | Dashboard counts |
-| `SledStructureStore` | `structure_idx:parent_entity:<id>:<sid>` | ⚠️ | verify on `main` | Committee listing |
-| `SledActivityStore` | `activity_idx:parent_entity:<id>:<aid>` | ⚠️ | verify on `main` | Activity listing |
-| `SledMeetingStore` | `meeting_idx:scope:<tag>:<id>:<scheduled_at>:<mid>` | ⚠️ | verify on #1543 | Upcoming meetings within 48h for digest |
-| `SledProgramStore` | primary + parent-entity + status + kind indexes | ❌ | `spec_only` | All program views |
-| `SledSponsorStore` | `sponsor_idx:program:<pid>:<sid>` + `...:status:...` | ❌ | `spec_only` | Sponsor pipeline view |
-| `SledBudgetItemStore` | `budget_idx:program:<pid>:<bid>` | ❌ | `spec_only` | Program budget view |
-| `SledSessionStore` | `session_idx:program:<pid>:<sid>` + `...:status:...` | ❌ | `spec_only` | Program content view |
-| `SledRegistrationStore` | `registration_idx:program:<pid>:<rid>` + `...:actor:<did>:...` | ❌ | `spec_only` | Attendee counts, user's registrations |
-| `SledDocumentStore` | `doc_idx:<domain>:<type>:<timestamp>` + `doc_link:<scope>:<id>:<doc_id>` | ❌ | `spec_only` | Phase 5 document queries |
+| `SledActionItemStore` | `action_item_by_parent:{parent_tag}:{parent_id}:{domain_id}:{item_id}` | ❌ | `spec_only` | Scope-scoped queries |
+| `SledActionItemStore` | `action_item_by_status:{status}:{domain_id}:{item_id}` | ❌ | `spec_only` | Dashboard counts |
+| `SledMeetingStore` | `meeting:{meeting_id}`, `meeting_by_scope:{scope_tag}:{scope_id}:{scheduled_at}:{meeting_id}` | ⚠️ | verify on #1543 | Upcoming meetings within 48h for digest |
+| `SledProgramStore` | `program:{id}`, `program_by_entity:{entity_id}:{id}`, `program_by_status:{status}:{id}`, `program_by_kind:{kind}:{id}` | ❌ | `spec_only` | All program views |
+| `SledSponsorStore` | `sponsor:{id}`, `sponsor_by_program:{program_id}:{id}`, `sponsor_by_status:{status}:{id}` | ❌ | `spec_only` | Sponsor pipeline view |
+| `SledBudgetItemStore` | `budget_item:{id}`, `budget_item_by_program:{program_id}:{id}` | ❌ | `spec_only` | Program budget view |
+| `SledSessionStore` | `session:{id}`, `session_by_program:{program_id}:{id}`, `session_by_status:{status}:{id}` | ❌ | `spec_only` | Program content view |
+| `SledRegistrationStore` | `registration:{id}`, `registration_by_program:{program_id}:{id}`, `registration_by_actor:{did}:{id}` | ❌ | `spec_only` | Attendee counts, user's registrations |
+| `SledDocumentStore` | `document:{doc_hash}`, `document_by_domain_type:{domain_id}:{type}:{timestamp}:{doc_hash}`, `document_by_scope:{scope_tag}:{scope_id}:{doc_hash}` | ❌ | `spec_only` | Phase 5 document queries |
 
 **Migration-safe index rule**: every new index gets a `_meta:idx_version:<name>` marker. On store init, if absent or below current version, walk rows and populate. Test coverage must include both "empty store" and "pre-populated store".
 
@@ -147,30 +158,49 @@
 
 ## 5. Gateway events
 
-| Event | Status | Source |
-|-------|--------|--------|
-| `ProposalOpened/Accepted/Rejected` | ✅ | `main` |
-| `ActionItemCreated/Updated/Completed` | ⚠️ | verify coverage in `events.rs` on `main` |
-| `StructureCreated`, `RoleAssigned` | ⚠️ | verify on `main` (via #1540) |
-| `ActivityCreated`, `ActivityStatusChanged` | ⚠️ | verify on `main` (via #1540) |
-| `MeetingCreated/Started/Ended` | 🚧 | `open_pr` #1543 |
-| `ProgramOpened/Closed`, `MilestoneCompleted/Blocked` | ❌ | `spec_only` (Tranche 1) |
-| `SponsorStatusChanged` | ❌ | `spec_only` (Tranche 2) |
-| `BudgetItemCreated/Updated` | ❌ | `spec_only` (Tranche 2) |
-| `SessionPublished`, `SessionStatusChanged` | ❌ | `spec_only` (Tranche 3) |
-| `RegistrationConfirmed`, `RegistrationCheckedIn` | ❌ | `spec_only` (Tranche 3) |
-| `DocumentCreated`, `DocumentUpdated` | ❌ | `spec_only` (Tranche 5) |
+Current `GatewayEvent` governance-related variants on `main` (verified in `icn/crates/icn-gateway/src/events.rs`):
+
+| Event variant | Status | Source |
+|---------------|--------|--------|
+| `GovernanceDomainCreated` | ✅ | `main` |
+| `GovernanceProposalCreated` | ✅ | `main` |
+| `GovernanceProposalOpened` | ✅ | `main` |
+| `GovernanceProposalClosed { outcome: String, ... }` | ✅ | `main` |
+| `GovernanceVoteCast` | ✅ | `main` |
+
+Proposed additions — **none of these exist on `main` yet**:
+
+| Event variant | Status | Source | Tranche |
+|---------------|--------|--------|---------|
+| `GovernanceActionItemCreated` (emitted when decision→action bridge materializes items) | ❌ | `spec_only` | **0b (add alongside digest PR so digest architecture is event-driven from day 1)** |
+| `GovernanceActionItemUpdated/Completed` | ❌ | `spec_only` | 1 |
+| `GovernanceStructureCreated`, `GovernanceRoleAssigned` | ❌ | `spec_only` | 1 |
+| `GovernanceActivityCreated`, `GovernanceActivityStatusChanged` | ❌ | `spec_only` | 1 |
+| `GovernanceMeetingCreated/Started/Ended` | 🚧 | `open_pr` #1543 | 0a |
+| `GovernanceProgramOpened/Closed`, `GovernanceMilestoneCompleted/Blocked` | ❌ | `spec_only` | 1 |
+| `GovernanceSponsorStatusChanged` | ❌ | `spec_only` | 2 |
+| `GovernanceBudgetItemCreated/Updated` | ❌ | `spec_only` | 2 |
+| `GovernanceSessionPublished`, `GovernanceSessionStatusChanged` | ❌ | `spec_only` | 3 |
+| `GovernanceRegistrationConfirmed`, `GovernanceRegistrationCheckedIn` | ❌ | `spec_only` | 3 |
+| `GovernanceDocumentCreated/Updated` | ❌ | `spec_only` | 5 |
+
+**Naming convention**: follow the existing `Governance<Thing><Verb>` pattern on `GatewayEvent`. Do not invent a parallel naming scheme.
 
 ---
 
 ## 6. HTTP API surface
 
-### 6.1 On `main`
+All governance routes are mounted under the `/gov` scope (see `icn/crates/icn-gateway/src/server.rs:2008`).
 
-- `POST/GET /gov/domains/...`, `POST /gov/proposals`, vote/close
-- `POST/GET /gov/action-items`, `PATCH /gov/action-items/{id}`
-- `POST/GET /gov/structures`, `POST /gov/structures/{id}/roles`
-- `POST/GET /gov/activities`
+### 6.1 On `main` (verified in `apps/governance/src/http/configure.rs`)
+
+- **Domains**: `POST/GET /gov/domains`, `GET /gov/domains/{domain_id}`, `POST/DELETE /gov/domains/{domain_id}/members`
+- **Proposals**: `POST/GET /gov/proposals`, `GET /gov/proposals/{id}`, `POST /gov/proposals/{id}/{open,close,vote}`, `GET /gov/proposals/{id}/{tally,proof,chain,discussion}`, discussion comment CRUD
+- **Delegations** (vote-level): `POST/GET /gov/delegations`, `GET /gov/delegations/{id}`
+- **Action items** (domain-scoped): `GET /gov/domains/{domain_id}/action-items`, `GET /gov/domains/{domain_id}/action-items/{item_id}`, `PATCH .../status`, `POST .../notes`
+- **Structures** (entity-scoped): `POST/GET /gov/entities/{entity_id}/structures`, `GET /gov/structures/{structure_id}`, `POST /gov/structures/{structure_id}/roles`
+- **Activities** (entity-scoped): `POST/GET /gov/entities/{entity_id}/activities`, `GET /gov/activities/{activity_id}`
+- **Federation / SDIS proposal shortcuts**: `/gov/proposals/federation/...`, `/gov/proposals/sdis/...`
 
 ### 6.2 On PR #1543
 
@@ -185,7 +215,7 @@
 
 ### 6.4 Proposed per tranche
 
-- **Tranche 1 (Program)**: `/gov/programs` CRUD, `/{id}/milestones` CRUD, `/{id}/close`, `/{id}/dashboard`; `/me/scopes`, `/me/work`; scope-partitioned `/gov/digest?scope=...`
+- **Tranche 1 (Program)**: `POST/GET /gov/entities/{entity_id}/programs`, `GET /gov/programs/{program_id}`, `POST /gov/programs/{id}/milestones`, `PATCH .../{mid}`, `POST /gov/programs/{id}/close`, `GET /gov/programs/{id}/dashboard`; `GET /gov/me/scopes`, `GET /gov/me/work`; scope-partitioned `GET /gov/digest?scope=...`
 - **Tranche 2 (Funding)**: `/gov/sponsors` CRUD, `/gov/programs/{id}/sponsors`, `/gov/budget-items` CRUD, `/gov/programs/{id}/budget`
 - **Tranche 3 (Content/Attendees)**: `/gov/sessions` CRUD, `/gov/programs/{id}/sessions`, `/gov/registrations` CRUD, `/gov/programs/{id}/registrations`, `/gov/programs/{id}/accessibility-status`, `/gov/programs/{id}/representation`
 - **Tranche 4 (Migration)**: provenance reads `/gov/history/{ref}`, `/gov/provenance/{ref}` (if not deferred to Tranche 5)

--- a/docs/strategy/NYCN-Implementation-Matrix.md
+++ b/docs/strategy/NYCN-Implementation-Matrix.md
@@ -196,8 +196,8 @@ All governance routes are mounted under the `/gov` scope (see `icn/crates/icn-ga
 
 - **Domains**: `POST/GET /gov/domains`, `GET /gov/domains/{domain_id}`, `POST/DELETE /gov/domains/{domain_id}/members`
 - **Proposals**: `POST/GET /gov/proposals`, `GET /gov/proposals/{id}`, `POST /gov/proposals/{id}/{open,close,vote}`, `GET /gov/proposals/{id}/{tally,proof,chain,discussion}`, discussion comment CRUD
-- **Delegations** (vote-level): `POST/GET /gov/delegations`, `GET /gov/delegations/{id}`
-- **Action items** (domain-scoped): `GET /gov/domains/{domain_id}/action-items`, `GET /gov/domains/{domain_id}/action-items/{item_id}`, `PATCH .../status`, `POST .../notes`
+- **Delegations** (vote-level): `POST/GET /gov/delegations`, `DELETE /gov/delegations/{id}` (revoke — no GET-by-id handler exists on `main`)
+- **Action items** (domain-scoped): `POST/GET /gov/domains/{domain_id}/action-items`, `GET /gov/domains/{domain_id}/action-items/{item_id}`, `PUT .../status`, `POST .../notes`
 - **Structures** (entity-scoped): `POST/GET /gov/entities/{entity_id}/structures`, `GET /gov/structures/{structure_id}`, `POST /gov/structures/{structure_id}/roles`
 - **Activities** (entity-scoped): `POST/GET /gov/entities/{entity_id}/activities`, `GET /gov/activities/{activity_id}`
 - **Federation / SDIS proposal shortcuts**: `/gov/proposals/federation/...`, `/gov/proposals/sdis/...`
@@ -289,11 +289,11 @@ Bootstrapping NYCN on a running ICN node requires seed data. This is not current
 |-------------|--------|-----------------|----------------|--------|
 | NYCN federation entity | `icn-entity` create | `EntityId: "nycn"`, `type: Federation`, `FederationProfile { member_entities: [...] }` | 0 (pre-merge) or 1 | ❌ no seed script |
 | `nycn-organizers` co-op entity | `icn-entity` create | `EntityId: "nycn-organizers"`, `parent_id: "nycn"`, `type: Cooperative`, treasury account | 0 or 1 | ❌ |
-| Committee structures (backbone, finance, content, logistics, marketing) | `POST /gov/structures` | `StructureId::from_raw("nycn-{name}")`, `kind: Committee`, `parent_entity_id: "nycn-organizers"` | 1 | ❌ |
-| Accessibility working group | `POST /gov/structures` | `kind: WorkingGroup` | 1 | ❌ |
-| Summit-year program | `POST /gov/programs` | `ProgramId::from_raw("summit-2026")`, `kind: AnnualSummit`, `parent_entity_id: "nycn-organizers"`, milestone set | 1 | ❌ (needs Program impl) |
-| Default milestones for summit cycle | `POST /gov/programs/{id}/milestones` | `StrategyLocked`, `VenueLocked`, `BudgetLocked`, `PublicLaunchReady`, `EventReady`, `ClosureComplete` | 1 | ❌ |
-| Initial RoleAssignments for core organizers | `POST /gov/structures/{id}/roles` | one per committee lead | 1 | ❌ |
+| Committee structures (backbone, finance, content, logistics, marketing) | `POST /gov/entities/nycn-organizers/structures` | `StructureId::from_raw("nycn-{name}")`, `kind: Committee`, `parent_entity_id: "nycn-organizers"` | 1 | ❌ |
+| Accessibility working group | `POST /gov/entities/nycn-organizers/structures` | `kind: WorkingGroup` | 1 | ❌ |
+| Summit-year program | `POST /gov/entities/nycn-organizers/programs` | `ProgramId::from_raw("summit-2026")`, `kind: AnnualSummit`, `parent_entity_id: "nycn-organizers"`, milestone set | 1 | ❌ (needs Program impl) |
+| Default milestones for summit cycle | `POST /gov/programs/{program_id}/milestones` | `StrategyLocked`, `VenueLocked`, `BudgetLocked`, `PublicLaunchReady`, `EventReady`, `ClosureComplete` | 1 | ❌ |
+| Initial RoleAssignments for core organizers | `POST /gov/structures/{structure_id}/roles` | one per committee lead | 1 | ❌ |
 | NYCN charter registration | `CharterStore` via governance actor | CCL body from `NYCN-Charter-Draft.yaml` | 1 | ⚠️ YAML exists, not seeded |
 | PolicyOracle config for backbone ratification rules | oracle registration via governance actor | type-to-rule mapping | 1 or 2 | ❌ |
 

--- a/docs/strategy/NYCN-Repo-Architecture-Spec.md
+++ b/docs/strategy/NYCN-Repo-Architecture-Spec.md
@@ -79,7 +79,7 @@ Grounded in direct inspection of `icn/crates/icn-governance/src/` and `icn/apps/
 | Action items (CRUD, status, priority, notes, filter, sled store) | `icn-governance::action_item` (1281 LOC) | Full store trait + `SledActionItemStore` + assignee index |
 | Decision→action bridge: accepted proposals auto-materialize `ActionItemSpec`s with provenance | `icn-governance::proposal::ActionItemSpec`, `apps/governance/src/actor.rs` | #1532 merged |
 | Institutional Structure (Committee / WorkingGroup / Team / Office) + sled store | `icn-governance::structure` (548 LOC), `apps/governance/src/manager.rs::SledStructureStore` | #1540 merged |
-| Role Assignment (scope-aware, authority-typed) | `icn-governance::structure::RoleAssignment` | #1540 merged |
+| Role Assignment (`structure_id`, `person_did`, `role: String`, `authority_scope: Vec<String>`, start/end) | `icn-governance::structure::RoleAssignment` | #1540 merged. Authority is capability-string based, not a typed enum. |
 | Activity (Event / Program / Project / Initiative) + sled store | `icn-governance::activity` (335 LOC), `apps/governance/src/manager.rs::SledActivityStore` | #1540 merged |
 | Polymorphic `InstitutionalParent` attachment for action items | `icn-governance::parent`, `action_item::ActionItem.parent` | #1540 merged |
 | Federation charter / charter store | `icn-governance::{charter, charter_store}` | Mature |
@@ -162,7 +162,7 @@ Every object from the institutional review, mapped to repo reality.
 | `Person / Actor` | `icn-identity::Did` | ✅ | |
 | `Participation` | `icn-governance::membership` + `RoleAssignment` | ✅ for member/role cases | Sponsor / speaker / attendee participation is MISSING (see §3 below) |
 | `Structure` | `icn-governance::structure::Structure` | ✅ | `kind: Committee/WorkingGroup/Team/Office` |
-| `RoleAssignment` | `icn-governance::structure::RoleAssignment` | ✅ | Scope-aware, authority-typed (advisory / binding / delegated / temporary / emergency — verify enum matches) |
+| `RoleAssignment` | `icn-governance::structure::RoleAssignment` | ✅ | Scope-aware; authority represented by `authority_scope: Vec<String>` capability strings + freeform `role` — **not** a typed authority-level enum |
 | **Program** | proposed `icn-governance::program::Program` | ❌ missing | Wraps `Activity` with milestones, phase state, closure hooks |
 | `Activity` | `icn-governance::activity::Activity` | ✅ | Use as building block for Program |
 | `Meeting` | `icn-governance::meeting::Meeting` | 🚧 PR #1543 | |
@@ -199,24 +199,26 @@ Two options:
 
 ## 4. Authority and scope model
 
-### 4.1 What currently supports scope switching
+### 4.1 What currently supports scoped authority
 
-`RoleAssignment` (in `icn-governance::structure`) already carries:
-- `actor_did` (who)
-- `scope` — structure ID the role is for
-- role type + authority level
-- start/end
+`RoleAssignment` (in `icn-governance::structure`) carries:
+- `structure_id` — the structure the assignment belongs to
+- `person_did` — who holds the assignment
+- `role: String` — a freeform role label (e.g. `"coordinator"`, `"facilitator"`, `"note_taker"`, `"member"`)
+- `authority_scope: Vec<String>` — delegated capability strings within that role (narrower than or equal to the structure's scope)
+- `start_date` / `end_date` — time-bounded
+- `assigned_by_decision: Option<ProposalId>` — provenance link if proposal-backed
 
-Combined with `MembershipCapability` on entity membership, a user can already be "Matt acting as finance-committee lead on nycn-finance" vs. "Matt acting as an attendee on summit-2026". **This is the primitive for scope switching.**
+Combined with `MembershipCapability` on entity membership, a user can already hold a structure-specific governance role with delegated capability scopes — e.g., "Matt is assigned as finance-committee lead on `nycn-finance` with `authority_scope: ["propose", "approve-budget-<=5000"]`". **This is the primitive scoped-authority plumbing.**
 
 What is missing:
-- **Active-scope selection** at the HTTP/session layer. The gateway currently takes JWTs with `coop_id` and `scopes`. It does not yet have a first-class "act-as-structure-X-with-role-Y" selection mechanism.
-- **Delegation records** for temporary role handoff ("Matt delegates venue-selection to Priya for 2 weeks").
+- **Active-scope selection** at the HTTP/session layer. The gateway currently takes JWTs with `coop_id` and `scopes`. It does not yet have a first-class "act-as-structure-X-with-role-Y" request-context mechanism resolved against the `RoleAssignment` store.
+- **Operational role delegation** for temporary handoff ("Matt delegates venue-selection to Priya for 2 weeks"), beyond the delegated capabilities already on an assignment.
 
 ### 4.2 Proposed additions
 
-1. **`SessionScope` in gateway request context** — resolved from DID + active scope claim against `RoleAssignment` store. Belongs in `icn-gateway::auth` / wherever JWT claims are validated.
-2. **`RoleDelegation`** — in `icn-governance::structure` or a new `icn-governance::role_delegation` module. Fields: `grantor`, `grantee`, `scope_ref`, `capabilities`, `starts_at`, `ends_at`, `reason`, `revoked_at`. Distinct from `icn-governance::delegation` (which is vote-delegation).
+1. **`SessionScope` in gateway request context** — resolved from DID + active structure/role claim against the `RoleAssignment` store. Belongs in `icn-gateway::auth` / wherever JWT claims are validated.
+2. **`RoleDelegation`** — new `icn-governance::role_delegation` module. Fields: `grantor`, `grantee`, `scope_ref`, `capabilities: Vec<String>` (same capability-string vocabulary as `authority_scope`), `starts_at`, `ends_at`, `reason`, `revoked_at`. Distinct from `icn-governance::delegation` (which is vote-delegation).
 
 ### 4.3 Backbone authority
 
@@ -224,14 +226,14 @@ The backbone group is one of the most politically load-bearing concepts in NYCN 
 
 ```rust
 Structure {
-    id: StructureId("nycn-backbone"),
+    id: StructureId::from_raw("nycn-backbone"),
     parent_entity_id: "nycn-organizers",
     kind: StructureKind::Committee,
     // metadata: { "authority_class": "backbone", "requires_ratification_for": ["...categories..."] }
 }
 ```
 
-Authority-rule enforcement should be a **PolicyOracle decision**, not a hard-coded match. Specifically: when a proposal is opened in a backbone-group domain with a type that requires full-network ratification, the oracle refuses to finalize unilaterally and flags it as requiring downstream ratification in the parent's governance domain. This keeps the meaning firewall intact and makes NYCN's authority rules data-driven rather than NYCN-specific code.
+Role holders on the backbone structure carry capability strings like `"backbone-authority"` in their `authority_scope`. Authority-rule enforcement is then a **PolicyOracle decision** keyed off those capability strings — not hard-coded match arms, not a new enum. Specifically: when a proposal is opened in a backbone-scoped domain with a type that requires full-network ratification, the oracle refuses to finalize unilaterally and flags it as requiring a downstream ratification proposal in the parent entity's governance domain. This keeps the meaning firewall intact (CCL/oracle config expresses which proposal types require ratification; the code does not hard-code NYCN categories) and makes the rule set data-driven.
 
 ---
 
@@ -333,18 +335,31 @@ Add to `icn-gateway::events::GatewayEvent`:
 
 ## 6. Event-driven flow mapping
 
-ICN already has `GatewayEvent` emission on proposal/action-item/structure/activity lifecycle. The NYCN integration does **not** require a new event bus — it requires adding variants and wiring more materializers.
+ICN already has `GatewayEvent` emission on **proposal lifecycle** (domain create, proposal create/open/close, vote cast). It does **not** yet emit events for action-items, structures, or activities. The NYCN integration requires both adding variants **and** wiring the emission sites — not just consumer materializers.
 
-### 6.1 Governance → task chain (already wired)
+Current governance-related variants on `main` (verified in `icn/crates/icn-gateway/src/events.rs`):
+
+- `GovernanceDomainCreated`
+- `GovernanceProposalCreated`
+- `GovernanceProposalOpened`
+- `GovernanceProposalClosed { outcome: String, ... }`
+- `GovernanceVoteCast`
+
+### 6.1 Governance → task chain (partial — consumer side wired, event side missing)
+
+State-change side **already works on `main`** (the decision→action bridge materializes action items in `apps/governance/src/actor.rs` after a proposal is accepted). The **event emission** for downstream consumers is incomplete:
 
 ```
-proposal.accepted
-  → action_item.created (n, via ActionItemSpec materialization in actor.rs)
-  → GatewayEvent::ProposalAccepted
-  → GatewayEvent::ActionItemCreated (per item)
+proposal.accepted (state change)
+  → action_item records created (✅ on main, via ActionItemSpec materialization)
+  → GatewayEvent::GovernanceProposalClosed { outcome: "accepted", ... }  (✅ on main)
+  → GatewayEvent::GovernanceActionItemCreated (per item)                  (❌ not emitted; must be added)
 ```
 
-Gap: no `digest.generated` event is emitted downstream. Add when digest service gets a real task loop.
+Gap 1: no per-action-item event is emitted. Consumers that need to react on materialization (digests, external integrations) cannot today — they must poll stores.
+Gap 2: no `digest.generated` event. Add when digest service gets a real task loop.
+
+**Recommended placement**: add `GovernanceActionItemCreated { item_id, domain_id, linked_proposal, assignee }` as part of the Tranche 0b (notification-digests) PR, so the digest architecture can converge on event-driven materialization from the start.
 
 ### 6.2 Meeting closure chain (after #1543 merges)
 
@@ -590,21 +605,43 @@ Every state transition on a canonical object should be attributable. If the Rust
 
 ## 13. API surface expectations
 
-Consolidated from §5, §6, §8, §9. Group under `/gov/` (existing governance HTTP namespace in `apps/governance/src/http/`):
+All governance routes are mounted under the `/gov` scope in the gateway (see `icn/crates/icn-gateway/src/server.rs:2008`). Routes that act on a specific governance domain or parent entity are nested under the scope segment — they are **not** flat top-level paths.
 
-- Structures: `POST /structures`, `GET /structures`, `GET /structures/{id}`, `POST /structures/{id}/roles`, `GET /structures/{id}/action-items`, `GET /structures/{id}/meetings` (after #1543)
-- Activities: existing
-- **Programs** (new): `POST /programs`, `GET /programs`, `GET /programs/{id}`, `POST /programs/{id}/milestones`, `PATCH /programs/{id}/milestones/{mid}`, `POST /programs/{id}/close`, `GET /programs/{id}/dashboard`, `GET /programs/{id}/sessions`, `GET /programs/{id}/sponsors`, `GET /programs/{id}/registrations`, `GET /programs/{id}/accessibility-status`, `GET /programs/{id}/representation`
-- Meetings: `POST /meetings`, `GET /meetings/{id}`, `POST /meetings/{id}/agenda-items`, `POST /meetings/{id}/close`, `GET /meetings/{id}/summary` (after #1543)
-- Proposals: existing, incl. `action_items_on_accept`
-- Action items: existing + `GET /action-items/my`
-- **Sponsors** (new): `POST /sponsors`, `PATCH /sponsors/{id}`, `GET /sponsors`, `GET /programs/{id}/sponsors`
-- **Budget items** (new): `POST /budget-items`, `GET /programs/{id}/budget`, `PATCH /budget-items/{id}`
-- **Sessions** (new): `POST /sessions`, `PATCH /sessions/{id}`, `GET /programs/{id}/sessions`
-- **Registrations** (new): `POST /registrations`, `GET /programs/{id}/registrations`
-- Digests: `GET /digest` (DID-level), `GET /digest?scope=structure:nycn-finance`, `GET /my/digests/...` (later)
-- Me / scope: `GET /me/scopes` (new), `GET /me/work` (new — composes `MyActionQueueView`)
-- Provenance: `GET /history/{ref}`, `GET /provenance/{ref}` (later)
+### 13.1 Existing on `main` (verified in `apps/governance/src/http/configure.rs`)
+
+- Domains: `POST/GET /gov/domains`, `GET /gov/domains/{domain_id}`, `POST/DELETE /gov/domains/{domain_id}/members`
+- Proposals: `POST/GET /gov/proposals`, `GET /gov/proposals/{id}`, `POST /gov/proposals/{id}/open`, `POST .../close`, `POST .../vote`, `GET .../tally`, `GET .../proof`, `GET .../chain`, `GET .../discussion`, plus `discussion/comments[/{id}[/reactions]]`
+- Delegations: `POST/GET /gov/delegations`, `GET /gov/delegations/{id}`
+- Action items: `GET /gov/domains/{domain_id}/action-items`, `GET /gov/domains/{domain_id}/action-items/{item_id}`, `PATCH .../status`, `POST .../notes`
+- Structures: `POST/GET /gov/entities/{entity_id}/structures`, `GET /gov/structures/{structure_id}`, `POST /gov/structures/{structure_id}/roles`
+- Activities: `POST/GET /gov/entities/{entity_id}/activities`, `GET /gov/activities/{activity_id}`
+- Federation / SDIS proposal shortcuts: `/gov/proposals/federation/...`, `/gov/proposals/sdis/...`
+
+### 13.2 On PR #1543 (meetings)
+
+- `POST/GET /gov/meetings`, `GET /gov/meetings/{id}`, `PATCH /gov/meetings/{id}`
+- `POST /gov/meetings/{id}/agenda-items`, `PATCH .../{aid}`
+- `POST /gov/meetings/{id}/start`, `POST .../end`
+- Attendance endpoint (verify exact path against PR)
+
+### 13.3 Proposed additions (by tranche)
+
+- **Tranche 0b (digest)**: `GET /gov/digest` (DID-level)
+- **Tranche 1 (Program + views)**:
+  - Programs: `POST/GET /gov/entities/{entity_id}/programs`, `GET /gov/programs/{program_id}`, `POST /gov/programs/{id}/milestones`, `PATCH /gov/programs/{id}/milestones/{mid}`, `POST /gov/programs/{id}/close`, `GET /gov/programs/{id}/dashboard`
+  - Scope + work: `GET /gov/me/scopes`, `GET /gov/me/work`
+  - Scope-partitioned digest: `GET /gov/digest?scope=structure:nycn-finance`
+- **Tranche 2 (funding)**:
+  - Sponsors: `POST/GET /gov/sponsors`, `PATCH /gov/sponsors/{id}`, `GET /gov/programs/{id}/sponsors`
+  - Budget: `POST/GET /gov/budget-items`, `PATCH /gov/budget-items/{id}`, `GET /gov/programs/{id}/budget`
+- **Tranche 3 (content/attendees)**:
+  - Sessions: `POST/GET /gov/sessions`, `PATCH /gov/sessions/{id}`, `GET /gov/programs/{id}/sessions`
+  - Registrations: `POST/GET /gov/registrations`, `GET /gov/programs/{id}/registrations`
+  - Derived views: `GET /gov/programs/{id}/accessibility-status`, `GET /gov/programs/{id}/representation`
+- **Tranche 5 (documents)**: `POST/GET /gov/documents`, version history, search
+- **Provenance** (Tranche 4 or 5): `GET /gov/history/{ref}`, `GET /gov/provenance/{ref}`
+
+New parent/entity/program-scoped routes should follow the established `/gov/{parent-type}/{parent-id}/{child}` pattern rather than flat top-level paths.
 
 ### 13.1 TypeScript SDK drift
 
@@ -619,23 +656,32 @@ Every new HTTP model added to `apps/governance/src/http/models.rs` requires rege
 For each new domain object:
 1. Define the struct + store trait in `icn-governance::<module>`.
 2. Implement `InMemory<X>Store` in-module for tests.
-3. Implement `Sled<X>Store` in `apps/governance/src/manager.rs` with sled key prefixes `<module>:<id>` and any secondary indexes (`<module>_idx:<field>:<value>`).
+3. Implement `Sled<X>Store` in `apps/governance/src/manager.rs` following the existing naming pattern: primary keys as `<thing>:{scope}:{id}` (or `<thing>:{id}` when globally scoped), secondary indexes as `<thing>_by_<scope>:{scope_id}:{id}`.
 4. Wire into `GovernanceManager`.
 5. Use content-addressing for document-like objects (blake3 of canonical body).
 
-### 14.2 Indexes to plan
+### 14.2 Indexes — existing on `main` (verified in `apps/governance/src/manager.rs`)
 
-| Store | Primary | Secondary indexes required |
-|-------|---------|---------------------------|
-| ActionItem | `action_item:<id>` | `ai_idx:assignee:<did>:<id>` (on `feat/notification-digests`), plus needed: `ai_idx:parent:<parent_tag>:<parent_id>:<id>`, `ai_idx:status:<status>:<id>` |
-| Structure | `structure:<id>` | `structure_idx:parent_entity:<id>:<sid>` |
-| Activity | `activity:<id>` | `activity_idx:parent_entity:<id>:<aid>` |
-| Program (new) | `program:<id>` | `program_idx:parent_entity:<id>:<pid>`, `program_idx:status:<status>:<pid>`, `program_idx:kind:<kind>:<pid>` |
-| Meeting (PR) | `meeting:<id>` | `meeting_idx:scope:<scope_tag>:<scope_id>:<scheduled_at>:<mid>` |
-| Sponsor (new) | `sponsor:<id>` | `sponsor_idx:program:<pid>:<sid>`, `sponsor_idx:status:<status>:<sid>` |
-| BudgetItem (new) | `budget_item:<id>` | `budget_idx:program:<pid>:<bid>` |
-| Session (new) | `session:<id>` | `session_idx:program:<pid>:<sid>`, `session_idx:status:<status>:<sid>` |
-| Registration (new) | `registration:<id>` | `registration_idx:program:<pid>:<rid>`, `registration_idx:actor:<did>:<rid>` |
+| Store | Primary key | Secondary / scoped keys |
+|-------|-------------|-------------------------|
+| `SledActionItemStore` | `action_item:{domain_id}:{item_id}` | — (no secondary index yet) |
+| `SledStructureStore` | `structure:{structure_id}` | `structure_by_entity:{entity_id}:{structure_id}`, `role:{role_id}`, `role_by_structure:{structure_id}:{role_id}` |
+| `SledActivityStore` | `activity:{activity_id}` | `activity_by_entity:{entity_id}:{activity_id}` |
+
+### 14.3 Indexes — proposed additions (new sled keys must follow the established `<thing>_by_<scope>:...` convention)
+
+| Store | Primary key | Secondary keys | Tranche |
+|-------|-------------|----------------|---------|
+| `SledActionItemStore` | (existing) | `action_item_by_assignee:{did}:{domain_id}:{item_id}` | 0b (digest) |
+| `SledActionItemStore` | (existing) | `action_item_by_parent:{parent_tag}:{parent_id}:{domain_id}:{item_id}` | 1 (views) |
+| `SledActionItemStore` | (existing) | `action_item_by_status:{status}:{domain_id}:{item_id}` | 1 (dashboard counts) |
+| `SledMeetingStore` | verify on #1543 | verify on #1543 — should include `meeting_by_scope:{scope_tag}:{scope_id}:{scheduled_at}:{meeting_id}` to support upcoming-meetings digest | 0a |
+| `SledProgramStore` (new) | `program:{program_id}` | `program_by_entity:{entity_id}:{program_id}`, `program_by_status:{status}:{program_id}`, `program_by_kind:{kind}:{program_id}` | 1 |
+| `SledSponsorStore` (new) | `sponsor:{sponsor_id}` | `sponsor_by_program:{program_id}:{sponsor_id}`, `sponsor_by_status:{status}:{sponsor_id}` | 2 |
+| `SledBudgetItemStore` (new) | `budget_item:{item_id}` | `budget_item_by_program:{program_id}:{item_id}` | 2 |
+| `SledSessionStore` (new) | `session:{session_id}` | `session_by_program:{program_id}:{session_id}`, `session_by_status:{status}:{session_id}` | 3 |
+| `SledRegistrationStore` (new) | `registration:{registration_id}` | `registration_by_program:{program_id}:{registration_id}`, `registration_by_actor:{did}:{registration_id}` | 3 |
+| `SledDocumentStore` (new) | `document:{doc_hash}` | `document_by_domain_type:{domain_id}:{doc_type}:{timestamp}:{doc_hash}`, `document_by_scope:{scope_tag}:{scope_id}:{doc_hash}` | 5 |
 
 ### 14.3 Migration-safe index construction
 
@@ -698,7 +744,7 @@ Phase 0 alone adds ~12 meeting-management endpoints and ~1 digest endpoint. Phas
 
 ### 17.3 Authority ambiguity
 
-The backbone-group question is political-process ambiguity bleeding into code. Keep the code honest: authority is `RoleAssignment.authority_type` + `RoleDelegation` + policy-oracle rules, not hard-coded backbone-group logic.
+The backbone-group question is political-process ambiguity bleeding into code. Keep the code honest: authority is `RoleAssignment.authority_scope` capability strings + `RoleDelegation` + policy-oracle rules keyed off those capability strings, not hard-coded backbone-group logic.
 
 ### 17.4 Organizer-hostile UX
 

--- a/docs/strategy/NYCN-Repo-Architecture-Spec.md
+++ b/docs/strategy/NYCN-Repo-Architecture-Spec.md
@@ -611,8 +611,8 @@ All governance routes are mounted under the `/gov` scope in the gateway (see `ic
 
 - Domains: `POST/GET /gov/domains`, `GET /gov/domains/{domain_id}`, `POST/DELETE /gov/domains/{domain_id}/members`
 - Proposals: `POST/GET /gov/proposals`, `GET /gov/proposals/{id}`, `POST /gov/proposals/{id}/open`, `POST .../close`, `POST .../vote`, `GET .../tally`, `GET .../proof`, `GET .../chain`, `GET .../discussion`, plus `discussion/comments[/{id}[/reactions]]`
-- Delegations: `POST/GET /gov/delegations`, `GET /gov/delegations/{id}`
-- Action items: `GET /gov/domains/{domain_id}/action-items`, `GET /gov/domains/{domain_id}/action-items/{item_id}`, `PATCH .../status`, `POST .../notes`
+- Delegations: `POST/GET /gov/delegations`, `DELETE /gov/delegations/{id}` (revoke — no GET-by-id handler exists on `main`)
+- Action items: `POST/GET /gov/domains/{domain_id}/action-items`, `GET /gov/domains/{domain_id}/action-items/{item_id}`, `PUT .../status`, `POST .../notes`
 - Structures: `POST/GET /gov/entities/{entity_id}/structures`, `GET /gov/structures/{structure_id}`, `POST /gov/structures/{structure_id}/roles`
 - Activities: `POST/GET /gov/entities/{entity_id}/activities`, `GET /gov/activities/{activity_id}`
 - Federation / SDIS proposal shortcuts: `/gov/proposals/federation/...`, `/gov/proposals/sdis/...`

--- a/docs/strategy/NYCN-Repo-Architecture-Spec.md
+++ b/docs/strategy/NYCN-Repo-Architecture-Spec.md
@@ -1,0 +1,735 @@
+# NYCN × ICN Repo-Shaped Architecture Spec
+
+**Status**: Spec (docs-only, grounded against `main` at `37ec91e0` — 2026-04-14)
+**Supersedes**: portions of `NYCN-Institutional-Design.md` (see §0.3)
+**Companion docs**:
+- `NYCN-Implementation-Matrix.md` — per-object gap table (exists / partial / missing)
+- `NYCN-Execution-Tranches.md` — merge-order + dependency plan
+
+---
+
+## 0. Preamble
+
+### 0.1 Purpose
+
+Turn the NYCN/NYCS institutional design into a **repo-shaped technical map**: which crates, which modules, which stores, which events, which HTTP routes. Ground every claim in code that exists on `main` today, on open PRs, or in committed design docs — and clearly distinguish the three.
+
+This is **not** a re-derivation of the institutional model. The institutional model was locked on 2026-04-14 (layered ontology: sovereign entities vs. internal structures vs. time-bounded activities). This document is the mechanical follow-through.
+
+### 0.2 Ground truth as of writing
+
+Verified directly against the repo on 2026-04-14:
+
+| Fact | Source | Value |
+|------|--------|-------|
+| Main HEAD | `git log origin/main` | `37ec91e0 feat(governance): institutional structure + event model (Tranche 2, part 1) (#1540)` |
+| PR #1532 decision→action bridge | `gh pr view 1532` | **MERGED** |
+| PR #1533 consent mode | `gh pr view 1533` | **MERGED** |
+| PR #1540 structure + activity + parent | `gh pr view 1540` | **MERGED** |
+| PR #1542 security audit fix | `gh pr view 1542` | **MERGED** |
+| PR #1543 meeting management | `gh pr view 1543` | **OPEN, mergeable, CI green except benchmark regression (non-blocking with `perf-regression-ok`)** |
+| `feat/notification-digests` | `git branch` | Local + remote, **no PR opened** |
+| `docs/strategy/NYCN-*` docs | filesystem | `Charter-Draft.yaml`, `Implementation-Plan.md`, `Institutional-Design.md`, `Institutional-Strategy.md`, `Sprint-Plan.md` (NOT the `Bootstrap-Runbook.md` / `Schema-Mapping.md` the prior session claimed — those do not exist) |
+
+### 0.3 Correction to prior design docs
+
+`NYCN-Institutional-Design.md` (committed 2026-04-13) maps committees (finance, content, logistics, marketing, steering) and `nycn-summit-2026` to `Community(CommunityProfile)` entities. **This is superseded.** The locked layered ontology (2026-04-14, merged as #1540) states:
+
+- **Entities** (sovereign, join federations, hold independent treasury): NYCN federation, `nycn-organizers` co-op, member co-ops.
+- **Structures** (non-sovereign, owned by a parent entity, delegated authority): committees, working groups, backbone group, host pods. `icn-governance::structure::Structure { kind: Committee | WorkingGroup | Team | Office }`.
+- **Activities** (time-bounded, owned by a parent entity): the summit cycle, regional meetup series, policy-advocacy day, sponsor campaigns. `icn-governance::activity::Activity { kind: Event | Program | Project | Initiative }`.
+
+Operational objects (action items, meetings, documents) attach to any of the three layers via `icn-governance::parent::InstitutionalParent`.
+
+Concretely, the NYCN topology becomes:
+
+```
+nycn                          Entity: Federation
+├── nycn-organizers           Entity: Cooperative (parent_id: "nycn")
+│   ├── nycn-backbone         Structure { kind: Committee, parent_entity_id: "nycn-organizers" }
+│   ├── nycn-finance          Structure { kind: Committee, parent_entity_id: "nycn-organizers" }
+│   ├── nycn-content          Structure { kind: Committee, parent_entity_id: "nycn-organizers" }
+│   ├── nycn-logistics        Structure { kind: Committee, parent_entity_id: "nycn-organizers" }
+│   ├── nycn-marketing        Structure { kind: Committee, parent_entity_id: "nycn-organizers" }
+│   └── nycn-accessibility-wg Structure { kind: WorkingGroup, parent_entity_id: "nycn-organizers" }
+└── summit-2026               Activity { kind: Event, parent_entity_id: "nycn-organizers" }
+    (references committees via Activity.structures: Vec<StructureId>)
+```
+
+The older design doc's entity tree should be edited in a follow-up docs PR to match this.
+
+### 0.4 Decisive test
+
+> Can a new organizer enter the system mid-cycle, switch into the right scope, see the summit's current phase, understand what was decided, know what is blocked, receive their obligations, trace why they exist, and continue the work without needing private oral history?
+
+Every architectural choice below is evaluated against that question.
+
+---
+
+## 1. Current-state audit
+
+### 1.1 What is already implemented on `main`
+
+Grounded in direct inspection of `icn/crates/icn-governance/src/` and `icn/apps/governance/src/`:
+
+| Capability | Code location | Notes |
+|-----------|---------------|-------|
+| Governance domain + proposals + voting | `icn-governance::{domain,proposal,vote,tally,profile}` | Mature |
+| Consent decision mode (majority / consent, `max_objections`) | `icn-governance::config`, `profile.rs` | #1533 merged |
+| Action items (CRUD, status, priority, notes, filter, sled store) | `icn-governance::action_item` (1281 LOC) | Full store trait + `SledActionItemStore` + assignee index |
+| Decision→action bridge: accepted proposals auto-materialize `ActionItemSpec`s with provenance | `icn-governance::proposal::ActionItemSpec`, `apps/governance/src/actor.rs` | #1532 merged |
+| Institutional Structure (Committee / WorkingGroup / Team / Office) + sled store | `icn-governance::structure` (548 LOC), `apps/governance/src/manager.rs::SledStructureStore` | #1540 merged |
+| Role Assignment (scope-aware, authority-typed) | `icn-governance::structure::RoleAssignment` | #1540 merged |
+| Activity (Event / Program / Project / Initiative) + sled store | `icn-governance::activity` (335 LOC), `apps/governance/src/manager.rs::SledActivityStore` | #1540 merged |
+| Polymorphic `InstitutionalParent` attachment for action items | `icn-governance::parent`, `action_item::ActionItem.parent` | #1540 merged |
+| Federation charter / charter store | `icn-governance::{charter, charter_store}` | Mature |
+| Steward / steward store (SDIS) | `icn-governance::{steward, steward_store}` | Mature |
+| Delegation | `icn-governance::delegation` (1717 LOC) | Mature |
+| Discussion / appeal / amendment | `icn-governance::{discussion, appeal, amendment}` | Mature |
+| Gateway events (structure/activity/proposal lifecycle) | `icn-gateway::events::GatewayEvent` | |
+| HTTP surface for governance | `apps/governance/src/http/{configure,handlers,models}.rs` | Proposals, action items, structures, activities wired |
+
+### 1.2 What is on open / unlanded branches
+
+| Capability | Branch | Status |
+|-----------|--------|--------|
+| **Meeting** primitive (564 LOC model + store + 9 HTTP endpoints + gateway events) | `feat/meeting-management` / **PR #1543** | OPEN, mergeable, CI green except non-blocking benchmark regression. Review comments from codex + copilot-reviewer; no blocking human review yet. |
+| **Notification digest** endpoint (`DigestSummary`, `PendingVoteDigest`, `OverdueItemDigest`, `list_by_assignee` default + sled assignee secondary index, `GET /digest` handler) | `feat/notification-digests` | Local + remote branch, 1 commit ahead of main, **NO PR yet opened**. Upcoming-meetings stubbed at 0 because #1543 wasn't merged. Assignee secondary index not backfilled. |
+
+### 1.3 What exists only as strategy / design docs
+
+- `docs/strategy/NYCN-Institutional-Strategy.md`
+- `docs/strategy/NYCN-Institutional-Design.md` (partially superseded — see §0.3)
+- `docs/strategy/NYCN-Implementation-Plan.md` (5-phase plan; phases 1/2 shipped, phase 3 in PR, phase 4 on unpushed-PR branch, phase 5 unstarted)
+- `docs/strategy/NYCN-Sprint-Plan.md` (3-lane sprint, largely executed)
+- `docs/strategy/NYCN-Charter-Draft.yaml` (CCL draft for NYCN federation charter)
+
+### 1.4 What is missing entirely
+
+No code or open branch addresses:
+
+1. **Program/cycle container** as a first-class domain concept beyond `Activity`. Activity is enough for the summit as an *event*; it does **not yet carry milestones, stage gates, closure state, or cycle-handoff hooks**.
+2. **Program milestones** with machine-readable required-check predicates (`venue_locked`, `budget_locked`, `public_launch_ready`, `closure_complete`).
+3. **Sponsor pipeline**: no `Sponsor` type, no status lifecycle, no pipeline view.
+4. **Budget items / financial obligations** at the program level (treasury exists at the entity level, but no per-program earmarking).
+5. **Sessions / speakers**: no `Session` primitive, no publication state, no language-needs tracking.
+6. **Registrations** with structured accessibility/childcare/language/dietary fields.
+7. **Accessibility state model**: no typed accessibility scoring for venues/programs.
+8. **Institutional document / memory store**: no typed `InstitutionalDocument` with version lineage, authorship, content addressing, or meeting/proposal linkage. (Phase 5 of the implementation plan; unstarted.)
+9. **External-source provenance edges**: no `SourceRef` type to link Google Docs, Sheets, mailing lists, ny-coop-net rows, legacy repos with `linked | mirrored | imported | derived` provenance classification.
+10. **Delegation of role-bound capabilities** with explicit grantor/grantee/scope/authority/time-window records distinct from the `delegation.rs` crate (which is about governance delegation, not operational scope delegation).
+11. **Digest partitioning** by scope/role; current digest is DID-level only.
+12. **Cycle-comparison / year-over-year view** derived from activity records.
+13. **Organizer onboarding pipeline** (interest → orientation → role → first task).
+
+### 1.5 Meaning-firewall status
+
+`icn-governance` is an **app-layer** crate by convention (it implements `PolicyOracle`, it imports `icn-identity::Did`). It is legitimately allowed to hold domain types. What the firewall forbids is **kernel** crates importing domain types. Nothing in this architecture proposes kernel imports of NYCN-specific anything. Every NYCN concept lives inside `icn-governance` (domain primitive) or `apps/governance` (persistence + HTTP).
+
+The only firewall risk to watch: **do not hardcode NYCN-specific string constants into kernel crates.** Use NYCN as a test fixture, not a dependency.
+
+---
+
+## 2. Bounded domain mapping
+
+Eleven bounded domains were identified in the institutional review. Map each to the concrete ICN ownership:
+
+| Domain | Owning crate(s) | Status | Notes |
+|--------|----------------|--------|-------|
+| Identity & participation | `icn-identity`, `icn-entity`, `icn-governance::membership`, `icn-governance::structure::RoleAssignment` | ✅ sufficient for NYCN bootstrap | Membership + role-assignment cover organizers, committee members, partner-org membership |
+| Institutional structure | `icn-governance::structure` + `apps/governance/src/manager.rs::SledStructureStore` | ✅ covers committees / working groups / backbone / host-pods | Do **not** promote committees to entities |
+| Governance | `icn-governance::{proposal, vote, tally, profile, config, discussion, appeal, amendment}` + `apps/governance/src/actor.rs` | ✅ mature, incl. consent mode + decision→action bridge | |
+| **Program / cycle** | **Proposed: `icn-governance::program` (NEW)** on top of `icn-governance::activity` | ⚠️ Activity exists, Program container + milestones missing | See §5 |
+| Meeting | `icn-governance::meeting` + `apps/governance/src/manager.rs::SledMeetingStore` | 🚧 on PR #1543 | Merge, validate with an NYCN scenario test, then build on it |
+| Work execution | `icn-governance::action_item` + decision-bridge | ✅ with `InstitutionalParent` attachment | `meeting_id: Option<MeetingId>` field added on #1543 |
+| Communications / digests | `apps/governance::manager::{DigestSummary, PendingVoteDigest, OverdueItemDigest}` on `feat/notification-digests` | 🚧 unpushed PR, upcoming-meetings stub | Must be redone to consume #1543's meeting store once merged, and eventually partitioned by scope |
+| Funding / resource | Treasury: `icn-ledger` (mature). **Sponsor / budget items: MISSING** | ❌ missing | Propose `icn-governance::sponsor` + `icn-governance::budget_item` (or place in a dedicated `apps/programs` app if the scope grows) |
+| Content / session | **MISSING** | ❌ missing | Propose `icn-governance::session` |
+| Registration / attendee | **MISSING** | ❌ missing | Propose `icn-governance::registration` with structured accessibility fields |
+| Archive / provenance | `icn-governance::proof` (governance receipts), `icn-store` (sled). **InstitutionalDocument: MISSING** | ⚠️ provenance exists for decisions; institutional docs missing | Phase 5 of implementation plan |
+
+**Design principle carried from the institutional review**: each domain gets its own module inside `icn-governance`, with a paired `Sled<X>Store` in `apps/governance/src/manager.rs` and an HTTP surface in `apps/governance/src/http/`. This matches the pattern already established by `structure`, `activity`, `action_item`, and (in PR) `meeting`. Do not invent new crate boundaries until a domain has justified it (e.g. sponsor + budget + session may eventually move to an `apps/programs` app once they reach ~3k LOC and their own oracle semantics emerge).
+
+---
+
+## 3. Canonical object mapping
+
+Every object from the institutional review, mapped to repo reality.
+
+| Object | Canonical home | Status | Notes |
+|--------|---------------|--------|-------|
+| `Entity` | `icn-entity` (existing) | ✅ | `Federation`, `Cooperative`, `Community`, `Individual` — used for NYCN, nycn-organizers, member co-ops only |
+| `Person / Actor` | `icn-identity::Did` | ✅ | |
+| `Participation` | `icn-governance::membership` + `RoleAssignment` | ✅ for member/role cases | Sponsor / speaker / attendee participation is MISSING (see §3 below) |
+| `Structure` | `icn-governance::structure::Structure` | ✅ | `kind: Committee/WorkingGroup/Team/Office` |
+| `RoleAssignment` | `icn-governance::structure::RoleAssignment` | ✅ | Scope-aware, authority-typed (advisory / binding / delegated / temporary / emergency — verify enum matches) |
+| **Program** | proposed `icn-governance::program::Program` | ❌ missing | Wraps `Activity` with milestones, phase state, closure hooks |
+| `Activity` | `icn-governance::activity::Activity` | ✅ | Use as building block for Program |
+| `Meeting` | `icn-governance::meeting::Meeting` | 🚧 PR #1543 | |
+| `AgendaItem` | `icn-governance::meeting::AgendaItem` | 🚧 PR #1543 | |
+| `Proposal / Decision` | `icn-governance::proposal::Proposal` | ✅ | `action_items_on_accept` already wired |
+| `ActionItem` | `icn-governance::action_item::ActionItem` | ✅ | Carries `parent`, `linked_proposal`, `meeting_id` (on PR #1543) |
+| **Campaign / Initiative** | `Activity { kind: Initiative }` or `Activity { kind: Campaign }` | ⚠️ partial | `ActivityKind` enum has `Initiative` but no `Campaign` variant. Add if needed. |
+| **Sponsor record** | proposed `icn-governance::sponsor::Sponsor` | ❌ missing | |
+| **Budget item** | proposed `icn-governance::budget_item::BudgetItem` | ❌ missing | |
+| **Session / speaker** | proposed `icn-governance::session::Session` | ❌ missing | |
+| **Registration** | proposed `icn-governance::registration::Registration` | ❌ missing | |
+| **SourceRef / document link** | proposed `icn-governance::source_ref::SourceRef` (or lift to `icn-provenance` if cross-domain) | ❌ missing | |
+| **Digest packet** | `apps/governance::manager::DigestSummary` | 🚧 on `feat/notification-digests` | Needs rework to consume meeting store once #1543 lands |
+| **InstitutionalDocument** | proposed `icn-governance::document::InstitutionalDocument` | ❌ missing | Phase 5 of implementation plan |
+| **Milestone** | proposed `icn-governance::program::Milestone` | ❌ missing | Tied to Program |
+| **Delegation (operational)** | `icn-governance::delegation` (governance-flavored) | ⚠️ partial | Existing `delegation.rs` is for governance voting delegation. Operational role-delegation is a different shape; may be a new module `role_delegation.rs` or fields on `RoleAssignment` |
+
+### 3.1 Participation gap
+
+The institutional model needs participation records that are *not* governance membership:
+
+- Attendee → Program
+- Speaker → Session
+- Sponsor-contact (person) → Sponsor record
+- Volunteer → Program or Structure
+
+Two options:
+1. **Extend `RoleAssignment`** with more `role_type` values (but this overloads governance semantics onto non-governance relationships).
+2. **Add a separate `Participation` type** in `icn-governance::participation` that is *relational* (subject → object → type) without granting authority.
+
+**Recommendation**: option 2. Governance-bearing participation stays in `RoleAssignment`. Non-authority participation (sponsor, speaker, attendee, volunteer) lives in a new lightweight `Participation` module. This preserves the meaning firewall inside the app layer — authority-granting relationships remain auditable and distinct from data-only relationships.
+
+---
+
+## 4. Authority and scope model
+
+### 4.1 What currently supports scope switching
+
+`RoleAssignment` (in `icn-governance::structure`) already carries:
+- `actor_did` (who)
+- `scope` — structure ID the role is for
+- role type + authority level
+- start/end
+
+Combined with `MembershipCapability` on entity membership, a user can already be "Matt acting as finance-committee lead on nycn-finance" vs. "Matt acting as an attendee on summit-2026". **This is the primitive for scope switching.**
+
+What is missing:
+- **Active-scope selection** at the HTTP/session layer. The gateway currently takes JWTs with `coop_id` and `scopes`. It does not yet have a first-class "act-as-structure-X-with-role-Y" selection mechanism.
+- **Delegation records** for temporary role handoff ("Matt delegates venue-selection to Priya for 2 weeks").
+
+### 4.2 Proposed additions
+
+1. **`SessionScope` in gateway request context** — resolved from DID + active scope claim against `RoleAssignment` store. Belongs in `icn-gateway::auth` / wherever JWT claims are validated.
+2. **`RoleDelegation`** — in `icn-governance::structure` or a new `icn-governance::role_delegation` module. Fields: `grantor`, `grantee`, `scope_ref`, `capabilities`, `starts_at`, `ends_at`, `reason`, `revoked_at`. Distinct from `icn-governance::delegation` (which is vote-delegation).
+
+### 4.3 Backbone authority
+
+The backbone group is one of the most politically load-bearing concepts in NYCN and one of the least supported today. Model it as:
+
+```rust
+Structure {
+    id: StructureId("nycn-backbone"),
+    parent_entity_id: "nycn-organizers",
+    kind: StructureKind::Committee,
+    // metadata: { "authority_class": "backbone", "requires_ratification_for": ["...categories..."] }
+}
+```
+
+Authority-rule enforcement should be a **PolicyOracle decision**, not a hard-coded match. Specifically: when a proposal is opened in a backbone-group domain with a type that requires full-network ratification, the oracle refuses to finalize unilaterally and flags it as requiring downstream ratification in the parent's governance domain. This keeps the meaning firewall intact and makes NYCN's authority rules data-driven rather than NYCN-specific code.
+
+---
+
+## 5. Program / cycle model
+
+**Decision**: `Activity` is not enough. `Activity { kind: Event }` captures the summit-as-thing; it does not capture the summit-as-cycle-with-stage-gates. Promote to a `Program` primitive that wraps `Activity`.
+
+### 5.1 Proposed module: `icn-governance::program`
+
+```rust
+pub struct ProgramId(pub String);
+
+pub enum ProgramKind {
+    AnnualSummit,       // summit-2026
+    Campaign,           // sponsor outreach push
+    Initiative,         // organizer recruitment drive
+    Series,             // regional meetup series
+    PolicyDay,          // advocacy day
+}
+
+pub enum ProgramStatus {
+    Draft,
+    ActivePlanning,
+    PublicLaunch,
+    InExecution,
+    Closed,
+    Archived,
+}
+
+pub struct Program {
+    pub id: ProgramId,
+    pub parent_entity_id: String,
+    pub activity_id: Option<ActivityId>,  // optional link for legacy Activity-only consumers
+    pub kind: ProgramKind,
+    pub name: String,
+    pub year: Option<u32>,
+    pub status: ProgramStatus,
+    pub start_at: Option<Timestamp>,
+    pub end_at: Option<Timestamp>,
+    pub parent_program_id: Option<ProgramId>,
+    pub milestones: Vec<Milestone>,
+    pub metadata: serde_json::Value,
+    pub created_at: Timestamp,
+    pub closed_at: Option<Timestamp>,
+}
+
+pub struct Milestone {
+    pub id: MilestoneId,
+    pub program_id: ProgramId,
+    pub milestone_type: MilestoneType,
+    pub required_checks: Vec<CheckRef>,
+    pub status: MilestoneStatus,
+    pub completed_at: Option<Timestamp>,
+    pub completed_by: Option<Did>,
+}
+
+pub enum MilestoneType {
+    StrategyLocked,
+    VenueLocked,
+    BudgetLocked,
+    PublicLaunchReady,
+    EventReady,
+    ClosureComplete,
+    Custom(String),
+}
+```
+
+### 5.2 Why not just fatten `Activity`?
+
+1. **Lifecycle divergence**: Activities have 4 statuses (`Planned/Active/Completed/Cancelled`). Programs have 6+ including `PublicLaunch` and `InExecution` which are operationally distinct from "active". Overloading `ActivityStatus` degrades signal.
+2. **Stage-gate semantics**: Milestones with machine-readable required-check predicates are a Program concept, not a generic Activity concept. A regional meetup series (also an Activity) doesn't want milestones; it wants recurrence.
+3. **Cycle-comparison**: `parent_program_id` lets `summit-2026` point to `summit-2025` for year-over-year views. This is awkward as a generic Activity self-reference.
+4. **Sprint-plan coherence**: Several future objects (sponsor, budget_item, session, registration) naturally hang off a Program, not a generic Activity.
+
+**Activity remains the right level for**: meetings' parent context, one-off workshops, ad-hoc projects that don't need staging.
+**Program is the right level for**: recurring cycles with closure/handoff and stage-gated readiness.
+
+### 5.3 Storage + HTTP
+
+- `apps/governance/src/manager.rs::SledProgramStore` — follows the `SledActivityStore` pattern.
+- `apps/governance/src/http/`:
+  - `POST /programs`
+  - `GET /programs`
+  - `GET /programs/{id}`
+  - `POST /programs/{id}/milestones`
+  - `PATCH /programs/{id}/milestones/{mid}` (complete / fail / reset)
+  - `POST /programs/{id}/close`
+  - `GET /programs/{id}/dashboard` — derived view; see §9
+
+### 5.4 Events
+
+Add to `icn-gateway::events::GatewayEvent`:
+- `ProgramOpened`
+- `ProgramClosed`
+- `MilestoneCompleted`
+- `MilestoneBlocked`
+
+---
+
+## 6. Event-driven flow mapping
+
+ICN already has `GatewayEvent` emission on proposal/action-item/structure/activity lifecycle. The NYCN integration does **not** require a new event bus — it requires adding variants and wiring more materializers.
+
+### 6.1 Governance → task chain (already wired)
+
+```
+proposal.accepted
+  → action_item.created (n, via ActionItemSpec materialization in actor.rs)
+  → GatewayEvent::ProposalAccepted
+  → GatewayEvent::ActionItemCreated (per item)
+```
+
+Gap: no `digest.generated` event is emitted downstream. Add when digest service gets a real task loop.
+
+### 6.2 Meeting closure chain (after #1543 merges)
+
+```
+meeting.held  (status = Held)
+  → notes linked (document ref; see Phase 5)
+  → decisions recorded (proposal references on agenda items)
+  → action_items created (from AgendaItem.generated_action_items on close)
+  → post_meeting_digest.generated (new)
+```
+
+Requires a `POST /meetings/{id}/close` handler that:
+1. Validates meeting is `InProgress`.
+2. For each `AgendaItem` with unresolved state, optionally generates an `ActionItem` with `parent = InstitutionalParent::Activity(...)` or `Structure(...)` and `meeting_id` set.
+3. Emits `GatewayEvent::MeetingEnded`.
+4. Optionally triggers a digest packet generation addressed to attendees.
+
+### 6.3 Registration → operations chain
+
+```
+registration.confirmed
+  → attendee_count += 1 on program
+  → accessibility_requirements tallied
+  → logistics digest update
+```
+
+Not implementable until `Registration` primitive exists.
+
+### 6.4 Sponsor pipeline chain
+
+```
+sponsor.status_changed(confirmed)
+  → budget_item.created (income, amount, program)
+  → recognition_obligation.created (action item, parent = program, assignee = marketing-committee lead)
+  → finance_digest entry
+```
+
+Not implementable until `Sponsor` + `BudgetItem` exist.
+
+### 6.5 Meaning-firewall note on events
+
+Gateway events are **domain-shaped** but must remain kernel-neutral. Adding `SponsorConfirmed` to `GatewayEvent` is fine. What is **not** fine: embedding NYCN-specific payload fields ("nycn_sponsor_tier": "platinum") in the event. Sponsor tiers belong in the `Sponsor` record, not in the event envelope.
+
+---
+
+## 7. Stage gates as machine-readable milestones
+
+Already described in §5. Key implementation points:
+
+- `CheckRef` should be an enum pointing to concrete predicates (`VenueSelected`, `HotelAccessReviewEntered`, `TransitAccessReviewEntered`, `AccessibilityScoreEntered`, `PublicCopyPresent`, …).
+- Evaluating a milestone = running all its `required_checks` against the program state + linked records.
+- **Milestones do not auto-complete.** A user with appropriate scope (role on the owning structure or program lead) completes them explicitly, with the evaluator confirming all required checks pass.
+- Gating transitions (Draft → ActivePlanning → PublicLaunch → InExecution → Closed) on required milestone completion enforces stage-gate discipline without hardcoding NYCN's specific process.
+
+---
+
+## 8. Query / organizer UX model
+
+### 8.1 Derived views required
+
+| View | Inputs | Backing endpoint | Current status |
+|------|--------|-----------------|----------------|
+| `MyActionQueueView` | `ActionItem` by assignee, status, due | `GET /digest` (partial) | 🚧 on `feat/notification-digests`; needs completion |
+| `MyScopeView` | `RoleAssignment` by actor | **MISSING** (no `GET /me/scopes` handler) | ❌ |
+| `ProgramDashboardView` | `Program` + linked `Milestone`s + `ActionItem` counts + `Sponsor` counts + `Registration` counts | **MISSING** | ❌ (depends on Program + others) |
+| `CommitteeOperationalView` | `Structure` + recent meetings + open action items | partially buildable from existing stores | ⚠️ needs composition handler |
+| `SponsorPipelineView` | `Sponsor` by status | depends on Sponsor | ❌ |
+| `AccessibilityStatusView` | `Registration.accessibility_notes` + program venue accessibility fields | depends on Registration + venue model | ❌ |
+| `PostMeetingSummaryView` | `Meeting` + linked decisions + generated action items | depends on #1543 | 🚧 |
+| `CycleComparisonView` | `Program` + `parent_program_id` → previous cycle's objects | depends on Program | ❌ |
+| `OrganizerOnboardingView` | Onboarding pipeline state | **MISSING** (requires onboarding subsystem) | ❌ |
+
+### 8.2 Implementation pattern
+
+Each view = a struct in `apps/governance/src/http/views.rs` (new file) + a `GET` handler that composes multiple store reads. **Do not** build a separate "view store" with its own persistence; views are computed-from-canonical. If performance becomes a concern, add cached materializers behind feature flags.
+
+### 8.3 Where the mobile SDK ties in
+
+`docs/mobile/icn-mobile-ux-spec-v1.md` already anchors mobile surfaces to gateway API. The NYCN-facing mobile views (My Work, My Scope, Upcoming Meetings, Program Dashboard) should consume these same endpoints. Do not branch mobile-specific endpoints.
+
+---
+
+## 9. Communications and digest architecture
+
+### 9.1 Current state
+
+`feat/notification-digests` gives us:
+- `DigestSummary { pending_votes: Vec<PendingVoteDigest>, overdue_items: Vec<OverdueItemDigest>, upcoming_meetings: Vec<_> (stub) }`
+- `GovernanceManager::generate_digest(did) -> DigestSummary`
+- `GET /digest?did=...` handler
+- `list_by_assignee` on `ActionItemStoreBackend`
+- Assignee secondary index in `SledActionItemStore`
+
+### 9.2 Required rework before shipping
+
+Blocking issues identified in the review:
+
+1. **Upcoming meetings stub** — wire against `SledMeetingStore` once #1543 merges. The digest branch was created before meetings landed, so this field currently returns `Vec::new()`.
+2. **Assignee index not backfilled** — new items get indexed, existing items do not. Add a one-shot migration in `SledActionItemStore::ensure_assignee_index()` called on store init that walks all items once if an index version marker is absent.
+3. **No scope partitioning** — current digest is DID-level. Phase 4.5: partition by structure/program scope so a user can get "my finance committee digest" distinct from "my summit-2026 digest".
+4. **No delivery** — digest is pull-only. That's fine for v1, but add a `DigestDelivery` record (not yet implemented, not blocking) for later email/webhook integration.
+
+### 9.3 Digest types to expand to
+
+v1 (current PR scope): personal work digest
+v1.1 (follow-up): committee digest, program digest, pre-meeting packet, post-meeting summary
+v2 (later): decision announcement, sponsor follow-up, organizer onboarding sequence
+
+### 9.4 Storage rule
+
+Digests are **ephemeral derivations** unless explicitly persisted. `DigestSummary` is a response shape, not a stored record. If we later need "show me last week's digest as delivered", introduce a `DigestPacket` record with `generated_at`, `scope_ref`, `content_hash`, `delivery_state`. Do not prematurely store digests.
+
+---
+
+## 10. Accessibility and representation as structured data
+
+### 10.1 Proposal: `icn-governance::accessibility`
+
+A lightweight module that defines:
+
+```rust
+pub struct VenueAccessibility {
+    pub transit_score: Option<AccessibilityScore>,
+    pub hotel_walkability_score: Option<AccessibilityScore>,
+    pub childcare_fit: ChildcareFit,
+    pub interpretation_supported: Vec<LanguageCode>,
+    pub sobriety_friendly: bool,
+    pub navigation_clarity_score: Option<AccessibilityScore>,
+    pub restroom_inclusion_notes: Option<String>,
+    pub family_support_notes: Option<String>,
+    pub environmental_quality_notes: Option<String>,
+}
+
+pub enum AccessibilityScore { Poor, Fair, Good, Excellent, Unknown }
+pub enum ChildcareFit { None, OnSite, NearSite, NotEvaluated }
+```
+
+This struct is embedded on `Program` (for program-level fit) and referenced from venue records (TBD — venues may just live in `Program.metadata` initially).
+
+### 10.2 Registration-side accessibility fields
+
+When `Registration` is implemented, it carries:
+- `dietary_needs: Vec<String>`
+- `childcare_needs: Option<ChildcareNeed>`
+- `language_needs: Vec<LanguageCode>`
+- `accessibility_notes: Option<String>` (free text for requests the structured fields don't cover)
+
+The `AccessibilityStatusView` joins registration fields with venue fit to surface gaps.
+
+### 10.3 Representation tracking
+
+Add optional fields on `Session`:
+- `sector: Option<String>` (worker-coop, ag, housing, solidarity-econ, platform, …)
+- `geography: Option<String>`
+- `language: LanguageCode`
+- `cooperative_type: Option<String>`
+
+Plus a derived representation dashboard that aggregates these. Early implementation can be a `GET /programs/{id}/representation` handler that buckets confirmed sessions.
+
+---
+
+## 11. External tool integration and migration boundaries
+
+### 11.1 `SourceRef` primitive
+
+Proposed module `icn-governance::source_ref`:
+
+```rust
+pub enum SourceSystem {
+    GoogleDoc,
+    GoogleSheet,
+    DriveFile,
+    LegacyRepo,
+    MailingList,
+    NyCoopNetRow,
+    ManualEntry,
+    Other(String),
+}
+
+pub enum ProvenanceType {
+    Linked,     // reference only
+    Mirrored,   // synced copy in ICN
+    Imported,   // structured extraction
+    Derived,    // generated from other canonical records
+}
+
+pub struct SourceRef {
+    pub id: SourceRefId,
+    pub source_system: SourceSystem,
+    pub external_identifier: String,
+    pub title: Option<String>,
+    pub uri: Option<String>,
+    pub captured_at: Timestamp,
+    pub checksum: Option<String>,
+    pub provenance_type: ProvenanceType,
+}
+```
+
+Every canonical object that was imported from an external system should carry `source_refs: Vec<SourceRef>` (or equivalent).
+
+### 11.2 ny-coop-net migration
+
+`~/projects/ny-coop-net` (if present) is the legacy Postgres-backed operational app. The migration pattern:
+
+1. For each table in ny-coop-net, map rows to canonical ICN objects (entities, participations, programs, sponsors, etc.).
+2. Each materialized ICN record carries a `SourceRef { system: NyCoopNetRow, external_identifier: "<table>:<row_pk>" }`.
+3. Build a one-shot importer binary (`bins/icn-nycn-import` or a script in `scripts/`) that reads ny-coop-net and writes ICN records idempotently (re-running should not double-import).
+4. Do NOT write directly to ICN sled stores. Use the HTTP API so that the importer exercises the same validation path.
+
+### 11.3 Google Docs / Sheets
+
+- Link-only in v1 via `SourceRef { system: GoogleDoc, uri: "..." }`.
+- Mirroring and structured import are Phase 5 (document primitive) territory.
+
+### 11.4 Mailing lists
+
+- Link only. A user explicitly attaches a mailing-list archive link to a program or structure. Do not attempt mailing-list import in this integration.
+
+---
+
+## 12. Provenance and audit requirements
+
+### 12.1 Built-in provenance
+
+ICN's governance proof (`icn-governance::proof`), action item `linked_proposal`, and `ActionItem.parent` (`InstitutionalParent`) already give us:
+
+- Proposal → action item lineage (via `linked_proposal` + provenance hash in the decision-to-action bridge)
+- Action item → institutional scope (via `parent`)
+- Action item → meeting (via `meeting_id`, on PR #1543)
+
+### 12.2 Gaps
+
+- **Sponsor state changes** — will need an audit log of (who, when, old state, new state) when `Sponsor` is implemented. Pattern: store state-change events alongside the record, either inline (`Vec<StatusChange>`) or as a separate `SponsorStatusLog`.
+- **Milestone completion** — record `completed_by: Did` + `completed_at`. This is already in the proposed Milestone struct.
+- **Registration confirmation** — needs payment-state history if any.
+- **Document version lineage** — Phase 5; `InstitutionalDocument.parent_doc` gives us content-addressed version chains.
+
+### 12.3 Rule
+
+Every state transition on a canonical object should be attributable. If the Rust type doesn't record the actor of a transition, add a `changed_by: Did` field or a side-log, but do not silently mutate without actor attribution.
+
+---
+
+## 13. API surface expectations
+
+Consolidated from §5, §6, §8, §9. Group under `/gov/` (existing governance HTTP namespace in `apps/governance/src/http/`):
+
+- Structures: `POST /structures`, `GET /structures`, `GET /structures/{id}`, `POST /structures/{id}/roles`, `GET /structures/{id}/action-items`, `GET /structures/{id}/meetings` (after #1543)
+- Activities: existing
+- **Programs** (new): `POST /programs`, `GET /programs`, `GET /programs/{id}`, `POST /programs/{id}/milestones`, `PATCH /programs/{id}/milestones/{mid}`, `POST /programs/{id}/close`, `GET /programs/{id}/dashboard`, `GET /programs/{id}/sessions`, `GET /programs/{id}/sponsors`, `GET /programs/{id}/registrations`, `GET /programs/{id}/accessibility-status`, `GET /programs/{id}/representation`
+- Meetings: `POST /meetings`, `GET /meetings/{id}`, `POST /meetings/{id}/agenda-items`, `POST /meetings/{id}/close`, `GET /meetings/{id}/summary` (after #1543)
+- Proposals: existing, incl. `action_items_on_accept`
+- Action items: existing + `GET /action-items/my`
+- **Sponsors** (new): `POST /sponsors`, `PATCH /sponsors/{id}`, `GET /sponsors`, `GET /programs/{id}/sponsors`
+- **Budget items** (new): `POST /budget-items`, `GET /programs/{id}/budget`, `PATCH /budget-items/{id}`
+- **Sessions** (new): `POST /sessions`, `PATCH /sessions/{id}`, `GET /programs/{id}/sessions`
+- **Registrations** (new): `POST /registrations`, `GET /programs/{id}/registrations`
+- Digests: `GET /digest` (DID-level), `GET /digest?scope=structure:nycn-finance`, `GET /my/digests/...` (later)
+- Me / scope: `GET /me/scopes` (new), `GET /me/work` (new — composes `MyActionQueueView`)
+- Provenance: `GET /history/{ref}`, `GET /provenance/{ref}` (later)
+
+### 13.1 TypeScript SDK drift
+
+Every new HTTP model added to `apps/governance/src/http/models.rs` requires regenerating `sdk/typescript/src/generated/api-types.ts` via `cd sdk/typescript && npm ci && npm run generate-types`. Commit as `chore(sdk): regenerate TypeScript API types` per CLAUDE.md's drift-fix recipe.
+
+---
+
+## 14. Storage model guidance
+
+### 14.1 Pattern (already established)
+
+For each new domain object:
+1. Define the struct + store trait in `icn-governance::<module>`.
+2. Implement `InMemory<X>Store` in-module for tests.
+3. Implement `Sled<X>Store` in `apps/governance/src/manager.rs` with sled key prefixes `<module>:<id>` and any secondary indexes (`<module>_idx:<field>:<value>`).
+4. Wire into `GovernanceManager`.
+5. Use content-addressing for document-like objects (blake3 of canonical body).
+
+### 14.2 Indexes to plan
+
+| Store | Primary | Secondary indexes required |
+|-------|---------|---------------------------|
+| ActionItem | `action_item:<id>` | `ai_idx:assignee:<did>:<id>` (on `feat/notification-digests`), plus needed: `ai_idx:parent:<parent_tag>:<parent_id>:<id>`, `ai_idx:status:<status>:<id>` |
+| Structure | `structure:<id>` | `structure_idx:parent_entity:<id>:<sid>` |
+| Activity | `activity:<id>` | `activity_idx:parent_entity:<id>:<aid>` |
+| Program (new) | `program:<id>` | `program_idx:parent_entity:<id>:<pid>`, `program_idx:status:<status>:<pid>`, `program_idx:kind:<kind>:<pid>` |
+| Meeting (PR) | `meeting:<id>` | `meeting_idx:scope:<scope_tag>:<scope_id>:<scheduled_at>:<mid>` |
+| Sponsor (new) | `sponsor:<id>` | `sponsor_idx:program:<pid>:<sid>`, `sponsor_idx:status:<status>:<sid>` |
+| BudgetItem (new) | `budget_item:<id>` | `budget_idx:program:<pid>:<bid>` |
+| Session (new) | `session:<id>` | `session_idx:program:<pid>:<sid>`, `session_idx:status:<status>:<sid>` |
+| Registration (new) | `registration:<id>` | `registration_idx:program:<pid>:<rid>`, `registration_idx:actor:<did>:<rid>` |
+
+### 14.3 Migration-safe index construction
+
+Any new index added to an existing store must be backfilled on first start. Pattern: add a `pub(crate) const INDEX_VERSION_KEY: &str = "_meta:idx_version:<name>";`. On store init, check the marker; if absent or below current version, walk all rows once and populate.
+
+---
+
+## 15. Testing strategy
+
+### 15.1 Unit / crate-level (required minimum)
+
+Each new module gets standard unit coverage (`cargo test -p icn-governance`, `-p icn-gateway`, specific `apps/governance` tests).
+
+### 15.2 Scenario tests (the load-bearing ones)
+
+These belong in `icn/crates/icn-governance/tests/` or `icn/apps/governance/tests/` and should exercise full loops, not type construction:
+
+| Scenario | Objects exercised | What it proves |
+|---------|-------------------|----------------|
+| **S1: Backbone → full-team transition** | Entity, Structure(backbone), RoleAssignment, Proposal, Decision, Program, Milestone | Backbone group opens a program draft, venue options logged, recommendation proposal created, full organizer body ratifies via a second proposal in parent domain, milestone flips to VenueLocked |
+| **S2: Committee consent decision → action** | Structure(content committee), Proposal(mode=Consent), ActionItemSpec, ActionItem, DigestSummary | Content committee proposes theme change with `action_items_on_accept`; consent threshold met; action items materialize with committee as `parent`; digest reaches content-committee members |
+| **S3: Meeting closure continuity** | Meeting, AgendaItem, Proposal, ActionItem, DigestSummary | Meeting held with 3 agenda items; 2 become action items on close, 1 becomes a decision; post-meeting digest summarizes; new organizer queries `/meetings/{id}/summary` and reconstructs the meeting |
+| **S4: Registration accessibility feedback** | Program, Registration, AccessibilityStatusView | Attendee registers with childcare + Spanish needs; program's accessibility-status view reflects counts; logistics committee gets a digest item |
+| **S5: Sponsor pipeline** | Sponsor, BudgetItem, ActionItem, Program | Sponsor added as prospect; follow-up action item auto-created; sponsor confirmed; budget item income record created; recognition action item auto-created for marketing lead |
+| **S6: Cycle closure + handoff** | Program(summit-2026), Program(summit-2027, `parent_program_id=summit-2026`) | Summit 2026 closes; lessons-learned document attached; summit-2027 program seeded with prior-cycle comparison view accessible |
+| **S7: Provenance chain** | Document, Meeting, Proposal, ActionItem, SourceRef | Walk from an ActionItem back through meeting → proposal → accepted decision → source doc reference; ends at an external SourceRef |
+| **S8: Replay / idempotence** | Proposal, ActionItemSpec materialization | Duplicate close events do not create duplicate action items (already tested in #1532; keep regression-guard) |
+
+### 15.3 Test harness
+
+Use existing `icn-testkit::TestNode` pattern. Scenarios S1–S6 are single-node. S7 should include at least one cross-node gossip replication path if `InstitutionalDocument` is gossiped in Phase 5.
+
+---
+
+## 16. Implementation sequencing
+
+See the companion doc `NYCN-Execution-Tranches.md` for the full merge-order plan. Summary only here:
+
+1. **Phase 0 — land already-open work** (#1543, then push+PR `feat/notification-digests` with stub fixes).
+2. **Phase 1 — Program + Milestones + scope-aware digest partitioning** (core cycle container).
+3. **Phase 2 — Sponsor + BudgetItem** (funding closure loop).
+4. **Phase 3 — Session + Registration + Accessibility** (content + attendee + logistics loops).
+5. **Phase 4 — SourceRef + ny-coop-net importer** (migration).
+6. **Phase 5 — InstitutionalDocument + document-linked provenance** (phase 5 of the original implementation plan).
+7. **Phase 6 — RoleDelegation + OrganizerOnboarding subsystem** (continuity).
+
+Each phase is one or two PRs. Phases 2–3 can parallelize once Phase 1 lands.
+
+---
+
+## 17. Architecture risks and firewalls
+
+### 17.1 Ontology drift
+
+The layered ontology (entities vs. structures vs. activities vs. programs) is the single most fragile decision. Every time a new object is added, evaluate: does it sit cleanly in one layer? If it seems to need pieces of multiple layers, the model is being stretched — stop and re-examine.
+
+### 17.2 Endpoint sprawl before ontology freeze
+
+Phase 0 alone adds ~12 meeting-management endpoints and ~1 digest endpoint. Phase 1 adds program+milestone endpoints. **Do not** start adding sponsor/budget/session/registration endpoints until Phase 1 is reviewed and merged; the derived-view patterns need to stabilize first.
+
+### 17.3 Authority ambiguity
+
+The backbone-group question is political-process ambiguity bleeding into code. Keep the code honest: authority is `RoleAssignment.authority_type` + `RoleDelegation` + policy-oracle rules, not hard-coded backbone-group logic.
+
+### 17.4 Organizer-hostile UX
+
+Every new endpoint that returns raw domain objects instead of composed views is technical debt against the "can a new organizer continue the work" test. Pair every canonical endpoint with at least one composed view handler.
+
+### 17.5 Spreadsheet-shaped architecture
+
+Do not model `Sponsor`, `BudgetItem`, or `Registration` fields by copying the current Google Sheets columns. Model them by lifecycle and by the queries they need to serve. `SourceRef` preserves the link back to the spreadsheet; the ICN shape is structured and normalized.
+
+### 17.6 Ceremonial governance
+
+Every new proposal type should either use the decision→action bridge (via `action_items_on_accept`) or connect to a typed execution hook (config change, milestone completion, role assignment). Proposals without downstream effects should be rare and flagged.
+
+### 17.7 Meaning firewall
+
+Keep the firewall: no NYCN-specific strings, no NYCN-specific variants, no `"nycn"` matches in kernel crates. NYCN appears in code only as test fixtures (`StructureId::from_raw("nycn-finance")`, `ActivityId::from_raw("summit-2026")`) and in seed data (CCL charter YAML), not as branches in match arms.
+
+---
+
+## 18. Final technical thesis
+
+The correct technical target is: **implement NYCN as a scoped institutional domain on ICN, with summit-year programs, organizer structures, meetings, decisions, action materialization, digests, provenance, and migration-safe links to existing planning systems.**
+
+As of `37ec91e0`, the ICN governance layer already gives us ~70% of the institutional primitives NYCN needs. The remaining 30% is:
+
+- **merge the two already-built things** (meeting #1543, digest branch),
+- **add Program + Milestones** (real cycle container),
+- **add Sponsor + BudgetItem + Session + Registration + Accessibility** (operational domains),
+- **add SourceRef + importer** (migration),
+- **add InstitutionalDocument + RoleDelegation + OnboardingPipeline** (memory + continuity).
+
+None of this requires new kernel concepts. All of it fits inside `icn-governance` + `apps/governance` with gateway-event emission.
+
+If Phase 0–3 lands cleanly, NYCN can instantiate itself on a running ICN node and the decisive test starts to return "yes."


### PR DESCRIPTION
## Summary

Three companion strategy documents grounding the NYCN / NY Cooperative Summit integration into current ICN code (`main` @ `37ec91e0`).

- **`NYCN-Repo-Architecture-Spec.md`** — repo-shaped architectural map. Bounded domains, canonical objects, authority/scope model, Program/cycle design, event flows, storage, API surface, tests. Explicitly supersedes the committee-as-Community entity tree in `NYCN-Institutional-Design.md`: under the layered ontology locked on 2026-04-14 (merged via #1540), committees are `Structure { kind: Committee }` owned by `nycn-organizers`, not sovereign `Community` entities.

- **`NYCN-Implementation-Matrix.md`** — execution ledger. Per-object status with a mechanical `Source` column (`main` / `open_pr` / `branch_only` / `spec_only`), implementation touch points per row, storage-index map, gateway event map, bootstrap-and-seed section (elevated from docs-update to missing operational artifact), full ny-coop-net → ICN import crosswalk, and phase-gated open questions with decision deadlines.

- **`NYCN-Execution-Tranches.md`** — 7-tranche merge-order plan with entry/exit conditions, rollback strategy, test scaffolding, agent assignments. Tranche 0 (land #1543 + notification-digests PR) precedes all new work; Tranche 1 introduces `Program` + `Milestone`.

## Why

The prior NYCN strategy docs (2026-04-13) were strong on institutional thinking but drifted from code reality after #1540 merged the layered ontology. This set replaces the drift with a grounded, agent-consumable triple: **architecture spec explains the world, matrix explains the work, tranches explain the merge order.**

`docs/INDEX.md` updated with entries for all three and a note flagging the partial supersession of `NYCN-Institutional-Design.md`.

## Scope

Docs-only. No code changes. No SDK regeneration. No CI-relevant files modified beyond `docs/`.

## Verified state at authoring

- `main` at `37ec91e0`
- PR #1543 (meeting management) OPEN, mergeable, CI green except non-blocking benchmark regression
- `feat/notification-digests` branch local + remote, 1 commit ahead, no PR opened
- Prior-session claimed files `NYCN-Bootstrap-Runbook.md` and `NYCN-Schema-Mapping.md` verified as non-existent; flagged in matrix as outputs of later tranches

## Test plan

- [x] `git diff --stat` touches only `docs/`
- [x] No code changes; no need for `cargo` gates
- [ ] Docs review: confirm the architectural correction (committees are Structures, not Communities) matches the layered ontology locked 2026-04-14
- [ ] Docs review: confirm the next-PR recommendation (human review on #1543, then PR the notification-digests branch) matches current priorities

🤖 Generated with [Claude Code](https://claude.com/claude-code)