### PR TITLE
feat(sdis): extend receipt_ref evidence seam to suspend/reinstate/sanction

### DIFF
--- a/icn/apps/governance/tests/actor_path_dispatch_evidence_sink.rs
+++ b/icn/apps/governance/tests/actor_path_dispatch_evidence_sink.rs
@@ -598,6 +598,256 @@ async fn revoke_steward_noop_evidence_has_no_receipt_ref_but_is_success() {
     );
 }
 
+/// Successful SuspendSteward: the service publishes the commons
+/// `StewardId::to_hex()` and the sink persists it verbatim on the
+/// evidence row. Same seam as appoint/revoke/reconfirm.
+#[tokio::test(flavor = "current_thread")]
+async fn suspend_steward_evidence_carries_service_receipt_ref() {
+    let backend = Arc::new(MemoryReceiptBackend::new());
+    let ier = InstitutionalEffectRecord::new(
+        "prop-suspend-rref",
+        "coop",
+        None,
+        "suspend_steward",
+        Some("did:icn:steward-s".into()),
+        None,
+        None,
+        1,
+        serde_json::json!({}),
+    );
+    backend.put_institutional_effect(&ier).unwrap();
+
+    let sink =
+        GovernanceDispatchEvidenceSink::new(backend.clone() as Arc<dyn GovernanceReceiptBackend>);
+
+    let candidate: icn_identity::Did = IdentityBundle::generate().unwrap().did().clone();
+    let effects = vec![KernelEffect::Sdis(
+        icn_kernel_api::effects::SdisEffect::SuspendSteward {
+            steward_did: candidate.to_string(),
+            reason: "under investigation".into(),
+            duration_seconds: 86_400,
+            proposal_id: "prop-suspend-rref".into(),
+        },
+    )];
+    let steward_id_hex =
+        "c2a7bd1c4ee5fa0318d7c88a3b44f66b1e9d5e72c3a74b6cf88a1e0c2d3e4f50".to_string();
+    let results = vec![ok_result_with_receipt_ref("eff-suspend", &steward_id_hex)];
+
+    sink.record_effects(
+        "gov:domain-s:prop-suspend-rref:receipt",
+        &effects,
+        &results,
+        1_700_020_001,
+    );
+
+    let ev = backend.evidence_for("prop-suspend-rref");
+    assert_eq!(ev.len(), 1);
+    assert_eq!(
+        ev[0].receipt_ref,
+        Some(steward_id_hex),
+        "SuspendSteward must forward the steward_id the suspend was routed through"
+    );
+    assert_eq!(ev[0].subsystem, "sdis");
+    assert!(ev[0].success);
+    assert!(ev[0].error_message.is_none());
+}
+
+/// Successful ReinstateSteward (active-reinstate path): receipt_ref
+/// carries the real steward_id. The sink does not look at
+/// `was_suspended` — that flag lives only in the service-level result.
+#[tokio::test(flavor = "current_thread")]
+async fn reinstate_steward_evidence_carries_service_receipt_ref() {
+    let backend = Arc::new(MemoryReceiptBackend::new());
+    let ier = InstitutionalEffectRecord::new(
+        "prop-reinstate-rref",
+        "coop",
+        None,
+        "reinstate_steward",
+        Some("did:icn:steward-r".into()),
+        None,
+        None,
+        1,
+        serde_json::json!({}),
+    );
+    backend.put_institutional_effect(&ier).unwrap();
+
+    let sink =
+        GovernanceDispatchEvidenceSink::new(backend.clone() as Arc<dyn GovernanceReceiptBackend>);
+
+    let candidate: icn_identity::Did = IdentityBundle::generate().unwrap().did().clone();
+    let effects = vec![KernelEffect::Sdis(
+        icn_kernel_api::effects::SdisEffect::ReinstateSteward {
+            steward_did: candidate.to_string(),
+            proposal_id: "prop-reinstate-rref".into(),
+        },
+    )];
+    let steward_id_hex =
+        "d38e0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab".to_string();
+    let results = vec![ok_result_with_receipt_ref("eff-reinstate", &steward_id_hex)];
+
+    sink.record_effects(
+        "gov:domain-r:prop-reinstate-rref:receipt",
+        &effects,
+        &results,
+        1_700_020_002,
+    );
+
+    let ev = backend.evidence_for("prop-reinstate-rref");
+    assert_eq!(ev.len(), 1);
+    assert_eq!(
+        ev[0].receipt_ref,
+        Some(steward_id_hex),
+        "ReinstateSteward must forward the steward_id the reinstate was routed through"
+    );
+    assert_eq!(ev[0].subsystem, "sdis");
+    assert!(ev[0].success);
+}
+
+/// Successful SanctionSteward: the service minted a real receipt_ref
+/// (the steward_id the slash and optional suspend were routed through).
+/// Sink must persist it verbatim on the evidence row.
+#[tokio::test(flavor = "current_thread")]
+async fn sanction_steward_evidence_carries_service_receipt_ref() {
+    let backend = Arc::new(MemoryReceiptBackend::new());
+    let ier = InstitutionalEffectRecord::new(
+        "prop-sanction-rref",
+        "coop",
+        None,
+        "sanction_steward",
+        Some("did:icn:steward-x".into()),
+        None,
+        None,
+        1,
+        serde_json::json!({}),
+    );
+    backend.put_institutional_effect(&ier).unwrap();
+
+    let sink =
+        GovernanceDispatchEvidenceSink::new(backend.clone() as Arc<dyn GovernanceReceiptBackend>);
+
+    let candidate: icn_identity::Did = IdentityBundle::generate().unwrap().did().clone();
+    let effects = vec![KernelEffect::Sdis(
+        icn_kernel_api::effects::SdisEffect::SanctionSteward {
+            steward_did: candidate.to_string(),
+            bond_slash_amount: 250,
+            suspend_reason: "serious breach".into(),
+            reason: "serious breach".into(),
+            proposal_id: "prop-sanction-rref".into(),
+        },
+    )];
+    let steward_id_hex =
+        "e4f501234567899876543210fedcba987654321089abcdef0123456789abcd01".to_string();
+    let results = vec![ok_result_with_receipt_ref("eff-sanction", &steward_id_hex)];
+
+    sink.record_effects(
+        "gov:domain-x:prop-sanction-rref:receipt",
+        &effects,
+        &results,
+        1_700_020_003,
+    );
+
+    let ev = backend.evidence_for("prop-sanction-rref");
+    assert_eq!(ev.len(), 1);
+    assert_eq!(
+        ev[0].receipt_ref,
+        Some(steward_id_hex),
+        "SanctionSteward must forward the steward_id the slash was routed through"
+    );
+    assert_eq!(ev[0].subsystem, "sdis");
+    assert!(ev[0].success);
+}
+
+/// Suspend/Reinstate/Sanction hard-failure paths (no record, commons
+/// error): the kernel executor emits `success = false, receipt_ref =
+/// None`, and the sink must persist that faithfully. Pinned as one
+/// test because the sink logic is identical across all three effect
+/// kinds — only the effect enum variant differs.
+#[tokio::test(flavor = "current_thread")]
+async fn lifecycle_failure_evidence_has_no_receipt_ref() {
+    let backend = Arc::new(MemoryReceiptBackend::new());
+    for (idx, (effect_kind, prop)) in [
+        ("suspend_steward", "prop-suspend-fail"),
+        ("reinstate_steward", "prop-reinstate-fail"),
+        ("sanction_steward", "prop-sanction-fail"),
+    ]
+    .iter()
+    .enumerate()
+    {
+        let ier = InstitutionalEffectRecord::new(
+            *prop,
+            "coop",
+            None,
+            *effect_kind,
+            Some(format!("did:icn:ghost-{idx}")),
+            None,
+            None,
+            1,
+            serde_json::json!({}),
+        );
+        backend.put_institutional_effect(&ier).unwrap();
+    }
+
+    let sink =
+        GovernanceDispatchEvidenceSink::new(backend.clone() as Arc<dyn GovernanceReceiptBackend>);
+    let candidate: icn_identity::Did = IdentityBundle::generate().unwrap().did().clone();
+
+    let cases: [(KernelEffect, &str, &str); 3] = [
+        (
+            KernelEffect::Sdis(icn_kernel_api::effects::SdisEffect::SuspendSteward {
+                steward_did: candidate.to_string(),
+                reason: "x".into(),
+                duration_seconds: 3_600,
+                proposal_id: "prop-suspend-fail".into(),
+            }),
+            "prop-suspend-fail",
+            "commons lookup failed: no record",
+        ),
+        (
+            KernelEffect::Sdis(icn_kernel_api::effects::SdisEffect::ReinstateSteward {
+                steward_did: candidate.to_string(),
+                proposal_id: "prop-reinstate-fail".into(),
+            }),
+            "prop-reinstate-fail",
+            "commons lookup failed: no record",
+        ),
+        (
+            KernelEffect::Sdis(icn_kernel_api::effects::SdisEffect::SanctionSteward {
+                steward_did: candidate.to_string(),
+                bond_slash_amount: 10,
+                suspend_reason: String::new(),
+                reason: "x".into(),
+                proposal_id: "prop-sanction-fail".into(),
+            }),
+            "prop-sanction-fail",
+            "commons lookup failed: no record",
+        ),
+    ];
+
+    for (i, (effect, proposal_id, err_msg)) in cases.iter().enumerate() {
+        let effects = vec![effect.clone()];
+        let results = vec![failure_result(&format!("eff-fail-{i}"), err_msg)];
+        sink.record_effects(
+            &format!("gov:domain-f:{proposal_id}:receipt"),
+            &effects,
+            &results,
+            1_700_030_000 + i as u64,
+        );
+
+        let ev = backend.evidence_for(proposal_id);
+        assert_eq!(ev.len(), 1, "each effect kind produces one evidence row");
+        assert!(!ev[0].success, "failure must not be persisted as success");
+        assert_eq!(
+            ev[0].receipt_ref, None,
+            "failure paths must truthfully leave receipt_ref unset across all lifecycle operations"
+        );
+        assert_eq!(
+            ev[0].error_message.as_deref(),
+            Some(*err_msg),
+            "error_message must carry the service-layer diagnostic verbatim"
+        );
+    }
+}
+
 /// Failure path: when the service produced no downstream handle
 /// (e.g. commons.register_steward failed, revoke hit an idempotent
 /// no-op with no active record), `receipt_ref` must remain `None` on

--- a/icn/crates/icn-core/src/services/sdis_service.rs
+++ b/icn/crates/icn-core/src/services/sdis_service.rs
@@ -317,12 +317,18 @@ impl SdisService for SdisServiceImpl {
         let steward_did = icn_identity::Did::from_str(&request.steward_did)
             .map_err(|e| anyhow::anyhow!("Invalid steward DID '{}': {}", request.steward_did, e))?;
 
-        let result = tokio::task::block_in_place(|| {
+        // Returns (steward_id, was_suspended): capture the commons handle
+        // the reinstate was routed through so we can forward it into
+        // durable dispatch evidence. Populated on both active and no-op
+        // paths since the commons call succeeded against a real record;
+        // `state_change_hash` still distinguishes the two.
+        let result: Result<(String, bool)> = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
                 match self.commons.get_steward_by_did(&steward_did).await {
                     Ok(Some(record)) => {
                         let steward_id = record.id().to_hex();
-                        self.commons.reinstate_steward(&steward_id).await
+                        let was_suspended = self.commons.reinstate_steward(&steward_id).await?;
+                        Ok((steward_id, was_suspended))
                     }
                     Ok(None) => {
                         tracing::warn!(
@@ -340,18 +346,20 @@ impl SdisService for SdisServiceImpl {
         });
 
         match result {
-            Ok(was_suspended) => {
+            Ok((steward_id, was_suspended)) => {
                 let state_change_hash = if was_suspended {
                     let hash = Self::compute_reinstate_hash(&request);
                     info!(
                         steward_did = %request.steward_did,
                         state_change_hash = %hash,
+                        receipt_ref = %steward_id,
                         "Suspended steward reinstated in commons"
                     );
                     hash
                 } else {
                     info!(
                         steward_did = %request.steward_did,
+                        receipt_ref = %steward_id,
                         "ReinstateSteward no-op: steward was not suspended"
                     );
                     String::new()
@@ -361,6 +369,7 @@ impl SdisService for SdisServiceImpl {
                     was_suspended,
                     state_change_hash,
                     error: None,
+                    receipt_ref: Some(steward_id),
                 })
             }
             Err(e) => {
@@ -374,6 +383,7 @@ impl SdisService for SdisServiceImpl {
                     was_suspended: false,
                     state_change_hash: String::new(),
                     error: Some(e.to_string()),
+                    receipt_ref: None,
                 })
             }
         }
@@ -389,14 +399,17 @@ impl SdisService for SdisServiceImpl {
         );
         let steward_did = icn_identity::Did::from_str(&request.steward_did)
             .map_err(|e| anyhow::anyhow!("Invalid steward DID '{}': {}", request.steward_did, e))?;
-        let result = tokio::task::block_in_place(|| {
+        // Returns the steward_id the suspend was routed through, so it
+        // can be forwarded into durable dispatch evidence.
+        let result: Result<String> = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
                 match self.commons.get_steward_by_did(&steward_did).await {
                     Ok(Some(record)) => {
                         let steward_id = record.id().to_hex();
                         self.commons
                             .suspend_steward(&steward_id, request.reason.clone())
-                            .await
+                            .await?;
+                        Ok(steward_id)
                     }
                     Ok(None) => Err(anyhow::anyhow!(
                         "Steward '{}' not found — cannot suspend",
@@ -407,17 +420,19 @@ impl SdisService for SdisServiceImpl {
             })
         });
         match result {
-            Ok(()) => {
+            Ok(steward_id) => {
                 let hash = Self::compute_suspend_hash(&request);
                 info!(
                     steward_did = %request.steward_did,
                     state_change_hash = %hash,
+                    receipt_ref = %steward_id,
                     "Steward suspended in commons"
                 );
                 Ok(SuspendStewardResult {
                     success: true,
                     state_change_hash: hash,
                     error: None,
+                    receipt_ref: Some(steward_id),
                 })
             }
             Err(e) => {
@@ -430,6 +445,7 @@ impl SdisService for SdisServiceImpl {
                     success: false,
                     state_change_hash: String::new(),
                     error: Some(e.to_string()),
+                    receipt_ref: None,
                 })
             }
         }
@@ -475,12 +491,12 @@ impl SdisService for SdisServiceImpl {
                     false
                 };
 
-                Ok((remaining, suspended))
+                Ok((steward_id, remaining, suspended))
             })
         });
 
         match result {
-            Ok((remaining_bond, suspended)) => {
+            Ok((steward_id, remaining_bond, suspended)) => {
                 let mut hasher = Sha256::new();
                 hasher.update(b"sdis:sanction:");
                 hasher.update(request.steward_did.as_bytes());
@@ -495,6 +511,7 @@ impl SdisService for SdisServiceImpl {
                     remaining_bond = %remaining_bond,
                     suspended = %suspended,
                     state_change_hash = %state_change_hash,
+                    receipt_ref = %steward_id,
                     "Steward sanctioned (bond slashed) in commons"
                 );
                 Ok(SanctionStewardResult {
@@ -503,6 +520,7 @@ impl SdisService for SdisServiceImpl {
                     suspended,
                     state_change_hash,
                     error: None,
+                    receipt_ref: Some(steward_id),
                 })
             }
             Err(e) => {
@@ -517,6 +535,7 @@ impl SdisService for SdisServiceImpl {
                     suspended: false,
                     state_change_hash: String::new(),
                     error: Some(e.to_string()),
+                    receipt_ref: None,
                 })
             }
         }
@@ -862,6 +881,13 @@ mod tests {
             "state_change_hash must be non-empty when suspended was true"
         );
         assert!(result.error.is_none());
+        // Evidence-fidelity seam: reinstate publishes the same steward_id
+        // it routed the commons call through — the real downstream handle.
+        assert_eq!(
+            result.receipt_ref.as_deref(),
+            Some(record.id().to_hex().as_str()),
+            "ReinstateStewardResult.receipt_ref must be the steward_id the reinstate was routed through"
+        );
 
         // Verify the steward is now active again.
         assert!(
@@ -913,6 +939,20 @@ mod tests {
             "state_change_hash must be empty on no-op path"
         );
         assert!(result.error.is_none());
+        // No-op but record existed and commons call succeeded: the
+        // downstream handle is real, so receipt_ref is truthful.
+        // state_change_hash (empty) already distinguishes no-op from
+        // active reinstatement.
+        let record = commons
+            .get_steward_by_did(&holder)
+            .await
+            .expect("lookup must not error")
+            .expect("record must exist");
+        assert_eq!(
+            result.receipt_ref.as_deref(),
+            Some(record.id().to_hex().as_str()),
+            "reinstate no-op still routed through a real steward_id; receipt_ref must reflect it"
+        );
 
         // Steward still active.
         assert!(
@@ -941,6 +981,10 @@ mod tests {
         assert!(
             result.error.is_some(),
             "error field must be populated on failure"
+        );
+        assert_eq!(
+            result.receipt_ref, None,
+            "no commons record → no downstream handle → receipt_ref must remain None"
         );
     }
 
@@ -998,6 +1042,18 @@ mod tests {
             "state_change_hash must be populated on success"
         );
         assert!(result.error.is_none());
+        // Evidence-fidelity seam: suspend publishes the steward_id it
+        // routed the commons call through.
+        let record = commons
+            .get_steward_by_did(&holder)
+            .await
+            .expect("lookup must not error")
+            .expect("record must exist");
+        assert_eq!(
+            result.receipt_ref.as_deref(),
+            Some(record.id().to_hex().as_str()),
+            "SuspendStewardResult.receipt_ref must be the steward_id the suspend was routed through"
+        );
 
         // Read back durable state — steward must now be inactive (suspended).
         assert!(
@@ -1101,6 +1157,155 @@ mod tests {
         assert!(
             result.state_change_hash.is_empty(),
             "state_change_hash must be empty on failure"
+        );
+        assert_eq!(
+            result.receipt_ref, None,
+            "no commons record → no downstream handle → receipt_ref must remain None"
+        );
+    }
+
+    // ─── SanctionSteward proof tests ───────────────────────────────────────────
+
+    /// SanctionSteward → bond slashed in the durable commons record, and
+    /// the service-level receipt_ref carries the real commons
+    /// `StewardId::to_hex()` the slash was routed through.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_sanction_steward_slashes_bond_and_publishes_receipt_ref() {
+        let (svc, commons) = make_service_with_commons();
+        let holder = test_did(30);
+        let sponsor = test_did(31);
+
+        create_strong_holder(&commons, &holder, &sponsor).await;
+        let appoint_req = AppointStewardRequest {
+            steward_did: holder.to_string(),
+            jurisdiction_id: String::new(),
+            term_length_seconds: 86_400 * 30,
+            bond_amount: 1_000,
+            region: None,
+            proposal_id: "gov:coop:prop-040:receipt".to_string(),
+        };
+        svc.appoint_steward(appoint_req).unwrap();
+
+        let record = commons
+            .get_steward_by_did(&holder)
+            .await
+            .expect("lookup must not error")
+            .expect("record must exist");
+        let steward_id_hex = record.id().to_hex();
+
+        // Pure slash (no suspend).
+        let req = SanctionStewardRequest {
+            steward_did: holder.to_string(),
+            bond_slash_amount: 250,
+            suspend_reason: String::new(),
+            reason: "minor infraction".to_string(),
+            proposal_id: "gov:coop:prop-041:receipt".to_string(),
+        };
+        let result = svc.sanction_steward(req).unwrap();
+        assert!(result.success, "sanction must succeed");
+        // Commons slash_steward_bond returns the post-slash bond value
+        // from the commons layer; we don't pin an exact number here
+        // because the commons bond accounting semantics (starting bond,
+        // fees) live in icn-commons, not this service. What this test
+        // pins is that (a) the sanction succeeded, (b) a real receipt_ref
+        // was published, and (c) the suspended flag reflects the request.
+        assert!(
+            !result.suspended,
+            "empty suspend_reason → steward must not be suspended"
+        );
+        assert!(
+            !result.state_change_hash.is_empty(),
+            "state_change_hash must be populated on success"
+        );
+        assert_eq!(
+            result.receipt_ref.as_deref(),
+            Some(steward_id_hex.as_str()),
+            "SanctionStewardResult.receipt_ref must be the steward_id the slash was routed through"
+        );
+    }
+
+    /// SanctionSteward with `suspend_reason` also suspends the steward,
+    /// and still publishes the same `receipt_ref`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_sanction_steward_with_suspend_publishes_receipt_ref() {
+        let (svc, commons) = make_service_with_commons();
+        let holder = test_did(32);
+        let sponsor = test_did(33);
+
+        create_strong_holder(&commons, &holder, &sponsor).await;
+        svc.appoint_steward(AppointStewardRequest {
+            steward_did: holder.to_string(),
+            jurisdiction_id: String::new(),
+            term_length_seconds: 86_400 * 30,
+            bond_amount: 500,
+            region: None,
+            proposal_id: "gov:coop:prop-050:receipt".to_string(),
+        })
+        .unwrap();
+
+        let record = commons
+            .get_steward_by_did(&holder)
+            .await
+            .unwrap()
+            .expect("record must exist");
+        let steward_id_hex = record.id().to_hex();
+
+        let req = SanctionStewardRequest {
+            steward_did: holder.to_string(),
+            bond_slash_amount: 100,
+            suspend_reason: "serious breach".to_string(),
+            reason: "serious breach".to_string(),
+            proposal_id: "gov:coop:prop-051:receipt".to_string(),
+        };
+        let result = svc.sanction_steward(req).unwrap();
+        assert!(result.success);
+        assert!(
+            result.suspended,
+            "non-empty suspend_reason → steward must be suspended"
+        );
+        assert_eq!(
+            result.receipt_ref.as_deref(),
+            Some(steward_id_hex.as_str()),
+            "receipt_ref must carry the same steward_id the slash+suspend were routed through"
+        );
+
+        // Durable state: suspension visible.
+        assert!(
+            !commons
+                .is_active_steward(&holder)
+                .await
+                .expect("is_active must not error"),
+            "steward must be inactive after sanction-with-suspend"
+        );
+    }
+
+    /// SanctionSteward fails for an unknown DID: no record → no handle →
+    /// receipt_ref must remain None.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_sanction_steward_fails_for_unknown_did() {
+        let (svc, _commons) = make_service_with_commons();
+        let unknown = test_did(96);
+        let req = SanctionStewardRequest {
+            steward_did: unknown.to_string(),
+            bond_slash_amount: 100,
+            suspend_reason: String::new(),
+            reason: "no record".to_string(),
+            proposal_id: "gov:unknown:prop-000:receipt".to_string(),
+        };
+        let result = svc.sanction_steward(req).unwrap();
+        assert!(!result.success, "sanction for unknown DID must fail");
+        assert!(result.error.is_some());
+        assert_eq!(
+            result.remaining_bond, 0,
+            "failure must not leak a nonzero remaining_bond"
+        );
+        assert!(
+            result.state_change_hash.is_empty(),
+            "failure must leave state_change_hash empty"
+        );
+        assert_eq!(
+            result.receipt_ref, None,
+            "no commons record → receipt_ref must remain None on failure"
         );
     }
 }

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -2332,11 +2332,13 @@ impl KernelSdisExecutor {
                         info!(
                             steward_did = %steward_did,
                             state_change_hash = %result.state_change_hash,
+                            receipt_ref = ?result.receipt_ref,
                             "Suspended steward reinstated with durable state"
                         );
                     } else {
                         info!(
                             steward_did = %steward_did,
+                            receipt_ref = ?result.receipt_ref,
                             "ReinstateSteward: steward was not suspended — no-op"
                         );
                     }
@@ -2361,7 +2363,7 @@ impl KernelSdisExecutor {
                         },
                         ledger_entry_id: None,
                         not_executed: false,
-                        receipt_ref: None,
+                        receipt_ref: result.receipt_ref,
                     })
                 } else {
                     Ok(EffectResult {
@@ -2395,6 +2397,7 @@ impl KernelSdisExecutor {
                         steward_did = %steward_did,
                         state_change_hash = %result.state_change_hash,
                         duration_seconds = %duration_seconds,
+                        receipt_ref = ?result.receipt_ref,
                         "Steward suspended via governance dispatch \
                          (duration advisory — timed reinstatement not enforced)"
                     );
@@ -2408,7 +2411,7 @@ impl KernelSdisExecutor {
                         state_change_hash: Some(result.state_change_hash),
                         ledger_entry_id: None,
                         not_executed: false,
-                        receipt_ref: None,
+                        receipt_ref: result.receipt_ref,
                     })
                 } else {
                     Ok(EffectResult {
@@ -2445,6 +2448,7 @@ impl KernelSdisExecutor {
                         remaining_bond = %result.remaining_bond,
                         suspended = %result.suspended,
                         state_change_hash = %result.state_change_hash,
+                        receipt_ref = ?result.receipt_ref,
                         "Steward sanctioned (bond slashed) via governance dispatch"
                     );
                     Ok(EffectResult {
@@ -2457,7 +2461,7 @@ impl KernelSdisExecutor {
                         state_change_hash: Some(result.state_change_hash),
                         ledger_entry_id: None,
                         not_executed: false,
-                        receipt_ref: None,
+                        receipt_ref: result.receipt_ref,
                     })
                 } else {
                     Ok(EffectResult {

--- a/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
+++ b/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
@@ -761,6 +761,7 @@ async fn test_e2e_appoint_steward_scoped_to_chartered_domain() {
                 was_suspended: false,
                 state_change_hash: String::new(),
                 error: None,
+                receipt_ref: None,
             })
         }
 
@@ -774,6 +775,7 @@ async fn test_e2e_appoint_steward_scoped_to_chartered_domain() {
                 success: true,
                 state_change_hash: String::new(),
                 error: None,
+                receipt_ref: None,
             })
         }
 
@@ -789,6 +791,7 @@ async fn test_e2e_appoint_steward_scoped_to_chartered_domain() {
                 suspended: false,
                 state_change_hash: String::new(),
                 error: None,
+                receipt_ref: None,
             })
         }
     }

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -2264,6 +2264,12 @@ pub struct SuspendStewardResult {
     /// Stable hash of the state change (for audit); empty on failure.
     pub state_change_hash: String,
     pub error: Option<String>,
+    /// Downstream identifier for the suspended steward record (the commons
+    /// `StewardId::to_hex()` the suspend was routed through). See
+    /// [`AppointStewardResult::receipt_ref`] for semantics. `None` on
+    /// failure paths (e.g. no active record, commons error).
+    #[serde(default)]
+    pub receipt_ref: Option<String>,
 }
 
 /// Request to reinstate a previously suspended steward.
@@ -2285,6 +2291,14 @@ pub struct ReinstateStewardResult {
     /// Stable hash of the state change (for audit); empty on no-op path.
     pub state_change_hash: String,
     pub error: Option<String>,
+    /// Downstream identifier for the steward record the reinstate was
+    /// routed through (commons `StewardId::to_hex()`). Populated on both
+    /// the active-reinstate path and the no-op (was-not-suspended) path,
+    /// because in both cases the commons call succeeded against a real
+    /// record. `state_change_hash` still distinguishes the two. `None` on
+    /// failure (no record, commons error).
+    #[serde(default)]
+    pub receipt_ref: Option<String>,
 }
 
 /// Request to sanction a steward with a bond slash via governance dispatch.
@@ -2313,4 +2327,10 @@ pub struct SanctionStewardResult {
     /// Stable hash of the state change (for audit); empty on failure.
     pub state_change_hash: String,
     pub error: Option<String>,
+    /// Downstream identifier for the sanctioned steward record (commons
+    /// `StewardId::to_hex()` the slash — and optional suspend — were
+    /// routed through). See [`AppointStewardResult::receipt_ref`] for
+    /// semantics. `None` on failure (no record, commons error).
+    #[serde(default)]
+    pub receipt_ref: Option<String>,
 }


### PR DESCRIPTION
## What

Extend the `EffectResult.receipt_ref` seam established in #1568 to the remaining SDIS steward-lifecycle operations: `SuspendSteward`, `ReinstateSteward`, `SanctionSteward`. Each operation now forwards a truthful downstream handle (the `StewardId` hex) on success and `None` on failure, so dispatch evidence carries honest attribution end-to-end.

## Why

Phase 1 (#1568) closed the gap for `RevokeSteward` but left three sibling lifecycle ops producing `receipt_ref: None` even when they committed real state to the commons — an evidence-fidelity gap the next SDIS audit tranche would have flagged.

## How

- **icn-kernel-api**: add `receipt_ref: Option<String>` (with `#[serde(default)]`) to `SuspendStewardResult`, `ReinstateStewardResult`, `SanctionStewardResult`.
- **icn-core sdis_service**: capture the `StewardId::to_hex()` already computed internally and surface it through the result DTO.
  - Suspend: `Some(steward_id)` on success, `None` on failure.
  - Reinstate: `Some(steward_id)` on both active-reinstate and no-op paths (commons call succeeded against a real record). `state_change_hash` (empty on no-op) distinguishes them.
  - Sanction: `Some(steward_id)` on success, `None` on failure.
- **icn-core governance_executor**: forward `result.receipt_ref` into `EffectResult` for each of the three arms.
- **icn-gateway e2e stub**: add `receipt_ref: None` to the test `SdisService` impls.
- **apps/governance tests**: per-op positive assertions + a lifecycle-failure matrix verifying `receipt_ref == None` on error paths.

## Invariants preserved

- **Single dispatch owner**: kernel executor remains sole owner; no second dispatch path.
- **Meaning firewall**: `Option<String>` is opaque to the kernel; no domain semantics cross.
- **No-op vs real-change distinction**: preserved via `state_change_hash` (empty on no-op), consistent with the Phase 1 revoke pattern.

## Risk

Additive field on three result structs with `serde(default)`; no existing callers break. Only new assertions added to tests.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p icn-kernel-api -p icn-core -p icn-governance-actor -p icn-gateway --all-targets -- -D warnings`
- [x] `cargo test -p icn-core --lib services::sdis_service` — 14/14 pass
- [x] `cargo test -p icn-governance-actor --test actor_path_dispatch_evidence_sink` — 15/15 pass
- [x] `cargo test -p icn-gateway --features sled-storage --test e2e_institutional_flow` — 3/3 pass
