### PR TITLE
feat(governance): materialize action items from accepted proposals (standalone path)

### DIFF
--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -3966,4 +3966,253 @@ mod tests {
             "membership_resolver.resolve_members() must be invoked for TrustThreshold domains"
         );
     }
+
+    // ── Governance-to-execution bridge ──────────────────────────────────────
+
+    /// Proves: when a proposal with `action_items_on_accept` is accepted via
+    /// `close_proposal`, the specs are materialized as concrete `ActionItem`s
+    /// with correct provenance (`linked_proposal` set to the proposal ID).
+    ///
+    /// This tests the standalone/in-memory path (no actor). The actor path is
+    /// tested separately in `actor.rs`. Both paths must produce the same result.
+    #[tokio::test]
+    async fn accepted_proposal_materializes_action_items() {
+        // Seeds 1 and 2 are verified valid Ed25519 compressed points (used in
+        // hook_fires_with_correct_payload_on_acceptance).
+        let member_did = test_did(1);
+        let assignee_did = test_did(2);
+        let mgr = Arc::new(GovernanceManager::new());
+        let domain_id = GovernanceDomainId("bridge-test-coop".to_string());
+
+        // Domain: quorum=0, approval=0 → any close is Accepted.
+        mgr.create_domain(
+            domain_id.clone(),
+            "Bridge Test Coop".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::new(0, 0, 86_400),
+            MembershipConfig {
+                source: MembershipSource::StaticList(vec![member_did.clone()]),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Proposal with two obligation specs.
+        let proposal_id = ProposalId("obligation-proposal-1".to_string());
+        let specs = vec![
+            icn_governance::ActionItemSpec {
+                title: "Send meeting recap to members".to_string(),
+                description: Some("Within 48h of decision".to_string()),
+                assignee: Some(assignee_did.clone()),
+                due_offset_seconds: Some(48 * 60 * 60),
+                priority: icn_governance::ActionItemPriority::High,
+                tags: vec!["comms".to_string()],
+            },
+            icn_governance::ActionItemSpec {
+                title: "Update charter document".to_string(),
+                description: None,
+                assignee: None,
+                due_offset_seconds: None,
+                priority: icn_governance::ActionItemPriority::Medium,
+                tags: vec![],
+            },
+        ];
+
+        mgr.create_proposal_with_actions(
+            proposal_id.clone(),
+            domain_id.clone(),
+            member_did.clone(),
+            "Adopt new communication policy".to_string(),
+            "Governs how decisions are communicated to members".to_string(),
+            ProposalPayload::Text {
+                body: "Adopt new communication policy: meeting recaps within 48h, charter updates within 1 week.".to_string(),
+            },
+            ProposalScope::Local,
+            specs,
+        )
+        .await
+        .unwrap();
+
+        mgr.open_proposal(proposal_id.clone(), 86_400)
+            .await
+            .unwrap();
+
+        let ctx = GovernanceContext {
+            manager: mgr.clone(),
+            emitter: NoopEventEmitter,
+            on_charter_accepted: None,
+            on_proposal_accepted: None,
+            member_checker: None,
+            steward_checker: None,
+            suspension_checker: None,
+            membership_resolver: None,
+            sdis_service: None,
+        };
+
+        let app = test_app!(ctx, member_did);
+
+        // Close the proposal (quorum=0, approval=0 → Accepted immediately).
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri(&format!("/proposals/{}/close", proposal_id.0))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(
+            resp.status().as_u16(),
+            200,
+            "close_proposal should return 200 OK"
+        );
+
+        // Verify ActionItems were materialized with correct provenance.
+        let filter = icn_governance::ActionItemFilter {
+            linked_proposal: Some(proposal_id.clone()),
+            ..Default::default()
+        };
+        let items = mgr
+            .list_action_items(&domain_id, &filter)
+            .expect("list_action_items must not fail");
+
+        assert_eq!(
+            items.len(),
+            2,
+            "both obligation specs must be materialized as ActionItems"
+        );
+
+        let recap = items
+            .iter()
+            .find(|i| i.title == "Send meeting recap to members")
+            .expect("recap item must exist");
+        assert_eq!(
+            recap.linked_proposal.as_ref().map(|p| &p.0),
+            Some(&proposal_id.0),
+            "linked_proposal must be set to the originating proposal"
+        );
+        assert_eq!(
+            recap.assignee,
+            Some(assignee_did),
+            "assignee DID must be preserved from spec"
+        );
+        assert_eq!(
+            recap.priority,
+            icn_governance::ActionItemPriority::High,
+            "priority must be preserved from spec"
+        );
+        assert!(
+            recap.due_date.is_some(),
+            "due_date must be set from due_offset_seconds"
+        );
+        assert_eq!(recap.tags, vec!["comms".to_string()]);
+
+        let charter = items
+            .iter()
+            .find(|i| i.title == "Update charter document")
+            .expect("charter update item must exist");
+        assert_eq!(
+            charter.linked_proposal.as_ref().map(|p| &p.0),
+            Some(&proposal_id.0)
+        );
+        assert_eq!(charter.assignee, None);
+        assert_eq!(charter.priority, icn_governance::ActionItemPriority::Medium);
+    }
+
+    /// Proves: action items are NOT created when a proposal is Rejected.
+    ///
+    /// GovernanceParams(quorum=0, approval=100) + Against vote → Rejected.
+    #[tokio::test]
+    async fn rejected_proposal_does_not_materialize_action_items() {
+        // Seed 3 verified valid Ed25519 point (used in hook_not_fired_on_rejection).
+        let member_did = test_did(3);
+        let mgr = Arc::new(GovernanceManager::new());
+        let domain_id = GovernanceDomainId("rejection-test-coop".to_string());
+
+        mgr.create_domain(
+            domain_id.clone(),
+            "Rejection Test Coop".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::new(0, 100, 86_400), // 100% approval required → one Against vote → Rejected
+            MembershipConfig {
+                source: MembershipSource::StaticList(vec![member_did.clone()]),
+            },
+        )
+        .await
+        .unwrap();
+
+        let proposal_id = ProposalId("rejected-obligation-1".to_string());
+        let specs = vec![icn_governance::ActionItemSpec {
+            title: "Should not be created".to_string(),
+            description: None,
+            assignee: None,
+            due_offset_seconds: None,
+            priority: icn_governance::ActionItemPriority::Medium,
+            tags: vec![],
+        }];
+
+        mgr.create_proposal_with_actions(
+            proposal_id.clone(),
+            domain_id.clone(),
+            member_did.clone(),
+            "Proposal that will be rejected".to_string(),
+            "Test rejection does not materialize obligations".to_string(),
+            ProposalPayload::Text {
+                body: "This will be rejected.".to_string(),
+            },
+            ProposalScope::Local,
+            specs,
+        )
+        .await
+        .unwrap();
+
+        mgr.open_proposal(proposal_id.clone(), 86_400)
+            .await
+            .unwrap();
+
+        // Cast an Against vote so the proposal is Rejected.
+        mgr.cast_vote(
+            proposal_id.clone(),
+            member_did.clone(),
+            VoteChoice::Against,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let ctx = GovernanceContext {
+            manager: mgr.clone(),
+            emitter: NoopEventEmitter,
+            on_charter_accepted: None,
+            on_proposal_accepted: None,
+            member_checker: None,
+            steward_checker: None,
+            suspension_checker: None,
+            membership_resolver: None,
+            sdis_service: None,
+        };
+
+        let app = test_app!(ctx, member_did);
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri(&format!("/proposals/{}/close", proposal_id.0))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let filter = icn_governance::ActionItemFilter {
+            linked_proposal: Some(proposal_id.clone()),
+            ..Default::default()
+        };
+        let items = mgr
+            .list_action_items(&domain_id, &filter)
+            .expect("list_action_items must not fail");
+
+        assert!(
+            items.is_empty(),
+            "rejected proposal must NOT create action items; got {items:?}"
+        );
+    }
 }

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -2658,6 +2658,53 @@ impl GovernanceManager {
                 }
             }
 
+            // Decision→action bridge (standalone path).
+            //
+            // When the proposal is Accepted and carries `action_items_on_accept`
+            // specs, materialize them into concrete ActionItems now. This mirrors
+            // what the GovernanceActor does in the actor-backed path (see
+            // `actor.rs::materialize_action_items`). Without this, the
+            // in-memory/standalone path (used in tests and HTTP-only deployments)
+            // would silently skip obligation creation.
+            //
+            // Dedup guard: if items already exist for this proposal (e.g. because
+            // the actor path ran first on a re-close), skip to avoid duplicates.
+            if matches!(outcome, ProofOutcome::Accepted)
+                && !proposal.action_items_on_accept.is_empty()
+            {
+                let filter = icn_governance::ActionItemFilter {
+                    linked_proposal: Some(proposal_id.clone()),
+                    ..Default::default()
+                };
+                let already_exists = self
+                    .action_items
+                    .list(&proposal.domain_id, &filter)
+                    .map(|v| !v.is_empty())
+                    .unwrap_or(false);
+
+                if !already_exists {
+                    let domain_id = proposal.domain_id.clone();
+                    let proposer = proposal.proposer.clone();
+                    for spec in &proposal.action_items_on_accept {
+                        let item = spec.materialize(
+                            domain_id.clone(),
+                            proposal_id.clone(),
+                            proposer.clone(),
+                            now,
+                        );
+                        if let Err(e) = self.action_items.save(&item) {
+                            tracing::warn!(
+                                proposal_id = %proposal_id.0,
+                                action_item_title = %spec.title,
+                                error = %e,
+                                "Failed to materialize action item from accepted proposal — \
+                                 obligation may be lost"
+                            );
+                        }
+                    }
+                }
+            }
+
             Ok(())
         } else {
             anyhow::bail!(


### PR DESCRIPTION
## Summary

The standalone/in-memory `close_proposal_inner` path in `GovernanceManager` now materializes `action_items_on_accept` specs into concrete `ActionItem`s when a proposal is accepted — matching the behavior already present in the actor-backed path (`actor.rs::materialize_action_items`).

## Changes

- **`apps/governance/src/manager.rs`**: Added materialization block in `close_proposal_inner` that fires when `outcome == Accepted && !proposal.action_items_on_accept.is_empty()`. Includes a dedup guard (checks if items already exist for this proposal ID before writing) to prevent double-materialization if both the actor and standalone paths ever run on the same proposal.
- **`apps/governance/src/http/handlers.rs`**: Added two tests:
  - `accepted_proposal_materializes_action_items`: proposal with 2 specs → 2 `ActionItem`s with correct `linked_proposal`, assignee, priority, due date, tags
  - `rejected_proposal_does_not_materialize_action_items`: rejected proposal → 0 items

## Motivation

Without this fix, any deployment using the HTTP-only/standalone manager path (not wired to the GovernanceActor) would silently drop obligation specs when proposals were accepted. The actor path was the only path that materialized action items. Since the `action_items_on_accept` field already exists on `Proposal` and is accepted via the HTTP API, this was a silent correctness gap.

This is the minimal governance-to-execution bridge: an accepted proposal can now produce tracked obligations as generic `ActionItem`s with full provenance, no CCL evaluation required.

## Testing

- [x] `accepted_proposal_materializes_action_items` — verifies count, assignee, priority, due_date, tags, linked_proposal
- [x] `rejected_proposal_does_not_materialize_action_items` — verifies zero items on rejection
- [x] 86/86 tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean (0 warnings)

## Invariants

- [x] No panics introduced in protocol paths
- [x] Determinism preserved — materialization is deterministic given same specs
- [x] Canonical encodings unchanged
- [x] Trust gates not weakened
- [x] Kernel/app boundaries respected — changes confined to `apps/governance` (domain layer)

## Verification

```
cargo fmt --check -p icn-governance-actor  → exit 0
cargo clippy -p icn-governance-actor --all-targets -- -D warnings  → 0 warnings
cargo test -p icn-governance-actor --lib  → 86 passed; 0 failed
```

## Documentation

- [x] N/A — implementation of existing field semantics, no new API surface