### PR TITLE
feat(infra): add soft pod anti-affinity for K3s workload placement

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -19,6 +19,21 @@ spec:
         app: icn
         component: daemon
     spec:
+      affinity:
+        # Soft anti-affinity: prefer hosts that don't already run another ICN daemon
+        # (icn-daemon here plus the per-coop daemons in icn-coop-* namespaces). Keeps
+        # single-node dev clusters schedulable — this is a preference, not a requirement.
+        # See docs/operations/deployment/HOMELAB_DEPLOYMENT.md and issue #1598.
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                namespaceSelector: {}
+                labelSelector:
+                  matchLabels:
+                    app: icn
+                    component: daemon
       initContainers:
       - name: init-identity
         image: 10.8.30.40:30500/icn:latest

--- a/deploy/k8s/multi-node/scripts/deploy-coop.sh
+++ b/deploy/k8s/multi-node/scripts/deploy-coop.sh
@@ -262,6 +262,21 @@ spec:
         coop: $COOP_NAME
         component: daemon
     spec:
+      affinity:
+        # Soft anti-affinity: prefer hosts that don't already run another ICN daemon.
+        # Uses namespaceSelector: {} so it spreads across the per-coop namespaces and
+        # the main icn-daemon. Preference only — single-node dev clusters still schedule.
+        # See docs/operations/deployment/HOMELAB_DEPLOYMENT.md and issue #1598.
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                namespaceSelector: {}
+                labelSelector:
+                  matchLabels:
+                    app: icn
+                    component: daemon
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/deploy/k8s/pilot-ui-deployment.yaml
+++ b/deploy/k8s/pilot-ui-deployment.yaml
@@ -18,6 +18,18 @@ spec:
         app: icn
         component: pilot-ui
     spec:
+      affinity:
+        # Soft anti-affinity: if pilot-ui is ever scaled > 1, prefer spreading replicas
+        # across hosts. Harmless for the current single-replica deployment. See #1598.
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: icn
+                    component: pilot-ui
       containers:
       - name: pilot-ui
         image: 10.8.30.40:30500/icn-pilot-ui:latest


### PR DESCRIPTION
## What

Adds `preferredDuringSchedulingIgnoredDuringExecution` pod anti-affinity on `kubernetes.io/hostname` to the ICN-managed K3s workloads:

- `icn-daemon` — `deploy/k8s/deployment.yaml`
- `pilot-ui` — `deploy/k8s/pilot-ui-deployment.yaml`
- per-coop daemons — `deploy/k8s/multi-node/scripts/deploy-coop.sh` (generator)

For the daemon workloads, the selector uses `namespaceSelector: {}` so the main `icn-daemon` and the four per-coop daemons (`icn-alpha`/`beta`/`gamma`/`delta`, each in its own `icn-coop-*` namespace) spread across worker nodes.

## Why

Live placement on the homelab K3s cluster before this change:

```
k3s-worker-1: icn-alpha, icn-delta, icn-gamma  (3 coops)
k3s-worker-2: icn-beta, icn-daemon, pilot-ui, registry, grafana,
              prometheus-operator, kube-state-metrics  (1 coop + everything else)
```

Scheduler had no pressure to balance across nodes. Soft rules fix the next reschedule without making anything brittle.

## Details

- `preferredDuringSchedulingIgnoredDuringExecution` with `weight: 100` — preference, not a hard requirement.
- `topologyKey: kubernetes.io/hostname`.
- Daemon selectors match `app: icn, component: daemon` and use `namespaceSelector: {}` (K8s 1.21+) to reach across namespaces.
- `pilot-ui` selector is namespace-scoped (single replica today; rule only matters if someone scales it).
- `registry` and the Helm-managed monitoring stack (Grafana/Prometheus) are out of scope — not tracked as raw manifests in this repo.
- Single-node / dev deployments remain schedulable: the scheduler will place pods on the only available node since the rule is a preference.

## Validation

- `yaml.safe_load_all` parses the modified manifests cleanly.
- Rendered `deploy-coop.sh` output (alpha coop) parses cleanly with the same anti-affinity block.
- Server-side dry-run against the live cluster:
  - `kubectl apply --dry-run=server -f deployment.yaml -n icn` -> `deployment.apps/icn-daemon configured`
  - `kubectl apply --dry-run=server -f pilot-ui-deployment.yaml -n icn` -> `deployment.apps/pilot-ui configured`
  - `kubectl apply --dry-run=server -f <rendered-alpha-deployment>` -> `deployment.apps/icn-alpha configured`
- `git diff --check` clean.

Live rollout not performed in this PR. After merge, the next `make fast-deploy` / coop redeploy will apply the rules, and pods will relocate on the next restart.

## Risk

- Low. Soft rules can only change placement preference, not break scheduling.
- No impact on single-node dev clusters.
- Existing coop pods keep running; rebalance happens on next rollout/restart.

Closes #1598