### PR TITLE
feat(governance): GET /gov/programs/{id}/dashboard composite read surface

### DIFF
--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -362,6 +362,10 @@ where
                 .route(web::get().to(handlers::get_program::<E>)),
         )
         .service(
+            web::resource("/programs/{program_id}/dashboard")
+                .route(web::get().to(handlers::get_program_dashboard::<E>)),
+        )
+        .service(
             web::resource("/programs/{program_id}/milestones")
                 .route(web::post().to(handlers::create_milestone::<E>))
                 .route(web::get().to(handlers::list_milestones_by_program::<E>)),

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -3638,6 +3638,118 @@ pub async fn update_milestone_status<E: GovernanceEventEmitter + Clone + 'static
     Ok(HttpResponse::Ok().json(milestone_to_response(&m)))
 }
 
+// ── Program dashboard ─────────────────────────────────────────────────────────
+
+fn dashboard_milestone_summary(m: &icn_governance::Milestone) -> DashboardMilestoneSummary {
+    DashboardMilestoneSummary {
+        id: m.id.0.clone(),
+        name: m.name.clone(),
+        phase_index: m.phase_index,
+        status: milestone_status_str(&m.status).to_string(),
+        target_date: m.target_date,
+        completed_at: m.completed_at,
+    }
+}
+
+fn dashboard_activity_summary(a: &icn_governance::Activity) -> DashboardActivitySummary {
+    DashboardActivitySummary {
+        id: a.id.0.clone(),
+        name: a.name.clone(),
+        kind: match a.kind {
+            ActivityKind::Event => "event",
+            ActivityKind::Program => "program",
+            ActivityKind::Project => "project",
+            ActivityKind::Initiative => "initiative",
+        }
+        .to_string(),
+        status: match a.status {
+            ActivityStatus::Planned => "planned",
+            ActivityStatus::Active => "active",
+            ActivityStatus::Completed => "completed",
+            ActivityStatus::Cancelled => "cancelled",
+        }
+        .to_string(),
+    }
+}
+
+/// GET /gov/programs/{program_id}/dashboard — Composite program view.
+///
+/// Returns a compact read surface combining:
+/// - program metadata
+/// - ordered milestones with status counts
+/// - linked activity summaries
+/// - action item counts scoped to the program's activities
+///
+/// Requires `governance:read` scope. No write gates — this is a pure read.
+///
+/// **Meetings** are absent from this response. `Meeting` records link to
+/// activities via `linked_activities` but there is no activity-keyed index
+/// on the meeting store. Resolving meetings would require a full domain scan.
+/// Deferred until a `list_by_activity` index is available.
+pub async fn get_program_dashboard<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    program_id: web::Path<String>,
+) -> Result<HttpResponse, ApiError> {
+    require_scope::<BasicClaims>(&http_req, "governance:read")?;
+    let pid = ProgramId(program_id.into_inner());
+
+    let d = ctx
+        .manager
+        .get_program_dashboard(&pid)
+        .map_err(anyhow_to_api)?
+        .ok_or_else(|| err_not_found("Program not found"))?;
+
+    // Build milestone counts
+    let mut mc = DashboardMilestoneCounts {
+        total: d.milestones.len(),
+        ..Default::default()
+    };
+    for m in &d.milestones {
+        match m.status {
+            MilestoneStatus::Completed => mc.completed += 1,
+            MilestoneStatus::InProgress => mc.in_progress += 1,
+            MilestoneStatus::Blocked => mc.blocked += 1,
+            MilestoneStatus::Pending => mc.pending += 1,
+            MilestoneStatus::Skipped => mc.skipped += 1,
+        }
+    }
+
+    let ai = &d.action_item_counts;
+    let resp = ProgramDashboardResponse {
+        program_id: d.program.id.0.clone(),
+        domain_id: d.program.domain_id.0.clone(),
+        parent_entity_id: d.program.parent_entity_id.clone(),
+        name: d.program.name.clone(),
+        kind: program_kind_str(&d.program.kind),
+        status: program_status_str(&d.program.status).to_string(),
+        description: d.program.description.clone(),
+        start_at: d.program.start_at,
+        end_at: d.program.end_at,
+        milestones: d
+            .milestones
+            .iter()
+            .map(dashboard_milestone_summary)
+            .collect(),
+        milestone_counts: mc,
+        activities: d
+            .activities
+            .iter()
+            .map(dashboard_activity_summary)
+            .collect(),
+        action_item_counts: DashboardActionItemCounts {
+            pending: ai.pending,
+            in_progress: ai.in_progress,
+            completed: ai.completed,
+            deferred: ai.deferred,
+            cancelled: ai.cancelled,
+            total: ai.total(),
+        },
+    };
+
+    Ok(HttpResponse::Ok().json(resp))
+}
+
 // ── /me endpoints ─────────────────────────────────────────────────────────────
 
 /// GET /gov/me/scopes — Return all role assignments held by the authenticated DID.
@@ -4733,5 +4845,307 @@ mod tests {
             0,
             "rejected proposal must not produce ActionItems"
         );
+    }
+
+    // ── Program dashboard tests ────────────────────────────────────────────
+
+    macro_rules! dashboard_app {
+        ($ctx:expr) => {{
+            let ctx_data = web::Data::new($ctx);
+            test::init_service(
+                App::new()
+                    .app_data(ctx_data)
+                    .wrap_fn(move |req, srv| {
+                        req.extensions_mut().insert(BasicClaims {
+                            sub: "did:icn:reader".to_string(),
+                            scope: Some("governance:read".to_string()),
+                        });
+                        srv.call(req)
+                    })
+                    .route(
+                        "/programs/{program_id}/dashboard",
+                        web::get().to(get_program_dashboard::<NoopEventEmitter>),
+                    ),
+            )
+            .await
+        }};
+    }
+
+    fn make_dashboard_ctx(mgr: Arc<GovernanceManager>) -> GovernanceContext<NoopEventEmitter> {
+        GovernanceContext {
+            manager: mgr,
+            emitter: NoopEventEmitter,
+            on_proposal_accepted: None,
+            on_charter_accepted: None,
+            member_checker: None,
+            steward_checker: None,
+            suspension_checker: None,
+            membership_resolver: None,
+            sdis_service: None,
+        }
+    }
+
+    /// 404 when program does not exist.
+    #[actix_web::test]
+    async fn dashboard_404_for_missing_program() {
+        let mgr = Arc::new(GovernanceManager::new());
+        let app = dashboard_app!(make_dashboard_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/programs/nonexistent/dashboard")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 404);
+    }
+
+    /// Empty program returns zero counts and empty lists.
+    #[actix_web::test]
+    async fn dashboard_empty_program() {
+        let mgr = Arc::new(GovernanceManager::new());
+        let domain_id = GovernanceDomainId("dom-a".to_string());
+        mgr.create_domain(
+            domain_id.clone(),
+            "Domain A".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::default(),
+            MembershipConfig {
+                source: MembershipSource::StaticList(vec![]),
+            },
+        )
+        .await
+        .unwrap();
+
+        let prog = mgr
+            .create_program(
+                domain_id,
+                "entity-a".to_string(),
+                icn_governance::ProgramKind::Cycle,
+                "Summit Cycle 2026".to_string(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        let app = dashboard_app!(make_dashboard_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/programs/{}/dashboard", prog.id.0))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["program_id"], prog.id.0.as_str());
+        assert_eq!(body["name"], "Summit Cycle 2026");
+        assert_eq!(body["status"], "draft");
+        assert_eq!(body["kind"], "cycle");
+        assert_eq!(body["milestones"], serde_json::json!([]));
+        assert_eq!(body["activities"], serde_json::json!([]));
+        assert_eq!(body["milestone_counts"]["total"], 0);
+        assert_eq!(body["action_item_counts"]["total"], 0);
+    }
+
+    /// Milestones are returned ordered by phase_index; counts are correct.
+    #[actix_web::test]
+    async fn dashboard_milestones_ordered_and_counted() {
+        let mgr = Arc::new(GovernanceManager::new());
+        let domain_id = GovernanceDomainId("dom-b".to_string());
+        mgr.create_domain(
+            domain_id.clone(),
+            "Domain B".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::default(),
+            MembershipConfig {
+                source: MembershipSource::StaticList(vec![]),
+            },
+        )
+        .await
+        .unwrap();
+
+        let prog = mgr
+            .create_program(
+                domain_id.clone(),
+                "entity-b".to_string(),
+                icn_governance::ProgramKind::Campaign,
+                "Q3 Campaign".to_string(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        // Add milestones out of phase order
+        mgr.create_milestone(
+            prog.id.clone(),
+            "Phase 2 work".to_string(),
+            None,
+            2,
+            None,
+            vec![],
+        )
+        .unwrap();
+        let m0 = mgr
+            .create_milestone(
+                prog.id.clone(),
+                "Phase 0 kickoff".to_string(),
+                None,
+                0,
+                None,
+                vec![],
+            )
+            .unwrap();
+        let m1 = mgr
+            .create_milestone(
+                prog.id.clone(),
+                "Phase 1 plan".to_string(),
+                None,
+                1,
+                None,
+                vec![],
+            )
+            .unwrap();
+
+        // Mark m0 completed, m1 blocked
+        let caller = test_did(1);
+        mgr.update_milestone_status(&m0.id, MilestoneStatus::Completed, &caller)
+            .unwrap();
+        mgr.update_milestone_status(&m1.id, MilestoneStatus::Blocked, &caller)
+            .unwrap();
+
+        let app = dashboard_app!(make_dashboard_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/programs/{}/dashboard", prog.id.0))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        let milestones = body["milestones"].as_array().unwrap();
+        assert_eq!(milestones.len(), 3);
+        // Phase order preserved (snake_case field names — no camelCase rename on summary)
+        assert_eq!(milestones[0]["phase_index"], 0);
+        assert_eq!(milestones[1]["phase_index"], 1);
+        assert_eq!(milestones[2]["phase_index"], 2);
+        assert_eq!(milestones[0]["status"], "completed");
+        assert_eq!(milestones[1]["status"], "blocked");
+
+        let mc = &body["milestone_counts"];
+        assert_eq!(mc["total"], 3);
+        assert_eq!(mc["completed"], 1);
+        assert_eq!(mc["blocked"], 1);
+        assert_eq!(mc["pending"], 1);
+    }
+
+    /// Action items attached to program activities appear in counts;
+    /// domain items not attached to a program activity are excluded.
+    #[actix_web::test]
+    async fn dashboard_action_item_counts_scoped_to_program_activities() {
+        let mgr = Arc::new(GovernanceManager::new());
+        let domain_id = GovernanceDomainId("dom-c".to_string());
+        let creator = test_did(2);
+
+        mgr.create_domain(
+            domain_id.clone(),
+            "Domain C".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::default(),
+            MembershipConfig {
+                source: MembershipSource::StaticList(vec![creator.clone()]),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Create program and link an activity
+        let prog = mgr
+            .create_program(
+                domain_id.clone(),
+                "entity-c".to_string(),
+                icn_governance::ProgramKind::Cycle,
+                "Cycle".to_string(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        // Activity declares its own parent_program_id — dashboard discovers
+        // it via the reverse-link scan (activity → program direction).
+        let activity = mgr
+            .create_activity(
+                "entity-c".to_string(),
+                icn_governance::ActivityKind::Event,
+                "Summit Event".to_string(),
+                None,
+                None,
+                None,
+                Some(prog.id.clone()),
+            )
+            .unwrap();
+
+        // Action item attached to the program's activity (should be counted)
+        let mut item_in = mgr
+            .create_action_item(
+                domain_id.clone(),
+                "In-scope task".to_string(),
+                None,
+                creator.clone(),
+                None,
+                None,
+                icn_governance::ActionItemPriority::Medium,
+                None,
+                None,
+                vec![],
+            )
+            .unwrap();
+        item_in.parent = Some(icn_governance::InstitutionalParent::Activity {
+            id: activity.id.clone(),
+        });
+        mgr.update_action_item(&item_in).unwrap();
+
+        // Domain action item with no parent (should NOT be counted)
+        mgr.create_action_item(
+            domain_id.clone(),
+            "Unattached task".to_string(),
+            None,
+            creator.clone(),
+            None,
+            None,
+            icn_governance::ActionItemPriority::Medium,
+            None,
+            None,
+            vec![],
+        )
+        .unwrap();
+
+        let app = dashboard_app!(make_dashboard_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/programs/{}/dashboard", prog.id.0))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        let ai = &body["action_item_counts"];
+        assert_eq!(ai["pending"], 1, "only the attached item should be counted");
+        assert_eq!(ai["total"], 1);
+
+        let activities = body["activities"].as_array().unwrap();
+        assert_eq!(activities.len(), 1);
+        assert_eq!(activities[0]["name"], "Summit Event");
     }
 }

--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -865,3 +865,89 @@ pub struct MilestoneResponse {
     pub completed_by: Option<String>,
     pub created_at: u64,
 }
+
+// ============================================================================
+// Program dashboard (composite read surface)
+// ============================================================================
+
+/// Compact milestone row inside the program dashboard.
+///
+/// Uses the full `MilestoneResponse` field set minus `completion_criteria` and
+/// `created_at`, which are detail-level and inflate the composite response
+/// without helping a dashboard consumer understand program progress.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct DashboardMilestoneSummary {
+    pub id: String,
+    pub name: String,
+    pub phase_index: u32,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_date: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<u64>,
+}
+
+/// Milestone status counts for the program dashboard.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+pub struct DashboardMilestoneCounts {
+    pub total: usize,
+    pub completed: usize,
+    pub in_progress: usize,
+    pub blocked: usize,
+    pub pending: usize,
+    pub skipped: usize,
+}
+
+/// Compact activity row inside the program dashboard.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct DashboardActivitySummary {
+    pub id: String,
+    pub name: String,
+    pub kind: String,
+    pub status: String,
+}
+
+/// Action item status counts for the program dashboard.
+///
+/// Counts only items whose `parent` is an `Activity` listed in the program's
+/// `activities` vec. Domain items with no activity parent or a parent that
+/// does not belong to this program are excluded.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+pub struct DashboardActionItemCounts {
+    pub pending: usize,
+    pub in_progress: usize,
+    pub completed: usize,
+    pub deferred: usize,
+    pub cancelled: usize,
+    pub total: usize,
+}
+
+/// Composite program dashboard response.
+///
+/// Returned by `GET /gov/programs/{program_id}/dashboard`. Combines the program
+/// record, its ordered milestones (with status counts), its linked activities,
+/// and action item counts scoped to those activities.
+///
+/// Meetings are intentionally absent from v1: the `Meeting` type links to
+/// activities via `linked_activities: Vec<ActivityId>`, but there is no
+/// activity-keyed index on the meeting store. Resolving meetings would require
+/// a full domain scan. Deferred until a `list_by_activity` index exists.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ProgramDashboardResponse {
+    pub program_id: String,
+    pub domain_id: String,
+    pub parent_entity_id: String,
+    pub name: String,
+    pub kind: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_at: Option<u64>,
+    pub milestones: Vec<DashboardMilestoneSummary>,
+    pub milestone_counts: DashboardMilestoneCounts,
+    pub activities: Vec<DashboardActivitySummary>,
+    pub action_item_counts: DashboardActionItemCounts,
+}

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -106,6 +106,42 @@ pub struct ProvenanceChain {
 }
 
 // ============================================================================
+// Program dashboard aggregate types
+// ============================================================================
+
+/// Action item status counts for the program dashboard.
+///
+/// Only counts items whose `parent` is an `InstitutionalParent::Activity`
+/// belonging to the program. Domain items not attached to a program activity
+/// are excluded.
+#[derive(Debug, Clone, Default)]
+pub struct ProgramActionItemCounts {
+    pub pending: usize,
+    pub in_progress: usize,
+    pub completed: usize,
+    pub deferred: usize,
+    pub cancelled: usize,
+}
+
+impl ProgramActionItemCounts {
+    pub fn total(&self) -> usize {
+        self.pending + self.in_progress + self.completed + self.deferred + self.cancelled
+    }
+}
+
+/// Composite program dashboard: program + ordered milestones + linked
+/// activities + action item counts.
+///
+/// Assembled by [`GovernanceManager::get_program_dashboard`] and converted to
+/// [`crate::http::models::ProgramDashboardResponse`] by the HTTP handler.
+pub struct ProgramDashboard {
+    pub program: Program,
+    pub milestones: Vec<Milestone>,
+    pub activities: Vec<Activity>,
+    pub action_item_counts: ProgramActionItemCounts,
+}
+
+// ============================================================================
 // Sled-Backed Action Item Store
 // ============================================================================
 
@@ -4224,6 +4260,97 @@ impl GovernanceManager {
         id: &str,
     ) -> Result<Option<icn_governance::GovernanceProofV2>> {
         self.get_proof(&ProposalId(id.to_string())).await
+    }
+
+    // ========================================================================
+    // Program dashboard (composite read surface)
+    // ========================================================================
+
+    /// Compose a compact dashboard for a program.
+    ///
+    /// Returns `None` when the program does not exist.
+    ///
+    /// Composition strategy:
+    /// - **Program**: single `get_program` lookup.
+    /// - **Milestones**: `list_milestones_by_program` (already sorted by
+    ///   `phase_index`).
+    /// - **Activities**: fetched individually from `program.activities` (the
+    ///   program record is the source of truth for which activities belong to
+    ///   it). Missing activity records are silently skipped (soft-reference
+    ///   semantics: the program outlives individual activity deletions).
+    /// - **Action item counts**: all items in the program's domain are loaded
+    ///   once, then filtered in memory to those whose `parent` is an
+    ///   `InstitutionalParent::Activity` with an ID present in
+    ///   `program.activities`. Grouped by `ActionItemStatus`.
+    /// - **Meetings**: intentionally absent from v1 — no activity-keyed index
+    ///   on the meeting store; resolving would require a full domain scan.
+    pub fn get_program_dashboard(
+        &self,
+        program_id: &ProgramId,
+    ) -> Result<Option<ProgramDashboard>> {
+        // 1. Program record
+        let program = match self.get_program(program_id)? {
+            Some(p) => p,
+            None => return Ok(None),
+        };
+
+        // 2. Milestones (sorted by phase_index from the store)
+        let milestones = self.list_milestones_by_program(program_id)?;
+
+        // 3. Activities — two complementary sources, merged and deduped:
+        //    (a) program.activities: explicit list maintained by the program lead.
+        //    (b) list_activities(parent_entity_id) filtered by parent_program_id:
+        //        activities that declared their own parent program at creation time.
+        //
+        // Both sources are truthful; either can be populated independently.
+        // The union ensures dashboard completeness regardless of which
+        // linkage direction was used.
+        let mut seen_ids: HashSet<ActivityId> = program.activities.iter().cloned().collect();
+        let entity_activities = self.list_activities(&program.parent_entity_id)?;
+        for a in &entity_activities {
+            if a.parent_program_id.as_ref() == Some(program_id) {
+                seen_ids.insert(a.id.clone());
+            }
+        }
+
+        let mut activities: Vec<Activity> = Vec::with_capacity(seen_ids.len());
+        for act_id in &seen_ids {
+            if let Some(a) = self.get_activity(act_id)? {
+                activities.push(a);
+            }
+        }
+        // Stable ordering: sort by name so response is deterministic
+        activities.sort_by(|a, b| a.name.cmp(&b.name));
+
+        // 4. Action item counts — one domain list, in-memory filter
+        let activity_ids: HashSet<ActivityId> = seen_ids;
+        let all_items = self.list_action_items(&program.domain_id, &ActionItemFilter::default())?;
+
+        let mut counts = ProgramActionItemCounts::default();
+        for item in &all_items {
+            let belongs = match &item.parent {
+                Some(icn_governance::InstitutionalParent::Activity { id }) => {
+                    activity_ids.contains(id)
+                }
+                _ => false,
+            };
+            if belongs {
+                match item.status {
+                    ActionItemStatus::Pending => counts.pending += 1,
+                    ActionItemStatus::InProgress => counts.in_progress += 1,
+                    ActionItemStatus::Completed => counts.completed += 1,
+                    ActionItemStatus::Deferred => counts.deferred += 1,
+                    ActionItemStatus::Cancelled => counts.cancelled += 1,
+                }
+            }
+        }
+
+        Ok(Some(ProgramDashboard {
+            program,
+            milestones,
+            activities,
+            action_item_counts: counts,
+        }))
     }
 }
 


### PR DESCRIPTION
## Summary

Adds `GET /gov/programs/{program_id}/dashboard` — the first generic composite read surface for programs. Returns a compact view combining program metadata, ordered milestones, linked activities, and action item counts, without introducing any institution-specific semantics.

## Changes

- **`ProgramDashboardResponse`** + supporting types (`DashboardMilestoneSummary`, `DashboardMilestoneCounts`, `DashboardActivitySummary`, `DashboardActionItemCounts`) in `models.rs`
- **`ProgramDashboard`** / **`ProgramActionItemCounts`** aggregate structs in `manager.rs`
- **`get_program_dashboard(program_id)`** manager method: composes the view in four steps: (1) program lookup, (2) milestones via `list_milestones_by_program`, (3) activities via union of `program.activities` and reverse `parent_program_id` scan, (4) action item counts via single domain list filtered in memory to program's activities
- **`get_program_dashboard`** HTTP handler + `GET /programs/{program_id}/dashboard` route
- **3 tests**: 404 for missing program, empty program returns zero counts, milestone ordering + status counts, action item counts scoped to program activities (not all domain items)
- **Meetings deferred**: explicitly documented — `Meeting` links to activities via `linked_activities` but there is no activity-keyed index; a full domain scan would be required

## Motivation

Callers need a single endpoint to understand a program's current state without N+1 round-trips. The NYCN summit cycle dashboard, a generic member overview screen, and operator health views all need this shape. The dashboard is generic — any `ProgramKind` works unchanged.

## Testing

- [x] Unit tests added (3 new handler tests, 92 total passing)
- [x] Integration tests pass
- [x] Manual testing: N/A — full HTTP handler coverage via actix-web test harness

## Invariants

- [x] No panics introduced in protocol paths
- [x] Determinism preserved (activities sorted by name; milestones by phase_index from store)
- [x] Canonical encodings unchanged
- [x] Trust gates not weakened
- [x] Kernel/app boundaries respected — all changes within `icn-governance-actor`

## Verification

```
cargo fmt --check          → ok
cargo clippy -p icn-governance-actor -- -D warnings  → ok (0 errors)
cargo test -p icn-governance-actor
  92 passed, 0 failed
```

## Documentation

- [x] N/A — REST endpoint; no public API docs yet
- [x] Deferred items explicitly documented in code and handler doc comment