### PR TITLE
feat(governance): GET /gov/me/scopes and GET /gov/me/work (Tranche 1c)

### DIFF
--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -444,5 +444,8 @@ where
                 .route(web::post().to(handlers::create_remove_steward_proposal::<E>)),
         )
         // ── Notification digest ──────────────────────────────────────────
-        .service(web::resource("/digest").route(web::get().to(handlers::get_digest::<E>)));
+        .service(web::resource("/digest").route(web::get().to(handlers::get_digest::<E>)))
+        // ── Me (caller-scoped views) ─────────────────────────────────────
+        .service(web::resource("/me/scopes").route(web::get().to(handlers::get_my_scopes::<E>)))
+        .service(web::resource("/me/work").route(web::get().to(handlers::get_my_work::<E>)));
 }

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -3609,6 +3609,55 @@ pub async fn update_milestone_status<E: GovernanceEventEmitter + Clone + 'static
     Ok(HttpResponse::Ok().json(milestone_to_response(&m)))
 }
 
+// ── /me endpoints ─────────────────────────────────────────────────────────────
+
+/// GET /gov/me/scopes — Return all role assignments held by the authenticated DID.
+///
+/// The response is a flat list of [`RoleAssignmentResponse`] across every
+/// structure in the system where the caller holds a role. This is the primary
+/// entry point for an organizer or member to discover their authority scope
+/// without knowing which structures they belong to in advance.
+pub async fn get_my_scopes<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+) -> Result<HttpResponse, ApiError> {
+    let claims = require_scope::<BasicClaims>(&http_req, "governance:read")?;
+    let caller = parse_did(&claims.sub, "Invalid DID in token")?;
+
+    let roles = ctx
+        .manager
+        .list_roles_for_person(&caller)
+        .map_err(anyhow_to_api)?;
+
+    let responses: Vec<RoleAssignmentResponse> = roles.iter().map(role_to_response).collect();
+    Ok(HttpResponse::Ok().json(responses))
+}
+
+/// GET /gov/me/work — Return all action items assigned to the authenticated DID.
+///
+/// Returns items across **all** governance domains, sorted by creation date
+/// (oldest first). No filtering is applied — the caller receives their full
+/// open work queue. Filtering by status, priority, or tag will be added
+/// in a follow-up endpoint iteration.
+///
+/// **Note**: Items in any status are returned. Callers should filter client-side
+/// by `status` if they only want pending or in-progress items.
+pub async fn get_my_work<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+) -> Result<HttpResponse, ApiError> {
+    let claims = require_scope::<BasicClaims>(&http_req, "governance:read")?;
+    let caller = parse_did(&claims.sub, "Invalid DID in token")?;
+
+    let items = ctx
+        .manager
+        .list_work_for_person(&caller)
+        .map_err(anyhow_to_api)?;
+
+    let responses: Vec<ActionItemResponse> = items.iter().map(action_item_to_response).collect();
+    Ok(HttpResponse::Ok().json(responses))
+}
+
 // ============================================================================
 // Tests — governance → execution bridge
 // ============================================================================
@@ -3965,5 +4014,197 @@ mod tests {
             *resolver_called.lock().unwrap(),
             "membership_resolver.resolve_members() must be invoked for TrustThreshold domains"
         );
+    }
+
+    // ── /me endpoint tests ──────────────────────────────────────────────────
+
+    /// Build a minimal test app wired to both /me/scopes and /me/work.
+    macro_rules! me_test_app {
+        ($ctx:expr, $caller_did:expr) => {{
+            let ctx_data = web::Data::new($ctx);
+            let caller_did_str = $caller_did.to_string();
+            test::init_service(
+                App::new()
+                    .app_data(ctx_data)
+                    .wrap_fn(move |req, srv| {
+                        req.extensions_mut().insert(BasicClaims {
+                            sub: caller_did_str.clone(),
+                            scope: Some("governance:read".to_string()),
+                        });
+                        srv.call(req)
+                    })
+                    .route(
+                        "/me/scopes",
+                        web::get().to(get_my_scopes::<NoopEventEmitter>),
+                    )
+                    .route("/me/work", web::get().to(get_my_work::<NoopEventEmitter>)),
+            )
+            .await
+        }};
+    }
+
+    #[actix_web::test]
+    async fn get_my_scopes_empty() {
+        let caller = test_did(10);
+        let mgr = Arc::new(GovernanceManager::new());
+        let ctx = GovernanceContext {
+            manager: mgr,
+            emitter: NoopEventEmitter,
+            on_proposal_accepted: None,
+            on_charter_accepted: None,
+            member_checker: None,
+            steward_checker: None,
+            suspension_checker: None,
+            membership_resolver: None,
+            sdis_service: None,
+        };
+
+        let app = me_test_app!(ctx, caller);
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get().uri("/me/scopes").to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status().as_u16(), 200);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body, serde_json::json!([]));
+    }
+
+    #[actix_web::test]
+    async fn get_my_scopes_returns_assigned_roles() {
+        let caller = test_did(11);
+        let other = test_did(12);
+        let mgr = Arc::new(GovernanceManager::new());
+
+        // Create a structure and assign roles
+        let s = mgr
+            .create_structure(
+                "entity-abc".to_string(),
+                icn_governance::StructureKind::Committee,
+                "Tech Committee".to_string(),
+                None,
+            )
+            .unwrap();
+
+        mgr.assign_role(s.id.clone(), caller.clone(), "coordinator".to_string())
+            .unwrap();
+        mgr.assign_role(s.id.clone(), other.clone(), "member".to_string())
+            .unwrap();
+
+        let ctx = GovernanceContext {
+            manager: mgr,
+            emitter: NoopEventEmitter,
+            on_proposal_accepted: None,
+            on_charter_accepted: None,
+            member_checker: None,
+            steward_checker: None,
+            suspension_checker: None,
+            membership_resolver: None,
+            sdis_service: None,
+        };
+
+        let app = me_test_app!(ctx, caller.clone());
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get().uri("/me/scopes").to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status().as_u16(), 200);
+        let body: Vec<serde_json::Value> = test::read_body_json(resp).await;
+        // Only the caller's role should appear, not `other`'s
+        assert_eq!(body.len(), 1);
+        assert_eq!(body[0]["person_did"], caller.to_string());
+        assert_eq!(body[0]["role"], "coordinator");
+    }
+
+    #[actix_web::test]
+    async fn get_my_work_empty() {
+        let caller = test_did(10); // seed 10 produces a valid Ed25519 point
+        let mgr = Arc::new(GovernanceManager::new());
+        let ctx = GovernanceContext {
+            manager: mgr,
+            emitter: NoopEventEmitter,
+            on_proposal_accepted: None,
+            on_charter_accepted: None,
+            member_checker: None,
+            steward_checker: None,
+            suspension_checker: None,
+            membership_resolver: None,
+            sdis_service: None,
+        };
+
+        let app = me_test_app!(ctx, caller);
+        let resp =
+            test::call_service(&app, test::TestRequest::get().uri("/me/work").to_request()).await;
+
+        assert_eq!(resp.status().as_u16(), 200);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body, serde_json::json!([]));
+    }
+
+    #[actix_web::test]
+    async fn get_my_work_returns_assigned_items_across_domains() {
+        let caller = test_did(11); // seed 11 produces a valid Ed25519 point
+        let mgr = Arc::new(GovernanceManager::new());
+
+        // Create domains and action items
+        for domain_str in ["alpha", "beta"] {
+            let domain_id = GovernanceDomainId(domain_str.to_string());
+            mgr.create_domain(
+                domain_id.clone(),
+                format!("{domain_str} coop"),
+                "cooperative_default".to_string(),
+                GovernanceParams::new(0, 51, 86_400),
+                MembershipConfig {
+                    source: MembershipSource::StaticList(vec![caller.clone()]),
+                },
+            )
+            .await
+            .unwrap();
+
+            mgr.create_action_item(
+                domain_id,
+                format!("Task in {domain_str}"),
+                None,
+                caller.clone(),       // created_by
+                Some(caller.clone()), // assignee
+                None,
+                icn_governance::ActionItemPriority::Medium,
+                None,
+                None,
+                vec![],
+            )
+            .unwrap();
+        }
+
+        let ctx = GovernanceContext {
+            manager: mgr,
+            emitter: NoopEventEmitter,
+            on_proposal_accepted: None,
+            on_charter_accepted: None,
+            member_checker: None,
+            steward_checker: None,
+            suspension_checker: None,
+            membership_resolver: None,
+            sdis_service: None,
+        };
+
+        let app = me_test_app!(ctx, caller.clone());
+        let resp =
+            test::call_service(&app, test::TestRequest::get().uri("/me/work").to_request()).await;
+
+        assert_eq!(resp.status().as_u16(), 200);
+        let body: Vec<serde_json::Value> = test::read_body_json(resp).await;
+        assert_eq!(
+            body.len(),
+            2,
+            "should return items from both alpha and beta domains"
+        );
+        // All items belong to the caller
+        for item in &body {
+            assert_eq!(item["assignee"], caller.to_string());
+        }
     }
 }

--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -447,6 +447,24 @@ pub struct ActionItemFilterParams {
     pub tag: Option<String>,
 }
 
+/// Query parameters for `GET /gov/me/work`.
+///
+/// A subset of [`ActionItemFilterParams`] — the `assignee` field is omitted
+/// because `me/work` implicitly filters by the authenticated caller's DID.
+/// All fields default to `None` (no filtering applied).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+#[serde(default)]
+pub struct MyWorkFilterParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub overdue: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag: Option<String>,
+}
+
 // ============================================================================
 // Discussion
 // ============================================================================

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -641,6 +641,29 @@ impl icn_governance::StructureStoreBackend for SledStructureStore {
             .map(|opt| opt.is_some())
             .map_err(|e| GovernanceError::Internal(format!("Sled delete failed: {e}")))
     }
+
+    /// Scan all `role:` primary keys and collect those belonging to the given DID.
+    ///
+    /// This is a full scan (O(roles)) — acceptable for cooperative-scale deployments.
+    /// A `role_by_person` secondary index can be added later if profiling warrants it.
+    fn list_roles_by_person(
+        &self,
+        did: &icn_identity::Did,
+    ) -> std::result::Result<Vec<icn_governance::RoleAssignment>, GovernanceError> {
+        let prefix = "role:";
+        let mut out = Vec::new();
+        for result in self.db.scan_prefix(prefix.as_bytes()) {
+            let (_, value) = result
+                .map_err(|e| GovernanceError::Internal(format!("Sled scan (roles) failed: {e}")))?;
+            let r: icn_governance::RoleAssignment = icn_encoding::decode_versioned(&value)
+                .map_err(|e| GovernanceError::Internal(format!("Failed to decode role: {e}")))?;
+            if &r.person_did == did {
+                out.push(r);
+            }
+        }
+        out.sort_by(|a, b| a.start_date.cmp(&b.start_date));
+        Ok(out)
+    }
 }
 
 // ========== Sled store for Activities (Tranche 2) ==========
@@ -3751,6 +3774,25 @@ impl GovernanceManager {
         self.structure_store
             .list_roles_by_structure(structure_id)
             .map_err(|e| anyhow::anyhow!("Failed to list roles: {e}"))
+    }
+
+    /// List all role assignments held by the given DID across all structures.
+    ///
+    /// Used by `GET /gov/me/scopes` to return the caller's authority scope without
+    /// requiring them to know which structures they belong to.
+    pub fn list_roles_for_person(&self, did: &icn_identity::Did) -> Result<Vec<RoleAssignment>> {
+        self.structure_store
+            .list_roles_by_person(did)
+            .map_err(|e| anyhow::anyhow!("Failed to list roles for person: {e}"))
+    }
+
+    /// List all open action items assigned to the given DID across all domains.
+    ///
+    /// Used by `GET /gov/me/work` to return the caller's pending work queue.
+    pub fn list_work_for_person(&self, did: &icn_identity::Did) -> Result<Vec<ActionItem>> {
+        self.action_items
+            .list_by_assignee(did)
+            .map_err(|e| anyhow::anyhow!("Failed to list work for person: {e}"))
     }
 
     // ========================================================================

--- a/icn/crates/icn-governance/src/action_item.rs
+++ b/icn/crates/icn-governance/src/action_item.rs
@@ -571,6 +571,21 @@ impl ActionItemStoreBackend for InMemoryActionItemStore {
 
         Ok(count)
     }
+
+    /// In-memory cross-domain assignee scan. Used by `GET /gov/me/work`.
+    fn list_by_assignee(&self, assignee: &Did) -> Result<Vec<ActionItem>> {
+        let items = self
+            .items
+            .read()
+            .map_err(|_| crate::GovernanceError::LockPoisoned("action item store".to_string()))?;
+        let mut out: Vec<ActionItem> = items
+            .values()
+            .filter(|i| i.assignee.as_ref() == Some(assignee))
+            .cloned()
+            .collect();
+        out.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        Ok(out)
+    }
 }
 
 /// Sled key version for schema migration support.

--- a/icn/crates/icn-governance/src/structure.rs
+++ b/icn/crates/icn-governance/src/structure.rs
@@ -266,6 +266,12 @@ pub trait StructureStoreBackend: Send + Sync {
 
     /// Delete a role assignment.
     fn delete_role(&self, id: &RoleAssignmentId) -> std::result::Result<bool, GovernanceError>;
+
+    /// List all role assignments held by a given person (cross-structure).
+    fn list_roles_by_person(
+        &self,
+        did: &icn_identity::Did,
+    ) -> std::result::Result<Vec<RoleAssignment>, GovernanceError>;
 }
 
 // ========== In-Memory Store (for tests and default config) ==========
@@ -382,6 +388,23 @@ impl StructureStoreBackend for InMemoryStructureStore {
             .write()
             .map_err(|e| GovernanceError::Internal(format!("roles lock poisoned: {e}")))?;
         Ok(guard.remove(id).is_some())
+    }
+
+    fn list_roles_by_person(
+        &self,
+        did: &icn_identity::Did,
+    ) -> std::result::Result<Vec<RoleAssignment>, GovernanceError> {
+        let guard = self
+            .roles
+            .read()
+            .map_err(|e| GovernanceError::Internal(format!("roles lock poisoned: {e}")))?;
+        let mut out: Vec<RoleAssignment> = guard
+            .values()
+            .filter(|r| &r.person_did == did)
+            .cloned()
+            .collect();
+        out.sort_by(|a, b| a.start_date.cmp(&b.start_date));
+        Ok(out)
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the first member/organizer work-spine endpoints — the decisive test for Tranche 1c:

-  — returns all s held by the authenticated DID across every structure, without requiring the caller to know which structures they belong to
-  — returns all s assigned to the authenticated DID across all governance domains

## Changes

- Add  to  trait, , and  (full-scan, O(roles), governance-scale appropriate)
- Add  to  (previously used default no-op returning empty vec)
- Add  +  public methods to 
- Add  with  for future work filtering
- Register  and  routes in 
- 4 handler tests: empty-scopes, scopes-with-roles, empty-work, work-across-domains

## Motivation

 (PR #1551) identified  and  as the first decisive tests for the member-visible work spine. A new organizer can now see their scope and open work queue in a single round-trip, unblocking the NYCN institutional dashboard foundation.

## Testing

- [x]  — all 88 handler tests pass
- [x]  — clean
- [x]  — clean

## Invariants

- [x] No panics introduced in protocol paths
- [x] Determinism preserved
- [x] Canonical encodings unchanged
- [x] Trust gates not weakened
- [x] Kernel/app boundaries respected — all changes in  and  (app layer)

## Verification



## Documentation

- N/A — normative boundary doc is in PR #1551 (merged)
- Follow-up:  is wired but not yet connected to the endpoint (filtering deferred to next iteration)