### PR TITLE
docs(strategy): correct NYCN-Institutional-Design entity tree to layered ontology

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -383,7 +383,7 @@ Strategic direction and gap analysis (March 2026):
 - [ICN-Scenarios.md](strategy/ICN-Scenarios.md) - Six working scenarios with API calls
 - [ICN-Evolution-Arc.md](strategy/ICN-Evolution-Arc.md) - Two-year project history
 - [NYCN-Institutional-Strategy.md](strategy/NYCN-Institutional-Strategy.md) - NYCN as first real ICN institution (2026-04-13)
-- [NYCN-Institutional-Design.md](strategy/NYCN-Institutional-Design.md) - NYCN entity tree, governance model, and ICN primitive mapping (2026-04-13; partially superseded by Repo-Architecture-Spec §0.3 — committees are Structures, not Communities)
+- [NYCN-Institutional-Design.md](strategy/NYCN-Institutional-Design.md) - NYCN entity/structure/activity topology, governance model, and ICN primitive mapping (2026-04-13; Entity Structure section corrected 2026-04-15 to match layered ontology from #1540)
 - [NYCN-Implementation-Plan.md](strategy/NYCN-Implementation-Plan.md) - 5-phase platform feature plan: decision→action bridge, consent mode, meetings, digests, documents (2026-04-13)
 - [NYCN-Sprint-Plan.md](strategy/NYCN-Sprint-Plan.md) - 3-lane sprint plan: platform closure, institutional model, migration prep (2026-04-13)
 - [NYCN-Repo-Architecture-Spec.md](strategy/NYCN-Repo-Architecture-Spec.md) - Repo-shaped architectural map grounded in current code: bounded domains, canonical objects, authority model, Program/cycle design (2026-04-14)

--- a/docs/strategy/NYCN-Institutional-Design.md
+++ b/docs/strategy/NYCN-Institutional-Design.md
@@ -65,9 +65,9 @@ nycn                                   Entity: Federation(FederationProfile)
 │   │   └── nycn-accessibility-wg      Structure { kind: WorkingGroup }
 │   │
 │   └── [ACTIVITIES — owned by nycn-organizers]
-│       ├── summit-2026                Activity { kind: Event }   — wrapped by Program (Tranche 1)
-│       ├── summit-2027                Activity { kind: Event }   — future; parent_program_id = summit-2026
-│       └── regional-meetup-q3-2026    Activity { kind: Series }
+│       ├── summit-2026                Activity { kind: Event }       — to be wrapped by Program (Tranche 1)
+│       ├── summit-2027                Activity { kind: Event }       — future; once Program lands, Program.parent_program_id = summit-2026
+│       └── regional-meetups-2026      Activity { kind: Initiative }  — ongoing regional meetup series (Initiative is the closest existing ActivityKind)
 │
 ├── greenstar                          Entity: Cooperative(CooperativeProfile)
 ├── cooperation-buffalo                Entity: Cooperative(CooperativeProfile)
@@ -82,7 +82,10 @@ nycn                                   Entity: Federation(FederationProfile)
 
 3. **Committees are `Structure` records**, not entities. Each committee (`nycn-finance`, `nycn-content`, `nycn-logistics`, `nycn-marketing`, `nycn-backbone`, the accessibility working group) lives in `icn-governance::structure::Structure` with `kind: Committee` (or `WorkingGroup`) and `parent_entity_id: "nycn-organizers"`. A governance domain can optionally be provisioned for a structure where scoped proposals/votes are needed, but the structure itself is not a sovereign entity and does not appear in `FederationProfile.member_entities`. This is important: committees have delegated authority (via `RoleAssignment.authority_scope` capability strings), not sovereignty.
 
-4. **Summit 2026 is an `Activity { kind: Event }`**, owned by `nycn-organizers`, to be wrapped by a first-class `Program` primitive in Tranche 1 for milestones, stage gates (`StrategyLocked → VenueLocked → BudgetLocked → PublicLaunchReady → EventReady → ClosureComplete`), and cycle-to-cycle handoff via `parent_program_id` (so `summit-2027` references `summit-2026` for year-over-year comparison). Activities do not appear in `FederationProfile.member_entities` either.
+4. **Summit 2026 is an `Activity { kind: Event }`**, owned by `nycn-organizers`. Today, `Activity` has four kinds (`Event | Program | Project | Initiative`) and no cycle-level container fields. Tranche 1 introduces a first-class `Program` primitive that wraps the summit Activity and adds:
+   - milestones with machine-readable required-check predicates (`StrategyLocked → VenueLocked → BudgetLocked → PublicLaunchReady → EventReady → ClosureComplete`),
+   - cycle-to-cycle handoff via `Program.parent_program_id` (so `summit-2027`'s Program points back to `summit-2026`'s Program for year-over-year comparison).
+   Note: `parent_program_id` is a proposed field on the proposed `Program` type, not on `Activity`. Activities do not appear in `FederationProfile.member_entities`.
 
 5. **Member organizations are independent entities** that join the federation via the `member_entities` list on `FederationProfile`. They keep their own governance and treasury. The federation relationship is additive, not subordinating.
 

--- a/docs/strategy/NYCN-Institutional-Design.md
+++ b/docs/strategy/NYCN-Institutional-Design.md
@@ -1,10 +1,20 @@
 # NYCN on ICN — Institutional Design Document
 
+> **⚠️ Revision notice (2026-04-15)** — Entity Structure section corrected in-place.
+>
+> This doc's original entity tree (2026-04-13) modeled committees and the summit year as `Community` entities. That is **superseded** by the layered ontology merged in #1540 (2026-04-14) and locked in [`NYCN-Repo-Architecture-Spec.md`](NYCN-Repo-Architecture-Spec.md) §0.3:
+>
+> - **Entities** (sovereign; join federations; hold independent treasury): NYCN federation, `nycn-organizers` co-op, member co-ops.
+> - **Structures** (non-sovereign; owned by a parent entity; delegated authority): committees, working groups, backbone, host pods. `icn-governance::structure::Structure { kind: Committee | WorkingGroup | Team | Office }`.
+> - **Activities** (time-bounded; owned by a parent entity): the summit cycle, regional meetup series. `icn-governance::activity::Activity { kind: Event | Program | Project | Initiative }`, with a proposed first-class `Program` wrapper adding milestones and stage gates (Tranche 1 of the execution plan).
+>
+> For canonical repo state, see the three companion docs: [`NYCN-Repo-Architecture-Spec.md`](NYCN-Repo-Architecture-Spec.md), [`NYCN-Implementation-Matrix.md`](NYCN-Implementation-Matrix.md), [`NYCN-Execution-Tranches.md`](NYCN-Execution-Tranches.md).
+
 ## Introduction
 
 This document formalizes the design for the New York Cooperative Network (NYCN) as a **native institution inside the InterCooperative Network (ICN)**.
 
-NYCN is not an application that uses ICN. NYCN is an institutional structure that lives within ICN. Every entity, relationship, decision, financial event, and communication channel maps to an ICN primitive. There is no separate database, no parallel app, no bespoke backend.
+NYCN is not an application that uses ICN. NYCN is an institutional arrangement that lives within ICN. Every entity, internal structure, activity, decision, financial event, and communication channel maps to an ICN primitive. There is no separate database, no parallel app, no bespoke backend.
 
 The goal is to transform NYCN from an informal coordination network into a **durable, governed federation** with real operational capacity, institutional memory, and long-term continuity — and to prove that ICN can host real institutions in the process.
 
@@ -22,65 +32,61 @@ Every feature NYCN needs is a feature every future ICN institution needs. Nothin
 
 ### ICN Primitive Mapping
 
-ICN's entity model (`icn-entity`) supports four types: `Individual`, `Cooperative(CooperativeProfile)`, `Community(CommunityProfile)`, `Federation(FederationProfile)`. All entities support hierarchical nesting via `parent_id`. Each cooperative and federation has a `governance_domain_id` (links to proposal/voting system) and a `treasury_account` (links to ledger).
+NYCN maps across three layers of ICN governance/identity primitives:
 
-### NYCN Entity Tree
+1. **Entity model** (`icn-entity`): four sovereign types — `Individual`, `Cooperative(CooperativeProfile)`, `Community(CommunityProfile)`, `Federation(FederationProfile)`. Entities nest via `parent_id`, and each cooperative/federation has a `governance_domain_id` and a `treasury_account`. Entities are the only layer that can join federations or hold independent treasury.
+
+2. **Structure model** (`icn-governance::structure`): non-sovereign internal units — `Structure { kind: Committee | WorkingGroup | Team | Office }` — owned by a parent entity and carrying delegated authority. Structures have `RoleAssignment`s (with `authority_scope: Vec<String>` capability strings, not a typed enum). Structures cannot hold independent treasury or join federations.
+
+3. **Activity model** (`icn-governance::activity`): time-bounded work — `Activity { kind: Event | Program | Project | Initiative }` — owned by a parent entity. A proposed first-class `Program` primitive (Tranche 1) will wrap `Activity` with milestones and stage gates for cycle-level containment.
+
+Operational objects (action items, meetings, documents) attach to any of the three layers via `icn-governance::parent::InstitutionalParent`.
+
+### NYCN Entity / Structure / Activity Topology
 
 ```
-nycn                          Federation(FederationProfile)
-├── governance_domain_id:     "nycn-federation-gov"
-├── treasury_account:         "nycn-federation-treasury"
-├── member_entities:          [greenstar, cooperation-buffalo, ica-group, ...]
+nycn                                   Entity: Federation(FederationProfile)
+├── governance_domain_id:              "nycn-federation-gov"
+├── treasury_account:                  "nycn-federation-treasury"
+├── member_entities:                   [greenstar, cooperation-buffalo, ica-group, ...]
 │
-├── nycn-organizers           Cooperative(CooperativeProfile)
-│   ├── parent_id:            "nycn"
-│   ├── governance_domain_id: "nycn-organizers-gov"
-│   ├── treasury_account:     "nycn-ops-treasury"
+├── nycn-organizers                    Entity: Cooperative(CooperativeProfile)
+│   ├── parent_id:                     "nycn"
+│   ├── governance_domain_id:          "nycn-organizers-gov"
+│   ├── treasury_account:              "nycn-ops-treasury"
 │   │
-│   ├── nycn-steering         Community(CommunityProfile)
-│   │   ├── parent_id:        "nycn-organizers"
-│   │   └── governance_domain_id: "nycn-steering-gov"
+│   ├── [STRUCTURES — owned by nycn-organizers]
+│   │   ├── nycn-backbone              Structure { kind: Committee }
+│   │   ├── nycn-steering              Structure { kind: Committee }
+│   │   ├── nycn-content               Structure { kind: Committee }
+│   │   ├── nycn-logistics             Structure { kind: Committee }
+│   │   ├── nycn-marketing             Structure { kind: Committee }
+│   │   ├── nycn-finance               Structure { kind: Committee }
+│   │   └── nycn-accessibility-wg      Structure { kind: WorkingGroup }
 │   │
-│   ├── nycn-content          Community(CommunityProfile)
-│   │   ├── parent_id:        "nycn-organizers"
-│   │   └── governance_domain_id: "nycn-content-gov"
-│   │
-│   ├── nycn-logistics        Community(CommunityProfile)
-│   │   ├── parent_id:        "nycn-organizers"
-│   │   └── governance_domain_id: "nycn-logistics-gov"
-│   │
-│   ├── nycn-marketing        Community(CommunityProfile)
-│   │   ├── parent_id:        "nycn-organizers"
-│   │   └── governance_domain_id: "nycn-marketing-gov"
-│   │
-│   ├── nycn-finance          Community(CommunityProfile)
-│   │   ├── parent_id:        "nycn-organizers"
-│   │   └── governance_domain_id: "nycn-finance-gov"
-│   │
-│   └── nycn-summit-2026      Community(CommunityProfile)
-│       ├── parent_id:        "nycn-organizers"
-│       └── governance_domain_id: "nycn-summit-2026-gov"
+│   └── [ACTIVITIES — owned by nycn-organizers]
+│       ├── summit-2026                Activity { kind: Event }   — wrapped by Program (Tranche 1)
+│       ├── summit-2027                Activity { kind: Event }   — future; parent_program_id = summit-2026
+│       └── regional-meetup-q3-2026    Activity { kind: Series }
 │
-├── greenstar                 Cooperative(CooperativeProfile)
-│   └── (GreenStar's own entity, independent)
-│
-├── cooperation-buffalo       Cooperative(CooperativeProfile)
-│   └── (Cooperation Buffalo's own entity)
-│
-└── ... (217+ member organizations)
+├── greenstar                          Entity: Cooperative(CooperativeProfile)
+├── cooperation-buffalo                Entity: Cooperative(CooperativeProfile)
+└── ... (N member organizations as independent entities)
 ```
 
-**Key design decisions:**
+**Key design decisions (corrected):**
 
-1. **NYCN Federation** is the top-level entity. It governs network-wide decisions: membership admission, federation charter amendments, shared initiatives.
+1. **NYCN Federation** is the top-level entity. It governs network-wide decisions: membership admission, federation charter amendments, shared initiatives. `FederationProfile.member_entities` lists participating sovereign entities.
 
-2. **NYCN Organizers** is a `Cooperative` (not a Community) because it holds treasury and executes operations. It's the operational body — the people who actually run things.
+2. **NYCN Organizers** is a sovereign `Cooperative` entity because it holds treasury and executes operations. It is the operational body — the legal/economic container for the people and funds that actually run things.
 
-3. **Committees are `Community` entities** nested under the organizer co-op. Each gets its own `governance_domain_id`, meaning each committee can run its own proposals and votes scoped to committee members. A `Community` requires a governance domain but not a treasury — committee spending goes through the parent co-op's treasury with scoped authority.
+3. **Committees are `Structure` records**, not entities. Each committee (`nycn-finance`, `nycn-content`, `nycn-logistics`, `nycn-marketing`, `nycn-backbone`, the accessibility working group) lives in `icn-governance::structure::Structure` with `kind: Committee` (or `WorkingGroup`) and `parent_entity_id: "nycn-organizers"`. A governance domain can optionally be provisioned for a structure where scoped proposals/votes are needed, but the structure itself is not a sovereign entity and does not appear in `FederationProfile.member_entities`. This is important: committees have delegated authority (via `RoleAssignment.authority_scope` capability strings), not sovereignty.
 
-4. **Summit 2026 is a `Community` entity** with time-bounded lifecycle. Status progresses: `Forming` → `Active` → completed (dissolved or archived). Next year, `nycn-summit-2027` is created fresh, inheriting institutional records from 2026.
+4. **Summit 2026 is an `Activity { kind: Event }`**, owned by `nycn-organizers`, to be wrapped by a first-class `Program` primitive in Tranche 1 for milestones, stage gates (`StrategyLocked → VenueLocked → BudgetLocked → PublicLaunchReady → EventReady → ClosureComplete`), and cycle-to-cycle handoff via `parent_program_id` (so `summit-2027` references `summit-2026` for year-over-year comparison). Activities do not appear in `FederationProfile.member_entities` either.
 
 5. **Member organizations are independent entities** that join the federation via the `member_entities` list on `FederationProfile`. They keep their own governance and treasury. The federation relationship is additive, not subordinating.
+
+6. **Authority model**: governance authority is expressed through `RoleAssignment.authority_scope: Vec<String>` (capability strings like `"propose"`, `"approve-budget-<=5000"`, `"backbone-authority"`) combined with PolicyOracle rules. There is no typed authority-level enum; backbone ratification rules key off capability strings declared in CCL/oracle config. See [`NYCN-Repo-Architecture-Spec.md`](NYCN-Repo-Architecture-Spec.md) §4.3.
 
 ---
 


### PR DESCRIPTION
## Summary

Small, self-contained correction of the Entity Structure section of `NYCN-Institutional-Design.md` to match the layered ontology that is now canonical on `main` (merged via #1540 and #1544).

## Why

The original Entity Structure section (2026-04-13) modeled committees (`nycn-steering`, `nycn-content`, `nycn-logistics`, `nycn-marketing`, `nycn-finance`) and the summit year (`nycn-summit-2026`) as `Community(CommunityProfile)` entities. This was flagged as superseded in §0.3 of the `NYCN-Repo-Architecture-Spec.md` merged on 2026-04-15 (#1544).

Rather than leaving the old model in place with a supersession note, this PR **fixes the section in place** so the doc is self-consistent with the rest of the NYCN doc set.

## Changes

- Added a revision-notice banner at the top of the doc with links to the three companion specs on main.
- Rewrote **ICN Primitive Mapping** to describe all three layers (entity / structure / activity) rather than only the entity model.
- Replaced the entity tree with a topology showing:
  - Sovereign entities (`nycn`, `nycn-organizers`, member co-ops) in one group.
  - Structures (backbone, finance, content, logistics, marketing, steering, accessibility WG) as owned-children of `nycn-organizers` — **not** as `Community` entities.
  - Activities (`summit-2026`, `summit-2027`, regional series) also as owned-children of `nycn-organizers`, labeled distinctly from sovereign entities.
- Rewrote **Key design decisions** to reflect:
  - Committees are Structures (not entities) with delegated authority via `RoleAssignment.authority_scope` capability strings.
  - Summit is an Activity to be wrapped by a first-class Program primitive in Tranche 1 (milestones, stage gates, `parent_program_id` for cycle comparison).
  - Authority is capability-string based, not a typed enum.
- Updated `docs/INDEX.md` entry from "partially superseded" to "corrected in-place".

## Scope

Docs-only. No code changes. Downstream sections of the design doc (Identity, Membership, Governance, Ledger, Trust, Communication, Institutional Memory) were **not** edited — they remain largely compatible with the corrected ontology and should be read through `NYCN-Repo-Architecture-Spec.md` for API, store, and event truth.

## Test plan

- [x] `git diff --stat` touches only `docs/`
- [x] No code changes
- [ ] Docs review: confirm corrected entity tree matches locked layered ontology (entities vs. structures vs. activities)
- [ ] Docs review: revision banner clearly directs readers to the three canonical companion docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)