### PR TITLE
feat(governance): ADR-0014 AuthorityGrant revocation write-path

### DIFF
--- a/icn/apps/governance/src/grant_minting.rs
+++ b/icn/apps/governance/src/grant_minting.rs
@@ -401,7 +401,7 @@ fn apply_acceptance_lifecycle(
         // grants are never revoked by this domain's vote.
         SdisProposal::RemoveSteward { steward, .. }
         | SdisProposal::SuspendSteward { steward, .. } => {
-            revoke_active_grants_for_person(backend, steward, domain_id, now)?;
+            revoke_active_grants_for_person(backend, steward, domain_id, now, now)?;
             Ok(Vec::new())
         }
 
@@ -426,24 +426,27 @@ fn apply_acceptance_lifecycle(
                     | StewardPenalty::Probation { .. }
             );
             if revokes {
-                revoke_active_grants_for_person(backend, steward, domain_id, now)?;
+                revoke_active_grants_for_person(backend, steward, domain_id, now, now)?;
             }
             Ok(Vec::new())
         }
 
         // Institutional-authority revocation: honors the payload's
         // `effective_at` when set (allows a governance-granted grace
-        // period); otherwise takes effect at `now`. The backend
-        // enforces monotonic-minimum: a strictly-earlier revocation
-        // tightens, a later-or-equal one is a no-op. Scoped to grants
-        // this domain issued — cross-domain grants are not touched.
+        // period); otherwise takes effect at `now`. Candidate grants
+        // are still selected from the set active at acceptance time,
+        // so grants minted after `effective_at` but before acceptance
+        // are not silently missed. The backend enforces
+        // monotonic-minimum: a strictly-earlier revocation tightens,
+        // a later-or-equal one is a no-op. Scoped to grants this
+        // domain issued — cross-domain grants are not touched.
         SdisProposal::RevokeAuthority {
             authority_did,
             effective_at,
             ..
         } => {
             let revoke_at = effective_at.unwrap_or(now);
-            revoke_active_grants_for_person(backend, authority_did, domain_id, revoke_at)?;
+            revoke_active_grants_for_person(backend, authority_did, domain_id, now, revoke_at)?;
             Ok(Vec::new())
         }
 
@@ -543,8 +546,9 @@ fn apply_acceptance_lifecycle(
     }
 }
 
-/// Revoke every active grant whose grantee is the given person DID AND
-/// whose grantor is the deciding domain.
+/// Revoke every grant whose grantee is the given person DID, whose
+/// grantor is the deciding domain, and which is active at
+/// `selection_now`; stamp each revocation with `revoked_at`.
 ///
 /// Error propagation: any failure to *list* or *write* a revocation —
 /// other than the benign `grant_not_found` index-skew case — is
@@ -577,11 +581,12 @@ fn revoke_active_grants_for_person(
     backend: &dyn GovernanceReceiptBackend,
     person: &icn_identity::Did,
     domain_id: &GovernanceDomainId,
+    selection_now: Timestamp,
     revoked_at: Timestamp,
 ) -> Result<(), String> {
     let grantee = Grantee::Person(person.clone());
     let grants = backend
-        .list_active_authority_grants_by_grantee(&grantee, revoked_at)
+        .list_active_authority_grants_by_grantee(&grantee, selection_now)
         .map_err(|e| {
             tracing::error!(
                 grantee = ?grantee,
@@ -607,6 +612,7 @@ fn revoke_active_grants_for_person(
                 tracing::info!(
                     grant_id = %g.id,
                     grantee = ?grantee,
+                    selection_now,
                     revoked_at,
                     "revoked authority grant at acceptance seam"
                 );
@@ -1762,6 +1768,70 @@ mod tests {
             all[0].revoked_at,
             Some(5_555),
             "effective_at must override the acceptance `now` for revocation timestamp"
+        );
+    }
+
+    #[test]
+    fn revoke_authority_revokes_grants_minted_after_effective_at_but_before_acceptance() {
+        // Candidate selection must happen at acceptance time, not at
+        // `effective_at`. Otherwise a grant minted during the grace
+        // window would remain active forever after an accepted
+        // RevokeAuthority decision.
+        let backend = InMemoryGrantBackend::new();
+        let dom = domain();
+        let authority = did(41);
+
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-appoint-authority-late",
+            &dom,
+            [0xf3u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::AppointSteward {
+                    candidate: authority.clone(),
+                    sponsors: vec![did(1)],
+                    region: "nyc".into(),
+                    bond_amount: 100,
+                    term_length: 10_000,
+                },
+            },
+            5_800,
+        )
+        .unwrap();
+
+        // Grace-period revocation accepted after the grant was minted.
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-revoke-authority-late",
+            &dom,
+            [0xf4u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::RevokeAuthority {
+                    authority_did: authority.clone(),
+                    reason: "decertified".into(),
+                    effective_at: Some(5_555),
+                },
+            },
+            6_000,
+        )
+        .unwrap();
+
+        let all = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(authority.clone()))
+            .unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(
+            all[0].revoked_at,
+            Some(5_555),
+            "accepted revocation must stamp payload effective_at even for grants discovered at acceptance time"
+        );
+
+        let active_after_acceptance = backend
+            .list_active_authority_grants_by_grantee(&Grantee::Person(authority), 6_000)
+            .unwrap();
+        assert!(
+            active_after_acceptance.is_empty(),
+            "grant minted during the grace window must still be revoked once the decision is accepted"
         );
     }
 

--- a/icn/apps/governance/src/grant_minting.rs
+++ b/icn/apps/governance/src/grant_minting.rs
@@ -130,9 +130,29 @@ pub fn mint_and_persist_for_accepted(
         decision_hash,
     };
 
-    // Derive zero or more grants. Empty vec is the truthful default for
-    // most payload classes today.
-    let grants = derive_grants_for_accepted_proposal(payload, domain_id, &decision_prov, now);
+    // Apply lifecycle side effects (revocations / reinstatement) for
+    // SDIS proposal variants that mutate existing authority. Revocations
+    // are durably stamped on target primary records before we proceed to
+    // mandate composition. Reinstatement may mint a fresh grant that
+    // composes into the derive-path grant set below.
+    //
+    // Revocations happen outside the mandate transaction — they must, in
+    // this tranche, because `put_mandate_with_grants_atomic` is a write
+    // path (inserts + index updates) that does not know about primary-
+    // record mutations. This creates a recoverable race window: if a
+    // revocation lands but the mandate write subsequently fails, the
+    // caller retries this seam → the idempotency check at the top of
+    // this function misses (no mandate) → the lifecycle runs again →
+    // `revoke_authority_grant`'s first-write-wins semantics turn the
+    // repeat into a no-op → the mandate write is re-attempted. The
+    // original `revoked_at` timestamp is preserved across retries.
+    let lifecycle_grants =
+        apply_acceptance_lifecycle(backend, payload, domain_id, &decision_prov, now);
+
+    // Derive zero or more grants from the payload itself. Empty vec is
+    // the truthful default for most payload classes today.
+    let mut grants = derive_grants_for_accepted_proposal(payload, domain_id, &decision_prov, now);
+    grants.extend(lifecycle_grants);
     let grant_ids: Vec<_> = grants.iter().map(|g| g.id.clone()).collect();
 
     // When we derived grants, attempt the atomic
@@ -321,11 +341,15 @@ fn derive_sdis_grants(
         }
 
         // Removals, sanctions, suspensions, and authority revocations
-        // do not mint new grants — they *revoke* existing authority.
-        // Modeling that requires querying the mandate/grant store and
-        // updating `revoked_at` on prior grants, which is explicit
-        // future work. Returning an empty vec here is the truthful
-        // answer: this decision does not create new authority.
+        // do not mint **new** grants from the derive path — they
+        // *revoke* existing authority. The side-effecting lifecycle
+        // work (durably stamping `revoked_at` on the target's grants,
+        // and minting a fresh grant for reinstatement) happens in
+        // [`apply_acceptance_lifecycle`], which is a separate seam so
+        // revocation writes and the pending-grants fall-through stay
+        // untangled from pure derivation. Returning an empty vec here
+        // keeps the "derivation is pure; lifecycle is side-effecting"
+        // split clean.
         SdisProposal::RemoveSteward { .. }
         | SdisProposal::SanctionSteward { .. }
         | SdisProposal::SuspendSteward { .. }
@@ -337,6 +361,258 @@ fn derive_sdis_grants(
         | SdisProposal::UpdateJurisdictionTier { .. }
         | SdisProposal::ForceKeyRotation { .. } => Vec::new(),
     }
+}
+
+/// Apply lifecycle side effects (revocations, reinstatement) at proposal
+/// acceptance time and return any fresh grants minted by reinstatement.
+///
+/// Called from [`mint_and_persist_for_accepted`] after the idempotency
+/// check passes. For revocation-shaped SDIS payloads this durably stamps
+/// `revoked_at` on the target's active grants via
+/// [`GovernanceReceiptBackend::revoke_authority_grant`]. For
+/// [`SdisProposal::ReinstateSteward`] this mints a brand-new grant
+/// (fresh UUID) cloning class/scope/grantor from the most-recent prior
+/// grant — never mutating a revoked grant back to active.
+///
+/// Revocations are best-effort: backend errors are logged and do not
+/// abort the decision. A `grant_not_found` error from an in-flight index
+/// skew is treated as skippable.
+///
+/// All backend calls on the defaulted no-op trait methods return empty
+/// lists / `Ok(())`, so in-memory test backends that do not durably
+/// persist grants produce the truthful "no grants to revoke" answer
+/// without error.
+fn apply_acceptance_lifecycle(
+    backend: &dyn GovernanceReceiptBackend,
+    payload: &ProposalPayload,
+    domain_id: &GovernanceDomainId,
+    decision: &DecisionProvenance,
+    now: Timestamp,
+) -> Vec<AuthorityGrant> {
+    let ProposalPayload::Sdis { proposal } = payload else {
+        return Vec::new();
+    };
+    use icn_governance::sdis::{SdisProposal, StewardPenalty};
+
+    match proposal {
+        // Direct-removal / direct-suspension: the target loses active
+        // authority at `now`. No new grants are minted.
+        SdisProposal::RemoveSteward { steward, .. }
+        | SdisProposal::SuspendSteward { steward, .. } => {
+            revoke_active_grants_for_person(backend, steward, now);
+            Vec::new()
+        }
+
+        // Sanctions only revoke when the penalty is removal-shaped.
+        // Warnings, bond-slashes, tier-demotions, and probation do not
+        // terminate existing authority; they operate on other axes
+        // (reputation, bond, monitoring) that the grant record does
+        // not model. Suspension and Removal do terminate authority;
+        // those penalties revoke the target's active grants.
+        SdisProposal::SanctionSteward {
+            steward, penalty, ..
+        } => {
+            let revokes = matches!(
+                penalty,
+                StewardPenalty::Removal { .. } | StewardPenalty::Suspension { .. }
+            );
+            if revokes {
+                revoke_active_grants_for_person(backend, steward, now);
+            }
+            Vec::new()
+        }
+
+        // Institutional-authority revocation: honors the payload's
+        // `effective_at` when set (allows a governance-granted grace
+        // period); otherwise takes effect at `now`. Grants whose
+        // `revoked_at` is already set are left untouched by the
+        // first-write-wins semantics in the backend.
+        SdisProposal::RevokeAuthority {
+            authority_did,
+            effective_at,
+            ..
+        } => {
+            let revoke_at = effective_at.unwrap_or(now);
+            revoke_active_grants_for_person(backend, authority_did, revoke_at);
+            Vec::new()
+        }
+
+        // Reinstatement mints a **fresh** grant — new UUID, new
+        // `valid_from = now`, new provenance bound to *this* decision.
+        // It does not mutate the revoked grant back to active. If no
+        // prior grant is found, we decline (return empty) and log: the
+        // seam refuses to fabricate bounds a payload did not carry.
+        SdisProposal::ReinstateSteward { steward, .. } => {
+            match mint_reinstatement_grant(backend, steward, domain_id, decision, now) {
+                Some(g) => vec![g],
+                None => Vec::new(),
+            }
+        }
+
+        // Revocation appeals do not mutate the original revocation in
+        // place — that would violate the first-write-wins invariant on
+        // `revoked_at` and would lose the constitutional record of the
+        // original revocation event. If an appeal is upheld, the
+        // governance flow follows up with a targeted remint proposal
+        // (e.g. `ReinstateSteward` for a steward, or a fresh
+        // `AppointSteward`/authority-granting proposal). In this
+        // tranche the acceptance seam records the mandate (via the
+        // pending-grants path) without any grant-store mutation.
+        SdisProposal::RevocationAppeal { .. } => {
+            tracing::info!(
+                proposal_id = %decision.proposal_id,
+                "RevocationAppeal acceptance: no in-place grant mutation; any reinstatement routes through a separate reinstatement proposal"
+            );
+            Vec::new()
+        }
+
+        // Non-lifecycle SDIS variants (threshold, authority approval,
+        // jurisdiction-tier bumps, forced key rotation) do not revoke
+        // grants — they change other domain state. No lifecycle work.
+        SdisProposal::AppointSteward { .. }
+        | SdisProposal::ReconfirmSteward { .. }
+        | SdisProposal::ModifyThreshold { .. }
+        | SdisProposal::ApproveAuthority { .. }
+        | SdisProposal::UpdateJurisdictionTier { .. }
+        | SdisProposal::ForceKeyRotation { .. } => Vec::new(),
+    }
+}
+
+/// Revoke every active grant whose grantee is the given person DID,
+/// best-effort. Errors are logged and the decision continues; missing
+/// primaries (index skew) are warned and skipped.
+fn revoke_active_grants_for_person(
+    backend: &dyn GovernanceReceiptBackend,
+    person: &icn_identity::Did,
+    revoked_at: Timestamp,
+) {
+    let grantee = Grantee::Person(person.clone());
+    let grants = match backend.list_active_authority_grants_by_grantee(&grantee, revoked_at) {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::error!(
+                grantee = ?grantee,
+                error = %e,
+                "list_active_authority_grants_by_grantee failed; skipping revocation"
+            );
+            return;
+        }
+    };
+    for g in grants {
+        match backend.revoke_authority_grant(&g.id, revoked_at) {
+            Ok(()) => {
+                tracing::info!(
+                    grant_id = %g.id,
+                    grantee = ?grantee,
+                    revoked_at,
+                    "revoked authority grant at acceptance seam"
+                );
+            }
+            Err(e) if e.starts_with("grant_not_found") => {
+                tracing::warn!(
+                    grant_id = %g.id,
+                    error = %e,
+                    "revoke_authority_grant skipped: grant_not_found (index skew)"
+                );
+            }
+            Err(e) => {
+                tracing::error!(
+                    grant_id = %g.id,
+                    error = %e,
+                    "revoke_authority_grant failed"
+                );
+            }
+        }
+    }
+}
+
+/// Mint a fresh reinstatement grant for a steward, cloning
+/// class/scope/grantor from the most-recent prior grant. Returns
+/// `None` when no prior grant can be located; reinstatement declines
+/// rather than fabricate bounds the payload does not carry.
+///
+/// Term length is taken from the prior grant's
+/// `valid_until - valid_from` (when `valid_until` was bounded); for
+/// prior grants that were unbounded (`valid_until: None`) the fresh
+/// grant is also unbounded, which mirrors the prior authority shape.
+fn mint_reinstatement_grant(
+    backend: &dyn GovernanceReceiptBackend,
+    steward: &icn_identity::Did,
+    domain_id: &GovernanceDomainId,
+    decision: &DecisionProvenance,
+    now: Timestamp,
+) -> Option<AuthorityGrant> {
+    let grantee = Grantee::Person(steward.clone());
+    let all = match backend.list_authority_grants_by_grantee(&grantee) {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::error!(
+                grantee = ?grantee,
+                error = %e,
+                "list_authority_grants_by_grantee failed; declining to mint reinstatement grant"
+            );
+            return None;
+        }
+    };
+    // Prefer the most-recent revoked grant (typical reinstatement
+    // shape); fall back to the most-recent grant of any status so a
+    // reinstatement after a mere expiry also works. Backend returns
+    // oldest-first by `valid_from`, so we take the last entry.
+    let template = all
+        .iter()
+        .filter(|g| g.revoked_at.is_some())
+        .next_back()
+        .or_else(|| all.last());
+    let template = match template {
+        Some(t) => t.clone(),
+        None => {
+            tracing::warn!(
+                grantee = ?grantee,
+                proposal_id = %decision.proposal_id,
+                "ReinstateSteward: no prior grant found for steward; declining to mint (no term bounds to clone)"
+            );
+            return None;
+        }
+    };
+
+    let valid_until = match template.valid_until {
+        Some(old_until) => {
+            let term = old_until.saturating_sub(template.valid_from);
+            now.checked_add(term)
+        }
+        None => None,
+    };
+    // If we attempted to add a bounded term and it overflowed, decline
+    // rather than silently widen the grant to unbounded (same fail-
+    // closed rule as [`derive_sdis_grants`] applies to AppointSteward).
+    if template.valid_until.is_some() && valid_until.is_none() {
+        tracing::error!(
+            grantee = ?grantee,
+            now,
+            "ReinstateSteward term overflow cloning prior grant; declining to mint (would be unbounded)"
+        );
+        return None;
+    }
+
+    // Ensure the cloned scope still names the current decision's domain.
+    // Prior grants issued under a different domain are kept in scope
+    // with their original domain — we don't rewrite a grant's domain
+    // context in reinstatement. The grantor remains the sovereign entity
+    // that decided *this* reinstatement, which matches the derive-path
+    // convention.
+    let scope = template.scope.clone();
+
+    Some(AuthorityGrant {
+        id: AuthorityGrantId::new(),
+        class: template.class,
+        grantor: GrantorEntityId(domain_id.0.clone()),
+        grantee: Grantee::Person(steward.clone()),
+        scope,
+        granted_by: Some(decision.clone()),
+        valid_from: now,
+        valid_until,
+        revoked_at: None,
+    })
 }
 
 #[cfg(test)]
@@ -659,5 +935,530 @@ mod tests {
         let p = g.granted_by.as_ref().unwrap();
         assert_eq!(p.proposal_id, "prop-xyz");
         assert_eq!(p.decision_hash, [42u8; 32]);
+    }
+
+    // ========================================================================
+    // Acceptance-seam lifecycle tests (revocation + reinstatement)
+    // ========================================================================
+
+    /// In-memory backend that fully supports mandate + grant storage,
+    /// including the ADR-0014 revocation write-path. Used by
+    /// acceptance-seam lifecycle tests to exercise `apply_acceptance_lifecycle`
+    /// without depending on the sled-backed gateway store.
+    struct InMemoryGrantBackend {
+        mandates: std::sync::Mutex<Vec<Mandate>>,
+        grants: std::sync::Mutex<Vec<AuthorityGrant>>,
+    }
+
+    impl InMemoryGrantBackend {
+        fn new() -> Self {
+            Self {
+                mandates: std::sync::Mutex::new(vec![]),
+                grants: std::sync::Mutex::new(vec![]),
+            }
+        }
+    }
+
+    impl GovernanceReceiptBackend for InMemoryGrantBackend {
+        fn put_governance(
+            &self,
+            _: &icn_governance::GovernanceDecisionReceipt,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+        fn get_governance_by_proposal(
+            &self,
+            _: &str,
+        ) -> Result<Option<icn_governance::GovernanceDecisionReceipt>, String> {
+            Ok(None)
+        }
+        fn put_allocation(
+            &self,
+            _: &icn_kernel_api::AllocationReceipt,
+        ) -> Result<icn_kernel_api::Hash, String> {
+            Ok([0u8; 32])
+        }
+        fn get_governance_by_decision(
+            &self,
+            _: &icn_kernel_api::Hash,
+        ) -> Result<Option<icn_governance::GovernanceDecisionReceipt>, String> {
+            Ok(None)
+        }
+        fn list_allocations_by_decision(
+            &self,
+            _: &icn_kernel_api::Hash,
+        ) -> Result<Vec<icn_kernel_api::AllocationReceipt>, String> {
+            Ok(vec![])
+        }
+        fn put_mandate(&self, mandate: &Mandate) -> Result<(), String> {
+            self.mandates.lock().unwrap().push(mandate.clone());
+            Ok(())
+        }
+        fn get_mandate_by_proposal(&self, proposal_id: &str) -> Result<Option<Mandate>, String> {
+            Ok(self
+                .mandates
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|m| m.decision.proposal_id == proposal_id)
+                .cloned())
+        }
+        fn put_authority_grant(&self, grant: &AuthorityGrant) -> Result<(), String> {
+            let mut guard = self.grants.lock().unwrap();
+            if let Some(existing) = guard.iter_mut().find(|g| g.id == grant.id) {
+                *existing = grant.clone();
+            } else {
+                guard.push(grant.clone());
+            }
+            Ok(())
+        }
+        fn get_authority_grant(
+            &self,
+            grant_id: &AuthorityGrantId,
+        ) -> Result<Option<AuthorityGrant>, String> {
+            Ok(self
+                .grants
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|g| &g.id == grant_id)
+                .cloned())
+        }
+        fn list_active_authority_grants_by_grantee(
+            &self,
+            grantee: &Grantee,
+            now: Timestamp,
+        ) -> Result<Vec<AuthorityGrant>, String> {
+            Ok(self
+                .grants
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|g| &g.grantee == grantee && g.is_active_at(now))
+                .cloned()
+                .collect())
+        }
+        fn list_authority_grants_by_grantee(
+            &self,
+            grantee: &Grantee,
+        ) -> Result<Vec<AuthorityGrant>, String> {
+            let mut out: Vec<_> = self
+                .grants
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|g| &g.grantee == grantee)
+                .cloned()
+                .collect();
+            out.sort_by_key(|g| g.valid_from);
+            Ok(out)
+        }
+        fn revoke_authority_grant(
+            &self,
+            grant_id: &AuthorityGrantId,
+            revoked_at: Timestamp,
+        ) -> Result<(), String> {
+            let mut guard = self.grants.lock().unwrap();
+            let Some(g) = guard.iter_mut().find(|g| &g.id == grant_id) else {
+                return Err(format!("grant_not_found: {grant_id}"));
+            };
+            // First-write-wins idempotency.
+            if g.revoked_at.is_none() {
+                g.revoked_at = Some(revoked_at);
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn remove_steward_revokes_only_target_grants_at_acceptance_seam() {
+        // Two stewards with active grants; a RemoveSteward proposal for
+        // steward A must revoke A's grant and leave B's untouched. This
+        // is the scoped-revocation invariant the by-grantee index is
+        // designed to serve.
+        let backend = InMemoryGrantBackend::new();
+        let dom = domain();
+        let steward_a = did(10);
+        let steward_b = did(11);
+
+        // Mint via the normal AppointSteward path so both grants exist
+        // under the acceptance seam's own rules.
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-appoint-a",
+            &dom,
+            [0xa1u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::AppointSteward {
+                    candidate: steward_a.clone(),
+                    sponsors: vec![did(1)],
+                    region: "nyc".into(),
+                    bond_amount: 100,
+                    term_length: 3_600,
+                },
+            },
+            1_000,
+        )
+        .unwrap();
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-appoint-b",
+            &dom,
+            [0xa2u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::AppointSteward {
+                    candidate: steward_b.clone(),
+                    sponsors: vec![did(2)],
+                    region: "nyc".into(),
+                    bond_amount: 100,
+                    term_length: 3_600,
+                },
+            },
+            1_000,
+        )
+        .unwrap();
+
+        // Sanity: both grants are active pre-revocation.
+        let a_active = backend
+            .list_active_authority_grants_by_grantee(&Grantee::Person(steward_a.clone()), 2_000)
+            .unwrap();
+        let b_active = backend
+            .list_active_authority_grants_by_grantee(&Grantee::Person(steward_b.clone()), 2_000)
+            .unwrap();
+        assert_eq!(a_active.len(), 1);
+        assert_eq!(b_active.len(), 1);
+
+        // Now accept a RemoveSteward for A only.
+        let outcome = mint_and_persist_for_accepted(
+            &backend,
+            "prop-remove-a",
+            &dom,
+            [0xadu8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::RemoveSteward {
+                    steward: steward_a.clone(),
+                    reason: "breach".into(),
+                    return_bond: false,
+                },
+            },
+            2_500,
+        )
+        .unwrap();
+
+        // RemoveSteward itself mints no grant, so the mandate lands in
+        // pending-grants shape.
+        match outcome {
+            MandateMintOutcome::Minted {
+                grants_persisted, ..
+            } => assert_eq!(grants_persisted, 0),
+            other => panic!("expected Minted (pending-grants); got {other:?}"),
+        }
+
+        // A's active list must now be empty; B's must still be present.
+        let a_after = backend
+            .list_active_authority_grants_by_grantee(&Grantee::Person(steward_a.clone()), 3_000)
+            .unwrap();
+        let b_after = backend
+            .list_active_authority_grants_by_grantee(&Grantee::Person(steward_b.clone()), 3_000)
+            .unwrap();
+        assert!(
+            a_after.is_empty(),
+            "target steward's active grants must be revoked; got {a_after:?}"
+        );
+        assert_eq!(
+            b_after.len(),
+            1,
+            "non-target steward's grants must not be touched"
+        );
+
+        // A's revoked grant's `revoked_at` equals the decision `now`.
+        let a_all = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(steward_a.clone()))
+            .unwrap();
+        assert_eq!(a_all.len(), 1);
+        assert_eq!(a_all[0].revoked_at, Some(2_500));
+    }
+
+    #[test]
+    fn remove_steward_acceptance_is_idempotent_across_retries() {
+        // Retrying the RemoveSteward acceptance (e.g. after a mandate-
+        // write failure) must not move the original `revoked_at`. The
+        // seam-level idempotency check + first-write-wins at the backend
+        // together guarantee this.
+        let backend = InMemoryGrantBackend::new();
+        let dom = domain();
+        let steward = did(10);
+
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-appoint",
+            &dom,
+            [0xc1u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::AppointSteward {
+                    candidate: steward.clone(),
+                    sponsors: vec![did(1)],
+                    region: "nyc".into(),
+                    bond_amount: 100,
+                    term_length: 3_600,
+                },
+            },
+            1_000,
+        )
+        .unwrap();
+
+        // First acceptance of the RemoveSteward: revocation lands at
+        // now=2_500.
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-remove",
+            &dom,
+            [0xc2u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::RemoveSteward {
+                    steward: steward.clone(),
+                    reason: "breach".into(),
+                    return_bond: false,
+                },
+            },
+            2_500,
+        )
+        .unwrap();
+
+        // Simulated retry at a later now=9_999: seam short-circuits on
+        // idempotency (mandate already exists). Even if it didn't, the
+        // backend's first-write-wins would keep revoked_at at 2_500.
+        let outcome = mint_and_persist_for_accepted(
+            &backend,
+            "prop-remove",
+            &dom,
+            [0xc2u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::RemoveSteward {
+                    steward: steward.clone(),
+                    reason: "breach".into(),
+                    return_bond: false,
+                },
+            },
+            9_999,
+        )
+        .unwrap();
+        assert!(matches!(outcome, MandateMintOutcome::AlreadyMinted { .. }));
+
+        let all = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(steward))
+            .unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(
+            all[0].revoked_at,
+            Some(2_500),
+            "original revoked_at must be preserved across retries"
+        );
+    }
+
+    #[test]
+    fn reinstate_steward_mints_fresh_grant_not_mutating_revoked_one() {
+        // After a RemoveSteward + ReinstateSteward sequence, the original
+        // grant must remain revoked and a brand-new grant (distinct id)
+        // must exist for the steward. This is the fresh-grant invariant:
+        // reinstatement never resurrects a revoked record.
+        let backend = InMemoryGrantBackend::new();
+        let dom = domain();
+        let steward = did(20);
+
+        // Appoint.
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-appoint",
+            &dom,
+            [0xd1u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::AppointSteward {
+                    candidate: steward.clone(),
+                    sponsors: vec![did(1)],
+                    region: "nyc".into(),
+                    bond_amount: 100,
+                    term_length: 3_600,
+                },
+            },
+            1_000,
+        )
+        .unwrap();
+
+        let original_id = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(steward.clone()))
+            .unwrap()[0]
+            .id
+            .clone();
+
+        // Remove (revoke).
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-remove",
+            &dom,
+            [0xd2u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::RemoveSteward {
+                    steward: steward.clone(),
+                    reason: "misconduct".into(),
+                    return_bond: false,
+                },
+            },
+            2_000,
+        )
+        .unwrap();
+
+        // Reinstate.
+        let outcome = mint_and_persist_for_accepted(
+            &backend,
+            "prop-reinstate",
+            &dom,
+            [0xd3u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::ReinstateSteward {
+                    steward: steward.clone(),
+                    reason: "appeal upheld".into(),
+                },
+            },
+            3_000,
+        )
+        .unwrap();
+        match outcome {
+            MandateMintOutcome::Minted {
+                grants_persisted, ..
+            } => assert_eq!(
+                grants_persisted, 1,
+                "reinstatement must mint exactly one fresh grant"
+            ),
+            other => panic!("expected Minted with fresh grant; got {other:?}"),
+        }
+
+        let all = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(steward.clone()))
+            .unwrap();
+        assert_eq!(all.len(), 2, "original + fresh grant");
+
+        // Original still revoked; fresh grant has distinct id, is active
+        // at `now`, and carries the reinstatement decision's provenance.
+        let original = all.iter().find(|g| g.id == original_id).unwrap();
+        let fresh = all.iter().find(|g| g.id != original_id).unwrap();
+        assert_eq!(
+            original.revoked_at,
+            Some(2_000),
+            "revoked grant must not be mutated back to active"
+        );
+        assert!(
+            fresh.revoked_at.is_none(),
+            "fresh grant must not be born revoked"
+        );
+        assert_ne!(
+            fresh.id, original_id,
+            "reinstatement must allocate a fresh AuthorityGrantId"
+        );
+        assert!(fresh.is_active_at(3_500));
+        assert_eq!(
+            fresh.granted_by.as_ref().unwrap().proposal_id,
+            "prop-reinstate",
+            "fresh grant's provenance must bind to the reinstatement decision"
+        );
+        assert_eq!(fresh.class, AuthorityClass::Attestation);
+        assert_eq!(fresh.grantee, Grantee::Person(steward));
+        // Cloned term length: original was 3_600 (1_000..4_600); fresh
+        // starts at now=3_000 and must also span 3_600.
+        assert_eq!(fresh.valid_from, 3_000);
+        assert_eq!(fresh.valid_until, Some(3_000 + 3_600));
+    }
+
+    #[test]
+    fn reinstate_steward_without_prior_grant_declines_to_mint() {
+        // If no prior grant exists for the steward, reinstatement has
+        // no template to clone bounds from. It must decline rather than
+        // fabricate unbounded authority.
+        let backend = InMemoryGrantBackend::new();
+        let dom = domain();
+        let steward = did(30);
+
+        let outcome = mint_and_persist_for_accepted(
+            &backend,
+            "prop-reinstate-orphan",
+            &dom,
+            [0xe1u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::ReinstateSteward {
+                    steward: steward.clone(),
+                    reason: "mistaken identity".into(),
+                },
+            },
+            1_000,
+        )
+        .unwrap();
+
+        match outcome {
+            MandateMintOutcome::Minted {
+                grants_persisted, ..
+            } => assert_eq!(
+                grants_persisted, 0,
+                "reinstatement with no template must produce pending-grants mandate"
+            ),
+            other => panic!("expected Minted (pending-grants); got {other:?}"),
+        }
+        let all = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(steward))
+            .unwrap();
+        assert!(all.is_empty(), "no grant may be fabricated");
+    }
+
+    #[test]
+    fn revoke_authority_honors_effective_at() {
+        // RevokeAuthority may carry an `effective_at` grace-period
+        // timestamp; the revocation must stamp that value (not `now`)
+        // on the target's grants.
+        let backend = InMemoryGrantBackend::new();
+        let dom = domain();
+        let authority = did(40);
+
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-appoint-authority",
+            &dom,
+            [0xf1u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::AppointSteward {
+                    candidate: authority.clone(),
+                    sponsors: vec![did(1)],
+                    region: "nyc".into(),
+                    bond_amount: 100,
+                    term_length: 10_000,
+                },
+            },
+            1_000,
+        )
+        .unwrap();
+
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-revoke-authority",
+            &dom,
+            [0xf2u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::RevokeAuthority {
+                    authority_did: authority.clone(),
+                    reason: "decertified".into(),
+                    effective_at: Some(5_555),
+                },
+            },
+            2_000,
+        )
+        .unwrap();
+
+        let all = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(authority))
+            .unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(
+            all[0].revoked_at,
+            Some(5_555),
+            "effective_at must override the acceptance `now` for revocation timestamp"
+        );
     }
 }

--- a/icn/apps/governance/src/grant_minting.rs
+++ b/icn/apps/governance/src/grant_minting.rs
@@ -325,32 +325,14 @@ fn derive_sdis_grants(
             }]
         }
 
-        // Steward reconfirmation: the payload names the steward
-        // (grantee) and a new absolute term end (time bound). Same
-        // class / scope shape as appointment; the grant represents
-        // the refreshed term.
-        SdisProposal::ReconfirmSteward {
-            steward,
-            new_term_end,
-            ..
-        } => {
-            let scope = TypedScope {
-                domain: Some(domain_id.clone()),
-                proposal_class: vec!["Sdis".into()],
-                ..TypedScope::default()
-            };
-            vec![AuthorityGrant {
-                id: AuthorityGrantId::new(),
-                class: AuthorityClass::Attestation,
-                grantor: GrantorEntityId(domain_id.0.clone()),
-                grantee: Grantee::Person(steward.clone()),
-                scope,
-                granted_by: Some(decision.clone()),
-                valid_from: now,
-                valid_until: Some(*new_term_end),
-                revoked_at: None,
-            }]
-        }
+        // Steward reconfirmation handled in the lifecycle seam, not
+        // here. A pure derive path cannot enforce the history-aware
+        // preconditions (active in-domain grant must exist; the most
+        // recent in-domain grant must not be revoked; new term must
+        // be strictly in the future). Without those guards, the
+        // derive path is a stealth-reinstatement and stealth-
+        // appointment vector — see [`apply_acceptance_lifecycle`].
+        SdisProposal::ReconfirmSteward { .. } => Vec::new(),
 
         // Removals, sanctions, suspensions, and authority revocations
         // do not mint **new** grants from the derive path — they
@@ -477,6 +459,59 @@ fn apply_acceptance_lifecycle(
             },
         ),
 
+        // Steward reconfirmation: refresh the term of an already-
+        // active steward. History-aware guards:
+        //   - Decline if `new_term_end <= now`. An absolute timestamp
+        //     at or before `now` produces an inactive grant — silent
+        //     no-op. Fail closed instead.
+        //   - Decline unless an active in-domain grant exists. This
+        //     closes two attack paths the pure derive path had open:
+        //       (a) Stealth reinstatement — ReconfirmSteward on a
+        //           steward whose most-recent in-domain grant is
+        //           revoked would mint fresh active authority,
+        //           bypassing `mint_reinstatement_grant`'s revoked-
+        //           template guard and the Reinstate proposal flow.
+        //       (b) Stealth appointment — ReconfirmSteward on a DID
+        //           that never had a grant in this domain would mint
+        //           authority without the AppointSteward sponsorship/
+        //           bond/term-length flow.
+        //
+        // Scope is cloned from the active template rather than
+        // fabricated, mirroring `mint_reinstatement_grant`'s pattern
+        // so a refresh preserves the prior grant's authority shape
+        // rather than quietly rewriting it.
+        //
+        // The prior active grant is intentionally NOT pre-revoked.
+        // Revoking outside `put_mandate_with_grants` would create a
+        // retry-livelock under partial-failure: a failed mandate
+        // commit after a successful prior-revoke would make the
+        // retry's active-grant lookup miss and decline the refresh,
+        // leaving the steward with no active authority. Letting the
+        // prior grant expire naturally on its original `valid_until`
+        // keeps the refresh retry-safe. Short coexistence overlap
+        // (prior's remaining term) is a benign consequence: both
+        // grants are governance-minted under the same scope/class/
+        // grantor, so accumulation is not a privilege-extension
+        // vector — it is append-only continuity-of-authority until
+        // the old term lapses.
+        SdisProposal::ReconfirmSteward {
+            steward,
+            new_term_end,
+            ..
+        } => Ok(
+            match mint_reconfirmation_grant(
+                backend,
+                steward,
+                domain_id,
+                decision,
+                now,
+                *new_term_end,
+            ) {
+                Some(g) => vec![g],
+                None => Vec::new(),
+            },
+        ),
+
         // Revocation appeals do not un-revoke in place — reviving a
         // revoked grant by clearing `revoked_at` would lose the
         // constitutional record of the original revocation event and
@@ -498,8 +533,9 @@ fn apply_acceptance_lifecycle(
         // Non-lifecycle SDIS variants (threshold, authority approval,
         // jurisdiction-tier bumps, forced key rotation) do not revoke
         // grants — they change other domain state. No lifecycle work.
+        // AppointSteward is handled in the pure derive path (no prior
+        // state to consult).
         SdisProposal::AppointSteward { .. }
-        | SdisProposal::ReconfirmSteward { .. }
         | SdisProposal::ModifyThreshold { .. }
         | SdisProposal::ApproveAuthority { .. }
         | SdisProposal::UpdateJurisdictionTier { .. }
@@ -724,6 +760,93 @@ fn mint_reinstatement_grant(
     })
 }
 
+/// Mint a fresh reconfirmation grant for a steward, cloning
+/// class/scope from the current **active** prior grant issued by
+/// **this deciding domain** and setting `grantor` from `domain_id`.
+///
+/// Returns `None` (declines to mint) when:
+/// - `new_term_end <= now` — the payload carries a degenerate absolute
+///   timestamp that would produce an inactive grant (silent no-op).
+///   Fail closed rather than record a grant that never activates.
+/// - no active in-domain grant exists for this grantee at `now` —
+///   reconfirmation presupposes active authority. Declining closes
+///   the stealth-reinstatement path (ReconfirmSteward on a revoked
+///   steward) and the stealth-appointment path (ReconfirmSteward on
+///   a never-granted DID). The callers for those cases are
+///   ReinstateSteward and AppointSteward respectively.
+///
+/// The cloned scope mirrors `mint_reinstatement_grant` so a refresh
+/// preserves the prior grant's authority shape rather than
+/// fabricating a narrower/broader scope from the payload alone.
+///
+/// The prior active grant is NOT revoked here — see the comment on
+/// the `ReconfirmSteward` lifecycle arm for the retry-safety rationale.
+fn mint_reconfirmation_grant(
+    backend: &dyn GovernanceReceiptBackend,
+    steward: &icn_identity::Did,
+    domain_id: &GovernanceDomainId,
+    decision: &DecisionProvenance,
+    now: Timestamp,
+    new_term_end: Timestamp,
+) -> Option<AuthorityGrant> {
+    if new_term_end <= now {
+        tracing::warn!(
+            grantee = %steward,
+            proposal_id = %decision.proposal_id,
+            now,
+            new_term_end,
+            "ReconfirmSteward: new_term_end is at or before now; declining to mint (would be inactive on creation)"
+        );
+        return None;
+    }
+
+    let grantee = Grantee::Person(steward.clone());
+    let actives = match backend.list_active_authority_grants_by_grantee(&grantee, now) {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::error!(
+                grantee = ?grantee,
+                error = %e,
+                "list_active_authority_grants_by_grantee failed; declining to mint reconfirmation grant"
+            );
+            return None;
+        }
+    };
+    // Restrict candidates to grants issued by THIS deciding domain.
+    // A cross-domain active grant does not authorize this domain to
+    // refresh it — the grantor must match.
+    let template = actives
+        .iter()
+        .filter(|g| g.grantor.0 == domain_id.0)
+        .next_back();
+    let template = match template {
+        Some(t) => t.clone(),
+        None => {
+            tracing::warn!(
+                grantee = ?grantee,
+                proposal_id = %decision.proposal_id,
+                deciding_domain = %domain_id.0,
+                "ReconfirmSteward: no active in-domain grant found; declining to mint (reconfirmation requires an active grant issued by this domain — use AppointSteward for first-time authority, ReinstateSteward for a revoked template)"
+            );
+            return None;
+        }
+    };
+
+    let scope = template.scope.clone();
+
+    Some(AuthorityGrant {
+        id: AuthorityGrantId::new(),
+        class: template.class,
+        grantor: GrantorEntityId(domain_id.0.clone()),
+        grantee: Grantee::Person(steward.clone()),
+        scope,
+        granted_by: Some(decision.clone()),
+        valid_from: now,
+        valid_until: Some(new_term_end),
+        revoked_at: None,
+    })
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -784,24 +907,23 @@ mod tests {
     }
 
     #[test]
-    fn reconfirm_steward_mints_one_attestation_grant_bounded_by_new_term_end() {
-        let new_term_end: Timestamp = 5_000_000;
+    fn reconfirm_steward_is_not_a_pure_derive_path() {
+        // ReconfirmSteward now requires backend/history access (it is
+        // lifecycle, not pure derive). The pure derive path must
+        // return an empty vec; the real behavior is exercised via
+        // `mint_and_persist_for_accepted` against a backend.
         let payload = ProposalPayload::Sdis {
             proposal: SdisProposal::ReconfirmSteward {
                 steward: did(3),
-                new_term_end,
+                new_term_end: 5_000_000,
                 performance_notes: None,
             },
         };
-        let d = decision();
-        let dom = domain();
-
-        let grants = derive_grants_for_accepted_proposal(&payload, &dom, &d, 1_000);
-        assert_eq!(grants.len(), 1);
-        let g = &grants[0];
-        assert_eq!(g.class, AuthorityClass::Attestation);
-        assert_eq!(g.grantee, Grantee::Person(did(3)));
-        assert_eq!(g.valid_until, Some(new_term_end));
+        let grants = derive_grants_for_accepted_proposal(&payload, &domain(), &decision(), 1_000);
+        assert!(
+            grants.is_empty(),
+            "ReconfirmSteward must not mint from the pure derive path — needs history lookup"
+        );
     }
 
     #[test]
@@ -2123,5 +2245,372 @@ mod tests {
                 .is_some(),
             "mandate must be recorded on the successful retry"
         );
+    }
+
+    // ========================================================================
+    // ReconfirmSteward history-aware lifecycle tests
+    // ========================================================================
+
+    #[test]
+    fn reconfirm_steward_declines_when_steward_has_no_prior_grant() {
+        // ReconfirmSteward on a DID with no in-domain history must
+        // decline — this is the stealth-appointment path. First-time
+        // authority belongs to AppointSteward.
+        let backend = InMemoryGrantBackend::new();
+        let dom = domain();
+        let steward = did(90);
+
+        let outcome = mint_and_persist_for_accepted(
+            &backend,
+            "prop-reconfirm-ghost",
+            &dom,
+            [0xA0u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::ReconfirmSteward {
+                    steward: steward.clone(),
+                    new_term_end: 10_000,
+                    performance_notes: None,
+                },
+            },
+            1_000,
+        )
+        .unwrap();
+
+        match outcome {
+            MandateMintOutcome::Minted {
+                grants_persisted, ..
+            } => assert_eq!(
+                grants_persisted, 0,
+                "reconfirmation without any prior in-domain grant must decline"
+            ),
+            other => panic!("expected Minted (pending-grants); got {other:?}"),
+        }
+
+        let all = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(steward))
+            .unwrap();
+        assert!(
+            all.is_empty(),
+            "no grant may be minted for a never-appointed steward"
+        );
+    }
+
+    #[test]
+    fn reconfirm_steward_declines_when_only_revoked_in_domain_grant_exists() {
+        // The critical bug: ReconfirmSteward on a revoked steward was
+        // a stealth-reinstatement path in the pure derive version.
+        // Must decline — reinstatement of a revoked steward routes
+        // through ReinstateSteward, which mints from a valid revoked
+        // template under its own flow.
+        let backend = InMemoryGrantBackend::new();
+        let dom = domain();
+        let steward = did(91);
+
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-appoint-for-revoke",
+            &dom,
+            [0xA1u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::AppointSteward {
+                    candidate: steward.clone(),
+                    sponsors: vec![did(1)],
+                    region: "nyc".into(),
+                    bond_amount: 100,
+                    term_length: 3_600,
+                },
+            },
+            1_000,
+        )
+        .unwrap();
+
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-remove-before-reconfirm",
+            &dom,
+            [0xA2u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::RemoveSteward {
+                    steward: steward.clone(),
+                    reason: "breach".into(),
+                    return_bond: false,
+                },
+            },
+            2_000,
+        )
+        .unwrap();
+
+        // Attempt reconfirmation while the steward is revoked — must
+        // decline rather than silently re-activate.
+        let outcome = mint_and_persist_for_accepted(
+            &backend,
+            "prop-reconfirm-revoked",
+            &dom,
+            [0xA3u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::ReconfirmSteward {
+                    steward: steward.clone(),
+                    new_term_end: 10_000,
+                    performance_notes: None,
+                },
+            },
+            3_000,
+        )
+        .unwrap();
+
+        match outcome {
+            MandateMintOutcome::Minted {
+                grants_persisted, ..
+            } => assert_eq!(
+                grants_persisted, 0,
+                "reconfirmation of a revoked steward must decline (closes stealth-reinstatement path)"
+            ),
+            other => panic!("expected Minted (pending-grants); got {other:?}"),
+        }
+
+        let all = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(steward))
+            .unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(
+            all[0].revoked_at,
+            Some(2_000),
+            "revoked grant must remain revoked; no fresh active grant was minted"
+        );
+    }
+
+    #[test]
+    fn reconfirm_steward_declines_when_new_term_end_is_at_or_before_now() {
+        // An absolute `new_term_end <= now` would record a grant that
+        // is inactive on creation. Fail closed rather than record a
+        // silent no-op grant.
+        let backend = InMemoryGrantBackend::new();
+        let dom = domain();
+        let steward = did(92);
+
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-appoint-92",
+            &dom,
+            [0xA4u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::AppointSteward {
+                    candidate: steward.clone(),
+                    sponsors: vec![did(1)],
+                    region: "nyc".into(),
+                    bond_amount: 100,
+                    term_length: 10_000,
+                },
+            },
+            1_000,
+        )
+        .unwrap();
+
+        // new_term_end equal to now: must decline.
+        let outcome = mint_and_persist_for_accepted(
+            &backend,
+            "prop-reconfirm-now-eq-term",
+            &dom,
+            [0xA5u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::ReconfirmSteward {
+                    steward: steward.clone(),
+                    new_term_end: 5_000,
+                    performance_notes: None,
+                },
+            },
+            5_000,
+        )
+        .unwrap();
+        match outcome {
+            MandateMintOutcome::Minted {
+                grants_persisted, ..
+            } => assert_eq!(grants_persisted, 0, "new_term_end == now must decline"),
+            other => panic!("expected Minted; got {other:?}"),
+        }
+
+        // new_term_end strictly before now: must decline.
+        let outcome = mint_and_persist_for_accepted(
+            &backend,
+            "prop-reconfirm-term-in-past",
+            &dom,
+            [0xA6u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::ReconfirmSteward {
+                    steward: steward.clone(),
+                    new_term_end: 4_000,
+                    performance_notes: None,
+                },
+            },
+            5_000,
+        )
+        .unwrap();
+        match outcome {
+            MandateMintOutcome::Minted {
+                grants_persisted, ..
+            } => assert_eq!(grants_persisted, 0, "new_term_end < now must decline"),
+            other => panic!("expected Minted; got {other:?}"),
+        }
+
+        let all = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(steward))
+            .unwrap();
+        assert_eq!(
+            all.len(),
+            1,
+            "only the original appointment grant exists; no degenerate reconfirmation grants were recorded"
+        );
+    }
+
+    #[test]
+    fn reconfirm_steward_mints_fresh_grant_when_active_in_domain_grant_exists() {
+        // Happy path: steward has an active in-domain grant,
+        // `new_term_end > now`. Mints one fresh grant with
+        // `valid_from = now`, `valid_until = new_term_end`. The prior
+        // grant is intentionally left to expire naturally — retry-
+        // safety rationale is in the lifecycle arm comment.
+        let backend = InMemoryGrantBackend::new();
+        let dom = domain();
+        let steward = did(93);
+
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-appoint-93",
+            &dom,
+            [0xA7u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::AppointSteward {
+                    candidate: steward.clone(),
+                    sponsors: vec![did(1)],
+                    region: "nyc".into(),
+                    bond_amount: 100,
+                    term_length: 10_000,
+                },
+            },
+            1_000,
+        )
+        .unwrap();
+
+        let outcome = mint_and_persist_for_accepted(
+            &backend,
+            "prop-reconfirm-happy",
+            &dom,
+            [0xA8u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::ReconfirmSteward {
+                    steward: steward.clone(),
+                    new_term_end: 50_000,
+                    performance_notes: Some("solid term".into()),
+                },
+            },
+            5_000,
+        )
+        .unwrap();
+
+        match outcome {
+            MandateMintOutcome::Minted {
+                grants_persisted, ..
+            } => assert_eq!(
+                grants_persisted, 1,
+                "happy-path reconfirm mints one fresh grant"
+            ),
+            other => panic!("expected Minted; got {other:?}"),
+        }
+
+        let all = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(steward))
+            .unwrap();
+        assert_eq!(
+            all.len(),
+            2,
+            "history holds the appointment + the reconfirmation"
+        );
+
+        let refreshed = all
+            .iter()
+            .find(|g| g.valid_from == 5_000)
+            .expect("refresh exists");
+        assert_eq!(refreshed.valid_until, Some(50_000));
+        assert_eq!(refreshed.class, AuthorityClass::Attestation);
+        assert_eq!(refreshed.grantor, GrantorEntityId("coop:tech".into()));
+        assert!(refreshed.revoked_at.is_none());
+
+        let original = all
+            .iter()
+            .find(|g| g.valid_from == 1_000)
+            .expect("original exists");
+        assert!(
+            original.revoked_at.is_none(),
+            "prior grant is intentionally left active — retry-safety over pre-revoke"
+        );
+        assert_eq!(
+            original.valid_until,
+            Some(11_000),
+            "original term unchanged"
+        );
+    }
+
+    #[test]
+    fn reconfirm_steward_declines_when_only_cross_domain_active_grant_exists() {
+        // A cross-domain active grant does not authorize this domain
+        // to refresh. Only an active grant whose grantor matches the
+        // deciding domain counts.
+        let backend = InMemoryGrantBackend::new();
+        let steward = did(94);
+        let domain_a = GovernanceDomainId("coop:alpha".into());
+        let domain_b = GovernanceDomainId("coop:beta".into());
+
+        // Domain B appoints the steward.
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-appoint-b-94",
+            &domain_b,
+            [0xA9u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::AppointSteward {
+                    candidate: steward.clone(),
+                    sponsors: vec![did(2)],
+                    region: "nyc".into(),
+                    bond_amount: 100,
+                    term_length: 10_000,
+                },
+            },
+            1_000,
+        )
+        .unwrap();
+
+        // Domain A attempts to reconfirm — must decline (domain A has
+        // no grant to refresh).
+        let outcome = mint_and_persist_for_accepted(
+            &backend,
+            "prop-reconfirm-cross-domain",
+            &domain_a,
+            [0xAAu8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::ReconfirmSteward {
+                    steward: steward.clone(),
+                    new_term_end: 50_000,
+                    performance_notes: None,
+                },
+            },
+            2_000,
+        )
+        .unwrap();
+
+        match outcome {
+            MandateMintOutcome::Minted {
+                grants_persisted, ..
+            } => assert_eq!(
+                grants_persisted, 0,
+                "cross-domain reconfirmation must decline"
+            ),
+            other => panic!("expected Minted; got {other:?}"),
+        }
+
+        let all = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(steward))
+            .unwrap();
+        assert_eq!(all.len(), 1, "only domain_b's original grant exists");
+        assert_eq!(all[0].grantor, GrantorEntityId(domain_b.0));
     }
 }

--- a/icn/apps/governance/src/grant_minting.rs
+++ b/icn/apps/governance/src/grant_minting.rs
@@ -397,10 +397,12 @@ fn apply_acceptance_lifecycle(
 
     match proposal {
         // Direct-removal / direct-suspension: the target loses active
-        // authority at `now`. No new grants are minted.
+        // authority at `now`. No new grants are minted. Scoped to
+        // grants issued by the deciding domain only — another domain's
+        // grants are never revoked by this domain's vote.
         SdisProposal::RemoveSteward { steward, .. }
         | SdisProposal::SuspendSteward { steward, .. } => {
-            revoke_active_grants_for_person(backend, steward, now);
+            revoke_active_grants_for_person(backend, steward, domain_id, now);
             Vec::new()
         }
 
@@ -409,7 +411,8 @@ fn apply_acceptance_lifecycle(
         // terminate existing authority; they operate on other axes
         // (reputation, bond, monitoring) that the grant record does
         // not model. Suspension and Removal do terminate authority;
-        // those penalties revoke the target's active grants.
+        // those penalties revoke the target's active grants issued by
+        // the deciding domain.
         SdisProposal::SanctionSteward {
             steward, penalty, ..
         } => {
@@ -418,7 +421,7 @@ fn apply_acceptance_lifecycle(
                 StewardPenalty::Removal { .. } | StewardPenalty::Suspension { .. }
             );
             if revokes {
-                revoke_active_grants_for_person(backend, steward, now);
+                revoke_active_grants_for_person(backend, steward, domain_id, now);
             }
             Vec::new()
         }
@@ -427,14 +430,15 @@ fn apply_acceptance_lifecycle(
         // `effective_at` when set (allows a governance-granted grace
         // period); otherwise takes effect at `now`. Grants whose
         // `revoked_at` is already set are left untouched by the
-        // first-write-wins semantics in the backend.
+        // first-write-wins semantics in the backend. Scoped to grants
+        // this domain issued — cross-domain grants are not touched.
         SdisProposal::RevokeAuthority {
             authority_did,
             effective_at,
             ..
         } => {
             let revoke_at = effective_at.unwrap_or(now);
-            revoke_active_grants_for_person(backend, authority_did, revoke_at);
+            revoke_active_grants_for_person(backend, authority_did, domain_id, revoke_at);
             Vec::new()
         }
 
@@ -479,12 +483,21 @@ fn apply_acceptance_lifecycle(
     }
 }
 
-/// Revoke every active grant whose grantee is the given person DID,
-/// best-effort. Errors are logged and the decision continues; missing
-/// primaries (index skew) are warned and skipped.
+/// Revoke every active grant whose grantee is the given person DID AND
+/// whose grantor is the deciding domain, best-effort. Errors are logged
+/// and the decision continues; missing primaries (index skew) are
+/// warned and skipped.
+///
+/// Cross-domain guard: an accepted SDIS revocation runs in exactly one
+/// governance domain. That domain's vote must not strip authority
+/// granted by another sovereign entity — grants whose `grantor` does
+/// not match `domain_id` are skipped unconditionally. This preserves
+/// the ADR-0014 invariant that revocation is by-grantor: only the
+/// entity that issued a grant can end it.
 fn revoke_active_grants_for_person(
     backend: &dyn GovernanceReceiptBackend,
     person: &icn_identity::Did,
+    domain_id: &GovernanceDomainId,
     revoked_at: Timestamp,
 ) {
     let grantee = Grantee::Person(person.clone());
@@ -500,6 +513,17 @@ fn revoke_active_grants_for_person(
         }
     };
     for g in grants {
+        if g.grantor.0 != domain_id.0 {
+            // Cross-domain grant: this decision's domain did not
+            // issue it, so this decision does not terminate it.
+            tracing::debug!(
+                grant_id = %g.id,
+                grant_grantor = %g.grantor,
+                deciding_domain = %domain_id.0,
+                "skipping cross-domain grant during revocation"
+            );
+            continue;
+        }
         match backend.revoke_authority_grant(&g.id, revoked_at) {
             Ok(()) => {
                 tracing::info!(
@@ -1460,6 +1484,101 @@ mod tests {
             all[0].revoked_at,
             Some(5_555),
             "effective_at must override the acceptance `now` for revocation timestamp"
+        );
+    }
+
+    #[test]
+    fn remove_steward_does_not_revoke_cross_domain_grants() {
+        // Cross-domain guard: a RemoveSteward accepted in domain A must
+        // NOT revoke the same steward's active grant issued by domain B.
+        // Only the grantor entity that issued a grant can end it.
+        let backend = InMemoryGrantBackend::new();
+        let steward = did(12);
+        let domain_a = GovernanceDomainId("coop:alpha".into());
+        let domain_b = GovernanceDomainId("coop:beta".into());
+
+        // Mint a grant under domain A.
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-appoint-a",
+            &domain_a,
+            [0xaau8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::AppointSteward {
+                    candidate: steward.clone(),
+                    sponsors: vec![did(1)],
+                    region: "nyc".into(),
+                    bond_amount: 100,
+                    term_length: 3_600,
+                },
+            },
+            1_000,
+        )
+        .unwrap();
+        // Mint a grant under domain B for the same steward.
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-appoint-b",
+            &domain_b,
+            [0xbbu8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::AppointSteward {
+                    candidate: steward.clone(),
+                    sponsors: vec![did(2)],
+                    region: "nyc".into(),
+                    bond_amount: 100,
+                    term_length: 3_600,
+                },
+            },
+            1_000,
+        )
+        .unwrap();
+
+        // Sanity: two active grants for the same grantee, different grantors.
+        let active = backend
+            .list_active_authority_grants_by_grantee(&Grantee::Person(steward.clone()), 1_500)
+            .unwrap();
+        assert_eq!(active.len(), 2);
+
+        // Domain A accepts RemoveSteward — must NOT touch domain B's grant.
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-remove-a",
+            &domain_a,
+            [0xccu8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::RemoveSteward {
+                    steward: steward.clone(),
+                    reason: "breach".into(),
+                    return_bond: false,
+                },
+            },
+            2_000,
+        )
+        .unwrap();
+
+        let all = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(steward.clone()))
+            .unwrap();
+        assert_eq!(all.len(), 2, "no grant should be deleted");
+
+        let domain_a_grant = all
+            .iter()
+            .find(|g| g.grantor == GrantorEntityId(domain_a.0.clone()))
+            .expect("domain_a grant must exist");
+        let domain_b_grant = all
+            .iter()
+            .find(|g| g.grantor == GrantorEntityId(domain_b.0.clone()))
+            .expect("domain_b grant must exist");
+
+        assert_eq!(
+            domain_a_grant.revoked_at,
+            Some(2_000),
+            "domain_a's own grant must be revoked by its own RemoveSteward decision"
+        );
+        assert_eq!(
+            domain_b_grant.revoked_at, None,
+            "domain_b's grant must NOT be revoked by domain_a's decision — cross-domain guard"
         );
     }
 }

--- a/icn/apps/governance/src/grant_minting.rs
+++ b/icn/apps/governance/src/grant_minting.rs
@@ -552,14 +552,24 @@ fn revoke_active_grants_for_person(
 }
 
 /// Mint a fresh reinstatement grant for a steward, cloning
-/// class/scope/grantor from the most-recent prior grant. Returns
-/// `None` when no prior grant can be located; reinstatement declines
-/// rather than fabricate bounds the payload does not carry.
+/// class/scope from the most-recent **revoked** prior grant issued by
+/// **this deciding domain** and setting `grantor` from `domain_id`.
 ///
-/// Term length is taken from the prior grant's
-/// `valid_until - valid_from` (when `valid_until` was bounded); for
-/// prior grants that were unbounded (`valid_until: None`) the fresh
-/// grant is also unbounded, which mirrors the prior authority shape.
+/// Returns `None` (declines to mint) when:
+/// - no prior grant exists for this grantee in this domain,
+/// - no prior grant in this domain has been revoked (which includes
+///   the common case where the steward is already active — a
+///   reinstatement of an already-active steward is a no-op, never a
+///   privilege extension), or
+/// - cloning the prior term would overflow `now`.
+///
+/// Reinstatement declines rather than fabricate bounds the payload
+/// does not carry, and declines rather than clone a template from
+/// another domain's history. Term length is taken from the prior
+/// grant's `valid_until - valid_from` (when `valid_until` was
+/// bounded); for prior grants that were unbounded (`valid_until:
+/// None`) the fresh grant is also unbounded, mirroring the prior
+/// authority shape.
 fn mint_reinstatement_grant(
     backend: &dyn GovernanceReceiptBackend,
     steward: &icn_identity::Did,
@@ -579,22 +589,25 @@ fn mint_reinstatement_grant(
             return None;
         }
     };
-    // Prefer the most-recent revoked grant (typical reinstatement
-    // shape); fall back to the most-recent grant of any status so a
-    // reinstatement after a mere expiry also works. Backend returns
-    // oldest-first by `valid_from`, so we take the last entry.
+    // Restrict candidates to:
+    //   (a) grants issued by THIS deciding domain — cross-domain
+    //       reinstatement would import another sovereign's shape, and
+    //   (b) grants that have been revoked — reinstating an already-
+    //       active steward must be a no-op, not a privilege-extension
+    //       mint. Backend returns oldest-first by `valid_from`, so we
+    //       take the last matching entry (most-recent revoked).
     let template = all
         .iter()
-        .filter(|g| g.revoked_at.is_some())
-        .next_back()
-        .or_else(|| all.last());
+        .filter(|g| g.grantor.0 == domain_id.0 && g.revoked_at.is_some())
+        .next_back();
     let template = match template {
         Some(t) => t.clone(),
         None => {
             tracing::warn!(
                 grantee = ?grantee,
                 proposal_id = %decision.proposal_id,
-                "ReinstateSteward: no prior grant found for steward; declining to mint (no term bounds to clone)"
+                deciding_domain = %domain_id.0,
+                "ReinstateSteward: no revoked in-domain grant found; declining to mint (reinstatement needs a revoked template issued by this domain)"
             );
             return None;
         }
@@ -1580,5 +1593,154 @@ mod tests {
             domain_b_grant.revoked_at, None,
             "domain_b's grant must NOT be revoked by domain_a's decision — cross-domain guard"
         );
+    }
+
+    #[test]
+    fn reinstate_steward_declines_when_target_is_active() {
+        // Reinstating an already-active steward must be a no-op, not a
+        // fresh-grant mint. The common-case bug: repeated or erroneous
+        // ReinstateSteward proposals must NOT silently duplicate or
+        // extend privileges.
+        let backend = InMemoryGrantBackend::new();
+        let dom = domain();
+        let steward = did(50);
+
+        // Appoint — steward is active; there are no revoked grants.
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-appoint",
+            &dom,
+            [0x51u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::AppointSteward {
+                    candidate: steward.clone(),
+                    sponsors: vec![did(1)],
+                    region: "nyc".into(),
+                    bond_amount: 100,
+                    term_length: 3_600,
+                },
+            },
+            1_000,
+        )
+        .unwrap();
+
+        // Reinstate while still active — must decline.
+        let outcome = mint_and_persist_for_accepted(
+            &backend,
+            "prop-reinstate-active",
+            &dom,
+            [0x52u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::ReinstateSteward {
+                    steward: steward.clone(),
+                    reason: "redundant appeal".into(),
+                },
+            },
+            2_000,
+        )
+        .unwrap();
+
+        match outcome {
+            MandateMintOutcome::Minted {
+                grants_persisted, ..
+            } => assert_eq!(
+                grants_persisted, 0,
+                "reinstatement of an active steward must NOT mint a new grant"
+            ),
+            other => panic!("expected Minted (pending-grants); got {other:?}"),
+        }
+
+        let all = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(steward))
+            .unwrap();
+        assert_eq!(all.len(), 1, "exactly the original appointment grant");
+        assert!(
+            all[0].revoked_at.is_none(),
+            "original grant remains active and untouched"
+        );
+    }
+
+    #[test]
+    fn reinstate_steward_declines_when_only_cross_domain_revoked_template_exists() {
+        // Reinstatement must NOT clone a template from another domain.
+        // Domain B revoked the steward. Domain A (which never issued a
+        // grant to this steward) accepts a ReinstateSteward — must
+        // decline rather than import domain B's shape/bounds.
+        let backend = InMemoryGrantBackend::new();
+        let steward = did(51);
+        let domain_a = GovernanceDomainId("coop:alpha".into());
+        let domain_b = GovernanceDomainId("coop:beta".into());
+
+        // Appoint + revoke under domain B only.
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-appoint-b",
+            &domain_b,
+            [0x60u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::AppointSteward {
+                    candidate: steward.clone(),
+                    sponsors: vec![did(2)],
+                    region: "nyc".into(),
+                    bond_amount: 100,
+                    term_length: 3_600,
+                },
+            },
+            1_000,
+        )
+        .unwrap();
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-remove-b",
+            &domain_b,
+            [0x61u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::RemoveSteward {
+                    steward: steward.clone(),
+                    reason: "breach".into(),
+                    return_bond: false,
+                },
+            },
+            2_000,
+        )
+        .unwrap();
+
+        // Domain A tries to reinstate — no in-domain template exists.
+        let outcome = mint_and_persist_for_accepted(
+            &backend,
+            "prop-reinstate-a",
+            &domain_a,
+            [0x62u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::ReinstateSteward {
+                    steward: steward.clone(),
+                    reason: "cross-domain import attempt".into(),
+                },
+            },
+            3_000,
+        )
+        .unwrap();
+
+        match outcome {
+            MandateMintOutcome::Minted {
+                grants_persisted, ..
+            } => assert_eq!(
+                grants_persisted, 0,
+                "cross-domain reinstatement without an in-domain template must decline"
+            ),
+            other => panic!("expected Minted (pending-grants); got {other:?}"),
+        }
+
+        // Still only the domain_b grant exists (revoked); no domain_a grant minted.
+        let all = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(steward))
+            .unwrap();
+        assert_eq!(
+            all.len(),
+            1,
+            "no fresh grant should be minted — domain_b's revoked grant remains as the only record"
+        );
+        assert_eq!(all[0].grantor, GrantorEntityId(domain_b.0));
+        assert_eq!(all[0].revoked_at, Some(2_000));
     }
 }

--- a/icn/apps/governance/src/grant_minting.rs
+++ b/icn/apps/governance/src/grant_minting.rs
@@ -453,7 +453,7 @@ fn apply_acceptance_lifecycle(
         // prior grant is found, we decline (return empty) and log: the
         // seam refuses to fabricate bounds a payload did not carry.
         SdisProposal::ReinstateSteward { steward, .. } => Ok(
-            match mint_reinstatement_grant(backend, steward, domain_id, decision, now) {
+            match mint_reinstatement_grant(backend, steward, domain_id, decision, now)? {
                 Some(g) => vec![g],
                 None => Vec::new(),
             },
@@ -506,7 +506,7 @@ fn apply_acceptance_lifecycle(
                 decision,
                 now,
                 *new_term_end,
-            ) {
+            )? {
                 Some(g) => vec![g],
                 None => Vec::new(),
             },
@@ -635,7 +635,7 @@ fn revoke_active_grants_for_person(
 /// class/scope from the most-recent **revoked** prior grant issued by
 /// **this deciding domain** and setting `grantor` from `domain_id`.
 ///
-/// Returns `None` (declines to mint) when:
+/// Returns `Ok(None)` (benign decline) when:
 /// - no prior grant exists for this grantee in this domain,
 /// - no prior grant in this domain has been revoked (which includes
 ///   the common case where the steward is already active — a
@@ -647,6 +647,13 @@ fn revoke_active_grants_for_person(
 ///   would otherwise find the old revoked grant as a template and
 ///   silently mint a second concurrent active grant, or
 /// - cloning the prior term would overflow `now`.
+///
+/// Returns `Err(e)` when the backend read fails transiently. The
+/// caller must propagate so the mandate is NOT recorded — otherwise
+/// the idempotency check at the top of `mint_and_persist_for_accepted`
+/// would short-circuit retries to `AlreadyMinted`, skipping the
+/// lifecycle, and the accepted reinstatement would never actually
+/// materialize authority.
 ///
 /// Reinstatement declines rather than fabricate bounds the payload
 /// does not carry, and declines rather than clone a template from
@@ -661,19 +668,18 @@ fn mint_reinstatement_grant(
     domain_id: &GovernanceDomainId,
     decision: &DecisionProvenance,
     now: Timestamp,
-) -> Option<AuthorityGrant> {
+) -> Result<Option<AuthorityGrant>, String> {
     let grantee = Grantee::Person(steward.clone());
-    let all = match backend.list_authority_grants_by_grantee(&grantee) {
-        Ok(g) => g,
-        Err(e) => {
+    let all = backend
+        .list_authority_grants_by_grantee(&grantee)
+        .map_err(|e| {
             tracing::error!(
                 grantee = ?grantee,
                 error = %e,
-                "list_authority_grants_by_grantee failed; declining to mint reinstatement grant"
+                "list_authority_grants_by_grantee failed; aborting acceptance before mandate write"
             );
-            return None;
-        }
-    };
+            e
+        })?;
     // Precheck: if any in-domain grant is already active at `now`,
     // decline. The per-candidate filter below selects the most-recent
     // revoked in-domain template, but after a normal
@@ -693,7 +699,7 @@ fn mint_reinstatement_grant(
             deciding_domain = %domain_id.0,
             "ReinstateSteward: an in-domain grant is already active; declining to mint (reinstatement of an active steward is a no-op)"
         );
-        return None;
+        return Ok(None);
     }
 
     // Restrict candidates to:
@@ -716,7 +722,7 @@ fn mint_reinstatement_grant(
                 deciding_domain = %domain_id.0,
                 "ReinstateSteward: no revoked in-domain grant found; declining to mint (reinstatement needs a revoked template issued by this domain)"
             );
-            return None;
+            return Ok(None);
         }
     };
 
@@ -736,7 +742,7 @@ fn mint_reinstatement_grant(
             now,
             "ReinstateSteward term overflow cloning prior grant; declining to mint (would be unbounded)"
         );
-        return None;
+        return Ok(None);
     }
 
     // Reinstatement preserves the prior grant scope as-is by cloning the
@@ -747,7 +753,7 @@ fn mint_reinstatement_grant(
     // the derive-path convention.
     let scope = template.scope.clone();
 
-    Some(AuthorityGrant {
+    Ok(Some(AuthorityGrant {
         id: AuthorityGrantId::new(),
         class: template.class,
         grantor: GrantorEntityId(domain_id.0.clone()),
@@ -757,14 +763,14 @@ fn mint_reinstatement_grant(
         valid_from: now,
         valid_until,
         revoked_at: None,
-    })
+    }))
 }
 
 /// Mint a fresh reconfirmation grant for a steward, cloning
 /// class/scope from the current **active** prior grant issued by
 /// **this deciding domain** and setting `grantor` from `domain_id`.
 ///
-/// Returns `None` (declines to mint) when:
+/// Returns `Ok(None)` (benign decline) when:
 /// - `new_term_end <= now` — the payload carries a degenerate absolute
 ///   timestamp that would produce an inactive grant (silent no-op).
 ///   Fail closed rather than record a grant that never activates.
@@ -774,6 +780,13 @@ fn mint_reinstatement_grant(
 ///   steward) and the stealth-appointment path (ReconfirmSteward on
 ///   a never-granted DID). The callers for those cases are
 ///   ReinstateSteward and AppointSteward respectively.
+///
+/// Returns `Err(e)` when the backend read fails transiently. The
+/// caller must propagate so the mandate is NOT recorded — otherwise
+/// the idempotency check at the top of `mint_and_persist_for_accepted`
+/// would short-circuit retries to `AlreadyMinted`, skipping the
+/// lifecycle, and the accepted reconfirmation would never actually
+/// refresh authority.
 ///
 /// The cloned scope mirrors `mint_reinstatement_grant` so a refresh
 /// preserves the prior grant's authority shape rather than
@@ -788,7 +801,7 @@ fn mint_reconfirmation_grant(
     decision: &DecisionProvenance,
     now: Timestamp,
     new_term_end: Timestamp,
-) -> Option<AuthorityGrant> {
+) -> Result<Option<AuthorityGrant>, String> {
     if new_term_end <= now {
         tracing::warn!(
             grantee = %steward,
@@ -797,21 +810,20 @@ fn mint_reconfirmation_grant(
             new_term_end,
             "ReconfirmSteward: new_term_end is at or before now; declining to mint (would be inactive on creation)"
         );
-        return None;
+        return Ok(None);
     }
 
     let grantee = Grantee::Person(steward.clone());
-    let actives = match backend.list_active_authority_grants_by_grantee(&grantee, now) {
-        Ok(g) => g,
-        Err(e) => {
+    let actives = backend
+        .list_active_authority_grants_by_grantee(&grantee, now)
+        .map_err(|e| {
             tracing::error!(
                 grantee = ?grantee,
                 error = %e,
-                "list_active_authority_grants_by_grantee failed; declining to mint reconfirmation grant"
+                "list_active_authority_grants_by_grantee failed; aborting acceptance before mandate write"
             );
-            return None;
-        }
-    };
+            e
+        })?;
     // Restrict candidates to grants issued by THIS deciding domain.
     // A cross-domain active grant does not authorize this domain to
     // refresh it — the grantor must match.
@@ -828,13 +840,13 @@ fn mint_reconfirmation_grant(
                 deciding_domain = %domain_id.0,
                 "ReconfirmSteward: no active in-domain grant found; declining to mint (reconfirmation requires an active grant issued by this domain — use AppointSteward for first-time authority, ReinstateSteward for a revoked template)"
             );
-            return None;
+            return Ok(None);
         }
     };
 
     let scope = template.scope.clone();
 
-    Some(AuthorityGrant {
+    Ok(Some(AuthorityGrant {
         id: AuthorityGrantId::new(),
         class: template.class,
         grantor: GrantorEntityId(domain_id.0.clone()),
@@ -844,7 +856,7 @@ fn mint_reconfirmation_grant(
         valid_from: now,
         valid_until: Some(new_term_end),
         revoked_at: None,
-    })
+    }))
 }
 
 #[cfg(test)]
@@ -1184,6 +1196,18 @@ mod tests {
         /// error and clears the flag. Used to simulate a revocation
         /// write failure and verify the acceptance seam propagates it.
         fail_next_revoke: std::sync::atomic::AtomicBool,
+        /// One-shot fault-injection switch: when `true`, the next call
+        /// to `list_authority_grants_by_grantee` returns a transient
+        /// backend error and clears the flag. Used to verify
+        /// reinstatement read-path errors propagate and abort the
+        /// acceptance seam before the mandate write.
+        fail_next_list_all: std::sync::atomic::AtomicBool,
+        /// One-shot fault-injection switch: when `true`, the next call
+        /// to `list_active_authority_grants_by_grantee` returns a
+        /// transient backend error and clears the flag. Used to verify
+        /// reconfirmation read-path errors propagate and abort the
+        /// acceptance seam before the mandate write.
+        fail_next_list_active: std::sync::atomic::AtomicBool,
     }
 
     impl InMemoryGrantBackend {
@@ -1192,11 +1216,23 @@ mod tests {
                 mandates: std::sync::Mutex::new(vec![]),
                 grants: std::sync::Mutex::new(vec![]),
                 fail_next_revoke: std::sync::atomic::AtomicBool::new(false),
+                fail_next_list_all: std::sync::atomic::AtomicBool::new(false),
+                fail_next_list_active: std::sync::atomic::AtomicBool::new(false),
             }
         }
 
         fn arm_next_revoke_failure(&self) {
             self.fail_next_revoke
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+
+        fn arm_next_list_all_failure(&self) {
+            self.fail_next_list_all
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+
+        fn arm_next_list_active_failure(&self) {
+            self.fail_next_list_active
                 .store(true, std::sync::atomic::Ordering::SeqCst);
         }
     }
@@ -1271,6 +1307,12 @@ mod tests {
             grantee: &Grantee,
             now: Timestamp,
         ) -> Result<Vec<AuthorityGrant>, String> {
+            if self
+                .fail_next_list_active
+                .swap(false, std::sync::atomic::Ordering::SeqCst)
+            {
+                return Err("transient_backend_error: simulated list_active failure".into());
+            }
             Ok(self
                 .grants
                 .lock()
@@ -1284,6 +1326,12 @@ mod tests {
             &self,
             grantee: &Grantee,
         ) -> Result<Vec<AuthorityGrant>, String> {
+            if self
+                .fail_next_list_all
+                .swap(false, std::sync::atomic::Ordering::SeqCst)
+            {
+                return Err("transient_backend_error: simulated list_all failure".into());
+            }
             let mut out: Vec<_> = self
                 .grants
                 .lock()
@@ -2241,6 +2289,222 @@ mod tests {
         assert!(
             backend
                 .get_mandate_by_proposal("prop-remove-fail")
+                .unwrap()
+                .is_some(),
+            "mandate must be recorded on the successful retry"
+        );
+    }
+
+    #[test]
+    fn reinstate_steward_list_read_failure_aborts_acceptance_and_retry_succeeds() {
+        // Regression for the mint-helper read-failure path: if
+        // `list_authority_grants_by_grantee` fails transiently during
+        // `mint_reinstatement_grant`, the helper previously returned
+        // `None` which the lifecycle arm mapped to `Ok(Vec::new())`.
+        // That caused the mandate to still be recorded (as pending-
+        // grants), and retries then short-circuited on the idempotency
+        // check, so the accepted ReinstateSteward never actually minted
+        // authority. The read failure must now propagate, abort the
+        // mandate write, and let the retry recover.
+        let backend = InMemoryGrantBackend::new();
+        let dom = domain();
+        let steward = did(82);
+
+        // Appoint and revoke to produce a revoked in-domain template.
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-appoint-reinstate-read-fail",
+            &dom,
+            [0x93u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::AppointSteward {
+                    candidate: steward.clone(),
+                    sponsors: vec![did(1)],
+                    region: "nyc".into(),
+                    bond_amount: 100,
+                    term_length: 3_600,
+                },
+            },
+            1_000,
+        )
+        .unwrap();
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-remove-reinstate-read-fail",
+            &dom,
+            [0x94u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::RemoveSteward {
+                    steward: steward.clone(),
+                    reason: "breach".into(),
+                    return_bond: false,
+                },
+            },
+            2_000,
+        )
+        .unwrap();
+
+        // Arm one-shot list-all failure and attempt reinstatement —
+        // must Err, no mandate recorded.
+        backend.arm_next_list_all_failure();
+        let err = mint_and_persist_for_accepted(
+            &backend,
+            "prop-reinstate-read-fail",
+            &dom,
+            [0x95u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::ReinstateSteward {
+                    steward: steward.clone(),
+                    reason: "appeal upheld".into(),
+                },
+            },
+            3_000,
+        )
+        .expect_err("list read failure must propagate, not record mandate");
+        assert!(
+            err.contains("transient_backend_error"),
+            "propagated error should surface the backend failure cause, got: {err}"
+        );
+
+        assert!(
+            backend
+                .get_mandate_by_proposal("prop-reinstate-read-fail")
+                .unwrap()
+                .is_none(),
+            "no mandate may be recorded when the reinstatement read failed \
+             — otherwise the retry would short-circuit on AlreadyMinted"
+        );
+
+        // Retry — flag is cleared, reinstatement mints fresh grant.
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-reinstate-read-fail",
+            &dom,
+            [0x95u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::ReinstateSteward {
+                    steward: steward.clone(),
+                    reason: "appeal upheld".into(),
+                },
+            },
+            3_500,
+        )
+        .expect("retry after transient read failure must succeed");
+
+        let after_retry = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(steward))
+            .unwrap();
+        let active: Vec<_> = after_retry
+            .iter()
+            .filter(|g| g.is_active_at(3_500))
+            .collect();
+        assert_eq!(
+            active.len(),
+            1,
+            "retry must materialize exactly one active grant"
+        );
+        assert_eq!(active[0].valid_from, 3_500);
+        assert!(
+            backend
+                .get_mandate_by_proposal("prop-reinstate-read-fail")
+                .unwrap()
+                .is_some(),
+            "mandate must be recorded on the successful retry"
+        );
+    }
+
+    #[test]
+    fn reconfirm_steward_list_read_failure_aborts_acceptance_and_retry_succeeds() {
+        // Same regression class as the reinstatement read-failure test
+        // above, but for the reconfirmation arm:
+        // `list_active_authority_grants_by_grantee` failure during
+        // `mint_reconfirmation_grant` must propagate, abort the
+        // mandate write, and let the retry recover.
+        let backend = InMemoryGrantBackend::new();
+        let dom = domain();
+        let steward = did(83);
+
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-appoint-reconfirm-read-fail",
+            &dom,
+            [0x96u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::AppointSteward {
+                    candidate: steward.clone(),
+                    sponsors: vec![did(1)],
+                    region: "nyc".into(),
+                    bond_amount: 100,
+                    term_length: 10_000,
+                },
+            },
+            1_000,
+        )
+        .unwrap();
+
+        backend.arm_next_list_active_failure();
+        let err = mint_and_persist_for_accepted(
+            &backend,
+            "prop-reconfirm-read-fail",
+            &dom,
+            [0x97u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::ReconfirmSteward {
+                    steward: steward.clone(),
+                    new_term_end: 20_000,
+                    performance_notes: None,
+                },
+            },
+            2_000,
+        )
+        .expect_err("list_active read failure must propagate, not record mandate");
+        assert!(
+            err.contains("transient_backend_error"),
+            "propagated error should surface the backend failure cause, got: {err}"
+        );
+
+        assert!(
+            backend
+                .get_mandate_by_proposal("prop-reconfirm-read-fail")
+                .unwrap()
+                .is_none(),
+            "no mandate may be recorded when the reconfirmation read failed"
+        );
+
+        // Retry — flag is cleared, reconfirmation mints fresh grant.
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-reconfirm-read-fail",
+            &dom,
+            [0x97u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::ReconfirmSteward {
+                    steward: steward.clone(),
+                    new_term_end: 20_000,
+                    performance_notes: None,
+                },
+            },
+            2_500,
+        )
+        .expect("retry after transient read failure must succeed");
+
+        let all = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(steward))
+            .unwrap();
+        assert_eq!(
+            all.len(),
+            2,
+            "reconfirmation retry appends a fresh grant alongside the original (no pre-revoke)"
+        );
+        let fresh = all
+            .iter()
+            .find(|g| g.valid_from == 2_500)
+            .expect("fresh reconfirmation grant at retry `now` must exist");
+        assert_eq!(fresh.valid_until, Some(20_000));
+        assert!(fresh.revoked_at.is_none());
+        assert!(
+            backend
+                .get_mandate_by_proposal("prop-reconfirm-read-fail")
                 .unwrap()
                 .is_some(),
             "mandate must be recorded on the successful retry"

--- a/icn/apps/governance/src/grant_minting.rs
+++ b/icn/apps/governance/src/grant_minting.rs
@@ -143,9 +143,12 @@ pub fn mint_and_persist_for_accepted(
     // revocation lands but the mandate write subsequently fails, the
     // caller retries this seam → the idempotency check at the top of
     // this function misses (no mandate) → the lifecycle runs again →
-    // `revoke_authority_grant`'s first-write-wins semantics turn the
-    // repeat into a no-op → the mandate write is re-attempted. The
-    // original `revoked_at` timestamp is preserved across retries.
+    // `revoke_authority_grant`'s monotonic-minimum semantics turn the
+    // repeat into a no-op at the same-or-later `now` → the mandate
+    // write is re-attempted. The original `revoked_at` timestamp is
+    // preserved across same-or-later retries; a strictly-earlier
+    // retry would correctly tighten (which is also safe — the grant
+    // only terminates sooner, never later).
     let lifecycle_grants =
         apply_acceptance_lifecycle(backend, payload, domain_id, &decision_prov, now);
 
@@ -428,9 +431,9 @@ fn apply_acceptance_lifecycle(
 
         // Institutional-authority revocation: honors the payload's
         // `effective_at` when set (allows a governance-granted grace
-        // period); otherwise takes effect at `now`. Grants whose
-        // `revoked_at` is already set are left untouched by the
-        // first-write-wins semantics in the backend. Scoped to grants
+        // period); otherwise takes effect at `now`. The backend
+        // enforces monotonic-minimum: a strictly-earlier revocation
+        // tightens, a later-or-equal one is a no-op. Scoped to grants
         // this domain issued — cross-domain grants are not touched.
         SdisProposal::RevokeAuthority {
             authority_did,
@@ -454,10 +457,11 @@ fn apply_acceptance_lifecycle(
             }
         }
 
-        // Revocation appeals do not mutate the original revocation in
-        // place — that would violate the first-write-wins invariant on
-        // `revoked_at` and would lose the constitutional record of the
-        // original revocation event. If an appeal is upheld, the
+        // Revocation appeals do not un-revoke in place — reviving a
+        // revoked grant by clearing `revoked_at` would lose the
+        // constitutional record of the original revocation event and
+        // violate the one-way property the backend's monotonic-minimum
+        // rule enforces. If an appeal is upheld, the
         // governance flow follows up with a targeted remint proposal
         // (e.g. `ReinstateSteward` for a steward, or a fresh
         // `AppointSteward`/authority-granting proposal). In this
@@ -1100,9 +1104,13 @@ mod tests {
             let Some(g) = guard.iter_mut().find(|g| &g.id == grant_id) else {
                 return Err(format!("grant_not_found: {grant_id}"));
             };
-            // First-write-wins idempotency.
-            if g.revoked_at.is_none() {
-                g.revoked_at = Some(revoked_at);
+            // Monotonic-minimum idempotency, matching the ReceiptStore
+            // sled-backed semantics: the earliest effective revocation
+            // wins. A retry at a later-or-equal timestamp is a no-op;
+            // a strictly-earlier timestamp tightens termination.
+            match g.revoked_at {
+                Some(existing) if revoked_at >= existing => {}
+                _ => g.revoked_at = Some(revoked_at),
             }
             Ok(())
         }
@@ -1220,9 +1228,11 @@ mod tests {
     #[test]
     fn remove_steward_acceptance_is_idempotent_across_retries() {
         // Retrying the RemoveSteward acceptance (e.g. after a mandate-
-        // write failure) must not move the original `revoked_at`. The
-        // seam-level idempotency check + first-write-wins at the backend
-        // together guarantee this.
+        // write failure) must not move the original `revoked_at`
+        // forward. The seam-level idempotency check short-circuits on
+        // the already-minted mandate, and even if it didn't, the
+        // backend's monotonic-minimum revocation rule would reject the
+        // later-timestamp retry.
         let backend = InMemoryGrantBackend::new();
         let dom = domain();
         let steward = did(10);
@@ -1265,7 +1275,8 @@ mod tests {
 
         // Simulated retry at a later now=9_999: seam short-circuits on
         // idempotency (mandate already exists). Even if it didn't, the
-        // backend's first-write-wins would keep revoked_at at 2_500.
+        // backend's monotonic-minimum would keep revoked_at at 2_500
+        // (the later retry at 9_999 cannot loosen termination).
         let outcome = mint_and_persist_for_accepted(
             &backend,
             "prop-remove",

--- a/icn/apps/governance/src/grant_minting.rs
+++ b/icn/apps/governance/src/grant_minting.rs
@@ -409,19 +409,25 @@ fn apply_acceptance_lifecycle(
             Vec::new()
         }
 
-        // Sanctions only revoke when the penalty is removal-shaped.
-        // Warnings, bond-slashes, tier-demotions, and probation do not
-        // terminate existing authority; they operate on other axes
+        // Sanctions revoke when the penalty terminates authority
+        // operationally. Removal and Suspension terminate authority by
+        // definition. Probation is mapped by the execution layer
+        // (`handlers/execution.rs`) to `SdisEffect::SuspendSteward`, so
+        // for grant-lifecycle purposes it must behave as a suspension:
+        // leaving the grants active while the execution layer treats
+        // the steward as suspended would split "what the execution
+        // layer sees" from "what the grant store records". Warnings,
+        // bond-slashes, and tier-demotions operate on other axes
         // (reputation, bond, monitoring) that the grant record does
-        // not model. Suspension and Removal do terminate authority;
-        // those penalties revoke the target's active grants issued by
-        // the deciding domain.
+        // not model, so they do not revoke.
         SdisProposal::SanctionSteward {
             steward, penalty, ..
         } => {
             let revokes = matches!(
                 penalty,
-                StewardPenalty::Removal { .. } | StewardPenalty::Suspension { .. }
+                StewardPenalty::Removal { .. }
+                    | StewardPenalty::Suspension { .. }
+                    | StewardPenalty::Probation { .. }
             );
             if revokes {
                 revoke_active_grants_for_person(backend, steward, domain_id, now);
@@ -564,7 +570,12 @@ fn revoke_active_grants_for_person(
 /// - no prior grant in this domain has been revoked (which includes
 ///   the common case where the steward is already active — a
 ///   reinstatement of an already-active steward is a no-op, never a
-///   privilege extension), or
+///   privilege extension),
+/// - an active in-domain grant already exists for this grantee at
+///   `now` — the precheck blocks the "1 revoked + 1 active after a
+///   prior Remove→Reinstate cycle" case where a duplicate Reinstate
+///   would otherwise find the old revoked grant as a template and
+///   silently mint a second concurrent active grant, or
 /// - cloning the prior term would overflow `now`.
 ///
 /// Reinstatement declines rather than fabricate bounds the payload
@@ -593,6 +604,28 @@ fn mint_reinstatement_grant(
             return None;
         }
     };
+    // Precheck: if any in-domain grant is already active at `now`,
+    // decline. The per-candidate filter below selects the most-recent
+    // revoked in-domain template, but after a normal
+    // Remove→Reinstate cycle the history is [revoked_old, active_new].
+    // Without this precheck, a duplicate ReinstateSteward on the same
+    // steward would still find `revoked_old`, pass the filter, and
+    // silently mint a *second* concurrent active grant — re-opening
+    // the privilege-extension path the revoked-filter was supposed to
+    // close. Decline instead.
+    let has_active_in_domain = all
+        .iter()
+        .any(|g| g.grantor.0 == domain_id.0 && g.is_active_at(now));
+    if has_active_in_domain {
+        tracing::warn!(
+            grantee = ?grantee,
+            proposal_id = %decision.proposal_id,
+            deciding_domain = %domain_id.0,
+            "ReinstateSteward: an in-domain grant is already active; declining to mint (reinstatement of an active steward is a no-op)"
+        );
+        return None;
+    }
+
     // Restrict candidates to:
     //   (a) grants issued by THIS deciding domain — cross-domain
     //       reinstatement would import another sovereign's shape, and
@@ -1753,5 +1786,179 @@ mod tests {
         );
         assert_eq!(all[0].grantor, GrantorEntityId(domain_b.0));
         assert_eq!(all[0].revoked_at, Some(2_000));
+    }
+
+    #[test]
+    fn sanction_steward_probation_revokes_active_grants() {
+        // Probation maps to SdisEffect::SuspendSteward in
+        // handlers/execution.rs. Grant lifecycle must match: leaving
+        // grants active while the execution layer treats the steward
+        // as suspended would split operational state from the grant
+        // store. Probation therefore revokes the target's active
+        // in-domain grants, the same way an explicit Suspension does.
+        use icn_governance::sdis::StewardPenalty;
+
+        let backend = InMemoryGrantBackend::new();
+        let dom = domain();
+        let steward = did(70);
+
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-appoint-probation",
+            &dom,
+            [0x70u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::AppointSteward {
+                    candidate: steward.clone(),
+                    sponsors: vec![did(1)],
+                    region: "nyc".into(),
+                    bond_amount: 100,
+                    term_length: 3_600,
+                },
+            },
+            1_000,
+        )
+        .unwrap();
+
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-probation",
+            &dom,
+            [0x71u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::SanctionSteward {
+                    steward: steward.clone(),
+                    penalty: StewardPenalty::Probation {
+                        duration: 86_400,
+                        conditions: vec!["weekly check-in".into()],
+                    },
+                    reason: "conduct review".into(),
+                    evidence: vec![],
+                },
+            },
+            2_000,
+        )
+        .unwrap();
+
+        let all = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(steward))
+            .unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(
+            all[0].revoked_at,
+            Some(2_000),
+            "Probation must revoke active in-domain grants (execution layer treats it as SuspendSteward)"
+        );
+    }
+
+    #[test]
+    fn reinstate_steward_declines_when_active_in_domain_grant_exists_after_prior_cycle() {
+        // After a normal Remove→Reinstate cycle, grant history is
+        // [revoked_old, active_new]. A duplicate ReinstateSteward on
+        // the same steward must NOT mint a second active grant — the
+        // revoked-filter would otherwise still select `revoked_old`
+        // as a template. The active-in-domain precheck guards this.
+        let backend = InMemoryGrantBackend::new();
+        let dom = domain();
+        let steward = did(71);
+
+        // Appoint.
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-appoint-cycle",
+            &dom,
+            [0x80u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::AppointSteward {
+                    candidate: steward.clone(),
+                    sponsors: vec![did(1)],
+                    region: "nyc".into(),
+                    bond_amount: 100,
+                    term_length: 3_600,
+                },
+            },
+            1_000,
+        )
+        .unwrap();
+
+        // Remove → first grant is revoked.
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-remove-cycle",
+            &dom,
+            [0x81u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::RemoveSteward {
+                    steward: steward.clone(),
+                    reason: "breach".into(),
+                    return_bond: false,
+                },
+            },
+            2_000,
+        )
+        .unwrap();
+
+        // First Reinstate → mints a fresh active grant (valid cycle).
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-reinstate-1",
+            &dom,
+            [0x82u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::ReinstateSteward {
+                    steward: steward.clone(),
+                    reason: "appeal upheld".into(),
+                },
+            },
+            3_000,
+        )
+        .unwrap();
+
+        let after_first = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(steward.clone()))
+            .unwrap();
+        assert_eq!(
+            after_first.len(),
+            2,
+            "history after first cycle: 1 revoked + 1 active"
+        );
+        assert!(after_first.iter().any(|g| g.revoked_at.is_some()));
+        assert!(after_first.iter().any(|g| g.revoked_at.is_none()));
+
+        // Second (duplicate/erroneous) Reinstate while an active
+        // in-domain grant already exists — must decline to mint.
+        let outcome = mint_and_persist_for_accepted(
+            &backend,
+            "prop-reinstate-2",
+            &dom,
+            [0x83u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::ReinstateSteward {
+                    steward: steward.clone(),
+                    reason: "duplicate appeal".into(),
+                },
+            },
+            4_000,
+        )
+        .unwrap();
+
+        match outcome {
+            MandateMintOutcome::Minted {
+                grants_persisted, ..
+            } => assert_eq!(
+                grants_persisted, 0,
+                "duplicate reinstatement while an in-domain active grant exists must decline"
+            ),
+            other => panic!("expected Minted (pending-grants); got {other:?}"),
+        }
+
+        let after_second = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(steward))
+            .unwrap();
+        assert_eq!(
+            after_second.len(),
+            2,
+            "still exactly 1 revoked + 1 active; no second active grant minted"
+        );
     }
 }

--- a/icn/apps/governance/src/grant_minting.rs
+++ b/icn/apps/governance/src/grant_minting.rs
@@ -149,8 +149,17 @@ pub fn mint_and_persist_for_accepted(
     // preserved across same-or-later retries; a strictly-earlier
     // retry would correctly tighten (which is also safe — the grant
     // only terminates sooner, never later).
+    //
+    // The inverse window — lifecycle write fails and we still record
+    // the mandate — must NOT be allowed to close silently: the
+    // idempotency check at the top of this function would short-
+    // circuit retries to `AlreadyMinted`, skipping the lifecycle, and
+    // leave the target's grant active despite an accepted revocation
+    // decision. So lifecycle errors propagate; no mandate is recorded
+    // when any revocation write failed, and the retry re-runs the
+    // whole seam.
     let lifecycle_grants =
-        apply_acceptance_lifecycle(backend, payload, domain_id, &decision_prov, now);
+        apply_acceptance_lifecycle(backend, payload, domain_id, &decision_prov, now)?;
 
     // Derive zero or more grants from the payload itself. Empty vec is
     // the truthful default for most payload classes today.
@@ -378,9 +387,14 @@ fn derive_sdis_grants(
 /// and setting `grantor` from this reinstatement decision's
 /// `domain_id` — never mutating a revoked grant back to active.
 ///
-/// Revocations are best-effort: backend errors are logged and do not
-/// abort the decision. A `grant_not_found` error from an in-flight index
-/// skew is treated as skippable.
+/// Revocation write failures propagate: if a revocation cannot be
+/// durably stamped, the error is returned so the caller aborts before
+/// recording the mandate. Recording a mandate while a revocation is
+/// only logged-and-skipped would let the idempotency check at the top
+/// of `mint_and_persist_for_accepted` short-circuit retries and leave
+/// the target grant active indefinitely. Benign `grant_not_found`
+/// errors (index skew) are still skipped locally — the grant is
+/// already gone so the caller's intent is satisfied.
 ///
 /// All backend calls on the defaulted no-op trait methods return empty
 /// lists / `Ok(())`, so in-memory test backends that do not durably
@@ -392,9 +406,9 @@ fn apply_acceptance_lifecycle(
     domain_id: &GovernanceDomainId,
     decision: &DecisionProvenance,
     now: Timestamp,
-) -> Vec<AuthorityGrant> {
+) -> Result<Vec<AuthorityGrant>, String> {
     let ProposalPayload::Sdis { proposal } = payload else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
     use icn_governance::sdis::{SdisProposal, StewardPenalty};
 
@@ -405,8 +419,8 @@ fn apply_acceptance_lifecycle(
         // grants are never revoked by this domain's vote.
         SdisProposal::RemoveSteward { steward, .. }
         | SdisProposal::SuspendSteward { steward, .. } => {
-            revoke_active_grants_for_person(backend, steward, domain_id, now);
-            Vec::new()
+            revoke_active_grants_for_person(backend, steward, domain_id, now)?;
+            Ok(Vec::new())
         }
 
         // Sanctions revoke when the penalty terminates authority
@@ -430,9 +444,9 @@ fn apply_acceptance_lifecycle(
                     | StewardPenalty::Probation { .. }
             );
             if revokes {
-                revoke_active_grants_for_person(backend, steward, domain_id, now);
+                revoke_active_grants_for_person(backend, steward, domain_id, now)?;
             }
-            Vec::new()
+            Ok(Vec::new())
         }
 
         // Institutional-authority revocation: honors the payload's
@@ -447,8 +461,8 @@ fn apply_acceptance_lifecycle(
             ..
         } => {
             let revoke_at = effective_at.unwrap_or(now);
-            revoke_active_grants_for_person(backend, authority_did, domain_id, revoke_at);
-            Vec::new()
+            revoke_active_grants_for_person(backend, authority_did, domain_id, revoke_at)?;
+            Ok(Vec::new())
         }
 
         // Reinstatement mints a **fresh** grant — new UUID, new
@@ -456,12 +470,12 @@ fn apply_acceptance_lifecycle(
         // It does not mutate the revoked grant back to active. If no
         // prior grant is found, we decline (return empty) and log: the
         // seam refuses to fabricate bounds a payload did not carry.
-        SdisProposal::ReinstateSteward { steward, .. } => {
+        SdisProposal::ReinstateSteward { steward, .. } => Ok(
             match mint_reinstatement_grant(backend, steward, domain_id, decision, now) {
                 Some(g) => vec![g],
                 None => Vec::new(),
-            }
-        }
+            },
+        ),
 
         // Revocation appeals do not un-revoke in place — reviving a
         // revoked grant by clearing `revoked_at` would lose the
@@ -478,7 +492,7 @@ fn apply_acceptance_lifecycle(
                 proposal_id = %decision.proposal_id,
                 "RevocationAppeal acceptance: no in-place grant mutation; any reinstatement routes through a separate reinstatement proposal"
             );
-            Vec::new()
+            Ok(Vec::new())
         }
 
         // Non-lifecycle SDIS variants (threshold, authority approval,
@@ -489,14 +503,33 @@ fn apply_acceptance_lifecycle(
         | SdisProposal::ModifyThreshold { .. }
         | SdisProposal::ApproveAuthority { .. }
         | SdisProposal::UpdateJurisdictionTier { .. }
-        | SdisProposal::ForceKeyRotation { .. } => Vec::new(),
+        | SdisProposal::ForceKeyRotation { .. } => Ok(Vec::new()),
     }
 }
 
 /// Revoke every active grant whose grantee is the given person DID AND
-/// whose grantor is the deciding domain, best-effort. Errors are logged
-/// and the decision continues; missing primaries (index skew) are
-/// warned and skipped.
+/// whose grantor is the deciding domain.
+///
+/// Error propagation: any failure to *list* or *write* a revocation —
+/// other than the benign `grant_not_found` index-skew case — is
+/// returned to the caller so the acceptance seam can abort before
+/// recording the mandate. The mandate write must not land when a
+/// revocation write failed: if it did, the idempotency check at the
+/// top of `mint_and_persist_for_accepted` would short-circuit retries
+/// to `AlreadyMinted`, skipping the lifecycle, and the target grant
+/// would remain active indefinitely despite an accepted revocation
+/// decision. Propagating the error lets the retry re-run the lifecycle
+/// under monotonic-minimum semantics.
+///
+/// `grant_not_found` errors (primary record absent despite an active
+/// by-grantee index entry — in-flight index skew) are logged and
+/// skipped, not propagated: the grant the caller meant to revoke is
+/// already gone, so the caller's intent is satisfied. All other
+/// backend errors short-circuit the remaining revocations to avoid
+/// partial revocation state (some grants revoked, others not, yet no
+/// mandate recorded — but under a successful retry the list call
+/// re-discovers the not-yet-revoked grants, so stopping early costs
+/// at most one extra retry pass).
 ///
 /// Cross-domain guard: an accepted SDIS revocation runs in exactly one
 /// governance domain. That domain's vote must not strip authority
@@ -509,19 +542,18 @@ fn revoke_active_grants_for_person(
     person: &icn_identity::Did,
     domain_id: &GovernanceDomainId,
     revoked_at: Timestamp,
-) {
+) -> Result<(), String> {
     let grantee = Grantee::Person(person.clone());
-    let grants = match backend.list_active_authority_grants_by_grantee(&grantee, revoked_at) {
-        Ok(g) => g,
-        Err(e) => {
+    let grants = backend
+        .list_active_authority_grants_by_grantee(&grantee, revoked_at)
+        .map_err(|e| {
             tracing::error!(
                 grantee = ?grantee,
                 error = %e,
-                "list_active_authority_grants_by_grantee failed; skipping revocation"
+                "list_active_authority_grants_by_grantee failed; aborting acceptance before mandate write"
             );
-            return;
-        }
-    };
+            e
+        })?;
     for g in grants {
         if g.grantor.0 != domain_id.0 {
             // Cross-domain grant: this decision's domain did not
@@ -554,11 +586,13 @@ fn revoke_active_grants_for_person(
                 tracing::error!(
                     grant_id = %g.id,
                     error = %e,
-                    "revoke_authority_grant failed"
+                    "revoke_authority_grant failed; aborting acceptance before mandate write"
                 );
+                return Err(e);
             }
         }
     }
+    Ok(())
 }
 
 /// Mint a fresh reinstatement grant for a steward, cloning
@@ -1023,6 +1057,11 @@ mod tests {
     struct InMemoryGrantBackend {
         mandates: std::sync::Mutex<Vec<Mandate>>,
         grants: std::sync::Mutex<Vec<AuthorityGrant>>,
+        /// One-shot fault-injection switch: when `true`, the next call
+        /// to `revoke_authority_grant` returns a transient backend
+        /// error and clears the flag. Used to simulate a revocation
+        /// write failure and verify the acceptance seam propagates it.
+        fail_next_revoke: std::sync::atomic::AtomicBool,
     }
 
     impl InMemoryGrantBackend {
@@ -1030,7 +1069,13 @@ mod tests {
             Self {
                 mandates: std::sync::Mutex::new(vec![]),
                 grants: std::sync::Mutex::new(vec![]),
+                fail_next_revoke: std::sync::atomic::AtomicBool::new(false),
             }
+        }
+
+        fn arm_next_revoke_failure(&self) {
+            self.fail_next_revoke
+                .store(true, std::sync::atomic::Ordering::SeqCst);
         }
     }
 
@@ -1133,6 +1178,12 @@ mod tests {
             grant_id: &AuthorityGrantId,
             revoked_at: Timestamp,
         ) -> Result<(), String> {
+            if self
+                .fail_next_revoke
+                .swap(false, std::sync::atomic::Ordering::SeqCst)
+            {
+                return Err("transient_backend_error: simulated revoke failure".into());
+            }
             let mut guard = self.grants.lock().unwrap();
             let Some(g) = guard.iter_mut().find(|g| &g.id == grant_id) else {
                 return Err(format!("grant_not_found: {grant_id}"));
@@ -1959,6 +2010,118 @@ mod tests {
             after_second.len(),
             2,
             "still exactly 1 revoked + 1 active; no second active grant minted"
+        );
+    }
+
+    #[test]
+    fn remove_steward_revocation_write_failure_aborts_acceptance_and_retry_succeeds() {
+        // If a revocation write fails, the mandate MUST NOT be recorded:
+        // otherwise the idempotency check at the top of
+        // `mint_and_persist_for_accepted` short-circuits retries to
+        // `AlreadyMinted`, the lifecycle never re-runs, and the target
+        // grant stays active indefinitely despite an accepted
+        // revocation decision.
+        //
+        // Walk: appoint → arm one-shot revoke failure → RemoveSteward
+        // (must Err, no mandate recorded, grant still active) → retry
+        // (must succeed, mandate recorded, grant revoked).
+        let backend = InMemoryGrantBackend::new();
+        let dom = domain();
+        let steward = did(80);
+
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-appoint-fail",
+            &dom,
+            [0x90u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::AppointSteward {
+                    candidate: steward.clone(),
+                    sponsors: vec![did(1)],
+                    region: "nyc".into(),
+                    bond_amount: 100,
+                    term_length: 3_600,
+                },
+            },
+            1_000,
+        )
+        .unwrap();
+
+        // Arm one-shot failure and attempt revocation — must Err.
+        backend.arm_next_revoke_failure();
+        let err = mint_and_persist_for_accepted(
+            &backend,
+            "prop-remove-fail",
+            &dom,
+            [0x91u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::RemoveSteward {
+                    steward: steward.clone(),
+                    reason: "breach".into(),
+                    return_bond: false,
+                },
+            },
+            2_000,
+        )
+        .expect_err("revocation write failure must propagate, not record mandate");
+        assert!(
+            err.contains("transient_backend_error"),
+            "propagated error should surface the backend failure cause, got: {err}"
+        );
+
+        // Grant still active — revocation did not land.
+        let after_fail = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(steward.clone()))
+            .unwrap();
+        assert_eq!(after_fail.len(), 1);
+        assert!(
+            after_fail[0].revoked_at.is_none(),
+            "grant must remain active when revocation write failed"
+        );
+
+        // Mandate must NOT be recorded — otherwise retry would hit the
+        // idempotency short-circuit and skip the lifecycle forever.
+        assert!(
+            backend
+                .get_mandate_by_proposal("prop-remove-fail")
+                .unwrap()
+                .is_none(),
+            "no mandate may be recorded when a revocation write failed"
+        );
+
+        // Retry same proposal_id — flag is cleared, revocation lands,
+        // mandate records.
+        mint_and_persist_for_accepted(
+            &backend,
+            "prop-remove-fail",
+            &dom,
+            [0x91u8; 32],
+            &ProposalPayload::Sdis {
+                proposal: SdisProposal::RemoveSteward {
+                    steward: steward.clone(),
+                    reason: "breach".into(),
+                    return_bond: false,
+                },
+            },
+            2_500,
+        )
+        .expect("retry after transient failure must succeed");
+
+        let after_retry = backend
+            .list_authority_grants_by_grantee(&Grantee::Person(steward))
+            .unwrap();
+        assert_eq!(after_retry.len(), 1);
+        assert_eq!(
+            after_retry[0].revoked_at,
+            Some(2_500),
+            "retry must revoke at its own `now`"
+        );
+        assert!(
+            backend
+                .get_mandate_by_proposal("prop-remove-fail")
+                .unwrap()
+                .is_some(),
+            "mandate must be recorded on the successful retry"
         );
     }
 }

--- a/icn/apps/governance/src/grant_minting.rs
+++ b/icn/apps/governance/src/grant_minting.rs
@@ -371,8 +371,9 @@ fn derive_sdis_grants(
 /// `revoked_at` on the target's active grants via
 /// [`GovernanceReceiptBackend::revoke_authority_grant`]. For
 /// [`SdisProposal::ReinstateSteward`] this mints a brand-new grant
-/// (fresh UUID) cloning class/scope/grantor from the most-recent prior
-/// grant — never mutating a revoked grant back to active.
+/// (fresh UUID) cloning class/scope from the most-recent prior grant
+/// and setting `grantor` from this reinstatement decision's
+/// `domain_id` — never mutating a revoked grant back to active.
 ///
 /// Revocations are best-effort: backend errors are logged and do not
 /// abort the decision. A `grant_not_found` error from an in-flight index
@@ -594,12 +595,12 @@ fn mint_reinstatement_grant(
         return None;
     }
 
-    // Ensure the cloned scope still names the current decision's domain.
-    // Prior grants issued under a different domain are kept in scope
-    // with their original domain — we don't rewrite a grant's domain
-    // context in reinstatement. The grantor remains the sovereign entity
-    // that decided *this* reinstatement, which matches the derive-path
-    // convention.
+    // Reinstatement preserves the prior grant scope as-is by cloning the
+    // template scope without validating or rewriting any embedded domain
+    // identifier. Prior grants issued under a different domain therefore
+    // keep their original domain context. The grantor remains the
+    // sovereign entity that decided *this* reinstatement, which matches
+    // the derive-path convention.
     let scope = template.scope.clone();
 
     Some(AuthorityGrant {

--- a/icn/apps/governance/src/receipt_backend.rs
+++ b/icn/apps/governance/src/receipt_backend.rs
@@ -1,7 +1,9 @@
 //! Abstraction over gateway's ReceiptStore so GovernanceManager can live
 //! in this crate without a circular dependency on icn-gateway.
 
-use icn_governance::{AuthorityGrant, AuthorityGrantId, GovernanceDecisionReceipt, Mandate};
+use icn_governance::{
+    AuthorityGrant, AuthorityGrantId, GovernanceDecisionReceipt, Grantee, Mandate, Timestamp,
+};
 use icn_kernel_api::{AllocationReceipt, Hash};
 
 use crate::dispatch_evidence::EffectDispatchEvidence;
@@ -244,5 +246,71 @@ pub trait GovernanceReceiptBackend: Send + Sync {
         _decision_hash: &Hash,
     ) -> Result<Vec<AuthorityGrant>, String> {
         Ok(vec![])
+    }
+
+    /// List authority grants for a [`Grantee`] that are active at `now`.
+    ///
+    /// "Active" is defined by [`AuthorityGrant::is_active_at`]: not
+    /// revoked at or before `now`, `now >= valid_from`, and (if
+    /// `valid_until` is set) `now < valid_until`.
+    ///
+    /// Used by the ADR-0014 acceptance seam to resolve a target steward
+    /// or authority DID to its outstanding grants for revocation. The
+    /// default impl returns an empty list so backends that do not
+    /// durably persist grants produce the truthful "no grants to
+    /// revoke" answer; the sled-backed
+    /// [`ReceiptStore`](icn_gateway::receipt_store::ReceiptStore)
+    /// overrides via a dedicated by-grantee secondary index.
+    fn list_active_authority_grants_by_grantee(
+        &self,
+        _grantee: &Grantee,
+        _now: Timestamp,
+    ) -> Result<Vec<AuthorityGrant>, String> {
+        Ok(vec![])
+    }
+
+    /// List **all** authority grants ever issued to a [`Grantee`],
+    /// including revoked and expired ones, ordered oldest-first by
+    /// `valid_from`.
+    ///
+    /// Unlike [`Self::list_active_authority_grants_by_grantee`], this
+    /// method does not filter on `is_active_at`: the reinstatement seam
+    /// needs to inspect previously-revoked grants to clone class/scope/
+    /// grantor context for the fresh grant. Uses the same by-grantee
+    /// secondary index as the active-filtered variant; no new index is
+    /// introduced.
+    ///
+    /// Default impl returns an empty list.
+    fn list_authority_grants_by_grantee(
+        &self,
+        _grantee: &Grantee,
+    ) -> Result<Vec<AuthorityGrant>, String> {
+        Ok(vec![])
+    }
+
+    /// Revoke an [`AuthorityGrant`] by stamping `revoked_at` on its
+    /// primary record.
+    ///
+    /// **Seam contract:**
+    /// - First-write-wins: a grant already carrying `revoked_at: Some(_)`
+    ///   is a no-op; the recorded timestamp never moves. This keeps
+    ///   double-revocation safe and prevents a later proposal from
+    ///   silently rewriting the original revocation time.
+    /// - Missing grants are an error (`grant_not_found: …`). The
+    ///   acceptance seam logs and continues rather than aborting the
+    ///   entire decision.
+    ///
+    /// **Default impl:** no-op `Ok(())` so backends that do not durably
+    /// persist grants inherit the truthful "revocation not persisted"
+    /// behavior. Callers that need a real write-ack must use a backend
+    /// that overrides this method (the sled-backed
+    /// [`ReceiptStore`](icn_gateway::receipt_store::ReceiptStore)
+    /// overrides it with a transactional primary-record update).
+    fn revoke_authority_grant(
+        &self,
+        _grant_id: &AuthorityGrantId,
+        _revoked_at: Timestamp,
+    ) -> Result<(), String> {
+        Ok(())
     }
 }

--- a/icn/crates/icn-gateway/src/receipt_store.rs
+++ b/icn/crates/icn-gateway/src/receipt_store.rs
@@ -1073,13 +1073,28 @@ impl ReceiptStore {
     /// Revoke an authority grant by stamping `revoked_at` on its primary
     /// record.
     ///
-    /// **Semantics:**
+    /// **Semantics (monotonic minimum):**
     ///
-    /// - First-write-wins idempotency: if the grant is already revoked
-    ///   (i.e. `revoked_at` is `Some(_)`), this is a no-op. `revoked_at`
-    ///   never moves — not earlier, not later. This keeps double-revocation
-    ///   safe and prevents a later proposal from silently rewriting the
-    ///   original revocation time.
+    /// - If `revoked_at` is currently `None`, stamp it with the new
+    ///   timestamp.
+    /// - If `revoked_at` is currently `Some(existing)` and
+    ///   `new < existing`, replace with the earlier value. This covers
+    ///   the real case where a `RevokeAuthority` with
+    ///   `effective_at: Some(future)` lands first, and a later
+    ///   `RemoveSteward` at `now < future` must tighten the termination
+    ///   time rather than be silently ignored.
+    /// - If `revoked_at` is currently `Some(existing)` and
+    ///   `new >= existing`, this is a no-op. Once a grant is terminated,
+    ///   a later decision cannot loosen that termination — revocation
+    ///   is one-way. This preserves the ADR-0014 constitutional-record
+    ///   property: a double-revocation retry at a later `now` never
+    ///   moves the timestamp forward.
+    /// - Concurrent revocations serialize inside a single sled
+    ///   transaction on the primary key, so two concurrent writers
+    ///   cannot both observe the same pre-state and race to overwrite
+    ///   each other. The transaction computes `min(existing, new)` and
+    ///   writes only when that is strictly less than the current
+    ///   `revoked_at`.
     /// - Missing primary is an error: if no grant exists for `grant_id`,
     ///   returns `Err("grant_not_found: …")`. Callers decide whether this
     ///   is fatal or skippable (the acceptance seam logs and continues).
@@ -1096,11 +1111,12 @@ impl ReceiptStore {
         revoked_at: Timestamp,
     ) -> Result<(), String> {
         let primary_key = Self::grant_primary_key(grant_id);
-        // Read + check + write all happen inside one sled transaction so
-        // concurrent revocations cannot both observe `revoked_at: None`
-        // and race each other to the write. Sled serializes transactions
-        // against the same key; the first revocation wins and the second
-        // observes `revoked_at: Some(..)` and no-ops.
+        // Read + check + conditional write all happen inside one sled
+        // transaction so concurrent revocations serialize on the
+        // primary key: two callers cannot both observe the same
+        // pre-state and race to overwrite each other. The transaction
+        // body computes `min(existing, new)` and writes only when that
+        // is strictly less than the current `revoked_at`.
         self.db
             .transaction(|tx| {
                 let Some(bytes) = tx.get(primary_key.as_slice())? else {
@@ -1114,12 +1130,19 @@ impl ReceiptStore {
                             "deserialize AuthorityGrant: {e}"
                         ))
                     })?;
-                if grant.revoked_at.is_some() {
-                    // First-write-wins: already revoked. No-op, no rewrite, no
-                    // move of the existing revocation timestamp.
-                    return Ok(());
+                // Monotonic-minimum: keep the earliest effective
+                // revocation. A later decision can tighten but never
+                // loosen the termination time.
+                match grant.revoked_at {
+                    Some(existing) if revoked_at >= existing => {
+                        // No tightening: existing termination already
+                        // occurs no later than this one. Leave as-is.
+                        return Ok(());
+                    }
+                    _ => {
+                        grant.revoked_at = Some(revoked_at);
+                    }
                 }
-                grant.revoked_at = Some(revoked_at);
                 let new_bytes = serde_json::to_vec(&grant).map_err(|e| {
                     ConflictableTransactionError::Abort(format!(
                         "Failed to serialize AuthorityGrant: {e}"
@@ -1978,27 +2001,77 @@ mod tests {
     }
 
     #[test]
-    fn authority_grant_revocation_is_idempotent_keeps_original_timestamp() {
-        // First-write-wins: a second revocation of the same grant must
-        // not move `revoked_at` — neither earlier nor later. This keeps
-        // retries safe and preserves the constitutional record of the
-        // original revocation event.
+    fn authority_grant_revocation_later_retry_is_no_op() {
+        // Monotonic minimum: once `revoked_at` is set, a retry at a
+        // LATER timestamp must not loosen the termination. This keeps
+        // double-revocation retries safe and preserves the
+        // constitutional record: a later decision can tighten but
+        // never extend active authority.
         let store = ReceiptStore::new(temp_db());
         let grant = make_grant([0xa3u8; 32], 1_000);
         let grant_id = grant.id.clone();
         store.put_authority_grant(&grant).unwrap();
 
         store.revoke_authority_grant(&grant_id, 2_000).unwrap();
-        // Second revoke at a later time: must be a no-op.
+        // Second revoke at a strictly later time: must be a no-op.
         store.revoke_authority_grant(&grant_id, 9_999).unwrap();
-        // And an earlier-time retry must also be a no-op.
-        store.revoke_authority_grant(&grant_id, 1_500).unwrap();
+        // Revoke at the same time: also a no-op (>= comparison).
+        store.revoke_authority_grant(&grant_id, 2_000).unwrap();
 
         let g = store.get_authority_grant(&grant_id).unwrap().unwrap();
         assert_eq!(
             g.revoked_at,
             Some(2_000),
-            "double revocation must preserve the first `revoked_at` timestamp"
+            "later-or-equal retry must preserve the earlier `revoked_at`"
+        );
+    }
+
+    #[test]
+    fn authority_grant_revocation_tightens_to_earlier_timestamp() {
+        // Monotonic minimum: if an existing `revoked_at` is in the
+        // future (e.g. from a `RevokeAuthority { effective_at }` grace
+        // period), a later decision whose effective time is strictly
+        // earlier must tighten the termination. Otherwise an
+        // immediate-removal decision would be silently ignored while
+        // a grace-period revocation kept the grant active.
+        let store = ReceiptStore::new(temp_db());
+        let grant = make_grant([0xa4u8; 32], 1_000);
+        let grant_id = grant.id.clone();
+        store.put_authority_grant(&grant).unwrap();
+
+        // First revocation with a FUTURE effective_at (grace period).
+        store.revoke_authority_grant(&grant_id, 5_000).unwrap();
+        assert_eq!(
+            store
+                .get_authority_grant(&grant_id)
+                .unwrap()
+                .unwrap()
+                .revoked_at,
+            Some(5_000)
+        );
+
+        // Immediate-removal decision at `now = 3_000` must tighten.
+        store.revoke_authority_grant(&grant_id, 3_000).unwrap();
+        let g = store.get_authority_grant(&grant_id).unwrap().unwrap();
+        assert_eq!(
+            g.revoked_at,
+            Some(3_000),
+            "strictly-earlier revocation must tighten the termination time"
+        );
+        assert!(
+            !g.is_active_at(3_000),
+            "grant must be inactive at the tightened revocation time"
+        );
+
+        // A subsequent retry even earlier also tightens.
+        store.revoke_authority_grant(&grant_id, 2_500).unwrap();
+        assert_eq!(
+            store
+                .get_authority_grant(&grant_id)
+                .unwrap()
+                .unwrap()
+                .revoked_at,
+            Some(2_500)
         );
     }
 

--- a/icn/crates/icn-gateway/src/receipt_store.rs
+++ b/icn/crates/icn-gateway/src/receipt_store.rs
@@ -867,6 +867,68 @@ impl ReceiptStore {
             .map_err(|e: TransactionError<()>| format!("sled grant tx: {e:?}"))
     }
 
+    /// Backfill the by-grantee secondary index for grants persisted
+    /// before this index existed.
+    ///
+    /// PR #1575 wired `put_authority_grant` (primary + by-decision
+    /// index). PR #1579 added the by-grantee index wired into the
+    /// same write path. A sled database written between #1575 merging
+    /// and #1579 merging may hold primary grant records with no
+    /// corresponding by-grantee entry — `list_*_by_grantee` readers
+    /// would then miss those grants, and an accepted lifecycle
+    /// revocation in the acceptance seam would leave them active.
+    ///
+    /// This method scans every primary grant record and writes any
+    /// missing by-grantee entry with the deterministic
+    /// `(grantee, valid_from, id)` key. It is:
+    /// - **Idempotent**: keys are deterministic from the grant,
+    ///   so re-running against a fully backfilled db is a no-op.
+    /// - **Non-destructive**: primary records are never mutated; the
+    ///   by-decision index is never touched; no grant is revoked,
+    ///   deleted, or moved.
+    /// - **Per-entry atomic**: each missing index write uses a single
+    ///   `db.insert` (no cross-grant transaction). Partial failures
+    ///   leave the db in a consistent partial-backfill state that the
+    ///   next call resumes from.
+    ///
+    /// Callers typically invoke this once during gateway startup
+    /// immediately after opening the receipt store. Returns the number
+    /// of index entries written.
+    pub fn backfill_grant_by_grantee_index(&self) -> Result<usize, String> {
+        let mut written = 0usize;
+        for kv in self.db.scan_prefix(AUTHORITY_GRANT_PREFIX) {
+            let (key, value) = kv.map_err(|e| format!("sled scan grants: {e}"))?;
+            // `AUTHORITY_GRANT_PREFIX` ("adr0014:grant:") is a byte
+            // prefix of both secondary-index prefixes. Skip secondary
+            // entries explicitly — their values are bare grant-id
+            // bytes, not serialized grants, and attempting to
+            // deserialize them would be a category error.
+            if key.starts_with(AUTHORITY_GRANT_BY_DECISION_PREFIX)
+                || key.starts_with(AUTHORITY_GRANT_BY_GRANTEE_PREFIX)
+            {
+                continue;
+            }
+            let grant: AuthorityGrant = serde_json::from_slice(&value).map_err(|e| {
+                format!("deserialize AuthorityGrant during by-grantee backfill: {e}")
+            })?;
+            let grantee_key =
+                Self::grant_by_grantee_key(&grant.grantee, grant.valid_from, &grant.id);
+            if self
+                .db
+                .get(&grantee_key)
+                .map_err(|e| format!("sled get grantee idx during backfill: {e}"))?
+                .is_none()
+            {
+                let id_bytes = grant.id.0.hyphenated().to_string().into_bytes();
+                self.db
+                    .insert(&grantee_key, id_bytes.as_slice())
+                    .map_err(|e| format!("sled insert grantee idx during backfill: {e}"))?;
+                written += 1;
+            }
+        }
+        Ok(written)
+    }
+
     /// Retrieve an authority grant by its stable id.
     pub fn get_authority_grant(
         &self,
@@ -2010,6 +2072,50 @@ mod tests {
         assert_eq!(all[0].id, g1.id);
         assert_eq!(all[1].id, g2.id);
         assert!(all[1].revoked_at.is_some());
+    }
+
+    #[test]
+    fn backfill_by_grantee_index_recovers_legacy_grants() {
+        // Simulate a database written before the by-grantee index existed:
+        // write a primary grant record directly via the raw db, bypassing
+        // `put_authority_grant` which would populate the index. The
+        // listing-by-grantee reader must not see the grant, then after
+        // backfill runs it must see it. Running backfill again returns 0.
+        let store = ReceiptStore::new(temp_db());
+        let grantee = Grantee::Entity("svc:legacy".into());
+        let grant = AuthorityGrant {
+            grantee: grantee.clone(),
+            ..make_grant([0xd1u8; 32], 1_000)
+        };
+
+        // Write primary record ONLY — no by-grantee index entry.
+        let primary_key = ReceiptStore::grant_primary_key(&grant.id);
+        let bytes = serde_json::to_vec(&grant).unwrap();
+        store.db.insert(&primary_key, bytes).unwrap();
+
+        // Pre-backfill: primary reads fine, but by-grantee listing is empty.
+        assert_eq!(
+            store.get_authority_grant(&grant.id).unwrap().as_ref(),
+            Some(&grant)
+        );
+        assert!(store
+            .list_active_authority_grants_by_grantee(&grantee, 1_500)
+            .unwrap()
+            .is_empty());
+
+        // Run backfill.
+        let written = store.backfill_grant_by_grantee_index().unwrap();
+        assert_eq!(written, 1);
+
+        // Post-backfill: listing-by-grantee sees the grant.
+        let listed = store
+            .list_active_authority_grants_by_grantee(&grantee, 1_500)
+            .unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, grant.id);
+
+        // Idempotent: re-running does nothing.
+        assert_eq!(store.backfill_grant_by_grantee_index().unwrap(), 0);
     }
 
     #[test]

--- a/icn/crates/icn-gateway/src/receipt_store.rs
+++ b/icn/crates/icn-gateway/src/receipt_store.rs
@@ -9,8 +9,8 @@
 
 #[cfg_attr(not(test), allow(unused_imports))]
 use icn_governance::{
-    AuthorityGrant, AuthorityGrantId, GovernanceDecisionReceipt, Mandate, MandateId, ProofOutcome,
-    VoteTally,
+    AuthorityGrant, AuthorityGrantId, GovernanceDecisionReceipt, Grantee, Mandate, MandateId,
+    ProofOutcome, Timestamp, VoteTally,
 };
 use icn_governance_actor::dispatch_evidence::EffectDispatchEvidence;
 use icn_governance_actor::institutional_effect::InstitutionalEffectRecord;
@@ -48,6 +48,12 @@ const MANDATE_BY_DECISION_PREFIX: &[u8] = b"adr0014:mandate:by_decision:";
 const AUTHORITY_GRANT_PREFIX: &[u8] = b"adr0014:grant:";
 /// Secondary index: authority grant by decision_hash (sortable by valid_from)
 const AUTHORITY_GRANT_BY_DECISION_PREFIX: &[u8] = b"adr0014:grant:by_decision:";
+/// Secondary index: authority grant by grantee (ADR-0014 length-prefix key
+/// scheme). The grantee portion is length-prefixed so no two canonical
+/// grantee encodings can alias under `scan_prefix` — required because
+/// entity IDs are unconstrained strings that may contain `:`, and Person
+/// DIDs and Entity IDs share this index under distinct tag bytes.
+const AUTHORITY_GRANT_BY_GRANTEE_PREFIX: &[u8] = b"adr0014:grant:by_grantee:";
 
 /// Receipt storage service for governance and economic chain artifacts.
 ///
@@ -691,6 +697,53 @@ impl ReceiptStore {
         prefix
     }
 
+    /// Canonical byte encoding of a [`Grantee`] for secondary-index keying.
+    ///
+    /// - Person: tag byte `0x01` followed by the DID string bytes.
+    /// - Entity: tag byte `0x02` followed by the entity ID string bytes.
+    ///
+    /// The distinct tag bytes keep Person and Entity values in separate
+    /// key-spaces even when string bytes coincide, and the whole value is
+    /// further wrapped in [`Self::len_prefixed`] at the key-composition
+    /// site so two encodings where one is a prefix of the other cannot
+    /// alias under `scan_prefix`. This is the ADR-0014 length-prefix
+    /// scheme; raw colon-delimited composition would reintroduce the
+    /// exact aliasing bug that PR #1576 closed on the proposal-id side.
+    fn grantee_canonical_bytes(grantee: &Grantee) -> Vec<u8> {
+        match grantee {
+            Grantee::Person(did) => {
+                let s = did.as_str().as_bytes();
+                let mut out = Vec::with_capacity(1 + s.len());
+                out.push(0x01);
+                out.extend_from_slice(s);
+                out
+            }
+            Grantee::Entity(id) => {
+                let s = id.as_bytes();
+                let mut out = Vec::with_capacity(1 + s.len());
+                out.push(0x02);
+                out.extend_from_slice(s);
+                out
+            }
+        }
+    }
+
+    fn grant_by_grantee_key(grantee: &Grantee, valid_from: u64, id: &AuthorityGrantId) -> Vec<u8> {
+        let mut key = AUTHORITY_GRANT_BY_GRANTEE_PREFIX.to_vec();
+        let canon = Self::grantee_canonical_bytes(grantee);
+        key.extend_from_slice(&Self::len_prefixed(&canon));
+        key.extend_from_slice(&valid_from.to_be_bytes());
+        key.extend_from_slice(id.0.hyphenated().to_string().as_bytes());
+        key
+    }
+
+    fn grant_by_grantee_scan_prefix(grantee: &Grantee) -> Vec<u8> {
+        let mut prefix = AUTHORITY_GRANT_BY_GRANTEE_PREFIX.to_vec();
+        let canon = Self::grantee_canonical_bytes(grantee);
+        prefix.extend_from_slice(&Self::len_prefixed(&canon));
+        prefix
+    }
+
     /// Persist a mandate with its proposal and decision secondary indexes
     /// in a single sled transaction.
     ///
@@ -800,6 +853,7 @@ impl ReceiptStore {
             .granted_by
             .as_ref()
             .map(|p| Self::grant_by_decision_key(&p.decision_hash, grant.valid_from, &grant.id));
+        let grantee_idx = Self::grant_by_grantee_key(&grant.grantee, grant.valid_from, &grant.id);
 
         self.db
             .transaction(|tx| {
@@ -807,6 +861,7 @@ impl ReceiptStore {
                 if let Some(idx) = decision_idx.as_ref() {
                     tx.insert(idx.as_slice(), id_bytes.as_slice())?;
                 }
+                tx.insert(grantee_idx.as_slice(), id_bytes.as_slice())?;
                 Ok::<(), ConflictableTransactionError<()>>(())
             })
             .map_err(|e: TransactionError<()>| format!("sled grant tx: {e:?}"))
@@ -864,6 +919,146 @@ impl ReceiptStore {
         Ok(out)
     }
 
+    /// List all authority grants for a grantee that are active at `now`.
+    ///
+    /// "Active" is defined by [`AuthorityGrant::is_active_at`]: not
+    /// revoked at or before `now`, `now >= valid_from`, and (if
+    /// `valid_until` is set) `now < valid_until`. Ordering is oldest-first
+    /// by `valid_from` (the secondary-index sort order).
+    ///
+    /// Uses the by-grantee secondary index written at grant-creation
+    /// time. Iteration is `O(grants_for_grantee)` — bounded by the
+    /// number of grants ever issued to this grantee, not by the total
+    /// grant count.
+    pub fn list_active_authority_grants_by_grantee(
+        &self,
+        grantee: &Grantee,
+        now: Timestamp,
+    ) -> Result<Vec<AuthorityGrant>, String> {
+        let scan = Self::grant_by_grantee_scan_prefix(grantee);
+        let mut out = Vec::new();
+        for entry in self.db.scan_prefix(&scan) {
+            let (_k, v) = entry.map_err(|e| format!("sled scan grant by_grantee: {e}"))?;
+            let id_str =
+                std::str::from_utf8(&v).map_err(|e| format!("grant index value not UTF-8: {e}"))?;
+            let uuid = uuid::Uuid::parse_str(id_str)
+                .map_err(|e| format!("grant index value not a UUID: {e}"))?;
+            let primary = Self::grant_primary_key(&AuthorityGrantId(uuid));
+            let Some(bytes) = self
+                .db
+                .get(&primary)
+                .map_err(|e| format!("sled get grant primary: {e}"))?
+            else {
+                tracing::warn!(
+                    id = %id_str,
+                    "authority grant by-grantee index skew: primary missing"
+                );
+                continue;
+            };
+            let grant: AuthorityGrant = serde_json::from_slice(&bytes)
+                .map_err(|e| format!("deserialize AuthorityGrant: {e}"))?;
+            // Filter-on-read: the grantee index is authoritative for
+            // grantee-keyed lookup, but the canonical answer to "is this
+            // still active?" lives on the primary record (its
+            // `revoked_at` may have been updated since the index was
+            // written). `is_active_at` consults that canonical state.
+            if grant.is_active_at(now) {
+                out.push(grant);
+            }
+        }
+        Ok(out)
+    }
+
+    /// List **all** authority grants ever issued to a grantee, including
+    /// revoked and expired ones, ordered oldest-first by `valid_from`.
+    ///
+    /// Uses the same by-grantee secondary index as
+    /// [`Self::list_active_authority_grants_by_grantee`] but omits the
+    /// `is_active_at` filter. Used by the reinstatement seam to locate
+    /// the most-recent revoked grant as a template for the fresh grant
+    /// that reinstatement mints.
+    pub fn list_authority_grants_by_grantee(
+        &self,
+        grantee: &Grantee,
+    ) -> Result<Vec<AuthorityGrant>, String> {
+        let scan = Self::grant_by_grantee_scan_prefix(grantee);
+        let mut out = Vec::new();
+        for entry in self.db.scan_prefix(&scan) {
+            let (_k, v) = entry.map_err(|e| format!("sled scan grant by_grantee: {e}"))?;
+            let id_str =
+                std::str::from_utf8(&v).map_err(|e| format!("grant index value not UTF-8: {e}"))?;
+            let uuid = uuid::Uuid::parse_str(id_str)
+                .map_err(|e| format!("grant index value not a UUID: {e}"))?;
+            let primary = Self::grant_primary_key(&AuthorityGrantId(uuid));
+            let Some(bytes) = self
+                .db
+                .get(&primary)
+                .map_err(|e| format!("sled get grant primary: {e}"))?
+            else {
+                tracing::warn!(
+                    id = %id_str,
+                    "authority grant by-grantee index skew: primary missing"
+                );
+                continue;
+            };
+            let grant: AuthorityGrant = serde_json::from_slice(&bytes)
+                .map_err(|e| format!("deserialize AuthorityGrant: {e}"))?;
+            out.push(grant);
+        }
+        Ok(out)
+    }
+
+    /// Revoke an authority grant by stamping `revoked_at` on its primary
+    /// record.
+    ///
+    /// **Semantics:**
+    ///
+    /// - First-write-wins idempotency: if the grant is already revoked
+    ///   (i.e. `revoked_at` is `Some(_)`), this is a no-op. `revoked_at`
+    ///   never moves — not earlier, not later. This keeps double-revocation
+    ///   safe and prevents a later proposal from silently rewriting the
+    ///   original revocation time.
+    /// - Missing primary is an error: if no grant exists for `grant_id`,
+    ///   returns `Err("grant_not_found: …")`. Callers decide whether this
+    ///   is fatal or skippable (the acceptance seam logs and continues).
+    /// - Secondary indexes are intentionally untouched. The by-decision
+    ///   and by-grantee indexes are keyed by `valid_from` and grant id,
+    ///   neither of which changes on revocation. Consumers that need
+    ///   "active right now" semantics filter on read via
+    ///   [`AuthorityGrant::is_active_at`]. Rewriting index keys on
+    ///   revocation would only invalidate existing readers without
+    ///   adding correctness.
+    pub fn revoke_authority_grant(
+        &self,
+        grant_id: &AuthorityGrantId,
+        revoked_at: Timestamp,
+    ) -> Result<(), String> {
+        let primary_key = Self::grant_primary_key(grant_id);
+        let Some(bytes) = self
+            .db
+            .get(&primary_key)
+            .map_err(|e| format!("sled get grant primary: {e}"))?
+        else {
+            return Err(format!("grant_not_found: {grant_id}"));
+        };
+        let mut grant: AuthorityGrant = serde_json::from_slice(&bytes)
+            .map_err(|e| format!("deserialize AuthorityGrant: {e}"))?;
+        if grant.revoked_at.is_some() {
+            // First-write-wins: already revoked. No-op, no rewrite, no
+            // move of the existing revocation timestamp.
+            return Ok(());
+        }
+        grant.revoked_at = Some(revoked_at);
+        let new_bytes = serde_json::to_vec(&grant)
+            .map_err(|e| format!("Failed to serialize AuthorityGrant: {e}"))?;
+        self.db
+            .transaction(|tx| {
+                tx.insert(primary_key.as_slice(), new_bytes.as_slice())?;
+                Ok::<(), ConflictableTransactionError<()>>(())
+            })
+            .map_err(|e: TransactionError<()>| format!("sled revoke grant tx: {e:?}"))
+    }
+
     /// Atomically persist a mandate and all grants it references.
     ///
     /// All primary records and all secondary index entries land in a
@@ -900,6 +1095,7 @@ impl ReceiptStore {
             value: Vec<u8>,
             id_bytes: Vec<u8>,
             decision_idx: Option<Vec<u8>>,
+            grantee_idx: Vec<u8>,
         }
         let prepared: Vec<PreparedGrant> = grants
             .iter()
@@ -912,11 +1108,13 @@ impl ReceiptStore {
                     .granted_by
                     .as_ref()
                     .map(|p| Self::grant_by_decision_key(&p.decision_hash, g.valid_from, &g.id));
+                let grantee_idx = Self::grant_by_grantee_key(&g.grantee, g.valid_from, &g.id);
                 Ok(PreparedGrant {
                     primary_key,
                     value,
                     id_bytes,
                     decision_idx,
+                    grantee_idx,
                 })
             })
             .collect::<Result<_, String>>()?;
@@ -928,6 +1126,7 @@ impl ReceiptStore {
                     if let Some(idx) = pg.decision_idx.as_ref() {
                         tx.insert(idx.as_slice(), pg.id_bytes.as_slice())?;
                     }
+                    tx.insert(pg.grantee_idx.as_slice(), pg.id_bytes.as_slice())?;
                 }
                 tx.insert(mandate_primary_key.as_slice(), mandate_value.as_slice())?;
                 tx.insert(mandate_proposal_idx.as_slice(), mandate_id_bytes.as_slice())?;
@@ -1024,6 +1223,29 @@ impl GovernanceReceiptBackend for ReceiptStore {
         decision_hash: &Hash,
     ) -> Result<Vec<AuthorityGrant>, String> {
         self.list_authority_grants_by_decision(decision_hash)
+    }
+
+    fn list_active_authority_grants_by_grantee(
+        &self,
+        grantee: &Grantee,
+        now: Timestamp,
+    ) -> Result<Vec<AuthorityGrant>, String> {
+        self.list_active_authority_grants_by_grantee(grantee, now)
+    }
+
+    fn list_authority_grants_by_grantee(
+        &self,
+        grantee: &Grantee,
+    ) -> Result<Vec<AuthorityGrant>, String> {
+        self.list_authority_grants_by_grantee(grantee)
+    }
+
+    fn revoke_authority_grant(
+        &self,
+        grant_id: &AuthorityGrantId,
+        revoked_at: Timestamp,
+    ) -> Result<(), String> {
+        self.revoke_authority_grant(grant_id, revoked_at)
     }
 
     fn put_mandate_with_grants(
@@ -1616,6 +1838,165 @@ mod tests {
                 .is_empty(),
             "charter-direct grant must not be discoverable via decision scan"
         );
+    }
+
+    #[test]
+    fn authority_grant_revocation_roundtrip() {
+        // Put a fresh grant, revoke it, read it back, assert `revoked_at`
+        // is stamped and survives the primary-record roundtrip.
+        let store = ReceiptStore::new(temp_db());
+        let decision_hash = [0xa1u8; 32];
+        let grant = make_grant(decision_hash, 1_000);
+        let grant_id = grant.id.clone();
+
+        store.put_authority_grant(&grant).unwrap();
+        assert!(
+            store
+                .get_authority_grant(&grant_id)
+                .unwrap()
+                .unwrap()
+                .revoked_at
+                .is_none(),
+            "fresh grant must have revoked_at: None"
+        );
+
+        store.revoke_authority_grant(&grant_id, 2_000).unwrap();
+
+        let revoked = store.get_authority_grant(&grant_id).unwrap().unwrap();
+        assert_eq!(
+            revoked.revoked_at,
+            Some(2_000),
+            "revoke_authority_grant must stamp revoked_at on the primary record"
+        );
+    }
+
+    #[test]
+    fn authority_grant_is_active_at_flips_false_after_revocation() {
+        // After revocation, `is_active_at(now)` must return false for any
+        // `now >= revoked_at`. This is the canonical-state invariant the
+        // seam relies on to decide whether a grant still carries authority.
+        let store = ReceiptStore::new(temp_db());
+        let decision_hash = [0xa2u8; 32];
+        let grant = make_grant(decision_hash, 1_000); // valid_from 1_000, valid_until 4_600
+        let grant_id = grant.id.clone();
+        store.put_authority_grant(&grant).unwrap();
+
+        // Pre-revocation: active at a time inside the term.
+        let before = store.get_authority_grant(&grant_id).unwrap().unwrap();
+        assert!(before.is_active_at(2_000), "active before revocation");
+
+        store.revoke_authority_grant(&grant_id, 2_000).unwrap();
+
+        let after = store.get_authority_grant(&grant_id).unwrap().unwrap();
+        assert!(
+            !after.is_active_at(2_000),
+            "must not be active at t == revoked_at"
+        );
+        assert!(
+            !after.is_active_at(3_000),
+            "must not be active after revocation"
+        );
+        assert!(
+            after.is_active_at(1_500),
+            "must still be active at t < revoked_at (revocation is not retroactive)"
+        );
+    }
+
+    #[test]
+    fn authority_grant_revocation_is_idempotent_keeps_original_timestamp() {
+        // First-write-wins: a second revocation of the same grant must
+        // not move `revoked_at` — neither earlier nor later. This keeps
+        // retries safe and preserves the constitutional record of the
+        // original revocation event.
+        let store = ReceiptStore::new(temp_db());
+        let grant = make_grant([0xa3u8; 32], 1_000);
+        let grant_id = grant.id.clone();
+        store.put_authority_grant(&grant).unwrap();
+
+        store.revoke_authority_grant(&grant_id, 2_000).unwrap();
+        // Second revoke at a later time: must be a no-op.
+        store.revoke_authority_grant(&grant_id, 9_999).unwrap();
+        // And an earlier-time retry must also be a no-op.
+        store.revoke_authority_grant(&grant_id, 1_500).unwrap();
+
+        let g = store.get_authority_grant(&grant_id).unwrap().unwrap();
+        assert_eq!(
+            g.revoked_at,
+            Some(2_000),
+            "double revocation must preserve the first `revoked_at` timestamp"
+        );
+    }
+
+    #[test]
+    fn revoke_missing_grant_returns_grant_not_found() {
+        // Revoking a grant that was never persisted must surface as an
+        // error whose message begins with `grant_not_found:` so the
+        // acceptance seam can recognise it as skippable (vs a hard
+        // store failure).
+        let store = ReceiptStore::new(temp_db());
+        let stranger_id = AuthorityGrantId::new();
+        let err = store
+            .revoke_authority_grant(&stranger_id, 1_000)
+            .unwrap_err();
+        assert!(
+            err.starts_with("grant_not_found"),
+            "expected grant_not_found sentinel; got {err}"
+        );
+    }
+
+    #[test]
+    fn list_active_authority_grants_by_grantee_filters_revoked() {
+        // The active-filter variant must consult primary-record
+        // `revoked_at` and drop revoked grants even though the by-grantee
+        // index still points at them.
+        let store = ReceiptStore::new(temp_db());
+        // Uses an Entity grantee so this test stays focused on the
+        // revoke-vs-active filter and does not depend on Ed25519
+        // public-key validity for a synthetic DID.
+        let grantee = Grantee::Entity("svc:filter-test".into());
+        let active_grant = AuthorityGrant {
+            grantee: grantee.clone(),
+            ..make_grant([0xb1u8; 32], 1_000)
+        };
+        let to_revoke = AuthorityGrant {
+            grantee: grantee.clone(),
+            ..make_grant([0xb1u8; 32], 1_500)
+        };
+        store.put_authority_grant(&active_grant).unwrap();
+        store.put_authority_grant(&to_revoke).unwrap();
+        store.revoke_authority_grant(&to_revoke.id, 1_700).unwrap();
+
+        let listed = store
+            .list_active_authority_grants_by_grantee(&grantee, 2_000)
+            .unwrap();
+        assert_eq!(listed.len(), 1, "only the non-revoked grant must be listed");
+        assert_eq!(listed[0].id, active_grant.id);
+    }
+
+    #[test]
+    fn list_authority_grants_by_grantee_includes_revoked() {
+        // The unfiltered variant is what reinstatement uses to find a
+        // template; it must return the revoked grant as well.
+        let store = ReceiptStore::new(temp_db());
+        let grantee = Grantee::Entity("svc:unfiltered-test".into());
+        let g1 = AuthorityGrant {
+            grantee: grantee.clone(),
+            ..make_grant([0xb2u8; 32], 1_000)
+        };
+        let g2 = AuthorityGrant {
+            grantee: grantee.clone(),
+            ..make_grant([0xb2u8; 32], 1_500)
+        };
+        store.put_authority_grant(&g1).unwrap();
+        store.put_authority_grant(&g2).unwrap();
+        store.revoke_authority_grant(&g2.id, 1_700).unwrap();
+
+        let all = store.list_authority_grants_by_grantee(&grantee).unwrap();
+        assert_eq!(all.len(), 2, "unfiltered list must include revoked grants");
+        // Expect oldest-first by valid_from
+        assert_eq!(all[0].id, g1.id);
+        assert_eq!(all[1].id, g2.id);
+        assert!(all[1].revoked_at.is_some());
     }
 
     #[test]

--- a/icn/crates/icn-gateway/src/receipt_store.rs
+++ b/icn/crates/icn-gateway/src/receipt_store.rs
@@ -1034,29 +1034,42 @@ impl ReceiptStore {
         revoked_at: Timestamp,
     ) -> Result<(), String> {
         let primary_key = Self::grant_primary_key(grant_id);
-        let Some(bytes) = self
-            .db
-            .get(&primary_key)
-            .map_err(|e| format!("sled get grant primary: {e}"))?
-        else {
-            return Err(format!("grant_not_found: {grant_id}"));
-        };
-        let mut grant: AuthorityGrant = serde_json::from_slice(&bytes)
-            .map_err(|e| format!("deserialize AuthorityGrant: {e}"))?;
-        if grant.revoked_at.is_some() {
-            // First-write-wins: already revoked. No-op, no rewrite, no
-            // move of the existing revocation timestamp.
-            return Ok(());
-        }
-        grant.revoked_at = Some(revoked_at);
-        let new_bytes = serde_json::to_vec(&grant)
-            .map_err(|e| format!("Failed to serialize AuthorityGrant: {e}"))?;
+        // Read + check + write all happen inside one sled transaction so
+        // concurrent revocations cannot both observe `revoked_at: None`
+        // and race each other to the write. Sled serializes transactions
+        // against the same key; the first revocation wins and the second
+        // observes `revoked_at: Some(..)` and no-ops.
         self.db
             .transaction(|tx| {
+                let Some(bytes) = tx.get(primary_key.as_slice())? else {
+                    return Err(ConflictableTransactionError::Abort(format!(
+                        "grant_not_found: {grant_id}"
+                    )));
+                };
+                let mut grant: AuthorityGrant =
+                    serde_json::from_slice(bytes.as_ref()).map_err(|e| {
+                        ConflictableTransactionError::Abort(format!(
+                            "deserialize AuthorityGrant: {e}"
+                        ))
+                    })?;
+                if grant.revoked_at.is_some() {
+                    // First-write-wins: already revoked. No-op, no rewrite, no
+                    // move of the existing revocation timestamp.
+                    return Ok(());
+                }
+                grant.revoked_at = Some(revoked_at);
+                let new_bytes = serde_json::to_vec(&grant).map_err(|e| {
+                    ConflictableTransactionError::Abort(format!(
+                        "Failed to serialize AuthorityGrant: {e}"
+                    ))
+                })?;
                 tx.insert(primary_key.as_slice(), new_bytes.as_slice())?;
-                Ok::<(), ConflictableTransactionError<()>>(())
+                Ok(())
             })
-            .map_err(|e: TransactionError<()>| format!("sled revoke grant tx: {e:?}"))
+            .map_err(|e: TransactionError<String>| match e {
+                TransactionError::Abort(msg) => msg,
+                TransactionError::Storage(err) => format!("sled revoke grant tx: {err}"),
+            })
     }
 
     /// Atomically persist a mandate and all grants it references.

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -618,6 +618,42 @@ impl GatewayServer {
         let receipt_store = Arc::new(crate::receipt_store::ReceiptStore::new(db.clone()));
         info!("Receipt store initialized");
 
+        // One-shot startup backfill for the ADR-0014 by-grantee index.
+        // Databases written between PR #1575 (grant primary + by-decision
+        // index) and PR #1579 (by-grantee index + acceptance-seam
+        // revocations) hold primary grant records without a by-grantee
+        // entry. Without this, `list_*_by_grantee` readers miss those
+        // legacy grants and an accepted RemoveSteward/SuspendSteward/
+        // RevokeAuthority lifecycle silently leaves them active after
+        // acceptance. The backfill is idempotent (deterministic keys,
+        // no-op when the index is already complete) and non-destructive
+        // (never mutates primary records), so running on every startup
+        // is safe; steady-state cost is a single prefix scan with no
+        // writes.
+        match receipt_store.backfill_grant_by_grantee_index() {
+            Ok(0) => {
+                info!("ADR-0014 by-grantee index backfill: no legacy grants found");
+            }
+            Ok(written) => {
+                info!(
+                    written,
+                    "ADR-0014 by-grantee index backfill: recovered legacy grants"
+                );
+            }
+            Err(e) => {
+                // Non-fatal: startup continues. Revocation lookups for
+                // legacy grants may miss until the next successful
+                // backfill run, but the gateway itself is operational.
+                // Surfacing the error loudly so operators can investigate
+                // (and optionally re-run a manual backfill).
+                tracing::error!(
+                    error = %e,
+                    "ADR-0014 by-grantee index backfill failed at startup; \
+                     legacy grants may be invisible to by-grantee readers until next successful run"
+                );
+            }
+        }
+
         // Install receipt_store on the actor so actor-path `CloseProposal::Accept`
         // and `ForceCloseProposal::Accept` emit `InstitutionalEffectRecord`
         // durably. Without this, the HTTP-close path was the sole writer and


### PR DESCRIPTION
## Summary

Wires the revocation-and-reinstatement side of the ADR-0014 constitutional object model so accepted SDIS lifecycle proposals durably change authority rather than only recording intent. Downstream of #1576.

**Receipt-store layer** (icn-gateway):
- : sled-transactional primary-record update, first-write-wins idempotency,  sentinel on missing primary
- By-grantee secondary index (ADR-0014 length-prefix scheme: 0x01 Person / 0x02 Entity tag + length-prefixed canonical bytes) wired into  and 
-  /  accessors using the new index; active variant filters via  on the primary record

**Trait** ():
- New methods mirror the write-path + grantee-scoped reads
- Default impls return empty/ — backends that don't durably persist grants produce truthful no-ops without aborting acceptance

**Acceptance seam** ():
- New  handles the 6 SDIS variants previously returning :
  -  /  → revoke target's active grants
  -  → revoke only on  /  penalties
  -  → revoke, honoring  grace period
  -  → mint a **fresh** grant (new UUID) cloning class/scope/term from the most-recent prior grant; declines rather than fabricate bounds when no template exists
  -  → logged no-op; in-place mutation of  would violate first-write-wins
- Integrated into  before mandate composition; fresh reinstatement grants flow into  with the existing derive-path output

## Why not atomic across revoke + mandate?

Revocations land outside the  transaction. The race window (revoke lands, mandate write fails) is recoverable because:
-  is first-write-wins idempotent
- The seam's  idempotency check short-circuits duplicate acceptance
- So caller retries re-run the lifecycle, the revoke is a no-op, and the mandate write retries

Extending the atomic transaction across primary-record mutations is future work explicitly scoped out of this tranche.

## Test plan

**Receipt-store** (6 new tests):
- [x]  — stamp  survives sled roundtrip
- [x] 
- [x]  — earlier AND later retries are no-ops
- [x]  — sentinel caller can match
- [x] 
- [x] 

**Acceptance-seam** (5 new tests):
- [x]  — scoped-revocation invariant (A revoked, B untouched)
- [x]  — original  preserved
- [x]  — distinct UUID, original stays revoked, term cloned
- [x] 
- [x] 

**Verification**:
- [x] 
- [x] 
- [x] 
running 520 tests
test api::communities::tests::test_parse_community_type ... ok
test api::communities::tests::test_parse_member_type ... ok
test api::compute::tests::test_default_fuel_limit ... ok
test api::compute::tests::test_wasm_hash_accepts_valid_64_hex_chars ... ok
test api::compute::tests::test_wasm_hash_decodes_to_correct_bytes ... ok
test api::compute::tests::test_wasm_hash_rejects_bad_length ... ok
test api::compute::tests::test_wasm_hash_rejects_non_hex ... ok
test api::constitutional::tests::test_parse_amendment_type ... ok
test api::constitutional::tests::test_parse_amendment_scope ... ok
test api::constitutional::tests::test_parse_change_target ... ok
test api::constitutional::tests::test_parse_appeal_remedy ... ok
test api::constitutional::voting::tests::test_format_timestamp ... ok
test api::constitutional::voting::tests::test_vote_choice_conversion ... ok
test api::contracts::tests::test_parse_hash ... ok
test api::contracts::tests::test_parse_visibility ... ok
test api::entity::tests::test_format_entity_type ... ok
test api::entity::tests::test_format_membership_status ... ok
test api::entity::tests::test_format_role ... ok
test api::auth::tests::test_challenge_endpoint ... ok
test api::auth::tests::test_verify_endpoint_invalid_coop_id ... ok
test api::auth::tests::test_verify_endpoint_invalid_signature_length ... ok
test api::auth::tests::test_verify_endpoint_invalid_signature ... ok
test api::coops::tests::test_create_and_get_coop ... ok
test api::entity::tests::test_format_entity_status ... ok
test api::auth::tests::test_verify_endpoint_success ... ok
test api::auth::tests::test_ip_rate_limiting_on_challenge ... ok
test api::entity::tests::test_parse_entity_type ... ok
test api::coops::tests::test_create_coop_uses_authenticated_did ... ok
test api::entity::tests::test_parse_role ... ok
test api::execution::tests::parse_status_accepts_known_values ... ok
test api::execution::tests::parse_status_rejects_unknown_values ... ok
test api::coops::tests::test_cross_cooperative_authorization_fails ... ok
test api::coops::tests::test_authorization_scope_check ... ok
test api::coops::tests::test_add_remove_member ... ok
test api::commons::tests::test_get_holder_not_found ... ok
test api::auth::tests::test_ip_rate_limiting_on_verify ... ok
test api::federation::tests::test_get_vouches_origin_governance_when_service_present ... ok
test api::federation::tests::test_list_agreements_falls_back_to_fed_mgr_when_no_service ... ok
test api::federation::tests::test_empty_scope_ordering_does_not_steal_routes ... ok
test api::federation::tests::test_get_vouches_prefers_federation_service ... ok
test api::devices::tests::test_list_devices_unauthorized ... ok
test api::federation::tests::test_get_agreement_origin_governance_when_service_present ... ok
test api::federation::tests::test_get_agreement_prefers_federation_service ... ok
test api::federation::tests::test_federation_status_route_matches ... ok
test api::execution::tests::get_record_returns_none_for_missing_hash ... ok
test api::federation::tests::test_get_coop_origin_governance_when_service_present ... ok
test api::federation::tests::test_get_coop_prefers_federation_service ... ok
test api::federation::tests::test_get_position_falls_back_to_fed_mgr_when_no_service ... ok
test api::execution::tests::list_records_filters_by_status ... ok
test api::execution::tests::execution_response_exposes_truth_counters ... ok
test api::federation::tests::test_get_position_prefers_federation_service_over_local_manager ... ok
test api::health::tests::test_health_status_enum ... ok
test api::health::tests::test_readiness_endpoint ... ok
test api::health::tests::test_liveness_endpoint ... ok
test api::health::tests::test_health_endpoint ... ok
test api::federation::tests::test_list_agreements_origin_governance_when_service_present ... ok
test api::flow_c::tests::coops_alias_routes_are_registered ... ok
test api::flow_c::tests::cross_coop_access_is_enforced_on_coops_alias ... ok
test api::federation::tests::test_list_coops_falls_back_to_fed_mgr_when_no_service ... ok
test api::federation::tests::test_propose_adoption_404_for_unknown_agreement ... ok
test api::flow_c::tests::proposals_alias_routes_are_registered ... ok
test api::identity::tests::test_identity_health ... ok
test api::federation::tests::test_list_coops_prefers_federation_service ... ok
test api::health::tests::test_health_detailed_endpoint ... ok
test api::federation::tests::test_list_coops_origin_governance_when_service_present ... ok
test api::federation::tests::test_list_agreements_prefers_federation_service ... ok
test api::ledger::tests::test_create_payment_from_other_account_fails ... ok
test api::identity::tests::test_resolve_invalid_did ... ok
test api::health::tests::test_ready_endpoint ... ok
test api::ledger::tests::test_cross_payment_same_currency_rejected ... ok
test api::ledger::tests::test_cross_payment_from_other_account_rejected ... ok
test api::identity::tests::test_resolve_valid_did ... ok
test api::federation::tests::test_propose_adoption_happy_path_copies_terms_and_sets_provenance ... ok
test api::ledger::tests::test_cross_payment_self_payment_rejected ... ok
test api::ledger::tests::test_cross_payment_quote_same_currency_rejected ... ok
test api::listings::tests::test_parse_category ... ok
test api::listings::tests::test_parse_listing_type ... ok
test api::listings::tests::test_parse_status ... ok
test api::listings::tests::test_is_private_ip_ipv4 ... ok
test api::listings::tests::test_parse_visibility ... ok
test api::listings::tests::test_validate_photo_url_rejects_crlf_injection ... ok
test api::listings::tests::test_validate_photo_url_rejects_internal_tlds ... ok
test api::listings::tests::test_validate_photo_url_rejects_http ... ok
test api::listings::tests::test_validate_photo_url_rejects_localhost ... ok
test api::listings::tests::test_validate_photo_url_rejects_private_ips ... ok
test api::listings::tests::test_validate_photo_url_rejects_rfc6761_reserved ... ok
test api::listings::tests::test_validate_photo_url_valid_https ... ok
test api::listings::tests::test_validate_photo_url_valid_ipfs ... ok
test api::listings::tests::test_is_private_ip_ipv6 ... ok
test api::listings::tests::test_validate_photo_url_rejects_invalid_ipfs ... ok
test api::identity::tests::test_resolve_with_attestations_query ... ok
test api::ledger::tests::test_fx_quote_error_response_includes_error_code ... ok
test api::members::tests::test_update_member_profile_success ... ok
test api::names::tests::normalize_path_adds_leading_slash ... ok
test api::members::tests::test_update_member_profile_bad_request_empty_name ... ok
test api::members::tests::test_update_member_profile_forbidden_wrong_did ... ok
test api::names::tests::normalize_path_rejects_empty ... ok
test api::members::tests::test_get_member_profile_not_found ... ok
test api::members::tests::test_update_member_profile_bad_request_too_long ... ok
test api::names::tests::test_resolve_name_not_found_returns_404 ... ok
test api::names::tests::test_resolve_name_success_returns_200 ... ok
test api::ledger::tests::test_authorization_scope_check ... ok
test api::names::tests::test_resolve_name_unauthorized_returns_403 ... ok
test api::notifications::tests::test_get_delivery_status ... ok
test api::ledger::tests::test_create_settlement_and_get_position ... ok
test api::oracle::tests::test_currency_pair_creation ... ok
test api::oracle::tests::test_validate_currency_code_empty ... ok
test api::oracle::tests::test_validate_currency_code_invalid_chars ... ok
test api::oracle::tests::test_validate_currency_code_too_long ... ok
test api::oracle::tests::test_validate_currency_code_valid ... ok
test api::oracle::tests::test_validate_rate_nan_inf ... ok
test api::oracle::tests::test_validate_rate_too_large ... ok
test api::oracle::tests::test_validate_rate_too_small ... ok
test api::ledger::tests::test_fx_error_response_includes_error_code ... ok
test api::ledger::tests::test_cross_cooperative_ledger_privacy ... ok
test api::oracle::tests::test_validate_rate_valid ... ok
test api::members::tests::test_get_member_profile ... ok
test api::ledger::tests::test_cross_payment_authorization_check ... ok
test api::ledger::tests::test_inv1_missing_bearer_sig_stores_http_auth_missing ... ok
test api::notifications::tests::test_unregister_device ... ok
test api::notifications::tests::test_list_with_type_filter ... ok
test api::registry::tests::test_decision_status_serialization ... ok
test api::ledger::tests::test_self_payment_rejected ... ok
test api::registry::tests::test_decision_trace_structure ... ok
test api::registry::tests::test_decision_trace_unresolved ... ok
test api::registry::tests::test_index_decision_response_serialization ... ok
test api::notifications::tests::test_mark_read_operations ... ok
test api::registry::tests::test_index_decision_response_with_ledger_entry ... ok
test api::registry::tests::test_index_decision_request_deserialization ... ok
test api::notifications::tests::test_notification_count ... ok
test api::registry::tests::test_registry_get_decision ... ok
test api::ledger::tests::test_get_history ... ok
test api::registry::tests::test_registry_add_meeting ... ok
test api::ledger::tests::test_inv1_http_settlement_stores_jwt_sig_in_provenance ... ok
test api::registry::tests::test_registry_list_meetings ... ok
test api::registry::tests::test_registry_list_decisions_with_filter ... ok
test api::registry::tests::test_trace_with_verified_ledger_entry ... ok
test api::sdis::anchor::tests::test_add_device ... ok
test api::sdis::anchor::tests::test_anchor_record_creation ... ok
test api::sdis::anchor::tests::test_key_rotation ... ok
test api::sdis::anchor::tests::test_multiple_devices ... ok
test api::sdis::anchor::tests::test_multiple_rotations ... ok
test api::sdis::enrollment::tests::test_ceremony_approval ... ok
test api::sdis::enrollment::tests::test_ceremony_creation ... ok
test api::sdis::enrollment::tests::test_ceremony_rejection ... ok
test api::sdis::ephemeral::tests::test_channel_bitmap ... ok
test api::sdis::ephemeral::tests::test_verify_result ... ok
test api::sdis::qr::tests::test_decode_invalid_magic ... ok
test api::sdis::ephemeral::tests::test_validity_too_long ... ok
test api::sdis::qr::tests::test_decode_too_short ... ok
test api::sdis::ephemeral::tests::test_ephemeral_proof_generation ... ok
test api::sdis::ephemeral::tests::test_proof_expiry ... ok
test api::sdis::qr::tests::test_qr_version_estimation ... ok
test api::sdis::qr::tests::test_proof_type_encoding ... ok
test api::sdis::recovery::tests::test_recovery_approval ... ok
test api::sdis::recovery::tests::test_recovery_ceremony_creation ... ok
test api::sdis::recovery::tests::test_recovery_completion ... ok
test api::sdis::recovery::tests::test_recovery_rejection ... ok
test api::sdis::qr::tests::test_qr_estimate ... ok
test api::sdis::recovery::tests::test_validation_accepts_anchor_id ... ok
test api::sdis::qr::tests::test_encode_decode_roundtrip ... ok
test api::sdis::recovery::tests::test_validation_accepts_vui_hint ... ok
test api::sdis::recovery::tests::test_validation_requires_identifier ... ok
test api::sdis::simple_enrollment::tests::test_compute_temporary_vui_different_dids ... ok
test api::sdis::simple_enrollment::tests::test_compute_temporary_vui_deterministic ... ok
test api::registry::tests::test_load_execution_truth_for_registry_reflects_partial_execution ... ok
test api::ledger::tests::test_get_entries_by_decision_prefers_shared_service_boundary ... ok
test api::sdis::simple_enrollment::tests::test_compute_temporary_vui_is_32_bytes ... ok
test api::sdis::simple_enrollment::tests::test_device_info_structure ... ok
test api::sdis::simple_enrollment::tests::test_device_proof_structure ... ok
test api::sdis::simple_enrollment::tests::test_enrollment_session_level1 ... ok
test api::sdis::simple_enrollment::tests::test_enrollment_expiry_check ... ok
test api::sdis::simple_enrollment::tests::test_enrollment_session_level2 ... ok
test api::sdis::simple_enrollment::tests::test_enrollment_session_rejected ... ok
test api::sdis::simple_enrollment::tests::test_enrollment_session_status_levels ... ok
test api::sdis::simple_enrollment::tests::test_enrollment_store_insert_and_get ... ok
test api::sdis::simple_enrollment::tests::test_hash_did_for_audit_privacy_preserving ... ok
test api::sdis::simple_enrollment::tests::test_hash_did_for_audit_deterministic ... ok
test api::sdis::simple_enrollment::tests::test_format_timestamp ... ok
test api::sdis::simple_enrollment::tests::test_hash_did_for_audit_different_dids ... ok
test api::sdis::simple_enrollment::tests::test_hash_did_for_audit_is_8_chars ... ok
test api::notifications::tests::test_register_device ... ok
test api::sdis::simple_enrollment::tests::test_history_query_defaults ... ok
test api::sdis::simple_enrollment::tests::test_history_query_with_values ... ok
test api::sdis::simple_enrollment::tests::test_steward_min_trust_score_constant ... ok
test api::sdis::simple_enrollment::tests::test_recovery_codes_generation ... ok
test api::sdis::simple_enrollment::tests::test_recovery_codes_unique ... ok
test api::sdis::simple_enrollment::tests::test_start_enrollment_request_structure ... ok
test api::sdis::simple_enrollment::tests::test_verification_code_format ... ok
test api::registry::tests::test_decision_trace_endpoint_includes_execution_summary ... ok
test api::sdis::tests::test_verify_level1_invalid_base64 ... ok
test api::sdis::simple_enrollment::tests::test_enrollment_store_creation ... ok
test api::sdis::tests::test_verify_level1_valid ... ok
test api::sdis::tests::test_sdis_health ... ok
test api::sdis::verify::tests::test_level1_replay_detection ... ok
test api::sdis::verify::tests::test_binding_cache ... ok
test api::sdis::tests::test_generate_ephemeral ... ok
test api::sdis::tests::test_verify_level2_with_binding ... ok
test api::sdis::verify::tests::test_level1_expired_proof ... ok
test api::sdis::verify::tests::test_verifier_creation ... ok
test api::services::tests::test_endpoint_type_to_str_all_variants ... ok
test api::services::tests::test_parse_scope ... ok
test api::sdis::verify::tests::test_level1_verification ... ok
test api::services::tests::test_default_scope_and_ttl ... ok
test api::sdis::verify::tests::test_level2_verification ... ok
test api::registry::tests::test_decision_endpoint_hydrates_receipt_and_matches_ledger_by_decision ... ok
test api::sdis::verify::tests::test_level2_binding_mismatch ... ok
test api::sdis::simple_enrollment::tests::test_enrollment_store_default ... ok
test api::services::tests::test_query_services_params_custom ... ok
test api::notifications::tests::test_delete_notification ... ok
test api::services::tests::test_query_services_params_defaults ... ok
test api::services::tests::test_query_services_params_no_service_id ... ok
test api::services::tests::test_to_response_endpoint_type_matches_variant ... ok
test api::services::tests::test_to_response_populates_new_fields ... ok
test api::sessions::tests::test_create_session ... ok
test api::sessions::tests::test_get_session_not_found ... ok
test api::sessions::tests::test_get_session_status_pending ... ok
test api::treasury::tests::test_cross_coop_access_denied ... ok
test api::treasury::tests::test_spending_rules_empty ... ok
test api::treasury::tests::test_get_treasury_nonce_not_found ... ok
test api::treasury::tests::test_get_treasury_status_not_found ... ok
test audit::tests::test_invalid_scope_event ... ok
test api::receipts::tests::forced_accept_without_domain_id_hint_returns_empty_journal ... ok
test api::treasury::tests::test_audit_trail_pagination ... ok
test api::websocket::tests::test_websocket_endpoint ... ok
test auth::tests::test_create_challenge ... ok
test api::receipts::tests::full_execution_chain_is_complete ... ok
test audit::tests::test_audit_logger_formats ... ok
test api::treasury::tests::test_create_budget_requires_write_scope ... ok
test auth::tests::test_verify_challenge_no_challenge ... ok
test auth::tests::test_verify_challenge_success ... ok
test api::trust::tests::test_get_trust_edges ... ok
test auth::tests::test_verify_challenge_success_with_hardware_backed_bundle ... ok
test commons_mgr::tests::test_create_anchor_with_steward ... ok
test auth::tests::test_verify_challenge_invalid_signature ... ok
test commons_store::tests::test_in_memory_backend ... ok
test commons_mgr::tests::test_create_holder_from_anchor ... ok
test commons_mgr::tests::test_get_by_did ... ok
test commons_mgr::tests::test_join_and_leave_jurisdiction ... ok
test compute_mgr::tests::test_compute_manager_new ... ok
test compute_events::tests::test_forward_task_completed ... ok
test commons_store::tests::test_holder_operations ... ok
test compute_mgr::tests::test_cancel_task_without_daemon ... ok
test compute_mgr::tests::test_get_status_without_daemon ... ok
test compute_mgr::tests::test_query_by_receipt_malformed_hex_returns_none ... ok
test commons_store::tests::test_cache_behavior ... ok
test compute_mgr::tests::test_query_by_receipt_not_found_returns_not_found_status ... ok
test compute_mgr::tests::test_query_by_receipt_settled_returns_status_scope_task_id ... ok
test compute_mgr::tests::test_query_by_receipt_wrong_byte_length_returns_none ... ok
test api::treasury::tests::test_propose_spend_creates_spend_operation_payload ... ok
test compute_mgr::tests::test_submit_without_daemon ... ok
test api::receipts::tests::partial_execution_chain_is_not_complete ... ok
test coop::tests::test_cannot_remove_last_steward ... ok
test coop::tests::test_create_coop ... ok
test email_client::tests::test_email_message_creation ... ok
test commons_store::tests::test_charter_operations ... ok
test coop::tests::test_add_member ... ok
test email_client::tests::test_security_alert_template ... ok
test email_client::tests::test_smtp_config_sendgrid ... ok
test compute_events::tests::test_forward_task_claimed ... ok
test coop::tests::test_remove_member ... ok
test email_client::tests::test_email_templates ... ok
test coop::tests::test_role_check ... ok
test api::treasury::tests::test_list_budgets_not_found ... ok
test entity_audit::tests::test_extract_entity_id_from_key ... ok
test entity_audit::tests::test_operation_names ... ok
test entity_mgr::tests::test_ensure_entity_exists_creates_new ... ok
test entity_mgr::tests::test_cannot_remove_with_members ... ok
test entity_mgr::tests::test_ensure_entity_exists_handles_existing ... ok
test entity_mgr::tests::test_standalone_mode ... ok
test error::tests::gateway_kernel_error_http_mapping ... ok
test error::tests::gateway_kernel_error_maps_to_http ... ok
test events::tests::test_cleanup_closed_channels ... ok
test events::tests::test_backfill ... ok
test events::tests::test_multiple_subscribers ... ok
test events::tests::test_shutdown_broadcast ... ok
test events::tests::test_shutdown_broadcast_all ... ok
test events::tests::test_slow_client_detection ... ok
test events::tests::test_subscribe_and_broadcast ... ok
test events::tests::test_subscriber_count ... ok
test events::tests::test_subscriber_limit ... ok
test fcm_client::tests::test_create_notification_message ... ok
test fcm_client::tests::test_fcm_config_from_json ... ok
test entity_audit::tests::test_audit_pagination ... ok
test entity_audit::tests::test_count_audit_records ... ok
test api::receipts::tests::wrong_domain_id_hint_returns_empty_journal ... ok
test auth::tests::test_cleanup_expired_challenges ... ok
test compute_events::tests::test_create_forwarding_callback ... ok
test entity_audit::tests::test_get_entities_with_audits ... ok
test identity_mgr::tests::test_parse_capabilities ... ok
test identity_mgr::tests::test_parse_invalid_capability ... ok
test invite::tests::test_create_and_get_invite ... ok
test invite::tests::test_list_invites ... ok
test invite::tests::test_mark_used ... ok
test entity_audit::tests::test_prune_no_op_when_under_limit ... ok
test entity_audit::tests::test_audit_with_proposal ... ok
test federation_mgr::tests::test_federation_manager_init ... ok
test federation_mgr::tests::test_gateway_coop_list_reflects_only_gateway_registered_coops ... ok
test api::receipts::tests::forced_accept_with_domain_id_hint_finds_journal_entries ... ok
test federation_mgr::tests::test_gateway_clearing_list_does_not_surface_supervisor_agreements ... ok
test identity_mgr::tests::test_get_or_create_document ... ok
test invite::tests::test_validate_invite ... ok
test identity_mgr::tests::test_list_devices ... ok
test listings_mgr::tests::test_create_listing ... ok
test listings_mgr::tests::test_express_interest ... ok
test listings_mgr::tests::test_listing_filter ... ok
test listings_mgr::tests::test_listing_interest_serialization ... ok
test listings_mgr::tests::test_listing_lifecycle ... ok
test ledger_mgr::tests::test_inv1_direct_member_provenance_carries_jwt_sig ... ok
test listings_mgr::tests::test_sled_listing_roundtrip ... ok
test ledger_mgr::tests::test_inv1_system_path_records_system_executed_not_jwt_authenticated ... ok
test middleware::tests::test_jwt_auth_expired_token ... ok
test middleware::tests::test_jwt_auth_invalid_token ... ok
test models::schema_contract_tests::transaction_history_response_uses_transactions_key ... ok
test middleware::tests::test_jwt_auth_valid_token ... ok
test notification_processor::tests::test_config_from_env ... ok
test notification_processor::tests::test_delete_notification ... ok
test notification_processor::tests::test_fcm_config_from_env ... ok
test entity_audit::tests::test_record_and_retrieve_audit ... ok
test ledger_events::tests::test_bridge_forwards_resource_access_transferred ... ok
test notification_processor::tests::test_in_app_storage ... ok
test notification_queue::tests::test_calculate_backoff ... ok
test notification_queue::tests::test_notification_ready_check ... ok
test notification_queue::tests::test_notification_with_email ... ok
test notification_processor::tests::test_mark_read ... ok
test notification_processor::tests::test_unread_count ... ok
test notification_queue::tests::test_queued_notification_creation ... ok
test notification_queue::tests::test_security_alert_includes_email ... ok
test notification_queue::tests::test_settlement_notification_factory ... ok
test notification_store::tests::test_delivery_logs ... ok
test notification_queue::tests::test_queue_notification ... ok
test notification_triggers::tests::test_governance_trigger_proposal ... ok
test notification_store::tests::test_device_registration ... ok
test notification_store::tests::test_in_app_notifications ... ok
test notifications::tests::test_notification_creation ... ok
test notifications::tests::test_multiple_devices_per_did ... ok
test ledger_mgr::tests::test_create_settlement ... ok
test notifications::tests::test_unregister_device ... ok
test rate_limit::tests::test_category_rate_limiter_for_request ... ok
test rate_limit::tests::test_category_rate_limiter_different_limits ... ok
test rate_limit::tests::test_category_rate_limiter_per_did_independence ... ok
test rate_limit::tests::test_endpoint_category_configs ... ok
test rate_limit::tests::test_endpoint_category_from_request ... ok
test rate_limit::tests::test_rate_limiter_per_did ... ok
test rate_limit::tests::test_token_bucket_basic ... ok
test notifications::tests::test_register_and_get_device ... ok
test federation_mgr::tests::test_list_cooperatives_before_init ... ok
test rate_limit::tests::test_velocity_limit_config_defaults ... ok
test rate_limit::tests::test_velocity_limit_trust_levels ... ok
test ledger_mgr::tests::test_get_all_positions ... ok
test rate_limit::tests::test_velocity_limiter_basic ... ok
test rate_limit::tests::test_velocity_limiter_current_count ... ok
test rate_limit::tests::test_velocity_limiter_per_did ... ok
test ledger_mgr::tests::test_get_history ... ok
test listings_mgr::tests::test_sled_interest_roundtrip ... ok
test notification_listener::tests::test_payment_notification ... ok
test receipt_store::tests::authority_grant_rewrite_same_id_is_idempotent ... ok
test receipt_store::tests::authority_grant_is_active_at_flips_false_after_revocation ... ok
test receipt_store::tests::authority_grant_revocation_is_idempotent_keeps_original_timestamp ... ok
test receipt_store::tests::dispatch_evidence_duplicate_evidence_id_is_idempotent ... ok
test receipt_store::tests::charter_direct_grant_stores_primary_but_not_decision_index ... ok
test receipt_store::tests::authority_grants_list_by_decision_is_chronological ... ok
test receipt_store::tests::dispatch_evidence_roundtrip_and_ordering ... ok
test receipt_store::tests::dispatch_evidence_is_scoped_by_record ... ok
test receipt_store::tests::governance_proposal_index_does_not_alias_colon_prefixes ... ok
test receipt_store::tests::institutional_effect_dedup_not_fooled_by_colon_aliased_proposal_id ... ok
test receipt_store::tests::institutional_effect_index_does_not_alias_colon_prefixes ... ok
test receipt_store::tests::governance_proposal_index_returns_correct_receipt_when_both_exist ... ok
test receipt_store::tests::institutional_effect_index_is_scoped_when_both_proposal_ids_coexist ... ok
test receipt_store::tests::institutional_effects_are_scoped_by_proposal_id ... ok
test receipt_store::tests::institutional_effects_duplicate_write_is_idempotent ... ok
test federation_mgr::tests::test_persistent_storage_survives_manager_reconstruction ... ok
test receipt_store::tests::institutional_effects_roundtrip_in_chronological_order ... ok
test receipt_store::tests::authority_grant_roundtrip_by_id_and_decision ... ok
test receipt_store::tests::list_active_authority_grants_by_grantee_filters_revoked ... ok
test receipt_store::tests::list_authority_grants_by_grantee_includes_revoked ... ok
test receipt_store::tests::authority_grant_revocation_roundtrip ... ok
test receipt_store::tests::mandate_rewrite_same_id_is_idempotent ... ok
test receipt_store::tests::mandate_roundtrip_by_proposal_and_decision ... ok
test receipt_store::tests::mandate_list_by_decision_is_chronological ... ok
test receipt_store::tests::put_mandate_with_grants_atomic_on_serialization_failure_writes_nothing ... ok
test receipt_store::tests::mandate_by_proposal_index_does_not_alias_colon_prefixes ... ok
test receipt_store::tests::revoke_missing_grant_returns_grant_not_found ... ok
test receipt_store::tests::test_get_governance_by_proposal ... ok
test receipt_store::tests::test_canonical_hash_as_key ... ok
test receipt_store::tests::seam_idempotency_is_not_fooled_by_colon_aliased_proposal_id ... ok
test receipt_store::tests::test_governance_dual_indexing ... ok
test receipt_store::tests::seam_integration_with_real_receipt_store_persists_mandate_and_grant ... ok
test receipt_store::tests::put_mandate_with_grants_atomic_commits_all ... ok
test receipt_store::tests::test_list_governance_by_decision ... ok
test receipt_store::tests::test_put_get_governance ... ok
test security::tests::test_configure_cors_allowed_origins_mode ... ok
test receipt_store::tests::test_put_allocation_with_intents ... ok
test receipt_store::tests::test_put_get_allocation ... ok
test security::tests::test_configure_cors_disabled_mode ... ok
test receipt_store::tests::test_put_get_intent ... ok
test security::tests::test_configure_cors_empty_origins_falls_back_to_disabled ... ok
test security::tests::test_configure_cors_permissive_mode ... ok
test security::tests::test_cors_mode_default ... ok
test security::tests::test_cors_mode_equality ... ok
test security::tests::test_development_config_includes_all_localhost_variants ... ok
test security::tests::test_development_csp_allows_required_unsafe_directives ... ok
test security::tests::test_development_csp_differs_from_production ... ok
test security::tests::test_production_csp_has_default_self ... ok
test security::tests::test_production_csp_is_strict ... ok
test security::tests::test_production_with_origins_has_strict_csp ... ok
test security::tests::test_security_config_default ... ok
test security::tests::test_security_config_development ... ok
test security::tests::test_security_config_production ... ok
test security::tests::test_security_config_production_with_origins ... ok
test security::tests::test_with_csp_directive_accepts_complex_policy ... ok
test security::tests::test_with_csp_directive_accepts_valid ... ok
test security::tests::test_with_csp_directive_rejects_carriage_return ... ok
test security::tests::test_with_csp_directive_rejects_newline ... ok
test security::tests::test_with_csp_directive_rejects_null_byte ... ok
test server::tests::test_jwt_secret_32_bytes_passes_validation ... ok
test server::tests::test_jwt_secret_64_bytes_passes_validation ... ok
test server::tests::test_jwt_secret_empty_fails_startup ... ok
test server::tests::test_jwt_secret_too_short_fails_startup ... ok
test service_discovery_mgr::tests::test_announce_and_get ... ok
test service_discovery_mgr::tests::test_async_scoped_discovery_announce ... ok
test server::tests::test_jwt_secret_31_bytes_fails_startup ... ok
test service_discovery_mgr::tests::test_async_scoped_discovery_discover_endpoints ... ok
test service_discovery_mgr::tests::test_async_scoped_discovery_discover_filtered ... ok
test service_discovery_mgr::tests::test_async_scoped_discovery_withdraw ... ok
test service_discovery_mgr::tests::test_discover_capability_filter ... ok
test service_discovery_mgr::tests::test_discover_remote_without_gossip_returns_error ... ok
test service_discovery_mgr::tests::test_discover_scope_filter ... ok
test service_discovery_mgr::tests::test_expired_endpoints_filtered ... ok
test service_discovery_mgr::tests::test_pending_queries_state_management ... ok
test service_discovery_mgr::tests::test_remote_discover_outcome_variants ... ok
test service_discovery_mgr::tests::test_remove_expired ... ok
test service_discovery_mgr::tests::test_expired_query_ignored ... ok
test service_discovery_mgr::tests::test_query_handling_responds_with_local_results ... ok
test service_discovery_mgr::tests::test_set_signing_key ... ok
test service_discovery_mgr::tests::test_response_routed_to_pending_query ... ok
test service_discovery_mgr::tests::test_unsigned_response_dropped ... ok
test receipt_store::tests::test_list_by_decision ... ok
test service_discovery_mgr::tests::test_sled_persistence_announce_and_reload ... ok
test service_discovery_mgr::tests::test_sled_persistence_expired_cleaned_on_load ... ok
test service_discovery_mgr::tests::test_sled_remove_expired_cleans_sled ... ok
test service_discovery_mgr::tests::test_with_persistence_enables_write_through ... ok
test service_discovery_mgr::tests::test_withdraw ... ok
test service_discovery_mgr::tests::test_withdraw_wrong_provider ... ok
test session::tests::test_approve_session ... ok
test service_discovery_mgr::tests::test_with_persistence_loads_existing_endpoints ... ok
test service_discovery_mgr::tests::test_sled_persistence_withdraw_removes_entry ... ok
test session::tests::test_consume_session ... ok
test session::tests::test_create_session ... ok
test session::tests::test_get_session ... ok
test treasury_mgr::tests::test_actor_backed_mode ... ok
test treasury_mgr::tests::test_standalone_mode ... ok
test trust_mgr::tests::test_add_and_get_edge ... ok
test service_discovery_mgr::tests::test_with_persistence_merges_with_existing_memory ... ok
test service_discovery_mgr::tests::test_with_persistence_prunes_expired_on_attach ... ok
test trust_mgr::tests::test_async_add_and_get_edge ... ok
test trust_mgr::tests::test_async_compute_trust_score ... ok
test trust_mgr::tests::test_async_incoming_and_outgoing_edges ... ok
test trust_mgr::tests::test_async_concurrent_access ... ok
test trust_mgr::tests::test_compute_direct_trust ... ok
test trust_mgr::tests::test_compute_transitive_trust ... ok
test trust_mgr::tests::test_generation_counter_increments_on_mutations ... ok
test trust_mgr::tests::test_incoming_edges ... ok
test trust_mgr::tests::test_get_trust_network ... ok
test trust_mgr::tests::test_oracle_cache_hit_on_second_call ... ok
test trust_mgr::tests::test_oracle_cache_invalidated_by_async_edge_mutation ... ok
test trust_mgr::tests::test_oracle_cache_invalidated_by_edge_mutation ... ok
test trust_mgr::tests::test_oracle_cache_ttl_returns_zero ... ok
test trust_mgr::tests::test_oracle_invalid_did_returns_default ... ok
test trust_mgr::tests::test_oracle_non_trust_domain_bypasses_cache ... ok
test trust_mgr::tests::test_trust_oracle_custom_default_score ... ok
test trust_mgr::tests::test_trust_oracle_standalone ... ok
test validation::tests::test_validate_auto_accept_threshold ... ok
test validation::tests::test_validate_context ... ok
test validation::tests::test_validate_coop_count ... ok
test validation::tests::test_validate_coop_id ... ok
test validation::tests::test_validate_coop_name ... ok
test validation::tests::test_validate_credit_policy ... ok
test ledger_events::tests::test_bridge_forwards_transaction_created ... ok
test ledger_events::tests::test_bridge_forwards_balance_changed ... ok
test validation::tests::test_validate_data_sharing_level ... ok
test validation::tests::test_validate_dispute_resolution ... ok
test validation::tests::test_validate_domain_name ... ok
test validation::tests::test_validate_evidence ... ok
test validation::tests::test_validate_federation_id ... ok
test validation::tests::test_validate_governance_model ... ok
test validation::tests::test_validate_governance_params ... ok
test validation::tests::test_validate_grace_period_days ... ok
test validation::tests::test_validate_history_limit ... ok
test validation::tests::test_validate_history_offset ... ok
test validation::tests::test_validate_max_attestations_per_minute ... ok
test validation::tests::test_validate_max_imbalance ... ok
test validation::tests::test_validate_member_count ... ok
test validation::tests::test_validate_memo ... ok
test validation::tests::test_validate_domain_members ... ok
test validation::tests::test_validate_payment_amount ... ok
test validation::tests::test_validate_proposal_description ... ok
test validation::tests::test_validate_proposal_title ... ok
test validation::tests::test_validate_reason ... ok
test validation::tests::test_validate_scopes ... ok
test validation::tests::test_validate_settlement_interval ... ok
test validation::tests::test_validate_trust_decay_factor ... ok
test validation::tests::test_validate_trust_score ... ok
test validation::tests::test_validate_unit ... ok
test validation::tests::test_validate_vote_comment ... ok
test websocket::tests::test_create_session ... ok
test websocket::tests::test_server_message_serialization ... ok
test trust_mgr::tests::test_algorithm_consistency_standalone_vs_actor_backed ... ok
test notification_triggers::tests::test_ledger_trigger_handles_transaction ... ok
test entity_audit::tests::test_prune_by_count ... ok
test trust_mgr::tests::test_oracle_cache_ttl_expiration ... ok
test rate_limit::tests::test_rate_limiter_cleanup ... ok
test entity_audit::tests::test_audit_record_ordering ... ok
test entity_audit::tests::test_prune_all_entities ... ok
test entity_audit::tests::test_prune_specific_entity ... ok
test rate_limit::tests::test_token_bucket_refill ... ok
test rate_limit::tests::test_token_bucket_cap ... ok
test session::tests::test_cannot_approve_expired_session ... ok
test session::tests::test_cleanup_expired ... ok
test session::tests::test_session_expiration ... ok

test result: ok. 520 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.21s (520 passed)
- [x] 
running 201 tests
test dispatch_evidence::tests::empty_evidence_yields_emitted_only ... ok
test dispatch_evidence::tests::labels_are_stable_snake_case ... ok
test dispatch_evidence::tests::later_success_does_not_erase_earlier_failure ... ok
test dispatch_evidence::tests::most_recent_failure_message_wins_when_multiple_failures ... ok
test dispatch_evidence::tests::single_failure_yields_execution_failed_with_error ... ok
test dispatch_evidence::tests::single_success_yields_execution_evidenced ... ok
test dispatch_evidence_sink::tests::deferred_sink_drops_when_no_backend_installed ... ok
test dispatch_evidence_sink::tests::parse_proposal_id_handles_colon_containing_domain ... ok
test dispatch_evidence_sink::tests::parse_proposal_id_extracts_middle_segment ... ok
test dispatch_evidence_sink::tests::effect_kind_maps_sdis_variants ... ok
test dispatch_evidence_sink::tests::parse_proposal_id_rejects_empty_proposal ... ok
test dispatch_evidence_sink::tests::parse_proposal_id_rejects_empty_domain ... ok
test dispatch_evidence_sink::tests::parse_proposal_id_rejects_missing_suffix ... ok
test executor::tests::test_executor_failure ... ok
test executor::tests::test_executor_success ... ok
test dispatch_evidence_sink::tests::parse_proposal_id_rejects_missing_prefix ... ok
test grant_minting::tests::appoint_steward_mints_one_attestation_grant_bounded_by_term ... ok
test grant_minting::tests::appoint_steward_term_length_overflow_declines_to_mint ... ok
test grant_minting::tests::budget_payload_mints_zero_grants_until_truthful_mapping_exists ... ok
test executor::tests::test_executor_passes_arguments ... ok
test grant_minting::tests::no_op_grant_backend_falls_back_to_pending_grants_mandate ... ok
test grant_minting::tests::appoint_steward_grant_provenance_matches_decision ... ok
test grant_minting::tests::reconfirm_steward_mints_one_attestation_grant_bounded_by_new_term_end ... ok
test grant_minting::tests::overflow_and_no_op_backend_compose_to_pending_grants ... ok
test grant_minting::tests::reinstate_steward_without_prior_grant_declines_to_mint ... ok
test grant_minting::tests::remove_steward_mints_zero_grants ... ok
test grant_minting::tests::remove_steward_acceptance_is_idempotent_across_retries ... ok
test handlers::execution::tests::test_pilot_treasury_ops_do_not_fall_back_to_noop_with_legacy_env_flag ... ok
test handlers::execution::tests::test_translate_allocation_produces_budget_and_allocate_effects ... ok
test grant_minting::tests::remove_steward_revokes_only_target_grants_at_acceptance_seam ... ok
test grant_minting::tests::revoke_authority_honors_effective_at ... ok
test grant_minting::tests::text_payload_mints_zero_grants ... ok
test handlers::execution::tests::test_translate_bond_issuance_produces_issue_bond_effect ... ok
test grant_minting::tests::reinstate_steward_mints_fresh_grant_not_mutating_revoked_one ... ok
test handlers::execution::tests::test_translate_revoke_vouch ... ok
test handlers::execution::tests::test_translate_share_redemption_produces_redeem_shares_effect ... ok
test handlers::execution::tests::test_translate_surplus_allocation_carries_decision_provenance ... ok
test handlers::execution::tests::test_translate_terminate_clearing ... ok
test handlers::execution::tests::test_translate_treasury_spend_preserves_decision_provenance ... ok
test handlers::execution::tests::test_translate_unhandled_payload_returns_explicit_error ... ok
test http::handlers::tests::accepted_proposal_materializes_action_items ... ok
test http::handlers::tests::dashboard_action_item_counts_scoped_to_program_activities ... ok
test http::handlers::tests::dashboard_includes_meetings_linked_through_activities ... ok
test http::handlers::tests::dashboard_404_for_missing_program ... ok
test http::handlers::tests::event_log_no_duplicate_on_same_status ... ok
test http::handlers::tests::event_log_multiple_transitions_ordered_oldest_first ... ok
test http::handlers::tests::dashboard_empty_program ... ok
test http::handlers::tests::event_log_no_transitions_falls_back_to_lifecycle_bookmarks ... ok
test http::handlers::tests::dashboard_milestones_ordered_and_counted ... ok
test http::handlers::tests::get_my_scopes_empty ... ok
test http::handlers::tests::event_log_single_transition_appears_in_history ... ok
test http::handlers::tests::evidence_hook_persists_dispatch_evidence_on_appoint_steward_success ... ok
test http::handlers::tests::evidence_hook_persists_dispatch_evidence_on_accept ... ok
test http::handlers::tests::get_my_scopes_returns_assigned_roles ... ok
test http::handlers::tests::evidence_hook_persists_dispatch_evidence_on_revoke_steward_success ... ok
test http::handlers::tests::history_404_for_missing_milestone ... ok
test http::handlers::tests::get_my_work_empty ... ok
test http::handlers::tests::get_my_work_returns_assigned_items_across_domains ... ok
test http::handlers::tests::history_completed_milestone_has_two_entries ... ok
test http::handlers::tests::hook_not_fired_on_rejection ... ok
test http::handlers::tests::history_pending_milestone_has_one_entry ... ok
test http::handlers::tests::hook_fires_with_correct_payload_on_acceptance ... ok
test http::handlers::tests::my_work_filter_by_status ... ok
test http::handlers::tests::my_work_filter_overdue ... ok
test http::handlers::tests::my_work_filter_by_tag ... ok
test http::handlers::tests::my_work_filter_by_priority ... ok
test http::handlers::tests::my_work_sorted_oldest_first ... ok
test http::handlers::tests::preview_404_for_missing_milestone ... ok
test http::handlers::tests::preview_already_completed_is_not_ready ... ok
test http::handlers::tests::evidence_hook_persists_failure_on_appoint_steward_error ... ok
test http::handlers::tests::preview_skipped_earlier_phase_clears_blocker ... ok
test http::handlers::tests::preview_ready_when_first_phase_and_open ... ok
test http::handlers::tests::program_status_no_duplicate_on_same_status ... ok
test http::handlers::tests::program_status_multiple_transitions_recorded ... ok
test http::handlers::tests::rejected_proposal_does_not_materialize_action_items ... ok
test http::handlers::tests::program_status_update_400_for_unknown_status ... ok
test http::handlers::tests::preview_blocked_by_earlier_phase ... ok
test http::handlers::tests::program_status_update_404_for_missing_program ... ok
test http::handlers::tests::preview_blocked_status_is_not_ready ... ok
test http::handlers::tests::summary_all_milestones_terminal ... ok
test http::handlers::tests::trust_threshold_membership_resolver_invoked_at_close_time ... ok
test institutional_effect::tests::budget_payload_produces_no_record ... ok
test institutional_effect::tests::deploy_charter_stores_charter_id_as_target_ref_not_yaml_body ... ok
test http::handlers::tests::summary_mixed_milestone_states ... ok
test http::handlers::tests::summary_404_for_missing_program ... ok
test http::handlers::tests::summary_no_milestones ... ok
test institutional_effect::tests::emit_accepted_effect_dedups_by_effect_kind ... ok
test http::handlers::tests::program_status_update_draft_to_active_planning ... ok
test institutional_effect::tests::emit_accepted_effect_distinct_effect_kinds_coexist_on_same_proposal ... ok
test institutional_effect::tests::emit_accepted_effect_text_payload_is_no_effect ... ok
test institutional_effect::tests::emit_accepted_effect_writes_on_first_call ... ok
test institutional_effect::tests::freeze_member_populates_typed_fields_and_payload ... ok
test institutional_effect::tests::text_payload_produces_no_record ... ok
test actor::tests::test_delegation_revoked_wrong_sender_rejected ... ok
test manager::sled_meeting_store_tests::domain_ids_with_colons_do_not_leak_across_domains ... ok
test actor::tests::test_delegation_created_idempotent ... ok
test manager::sled_meeting_store_tests::delete_missing_returns_false ... ok
test manager::sled_meeting_store_tests::activity_index_cleaned_on_delete ... ok
test actor::tests::test_delegation_revoked_before_create_is_ignored ... ok
test manager::sled_meeting_store_tests::list_by_activity_filters_and_sorts ... ok
test actor::tests::test_delegation_created_correct_sender_accepted ... ok
test actor::tests::test_delegation_revoked_mismatched_revoked_by_rejected ... ok
test actor::tests::test_delegation_revoked_sets_revoked_at ... ok
test actor::tests::test_delegation_created_wrong_sender_rejected ... ok
test actor::tests::test_delegation_created_persisted ... ok
test manager::sled_meeting_store_tests::activity_index_cleaned_on_update ... ok
test manager::sled_meeting_store_tests::delete_removes_primary_and_index ... ok
test manager::sled_meeting_store_tests::list_by_activity_activity_id_prefix_isolation ... ok
test manager::sled_program_store_tests::milestone_list_by_program_isolates_programs ... ok
test manager::sled_program_store_tests::milestone_delete_missing_is_idempotent ... ok
test manager::sled_meeting_store_tests::list_by_domain_isolates_domains ... ok
test manager::sled_meeting_store_tests::get_is_o1_and_does_not_scan ... ok
test manager::sled_program_store_tests::milestone_list_by_program_orders_by_phase_index ... ok
test manager::tests::adr0014_appoint_steward_mints_bounded_authority_grant ... ok
test manager::tests::adr0014_mandate_distinct_from_institutional_effect_record ... ok
test manager::tests::adr0014_authority_grant_distinct_from_institutional_effect ... ok
test manager::tests::adr0014_mandate_minted_on_accepted_proposal ... ok
test manager::tests::adr0014_no_mandate_on_rejected_proposal ... ok
test manager::sled_meeting_store_tests::list_by_domain_sorted_newest_first ... ok
test manager::sled_program_store_tests::milestone_stale_program_index_cleaned_on_update ... ok
test manager::sled_program_store_tests::milestone_list_by_program_rejects_prefix_collisions ... ok
test manager::sled_meeting_store_tests::save_and_get_roundtrip ... ok
test manager::sled_program_store_tests::milestone_delete_cleans_index ... ok
test manager::sled_program_store_tests::milestone_save_and_get_roundtrip ... ok
test manager::tests::adr0014_rejected_appoint_steward_mints_no_grant ... ok
test manager::tests::apply_acceptance_effects_emits_freeze_record_once ... ok
test manager::tests::apply_acceptance_effects_emits_same_record_semantics_regardless_of_caller ... ok
test manager::tests::apply_acceptance_effects_dedups_across_http_and_actor_callers ... ok
test manager::tests::apply_acceptance_effects_noop_without_receipt_store ... ok
test manager::tests::apply_acceptance_effects_returns_no_effect_for_unhandled_payload ... ok
test manager::sled_program_store_tests::program_delete_cleans_both_indexes ... ok
test manager::tests::adr0014_text_proposal_mints_zero_grants_and_unbound_mandate ... ok
test manager::sled_program_store_tests::program_delete_missing_is_idempotent ... ok
test manager::sled_program_store_tests::program_list_by_domain_isolates_domains ... ok
test manager::tests::dashboard_sees_activity_via_forward_link_immediately ... ok
test manager::tests::create_activity_program_not_found_still_succeeds ... ok
test manager::tests::deliberation_collects_linked_agenda_items_across_meetings ... ok
test manager::tests::deliberation_effect_kind_labels_freeze_member ... ok
test manager::tests::deliberation_sort_interleaves_scheduled_only_entries ... ok
test manager::tests::deliberation_empty_when_no_meeting_references_proposal ... ok
test manager::tests::deliberation_surfaces_emitted_effects ... ok
test manager::tests::create_activity_with_parent_program_id_updates_forward_list ... ok
test manager::tests::deliberation_surfaces_execution_evidenced_when_success_recorded ... ok
test manager::tests::deliberation_surfaces_execution_failed_with_subsystem_error ... ok
test manager::tests::deliberation_none_when_proposal_missing ... ok
test manager::tests::digest_empty_for_did_with_no_activity ... ok
test manager::tests::institutional_effects_empty_without_receipt_store ... ok
test manager::tests::deliberation_includes_decision_receipt_after_close ... ok
test manager::tests::institutional_effects_roundtrip_and_ordering ... ok
test manager::tests::link_activity_to_program_activity_not_found_errors ... ok
test manager::tests::link_activity_to_program_both_sides_updated ... ok
test manager::tests::digest_pending_vote_includes_open_proposal_not_yet_voted ... ok
test manager::tests::digest_pending_vote_excluded_after_voting ... ok
test manager::tests::digest_upcoming_meetings_filter_by_window_and_attendee ... ok
test manager::tests::link_activity_to_program_idempotent ... ok
test manager::sled_program_store_tests::program_list_by_entity_isolates_entities ... ok
test manager::tests::link_moves_activity_between_programs ... ok
test manager::tests::dispatch_evidence_roundtrip_and_ordering_per_record ... ok
test manager::tests::relink_to_different_program_updates_both ... ok
test manager::tests::test_create_domain_with_builtin_profile ... ok
test manager::tests::test_create_domain_with_contract_profile ... ok
test manager::tests::test_delegation_different_scopes_no_cycle ... ok
test manager::tests::test_delegation_direct_cycle_rejected ... ok
test manager::tests::test_delegation_transitive_cycle_rejected ... ok
test manager::tests::test_inv5_chain_complete_text_proposal ... ok
test manager::tests::test_inv2_allocation_receipt_created_on_budget_acceptance ... ok
test manager::tests::test_inv5_chain_walkable_after_close ... ok
test manager::tests::test_delegation_max_depth_enforced ... ok
test manager::tests::test_inv2_no_allocation_receipt_for_text_proposal ... ok
test manager::tests::unlink_activity_not_linked_returns_false ... ok
test registry::models::tests::test_decision_filter_matches ... ok
test manager::tests::unlink_activity_from_program_both_sides_cleared ... ok
test manager::tests::unlink_clears_reverse_only_legacy_link ... ok
test registry::models::tests::test_decision_entry_serialization ... ok
test registry::models::tests::test_decision_status_default ... ok
test manager::tests::test_inv6_duplicate_vote_rejected ... ok
test registry::store::tests::test_registry_add_and_get_meeting ... ok
test registry::store::tests::test_registry_clear ... ok
test registry::store::tests::test_registry_counts ... ok
test manager::sled_program_store_tests::program_save_and_get_roundtrip ... ok
test registry::store::tests::test_registry_get_nonexistent ... ok
test registry::store::tests::test_registry_index_decision_upsert ... ok
test registry::store::tests::test_registry_list_decisions_with_filter ... ok
test registry::store::tests::test_registry_index_and_get_decision ... ok
test registry::store::tests::test_registry_duplicate_meeting_error ... ok
test registry::store::tests::test_registry_decision_with_meeting_association ... ok
test registry::store::tests::test_registry_list_meetings_by_coop ... ok
test manager::sled_program_store_tests::program_stale_scope_index_cleaned_on_update ... ok
test registry::models::tests::test_meeting_serialization ... ok
test registry::tests::test_registry_module_loads ... ok
test tests::test_pilot_proposal_uses_effect_subscription_even_with_legacy_env_flag ... ok
test tests::forced_accept_emits_canonical_governance_decision_hash_not_content_hash ... ok
test tests::test_unsupported_accepted_payload_emits_classified_noop ... ok
test manager::tests::digest_overdue_item_appears_for_assignee ... ok
test manager::tests::sled_action_items_list_by_assignee_across_domains ... ok
test manager::sled_program_store_tests::program_list_by_domain_sorted_newest_first ... ok
test manager::sled_program_store_tests::program_list_by_domain_rejects_prefix_collisions ... ok
test manager::tests::sled_action_items_assignee_index_cleaned_on_delete ... ok
test manager::tests::digest_overdue_excludes_completed_item ... ok
test manager::tests::sled_action_items_assignee_index_updated_on_reassign ... ok
test manager::tests::sled_action_items_list_by_assignee_colon_domain_id ... ok

test result: ok. 201 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.10s (201 passed)

## Scope discipline

- Added one by-grantee secondary index (existing access patterns were insufficient:  carries  only, no decision hash). Uses the ADR-0014 length-prefix scheme — no raw colon keys.
- Did **not** add executor gating, did not re-open ADR-0014, did not touch mandate-side indexes, did not widen into unrelated SDIS work.
- No toolchain or unrelated clippy changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)