### PR TITLE
fix(website): clarify homepage first-screen routing

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -470,9 +470,24 @@ import MaturityCard from '../components/MaturityCard.astro';
   border-top: 1px solid var(--border-subtle);
 }
 .hero-panel-links a {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.38rem 0.6rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: rgba(12, 17, 24, 0.56);
   font-family: var(--font-mono);
   font-size: 0.8125rem;
   letter-spacing: 0.04em;
+  line-height: 1;
+  transition:
+    border-color var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out),
+    background var(--duration-fast) var(--ease-out);
+}
+.hero-panel-links a:hover {
+  border-color: var(--border-default);
+  background: rgba(17, 24, 39, 0.9);
 }
 .badge-dot {
   width: 6px; height: 6px; border-radius: 50%;

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -374,7 +374,7 @@ import MaturityCard from '../components/MaturityCard.astro';
   position: relative;
   z-index: 2;
 }
-  .hero-shell {
+.hero-shell {
   display: grid;
   grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
   gap: var(--space-2xl);

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -19,14 +19,13 @@ import MaturityCard from '../components/MaturityCard.astro';
           </div>
 
           <h1>
-            The Intercooperative Network is infrastructure for<br/>
-            <span class="gradient-text">cooperatives, communities, and federations.</span>
+            Infrastructure for democratic institutions that need governance, records, and coordination to hold together.
           </h1>
 
           <p>
-            ICN is being developed as a shared digital infrastructure layer for democratic organizations.
-            Its purpose is to let institutions prove decisions, operate on infrastructure they control,
-            and coordinate with other organizations without surrendering those functions to a platform.
+            ICN is being built as shared digital infrastructure for cooperatives, communities, and federations.
+            The aim is not another app stack. It is a substrate where institutions can prove decisions,
+            keep records and obligations coherent, and coordinate across organizational boundaries on infrastructure they can govern.
           </p>
 
           <div class="hero-actions">
@@ -37,48 +36,87 @@ import MaturityCard from '../components/MaturityCard.astro';
             <a href="/get-involved" class="btn btn-secondary">Get Involved</a>
             <a href="/whats-real-now" class="btn btn-ghost">What's Real Now</a>
           </div>
-          <p class="hero-qualifier">For partners interested in durable institutional capacity, not another disconnected software tool.</p>
+          <p class="hero-qualifier">For institutions that need durable capacity, not another disconnected software tool.</p>
         </div>
 
-        <aside class="hero-panel animate-in animate-delay-2" aria-label="Summary">
+        <aside class="hero-panel animate-in animate-delay-2" aria-label="Start here">
           <div class="hero-panel-head">
-            <span class="eyebrow">Summary</span>
-            <h2>The institutional proposition.</h2>
+            <span class="eyebrow">Start Here</span>
+            <h2>Choose the right first page.</h2>
             <p>
-              ICN addresses a structural gap in the current cooperative software stack:
-              governance, records, obligations, and federation are usually carried across systems that were never designed to hold institutional authority together.
-            </p>
-            <p class="hero-panel-meta">
-              ICN is being designed as sector-governable infrastructure that democratic organizations can rely on together rather than rent indefinitely from outside vendors.
+              If you are evaluating ICN, start with the public framing. If you are trying to contribute,
+              partner, or support the work, use the engagement paths directly.
             </p>
           </div>
 
           <div class="hero-panel-list">
             <article class="hero-panel-item">
-              <span class="hero-panel-kicker">Provable decisions</span>
-              <p>Create governance records and receipts that members, partners, and counterparties can verify independently.</p>
+              <span class="hero-panel-kicker">Understand the project</span>
+              <p>Read <a href="/what-is-icn">What is ICN</a> and <a href="/whats-real-now">What's Real Now</a> for the public framing and current maturity.</p>
             </article>
             <article class="hero-panel-item">
-              <span class="hero-panel-kicker">Institution-controlled infrastructure</span>
-              <p>Keep identity, records, and core institutional processes on infrastructure your organization can govern and operate.</p>
+              <span class="hero-panel-kicker">Build or contribute</span>
+              <p>Use <a href="/for-developers">For Developers</a> and <a href="/get-involved">Get Involved</a> to find the actual contribution paths.</p>
             </article>
             <article class="hero-panel-item">
-              <span class="hero-panel-kicker">Cross-institutional coordination</span>
-              <p>Coordinate with partner organizations through shared protocols instead of routing cooperation through a single software landlord.</p>
+              <span class="hero-panel-kicker">Partner or support</span>
+              <p>Use <a href="/for-cooperatives">For Cooperatives</a> for institutional engagement and <a href="https://github.com/sponsors/InterCooperative-Network" target="_blank" rel="noopener">GitHub Sponsors</a> for financial support.</p>
             </article>
           </div>
 
           <div class="hero-panel-links">
+            <a href="/what-is-icn">What is ICN</a>
             <a href="/get-involved">Get Involved</a>
+            <a href="/for-developers">For Developers</a>
+            <a href="/for-cooperatives">For Cooperatives</a>
             <a href="/how-it-works">How It Works</a>
             <a href="/architecture">Architecture</a>
-            <a href="/roadmap">Roadmap</a>
-            <a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener">GitHub</a>
+            <a href="https://github.com/sponsors/InterCooperative-Network" target="_blank" rel="noopener">Support ICN</a>
           </div>
         </aside>
       </div>
     </div>
     <div class="hero-bg-grid" aria-hidden="true"></div>
+  </section>
+
+  <section class="section section-tight homepage-paths">
+    <div class="container">
+      <div class="section-header">
+        <span class="badge badge-amber">Engagement Paths</span>
+        <h2>Four concrete ways to engage.</h2>
+        <p>
+          The project has different entry points for technical contributors, non-code collaborators,
+          institutions, and financial supporters. Start with the path that matches what you are actually here to do.
+        </p>
+      </div>
+
+      <div class="grid grid-2 homepage-path-grid">
+        <article class="card card-accent-teal homepage-path-card">
+          <span class="homepage-path-num">01</span>
+          <h3>Developers and engineers</h3>
+          <p>Build the workspace, read the architectural guardrails, and pick a first contribution path that matches the repo as it actually exists.</p>
+          <a href="/for-developers" class="link-arrow">For Developers →</a>
+        </article>
+        <article class="card card-accent-amber homepage-path-card">
+          <span class="homepage-path-num">02</span>
+          <h3>Writers, designers, researchers, organizers</h3>
+          <p>Contribute documentation, design, policy thinking, testing, and ecosystem work without pretending the project is code-only.</p>
+          <a href="/get-involved#contribute" class="link-arrow">Non-technical contribution →</a>
+        </article>
+        <article class="card card-accent-purple homepage-path-card">
+          <span class="homepage-path-num">03</span>
+          <h3>Cooperatives and institutions</h3>
+          <p>Read the institutional framing first, then use the current discussion-led engagement path if your organization has a real use case and real capacity.</p>
+          <a href="/for-cooperatives" class="link-arrow">For Cooperatives →</a>
+        </article>
+        <article class="card card-accent-green homepage-path-card">
+          <span class="homepage-path-num">04</span>
+          <h3>Financial supporters</h3>
+          <p>GitHub Sponsors is the live support rail today. Use it if you want to sustain the work without inventing a funding structure that does not exist.</p>
+          <a href="https://github.com/sponsors/InterCooperative-Network" target="_blank" rel="noopener" class="link-arrow">Support on GitHub ↗</a>
+        </article>
+      </div>
+    </div>
   </section>
 
   <!-- ═══ PROBLEM ═══════════════════════════════════════════════ -->
@@ -336,22 +374,23 @@ import MaturityCard from '../components/MaturityCard.astro';
   position: relative;
   z-index: 2;
 }
-.hero-shell {
+  .hero-shell {
   display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(320px, 0.95fr);
+  grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
   gap: var(--space-2xl);
   align-items: start;
 }
 .hero-home .hero-content {
-  max-width: 720px;
+  max-width: 680px;
 }
 .hero-home .hero-content h1 {
-  font-size: clamp(2.25rem, 5.5vw, 3.75rem);
-  line-height: 1.08;
+  font-size: clamp(2rem, 4.7vw, 3.35rem);
+  line-height: 1.1;
+  max-width: 12ch;
 }
 .hero-home .hero-content > p {
-  max-width: 40em;
-  font-size: 1.0625rem;
+  max-width: 43em;
+  font-size: 1rem;
   line-height: 1.6;
 }
 
@@ -362,7 +401,7 @@ import MaturityCard from '../components/MaturityCard.astro';
 }
 .hero-panel {
   position: relative;
-  padding: var(--space-xl);
+  padding: var(--space-lg);
   background:
     linear-gradient(180deg, rgba(17, 24, 39, 0.9), rgba(11, 17, 27, 0.96));
   border: 1px solid var(--border-default);
@@ -383,28 +422,22 @@ import MaturityCard from '../components/MaturityCard.astro';
   );
 }
 .hero-panel-head h2 {
-  font-size: clamp(1.2rem, 2vw, 1.55rem);
+  font-size: clamp(1.1rem, 1.8vw, 1.4rem);
   margin: var(--space-sm) 0;
 }
 .hero-panel-head p {
   margin: 0;
-  font-size: 0.95rem;
-  line-height: 1.7;
+  font-size: 0.9rem;
+  line-height: 1.65;
   color: var(--text-secondary);
-}
-.hero-panel-meta {
-  margin-top: var(--space-sm) !important;
-  font-size: 0.8125rem !important;
-  line-height: 1.65 !important;
-  color: var(--text-muted) !important;
 }
 .hero-panel-list {
   display: grid;
-  gap: var(--space-md);
-  margin-top: var(--space-xl);
+  gap: var(--space-sm);
+  margin-top: var(--space-lg);
 }
 .hero-panel-item {
-  padding: var(--space-md) var(--space-lg);
+  padding: var(--space-md);
   background: rgba(12, 17, 24, 0.78);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
@@ -421,16 +454,19 @@ import MaturityCard from '../components/MaturityCard.astro';
 }
 .hero-panel-item p {
   margin: 0;
-  font-size: 0.9375rem;
-  line-height: 1.65;
+  font-size: 0.875rem;
+  line-height: 1.6;
   color: var(--text-secondary);
+}
+.hero-panel-item a {
+  color: var(--text-heading);
 }
 .hero-panel-links {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-sm) var(--space-md);
-  margin-top: var(--space-lg);
-  padding-top: var(--space-lg);
+  margin-top: var(--space-md);
+  padding-top: var(--space-md);
   border-top: 1px solid var(--border-subtle);
 }
 .hero-panel-links a {
@@ -461,6 +497,24 @@ import MaturityCard from '../components/MaturityCard.astro';
 /* Tighten the section right after the hero so the fold is not empty */
 .hero-home + .section-tight {
   padding-top: var(--space-xl);
+}
+.homepage-paths {
+  padding-bottom: var(--space-3xl);
+}
+.homepage-path-grid {
+  gap: var(--space-md);
+}
+.homepage-path-card {
+  position: relative;
+}
+.homepage-path-num {
+  display: inline-block;
+  margin-bottom: var(--space-sm);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: var(--accent-teal);
 }
 
 /* Left-aligned section headers inside narrow containers */


### PR DESCRIPTION
## Summary
- simplify the homepage hero copy and reduce the visual weight of the right-side panel
- turn the hero side panel into a clearer start-here routing surface
- add a homepage engagement-path section for developers, non-technical contributors, institutions, and financial supporters

## Why
The merged onboarding tranche improved the site architecture, but the homepage first screen still felt crowded and did not surface the contribution/support paths clearly enough.

## Verification
- cd website && npm run build
- cd website && npm run lint
