### PR TITLE
feat(sdis): add explicit EffectOutcome semantics to dispatch evidence

### DIFF
--- a/icn/apps/governance/src/dispatch_evidence.rs
+++ b/icn/apps/governance/src/dispatch_evidence.rs
@@ -89,10 +89,18 @@ pub struct EffectDispatchEvidence {
 impl EffectDispatchEvidence {
     /// Construct evidence with explicit outcome classification.
     ///
-    /// Prefer this over [`Self::new`] so the outcome field carries truthful
-    /// semantics rather than defaulting to `None`.
+    /// `outcome` is `Option<EffectOutcome>` rather than a default-to-`None`
+    /// so that every call site must make an explicit choice about whether
+    /// the writing layer can classify the result. Pass `None` only when
+    /// the writer genuinely has no structured outcome to offer (e.g. a
+    /// fire-and-forget hook, pre-outcome-seam legacy path, or test
+    /// fixture that is not exercising the classification field itself).
+    /// Callers that do know the classification — the kernel executor, the
+    /// SDIS service-path writers — MUST pass the concrete variant; an
+    /// unclassified row from a classifiable caller is a correctness bug,
+    /// not a wire-compat feature.
     #[allow(clippy::too_many_arguments)]
-    pub fn new_with_outcome(
+    pub fn new(
         effect_record_id: impl Into<String>,
         proposal_id: impl Into<String>,
         subsystem: impl Into<String>,
@@ -113,29 +121,6 @@ impl EffectDispatchEvidence {
             outcome,
             recorded_at,
         }
-    }
-
-    /// Legacy constructor — leaves `outcome` unclassified (`None`). Prefer
-    /// [`Self::new_with_outcome`] in new code so audit rows are self-describing.
-    pub fn new(
-        effect_record_id: impl Into<String>,
-        proposal_id: impl Into<String>,
-        subsystem: impl Into<String>,
-        receipt_ref: Option<String>,
-        success: bool,
-        error_message: Option<String>,
-        recorded_at: u64,
-    ) -> Self {
-        Self::new_with_outcome(
-            effect_record_id,
-            proposal_id,
-            subsystem,
-            receipt_ref,
-            success,
-            error_message,
-            None,
-            recorded_at,
-        )
     }
 }
 
@@ -221,6 +206,7 @@ mod tests {
             Some("state-hash-x".into()),
             success,
             err.map(String::from),
+            None,
             at,
         )
     }

--- a/icn/apps/governance/src/dispatch_evidence.rs
+++ b/icn/apps/governance/src/dispatch_evidence.rs
@@ -18,6 +18,7 @@
 //! effects will remain `emitted_only` until their surfaces are upgraded.
 //! This module does not pretend otherwise.
 
+use icn_kernel_api::EffectOutcome;
 use serde::{Deserialize, Serialize};
 
 use crate::institutional_effect::InstitutionalEffectRecord;
@@ -60,18 +61,45 @@ pub struct EffectDispatchEvidence {
     /// Error message surfaced by the subsystem on failure.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error_message: Option<String>,
+    /// Explicit structural outcome class — see [`EffectOutcome`].
+    ///
+    /// Complements `success` + `receipt_ref` + `state_change_hash`-derived
+    /// signals that previously forced auditors to infer semantics from
+    /// field combinations. A value of `None` means the evidence pre-dates
+    /// the outcome seam or the service-layer didn't classify — this is
+    /// intentionally distinct from `Some(Applied)` so stale data is
+    /// visibly unclassified rather than silently misclassified.
+    ///
+    /// When `Some`, the mapping to the other fields is contractually:
+    /// - [`EffectOutcome::Applied`]: `success = true`, real mutation;
+    ///   `receipt_ref` populated when a downstream handle exists.
+    /// - [`EffectOutcome::NoOp`]: `success = true`, no mutation.
+    ///   `receipt_ref` may be `None` or `Some` depending on whether the
+    ///   service reached a durable record at all.
+    /// - [`EffectOutcome::Partial`]: `success = false`, but a real
+    ///   mutation did commit before a later step failed; `receipt_ref`
+    ///   MUST be preserved.
+    /// - [`EffectOutcome::Failed`]: `success = false`, no mutation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<EffectOutcome>,
     /// Unix seconds when this evidence was persisted.
     pub recorded_at: u64,
 }
 
 impl EffectDispatchEvidence {
-    pub fn new(
+    /// Construct evidence with explicit outcome classification.
+    ///
+    /// Prefer this over [`Self::new`] so the outcome field carries truthful
+    /// semantics rather than defaulting to `None`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_outcome(
         effect_record_id: impl Into<String>,
         proposal_id: impl Into<String>,
         subsystem: impl Into<String>,
         receipt_ref: Option<String>,
         success: bool,
         error_message: Option<String>,
+        outcome: Option<EffectOutcome>,
         recorded_at: u64,
     ) -> Self {
         Self {
@@ -82,8 +110,32 @@ impl EffectDispatchEvidence {
             receipt_ref,
             success,
             error_message,
+            outcome,
             recorded_at,
         }
+    }
+
+    /// Legacy constructor — leaves `outcome` unclassified (`None`). Prefer
+    /// [`Self::new_with_outcome`] in new code so audit rows are self-describing.
+    pub fn new(
+        effect_record_id: impl Into<String>,
+        proposal_id: impl Into<String>,
+        subsystem: impl Into<String>,
+        receipt_ref: Option<String>,
+        success: bool,
+        error_message: Option<String>,
+        recorded_at: u64,
+    ) -> Self {
+        Self::new_with_outcome(
+            effect_record_id,
+            proposal_id,
+            subsystem,
+            receipt_ref,
+            success,
+            error_message,
+            None,
+            recorded_at,
+        )
     }
 }
 

--- a/icn/apps/governance/src/dispatch_evidence_sink.rs
+++ b/icn/apps/governance/src/dispatch_evidence_sink.rs
@@ -126,7 +126,7 @@ impl GovernanceDispatchEvidenceSink {
         } else {
             Some(result.message.clone())
         };
-        let evidence = EffectDispatchEvidence::new(
+        let evidence = EffectDispatchEvidence::new_with_outcome(
             effect_record_id.to_string(),
             proposal_id.to_string(),
             subsystem,
@@ -141,6 +141,12 @@ impl GovernanceDispatchEvidenceSink {
             result.receipt_ref.clone(),
             result.success,
             error_message,
+            // Explicit outcome class — forwarded verbatim from the service
+            // layer. `None` when the service didn't classify (non-SDIS
+            // effects today); classified rows let auditors distinguish
+            // applied / no_op / partial / failed without inferring from
+            // success + receipt_ref + state_change_hash combinations.
+            result.outcome,
             recorded_at,
         );
 

--- a/icn/apps/governance/src/dispatch_evidence_sink.rs
+++ b/icn/apps/governance/src/dispatch_evidence_sink.rs
@@ -126,7 +126,7 @@ impl GovernanceDispatchEvidenceSink {
         } else {
             Some(result.message.clone())
         };
-        let evidence = EffectDispatchEvidence::new_with_outcome(
+        let evidence = EffectDispatchEvidence::new(
             effect_record_id.to_string(),
             proposal_id.to_string(),
             subsystem,

--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -132,12 +132,17 @@ pub type ProposalAcceptedHook = Arc<dyn Fn(GovernanceEffect) + Send + Sync>;
 ///
 /// `subsystem` is lowercase stable (`"commons"`, `"ledger"`, `"sdis"`).
 /// `receipt_ref` is opaque — governance does not interpret or validate it.
+/// `outcome` is the structural classification the dispatcher is willing to
+/// stand behind for this result. `None` means the dispatcher has no truthful
+/// outcome to report (pre-outcome-seam hook, fire-and-forget surface). See
+/// [`icn_kernel_api::EffectOutcome`] for the full semantics of each variant.
 #[derive(Debug, Clone)]
 pub struct DispatchEvidenceSpec {
     pub subsystem: String,
     pub receipt_ref: Option<String>,
     pub success: bool,
     pub error_message: Option<String>,
+    pub outcome: Option<icn_kernel_api::EffectOutcome>,
 }
 
 /// Optional parallel hook that, when wired, returns downstream dispatch

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -1446,6 +1446,15 @@ pub async fn close_proposal<E: GovernanceEventEmitter + Clone + 'static>(
                             }
                         };
                         if let Some(record_id) = target_record_id.as_ref() {
+                            // AppointSteward has no NoOp / Partial semantics at
+                            // the service layer: success ⇒ Applied, failure ⇒
+                            // Failed (classification mirrors the kernel
+                            // executor, see supervisor::governance_executor).
+                            let outcome = if success {
+                                Some(icn_kernel_api::EffectOutcome::Applied)
+                            } else {
+                                Some(icn_kernel_api::EffectOutcome::Failed)
+                            };
                             let evidence = crate::dispatch_evidence::EffectDispatchEvidence::new(
                                 record_id.clone(),
                                 proposal.id.0.clone(),
@@ -1453,6 +1462,7 @@ pub async fn close_proposal<E: GovernanceEventEmitter + Clone + 'static>(
                                 receipt_ref,
                                 success,
                                 error,
+                                outcome,
                                 current_time_secs(),
                             );
                             if let Err(e) = ctx.manager.record_dispatch_evidence(&evidence) {
@@ -1493,6 +1503,21 @@ pub async fn close_proposal<E: GovernanceEventEmitter + Clone + 'static>(
                             }
                         };
                         if let Some(record_id) = target_record_id.as_ref() {
+                            // RevokeSteward can be a NoOp when no active record
+                            // exists for the target — but the HTTP test-path
+                            // collapses that into `success = true` without
+                            // surfacing the receipt_ref signal used by the
+                            // kernel executor. Classify conservatively: mark
+                            // `Applied` on success (may over-count NoOp in this
+                            // legacy test-path; the kernel-owned executor is
+                            // canonical for the NoOp distinction) and `Failed`
+                            // on failure. The service here does not expose
+                            // Partial mutations.
+                            let outcome = if success {
+                                Some(icn_kernel_api::EffectOutcome::Applied)
+                            } else {
+                                Some(icn_kernel_api::EffectOutcome::Failed)
+                            };
                             let evidence = crate::dispatch_evidence::EffectDispatchEvidence::new(
                                 record_id.clone(),
                                 proposal.id.0.clone(),
@@ -1500,6 +1525,7 @@ pub async fn close_proposal<E: GovernanceEventEmitter + Clone + 'static>(
                                 receipt_ref,
                                 success,
                                 error,
+                                outcome,
                                 current_time_secs(),
                             );
                             if let Err(e) = ctx.manager.record_dispatch_evidence(&evidence) {
@@ -1748,6 +1774,7 @@ async fn record_hook_dispatch_evidence<E: GovernanceEventEmitter + Clone + 'stat
         spec.receipt_ref,
         spec.success,
         spec.error_message,
+        spec.outcome,
         now,
     );
     if let Err(e) = ctx.manager.record_dispatch_evidence(&evidence) {
@@ -5096,6 +5123,7 @@ mod tests {
                     receipt_ref: Some("state-hash-abc".to_string()),
                     success: true,
                     error_message: None,
+                    outcome: Some(icn_kernel_api::EffectOutcome::Applied),
                 }),
                 _ => None,
             };
@@ -5220,6 +5248,7 @@ mod tests {
                         receipt_ref: Some(sid),
                         success: true,
                         error_message: None,
+                        outcome: Some(icn_kernel_api::EffectOutcome::Applied),
                     })
                 } else {
                     None
@@ -5342,6 +5371,7 @@ mod tests {
                         receipt_ref: None,
                         success: false,
                         error_message: Some("candidate has no holder record".to_string()),
+                        outcome: Some(icn_kernel_api::EffectOutcome::Failed),
                     })
                 } else {
                     None
@@ -5461,6 +5491,7 @@ mod tests {
                         receipt_ref: Some(sid),
                         success: true,
                         error_message: None,
+                        outcome: Some(icn_kernel_api::EffectOutcome::Applied),
                     })
                 } else {
                     None

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -6694,6 +6694,7 @@ mod tests {
             Some("state-hash-1".into()),
             true,
             None,
+            None,
             100,
         );
         let newer = EffectDispatchEvidence::new(
@@ -6703,11 +6704,12 @@ mod tests {
             Some("state-hash-2".into()),
             true,
             None,
+            None,
             200,
         );
         // Unrelated record — must not leak into rec-a's list.
         let other_record =
-            EffectDispatchEvidence::new("rec-b", "prop-2", "sdis", None, true, None, 150);
+            EffectDispatchEvidence::new("rec-b", "prop-2", "sdis", None, true, None, None, 150);
 
         mgr.record_dispatch_evidence(&newer).unwrap();
         mgr.record_dispatch_evidence(&older).unwrap();
@@ -6765,6 +6767,7 @@ mod tests {
             "commons",
             Some("commons-receipt-abc".into()),
             true,
+            None,
             None,
             20,
         ))
@@ -6829,6 +6832,7 @@ mod tests {
             None,
             false,
             Some("member not found".into()),
+            None,
             20,
         ))
         .unwrap();
@@ -6838,6 +6842,7 @@ mod tests {
             "commons",
             Some("later-hash".into()),
             true,
+            None,
             None,
             30,
         ))

--- a/icn/apps/governance/tests/actor_path_dispatch_evidence_sink.rs
+++ b/icn/apps/governance/tests/actor_path_dispatch_evidence_sink.rs
@@ -42,7 +42,9 @@ use icn_governance_actor::{
     receipt_backend::GovernanceReceiptBackend, DeferredDispatchEvidenceSink, GovernanceCommand,
 };
 use icn_identity::IdentityBundle;
-use icn_kernel_api::effects::{DispatchEvidenceSink, EffectResult, KernelEffect, SdisEffect};
+use icn_kernel_api::effects::{
+    DispatchEvidenceSink, EffectOutcome, EffectResult, KernelEffect, SdisEffect,
+};
 use icn_store::SledStore;
 use std::sync::{Arc, Mutex};
 
@@ -174,6 +176,7 @@ fn ok_result(effect_id: &str) -> EffectResult {
         ledger_entry_id: None,
         not_executed: false,
         receipt_ref: None,
+        outcome: None,
     }
 }
 
@@ -189,6 +192,7 @@ fn ok_result_with_receipt_ref(effect_id: &str, receipt_ref: &str) -> EffectResul
         ledger_entry_id: None,
         not_executed: false,
         receipt_ref: Some(receipt_ref.into()),
+        outcome: None,
     }
 }
 
@@ -202,6 +206,7 @@ fn failure_result(effect_id: &str, message: &str) -> EffectResult {
         ledger_entry_id: None,
         not_executed: false,
         receipt_ref: None,
+        outcome: None,
     }
 }
 
@@ -382,6 +387,7 @@ async fn sink_skips_noop_effects() {
         ledger_entry_id: None,
         not_executed: true,
         receipt_ref: None,
+        outcome: None,
     }];
     sink.record_effects(
         "gov:domain-x:prop-noop:receipt",
@@ -572,6 +578,7 @@ async fn revoke_steward_noop_evidence_has_no_receipt_ref_but_is_success() {
         ledger_entry_id: None,
         not_executed: false,
         receipt_ref: None,
+        outcome: None,
     }];
 
     sink.record_effects(
@@ -1080,5 +1087,260 @@ async fn deferred_sink_second_install_is_idempotent_no_op() {
     assert!(
         backend_b.evidence_for("prop-idem").is_empty(),
         "second install must not rebind the backend"
+    );
+}
+
+// =============================================================================
+// Phase 2: EffectResult.outcome → EffectDispatchEvidence.outcome forwarding
+// =============================================================================
+//
+// Pins that the sink copies `result.outcome` through to the durable evidence
+// row verbatim — no reclassification, no reconstruction from (success,
+// state_change_hash, receipt_ref). Audit can distinguish applied / no_op /
+// partial / failed without guessing.
+
+/// Successful appoint: outcome=Applied is persisted.
+#[tokio::test(flavor = "current_thread")]
+async fn sink_forwards_applied_outcome() {
+    let backend = Arc::new(MemoryReceiptBackend::new());
+    let ier = InstitutionalEffectRecord::new(
+        "prop-outcome-applied",
+        "coop",
+        None,
+        "appoint_steward",
+        Some("did:icn:s".into()),
+        Some("r".into()),
+        None,
+        1,
+        serde_json::json!({}),
+    );
+    backend.put_institutional_effect(&ier).unwrap();
+
+    let sink =
+        GovernanceDispatchEvidenceSink::new(backend.clone() as Arc<dyn GovernanceReceiptBackend>);
+    let candidate: icn_identity::Did = IdentityBundle::generate().unwrap().did().clone();
+    let effects = vec![sdis_approve_effect(&candidate, "prop-outcome-applied")];
+    let results = vec![EffectResult {
+        effect_id: "eff-app".into(),
+        success: true,
+        message: "ok".into(),
+        state_change_hash: Some("hash".into()),
+        ledger_entry_id: None,
+        not_executed: false,
+        receipt_ref: Some("handle".into()),
+        outcome: Some(EffectOutcome::Applied),
+    }];
+
+    sink.record_effects(
+        "gov:d:prop-outcome-applied:receipt",
+        &effects,
+        &results,
+        1_700_040_000,
+    );
+
+    let ev = backend.evidence_for("prop-outcome-applied");
+    assert_eq!(ev.len(), 1);
+    assert_eq!(ev[0].outcome, Some(EffectOutcome::Applied));
+}
+
+/// No-op revoke: outcome=NoOp is persisted — distinct from Applied even
+/// though success=true in both.
+#[tokio::test(flavor = "current_thread")]
+async fn sink_forwards_noop_outcome() {
+    let backend = Arc::new(MemoryReceiptBackend::new());
+    let ier = InstitutionalEffectRecord::new(
+        "prop-outcome-noop",
+        "coop",
+        None,
+        "revoke_steward",
+        Some("did:icn:s".into()),
+        None,
+        None,
+        1,
+        serde_json::json!({}),
+    );
+    backend.put_institutional_effect(&ier).unwrap();
+
+    let sink =
+        GovernanceDispatchEvidenceSink::new(backend.clone() as Arc<dyn GovernanceReceiptBackend>);
+    let candidate: icn_identity::Did = IdentityBundle::generate().unwrap().did().clone();
+    let effects = vec![KernelEffect::Sdis(
+        icn_kernel_api::effects::SdisEffect::RevokeSteward {
+            steward_did: candidate.to_string(),
+            reason: "x".into(),
+        },
+    )];
+    let results = vec![EffectResult {
+        effect_id: "eff-noop".into(),
+        success: true,
+        message: "no active record".into(),
+        state_change_hash: None,
+        ledger_entry_id: None,
+        not_executed: false,
+        receipt_ref: None,
+        outcome: Some(EffectOutcome::NoOp),
+    }];
+
+    sink.record_effects(
+        "gov:d:prop-outcome-noop:receipt",
+        &effects,
+        &results,
+        1_700_040_001,
+    );
+
+    let ev = backend.evidence_for("prop-outcome-noop");
+    assert_eq!(ev.len(), 1);
+    assert_eq!(ev[0].outcome, Some(EffectOutcome::NoOp));
+    assert!(ev[0].success);
+}
+
+/// Partial sanction: outcome=Partial is persisted, with receipt_ref and
+/// state_change_hash preserved. This is the Codex P1 invariant.
+#[tokio::test(flavor = "current_thread")]
+async fn sink_forwards_partial_outcome_preserving_attribution() {
+    let backend = Arc::new(MemoryReceiptBackend::new());
+    let ier = InstitutionalEffectRecord::new(
+        "prop-outcome-partial",
+        "coop",
+        None,
+        "sanction_steward",
+        Some("did:icn:s".into()),
+        None,
+        None,
+        1,
+        serde_json::json!({}),
+    );
+    backend.put_institutional_effect(&ier).unwrap();
+
+    let sink =
+        GovernanceDispatchEvidenceSink::new(backend.clone() as Arc<dyn GovernanceReceiptBackend>);
+    let candidate: icn_identity::Did = IdentityBundle::generate().unwrap().did().clone();
+    let effects = vec![KernelEffect::Sdis(
+        icn_kernel_api::effects::SdisEffect::SanctionSteward {
+            steward_did: candidate.to_string(),
+            bond_slash_amount: 50,
+            suspend_reason: "breach".into(),
+            reason: "breach".into(),
+            proposal_id: "prop-outcome-partial".into(),
+        },
+    )];
+    let results = vec![EffectResult {
+        effect_id: "eff-partial".into(),
+        success: false,
+        message: "bond slashed but suspend failed: io".into(),
+        state_change_hash: Some("hash".into()),
+        ledger_entry_id: None,
+        not_executed: false,
+        receipt_ref: Some("handle".into()),
+        outcome: Some(EffectOutcome::Partial),
+    }];
+
+    sink.record_effects(
+        "gov:d:prop-outcome-partial:receipt",
+        &effects,
+        &results,
+        1_700_040_002,
+    );
+
+    let ev = backend.evidence_for("prop-outcome-partial");
+    assert_eq!(ev.len(), 1);
+    assert_eq!(
+        ev[0].outcome,
+        Some(EffectOutcome::Partial),
+        "partial mutation must be classified Partial on the durable row, \
+         not conflated with Failed"
+    );
+    assert!(!ev[0].success);
+    assert_eq!(
+        ev[0].receipt_ref.as_deref(),
+        Some("handle"),
+        "partial row must still carry the downstream handle"
+    );
+}
+
+/// Hard failure with no downstream handle: outcome=Failed is persisted and
+/// no attribution leaks onto the row.
+#[tokio::test(flavor = "current_thread")]
+async fn sink_forwards_failed_outcome() {
+    let backend = Arc::new(MemoryReceiptBackend::new());
+    let ier = InstitutionalEffectRecord::new(
+        "prop-outcome-failed",
+        "coop",
+        None,
+        "appoint_steward",
+        Some("did:icn:s".into()),
+        Some("r".into()),
+        None,
+        1,
+        serde_json::json!({}),
+    );
+    backend.put_institutional_effect(&ier).unwrap();
+
+    let sink =
+        GovernanceDispatchEvidenceSink::new(backend.clone() as Arc<dyn GovernanceReceiptBackend>);
+    let candidate: icn_identity::Did = IdentityBundle::generate().unwrap().did().clone();
+    let effects = vec![sdis_approve_effect(&candidate, "prop-outcome-failed")];
+    let results = vec![EffectResult {
+        effect_id: "eff-fail".into(),
+        success: false,
+        message: "commons error".into(),
+        state_change_hash: None,
+        ledger_entry_id: None,
+        not_executed: false,
+        receipt_ref: None,
+        outcome: Some(EffectOutcome::Failed),
+    }];
+
+    sink.record_effects(
+        "gov:d:prop-outcome-failed:receipt",
+        &effects,
+        &results,
+        1_700_040_003,
+    );
+
+    let ev = backend.evidence_for("prop-outcome-failed");
+    assert_eq!(ev.len(), 1);
+    assert_eq!(ev[0].outcome, Some(EffectOutcome::Failed));
+    assert!(!ev[0].success);
+    assert!(ev[0].receipt_ref.is_none());
+}
+
+/// Legacy result with `outcome: None` must persist as `None` (unclassified),
+/// not silently upgraded. This preserves the "None = unknown" convention so
+/// audit can distinguish pre-Phase-2 evidence from post-Phase-2 rows.
+#[tokio::test(flavor = "current_thread")]
+async fn sink_forwards_legacy_none_outcome_as_unclassified() {
+    let backend = Arc::new(MemoryReceiptBackend::new());
+    let ier = InstitutionalEffectRecord::new(
+        "prop-outcome-legacy",
+        "coop",
+        None,
+        "appoint_steward",
+        Some("did:icn:s".into()),
+        Some("r".into()),
+        None,
+        1,
+        serde_json::json!({}),
+    );
+    backend.put_institutional_effect(&ier).unwrap();
+
+    let sink =
+        GovernanceDispatchEvidenceSink::new(backend.clone() as Arc<dyn GovernanceReceiptBackend>);
+    let candidate: icn_identity::Did = IdentityBundle::generate().unwrap().did().clone();
+    let effects = vec![sdis_approve_effect(&candidate, "prop-outcome-legacy")];
+    let results = vec![ok_result("eff-legacy")]; // helper produces outcome=None
+
+    sink.record_effects(
+        "gov:d:prop-outcome-legacy:receipt",
+        &effects,
+        &results,
+        1_700_040_004,
+    );
+
+    let ev = backend.evidence_for("prop-outcome-legacy");
+    assert_eq!(ev.len(), 1);
+    assert_eq!(
+        ev[0].outcome, None,
+        "sink must not synthesize an outcome when the result left it unset"
     );
 }

--- a/icn/crates/icn-core/src/services/state_hash.rs
+++ b/icn/crates/icn-core/src/services/state_hash.rs
@@ -448,6 +448,7 @@ mod tests {
                 ledger_entry_id: None,
                 not_executed: false,
                 receipt_ref: None,
+                outcome: None,
             },
             EffectResult {
                 effect_id: "membership_0".into(),
@@ -457,6 +458,7 @@ mod tests {
                 ledger_entry_id: None,
                 not_executed: false,
                 receipt_ref: None,
+                outcome: None,
             },
             EffectResult {
                 effect_id: "no_hash".into(),
@@ -466,6 +468,7 @@ mod tests {
                 ledger_entry_id: None,
                 not_executed: false,
                 receipt_ref: None,
+                outcome: None,
             },
         ];
 
@@ -485,6 +488,7 @@ mod tests {
             ledger_entry_id: None,
             not_executed: false,
             receipt_ref: None,
+            outcome: None,
         }];
 
         let results_b = vec![EffectResult {
@@ -495,6 +499,7 @@ mod tests {
             ledger_entry_id: None,
             not_executed: false,
             receipt_ref: None,
+            outcome: None,
         }];
 
         assert!(verify_effect_results_match(&results_a, &results_b));
@@ -510,6 +515,7 @@ mod tests {
             ledger_entry_id: None,
             not_executed: false,
             receipt_ref: None,
+            outcome: None,
         }];
 
         let results_b = vec![EffectResult {
@@ -520,6 +526,7 @@ mod tests {
             ledger_entry_id: None,
             not_executed: false,
             receipt_ref: None,
+            outcome: None,
         }];
 
         let comparison = compare_effect_results(&results_a, &results_b);

--- a/icn/crates/icn-core/src/supervisor/effect_dispatcher.rs
+++ b/icn/crates/icn-core/src/supervisor/effect_dispatcher.rs
@@ -119,6 +119,7 @@ impl EffectDispatcher {
                         ledger_entry_id: None,
                         not_executed: false,
                         receipt_ref: None,
+                        outcome: None,
                     };
                     row.debug_assert_semantic_invariants();
                     results.push(row);

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -17,7 +17,8 @@ use anyhow::Result;
 use async_trait::async_trait;
 use icn_kernel_api::budget::{BeginSpendOutcome, BudgetRecord, BudgetSpendError, BudgetStore};
 use icn_kernel_api::effects::{
-    ControlEffect, EffectResult, KernelEffect, MembershipEffect, ResourceEffect, TreasuryEffect,
+    ControlEffect, EffectOutcome, EffectResult, KernelEffect, MembershipEffect, ResourceEffect,
+    TreasuryEffect,
 };
 use icn_kernel_api::escrow::{BeginReleaseOutcome, EscrowReleaseError, EscrowStore};
 use icn_kernel_api::governance::{
@@ -170,6 +171,7 @@ impl KernelGovernanceExecutor {
                                 ledger_entry_id: None,
                                 not_executed: false,
                                 receipt_ref: None,
+                                outcome: None,
                             });
                         }
                     }
@@ -231,6 +233,7 @@ impl KernelGovernanceExecutor {
                             ledger_entry_id: None,
                             not_executed: false,
                             receipt_ref: None,
+                            outcome: None,
                         });
                     }
                 };
@@ -246,6 +249,7 @@ impl KernelGovernanceExecutor {
                             ledger_entry_id: None,
                             not_executed: false,
                             receipt_ref: None,
+                            outcome: None,
                         });
                     }
                 };
@@ -270,6 +274,7 @@ impl KernelGovernanceExecutor {
                             ledger_entry_id: None,
                             not_executed: false,
                             receipt_ref: None,
+                            outcome: None,
                         });
                     }
                     Err(e) => {
@@ -286,6 +291,7 @@ impl KernelGovernanceExecutor {
                             ledger_entry_id: None,
                             not_executed: false,
                             receipt_ref: None,
+                            outcome: None,
                         });
                     }
                 }
@@ -405,6 +411,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                             ledger_entry_id: None,
                             not_executed: false,
                             receipt_ref: None,
+                            outcome: None,
                         });
                     }
                 };
@@ -425,6 +432,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                             ledger_entry_id: None,
                             not_executed: false,
                             receipt_ref: None,
+                            outcome: None,
                         });
                     }
                 };
@@ -468,6 +476,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                             ledger_entry_id: None,
                             not_executed: false,
                             receipt_ref: None,
+                            outcome: None,
                         });
                     }
                     Err(EscrowReleaseError::AlreadyReleasedByOther {
@@ -490,6 +499,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                             ledger_entry_id: None,
                             not_executed: false,
                             receipt_ref: None,
+                            outcome: None,
                         });
                     }
                     Err(EscrowReleaseError::Cancelled) => {
@@ -505,6 +515,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                             ledger_entry_id: None,
                             not_executed: false,
                             receipt_ref: None,
+                            outcome: None,
                         });
                     }
                     Err(EscrowReleaseError::Failed {
@@ -529,6 +540,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                             ledger_entry_id: None,
                             not_executed: false,
                             receipt_ref: None,
+                            outcome: None,
                         });
                     }
                 }
@@ -623,6 +635,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                         ledger_entry_id: None,
                         not_executed: false,
                         receipt_ref: None,
+                        outcome: None,
                     })
                 }
             }
@@ -654,6 +667,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                     ledger_entry_id: None,
                     not_executed: true,
                     receipt_ref: None,
+                    outcome: None,
                 })
             }
             KernelEffect::Control(control_effect) => {
@@ -694,6 +708,7 @@ impl EffectExecutor for KernelGovernanceExecutor {
                     ledger_entry_id: None,
                     not_executed: false,
                     receipt_ref: None,
+                    outcome: None,
                 })
             }
             KernelEffect::Resource(resource_effect) => {
@@ -729,6 +744,7 @@ impl KernelGovernanceExecutor {
                     ledger_entry_id: None,
                     not_executed: false,
                     receipt_ref: None,
+                    outcome: None,
                 });
             }
         };
@@ -773,6 +789,7 @@ impl KernelGovernanceExecutor {
                         ledger_entry_id: None,
                         not_executed: false,
                         receipt_ref: None,
+                        outcome: None,
                     }),
                     Err(e) => Ok(EffectResult {
                         effect_id: decision_receipt_id.to_string(),
@@ -782,6 +799,7 @@ impl KernelGovernanceExecutor {
                         ledger_entry_id: None,
                         not_executed: false,
                         receipt_ref: None,
+                        outcome: None,
                     }),
                 }
             }
@@ -806,6 +824,7 @@ impl KernelGovernanceExecutor {
                         ledger_entry_id: None,
                         not_executed: false,
                         receipt_ref: None,
+                        outcome: None,
                     }),
                     Err(e) => Ok(EffectResult {
                         effect_id: decision_receipt_id.to_string(),
@@ -815,6 +834,7 @@ impl KernelGovernanceExecutor {
                         ledger_entry_id: None,
                         not_executed: false,
                         receipt_ref: None,
+                        outcome: None,
                     }),
                 }
             }
@@ -1664,6 +1684,7 @@ fn execution_outcome_to_effect_result(outcome: ExecutionOutcome, effect_id: &str
                 ledger_entry_id,
                 not_executed: false,
                 receipt_ref: None,
+                outcome: None,
             }
         }
         ExecutionOutcome::Failed { reason, .. } => EffectResult {
@@ -1674,6 +1695,7 @@ fn execution_outcome_to_effect_result(outcome: ExecutionOutcome, effect_id: &str
             ledger_entry_id: None,
             not_executed: false,
             receipt_ref: None,
+            outcome: None,
         },
         ExecutionOutcome::Deferred { reason, .. } => EffectResult {
             effect_id: effect_id.to_string(),
@@ -1683,6 +1705,7 @@ fn execution_outcome_to_effect_result(outcome: ExecutionOutcome, effect_id: &str
             ledger_entry_id: None,
             not_executed: true,
             receipt_ref: None,
+            outcome: None,
         },
     }
 }
@@ -2157,6 +2180,7 @@ impl KernelSdisExecutor {
                 ledger_entry_id: None,
                 not_executed: false,
                 receipt_ref: None,
+                outcome: Some(EffectOutcome::Failed),
             });
         };
 
@@ -2196,6 +2220,7 @@ impl KernelSdisExecutor {
                         ledger_entry_id: None,
                         not_executed: false,
                         receipt_ref: result.receipt_ref,
+                        outcome: Some(EffectOutcome::Applied),
                     })
                 } else {
                     Ok(EffectResult {
@@ -2208,6 +2233,7 @@ impl KernelSdisExecutor {
                         ledger_entry_id: None,
                         not_executed: false,
                         receipt_ref: None,
+                        outcome: Some(EffectOutcome::Failed),
                     })
                 }
             }
@@ -2242,6 +2268,7 @@ impl KernelSdisExecutor {
                             ledger_entry_id: None,
                             not_executed: false,
                             receipt_ref: result.receipt_ref,
+                            outcome: Some(EffectOutcome::Applied),
                         })
                     } else {
                         info!(
@@ -2259,6 +2286,7 @@ impl KernelSdisExecutor {
                             ledger_entry_id: None,
                             not_executed: false,
                             receipt_ref: None,
+                            outcome: Some(EffectOutcome::NoOp),
                         })
                     }
                 } else {
@@ -2272,6 +2300,7 @@ impl KernelSdisExecutor {
                         ledger_entry_id: None,
                         not_executed: false,
                         receipt_ref: None,
+                        outcome: Some(EffectOutcome::Failed),
                     })
                 }
             }
@@ -2303,6 +2332,7 @@ impl KernelSdisExecutor {
                         ledger_entry_id: None,
                         not_executed: false,
                         receipt_ref: result.receipt_ref,
+                        outcome: Some(EffectOutcome::Applied),
                     })
                 } else {
                     Ok(EffectResult {
@@ -2315,6 +2345,7 @@ impl KernelSdisExecutor {
                         ledger_entry_id: None,
                         not_executed: false,
                         receipt_ref: None,
+                        outcome: Some(EffectOutcome::Failed),
                     })
                 }
             }
@@ -2364,6 +2395,11 @@ impl KernelSdisExecutor {
                         ledger_entry_id: None,
                         not_executed: false,
                         receipt_ref: result.receipt_ref,
+                        outcome: if result.was_suspended {
+                            Some(EffectOutcome::Applied)
+                        } else {
+                            Some(EffectOutcome::NoOp)
+                        },
                     })
                 } else {
                     Ok(EffectResult {
@@ -2376,6 +2412,7 @@ impl KernelSdisExecutor {
                         ledger_entry_id: None,
                         not_executed: false,
                         receipt_ref: None,
+                        outcome: Some(EffectOutcome::Failed),
                     })
                 }
             }
@@ -2412,6 +2449,7 @@ impl KernelSdisExecutor {
                         ledger_entry_id: None,
                         not_executed: false,
                         receipt_ref: result.receipt_ref,
+                        outcome: Some(EffectOutcome::Applied),
                     })
                 } else {
                     Ok(EffectResult {
@@ -2424,6 +2462,7 @@ impl KernelSdisExecutor {
                         ledger_entry_id: None,
                         not_executed: false,
                         receipt_ref: None,
+                        outcome: Some(EffectOutcome::Failed),
                     })
                 }
             }
@@ -2462,6 +2501,7 @@ impl KernelSdisExecutor {
                         ledger_entry_id: None,
                         not_executed: false,
                         receipt_ref: result.receipt_ref,
+                        outcome: Some(EffectOutcome::Applied),
                     })
                 } else {
                     // success=false is either a hard pre-slash failure (no
@@ -2482,6 +2522,14 @@ impl KernelSdisExecutor {
                             "Sanction partially applied (bond slashed, later step failed); preserving attribution"
                         );
                     }
+                    let outcome = if state_change_hash.is_some() {
+                        // Bond slashed but a later step failed — partial
+                        // mutation with durable attribution preserved.
+                        Some(EffectOutcome::Partial)
+                    } else {
+                        // Pre-slash failure: no commons state change.
+                        Some(EffectOutcome::Failed)
+                    };
                     Ok(EffectResult {
                         effect_id: decision_receipt_id.to_string(),
                         success: false,
@@ -2492,6 +2540,7 @@ impl KernelSdisExecutor {
                         ledger_entry_id: None,
                         not_executed: false,
                         receipt_ref: result.receipt_ref,
+                        outcome,
                     })
                 }
             }
@@ -3251,5 +3300,415 @@ mod tests {
             "NoOp message should state not executed: {}",
             effect_result.message
         );
+    }
+
+    // =========================================================================
+    // SDIS EffectOutcome classification — Phase 2 seam
+    // =========================================================================
+    //
+    // These tests pin the mapping from SdisService results to
+    // `EffectResult.outcome`. They intentionally bypass the real
+    // `SdisServiceImpl`/`CommonsHandle` path and inject a canned result per
+    // SDIS arm, so the assertions cover only the executor's classification
+    // rule (what counts as Applied / NoOp / Partial / Failed), not the
+    // commons layer.
+    //
+    // Coverage matrix:
+    //   ApproveSteward     → Applied / Failed
+    //   RevokeSteward      → Applied (with receipt_ref) / NoOp / Failed
+    //   ReconfirmSteward   → Applied / Failed
+    //   ReinstateSteward   → Applied (was_suspended=true) / NoOp (was_suspended=false) / Failed
+    //   SuspendSteward     → Applied / Failed
+    //   SanctionSteward    → Applied / Partial (slash committed, later step failed) / Failed
+    //   service missing    → Failed
+
+    mod sdis_outcome_classification {
+        use super::*;
+        use icn_kernel_api::effects::{EffectOutcome, SdisEffect};
+        use icn_kernel_api::{
+            AppointStewardRequest, AppointStewardResult, ReconfirmStewardRequest,
+            ReconfirmStewardResult, ReinstateStewardRequest, ReinstateStewardResult,
+            RevokeStewardRequest, RevokeStewardResult, SanctionStewardRequest,
+            SanctionStewardResult, SdisService, SuspendStewardRequest, SuspendStewardResult,
+        };
+        use std::sync::Arc;
+
+        /// Canned-response SdisService: each method returns a pre-seeded
+        /// result. Unused arms panic so tests stay loud about accidental
+        /// coverage gaps.
+        struct StubSdisService {
+            appoint: Option<AppointStewardResult>,
+            revoke: Option<RevokeStewardResult>,
+            reconfirm: Option<ReconfirmStewardResult>,
+            reinstate: Option<ReinstateStewardResult>,
+            suspend: Option<SuspendStewardResult>,
+            sanction: Option<SanctionStewardResult>,
+        }
+
+        impl StubSdisService {
+            fn empty() -> Self {
+                Self {
+                    appoint: None,
+                    revoke: None,
+                    reconfirm: None,
+                    reinstate: None,
+                    suspend: None,
+                    sanction: None,
+                }
+            }
+        }
+
+        impl SdisService for StubSdisService {
+            fn appoint_steward(
+                &self,
+                _: AppointStewardRequest,
+            ) -> std::result::Result<AppointStewardResult, anyhow::Error> {
+                Ok(self
+                    .appoint
+                    .clone()
+                    .expect("appoint result not seeded in stub"))
+            }
+            fn revoke_steward(
+                &self,
+                _: RevokeStewardRequest,
+            ) -> std::result::Result<RevokeStewardResult, anyhow::Error> {
+                Ok(self
+                    .revoke
+                    .clone()
+                    .expect("revoke result not seeded in stub"))
+            }
+            fn reconfirm_steward(
+                &self,
+                _: ReconfirmStewardRequest,
+            ) -> std::result::Result<ReconfirmStewardResult, anyhow::Error> {
+                Ok(self
+                    .reconfirm
+                    .clone()
+                    .expect("reconfirm result not seeded in stub"))
+            }
+            fn reinstate_steward(
+                &self,
+                _: ReinstateStewardRequest,
+            ) -> std::result::Result<ReinstateStewardResult, anyhow::Error> {
+                Ok(self
+                    .reinstate
+                    .clone()
+                    .expect("reinstate result not seeded in stub"))
+            }
+            fn suspend_steward(
+                &self,
+                _: SuspendStewardRequest,
+            ) -> std::result::Result<SuspendStewardResult, anyhow::Error> {
+                Ok(self
+                    .suspend
+                    .clone()
+                    .expect("suspend result not seeded in stub"))
+            }
+            fn sanction_steward(
+                &self,
+                _: SanctionStewardRequest,
+            ) -> std::result::Result<SanctionStewardResult, anyhow::Error> {
+                Ok(self
+                    .sanction
+                    .clone()
+                    .expect("sanction result not seeded in stub"))
+            }
+        }
+
+        fn exec_with(stub: StubSdisService, effect: SdisEffect) -> EffectResult {
+            let svc: Arc<dyn SdisService> = Arc::new(stub);
+            KernelSdisExecutor::with_service(svc)
+                .execute_sdis_effect(&effect, "gov:t:p:receipt")
+                .expect("executor must not error in classification tests")
+        }
+
+        fn approve_effect() -> SdisEffect {
+            SdisEffect::ApproveSteward {
+                steward_did: "did:icn:s".into(),
+                jurisdiction_id: "jur".into(),
+                term_length_seconds: 3600,
+                bond_amount: 100,
+                region: None,
+                proposal_id: "p".into(),
+                capabilities_hash: String::new(),
+            }
+        }
+
+        #[test]
+        fn approve_success_classifies_as_applied() {
+            let mut stub = StubSdisService::empty();
+            stub.appoint = Some(AppointStewardResult {
+                success: true,
+                state_change_hash: "hash".into(),
+                error: None,
+                receipt_ref: Some("handle".into()),
+            });
+            let r = exec_with(stub, approve_effect());
+            assert!(r.success);
+            assert_eq!(r.outcome, Some(EffectOutcome::Applied));
+            assert_eq!(r.receipt_ref.as_deref(), Some("handle"));
+        }
+
+        #[test]
+        fn approve_failure_classifies_as_failed() {
+            let mut stub = StubSdisService::empty();
+            stub.appoint = Some(AppointStewardResult {
+                success: false,
+                state_change_hash: String::new(),
+                error: Some("commons error".into()),
+                receipt_ref: None,
+            });
+            let r = exec_with(stub, approve_effect());
+            assert!(!r.success);
+            assert_eq!(r.outcome, Some(EffectOutcome::Failed));
+            assert!(r.receipt_ref.is_none());
+            assert!(r.state_change_hash.is_none());
+        }
+
+        #[test]
+        fn revoke_with_receipt_ref_classifies_as_applied() {
+            let mut stub = StubSdisService::empty();
+            stub.revoke = Some(RevokeStewardResult {
+                success: true,
+                state_change_hash: "hash".into(),
+                error: None,
+                receipt_ref: Some("handle".into()),
+            });
+            let r = exec_with(
+                stub,
+                SdisEffect::RevokeSteward {
+                    steward_did: "did:icn:s".into(),
+                    reason: "ended".into(),
+                },
+            );
+            assert!(r.success);
+            assert_eq!(r.outcome, Some(EffectOutcome::Applied));
+        }
+
+        #[test]
+        fn revoke_no_active_record_classifies_as_noop() {
+            let mut stub = StubSdisService::empty();
+            stub.revoke = Some(RevokeStewardResult {
+                success: true,
+                state_change_hash: String::new(),
+                error: None,
+                receipt_ref: None,
+            });
+            let r = exec_with(
+                stub,
+                SdisEffect::RevokeSteward {
+                    steward_did: "did:icn:s".into(),
+                    reason: "ended".into(),
+                },
+            );
+            assert!(r.success);
+            assert_eq!(r.outcome, Some(EffectOutcome::NoOp));
+            assert!(r.receipt_ref.is_none());
+            assert!(r.state_change_hash.is_none());
+        }
+
+        #[test]
+        fn revoke_failure_classifies_as_failed() {
+            let mut stub = StubSdisService::empty();
+            stub.revoke = Some(RevokeStewardResult {
+                success: false,
+                state_change_hash: String::new(),
+                error: Some("boom".into()),
+                receipt_ref: None,
+            });
+            let r = exec_with(
+                stub,
+                SdisEffect::RevokeSteward {
+                    steward_did: "did:icn:s".into(),
+                    reason: "ended".into(),
+                },
+            );
+            assert!(!r.success);
+            assert_eq!(r.outcome, Some(EffectOutcome::Failed));
+        }
+
+        #[test]
+        fn reconfirm_success_classifies_as_applied() {
+            let mut stub = StubSdisService::empty();
+            stub.reconfirm = Some(ReconfirmStewardResult {
+                success: true,
+                state_change_hash: "hash".into(),
+                error: None,
+                receipt_ref: Some("handle".into()),
+            });
+            let r = exec_with(
+                stub,
+                SdisEffect::ReconfirmSteward {
+                    steward_did: "did:icn:s".into(),
+                    new_term_end: 9_999_999_999,
+                    proposal_id: "p".into(),
+                },
+            );
+            assert_eq!(r.outcome, Some(EffectOutcome::Applied));
+        }
+
+        #[test]
+        fn reinstate_was_suspended_classifies_as_applied() {
+            let mut stub = StubSdisService::empty();
+            stub.reinstate = Some(ReinstateStewardResult {
+                success: true,
+                was_suspended: true,
+                state_change_hash: "hash".into(),
+                error: None,
+                receipt_ref: Some("handle".into()),
+            });
+            let r = exec_with(
+                stub,
+                SdisEffect::ReinstateSteward {
+                    steward_did: "did:icn:s".into(),
+                    proposal_id: "p".into(),
+                },
+            );
+            assert!(r.success);
+            assert_eq!(r.outcome, Some(EffectOutcome::Applied));
+        }
+
+        #[test]
+        fn reinstate_not_suspended_classifies_as_noop() {
+            let mut stub = StubSdisService::empty();
+            stub.reinstate = Some(ReinstateStewardResult {
+                success: true,
+                was_suspended: false,
+                state_change_hash: String::new(),
+                error: None,
+                receipt_ref: Some("handle".into()),
+            });
+            let r = exec_with(
+                stub,
+                SdisEffect::ReinstateSteward {
+                    steward_did: "did:icn:s".into(),
+                    proposal_id: "p".into(),
+                },
+            );
+            assert!(r.success);
+            assert_eq!(r.outcome, Some(EffectOutcome::NoOp));
+            // receipt_ref still forwarded — a real commons record existed.
+            assert_eq!(r.receipt_ref.as_deref(), Some("handle"));
+            // state_change_hash stays None — no mutation actually occurred.
+            assert!(r.state_change_hash.is_none());
+        }
+
+        #[test]
+        fn suspend_success_classifies_as_applied() {
+            let mut stub = StubSdisService::empty();
+            stub.suspend = Some(SuspendStewardResult {
+                success: true,
+                state_change_hash: "hash".into(),
+                error: None,
+                receipt_ref: Some("handle".into()),
+            });
+            let r = exec_with(
+                stub,
+                SdisEffect::SuspendSteward {
+                    steward_did: "did:icn:s".into(),
+                    reason: "x".into(),
+                    duration_seconds: 3600,
+                    proposal_id: "p".into(),
+                },
+            );
+            assert_eq!(r.outcome, Some(EffectOutcome::Applied));
+        }
+
+        #[test]
+        fn sanction_full_success_classifies_as_applied() {
+            let mut stub = StubSdisService::empty();
+            stub.sanction = Some(SanctionStewardResult {
+                success: true,
+                remaining_bond: 250,
+                suspended: true,
+                state_change_hash: "hash".into(),
+                error: None,
+                receipt_ref: Some("handle".into()),
+            });
+            let r = exec_with(
+                stub,
+                SdisEffect::SanctionSteward {
+                    steward_did: "did:icn:s".into(),
+                    bond_slash_amount: 50,
+                    suspend_reason: "serious".into(),
+                    reason: "serious".into(),
+                    proposal_id: "p".into(),
+                },
+            );
+            assert!(r.success);
+            assert_eq!(r.outcome, Some(EffectOutcome::Applied));
+        }
+
+        #[test]
+        fn sanction_partial_mutation_classifies_as_partial() {
+            // Slash committed, suspend failed: success=false but
+            // state_change_hash + receipt_ref are populated. This is the
+            // Codex P1 path — the executor must mark it Partial and
+            // preserve the durable attribution.
+            let mut stub = StubSdisService::empty();
+            stub.sanction = Some(SanctionStewardResult {
+                success: false,
+                remaining_bond: 250,
+                suspended: false,
+                state_change_hash: "hash".into(),
+                error: Some("bond slashed but suspend failed: io".into()),
+                receipt_ref: Some("handle".into()),
+            });
+            let r = exec_with(
+                stub,
+                SdisEffect::SanctionSteward {
+                    steward_did: "did:icn:s".into(),
+                    bond_slash_amount: 50,
+                    suspend_reason: "serious".into(),
+                    reason: "serious".into(),
+                    proposal_id: "p".into(),
+                },
+            );
+            assert!(!r.success);
+            assert_eq!(
+                r.outcome,
+                Some(EffectOutcome::Partial),
+                "slash-committed + later-step-failed must be Partial, not Failed"
+            );
+            assert_eq!(r.receipt_ref.as_deref(), Some("handle"));
+            assert_eq!(r.state_change_hash.as_deref(), Some("hash"));
+        }
+
+        #[test]
+        fn sanction_pre_slash_failure_classifies_as_failed() {
+            let mut stub = StubSdisService::empty();
+            stub.sanction = Some(SanctionStewardResult {
+                success: false,
+                remaining_bond: 0,
+                suspended: false,
+                state_change_hash: String::new(),
+                error: Some("steward not found".into()),
+                receipt_ref: None,
+            });
+            let r = exec_with(
+                stub,
+                SdisEffect::SanctionSteward {
+                    steward_did: "did:icn:s".into(),
+                    bond_slash_amount: 50,
+                    suspend_reason: "serious".into(),
+                    reason: "serious".into(),
+                    proposal_id: "p".into(),
+                },
+            );
+            assert!(!r.success);
+            assert_eq!(r.outcome, Some(EffectOutcome::Failed));
+            assert!(r.receipt_ref.is_none());
+            assert!(r.state_change_hash.is_none());
+        }
+
+        #[test]
+        fn missing_service_classifies_as_failed() {
+            // No service wired → executor returns a synthetic failure.
+            let r = KernelSdisExecutor::new()
+                .execute_sdis_effect(&approve_effect(), "gov:t:p:receipt")
+                .expect("no-service path is a success-result with failure classification");
+            assert!(!r.success);
+            assert_eq!(r.outcome, Some(EffectOutcome::Failed));
+        }
     }
 }

--- a/icn/crates/icn-core/tests/federated_two_node_pilot.rs
+++ b/icn/crates/icn-core/tests/federated_two_node_pilot.rs
@@ -731,6 +731,7 @@ async fn test_two_node_effect_batch_determinism() -> Result<()> {
                             ledger_entry_id: None,
                             not_executed: false,
                             receipt_ref: None,
+                            outcome: None,
                         }
                     }
                     _ => panic!("Batch effect failed on Node A"),
@@ -747,6 +748,7 @@ async fn test_two_node_effect_batch_determinism() -> Result<()> {
                 ledger_entry_id: None,
                 not_executed: true,
                 receipt_ref: None,
+                outcome: None,
             },
             _ => panic!("Unexpected effect type in batch"),
         };
@@ -785,6 +787,7 @@ async fn test_two_node_effect_batch_determinism() -> Result<()> {
                             ledger_entry_id: None,
                             not_executed: false,
                             receipt_ref: None,
+                            outcome: None,
                         }
                     }
                     _ => panic!("Batch effect failed on Node B"),
@@ -801,6 +804,7 @@ async fn test_two_node_effect_batch_determinism() -> Result<()> {
                 ledger_entry_id: None,
                 not_executed: true,
                 receipt_ref: None,
+                outcome: None,
             },
             _ => panic!("Unexpected effect type in batch"),
         };

--- a/icn/crates/icn-gateway/src/receipt_store.rs
+++ b/icn/crates/icn-gateway/src/receipt_store.rs
@@ -872,6 +872,7 @@ mod tests {
             Some("state-hash-1".into()),
             true,
             None,
+            None,
             100,
         );
         let newer = EffectDispatchEvidence::new(
@@ -881,6 +882,7 @@ mod tests {
             Some("state-hash-2".into()),
             false,
             Some("boom".into()),
+            None,
             200,
         );
 
@@ -903,12 +905,12 @@ mod tests {
         let store = ReceiptStore::new(temp_db());
         store
             .put_effect_dispatch_evidence(&EffectDispatchEvidence::new(
-                "rec-a", "prop-1", "sdis", None, true, None, 10,
+                "rec-a", "prop-1", "sdis", None, true, None, None, 10,
             ))
             .unwrap();
         store
             .put_effect_dispatch_evidence(&EffectDispatchEvidence::new(
-                "rec-b", "prop-2", "sdis", None, true, None, 20,
+                "rec-b", "prop-2", "sdis", None, true, None, None, 20,
             ))
             .unwrap();
 
@@ -932,7 +934,8 @@ mod tests {
     #[test]
     fn dispatch_evidence_duplicate_evidence_id_is_idempotent() {
         let store = ReceiptStore::new(temp_db());
-        let ev = EffectDispatchEvidence::new("rec-dup", "prop-dup", "sdis", None, true, None, 10);
+        let ev =
+            EffectDispatchEvidence::new("rec-dup", "prop-dup", "sdis", None, true, None, None, 10);
         store.put_effect_dispatch_evidence(&ev).unwrap();
         store.put_effect_dispatch_evidence(&ev).unwrap();
 

--- a/icn/crates/icn-kernel-api/src/effects.rs
+++ b/icn/crates/icn-kernel-api/src/effects.rs
@@ -506,6 +506,47 @@ pub enum SdisEffect {
 // Execution Result
 // =============================================================================
 
+/// Explicit outcome semantics for a kernel-dispatched effect.
+///
+/// Kernel-neutral: describes the **structural** result of an effect
+/// (whether durable state changed, fully or partially) without referring to
+/// any domain concept. Orthogonal to the boolean `success` / `not_executed`
+/// flags, which were insufficient to distinguish four real-world cases:
+///
+/// - [`Applied`](Self::Applied): execution committed the intended durable
+///   change.
+/// - [`NoOp`](Self::NoOp): the target was already in the desired state and
+///   the executing service intentionally made no change. `state_change_hash`
+///   should be `None`.
+/// - [`Partial`](Self::Partial): a multi-step effect committed some durable
+///   changes but a later step failed. Attribution (`receipt_ref`,
+///   `state_change_hash`) must remain populated — the change really happened.
+/// - [`Failed`](Self::Failed): hard failure with no durable mutation.
+///
+/// Additive on the wire: legacy readers that don't know this field receive
+/// `None` (see [`EffectResult::outcome`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EffectOutcome {
+    Applied,
+    NoOp,
+    Partial,
+    Failed,
+}
+
+impl EffectOutcome {
+    /// Short lowercase label for logs / audit rows. Matches serde repr.
+    #[inline]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            EffectOutcome::Applied => "applied",
+            EffectOutcome::NoOp => "no_op",
+            EffectOutcome::Partial => "partial",
+            EffectOutcome::Failed => "failed",
+        }
+    }
+}
+
 /// Result of executing a kernel effect
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EffectResult {
@@ -543,6 +584,15 @@ pub struct EffectResult {
     /// kernel boundary.
     #[serde(default)]
     pub receipt_ref: Option<String>,
+    /// Explicit structural outcome class — see [`EffectOutcome`].
+    ///
+    /// Populated by service layers that know which class applies. `None` is
+    /// intentionally distinct from [`EffectOutcome::Applied`] so legacy or
+    /// unclassified rows are visibly unclassified rather than silently
+    /// misclassified. Complements — does not replace — `success`,
+    /// `not_executed`, `state_change_hash`, and `receipt_ref`.
+    #[serde(default)]
+    pub outcome: Option<EffectOutcome>,
 }
 
 impl EffectResult {
@@ -691,6 +741,7 @@ mod tests {
             ledger_entry_id: None,
             not_executed: false,
             receipt_ref: None,
+            outcome: None,
         };
         assert!(hard.is_hard_failure());
         assert!(!hard.is_structurally_not_executed());
@@ -703,6 +754,7 @@ mod tests {
             ledger_entry_id: None,
             not_executed: true,
             receipt_ref: None,
+            outcome: None,
         };
         assert!(!nx.is_hard_failure());
         assert!(nx.is_structurally_not_executed());
@@ -715,6 +767,7 @@ mod tests {
             ledger_entry_id: Some("L1".into()),
             not_executed: false,
             receipt_ref: None,
+            outcome: None,
         };
         assert!(!ok.is_hard_failure());
         assert!(!ok.is_structurally_not_executed());
@@ -731,6 +784,7 @@ mod tests {
                 ledger_entry_id: None,
                 not_executed: true,
                 receipt_ref: None,
+                outcome: None,
             },
             EffectResult {
                 effect_id: "b".into(),
@@ -740,6 +794,7 @@ mod tests {
                 ledger_entry_id: None,
                 not_executed: false,
                 receipt_ref: None,
+                outcome: None,
             },
         ];
         for r in &rows {
@@ -960,6 +1015,7 @@ mod tests {
                 ledger_entry_id: Some("entry-123".into()),
                 not_executed: false,
                 receipt_ref: None,
+                outcome: None,
             },
             EffectResult {
                 effect_id: "eff-2".into(),
@@ -969,6 +1025,7 @@ mod tests {
                 ledger_entry_id: None,
                 not_executed: false,
                 receipt_ref: None,
+                outcome: None,
             },
         ];
 

--- a/icn/crates/icn-kernel-api/src/governance.rs
+++ b/icn/crates/icn-kernel-api/src/governance.rs
@@ -265,6 +265,7 @@ impl EffectExecutor for DefaultEffectExecutor {
                 ledger_entry_id: None,
                 not_executed: false,
                 receipt_ref: None,
+                outcome: None,
             }),
             KernelEffect::Treasury(treasury_effect) => {
                 // Convert TreasuryEffect to TreasuryOperation
@@ -298,6 +299,7 @@ impl EffectExecutor for DefaultEffectExecutor {
                         ledger_entry_id: None,
                         not_executed: false,
                         receipt_ref: None,
+                        outcome: None,
                     })
                 }
             }
@@ -312,6 +314,7 @@ impl EffectExecutor for DefaultEffectExecutor {
                 ledger_entry_id: None,
                 not_executed: true,
                 receipt_ref: None,
+                outcome: None,
             }),
             // For other effect types, return success placeholder
             _ => Ok(EffectResult {
@@ -322,6 +325,7 @@ impl EffectExecutor for DefaultEffectExecutor {
                 ledger_entry_id: None,
                 not_executed: false,
                 receipt_ref: None,
+                outcome: None,
             }),
         }
     }
@@ -550,6 +554,7 @@ fn execution_outcome_to_effect_result(outcome: ExecutionOutcome, effect_id: &str
             ledger_entry_id: None,
             not_executed: false,
             receipt_ref: None,
+            outcome: None,
         },
         ExecutionOutcome::Failed { reason, .. } => EffectResult {
             effect_id: effect_id.to_string(),
@@ -559,6 +564,7 @@ fn execution_outcome_to_effect_result(outcome: ExecutionOutcome, effect_id: &str
             ledger_entry_id: None,
             not_executed: false,
             receipt_ref: None,
+            outcome: None,
         },
         ExecutionOutcome::Deferred { reason, .. } => EffectResult {
             effect_id: effect_id.to_string(),
@@ -568,6 +574,7 @@ fn execution_outcome_to_effect_result(outcome: ExecutionOutcome, effect_id: &str
             ledger_entry_id: None,
             not_executed: true,
             receipt_ref: None,
+            outcome: None,
         },
     }
 }

--- a/icn/crates/icn-kernel-api/src/lib.rs
+++ b/icn/crates/icn-kernel-api/src/lib.rs
@@ -82,9 +82,9 @@ pub use container::{
 pub use coord::Coordination;
 pub use economics::{AssetType, DepreciationSchedule, SettlementIntent};
 pub use effects::{
-    kernel_effect_subsystem, ControlEffect, DispatchEvidenceSink, DisputeEffect, EffectResult,
-    FederationEffect, KernelEffect, MembershipEffect, ProtocolEffect, ResourceEffect, SdisEffect,
-    TreasuryEffect,
+    kernel_effect_subsystem, ControlEffect, DispatchEvidenceSink, DisputeEffect, EffectOutcome,
+    EffectResult, FederationEffect, KernelEffect, MembershipEffect, ProtocolEffect, ResourceEffect,
+    SdisEffect, TreasuryEffect,
 };
 pub use error::{ErrCode, IcnError};
 pub use escrow::{


### PR DESCRIPTION
## Summary

Adds an explicit, kernel-neutral `EffectOutcome` enum (`Applied | NoOp | Partial | Failed`) on `EffectResult` and `EffectDispatchEvidence`, and wires the kernel executor to classify every SDIS arm. SDIS durable evidence previously conflated:

- `(success=true, no mutation)` with `(success=true, mutation applied)`
- `(success=false, partial mutation)` with `(success=false, no mutation)`

Audit had to reconstruct intent from `(success, state_change_hash, receipt_ref)` — fragile and lossy. This change makes outcome explicit on the durable row without changing dispatch ownership or crossing the meaning firewall.

## Design

**Additive + wire-compat**: `Option<EffectOutcome>` with `#[serde(default)]` and (on evidence) `skip_serializing_if = Option::is_none`. Legacy rows deserialize as `None` (unclassified), not silently promoted to `Applied`. Audit can distinguish pre-Phase-2 from post-Phase-2 evidence.

**Classification lives in the kernel executor** (`icn-core/src/supervisor/governance_executor.rs`) — the sink forwards verbatim, never reclassifies:

| SDIS arm | `Applied` | `NoOp` | `Partial` | `Failed` |
|---|---|---|---|---|
| `ApproveSteward` | success | — | — | else |
| `RevokeSteward` | success + receipt_ref | success + no record | — | else |
| `ReconfirmSteward` | success | — | — | else |
| `ReinstateSteward` | success + was_suspended | success + !was_suspended | — | else |
| `SuspendSteward` | success | — | — | else |
| `SanctionSteward` | success | — | success=false + state_change_hash | else |
| no SDIS service wired | — | — | — | Failed |

The `Partial` classification on `SanctionSteward` is the Codex P1 bugfix extended: bond-slashed + later-step-failed now records `Partial` with receipt_ref + state_change_hash preserved on the durable row — not masked as `Failed`.

## Invariants preserved

- **Kernel/app boundary**: `EffectOutcome` is a plain enum with no domain semantics. Apps don't need to interpret it to persist it.
- **Meaning firewall**: the executor classifies from the service-layer contract only (`success`, `was_suspended`, `state_change_hash`, `receipt_ref`), never from domain-specific reasoning.
- **Single-owner**: no new dispatch paths; only the kernel executor writes evidence and the sink still forwards one-to-one.
- **Legacy deserialization**: `outcome: None` round-trips as `None` — never synthesized.

## Testing

- **13 new executor unit tests** in `icn-core` (`sdis_outcome_classification`) pin every arm's classification using a stub `SdisService`. Covers each row in the table above — including sanction Partial vs Failed vs Applied.
- **5 new sink tests** in `apps/governance/tests/actor_path_dispatch_evidence_sink.rs` assert verbatim outcome forwarding: `Applied`, `NoOp`, `Partial` (preserves attribution), `Failed`, and legacy `None` (must stay `None`, never synthesized).

All prior sink parity tests (receipt_ref pass-through, single-owner, deferred install, duplicate-evidence invariant) continue to pass.

## Verification

```
cargo fmt --all --check                                                          # clean
cargo clippy -p icn-kernel-api -p icn-core -p icn-governance-actor \
  --all-targets -- -D warnings                                                    # clean
cargo test -p icn-kernel-api -p icn-core -p icn-governance-actor                  # all green
cargo check --workspace --all-targets                                             # clean
```

## Risk

- Additive serde field with `default` — forward/backward compatible on both `EffectResult` and `EffectDispatchEvidence`.
- No domain crate imports added; no new dispatch owners; no change to trust/membership/ledger paths.
- Partial-mutation path now reports `Partial` instead of `Failed` — this is a classification refinement; callers inspecting only `success` see no behavior change.

## Test plan

- [x] Executor classification unit tests pass (13)
- [x] Sink forwarding tests pass (5 new + 15 pre-existing)
- [x] Workspace compiles with `--all-targets`
- [x] fmt + clippy clean
