### PR TITLE
feat(governance): close actor-path receipt_store parity gap

### DIFF
--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -548,11 +548,11 @@ impl GovernanceHandle {
     /// to the HTTP close handler's post-actor emission (which does not run
     /// for actor-only force-close). Wire this for any deployment where
     /// force-accept must produce the same audit trail as normal accept.
-    pub fn with_receipt_store(
+    pub async fn with_receipt_store(
         self,
         store: Arc<dyn crate::receipt_backend::GovernanceReceiptBackend>,
     ) -> Self {
-        self.install_receipt_store(store);
+        self.install_receipt_store(store).await;
         self
     }
 
@@ -572,20 +572,19 @@ impl GovernanceHandle {
     /// `InstitutionalEffectRecord` in daemon deployments (the HTTP-close path
     /// remained the sole writer).
     ///
+    /// Awaits the inner write lock rather than using `try_write`: a transient
+    /// lock contention window (e.g. an in-flight `submit`) during gateway
+    /// startup must NOT silently drop the install and re-open the parity gap
+    /// the setter exists to close. `submit` only holds the lock for the
+    /// duration of a single command, so this await completes quickly.
+    ///
     /// Idempotent: repeat calls replace the previously-installed store.
-    pub fn install_receipt_store(
+    pub async fn install_receipt_store(
         &self,
         store: Arc<dyn crate::receipt_backend::GovernanceReceiptBackend>,
     ) {
-        if let Ok(mut actor) = self.inner.try_write() {
-            actor.receipt_store = Some(store);
-        } else {
-            tracing::error!(
-                "install_receipt_store: actor inner lock contended; receipt_store \
-                 not installed. Actor-backed force-close will not emit \
-                 InstitutionalEffectRecord until this is retried."
-            );
-        }
+        let mut actor = self.inner.write().await;
+        actor.receipt_store = Some(store);
     }
 
     /// List all protocol parameters

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -552,10 +552,40 @@ impl GovernanceHandle {
         self,
         store: Arc<dyn crate::receipt_backend::GovernanceReceiptBackend>,
     ) -> Self {
+        self.install_receipt_store(store);
+        self
+    }
+
+    /// Shared-ref variant of `with_receipt_store`: install the receipt backend
+    /// on an already-cloned handle.
+    ///
+    /// The builder-style `with_receipt_store` consumes `self`, which is
+    /// incompatible with production wiring where the concrete
+    /// `GovernanceHandle` has already been cloned into `Arc<dyn GovernanceOps>`
+    /// before the receipt_store is created (receipt_store's backing DB is only
+    /// opened when the gateway server starts, after the actor is spawned).
+    ///
+    /// This setter mutates the shared actor state via the same
+    /// `Arc<RwLock<GovernanceActor>>`, so every clone of the handle sees the
+    /// newly-installed store. Closes the actor-path parity gap: without this,
+    /// force-close accept and deadline auto-close emit no
+    /// `InstitutionalEffectRecord` in daemon deployments (the HTTP-close path
+    /// remained the sole writer).
+    ///
+    /// Idempotent: repeat calls replace the previously-installed store.
+    pub fn install_receipt_store(
+        &self,
+        store: Arc<dyn crate::receipt_backend::GovernanceReceiptBackend>,
+    ) {
         if let Ok(mut actor) = self.inner.try_write() {
             actor.receipt_store = Some(store);
+        } else {
+            tracing::error!(
+                "install_receipt_store: actor inner lock contended; receipt_store \
+                 not installed. Actor-backed force-close will not emit \
+                 InstitutionalEffectRecord until this is retried."
+            );
         }
-        self
     }
 
     /// List all protocol parameters

--- a/icn/apps/governance/tests/actor_receipt_store_parity.rs
+++ b/icn/apps/governance/tests/actor_receipt_store_parity.rs
@@ -194,7 +194,7 @@ async fn actor_force_close_accept_emits_appoint_steward_effect() {
     // where the gateway opens its sled DB (and builds ReceiptStore) only
     // after the supervisor has already spawned the actor.
     let backend = Arc::new(MemoryReceiptBackend::new());
-    actor_handle.install_receipt_store(backend.clone());
+    actor_handle.install_receipt_store(backend.clone()).await;
 
     // Force-close accept. The normal close path would also emit, but the
     // specific regression this test pins is the actor-path force-close.
@@ -286,7 +286,7 @@ async fn actor_force_close_accept_emits_revoke_steward_effect() {
         .expect("open_proposal");
 
     let backend = Arc::new(MemoryReceiptBackend::new());
-    actor_handle.install_receipt_store(backend.clone());
+    actor_handle.install_receipt_store(backend.clone()).await;
 
     actor_handle
         .submit(GovernanceCommand::ForceCloseProposal {

--- a/icn/apps/governance/tests/actor_receipt_store_parity.rs
+++ b/icn/apps/governance/tests/actor_receipt_store_parity.rs
@@ -1,0 +1,391 @@
+//! Actor-path receipt-store parity: force-close-accept emits
+//! `InstitutionalEffectRecord` after `install_receipt_store`.
+//!
+//! ## What this pins
+//!
+//! Before this test existed, the actor-backed governance path could emit
+//! `InstitutionalEffectRecord` only if the actor was spawned with a
+//! receipt_store wired in at construction. In production wiring the gateway
+//! creates the receipt_store *after* the actor is spawned (the gateway opens
+//! the sled DB that the receipt store is backed by). The builder-style
+//! `GovernanceHandle::with_receipt_store(self, ...)` consumes the handle and
+//! is incompatible with that order — so the only writer of
+//! `InstitutionalEffectRecord` was the HTTP `close_proposal` handler.
+//!
+//! Consequences: force-close-accept and deadline-driven auto-close (both of
+//! which run *inside* the actor without returning through HTTP) produced no
+//! institutional artifact. Audit verify would report "no institutional
+//! effect" for any AppointSteward / RevokeSteward that landed via
+//! force-close or scheduler — even though the decision was durable.
+//!
+//! This test pins the parity fix: after installing the receipt backend via
+//! the shared-ref setter `install_receipt_store(&self, ...)`, force-close
+//! accept of an `AppointSteward` proposal emits a durable
+//! `InstitutionalEffectRecord` with `effect_kind == "appoint_steward"`.
+//! Same pinning for `RemoveSteward` / `effect_kind == "revoke_steward"`.
+//!
+//! ## What this does NOT prove
+//!
+//! - End-to-end dispatch to the commons steward service (that is the
+//!   gateway's `on_proposal_accepted_with_evidence` hook — still
+//!   gateway-only).
+//! - Deadline-driven auto-close (tested separately by the scheduler tests).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use icn_gossip::{AccessControl, GossipActor, Topic};
+use icn_governance::{
+    sdis::SdisProposal, ForcedOutcome, GovernanceDomainId, GovernanceOps, GovernanceParams,
+    MembershipConfig, ProposalId, ProposalPayload, ProposalScope, StaticMembershipResolver,
+};
+use icn_governance_actor::{
+    actor::{GovernanceActor, GovernanceCommand},
+    institutional_effect::InstitutionalEffectRecord,
+    manager::GovernanceManager,
+    receipt_backend::GovernanceReceiptBackend,
+};
+use icn_identity::IdentityBundle;
+use icn_store::SledStore;
+use std::sync::{Arc, Mutex};
+
+/// In-memory receipt backend that records only `InstitutionalEffectRecord`
+/// writes — that is the artifact under test.
+struct MemoryReceiptBackend {
+    effects: Mutex<Vec<InstitutionalEffectRecord>>,
+}
+
+impl MemoryReceiptBackend {
+    fn new() -> Self {
+        Self {
+            effects: Mutex::new(vec![]),
+        }
+    }
+
+    fn effects_for(&self, proposal_id: &str) -> Vec<InstitutionalEffectRecord> {
+        self.effects
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|r| r.proposal_id == proposal_id)
+            .cloned()
+            .collect()
+    }
+}
+
+impl GovernanceReceiptBackend for MemoryReceiptBackend {
+    fn put_governance(&self, _: &icn_governance::GovernanceDecisionReceipt) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_governance_by_proposal(
+        &self,
+        _: &str,
+    ) -> Result<Option<icn_governance::GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn put_allocation(
+        &self,
+        _: &icn_kernel_api::AllocationReceipt,
+    ) -> Result<icn_kernel_api::Hash, String> {
+        Ok([0u8; 32])
+    }
+    fn get_governance_by_decision(
+        &self,
+        _: &icn_kernel_api::Hash,
+    ) -> Result<Option<icn_governance::GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn list_allocations_by_decision(
+        &self,
+        _: &icn_kernel_api::Hash,
+    ) -> Result<Vec<icn_kernel_api::AllocationReceipt>, String> {
+        Ok(vec![])
+    }
+    fn put_institutional_effect(&self, record: &InstitutionalEffectRecord) -> Result<(), String> {
+        self.effects.lock().unwrap().push(record.clone());
+        Ok(())
+    }
+    fn list_institutional_effects_by_proposal(
+        &self,
+        proposal_id: &str,
+    ) -> Result<Vec<InstitutionalEffectRecord>, String> {
+        Ok(self.effects_for(proposal_id))
+    }
+}
+
+async fn gossip_with_governance_topic(
+    did: icn_identity::Did,
+) -> Arc<tokio::sync::RwLock<GossipActor>> {
+    let gossip = GossipActor::spawn(did, None);
+    gossip.write().await.create_topic(Topic::new(
+        "governance:proposal".to_string(),
+        AccessControl::Public,
+    ));
+    gossip
+}
+
+/// Drive a domain + open AppointSteward proposal up to the force-close seam,
+/// install the receipt_store *after* open (mirroring production order where
+/// the gateway creates the backend after actor spawn), then force-accept and
+/// assert the durable `InstitutionalEffectRecord` was written.
+#[tokio::test]
+async fn actor_force_close_accept_emits_appoint_steward_effect() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db_path = tmp.path().to_path_buf();
+
+    let bundle = IdentityBundle::generate().expect("IdentityBundle::generate");
+    let did = bundle.did().clone();
+    let candidate_bundle = IdentityBundle::generate().expect("candidate keypair");
+    let candidate_did = candidate_bundle.did().clone();
+
+    let store = Arc::new(SledStore::open(&db_path).expect("SledStore::open"));
+    let gossip = gossip_with_governance_topic(did.clone()).await;
+    let resolver = Arc::new(StaticMembershipResolver::new());
+
+    let actor_handle =
+        GovernanceActor::spawn(did.clone(), store.clone(), gossip, resolver, None, None)
+            .await
+            .expect("GovernanceActor::spawn");
+
+    let domain_id = GovernanceDomainId("steward-parity-domain".to_string());
+    let manager = GovernanceManager::with_handle(
+        Arc::new(actor_handle.clone()) as Arc<dyn GovernanceOps + Send + Sync>
+    );
+
+    manager
+        .create_domain(
+            domain_id.clone(),
+            "Steward Parity Domain".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::new(50, 50, 3600),
+            MembershipConfig::static_list(vec![did.clone()]),
+        )
+        .await
+        .expect("create_domain");
+
+    let payload = ProposalPayload::Sdis {
+        proposal: SdisProposal::AppointSteward {
+            candidate: candidate_did.clone(),
+            sponsors: vec![did.clone()],
+            region: "region-north".to_string(),
+            bond_amount: 1_000,
+            term_length: 3600 * 24 * 30,
+        },
+    };
+
+    let proposal_id = manager
+        .create_proposal(
+            ProposalId("_ignored".to_string()),
+            domain_id.clone(),
+            did.clone(),
+            "Appoint steward Alice".to_string(),
+            "Parity test".to_string(),
+            payload,
+            ProposalScope::Local,
+        )
+        .await
+        .expect("create_proposal");
+
+    manager
+        .open_proposal(proposal_id.clone(), 3600)
+        .await
+        .expect("open_proposal");
+
+    // Install the receipt_store AFTER open — this mirrors production wiring
+    // where the gateway opens its sled DB (and builds ReceiptStore) only
+    // after the supervisor has already spawned the actor.
+    let backend = Arc::new(MemoryReceiptBackend::new());
+    actor_handle.install_receipt_store(backend.clone());
+
+    // Force-close accept. The normal close path would also emit, but the
+    // specific regression this test pins is the actor-path force-close.
+    actor_handle
+        .submit(GovernanceCommand::ForceCloseProposal {
+            proposal_id: proposal_id.clone(),
+            forced_outcome: ForcedOutcome::Accept,
+            reason: "parity test force-accept".to_string(),
+        })
+        .await
+        .expect("ForceCloseProposal submit");
+
+    let effects = backend.effects_for(&proposal_id.0);
+    assert_eq!(
+        effects.len(),
+        1,
+        "force-close-accept must emit exactly one InstitutionalEffectRecord after receipt_store install; got {effects:?}"
+    );
+    let rec = &effects[0];
+    assert_eq!(rec.effect_kind, "appoint_steward");
+    assert_eq!(rec.target_did.as_deref(), Some(candidate_did.as_str()));
+    assert_eq!(rec.target_ref.as_deref(), Some("region-north"));
+
+    actor_handle.shutdown().await;
+}
+
+/// Same pin for `RemoveSteward` / `effect_kind == "revoke_steward"` — this
+/// is the other half of the steward-authority slice called out in the
+/// parity directive.
+#[tokio::test]
+async fn actor_force_close_accept_emits_revoke_steward_effect() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db_path = tmp.path().to_path_buf();
+
+    let bundle = IdentityBundle::generate().expect("IdentityBundle::generate");
+    let did = bundle.did().clone();
+    let steward_bundle = IdentityBundle::generate().expect("steward keypair");
+    let steward_did = steward_bundle.did().clone();
+
+    let store = Arc::new(SledStore::open(&db_path).expect("SledStore::open"));
+    let gossip = gossip_with_governance_topic(did.clone()).await;
+    let resolver = Arc::new(StaticMembershipResolver::new());
+
+    let actor_handle =
+        GovernanceActor::spawn(did.clone(), store.clone(), gossip, resolver, None, None)
+            .await
+            .expect("GovernanceActor::spawn");
+
+    let domain_id = GovernanceDomainId("revoke-parity-domain".to_string());
+    let manager = GovernanceManager::with_handle(
+        Arc::new(actor_handle.clone()) as Arc<dyn GovernanceOps + Send + Sync>
+    );
+
+    manager
+        .create_domain(
+            domain_id.clone(),
+            "Revoke Parity Domain".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::new(50, 50, 3600),
+            MembershipConfig::static_list(vec![did.clone()]),
+        )
+        .await
+        .expect("create_domain");
+
+    let payload = ProposalPayload::Sdis {
+        proposal: SdisProposal::RemoveSteward {
+            steward: steward_did.clone(),
+            reason: "breach of duty".to_string(),
+            return_bond: false,
+        },
+    };
+
+    let proposal_id = manager
+        .create_proposal(
+            ProposalId("_ignored".to_string()),
+            domain_id.clone(),
+            did.clone(),
+            "Remove steward Bob".to_string(),
+            "Parity test".to_string(),
+            payload,
+            ProposalScope::Local,
+        )
+        .await
+        .expect("create_proposal");
+
+    manager
+        .open_proposal(proposal_id.clone(), 3600)
+        .await
+        .expect("open_proposal");
+
+    let backend = Arc::new(MemoryReceiptBackend::new());
+    actor_handle.install_receipt_store(backend.clone());
+
+    actor_handle
+        .submit(GovernanceCommand::ForceCloseProposal {
+            proposal_id: proposal_id.clone(),
+            forced_outcome: ForcedOutcome::Accept,
+            reason: "parity test force-accept".to_string(),
+        })
+        .await
+        .expect("ForceCloseProposal submit");
+
+    let effects = backend.effects_for(&proposal_id.0);
+    assert_eq!(
+        effects.len(),
+        1,
+        "force-close-accept must emit exactly one InstitutionalEffectRecord after receipt_store install; got {effects:?}"
+    );
+    let rec = &effects[0];
+    assert_eq!(rec.effect_kind, "revoke_steward");
+    assert_eq!(rec.target_did.as_deref(), Some(steward_did.as_str()));
+    assert_eq!(rec.reason.as_deref(), Some("breach of duty"));
+
+    actor_handle.shutdown().await;
+}
+
+/// Regression: force-close-accept without a receipt_store must not panic
+/// and must not emit (silent no-op is the honest behavior). This pins the
+/// "missing store" half of the parity contract.
+#[tokio::test]
+async fn actor_force_close_accept_without_receipt_store_emits_nothing() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db_path = tmp.path().to_path_buf();
+
+    let bundle = IdentityBundle::generate().expect("IdentityBundle::generate");
+    let did = bundle.did().clone();
+    let candidate_bundle = IdentityBundle::generate().expect("candidate keypair");
+    let candidate_did = candidate_bundle.did().clone();
+
+    let store = Arc::new(SledStore::open(&db_path).expect("SledStore::open"));
+    let gossip = gossip_with_governance_topic(did.clone()).await;
+    let resolver = Arc::new(StaticMembershipResolver::new());
+
+    let actor_handle =
+        GovernanceActor::spawn(did.clone(), store.clone(), gossip, resolver, None, None)
+            .await
+            .expect("GovernanceActor::spawn");
+
+    let domain_id = GovernanceDomainId("nostore-domain".to_string());
+    let manager = GovernanceManager::with_handle(
+        Arc::new(actor_handle.clone()) as Arc<dyn GovernanceOps + Send + Sync>
+    );
+
+    manager
+        .create_domain(
+            domain_id.clone(),
+            "No Store Domain".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::new(50, 50, 3600),
+            MembershipConfig::static_list(vec![did.clone()]),
+        )
+        .await
+        .expect("create_domain");
+
+    let payload = ProposalPayload::Sdis {
+        proposal: SdisProposal::AppointSteward {
+            candidate: candidate_did.clone(),
+            sponsors: vec![did.clone()],
+            region: "r".to_string(),
+            bond_amount: 1,
+            term_length: 3600,
+        },
+    };
+
+    let proposal_id = manager
+        .create_proposal(
+            ProposalId("_ignored".to_string()),
+            domain_id.clone(),
+            did.clone(),
+            "No receipt store".to_string(),
+            "".to_string(),
+            payload,
+            ProposalScope::Local,
+        )
+        .await
+        .expect("create_proposal");
+
+    manager
+        .open_proposal(proposal_id.clone(), 3600)
+        .await
+        .expect("open_proposal");
+
+    // NOTE: no install_receipt_store call.
+    actor_handle
+        .submit(GovernanceCommand::ForceCloseProposal {
+            proposal_id: proposal_id.clone(),
+            forced_outcome: ForcedOutcome::Accept,
+            reason: "no backend".to_string(),
+        })
+        .await
+        .expect("ForceCloseProposal submit must not panic without a receipt_store");
+
+    actor_handle.shutdown().await;
+}

--- a/icn/crates/icn-core/src/supervisor/actors.rs
+++ b/icn/crates/icn-core/src/supervisor/actors.rs
@@ -19,6 +19,10 @@ pub struct GatewayActorHandles {
     pub trust_service: Option<Arc<dyn icn_kernel_api::services::TrustService>>,
     pub ledger_service: Option<Arc<dyn icn_kernel_api::services::LedgerService>>,
     pub governance: Option<icn_gateway::governance_mgr::GovernanceHandle>,
+    /// Concrete actor-backed governance handle. Parallel to `governance`
+    /// (which is the trait-object alias). Needed for installing the
+    /// gateway's receipt_store on the actor's inner state.
+    pub governance_actor_handle: Option<icn_governance_actor::GovernanceHandle>,
     pub treasury: Option<icn_gateway::TreasuryHandle>,
     pub ledger: Option<icn_gateway::LedgerHandle>,
     pub entity: Option<icn_entity::EntityHandle>,

--- a/icn/crates/icn-core/src/supervisor/init_gateway.rs
+++ b/icn/crates/icn-core/src/supervisor/init_gateway.rs
@@ -29,6 +29,16 @@ pub struct GatewayHandles {
     pub ledger_service: Option<Arc<dyn icn_kernel_api::services::LedgerService>>,
     /// Governance handle for governance operations
     pub governance: Option<icn_gateway::governance_mgr::GovernanceHandle>,
+    /// Concrete actor-backed governance handle (parallel to the trait-object
+    /// `governance` handle above). Needed so the gateway can install its
+    /// receipt_store on the actor via `install_receipt_store`, closing the
+    /// actor-path parity gap for force-close accept and deadline auto-close
+    /// (which would otherwise emit no `InstitutionalEffectRecord`).
+    ///
+    /// The trait-object `governance` alias (`Arc<dyn GovernanceOps>`) does
+    /// not expose the setter because doing so would pull
+    /// `GovernanceReceiptBackend` (app-layer) into the kernel trait.
+    pub governance_actor_handle: Option<icn_governance_actor::GovernanceHandle>,
     /// Treasury handle for treasury operations
     pub treasury: Option<icn_gateway::TreasuryHandle>,
     /// Ledger handle for balance queries
@@ -111,6 +121,7 @@ pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: Gateway
     let trust_service_handle = handles.trust_service;
     let ledger_service_handle = handles.ledger_service;
     let governance_handle = handles.governance;
+    let governance_actor_handle = handles.governance_actor_handle;
     let treasury_handle = handles.treasury;
     let ledger_handle = handles.ledger;
     let entity_handle = handles.entity;
@@ -164,6 +175,10 @@ pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: Gateway
 
             if let Some(handle) = governance_handle {
                 gateway_server = gateway_server.with_governance_handle(handle);
+            }
+
+            if let Some(handle) = governance_actor_handle {
+                gateway_server = gateway_server.with_governance_actor_handle(handle);
             }
 
             if let Some(handle) = treasury_handle {

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -135,6 +135,7 @@ pub async fn run_supervisor(
             trust_service: gateway_handles.trust_service,
             ledger_service: gateway_handles.ledger_service,
             governance: gateway_handles.governance,
+            governance_actor_handle: gateway_handles.governance_actor_handle,
             treasury: gateway_handles.treasury,
             ledger: gateway_handles.ledger,
             entity: gateway_handles.entity,
@@ -684,6 +685,9 @@ async fn spawn_actors_with_identity(
 
     // Store handles for gateway
     gateway_handles.governance = Some(Arc::new(governance_handle.clone()));
+    // Also expose the concrete actor handle so the gateway can install its
+    // receipt_store on the actor (closes actor-path force-close parity gap).
+    gateway_handles.governance_actor_handle = Some(governance_handle.clone());
     gateway_handles.treasury = Some(treasury_manager_handle.clone());
     gateway_handles.ledger = Some(ledger_handle.clone());
 

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -595,7 +595,9 @@ impl GatewayServer {
         // durably. Without this, the HTTP-close path was the sole writer and
         // force-close / deadline auto-close produced no institutional artifact.
         if let Some(ref actor_handle) = self.governance_actor_handle {
-            actor_handle.install_receipt_store(receipt_store.clone());
+            actor_handle
+                .install_receipt_store(receipt_store.clone())
+                .await;
             info!("Receipt store installed on governance actor (actor-path parity)");
         }
 

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -99,6 +99,12 @@ pub struct GatewayServer {
     federation_service_handle: Option<Arc<dyn icn_kernel_api::services::FederationService>>,
     /// Optional handle to daemon's GovernanceActor (for actor-backed mode)
     governance_handle: Option<GovernanceHandle>,
+    /// Optional concrete actor handle, parallel to `governance_handle`.
+    /// Used solely to install `receipt_store` onto the actor at startup so
+    /// actor-path `CloseProposal::Accept` and `ForceCloseProposal::Accept`
+    /// emit `InstitutionalEffectRecord` durably (closes parity gap with
+    /// the gateway-path close).
+    governance_actor_handle: Option<icn_governance_actor::GovernanceHandle>,
     /// Optional handle to daemon's ContractRegistryActor (for contract management)
     contract_registry_handle: Option<icn_ccl::ContractRegistryHandle>,
     /// Optional handle to daemon's TreasuryManager (for treasury operations)
@@ -151,6 +157,7 @@ impl GatewayServer {
             ledger_service_handle: None,
             federation_service_handle: None,
             governance_handle: None,
+            governance_actor_handle: None,
             contract_registry_handle: None,
             treasury_handle: None,
             ledger_handle: None,
@@ -197,6 +204,7 @@ impl GatewayServer {
             ledger_service_handle: None,
             federation_service_handle: None,
             governance_handle: None,
+            governance_actor_handle: None,
             contract_registry_handle: None,
             treasury_handle: None,
             ledger_handle: None,
@@ -244,6 +252,7 @@ impl GatewayServer {
             ledger_service_handle: None,
             federation_service_handle: None,
             governance_handle: None,
+            governance_actor_handle: None,
             contract_registry_handle: None,
             treasury_handle: None,
             ledger_handle: None,
@@ -366,6 +375,21 @@ impl GatewayServer {
     /// GovernanceActor, ensuring persistence and gossip synchronization.
     pub fn with_governance_handle(mut self, handle: GovernanceHandle) -> Self {
         self.governance_handle = Some(handle);
+        self
+    }
+
+    /// Set the concrete actor-backed governance handle.
+    ///
+    /// This is parallel to `with_governance_handle`, which accepts the
+    /// trait-object alias (`Arc<dyn GovernanceOps>`). The concrete handle is
+    /// required so the gateway can install its `receipt_store` on the actor
+    /// via `install_receipt_store` — without it, actor-path force-close
+    /// accept and deadline auto-close do not emit `InstitutionalEffectRecord`.
+    pub fn with_governance_actor_handle(
+        mut self,
+        handle: icn_governance_actor::GovernanceHandle,
+    ) -> Self {
+        self.governance_actor_handle = Some(handle);
         self
     }
 
@@ -565,6 +589,15 @@ impl GatewayServer {
         // Create receipt store early so governance manager can reference it
         let receipt_store = Arc::new(crate::receipt_store::ReceiptStore::new(db.clone()));
         info!("Receipt store initialized");
+
+        // Install receipt_store on the actor so actor-path `CloseProposal::Accept`
+        // and `ForceCloseProposal::Accept` emit `InstitutionalEffectRecord`
+        // durably. Without this, the HTTP-close path was the sole writer and
+        // force-close / deadline auto-close produced no institutional artifact.
+        if let Some(ref actor_handle) = self.governance_actor_handle {
+            actor_handle.install_receipt_store(receipt_store.clone());
+            info!("Receipt store installed on governance actor (actor-path parity)");
+        }
 
         // Execution record query store (read-only API surface).
         // Uses the daemon core store path when available: <data_dir>/store/execution


### PR DESCRIPTION
## Summary
- Adds `GovernanceHandle::install_receipt_store(&self, store)` — shared-ref setter so the gateway can wire the receipt_store into the already-spawned actor (the prior consuming `with_receipt_store` was incompatible with gateway spawn order).
- Threads the concrete `icn_governance_actor::GovernanceHandle` through supervisor → `spawn_gateway` → `GatewayServer` in parallel to the trait-object `Arc<dyn GovernanceOps>` (adding the setter to the trait would pull `GovernanceReceiptBackend` across the kernel/app boundary).
- `GatewayServer` installs the receipt_store on the actor immediately after constructing it, closing the actor-path emission gap for force-close-accept and deadline auto-close.

## Why
Before this change, actor-internal paths (force-close-accept; deadline-driven auto-close) produced no `InstitutionalEffectRecord` for `AppointSteward`/`RemoveSteward` decisions, even though the decisions themselves were durable. Only the HTTP close handler was emitting institutional artifacts.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p icn-governance-actor -p icn-core -p icn-gateway --all-targets -- -D warnings`
- [x] `cargo test -p icn-governance-actor -p icn-core -p icn-gateway` (all green, incl. new `actor_receipt_store_parity` suite: appoint_steward effect, revoke_steward effect, silent no-op without installed store)

## Out of scope
- End-to-end dispatch evidence to the commons steward service from the actor path (the `on_proposal_accepted_with_evidence` hook still only runs on the gateway-close path).
- Integration test exercising deadline-driven auto-close (the shared force-accept emission branch is covered; deadline scheduler path is not).
