### PR TITLE
fix(monitoring): move Prometheus to Atlas-backed persistent storage

### DIFF
--- a/deploy/k8s/monitoring/README.md
+++ b/deploy/k8s/monitoring/README.md
@@ -1,0 +1,38 @@
+# Monitoring overlays for the ICN homelab K3s cluster
+
+The monitoring stack itself is deployed via the upstream
+`prometheus-community/kube-prometheus-stack` Helm chart. This directory holds
+the ICN-specific overlays that live alongside the chart release.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `servicemonitor.yaml` | ServiceMonitor + PrometheusRule for the ICN daemon. |
+| `values-kube-prometheus-stack.yaml` | Helm values overlay: durable Atlas-backed storage for Prometheus + Alertmanager (replaces default `emptyDir`). See issue #1596. |
+
+## Apply the Helm values overlay
+
+```bash
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+
+helm upgrade --install kube-prometheus-stack \
+  prometheus-community/kube-prometheus-stack \
+  --namespace monitoring --create-namespace \
+  -f deploy/k8s/monitoring/values-kube-prometheus-stack.yaml
+```
+
+## Verify after rollout
+
+```bash
+kubectl -n monitoring get pvc
+kubectl -n monitoring get sts prometheus-kube-prometheus-stack-prometheus \
+  -o jsonpath='{.spec.volumeClaimTemplates[*].spec.storageClassName}{"\n"}'
+kubectl -n monitoring describe pod \
+  prometheus-kube-prometheus-stack-prometheus-0 | grep -A2 'Volumes:'
+```
+
+Expect: a `Bound` PVC on `atlas-nfs`, storage class `atlas-nfs` on the
+volumeClaimTemplate, and the `/prometheus` mount backed by a PVC (not
+`emptyDir`).

--- a/deploy/k8s/monitoring/values-kube-prometheus-stack.yaml
+++ b/deploy/k8s/monitoring/values-kube-prometheus-stack.yaml
@@ -1,0 +1,56 @@
+# Helm values for kube-prometheus-stack on the ICN homelab K3s cluster.
+#
+# Purpose: replace the default `emptyDir: {}` storage for Prometheus with a
+# durable PVC backed by the cluster's `atlas-nfs` StorageClass (Atlas NFS at
+# 10.8.10.25, csi-driver-nfs v4.9.0).
+#
+# Context:
+#   - Prior incident (see docs/development/sessions/2026-04/2026-04-08-zenith-ops-recovery.md):
+#     Prometheus CrashLoopBackOff with `panic: series ID exceeds 5 bytes`.
+#     TSDB head chunk reference overflow on long-running instance. Pod was using
+#     emptyDir so a pod delete was the entire recovery — every reschedule
+#     silently wipes metric history.
+#   - Issue: #1596
+#   - StorageClass `atlas-nfs` is already in use by ICN workload PVCs
+#     (see deploy/k8s/pvc.yaml, deploy/k8s/multi-node/scripts/deploy-coop.sh).
+#
+# Apply (from a host with kubectl + helm access to the cluster):
+#
+#   helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+#   helm repo update
+#   helm upgrade --install kube-prometheus-stack \
+#     prometheus-community/kube-prometheus-stack \
+#     --namespace monitoring --create-namespace \
+#     -f deploy/k8s/monitoring/values-kube-prometheus-stack.yaml
+#
+# Rollout notes:
+#   - The existing Prometheus pod uses emptyDir; its in-memory TSDB history is
+#     disposable. The upgrade will cause a one-time data loss equivalent to a
+#     pod reschedule, which already happened routinely under the prior config.
+#   - After upgrade, verify: the Prometheus pod has a PVC mounted at /prometheus
+#     (not emptyDir) and `kubectl -n monitoring get pvc` shows a Bound claim on
+#     `atlas-nfs`.
+
+prometheus:
+  prometheusSpec:
+    retention: 30d
+    retentionSize: 18GB
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          accessModes: ["ReadWriteOnce"]
+          storageClassName: atlas-nfs
+          resources:
+            requests:
+              storage: 20Gi
+
+alertmanager:
+  alertmanagerSpec:
+    storage:
+      volumeClaimTemplate:
+        spec:
+          accessModes: ["ReadWriteOnce"]
+          storageClassName: atlas-nfs
+          resources:
+            requests:
+              storage: 2Gi

--- a/docs/operations/deployment/HOMELAB_DEPLOYMENT.md
+++ b/docs/operations/deployment/HOMELAB_DEPLOYMENT.md
@@ -53,13 +53,19 @@ make logs
 
 ## Monitoring Stack (rebuilt 2026-02-21)
 
-Deployed via `kube-prometheus-stack` Helm chart in `monitoring` namespace.
+Deployed via `kube-prometheus-stack` Helm chart in `monitoring` namespace. The
+ICN-specific overlay (ServiceMonitor, alert rules, and durable storage values)
+lives in [`deploy/k8s/monitoring/`](../../../deploy/k8s/monitoring/README.md).
 
 | Component | Access | Notes |
 |-----------|--------|-------|
 | **Grafana** | http://10.8.30.40:30300 | Default admin/prom-operator |
 | **Prometheus** | http://10.8.30.40:30090 | Scrapes ICN metrics |
 | **AlertManager** | K3s internal only | Via kube-prometheus-stack |
+
+Storage: Prometheus and Alertmanager use PVCs on the `atlas-nfs` StorageClass
+via `deploy/k8s/monitoring/values-kube-prometheus-stack.yaml`. Apply with
+`helm upgrade --install kube-prometheus-stack … -f <that file>`.
 
 ## CI/CD Pipeline (rebuilt 2026-02-21)
 


### PR DESCRIPTION
## What

Adds a repo-backed kube-prometheus-stack values overlay that moves Prometheus and Alertmanager storage onto the existing `atlas-nfs` StorageClass.

## Why

Prometheus was previously running on disposable `emptyDir` storage. That made metric history pod-local and meant recovery from TSDB corruption depended on deleting the pod and losing state. Monitoring should have durable, repo-declared storage instead of undocumented scratch state.

## Details

- Adds `deploy/k8s/monitoring/values-kube-prometheus-stack.yaml`.
- Configures Prometheus with a 20Gi `atlas-nfs` PVC.
- Configures Alertmanager with a 2Gi `atlas-nfs` PVC.
- Sets Prometheus retention to 30d with `retentionSize: 18GB`.
- Adds a monitoring README with the intended Helm upgrade and verification commands.
- Links the monitoring overlay from the homelab deployment guide.

## Validation

- [x] `git diff --check`
- [x] YAML parses with Python `yaml.safe_load_all`
- [x] `storageClassName: atlas-nfs` confirmed for Prometheus
- [x] `storageClassName: atlas-nfs` confirmed for Alertmanager
- [x] No live cluster mutation performed
- [ ] Helm render/lint not run because `helm` was not available in PATH

## Rollout notes

This PR intentionally does not mutate the live K3s cluster. After merge, perform a controlled Helm upgrade against the monitoring release and verify that the Prometheus StatefulSet uses a Bound PVC on `atlas-nfs`.

Existing emptyDir TSDB history should be treated as disposable only because the current live setup was confirmed as scratch storage in the prior session notes.

## Risk

- Requires a controlled live rollout after merge.
- A one-time emptyDir wipe/reschedule is expected when moving to PVC-backed storage.
- Atlas remains `10.8.10.25`; do not rewrite this unless live infra checks prove the backend changed.

Refs #1596