### PR TITLE
feat(website): sharpen public messaging and reality anchors

### DIFF
--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import '../styles/global.css';
 import ThemeToggle from '../components/ThemeToggle.astro';
 

--- a/website/src/pages/community.astro
+++ b/website/src/pages/community.astro
@@ -9,8 +9,12 @@ import stats from '../data/stats.json';
     <div class="container">
       <div class="section-header" style="text-align: left; max-width: none;">
         <span class="badge badge-purple">Community</span>
-        <h1>Join the Cooperative Movement</h1>
-        <p>ICN is built by and for cooperatives. Code, documentation, use cases, governance patterns, or just showing up and telling us what you need. Every contribution shapes what this becomes.</p>
+        <h1>Follow the work, contribute to it, or bring a real institutional use case.</h1>
+        <p>
+          ICN is built in the open. This is the page for readers who want to track the repository,
+          contribute code or documentation, or bring concrete cooperative, community, and federation needs into the work.
+          Repository counts below are generated from the repo at build time.
+        </p>
       </div>
 
       <div class="grid grid-3">

--- a/website/src/pages/for-cooperatives.astro
+++ b/website/src/pages/for-cooperatives.astro
@@ -10,26 +10,25 @@ import ReadingLadder from '../components/ReadingLadder.astro';
     <div class="container narrow">
       <div class="page-hero">
         <span class="badge badge-amber">For Cooperatives</span>
-        <h1>ICN is being built for the kind of institution that has to hold itself together with people, memory, and care.</h1>
+        <h1>ICN is intended as institutional infrastructure for cooperatives and cooperative networks.</h1>
         <p class="lead">
-          If you run a cooperative, a community organization, or a federation,
-          you already know the shape of the problem. ICN should be understood as an attempt
-          to build an institutional layer equal to the legal, economic, and governance responsibilities your organization already carries.
+          For cooperatives, the point is not software novelty. It is to reduce dependence on generic tools
+          and give governance, obligations, records, and federation a more reliable technical foundation.
         </p>
       </div>
 
       <div class="truth-grid truth-grid-2">
         <div class="truth-note truth-note-teal">
           <span class="truth-note-label">Partner value</span>
-          <h3>Greater continuity, legibility, and interoperability</h3>
+          <h3>Continuity, accountability, and interoperability</h3>
           <p>
-            The value is not just better tooling. It is stronger institutional memory,
+            The value is not only better tooling. It is stronger institutional memory,
             more credible governance records, and better coordination across cooperative relationships.
           </p>
         </div>
         <div class="truth-note truth-note-amber">
           <span class="truth-note-label">Strategic direction</span>
-          <h3>Shared infrastructure for the cooperative sector</h3>
+          <h3>Built with institutions, not sold to them as tenants</h3>
           <p>
             The larger goal is infrastructure that the movement can use, govern, and improve collectively
             rather than license indefinitely from outside vendors.
@@ -62,8 +61,8 @@ import ReadingLadder from '../components/ReadingLadder.astro';
       <h2>Why generic software is not enough</h2>
       <p>
         The underlying problem is that none of those tools model the institution itself.
-        They do not know what a member is, in the sense that matters to a cooperative.
-        They do not know what a rule is, in the sense that should bind practice.
+        They do not know what a member is in the sense that matters to a cooperative.
+        They do not know what a rule is in the sense that should bind practice.
         They do not know what it means for a decision to authorize an action.
         Integrating them only spreads the gap more evenly.
       </p>

--- a/website/src/pages/for-cooperatives.astro
+++ b/website/src/pages/for-cooperatives.astro
@@ -20,19 +20,19 @@ import ReadingLadder from '../components/ReadingLadder.astro';
 
       <div class="truth-grid truth-grid-2">
         <div class="truth-note truth-note-teal">
-          <span class="truth-note-label">As of April 2026</span>
-          <h3>What is solid already</h3>
+          <span class="truth-note-label">What this could change</span>
+          <h3>Your institution stops living in borrowed systems</h3>
           <p>
-            The clearest strength today is institutional memory: standing, governance records,
-            receipts, and provenance that stay attached to the actions they authorize.
+            Governance, records, obligations, and federation no longer have to be scattered across tools
+            built for firms, vendors, or administrative convenience.
           </p>
         </div>
         <div class="truth-note truth-note-amber">
-          <span class="truth-note-label">How to approach it now</span>
-          <h3>Better for collaboration than rollout</h3>
+          <span class="truth-note-label">What it aims to become</span>
+          <h3>A cooperative stack the movement can actually own</h3>
           <p>
-            Right now ICN fits best as something to follow closely, shape with us,
-            or adopt with engineering help. The member-facing product surface is still the roughest part.
+            The point is not to make cooperatives better tenants of the platform economy.
+            The point is to give them infrastructure worthy of democratic ownership.
           </p>
         </div>
       </div>

--- a/website/src/pages/for-cooperatives.astro
+++ b/website/src/pages/for-cooperatives.astro
@@ -17,6 +17,26 @@ import ReadingLadder from '../components/ReadingLadder.astro';
           It is here to explain what ICN is trying to do for you — and what it is not yet ready to do.
         </p>
       </div>
+
+      <div class="truth-grid truth-grid-2">
+        <div class="truth-note truth-note-teal">
+          <span class="truth-note-label">Reviewed 2026-04-21</span>
+          <h3>What a cooperative can count on today</h3>
+          <p>
+            The strongest promise is better institutional memory: standing, governance records, receipts, and provenance
+            that stay attached to the actions they authorize. The recent codebase has also widened real governance primitives
+            around meetings, structures, notifications, and decision-to-action links.
+          </p>
+        </div>
+        <div class="truth-note truth-note-amber">
+          <span class="truth-note-label">Best fit right now</span>
+          <h3>Observation or close collaboration, not turnkey rollout</h3>
+          <p>
+            The honest current relationship is usually observation, design collaboration, or engineering-backed early adoption.
+            The member-facing product surface is still the part a real cooperative would feel as unfinished.
+          </p>
+        </div>
+      </div>
     </div>
   </section>
 

--- a/website/src/pages/for-cooperatives.astro
+++ b/website/src/pages/for-cooperatives.astro
@@ -10,7 +10,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
     <div class="container narrow">
       <div class="page-hero">
         <span class="badge badge-amber">For Cooperatives</span>
-        <h1>ICN is intended as institutional infrastructure for cooperatives and cooperative networks.</h1>
+        <h1>ICN is institutional infrastructure for cooperatives and cooperative networks.</h1>
         <p class="lead">
           For cooperatives, the point is not software novelty. It is to reduce dependence on generic tools
           and give governance, obligations, records, and federation a more reliable technical foundation.
@@ -145,7 +145,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
       </p>
       <p>
         What we would ask you not to do is treat ICN as a SaaS product to pilot next quarter.
-        That is not the current shape of the project.
+        That is not where the work stands today.
       </p>
 
       <h2>This is about enhancing human institutions, not automating them away</h2>

--- a/website/src/pages/for-cooperatives.astro
+++ b/website/src/pages/for-cooperatives.astro
@@ -51,6 +51,11 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         Execution depends on whoever remembered what they were supposed to do.
       </p>
       <p>
+        Concretely, that often means Google Workspace or Microsoft 365 for documents and internal records,
+        Loomio for voting, QuickBooks for accounting, Slack or Teams for day-to-day coordination,
+        and some combination of CRM, Airtable, or spreadsheets for membership and standing.
+      </p>
+      <p>
         Each of these tools, in isolation, can be made to work. Together, they produce drift.
         Decisions do not reliably become action. Rules do not reliably bind practice.
         Accountability decays into trust in the specific people holding the pieces together in their heads.
@@ -65,6 +70,11 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         They do not know what a rule is in the sense that should bind practice.
         They do not know what it means for a decision to authorize an action.
         Integrating them only spreads the gap more evenly.
+      </p>
+      <p>
+        This also means ICN should not be understood as a one-for-one clone of Google, Microsoft, Slack, QuickBooks, or Loomio.
+        The aim is deeper than substitution at the app layer. It is to give the cooperative its own institutional substrate,
+        so those functions no longer depend on a bundle of external systems held together by staff discipline.
       </p>
 
       <h2>What changes when the institutional loop is closed</h2>

--- a/website/src/pages/for-cooperatives.astro
+++ b/website/src/pages/for-cooperatives.astro
@@ -13,26 +13,26 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         <h1>ICN is being built for the kind of institution that has to hold itself together with people, memory, and care.</h1>
         <p class="lead">
           If you run a cooperative, a community organization, or a federation,
-          you already know the shape of the problem. This page is not here to explain cooperatives to you.
-          It is here to explain what ICN is trying to do for you — and what it is not yet ready to do.
+          you already know the shape of the problem. ICN should be understood as an attempt
+          to build an institutional layer equal to the legal, economic, and governance responsibilities your organization already carries.
         </p>
       </div>
 
       <div class="truth-grid truth-grid-2">
         <div class="truth-note truth-note-teal">
-          <span class="truth-note-label">What this could change</span>
-          <h3>Your institution stops living in borrowed systems</h3>
+          <span class="truth-note-label">Partner value</span>
+          <h3>Greater continuity, legibility, and interoperability</h3>
           <p>
-            Governance, records, obligations, and federation no longer have to be scattered across tools
-            built for firms, vendors, or administrative convenience.
+            The value is not just better tooling. It is stronger institutional memory,
+            more credible governance records, and better coordination across cooperative relationships.
           </p>
         </div>
         <div class="truth-note truth-note-amber">
-          <span class="truth-note-label">What it aims to become</span>
-          <h3>A cooperative stack the movement can actually own</h3>
+          <span class="truth-note-label">Strategic direction</span>
+          <h3>Shared infrastructure for the cooperative sector</h3>
           <p>
-            The point is not to make cooperatives better tenants of the platform economy.
-            The point is to give them infrastructure worthy of democratic ownership.
+            The larger goal is infrastructure that the movement can use, govern, and improve collectively
+            rather than license indefinitely from outside vendors.
           </p>
         </div>
       </div>

--- a/website/src/pages/for-cooperatives.astro
+++ b/website/src/pages/for-cooperatives.astro
@@ -38,7 +38,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
     </div>
   </section>
 
-  <section class="section-alt">
+  <section class="section-alt section-pre-ladder">
     <div class="container narrow prose">
       <h2>The institutional problem you actually face</h2>
       <p>
@@ -162,7 +162,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
     </div>
   </section>
 
-  <section class="section">
+  <section class="section section-ladder">
     <div class="container narrow">
       <ReadingLadder current="for-cooperatives">
         <Fragment slot="extras">

--- a/website/src/pages/for-cooperatives.astro
+++ b/website/src/pages/for-cooperatives.astro
@@ -20,20 +20,19 @@ import ReadingLadder from '../components/ReadingLadder.astro';
 
       <div class="truth-grid truth-grid-2">
         <div class="truth-note truth-note-teal">
-          <span class="truth-note-label">Reviewed 2026-04-21</span>
-          <h3>What a cooperative can count on today</h3>
+          <span class="truth-note-label">As of April 2026</span>
+          <h3>What is solid already</h3>
           <p>
-            The strongest promise is better institutional memory: standing, governance records, receipts, and provenance
-            that stay attached to the actions they authorize. The recent codebase has also widened real governance primitives
-            around meetings, structures, notifications, and decision-to-action links.
+            The clearest strength today is institutional memory: standing, governance records,
+            receipts, and provenance that stay attached to the actions they authorize.
           </p>
         </div>
         <div class="truth-note truth-note-amber">
-          <span class="truth-note-label">Best fit right now</span>
-          <h3>Observation or close collaboration, not turnkey rollout</h3>
+          <span class="truth-note-label">How to approach it now</span>
+          <h3>Better for collaboration than rollout</h3>
           <p>
-            The honest current relationship is usually observation, design collaboration, or engineering-backed early adoption.
-            The member-facing product surface is still the part a real cooperative would feel as unfinished.
+            Right now ICN fits best as something to follow closely, shape with us,
+            or adopt with engineering help. The member-facing product surface is still the roughest part.
           </p>
         </div>
       </div>

--- a/website/src/pages/for-developers.astro
+++ b/website/src/pages/for-developers.astro
@@ -20,19 +20,19 @@ import ReadingLadder from '../components/ReadingLadder.astro';
 
       <div class="truth-grid truth-grid-2">
         <div class="truth-note truth-note-teal">
-          <span class="truth-note-label">Start here</span>
-          <h3>Best place to begin in the code</h3>
+          <span class="truth-note-label">Why build here</span>
+          <h3>Infrastructure for democratic institutions, not another SaaS</h3>
           <p>
-            Start with governance, provenance, gateway surfaces, and the kernel/app boundary.
-            That is where the system is easiest to evaluate on its own terms.
+            ICN is trying to become the substrate democratic organizations can rely on the way firms rely on ERP systems,
+            cloud platforms, and payment rails today, except without surrendering ownership or governance.
           </p>
         </div>
         <div class="truth-note truth-note-amber">
-          <span class="truth-note-label">Also true</span>
-          <h3>The repo is ahead of the website</h3>
+          <span class="truth-note-label">What kind of system this wants to be</span>
+          <h3>A shared public utility for institutional coordination</h3>
           <p>
-            Federation, commons/compute, and adjacent economic semantics go deeper in the codebase
-            than they do on the public site. The member-facing and documentation surfaces still lag.
+            The long game is not a winner-take-all platform. It is shared digital infrastructure
+            that many organizations can run, extend, and govern without being captured by a landlord.
           </p>
         </div>
       </div>

--- a/website/src/pages/for-developers.astro
+++ b/website/src/pages/for-developers.astro
@@ -39,7 +39,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
     </div>
   </section>
 
-  <section class="section-alt">
+  <section class="section-alt section-pre-ladder">
     <div class="container narrow prose">
       <h2>Why ICN may be interesting to technical readers</h2>
       <ul>
@@ -161,7 +161,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
     </div>
   </section>
 
-  <section class="section">
+  <section class="section section-ladder">
     <div class="container narrow">
       <ReadingLadder current="for-developers">
         <Fragment slot="extras">

--- a/website/src/pages/for-developers.astro
+++ b/website/src/pages/for-developers.astro
@@ -20,19 +20,19 @@ import ReadingLadder from '../components/ReadingLadder.astro';
 
       <div class="truth-grid truth-grid-2">
         <div class="truth-note truth-note-teal">
-          <span class="truth-note-label">Reviewed 2026-04-21</span>
-          <h3>Best read path in the current repo</h3>
+          <span class="truth-note-label">Start here</span>
+          <h3>Best place to begin in the code</h3>
           <p>
-            If you want the most grounded first impression, start with governance, provenance, gateway surfaces,
-            and the kernel/app boundary. That is where the implementation is most integrated and easiest to evaluate honestly.
+            Start with governance, provenance, gateway surfaces, and the kernel/app boundary.
+            That is where the system is easiest to evaluate on its own terms.
           </p>
         </div>
         <div class="truth-note truth-note-amber">
-          <span class="truth-note-label">Reality check</span>
-          <h3>Where the code is ahead of the public surface</h3>
+          <span class="truth-note-label">Also true</span>
+          <h3>The repo is ahead of the website</h3>
           <p>
-            Federation, commons/compute, and adjacent economic semantics have serious implementation behind them, but the member-facing
-            and public-documentation surfaces still lag. The repo is stronger than the marketing surface, and the site should say so.
+            Federation, commons/compute, and adjacent economic semantics go deeper in the codebase
+            than they do on the public site. The member-facing and documentation surfaces still lag.
           </p>
         </div>
       </div>
@@ -75,7 +75,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
       <ul>
         <li><strong>The meaning firewall.</strong> Kernel crates enforce constraints; app crates supply meaning. The kernel is not allowed to understand what a "trust score" or a "cooperative" is. The boundary is enforced in the crate graph itself, not as a design aspiration.</li>
         <li><strong>Policy oracles.</strong> An app that implements the <code>PolicyOracle</code> interface is the bridge between domain semantics and kernel enforcement. The trust oracle is the canonical example.</li>
-        <li><strong>The governance executor.</strong> A kernel-dispatch bridge between accepted governance payloads and the subsystems that carry them into operational effect. Widening the set of payload types it dispatches is the active frontier of the project.</li>
+        <li><strong>The governance executor.</strong> A kernel-dispatch bridge between accepted governance payloads and the subsystems that carry them into operational effect. Expanding the set of payload types it dispatches is one of the main areas of active work.</li>
         <li><strong>Scopes as first-class institutions.</strong> A member, a cooperative, a community, a federation, and a commons are each modeled as a distinct scope. Each has its own crate in the workspace.</li>
         <li><strong>Actors and supervision.</strong> The runtime is built around long-lived actors managed by a supervisor, communicating through message passing.</li>
         <li><strong>Trust-gated rate limiting and placement.</strong> Trust class affects message rate limits, credit relationships, and task placement. Trust is native, not trustless.</li>

--- a/website/src/pages/for-developers.astro
+++ b/website/src/pages/for-developers.astro
@@ -17,6 +17,25 @@ import ReadingLadder from '../components/ReadingLadder.astro';
           ICN is neither. This page is where the public narrative meets the implementation.
         </p>
       </div>
+
+      <div class="truth-grid truth-grid-2">
+        <div class="truth-note truth-note-teal">
+          <span class="truth-note-label">Reviewed 2026-04-21</span>
+          <h3>Best read path in the current repo</h3>
+          <p>
+            If you want the most grounded first impression, start with governance, provenance, gateway surfaces,
+            and the kernel/app boundary. That is where the implementation is most integrated and easiest to evaluate honestly.
+          </p>
+        </div>
+        <div class="truth-note truth-note-amber">
+          <span class="truth-note-label">Reality check</span>
+          <h3>Where the code is ahead of the public surface</h3>
+          <p>
+            Federation, commons/compute, and adjacent economic semantics have serious implementation behind them, but the member-facing
+            and public-documentation surfaces still lag. The repo is stronger than the marketing surface, and the site should say so.
+          </p>
+        </div>
+      </div>
     </div>
   </section>
 
@@ -109,8 +128,8 @@ import ReadingLadder from '../components/ReadingLadder.astro';
       <p>
         The main monorepo is at
         <a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener">InterCooperative-Network/icn</a>.
-        It is a Cargo workspace with crates in <code>icn/crates/</code> and apps in <code>icn/apps/</code>,
-        binaries in <code>icn/bins/</code>.
+        The Rust workspace lives under <code>icn/</code> inside the repo, with crates in <code>icn/crates/</code>,
+        apps in <code>icn/apps/</code>, and binaries in <code>icn/bins/</code>.
       </p>
       <p>A reasonable reading order for someone new:</p>
       <ol>

--- a/website/src/pages/how-it-works.astro
+++ b/website/src/pages/how-it-works.astro
@@ -20,6 +20,25 @@ import ReadingLadder from '../components/ReadingLadder.astro';
           ICN is built on the premise that this fragmentation is not a fact of nature.
         </p>
       </div>
+
+      <div class="truth-grid truth-grid-2">
+        <div class="truth-note truth-note-teal">
+          <span class="truth-note-label">Working spine</span>
+          <h3>Where the implementation is already load-bearing</h3>
+          <p>
+            Identity, governance records, provenance, and the decision-to-outcome chain are the strongest integrated surfaces today.
+            They are the backbone this page is describing, not speculative future architecture.
+          </p>
+        </div>
+        <div class="truth-note truth-note-amber">
+          <span class="truth-note-label">Current frontier</span>
+          <h3>Where the page describes active work</h3>
+          <p>
+            Policy binding practice, wider execution coverage, and the member-facing APIs remain the places where the substrate
+            is ahead of the public surface. Federation and commons are real, but still under-explained externally.
+          </p>
+        </div>
+      </div>
     </div>
   </section>
 

--- a/website/src/pages/how-it-works.astro
+++ b/website/src/pages/how-it-works.astro
@@ -23,19 +23,19 @@ import ReadingLadder from '../components/ReadingLadder.astro';
 
       <div class="truth-grid truth-grid-2">
         <div class="truth-note truth-note-teal">
-          <span class="truth-note-label">Strongest today</span>
-          <h3>The core loop is real</h3>
+          <span class="truth-note-label">What it is trying to hold together</span>
+          <h3>Decision, action, and proof in one place</h3>
           <p>
-            Identity, governance records, provenance, and the decision-to-outcome chain
-            are already doing real work in the system.
+            ICN is meant to keep membership, governance, economic life, execution, and institutional memory
+            from fragmenting across separate tools and separate authorities.
           </p>
         </div>
         <div class="truth-note truth-note-amber">
-          <span class="truth-note-label">Still catching up</span>
-          <h3>The rough edges are still real</h3>
+          <span class="truth-note-label">What success would feel like</span>
+          <h3>Your institution becomes legible to itself</h3>
           <p>
-            Policy binding practice, broader execution coverage, and the member-facing APIs
-            still need more work. Federation and commons are real too, but the public explanation lags the implementation.
+            A member should be able to see what was decided, why it was legitimate, what happened next,
+            and how that connects to the wider network their institution belongs to.
           </p>
         </div>
       </div>

--- a/website/src/pages/how-it-works.astro
+++ b/website/src/pages/how-it-works.astro
@@ -23,19 +23,19 @@ import ReadingLadder from '../components/ReadingLadder.astro';
 
       <div class="truth-grid truth-grid-2">
         <div class="truth-note truth-note-teal">
-          <span class="truth-note-label">Working spine</span>
-          <h3>Where the implementation is already load-bearing</h3>
+          <span class="truth-note-label">Strongest today</span>
+          <h3>The core loop is real</h3>
           <p>
-            Identity, governance records, provenance, and the decision-to-outcome chain are the strongest integrated surfaces today.
-            They are the backbone this page is describing, not speculative future architecture.
+            Identity, governance records, provenance, and the decision-to-outcome chain
+            are already doing real work in the system.
           </p>
         </div>
         <div class="truth-note truth-note-amber">
-          <span class="truth-note-label">Current frontier</span>
-          <h3>Where the page describes active work</h3>
+          <span class="truth-note-label">Still catching up</span>
+          <h3>The rough edges are still real</h3>
           <p>
-            Policy binding practice, wider execution coverage, and the member-facing APIs remain the places where the substrate
-            is ahead of the public surface. Federation and commons are real, but still under-explained externally.
+            Policy binding practice, broader execution coverage, and the member-facing APIs
+            still need more work. Federation and commons are real too, but the public explanation lags the implementation.
           </p>
         </div>
       </div>

--- a/website/src/pages/how-it-works.astro
+++ b/website/src/pages/how-it-works.astro
@@ -42,7 +42,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
     </div>
   </section>
 
-  <section class="section-alt">
+  <section class="section-alt section-pre-ladder">
     <div class="container narrow prose">
       <p>
         The same institution can hold membership, governance, shared rules, economic coordination,
@@ -252,7 +252,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
     </div>
   </section>
 
-  <section class="section">
+  <section class="section section-ladder">
     <div class="container narrow">
       <ReadingLadder current="how-it-works" />
     </div>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -24,7 +24,7 @@ import MaturityCard from '../components/MaturityCard.astro';
           </h1>
 
           <p>
-            ICN makes membership, governance, shared rules, economic coordination,
+            ICN, the Intercooperative Network, makes membership, governance, shared rules, economic coordination,
             and institutional accountability native to the system itself —
             so decisions, action, and proof do not have to live in separate worlds.
           </p>
@@ -37,19 +37,20 @@ import MaturityCard from '../components/MaturityCard.astro';
             <a href="/how-it-works" class="btn btn-secondary">How It Works</a>
             <a href="/whats-real-now" class="btn btn-ghost">What's Real Now</a>
           </div>
-          <p class="hero-qualifier">Under active construction. This site is explicit about what is proven, what is advancing, and what is not yet built.</p>
+          <p class="hero-qualifier">Built in the open. Strongest today: provenance, governance records, and auditability. Still catching up: broader execution and the member-facing product surface.</p>
         </div>
 
         <aside class="hero-panel animate-in animate-delay-2" aria-label="At a glance">
           <div class="hero-panel-head">
             <span class="eyebrow">At a glance</span>
-            <h2>Public infrastructure, explained without hype.</h2>
+            <h2>Public infrastructure, without the pitch.</h2>
             <p>
-              The site is designed to make three things legible right away:
-              what ICN is for, what is already real, and what still needs building.
+              Start here if you want the shape of the project, what already works,
+              and what still needs work.
             </p>
             <p class="hero-panel-meta">
-              Reviewed against repo state on April 21, 2026. The strongest public through-line is still provenance and auditable coordination; active work is concentrated on widening execution coverage and tightening governance-to-economics proof.
+              As of April 21, 2026, the strongest parts of ICN are provenance, governance records,
+              and auditable coordination. Broader execution coverage and member-facing surfaces are still catching up.
             </p>
           </div>
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -43,7 +43,7 @@ import MaturityCard from '../components/MaturityCard.astro';
         <aside class="hero-panel animate-in animate-delay-2" aria-label="At a glance">
           <div class="hero-panel-head">
             <span class="eyebrow">At a glance</span>
-            <h2>What the project is intended to provide.</h2>
+            <h2>The institutional proposition.</h2>
             <p>
               ICN addresses a structural gap in the current cooperative software stack:
               governance, records, obligations, and federation are usually carried across systems that were never designed to hold institutional authority together.

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -15,7 +15,7 @@ import MaturityCard from '../components/MaturityCard.astro';
         <div class="hero-content animate-in">
           <div class="badge badge-teal mb-lg">
             <span class="badge-dot"></span>
-            Active project · open infrastructure
+            Open infrastructure effort
           </div>
 
           <h1>
@@ -40,16 +40,16 @@ import MaturityCard from '../components/MaturityCard.astro';
           <p class="hero-qualifier">For partners interested in durable institutional capacity, not another disconnected software tool.</p>
         </div>
 
-        <aside class="hero-panel animate-in animate-delay-2" aria-label="At a glance">
+        <aside class="hero-panel animate-in animate-delay-2" aria-label="Summary">
           <div class="hero-panel-head">
-            <span class="eyebrow">At a glance</span>
+            <span class="eyebrow">Summary</span>
             <h2>The institutional proposition.</h2>
             <p>
               ICN addresses a structural gap in the current cooperative software stack:
               governance, records, obligations, and federation are usually carried across systems that were never designed to hold institutional authority together.
             </p>
             <p class="hero-panel-meta">
-              The long-term aim is sector-governable infrastructure that democratic organizations can rely on together rather than rent indefinitely from outside vendors.
+              ICN is being designed as sector-governable infrastructure that democratic organizations can rely on together rather than rent indefinitely from outside vendors.
             </p>
           </div>
 
@@ -109,10 +109,10 @@ import MaturityCard from '../components/MaturityCard.astro';
   <section class="section-alt">
     <div class="container">
       <div class="section-header">
-        <span class="badge badge-teal">What ICN Does</span>
-        <h2>Provides an institutional infrastructure layer.</h2>
+        <span class="badge badge-teal">Core Capabilities</span>
+        <h2>An infrastructure layer for governance, records, and coordination.</h2>
         <p>
-          ICN is intended to provide the layer where membership, governance, economic coordination,
+          ICN provides the layer where membership, governance, economic coordination,
           execution, and institutional memory remain connected instead of being split across unrelated systems.
         </p>
       </div>
@@ -214,10 +214,9 @@ import MaturityCard from '../components/MaturityCard.astro';
     <div class="container narrow">
       <div class="section-header section-header-left">
         <span class="badge badge-green">What's Real Now</span>
-        <h2>Uneven, but real.</h2>
+        <h2>Current maturity.</h2>
         <p>
-          ICN is an active infrastructure project. Different parts of the system are at different
-          levels of maturity, and this section says so plainly.
+          Different parts of ICN are at different levels of maturity. This section states those differences plainly.
         </p>
       </div>
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -24,9 +24,9 @@ import MaturityCard from '../components/MaturityCard.astro';
           </h1>
 
           <p>
-            ICN, the Intercooperative Network, is being built so democratic organizations can
-            prove their decisions, own the infrastructure they depend on, and coordinate across boundaries
-            without surrendering themselves to a platform.
+            ICN, the Intercooperative Network, is a digital infrastructure project for democratic organizations.
+            It is designed to support verifiable governance, institution-controlled records, and coordination
+            across organizational boundaries without dependence on a central platform.
           </p>
 
           <div class="hero-actions">
@@ -37,35 +37,35 @@ import MaturityCard from '../components/MaturityCard.astro';
             <a href="/how-it-works" class="btn btn-secondary">How It Works</a>
             <a href="/whats-real-now" class="btn btn-ghost">What's Real Now</a>
           </div>
-          <p class="hero-qualifier">A digital foundation for the democratic economy: prove decisions, own records, coordinate with neighbors.</p>
+          <p class="hero-qualifier">For institutions that need legitimacy, autonomy, and reliable coordination at network scale.</p>
         </div>
 
         <aside class="hero-panel animate-in animate-delay-2" aria-label="At a glance">
           <div class="hero-panel-head">
             <span class="eyebrow">At a glance</span>
-            <h2>What ICN is trying to make possible.</h2>
+            <h2>A coordination layer for democratic institutions.</h2>
             <p>
-              A cooperative, a land trust, a mutual aid network, or a federation
-              should be able to run on infrastructure it actually owns.
+              ICN addresses a practical gap in the current cooperative stack:
+              governance, records, obligations, and federation are usually spread across systems that were never designed to work together.
             </p>
             <p class="hero-panel-meta">
-              If ICN succeeds, democratic organizations will no longer have to choose between
-              legitimacy, autonomy, and coordination.
+              The long-term aim is shared infrastructure that democratic organizations can govern, extend,
+              and rely on together rather than rent from outside platforms.
             </p>
           </div>
 
           <div class="hero-panel-list">
             <article class="hero-panel-item">
-              <span class="hero-panel-kicker">Prove decisions</span>
-              <p>Turn votes, approvals, and institutional actions into records other people can verify.</p>
+              <span class="hero-panel-kicker">Verifiable governance</span>
+              <p>Create governance records and receipts that partners, funders, and members can independently verify.</p>
             </article>
             <article class="hero-panel-item">
-              <span class="hero-panel-kicker">Own infrastructure</span>
-              <p>Keep identity, records, and governance on systems your institution controls.</p>
+              <span class="hero-panel-kicker">Institutional sovereignty</span>
+              <p>Keep identity, records, and core institutional processes on infrastructure your organization controls.</p>
             </article>
             <article class="hero-panel-item">
-              <span class="hero-panel-kicker">Coordinate without surrender</span>
-              <p>Work with other organizations without handing everyone over to the same platform landlord.</p>
+              <span class="hero-panel-kicker">Federated coordination</span>
+              <p>Work with partner organizations through shared protocols rather than through a single vendor platform.</p>
             </article>
           </div>
 
@@ -99,10 +99,8 @@ import MaturityCard from '../components/MaturityCard.astro';
           Accountability decays into trust in individual people instead of trust in the institution.
         </p>
         <p>
-          Underneath all of this sits a deeper problem: most of the systems we depend on
-          do not answer to the people who live inside them. They answer to ownership, management,
-          capital, or centralized administration. Democratic institutions are forced to operate
-          through software that fights the way they are supposed to work.
+          Beneath the operational friction is a structural issue: democratic institutions are still
+          expected to rely on digital systems controlled by outside owners, outside incentives, and outside priorities.
         </p>
       </div>
     </div>
@@ -115,9 +113,8 @@ import MaturityCard from '../components/MaturityCard.astro';
         <span class="badge badge-teal">What ICN Does</span>
         <h2>Closes the institutional loop.</h2>
         <p>
-          ICN is not a management tool layered on top of a generic platform.
-          It is a substrate where the pieces of institutional life hold together
-          as stations of one coherent loop.
+          ICN is intended to provide the missing institutional layer:
+          the place where membership, governance, economic coordination, execution, and institutional memory can remain connected.
         </p>
       </div>
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -24,9 +24,9 @@ import MaturityCard from '../components/MaturityCard.astro';
           </h1>
 
           <p>
-            ICN, the Intercooperative Network, makes membership, governance, shared rules, economic coordination,
-            and institutional accountability native to the system itself —
-            so decisions, action, and proof do not have to live in separate worlds.
+            ICN, the Intercooperative Network, is being built so democratic organizations can
+            prove their decisions, own the infrastructure they depend on, and coordinate across boundaries
+            without surrendering themselves to a platform.
           </p>
 
           <div class="hero-actions">
@@ -37,35 +37,35 @@ import MaturityCard from '../components/MaturityCard.astro';
             <a href="/how-it-works" class="btn btn-secondary">How It Works</a>
             <a href="/whats-real-now" class="btn btn-ghost">What's Real Now</a>
           </div>
-          <p class="hero-qualifier">Built in the open. Strongest today: provenance, governance records, and auditability. Still catching up: broader execution and the member-facing product surface.</p>
+          <p class="hero-qualifier">A digital foundation for the democratic economy: prove decisions, own records, coordinate with neighbors.</p>
         </div>
 
         <aside class="hero-panel animate-in animate-delay-2" aria-label="At a glance">
           <div class="hero-panel-head">
             <span class="eyebrow">At a glance</span>
-            <h2>Public infrastructure, without the pitch.</h2>
+            <h2>What ICN is trying to make possible.</h2>
             <p>
-              Start here if you want the shape of the project, what already works,
-              and what still needs work.
+              A cooperative, a land trust, a mutual aid network, or a federation
+              should be able to run on infrastructure it actually owns.
             </p>
             <p class="hero-panel-meta">
-              As of April 21, 2026, the strongest parts of ICN are provenance, governance records,
-              and auditable coordination. Broader execution coverage and member-facing surfaces are still catching up.
+              If ICN succeeds, democratic organizations will no longer have to choose between
+              legitimacy, autonomy, and coordination.
             </p>
           </div>
 
           <div class="hero-panel-list">
             <article class="hero-panel-item">
-              <span class="hero-panel-kicker">Scope and standing</span>
-              <p>Who is acting, in what institution, with what recognized place in the system.</p>
+              <span class="hero-panel-kicker">Prove decisions</span>
+              <p>Turn votes, approvals, and institutional actions into records other people can verify.</p>
             </article>
             <article class="hero-panel-item">
-              <span class="hero-panel-kicker">Decision to effect</span>
-              <p>Where governance already carries into operational consequences and where the coverage is still expanding.</p>
+              <span class="hero-panel-kicker">Own infrastructure</span>
+              <p>Keep identity, records, and governance on systems your institution controls.</p>
             </article>
             <article class="hero-panel-item">
-              <span class="hero-panel-kicker">Proof and memory</span>
-              <p>How receipts, provenance, and institutional history stay attached to the actions they authorize.</p>
+              <span class="hero-panel-kicker">Coordinate without surrender</span>
+              <p>Work with other organizations without handing everyone over to the same platform landlord.</p>
             </article>
           </div>
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -93,6 +93,11 @@ import MaturityCard from '../components/MaturityCard.astro';
           what was decided. Execution depends on whoever remembered what they were supposed to do.
         </p>
         <p>
+          In practice, that often means Google Workspace or Microsoft 365 for documents and email,
+          Loomio for voting, QuickBooks for accounting, Slack or Teams for coordination,
+          and a CRM or spreadsheet standing in for membership and standing.
+        </p>
+        <p>
           Each tool is fine in isolation. Together, they produce drift.
           Decisions do not reliably become action. Rules do not reliably bind practice.
           Accountability decays into trust in individual people instead of trust in the institution.

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -10,33 +10,70 @@ import MaturityCard from '../components/MaturityCard.astro';
 
   <!-- ═══ HERO ═══════════════════════════════════════════════════ -->
   <section class="hero hero-home">
-    <div class="container narrow hero-container">
-      <div class="hero-content animate-in">
-        <div class="badge badge-teal mb-lg">
-          <span class="badge-dot"></span>
-          Active project · open infrastructure
+    <div class="container hero-container">
+      <div class="hero-shell">
+        <div class="hero-content animate-in">
+          <div class="badge badge-teal mb-lg">
+            <span class="badge-dot"></span>
+            Active project · open infrastructure
+          </div>
+
+          <h1>
+            Digital infrastructure for<br/>
+            <span class="gradient-text">cooperatives, communities, and federations.</span>
+          </h1>
+
+          <p>
+            ICN makes membership, governance, shared rules, economic coordination,
+            and institutional accountability native to the system itself —
+            so decisions, action, and proof do not have to live in separate worlds.
+          </p>
+
+          <div class="hero-actions">
+            <a href="/what-is-icn" class="btn btn-primary">
+              What is ICN
+              <svg class="btn-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"/></svg>
+            </a>
+            <a href="/how-it-works" class="btn btn-secondary">How It Works</a>
+            <a href="/whats-real-now" class="btn btn-ghost">What's Real Now</a>
+          </div>
+          <p class="hero-qualifier">Under active construction. This site is explicit about what is proven, what is advancing, and what is not yet built.</p>
         </div>
 
-        <h1>
-          Digital infrastructure for<br/>
-          <span class="gradient-text">cooperatives, communities, and federations.</span>
-        </h1>
+        <aside class="hero-panel animate-in animate-delay-2" aria-label="At a glance">
+          <div class="hero-panel-head">
+            <span class="eyebrow">At a glance</span>
+            <h2>Public infrastructure, explained without hype.</h2>
+            <p>
+              The site is designed to make three things legible right away:
+              what ICN is for, what is already real, and what still needs building.
+            </p>
+            <p class="hero-panel-meta">
+              Reviewed against repo state on April 21, 2026. The strongest public through-line is still provenance and auditable coordination; active work is concentrated on widening execution coverage and tightening governance-to-economics proof.
+            </p>
+          </div>
 
-        <p>
-          ICN makes membership, governance, shared rules, economic coordination,
-          and institutional accountability native to the system itself —
-          so decisions, action, and proof do not have to live in separate worlds.
-        </p>
+          <div class="hero-panel-list">
+            <article class="hero-panel-item">
+              <span class="hero-panel-kicker">Scope and standing</span>
+              <p>Who is acting, in what institution, with what recognized place in the system.</p>
+            </article>
+            <article class="hero-panel-item">
+              <span class="hero-panel-kicker">Decision to effect</span>
+              <p>Where governance already carries into operational consequences and where the coverage is still expanding.</p>
+            </article>
+            <article class="hero-panel-item">
+              <span class="hero-panel-kicker">Proof and memory</span>
+              <p>How receipts, provenance, and institutional history stay attached to the actions they authorize.</p>
+            </article>
+          </div>
 
-        <div class="hero-actions">
-          <a href="/what-is-icn" class="btn btn-primary">
-            What is ICN
-            <svg class="btn-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"/></svg>
-          </a>
-          <a href="/how-it-works" class="btn btn-secondary">How It Works</a>
-          <a href="/whats-real-now" class="btn btn-ghost">What's Real Now</a>
-        </div>
-        <p class="hero-qualifier">Under active construction. This site is explicit about what is proven, what is advancing, and what is not yet built.</p>
+          <div class="hero-panel-links">
+            <a href="/architecture">Architecture</a>
+            <a href="/roadmap">Roadmap</a>
+            <a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener">GitHub</a>
+          </div>
+        </aside>
       </div>
     </div>
     <div class="hero-bg-grid" aria-hidden="true"></div>
@@ -217,7 +254,7 @@ import MaturityCard from '../components/MaturityCard.astro';
       </div>
 
       <div class="grid grid-2">
-        <div class="card">
+        <div class="card card-accent-teal">
           <h3>Cooperatives, communities, and federations</h3>
           <p>
             Organizations that already know how hard running a real institution is,
@@ -227,7 +264,7 @@ import MaturityCard from '../components/MaturityCard.astro';
           </p>
           <a href="/for-cooperatives" class="link-arrow">For Cooperatives →</a>
         </div>
-        <div class="card">
+        <div class="card card-accent-amber">
           <h3>Developers, architects, and researchers</h3>
           <p>
             Technical readers evaluating ICN as a system. Kernel/app separation with a strict meaning firewall,
@@ -292,8 +329,14 @@ import MaturityCard from '../components/MaturityCard.astro';
   position: relative;
   z-index: 2;
 }
+.hero-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(320px, 0.95fr);
+  gap: var(--space-2xl);
+  align-items: start;
+}
 .hero-home .hero-content {
-  max-width: 760px;
+  max-width: 720px;
 }
 .hero-home .hero-content h1 {
   font-size: clamp(2.25rem, 5.5vw, 3.75rem);
@@ -309,6 +352,84 @@ import MaturityCard from '../components/MaturityCard.astro';
 .hero-qualifier {
   font-size: .8125rem; color: var(--text-muted);
   margin: var(--space-sm) 0 0; letter-spacing: .01em; max-width: 42em;
+}
+.hero-panel {
+  position: relative;
+  padding: var(--space-xl);
+  background:
+    linear-gradient(180deg, rgba(17, 24, 39, 0.9), rgba(11, 17, 27, 0.96));
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-2xl);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+}
+.hero-panel::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 3px;
+  background: linear-gradient(
+    90deg,
+    var(--accent-teal) 0%,
+    var(--accent-amber) 55%,
+    var(--accent-blue) 100%
+  );
+}
+.hero-panel-head h2 {
+  font-size: clamp(1.2rem, 2vw, 1.55rem);
+  margin: var(--space-sm) 0;
+}
+.hero-panel-head p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.7;
+  color: var(--text-secondary);
+}
+.hero-panel-meta {
+  margin-top: var(--space-sm) !important;
+  font-size: 0.8125rem !important;
+  line-height: 1.65 !important;
+  color: var(--text-muted) !important;
+}
+.hero-panel-list {
+  display: grid;
+  gap: var(--space-md);
+  margin-top: var(--space-xl);
+}
+.hero-panel-item {
+  padding: var(--space-md) var(--space-lg);
+  background: rgba(12, 17, 24, 0.78);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+}
+.hero-panel-kicker {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent-teal);
+  margin-bottom: var(--space-xs);
+}
+.hero-panel-item p {
+  margin: 0;
+  font-size: 0.9375rem;
+  line-height: 1.65;
+  color: var(--text-secondary);
+}
+.hero-panel-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm) var(--space-md);
+  margin-top: var(--space-lg);
+  padding-top: var(--space-lg);
+  border-top: 1px solid var(--border-subtle);
+}
+.hero-panel-links a {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  letter-spacing: 0.04em;
 }
 .badge-dot {
   width: 6px; height: 6px; border-radius: 50%;
@@ -397,12 +518,20 @@ import MaturityCard from '../components/MaturityCard.astro';
     padding-top: calc(64px + var(--space-xl));
     padding-bottom: var(--space-xl);
   }
+  .hero-shell {
+    grid-template-columns: 1fr;
+    gap: var(--space-xl);
+  }
   .hero-home .hero-content h1 {
     font-size: clamp(1.75rem, 7vw, 2.5rem);
     line-height: 1.15;
   }
   .hero-home .hero-content > p {
     font-size: 0.9375rem;
+  }
+  .hero-panel {
+    padding: var(--space-lg);
+    border-radius: var(--radius-xl);
   }
   .hero-actions .btn {
     flex: 1 1 auto;

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -19,14 +19,14 @@ import MaturityCard from '../components/MaturityCard.astro';
           </div>
 
           <h1>
-            Digital infrastructure for<br/>
+            The Intercooperative Network is infrastructure for<br/>
             <span class="gradient-text">cooperatives, communities, and federations.</span>
           </h1>
 
           <p>
-            ICN, the Intercooperative Network, is a digital infrastructure project for democratic organizations.
-            It is designed to support verifiable governance, institution-controlled records, and coordination
-            across organizational boundaries without dependence on a central platform.
+            ICN is being developed as a shared digital infrastructure layer for democratic organizations.
+            Its purpose is to let institutions prove decisions, operate on infrastructure they control,
+            and coordinate with other organizations without surrendering those functions to a platform.
           </p>
 
           <div class="hero-actions">
@@ -37,35 +37,34 @@ import MaturityCard from '../components/MaturityCard.astro';
             <a href="/how-it-works" class="btn btn-secondary">How It Works</a>
             <a href="/whats-real-now" class="btn btn-ghost">What's Real Now</a>
           </div>
-          <p class="hero-qualifier">For institutions that need legitimacy, autonomy, and reliable coordination at network scale.</p>
+          <p class="hero-qualifier">For partners interested in durable institutional capacity, not another disconnected software tool.</p>
         </div>
 
         <aside class="hero-panel animate-in animate-delay-2" aria-label="At a glance">
           <div class="hero-panel-head">
             <span class="eyebrow">At a glance</span>
-            <h2>A coordination layer for democratic institutions.</h2>
+            <h2>What the project is intended to provide.</h2>
             <p>
-              ICN addresses a practical gap in the current cooperative stack:
-              governance, records, obligations, and federation are usually spread across systems that were never designed to work together.
+              ICN addresses a structural gap in the current cooperative software stack:
+              governance, records, obligations, and federation are usually carried across systems that were never designed to hold institutional authority together.
             </p>
             <p class="hero-panel-meta">
-              The long-term aim is shared infrastructure that democratic organizations can govern, extend,
-              and rely on together rather than rent from outside platforms.
+              The long-term aim is sector-governable infrastructure that democratic organizations can rely on together rather than rent indefinitely from outside vendors.
             </p>
           </div>
 
           <div class="hero-panel-list">
             <article class="hero-panel-item">
-              <span class="hero-panel-kicker">Verifiable governance</span>
-              <p>Create governance records and receipts that partners, funders, and members can independently verify.</p>
+              <span class="hero-panel-kicker">Provable decisions</span>
+              <p>Create governance records and receipts that members, partners, and counterparties can verify independently.</p>
             </article>
             <article class="hero-panel-item">
-              <span class="hero-panel-kicker">Institutional sovereignty</span>
-              <p>Keep identity, records, and core institutional processes on infrastructure your organization controls.</p>
+              <span class="hero-panel-kicker">Institution-controlled infrastructure</span>
+              <p>Keep identity, records, and core institutional processes on infrastructure your organization can govern and operate.</p>
             </article>
             <article class="hero-panel-item">
-              <span class="hero-panel-kicker">Federated coordination</span>
-              <p>Work with partner organizations through shared protocols rather than through a single vendor platform.</p>
+              <span class="hero-panel-kicker">Cross-institutional coordination</span>
+              <p>Coordinate with partner organizations through shared protocols instead of routing cooperation through a single software landlord.</p>
             </article>
           </div>
 
@@ -85,7 +84,7 @@ import MaturityCard from '../components/MaturityCard.astro';
     <div class="container narrow">
       <div class="section-header section-header-left">
         <span class="badge badge-amber">The Problem</span>
-        <h2>Most institutions run across tools that were never designed for them.</h2>
+        <h2>Most democratic institutions still operate across software that does not model the institution itself.</h2>
       </div>
       <div class="prose-block">
         <p>
@@ -99,7 +98,7 @@ import MaturityCard from '../components/MaturityCard.astro';
           Accountability decays into trust in individual people instead of trust in the institution.
         </p>
         <p>
-          Beneath the operational friction is a structural issue: democratic institutions are still
+          Beneath the operational friction is a deeper dependency problem: democratic institutions are still
           expected to rely on digital systems controlled by outside owners, outside incentives, and outside priorities.
         </p>
       </div>
@@ -111,10 +110,10 @@ import MaturityCard from '../components/MaturityCard.astro';
     <div class="container">
       <div class="section-header">
         <span class="badge badge-teal">What ICN Does</span>
-        <h2>Closes the institutional loop.</h2>
+        <h2>Provides an institutional infrastructure layer.</h2>
         <p>
-          ICN is intended to provide the missing institutional layer:
-          the place where membership, governance, economic coordination, execution, and institutional memory can remain connected.
+          ICN is intended to provide the layer where membership, governance, economic coordination,
+          execution, and institutional memory remain connected instead of being split across unrelated systems.
         </p>
       </div>
 

--- a/website/src/pages/what-is-icn.astro
+++ b/website/src/pages/what-is-icn.astro
@@ -24,7 +24,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
           <span class="truth-note-label">Practical proposition</span>
           <h3>A shared substrate for governance, records, and coordination</h3>
           <p>
-            ICN is meant to give democratic organizations a technical foundation for identity,
+            ICN gives democratic organizations a technical foundation for identity,
             governance, rules, records, and inter-organizational coordination.
           </p>
         </div>
@@ -32,7 +32,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
           <span class="truth-note-label">Long-term direction</span>
           <h3>Sector-governable infrastructure instead of platform tenancy</h3>
           <p>
-            The long-term aim is a shared digital foundation that cooperatives, communities,
+            The direction is a shared digital foundation that cooperatives, communities,
             and federations can rely on, help govern, and improve together.
           </p>
         </div>
@@ -97,7 +97,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         <li><strong>Not a blockchain.</strong> ICN is not oriented around tokens, speculation, or trustless global consensus. It is oriented around institutions and their accountability to themselves and each other.</li>
         <li><strong>Not a DAO framework.</strong> DAOs typically treat governance as voting over a treasury. ICN treats governance as one part of a much larger institutional substrate.</li>
         <li><strong>Not a SaaS suite.</strong> ICN is not a bundle of management tools. It is the layer those tools should sit on top of.</li>
-        <li><strong>Not finished.</strong> ICN is a real, active project with uneven maturity. See <a href="/whats-real-now">What's Real Now</a> for a direct account.</li>
+        <li><strong>Not yet complete.</strong> ICN has uneven maturity today. See <a href="/whats-real-now">What's Real Now</a> for a direct account.</li>
       </ul>
 
       <h2>Why this framing matters</h2>

--- a/website/src/pages/what-is-icn.astro
+++ b/website/src/pages/what-is-icn.astro
@@ -17,6 +17,25 @@ import ReadingLadder from '../components/ReadingLadder.astro';
           so decisions, action, and proof do not have to live in separate worlds.
         </p>
       </div>
+
+      <div class="truth-grid truth-grid-2">
+        <div class="truth-note truth-note-teal">
+          <span class="truth-note-label">Reviewed 2026-04-21</span>
+          <h3>What is most concrete today</h3>
+          <p>
+            The strongest public through-line is provenance: identity, governance records, receipts, and the chain
+            from accepted decision to auditable outcome. That is the part of ICN the repo can already defend most clearly.
+          </p>
+        </div>
+        <div class="truth-note truth-note-amber">
+          <span class="truth-note-label">Still advancing</span>
+          <h3>What this page does not overclaim</h3>
+          <p>
+            Recent governance institutional primitives have landed, but execution coverage and the unified member-facing
+            surface are still catching up. This is infrastructure under active construction, not a finished product.
+          </p>
+        </div>
+      </div>
     </div>
   </section>
 

--- a/website/src/pages/what-is-icn.astro
+++ b/website/src/pages/what-is-icn.astro
@@ -13,26 +13,26 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         <span class="badge badge-teal">What is ICN</span>
         <h1>ICN is digital infrastructure for cooperatives, communities, and federations.</h1>
         <p class="lead">
-          ICN stands for the Intercooperative Network. It gives institutions a coherent substrate where membership, governance, shared rules, economic coordination, and accountability are native —
-          so decisions, action, and proof do not have to live in separate worlds.
+          ICN stands for the Intercooperative Network. It is being built so democratic organizations can prove their decisions,
+          run on infrastructure they control, and coordinate with each other without depending on a platform they do not own.
         </p>
       </div>
 
       <div class="truth-grid truth-grid-2">
         <div class="truth-note truth-note-teal">
-          <span class="truth-note-label">As of April 2026</span>
-          <h3>What is strongest today</h3>
+          <span class="truth-note-label">What it makes possible</span>
+          <h3>Prove, own, coordinate</h3>
           <p>
-            The strongest part of ICN today is provenance: identity, governance records, receipts,
-            and the chain from accepted decision to recorded outcome.
+            ICN is aimed at a simple shift: democratic institutions should be able to prove decisions,
+            own their records, and work across organizational boundaries without asking a platform for permission.
           </p>
         </div>
         <div class="truth-note truth-note-amber">
-          <span class="truth-note-label">Still being built</span>
-          <h3>What is not finished</h3>
+          <span class="truth-note-label">What it points toward</span>
+          <h3>A democratic economy on its own infrastructure</h3>
           <p>
-            Governance has moved forward, but execution coverage and the unified member-facing
-            surface are still catching up. This is real infrastructure, but it is not finished.
+            The larger ambition is not one more governance app. It is a shared digital substrate
+            that cooperatives, communities, and federations can actually inhabit and govern together.
           </p>
         </div>
       </div>

--- a/website/src/pages/what-is-icn.astro
+++ b/website/src/pages/what-is-icn.astro
@@ -56,6 +56,12 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         staff memory, and disconnected tools that were never designed to carry institutional weight.
         ICN is an attempt to provide a durable alternative.
       </p>
+      <p>
+        Today that usually means relying on systems such as Google Workspace or Microsoft 365 for records,
+        Loomio for voting, QuickBooks for accounting, Slack or Teams for coordination, and a CRM or spreadsheet
+        for membership. ICN is not trying to flatter that stack with better integrations. It is trying to reduce
+        the institution's dependence on it.
+      </p>
 
       <h2>What ICN models directly</h2>
       <p>Most software models users and accounts. ICN models institutions.</p>

--- a/website/src/pages/what-is-icn.astro
+++ b/website/src/pages/what-is-icn.astro
@@ -40,7 +40,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
     </div>
   </section>
 
-  <section class="section-alt">
+  <section class="section-alt section-pre-ladder">
     <div class="container narrow prose">
       <h2>A different kind of system</h2>
       <p>
@@ -113,7 +113,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
     </div>
   </section>
 
-  <section class="section">
+  <section class="section section-ladder">
     <div class="container narrow">
       <ReadingLadder current="what-is-icn" />
     </div>

--- a/website/src/pages/what-is-icn.astro
+++ b/website/src/pages/what-is-icn.astro
@@ -13,26 +13,26 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         <span class="badge badge-teal">What is ICN</span>
         <h1>ICN is digital infrastructure for cooperatives, communities, and federations.</h1>
         <p class="lead">
-          ICN stands for the Intercooperative Network. It is being built so democratic organizations can prove their decisions,
-          run on infrastructure they control, and coordinate with each other without depending on a platform they do not own.
+          ICN stands for the Intercooperative Network. It is a digital infrastructure project for democratic organizations
+          that need verifiable governance, institution-controlled records, and a credible way to coordinate with peers.
         </p>
       </div>
 
       <div class="truth-grid truth-grid-2">
         <div class="truth-note truth-note-teal">
-          <span class="truth-note-label">What it makes possible</span>
-          <h3>Prove, own, coordinate</h3>
+          <span class="truth-note-label">Practical proposition</span>
+          <h3>An institutional layer, not another standalone tool</h3>
           <p>
-            ICN is aimed at a simple shift: democratic institutions should be able to prove decisions,
-            own their records, and work across organizational boundaries without asking a platform for permission.
+            ICN is meant to give democratic organizations a shared technical substrate for identity, governance,
+            rules, records, and inter-organizational coordination.
           </p>
         </div>
         <div class="truth-note truth-note-amber">
-          <span class="truth-note-label">What it points toward</span>
-          <h3>A democratic economy on its own infrastructure</h3>
+          <span class="truth-note-label">Long-term direction</span>
+          <h3>Infrastructure the sector can rely on and govern</h3>
           <p>
-            The larger ambition is not one more governance app. It is a shared digital substrate
-            that cooperatives, communities, and federations can actually inhabit and govern together.
+            The long-term aim is a shared digital foundation that cooperatives, communities,
+            and federations can operate on together rather than consume as tenants.
           </p>
         </div>
       </div>

--- a/website/src/pages/what-is-icn.astro
+++ b/website/src/pages/what-is-icn.astro
@@ -13,26 +13,26 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         <span class="badge badge-teal">What is ICN</span>
         <h1>ICN is digital infrastructure for cooperatives, communities, and federations.</h1>
         <p class="lead">
-          It gives institutions a coherent substrate where membership, governance, shared rules, economic coordination, and accountability are native —
+          ICN stands for the Intercooperative Network. It gives institutions a coherent substrate where membership, governance, shared rules, economic coordination, and accountability are native —
           so decisions, action, and proof do not have to live in separate worlds.
         </p>
       </div>
 
       <div class="truth-grid truth-grid-2">
         <div class="truth-note truth-note-teal">
-          <span class="truth-note-label">Reviewed 2026-04-21</span>
-          <h3>What is most concrete today</h3>
+          <span class="truth-note-label">As of April 2026</span>
+          <h3>What is strongest today</h3>
           <p>
-            The strongest public through-line is provenance: identity, governance records, receipts, and the chain
-            from accepted decision to auditable outcome. That is the part of ICN the repo can already defend most clearly.
+            The strongest part of ICN today is provenance: identity, governance records, receipts,
+            and the chain from accepted decision to recorded outcome.
           </p>
         </div>
         <div class="truth-note truth-note-amber">
-          <span class="truth-note-label">Still advancing</span>
-          <h3>What this page does not overclaim</h3>
+          <span class="truth-note-label">Still being built</span>
+          <h3>What is not finished</h3>
           <p>
-            Recent governance institutional primitives have landed, but execution coverage and the unified member-facing
-            surface are still catching up. This is infrastructure under active construction, not a finished product.
+            Governance has moved forward, but execution coverage and the unified member-facing
+            surface are still catching up. This is real infrastructure, but it is not finished.
           </p>
         </div>
       </div>
@@ -90,7 +90,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         That is the loop. ICN exists to close it.
         Parts of it are already closed today; other parts are still being filled in.
         See <a href="/whats-real-now">What's Real Now</a> for the direct account
-        of which stations are strongest, which are the active frontier, and which are still behind.
+        of which stations are strongest, where work is focused, and which are still behind.
       </p>
 
       <h2>What ICN is not</h2>

--- a/website/src/pages/what-is-icn.astro
+++ b/website/src/pages/what-is-icn.astro
@@ -11,28 +11,29 @@ import ReadingLadder from '../components/ReadingLadder.astro';
     <div class="container narrow">
       <div class="page-hero">
         <span class="badge badge-teal">What is ICN</span>
-        <h1>ICN is digital infrastructure for cooperatives, communities, and federations.</h1>
+        <h1>ICN is shared digital infrastructure for democratic organizations.</h1>
         <p class="lead">
-          ICN stands for the Intercooperative Network. It is a digital infrastructure project for democratic organizations
-          that need verifiable governance, institution-controlled records, and a credible way to coordinate with peers.
+          ICN stands for the Intercooperative Network. It is being developed as an institutional
+          infrastructure layer for cooperatives, communities, and federations that need to prove decisions,
+          keep authoritative records under their own control, and coordinate credibly with peers.
         </p>
       </div>
 
       <div class="truth-grid truth-grid-2">
         <div class="truth-note truth-note-teal">
           <span class="truth-note-label">Practical proposition</span>
-          <h3>An institutional layer, not another standalone tool</h3>
+          <h3>A shared substrate for governance, records, and coordination</h3>
           <p>
-            ICN is meant to give democratic organizations a shared technical substrate for identity, governance,
-            rules, records, and inter-organizational coordination.
+            ICN is meant to give democratic organizations a technical foundation for identity,
+            governance, rules, records, and inter-organizational coordination.
           </p>
         </div>
         <div class="truth-note truth-note-amber">
           <span class="truth-note-label">Long-term direction</span>
-          <h3>Infrastructure the sector can rely on and govern</h3>
+          <h3>Sector-governable infrastructure instead of platform tenancy</h3>
           <p>
             The long-term aim is a shared digital foundation that cooperatives, communities,
-            and federations can operate on together rather than consume as tenants.
+            and federations can rely on, help govern, and improve together.
           </p>
         </div>
       </div>
@@ -43,19 +44,17 @@ import ReadingLadder from '../components/ReadingLadder.astro';
     <div class="container narrow prose">
       <h2>A different kind of system</h2>
       <p>
-        ICN is not an app. It is not a management SaaS. It is not a blockchain,
-        and it is not a DAO platform.
+        ICN is not an app, a management SaaS, a blockchain, or a DAO platform.
       </p>
       <p>
-        It is infrastructure — the layer underneath institutional life that most democratic organizations
-        have never had. The layer that says <em>who is a member</em>, <em>what the rules are</em>,
-        <em>what was decided</em>, <em>what happened</em>, <em>what is owed</em>,
-        and <em>what can be proven later</em>.
+        It is infrastructure: the layer underneath institutional life that most democratic organizations
+        have never had. The premise is that membership, authority, rules, records, and coordination
+        should not have to live in separate products owned by somebody else.
       </p>
       <p>
         Today that layer is improvised. It lives in spreadsheets, chat threads, documents,
         staff memory, and disconnected tools that were never designed to carry institutional weight.
-        ICN is an attempt to give it a real home.
+        ICN is an attempt to provide a durable alternative.
       </p>
 
       <h2>What ICN models directly</h2>

--- a/website/src/pages/whats-real-now.astro
+++ b/website/src/pages/whats-real-now.astro
@@ -24,9 +24,8 @@ import ReadingLadder from '../components/ReadingLadder.astro';
       <div class="status-anchor">
         <span class="status-anchor-label">Reviewed 2026-04-21</span>
         <p>
-          This page was checked against <code>docs/STATE.md</code>, current merged governance work, and the live repo tree.
-          Recent governance institutional primitives have landed, the provenance chain remains the most durable public surface,
-          and the active frontier is still broader decision-to-effect coverage plus stronger governance-to-economics proof.
+          As of April 21, 2026, governance structures, meetings, notifications, and decision-to-action work have landed.
+          Provenance is still the strongest part of the system. Broader execution coverage and stronger governance-to-economics links are still being built.
         </p>
       </div>
     </div>
@@ -65,7 +64,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         <strong>Provenance and institutional memory.</strong>
         The deepest mature part of ICN is the chain that carries an outcome back through the rule that shaped it,
         the decision that authorized it, and the members who held standing. Proposals, votes, receipts,
-        and the decision-to-outcome chain are the strongest through-line in the current system.
+        and the decision-to-outcome chain are the most mature path in the current system.
       </p>
       <p>
         <strong>Auditable coordination.</strong>

--- a/website/src/pages/whats-real-now.astro
+++ b/website/src/pages/whats-real-now.astro
@@ -57,7 +57,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
     </div>
   </section>
 
-  <section class="section">
+  <section class="section section-pre-ladder">
     <div class="container narrow prose">
       <h2>Strong today</h2>
       <p>
@@ -167,7 +167,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
     </div>
   </section>
 
-  <section class="section-alt">
+  <section class="section-alt section-ladder">
     <div class="container narrow">
       <ReadingLadder current="whats-real-now" />
     </div>

--- a/website/src/pages/whats-real-now.astro
+++ b/website/src/pages/whats-real-now.astro
@@ -20,6 +20,15 @@ import ReadingLadder from '../components/ReadingLadder.astro';
           Every other page on this site should be readable against what is here without contradiction.
         </p>
       </div>
+
+      <div class="status-anchor">
+        <span class="status-anchor-label">Reviewed 2026-04-21</span>
+        <p>
+          This page was checked against <code>docs/STATE.md</code>, current merged governance work, and the live repo tree.
+          Recent governance institutional primitives have landed, the provenance chain remains the most durable public surface,
+          and the active frontier is still broader decision-to-effect coverage plus stronger governance-to-economics proof.
+        </p>
+      </div>
     </div>
   </section>
 
@@ -172,6 +181,30 @@ import ReadingLadder from '../components/ReadingLadder.astro';
 .page-hero .badge { align-self: flex-start; }
 .page-hero h1 { margin: 0; }
 .lead { font-size: 1.125rem; color: var(--text-body); line-height: 1.6; margin: 0; }
+.status-anchor {
+  margin-top: var(--space-xl);
+  padding: var(--space-lg) var(--space-xl);
+  background: var(--bg-card);
+  border: 1px solid var(--border-default);
+  border-left: 3px solid var(--accent-amber);
+  border-radius: var(--radius-lg);
+}
+.status-anchor-label {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent-amber);
+  margin-bottom: var(--space-sm);
+}
+.status-anchor p {
+  margin: 0;
+  font-size: 0.9375rem;
+  line-height: 1.7;
+  color: var(--text-secondary);
+}
 
 .prose h2 { margin-top: var(--space-2xl); margin-bottom: var(--space-md); }
 .prose p { margin: 0 0 var(--space-md); line-height: 1.7; }

--- a/website/src/pages/whats-real-now.astro
+++ b/website/src/pages/whats-real-now.astro
@@ -15,8 +15,8 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         <span class="badge badge-amber">Maturity Anchor</span>
         <h1>What's Real Now</h1>
         <p class="lead">
-          ICN is a real, active infrastructure project with uneven maturity.
-          This page is where we say what is proven, what is advancing, and what is not yet finished.
+          ICN has uneven maturity across its subsystems.
+          This page states what is proven, what is advancing, and what is not yet complete.
           Every other page on this site should be readable against what is here without contradiction.
         </p>
       </div>
@@ -42,7 +42,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
 
       <MaturityGrid>
         <MaturityCard band="strong">
-          <p>Implemented, integrated, and load-bearing. The project is willing to stand behind these capabilities in public.</p>
+          <p>Implemented, integrated, and load-bearing. These are capabilities we are prepared to stand behind in public.</p>
         </MaturityCard>
         <MaturityCard band="advancing">
           <p>Actively under development with visible progress. Not yet something to rely on, but moving.</p>
@@ -51,7 +51,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
           <p>Serious implementation exists. Surfaces and integrations are still being finished. Implementation is often ahead of the public-facing story.</p>
         </MaturityCard>
         <MaturityCard band="notyet">
-          <p>Scoped and intended, but not where real work is concentrated right now. We would rather say that directly than imply a schedule.</p>
+          <p>Scoped, but not where work is concentrated right now. We would rather say that directly than imply a schedule.</p>
         </MaturityCard>
       </MaturityGrid>
     </div>
@@ -134,7 +134,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         than paint pictures we cannot yet stand behind.
       </p>
       <p>
-        Other parts of the system are scoped and intended but not where active work is concentrated right now.
+        Other parts of the system are scoped but not where active work is concentrated right now.
         When outsiders ask "does ICN do X," the honest answer is sometimes <em>not yet, and we are not pretending otherwise</em>.
       </p>
 

--- a/website/src/pages/why-icn.astro
+++ b/website/src/pages/why-icn.astro
@@ -12,18 +12,18 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         <span class="badge badge-amber">Why ICN</span>
         <h1>Cooperatives and democratic institutions should not have to govern themselves through toolchains built for firms, platforms, and administrative convenience.</h1>
         <p class="lead">
-          ICN exists because the software stack available to collective institutions
-          actively fights the way those institutions are supposed to work.
+          ICN exists because the current software stack fragments institutional authority, memory,
+          and action across systems that were not designed for democratic organizations.
         </p>
       </div>
 
       <div class="truth-grid">
         <div class="truth-note truth-note-amber">
-          <span class="truth-note-label">What is at stake</span>
-          <h3>The democratic economy still runs on landlords</h3>
+          <span class="truth-note-label">Institutional consequence</span>
+          <h3>Democratic organizations still depend on non-democratic infrastructure</h3>
           <p>
-            Cooperatives and community institutions have spent generations building alternatives to capitalist ownership,
-            while still depending on digital systems they do not own. ICN exists to change that.
+            This is not only a tooling issue. It is a governance issue, a continuity issue,
+            and ultimately an ownership issue for the democratic economy.
           </p>
         </div>
       </div>

--- a/website/src/pages/why-icn.astro
+++ b/website/src/pages/why-icn.astro
@@ -16,6 +16,18 @@ import ReadingLadder from '../components/ReadingLadder.astro';
           actively fights the way those institutions are supposed to work.
         </p>
       </div>
+
+      <div class="truth-grid">
+        <div class="truth-note truth-note-amber">
+          <span class="truth-note-label">Why now</span>
+          <h3>The gap is easier to point to concretely now</h3>
+          <p>
+            Recent repo work widened the governance surface with institutional structures, meetings, notifications,
+            and decision-to-action primitives. That makes the public argument less abstract: the problem is still the
+            fracture between decision, rule, action, and proof, and the codebase is increasingly organized around closing it.
+          </p>
+        </div>
+      </div>
     </div>
   </section>
 

--- a/website/src/pages/why-icn.astro
+++ b/website/src/pages/why-icn.astro
@@ -64,6 +64,12 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         to capital, or to centralized administration.
       </p>
       <p>
+        Name the stack plainly and the problem becomes clearer: Google Workspace or Microsoft 365
+        hold documents, mail, and calendars; Loomio holds votes; QuickBooks holds the books;
+        Slack or Teams hold operational coordination; Salesforce, Airtable, or a spreadsheet often stand in for membership.
+        The institution lives across all of them, but none of them carries the institution as a whole.
+      </p>
+      <p>
         This is not a conspiracy. It is the default shape of software built for firms and platforms.
         Democratic institutions are forced to operate inside it, and they pay the translation cost every day,
         in staff time, in lost history, in weakened accountability, in the quiet conversion of institutional trust into individual trust.
@@ -83,6 +89,11 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         None of them know what a rule is.
         None of them know what it means for a decision to bind action.
         Integrating them only spreads the gap more evenly.
+      </p>
+      <p>
+        In that sense, the goal is not merely to swap Google for Microsoft, Slack for Teams, or one voting app for another.
+        The goal is to replace the dependency pattern itself with infrastructure that can carry governance,
+        records, obligations, and coordination as institutional facts.
       </p>
       <p>
         A cooperative running on a stack of generic tools is not running on infrastructure built for cooperatives.

--- a/website/src/pages/why-icn.astro
+++ b/website/src/pages/why-icn.astro
@@ -19,12 +19,11 @@ import ReadingLadder from '../components/ReadingLadder.astro';
 
       <div class="truth-grid">
         <div class="truth-note truth-note-amber">
-          <span class="truth-note-label">As of April 2026</span>
-          <h3>The gap is no longer abstract</h3>
+          <span class="truth-note-label">What is at stake</span>
+          <h3>The democratic economy still runs on landlords</h3>
           <p>
-            Recent work added institutional structures, meetings, notifications, and decision-to-action links.
-            The basic problem has not changed: most institutions still have to split decision, rule, action,
-            and proof across tools that do not belong together.
+            Cooperatives and community institutions have spent generations building alternatives to capitalist ownership,
+            while still depending on digital systems they do not own. ICN exists to change that.
           </p>
         </div>
       </div>

--- a/website/src/pages/why-icn.astro
+++ b/website/src/pages/why-icn.astro
@@ -30,7 +30,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
     </div>
   </section>
 
-  <section class="section-alt">
+  <section class="section-alt section-pre-ladder">
     <div class="container narrow prose">
       <h2>The fracture</h2>
       <p>
@@ -133,7 +133,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
     </div>
   </section>
 
-  <section class="section">
+  <section class="section section-ladder">
     <div class="container narrow">
       <ReadingLadder current="why-icn" />
     </div>

--- a/website/src/pages/why-icn.astro
+++ b/website/src/pages/why-icn.astro
@@ -10,17 +10,17 @@ import ReadingLadder from '../components/ReadingLadder.astro';
     <div class="container narrow">
       <div class="page-hero">
         <span class="badge badge-amber">Why ICN</span>
-        <h1>Cooperatives and democratic institutions should not have to govern themselves through toolchains built for firms, platforms, and administrative convenience.</h1>
+        <h1>Democratic institutions need infrastructure that preserves authority, memory, and accountability.</h1>
         <p class="lead">
-          ICN exists because the current software stack fragments institutional authority, memory,
-          and action across systems that were not designed for democratic organizations.
+          ICN exists because the current software stack fragments institutional authority, records,
+          and execution across systems that were not designed for democratic organizations.
         </p>
       </div>
 
       <div class="truth-grid">
         <div class="truth-note truth-note-amber">
           <span class="truth-note-label">Institutional consequence</span>
-          <h3>Democratic organizations still depend on non-democratic infrastructure</h3>
+          <h3>This is a structural dependence problem, not just a tooling problem</h3>
           <p>
             This is not only a tooling issue. It is a governance issue, a continuity issue,
             and ultimately an ownership issue for the democratic economy.
@@ -52,8 +52,8 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         And when something goes wrong, there is no path back from the outcome to the decision that was supposed to govern it.
       </p>
       <p>
-        This is not a failure of any one tool. It is the shape of the gap between institutional life
-        and the software stack it has been forced to use.
+        This is not a failure of any one tool. It is the gap between institutional life
+        and the software stack democratic organizations have been forced to use.
       </p>
 
       <h2>Most of the tools we depend on do not answer to us</h2>
@@ -64,12 +64,12 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         to capital, or to centralized administration.
       </p>
       <p>
-        This is not a conspiracy. It is just the default shape of software built for firms and platforms.
+        This is not a conspiracy. It is the default shape of software built for firms and platforms.
         Democratic institutions are forced to operate inside it, and they pay the translation cost every day,
         in staff time, in lost history, in weakened accountability, in the quiet conversion of institutional trust into individual trust.
       </p>
 
-      <h2>Why generic tools do not fix this</h2>
+      <h2>Why better tooling alone does not fix this</h2>
       <p>
         It is tempting to believe the answer is a better project management tool,
         a better voting app, a better accounting package, or tighter integration between them.

--- a/website/src/pages/why-icn.astro
+++ b/website/src/pages/why-icn.astro
@@ -19,12 +19,12 @@ import ReadingLadder from '../components/ReadingLadder.astro';
 
       <div class="truth-grid">
         <div class="truth-note truth-note-amber">
-          <span class="truth-note-label">Why now</span>
-          <h3>The gap is easier to point to concretely now</h3>
+          <span class="truth-note-label">As of April 2026</span>
+          <h3>The gap is no longer abstract</h3>
           <p>
-            Recent repo work widened the governance surface with institutional structures, meetings, notifications,
-            and decision-to-action primitives. That makes the public argument less abstract: the problem is still the
-            fracture between decision, rule, action, and proof, and the codebase is increasingly organized around closing it.
+            Recent work added institutional structures, meetings, notifications, and decision-to-action links.
+            The basic problem has not changed: most institutions still have to split decision, rule, action,
+            and proof across tools that do not belong together.
           </p>
         </div>
       </div>

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -654,7 +654,7 @@ pre code {
   padding: var(--space-xs);
 }
 @media (max-width: 1180px) {
-  .nav-logo span {
+  .nav .nav-logo span {
     display: none;
   }
   .nav-inner {

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -1,4 +1,4 @@
-﻿/* ICN Design System — intercooperative.network */
+/* ICN Design System — intercooperative.network */
 
 :root {
   --bg-primary: #06090f;
@@ -107,7 +107,7 @@
   --shadow-glow-amber: 0 0 20px rgba(194, 65, 12, 0.15);
   --shadow-glow-blue: 0 0 20px rgba(3, 105, 161, 0.15);
 }
-﻿*,
+*,
 *::before,
 *::after {
   box-sizing: border-box;
@@ -294,6 +294,54 @@ pre code {
 .section-header p {
   margin: 0 auto;
 }
+.truth-grid {
+  display: grid;
+  gap: var(--space-lg);
+  margin-top: var(--space-xl);
+}
+.truth-grid-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.truth-note {
+  padding: var(--space-lg) var(--space-xl);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 100%),
+    var(--bg-card);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+.truth-note-label {
+  display: inline-block;
+  margin-bottom: var(--space-sm);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.truth-note h3 {
+  margin: 0 0 var(--space-sm);
+  font-size: 1.05rem;
+}
+.truth-note p {
+  margin: 0;
+  max-width: none;
+  font-size: 0.95rem;
+  line-height: 1.7;
+}
+.truth-note-teal {
+  border-color: var(--border-teal);
+}
+.truth-note-teal .truth-note-label {
+  color: var(--accent-teal);
+}
+.truth-note-amber {
+  border-color: var(--border-accent);
+}
+.truth-note-amber .truth-note-label {
+  color: var(--accent-amber);
+}
 .grid {
   display: grid;
   gap: var(--space-xl);
@@ -308,11 +356,17 @@ pre code {
   .grid-3 {
     grid-template-columns: repeat(2, 1fr);
   }
+  .truth-grid-2 {
+    grid-template-columns: 1fr;
+  }
 }
 @media (max-width: 600px) {
   .grid-2,
   .grid-3 {
     grid-template-columns: 1fr;
+  }
+  .truth-note {
+    padding: var(--space-lg);
   }
 }
 
@@ -397,13 +451,18 @@ pre code {
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
+  min-height: 100%;
   transition:
     border-color var(--duration-fast) var(--ease-out),
-    background var(--duration-fast) var(--ease-out);
+    background var(--duration-fast) var(--ease-out),
+    transform var(--duration-fast) var(--ease-out),
+    box-shadow var(--duration-fast) var(--ease-out);
 }
 .inst-card:hover {
   border-color: var(--accent-teal);
   background: var(--bg-card-hover);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
 }
 .inst-card-eyebrow {
   font-family: var(--font-mono);
@@ -502,13 +561,13 @@ pre code {
   margin-bottom: var(--space-md);
 }
 
-﻿.nav {
+.nav {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   z-index: 100;
-  background: rgba(6, 9, 15, 0.85);
+  background: rgba(6, 9, 15, 0.88);
   backdrop-filter: blur(16px);
   border-bottom: 1px solid var(--border-subtle);
   height: 64px;
@@ -520,7 +579,7 @@ pre code {
   height: 100%;
   display: flex;
   align-items: center;
-  gap: var(--space-xl);
+  gap: var(--space-lg);
 }
 .nav-logo {
   display: flex;
@@ -542,15 +601,16 @@ pre code {
 .nav-links {
   display: flex;
   align-items: center;
-  gap: var(--space-sm);
+  gap: 2px;
   list-style: none;
   flex: 1;
+  justify-content: center;
 }
 .nav-links a {
   color: var(--text-secondary);
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
   font-weight: 500;
-  padding: var(--space-xs) var(--space-sm);
+  padding: 0.38rem 0.62rem;
   border-radius: var(--radius-md);
   transition: all var(--duration-fast) var(--ease-out);
   text-decoration: none;
@@ -586,17 +646,26 @@ pre code {
   cursor: pointer;
   padding: var(--space-xs);
 }
+@media (max-width: 1180px) {
+  .nav-logo span {
+    display: none;
+  }
+  .nav-inner {
+    gap: var(--space-md);
+  }
+}
 @media (max-width: 768px) {
   .nav-links {
     display: none;
     position: absolute;
-    top: 64px;
-    left: 0;
-    right: 0;
-    background: var(--bg-secondary);
-    border-bottom: 1px solid var(--border-subtle);
+    top: calc(100% + 8px);
+    left: var(--space-md);
+    right: var(--space-md);
+    background: rgba(12, 17, 24, 0.98);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-xl);
     flex-direction: column;
-    padding: var(--space-md);
+    padding: var(--space-sm);
     gap: 0;
     z-index: 999;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
@@ -607,7 +676,7 @@ pre code {
   }
   .nav-links a {
     display: block;
-    padding: var(--space-md) var(--space-lg);
+    padding: 0.9rem 1rem;
     font-size: 1rem;
     width: 100%;
     border-radius: var(--radius-md);
@@ -731,11 +800,12 @@ pre code {
   color: var(--accent-purple);
   border: 1px solid var(--border-subtle);
 }
-﻿.card {
+.card {
   background: var(--bg-card);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-xl);
   padding: var(--space-xl);
+  min-height: 100%;
   transition: all var(--duration-normal) var(--ease-out);
 }
 .card:hover {
@@ -958,8 +1028,24 @@ pre code {
   }
 }
 @media (max-width: 600px) {
+  .container,
+  .container-narrow {
+    padding: 0 var(--space-lg);
+  }
+  .section,
+  .section-alt {
+    padding: var(--space-3xl) 0;
+  }
+  .section-header {
+    margin-bottom: var(--space-2xl);
+  }
+  .card,
+  .inst-card {
+    padding: var(--space-lg);
+  }
   .footer-inner {
     grid-template-columns: 1fr;
+    gap: var(--space-xl);
   }
   .footer-bottom {
     flex-direction: column;

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -283,6 +283,13 @@ pre code {
   border-top: 1px solid var(--border-subtle);
   border-bottom: 1px solid var(--border-subtle);
 }
+.section-pre-ladder {
+  padding-bottom: var(--space-2xl);
+}
+.section-ladder {
+  padding-top: var(--space-2xl);
+  padding-bottom: var(--space-3xl);
+}
 .section-header {
   text-align: center;
   max-width: 680px;
@@ -1035,6 +1042,13 @@ pre code {
   .section,
   .section-alt {
     padding: var(--space-3xl) 0;
+  }
+  .section-pre-ladder {
+    padding-bottom: var(--space-xl);
+  }
+  .section-ladder {
+    padding-top: var(--space-xl);
+    padding-bottom: var(--space-2xl);
   }
   .section-header {
     margin-bottom: var(--space-2xl);


### PR DESCRIPTION
# Pull Request

## Summary
Polish the public website and bring the copy in line with verified April 2026 repo state.

This branch:
- tightens the homepage hero, navigation spacing, card rhythm, and mobile layout behavior
- sharpens the public explainer pages so they speak plainly about what ICN is, what is real now, and what is still unfinished
- adds explicit reality anchors on key pages so the public site stays aligned with the codebase instead of reading like timeless marketing copy

## Related
- Issues: <!-- Fixes # / Closes # -->
- Specs / ADRs / RFCs:
  - `docs/STATE.md`
  - `docs/design-language/brief-v0.md`

## Work mode
- [ ] Discovery output
- [x] Delivery tranche
- [ ] Mixed, but bounded

## Risk
- This is a public-site messaging and layout pass, so the main risks are copy drift, awkward mobile spacing, or visual regressions on the core explainer pages.
- No production deploy behavior is changed in this branch; `intercooperative.network` still deploys from `main` via `.github/workflows/website-deploy.yml`.

## Documentation control (required when `docs/**` changes)
- [ ] New or moved docs declare **truth class** and **role** (see `docs/DOCUMENTATION_CONTROL_SYSTEM.md`; vocabulary: `normative` / `descriptive` / `operational` / `historical` / `draft`)
- [ ] `docs/registry.toml` updated (explicit `[docs."path"]` entry when defaults are wrong)
- [ ] Placement matches allowlisted `docs/` subtree (see `[control].allowlisted_docs_subdirs` in `registry.toml`)
- [ ] Control-plane canonical paths (exact set: `[control].canonical_doc_paths` — same four files as below) unchanged **or** YAML headers + merged registry row updated **together**
- [ ] Ran: `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` (add `--strict` if you touched registry structure, canon paths, or supersession; see `docs/DOCUMENTATION_MAINTENANCE.md`)
- [ ] If `DOCUMENT_REGISTRY.md` should reflect corpus stats: same command with `--write-document-registry docs/DOCUMENT_REGISTRY.md`

## Structural changes (docs migrations)
- Files added: none
- Files moved: none
- Files archived: none
- Files marked superseded: none

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Tests
- [ ] Refactor (no behavior change)

## Verification
What you actually ran (commands and result):
- [ ] `python3 docs/scripts/doc_control_check.py` (if docs touched)
- [x] Tests / clippy / fmt as applicable
- `cd website && npm run build` ✅
- `cd website && npm run lint` ⚠️ fails on pre-existing Astro/TypeScript issues in `src/components/Icon.astro`, `src/components/Search.astro`, and blog/rss files; this branch did not add new lint failures
- Manual desktop/mobile visual spot-check of updated explainer layout ✅

## Non-goals
- No new deploy pipeline or branch-preview infrastructure in this PR
- No attempt to fix the pre-existing Astro typing errors outside the touched website copy/layout pass
- No logo/brand-system redesign yet

## Remaining unknowns
- If we want branch previews for website PRs, we still need a dedicated preview deploy workflow or staging host.
- The existing lint/type issues in blog/search/icon files remain and deserve a separate cleanup PR.
