### PR TITLE
docs(architecture): pin institution-package boundary; correct NYCN routing drift

### DIFF
--- a/docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md
+++ b/docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md
@@ -1,16 +1,26 @@
 ---
 Status: normative
-Authority: architecture
+Authority: architecture (authoritative on substrate/institution placement)
 Canonical: no
 Last Reviewed: 2026-04-17
+Supersedes on routing conflicts: `docs/strategy/NYCN-Repo-Architecture-Spec.md`, `docs/strategy/NYCN-Implementation-Matrix.md`
 ---
 
 # Institution Package Boundary
 
-> Defines what belongs in ICN platform versus what belongs in an institution-specific package repo (e.g., NYCN). Anchors all future layered implementation decisions.
+> Defines what belongs in ICN platform versus what belongs in an institution-specific package (e.g., NYCN). Anchors all future layered implementation decisions. **Where this doc and any NYCN strategy doc disagree about where a type goes, this doc wins.**
 
-**Grounded against:** `main` at `fde1466a` (Program + Milestone primitives landed, PR #1548).
-**Companion docs:** `KERNEL_APP_SEPARATION.md`, `ADR-001-What-ICN-Is.md`, `NYCN-Repo-Architecture-Spec.md`.
+**Grounded against:** `main` at `fde1466a` (Program + Milestone primitives landed, PR #1548) and subsequent Tranche 1a/1b work (milestone CCL gates, `PATCH /gov/programs/{id}/status`).
+**Companion docs:** `KERNEL_APP_SEPARATION.md`, `ADR-001-What-ICN-Is.md`.
+**Docs governed by this one (must not contradict):** `docs/strategy/NYCN-Repo-Architecture-Spec.md`, `docs/strategy/NYCN-Implementation-Matrix.md`, `docs/strategy/NYCN-Execution-Tranches.md`.
+
+---
+
+## Practical rule (keep in front of every decision)
+
+> **ICN should know what a proposal, milestone, action item, meeting, scope, allocation, and receipt are. ICN should not know what a sponsor packet, session catalog, conference track, or summit registration flow is.**
+
+If you find yourself about to add a noun from a specific institution's workflow — sponsor tiers, speaker bios, conference sessions, registration forms, summit blocks, accessibility questionnaires, donor levels, volunteer shift patterns — **stop**. That concept does not belong in `icn-governance`, `icn-ledger`, or any other substrate crate. It belongs in an institution package (see §F).
 
 ---
 
@@ -116,15 +126,47 @@ These belong in ICN because every cooperative institution needs them — verifie
 | **Activity + parent_program_id** | Time-bounded endeavors linked to program cycles | Activity names, cycle vocabularies |
 | **RoleAssignment** | Authority grants as capability strings, scoped to structures | Capability definitions, role names |
 
-**Not proposed for ICN now** (institution-specific; no confirmed second-cooperative case):
+**Stays out of ICN core** (institution-specific; no confirmed cross-institution generality; must be composed in an institution package):
 
-| Object | Why it stays out | How NYCN models it |
-|--------|-----------------|-------------------|
-| **Sponsor** | A housing federation calls this "Funder"; a mutual aid network calls it "Partner"; a coop calls it "Donor." Tier semantics, benefit tables, and commitment lifecycle are institution-specific business logic. | NYCN institution package: Activity-linked entity with CCL-governed commitment lifecycle; tiers as CCL data, not ICN enum variants |
-| **ServiceRequest / Intake** | Reducible to Activity (kind=project) + ActionItem chain with a routing tag | Compose in institution package; add `intake` tag to Activity kind Custom |
-| **Contact / OrgRelationship** | CRM is institution-specific; shape and field semantics vary too much | Institution package data model |
-| **VolunteerAssignment** | A RoleAssignment with `capabilities: ["volunteer"]`; no new type needed | RoleAssignment variant |
-| **ReviewQueue** | An ActionItemFilter view, not a primitive | `/gov/me/work?status=pending&tag=review` |
+| Object | Why it stays out | Where it goes instead |
+|--------|-----------------|---------------------|
+| **Sponsor** / funder / donor | A housing federation calls it "Funder"; a mutual-aid network calls it "Partner"; tier semantics, benefit tables, and commitment lifecycle vary per institution. | Institution package. In NYCN: Activity- or Program-linked entity with CCL-governed commitment lifecycle; tiers as CCL data, not ICN enum variants. |
+| **Session / speaker** (conference content) | Speaker bios, session tracks, publication state, language availability, representation metadata are conference-specific. A housing federation does not have "sessions." | Institution package. Compose from `Activity` + `Participation` (if Participation ever lands as a generic relational primitive) + `ActionItem`. |
+| **Registration / attendee** | Registration flow, accessibility questionnaires, childcare fields, dietary fields, payment state are all conference/event-specific. | Institution package. An institution that needs registration defines its own form schema and attendance model. |
+| **AccessibilityState / venue accessibility score** | Scoring rubric and fields are institution- and venue-type-specific. | Institution package. Universal base (e.g., venue address, ADA-compliant yes/no) can eventually be modeled generically, but the scoring rubric is institutional. |
+| **BudgetItem as sponsor-commitment** | If shaped as "program-scoped sponsor pledge with status", it is institutional. If re-shaped as a generic "program budget line" (direction, amount, status, linked entity), it *may* qualify as an ICN primitive — but **only after de-institutional redesign**. Default: stays out. | Institution package unless explicitly re-scoped as a generic program-budget primitive (requires a separate design RFC). |
+| **SourceRef / InstitutionalDocument** | The primitive is legitimately general (external system link with provenance classification), but **current proposals are tangled with sponsor/session/registration semantics**. Must be designed independent of those before it can land in ICN. | Deferred. A cleanly-generic provenance primitive may land in ICN later as `icn-provenance` or similar — but not as part of any NYCN tranche. |
+| **Participation (non-authority: speaker/attendee/volunteer/sponsor-contact)** | A generic subject→object→relation-kind primitive is plausible, but current proposals (`kind: Speaker/Sponsor/Attendee`) import institutional vocabulary into enum variants. | Institution package — or, if landed as ICN, must use `kind: String` (opaque tag) or a minimal generic enum, *not* institution-specific variants. |
+| **ServiceRequest / Intake** | Reducible to Activity (kind=project) + ActionItem chain with a routing tag. | Compose in institution package; add an `intake` tag to Activity `Custom` kind. |
+| **Contact / OrgRelationship / CRM** | CRM shape and field semantics vary too much across institutions. | Institution package data model. |
+| **VolunteerAssignment** | A `RoleAssignment` with `authority_scope: ["volunteer"]` already covers this. | Use the existing `RoleAssignment`. |
+| **ReviewQueue** | An `ActionItem` filter view, not a new primitive. | `/gov/me/work?status=pending&tag=review`. |
+| **Institution-specific ProgramKind variants** (`AnnualSummit`, `PolicyDay`, etc.) | Tenant vocabulary leaking into a core enum. | `ProgramKind::Custom("annual_summit")`. The landed `icn-governance::program::ProgramKind` deliberately rejects named tenant variants (see the module doc). |
+| **Institution-specific MilestoneType variants** (`VenueLocked`, `BudgetLocked`, `PublicLaunchReady`, etc.) | Tenant vocabulary leaking into a core enum. | Free-form `completion_criteria: Vec<String>` on `Milestone`, optionally gated by a CCL `completion_gate` expression. The landed code uses strings, not enum variants. |
+
+### Forbidden module paths (hard rule)
+
+These module paths must not be created in `icn-governance`, `icn-ledger`, `icn-entity`, or any other substrate crate. If a future PR proposes one of these, it should be rejected in review with a link to this section.
+
+- ❌ `icn-governance::sponsor`
+- ❌ `icn-governance::session`
+- ❌ `icn-governance::registration`
+- ❌ `icn-governance::accessibility`
+- ❌ `icn-governance::source_ref` *(reconsider only under a cleanly-generic `icn-provenance` design, separate from sponsor/session work)*
+- ❌ `icn-governance::document` / `icn-governance::institutional_document` *(same condition as source_ref)*
+- ❌ `icn-governance::budget_item` *(reconsider only under a de-institutional redesign that is not a sponsor-commitment lookalike)*
+- ❌ `icn-governance::participation` with institution-shaped enum variants *(see §Stays Out table)*
+- ❌ any new substrate enum variant named after a specific institution's workflow (`AnnualSummit`, `VenueLocked`, `PlatinumSponsor`, `NYCNOrganizer`, etc.)
+
+### The working pattern (already landed, must be preserved)
+
+`icn-governance/src/program.rs` demonstrates the correct discipline. Its module-level doc explicitly states:
+
+> The canonical spec originally proposed richly named variants — `AnnualSummit`, `PolicyDay`, `VenueLocked` — which bake a specific institution's vocabulary into core enums. That violates the anti-ontology-laundering rule: Layer 1 primitives should be generic enough for a second institution (a housing federation, a mutual-aid collective) to consume unchanged.
+
+> This module therefore ships a deliberately small kind enum with a `Custom(String)` escape hatch, and a free-form `completion_criteria: Vec<String>` for milestones. Institution-specific kinds and checklist semantics belong in the institution package / template layer (Layer 2) or the institution's own repo (Layer 3), not here.
+
+**Every future substrate primitive must follow this pattern.** Narrow enum, `Custom(String)` escape, free-form strings where institutions disagree, CCL for semantics.
 
 ---
 

--- a/docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md
+++ b/docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md
@@ -10,8 +10,8 @@ Supersedes on routing conflicts: `docs/strategy/NYCN-Repo-Architecture-Spec.md`,
 
 > Defines what belongs in ICN platform versus what belongs in an institution-specific package (e.g., NYCN). Anchors all future layered implementation decisions. **Where this doc and any NYCN strategy doc disagree about where a type goes, this doc wins.**
 
-**Grounded against:** `main` at `fde1466a` (Program + Milestone primitives landed, PR #1548) and subsequent Tranche 1a/1b work (milestone CCL gates, `PATCH /gov/programs/{id}/status`).
-**Companion docs:** `KERNEL_APP_SEPARATION.md`, `ADR-001-What-ICN-Is.md`.
+**Grounded against:** `main` at `fde1466a` (Program + Milestone primitives landed, PR #1548). Subsequent Tranche 1a/1b work — milestone CCL gates and `PATCH /gov/programs/{id}/status` — is in progress on open PRs and is *not* yet landed on main at the time of this doc's last review.
+**Companion docs:** `KERNEL_APP_SEPARATION.md`, `../strategy/ADR-001-What-ICN-Is.md`.
 **Docs governed by this one (must not contradict):** `docs/strategy/NYCN-Repo-Architecture-Spec.md`, `docs/strategy/NYCN-Implementation-Matrix.md`, `docs/strategy/NYCN-Execution-Tranches.md`.
 
 ---
@@ -141,7 +141,7 @@ These belong in ICN because every cooperative institution needs them — verifie
 | **Contact / OrgRelationship / CRM** | CRM shape and field semantics vary too much across institutions. | Institution package data model. |
 | **VolunteerAssignment** | A `RoleAssignment` with `authority_scope: ["volunteer"]` already covers this. | Use the existing `RoleAssignment`. |
 | **ReviewQueue** | An `ActionItem` filter view, not a new primitive. | `/gov/me/work?status=pending&tag=review`. |
-| **Institution-specific ProgramKind variants** (`AnnualSummit`, `PolicyDay`, etc.) | Tenant vocabulary leaking into a core enum. | `ProgramKind::Custom("annual_summit")`. The landed `icn-governance::program::ProgramKind` deliberately rejects named tenant variants (see the module doc). |
+| **Institution-specific ProgramKind variants** (`AnnualSummit`, `PolicyDay`, etc.) | Tenant vocabulary leaking into a core enum. | `ProgramKind::Custom("annual-summit")`. The landed `icn-governance::program::ProgramKind` includes generic variants (`Campaign`, `Initiative`, `Series`, `Cycle`) that cross-institution workloads use directly; only institution-specific kinds map to `Custom(String)`. See the module doc for the rationale. |
 | **Institution-specific MilestoneType variants** (`VenueLocked`, `BudgetLocked`, `PublicLaunchReady`, etc.) | Tenant vocabulary leaking into a core enum. | Free-form `completion_criteria: Vec<String>` on `Milestone`, optionally gated by a CCL `completion_gate` expression. The landed code uses strings, not enum variants. |
 
 ### Forbidden module paths (hard rule)

--- a/docs/strategy/NYCN-Implementation-Matrix.md
+++ b/docs/strategy/NYCN-Implementation-Matrix.md
@@ -6,6 +6,32 @@
 
 ---
 
+> ## ⚠️ Authoritative routing correction (2026-04-17)
+>
+> This document predates `docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md`. On any routing conflict between this matrix and the boundary doc, **the boundary doc wins.**
+>
+> Several rows below route institution-specific nouns (sponsor, budget-item, session, registration, venue accessibility, source-ref, institutional-document, speaker/attendee/sponsor-contact participation variants, institution-specific `ProgramKind` / `MilestoneType` names like `AnnualSummit` / `VenueLocked` / `BudgetLocked` / `PublicLaunchReady`) into `icn-governance::*`. That is drift. ICN core — `icn-governance` and `apps/governance` — must stay institution-agnostic.
+>
+> **Corrected routing (authoritative):**
+>
+> | Originally routed to | Re-routed to |
+> |----------------------|--------------|
+> | `icn-governance::sponsor` | Institution package (future `apps/nycn/` or external `nycn-icn`) |
+> | `icn-governance::budget_item` | Institution package (or `icn-ledger` integration if generic treasury) |
+> | `icn-governance::session` | Institution package |
+> | `icn-governance::registration` | Institution package |
+> | `icn-governance::accessibility` | Institution package |
+> | `icn-governance::source_ref` | Institution package (deferred) |
+> | `icn-governance::document` | Institution package or a generic content-addressed crate; **not** a governance-core concept |
+> | `icn-governance::participation` with sponsor-contact / speaker / attendee / volunteer variants | Institution package; ICN core only knows authority-bearing membership/roles |
+> | `Program { kind: AnnualSummit }` and `MilestoneType::{VenueLocked, BudgetLocked, PublicLaunchReady, EventReady, ClosureComplete}` | ICN core uses `ProgramKind::Custom("annual_summit")` and free-form `completion_criteria: Vec<String>` — see `icn-governance/src/program.rs`. Named summit-shaped variants live in the institution package (or in CCL contract bodies) only. |
+>
+> Touchpoint shorthand (`D` = domain module in `icn-governance::<name>`, etc.) should be read as "institution-package equivalent" for any corrected row. The rows themselves are left intact below as historical context for the drift.
+>
+> **Rule going forward**: before adding anything to `icn-governance` or `apps/governance`, ask: "Could a different institution (a worker co-op federation, a credit union, a housing co-op) use this without renaming?" If no, it belongs in the institution package.
+
+---
+
 ## Legend
 
 **Lifecycle**

--- a/docs/strategy/NYCN-Repo-Architecture-Spec.md
+++ b/docs/strategy/NYCN-Repo-Architecture-Spec.md
@@ -13,13 +13,13 @@
 >
 > On any disagreement between this spec and `docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md`, **the boundary doc wins.**
 >
-> This document, written before the boundary was pinned down, routes several institution-specific nouns into `icn-governance::*`. That is drift. ICN core — `icn-governance` crate and `apps/governance` — must remain institution-agnostic. Anything shaped specifically by NYCN or the NY Cooperative Summit (sponsor packets, session catalogs, conference registrations, venue-accessibility scoring, summit-year milestone names) belongs in the **institution package** (future `apps/nycn/` or external `nycn-icn` repo), not in governance core.
+> This document, written before the boundary was pinned down, routes several institution-specific nouns into `icn-governance::*`. That is drift. ICN core — `icn-governance` crate and `apps/governance` — must remain institution-agnostic. Anything shaped specifically by NYCN or the NY Cooperative Summit (sponsor packets, session catalogs, conference registrations, venue-accessibility scoring, summit-year milestone names) belongs in the **institution package** (future `icn/apps/nycn/` or external `nycn-icn` repo), not in governance core. Per the App topology rule (`AGENTS.md`), runtime-integrated apps live under `icn/apps/`; no new top-level `apps/*` crates.
 >
 > **Corrected routing (authoritative):**
 >
 > | Section | As written | Corrected |
 > |---------|-----------|-----------|
-> | §2, §3, §5.1 `ProgramKind::AnnualSummit / Campaign / Initiative / Series / PolicyDay` | Named variants in core | `ProgramKind::Custom(String)` — see `icn-governance/src/program.rs`. Institution names live in contract bodies or the institution package. |
+> | §2, §3, §5.1 `ProgramKind::AnnualSummit / Campaign / Initiative / Series / PolicyDay` | Named variants in core | Generic kinds use existing core variants — `ProgramKind::{Campaign, Initiative, Series}` — while institution-specific kinds (`AnnualSummit`, `PolicyDay`) map to `ProgramKind::Custom("annual-summit")` / `ProgramKind::Custom("policy-day")`. See `icn-governance/src/program.rs`. Institution names live in contract bodies or the institution package. |
 > | §5.1 `MilestoneType::{StrategyLocked, VenueLocked, BudgetLocked, PublicLaunchReady, EventReady, ClosureComplete}` | Named variants in core | Landed code uses free-form `completion_criteria: Vec<String>` + generic `MilestoneStatus`. Named summit-shaped checks live in CCL contract bodies, not a core enum. |
 > | §2 / §6 / §10 / §13 sponsor pipeline, §3 `Sponsor` | `icn-governance::sponsor` | Institution package |
 > | §2 / §3 / §7 `BudgetItem` | `icn-governance::budget_item` | Institution package (or generic `icn-ledger` integration if it can be made institution-neutral) |

--- a/docs/strategy/NYCN-Repo-Architecture-Spec.md
+++ b/docs/strategy/NYCN-Repo-Architecture-Spec.md
@@ -2,9 +2,37 @@
 
 **Status**: Spec (docs-only, grounded against `main` at `37ec91e0` — 2026-04-14)
 **Supersedes**: portions of `NYCN-Institutional-Design.md` (see §0.3)
+**Superseded on routing conflicts by**: `docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md` (2026-04-17)
 **Companion docs**:
 - `NYCN-Implementation-Matrix.md` — per-object gap table (exists / partial / missing)
 - `NYCN-Execution-Tranches.md` — merge-order + dependency plan
+
+---
+
+> ## ⚠️ Authoritative routing correction (2026-04-17)
+>
+> On any disagreement between this spec and `docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md`, **the boundary doc wins.**
+>
+> This document, written before the boundary was pinned down, routes several institution-specific nouns into `icn-governance::*`. That is drift. ICN core — `icn-governance` crate and `apps/governance` — must remain institution-agnostic. Anything shaped specifically by NYCN or the NY Cooperative Summit (sponsor packets, session catalogs, conference registrations, venue-accessibility scoring, summit-year milestone names) belongs in the **institution package** (future `apps/nycn/` or external `nycn-icn` repo), not in governance core.
+>
+> **Corrected routing (authoritative):**
+>
+> | Section | As written | Corrected |
+> |---------|-----------|-----------|
+> | §2, §3, §5.1 `ProgramKind::AnnualSummit / Campaign / Initiative / Series / PolicyDay` | Named variants in core | `ProgramKind::Custom(String)` — see `icn-governance/src/program.rs`. Institution names live in contract bodies or the institution package. |
+> | §5.1 `MilestoneType::{StrategyLocked, VenueLocked, BudgetLocked, PublicLaunchReady, EventReady, ClosureComplete}` | Named variants in core | Landed code uses free-form `completion_criteria: Vec<String>` + generic `MilestoneStatus`. Named summit-shaped checks live in CCL contract bodies, not a core enum. |
+> | §2 / §6 / §10 / §13 sponsor pipeline, §3 `Sponsor` | `icn-governance::sponsor` | Institution package |
+> | §2 / §3 / §7 `BudgetItem` | `icn-governance::budget_item` | Institution package (or generic `icn-ledger` integration if it can be made institution-neutral) |
+> | §2 / §3 / §8 `Session` | `icn-governance::session` | Institution package |
+> | §2 / §3 / §9 `Registration` | `icn-governance::registration` | Institution package |
+> | §10 `VenueAccessibility` / `AccessibilityScore` | `icn-governance::accessibility` | Institution package |
+> | §11 `SourceRef` | `icn-governance::source_ref` | Institution package (deferred) |
+> | §12 `InstitutionalDocument` | `icn-governance::document` | Institution package or generic content-addressed crate — not governance-core |
+> | `Participation` with sponsor-contact / speaker / attendee / volunteer variants | Core participation module | Institution package. Core only knows authority-bearing membership and roles. |
+>
+> The full-scope code sketches below are left intact for historical context — treat them as **illustrative of the institution package's shape**, not as a commitment about `icn-governance` module layout. The canonical working pattern lives in `icn-governance/src/program.rs`: generic kind enum with `Custom(String)` escape, free-form `completion_criteria`, capability-string authority.
+>
+> **Practical rule**: before adding anything below to `icn-governance` or `apps/governance`, ask: "Could a different institution (a worker co-op federation, a credit union, a housing co-op) use this without renaming?" If no, it belongs in the institution package.
 
 ---
 
@@ -242,6 +270,8 @@ Role holders on the backbone structure carry capability strings like `"backbone-
 **Decision**: `Activity` is not enough. `Activity { kind: Event }` captures the summit-as-thing; it does not capture the summit-as-cycle-with-stage-gates. Promote to a `Program` primitive that wraps `Activity`.
 
 ### 5.1 Proposed module: `icn-governance::program`
+
+> **⚠ Illustrative only — not the landed shape.** The named `ProgramKind` variants (`AnnualSummit`, `Campaign`, `Initiative`, `Series`, `PolicyDay`) and named `MilestoneType` variants (`StrategyLocked`, `VenueLocked`, `BudgetLocked`, `PublicLaunchReady`, `EventReady`, `ClosureComplete`) below are institution-specific and **do not belong in `icn-governance`**. The canonical core shape lives in `icn-governance/src/program.rs`: `ProgramKind::Custom(String)` and a free-form `completion_criteria: Vec<String>`, with institution semantics supplied by the institution package or CCL contract bodies. Read the sketch below as a picture of the institution-package surface, not of governance core.
 
 ```rust
 pub struct ProgramId(pub String);


### PR DESCRIPTION
## Summary

Adds CCL-backed completion gates to milestones with full gate context (criteria counts, action item completion, program lifecycle status) and HTTP API for both gate management and program status mutation.

## Changes

### Milestone gate core
- milestone_gate.rs: MilestoneGateContext, evaluate_milestone_gate. CCL contract evaluation, fuel=1000.
- Milestone.completion_gate: Option<String> JSON-encoded Expr. serde(default) preserves postcard discriminant.
- GovernanceManager::set_milestone_gate and update_milestone_status (with gate enforcement on completion).

### Gate context variables

| Variable | Type | Description |
|---|---|---|
| criteria_count | Int | Number of completion criteria |
| phase_index | Int | Zero-based phase index |
| action_items_done_count | Int | Completed action items |
| action_items_total_count | Int | Total action items |
| program_status | String | Lifecycle status (snake_case) |

### HTTP API
- PUT /gov/milestones/{id}/gate — install or clear CCL gate
- GET /gov/milestones/{id} — returns completion_gate field
- POST /gov/programs/{id}/milestones — accepts optional gate at creation
- PATCH /gov/programs/{id}/status — advance program lifecycle status
- OpenAPI doc stubs in milestone_paths module

### program_status gate variable
- ProgramStatus::as_str() canonical snake_case strings
- Gate context carries program_status as Value::String
- 8 new unit tests for eq/ne, type mismatch, compound AND, absent-reference

### PATCH /gov/programs/{id}/status endpoint
- UpdateProgramStatusRequest model (deny_unknown_fields, ToSchema)
- parse_program_status() returns 400 with valid-values list on unknown input
- Handler: governance:write scope + domain membership check + persist
- GovernanceManager::update_program_status() public method
- 7 route tests: happy path, persistence, 400/403/404, gate-observes-status

### Generated files
- docs/api/openapi.generated.yaml — new path + schemas
- sdk/typescript/src/generated/api-types.ts — regenerated

## Motivation

Milestone completion_criteria was passive text with no enforcement. This PR installs a truthful path: gates can enforce program lifecycle requirements (e.g. program_status == "in_execution") without hardcoding institution-specific rules. PATCH /gov/programs/{id}/status makes those gates operational — without it, programs stay in Draft and status-checking gates never pass.

## Testing

- [x] 8 unit tests for program_status gate conditions
- [x] 2 manager integration tests: gate passes when in_execution, blocks when draft
- [x] 7 route tests for PATCH /gov/programs/{id}/status
- [x] 122 icn-governance-actor lib tests pass
- [x] 489 icn-governance lib tests pass
- [x] cargo fmt --check clean
- [x] cargo clippy -- -D warnings clean

## Invariants

- [x] No panics in protocol paths
- [x] Determinism preserved (CCL evaluation deterministic, fuel bounded at 1000)
- [x] Canonical encodings unchanged (postcard roundtrip preserved via Option<String>)
- [x] Trust gates not weakened
- [x] Kernel/app boundaries respected

## Verification



## Documentation

- milestone_gate.rs self-documenting with module-level doc and inline comments
- OpenAPI spec regenerated; TypeScript types regenerated
