### PR TITLE
feat(governance): steward authority execution bridge

### DIFF
--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -149,11 +149,23 @@ pub struct DispatchEvidenceSpec {
 /// Returning `None` is valid and means "this dispatcher does not report
 /// evidence" — reconciliation stays `emitted_only` for that effect.
 ///
+/// Async-returning: dispatchers that await real downstream work (e.g.
+/// `register_steward` / `revoke_steward` in commons) can capture the
+/// success/failure result before returning a `DispatchEvidenceSpec`.
+/// Dispatchers that produce evidence synchronously still fit — wrap the
+/// sync computation in `Box::pin(async move { ... })`.
+///
 /// This is additive to `ProposalAcceptedHook`. Gateways that do not
 /// provide evidence-returning dispatchers can leave this `None` and keep
 /// using the fire-and-forget hook.
-pub type ProposalDispatchEvidenceHook =
-    Arc<dyn Fn(&GovernanceEffect) -> Option<DispatchEvidenceSpec> + Send + Sync>;
+pub type ProposalDispatchEvidenceHook = Arc<
+    dyn Fn(
+            &GovernanceEffect,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Option<DispatchEvidenceSpec>> + Send>,
+        > + Send
+        + Sync,
+>;
 
 /// Async predicate: is `did` an active steward in the commons layer?
 ///

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -1360,6 +1360,16 @@ pub async fn close_proposal<E: GovernanceEventEmitter + Clone + 'static>(
         // `EffectDispatchEvidence` tied to the institutional effect record
         // persisted earlier in this handler. Other dispatch paths (charter/
         // freeze hooks) are fire-and-forget and remain `emitted_only`.
+        //
+        // Double-dispatch guard: for steward authority proposals, the
+        // evidence-returning hook (`on_proposal_accepted_with_evidence`, wired
+        // by the gateway to commons.register_steward / revoke_steward) is now
+        // canonical. If both are configured, running the sdis_service block
+        // below would re-enter register/revoke and produce conflicting
+        // evidence. When the evidence hook is wired, skip sdis_service for
+        // AppointSteward/RemoveSteward variants — other SDIS variants still
+        // flow through sdis_service unchanged.
+        let evidence_hook_handles_steward = ctx.on_proposal_accepted_with_evidence.is_some();
         if let Some(ref svc) = ctx.sdis_service {
             use icn_kernel_api::{AppointStewardRequest, RevokeStewardRequest};
             if let icn_governance::ProposalPayload::Sdis {
@@ -1394,6 +1404,13 @@ pub async fn close_proposal<E: GovernanceEventEmitter + Clone + 'static>(
                 };
 
                 match sdis_proposal {
+                    icn_governance::sdis::SdisProposal::AppointSteward { .. }
+                    | icn_governance::sdis::SdisProposal::RemoveSteward { .. }
+                        if evidence_hook_handles_steward =>
+                    {
+                        // Evidence hook is canonical for steward variants — skip
+                        // sdis_service to avoid double-dispatch.
+                    }
                     icn_governance::sdis::SdisProposal::AppointSteward {
                         candidate,
                         bond_amount,

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -1280,13 +1280,38 @@ pub async fn close_proposal<E: GovernanceEventEmitter + Clone + 'static>(
                         charter_id: charter_id.clone(),
                     }
                 }
-                // SDIS steward proposals are handled via ctx.sdis_service when set (test
-                // path). In daemon mode sdis_service is None — the actor event system
-                // handles execution (KernelGovernanceExecutor → SdisServiceImpl). Emit
-                // Unhandled so the hook is a no-op for SDIS in both paths.
-                icn_governance::ProposalPayload::Sdis { .. } => GovernanceEffect::Unhandled {
-                    proposal_id: proposal.id.0.clone(),
-                    payload_type: proposal.payload.type_name().to_owned(),
+                // SDIS steward proposals: translate to concrete authority effects so the
+                // evidence-returning hook (wired by the gateway to commons.register_steward
+                // / commons.revoke_steward) can produce real dispatch evidence. Other SDIS
+                // variants fall through to Unhandled — they are carried by the actor event
+                // system (KernelGovernanceExecutor → SdisServiceImpl) and produce no
+                // in-process evidence from this handler.
+                icn_governance::ProposalPayload::Sdis { proposal: sdis } => match sdis {
+                    icn_governance::sdis::SdisProposal::AppointSteward {
+                        candidate,
+                        region,
+                        bond_amount,
+                        term_length,
+                        ..
+                    } => GovernanceEffect::AppointSteward {
+                        proposal_id: proposal.id.0.clone(),
+                        domain_id: proposal.domain_id.0.clone(),
+                        candidate: candidate.clone(),
+                        region: region.clone(),
+                        bond_amount: *bond_amount,
+                        term_length_seconds: *term_length,
+                    },
+                    icn_governance::sdis::SdisProposal::RemoveSteward {
+                        steward, reason, ..
+                    } => GovernanceEffect::RevokeSteward {
+                        proposal_id: proposal.id.0.clone(),
+                        steward: steward.clone(),
+                        reason: reason.clone(),
+                    },
+                    _ => GovernanceEffect::Unhandled {
+                        proposal_id: proposal.id.0.clone(),
+                        payload_type: proposal.payload.type_name().to_owned(),
+                    },
                 },
                 _ => GovernanceEffect::Unhandled {
                     proposal_id: proposal.id.0.clone(),
@@ -1301,7 +1326,7 @@ pub async fn close_proposal<E: GovernanceEventEmitter + Clone + 'static>(
             // effect record. Effect kind must match one of our translated
             // labels — for Unhandled we skip (no record was emitted).
             if let Some(ev_hook) = &ctx.on_proposal_accepted_with_evidence {
-                if let Some(spec) = ev_hook(&effect) {
+                if let Some(spec) = ev_hook(&effect).await {
                     let effect_kind = match &effect {
                         GovernanceEffect::FreezeMember { .. } => Some("freeze_member"),
                         GovernanceEffect::UnfreezeMember { .. } => Some("unfreeze_member"),
@@ -5047,14 +5072,17 @@ mod tests {
 
         // The evidence hook simulates a downstream dispatcher reporting back
         // with a state_change_hash after successful side-effects.
-        let ev_hook: ProposalDispatchEvidenceHook = Arc::new(move |effect| match effect {
-            GovernanceEffect::FreezeMember { .. } => Some(DispatchEvidenceSpec {
-                subsystem: "commons".to_string(),
-                receipt_ref: Some("state-hash-abc".to_string()),
-                success: true,
-                error_message: None,
-            }),
-            _ => None,
+        let ev_hook: ProposalDispatchEvidenceHook = Arc::new(move |effect| {
+            let spec = match effect {
+                GovernanceEffect::FreezeMember { .. } => Some(DispatchEvidenceSpec {
+                    subsystem: "commons".to_string(),
+                    receipt_ref: Some("state-hash-abc".to_string()),
+                    success: true,
+                    error_message: None,
+                }),
+                _ => None,
+            };
+            Box::pin(async move { spec })
         });
 
         let ctx = GovernanceContext {
@@ -5090,6 +5118,368 @@ mod tests {
         assert!(evidence[0].success);
 
         // Reconciliation derives to ExecutionEvidenced on success.
+        let status = crate::dispatch_evidence::derive_reconciliation_status(&records[0], &evidence);
+        assert_eq!(status, ReconciliationStatus::ExecutionEvidenced);
+    }
+
+    /// Proves the `appoint_steward` dispatch lane produces real execution
+    /// evidence on success:
+    ///   SDIS AppointSteward proposal accepted
+    ///   → `InstitutionalEffectRecord(effect_kind = "appoint_steward")`
+    ///   → evidence hook awaits a simulated downstream steward registration,
+    ///     returns `DispatchEvidenceSpec { success: true, receipt_ref: Some(id) }`
+    ///   → dispatch evidence is persisted against the record
+    ///   → derived `ReconciliationStatus` is `ExecutionEvidenced`.
+    ///
+    /// The simulated downstream is the async commons `register_steward` call
+    /// in gateway/server.rs — same contract, substituted for a sync return
+    /// here to avoid pulling in commons.
+    #[tokio::test]
+    async fn evidence_hook_persists_dispatch_evidence_on_appoint_steward_success() {
+        use crate::dispatch_evidence::ReconciliationStatus;
+        use crate::http::configure::{DispatchEvidenceSpec, ProposalDispatchEvidenceHook};
+        use icn_governance::sdis::SdisProposal;
+
+        let steward_did = test_did(11);
+        let candidate_did = test_did(22);
+
+        let mgr = Arc::new(
+            GovernanceManager::new().with_receipt_store(Arc::new(HandlerTestReceiptBackend::new())),
+        );
+        let domain_id = GovernanceDomainId("steward-coop".to_string());
+        mgr.create_domain(
+            domain_id.clone(),
+            "steward coop".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::new(0, 0, 86_400),
+            MembershipConfig {
+                source: MembershipSource::StaticList(vec![steward_did.clone()]),
+            },
+        )
+        .await
+        .unwrap();
+
+        let proposal_id = ProposalId("appoint-1".to_string());
+        mgr.create_proposal(
+            proposal_id.clone(),
+            domain_id.clone(),
+            steward_did.clone(),
+            "Appoint candidate as steward".to_string(),
+            "appoint_steward".to_string(),
+            ProposalPayload::Sdis {
+                proposal: SdisProposal::AppointSteward {
+                    candidate: candidate_did.clone(),
+                    sponsors: vec![steward_did.clone()],
+                    region: domain_id.0.clone(),
+                    bond_amount: 1000,
+                    term_length: 31_536_000, // 1 year
+                },
+            },
+            ProposalScope::Local,
+        )
+        .await
+        .unwrap();
+        mgr.open_proposal(proposal_id.clone(), 86_400)
+            .await
+            .unwrap();
+        mgr.cast_vote(
+            proposal_id.clone(),
+            steward_did.clone(),
+            VoteChoice::For,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let simulated_steward_id = "abcd1234".to_string();
+        let sid_clone = simulated_steward_id.clone();
+        let ev_hook: ProposalDispatchEvidenceHook = Arc::new(move |effect| {
+            let sid = sid_clone.clone();
+            let matched = matches!(effect, GovernanceEffect::AppointSteward { .. });
+            Box::pin(async move {
+                if matched {
+                    Some(DispatchEvidenceSpec {
+                        subsystem: "commons".to_string(),
+                        receipt_ref: Some(sid),
+                        success: true,
+                        error_message: None,
+                    })
+                } else {
+                    None
+                }
+            })
+        });
+
+        let ctx = GovernanceContext {
+            manager: mgr.clone(),
+            emitter: NoopEventEmitter,
+            on_charter_accepted: None,
+            on_proposal_accepted: Some(Arc::new(|_| {})),
+            on_proposal_accepted_with_evidence: Some(ev_hook),
+            member_checker: None,
+            steward_checker: None,
+            suspension_checker: None,
+            membership_resolver: None,
+            sdis_service: None,
+        };
+
+        let app = test_app!(ctx, steward_did);
+        let req = test::TestRequest::post()
+            .uri(&format!("/proposals/{}/close", proposal_id.0))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let records = mgr.list_institutional_effects(&proposal_id).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].effect_kind, "appoint_steward");
+
+        let evidence = mgr.list_dispatch_evidence(&records[0].record_id).unwrap();
+        assert_eq!(evidence.len(), 1);
+        assert_eq!(evidence[0].subsystem, "commons");
+        assert_eq!(
+            evidence[0].receipt_ref.as_deref(),
+            Some(simulated_steward_id.as_str())
+        );
+        assert!(evidence[0].success);
+        assert!(evidence[0].error_message.is_none());
+
+        let status = crate::dispatch_evidence::derive_reconciliation_status(&records[0], &evidence);
+        assert_eq!(status, ReconciliationStatus::ExecutionEvidenced);
+    }
+
+    /// Proves the `appoint_steward` dispatch lane records failures durably:
+    ///   downstream register_steward fails (e.g. no holder record, unratified charter)
+    ///   → `InstitutionalEffectRecord(effect_kind = "appoint_steward")`
+    ///   → evidence hook returns `DispatchEvidenceSpec { success: false, error_message }`
+    ///   → dispatch evidence is persisted
+    ///   → derived `ReconciliationStatus` is `ExecutionFailed`.
+    ///
+    /// Failure must be durable, not silently swallowed — this is what makes
+    /// reconciliation truthful. A later retry succeeding elsewhere must not
+    /// overwrite this failure; that stickiness is enforced by the status
+    /// derivation itself.
+    #[tokio::test]
+    async fn evidence_hook_persists_failure_on_appoint_steward_error() {
+        use crate::dispatch_evidence::ReconciliationStatus;
+        use crate::http::configure::{DispatchEvidenceSpec, ProposalDispatchEvidenceHook};
+        use icn_governance::sdis::SdisProposal;
+
+        let steward_did = test_did(11);
+        let candidate_did = test_did(24);
+
+        let mgr = Arc::new(
+            GovernanceManager::new().with_receipt_store(Arc::new(HandlerTestReceiptBackend::new())),
+        );
+        let domain_id = GovernanceDomainId("steward-fail-coop".to_string());
+        mgr.create_domain(
+            domain_id.clone(),
+            "steward fail coop".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::new(0, 0, 86_400),
+            MembershipConfig {
+                source: MembershipSource::StaticList(vec![steward_did.clone()]),
+            },
+        )
+        .await
+        .unwrap();
+
+        let proposal_id = ProposalId("appoint-fail-1".to_string());
+        mgr.create_proposal(
+            proposal_id.clone(),
+            domain_id.clone(),
+            steward_did.clone(),
+            "Appoint — will fail downstream".to_string(),
+            "appoint_steward".to_string(),
+            ProposalPayload::Sdis {
+                proposal: SdisProposal::AppointSteward {
+                    candidate: candidate_did.clone(),
+                    sponsors: vec![steward_did.clone()],
+                    region: domain_id.0.clone(),
+                    bond_amount: 0,
+                    term_length: 31_536_000,
+                },
+            },
+            ProposalScope::Local,
+        )
+        .await
+        .unwrap();
+        mgr.open_proposal(proposal_id.clone(), 86_400)
+            .await
+            .unwrap();
+        mgr.cast_vote(
+            proposal_id.clone(),
+            steward_did.clone(),
+            VoteChoice::For,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let ev_hook: ProposalDispatchEvidenceHook = Arc::new(move |effect| {
+            let matched = matches!(effect, GovernanceEffect::AppointSteward { .. });
+            Box::pin(async move {
+                if matched {
+                    Some(DispatchEvidenceSpec {
+                        subsystem: "commons".to_string(),
+                        receipt_ref: None,
+                        success: false,
+                        error_message: Some("candidate has no holder record".to_string()),
+                    })
+                } else {
+                    None
+                }
+            })
+        });
+
+        let ctx = GovernanceContext {
+            manager: mgr.clone(),
+            emitter: NoopEventEmitter,
+            on_charter_accepted: None,
+            on_proposal_accepted: Some(Arc::new(|_| {})),
+            on_proposal_accepted_with_evidence: Some(ev_hook),
+            member_checker: None,
+            steward_checker: None,
+            suspension_checker: None,
+            membership_resolver: None,
+            sdis_service: None,
+        };
+
+        let app = test_app!(ctx, steward_did);
+        let req = test::TestRequest::post()
+            .uri(&format!("/proposals/{}/close", proposal_id.0))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let records = mgr.list_institutional_effects(&proposal_id).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].effect_kind, "appoint_steward");
+
+        let evidence = mgr.list_dispatch_evidence(&records[0].record_id).unwrap();
+        assert_eq!(evidence.len(), 1);
+        assert!(!evidence[0].success);
+        assert_eq!(
+            evidence[0].error_message.as_deref(),
+            Some("candidate has no holder record"),
+        );
+
+        let status = crate::dispatch_evidence::derive_reconciliation_status(&records[0], &evidence);
+        match status {
+            ReconciliationStatus::ExecutionFailed { error } => {
+                assert_eq!(error.as_deref(), Some("candidate has no holder record"));
+            }
+            other => panic!("expected ExecutionFailed, got {other:?}"),
+        }
+    }
+
+    /// Proves the `revoke_steward` dispatch lane mirrors the appoint lane:
+    /// on successful commons revocation, evidence is persisted with the
+    /// commons steward-id as receipt_ref and reconciliation derives to
+    /// `ExecutionEvidenced`.
+    #[tokio::test]
+    async fn evidence_hook_persists_dispatch_evidence_on_revoke_steward_success() {
+        use crate::dispatch_evidence::ReconciliationStatus;
+        use crate::http::configure::{DispatchEvidenceSpec, ProposalDispatchEvidenceHook};
+        use icn_governance::sdis::SdisProposal;
+
+        let steward_did = test_did(11);
+        let target_steward = test_did(26);
+
+        let mgr = Arc::new(
+            GovernanceManager::new().with_receipt_store(Arc::new(HandlerTestReceiptBackend::new())),
+        );
+        let domain_id = GovernanceDomainId("revoke-coop".to_string());
+        mgr.create_domain(
+            domain_id.clone(),
+            "revoke coop".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::new(0, 0, 86_400),
+            MembershipConfig {
+                source: MembershipSource::StaticList(vec![steward_did.clone()]),
+            },
+        )
+        .await
+        .unwrap();
+
+        let proposal_id = ProposalId("revoke-1".to_string());
+        mgr.create_proposal(
+            proposal_id.clone(),
+            domain_id.clone(),
+            steward_did.clone(),
+            "Revoke target steward".to_string(),
+            "revoke_steward".to_string(),
+            ProposalPayload::Sdis {
+                proposal: SdisProposal::RemoveSteward {
+                    steward: target_steward.clone(),
+                    reason: "performance".to_string(),
+                    return_bond: true,
+                },
+            },
+            ProposalScope::Local,
+        )
+        .await
+        .unwrap();
+        mgr.open_proposal(proposal_id.clone(), 86_400)
+            .await
+            .unwrap();
+        mgr.cast_vote(
+            proposal_id.clone(),
+            steward_did.clone(),
+            VoteChoice::For,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let sid = "revoked-id-xyz".to_string();
+        let sid_clone = sid.clone();
+        let ev_hook: ProposalDispatchEvidenceHook = Arc::new(move |effect| {
+            let sid = sid_clone.clone();
+            let matched = matches!(effect, GovernanceEffect::RevokeSteward { .. });
+            Box::pin(async move {
+                if matched {
+                    Some(DispatchEvidenceSpec {
+                        subsystem: "commons".to_string(),
+                        receipt_ref: Some(sid),
+                        success: true,
+                        error_message: None,
+                    })
+                } else {
+                    None
+                }
+            })
+        });
+
+        let ctx = GovernanceContext {
+            manager: mgr.clone(),
+            emitter: NoopEventEmitter,
+            on_charter_accepted: None,
+            on_proposal_accepted: Some(Arc::new(|_| {})),
+            on_proposal_accepted_with_evidence: Some(ev_hook),
+            member_checker: None,
+            steward_checker: None,
+            suspension_checker: None,
+            membership_resolver: None,
+            sdis_service: None,
+        };
+
+        let app = test_app!(ctx, steward_did);
+        let req = test::TestRequest::post()
+            .uri(&format!("/proposals/{}/close", proposal_id.0))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let records = mgr.list_institutional_effects(&proposal_id).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].effect_kind, "revoke_steward");
+
+        let evidence = mgr.list_dispatch_evidence(&records[0].record_id).unwrap();
+        assert_eq!(evidence.len(), 1);
+        assert_eq!(evidence[0].receipt_ref.as_deref(), Some(sid.as_str()));
+        assert!(evidence[0].success);
+
         let status = crate::dispatch_evidence::derive_reconciliation_status(&records[0], &evidence);
         assert_eq!(status, ReconciliationStatus::ExecutionEvidenced);
     }

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -1182,97 +1182,13 @@ impl GatewayServer {
                             }
                         });
                     }
-                    GovernanceEffect::AppointSteward {
-                        proposal_id,
-                        domain_id,
-                        candidate,
-                        region: _,
-                        bond_amount,
-                        term_length_seconds,
-                    } => {
-                        // Register the candidate as a steward in commons, scoped to the
-                        // governance domain that approved the appointment.  The domain must
-                        // have a ratified charter (via DeployCharter) for the jurisdiction
-                        // binding to succeed.
-                        // If the candidate has no Commons Holder record or the charter is not
-                        // yet registered, register_steward returns Err and we log a warning.
-                        let commons_mgr = commons_mgr_for_gov.clone();
-                        tokio::spawn(async move {
-                            let term_days = term_length_seconds / 86_400;
-                            let bond = bond_amount.max(0) as u64;
-                            match commons_mgr
-                                .register_steward(
-                                    &candidate,
-                                    &candidate,
-                                    term_days,
-                                    bond,
-                                    proposal_id,
-                                    Some(domain_id.clone()),
-                                    vec![],
-                                )
-                                .await
-                            {
-                                Ok(_) => {
-                                    tracing::info!(
-                                        did = %candidate,
-                                        jurisdiction = %domain_id,
-                                        "AppointSteward: steward registered in commons"
-                                    );
-                                }
-                                Err(e) => {
-                                    tracing::warn!(
-                                        error = %e,
-                                        did = %candidate,
-                                        jurisdiction = %domain_id,
-                                        "AppointSteward: failed to register steward"
-                                    );
-                                }
-                            }
-                        });
-                    }
-                    GovernanceEffect::RevokeSteward {
-                        proposal_id: _,
-                        steward,
-                        reason,
-                    } => {
-                        // Revoke the steward's appointment in commons.
-                        // If no steward record exists for this DID, this is a no-op.
-                        let commons_mgr = commons_mgr_for_gov.clone();
-                        tokio::spawn(async move {
-                            match commons_mgr.get_steward_by_did(&steward).await {
-                                Ok(Some(record)) => {
-                                    let steward_id = record.id().to_hex();
-                                    if let Err(e) = commons_mgr
-                                        .revoke_steward(&steward_id, reason, vec![])
-                                        .await
-                                    {
-                                        tracing::warn!(
-                                            error = %e,
-                                            did = %steward,
-                                            "RevokeSteward: failed to revoke steward"
-                                        );
-                                    } else {
-                                        tracing::info!(
-                                            did = %steward,
-                                            "RevokeSteward: steward revoked in commons"
-                                        );
-                                    }
-                                }
-                                Ok(None) => {
-                                    tracing::debug!(
-                                        did = %steward,
-                                        "RevokeSteward: no steward record found, skipping"
-                                    );
-                                }
-                                Err(e) => {
-                                    tracing::warn!(
-                                        error = %e,
-                                        did = %steward,
-                                        "RevokeSteward: steward lookup failed"
-                                    );
-                                }
-                            }
-                        });
+                    GovernanceEffect::AppointSteward { .. }
+                    | GovernanceEffect::RevokeSteward { .. } => {
+                        // Handled by the evidence-returning hook
+                        // `on_proposal_accepted_with_evidence` wired below, which awaits
+                        // the commons call and persists the outcome as a durable
+                        // `EffectDispatchEvidence` record against the institutional
+                        // effect. Skipping here avoids double-execution.
                     }
                     GovernanceEffect::Unhandled {
                         proposal_id,
@@ -1332,12 +1248,175 @@ impl GatewayServer {
                 Box::pin(async move { mgr.is_member_suspended(&domain_id, &did).await })
             });
 
+        // Evidence-returning dispatch hook for steward authority effects.
+        //
+        // Unlike `on_proposal_accepted` (fire-and-forget), this hook awaits the
+        // commons mutation and returns a `DispatchEvidenceSpec` describing the
+        // real outcome. The governance app persists that spec as an
+        // `EffectDispatchEvidence` record tied to the `InstitutionalEffectRecord`
+        // emitted at acceptance, bringing the effect's `reconciliation_status`
+        // out of `emitted_only`:
+        //   * success → `ExecutionEvidenced` with a commons steward-id receipt_ref
+        //   * failure → `ExecutionFailed` with a durable error_message
+        // Sticky-failure semantics (failures shadow later successes) are enforced
+        // in the app layer, so a once-failed effect stays auditable even if a
+        // later retry succeeds elsewhere.
+        //
+        // Only `AppointSteward` and `RevokeSteward` are wired through this hook
+        // in this slice — these are the first production effects with real
+        // execution evidence. Other effects fall through to `None` and remain
+        // `emitted_only` until their dispatcher is promoted to evidence-returning.
+        let commons_mgr_for_evidence = commons_manager.clone();
+        let on_proposal_accepted_with_evidence: icn_governance_actor::http::configure::ProposalDispatchEvidenceHook =
+            std::sync::Arc::new(move |effect| {
+                use icn_governance_actor::http::configure::{
+                    DispatchEvidenceSpec, GovernanceEffect,
+                };
+                let commons = commons_mgr_for_evidence.clone();
+                let effect = effect.clone();
+                Box::pin(async move {
+                    match effect {
+                        GovernanceEffect::AppointSteward {
+                            proposal_id,
+                            domain_id,
+                            candidate,
+                            region: _,
+                            bond_amount,
+                            term_length_seconds,
+                        } => {
+                            let term_days = term_length_seconds / 86_400;
+                            let bond = bond_amount.max(0) as u64;
+                            match commons
+                                .register_steward(
+                                    &candidate,
+                                    &candidate,
+                                    term_days,
+                                    bond,
+                                    proposal_id,
+                                    Some(domain_id.clone()),
+                                    vec![],
+                                )
+                                .await
+                            {
+                                Ok(record) => {
+                                    let steward_id = record.id().to_hex();
+                                    tracing::info!(
+                                        did = %candidate,
+                                        jurisdiction = %domain_id,
+                                        steward_id = %steward_id,
+                                        "AppointSteward: steward registered in commons"
+                                    );
+                                    Some(DispatchEvidenceSpec {
+                                        subsystem: "commons".to_string(),
+                                        receipt_ref: Some(steward_id),
+                                        success: true,
+                                        error_message: None,
+                                    })
+                                }
+                                Err(e) => {
+                                    let msg = e.to_string();
+                                    tracing::warn!(
+                                        error = %msg,
+                                        did = %candidate,
+                                        jurisdiction = %domain_id,
+                                        "AppointSteward: failed to register steward"
+                                    );
+                                    Some(DispatchEvidenceSpec {
+                                        subsystem: "commons".to_string(),
+                                        receipt_ref: None,
+                                        success: false,
+                                        error_message: Some(msg),
+                                    })
+                                }
+                            }
+                        }
+                        GovernanceEffect::RevokeSteward {
+                            proposal_id: _,
+                            steward,
+                            reason,
+                        } => match commons.get_steward_by_did(&steward).await {
+                            Ok(Some(record)) => {
+                                let steward_id = record.id().to_hex();
+                                match commons
+                                    .revoke_steward(&steward_id, reason, vec![])
+                                    .await
+                                {
+                                    Ok(()) => {
+                                        tracing::info!(
+                                            did = %steward,
+                                            steward_id = %steward_id,
+                                            "RevokeSteward: steward revoked in commons"
+                                        );
+                                        Some(DispatchEvidenceSpec {
+                                            subsystem: "commons".to_string(),
+                                            receipt_ref: Some(steward_id),
+                                            success: true,
+                                            error_message: None,
+                                        })
+                                    }
+                                    Err(e) => {
+                                        let msg = e.to_string();
+                                        tracing::warn!(
+                                            error = %msg,
+                                            did = %steward,
+                                            "RevokeSteward: failed to revoke steward"
+                                        );
+                                        Some(DispatchEvidenceSpec {
+                                            subsystem: "commons".to_string(),
+                                            receipt_ref: Some(steward_id),
+                                            success: false,
+                                            error_message: Some(msg),
+                                        })
+                                    }
+                                }
+                            }
+                            Ok(None) => {
+                                // No steward record exists — treat as failed
+                                // dispatch with a durable explanation rather
+                                // than silent no-op. Reconciliation should
+                                // surface this truthfully.
+                                tracing::warn!(
+                                    did = %steward,
+                                    "RevokeSteward: no steward record found"
+                                );
+                                Some(DispatchEvidenceSpec {
+                                    subsystem: "commons".to_string(),
+                                    receipt_ref: None,
+                                    success: false,
+                                    error_message: Some(
+                                        "no active steward record for DID".to_string(),
+                                    ),
+                                })
+                            }
+                            Err(e) => {
+                                let msg = e.to_string();
+                                tracing::warn!(
+                                    error = %msg,
+                                    did = %steward,
+                                    "RevokeSteward: steward lookup failed"
+                                );
+                                Some(DispatchEvidenceSpec {
+                                    subsystem: "commons".to_string(),
+                                    receipt_ref: None,
+                                    success: false,
+                                    error_message: Some(msg),
+                                })
+                            }
+                        },
+                        // Other effects: no evidence-returning dispatcher wired
+                        // yet. Reconciliation stays `emitted_only` for them —
+                        // this is truthful given current implementation.
+                        _ => None,
+                    }
+                })
+            });
+
         let gov_ctx = GovernanceContext {
             manager: governance_manager.clone(),
             emitter: GatewayEventAdapter::new(event_broadcaster.clone()),
             on_charter_accepted: self.charter_accepted_hook,
             on_proposal_accepted: Some(on_proposal_accepted),
-            on_proposal_accepted_with_evidence: None,
+            on_proposal_accepted_with_evidence: Some(on_proposal_accepted_with_evidence),
             member_checker: Some(member_checker),
             steward_checker: Some(steward_checker),
             suspension_checker: Some(suspension_checker),

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -1371,21 +1371,22 @@ impl GatewayServer {
                                 }
                             }
                             Ok(None) => {
-                                // No steward record exists — treat as failed
-                                // dispatch with a durable explanation rather
-                                // than silent no-op. Reconciliation should
-                                // surface this truthfully.
-                                tracing::warn!(
+                                // No active steward record exists — the desired
+                                // revoked state is already satisfied. Align with
+                                // the SdisService kernel path (services/sdis_service.rs)
+                                // which treats this as an idempotent no-op success.
+                                // Because reconciliation failures are sticky, recording
+                                // a false failure here would permanently misclassify
+                                // an already-revoked steward as ExecutionFailed.
+                                tracing::info!(
                                     did = %steward,
-                                    "RevokeSteward: no steward record found"
+                                    "RevokeSteward: no active steward record; treating as already revoked"
                                 );
                                 Some(DispatchEvidenceSpec {
                                     subsystem: "commons".to_string(),
                                     receipt_ref: None,
-                                    success: false,
-                                    error_message: Some(
-                                        "no active steward record for DID".to_string(),
-                                    ),
+                                    success: true,
+                                    error_message: None,
                                 })
                             }
                             Err(e) => {


### PR DESCRIPTION
## Summary

Wires **appoint_steward** and **revoke_steward** as real governance-to-execution closures, not labels. An accepted SDIS  /  proposal now:

1. Emits a canonical  (via shared ).
2. Translates to  /  (previously , which dropped the dispatch signal).
3. Invokes the gateway-wired evidence hook, which awaits  /  and returns a  — success returns the steward-id as ; failure returns the error message.
4. Persists  durably against the record.
5.  reads as  on success,  on downstream failure — sticky across retries.

## Why

Previous tranche (#1562) built the record/evidence/reconciliation substrate for . This slice applies it to authority effects — the first lane that proves steward lifecycle is truthful: , downstream call actually happened, failure is not swallowed.

## How

- : converted to  so the hook can await commons async calls.
-  handler: SDIS / arms now return / (other SDIS variants remain  — carried by the actor event bus).
- Gateway : awaits  and , mapping their  into .
- HTTP  arms for AppointSteward/RevokeSteward collapsed to  — single source of dispatch.

## Test plan

-  → **172/172** (+3 new).
-  → **497/497**.
-  → clean.
-  → clean.

New tests:
-  — records + evidence persisted; reconciliation = ExecutionEvidenced.
-  — failure durable; reconciliation = ExecutionFailed { error }.
-  — mirror for revoke.

## Risk

- Actor-path force-close parity:  doesn't expose , so the actor-backed force-close path still emits without a backing receipt_store in daemon deployment. Deferred to a follow-up: add  (or wire the store at actor construction).
- No behavior change for  /  /  /  — existing tests pin contract.
- Domain-agnostic SDIS variants (, , etc.) still route as  — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)