### PR TITLE
docs(design): add ICN visual system draft

### DIFF
--- a/docs/design/ICN_PROMPT_LIBRARY.md
+++ b/docs/design/ICN_PROMPT_LIBRARY.md
@@ -1,0 +1,265 @@
+---
+Status: draft
+Canonical: no
+Depends-On: docs/design/ICN_VISUAL_SYSTEM.md
+Last Reviewed: 2026-04-22
+Last Updated: 2026-04-22
+Purpose: Tactical prompt library for image generation and visual exploration aligned with ICN visual doctrine.
+---
+
+# ICN Prompt Library
+
+## 1. How to use this file
+
+This file is tactical and fast-changing.
+
+It exists to help generate visual references for:
+
+- website hero assets
+- docs illustrations
+- product concept images
+- summit/demo materials
+- onboarding graphics
+- institutional explainer visuals
+
+These prompts must follow the rules in `ICN_VISUAL_SYSTEM.md`, especially:
+
+- truthfulness over aspiration
+- accessibility-minded composition
+- no default fintech/crypto framing
+- no generic startup/SaaS sludge
+- no meaningless network-globe abstraction
+
+Each prompt should be tagged as one of:
+
+- **concept art**
+- **product concept**
+- **diagram / explainer**
+- **website visual**
+- **docs visual**
+- **demo visual**
+
+---
+
+## 2. Prompt template
+
+Use this structure when creating or revising prompts:
+
+**Surface:** website / docs / product / demo / onboarding  
+**Type:** concept art / product concept / explainer  
+**Audience:** member / organizer / developer / partner / general public  
+**Goal:** what the image must explain  
+**Must show:** required visual concepts  
+**Must avoid:** banned motifs  
+**Truthfulness note:** what the image must not overclaim
+
+---
+
+## 3. Anchor asset 01 — Homepage hero
+
+**Surface:** website  
+**Type:** concept art  
+**Audience:** general public, prospective partners, contributors  
+**Goal:** make ICN feel like real democratic infrastructure rather than abstract software
+
+**Prompt**  
+Create a cinematic but grounded visual of democratic coordination infrastructure connecting cooperatives, communities, and federations across a real region. Show ordinary people participating through humane technology and real institutional settings. Emphasize federated self-governance, visible coordination, and post-corporate civic modernity. The image should feel serious, accessible, and socially grounded, not utopian fluff and not dystopian sludge. Avoid crypto aesthetics, fintech cues, generic startup branding, abstract network globes, fake 3D coins, and empty "connected future" imagery.
+
+**Must show**
+
+- people
+- institutions
+- coordination
+- non-centralized structure
+- real environments
+
+**Must avoid**
+
+- token imagery
+- exchange/wallet vibes
+- generic glowing nodes in a void
+- corporate office stock-photo energy
+
+**Truthfulness note**  
+Do not imply fully shipped product surfaces or turnkey institutional deployment.
+
+---
+
+## 4. Anchor asset 02 — Member participation surface
+
+**Surface:** product / docs / website  
+**Type:** product concept  
+**Audience:** members, organizers, contributors  
+**Goal:** show what member-centered participation feels like without freezing one temporary layout as doctrine
+
+**Prompt**  
+Create a mobile-first civic product concept showing a member-centered participation interface for democratic coordination across multiple institutional contexts. Show a persistent person acting across different scopes, with clear action cards, visible status, readable hierarchy, and proof/verification affordances. The interface should feel humane, serious, accessible, and modern without resembling a banking app, crypto wallet, or enterprise dashboard. Emphasize legible actionability, scope context, and trustworthy state presentation.
+
+**Must show**
+
+- member-centered continuity
+- multiple scopes
+- action-oriented participation
+- visible status
+- verification affordances
+
+**Must avoid**
+
+- fintech defaults
+- wallet/balance metaphors as the main frame
+- overcompressed mobile layouts
+- inaccessible tiny text
+
+**Truthfulness note**  
+Treat this as directional product concept art unless the exact flow is already implemented.
+
+---
+
+## 5. Anchor asset 03 — Provenance / verification chain
+
+**Surface:** docs / website / demo  
+**Type:** explainer visual  
+**Audience:** members, organizers, developers, partners  
+**Goal:** make authorization and proof understandable
+
+**Prompt**  
+Create a clear visual explainer showing how a democratic decision produces downstream effects through a visible chain of authorization and verification. Show a proposal, decision proof, authorization record, completion record, and resulting state change in a way that ordinary people can understand at a glance. The visual should communicate transparency, traceability, and democratic legitimacy. Use structured, readable composition with progressive disclosure cues. Avoid blockchain hype aesthetics, fake hashes floating everywhere, or opaque technical mystique.
+
+**Must show**
+
+- upstream decision
+- downstream consequence
+- visible chain
+- comprehensible verification
+- calm trustworthy structure
+
+**Must avoid**
+
+- techno-mysticism
+- meaningless cryptographic theater
+- "magic auditability" vibes
+
+**Truthfulness note**  
+Only depict proof relationships that reflect real or explicitly planned ICN provenance logic.
+
+---
+
+## 6. Anchor asset 04 — Scope switching
+
+**Surface:** docs / product / onboarding  
+**Type:** product concept  
+**Audience:** members and contributors  
+**Goal:** show co-equal scopes and continuity of identity
+
+**Prompt**  
+Create a product concept showing the same member participating across multiple institutional contexts such as a cooperative, a community, and a federation. Show that the person remains continuous while the role, permissions, and context change by scope. Emphasize co-equal participation contexts rather than hierarchy. The design should feel clear, grounded, and institutionally real, not like a role picker in enterprise admin software.
+
+**Must show**
+
+- same person
+- multiple institutions
+- continuity of identity
+- role/context change
+- equal dignity across scopes
+
+**Must avoid**
+
+- ladder metaphors
+- admin-console visual language
+- gamified switching
+
+**Truthfulness note**  
+Do not imply fully solved multi-surface implementations if the image is conceptual.
+
+---
+
+## 7. Anchor asset 05 — Institution formation
+
+**Surface:** website / docs / demo  
+**Type:** concept art / explainer  
+**Audience:** organizers, cooperative partners, contributors  
+**Goal:** show institution creation without overclaiming "one-click" simplicity
+
+**Prompt**  
+Create a grounded visual concept showing a new cooperative or community institution being established with reusable democratic infrastructure. Show chartering, membership formation, governance setup, and participation tools as connected steps. The image should feel practical, serious, and socially rooted rather than magical or overly automated. Avoid implying that institution creation is fully turnkey if it is not yet implemented.
+
+**Must show**
+
+- charter
+- people
+- institution formation
+- governance setup
+- practical process
+
+**Must avoid**
+
+- "instant app creation" fantasy
+- startup onboarding cliches
+- fake no-code miracle branding
+
+**Truthfulness note**  
+Depict this as institutional direction unless the exact packaging exists.
+
+---
+
+## 8. Anchor asset 06 — Commons layer
+
+**Surface:** docs / strategy / website  
+**Type:** concept art / explainer  
+**Audience:** contributors, partners, technically literate public  
+**Goal:** show governed shared infrastructure without monopoly-platform framing
+
+**Prompt**  
+Create a visual concept of communities and institutions sharing compute, storage, and infrastructure through governed commons rather than platform monopolies. Show collective stewardship, transparent allocation, and institutional control in a grounded, comprehensible way. The image should communicate shared capability without collapsing into cloud-platform or crypto-mining aesthetics.
+
+**Must show**
+
+- shared infrastructure
+- governance
+- resource stewardship
+- collective control
+- transparency
+
+**Must avoid**
+
+- data-center worship
+- cloud-company branding cues
+- crypto-mining imagery
+- sci-fi server mysticism
+
+**Truthfulness note**  
+Do not imply implementation completeness beyond current subsystem reality.
+
+---
+
+## 9. Reusable negative prompt language
+
+Use as needed:
+
+- no crypto
+- no fake 3D coins
+- no exchange or wallet interface
+- no corporate SaaS dashboard
+- no abstract network globe
+- no stock-photo startup office
+- no cyberpunk neon overload
+- no luxury fintech branding
+- no inaccessible tiny text
+- no meaningless holograms
+- no magical AI-control-room aesthetic
+- no bureaucratic dead portal styling
+
+---
+
+## 10. Asset acceptance checklist
+
+Before keeping a generated image, ask:
+
+- Does it make ICN more understandable?
+- Does it avoid misclassifying ICN as fintech, crypto, or SaaS?
+- Does it show institutions and people rather than generic nodes?
+- Does it feel accessible and mobile-aware where relevant?
+- Does it remain truthful about current implementation?
+- Does it support a real surface: website, docs, product, onboarding, or demo?
+
+If not, discard it and iterate.

--- a/docs/design/ICN_PROMPT_LIBRARY.md
+++ b/docs/design/ICN_PROMPT_LIBRARY.md
@@ -1,7 +1,7 @@
 ---
 Status: draft
 Canonical: no
-Depends-On: docs/design/ICN_VISUAL_SYSTEM.md
+Depends On: docs/design/ICN_VISUAL_SYSTEM.md
 Last Reviewed: 2026-04-22
 Last Updated: 2026-04-22
 Purpose: Tactical prompt library for image generation and visual exploration aligned with ICN visual doctrine.

--- a/docs/design/ICN_VISUAL_SYSTEM.md
+++ b/docs/design/ICN_VISUAL_SYSTEM.md
@@ -1,0 +1,385 @@
+---
+Status: draft
+Canonical: no
+Owner: Matt Faherty
+Last Reviewed: 2026-04-22
+Last Updated: 2026-04-22
+Purpose: Define the stable visual doctrine for ICN across website, docs, product surfaces, onboarding, demo materials, and future institutional deployments.
+---
+
+# ICN Visual System
+
+## 1. Why this exists
+
+ICN is building democratic coordination infrastructure.
+
+That means the visual system cannot be decorative garnish, startup theater, or a thin stylistic layer over inherited platform metaphors. It has a real job:
+
+- make ICN legible
+- make institutions, participation, and verification visible
+- support trust without pretending certainty where none exists
+- give website, docs, product surfaces, and demos a coherent language
+- support implementation rather than drift away from it
+
+The visual system exists to help people understand what ICN is, what it does, and why it is structurally different from corporate platforms, fintech products, and crypto spectacle.
+
+**ICN should look like democratic infrastructure that ordinary people can actually use.**
+
+---
+
+## 2. Core visual thesis
+
+ICN visuals should communicate five things at once:
+
+1. **Human participation**  
+   Real people acting inside institutions, not abstract "users" floating in a tech void.
+
+2. **Federated institutional structure**  
+   ICN is not one giant central platform. It is a network of self-governing entities that coordinate without collapsing into one owner or one command point.
+
+3. **Scope-aware membership**  
+   A person can participate across multiple institutional contexts while remaining the same member.
+
+4. **Proof-backed coordination**  
+   Actions are not magic. They are authorized, traceable, and verifiable.
+
+5. **Humane post-corporate modernity**  
+   The system should feel capable, accessible, serious, and socially real without becoming sterile, authoritarian, or dystopian.
+
+---
+
+## 3. Stable design principles
+
+### 3.1 Make the invisible visible
+
+ICN exists to expose hidden mechanisms of coordination, authorization, obligation, and institutional action.
+
+The visual system should therefore make visible:
+
+- who can act
+- why they can act
+- what authorized the action
+- what changed
+- what scope the action belongs to
+- where verification lives
+- how downstream effects connect upstream
+
+If a visual looks impressive but increases confusion, it failed.
+
+### 3.2 Member-first, not institution-first
+
+The anchor of the experience is the member.
+
+The person persists.  
+The institutional context changes.
+
+Visuals should reflect continuity of identity across multiple scopes, roles, and contexts.
+
+This does **not** require freezing any one product navigation model into doctrine. It means the system should consistently present participation from the member's point of view rather than treating institutions as the only stable center.
+
+### 3.3 Scope coequality
+
+Cooperatives, communities, and federations should not be depicted as a fake civilizational ladder.
+
+They are distinct institutional forms with different jobs, different powers, and different contexts. A member can inhabit several of them at once. The visual system should reinforce that these are co-equal scopes of participation rather than stages in a hierarchy.
+
+### 3.4 Proof must be understandable
+
+Verification is politically useless if only developers can interpret it.
+
+The visual system should make provenance legible through progressive disclosure:
+
+- simple first layer
+- deeper explanation on inspection
+- raw proof material available beneath that
+
+The system should always be able to answer:
+
+- Why does this exist?
+- Who authorized it?
+- What followed from it?
+
+### 3.5 Civic seriousness without bureaucratic deadness
+
+ICN should feel:
+
+- serious
+- trustworthy
+- calm
+- coherent
+- capable
+- transparent
+- socially grounded
+
+It should not feel like:
+
+- a dead government portal
+- a venture-backed SaaS dashboard
+- a speculative finance product
+- a cyberpunk scam
+- a productivity app pretending to be governance
+
+### 3.6 Accessibility is a first-order requirement
+
+Accessibility is not a brand value or a compliance footnote. It is a participation requirement.
+
+If the interface excludes people, the institution excludes people.
+
+The visual system must therefore support broad participation across device quality, motor conditions, visual needs, cognitive load, and environmental constraints.
+
+### 3.7 Language is part of the architecture
+
+Words are not cosmetic. They encode assumptions.
+
+ICN should avoid defaulting to metaphors that smuggle in the wrong institutional model. But vocabulary bans should not be absolute. A term may be correct on a specific surface when that concept is literally what is being shown.
+
+The rule is:
+
+**Do not use financial-platform or custodial language as the primary framing unless the surface is specifically about that concept and the term is literally accurate.**
+
+For example, terms like `account`, `balance`, `payment`, or `transaction` should not become the default conceptual frame for ICN as a whole. But they may be appropriate on a narrow surface when they truthfully describe the thing being shown.
+
+### 3.8 Truthfulness over aspiration
+
+Do not depict product capabilities, member flows, institutional packaging, automation, or deployment simplicity as if they already exist when they do not.
+
+Visuals may illustrate direction, but they must not misrepresent implementation reality.
+
+Rules:
+
+- do not imply fully shipped flows where only specs exist
+- do not depict institutional packaging as turnkey if it is still conceptual
+- do not show proof/verification affordances that the product cannot yet support on that surface
+- do not imply that a demo artifact is the same thing as a production-ready member experience
+- clearly distinguish concept art, UX direction, and implemented product
+
+The visual system should build trust, not spend it dishonestly.
+
+---
+
+## 4. Concrete accessibility requirements
+
+These are minimum requirements for implementation-facing design work.
+
+### 4.1 Contrast
+
+- Body text and critical UI text must meet WCAG AA contrast at minimum
+- Important controls and status indicators must not rely on color alone
+- Proof/verification states must remain distinguishable in grayscale and low-light conditions
+
+### 4.2 Touch targets
+
+- Interactive touch targets should be at least 44x44 CSS pixels minimum
+- Dense card layouts must preserve reliable tap areas even on narrow mobile screens
+- Primary actions must remain reachable with one-handed use where practical
+
+### 4.3 Motion
+
+- Respect reduced-motion preferences
+- Avoid motion as the sole carrier of state change
+- Eliminate decorative animation that adds cognitive overhead without increasing comprehension
+
+### 4.4 Type
+
+- Use a readable type scale with clear hierarchy
+- Avoid tiny metadata text that becomes illegible on mobile
+- Maintain comfortable line length and spacing
+- Prefer clarity over compression
+
+### 4.5 Mobile-first hierarchy
+
+- Design the information hierarchy for the small screen first
+- The most important state, action, and verification information must appear without requiring desktop assumptions
+- Do not hide core participation functions behind hover, dense menus, or desktop-only affordances
+
+---
+
+## 5. Emotional tone
+
+ICN should feel:
+
+- grounded
+- dignified
+- humane
+- modern
+- trustworthy
+- high-signal
+- transparent
+- collectively serious
+
+It should not feel:
+
+- whimsical
+- gamified
+- luxury-branded
+- hype-driven
+- militarized
+- mystical
+- surveillance-heavy
+- abstract to the point of uselessness
+
+---
+
+## 6. Visual motifs
+
+These motifs should recur across illustrations, diagrams, product references, and public-facing assets.
+
+### 6.1 The persistent member
+
+A recurring motif: the same person acting across multiple institutional contexts while remaining the same person.
+
+### 6.2 Visible authorization
+
+A recurring motif: decisions visibly producing downstream effects through traceable authorization and verification.
+
+### 6.3 Federation without centralization
+
+A recurring motif: distinct institutions coordinating through shared infrastructure without disappearing into one sovereign center.
+
+### 6.4 Humane civic infrastructure
+
+A recurring motif: real environments, real institutions, real social settings, and real participation — not glowing UI fragments floating in a void.
+
+### 6.5 Legible state
+
+A recurring motif: interfaces and diagrams that make status, scope, actionability, and provenance obvious at a glance.
+
+---
+
+## 7. Anti-patterns and banned aesthetics
+
+These are recurring failure modes.
+
+### 7.1 Corporate SaaS sludge
+
+Avoid:
+
+- generic enterprise dashboard polish
+- stock-photo office teamwork theater
+- shallow "productivity" visual language
+- growth-chart aesthetics as identity
+- empty startup branding cues
+
+### 7.2 Crypto-bro futurism
+
+Avoid:
+
+- token iconography
+- fake 3D coins
+- exchange/wallet aesthetics as default framing
+- speculative-finance visual cues
+- neon "decentralization" theater
+- blockchain cliche imagery with no institutional content
+
+### 7.3 Abstract network-globe nonsense
+
+Avoid:
+
+- glowing globes with random lines
+- meaningless node webs
+- "connected future" visuals with no people, no institutions, and no causality
+
+### 7.4 Bureaucratic deadness
+
+Avoid:
+
+- lifeless administrative flatness
+- sterile civic minimalism with no human presence
+- visual monotony that makes participation feel like paperwork punishment
+
+### 7.5 Custodial-finance default framing
+
+Avoid using bank, wallet, exchange, or custody metaphors as the default way of representing ICN unless the surface is specifically and truthfully about that concept.
+
+---
+
+## 8. Vocabulary guidance
+
+Language and visuals must reinforce the correct institutional model.
+
+Preferred framing often includes:
+
+- participation
+- governance
+- proof
+- verification
+- scope
+- member
+- group
+- obligation
+- authorization
+- activity
+- charter
+- federation
+- institution
+- position
+- settlement
+- unit
+
+Terms such as `account`, `balance`, `payment`, and `transaction` are not categorically forbidden, but they should not become the primary framing unless they are literally accurate for the specific surface being represented.
+
+The visual system must not accidentally teach the user that ICN is "basically a bank app," "basically a crypto wallet," or "basically project management."
+
+---
+
+## 9. Temporary logo and wordmark guidance
+
+ICN does not yet have its final logo system locked.
+
+Until that exists:
+
+- use simple, restrained wordmark treatment
+- prefer typographic clarity over ornamental symbolism
+- avoid faux-foundation seals, fintech crests, or blockchain emblems
+- avoid overclaiming institutional maturity through invented pseudo-heraldry
+- do not anchor the entire visual identity on a provisional mark
+
+Temporary marks should behave like placeholders for consistency, not like final brand mythology.
+
+---
+
+## 10. Surface-specific interpretation
+
+This document defines stable doctrine, not frozen product layout.
+
+Each surface should interpret the doctrine according to its job:
+
+- **Website:** legitimacy, explanation, orientation
+- **Docs:** architecture, concepts, system legibility
+- **Product surfaces:** action, verification, participation
+- **Demo materials:** narrative clarity without overstating implementation
+- **Onboarding:** confidence, comprehension, low-friction entry
+
+Current product concepts, navigation models, and image prompts belong in separate, faster-changing files.
+
+---
+
+## 11. Review criteria
+
+Every significant visual asset should be reviewed against these questions:
+
+1. Does this make ICN more legible?
+2. Does it reinforce member-centered participation?
+3. Does it help explain authorization, proof, or provenance?
+4. Does it avoid defaulting to fintech, crypto, or SaaS metaphors?
+5. Does it remain truthful about implementation reality?
+6. Does it support accessibility rather than decorate around it?
+7. Does it depict federated institutions rather than generic "users on a platform"?
+8. Does it feel humane, serious, and socially real?
+
+If the answer to several of these is no, the asset should be revised or discarded.
+
+---
+
+## 12. Bottom line
+
+ICN's visual system is part of the political and technical work.
+
+If the visuals fail, people do not understand the system.
+If people do not understand the system, they do not trust it.
+If they do not trust it, they do not use it.
+And if they do not use it, the institutional machinery does not matter.
+
+The visual system therefore has one job:
+
+**Make democratic infrastructure visible, comprehensible, truthful, and usable.**

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -17,6 +17,10 @@ Every claim has been verified against the codebase. If a document says "Not Supp
 
 ## Subsystem Design
 
+### Visual System
+- [ICN Visual System](ICN_VISUAL_SYSTEM.md) - Stable visual doctrine for website, docs, product surfaces, and demos
+- [ICN Prompt Library](ICN_PROMPT_LIBRARY.md) - Tactical prompt library for doctrine-aligned image generation
+
 ### Economics
 - [Economic Architecture](economics/ECONOMIC_ARCHITECTURE.md) - Core economic system design
 - [Economic Vision](economics/ECONOMIC_VISION.md) - Long-term economic vision

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -1146,6 +1146,38 @@ last_updated = "2026-03-10"
 owner = "matt"
 audiences = ["architects", "developers"]
 
+[docs."docs/design/ICN_VISUAL_SYSTEM.md"]
+category = "design"
+status = "draft"
+title = "ICN Visual System"
+description = "Stable visual doctrine for ICN across website, docs, product surfaces, onboarding, demo materials, and future institutional deployments"
+last_updated = "2026-04-22"
+owner = "matt"
+audiences = ["architects", "developers", "stakeholders"]
+truth_class = "draft"
+role = "design"
+canonical = "no"
+freshness = "current"
+domain_tags = ["design", "visual-system"]
+recommended_action = "keep"
+last_reviewed = "2026-04-22"
+
+[docs."docs/design/ICN_PROMPT_LIBRARY.md"]
+category = "design"
+status = "draft"
+title = "ICN Prompt Library"
+description = "Tactical prompt library for doctrine-aligned image generation and visual exploration"
+last_updated = "2026-04-22"
+owner = "matt"
+audiences = ["architects", "developers", "designers"]
+truth_class = "draft"
+role = "design"
+canonical = "no"
+freshness = "current"
+domain_tags = ["design", "prompt-library"]
+recommended_action = "keep"
+last_reviewed = "2026-04-22"
+
 # ============================================================================
 # STRATEGY DOCUMENTS
 # ============================================================================


### PR DESCRIPTION
## Summary
- add a stable ICN visual system draft under `docs/design/`
- add a tactical prompt library that depends on the visual-system doctrine
- register both docs in `docs/registry.toml` and link them from the design index

## Verification
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml`

## Notes
- keeps doctrine separate from current product/layout assumptions
- keeps truthfulness and accessibility as explicit design requirements
