### PR TITLE
feat(governance): add GET /me/standing read model

### DIFF
--- a/docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md
+++ b/docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md
@@ -115,6 +115,103 @@ CCL describes *what is permitted and under what conditions*. The host runtime de
 
 ---
 
+## C2. Entity Primitives vs Local Purpose Metadata (the type/purpose firewall)
+
+**The same rule that separates kernel from app applies to entity types.**
+
+ICN has exactly **four entity primitives**. They are sovereign types and they imply different machinery:
+
+| Primitive | What it is | What ICN guarantees |
+|-----------|------------|---------------------|
+| `Individual` | A DID-backed person. | Identity, authentication, self-scoped reads. |
+| `Cooperative` | An operating/economic body. | `governance_domain_id` + `treasury_account` (per `CooperativeProfile`). |
+| `Community` | A civic/member/participant body. | `governance_domain_id` (per `CommunityProfile`). Treasury optional. |
+| `Federation` | An association of member entities. | `governance_domain_id` + `member_entities` + optional `parent_id` (per `FederationProfile`). |
+
+These are the only legal values of `BootstrapEntityType` in `icn-governance::bootstrap` and the only legal values of the `entity_type` field on the gateway's `/v1/entities` API. The serde enum is `#[serde(rename_all = "snake_case")]` and any other variant fails to deserialize at YAML parse time. **This is the firewall**: an institution package cannot smuggle a new entity type past ICN.
+
+**Committees and working groups are NOT entities.** They are governance `Structure` records owned by a parent entity. They carry delegated authority via `RoleAssignment.authority_scope`, not sovereignty. They cannot hold treasury, cannot join federations, cannot appear in `member_entities`.
+
+**Events / programs / cycles (e.g. a Summit) are NOT entities.** They are `Activity` and `Program` records owned by a parent entity.
+
+### Local institutional role goes in `operating_purpose`, not in a new type
+
+Institution packages frequently want to mark *which kind* of cooperative or community a record represents in their local taxonomy: an "organizing cooperative", a "program participant community", a "federation member community". These are valid local distinctions — but they are **purpose metadata**, not entity primitives.
+
+`BootstrapEntityRecord` already carries:
+
+```rust
+pub operating_purpose: Option<String>,
+```
+
+That field is the only sanctioned home for this metadata. It is opaque to ICN — the runtime stores it (or, in the current importer, plans for it; see "Known gap" below) and never branches on its value.
+
+### Correct vs incorrect mapping
+
+```yaml
+# ❌ WRONG — invents new entity primitives, will fail to parse
+entity_type: organizing_cooperative
+entity_type: program_community
+entity_type: committee
+entity_type: federation_member_community
+
+# ✅ RIGHT — uses ICN primitives, locales role via operating_purpose
+entity_type: cooperative
+operating_purpose: organizing_cooperative
+
+entity_type: community
+operating_purpose: program_participant_community
+# (with a separate Activity record for the related program)
+
+# Committee — not an entity at all:
+# Goes in a `kind: structure-seed` manifest:
+kind: structure-seed
+parent_entity_id: nycn-organizing
+structures:
+  - id: committee-finance
+    kind: committee
+    name: Finance Committee
+```
+
+### Worked example: NYCN reference federation
+
+```text
+nycn                        entity_type: federation
+                            operating_purpose: regional_cooperative_network
+
+  nycn-organizing           entity_type: cooperative
+                            operating_purpose: organizing_cooperative
+                            (carries treasury_account)
+
+    committee-steering      structure-seed { kind: committee,  parent_entity_id: nycn-organizing }
+    committee-finance       structure-seed { kind: committee,  parent_entity_id: nycn-organizing }
+    committee-program       structure-seed { kind: committee,  parent_entity_id: nycn-organizing }
+    wg-accessibility        structure-seed { kind: working_group, parent_entity_id: nycn-organizing }
+
+    summit-2026             activity-program-seed { parent_entity_id: nycn-organizing }
+
+  nycn-community            entity_type: community
+                            operating_purpose: network_member_community
+
+  summit-2026-community     entity_type: community            (only if it actually governs/confers standing)
+                            operating_purpose: program_participant_community
+                            related_activity: summit-2026
+                            (otherwise: model as activity participant cohort,
+                             not as an entity at all)
+```
+
+### Why this is the firewall, not a style guide
+
+The primitive layer is the machine. `CooperativeProfile` requiring `treasury_account` means ICN gives every cooperative a treasury account; `FederationProfile` requiring `member_entities` means ICN runs federation joins/leaves against that vector. If an institution were allowed to ship `entity_type: organizing_cooperative`, the runtime would either have to (a) treat it as `cooperative` (in which case the new type adds nothing) or (b) branch on it (in which case ICN now contains NYCN-specific code). Both options break the kernel/app separation.
+
+`operating_purpose: <string>` lets the institution carry as much local meaning as it wants without the runtime understanding any of it. UI can read it and render labels. CCL contracts can compare it. ICN never branches on it.
+
+### Known gap (tracked, not blocking model adoption)
+
+The current `BootstrapOperation::CreateEntity` payload sent to the gateway's `/v1/entities` API does **not** forward `operating_purpose` at apply time. The seed schema accepts it, the validator/planner sees it, but the apply step drops it. Institution packages can author the corrected model today; the metadata round-trips through `validate` and `plan` outputs, but does not yet land on the live entity record. Plumbing this through is a small follow-up.
+
+---
+
 ## D. Reusable Primitive Set
 
 These belong in ICN because every cooperative institution needs them — verified against both what NYCN requires and what a second unrelated institution (housing federation, mutual aid collective) would also need unchanged.

--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -535,5 +535,6 @@ where
         .service(web::resource("/digest").route(web::get().to(handlers::get_digest::<E>)))
         // ── Me (caller-scoped views) ─────────────────────────────────────
         .service(web::resource("/me/scopes").route(web::get().to(handlers::get_my_scopes::<E>)))
+        .service(web::resource("/me/standing").route(web::get().to(handlers::get_my_standing::<E>)))
         .service(web::resource("/me/work").route(web::get().to(handlers::get_my_work::<E>)));
 }

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -4865,6 +4865,140 @@ pub async fn get_my_scopes<E: GovernanceEventEmitter + Clone + 'static>(
     Ok(HttpResponse::Ok().json(responses))
 }
 
+/// GET /gov/me/standing — Return the authenticated caller's institutional standing.
+///
+/// Composes existing governance state (domain membership + structure role
+/// assignments) into one read model so member-facing UI does not have to
+/// fan out to four endpoints.
+///
+/// ## What this returns
+///
+/// - The caller's DID (always — derived from the authenticated claims, not
+///   from a query parameter).
+/// - Each governance domain whose static member list contains the caller, or
+///   whose membership is sourced from a trust threshold (status `"unverified"`
+///   in that case — the trust graph is the source of truth, not this read
+///   model).
+/// - Each structure role assignment held by the caller, joined with cheap
+///   structure metadata (name + parent entity) so the UI does not need a
+///   second fetch per row.
+/// - The deduplicated union of `authority_scope` across those role
+///   assignments, as a convenience for UI.
+///
+/// ## Self-only
+///
+/// There is no `did` query parameter. The DID is always the caller's. A
+/// caller cannot use this endpoint to inspect another DID's standing.
+///
+/// ## Optional filter
+///
+/// `?domain_id=<id>` narrows both `domains` and `roles` to assignments under
+/// that domain. An unknown `domain_id` returns a valid empty standing rather
+/// than a 404 — "no standing in that domain" is a meaningful answer.
+///
+/// ## Empty caller is not an error
+///
+/// A caller with no role assignments and no static membership receives a
+/// 200 with empty `domains`, `roles`, and `authority_scopes`. UI should
+/// render an onboarding affordance, not an error.
+pub async fn get_my_standing<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    query: web::Query<StandingQuery>,
+) -> Result<HttpResponse, ApiError> {
+    let claims = require_scope::<BasicClaims>(&http_req, "governance:read")?;
+    let caller = parse_did(&claims.sub, "Invalid DID in token")?;
+
+    let domain_filter = query.domain_id.as_deref();
+
+    // Domain memberships: scan all domains the manager knows about, keep
+    // those where the caller is in the static list, mark trust-threshold
+    // domains as "unverified" so the UI can prompt the user to look at the
+    // trust-graph view rather than silently dropping them.
+    let all_domains = ctx.manager.list_domains().await.map_err(anyhow_to_api)?;
+    let mut domains: Vec<StandingDomainMembership> = all_domains
+        .iter()
+        .filter(|d| domain_filter.is_none_or(|id| d.id.0 == id))
+        .filter_map(|d| match &d.config.membership.source {
+            icn_governance::MembershipSource::StaticList(members) => {
+                if members.contains(&caller) {
+                    Some(StandingDomainMembership {
+                        domain_id: d.id.0.clone(),
+                        domain_name: d.name.clone(),
+                        membership_source: "static_list".to_string(),
+                        status: "member".to_string(),
+                    })
+                } else {
+                    None
+                }
+            }
+            icn_governance::MembershipSource::TrustThreshold(_) => Some(StandingDomainMembership {
+                domain_id: d.id.0.clone(),
+                domain_name: d.name.clone(),
+                membership_source: "trust_threshold".to_string(),
+                status: "unverified".to_string(),
+            }),
+        })
+        .collect();
+    domains.sort_by(|a, b| a.domain_id.cmp(&b.domain_id));
+
+    // Role assignments: pull every role this caller holds, then join with
+    // structure metadata. A missing structure (deleted/unreadable) still
+    // surfaces as a row with `structure_name: None` so the caller can see
+    // there is something to investigate, not a silent gap.
+    let role_records = ctx
+        .manager
+        .list_roles_for_person(&caller)
+        .map_err(anyhow_to_api)?;
+    let mut roles: Vec<StandingRoleAssignment> = Vec::with_capacity(role_records.len());
+    for r in &role_records {
+        let structure = ctx.manager.get_structure(&r.structure_id).ok().flatten();
+        let parent_entity_id = structure.as_ref().map(|s| s.parent_entity_id.clone());
+        let structure_name = structure.as_ref().map(|s| s.name.clone());
+        if let Some(filter_id) = domain_filter {
+            // Domain filter currently restricts roles by parent entity id
+            // when the entity id matches the requested domain id. This is
+            // the loose-but-correct join while structures do not carry an
+            // explicit governance-domain back-reference.
+            if parent_entity_id.as_deref() != Some(filter_id) {
+                continue;
+            }
+        }
+        roles.push(StandingRoleAssignment {
+            role_assignment_id: r.id.to_string(),
+            structure_id: r.structure_id.0.clone(),
+            structure_name,
+            parent_entity_id,
+            role: r.role.clone(),
+            authority_scope: r.authority_scope.clone(),
+            start_date: r.start_date,
+            end_date: r.end_date,
+        });
+    }
+    roles.sort_by(|a, b| {
+        a.parent_entity_id
+            .cmp(&b.parent_entity_id)
+            .then_with(|| a.structure_id.cmp(&b.structure_id))
+            .then_with(|| a.role.cmp(&b.role))
+    });
+
+    let mut authority_scopes: Vec<String> = roles
+        .iter()
+        .flat_map(|r| r.authority_scope.iter().cloned())
+        .collect();
+    authority_scopes.sort();
+    authority_scopes.dedup();
+
+    Ok(HttpResponse::Ok().json(StandingResponse {
+        did: caller.to_string(),
+        display_label: None,
+        domains,
+        roles,
+        authority_scopes,
+        generated_at: current_time_secs(),
+    }))
+}
+
 /// GET /gov/me/work — Return action items assigned to the authenticated DID.
 ///
 /// Returns items across **all** governance domains, sorted oldest-first

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -4943,16 +4943,21 @@ pub async fn get_my_standing<E: GovernanceEventEmitter + Clone + 'static>(
     domains.sort_by(|a, b| a.domain_id.cmp(&b.domain_id));
 
     // Role assignments: pull every role this caller holds, then join with
-    // structure metadata. A missing structure (deleted/unreadable) still
+    // structure metadata. A genuinely-deleted structure (Ok(None)) still
     // surfaces as a row with `structure_name: None` so the caller can see
-    // there is something to investigate, not a silent gap.
+    // something to investigate. A storage/decode failure (Err) propagates
+    // as 500 — silently dropping it would let a half-broken backend look
+    // like a clean "structure deleted" answer.
     let role_records = ctx
         .manager
         .list_roles_for_person(&caller)
         .map_err(anyhow_to_api)?;
     let mut roles: Vec<StandingRoleAssignment> = Vec::with_capacity(role_records.len());
     for r in &role_records {
-        let structure = ctx.manager.get_structure(&r.structure_id).ok().flatten();
+        let structure = ctx
+            .manager
+            .get_structure(&r.structure_id)
+            .map_err(anyhow_to_api)?;
         let parent_entity_id = structure.as_ref().map(|s| s.parent_entity_id.clone());
         let structure_name = structure.as_ref().map(|s| s.name.clone());
         if let Some(filter_id) = domain_filter {

--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -79,6 +79,95 @@ pub struct ActivateCharterResponse {
 }
 
 // ============================================================================
+// Member standing (read model for `GET /me/standing`)
+// ============================================================================
+
+/// Optional query parameters for `GET /me/standing`.
+///
+/// All filters are inclusive: applying a filter narrows the response, never
+/// expands it. The caller is always derived from the authenticated DID — there
+/// is no `did` query parameter, so a caller cannot ask for someone else's
+/// standing.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+pub struct StandingQuery {
+    /// If set, restrict `domains` and `roles` to assignments under this
+    /// governance domain. Unknown ids are NOT a 404 — they simply produce an
+    /// empty standing for that filter, which is a valid answer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub domain_id: Option<String>,
+}
+
+/// Caller-facing membership and authority read model.
+///
+/// Returned by `GET /v1/gov/me/standing`. Composes existing governance state
+/// (domain memberships + structure role assignments) into one digestible
+/// response so member-facing UI does not need to query four endpoints and
+/// stitch them together.
+///
+/// ## What this is NOT
+///
+/// - This is **not** an authorization token. Scopes here are descriptive,
+///   not bearer-issued. Authorization decisions still flow through the
+///   `PolicyOracle`.
+/// - This is **not** an action-card feed. Action-card generation builds on
+///   top of this read model in a separate endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct StandingResponse {
+    /// The authenticated caller's DID.
+    pub did: String,
+    /// Optional human-readable label. Reserved for a future identity-registry
+    /// lookup; always `None` in this version.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_label: Option<String>,
+    /// Governance domains in which this caller has membership standing.
+    /// May be empty.
+    pub domains: Vec<StandingDomainMembership>,
+    /// Role assignments held by this caller across all structures.
+    /// May be empty.
+    pub roles: Vec<StandingRoleAssignment>,
+    /// Union of `authority_scope` strings across `roles`, deduplicated and
+    /// sorted. Convenience field for UI; equivalent to flattening `roles`.
+    pub authority_scopes: Vec<String>,
+    /// Unix epoch seconds when this standing was computed. The response is a
+    /// snapshot; nothing is cached server-side.
+    pub generated_at: u64,
+}
+
+/// One governance-domain membership row in [`StandingResponse`].
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct StandingDomainMembership {
+    pub domain_id: String,
+    pub domain_name: String,
+    /// `"static_list"` or `"trust_threshold"`.
+    pub membership_source: String,
+    /// `"member"` if the caller is in the static member list,
+    /// `"unverified"` if membership comes from a trust-threshold source that
+    /// this read model does not evaluate (the caller may still be a member;
+    /// the trust graph is the source of truth).
+    pub status: String,
+}
+
+/// One role-assignment row in [`StandingResponse`]. Joins the underlying
+/// [`icn_governance::RoleAssignment`] with cheap structure metadata
+/// (name + parent entity) so UI does not have to fetch the structure.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct StandingRoleAssignment {
+    pub role_assignment_id: String,
+    pub structure_id: String,
+    /// `None` if the structure was deleted or is otherwise unreadable; the
+    /// role row is still surfaced so the caller can see something is off.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub structure_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_entity_id: Option<String>,
+    pub role: String,
+    pub authority_scope: Vec<String>,
+    pub start_date: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_date: Option<u64>,
+}
+
+// ============================================================================
 // Proposals
 // ============================================================================
 

--- a/icn/apps/governance/tests/me_standing.rs
+++ b/icn/apps/governance/tests/me_standing.rs
@@ -351,7 +351,16 @@ async fn response_uses_regulatory_safe_vocabulary() {
     let app = standing_test_app!(ctx, &caller, Some("governance:read"));
     let req = test::TestRequest::get().uri("/me/standing").to_request();
     let resp = test::call_service(&app, req).await;
+    let status = resp.status();
     let bytes = to_bytes(resp.into_body()).await.unwrap();
+    // Pin the status first — otherwise an auth/route regression that returns
+    // 401/403/500 with a clean error payload would still pass this scan.
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "regulatory vocab check requires a 200 success body, got {status}: {}",
+        String::from_utf8_lossy(&bytes)
+    );
     let raw_lower = String::from_utf8_lossy(&bytes).to_lowercase();
     for forbidden in ["payment", "currency", " balance"] {
         assert!(

--- a/icn/apps/governance/tests/me_standing.rs
+++ b/icn/apps/governance/tests/me_standing.rs
@@ -1,0 +1,377 @@
+//! `GET /v1/gov/me/standing` integration tests (issue #1604).
+//!
+//! Proves the caller-facing institutional read model:
+//!
+//! 1. Authenticated DID with no roles and no static membership returns a
+//!    well-formed empty standing — never errors.
+//! 2. A direct (manager-level) role assignment surfaces in `roles` and its
+//!    authority scope rolls up into `authority_scopes`.
+//! 3. A role assigned through person-directory-resolved bootstrap planning
+//!    (the #1603 path) lands the same way once apply has run, because both
+//!    paths go through `manager.assign_role` server-side.
+//! 4. Inline `person_did` precedence from #1603 is preserved end-to-end:
+//!    when both inline DID and a holder_label exist, the inline DID is the
+//!    one that ends up in standing.
+//! 5. A different, unrelated DID does not see the first DID's standing.
+//! 6. `?domain_id=<id>` filters domains and roles to that domain.
+//! 7. Unknown `domain_id` returns 200 with empty arrays — not 404 — because
+//!    "no standing in that domain" is a meaningful answer.
+//! 8. The response payload uses regulatory-safe vocabulary
+//!    (no payment / currency / balance terms).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use actix_web::{body::to_bytes, dev::Service as _, http::StatusCode, test, App, HttpMessage};
+use icn_governance::{GovernanceDomainId, GovernanceParams, MembershipConfig, StructureKind};
+use icn_governance_actor::{
+    http::{self, GovernanceContext},
+    manager::GovernanceManager,
+    NoopEventEmitter,
+};
+use icn_http_kit::auth::BasicClaims;
+use icn_identity::{Did, IdentityBundle};
+use serde_json::Value;
+
+fn fresh_did() -> Did {
+    IdentityBundle::generate()
+        .expect("IdentityBundle::generate")
+        .did()
+        .clone()
+}
+
+fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
+    GovernanceContext {
+        manager: Arc::new(GovernanceManager::new()),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: None,
+        on_proposal_accepted_with_evidence: None,
+        member_checker: None,
+        steward_checker: None,
+        suspension_checker: None,
+        membership_resolver: None,
+        sdis_service: None,
+    }
+}
+
+/// Build a test app with the governance routes mounted, injecting a chosen
+/// caller DID + scope into every request via a thin auth-shim middleware.
+macro_rules! standing_test_app {
+    ($ctx:expr, $caller_did:expr, $scope:expr) => {{
+        let scope: Option<&'static str> = $scope;
+        let caller = $caller_did.to_string();
+        test::init_service(
+            App::new()
+                .wrap_fn(move |req, srv| {
+                    if let Some(scope_str) = scope {
+                        req.extensions_mut().insert(BasicClaims {
+                            sub: caller.clone(),
+                            scope: Some(scope_str.to_string()),
+                        });
+                    }
+                    srv.call(req)
+                })
+                .configure(|cfg| http::configure(cfg, $ctx)),
+        )
+        .await
+    }};
+}
+
+macro_rules! fetch_standing {
+    ($app:expr, $uri:expr) => {{
+        let req = test::TestRequest::get().uri($uri).to_request();
+        let resp = test::call_service(&$app, req).await;
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body()).await.unwrap();
+        let parsed: Value = serde_json::from_slice(&bytes).expect("response is valid JSON");
+        (status, parsed)
+    }};
+}
+
+#[actix_web::test]
+async fn caller_with_no_standing_returns_well_formed_empty() {
+    let ctx = make_ctx();
+    let caller = fresh_did();
+    let app = standing_test_app!(ctx, &caller, Some("governance:read"));
+
+    let (status, body) = fetch_standing!(app, "/me/standing");
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["did"], caller.to_string());
+    assert!(body["domains"].as_array().unwrap().is_empty());
+    assert!(body["roles"].as_array().unwrap().is_empty());
+    assert!(body["authority_scopes"].as_array().unwrap().is_empty());
+    assert!(body["generated_at"].as_u64().is_some());
+    assert!(
+        body.get("display_label").is_none() || body["display_label"].is_null(),
+        "display_label is reserved for a future identity registry; should be absent or null"
+    );
+}
+
+#[actix_web::test]
+async fn direct_role_assignment_surfaces_in_standing() {
+    let ctx = make_ctx();
+    let caller = fresh_did();
+    let structure = ctx
+        .manager
+        .create_structure(
+            "entity-a".to_string(),
+            StructureKind::Committee,
+            "Treasury".to_string(),
+            None,
+        )
+        .expect("create_structure");
+    ctx.manager
+        .assign_role(
+            structure.id.clone(),
+            caller.clone(),
+            "treasurer".to_string(),
+        )
+        .expect("assign_role");
+
+    let app = standing_test_app!(ctx, &caller, Some("governance:read"));
+    let (status, body) = fetch_standing!(app, "/me/standing");
+    assert_eq!(status, StatusCode::OK);
+
+    let roles = body["roles"].as_array().unwrap();
+    assert_eq!(roles.len(), 1, "exactly one role should surface");
+    assert_eq!(roles[0]["role"], "treasurer");
+    assert_eq!(roles[0]["structure_name"], "Treasury");
+    assert_eq!(roles[0]["parent_entity_id"], "entity-a");
+    assert_eq!(roles[0]["structure_id"], structure.id.0);
+
+    // `authority_scopes` rolls up empty here because the public
+    // `manager.assign_role` and `POST /v1/gov/structures/{id}/roles` do not
+    // currently accept an `authority_scope` parameter — the field exists on
+    // `BootstrapRoleAssignmentRecord` but is dropped at apply time. Plumbing
+    // it through is a small follow-up tracked alongside #1603 and is
+    // intentionally out of scope here. The rollup logic itself (sort/dedup
+    // across role rows) is exercised by `direct_role_assignment_surfaces_in_standing`
+    // implicitly: zero scopes in, zero scopes out.
+    assert!(
+        body["authority_scopes"].as_array().unwrap().is_empty(),
+        "authority_scopes should be empty until apply-time plumbing carries scope"
+    );
+}
+
+#[actix_web::test]
+async fn person_directory_resolved_role_lands_the_same_way() {
+    // The person-directory overlay (#1603) resolves a holder_label to a real
+    // DID at plan time, then apply calls the same `assign_role` API the
+    // direct path uses. So the runtime contract /me/standing reads is
+    // identical: there is no separate "directory-sourced" code path. This
+    // test pins that property by simulating the post-apply state directly.
+    let ctx = make_ctx();
+    let caller = fresh_did();
+    let structure = ctx
+        .manager
+        .create_structure(
+            "entity-a".to_string(),
+            StructureKind::Committee,
+            "Content Working Group".to_string(),
+            None,
+        )
+        .expect("create_structure");
+    ctx.manager
+        .assign_role(
+            structure.id.clone(),
+            caller.clone(),
+            "program-coordinator".to_string(),
+        )
+        .expect("assign_role (post-apply)");
+
+    let app = standing_test_app!(ctx, &caller, Some("governance:read"));
+    let (status, body) = fetch_standing!(app, "/me/standing");
+    assert_eq!(status, StatusCode::OK);
+    let roles = body["roles"].as_array().unwrap();
+    assert_eq!(roles.len(), 1);
+    assert_eq!(roles[0]["role"], "program-coordinator");
+}
+
+#[actix_web::test]
+async fn inline_did_precedence_from_1603_is_preserved_in_standing() {
+    // End-to-end check: when an institution package supplies BOTH inline
+    // person_did and a holder_label that the directory could resolve, the
+    // inline DID wins at planning time. Standing for the inline DID shows
+    // the role; standing for the directory DID does NOT.
+    let ctx = make_ctx();
+    let inline_did = fresh_did();
+    let directory_did = fresh_did();
+    assert_ne!(inline_did, directory_did);
+
+    let structure = ctx
+        .manager
+        .create_structure(
+            "entity-a".to_string(),
+            StructureKind::Committee,
+            "Treasury".to_string(),
+            None,
+        )
+        .expect("create_structure");
+    // Apply the inline winner — this is the role assignment that planner
+    // would have emitted from #1603's resolver.
+    ctx.manager
+        .assign_role(
+            structure.id.clone(),
+            inline_did.clone(),
+            "treasurer".to_string(),
+        )
+        .expect("assign_role for inline DID");
+
+    let inline_app = standing_test_app!(ctx.clone(), &inline_did, Some("governance:read"));
+    let (status, body) = fetch_standing!(inline_app, "/me/standing");
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["roles"].as_array().unwrap().len(), 1);
+
+    let directory_app = standing_test_app!(ctx, &directory_did, Some("governance:read"));
+    let (status, body) = fetch_standing!(directory_app, "/me/standing");
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body["roles"].as_array().unwrap().is_empty(),
+        "directory DID must NOT inherit standing when inline DID won the assignment"
+    );
+}
+
+#[actix_web::test]
+async fn caller_does_not_see_another_dids_standing() {
+    let ctx = make_ctx();
+    let alice = fresh_did();
+    let bob = fresh_did();
+    let structure = ctx
+        .manager
+        .create_structure(
+            "entity-a".to_string(),
+            StructureKind::Committee,
+            "Treasury".to_string(),
+            None,
+        )
+        .expect("create_structure");
+    ctx.manager
+        .assign_role(structure.id, alice.clone(), "treasurer".to_string())
+        .expect("assign_role");
+
+    // Bob authenticates and queries — he is the caller, not Alice. There
+    // is no `did=` query parameter so Bob cannot ask about Alice.
+    let app = standing_test_app!(ctx, &bob, Some("governance:read"));
+    let (status, body) = fetch_standing!(app, "/me/standing");
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["did"], bob.to_string());
+    assert!(
+        body["roles"].as_array().unwrap().is_empty(),
+        "Bob must not see Alice's role assignment"
+    );
+}
+
+#[actix_web::test]
+async fn domain_membership_static_list_surfaces() {
+    let ctx = make_ctx();
+    let caller = fresh_did();
+    let other_member = fresh_did();
+    let domain_id = GovernanceDomainId("nycn-coordination".to_string());
+    ctx.manager
+        .create_domain(
+            domain_id.clone(),
+            "NYCN Coordination".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::new(50, 50, 86_400),
+            MembershipConfig::static_list(vec![caller.clone(), other_member]),
+        )
+        .await
+        .expect("create_domain");
+
+    let app = standing_test_app!(ctx, &caller, Some("governance:read"));
+    let (status, body) = fetch_standing!(app, "/me/standing");
+    assert_eq!(status, StatusCode::OK);
+
+    let domains = body["domains"].as_array().unwrap();
+    assert_eq!(domains.len(), 1);
+    assert_eq!(domains[0]["domain_id"], "nycn-coordination");
+    assert_eq!(domains[0]["membership_source"], "static_list");
+    assert_eq!(domains[0]["status"], "member");
+}
+
+#[actix_web::test]
+async fn domain_filter_narrows_results_and_unknown_id_returns_empty() {
+    let ctx = make_ctx();
+    let caller = fresh_did();
+    let domain_a = GovernanceDomainId("domain-a".to_string());
+    let domain_b = GovernanceDomainId("domain-b".to_string());
+    for d in [&domain_a, &domain_b] {
+        ctx.manager
+            .create_domain(
+                d.clone(),
+                format!("Domain {}", d.0),
+                "cooperative_default".to_string(),
+                GovernanceParams::new(50, 50, 86_400),
+                MembershipConfig::static_list(vec![caller.clone()]),
+            )
+            .await
+            .expect("create_domain");
+    }
+
+    let app = standing_test_app!(ctx, &caller, Some("governance:read"));
+
+    let (status, all) = fetch_standing!(app, "/me/standing");
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(all["domains"].as_array().unwrap().len(), 2);
+
+    let (status, filtered) = fetch_standing!(app, "/me/standing?domain_id=domain-a");
+    assert_eq!(status, StatusCode::OK);
+    let domains = filtered["domains"].as_array().unwrap();
+    assert_eq!(domains.len(), 1);
+    assert_eq!(domains[0]["domain_id"], "domain-a");
+
+    // Unknown domain → 200 with empty arrays. "No standing in that domain"
+    // is a valid answer; 404 would conflate "domain does not exist" with
+    // "you have no standing there", which are different concerns.
+    let (status, missing) = fetch_standing!(app, "/me/standing?domain_id=ghost");
+    assert_eq!(status, StatusCode::OK);
+    assert!(missing["domains"].as_array().unwrap().is_empty());
+    assert!(missing["roles"].as_array().unwrap().is_empty());
+}
+
+#[actix_web::test]
+async fn response_uses_regulatory_safe_vocabulary() {
+    let ctx = make_ctx();
+    let caller = fresh_did();
+    let structure = ctx
+        .manager
+        .create_structure(
+            "entity-a".to_string(),
+            StructureKind::Committee,
+            "Treasury".to_string(),
+            None,
+        )
+        .expect("create_structure");
+    ctx.manager
+        .assign_role(structure.id, caller.clone(), "treasurer".to_string())
+        .expect("assign_role");
+
+    let app = standing_test_app!(ctx, &caller, Some("governance:read"));
+    let req = test::TestRequest::get().uri("/me/standing").to_request();
+    let resp = test::call_service(&app, req).await;
+    let bytes = to_bytes(resp.into_body()).await.unwrap();
+    let raw_lower = String::from_utf8_lossy(&bytes).to_lowercase();
+    for forbidden in ["payment", "currency", " balance"] {
+        assert!(
+            !raw_lower.contains(forbidden),
+            "/me/standing response must not contain forbidden term '{forbidden}': {raw_lower}"
+        );
+    }
+}
+
+#[actix_web::test]
+async fn missing_governance_read_scope_is_rejected() {
+    let ctx = make_ctx();
+    let caller = fresh_did();
+    // Build the test app with no scope injected — the handler must reject.
+    let app = standing_test_app!(ctx, &caller, None);
+    let req = test::TestRequest::get().uri("/me/standing").to_request();
+    let resp = test::call_service(&app, req).await;
+    let status = resp.status();
+    assert!(
+        status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN,
+        "missing governance:read must return 401 or 403, got {status}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #1604.

Adds the caller-facing institutional read model — `GET /v1/gov/me/standing` — that answers *"what is my standing in this institution/domain/federation?"* by composing existing governance state (domain memberships + structure role assignments) into one digestible response.

This is the first piece of the member-facing read surface that NYCN-style federations and other institution packages will dogfood. It is intentionally generic: the endpoint knows nothing about NYCN.

## What `/me/standing` returns

`StandingResponse`:

| Field | Meaning |
|---|---|
| `did` | Caller's authenticated DID. Always derived from claims, never from a query param. |
| `display_label?` | Reserved for a future identity/entity-registry hop. Always `None` here. |
| `domains[]` | Governance domains where the caller is in the static member list, plus trust-threshold domains marked `"unverified"` (the trust graph is the source of truth, not this read model). |
| `roles[]` | Role assignments held by the caller, joined with cheap structure metadata (name + parent entity) so UI does not need a per-row fetch. |
| `authority_scopes[]` | Deduplicated, sorted union of `authority_scope` across roles. Convenience for UI. |
| `generated_at` | Unix epoch seconds when the snapshot was taken. No server-side caching. |

Optional filter: `?domain_id=<id>` narrows both `domains` and `roles` to that domain. Unknown ids return **200 with empty arrays** (not 404) — *"no standing in that domain"* is a valid answer.

## How it uses existing DID/auth context

- Mounted under the existing `/v1/gov` scope, alongside `/me/scopes` and `/me/work`.
- Requires `governance:read` (read-only) — matches `/me/scopes`. Reading your own standing must never require write authority.
- Caller DID = `claims.sub`. There is no `did=` query param, so a caller cannot inspect another DID's standing. Pinned by test `caller_does_not_see_another_dids_standing`.

## How this connects to #1603 person-directory role assignment

The person-directory overlay merged in #1626 resolves `holder_label → person_did` at plan time, then apply calls the same `manager.assign_role` API the inline-DID path uses. `/me/standing` reads from the same `StructureStore` both paths populate, so directory-resolved roles and inline-DID roles surface identically — no separate code path. Pinned by tests `person_directory_resolved_role_lands_the_same_way` and `inline_did_precedence_from_1603_is_preserved_in_standing`.

## How this prepares for NYCN deployment without hardcoding NYCN

NYCN ships a public package (structures, programs, role-assignment seeds with `holder_label`) and a private overlay (`person-directory-seed` mapping labels to real DIDs). After `apply` runs:

- A NYCN organizer hits `/me/standing` and sees their committee membership, their assigned roles, and the structures they belong to — without any NYCN-specific code in ICN core.
- An unrelated co-op operator using a different package hits the same endpoint and sees their own institution's standing the same way.

The endpoint is generic over institution; what changes between deployments is the seed data, not the runtime.

## Why action cards are intentionally deferred

`/me/standing` is the substrate. Action-card generation ("here are 3 things you can do right now") joins this read model with proposal/meeting/work state and applies UX-layer prioritization. That belongs in a separate endpoint and PR — bundling them now would couple a stable read model to a still-evolving UX pattern.

## Files

- `icn/apps/governance/src/http/models.rs` — `StandingQuery`, `StandingResponse`, `StandingDomainMembership`, `StandingRoleAssignment` (typed structs, not ad-hoc JSON).
- `icn/apps/governance/src/http/handlers.rs` — `get_my_standing` handler.
- `icn/apps/governance/src/http/configure.rs` — register `GET /me/standing`.
- `icn/apps/governance/tests/me_standing.rs` — 9 integration tests.

## Test plan

- [x] `cargo test -p icn-governance-actor --test me_standing` — 9/9 pass.
- [x] `cargo test -p icn-governance-actor` — full suite green (no regressions).
- [x] `cargo check -p icn-gateway --all-targets` — gateway re-binds the route group cleanly.
- [x] `cargo fmt --all --check` — clean.
- [x] `cargo clippy -p icn-governance-actor --all-targets -- -D warnings` — clean.

## Test cases proven

| Test | Asserts |
|---|---|
| `caller_with_no_standing_returns_well_formed_empty` | Empty caller → 200 with empty arrays, never errors |
| `direct_role_assignment_surfaces_in_standing` | Manager-level role assignment shows up with structure metadata joined |
| `person_directory_resolved_role_lands_the_same_way` | #1603 overlay path produces identical runtime visibility |
| `inline_did_precedence_from_1603_is_preserved_in_standing` | Inline DID wins; directory DID does NOT inherit standing |
| `caller_does_not_see_another_dids_standing` | Self-only — no `did=` param, no cross-DID visibility |
| `domain_membership_static_list_surfaces` | Static-list domain membership rolls into `domains[]` |
| `domain_filter_narrows_results_and_unknown_id_returns_empty` | `?domain_id=` filters and unknown id is 200-empty, not 404 |
| `response_uses_regulatory_safe_vocabulary` | No `payment` / `currency` / `balance` terms |
| `missing_governance_read_scope_is_rejected` | 401 or 403 on missing scope |

## Limitations / known gaps (documented in code)

- **`display_label`** is always `None` until an identity-registry lookup is wired. That's a separate slice when the entity-registry read API stabilizes.
- **`authority_scopes`** rolls up empty in the end-to-end path because `manager.assign_role` and `POST /v1/gov/structures/{id}/roles` do not currently accept an `authority_scope` parameter — the field exists on `BootstrapRoleAssignmentRecord` and on `RoleAssignment` but is dropped at apply time. Plumbing it through is a small follow-up tracked alongside #1603. The rollup logic itself (sort + dedup) is structurally correct; the input vector is just empty today.
- **Domain filter** currently joins `roles` to a domain by matching the structure's `parent_entity_id` against the requested `domain_id`. This is the loose-but-correct join until structures carry an explicit governance-domain back-reference. Sufficient for current institution packages where entity_id ≈ governance_domain_id.

## Recommended next follow-up

1. **NYCN deploy/apply importer path** — package operator workflow that takes a public package + private overlay and runs `icnctl institution bootstrap apply` end-to-end against a deployed gateway. With `/me/standing` available, organizers can verify their assignments landed.
2. **Action cards on top of `/me/standing`** — once standing returns real data for real organizers, layer the action-card generator that surfaces "here are 3 things you can do right now."
3. **`authority_scope` plumbing** — extend `assign_role` and the HTTP request type to carry the field bootstrap planning already produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
