### PR TITLE
fix(website): tighten homepage hero proportions

### DIFF
--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -148,6 +148,7 @@ const jsonLd = {
             <li><a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener">GitHub</a></li>
             <li><a href="https://github.com/InterCooperative-Network/icn/issues" target="_blank" rel="noopener">Issues</a></li>
             <li><a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank" rel="noopener">Discussions</a></li>
+            <li><a href="https://discord.gg/sAEFCnEahn" target="_blank" rel="noopener">Discord</a></li>
             <li><a href="/community">Community</a></li>
             <li><a href="https://github.com/sponsors/InterCooperative-Network" target="_blank" rel="noopener">GitHub Sponsors</a></li>
             <li><a href="/blog">Blog</a></li>

--- a/website/src/pages/community.astro
+++ b/website/src/pages/community.astro
@@ -72,10 +72,10 @@ import stats from '../data/stats.json';
           <p>The live financial-support rail today. Sponsor the organization-level work sustaining the substrate.</p>
         </a>
 
-        <a href="https://matrix.to/#/#icn:matrix.org" target="_blank" rel="noopener noreferrer" class="community-card">
+        <a href="https://discord.gg/sAEFCnEahn" target="_blank" rel="noopener noreferrer" class="community-card">
           <div class="card-icon">09</div>
-          <h3>Matrix Room</h3>
-          <p>Real-time chat with ICN developers and cooperative technologists. Join <code>#icn:matrix.org</code> — no account required to read.</p>
+          <h3>Discord</h3>
+          <p>The live real-time chat surface today. Join the ICN Discord server for coordination, contributor questions, and project discussion.</p>
         </a>
 
         <a href="https://github.com/InterCooperative-Network/icn/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue" target="_blank" rel="noopener noreferrer" class="community-card">

--- a/website/src/pages/get-involved.astro
+++ b/website/src/pages/get-involved.astro
@@ -230,7 +230,7 @@ cargo test --workspace --lib</code></pre>
             about cooperative infrastructure that don't route through platform incumbents.
           </p>
           <p class="contribution-next">
-            <strong>First step:</strong> join <a href="https://matrix.to/#/#icn:matrix.org" target="_blank" rel="noopener"><code>#icn:matrix.org</code></a>
+            <strong>First step:</strong> join the <a href="https://discord.gg/sAEFCnEahn" target="_blank" rel="noopener">ICN Discord server</a>
             or post in <a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank" rel="noopener">Discussions</a>.
           </p>
         </article>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -23,7 +23,7 @@ import MaturityCard from '../components/MaturityCard.astro';
           </h1>
 
           <p>
-            ICN is being built as shared digital infrastructure for cooperatives, communities, and federations.
+            The InterCooperative Network is being built as shared digital infrastructure for cooperatives, communities, and federations.
             The aim is not another app stack. It is a substrate where institutions can prove decisions,
             keep records and obligations coherent, and coordinate across organizational boundaries on infrastructure they can govern.
           </p>
@@ -44,7 +44,7 @@ import MaturityCard from '../components/MaturityCard.astro';
             <span class="eyebrow">Start Here</span>
             <h2>Choose the right first page.</h2>
             <p>
-              If you are evaluating ICN, start with the public framing. If you are trying to contribute,
+              If you are evaluating the InterCooperative Network, start with the public framing. If you are trying to contribute,
               partner, or support the work, use the engagement paths directly.
             </p>
           </div>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -367,8 +367,8 @@ import MaturityCard from '../components/MaturityCard.astro';
   min-height: 0;
   height: auto;
   display: block;
-  padding-top: calc(64px + var(--space-3xl));
-  padding-bottom: var(--space-3xl);
+  padding-top: calc(64px + var(--space-2xl));
+  padding-bottom: var(--space-xl);
 }
 .hero-container {
   position: relative;
@@ -376,22 +376,23 @@ import MaturityCard from '../components/MaturityCard.astro';
 }
 .hero-shell {
   display: grid;
-  grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
-  gap: var(--space-2xl);
+  grid-template-columns: minmax(0, 1.22fr) minmax(300px, 0.78fr);
+  gap: var(--space-xl);
   align-items: start;
 }
 .hero-home .hero-content {
-  max-width: 680px;
+  max-width: 720px;
 }
 .hero-home .hero-content h1 {
-  font-size: clamp(2rem, 4.7vw, 3.35rem);
-  line-height: 1.1;
-  max-width: 12ch;
+  font-size: clamp(2rem, 4.4vw, 3.15rem);
+  line-height: 1.08;
+  max-width: 14ch;
+  margin-bottom: var(--space-md);
 }
 .hero-home .hero-content > p {
-  max-width: 43em;
-  font-size: 1rem;
-  line-height: 1.6;
+  max-width: 40em;
+  font-size: 0.98rem;
+  line-height: 1.55;
 }
 
 
@@ -401,7 +402,7 @@ import MaturityCard from '../components/MaturityCard.astro';
 }
 .hero-panel {
   position: relative;
-  padding: var(--space-lg);
+  padding: var(--space-md) var(--space-lg);
   background:
     linear-gradient(180deg, rgba(17, 24, 39, 0.9), rgba(11, 17, 27, 0.96));
   border: 1px solid var(--border-default);
@@ -422,22 +423,22 @@ import MaturityCard from '../components/MaturityCard.astro';
   );
 }
 .hero-panel-head h2 {
-  font-size: clamp(1.1rem, 1.8vw, 1.4rem);
+  font-size: clamp(1.05rem, 1.7vw, 1.3rem);
   margin: var(--space-sm) 0;
 }
 .hero-panel-head p {
   margin: 0;
-  font-size: 0.9rem;
-  line-height: 1.65;
+  font-size: 0.875rem;
+  line-height: 1.6;
   color: var(--text-secondary);
 }
 .hero-panel-list {
   display: grid;
   gap: var(--space-sm);
-  margin-top: var(--space-lg);
+  margin-top: var(--space-md);
 }
 .hero-panel-item {
-  padding: var(--space-md);
+  padding: 0.85rem var(--space-md);
   background: rgba(12, 17, 24, 0.78);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
@@ -454,8 +455,8 @@ import MaturityCard from '../components/MaturityCard.astro';
 }
 .hero-panel-item p {
   margin: 0;
-  font-size: 0.875rem;
-  line-height: 1.6;
+  font-size: 0.84rem;
+  line-height: 1.55;
   color: var(--text-secondary);
 }
 .hero-panel-item a {
@@ -464,20 +465,20 @@ import MaturityCard from '../components/MaturityCard.astro';
 .hero-panel-links {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-sm) var(--space-md);
-  margin-top: var(--space-md);
-  padding-top: var(--space-md);
+  gap: 0.4rem 0.5rem;
+  margin-top: var(--space-sm);
+  padding-top: var(--space-sm);
   border-top: 1px solid var(--border-subtle);
 }
 .hero-panel-links a {
   display: inline-flex;
   align-items: center;
-  padding: 0.38rem 0.6rem;
+  padding: 0.34rem 0.54rem;
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
   background: rgba(12, 17, 24, 0.56);
   font-family: var(--font-mono);
-  font-size: 0.8125rem;
+  font-size: 0.75rem;
   letter-spacing: 0.04em;
   line-height: 1;
   transition:
@@ -511,10 +512,11 @@ import MaturityCard from '../components/MaturityCard.astro';
 
 /* Tighten the section right after the hero so the fold is not empty */
 .hero-home + .section-tight {
-  padding-top: var(--space-xl);
+  padding-top: var(--space-md);
 }
 .homepage-paths {
-  padding-bottom: var(--space-3xl);
+  padding-top: var(--space-lg);
+  padding-bottom: var(--space-2xl);
 }
 .homepage-path-grid {
   gap: var(--space-md);

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -465,6 +465,7 @@ import MaturityCard from '../components/MaturityCard.astro';
 .hero-panel-links {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 0.4rem 0.5rem;
   margin-top: var(--space-sm);
   padding-top: var(--space-sm);

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -474,14 +474,16 @@ import MaturityCard from '../components/MaturityCard.astro';
 .hero-panel-links a {
   display: inline-flex;
   align-items: center;
-  padding: 0.34rem 0.54rem;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.5rem 0.75rem;
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
   background: rgba(12, 17, 24, 0.56);
   font-family: var(--font-mono);
-  font-size: 0.75rem;
+  font-size: 0.78rem;
   letter-spacing: 0.04em;
-  line-height: 1;
+  line-height: 1.1;
   transition:
     border-color var(--duration-fast) var(--ease-out),
     color var(--duration-fast) var(--ease-out),
@@ -516,7 +518,6 @@ import MaturityCard from '../components/MaturityCard.astro';
   padding-top: var(--space-md);
 }
 .homepage-paths {
-  padding-top: var(--space-lg);
   padding-bottom: var(--space-2xl);
 }
 .homepage-path-grid {


### PR DESCRIPTION
## Summary
- reduce the homepage hero's excess top and bottom padding
- widen the headline measure and rebalance the hero columns
- lighten the right-side panel and pull the engagement section closer to the fold

## Why
The live homepage content is correct, but the first screen still feels awkwardly stretched and visually unbalanced on desktop.

## Verification
- cd website && npm run build
- cd website && npm run lint
