### PR TITLE
fix(governance): persist domains across gateway restart in standalone mode

### DIFF
--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -11,6 +11,7 @@ use crate::dispatch_evidence::{
 };
 use crate::institutional_effect::InstitutionalEffectRecord;
 use crate::receipt_backend::GovernanceReceiptBackend;
+use crate::state_store::{GovernanceStateStore, SledGovernanceStateStore};
 use anyhow::Result;
 use icn_federation::BilateralClearingAgreement;
 use icn_governance::{
@@ -30,6 +31,7 @@ use icn_governance::{
 };
 use icn_identity::Did;
 use icn_kernel_api::{AllocationReceipt, ScopeLevel, SettlementIntent};
+use icn_store::SledStore;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 use tracing::debug;
@@ -2714,6 +2716,15 @@ pub struct GovernanceManager {
     milestone_store: Arc<dyn MilestoneStoreBackend>,
     /// Optional handle to daemon's GovernanceActor (actor-backed mode)
     governance_handle: Option<GovernanceHandle>,
+    /// Optional persistent store for domains (standalone mode only).
+    ///
+    /// When `Some`, standalone-mode domain writes are written through to
+    /// this store and the in-memory `domains` map is seeded from it on
+    /// construction. Unused in actor-backed mode (the actor owns its own
+    /// store). Re-uses `SledGovernanceStateStore`'s `gov:domain:*` key
+    /// space so a future migration to actor-backed mode reads the same
+    /// records.
+    domain_store: Option<Arc<dyn GovernanceStateStore>>,
     /// Optional receipt store for persisting GovernanceDecisionReceipts
     receipt_store: Option<Arc<dyn GovernanceReceiptBackend>>,
     /// Optional append-only log of milestone status transitions.
@@ -2749,6 +2760,7 @@ impl GovernanceManager {
             program_store: Arc::new(InMemoryProgramStore::new()),
             milestone_store: Arc::new(InMemoryMilestoneStore::new()),
             governance_handle: None,
+            domain_store: None,
             receipt_store: None,
             milestone_event_log: None,
             program_event_log: None,
@@ -2787,6 +2799,7 @@ impl GovernanceManager {
             program_store: Arc::new(InMemoryProgramStore::new()),
             milestone_store: Arc::new(InMemoryMilestoneStore::new()),
             governance_handle: Some(handle),
+            domain_store: None,
             receipt_store: None,
             milestone_event_log: None,
             program_event_log: None,
@@ -2893,6 +2906,9 @@ impl GovernanceManager {
             milestone_store: Arc::new(SledMilestoneStore::new(db.clone())),
             governance_handle: Some(handle),
             receipt_store: None,
+            // Actor-backed mode: the actor owns its own state store. Standalone-mode
+            // domain persistence is intentionally not wired here.
+            domain_store: None,
             milestone_event_log: Some(Arc::new(SledMilestoneEventLog::new(db.clone()))),
             program_event_log: Some(Arc::new(SledProgramEventLog::new(db))),
         }
@@ -2901,10 +2917,42 @@ impl GovernanceManager {
     /// Create a standalone governance manager with Sled-backed action item storage
     ///
     /// Useful for testing persistence without a daemon connection.
+    ///
+    /// Governance domains are persisted in the same `gov:domain:*` key space
+    /// the GovernanceActor uses (see `state_store::SledGovernanceStateStore`).
+    /// Existing domains are loaded into the in-memory cache on construction so
+    /// reads stay fast; writes are written through to the store. This makes
+    /// NYCN-style bootstrap apply survive gateway restarts in standalone mode
+    /// (issue #1600).
     pub fn new_with_sled(db: Arc<sled::Db>) -> Self {
-        debug!("GovernanceManager created in standalone mode with Sled action item store");
+        debug!("GovernanceManager created in standalone mode with Sled stores");
+
+        let store: Arc<dyn icn_store::Store> = Arc::new(SledStore::from_db((*db).clone()));
+        let domain_store: Arc<dyn GovernanceStateStore> =
+            Arc::new(SledGovernanceStateStore::new(store));
+
+        // Seed the in-memory cache from the persistent store. If load fails
+        // (e.g. a corrupt entry) we log and continue with an empty cache —
+        // create_domain() will surface conflicts on duplicate IDs once the
+        // failing rows are repaired.
+        let mut domains_map = HashMap::new();
+        match domain_store.list_domains() {
+            Ok(loaded) => {
+                debug!(
+                    "Loaded {} persisted governance domain(s) from store",
+                    loaded.len()
+                );
+                for d in loaded {
+                    domains_map.insert(d.id.clone(), d);
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Failed to load persisted governance domains; starting empty: {e}");
+            }
+        }
+
         GovernanceManager {
-            domains: RwLock::new(HashMap::new()),
+            domains: RwLock::new(domains_map),
             proposals: RwLock::new(HashMap::new()),
             votes: RwLock::new(HashMap::new()),
             delegations: RwLock::new(HashMap::new()),
@@ -2918,6 +2966,7 @@ impl GovernanceManager {
             program_store: Arc::new(SledProgramStore::new(db.clone())),
             milestone_store: Arc::new(SledMilestoneStore::new(db.clone())),
             governance_handle: None,
+            domain_store: Some(domain_store),
             receipt_store: None,
             milestone_event_log: Some(Arc::new(SledMilestoneEventLog::new(db.clone()))),
             program_event_log: Some(Arc::new(SledProgramEventLog::new(db))),
@@ -2970,6 +3019,15 @@ impl GovernanceManager {
             );
         }
 
+        // Write-through to persistent store before mutating the in-memory cache,
+        // so a store failure aborts the create cleanly without leaving an
+        // unpersisted domain that disappears on restart.
+        if let Some(store) = self.domain_store.as_ref() {
+            store
+                .save_domain(&domain)
+                .map_err(|e| anyhow::anyhow!("Failed to persist domain '{}': {e}", domain_id.0))?;
+        }
+
         domains.insert(domain_id, domain);
         Ok(())
     }
@@ -3018,6 +3076,17 @@ impl GovernanceManager {
         }
 
         domain.updated_at = icn_time::current_timestamp_secs();
+
+        // Mirror the membership change into the persistent store so it
+        // survives gateway restart in standalone mode.
+        if let Some(store) = self.domain_store.as_ref() {
+            store.save_domain(domain).map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to persist membership update for domain '{}': {e}",
+                    domain_id.0
+                )
+            })?;
+        }
         Ok(())
     }
 

--- a/icn/apps/governance/tests/standalone_domain_persistence.rs
+++ b/icn/apps/governance/tests/standalone_domain_persistence.rs
@@ -1,0 +1,153 @@
+//! Standalone-mode governance domain persistence proof (issue #1600).
+//!
+//! Proves that domains created through `GovernanceManager::new_with_sled`
+//! survive a sled close+reopen boundary — the standalone-mode equivalent
+//! of `persistence_proof::test_governance_restart_persistence` (which
+//! covers actor-backed mode).
+//!
+//! Before this fix, standalone-mode domains lived only in an in-memory
+//! `HashMap` and disappeared on every gateway restart. After the fix,
+//! they are written through to the same `gov:domain:*` key space the
+//! actor uses, and seeded back into the cache on construction.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use icn_governance::{
+    GovernanceDomainId, GovernanceParams, MembershipAction, MembershipConfig, MembershipSource,
+};
+use icn_governance_actor::manager::GovernanceManager;
+use icn_identity::{Did, IdentityBundle};
+use std::sync::Arc;
+
+fn fresh_did() -> Did {
+    IdentityBundle::generate()
+        .expect("IdentityBundle::generate")
+        .did()
+        .clone()
+}
+
+#[tokio::test]
+async fn standalone_domain_survives_sled_restart() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db_path = tmp.path().to_path_buf();
+
+    let domain_id = GovernanceDomainId("nycn-bootstrap".to_string());
+    let alice = fresh_did();
+    let bob = fresh_did();
+
+    // ── Phase 1: write a domain and drop ────────────────────────────────────
+    {
+        let db = Arc::new(sled::open(&db_path).expect("Phase1: sled::open"));
+        let manager = GovernanceManager::new_with_sled(db.clone());
+
+        manager
+            .create_domain(
+                domain_id.clone(),
+                "NYCN Bootstrap".to_string(),
+                "cooperative_default".to_string(),
+                GovernanceParams::new(50, 50, 3600),
+                MembershipConfig::static_list(vec![alice.clone()]),
+            )
+            .await
+            .expect("Phase1: create_domain");
+
+        let listed = manager.list_domains().await.expect("Phase1: list_domains");
+        assert_eq!(listed.len(), 1, "Phase1: exactly one domain after create");
+
+        // Drop manager and Arc so sled flushes and releases the lock.
+        drop(manager);
+        drop(db);
+    }
+
+    // ── Phase 2: reopen and prove the domain is still there ─────────────────
+    {
+        let db = Arc::new(sled::open(&db_path).expect("Phase2: sled::open after drop"));
+        let manager = GovernanceManager::new_with_sled(db.clone());
+
+        let listed = manager.list_domains().await.expect("Phase2: list_domains");
+        assert_eq!(
+            listed.len(),
+            1,
+            "Phase2: domain must persist across restart, found {}",
+            listed.len()
+        );
+
+        let loaded = manager
+            .get_domain(&domain_id)
+            .await
+            .expect("Phase2: get_domain")
+            .expect("Phase2: domain must exist after restart");
+        assert_eq!(loaded.id, domain_id);
+        assert_eq!(loaded.name, "NYCN Bootstrap");
+        match &loaded.config.membership.source {
+            MembershipSource::StaticList(members) => {
+                assert_eq!(members, &vec![alice.clone()], "members must round-trip");
+            }
+            other => panic!("unexpected membership source after restart: {other:?}"),
+        }
+
+        // Re-creating the same domain id must error — proving the cache was
+        // seeded from disk (not blank).
+        let dup = manager
+            .create_domain(
+                domain_id.clone(),
+                "Duplicate".to_string(),
+                "cooperative_default".to_string(),
+                GovernanceParams::new(50, 50, 3600),
+                MembershipConfig::static_list(vec![alice.clone()]),
+            )
+            .await;
+        assert!(
+            dup.is_err(),
+            "creating an already-persisted domain id must fail"
+        );
+
+        // Membership update must also persist.
+        manager
+            .update_domain_membership(domain_id.clone(), bob.clone(), MembershipAction::Add)
+            .await
+            .expect("Phase2: update_domain_membership add bob");
+
+        drop(manager);
+        drop(db);
+    }
+
+    // ── Phase 3: reopen once more and prove the membership update persisted ─
+    {
+        let db = Arc::new(sled::open(&db_path).expect("Phase3: sled::open"));
+        let manager = GovernanceManager::new_with_sled(db);
+
+        let loaded = manager
+            .get_domain(&domain_id)
+            .await
+            .expect("Phase3: get_domain")
+            .expect("Phase3: domain still present");
+
+        match &loaded.config.membership.source {
+            MembershipSource::StaticList(members) => {
+                assert_eq!(
+                    members.len(),
+                    2,
+                    "Phase3: membership update must persist, got {members:?}"
+                );
+                assert!(members.contains(&alice), "alice must persist");
+                assert!(members.contains(&bob), "bob must persist");
+            }
+            other => panic!("Phase3: unexpected membership source: {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn standalone_empty_db_starts_clean() {
+    // Sanity: a fresh sled with no prior domains should yield an empty manager.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db = Arc::new(sled::open(tmp.path()).expect("sled::open"));
+    let manager = GovernanceManager::new_with_sled(db);
+
+    let listed = manager.list_domains().await.expect("list_domains");
+    assert!(
+        listed.is_empty(),
+        "fresh standalone manager must have no domains"
+    );
+}

--- a/icn/crates/icn-store/src/lib.rs
+++ b/icn/crates/icn-store/src/lib.rs
@@ -616,6 +616,15 @@ impl SledStore {
         Ok(SledStore { db })
     }
 
+    /// Wrap an already-opened Sled database.
+    ///
+    /// Use this when a caller already holds a `sled::Db` (often via `Arc<sled::Db>`)
+    /// and needs `Store`-trait access without opening a second handle. `sled::Db`
+    /// is internally reference-counted, so cloning into the wrapper is cheap.
+    pub fn from_db(db: sled::Db) -> Self {
+        SledStore { db }
+    }
+
     /// Get direct access to underlying Sled database
     ///
     /// This is useful for components that need raw Sled access


### PR DESCRIPTION
## Summary

Closes #1600.

Standalone-mode `GovernanceManager::new_with_sled` previously kept governance domains only in an in-memory `HashMap`. Every gateway restart wiped the institutional state and forced NYCN bootstrap apply to be re-run from scratch.

This wires the manager to the same `gov:domain:*` Sled key space the `GovernanceActor` already uses via `SledGovernanceStateStore`. Reads stay fast (in-memory cache, seeded on construction); writes go through to the store first, then mutate the cache.

## What changed

- `icn-store`: add `SledStore::from_db(db: sled::Db) -> Self` so callers holding an `Arc<sled::Db>` can obtain `Store`-trait access without opening a second handle.
- `apps/governance` (`manager.rs`):
  - new optional `domain_store: Arc<dyn GovernanceStateStore>` field
  - `new_with_sled` constructs `SledGovernanceStateStore` and seeds the in-memory cache from `list_domains()`
  - `create_domain` and `update_domain_membership` write through before mutating the cache
  - actor-backed constructors set `domain_store: None` (the actor owns its own state store)
- `apps/governance/tests/standalone_domain_persistence.rs` (new): three-phase proof — write, restart, verify; mutate, restart, verify; plus a clean-start sanity check.

## Scope

Narrow to domains. Proposals, votes, and delegations remain in-memory in standalone mode — same root cause, but separate follow-ups so each PR stays reviewable.

## Why this order

Persistent domains is the first prerequisite for the broader institutional ecosystem loop (#1602 charter activation, #1603 real-DID role assignment, #1604 `/me/standing`, #1608 `/me/action-cards`). Without it, every restart erases the institution.

See `docs/strategy/institutional-ecosystem-arc.md` (separate PR) for the long-arc framing.

## Test plan

- [x] `cargo test -p icn-governance-actor --test standalone_domain_persistence` (2 new tests pass)
- [x] `cargo test -p icn-governance-actor -p icn-store` (full crate suites pass)
- [x] `cargo check --workspace --all-targets` (no breakage in downstream crates)
- [x] `cargo clippy -p icn-governance-actor -p icn-store --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all --check` (clean)

## Risk

- Low. Additive change: a new optional field, a new pub fn on `SledStore`, a new test file. Actor-backed mode is unchanged. In-memory `new()` mode is unchanged. A restart with a corrupt persisted entry logs a warning and continues with an empty cache rather than panicking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
