### PR TITLE
feat(ci): mount ci-runner sccache on Atlas NFS

### DIFF
--- a/deploy/ci-runner/README.md
+++ b/deploy/ci-runner/README.md
@@ -1,0 +1,87 @@
+# ci-runner configuration
+
+Configuration artifacts for the ICN self-hosted GitHub Actions runner
+(`ci-runner`, VM at `10.8.30.46`). The runner itself is installed under
+`~/actions-runner` on the VM; this directory holds the repo-backed pieces that
+operators should apply to the host.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `atlas-sccache-setup.sh` | Mount the shared Atlas-backed sccache and point the runner env at it. See issue #1597. |
+
+## Atlas-backed sccache
+
+The runner historically used a local 10G cache at `~/.cache/sccache`. On a
+77G root filesystem that fills to 80%+ under routine Rust builds, which in turn
+starves builds. `icn-dev` (`10.8.30.45`) has long used a shared NFS cache at
+`/mnt/icn-sccache` backed by Atlas (`10.8.10.25`, ~892G pool). This directory
+captures the same setup for `ci-runner`.
+
+### Apply
+
+Run on the ci-runner host **in a quiet window** (no active GitHub Actions
+jobs — the final step restarts the runner service):
+
+```bash
+# From a workstation:
+scp deploy/ci-runner/atlas-sccache-setup.sh icn-dev-cursor:/tmp/
+ssh icn-dev-cursor "scp /tmp/atlas-sccache-setup.sh ubuntu@10.8.30.46:/tmp/"
+ssh icn-dev-cursor "ssh ubuntu@10.8.30.46 'sudo bash /tmp/atlas-sccache-setup.sh'"
+```
+
+The script is idempotent:
+- Only installs `nfs-common` if missing.
+- Only appends to `/etc/fstab` if no entry for `/mnt/icn-sccache` exists.
+- Only mounts if the path isn't already a mountpoint.
+- Only adds the sccache block to `~ubuntu/.bashrc` if its tagged marker is absent.
+- Rewrites `RUSTC_WRAPPER`, `SCCACHE_DIR`, `SCCACHE_CACHE_SIZE` in
+  `~ubuntu/actions-runner/.env`, preserving other lines.
+- Snapshots `/etc/fstab`, mount table, df, and the runner env to
+  `/tmp/ci-runner-sccache-snapshot-<timestamp>/` before mutating.
+
+### Skip the runner restart
+
+To apply the mount and env changes without restarting the runner service
+(useful while a job is active — the env change won't take effect until the
+next restart):
+
+```bash
+sudo SKIP_RESTART=1 bash /tmp/atlas-sccache-setup.sh
+# later, in a quiet window:
+sudo systemctl restart actions.runner.InterCooperative-Network-icn.ci-runner.service
+```
+
+If `Runner.Worker` is active and `SKIP_RESTART` is not set, the script
+refuses to restart and exits non-zero — rerun later or use `SKIP_RESTART=1`.
+
+### Verify
+
+```bash
+ssh icn-dev-cursor "ssh ubuntu@10.8.30.46 '
+  df -hT /mnt/icn-sccache
+  findmnt /mnt/icn-sccache
+  grep SCCACHE ~/actions-runner/.env
+  systemctl status actions.runner.InterCooperative-Network-icn.ci-runner.service --no-pager --lines=0
+'"
+```
+
+Expected:
+- `/mnt/icn-sccache` mounted on `10.8.10.25:/mnt/ssd_pool/icn-vols/sccache-cache`
+  (NFS v4.2, `hard,noatime,nofail,_netdev`).
+- `~/actions-runner/.env` contains `SCCACHE_DIR=/mnt/icn-sccache` and
+  `SCCACHE_CACHE_SIZE=100G`.
+- Runner service is `active (running)`.
+
+### Rollback
+
+The script does not reclaim the local `~/.cache/sccache` directory. To fully
+revert:
+
+```bash
+sudo umount /mnt/icn-sccache
+sudo sed -i '\|# ICN shared sccache (issue #1597)|,+1d' /etc/fstab
+# restore ~/actions-runner/.env and ~/.bashrc from the snapshot directory
+sudo systemctl restart actions.runner.InterCooperative-Network-icn.ci-runner.service
+```

--- a/deploy/ci-runner/atlas-sccache-setup.sh
+++ b/deploy/ci-runner/atlas-sccache-setup.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# Mount the shared Atlas-backed sccache on a GitHub Actions self-hosted runner.
+#
+# Converts the runner from a local 10G cache (~/.cache/sccache) to the shared
+# NFS cache at /mnt/icn-sccache (Atlas 10.8.10.25, ~892G pool), matching
+# icn-dev (10.8.30.45) which already uses this cache.
+#
+# Context: issue #1597. The NFS export is:
+#     10.8.10.25:/mnt/ssd_pool/icn-vols/sccache-cache
+#
+# Apply on the ci-runner host (10.8.30.46) during a quiet window when no
+# GitHub Actions jobs are running. Check with:
+#
+#     ps aux | grep -E 'Runner.Worker|cargo|rustc' | grep -v grep
+#
+# The final `systemctl restart` interrupts in-progress jobs.
+
+set -euo pipefail
+
+ATLAS_EXPORT="${ATLAS_EXPORT:-10.8.10.25:/mnt/ssd_pool/icn-vols/sccache-cache}"
+MOUNT_POINT="${MOUNT_POINT:-/mnt/icn-sccache}"
+MOUNT_OPTS="${MOUNT_OPTS:-nfs4 rw,hard,noatime,nofail,_netdev,vers=4.2}"
+CACHE_SIZE="${CACHE_SIZE:-100G}"
+RUNNER_USER="${RUNNER_USER:-ubuntu}"
+RUNNER_HOME="/home/${RUNNER_USER}"
+RUNNER_ENV="${RUNNER_HOME}/actions-runner/.env"
+RUNNER_BASHRC="${RUNNER_HOME}/.bashrc"
+RUNNER_SERVICE="${RUNNER_SERVICE:-actions.runner.InterCooperative-Network-icn.ci-runner.service}"
+
+log() { printf '[atlas-sccache-setup] %s\n' "$*"; }
+fail() { printf '[atlas-sccache-setup] ERROR: %s\n' "$*" >&2; exit 1; }
+
+require_root() {
+  [[ $EUID -eq 0 ]] || fail "run as root (sudo)"
+}
+
+snapshot() {
+  local ts
+  ts="$(date +%Y%m%d-%H%M%S)"
+  local dir="/tmp/ci-runner-sccache-snapshot-${ts}"
+  mkdir -p "$dir"
+  cp /etc/fstab "$dir/fstab.before"
+  mount > "$dir/mount.before"
+  df -hT > "$dir/df.before"
+  findmnt -a > "$dir/findmnt.before" || true
+  [[ -f "$RUNNER_ENV" ]] && cp "$RUNNER_ENV" "$dir/actions-runner.env.before" || true
+  [[ -f "$RUNNER_BASHRC" ]] && cp "$RUNNER_BASHRC" "$dir/bashrc.before" || true
+  log "snapshot at $dir"
+  echo "$dir"
+}
+
+install_nfs_client() {
+  if ! dpkg -s nfs-common >/dev/null 2>&1; then
+    log "installing nfs-common"
+    apt-get update -q
+    apt-get install -y nfs-common
+  else
+    log "nfs-common already installed"
+  fi
+}
+
+ensure_mountpoint() {
+  install -d -o "$RUNNER_USER" -g "$RUNNER_USER" -m 0755 "$MOUNT_POINT"
+}
+
+add_fstab() {
+  local entry="${ATLAS_EXPORT} ${MOUNT_POINT} ${MOUNT_OPTS} 0 0"
+  if grep -qsE "^[^#]*${MOUNT_POINT}[[:space:]]" /etc/fstab; then
+    log "fstab entry for ${MOUNT_POINT} already present, leaving alone"
+  else
+    log "appending fstab entry"
+    printf '\n# ICN shared sccache (issue #1597)\n%s\n' "$entry" >> /etc/fstab
+  fi
+}
+
+mount_cache() {
+  if mountpoint -q "$MOUNT_POINT"; then
+    log "${MOUNT_POINT} already mounted"
+    return
+  fi
+  log "mounting ${ATLAS_EXPORT} → ${MOUNT_POINT}"
+  mount "$MOUNT_POINT"
+}
+
+verify_write() {
+  local probe="${MOUNT_POINT}/.ci-runner-write-probe"
+  sudo -u "$RUNNER_USER" touch "$probe" || fail "runner user cannot write to ${MOUNT_POINT}"
+  sudo -u "$RUNNER_USER" rm -f "$probe"
+  log "verified runner user can write to ${MOUNT_POINT}"
+}
+
+update_env() {
+  local tmp
+  tmp="$(mktemp)"
+  if [[ -f "$RUNNER_ENV" ]]; then
+    grep -v -E '^(RUSTC_WRAPPER|SCCACHE_DIR|SCCACHE_CACHE_SIZE)=' "$RUNNER_ENV" > "$tmp" || true
+  fi
+  {
+    echo "RUSTC_WRAPPER=sccache"
+    echo "SCCACHE_DIR=${MOUNT_POINT}"
+    echo "SCCACHE_CACHE_SIZE=${CACHE_SIZE}"
+  } >> "$tmp"
+  install -o "$RUNNER_USER" -g "$RUNNER_USER" -m 0644 "$tmp" "$RUNNER_ENV"
+  rm -f "$tmp"
+  log "wrote ${RUNNER_ENV}"
+}
+
+update_bashrc() {
+  local tag='# === sccache: shared compile cache on Atlas via NFS (issue #1597) ==='
+  if grep -qsF "$tag" "$RUNNER_BASHRC"; then
+    log "bashrc already tagged, leaving alone"
+    return
+  fi
+  cat >> "$RUNNER_BASHRC" <<BRC
+
+${tag}
+if [ -d ${MOUNT_POINT} ] && [ -w ${MOUNT_POINT} ]; then
+  export RUSTC_WRAPPER=sccache
+  export SCCACHE_DIR=${MOUNT_POINT}
+  export SCCACHE_CACHE_SIZE=${CACHE_SIZE}
+fi
+BRC
+  chown "$RUNNER_USER:$RUNNER_USER" "$RUNNER_BASHRC"
+  log "appended sccache block to ${RUNNER_BASHRC}"
+}
+
+restart_runner() {
+  if [[ "${SKIP_RESTART:-0}" == "1" ]]; then
+    log "SKIP_RESTART=1 set — not restarting runner; apply new env by running:"
+    log "    sudo systemctl restart ${RUNNER_SERVICE}"
+    return
+  fi
+  if pgrep -f 'Runner.Worker' >/dev/null 2>&1; then
+    fail "Runner.Worker is active — refusing to restart. Re-run later or export SKIP_RESTART=1."
+  fi
+  log "restarting ${RUNNER_SERVICE}"
+  systemctl restart "$RUNNER_SERVICE"
+  systemctl --no-pager --lines=0 status "$RUNNER_SERVICE" || true
+}
+
+main() {
+  require_root
+  snapshot >/dev/null
+  install_nfs_client
+  ensure_mountpoint
+  add_fstab
+  mount_cache
+  verify_write
+  update_env
+  update_bashrc
+  restart_runner
+  log "done. df -hT ${MOUNT_POINT}:"
+  df -hT "$MOUNT_POINT"
+}
+
+main "$@"

--- a/docs/operations/deployment/HOMELAB_DEPLOYMENT.md
+++ b/docs/operations/deployment/HOMELAB_DEPLOYMENT.md
@@ -78,6 +78,7 @@ via `deploy/k8s/monitoring/values-kube-prometheus-stack.yaml`. Apply with
 | **Specs** | 8 vCPU, 6GB RAM, 80GB disk |
 | **Labels** | `self-hosted, linux, x64, homelab, k3s` |
 | **Rust** | 1.88.0 with sccache |
+| **sccache** | Shared Atlas NFS at `/mnt/icn-sccache` (see [`deploy/ci-runner/`](../../../deploy/ci-runner/README.md), issue #1597) |
 | **Docker** | Configured with insecure registry (10.8.30.40:30500) |
 | **kubectl** | Has kubeconfig for cluster access |
 


### PR DESCRIPTION
## What

Adds a repo-backed, idempotent setup script and runbook for mounting the
shared Atlas-backed sccache on the self-hosted GitHub Actions runner
(`ci-runner`, `10.8.30.46`). Matches the existing `icn-dev` (`10.8.30.45`)
configuration:

```
10.8.10.25:/mnt/ssd_pool/icn-vols/sccache-cache  ->  /mnt/icn-sccache
```

Files:
- `deploy/ci-runner/atlas-sccache-setup.sh` — idempotent setup script (install nfs-common, mkdir, fstab, mount, runner env, optional restart).
- `deploy/ci-runner/README.md` — apply/verify/rollback runbook, including the live-apply path via the `icn-dev-cursor` bridge.
- `docs/operations/deployment/HOMELAB_DEPLOYMENT.md` — references the new setup from the existing ci-runner table.

## Why

`ci-runner` root was at 84% (`64G/77G`) under a local 10G cache at `~/.cache/sccache`, while `icn-dev` already uses the shared 892G Atlas pool. Shifting the runner onto the same mount reduces local disk pressure, increases cache size to 100G, and makes cache hits durable across runner VM rebuilds and reuseable across builds. See issue #1597.

## How

- The script snapshots `/etc/fstab`, `mount`, `df`, and the runner `.env` into `/tmp/ci-runner-sccache-snapshot-<timestamp>/` before mutating anything.
- fstab options (`vers=4.2,hard,noatime,nofail,_netdev`) mirror what is currently live on icn-dev, confirmed via `findmnt` read-only inspection.
- The final `systemctl restart` of the runner service is gated: it refuses to run while `Runner.Worker` is active. Operators can force a deferred restart with `SKIP_RESTART=1`.

## Risk

- **Not applied live yet.** At inspection time the runner was in the middle of a `docker build` for the merge commit of #1617; a restart would have killed that job. The PR ships the runbook; live rollout happens in a quiet window.
- Mount is NFS-only — if Atlas is unreachable at boot, `nofail` prevents the runner from failing to boot; sccache silently falls back to no-cache builds (same pre-state behavior).
- If the runner user UID/GID doesn't match the Atlas export permissions, `verify_write` fails fast and stops the script before env changes land. icn-dev proves ubuntu:ubuntu already works.

## Test plan

Live verification, to be performed in a quiet window after merge:

```bash
# Copy script to runner via bridge
scp deploy/ci-runner/atlas-sccache-setup.sh icn-dev-cursor:/tmp/
ssh icn-dev-cursor "scp /tmp/atlas-sccache-setup.sh ubuntu@10.8.30.46:/tmp/"

# Apply (runner must be idle — script refuses if Runner.Worker is active)
ssh icn-dev-cursor "ssh ubuntu@10.8.30.46 'sudo bash /tmp/atlas-sccache-setup.sh'"

# Verify
ssh icn-dev-cursor "ssh ubuntu@10.8.30.46 '
  df -hT /mnt/icn-sccache
  findmnt /mnt/icn-sccache
  grep SCCACHE ~/actions-runner/.env
  systemctl status actions.runner.InterCooperative-Network-icn.ci-runner.service --no-pager --lines=0
'"
```

Expected post-apply:
- `/mnt/icn-sccache` mounted on `10.8.10.25:/mnt/ssd_pool/icn-vols/sccache-cache` (~892G / ~510G free).
- `~/actions-runner/.env` has `SCCACHE_DIR=/mnt/icn-sccache` and `SCCACHE_CACHE_SIZE=100G`.
- First post-restart Rust build on ci-runner shares cache hits with icn-dev.
- ci-runner root usage drops from 84% toward its pre-cache baseline as the local `~/.cache/sccache` is no longer growing (reclaim is a separate cleanup).

Refs #1597.

🤖 Generated with [Claude Code](https://claude.com/claude-code)