### PR TITLE
docs(monitoring): document Helm access path for kube-prometheus-stack upgrade

### DIFF
--- a/deploy/k8s/monitoring/README.md
+++ b/deploy/k8s/monitoring/README.md
@@ -13,14 +13,49 @@ the ICN-specific overlays that live alongside the chart release.
 
 ## Apply the Helm values overlay
 
-```bash
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo update
+Helm is installed on `k3s-control` (`10.8.30.40`) at `/usr/local/bin/helm`. It must be
+invoked with `KUBECONFIG=/etc/rancher/k3s/k3s.yaml` in non-interactive SSH sessions
+(the default kubeconfig falls back to `localhost:8080` which fails over SSH).
 
-helm upgrade --install kube-prometheus-stack \
-  prometheus-community/kube-prometheus-stack \
-  --namespace monitoring --create-namespace \
-  -f deploy/k8s/monitoring/values-kube-prometheus-stack.yaml
+**Copy values file to control node, then upgrade:**
+
+```bash
+# 1. Copy values file to control node
+scp deploy/k8s/monitoring/values-kube-prometheus-stack.yaml \
+    ubuntu@10.8.30.40:/tmp/values-kube-prometheus-stack.yaml
+
+# 2. Dry-run first
+ssh ubuntu@10.8.30.40 \
+  'KUBECONFIG=/etc/rancher/k3s/k3s.yaml sudo -E helm upgrade prometheus \
+    prometheus-community/kube-prometheus-stack \
+    --namespace monitoring \
+    --reuse-values \
+    -f /tmp/values-kube-prometheus-stack.yaml \
+    --dry-run'
+
+# 3. Apply
+ssh ubuntu@10.8.30.40 \
+  'KUBECONFIG=/etc/rancher/k3s/k3s.yaml sudo -E helm upgrade prometheus \
+    prometheus-community/kube-prometheus-stack \
+    --namespace monitoring \
+    --reuse-values \
+    -f /tmp/values-kube-prometheus-stack.yaml \
+    --wait --timeout 10m'
+```
+
+The release name is `prometheus` (not `kube-prometheus-stack`). Use `--reuse-values` to
+avoid resetting other chart defaults that were set at install time.
+
+**Alternative (if routed via icn-dev):**
+
+```bash
+scp deploy/k8s/monitoring/values-kube-prometheus-stack.yaml icn-dev-cursor:/tmp/
+ssh icn-dev-cursor "scp /tmp/values-kube-prometheus-stack.yaml ubuntu@10.8.30.40:/tmp/"
+ssh icn-dev-cursor "ssh ubuntu@10.8.30.40 \
+  'KUBECONFIG=/etc/rancher/k3s/k3s.yaml sudo -E helm upgrade prometheus \
+    prometheus-community/kube-prometheus-stack \
+    --namespace monitoring --reuse-values \
+    -f /tmp/values-kube-prometheus-stack.yaml --wait --timeout 10m'"
 ```
 
 ## Verify after rollout


### PR DESCRIPTION
## What

Updates `deploy/k8s/monitoring/README.md` with the working Helm invocation path discovered during the 2026-04-24 emergency Prometheus recovery.

## Why

Helm is on `k3s-control` but its default kubeconfig falls back to `localhost:8080` in non-interactive SSH sessions. Without `KUBECONFIG=/etc/rancher/k3s/k3s.yaml`, every `helm` command fails with _"Kubernetes cluster unreachable: dial tcp [::1]:8080: connect: connection refused"_. This was the blocker that forced the direct CRD patch path during recovery.

Documenting the working pattern now means the next upgrade (tracked in #1615) can be done through Helm correctly instead of repeating the CRD patch path.

## Details

- Documents release name: `prometheus` (not `kube-prometheus-stack`)
- Documents `--reuse-values` requirement
- Documents `KUBECONFIG=/etc/rancher/k3s/k3s.yaml sudo -E helm` invocation
- Documents both direct (`ssh ubuntu@10.8.30.40`) and two-hop (`icn-dev → k3s-control`) routing

## Validation

- [x] `git diff --check`
- [x] Docs-only; no Rust gates required
- [x] Drift check: PASS

Refs #1615