### PR TITLE
fix(website): simplify homepage hero and header

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -6380,9 +6380,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -61,12 +61,6 @@ const jsonLd = {
   <nav class="nav" id="main-nav" aria-label="Primary">
     <div class="nav-inner">
       <a href="/" class="nav-logo" aria-label="InterCooperative Network — home">
-        <svg class="nav-logo-svg" width="28" height="28" viewBox="0 0 128 128" fill="none" aria-hidden="true" focusable="false">
-          <rect width="128" height="128" rx="28" fill="#0c1420"/>
-          <path d="M64 34 C84 34, 96 48, 96 64 C96 80, 84 94, 64 94 C44 94, 32 80, 32 64 C32 52, 39 42, 50 37" stroke="#2dd4bf" stroke-width="7" stroke-linecap="round" fill="none"/>
-          <path d="M50 37 L44 28 M50 37 L42 42" stroke="#2dd4bf" stroke-width="5.5" stroke-linecap="round"/>
-          <circle cx="64" cy="64" r="4.5" fill="#2dd4bf"/>
-        </svg>
         <span>ICN</span>
       </a>
 
@@ -105,12 +99,6 @@ const jsonLd = {
       <div class="footer-inner">
         <div class="footer-brand">
           <a href="/" class="nav-logo" aria-label="InterCooperative Network — home">
-            <svg class="nav-logo-svg" width="28" height="28" viewBox="0 0 128 128" fill="none" aria-hidden="true" focusable="false">
-              <rect width="128" height="128" rx="28" fill="#0c1420"/>
-              <path d="M64 34 C84 34, 96 48, 96 64 C96 80, 84 94, 64 94 C44 94, 32 80, 32 64 C32 52, 39 42, 50 37" stroke="#2dd4bf" stroke-width="7" stroke-linecap="round" fill="none"/>
-              <path d="M50 37 L44 28 M50 37 L42 42" stroke="#2dd4bf" stroke-width="5.5" stroke-linecap="round"/>
-              <circle cx="64" cy="64" r="4.5" fill="#2dd4bf"/>
-            </svg>
             <span>InterCooperative Network</span>
           </a>
           <p>Institutional infrastructure for cooperative and federated organizations. Identity, governance, accounting, and coordination — auditable and member-owned.</p>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -19,13 +19,13 @@ import MaturityCard from '../components/MaturityCard.astro';
           </div>
 
           <h1>
-            Infrastructure for democratic institutions that need governance, records, and coordination to hold together.
+            <span>Infrastructure for</span>
+            <span class="hero-accent">democratic institutions.</span>
           </h1>
 
           <p>
-            The InterCooperative Network is being built as shared digital infrastructure for cooperatives, communities, and federations.
-            The aim is not another app stack. It is a substrate where institutions can prove decisions,
-            keep records and obligations coherent, and coordinate across organizational boundaries on infrastructure they can govern.
+            The InterCooperative Network is shared digital infrastructure for cooperatives, communities, and federations.
+            It helps institutions keep decisions, records, obligations, and coordination on infrastructure they can govern.
           </p>
 
           <div class="hero-actions">
@@ -36,44 +36,42 @@ import MaturityCard from '../components/MaturityCard.astro';
             <a href="/get-involved" class="btn btn-secondary">Get Involved</a>
             <a href="/whats-real-now" class="btn btn-ghost">What's Real Now</a>
           </div>
-          <p class="hero-qualifier">For institutions that need durable capacity, not another disconnected software tool.</p>
+          <p class="hero-qualifier">For institutions that need durable capacity, not another disconnected software stack.</p>
+          <aside class="hero-panel animate-in animate-delay-2" aria-label="Start here">
+            <div class="hero-panel-head">
+              <span class="eyebrow">Start Here</span>
+              <h2>Choose the right first page.</h2>
+              <p>
+                If you are evaluating the InterCooperative Network, start with the public framing. If you are trying to contribute,
+                partner, or support the work, use the engagement paths directly.
+              </p>
+            </div>
+
+            <div class="hero-panel-list">
+              <article class="hero-panel-item">
+                <span class="hero-panel-kicker">Understand the project</span>
+                <p>Read <a href="/what-is-icn">What is ICN</a> and <a href="/whats-real-now">What's Real Now</a> for the public framing and current maturity.</p>
+              </article>
+              <article class="hero-panel-item">
+                <span class="hero-panel-kicker">Build or contribute</span>
+                <p>Use <a href="/for-developers">For Developers</a> and <a href="/get-involved">Get Involved</a> to find the actual contribution paths.</p>
+              </article>
+              <article class="hero-panel-item">
+                <span class="hero-panel-kicker">Partner or support</span>
+                <p>Use <a href="/for-cooperatives">For Cooperatives</a> for institutional engagement and <a href="https://github.com/sponsors/InterCooperative-Network" target="_blank" rel="noopener">GitHub Sponsors</a> for financial support.</p>
+              </article>
+            </div>
+
+            <div class="hero-panel-links">
+              <a href="/what-is-icn">What is ICN</a>
+              <a href="/whats-real-now">What's Real Now</a>
+              <a href="/for-developers">For Developers</a>
+              <a href="/for-cooperatives">For Cooperatives</a>
+              <a href="/get-involved">Get Involved</a>
+              <a href="https://github.com/sponsors/InterCooperative-Network" target="_blank" rel="noopener">Support ICN</a>
+            </div>
+          </aside>
         </div>
-
-        <aside class="hero-panel animate-in animate-delay-2" aria-label="Start here">
-          <div class="hero-panel-head">
-            <span class="eyebrow">Start Here</span>
-            <h2>Choose the right first page.</h2>
-            <p>
-              If you are evaluating the InterCooperative Network, start with the public framing. If you are trying to contribute,
-              partner, or support the work, use the engagement paths directly.
-            </p>
-          </div>
-
-          <div class="hero-panel-list">
-            <article class="hero-panel-item">
-              <span class="hero-panel-kicker">Understand the project</span>
-              <p>Read <a href="/what-is-icn">What is ICN</a> and <a href="/whats-real-now">What's Real Now</a> for the public framing and current maturity.</p>
-            </article>
-            <article class="hero-panel-item">
-              <span class="hero-panel-kicker">Build or contribute</span>
-              <p>Use <a href="/for-developers">For Developers</a> and <a href="/get-involved">Get Involved</a> to find the actual contribution paths.</p>
-            </article>
-            <article class="hero-panel-item">
-              <span class="hero-panel-kicker">Partner or support</span>
-              <p>Use <a href="/for-cooperatives">For Cooperatives</a> for institutional engagement and <a href="https://github.com/sponsors/InterCooperative-Network" target="_blank" rel="noopener">GitHub Sponsors</a> for financial support.</p>
-            </article>
-          </div>
-
-          <div class="hero-panel-links">
-            <a href="/what-is-icn">What is ICN</a>
-            <a href="/get-involved">Get Involved</a>
-            <a href="/for-developers">For Developers</a>
-            <a href="/for-cooperatives">For Cooperatives</a>
-            <a href="/how-it-works">How It Works</a>
-            <a href="/architecture">Architecture</a>
-            <a href="https://github.com/sponsors/InterCooperative-Network" target="_blank" rel="noopener">Support ICN</a>
-          </div>
-        </aside>
       </div>
     </div>
     <div class="hero-bg-grid" aria-hidden="true"></div>
@@ -367,42 +365,58 @@ import MaturityCard from '../components/MaturityCard.astro';
   min-height: 0;
   height: auto;
   display: block;
-  padding-top: calc(64px + var(--space-2xl));
-  padding-bottom: var(--space-xl);
+  padding-top: calc(64px + var(--space-xl));
+  padding-bottom: var(--space-lg);
 }
 .hero-container {
   position: relative;
   z-index: 2;
 }
 .hero-shell {
-  display: grid;
-  grid-template-columns: minmax(0, 1.22fr) minmax(300px, 0.78fr);
-  gap: var(--space-xl);
-  align-items: start;
+  display: block;
 }
 .hero-home .hero-content {
-  max-width: 720px;
+  max-width: 900px;
+  margin: 0 auto;
+  text-align: center;
 }
 .hero-home .hero-content h1 {
-  font-size: clamp(2rem, 4.4vw, 3.15rem);
-  line-height: 1.08;
-  max-width: 14ch;
-  margin-bottom: var(--space-md);
+  font-size: clamp(2.35rem, 4.7vw, 4.1rem);
+  line-height: 1.04;
+  max-width: 11.5ch;
+  margin-bottom: var(--space-sm);
+  margin-left: auto;
+  margin-right: auto;
+}
+.hero-home .hero-content h1 span {
+  display: block;
+}
+.hero-accent {
+  color: var(--text-heading);
 }
 .hero-home .hero-content > p {
-  max-width: 40em;
-  font-size: 0.98rem;
-  line-height: 1.55;
+  max-width: 38rem;
+  font-size: 1rem;
+  line-height: 1.65;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 
 .hero-qualifier {
   font-size: .8125rem; color: var(--text-muted);
-  margin: var(--space-sm) 0 0; letter-spacing: .01em; max-width: 42em;
+  margin: 0.75rem auto 0; letter-spacing: .01em; max-width: 42em;
+}
+.hero-home .hero-actions {
+  justify-content: center;
 }
 .hero-panel {
   position: relative;
-  padding: var(--space-md) var(--space-lg);
+  margin-top: var(--space-xl);
+  max-width: 980px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 1rem 1rem 1.05rem;
   background:
     linear-gradient(180deg, rgba(17, 24, 39, 0.9), rgba(11, 17, 27, 0.96));
   border: 1px solid var(--border-default);
@@ -423,22 +437,23 @@ import MaturityCard from '../components/MaturityCard.astro';
   );
 }
 .hero-panel-head h2 {
-  font-size: clamp(1.05rem, 1.7vw, 1.3rem);
-  margin: var(--space-sm) 0;
+  font-size: clamp(1rem, 1.45vw, 1.18rem);
+  margin: 0.45rem 0 0.5rem;
 }
 .hero-panel-head p {
   margin: 0;
-  font-size: 0.875rem;
-  line-height: 1.6;
+  font-size: 0.84rem;
+  line-height: 1.55;
   color: var(--text-secondary);
 }
 .hero-panel-list {
   display: grid;
-  gap: var(--space-sm);
-  margin-top: var(--space-md);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.7rem;
+  margin-top: 0.85rem;
 }
 .hero-panel-item {
-  padding: 0.85rem var(--space-md);
+  padding: 0.72rem 0.85rem;
   background: rgba(12, 17, 24, 0.78);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
@@ -455,33 +470,32 @@ import MaturityCard from '../components/MaturityCard.astro';
 }
 .hero-panel-item p {
   margin: 0;
-  font-size: 0.84rem;
-  line-height: 1.55;
+  font-size: 0.81rem;
+  line-height: 1.5;
   color: var(--text-secondary);
 }
 .hero-panel-item a {
   color: var(--text-heading);
 }
 .hero-panel-links {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 0.4rem 0.5rem;
-  margin-top: var(--space-sm);
-  padding-top: var(--space-sm);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.42rem;
+  margin-top: 0.85rem;
+  padding-top: 0.85rem;
   border-top: 1px solid var(--border-subtle);
 }
 .hero-panel-links a {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 2.75rem;
-  padding: 0.5rem 0.75rem;
+  min-height: 2.5rem;
+  padding: 0.45rem 0.65rem;
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
   background: rgba(12, 17, 24, 0.56);
   font-family: var(--font-mono);
-  font-size: 0.78rem;
+  font-size: 0.74rem;
   letter-spacing: 0.04em;
   line-height: 1.1;
   transition:
@@ -598,13 +612,10 @@ import MaturityCard from '../components/MaturityCard.astro';
     padding-top: calc(64px + var(--space-xl));
     padding-bottom: var(--space-xl);
   }
-  .hero-shell {
-    grid-template-columns: 1fr;
-    gap: var(--space-xl);
-  }
   .hero-home .hero-content h1 {
     font-size: clamp(1.75rem, 7vw, 2.5rem);
     line-height: 1.15;
+    max-width: 10.5ch;
   }
   .hero-home .hero-content > p {
     font-size: 0.9375rem;
@@ -612,6 +623,12 @@ import MaturityCard from '../components/MaturityCard.astro';
   .hero-panel {
     padding: var(--space-lg);
     border-radius: var(--radius-xl);
+  }
+  .hero-panel-list {
+    grid-template-columns: 1fr;
+  }
+  .hero-panel-links {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
   .hero-actions .btn {
     flex: 1 1 auto;

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -602,9 +602,6 @@ pre code {
 .nav-logo:hover {
   color: var(--text-heading);
 }
-.nav-logo-svg {
-  border-radius: 8px;
-}
 .nav-links {
   display: flex;
   align-items: center;
@@ -681,9 +678,6 @@ pre code {
   padding: var(--space-xs);
 }
 @media (max-width: 1180px) {
-  .nav .nav-logo span {
-    display: none;
-  }
   .nav-inner {
     gap: var(--space-md);
   }

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -611,6 +611,8 @@ pre code {
   gap: 2px;
   list-style: none;
   flex: 1;
+  min-width: 0;
+  flex-wrap: nowrap;
   justify-content: center;
 }
 .nav-mobile-only {
@@ -624,6 +626,7 @@ pre code {
   border-radius: var(--radius-md);
   transition: all var(--duration-fast) var(--ease-out);
   text-decoration: none;
+  white-space: nowrap;
 }
 .nav-links a:hover {
   color: var(--text-primary);
@@ -685,7 +688,17 @@ pre code {
     gap: var(--space-md);
   }
 }
-@media (max-width: 768px) {
+@media (max-width: 1280px) {
+  .nav-links a {
+    font-size: 0.8125rem;
+    padding: 0.34rem 0.5rem;
+  }
+  .nav-support {
+    padding: 0.34rem 0.6rem;
+    font-size: 0.78rem;
+  }
+}
+@media (max-width: 1120px) {
   .nav-links {
     display: none;
     position: absolute;


### PR DESCRIPTION
## Summary
- simplify the homepage first screen with a shorter centered hero statement
- move the start-here routing block under the hero and tighten its structure
- remove the temporary nav/footer icon and keep a clean text wordmark for now
- improve top-nav behavior on narrower desktop widths

## Verification
- cd website && npm run build
- cd website && npm run lint