### PR TITLE
feat(governance): activity-keyed meeting index + program dashboard meetings

### DIFF
--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -3660,13 +3660,24 @@ fn meeting_status_str(s: &MeetingStatus) -> &'static str {
     }
 }
 
-fn dashboard_meeting_summary(m: &icn_governance::Meeting) -> DashboardMeetingSummary {
+fn dashboard_meeting_summary(
+    m: &icn_governance::Meeting,
+    program_activity_ids: &std::collections::HashSet<&str>,
+) -> DashboardMeetingSummary {
     DashboardMeetingSummary {
         id: m.id.0.clone(),
         title: m.title.clone(),
         status: meeting_status_str(&m.status).to_string(),
         scheduled_at: m.scheduled_at,
-        linked_activity_ids: m.linked_activities.iter().map(|a| a.0.clone()).collect(),
+        // Only expose activity IDs that belong to THIS program. A meeting
+        // may legitimately be linked to unrelated activities; those IDs are
+        // intentionally omitted from the program-scoped dashboard summary.
+        linked_activity_ids: m
+            .linked_activities
+            .iter()
+            .filter(|a| program_activity_ids.contains(a.0.as_str()))
+            .map(|a| a.0.clone())
+            .collect(),
     }
 }
 
@@ -3759,7 +3770,14 @@ pub async fn get_program_dashboard<E: GovernanceEventEmitter + Clone + 'static>(
             cancelled: ai.cancelled,
             total: ai.total(),
         },
-        meetings: d.meetings.iter().map(dashboard_meeting_summary).collect(),
+        meetings: {
+            let program_activity_ids: std::collections::HashSet<&str> =
+                d.activities.iter().map(|a| a.id.0.as_str()).collect();
+            d.meetings
+                .iter()
+                .map(|m| dashboard_meeting_summary(m, &program_activity_ids))
+                .collect()
+        },
     };
 
     Ok(HttpResponse::Ok().json(resp))

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -3651,6 +3651,25 @@ fn dashboard_milestone_summary(m: &icn_governance::Milestone) -> DashboardMilest
     }
 }
 
+fn meeting_status_str(s: &MeetingStatus) -> &'static str {
+    match s {
+        MeetingStatus::Scheduled => "scheduled",
+        MeetingStatus::InProgress => "in_progress",
+        MeetingStatus::Completed => "completed",
+        MeetingStatus::Cancelled => "cancelled",
+    }
+}
+
+fn dashboard_meeting_summary(m: &icn_governance::Meeting) -> DashboardMeetingSummary {
+    DashboardMeetingSummary {
+        id: m.id.0.clone(),
+        title: m.title.clone(),
+        status: meeting_status_str(&m.status).to_string(),
+        scheduled_at: m.scheduled_at,
+        linked_activity_ids: m.linked_activities.iter().map(|a| a.0.clone()).collect(),
+    }
+}
+
 fn dashboard_activity_summary(a: &icn_governance::Activity) -> DashboardActivitySummary {
     DashboardActivitySummary {
         id: a.id.0.clone(),
@@ -3681,11 +3700,6 @@ fn dashboard_activity_summary(a: &icn_governance::Activity) -> DashboardActivity
 /// - action item counts scoped to the program's activities
 ///
 /// Requires `governance:read` scope. No write gates — this is a pure read.
-///
-/// **Meetings** are absent from this response. `Meeting` records link to
-/// activities via `linked_activities` but there is no activity-keyed index
-/// on the meeting store. Resolving meetings would require a full domain scan.
-/// Deferred until a `list_by_activity` index is available.
 pub async fn get_program_dashboard<E: GovernanceEventEmitter + Clone + 'static>(
     ctx: web::Data<GovernanceContext<E>>,
     http_req: HttpRequest,
@@ -3745,6 +3759,7 @@ pub async fn get_program_dashboard<E: GovernanceEventEmitter + Clone + 'static>(
             cancelled: ai.cancelled,
             total: ai.total(),
         },
+        meetings: d.meetings.iter().map(dashboard_meeting_summary).collect(),
     };
 
     Ok(HttpResponse::Ok().json(resp))
@@ -5147,5 +5162,148 @@ mod tests {
         let activities = body["activities"].as_array().unwrap();
         assert_eq!(activities.len(), 1);
         assert_eq!(activities[0]["name"], "Summit Event");
+    }
+
+    /// Meetings linked to program activities are included in the dashboard.
+    /// A meeting linked to two activities in the same program appears once
+    /// (dedup). Meetings not linked to any program activity are excluded.
+    #[actix_web::test]
+    async fn dashboard_includes_meetings_linked_through_activities() {
+        let mgr = Arc::new(GovernanceManager::new());
+        let domain_id = GovernanceDomainId("dom-d".to_string());
+        let creator = test_did(3);
+
+        mgr.create_domain(
+            domain_id.clone(),
+            "Domain D".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::default(),
+            MembershipConfig {
+                source: MembershipSource::StaticList(vec![creator.clone()]),
+            },
+        )
+        .await
+        .unwrap();
+
+        let prog = mgr
+            .create_program(
+                domain_id.clone(),
+                "entity-d".to_string(),
+                icn_governance::ProgramKind::Initiative,
+                "Initiative 2026".to_string(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        // Two activities in this program
+        let act1 = mgr
+            .create_activity(
+                "entity-d".to_string(),
+                icn_governance::ActivityKind::Event,
+                "Kickoff Event".to_string(),
+                None,
+                None,
+                None,
+                Some(prog.id.clone()),
+            )
+            .unwrap();
+
+        let act2 = mgr
+            .create_activity(
+                "entity-d".to_string(),
+                icn_governance::ActivityKind::Event,
+                "Review Session".to_string(),
+                None,
+                None,
+                None,
+                Some(prog.id.clone()),
+            )
+            .unwrap();
+
+        // meeting_a: linked to act1 only, scheduled at 2000
+        let mut meeting_a = mgr
+            .create_meeting(
+                domain_id.0.clone(),
+                "Kickoff Meeting".to_string(),
+                None,
+                Some(2000),
+                creator.to_string(),
+            )
+            .unwrap();
+        meeting_a.linked_activities = vec![act1.id.clone()];
+        mgr.update_meeting(&meeting_a).unwrap();
+
+        // meeting_b: linked to BOTH act1 and act2, scheduled at 1000 (earlier)
+        let mut meeting_b = mgr
+            .create_meeting(
+                domain_id.0.clone(),
+                "Joint Meeting".to_string(),
+                None,
+                Some(1000),
+                creator.to_string(),
+            )
+            .unwrap();
+        meeting_b.linked_activities = vec![act1.id.clone(), act2.id.clone()];
+        mgr.update_meeting(&meeting_b).unwrap();
+
+        // meeting_c: linked to an activity NOT in this program — should be excluded
+        let other_act = mgr
+            .create_activity(
+                "entity-d".to_string(),
+                icn_governance::ActivityKind::Event,
+                "Other Event".to_string(),
+                None,
+                None,
+                None,
+                None, // no parent_program_id
+            )
+            .unwrap();
+        let mut meeting_c = mgr
+            .create_meeting(
+                domain_id.0.clone(),
+                "Unrelated Meeting".to_string(),
+                None,
+                None,
+                creator.to_string(),
+            )
+            .unwrap();
+        meeting_c.linked_activities = vec![other_act.id.clone()];
+        mgr.update_meeting(&meeting_c).unwrap();
+
+        let app = dashboard_app!(make_dashboard_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/programs/{}/dashboard", prog.id.0))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        let meetings = body["meetings"].as_array().unwrap();
+
+        // meeting_b (scheduled 1000) and meeting_a (scheduled 2000);
+        // meeting_b also links to act2 — should NOT be duplicated.
+        assert_eq!(meetings.len(), 2, "two distinct meetings in program");
+        assert_eq!(
+            meetings[0]["title"], "Joint Meeting",
+            "earliest scheduled first"
+        );
+        assert_eq!(meetings[1]["title"], "Kickoff Meeting");
+
+        // meeting_b is linked to both activities
+        let joint_linked: Vec<&str> = meetings[0]["linked_activity_ids"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert_eq!(joint_linked.len(), 2);
+
+        assert_eq!(meetings[0]["status"], "scheduled");
     }
 }

--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -922,16 +922,28 @@ pub struct DashboardActionItemCounts {
     pub total: usize,
 }
 
+/// Compact meeting row inside the program dashboard.
+///
+/// Returned as part of [`ProgramDashboardResponse`]. Only includes the fields
+/// a dashboard consumer needs to render meeting status; full meeting details
+/// (agenda, attendees, notes) are available via `GET /gov/meetings/{id}`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct DashboardMeetingSummary {
+    pub id: String,
+    pub title: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheduled_at: Option<u64>,
+    /// Activity IDs from this program that the meeting is linked to.
+    pub linked_activity_ids: Vec<String>,
+}
+
 /// Composite program dashboard response.
 ///
 /// Returned by `GET /gov/programs/{program_id}/dashboard`. Combines the program
 /// record, its ordered milestones (with status counts), its linked activities,
-/// and action item counts scoped to those activities.
-///
-/// Meetings are intentionally absent from v1: the `Meeting` type links to
-/// activities via `linked_activities: Vec<ActivityId>`, but there is no
-/// activity-keyed index on the meeting store. Resolving meetings would require
-/// a full domain scan. Deferred until a `list_by_activity` index exists.
+/// action item counts scoped to those activities, and meetings linked through
+/// those activities.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ProgramDashboardResponse {
     pub program_id: String,
@@ -950,4 +962,8 @@ pub struct ProgramDashboardResponse {
     pub milestone_counts: DashboardMilestoneCounts,
     pub activities: Vec<DashboardActivitySummary>,
     pub action_item_counts: DashboardActionItemCounts,
+    /// Meetings linked to at least one activity that belongs to this program.
+    /// Deduped (a meeting linked to multiple activities appears once), sorted
+    /// earliest `scheduled_at` first; unscheduled meetings sort last.
+    pub meetings: Vec<DashboardMeetingSummary>,
 }

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -1296,14 +1296,25 @@ impl MeetingStoreBackend for SledMeetingStore {
         let index_key = Self::index_key(&m.domain_id, &m.id);
 
         // Load the existing record (if any) to diff linked_activities for
-        // index maintenance. On first save this returns empty.
-        let old_activities: Vec<ActivityId> = self
-            .db
-            .get(primary_key.as_bytes())
-            .map_err(|e| GovernanceError::Internal(format!("Sled get (pre-save) failed: {e}")))?
-            .and_then(|v| icn_encoding::decode_versioned::<Meeting>(&v).ok())
-            .map(|old| old.linked_activities)
-            .unwrap_or_default();
+        // index maintenance. On first save this returns empty. If an existing
+        // record cannot be decoded, surface the decode failure rather than
+        // silently treating it as "no prior activities" — that would leave
+        // stale activity-index rows pointing at a now-absent meeting.
+        let old_activities: Vec<ActivityId> =
+            match self.db.get(primary_key.as_bytes()).map_err(|e| {
+                GovernanceError::Internal(format!("Sled get (pre-save) failed: {e}"))
+            })? {
+                Some(v) => {
+                    icn_encoding::decode_versioned::<Meeting>(&v)
+                        .map_err(|e| {
+                            GovernanceError::Internal(format!(
+                                "Failed to decode existing meeting for index diff: {e}"
+                            ))
+                        })?
+                        .linked_activities
+                }
+                None => Vec::new(),
+            };
 
         let value = icn_encoding::encode_versioned(m)
             .map_err(|e| GovernanceError::Internal(format!("Failed to encode meeting: {e}")))?;
@@ -1318,23 +1329,26 @@ impl MeetingStoreBackend for SledMeetingStore {
             .insert(index_key.as_bytes(), &[] as &[u8])
             .map_err(|e| GovernanceError::Internal(format!("Sled insert (index) failed: {e}")))?;
 
-        // Remove stale activity index entries (activities that were linked
-        // before but are no longer present in the new record).
-        for act_id in &old_activities {
-            if !m.linked_activities.contains(act_id) {
-                let k = Self::activity_index_key(act_id, &m.id);
-                self.db.remove(k.as_bytes()).map_err(|e| {
-                    GovernanceError::Internal(format!("Sled remove (activity index) failed: {e}"))
-                })?;
-            }
-        }
-        // Write new activity index entries (activities now linked that weren't
-        // linked before — or all of them on first save).
-        for act_id in &m.linked_activities {
-            if !old_activities.contains(act_id) {
-                let k = Self::activity_index_key(act_id, &m.id);
+        // Reconcile the activity secondary index against the *desired* set
+        // (`m.linked_activities`). We take the union of the old record's
+        // activities and the new record's activities as the set to touch —
+        // this means a retry after a partial-failure previous save still
+        // rebuilds any missing index rows for activities that are listed in
+        // the new primary record.
+        let desired: std::collections::HashSet<&ActivityId> = m.linked_activities.iter().collect();
+        let union: std::collections::HashSet<&ActivityId> = old_activities
+            .iter()
+            .chain(m.linked_activities.iter())
+            .collect();
+        for act_id in union {
+            let k = Self::activity_index_key(act_id, &m.id);
+            if desired.contains(act_id) {
                 self.db.insert(k.as_bytes(), &[] as &[u8]).map_err(|e| {
                     GovernanceError::Internal(format!("Sled insert (activity index) failed: {e}"))
+                })?;
+            } else {
+                self.db.remove(k.as_bytes()).map_err(|e| {
+                    GovernanceError::Internal(format!("Sled remove (activity index) failed: {e}"))
                 })?;
             }
         }
@@ -4595,7 +4609,16 @@ impl GovernanceManager {
                 }
             }
         }
-        meetings.sort_by_key(|m| m.scheduled_at.unwrap_or(u64::MAX));
+        // Deterministic ordering: primary key is `scheduled_at` (earliest
+        // first, `None` sorts last), secondary key is `MeetingId` so meetings
+        // with identical timestamps (common for `None`) have a stable order
+        // independent of `HashSet` iteration order.
+        meetings.sort_by(|a, b| {
+            a.scheduled_at
+                .unwrap_or(u64::MAX)
+                .cmp(&b.scheduled_at.unwrap_or(u64::MAX))
+                .then_with(|| a.id.0.cmp(&b.id.0))
+        });
 
         Ok(Some(ProgramDashboard {
             program,

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -130,7 +130,7 @@ impl ProgramActionItemCounts {
 }
 
 /// Composite program dashboard: program + ordered milestones + linked
-/// activities + action item counts.
+/// activities + action item counts + meetings linked through those activities.
 ///
 /// Assembled by [`GovernanceManager::get_program_dashboard`] and converted to
 /// [`crate::http::models::ProgramDashboardResponse`] by the HTTP handler.
@@ -139,6 +139,10 @@ pub struct ProgramDashboard {
     pub milestones: Vec<Milestone>,
     pub activities: Vec<Activity>,
     pub action_item_counts: ProgramActionItemCounts,
+    /// All meetings linked to at least one activity that belongs to this
+    /// program. Deduped (a meeting linked to two activities appears once),
+    /// sorted earliest `scheduled_at` first; unscheduled meetings sort last.
+    pub meetings: Vec<Meeting>,
 }
 
 // ============================================================================
@@ -1276,24 +1280,64 @@ impl SledMeetingStore {
     fn domain_index_prefix(domain_id: &str) -> String {
         format!("meeting_by_domain:{}:", domain_id)
     }
+
+    fn activity_index_key(activity_id: &ActivityId, meeting_id: &MeetingId) -> String {
+        format!("meeting_by_activity:{}:{}", activity_id.0, meeting_id.0)
+    }
+
+    fn activity_index_prefix(activity_id: &ActivityId) -> String {
+        format!("meeting_by_activity:{}:", activity_id.0)
+    }
 }
 
 impl MeetingStoreBackend for SledMeetingStore {
     fn save(&self, m: &Meeting) -> std::result::Result<(), GovernanceError> {
         let primary_key = Self::meeting_key(&m.id);
         let index_key = Self::index_key(&m.domain_id, &m.id);
+
+        // Load the existing record (if any) to diff linked_activities for
+        // index maintenance. On first save this returns empty.
+        let old_activities: Vec<ActivityId> = self
+            .db
+            .get(primary_key.as_bytes())
+            .map_err(|e| GovernanceError::Internal(format!("Sled get (pre-save) failed: {e}")))?
+            .and_then(|v| icn_encoding::decode_versioned::<Meeting>(&v).ok())
+            .map(|old| old.linked_activities)
+            .unwrap_or_default();
+
         let value = icn_encoding::encode_versioned(m)
             .map_err(|e| GovernanceError::Internal(format!("Failed to encode meeting: {e}")))?;
 
-        // Best-effort atomic: write primary, then index. If either fails, the
-        // caller sees an error and can retry. sled::Batch would be stronger but
-        // is not used elsewhere in this store for this pattern.
+        // Best-effort atomic: write primary, then domain index. If either
+        // fails the caller sees an error and can retry. sled::Batch would be
+        // stronger but is not used elsewhere in this store for this pattern.
         self.db
             .insert(primary_key.as_bytes(), value)
             .map_err(|e| GovernanceError::Internal(format!("Sled insert (primary) failed: {e}")))?;
         self.db
             .insert(index_key.as_bytes(), &[] as &[u8])
             .map_err(|e| GovernanceError::Internal(format!("Sled insert (index) failed: {e}")))?;
+
+        // Remove stale activity index entries (activities that were linked
+        // before but are no longer present in the new record).
+        for act_id in &old_activities {
+            if !m.linked_activities.contains(act_id) {
+                let k = Self::activity_index_key(act_id, &m.id);
+                self.db.remove(k.as_bytes()).map_err(|e| {
+                    GovernanceError::Internal(format!("Sled remove (activity index) failed: {e}"))
+                })?;
+            }
+        }
+        // Write new activity index entries (activities now linked that weren't
+        // linked before — or all of them on first save).
+        for act_id in &m.linked_activities {
+            if !old_activities.contains(act_id) {
+                let k = Self::activity_index_key(act_id, &m.id);
+                self.db.insert(k.as_bytes(), &[] as &[u8]).map_err(|e| {
+                    GovernanceError::Internal(format!("Sled insert (activity index) failed: {e}"))
+                })?;
+            }
+        }
         Ok(())
     }
 
@@ -1359,7 +1403,8 @@ impl MeetingStoreBackend for SledMeetingStore {
     }
 
     fn delete(&self, id: &MeetingId) -> std::result::Result<bool, GovernanceError> {
-        // Load the meeting to discover its domain_id so we can clean up the index.
+        // Load the meeting to discover domain_id + linked_activities so we
+        // can clean up both the domain index and all activity index entries.
         let primary_key = Self::meeting_key(id);
         let Some(value) = self
             .db
@@ -1378,6 +1423,16 @@ impl MeetingStoreBackend for SledMeetingStore {
         self.db
             .remove(index_key.as_bytes())
             .map_err(|e| GovernanceError::Internal(format!("Sled delete (index) failed: {e}")))?;
+
+        // Clean up all activity index entries for this meeting.
+        for act_id in &m.linked_activities {
+            let k = Self::activity_index_key(act_id, id);
+            self.db.remove(k.as_bytes()).map_err(|e| {
+                GovernanceError::Internal(format!(
+                    "Sled remove (activity index on delete) failed: {e}"
+                ))
+            })?;
+        }
         Ok(true)
     }
 
@@ -1413,6 +1468,47 @@ impl MeetingStoreBackend for SledMeetingStore {
             }
         }
         out.sort_by_key(|m| m.scheduled_at.unwrap_or(0));
+        Ok(out)
+    }
+
+    fn list_by_activity(
+        &self,
+        activity_id: &ActivityId,
+    ) -> std::result::Result<Vec<Meeting>, GovernanceError> {
+        let prefix = Self::activity_index_prefix(activity_id);
+        // `meeting_by_activity:{activity_id}:` — split on last ':' to get the
+        // meeting ID, then load from primary. Activity IDs may contain ':' so
+        // we use rsplit_once (same convention as list_by_domain).
+        let expected_prefix = format!("meeting_by_activity:{}", activity_id.0);
+        let mut out = Vec::new();
+        for result in self.db.scan_prefix(prefix.as_bytes()) {
+            let (key, _) =
+                result.map_err(|e| GovernanceError::Internal(format!("Sled scan failed: {e}")))?;
+            let key_str = std::str::from_utf8(&key)
+                .map_err(|e| GovernanceError::Internal(format!("Invalid UTF-8 key: {e}")))?;
+            let Some((activity_portion, meeting_id_str)) = key_str.rsplit_once(':') else {
+                continue;
+            };
+            // Reject keys whose activity portion doesn't exactly match — guards
+            // against activity IDs that are prefixes of other activity IDs.
+            if activity_portion != expected_prefix {
+                continue;
+            }
+            let primary_key = format!("meeting:{}", meeting_id_str);
+            let Some(value) = self
+                .db
+                .get(primary_key.as_bytes())
+                .map_err(|e| GovernanceError::Internal(format!("Sled get failed: {e}")))?
+            else {
+                // Dangling index entry — skip.
+                continue;
+            };
+            let m: Meeting = icn_encoding::decode_versioned(&value)
+                .map_err(|e| GovernanceError::Internal(format!("Failed to decode meeting: {e}")))?;
+            out.push(m);
+        }
+        // Earliest scheduled first; unscheduled (None) sort last.
+        out.sort_by_key(|m| m.scheduled_at.unwrap_or(u64::MAX));
         Ok(out)
     }
 }
@@ -1559,6 +1655,148 @@ mod sled_meeting_store_tests {
         let listing = store.list_by_domain("dom-a").unwrap();
         assert_eq!(listing[0].title, "new");
         assert_eq!(listing[1].title, "old");
+    }
+
+    #[test]
+    fn list_by_activity_filters_and_sorts() {
+        use icn_governance::ActivityId;
+        let (db, _dir) = open_temp_db();
+        let store = SledMeetingStore::new(db.clone());
+
+        let act_a = ActivityId("act-alpha".to_string());
+        let act_b = ActivityId("act-beta".to_string());
+
+        // m1: linked to act_a, scheduled at 2000
+        let mut m1 = mk_meeting("dom", "meeting-1");
+        m1.scheduled_at = Some(2000);
+        m1.linked_activities = vec![act_a.clone()];
+        store.save(&m1).unwrap();
+
+        // m2: linked to act_a + act_b, scheduled at 1000 (earlier)
+        let mut m2 = mk_meeting("dom", "meeting-2");
+        m2.scheduled_at = Some(1000);
+        m2.linked_activities = vec![act_a.clone(), act_b.clone()];
+        store.save(&m2).unwrap();
+
+        // m3: linked only to act_b, unscheduled
+        let mut m3 = mk_meeting("dom", "meeting-3");
+        m3.linked_activities = vec![act_b.clone()];
+        store.save(&m3).unwrap();
+
+        // m4: no linked activities
+        store.save(&mk_meeting("dom", "meeting-4")).unwrap();
+
+        let by_a = store.list_by_activity(&act_a).unwrap();
+        assert_eq!(by_a.len(), 2, "act_a has two meetings");
+        assert_eq!(
+            by_a[0].title, "meeting-2",
+            "earlier scheduled_at sorts first"
+        );
+        assert_eq!(by_a[1].title, "meeting-1");
+
+        let by_b = store.list_by_activity(&act_b).unwrap();
+        assert_eq!(by_b.len(), 2, "act_b has two meetings");
+        assert_eq!(by_b[0].title, "meeting-2");
+        assert_eq!(by_b[1].title, "meeting-3", "unscheduled sorts last");
+
+        assert!(store
+            .list_by_activity(&ActivityId("no-such".to_string()))
+            .unwrap()
+            .is_empty());
+
+        // Verify index keys physically exist in sled
+        let idx = format!("meeting_by_activity:act-alpha:{}", m1.id.0);
+        assert!(
+            db.get(idx.as_bytes()).unwrap().is_some(),
+            "activity index entry present"
+        );
+    }
+
+    #[test]
+    fn list_by_activity_activity_id_prefix_isolation() {
+        // Regression: "act-a:" must not match "act-alpha:" entries
+        use icn_governance::ActivityId;
+        let (db, _dir) = open_temp_db();
+        let store = SledMeetingStore::new(db);
+
+        let act_a = ActivityId("act-a".to_string());
+        let act_alpha = ActivityId("act-alpha".to_string());
+
+        let mut m_a = mk_meeting("dom", "for-act-a");
+        m_a.linked_activities = vec![act_a.clone()];
+        store.save(&m_a).unwrap();
+
+        let mut m_alpha = mk_meeting("dom", "for-act-alpha");
+        m_alpha.linked_activities = vec![act_alpha.clone()];
+        store.save(&m_alpha).unwrap();
+
+        let by_a = store.list_by_activity(&act_a).unwrap();
+        let by_alpha = store.list_by_activity(&act_alpha).unwrap();
+        assert_eq!(by_a.len(), 1, "act-a must not pick up act-alpha entries");
+        assert_eq!(by_alpha.len(), 1);
+        assert_eq!(by_a[0].title, "for-act-a");
+        assert_eq!(by_alpha[0].title, "for-act-alpha");
+    }
+
+    #[test]
+    fn activity_index_cleaned_on_update() {
+        // Removing an activity from linked_activities on re-save must remove
+        // the corresponding index entry.
+        use icn_governance::ActivityId;
+        let (db, _dir) = open_temp_db();
+        let store = SledMeetingStore::new(db.clone());
+
+        let act_a = ActivityId("act-a".to_string());
+        let act_b = ActivityId("act-b".to_string());
+
+        let mut m = mk_meeting("dom", "relink");
+        m.linked_activities = vec![act_a.clone()];
+        store.save(&m).unwrap();
+
+        // Confirm act_a index entry is present
+        let k_a = format!("meeting_by_activity:act-a:{}", m.id.0);
+        assert!(db.get(k_a.as_bytes()).unwrap().is_some());
+
+        // Re-save with act_b only
+        m.linked_activities = vec![act_b.clone()];
+        store.save(&m).unwrap();
+
+        // act_a index must be removed; act_b must be present
+        assert!(
+            db.get(k_a.as_bytes()).unwrap().is_none(),
+            "stale act-a index entry should be removed"
+        );
+        let k_b = format!("meeting_by_activity:act-b:{}", m.id.0);
+        assert!(
+            db.get(k_b.as_bytes()).unwrap().is_some(),
+            "act-b index entry added"
+        );
+
+        assert!(store.list_by_activity(&act_a).unwrap().is_empty());
+        assert_eq!(store.list_by_activity(&act_b).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn activity_index_cleaned_on_delete() {
+        use icn_governance::ActivityId;
+        let (db, _dir) = open_temp_db();
+        let store = SledMeetingStore::new(db.clone());
+
+        let act = ActivityId("act-x".to_string());
+        let mut m = mk_meeting("dom", "will-delete");
+        m.linked_activities = vec![act.clone()];
+        store.save(&m).unwrap();
+
+        let k = format!("meeting_by_activity:act-x:{}", m.id.0);
+        assert!(db.get(k.as_bytes()).unwrap().is_some());
+
+        store.delete(&m.id).unwrap();
+
+        assert!(
+            db.get(k.as_bytes()).unwrap().is_none(),
+            "activity index entry must be removed on delete"
+        );
+        assert!(store.list_by_activity(&act).unwrap().is_empty());
     }
 }
 
@@ -4282,8 +4520,8 @@ impl GovernanceManager {
     ///   once, then filtered in memory to those whose `parent` is an
     ///   `InstitutionalParent::Activity` with an ID present in
     ///   `program.activities`. Grouped by `ActionItemStatus`.
-    /// - **Meetings**: intentionally absent from v1 — no activity-keyed index
-    ///   on the meeting store; resolving would require a full domain scan.
+    /// - **Meetings**: all meetings linked to at least one program activity,
+    ///   deduped and sorted by `scheduled_at` (earliest first).
     pub fn get_program_dashboard(
         &self,
         program_id: &ProgramId,
@@ -4345,11 +4583,26 @@ impl GovernanceManager {
             }
         }
 
+        // 5. Meetings — one list_by_activity call per discovered activity,
+        //    deduped by meeting ID (same meeting may link to several activities).
+        let mut seen_meeting_ids: HashSet<MeetingId> = HashSet::new();
+        let mut meetings: Vec<Meeting> = Vec::new();
+        for act_id in &activity_ids {
+            let act_meetings = self.meeting_store.list_by_activity(act_id)?;
+            for m in act_meetings {
+                if seen_meeting_ids.insert(m.id.clone()) {
+                    meetings.push(m);
+                }
+            }
+        }
+        meetings.sort_by_key(|m| m.scheduled_at.unwrap_or(u64::MAX));
+
         Ok(Some(ProgramDashboard {
             program,
             milestones,
             activities,
             action_item_counts: counts,
+            meetings,
         }))
     }
 }

--- a/icn/crates/icn-governance/src/meeting.rs
+++ b/icn/crates/icn-governance/src/meeting.rs
@@ -387,15 +387,12 @@ pub trait MeetingStoreBackend: Send + Sync {
     /// given a program's activities, collect meetings attached to those
     /// activities without a full domain scan.
     ///
-    /// The default implementation is an in-memory linear scan over all
-    /// meetings in the store, provided by delegating to the store's own
-    /// iteration. Stores with an explicit activity index (e.g.
-    /// `SledMeetingStore`) MUST override this method for O(log N) reads.
-    ///
-    /// **Note**: this default is deliberately left unimplemented rather than
-    /// returning an empty vec, so stores that don't override it fail loudly at
-    /// compile time via the missing-method error. Providing a correct default
-    /// requires access to the store's internal state, which varies per
+    /// This method has no default implementation: every backend must provide
+    /// one explicitly. Stores with an activity index (e.g. `SledMeetingStore`)
+    /// should serve this in O(log N) via the secondary index; stores without
+    /// one (e.g. `InMemoryMeetingStore`) fall back to a linear scan over their
+    /// own state. A correct default cannot be provided here because it would
+    /// require access to each backend's internal iteration, which varies per
     /// implementation.
     fn list_by_activity(
         &self,

--- a/icn/crates/icn-governance/src/meeting.rs
+++ b/icn/crates/icn-governance/src/meeting.rs
@@ -378,6 +378,29 @@ pub trait MeetingStoreBackend: Send + Sync {
     ) -> std::result::Result<Vec<Meeting>, GovernanceError> {
         Ok(Vec::new())
     }
+
+    /// List meetings linked to a specific activity, ordered by `scheduled_at`
+    /// ascending (earliest first, unscheduled last).
+    ///
+    /// A meeting is included if its `linked_activities` vec contains
+    /// `activity_id`. This is the primary read path for the program dashboard:
+    /// given a program's activities, collect meetings attached to those
+    /// activities without a full domain scan.
+    ///
+    /// The default implementation is an in-memory linear scan over all
+    /// meetings in the store, provided by delegating to the store's own
+    /// iteration. Stores with an explicit activity index (e.g.
+    /// `SledMeetingStore`) MUST override this method for O(log N) reads.
+    ///
+    /// **Note**: this default is deliberately left unimplemented rather than
+    /// returning an empty vec, so stores that don't override it fail loudly at
+    /// compile time via the missing-method error. Providing a correct default
+    /// requires access to the store's internal state, which varies per
+    /// implementation.
+    fn list_by_activity(
+        &self,
+        activity_id: &crate::activity::ActivityId,
+    ) -> std::result::Result<Vec<Meeting>, GovernanceError>;
 }
 
 // ========== In-Memory Store ==========
@@ -463,6 +486,24 @@ impl MeetingStoreBackend for InMemoryMeetingStore {
             .cloned()
             .collect();
         out.sort_by_key(|m| m.scheduled_at.unwrap_or(0));
+        Ok(out)
+    }
+
+    fn list_by_activity(
+        &self,
+        activity_id: &crate::activity::ActivityId,
+    ) -> std::result::Result<Vec<Meeting>, GovernanceError> {
+        let guard = self
+            .meetings
+            .read()
+            .map_err(|e| GovernanceError::Internal(format!("meetings lock poisoned: {e}")))?;
+        let mut out: Vec<Meeting> = guard
+            .values()
+            .filter(|m| m.linked_activities.contains(activity_id))
+            .cloned()
+            .collect();
+        // Earliest scheduled first; unscheduled (None) sort last (u64::MAX)
+        out.sort_by_key(|m| m.scheduled_at.unwrap_or(u64::MAX));
         Ok(out)
     }
 }
@@ -602,5 +643,78 @@ mod tests {
         // They serialize to snake_case strings, not special authority tokens.
         let s = serde_json::to_string(&facilitator).unwrap();
         assert_eq!(s, "\"facilitator\"");
+    }
+
+    #[test]
+    fn test_list_by_activity_filters_and_sorts() {
+        let store = InMemoryMeetingStore::new();
+        let act_a = ActivityId("act-alpha".to_string());
+        let act_b = ActivityId("act-beta".to_string());
+
+        // m1: linked to act_a, scheduled at 2000
+        let mut m1 = make_meeting("m1", "dom");
+        m1.scheduled_at = Some(2000);
+        m1.linked_activities = vec![act_a.clone()];
+        store.save(&m1).unwrap();
+
+        // m2: linked to act_a + act_b, scheduled at 1000 (earlier)
+        let mut m2 = make_meeting("m2", "dom");
+        m2.scheduled_at = Some(1000);
+        m2.linked_activities = vec![act_a.clone(), act_b.clone()];
+        store.save(&m2).unwrap();
+
+        // m3: linked only to act_b, unscheduled
+        let mut m3 = make_meeting("m3", "dom");
+        m3.linked_activities = vec![act_b.clone()];
+        store.save(&m3).unwrap();
+
+        // m4: no linked activities
+        store.save(&make_meeting("m4", "dom")).unwrap();
+
+        let by_a = store.list_by_activity(&act_a).unwrap();
+        assert_eq!(by_a.len(), 2, "act_a has two meetings");
+        assert_eq!(by_a[0].id.0, "m2", "earlier scheduled_at sorts first");
+        assert_eq!(by_a[1].id.0, "m1");
+
+        let by_b = store.list_by_activity(&act_b).unwrap();
+        assert_eq!(by_b.len(), 2, "act_b has two meetings");
+        // m2 (scheduled 1000) < m3 (unscheduled → u64::MAX)
+        assert_eq!(by_b[0].id.0, "m2");
+        assert_eq!(by_b[1].id.0, "m3", "unscheduled sorts last");
+
+        let by_c = store
+            .list_by_activity(&ActivityId("no-such".to_string()))
+            .unwrap();
+        assert!(by_c.is_empty());
+    }
+
+    #[test]
+    fn test_list_by_activity_updates_on_relink() {
+        // Verify that saving a meeting again with different linked_activities
+        // correctly changes which activity queries return it.
+        let store = InMemoryMeetingStore::new();
+        let act_a = ActivityId("act-a".to_string());
+        let act_b = ActivityId("act-b".to_string());
+
+        let mut m = make_meeting("m-relink", "dom");
+        m.linked_activities = vec![act_a.clone()];
+        store.save(&m).unwrap();
+
+        assert_eq!(store.list_by_activity(&act_a).unwrap().len(), 1);
+        assert!(store.list_by_activity(&act_b).unwrap().is_empty());
+
+        // Re-save with act_b instead of act_a
+        m.linked_activities = vec![act_b.clone()];
+        store.save(&m).unwrap();
+
+        assert!(
+            store.list_by_activity(&act_a).unwrap().is_empty(),
+            "stale link removed"
+        );
+        assert_eq!(
+            store.list_by_activity(&act_b).unwrap().len(),
+            1,
+            "new link added"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds a `list_by_activity` index to the meeting store and wires meetings into the program dashboard response. A program's dashboard now returns all meetings linked to its activities, deduped and sorted by `scheduled_at`.

## Changes

- `MeetingStoreBackend::list_by_activity` — required trait method (no silent empty-vec fallback)
- `InMemoryMeetingStore` — linear filter over `linked_activities` vec
- `SledMeetingStore` — `meeting_by_activity:{act_id}:{meeting_id}` secondary index; maintained by `save()` (diffs old/new `linked_activities`) and cleaned by `delete()`
- `ProgramDashboard` struct — adds `meetings: Vec<Meeting>` field
- `GovernanceManager::get_program_dashboard` — one `list_by_activity` call per discovered activity, deduped by `MeetingId`, sorted earliest `scheduled_at` first
- `DashboardMeetingSummary` model + `meetings` field on `ProgramDashboardResponse`
- Dashboard HTTP handler wired with `meeting_status_str` + `dashboard_meeting_summary` helpers
- Tests: `InMemoryMeetingStore` filter/sort/relink, `SledMeetingStore` index maintenance + prefix isolation + delete cleanup, dashboard HTTP integration (dedup across two activities)

## Motivation

The program dashboard explicitly deferred meetings because no activity-keyed index existed. This PR implements the index and closes that gap. Generic — no NYCN-specific nouns anywhere in the implementation.

## Testing

- [x] Unit tests added/updated — `meeting.rs` (InMemory), `manager.rs` (Sled), `handlers.rs` (HTTP)
- [x] Integration tests pass — 471 + 104 + 42 + 4 tests, all green
- [x] Manual testing: N/A (full coverage via automated tests)

## Invariants

- [x] No panics introduced in protocol paths
- [x] Determinism preserved — sort by `scheduled_at.unwrap_or(u64::MAX)` is stable
- [x] Canonical encodings unchanged (or versioned) — meeting encoding unchanged
- [x] Trust gates not weakened
- [x] Kernel/app boundaries respected — stays in app layer

## Verification

```
cargo check -p icn-governance -p icn-governance-actor  → Finished in 19.95s (clean)
cargo clippy -p icn-governance -p icn-governance-actor → 0 warnings
cargo test  -p icn-governance -p icn-governance-actor  → 621 passed; 0 failed
```

## Documentation

- [x] Stale "meetings absent" comments removed from handler + manager
- [ ] OpenAPI regen needed — `ProgramDashboardResponse` shape changed; follow-up chore
