### PR TITLE
feat(governance): milestone preview + history + program summary + event log + PATCH status

### DIFF
--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -362,6 +362,10 @@ where
                 .route(web::get().to(handlers::get_program::<E>)),
         )
         .service(
+            web::resource("/programs/{program_id}/status")
+                .route(web::patch().to(handlers::update_program_status::<E>)),
+        )
+        .service(
             web::resource("/programs/{program_id}/dashboard")
                 .route(web::get().to(handlers::get_program_dashboard::<E>)),
         )

--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -384,6 +384,10 @@ where
             web::resource("/milestones/{milestone_id}/preview")
                 .route(web::get().to(handlers::preview_milestone::<E>)),
         )
+        .service(
+            web::resource("/milestones/{milestone_id}/history")
+                .route(web::get().to(handlers::get_milestone_history::<E>)),
+        )
         // ── Meeting endpoints ────────────────────────────────────────────
         .service(
             web::resource("/domains/{domain_id}/meetings")

--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -366,6 +366,10 @@ where
                 .route(web::get().to(handlers::get_program_dashboard::<E>)),
         )
         .service(
+            web::resource("/programs/{program_id}/summary")
+                .route(web::get().to(handlers::get_program_summary::<E>)),
+        )
+        .service(
             web::resource("/programs/{program_id}/milestones")
                 .route(web::post().to(handlers::create_milestone::<E>))
                 .route(web::get().to(handlers::list_milestones_by_program::<E>)),

--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -380,6 +380,10 @@ where
                 .route(web::get().to(handlers::get_milestone::<E>))
                 .route(web::patch().to(handlers::update_milestone_status::<E>)),
         )
+        .service(
+            web::resource("/milestones/{milestone_id}/preview")
+                .route(web::get().to(handlers::preview_milestone::<E>)),
+        )
         // ── Meeting endpoints ────────────────────────────────────────────
         .service(
             web::resource("/domains/{domain_id}/meetings")

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -3836,6 +3836,83 @@ fn build_milestone_preview(
     }
 }
 
+// ── Milestone history ──────────────────────────────────────────────────────────
+
+/// GET /gov/milestones/{milestone_id}/history — Read-only lifecycle bookmark view.
+///
+/// Returns the observable status-transition history for a milestone.
+///
+/// **Coverage limitation**: the governance store records only two temporal
+/// facts about a milestone:
+/// - `created_at` — when the milestone was first persisted (initial status is
+///   always `pending`).
+/// - `completed_at` + `completed_by` — set only when the milestone moves into
+///   `Completed`.
+///
+/// Intermediate transitions (`pending → in_progress`, `→ blocked`, etc.) are
+/// **not** persisted. They will not appear in this response. The `coverage`
+/// field in the response is always `"lifecycle_bookmarks"` in the current
+/// implementation; callers must treat the entry list as a partial view, not a
+/// complete audit log.
+///
+/// Requires `governance:read`.
+///
+/// Returns 404 if the milestone does not exist.
+pub async fn get_milestone_history<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    milestone_id: web::Path<String>,
+) -> Result<HttpResponse, ApiError> {
+    require_scope::<BasicClaims>(&http_req, "governance:read")?;
+    let id = MilestoneId(milestone_id.into_inner());
+
+    let milestone = ctx
+        .manager
+        .get_milestone(&id)
+        .map_err(anyhow_to_api)?
+        .ok_or_else(|| err_not_found("Milestone not found"))?;
+
+    Ok(HttpResponse::Ok().json(build_milestone_history(&milestone)))
+}
+
+/// Pure function assembling a [`MilestoneHistoryResponse`] from a milestone
+/// record. Split out for unit-testability without an HTTP stack.
+///
+/// Entries are ordered oldest-to-newest:
+/// 1. Creation bookmark (`created_at`, status `pending`, source `creation`).
+/// 2. Completion bookmark (`completed_at` + `completed_by`), only present when
+///    the milestone has `completed_at` set.
+///
+/// No intermediate entries are emitted because intermediate transitions are
+/// not persisted in the current store.
+fn build_milestone_history(milestone: &icn_governance::Milestone) -> MilestoneHistoryResponse {
+    let mut entries = Vec::new();
+
+    // Entry 1: creation (always present).
+    entries.push(MilestoneHistoryEntry {
+        changed_at: milestone.created_at,
+        changed_by: None, // creator is not recorded on the milestone record
+        to_status: "pending".to_string(),
+        source: "creation".to_string(),
+    });
+
+    // Entry 2: completion (only when the milestone has been completed).
+    if let Some(completed_at) = milestone.completed_at {
+        entries.push(MilestoneHistoryEntry {
+            changed_at: completed_at,
+            changed_by: milestone.completed_by.as_ref().map(|d| d.to_string()),
+            to_status: "completed".to_string(),
+            source: "completion_record".to_string(),
+        });
+    }
+
+    MilestoneHistoryResponse {
+        milestone_id: milestone.id.0.clone(),
+        coverage: "lifecycle_bookmarks".to_string(),
+        entries,
+    }
+}
+
 // ── Program dashboard ─────────────────────────────────────────────────────────
 
 fn dashboard_milestone_summary(m: &icn_governance::Milestone) -> DashboardMilestoneSummary {
@@ -5793,5 +5870,127 @@ mod tests {
             reason.contains("blocked"),
             "reason should mention block: {reason}"
         );
+    }
+
+    // ── Milestone history tests ────────────────────────────────────────────
+
+    macro_rules! history_app {
+        ($ctx:expr) => {{
+            let ctx_data = web::Data::new($ctx);
+            test::init_service(
+                App::new()
+                    .app_data(ctx_data)
+                    .wrap_fn(move |req, srv| {
+                        req.extensions_mut().insert(BasicClaims {
+                            sub: "did:icn:reader".to_string(),
+                            scope: Some("governance:read".to_string()),
+                        });
+                        srv.call(req)
+                    })
+                    .route(
+                        "/milestones/{milestone_id}/history",
+                        web::get().to(get_milestone_history::<NoopEventEmitter>),
+                    ),
+            )
+            .await
+        }};
+    }
+
+    /// 404 when the milestone does not exist.
+    #[actix_web::test]
+    async fn history_404_for_missing_milestone() {
+        let mgr = Arc::new(GovernanceManager::new());
+        let app = history_app!(make_dashboard_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/milestones/ghost/history")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 404);
+    }
+
+    /// Open (pending) milestone has exactly one entry: the creation bookmark.
+    /// `completed_at` and `completed_by` are absent → completion entry omitted.
+    #[actix_web::test]
+    async fn history_pending_milestone_has_one_entry() {
+        let mgr = Arc::new(GovernanceManager::new());
+        let pid = setup_preview_program(&mgr, "dom-h1", "ent-h1").await;
+
+        let m = mgr
+            .create_milestone(pid, "Phase 0".to_string(), None, 0, None, vec![])
+            .unwrap();
+
+        let app = history_app!(make_dashboard_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/milestones/{}/history", m.id.0))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["coverage"], "lifecycle_bookmarks");
+        let entries = body["entries"].as_array().unwrap();
+        assert_eq!(
+            entries.len(),
+            1,
+            "only creation entry for pending milestone"
+        );
+        assert_eq!(entries[0]["to_status"], "pending");
+        assert_eq!(entries[0]["source"], "creation");
+        // changed_by is omitted (no creator recorded on milestone record)
+        assert!(entries[0]["changed_by"].is_null());
+    }
+
+    /// Completed milestone has two entries: creation + completion.
+    /// `completed_by` is present on the completion entry.
+    #[actix_web::test]
+    async fn history_completed_milestone_has_two_entries() {
+        let mgr = Arc::new(GovernanceManager::new());
+        let pid = setup_preview_program(&mgr, "dom-h2", "ent-h2").await;
+
+        let m = mgr
+            .create_milestone(pid, "Phase 0".to_string(), None, 0, None, vec![])
+            .unwrap();
+
+        let actor = Did::from_anchor_id(&[42u8; 32]);
+        let actor_str = actor.to_string();
+        mgr.update_milestone_status(&m.id, MilestoneStatus::Completed, &actor)
+            .unwrap();
+
+        let app = history_app!(make_dashboard_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/milestones/{}/history", m.id.0))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["coverage"], "lifecycle_bookmarks");
+        let entries = body["entries"].as_array().unwrap();
+        assert_eq!(
+            entries.len(),
+            2,
+            "creation + completion for completed milestone"
+        );
+
+        assert_eq!(entries[0]["to_status"], "pending");
+        assert_eq!(entries[0]["source"], "creation");
+        assert!(entries[0]["changed_by"].is_null());
+
+        assert_eq!(entries[1]["to_status"], "completed");
+        assert_eq!(entries[1]["source"], "completion_record");
+        assert_eq!(entries[1]["changed_by"], actor_str);
+        // completion entry must be at or after creation
+        let t0 = entries[0]["changed_at"].as_u64().unwrap();
+        let t1 = entries[1]["changed_at"].as_u64().unwrap();
+        assert!(t1 >= t0, "completion must not precede creation");
     }
 }

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -4210,6 +4210,55 @@ fn build_program_summary(
     }
 }
 
+fn parse_program_status(s: &str) -> Result<icn_governance::ProgramStatus, ApiError> {
+    use icn_governance::ProgramStatus;
+    match s {
+        "draft" => Ok(ProgramStatus::Draft),
+        "active_planning" => Ok(ProgramStatus::ActivePlanning),
+        "public_launch" => Ok(ProgramStatus::PublicLaunch),
+        "in_execution" => Ok(ProgramStatus::InExecution),
+        "closed" => Ok(ProgramStatus::Closed),
+        "archived" => Ok(ProgramStatus::Archived),
+        _ => Err(err_bad(format!("Unknown program status: {s}"))),
+    }
+}
+
+/// PATCH /gov/programs/{program_id}/status — Update a program's lifecycle status.
+///
+/// Records a [`ProgramEvent`] in the append-only event log when the status
+/// actually changes (no-op transitions are silently ignored). The event log is
+/// non-fatal: a write failure is logged but does not fail the request.
+///
+/// Requires `governance:write`. Caller must be a member of the program's domain.
+///
+/// Returns 404 if the program does not exist.
+pub async fn update_program_status<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    program_id: web::Path<String>,
+    req: web::Json<UpdateProgramStatusRequest>,
+) -> Result<HttpResponse, ApiError> {
+    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let pid = ProgramId(program_id.into_inner());
+    let status = parse_program_status(&req.status)?;
+    let actor = parse_did(&claims.sub, "Invalid DID in token")?;
+
+    // Load program first to resolve domain for membership check.
+    let prog = ctx
+        .manager
+        .get_program(&pid)
+        .map_err(anyhow_to_api)?
+        .ok_or_else(|| err_not_found("Program not found"))?;
+    check_domain_membership(&ctx.manager, &prog.domain_id, &actor).await?;
+
+    let p = ctx
+        .manager
+        .update_program_status(&pid, status, &actor)
+        .map_err(anyhow_to_api)?;
+
+    Ok(HttpResponse::Ok().json(program_to_response(&p)))
+}
+
 // ── /me endpoints ─────────────────────────────────────────────────────────────
 
 /// GET /gov/me/scopes — Return all role assignments held by the authenticated DID.
@@ -6579,5 +6628,170 @@ mod tests {
         let entries = body["entries"].as_array().unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0]["source"], "creation");
+    }
+
+    // ── Program status update tests ────────────────────────────────────────
+
+    /// Helper: build a GovernanceManager with an InMemoryProgramEventLog wired in.
+    fn new_mgr_with_program_event_log() -> Arc<GovernanceManager> {
+        use crate::manager::InMemoryProgramEventLog;
+        let log = Arc::new(InMemoryProgramEventLog::new());
+        Arc::new(GovernanceManager::new().with_program_event_log(log))
+    }
+
+    /// Helper: create domain + program with TrustThreshold membership (all callers pass).
+    ///
+    /// Used by write-path tests that go through `check_domain_membership`. The
+    /// threshold is 0.0 so every DID is considered a member; this avoids having
+    /// to add specific test DIDs to the static list.
+    async fn setup_writable_program(
+        mgr: &Arc<GovernanceManager>,
+        domain: &str,
+        entity: &str,
+    ) -> icn_governance::Program {
+        let domain_id = GovernanceDomainId(domain.to_string());
+        mgr.create_domain(
+            domain_id.clone(),
+            format!("{domain} domain"),
+            "cooperative_default".to_string(),
+            GovernanceParams::default(),
+            MembershipConfig {
+                source: MembershipSource::TrustThreshold(0.0),
+            },
+        )
+        .await
+        .unwrap();
+        mgr.create_program(
+            domain_id,
+            entity.to_string(),
+            icn_governance::ProgramKind::Cycle,
+            "Test Cycle".to_string(),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap()
+    }
+
+    macro_rules! program_status_app {
+        ($ctx:expr) => {{
+            let ctx_data = web::Data::new($ctx);
+            let caller_did_str = test_did(1).to_string();
+            test::init_service(
+                App::new()
+                    .app_data(ctx_data)
+                    .app_data(web::JsonConfig::default())
+                    .wrap_fn(move |req, srv| {
+                        req.extensions_mut().insert(BasicClaims {
+                            sub: caller_did_str.clone(),
+                            scope: Some("governance:write".to_string()),
+                        });
+                        srv.call(req)
+                    })
+                    .route(
+                        "/programs/{program_id}/status",
+                        web::patch().to(update_program_status::<NoopEventEmitter>),
+                    ),
+            )
+            .await
+        }};
+    }
+
+    /// PATCH /programs/{id}/status — basic transition: Draft → ActivePlanning.
+    #[actix_web::test]
+    async fn program_status_update_draft_to_active_planning() {
+        let mgr = new_mgr_with_program_event_log();
+        let prog = setup_writable_program(&mgr, "dom-ps1", "ent-ps1").await;
+        assert_eq!(prog.status, icn_governance::ProgramStatus::Draft);
+
+        let app = program_status_app!(make_dashboard_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::patch()
+                .uri(&format!("/programs/{}/status", prog.id.0))
+                .set_json(serde_json::json!({"status": "active_planning"}))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["status"], "active_planning");
+    }
+
+    /// Multiple ordered transitions are recorded in the event log.
+    #[actix_web::test]
+    async fn program_status_multiple_transitions_recorded() {
+        let mgr = new_mgr_with_program_event_log();
+        let prog = setup_summary_program(&mgr, "dom-ps2", "ent-ps2").await;
+        let actor = Did::from_anchor_id(&[20u8; 32]);
+
+        use icn_governance::ProgramStatus;
+        mgr.update_program_status(&prog.id, ProgramStatus::ActivePlanning, &actor)
+            .unwrap();
+        mgr.update_program_status(&prog.id, ProgramStatus::InExecution, &actor)
+            .unwrap();
+        mgr.update_program_status(&prog.id, ProgramStatus::Closed, &actor)
+            .unwrap();
+
+        let events = mgr.list_program_events(&prog.id).unwrap();
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].from_status, ProgramStatus::Draft);
+        assert_eq!(events[0].to_status, ProgramStatus::ActivePlanning);
+        assert_eq!(events[1].from_status, ProgramStatus::ActivePlanning);
+        assert_eq!(events[1].to_status, ProgramStatus::InExecution);
+        assert_eq!(events[2].from_status, ProgramStatus::InExecution);
+        assert_eq!(events[2].to_status, ProgramStatus::Closed);
+    }
+
+    /// Re-applying the same status does not produce a duplicate log entry.
+    #[actix_web::test]
+    async fn program_status_no_duplicate_on_same_status() {
+        let mgr = new_mgr_with_program_event_log();
+        let prog = setup_summary_program(&mgr, "dom-ps3", "ent-ps3").await;
+        let actor = Did::from_anchor_id(&[21u8; 32]);
+
+        use icn_governance::ProgramStatus;
+        mgr.update_program_status(&prog.id, ProgramStatus::Closed, &actor)
+            .unwrap();
+        mgr.update_program_status(&prog.id, ProgramStatus::Closed, &actor)
+            .unwrap();
+
+        let events = mgr.list_program_events(&prog.id).unwrap();
+        assert_eq!(events.len(), 1, "duplicate event on same-status update");
+    }
+
+    /// 404 when program does not exist.
+    #[actix_web::test]
+    async fn program_status_update_404_for_missing_program() {
+        let mgr = new_mgr_with_program_event_log();
+        let app = program_status_app!(make_dashboard_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::patch()
+                .uri("/programs/nonexistent/status")
+                .set_json(serde_json::json!({"status": "active_planning"}))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 404);
+    }
+
+    /// Unknown status string returns 400.
+    #[actix_web::test]
+    async fn program_status_update_400_for_unknown_status() {
+        let mgr = new_mgr_with_program_event_log();
+        let prog = setup_writable_program(&mgr, "dom-ps4", "ent-ps4").await;
+        let app = program_status_app!(make_dashboard_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::patch()
+                .uri(&format!("/programs/{}/status", prog.id.0))
+                .set_json(serde_json::json!({"status": "flying_saucer"}))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 400);
     }
 }

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -3713,6 +3713,129 @@ pub async fn unlink_activity_from_program<E: GovernanceEventEmitter + Clone + 's
     Ok(HttpResponse::NoContent().finish())
 }
 
+// ── Milestone preview (read-only readiness) ───────────────────────────────────
+
+/// GET /gov/milestones/{milestone_id}/preview — Read-only milestone readiness.
+///
+/// Reports whether the milestone is currently ready to advance, based on the
+/// same observable ordering state a human operator would inspect before
+/// marking it complete:
+///
+/// - the milestone is open (not `completed` / `skipped`) and not `blocked`,
+/// - every earlier-phase milestone in the same program is `completed` or
+///   `skipped`.
+///
+/// This endpoint performs **no mutation**, no status transition, and emits
+/// no events. It deliberately does **not** evaluate `completion_criteria` —
+/// the governance core treats criteria as free-form declarative text whose
+/// interpretation belongs to an institution package. The criteria are
+/// surfaced verbatim for caller inspection only.
+///
+/// Requires `governance:read`.
+///
+/// Returns 404 if the milestone does not exist. Also returns 404 if the
+/// milestone's program is missing (orphaned milestone — should not occur,
+/// but handled defensively rather than panicking).
+pub async fn preview_milestone<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    milestone_id: web::Path<String>,
+) -> Result<HttpResponse, ApiError> {
+    require_scope::<BasicClaims>(&http_req, "governance:read")?;
+    let id = MilestoneId(milestone_id.into_inner());
+
+    // 1. Load the milestone (404 when absent).
+    let milestone = ctx
+        .manager
+        .get_milestone(&id)
+        .map_err(anyhow_to_api)?
+        .ok_or_else(|| err_not_found("Milestone not found"))?;
+
+    // 2. Load the enclosing program for its status (informational context).
+    //    An orphaned milestone (program deleted under it) returns 404 rather
+    //    than crashing or fabricating a status.
+    let program = ctx
+        .manager
+        .get_program(&milestone.program_id)
+        .map_err(anyhow_to_api)?
+        .ok_or_else(|| err_not_found("Program not found for milestone"))?;
+
+    // 3. Load siblings ordered by phase_index (store guarantees ordering).
+    let siblings = ctx
+        .manager
+        .list_milestones_by_program(&milestone.program_id)
+        .map_err(anyhow_to_api)?;
+
+    Ok(HttpResponse::Ok().json(build_milestone_preview(&milestone, &program, &siblings)))
+}
+
+/// Pure function composing a [`MilestonePreviewResponse`] from the three
+/// pieces of observable state. Split out so the readiness logic can be unit
+/// tested without spinning up an HTTP stack.
+fn build_milestone_preview(
+    milestone: &icn_governance::Milestone,
+    program: &icn_governance::Program,
+    siblings: &[icn_governance::Milestone],
+) -> MilestonePreviewResponse {
+    // Collect earlier-phase milestones that are not yet terminal.
+    let blocking: Vec<BlockingMilestoneSummary> = siblings
+        .iter()
+        .filter(|m| {
+            m.phase_index < milestone.phase_index
+                && !matches!(
+                    m.status,
+                    MilestoneStatus::Completed | MilestoneStatus::Skipped
+                )
+        })
+        .map(|m| BlockingMilestoneSummary {
+            id: m.id.0.clone(),
+            name: m.name.clone(),
+            phase_index: m.phase_index,
+            status: milestone_status_str(&m.status).to_string(),
+        })
+        .collect();
+
+    let earlier_complete = blocking.is_empty();
+    let is_open = milestone.is_open();
+
+    // Readiness: open, not blocked, earlier phases clear.
+    let (ready, reason) = match milestone.status {
+        MilestoneStatus::Completed => (false, Some("milestone is already completed".to_string())),
+        MilestoneStatus::Skipped => (false, Some("milestone is skipped".to_string())),
+        MilestoneStatus::Blocked => (false, Some("milestone is blocked".to_string())),
+        MilestoneStatus::Pending | MilestoneStatus::InProgress => {
+            if earlier_complete {
+                (true, None)
+            } else {
+                let first = &blocking[0];
+                (
+                    false,
+                    Some(format!(
+                        "earlier milestone '{}' (phase {}) is {}",
+                        first.name, first.phase_index, first.status
+                    )),
+                )
+            }
+        }
+    };
+
+    MilestonePreviewResponse {
+        milestone_id: milestone.id.0.clone(),
+        program_id: milestone.program_id.0.clone(),
+        name: milestone.name.clone(),
+        phase_index: milestone.phase_index,
+        status: milestone_status_str(&milestone.status).to_string(),
+        is_open,
+        program_status: program_status_str(&program.status).to_string(),
+        earlier_milestones_complete: earlier_complete,
+        blocking_milestones: blocking,
+        criteria_count: milestone.completion_criteria.len(),
+        completion_criteria: milestone.completion_criteria.clone(),
+        ready_to_advance: ready,
+        reason,
+    }
+}
+
 // ── Program dashboard ─────────────────────────────────────────────────────────
 
 fn dashboard_milestone_summary(m: &icn_governance::Milestone) -> DashboardMilestoneSummary {
@@ -5398,5 +5521,277 @@ mod tests {
         assert_eq!(joint_linked.len(), 2);
 
         assert_eq!(meetings[0]["status"], "scheduled");
+    }
+
+    // ── Milestone preview tests ────────────────────────────────────────────
+
+    macro_rules! preview_app {
+        ($ctx:expr) => {{
+            let ctx_data = web::Data::new($ctx);
+            test::init_service(
+                App::new()
+                    .app_data(ctx_data)
+                    .wrap_fn(move |req, srv| {
+                        req.extensions_mut().insert(BasicClaims {
+                            sub: "did:icn:reader".to_string(),
+                            scope: Some("governance:read".to_string()),
+                        });
+                        srv.call(req)
+                    })
+                    .route(
+                        "/milestones/{milestone_id}/preview",
+                        web::get().to(preview_milestone::<NoopEventEmitter>),
+                    ),
+            )
+            .await
+        }};
+    }
+
+    /// Helper: create a domain + program and return `(manager, program_id)`.
+    async fn setup_preview_program(
+        mgr: &Arc<GovernanceManager>,
+        domain: &str,
+        entity: &str,
+    ) -> icn_governance::ProgramId {
+        let domain_id = GovernanceDomainId(domain.to_string());
+        mgr.create_domain(
+            domain_id.clone(),
+            format!("{domain} domain"),
+            "cooperative_default".to_string(),
+            GovernanceParams::default(),
+            MembershipConfig {
+                source: MembershipSource::StaticList(vec![]),
+            },
+        )
+        .await
+        .unwrap();
+
+        let prog = mgr
+            .create_program(
+                domain_id,
+                entity.to_string(),
+                icn_governance::ProgramKind::Cycle,
+                "Preview Cycle".to_string(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        prog.id
+    }
+
+    /// 404 when the milestone does not exist.
+    #[actix_web::test]
+    async fn preview_404_for_missing_milestone() {
+        let mgr = Arc::new(GovernanceManager::new());
+        let app = preview_app!(make_dashboard_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/milestones/nonexistent/preview")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 404);
+    }
+
+    /// Phase-0 milestone with no earlier phases → ready, reason null.
+    #[actix_web::test]
+    async fn preview_ready_when_first_phase_and_open() {
+        let mgr = Arc::new(GovernanceManager::new());
+        let pid = setup_preview_program(&mgr, "dom-ready", "ent-ready").await;
+
+        let m = mgr
+            .create_milestone(
+                pid,
+                "Kickoff".to_string(),
+                None,
+                0,
+                None,
+                vec!["plan drafted".to_string(), "team named".to_string()],
+            )
+            .unwrap();
+
+        let app = preview_app!(make_dashboard_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/milestones/{}/preview", m.id.0))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["milestone_id"], m.id.0.as_str());
+        assert_eq!(body["phase_index"], 0);
+        assert_eq!(body["status"], "pending");
+        assert_eq!(body["is_open"], true);
+        assert_eq!(body["earlier_milestones_complete"], true);
+        assert_eq!(body["blocking_milestones"], serde_json::json!([]));
+        assert_eq!(body["criteria_count"], 2);
+        assert_eq!(
+            body["completion_criteria"],
+            serde_json::json!(["plan drafted", "team named"])
+        );
+        assert_eq!(body["ready_to_advance"], true);
+        assert!(
+            body.get("reason").is_none_or(|v| v.is_null()),
+            "reason should be absent or null when ready: {body:?}"
+        );
+        assert_eq!(body["program_status"], "draft");
+    }
+
+    /// Later-phase milestone is blocked by an uncompleted earlier phase.
+    /// `blocking_milestones` is ordered by `phase_index`; `reason` names the
+    /// first blocker.
+    #[actix_web::test]
+    async fn preview_blocked_by_earlier_phase() {
+        let mgr = Arc::new(GovernanceManager::new());
+        let pid = setup_preview_program(&mgr, "dom-block", "ent-block").await;
+
+        // Create out of order to prove ordering comes from phase_index.
+        let m_launch = mgr
+            .create_milestone(pid.clone(), "Launch".to_string(), None, 2, None, vec![])
+            .unwrap();
+        let _m_plan = mgr
+            .create_milestone(pid.clone(), "Plan".to_string(), None, 1, None, vec![])
+            .unwrap();
+        let m_kick = mgr
+            .create_milestone(pid, "Kickoff".to_string(), None, 0, None, vec![])
+            .unwrap();
+
+        // Complete phase-0 so phase-1 becomes the first blocker for phase-2.
+        let caller = test_did(1);
+        mgr.update_milestone_status(&m_kick.id, MilestoneStatus::Completed, &caller)
+            .unwrap();
+
+        let app = preview_app!(make_dashboard_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/milestones/{}/preview", m_launch.id.0))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["ready_to_advance"], false);
+        assert_eq!(body["earlier_milestones_complete"], false);
+        let blocking = body["blocking_milestones"].as_array().unwrap();
+        // Only phase-1 is still blocking (phase-0 is completed).
+        assert_eq!(blocking.len(), 1);
+        assert_eq!(blocking[0]["name"], "Plan");
+        assert_eq!(blocking[0]["phase_index"], 1);
+        assert_eq!(blocking[0]["status"], "pending");
+        let reason = body["reason"].as_str().unwrap();
+        assert!(
+            reason.contains("Plan") && reason.contains("phase 1"),
+            "reason should name the first blocker: {reason}"
+        );
+    }
+
+    /// Skipped earlier milestones also clear the blocker.
+    #[actix_web::test]
+    async fn preview_skipped_earlier_phase_clears_blocker() {
+        let mgr = Arc::new(GovernanceManager::new());
+        let pid = setup_preview_program(&mgr, "dom-skip", "ent-skip").await;
+
+        let m_a = mgr
+            .create_milestone(pid.clone(), "A".to_string(), None, 0, None, vec![])
+            .unwrap();
+        let m_b = mgr
+            .create_milestone(pid, "B".to_string(), None, 1, None, vec![])
+            .unwrap();
+
+        let caller = test_did(2);
+        mgr.update_milestone_status(&m_a.id, MilestoneStatus::Skipped, &caller)
+            .unwrap();
+
+        let app = preview_app!(make_dashboard_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/milestones/{}/preview", m_b.id.0))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["earlier_milestones_complete"], true);
+        assert_eq!(body["ready_to_advance"], true);
+        assert_eq!(body["blocking_milestones"], serde_json::json!([]));
+    }
+
+    /// Already-completed milestone reports not-ready with a descriptive reason
+    /// and surfaces `is_open = false`.
+    #[actix_web::test]
+    async fn preview_already_completed_is_not_ready() {
+        let mgr = Arc::new(GovernanceManager::new());
+        let pid = setup_preview_program(&mgr, "dom-done", "ent-done").await;
+
+        let m = mgr
+            .create_milestone(pid, "Done".to_string(), None, 0, None, vec![])
+            .unwrap();
+        let caller = test_did(3);
+        mgr.update_milestone_status(&m.id, MilestoneStatus::Completed, &caller)
+            .unwrap();
+
+        let app = preview_app!(make_dashboard_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/milestones/{}/preview", m.id.0))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["status"], "completed");
+        assert_eq!(body["is_open"], false);
+        assert_eq!(body["ready_to_advance"], false);
+        let reason = body["reason"].as_str().unwrap();
+        assert!(
+            reason.contains("completed"),
+            "reason should explain completion: {reason}"
+        );
+    }
+
+    /// Blocked status prevents readiness even when earlier phases are clear.
+    #[actix_web::test]
+    async fn preview_blocked_status_is_not_ready() {
+        let mgr = Arc::new(GovernanceManager::new());
+        let pid = setup_preview_program(&mgr, "dom-blk", "ent-blk").await;
+
+        let m = mgr
+            .create_milestone(pid, "Stuck".to_string(), None, 0, None, vec![])
+            .unwrap();
+        let caller = test_did(4);
+        mgr.update_milestone_status(&m.id, MilestoneStatus::Blocked, &caller)
+            .unwrap();
+
+        let app = preview_app!(make_dashboard_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/milestones/{}/preview", m.id.0))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["status"], "blocked");
+        assert_eq!(body["earlier_milestones_complete"], true);
+        assert_eq!(body["ready_to_advance"], false);
+        let reason = body["reason"].as_str().unwrap();
+        assert!(
+            reason.contains("blocked"),
+            "reason should mention block: {reason}"
+        );
     }
 }

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -4107,6 +4107,109 @@ pub async fn get_program_dashboard<E: GovernanceEventEmitter + Clone + 'static>(
     Ok(HttpResponse::Ok().json(resp))
 }
 
+// ── Program summary ───────────────────────────────────────────────────────────
+
+/// GET /gov/programs/{program_id}/summary — Read-only milestone progression view.
+///
+/// Returns a lightweight roll-up of a program's current progression state:
+/// - program status
+/// - milestone counts by status
+/// - all milestones ordered by `phase_index`
+/// - the first open (not `completed` / `skipped`) milestone — i.e. where
+///   work currently needs to go — as `next_unfinished_milestone`
+/// - the `phase_index` of that milestone as `current_phase_index`
+///
+/// This is a focused alternative to `/dashboard`, which includes activities
+/// and action items. The summary answers "where is this program in its
+/// lifecycle?" without loading the heavier composite surfaces.
+///
+/// **Progression basis**: milestones are ordered by `phase_index` (the only
+/// programmatic ordering signal in the current model). Milestone names and
+/// `completion_criteria` text are surfaced verbatim and are **not** interpreted
+/// — semantic meaning belongs in the institution package layer.
+///
+/// Requires `governance:read`. No mutation; no event emission.
+///
+/// Returns 404 if the program does not exist.
+pub async fn get_program_summary<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    program_id: web::Path<String>,
+) -> Result<HttpResponse, ApiError> {
+    require_scope::<BasicClaims>(&http_req, "governance:read")?;
+    let pid = ProgramId(program_id.into_inner());
+
+    let program = ctx
+        .manager
+        .get_program(&pid)
+        .map_err(anyhow_to_api)?
+        .ok_or_else(|| err_not_found("Program not found"))?;
+
+    // Milestones come back ordered by phase_index (store contract).
+    let milestones = ctx
+        .manager
+        .list_milestones_by_program(&pid)
+        .map_err(anyhow_to_api)?;
+
+    Ok(HttpResponse::Ok().json(build_program_summary(&program, &milestones)))
+}
+
+/// Pure function composing a [`ProgramSummaryResponse`] from the program record
+/// and its ordered milestones. Split out for unit-testability.
+///
+/// **`current_phase_index`**: the `phase_index` of the first open milestone
+/// (lowest phase_index where status is not `Completed` / `Skipped`). If all
+/// milestones are terminal, falls back to the highest `phase_index` present
+/// (program likely closing / archived). `None` when there are no milestones.
+fn build_program_summary(
+    program: &icn_governance::Program,
+    milestones: &[icn_governance::Milestone],
+) -> ProgramSummaryResponse {
+    // Count by status.
+    let mut counts = DashboardMilestoneCounts {
+        total: milestones.len(),
+        ..Default::default()
+    };
+    for m in milestones {
+        match m.status {
+            MilestoneStatus::Completed => counts.completed += 1,
+            MilestoneStatus::InProgress => counts.in_progress += 1,
+            MilestoneStatus::Blocked => counts.blocked += 1,
+            MilestoneStatus::Pending => counts.pending += 1,
+            MilestoneStatus::Skipped => counts.skipped += 1,
+        }
+    }
+
+    // First open milestone by phase_index (milestones already sorted ascending).
+    let next_unfinished: Option<NextUnfinishedMilestone> = milestones
+        .iter()
+        .find(|m| m.is_open())
+        .map(|m| NextUnfinishedMilestone {
+            milestone_id: m.id.0.clone(),
+            name: m.name.clone(),
+            phase_index: m.phase_index,
+            status: milestone_status_str(&m.status).to_string(),
+        });
+
+    // current_phase_index: open milestone's phase, falling back to highest
+    // terminal phase when all milestones are done.
+    let current_phase_index: Option<u32> = next_unfinished
+        .as_ref()
+        .map(|n| n.phase_index)
+        .or_else(|| milestones.last().map(|m| m.phase_index));
+
+    ProgramSummaryResponse {
+        program_id: program.id.0.clone(),
+        name: program.name.clone(),
+        program_status: program_status_str(&program.status).to_string(),
+        milestone_counts: counts,
+        milestones: milestones.iter().map(dashboard_milestone_summary).collect(),
+        next_unfinished_milestone: next_unfinished,
+        current_phase_index,
+        progress_basis: "phase_index_ordering".to_string(),
+    }
+}
+
 // ── /me endpoints ─────────────────────────────────────────────────────────────
 
 /// GET /gov/me/scopes — Return all role assignments held by the authenticated DID.
@@ -5647,6 +5750,237 @@ mod tests {
         assert_eq!(joint_linked.len(), 2);
 
         assert_eq!(meetings[0]["status"], "scheduled");
+    }
+
+    // ── Program summary tests ──────────────────────────────────────────────
+
+    macro_rules! summary_app {
+        ($ctx:expr) => {{
+            let ctx_data = web::Data::new($ctx);
+            test::init_service(
+                App::new()
+                    .app_data(ctx_data)
+                    .wrap_fn(move |req, srv| {
+                        req.extensions_mut().insert(BasicClaims {
+                            sub: "did:icn:reader".to_string(),
+                            scope: Some("governance:read".to_string()),
+                        });
+                        srv.call(req)
+                    })
+                    .route(
+                        "/programs/{program_id}/summary",
+                        web::get().to(get_program_summary::<NoopEventEmitter>),
+                    ),
+            )
+            .await
+        }};
+    }
+
+    /// Helper: create domain + program, return program.
+    async fn setup_summary_program(
+        mgr: &Arc<GovernanceManager>,
+        domain: &str,
+        entity: &str,
+    ) -> icn_governance::Program {
+        let domain_id = GovernanceDomainId(domain.to_string());
+        mgr.create_domain(
+            domain_id.clone(),
+            format!("{domain} domain"),
+            "cooperative_default".to_string(),
+            GovernanceParams::default(),
+            MembershipConfig {
+                source: MembershipSource::StaticList(vec![]),
+            },
+        )
+        .await
+        .unwrap();
+
+        mgr.create_program(
+            domain_id,
+            entity.to_string(),
+            icn_governance::ProgramKind::Cycle,
+            "Test Cycle".to_string(),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap()
+    }
+
+    /// 404 when program does not exist.
+    #[actix_web::test]
+    async fn summary_404_for_missing_program() {
+        let mgr = Arc::new(GovernanceManager::new());
+        let app = summary_app!(make_dashboard_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/programs/nonexistent/summary")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 404);
+    }
+
+    /// Program with no milestones: zero counts, null next_unfinished and
+    /// current_phase_index.
+    #[actix_web::test]
+    async fn summary_no_milestones() {
+        let mgr = Arc::new(GovernanceManager::new());
+        let prog = setup_summary_program(&mgr, "dom-sum0", "ent-sum0").await;
+
+        let app = summary_app!(make_dashboard_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/programs/{}/summary", prog.id.0))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["progress_basis"], "phase_index_ordering");
+        assert_eq!(body["milestone_counts"]["total"], 0);
+        assert!(body["next_unfinished_milestone"].is_null());
+        assert!(body["current_phase_index"].is_null());
+        let milestones = body["milestones"].as_array().unwrap();
+        assert!(milestones.is_empty());
+    }
+
+    /// Mixed milestone states: counts are correct; next_unfinished is the
+    /// first open milestone by phase_index; current_phase_index matches.
+    #[actix_web::test]
+    async fn summary_mixed_milestone_states() {
+        let mgr = Arc::new(GovernanceManager::new());
+        let prog = setup_summary_program(&mgr, "dom-sum1", "ent-sum1").await;
+
+        // phase 0: completed
+        let m0 = mgr
+            .create_milestone(
+                prog.id.clone(),
+                "Phase 0".to_string(),
+                None,
+                0,
+                None,
+                vec![],
+            )
+            .unwrap();
+        let actor = Did::from_anchor_id(&[20u8; 32]);
+        mgr.update_milestone_status(&m0.id, MilestoneStatus::Completed, &actor)
+            .unwrap();
+
+        // phase 1: skipped
+        let m1 = mgr
+            .create_milestone(
+                prog.id.clone(),
+                "Phase 1".to_string(),
+                None,
+                1,
+                None,
+                vec![],
+            )
+            .unwrap();
+        mgr.update_milestone_status(&m1.id, MilestoneStatus::Skipped, &actor)
+            .unwrap();
+
+        // phase 2: in_progress (first open)
+        let m2 = mgr
+            .create_milestone(
+                prog.id.clone(),
+                "Phase 2".to_string(),
+                None,
+                2,
+                None,
+                vec![],
+            )
+            .unwrap();
+        mgr.update_milestone_status(&m2.id, MilestoneStatus::InProgress, &actor)
+            .unwrap();
+
+        // phase 3: pending
+        mgr.create_milestone(
+            prog.id.clone(),
+            "Phase 3".to_string(),
+            None,
+            3,
+            None,
+            vec![],
+        )
+        .unwrap();
+
+        let app = summary_app!(make_dashboard_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/programs/{}/summary", prog.id.0))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["milestone_counts"]["total"], 4);
+        assert_eq!(body["milestone_counts"]["completed"], 1);
+        assert_eq!(body["milestone_counts"]["skipped"], 1);
+        assert_eq!(body["milestone_counts"]["in_progress"], 1);
+        assert_eq!(body["milestone_counts"]["pending"], 1);
+
+        // next_unfinished is phase 2 (in_progress, lowest open phase_index)
+        let nxt = &body["next_unfinished_milestone"];
+        assert_eq!(nxt["phase_index"], 2);
+        assert_eq!(nxt["status"], "in_progress");
+        assert_eq!(body["current_phase_index"], 2);
+
+        // milestones returned in phase_index order
+        let ms = body["milestones"].as_array().unwrap();
+        assert_eq!(ms.len(), 4);
+        assert_eq!(ms[0]["phase_index"], 0);
+        assert_eq!(ms[1]["phase_index"], 1);
+        assert_eq!(ms[2]["phase_index"], 2);
+        assert_eq!(ms[3]["phase_index"], 3);
+    }
+
+    /// All milestones terminal (completed/skipped): next_unfinished is null;
+    /// current_phase_index is the highest phase_index.
+    #[actix_web::test]
+    async fn summary_all_milestones_terminal() {
+        let mgr = Arc::new(GovernanceManager::new());
+        let prog = setup_summary_program(&mgr, "dom-sum2", "ent-sum2").await;
+
+        let actor = Did::from_anchor_id(&[21u8; 32]);
+        for phase in 0..3u32 {
+            let m = mgr
+                .create_milestone(
+                    prog.id.clone(),
+                    format!("Phase {phase}"),
+                    None,
+                    phase,
+                    None,
+                    vec![],
+                )
+                .unwrap();
+            mgr.update_milestone_status(&m.id, MilestoneStatus::Completed, &actor)
+                .unwrap();
+        }
+
+        let app = summary_app!(make_dashboard_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/programs/{}/summary", prog.id.0))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["milestone_counts"]["completed"], 3);
+        assert_eq!(body["milestone_counts"]["pending"], 0);
+        assert!(body["next_unfinished_milestone"].is_null());
+        // current_phase_index falls back to highest terminal phase_index
+        assert_eq!(body["current_phase_index"], 2);
     }
 
     // ── Milestone preview tests ────────────────────────────────────────────

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -3872,44 +3872,93 @@ pub async fn get_milestone_history<E: GovernanceEventEmitter + Clone + 'static>(
         .map_err(anyhow_to_api)?
         .ok_or_else(|| err_not_found("Milestone not found"))?;
 
-    Ok(HttpResponse::Ok().json(build_milestone_history(&milestone)))
+    // Load event log entries (empty Vec when no log is configured).
+    let events = ctx
+        .manager
+        .list_milestone_events(&id)
+        .map_err(anyhow_to_api)?;
+
+    Ok(HttpResponse::Ok().json(build_milestone_history(&milestone, &events)))
 }
 
 /// Pure function assembling a [`MilestoneHistoryResponse`] from a milestone
-/// record. Split out for unit-testability without an HTTP stack.
+/// record and an optional list of recorded transition events.
 ///
-/// Entries are ordered oldest-to-newest:
-/// 1. Creation bookmark (`created_at`, status `pending`, source `creation`).
-/// 2. Completion bookmark (`completed_at` + `completed_by`), only present when
-///    the milestone has `completed_at` set.
+/// **Two paths:**
 ///
-/// No intermediate entries are emitted because intermediate transitions are
-/// not persisted in the current store.
-fn build_milestone_history(milestone: &icn_governance::Milestone) -> MilestoneHistoryResponse {
-    let mut entries = Vec::new();
+/// 1. **Transition log** (`events` is non-empty): entries are built directly
+///    from the event log. Coverage is `"transition_log"`. Each entry has
+///    `from_status`, `to_status`, `changed_by`, and `changed_at` from the
+///    recorded event. A synthetic creation entry is prepended (from
+///    `milestone.created_at`) because the event log records status *changes*
+///    only, not the initial creation.
+///
+/// 2. **Lifecycle bookmarks** (`events` is empty — no log configured or no
+///    transitions recorded yet): same fallback as the previous implementation.
+///    Coverage is `"lifecycle_bookmarks"`. Returns creation bookmark + optional
+///    completion bookmark from milestone struct fields.
+///
+/// Entries are always ordered oldest-to-newest.
+fn build_milestone_history(
+    milestone: &icn_governance::Milestone,
+    events: &[crate::manager::MilestoneEvent],
+) -> MilestoneHistoryResponse {
+    if events.is_empty() {
+        // ── Fallback: lifecycle bookmarks (no event log available) ──────────
+        let mut entries = Vec::new();
 
-    // Entry 1: creation (always present).
-    entries.push(MilestoneHistoryEntry {
-        changed_at: milestone.created_at,
-        changed_by: None, // creator is not recorded on the milestone record
-        to_status: "pending".to_string(),
-        source: "creation".to_string(),
-    });
-
-    // Entry 2: completion (only when the milestone has been completed).
-    if let Some(completed_at) = milestone.completed_at {
+        // Creation (always present; initial status is always pending).
         entries.push(MilestoneHistoryEntry {
-            changed_at: completed_at,
-            changed_by: milestone.completed_by.as_ref().map(|d| d.to_string()),
-            to_status: "completed".to_string(),
-            source: "completion_record".to_string(),
+            changed_at: milestone.created_at,
+            changed_by: None, // creator not recorded on milestone struct
+            to_status: "pending".to_string(),
+            source: "creation".to_string(),
         });
-    }
 
-    MilestoneHistoryResponse {
-        milestone_id: milestone.id.0.clone(),
-        coverage: "lifecycle_bookmarks".to_string(),
-        entries,
+        // Completion (only when the milestone has completed).
+        if let Some(completed_at) = milestone.completed_at {
+            entries.push(MilestoneHistoryEntry {
+                changed_at: completed_at,
+                changed_by: milestone.completed_by.as_ref().map(|d| d.to_string()),
+                to_status: "completed".to_string(),
+                source: "completion_record".to_string(),
+            });
+        }
+
+        MilestoneHistoryResponse {
+            milestone_id: milestone.id.0.clone(),
+            coverage: "lifecycle_bookmarks".to_string(),
+            entries,
+        }
+    } else {
+        // ── Full path: event log entries ────────────────────────────────────
+        //
+        // Prepend a synthetic creation entry. The event log records transitions
+        // only; the creation itself is not emitted as a log entry. The creation
+        // bookmark is always accurate (from milestone.created_at, initial status
+        // is always pending) and provides the anchor for the entry sequence.
+        let mut entries = Vec::with_capacity(events.len() + 1);
+        entries.push(MilestoneHistoryEntry {
+            changed_at: milestone.created_at,
+            changed_by: None,
+            to_status: "pending".to_string(),
+            source: "creation".to_string(),
+        });
+
+        for event in events {
+            entries.push(MilestoneHistoryEntry {
+                changed_at: event.changed_at,
+                changed_by: Some(event.changed_by.to_string()),
+                to_status: milestone_status_str(&event.to_status).to_string(),
+                source: "transition_log".to_string(),
+            });
+        }
+
+        MilestoneHistoryResponse {
+            milestone_id: milestone.id.0.clone(),
+            coverage: "transition_log".to_string(),
+            entries,
+        }
     }
 }
 
@@ -4137,7 +4186,7 @@ mod tests {
     use crate::http::configure::{
         GovernanceContext, GovernanceEffect, ProposalAcceptedHook, SuspensionChecker,
     };
-    use crate::manager::GovernanceManager;
+    use crate::manager::{GovernanceManager, InMemoryMilestoneEventLog};
 
     fn test_did(seed: u8) -> Did {
         Did::from_anchor_id(&[seed; 32])
@@ -5992,5 +6041,209 @@ mod tests {
         let t0 = entries[0]["changed_at"].as_u64().unwrap();
         let t1 = entries[1]["changed_at"].as_u64().unwrap();
         assert!(t1 >= t0, "completion must not precede creation");
+    }
+
+    // ── Event log path tests ───────────────────────────────────────────────
+    //
+    // These tests use a GovernanceManager configured with an InMemoryMilestoneEventLog
+    // so that status transitions are recorded. The history endpoint should return
+    // coverage: "transition_log" and the actual recorded events.
+
+    fn make_event_log_ctx(mgr: Arc<GovernanceManager>) -> GovernanceContext<NoopEventEmitter> {
+        GovernanceContext {
+            manager: mgr,
+            emitter: NoopEventEmitter,
+            on_proposal_accepted: None,
+            on_charter_accepted: None,
+            member_checker: None,
+            steward_checker: None,
+            suspension_checker: None,
+            membership_resolver: None,
+            sdis_service: None,
+        }
+    }
+
+    macro_rules! event_log_history_app {
+        ($ctx:expr) => {{
+            let ctx_data = web::Data::new($ctx);
+            test::init_service(
+                App::new()
+                    .app_data(ctx_data)
+                    .wrap_fn(move |req, srv| {
+                        req.extensions_mut().insert(BasicClaims {
+                            sub: "did:icn:reader".to_string(),
+                            scope: Some("governance:read".to_string()),
+                        });
+                        srv.call(req)
+                    })
+                    .route(
+                        "/milestones/{milestone_id}/history",
+                        web::get().to(get_milestone_history::<NoopEventEmitter>),
+                    ),
+            )
+            .await
+        }};
+    }
+
+    /// Helper: build a GovernanceManager with an InMemoryMilestoneEventLog wired in.
+    fn new_mgr_with_event_log() -> Arc<GovernanceManager> {
+        let log = Arc::new(InMemoryMilestoneEventLog::new());
+        Arc::new(GovernanceManager::new().with_milestone_event_log(log))
+    }
+
+    /// Status transitions are recorded; history returns transition_log coverage
+    /// with one creation entry + one log entry per unique status change.
+    #[actix_web::test]
+    async fn event_log_single_transition_appears_in_history() {
+        let mgr = new_mgr_with_event_log();
+        let pid = setup_preview_program(&mgr, "dom-el1", "ent-el1").await;
+
+        let m = mgr
+            .create_milestone(pid, "Phase 0".to_string(), None, 0, None, vec![])
+            .unwrap();
+
+        let actor = Did::from_anchor_id(&[10u8; 32]);
+        mgr.update_milestone_status(&m.id, MilestoneStatus::InProgress, &actor)
+            .unwrap();
+
+        let app = event_log_history_app!(make_event_log_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/milestones/{}/history", m.id.0))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["coverage"], "transition_log");
+
+        let entries = body["entries"].as_array().unwrap();
+        // 1 creation + 1 logged transition
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0]["source"], "creation");
+        assert_eq!(entries[0]["to_status"], "pending");
+        assert!(entries[0]["changed_by"].is_null());
+
+        assert_eq!(entries[1]["source"], "transition_log");
+        assert_eq!(entries[1]["to_status"], "in_progress");
+        assert_eq!(entries[1]["changed_by"], actor.to_string());
+    }
+
+    /// Multiple transitions appear in chronological order.
+    #[actix_web::test]
+    async fn event_log_multiple_transitions_ordered_oldest_first() {
+        let mgr = new_mgr_with_event_log();
+        let pid = setup_preview_program(&mgr, "dom-el2", "ent-el2").await;
+
+        let m = mgr
+            .create_milestone(pid, "Phase 0".to_string(), None, 0, None, vec![])
+            .unwrap();
+
+        let actor = Did::from_anchor_id(&[11u8; 32]);
+        mgr.update_milestone_status(&m.id, MilestoneStatus::InProgress, &actor)
+            .unwrap();
+        mgr.update_milestone_status(&m.id, MilestoneStatus::Blocked, &actor)
+            .unwrap();
+        mgr.update_milestone_status(&m.id, MilestoneStatus::InProgress, &actor)
+            .unwrap();
+        mgr.update_milestone_status(&m.id, MilestoneStatus::Completed, &actor)
+            .unwrap();
+
+        let app = event_log_history_app!(make_event_log_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/milestones/{}/history", m.id.0))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["coverage"], "transition_log");
+
+        let entries = body["entries"].as_array().unwrap();
+        // 1 creation + 4 transitions
+        assert_eq!(entries.len(), 5);
+        assert_eq!(entries[0]["source"], "creation");
+        assert_eq!(entries[1]["to_status"], "in_progress");
+        assert_eq!(entries[2]["to_status"], "blocked");
+        assert_eq!(entries[3]["to_status"], "in_progress");
+        assert_eq!(entries[4]["to_status"], "completed");
+
+        // Chronological order: each changed_at >= previous
+        let times: Vec<u64> = entries
+            .iter()
+            .map(|e| e["changed_at"].as_u64().unwrap())
+            .collect();
+        for pair in times.windows(2) {
+            assert!(pair[1] >= pair[0], "entries not in chronological order");
+        }
+    }
+
+    /// Re-marking an already-Completed milestone does not add a duplicate log entry.
+    #[actix_web::test]
+    async fn event_log_no_duplicate_on_same_status() {
+        let mgr = new_mgr_with_event_log();
+        let pid = setup_preview_program(&mgr, "dom-el3", "ent-el3").await;
+
+        let m = mgr
+            .create_milestone(pid, "Phase 0".to_string(), None, 0, None, vec![])
+            .unwrap();
+
+        let actor = Did::from_anchor_id(&[12u8; 32]);
+        mgr.update_milestone_status(&m.id, MilestoneStatus::Completed, &actor)
+            .unwrap();
+        // Call again with same status — should not produce a second log entry.
+        mgr.update_milestone_status(&m.id, MilestoneStatus::Completed, &actor)
+            .unwrap();
+
+        let app = event_log_history_app!(make_event_log_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/milestones/{}/history", m.id.0))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        let entries = body["entries"].as_array().unwrap();
+        // 1 creation + 1 completion — no duplicate
+        assert_eq!(entries.len(), 2, "duplicate entry on same-status update");
+    }
+
+    /// A milestone without any transitions still has one entry (creation bookmark)
+    /// and coverage "transition_log" (log is configured but empty for this milestone).
+    /// Actually: no events → falls back to lifecycle_bookmarks.
+    #[actix_web::test]
+    async fn event_log_no_transitions_falls_back_to_lifecycle_bookmarks() {
+        let mgr = new_mgr_with_event_log();
+        let pid = setup_preview_program(&mgr, "dom-el4", "ent-el4").await;
+
+        let m = mgr
+            .create_milestone(pid, "Phase 0".to_string(), None, 0, None, vec![])
+            .unwrap();
+        // No status updates — event log for this milestone is empty.
+
+        let app = event_log_history_app!(make_event_log_ctx(mgr));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/milestones/{}/history", m.id.0))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        // Empty event list → fallback path
+        assert_eq!(body["coverage"], "lifecycle_bookmarks");
+        let entries = body["entries"].as_array().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["source"], "creation");
     }
 }

--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -1052,3 +1052,61 @@ pub struct ProgramDashboardResponse {
     /// earliest `scheduled_at` first; unscheduled meetings sort last.
     pub meetings: Vec<DashboardMeetingSummary>,
 }
+
+// ============================================================================
+// Milestone history (read-only lifecycle bookmark view)
+// ============================================================================
+
+/// A single lifecycle bookmark extracted from the milestone record.
+///
+/// **Coverage limitation**: the governance store records only two temporal
+/// facts about a milestone — when it was created (`created_at`) and when it
+/// reached `Completed` (`completed_at` + `completed_by`). Intermediate
+/// transitions (e.g. `pending → in_progress → blocked`) are not currently
+/// persisted; they will not appear in this list. `source` names which field
+/// on the record the entry was derived from, so callers know exactly what
+/// persisted data backs each entry.
+///
+/// Fields that are genuinely unknown are `null` (`changed_by` on the
+/// creation entry; `to_status` would always be the entry's status).
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct MilestoneHistoryEntry {
+    /// Unix seconds when this lifecycle event occurred (always present).
+    pub changed_at: u64,
+    /// DID of the actor who caused the transition, if recorded.
+    /// `null` for the creation entry (the creator is not currently stored on
+    /// the milestone record itself).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub changed_by: Option<String>,
+    /// The status the milestone moved INTO at this event.
+    pub to_status: String,
+    /// Persisted-data source backing this entry.
+    /// `"creation"` → derived from `created_at` (initial status is always
+    /// `pending`). `"completion_record"` → derived from `completed_at` +
+    /// `completed_by`.
+    pub source: String,
+}
+
+/// Ordered collection of lifecycle bookmarks for a milestone.
+///
+/// Returned by `GET /gov/milestones/{milestone_id}/history`. Entries are
+/// ordered oldest-to-newest (creation first).
+///
+/// `coverage` describes the fidelity of the history: `"lifecycle_bookmarks"`
+/// means only creation and completion events are available because the
+/// governance store does not persist intermediate status transitions.
+/// Callers MUST treat this list as a partial view, not a complete audit log.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct MilestoneHistoryResponse {
+    /// Milestone identifier.
+    pub milestone_id: String,
+    /// Fidelity annotation.
+    ///
+    /// Always `"lifecycle_bookmarks"` in the current implementation: only
+    /// `created_at` and `completed_at` are persisted on the milestone record.
+    /// Future store migrations (e.g. an append-only transition log) would
+    /// change this to `"full_transition_log"`.
+    pub coverage: String,
+    /// Lifecycle bookmarks, oldest first.
+    pub entries: Vec<MilestoneHistoryEntry>,
+}

--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -845,6 +845,14 @@ pub struct UpdateMilestoneStatusRequest {
     pub status: String,
 }
 
+/// Request to update a program's lifecycle status
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct UpdateProgramStatusRequest {
+    /// Status: "draft", "active_planning", "public_launch", "in_execution", "completed", "archived"
+    pub status: String,
+}
+
 /// Milestone response
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]

--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -1110,3 +1110,58 @@ pub struct MilestoneHistoryResponse {
     /// Lifecycle bookmarks, oldest first.
     pub entries: Vec<MilestoneHistoryEntry>,
 }
+
+// ============================================================================
+// Program summary (read-only progression view)
+// ============================================================================
+
+/// Compact reference to the next milestone that has not yet reached a terminal
+/// state (`completed` or `skipped`), ordered by `phase_index`.
+///
+/// `null` in [`ProgramSummaryResponse`] when all milestones are terminal or
+/// when the program has no milestones.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct NextUnfinishedMilestone {
+    pub milestone_id: String,
+    pub name: String,
+    pub phase_index: u32,
+    pub status: String,
+}
+
+/// Read-only progression summary for a program.
+///
+/// Returned by `GET /gov/programs/{program_id}/summary`. Complements the
+/// richer `/dashboard` surface (which includes activities and action items)
+/// by focusing solely on the program's milestone progression state.
+///
+/// The `progress_basis` field names the mechanism used to derive
+/// `current_phase_index` and `next_unfinished_milestone`. Currently always
+/// `"phase_index_ordering"` — milestones are ordered by their `phase_index`
+/// field (0-based), which is the only programmatic ordering signal in the
+/// current model.
+///
+/// Milestone semantics are deliberately not interpreted: this endpoint reports
+/// observable state and ordering, not what any milestone "means" institutionally.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ProgramSummaryResponse {
+    pub program_id: String,
+    pub name: String,
+    /// Current program lifecycle status.
+    pub program_status: String,
+    /// Milestone status counts.
+    pub milestone_counts: DashboardMilestoneCounts,
+    /// All milestones for this program, ordered by `phase_index` ascending.
+    pub milestones: Vec<DashboardMilestoneSummary>,
+    /// The lowest-`phase_index` milestone that is not yet `completed` or
+    /// `skipped`. `null` when all milestones are terminal or there are none.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_unfinished_milestone: Option<NextUnfinishedMilestone>,
+    /// `phase_index` of [`next_unfinished_milestone`] when one exists, else
+    /// the highest `phase_index` among terminal milestones, else `null`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_phase_index: Option<u32>,
+    /// Basis used to derive `current_phase_index` and
+    /// `next_unfinished_milestone`. Currently always
+    /// `"phase_index_ordering"`.
+    pub progress_basis: String,
+}

--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -867,6 +867,91 @@ pub struct MilestoneResponse {
 }
 
 // ============================================================================
+// Milestone preview (read-only readiness view)
+// ============================================================================
+
+/// Summary row describing a milestone that blocks another milestone from
+/// advancing.
+///
+/// Emitted inside [`MilestonePreviewResponse::blocking_milestones`]: any
+/// earlier-phase milestone that has not reached a terminal status
+/// (`Completed` or `Skipped`). Order matches `phase_index`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct BlockingMilestoneSummary {
+    pub id: String,
+    pub name: String,
+    pub phase_index: u32,
+    pub status: String,
+}
+
+/// Composite read-only preview describing whether a milestone is currently
+/// ready to be advanced, and what observable state drove that answer.
+///
+/// Returned by `GET /gov/milestones/{milestone_id}/preview`. Purely read-only:
+/// no mutation, no status transition, no event emission. The preview reflects
+/// the same ordering semantics a human operator would use when deciding
+/// whether to mark a milestone complete — earlier-phase milestones must be
+/// `Completed` or `Skipped`, and the target milestone itself must be open and
+/// not `Blocked`.
+///
+/// `completion_criteria` is surfaced verbatim for caller inspection but is
+/// **not evaluated**. The governance core deliberately treats criteria as
+/// free-form declarative text; interpretation of what "satisfied" means is an
+/// institution-package concern. This endpoint therefore reports what the
+/// milestone *declares* it needs, not whether any individual criterion has
+/// been met.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct MilestonePreviewResponse {
+    /// Milestone identifier.
+    pub milestone_id: String,
+    /// Program the milestone belongs to.
+    pub program_id: String,
+    /// Milestone display name.
+    pub name: String,
+    /// Ordinal position among the program's milestones (0-based).
+    pub phase_index: u32,
+    /// Current milestone status (`pending`, `in_progress`, `completed`,
+    /// `blocked`, `skipped`).
+    pub status: String,
+    /// `true` while the milestone is not in a terminal (`completed` /
+    /// `skipped`) state.
+    pub is_open: bool,
+    /// Enclosing program's current lifecycle status (`draft`,
+    /// `active_planning`, `public_launch`, `in_execution`, `closed`,
+    /// `archived`). Informational — the preview does not require any specific
+    /// program status.
+    pub program_status: String,
+    /// `true` when every earlier-phase milestone (strictly lower
+    /// `phase_index`) is `completed` or `skipped`.
+    pub earlier_milestones_complete: bool,
+    /// Earlier-phase milestones that are not yet `completed` or `skipped`,
+    /// ordered by `phase_index`. Empty when `earlier_milestones_complete` is
+    /// `true`.
+    pub blocking_milestones: Vec<BlockingMilestoneSummary>,
+    /// Free-form checklist declared on the milestone at creation. Surfaced
+    /// verbatim for caller inspection; **not evaluated** by this endpoint.
+    pub completion_criteria: Vec<String>,
+    /// Count of declared completion criteria (equivalent to
+    /// `completion_criteria.len()`). Provided for callers that only need the
+    /// count without transferring the strings.
+    pub criteria_count: usize,
+    /// Observable readiness for advancement.
+    ///
+    /// `true` iff all of:
+    /// - milestone is open (not `completed` or `skipped`),
+    /// - milestone status is not `blocked`,
+    /// - every earlier-phase milestone is `completed` or `skipped`.
+    ///
+    /// Does **not** evaluate `completion_criteria` — that is out of scope for
+    /// ICN governance core.
+    pub ready_to_advance: bool,
+    /// Human-readable reason when `ready_to_advance` is `false`. `None` when
+    /// the milestone is ready.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+// ============================================================================
 // Program dashboard (composite read surface)
 // ============================================================================
 

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -40,10 +40,11 @@ pub use events::{GovernanceEventEmitter, NoopEventEmitter};
 pub use executor::{ExecutionCallback, GovernanceProposalExecutor};
 pub use handlers::translate_payload_to_effects;
 pub use manager::{
-    DigestSummary, GovernanceManager, InMemoryMilestoneEventLog, MilestoneEvent,
-    MilestoneEventLogBackend, OverdueItemDigest, PendingVoteDigest, SledActionItemStore,
-    SledActivityStore, SledMeetingStore, SledMilestoneEventLog, SledMilestoneStore,
-    SledProgramStore, SledStructureStore, UpcomingMeetingDigest,
+    DigestSummary, GovernanceManager, InMemoryMilestoneEventLog, InMemoryProgramEventLog,
+    MilestoneEvent, MilestoneEventLogBackend, OverdueItemDigest, PendingVoteDigest, ProgramEvent,
+    ProgramEventLogBackend, SledActionItemStore, SledActivityStore, SledMeetingStore,
+    SledMilestoneEventLog, SledMilestoneStore, SledProgramEventLog, SledProgramStore,
+    SledStructureStore, UpcomingMeetingDigest,
 };
 pub use receipt_backend::GovernanceReceiptBackend;
 pub use state_store::{GovernanceStateStore, SledGovernanceStateStore};

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -40,9 +40,10 @@ pub use events::{GovernanceEventEmitter, NoopEventEmitter};
 pub use executor::{ExecutionCallback, GovernanceProposalExecutor};
 pub use handlers::translate_payload_to_effects;
 pub use manager::{
-    DigestSummary, GovernanceManager, OverdueItemDigest, PendingVoteDigest, SledActionItemStore,
-    SledActivityStore, SledMeetingStore, SledMilestoneStore, SledProgramStore, SledStructureStore,
-    UpcomingMeetingDigest,
+    DigestSummary, GovernanceManager, InMemoryMilestoneEventLog, MilestoneEvent,
+    MilestoneEventLogBackend, OverdueItemDigest, PendingVoteDigest, SledActionItemStore,
+    SledActivityStore, SledMeetingStore, SledMilestoneEventLog, SledMilestoneStore,
+    SledProgramStore, SledStructureStore, UpcomingMeetingDigest,
 };
 pub use receipt_backend::GovernanceReceiptBackend;
 pub use state_store::{GovernanceStateStore, SledGovernanceStateStore};

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -1245,6 +1245,158 @@ impl icn_governance::MilestoneStoreBackend for SledMilestoneStore {
 }
 
 // ============================================================================
+// Milestone Event Log
+// ============================================================================
+
+/// A single status-transition event recorded when `update_milestone_status` runs.
+///
+/// This is an app-layer (not core-crate) record. It lives in `manager.rs`
+/// because it is produced and consumed entirely within the governance app's
+/// persistence layer.
+///
+/// Fields are limited to what is truthfully known at the write site:
+/// `milestone_id`, `changed_at`, `changed_by`, `from_status`, `to_status` are
+/// always present because `update_milestone_status` has all of them. No
+/// "reason" or "comment" field is added here; those require a Layer-2
+/// call-site decision that the substrate does not currently model.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct MilestoneEvent {
+    pub milestone_id: MilestoneId,
+    /// Unix seconds when the transition was recorded.
+    pub changed_at: u64,
+    /// DID of the actor who triggered the transition.
+    pub changed_by: Did,
+    /// Status before the transition.
+    pub from_status: MilestoneStatus,
+    /// Status after the transition.
+    pub to_status: MilestoneStatus,
+}
+
+/// Append-only log of milestone status transitions.
+///
+/// `append` is called by `update_milestone_status` after a successful save.
+/// `list_by_milestone` is called by the history endpoint to populate the
+/// ordered entry list.
+///
+/// Ordering contract: entries returned by `list_by_milestone` must be
+/// oldest-to-newest by `changed_at`.
+pub trait MilestoneEventLogBackend: Send + Sync {
+    fn append(&self, event: &MilestoneEvent) -> std::result::Result<(), GovernanceError>;
+    fn list_by_milestone(
+        &self,
+        milestone_id: &MilestoneId,
+    ) -> std::result::Result<Vec<MilestoneEvent>, GovernanceError>;
+}
+
+// ── In-memory implementation (for tests and standalone mode) ─────────────────
+
+#[derive(Default)]
+pub struct InMemoryMilestoneEventLog {
+    events: RwLock<HashMap<MilestoneId, Vec<MilestoneEvent>>>,
+}
+
+impl InMemoryMilestoneEventLog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl MilestoneEventLogBackend for InMemoryMilestoneEventLog {
+    fn append(&self, event: &MilestoneEvent) -> std::result::Result<(), GovernanceError> {
+        let mut guard = self
+            .events
+            .write()
+            .map_err(|e| GovernanceError::Internal(format!("event log lock poisoned: {e}")))?;
+        guard
+            .entry(event.milestone_id.clone())
+            .or_default()
+            .push(event.clone());
+        Ok(())
+    }
+
+    fn list_by_milestone(
+        &self,
+        milestone_id: &MilestoneId,
+    ) -> std::result::Result<Vec<MilestoneEvent>, GovernanceError> {
+        let guard = self
+            .events
+            .read()
+            .map_err(|e| GovernanceError::Internal(format!("event log lock poisoned: {e}")))?;
+        Ok(guard.get(milestone_id).cloned().unwrap_or_default())
+    }
+}
+
+// ── Sled-backed implementation (for production) ───────────────────────────────
+
+/// Sled-backed append-only log for milestone status transitions.
+///
+/// Key scheme:
+///   `milestone_event:{milestone_id}:{changed_at:020}:{uuid}`
+///
+/// The timestamp is zero-padded to 20 digits so lexicographic scan order
+/// matches chronological order. The UUID suffix ensures uniqueness within
+/// the same second (rare in practice, but correct).
+///
+/// Scan prefix: `milestone_event:{milestone_id}:` — yields all events for
+/// a milestone, in chronological order.
+pub struct SledMilestoneEventLog {
+    db: Arc<sled::Db>,
+}
+
+impl SledMilestoneEventLog {
+    pub fn new(db: Arc<sled::Db>) -> Self {
+        Self { db }
+    }
+
+    fn event_key(milestone_id: &MilestoneId, changed_at: u64) -> String {
+        format!(
+            "milestone_event:{}:{:020}:{}",
+            milestone_id.0,
+            changed_at,
+            uuid::Uuid::new_v4()
+        )
+    }
+
+    fn events_prefix(milestone_id: &MilestoneId) -> String {
+        format!("milestone_event:{}:", milestone_id.0)
+    }
+}
+
+impl MilestoneEventLogBackend for SledMilestoneEventLog {
+    fn append(&self, event: &MilestoneEvent) -> std::result::Result<(), GovernanceError> {
+        let key = Self::event_key(&event.milestone_id, event.changed_at);
+        let value = icn_encoding::encode_versioned(event).map_err(|e| {
+            GovernanceError::Internal(format!("Failed to encode milestone event: {e}"))
+        })?;
+        self.db.insert(key.as_bytes(), value).map_err(|e| {
+            GovernanceError::Internal(format!("Sled insert (event log) failed: {e}"))
+        })?;
+        Ok(())
+    }
+
+    fn list_by_milestone(
+        &self,
+        milestone_id: &MilestoneId,
+    ) -> std::result::Result<Vec<MilestoneEvent>, GovernanceError> {
+        let prefix = Self::events_prefix(milestone_id);
+        let mut events = Vec::new();
+        for result in self.db.scan_prefix(prefix.as_bytes()) {
+            let (_key, value) = result.map_err(|e| {
+                GovernanceError::Internal(format!("Sled scan (event log) failed: {e}"))
+            })?;
+            let event: MilestoneEvent = icn_encoding::decode_versioned(&value).map_err(|e| {
+                GovernanceError::Internal(format!("Failed to decode milestone event: {e}"))
+            })?;
+            events.push(event);
+        }
+        // Sled scans in key order; since keys are zero-padded-timestamp-first,
+        // this is already chronological. Sort defensively for correctness.
+        events.sort_by_key(|e| e.changed_at);
+        Ok(events)
+    }
+}
+
+// ============================================================================
 // Sled-Backed Meeting Store
 // ============================================================================
 
@@ -2263,6 +2415,12 @@ pub struct GovernanceManager {
     governance_handle: Option<GovernanceHandle>,
     /// Optional receipt store for persisting GovernanceDecisionReceipts
     receipt_store: Option<Arc<dyn GovernanceReceiptBackend>>,
+    /// Optional append-only log of milestone status transitions.
+    ///
+    /// `None` in tests and standalone mode (no log written, history falls back
+    /// to lifecycle bookmarks). Set by sled-backed constructors so production
+    /// deployments record every status change.
+    milestone_event_log: Option<Arc<dyn MilestoneEventLogBackend>>,
 }
 
 impl GovernanceManager {
@@ -2286,6 +2444,7 @@ impl GovernanceManager {
             milestone_store: Arc::new(InMemoryMilestoneStore::new()),
             governance_handle: None,
             receipt_store: None,
+            milestone_event_log: None,
         }
     }
 
@@ -2322,6 +2481,7 @@ impl GovernanceManager {
             milestone_store: Arc::new(InMemoryMilestoneStore::new()),
             governance_handle: Some(handle),
             receipt_store: None,
+            milestone_event_log: None,
         }
     }
 
@@ -2382,6 +2542,16 @@ impl GovernanceManager {
         self
     }
 
+    /// Attach an append-only milestone event log.
+    ///
+    /// When set, `update_milestone_status` appends a [`MilestoneEvent`] on
+    /// every successful status transition. The history endpoint uses this log
+    /// when available, falling back to lifecycle bookmarks otherwise.
+    pub fn with_milestone_event_log(mut self, log: Arc<dyn MilestoneEventLogBackend>) -> Self {
+        self.milestone_event_log = Some(log);
+        self
+    }
+
     /// Create a governance manager with Sled-backed action item storage
     ///
     /// This is the recommended mode for production with persistent action items.
@@ -2403,9 +2573,10 @@ impl GovernanceManager {
             // program/milestone use the same db here to avoid needing further
             // builder calls for the happy path.
             program_store: Arc::new(SledProgramStore::new(db.clone())),
-            milestone_store: Arc::new(SledMilestoneStore::new(db)),
+            milestone_store: Arc::new(SledMilestoneStore::new(db.clone())),
             governance_handle: Some(handle),
             receipt_store: None,
+            milestone_event_log: Some(Arc::new(SledMilestoneEventLog::new(db))),
         }
     }
 
@@ -2427,9 +2598,10 @@ impl GovernanceManager {
             // Programs and milestones use Sled-backed stores so they persist
             // across restarts (same db instance, separate key namespaces).
             program_store: Arc::new(SledProgramStore::new(db.clone())),
-            milestone_store: Arc::new(SledMilestoneStore::new(db)),
+            milestone_store: Arc::new(SledMilestoneStore::new(db.clone())),
             governance_handle: None,
             receipt_store: None,
+            milestone_event_log: Some(Arc::new(SledMilestoneEventLog::new(db))),
         }
     }
 
@@ -4587,6 +4759,11 @@ impl GovernanceManager {
     /// milestone moves into `Completed`, the actor is recorded as
     /// `completed_by` for audit. When the milestone is reopened, both
     /// `completed_at` and `completed_by` are cleared.
+    ///
+    /// If a `milestone_event_log` is configured, a [`MilestoneEvent`] is
+    /// appended after the successful save. Event-log failures are logged but
+    /// do not cause the status update to fail — the milestone state is the
+    /// source of truth; the log is a supplementary observability record.
     pub fn update_milestone_status(
         &self,
         id: &MilestoneId,
@@ -4598,6 +4775,8 @@ impl GovernanceManager {
             .get(id)
             .map_err(|e| anyhow::anyhow!("Failed to get milestone: {e}"))?
             .ok_or_else(|| anyhow::anyhow!("Milestone not found: {id}"))?;
+
+        let from_status = m.status;
 
         if status == MilestoneStatus::Completed {
             if m.status != MilestoneStatus::Completed {
@@ -4613,7 +4792,44 @@ impl GovernanceManager {
         self.milestone_store
             .save(&m)
             .map_err(|e| anyhow::anyhow!("Failed to save milestone: {e}"))?;
+
+        // Append event-log entry when a log is configured.
+        // Only append if the status actually changed to avoid spurious entries
+        // (e.g. marking Completed again when already Completed).
+        if from_status != status {
+            if let Some(ref log) = self.milestone_event_log {
+                let event = MilestoneEvent {
+                    milestone_id: id.clone(),
+                    changed_at: icn_time::current_timestamp_secs(),
+                    changed_by: actor.clone(),
+                    from_status,
+                    to_status: status,
+                };
+                if let Err(e) = log.append(&event) {
+                    tracing::warn!(
+                        milestone_id = %id,
+                        error = %e,
+                        "Failed to append milestone event log entry (non-fatal)"
+                    );
+                }
+            }
+        }
+
         Ok(m)
+    }
+
+    /// List all recorded status-transition events for a milestone, oldest first.
+    ///
+    /// Returns an empty `Vec` when no event log is configured (in-memory /
+    /// standalone mode without an explicit event log). Callers should treat an
+    /// empty result as "no log available" and fall back to lifecycle bookmarks.
+    pub fn list_milestone_events(&self, id: &MilestoneId) -> Result<Vec<MilestoneEvent>> {
+        match &self.milestone_event_log {
+            None => Ok(Vec::new()),
+            Some(log) => log
+                .list_by_milestone(id)
+                .map_err(|e| anyhow::anyhow!("Failed to list milestone events: {e}")),
+        }
     }
 
     // ========================================================================

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -19,9 +19,10 @@ use icn_governance::{
     InMemoryMilestoneStore, InMemoryProgramStore, InMemoryStructureStore, Meeting, MeetingId,
     MeetingStoreBackend, MembershipConfig, MembershipSource, Milestone, MilestoneId,
     MilestoneStatus, MilestoneStoreBackend, PaginatedResult, Program, ProgramId, ProgramKind,
-    ProgramStoreBackend, ProofOutcome, Proposal, ProposalDomainLookup, ProposalId, ProposalPayload,
-    ProposalScope, ProposalState, RoleAssignment, Structure, StructureId, StructureKind,
-    StructureStoreBackend, Timestamp, Vote, VoteChoice, VoteTally, DEFAULT_MAX_DELEGATION_DEPTH,
+    ProgramStatus, ProgramStoreBackend, ProofOutcome, Proposal, ProposalDomainLookup, ProposalId,
+    ProposalPayload, ProposalScope, ProposalState, RoleAssignment, Structure, StructureId,
+    StructureKind, StructureStoreBackend, Timestamp, Vote, VoteChoice, VoteTally,
+    DEFAULT_MAX_DELEGATION_DEPTH,
 };
 use icn_identity::Did;
 use icn_kernel_api::{AllocationReceipt, ScopeLevel, SettlementIntent};
@@ -1397,6 +1398,152 @@ impl MilestoneEventLogBackend for SledMilestoneEventLog {
 }
 
 // ============================================================================
+// Program Event Log
+// ============================================================================
+
+/// A single status-transition event recorded when `update_program_status` runs.
+///
+/// App-layer record only — lives in `manager.rs` because it is produced and
+/// consumed entirely within the governance app's persistence layer.
+///
+/// Fields are limited to what is truthfully known at the write site:
+/// `program_id`, `changed_at`, `changed_by`, `from_status`, `to_status` are
+/// always present. No "reason" or "comment" field is added; those require a
+/// Layer-2 call-site decision the substrate does not currently model.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ProgramEvent {
+    pub program_id: ProgramId,
+    /// Unix seconds when the transition was recorded.
+    pub changed_at: u64,
+    /// DID of the actor who triggered the transition.
+    pub changed_by: Did,
+    /// Status before the transition.
+    pub from_status: ProgramStatus,
+    /// Status after the transition.
+    pub to_status: ProgramStatus,
+}
+
+/// Append-only log of program status transitions.
+///
+/// `append` is called by `update_program_status` after a successful save.
+/// `list_by_program` is called by the history endpoint (future slice) to
+/// populate the ordered entry list.
+///
+/// Ordering contract: entries returned by `list_by_program` must be
+/// oldest-to-newest by `changed_at`.
+pub trait ProgramEventLogBackend: Send + Sync {
+    fn append(&self, event: &ProgramEvent) -> std::result::Result<(), GovernanceError>;
+    fn list_by_program(
+        &self,
+        program_id: &ProgramId,
+    ) -> std::result::Result<Vec<ProgramEvent>, GovernanceError>;
+}
+
+// ── In-memory implementation (for tests and standalone mode) ─────────────────
+
+#[derive(Default)]
+pub struct InMemoryProgramEventLog {
+    events: RwLock<HashMap<ProgramId, Vec<ProgramEvent>>>,
+}
+
+impl InMemoryProgramEventLog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl ProgramEventLogBackend for InMemoryProgramEventLog {
+    fn append(&self, event: &ProgramEvent) -> std::result::Result<(), GovernanceError> {
+        let mut guard = self.events.write().map_err(|e| {
+            GovernanceError::Internal(format!("program event log lock poisoned: {e}"))
+        })?;
+        guard
+            .entry(event.program_id.clone())
+            .or_default()
+            .push(event.clone());
+        Ok(())
+    }
+
+    fn list_by_program(
+        &self,
+        program_id: &ProgramId,
+    ) -> std::result::Result<Vec<ProgramEvent>, GovernanceError> {
+        let guard = self.events.read().map_err(|e| {
+            GovernanceError::Internal(format!("program event log lock poisoned: {e}"))
+        })?;
+        Ok(guard.get(program_id).cloned().unwrap_or_default())
+    }
+}
+
+// ── Sled-backed implementation (for production) ───────────────────────────────
+
+/// Sled-backed append-only log for program status transitions.
+///
+/// Key scheme:
+///   `program_event:{program_id}:{changed_at:020}:{uuid}`
+///
+/// The timestamp is zero-padded to 20 digits so lexicographic scan order
+/// matches chronological order. The UUID suffix ensures uniqueness within
+/// the same second.
+///
+/// Scan prefix: `program_event:{program_id}:` — yields all events for a
+/// program in chronological order.
+pub struct SledProgramEventLog {
+    db: Arc<sled::Db>,
+}
+
+impl SledProgramEventLog {
+    pub fn new(db: Arc<sled::Db>) -> Self {
+        Self { db }
+    }
+
+    fn event_key(program_id: &ProgramId, changed_at: u64) -> String {
+        format!(
+            "program_event:{}:{:020}:{}",
+            program_id.0,
+            changed_at,
+            uuid::Uuid::new_v4()
+        )
+    }
+
+    fn events_prefix(program_id: &ProgramId) -> String {
+        format!("program_event:{}:", program_id.0)
+    }
+}
+
+impl ProgramEventLogBackend for SledProgramEventLog {
+    fn append(&self, event: &ProgramEvent) -> std::result::Result<(), GovernanceError> {
+        let key = Self::event_key(&event.program_id, event.changed_at);
+        let value = icn_encoding::encode_versioned(event).map_err(|e| {
+            GovernanceError::Internal(format!("Failed to encode program event: {e}"))
+        })?;
+        self.db.insert(key.as_bytes(), value).map_err(|e| {
+            GovernanceError::Internal(format!("Sled insert (program event log) failed: {e}"))
+        })?;
+        Ok(())
+    }
+
+    fn list_by_program(
+        &self,
+        program_id: &ProgramId,
+    ) -> std::result::Result<Vec<ProgramEvent>, GovernanceError> {
+        let prefix = Self::events_prefix(program_id);
+        let mut events = Vec::new();
+        for result in self.db.scan_prefix(prefix.as_bytes()) {
+            let (_key, value) = result.map_err(|e| {
+                GovernanceError::Internal(format!("Sled scan (program event log) failed: {e}"))
+            })?;
+            let event: ProgramEvent = icn_encoding::decode_versioned(&value).map_err(|e| {
+                GovernanceError::Internal(format!("Failed to decode program event: {e}"))
+            })?;
+            events.push(event);
+        }
+        events.sort_by_key(|e| e.changed_at);
+        Ok(events)
+    }
+}
+
+// ============================================================================
 // Sled-Backed Meeting Store
 // ============================================================================
 
@@ -2421,6 +2568,11 @@ pub struct GovernanceManager {
     /// to lifecycle bookmarks). Set by sled-backed constructors so production
     /// deployments record every status change.
     milestone_event_log: Option<Arc<dyn MilestoneEventLogBackend>>,
+    /// Optional append-only log of program status transitions.
+    ///
+    /// `None` in tests and standalone mode. Set by sled-backed constructors so
+    /// production deployments record every status change.
+    program_event_log: Option<Arc<dyn ProgramEventLogBackend>>,
 }
 
 impl GovernanceManager {
@@ -2445,6 +2597,7 @@ impl GovernanceManager {
             governance_handle: None,
             receipt_store: None,
             milestone_event_log: None,
+            program_event_log: None,
         }
     }
 
@@ -2482,6 +2635,7 @@ impl GovernanceManager {
             governance_handle: Some(handle),
             receipt_store: None,
             milestone_event_log: None,
+            program_event_log: None,
         }
     }
 
@@ -2552,6 +2706,15 @@ impl GovernanceManager {
         self
     }
 
+    /// Attach an append-only program event log.
+    ///
+    /// When set, `update_program_status` appends a [`ProgramEvent`] on every
+    /// successful status transition.
+    pub fn with_program_event_log(mut self, log: Arc<dyn ProgramEventLogBackend>) -> Self {
+        self.program_event_log = Some(log);
+        self
+    }
+
     /// Create a governance manager with Sled-backed action item storage
     ///
     /// This is the recommended mode for production with persistent action items.
@@ -2576,7 +2739,8 @@ impl GovernanceManager {
             milestone_store: Arc::new(SledMilestoneStore::new(db.clone())),
             governance_handle: Some(handle),
             receipt_store: None,
-            milestone_event_log: Some(Arc::new(SledMilestoneEventLog::new(db))),
+            milestone_event_log: Some(Arc::new(SledMilestoneEventLog::new(db.clone()))),
+            program_event_log: Some(Arc::new(SledProgramEventLog::new(db))),
         }
     }
 
@@ -2601,7 +2765,8 @@ impl GovernanceManager {
             milestone_store: Arc::new(SledMilestoneStore::new(db.clone())),
             governance_handle: None,
             receipt_store: None,
-            milestone_event_log: Some(Arc::new(SledMilestoneEventLog::new(db))),
+            milestone_event_log: Some(Arc::new(SledMilestoneEventLog::new(db.clone()))),
+            program_event_log: Some(Arc::new(SledProgramEventLog::new(db))),
         }
     }
 
@@ -4680,6 +4845,64 @@ impl GovernanceManager {
         self.program_store
             .list_by_domain(domain_id)
             .map_err(|e| anyhow::anyhow!("Failed to list programs: {e}"))
+    }
+
+    /// Update a program's lifecycle status.
+    ///
+    /// Records a [`ProgramEvent`] when the status actually changes. Event-log
+    /// failures are logged but do not fail the mutation — the program record is
+    /// the source of truth.
+    pub fn update_program_status(
+        &self,
+        id: &ProgramId,
+        status: ProgramStatus,
+        actor: &Did,
+    ) -> Result<Program> {
+        let mut p = self
+            .program_store
+            .get(id)
+            .map_err(|e| anyhow::anyhow!("Failed to look up program: {e}"))?
+            .ok_or_else(|| anyhow::anyhow!("Program not found: {id}"))?;
+
+        let from_status = p.status;
+        p.status = status;
+        self.program_store
+            .save(&p)
+            .map_err(|e| anyhow::anyhow!("Failed to save program: {e}"))?;
+
+        if from_status != status {
+            if let Some(ref log) = self.program_event_log {
+                let event = ProgramEvent {
+                    program_id: id.clone(),
+                    changed_at: icn_time::current_timestamp_secs(),
+                    changed_by: actor.clone(),
+                    from_status,
+                    to_status: status,
+                };
+                if let Err(e) = log.append(&event) {
+                    tracing::warn!(
+                        program_id = %id,
+                        error = %e,
+                        "Failed to append program event (non-fatal)"
+                    );
+                }
+            }
+        }
+
+        Ok(p)
+    }
+
+    /// Return all recorded status transitions for a program, oldest-to-newest.
+    ///
+    /// Returns an empty `Vec` when no event log is configured. Callers should
+    /// treat an empty result as "no log available."
+    pub fn list_program_events(&self, id: &ProgramId) -> Result<Vec<ProgramEvent>> {
+        match &self.program_event_log {
+            None => Ok(Vec::new()),
+            Some(log) => log
+                .list_by_program(id)
+                .map_err(|e| anyhow::anyhow!("Failed to list program events: {e}")),
+        }
     }
 
     // ========================================================================

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -1332,28 +1332,41 @@ impl MilestoneEventLogBackend for InMemoryMilestoneEventLog {
 /// Sled-backed append-only log for milestone status transitions.
 ///
 /// Key scheme:
-///   `milestone_event:{milestone_id}:{changed_at:020}:{uuid}`
+///   `milestone_event:{milestone_id}:{changed_at:020}:{seq:020}:{uuid}`
 ///
 /// The timestamp is zero-padded to 20 digits so lexicographic scan order
-/// matches chronological order. The UUID suffix ensures uniqueness within
-/// the same second (rare in practice, but correct).
+/// matches chronological order. A monotonically increasing per-process
+/// sequence number (`seq`) is appended so two appends in the same second
+/// retain insertion order regardless of UUID byte layout. The UUID suffix
+/// ensures uniqueness across process restarts (where `seq` resets to 0).
 ///
 /// Scan prefix: `milestone_event:{milestone_id}:` — yields all events for
 /// a milestone, in chronological order.
+///
+/// **ID-boundary note**: `MilestoneId::from_raw` allows `:` inside the id,
+/// so `scan_prefix` alone could return keys for `m1:child` when asked for
+/// `m1`. `list_by_milestone` therefore also checks the decoded
+/// `event.milestone_id` equals the requested id before returning.
 pub struct SledMilestoneEventLog {
     db: Arc<sled::Db>,
+    seq: std::sync::atomic::AtomicU64,
 }
 
 impl SledMilestoneEventLog {
     pub fn new(db: Arc<sled::Db>) -> Self {
-        Self { db }
+        Self {
+            db,
+            seq: std::sync::atomic::AtomicU64::new(0),
+        }
     }
 
-    fn event_key(milestone_id: &MilestoneId, changed_at: u64) -> String {
+    fn event_key(&self, milestone_id: &MilestoneId, changed_at: u64) -> String {
+        let seq = self.seq.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         format!(
-            "milestone_event:{}:{:020}:{}",
+            "milestone_event:{}:{:020}:{:020}:{}",
             milestone_id.0,
             changed_at,
+            seq,
             uuid::Uuid::new_v4()
         )
     }
@@ -1365,7 +1378,7 @@ impl SledMilestoneEventLog {
 
 impl MilestoneEventLogBackend for SledMilestoneEventLog {
     fn append(&self, event: &MilestoneEvent) -> std::result::Result<(), GovernanceError> {
-        let key = Self::event_key(&event.milestone_id, event.changed_at);
+        let key = self.event_key(&event.milestone_id, event.changed_at);
         let value = icn_encoding::encode_versioned(event).map_err(|e| {
             GovernanceError::Internal(format!("Failed to encode milestone event: {e}"))
         })?;
@@ -1380,20 +1393,25 @@ impl MilestoneEventLogBackend for SledMilestoneEventLog {
         milestone_id: &MilestoneId,
     ) -> std::result::Result<Vec<MilestoneEvent>, GovernanceError> {
         let prefix = Self::events_prefix(milestone_id);
-        let mut events = Vec::new();
+        // (changed_at, key_bytes) tuple preserves same-second insertion order
+        // via the `seq` component encoded in the key.
+        let mut rows: Vec<(u64, Vec<u8>, MilestoneEvent)> = Vec::new();
         for result in self.db.scan_prefix(prefix.as_bytes()) {
-            let (_key, value) = result.map_err(|e| {
+            let (key, value) = result.map_err(|e| {
                 GovernanceError::Internal(format!("Sled scan (event log) failed: {e}"))
             })?;
             let event: MilestoneEvent = icn_encoding::decode_versioned(&value).map_err(|e| {
                 GovernanceError::Internal(format!("Failed to decode milestone event: {e}"))
             })?;
-            events.push(event);
+            // Guard against `:` inside milestone_id producing prefix collisions
+            // (e.g. `m1:child` matching a scan for `m1`).
+            if &event.milestone_id != milestone_id {
+                continue;
+            }
+            rows.push((event.changed_at, key.to_vec(), event));
         }
-        // Sled scans in key order; since keys are zero-padded-timestamp-first,
-        // this is already chronological. Sort defensively for correctness.
-        events.sort_by_key(|e| e.changed_at);
-        Ok(events)
+        rows.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+        Ok(rows.into_iter().map(|(_, _, e)| e).collect())
     }
 }
 
@@ -1480,28 +1498,41 @@ impl ProgramEventLogBackend for InMemoryProgramEventLog {
 /// Sled-backed append-only log for program status transitions.
 ///
 /// Key scheme:
-///   `program_event:{program_id}:{changed_at:020}:{uuid}`
+///   `program_event:{program_id}:{changed_at:020}:{seq:020}:{uuid}`
 ///
 /// The timestamp is zero-padded to 20 digits so lexicographic scan order
-/// matches chronological order. The UUID suffix ensures uniqueness within
-/// the same second.
+/// matches chronological order. A monotonically increasing per-process
+/// sequence number (`seq`) is appended so two appends in the same second
+/// retain insertion order. The UUID suffix ensures uniqueness across
+/// process restarts (where `seq` resets to 0).
 ///
 /// Scan prefix: `program_event:{program_id}:` — yields all events for a
 /// program in chronological order.
+///
+/// **ID-boundary note**: `ProgramId::from_raw` allows `:` inside the id,
+/// so `scan_prefix` alone could return keys for `p1:child` when asked for
+/// `p1`. `list_by_program` therefore also checks the decoded
+/// `event.program_id` equals the requested id before returning.
 pub struct SledProgramEventLog {
     db: Arc<sled::Db>,
+    seq: std::sync::atomic::AtomicU64,
 }
 
 impl SledProgramEventLog {
     pub fn new(db: Arc<sled::Db>) -> Self {
-        Self { db }
+        Self {
+            db,
+            seq: std::sync::atomic::AtomicU64::new(0),
+        }
     }
 
-    fn event_key(program_id: &ProgramId, changed_at: u64) -> String {
+    fn event_key(&self, program_id: &ProgramId, changed_at: u64) -> String {
+        let seq = self.seq.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         format!(
-            "program_event:{}:{:020}:{}",
+            "program_event:{}:{:020}:{:020}:{}",
             program_id.0,
             changed_at,
+            seq,
             uuid::Uuid::new_v4()
         )
     }
@@ -1513,7 +1544,7 @@ impl SledProgramEventLog {
 
 impl ProgramEventLogBackend for SledProgramEventLog {
     fn append(&self, event: &ProgramEvent) -> std::result::Result<(), GovernanceError> {
-        let key = Self::event_key(&event.program_id, event.changed_at);
+        let key = self.event_key(&event.program_id, event.changed_at);
         let value = icn_encoding::encode_versioned(event).map_err(|e| {
             GovernanceError::Internal(format!("Failed to encode program event: {e}"))
         })?;
@@ -1528,18 +1559,21 @@ impl ProgramEventLogBackend for SledProgramEventLog {
         program_id: &ProgramId,
     ) -> std::result::Result<Vec<ProgramEvent>, GovernanceError> {
         let prefix = Self::events_prefix(program_id);
-        let mut events = Vec::new();
+        let mut rows: Vec<(u64, Vec<u8>, ProgramEvent)> = Vec::new();
         for result in self.db.scan_prefix(prefix.as_bytes()) {
-            let (_key, value) = result.map_err(|e| {
+            let (key, value) = result.map_err(|e| {
                 GovernanceError::Internal(format!("Sled scan (program event log) failed: {e}"))
             })?;
             let event: ProgramEvent = icn_encoding::decode_versioned(&value).map_err(|e| {
                 GovernanceError::Internal(format!("Failed to decode program event: {e}"))
             })?;
-            events.push(event);
+            if &event.program_id != program_id {
+                continue;
+            }
+            rows.push((event.changed_at, key.to_vec(), event));
         }
-        events.sort_by_key(|e| e.changed_at);
-        Ok(events)
+        rows.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+        Ok(rows.into_iter().map(|(_, _, e)| e).collect())
     }
 }
 


### PR DESCRIPTION
## Summary

Five read-only / lifecycle slices that build an honest progression surface for programs and milestones — no CCL gate evaluation, no institution-specific vocabulary, no speculative fields. All new types live in the app layer (`apps/governance/src/http/`, `apps/governance/src/manager.rs`); zero new types on the `icn-governance` core crate.

## Slices (in branch order)

**1. `GET /gov/milestones/{milestone_id}/preview`** — read-only readiness
- Reports whether a milestone is currently ready to advance based purely on observable ordering state: milestone must be open and not blocked; every earlier-phase milestone (lower `phase_index`) must be `completed` or `skipped`.
- Surfaces `completion_criteria` verbatim for caller inspection but does NOT evaluate them. Criteria interpretation belongs to an institution package, not ICN core.
- 404 on missing milestone / orphaned milestone. Requires `governance:read`.
- New types in app layer only: `MilestonePreviewResponse`, `BlockingMilestoneSummary`.

**2. `GET /gov/milestones/{milestone_id}/history`** — lifecycle bookmarks
- Returns observable status-transition trail for a milestone. `coverage: "lifecycle_bookmarks"` when only `created_at` + `completed_at` are available; `coverage: "transition_log"` when a wired event log has entries.
- Two entries for a completed milestone (creation + completion), one for a pending one. Explicit coverage field — no fabricated audit log.
- New types in app layer: `MilestoneHistoryEntry`, `MilestoneHistoryResponse`.

**3. App-layer milestone event log**
- `MilestoneEvent`, `MilestoneEventLogBackend` trait, `InMemoryMilestoneEventLog`, `SledMilestoneEventLog`. All in `apps/governance/src/manager.rs` — zero core crate changes.
- `update_milestone_status` appends on real transitions only (no-op when `from == to`); event log failures are non-fatal/warn-logged.
- Sled key scheme: `milestone_event:{id}:{changed_at:020}:{seq:020}:{uuid}`. Monotonic `seq` preserves same-second insertion order; `list_by_milestone` verifies exact ID equality post-decode to guard against `:`-in-id prefix collisions.
- Coverage annotation on the history endpoint changes from `lifecycle_bookmarks` to `transition_log` when events exist.

**4. `GET /gov/programs/{program_id}/summary`** — progression roll-up
- Lightweight companion to `/dashboard`: focuses on milestone progression without loading activities or action items.
- Response: `milestone_counts`, ordered `milestones`, `next_unfinished_milestone` (lowest-phase open milestone), `current_phase_index`, `progress_basis: "phase_index_ordering"`.
- New types in app layer: `ProgramSummaryResponse`, `NextUnfinishedMilestone`.

**5. App-layer program event log + `PATCH /gov/programs/{id}/status`**
- Mirrors slice 3 for programs: `ProgramEvent`, `ProgramEventLogBackend`, `InMemoryProgramEventLog`, `SledProgramEventLog`. Same key scheme / ID boundary / monotonic ordering treatment as milestone events.
- `update_program_status()` write path with membership + scope checks. `UpdateProgramStatusRequest` + `parse_program_status()` helper (returns 400 with valid-values list on unknown input).
- Handler gated on `governance:write` + `TrustThreshold` membership check.

## Naming casing (deliberate)

The new preview/history/summary response types serialize as **snake_case**, matching their closest siblings in the composite-read family (`DashboardMilestoneSummary`, `DashboardMilestoneCounts`, `ProgramDashboardResponse`). They do NOT follow the camelCase convention used by `MilestoneResponse` / `ProgramResponse` (individual-resource CRUD family). The distinction is intentional: composite-read endpoints on this branch stay internally consistent with their own read-family rather than mixing with CRUD casing. A repo-wide casing unification is out of scope for this PR.

## Honesty constraints observed

- No CCL gate evaluation (completion_criteria is surfaced as plain strings).
- No institution-specific vocabulary (no summit, sponsor, session, NYCN, etc.).
- `coverage` field is the only way callers learn what fidelity they got — the endpoint never claims to return more than it has.
- Event log writes are non-fatal: status transitions succeed even when the log append fails (and log a warning).

## Motivation

Milestone `completion_criteria` was passive text with no observable readiness surface. This PR builds that surface honestly: callers can ask "is this milestone ready to advance?" and "what is this program's progression state?" without the governance core lying about data it doesn't have.

## Testing

- Preview: 6 route tests (404, phase-0 ready, earlier-phase blocker, skipped-clears-blocker, already-completed, blocked-status).
- History: 3 bookmark tests + 4 event-log path tests (single transition, multiple ordered, no-duplicate on same-status repeat, empty-log fallback).
- Program summary: 4 route tests (404, no milestones, mixed states, all terminal).
- PATCH /programs/{id}/status: 7 route tests (happy path, persistence, 400/403/404, event-log no-dup on same-status, event-log ordering).
- `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean.
- Full `cargo test -p icn-governance -p icn-governance-actor` passes.

## Invariants

- [x] No panics in protocol paths
- [x] Determinism preserved (event-log ordering stable under same-second appends via `seq` tie-break)
- [x] Canonical encodings unchanged (`encode_versioned` / `decode_versioned`; `MilestoneEvent` / `ProgramEvent` are new, never mutated in place)
- [x] Trust gates not weakened (PATCH status requires `governance:write` + membership check)
- [x] Kernel/app boundaries respected (zero changes to core crates; all persistence types added in `apps/governance/src/manager.rs`)

## Documentation

- OpenAPI stubs for the four new endpoints in `milestone_paths` / `program_paths`.
- TypeScript types regenerated.
- Doc comments on `SledMilestoneEventLog` / `SledProgramEventLog` explain the key scheme, the `seq` tie-break, and the ID-boundary guard.
