### PR TITLE
fix(governance): close residual acceptance-closure atomicity hazards

### DIFF
--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -1913,79 +1913,14 @@ impl GovernanceActor {
                     );
                 }
 
-                // For execution-required accepted outcomes, prove closure artifacts
-                // are persistable before committing terminal proposal state.
-                if requires_execution_closure {
-                    if let Some(ref store) = self.receipt_store {
-                        use icn_governance::proof::ProofOutcome;
-                        let preflight_receipt = GovernanceDecisionReceipt::new(
-                            proposal_id.0.clone(),
-                            proposal.domain_id.0.clone(),
-                            ProofOutcome::Accepted,
-                            tally.clone(),
-                            &votes,
-                        );
-                        crate::institutional_effect::emit_accepted_effect(
-                            store.as_ref(),
-                            &proposal_id.0,
-                            &proposal.domain_id.0,
-                            Some(preflight_receipt.decision_hash),
-                            &proposal.payload,
-                            now,
-                        )
-                        .map_err(|e| {
-                            anyhow::anyhow!(
-                                "Proposal '{}' requires execution closure but actor effect emission preflight failed: {e}",
-                                proposal_id.0
-                            )
-                        })?;
-
-                        match crate::grant_minting::mint_and_persist_for_accepted(
-                            store.as_ref(),
-                            &proposal_id.0,
-                            &proposal.domain_id,
-                            preflight_receipt.decision_hash,
-                            &proposal.payload,
-                            now,
-                        ) {
-                            Ok(crate::grant_minting::MandateMintOutcome::Minted { .. })
-                            | Ok(crate::grant_minting::MandateMintOutcome::AlreadyMinted {
-                                ..
-                            }) => {}
-                            Ok(crate::grant_minting::MandateMintOutcome::HashFailed) => {
-                                anyhow::bail!(
-                                    "Proposal '{}' requires execution closure but actor mandate preflight hash failed.",
-                                    proposal_id.0
-                                );
-                            }
-                            Err(e) => {
-                                anyhow::bail!(
-                                    "Proposal '{}' requires execution closure but actor mandate preflight persistence failed: {e}",
-                                    proposal_id.0
-                                );
-                            }
-                        }
-                    }
-                }
-
-                // Update proposal
-                proposal.close(new_state)?;
-
-                // Persist updated state
-                self.store.save_proposal(&proposal)?;
-
-                // Invariant 7: gate all Accepted decisions before effect dispatch.
+                // Invariant 7 gate + closure preflight run BEFORE terminal proposal
+                // persistence. Any failure here must leave the proposal in its
+                // prior state — the only way to keep `save_proposal` and the
+                // caller's result in agreement is to bail before `close()`.
                 //
-                // Construct the receipt from current vote state and verify it passes
-                // check_execution_gate. This is the production enforcement point — no
-                // ProposalAccepted event fires without a receipt that is (a) Accepted and
-                // (b) internally consistent (verify() passes). Non-Accepted outcomes skip
-                // the gate entirely; they never produce resource-allocation effects.
-                //
-                // The canonical governance decision hash (gate_receipt.decision_hash) is
-                // propagated to the ProposalAccepted event so that journal entries created
-                // by create_effect_subscription carry the same hash that keys the
-                // governance receipt chain — enabling hash-level audit verification.
+                // The gate receipt here is canonical: its decision_hash keys the
+                // institutional-effect record, the ADR-0014 mandate, and the
+                // ProposalAccepted event. Construct it once and reuse.
                 let governance_decision_hash: Option<String> = if matches!(
                     outcome_result,
                     DecisionOutcome::Accepted
@@ -2002,25 +1937,78 @@ impl GovernanceActor {
                         error!(
                             proposal_id = %proposal_id.0,
                             error = %gate_err,
-                            "Invariant 7 gate rejected accepted proposal — blocking effect dispatch"
+                            "Invariant 7 gate rejected accepted proposal — blocking terminal persistence"
                         );
                         bail!(
                             "Invariant 7 gate failure for proposal {}: {gate_err}",
                             proposal_id.0
                         );
                     }
-                    let decision_hash_hex = hex::encode(gate_receipt.decision_hash);
+                    let decision_hash = gate_receipt.decision_hash;
                     info!(
                         proposal_id = %proposal_id.0,
-                        decision_hash = %decision_hash_hex,
+                        decision_hash = %hex::encode(decision_hash),
                         "Invariant 7 gate passed"
                     );
-                    Some(decision_hash_hex)
+
+                    // Execution-required preflight: prove closure artifacts are
+                    // persistable before committing terminal proposal state.
+                    if requires_execution_closure {
+                        if let Some(ref store) = self.receipt_store {
+                            crate::institutional_effect::emit_accepted_effect(
+                                store.as_ref(),
+                                &proposal_id.0,
+                                &proposal.domain_id.0,
+                                Some(decision_hash),
+                                &proposal.payload,
+                                now,
+                            )
+                            .map_err(|e| {
+                                anyhow::anyhow!(
+                                    "Proposal '{}' requires execution closure but actor effect emission preflight failed: {e}",
+                                    proposal_id.0
+                                )
+                            })?;
+
+                            match crate::grant_minting::mint_and_persist_for_accepted(
+                                store.as_ref(),
+                                &proposal_id.0,
+                                &proposal.domain_id,
+                                decision_hash,
+                                &proposal.payload,
+                                now,
+                            ) {
+                                Ok(crate::grant_minting::MandateMintOutcome::Minted { .. })
+                                | Ok(crate::grant_minting::MandateMintOutcome::AlreadyMinted {
+                                    ..
+                                }) => {}
+                                Ok(crate::grant_minting::MandateMintOutcome::HashFailed) => {
+                                    anyhow::bail!(
+                                        "Proposal '{}' requires execution closure but actor mandate preflight hash failed.",
+                                        proposal_id.0
+                                    );
+                                }
+                                Err(e) => {
+                                    anyhow::bail!(
+                                        "Proposal '{}' requires execution closure but actor mandate preflight persistence failed: {e}",
+                                        proposal_id.0
+                                    );
+                                }
+                            }
+                        }
+                    }
+
+                    Some(hex::encode(decision_hash))
                 } else {
                     None
                 };
 
-                // Generate GovernanceProofV2 if signing key is available
+                // Generate + persist GovernanceProofV2 BEFORE terminal proposal
+                // save. If proof persistence fails, the proposal must not be
+                // persisted as closed — otherwise the API returns Err while the
+                // store disagrees. Non-Accepted outcomes still emit a proof
+                // (useful for audit of rejection / no-quorum signals) but they
+                // bypass the Invariant 7 gate above.
                 let proof_bytes = if let Some(ref signing_key) = self.signing_key {
                     use icn_governance::ProofOutcome;
 
@@ -2048,7 +2036,9 @@ impl GovernanceActor {
 
                     let serialized = serde_json::to_vec(&proof)?;
 
-                    // Persist proof for later retrieval
+                    // Persist proof for later retrieval. A failure here bails
+                    // before terminal proposal persistence — see block comment
+                    // above.
                     self.store.save_proof_bytes(&proposal_id, &serialized)?;
 
                     info!(
@@ -2065,6 +2055,14 @@ impl GovernanceActor {
                     );
                     None
                 };
+
+                // Update proposal
+                proposal.close(new_state)?;
+
+                // Persist updated state. All invariant checks and durable
+                // closure artifacts (Invariant 7 gate, IER, mandate, proof
+                // bytes) have already passed/persisted at this point.
+                self.store.save_proposal(&proposal)?;
 
                 // Create tally snapshot for broadcast
                 let tally_snapshot = TallySnapshot::new(
@@ -2156,18 +2154,23 @@ impl GovernanceActor {
                 }
 
                 // Canonical institutional-effect emission for actor-backed
-                // normal close. Idempotent on (proposal_id, effect_kind), so
-                // the HTTP close handler's post-actor emission will return
-                // AlreadyEmitted rather than duplicate. When no receipt store
-                // is wired, emission is a no-op and the HTTP handler remains
-                // the sole writer.
+                // normal close (non-execution-required payloads only).
+                // Execution-required payloads already emitted + minted in the
+                // preflight block above; repeating the call would be wasted
+                // work on the idempotent helpers. The HTTP close handler's
+                // post-actor emission remains idempotent on (proposal_id,
+                // effect_kind), so it returns AlreadyEmitted rather than
+                // duplicating. When no receipt store is wired, emission is a
+                // no-op and the HTTP handler remains the sole writer.
                 //
                 // ADR-0014 constitutional-memory seam: mandate + narrow
                 // authority grants are minted through the shared helper
                 // so this actor path produces the same constitutional
                 // artifacts as the standalone `close_proposal_inner`.
                 // Idempotent on `proposal_id` via `get_mandate_by_proposal`.
-                if matches!(outcome_result, DecisionOutcome::Accepted) {
+                if matches!(outcome_result, DecisionOutcome::Accepted)
+                    && !requires_execution_closure
+                {
                     if let Some(ref store) = self.receipt_store {
                         use icn_governance::proof::ProofOutcome;
                         let gate_receipt = GovernanceDecisionReceipt::new(
@@ -2334,60 +2337,97 @@ impl GovernanceActor {
                     );
                 }
 
-                // For execution-required forced accepts, prove closure artifacts are
-                // persistable before committing terminal proposal state.
-                if requires_execution_closure {
-                    if let Some(ref store) = self.receipt_store {
-                        use icn_governance::proof::ProofOutcome;
-                        let forced_receipt = GovernanceDecisionReceipt::new(
-                            proposal_id.0.clone(),
-                            proposal.domain_id.0.clone(),
-                            ProofOutcome::Accepted,
-                            VoteTally::empty(),
-                            &[],
+                // Invariant 7 gate + closure preflight for forced accepts.
+                //
+                // Force-close is an administrative override of vote thresholds,
+                // not of governance-receipt correctness. The gate still applies:
+                // a forced Accept must produce an internally consistent
+                // GovernanceDecisionReceipt before terminal proposal state is
+                // persisted. Forced accepts use VoteTally::empty() and no votes
+                // — the receipt still verifies because the stored hash is
+                // derived from those exact inputs.
+                let force_decision_hash: Option<icn_kernel_api::receipts::Hash> = if matches!(
+                    &forced_outcome,
+                    ForcedOutcome::Accept
+                ) {
+                    use icn_governance::proof::ProofOutcome;
+                    let forced_receipt = GovernanceDecisionReceipt::new(
+                        proposal_id.0.clone(),
+                        proposal.domain_id.0.clone(),
+                        ProofOutcome::Accepted,
+                        VoteTally::empty(),
+                        &[],
+                    );
+                    if let Err(gate_err) = check_execution_gate(&forced_receipt) {
+                        error!(
+                            proposal_id = %proposal_id.0,
+                            error = %gate_err,
+                            "Invariant 7 gate rejected forced-accept — blocking terminal persistence"
                         );
-                        crate::institutional_effect::emit_accepted_effect(
-                            store.as_ref(),
-                            &proposal_id.0,
-                            &proposal.domain_id.0,
-                            Some(forced_receipt.decision_hash),
-                            &proposal.payload,
-                            now_seconds(),
-                        )
-                        .map_err(|e| {
-                            anyhow::anyhow!(
-                                "Proposal '{}' requires execution closure but force-accept effect preflight failed: {e}",
-                                proposal_id.0
-                            )
-                        })?;
+                        bail!(
+                            "Invariant 7 gate failure for forced-accept of proposal {}: {gate_err}",
+                            proposal_id.0
+                        );
+                    }
+                    let decision_hash = forced_receipt.decision_hash;
+                    info!(
+                        proposal_id = %proposal_id.0,
+                        decision_hash = %hex::encode(decision_hash),
+                        "Invariant 7 gate passed (forced accept)"
+                    );
 
-                        match crate::grant_minting::mint_and_persist_for_accepted(
-                            store.as_ref(),
-                            &proposal_id.0,
-                            &proposal.domain_id,
-                            forced_receipt.decision_hash,
-                            &proposal.payload,
-                            now_seconds(),
-                        ) {
-                            Ok(crate::grant_minting::MandateMintOutcome::Minted { .. })
-                            | Ok(crate::grant_minting::MandateMintOutcome::AlreadyMinted {
-                                ..
-                            }) => {}
-                            Ok(crate::grant_minting::MandateMintOutcome::HashFailed) => {
-                                anyhow::bail!(
-                                    "Proposal '{}' requires execution closure but force-accept mandate preflight hash failed.",
-                                    proposal_id.0
-                                );
-                            }
-                            Err(e) => {
-                                anyhow::bail!(
-                                    "Proposal '{}' requires execution closure but force-accept mandate preflight persistence failed: {e}",
-                                    proposal_id.0
-                                );
+                    // Execution-required preflight: prove closure artifacts
+                    // are persistable before committing terminal state.
+                    if requires_execution_closure {
+                        if let Some(ref store) = self.receipt_store {
+                            let now = now_seconds();
+                            crate::institutional_effect::emit_accepted_effect(
+                                    store.as_ref(),
+                                    &proposal_id.0,
+                                    &proposal.domain_id.0,
+                                    Some(decision_hash),
+                                    &proposal.payload,
+                                    now,
+                                )
+                                .map_err(|e| {
+                                    anyhow::anyhow!(
+                                        "Proposal '{}' requires execution closure but force-accept effect preflight failed: {e}",
+                                        proposal_id.0
+                                    )
+                                })?;
+
+                            match crate::grant_minting::mint_and_persist_for_accepted(
+                                store.as_ref(),
+                                &proposal_id.0,
+                                &proposal.domain_id,
+                                decision_hash,
+                                &proposal.payload,
+                                now,
+                            ) {
+                                Ok(crate::grant_minting::MandateMintOutcome::Minted { .. })
+                                | Ok(crate::grant_minting::MandateMintOutcome::AlreadyMinted {
+                                    ..
+                                }) => {}
+                                Ok(crate::grant_minting::MandateMintOutcome::HashFailed) => {
+                                    anyhow::bail!(
+                                            "Proposal '{}' requires execution closure but force-accept mandate preflight hash failed.",
+                                            proposal_id.0
+                                        );
+                                }
+                                Err(e) => {
+                                    anyhow::bail!(
+                                            "Proposal '{}' requires execution closure but force-accept mandate preflight persistence failed: {e}",
+                                            proposal_id.0
+                                        );
+                                }
                             }
                         }
                     }
-                }
+
+                    Some(decision_hash)
+                } else {
+                    None
+                };
 
                 // Force close the proposal
                 proposal.force_close(proposal_outcome.clone(), reason.clone())?;
@@ -2404,26 +2444,10 @@ impl GovernanceActor {
                                 let canonical_payload_hash = serde_json::to_string(&payload)
                                     .ok()
                                     .map(|s| blake3::hash(s.as_bytes()).to_hex().to_string());
-                                // Compute a canonical governance decision hash for the forced
-                                // accept using the same GovernanceDecisionReceipt encoding as
-                                // voted accepts.  VoteTally{0,0,0} accurately represents
-                                // "forced by authority — no votes were cast."
-                                //
-                                // NOTE: no GovernanceDecisionReceipt is stored in the receipt
-                                // backend for forced accepts (the actor has no receipt_store).
-                                // Audit verify will find journal entries via this hash but will
-                                // report "No governance receipt present" — which is honest.
-                                use icn_governance::proof::ProofOutcome;
-                                let forced_decision_hash = {
-                                    let receipt = GovernanceDecisionReceipt::new(
-                                        proposal_id.0.clone(),
-                                        proposal.domain_id.0.clone(),
-                                        ProofOutcome::Accepted,
-                                        VoteTally::empty(),
-                                        &[],
-                                    );
-                                    Some(hex::encode(receipt.decision_hash))
-                                };
+                                // Reuse the gate-verified decision hash computed in the
+                                // preflight block above. VoteTally{0,0,0} accurately
+                                // represents "forced by authority — no votes were cast."
+                                let forced_decision_hash = force_decision_hash.map(hex::encode);
                                 SystemEvent::ProposalAccepted {
                                     proposal_id: proposal_id.0.clone(),
                                     domain_id: proposal.domain_id.0.clone(),
@@ -2466,32 +2490,29 @@ impl GovernanceActor {
                 }
 
                 // Canonical institutional-effect emission for force-accepted
-                // proposals. This closes the historical divergence where
-                // force-accept produced no InstitutionalEffectRecord while
-                // normal accept did. Uses the same translation helper so
-                // audit semantics are path-agnostic. Idempotent on
-                // (proposal_id, effect_kind).
-                if matches!(&forced_outcome, ForcedOutcome::Accept) {
-                    if let Some(ref store) = self.receipt_store {
+                // non-execution-required proposals. Execution-required
+                // payloads already emitted + minted in the preflight block
+                // above (this path's sole writer for them is the preflight);
+                // repeating the idempotent helpers here would be wasted work.
+                // For declarative / non-execution-required force-accepts we
+                // still need a writer, and this block is it — keeping audit
+                // semantics path-agnostic.
+                if matches!(&forced_outcome, ForcedOutcome::Accept) && !requires_execution_closure {
+                    // Reuse the gate-verified decision hash computed in the
+                    // preflight block above so we don't rebuild the receipt
+                    // twice per command. `force_decision_hash` is `Some`
+                    // whenever `forced_outcome == Accept`; if that invariant
+                    // ever breaks the inner block degrades to a no-op rather
+                    // than panicking.
+                    if let (Some(ref store), Some(forced_decision_hash)) =
+                        (self.receipt_store.as_ref(), force_decision_hash)
+                    {
                         let now = now_seconds();
-                        let forced_decision_hash: icn_kernel_api::receipts::Hash = {
-                            use icn_governance::proof::ProofOutcome;
-                            let receipt = GovernanceDecisionReceipt::new(
-                                proposal_id.0.clone(),
-                                proposal.domain_id.0.clone(),
-                                ProofOutcome::Accepted,
-                                VoteTally::empty(),
-                                &[],
-                            );
-                            receipt.decision_hash
-                        };
-                        let decision_hash_bytes: Option<icn_kernel_api::receipts::Hash> =
-                            Some(forced_decision_hash);
                         match crate::institutional_effect::emit_accepted_effect(
                             store.as_ref(),
                             &proposal_id.0,
                             &proposal.domain_id.0,
-                            decision_hash_bytes,
+                            Some(forced_decision_hash),
                             &proposal.payload,
                             now,
                         ) {

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -2059,9 +2059,12 @@ impl GovernanceActor {
                 // Update proposal
                 proposal.close(new_state)?;
 
-                // Persist updated state. All invariant checks and durable
-                // closure artifacts (Invariant 7 gate, IER, mandate, proof
-                // bytes) have already passed/persisted at this point.
+                // Persist updated state. Invariant 7 gate has passed and,
+                // for execution-required Accepted payloads, IER + mandate
+                // preflight writes have already landed. Proof bytes (when
+                // present) were persisted above. IER / mandate for
+                // Accepted + non-execution-required payloads may still be
+                // written below in the guarded post-save block.
                 self.store.save_proposal(&proposal)?;
 
                 // Create tally snapshot for broadcast

--- a/icn/apps/governance/tests/actor_acceptance_closure_atomicity.rs
+++ b/icn/apps/governance/tests/actor_acceptance_closure_atomicity.rs
@@ -32,6 +32,7 @@ use icn_governance_actor::{
 };
 use icn_identity::IdentityBundle;
 use icn_store::SledStore;
+use std::collections::HashMap;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc, Mutex,
@@ -49,6 +50,7 @@ struct CountingReceiptBackend {
     get_mandate_by_proposal_calls: AtomicUsize,
     fail_put_institutional_effect: bool,
     mandates_by_proposal: Mutex<Vec<icn_governance::Mandate>>,
+    grants: Mutex<HashMap<icn_governance::AuthorityGrantId, icn_governance::AuthorityGrant>>,
 }
 
 impl CountingReceiptBackend {
@@ -62,6 +64,7 @@ impl CountingReceiptBackend {
             get_mandate_by_proposal_calls: AtomicUsize::new(0),
             fail_put_institutional_effect: false,
             mandates_by_proposal: Mutex::new(vec![]),
+            grants: Mutex::new(HashMap::new()),
         }
     }
 
@@ -153,30 +156,29 @@ impl GovernanceReceiptBackend for CountingReceiptBackend {
     ) -> Result<(), String> {
         self.put_mandate_with_grants_calls
             .fetch_add(1, Ordering::SeqCst);
+        // Durably record the mandate and every grant so the seam's
+        // read-after-write contract holds.
         self.mandates_by_proposal
             .lock()
             .unwrap()
             .push(mandate.clone());
-        // Also record grants on the no-op defaults so the helper doesn't
-        // abort with grant_durability_not_supported.
         for g in grants {
             self.put_authority_grant(g)?;
-            // read-after-write: return the same grant.
-            let _ = self.get_authority_grant(&g.id)?;
         }
         Ok(())
     }
-    fn put_authority_grant(&self, _grant: &icn_governance::AuthorityGrant) -> Result<(), String> {
+    fn put_authority_grant(&self, grant: &icn_governance::AuthorityGrant) -> Result<(), String> {
+        self.grants
+            .lock()
+            .unwrap()
+            .insert(grant.id.clone(), grant.clone());
         Ok(())
     }
     fn get_authority_grant(
         &self,
-        _grant_id: &icn_governance::AuthorityGrantId,
+        grant_id: &icn_governance::AuthorityGrantId,
     ) -> Result<Option<icn_governance::AuthorityGrant>, String> {
-        // Return a sentinel so the default put_mandate_with_grants fallback
-        // doesn't trip the grant_durability_not_supported sentinel when the
-        // override is used; but the override above never invokes this.
-        Ok(None)
+        Ok(self.grants.lock().unwrap().get(grant_id).cloned())
     }
 }
 

--- a/icn/apps/governance/tests/actor_acceptance_closure_atomicity.rs
+++ b/icn/apps/governance/tests/actor_acceptance_closure_atomicity.rs
@@ -1,0 +1,575 @@
+//! Residual acceptance-closure atomicity regressions (see issue #1588).
+//!
+//! PR #1586 landed the primary atomicity fix: execution-required accepted
+//! proposals now preflight `emit_accepted_effect` and
+//! `mint_and_persist_for_accepted` before `proposal.close()` + `save_proposal`.
+//! This file pins the *residual* invariants that follow from moving the
+//! Invariant 7 gate + proof-byte persistence in front of terminal save and
+//! guarding the redundant post-save emission block:
+//!
+//! 1. Execution-required accepted proposals (both normal close and force
+//!    close) emit their InstitutionalEffectRecord and mandate **exactly
+//!    once** — the preflight is the sole writer, the post-save block is
+//!    skipped.
+//! 2. A preflight failure leaves the proposal in its prior state (Open),
+//!    not persisted as Accepted. The caller sees `Err` and the store
+//!    agrees.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use icn_gossip::{AccessControl, GossipActor, Topic};
+use icn_governance::{
+    sdis::SdisProposal, ForcedOutcome, GovernanceDomainId, GovernanceOps, GovernanceParams,
+    MembershipConfig, ProposalId, ProposalPayload, ProposalScope, ProposalState,
+    StaticMembershipResolver,
+};
+use icn_governance_actor::{
+    actor::GovernanceActor,
+    institutional_effect::InstitutionalEffectRecord,
+    receipt_backend::GovernanceReceiptBackend,
+    state_store::{GovernanceStateStore, SledGovernanceStateStore},
+    GovernanceCommand, GovernanceManager,
+};
+use icn_identity::IdentityBundle;
+use icn_store::SledStore;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc, Mutex,
+};
+
+/// Counting receipt backend. Records every call to `put_institutional_effect`,
+/// `put_mandate_with_grants`, and `put_mandate`, and supports forcing those
+/// writes to fail via a `fail_put_institutional_effect` flag.
+struct CountingReceiptBackend {
+    effects: Mutex<Vec<InstitutionalEffectRecord>>,
+    put_institutional_effect_calls: AtomicUsize,
+    list_institutional_effects_calls: AtomicUsize,
+    put_mandate_calls: AtomicUsize,
+    put_mandate_with_grants_calls: AtomicUsize,
+    get_mandate_by_proposal_calls: AtomicUsize,
+    fail_put_institutional_effect: bool,
+    mandates_by_proposal: Mutex<Vec<icn_governance::Mandate>>,
+}
+
+impl CountingReceiptBackend {
+    fn new() -> Self {
+        Self {
+            effects: Mutex::new(vec![]),
+            put_institutional_effect_calls: AtomicUsize::new(0),
+            list_institutional_effects_calls: AtomicUsize::new(0),
+            put_mandate_calls: AtomicUsize::new(0),
+            put_mandate_with_grants_calls: AtomicUsize::new(0),
+            get_mandate_by_proposal_calls: AtomicUsize::new(0),
+            fail_put_institutional_effect: false,
+            mandates_by_proposal: Mutex::new(vec![]),
+        }
+    }
+
+    fn new_failing_put_institutional_effect() -> Self {
+        let mut b = Self::new();
+        b.fail_put_institutional_effect = true;
+        b
+    }
+}
+
+impl GovernanceReceiptBackend for CountingReceiptBackend {
+    fn put_governance(&self, _: &icn_governance::GovernanceDecisionReceipt) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_governance_by_proposal(
+        &self,
+        _: &str,
+    ) -> Result<Option<icn_governance::GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn put_allocation(
+        &self,
+        _: &icn_kernel_api::AllocationReceipt,
+    ) -> Result<icn_kernel_api::Hash, String> {
+        Ok([0u8; 32])
+    }
+    fn get_governance_by_decision(
+        &self,
+        _: &icn_kernel_api::Hash,
+    ) -> Result<Option<icn_governance::GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn list_allocations_by_decision(
+        &self,
+        _: &icn_kernel_api::Hash,
+    ) -> Result<Vec<icn_kernel_api::AllocationReceipt>, String> {
+        Ok(vec![])
+    }
+    fn put_institutional_effect(&self, record: &InstitutionalEffectRecord) -> Result<(), String> {
+        self.put_institutional_effect_calls
+            .fetch_add(1, Ordering::SeqCst);
+        if self.fail_put_institutional_effect {
+            return Err("injected: put_institutional_effect failed".to_string());
+        }
+        self.effects.lock().unwrap().push(record.clone());
+        Ok(())
+    }
+    fn list_institutional_effects_by_proposal(
+        &self,
+        proposal_id: &str,
+    ) -> Result<Vec<InstitutionalEffectRecord>, String> {
+        self.list_institutional_effects_calls
+            .fetch_add(1, Ordering::SeqCst);
+        Ok(self
+            .effects
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|r| r.proposal_id == proposal_id)
+            .cloned()
+            .collect())
+    }
+    fn put_mandate(&self, mandate: &icn_governance::Mandate) -> Result<(), String> {
+        self.put_mandate_calls.fetch_add(1, Ordering::SeqCst);
+        self.mandates_by_proposal
+            .lock()
+            .unwrap()
+            .push(mandate.clone());
+        Ok(())
+    }
+    fn get_mandate_by_proposal(
+        &self,
+        proposal_id: &str,
+    ) -> Result<Option<icn_governance::Mandate>, String> {
+        self.get_mandate_by_proposal_calls
+            .fetch_add(1, Ordering::SeqCst);
+        Ok(self
+            .mandates_by_proposal
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|m| m.decision.proposal_id == proposal_id)
+            .cloned())
+    }
+    fn put_mandate_with_grants(
+        &self,
+        mandate: &icn_governance::Mandate,
+        grants: &[icn_governance::AuthorityGrant],
+    ) -> Result<(), String> {
+        self.put_mandate_with_grants_calls
+            .fetch_add(1, Ordering::SeqCst);
+        self.mandates_by_proposal
+            .lock()
+            .unwrap()
+            .push(mandate.clone());
+        // Also record grants on the no-op defaults so the helper doesn't
+        // abort with grant_durability_not_supported.
+        for g in grants {
+            self.put_authority_grant(g)?;
+            // read-after-write: return the same grant.
+            let _ = self.get_authority_grant(&g.id)?;
+        }
+        Ok(())
+    }
+    fn put_authority_grant(&self, _grant: &icn_governance::AuthorityGrant) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_authority_grant(
+        &self,
+        _grant_id: &icn_governance::AuthorityGrantId,
+    ) -> Result<Option<icn_governance::AuthorityGrant>, String> {
+        // Return a sentinel so the default put_mandate_with_grants fallback
+        // doesn't trip the grant_durability_not_supported sentinel when the
+        // override is used; but the override above never invokes this.
+        Ok(None)
+    }
+}
+
+async fn gossip_with_governance_topic(
+    did: icn_identity::Did,
+) -> Arc<tokio::sync::RwLock<GossipActor>> {
+    let gossip = GossipActor::spawn(did, None);
+    gossip.write().await.create_topic(Topic::new(
+        "governance:proposal".to_string(),
+        AccessControl::Public,
+    ));
+    gossip
+}
+
+fn appoint_steward_payload(
+    candidate: icn_identity::Did,
+    sponsor: icn_identity::Did,
+) -> ProposalPayload {
+    ProposalPayload::Sdis {
+        proposal: SdisProposal::AppointSteward {
+            candidate,
+            sponsors: vec![sponsor],
+            region: "region-atom".to_string(),
+            bond_amount: 1_000,
+            term_length: 3600 * 24 * 30,
+        },
+    }
+}
+
+/// Execution-required accepted proposals closed via the normal `CloseProposal`
+/// path must emit their `InstitutionalEffectRecord` via the preflight and not
+/// re-run the post-save emission block. We observe this by asserting the
+/// shared helper's `list_institutional_effects_by_proposal` probe runs exactly
+/// once — before the guard, it ran twice (once per emit_accepted_effect call).
+#[tokio::test(flavor = "current_thread")]
+async fn normal_close_execution_required_emits_exactly_once() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db_path = tmp.path().to_path_buf();
+
+    let bundle = IdentityBundle::generate().expect("IdentityBundle::generate");
+    let did = bundle.did().clone();
+    let candidate = IdentityBundle::generate().expect("candidate").did().clone();
+
+    let store: Arc<dyn icn_store::Store> =
+        Arc::new(SledStore::open(&db_path).expect("SledStore::open"));
+    let gossip = gossip_with_governance_topic(did.clone()).await;
+    let resolver = Arc::new(StaticMembershipResolver::new());
+
+    let actor_handle =
+        GovernanceActor::spawn(did.clone(), store.clone(), gossip, resolver, None, None)
+            .await
+            .expect("GovernanceActor::spawn");
+
+    let domain_id = GovernanceDomainId("single-emit-domain".to_string());
+    let manager = GovernanceManager::with_handle(
+        Arc::new(actor_handle.clone()) as Arc<dyn GovernanceOps + Send + Sync>
+    );
+    manager
+        .create_domain(
+            domain_id.clone(),
+            "Single-emit domain".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::new(50, 50, 3600),
+            MembershipConfig::static_list(vec![did.clone()]),
+        )
+        .await
+        .expect("create_domain");
+
+    let proposal_id = manager
+        .create_proposal(
+            ProposalId("_ignored".to_string()),
+            domain_id.clone(),
+            did.clone(),
+            "Appoint steward (single-emit)".to_string(),
+            "".to_string(),
+            appoint_steward_payload(candidate.clone(), did.clone()),
+            ProposalScope::Local,
+        )
+        .await
+        .expect("create_proposal");
+
+    manager
+        .open_proposal(proposal_id.clone(), 3600)
+        .await
+        .expect("open_proposal");
+    manager
+        .cast_vote(
+            proposal_id.clone(),
+            did.clone(),
+            icn_governance::VoteChoice::For,
+            None,
+        )
+        .await
+        .expect("cast_vote");
+
+    let backend = Arc::new(CountingReceiptBackend::new());
+    actor_handle.install_receipt_store(backend.clone()).await;
+
+    actor_handle
+        .submit(GovernanceCommand::CloseProposal {
+            proposal_id: proposal_id.clone(),
+            eligible_voters: None,
+            excluded_delegators: None,
+        })
+        .await
+        .expect("CloseProposal submit");
+
+    // Exactly one IER landed in the store.
+    assert_eq!(
+        backend
+            .put_institutional_effect_calls
+            .load(Ordering::SeqCst),
+        1,
+        "execution-required normal close must call put_institutional_effect exactly once"
+    );
+    // The helper's existence-check probe must not have been called twice —
+    // that would mean the post-save emission block ran redundantly.
+    assert_eq!(
+        backend
+            .list_institutional_effects_calls
+            .load(Ordering::SeqCst),
+        1,
+        "execution-required normal close must not re-run the post-save emission helper"
+    );
+    // Mandate existence-check probe: same invariant.
+    assert!(
+        backend.get_mandate_by_proposal_calls.load(Ordering::SeqCst) <= 1,
+        "execution-required normal close must not re-run the post-save mandate helper; got {}",
+        backend.get_mandate_by_proposal_calls.load(Ordering::SeqCst)
+    );
+
+    actor_handle.shutdown().await;
+}
+
+/// Same invariant for the force-close path: execution-required force-accept
+/// must not double-emit through the post-save block.
+#[tokio::test(flavor = "current_thread")]
+async fn force_close_execution_required_emits_exactly_once() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db_path = tmp.path().to_path_buf();
+
+    let bundle = IdentityBundle::generate().expect("IdentityBundle::generate");
+    let did = bundle.did().clone();
+    let candidate = IdentityBundle::generate().expect("candidate").did().clone();
+
+    let store: Arc<dyn icn_store::Store> =
+        Arc::new(SledStore::open(&db_path).expect("SledStore::open"));
+    let gossip = gossip_with_governance_topic(did.clone()).await;
+    let resolver = Arc::new(StaticMembershipResolver::new());
+
+    let actor_handle =
+        GovernanceActor::spawn(did.clone(), store.clone(), gossip, resolver, None, None)
+            .await
+            .expect("GovernanceActor::spawn");
+
+    let domain_id = GovernanceDomainId("single-emit-force-domain".to_string());
+    let manager = GovernanceManager::with_handle(
+        Arc::new(actor_handle.clone()) as Arc<dyn GovernanceOps + Send + Sync>
+    );
+    manager
+        .create_domain(
+            domain_id.clone(),
+            "Single-emit force domain".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::new(50, 50, 3600),
+            MembershipConfig::static_list(vec![did.clone()]),
+        )
+        .await
+        .expect("create_domain");
+
+    let proposal_id = manager
+        .create_proposal(
+            ProposalId("_ignored".to_string()),
+            domain_id.clone(),
+            did.clone(),
+            "Appoint steward (force, single-emit)".to_string(),
+            "".to_string(),
+            appoint_steward_payload(candidate.clone(), did.clone()),
+            ProposalScope::Local,
+        )
+        .await
+        .expect("create_proposal");
+
+    manager
+        .open_proposal(proposal_id.clone(), 3600)
+        .await
+        .expect("open_proposal");
+
+    let backend = Arc::new(CountingReceiptBackend::new());
+    actor_handle.install_receipt_store(backend.clone()).await;
+
+    actor_handle
+        .submit(GovernanceCommand::ForceCloseProposal {
+            proposal_id: proposal_id.clone(),
+            forced_outcome: ForcedOutcome::Accept,
+            reason: "atomicity regression test".to_string(),
+        })
+        .await
+        .expect("ForceCloseProposal submit");
+
+    assert_eq!(
+        backend
+            .put_institutional_effect_calls
+            .load(Ordering::SeqCst),
+        1,
+        "execution-required force close must call put_institutional_effect exactly once"
+    );
+    assert_eq!(
+        backend
+            .list_institutional_effects_calls
+            .load(Ordering::SeqCst),
+        1,
+        "execution-required force close must not re-run the post-save emission helper"
+    );
+
+    actor_handle.shutdown().await;
+}
+
+/// When the preflight persistence fails on the normal close path, the actor
+/// must leave the proposal in its prior state (`Open`) — not persisted as
+/// `Accepted`. This is the load-bearing atomicity invariant: caller sees
+/// `Err` ⟺ store agrees.
+#[tokio::test(flavor = "current_thread")]
+async fn normal_close_preflight_failure_leaves_proposal_open() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db_path = tmp.path().to_path_buf();
+
+    let bundle = IdentityBundle::generate().expect("IdentityBundle::generate");
+    let did = bundle.did().clone();
+    let candidate = IdentityBundle::generate().expect("candidate").did().clone();
+
+    let store_raw: Arc<dyn icn_store::Store> =
+        Arc::new(SledStore::open(&db_path).expect("SledStore::open"));
+    let gossip = gossip_with_governance_topic(did.clone()).await;
+    let resolver = Arc::new(StaticMembershipResolver::new());
+
+    let actor_handle =
+        GovernanceActor::spawn(did.clone(), store_raw.clone(), gossip, resolver, None, None)
+            .await
+            .expect("GovernanceActor::spawn");
+
+    let domain_id = GovernanceDomainId("preflight-fail-domain".to_string());
+    let manager = GovernanceManager::with_handle(
+        Arc::new(actor_handle.clone()) as Arc<dyn GovernanceOps + Send + Sync>
+    );
+    manager
+        .create_domain(
+            domain_id.clone(),
+            "Preflight-fail domain".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::new(50, 50, 3600),
+            MembershipConfig::static_list(vec![did.clone()]),
+        )
+        .await
+        .expect("create_domain");
+
+    let proposal_id = manager
+        .create_proposal(
+            ProposalId("_ignored".to_string()),
+            domain_id.clone(),
+            did.clone(),
+            "Preflight-fail proposal".to_string(),
+            "".to_string(),
+            appoint_steward_payload(candidate.clone(), did.clone()),
+            ProposalScope::Local,
+        )
+        .await
+        .expect("create_proposal");
+
+    manager
+        .open_proposal(proposal_id.clone(), 3600)
+        .await
+        .expect("open_proposal");
+    manager
+        .cast_vote(
+            proposal_id.clone(),
+            did.clone(),
+            icn_governance::VoteChoice::For,
+            None,
+        )
+        .await
+        .expect("cast_vote");
+
+    // Install a backend that fails put_institutional_effect during preflight.
+    let backend = Arc::new(CountingReceiptBackend::new_failing_put_institutional_effect());
+    actor_handle.install_receipt_store(backend.clone()).await;
+
+    let result = actor_handle
+        .submit(GovernanceCommand::CloseProposal {
+            proposal_id: proposal_id.clone(),
+            eligible_voters: None,
+            excluded_delegators: None,
+        })
+        .await;
+    assert!(result.is_err(), "preflight failure must surface as Err");
+
+    // Re-read the proposal from the same underlying store. State must not
+    // have advanced to Accepted.
+    let state_store: Arc<dyn GovernanceStateStore> =
+        Arc::new(SledGovernanceStateStore::new(store_raw.clone()));
+    let persisted = state_store
+        .get_proposal(&proposal_id)
+        .expect("get_proposal")
+        .expect("proposal must still exist");
+    assert!(
+        matches!(persisted.state, ProposalState::Open { .. }),
+        "preflight failure must leave proposal Open; got {:?}",
+        persisted.state
+    );
+
+    actor_handle.shutdown().await;
+}
+
+/// Same invariant for force-close: preflight persistence failure must not
+/// leave the proposal persisted as Accepted.
+#[tokio::test(flavor = "current_thread")]
+async fn force_close_preflight_failure_leaves_proposal_open() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db_path = tmp.path().to_path_buf();
+
+    let bundle = IdentityBundle::generate().expect("IdentityBundle::generate");
+    let did = bundle.did().clone();
+    let candidate = IdentityBundle::generate().expect("candidate").did().clone();
+
+    let store_raw: Arc<dyn icn_store::Store> =
+        Arc::new(SledStore::open(&db_path).expect("SledStore::open"));
+    let gossip = gossip_with_governance_topic(did.clone()).await;
+    let resolver = Arc::new(StaticMembershipResolver::new());
+
+    let actor_handle =
+        GovernanceActor::spawn(did.clone(), store_raw.clone(), gossip, resolver, None, None)
+            .await
+            .expect("GovernanceActor::spawn");
+
+    let domain_id = GovernanceDomainId("preflight-fail-force-domain".to_string());
+    let manager = GovernanceManager::with_handle(
+        Arc::new(actor_handle.clone()) as Arc<dyn GovernanceOps + Send + Sync>
+    );
+    manager
+        .create_domain(
+            domain_id.clone(),
+            "Preflight-fail force domain".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::new(50, 50, 3600),
+            MembershipConfig::static_list(vec![did.clone()]),
+        )
+        .await
+        .expect("create_domain");
+
+    let proposal_id = manager
+        .create_proposal(
+            ProposalId("_ignored".to_string()),
+            domain_id.clone(),
+            did.clone(),
+            "Preflight-fail proposal (force)".to_string(),
+            "".to_string(),
+            appoint_steward_payload(candidate.clone(), did.clone()),
+            ProposalScope::Local,
+        )
+        .await
+        .expect("create_proposal");
+
+    manager
+        .open_proposal(proposal_id.clone(), 3600)
+        .await
+        .expect("open_proposal");
+
+    let backend = Arc::new(CountingReceiptBackend::new_failing_put_institutional_effect());
+    actor_handle.install_receipt_store(backend.clone()).await;
+
+    let result = actor_handle
+        .submit(GovernanceCommand::ForceCloseProposal {
+            proposal_id: proposal_id.clone(),
+            forced_outcome: ForcedOutcome::Accept,
+            reason: "preflight fail test".to_string(),
+        })
+        .await;
+    assert!(
+        result.is_err(),
+        "force-close preflight failure must surface as Err"
+    );
+
+    let state_store: Arc<dyn GovernanceStateStore> =
+        Arc::new(SledGovernanceStateStore::new(store_raw.clone()));
+    let persisted = state_store
+        .get_proposal(&proposal_id)
+        .expect("get_proposal")
+        .expect("proposal must still exist");
+    assert!(
+        matches!(persisted.state, ProposalState::Open { .. }),
+        "force-close preflight failure must leave proposal Open; got {:?}",
+        persisted.state
+    );
+
+    actor_handle.shutdown().await;
+}


### PR DESCRIPTION
## Summary

Residual acceptance-closure atomicity cleanup after [#1586](https://github.com/InterCooperative-Network/icn/pull/1586). The primary preflight fix (emit_accepted_effect + mint_and_persist_for_accepted before terminal save) already shipped on main; this PR closes the remaining ordering hazards in the proposal close / force-close accepted paths.

Addresses [#1588](https://github.com/InterCooperative-Network/icn/issues/1588).

## Changes

**[apps/governance/src/actor.rs](https://github.com/InterCooperative-Network/icn/blob/main/icn/apps/governance/src/actor.rs)** — staged-failure ordering:

1. **Normal close**: Invariant 7 ExecutionReceiptGate moved in front of save_proposal; decision_hash is reused for preflight and event emission.
2. **Force close**: ExecutionReceiptGate + preflight persistence now run before proposal.close() + save_proposal. The forced decision_hash is threaded through event emission so the observable digest matches the gated one.
3. **Normal close**: save_proof_bytes moved before save_proposal. A proof-blob store failure now aborts closure instead of leaving a terminally Accepted proposal with a missing proof.
4. **Both paths**: post-save accepted-effect / mandate emission block guarded with . Execution-required proposals already emitted under preflight; the post-save block is only for the non-execution-required path.

**[apps/governance/tests/actor_acceptance_closure_atomicity.rs](https://github.com/InterCooperative-Network/icn/blob/main/icn/apps/governance/tests/actor_acceptance_closure_atomicity.rs)** (new, 575 lines) — 4 regression tests using a CountingReceiptBackend with atomic call counters and a fail-injection flag:

- `normal_close_execution_required_emits_exactly_once` — asserts put_institutional_effect + list_institutional_effects each called exactly once.
- `force_close_execution_required_emits_exactly_once` — same for ForceCloseProposal { forced: Accepted }.
- `normal_close_preflight_failure_leaves_proposal_open` — failing put_institutional_effect during preflight returns Err and store still reports ProposalState::Open.
- `force_close_preflight_failure_leaves_proposal_open` — same for ForceCloseProposal.

All tests spawn the full GovernanceActor + SledGovernanceStateStore + GossipActor — no internal-state mocking.

## Why

Staged-failure ordering: if any step in the accepted-close pipeline fails, the caller must see Err and the store must agree (no terminally-Accepted proposal with missing side-effects). The preflight fix in #1586 handled the primary emit/mint race; these residuals close the remaining gaps (gate, proof bytes, duplicate emission).

## How

Scope strictly limited to ordering and the  guard. Public semantics unchanged: non-execution-required paths keep their post-save emission; event shape is unchanged; Err contract on preflight failure is unchanged.

## Risk

- Low. The changes are reorderings + one guard predicate; no new control-flow states.
- Force-close path previously bypassed the Invariant 7 gate entirely. Now it enforces it. A force-close of an Accepted proposal whose receipt hash would not verify will now return Err — but such a receipt was never safe to commit, so this is the correct tightening.

## Test plan

- [x] `cargo check -p icn-governance-actor --tests`
- [x] `cargo test -p icn-governance-actor` — all existing tests (250) + 4 new pass
- [x] `cargo test -p icn-governance-actor --test actor_acceptance_closure_atomicity` — 4/4 pass
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p icn-governance-actor --all-targets --all-features -- -D warnings`
- [ ] Full-workspace clippy / test (deferred to CI)

## Deferred

- Issue B (colon-alias migration for `PROPOSAL_INDEX_PREFIX` and `INSTITUTIONAL_EFFECT_BY_PROPOSAL_PREFIX`) is tracked separately and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)