### PR TITLE
fix(web): derive steward dashboard gateway URL from request context

### DIFF
--- a/web/pilot-ui/steward-dashboard.js
+++ b/web/pilot-ui/steward-dashboard.js
@@ -1,5 +1,16 @@
 // Steward Dashboard JavaScript
 
+// Derive the gateway API base URL from current browser context.
+// Precedence: explicit localStorage override → host-derived port swap → localhost dev fallback.
+// Mirrors the detectGatewayUrl() logic in app.js so both pages use the same gateway.
+function deriveGatewayUrl(hostname, protocol, savedGateway) {
+    if (savedGateway) return savedGateway;
+    if (hostname !== 'localhost' && hostname !== '127.0.0.1') {
+        return `${protocol}//${hostname}:30080`;
+    }
+    return 'http://localhost:8080';
+}
+
 class StewardDashboard {
     constructor() {
         this.apiBase = this.detectApiBase();
@@ -13,11 +24,11 @@ class StewardDashboard {
     }
 
     detectApiBase() {
-        // Use current origin or fallback to gateway
-        if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
-            return 'http://10.8.10.40:30080';
-        }
-        return window.location.origin;
+        return deriveGatewayUrl(
+            window.location.hostname,
+            window.location.protocol,
+            localStorage.getItem('icn-gateway')
+        );
     }
 
     getAuthToken() {

--- a/web/pilot-ui/steward-dashboard.js
+++ b/web/pilot-ui/steward-dashboard.js
@@ -1,8 +1,8 @@
 // Steward Dashboard JavaScript
 
 // Derive the gateway API base URL from current browser context.
-// Precedence: explicit localStorage override → host-derived port swap → localhost dev fallback.
-// Mirrors the detectGatewayUrl() logic in app.js so both pages use the same gateway.
+// The host-derived detection matches app.js; this helper also applies the saved gateway
+// override that app.js handles separately when choosing between saved and detected URLs.
 function deriveGatewayUrl(hostname, protocol, savedGateway) {
     if (savedGateway) return savedGateway;
     if (hostname !== 'localhost' && hostname !== '127.0.0.1') {

--- a/web/pilot-ui/tests/steward-gateway-url.test.js
+++ b/web/pilot-ui/tests/steward-gateway-url.test.js
@@ -1,16 +1,25 @@
 /**
  * Tests for steward dashboard gateway URL derivation logic.
- * Mirrors the deriveGatewayUrl function in steward-dashboard.js.
+ * Loads the real deriveGatewayUrl function from steward-dashboard.js
+ * so tests exercise the production implementation.
  */
 
-// Inline the function under test (browser script has no module exports)
-function deriveGatewayUrl(hostname, protocol, savedGateway) {
-    if (savedGateway) return savedGateway;
-    if (hostname !== 'localhost' && hostname !== '127.0.0.1') {
-        return `${protocol}//${hostname}:30080`;
+const fs = require('fs');
+const path = require('path');
+
+function loadDeriveGatewayUrl() {
+    const stewardDashboardPath = path.resolve(__dirname, '../steward-dashboard.js');
+    const source = fs.readFileSync(stewardDashboardPath, 'utf8');
+    const match = source.match(/function\s+deriveGatewayUrl\s*\([^)]*\)\s*\{[\s\S]*?\n\}/);
+
+    if (!match) {
+        throw new Error(`Could not locate deriveGatewayUrl in ${stewardDashboardPath}`);
     }
-    return 'http://localhost:8080';
+
+    return new Function(`${match[0]}; return deriveGatewayUrl;`)();
 }
+
+const deriveGatewayUrl = loadDeriveGatewayUrl();
 
 describe('deriveGatewayUrl', () => {
     test('explicit localStorage override wins over everything', () => {

--- a/web/pilot-ui/tests/steward-gateway-url.test.js
+++ b/web/pilot-ui/tests/steward-gateway-url.test.js
@@ -1,0 +1,55 @@
+/**
+ * Tests for steward dashboard gateway URL derivation logic.
+ * Mirrors the deriveGatewayUrl function in steward-dashboard.js.
+ */
+
+// Inline the function under test (browser script has no module exports)
+function deriveGatewayUrl(hostname, protocol, savedGateway) {
+    if (savedGateway) return savedGateway;
+    if (hostname !== 'localhost' && hostname !== '127.0.0.1') {
+        return `${protocol}//${hostname}:30080`;
+    }
+    return 'http://localhost:8080';
+}
+
+describe('deriveGatewayUrl', () => {
+    test('explicit localStorage override wins over everything', () => {
+        expect(deriveGatewayUrl('10.8.30.40', 'http:', 'http://custom-gateway:9000'))
+            .toBe('http://custom-gateway:9000');
+    });
+
+    test('explicit override wins even on localhost', () => {
+        expect(deriveGatewayUrl('localhost', 'http:', 'http://override:8888'))
+            .toBe('http://override:8888');
+    });
+
+    test('non-localhost host derives port 30080 from same hostname', () => {
+        expect(deriveGatewayUrl('10.8.30.40', 'http:', null))
+            .toBe('http://10.8.30.40:30080');
+    });
+
+    test('preserves https protocol for TLS deployments', () => {
+        expect(deriveGatewayUrl('icn.example.coop', 'https:', null))
+            .toBe('https://icn.example.coop:30080');
+    });
+
+    test('localhost falls back to dev gateway', () => {
+        expect(deriveGatewayUrl('localhost', 'http:', null))
+            .toBe('http://localhost:8080');
+    });
+
+    test('127.0.0.1 falls back to dev gateway', () => {
+        expect(deriveGatewayUrl('127.0.0.1', 'http:', null))
+            .toBe('http://localhost:8080');
+    });
+
+    test('undefined savedGateway treated as no override', () => {
+        expect(deriveGatewayUrl('10.8.30.40', 'http:', undefined))
+            .toBe('http://10.8.30.40:30080');
+    });
+
+    test('empty string savedGateway treated as no override', () => {
+        expect(deriveGatewayUrl('localhost', 'http:', ''))
+            .toBe('http://localhost:8080');
+    });
+});


### PR DESCRIPTION
## What

Replaces the hardcoded `http://10.8.10.40:30080` fallback in `steward-dashboard.js` with the same host-aware derivation used by `app.js`.

## Why

The steward dashboard was returning a stale homelab IP when opened on localhost, and returning `window.location.origin` (port 30030, the UI port) on deployed hosts — meaning every API call would go to the wrong endpoint. The fix aligns with the existing `detectGatewayUrl()` pattern in `app.js`.

## Details

- Extracts a pure `deriveGatewayUrl(hostname, protocol, savedGateway)` function at module scope (testable without DOM).
- Precedence: explicit `icn-gateway` localStorage override → host-derived port swap to 30080 → `http://localhost:8080` dev fallback.
- `detectApiBase()` becomes a thin wrapper calling `deriveGatewayUrl` with `window.location` values and `localStorage.getItem('icn-gateway')`.
- Local dev behavior preserved: localhost/127.0.0.1 → `http://localhost:8080`.
- Deployed behavior fixed: same hostname as the UI but port 30080, respecting HTTPS.

## Validation

- 8 new unit tests in `tests/steward-gateway-url.test.js` covering: localStorage override, non-localhost derivation, HTTPS protocol, localhost fallback, 127.0.0.1 fallback, undefined/empty override.
- Full suite: `npx jest` → 40/40 passed (2 suites).
- `git diff --check` clean.
- No Rust changes; no cargo gates needed.

Closes #1599