### PR TITLE
feat(governance): ADR-0014 constitutional object model — typed substrate

### DIFF
--- a/icn/crates/icn-governance/src/authority.rs
+++ b/icn/crates/icn-governance/src/authority.rs
@@ -1,0 +1,631 @@
+//! Constitutional authority primitives — ADR-0014.
+//!
+//! This module introduces the typed application-layer substrate for
+//! institutional authority in ICN. It is **types-first and behavior-neutral**:
+//! no executor gating, no dispatcher wiring, no enforcement path. Future
+//! tranches build on these types; this one only names them.
+//!
+//! # What lives here
+//!
+//! - [`AuthorityClass`] — closed enumeration of authority kinds
+//!   (Representation / Execution / Attestation). Distinct by construction;
+//!   the type system enforces the anti-capture rule that these three are
+//!   not silently conflatable.
+//! - [`AuthorityGrant`] — a bounded, auditable grant issued by a sovereign
+//!   entity to a grantee, in exactly one [`AuthorityClass`].
+//! - [`TypedScope`] — the typed replacement path for today's string-smeared
+//!   `RoleAssignment.authority_scope: Vec<String>`. A conjunction of scope
+//!   categories; absent categories are "unbounded along that axis" but a
+//!   grant with no populated categories is malformed by construction.
+//!
+//! # Layer placement
+//!
+//! These types live at the **governance app layer** and must never be
+//! imported by kernel crates. The Meaning Firewall remains intact: the
+//! kernel enforces [`icn_kernel_api::authz::ConstraintSet`] and dispatches
+//! [`icn_kernel_api::effects::KernelEffect`] without learning that
+//! `AuthorityClass`, `AuthorityGrant`, or `TypedScope` exist.
+//!
+//! # What this is NOT
+//!
+//! - Not a replacement for `icn_kernel_api::authz::Capability` (the kernel
+//!   bearer token). A future implementation may mint kernel capabilities
+//!   from these grants, but they remain in distinct layers.
+//! - Not a replacement for [`crate::delegation::Delegation`], which is
+//!   strictly vote delegation (Representation authority, proposal-scoped).
+//! - Not a replacement for [`crate::structure::RoleAssignment`], which
+//!   continues to ship as a structural placement.
+//! - Not a [`crate::mandate::Mandate`]. A grant is reusable authority;
+//!   a mandate is a per-decision authorization that composes one or more
+//!   grants with a specific decision's provenance.
+//!
+//! See `docs/adr/ADR-0014-constitutional-object-model.md` for full semantics.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::domain::GovernanceDomainId;
+use crate::proof::Hash;
+use crate::Timestamp;
+use icn_identity::Did;
+
+/// Closed enumeration of constitutional authority kinds.
+///
+/// Exactly three variants, and only three, at the constitutional level.
+/// These classes are **distinct and must not be silently conflated.** A
+/// grant of one class does not confer the powers of another. Conflating
+/// them is the usual mechanism of institutional capture; typing prevents
+/// it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthorityClass {
+    /// Speaking or voting in place of another identity within a bounded
+    /// scope. Does not permit executing effects or issuing attestations.
+    Representation,
+    /// Carrying out an action that mutates institutional state under a
+    /// scope. Does not permit voting in place of others or issuing
+    /// primary attestations.
+    Execution,
+    /// Issuing signed statements of fact or status that downstream
+    /// consumers may rely on. Does not permit deciding policy or
+    /// executing effects.
+    Attestation,
+}
+
+/// Institutional unit for an amount-ceiling scope.
+///
+/// These are policy-governed institutional positions — not hosted balances,
+/// not operator-routed value, not platform-issued currency. The enum is
+/// closed over the two canonical cooperative units with an explicit
+/// resource-type escape hatch for coop-defined resource allocations.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "name")]
+pub enum AmountUnit {
+    /// Mutual-credit units carried on the ICN ledger as policy-governed
+    /// positions.
+    CreditUnits,
+    /// Time-denominated labor contributions.
+    LaborHours,
+    /// Coop-defined resource allocation unit (e.g. `"bandwidth_gbps"`,
+    /// `"storage_tib"`). The institutional meaning is defined by the
+    /// grantor's charter, not by ICN.
+    Resource(String),
+}
+
+/// A non-negative magnitude bound expressed in an institutional unit.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AmountCeiling {
+    /// Ceiling value. Interpretation depends on `unit`.
+    pub value: i64,
+    /// The institutional unit the value is expressed in.
+    pub unit: AmountUnit,
+}
+
+/// A half-open institutional time window `[start, end)`.
+///
+/// This is a finer-grained bound *within* a grant's outer `valid_from` /
+/// `valid_until` — e.g. a budget grant that only applies during a specific
+/// fiscal window, or a meeting-quorum representation grant that only
+/// applies while the meeting is in session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TimeWindow {
+    /// Unix timestamp (seconds) when the window opens.
+    pub start: Timestamp,
+    /// Unix timestamp (seconds) when the window closes.
+    pub end: Timestamp,
+}
+
+/// The typed replacement path for today's `RoleAssignment.authority_scope:
+/// Vec<String>` capability strings.
+///
+/// A `TypedScope` is a **conjunction** of the categories that are present.
+/// Absent categories are "unbounded along that axis." A grant must have at
+/// least one populated category to be meaningful; the [`TypedScope::is_empty`]
+/// helper exists to catch the "unbounded on everything" malformation.
+///
+/// The semantic categories are frozen by ADR-0014; exact encoding may
+/// refine at future implementation time (e.g. moving from `Option<T>`
+/// fields to a `Vec<ScopeClause>`), but the categories below are stable.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TypedScope {
+    /// Governance-domain scope: the grant applies only within this domain.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub domain: Option<GovernanceDomainId>,
+    /// Proposal-class scope: the grant applies only to proposals whose
+    /// payload tag matches one of these labels. Stable labels are
+    /// proposal-payload-variant names (e.g. `"Treasury"`, `"Membership"`,
+    /// `"DeployCharter"`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub proposal_class: Vec<String>,
+    /// Action-kind scope: the grant authorizes only these kernel-effect
+    /// variant names (e.g. `"Treasury::Spend"`, `"Membership::Freeze"`).
+    /// Applies to [`AuthorityClass::Execution`] grants only.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub action_kind: Vec<String>,
+    /// Amount / ceiling scope: magnitude bound in an institutional unit.
+    /// Applies to [`AuthorityClass::Execution`] grants bounded by size.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub amount_ceiling: Option<AmountCeiling>,
+    /// Time-window scope: finer-grained time bound within the outer
+    /// grant validity window.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub time_window: Option<TimeWindow>,
+}
+
+impl TypedScope {
+    /// Return `true` if no scope category is populated.
+    ///
+    /// A grant whose scope satisfies `is_empty()` is malformed by the
+    /// ADR-0014 rule that at least one category must be populated.
+    /// Callers constructing grants should reject this case.
+    pub fn is_empty(&self) -> bool {
+        self.domain.is_none()
+            && self.proposal_class.is_empty()
+            && self.action_kind.is_empty()
+            && self.amount_ceiling.is_none()
+            && self.time_window.is_none()
+    }
+}
+
+/// Provenance link from an [`AuthorityGrant`] or [`crate::mandate::Mandate`]
+/// to a specific governance decision.
+///
+/// Always carried as the pair `(proposal_id, decision_hash)` — the
+/// proposal identifier plus the blake3 binding hash of the decision
+/// receipt. Exact hashing lives in [`crate::proof::GovernanceDecisionReceipt`];
+/// this type only records the reference.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DecisionProvenance {
+    /// Originating proposal identifier.
+    pub proposal_id: String,
+    /// Blake3 binding hash of the decision receipt.
+    pub decision_hash: Hash,
+}
+
+/// The identifier of a sovereign entity acting as the source of an
+/// authority grant.
+///
+/// A valid grantor is a **cooperative, community, or federation** acting
+/// under its own charter's process. The ICN runtime, daemon, gateway, or
+/// any non-entity platform component is **never** a valid grantor. This
+/// newtype exists to give the grantor field a distinct, searchable type —
+/// construction is unconstrained here, but downstream code that mints
+/// `AuthorityGrant` must enforce that the identifier resolves to a
+/// sovereign entity under the receiving deployment's entity registry.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct GrantorEntityId(pub String);
+
+impl std::fmt::Display for GrantorEntityId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// The recipient of an authority grant.
+///
+/// Most grants are issued to a person (a [`Did`]). Grants may also be
+/// issued to another entity (e.g. a federation grants a cooperative
+/// authority to clear on its behalf) or to a shared-service entity acting
+/// as an institutional actor (e.g. a cooperative grants a commons service
+/// an attestation-class grant to issue personhood attestations bounded by
+/// scope). Shared-service entities are legitimate grantees precisely
+/// because they must be legible institutional actors, not invisible
+/// platform conveniences.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "id")]
+pub enum Grantee {
+    /// A person identified by DID.
+    Person(Did),
+    /// Another entity identified by its entity identifier (cooperative,
+    /// community, federation, or shared-service entity).
+    Entity(String),
+}
+
+/// Unique identifier for an [`AuthorityGrant`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct AuthorityGrantId(pub Uuid);
+
+impl AuthorityGrantId {
+    /// Generate a fresh v4 identifier.
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    /// Wrap an existing UUID.
+    pub fn from_uuid(uuid: Uuid) -> Self {
+        Self(uuid)
+    }
+}
+
+impl Default for AuthorityGrantId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for AuthorityGrantId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A bounded, auditable grant of authority issued by a sovereign entity to
+/// a grantee, in exactly one [`AuthorityClass`].
+///
+/// Grants descend from entities acting under their charters. They do not
+/// descend from the platform, the runtime, the gateway, a daemon instance,
+/// or a shared service. Every grant carries validity bounds and an
+/// explicit revocation field: revocation is always possible by the
+/// grantor entity.
+///
+/// This type is app-layer constitutional meaning. It is never imported by
+/// kernel crates. See ADR-0014 for full semantics.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthorityGrant {
+    /// Stable identifier for the grant.
+    pub id: AuthorityGrantId,
+    /// Exactly one of Representation / Execution / Attestation.
+    pub class: AuthorityClass,
+    /// The sovereign entity that issues the grant.
+    pub grantor: GrantorEntityId,
+    /// The recipient of the grant.
+    pub grantee: Grantee,
+    /// The typed scope that bounds the grant. Must not be
+    /// [`TypedScope::is_empty`].
+    pub scope: TypedScope,
+    /// Optional provenance back to the governance decision that produced
+    /// this grant. `None` for charter-direct grants (e.g. ratified at
+    /// charter adoption); `Some(_)` for decision-produced grants.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub granted_by: Option<DecisionProvenance>,
+    /// Unix timestamp when the grant takes effect.
+    pub valid_from: Timestamp,
+    /// Optional Unix timestamp when the grant expires. `None` means
+    /// charter- or entity-lifetime-bounded; no grant is eternal without
+    /// a named charter clause sustaining it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub valid_until: Option<Timestamp>,
+    /// Unix timestamp of explicit revocation, if any. Revocation is
+    /// always possible by the grantor entity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revoked_at: Option<Timestamp>,
+}
+
+impl AuthorityGrant {
+    /// Return `true` if the grant is active at the given Unix timestamp.
+    ///
+    /// Active means: not revoked at or before `now`, `now >= valid_from`,
+    /// and (if `valid_until` is set) `now < valid_until`.
+    ///
+    /// This is a time-check helper, **not** an enforcement gate. It does
+    /// not consult any registry, charter, or state store. Future
+    /// enforcement work will layer additional checks on top.
+    pub fn is_active_at(&self, now: Timestamp) -> bool {
+        if let Some(revoked_at) = self.revoked_at {
+            if revoked_at <= now {
+                return false;
+            }
+        }
+        if now < self.valid_from {
+            return false;
+        }
+        if let Some(valid_until) = self.valid_until {
+            if now >= valid_until {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Return `true` if the grant has been explicitly revoked by `now`.
+    pub fn is_revoked_at(&self, now: Timestamp) -> bool {
+        matches!(self.revoked_at, Some(t) if t <= now)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Compatibility bridge: `authority_scope: Vec<String>` → `TypedScope`
+// ---------------------------------------------------------------------------
+
+/// Parse a vector of string capability labels into a [`TypedScope`].
+///
+/// This is the non-breaking bridge from today's
+/// `RoleAssignment.authority_scope: Vec<String>` world toward the typed
+/// scope model. It is intentionally conservative:
+///
+/// - Recognized label prefixes are merged into the returned `TypedScope`.
+/// - Unrecognized labels are silently ignored (no error). A future
+///   implementation is expected to count these as a metric for visibility
+///   into migration progress.
+/// - Returns `None` if and only if no label matched any recognized form.
+///   This preserves the invariant that a `Some(scope)` result has at
+///   least one populated scope category.
+///
+/// Recognized grammar (extensible in future tranches):
+///
+/// | Label form                          | Meaning                              |
+/// |------------------------------------|--------------------------------------|
+/// | `domain:<domain_id>`               | Sets `domain` scope.                 |
+/// | `proposal_class:<class_name>`      | Appends to `proposal_class` scope.   |
+/// | `action_kind:<kind_name>`          | Appends to `action_kind` scope.      |
+/// | `amount_ceiling:<int>:<unit>`      | Sets `amount_ceiling` (credit_units / |
+/// |                                    | labor_hours / `resource:<name>`).    |
+///
+/// Duplicate prefixes accumulate for `proposal_class` and `action_kind`;
+/// the last `domain:` and `amount_ceiling:` entries win.
+///
+/// This function is intentionally not a behavioral enforcement gate. It
+/// exists to let future consumers read a typed projection of existing
+/// string scopes without forcing any call site to rewrite today.
+pub fn parse_authority_scope_strings(labels: &[String]) -> Option<TypedScope> {
+    let mut scope = TypedScope::default();
+    let mut any_recognized = false;
+
+    for label in labels {
+        let Some((prefix, rest)) = label.split_once(':') else {
+            continue;
+        };
+        match prefix {
+            "domain" => {
+                scope.domain = Some(GovernanceDomainId(rest.to_string()));
+                any_recognized = true;
+            }
+            "proposal_class" => {
+                if !rest.is_empty() {
+                    scope.proposal_class.push(rest.to_string());
+                    any_recognized = true;
+                }
+            }
+            "action_kind" => {
+                if !rest.is_empty() {
+                    scope.action_kind.push(rest.to_string());
+                    any_recognized = true;
+                }
+            }
+            "amount_ceiling" => {
+                // Expect `<int>:<unit>` in `rest`.
+                let Some((value_str, unit_str)) = rest.split_once(':') else {
+                    continue;
+                };
+                let Ok(value) = value_str.parse::<i64>() else {
+                    continue;
+                };
+                let unit = match unit_str {
+                    "credit_units" => AmountUnit::CreditUnits,
+                    "labor_hours" => AmountUnit::LaborHours,
+                    other => {
+                        if let Some(res) = other.strip_prefix("resource:") {
+                            AmountUnit::Resource(res.to_string())
+                        } else {
+                            continue;
+                        }
+                    }
+                };
+                scope.amount_ceiling = Some(AmountCeiling { value, unit });
+                any_recognized = true;
+            }
+            _ => {}
+        }
+    }
+
+    if any_recognized {
+        Some(scope)
+    } else {
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn did(seed: u8) -> Did {
+        Did::from_anchor_id(&[seed; 32])
+    }
+
+    #[test]
+    fn authority_class_serde_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&AuthorityClass::Representation).unwrap(),
+            "\"representation\""
+        );
+        assert_eq!(
+            serde_json::to_string(&AuthorityClass::Execution).unwrap(),
+            "\"execution\""
+        );
+        assert_eq!(
+            serde_json::to_string(&AuthorityClass::Attestation).unwrap(),
+            "\"attestation\""
+        );
+
+        let round: AuthorityClass = serde_json::from_str("\"execution\"").unwrap();
+        assert_eq!(round, AuthorityClass::Execution);
+    }
+
+    #[test]
+    fn typed_scope_default_is_empty() {
+        let s = TypedScope::default();
+        assert!(s.is_empty());
+    }
+
+    #[test]
+    fn typed_scope_with_any_field_populated_is_not_empty() {
+        let s = TypedScope {
+            domain: Some(GovernanceDomainId("demo".into())),
+            ..TypedScope::default()
+        };
+        assert!(!s.is_empty());
+
+        let s = TypedScope {
+            action_kind: vec!["Treasury::Spend".into()],
+            ..TypedScope::default()
+        };
+        assert!(!s.is_empty());
+
+        let s = TypedScope {
+            amount_ceiling: Some(AmountCeiling {
+                value: 100,
+                unit: AmountUnit::CreditUnits,
+            }),
+            ..TypedScope::default()
+        };
+        assert!(!s.is_empty());
+    }
+
+    #[test]
+    fn amount_unit_resource_variant_serde() {
+        let u = AmountUnit::Resource("bandwidth_gbps".into());
+        let json = serde_json::to_string(&u).unwrap();
+        let back: AmountUnit = serde_json::from_str(&json).unwrap();
+        assert_eq!(u, back);
+    }
+
+    #[test]
+    fn grantee_person_and_entity_serde_roundtrip() {
+        let p = Grantee::Person(did(1));
+        let e = Grantee::Entity("coop:tech".into());
+        let p2: Grantee = serde_json::from_str(&serde_json::to_string(&p).unwrap()).unwrap();
+        let e2: Grantee = serde_json::from_str(&serde_json::to_string(&e).unwrap()).unwrap();
+        assert_eq!(p, p2);
+        assert_eq!(e, e2);
+    }
+
+    fn sample_grant() -> AuthorityGrant {
+        AuthorityGrant {
+            id: AuthorityGrantId::new(),
+            class: AuthorityClass::Execution,
+            grantor: GrantorEntityId("coop:tech".into()),
+            grantee: Grantee::Person(did(1)),
+            scope: TypedScope {
+                action_kind: vec!["Treasury::Spend".into()],
+                amount_ceiling: Some(AmountCeiling {
+                    value: 1000,
+                    unit: AmountUnit::CreditUnits,
+                }),
+                ..TypedScope::default()
+            },
+            granted_by: Some(DecisionProvenance {
+                proposal_id: "prop-1".into(),
+                decision_hash: [0u8; 32],
+            }),
+            valid_from: 100,
+            valid_until: Some(1000),
+            revoked_at: None,
+        }
+    }
+
+    #[test]
+    fn authority_grant_active_window() {
+        let g = sample_grant();
+        assert!(!g.is_active_at(50)); // before valid_from
+        assert!(g.is_active_at(100)); // at valid_from
+        assert!(g.is_active_at(500)); // in-window
+        assert!(!g.is_active_at(1000)); // at valid_until (half-open)
+        assert!(!g.is_active_at(2000)); // after valid_until
+    }
+
+    #[test]
+    fn authority_grant_revocation_blocks_activity() {
+        let mut g = sample_grant();
+        g.revoked_at = Some(200);
+        assert!(g.is_active_at(150)); // before revocation
+        assert!(!g.is_active_at(200)); // at revocation
+        assert!(!g.is_active_at(500)); // after revocation, still in-window
+        assert!(g.is_revoked_at(200));
+        assert!(!g.is_revoked_at(199));
+    }
+
+    #[test]
+    fn authority_grant_roundtrip_serde() {
+        let g = sample_grant();
+        let json = serde_json::to_string(&g).unwrap();
+        let back: AuthorityGrant = serde_json::from_str(&json).unwrap();
+        assert_eq!(g, back);
+    }
+
+    #[test]
+    fn parse_scope_strings_recognizes_domain_and_action_kind() {
+        let labels = vec![
+            "domain:treasury".to_string(),
+            "action_kind:Treasury::Spend".to_string(),
+            "action_kind:Treasury::Allocate".to_string(),
+        ];
+        let scope = parse_authority_scope_strings(&labels).unwrap();
+        assert_eq!(scope.domain, Some(GovernanceDomainId("treasury".into())));
+        assert_eq!(
+            scope.action_kind,
+            vec![
+                "Treasury::Spend".to_string(),
+                "Treasury::Allocate".to_string()
+            ]
+        );
+        assert!(scope.proposal_class.is_empty());
+        assert!(scope.amount_ceiling.is_none());
+    }
+
+    #[test]
+    fn parse_scope_strings_recognizes_amount_ceiling() {
+        let scope = parse_authority_scope_strings(&["amount_ceiling:500:credit_units".to_string()])
+            .unwrap();
+        assert_eq!(
+            scope.amount_ceiling,
+            Some(AmountCeiling {
+                value: 500,
+                unit: AmountUnit::CreditUnits,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_scope_strings_recognizes_resource_unit() {
+        let scope = parse_authority_scope_strings(&[
+            "amount_ceiling:10:resource:bandwidth_gbps".to_string()
+        ])
+        .unwrap();
+        assert_eq!(
+            scope.amount_ceiling,
+            Some(AmountCeiling {
+                value: 10,
+                unit: AmountUnit::Resource("bandwidth_gbps".into()),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_scope_strings_ignores_unknown_and_returns_none_if_nothing_parsed() {
+        let result = parse_authority_scope_strings(&[
+            "unrecognized:foo".to_string(),
+            "bareword".to_string(),
+        ]);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn parse_scope_strings_ignores_malformed_amount_ceiling() {
+        // Missing unit
+        assert!(parse_authority_scope_strings(&["amount_ceiling:100".to_string()]).is_none());
+        // Non-integer value
+        assert!(
+            parse_authority_scope_strings(&["amount_ceiling:abc:credit_units".to_string()])
+                .is_none()
+        );
+        // Unknown unit (no resource: prefix, no known bare unit)
+        assert!(parse_authority_scope_strings(&["amount_ceiling:100:usd".to_string()]).is_none());
+    }
+
+    #[test]
+    fn parse_scope_strings_mixes_recognized_and_unrecognized() {
+        let labels = vec![
+            "domain:coop-a".to_string(),
+            "unknown:thing".to_string(),
+            "proposal_class:Treasury".to_string(),
+        ];
+        let scope = parse_authority_scope_strings(&labels).unwrap();
+        assert_eq!(scope.domain, Some(GovernanceDomainId("coop-a".into())));
+        assert_eq!(scope.proposal_class, vec!["Treasury".to_string()]);
+    }
+}

--- a/icn/crates/icn-governance/src/authority.rs
+++ b/icn/crates/icn-governance/src/authority.rs
@@ -93,10 +93,15 @@ pub enum AmountUnit {
 }
 
 /// A non-negative magnitude bound expressed in an institutional unit.
+///
+/// The typed bound is deliberately unsigned: a ceiling expresses "at most
+/// this much" and a negative bound has no institutional meaning. Parsers
+/// that receive signed input reject negatives rather than silently
+/// coercing them.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AmountCeiling {
-    /// Ceiling value. Interpretation depends on `unit`.
-    pub value: i64,
+    /// Non-negative ceiling value. Interpretation depends on `unit`.
+    pub value: u64,
     /// The institutional unit the value is expressed in.
     pub unit: AmountUnit,
 }
@@ -367,8 +372,10 @@ pub fn parse_authority_scope_strings(labels: &[String]) -> Option<TypedScope> {
         };
         match prefix {
             "domain" => {
-                scope.domain = Some(GovernanceDomainId(rest.to_string()));
-                any_recognized = true;
+                if !rest.is_empty() {
+                    scope.domain = Some(GovernanceDomainId(rest.to_string()));
+                    any_recognized = true;
+                }
             }
             "proposal_class" => {
                 if !rest.is_empty() {
@@ -383,11 +390,13 @@ pub fn parse_authority_scope_strings(labels: &[String]) -> Option<TypedScope> {
                 }
             }
             "amount_ceiling" => {
-                // Expect `<int>:<unit>` in `rest`.
+                // Expect `<non-negative int>:<unit>` in `rest`.
                 let Some((value_str, unit_str)) = rest.split_once(':') else {
                     continue;
                 };
-                let Ok(value) = value_str.parse::<i64>() else {
+                // u64 parse rejects negatives by construction; `AmountCeiling`
+                // carries a non-negative bound.
+                let Ok(value) = value_str.parse::<u64>() else {
                     continue;
                 };
                 let unit = match unit_str {
@@ -395,6 +404,9 @@ pub fn parse_authority_scope_strings(labels: &[String]) -> Option<TypedScope> {
                     "labor_hours" => AmountUnit::LaborHours,
                     other => {
                         if let Some(res) = other.strip_prefix("resource:") {
+                            if res.is_empty() {
+                                continue;
+                            }
                             AmountUnit::Resource(res.to_string())
                         } else {
                             continue;
@@ -615,6 +627,25 @@ mod tests {
         );
         // Unknown unit (no resource: prefix, no known bare unit)
         assert!(parse_authority_scope_strings(&["amount_ceiling:100:usd".to_string()]).is_none());
+        // Negative value (rejected: `AmountCeiling` is non-negative by type)
+        assert!(
+            parse_authority_scope_strings(&["amount_ceiling:-1:credit_units".to_string()])
+                .is_none()
+        );
+        // Empty resource name
+        assert!(
+            parse_authority_scope_strings(&["amount_ceiling:10:resource:".to_string()]).is_none()
+        );
+    }
+
+    #[test]
+    fn parse_scope_strings_ignores_empty_label_payloads() {
+        // Empty `domain:` must not produce `domain: Some("")`.
+        assert!(parse_authority_scope_strings(&["domain:".to_string()]).is_none());
+        // Empty `proposal_class:` must not populate the list.
+        assert!(parse_authority_scope_strings(&["proposal_class:".to_string()]).is_none());
+        // Empty `action_kind:` must not populate the list.
+        assert!(parse_authority_scope_strings(&["action_kind:".to_string()]).is_none());
     }
 
     #[test]

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -211,7 +211,7 @@ pub use authority::{
     parse_authority_scope_strings, AmountCeiling, AmountUnit, AuthorityClass, AuthorityGrant,
     AuthorityGrantId, DecisionProvenance, Grantee, GrantorEntityId, TimeWindow, TypedScope,
 };
-pub use mandate::{Mandate, MandateId, MandateStatus};
+pub use mandate::{Mandate, MandateError, MandateId, MandateStatus};
 
 /// Unix timestamp in seconds
 pub type Timestamp = u64;

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -95,6 +95,12 @@ pub mod orphan_cleanup;
 // Proposal cleanup and archival
 pub mod proposal_cleanup;
 
+// Constitutional object model (ADR-0014): types-first, behavior-neutral.
+// Authority: AuthorityClass, AuthorityGrant, TypedScope + compatibility bridge.
+// Mandate: the constitutional mediation layer between decision and execution.
+pub mod authority;
+pub mod mandate;
+
 pub use amendment::{
     Amendment, AmendmentChange, AmendmentId, AmendmentScope, AmendmentStatus, AmendmentType,
     ChangeTarget, ChangeType, Ratification, RatificationRequirements, RatificationResult,
@@ -199,6 +205,13 @@ pub use structure::{
     InMemoryStructureStore, RoleAssignment, RoleAssignmentId, Structure, StructureId,
     StructureKind, StructureStatus, StructureStoreBackend,
 };
+
+// Constitutional object model (ADR-0014) re-exports
+pub use authority::{
+    parse_authority_scope_strings, AmountCeiling, AmountUnit, AuthorityClass, AuthorityGrant,
+    AuthorityGrantId, DecisionProvenance, Grantee, GrantorEntityId, TimeWindow, TypedScope,
+};
+pub use mandate::{Mandate, MandateId, MandateStatus};
 
 /// Unix timestamp in seconds
 pub type Timestamp = u64;

--- a/icn/crates/icn-governance/src/mandate.rs
+++ b/icn/crates/icn-governance/src/mandate.rs
@@ -70,12 +70,23 @@
 //! semantics.
 
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use uuid::Uuid;
 
 use crate::authority::{AuthorityGrantId, DecisionProvenance};
 use crate::proof::Hash;
 use crate::Timestamp;
 use icn_identity::Did;
+
+/// Errors returned when constructing a [`Mandate`] that violates an
+/// ADR-0014 invariant.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum MandateError {
+    /// Grants vector was empty. A mandate must compose at least one
+    /// [`AuthorityGrantId`] — unbounded authorization is forbidden.
+    #[error("mandate must carry at least one authority grant")]
+    EmptyGrants,
+}
 
 /// Unique identifier for a [`Mandate`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -142,8 +153,10 @@ pub enum MandateStatus {
 /// [`MandateStatus::Pending`]. Callers must supply the decision
 /// provenance, payload hash, and at least one [`AuthorityGrantId`]. A
 /// mandate with an empty `grants` vector is not a valid constitutional
-/// authorization; downstream code minting mandates should refuse that
-/// case (the ADR-0014 rule that authority must be bounded).
+/// authorization — the ADR-0014 rule is that authority must be bounded.
+/// The constructor enforces this invariant and returns
+/// [`MandateError::EmptyGrants`] if violated, so no caller can mint an
+/// unbounded mandate.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Mandate {
     /// Stable identifier for the mandate.
@@ -178,6 +191,10 @@ pub struct Mandate {
 impl Mandate {
     /// Construct a new mandate with a fresh identifier and
     /// [`MandateStatus::Pending`].
+    ///
+    /// Returns [`MandateError::EmptyGrants`] if `grants` is empty. This
+    /// enforces the ADR-0014 invariant that a mandate must carry bounded
+    /// authority; no caller may mint an unbounded mandate.
     pub fn new(
         decision: DecisionProvenance,
         payload_hash: Hash,
@@ -185,8 +202,11 @@ impl Mandate {
         executor: Option<Did>,
         deadline: Option<Timestamp>,
         issued_at: Timestamp,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, MandateError> {
+        if grants.is_empty() {
+            return Err(MandateError::EmptyGrants);
+        }
+        Ok(Self {
             id: MandateId::new(),
             decision,
             payload_hash,
@@ -195,7 +215,7 @@ impl Mandate {
             deadline,
             status: MandateStatus::Pending,
             issued_at,
-        }
+        })
     }
 
     /// Return `true` if `now >= deadline` (when a deadline is set).
@@ -234,8 +254,15 @@ mod tests {
             Some(did(1)),
             Some(1000),
             100,
-        );
+        )
+        .unwrap();
         assert_eq!(m.status, MandateStatus::Pending);
+    }
+
+    #[test]
+    fn mandate_new_rejects_empty_grants() {
+        let err = Mandate::new(sample_decision(), [0u8; 32], vec![], None, None, 0).unwrap_err();
+        assert_eq!(err, MandateError::EmptyGrants);
     }
 
     #[test]
@@ -243,8 +270,8 @@ mod tests {
         let d = sample_decision();
         let p = [0u8; 32];
         let g = AuthorityGrantId::new();
-        let m1 = Mandate::new(d.clone(), p, vec![g.clone()], None, None, 0);
-        let m2 = Mandate::new(d.clone(), p, vec![g.clone()], None, None, 0);
+        let m1 = Mandate::new(d.clone(), p, vec![g.clone()], None, None, 0).unwrap();
+        let m2 = Mandate::new(d.clone(), p, vec![g.clone()], None, None, 0).unwrap();
         assert_ne!(m1.id, m2.id);
         assert_eq!(m1.decision, m2.decision);
     }
@@ -258,7 +285,8 @@ mod tests {
             None,
             Some(500),
             100,
-        );
+        )
+        .unwrap();
         assert!(!m.is_past_deadline(499));
         assert!(m.is_past_deadline(500));
         assert!(m.is_past_deadline(1000));
@@ -270,7 +298,8 @@ mod tests {
             None,
             None,
             100,
-        );
+        )
+        .unwrap();
         assert!(!m_no_deadline.is_past_deadline(u64::MAX));
     }
 
@@ -300,7 +329,8 @@ mod tests {
             Some(did(1)),
             Some(2000),
             1500,
-        );
+        )
+        .unwrap();
         let json = serde_json::to_string(&m).unwrap();
         let back: Mandate = serde_json::from_str(&json).unwrap();
         assert_eq!(m, back);

--- a/icn/crates/icn-governance/src/mandate.rs
+++ b/icn/crates/icn-governance/src/mandate.rs
@@ -1,0 +1,308 @@
+//! Constitutional mandate — ADR-0014.
+//!
+//! A [`Mandate`] is the constitutional mediation layer between a governance
+//! decision and the execution of its effects. It is the object the repo was
+//! missing before ADR-0014 and the one that makes the full chain
+//!
+//! ```text
+//!     Charter → Decision → Mandate → Action → Receipt → Evidence
+//! ```
+//!
+//! expressible end-to-end.
+//!
+//! # What a Mandate *is*
+//!
+//! An accepted decision has produced a bounded institutional authorization
+//! to carry out one or more classes of action, optionally assigning an
+//! executor, a deadline, and one or more authority grants. Executing the
+//! mandated action under the mandate is what makes the effect legitimate
+//! — not merely the fact that the decision was recorded.
+//!
+//! `Mandate` is also, in its own right, a **first-class institutional-memory
+//! record**: the durable answer to the question "under whose authority,
+//! grounded in which decision, was this action permitted?" That answer
+//! must survive personnel turnover, platform upgrades, and the passage of
+//! time.
+//!
+//! # What a Mandate is *not*
+//!
+//! A `Mandate` is deliberately distinct from the adjacent forms already
+//! in the repo:
+//!
+//! - **Not a [`crate::delegation::Delegation`].** Delegation is strictly
+//!   vote delegation (Representation authority, proposal-scoped). A
+//!   mandate typically binds Execution authority.
+//! - **Not a [`crate::structure::RoleAssignment`].** A role assignment
+//!   places a DID in an ongoing structural position (e.g. Treasurer). A
+//!   mandate is issued per-decision (or per-charter-clause) and is
+//!   bounded.
+//! - **Not a [`crate::structure::Structure`] of kind `Office`.** An office
+//!   is an institutional seat; a mandate is an authorization to act, often
+//!   by a seat-holder, but distinct from the seat itself.
+//! - **Not an `InstitutionalEffectRecord`.** That record (see
+//!   `apps/governance::institutional_effect`) is *evidence* that a
+//!   translation from accepted payload to kernel effect occurred. Mandate
+//!   is *authority* to perform that translation in the first place.
+//! - **Not a [`crate::proof::GovernanceDecisionReceipt`].** The receipt
+//!   records that a decision was reached under canonical process. The
+//!   mandate binds that decision to a bounded authorization.
+//! - **Not a federation `Agreement`.** An agreement is a bilateral or
+//!   multilateral compact between entities. A mandate is an internal
+//!   authorization within an entity (or from an entity to a named
+//!   executor) to carry out a decision.
+//! - **Not a [`crate::charter::Charter`].** The charter is the sovereign
+//!   constitutional source. A mandate is an authorization grounded in
+//!   the charter's process.
+//!
+//! # Layer placement
+//!
+//! Like the rest of the ADR-0014 types, `Mandate` lives at the governance
+//! app layer and must not be imported by kernel crates. The Meaning
+//! Firewall remains intact.
+//!
+//! # Behavioral status
+//!
+//! **Types-first, behavior-neutral.** This module introduces no executor
+//! gating and no dispatcher wiring. Later tranches consult `Mandate` when
+//! they land execution enforcement; this tranche only names the object.
+//!
+//! See `docs/adr/ADR-0014-constitutional-object-model.md` for full
+//! semantics.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::authority::{AuthorityGrantId, DecisionProvenance};
+use crate::proof::Hash;
+use crate::Timestamp;
+use icn_identity::Did;
+
+/// Unique identifier for a [`Mandate`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct MandateId(pub Uuid);
+
+impl MandateId {
+    /// Generate a fresh v4 identifier.
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    /// Wrap an existing UUID.
+    pub fn from_uuid(uuid: Uuid) -> Self {
+        Self(uuid)
+    }
+}
+
+impl Default for MandateId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for MandateId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Lifecycle status of a [`Mandate`].
+///
+/// Transitions follow the ADR-0014 state machine
+/// `Pending → InProgress → Discharged | Expired | Revoked`. This module
+/// only names the states; transition enforcement is future work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MandateStatus {
+    /// Issued but no execution attempt has started.
+    Pending,
+    /// Execution has begun; at least one effect has been dispatched
+    /// under this mandate.
+    InProgress,
+    /// All authorized effects have been applied; the mandate is closed.
+    Discharged,
+    /// Deadline passed without full discharge. Recorded as institutional
+    /// memory that the authorization existed and was not fully exercised.
+    Expired,
+    /// Explicit revocation by the grantor entity or by superseding
+    /// governance decision. Blocks further execution even if prior
+    /// effects have already landed.
+    Revoked,
+}
+
+/// A `Mandate` — bounded institutional authorization to carry out the
+/// effects of a specific governance decision.
+///
+/// See the module-level documentation for full distinctness and layer
+/// placement. See ADR-0014 for frozen semantics.
+///
+/// # Construction
+///
+/// Use [`Mandate::new`] for standard construction: it auto-generates a
+/// fresh [`MandateId`] and initializes status to
+/// [`MandateStatus::Pending`]. Callers must supply the decision
+/// provenance, payload hash, and at least one [`AuthorityGrantId`]. A
+/// mandate with an empty `grants` vector is not a valid constitutional
+/// authorization; downstream code minting mandates should refuse that
+/// case (the ADR-0014 rule that authority must be bounded).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Mandate {
+    /// Stable identifier for the mandate.
+    pub id: MandateId,
+    /// Provenance back to the originating governance decision.
+    pub decision: DecisionProvenance,
+    /// Hash of the accepted proposal payload; binds the mandate to the
+    /// concrete content of the decision, not just its identity.
+    pub payload_hash: Hash,
+    /// References to one or more [`crate::authority::AuthorityGrant`]s
+    /// that together confer the authority this mandate relies on.
+    /// Typically Execution-class, but a mandate may bundle
+    /// Representation or Attestation grants if the decision names them.
+    pub grants: Vec<AuthorityGrantId>,
+    /// The party named to carry out the action. `None` when the mandate
+    /// is self-dispatching (the decision body itself executes) or is
+    /// addressed to a role rather than a specific DID.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub executor: Option<Did>,
+    /// Unix timestamp after which the mandate expires without further
+    /// execution. `None` means charter- or decision-bounded without a
+    /// distinct deadline.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deadline: Option<Timestamp>,
+    /// Lifecycle status. Initialized to [`MandateStatus::Pending`] at
+    /// construction.
+    pub status: MandateStatus,
+    /// Unix timestamp when the mandate was issued.
+    pub issued_at: Timestamp,
+}
+
+impl Mandate {
+    /// Construct a new mandate with a fresh identifier and
+    /// [`MandateStatus::Pending`].
+    pub fn new(
+        decision: DecisionProvenance,
+        payload_hash: Hash,
+        grants: Vec<AuthorityGrantId>,
+        executor: Option<Did>,
+        deadline: Option<Timestamp>,
+        issued_at: Timestamp,
+    ) -> Self {
+        Self {
+            id: MandateId::new(),
+            decision,
+            payload_hash,
+            grants,
+            executor,
+            deadline,
+            status: MandateStatus::Pending,
+            issued_at,
+        }
+    }
+
+    /// Return `true` if `now >= deadline` (when a deadline is set).
+    ///
+    /// This is a time-check helper, **not** an enforcement gate. Callers
+    /// that must observe expiration semantics should also consult
+    /// [`Self::status`] (a mandate may have been explicitly revoked or
+    /// already discharged, which overrides deadline expiry).
+    pub fn is_past_deadline(&self, now: Timestamp) -> bool {
+        matches!(self.deadline, Some(d) if now >= d)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::authority::{AuthorityGrantId, DecisionProvenance};
+
+    fn did(seed: u8) -> Did {
+        Did::from_anchor_id(&[seed; 32])
+    }
+
+    fn sample_decision() -> DecisionProvenance {
+        DecisionProvenance {
+            proposal_id: "prop-42".into(),
+            decision_hash: [7u8; 32],
+        }
+    }
+
+    #[test]
+    fn mandate_new_is_pending() {
+        let m = Mandate::new(
+            sample_decision(),
+            [9u8; 32],
+            vec![AuthorityGrantId::new()],
+            Some(did(1)),
+            Some(1000),
+            100,
+        );
+        assert_eq!(m.status, MandateStatus::Pending);
+    }
+
+    #[test]
+    fn mandate_ids_are_distinct_for_same_decision() {
+        let d = sample_decision();
+        let p = [0u8; 32];
+        let g = AuthorityGrantId::new();
+        let m1 = Mandate::new(d.clone(), p, vec![g.clone()], None, None, 0);
+        let m2 = Mandate::new(d.clone(), p, vec![g.clone()], None, None, 0);
+        assert_ne!(m1.id, m2.id);
+        assert_eq!(m1.decision, m2.decision);
+    }
+
+    #[test]
+    fn mandate_deadline_check() {
+        let m = Mandate::new(
+            sample_decision(),
+            [0u8; 32],
+            vec![AuthorityGrantId::new()],
+            None,
+            Some(500),
+            100,
+        );
+        assert!(!m.is_past_deadline(499));
+        assert!(m.is_past_deadline(500));
+        assert!(m.is_past_deadline(1000));
+
+        let m_no_deadline = Mandate::new(
+            sample_decision(),
+            [0u8; 32],
+            vec![AuthorityGrantId::new()],
+            None,
+            None,
+            100,
+        );
+        assert!(!m_no_deadline.is_past_deadline(u64::MAX));
+    }
+
+    #[test]
+    fn mandate_status_serde_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&MandateStatus::InProgress).unwrap(),
+            "\"in_progress\""
+        );
+        assert_eq!(
+            serde_json::to_string(&MandateStatus::Discharged).unwrap(),
+            "\"discharged\""
+        );
+        let round: MandateStatus = serde_json::from_str("\"revoked\"").unwrap();
+        assert_eq!(round, MandateStatus::Revoked);
+    }
+
+    #[test]
+    fn mandate_roundtrip_serde() {
+        // Use seed=1 because `Did::from_anchor_id` does not validate that
+        // arbitrary bytes decompress to a valid Ed25519 point, but
+        // `Did`'s deserializer does. Seed 1 is known to round-trip.
+        let m = Mandate::new(
+            sample_decision(),
+            [3u8; 32],
+            vec![AuthorityGrantId::new(), AuthorityGrantId::new()],
+            Some(did(1)),
+            Some(2000),
+            1500,
+        );
+        let json = serde_json::to_string(&m).unwrap();
+        let back: Mandate = serde_json::from_str(&json).unwrap();
+        assert_eq!(m, back);
+    }
+}

--- a/icn/crates/icn-governance/src/structure.rs
+++ b/icn/crates/icn-governance/src/structure.rs
@@ -225,6 +225,25 @@ impl RoleAssignment {
             None => true,
         }
     }
+
+    /// Compatibility bridge from the stringly-typed `authority_scope` to
+    /// the typed [`crate::authority::TypedScope`] frozen by ADR-0014.
+    ///
+    /// This is a read-only projection: the underlying `Vec<String>`
+    /// field is unchanged. Unrecognized labels are silently ignored. A
+    /// return value of `None` means no label in the current scope matched
+    /// any recognized form — i.e. the typed projection would be empty.
+    ///
+    /// See [`crate::authority::parse_authority_scope_strings`] for the
+    /// grammar and the extensibility story.
+    ///
+    /// This helper adds no behavioral enforcement: existing consumers
+    /// that read `authority_scope` directly continue to work unchanged.
+    /// Future consumers that want a typed view can call this method
+    /// without forcing a migration of any call site today.
+    pub fn typed_scope(&self) -> Option<crate::authority::TypedScope> {
+        crate::authority::parse_authority_scope_strings(&self.authority_scope)
+    }
 }
 
 // ========== Store Backend ==========
@@ -528,6 +547,43 @@ mod tests {
         assert!(role.is_active_at(1500));
         assert!(!role.is_active_at(2000)); // at end (exclusive)
         assert!(!role.is_active_at(3000));
+    }
+
+    #[test]
+    fn test_role_typed_scope_bridge_none_when_empty_or_unrecognized() {
+        // ADR-0014 compatibility bridge: empty authority_scope and
+        // unrecognized labels both yield None.
+        let sid = StructureId::from_raw("s");
+        let role = RoleAssignment::new(sid.clone(), test_did(), "coordinator".into(), 1000);
+        assert!(role.typed_scope().is_none());
+
+        let mut with_unknown = role.clone();
+        with_unknown.authority_scope = vec!["not-a-known-label".into()];
+        assert!(with_unknown.typed_scope().is_none());
+    }
+
+    #[test]
+    fn test_role_typed_scope_bridge_projects_known_labels() {
+        // ADR-0014 compatibility bridge: recognized labels project into
+        // a typed scope without mutating the underlying string vector.
+        let sid = StructureId::from_raw("s");
+        let mut role = RoleAssignment::new(sid, test_did(), "treasurer".into(), 1000);
+        role.authority_scope = vec![
+            "domain:treasury".into(),
+            "action_kind:Treasury::Spend".into(),
+            "amount_ceiling:500:credit_units".into(),
+        ];
+
+        let scope = role.typed_scope().expect("bridge should yield Some");
+        assert_eq!(
+            scope.domain.as_ref().map(|d| d.0.as_str()),
+            Some("treasury")
+        );
+        assert_eq!(scope.action_kind, vec!["Treasury::Spend".to_string()]);
+        assert!(scope.amount_ceiling.is_some());
+
+        // The underlying string vector remains as-is — no migration side-effect.
+        assert_eq!(role.authority_scope.len(), 3);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implement the minimal **types-first, behavior-neutral** substrate for the constitutional object model frozen by [ADR-0014](../blob/main/docs/adr/ADR-0014-constitutional-object-model.md) (landed as #1572). No executor gating, no dispatcher wiring, no new effect families, no behavioral enforcement.

This tranche moves the ADR from "well-written semantic freeze" to "real typed substrate the repo can safely build on."

## Changes

### New module — `icn-governance::authority`

- **`AuthorityClass`** — closed enum `{ Representation, Execution, Attestation }`. Exactly three, distinct, anti-capture by type system.
- **`TypedScope`** — conjunction of scope categories (`domain`, `proposal_class`, `action_kind`, `amount_ceiling`, `time_window`) with `is_empty()` helper enforcing the ADR rule that at least one category must be populated.
- **`AmountUnit`** — closed enum `{ CreditUnits, LaborHours, Resource(String) }`. Institutional units only; no balance worldview can re-enter via this seam.
- **`AmountCeiling`**, **`TimeWindow`** — value-bound and time-window primitives.
- **`DecisionProvenance { proposal_id, decision_hash }`** — the inlined-tuple form agreed during PR #1572 review (resolves the `DecisionRef` ambiguity).
- **`GrantorEntityId(String)`** — newtype with doc contract that the ICN runtime, daemon, gateway, or system are *never* valid grantors. Authority descends from sovereign entities under their charters.
- **`Grantee::{ Person(Did), Entity(String) }`** — covers both DID and entity recipients (federation, coop, shared-service entity).
- **`AuthorityGrant`** — sovereign-issued, bounded, revocable. `is_active_at()` and `is_revoked_at()` are time helpers, not enforcement gates.
- **`parse_authority_scope_strings()`** — non-breaking compatibility bridge from today's `RoleAssignment.authority_scope: Vec<String>` to `TypedScope`. Conservative: unrecognized labels ignored, returns `None` if nothing parsed. Grammar: `domain:<id>`, `proposal_class:<name>`, `action_kind:<kind>`, `amount_ceiling:<int>:<unit>` (with `credit_units` / `labor_hours` / `resource:<name>`).

### New module — `icn-governance::mandate`

- **`MandateId(Uuid)`** newtype.
- **`MandateStatus`** — `{ Pending, InProgress, Discharged, Expired, Revoked }`. Names only; transition enforcement is future work.
- **`Mandate`** — the constitutional mediation layer between decision and execution. Module doc enumerates the seven distinctions (not a delegation, not a role assignment, not an office, not an `InstitutionalEffectRecord`, not a `GovernanceDecisionReceipt`, not a federation `Agreement`, not a `Charter`).
- **`Mandate::new()`** constructor; **`is_past_deadline()`** time helper (not a gate).

### Compatibility bridge — `RoleAssignment::typed_scope()`

New read-only method on `RoleAssignment` that projects the existing `authority_scope: Vec<String>` into `Option<TypedScope>`. The underlying vector is unchanged. No call site is forced to migrate today; new consumers can adopt the typed projection incrementally.

## Tests added (21 new)

- `authority::tests` — 14: enum `snake_case` serde; `TypedScope::is_empty`; `AmountUnit::Resource` variant roundtrip; `Grantee` roundtrip; `AuthorityGrant` active-window + revocation + full serde roundtrip; 7 scope-string bridge tests (domain, action_kind, amount_ceiling, resource unit, unknown-rejection, malformed-rejection, mixed recognized).
- `mandate::tests` — 5: new-is-pending; distinct ids for same decision; deadline check; `MandateStatus` serde; `Mandate` full roundtrip.
- `structure::tests` — 2 new bridge tests: `typed_scope()` returns `None` when empty or unrecognized; projects known labels without mutating the underlying string vector.

## ADR alignment

This PR implements exactly what ADR-0014 freezes and nothing more:
- ✅ Entity sovereignty: `GrantorEntityId` doc-contract forbids platform/runtime/gateway as grantor.
- ✅ Typed separation: `AuthorityClass` is a closed three-variant enum; the type system prevents silent conflation.
- ✅ Institutional (not financial) vocabulary: `AmountUnit` is a closed enum over credit units, labor hours, and coop-defined resources. No balance abstraction can re-enter.
- ✅ Meaning Firewall: all new types live in `icn-governance`. Kernel crates do not import them. `check-meaning-firewall.sh` reports the same pre-existing violations as before (3 in `icn-gateway`, unchanged).
- ✅ Mandate as institutional-memory record: module docs anchor this explicitly.
- ✅ Additive migration: `RoleAssignment.authority_scope: Vec<String>` is unchanged; `typed_scope()` is a read-only projection.
- ✅ Constitutional legibility substrate preserved for future member surfaces.

## Hard-constraint compliance

- ❌ No executor gating.
- ❌ No effect plumbing widening; `KernelEffect` untouched; `EffectOutcome` / `receipt_ref` untouched.
- ❌ No second dispatch owner.
- ❌ No new receipt semantics.
- ❌ No federation-authority narrowing.
- ❌ No mobile SDK or shell work.
- ❌ No kernel meaning changes; kernel crates do not import these types.
- ❌ No HTTP endpoints added (the ADR leaves `/gov/mandates/*` to a later tranche).
- ❌ No storage migrations.
- ❌ No phase-status promotion.
- ❌ No conflation of `Mandate` with receipt / evidence / delegation / office / compact / charter — distinctness enumerated in module docs.

## Invariants

- **Adversarial-by-default**: typed separation is a type-level anti-capture rule.
- **Determinism**: `AuthorityGrantId` / `MandateId` are UUIDv4 (id-space only; not part of any canonical hash). Existing deterministic hashing in `GovernanceDecisionReceipt` is unchanged.
- **Canonical encodings**: serde uses the project convention (`#[serde(rename_all = "snake_case")]` on enums).
- **No panics**: all new code obeys `#![deny(clippy::unwrap_used, clippy::expect_used)]`; test-only `unwrap()` permitted per crate convention.
- **Kernel/app boundaries**: preserved. Firewall ratchet unchanged (no new violations introduced).

## Verification run

WSL Ubuntu-24.04, Rust 1.89.0:

- `cargo fmt --all --check` ✓
- `cargo clippy -p icn-governance --all-targets --all-features -- -D warnings` ✓
- `cargo test -p icn-governance` ✓
  - lib: **492 passed** (471 pre-existing + 14 authority + 5 mandate + 2 structure bridge)
  - integration: 42 passed
  - doc-tests: 7 passed / 6 ignored
- `cargo check --workspace` ✓
- `scripts/check-meaning-firewall.sh` ✓ (only pre-existing `icn-gateway→icn_trust` violations; no new violations from these types)

## Test plan

- [x] Compile workspace cleanly.
- [x] Run `cargo fmt --all --check`.
- [x] Run scoped `cargo clippy -p icn-governance --all-targets --all-features -- -D warnings`.
- [x] Run `cargo test -p icn-governance` and confirm all 492 lib tests pass.
- [x] Run workspace-wide `cargo check`.
- [x] Run the Meaning Firewall script; confirm no new violations.

## Intentionally out of scope

Executor gating, federation-authority narrowing, new HTTP endpoints, mobile SDK hooks, shared-service refactor, `icn-commons` centralization cleanup, storage migration of `authority_scope`, kernel changes, phase-status promotion. All of these are downstream of this substrate and are tracked by ADR-0014's "What this freeze prepares" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)