### PR TITLE
fix(sdis): derive enrollment gateway URL from request

### DIFF
--- a/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
@@ -1157,6 +1157,10 @@ mod tests {
 
     #[actix_web::test]
     async fn test_start_enrollment_uses_request_gateway_url() {
+        // Ensure env-based overrides do not short-circuit the request-derived path.
+        std::env::remove_var("GATEWAY_BASE_URL");
+        std::env::remove_var("TRUSTED_PROXY_IPS");
+
         let app = actix_web::test::init_service(
             App::new()
                 .app_data(web::Data::new(Arc::new(EnrollmentStore::new())))

--- a/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
@@ -54,6 +54,7 @@ use tokio::sync::RwLock;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
+use crate::api::sessions::get_gateway_url;
 use crate::auth::AuthManager;
 use crate::error::{GatewayError, Result};
 use crate::steward_mgr::StewardManager;
@@ -279,6 +280,7 @@ pub struct CompleteEnrollmentResponse {
 /// POST /enrollment/start
 #[post("/enrollment/start")]
 pub async fn start_enrollment(
+    http_req: HttpRequest,
     store: web::Data<Arc<EnrollmentStore>>,
     req: web::Json<StartEnrollmentRequest>,
 ) -> Result<HttpResponse> {
@@ -292,7 +294,7 @@ pub async fn start_enrollment(
         "type": "icn-enrollment",
         "enrollment_id": enrollment_id,
         "challenge": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, enrollment_id.as_bytes()),
-        "gateway_url": "http://10.8.10.40:30080"
+        "gateway_url": get_gateway_url(&http_req)
     });
 
     // Create enrollment session
@@ -1130,6 +1132,7 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use actix_web::App;
 
     #[test]
     fn test_enrollment_store_creation() {
@@ -1150,6 +1153,33 @@ mod tests {
             let enrollments = store.enrollments.read().await;
             assert!(enrollments.is_empty());
         });
+    }
+
+    #[actix_web::test]
+    async fn test_start_enrollment_uses_request_gateway_url() {
+        let app = actix_web::test::init_service(
+            App::new()
+                .app_data(web::Data::new(Arc::new(EnrollmentStore::new())))
+                .service(web::scope("/v1/sdis").service(start_enrollment)),
+        )
+        .await;
+
+        let req = actix_web::test::TestRequest::post()
+            .uri("/v1/sdis/enrollment/start")
+            .insert_header(("host", "10.8.30.40:30080"))
+            .insert_header(("content-type", "application/json"))
+            .set_payload(r#"{"identity_name":"Test User","coop_id":"test-coop"}"#)
+            .to_request();
+
+        let body = actix_web::test::call_and_read_body(&app, req).await;
+        let resp: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            resp["qr_code"]
+                .as_str()
+                .unwrap()
+                .contains("\"gateway_url\":\"http://10.8.30.40:30080\""),
+            "qr payload should advertise the current request gateway"
+        );
     }
 
     #[test]

--- a/icn/crates/icn-gateway/src/api/sessions.rs
+++ b/icn/crates/icn-gateway/src/api/sessions.rs
@@ -44,7 +44,7 @@ fn get_client_ip(req: &HttpRequest) -> String {
 /// **Security**: Pinned GATEWAY_BASE_URL prevents X-Forwarded-* header spoofing.
 /// If GATEWAY_BASE_URL is not set, X-Forwarded-* headers are only trusted if the
 /// request comes from a trusted proxy IP (configured via TRUSTED_PROXY_IPS).
-fn get_gateway_url(req: &HttpRequest) -> String {
+pub(crate) fn get_gateway_url(req: &HttpRequest) -> String {
     // First try environment variable (recommended for production)
     // This takes precedence over all headers to prevent spoofing
     if let Ok(url) = std::env::var("GATEWAY_BASE_URL") {


### PR DESCRIPTION
## What

Updates SDIS enrollment so the gateway URL is derived from the incoming request context instead of stale/static topology assumptions.

## Why

Enrollment links should reflect the gateway address actually used by the requester. The previous hardcoded `http://10.8.10.40:30080` was a VLAN IP that leaks homelab topology assumptions into enrollment behavior and breaks for any node at a different address. This keeps the runtime path separate from the homelab topology docs/config sync in #1594.

## Changes

- Promotes `get_gateway_url` from `fn` to `pub(crate)` in `sessions.rs` so it can be shared.
- `simple_enrollment.rs`: adds `HttpRequest` parameter to `start_enrollment`, replaces hardcoded IP with `get_gateway_url(&http_req)`.
- Adds `test_start_enrollment_uses_request_gateway_url`: actix-web integration test asserting the QR payload `gateway_url` field reflects the request's `Host` header.

## Validation

- `cargo fmt --all --check` ✓
- `cargo check -p icn-gateway` ✓
- `cargo test -p icn-gateway test_start_enrollment_uses_request_gateway_url -- --nocapture` ✓ (1 passed)

## Risk

Low. Scoped to SDIS enrollment URL construction in `simple_enrollment.rs` and visibility change in `sessions.rs`. Does not touch NYCN bootstrap, topology docs, Prometheus, runner config, or Commons/member-shell work.

## Deferred

- PR C (steward dashboard fallback) — separate branch when ready
- Prometheus/ci-runner/Commons work — unrelated to this fix