### PR TITLE
feat(governance): live charter activation endpoint

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -3284,6 +3284,7 @@ dependencies = [
  "blake3",
  "ed25519-dalek",
  "hex",
+ "icn-ccl",
  "icn-encoding",
  "icn-entity",
  "icn-federation",

--- a/icn/apps/governance/Cargo.toml
+++ b/icn/apps/governance/Cargo.toml
@@ -13,6 +13,9 @@ icn-kernel-api = { path = "../../crates/icn-kernel-api" }
 # Governance domain types (proposals, votes, domains, etc.)
 icn-governance = { path = "../../crates/icn-governance" }
 
+# CCL schema (charter YAML parsing/validation at the HTTP boundary)
+icn-ccl = { path = "../../crates/icn-ccl" }
+
 # Identity types (Did)
 icn-identity = { path = "../../crates/icn-identity" }
 

--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -295,6 +295,8 @@ where
                 .route(web::post().to(handlers::add_domain_member::<E>))
                 .route(web::delete().to(handlers::remove_domain_member::<E>)),
         )
+        // ── Charter activation ────────────────────────────────────────────
+        .service(web::resource("/charters").route(web::post().to(handlers::activate_charter::<E>)))
         // ── Proposal endpoints ────────────────────────────────────────────
         .service(
             web::resource("/proposals")

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -638,18 +638,59 @@ pub async fn remove_domain_member<E: GovernanceEventEmitter + Clone + 'static>(
 // Charter activation handlers
 // ============================================================================
 
+/// Stable, recognizable proposal_id used when the direct charter-activation
+/// path emits a [`GovernanceEffect::DeployCharter`]. The dispatch site
+/// (`server.rs`) keys commons registration on `charter_id` and ignores
+/// `proposal_id`, so a synthetic value is safe and makes the provenance
+/// origin obvious in logs.
+fn direct_activation_pseudo_proposal_id(charter_id: &str) -> String {
+    format!("direct-activation:{charter_id}")
+}
+
 /// POST /gov/charters — Activate a CCL charter directly.
 ///
 /// Bootstrap-side counterpart to the governance-ratification path: hands a
-/// validated CCL document straight to the gateway's `on_charter_accepted`
-/// hook (which deploys it into the `CharterPolicyOracle`).  Does **not**
-/// create a proposal, record a vote, or emit a decision — the charter is
-/// treated as already-decided by an out-of-band ratification.
+/// validated CCL document to the same downstream pair the accepted-proposal
+/// path uses.
 ///
-/// Idempotency: deploying the same `charter_id` again overwrites the prior
-/// document in the oracle. Reactivations therefore succeed and return the
-/// new `activated_at` timestamp; callers that need single-shot semantics
-/// must dedupe upstream.
+/// ## Equivalence with the accepted-proposal path
+///
+/// `close_proposal` (handlers.rs) does two things on charter acceptance:
+///
+/// 1. Calls `on_charter_accepted(charter_id, charter_yaml)` — wired by the
+///    daemon to `CharterPolicyOracle::deploy_charter`, so the kernel starts
+///    enforcing the charter's CCL constraints immediately.
+/// 2. Calls `on_proposal_accepted(GovernanceEffect::DeployCharter)` — wired
+///    by the gateway to `commons.store_charter(...)`, registering the domain
+///    in the commons charter store so downstream `register_steward` /
+///    jurisdiction-binding flows will recognize it.
+///
+/// This handler invokes **both** hooks. Without the second dispatch the
+/// endpoint would silently leave commons unaware of the domain, breaking
+/// SDIS steward registration (which validates that the jurisdiction's
+/// charter exists in commons).
+///
+/// ## Out of scope (intentional)
+///
+/// - **Institutional effect record / decision-hash provenance.** The
+///   ratified path persists an `InstitutionalEffectRecord` keyed by a real
+///   proposal_id and bound to the governance receipt's `decision_hash`.
+///   Direct activation has no proposal/decision, so no such record is
+///   emitted. Provenance for this path is the `tracing` audit trail plus
+///   the synthetic `direct-activation:<charter_id>` proposal_id appearing
+///   in commons logs. Adding a synthetic proposal record would require a
+///   broader institutional-history redesign — tracked elsewhere.
+/// - **Dispatch evidence (`on_proposal_accepted_with_evidence`).** The
+///   evidence sink writes rows keyed by a real `proposal_id`; firing it
+///   here would create orphan rows. Skipped intentionally.
+///
+/// ## Idempotency
+///
+/// `CharterPolicyOracle::deploy_charter` overwrites in place per
+/// `charter_id`, and the commons dispatch treats "already exists" as a
+/// no-op (`server.rs` DeployCharter handler). Reactivating the same
+/// `charter_id` therefore succeeds with a fresh `activated_at`. Callers
+/// that need single-shot semantics must dedupe upstream.
 pub async fn activate_charter<E: GovernanceEventEmitter + Clone + 'static>(
     ctx: web::Data<GovernanceContext<E>>,
     http_req: HttpRequest,
@@ -668,11 +709,32 @@ pub async fn activate_charter<E: GovernanceEventEmitter + Clone + 'static>(
     doc.validate()
         .map_err(|e| err_bad(format!("Charter validation failed: {e}")))?;
 
-    let hook = ctx
+    let charter_hook = ctx
         .on_charter_accepted
         .as_ref()
         .ok_or_else(|| err_internal("Charter activation hook is not wired"))?;
-    hook(req.charter_id.clone(), req.charter_yaml.clone());
+    charter_hook(req.charter_id.clone(), req.charter_yaml.clone());
+
+    // Mirror the accepted-proposal close path: emit DeployCharter so the
+    // gateway registers the domain in the commons charter store. Without
+    // this, downstream `register_steward` / jurisdiction-binding checks
+    // (which read the commons charter table) will not see the domain even
+    // though the charter is live in the policy oracle.
+    if let Some(proposal_hook) = &ctx.on_proposal_accepted {
+        proposal_hook(GovernanceEffect::DeployCharter {
+            proposal_id: direct_activation_pseudo_proposal_id(&req.charter_id),
+            charter_id: req.charter_id.clone(),
+        });
+    } else {
+        // Defensive: missing the proposal hook means commons registration
+        // will not happen and the success response would be misleading.
+        // The daemon wires both hooks unconditionally; this branch only
+        // fires in misconfigured deployments or test envs that opt out.
+        return Err(err_internal(
+            "Charter activation rejected: governance acceptance hook is not wired, \
+             so commons registration cannot run and the charter would be only partially active",
+        ));
+    }
 
     Ok(HttpResponse::Created().json(ActivateCharterResponse {
         charter_id: req.charter_id.clone(),

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -635,6 +635,53 @@ pub async fn remove_domain_member<E: GovernanceEventEmitter + Clone + 'static>(
 }
 
 // ============================================================================
+// Charter activation handlers
+// ============================================================================
+
+/// POST /gov/charters — Activate a CCL charter directly.
+///
+/// Bootstrap-side counterpart to the governance-ratification path: hands a
+/// validated CCL document straight to the gateway's `on_charter_accepted`
+/// hook (which deploys it into the `CharterPolicyOracle`).  Does **not**
+/// create a proposal, record a vote, or emit a decision — the charter is
+/// treated as already-decided by an out-of-band ratification.
+///
+/// Idempotency: deploying the same `charter_id` again overwrites the prior
+/// document in the oracle. Reactivations therefore succeed and return the
+/// new `activated_at` timestamp; callers that need single-shot semantics
+/// must dedupe upstream.
+pub async fn activate_charter<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    req: web::Json<ActivateCharterRequest>,
+) -> Result<HttpResponse, ApiError> {
+    require_scope::<BasicClaims>(&http_req, "governance:write")?;
+
+    val::validate_charter_id(&req.charter_id)?;
+    val::validate_charter_yaml(&req.charter_yaml)?;
+
+    // Parse and structurally validate at the boundary so malformed input
+    // returns 400 instead of being silently dropped by the fire-and-forget
+    // hook.
+    let doc = icn_ccl::schema::CclDocument::from_yaml(&req.charter_yaml)
+        .map_err(|e| err_bad(format!("Invalid CCL YAML: {e}")))?;
+    doc.validate()
+        .map_err(|e| err_bad(format!("Charter validation failed: {e}")))?;
+
+    let hook = ctx
+        .on_charter_accepted
+        .as_ref()
+        .ok_or_else(|| err_internal("Charter activation hook is not wired"))?;
+    hook(req.charter_id.clone(), req.charter_yaml.clone());
+
+    Ok(HttpResponse::Created().json(ActivateCharterResponse {
+        charter_id: req.charter_id.clone(),
+        status: "active".to_string(),
+        activated_at: current_time_secs(),
+    }))
+}
+
+// ============================================================================
 // Proposal handlers
 // ============================================================================
 

--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -48,6 +48,37 @@ fn default_weight() -> f64 {
 }
 
 // ============================================================================
+// Charter activation
+// ============================================================================
+
+/// Activate a CCL charter so the running runtime starts enforcing it.
+///
+/// Hands a validated CCL document off to the gateway's charter ratification hook
+/// (which deploys it into `CharterPolicyOracle`). This is the bootstrap-side
+/// counterpart to the governance-ratification path: it does not create a
+/// proposal, it does not record a decision — it registers an already-decided
+/// charter so the kernel can enforce it.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ActivateCharterRequest {
+    /// Stable identifier for the charter. Convention: equals the governance
+    /// domain id this charter governs (e.g. cooperative DID or human handle).
+    pub charter_id: String,
+    /// Full CCL document, YAML-serialized. Parsed and validated at the
+    /// boundary; malformed input returns 400.
+    pub charter_yaml: String,
+}
+
+/// Response returned after a successful charter activation.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ActivateCharterResponse {
+    pub charter_id: String,
+    /// `"active"` once deployed into the policy oracle.
+    pub status: String,
+    /// Unix epoch seconds when activation was recorded.
+    pub activated_at: u64,
+}
+
+// ============================================================================
 // Proposals
 // ============================================================================
 

--- a/icn/apps/governance/src/http/validation.rs
+++ b/icn/apps/governance/src/http/validation.rs
@@ -11,6 +11,11 @@ use icn_http_kit::error::ApiError;
 // ============================================================================
 
 pub const MAX_DOMAIN_ID_LEN: usize = 128;
+pub const MAX_CHARTER_ID_LEN: usize = 128;
+/// Hard cap on charter document size (1 MiB). Charter documents are CCL YAML;
+/// real institutional charters are well under this bound. The cap is a DoS
+/// guard, not a structural limit.
+pub const MAX_CHARTER_YAML_BYTES: usize = 1_048_576;
 pub const MAX_DOMAIN_NAME_LEN: usize = 256;
 pub const MAX_GOVERNANCE_MODEL_LEN: usize = 64;
 pub const MAX_PROPOSAL_TITLE_LEN: usize = 256;
@@ -48,6 +53,46 @@ pub fn validate_domain_id(id: &str) -> Result<(), ApiError> {
             "Domain ID must contain only alphanumeric characters, hyphens, underscores, and colons"
                 .into(),
         ));
+    }
+    Ok(())
+}
+
+/// Charter identifiers share the structural rules of governance domain IDs.
+/// Per governance convention `charter_id == domain_id` for the cooperative the
+/// charter governs, so reusing the alphabet keeps both surfaces consistent.
+pub fn validate_charter_id(id: &str) -> Result<(), ApiError> {
+    if id.is_empty() {
+        return Err(ApiError::BadRequest("Charter ID cannot be empty".into()));
+    }
+    if id.len() > MAX_CHARTER_ID_LEN {
+        return Err(ApiError::BadRequest(format!(
+            "Charter ID exceeds maximum length of {MAX_CHARTER_ID_LEN} characters"
+        )));
+    }
+    if !id
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_' || c == ':')
+    {
+        return Err(ApiError::BadRequest(
+            "Charter ID must contain only alphanumeric characters, hyphens, underscores, and colons"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Bound the raw YAML payload before handing it to the CCL parser. Empty input
+/// is rejected with a clear message; oversize input is rejected as a DoS guard.
+pub fn validate_charter_yaml(yaml: &str) -> Result<(), ApiError> {
+    if yaml.is_empty() || yaml.trim().is_empty() {
+        return Err(ApiError::BadRequest(
+            "Charter YAML cannot be empty or whitespace-only".into(),
+        ));
+    }
+    if yaml.len() > MAX_CHARTER_YAML_BYTES {
+        return Err(ApiError::BadRequest(format!(
+            "Charter YAML exceeds maximum size of {MAX_CHARTER_YAML_BYTES} bytes"
+        )));
     }
     Ok(())
 }

--- a/icn/apps/governance/src/http/validation.rs
+++ b/icn/apps/governance/src/http/validation.rs
@@ -12,10 +12,15 @@ use icn_http_kit::error::ApiError;
 
 pub const MAX_DOMAIN_ID_LEN: usize = 128;
 pub const MAX_CHARTER_ID_LEN: usize = 128;
-/// Hard cap on charter document size (1 MiB). Charter documents are CCL YAML;
-/// real institutional charters are well under this bound. The cap is a DoS
-/// guard, not a structural limit.
-pub const MAX_CHARTER_YAML_BYTES: usize = 1_048_576;
+/// Hard cap on charter document size (256 KiB). Aligned with the gateway-wide
+/// `web::JsonConfig::default().limit(262_144)` in `icn-gateway/src/server.rs` so
+/// every request that reaches this validator is also accepted by Actix's JSON
+/// extractor — a request larger than this is rejected as 413 by the framework
+/// before the handler runs. Real institutional CCL charters are well under
+/// this bound; the cap is a DoS guard, not a structural limit.
+///
+/// If the gateway-wide JSON limit ever moves, this constant must move with it.
+pub const MAX_CHARTER_YAML_BYTES: usize = 262_144;
 pub const MAX_DOMAIN_NAME_LEN: usize = 256;
 pub const MAX_GOVERNANCE_MODEL_LEN: usize = 64;
 pub const MAX_PROPOSAL_TITLE_LEN: usize = 256;

--- a/icn/apps/governance/tests/charter_activation.rs
+++ b/icn/apps/governance/tests/charter_activation.rs
@@ -5,13 +5,20 @@
 //! 1. Validated CCL YAML → 201 with `{ charter_id, status: "active", activated_at }`
 //!    and the wired `on_charter_accepted` hook is invoked exactly once with the
 //!    submitted (charter_id, charter_yaml) pair.
-//! 2. Reactivation of an existing `charter_id` succeeds (idempotent — the
+//! 2. The same activation also dispatches `GovernanceEffect::DeployCharter` via
+//!    `on_proposal_accepted`, mirroring the accepted-proposal close path so
+//!    commons / SDIS jurisdiction-binding flows see the domain.
+//! 3. Reactivation of an existing `charter_id` succeeds (idempotent — the
 //!    underlying oracle overwrites in place).
-//! 3. Malformed YAML is rejected at the boundary with 400 (the hook is *not*
-//!    invoked, preventing silent drops downstream).
-//! 4. Empty `charter_id` and oversize `charter_yaml` are rejected with 400.
-//! 5. Missing `governance:write` scope returns 403.
-//! 6. Response payload uses regulatory-safe vocabulary
+//! 4. Malformed YAML is rejected at the boundary with 400 (neither hook fires).
+//! 5. Empty `charter_id` and whitespace-only `charter_yaml` are rejected with 400.
+//! 6. Oversize `charter_yaml` (exceeding `MAX_CHARTER_YAML_BYTES`) is rejected
+//!    with 400 by the validator before downstream dispatch.
+//! 7. Missing `governance:write` scope returns 401 or 403 (auth layer choice;
+//!    both are accepted as evidence of unauthorized rejection).
+//! 8. If the proposal-acceptance hook is unwired, the endpoint returns 500
+//!    rather than silently succeeding with commons unaware of the domain.
+//! 9. Response payload uses regulatory-safe vocabulary
 //!    (no "payment", "currency", or "balance" terms).
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
@@ -20,7 +27,11 @@ use std::sync::{Arc, Mutex};
 
 use actix_web::{body::to_bytes, dev::Service as _, http::StatusCode, test, App, HttpMessage};
 use icn_governance_actor::{
-    http::{self, configure::CharterAcceptedHook, GovernanceContext},
+    http::{
+        self,
+        configure::{CharterAcceptedHook, GovernanceEffect, ProposalAcceptedHook},
+        GovernanceContext,
+    },
     manager::GovernanceManager,
     NoopEventEmitter,
 };
@@ -37,20 +48,36 @@ entity:
   type: cooperative
 "#;
 
-type CapturedHookCalls = Arc<Mutex<Vec<(String, String)>>>;
+type CapturedCharterCalls = Arc<Mutex<Vec<(String, String)>>>;
+type CapturedEffectCalls = Arc<Mutex<Vec<GovernanceEffect>>>;
 
-fn make_ctx_with_capture() -> (GovernanceContext<NoopEventEmitter>, CapturedHookCalls) {
-    let captured: CapturedHookCalls = Arc::new(Mutex::new(Vec::new()));
-    let captured_clone = captured.clone();
-    let hook: CharterAcceptedHook = Arc::new(move |id, yaml| {
-        captured_clone.lock().unwrap().push((id, yaml));
+struct CapturedHooks {
+    charter_calls: CapturedCharterCalls,
+    effect_calls: CapturedEffectCalls,
+}
+
+/// Build a context with both the charter-accepted and proposal-accepted hooks
+/// wired to in-memory captures. The handler invokes both hooks on success, so
+/// every test that exercises the success path must wire both.
+fn make_ctx_with_capture() -> (GovernanceContext<NoopEventEmitter>, CapturedHooks) {
+    let charter_calls: CapturedCharterCalls = Arc::new(Mutex::new(Vec::new()));
+    let effect_calls: CapturedEffectCalls = Arc::new(Mutex::new(Vec::new()));
+
+    let charter_calls_clone = charter_calls.clone();
+    let charter_hook: CharterAcceptedHook = Arc::new(move |id, yaml| {
+        charter_calls_clone.lock().unwrap().push((id, yaml));
+    });
+
+    let effect_calls_clone = effect_calls.clone();
+    let proposal_hook: ProposalAcceptedHook = Arc::new(move |effect| {
+        effect_calls_clone.lock().unwrap().push(effect);
     });
 
     let ctx = GovernanceContext {
         manager: Arc::new(GovernanceManager::new()),
         emitter: NoopEventEmitter,
-        on_charter_accepted: Some(hook),
-        on_proposal_accepted: None,
+        on_charter_accepted: Some(charter_hook),
+        on_proposal_accepted: Some(proposal_hook),
         on_proposal_accepted_with_evidence: None,
         member_checker: None,
         steward_checker: None,
@@ -59,7 +86,13 @@ fn make_ctx_with_capture() -> (GovernanceContext<NoopEventEmitter>, CapturedHook
         sdis_service: None,
     };
 
-    (ctx, captured)
+    (
+        ctx,
+        CapturedHooks {
+            charter_calls,
+            effect_calls,
+        },
+    )
 }
 
 /// Build a test app with full governance route configuration, injecting the
@@ -124,10 +157,32 @@ async fn activate_charter_returns_201_and_fires_hook() {
         );
     }
 
-    let captured = captured.lock().unwrap();
-    assert_eq!(captured.len(), 1, "hook must fire exactly once");
-    assert_eq!(captured[0].0, "nycn-bootstrap");
-    assert_eq!(captured[0].1, VALID_CHARTER_YAML);
+    let charter = captured.charter_calls.lock().unwrap();
+    assert_eq!(charter.len(), 1, "charter hook must fire exactly once");
+    assert_eq!(charter[0].0, "nycn-bootstrap");
+    assert_eq!(charter[0].1, VALID_CHARTER_YAML);
+
+    // Equivalence with the accepted-proposal close path: the same activation
+    // must dispatch DeployCharter so commons registers the domain.
+    let effects = captured.effect_calls.lock().unwrap();
+    assert_eq!(
+        effects.len(),
+        1,
+        "proposal-accepted hook must fire exactly once"
+    );
+    match &effects[0] {
+        GovernanceEffect::DeployCharter {
+            charter_id,
+            proposal_id,
+        } => {
+            assert_eq!(charter_id, "nycn-bootstrap");
+            assert!(
+                proposal_id.starts_with("direct-activation:"),
+                "synthetic proposal_id must mark the direct-activation origin, got {proposal_id}"
+            );
+        }
+        other => panic!("expected GovernanceEffect::DeployCharter, got {other:?}"),
+    }
 }
 
 #[actix_web::test]
@@ -153,15 +208,22 @@ async fn activate_charter_idempotent_on_reactivation() {
         );
     }
 
-    let captured = captured.lock().unwrap();
+    let charter = captured.charter_calls.lock().unwrap();
     assert_eq!(
-        captured.len(),
+        charter.len(),
         2,
-        "hook must fire once per activation request"
+        "charter hook must fire once per activation request"
     );
     assert_eq!(
-        captured[0].0, captured[1].0,
+        charter[0].0, charter[1].0,
         "charter_id stable across reactivation"
+    );
+
+    let effects = captured.effect_calls.lock().unwrap();
+    assert_eq!(
+        effects.len(),
+        2,
+        "proposal-accepted hook must fire once per activation"
     );
 }
 
@@ -189,8 +251,51 @@ async fn activate_charter_rejects_malformed_yaml() {
     );
 
     assert!(
-        captured.lock().unwrap().is_empty(),
-        "hook must NOT fire on malformed input — boundary validation must reject before deploy"
+        captured.charter_calls.lock().unwrap().is_empty(),
+        "charter hook must NOT fire on malformed input"
+    );
+    assert!(
+        captured.effect_calls.lock().unwrap().is_empty(),
+        "proposal-accepted hook must NOT fire on malformed input"
+    );
+}
+
+#[actix_web::test]
+async fn activate_charter_rejects_oversize_yaml() {
+    let (ctx, captured) = make_ctx_with_capture();
+    let app = charter_test_app!(ctx, Some("governance:write"));
+
+    // MAX_CHARTER_YAML_BYTES is 256 KiB (matched to the gateway-wide JsonConfig
+    // limit). Build a YAML body that is structurally valid but exceeds that
+    // bound, by inflating the entity name with filler text. The validator
+    // must reject this with 400 before any hook fires. (The init_service test
+    // harness used here has no JsonConfig limit wired, so the request reaches
+    // the validator — proving the validator alone enforces the cap.)
+    let filler = "x".repeat(300_000);
+    let oversize_yaml =
+        format!("schema_version: v0\nentity:\n  name: \"{filler}\"\n  type: cooperative\n");
+    let body = json!({
+        "charter_id": "oversize-coop",
+        "charter_yaml": oversize_yaml,
+    });
+    let req = test::TestRequest::post()
+        .uri("/charters")
+        .set_json(&body)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "oversize charter_yaml must return 400 from the boundary validator"
+    );
+    assert!(
+        captured.charter_calls.lock().unwrap().is_empty(),
+        "charter hook must NOT fire on oversize input"
+    );
+    assert!(
+        captured.effect_calls.lock().unwrap().is_empty(),
+        "proposal-accepted hook must NOT fire on oversize input"
     );
 }
 
@@ -241,7 +346,9 @@ async fn activate_charter_rejects_empty_yaml() {
 #[actix_web::test]
 async fn activate_charter_requires_governance_write_scope() {
     let (ctx, captured) = make_ctx_with_capture();
-    // No claims at all → middleware injects nothing, require_scope returns Forbidden.
+    // No claims at all → middleware injects nothing, require_scope returns
+    // an unauthorized error. The exact code (401 vs 403) is the auth layer's
+    // choice; both are accepted as evidence of unauthorized rejection.
     let app = charter_test_app!(ctx, None);
 
     let body = json!({
@@ -261,19 +368,65 @@ async fn activate_charter_requires_governance_write_scope() {
     );
 
     assert!(
-        captured.lock().unwrap().is_empty(),
-        "hook must NOT fire without governance:write scope"
+        captured.charter_calls.lock().unwrap().is_empty(),
+        "charter hook must NOT fire without governance:write scope"
+    );
+    assert!(
+        captured.effect_calls.lock().unwrap().is_empty(),
+        "proposal-accepted hook must NOT fire without governance:write scope"
     );
 }
 
 #[actix_web::test]
-async fn activate_charter_returns_500_when_hook_not_wired() {
-    // Build a context with `on_charter_accepted: None` to prove the handler
-    // surfaces a clear server error instead of silently succeeding.
+async fn activate_charter_returns_500_when_charter_hook_not_wired() {
+    // `on_charter_accepted: None` — the handler surfaces 500 rather than
+    // silently succeeding (the kernel would never start enforcing the charter).
     let ctx = GovernanceContext {
         manager: Arc::new(GovernanceManager::new()),
         emitter: NoopEventEmitter,
         on_charter_accepted: None,
+        on_proposal_accepted: Some(Arc::new(|_| {})),
+        on_proposal_accepted_with_evidence: None,
+        member_checker: None,
+        steward_checker: None,
+        suspension_checker: None,
+        membership_resolver: None,
+        sdis_service: None,
+    };
+    let app = charter_test_app!(ctx, Some("governance:write"));
+
+    let body = json!({
+        "charter_id": "nycn-bootstrap",
+        "charter_yaml": VALID_CHARTER_YAML,
+    });
+    let req = test::TestRequest::post()
+        .uri("/charters")
+        .set_json(&body)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "missing charter hook must return 500, not silently succeed"
+    );
+}
+
+#[actix_web::test]
+async fn activate_charter_returns_500_when_proposal_hook_not_wired() {
+    // `on_proposal_accepted: None` — without it commons never registers the
+    // domain, so steward / jurisdiction-binding flows would fail downstream.
+    // Returning 500 keeps the contract honest: a 201 response means the
+    // charter is fully activated, not just half-activated.
+    let charter_calls: CapturedCharterCalls = Arc::new(Mutex::new(Vec::new()));
+    let charter_calls_clone = charter_calls.clone();
+    let charter_hook: CharterAcceptedHook = Arc::new(move |id, yaml| {
+        charter_calls_clone.lock().unwrap().push((id, yaml));
+    });
+    let ctx = GovernanceContext {
+        manager: Arc::new(GovernanceManager::new()),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: Some(charter_hook),
         on_proposal_accepted: None,
         on_proposal_accepted_with_evidence: None,
         member_checker: None,
@@ -297,6 +450,15 @@ async fn activate_charter_returns_500_when_hook_not_wired() {
     assert_eq!(
         resp.status(),
         StatusCode::INTERNAL_SERVER_ERROR,
-        "missing hook must return 500, not silently succeed"
+        "missing proposal-accepted hook must return 500"
+    );
+    // Note: the charter hook fires before the proposal-hook check, so the
+    // CharterPolicyOracle has already deployed the document. That is
+    // acceptable — the kernel is now enforcing the charter — and is the
+    // narrowest behavior to assert without a synchronous rollback path.
+    assert_eq!(
+        charter_calls.lock().unwrap().len(),
+        1,
+        "charter hook fires before the proposal-hook check"
     );
 }

--- a/icn/apps/governance/tests/charter_activation.rs
+++ b/icn/apps/governance/tests/charter_activation.rs
@@ -1,0 +1,302 @@
+//! Charter activation HTTP endpoint (issue #1602).
+//!
+//! Proves the bootstrap-side `POST /charters` endpoint:
+//!
+//! 1. Validated CCL YAML → 201 with `{ charter_id, status: "active", activated_at }`
+//!    and the wired `on_charter_accepted` hook is invoked exactly once with the
+//!    submitted (charter_id, charter_yaml) pair.
+//! 2. Reactivation of an existing `charter_id` succeeds (idempotent — the
+//!    underlying oracle overwrites in place).
+//! 3. Malformed YAML is rejected at the boundary with 400 (the hook is *not*
+//!    invoked, preventing silent drops downstream).
+//! 4. Empty `charter_id` and oversize `charter_yaml` are rejected with 400.
+//! 5. Missing `governance:write` scope returns 403.
+//! 6. Response payload uses regulatory-safe vocabulary
+//!    (no "payment", "currency", or "balance" terms).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::{Arc, Mutex};
+
+use actix_web::{body::to_bytes, dev::Service as _, http::StatusCode, test, App, HttpMessage};
+use icn_governance_actor::{
+    http::{self, configure::CharterAcceptedHook, GovernanceContext},
+    manager::GovernanceManager,
+    NoopEventEmitter,
+};
+use icn_http_kit::auth::BasicClaims;
+use serde_json::{json, Value};
+
+/// Minimal valid CCL YAML — `from_yaml` + `validate` accept an empty document
+/// (all sections are `Option<...>`). For rigor we still pass a populated entity
+/// section so a future tightening of `validate()` will fail loudly here.
+const VALID_CHARTER_YAML: &str = r#"
+schema_version: v0
+entity:
+  name: "Test Cooperative"
+  type: cooperative
+"#;
+
+type CapturedHookCalls = Arc<Mutex<Vec<(String, String)>>>;
+
+fn make_ctx_with_capture() -> (GovernanceContext<NoopEventEmitter>, CapturedHookCalls) {
+    let captured: CapturedHookCalls = Arc::new(Mutex::new(Vec::new()));
+    let captured_clone = captured.clone();
+    let hook: CharterAcceptedHook = Arc::new(move |id, yaml| {
+        captured_clone.lock().unwrap().push((id, yaml));
+    });
+
+    let ctx = GovernanceContext {
+        manager: Arc::new(GovernanceManager::new()),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: Some(hook),
+        on_proposal_accepted: None,
+        on_proposal_accepted_with_evidence: None,
+        member_checker: None,
+        steward_checker: None,
+        suspension_checker: None,
+        membership_resolver: None,
+        sdis_service: None,
+    };
+
+    (ctx, captured)
+}
+
+/// Build a test app with full governance route configuration, injecting the
+/// given scope (or none) into every request — bypasses JWT validation.
+macro_rules! charter_test_app {
+    ($ctx:expr, $scope:expr) => {{
+        let scope: Option<&'static str> = $scope;
+        test::init_service(
+            App::new()
+                .wrap_fn(move |req, srv| {
+                    if let Some(scope_str) = scope {
+                        req.extensions_mut().insert(BasicClaims {
+                            sub: "did:icn:caller".to_string(),
+                            scope: Some(scope_str.to_string()),
+                        });
+                    }
+                    srv.call(req)
+                })
+                .configure(|cfg| http::configure(cfg, $ctx)),
+        )
+        .await
+    }};
+}
+
+#[actix_web::test]
+async fn activate_charter_returns_201_and_fires_hook() {
+    let (ctx, captured) = make_ctx_with_capture();
+    let app = charter_test_app!(ctx, Some("governance:write"));
+
+    let body = json!({
+        "charter_id": "nycn-bootstrap",
+        "charter_yaml": VALID_CHARTER_YAML,
+    });
+    let req = test::TestRequest::post()
+        .uri("/charters")
+        .set_json(&body)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let status = resp.status();
+    let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "valid charter must return 201 Created, body: {}",
+        String::from_utf8_lossy(&body_bytes)
+    );
+    let parsed: Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(parsed["charter_id"], "nycn-bootstrap");
+    assert_eq!(parsed["status"], "active");
+    assert!(
+        parsed["activated_at"].as_u64().is_some(),
+        "activated_at must be a unix epoch seconds u64"
+    );
+
+    // Regulatory-safe vocabulary: response must not leak economic-payment terms.
+    let raw = String::from_utf8(body_bytes.to_vec()).unwrap();
+    let raw_lower = raw.to_lowercase();
+    for forbidden in ["payment", "currency", "balance"] {
+        assert!(
+            !raw_lower.contains(forbidden),
+            "response must not contain forbidden term '{forbidden}': {raw}"
+        );
+    }
+
+    let captured = captured.lock().unwrap();
+    assert_eq!(captured.len(), 1, "hook must fire exactly once");
+    assert_eq!(captured[0].0, "nycn-bootstrap");
+    assert_eq!(captured[0].1, VALID_CHARTER_YAML);
+}
+
+#[actix_web::test]
+async fn activate_charter_idempotent_on_reactivation() {
+    let (ctx, captured) = make_ctx_with_capture();
+    let app = charter_test_app!(ctx, Some("governance:write"));
+
+    let body = json!({
+        "charter_id": "nycn-bootstrap",
+        "charter_yaml": VALID_CHARTER_YAML,
+    });
+
+    for attempt in 0..2 {
+        let req = test::TestRequest::post()
+            .uri("/charters")
+            .set_json(&body)
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::CREATED,
+            "reactivation attempt {attempt} must succeed"
+        );
+    }
+
+    let captured = captured.lock().unwrap();
+    assert_eq!(
+        captured.len(),
+        2,
+        "hook must fire once per activation request"
+    );
+    assert_eq!(
+        captured[0].0, captured[1].0,
+        "charter_id stable across reactivation"
+    );
+}
+
+#[actix_web::test]
+async fn activate_charter_rejects_malformed_yaml() {
+    let (ctx, captured) = make_ctx_with_capture();
+    let app = charter_test_app!(ctx, Some("governance:write"));
+
+    let body = json!({
+        "charter_id": "bad-coop",
+        // Invalid YAML — unbalanced braces
+        "charter_yaml": "schema_version: v0\nentity: { id: ",
+    });
+    let req = test::TestRequest::post()
+        .uri("/charters")
+        .set_json(&body)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "malformed YAML must return 400, got {}",
+        resp.status()
+    );
+
+    assert!(
+        captured.lock().unwrap().is_empty(),
+        "hook must NOT fire on malformed input — boundary validation must reject before deploy"
+    );
+}
+
+#[actix_web::test]
+async fn activate_charter_rejects_empty_id() {
+    let (ctx, _captured) = make_ctx_with_capture();
+    let app = charter_test_app!(ctx, Some("governance:write"));
+
+    let body = json!({
+        "charter_id": "",
+        "charter_yaml": VALID_CHARTER_YAML,
+    });
+    let req = test::TestRequest::post()
+        .uri("/charters")
+        .set_json(&body)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "empty charter_id must return 400"
+    );
+}
+
+#[actix_web::test]
+async fn activate_charter_rejects_empty_yaml() {
+    let (ctx, _captured) = make_ctx_with_capture();
+    let app = charter_test_app!(ctx, Some("governance:write"));
+
+    let body = json!({
+        "charter_id": "nycn-bootstrap",
+        "charter_yaml": "   \n   ",
+    });
+    let req = test::TestRequest::post()
+        .uri("/charters")
+        .set_json(&body)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "whitespace-only YAML must return 400"
+    );
+}
+
+#[actix_web::test]
+async fn activate_charter_requires_governance_write_scope() {
+    let (ctx, captured) = make_ctx_with_capture();
+    // No claims at all → middleware injects nothing, require_scope returns Forbidden.
+    let app = charter_test_app!(ctx, None);
+
+    let body = json!({
+        "charter_id": "nycn-bootstrap",
+        "charter_yaml": VALID_CHARTER_YAML,
+    });
+    let req = test::TestRequest::post()
+        .uri("/charters")
+        .set_json(&body)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    let status = resp.status();
+    assert!(
+        status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN,
+        "missing scope must return 401 or 403, got {status}"
+    );
+
+    assert!(
+        captured.lock().unwrap().is_empty(),
+        "hook must NOT fire without governance:write scope"
+    );
+}
+
+#[actix_web::test]
+async fn activate_charter_returns_500_when_hook_not_wired() {
+    // Build a context with `on_charter_accepted: None` to prove the handler
+    // surfaces a clear server error instead of silently succeeding.
+    let ctx = GovernanceContext {
+        manager: Arc::new(GovernanceManager::new()),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: None,
+        on_proposal_accepted_with_evidence: None,
+        member_checker: None,
+        steward_checker: None,
+        suspension_checker: None,
+        membership_resolver: None,
+        sdis_service: None,
+    };
+    let app = charter_test_app!(ctx, Some("governance:write"));
+
+    let body = json!({
+        "charter_id": "nycn-bootstrap",
+        "charter_yaml": VALID_CHARTER_YAML,
+    });
+    let req = test::TestRequest::post()
+        .uri("/charters")
+        .set_json(&body)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "missing hook must return 500, not silently succeed"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #1602.

Adds **POST /v1/gov/charters** — the bootstrap-side counterpart to the governance-ratification charter path. Lets a caller hand a validated CCL document directly to the running runtime so `CharterPolicyOracle::deploy_charter` takes effect without going through the proposal/vote/close flow.

This unblocks the NYCN bootstrap arc: `icnctl institution bootstrap apply` was reporting "store charter" as Unsupported because the only path that deployed charters was a fully-ratified `Charter` proposal. The endpoint reuses the existing `on_charter_accepted` hook (already wired by icnd to the charter oracle), so deployment goes through exactly the same code path that ratified proposals use — no parallel charter-deployment lane.

## Why

Bootstrap and governance-ratification are *both* legitimate paths for charter activation. Bootstrap charters are out-of-band ratifications (a coop's existing constitution, a federation's founding accord) — there is no proposal to vote on, the decision is already made. The endpoint accepts that semantic and gets the document into the oracle so the kernel can enforce it.

## How

- **Validation at the boundary.** Parse + structurally validate the CCL YAML in the handler. Malformed input returns 400 instead of being silently dropped by the fire-and-forget hook.
- **Reuse the existing hook.** `activate_charter` calls `ctx.on_charter_accepted` with `(charter_id, charter_yaml)` — the same hook the governance-ratification path uses. Wiring is unchanged in icnd.
- **Idempotent reactivation.** `deploy_charter` overwrites in place per `charter_id`, so re-activating the same id succeeds with a fresh `activated_at`. Callers needing single-shot semantics dedupe upstream.
- **Auth.** Requires `governance:write` scope (matches `create_domain`).
- **Regulatory-safe vocabulary.** Response uses `status`, `activated_at` — no `payment`, `currency`, or `balance` terms (asserted in tests).

### Files
- `apps/governance/Cargo.toml` — add `icn-ccl` dep for boundary validation.
- `apps/governance/src/http/models.rs` — `ActivateCharterRequest` / `ActivateCharterResponse`.
- `apps/governance/src/http/validation.rs` — `validate_charter_id` (alphanumeric/-/_/:, ≤128), `validate_charter_yaml` (non-empty, ≤1 MiB DoS guard).
- `apps/governance/src/http/handlers.rs` — `activate_charter` handler.
- `apps/governance/src/http/configure.rs` — register `POST /charters`.
- `apps/governance/tests/charter_activation.rs` — 7 integration tests.

## Risk

- **Hook ordering.** If `on_charter_accepted` is unwired the endpoint returns **500** (never silently succeeds). icnd wires it unconditionally; only test environments that opt out would see 500.
- **Idempotent overwrite.** Reactivation replaces the prior CCL document in the oracle. This matches what governance-ratification does today, but a malicious caller with `governance:write` could push a weakened charter. That risk already exists via the proposal path; the endpoint inherits the same scope check.
- **Persistence.** The oracle is in-memory. After gateway restart the charter must be re-activated. This is consistent with the governance-ratification path and not introduced by this PR.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p icn-governance-actor -p icn-store -p icn-gateway --all-targets -- -D warnings`
- [x] `cargo test -p icn-governance-actor` — 7 new tests pass + existing tests unchanged.
- [x] `cargo test -p icn-store -p icn-gateway` — green.
- [x] `cargo check --workspace --all-targets` — green.

## Test cases proven

| Test | Asserts |
|---|---|
| `activate_charter_returns_201_and_fires_hook` | Valid YAML → 201 with stable identifiers, hook invoked exactly once with submitted (id, yaml), regulatory-safe vocabulary in response |
| `activate_charter_idempotent_on_reactivation` | Same charter_id twice → both 201 |
| `activate_charter_rejects_malformed_yaml` | Bad YAML → 400, hook NOT invoked |
| `activate_charter_rejects_empty_id` | empty charter_id → 400 |
| `activate_charter_rejects_empty_yaml` | whitespace-only YAML → 400 |
| `activate_charter_requires_governance_write_scope` | Missing claims → 401/403, hook NOT invoked |
| `activate_charter_returns_500_when_hook_not_wired` | Unwired hook → 500 (never silent success) |

## Follow-ups

- #1623 (separate issue) — Standalone-mode persistence for proposals/votes/delegations. Not in scope here.
- OpenAPI/TypeScript types regenerate on the next SDK refresh; no manual regen needed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
