### PR TITLE
feat(governance): mint ADR-0014 Mandate at decision-acceptance seam

### DIFF
--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -16,17 +16,17 @@ use icn_federation::BilateralClearingAgreement;
 use icn_governance::{
     scopes_overlap, ActionItem, ActionItemFilter, ActionItemId, ActionItemPriority,
     ActionItemStatus, ActionItemStoreBackend, Activity, ActivityId, ActivityKind,
-    ActivityStoreBackend, Comment, CommentId, Delegation, DelegationId, DelegationScope,
-    Discussion, DiscussionStore, GovernanceConfig, GovernanceDecisionReceipt, GovernanceDomain,
-    GovernanceDomainId, GovernanceError, GovernanceOps, GovernanceParams, GovernanceProfileId,
-    InMemoryActionItemStore, InMemoryActivityStore, InMemoryDiscussionStore, InMemoryMeetingStore,
-    InMemoryMilestoneStore, InMemoryProgramStore, InMemoryStructureStore, Meeting, MeetingId,
-    MeetingStoreBackend, MembershipConfig, MembershipSource, Milestone, MilestoneId,
-    MilestoneStatus, MilestoneStoreBackend, PaginatedResult, Program, ProgramId, ProgramKind,
-    ProgramStatus, ProgramStoreBackend, ProofOutcome, Proposal, ProposalDomainLookup, ProposalId,
-    ProposalPayload, ProposalScope, ProposalState, RoleAssignment, Structure, StructureId,
-    StructureKind, StructureStoreBackend, Timestamp, Vote, VoteChoice, VoteTally,
-    DEFAULT_MAX_DELEGATION_DEPTH,
+    ActivityStoreBackend, Comment, CommentId, DecisionProvenance, Delegation, DelegationId,
+    DelegationScope, Discussion, DiscussionStore, GovernanceConfig, GovernanceDecisionReceipt,
+    GovernanceDomain, GovernanceDomainId, GovernanceError, GovernanceOps, GovernanceParams,
+    GovernanceProfileId, InMemoryActionItemStore, InMemoryActivityStore, InMemoryDiscussionStore,
+    InMemoryMeetingStore, InMemoryMilestoneStore, InMemoryProgramStore, InMemoryStructureStore,
+    Mandate, Meeting, MeetingId, MeetingStoreBackend, MembershipConfig, MembershipSource,
+    Milestone, MilestoneId, MilestoneStatus, MilestoneStoreBackend, PaginatedResult, Program,
+    ProgramId, ProgramKind, ProgramStatus, ProgramStoreBackend, ProofOutcome, Proposal,
+    ProposalDomainLookup, ProposalId, ProposalPayload, ProposalScope, ProposalState,
+    RoleAssignment, Structure, StructureId, StructureKind, StructureStoreBackend, Timestamp, Vote,
+    VoteChoice, VoteTally, DEFAULT_MAX_DELEGATION_DEPTH,
 };
 use icn_identity::Did;
 use icn_kernel_api::{AllocationReceipt, ScopeLevel, SettlementIntent};
@@ -162,6 +162,30 @@ pub struct ReconciledEffectEntry {
     pub record: InstitutionalEffectRecord,
     pub dispatch_evidence: Vec<EffectDispatchEvidence>,
     pub reconciliation_status: ReconciliationStatus,
+}
+
+/// Compute a deterministic blake3 hash over the serialized proposal
+/// payload, for binding a [`Mandate`] to the concrete content of the
+/// decision (ADR-0014 `payload_hash` field).
+///
+/// The hash is taken over `serde_json::to_vec(payload)`. JSON is
+/// canonical here because `ProposalPayload` already derives `Serialize`
+/// for cross-node use; if serialization fails (which shouldn't happen
+/// for a well-formed payload that was accepted by the governance
+/// pipeline), we fall back to a zeroed hash so the mandate still records
+/// the decision provenance rather than being silently dropped.
+fn hash_proposal_payload(payload: &ProposalPayload) -> icn_kernel_api::Hash {
+    match serde_json::to_vec(payload) {
+        Ok(bytes) => *blake3::hash(&bytes).as_bytes(),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "Failed to serialize proposal payload for mandate payload_hash; \
+                 falling back to zeroed hash"
+            );
+            [0u8; 32]
+        }
+    }
 }
 
 /// Label the translated [`crate::http::configure::GovernanceEffect`] shape
@@ -3470,6 +3494,44 @@ impl GovernanceManager {
                     // the governance→economics provenance chain is broken (PS-3).
                 }
 
+                // ADR-0014 constitutional-memory seam.
+                //
+                // An Accepted decision produces a bounded institutional
+                // authorization to carry out its effects — a `Mandate`. We
+                // record that mandate here, upstream of any
+                // `InstitutionalEffectRecord` or `EffectDispatchEvidence`
+                // (which are evidence-side, see `institutional_effect.rs`).
+                //
+                // Bootstrap-phase posture: typed `AuthorityGrant` minting is
+                // not yet implemented, so we use
+                // `Mandate::new_pending_grants`. The mandate is
+                // institutional memory that authorization arose from this
+                // decision; it carries no executable authority until a
+                // later tranche attaches grants. This is intentionally
+                // **behavior-neutral**: no executor gating, no dispatcher
+                // wiring changes.
+                if matches!(outcome, ProofOutcome::Accepted) {
+                    let payload_hash = hash_proposal_payload(&proposal.payload);
+                    let mandate = Mandate::new_pending_grants(
+                        DecisionProvenance {
+                            proposal_id: proposal_id.0.clone(),
+                            decision_hash: receipt.decision_hash,
+                        },
+                        payload_hash,
+                        None,
+                        None,
+                        now,
+                    );
+                    if let Err(e) = store.put_mandate(&mandate) {
+                        tracing::error!(
+                            proposal_id = %proposal_id.0,
+                            mandate_id = %mandate.id,
+                            error = %e,
+                            "Failed to store mandate — constitutional-memory record lost"
+                        );
+                    }
+                }
+
                 // Wire governance→economics binding (INV-2: Allocation Completeness)
                 // When a budget/treasury/allocation proposal is accepted, create an
                 // AllocationReceipt linking the decision to economic intents.
@@ -5895,6 +5957,7 @@ mod tests {
         allocations: std::sync::Mutex<Vec<AllocationReceipt>>,
         institutional_effects: std::sync::Mutex<Vec<InstitutionalEffectRecord>>,
         dispatch_evidence: std::sync::Mutex<Vec<EffectDispatchEvidence>>,
+        mandates: std::sync::Mutex<Vec<icn_governance::Mandate>>,
     }
 
     impl InMemoryReceiptBackend {
@@ -5904,6 +5967,7 @@ mod tests {
                 allocations: std::sync::Mutex::new(vec![]),
                 institutional_effects: std::sync::Mutex::new(vec![]),
                 dispatch_evidence: std::sync::Mutex::new(vec![]),
+                mandates: std::sync::Mutex::new(vec![]),
             }
         }
     }
@@ -6009,6 +6073,37 @@ mod tests {
                 .cloned()
                 .collect();
             items.sort_by_key(|e| e.recorded_at);
+            Ok(items)
+        }
+        fn put_mandate(&self, mandate: &icn_governance::Mandate) -> Result<(), String> {
+            self.mandates.lock().unwrap().push(mandate.clone());
+            Ok(())
+        }
+        fn get_mandate_by_proposal(
+            &self,
+            proposal_id: &str,
+        ) -> Result<Option<icn_governance::Mandate>, String> {
+            Ok(self
+                .mandates
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|m| m.decision.proposal_id == proposal_id)
+                .cloned())
+        }
+        fn list_mandates_by_decision(
+            &self,
+            decision_hash: &icn_kernel_api::Hash,
+        ) -> Result<Vec<icn_governance::Mandate>, String> {
+            let mut items: Vec<icn_governance::Mandate> = self
+                .mandates
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|m| m.decision.decision_hash == *decision_hash)
+                .cloned()
+                .collect();
+            items.sort_by_key(|m| m.issued_at);
             Ok(items)
         }
     }
@@ -7951,5 +8046,179 @@ mod tests {
         );
         assert!(pb.activities.contains(&act.id));
         assert_eq!(a2.parent_program_id.as_ref(), Some(&prog_b.id));
+    }
+
+    // ============================================================================
+    // ADR-0014: Mandate recording at the decision-acceptance seam
+    // ============================================================================
+
+    /// Accepted proposal mints a pending-grants `Mandate` bound to the
+    /// decision provenance and payload content, recorded distinctly from
+    /// the governance receipt.
+    #[tokio::test]
+    async fn adr0014_mandate_minted_on_accepted_proposal() {
+        let (mgr, domain_id, member_did) = make_manager_with_domain().await;
+        let backend = Arc::new(InMemoryReceiptBackend::new());
+        let mgr = mgr.with_receipt_store(backend.clone());
+
+        let proposal_id = mgr
+            .create_proposal(
+                ProposalId(format!("prop-{}", uuid::Uuid::new_v4())),
+                domain_id.clone(),
+                member_did.clone(),
+                "Adopt policy".to_string(),
+                "A non-economic policy decision".to_string(),
+                ProposalPayload::Text {
+                    body: "Adopt the house rules.".to_string(),
+                },
+                ProposalScope::Local,
+            )
+            .await
+            .unwrap();
+
+        mgr.open_proposal(proposal_id.clone(), 86400).await.unwrap();
+        mgr.cast_vote(
+            proposal_id.clone(),
+            member_did.clone(),
+            VoteChoice::For,
+            None,
+        )
+        .await
+        .unwrap();
+        mgr.close_proposal(proposal_id.clone()).await.unwrap();
+
+        // Governance receipt exists.
+        let gov_receipt = backend
+            .get_governance_by_proposal(&proposal_id.0)
+            .unwrap()
+            .expect("governance receipt must exist");
+        assert_eq!(gov_receipt.outcome, ProofOutcome::Accepted);
+
+        // Mandate exists and binds the same decision provenance.
+        let mandate = backend
+            .get_mandate_by_proposal(&proposal_id.0)
+            .unwrap()
+            .expect("mandate must be recorded on Accepted path");
+        assert_eq!(mandate.decision.proposal_id, proposal_id.0);
+        assert_eq!(mandate.decision.decision_hash, gov_receipt.decision_hash);
+        // Bootstrap phase: no typed grants attached yet.
+        assert!(
+            mandate.has_no_grants(),
+            "bootstrap-phase mandate carries no attached grants"
+        );
+        assert_eq!(mandate.status, icn_governance::MandateStatus::Pending);
+        // payload_hash is bound to the payload content (non-zero).
+        assert_ne!(
+            mandate.payload_hash, [0u8; 32],
+            "payload_hash must be bound to actual payload serialization"
+        );
+
+        // Indexing by decision_hash returns the same mandate.
+        let by_decision = backend
+            .list_mandates_by_decision(&gov_receipt.decision_hash)
+            .unwrap();
+        assert_eq!(by_decision.len(), 1);
+        assert_eq!(by_decision[0].id, mandate.id);
+    }
+
+    /// Rejected proposal must not mint a mandate — a mandate is
+    /// *authorization*, which only arises from acceptance.
+    #[tokio::test]
+    async fn adr0014_no_mandate_on_rejected_proposal() {
+        let (mgr, domain_id, member_did) = make_manager_with_domain().await;
+        let backend = Arc::new(InMemoryReceiptBackend::new());
+        let mgr = mgr.with_receipt_store(backend.clone());
+
+        let proposal_id = mgr
+            .create_proposal(
+                ProposalId(format!("prop-{}", uuid::Uuid::new_v4())),
+                domain_id.clone(),
+                member_did.clone(),
+                "Reject this".to_string(),
+                "Expected rejection".to_string(),
+                ProposalPayload::Text {
+                    body: "A thing that will be voted down.".to_string(),
+                },
+                ProposalScope::Local,
+            )
+            .await
+            .unwrap();
+
+        mgr.open_proposal(proposal_id.clone(), 86400).await.unwrap();
+        mgr.cast_vote(
+            proposal_id.clone(),
+            member_did.clone(),
+            VoteChoice::Against,
+            None,
+        )
+        .await
+        .unwrap();
+        mgr.close_proposal(proposal_id.clone()).await.unwrap();
+
+        let gov_receipt = backend
+            .get_governance_by_proposal(&proposal_id.0)
+            .unwrap()
+            .expect("governance receipt must exist");
+        assert_eq!(gov_receipt.outcome, ProofOutcome::Rejected);
+
+        let mandate = backend.get_mandate_by_proposal(&proposal_id.0).unwrap();
+        assert!(
+            mandate.is_none(),
+            "Rejected proposal must not mint a mandate — authorization requires acceptance"
+        );
+    }
+
+    /// The Mandate record must remain upstream of evidence-side records.
+    /// Acceptance of a non-effect-translating proposal (`Text`) still mints
+    /// a Mandate (authorization provenance) but no `InstitutionalEffectRecord`
+    /// (evidence of translation). This pins the Mandate/Evidence distinction.
+    #[tokio::test]
+    async fn adr0014_mandate_distinct_from_institutional_effect_record() {
+        let (mgr, domain_id, member_did) = make_manager_with_domain().await;
+        let backend = Arc::new(InMemoryReceiptBackend::new());
+        let mgr = mgr.with_receipt_store(backend.clone());
+
+        let proposal_id = mgr
+            .create_proposal(
+                ProposalId(format!("prop-{}", uuid::Uuid::new_v4())),
+                domain_id.clone(),
+                member_did.clone(),
+                "Text only".to_string(),
+                "No effect translation".to_string(),
+                ProposalPayload::Text {
+                    body: "Declarative text; no kernel effect.".to_string(),
+                },
+                ProposalScope::Local,
+            )
+            .await
+            .unwrap();
+        mgr.open_proposal(proposal_id.clone(), 86400).await.unwrap();
+        mgr.cast_vote(
+            proposal_id.clone(),
+            member_did.clone(),
+            VoteChoice::For,
+            None,
+        )
+        .await
+        .unwrap();
+        mgr.close_proposal(proposal_id.clone()).await.unwrap();
+
+        // Mandate: recorded (authorization arose from the decision).
+        let mandate = backend.get_mandate_by_proposal(&proposal_id.0).unwrap();
+        assert!(
+            mandate.is_some(),
+            "Mandate must be recorded for any accepted decision"
+        );
+
+        // InstitutionalEffectRecord: NOT recorded for Text payloads, since
+        // they do not translate to a structured GovernanceEffect. This is
+        // the explicit distinctness: authorization is upstream of translation.
+        let effects = backend
+            .list_institutional_effects_by_proposal(&proposal_id.0)
+            .unwrap();
+        assert!(
+            effects.is_empty(),
+            "Text payload translates to no effect record; mandate remains upstream"
+        );
     }
 }

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -168,24 +168,26 @@ pub struct ReconciledEffectEntry {
 /// payload, for binding a [`Mandate`] to the concrete content of the
 /// decision (ADR-0014 `payload_hash` field).
 ///
-/// The hash is taken over `serde_json::to_vec(payload)`. JSON is
-/// canonical here because `ProposalPayload` already derives `Serialize`
-/// for cross-node use; if serialization fails (which shouldn't happen
-/// for a well-formed payload that was accepted by the governance
-/// pipeline), we fall back to a zeroed hash so the mandate still records
-/// the decision provenance rather than being silently dropped.
-fn hash_proposal_payload(payload: &ProposalPayload) -> icn_kernel_api::Hash {
-    match serde_json::to_vec(payload) {
-        Ok(bytes) => *blake3::hash(&bytes).as_bytes(),
-        Err(e) => {
-            tracing::warn!(
-                error = %e,
-                "Failed to serialize proposal payload for mandate payload_hash; \
-                 falling back to zeroed hash"
-            );
-            [0u8; 32]
-        }
-    }
+/// The hash is taken over the current `serde_json::to_vec(payload)`
+/// byte representation. This is treated as deterministic for the
+/// `ProposalPayload` shape and `serde_json` configuration used at
+/// acceptance time, but it is **not** a formally canonical JSON
+/// encoding — if `ProposalPayload` changes shape or `serde_json`
+/// semantics drift, payload hashes from older decisions will not be
+/// reproducible and must be read from the mandate record rather than
+/// recomputed.
+///
+/// Returns `Err` on serialization failure. The caller must decline to
+/// mint a mandate in that case; substituting a sentinel hash would
+/// collapse distinct payloads to the same content-binding and silently
+/// break the mandate↔payload invariant. Serialization failure on a
+/// payload that was accepted by the governance pipeline is not
+/// expected in practice.
+fn hash_proposal_payload(
+    payload: &ProposalPayload,
+) -> Result<icn_kernel_api::Hash, serde_json::Error> {
+    let bytes = serde_json::to_vec(payload)?;
+    Ok(*blake3::hash(&bytes).as_bytes())
 }
 
 /// Label the translated [`crate::http::configure::GovernanceEffect`] shape
@@ -3511,24 +3513,35 @@ impl GovernanceManager {
                 // **behavior-neutral**: no executor gating, no dispatcher
                 // wiring changes.
                 if matches!(outcome, ProofOutcome::Accepted) {
-                    let payload_hash = hash_proposal_payload(&proposal.payload);
-                    let mandate = Mandate::new_pending_grants(
-                        DecisionProvenance {
-                            proposal_id: proposal_id.0.clone(),
-                            decision_hash: receipt.decision_hash,
-                        },
-                        payload_hash,
-                        None,
-                        None,
-                        now,
-                    );
-                    if let Err(e) = store.put_mandate(&mandate) {
-                        tracing::error!(
-                            proposal_id = %proposal_id.0,
-                            mandate_id = %mandate.id,
-                            error = %e,
-                            "Failed to store mandate — constitutional-memory record lost"
-                        );
+                    match hash_proposal_payload(&proposal.payload) {
+                        Ok(payload_hash) => {
+                            let mandate = Mandate::new_pending_grants(
+                                DecisionProvenance {
+                                    proposal_id: proposal_id.0.clone(),
+                                    decision_hash: receipt.decision_hash,
+                                },
+                                payload_hash,
+                                None,
+                                None,
+                                now,
+                            );
+                            if let Err(e) = store.put_mandate(&mandate) {
+                                tracing::error!(
+                                    proposal_id = %proposal_id.0,
+                                    mandate_id = %mandate.id,
+                                    error = %e,
+                                    "Failed to store mandate — constitutional-memory record lost"
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                proposal_id = %proposal_id.0,
+                                error = %e,
+                                "Failed to hash proposal payload for mandate payload_hash — \
+                                 declining to mint mandate to avoid breaking content-binding invariant"
+                            );
+                        }
                     }
                 }
 

--- a/icn/apps/governance/src/receipt_backend.rs
+++ b/icn/apps/governance/src/receipt_backend.rs
@@ -108,8 +108,18 @@ pub trait GovernanceReceiptBackend: Send + Sync {
     ///
     /// Append-only; implementations treat a same-`MandateId` re-write as
     /// idempotent. Default impl is a no-op so downstream backends can
-    /// opt in without breaking. The in-memory test backend and the
-    /// sled-backed `ReceiptStore` both override.
+    /// opt in without breaking.
+    ///
+    /// **Override status (ADR-0014 bootstrap):** The in-memory test
+    /// backend overrides. The production sled-backed
+    /// [`ReceiptStore`](icn_gateway::receipt_store::ReceiptStore) does
+    /// **not** yet override — a follow-up tranche is required to add
+    /// sled column families for mandate storage. Until then, the
+    /// gateway's acceptance path records the mandate in tracing logs
+    /// (via the `GovernanceManager` error path when a backend returns
+    /// an error) but the sled backend simply no-ops. Operators that
+    /// need durable mandate records today must provide their own
+    /// overriding backend.
     fn put_mandate(&self, _mandate: &Mandate) -> Result<(), String> {
         Ok(())
     }

--- a/icn/apps/governance/src/receipt_backend.rs
+++ b/icn/apps/governance/src/receipt_backend.rs
@@ -1,7 +1,7 @@
 //! Abstraction over gateway's ReceiptStore so GovernanceManager can live
 //! in this crate without a circular dependency on icn-gateway.
 
-use icn_governance::GovernanceDecisionReceipt;
+use icn_governance::{GovernanceDecisionReceipt, Mandate};
 use icn_kernel_api::{AllocationReceipt, Hash};
 
 use crate::dispatch_evidence::EffectDispatchEvidence;
@@ -94,6 +94,42 @@ pub trait GovernanceReceiptBackend: Send + Sync {
         &self,
         _effect_record_id: &str,
     ) -> Result<Vec<EffectDispatchEvidence>, String> {
+        Ok(vec![])
+    }
+
+    /// Persist a [`Mandate`] minted at proposal acceptance time.
+    ///
+    /// A mandate is the constitutional mediation layer between an
+    /// accepted decision and its execution (ADR-0014). It is
+    /// **upstream** of evidence-side records (`InstitutionalEffectRecord`,
+    /// `EffectDispatchEvidence`) and **distinct** from them: a mandate
+    /// records *authority to act*, evidence records document *what was
+    /// done*.
+    ///
+    /// Append-only; implementations treat a same-`MandateId` re-write as
+    /// idempotent. Default impl is a no-op so downstream backends can
+    /// opt in without breaking. The in-memory test backend and the
+    /// sled-backed `ReceiptStore` both override.
+    fn put_mandate(&self, _mandate: &Mandate) -> Result<(), String> {
+        Ok(())
+    }
+
+    /// Retrieve the mandate minted for a proposal, if any.
+    ///
+    /// Returns `Ok(None)` when no mandate exists or when the backend
+    /// does not implement mandate storage (default).
+    fn get_mandate_by_proposal(&self, _proposal_id: &str) -> Result<Option<Mandate>, String> {
+        Ok(None)
+    }
+
+    /// Retrieve all mandates anchored to a governance decision hash,
+    /// oldest-first by `issued_at`.
+    ///
+    /// A single decision usually yields one mandate, but this returns a
+    /// `Vec` to keep the API symmetric with
+    /// [`Self::list_allocations_by_decision`] and to permit future
+    /// multi-mandate decisions without a migration.
+    fn list_mandates_by_decision(&self, _decision_hash: &Hash) -> Result<Vec<Mandate>, String> {
         Ok(vec![])
     }
 }

--- a/icn/crates/icn-governance/src/mandate.rs
+++ b/icn/crates/icn-governance/src/mandate.rs
@@ -218,6 +218,54 @@ impl Mandate {
         })
     }
 
+    /// Construct a mandate for the **bootstrap-phase decision-acceptance
+    /// seam**, where typed [`AuthorityGrant`] minting is not yet
+    /// implemented.
+    ///
+    /// Unlike [`Mandate::new`], this constructor **accepts an empty
+    /// `grants` vector** and does not return a `Result`. It exists
+    /// precisely because the current live governance path can identify
+    /// the decision but cannot yet identify the specific
+    /// [`AuthorityGrant`]s that bound the decision's authority — that
+    /// layer is future work.
+    ///
+    /// Status is initialized to [`MandateStatus::Pending`]. The mandate
+    /// is recorded as institutional memory that the decision conferred
+    /// bounded authorization under its domain's charter; the specific
+    /// grant binding is deferred.
+    ///
+    /// # Downstream obligations
+    ///
+    /// Callers that later wire execution gating **must** treat a mandate
+    /// constructed here (i.e. with `grants.is_empty()`) as **ineligible
+    /// for execution authorization checks** until a future tranche
+    /// attaches real grants. This constructor is the explicit
+    /// acknowledgement that we have authorization-provenance without
+    /// authority-binding, and it is behavior-neutral by design.
+    ///
+    /// This constructor is expected to be removed (or replaced by
+    /// stricter construction) once typed grant minting is landed.
+    ///
+    /// [`AuthorityGrant`]: crate::authority::AuthorityGrant
+    pub fn new_pending_grants(
+        decision: DecisionProvenance,
+        payload_hash: Hash,
+        executor: Option<Did>,
+        deadline: Option<Timestamp>,
+        issued_at: Timestamp,
+    ) -> Self {
+        Self {
+            id: MandateId::new(),
+            decision,
+            payload_hash,
+            grants: Vec::new(),
+            executor,
+            deadline,
+            status: MandateStatus::Pending,
+            issued_at,
+        }
+    }
+
     /// Return `true` if `now >= deadline` (when a deadline is set).
     ///
     /// This is a time-check helper, **not** an enforcement gate. Callers
@@ -226,6 +274,18 @@ impl Mandate {
     /// already discharged, which overrides deadline expiry).
     pub fn is_past_deadline(&self, now: Timestamp) -> bool {
         matches!(self.deadline, Some(d) if now >= d)
+    }
+
+    /// Return `true` if this mandate was minted before any typed
+    /// [`AuthorityGrant`]s could be attached.
+    ///
+    /// Downstream execution-gating code must refuse mandates where this
+    /// returns `true`; they are institutional-memory records, not
+    /// execution authorizations.
+    ///
+    /// [`AuthorityGrant`]: crate::authority::AuthorityGrant
+    pub fn has_no_grants(&self) -> bool {
+        self.grants.is_empty()
     }
 }
 
@@ -263,6 +323,14 @@ mod tests {
     fn mandate_new_rejects_empty_grants() {
         let err = Mandate::new(sample_decision(), [0u8; 32], vec![], None, None, 0).unwrap_err();
         assert_eq!(err, MandateError::EmptyGrants);
+    }
+
+    #[test]
+    fn mandate_new_pending_grants_allows_empty_and_marks_unbound() {
+        let m = Mandate::new_pending_grants(sample_decision(), [1u8; 32], None, Some(500), 100);
+        assert!(m.has_no_grants());
+        assert_eq!(m.status, MandateStatus::Pending);
+        assert_eq!(m.payload_hash, [1u8; 32]);
     }
 
     #[test]

--- a/icn/crates/icn-governance/src/mandate.rs
+++ b/icn/crates/icn-governance/src/mandate.rs
@@ -154,9 +154,23 @@ pub enum MandateStatus {
 /// provenance, payload hash, and at least one [`AuthorityGrantId`]. A
 /// mandate with an empty `grants` vector is not a valid constitutional
 /// authorization — the ADR-0014 rule is that authority must be bounded.
-/// The constructor enforces this invariant and returns
-/// [`MandateError::EmptyGrants`] if violated, so no caller can mint an
-/// unbounded mandate.
+/// The standard constructor enforces this invariant and returns
+/// [`MandateError::EmptyGrants`] if violated.
+///
+/// [`Mandate::new_pending_grants`] is the **only sanctioned** path that
+/// produces a mandate with an empty `grants` vector; it exists for the
+/// bootstrap-phase acceptance seam where typed
+/// [`crate::authority::AuthorityGrant`] minting is not yet wired, and
+/// the downstream obligation (no execution under an empty-grants
+/// mandate) is stated on that constructor.
+///
+/// Note that `Mandate`'s fields are currently `pub`, so a struct
+/// literal or a future custom `Deserialize` path could technically
+/// construct a `Mandate` with `grants.is_empty()` outside either
+/// constructor. Consumers that enforce execution gating must therefore
+/// call [`Mandate::has_no_grants`] rather than assume construction
+/// site alone guarantees non-emptiness. Tightening field visibility to
+/// close this gap is deliberate follow-up work.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Mandate {
     /// Stable identifier for the mandate.


### PR DESCRIPTION
## Summary

Makes `Mandate` participate in the live governance decision pipeline as a first-class, durable, app-layer constitutional-memory record. On accepted proposals only, `GovernanceManager` now mints a `Mandate` bound to the real decision provenance and persists it via `GovernanceReceiptBackend`.

Stacks on #1573 (which introduces the `Mandate`/`AuthorityGrant`/`DecisionProvenance` types). Retarget to `main` after #1573 merges.

## Why

ADR-0014 promotes constitutional authorization to a first-class object. The prior tranche gave us the types. This tranche gives us one live durable instance: every accepted proposal now produces a provenance-bound `Mandate` record in the receipt backend, sitting upstream of the existing evidence records (`InstitutionalEffectRecord`, `EffectDispatchEvidence`) — *authority to act* vs *what was done*.

## How

- `close_proposal_inner` (apps/governance) mints a `Mandate` immediately after `put_governance` when `ProofOutcome::Accepted`. Payload hash is blake3 over canonical `serde_json` of the `ProposalPayload`. Storage failures log but do not abort acceptance.
- New bootstrap-phase constructor `Mandate::new_pending_grants` (+ `has_no_grants()` helper) lets the live seam record a mandate honestly while `AuthorityGrant` minting is not yet wired. Strict `Mandate::new` (non-empty grants) is preserved untouched for the future grants-wired path. Doc calls out the obligation: downstream execution gating must refuse `has_no_grants()` mandates.
- `GovernanceReceiptBackend` gains three defaulted-no-op methods: `put_mandate`, `get_mandate_by_proposal`, `list_mandates_by_decision`. The sled-backed `ReceiptStore` in `icn-gateway` is unchanged — it inherits the no-ops. In-memory test backend overrides.

## Scope discipline (what this is NOT)

- No executor gating, no new dispatch owner, no effect-family widening, no fake `receipt_ref`.
- Rejected proposals mint nothing.
- `GovernanceEffect` translation / `InstitutionalEffectRecord` creation is unchanged — Mandate is distinct from and concurrent with evidence, not a replacement.
- No kernel crate imports governance meaning. Meaning Firewall intact.
- Gateway `ReceiptStore` gets no new sled column families in this PR — follow-up.

## Risk

Low. Behavior-neutral for all existing code paths: the addition is an extra `put_mandate` call on accepted proposals, whose failure is logged but non-fatal. No signature changes to public APIs outside the new trait methods (defaulted). No kernel boundary change.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p icn-governance -p icn-governance-actor --all-targets --all-features -- -D warnings`
- [x] `cargo test -p icn-governance -p icn-governance-actor` (495 + 183 lib tests, 42 integration)
- [x] Three new ADR-0014 tests:
  - `adr0014_mandate_minted_on_accepted_proposal` — provenance bound, pending, no grants, non-zero payload hash, indexed by decision hash
  - `adr0014_no_mandate_on_rejected_proposal` — Against outcome mints nothing
  - `adr0014_mandate_distinct_from_institutional_effect_record` — accepted Text payload: mandate present, effects list empty

## Follow-ups (out of scope)

1. Wire `AuthorityGrant` minting at acceptance so mandates can be constructed via strict `Mandate::new`.
2. Add sled column families in `icn-gateway::receipt_store` for the three new methods.
3. Introduce execution-gating layer that reads `has_no_grants()` and refuses unbound mandates.