### PR TITLE
feat(governance): add generic institution bootstrap package path

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The repo is split across several surfaces:
 - [`icn/`](icn/) — Rust workspace: crates in `icn/crates/`, runtime apps in `icn/apps/`, binaries in `icn/bins/`
 - [`website/`](website/) — public site for `intercooperative.network`
 - [`docs/`](docs/) — architecture, reference, contributor, and operator documentation
+- [`institutions/`](institutions/) — in-monorepo institution packages such as `institutions/nycn/`, kept boundary-clean for later extraction
 - [`sdk/`](sdk/) — TypeScript and React Native SDK work
 - [`deploy/`](deploy/) — deployment manifests and cluster configuration
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -399,6 +399,8 @@ Strategic direction and gap analysis (March 2026):
 - [NYCN-Repo-Architecture-Spec.md](strategy/NYCN-Repo-Architecture-Spec.md) - Repo-shaped architectural map grounded in current code: bounded domains, canonical objects, authority model, Program/cycle design (2026-04-14)
 - [NYCN-Implementation-Matrix.md](strategy/NYCN-Implementation-Matrix.md) - Execution ledger: per-object status (main/open_pr/branch_only/spec_only), touch points, bootstrap seed, ny-coop-net import crosswalk, phase-gated open questions (2026-04-14)
 - [NYCN-Execution-Tranches.md](strategy/NYCN-Execution-Tranches.md) - Merge-order + dependency plan across 7 tranches, rollback strategy, agent assignments (2026-04-14)
+- [../institutions/nycn/README.md](../institutions/nycn/README.md) - NYCN institution package boundary, ownership rules, and package scaffold (2026-04-22)
+- [../institutions/nycn/docs/INDEX.md](../institutions/nycn/docs/INDEX.md) - NYCN package-local docs, bootstrap runbook, summit materials, and seed entrypoints (2026-04-22)
 
 ### Current Status Reports (`status/`)
 
@@ -419,6 +421,10 @@ Formal architectural decisions:
 ### Templates (`templates/`)
 
 Documentation and code templates for consistency.
+
+### Reference Additions
+
+- [reference/institution-package-bootstrap.md](reference/institution-package-bootstrap.md) - Generic institution-package bootstrap manifest, ordering, and current executor reality
 
 ### Vision Documents (`vision/`)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,8 @@ This directory contains comprehensive documentation for the ICN project.
 
 **→ Start here: [Documentation Index (INDEX.md)](INDEX.md)** - Complete navigation to all documentation.
 
+Institution-package note: platform-level docs stay under `docs/`, while NYCN package-local artifacts now live under [`../institutions/nycn/`](../institutions/nycn/README.md).
+
 ## Quick Links
 
 - **[Getting Started](GETTING_STARTED.md)** - Quick start for new developers

--- a/docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md
+++ b/docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md
@@ -44,6 +44,8 @@ If you find yourself about to add a noun from a specific institution's workflow 
 
 The boundary between the top two layers is what this document defines.
 
+For the current in-monorepo NYCN package home, see `institutions/nycn/`. That directory should be treated as if it were already an external institution repo.
+
 ---
 
 ## B. ICN vs Institution Package

--- a/docs/design/dual-foundation-minimal-seams.md
+++ b/docs/design/dual-foundation-minimal-seams.md
@@ -1,0 +1,37 @@
+# Dual-Foundation Minimal-Seams Slice
+
+Status: implemented as a narrow boundary hardening slice.
+
+## What This Slice Changes
+
+This tranche closes two structural gaps without broad refactoring:
+
+1. Economics seam:
+   - `icn-compute` no longer has to own credit-requirement meaning directly.
+   - A deterministic policy contract callback can provide required credits.
+   - Compute keeps mechanical enforcement at submit/admission and reservation seams.
+   - Fallback to local formula remains for compatibility when no policy callback is wired.
+
+2. Governance seam:
+   - Proposal payloads are now explicitly classified as:
+     - `Declarative`
+     - `ExecutionRequired`
+   - `ExecutionRequired` proposals cannot finalize as accepted without a traceable closure backend.
+   - In manager/actor close paths, accepted execution-required proposals fail when closure artifacts cannot be persisted.
+
+## Boundary Definitions
+
+- Policy meaning vs compute enforcement:
+  - Policy/app layer decides required credits (deterministic output).
+  - Compute actor enforces mechanically (`balance >= required`, reserve/reject).
+
+- Governance acceptance vs execution closure:
+  - Acceptance is not sufficient for operational payloads.
+  - Execution-required decisions must be closable into durable provenance artifacts (receipt-store backed governance receipt and mandate path, plus allocation artifacts for economic payloads).
+
+## Intentionally Left Out
+
+- No full reservation/settlement redesign.
+- No broad CCL/PolicyOracle migration across all compute pricing semantics.
+- No new parallel governance receipt systems.
+- No payload-by-payload executor redesign; this slice only hardens closure invariants at acceptance seams.

--- a/docs/reference/institution-package-bootstrap.md
+++ b/docs/reference/institution-package-bootstrap.md
@@ -1,0 +1,120 @@
+# Institution Package Bootstrap Contract
+
+Status: draft reference
+
+This document defines the generic bootstrap contract for institution packages inside the ICN monorepo. It is intentionally generic: it describes how package-owned manifests are loaded and planned without introducing institution-specific semantics into ICN core.
+
+## Entry Point
+
+Each package exposes a top-level `bootstrap.yaml` manifest.
+
+Required fields:
+
+```yaml
+manifest_version: v0
+package_id: nycn
+package_kind: institution
+charter:
+  path: charter/nycn-federation.charter.yaml
+seeds:
+  - order: 0
+    kind: entity-seed
+    path: seed/00-nycn-federation.seed.yaml
+```
+
+## Loading Semantics
+
+1. Load `bootstrap.yaml`.
+2. Resolve the package-owned charter path relative to the package root.
+3. Parse and validate the charter as a CCL document.
+4. Load seed manifests in strictly increasing `order`.
+5. Verify each seed file's internal `kind` matches the `bootstrap.yaml` entry.
+6. Build a generic bootstrap operation plan from the loaded seeds.
+
+## Supported Seed Kinds
+
+- `entity-seed`
+- `governance-domain-seed`
+- `structure-seed`
+- `activity-program-seed`
+- `milestone-template-seed`
+- `role-assignment-seed`
+
+## Ordering Contract
+
+The current stable bootstrap order is:
+
+1. federation/entity seed
+2. organizer cooperative seed
+3. governance-domain seed
+4. structures/committees seed
+5. activity/program seed
+6. milestone seed
+7. role-assignment seed
+
+This order exists to preserve generic dependencies:
+- structures need parent entities
+- governance domains must be declared before program writes can target them
+- activities/programs need parent entities and linked structures
+- milestones need target programs
+- role assignments need target structures and, for live application, real DIDs
+
+## Current Executor Reality
+
+Today the platform provides:
+- generic manifest and seed types in `icn-governance::bootstrap`
+- package loading, charter validation, ordering checks, and plan emission through `icnctl institution bootstrap validate|plan`
+- a first generic live executor through `icnctl institution bootstrap apply`
+
+## Live Apply Semantics
+
+`icnctl institution bootstrap apply` is intentionally honest about platform gaps.
+
+It currently does:
+- validate the package-owned charter locally before any live writes
+- create entities through the generic entity gateway API
+- provision governance domains through the generic governance API when domain seeds provide usable member DIDs
+- create structures through the generic governance gateway API when the seed does not require fields the current write API cannot persist
+- create programs through the generic governance gateway API only when the target governance domain already exists and the authenticated caller is allowed to write there
+- create activities through the generic governance gateway API including `linked_structures` when referenced structures are live-resolvable
+- create milestones through the generic governance gateway API only when the target program already exists as a live program ID
+- apply role assignments when a real `person_did` exists and the target structure exists as a live structure ID
+- defer role assignments that still have no `person_did`
+
+It does not yet do:
+- register or activate package-owned CCL charters through a generic live charter sink
+- persist structure `scope` fields through the current generic structure create API
+- preserve package-local aliases as runtime IDs for structures, activities, programs, or milestones
+
+`governance-domain-seed` records use the same generic shape as `POST /v1/gov/domains`:
+- `id`
+- `name`
+- `profile`
+- `quorum_percent`
+- `approval_percent`
+- `voting_period_days`
+- `members`
+- optional `decision_mode`
+- optional `max_objections`
+
+For bootstrap convenience, members may include the explicit placeholder
+`$bootstrap_subject_did`, which resolves to the DID used for gateway bootstrap authentication at apply time.
+
+The apply report therefore separates:
+- `completed`: real writes that succeeded
+- `deferred`: intentionally skipped writes such as role assignments without DIDs
+- `unsupported`: plan steps whose current generic runtime surfaces cannot faithfully persist the package manifest shape
+- `failed`: a concrete live write failed and apply stopped
+
+## NYCN Reality
+
+With the current NYCN package and current platform surfaces:
+- entities can be created live
+- governance domains can be provisioned live from package seeds
+- committee structures can be created live
+- the summit program is no longer blocked on out-of-band domain provisioning
+- the summit activity is no longer blocked by `linked_structures` contract mismatch
+- milestones can proceed when summit program and activity writes succeed
+- charter registration/activation remains validation-only
+
+That means NYCN is now **partially live-applicable**, but not yet **fully bootstrappable end-to-end**.

--- a/docs/strategy/NYCN-Implementation-Matrix.md
+++ b/docs/strategy/NYCN-Implementation-Matrix.md
@@ -10,7 +10,7 @@
 >
 > This document predates `docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md`. On any routing conflict between this matrix and the boundary doc, **the boundary doc wins.**
 >
-> Several rows below route institution-specific nouns (sponsor, budget-item, session, registration, venue accessibility, source-ref, institutional-document, speaker/attendee/sponsor-contact participation variants, institution-specific `ProgramKind` / `MilestoneType` names like `AnnualSummit` / `VenueLocked` / `BudgetLocked` / `PublicLaunchReady`) into `icn-governance::*`. That is drift. ICN core — `icn-governance` and `apps/governance` — must stay institution-agnostic.
+> Several rows below route institution-specific nouns (sponsor, budget-item, session, registration, venue accessibility, source-ref, institutional-document, speaker/attendee/sponsor-contact participation variants, institution-specific `ProgramKind` / `MilestoneType` names like `AnnualSummit` / `VenueLocked` / `BudgetLocked` / `PublicLaunchReady`) into `icn-governance::*`. That is drift. ICN core — `icn-governance` and `apps/governance` — must stay institution-agnostic. In this monorepo, those institution-owned artifacts now belong under `institutions/nycn/` until they are split into their own repo.
 >
 > **Corrected routing (authoritative):**
 >

--- a/docs/strategy/NYCN-Repo-Architecture-Spec.md
+++ b/docs/strategy/NYCN-Repo-Architecture-Spec.md
@@ -13,7 +13,7 @@
 >
 > On any disagreement between this spec and `docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md`, **the boundary doc wins.**
 >
-> This document, written before the boundary was pinned down, routes several institution-specific nouns into `icn-governance::*`. That is drift. ICN core — `icn-governance` crate and `apps/governance` — must remain institution-agnostic. Anything shaped specifically by NYCN or the NY Cooperative Summit (sponsor packets, session catalogs, conference registrations, venue-accessibility scoring, summit-year milestone names) belongs in the **institution package** (future `icn/apps/nycn/` or external `nycn-icn` repo), not in governance core. Per the App topology rule (`AGENTS.md`), runtime-integrated apps live under `icn/apps/`; no new top-level `apps/*` crates.
+> This document, written before the boundary was pinned down, routes several institution-specific nouns into `icn-governance::*`. That is drift. ICN core — `icn-governance` crate and `apps/governance` — must remain institution-agnostic. Anything shaped specifically by NYCN or the NY Cooperative Summit (sponsor packets, session catalogs, conference registrations, venue-accessibility scoring, summit-year milestone names) belongs in the **institution package** (currently `institutions/nycn/`, later split to an external `nycn-icn` repo), not in governance core. Per the App topology rule (`AGENTS.md`), runtime-integrated apps live under `icn/apps/`; no new top-level `apps/*` crates.
 >
 > **Corrected routing (authoritative):**
 >

--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -3871,6 +3871,7 @@ dependencies = [
  "rust-i18n",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "sys-locale",
  "tar",

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -1903,6 +1903,15 @@ impl GovernanceActor {
                     DecisionOutcome::NoQuorum => ProposalState::NoQuorum { closed_at: now },
                 };
 
+                let requires_execution_closure = matches!(outcome_result, DecisionOutcome::Accepted)
+                    && proposal.payload.requires_execution_closure();
+                if requires_execution_closure && self.receipt_store.is_none() {
+                    anyhow::bail!(
+                        "Proposal '{}' requires execution closure but no receipt_store is installed on actor.",
+                        proposal_id.0
+                    );
+                }
+
                 // Update proposal
                 proposal.close(new_state)?;
 
@@ -2176,6 +2185,12 @@ impl GovernanceActor {
                                     proposal_id = %proposal_id.0,
                                     "Actor failed to hash payload for mandate — declining to mint"
                                 );
+                                if requires_execution_closure {
+                                    anyhow::bail!(
+                                        "Proposal '{}' requires execution closure but actor mandate mint hash failed.",
+                                        proposal_id.0
+                                    );
+                                }
                             }
                             Err(e) => {
                                 error!(
@@ -2183,6 +2198,12 @@ impl GovernanceActor {
                                     error = %e,
                                     "Actor failed to persist ADR-0014 mandate (non-fatal)"
                                 );
+                                if requires_execution_closure {
+                                    anyhow::bail!(
+                                        "Proposal '{}' requires execution closure but actor mandate persistence failed: {e}",
+                                        proposal_id.0
+                                    );
+                                }
                             }
                         }
                     }
@@ -2260,6 +2281,15 @@ impl GovernanceActor {
                     ForcedOutcome::Cancel => ProposalOutcome::NoQuorum, // Treat Cancel as NoQuorum
                 };
 
+                let requires_execution_closure = matches!(&forced_outcome, ForcedOutcome::Accept)
+                    && proposal.payload.requires_execution_closure();
+                if requires_execution_closure && self.receipt_store.is_none() {
+                    anyhow::bail!(
+                        "Proposal '{}' requires execution closure but no receipt_store is installed on actor.",
+                        proposal_id.0
+                    );
+                }
+
                 // Force close the proposal
                 proposal.force_close(proposal_outcome.clone(), reason.clone())?;
 
@@ -2269,7 +2299,7 @@ impl GovernanceActor {
                 // Emit appropriate event
                 if let Some(ref event_bus) = self.event_bus {
                     let now = now_seconds();
-                    let event = match forced_outcome {
+                    let event = match &forced_outcome {
                         ForcedOutcome::Accept => match serde_json::to_value(&proposal.payload) {
                             Ok(payload) => {
                                 let canonical_payload_hash = serde_json::to_string(&payload)
@@ -2342,10 +2372,10 @@ impl GovernanceActor {
                 // normal accept did. Uses the same translation helper so
                 // audit semantics are path-agnostic. Idempotent on
                 // (proposal_id, effect_kind).
-                if matches!(forced_outcome, ForcedOutcome::Accept) {
+                if matches!(&forced_outcome, ForcedOutcome::Accept) {
                     if let Some(ref store) = self.receipt_store {
                         let now = now_seconds();
-                        let decision_hash_bytes: Option<icn_kernel_api::receipts::Hash> = {
+                        let forced_decision_hash: icn_kernel_api::receipts::Hash = {
                             use icn_governance::proof::ProofOutcome;
                             let receipt = GovernanceDecisionReceipt::new(
                                 proposal_id.0.clone(),
@@ -2354,8 +2384,10 @@ impl GovernanceActor {
                                 VoteTally::empty(),
                                 &[],
                             );
-                            Some(receipt.decision_hash)
+                            receipt.decision_hash
                         };
+                        let decision_hash_bytes: Option<icn_kernel_api::receipts::Hash> =
+                            Some(forced_decision_hash);
                         match crate::institutional_effect::emit_accepted_effect(
                             store.as_ref(),
                             &proposal_id.0,
@@ -2381,6 +2413,42 @@ impl GovernanceActor {
                                     error = %e,
                                     "Force-accept failed to emit InstitutionalEffectRecord (non-fatal)"
                                 );
+                                if requires_execution_closure {
+                                    anyhow::bail!(
+                                        "Proposal '{}' requires execution closure but force-accept effect emission failed: {e}",
+                                        proposal_id.0
+                                    );
+                                }
+                            }
+                        }
+
+                        match crate::grant_minting::mint_and_persist_for_accepted(
+                            store.as_ref(),
+                            &proposal_id.0,
+                            &proposal.domain_id,
+                            forced_decision_hash,
+                            &proposal.payload,
+                            now,
+                        ) {
+                            Ok(crate::grant_minting::MandateMintOutcome::Minted { .. })
+                            | Ok(crate::grant_minting::MandateMintOutcome::AlreadyMinted {
+                                ..
+                            }) => {}
+                            Ok(crate::grant_minting::MandateMintOutcome::HashFailed) => {
+                                if requires_execution_closure {
+                                    anyhow::bail!(
+                                        "Proposal '{}' requires execution closure but force-accept mandate hash failed.",
+                                        proposal_id.0
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                if requires_execution_closure {
+                                    anyhow::bail!(
+                                        "Proposal '{}' requires execution closure but force-accept mandate persistence failed: {e}",
+                                        proposal_id.0
+                                    );
+                                }
                             }
                         }
                     }

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -1903,13 +1903,69 @@ impl GovernanceActor {
                     DecisionOutcome::NoQuorum => ProposalState::NoQuorum { closed_at: now },
                 };
 
-                let requires_execution_closure = matches!(outcome_result, DecisionOutcome::Accepted)
-                    && proposal.payload.requires_execution_closure();
+                let requires_execution_closure =
+                    matches!(outcome_result, DecisionOutcome::Accepted)
+                        && proposal.payload.requires_execution_closure();
                 if requires_execution_closure && self.receipt_store.is_none() {
                     anyhow::bail!(
                         "Proposal '{}' requires execution closure but no receipt_store is installed on actor.",
                         proposal_id.0
                     );
+                }
+
+                // For execution-required accepted outcomes, prove closure artifacts
+                // are persistable before committing terminal proposal state.
+                if requires_execution_closure {
+                    if let Some(ref store) = self.receipt_store {
+                        use icn_governance::proof::ProofOutcome;
+                        let preflight_receipt = GovernanceDecisionReceipt::new(
+                            proposal_id.0.clone(),
+                            proposal.domain_id.0.clone(),
+                            ProofOutcome::Accepted,
+                            tally.clone(),
+                            &votes,
+                        );
+                        crate::institutional_effect::emit_accepted_effect(
+                            store.as_ref(),
+                            &proposal_id.0,
+                            &proposal.domain_id.0,
+                            Some(preflight_receipt.decision_hash),
+                            &proposal.payload,
+                            now,
+                        )
+                        .map_err(|e| {
+                            anyhow::anyhow!(
+                                "Proposal '{}' requires execution closure but actor effect emission preflight failed: {e}",
+                                proposal_id.0
+                            )
+                        })?;
+
+                        match crate::grant_minting::mint_and_persist_for_accepted(
+                            store.as_ref(),
+                            &proposal_id.0,
+                            &proposal.domain_id,
+                            preflight_receipt.decision_hash,
+                            &proposal.payload,
+                            now,
+                        ) {
+                            Ok(crate::grant_minting::MandateMintOutcome::Minted { .. })
+                            | Ok(crate::grant_minting::MandateMintOutcome::AlreadyMinted {
+                                ..
+                            }) => {}
+                            Ok(crate::grant_minting::MandateMintOutcome::HashFailed) => {
+                                anyhow::bail!(
+                                    "Proposal '{}' requires execution closure but actor mandate preflight hash failed.",
+                                    proposal_id.0
+                                );
+                            }
+                            Err(e) => {
+                                anyhow::bail!(
+                                    "Proposal '{}' requires execution closure but actor mandate preflight persistence failed: {e}",
+                                    proposal_id.0
+                                );
+                            }
+                        }
+                    }
                 }
 
                 // Update proposal
@@ -2185,12 +2241,6 @@ impl GovernanceActor {
                                     proposal_id = %proposal_id.0,
                                     "Actor failed to hash payload for mandate — declining to mint"
                                 );
-                                if requires_execution_closure {
-                                    anyhow::bail!(
-                                        "Proposal '{}' requires execution closure but actor mandate mint hash failed.",
-                                        proposal_id.0
-                                    );
-                                }
                             }
                             Err(e) => {
                                 error!(
@@ -2198,12 +2248,6 @@ impl GovernanceActor {
                                     error = %e,
                                     "Actor failed to persist ADR-0014 mandate (non-fatal)"
                                 );
-                                if requires_execution_closure {
-                                    anyhow::bail!(
-                                        "Proposal '{}' requires execution closure but actor mandate persistence failed: {e}",
-                                        proposal_id.0
-                                    );
-                                }
                             }
                         }
                     }
@@ -2288,6 +2332,61 @@ impl GovernanceActor {
                         "Proposal '{}' requires execution closure but no receipt_store is installed on actor.",
                         proposal_id.0
                     );
+                }
+
+                // For execution-required forced accepts, prove closure artifacts are
+                // persistable before committing terminal proposal state.
+                if requires_execution_closure {
+                    if let Some(ref store) = self.receipt_store {
+                        use icn_governance::proof::ProofOutcome;
+                        let forced_receipt = GovernanceDecisionReceipt::new(
+                            proposal_id.0.clone(),
+                            proposal.domain_id.0.clone(),
+                            ProofOutcome::Accepted,
+                            VoteTally::empty(),
+                            &[],
+                        );
+                        crate::institutional_effect::emit_accepted_effect(
+                            store.as_ref(),
+                            &proposal_id.0,
+                            &proposal.domain_id.0,
+                            Some(forced_receipt.decision_hash),
+                            &proposal.payload,
+                            now_seconds(),
+                        )
+                        .map_err(|e| {
+                            anyhow::anyhow!(
+                                "Proposal '{}' requires execution closure but force-accept effect preflight failed: {e}",
+                                proposal_id.0
+                            )
+                        })?;
+
+                        match crate::grant_minting::mint_and_persist_for_accepted(
+                            store.as_ref(),
+                            &proposal_id.0,
+                            &proposal.domain_id,
+                            forced_receipt.decision_hash,
+                            &proposal.payload,
+                            now_seconds(),
+                        ) {
+                            Ok(crate::grant_minting::MandateMintOutcome::Minted { .. })
+                            | Ok(crate::grant_minting::MandateMintOutcome::AlreadyMinted {
+                                ..
+                            }) => {}
+                            Ok(crate::grant_minting::MandateMintOutcome::HashFailed) => {
+                                anyhow::bail!(
+                                    "Proposal '{}' requires execution closure but force-accept mandate preflight hash failed.",
+                                    proposal_id.0
+                                );
+                            }
+                            Err(e) => {
+                                anyhow::bail!(
+                                    "Proposal '{}' requires execution closure but force-accept mandate preflight persistence failed: {e}",
+                                    proposal_id.0
+                                );
+                            }
+                        }
+                    }
                 }
 
                 // Force close the proposal
@@ -2413,12 +2512,6 @@ impl GovernanceActor {
                                     error = %e,
                                     "Force-accept failed to emit InstitutionalEffectRecord (non-fatal)"
                                 );
-                                if requires_execution_closure {
-                                    anyhow::bail!(
-                                        "Proposal '{}' requires execution closure but force-accept effect emission failed: {e}",
-                                        proposal_id.0
-                                    );
-                                }
                             }
                         }
 
@@ -2435,20 +2528,17 @@ impl GovernanceActor {
                                 ..
                             }) => {}
                             Ok(crate::grant_minting::MandateMintOutcome::HashFailed) => {
-                                if requires_execution_closure {
-                                    anyhow::bail!(
-                                        "Proposal '{}' requires execution closure but force-accept mandate hash failed.",
-                                        proposal_id.0
-                                    );
-                                }
+                                tracing::error!(
+                                    proposal_id = %proposal_id.0,
+                                    "Force-accept failed to hash payload for mandate — declining to mint"
+                                );
                             }
                             Err(e) => {
-                                if requires_execution_closure {
-                                    anyhow::bail!(
-                                        "Proposal '{}' requires execution closure but force-accept mandate persistence failed: {e}",
-                                        proposal_id.0
-                                    );
-                                }
+                                tracing::error!(
+                                    proposal_id = %proposal_id.0,
+                                    error = %e,
+                                    "Force-accept failed to persist ADR-0014 mandate (non-fatal)"
+                                );
                             }
                         }
                     }

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -4980,6 +4980,54 @@ mod tests {
         (mgr, proposal_id)
     }
 
+    /// Same as `setup_freeze_proposal`, but with a receipt store wired so
+    /// accepted execution-required payloads can persist closure artifacts.
+    async fn setup_freeze_proposal_with_store(
+        coop_id: &str,
+        member_did: Did,
+        target_did: Did,
+        params: GovernanceParams,
+    ) -> (Arc<GovernanceManager>, ProposalId) {
+        let mgr = Arc::new(
+            GovernanceManager::new().with_receipt_store(Arc::new(HandlerTestReceiptBackend::new())),
+        );
+        let domain_id = GovernanceDomainId(coop_id.to_string());
+
+        mgr.create_domain(
+            domain_id.clone(),
+            format!("{coop_id} coop"),
+            "cooperative_default".to_string(),
+            params,
+            MembershipConfig {
+                source: MembershipSource::StaticList(vec![member_did.clone()]),
+            },
+        )
+        .await
+        .unwrap();
+
+        let proposal_id = ProposalId("freeze-proposal-1".to_string());
+        mgr.create_proposal(
+            proposal_id.clone(),
+            domain_id.clone(),
+            member_did,
+            "Freeze disruptive member".to_string(),
+            "Emergency action — account compromise suspected".to_string(),
+            ProposalPayload::FreezeMember {
+                member: target_did,
+                reason: "account compromise suspected".to_string(),
+                duration_seconds: Some(604_800),
+            },
+            ProposalScope::Local,
+        )
+        .await
+        .unwrap();
+
+        mgr.open_proposal(proposal_id.clone(), 86_400)
+            .await
+            .unwrap();
+        (mgr, proposal_id)
+    }
+
     /// Proves: when `close_proposal` finalises a `FreezeMember` proposal as
     /// `Accepted`, the `on_proposal_accepted` hook fires and delivers the
     /// correct member DID, reason, and duration.
@@ -4999,7 +5047,7 @@ mod tests {
         let target_did = test_did(2);
 
         // GovernanceParams(quorum=0, approval=0) → any close is Accepted
-        let (mgr, proposal_id) = setup_freeze_proposal(
+        let (mgr, proposal_id) = setup_freeze_proposal_with_store(
             "alpha",
             member_did.clone(),
             target_did.clone(),
@@ -5626,7 +5674,9 @@ mod tests {
         let alice_did = alice_kp.did().clone();
         let bob_did = bob_kp.did().clone();
 
-        let mgr = Arc::new(GovernanceManager::new());
+        let mgr = Arc::new(
+            GovernanceManager::new().with_receipt_store(Arc::new(HandlerTestReceiptBackend::new())),
+        );
         let domain_id = GovernanceDomainId("tt-resolver-test".to_string());
 
         // TrustThreshold domain: members cannot be enumerated without a resolver

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -3314,15 +3314,21 @@ pub async fn create_activity<E: GovernanceEventEmitter + Clone + 'static>(
         .parent_program_id
         .as_deref()
         .map(|s| icn_governance::program::ProgramId(s.to_string()));
+    let linked_structures = req
+        .linked_structures
+        .iter()
+        .map(|id| StructureId(id.clone()))
+        .collect();
     let a = ctx
         .manager
-        .create_activity(
+        .create_activity_with_links(
             entity,
             kind,
             req.name.clone(),
             req.description.clone(),
             req.start_date,
             req.end_date,
+            linked_structures,
             parent_program_id,
         )
         .map_err(anyhow_to_api)?;

--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -627,6 +627,9 @@ pub struct CreateActivityRequest {
     pub start_date: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub end_date: Option<u64>,
+    /// Structures linked to this activity by structure ID.
+    #[serde(default)]
+    pub linked_structures: Vec<String>,
     /// Optional parent program ID (e.g., "annual-summit-cycle")
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_program_id: Option<String>,

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -185,7 +185,10 @@ fn payload_requires_allocation_receipt(payload: &ProposalPayload) -> bool {
     matches!(
         payload,
         ProposalPayload::Budget { .. }
-            | ProposalPayload::Treasury { .. }
+            | ProposalPayload::Treasury {
+                operation: icn_governance::TreasuryProposalOperation::CreateBudget { .. }
+                    | icn_governance::TreasuryProposalOperation::Spend { .. },
+            }
             | ProposalPayload::Allocation { .. }
             | ProposalPayload::SurplusAllocation { .. }
     )
@@ -3460,8 +3463,8 @@ impl GovernanceManager {
                 _ => unreachable!("final_state is always Accepted/Rejected/NoQuorum"),
             };
 
-            let requires_execution_closure =
-                matches!(outcome, ProofOutcome::Accepted) && proposal.payload.requires_execution_closure();
+            let requires_execution_closure = matches!(outcome, ProofOutcome::Accepted)
+                && proposal.payload.requires_execution_closure();
             if requires_execution_closure && self.receipt_store.is_none() {
                 anyhow::bail!(
                     "Proposal '{}' requires execution closure but no receipt store is wired. \
@@ -3469,8 +3472,6 @@ impl GovernanceManager {
                     proposal_id.0
                 );
             }
-
-            proposal.close(final_state)?;
 
             if let Some(ref store) = self.receipt_store {
                 let receipt = GovernanceDecisionReceipt::new(
@@ -3548,12 +3549,6 @@ impl GovernanceManager {
                                 "Failed to hash proposal payload for mandate payload_hash — \
                                  declining to mint mandate to avoid breaking content-binding invariant"
                             );
-                            if requires_execution_closure {
-                                anyhow::bail!(
-                                    "Proposal '{}' requires execution closure but mandate minting failed (hash).",
-                                    proposal_id.0
-                                );
-                            }
                         }
                         Err(e) => {
                             tracing::error!(
@@ -3561,12 +3556,6 @@ impl GovernanceManager {
                                 error = %e,
                                 "Failed to persist ADR-0014 mandate — constitutional-memory record lost"
                             );
-                            if requires_execution_closure {
-                                anyhow::bail!(
-                                    "Proposal '{}' requires execution closure but mandate persistence failed: {e}",
-                                    proposal_id.0
-                                );
-                            }
                         }
                     }
                 }
@@ -3588,12 +3577,6 @@ impl GovernanceManager {
                                 error = %e,
                                 "Failed to store allocation receipt — economics binding broken"
                             );
-                            if requires_execution_closure {
-                                anyhow::bail!(
-                                    "Proposal '{}' requires execution closure but allocation receipt persistence failed: {e}",
-                                    proposal_id.0
-                                );
-                            }
                         } else {
                             tracing::info!(
                                 proposal_id = %proposal_id.0,
@@ -3609,6 +3592,8 @@ impl GovernanceManager {
                     }
                 }
             }
+
+            proposal.close(final_state)?;
 
             // Decision→action bridge (standalone path).
             //
@@ -3745,7 +3730,8 @@ impl GovernanceManager {
                     // Look up the proposal to determine if it requires allocations.
                     match self.get_proposal(proposal_id).await.ok().flatten() {
                         Some(p) => {
-                            let is_economic_payload = payload_requires_allocation_receipt(&p.payload);
+                            let is_economic_payload =
+                                payload_requires_allocation_receipt(&p.payload);
                             if is_economic_payload {
                                 has_allocations
                             } else {

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -181,6 +181,16 @@ fn payload_effect_kind(payload: &ProposalPayload) -> &'static str {
     }
 }
 
+fn payload_requires_allocation_receipt(payload: &ProposalPayload) -> bool {
+    matches!(
+        payload,
+        ProposalPayload::Budget { .. }
+            | ProposalPayload::Treasury { .. }
+            | ProposalPayload::Allocation { .. }
+            | ProposalPayload::SurplusAllocation { .. }
+    )
+}
+
 /// Unix-seconds timestamp the proposal reached a terminal lifecycle state,
 /// or `None` if still in-flight. Used by the deliberation endpoint to tag
 /// when a decision was recorded without depending on receipt fields.
@@ -3450,6 +3460,16 @@ impl GovernanceManager {
                 _ => unreachable!("final_state is always Accepted/Rejected/NoQuorum"),
             };
 
+            let requires_execution_closure =
+                matches!(outcome, ProofOutcome::Accepted) && proposal.payload.requires_execution_closure();
+            if requires_execution_closure && self.receipt_store.is_none() {
+                anyhow::bail!(
+                    "Proposal '{}' requires execution closure but no receipt store is wired. \
+                     Refusing to finalize Accepted without a traceable closure artifact.",
+                    proposal_id.0
+                );
+            }
+
             proposal.close(final_state)?;
 
             if let Some(ref store) = self.receipt_store {
@@ -3468,6 +3488,12 @@ impl GovernanceManager {
                     );
                     // Escalated from warn to error: receipt store failure means
                     // the governance→economics provenance chain is broken (PS-3).
+                    if requires_execution_closure {
+                        anyhow::bail!(
+                            "Proposal '{}' requires execution closure but governance receipt persistence failed: {e}",
+                            proposal_id.0
+                        );
+                    }
                 }
 
                 // ADR-0014 constitutional-memory seam.
@@ -3522,6 +3548,12 @@ impl GovernanceManager {
                                 "Failed to hash proposal payload for mandate payload_hash — \
                                  declining to mint mandate to avoid breaking content-binding invariant"
                             );
+                            if requires_execution_closure {
+                                anyhow::bail!(
+                                    "Proposal '{}' requires execution closure but mandate minting failed (hash).",
+                                    proposal_id.0
+                                );
+                            }
                         }
                         Err(e) => {
                             tracing::error!(
@@ -3529,6 +3561,12 @@ impl GovernanceManager {
                                 error = %e,
                                 "Failed to persist ADR-0014 mandate — constitutional-memory record lost"
                             );
+                            if requires_execution_closure {
+                                anyhow::bail!(
+                                    "Proposal '{}' requires execution closure but mandate persistence failed: {e}",
+                                    proposal_id.0
+                                );
+                            }
                         }
                     }
                 }
@@ -3550,6 +3588,12 @@ impl GovernanceManager {
                                 error = %e,
                                 "Failed to store allocation receipt — economics binding broken"
                             );
+                            if requires_execution_closure {
+                                anyhow::bail!(
+                                    "Proposal '{}' requires execution closure but allocation receipt persistence failed: {e}",
+                                    proposal_id.0
+                                );
+                            }
                         } else {
                             tracing::info!(
                                 proposal_id = %proposal_id.0,
@@ -3557,6 +3601,11 @@ impl GovernanceManager {
                                 "Allocation receipt created: governance→economics chain bound"
                             );
                         }
+                    } else if payload_requires_allocation_receipt(&proposal.payload) {
+                        anyhow::bail!(
+                            "Proposal '{}' requires an allocation receipt closure artifact, but no receipt was generated.",
+                            proposal_id.0
+                        );
                     }
                 }
             }
@@ -3696,13 +3745,7 @@ impl GovernanceManager {
                     // Look up the proposal to determine if it requires allocations.
                     match self.get_proposal(proposal_id).await.ok().flatten() {
                         Some(p) => {
-                            let is_economic_payload = matches!(
-                                p.payload,
-                                ProposalPayload::Budget { .. }
-                                    | ProposalPayload::Treasury { .. }
-                                    | ProposalPayload::Allocation { .. }
-                                    | ProposalPayload::SurplusAllocation { .. }
-                            );
+                            let is_economic_payload = payload_requires_allocation_receipt(&p.payload);
                             if is_economic_payload {
                                 has_allocations
                             } else {
@@ -6175,6 +6218,78 @@ mod tests {
         .unwrap();
 
         (mgr, domain_id, member_did)
+    }
+
+    #[tokio::test]
+    async fn declarative_text_proposal_can_close_without_receipt_store() {
+        let (mgr, domain_id, member_did) = make_manager_with_domain().await;
+        let proposal_id = mgr
+            .create_proposal(
+                ProposalId(format!("prop-{}", uuid::Uuid::new_v4())),
+                domain_id.clone(),
+                member_did.clone(),
+                "Adopt statement".to_string(),
+                "Declarative text".to_string(),
+                ProposalPayload::Text {
+                    body: "We endorse this statement.".to_string(),
+                },
+                ProposalScope::Local,
+            )
+            .await
+            .unwrap();
+
+        mgr.open_proposal(proposal_id.clone(), 86400).await.unwrap();
+        mgr.cast_vote(
+            proposal_id.clone(),
+            member_did.clone(),
+            VoteChoice::For,
+            None,
+        )
+        .await
+        .unwrap();
+        mgr.close_proposal(proposal_id.clone()).await.unwrap();
+
+        let closed = mgr.get_proposal(&proposal_id).await.unwrap().unwrap();
+        assert!(
+            matches!(closed.state, ProposalState::Accepted { .. }),
+            "declarative payload should remain closable without execution linkage backend"
+        );
+    }
+
+    #[tokio::test]
+    async fn execution_required_payload_rejects_accept_without_receipt_store() {
+        let (mgr, domain_id, member_did) = make_manager_with_domain().await;
+        let target = test_did(77);
+        let proposal_id = mgr
+            .create_proposal(
+                ProposalId(format!("prop-{}", uuid::Uuid::new_v4())),
+                domain_id.clone(),
+                member_did.clone(),
+                "Freeze member".to_string(),
+                "Execution-required".to_string(),
+                ProposalPayload::FreezeMember {
+                    member: target,
+                    reason: "policy breach".to_string(),
+                    duration_seconds: Some(3600),
+                },
+                ProposalScope::Local,
+            )
+            .await
+            .unwrap();
+
+        mgr.open_proposal(proposal_id.clone(), 86400).await.unwrap();
+        mgr.cast_vote(proposal_id.clone(), member_did, VoteChoice::For, None)
+            .await
+            .unwrap();
+
+        let result = mgr.close_proposal(proposal_id.clone()).await;
+        assert!(
+            result
+                .as_ref()
+                .err()
+                .is_some_and(|e| e.to_string().contains("requires execution closure")),
+            "execution-required payload must not close Accepted without closure backend; got {result:?}"
+        );
     }
 
     /// INV-2 TEST: Accepted Budget proposal creates AllocationReceipt.

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -5059,10 +5059,47 @@ impl GovernanceManager {
         end_date: Option<u64>,
         parent_program_id: Option<icn_governance::program::ProgramId>,
     ) -> Result<Activity> {
+        self.create_activity_with_links(
+            parent_entity_id,
+            kind,
+            name,
+            description,
+            start_date,
+            end_date,
+            Vec::new(),
+            parent_program_id,
+        )
+    }
+
+    /// Create a new activity with explicit linked structures.
+    pub fn create_activity_with_links(
+        &self,
+        parent_entity_id: String,
+        kind: ActivityKind,
+        name: String,
+        description: Option<String>,
+        start_date: Option<u64>,
+        end_date: Option<u64>,
+        linked_structures: Vec<StructureId>,
+        parent_program_id: Option<icn_governance::program::ProgramId>,
+    ) -> Result<Activity> {
         // Validate date range when both are provided
         if let (Some(start), Some(end)) = (start_date, end_date) {
             if end < start {
                 return Err(anyhow::anyhow!("Activity end_date must be >= start_date"));
+            }
+        }
+        for structure_id in &linked_structures {
+            if self
+                .structure_store
+                .get_structure(structure_id)
+                .map_err(|e| anyhow::anyhow!("Failed to look up structure: {e}"))?
+                .is_none()
+            {
+                return Err(anyhow::anyhow!(
+                    "Linked structure not found: {}",
+                    structure_id
+                ));
             }
         }
         let now = icn_time::current_timestamp_secs();
@@ -5071,6 +5108,7 @@ impl GovernanceManager {
         a.description = description;
         a.start_date = start_date;
         a.end_date = end_date;
+        a.linked_structures = linked_structures;
         a.parent_program_id = parent_program_id.clone();
         self.activity_store
             .save(&a)
@@ -7761,6 +7799,55 @@ mod tests {
 
         // Activity was created and carries the reverse link.
         assert_eq!(act.parent_program_id.as_ref(), Some(&ghost_program_id));
+    }
+
+    #[tokio::test]
+    async fn create_activity_with_linked_structures_persists_links() {
+        let (mgr, _domain_id, _member) = make_manager_with_domain().await;
+        let structure = mgr
+            .create_structure(
+                "ent-1".to_string(),
+                StructureKind::Committee,
+                "Content".to_string(),
+                None,
+            )
+            .unwrap();
+
+        let act = mgr
+            .create_activity_with_links(
+                "ent-1".to_string(),
+                icn_governance::ActivityKind::Event,
+                "Linked Activity".to_string(),
+                None,
+                None,
+                None,
+                vec![structure.id.clone()],
+                None,
+            )
+            .unwrap();
+
+        assert_eq!(act.linked_structures, vec![structure.id]);
+    }
+
+    #[tokio::test]
+    async fn create_activity_with_missing_linked_structure_fails() {
+        let (mgr, _domain_id, _member) = make_manager_with_domain().await;
+        let missing_structure = StructureId::generate();
+        let err = mgr
+            .create_activity_with_links(
+                "ent-1".to_string(),
+                icn_governance::ActivityKind::Event,
+                "Broken Linked Activity".to_string(),
+                None,
+                None,
+                None,
+                vec![missing_structure.clone()],
+                None,
+            )
+            .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains(&format!("Linked structure not found: {missing_structure}")));
     }
 
     /// `link_activity_to_program` must write both directions: program gains the

--- a/icn/apps/governance/tests/actor_close_proposal_accept_parity.rs
+++ b/icn/apps/governance/tests/actor_close_proposal_accept_parity.rs
@@ -255,13 +255,10 @@ async fn actor_close_proposal_accept_emits_appoint_steward_effect() {
     actor_handle.shutdown().await;
 }
 
-/// Negative parity: with no receipt_store installed, `CloseProposal::Accept`
-/// must not panic and must simply record nothing — the handler-level
-/// emission (or a later `install_receipt_store` + re-close in force mode)
-/// remains the writer. Mirrors the force-close variant in
-/// `actor_receipt_store_parity`.
+/// Execution-required proposals cannot terminate Accepted on actor path when
+/// `receipt_store` is absent.
 #[tokio::test(flavor = "current_thread")]
-async fn actor_close_proposal_accept_without_receipt_store_is_noop() {
+async fn actor_close_proposal_accept_without_receipt_store_is_rejected() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let db_path = tmp.path().to_path_buf();
 
@@ -327,33 +324,20 @@ async fn actor_close_proposal_accept_without_receipt_store_is_noop() {
         .await
         .expect("cast_vote");
 
-    // NOTE: no install_receipt_store call before close — at emission time
-    // the actor's receipt_store is None, so the CloseProposal::Accept
-    // emission branch is a documented no-op.
-    actor_handle
+    // NOTE: no install_receipt_store call before close.
+    let result = actor_handle
         .submit(GovernanceCommand::CloseProposal {
             proposal_id: proposal_id.clone(),
             eligible_voters: None,
             excluded_delegators: None,
         })
-        .await
-        .expect("CloseProposal submit must not panic without a receipt_store");
-
-    // Make the no-op contract observable: install a spy backend AFTER the
-    // close has already processed and confirm no IER exists for this
-    // proposal. The spy sees all writes routed through it — if the close
-    // had silently emitted anywhere it would show up, because the spy now
-    // owns the only readable institutional-effect surface.
-    let spy = Arc::new(MemoryReceiptBackend::new());
-    actor_handle.install_receipt_store(spy.clone()).await;
-
-    let post_close_effects = spy
-        .list_institutional_effects_by_proposal(&proposal_id.0)
-        .expect("list_institutional_effects_by_proposal");
+        .await;
     assert!(
-        post_close_effects.is_empty(),
-        "CloseProposal::Accept with no receipt_store at emission time must leave no \
-         InstitutionalEffectRecord behind; got {post_close_effects:?}"
+        result
+            .as_ref()
+            .err()
+            .is_some_and(|e| e.to_string().contains("requires execution closure")),
+        "CloseProposal::Accept without receipt_store must be rejected for execution-required payloads; got {result:?}"
     );
 
     actor_handle.shutdown().await;

--- a/icn/apps/governance/tests/actor_receipt_store_parity.rs
+++ b/icn/apps/governance/tests/actor_receipt_store_parity.rs
@@ -311,11 +311,11 @@ async fn actor_force_close_accept_emits_revoke_steward_effect() {
     actor_handle.shutdown().await;
 }
 
-/// Regression: force-close-accept without a receipt_store must not panic
-/// and must not emit (silent no-op is the honest behavior). This pins the
-/// "missing store" half of the parity contract.
+/// Execution-required proposals cannot be force-accepted without a receipt_store.
+/// The actor must reject the terminal transition rather than silently accepting
+/// an operationally unlinked decision.
 #[tokio::test]
-async fn actor_force_close_accept_without_receipt_store_emits_nothing() {
+async fn actor_force_close_accept_without_receipt_store_is_rejected() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let db_path = tmp.path().to_path_buf();
 
@@ -378,14 +378,20 @@ async fn actor_force_close_accept_without_receipt_store_emits_nothing() {
         .expect("open_proposal");
 
     // NOTE: no install_receipt_store call.
-    actor_handle
+    let result = actor_handle
         .submit(GovernanceCommand::ForceCloseProposal {
             proposal_id: proposal_id.clone(),
             forced_outcome: ForcedOutcome::Accept,
             reason: "no backend".to_string(),
         })
-        .await
-        .expect("ForceCloseProposal submit must not panic without a receipt_store");
+        .await;
+    assert!(
+        result
+            .as_ref()
+            .err()
+            .is_some_and(|e| e.to_string().contains("requires execution closure")),
+        "force-accept without receipt_store must be rejected with closure error; got {result:?}"
+    );
 
     actor_handle.shutdown().await;
 }

--- a/icn/bins/icnctl/Cargo.toml
+++ b/icn/bins/icnctl/Cargo.toml
@@ -24,6 +24,7 @@ serde.workspace = true
 toml.workspace = true
 zeroize.workspace = true
 serde_json = "1.0"
+serde_yaml = "0.9"
 rpassword = "7.3"
 dirs = "6.0"
 sha2 = "0.10"

--- a/icn/bins/icnctl/src/institution_bootstrap.rs
+++ b/icn/bins/icnctl/src/institution_bootstrap.rs
@@ -1,0 +1,1568 @@
+use crate::{get_keystore_path, print_gateway_error, print_http_error, read_passphrase};
+use anyhow::{bail, Context, Result};
+use clap::Subcommand;
+use icn_governance::{
+    ActivityKind, BootstrapEntityType, BootstrapOperation, BootstrapPlan, BootstrapSeedManifest,
+    BootstrapSeedRef, InstitutionBootstrapManifest, ProgramKind, StructureKind,
+};
+use serde::Serialize;
+use serde_json::json;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Subcommand, Debug)]
+pub enum InstitutionCommands {
+    /// Validate or plan a generic institution package bootstrap
+    Bootstrap {
+        #[command(subcommand)]
+        command: InstitutionBootstrapCommands,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum InstitutionBootstrapCommands {
+    /// Validate package manifest ordering, charter parsing, and seed references
+    Validate {
+        /// Path to the institution package directory
+        #[arg(long)]
+        package: PathBuf,
+
+        /// Output machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Build the ordered generic bootstrap plan for a package
+    Plan {
+        /// Path to the institution package directory
+        #[arg(long)]
+        package: PathBuf,
+
+        /// Output machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Apply the generic bootstrap plan to a running node as far as supported
+    Apply {
+        /// Path to the institution package directory
+        #[arg(long)]
+        package: PathBuf,
+
+        /// Gateway API URL
+        #[arg(short, long, default_value = "http://localhost:8080")]
+        gateway: String,
+
+        /// Cooperative ID used for gateway authentication
+        #[arg(short, long)]
+        coop_id: String,
+
+        /// Output machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BootstrapValidationReport {
+    pub package_dir: String,
+    pub manifest_path: String,
+    pub charter_path: String,
+    pub charter_valid: bool,
+    pub seed_count: usize,
+    pub validated_seed_files: Vec<String>,
+    pub warnings: Vec<String>,
+    pub blockers: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BootstrapPlanReport {
+    pub manifest_path: String,
+    pub charter_path: String,
+    pub charter_valid: bool,
+    pub plan: BootstrapPlan,
+    pub preview: BootstrapPreview,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct BootstrapPreview {
+    pub entity_count: usize,
+    pub governance_domain_count: usize,
+    pub structure_count: usize,
+    pub activity_count: usize,
+    pub program_count: usize,
+    pub milestone_count: usize,
+    pub role_assignment_count: usize,
+    pub deferred_role_assignment_count: usize,
+    pub live_apply_supported: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BootstrapApplyReport {
+    pub manifest_path: String,
+    pub charter_path: String,
+    pub charter_valid: bool,
+    pub completed: Vec<BootstrapApplyStepReport>,
+    pub deferred: Vec<BootstrapApplyStepReport>,
+    pub unsupported: Vec<BootstrapApplyStepReport>,
+    pub failed: Option<BootstrapApplyFailure>,
+    pub alias_bindings: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BootstrapApplyStepReport {
+    pub operation: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BootstrapApplyFailure {
+    pub operation: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Default)]
+struct ApplyState {
+    alias_bindings: BTreeMap<String, String>,
+}
+
+impl ApplyState {
+    fn bind(&mut self, alias: &str, live_id: &str) {
+        self.alias_bindings
+            .insert(alias.to_string(), live_id.to_string());
+    }
+
+    fn resolve(&self, alias_or_id: &str) -> String {
+        self.alias_bindings
+            .get(alias_or_id)
+            .cloned()
+            .unwrap_or_else(|| alias_or_id.to_string())
+    }
+
+    fn resolve_bound(&self, alias_or_id: &str) -> Option<String> {
+        self.alias_bindings.get(alias_or_id).cloned()
+    }
+}
+
+enum ApplyOutcome {
+    Completed(String),
+    Deferred(String),
+    Unsupported(String),
+    Failed(String),
+}
+
+const BOOTSTRAP_SUBJECT_DID_PLACEHOLDER: &str = "$bootstrap_subject_did";
+
+#[derive(Debug, Clone)]
+struct BootstrapAuthContext {
+    token: String,
+    subject_did: String,
+}
+
+pub async fn handle_institution_command(cmd: InstitutionCommands, data_dir: &Path) -> Result<()> {
+    match cmd {
+        InstitutionCommands::Bootstrap { command } => match command {
+            InstitutionBootstrapCommands::Validate { package, json } => {
+                let report = validate_package(&package)?;
+                if json {
+                    println!("{}", serde_json::to_string_pretty(&report)?);
+                } else {
+                    print_validation_report(&report);
+                }
+            }
+            InstitutionBootstrapCommands::Plan { package, json } => {
+                let report = build_plan_report(&package)?;
+                if json {
+                    println!("{}", serde_json::to_string_pretty(&report)?);
+                } else {
+                    print_plan_report(&report);
+                }
+            }
+            InstitutionBootstrapCommands::Apply {
+                package,
+                gateway,
+                coop_id,
+                json,
+            } => {
+                let report = apply_package(&package, &gateway, &coop_id, data_dir).await?;
+                if json {
+                    println!("{}", serde_json::to_string_pretty(&report)?);
+                } else {
+                    print_apply_report(&report);
+                }
+            }
+        },
+    }
+
+    Ok(())
+}
+
+fn print_validation_report(report: &BootstrapValidationReport) {
+    println!("Institution Bootstrap Validation");
+    println!("================================\n");
+    println!("Package:         {}", report.package_dir);
+    println!("Manifest:        {}", report.manifest_path);
+    println!("Charter:         {}", report.charter_path);
+    println!(
+        "Charter status:  {}",
+        if report.charter_valid {
+            "valid"
+        } else {
+            "invalid"
+        }
+    );
+    println!("Seed files:      {}", report.seed_count);
+
+    if !report.validated_seed_files.is_empty() {
+        println!("\nValidated seed files:");
+        for path in &report.validated_seed_files {
+            println!("  - {path}");
+        }
+    }
+
+    if !report.warnings.is_empty() {
+        println!("\nWarnings:");
+        for warning in &report.warnings {
+            println!("  - {warning}");
+        }
+    }
+
+    if !report.blockers.is_empty() {
+        println!("\nBlockers:");
+        for blocker in &report.blockers {
+            println!("  - {blocker}");
+        }
+    }
+}
+
+fn print_plan_report(report: &BootstrapPlanReport) {
+    println!("Institution Bootstrap Plan");
+    println!("==========================\n");
+    println!("Manifest:        {}", report.manifest_path);
+    println!("Charter:         {}", report.charter_path);
+    println!(
+        "Charter status:  {}",
+        if report.charter_valid {
+            "valid"
+        } else {
+            "invalid"
+        }
+    );
+    println!("Operations:      {}", report.plan.operations.len());
+    println!();
+
+    for op in &report.plan.operations {
+        println!("- {}", summarize_operation(op));
+    }
+
+    println!("\nPreview counts:");
+    println!("  Entities:              {}", report.preview.entity_count);
+    println!(
+        "  Governance domains:    {}",
+        report.preview.governance_domain_count
+    );
+    println!(
+        "  Structures:            {}",
+        report.preview.structure_count
+    );
+    println!("  Activities:            {}", report.preview.activity_count);
+    println!("  Programs:              {}", report.preview.program_count);
+    println!(
+        "  Milestones:            {}",
+        report.preview.milestone_count
+    );
+    println!(
+        "  Role assignments:      {}",
+        report.preview.role_assignment_count
+    );
+    println!(
+        "  Deferred role records: {}",
+        report.preview.deferred_role_assignment_count
+    );
+    println!(
+        "  Live apply supported:  {}",
+        if report.preview.live_apply_supported {
+            "yes"
+        } else {
+            "no"
+        }
+    );
+
+    if !report.plan.warnings.is_empty() {
+        println!("\nWarnings:");
+        for warning in &report.plan.warnings {
+            println!("  - {warning}");
+        }
+    }
+
+    if !report.plan.blockers.is_empty() {
+        println!("\nBlockers:");
+        for blocker in &report.plan.blockers {
+            println!("  - {blocker}");
+        }
+    }
+}
+
+fn print_apply_report(report: &BootstrapApplyReport) {
+    println!("Institution Bootstrap Apply");
+    println!("===========================\n");
+    println!("Manifest:        {}", report.manifest_path);
+    println!("Charter:         {}", report.charter_path);
+    println!(
+        "Charter status:  {}",
+        if report.charter_valid {
+            "valid"
+        } else {
+            "invalid"
+        }
+    );
+    println!("Completed:       {}", report.completed.len());
+    println!("Deferred:        {}", report.deferred.len());
+    println!("Unsupported:     {}", report.unsupported.len());
+    println!(
+        "Failed:          {}",
+        if report.failed.is_some() { "yes" } else { "no" }
+    );
+
+    if !report.completed.is_empty() {
+        println!("\nCompleted steps:");
+        for step in &report.completed {
+            println!("  - {}: {}", step.operation, step.detail);
+        }
+    }
+
+    if !report.deferred.is_empty() {
+        println!("\nDeferred steps:");
+        for step in &report.deferred {
+            println!("  - {}: {}", step.operation, step.detail);
+        }
+    }
+
+    if !report.unsupported.is_empty() {
+        println!("\nUnsupported steps:");
+        for step in &report.unsupported {
+            println!("  - {}: {}", step.operation, step.detail);
+        }
+    }
+
+    if !report.alias_bindings.is_empty() {
+        println!("\nAlias bindings:");
+        for (alias, live_id) in &report.alias_bindings {
+            println!("  - {alias} -> {live_id}");
+        }
+    }
+
+    if let Some(failure) = &report.failed {
+        println!("\nFailure:");
+        println!("  - {}: {}", failure.operation, failure.detail);
+    }
+}
+
+fn summarize_operation(op: &BootstrapOperation) -> String {
+    match op {
+        BootstrapOperation::ValidateCharter { path } => format!("validate charter {path}"),
+        BootstrapOperation::CreateEntity {
+            id, entity_type, ..
+        } => {
+            format!("create {:?} entity {id}", entity_type)
+        }
+        BootstrapOperation::ProvisionGovernanceDomain { id, .. } => {
+            format!("provision governance domain {id}")
+        }
+        BootstrapOperation::CreateStructure { id, kind, .. } => {
+            format!("create {:?} structure {id}", kind)
+        }
+        BootstrapOperation::CreateProgram { id, .. } => format!("create program {id}"),
+        BootstrapOperation::CreateActivity { id, .. } => format!("create activity {id}"),
+        BootstrapOperation::CreateMilestone { id, program_id, .. } => {
+            format!("create milestone {id} in {program_id}")
+        }
+        BootstrapOperation::AssignRole {
+            structure_id,
+            person_did,
+            role,
+            ..
+        } => format!("assign role {role} on {structure_id} to {person_did}"),
+        BootstrapOperation::DeferRoleAssignment {
+            structure_id, role, ..
+        } => format!("defer role {role} on {structure_id}"),
+    }
+}
+
+pub fn validate_package(package_dir: &Path) -> Result<BootstrapValidationReport> {
+    let loaded = load_package(package_dir)?;
+    Ok(BootstrapValidationReport {
+        package_dir: package_dir.display().to_string(),
+        manifest_path: loaded.manifest_path.display().to_string(),
+        charter_path: loaded.charter_path.display().to_string(),
+        charter_valid: true,
+        seed_count: loaded.seed_paths.len(),
+        validated_seed_files: loaded
+            .seed_paths
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect(),
+        warnings: loaded.warnings,
+        blockers: loaded.blockers,
+    })
+}
+
+pub fn build_plan_report(package_dir: &Path) -> Result<BootstrapPlanReport> {
+    let loaded = load_package(package_dir)?;
+    let plan = make_plan(&loaded);
+    let preview = preview_execute(&plan);
+    Ok(BootstrapPlanReport {
+        manifest_path: loaded.manifest_path.display().to_string(),
+        charter_path: loaded.charter_path.display().to_string(),
+        charter_valid: true,
+        plan,
+        preview,
+    })
+}
+
+pub async fn apply_package(
+    package_dir: &Path,
+    gateway: &str,
+    coop_id: &str,
+    data_dir: &Path,
+) -> Result<BootstrapApplyReport> {
+    let loaded = load_package(package_dir)?;
+    let plan = make_plan(&loaded);
+    let auth = get_bootstrap_gateway_token(gateway, coop_id, data_dir).await?;
+    let client = reqwest::Client::new();
+    let mut state = ApplyState::default();
+
+    let mut report = BootstrapApplyReport {
+        manifest_path: loaded.manifest_path.display().to_string(),
+        charter_path: loaded.charter_path.display().to_string(),
+        charter_valid: true,
+        completed: Vec::new(),
+        deferred: Vec::new(),
+        unsupported: vec![BootstrapApplyStepReport {
+            operation: "store charter".to_string(),
+            detail: "package-owned CCL charters validate locally today, but there is no generic live CCL charter registration/activation sink yet".to_string(),
+        }],
+        failed: None,
+        alias_bindings: BTreeMap::new(),
+    };
+
+    for op in &plan.operations {
+        let operation = summarize_operation(op);
+        match apply_operation(op, gateway, &client, &auth, &mut state).await {
+            ApplyOutcome::Completed(detail) => report
+                .completed
+                .push(BootstrapApplyStepReport { operation, detail }),
+            ApplyOutcome::Deferred(detail) => report
+                .deferred
+                .push(BootstrapApplyStepReport { operation, detail }),
+            ApplyOutcome::Unsupported(detail) => report
+                .unsupported
+                .push(BootstrapApplyStepReport { operation, detail }),
+            ApplyOutcome::Failed(detail) => {
+                report.failed = Some(BootstrapApplyFailure { operation, detail });
+                report.alias_bindings = state.alias_bindings;
+                return Ok(report);
+            }
+        }
+    }
+
+    report.alias_bindings = state.alias_bindings;
+    Ok(report)
+}
+
+struct LoadedPackage {
+    manifest_path: PathBuf,
+    charter_path: PathBuf,
+    seed_paths: Vec<PathBuf>,
+    manifest: InstitutionBootstrapManifest,
+    seeds: Vec<BootstrapSeedManifest>,
+    warnings: Vec<String>,
+    blockers: Vec<String>,
+}
+
+fn load_package(package_dir: &Path) -> Result<LoadedPackage> {
+    let manifest_path = package_dir.join("bootstrap.yaml");
+    let manifest_yaml = fs::read_to_string(&manifest_path)
+        .with_context(|| format!("Failed to read {}", manifest_path.display()))?;
+    let manifest: InstitutionBootstrapManifest = serde_yaml::from_str(&manifest_yaml)
+        .with_context(|| format!("Failed to parse {}", manifest_path.display()))?;
+
+    let charter_path = package_dir.join(&manifest.charter.path);
+    let charter_yaml = fs::read_to_string(&charter_path)
+        .with_context(|| format!("Failed to read {}", charter_path.display()))?;
+    let charter_doc = icn_ccl::schema::CclDocument::from_yaml(&charter_yaml)
+        .with_context(|| format!("Failed to parse {}", charter_path.display()))?;
+    charter_doc
+        .validate()
+        .with_context(|| format!("Validation failed for {}", charter_path.display()))?;
+
+    validate_seed_order(&manifest.seeds)?;
+
+    let mut seeds = Vec::new();
+    let mut seed_paths = Vec::new();
+    for seed_ref in &manifest.seeds {
+        let seed_path = package_dir.join(&seed_ref.path);
+        let seed_yaml = fs::read_to_string(&seed_path)
+            .with_context(|| format!("Failed to read {}", seed_path.display()))?;
+        let seed: BootstrapSeedManifest = serde_yaml::from_str(&seed_yaml)
+            .with_context(|| format!("Failed to parse {}", seed_path.display()))?;
+        if seed.seed_kind() != seed_ref.kind {
+            bail!(
+                "Seed kind mismatch for {}: manifest says {:?}, file says {:?}",
+                seed_path.display(),
+                seed_ref.kind,
+                seed.seed_kind()
+            );
+        }
+        seeds.push(seed);
+        seed_paths.push(seed_path);
+    }
+
+    let (warnings, blockers) = validate_seed_graph(&seeds);
+
+    Ok(LoadedPackage {
+        manifest_path,
+        charter_path,
+        seed_paths,
+        manifest,
+        seeds,
+        warnings,
+        blockers,
+    })
+}
+
+fn validate_seed_order(seeds: &[BootstrapSeedRef]) -> Result<()> {
+    let mut last = None;
+    let mut seen_orders = BTreeSet::new();
+    for seed in seeds {
+        if !seen_orders.insert(seed.order) {
+            bail!("Duplicate bootstrap seed order {}", seed.order);
+        }
+        if let Some(prev) = last {
+            if seed.order <= prev {
+                bail!("Bootstrap seed order must be strictly increasing");
+            }
+        }
+        last = Some(seed.order);
+    }
+    Ok(())
+}
+
+fn validate_seed_graph(seeds: &[BootstrapSeedManifest]) -> (Vec<String>, Vec<String>) {
+    let mut warnings = Vec::new();
+    let mut blockers = Vec::new();
+    let mut entities = BTreeSet::new();
+    let mut declared_domains = BTreeSet::new();
+    let mut referenced_domains = BTreeSet::new();
+    let mut structures = BTreeSet::new();
+    let mut programs = BTreeSet::new();
+
+    for seed in seeds {
+        match seed {
+            BootstrapSeedManifest::Entity(entity_seed) => {
+                let entity = &entity_seed.entity;
+                if let Some(parent) = &entity.parent_entity_id {
+                    if !entities.contains(parent) {
+                        blockers.push(format!(
+                            "Entity {} references missing parent entity {}",
+                            entity.id, parent
+                        ));
+                    }
+                }
+                referenced_domains.insert(entity.governance_domain_id.clone());
+                entities.insert(entity.id.clone());
+            }
+            BootstrapSeedManifest::GovernanceDomain(domain_seed) => {
+                for domain in &domain_seed.domains {
+                    if !declared_domains.insert(domain.id.clone()) {
+                        blockers.push(format!(
+                            "Governance domain seed declares duplicate domain {}",
+                            domain.id
+                        ));
+                    }
+                    if domain.members.is_empty() {
+                        warnings.push(format!(
+                            "Governance domain {} has no declared members; live apply will be unsupported until at least one member DID (or {BOOTSTRAP_SUBJECT_DID_PLACEHOLDER}) is provided",
+                            domain.id
+                        ));
+                    }
+                }
+            }
+            BootstrapSeedManifest::Structure(structure_seed) => {
+                if !entities.contains(&structure_seed.parent_entity_id) {
+                    blockers.push(format!(
+                        "Structure seed references missing parent entity {}",
+                        structure_seed.parent_entity_id
+                    ));
+                }
+                for structure in &structure_seed.structures {
+                    structures.insert(structure.id.clone());
+                }
+            }
+            BootstrapSeedManifest::ActivityProgram(activity_program_seed) => {
+                if !entities.contains(&activity_program_seed.parent_entity_id) {
+                    blockers.push(format!(
+                        "Activity/program seed references missing parent entity {}",
+                        activity_program_seed.parent_entity_id
+                    ));
+                }
+                for linked_structure in &activity_program_seed.activity.linked_structures {
+                    if !structures.contains(linked_structure) {
+                        blockers.push(format!(
+                            "Activity {} references missing structure {}",
+                            activity_program_seed.activity.id, linked_structure
+                        ));
+                    }
+                }
+                if let Some(prior) = &activity_program_seed.program.prior_cycle_program_id {
+                    warnings.push(format!(
+                        "Program {} references prior cycle {} which is not created by this package seed set",
+                        activity_program_seed.program.id, prior
+                    ));
+                }
+                programs.insert(activity_program_seed.program.id.clone());
+            }
+            BootstrapSeedManifest::MilestoneTemplate(milestone_seed) => {
+                if !programs.contains(&milestone_seed.program_id) {
+                    blockers.push(format!(
+                        "Milestone seed references missing program {}",
+                        milestone_seed.program_id
+                    ));
+                }
+            }
+            BootstrapSeedManifest::RoleAssignment(role_seed) => {
+                for assignment in &role_seed.assignments {
+                    if !structures.contains(&assignment.structure_id) {
+                        blockers.push(format!(
+                            "Role assignment references missing structure {}",
+                            assignment.structure_id
+                        ));
+                    }
+                    if assignment.person_did.is_none() {
+                        warnings.push(format!(
+                            "Role assignment for structure {} and role {} has no DID yet; it will be deferred",
+                            assignment.structure_id, assignment.role
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    for domain_id in &referenced_domains {
+        if !declared_domains.contains(domain_id) {
+            blockers.push(format!(
+                "Entity references governance domain {} but no governance-domain-seed declares it",
+                domain_id
+            ));
+        }
+    }
+
+    for domain_id in &declared_domains {
+        if !referenced_domains.contains(domain_id) {
+            warnings.push(format!(
+                "Governance domain {} is declared but not referenced by any entity seed",
+                domain_id
+            ));
+        }
+    }
+
+    (warnings, blockers)
+}
+
+fn make_plan(loaded: &LoadedPackage) -> BootstrapPlan {
+    let mut operations = vec![BootstrapOperation::ValidateCharter {
+        path: loaded.charter_path.display().to_string(),
+    }];
+
+    let mut entity_domains = BTreeMap::new();
+    let mut declared_domains = BTreeMap::new();
+    let mut provisioned_domains = BTreeSet::new();
+
+    for seed in &loaded.seeds {
+        match seed {
+            BootstrapSeedManifest::Entity(entity_seed) => {
+                let entity = &entity_seed.entity;
+                entity_domains.insert(entity.id.clone(), entity.governance_domain_id.clone());
+                operations.push(BootstrapOperation::CreateEntity {
+                    id: entity.id.clone(),
+                    entity_type: entity.entity_type,
+                    parent_entity_id: entity.parent_entity_id.clone(),
+                    display_name: entity.display_name.clone(),
+                    governance_domain_id: entity.governance_domain_id.clone(),
+                    charter_ref: entity.charter_ref.clone(),
+                });
+            }
+            BootstrapSeedManifest::GovernanceDomain(domain_seed) => {
+                for domain in &domain_seed.domains {
+                    declared_domains.insert(domain.id.clone(), domain.clone());
+                    operations.push(BootstrapOperation::ProvisionGovernanceDomain {
+                        id: domain.id.clone(),
+                        name: domain.name.clone(),
+                        profile: domain.profile.clone(),
+                        quorum_percent: domain.quorum_percent,
+                        approval_percent: domain.approval_percent,
+                        voting_period_days: domain.voting_period_days,
+                        members: domain.members.clone(),
+                        decision_mode: domain.decision_mode.clone(),
+                        max_objections: domain.max_objections,
+                    });
+                    provisioned_domains.insert(domain.id.clone());
+                }
+            }
+            BootstrapSeedManifest::Structure(structure_seed) => {
+                for structure in &structure_seed.structures {
+                    operations.push(BootstrapOperation::CreateStructure {
+                        id: structure.id.clone(),
+                        parent_entity_id: structure_seed.parent_entity_id.clone(),
+                        kind: structure.kind,
+                        name: structure.name.clone(),
+                        mandate: structure.mandate.clone(),
+                        scope: structure.scope.clone(),
+                    });
+                }
+            }
+            BootstrapSeedManifest::ActivityProgram(activity_program_seed) => {
+                let program = &activity_program_seed.program;
+                let domain_id = entity_domains
+                    .get(&activity_program_seed.parent_entity_id)
+                    .cloned()
+                    .unwrap_or_else(|| activity_program_seed.parent_entity_id.clone());
+                if !provisioned_domains.contains(&domain_id) {
+                    if let Some(domain) = declared_domains.get(&domain_id) {
+                        operations.push(BootstrapOperation::ProvisionGovernanceDomain {
+                            id: domain.id.clone(),
+                            name: domain.name.clone(),
+                            profile: domain.profile.clone(),
+                            quorum_percent: domain.quorum_percent,
+                            approval_percent: domain.approval_percent,
+                            voting_period_days: domain.voting_period_days,
+                            members: domain.members.clone(),
+                            decision_mode: domain.decision_mode.clone(),
+                            max_objections: domain.max_objections,
+                        });
+                        provisioned_domains.insert(domain_id.clone());
+                    }
+                }
+                operations.push(BootstrapOperation::CreateProgram {
+                    id: program.id.clone(),
+                    domain_id,
+                    parent_entity_id: activity_program_seed.parent_entity_id.clone(),
+                    kind: program.kind.to_program_kind(),
+                    name: program.name.clone(),
+                    description: program.description.clone(),
+                    prior_cycle_program_id: program.prior_cycle_program_id.clone(),
+                });
+                operations.push(BootstrapOperation::CreateActivity {
+                    id: activity_program_seed.activity.id.clone(),
+                    parent_entity_id: activity_program_seed.parent_entity_id.clone(),
+                    kind: activity_program_seed.activity.kind,
+                    name: activity_program_seed.activity.name.clone(),
+                    description: activity_program_seed.activity.description.clone(),
+                    linked_structures: activity_program_seed.activity.linked_structures.clone(),
+                    parent_program_id: Some(program.id.clone()),
+                });
+            }
+            BootstrapSeedManifest::MilestoneTemplate(milestone_seed) => {
+                for milestone in &milestone_seed.milestones {
+                    operations.push(BootstrapOperation::CreateMilestone {
+                        id: milestone.id.clone(),
+                        program_id: milestone_seed.program_id.clone(),
+                        title: milestone.title.clone(),
+                        description: milestone.description.clone(),
+                        phase_index: milestone.phase_index,
+                        target_date: milestone.target_date,
+                        completion_criteria: milestone.completion_criteria.clone(),
+                    });
+                }
+            }
+            BootstrapSeedManifest::RoleAssignment(role_seed) => {
+                for assignment in &role_seed.assignments {
+                    match &assignment.person_did {
+                        Some(did) => operations.push(BootstrapOperation::AssignRole {
+                            structure_id: assignment.structure_id.clone(),
+                            person_did: did.clone(),
+                            role: assignment.role.clone(),
+                            authority_scope: assignment.authority_scope.clone(),
+                        }),
+                        None => operations.push(BootstrapOperation::DeferRoleAssignment {
+                            structure_id: assignment.structure_id.clone(),
+                            role: assignment.role.clone(),
+                            holder_label: assignment.holder_label.clone(),
+                            authority_scope: assignment.authority_scope.clone(),
+                            reason: "no person_did supplied in seed".to_string(),
+                        }),
+                    }
+                }
+            }
+        }
+    }
+
+    BootstrapPlan {
+        package_id: loaded.manifest.package_id.clone(),
+        charter_path: loaded.charter_path.display().to_string(),
+        operations,
+        warnings: loaded.warnings.clone(),
+        blockers: loaded.blockers.clone(),
+    }
+}
+
+fn preview_execute(plan: &BootstrapPlan) -> BootstrapPreview {
+    let mut preview = BootstrapPreview {
+        live_apply_supported: true,
+        ..BootstrapPreview::default()
+    };
+
+    for op in &plan.operations {
+        match op {
+            BootstrapOperation::ValidateCharter { .. } => {}
+            BootstrapOperation::CreateEntity { .. } => preview.entity_count += 1,
+            BootstrapOperation::ProvisionGovernanceDomain { .. } => {
+                preview.governance_domain_count += 1
+            }
+            BootstrapOperation::CreateStructure { .. } => preview.structure_count += 1,
+            BootstrapOperation::CreateProgram { .. } => preview.program_count += 1,
+            BootstrapOperation::CreateActivity { .. } => preview.activity_count += 1,
+            BootstrapOperation::CreateMilestone { .. } => preview.milestone_count += 1,
+            BootstrapOperation::AssignRole { .. } => preview.role_assignment_count += 1,
+            BootstrapOperation::DeferRoleAssignment { .. } => {
+                preview.deferred_role_assignment_count += 1
+            }
+        }
+    }
+
+    preview
+}
+
+async fn apply_operation(
+    op: &BootstrapOperation,
+    gateway: &str,
+    client: &reqwest::Client,
+    auth: &BootstrapAuthContext,
+    state: &mut ApplyState,
+) -> ApplyOutcome {
+    match op {
+        BootstrapOperation::ValidateCharter { path } => ApplyOutcome::Completed(format!(
+            "validated charter locally at {path}; live charter registration remains unsupported"
+        )),
+        BootstrapOperation::CreateEntity {
+            id,
+            entity_type,
+            parent_entity_id,
+            display_name,
+            governance_domain_id,
+            charter_ref,
+        } => {
+            let parent_id = parent_entity_id
+                .as_deref()
+                .map(|parent| state.resolve(parent));
+            let body = json!({
+                "entity_type": entity_type_api_name(*entity_type),
+                "identifier": id,
+                "name": display_name,
+                "description": charter_ref
+                    .as_ref()
+                    .map(|reference| format!("package charter ref: {reference}")),
+                "parent_id": parent_id,
+            });
+            match post_json(client, gateway, &auth.token, "/v1/entities", &body).await {
+                Ok(resp) => match required_string_field(&resp, "id") {
+                    Ok(live_id) => {
+                        state.bind(id, &live_id);
+                        ApplyOutcome::Completed(format!(
+                            "created entity as {live_id}; governance domain alias {governance_domain_id} recorded for subsequent provisioning"
+                        ))
+                    }
+                    Err(err) => ApplyOutcome::Failed(err.to_string()),
+                },
+                Err(err) => ApplyOutcome::Failed(err),
+            }
+        }
+        BootstrapOperation::ProvisionGovernanceDomain {
+            id,
+            name,
+            profile,
+            quorum_percent,
+            approval_percent,
+            voting_period_days,
+            members,
+            decision_mode,
+            max_objections,
+        } => {
+            let resolved_members = resolve_bootstrap_member_dids(members, &auth.subject_did);
+            if resolved_members.is_empty() {
+                return ApplyOutcome::Unsupported(format!(
+                    "governance domain {id} has no usable members after resolving placeholders; provide at least one DID or {BOOTSTRAP_SUBJECT_DID_PLACEHOLDER}"
+                ));
+            }
+            match remote_exists(
+                client,
+                gateway,
+                &auth.token,
+                &format!("/v1/gov/domains/{id}"),
+            )
+            .await
+            {
+                Ok(true) => {
+                    ApplyOutcome::Completed(format!("governance domain {id} already exists"))
+                }
+                Ok(false) => {
+                    let body = json!({
+                        "id": id,
+                        "name": name,
+                        "profile": profile,
+                        "quorum_percent": quorum_percent,
+                        "approval_percent": approval_percent,
+                        "voting_period_days": voting_period_days,
+                        "members": resolved_members,
+                        "decision_mode": decision_mode,
+                        "max_objections": max_objections,
+                    });
+                    match post_json(client, gateway, &auth.token, "/v1/gov/domains", &body).await {
+                        Ok(resp) => match required_string_field(&resp, "id") {
+                            Ok(live_id) => ApplyOutcome::Completed(format!(
+                                "provisioned governance domain as {live_id}"
+                            )),
+                            Err(err) => ApplyOutcome::Failed(err.to_string()),
+                        },
+                        Err(err) => ApplyOutcome::Failed(err),
+                    }
+                }
+                Err(err) => ApplyOutcome::Failed(err),
+            }
+        }
+        BootstrapOperation::CreateStructure {
+            id,
+            parent_entity_id,
+            kind,
+            name,
+            mandate,
+            scope,
+        } => {
+            if !scope.is_empty() {
+                return ApplyOutcome::Unsupported(format!(
+                    "structure scope is not writable through the current generic create_structure API for alias {id}"
+                ));
+            }
+            let parent = state.resolve(parent_entity_id);
+            let path = format!("/v1/gov/entities/{parent}/structures");
+            let body = json!({
+                "kind": structure_kind_api_name(*kind),
+                "name": name,
+                "description": mandate,
+            });
+            match post_json(client, gateway, &auth.token, &path, &body).await {
+                Ok(resp) => match required_string_field(&resp, "id") {
+                    Ok(live_id) => {
+                        state.bind(id, &live_id);
+                        ApplyOutcome::Completed(format!("created structure as {live_id}"))
+                    }
+                    Err(err) => ApplyOutcome::Failed(err.to_string()),
+                },
+                Err(err) => ApplyOutcome::Failed(err),
+            }
+        }
+        BootstrapOperation::CreateProgram {
+            id,
+            domain_id,
+            parent_entity_id,
+            kind,
+            name,
+            description,
+            prior_cycle_program_id,
+        } => {
+            if let Some(prior) = prior_cycle_program_id {
+                return ApplyOutcome::Unsupported(format!(
+                    "prior cycle linkage {prior} is not writable through the current generic create_program API for alias {id}"
+                ));
+            }
+            match remote_exists(
+                client,
+                gateway,
+                &auth.token,
+                &format!("/v1/gov/domains/{domain_id}"),
+            )
+            .await
+            {
+                Ok(true) => {}
+                Ok(false) => {
+                    return ApplyOutcome::Unsupported(format!(
+                        "governance domain {domain_id} is still missing after domain-provisioning steps; verify governance-domain seeds and apply permissions"
+                    ));
+                }
+                Err(err) => return ApplyOutcome::Failed(err),
+            }
+            let parent_entity = state.resolve(parent_entity_id);
+            let path = format!("/v1/gov/domains/{domain_id}/programs");
+            let body = json!({
+                "parent_entity_id": parent_entity,
+                "kind": program_kind_api_name(kind),
+                "name": name,
+                "description": description,
+                "start_at": serde_json::Value::Null,
+                "end_at": serde_json::Value::Null,
+                "created_by_decision": serde_json::Value::Null,
+            });
+            match post_json(client, gateway, &auth.token, &path, &body).await {
+                Ok(resp) => match required_string_field(&resp, "id") {
+                    Ok(live_id) => {
+                        state.bind(id, &live_id);
+                        ApplyOutcome::Completed(format!("created program as {live_id}"))
+                    }
+                    Err(err) => ApplyOutcome::Failed(err.to_string()),
+                },
+                Err(err) => ApplyOutcome::Failed(err),
+            }
+        }
+        BootstrapOperation::CreateActivity {
+            id,
+            parent_entity_id,
+            kind,
+            name,
+            description,
+            linked_structures,
+            parent_program_id,
+        } => {
+            let resolved_parent_program_id = match parent_program_id {
+                Some(program_id) => match resolve_live_or_existing_id(
+                    client,
+                    gateway,
+                    &auth.token,
+                    state,
+                    program_id,
+                    "/v1/gov/programs",
+                )
+                .await
+                {
+                    Ok(Some(resolved)) => Some(resolved),
+                    Ok(None) => {
+                        return ApplyOutcome::Unsupported(format!(
+                            "parent program {program_id} is not available as a live program ID for activity alias {id}"
+                        ));
+                    }
+                    Err(err) => return ApplyOutcome::Failed(err),
+                },
+                None => None,
+            };
+            let parent_entity = state.resolve(parent_entity_id);
+            let path = format!("/v1/gov/entities/{parent_entity}/activities");
+            let resolved_linked_structures: Vec<String> = linked_structures
+                .iter()
+                .map(|structure_id| state.resolve(structure_id))
+                .collect();
+            let body = json!({
+                "kind": activity_kind_api_name(*kind),
+                "name": name,
+                "description": description,
+                "start_date": serde_json::Value::Null,
+                "end_date": serde_json::Value::Null,
+                "linked_structures": resolved_linked_structures,
+                "parent_program_id": resolved_parent_program_id,
+            });
+            match post_json(client, gateway, &auth.token, &path, &body).await {
+                Ok(resp) => match required_string_field(&resp, "id") {
+                    Ok(live_id) => {
+                        state.bind(id, &live_id);
+                        ApplyOutcome::Completed(format!("created activity as {live_id}"))
+                    }
+                    Err(err) => ApplyOutcome::Failed(err.to_string()),
+                },
+                Err(err) => ApplyOutcome::Failed(err),
+            }
+        }
+        BootstrapOperation::CreateMilestone {
+            id,
+            program_id,
+            title,
+            description,
+            phase_index,
+            target_date,
+            completion_criteria,
+        } => {
+            let resolved_program_id = match resolve_live_or_existing_id(
+                client,
+                gateway,
+                &auth.token,
+                state,
+                program_id,
+                "/v1/gov/programs",
+            )
+            .await
+            {
+                Ok(Some(resolved)) => resolved,
+                Ok(None) => {
+                    return ApplyOutcome::Unsupported(format!(
+                        "target program {program_id} is not available as a live program ID for milestone alias {id}"
+                    ));
+                }
+                Err(err) => return ApplyOutcome::Failed(err),
+            };
+            let path = format!("/v1/gov/programs/{resolved_program_id}/milestones");
+            let body = json!({
+                "name": title,
+                "description": description,
+                "phase_index": phase_index,
+                "target_date": target_date,
+                "completion_criteria": completion_criteria,
+            });
+            match post_json(client, gateway, &auth.token, &path, &body).await {
+                Ok(resp) => match required_string_field(&resp, "id") {
+                    Ok(live_id) => {
+                        state.bind(id, &live_id);
+                        ApplyOutcome::Completed(format!("created milestone as {live_id}"))
+                    }
+                    Err(err) => ApplyOutcome::Failed(err.to_string()),
+                },
+                Err(err) => ApplyOutcome::Failed(err),
+            }
+        }
+        BootstrapOperation::AssignRole {
+            structure_id,
+            person_did,
+            role,
+            ..
+        } => {
+            let resolved_structure_id = match resolve_live_or_existing_id(
+                client,
+                gateway,
+                &auth.token,
+                state,
+                structure_id,
+                "/v1/gov/structures",
+            )
+            .await
+            {
+                Ok(Some(resolved)) => resolved,
+                Ok(None) => {
+                    return ApplyOutcome::Unsupported(format!(
+                        "target structure {structure_id} is not available as a live structure ID"
+                    ));
+                }
+                Err(err) => return ApplyOutcome::Failed(err),
+            };
+            let path = format!("/v1/gov/structures/{resolved_structure_id}/roles");
+            let body = json!({
+                "did": person_did.to_string(),
+                "role": role,
+            });
+            match post_json(client, gateway, &auth.token, &path, &body).await {
+                Ok(_) => ApplyOutcome::Completed(format!(
+                    "assigned role {role} on live structure {resolved_structure_id}"
+                )),
+                Err(err) => ApplyOutcome::Failed(err),
+            }
+        }
+        BootstrapOperation::DeferRoleAssignment {
+            reason,
+            holder_label,
+            ..
+        } => ApplyOutcome::Deferred(match holder_label {
+            Some(label) => format!("{reason}; awaiting DID for {label}"),
+            None => reason.clone(),
+        }),
+    }
+}
+
+async fn get_bootstrap_gateway_token(
+    gateway: &str,
+    coop_id: &str,
+    data_dir: &Path,
+) -> Result<BootstrapAuthContext> {
+    use icn_identity::{AgeKeyStore, KeyStore};
+
+    let keystore_path = get_keystore_path(data_dir);
+    if !keystore_path.exists() {
+        bail!("No identity found. Run 'icnctl id init' first.");
+    }
+
+    let passphrase = read_passphrase("Keystore passphrase: ")?;
+    let mut keystore = AgeKeyStore::open(&keystore_path)?;
+    keystore.unlock(&passphrase)?;
+    let keypair = keystore.get_keypair()?;
+    let did = keypair.did().to_string();
+
+    let client = reqwest::Client::new();
+    let challenge_url = format!("{gateway}/v1/auth/challenge");
+    let challenge_req = json!({ "did": did });
+    let challenge_resp = client
+        .post(&challenge_url)
+        .json(&challenge_req)
+        .send()
+        .await
+        .context("Failed to connect to gateway for auth challenge")?;
+
+    if !challenge_resp.status().is_success() {
+        bail!("Failed to get auth challenge: {}", challenge_resp.status());
+    }
+
+    let challenge_data: serde_json::Value = challenge_resp
+        .json()
+        .await
+        .context("Failed to parse auth challenge response")?;
+    let nonce = challenge_data["nonce"]
+        .as_str()
+        .context("Missing nonce in auth challenge response")?;
+    let nonce_bytes = hex::decode(nonce).context("Invalid nonce format from gateway")?;
+    let signature = keypair.sign(&nonce_bytes);
+
+    let verify_url = format!("{gateway}/v1/auth/verify");
+    let verify_req = json!({
+        "did": did,
+        "signature": hex::encode(signature.to_bytes()),
+        "coop_id": coop_id,
+        "scopes": ["entity:write", "governance:read", "governance:write"],
+    });
+    let verify_resp = client
+        .post(&verify_url)
+        .json(&verify_req)
+        .send()
+        .await
+        .context("Failed to verify auth challenge")?;
+
+    if !verify_resp.status().is_success() {
+        bail!(
+            "Failed to get bootstrap auth token: {}",
+            verify_resp.status()
+        );
+    }
+
+    let token_data: serde_json::Value = verify_resp
+        .json()
+        .await
+        .context("Failed to parse auth token response")?;
+    let token = token_data["token"]
+        .as_str()
+        .context("Missing token in auth response")?;
+
+    Ok(BootstrapAuthContext {
+        token: token.to_string(),
+        subject_did: did,
+    })
+}
+
+fn resolve_bootstrap_member_dids(members: &[String], bootstrap_subject_did: &str) -> Vec<String> {
+    members
+        .iter()
+        .map(|member| {
+            if member == BOOTSTRAP_SUBJECT_DID_PLACEHOLDER {
+                bootstrap_subject_did.to_string()
+            } else {
+                member.clone()
+            }
+        })
+        .filter(|member| !member.trim().is_empty())
+        .collect()
+}
+
+async fn post_json(
+    client: &reqwest::Client,
+    gateway: &str,
+    token: &str,
+    path: &str,
+    body: &serde_json::Value,
+) -> std::result::Result<serde_json::Value, String> {
+    let url = format!("{gateway}{path}");
+    match client
+        .post(&url)
+        .header("Authorization", format!("Bearer {token}"))
+        .json(body)
+        .send()
+        .await
+    {
+        Ok(resp) => {
+            let status = resp.status();
+            if status.is_success() {
+                resp.json::<serde_json::Value>()
+                    .await
+                    .map_err(|err| format!("Failed to parse success response from {path}: {err}"))
+            } else {
+                let body_text = resp.text().await.unwrap_or_default();
+                Err(format_http_error(path, status, &body_text))
+            }
+        }
+        Err(err) => {
+            print_gateway_error(gateway, &err);
+            Err(format!("Failed to call {path}: {err}"))
+        }
+    }
+}
+
+async fn remote_exists(
+    client: &reqwest::Client,
+    gateway: &str,
+    token: &str,
+    path: &str,
+) -> std::result::Result<bool, String> {
+    let url = format!("{gateway}{path}");
+    match client
+        .get(&url)
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+    {
+        Ok(resp) => {
+            let status = resp.status();
+            if status == reqwest::StatusCode::NOT_FOUND {
+                Ok(false)
+            } else if status.is_success() {
+                Ok(true)
+            } else {
+                let body_text = resp.text().await.unwrap_or_default();
+                Err(format_http_error(path, status, &body_text))
+            }
+        }
+        Err(err) => {
+            print_gateway_error(gateway, &err);
+            Err(format!("Failed to call {path}: {err}"))
+        }
+    }
+}
+
+async fn resolve_live_or_existing_id(
+    client: &reqwest::Client,
+    gateway: &str,
+    token: &str,
+    state: &ApplyState,
+    alias_or_id: &str,
+    resource_prefix: &str,
+) -> std::result::Result<Option<String>, String> {
+    if let Some(bound) = state.resolve_bound(alias_or_id) {
+        return Ok(Some(bound));
+    }
+    let candidate_path = format!("{resource_prefix}/{alias_or_id}");
+    if remote_exists(client, gateway, token, &candidate_path).await? {
+        Ok(Some(alias_or_id.to_string()))
+    } else {
+        Ok(None)
+    }
+}
+
+fn required_string_field(value: &serde_json::Value, field: &str) -> Result<String> {
+    value
+        .get(field)
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .with_context(|| format!("Missing string field '{field}' in response: {value}"))
+}
+
+fn entity_type_api_name(entity_type: BootstrapEntityType) -> &'static str {
+    match entity_type {
+        BootstrapEntityType::Federation => "federation",
+        BootstrapEntityType::Cooperative => "cooperative",
+        BootstrapEntityType::Community => "community",
+        BootstrapEntityType::Individual => "individual",
+    }
+}
+
+fn structure_kind_api_name(kind: StructureKind) -> &'static str {
+    match kind {
+        StructureKind::Committee => "committee",
+        StructureKind::WorkingGroup => "working_group",
+        StructureKind::Team => "team",
+        StructureKind::Office => "office",
+    }
+}
+
+fn activity_kind_api_name(kind: ActivityKind) -> &'static str {
+    match kind {
+        ActivityKind::Event => "event",
+        ActivityKind::Program => "program",
+        ActivityKind::Project => "project",
+        ActivityKind::Initiative => "initiative",
+    }
+}
+
+fn program_kind_api_name(kind: &ProgramKind) -> String {
+    match kind {
+        ProgramKind::Cycle => "cycle".to_string(),
+        ProgramKind::Campaign => "campaign".to_string(),
+        ProgramKind::Initiative => "initiative".to_string(),
+        ProgramKind::Series => "series".to_string(),
+        ProgramKind::Custom(name) => name.clone(),
+    }
+}
+
+fn format_http_error(path: &str, status: reqwest::StatusCode, body: &str) -> String {
+    print_http_error(path, status, body);
+    if let Ok(json_body) = serde_json::from_str::<serde_json::Value>(body) {
+        if let Some(message) = json_body.get("message").or_else(|| json_body.get("error")) {
+            if let Some(text) = message.as_str() {
+                return format!("HTTP {status} on {path}: {text}");
+            }
+        }
+    }
+    if body.is_empty() {
+        format!("HTTP {status} on {path}")
+    } else {
+        format!("HTTP {status} on {path}: {body}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn nycn_package_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../..")
+            .join("institutions/nycn")
+    }
+
+    #[test]
+    fn validates_nycn_package() {
+        let report = validate_package(&nycn_package_dir()).expect("package should validate");
+        assert!(report.charter_valid);
+        assert_eq!(report.seed_count, 7);
+    }
+
+    #[test]
+    fn builds_nycn_plan_with_expected_core_ops() {
+        let report = build_plan_report(&nycn_package_dir()).expect("plan should build");
+        assert!(report.plan.operations.len() >= 10);
+        assert_eq!(report.preview.entity_count, 2);
+        assert_eq!(report.preview.governance_domain_count, 2);
+        assert_eq!(report.preview.structure_count, 7);
+        assert_eq!(report.preview.program_count, 1);
+        assert_eq!(report.preview.activity_count, 1);
+        assert_eq!(report.preview.milestone_count, 4);
+        assert_eq!(report.preview.deferred_role_assignment_count, 4);
+        assert!(report.preview.live_apply_supported);
+    }
+
+    #[test]
+    fn validate_seed_graph_blocks_missing_governance_domain_declaration() {
+        let seeds = vec![BootstrapSeedManifest::Entity(
+            icn_governance::EntitySeedManifest {
+                seed_version: "draft-0".to_string(),
+                entity: icn_governance::BootstrapEntityRecord {
+                    id: "entity-a".to_string(),
+                    entity_type: BootstrapEntityType::Cooperative,
+                    parent_entity_id: None,
+                    display_name: "Entity A".to_string(),
+                    governance_domain_id: "domain-a".to_string(),
+                    charter_ref: None,
+                    operating_purpose: None,
+                },
+                notes: vec![],
+            },
+        )];
+        let (_, blockers) = validate_seed_graph(&seeds);
+        assert!(blockers
+            .iter()
+            .any(|b| b.contains("no governance-domain-seed declares it")));
+    }
+
+    #[test]
+    fn plan_orders_domain_provisioning_before_program_creation() {
+        let report = build_plan_report(&nycn_package_dir()).expect("plan should build");
+        let domain_pos = report
+            .plan
+            .operations
+            .iter()
+            .position(|op| matches!(op, BootstrapOperation::ProvisionGovernanceDomain { id, .. } if id == "nycn-organizers-gov"))
+            .expect("domain provision step should exist");
+        let program_pos = report
+            .plan
+            .operations
+            .iter()
+            .position(|op| matches!(op, BootstrapOperation::CreateProgram { id, .. } if id == "summit-cycle-2026"))
+            .expect("program create step should exist");
+        assert!(domain_pos < program_pos);
+    }
+
+    #[test]
+    fn program_kind_custom_maps_to_custom_string() {
+        let kind = ProgramKind::Custom("annual-summit".to_string());
+        assert_eq!(program_kind_api_name(&kind), "annual-summit");
+    }
+
+    #[tokio::test]
+    async fn activity_with_linked_structures_attempts_live_write() {
+        let op = BootstrapOperation::CreateActivity {
+            id: "act-a".to_string(),
+            parent_entity_id: "entity-a".to_string(),
+            kind: ActivityKind::Event,
+            name: "Summit".to_string(),
+            description: None,
+            linked_structures: vec!["committee-a".to_string()],
+            parent_program_id: Some("program-a".to_string()),
+        };
+        let mut state = ApplyState::default();
+        state.bind("program-a", "program-live");
+        state.bind("committee-a", "structure-live");
+        let outcome = apply_operation(
+            &op,
+            "http://localhost:8080",
+            &reqwest::Client::new(),
+            &BootstrapAuthContext {
+                token: "token".to_string(),
+                subject_did: "did:icn:testsubject".to_string(),
+            },
+            &mut state,
+        )
+        .await;
+        match outcome {
+            ApplyOutcome::Failed(reason) => {
+                assert!(reason.contains("/v1/gov/entities/entity-a/activities"));
+            }
+            _ => panic!("activity should attempt a live write when prerequisites resolve"),
+        }
+    }
+
+    #[tokio::test]
+    async fn governance_domain_without_members_is_unsupported() {
+        let op = BootstrapOperation::ProvisionGovernanceDomain {
+            id: "domain-a".to_string(),
+            name: "Domain A".to_string(),
+            profile: "cooperative_default".to_string(),
+            quorum_percent: 50,
+            approval_percent: 50,
+            voting_period_days: 7,
+            members: vec![],
+            decision_mode: None,
+            max_objections: None,
+        };
+        let outcome = apply_operation(
+            &op,
+            "http://localhost:8080",
+            &reqwest::Client::new(),
+            &BootstrapAuthContext {
+                token: "token".to_string(),
+                subject_did: "did:icn:testsubject".to_string(),
+            },
+            &mut ApplyState::default(),
+        )
+        .await;
+        match outcome {
+            ApplyOutcome::Unsupported(reason) => {
+                assert!(reason.contains("no usable members"));
+            }
+            _ => panic!("domain provisioning should be unsupported without members"),
+        }
+    }
+
+    #[test]
+    fn apply_state_resolves_alias_bindings() {
+        let mut state = ApplyState::default();
+        state.bind("program-a", "prog-live-1");
+        assert_eq!(state.resolve("program-a"), "prog-live-1");
+        assert_eq!(state.resolve("already-live"), "already-live");
+    }
+
+    #[test]
+    fn resolves_bootstrap_subject_member_placeholder() {
+        let members = vec![
+            BOOTSTRAP_SUBJECT_DID_PLACEHOLDER.to_string(),
+            "did:icn:static-member".to_string(),
+        ];
+        let resolved = resolve_bootstrap_member_dids(&members, "did:icn:bootstrap-member");
+        assert_eq!(
+            resolved,
+            vec![
+                "did:icn:bootstrap-member".to_string(),
+                "did:icn:static-member".to_string()
+            ]
+        );
+    }
+}

--- a/icn/bins/icnctl/src/institution_bootstrap.rs
+++ b/icn/bins/icnctl/src/institution_bootstrap.rs
@@ -1411,14 +1411,20 @@ mod tests {
 
     #[test]
     fn validates_nycn_package() {
-        let report = validate_package(&nycn_package_dir()).expect("package should validate");
+        let report = match validate_package(&nycn_package_dir()) {
+            Ok(report) => report,
+            Err(err) => panic!("package should validate: {err}"),
+        };
         assert!(report.charter_valid);
         assert_eq!(report.seed_count, 7);
     }
 
     #[test]
     fn builds_nycn_plan_with_expected_core_ops() {
-        let report = build_plan_report(&nycn_package_dir()).expect("plan should build");
+        let report = match build_plan_report(&nycn_package_dir()) {
+            Ok(report) => report,
+            Err(err) => panic!("plan should build: {err}"),
+        };
         assert!(report.plan.operations.len() >= 10);
         assert_eq!(report.preview.entity_count, 2);
         assert_eq!(report.preview.governance_domain_count, 2);
@@ -1455,19 +1461,22 @@ mod tests {
 
     #[test]
     fn plan_orders_domain_provisioning_before_program_creation() {
-        let report = build_plan_report(&nycn_package_dir()).expect("plan should build");
+        let report = match build_plan_report(&nycn_package_dir()) {
+            Ok(report) => report,
+            Err(err) => panic!("plan should build: {err}"),
+        };
         let domain_pos = report
             .plan
             .operations
             .iter()
             .position(|op| matches!(op, BootstrapOperation::ProvisionGovernanceDomain { id, .. } if id == "nycn-organizers-gov"))
-            .expect("domain provision step should exist");
+            .unwrap_or_else(|| panic!("domain provision step should exist"));
         let program_pos = report
             .plan
             .operations
             .iter()
             .position(|op| matches!(op, BootstrapOperation::CreateProgram { id, .. } if id == "summit-cycle-2026"))
-            .expect("program create step should exist");
+            .unwrap_or_else(|| panic!("program create step should exist"));
         assert!(domain_pos < program_pos);
     }
 

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -1,6 +1,8 @@
 //! icnctl - CLI for managing ICNd
 #![deny(clippy::unwrap_used, clippy::expect_used)]
 
+mod institution_bootstrap;
+
 use anyhow::{bail, Context, Result};
 use rust_i18n::t;
 
@@ -87,6 +89,10 @@ enum Commands {
     /// Governance operations (domains, proposals, votes)
     #[command(subcommand)]
     Gov(GovCommands),
+
+    /// Institution package bootstrap operations
+    #[command(subcommand)]
+    Institution(institution_bootstrap::InstitutionCommands),
 
     /// Backup data directory
     Backup {
@@ -2156,6 +2162,10 @@ async fn main() -> Result<()> {
         }
 
         Commands::Gov(gov_cmd) => handle_gov_command(gov_cmd, &data_dir, &args.endpoint).await?,
+
+        Commands::Institution(institution_cmd) => {
+            institution_bootstrap::handle_institution_command(institution_cmd, &data_dir).await?
+        }
 
         Commands::Snapshot(snapshot_cmd) => handle_snapshot_command(snapshot_cmd, &data_dir)?,
 

--- a/icn/crates/icn-compute/src/actor/lifecycle.rs
+++ b/icn/crates/icn-compute/src/actor/lifecycle.rs
@@ -1357,6 +1357,20 @@ impl ComputeActor {
         Ok(())
     }
 
+    fn required_commons_credits(&self, task: &ComputeTask) -> Result<i64, ComputeError> {
+        if let Some(ref policy_cb) = self.commons_required_credits_callback {
+            let required = policy_cb(task).map_err(ComputeError::PolicyViolation)?;
+            if required < 1 {
+                return Err(ComputeError::PolicyViolation(format!(
+                    "commons required credits must be >= 1, got {required}"
+                )));
+            }
+            return Ok(required);
+        }
+
+        Ok(crate::cost::compute_credits_required(task))
+    }
+
     /// Handle task submission (validation and broadcasting)
     pub(super) async fn handle_submit(&self, task: ComputeTask) -> Result<TaskHash, ComputeError> {
         tracing::debug!(
@@ -1435,7 +1449,7 @@ impl ComputeActor {
         if task.scope == icn_kernel_api::ScopeLevel::Commons {
             if let Some(ref balance_cb) = self.balance_callback {
                 let balance = balance_cb(&task.submitter);
-                let required = crate::cost::compute_credits_required(&task);
+                let required = self.required_commons_credits(&task)?;
                 if balance < required {
                     tracing::warn!(
                         task_id = %task.id,
@@ -1460,7 +1474,7 @@ impl ComputeActor {
         // This is not race-free correctness mode — configure the callback for correct enforcement.
         if task.scope == icn_kernel_api::ScopeLevel::Commons {
             if let Some(ref reserve_cb) = self.commons_reserve_callback {
-                let required = crate::cost::compute_credits_required(&task);
+                let required = self.required_commons_credits(&task)?;
                 match reserve_cb(CommonsReserveRequest {
                     consumer: task.submitter.clone(),
                     amount: required,

--- a/icn/crates/icn-compute/src/actor/lifecycle.rs
+++ b/icn/crates/icn-compute/src/actor/lifecycle.rs
@@ -1439,6 +1439,14 @@ impl ComputeActor {
             }
         }
 
+        let required_commons_credits = if task.scope == icn_kernel_api::ScopeLevel::Commons
+            && (self.balance_callback.is_some() || self.commons_reserve_callback.is_some())
+        {
+            Some(self.required_commons_credits(&task)?)
+        } else {
+            None
+        };
+
         // Commons credit floor check (#1397)
         // Prevents zero-balance submitters from consuming commons compute.
         // Applies only to Commons-scoped tasks; Local/Cell tasks are unaffected.
@@ -1449,7 +1457,8 @@ impl ComputeActor {
         if task.scope == icn_kernel_api::ScopeLevel::Commons {
             if let Some(ref balance_cb) = self.balance_callback {
                 let balance = balance_cb(&task.submitter);
-                let required = self.required_commons_credits(&task)?;
+                let required = required_commons_credits
+                    .unwrap_or_else(|| crate::cost::compute_credits_required(&task));
                 if balance < required {
                     tracing::warn!(
                         task_id = %task.id,
@@ -1474,7 +1483,8 @@ impl ComputeActor {
         // This is not race-free correctness mode — configure the callback for correct enforcement.
         if task.scope == icn_kernel_api::ScopeLevel::Commons {
             if let Some(ref reserve_cb) = self.commons_reserve_callback {
-                let required = self.required_commons_credits(&task)?;
+                let required = required_commons_credits
+                    .unwrap_or_else(|| crate::cost::compute_credits_required(&task));
                 match reserve_cb(CommonsReserveRequest {
                     consumer: task.submitter.clone(),
                     amount: required,

--- a/icn/crates/icn-compute/src/actor/mod.rs
+++ b/icn/crates/icn-compute/src/actor/mod.rs
@@ -15,9 +15,10 @@ mod types;
 pub use handle::ComputeHandle;
 pub use types::{
     BalanceCallback, CommonsPaymentRequest, CommonsReleaseCallback, CommonsReleaseRequest,
-    CommonsReserveCallback, CommonsReserveRequest, CommonsSettlementCallback, ComputeEvent,
-    EventCallback, FederationClearingCallback, FederationClearingNotification, LocalityCallback,
-    PaymentCallback, PaymentRequest, SendCallback, TrustCallback,
+    CommonsRequiredCreditsCallback, CommonsReserveCallback, CommonsReserveRequest,
+    CommonsSettlementCallback, ComputeEvent, EventCallback, FederationClearingCallback,
+    FederationClearingNotification, LocalityCallback, PaymentCallback, PaymentRequest,
+    SendCallback, TrustCallback,
 };
 
 // Internal imports from submodules
@@ -119,6 +120,10 @@ pub struct ComputeActor {
     /// Callback for querying submitter ledger balances (E7 - #1134).
     /// Required for credit ceiling enforcement via `CommonsPoolPolicy::validate_submitter_credit`.
     balance_callback: Option<BalanceCallback>,
+    /// Policy-owned deterministic credit requirement contract for commons admission.
+    /// When configured, `handle_submit()` uses this callback instead of the local
+    /// `cost::compute_credits_required` fallback.
+    commons_required_credits_callback: Option<CommonsRequiredCreditsCallback>,
     /// Callback for settling commons credits on task completion (E7 - #948).
     /// Fires when a commons-scope task completes successfully.
     /// App-layer implementation must reconcile against the reservation established
@@ -191,6 +196,7 @@ impl ComputeActor {
             stale_participant_max_age: None,
             commons_pool_policy: None,
             balance_callback: None,
+            commons_required_credits_callback: None,
             commons_settlement_callback: None,
             commons_reserve_callback: None,
             commons_release_callback: None,
@@ -258,10 +264,19 @@ impl ComputeActor {
         self.balance_callback = Some(cb);
     }
 
+    /// Set deterministic commons credit requirement policy callback.
+    ///
+    /// This is the preferred seam for policy-owned cost meaning. Compute uses
+    /// the returned requirement mechanically at submit time and for reservation.
+    /// When not set, compute falls back to `cost::compute_credits_required`.
+    pub fn set_commons_required_credits_callback(&mut self, cb: CommonsRequiredCreditsCallback) {
+        self.commons_required_credits_callback = Some(cb);
+    }
+
     /// Set the authoritative commons credit reservation callback (#1404).
     ///
     /// When set, `handle_submit()` calls this after the advisory balance floor check
-    /// to atomically hold `compute_credits_required(&task)` credits. If the callee
+    /// to atomically hold the policy-determined required credits. If the callee
     /// returns `Err`, the task is rejected with `InsufficientCommonsCredits`.
     ///
     /// **Must be set alongside `set_commons_release_callback`** for complete two-phase

--- a/icn/crates/icn-compute/src/actor/types.rs
+++ b/icn/crates/icn-compute/src/actor/types.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use crate::scheduler::NodeCapacity;
-use crate::types::{ComputeMessage, ComputeResult, ExecutorCapability, TaskHash};
+use crate::types::{ComputeMessage, ComputeResult, ComputeTask, ExecutorCapability, TaskHash};
 
 /// Information about an available executor
 ///
@@ -165,6 +165,17 @@ pub type LocalityCallback = Arc<dyn Fn(&str) -> crate::scheduler::LocalityContex
 /// Negative balances indicate debt. Used by `CommonsPoolPolicy::validate_submitter_credit`.
 pub type BalanceCallback = Arc<dyn Fn(&str) -> i64 + Send + Sync>;
 
+/// Deterministic commons credit requirement contract for admission checks.
+///
+/// This callback lets app/policy layers own the "how many credits are required"
+/// meaning while compute remains the mechanical enforcer at submit time.
+///
+/// Return:
+/// - `Ok(required_credits)` for a valid requirement (`>= 1`)
+/// - `Err(reason)` when the policy path cannot produce a deterministic value
+pub type CommonsRequiredCreditsCallback =
+    Arc<dyn Fn(&ComputeTask) -> Result<i64, String> + Send + Sync>;
+
 /// Commons credit settlement request (E7 - #948).
 ///
 /// Fired by the compute actor when a commons-scope task completes successfully.
@@ -210,7 +221,7 @@ pub type CommonsSettlementCallback = Arc<dyn Fn(CommonsPaymentRequest) + Send + 
 pub struct CommonsReserveRequest {
     /// DID of the consumer (submitter — credits are held from their balance).
     pub consumer: String,
-    /// Credits to reserve. Computed by `cost::compute_credits_required(&task)`.
+    /// Credits to reserve. Computed via the configured commons requirement contract.
     pub amount: i64,
     /// Task ID used as the reservation key. Unique per submission.
     pub task_id: String,

--- a/icn/crates/icn-compute/src/lib.rs
+++ b/icn/crates/icn-compute/src/lib.rs
@@ -48,10 +48,10 @@ mod wasm_registry;
 
 pub use actor::{
     BalanceCallback, CommonsPaymentRequest, CommonsReleaseCallback, CommonsReleaseRequest,
-    CommonsReserveCallback, CommonsReserveRequest, CommonsSettlementCallback, ComputeActor,
-    ComputeEvent, ComputeHandle, EventCallback, FederationClearingCallback,
-    FederationClearingNotification, LocalityCallback, PaymentCallback, PaymentRequest,
-    SendCallback, TrustCallback,
+    CommonsRequiredCreditsCallback, CommonsReserveCallback, CommonsReserveRequest,
+    CommonsSettlementCallback, ComputeActor, ComputeEvent, ComputeHandle, EventCallback,
+    FederationClearingCallback, FederationClearingNotification, LocalityCallback, PaymentCallback,
+    PaymentRequest, SendCallback, TrustCallback,
 };
 pub use actor_model::{
     ActorCheckpoint, ActorEvent, ActorId, ActorMode, ActorRuntimeState, MigrationDecision,

--- a/icn/crates/icn-compute/tests/commons_integration.rs
+++ b/icn/crates/icn-compute/tests/commons_integration.rs
@@ -281,7 +281,9 @@ async fn test_scheduling_uses_policy_required_credit_callback() {
     actor.set_commons_required_credits_callback(policy_required.clone());
     let handle = actor.spawn();
 
-    let denied = handle.submit(make_commons_task("did:icn:insufficient", 500)).await;
+    let denied = handle
+        .submit(make_commons_task("did:icn:insufficient", 500))
+        .await;
     assert!(
         matches!(
             denied,
@@ -298,7 +300,9 @@ async fn test_scheduling_uses_policy_required_credit_callback() {
     actor2.set_balance_callback(enough_balance);
     actor2.set_commons_required_credits_callback(policy_required);
     let handle2 = actor2.spawn();
-    let accepted = handle2.submit(make_commons_task("did:icn:sufficient", 500)).await;
+    let accepted = handle2
+        .submit(make_commons_task("did:icn:sufficient", 500))
+        .await;
     assert!(
         accepted.is_ok(),
         "submitter with callback-required balance should pass; got {accepted:?}"

--- a/icn/crates/icn-compute/tests/commons_integration.rs
+++ b/icn/crates/icn-compute/tests/commons_integration.rs
@@ -234,6 +234,142 @@ async fn test_scheduling_enforces_credits() {
     );
 }
 
+/// Test 5b: Custom policy requirement callback drives commons admission threshold.
+#[tokio::test]
+async fn test_scheduling_uses_policy_required_credit_callback() {
+    use icn_compute::{
+        BalanceCallback, CommonsRequiredCreditsCallback, ComputeError, ComputeTask,
+        DeterminismClass, ExecutorCapability, FuelLimit, PrivacyClass, TaskCode, TaskPriority,
+    };
+
+    fn make_commons_task(submitter: &str, fuel_limit: u64) -> ComputeTask {
+        ComputeTask {
+            id: "test-policy-required".into(),
+            submitter: submitter.into(),
+            coop_id: None,
+            code: TaskCode::Ccl("(define x 1)".into()),
+            inputs: vec![],
+            fuel_limit: FuelLimit(fuel_limit),
+            required_capabilities: vec![ExecutorCapability::Ccl],
+            priority: TaskPriority::Normal,
+            created_at: 1000,
+            deadline: None,
+            payment_rate: None,
+            payment_currency: None,
+            resource_profile: None,
+            actor_mode: None,
+            placement_constraints: None,
+            federation_constraints: None,
+            estimated_value: None,
+            verification: None,
+            inputs_hash: None,
+            policy_hash: None,
+            determinism_class: DeterminismClass::default(),
+            privacy_class: PrivacyClass::default(),
+            storage_class: None,
+            data_locality: None,
+            scope: icn_kernel_api::ScopeLevel::Commons,
+        }
+    }
+
+    // Fuel-limit formula would require only 1 here; callback forces 5.
+    let policy_required: CommonsRequiredCreditsCallback = Arc::new(|_task| Ok(5));
+    let trust_cb: TrustCallback = Arc::new(|_| 1.0);
+    let low_balance: BalanceCallback = Arc::new(|_| 4);
+    let mut actor = ComputeActor::new("did:icn:scheduler".into(), trust_cb.clone());
+    actor.set_balance_callback(low_balance);
+    actor.set_commons_required_credits_callback(policy_required.clone());
+    let handle = actor.spawn();
+
+    let denied = handle.submit(make_commons_task("did:icn:insufficient", 500)).await;
+    assert!(
+        matches!(
+            denied,
+            Err(ComputeError::InsufficientCommonsCredits {
+                balance: 4,
+                required: 5
+            })
+        ),
+        "policy-required threshold should be enforced; got {denied:?}"
+    );
+
+    let enough_balance: BalanceCallback = Arc::new(|_| 5);
+    let mut actor2 = ComputeActor::new("did:icn:scheduler".into(), trust_cb);
+    actor2.set_balance_callback(enough_balance);
+    actor2.set_commons_required_credits_callback(policy_required);
+    let handle2 = actor2.spawn();
+    let accepted = handle2.submit(make_commons_task("did:icn:sufficient", 500)).await;
+    assert!(
+        accepted.is_ok(),
+        "submitter with callback-required balance should pass; got {accepted:?}"
+    );
+}
+
+/// Test 5c: Requirement callback failure/malformed outputs are explicit.
+#[tokio::test]
+async fn test_scheduling_rejects_invalid_policy_requirement_path() {
+    use icn_compute::{
+        BalanceCallback, CommonsRequiredCreditsCallback, ComputeError, ComputeTask,
+        DeterminismClass, ExecutorCapability, FuelLimit, PrivacyClass, TaskCode, TaskPriority,
+    };
+
+    fn make_commons_task() -> ComputeTask {
+        ComputeTask {
+            id: "test-policy-invalid".into(),
+            submitter: "did:icn:submitter".into(),
+            coop_id: None,
+            code: TaskCode::Ccl("(define x 1)".into()),
+            inputs: vec![],
+            fuel_limit: FuelLimit(1_000),
+            required_capabilities: vec![ExecutorCapability::Ccl],
+            priority: TaskPriority::Normal,
+            created_at: 1000,
+            deadline: None,
+            payment_rate: None,
+            payment_currency: None,
+            resource_profile: None,
+            actor_mode: None,
+            placement_constraints: None,
+            federation_constraints: None,
+            estimated_value: None,
+            verification: None,
+            inputs_hash: None,
+            policy_hash: None,
+            determinism_class: DeterminismClass::default(),
+            privacy_class: PrivacyClass::default(),
+            storage_class: None,
+            data_locality: None,
+            scope: icn_kernel_api::ScopeLevel::Commons,
+        }
+    }
+
+    let trust_cb: TrustCallback = Arc::new(|_| 1.0);
+    let plenty: BalanceCallback = Arc::new(|_| 100);
+
+    let erring_cb: CommonsRequiredCreditsCallback =
+        Arc::new(|_task| Err("policy unavailable".to_string()));
+    let mut actor = ComputeActor::new("did:icn:scheduler".into(), trust_cb.clone());
+    actor.set_balance_callback(plenty.clone());
+    actor.set_commons_required_credits_callback(erring_cb);
+    let handle = actor.spawn();
+    let result = handle.submit(make_commons_task()).await;
+    assert!(
+        matches!(result, Err(ComputeError::PolicyViolation(ref msg)) if msg.contains("policy unavailable")),
+        "policy callback errors should surface explicitly; got {result:?}"
+    );
+
+    let malformed_cb: CommonsRequiredCreditsCallback = Arc::new(|_task| Ok(0));
+    let mut actor2 = ComputeActor::new("did:icn:scheduler".into(), trust_cb);
+    actor2.set_balance_callback(plenty);
+    actor2.set_commons_required_credits_callback(malformed_cb);
+    let handle2 = actor2.spawn();
+    let result2 = handle2.submit(make_commons_task()).await;
+    assert!(
+        matches!(result2, Err(ComputeError::PolicyViolation(ref msg)) if msg.contains("must be >=")),
+        "malformed requirements should reject explicitly; got {result2:?}"
+    );
+}
+
 /// Test 6: Receipt-backed earn entries produce distinct hashes (replay protection).
 #[test]
 fn test_receipt_backed_earn_entries_are_distinct() {

--- a/icn/crates/icn-core/tests/receipt_chain_vertical_slice.rs
+++ b/icn/crates/icn-core/tests/receipt_chain_vertical_slice.rs
@@ -16,11 +16,85 @@ use icn_governance::{
     AllocationOption, GovernanceDomainId, GovernanceParams, MembershipConfig, ProposalId,
     ProposalPayload, ProposalScope, StaticMembershipResolver, VoteChoice,
 };
+use icn_governance_actor::receipt_backend::GovernanceReceiptBackend;
 use icn_governance_actor::{GovernanceActor, GovernanceCommand, GovernanceConfigLite};
 use icn_identity::KeyPair;
 use icn_kernel_api::effects::{KernelEffect, TreasuryEffect};
+use icn_kernel_api::{AllocationReceipt, CanonicalReceipt, Hash};
 use icn_store::SledStore;
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+
+#[derive(Default)]
+struct TestReceiptBackend {
+    governance_by_proposal: Mutex<HashMap<String, icn_governance::GovernanceDecisionReceipt>>,
+    governance_by_decision: Mutex<HashMap<Hash, icn_governance::GovernanceDecisionReceipt>>,
+    allocations_by_decision: Mutex<HashMap<Hash, Vec<AllocationReceipt>>>,
+}
+
+impl GovernanceReceiptBackend for TestReceiptBackend {
+    fn put_governance(
+        &self,
+        receipt: &icn_governance::GovernanceDecisionReceipt,
+    ) -> Result<(), String> {
+        self.governance_by_proposal
+            .lock()
+            .map_err(|e| e.to_string())?
+            .insert(receipt.proposal_id.clone(), receipt.clone());
+        self.governance_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .insert(receipt.decision_hash, receipt.clone());
+        Ok(())
+    }
+
+    fn get_governance_by_proposal(
+        &self,
+        proposal_id: &str,
+    ) -> Result<Option<icn_governance::GovernanceDecisionReceipt>, String> {
+        Ok(self
+            .governance_by_proposal
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(proposal_id)
+            .cloned())
+    }
+
+    fn put_allocation(&self, receipt: &AllocationReceipt) -> Result<Hash, String> {
+        self.allocations_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .entry(receipt.decision_hash)
+            .or_default()
+            .push(receipt.clone());
+        Ok(receipt.canonical_hash())
+    }
+
+    fn get_governance_by_decision(
+        &self,
+        decision_hash: &Hash,
+    ) -> Result<Option<icn_governance::GovernanceDecisionReceipt>, String> {
+        Ok(self
+            .governance_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(decision_hash)
+            .cloned())
+    }
+
+    fn list_allocations_by_decision(
+        &self,
+        decision_hash: &Hash,
+    ) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(self
+            .allocations_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(decision_hash)
+            .cloned()
+            .unwrap_or_default())
+    }
+}
 
 /// Spawn a minimal single-member GovernanceActor wired to an EventBus.
 async fn make_actor() -> Result<(
@@ -64,6 +138,9 @@ async fn make_actor() -> Result<(
         None,
     )
     .await?;
+    actor
+        .install_receipt_store(Arc::new(TestReceiptBackend::default()))
+        .await;
 
     let domain_id = GovernanceDomainId::new("vertical-slice-domain");
     actor

--- a/icn/crates/icn-core/tests/vertical_slice_integration.rs
+++ b/icn/crates/icn-core/tests/vertical_slice_integration.rs
@@ -21,9 +21,11 @@ use icn_governance::{
     ProofOutcome, ProposalId, ProposalPayload, ProposalScope, StaticMembershipResolver, VoteChoice,
     VoteTally,
 };
+use icn_governance_actor::receipt_backend::GovernanceReceiptBackend;
 use icn_governance_actor::{GovernanceActor, GovernanceCommand, GovernanceConfigLite};
 use icn_identity::KeyPair;
 use icn_kernel_api::receipts::CanonicalReceipt;
+use icn_kernel_api::{AllocationReceipt, Hash};
 use icn_ledger::asset_types::{AssetClass, AssetCondition, AssetMetadata, AssetRegistry};
 use icn_ledger::create_budget_allocation;
 use icn_ledger::entry::JournalEntryBuilder;
@@ -33,7 +35,8 @@ use icn_membership_app::coop_core::actor::CoopActor;
 use icn_membership_app::coop_core::handle::CoopHandle;
 use icn_membership_app::coop_core::types::{CoopType, MemberRole};
 use icn_store::{SledStore, Store};
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 use tokio::sync::RwLock;
 use tracing::info;
 
@@ -60,6 +63,74 @@ impl TestIdentity {
 impl std::fmt::Display for TestIdentity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}({})", self.name, &self.did().to_string()[..16])
+    }
+}
+
+#[derive(Default)]
+struct TestReceiptBackend {
+    governance_by_proposal: Mutex<HashMap<String, GovernanceDecisionReceipt>>,
+    governance_by_decision: Mutex<HashMap<Hash, GovernanceDecisionReceipt>>,
+    allocations_by_decision: Mutex<HashMap<Hash, Vec<AllocationReceipt>>>,
+}
+
+impl GovernanceReceiptBackend for TestReceiptBackend {
+    fn put_governance(&self, receipt: &GovernanceDecisionReceipt) -> Result<(), String> {
+        self.governance_by_proposal
+            .lock()
+            .map_err(|e| e.to_string())?
+            .insert(receipt.proposal_id.clone(), receipt.clone());
+        self.governance_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .insert(receipt.decision_hash, receipt.clone());
+        Ok(())
+    }
+
+    fn get_governance_by_proposal(
+        &self,
+        proposal_id: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(self
+            .governance_by_proposal
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(proposal_id)
+            .cloned())
+    }
+
+    fn put_allocation(&self, receipt: &AllocationReceipt) -> Result<Hash, String> {
+        self.allocations_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .entry(receipt.decision_hash)
+            .or_default()
+            .push(receipt.clone());
+        Ok(receipt.canonical_hash())
+    }
+
+    fn get_governance_by_decision(
+        &self,
+        decision_hash: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(self
+            .governance_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(decision_hash)
+            .cloned())
+    }
+
+    fn list_allocations_by_decision(
+        &self,
+        decision_hash: &Hash,
+    ) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(self
+            .allocations_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(decision_hash)
+            .cloned()
+            .unwrap_or_default())
     }
 }
 
@@ -305,6 +376,9 @@ async fn test_tool_library_cooperative_vertical_slice() -> Result<()> {
         None, // no signing key
     )
     .await?;
+    gov_handle
+        .install_receipt_store(Arc::new(TestReceiptBackend::default()))
+        .await;
 
     // Create governance domain for the cooperative
     let domain_id = GovernanceDomainId::new("tool-library-gov");

--- a/icn/crates/icn-gateway/tests/e2e_create_delegation_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_create_delegation_gate.rs
@@ -35,8 +35,8 @@ use actix_web::{test, web, App};
 use actix_web_httpauth::middleware::HttpAuthentication;
 use icn_gateway::{api, auth::AuthManager, middleware::jwt_auth, rate_limit::IpRateLimiter};
 use icn_governance::{
-    GovernanceDomainId, GovernanceParams, MembershipConfig, MembershipSource, ProposalId,
-    ProposalPayload, ProposalScope,
+    GovernanceDecisionReceipt, GovernanceDomainId, GovernanceParams, MembershipConfig,
+    MembershipSource, ProposalId, ProposalPayload, ProposalScope,
 };
 use icn_governance_actor::{
     events::NoopEventEmitter,
@@ -44,11 +44,85 @@ use icn_governance_actor::{
         GovernanceContext, GovernanceEffect, ProposalAcceptedHook, SuspensionChecker,
     },
     manager::GovernanceManager,
+    receipt_backend::GovernanceReceiptBackend,
 };
 use icn_identity::{Did, IdentityBundle, KeyPair};
+use icn_kernel_api::receipts::CanonicalReceipt;
+use icn_kernel_api::{AllocationReceipt, Hash};
 use serde_json::{json, Value};
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{Arc, Mutex},
+};
 use tokio::sync::RwLock;
+
+#[derive(Default)]
+struct TestReceiptBackend {
+    governance_by_proposal: Mutex<HashMap<String, GovernanceDecisionReceipt>>,
+    governance_by_decision: Mutex<HashMap<Hash, GovernanceDecisionReceipt>>,
+    allocations_by_decision: Mutex<HashMap<Hash, Vec<AllocationReceipt>>>,
+}
+
+impl GovernanceReceiptBackend for TestReceiptBackend {
+    fn put_governance(&self, receipt: &GovernanceDecisionReceipt) -> Result<(), String> {
+        self.governance_by_proposal
+            .lock()
+            .map_err(|e| e.to_string())?
+            .insert(receipt.proposal_id.clone(), receipt.clone());
+        self.governance_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .insert(receipt.decision_hash, receipt.clone());
+        Ok(())
+    }
+
+    fn get_governance_by_proposal(
+        &self,
+        proposal_id: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(self
+            .governance_by_proposal
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(proposal_id)
+            .cloned())
+    }
+
+    fn put_allocation(&self, receipt: &AllocationReceipt) -> Result<Hash, String> {
+        self.allocations_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .entry(receipt.decision_hash)
+            .or_default()
+            .push(receipt.clone());
+        Ok(receipt.canonical_hash())
+    }
+
+    fn get_governance_by_decision(
+        &self,
+        decision_hash: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(self
+            .governance_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(decision_hash)
+            .cloned())
+    }
+
+    fn list_allocations_by_decision(
+        &self,
+        decision_hash: &Hash,
+    ) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(self
+            .allocations_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(decision_hash)
+            .cloned()
+            .unwrap_or_default())
+    }
+}
 
 /// Auth helper: challenge → sign → JWT.
 async fn get_jwt(
@@ -183,7 +257,9 @@ async fn test_suspended_member_cannot_create_delegation() {
     let jwt_secret = b"delegation-gate-enforcement-sec32".to_vec();
     let auth_manager = Arc::new(AuthManager::new(jwt_secret));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
-    let governance_manager = Arc::new(GovernanceManager::new());
+    let governance_manager = Arc::new(
+        GovernanceManager::new().with_receipt_store(Arc::new(TestReceiptBackend::default())),
+    );
 
     let gov_ctx = GovernanceContext {
         manager: governance_manager.clone(),
@@ -414,7 +490,9 @@ async fn test_suspended_member_cannot_create_blanket_delegation() {
     let jwt_secret = b"blanket-gate-enforcement-sec--32".to_vec();
     let auth_manager = Arc::new(AuthManager::new(jwt_secret));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
-    let governance_manager = Arc::new(GovernanceManager::new());
+    let governance_manager = Arc::new(
+        GovernanceManager::new().with_receipt_store(Arc::new(TestReceiptBackend::default())),
+    );
 
     let gov_ctx = GovernanceContext {
         manager: governance_manager.clone(),

--- a/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
+++ b/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
@@ -32,20 +32,94 @@ use icn_gateway::{
     rate_limit::IpRateLimiter,
 };
 use icn_governance::{
-    sdis::SdisProposal, GovernanceDomainId, GovernanceParams, MembershipConfig, MembershipSource,
-    ProposalId, ProposalPayload, ProposalScope,
+    sdis::SdisProposal, GovernanceDecisionReceipt, GovernanceDomainId, GovernanceParams,
+    MembershipConfig, MembershipSource, ProposalId, ProposalPayload, ProposalScope,
 };
 use icn_governance_actor::{
     events::NoopEventEmitter,
     http::configure::{GovernanceContext, GovernanceEffect, ProposalAcceptedHook},
     manager::GovernanceManager,
+    receipt_backend::GovernanceReceiptBackend,
 };
 use icn_identity::{
     commons::{JurisdictionId, MembershipCapability, MembershipStatus},
     IdentityBundle, KeyPair,
 };
+use icn_kernel_api::receipts::CanonicalReceipt;
+use icn_kernel_api::{AllocationReceipt, Hash};
 use serde_json::{json, Value};
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+#[derive(Default)]
+struct TestReceiptBackend {
+    governance_by_proposal: Mutex<HashMap<String, GovernanceDecisionReceipt>>,
+    governance_by_decision: Mutex<HashMap<Hash, GovernanceDecisionReceipt>>,
+    allocations_by_decision: Mutex<HashMap<Hash, Vec<AllocationReceipt>>>,
+}
+
+impl GovernanceReceiptBackend for TestReceiptBackend {
+    fn put_governance(&self, receipt: &GovernanceDecisionReceipt) -> Result<(), String> {
+        self.governance_by_proposal
+            .lock()
+            .map_err(|e| e.to_string())?
+            .insert(receipt.proposal_id.clone(), receipt.clone());
+        self.governance_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .insert(receipt.decision_hash, receipt.clone());
+        Ok(())
+    }
+
+    fn get_governance_by_proposal(
+        &self,
+        proposal_id: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(self
+            .governance_by_proposal
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(proposal_id)
+            .cloned())
+    }
+
+    fn put_allocation(&self, receipt: &AllocationReceipt) -> Result<Hash, String> {
+        self.allocations_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .entry(receipt.decision_hash)
+            .or_default()
+            .push(receipt.clone());
+        Ok(receipt.canonical_hash())
+    }
+
+    fn get_governance_by_decision(
+        &self,
+        decision_hash: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(self
+            .governance_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(decision_hash)
+            .cloned())
+    }
+
+    fn list_allocations_by_decision(
+        &self,
+        decision_hash: &Hash,
+    ) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(self
+            .allocations_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(decision_hash)
+            .cloned()
+            .unwrap_or_default())
+    }
+}
 
 /// Auth helper: challenge → sign → JWT.
 async fn get_jwt(
@@ -223,7 +297,9 @@ async fn test_e2e_freeze_member_suspends_commons_affiliation() {
     let jwt_secret = b"e2e-institutional-flow-test-secret32".to_vec();
     let auth_manager = Arc::new(AuthManager::new(jwt_secret));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
-    let governance_manager = Arc::new(GovernanceManager::new());
+    let governance_manager = Arc::new(
+        GovernanceManager::new().with_receipt_store(Arc::new(TestReceiptBackend::default())),
+    );
 
     let gov_ctx = GovernanceContext {
         manager: governance_manager.clone(),
@@ -478,7 +554,9 @@ async fn test_e2e_unfreeze_member_reinstates_commons_affiliation() {
     let jwt_secret = b"e2e-unfreeze-flow-test-secret-min32".to_vec();
     let auth_manager = Arc::new(AuthManager::new(jwt_secret));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
-    let governance_manager = Arc::new(GovernanceManager::new());
+    let governance_manager = Arc::new(
+        GovernanceManager::new().with_receipt_store(Arc::new(TestReceiptBackend::default())),
+    );
 
     let gov_ctx = GovernanceContext {
         manager: governance_manager.clone(),
@@ -822,7 +900,9 @@ async fn test_e2e_appoint_steward_scoped_to_chartered_domain() {
     let jwt_secret = b"e2e-scoped-steward-test-secret-32bc".to_vec();
     let auth_manager = Arc::new(AuthManager::new(jwt_secret));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
-    let governance_manager = Arc::new(GovernanceManager::new());
+    let governance_manager = Arc::new(
+        GovernanceManager::new().with_receipt_store(Arc::new(TestReceiptBackend::default())),
+    );
     let sdis_svc: Arc<dyn SdisService> = Arc::new(InlineSdisService {
         commons: commons_handle.clone(),
     });

--- a/icn/crates/icn-gateway/tests/e2e_ledger_freeze_enforcement.rs
+++ b/icn/crates/icn-gateway/tests/e2e_ledger_freeze_enforcement.rs
@@ -32,20 +32,94 @@ use actix_web::{test, web, App};
 use actix_web_httpauth::middleware::HttpAuthentication;
 use icn_gateway::{api, auth::AuthManager, middleware::jwt_auth, rate_limit::IpRateLimiter};
 use icn_governance::{
-    GovernanceDomainId, GovernanceParams, MembershipConfig, MembershipSource, ProposalId,
-    ProposalPayload, ProposalScope,
+    GovernanceDecisionReceipt, GovernanceDomainId, GovernanceParams, MembershipConfig,
+    MembershipSource, ProposalId, ProposalPayload, ProposalScope,
 };
 use icn_governance_actor::{
     events::NoopEventEmitter,
     http::configure::{GovernanceContext, GovernanceEffect, ProposalAcceptedHook},
     manager::GovernanceManager,
+    receipt_backend::GovernanceReceiptBackend,
 };
 use icn_identity::{IdentityBundle, KeyPair};
+use icn_kernel_api::receipts::CanonicalReceipt;
+use icn_kernel_api::{AllocationReceipt, Hash};
 use icn_ledger::{entry::JournalEntryBuilder, Ledger};
 use icn_store::SledStore;
 use serde_json::{json, Value};
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 use tokio::sync::RwLock;
+
+#[derive(Default)]
+struct TestReceiptBackend {
+    governance_by_proposal: Mutex<HashMap<String, GovernanceDecisionReceipt>>,
+    governance_by_decision: Mutex<HashMap<Hash, GovernanceDecisionReceipt>>,
+    allocations_by_decision: Mutex<HashMap<Hash, Vec<AllocationReceipt>>>,
+}
+
+impl GovernanceReceiptBackend for TestReceiptBackend {
+    fn put_governance(&self, receipt: &GovernanceDecisionReceipt) -> Result<(), String> {
+        self.governance_by_proposal
+            .lock()
+            .map_err(|e| e.to_string())?
+            .insert(receipt.proposal_id.clone(), receipt.clone());
+        self.governance_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .insert(receipt.decision_hash, receipt.clone());
+        Ok(())
+    }
+
+    fn get_governance_by_proposal(
+        &self,
+        proposal_id: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(self
+            .governance_by_proposal
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(proposal_id)
+            .cloned())
+    }
+
+    fn put_allocation(&self, receipt: &AllocationReceipt) -> Result<Hash, String> {
+        self.allocations_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .entry(receipt.decision_hash)
+            .or_default()
+            .push(receipt.clone());
+        Ok(receipt.canonical_hash())
+    }
+
+    fn get_governance_by_decision(
+        &self,
+        decision_hash: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(self
+            .governance_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(decision_hash)
+            .cloned())
+    }
+
+    fn list_allocations_by_decision(
+        &self,
+        decision_hash: &Hash,
+    ) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(self
+            .allocations_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(decision_hash)
+            .cloned()
+            .unwrap_or_default())
+    }
+}
 
 /// Auth helper: challenge → sign → JWT.
 async fn get_jwt(
@@ -139,7 +213,9 @@ async fn test_freeze_member_blocks_ledger_entries_after_governance_acceptance() 
     let jwt_secret = b"ledger-freeze-enforcement-test-sec32".to_vec();
     let auth_manager = Arc::new(AuthManager::new(jwt_secret));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
-    let governance_manager = Arc::new(GovernanceManager::new());
+    let governance_manager = Arc::new(
+        GovernanceManager::new().with_receipt_store(Arc::new(TestReceiptBackend::default())),
+    );
 
     let gov_ctx = GovernanceContext {
         manager: governance_manager.clone(),

--- a/icn/crates/icn-gateway/tests/e2e_open_proposal_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_open_proposal_gate.rs
@@ -34,8 +34,8 @@ use actix_web::{test, web, App};
 use actix_web_httpauth::middleware::HttpAuthentication;
 use icn_gateway::{api, auth::AuthManager, middleware::jwt_auth, rate_limit::IpRateLimiter};
 use icn_governance::{
-    GovernanceDomainId, GovernanceParams, MembershipConfig, MembershipSource, ProposalId,
-    ProposalPayload, ProposalScope,
+    GovernanceDecisionReceipt, GovernanceDomainId, GovernanceParams, MembershipConfig,
+    MembershipSource, ProposalId, ProposalPayload, ProposalScope,
 };
 use icn_governance_actor::{
     events::NoopEventEmitter,
@@ -43,11 +43,85 @@ use icn_governance_actor::{
         GovernanceContext, GovernanceEffect, ProposalAcceptedHook, SuspensionChecker,
     },
     manager::GovernanceManager,
+    receipt_backend::GovernanceReceiptBackend,
 };
 use icn_identity::{Did, IdentityBundle, KeyPair};
+use icn_kernel_api::receipts::CanonicalReceipt;
+use icn_kernel_api::{AllocationReceipt, Hash};
 use serde_json::{json, Value};
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{Arc, Mutex},
+};
 use tokio::sync::RwLock;
+
+#[derive(Default)]
+struct TestReceiptBackend {
+    governance_by_proposal: Mutex<HashMap<String, GovernanceDecisionReceipt>>,
+    governance_by_decision: Mutex<HashMap<Hash, GovernanceDecisionReceipt>>,
+    allocations_by_decision: Mutex<HashMap<Hash, Vec<AllocationReceipt>>>,
+}
+
+impl GovernanceReceiptBackend for TestReceiptBackend {
+    fn put_governance(&self, receipt: &GovernanceDecisionReceipt) -> Result<(), String> {
+        self.governance_by_proposal
+            .lock()
+            .map_err(|e| e.to_string())?
+            .insert(receipt.proposal_id.clone(), receipt.clone());
+        self.governance_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .insert(receipt.decision_hash, receipt.clone());
+        Ok(())
+    }
+
+    fn get_governance_by_proposal(
+        &self,
+        proposal_id: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(self
+            .governance_by_proposal
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(proposal_id)
+            .cloned())
+    }
+
+    fn put_allocation(&self, receipt: &AllocationReceipt) -> Result<Hash, String> {
+        self.allocations_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .entry(receipt.decision_hash)
+            .or_default()
+            .push(receipt.clone());
+        Ok(receipt.canonical_hash())
+    }
+
+    fn get_governance_by_decision(
+        &self,
+        decision_hash: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(self
+            .governance_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(decision_hash)
+            .cloned())
+    }
+
+    fn list_allocations_by_decision(
+        &self,
+        decision_hash: &Hash,
+    ) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(self
+            .allocations_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(decision_hash)
+            .cloned()
+            .unwrap_or_default())
+    }
+}
 
 /// Auth helper: challenge → sign → JWT.
 async fn get_jwt(
@@ -124,7 +198,9 @@ async fn test_suspended_member_cannot_open_proposal() {
     let jwt_secret = b"open-proposal-gate-enforcement-sec32".to_vec();
     let auth_manager = Arc::new(AuthManager::new(jwt_secret));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
-    let governance_manager = Arc::new(GovernanceManager::new());
+    let governance_manager = Arc::new(
+        GovernanceManager::new().with_receipt_store(Arc::new(TestReceiptBackend::default())),
+    );
 
     let gov_ctx = GovernanceContext {
         manager: governance_manager.clone(),

--- a/icn/crates/icn-gateway/tests/e2e_proposal_submission_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_proposal_submission_gate.rs
@@ -32,8 +32,8 @@ use actix_web::{test, web, App};
 use actix_web_httpauth::middleware::HttpAuthentication;
 use icn_gateway::{api, auth::AuthManager, middleware::jwt_auth, rate_limit::IpRateLimiter};
 use icn_governance::{
-    GovernanceDomainId, GovernanceParams, MembershipConfig, MembershipSource, ProposalId,
-    ProposalPayload, ProposalScope,
+    GovernanceDecisionReceipt, GovernanceDomainId, GovernanceParams, MembershipConfig,
+    MembershipSource, ProposalId, ProposalPayload, ProposalScope,
 };
 use icn_governance_actor::{
     events::NoopEventEmitter,
@@ -41,11 +41,85 @@ use icn_governance_actor::{
         GovernanceContext, GovernanceEffect, ProposalAcceptedHook, SuspensionChecker,
     },
     manager::GovernanceManager,
+    receipt_backend::GovernanceReceiptBackend,
 };
 use icn_identity::{Did, IdentityBundle, KeyPair};
+use icn_kernel_api::receipts::CanonicalReceipt;
+use icn_kernel_api::{AllocationReceipt, Hash};
 use serde_json::{json, Value};
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{Arc, Mutex},
+};
 use tokio::sync::RwLock;
+
+#[derive(Default)]
+struct TestReceiptBackend {
+    governance_by_proposal: Mutex<HashMap<String, GovernanceDecisionReceipt>>,
+    governance_by_decision: Mutex<HashMap<Hash, GovernanceDecisionReceipt>>,
+    allocations_by_decision: Mutex<HashMap<Hash, Vec<AllocationReceipt>>>,
+}
+
+impl GovernanceReceiptBackend for TestReceiptBackend {
+    fn put_governance(&self, receipt: &GovernanceDecisionReceipt) -> Result<(), String> {
+        self.governance_by_proposal
+            .lock()
+            .map_err(|e| e.to_string())?
+            .insert(receipt.proposal_id.clone(), receipt.clone());
+        self.governance_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .insert(receipt.decision_hash, receipt.clone());
+        Ok(())
+    }
+
+    fn get_governance_by_proposal(
+        &self,
+        proposal_id: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(self
+            .governance_by_proposal
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(proposal_id)
+            .cloned())
+    }
+
+    fn put_allocation(&self, receipt: &AllocationReceipt) -> Result<Hash, String> {
+        self.allocations_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .entry(receipt.decision_hash)
+            .or_default()
+            .push(receipt.clone());
+        Ok(receipt.canonical_hash())
+    }
+
+    fn get_governance_by_decision(
+        &self,
+        decision_hash: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(self
+            .governance_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(decision_hash)
+            .cloned())
+    }
+
+    fn list_allocations_by_decision(
+        &self,
+        decision_hash: &Hash,
+    ) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(self
+            .allocations_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(decision_hash)
+            .cloned()
+            .unwrap_or_default())
+    }
+}
 
 /// Auth helper: challenge → sign → JWT.
 async fn get_jwt(
@@ -158,7 +232,9 @@ async fn test_suspended_member_cannot_submit_proposals() {
     let jwt_secret = b"proposal-gate-enforcement-test-sec32".to_vec();
     let auth_manager = Arc::new(AuthManager::new(jwt_secret));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
-    let governance_manager = Arc::new(GovernanceManager::new());
+    let governance_manager = Arc::new(
+        GovernanceManager::new().with_receipt_store(Arc::new(TestReceiptBackend::default())),
+    );
 
     let gov_ctx = GovernanceContext {
         manager: governance_manager.clone(),

--- a/icn/crates/icn-governance/src/bootstrap.rs
+++ b/icn/crates/icn-governance/src/bootstrap.rs
@@ -1,0 +1,405 @@
+//! Generic institution-package bootstrap manifest types.
+//!
+//! These types define the package-owned manifest contract for institution
+//! bootstrapping without embedding any institution-specific vocabulary into ICN
+//! core. They are transport- and filesystem-agnostic: CLI, gateway, tests, or
+//! future runtime executors can all consume the same shapes.
+
+use crate::{ActivityKind, ProgramKind, StructureKind};
+use icn_identity::Did;
+use serde::{Deserialize, Serialize};
+
+/// Top-level manifest for an institution package bootstrap entrypoint.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InstitutionBootstrapManifest {
+    /// Contract version for the package bootstrap loader.
+    pub manifest_version: String,
+    /// Stable package identifier, e.g. `nycn`.
+    pub package_id: String,
+    /// Package kind, currently expected to be `institution`.
+    pub package_kind: String,
+    /// Package-owned working charter location.
+    pub charter: BootstrapCharterRef,
+    /// Ordered seed manifests to ingest.
+    pub seeds: Vec<BootstrapSeedRef>,
+}
+
+/// Pointer to the package-owned charter file.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BootstrapCharterRef {
+    pub path: String,
+}
+
+/// Pointer to a specific ordered seed manifest.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BootstrapSeedRef {
+    pub order: u32,
+    pub kind: BootstrapSeedKind,
+    pub path: String,
+}
+
+/// Supported generic seed kinds.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "kebab-case")]
+pub enum BootstrapSeedKind {
+    EntitySeed,
+    GovernanceDomainSeed,
+    StructureSeed,
+    ActivityProgramSeed,
+    MilestoneTemplateSeed,
+    RoleAssignmentSeed,
+}
+
+/// Parsed seed manifest, tagged by the `kind` field in the YAML file.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind")]
+pub enum BootstrapSeedManifest {
+    #[serde(rename = "entity-seed")]
+    Entity(EntitySeedManifest),
+    #[serde(rename = "governance-domain-seed")]
+    GovernanceDomain(GovernanceDomainSeedManifest),
+    #[serde(rename = "structure-seed")]
+    Structure(StructureSeedManifest),
+    #[serde(rename = "activity-program-seed")]
+    ActivityProgram(ActivityProgramSeedManifest),
+    #[serde(rename = "milestone-template-seed")]
+    MilestoneTemplate(MilestoneTemplateSeedManifest),
+    #[serde(rename = "role-assignment-seed")]
+    RoleAssignment(RoleAssignmentSeedManifest),
+}
+
+impl BootstrapSeedManifest {
+    pub fn seed_kind(&self) -> BootstrapSeedKind {
+        match self {
+            Self::Entity(_) => BootstrapSeedKind::EntitySeed,
+            Self::GovernanceDomain(_) => BootstrapSeedKind::GovernanceDomainSeed,
+            Self::Structure(_) => BootstrapSeedKind::StructureSeed,
+            Self::ActivityProgram(_) => BootstrapSeedKind::ActivityProgramSeed,
+            Self::MilestoneTemplate(_) => BootstrapSeedKind::MilestoneTemplateSeed,
+            Self::RoleAssignment(_) => BootstrapSeedKind::RoleAssignmentSeed,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EntitySeedManifest {
+    pub seed_version: String,
+    pub entity: BootstrapEntityRecord,
+    #[serde(default)]
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BootstrapEntityRecord {
+    pub id: String,
+    pub entity_type: BootstrapEntityType,
+    #[serde(default)]
+    pub parent_entity_id: Option<String>,
+    pub display_name: String,
+    pub governance_domain_id: String,
+    #[serde(default)]
+    pub charter_ref: Option<String>,
+    #[serde(default)]
+    pub operating_purpose: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GovernanceDomainSeedManifest {
+    pub seed_version: String,
+    pub domains: Vec<BootstrapGovernanceDomainRecord>,
+    #[serde(default)]
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BootstrapGovernanceDomainRecord {
+    pub id: String,
+    pub name: String,
+    pub profile: String,
+    pub quorum_percent: u8,
+    pub approval_percent: u8,
+    pub voting_period_days: u64,
+    #[serde(default)]
+    pub members: Vec<String>,
+    #[serde(default)]
+    pub decision_mode: Option<String>,
+    #[serde(default)]
+    pub max_objections: Option<u8>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BootstrapEntityType {
+    Federation,
+    Cooperative,
+    Community,
+    Individual,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StructureSeedManifest {
+    pub seed_version: String,
+    pub parent_entity_id: String,
+    pub structures: Vec<BootstrapStructureRecord>,
+    #[serde(default)]
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BootstrapStructureRecord {
+    pub id: String,
+    pub kind: StructureKind,
+    pub name: String,
+    #[serde(default)]
+    pub mandate: Option<String>,
+    #[serde(default)]
+    pub scope: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ActivityProgramSeedManifest {
+    pub seed_version: String,
+    pub parent_entity_id: String,
+    pub activity: BootstrapActivityRecord,
+    pub program: BootstrapProgramRecord,
+    #[serde(default)]
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BootstrapActivityRecord {
+    pub id: String,
+    pub kind: ActivityKind,
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub linked_structures: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BootstrapProgramRecord {
+    pub id: String,
+    pub kind: BootstrapProgramKindSpec,
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub parent_activity_id: Option<String>,
+    #[serde(default)]
+    pub prior_cycle_program_id: Option<String>,
+    #[serde(default)]
+    pub views: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BootstrapProgramKindSpec {
+    pub kind: BootstrapProgramKindName,
+    #[serde(default)]
+    pub kind_tag: Option<String>,
+}
+
+impl BootstrapProgramKindSpec {
+    pub fn to_program_kind(&self) -> ProgramKind {
+        match self.kind {
+            BootstrapProgramKindName::Cycle => ProgramKind::Cycle,
+            BootstrapProgramKindName::Campaign => ProgramKind::Campaign,
+            BootstrapProgramKindName::Initiative => ProgramKind::Initiative,
+            BootstrapProgramKindName::Series => ProgramKind::Series,
+            BootstrapProgramKindName::Custom => ProgramKind::Custom(
+                self.kind_tag
+                    .clone()
+                    .unwrap_or_else(|| "custom".to_string()),
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BootstrapProgramKindName {
+    Cycle,
+    Campaign,
+    Initiative,
+    Series,
+    Custom,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MilestoneTemplateSeedManifest {
+    pub seed_version: String,
+    pub program_id: String,
+    pub milestones: Vec<BootstrapMilestoneRecord>,
+    #[serde(default)]
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BootstrapMilestoneRecord {
+    pub id: String,
+    pub title: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub phase_index: u32,
+    #[serde(default)]
+    pub target_date: Option<u64>,
+    #[serde(default)]
+    pub completion_criteria: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RoleAssignmentSeedManifest {
+    pub seed_version: String,
+    pub assignments: Vec<BootstrapRoleAssignmentRecord>,
+    #[serde(default)]
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BootstrapRoleAssignmentRecord {
+    pub structure_id: String,
+    pub role: String,
+    #[serde(default)]
+    pub person_did: Option<Did>,
+    #[serde(default)]
+    pub holder_label: Option<String>,
+    #[serde(default)]
+    pub authority_scope: Vec<String>,
+}
+
+/// Generic operation plan emitted by a package bootstrap loader.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BootstrapPlan {
+    pub package_id: String,
+    pub charter_path: String,
+    pub operations: Vec<BootstrapOperation>,
+    #[serde(default)]
+    pub warnings: Vec<String>,
+    #[serde(default)]
+    pub blockers: Vec<String>,
+}
+
+/// Generic bootstrap operations. These are platform-shape operations, not
+/// institution-specific behaviors.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum BootstrapOperation {
+    ValidateCharter {
+        path: String,
+    },
+    CreateEntity {
+        id: String,
+        entity_type: BootstrapEntityType,
+        parent_entity_id: Option<String>,
+        display_name: String,
+        governance_domain_id: String,
+        charter_ref: Option<String>,
+    },
+    ProvisionGovernanceDomain {
+        id: String,
+        name: String,
+        profile: String,
+        quorum_percent: u8,
+        approval_percent: u8,
+        voting_period_days: u64,
+        members: Vec<String>,
+        decision_mode: Option<String>,
+        max_objections: Option<u8>,
+    },
+    CreateStructure {
+        id: String,
+        parent_entity_id: String,
+        kind: StructureKind,
+        name: String,
+        mandate: Option<String>,
+        scope: Vec<String>,
+    },
+    CreateProgram {
+        id: String,
+        domain_id: String,
+        parent_entity_id: String,
+        kind: ProgramKind,
+        name: String,
+        description: Option<String>,
+        prior_cycle_program_id: Option<String>,
+    },
+    CreateActivity {
+        id: String,
+        parent_entity_id: String,
+        kind: ActivityKind,
+        name: String,
+        description: Option<String>,
+        linked_structures: Vec<String>,
+        parent_program_id: Option<String>,
+    },
+    CreateMilestone {
+        id: String,
+        program_id: String,
+        title: String,
+        description: Option<String>,
+        phase_index: u32,
+        target_date: Option<u64>,
+        completion_criteria: Vec<String>,
+    },
+    AssignRole {
+        structure_id: String,
+        person_did: Did,
+        role: String,
+        authority_scope: Vec<String>,
+    },
+    DeferRoleAssignment {
+        structure_id: String,
+        role: String,
+        holder_label: Option<String>,
+        authority_scope: Vec<String>,
+        reason: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn custom_program_kind_maps_to_custom_variant() {
+        let spec = BootstrapProgramKindSpec {
+            kind: BootstrapProgramKindName::Custom,
+            kind_tag: Some("annual-summit".to_string()),
+        };
+        assert_eq!(
+            spec.to_program_kind(),
+            ProgramKind::Custom("annual-summit".to_string())
+        );
+    }
+
+    #[test]
+    fn seed_enum_reports_kind() {
+        let seed = BootstrapSeedManifest::MilestoneTemplate(MilestoneTemplateSeedManifest {
+            seed_version: "draft-0".to_string(),
+            program_id: "p".to_string(),
+            milestones: vec![],
+            notes: vec![],
+        });
+        assert_eq!(seed.seed_kind(), BootstrapSeedKind::MilestoneTemplateSeed);
+    }
+
+    #[test]
+    fn governance_domain_seed_reports_kind() {
+        let seed = BootstrapSeedManifest::GovernanceDomain(GovernanceDomainSeedManifest {
+            seed_version: "draft-0".to_string(),
+            domains: vec![BootstrapGovernanceDomainRecord {
+                id: "domain-a".to_string(),
+                name: "Domain A".to_string(),
+                profile: "cooperative_default".to_string(),
+                quorum_percent: 50,
+                approval_percent: 50,
+                voting_period_days: 7,
+                members: vec!["$bootstrap_subject_did".to_string()],
+                decision_mode: None,
+                max_objections: None,
+            }],
+            notes: vec![],
+        });
+        assert_eq!(seed.seed_kind(), BootstrapSeedKind::GovernanceDomainSeed);
+    }
+}

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -81,6 +81,7 @@ pub mod vote;
 
 // Action items for meeting/task tracking
 pub mod action_item;
+pub mod bootstrap;
 
 // Institutional structure + event model (Tranche 2)
 pub mod activity;
@@ -191,6 +192,15 @@ pub use action_item::{
 };
 pub use activity::{
     Activity, ActivityId, ActivityKind, ActivityStatus, ActivityStoreBackend, InMemoryActivityStore,
+};
+pub use bootstrap::{
+    ActivityProgramSeedManifest, BootstrapActivityRecord, BootstrapCharterRef,
+    BootstrapEntityRecord, BootstrapEntityType, BootstrapGovernanceDomainRecord,
+    BootstrapMilestoneRecord, BootstrapOperation, BootstrapPlan, BootstrapProgramKindName,
+    BootstrapProgramKindSpec, BootstrapProgramRecord, BootstrapRoleAssignmentRecord,
+    BootstrapSeedKind, BootstrapSeedManifest, BootstrapSeedRef, BootstrapStructureRecord,
+    EntitySeedManifest, GovernanceDomainSeedManifest, InstitutionBootstrapManifest,
+    MilestoneTemplateSeedManifest, RoleAssignmentSeedManifest, StructureSeedManifest,
 };
 pub use meeting::{
     AgendaItem, AgendaItemId, AttendanceStatus, InMemoryMeetingStore, Meeting, MeetingAttendee,

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -140,9 +140,9 @@ pub use proof::{
 };
 pub use proposal::{
     AllocationOption, DataSharingLevel, DisputeResolutionMethod, DisputeResolutionOutcome,
-    FederationProposal, FederationTerms, ForcedOutcome, MembershipAction, Proposal, ProposalId,
-    ProposalPayload, ProposalScope, ProposalState, ResourceAccessAction, TreasuryApprovalType,
-    TreasuryProposalOperation, Version,
+    ExecutionClosureClass, FederationProposal, FederationTerms, ForcedOutcome, MembershipAction,
+    Proposal, ProposalId, ProposalPayload, ProposalScope, ProposalState, ResourceAccessAction,
+    TreasuryApprovalType, TreasuryProposalOperation, Version,
 };
 pub use resolver::{MembershipResolver, StaticMembershipResolver, TrustServiceMembershipResolver};
 pub use sdis::{

--- a/icn/crates/icn-governance/src/proposal.rs
+++ b/icn/crates/icn-governance/src/proposal.rs
@@ -710,6 +710,17 @@ pub enum ProposalPayload {
     },
 }
 
+/// Whether an accepted proposal must close into a downstream execution artifact.
+///
+/// - `Declarative`: acceptance itself is the terminal semantic outcome.
+/// - `ExecutionRequired`: acceptance is only a decision signal and must be paired
+///   with a traceable closure artifact (allocation receipt, mandate/provenance, etc).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ExecutionClosureClass {
+    Declarative,
+    ExecutionRequired,
+}
+
 impl ProposalPayload {
     /// Get a string name for the proposal type (for metrics labeling)
     pub fn type_name(&self) -> &'static str {
@@ -758,6 +769,26 @@ impl ProposalPayload {
     /// Check if this is an emergency proposal (requires higher quorum)
     pub fn is_emergency(&self) -> bool {
         self.emergency_type().is_some()
+    }
+
+    /// Classify whether this payload requires downstream execution closure when accepted.
+    ///
+    /// `Text` resolutions are purely declarative in current ICN semantics.
+    /// All other payloads represent operational changes and must not end at
+    /// "accepted" without a durable closure artifact.
+    pub fn execution_closure_class(&self) -> ExecutionClosureClass {
+        match self {
+            ProposalPayload::Text { .. } => ExecutionClosureClass::Declarative,
+            _ => ExecutionClosureClass::ExecutionRequired,
+        }
+    }
+
+    /// Convenience helper for acceptance guards.
+    pub fn requires_execution_closure(&self) -> bool {
+        matches!(
+            self.execution_closure_class(),
+            ExecutionClosureClass::ExecutionRequired
+        )
     }
 }
 
@@ -1585,6 +1616,32 @@ mod tests {
         assert_eq!(proposal.title, "Test Proposal");
         assert_eq!(proposal.state, ProposalState::Draft);
         assert!(proposal.created_at > 0);
+    }
+
+    #[test]
+    fn test_execution_closure_classification_for_declarative_payload() {
+        let payload = ProposalPayload::Text {
+            body: "declarative statement".to_string(),
+        };
+        assert_eq!(
+            payload.execution_closure_class(),
+            ExecutionClosureClass::Declarative
+        );
+        assert!(!payload.requires_execution_closure());
+    }
+
+    #[test]
+    fn test_execution_closure_classification_for_operational_payload() {
+        let payload = ProposalPayload::FreezeMember {
+            member: icn_identity::Did::from_anchor_id(&[7u8; 32]),
+            reason: "policy breach".to_string(),
+            duration_seconds: Some(600),
+        };
+        assert_eq!(
+            payload.execution_closure_class(),
+            ExecutionClosureClass::ExecutionRequired
+        );
+        assert!(payload.requires_execution_closure());
     }
 
     #[test]

--- a/institutions/README.md
+++ b/institutions/README.md
@@ -1,0 +1,10 @@
+# Institution Packages
+
+This directory holds institution-specific packages that are kept inside the ICN monorepo for now but should behave as if they were already externally owned repositories.
+
+Rules:
+- Generic institutional primitives stay in ICN core and `icn/apps/`.
+- Institution vocabulary, seed data, templates, workflows, local views, and migration glue live here.
+- Packages in this directory should avoid reaching back into core with institution-specific type pressure.
+
+The first package scaffold is [`nycn/`](nycn/).

--- a/institutions/nycn/README.md
+++ b/institutions/nycn/README.md
@@ -1,0 +1,51 @@
+# NYCN Institution Package
+
+NYCN lives here as an institution package inside the monorepo.
+
+This directory is intentionally shaped as if it were already an external repository. Its job is to hold NYCN-specific vocabulary, seeds, templates, summit operations, views, migration glue, and workflow definitions without contaminating ICN core.
+
+## What Belongs Here
+
+- Charter configuration and institution-level policy data
+- Bootstrap seeds for NYCN entities, structures, activities, programs, milestones, and role assignments
+- NYCN-specific and summit-specific templates, docs, and operational runbooks
+- Local dashboards, app/view configuration, and institution-owned UI wiring
+- Migration/import placeholders for `ny-coop-net`, spreadsheets, Google Workspace, and other local systems
+- Institution-specific workflows such as sponsor handling, session intake, registration ops, and venue-selection operations
+
+## What Must Stay In ICN Core
+
+- Generic primitives such as `Entity`, `Structure`, `Activity`, `Program`, `Milestone`, `Meeting`, `ActionItem`, `RoleAssignment`, provenance/receipt objects, and generic scope/work views
+- Kernel and app-layer mechanics for storage, transport, authorization, receipts, event emission, and generic CRUD/state transitions
+- Generic APIs that a second institution could reuse unchanged
+
+## Why Summit Logic Belongs Here
+
+The summit is a NYCN activity and program domain, not a platform primitive. ICN core should know how to store and govern generic activities, programs, milestones, and meetings. It should not know NYCN's sponsor tiers, session catalog shape, registration workflow, venue rubric, branding, or summit-year milestone names. Those semantics belong in this package because another institution would rename or reshape them.
+
+## Package Layout
+
+- `charter/` — charter documents and institution-level policy material
+- `config/` — package metadata and local configuration defaults
+- `seed/` — bootstrap manifests for initial instantiation
+- `definitions/` — institution-owned entity/structure/activity/program definitions
+- `summit/` — summit templates, docs, and summit-only operational artifacts
+- `views/` — dashboards and local app/view config
+- `migrations/` — import placeholders and crosswalks
+- `workflows/` — institution-specific workflow definitions
+- `docs/` — package-local indexes and runbooks
+
+## Conditions For A Later Split Into Its Own Repo
+
+- Package artifacts stop depending on ad hoc relative paths back into this repo
+- Bootstrap manifests can be consumed by a stable institution-instantiation flow
+- Package-owned views/workflows can target stable ICN APIs without patching core
+- Migration/import logic is isolated to package-owned scripts or manifests
+- Canonical platform docs point to package boundaries instead of embedding NYCN semantics
+- Ownership and release cadence for NYCN artifacts are separable from ICN core release cadence
+
+## Current Status
+
+- Canonical platform boundary remains [`docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md`](../../docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md)
+- Repo-grounded NYCN architecture remains in [`docs/strategy/NYCN-Repo-Architecture-Spec.md`](../../docs/strategy/NYCN-Repo-Architecture-Spec.md)
+- This package is the operational home for institution-owned artifacts going forward

--- a/institutions/nycn/bootstrap.yaml
+++ b/institutions/nycn/bootstrap.yaml
@@ -1,0 +1,27 @@
+manifest_version: v0
+package_id: nycn
+package_kind: institution
+charter:
+  path: charter/nycn-federation.charter.yaml
+seeds:
+  - order: 0
+    kind: entity-seed
+    path: seed/00-nycn-federation.seed.yaml
+  - order: 1
+    kind: entity-seed
+    path: seed/01-organizer-cooperative.seed.yaml
+  - order: 2
+    kind: governance-domain-seed
+    path: seed/02-governance-domains.seed.yaml
+  - order: 3
+    kind: structure-seed
+    path: seed/02-structures-committees.seed.yaml
+  - order: 4
+    kind: activity-program-seed
+    path: seed/03-summit-activity-program.seed.yaml
+  - order: 5
+    kind: milestone-template-seed
+    path: seed/04-milestone-template.seed.yaml
+  - order: 6
+    kind: role-assignment-seed
+    path: seed/05-role-assignment.seed.yaml

--- a/institutions/nycn/charter/nycn-federation.charter.yaml
+++ b/institutions/nycn/charter/nycn-federation.charter.yaml
@@ -13,10 +13,6 @@
 #
 # Status: DRAFT — requires community review before ratification proposal.
 
-# Historical docs copy of the NYCN charter draft.
-# Working package-owned copy now lives at:
-# institutions/nycn/charter/nycn-federation.charter.yaml
-
 charter:
   name: "New York Cooperative Network"
   version: 1

--- a/institutions/nycn/config/package.yaml
+++ b/institutions/nycn/config/package.yaml
@@ -1,0 +1,20 @@
+package_id: nycn
+display_name: New York Cooperative Network
+package_kind: institution
+status: scaffold
+boundary_mode: monorepo-package
+intended_future_extraction: standalone-repo
+platform_repo: InterCooperative-Network/icn
+canonical_boundary_doc: ../../docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md
+canonical_platform_architecture_doc: ../../docs/strategy/NYCN-Repo-Architecture-Spec.md
+local_entrypoints:
+  bootstrap: ../bootstrap.yaml
+  charter: ../charter/nycn-federation.charter.yaml
+  seeds: ../seed
+  definitions: ../definitions
+  summit: ../summit
+  views: ../views
+  workflows: ../workflows
+notes:
+  - "Generic loader entrypoint now lives at ../bootstrap.yaml."
+  - "Keep institution-specific semantics here and generic primitives in ICN core."

--- a/institutions/nycn/definitions/README.md
+++ b/institutions/nycn/definitions/README.md
@@ -1,0 +1,3 @@
+# NYCN Definitions
+
+These files define NYCN-owned institution shapes on top of generic ICN primitives. They are templates and reference catalogs, not runtime code.

--- a/institutions/nycn/definitions/activities.yaml
+++ b/institutions/nycn/definitions/activities.yaml
@@ -1,0 +1,11 @@
+activities:
+  - id: summit-2026
+    core_primitive: Activity
+    subtype: event
+    institution_tag: annual-summit
+    purpose: "Primary summit event instance."
+  - id: regional-meetups-2026
+    core_primitive: Activity
+    subtype: initiative
+    institution_tag: regional-meetup-series
+    purpose: "Supporting organizer and movement activity outside the summit."

--- a/institutions/nycn/definitions/entities.yaml
+++ b/institutions/nycn/definitions/entities.yaml
@@ -1,0 +1,9 @@
+entities:
+  - id: nycn
+    core_primitive: Entity
+    subtype: federation
+    meaning: "Regional network federation."
+  - id: nycn-organizers
+    core_primitive: Entity
+    subtype: cooperative
+    meaning: "Operational owner for NYCN structures and summit execution."

--- a/institutions/nycn/definitions/programs.yaml
+++ b/institutions/nycn/definitions/programs.yaml
@@ -1,0 +1,15 @@
+programs:
+  - id: summit-cycle-annual
+    core_primitive: Program
+    kind: custom
+    kind_tag: annual-summit
+    owned_semantics:
+      - summit milestones
+      - sponsor pipeline
+      - session intake
+      - registration operations
+    must_not_move_to_core:
+      - sponsor tiers
+      - session catalog states
+      - registration forms
+      - venue scoring rubrics

--- a/institutions/nycn/definitions/structures.yaml
+++ b/institutions/nycn/definitions/structures.yaml
@@ -1,0 +1,17 @@
+structures:
+  - id: nycn-steering
+    core_primitive: Structure
+    subtype: committee
+    purpose: "Ratification and cross-committee coordination."
+  - id: nycn-finance
+    core_primitive: Structure
+    subtype: committee
+    purpose: "Budget review, sponsorship review, treasury coordination."
+  - id: nycn-content
+    core_primitive: Structure
+    subtype: committee
+    purpose: "Program shaping and session review."
+  - id: nycn-logistics
+    core_primitive: Structure
+    subtype: committee
+    purpose: "Venue, schedule, and operations."

--- a/institutions/nycn/docs/INDEX.md
+++ b/institutions/nycn/docs/INDEX.md
@@ -1,0 +1,16 @@
+# NYCN Package Docs
+
+Primary entrypoints:
+- [`../README.md`](../README.md) — package boundary and ownership rules
+- [`../bootstrap.yaml`](../bootstrap.yaml) — generic package bootstrap manifest consumed by `icnctl`
+- [`../charter/nycn-federation.charter.yaml`](../charter/nycn-federation.charter.yaml) — charter working copy
+- [`../seed/README.md`](../seed/README.md) — bootstrap manifest order
+- [`institutional-strategy.md`](institutional-strategy.md) — NYCN institution framing copied into the package docs area
+- [`institutional-design.md`](institutional-design.md) — NYCN entity/structure/activity design copied into the package docs area
+- [`../summit/docs/workshop-proposal-draft.md`](../summit/docs/workshop-proposal-draft.md) — summit-specific draft content
+- [`bootstrap-runbook.md`](bootstrap-runbook.md) — next-step bootstrap sequence
+
+Canonical platform references that still stay under `docs/`:
+- [`../../../docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md`](../../../docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md)
+- [`../../../docs/strategy/NYCN-Repo-Architecture-Spec.md`](../../../docs/strategy/NYCN-Repo-Architecture-Spec.md)
+- [`../../../docs/strategy/NYCN-Implementation-Matrix.md`](../../../docs/strategy/NYCN-Implementation-Matrix.md)

--- a/institutions/nycn/docs/bootstrap-runbook.md
+++ b/institutions/nycn/docs/bootstrap-runbook.md
@@ -1,0 +1,37 @@
+# NYCN Bootstrap Runbook
+
+Current bootstrap entrypoint:
+
+```bash
+cd /home/matt/projects/icn/icn
+cargo run -p icnctl -- institution bootstrap validate --package ../institutions/nycn
+cargo run -p icnctl -- institution bootstrap plan --package ../institutions/nycn
+cargo run -p icnctl -- institution bootstrap apply --package ../institutions/nycn --coop-id <existing-auth-coop>
+```
+
+What works now:
+1. The package charter is loaded from `../charter/nycn-federation.charter.yaml`.
+2. The package bootstrap manifest is loaded from `../bootstrap.yaml`.
+3. Seed ordering is validated for entities, structures, activity/program, milestones, and role assignments.
+4. Governance domain declarations are validated against entity `governance_domain_id` references.
+5. Cross-reference checks run for parent entities, linked structures, and target programs.
+6. A generic bootstrap plan is emitted for entity, governance-domain, structure, activity, program, milestone, and role-assignment operations.
+7. `apply` can perform real live writes for the subset of steps the current generic gateway APIs can faithfully represent.
+
+What `apply` can really persist today:
+1. The NYCN federation entity.
+2. The organizer cooperative entity.
+3. NYCN governance domains declared in `02-governance-domains.seed.yaml`.
+4. Committee and working-group structures under the organizer cooperative.
+5. Summit activity records including `linked_structures` when target structures are live-resolvable.
+
+What `apply` still cannot complete for NYCN:
+1. Charter storage and activation through a generic package bootstrap sink.
+2. Role assignment application where no `person_did` has been supplied yet.
+
+Current practical order:
+1. Validate the package with `icnctl institution bootstrap validate`.
+2. Review the generic operation sequence with `icnctl institution bootstrap plan`.
+3. Run `icnctl institution bootstrap apply --package ../institutions/nycn --coop-id <existing-auth-coop>`.
+4. Inspect the apply report for completed, deferred, unsupported, and failed steps.
+5. Supply real DIDs for role assignments when organizer identities exist.

--- a/institutions/nycn/docs/institutional-design.md
+++ b/institutions/nycn/docs/institutional-design.md
@@ -1,0 +1,568 @@
+# NYCN on ICN — Institutional Design Document
+
+> **⚠️ Revision notice (2026-04-15)** — Entity Structure section corrected in-place.
+>
+> This doc's original entity tree (2026-04-13) modeled committees and the summit year as `Community` entities. That is **superseded** by the layered ontology merged in #1540 (2026-04-14) and locked in [`NYCN-Repo-Architecture-Spec.md`](NYCN-Repo-Architecture-Spec.md) §0.3:
+>
+> - **Entities** (sovereign; join federations; hold independent treasury): NYCN federation, `nycn-organizers` co-op, member co-ops.
+> - **Structures** (non-sovereign; owned by a parent entity; delegated authority): committees, working groups, backbone, host pods. `icn-governance::structure::Structure { kind: Committee | WorkingGroup | Team | Office }`.
+> - **Activities** (time-bounded; owned by a parent entity): the summit cycle, regional meetup series. `icn-governance::activity::Activity { kind: Event | Program | Project | Initiative }`, with a proposed first-class `Program` wrapper adding milestones and stage gates (Tranche 1 of the execution plan).
+>
+> For canonical repo state, see the three companion docs: [`NYCN-Repo-Architecture-Spec.md`](NYCN-Repo-Architecture-Spec.md), [`NYCN-Implementation-Matrix.md`](NYCN-Implementation-Matrix.md), [`NYCN-Execution-Tranches.md`](NYCN-Execution-Tranches.md).
+
+## Introduction
+
+This document formalizes the design for the New York Cooperative Network (NYCN) as a **native institution inside the InterCooperative Network (ICN)**.
+
+NYCN is not an application that uses ICN. NYCN is an institutional arrangement that lives within ICN. Every entity, internal structure, activity, decision, financial event, and communication channel maps to an ICN primitive. There is no separate database, no parallel app, no bespoke backend.
+
+The goal is to transform NYCN from an informal coordination network into a **durable, governed federation** with real operational capacity, institutional memory, and long-term continuity — and to prove that ICN can host real institutions in the process.
+
+---
+
+## Core Thesis
+
+> NYCN is a regional federation of cooperatives, communities, and aligned organizations that coordinate, govern shared initiatives, and organize the annual summit through ICN-native identity, governance, and economic primitives.
+
+Every feature NYCN needs is a feature every future ICN institution needs. Nothing built for NYCN is bespoke. Everything built is platform.
+
+---
+
+## Entity Structure
+
+### ICN Primitive Mapping
+
+NYCN maps across three layers of ICN governance/identity primitives:
+
+1. **Entity model** (`icn-entity`): four sovereign types — `Individual`, `Cooperative(CooperativeProfile)`, `Community(CommunityProfile)`, `Federation(FederationProfile)`. Entities nest via `parent_id`, and each cooperative/federation has a `governance_domain_id` and a `treasury_account`. Entities are the only layer that can join federations or hold independent treasury.
+
+2. **Structure model** (`icn-governance::structure`): non-sovereign internal units — `Structure { kind: Committee | WorkingGroup | Team | Office }` — owned by a parent entity and carrying delegated authority. Structures have `RoleAssignment`s (with `authority_scope: Vec<String>` capability strings, not a typed enum). Structures cannot hold independent treasury or join federations.
+
+3. **Activity model** (`icn-governance::activity`): time-bounded work — `Activity { kind: Event | Program | Project | Initiative }` — owned by a parent entity. A proposed first-class `Program` primitive (Tranche 1) will wrap `Activity` with milestones and stage gates for cycle-level containment.
+
+Operational objects (action items, meetings, documents) attach to any of the three layers via `icn-governance::parent::InstitutionalParent`.
+
+### NYCN Entity / Structure / Activity Topology
+
+```
+nycn                                   Entity: Federation(FederationProfile)
+├── governance_domain_id:              "nycn-federation-gov"
+├── treasury_account:                  "nycn-federation-treasury"
+├── member_entities:                   [greenstar, cooperation-buffalo, ica-group, ...]
+│
+├── nycn-organizers                    Entity: Cooperative(CooperativeProfile)
+│   ├── parent_id:                     "nycn"
+│   ├── governance_domain_id:          "nycn-organizers-gov"
+│   ├── treasury_account:              "nycn-ops-treasury"
+│   │
+│   ├── [STRUCTURES — owned by nycn-organizers]
+│   │   ├── nycn-backbone              Structure { kind: Committee }
+│   │   ├── nycn-steering              Structure { kind: Committee }
+│   │   ├── nycn-content               Structure { kind: Committee }
+│   │   ├── nycn-logistics             Structure { kind: Committee }
+│   │   ├── nycn-marketing             Structure { kind: Committee }
+│   │   ├── nycn-finance               Structure { kind: Committee }
+│   │   └── nycn-accessibility-wg      Structure { kind: WorkingGroup }
+│   │
+│   └── [ACTIVITIES — owned by nycn-organizers]
+│       ├── summit-2026                Activity { kind: Event }       — to be wrapped by Program (Tranche 1)
+│       ├── summit-2027                Activity { kind: Event }       — future; once Program lands, Program.parent_program_id = summit-2026
+│       └── regional-meetups-2026      Activity { kind: Initiative }  — ongoing regional meetup series (Initiative is the closest existing ActivityKind)
+│
+├── greenstar                          Entity: Cooperative(CooperativeProfile)
+├── cooperation-buffalo                Entity: Cooperative(CooperativeProfile)
+└── ... (N member organizations as independent entities)
+```
+
+**Key design decisions (corrected):**
+
+1. **NYCN Federation** is the top-level entity. It governs network-wide decisions: membership admission, federation charter amendments, shared initiatives. `FederationProfile.member_entities` lists participating sovereign entities.
+
+2. **NYCN Organizers** is a sovereign `Cooperative` entity because it holds treasury and executes operations. It is the operational body — the legal/economic container for the people and funds that actually run things.
+
+3. **Committees are `Structure` records**, not entities. Each committee (`nycn-finance`, `nycn-content`, `nycn-logistics`, `nycn-marketing`, `nycn-backbone`, the accessibility working group) lives in `icn-governance::structure::Structure` with `kind: Committee` (or `WorkingGroup`) and `parent_entity_id: "nycn-organizers"`. A governance domain can optionally be provisioned for a structure where scoped proposals/votes are needed, but the structure itself is not a sovereign entity and does not appear in `FederationProfile.member_entities`. This is important: committees have delegated authority (via `RoleAssignment.authority_scope` capability strings), not sovereignty.
+
+4. **Summit 2026 is an `Activity { kind: Event }`**, owned by `nycn-organizers`. Today, `Activity` has four kinds (`Event | Program | Project | Initiative`) and no cycle-level container fields. Tranche 1 introduces a first-class `Program` primitive that wraps the summit Activity and adds:
+   - milestones with machine-readable required-check predicates (`StrategyLocked → VenueLocked → BudgetLocked → PublicLaunchReady → EventReady → ClosureComplete`),
+   - cycle-to-cycle handoff via `Program.parent_program_id` (so `summit-2027`'s Program points back to `summit-2026`'s Program for year-over-year comparison).
+   Note: `parent_program_id` is a proposed field on the proposed `Program` type, not on `Activity`. Activities do not appear in `FederationProfile.member_entities`.
+
+5. **Member organizations are independent entities** that join the federation via the `member_entities` list on `FederationProfile`. They keep their own governance and treasury. The federation relationship is additive, not subordinating.
+
+6. **Authority model**: governance authority is expressed through `RoleAssignment.authority_scope: Vec<String>` (capability strings like `"propose"`, `"approve-budget-<=5000"`, `"backbone-authority"`) combined with PolicyOracle rules. There is no typed authority-level enum; backbone ratification rules key off capability strings declared in CCL/oracle config. See [`NYCN-Repo-Architecture-Spec.md`](NYCN-Repo-Architecture-Spec.md) §4.3.
+
+---
+
+## Identity
+
+### ICN Primitive
+
+DIDs: `did:icn:<base58-ed25519-public-key>`. Created locally via `icnctl id init`. Authentication is challenge-response: gateway issues 32-byte nonce → client signs with private key → gateway verifies → issues JWT with `sub` (DID), `coop_id`, and `scopes`.
+
+### NYCN Application
+
+Every organizer gets a DID. Every participating organization gets one. The practical value is **scope switching**.
+
+When Matt authenticates with `coop_id: "nycn-marketing"` and scopes `["propose", "vote"]`, he's acting as the marketing committee. When he authenticates with `coop_id: "nycn-organizers"` and scopes `["propose", "vote", "treasury_access"]`, he's acting as a co-op steward. Same person, same DID, different institutional hat.
+
+This solves the authority ambiguity problem: when someone approves a $2,000 sponsorship commitment, the system records that they did it as the finance committee coordinator with `TreasuryAccess` capability on `nycn-finance`, not as a random volunteer.
+
+**First circle:** Core organizers (~15 people) and participating organizations. Attendees get identities optionally and later.
+
+---
+
+## Membership Model
+
+### ICN Primitives
+
+`MembershipRole` enum provides:
+
+**Individual roles**: `Founder`, `Member`, `Worker`, `Consumer`, `Producer`, `BoardMember`, `Officer { title }`.
+
+**Entity roles** (when the member is itself an organization): `FederatedMember`, `AssociateMember`, `ObserverMember`, `ProvisionalMember`.
+
+**Custom**: `Custom { name }` for anything else.
+
+Each role carries default `MembershipCapability` grants: `Vote`, `Propose`, `TreasuryAccess`, `Invite`, `ManageSubEntities`, `Sign`, `Configure`.
+
+### NYCN Membership Tiers
+
+| Tier | ICN Entity Type | Federation Role | Capabilities |
+|------|----------------|-----------------|-------------|
+| **Full Member Co-op** | `Cooperative` | `FederatedMember` | Vote, Propose, TreasuryAccess (if applicable), Invite |
+| **Affiliate Organization** | `Cooperative` or `Community` | `AssociateMember` | Vote (limited), Propose (limited) |
+| **Emerging Co-op / Community** | `Community` | `ProvisionalMember` | Propose (community-scoped only) |
+| **Individual Participant** | `Individual` | `Member` | Vote (in committees they belong to), Propose |
+| **Observer** | `Individual` or `Cooperative` | `ObserverMember` | Read-only, can attend but not vote |
+
+### Roles Within the Organizer Co-op
+
+| Role | ICN `MembershipRole` | Capabilities |
+|------|---------------------|-------------|
+| **Co-op Founder** | `Founder` | All capabilities (Vote, Propose, TreasuryAccess, Invite, ManageSubEntities, Sign, Configure) |
+| **Steering Member** | `BoardMember` | Vote, Propose, TreasuryAccess, Invite |
+| **Committee Coordinator** | `Officer { title: "Coordinator" }` | Vote, Propose, Invite, Configure (within committee scope) |
+| **Organizer** | `Member` | Vote, Propose |
+| **Volunteer** | `Custom { name: "Volunteer" }` | Propose (limited scope) |
+
+### Membership Flow
+
+1. Organization exists as an ICN entity (or individual creates a DID)
+2. Organization assigns a delegate (membership with `FederatedMember` role)
+3. Delegate submits membership request to `nycn-federation-gov`
+4. Membership committee reviews (or auto-qualifies based on charter rules)
+5. `Membership { action: Add, member: did }` proposal created in federation governance domain
+6. Federation members vote per charter thresholds
+7. On acceptance: entity added to `FederationProfile.member_entities`, membership record created in sled
+
+---
+
+## Governance
+
+### ICN Primitives
+
+`ProposalPayload` variants available today:
+
+- `Text { body }` — Discussion, resolutions, records
+- `Budget { amount, currency, recipient, purpose }` — Single-recipient allocation
+- `Allocation { pool_amount, unit, options, purpose }` — Participatory budgeting across competing options
+- `Membership { action, member }` — Add or remove members
+- `ConfigChange { new_config }` — Governance parameter changes
+- `FreezeMember { member, reason, duration }` — Emergency member suspension
+- `VetoProposal { target_proposal_id, reason }` — Override governance process
+- `ForceCloseProposal { target_proposal_id, reason, forced_outcome }` — Emergency halt
+
+Proposal lifecycle: `Draft → [Deliberation] → Open → Accepted / Rejected / NoQuorum`
+
+Each entity's `governance_domain_id` scopes proposals — steering proposals live in `nycn-steering-gov`, content proposals live in `nycn-content-gov`, etc.
+
+### NYCN Governance Model
+
+**Federation-level decisions** (domain: `nycn-federation-gov`):
+
+| Decision | Payload Type | Threshold | Who Votes |
+|----------|-------------|-----------|-----------|
+| Admit new member co-op | `Membership { action: Add }` | Simple majority, quorum 50% | All `FederatedMember` delegates |
+| Amend federation charter | `ConfigChange` | Two-thirds supermajority | All `FederatedMember` delegates |
+| Federation-wide initiative | `Text` | Simple majority | All `FederatedMember` delegates |
+| Remove member | `Membership { action: Remove }` | Two-thirds supermajority | All `FederatedMember` delegates |
+
+**Steering committee decisions** (domain: `nycn-steering-gov`):
+
+| Decision | Payload Type | Threshold | Who Votes |
+|----------|-------------|-----------|-----------|
+| Approve annual budget | `Allocation` | Two-thirds, quorum 50% | Steering committee members |
+| Select venue | `Text` (with options in body) | Simple majority | Steering committee members |
+| Approve program structure | `Text` | Simple majority | Steering committee members |
+| Accept sponsorship > $500 | `Budget` | Simple majority | Steering committee members |
+| Form new committee | `Text` + follow-up entity creation | Simple majority | Steering committee members |
+| Emergency member freeze | `FreezeMember` | Supermajority | Steering committee members |
+
+**Committee-level decisions** (domain: `nycn-{committee}-gov`):
+
+| Decision | Payload Type | Authority | Who Decides |
+|----------|-------------|-----------|-------------|
+| Approve individual session | `Text` | Autonomous (no steering approval) | Content committee members |
+| Accept sponsorship ≤ $500 | `Budget` | Autonomous | Finance committee members |
+| Marketing plan approval | `Text` | Autonomous | Marketing committee members |
+| Expense within allocation | `Budget` | Autonomous, within budget limit | Committee coordinator |
+
+The charter defines the **governance-management boundary**: which decisions require a governance vote and which the committee handles autonomously. This boundary is the key organizational design choice.
+
+### Concrete Decision Flow: Venue Selection
+
+1. Logistics committee researches venues, narrows to three options
+2. Logistics coordinator creates proposal in `nycn-steering-gov`:
+   ```
+   ProposalPayload::Text {
+     body: "Venue selection: Albany Convention Center ($1,500 deposit, 200 cap, accessible)
+            vs. Buffalo Conference Hall ($1,200, 150 cap, limited transit)
+            vs. Syracuse Community Center ($800, 120 cap, full accessibility)
+            Recommendation: Albany. Cost higher but capacity and accessibility justify it."
+   }
+   ```
+3. Proposal enters deliberation period (charter-defined, e.g., 72 hours)
+4. After deliberation, proposal opens for voting
+5. Steering members cast votes (threshold: simple majority, quorum: half of steering)
+6. On acceptance: decision recorded with full provenance — proposer DID, every vote with DID, timestamps, tally
+7. 2027 logistics committee queries `GET /governance/nycn-steering-gov/proposals?state=accepted` and sees exactly why Albany was chosen
+
+---
+
+## Ledger and Budget
+
+### ICN Primitives
+
+`icn-ledger` provides double-entry mutual credit. Every financial event is an immutable `Entry` with debit, credit, timestamp, and metadata. Treasury operations include allocations (capacity grants), settlements (bilateral transfers), and dispute handling. Dynamic credit limits based on trust scores.
+
+### NYCN Budget Architecture
+
+**Treasury accounts** (mapped to entity tree):
+
+```
+nycn-federation-treasury     Federation-level funds (dues, shared resources)
+nycn-ops-treasury            Organizer co-op operating funds
+  ├── allocated to:
+  │   nycn-steering          (no separate treasury — uses ops-treasury with scoped authority)
+  │   nycn-content           $1,000 allocation
+  │   nycn-logistics         $3,000 allocation
+  │   nycn-marketing         $500 allocation
+  │   nycn-finance           $200 allocation (admin costs)
+  │   nycn-summit-2026       event-specific allocation
+```
+
+### Budget Lifecycle
+
+**1. Budget approval** — Finance committee drafts budget, submits as `Allocation` proposal to `nycn-steering-gov`:
+
+```
+ProposalPayload::Allocation {
+    pool_amount: 5200,
+    unit: "USD",
+    options: [
+        { name: "content", amount: 1000, description: "Speaker fees, materials" },
+        { name: "logistics", amount: 3000, description: "Venue, AV, catering" },
+        { name: "marketing", amount: 500, description: "Ads, printing, outreach" },
+        { name: "finance", amount: 200, description: "Banking, admin" },
+        { name: "reserve", amount: 500, description: "Contingency" },
+    ],
+    purpose: "Summit 2026 operating budget",
+}
+```
+
+When approved (two-thirds of steering), allocations become ledger entries — credits to each committee's scoped account.
+
+**2. Income tracking**:
+
+| Source | Ledger Entry | Provenance |
+|--------|-------------|-----------|
+| Registration (SimpleTix) | Credit to `nycn-ops-treasury`, metadata: `{ source: "simpletix", batch: "2026-Q3" }` | External receipt — no governance proposal needed |
+| Sponsorship (GreenStar, $1,000) | Credit to `nycn-ops-treasury`, metadata: `{ sponsor: "greenstar", proposal_id: "prop-42" }` | Links to governance approval record |
+| Grant (CDF Ed Fund) | Credit to `nycn-ops-treasury`, metadata: `{ grant: "cdf-ed-fund-2026" }` | External receipt with grant reference |
+
+**3. Spending**:
+
+When logistics books a $1,500 venue deposit:
+```
+Settlement {
+    from: "nycn-logistics" (scoped allocation),
+    to: "external:albany-convention-center",
+    amount: 1500,
+    currency: "USD",
+    reference: "venue-deposit-2026",
+    metadata: { proposal_id: "prop-37" }  // links to venue approval
+}
+```
+
+The ledger knows logistics had $3,000 allocated and now has $1,500 remaining. Every organizer with `ledger:read` scope can see this.
+
+**4. Reconciliation**: At end of cycle, the ledger provides complete financial picture — all income, all expenses, all committee allocations, all surplus or deficit. Not a manually assembled spreadsheet. The actual institutional record.
+
+---
+
+## Trust
+
+### ICN Primitive
+
+`icn-trust` computes trust scores from a graph of attestations. Trust scores gate rate limits, capability grants, and access control. The `TrustPolicyOracle` converts trust scores into `ConstraintSet` values the kernel enforces.
+
+### NYCN Trust Model
+
+Trust is not arbitrary hierarchy. It makes explicit what already happens informally.
+
+| Trust Level | Who | What They Can Do |
+|------------|-----|-----------------|
+| **New volunteer** (trust < 0.2) | First-time participant | Join committees, propose session topics, participate in discussions |
+| **Active organizer** (trust 0.2–0.5) | Returning volunteer with track record | Vote on committee decisions, propose committee-level actions |
+| **Committee coordinator** (trust 0.5–0.7) | Experienced organizer, elected/appointed | Approve spending within committee allocation, invite members |
+| **Steering member** (trust 0.7+) | Core leadership | Propose budget amendments, vote on federation decisions, sign on behalf of entity |
+
+Trust builds through participation: attending meetings, completing commitments, participating in governance votes, receiving attestations from other members. The charter defines which trust thresholds gate which capabilities — anyone can propose a session topic, but only organizers above 0.5 trust can propose budget amendments.
+
+---
+
+## Communication
+
+### ICN Primitive
+
+`icn-gossip` provides topic-based pub/sub with access control. Topics have `AccessControl`: `Public`, `MinTrustScore(f64)`, or `Participants(Vec<Did>)`. Messages propagate via hybrid push/pull protocol.
+
+### NYCN Topic Structure
+
+```
+Topic                                   ACL                              Purpose
+────────────────────────────────────────────────────────────────────────────────────
+nycn:federation:announcements           MinTrustScore(0.1)               Network-wide announcements
+nycn:organizers:general                 Participants([organizer DIDs])   Organizer coordination
+nycn:steering:discussion                Participants([steering DIDs])    Steering deliberation
+nycn:content:coordination               Participants([content DIDs])     Content committee
+nycn:logistics:coordination             Participants([logistics DIDs])   Logistics committee
+nycn:marketing:coordination             Participants([marketing DIDs])   Marketing committee
+nycn:finance:coordination               Participants([finance DIDs])     Finance committee
+nycn:summit-2026:updates                MinTrustScore(0.1)               Summit planning updates
+nycn:federation:public                  Public                           Public community space
+```
+
+Communication is scoped to institutional structure. Marketing coordination stays in marketing scope. Steering deliberation stays in steering scope. Cross-committee announcements go to the organizer channel. Public announcements go to the community-facing topic.
+
+---
+
+## Institutional Memory
+
+### The Problem
+
+13 years of NYCN organizing knowledge is scattered across Google Drive with inconsistent ownership, naming, and structure. Every year, new organizers reconstruct context from scratch. Knowledge is lost when people leave.
+
+### The ICN Solution
+
+Every meeting record, decision, budget, evaluation, and committee report is stored as a content-addressed, provenance-tracked artifact in ICN's storage layer. It doesn't disappear when someone's Google account changes. It doesn't get filed in the wrong folder.
+
+**What becomes institutional record:**
+
+| Artifact | How It's Stored | Provenance |
+|----------|----------------|-----------|
+| Meeting agenda | Document artifact scoped to committee entity | Author DID, committee scope, timestamp |
+| Meeting notes | Document artifact scoped to committee entity | Author DID, attendee list, decisions captured |
+| Governance decision | Proposal record in governance domain | Proposer, all votes, tally, timestamps |
+| Budget approval | Allocation proposal + ledger entries | Full chain from proposal to expenditure |
+| Committee report | Document artifact scoped to committee entity | Author DID, reporting period |
+| Summit evaluation | Document artifact scoped to summit entity | Year, metrics, lessons learned |
+| Sponsorship record | Ledger entry + governance approval | Sponsor entity, approval vote, payment receipt |
+
+The 2028 planning committee can trace the complete institutional history: how 2026 was organized, what was decided, what evaluations said, what the budget looked like, who was on each committee and what they did.
+
+---
+
+## Federation
+
+### ICN Primitive
+
+`FederationProfile` tracks `member_entities: Vec<EntityId>` with optional `parent_id` for nested federations. `icn-federation` provides clearing management — multi-party netting, bilateral settlement, receipt generation.
+
+### NYCN Federation Model
+
+The 217+ organizations in the NYCN directory become real federation members or affiliates. Each participating co-op has its own ICN entity. The federation surface lets them:
+
+- **Discover each other** through the federation member registry
+- **Coordinate on shared concerns** through federation governance proposals
+- **Participate in network governance** through delegate voting
+- **Contribute shared resources** through commons artifacts
+- **Track inter-organizational relationships** through federation clearing
+
+When GreenStar sponsors the summit for $1,000, that's an inter-entity transaction in the federation ledger, with governance provenance, visible to all federation members who have `ledger:read` scope.
+
+When a Buffalo co-op sends a speaker, that's a cross-entity contribution tracked in the trust system — an attestation that builds the institutional relationship between organizations.
+
+The summit becomes the annual convening of a living network — not a one-off event a small team scrambles to produce.
+
+---
+
+## Summit Lifecycle
+
+### Before (January–September)
+
+**January**: Steering committee meets. Agenda posted as artifact in ICN storage. Committee reports submitted. Steering votes to approve budget (`Allocation` proposal, two-thirds threshold). Allocations become ledger entries. Meeting notes become permanent institutional record.
+
+**February**: Marketing committee operates within $500 allocation autonomously. Marketing plan stored as artifact scoped to marketing entity. $150 Facebook ads logged as settlement against authorized budget.
+
+**March**: Content committee proposes program structure (four tracks, keynote, 20 sessions) as `Text` proposal to `nycn-steering-gov`. Approved. Individual sessions approved within content committee's delegated authority via `nycn-content-gov`.
+
+**April**: Logistics proposes Albany as venue → steering vote → passes. Venue deposit ($1,500) recorded as settlement from logistics allocation, referencing venue approval proposal.
+
+**May–September**: Sponsor commitments flow through governance (above $500) or autonomous committee authority (below $500). All financial events recorded in ledger. Operational execution happens in external tools (email, task apps, etc.) but every institutional decision flows through ICN.
+
+### During (October)
+
+Summit happens. Registration data links attendees to event. Financial transactions (ticket revenue, on-site sponsorship, expenses) flow through ledger.
+
+### After (November)
+
+Post-event. Evaluation data captured and stored as artifact. Financial reconciliation generated from ledger. Knowledge capture: what worked, what didn't, what committees learned. All permanent institutional memory. The 2027 planning committee inherits a complete, auditable, structured record.
+
+---
+
+## What Stays Outside ICN
+
+| Outside ICN | Why |
+|-------------|-----|
+| Task-level operations ("email sponsor back," "print badges") | Management, not governance. Use whatever task tool organizers prefer. |
+| Email campaigns | Mailchimp or equivalent. ICN is not an email platform. |
+| Ticket sales UX | SimpleTix or equivalent. Registration needs a consumer-facing interface. |
+| Website | Public marketing surface. |
+| Social media | External platforms. |
+| Day-of logistics | Room assignments, AV, volunteer shifts, food. Operational execution. |
+
+**The line**: ICN holds the institutional reality (who, what authority, what was decided, what money moved, what the rules are). External tools handle operational execution (the actual doing of tasks, the public-facing surfaces, the marketing).
+
+---
+
+## Design Principles
+
+1. **Federation, not centralization.** Member co-ops retain sovereignty. The federation coordinates; it does not govern member internals.
+2. **Governed shared layer.** What's shared (budget, program, standards) is governed through proposals and voting. What's internal is each member's business.
+3. **Durable institutional memory.** Every decision, every budget, every evaluation persists with provenance. New organizers inherit complete context.
+4. **Transparency and accountability.** Every organizer can see budget position, decision history, and committee status at any time.
+5. **Actionable coordination, not symbolic membership.** Membership implies structured participation — voting rights, committee access, governance voice. Not just a directory listing.
+6. **Scope-bound authority.** Roles and capabilities are per-entity, not global. You act as a committee coordinator within your committee, not across the whole organization.
+
+---
+
+## ICN Platform Gaps
+
+These are features NYCN needs that ICN does not yet provide. They are listed as platform gaps, not NYCN customizations — every institution would need them.
+
+### Exists But Needs Wiring
+
+| Gap | Current State | What's Needed |
+|-----|---------------|---------------|
+| **Budget-as-constraints** | Charter engine evaluates proposals; ledger tracks balances | Wire allocation approval → spending authority enforcement. When marketing tries to settle $600 but only has $500 allocated, the system should reject or flag. |
+| **Multi-domain navigation in UI** | Pilot UI shows one governance domain at a time | Organizer needs to see "my committees → each committee's proposals" in one view. Dashboard scoped to identity and roles. |
+| **Proposal creation forms** | API endpoints exist; UI has basic governance tab | Need full proposal creation UX — select type, fill fields, submit, track status |
+
+### Does Not Exist Yet
+
+| Gap | What's Needed | Why Every Institution Needs It |
+|-----|---------------|-------------------------------|
+| **Content-addressed document storage** | Artifacts (agendas, reports, evaluations, templates) stored with authorship, scope, and provenance | Every institution produces documents. Without this, institutional memory is incomplete. |
+| **Onboarding UX** | Invite link → create identity → join entity → get role, all in-browser without crypto key management expertise | Volunteer organizers will not adopt DID-based identity if the onboarding is `icnctl id init` in a terminal. |
+| **Notification system** | Push notifications, email digest, "you have 3 pending votes" summaries | No one polls a dashboard. Governance participation requires notification when votes open. |
+| **Calendar/event primitive** | Lightweight event/milestone type attached to entities with time-bounded lifecycle | Summits, meetings, deadlines are universal institutional artifacts. |
+| **Rich member profiles** | Structured profile fields (skills, organization affiliation, contact info, bio) on entities | Every institution needs a member directory that's more than a list of DIDs. |
+| **Seasonal lifecycle** | Entity status patterns for dormant ↔ active ↔ intense ↔ dormant cycles | The summit happens once a year. The institution persists. Entities need to handle seasonal intensity without creating/destroying structure. |
+
+---
+
+## Charter Outline (Draft)
+
+The NYCN federation charter, written in CCL, would define:
+
+### Governance Parameters
+
+```yaml
+federation:
+  name: "New York Cooperative Network"
+  governance:
+    membership_admission:
+      threshold: simple_majority
+      quorum: 0.5
+      eligible_voters: federated_members
+    charter_amendment:
+      threshold: supermajority_two_thirds
+      quorum: 0.5
+      eligible_voters: federated_members
+    
+organizer_coop:
+  governance:
+    budget_approval:
+      threshold: supermajority_two_thirds
+      quorum: 0.5
+      eligible_voters: steering_members
+    venue_selection:
+      threshold: simple_majority
+      quorum: 0.5
+      eligible_voters: steering_members
+    sponsorship_above_500:
+      threshold: simple_majority
+      quorum: 0.5
+      eligible_voters: steering_members
+
+committees:
+  delegation:
+    - content: autonomous for individual session approval
+    - finance: autonomous for sponsorship ≤ $500
+    - marketing: autonomous within budget allocation
+    - logistics: autonomous within budget allocation
+  escalation:
+    - program_structure: requires steering approval
+    - budget_amendment: requires steering approval
+    - new_committee: requires steering approval
+
+trust:
+  thresholds:
+    propose_session: 0.0        # anyone
+    vote_committee: 0.1         # minimal participation
+    propose_budget_change: 0.5  # established organizer
+    committee_coordinator: 0.5  # elected/appointed
+    steering_membership: 0.7    # core leadership
+```
+
+---
+
+## Bootstrap Sequence
+
+The minimum viable institutional instantiation:
+
+1. **Create federation entity** (`nycn`, type `Federation`)
+2. **Create organizer co-op** (`nycn-organizers`, type `Cooperative`, parent: `nycn`)
+3. **Create steering committee** (`nycn-steering`, type `Community`, parent: `nycn-organizers`)
+4. **Issue identities** to 3–5 founding organizers via `icnctl id init`
+5. **Add founders** to `nycn-organizers` with `Founder` role
+6. **Add founders** to `nycn-steering` with `BoardMember` role
+7. **Submit and ratify bootstrap charter** via `Charter` proposal in `nycn-organizers-gov`
+8. **Create remaining committees** (content, logistics, marketing, finance)
+9. **Invite additional organizers** — founders use `Invite` capability to bring in the broader team
+10. **Submit and ratify budget** via `Allocation` proposal in `nycn-steering-gov`
+11. **Begin admitting member organizations** to the federation
+
+Steps 1–7 can happen in a single session. Steps 8–11 happen over the following weeks as the institution becomes operational.
+
+---
+
+## Conclusion
+
+NYCN becomes a real institution when:
+
+- Membership implies structured participation, not just a directory listing
+- Decisions are governed through proposals with recorded provenance
+- Budget is a real ledger with double-entry accounting, not a spreadsheet
+- Coordination is persistent, scoped, and survives leadership transitions
+- The summit is one function of an ongoing institutional structure
+- Member organizations are federation entities with real relationships, not rows in a database
+
+This design establishes NYCN as the first real institutional implementation of ICN. Everything required to make NYCN function is everything required to make ICN function for any institution.
+
+The first serious proof that ICN works will not be a feature checklist. It will be a real federation using it to govern itself.
+
+---
+
+*Established 2026-04-13.*

--- a/institutions/nycn/docs/institutional-strategy.md
+++ b/institutions/nycn/docs/institutional-strategy.md
@@ -1,0 +1,264 @@
+# NYCN Is Not an App
+
+> NYCN is where ICN stops performing institutionhood and starts containing institutions.
+
+## The Frame
+
+NYCN is not an app built on top of ICN.
+
+NYCN is a federation living inside ICN.
+
+Its organizing, planning, meetings, budget, directory, communication, records, and governance all happen through ICN's native institutional features. Not through a custom side application. Not through a parallel stack. Through ICN itself.
+
+That means **ny-coop-net disappears** as a separate product. There is no second system. No bespoke organizer app. The interface organizers use is ICN's interface: pilot UI, web portal, console, mobile shell, whatever ICN's standard institutional surface becomes.
+
+And that has a hard implication:
+
+If ICN's interface is not good enough for real organizers doing real work, then ICN is not good enough yet.
+
+Fixing that is not "supporting NYCN."
+Fixing that **is ICN development**.
+
+---
+
+## The Development Principle
+
+NYCN's needs are not special requests.
+They are ICN's feature requirements.
+
+Meeting management is not an NYCN feature.
+It is an ICN platform feature.
+
+Budget visibility is not an NYCN feature.
+It is an ICN platform feature.
+
+Committee views, event structures, document collaboration, sponsor tracking, role-scoped communication, institutional records, and organizer workflows are not customizations for one federation. They are the baseline requirements of any serious cooperative, community, or federation operating inside the system.
+
+So every sprint, every primitive, every workflow gets tested against one question:
+
+**Can NYCN use this to do real organizing work?**
+
+If yes, ship it.
+If no, it is not done.
+
+---
+
+## Identity: Who's Who and Acting As What
+
+Every organizer gets a DID. Every participating organization gets one. The practical value is **scope switching** — Matt acting as himself versus Matt acting as the marketing committee versus Matt acting as an NYCN organizer.
+
+This matters because volunteer organizing is full of ambiguity about who has authority to commit to what on behalf of whom. Right now that's handled informally ("Joe said it was fine"). On ICN, when someone approves a $2,000 sponsorship commitment, the system knows they did it as the finance committee chair with budget authority, not as a random volunteer.
+
+First circle: organizers and participating organizations. Attendees optionally later.
+
+---
+
+## Entity Structure: What Exists
+
+The NYCN federation is the top-level network entity. Under it, the organizer co-op is the body that actually runs things. Under the co-op, you have working groups: steering, content, logistics, marketing, finance. Summit 2026 is a recurring event instance attached to the co-op. Member organizations (the 217+ co-ops, credit unions, nonprofits in the directory) relate to the federation as members or affiliates.
+
+```
+NYCN Federation (top-level network entity)
+├── Organizer Co-op (the body that runs things)
+│   ├── Steering Committee
+│   ├── Content Committee
+│   ├── Logistics Committee
+│   ├── Marketing Committee
+│   ├── Finance Committee
+│   └── Summit 2026 (recurring event instance)
+└── Member Organizations (217+ co-ops, credit unions, nonprofits)
+    └── Each relates to federation as member or affiliate
+```
+
+The practical effect is that every committee, every event, every organizational relationship is a real addressable thing in the system — not a row in a spreadsheet that someone might delete.
+
+---
+
+## Governance: What Gets Decided and How
+
+The NYCN charter (written in CCL) defines: how decisions get made, what thresholds apply, what authority committees have, and what requires full steering committee approval.
+
+### Concrete Decision Flows
+
+**Venue selection.** Logistics committee researches options, narrows to two or three, and submits a proposal to the steering committee. The proposal includes the options, cost comparison, accessibility analysis, and a recommendation. Steering committee members vote. The charter says venue decisions require simple majority with quorum of half the steering committee. When the vote passes, the decision is recorded with full provenance — who proposed, who voted, what the options were, when it was decided. That receipt is permanent. Next year's logistics committee can look at it and understand exactly why Albany was chosen over Buffalo.
+
+**Budget approval.** Finance committee drafts the budget as a document. It gets submitted as a governance proposal. The charter says budget approval requires two-thirds of the steering committee. When approved, the budget becomes a set of treasury constraints enforced by the charter engine. The marketing committee gets a $500 allocation. The logistics committee gets $3,000. Those limits are real — if marketing tries to commit $600 to a print run, the system knows it exceeds their authority and requires an additional approval or budget amendment proposal.
+
+**Speaker/program approval.** Content committee proposes sessions. Depending on the charter, the committee might have autonomous authority to approve individual sessions (no full-body vote needed), but the overall program structure — keynote selection, track organization, session count — might require steering committee sign-off. The charter defines that boundary. This is the governance versus management line made explicit.
+
+**Committee formation.** If someone proposes a new working group (say, a volunteer coordination committee), that's a governance proposal. It defines the scope, authority, and membership of the new group. When approved, the committee becomes a real entity in ICN with its own scope and permissions.
+
+**Sponsorship commitments above a threshold.** Say the charter sets $500 as the line. Below that, the finance committee can accept sponsors autonomously. Above that, it requires a steering committee vote. When a sponsor commits, it becomes a ledger entry and a governance record.
+
+---
+
+## Ledger: Money and Obligations
+
+The summit budget lives in ICN's mutual credit ledger as a treasury. Every financial event is a double-entry journal record.
+
+**Registration income.** When someone registers and pays, that's a credit to the treasury. The entry links to the registrant's identity (if they have one) or is logged as an external receipt.
+
+**Sponsorship income.** When a sponsor's payment comes in, it's a ledger entry linked to the governance record that approved the sponsorship. The provenance chain is: sponsor commits → governance approval → payment received → ledger entry. An auditor can trace it end to end.
+
+**Grant income.** CDF Ed Fund grant, Verizon Digital Ready — each is a ledger entry with its own provenance.
+
+**Expenses.** When the logistics committee books a venue deposit, that's a debit from the treasury. The entry references the budget authorization and the committee's spending authority. If the finance committee set a $3,000 logistics allocation and $2,800 has already been spent, the system knows there's $200 left before the committee needs to request more.
+
+**Financial reconciliation.** At end of cycle, the ledger gives you a complete financial picture: all income, all expenses, all committee allocations, all surplus or deficit. This is not a manually assembled spreadsheet. It's the actual institutional record.
+
+The real power here is transparency. Every organizer can see the budget position at any time. No more "I think we're on track financially but I'd have to check with Frank."
+
+---
+
+## Trust: Earned Authority
+
+New volunteers start with lower trust. They can participate, take on tasks, join committees. But they can't unilaterally commit the organization to financial obligations or make governance proposals until they've built trust through participation. Experienced organizers start with higher trust based on their history.
+
+This isn't arbitrary hierarchy. It's the same thing that already happens informally ("we wouldn't let a brand new volunteer approve a $2,000 sponsorship"), just made explicit and consistent. The charter can define trust thresholds for different actions: anyone can propose a session topic, but only organizers above a certain trust level can propose budget amendments.
+
+---
+
+## Institutional Memory: The Killer Feature
+
+The current situation: 13 years of organizing knowledge scattered across a Google Drive with inconsistent ownership, naming, and structure. Every year, new organizers reconstruct context from scratch.
+
+On ICN, every meeting record, every decision, every budget, every evaluation, every committee report is a content-addressed, provenance-tracked institutional artifact. It doesn't disappear when someone's Google account changes. It doesn't get filed in the wrong folder. The 2028 planning committee can trace the complete institutional history: here's how 2026 was organized, here's what was decided, here's what the evaluations said, here's what the budget looked like, here's who was on each committee and what they did.
+
+Durable institutional memory. The thing NYCN has never had and desperately needs.
+
+---
+
+## Communication: Committee Channels
+
+ICN's gossip layer gives each committee its own communication channel. Steering committee discussions stay in the steering scope. Marketing coordination stays in marketing scope. Cross-committee announcements go to the broader organizing space. Public announcements go to the community-facing layer.
+
+This replaces email threads, group texts, and "did everyone see what was posted in the Facebook group?" The communication is scoped to the institutional structure.
+
+---
+
+## Federation: The Network Beyond the Summit
+
+The 217 organizations in the directory become real federation members (or affiliates, depending on their engagement level). Each participating co-op has its own entity. The federation surface lets them: discover each other, coordinate on shared concerns, participate in network governance, contribute to shared resources.
+
+The summit then becomes the annual convening of that living network — not a one-off event that a small team scrambles to produce each year.
+
+---
+
+## Where ICN Becomes Real
+
+### Compute
+
+Budget calculations enforcing charter constraints. Evaluation analysis. Automated reports derived from governance and ledger state. Session-speaker matching. Routine institutional computation executed through ICN's compute primitive.
+
+That is how compute stops being theoretical. It starts doing normal organizational work under real institutional constraints.
+
+### Commons
+
+The cooperative directory becomes a shared federation resource. Organizing guides, marketing templates, onboarding materials, speaker resources, archival records, and source indexes become commons artifacts.
+
+Accessible across the federation. Maintained collectively. Persisting across volunteer turnover and leadership transitions.
+
+That is how commons stops being rhetoric and becomes durable institutional memory.
+
+### Federation
+
+Cooperation Buffalo, GreenStar, ICA Group, and every other participant stop being rows in a sponsor sheet. They become federation members with their own identities, entity records, permissions, relationships, and history.
+
+A sponsorship becomes an inter-entity transaction with governance provenance. A co-op sending a speaker becomes a cross-entity contribution tracked in the trust and contribution systems. A working relationship becomes an institutional relationship expressed in the substrate.
+
+### Gossip
+
+Committee communication becomes entity-scoped ICN gossip. The marketing committee channel exists because the marketing committee is a real institutional entity. When the steering committee makes an announcement, it propagates through the federation's gossip topology. Communication is not an external bolt-on. It is what the protocol does when institutions actually inhabit it.
+
+### Trust
+
+A new volunteer joins for the 2027 summit. They receive identity. They join committees. They attend meetings, complete tasks, contribute to decisions, build reputation, accumulate trust. Later, that trust supports real authority: budget access, committee leadership, proposal sponsorship, governance weight. Trust is no longer abstract scoring. It's the tracked history of real participation.
+
+### Charter Engine
+
+NYCN's charter becomes the constitutional document of an actual federation using the system to govern itself. Real quorum thresholds. Real committee authority. Real spending constraints. Real proposal rules. Not demo governance. A real institution governing itself through the charter engine.
+
+---
+
+## What Stays Outside ICN
+
+Not everything should live on ICN. These stay app-layer or external:
+
+- **Task-level operations**: "email this sponsor back," "design the flyer," "book the AV equipment." Management, not governance.
+- **Email campaigns**: Mailchimp or equivalent.
+- **Ticket sales UX**: SimpleTix or equivalent.
+- **Website**: Public marketing surface.
+- **Social media**: External platforms.
+- **Day-of logistics**: Room assignments, AV setup, volunteer shifts, food service coordination.
+
+**The line**: ICN holds the institutional reality (who, what authority, what was decided, what money moved, what the rules are). External tools handle operational execution.
+
+---
+
+## What This Means for ICN Development
+
+### Pilot UI
+
+Stops being a demo shell and starts being where organizers actually work.
+
+Needs: dashboards scoped to identity and roles, navigation following entity structure (my committees, my federation, upcoming meetings, recent decisions), document viewing and editing, governance proposal submission and voting, ledger/budget visibility, communication, institutional records that remain legible over time.
+
+If organizers cannot run NYCN through the UI, the UI is not finished.
+
+### Gateway API
+
+Full range of operations per organizer session: check my committees, open tomorrow's agenda, add notes, review recent decisions, submit a proposal, inspect budget state, message logistics, track pending votes, retrieve federation documents, follow provenance from governance to expenditure.
+
+That is what a real institutional API looks like.
+
+### Storage
+
+Content-addressed, provenance-tracked artifacts scoped to producing entity: meeting agendas, notes, committee reports, planning documents, evaluation data, templates, images, directories, onboarding material, shared knowledge artifacts. Not just files in a bucket. Institutional memory with authorship, scope, and history.
+
+### Entity Model
+
+Must hold the actual NYCN topology: federation with member organizations, organizer co-op with committees as working groups, event instances, individual members across multiple scopes, nested governance authority, delegated roles, cross-entity relationships.
+
+If the entity model can't represent that cleanly, it can't represent real institutions.
+
+---
+
+## Concrete Scenario: 2026 Summit on ICN
+
+**January**: Steering committee meets. Agenda in ICN storage. Committee reports submitted. Steering votes to approve 2026 budget (two-thirds threshold). Finance committee draft becomes ratified charter constraint. Committee allocations set. Meeting notes become permanent institutional record.
+
+**February**: Marketing committee operates within $500 allocation autonomously. Marketing plan stored in ICN, scoped to marketing working group. $150 Facebook ads spend logged against authorized budget.
+
+**March**: Content committee proposes program structure (four tracks, keynote, 20 sessions) → steering governance proposal → approved. Individual sessions approved within content committee's delegated authority.
+
+**April**: Logistics proposes Albany as venue → steering vote → passes → decision recorded with provenance. Venue deposit ($1,500) = ledger entry debited from logistics allocation, referencing venue approval.
+
+**May**: Sponsor commitments. Below $500: finance committee accepts autonomously. GreenStar commits $1,000 → requires steering approval per charter → proposal, vote, approval, ledger entry.
+
+**June–September**: Operational execution in external tools. Every financial commitment, major decision, and committee action that matters institutionally flows through ICN.
+
+**October**: Summit happens. Registration data links attendees to event. Financial transactions flow through ledger.
+
+**November**: Post-event. Evaluation captured and stored. Financial reconciliation from ledger. Knowledge capture. Everything becomes permanent institutional memory. 2027 planning committee inherits complete, auditable, structured record.
+
+---
+
+## The Demo Changes
+
+When ICN is demoed, NYCN is the demo.
+
+Not an invented scenario. Not abstract "cooperative governance." Not a sterile proof of concept.
+
+A real federation. Real members. Real committees. Real meetings. Real proposals. Real budget flows. Real institutional records. Real governance. Real work.
+
+That is not proof of concept. That is **proof of life**.
+
+And when the next co-op, network, or federation asks what it would actually look like to use ICN, the answer is:
+
+**Look at NYCN.**
+
+NYCN becomes the reference institution. The first real inhabitant of the system. Everything required to make NYCN function is everything required to make ICN function for anyone.
+
+---
+
+*Established 2026-04-13. The first serious proof that ICN works will not be a feature checklist. It will be a real federation using it to govern itself.*

--- a/institutions/nycn/migrations/README.md
+++ b/institutions/nycn/migrations/README.md
@@ -1,0 +1,3 @@
+# Migration Placeholders
+
+This directory is reserved for NYCN-owned import and migration work. None of these files imply the import flow is implemented yet.

--- a/institutions/nycn/migrations/ny-coop-net-import.placeholder.yaml
+++ b/institutions/nycn/migrations/ny-coop-net-import.placeholder.yaml
@@ -1,0 +1,14 @@
+migration_id: ny-coop-net-import
+status: placeholder
+source_system: ny-coop-net
+targets:
+  - entities
+  - memberships
+  - contacts
+  - summit history links
+required_outputs:
+  - deterministic-id-crosswalk
+  - rerunnable-import-log
+  - provenance-notes
+notes:
+  - "Importer should live with the package, not as a core governance concept."

--- a/institutions/nycn/migrations/schema-crosswalk.placeholder.md
+++ b/institutions/nycn/migrations/schema-crosswalk.placeholder.md
@@ -1,0 +1,8 @@
+# NYCN Schema Crosswalk Placeholder
+
+Planned sections:
+- source tables or sheets
+- target ICN primitives
+- institution-package-only objects
+- unresolved normalization questions
+- idempotence and provenance rules

--- a/institutions/nycn/seed/00-nycn-federation.seed.yaml
+++ b/institutions/nycn/seed/00-nycn-federation.seed.yaml
@@ -1,0 +1,11 @@
+seed_version: draft-0
+kind: entity-seed
+entity:
+  id: nycn
+  entity_type: federation
+  display_name: New York Cooperative Network
+  governance_domain_id: nycn-federation-gov
+  charter_ref: ../charter/nycn-federation.charter.yaml
+  notes:
+    - "Top-level sovereign federation entity."
+    - "Member entity roster remains package-owned configuration, not a core enum."

--- a/institutions/nycn/seed/01-organizer-cooperative.seed.yaml
+++ b/institutions/nycn/seed/01-organizer-cooperative.seed.yaml
@@ -1,0 +1,12 @@
+seed_version: draft-0
+kind: entity-seed
+entity:
+  id: nycn-organizers
+  entity_type: cooperative
+  parent_entity_id: nycn
+  display_name: NYCN Organizers Cooperative
+  governance_domain_id: nycn-organizers-gov
+  operating_purpose: "Runs NYCN operations and summit execution inside the federation."
+  notes:
+    - "Operational owner for structures and activities."
+    - "Separate sovereign entity from the federation."

--- a/institutions/nycn/seed/02-governance-domains.seed.yaml
+++ b/institutions/nycn/seed/02-governance-domains.seed.yaml
@@ -1,0 +1,26 @@
+seed_version: draft-0
+kind: governance-domain-seed
+domains:
+  - id: nycn-federation-gov
+    name: NYCN Federation Governance
+    profile: cooperative_default
+    quorum_percent: 50
+    approval_percent: 50
+    voting_period_days: 7
+    members:
+      - $bootstrap_subject_did
+    decision_mode: consent
+    max_objections: 0
+  - id: nycn-organizers-gov
+    name: NYCN Organizers Governance
+    profile: cooperative_default
+    quorum_percent: 50
+    approval_percent: 50
+    voting_period_days: 7
+    members:
+      - $bootstrap_subject_did
+    decision_mode: consent
+    max_objections: 0
+notes:
+  - "Explicit package-owned governance domains required by NYCN entities."
+  - "The bootstrap runner can resolve $bootstrap_subject_did to the authenticated bootstrap identity DID."

--- a/institutions/nycn/seed/02-structures-committees.seed.yaml
+++ b/institutions/nycn/seed/02-structures-committees.seed.yaml
@@ -1,0 +1,27 @@
+seed_version: draft-0
+kind: structure-seed
+parent_entity_id: nycn-organizers
+structures:
+  - id: nycn-backbone
+    kind: committee
+    name: Backbone Committee
+  - id: nycn-steering
+    kind: committee
+    name: Steering Committee
+  - id: nycn-content
+    kind: committee
+    name: Content Committee
+  - id: nycn-logistics
+    kind: committee
+    name: Logistics Committee
+  - id: nycn-marketing
+    kind: committee
+    name: Marketing Committee
+  - id: nycn-finance
+    kind: committee
+    name: Finance Committee
+  - id: nycn-accessibility-wg
+    kind: working_group
+    name: Accessibility Working Group
+notes:
+  - "These are institution structures built from generic core primitives."

--- a/institutions/nycn/seed/03-summit-activity-program.seed.yaml
+++ b/institutions/nycn/seed/03-summit-activity-program.seed.yaml
@@ -1,0 +1,25 @@
+seed_version: draft-0
+kind: activity-program-seed
+parent_entity_id: nycn-organizers
+activity:
+  id: summit-2026
+  kind: event
+  name: New York Cooperative Summit 2026
+  linked_structures:
+    - nycn-content
+    - nycn-logistics
+    - nycn-marketing
+    - nycn-finance
+program:
+  id: summit-cycle-2026
+  kind:
+    kind: custom
+    kind_tag: annual-summit
+  name: Summit Cycle 2026
+  parent_activity_id: summit-2026
+  prior_cycle_program_id: null
+  views:
+    - summit-operations
+    - sponsor-pipeline
+notes:
+  - "Summit semantics remain package-owned via kind_tag, templates, and workflows."

--- a/institutions/nycn/seed/04-milestone-template.seed.yaml
+++ b/institutions/nycn/seed/04-milestone-template.seed.yaml
@@ -1,0 +1,31 @@
+seed_version: draft-0
+kind: milestone-template-seed
+program_id: summit-cycle-2026
+milestones:
+  - id: summit-strategy-locked
+    title: Strategy Locked
+    phase_index: 0
+    completion_criteria:
+      - "charter:governance-window-confirmed"
+      - "package:committee-owners-confirmed"
+  - id: summit-venue-ready
+    title: Venue Ready
+    phase_index: 1
+    completion_criteria:
+      - "package:venue-review-complete"
+      - "package:accessibility-review-complete"
+  - id: summit-public-launch-ready
+    title: Public Launch Ready
+    phase_index: 2
+    completion_criteria:
+      - "package:registration-flow-published"
+      - "package:communications-kit-approved"
+  - id: summit-cycle-closeout
+    title: Cycle Closeout
+    phase_index: 3
+    completion_criteria:
+      - "package:post-event-retrospective-linked"
+      - "package:next-cycle-handoff-prepared"
+notes:
+  - "Milestone names and criteria are institution-package semantics, not core enums."
+  - "This seed now targets a concrete program_id so the bootstrap planner can produce generic milestone-create operations."

--- a/institutions/nycn/seed/05-role-assignment.seed.yaml
+++ b/institutions/nycn/seed/05-role-assignment.seed.yaml
@@ -1,0 +1,35 @@
+seed_version: draft-0
+kind: role-assignment-seed
+assignments:
+  - structure_id: nycn-steering
+    role: coordinator
+    holder_label: steering-coordinator-placeholder
+    authority_scope:
+      - propose
+      - vote
+      - ratify-summit-plan
+  - structure_id: nycn-finance
+    role: treasurer
+    holder_label: finance-treasurer-placeholder
+    authority_scope:
+      - propose
+      - vote
+      - approve-budget-within-policy
+      - confirm-sponsor-commitment
+  - structure_id: nycn-content
+    role: program-coordinator
+    holder_label: content-program-coordinator-placeholder
+    authority_scope:
+      - propose
+      - vote
+      - curate-session-intake
+  - structure_id: nycn-logistics
+    role: operations-lead
+    holder_label: logistics-operations-lead-placeholder
+    authority_scope:
+      - propose
+      - vote
+      - manage-venue-workflow
+notes:
+  - "Illustrative authority scopes only; final assignments depend on charter rules and live organizers."
+  - "Assignments without person_did are intentionally deferred by the generic bootstrap planner until real DIDs exist."

--- a/institutions/nycn/seed/README.md
+++ b/institutions/nycn/seed/README.md
@@ -1,0 +1,22 @@
+# NYCN Bootstrap Seeds
+
+These manifests are now consumed by the generic package loader entrypoint at `../bootstrap.yaml`.
+
+Current reality:
+- charter parsing and validation work today
+- seed ordering and cross-reference validation work today
+- a generic bootstrap plan can be emitted today
+- a generic bootstrap apply command now exists
+- governance domain provisioning from package seeds now works through the generic domain API
+- activity `linked_structures` can now be persisted through the generic activity API path
+- live entity and structure writes are available today through the generic gateway-backed executor
+- charter registration and role assignments without DIDs are still partial or deferred
+
+Bootstrap order:
+1. `00-nycn-federation.seed.yaml`
+2. `01-organizer-cooperative.seed.yaml`
+3. `02-governance-domains.seed.yaml`
+4. `02-structures-committees.seed.yaml`
+5. `03-summit-activity-program.seed.yaml`
+6. `04-milestone-template.seed.yaml`
+7. `05-role-assignment.seed.yaml`

--- a/institutions/nycn/summit/README.md
+++ b/institutions/nycn/summit/README.md
@@ -1,0 +1,8 @@
+# Summit Layer
+
+This area is for summit-specific materials that should not live in ICN core.
+
+Included here:
+- summit docs and messaging artifacts
+- summit-only templates for sponsor/session/registration operations
+- summit workflow definitions referenced by package-local dashboards and seeds

--- a/institutions/nycn/summit/docs/workshop-proposal-draft.md
+++ b/institutions/nycn/summit/docs/workshop-proposal-draft.md
@@ -1,0 +1,148 @@
+# Workshop Proposal: Democratic Infrastructure for Cooperatives
+
+**Submitted to:** New York Cooperative Summit — October 2026 Call for Presenters
+**Draft date:** 2026-03-23
+**Track:** Technology & Infrastructure
+**Format:** Workshop (90 minutes)
+
+---
+
+## Title
+
+**Infrastructure That Cooperatives Own: A Live Demo of Democratic Coordination**
+
+## Tagline
+
+What if your cooperative's governance rules were enforced by code you controlled — not a platform that could change its terms on you tomorrow?
+
+---
+
+## Abstract
+
+Most cooperative technology runs on platforms owned by someone else. You can use Slack until Slack decides to change its pricing. You can organize on Google Drive until Google decides your account violates a policy. The coordination layer — the substrate on which your democratic processes run — is rented infrastructure, not cooperative infrastructure.
+
+The InterCooperative Network (ICN) is an attempt to fix that. It is free and open-source coordination software, built in Rust, deployed on hardware cooperatives own, where the rules of governance are expressed in a cooperative contract language and enforced by code that anyone can audit.
+
+This workshop is a live demonstration. We will run five cooperative scenarios, end to end, on a real Kubernetes cluster — not a slide deck, not a mockup. Attendees will watch:
+
+- A cooperative governance vote run and produce a verifiable receipt
+- Patronage dividends settled and anchored to the decision that authorized them
+- A clearinghouse record cross-cooperative credit positions across member organizations
+- A worker cooperative generate a signed compliance report over its own transaction history
+- A compute task submitted to a commons resource pool, admitted by trust score, rejected by a restricted token
+
+Five cooperatives. Five cryptographic proofs. Zero central servers.
+
+The session is designed for cooperative organizers, not engineers. The math stays off the screen. The questions it answers are: Can your members verify the vote count without trusting the software vendor? Can you prove where your money went without hiring an auditor? Can you share infrastructure with another cooperative without merging your organizations?
+
+---
+
+## Session Format and Agenda
+
+**Total time:** 90 minutes
+
+### Part 1: Why Cooperative Technology Is a Contradiction Right Now (20 minutes)
+
+Open with the framing problem: cooperatives organize around democratic ownership, but they run their organizations on platforms owned by venture capital. The governance layer is democratic; the infrastructure layer is not.
+
+Brief survey of what this costs cooperatives in practice:
+- Platform lock-in prevents data portability between coops
+- Pricing changes are imposed, not negotiated
+- Surveillance capitalism extracts value from cooperative activity
+- No interoperability between organizations without a shared platform
+
+Introduce the thesis: coordination infrastructure should be a commons. Not a product. Not a service. Infrastructure.
+
+### Part 2: What ICN Does (15 minutes)
+
+Non-technical overview of the five-layer stack:
+
+1. **Identity** — Every member gets a cryptographic identity they control. Not a username in a database. A key pair they own.
+2. **Governance** — Proposals, votes, and tallies produce verifiable receipts. The audit trail is mathematically provable, not organizationally promised.
+3. **Economics** — Mutual credit, patronage settlement, and treasury management without a bank as the trust intermediary.
+4. **Compute** — Shared compute resources allocated by cooperative rules, not market pricing.
+5. **Federation** — Inter-cooperative trust and clearing, without a central clearinghouse.
+
+Key architectural principle: the rules of your cooperative — your bylaws, your governance procedures — are expressed in a contract language that the system enforces mechanically. The rules and the enforcement are not separated.
+
+### Part 3: Live Demo — Five Cooperative Flows (40 minutes)
+
+Live terminal demo on a real Kubernetes cluster. Five scenarios, five cooperatives:
+
+**Flow 1 — Governance (8 min)**
+Brightworks Collective runs a membership vote. A member proposes expanding digital services. Three members vote. Outcome: accepted, with a cryptographic receipt containing the decision hash. The receipt can be verified by any member at any time without trusting the platform.
+
+**Flow 2 — Patronage Settlement (10 min)**
+Brightworks distributes patronage dividends. The settlement is anchored to the governance receipt from Flow 1 via a provenance chain — the economic outcome is cryptographically linked to the democratic decision that authorized it. Governance and economics are not separate systems; they are the same ledger.
+
+**Flow 3 — Clearinghouse (8 min)**
+Rochester Cooperative Clearinghouse records inter-cooperative credit positions. Mutual credit clearing across organizations without a bank. The network is the bank.
+
+**Flow 4 — Compliance Reporting (8 min)**
+Harbor Freight Workers Cooperative generates a signed compliance report over its transaction history. The report is anchored to governance decisions. An auditor can verify the chain without access to internal systems.
+
+**Flow 5 — Commons Compute (6 min)**
+Finger Lakes CDN submits a compute task to a commons pool. Two gates: the member's capability token must carry compute:write scope, and their trust score must meet the admission threshold. Both pass. The task enters the queue with a provenance hash. A restricted token is then used to attempt the same submission — and is rejected. Authorization is not advisory.
+
+**What we do not claim:** Task execution by registered executor nodes is next-sprint work. The admission gate — the trust check, the scope enforcement, the provenance hash — is what we demonstrate. We are precise about what is proven.
+
+### Part 4: Discussion — What Would You Build? (15 minutes)
+
+Structured Q&A structured around cooperative use cases:
+
+- What decisions does your cooperative make that should have verifiable receipts?
+- What data do you share with other cooperatives that you currently can't verify?
+- What shared infrastructure could your federation run if you owned the coordination layer?
+
+Close with the open-source status: ICN is free, self-hosted, and accepts contributions. The code runs on commodity hardware. The cooperatives that ran this demo are fictional; the infrastructure running them is not.
+
+---
+
+## Learning Outcomes
+
+Attendees will leave with:
+
+1. A concrete mental model of what cooperative-owned coordination infrastructure looks like and how it differs from cooperative-controlled tooling on proprietary platforms
+2. Familiarity with five specific coordination patterns — governance, settlement, clearing, reporting, and compute — and how cryptographic receipts make them auditable
+3. An understanding of the trust graph model and why cooperative participation history is a better basis for resource allocation than market pricing
+4. A list of practical questions to ask about their organization's current technology stack: who owns it, what can you verify, and what happens if the platform changes its terms
+5. Contact with ICN's contribution pathways for technically-inclined members
+
+---
+
+## Who This Is For
+
+**Primary audience:** Cooperative organizers, federation builders, and cooperative developers who are thinking about long-term infrastructure strategy. No technical background required.
+
+**Secondary audience:** Cooperative technologists who want to understand the ICN architecture and evaluate it for their organization.
+
+**Not for:** People looking for a ready-to-deploy product with support SLAs. ICN is research-grade infrastructure. This session is honest about that.
+
+---
+
+## Presenter
+
+**Matthew Faherty** — Software architect and cooperative organizer. Core developer of the InterCooperative Network. Organizer of the NY Cooperative Summit (2nd year running, technology track). Based in the Finger Lakes region of New York.
+
+ICN is maintained at [github.com/InterCooperative-Network/icn](https://github.com/InterCooperative-Network/icn).
+
+---
+
+## Technical Requirements
+
+- HDMI connection to projector or large display
+- Reliable internet connection (demo runs on a remote K3s cluster; fallback is local Docker Compose network)
+- Tables or chairs that allow attendees to see the presenter's screen
+- Optional but useful: power strips if attendees want to follow along on laptops
+
+---
+
+## Notes for Organizers
+
+This session intentionally avoids the word "blockchain." ICN is not a blockchain. It has no token, no coin, and no distributed ledger in the cryptocurrency sense. It is a peer-to-peer coordination substrate built on established cryptographic primitives (Ed25519 signatures, QUIC transport, Blake3 hashes). The terminology that matters: cooperative infrastructure, verifiable receipts, and democratic governance enforcement.
+
+The demo scenarios use fictional cooperatives but real software. The Brightworks Collective, Harbor Freight Workers Cooperative, Rochester Cooperative Clearinghouse, New England Mesh Network, and Finger Lakes CDN are illustrative; the Kubernetes cluster they run on is physical homelab hardware.
+
+---
+
+*Draft — 2026-03-23. Not submitted.*

--- a/institutions/nycn/summit/templates/registration-form.template.yaml
+++ b/institutions/nycn/summit/templates/registration-form.template.yaml
@@ -1,0 +1,17 @@
+template_id: summit-registration
+scope: institution-package
+fields:
+  - id: attendee_name
+    type: string
+  - id: organization
+    type: string
+  - id: access_needs
+    type: text
+  - id: childcare_needs
+    type: text
+  - id: dietary_needs
+    type: text
+  - id: payment_state
+    type: string
+notes:
+  - "Registration form shape is package logic, not an ICN core primitive."

--- a/institutions/nycn/summit/templates/session-catalog.template.yaml
+++ b/institutions/nycn/summit/templates/session-catalog.template.yaml
@@ -1,0 +1,17 @@
+template_id: summit-session-catalog
+scope: institution-package
+fields:
+  - id: title
+    type: string
+  - id: description
+    type: text
+  - id: presenters
+    type: list
+  - id: track_tag
+    type: string
+  - id: accessibility_notes
+    type: text
+  - id: status
+    type: string
+notes:
+  - "Session semantics are summit-specific and should not become core enums."

--- a/institutions/nycn/summit/templates/sponsor-commitment.template.yaml
+++ b/institutions/nycn/summit/templates/sponsor-commitment.template.yaml
@@ -1,0 +1,15 @@
+template_id: summit-sponsor-commitment
+scope: institution-package
+fields:
+  - id: sponsor_name
+    type: string
+  - id: commitment_tier_tag
+    type: string
+  - id: benefits_package_ref
+    type: string
+  - id: payment_status
+    type: string
+  - id: steward_structure_id
+    type: string
+notes:
+  - "Sponsor vocabulary stays package-owned."

--- a/institutions/nycn/views/README.md
+++ b/institutions/nycn/views/README.md
@@ -1,0 +1,3 @@
+# NYCN Views
+
+These files describe NYCN-local dashboards and view wiring that sit on top of generic ICN APIs.

--- a/institutions/nycn/views/app-config.yaml
+++ b/institutions/nycn/views/app-config.yaml
@@ -1,0 +1,13 @@
+app_id: nycn
+status: draft
+default_scope_order:
+  - entity:nycn-organizers
+  - structure:nycn-steering
+  - program:summit-cycle-2026
+default_views:
+  - organizer-home
+  - summit-operations
+  - sponsor-pipeline
+  - committee-work
+notes:
+  - "View identifiers are package-owned and may later move into a standalone repo UI."

--- a/institutions/nycn/views/dashboards/organizer-home.view.yaml
+++ b/institutions/nycn/views/dashboards/organizer-home.view.yaml
@@ -1,0 +1,9 @@
+view_id: organizer-home
+backed_by_core_surfaces:
+  - /gov/me/scopes
+  - /gov/me/work
+panels:
+  - active-scopes
+  - urgent-work
+  - upcoming-meetings
+  - current-programs

--- a/institutions/nycn/views/dashboards/sponsor-pipeline.view.yaml
+++ b/institutions/nycn/views/dashboards/sponsor-pipeline.view.yaml
@@ -1,0 +1,8 @@
+view_id: sponsor-pipeline
+scope: program:summit-cycle-2026
+panels:
+  - open-prospects
+  - commitments-awaiting-confirmation
+  - receipts-linked-to-commitments
+notes:
+  - "Sponsor pipeline is institution-package UI, not a generic core dashboard."

--- a/institutions/nycn/views/dashboards/summit-operations.view.yaml
+++ b/institutions/nycn/views/dashboards/summit-operations.view.yaml
@@ -1,0 +1,9 @@
+view_id: summit-operations
+scope: program:summit-cycle-2026
+panels:
+  - milestone-status
+  - committee-readiness
+  - registration-status
+  - venue-readiness
+notes:
+  - "The view is local to NYCN even when it reads generic program/action-item surfaces."

--- a/institutions/nycn/workflows/README.md
+++ b/institutions/nycn/workflows/README.md
@@ -1,0 +1,3 @@
+# NYCN Workflows
+
+These workflows describe institution-specific operational flows that should remain outside ICN core.

--- a/institutions/nycn/workflows/registration-ops.workflow.md
+++ b/institutions/nycn/workflows/registration-ops.workflow.md
@@ -1,0 +1,5 @@
+# Registration Operations Workflow
+
+1. Registration data is collected through package-owned form definitions.
+2. Accessibility, childcare, dietary, and payment fields remain NYCN/summit package concerns.
+3. Aggregate outputs can inform generic ICN work views without pushing the form model into core.

--- a/institutions/nycn/workflows/session-intake.workflow.md
+++ b/institutions/nycn/workflows/session-intake.workflow.md
@@ -1,0 +1,5 @@
+# Session Intake Workflow
+
+1. Content committee collects proposals through the summit session template.
+2. Review and tagging happen in package-owned workflow state, not in core enums.
+3. Accepted sessions are linked back to the summit program and relevant action items.

--- a/institutions/nycn/workflows/sponsor-commitment.workflow.md
+++ b/institutions/nycn/workflows/sponsor-commitment.workflow.md
@@ -1,0 +1,6 @@
+# Sponsor Commitment Workflow
+
+1. Finance committee records prospect data using the package sponsor template.
+2. If commitment authority is within committee policy, confirm locally; otherwise open the required governance proposal.
+3. Link the commitment to the appropriate summit program and receipt trail.
+4. Update package-local sponsor pipeline views.

--- a/institutions/nycn/workflows/venue-selection.workflow.md
+++ b/institutions/nycn/workflows/venue-selection.workflow.md
@@ -1,0 +1,5 @@
+# Venue Selection Workflow
+
+1. Logistics committee gathers venue candidates and accessibility notes.
+2. Package-local readiness criteria determine when the proposal is ready for ratification.
+3. The selected venue is reflected through summit milestone completion and local views.


### PR DESCRIPTION
## Summary
- add a generic institution-package bootstrap contract in `icn-governance` and wire `icnctl institution bootstrap validate|plan|apply`
- add explicit governance-domain provisioning (`governance-domain-seed` + `ProvisionGovernanceDomain`) and enforce domain reference validation
- add generic activity `linked_structures` persistence through governance HTTP + manager path, and scaffold the NYCN institution package/seeds/docs inside the monorepo boundary

## Test Plan
- [x] `cargo fmt --all --check`
- [x] `cargo test -p icn-governance`
- [x] `cargo test -p icn-governance-actor`
- [x] `cargo test -p icnctl`
- [x] `cargo run -p icnctl -- institution bootstrap validate --package ../institutions/nycn`
- [x] `cargo run -p icnctl -- institution bootstrap plan --package ../institutions/nycn`
- [ ] `cargo run -p icnctl -- institution bootstrap apply --package ../institutions/nycn --coop-id <existing-auth-coop>`

## Current Reality
- live apply is blocked in this environment by local keystore/TTY auth (`No such device or address (os error 6)`)
- contract/plan/apply logic now supports generic domain provisioning and `linked_structures`
- remaining known platform gaps after this tranche:
  - generic charter live registration/activation
  - role assignment application once real `person_did` values exist