### PR TITLE
feat(website): add onboarding and support intake paths

### DIFF
--- a/.agents/skills/bench/SKILL.md
+++ b/.agents/skills/bench/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: bench
+description: Run criterion benchmarks locally for one or all ICN crates. CI runs these on ubuntu-latest; local runs on icn-dev are for relative comparison only.
+argument-hint: "[crate-name | all]"
+user-invocable: true
+allowed-tools: "Bash"
+truth_contract:
+  canonical_sources:
+    - ops/state/config/repo-map.json    # workspace root (cargo commands from icn/)
+  live_load_required:
+    - "cargo metadata --no-deps --format-version 1"   # package name resolution
+  examples_only: []
+  never_hardcode:
+    - package names (resolve via cargo metadata)
+    - workspace paths (resolve via git rev-parse --show-toplevel)
+---
+
+Run criterion benchmarks for the specified crate, or all six targets.
+
+## Benchmark targets
+
+Pass the short name (without `icn-` prefix) as `$ARGUMENTS`, e.g. `gossip` for `icn-gossip`.
+
+| Short name | Full crate | Bench file |
+|-----------|-----------|-----------|
+| ledger | icn-ledger | ledger_bench |
+| gossip | icn-gossip | gossip_bench |
+| trust | icn-trust | trust_bench |
+| net | icn-net | net_bench |
+| compute | icn-compute | compute_bench |
+| gateway | icn-gateway | commons_bench |
+
+All commands run from the Rust workspace root (`icn/` within the monorepo).
+
+## Steps
+
+1. Confirm working directory: `cd "$CLAUDE_PROJECT_DIR/icn"`
+
+2. If `$ARGUMENTS` is a short crate name (e.g. `gossip`), look up its bench file above and run:
+   ```bash
+   cargo bench -p icn-<short-name> --bench <bench_file>
+   ```
+   Example: `cargo bench -p icn-gossip --bench gossip_bench`
+
+3. If `$ARGUMENTS` is `all` or empty, run all six:
+   ```bash
+   cargo bench --bench compute_bench --bench commons_bench --bench gossip_bench \
+     --bench ledger_bench --bench net_bench --bench trust_bench
+   ```
+
+4. Criterion prints regression vs previous run automatically. Flag regressions in
+   `gossip_bench`, `net_bench`, or `ledger_bench` as high-priority (protocol-critical paths).
+
+## Notes
+
+- Local results reflect icn-dev hardware, not ubuntu-latest CI. Use for relative comparison only.
+- Benchmarks are slow. Run scoped to the crate you are touching.
+- Do not commit `target/criterion/` artifacts.
+- "No samples were collected" means the bench binary failed to build — run
+  `cargo check -p <crate>` first.

--- a/.agents/skills/changelog/SKILL.md
+++ b/.agents/skills/changelog/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: changelog
+description: Generate a CHANGELOG.md entry from commits since the last git tag. Groups by type (feat/fix/refactor/etc), formats as Keep-a-Changelog.
+argument-hint: "[version] [--dry-run]"
+user-invocable: true
+allowed-tools: "Bash, Read, Edit"
+truth_contract:
+  canonical_sources: []
+  live_load_required:
+    - "git tag --sort=-version:refname | head -1"
+    - "git log <last-tag>..HEAD --oneline"
+  examples_only: []
+  never_hardcode:
+    - version numbers
+    - commit ranges
+---
+
+Generate a Keep-a-Changelog entry from commits since the last git tag and prepend it to CHANGELOG.md.
+
+## Steps
+
+### 1. Gather context
+
+Run in parallel:
+- `git tag --sort=-version:refname | head -5` — find last release tag
+- `git branch --show-current` — confirm branch
+- `git log --oneline $(git describe --tags --abbrev=0 2>/dev/null || echo "")..HEAD` — commits since last tag (or all if no tags)
+
+### 2. Determine version
+
+- If `$ARGUMENTS` contains a version (e.g. `0.2.0`), use that.
+- Otherwise, infer from last tag + increment (patch for fixes only, minor if any feat, major if any breaking change marked with `!`).
+- Print the determined version before proceeding.
+
+### 3. Parse commits into groups
+
+Group commits by conventional-commit type:
+- `feat` → `### Added`
+- `fix` → `### Fixed`
+- `refactor` → `### Changed`
+- `docs` → `### Documentation`
+- `test` → `### Tests`
+- `chore`, `ci` → `### Internal`
+- `perf` → `### Performance`
+
+Skip merge commits (`Merge pull request`, `Merge branch`). Skip commits with scope `ops` or `chore(ops)`.
+
+Extract PR number from commit message if present (e.g., `(#1234)`) and format as link: `([#1234](../../pull/1234))`.
+
+### 4. Format the entry
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### Added
+- feat(scope): description ([#N](../../pull/N))
+
+### Fixed
+- fix(scope): description
+
+### Changed
+- ...
+```
+
+Use today's date (ISO 8601). Omit sections that have no entries.
+
+### 5. Prepend to CHANGELOG.md
+
+- Read current CHANGELOG.md
+- Insert the new entry after the `# Changelog` header line (or at top if no header)
+- Write the updated file
+
+Skip this step if `$ARGUMENTS` contains `--dry-run` (print entry to stdout only, don't write).
+
+### 6. Confirm
+
+Print: "Changelog updated for vX.Y.Z with N entries."
+List the sections and entry counts.
+
+## Important
+
+- Do NOT create a git commit — leave that to the user.
+- If CHANGELOG.md doesn't exist, create it with the `# Changelog` header followed by the entry.
+- Keep entries concise: one line per commit.
+- Scope is law: do not rewrite or reformat existing CHANGELOG entries.

--- a/.agents/skills/fix-rust-lints/SKILL.md
+++ b/.agents/skills/fix-rust-lints/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: fix-rust-lints
+description: Classify clippy/compiler failures by lint family and apply canonical idiomatic fixes.
+argument-hint: "[lint output | --scan]"
+user-invocable: true
+allowed-tools: "Bash, Read, Edit, Grep"
+truth_contract:
+  canonical_sources:
+    - ops/state/config/repo-map.json    # workspace root (cargo commands from icn/)
+  live_load_required:
+    - "cargo clippy --workspace --all-targets -- -D warnings 2>&1"
+    - "git diff --name-only $(git merge-base HEAD origin/main)..HEAD"
+  examples_only: []
+  never_hardcode:
+    - toolchain version (read from rust-toolchain.toml)
+    - branch name or changed file list (always live-query)
+---
+
+Turn recurring Rust lint failures into known remediation classes. Never debug clippy from scratch.
+
+## The Problem This Solves
+
+The transcript discovered two lint patterns mid-run and fixed them ad hoc. Those same patterns
+will recur. This skill pre-encodes them as named classes with canonical fix shapes so the model
+stops relearning under pressure.
+
+## Steps
+
+1. **Collect failures**: If `$ARGUMENTS` is empty, run:
+   ```bash
+   cargo clippy --workspace --all-targets -- -D warnings 2>&1 | grep "^error"
+   ```
+   Or read from provided output.
+
+2. **Classify each error** by lint name (appears in brackets after `error:`):
+   ```bash
+   cargo clippy ... 2>&1 | grep -E "^error\[|^\s+-->"
+   ```
+
+3. **Apply canonical fix** from the playbook below.
+
+4. **Scan for recurrences** of the same anti-pattern in nearby code:
+   ```bash
+   grep -rn "<pattern>" crates/ apps/ bins/
+   ```
+
+5. **Verify**: Re-run the scoped clippy command to confirm the fix.
+
+---
+
+## Lint Remediation Playbook
+
+### `field_reassign_with_default`
+
+**Trigger**: `let mut x = T::default(); x.field = value;`
+
+**Canonical fix**: Struct update syntax
+```rust
+// BEFORE
+let mut cfg = FooConfig::default();
+cfg.some_field = new_value;
+
+// AFTER
+let cfg = FooConfig {
+    some_field: new_value,
+    ..Default::default()
+};
+```
+
+**Why**: Removes the `mut` binding, signals intent at construction, eliminates post-init mutation.
+
+**Scan for recurrences**:
+```bash
+grep -rn "let mut .* = .*::default();" crates/ apps/ bins/ --include="*.rs"
+```
+
+---
+
+### Deprecated item in `--all-targets` (test code)
+
+**Trigger**: `use of deprecated ...` in test modules when compiling with `--all-targets -D warnings`
+
+**Root cause**: `#[deprecated]` is transitive. CI uses `--all-targets`, which compiles test code.
+A deprecated constant marked in a library still fires as an error wherever test code references it,
+even if the non-test code is clean.
+
+**Canonical fix**: Replace deprecated references with the recommended replacement, even in tests.
+Do NOT use `#[allow(deprecated)]` unless the replacement doesn't exist yet.
+
+```rust
+// BEFORE (in test)
+membership_age_secs: MIN_MEMBERSHIP_AGE_SECS + 1,
+
+// AFTER
+membership_age_secs: AttestationThresholds::default().min_membership_age_secs + 1,
+```
+
+**Scan for recurrences**:
+```bash
+# Find uses of deprecated constants in test modules
+grep -rn "MIN_MEMBERSHIP_AGE_SECS\|MAX_ATTESTATIONS_PER_PERIOD\|MIN_TRUST_TO_ATTEST" \
+  crates/ apps/ --include="*.rs" | grep -v "pub const\|#\[deprecated"
+```
+
+**Re-export workaround**: When a module re-exports deprecated items for backward compat,
+add `#[allow(deprecated)]` on the `pub use` block only, not on callers:
+```rust
+#[allow(deprecated)]
+pub use attestation::{LEGACY_CONST, old_function};
+```
+
+---
+
+### `clippy::unwrap_used` / `clippy::expect_used` in tests
+
+**Trigger**: `error: used unwrap() on a Result value` in test code
+
+**Canonical fix**: Add workspace-level test allowance or use `#![cfg_attr(test, allow(...))]`
+in the crate root. Do NOT sprinkle `#[allow]` throughout test functions.
+
+```rust
+// In lib.rs crate root:
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+```
+
+---
+
+### `clippy::too_many_arguments`
+
+**Trigger**: Function has 8+ parameters.
+
+**Canonical fix**: Either group related params into a config struct, or accept the lint suppression
+if the function is a one-off constructor:
+```rust
+// Group into struct when params are logically related
+pub fn build_policy(config: PolicyConfig) -> Policy { ... }
+
+// Or suppress if it's an internal constructor unlikely to be called repeatedly
+#[allow(clippy::too_many_arguments)]
+pub fn new_internal(a: T, b: U, ...) -> Self { ... }
+```
+
+**ICN note**: Prefer the config struct approach for any function that appears in lifecycle.rs,
+since those wire multiple values from config objects.
+
+---
+
+### `clippy::missing_errors_doc` / `clippy::missing_panics_doc`
+
+**Trigger**: Public function lacks `# Errors` / `# Panics` doc section.
+
+**Canonical fix**: Add the section, or suppress at crate level with `#![allow(missing_docs)]`
+if the crate already has that allowance:
+```rust
+/// Does the thing.
+///
+/// # Errors
+/// Returns `Err` if the configuration is invalid.
+pub fn do_thing(&self) -> Result<(), String> { ... }
+```
+
+---
+
+### Overflow / underflow in time arithmetic
+
+**Trigger**: `SystemTime` subtraction that can underflow, or `u64::checked_mul` missing.
+
+**Canonical fix**:
+```rust
+// BEFORE (panics on underflow in debug mode)
+let cutoff = now - duration;
+
+// AFTER
+let cutoff = now.checked_sub(duration).unwrap_or(SystemTime::UNIX_EPOCH);
+
+// For u64 multiplication that might overflow:
+let secs = days.checked_mul(SECONDS_PER_DAY).unwrap_or(u64::MAX);
+```
+
+---
+
+## Guardrails
+
+- Never suppress a lint without understanding its class. Find the canonical fix first.
+- Prefer fixing the anti-pattern to suppressing the warning.
+- After fixing, scan for the same pattern in nearby code before committing.
+- A fix that passes local `cargo clippy -p <crate>` may still fail CI `--workspace --all-targets`.
+  Always scope-check with `--all-targets` before declaring victory.

--- a/.agents/skills/handoff/SKILL.md
+++ b/.agents/skills/handoff/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: handoff
+description: Write a session handoff to docs/dev/ using the structured template with truth-plane labeling.
+argument-hint: "[--push]"
+user-invocable: true
+allowed-tools: "Bash, Read, Write, Grep"
+truth_contract:
+  canonical_sources:
+    - docs/dev/HANDOFF_TEMPLATE.md        # structured handoff template
+    - docs/ai/ICN_SESSION_FRAME_TEMPLATE.md  # session frame (include in handoff)
+  live_load_required:
+    - "git branch --show-current"
+    - "git log --oneline -10"
+    - "gh pr list --json number,title,headRefName --limit 5"
+  examples_only: []
+  never_hardcode:
+    - sprint number
+    - PR numbers or branch names
+    - session date (read from system)
+---
+
+Write a session handoff note so the next session (or next agent) can resume without context loss.
+
+## Steps
+
+### 1. Gather state
+
+Run in parallel:
+```bash
+git branch --show-current
+git log --oneline -10
+git status --short
+git stash list
+```
+
+Also:
+```bash
+# Open PRs on this branch (if gh available)
+gh pr list --head $(git branch --show-current) --json number,title,state 2>/dev/null || echo "gh not available"
+# Uncommitted TODOs added in this session
+git diff origin/main...HEAD 2>/dev/null | grep '^+.*// TODO' | head -20
+```
+
+### 2. Identify open threads
+
+- List any tests that are failing or skipped
+- Note any `// TODO`, `// FIXME`, or `// HACK` lines added on this branch
+- Note any files edited but not committed
+- Note any decisions made this session (summarize from recent tool use context)
+
+### 3. Write the handoff file
+
+Target: `docs/dev/handoff-YYYY-MM-DD.md`
+
+Where `YYYY-MM-DD` = today's date (`date +%Y-%m-%d`).
+
+If a file for today already exists, use suffix: `handoff-YYYY-MM-DD-b.md`.
+
+**Use the structured template from `docs/dev/HANDOFF_TEMPLATE.md`.** Each section explicitly labels its truth type. At minimum include:
+
+- **Final State (Verified)** — only facts confirmed by commands
+- **What Changed** — execution truth from this session
+- **What's Open** — known incomplete work
+- **Unsafe Assumptions** — anything relied on but not verified (do NOT skip this)
+- **Next Move** — exact sequence for next session
+- **Truth-Plane Notes** — which truth types were relied on, any known conflicts
+
+### 4. Clean up
+
+- Remind: `git stash list` should be empty — stash or commit before ending
+- If `$ARGUMENTS` includes `--push` AND working tree is clean: run `/push` to push the branch
+
+### 5. Report
+
+Print:
+```
+Handoff written to docs/dev/handoff-YYYY-MM-DD.md
+Branch: <name> | Commits: <n> | Open PRs: <n> | Open threads: <n>
+```
+
+## Important
+
+- Do NOT commit the handoff file automatically. User decides.
+- If `docs/dev/` doesn't exist, create it.
+- Keep notes concise — this is for the next session, not a full PR description.
+- The "Unsafe Assumptions" section is the most important section. If you skip one, do not skip that one.

--- a/.agents/skills/icn-dev/SKILL.md
+++ b/.agents/skills/icn-dev/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: icn-dev
+description: >
+  ICN development companion for the InterCooperative Network Rust monorepo. Use when
+  working on ICN code, docs, deployment, or protocol design. Provides crate-aware routing
+  to specialist agents (icn-architect, icn-economist, icn-ops), enforces project conventions,
+  and understands the current sprint state, cluster topology, and demo flow status.
+  Triggers on: any ICN crate names, "cooperative contract", "mutual credit", "governance",
+  "gossip", "K3s", "icn-dev", "ops/mcp", "Sprint", "demo flow", "CCL", "federation",
+  "DID", "ledger", "trust graph", "icnd", "icnctl".
+version: 0.1.0
+truth_contract:
+  canonical_sources:
+    - ops/state/sprint/current.json     # sprint number, tasks, goals (ALWAYS live-read)
+    - ops/state/truth/agents.json       # agent routing table
+    - ops/state/config/repo-map.json    # cluster topology, workspace structure
+  live_load_required:
+    - "cat \"$(git rev-parse --show-toplevel)/ops/state/sprint/current.json\""
+    - "git branch --show-current"
+  examples_only: []
+  never_hardcode:
+    - sprint number (always read from current.json)
+    - cluster IPs (read from repo-map.json)
+    - PR numbers or branch names
+    - demo flow status (live-read from sprint/current.json or kubectl)
+---
+
+# ICN Dev Skill — Routing and Context Layer
+
+This skill is the routing and context layer for ICN development sessions. It loads project state, routes to specialist agents, enforces conventions, and tracks the current sprint.
+
+## Core Principle
+
+Every ICN request passes through three questions:
+1. **Which domain?** Code architecture / economics / deployment / docs / planning
+2. **Which agent?** Route to the specialist with the right mental model
+3. **What's the current state?** Load sprint context before acting
+
+## Specialist Routing
+
+| Domain | Route to | When |
+|--------|----------|------|
+| Crate boundaries, kernel/app separation, public API, refactors, ADRs, protocol shape, concurrency | **icn-architect** | Anything touching crate structure or protocol design |
+| Ledger, CCL, mutual credit, treasury, mana, settlement flows, regulatory terminology, economic invariants | **icn-economist** | Anything touching economics or the compliance sprint |
+| K3s cluster, pods, demo flows, CI, release readiness, ops/mcp, disk space | **icn-ops** | Anything touching deployment or demo validation |
+| Cross-cutting: feature trace, audit, state sync | **/icn-trace, /icn-audit, /icn-state-sync** | Use the commands directly |
+
+**When in doubt:** Use **icn-architect** as the default. It has the broadest view and can re-route.
+
+## Project State (load on every ICN session)
+
+**Always read live state — never trust hardcoded snapshots in this file.**
+
+```bash
+# Sprint state
+cat "$(git rev-parse --show-toplevel)/ops/state/sprint/current.json"
+
+# Open PRs
+gh pr list --repo InterCooperative-Network/icn --json number,title,headRefName,mergeable
+
+# Recent CI
+gh run list --repo InterCooperative-Network/icn --branch main --limit 3 --json status,conclusion,name
+```
+
+**Cluster endpoints** (post Feb-2026 VLAN 30 migration):
+- Control: `10.8.30.40`, Workers: `10.8.30.41`, `10.8.30.42`, Dev VM: `10.8.30.45`
+- Gateway: `10.8.30.40:30080`, Pilot UI: `10.8.30.40:30030`, Metrics: `10.8.30.40:30090`
+
+## Convention Enforcement
+
+When working in this skill context, enforce:
+
+1. **Branch discipline** — always verify `git branch --show-current` before editing. ICN uses feature branches.
+2. **Regulatory terminology** — immediately flag and suggest replacement for: payment, currency, wallet, token, blockchain, transaction fee.
+3. **Kernel/app boundary** — flag changes to kernel crates (icn-identity, icn-trust, icn-net, icn-gossip, icn-core, icn-store, icn-encoding, icn-obs, icn-time, icn-snapshot, icn-security, icn-rpc, icn-crypto-pq, icn-zkp, icn-steward) that need ADR review.
+4. **Test coverage** — new logic in any crate must have tests. Flag if missing.
+5. **Provenance required** — any JournalEntry creation must have provenance set. Flag if empty/None.
+
+## Crate Quick Reference
+
+**Kernel (ADR required for public API changes):**
+icn-identity, icn-trust, icn-net, icn-gossip, icn-privacy, icn-core, icn-store, icn-encoding, icn-obs, icn-rpc, icn-time, icn-snapshot, icn-security, icn-crypto-pq, icn-zkp, icn-steward
+
+**Application (normal change process):**
+icn-ledger, icn-ccl, icn-compute, icn-gateway, icn-governance, icn-federation, icn-community, icn-entity, icn-coop
+
+**Binaries:** icnd, icnctl, icn-console
+
+## Reference Files
+
+**In-repo sources (authoritative):**
+- Sprint state: `icn/ops/state/sprint/current.json`
+- ADRs: `icn/ops/state/decisions/`
+- Architecture: `icn/docs/ARCHITECTURE.md`
+- Current state: `icn/docs/STATE.md`
+- Planning: `icn/docs/planning/` and `icn/docs/strategy/`
+
+**Launchpad docs** (on Zentith / Launchpad HQ — not on this dev VM):
+- `~/.claude_launchpad/projects/icn/icn-crate-reference.md`
+- `~/.claude_launchpad/projects/icn/icn-forward-plan.md`
+- Only accessible if SSH'd to Zentith (10.8.10.100) or running locally there.
+
+## Commands
+
+- `/icn-trace` — map a feature across crates, routes, tests, docs
+- `/icn-audit` — security, trust, and regulatory audit of a code path
+- `/icn-demo-check` — full demo readiness check with live cluster queries
+- `/icn-state-sync` — sync state docs and flag stale documentation
+
+## Operating Rules
+
+1. **State before action.** Read `ops/state/sprint/current.json` before making architectural recommendations. The project is deep into Sprint 26+ — do not reason from first principles about what's been built.
+2. **Regulatory framing is not optional.** The Sovereign Tech Fund grant and cooperative framing depend on clean terminology. Flag violations in code review even when they seem cosmetic.
+3. **The economists and architects don't talk to each other by default.** When a change spans economics AND protocol shape (e.g. changing how the ledger Merkle-DAG is structured), explicitly involve both icn-architect and icn-economist.
+4. **ops/mcp dirty state blocks session continuity.** If icn-dev has uncommitted ops/mcp changes, recommend committing before doing other work. The event bus and decision log aren't trustworthy with dirty state.
+5. **Four demo flows are the acceptance criteria.** "Done" means the relevant demo flows pass. Code that compiles but breaks a demo flow is not done.
+6. **icn-dev disk is a recurring hazard.** Rust build artifacts fill `/var/lib/rancher`. Check before long build sessions. `cargo clean` is safe.

--- a/.agents/skills/integrate-pr-stack/SKILL.md
+++ b/.agents/skills/integrate-pr-stack/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: integrate-pr-stack
+description: Full sprint-batch or stacked-PR integration pipeline. Owns merge order, rebases, local gates, and main sync.
+argument-hint: "[PR numbers...] [--admin] [--dry-run]"
+user-invocable: true
+allowed-tools: "Bash, Read"
+truth_contract:
+  canonical_sources:
+    - ops/state/truth/policy.json       # required checks, merge strategy
+  live_load_required:
+    - "gh pr list --json number,title,headRefName,baseRefName,mergeable,mergeStateStatus"
+    - "gh api repos/InterCooperative-Network/icn/branches/main/protection --jq '.required_status_checks.contexts'"
+  examples_only: []
+  never_hardcode:
+    - PR numbers, branches, or merge order — resolve from GitHub at runtime
+---
+
+Own the full lifecycle of safely integrating a batch of PRs into `main`. This is not a thin wrapper
+around `gh pr merge`. It is the standard integration pipeline for ICN sprint closes.
+
+## Step 0 — Preflight (run first, always)
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+bash "${REPO_ROOT}/ops/scripts/what-matters-now.sh" 2>/dev/null || true
+```
+
+If `what-matters-now.sh` reports drift errors → **stop and fix drift before proceeding**.
+Drift in agent files means the tooling you're running may itself encode stale policy.
+
+## The Problem This Solves
+
+The transcript improvised rebase sequencing, rediscovered branch names mid-flight, and had to
+manually orchestrate the merge order. This skill makes that the default path, not a recovery.
+
+## Steps
+
+### Phase 1: Resolve and classify
+
+For each PR in `$ARGUMENTS` (or all open PRs if none given):
+
+```bash
+# Resolve head branches from GitHub — never trust plan docs
+gh pr list --json number,title,headRefName,baseRefName,mergeable,mergeStateStatus \
+  --jq '.[] | {pr:.number, title:.title, head:.headRefName, base:.baseRefName, mergeable:.mergeable, state:.mergeStateStatus}'
+```
+
+For each PR, fetch required check status:
+```bash
+gh api repos/InterCooperative-Network/icn/branches/main/protection \
+  --jq '.required_status_checks.contexts'
+```
+
+Then for each PR:
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+gh pr checks <N> --json name,state,conclusion \
+  | python3 -c "
+import sys, json
+# Load required checks from canonical source — never hardcode
+required = set(json.load(open('${REPO_ROOT}/ops/state/truth/policy.json'))['merge']['required_checks'])
+checks = json.load(sys.stdin)
+req = [(c['name'],c['state'],c['conclusion']) for c in checks if c['name'] in required]
+opt = [(c['name'],c['state'],c['conclusion']) for c in checks if c['name'] not in required and c['conclusion']=='failure']
+print('REQUIRED:', req)
+print('NON-BLOCKING FAILURES:', opt)
+"
+```
+
+Classify each PR:
+- **GREEN**: all required checks pass, `mergeable=MERGEABLE`
+- **PENDING**: required checks still running
+- **BLOCKED**: a required check failed
+- **UNSTABLE**: only non-blocking checks failed — treat as GREEN for merge purposes
+- **STACKED**: base ≠ main — must be merged after its base PR
+
+### Phase 2: Determine merge order
+
+1. Identify stacked PRs (base ≠ main) and sort them after their dependencies.
+2. Among independent PRs, merge smallest/least-risky first.
+3. If `--dry-run`, print the plan and stop.
+
+Suggested ICN ordering heuristic (from sprint patterns):
+- Security/obs (isolated, small) → compute (isolated) → ledger (medium) → docs/meta (last)
+
+### Phase 3: Integrate loop
+
+For each PR in merge order:
+
+**a. Pre-merge checks**
+```bash
+gh pr view <N> --json mergeable,mergeStateStatus \
+  --jq '"mergeable=\(.mergeable) state=\(.mergeStateStatus)"'
+```
+Stop if `mergeable != MERGEABLE`.
+
+**b. Merge**
+```bash
+# Green required checks → direct merge
+gh pr merge <N> --squash          # or --squash --admin if $ARGUMENTS includes --admin
+
+# Pending required checks → auto-merge (prefer --auto over waiting in a loop)
+gh pr merge <N> --auto --squash
+```
+
+**c. Pull main**
+```bash
+git checkout main && git pull
+```
+
+**d. Rebase remaining PR branches**
+For each remaining PR branch:
+```bash
+git checkout <branch> && git rebase origin/main
+```
+
+After rebase, run scoped local verification before force-pushing:
+```bash
+# Use resolve-rust-targets to find the right scope
+cargo clippy -p <affected-packages> --all-targets -- -D warnings
+```
+
+Only force-push if verification passes:
+```bash
+git push --force-with-lease
+```
+
+**e. Log progress**: `#<N> merged · rebased [branch1, branch2]`
+
+### Phase 4: Finalize
+
+```bash
+# Confirm main state
+git checkout main && git log --oneline -5
+
+# Check for main CI fallout
+gh run list --branch main --limit 3 --json status,conclusion,name,databaseId \
+  --jq '.[] | "\(.databaseId) \(.name) \(.status) \(.conclusion)"'
+```
+
+Print batch summary:
+```
+Merged:   #1389, #1391, #1392, #1390
+Rebased:  feat/s22-compute-policy-config (after #1389), feat/s22-obs-attestation-config (after #1391)
+Main CI:  in_progress (non-blocking only)
+Lessons:  none new
+```
+
+## Guardrails
+
+- **Never trust branch names from plan docs.** Always resolve from `gh pr view <N> --json headRefName`.
+- **UNSTABLE ≠ blocked.** If required checks are green and `mergeable=MERGEABLE`, merge.
+- **After every rebase, run scoped local verification before force-pushing.** The rebase may have
+  introduced new base-crate changes that affect the branch's compilation.
+- **Never skip `git pull` after each merge.** Subsequent rebases need an updated local main.
+- **Stacked PRs must merge in dependency order.** If PR B has base = PR A's branch, merge A first,
+  then update B's base to main before merging B.
+- **`--admin` is for queue-stalled runners only**, not for bypassing genuine failures.
+  Confirm required gates are actually green before using `--admin`.
+
+## ICN-specific notes
+
+- Required gates: `Build Release`, `Test`, `Clippy`, `Format Check` (from branch protection API).
+- Non-blocking: `Test Coverage`, `Compare Against Base`, `Benchmarks`, `Codex-review`.
+- Single self-hosted runner (`ci-runner` at 10.8.30.46) means parallel PRs queue up. A PR
+  showing `pending / 0s` for >30 min is likely queue-stalled, not failing.
+- `mergeStateStatus=UNSTABLE` with `mergeable=MERGEABLE` means only non-blocking checks failed.
+  Safe to merge with `--admin`.
+- After merging multiple PRs in sequence, expect CI on main to run the full workspace build.
+  That's normal — not a sign of regression.

--- a/.agents/skills/repair-gh-workflow/SKILL.md
+++ b/.agents/skills/repair-gh-workflow/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: repair-gh-workflow
+description: Diagnose and fix GitHub Actions failures with branch protection, token permissions, and repo policy in mind.
+argument-hint: "[workflow name | run ID | --main]"
+user-invocable: true
+allowed-tools: "Bash, Read, Edit"
+truth_contract:
+  canonical_sources:
+    - ops/state/truth/policy.json       # required checks, merge strategy (source of truth for CI policy)
+  live_load_required:
+    - "gh run view <RUN_ID> --log-failed"
+    - "gh api repos/InterCooperative-Network/icn/branches/main/protection --jq '.required_status_checks'"
+    - "gh api repos/InterCooperative-Network/icn/actions/runners --jq '.runners[]'"
+  examples_only: []
+  never_hardcode:
+    - required check list (always live-query branch protection API)
+    - GITHUB_TOKEN capabilities (derive from actual workflow context)
+---
+
+Diagnose GitHub Actions failures that involve branch protection, token permissions, or workflow design.
+Start with the protection model, not with the error message alone.
+
+## The Problem This Solves
+
+The transcript's `Sync Website Stats` cron workflow failed daily with `GH006: Protected branch update
+failed`. The fix was clear once branch protection was checked: `GITHUB_TOKEN` cannot push to protected
+`main` regardless of `permissions: contents: write`. That constraint should be known upfront, not
+discovered after a failure has been running for days.
+
+## Steps
+
+### Phase 1: Identify failure context
+
+```bash
+# Find recent failures on main
+gh run list --branch main --limit 10 --json status,conclusion,name,databaseId,createdAt \
+  --jq '.[] | select(.conclusion == "failure") | "\(.databaseId) \(.name) \(.createdAt)"'
+
+# Get failed job and step
+gh api repos/InterCooperative-Network/icn/actions/runs/<RUN_ID>/jobs \
+  --jq '.jobs[] | select(.conclusion == "failure") | {name:.name, steps:[.steps[] | select(.conclusion=="failure") | .name]}'
+```
+
+### Phase 2: Classify failure type
+
+| Error pattern | Class | Fix direction |
+|---------------|-------|---------------|
+| `GH006: Protected branch update failed` | Permission | Don't push to main directly; use PAT or make non-fatal |
+| `remote: Repository not found` | Auth | Token scope or GITHUB_TOKEN missing repo access |
+| `Resource not accessible by integration` | Token scope | Add `permissions:` block to workflow |
+| Exit code 1 on `git push` | Permission or protection | Check branch protection + token capability |
+| Timeout / no logs | Runner contention | Self-hosted runner busy; not a code failure |
+| Missing step output | Upstream step skipped | Check `if:` conditions in prior steps |
+
+### Phase 3: Check branch protection before patching
+
+Always verify the actual protection model before deciding on a fix:
+
+```bash
+gh api repos/InterCooperative-Network/icn/branches/main/protection \
+  --jq '{
+    required_checks: .required_status_checks.contexts,
+    strict: .required_status_checks.strict,
+    enforce_admins: .enforce_admins.enabled,
+    required_approvals: .required_pull_request_reviews.required_approving_review_count
+  }'
+```
+
+**The critical invariant for ICN main**:
+- `GITHUB_TOKEN` (even with `contents: write`) cannot push directly to `main` when `required_status_checks`
+  are set, because the push bypasses the check gates.
+- Only a PAT from an account with admin bypass (and `enforce_admins: false`) can push directly.
+
+### Phase 4: Apply fix by class
+
+**Class: write-back is essential** (data must land in the repo)
+→ Use a PR-based flow:
+```yaml
+- name: Create PR with updated stats
+  run: |
+    git checkout -b chore/update-stats-$(date +%Y%m%d)
+    git commit -m "chore: update stats.json [skip ci]"
+    git push -u origin HEAD
+    gh pr create --title "chore: update stats.json" --body "Automated." --base main
+```
+
+**Class: write-back is a cache warm** (artifact regenerated elsewhere)
+→ Make the push step non-fatal:
+```yaml
+- name: Commit if changed
+  continue-on-error: true   # ← push may be rejected by branch protection; that's OK
+  run: |
+    git add -f path/to/generated-file
+    git diff --quiet --cached || git commit -m "chore: update [skip ci]" && git push
+```
+
+**Class: write-back requires admin**
+→ Add a PAT secret and use it in checkout:
+```yaml
+- uses: actions/checkout@v4
+  with:
+    token: ${{ secrets.ADMIN_PAT }}
+```
+Then document the secret requirement in the workflow comment. Do not add PAT secrets without user approval.
+
+### Phase 5: Verify fix
+
+After patching:
+```bash
+# Trigger a manual run to confirm
+gh workflow run <workflow-name>
+
+# Watch the run
+gh run list --workflow <workflow-file> --limit 3 --json status,conclusion,databaseId \
+  --jq '.[] | "\(.databaseId) \(.status) \(.conclusion // "running")"'
+```
+
+## ICN-specific workflow inventory
+
+| Workflow | File | Failure pattern | Fix class |
+|----------|------|----------------|-----------|
+| `Sync Website Stats` | `sync-stats.yml` | Push to protected main | Cache warm → `continue-on-error: true` (applied PR #1393) |
+| `CI` | `ci.yml` | Various; required gates | Fix code, not workflow |
+| `Build and Deploy to K3s` | `deploy.yml` | Registry push / K3s apply | Infra issue; check cluster |
+| `Benchmarks` | `benchmarks.yml` | Compare fails on base delta | Non-blocking; ignore unless spike |
+
+## Guardrails
+
+- **Never design a workflow that depends on `GITHUB_TOKEN` pushing to protected `main`.** It will fail.
+- **Non-essential write-backs should always have `continue-on-error: true`.** A failed cache warm
+  should never turn a cron workflow red.
+- **Do not add PAT secrets without explicit user approval.** Propose it, wait for confirmation.
+- **Check `enforce_admins` before assuming `--admin` works.** If `enforce_admins: true`, even admin
+  merges require passing checks.
+- **Workflow security**: Never interpolate untrusted GitHub event data (PR titles, issue bodies,
+  commit messages) directly into `run:` commands. Always use `env:` variables with proper quoting.

--- a/.agents/skills/resolve-pr-branch/SKILL.md
+++ b/.agents/skills/resolve-pr-branch/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: resolve-pr-branch
+description: Resolve PR↔branch identity from GitHub. Never trust plan docs or memory for branch names.
+argument-hint: "[PR number | branch name]"
+user-invocable: true
+allowed-tools: "Bash"
+truth_contract:
+  canonical_sources: []
+  live_load_required:
+    - "gh pr view <N> --json number,headRefName,baseRefName,mergeable,mergeStateStatus"
+    - "gh pr list --json number,headRefName,baseRefName"
+  examples_only: []
+  never_hardcode:
+    - branch names (always resolve from GitHub — never trust plan docs or memory)
+    - PR numbers
+    - base branch assumptions
+---
+
+Resolve PR and branch identity from GitHub as the authoritative source. Use this before any
+checkout, rebase, force-push, or when a plan references a branch by name.
+
+## The Problem This Solves
+
+Branch names in plans, notes, and memory drift. The transcript showed a `git checkout feat/s22-compute-config`
+failing because the true head ref was `feat/s22-compute-policy-config`. That lookup took an extra round-trip
+to recover. This skill makes the lookup the first step, not a recovery.
+
+## Steps
+
+1. **Determine lookup direction from `$ARGUMENTS`**:
+   - If argument looks like a number → PR lookup
+   - If argument looks like a branch name → branch lookup
+   - If empty → show all open PRs with their head branches
+
+2. **PR → head branch**:
+   ```bash
+   gh pr view <N> --json number,title,headRefName,baseRefName,state \
+     --jq '{pr: .number, title: .title, head: .headRefName, base: .baseRefName, state: .state}'
+   ```
+
+3. **Branch → PR**:
+   ```bash
+   gh pr list --json number,title,headRefName,state \
+     --jq '.[] | select(.headRefName == "<branch>") | {pr: .number, title: .title, state: .state}'
+   ```
+
+4. **Check local branch existence**:
+   ```bash
+   git branch --list <branch>          # local
+   git ls-remote --heads origin <branch> | grep -q . && echo "exists remotely"
+   ```
+
+5. **Fetch if missing locally but present remotely**:
+   ```bash
+   git fetch origin <branch>
+   ```
+
+6. **Detect stacked PRs** (base ≠ main):
+   ```bash
+   gh pr list --json number,headRefName,baseRefName \
+     --jq '.[] | select(.baseRefName != "main") | "PR #\(.number) \(.headRefName) → \(.baseRefName)"'
+   ```
+
+## Output format
+
+```
+PR #1391 · feat/s22-compute-policy-config → main  [OPEN]
+  local branch: present
+  remote:       present
+  stacked:      no
+```
+
+## Guardrails
+
+- Never proceed with a branch name that hasn't been confirmed against GitHub.
+- When a local checkout fails with "pathspec did not match", immediately run this skill instead of
+  trying other branch name guesses.
+- Treat stacked PRs (base ≠ main) as requiring ordered integration.
+
+## ICN-specific notes
+
+- Sprint plan docs (`ops/state/sprint/current.json`) store branch names that can drift between
+  plan-time and execution-time. Always verify against `gh pr view`.
+- Worktrees in `icn-wt/` hold their own branch refs; a branch that appears absent may just be
+  checked out in a worktree.

--- a/.agents/skills/resolve-rust-targets/SKILL.md
+++ b/.agents/skills/resolve-rust-targets/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: resolve-rust-targets
+description: Resolve Rust package names and verification scope from cargo metadata. Never guess package IDs.
+argument-hint: "[file-path | package-name | --touched]"
+user-invocable: true
+allowed-tools: "Bash"
+truth_contract:
+  canonical_sources:
+    - ops/state/config/repo-map.json    # workspace root (cargo commands from icn/)
+  live_load_required:
+    - "cargo metadata --no-deps --format-version 1"
+    - "git diff --name-only $(git merge-base HEAD origin/main)..HEAD"
+  examples_only: []
+  never_hardcode:
+    - package names (always resolve via cargo metadata — human labels ≠ cargo IDs)
+    - changed file list (always live-query from git)
+---
+
+Use `cargo metadata` as the authoritative source for package names, manifests, and verification scope.
+Run before clippy, test, or build commands when the target package is even slightly uncertain.
+
+## The Problem This Solves
+
+The transcript hit `ledger` → `icn-ledger-app` → `icn-ledger-actor` before landing on the right package.
+That cost two dead-end compile attempts. `cargo metadata` answers this in one call.
+
+## Steps
+
+### Mode 1: Resolve from changed files (`$ARGUMENTS` is `--touched` or empty)
+
+```bash
+# Get files changed on this branch
+git diff --name-only $(git merge-base HEAD origin/main)..HEAD
+
+# Get all workspace package names and their root dirs
+cargo metadata --no-deps --format-version 1 \
+  | python3 -c "
+import sys, json
+md = json.load(sys.stdin)
+for p in md['packages']:
+    root = p['manifest_path'].replace('/Cargo.toml','')
+    print(f\"{p['name']:40s}  {root}\")
+" | sort
+```
+
+Then for each changed file, find its containing package by matching path prefix to manifest root.
+
+### Mode 2: Resolve a human label (`$ARGUMENTS` is a name like "ledger")
+
+```bash
+cargo metadata --no-deps --format-version 1 \
+  | python3 -c "
+import sys, json, difflib
+name = '$ARGUMENTS'
+md = json.load(sys.stdin)
+packages = [(p['name'], p['manifest_path']) for p in md['packages']]
+# Exact match first
+exact = [p for p in packages if p[0] == name]
+if exact:
+    print('EXACT:', exact[0][0])
+else:
+    # Near-match suggestions
+    names = [p[0] for p in packages]
+    close = difflib.get_close_matches(name, names, n=5, cutoff=0.4)
+    for c in close:
+        m = next(p for p in packages if p[0] == c)
+        print(f'NEAR:  {m[0]:40s}  {m[1]}')
+"
+```
+
+### Mode 3: Generate verification commands for a set of packages
+
+Given a list of resolved package names, produce the minimal cargo command set:
+
+```bash
+# For scoped verification (preferred — faster):
+cargo clippy -p <pkg1> -p <pkg2> --all-targets -- -D warnings
+cargo test -p <pkg1> -p <pkg2>
+
+# For cross-cutting changes (bins, icnd, core):
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+## Package taxonomy (ICN workspace)
+
+| Location | Pattern | Example |
+|----------|---------|---------|
+| `icn/crates/<name>/` | `icn-<name>` | `icn-ledger`, `icn-obs`, `icn-security` |
+| `icn/apps/<name>/` | `icn-<name>-actor` or `icn-<name>-app` | `icn-ledger-actor`, `icn-governance-actor` |
+| `icn/bins/<name>/` | `<name>` | `icnd`, `icnctl`, `icn-console` |
+
+Common confusions from the transcript:
+- `"ledger"` → `icn-ledger` (crate) or `icn-ledger-actor` (app) — both exist
+- `"ledger app"` → `icn-ledger-actor`
+- `"icn-ledger-app"` → does not exist; nearest is `icn-ledger-actor`
+- `"obs"` → `icn-obs`
+- `"security"` → `icn-security`
+- `"compute"` → `icn-compute`
+
+## Output
+
+```
+Changed files → packages:
+  icn/crates/icn-obs/src/attestation.rs     icn-obs
+  icn/crates/icn-core/src/config/obs.rs     icn-core
+
+Suggested scoped command:
+  cargo clippy -p icn-obs -p icn-core --all-targets -- -D warnings
+  cargo test -p icn-obs -p icn-core
+```
+
+## Guardrails
+
+- Never run `cargo clippy --workspace` when scoped commands are sufficient.
+- When a package name yields "error: package ID specification did not match", immediately run
+  this skill with the human label to find the correct name before retrying.
+- Bins (`icnd`) depend on everything; touching `icnd/src/main.rs` requires workspace-wide verify.

--- a/.agents/skills/sync-docs/SKILL.md
+++ b/.agents/skills/sync-docs/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: sync-docs
+description: Check for documentation drift — crate inventory vs workspace, GOLDEN_PROMPT freshness, broken doc links.
+argument-hint: "[--fix-index]"
+user-invocable: true
+allowed-tools: "Bash, Read, Grep, Glob"
+truth_contract:
+  canonical_sources:
+    - ops/state/config/repo-map.json    # workspace root
+  live_load_required:
+    - "cargo metadata --no-deps --format-version 1"   # authoritative crate list
+    - "git log --oneline -1 docs/GOLDEN_PROMPT.md 2>/dev/null || echo 'no golden prompt'"
+  examples_only: []
+  never_hardcode:
+    - crate list (always derive from cargo metadata)
+    - doc freshness dates
+---
+
+Audit documentation drift. Reports problems; does not auto-fix (unless --fix-index).
+
+## Checks
+
+### 1. Crate inventory drift
+
+Read workspace members (parse only the `members = [...]` array to avoid picking up dependency versions and paths):
+```bash
+grep -A999 '^\[workspace\]' icn/Cargo.toml | awk '/members *= *\[/,/\]/' | grep '"' | grep -v '#' | sed 's/.*"\(.*\)".*/\1/'
+```
+
+Compare against crate names mentioned in:
+- `docs/planning/icn-crate-reference.md`
+- `docs/ARCHITECTURE.md` (search for `icn-` patterns)
+
+Report:
+- Crates in workspace but NOT documented
+- Crates documented but NOT in workspace (may be removed/renamed)
+
+### 2. GOLDEN_PROMPT.md freshness
+
+```bash
+# Last modification date
+git log -1 --format="%ci" -- docs/GOLDEN_PROMPT.md
+
+# Last git tag date
+git log -1 --format="%ci" $(git describe --tags --abbrev=0 2>/dev/null) 2>/dev/null || echo "no tags"
+
+# Days since last update
+python3 -c "
+from datetime import datetime, timezone
+import subprocess
+result = subprocess.run(['git','log','-1','--format=%ct','--','docs/GOLDEN_PROMPT.md'], capture_output=True, text=True)
+if result.stdout.strip():
+    ts = int(result.stdout.strip())
+    days = (datetime.now(timezone.utc).timestamp() - ts) / 86400
+    print(f'GOLDEN_PROMPT.md last updated {days:.0f} days ago')
+else:
+    print('GOLDEN_PROMPT.md: unknown modification date')
+"
+```
+
+Warn if > 14 days since last update.
+
+### 3. KNOWLEDGE_INDEX.yaml freshness
+
+Check if `docs/dev-journal/KNOWLEDGE_INDEX.yaml` exists:
+- If not: report as missing, suggest creating it
+- If exists: check `last_updated` field vs today, warn if > 7 days stale
+
+### 4. Broken internal doc links (sampled)
+
+Search for markdown links in `docs/` that reference files starting with `../` or `./`:
+```bash
+grep -rn '\]\(\.\.' docs/ --include='*.md' | head -30
+```
+
+For a sample of 10 such links, verify the target file exists. Report missing targets.
+
+### 5. docs/INDEX.md completeness
+
+Count `.md` files in `docs/`:
+```bash
+find docs/ -name '*.md' | wc -l
+```
+
+Count entries in `docs/INDEX.md`:
+```bash
+grep -c '\.md' docs/INDEX.md 2>/dev/null || echo "INDEX.md missing"
+```
+
+Report gap (files not indexed).
+
+## Output
+
+```
+=== Docs Sync Report ===
+
+Crate drift:
+  In workspace, not documented: <list or "none">
+  Documented, not in workspace: <list or "none">
+
+GOLDEN_PROMPT.md: <N> days old <WARN if > 14>
+KNOWLEDGE_INDEX.yaml: <exists/missing> <staleness>
+
+Broken links: <N> checked, <N> broken
+  - <file>:<line> -> <target> (missing)
+
+INDEX.md: <N> .md files in docs/, <N> in INDEX.md, <gap> unindexed
+```
+
+## --fix-index
+
+If `$ARGUMENTS` includes `--fix-index`:
+- Append missing doc paths to `docs/INDEX.md` under an `## Unindexed` section
+- Print: "Added <N> entries to docs/INDEX.md — review and categorize"
+- Do NOT auto-commit
+
+## Important
+
+- Report only. No auto-fixes except `--fix-index`.
+- Do not modify any Rust files.
+- If a crate is in workspace but marked as deprecated/example, note that instead of flagging as undocumented.

--- a/.agents/skills/watch-ci-and-advance/SKILL.md
+++ b/.agents/skills/watch-ci-and-advance/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: watch-ci-and-advance
+description: Monitor CI as a queue system. Advance other ready work while waiting. Report gate deltas, not polls.
+argument-hint: "[PR number | run ID]"
+user-invocable: true
+allowed-tools: "Bash"
+truth_contract:
+  canonical_sources:
+    - ops/state/truth/policy.json       # required_checks, non_blocking_checks, admin_bypass
+    - ops/state/config/repo-map.json    # infrastructure.k3s.ci_runner IP
+  live_load_required:
+    - "gh run list --limit 5 --json databaseId,status,name,conclusion,createdAt"
+    - "gh api repos/InterCooperative-Network/icn/actions/runners --jq '.runners[]'"
+  examples_only:
+    - "The 4-check example in Phase 3 is illustrative — always use all required checks from policy.json"
+  never_hardcode:
+    - required check set or count (read from ops/state/truth/policy.json#merge.required_checks or branch protection API)
+    - runner IP (read from ops/state/config/repo-map.json#infrastructure.k3s.ci_runner)
+---
+
+Treat CI as a queue system. While the runner is busy, do useful work. Report only meaningful
+state changes, not repetitive status dumps.
+
+## The Problem This Solves
+
+The transcript spent significant time in a passive poll cycle: check → still pending → wait → check.
+Meanwhile, other PRs could have been rebased, verified, and readied. This skill turns waiting time
+into advance work.
+
+## Steps
+
+### Phase 1: Assess current queue state
+
+```bash
+# Check if runner is actively processing or just queued
+gh run list --limit 5 --json databaseId,status,name,conclusion,createdAt \
+  --jq '.[] | "\(.databaseId) \(.name) \(.status) \(.conclusion // "running")"'
+```
+
+Classify:
+- `in_progress`: runner is actively working — productive wait
+- `queued` + age > 5 min: runner contention likely
+- `queued` + age > 30 min: definitely queue-stalled, likely safe to `--admin` merge after manual local verify
+
+```bash
+# Check runner health
+gh api repos/InterCooperative-Network/icn/actions/runners \
+  --jq '.runners[] | {name:.name, status:.status, busy:.busy}'
+```
+
+### Phase 2: Identify useful advance work
+
+While CI runs, prioritize in this order:
+
+1. **Rebase other PR branches onto latest main** (no runner needed)
+2. **Run scoped local verification on rebased branches**
+3. **Check main for workflow failures** (may reveal pre-existing breakage)
+4. **Inspect non-running PRs for review comments that can be addressed**
+
+```bash
+# Find PRs not currently in CI queue
+gh pr list --json number,headRefName,statusCheckRollup \
+  --jq '.[] | select(.statusCheckRollup | length == 0 or all(.[]; .state != "IN_PROGRESS")) | .number'
+```
+
+### Phase 3: Report gate deltas, not full dumps
+
+Instead of printing the full check table every poll, track which gates changed:
+
+```bash
+# Snapshot required gates only (read policy.json for the canonical list — never hardcode)
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+REQUIRED=$(python3 -c "
+import json
+p = json.load(open('${REPO_ROOT}/ops/state/truth/policy.json'))
+print(repr(set(p['merge']['required_checks'])))
+")
+gh pr checks <N> --json name,state,conclusion \
+  | python3 -c "
+import sys, json
+required = $REQUIRED
+checks = {c['name']:c for c in json.load(sys.stdin) if c['name'] in required}
+for name, c in sorted(checks.items()):
+    status = c['conclusion'] if c['state'] == 'COMPLETED' else c['state']
+    print(f'{name:20s} {status}')
+"
+```
+
+Output format — only report changes, not repeats:
+```
+[CI delta] Clippy: pass (was pending)
+[CI delta] Build Release: pass (was pending)
+[CI delta] Test: still running
+```
+
+### Phase 4: Merge decision
+
+When required gates resolve:
+- All pass → proceed with merge (use `integrate-pr-stack` for sequencing)
+- A required gate fails → run `fix-ci` or `fix-rust-lints` to address
+- Non-blocking fails → explicitly note "non-blocking only, safe to merge"
+
+## Distinguishing queue stall from genuine failure
+
+| Signal | Meaning |
+|--------|---------|
+| `pending / 0s` for < 5 min | Normal startup delay |
+| `pending / 0s` for 5–30 min | Likely queue contention |
+| `pending / 0s` for > 30 min | Queue-stalled; local verify + `--admin` is valid |
+| `in_progress` for > 20 min | Likely running (full workspace test suite takes ~14 min) |
+| Check disappears after push | Normal: new commit resets CI identity |
+
+## ICN-specific notes
+
+- ICN has one self-hosted runner (`ci-runner`). IP in `ops/state/config/repo-map.json#infrastructure.k3s.ci_runner`. Parallel PR merges cause queue.
+- Full workspace test suite runs ~14 min on the self-hosted runner.
+- Build Release + Clippy + Test tend to run sequentially on the same runner job.
+- `Test Coverage` and `Compare Against Base` often tail the required gates — ignore them for merge decisions.
+- After rebasing a PR branch and force-pushing, GitHub resets its CI run. The old pass result is
+  gone. New run must complete before the PR regains green status. Use `--admin` after local verify
+  if the queue is stalled.
+
+## Guardrails
+
+- Do NOT poll blindly in a loop. Check, do advance work, check again.
+- Do NOT conflate non-blocking failures with merge blockers.
+- Do NOT report the full check table unchanged on every check — that adds noise without signal.
+- When the runner has been busy for > 30 min and local gates pass, inform the user that `--admin`
+  is viable rather than waiting indefinitely.

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ icn/apps/*/Cargo.lock
 # Claude Code
 .claude/settings.local.json
 .claude/.env
+.claude/scheduled_tasks.lock
 
 # Local cargo config overrides (machine-specific, not for CI)
 icn/.cargo/config.user.toml
@@ -108,3 +109,6 @@ icn-wt/
 
 # Playwright MCP debug artifacts (screenshots, console logs, snapshots)
 .playwright-mcp/
+
+# Session scratch artifacts
+.tmp/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,30 @@
 # Contributing to ICN
 
+## Start Here
+
+ICN is a large repo with a strict architecture. Before opening a PR, start from the entrypoint that matches the kind of work you want to do:
+
+- **Code contributions**: read [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md), then [AGENTS.md](AGENTS.md), then this file
+- **Documentation contributions**: use the routing in [README.md](README.md), [docs/INDEX.md](docs/INDEX.md), and [intercooperative.network/get-involved](https://intercooperative.network/get-involved)
+- **Design, testing, research, institutional input**: use the public [Get Involved](https://intercooperative.network/get-involved) page and open a [GitHub Discussion](https://github.com/InterCooperative-Network/icn/discussions) when the work is not already scoped as an issue
+
+## Before You Open a PR
+
+Every contribution should be able to answer these plainly:
+
+1. What exactly changed?
+2. Why is this the right scope?
+3. What risk does it carry?
+4. What checks did you run?
+
+Additional expectations:
+
+- Keep diffs small and reviewable.
+- Work on a branch, not on `main`.
+- Run the verification commands that match the area you touched.
+- Do not weaken invariants, validation, signature requirements, or crate boundaries to make tests pass.
+- If the change affects public wording, docs, or user-facing behavior, make the routing and terminology more truthful, not less.
+
 ## Architectural Guardrails
 
 ### 1. Interfaces First

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ The Rust workspace lives in [`icn/`](icn/). The public site lives in [`website/`
 ## Start Here by Role
 
 - **Understand the project first**: start with [intercooperative.network](https://intercooperative.network), especially [What is ICN](https://intercooperative.network/what-is-icn), [What's Real Now](https://intercooperative.network/whats-real-now), and [Get Involved](https://intercooperative.network/get-involved).
-- **Contribute technically**: read [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md), then [CONTRIBUTING.md](CONTRIBUTING.md), then [docs/onboarding/README.md](docs/onboarding/README.md).
-- **Contribute non-technically**: use the public [Get Involved](https://intercooperative.network/get-involved) page for docs, design, testing, research, policy, and ecosystem paths.
-- **Bring an institutional use case**: read [For Cooperatives](https://intercooperative.network/for-cooperatives) and open a [GitHub Discussion](https://github.com/InterCooperative-Network/icn/discussions).
+- **Contribute technically**: read [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md), then [CONTRIBUTING.md](CONTRIBUTING.md), then [docs/onboarding/README.md](docs/onboarding/README.md). For a first scoped contribution, start with [good first issues](https://github.com/InterCooperative-Network/icn/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue).
+- **Contribute non-technically**: use the public [Get Involved](https://intercooperative.network/get-involved) page for docs, design, testing, research, policy, and ecosystem paths, then open a [GitHub Discussion](https://github.com/InterCooperative-Network/icn/discussions) or issue once the work is concrete.
+- **Bring an institutional use case**: read [For Cooperatives](https://intercooperative.network/for-cooperatives) and [What's Real Now](https://intercooperative.network/whats-real-now), then open a [GitHub Discussion](https://github.com/InterCooperative-Network/icn/discussions).
 - **Support the work financially**: the live rail today is [GitHub Sponsors](https://github.com/sponsors/InterCooperative-Network).
 
 ---

--- a/README.md
+++ b/README.md
@@ -3,13 +3,40 @@
 [![CI](https://github.com/InterCooperative-Network/icn/actions/workflows/ci.yml/badge.svg)](https://github.com/InterCooperative-Network/icn/actions/workflows/ci.yml)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)
 
-A substrate daemon for the cooperative internet.
+A shared infrastructure effort for cooperatives, communities, and federations.
 
 **[intercooperative.network](https://intercooperative.network)**
 
-ICN is a P2P coordination layer for cooperatives, communities, and federations. It is not a blockchain or federation server — it's a constraint engine where apps translate cooperative governance into generic constraints, and the kernel enforces them without understanding their meaning.
+ICN is institutional infrastructure for democratic organizations. It is being built so cooperatives, communities, and federations can prove decisions, operate on infrastructure they control, and coordinate across organizational boundaries without handing those functions to a platform landlord.
+
+The Rust workspace lives in [`icn/`](icn/). The public site lives in [`website/`](website/). The project is large and uneven in maturity, so the fastest way to avoid getting lost is to start from the right entrypoint for your role.
+
+## Start Here by Role
+
+- **Understand the project first**: start with [intercooperative.network](https://intercooperative.network), especially [What is ICN](https://intercooperative.network/what-is-icn), [What's Real Now](https://intercooperative.network/whats-real-now), and [Get Involved](https://intercooperative.network/get-involved).
+- **Contribute technically**: read [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md), then [CONTRIBUTING.md](CONTRIBUTING.md), then [docs/onboarding/README.md](docs/onboarding/README.md).
+- **Contribute non-technically**: use the public [Get Involved](https://intercooperative.network/get-involved) page for docs, design, testing, research, policy, and ecosystem paths.
+- **Bring an institutional use case**: read [For Cooperatives](https://intercooperative.network/for-cooperatives) and open a [GitHub Discussion](https://github.com/InterCooperative-Network/icn/discussions).
+- **Support the work financially**: the live rail today is [GitHub Sponsors](https://github.com/sponsors/InterCooperative-Network).
 
 ---
+
+## Developer Quickstart
+
+If you want to build the codebase and orient quickly:
+
+```bash
+git clone https://github.com/InterCooperative-Network/icn.git
+cd icn/icn
+cargo build
+cargo test --workspace --lib
+```
+
+Before opening a PR, read:
+
+- [AGENTS.md](AGENTS.md) for repo operating rules, verification routing, and invariants
+- [CONTRIBUTING.md](CONTRIBUTING.md) for architectural guardrails
+- [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) for a cleaner contributor-first startup path
 
 ## What ICN Provides
 
@@ -39,43 +66,17 @@ The kernel never sees "trust scores" or "governance rules" — only generic cons
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full architecture documentation.
 
-## Quick Start
+## Repo Map
 
-```bash
-# Build
-cd icn && cargo build --release
+The repo is split across several surfaces:
 
-# Start node alpha (terminal 1)
-./target/release/icnd --config ../config/icn-alpha.toml
+- [`icn/`](icn/) — Rust workspace: crates in `icn/crates/`, runtime apps in `icn/apps/`, binaries in `icn/bins/`
+- [`website/`](website/) — public site for `intercooperative.network`
+- [`docs/`](docs/) — architecture, reference, contributor, and operator documentation
+- [`sdk/`](sdk/) — TypeScript and React Native SDK work
+- [`deploy/`](deploy/) — deployment manifests and cluster configuration
 
-# Start node beta (terminal 2)
-./target/release/icnd --config ../config/icn-beta.toml
-
-# Check status (terminal 3)
-./target/release/icnctl network status
-./target/release/icnctl network peers
-# Nodes discover each other via mDNS within seconds
-```
-
-### Identity Management
-
-```bash
-icnctl id init          # Create identity (DID + keystore)
-icnctl id show          # Show current DID
-icnctl id rotate        # Rotate keys
-icnctl id export b.age  # Export encrypted backup
-```
-
-### Trust & Networking
-
-```bash
-icnctl trust add did:icn:z6Mk... --score 0.8 --label partner
-icnctl trust list
-icnctl network peers
-icnctl network stats
-```
-
-### Ports
+### Common Ports
 
 | Service | Port | Protocol | Purpose |
 |---------|------|----------|---------|
@@ -84,82 +85,18 @@ icnctl network stats
 | Metrics | 9100 | HTTP | Prometheus exporter |
 | Health | 8080 | HTTP | Health checks |
 
-## Project Structure
-
-**35 crates** in `icn/crates/`, **4 app crates** in `apps/`, **3 binaries** in `icn/bins/`.
-
-### Kernel (domain-agnostic)
-
-| Crate | Purpose |
-|-------|---------|
-| `icn-kernel-api` | Trait definitions (PolicyOracle, State, Compute, Comms) |
-| `icn-core` | Tokio runtime, supervisor, actor lifecycle |
-| `icn-net` | QUIC/TLS sessions, mDNS discovery |
-| `icn-gossip` | Topic-based replication with causal ordering |
-| `icn-gateway` | REST + WebSocket API |
-| `icn-rpc` | gRPC API server |
-| `icn-store` | Persistent KV storage (sled) |
-| `icn-obs` | Prometheus metrics, tracing |
-| `icn-identity` | DIDs, Ed25519 keypairs, encrypted keystore |
-| `icn-encoding` | Serialization utilities |
-| `icn-time` | Clock synchronization |
-| `icn-snapshot` | State snapshots for graceful restarts |
-| `icn-api` | Shared validation and error handling |
-| `icn-testkit` | Test utilities |
-
-### Apps (domain-specific, Policy Oracles)
-
-| Crate | Purpose |
-|-------|---------|
-| `apps/trust` | Trust graph → PolicyOracle (rate limits, credit multipliers) |
-| `apps/governance` | GovernanceActor, proposal execution |
-| `apps/ledger` | Ledger reduction and settlement |
-| `apps/echo` | Example app for testing |
-
-### Domain Crates
-
-| Crate | Purpose |
-|-------|---------|
-| `icn-trust` | Trust graph storage and computation |
-| `icn-governance` | Governance primitives (proposals, voting, parameters) |
-| `icn-ledger` | Double-entry mutual credit with Merkle-DAG |
-| `icn-ccl` | Contract language AST, interpreter, fuel metering |
-| `icn-compute` | Distributed compute with trust-gated execution |
-| `icn-federation` | Inter-cooperative coordination |
-| `icn-entity` | Unified entity model |
-| `icn-coop` | Cooperative management |
-| `icn-community` | Community structures |
-| `icn-security` | Byzantine fault detection |
-| `icn-privacy` | Privacy primitives |
-| `icn-crypto-pq` | Post-quantum hybrid cryptography |
-| `icn-steward` | SDIS steward network |
-| `icn-zkp` | Zero-knowledge proofs |
-
-### Binaries
-
-| Binary | Purpose |
-|--------|---------|
-| `icnd` | The ICN daemon |
-| `icnctl` | CLI management tool |
-| `icn-console` | Interactive TUI |
-
 ## Development
 
 ```bash
 cd icn
 
-# Build
 cargo build
-
-# Test
-cargo test --all-features
-
-# Lint
-cargo fmt --check
-cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --lib
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for architectural guardrails and the git workflow.
+Run the checks that match what you touched. [AGENTS.md](AGENTS.md) is the routing table for Rust crates, website work, SDK work, and docs changes.
 
 ## Security
 
@@ -173,21 +110,17 @@ Trust-gated rate limiting enforces per-actor throughput bounds based on trust cl
 
 ## Documentation
 
-- **[Architecture](docs/ARCHITECTURE.md)** — Constraint engine model, kernel/app separation, Policy Oracle pattern
-- **[Getting Started](docs/GETTING_STARTED.md)** — Installation and first steps
-- **[FAQ](docs/FAQ.md)** — Common questions
-- **[Contributing](CONTRIBUTING.md)** — Development workflow and architectural guardrails
-- **[Architecture Index](docs/architecture/)** — Visual diagrams, kernel/app separation details
-- **[Onboarding Modules](docs/onboarding/)** — Deep-dive learning modules
-- **[Production Hardening](docs/production-hardening.md)** — Security and deployment
-- **[Roadmap](docs/strategy/ICN-Roadmap-Live.md)** — Current sprint and tranche progress
-- **[Phase History](docs/PHASE_HISTORY.md)** — Completed development phases
+- **[docs/GETTING_STARTED.md](docs/GETTING_STARTED.md)** — developer and evaluator startup path
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** — contribution guardrails and PR expectations
+- **[docs/onboarding/README.md](docs/onboarding/README.md)** — deeper developer onboarding curriculum
+- **[docs/INDEX.md](docs/INDEX.md)** — master doc navigation
+- **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — architecture deep dive
+- **[docs/STATE.md](docs/STATE.md)** — current project snapshot
+- **[Production Hardening](docs/production-hardening.md)** — security and deployment
 
 ## Status
 
-~198K lines of Rust across 35 crates, 4 app crates, and 3 binaries. Deployed on a K3s cluster since December 2025.
-
-Kernel/app separation (Phases 0-7) is complete. The Charter Engine is live — YAML charter documents produce kernel-enforced constraints. Active development follows [Governance Dispatch Tranches](docs/strategy/ICN-Roadmap-Live.md) (Tranches 9-18), wiring remaining governance decision types through the executor pipeline. Phase 2 (Pilot Launch) is blocked on cooperative partner identification.
+ICN is real, active, and uneven in maturity. The strongest parts today are provenance, cryptographic identity, and the decision-to-record path. Member-facing polish, broader execution coverage, and cleaner onboarding surfaces are still being built. For the current truth plane, read [docs/STATE.md](docs/STATE.md) and the public [What's Real Now](https://intercooperative.network/whats-real-now) page.
 
 ## License
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -62,13 +62,12 @@ Important: the Rust workspace is in the `icn/` subdirectory, not at the repo roo
 ### Verify before you push
 
 ```bash
-cd icn
 cargo fmt --all --check
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --workspace --lib
 ```
 
-Run the checks that match the area you touched. `AGENTS.md` is the routing table for workspace crates, website work, SDK work, and docs.
+Run the checks that match the area you touched from `icn/`, the workspace directory you entered in the build step. `AGENTS.md` is the routing table for workspace crates, website work, SDK work, and docs.
 
 ## Running a Local Node
 
@@ -77,7 +76,6 @@ If you want to inspect the daemon and CLI directly after building:
 ### Create an identity
 
 ```bash
-cd icn
 ./target/debug/icnctl --data-dir ~/.icn id init
 ./target/debug/icnctl --data-dir ~/.icn id show
 ```
@@ -85,14 +83,12 @@ cd icn
 ### Start the daemon
 
 ```bash
-cd icn
 ./target/debug/icnd --data-dir ~/.icn
 ```
 
 ### Check status from another terminal
 
 ```bash
-cd icn
 ./target/debug/icnctl --data-dir ~/.icn status
 ./target/debug/icnctl --data-dir ~/.icn network peers
 ```

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,411 +1,125 @@
 # Getting Started with ICN
 
-Welcome to ICN (Intercooperative Network)! This guide will help you get up and running with ICN in minutes.
+This guide is the contributor and evaluator entrypoint for the ICN repo. It is written for people who want to understand the project, build the codebase, run the main checks, and choose an initial way to help without guessing their way through the repository.
 
-## What is ICN?
+If you are looking for institutional engagement, non-technical contribution, or financial support, use the public [Get Involved](https://intercooperative.network/get-involved) page first.
 
-ICN is a **peer-to-peer coordination substrate** for cooperatives and community organizations. It provides:
+## Choose Your Starting Path
 
-- **Decentralized Identity** (DIDs) with Ed25519 cryptography
-- **Trust Graph** for reputation and access control
-- **Mutual Credit Ledger** for community currency
-- **Gossip Protocol** for P2P communication
-- **Cooperative Contracts** (CCL) for programmable agreements
-- **Governance Primitives** for democratic decision-making
+- **I want to understand the project before building anything**: start with [intercooperative.network/what-is-icn](https://intercooperative.network/what-is-icn), [intercooperative.network/for-developers](https://intercooperative.network/for-developers), and [intercooperative.network/whats-real-now](https://intercooperative.network/whats-real-now)
+- **I want to contribute code**: keep reading this guide, then read [CONTRIBUTING.md](../CONTRIBUTING.md)
+- **I want a deeper technical curriculum**: use [docs/onboarding/README.md](onboarding/README.md)
+- **I want to run a node locally and inspect the daemon**: follow the local-node section below after you build the workspace
 
-Think of it as infrastructure for the cooperative economy - like Git for collaboration, but for economic coordination.
+## Developer Quickstart
 
----
+### Prerequisites
 
-## Quick Start (5 minutes)
+- Rust toolchain from `icn/rust-toolchain.toml`
+- Git
+- Enough disk for a full workspace build and incremental cache
 
-### 1. Install ICN
+### Clone and build
 
-**One-line install** (Linux/macOS):
-```bash
-curl -fsSL https://raw.githubusercontent.com/InterCooperative-Network/icn/main/scripts/install.sh | bash
-```
-
-**Manual install** (build from source):
 ```bash
 git clone https://github.com/InterCooperative-Network/icn.git
 cd icn/icn
-cargo build --release
-sudo cp target/release/{icnd,icnctl} /usr/local/bin/
+cargo build
+cargo test --workspace --lib
 ```
 
-**Verify installation:**
-```bash
-icnctl --version
-icnd --version
-```
+Important: the Rust workspace is in the `icn/` subdirectory, not at the repo root.
 
-### 2. Create Your Identity
+### Read these next
 
-ICN uses decentralized identifiers (DIDs) instead of usernames. Let's create yours:
+1. [README.md](../README.md) — repo map and role-based routing
+2. [AGENTS.md](../AGENTS.md) — verification rules, invariants, and crate layout
+3. [CONTRIBUTING.md](../CONTRIBUTING.md) — PR expectations and architectural guardrails
+4. [docs/onboarding/README.md](onboarding/README.md) — structured contributor path
 
-```bash
-# Use an explicit data dir so icnctl and icnd read the same identity state
-icnctl --data-dir ~/.icn id init
-```
+### Repo orientation
 
-You'll be prompted to:
-1. **Choose a passphrase** (encrypts your private key)
-2. **Confirm the passphrase**
+- `icn/` — Rust workspace
+- `icn/crates/` — core crates and shared subsystems
+- `icn/apps/` — runtime-integrated application crates
+- `icn/bins/` — binaries such as `icnd` and `icnctl`
+- `website/` — public site for `intercooperative.network`
+- `docs/` — architecture, guides, reference material, and onboarding
 
-Your DID will look like: `did:icn:5Xk8Y2r...` (based on your public key)
+### Choose an initial area
 
-**View your identity:**
-```bash
-icnctl --data-dir ~/.icn id show
-```
+- Start with [good first issues](https://github.com/InterCooperative-Network/icn/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue) if you want a scoped first PR
+- Use [GitHub Discussions](https://github.com/InterCooperative-Network/icn/discussions) if the work is exploratory, architectural, institutional, or not yet issue-shaped
+- If you want to read first and patch later, follow the reading order on [For Developers](https://intercooperative.network/for-developers)
 
-### 3. Start the Daemon
-
-ICN runs as a background daemon (`icnd`):
+### Verify before you push
 
 ```bash
-# Start manually (foreground, for testing)
-icnd --data-dir ~/.icn
-
-# Or install as a system service
-sudo systemctl enable --now icnd  # Linux
-sudo launchctl load /Library/LaunchDaemons/com.icn.icnd.plist  # macOS
+cd icn
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --lib
 ```
 
-**Check daemon status:**
-```bash
-icnctl --data-dir ~/.icn status
-```
+Run the checks that match the area you touched. `AGENTS.md` is the routing table for workspace crates, website work, SDK work, and docs.
 
-### 4. Join a Cooperative
+## Running a Local Node
 
-If you're joining an existing cooperative, you need:
-1. The **cooperative's invite link** or **bootstrap node address**
-2. **Trust attestation** from an existing member
+If you want to inspect the daemon and CLI directly after building:
+
+### Create an identity
 
 ```bash
-# Connect to a bootstrap node
-icnctl network add-peer 192.168.1.100:7777 did:icn:abc123...
-
-# Request trust from a member
-# (They run: icnctl trust add did:icn:YOUR_DID 0.5)
+cd icn
+./target/debug/icnctl --data-dir ~/.icn id init
+./target/debug/icnctl --data-dir ~/.icn id show
 ```
 
-### 5. Your First Transaction
-
-Once you're trusted by the cooperative, you can participate in the mutual credit ledger:
+### Start the daemon
 
 ```bash
-# Check your balance
-icnctl ledger balance
-
-# Record a transaction (e.g., "I gave Alice 2 hours of help")
-icnctl ledger pay did:icn:alice... 2 hours "Gardening help"
-
-# View transaction history
-icnctl ledger history
+cd icn
+./target/debug/icnd --data-dir ~/.icn
 ```
 
----
-
-## Core Concepts
-
-### Identity & Trust
-
-- **DID (Decentralized Identifier)**: Your cryptographic identity (e.g., `did:icn:5Xk8Y...`)
-- **Keystore**: Encrypted file storing your private key (`{data_dir}/identity.age`, for example `~/.icn/identity.age` when using `--data-dir ~/.icn`)
-- **Trust Score**: How much the network trusts you (0.0 to 1.0)
-- **Trust Graph**: Web of trust relationships between members
-
-Trust is **transitive**: If Alice trusts Bob (0.8) and Bob trusts Carol (0.6), Alice implicitly trusts Carol (~0.48).
-
-### Mutual Credit Ledger
-
-- **Mutual Credit**: Community currency where balances net to zero
-- **Double-Entry Accounting**: Every transaction has a debit and credit
-- **Credit Limits**: Maximum negative balance (based on trust + history)
-- **Currencies**: Hours, USD, credits, kWh, etc. (configurable per cooperative)
-
-**Example:**
-```
-Alice helps Bob for 2 hours
-  Alice: +2 hours
-  Bob: -2 hours
-  Network total: 0 hours
-```
-
-### Gossip Protocol
-
-ICN uses **gossip** (epidemic broadcast) for P2P communication:
-
-- **Topics**: Channels like `ledger:sync`, `governance:proposals`, `compute:tasks`
-- **Access Control**: Public, private, or trust-gated topics
-- **Anti-Entropy**: Automatic conflict resolution and missing data repair
-- **Vector Clocks**: Track causal ordering of events
-
-You don't need to understand gossip to use ICN - it's automatic!
-
-### Governance
-
-ICN provides **primitives** for democratic decision-making:
-
-- **Domains**: Governance contexts (e.g., "food-coop:membership")
-- **Proposals**: Motions to be voted on
-- **Voting**: For/Against/Abstain with configurable thresholds
-- **Profiles**: Decision rules (consensus, majority, consent, etc.)
+### Check status from another terminal
 
 ```bash
-# Create a governance domain
-icnctl gov domain create --domain-id my-coop --name "My Cooperative"
-
-# Create a proposal
-icnctl gov proposal create --domain-id my-coop --title "Approve new supplier" --kind text
-
-# Vote
-icnctl gov vote cast --proposal-id abc123 --choice for
+cd icn
+./target/debug/icnctl --data-dir ~/.icn status
+./target/debug/icnctl --data-dir ~/.icn network peers
 ```
 
----
+### Useful local endpoints
 
-## Common Workflows
+- Gateway health: `http://localhost:8080/v1/health`
+- Metrics: `http://localhost:9100/metrics`
 
-### Set Up a New Cooperative
+## Other Real Ways to Help
 
-1. **Choose a member** to initialize:
-   ```bash
-   icnctl init-coop --name "My Food Coop" --members "did:icn:alice,did:icn:bob,did:icn:carol"
-   ```
+If you are not contributing Rust code, there are still real paths:
 
-2. **Set initial trust**:
-   ```bash
-   # Members trust each other
-   icnctl trust add did:icn:alice 0.8
-   icnctl trust add did:icn:bob 0.8
-   ```
+- docs, design, testing, research, governance, and ecosystem work are routed through [intercooperative.network/get-involved](https://intercooperative.network/get-involved)
+- institutional use cases and partnership questions belong in [GitHub Discussions](https://github.com/InterCooperative-Network/icn/discussions)
+- financial support goes through [GitHub Sponsors](https://github.com/sponsors/InterCooperative-Network)
 
-3. **Create governance domain**:
-   ```bash
-   icnctl gov domain create --domain-id food-coop --name "Food Coop Governance"
-   ```
+## What This Guide Does Not Promise
 
-4. **Set credit policies** (optional):
-   ```bash
-   # Via CCL contract or manual configuration
-   # See docs/economic-safety.md for details
-   ```
+- a polished non-technical onboarding flow for ordinary members
+- a hosted sign-up path or managed pilot program
+- a finished member-facing product surface
 
-### Backup Your Identity
+Those are still in progress. This guide is for building, reading, testing, and contributing against the repo as it exists today.
 
-**IMPORTANT**: Your keystore is your identity. Back it up!
+## Next Documents
 
-```bash
-# Backup entire data directory (keystore + ledger + trust graph)
-icnctl backup ~/icn-backup-$(date +%Y%m%d).tar.gz.age
+- [README.md](../README.md) for the repo map and public-routing layer
+- [CONTRIBUTING.md](../CONTRIBUTING.md) for PR expectations and architectural guardrails
+- [onboarding/README.md](onboarding/README.md) for the longer contributor curriculum
+- [ARCHITECTURE.md](ARCHITECTURE.md) and [STATE.md](STATE.md) if you need deeper technical and project-status context
 
-# Restore from backup
-icnctl restore ~/icn-backup-20251121.tar.gz.age --force
-```
+## Where To Ask Or Contribute Next
 
-Store backups:
-- **Off-site** (cloud storage, different physical location)
-- **Encrypted** (backups are Age-encrypted with your passphrase)
-- **Regularly** (weekly for active cooperatives)
-
-### Monitor Your Node
-
-1. **Gateway Health Endpoint**:
-   ```bash
-   curl http://localhost:8080/v1/health
-   ```
-
-2. **Prometheus Metrics**:
-   ```
-   curl http://localhost:9100/metrics
-   ```
-
-3. **Health Check**:
-   ```bash
-   curl http://localhost:8080/v1/health
-   icnctl network status
-   ```
-
-### Multi-Device Setup
-
-Use your identity on multiple devices (laptop + phone):
-
-```bash
-# On Device 1 (primary)
-icnctl device add --name "My Phone" --capabilities sign
-
-# On Device 2 (new device)
-# 1. Copy the device keypair from Device 1
-# 2. Import and approve the device
-icnctl device list
-```
-
-See [Multi-Device Identity Design](design/multi-device-identity-design.md) for details.
-
----
-
-## Authentication for Web/Mobile Apps
-
-ICN provides a **Gateway API** for building user-facing applications:
-
-1. **Get a JWT token**:
-   ```bash
-   icnctl auth token --gateway http://localhost:8080 --coop-id my-coop
-   ```
-
-2. **Use the token** in HTTP requests:
-   ```bash
-   curl -H "Authorization: Bearer eyJ0eXAi..." \
-        http://localhost:8080/v1/coops/my-coop
-   ```
-
-3. **WebSocket for real-time updates**:
-   ```javascript
-   const ws = new WebSocket('ws://localhost:8080/v1/ws/my-coop');
-   ws.send(JSON.stringify({type: 'Auth', token: 'eyJ0eXAi...'}));
-   ```
-
-See [Platform Layer Design](design/platform-layer-design.md) and the TypeScript SDK ([sdk/typescript/](../sdk/typescript/)).
-
----
-
-## Troubleshooting
-
-### "Identity already exists"
-You've already run `icnctl id init`. View your existing identity:
-```bash
-icnctl id show
-```
-
-### "Failed to unlock keystore"
-Wrong passphrase. Try again or restore from backup.
-
-### "No peers connected"
-Your node hasn't discovered peers yet. Either:
-1. Wait for mDNS discovery (~30 seconds on LAN)
-2. Manually add a peer: `icnctl network add-peer <addr> <did>`
-3. Check firewall settings (port 7777/UDP for QUIC)
-
-### "Transaction rejected: insufficient credit"
-You've hit your credit limit. Either:
-1. Receive payments from others (increase balance)
-2. Build more trust (increases limit)
-3. Wait for credit limit ramp (new members have throttled limits)
-
-### "Proposal not found"
-The proposal hasn't gossiped to your node yet. Wait 10-30 seconds and try again.
-
-### Logs and Debugging
-```bash
-# View logs (systemd)
-journalctl -u icnd -f
-
-# View logs (manual run)
-RUST_LOG=debug icnd
-
-# Check network connectivity
-icnctl network peers
-icnctl network status
-```
-
----
-
-## Next Steps
-
-### Learn More
-- [Architecture Overview](ARCHITECTURE.md) - How ICN works under the hood
-- [Operations Guide](guides/operations/operations-guide.md) - Day-to-day management
-- [Economic Safety](design/economics/economic-safety.md) - Credit limits, dispute resolution
-- [Governance Primitives](design/governance/governance-primitives.md) - Democratic decision-making
-- [Deployment Guide](operations/deployment/deployment-guide.md) - Production deployment
-
-### Build on ICN
-
-**Quick TypeScript Example**:
-```typescript
-import { ICNClient } from '@icn/client';
-
-const client = new ICNClient({ baseUrl: 'http://localhost:8080' });
-
-// Authenticate (you provide signing logic)
-await client.authenticate('did:icn:alice', signer, 'my-coop', ['ledger:read']);
-
-// Make a payment
-await client.pay('my-coop', {
-  from: 'did:icn:alice',
-  to: 'did:icn:bob',
-  amount: 5,
-  currency: 'hours',
-});
-
-// Submit a compute task
-const task = await client.submitTask({
-  code: JSON.stringify(cclContract),
-  fuel_limit: 10000,
-});
-const result = await client.waitForTask(task.task_hash);
-```
-
-**More Resources**:
-- [Gateway API Reference](reference/api/API_REFERENCE.md) - REST + WebSocket API
-- [TypeScript SDK](../sdk/typescript/) - `@icn/client` npm package
-- [Platform Layer Design](design/platform-layer-design.md) - App architecture
-
-### Get Help
-- **GitHub Issues**: https://github.com/InterCooperative-Network/icn/issues
-- **Documentation**: All docs in `docs/` directory
-- **Examples**: See `examples/` directory
-
-### Contribute
-- [Contributing Guide](../CONTRIBUTING.md) - How to contribute
-- [Code of Conduct](../CODE_OF_CONDUCT.md) - Community standards
-- [Phase History](PHASE_HISTORY.md) - Completed development phases
-- [Current TODO](TODO.md) - What's being built next
-
----
-
-## Quick Reference Card
-
-```bash
-# Identity
-icnctl id init              # Create new identity
-icnctl id show              # View your DID
-icnctl id rotate            # Rotate to new keypair
-
-# Trust
-icnctl trust add <did> <score>     # Add trust edge
-icnctl trust list                  # View trust graph
-icnctl trust score <did>           # Query trust score
-
-# Ledger
-icnctl ledger balance              # Check balance
-icnctl ledger pay <did> <amount> <currency> <memo>
-icnctl ledger history              # Transaction history
-
-# Governance
-icnctl gov domain create --domain-id <id> --name <name>
-icnctl gov proposal create --domain-id <id> --title <title>
-icnctl gov vote cast --proposal-id <id> --choice for|against|abstain
-
-# Network
-icnctl network status              # Show peers, gossip state
-icnctl network add-peer <addr> <did>  # Manual peering
-
-# Backup
-icnctl backup <path>               # Create encrypted backup
-icnctl restore <path>              # Restore from backup
-
-# Daemon
-icnd                               # Start daemon (foreground)
-icnctl status                      # Check daemon status
-```
-
----
-
-**Welcome to the cooperative internet!** 🎉
-
-If you have questions, check the [docs/](.) directory or open a [GitHub issue](https://github.com/InterCooperative-Network/icn/issues).
+- Use [GitHub Issues](https://github.com/InterCooperative-Network/icn/issues) for scoped implementation and documentation work
+- Use [GitHub Discussions](https://github.com/InterCooperative-Network/icn/discussions) for design questions, institutional use cases, and broader project conversation
+- Use [intercooperative.network/get-involved](https://intercooperative.network/get-involved) if you are deciding how to help across technical, non-technical, institutional, or financial paths

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -52,6 +52,13 @@ Important: the Rust workspace is in the `icn/` subdirectory, not at the repo roo
 - Use [GitHub Discussions](https://github.com/InterCooperative-Network/icn/discussions) if the work is exploratory, architectural, institutional, or not yet issue-shaped
 - If you want to read first and patch later, follow the reading order on [For Developers](https://intercooperative.network/for-developers)
 
+### If you are helping without writing Rust
+
+- Documentation work: use [docs/INDEX.md](INDEX.md) to find the right surface, then open a scoped docs issue or PR
+- Design, research, testing, and ecosystem work: use [intercooperative.network/get-involved](https://intercooperative.network/get-involved) for the current public routing, then move concrete proposals into [GitHub Discussions](https://github.com/InterCooperative-Network/icn/discussions)
+- Institutional questions: start with [intercooperative.network/for-cooperatives](https://intercooperative.network/for-cooperatives) and [intercooperative.network/whats-real-now](https://intercooperative.network/whats-real-now), then open a Discussion with the real use case
+- Financial support: the live path today is [GitHub Sponsors](https://github.com/sponsors/InterCooperative-Network)
+
 ### Verify before you push
 
 ```bash

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -35,12 +35,20 @@ Welcome to the ICN (Intercooperative Network) documentation! This index provides
 ## 📋 Quick Navigation
 
 - **New to ICN?** → Start with [Getting Started Guide](GETTING_STARTED.md)
+- **Looking for the public engagement map?** → Start with [intercooperative.network/get-involved](https://intercooperative.network/get-involved)
 - **Understanding the system?** → Read [Architecture Overview](ARCHITECTURE.md)
 - **Building the public site?** → Start with [Design Language Brief v0](design-language/brief-v0.md)
 - **Building features?** → Check [Developer Guides](#developer-guides)
 - **Deploying ICN?** → See [Operations Guides](#operations-guides)
 - **Looking for APIs?** → Browse [API Reference](#api-reference)
 - **Historical context?** → Explore [Archives](#archives)
+
+### Start here by role
+
+- **Developer or technical contributor**: [GETTING_STARTED.md](GETTING_STARTED.md) → [CONTRIBUTING.md](../CONTRIBUTING.md) → [onboarding/README.md](onboarding/README.md)
+- **Non-technical contributor**: [intercooperative.network/get-involved](https://intercooperative.network/get-involved)
+- **Institutional partner or cooperative evaluator**: [intercooperative.network/for-cooperatives](https://intercooperative.network/for-cooperatives) and [intercooperative.network/whats-real-now](https://intercooperative.network/whats-real-now)
+- **Financial supporter**: [GitHub Sponsors](https://github.com/sponsors/InterCooperative-Network)
 
 ### Design language (canonical)
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -45,9 +45,9 @@ Welcome to the ICN (Intercooperative Network) documentation! This index provides
 
 ### Start here by role
 
-- **Developer or technical contributor**: [GETTING_STARTED.md](GETTING_STARTED.md) → [CONTRIBUTING.md](../CONTRIBUTING.md) → [onboarding/README.md](onboarding/README.md)
-- **Non-technical contributor**: [intercooperative.network/get-involved](https://intercooperative.network/get-involved)
-- **Institutional partner or cooperative evaluator**: [intercooperative.network/for-cooperatives](https://intercooperative.network/for-cooperatives) and [intercooperative.network/whats-real-now](https://intercooperative.network/whats-real-now)
+- **Developer or technical contributor**: [GETTING_STARTED.md](GETTING_STARTED.md) → [CONTRIBUTING.md](../CONTRIBUTING.md) → [onboarding/README.md](onboarding/README.md) → [good first issues](https://github.com/InterCooperative-Network/icn/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue)
+- **Non-technical contributor**: [intercooperative.network/get-involved](https://intercooperative.network/get-involved) → [GitHub Discussions](https://github.com/InterCooperative-Network/icn/discussions)
+- **Institutional partner or cooperative evaluator**: [intercooperative.network/for-cooperatives](https://intercooperative.network/for-cooperatives) → [intercooperative.network/whats-real-now](https://intercooperative.network/whats-real-now) → [GitHub Discussions](https://github.com/InterCooperative-Network/icn/discussions)
 - **Financial supporter**: [GitHub Sponsors](https://github.com/sponsors/InterCooperative-Network)
 
 ### Design language (canonical)

--- a/docs/onboarding/manual.md
+++ b/docs/onboarding/manual.md
@@ -223,7 +223,7 @@ Governance is how communities change rules without breaking trust.
 
 - `docs/onboarding/reference/module-14-governance-ccl-deep-dive.md`
 - `icn/crates/icn-governance/`
-- `docs/governance-primitives.md`
+- `docs/design/governance/governance-primitives.md`
 
 ## Part 6: Gateway, SDK, and Web UI
 

--- a/docs/onboarding/path/phase-2-architecture/05-the-meaning-firewall.md
+++ b/docs/onboarding/path/phase-2-architecture/05-the-meaning-firewall.md
@@ -178,7 +178,7 @@ if trust_score < 0.5 {
 #### **✅ CORRECT: Oracle Translating Trust to Constraints**
 
 ```rust
-// In icn/crates/icn-net/src/actor.rs (CORRECT)
+// In icn/crates/icn-net/src/actor/mod.rs (CORRECT)
 let request = PolicyRequest::new(
     peer_did.clone(),
     ActionKind::custom("dial_peer"),

--- a/docs/onboarding/path/phase-3-systems/gate-3.md
+++ b/docs/onboarding/path/phase-3-systems/gate-3.md
@@ -67,7 +67,7 @@ Complete **all three** artifacts below. Each demonstrates systems-level understa
 **Requirements**:
 - Practical, specific, actionable
 - Includes code examples or real file paths
-- Submitted as markdown in `docs/onboarding/resources/` or in #onboarding
+- Submitted as markdown in `docs/onboarding/resources/` or in a project discussion thread
 
 **Verification**: Your teaching artifact helps another contributor solve a problem.
 

--- a/docs/onboarding/path/phase-4-ownership/10-federation-and-ops.md
+++ b/docs/onboarding/path/phase-4-ownership/10-federation-and-ops.md
@@ -78,5 +78,5 @@ You've completed this layer when you can:
 
 → `reference/module-11-federation.md` — Full federation protocol  
 → `reference/module-09-ops-deploy.md` — Deployment, monitoring, backups  
-→ `docs/HOMELAB_DEPLOYMENT.md` — Live deployment example  
+→ `docs/operations/deployment/HOMELAB_DEPLOYMENT.md` — Live deployment example
 → `deploy/k8s/README.md` — Kubernetes deployment guide

--- a/docs/onboarding/path/phase-4-ownership/11-maintainer.md
+++ b/docs/onboarding/path/phase-4-ownership/11-maintainer.md
@@ -44,7 +44,7 @@ Maintainers make architectural decisions, review boundary-crossing PRs, and ment
 
 ### 4. Load Testing
 
-**File**: `icn/tests/load_tests.rs`
+**Reference docs**: `docs/performance/BENCHMARKS.md`, `docs/performance/PROFILING.md`
 
 Simulate 100+ nodes, 1000+ messages/sec, measure:
 - Gossip convergence time

--- a/docs/onboarding/reading-map.md
+++ b/docs/onboarding/reading-map.md
@@ -4,13 +4,13 @@ This map links each module to the highest-signal files and docs.
 
 ## Module 0: Setup and tooling
 - `README.md`
-- `docs/DEV_ENVIRONMENT.md`
+- `docs/guides/developer/DEV_ENVIRONMENT.md`
 - `CONTRIBUTING.md`
 - `scripts/dev-setup.sh`
 
 ## Module 1: Rust fundamentals
 - `icn/` crate structure
-- `icn/crates/*/src/lib.rs` (public APIs)
+- `icn/crates/` (see each crate's `src/lib.rs` for public APIs)
 
 ## Module 2: ICN architecture overview
 - `docs/ARCHITECTURE.md`
@@ -26,19 +26,19 @@ This map links each module to the highest-signal files and docs.
 - `icn/crates/icn-identity/`
 - `icn/crates/icn-trust/`
 - `docs/ARCHITECTURE.md` (Identity, Trust sections)
-- `docs/multi-device-identity-design.md`
+- `docs/design/multi-device-identity-design.md`
 
 ## Module 5: Network and gossip
 - `icn/crates/icn-net/`
 - `icn/crates/icn-gossip/`
 - `docs/ARCHITECTURE.md` (Network, Gossip sections)
-- `docs/gossip-signed-envelope-migration.md`
+- `docs/development/gossip-signed-envelope-migration.md`
 
 ## Module 6: Ledger and contracts
 - `icn/crates/icn-ledger/`
 - `icn/crates/icn-ccl/`
 - `docs/ARCHITECTURE.md` (Ledger, Contracts sections)
-- `docs/governance-primitives.md`
+- `docs/design/governance/governance-primitives.md`
 
 ## Module 7: Gateway API and SDK
 - `icn/crates/icn-gateway/README.md`
@@ -79,4 +79,4 @@ This map links each module to the highest-signal files and docs.
 ## Module 14: Governance and CCL deep dive
 - `icn/crates/icn-governance/`
 - `icn/crates/icn-ccl/`
-- `docs/governance-primitives.md`
+- `docs/design/governance/governance-primitives.md`

--- a/docs/onboarding/reference/module-00-setup.md
+++ b/docs/onboarding/reference/module-00-setup.md
@@ -43,7 +43,7 @@ and be ready to explore the codebase.
 - `README.md` - Project overview
 - `CLAUDE.md` - Developer guidance and conventions
 - `CONTRIBUTING.md` - How to contribute
-- `docs/DEV_ENVIRONMENT.md` - Detailed environment setup
+- `docs/guides/developer/DEV_ENVIRONMENT.md` - Detailed environment setup
 
 ## Walkthrough
 

--- a/docs/onboarding/reference/module-09-ops-deploy.md
+++ b/docs/onboarding/reference/module-09-ops-deploy.md
@@ -21,7 +21,7 @@ By the end of this module, you will:
 - `deploy/README.md`
 - `config/README.md`
 - `docs/security/production-hardening.md`
-- `docs/HOMELAB_DEPLOYMENT.md`
+- `docs/operations/deployment/HOMELAB_DEPLOYMENT.md`
 
 ---
 

--- a/docs/onboarding/reference/module-10-contributor-workflow.md
+++ b/docs/onboarding/reference/module-10-contributor-workflow.md
@@ -721,7 +721,7 @@ Update documentation when you:
 | Architecture | `docs/ARCHITECTURE.md` |
 | API reference | Code doc comments + OpenAPI |
 | Onboarding | `docs/onboarding/reference/` |
-| Deployment | `deploy/README.md`, `docs/HOMELAB_DEPLOYMENT.md` |
+| Deployment | `deploy/README.md`, `docs/operations/deployment/HOMELAB_DEPLOYMENT.md` |
 | Security | `docs/security/`, `docs/security/production-hardening.md` |
 | Changelog | `CHANGELOG.md` |
 

--- a/docs/onboarding/reference/module-14-governance-ccl-deep-dive.md
+++ b/docs/onboarding/reference/module-14-governance-ccl-deep-dive.md
@@ -18,7 +18,7 @@ the "how" and "why" of policy creation, voting, and capability enforcement.
 ## Key Reading
 - `icn/crates/icn-governance/` - Governance engine
 - `icn/crates/icn-ccl/` - Contract language implementation
-- `docs/governance-primitives.md` - Governance system reference
+- `docs/design/governance/governance-primitives.md` - Governance system reference
 - `icn/crates/icn-governance/tests/governance_integration.rs`
 
 ---

--- a/docs/onboarding/resources/README.md
+++ b/docs/onboarding/resources/README.md
@@ -1,0 +1,7 @@
+# Onboarding Resources
+
+This directory exists as a drop point for onboarding artifacts referenced by the
+curriculum.
+
+If a module or gate asks for a short written artifact, store it here unless the
+project is using a different explicitly named surface for that exercise.

--- a/docs/onboarding/workshops/workshop-03-runtime.md
+++ b/docs/onboarding/workshops/workshop-03-runtime.md
@@ -106,7 +106,7 @@ self.wire_gossip_to_ledger().await?;
 
 1. **Message-passing handles** (e.g., `NetworkActor`):
    ```rust
-   // icn/crates/icn-net/src/actor.rs:122
+   // icn/crates/icn-net/src/actor/mod.rs
    pub struct NetworkHandle {
        tx: mpsc::Sender<NetworkCommand>,
    }

--- a/docs/onboarding/workshops/workshop-05-network-gossip.md
+++ b/docs/onboarding/workshops/workshop-05-network-gossip.md
@@ -30,7 +30,7 @@ including topic subscriptions, vector clocks, and anti-entropy synchronization.
 ## Part 1: Network Actor Structure
 
 ### Steps
-1. Open `icn/crates/icn-net/src/actor.rs`
+1. Open `icn/crates/icn-net/src/actor/mod.rs`
 2. Find the `NetworkActor` struct definition
 3. Identify the key components: endpoint, sessions, router
 

--- a/docs/onboarding/workshops/workshop-14-governance-ccl.md
+++ b/docs/onboarding/workshops/workshop-14-governance-ccl.md
@@ -22,7 +22,7 @@ enforces cooperative policy decisions.
 ## Related Materials
 - `icn/crates/icn-governance/`
 - `icn/crates/icn-ccl/`
-- `docs/governance-primitives.md`
+- `docs/design/governance/governance-primitives.md`
 
 ---
 

--- a/ops/state/truth/skills.json
+++ b/ops/state/truth/skills.json
@@ -3,7 +3,7 @@
   "description": "Registry of all skills with canonical paths and ownership. Generated indexes and routing tables should derive from here. Do not maintain separate skill lists in prompt files.",
   "canonical_skill_sources": {
     "ops_automation": "ops/automation/skills/",
-    "icn_level": ".claude/skills/",
+    "icn_level": ".agents/skills/",
     "project_level": "../../../.claude/skills/"
   },
   "note_on_duplication": "ops/automation/skills/ is the canonical source for shared operational skills. The project-level .claude/skills/ for {status, sync-and-build, worktree} MUST be symlinks to ops/automation/skills/. Run ops/scripts/setup-skill-symlinks.sh to create/verify.",
@@ -41,9 +41,9 @@
       "resume-session", "rust-verify", "update-session-state"
     ],
     "overlapping_ownership_notes": {
-      "fix-ci": "Both icn-level and project-level have this. icn/.claude/skills/fix-ci is authoritative for ICN-specific CI work.",
-      "icn-preflight": "Both levels have this. icn/.claude/skills/icn-preflight is authoritative — it uses the ICN-specific change routing matrix.",
-      "merge-prs": "Both levels have this. icn/.claude/skills/merge-prs is authoritative for ICN — has the correct squash policy and 10 required checks."
+      "fix-ci": "Both icn-level and project-level have this. .agents/skills/fix-ci is authoritative for ICN-specific CI work.",
+      "icn-preflight": "Both levels have this. .agents/skills/icn-preflight is authoritative — it uses the ICN-specific change routing matrix.",
+      "merge-prs": "Both levels have this. .agents/skills/merge-prs is authoritative for ICN — has the correct squash policy and 10 required checks."
     }
   }
 }

--- a/website/src/components/Icon.astro
+++ b/website/src/components/Icon.astro
@@ -51,8 +51,8 @@ if (!icon) {
 
 const isDecorative = !label;
 const accessibilityAttrs = isDecorative
-  ? { 'aria-hidden': 'true' }
-  : { role: 'img', 'aria-label': label };
+  ? { 'aria-hidden': true }
+  : { role: 'img' as const, 'aria-label': label };
 ---
 
 <svg

--- a/website/src/components/ReadingLadder.astro
+++ b/website/src/components/ReadingLadder.astro
@@ -145,7 +145,7 @@ function isFork(
     --ladder-accent: var(--accent-teal);
     --ladder-rail: var(--border-default);
     margin: 0;
-    padding: var(--space-xl) 0 0;
+    padding: var(--space-sm) 0 0;
     display: flex;
     flex-direction: column;
     gap: var(--space-lg);
@@ -189,6 +189,7 @@ function isFork(
     transition:
       border-color var(--duration-fast) var(--ease-out),
       background var(--duration-fast) var(--ease-out);
+    min-width: 0;
   }
 
   .ladder-link:hover {
@@ -215,6 +216,8 @@ function isFork(
     letter-spacing: -0.01em;
     flex: 1;
     min-width: 0;
+    overflow-wrap: anywhere;
+    word-break: normal;
   }
 
   /* Current step: teal-bordered, with a dot marker AND a "you are here"
@@ -303,6 +306,7 @@ function isFork(
     transition:
       border-color var(--duration-fast) var(--ease-out),
       background var(--duration-fast) var(--ease-out);
+    min-width: 0;
   }
 
   .ladder-fork-opt.ladder-link:hover {
@@ -349,9 +353,18 @@ function isFork(
       padding: var(--space-md);
       height: 100%;
     }
+    .ladder-fork-options {
+      min-width: 0;
+    }
     .ladder-fork-num {
       min-width: 0;
       align-self: flex-start;
+    }
+    .ladder-fork-opt {
+      align-items: flex-start;
+    }
+    .ladder-fork-opt .ladder-label {
+      width: 100%;
     }
   }
 
@@ -399,6 +412,7 @@ function isFork(
     font-size: 1rem;
     color: var(--text-heading);
     line-height: 1.3;
+    overflow-wrap: anywhere;
   }
 
   .ladder-nav-next-wrap {

--- a/website/src/components/Search.astro
+++ b/website/src/components/Search.astro
@@ -1,6 +1,12 @@
 ---
+interface SearchItem {
+  slug: string;
+  title: string;
+  description?: string;
+}
+
 interface Props {
-  searchList: any[];
+  searchList: SearchItem[];
 }
 
 const { searchList } = Astro.props;
@@ -37,7 +43,13 @@ const { searchList } = Astro.props;
   class SearchComponent extends HTMLElement {
     constructor() {
       super();
-      const listData = JSON.parse(this.dataset.list || '[]');
+      type SearchItem = {
+        slug: string;
+        title: string;
+        description?: string;
+      };
+
+      const listData = JSON.parse(this.dataset.list || '[]') as SearchItem[];
       const input = this.querySelector('input');
       const countEl = this.querySelector('#match-count');
       const countContainer = this.querySelector('#search-results-count');
@@ -46,25 +58,25 @@ const { searchList } = Astro.props;
       
       if (!input) return;
 
-      const fuse = new Fuse(listData, {
+      const fuse = new Fuse<SearchItem>(listData, {
         keys: ['title', 'slug', 'description'],
         threshold: 0.4,
         ignoreLocation: true,
       });
 
       // Local Storage Helpers
-      const getRecent = () => {
+      const getRecent = (): string[] => {
         try {
-          return JSON.parse(localStorage.getItem('icn-recent-searches') || '[]');
+          return JSON.parse(localStorage.getItem('icn-recent-searches') || '[]') as string[];
         } catch {
           return [];
         }
       };
 
-      const addRecent = (term) => {
+      const addRecent = (term: string) => {
         if (!term) return;
         let recent = getRecent();
-        recent = [term, ...recent.filter(t => t !== term)].slice(0, 5);
+        recent = [term, ...recent.filter((t: string) => t !== term)].slice(0, 5);
         localStorage.setItem('icn-recent-searches', JSON.stringify(recent));
       };
 
@@ -75,7 +87,7 @@ const { searchList } = Astro.props;
           recentContainer.classList.add('hidden');
           return;
         }
-        recentList.innerHTML = recent.map(term => `
+        recentList.innerHTML = recent.map((term: string) => `
           <li>
             <button type="button" class="recent-item">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>

--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -19,6 +19,7 @@ const blog = defineCollection({
     pubDate: z.coerce.date(),
     updatedDate: z.coerce.date().optional(),
     heroImage: z.string().optional(),
+    tags: z.array(z.string()).optional(),
   }),
 });
 

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -79,6 +79,7 @@ const jsonLd = {
         <li><a href="/for-developers" class:list={[{ active: activeNav === 'for-developers' || currentPath.startsWith('/for-developers') }]} aria-current={activeNav === 'for-developers' || currentPath.startsWith('/for-developers') ? 'page' : undefined}>For Developers</a></li>
         <li><a href="/get-involved" class:list={[{ active: activeNav === 'get-involved' || currentPath.startsWith('/get-involved') }]} aria-current={activeNav === 'get-involved' || currentPath.startsWith('/get-involved') ? 'page' : undefined}>Get Involved</a></li>
         <li><a href="/docs" class:list={[{ active: activeNav === 'docs' || currentPath.startsWith('/docs') || currentPath.startsWith('/architecture') }]} aria-current={activeNav === 'docs' || currentPath.startsWith('/docs') || currentPath.startsWith('/architecture') ? 'page' : undefined}>Explore</a></li>
+        <li class="nav-mobile-only"><a href="https://github.com/sponsors/InterCooperative-Network" target="_blank" rel="noopener">Support ICN</a></li>
       </ul>
 
       <div class="nav-cta">

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -83,6 +83,7 @@ const jsonLd = {
 
       <div class="nav-cta">
         <ThemeToggle />
+        <a href="https://github.com/sponsors/InterCooperative-Network" target="_blank" rel="noopener" class="nav-support">Support ICN</a>
         <a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener" class="nav-github" aria-label="InterCooperative Network on GitHub">
           <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
         </a>
@@ -112,6 +113,7 @@ const jsonLd = {
             <span>InterCooperative Network</span>
           </a>
           <p>Institutional infrastructure for cooperative and federated organizations. Identity, governance, accounting, and coordination — auditable and member-owned.</p>
+          <p><a href="https://github.com/sponsors/InterCooperative-Network" target="_blank" rel="noopener">Support the work on GitHub Sponsors</a>.</p>
         </div>
 
         <div class="footer-col">

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -41,7 +41,7 @@ const jsonLd = {
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content={description} />
   <meta name="theme-color" content="#06090f" />
-  <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+  <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -77,6 +77,7 @@ const jsonLd = {
         <li><a href="/whats-real-now" class:list={[{ active: activeNav === 'whats-real-now' || currentPath.startsWith('/whats-real-now') }]} aria-current={activeNav === 'whats-real-now' || currentPath.startsWith('/whats-real-now') ? 'page' : undefined}>What's Real Now</a></li>
         <li><a href="/for-cooperatives" class:list={[{ active: activeNav === 'for-cooperatives' || currentPath.startsWith('/for-cooperatives') }]} aria-current={activeNav === 'for-cooperatives' || currentPath.startsWith('/for-cooperatives') ? 'page' : undefined}>For Cooperatives</a></li>
         <li><a href="/for-developers" class:list={[{ active: activeNav === 'for-developers' || currentPath.startsWith('/for-developers') }]} aria-current={activeNav === 'for-developers' || currentPath.startsWith('/for-developers') ? 'page' : undefined}>For Developers</a></li>
+        <li><a href="/get-involved" class:list={[{ active: activeNav === 'get-involved' || currentPath.startsWith('/get-involved') }]} aria-current={activeNav === 'get-involved' || currentPath.startsWith('/get-involved') ? 'page' : undefined}>Get Involved</a></li>
         <li><a href="/docs" class:list={[{ active: activeNav === 'docs' || currentPath.startsWith('/docs') || currentPath.startsWith('/architecture') }]} aria-current={activeNav === 'docs' || currentPath.startsWith('/docs') || currentPath.startsWith('/architecture') ? 'page' : undefined}>Explore</a></li>
       </ul>
 
@@ -122,6 +123,7 @@ const jsonLd = {
             <li><a href="/whats-real-now">What's Real Now</a></li>
             <li><a href="/for-cooperatives">For Cooperatives</a></li>
             <li><a href="/for-developers">For Developers</a></li>
+            <li><a href="/get-involved">Get Involved</a></li>
           </ul>
         </div>
 
@@ -144,6 +146,7 @@ const jsonLd = {
             <li><a href="https://github.com/InterCooperative-Network/icn/issues" target="_blank" rel="noopener">Issues</a></li>
             <li><a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank" rel="noopener">Discussions</a></li>
             <li><a href="/community">Community</a></li>
+            <li><a href="https://github.com/sponsors/InterCooperative-Network" target="_blank" rel="noopener">GitHub Sponsors</a></li>
             <li><a href="/blog">Blog</a></li>
           </ul>
         </div>

--- a/website/src/lib/blog-slug.ts
+++ b/website/src/lib/blog-slug.ts
@@ -1,0 +1,3 @@
+export function blogSlugFromId(id: string): string {
+  return id.replace(/\.md$/, "");
+}

--- a/website/src/pages/about.astro
+++ b/website/src/pages/about.astro
@@ -84,6 +84,16 @@ import Layout from '../layouts/Layout.astro';
         and <a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank" rel="noopener">GitHub discussions</a>
         are the right places.
       </p>
+      <p>
+        If you want the shortest route map instead of reading across multiple pages,
+        use <a href="/get-involved">Get Involved</a>. It is the current public intake surface for
+        developers, non-technical contributors, institutions, and supporters.
+      </p>
+      <p>
+        If you want to support the work financially, the live rail today is
+        <a href="https://github.com/sponsors/InterCooperative-Network" target="_blank" rel="noopener">GitHub Sponsors</a>.
+        There is no separate donation portal or paid support program advertised here.
+      </p>
     </div>
   </section>
 
@@ -98,6 +108,8 @@ import Layout from '../layouts/Layout.astro';
         <a href="/whats-real-now" class="btn btn-ghost">What's Real Now</a>
         <a href="/for-cooperatives" class="btn btn-ghost">For Cooperatives</a>
         <a href="/for-developers" class="btn btn-ghost">For Developers</a>
+        <a href="/get-involved" class="btn btn-ghost">Get Involved</a>
+        <a href="https://github.com/sponsors/InterCooperative-Network" target="_blank" rel="noopener" class="btn btn-ghost">Support the work ↗</a>
       </div>
     </div>
   </section>

--- a/website/src/pages/blog/[...slug].astro
+++ b/website/src/pages/blog/[...slug].astro
@@ -1,12 +1,12 @@
 ---
 import { render, type CollectionEntry, getCollection } from 'astro:content';
 import Layout from '../../layouts/Layout.astro';
+import { blogSlugFromId } from '../../lib/blog-slug';
 
 export async function getStaticPaths() {
 	const posts = await getCollection('blog');
-	const slugFor = (id: string) => id.replace(/\.md$/, '');
 	return posts.map((post) => ({
-		params: { slug: slugFor(post.id) },
+		params: { slug: blogSlugFromId(post.id) },
 		props: post,
 	}));
 }

--- a/website/src/pages/blog/[...slug].astro
+++ b/website/src/pages/blog/[...slug].astro
@@ -1,18 +1,19 @@
 ---
-import { type CollectionEntry, getCollection } from 'astro:content';
+import { render, type CollectionEntry, getCollection } from 'astro:content';
 import Layout from '../../layouts/Layout.astro';
 
 export async function getStaticPaths() {
 	const posts = await getCollection('blog');
+	const slugFor = (id: string) => id.replace(/\.md$/, '');
 	return posts.map((post) => ({
-		params: { slug: post.slug },
+		params: { slug: slugFor(post.id) },
 		props: post,
 	}));
 }
 type Props = CollectionEntry<'blog'>;
 
-const post = Astro.props;
-const { Content } = await post.render();
+const post = Astro.props as Props;
+const { Content } = await render(post);
 ---
 
 <Layout title={post.data.title} description={post.data.description} activeNav="blog">

--- a/website/src/pages/blog/index.astro
+++ b/website/src/pages/blog/index.astro
@@ -5,6 +5,8 @@ import { getCollection } from 'astro:content';
 const posts = (await getCollection('blog')).sort(
 	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
 );
+
+const slugFor = (id: string) => id.replace(/\.md$/, '');
 ---
 
 <Layout title="Blog" activeNav="blog">
@@ -18,7 +20,7 @@ const posts = (await getCollection('blog')).sort(
 			
 			<div class="blog-grid">
 				{posts.map((post) => (
-					<a href={`/blog/${post.slug}/`} class="blog-card group">
+					<a href={`/blog/${slugFor(post.id)}/`} class="blog-card group">
 						{post.data.heroImage && (
 							<img width={720} height={360} src={post.data.heroImage} alt="" class="blog-img" />
 						)}
@@ -33,7 +35,7 @@ const posts = (await getCollection('blog')).sort(
 								</time>
 								{(post.data.tags ?? []).length > 0 && (
 									<span class="blog-tags">
-										{(post.data.tags ?? []).map(tag => `#${tag}`).join(' ')}
+										{(post.data.tags ?? []).map((tag: string) => `#${tag}`).join(' ')}
 									</span>
 								)}
 							</div>

--- a/website/src/pages/blog/index.astro
+++ b/website/src/pages/blog/index.astro
@@ -1,12 +1,12 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import { getCollection } from 'astro:content';
+import { blogSlugFromId } from '../../lib/blog-slug';
 
 const posts = (await getCollection('blog')).sort(
 	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
 );
 
-const slugFor = (id: string) => id.replace(/\.md$/, '');
 ---
 
 <Layout title="Blog" activeNav="blog">
@@ -20,7 +20,7 @@ const slugFor = (id: string) => id.replace(/\.md$/, '');
 			
 			<div class="blog-grid">
 				{posts.map((post) => (
-					<a href={`/blog/${slugFor(post.id)}/`} class="blog-card group">
+						<a href={`/blog/${blogSlugFromId(post.id)}/`} class="blog-card group">
 						{post.data.heroImage && (
 							<img width={720} height={360} src={post.data.heroImage} alt="" class="blog-img" />
 						)}

--- a/website/src/pages/community.astro
+++ b/website/src/pages/community.astro
@@ -9,65 +9,77 @@ import stats from '../data/stats.json';
     <div class="container">
       <div class="section-header" style="text-align: left; max-width: none;">
         <span class="badge badge-purple">Community</span>
-        <h1>Follow the work, contribute to it, or bring a real institutional use case.</h1>
+        <h1>Where the work is visible, discussable, and open to contribution.</h1>
         <p>
-          ICN is built in the open. This is the page for readers who want to track the repository,
-          contribute code or documentation, or bring concrete cooperative, community, and federation needs into the work.
-          Repository counts below are generated from the repo at build time.
+          ICN is built in the open. This page collects the working surfaces: how to choose a contribution path,
+          where to discuss design and institutional questions, where to file issues, and where financial support
+          actually goes today. Repository counts below are generated from the repo at build time.
         </p>
       </div>
 
       <div class="grid grid-3">
+        <a href="/get-involved" class="community-card">
+          <div class="card-icon">01</div>
+          <h3>Get Involved</h3>
+          <p>The route map for developers, non-technical contributors, institutions, and sponsors.</p>
+        </a>
+
         <a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener noreferrer" class="community-card">
-          <div class="card-icon">⭐</div>
+          <div class="card-icon">02</div>
           <h3>Star on GitHub</h3>
           <p>Show your support and stay updated. {stats.activeBranches} branches, {stats.mergedPRs} merged PRs.</p>
         </a>
 
         <a href="https://github.com/InterCooperative-Network/icn/issues" target="_blank" rel="noopener noreferrer" class="community-card">
-          <div class="card-icon">🐛</div>
-          <h3>Report Issues</h3>
-          <p>Found a bug or have a feature idea? Open an issue and help us improve.</p>
+          <div class="card-icon">03</div>
+          <h3>Open or review issues</h3>
+          <p>Use issues for bugs, scoped implementation work, documentation gaps, and concrete follow-up tasks.</p>
         </a>
 
         <a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank" rel="noopener noreferrer" class="community-card">
-          <div class="card-icon">💬</div>
+          <div class="card-icon">04</div>
           <h3>Discussions</h3>
-          <p>Join conversations about cooperative technology, governance patterns, and ICN development.</p>
+          <p>Use discussions for design questions, governance patterns, institutional use cases, and broader project conversation.</p>
         </a>
 
         <a href="https://github.com/InterCooperative-Network/icn/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer" class="community-card">
-          <div class="card-icon">🤝</div>
+          <div class="card-icon">05</div>
           <h3>Contributing Guide</h3>
-          <p>Read the guidelines for contributing code, documentation, and architectural proposals.</p>
+          <p>Architectural guardrails, regulatory invariants, and what a good ICN pull request must respect.</p>
         </a>
 
         <a href="/docs/GETTING_STARTED" class="community-card">
-          <div class="card-icon">🚀</div>
-          <h3>Getting Started</h3>
-          <p>Set up your development environment and run ICN locally in minutes.</p>
+          <div class="card-icon">06</div>
+          <h3>Developer getting started</h3>
+          <p>Use the repo quickstart when you want to build the workspace, run the checks, and contribute without getting lost.</p>
         </a>
 
         <a href="/docs" class="community-card">
-          <div class="card-icon">📚</div>
+          <div class="card-icon">07</div>
           <h3>Documentation</h3>
           <p>{stats.docFiles}+ documents covering architecture, APIs, guides, economics, and governance.</p>
         </a>
 
+        <a href="https://github.com/sponsors/InterCooperative-Network" target="_blank" rel="noopener noreferrer" class="community-card">
+          <div class="card-icon">08</div>
+          <h3>GitHub Sponsors</h3>
+          <p>The live financial-support rail today. Sponsor the organization-level work sustaining the substrate.</p>
+        </a>
+
         <a href="https://matrix.to/#/#icn:matrix.org" target="_blank" rel="noopener noreferrer" class="community-card">
-          <div class="card-icon">💬</div>
+          <div class="card-icon">09</div>
           <h3>Matrix Room</h3>
           <p>Real-time chat with ICN developers and cooperative technologists. Join <code>#icn:matrix.org</code> — no account required to read.</p>
         </a>
 
         <a href="https://github.com/InterCooperative-Network/icn/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue" target="_blank" rel="noopener noreferrer" class="community-card">
-          <div class="card-icon">🌱</div>
+          <div class="card-icon">10</div>
           <h3>Good First Issues</h3>
           <p>Labeled, scoped, and documented. If you want to contribute code but don't know where to start, start here.</p>
         </a>
 
         <a href="https://github.com/InterCooperative-Network/icn/discussions/categories/announcements" target="_blank" rel="noopener noreferrer" class="community-card">
-          <div class="card-icon">📬</div>
+          <div class="card-icon">11</div>
           <h3>Announcements</h3>
           <p>Sprint summaries, release notes, and major milestones. Subscribe to the Announcements discussion category on GitHub.</p>
         </a>
@@ -120,8 +132,21 @@ import stats from '../data/stats.json';
   }
 
   .community-card .card-icon {
-    font-size: 2rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.25rem;
+    min-height: 2.25rem;
+    padding: 0 var(--space-sm);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    color: var(--accent-teal);
     margin-bottom: var(--space-md);
+    background: var(--bg-surface);
   }
 
   .community-card h3 {

--- a/website/src/pages/community.astro
+++ b/website/src/pages/community.astro
@@ -18,6 +18,12 @@ import stats from '../data/stats.json';
       </div>
 
       <div class="grid grid-3">
+        <a href="/whats-real-now" class="community-card">
+          <div class="card-icon">00</div>
+          <h3>Truth anchor</h3>
+          <p>Read the current maturity account before you assume what ICN can already carry for contributors or institutions.</p>
+        </a>
+
         <a href="/get-involved" class="community-card">
           <div class="card-icon">01</div>
           <h3>Get Involved</h3>
@@ -93,19 +99,19 @@ import stats from '../data/stats.json';
       <h2 class="text-center" style="margin-bottom: var(--space-xl);">Contributing Principles</h2>
       <div class="grid grid-2">
         <div class="card">
-          <h3>🏗️ Interfaces First</h3>
+          <h3>Interfaces First</h3>
           <p>Design the interface before the implementation. Every public API should be driven by use cases from cooperative governance, economics, or federation scenarios.</p>
         </div>
         <div class="card">
-          <h3>🧱 No Drive-By Refactors</h3>
+          <h3>No Drive-By Refactors</h3>
           <p>Each PR touches one concern. If you notice something that needs refactoring while working on a feature, open a separate issue.</p>
         </div>
         <div class="card">
-          <h3>🔥 The Meaning Firewall</h3>
+          <h3>The Meaning Firewall</h3>
           <p>The kernel must never understand the semantic meaning of what it processes. If domain logic leaks into kernel crates, the architecture is broken.</p>
         </div>
         <div class="card">
-          <h3>📐 Architectural Guardrails</h3>
+          <h3>Architectural Guardrails</h3>
           <p>All changes must respect crate boundaries, the app/kernel separation, and the constraint engine model. See CONTRIBUTING.md for details.</p>
         </div>
       </div>

--- a/website/src/pages/docs/[...slug].astro
+++ b/website/src/pages/docs/[...slug].astro
@@ -52,7 +52,7 @@ const segments = slug!.split('/');
       <!-- Breadcrumb -->
       <nav class="breadcrumb">
         <a href="/docs">Docs</a>
-        {segments.length > 1 && segments.slice(0, -1).map((seg, i) => (
+        {segments.length > 1 && segments.slice(0, -1).map((seg) => (
           <span class="breadcrumb-sep">/</span>
           <span class="breadcrumb-dir">{seg.replace(/[-_]/g, ' ')}</span>
         ))}

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -148,6 +148,24 @@ const allDocs = sections.flatMap(s => s.docs);
         <p>Everything you need to understand, deploy, and contribute to the InterCooperative Network. These docs are synced directly from the main repository.</p>
       </div>
 
+      <div class="docs-quickstart">
+        <a href="/docs/GETTING_STARTED" class="docs-quickstart-card">
+          <span class="docs-quickstart-label">Developers</span>
+          <h2>Start with Getting Started</h2>
+          <p>Build the workspace, orient in the repo, and find the right contributor path without getting lost.</p>
+        </a>
+        <a href="/get-involved" class="docs-quickstart-card">
+          <span class="docs-quickstart-label">Contributors</span>
+          <h2>Use the engagement map</h2>
+          <p>Route yourself into docs, design, testing, research, institutional collaboration, or ecosystem work.</p>
+        </a>
+        <a href="https://github.com/sponsors/InterCooperative-Network" target="_blank" rel="noopener" class="docs-quickstart-card">
+          <span class="docs-quickstart-label">Supporters</span>
+          <h2>Support the work</h2>
+          <p>GitHub Sponsors is the live public support rail today for sustaining the project’s engineering work.</p>
+        </a>
+      </div>
+
       <!-- Search -->
       <Search searchList={allDocs} />
 
@@ -200,6 +218,52 @@ const allDocs = sections.flatMap(s => s.docs);
 </Layout>
 
 <style>
+  .docs-quickstart {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-md);
+    margin: 0 0 var(--space-xl);
+  }
+
+  .docs-quickstart-card {
+    display: block;
+    padding: var(--space-lg);
+    background: var(--bg-card);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-xl);
+    text-decoration: none;
+    transition: all var(--duration-normal) var(--ease-out);
+  }
+
+  .docs-quickstart-card:hover {
+    border-color: var(--border-accent);
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-glow-teal);
+  }
+
+  .docs-quickstart-label {
+    display: inline-block;
+    margin-bottom: var(--space-sm);
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent-teal);
+  }
+
+  .docs-quickstart-card h2 {
+    font-size: 1.125rem;
+    margin: 0 0 var(--space-sm);
+  }
+
+  .docs-quickstart-card p {
+    margin: 0;
+    font-size: 0.9375rem;
+    color: var(--text-secondary);
+    max-width: none;
+  }
+
   .docs-index-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
@@ -245,5 +309,11 @@ const allDocs = sections.flatMap(s => s.docs);
   .docs-section-card li a:hover {
     background: var(--accent-teal-glow);
     color: var(--accent-teal);
+  }
+
+  @media (max-width: 900px) {
+    .docs-quickstart {
+      grid-template-columns: 1fr;
+    }
   }
 </style>

--- a/website/src/pages/for-cooperatives.astro
+++ b/website/src/pages/for-cooperatives.astro
@@ -158,6 +158,14 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         That is not where the work stands today.
       </p>
 
+      <h2>How to engage right now</h2>
+      <ul>
+        <li><strong>Track the work before you commit institutional energy.</strong> Start with <a href="/whats-real-now">What's Real Now</a>, then use <a href="/community">Community</a> to follow the repository and discussions.</li>
+        <li><strong>Bring institutional patterns, not just product requests.</strong> If your cooperative, federation, or aligned project has a real governance, accounting, or coordination problem that the current stack cannot carry cleanly, use <a href="/get-involved">Get Involved</a> for the current collaboration path.</li>
+        <li><strong>Assume early collaboration is engineering-heavy.</strong> There is no formal pilot program or managed onboarding track yet. Institutions engaging in depth are helping shape the substrate directly.</li>
+        <li><strong>If you want to support the work financially without implying a vendor relationship,</strong> the live path today is the GitHub Sponsors rail surfaced on <a href="/get-involved#support">Get Involved</a>.</li>
+      </ul>
+
       <h2>This is about enhancing human institutions, not automating them away</h2>
       <p>
         The work of running a cooperative — deliberation, interpretation, care, negotiation, political judgment,
@@ -176,6 +184,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
     <div class="container narrow">
       <ReadingLadder current="for-cooperatives">
         <Fragment slot="extras">
+          <a href="/get-involved" class="btn btn-ghost">Get Involved</a>
           <a href="/community" class="btn btn-ghost">Community</a>
           <a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener" class="btn btn-ghost">GitHub ↗</a>
         </Fragment>

--- a/website/src/pages/for-cooperatives.astro
+++ b/website/src/pages/for-cooperatives.astro
@@ -159,6 +159,15 @@ import ReadingLadder from '../components/ReadingLadder.astro';
       </p>
 
       <h2>How to engage right now</h2>
+      <p>
+        The practical next step depends on what kind of relationship you want with the project.
+        These are the current real paths:
+      </p>
+      <ol>
+        <li><strong>Evaluate first.</strong> Read <a href="/whats-real-now">What's Real Now</a> and confirm that the current maturity is compatible with your timing.</li>
+        <li><strong>Bring a concrete institutional case.</strong> Open a <a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank" rel="noopener">GitHub Discussion</a> that describes the governance, accounting, coordination, or federation problem your current stack does not carry well.</li>
+        <li><strong>If you only want to support the work without implying a vendor relationship,</strong> use the GitHub Sponsors rail on <a href="/get-involved#support">Get Involved</a>.</li>
+      </ol>
       <ul>
         <li><strong>Track the work before you commit institutional energy.</strong> Start with <a href="/whats-real-now">What's Real Now</a>, then use <a href="/community">Community</a> to follow the repository and discussions.</li>
         <li><strong>Bring institutional patterns, not just product requests.</strong> If your cooperative, federation, or aligned project has a real governance, accounting, or coordination problem that the current stack cannot carry cleanly, use <a href="/get-involved">Get Involved</a> for the current collaboration path.</li>

--- a/website/src/pages/for-developers.astro
+++ b/website/src/pages/for-developers.astro
@@ -41,6 +41,30 @@ import ReadingLadder from '../components/ReadingLadder.astro';
 
   <section class="section-alt section-pre-ladder">
     <div class="container narrow prose">
+      <h2>Your first hour in the repo</h2>
+      <div class="truth-grid truth-grid-2">
+        <div class="truth-note truth-note-teal">
+          <span class="truth-note-label">1. Build</span>
+          <h3>Confirm the workspace compiles from the real root</h3>
+          <p>Clone the repo, change into <code>icn/</code>, then run <code>cargo build</code> and <code>cargo test --workspace --lib</code>. The Rust workspace is not at the repo root.</p>
+        </div>
+        <div class="truth-note truth-note-amber">
+          <span class="truth-note-label">2. Verify</span>
+          <h3>Use the same checks the repo expects</h3>
+          <p>Read <a href="/docs/GETTING_STARTED">Getting Started</a>, then run <code>cargo fmt --all --check</code>, <code>cargo clippy --workspace --all-targets --all-features -- -D warnings</code>, and the test scope that matches your change.</p>
+        </div>
+        <div class="truth-note truth-note-teal">
+          <span class="truth-note-label">3. Read the guardrails</span>
+          <h3>Start from the repo’s operating documents</h3>
+          <p><a href="/docs/GETTING_STARTED">Getting Started</a> tells you how to build and orient. <a href="https://github.com/InterCooperative-Network/icn/blob/main/AGENTS.md" target="_blank" rel="noopener"><code>AGENTS.md</code></a> and <a href="https://github.com/InterCooperative-Network/icn/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener"><code>CONTRIBUTING.md</code></a> tell you how not to break the repo.</p>
+        </div>
+        <div class="truth-note truth-note-amber">
+          <span class="truth-note-label">4. Choose a first patch</span>
+          <h3>Pick something scoped before you wander</h3>
+          <p>Use <a href="https://github.com/InterCooperative-Network/icn/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue" target="_blank" rel="noopener">good first issues</a> for a first code change, or close a concrete docs gap if you want to contribute without starting in the deepest Rust paths.</p>
+        </div>
+      </div>
+
       <h2>Why ICN may be interesting to technical readers</h2>
       <ul>
         <li><strong>Kernel/app separation with a strict meaning firewall.</strong> The kernel enforces generic constraints without understanding their domain semantics. Apps translate domain meaning into those constraints. The boundary is enforced in the crate graph.</li>
@@ -151,6 +175,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         <li><strong>Start with the contributor entry docs.</strong> Read <a href="/docs/GETTING_STARTED">Getting Started</a>, then <a href="https://github.com/InterCooperative-Network/icn/blob/main/README.md" target="_blank" rel="noopener"><code>README.md</code></a>, then <a href="https://github.com/InterCooperative-Network/icn/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener"><code>CONTRIBUTING.md</code></a>.</li>
         <li><strong>Use the onboarding curriculum when you want a deeper path.</strong> The full developer ladder is in <a href="https://github.com/InterCooperative-Network/icn/blob/main/docs/onboarding/README.md" target="_blank" rel="noopener"><code>docs/onboarding/README.md</code></a>.</li>
         <li><strong>Choose a first area deliberately.</strong> Start with <a href="https://github.com/InterCooperative-Network/icn/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue" target="_blank" rel="noopener">good first issues</a> or with one documentation gap you can close cleanly.</li>
+        <li><strong>Run from the right directory.</strong> Cargo commands belong in <code>icn/</code>, not the repo root. That one detail prevents a surprising amount of confusion.</li>
         <li><strong>Use the public contribution map if you are deciding how to help.</strong> <a href="/get-involved">Get Involved</a> is the route map for code, docs, design, institutional input, and financial support.</li>
       </ul>
 

--- a/website/src/pages/for-developers.astro
+++ b/website/src/pages/for-developers.astro
@@ -141,6 +141,19 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         <li>Read the governance app to see how proposals, decisions, and the transition from governance to policy are handled today.</li>
       </ol>
 
+      <h2>If you want to contribute now</h2>
+      <p>
+        The shortest path to a truthful first contribution is: orient on the public framing,
+        build the workspace locally, choose one scoped issue, and verify only the checks that match
+        the area you touched.
+      </p>
+      <ul>
+        <li><strong>Start with the contributor entry docs.</strong> Read <a href="/docs/GETTING_STARTED">Getting Started</a>, then <a href="https://github.com/InterCooperative-Network/icn/blob/main/README.md" target="_blank" rel="noopener"><code>README.md</code></a>, then <a href="https://github.com/InterCooperative-Network/icn/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener"><code>CONTRIBUTING.md</code></a>.</li>
+        <li><strong>Use the onboarding curriculum when you want a deeper path.</strong> The full developer ladder is in <a href="https://github.com/InterCooperative-Network/icn/blob/main/docs/onboarding/README.md" target="_blank" rel="noopener"><code>docs/onboarding/README.md</code></a>.</li>
+        <li><strong>Choose a first area deliberately.</strong> Start with <a href="https://github.com/InterCooperative-Network/icn/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue" target="_blank" rel="noopener">good first issues</a> or with one documentation gap you can close cleanly.</li>
+        <li><strong>Use the public contribution map if you are deciding how to help.</strong> <a href="/get-involved">Get Involved</a> is the route map for code, docs, design, institutional input, and financial support.</li>
+      </ul>
+
       <h2>How to contribute without misunderstanding the project</h2>
       <ul>
         <li><strong>ICN is institutional infrastructure, not a protocol in search of a use case.</strong> Contributions that treat it as a generic substrate for arbitrary coordination tend to miss the point.</li>
@@ -165,6 +178,8 @@ import ReadingLadder from '../components/ReadingLadder.astro';
     <div class="container narrow">
       <ReadingLadder current="for-developers">
         <Fragment slot="extras">
+          <a href="/get-involved" class="btn btn-ghost">Get Involved</a>
+          <a href="/docs/GETTING_STARTED" class="btn btn-ghost">Getting Started</a>
           <a href="/architecture" class="btn btn-ghost">Architecture reference →</a>
           <a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener" class="btn btn-ghost">GitHub ↗</a>
           <a href="/docs" class="btn btn-ghost">Docs</a>

--- a/website/src/pages/get-involved.astro
+++ b/website/src/pages/get-involved.astro
@@ -1,0 +1,744 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout
+  title="Get Involved"
+  activeNav="get-involved"
+  description="Concrete paths to engage with ICN: build the codebase, contribute non-technically, bring an institutional use case, or support the project financially."
+>
+
+  <section class="section" style="padding-top: calc(64px + var(--space-3xl));">
+    <div class="container narrow">
+      <div class="page-hero">
+        <span class="badge badge-teal">Get Involved</span>
+        <h1>How to engage with ICN.</h1>
+        <p class="lead">
+          ICN is open infrastructure. There are four concrete ways to engage — building the codebase,
+          contributing non-technically, bringing an institutional use case, or supporting the work financially.
+          Each path below tells you what the first step is, not where to start guessing.
+        </p>
+      </div>
+
+      <div class="path-nav" aria-label="Jump to a path">
+        <a href="#build" class="path-nav-item">
+          <span class="path-nav-num">01</span>
+          <span class="path-nav-label">Build</span>
+          <span class="path-nav-hint">Developers and engineers</span>
+        </a>
+        <a href="#contribute" class="path-nav-item">
+          <span class="path-nav-num">02</span>
+          <span class="path-nav-label">Contribute</span>
+          <span class="path-nav-hint">Writers, designers, researchers, organizers</span>
+        </a>
+        <a href="#partner" class="path-nav-item">
+          <span class="path-nav-num">03</span>
+          <span class="path-nav-label">Partner</span>
+          <span class="path-nav-hint">Cooperatives, federations, aligned institutions</span>
+        </a>
+        <a href="#support" class="path-nav-item">
+          <span class="path-nav-num">04</span>
+          <span class="path-nav-label">Support</span>
+          <span class="path-nav-hint">Sponsor the work financially</span>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══ BUILD ═══════════════════════════════════════════════════ -->
+  <section id="build" class="section-alt path-section">
+    <div class="container narrow">
+      <div class="path-header">
+        <span class="path-header-num">01</span>
+        <div>
+          <span class="badge badge-teal">Build</span>
+          <h2>Developers and engineers.</h2>
+          <p class="path-header-lede">
+            Rust workspace, actor-based runtime, strict kernel/app separation. If you write systems code
+            and want to work on cooperative infrastructure that is not another SaaS or token protocol,
+            this is the path.
+          </p>
+        </div>
+      </div>
+
+      <ol class="path-steps">
+        <li>
+          <h3>Read first</h3>
+          <ul>
+            <li><a href="/for-developers">For Developers</a> — what ICN is as a system, and what it is not.</li>
+            <li><a href="/architecture">Architecture</a> — meaning firewall, kernel/app separation, policy oracles.</li>
+            <li><a href="/whats-real-now">What's Real Now</a> — what is load-bearing today and what is still being built.</li>
+          </ul>
+        </li>
+        <li>
+          <h3>Prerequisites</h3>
+          <ul>
+            <li>Rust toolchain (pinned — don't upgrade it). Toolchain version lives in <code>icn/rust-toolchain.toml</code>.</li>
+            <li>Git.</li>
+            <li>Roughly 8 GB of free disk for a full build + incremental cache.</li>
+          </ul>
+        </li>
+        <li>
+          <h3>Clone and build</h3>
+          <pre><code>git clone https://github.com/InterCooperative-Network/icn.git
+cd icn/icn
+cargo build
+cargo test --workspace --lib</code></pre>
+          <p class="path-step-note">
+            The Rust workspace lives inside the <code>icn/</code> subdirectory, not at the repo root.
+            Run all cargo commands from there.
+          </p>
+        </li>
+        <li>
+          <h3>Orient in the repo</h3>
+          <ul>
+            <li><a href="https://github.com/InterCooperative-Network/icn/blob/main/README.md" target="_blank" rel="noopener"><code>README.md</code></a> — repo map and first-stop routing for contributors.</li>
+            <li><a href="https://github.com/InterCooperative-Network/icn/blob/main/docs/GETTING_STARTED.md" target="_blank" rel="noopener"><code>docs/GETTING_STARTED.md</code></a> — build, run, and verification quickstart.</li>
+            <li><a href="https://github.com/InterCooperative-Network/icn/blob/main/AGENTS.md" target="_blank" rel="noopener"><code>AGENTS.md</code></a> — operating rules, verification commands, invariants, crate layout.</li>
+            <li><a href="https://github.com/InterCooperative-Network/icn/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener"><code>CONTRIBUTING.md</code></a> — architectural guardrails and the regulatory invariants PR checklist.</li>
+            <li><a href="https://github.com/InterCooperative-Network/icn/blob/main/CLAUDE.md" target="_blank" rel="noopener"><code>CLAUDE.md</code></a> — deep project map (also useful even if you aren't using Claude Code).</li>
+          </ul>
+        </li>
+        <li>
+          <h3>Pick an initial area</h3>
+          <ul>
+            <li>
+              <a href="https://github.com/InterCooperative-Network/icn/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue" target="_blank" rel="noopener">Good first issues</a>
+              — scoped, labeled, and documented. The path of least resistance for a first PR.
+            </li>
+            <li>
+              <a href="https://github.com/InterCooperative-Network/icn/issues" target="_blank" rel="noopener">Open issues</a>
+              — every issue has one <code>epic:*</code> label and one <code>type:*</code> label. Pick an epic that matches your interest.
+            </li>
+            <li>
+              If you want to read the code first rather than an issue first,
+              <a href="/for-developers#how-to-explore-the-codebase-and-docs">the reading order on For Developers</a>
+              tells you where to start.
+            </li>
+            <li>
+              If you want a deeper contributor path rather than a first patch,
+              use <a href="https://github.com/InterCooperative-Network/icn/blob/main/docs/onboarding/README.md" target="_blank" rel="noopener"><code>docs/onboarding/README.md</code></a>.
+            </li>
+          </ul>
+        </li>
+        <li>
+          <h3>Verify before you push</h3>
+          <pre><code>cd icn
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --lib</code></pre>
+          <p class="path-step-note">
+            Run the checks that match what you touched. Full routing table is in <code>AGENTS.md</code>.
+          </p>
+        </li>
+        <li>
+          <h3>Submit</h3>
+          <p>
+            Work on a feature branch (<code>feat/&lt;slug&gt;</code>, <code>fix/&lt;slug&gt;</code>,
+            <code>docs/&lt;slug&gt;</code>). Open a PR against <code>main</code>. Every PR includes a
+            <strong>what</strong>, <strong>why</strong>, <strong>risk</strong>, and <strong>test plan</strong>.
+            If the change touches gateway APIs, ledger logic, or member-facing text, step through the regulatory
+            invariants checklist in <code>CONTRIBUTING.md</code>.
+          </p>
+        </li>
+      </ol>
+
+      <div class="path-cta">
+        <a href="/for-developers" class="btn btn-primary">Read For Developers</a>
+        <a href="https://github.com/InterCooperative-Network/icn/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue" target="_blank" rel="noopener" class="btn btn-secondary">Good first issues ↗</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══ CONTRIBUTE (NON-TECHNICAL) ═════════════════════════════ -->
+  <section id="contribute" class="section path-section">
+    <div class="container narrow">
+      <div class="path-header">
+        <span class="path-header-num">02</span>
+        <div>
+          <span class="badge badge-amber">Contribute</span>
+          <h2>Writers, designers, researchers, organizers.</h2>
+          <p class="path-header-lede">
+            ICN is not only a Rust project. The substrate has to be described, designed, stress-tested, and
+            translated into something cooperatives can actually use. The work below is real and needed.
+          </p>
+        </div>
+      </div>
+
+      <div class="contribution-grid">
+        <article class="contribution-card">
+          <h3>Documentation</h3>
+          <p>
+            Writing that explains what the system actually does without overclaiming. Gaps we know about:
+            user-facing guides for non-developer members, step-by-step operator guides, explainers that
+            keep <a href="/whats-real-now">What's Real Now</a> honest as the surface changes.
+          </p>
+          <p class="contribution-next">
+            <strong>First step:</strong> read <code>docs/INDEX.md</code>, find a gap, open a
+            <a href="https://github.com/InterCooperative-Network/icn/issues/new" target="_blank" rel="noopener">docs issue</a>
+            with <code>type:doc</code>.
+          </p>
+        </article>
+
+        <article class="contribution-card">
+          <h3>Design and member-facing UX</h3>
+          <p>
+            The member-facing experience is the part of the system most visibly trailing the substrate underneath.
+            Design work on how identity, standing, governance, and receipts cohere into something a person can use
+            is wanted and has room.
+          </p>
+          <p class="contribution-next">
+            <strong>First step:</strong> read <code>docs/design-language/brief-v0.md</code> and
+            <a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank" rel="noopener">start a discussion</a>
+            describing what you would want to work on.
+          </p>
+        </article>
+
+        <article class="contribution-card">
+          <h3>Research, policy, governance</h3>
+          <p>
+            Cooperative governance patterns, policy mechanisms, economic accounting rules, regulatory framing.
+            ICN is shaped by how real institutions actually run; we need people who know that terrain to push back
+            on designs that won't survive contact with a real membership.
+          </p>
+          <p class="contribution-next">
+            <strong>First step:</strong> open a
+            <a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank" rel="noopener">GitHub Discussion</a>
+            under <em>Ideas</em> or <em>General</em> with the question or proposal.
+          </p>
+        </article>
+
+        <article class="contribution-card">
+          <h3>Testing and pilot feedback</h3>
+          <p>
+            Running the daemon, running through the flows, filing specific bugs, and telling us where the
+            experience breaks down. Adversarial reading of the public site and docs is valuable — inconsistency
+            between <a href="/whats-real-now">What's Real Now</a> and the rest of the site is a defect.
+          </p>
+          <p class="contribution-next">
+            <strong>First step:</strong>
+            <a href="/docs/GETTING_STARTED">Getting Started</a> to stand up a node, then open an
+            <a href="https://github.com/InterCooperative-Network/icn/issues/new" target="_blank" rel="noopener">issue</a>
+            for anything that breaks, misleads, or surprises.
+          </p>
+        </article>
+
+        <article class="contribution-card">
+          <h3>Community and ecosystem</h3>
+          <p>
+            Connecting ICN to the cooperative, solidarity-economy, and public-interest-technology networks that
+            should know about it. Introductions to aligned projects and institutions. Organizing conversations
+            about cooperative infrastructure that don't route through platform incumbents.
+          </p>
+          <p class="contribution-next">
+            <strong>First step:</strong> join <a href="https://matrix.to/#/#icn:matrix.org" target="_blank" rel="noopener"><code>#icn:matrix.org</code></a>
+            or post in <a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank" rel="noopener">Discussions</a>.
+          </p>
+        </article>
+
+        <article class="contribution-card">
+          <h3>Translation and localization</h3>
+          <p>
+            Cooperative movements are not Anglophone. The public site, docs, and concept glossary will need to be
+            readable across at least the languages where active cooperative infrastructure communities already exist.
+            This work has not started and is open.
+          </p>
+          <p class="contribution-next">
+            <strong>First step:</strong> open a
+            <a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank" rel="noopener">Discussion</a>
+            describing the target language and which surface (site, docs, glossary) you want to cover first.
+          </p>
+        </article>
+      </div>
+
+      <div class="path-cta">
+        <a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank" rel="noopener" class="btn btn-primary">Start a Discussion ↗</a>
+        <a href="https://github.com/InterCooperative-Network/icn/issues/new" target="_blank" rel="noopener" class="btn btn-secondary">Open an Issue ↗</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══ PARTNER (INSTITUTIONS) ═════════════════════════════════ -->
+  <section id="partner" class="section-alt path-section">
+    <div class="container narrow">
+      <div class="path-header">
+        <span class="path-header-num">03</span>
+        <div>
+          <span class="badge badge-purple">Partner</span>
+          <h2>Cooperatives, federations, aligned institutions.</h2>
+          <p class="path-header-lede">
+            If your cooperative, network, or aligned project is thinking about ICN as institutional infrastructure,
+            the honest frame is not "vendor selection." It is early collaboration on a substrate that is still being built.
+          </p>
+        </div>
+      </div>
+
+      <div class="partner-stages">
+        <article class="partner-stage">
+          <span class="partner-stage-label">Observe</span>
+          <h3>Follow the work before committing</h3>
+          <p>
+            Read <a href="/for-cooperatives">For Cooperatives</a> and <a href="/whats-real-now">What's Real Now</a>.
+            Watch the repository on GitHub. This is the right relationship for most cooperatives right now — you
+            stay oriented without investing engineering capacity in something that isn't ready to hold your institution yet.
+          </p>
+        </article>
+
+        <article class="partner-stage">
+          <span class="partner-stage-label">Contribute expertise</span>
+          <h3>Bring how your institution actually runs</h3>
+          <p>
+            Governance patterns that work, accounting rules that don't fit generic tools, federation relationships
+            that current software can't carry — this knowledge shapes the substrate. You don't need to write code to do this.
+            Open a <a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank" rel="noopener">Discussion</a>
+            describing what your institution does and where the current stack fails.
+          </p>
+        </article>
+
+        <article class="partner-stage">
+          <span class="partner-stage-label">Early collaboration</span>
+          <h3>Work in depth, with engineering capacity</h3>
+          <p>
+            If your institution has the capacity and the interest, working with the project directly as a cooperative
+            or federation willing to shape how the substrate gets built is an option. This is engineering-heavy.
+            You are helping build it, not buying it finished.
+          </p>
+          <p>
+            There is no formal pilot-application process yet. The current path is: open a
+            <a href="https://github.com/InterCooperative-Network/icn/discussions/new?category=general" target="_blank" rel="noopener">Discussion</a>
+            describing your institution, the scope of engagement you have in mind, and the engineering capacity you can commit.
+          </p>
+        </article>
+      </div>
+
+      <div class="partner-caveat">
+        <p>
+          <strong>What we'd ask you not to do:</strong> treat ICN as a SaaS product to pilot next quarter.
+          That is not where the work stands today. <a href="/for-cooperatives#how-to-think-about-timing-and-adoption">What honest adoption looks like</a>.
+        </p>
+      </div>
+
+      <div class="path-cta">
+        <a href="/for-cooperatives" class="btn btn-primary">Read For Cooperatives</a>
+        <a href="https://github.com/InterCooperative-Network/icn/discussions/new?category=general" target="_blank" rel="noopener" class="btn btn-secondary">Open a partnership Discussion ↗</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══ SUPPORT (FINANCIAL) ═════════════════════════════════════ -->
+  <section id="support" class="section path-section">
+    <div class="container narrow">
+      <div class="path-header">
+        <span class="path-header-num">04</span>
+        <div>
+          <span class="badge badge-green">Support</span>
+          <h2>Sponsor the work financially.</h2>
+          <p class="path-header-lede">
+            ICN is open infrastructure. Financial support goes to sustaining engineering capacity on the
+            substrate — not to a commercial product with an investor ladder behind it.
+          </p>
+        </div>
+      </div>
+
+      <div class="support-card">
+        <div class="support-card-body">
+          <h3>GitHub Sponsors</h3>
+          <p>
+            The current financial-support rail is GitHub Sponsors, at the organization level. Sponsorship goes
+            to sustaining work across the whole project, not to a specific sub-project or individual.
+          </p>
+          <p>
+            This is the only live donation rail today. We are not running Patreon, Open Collective, or a
+            fiscal-sponsor donation portal. If a more structured funding path (fiscal sponsor, grants, institutional
+            membership) becomes appropriate, it will be described on this page when it exists — not before.
+          </p>
+          <a
+            href="https://github.com/sponsors/InterCooperative-Network"
+            target="_blank"
+            rel="noopener"
+            class="btn btn-primary btn-lg support-cta"
+          >
+            Sponsor on GitHub ↗
+          </a>
+        </div>
+      </div>
+
+      <div class="support-meta">
+        <h3>What we are honest about</h3>
+        <ul>
+          <li>
+            <strong>There is no paid support contract.</strong> Sponsoring the project does not buy you a
+            support SLA, a hotline, or prioritized issue handling.
+          </li>
+          <li>
+            <strong>Sponsorship is not a security audit commitment.</strong> ICN's security posture stands on its own
+            architecture and code review; sponsors are not promised an audit in exchange.
+          </li>
+          <li>
+            <strong>We are not issuing tokens, equity, or governance rights in exchange for funding.</strong>
+            ICN's governance lives in the cooperative substrate it builds, not in a funding tier.
+          </li>
+          <li>
+            <strong>For institutional funding conversations</strong> — grants, fiscal sponsorship, aligned-foundation
+            support — open a <a href="https://github.com/InterCooperative-Network/icn/discussions/new?category=general" target="_blank" rel="noopener">Discussion</a>
+            describing the funding context. The project will respond in the open where possible.
+          </li>
+        </ul>
+      </div>
+
+      <div class="path-cta">
+        <a href="https://github.com/sponsors/InterCooperative-Network" target="_blank" rel="noopener" class="btn btn-primary">Sponsor on GitHub ↗</a>
+        <a href="https://github.com/InterCooperative-Network/icn/discussions/new?category=general" target="_blank" rel="noopener" class="btn btn-ghost">Funding conversation ↗</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="section-alt">
+    <div class="container narrow">
+      <div class="section-header section-header-left" style="margin-bottom: var(--space-xl);">
+        <span class="badge badge-amber">What ICN Needs</span>
+        <h2>What is most useful now versus later.</h2>
+      </div>
+
+      <div class="contribution-grid">
+        <article class="contribution-card">
+          <h3>Useful now</h3>
+          <p>Developer work that expands execution coverage, improves contributor onboarding, or tightens member-facing and operator-facing surfaces.</p>
+          <p>Documentation work that makes the project easier to evaluate honestly and easier to contribute to without internal context.</p>
+          <p>Design, testing, and pilot feedback that exposes where the current user-facing surfaces still break down.</p>
+          <p>Institutional input from cooperatives, federations, and aligned networks about governance, accounting, and coordination problems the current stack fails to carry.</p>
+        </article>
+
+        <article class="contribution-card">
+          <h3>Later, not promised yet</h3>
+          <p>A polished non-technical onboarding flow for ordinary members, a formal pilot intake program, or a managed vendor-style adoption path.</p>
+          <p>Additional donation infrastructure beyond GitHub Sponsors.</p>
+          <p>A finished brand system or final ICN logo.</p>
+          <p>Any hosted sign-up surface that would let institutions treat ICN like a normal SaaS product.</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══ FALLBACK / ROUTING ═════════════════════════════════════ -->
+  <section class="section-alt">
+    <div class="container narrow text-center">
+      <h2>Not sure which path fits?</h2>
+      <p class="section-lede">
+        If you are still figuring out what ICN is before deciding how to engage, start with
+        <a href="/what-is-icn">What is ICN</a> and <a href="/whats-real-now">What's Real Now</a>.
+        Then come back here.
+      </p>
+      <div class="hero-actions" style="justify-content: center;">
+        <a href="/what-is-icn" class="btn btn-primary">What is ICN</a>
+        <a href="/whats-real-now" class="btn btn-secondary">What's Real Now</a>
+        <a href="/community" class="btn btn-ghost">Where work happens</a>
+      </div>
+    </div>
+  </section>
+</Layout>
+
+<style>
+.narrow { max-width: 820px; }
+.page-hero { display: flex; flex-direction: column; gap: var(--space-md); align-items: flex-start; }
+.page-hero .badge { align-self: flex-start; }
+.page-hero h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 3.8vw, 2.5rem);
+  line-height: 1.2;
+}
+.lead { font-size: 1.125rem; color: var(--text-body); line-height: 1.6; margin: 0; }
+
+/* Path nav at the top */
+.path-nav {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-sm);
+  margin-top: var(--space-2xl);
+}
+.path-nav-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--space-md);
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  text-decoration: none;
+  transition: border-color var(--duration-normal) var(--ease-out), transform var(--duration-normal) var(--ease-out);
+}
+.path-nav-item:hover {
+  border-color: var(--border-accent);
+  transform: translateY(-2px);
+}
+.path-nav-num {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  color: var(--accent-teal);
+}
+.path-nav-label {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-heading);
+}
+.path-nav-hint {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+/* Path sections */
+.path-section { scroll-margin-top: 80px; }
+.path-header {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--space-lg);
+  align-items: start;
+  margin-bottom: var(--space-2xl);
+}
+.path-header-num {
+  font-family: var(--font-mono);
+  font-size: 3rem;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--accent-teal);
+  opacity: 0.35;
+}
+.path-header h2 {
+  margin: var(--space-xs) 0 var(--space-sm);
+  font-size: clamp(1.5rem, 3vw, 1.875rem);
+  line-height: 1.2;
+}
+.path-header-lede {
+  font-size: 1.0625rem;
+  line-height: 1.65;
+  color: var(--text-body);
+  margin: 0;
+}
+
+/* Build path steps */
+.path-steps {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 var(--space-2xl);
+  counter-reset: step;
+  display: grid;
+  gap: var(--space-lg);
+}
+.path-steps > li {
+  position: relative;
+  padding: var(--space-lg) var(--space-lg) var(--space-lg) var(--space-2xl);
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xl);
+  counter-increment: step;
+}
+.path-steps > li::before {
+  content: counter(step, decimal-leading-zero);
+  position: absolute;
+  left: var(--space-md);
+  top: var(--space-lg);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--accent-teal);
+  letter-spacing: 0.08em;
+}
+.path-steps h3 {
+  margin: 0 0 var(--space-sm);
+  font-size: 1.0625rem;
+  color: var(--text-heading);
+}
+.path-steps p { margin: 0 0 var(--space-sm); line-height: 1.65; }
+.path-steps ul {
+  margin: 0;
+  padding-left: var(--space-lg);
+  display: grid;
+  gap: var(--space-xs);
+}
+.path-steps li ul li { line-height: 1.6; }
+.path-steps pre {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  overflow-x: auto;
+  font-size: 0.875rem;
+  margin: var(--space-sm) 0;
+}
+.path-steps code {
+  font-size: 0.85em;
+  font-family: var(--font-mono);
+}
+.path-steps pre code {
+  background: none;
+  padding: 0;
+}
+.path-steps :not(pre) > code {
+  background: var(--bg-surface);
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+}
+.path-step-note {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  margin-top: var(--space-sm) !important;
+}
+
+/* Contribution grid */
+.contribution-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-md);
+  margin-bottom: var(--space-2xl);
+}
+.contribution-card {
+  padding: var(--space-lg);
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xl);
+}
+.contribution-card h3 {
+  margin: 0 0 var(--space-sm);
+  font-size: 1.0625rem;
+  color: var(--text-heading);
+}
+.contribution-card p {
+  margin: 0 0 var(--space-sm);
+  line-height: 1.65;
+  font-size: 0.9375rem;
+}
+.contribution-card p:last-child { margin-bottom: 0; }
+.contribution-next {
+  padding-top: var(--space-sm);
+  margin-top: var(--space-sm) !important;
+  border-top: 1px solid var(--border-subtle);
+  font-size: 0.875rem !important;
+  color: var(--text-muted);
+}
+.contribution-next strong { color: var(--text-body); }
+.contribution-card code {
+  font-size: 0.85em;
+  background: var(--bg-surface);
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+}
+
+/* Partner stages */
+.partner-stages {
+  display: grid;
+  gap: var(--space-md);
+  margin-bottom: var(--space-xl);
+}
+.partner-stage {
+  padding: var(--space-lg);
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xl);
+  border-left: 3px solid var(--accent-purple, var(--accent-teal));
+}
+.partner-stage-label {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent-teal);
+  margin-bottom: var(--space-xs);
+}
+.partner-stage h3 {
+  margin: 0 0 var(--space-sm);
+  font-size: 1.125rem;
+  color: var(--text-heading);
+}
+.partner-stage p {
+  margin: 0 0 var(--space-sm);
+  line-height: 1.65;
+}
+.partner-stage p:last-child { margin-bottom: 0; }
+.partner-caveat {
+  padding: var(--space-md) var(--space-lg);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  margin-bottom: var(--space-xl);
+}
+.partner-caveat p {
+  margin: 0;
+  font-size: 0.9375rem;
+  line-height: 1.65;
+  color: var(--text-muted);
+}
+.partner-caveat strong { color: var(--text-body); }
+
+/* Support path */
+.support-card {
+  padding: var(--space-xl);
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xl);
+  margin-bottom: var(--space-xl);
+}
+.support-card h3 {
+  margin: 0 0 var(--space-md);
+  font-size: 1.25rem;
+  color: var(--text-heading);
+}
+.support-card p {
+  margin: 0 0 var(--space-md);
+  line-height: 1.7;
+}
+.support-cta { margin-top: var(--space-md); }
+.support-meta h3 {
+  font-size: 1.0625rem;
+  margin-top: var(--space-xl);
+  margin-bottom: var(--space-sm);
+}
+.support-meta ul {
+  margin: 0 0 var(--space-xl);
+  padding-left: var(--space-lg);
+  display: grid;
+  gap: var(--space-sm);
+}
+.support-meta li { line-height: 1.65; }
+
+/* Shared CTA row for each path */
+.path-cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  margin-top: var(--space-xl);
+}
+.btn-lg { font-size: 1rem; padding: 0.75rem 1.5rem; }
+
+.section-lede {
+  font-size: 1.0625rem;
+  color: var(--text-muted);
+  margin: 0 auto var(--space-xl);
+  max-width: 40em;
+}
+
+@media (max-width: 768px) {
+  .path-nav {
+    grid-template-columns: 1fr;
+  }
+  .path-header {
+    grid-template-columns: 1fr;
+    gap: var(--space-sm);
+  }
+  .path-header-num { font-size: 2rem; }
+  .contribution-grid {
+    grid-template-columns: 1fr;
+  }
+  .path-steps > li {
+    padding: var(--space-md) var(--space-md) var(--space-md) var(--space-xl);
+  }
+  .path-steps > li::before {
+    left: var(--space-sm);
+    top: var(--space-md);
+  }
+}
+</style>

--- a/website/src/pages/get-involved.astro
+++ b/website/src/pages/get-involved.astro
@@ -20,7 +20,7 @@ import Layout from '../layouts/Layout.astro';
         </p>
       </div>
 
-      <div class="path-nav" aria-label="Jump to a path">
+      <nav class="path-nav" aria-label="Jump to a path">
         <a href="#build" class="path-nav-item">
           <span class="path-nav-num">01</span>
           <span class="path-nav-label">Build</span>
@@ -41,7 +41,7 @@ import Layout from '../layouts/Layout.astro';
           <span class="path-nav-label">Support</span>
           <span class="path-nav-hint">Sponsor the work financially</span>
         </a>
-      </div>
+      </nav>
     </div>
   </section>
 
@@ -123,12 +123,11 @@ cargo test --workspace --lib</code></pre>
         </li>
         <li>
           <h3>Verify before you push</h3>
-          <pre><code>cd icn
-cargo fmt --all --check
+          <pre><code>cargo fmt --all --check
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --workspace --lib</code></pre>
           <p class="path-step-note">
-            Run the checks that match what you touched. Full routing table is in <code>AGENTS.md</code>.
+            Run these from <code>icn/</code>, the Rust workspace you entered in the build step. Full routing table is in <code>AGENTS.md</code>.
           </p>
         </li>
         <li>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -34,7 +34,7 @@ import MaturityCard from '../components/MaturityCard.astro';
               What is ICN
               <svg class="btn-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"/></svg>
             </a>
-            <a href="/how-it-works" class="btn btn-secondary">How It Works</a>
+            <a href="/get-involved" class="btn btn-secondary">Get Involved</a>
             <a href="/whats-real-now" class="btn btn-ghost">What's Real Now</a>
           </div>
           <p class="hero-qualifier">For partners interested in durable institutional capacity, not another disconnected software tool.</p>
@@ -69,6 +69,8 @@ import MaturityCard from '../components/MaturityCard.astro';
           </div>
 
           <div class="hero-panel-links">
+            <a href="/get-involved">Get Involved</a>
+            <a href="/how-it-works">How It Works</a>
             <a href="/architecture">Architecture</a>
             <a href="/roadmap">Roadmap</a>
             <a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener">GitHub</a>
@@ -308,8 +310,12 @@ import MaturityCard from '../components/MaturityCard.astro';
   <section class="section-alt">
     <div class="container narrow text-center">
       <h2>Where to go next</h2>
-      <p class="section-lede">These pages are designed to be read in order, starting here.</p>
-      <a href="/what-is-icn" class="btn btn-primary btn-lg">Start reading: What is ICN →</a>
+      <p class="section-lede">If you are here to understand the project, start reading. If you are here to help shape it, use the engagement paths directly.</p>
+      <div class="hero-actions" style="justify-content: center;">
+        <a href="/what-is-icn" class="btn btn-primary btn-lg">Start reading: What is ICN →</a>
+        <a href="/get-involved" class="btn btn-secondary btn-lg">Choose a path: Get Involved</a>
+        <a href="https://github.com/sponsors/InterCooperative-Network" target="_blank" rel="noopener" class="btn btn-ghost btn-lg">Support the work ↗</a>
+      </div>
     </div>
   </section>
 

--- a/website/src/pages/rss.xml.ts
+++ b/website/src/pages/rss.xml.ts
@@ -11,7 +11,7 @@ export async function GET(context: any) {
       title: post.data.title,
       pubDate: post.data.pubDate,
       description: post.data.description,
-      link: `/blog/${post.slug}/`,
+      link: `/blog/${post.id.replace(/\.md$/, "")}/`,
     })),
   });
 }

--- a/website/src/pages/rss.xml.ts
+++ b/website/src/pages/rss.xml.ts
@@ -1,5 +1,6 @@
 import rss from "@astrojs/rss";
 import { getCollection } from "astro:content";
+import { blogSlugFromId } from "../lib/blog-slug";
 
 export async function GET(context: any) {
   const posts = await getCollection("blog");
@@ -11,7 +12,7 @@ export async function GET(context: any) {
       title: post.data.title,
       pubDate: post.data.pubDate,
       description: post.data.description,
-      link: `/blog/${post.id.replace(/\.md$/, "")}/`,
+      link: `/blog/${blogSlugFromId(post.id)}/`,
     })),
   });
 }

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -613,6 +613,9 @@ pre code {
   flex: 1;
   justify-content: center;
 }
+.nav-mobile-only {
+  display: none;
+}
 .nav-links a {
   color: var(--text-secondary);
   font-size: 0.875rem;
@@ -701,6 +704,12 @@ pre code {
   .nav-links li {
     list-style: none;
     width: 100%;
+  }
+  .nav-mobile-only {
+    display: block;
+    margin-top: var(--space-xs);
+    padding-top: var(--space-xs);
+    border-top: 1px solid var(--border-subtle);
   }
   .nav-links a {
     display: block;

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -636,6 +636,27 @@ pre code {
   gap: var(--space-sm);
   flex-shrink: 0;
 }
+.nav-support {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.38rem 0.7rem;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  line-height: 1;
+  text-decoration: none;
+  transition:
+    color var(--duration-fast) var(--ease-out),
+    border-color var(--duration-fast) var(--ease-out),
+    background var(--duration-fast) var(--ease-out);
+}
+.nav-support:hover {
+  color: var(--text-heading);
+  border-color: var(--border-accent);
+  background: var(--accent-amber-glow);
+}
 .nav-github {
   color: var(--text-muted);
   display: flex;
@@ -702,6 +723,9 @@ pre code {
     padding: var(--space-sm);
   }
   .nav-cta .btn {
+    display: none;
+  }
+  .nav-cta .nav-support {
     display: none;
   }
   .nav-cta .nav-github {
@@ -994,6 +1018,9 @@ pre code {
   margin-top: var(--space-md);
   font-size: 0.9375rem;
   max-width: 36ch;
+}
+.footer-brand p + p {
+  margin-top: var(--space-sm);
 }
 .footer-col h4 {
   font-size: 0.75rem;

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -284,11 +284,11 @@ pre code {
   border-bottom: 1px solid var(--border-subtle);
 }
 .section-pre-ladder {
-  padding-bottom: var(--space-2xl);
+  padding-bottom: var(--space-lg);
 }
 .section-ladder {
-  padding-top: var(--space-2xl);
-  padding-bottom: var(--space-3xl);
+  padding-top: var(--space-lg);
+  padding-bottom: var(--space-2xl);
 }
 .section-header {
   text-align: center;
@@ -1044,11 +1044,11 @@ pre code {
     padding: var(--space-3xl) 0;
   }
   .section-pre-ladder {
-    padding-bottom: var(--space-xl);
+    padding-bottom: var(--space-md);
   }
   .section-ladder {
-    padding-top: var(--space-xl);
-    padding-bottom: var(--space-2xl);
+    padding-top: var(--space-md);
+    padding-bottom: var(--space-xl);
   }
   .section-header {
     margin-bottom: var(--space-2xl);


### PR DESCRIPTION
## Summary
- add a public Get Involved page for technical, non-technical, institutional, and financial participation
- wire onboarding and support paths across the website, repo entry docs, and docs index
- repair onboarding doc-map drift and clean website type-check blockers so the intake surfaces verify cleanly

## Verification
- cd website && npm run lint
- cd website && npm run build
- ./scripts/check-onboarding-maps.sh HEAD
- git diff --check

## Notes
- GitHub Sponsors is surfaced as the real live financial support rail
- icn.zone redirect setup is intentionally out of scope for this PR and remains external Cloudflare work