### PR TITLE
fix(coop): release sled db lock before reopen test

### DIFF
--- a/icn/crates/icn-coop/src/store.rs
+++ b/icn/crates/icn-coop/src/store.rs
@@ -811,8 +811,8 @@ mod tests {
         let db_path = dir.path().to_path_buf();
 
         // Open store, increment nonce, close
-        let db = sled::open(&db_path).unwrap();
-        let store = CoopStore::new(Arc::new(db));
+        let db = Arc::new(sled::open(&db_path).unwrap());
+        let store = CoopStore::new(Arc::clone(&db));
         store
             .check_and_increment_treasury_nonce("did:icn:persistent", 0)
             .unwrap();
@@ -823,6 +823,7 @@ mod tests {
         // before reopening. Block scoping alone is insufficient because
         // Arc<Db> drop order is not guaranteed under parallel test execution.
         drop(store);
+        drop(db);
 
         // Reopen store and verify nonce was persisted
         {


### PR DESCRIPTION
## Summary
- fix flaky `icn-coop` nonce persistence unit test by retaining and explicitly dropping the shared `Db` handle before reopening the same sled path
- prevent intermittent CI failure in parallel unit test execution caused by temp DB lock contention

## Test plan
- [x] `cd icn && cargo test -p icn-coop --lib`
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)