### PR TITLE
feat(sdis): restore downstream receipt_ref on kernel-owned dispatch

### DIFF
--- a/icn/apps/governance/src/dispatch_evidence.rs
+++ b/icn/apps/governance/src/dispatch_evidence.rs
@@ -43,7 +43,16 @@ pub struct EffectDispatchEvidence {
     /// `"commons"`, `"ledger"`, …
     pub subsystem: String,
     /// Opaque receipt reference minted by the downstream subsystem.
-    /// For SDIS, this is the steward-store `state_change_hash`.
+    ///
+    /// For SDIS `AppointSteward` / `RevokeSteward` / `ReconfirmSteward`,
+    /// this is the content-addressed `StewardId::to_hex()` published by
+    /// the commons layer — *not* a steward-store `state_change_hash`.
+    ///
+    /// `None` means the executing service had no downstream handle to
+    /// attribute: a failure, a no-op (e.g. revoke against a DID with no
+    /// active record), or an effect family that does not yet produce a
+    /// downstream receipt. Consumers that need the full downstream
+    /// receipt must look it up in the subsystem's own store.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub receipt_ref: Option<String>,
     /// Whether the subsystem reported success.

--- a/icn/apps/governance/src/dispatch_evidence_sink.rs
+++ b/icn/apps/governance/src/dispatch_evidence_sink.rs
@@ -130,10 +130,15 @@ impl GovernanceDispatchEvidenceSink {
             effect_record_id.to_string(),
             proposal_id.to_string(),
             subsystem,
-            // The kernel path does not mint a downstream receipt_ref;
-            // leave None and let evidence-returning hooks (gateway path)
-            // fill it in when they exist.
-            None,
+            // Honest forwarding of whatever downstream handle the executing
+            // service published on `EffectResult.receipt_ref`. For SDIS
+            // AppointSteward / RevokeSteward / ReconfirmSteward this is the
+            // content-addressed `StewardId::to_hex()` minted by the commons
+            // layer. `None` when the service layer had no downstream handle
+            // to attribute (failure, no-op revoke, non-evidence-producing
+            // effects). No synthesis — what you see here is what the
+            // executor actually produced.
+            result.receipt_ref.clone(),
             result.success,
             error_message,
             recorded_at,

--- a/icn/apps/governance/tests/actor_path_dispatch_evidence_sink.rs
+++ b/icn/apps/governance/tests/actor_path_dispatch_evidence_sink.rs
@@ -173,6 +173,35 @@ fn ok_result(effect_id: &str) -> EffectResult {
         state_change_hash: Some("state-hash-abc".into()),
         ledger_entry_id: None,
         not_executed: false,
+        receipt_ref: None,
+    }
+}
+
+/// Successful result carrying a downstream receipt_ref, emulating what
+/// `SdisServiceImpl::appoint_steward` now publishes (the commons
+/// `StewardId::to_hex()`).
+fn ok_result_with_receipt_ref(effect_id: &str, receipt_ref: &str) -> EffectResult {
+    EffectResult {
+        effect_id: effect_id.into(),
+        success: true,
+        message: "approved".into(),
+        state_change_hash: Some("state-hash-abc".into()),
+        ledger_entry_id: None,
+        not_executed: false,
+        receipt_ref: Some(receipt_ref.into()),
+    }
+}
+
+/// Hard-failure result: no success, no downstream handle minted.
+fn failure_result(effect_id: &str, message: &str) -> EffectResult {
+    EffectResult {
+        effect_id: effect_id.into(),
+        success: false,
+        message: message.into(),
+        state_change_hash: None,
+        ledger_entry_id: None,
+        not_executed: false,
+        receipt_ref: None,
     }
 }
 
@@ -352,6 +381,7 @@ async fn sink_skips_noop_effects() {
         state_change_hash: None,
         ledger_entry_id: None,
         not_executed: true,
+        receipt_ref: None,
     }];
     sink.record_effects(
         "gov:domain-x:prop-noop:receipt",
@@ -380,6 +410,173 @@ async fn sink_rejects_malformed_receipt_id() {
     sink.record_effects("not-a-governance-id", &effects, &results, 1_700_000_000);
 
     assert!(backend.evidence_for("anything").is_empty());
+}
+
+// =============================================================================
+// Evidence-fidelity: receipt_ref carries the downstream service handle
+// =============================================================================
+//
+// These three tests pin the Phase-2b seam: `EffectResult.receipt_ref`, set
+// by the executing service (`SdisServiceImpl` publishes the commons
+// `StewardId::to_hex()`), is forwarded verbatim into
+// `EffectDispatchEvidence.receipt_ref`. This is what restores the durable
+// steward-handle trail we lost when the gateway HTTP hook was removed,
+// without reintroducing a second dispatch owner.
+
+/// Successful AppointSteward: receipt_ref from the service result must
+/// appear on the persisted evidence row exactly as produced.
+#[tokio::test(flavor = "current_thread")]
+async fn appoint_steward_evidence_carries_service_receipt_ref() {
+    let backend = Arc::new(MemoryReceiptBackend::new());
+    let ier = InstitutionalEffectRecord::new(
+        "prop-appoint-rref",
+        "coop",
+        None,
+        "appoint_steward",
+        Some("did:icn:steward-a".into()),
+        Some("region-a".into()),
+        None,
+        1,
+        serde_json::json!({}),
+    );
+    backend.put_institutional_effect(&ier).unwrap();
+
+    let sink =
+        GovernanceDispatchEvidenceSink::new(backend.clone() as Arc<dyn GovernanceReceiptBackend>);
+
+    let candidate: icn_identity::Did = IdentityBundle::generate().unwrap().did().clone();
+    let effects = vec![sdis_approve_effect(&candidate, "prop-appoint-rref")];
+    // The real commons handle minted by register_steward — content-addressed,
+    // 64-hex-chars. We pass a representative literal; the sink must forward
+    // it verbatim without interpreting or rewriting.
+    let steward_id_hex =
+        "b1946ac92492d2347c6235b4d2611184dc2e8d6b6fbe7d42a3a0b4e9ef6e2a11".to_string();
+    let results = vec![ok_result_with_receipt_ref("eff-appoint", &steward_id_hex)];
+
+    sink.record_effects(
+        "gov:domain-a:prop-appoint-rref:receipt",
+        &effects,
+        &results,
+        1_700_010_000,
+    );
+
+    let ev = backend.evidence_for("prop-appoint-rref");
+    assert_eq!(
+        ev.len(),
+        1,
+        "single-owner invariant: exactly one evidence row for one dispatch"
+    );
+    assert_eq!(
+        ev[0].receipt_ref,
+        Some(steward_id_hex),
+        "sink must forward EffectResult.receipt_ref verbatim; no synthesis"
+    );
+    assert_eq!(ev[0].effect_record_id, ier.record_id);
+    assert_eq!(ev[0].subsystem, "sdis");
+    assert!(ev[0].success);
+    assert!(ev[0].error_message.is_none());
+}
+
+/// Successful RevokeSteward: same seam. Distinct data shape from appoint
+/// because the service looks up the steward record and publishes its id.
+#[tokio::test(flavor = "current_thread")]
+async fn revoke_steward_evidence_carries_service_receipt_ref() {
+    let backend = Arc::new(MemoryReceiptBackend::new());
+    let ier = InstitutionalEffectRecord::new(
+        "prop-revoke-rref",
+        "coop",
+        None,
+        "revoke_steward",
+        Some("did:icn:steward-b".into()),
+        None,
+        None,
+        1,
+        serde_json::json!({}),
+    );
+    backend.put_institutional_effect(&ier).unwrap();
+
+    let sink =
+        GovernanceDispatchEvidenceSink::new(backend.clone() as Arc<dyn GovernanceReceiptBackend>);
+
+    let candidate: icn_identity::Did = IdentityBundle::generate().unwrap().did().clone();
+    // RevokeSteward is a distinct effect shape — build it directly.
+    let effects = vec![KernelEffect::Sdis(
+        icn_kernel_api::effects::SdisEffect::RevokeSteward {
+            steward_did: candidate.to_string(),
+            reason: "term ended".into(),
+        },
+    )];
+    let steward_id_hex =
+        "a0b4e9ef6e2a11b1946ac92492d2347c6235b4d2611184dc2e8d6b6fbe7d42a3".to_string();
+    let results = vec![ok_result_with_receipt_ref("eff-revoke", &steward_id_hex)];
+
+    sink.record_effects(
+        "gov:domain-b:prop-revoke-rref:receipt",
+        &effects,
+        &results,
+        1_700_010_001,
+    );
+
+    let ev = backend.evidence_for("prop-revoke-rref");
+    assert_eq!(ev.len(), 1);
+    assert_eq!(
+        ev[0].receipt_ref,
+        Some(steward_id_hex),
+        "RevokeSteward must forward the service-layer steward_id the revoke was routed through"
+    );
+    assert_eq!(ev[0].subsystem, "sdis");
+    assert!(ev[0].success);
+}
+
+/// Failure path: when the service produced no downstream handle
+/// (e.g. commons.register_steward failed, revoke hit an idempotent
+/// no-op with no active record), `receipt_ref` must remain `None` on
+/// the durable evidence row. No synthesis, no placeholders.
+#[tokio::test(flavor = "current_thread")]
+async fn failure_evidence_has_no_receipt_ref() {
+    let backend = Arc::new(MemoryReceiptBackend::new());
+    let ier = InstitutionalEffectRecord::new(
+        "prop-fail-rref",
+        "coop",
+        None,
+        "appoint_steward",
+        Some("did:icn:steward-c".into()),
+        Some("region-c".into()),
+        None,
+        1,
+        serde_json::json!({}),
+    );
+    backend.put_institutional_effect(&ier).unwrap();
+
+    let sink =
+        GovernanceDispatchEvidenceSink::new(backend.clone() as Arc<dyn GovernanceReceiptBackend>);
+
+    let candidate: icn_identity::Did = IdentityBundle::generate().unwrap().did().clone();
+    let effects = vec![sdis_approve_effect(&candidate, "prop-fail-rref")];
+    let results = vec![failure_result(
+        "eff-fail",
+        "commons.register_steward failed",
+    )];
+
+    sink.record_effects(
+        "gov:domain-c:prop-fail-rref:receipt",
+        &effects,
+        &results,
+        1_700_010_002,
+    );
+
+    let ev = backend.evidence_for("prop-fail-rref");
+    assert_eq!(ev.len(), 1);
+    assert_eq!(
+        ev[0].receipt_ref, None,
+        "failure paths must truthfully leave receipt_ref unset"
+    );
+    assert!(!ev[0].success);
+    assert_eq!(
+        ev[0].error_message.as_deref(),
+        Some("commons.register_steward failed"),
+        "error_message still carries the service-layer diagnostic"
+    );
 }
 
 /// Regression pin for the Phase-2 single-ownership decision.

--- a/icn/apps/governance/tests/actor_path_dispatch_evidence_sink.rs
+++ b/icn/apps/governance/tests/actor_path_dispatch_evidence_sink.rs
@@ -528,6 +528,76 @@ async fn revoke_steward_evidence_carries_service_receipt_ref() {
     assert!(ev[0].success);
 }
 
+/// No-op revoke (success + no downstream handle) must be persisted as a
+/// distinct durable row from a real revocation: `success = true` with
+/// `receipt_ref = None` and no `error_message`. This is what the
+/// kernel executor's no-op branch now emits when the service reports
+/// `receipt_ref = None` on the success path.
+#[tokio::test(flavor = "current_thread")]
+async fn revoke_steward_noop_evidence_has_no_receipt_ref_but_is_success() {
+    let backend = Arc::new(MemoryReceiptBackend::new());
+    let ier = InstitutionalEffectRecord::new(
+        "prop-revoke-noop",
+        "coop",
+        None,
+        "revoke_steward",
+        Some("did:icn:steward-ghost".into()),
+        None,
+        None,
+        1,
+        serde_json::json!({}),
+    );
+    backend.put_institutional_effect(&ier).unwrap();
+
+    let sink =
+        GovernanceDispatchEvidenceSink::new(backend.clone() as Arc<dyn GovernanceReceiptBackend>);
+
+    let candidate: icn_identity::Did = IdentityBundle::generate().unwrap().did().clone();
+    let effects = vec![KernelEffect::Sdis(
+        icn_kernel_api::effects::SdisEffect::RevokeSteward {
+            steward_did: candidate.to_string(),
+            reason: "never was steward".into(),
+        },
+    )];
+    // Emulates what the kernel executor now produces for the no-op
+    // branch: success=true, state_change_hash=None, receipt_ref=None.
+    let results = vec![EffectResult {
+        effect_id: "eff-revoke-noop".into(),
+        success: true,
+        message: format!(
+            "Steward {} revoke was a no-op (no active record)",
+            candidate
+        ),
+        state_change_hash: None,
+        ledger_entry_id: None,
+        not_executed: false,
+        receipt_ref: None,
+    }];
+
+    sink.record_effects(
+        "gov:domain-b:prop-revoke-noop:receipt",
+        &effects,
+        &results,
+        1_700_010_003,
+    );
+
+    let ev = backend.evidence_for("prop-revoke-noop");
+    assert_eq!(ev.len(), 1);
+    assert!(
+        ev[0].success,
+        "no-op revoke is a success at the governance layer — it satisfies the decision idempotently"
+    );
+    assert_eq!(
+        ev[0].receipt_ref, None,
+        "no active record → no handle to attribute → receipt_ref must stay None"
+    );
+    assert!(
+        ev[0].error_message.is_none(),
+        "no-op is not a failure; error_message must be None so audit can \
+         distinguish it from a hard commons failure"
+    );
+}
+
 /// Failure path: when the service produced no downstream handle
 /// (e.g. commons.register_steward failed, revoke hit an idempotent
 /// no-op with no active record), `receipt_ref` must remain `None` on

--- a/icn/crates/icn-core/src/services/sdis_service.rs
+++ b/icn/crates/icn-core/src/services/sdis_service.rs
@@ -155,11 +155,11 @@ impl SdisService for SdisServiceImpl {
         let steward_did = icn_identity::Did::from_str(&request.steward_did)
             .map_err(|e| anyhow::anyhow!("Invalid steward DID '{}': {}", request.steward_did, e))?;
 
-        // Returns (success, Option<steward_id>): the steward_id is the
-        // commons handle we routed the revoke through. `None` means the
-        // idempotent no-op case (no active record existed) — honestly
-        // reflected in receipt_ref below.
-        let result: Result<(bool, Option<String>)> = tokio::task::block_in_place(|| {
+        // Returns `Some(steward_id)` when the revoke was routed through a
+        // real commons handle; `None` when no active record existed and this
+        // is an idempotent no-op. The inner `Result` disambiguates success
+        // from commons failure — we do not need a separate bool.
+        let result: Result<Option<String>> = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
                 match self.commons.get_steward_by_did(&steward_did).await {
                     Ok(Some(record)) => {
@@ -167,7 +167,7 @@ impl SdisService for SdisServiceImpl {
                         self.commons
                             .revoke_steward(&steward_id, request.reason.clone(), vec![])
                             .await
-                            .map(|_| (true, Some(steward_id)))
+                            .map(|_| Some(steward_id))
                     }
                     Ok(None) => {
                         // No record found — idempotent no-op. No steward_id
@@ -176,7 +176,7 @@ impl SdisService for SdisServiceImpl {
                             steward_did = %request.steward_did,
                             "RevokeSteward: no active steward record found, treating as no-op"
                         );
-                        Ok((true, None))
+                        Ok(None)
                     }
                     Err(e) => Err(e),
                 }
@@ -184,20 +184,37 @@ impl SdisService for SdisServiceImpl {
         });
 
         match result {
-            Ok((_, receipt_ref)) => {
-                let state_change_hash = Self::compute_revoke_hash(&request);
-                info!(
-                    steward_did = %request.steward_did,
-                    state_change_hash = %state_change_hash,
-                    receipt_ref = ?receipt_ref,
-                    "Steward revoked in commons"
-                );
-                Ok(RevokeStewardResult {
-                    success: true,
-                    state_change_hash,
-                    error: None,
-                    receipt_ref,
-                })
+            Ok(receipt_ref) => {
+                // Only count a real revoke as state-changing. The no-op
+                // (no active record) branch keeps `state_change_hash`
+                // empty so downstream audit surfaces can distinguish a
+                // genuine revocation from an idempotent repeat.
+                if receipt_ref.is_some() {
+                    let state_change_hash = Self::compute_revoke_hash(&request);
+                    info!(
+                        steward_did = %request.steward_did,
+                        state_change_hash = %state_change_hash,
+                        receipt_ref = ?receipt_ref,
+                        "Steward revoked in commons"
+                    );
+                    Ok(RevokeStewardResult {
+                        success: true,
+                        state_change_hash,
+                        error: None,
+                        receipt_ref,
+                    })
+                } else {
+                    info!(
+                        steward_did = %request.steward_did,
+                        "Steward revoke was a no-op in commons (no active record)"
+                    );
+                    Ok(RevokeStewardResult {
+                        success: true,
+                        state_change_hash: String::new(),
+                        error: None,
+                        receipt_ref: None,
+                    })
+                }
             }
             Err(e) => {
                 tracing::warn!(
@@ -687,6 +704,15 @@ mod tests {
         assert_eq!(
             revoke.receipt_ref, None,
             "no active record → no handle to attribute → receipt_ref must remain None"
+        );
+        assert!(
+            revoke.state_change_hash.is_empty(),
+            "no-op revoke must not claim a state_change_hash — audit must be able \
+             to distinguish a real revocation from an idempotent no-op"
+        );
+        assert!(
+            revoke.error.is_none(),
+            "no-op revoke is a success, not a failure; error must be None"
         );
     }
 

--- a/icn/crates/icn-core/src/services/sdis_service.rs
+++ b/icn/crates/icn-core/src/services/sdis_service.rs
@@ -113,17 +113,20 @@ impl SdisService for SdisServiceImpl {
         });
 
         match result {
-            Ok(_record) => {
+            Ok(record) => {
                 let state_change_hash = Self::compute_appoint_hash(&request);
+                let steward_id = record.id().to_hex();
                 info!(
                     steward_did = %request.steward_did,
                     state_change_hash = %state_change_hash,
+                    steward_id = %steward_id,
                     "Steward appointed and registered in commons"
                 );
                 Ok(AppointStewardResult {
                     success: true,
                     state_change_hash,
                     error: None,
+                    receipt_ref: Some(steward_id),
                 })
             }
             Err(e) => {
@@ -136,6 +139,7 @@ impl SdisService for SdisServiceImpl {
                     success: false,
                     state_change_hash: String::new(),
                     error: Some(e.to_string()),
+                    receipt_ref: None,
                 })
             }
         }
@@ -151,24 +155,28 @@ impl SdisService for SdisServiceImpl {
         let steward_did = icn_identity::Did::from_str(&request.steward_did)
             .map_err(|e| anyhow::anyhow!("Invalid steward DID '{}': {}", request.steward_did, e))?;
 
-        let result = tokio::task::block_in_place(|| {
+        // Returns (success, Option<steward_id>): the steward_id is the
+        // commons handle we routed the revoke through. `None` means the
+        // idempotent no-op case (no active record existed) — honestly
+        // reflected in receipt_ref below.
+        let result: Result<(bool, Option<String>)> = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
-                // Look up by DID first, then revoke by record ID
                 match self.commons.get_steward_by_did(&steward_did).await {
                     Ok(Some(record)) => {
                         let steward_id = record.id().to_hex();
                         self.commons
                             .revoke_steward(&steward_id, request.reason.clone(), vec![])
                             .await
-                            .map(|_| true)
+                            .map(|_| (true, Some(steward_id)))
                     }
                     Ok(None) => {
-                        // No record found — idempotent no-op
+                        // No record found — idempotent no-op. No steward_id
+                        // to attribute to this revoke.
                         tracing::debug!(
                             steward_did = %request.steward_did,
                             "RevokeSteward: no active steward record found, treating as no-op"
                         );
-                        Ok(true)
+                        Ok((true, None))
                     }
                     Err(e) => Err(e),
                 }
@@ -176,17 +184,19 @@ impl SdisService for SdisServiceImpl {
         });
 
         match result {
-            Ok(_) => {
+            Ok((_, receipt_ref)) => {
                 let state_change_hash = Self::compute_revoke_hash(&request);
                 info!(
                     steward_did = %request.steward_did,
                     state_change_hash = %state_change_hash,
+                    receipt_ref = ?receipt_ref,
                     "Steward revoked in commons"
                 );
                 Ok(RevokeStewardResult {
                     success: true,
                     state_change_hash,
                     error: None,
+                    receipt_ref,
                 })
             }
             Err(e) => {
@@ -199,6 +209,7 @@ impl SdisService for SdisServiceImpl {
                     success: false,
                     state_change_hash: String::new(),
                     error: Some(e.to_string()),
+                    receipt_ref: None,
                 })
             }
         }
@@ -218,7 +229,7 @@ impl SdisService for SdisServiceImpl {
         let steward_did = icn_identity::Did::from_str(&request.steward_did)
             .map_err(|e| anyhow::anyhow!("Invalid steward DID '{}': {}", request.steward_did, e))?;
 
-        let result = tokio::task::block_in_place(|| {
+        let result: Result<Option<String>> = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
                 match self.commons.get_steward_by_did(&steward_did).await {
                     Ok(Some(record)) => {
@@ -226,7 +237,7 @@ impl SdisService for SdisServiceImpl {
                         self.commons
                             .extend_steward_term(&steward_id, request.new_term_end)
                             .await
-                            .map(|_| true)
+                            .map(|_| Some(steward_id))
                     }
                     Ok(None) => {
                         tracing::warn!(
@@ -244,18 +255,20 @@ impl SdisService for SdisServiceImpl {
         });
 
         match result {
-            Ok(_) => {
+            Ok(receipt_ref) => {
                 let state_change_hash = Self::compute_reconfirm_hash(&request);
                 info!(
                     steward_did = %request.steward_did,
                     new_term_end = %request.new_term_end,
                     state_change_hash = %state_change_hash,
+                    receipt_ref = ?receipt_ref,
                     "Steward term extended in commons"
                 );
                 Ok(ReconfirmStewardResult {
                     success: true,
                     state_change_hash,
                     error: None,
+                    receipt_ref,
                 })
             }
             Err(e) => {
@@ -268,6 +281,7 @@ impl SdisService for SdisServiceImpl {
                     success: false,
                     state_change_hash: String::new(),
                     error: Some(e.to_string()),
+                    receipt_ref: None,
                 })
             }
         }
@@ -554,14 +568,22 @@ mod tests {
         assert!(result.error.is_none());
 
         // Verify the steward record is now present in commons
-        let found = commons
+        let record = commons
             .get_steward_by_did(&holder)
             .await
             .expect("get_steward_by_did must not error")
-            .is_some();
-        assert!(
-            found,
-            "steward must be present in commons after appointment"
+            .expect("steward must be present in commons after appointment");
+
+        // Evidence-fidelity seam: the service must publish the commons
+        // StewardId::to_hex() as receipt_ref so the dispatch-evidence sink
+        // can persist it verbatim (see
+        // `apps/governance/tests/actor_path_dispatch_evidence_sink.rs`).
+        let expected_receipt_ref = record.id().to_hex();
+        assert_eq!(
+            result.receipt_ref,
+            Some(expected_receipt_ref),
+            "AppointStewardResult.receipt_ref must equal the commons StewardId::to_hex() \
+             so kernel-path dispatch evidence carries the real downstream handle"
         );
     }
 
@@ -586,11 +608,21 @@ mod tests {
         };
         let appoint = svc.appoint_steward(appoint_req).unwrap();
         assert!(appoint.success, "appoint must succeed");
+        let appoint_receipt_ref = appoint
+            .receipt_ref
+            .clone()
+            .expect("AppointStewardResult must publish receipt_ref on success");
 
         // Confirm presence before revoke
-        assert!(
-            commons.get_steward_by_did(&holder).await.unwrap().is_some(),
-            "steward must exist before revocation"
+        let record_before = commons
+            .get_steward_by_did(&holder)
+            .await
+            .unwrap()
+            .expect("steward must exist before revocation");
+        assert_eq!(
+            record_before.id().to_hex(),
+            appoint_receipt_ref,
+            "appoint receipt_ref must match the commons StewardId of the record the service created"
         );
 
         let revoke_req = RevokeStewardRequest {
@@ -600,8 +632,21 @@ mod tests {
         let revoke = svc.revoke_steward(revoke_req).unwrap();
         assert!(revoke.success, "revoke_steward should succeed");
         assert!(!revoke.state_change_hash.is_empty());
+        // Evidence-fidelity seam: revoke publishes the same steward_id it
+        // routed through — the handle the revoke operation actually used.
+        assert_eq!(
+            revoke.receipt_ref,
+            Some(appoint_receipt_ref),
+            "RevokeStewardResult.receipt_ref must be the steward_id the revoke was routed through"
+        );
 
-        // Idempotent second revoke must succeed (no-op on missing record)
+        // Idempotent second revoke must succeed. Because commons retains
+        // revoked records (get_steward_by_did does not filter by active
+        // status), the service still has a real handle to attribute the
+        // repeat revoke to — so receipt_ref remains Some(steward_id).
+        // The honestly-None path is exercised by
+        // `test_revoke_missing_steward_is_noop_with_no_receipt_ref` below,
+        // where no record ever existed.
         let idempotent = svc
             .revoke_steward(RevokeStewardRequest {
                 steward_did: steward_did_str,
@@ -611,6 +656,37 @@ mod tests {
         assert!(
             idempotent.success,
             "second revoke is a no-op and must succeed"
+        );
+        assert!(
+            idempotent.receipt_ref.is_some(),
+            "idempotent repeat revoke still routes through the retained record; \
+             receipt_ref must still point at that steward_id"
+        );
+    }
+
+    /// RevokeSteward against a DID that was never registered → no active
+    /// record → service returns success (idempotent no-op) but must truthfully
+    /// leave `receipt_ref` as `None` because there is no downstream handle
+    /// to attribute.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_revoke_missing_steward_is_noop_with_no_receipt_ref() {
+        let (svc, _commons) = make_service_with_commons();
+        let unknown = test_did(77);
+
+        let revoke = svc
+            .revoke_steward(RevokeStewardRequest {
+                steward_did: unknown.to_string(),
+                reason: "never appointed".to_string(),
+            })
+            .unwrap();
+
+        assert!(
+            revoke.success,
+            "revoke of a non-existent steward must succeed as an idempotent no-op"
+        );
+        assert_eq!(
+            revoke.receipt_ref, None,
+            "no active record → no handle to attribute → receipt_ref must remain None"
         );
     }
 

--- a/icn/crates/icn-core/src/services/state_hash.rs
+++ b/icn/crates/icn-core/src/services/state_hash.rs
@@ -447,6 +447,7 @@ mod tests {
                 state_change_hash: Some("hash_t".into()),
                 ledger_entry_id: None,
                 not_executed: false,
+                receipt_ref: None,
             },
             EffectResult {
                 effect_id: "membership_0".into(),
@@ -455,6 +456,7 @@ mod tests {
                 state_change_hash: Some("hash_m".into()),
                 ledger_entry_id: None,
                 not_executed: false,
+                receipt_ref: None,
             },
             EffectResult {
                 effect_id: "no_hash".into(),
@@ -463,6 +465,7 @@ mod tests {
                 state_change_hash: None,
                 ledger_entry_id: None,
                 not_executed: false,
+                receipt_ref: None,
             },
         ];
 
@@ -481,6 +484,7 @@ mod tests {
             state_change_hash: Some("same_hash".into()),
             ledger_entry_id: None,
             not_executed: false,
+            receipt_ref: None,
         }];
 
         let results_b = vec![EffectResult {
@@ -490,6 +494,7 @@ mod tests {
             state_change_hash: Some("same_hash".into()),
             ledger_entry_id: None,
             not_executed: false,
+            receipt_ref: None,
         }];
 
         assert!(verify_effect_results_match(&results_a, &results_b));
@@ -504,6 +509,7 @@ mod tests {
             state_change_hash: Some("hash_a".into()),
             ledger_entry_id: None,
             not_executed: false,
+            receipt_ref: None,
         }];
 
         let results_b = vec![EffectResult {
@@ -513,6 +519,7 @@ mod tests {
             state_change_hash: Some("hash_b".into()),
             ledger_entry_id: None,
             not_executed: false,
+            receipt_ref: None,
         }];
 
         let comparison = compare_effect_results(&results_a, &results_b);

--- a/icn/crates/icn-core/src/supervisor/effect_dispatcher.rs
+++ b/icn/crates/icn-core/src/supervisor/effect_dispatcher.rs
@@ -118,6 +118,7 @@ impl EffectDispatcher {
                         state_change_hash: None,
                         ledger_entry_id: None,
                         not_executed: false,
+                        receipt_ref: None,
                     };
                     row.debug_assert_semantic_invariants();
                     results.push(row);

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -2221,23 +2221,46 @@ impl KernelSdisExecutor {
                 };
                 let result = service.revoke_steward(request)?;
                 if result.success {
-                    info!(
-                        state_change_hash = %result.state_change_hash,
-                        receipt_ref = ?result.receipt_ref,
-                        "Steward revoked with durable state"
-                    );
-                    Ok(EffectResult {
-                        effect_id: decision_receipt_id.to_string(),
-                        success: true,
-                        message: format!(
-                            "Steward {} revoked -> state_hash={}",
-                            steward_did, result.state_change_hash
-                        ),
-                        state_change_hash: Some(result.state_change_hash),
-                        ledger_entry_id: None,
-                        not_executed: false,
-                        receipt_ref: result.receipt_ref,
-                    })
+                    // Distinguish a genuine revocation from an idempotent
+                    // no-op. `receipt_ref = Some(steward_id)` means the
+                    // service actually routed through a commons record;
+                    // `None` means there was no active record to revoke.
+                    if result.receipt_ref.is_some() {
+                        info!(
+                            state_change_hash = %result.state_change_hash,
+                            receipt_ref = ?result.receipt_ref,
+                            "Steward revoked with durable state"
+                        );
+                        Ok(EffectResult {
+                            effect_id: decision_receipt_id.to_string(),
+                            success: true,
+                            message: format!(
+                                "Steward {} revoked -> state_hash={}",
+                                steward_did, result.state_change_hash
+                            ),
+                            state_change_hash: Some(result.state_change_hash),
+                            ledger_entry_id: None,
+                            not_executed: false,
+                            receipt_ref: result.receipt_ref,
+                        })
+                    } else {
+                        info!(
+                            steward_did = %steward_did,
+                            "Steward revoke dispatched as no-op (no active record)"
+                        );
+                        Ok(EffectResult {
+                            effect_id: decision_receipt_id.to_string(),
+                            success: true,
+                            message: format!(
+                                "Steward {} revoke was a no-op (no active record)",
+                                steward_did
+                            ),
+                            state_change_hash: None,
+                            ledger_entry_id: None,
+                            not_executed: false,
+                            receipt_ref: None,
+                        })
+                    }
                 } else {
                     Ok(EffectResult {
                         effect_id: decision_receipt_id.to_string(),

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -169,6 +169,7 @@ impl KernelGovernanceExecutor {
                                 state_change_hash: None,
                                 ledger_entry_id: None,
                                 not_executed: false,
+                                receipt_ref: None,
                             });
                         }
                     }
@@ -229,6 +230,7 @@ impl KernelGovernanceExecutor {
                             state_change_hash: None,
                             ledger_entry_id: None,
                             not_executed: false,
+                            receipt_ref: None,
                         });
                     }
                 };
@@ -243,6 +245,7 @@ impl KernelGovernanceExecutor {
                             state_change_hash: None,
                             ledger_entry_id: None,
                             not_executed: false,
+                            receipt_ref: None,
                         });
                     }
                 };
@@ -266,6 +269,7 @@ impl KernelGovernanceExecutor {
                             state_change_hash: None,
                             ledger_entry_id: None,
                             not_executed: false,
+                            receipt_ref: None,
                         });
                     }
                     Err(e) => {
@@ -281,6 +285,7 @@ impl KernelGovernanceExecutor {
                             state_change_hash: None,
                             ledger_entry_id: None,
                             not_executed: false,
+                            receipt_ref: None,
                         });
                     }
                 }
@@ -399,6 +404,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                             state_change_hash: None,
                             ledger_entry_id: None,
                             not_executed: false,
+                            receipt_ref: None,
                         });
                     }
                 };
@@ -418,6 +424,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                             state_change_hash: None,
                             ledger_entry_id: None,
                             not_executed: false,
+                            receipt_ref: None,
                         });
                     }
                 };
@@ -460,6 +467,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                             state_change_hash: None,
                             ledger_entry_id: None,
                             not_executed: false,
+                            receipt_ref: None,
                         });
                     }
                     Err(EscrowReleaseError::AlreadyReleasedByOther {
@@ -481,6 +489,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                             state_change_hash: None,
                             ledger_entry_id: None,
                             not_executed: false,
+                            receipt_ref: None,
                         });
                     }
                     Err(EscrowReleaseError::Cancelled) => {
@@ -495,6 +504,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                             state_change_hash: None,
                             ledger_entry_id: None,
                             not_executed: false,
+                            receipt_ref: None,
                         });
                     }
                     Err(EscrowReleaseError::Failed {
@@ -518,6 +528,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                             state_change_hash: None,
                             ledger_entry_id: None,
                             not_executed: false,
+                            receipt_ref: None,
                         });
                     }
                 }
@@ -611,6 +622,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                         state_change_hash: None,
                         ledger_entry_id: None,
                         not_executed: false,
+                        receipt_ref: None,
                     })
                 }
             }
@@ -641,6 +653,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                     state_change_hash: None,
                     ledger_entry_id: None,
                     not_executed: true,
+                    receipt_ref: None,
                 })
             }
             KernelEffect::Control(control_effect) => {
@@ -680,6 +693,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                     state_change_hash: None,
                     ledger_entry_id: None,
                     not_executed: false,
+                    receipt_ref: None,
                 })
             }
             KernelEffect::Resource(resource_effect) => {
@@ -714,6 +728,7 @@ impl KernelGovernanceExecutor {
                     state_change_hash: None,
                     ledger_entry_id: None,
                     not_executed: false,
+                    receipt_ref: None,
                 });
             }
         };
@@ -757,6 +772,7 @@ impl KernelGovernanceExecutor {
                         state_change_hash: Some(access_model_hash.clone()),
                         ledger_entry_id: None,
                         not_executed: false,
+                        receipt_ref: None,
                     }),
                     Err(e) => Ok(EffectResult {
                         effect_id: decision_receipt_id.to_string(),
@@ -765,6 +781,7 @@ impl KernelGovernanceExecutor {
                         state_change_hash: None,
                         ledger_entry_id: None,
                         not_executed: false,
+                        receipt_ref: None,
                     }),
                 }
             }
@@ -788,6 +805,7 @@ impl KernelGovernanceExecutor {
                         state_change_hash: None,
                         ledger_entry_id: None,
                         not_executed: false,
+                        receipt_ref: None,
                     }),
                     Err(e) => Ok(EffectResult {
                         effect_id: decision_receipt_id.to_string(),
@@ -796,6 +814,7 @@ impl KernelGovernanceExecutor {
                         state_change_hash: None,
                         ledger_entry_id: None,
                         not_executed: false,
+                        receipt_ref: None,
                     }),
                 }
             }
@@ -1644,6 +1663,7 @@ fn execution_outcome_to_effect_result(outcome: ExecutionOutcome, effect_id: &str
                 state_change_hash,
                 ledger_entry_id,
                 not_executed: false,
+                receipt_ref: None,
             }
         }
         ExecutionOutcome::Failed { reason, .. } => EffectResult {
@@ -1653,6 +1673,7 @@ fn execution_outcome_to_effect_result(outcome: ExecutionOutcome, effect_id: &str
             state_change_hash: None,
             ledger_entry_id: None,
             not_executed: false,
+            receipt_ref: None,
         },
         ExecutionOutcome::Deferred { reason, .. } => EffectResult {
             effect_id: effect_id.to_string(),
@@ -1661,6 +1682,7 @@ fn execution_outcome_to_effect_result(outcome: ExecutionOutcome, effect_id: &str
             state_change_hash: None,
             ledger_entry_id: None,
             not_executed: true,
+            receipt_ref: None,
         },
     }
 }
@@ -2134,6 +2156,7 @@ impl KernelSdisExecutor {
                 state_change_hash: None,
                 ledger_entry_id: None,
                 not_executed: false,
+                receipt_ref: None,
             });
         };
 
@@ -2159,6 +2182,7 @@ impl KernelSdisExecutor {
                 if result.success {
                     info!(
                         state_change_hash = %result.state_change_hash,
+                        receipt_ref = ?result.receipt_ref,
                         "Steward appointed with durable state"
                     );
                     Ok(EffectResult {
@@ -2171,6 +2195,7 @@ impl KernelSdisExecutor {
                         state_change_hash: Some(result.state_change_hash),
                         ledger_entry_id: None,
                         not_executed: false,
+                        receipt_ref: result.receipt_ref,
                     })
                 } else {
                     Ok(EffectResult {
@@ -2182,6 +2207,7 @@ impl KernelSdisExecutor {
                         state_change_hash: None,
                         ledger_entry_id: None,
                         not_executed: false,
+                        receipt_ref: None,
                     })
                 }
             }
@@ -2197,6 +2223,7 @@ impl KernelSdisExecutor {
                 if result.success {
                     info!(
                         state_change_hash = %result.state_change_hash,
+                        receipt_ref = ?result.receipt_ref,
                         "Steward revoked with durable state"
                     );
                     Ok(EffectResult {
@@ -2209,6 +2236,7 @@ impl KernelSdisExecutor {
                         state_change_hash: Some(result.state_change_hash),
                         ledger_entry_id: None,
                         not_executed: false,
+                        receipt_ref: result.receipt_ref,
                     })
                 } else {
                     Ok(EffectResult {
@@ -2220,6 +2248,7 @@ impl KernelSdisExecutor {
                         state_change_hash: None,
                         ledger_entry_id: None,
                         not_executed: false,
+                        receipt_ref: None,
                     })
                 }
             }
@@ -2237,6 +2266,7 @@ impl KernelSdisExecutor {
                 if result.success {
                     info!(
                         state_change_hash = %result.state_change_hash,
+                        receipt_ref = ?result.receipt_ref,
                         "Steward term extended with durable state"
                     );
                     Ok(EffectResult {
@@ -2249,6 +2279,7 @@ impl KernelSdisExecutor {
                         state_change_hash: Some(result.state_change_hash),
                         ledger_entry_id: None,
                         not_executed: false,
+                        receipt_ref: result.receipt_ref,
                     })
                 } else {
                     Ok(EffectResult {
@@ -2260,6 +2291,7 @@ impl KernelSdisExecutor {
                         state_change_hash: None,
                         ledger_entry_id: None,
                         not_executed: false,
+                        receipt_ref: None,
                     })
                 }
             }
@@ -2306,6 +2338,7 @@ impl KernelSdisExecutor {
                         },
                         ledger_entry_id: None,
                         not_executed: false,
+                        receipt_ref: None,
                     })
                 } else {
                     Ok(EffectResult {
@@ -2317,6 +2350,7 @@ impl KernelSdisExecutor {
                         state_change_hash: None,
                         ledger_entry_id: None,
                         not_executed: false,
+                        receipt_ref: None,
                     })
                 }
             }
@@ -2351,6 +2385,7 @@ impl KernelSdisExecutor {
                         state_change_hash: Some(result.state_change_hash),
                         ledger_entry_id: None,
                         not_executed: false,
+                        receipt_ref: None,
                     })
                 } else {
                     Ok(EffectResult {
@@ -2362,6 +2397,7 @@ impl KernelSdisExecutor {
                         state_change_hash: None,
                         ledger_entry_id: None,
                         not_executed: false,
+                        receipt_ref: None,
                     })
                 }
             }
@@ -2398,6 +2434,7 @@ impl KernelSdisExecutor {
                         state_change_hash: Some(result.state_change_hash),
                         ledger_entry_id: None,
                         not_executed: false,
+                        receipt_ref: None,
                     })
                 } else {
                     Ok(EffectResult {
@@ -2409,6 +2446,7 @@ impl KernelSdisExecutor {
                         state_change_hash: None,
                         ledger_entry_id: None,
                         not_executed: false,
+                        receipt_ref: None,
                     })
                 }
             }

--- a/icn/crates/icn-core/tests/federated_two_node_pilot.rs
+++ b/icn/crates/icn-core/tests/federated_two_node_pilot.rs
@@ -730,6 +730,7 @@ async fn test_two_node_effect_batch_determinism() -> Result<()> {
                             state_change_hash: extract_state_hash_from_effects(&effects),
                             ledger_entry_id: None,
                             not_executed: false,
+                            receipt_ref: None,
                         }
                     }
                     _ => panic!("Batch effect failed on Node A"),
@@ -745,6 +746,7 @@ async fn test_two_node_effect_batch_determinism() -> Result<()> {
                 state_change_hash: None,
                 ledger_entry_id: None,
                 not_executed: true,
+                receipt_ref: None,
             },
             _ => panic!("Unexpected effect type in batch"),
         };
@@ -782,6 +784,7 @@ async fn test_two_node_effect_batch_determinism() -> Result<()> {
                             state_change_hash: extract_state_hash_from_effects(&effects),
                             ledger_entry_id: None,
                             not_executed: false,
+                            receipt_ref: None,
                         }
                     }
                     _ => panic!("Batch effect failed on Node B"),
@@ -797,6 +800,7 @@ async fn test_two_node_effect_batch_determinism() -> Result<()> {
                 state_change_hash: None,
                 ledger_entry_id: None,
                 not_executed: true,
+                receipt_ref: None,
             },
             _ => panic!("Unexpected effect type in batch"),
         };

--- a/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
+++ b/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
@@ -722,6 +722,7 @@ async fn test_e2e_appoint_steward_scoped_to_chartered_domain() {
                 success: true,
                 state_change_hash: String::new(),
                 error: None,
+                receipt_ref: None,
             })
         }
         fn revoke_steward(
@@ -732,6 +733,7 @@ async fn test_e2e_appoint_steward_scoped_to_chartered_domain() {
                 success: true,
                 state_change_hash: String::new(),
                 error: None,
+                receipt_ref: None,
             })
         }
         fn reconfirm_steward(
@@ -744,6 +746,7 @@ async fn test_e2e_appoint_steward_scoped_to_chartered_domain() {
                 success: true,
                 state_change_hash: String::new(),
                 error: None,
+                receipt_ref: None,
             })
         }
 

--- a/icn/crates/icn-kernel-api/src/effects.rs
+++ b/icn/crates/icn-kernel-api/src/effects.rs
@@ -528,6 +528,21 @@ pub struct EffectResult {
     /// execution failure at the decision level.
     #[serde(default)]
     pub not_executed: bool,
+    /// Opaque downstream identifier produced by the executing service, if any.
+    ///
+    /// Kernel-neutral: the kernel treats this as an opaque string — a content-addressed
+    /// record id, a ledger row handle, or whatever the executing service layer returned.
+    /// Populated by service implementations that have a real downstream handle to
+    /// expose (e.g. `SdisServiceImpl::appoint_steward` publishes the commons
+    /// `StewardId::to_hex()`). Left `None` when no such identifier exists
+    /// (failure paths, NoOp, effects whose services don't mint a handle).
+    ///
+    /// This field is what `GovernanceDispatchEvidenceSink` writes into
+    /// `EffectDispatchEvidence.receipt_ref`, so a richer service layer produces
+    /// a richer durable audit trail without any app-layer types crossing the
+    /// kernel boundary.
+    #[serde(default)]
+    pub receipt_ref: Option<String>,
 }
 
 impl EffectResult {
@@ -562,6 +577,11 @@ impl EffectResult {
             debug_assert!(
                 self.state_change_hash.is_none(),
                 "EffectResult: not_executed rows must not set state_change_hash (effect_id={})",
+                self.effect_id
+            );
+            debug_assert!(
+                self.receipt_ref.is_none(),
+                "EffectResult: not_executed rows must not set receipt_ref (effect_id={})",
                 self.effect_id
             );
         }
@@ -670,6 +690,7 @@ mod tests {
             state_change_hash: None,
             ledger_entry_id: None,
             not_executed: false,
+            receipt_ref: None,
         };
         assert!(hard.is_hard_failure());
         assert!(!hard.is_structurally_not_executed());
@@ -681,6 +702,7 @@ mod tests {
             state_change_hash: None,
             ledger_entry_id: None,
             not_executed: true,
+            receipt_ref: None,
         };
         assert!(!nx.is_hard_failure());
         assert!(nx.is_structurally_not_executed());
@@ -692,6 +714,7 @@ mod tests {
             state_change_hash: Some("h".into()),
             ledger_entry_id: Some("L1".into()),
             not_executed: false,
+            receipt_ref: None,
         };
         assert!(!ok.is_hard_failure());
         assert!(!ok.is_structurally_not_executed());
@@ -707,6 +730,7 @@ mod tests {
                 state_change_hash: None,
                 ledger_entry_id: None,
                 not_executed: true,
+                receipt_ref: None,
             },
             EffectResult {
                 effect_id: "b".into(),
@@ -715,6 +739,7 @@ mod tests {
                 state_change_hash: Some("x".into()),
                 ledger_entry_id: None,
                 not_executed: false,
+                receipt_ref: None,
             },
         ];
         for r in &rows {
@@ -934,6 +959,7 @@ mod tests {
                 state_change_hash: Some("statehash123".into()),
                 ledger_entry_id: Some("entry-123".into()),
                 not_executed: false,
+                receipt_ref: None,
             },
             EffectResult {
                 effect_id: "eff-2".into(),
@@ -942,6 +968,7 @@ mod tests {
                 state_change_hash: None,
                 ledger_entry_id: None,
                 not_executed: false,
+                receipt_ref: None,
             },
         ];
 

--- a/icn/crates/icn-kernel-api/src/governance.rs
+++ b/icn/crates/icn-kernel-api/src/governance.rs
@@ -264,6 +264,7 @@ impl EffectExecutor for DefaultEffectExecutor {
                 state_change_hash: None,
                 ledger_entry_id: None,
                 not_executed: false,
+                receipt_ref: None,
             }),
             KernelEffect::Treasury(treasury_effect) => {
                 // Convert TreasuryEffect to TreasuryOperation
@@ -296,6 +297,7 @@ impl EffectExecutor for DefaultEffectExecutor {
                         state_change_hash: None,
                         ledger_entry_id: None,
                         not_executed: false,
+                        receipt_ref: None,
                     })
                 }
             }
@@ -309,6 +311,7 @@ impl EffectExecutor for DefaultEffectExecutor {
                 state_change_hash: None,
                 ledger_entry_id: None,
                 not_executed: true,
+                receipt_ref: None,
             }),
             // For other effect types, return success placeholder
             _ => Ok(EffectResult {
@@ -318,6 +321,7 @@ impl EffectExecutor for DefaultEffectExecutor {
                 state_change_hash: None,
                 ledger_entry_id: None,
                 not_executed: false,
+                receipt_ref: None,
             }),
         }
     }
@@ -545,6 +549,7 @@ fn execution_outcome_to_effect_result(outcome: ExecutionOutcome, effect_id: &str
             state_change_hash: None,
             ledger_entry_id: None,
             not_executed: false,
+            receipt_ref: None,
         },
         ExecutionOutcome::Failed { reason, .. } => EffectResult {
             effect_id: effect_id.to_string(),
@@ -553,6 +558,7 @@ fn execution_outcome_to_effect_result(outcome: ExecutionOutcome, effect_id: &str
             state_change_hash: None,
             ledger_entry_id: None,
             not_executed: false,
+            receipt_ref: None,
         },
         ExecutionOutcome::Deferred { reason, .. } => EffectResult {
             effect_id: effect_id.to_string(),
@@ -561,6 +567,7 @@ fn execution_outcome_to_effect_result(outcome: ExecutionOutcome, effect_id: &str
             state_change_hash: None,
             ledger_entry_id: None,
             not_executed: true,
+            receipt_ref: None,
         },
     }
 }

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -2138,6 +2138,12 @@ pub struct AppointStewardResult {
     /// Stable hash of the steward record (for audit)
     pub state_change_hash: String,
     pub error: Option<String>,
+    /// Downstream identifier for the registered steward (e.g. content-addressed
+    /// `StewardId::to_hex()` minted by the commons layer). Carried through to
+    /// `EffectResult.receipt_ref` and into durable dispatch evidence. `None`
+    /// on failure paths or when the service layer cannot honestly produce one.
+    #[serde(default)]
+    pub receipt_ref: Option<String>,
 }
 
 /// Request to revoke a steward appointment.
@@ -2155,6 +2161,13 @@ pub struct RevokeStewardResult {
     pub success: bool,
     pub state_change_hash: String,
     pub error: Option<String>,
+    /// Downstream identifier for the revoked steward record (the commons
+    /// `StewardId::to_hex()` the revoke was routed through). See
+    /// [`AppointStewardResult::receipt_ref`] for semantics. `None` when the
+    /// revoke was an idempotent no-op (no active record existed) or on
+    /// failure.
+    #[serde(default)]
+    pub receipt_ref: Option<String>,
 }
 
 /// Request to reconfirm (extend the term of) an existing steward.
@@ -2175,6 +2188,10 @@ pub struct ReconfirmStewardResult {
     /// Stable hash of the state change (for audit)
     pub state_change_hash: String,
     pub error: Option<String>,
+    /// Downstream identifier for the reconfirmed steward record. See
+    /// [`AppointStewardResult::receipt_ref`] for semantics.
+    #[serde(default)]
+    pub receipt_ref: Option<String>,
 }
 
 /// Trait for SDIS steward appointment, revocation, and lifecycle management.


### PR DESCRIPTION
## Summary
- Adds receipt_ref: Option<String> to EffectResult and SDIS service result types
- SdisServiceImpl now publishes the commons StewardId::to_hex() on appoint/revoke/reconfirm
- GovernanceDispatchEvidenceSink forwards it verbatim into EffectDispatchEvidence.receipt_ref
- Preserves the single-owner invariant from #1567; no reintroduction of the gateway HTTP hook

## Why
Phase 2 (#1567) made the kernel executor the sole owner of SDIS dispatch, but the old HTTP evidence hook used to attach a downstream steward identifier to EffectDispatchEvidence.receipt_ref that the kernel path could not carry through. The data was already being produced inside SdisServiceImpl and thrown away.

## How
- EffectResult gains a generic, kernel-neutral receipt_ref: Option<String> (parallel to ledger_entry_id)
- AppointStewardResult / RevokeStewardResult / ReconfirmStewardResult gain the same field
- SdisServiceImpl captures the StewardRecord id (appoint) or looked-up steward_id (revoke/reconfirm) and populates receipt_ref
- KernelGovernanceExecutor forwards result.receipt_ref into EffectResult.receipt_ref
- GovernanceDispatchEvidenceSink reads it and writes it onto the durable row
- debug_assert_semantic_invariants extended to require receipt_ref: None on not_executed rows

## Honest failure paths
- register_steward error -> receipt_ref: None
- revoke of a never-appointed DID -> idempotent no-op, receipt_ref: None
- NoOp effects -> unchanged (no evidence row)

## Test plan
- [x] cargo fmt --all --check
- [x] cargo clippy -p icn-kernel-api -p icn-core -p icn-governance-actor -p icn-gateway -p icnd --all-targets -- -D warnings
- [x] cargo test -p icn-kernel-api -p icn-core -p icn-governance-actor
- [x] cargo test -p icn-gateway --features sled-storage
- [x] cargo check --workspace
- [x] New sink unit tests: appoint/revoke success with receipt_ref, failure with None
- [x] Extended SdisServiceImpl tests against real CommonsHandle assert exact StewardId::to_hex() equality
- [x] New test for revoke of never-appointed DID asserts honest None
- [x] Prior single-ownership tests (incl. two_sink_invocations_produce_duplicate_evidence_rows) preserved

No domain types cross the kernel boundary. Single-owner invariant preserved.