### PR TITLE
feat(governance): plumb authority_scope through assign_role end-to-end

### DIFF
--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -3282,6 +3282,7 @@ fn role_to_response(r: &icn_governance::RoleAssignment) -> RoleAssignmentRespons
         structure_id: r.structure_id.0.clone(),
         person_did: r.person_did.to_string(),
         role: r.role.clone(),
+        authority_scope: r.authority_scope.clone(),
         start_date: r.start_date,
         end_date: r.end_date,
     }
@@ -3385,7 +3386,12 @@ pub async fn assign_role<E: GovernanceEventEmitter + Clone + 'static>(
 
     let assignment = ctx
         .manager
-        .assign_role(sid, person_did, req.role.clone())
+        .assign_role(
+            sid,
+            person_did,
+            req.role.clone(),
+            req.authority_scope.clone(),
+        )
         .map_err(anyhow_to_api)?;
 
     Ok(HttpResponse::Created().json(role_to_response(&assignment)))
@@ -6094,9 +6100,14 @@ mod tests {
             )
             .unwrap();
 
-        mgr.assign_role(s.id.clone(), caller.clone(), "coordinator".to_string())
-            .unwrap();
-        mgr.assign_role(s.id.clone(), other.clone(), "member".to_string())
+        mgr.assign_role(
+            s.id.clone(),
+            caller.clone(),
+            "coordinator".to_string(),
+            vec![],
+        )
+        .unwrap();
+        mgr.assign_role(s.id.clone(), other.clone(), "member".to_string(), vec![])
             .unwrap();
 
         let ctx = GovernanceContext {

--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -717,6 +717,14 @@ pub struct AssignRoleRequest {
     pub did: String,
     /// Role name: "coordinator", "member", "facilitator", "note_taker", etc.
     pub role: String,
+    /// Delegated authority scopes attached to this assignment.
+    ///
+    /// Opaque to ICN — institutions define their own scope vocabulary
+    /// (e.g. `"approve_budget_within_policy"`, `"curate_session_intake"`).
+    /// Omitting the field defaults to an empty scope, preserving backward
+    /// compatibility with callers that predate #1629.
+    #[serde(default)]
+    pub authority_scope: Vec<String>,
 }
 
 /// Role assignment response
@@ -726,6 +734,11 @@ pub struct RoleAssignmentResponse {
     pub structure_id: String,
     pub person_did: String,
     pub role: String,
+    /// Delegated authority scopes for this assignment. May be empty.
+    /// Serialized even when empty so clients can rely on the field's
+    /// presence in the response shape.
+    #[serde(default)]
+    pub authority_scope: Vec<String>,
     pub start_date: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub end_date: Option<u64>,

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -5038,6 +5038,7 @@ impl GovernanceManager {
         structure_id: StructureId,
         person_did: icn_identity::Did,
         role: String,
+        authority_scope: Vec<String>,
     ) -> Result<RoleAssignment> {
         // Validate the structure exists before persisting the role
         let exists = self
@@ -5048,7 +5049,8 @@ impl GovernanceManager {
             return Err(anyhow::anyhow!("Structure {} not found", structure_id));
         }
         let now = icn_time::current_timestamp_secs();
-        let assignment = RoleAssignment::new(structure_id, person_did, role, now);
+        let mut assignment = RoleAssignment::new(structure_id, person_did, role, now);
+        assignment.authority_scope = authority_scope;
         self.structure_store
             .save_role(&assignment)
             .map_err(|e| anyhow::anyhow!("Failed to save role assignment: {e}"))?;

--- a/icn/apps/governance/tests/assign_role_authority_scope.rs
+++ b/icn/apps/governance/tests/assign_role_authority_scope.rs
@@ -1,0 +1,214 @@
+//! End-to-end HTTP round-trip for `authority_scope` on role assignment (#1629).
+//!
+//! Proves the new field on `AssignRoleRequest` lands on the persisted
+//! `RoleAssignment`, surfaces on the `RoleAssignmentResponse`, and rolls up
+//! into `/me/standing.authority_scopes`. Backward-compat is pinned by a
+//! second request that omits the field entirely.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use actix_web::{body::to_bytes, dev::Service as _, http::StatusCode, test, App, HttpMessage};
+use icn_governance::StructureKind;
+use icn_governance_actor::{
+    http::{self, GovernanceContext},
+    manager::GovernanceManager,
+    NoopEventEmitter,
+};
+use icn_http_kit::auth::BasicClaims;
+use icn_identity::{Did, IdentityBundle};
+use serde_json::{json, Value};
+
+fn fresh_did() -> Did {
+    IdentityBundle::generate()
+        .expect("IdentityBundle::generate")
+        .did()
+        .clone()
+}
+
+fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
+    GovernanceContext {
+        manager: Arc::new(GovernanceManager::new()),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: None,
+        on_proposal_accepted_with_evidence: None,
+        member_checker: None,
+        steward_checker: None,
+        suspension_checker: None,
+        membership_resolver: None,
+        sdis_service: None,
+    }
+}
+
+/// Build a test app injecting the given caller + scope on every request.
+macro_rules! role_test_app {
+    ($ctx:expr, $caller_did:expr, $scope:expr) => {{
+        let scope: &'static str = $scope;
+        let caller = $caller_did.to_string();
+        test::init_service(
+            App::new()
+                .wrap_fn(move |req, srv| {
+                    req.extensions_mut().insert(BasicClaims {
+                        sub: caller.clone(),
+                        scope: Some(scope.to_string()),
+                    });
+                    srv.call(req)
+                })
+                .configure(|cfg| http::configure(cfg, $ctx)),
+        )
+        .await
+    }};
+}
+
+#[actix_web::test]
+async fn assign_role_with_authority_scope_round_trips_to_me_standing() {
+    let ctx = make_ctx();
+    let caller = fresh_did();
+
+    // Pre-create a structure the role will attach to. parent_entity_id is
+    // arbitrary — the test pins behavior, not NYCN topology.
+    let structure = ctx
+        .manager
+        .create_structure(
+            "entity-a".to_string(),
+            StructureKind::Committee,
+            "Finance Committee".to_string(),
+            None,
+        )
+        .expect("create_structure");
+
+    // The handler registry differs across requests because /me/standing needs
+    // governance:read while POST /roles needs governance:write. Build two
+    // apps from the same context — manager state is shared via Arc.
+    let writer_app = role_test_app!(ctx.clone(), &caller, "governance:write");
+    let reader_app = role_test_app!(ctx.clone(), &caller, "governance:read");
+
+    // 1) POST /structures/{id}/roles with explicit authority_scope.
+    let assign_body = json!({
+        "did": caller.to_string(),
+        "role": "treasurer",
+        "authority_scope": [
+            "approve_budget_within_policy",
+            "confirm_settlement_within_policy",
+        ],
+    });
+    let req = test::TestRequest::post()
+        .uri(&format!("/structures/{}/roles", structure.id.0))
+        .set_json(&assign_body)
+        .to_request();
+    let resp = test::call_service(&writer_app, req).await;
+    let status = resp.status();
+    let bytes = to_bytes(resp.into_body()).await.unwrap();
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "POST /roles must return 201, got {status}, body: {}",
+        String::from_utf8_lossy(&bytes)
+    );
+    let role_resp: Value = serde_json::from_slice(&bytes).unwrap();
+    let returned_scope: Vec<String> = role_resp["authority_scope"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        returned_scope,
+        vec![
+            "approve_budget_within_policy".to_string(),
+            "confirm_settlement_within_policy".to_string(),
+        ],
+        "AssignRoleRequest.authority_scope must round-trip on the response"
+    );
+
+    // 2) GET /me/standing returns the same scope on the role row and in the
+    // top-level union.
+    let req = test::TestRequest::get().uri("/me/standing").to_request();
+    let resp = test::call_service(&reader_app, req).await;
+    let status = resp.status();
+    let bytes = to_bytes(resp.into_body()).await.unwrap();
+    assert_eq!(status, StatusCode::OK);
+    let standing: Value = serde_json::from_slice(&bytes).unwrap();
+    let roles = standing["roles"].as_array().unwrap();
+    assert_eq!(roles.len(), 1);
+    let row_scope: Vec<String> = roles[0]["authority_scope"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        row_scope,
+        vec![
+            "approve_budget_within_policy".to_string(),
+            "confirm_settlement_within_policy".to_string(),
+        ],
+        "/me/standing roles[].authority_scope must match the assigned scope"
+    );
+    let rollup: Vec<String> = standing["authority_scopes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    // Sorted/deduped union — same two entries, alphabetical order.
+    assert_eq!(
+        rollup,
+        vec![
+            "approve_budget_within_policy".to_string(),
+            "confirm_settlement_within_policy".to_string(),
+        ],
+        "/me/standing.authority_scopes union must include all per-role scopes"
+    );
+}
+
+#[actix_web::test]
+async fn assign_role_without_authority_scope_remains_valid_and_empty() {
+    let ctx = make_ctx();
+    let caller = fresh_did();
+    let structure = ctx
+        .manager
+        .create_structure(
+            "entity-a".to_string(),
+            StructureKind::Committee,
+            "Steering".to_string(),
+            None,
+        )
+        .expect("create_structure");
+
+    let writer_app = role_test_app!(ctx.clone(), &caller, "governance:write");
+    let reader_app = role_test_app!(ctx.clone(), &caller, "governance:read");
+
+    // Backward-compat: POST without `authority_scope` must still succeed.
+    // The serde default keeps this an empty vector, not a missing-field
+    // error — old clients keep working unchanged.
+    let assign_body = json!({
+        "did": caller.to_string(),
+        "role": "coordinator",
+    });
+    let req = test::TestRequest::post()
+        .uri(&format!("/structures/{}/roles", structure.id.0))
+        .set_json(&assign_body)
+        .to_request();
+    let resp = test::call_service(&writer_app, req).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let bytes = to_bytes(resp.into_body()).await.unwrap();
+    let role_resp: Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(
+        role_resp["authority_scope"].as_array().unwrap().is_empty(),
+        "missing authority_scope must default to empty, not error"
+    );
+
+    // /me/standing rolls up empty.
+    let req = test::TestRequest::get().uri("/me/standing").to_request();
+    let resp = test::call_service(&reader_app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = to_bytes(resp.into_body()).await.unwrap();
+    let standing: Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(standing["authority_scopes"].as_array().unwrap().is_empty());
+    let roles = standing["roles"].as_array().unwrap();
+    assert_eq!(roles.len(), 1);
+    assert!(roles[0]["authority_scope"].as_array().unwrap().is_empty());
+}

--- a/icn/apps/governance/tests/me_standing.rs
+++ b/icn/apps/governance/tests/me_standing.rs
@@ -18,6 +18,8 @@
 //!    "no standing in that domain" is a meaningful answer.
 //! 8. The response payload uses regulatory-safe vocabulary
 //!    (no payment / currency / balance terms).
+//! 9. `authority_scope` round-trips through `assign_role` and rolls up into
+//!    the top-level `authority_scopes` union (#1629).
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -127,6 +129,7 @@ async fn direct_role_assignment_surfaces_in_standing() {
             structure.id.clone(),
             caller.clone(),
             "treasurer".to_string(),
+            vec!["approve_budget_within_policy".to_string()],
         )
         .expect("assign_role");
 
@@ -140,19 +143,26 @@ async fn direct_role_assignment_surfaces_in_standing() {
     assert_eq!(roles[0]["structure_name"], "Treasury");
     assert_eq!(roles[0]["parent_entity_id"], "entity-a");
     assert_eq!(roles[0]["structure_id"], structure.id.0);
-
-    // `authority_scopes` rolls up empty here because the public
-    // `manager.assign_role` and `POST /v1/gov/structures/{id}/roles` do not
-    // currently accept an `authority_scope` parameter — the field exists on
-    // `BootstrapRoleAssignmentRecord` but is dropped at apply time. Plumbing
-    // it through is a small follow-up tracked alongside #1603 and is
-    // intentionally out of scope here. The rollup logic itself (sort/dedup
-    // across role rows) is exercised by `direct_role_assignment_surfaces_in_standing`
-    // implicitly: zero scopes in, zero scopes out.
-    assert!(
-        body["authority_scopes"].as_array().unwrap().is_empty(),
-        "authority_scopes should be empty until apply-time plumbing carries scope"
+    assert_eq!(
+        roles[0]["authority_scope"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect::<Vec<_>>(),
+        vec!["approve_budget_within_policy".to_string()],
+        "authority_scope must round-trip on the role row"
     );
+
+    // Rollup union: the same scope appears in `authority_scopes` on the
+    // top-level standing.
+    let scopes: Vec<String> = body["authority_scopes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(scopes, vec!["approve_budget_within_policy".to_string()]);
 }
 
 #[actix_web::test]
@@ -178,6 +188,7 @@ async fn person_directory_resolved_role_lands_the_same_way() {
             structure.id.clone(),
             caller.clone(),
             "program-coordinator".to_string(),
+            vec!["curate_session_intake".to_string()],
         )
         .expect("assign_role (post-apply)");
 
@@ -216,6 +227,7 @@ async fn inline_did_precedence_from_1603_is_preserved_in_standing() {
             structure.id.clone(),
             inline_did.clone(),
             "treasurer".to_string(),
+            vec![],
         )
         .expect("assign_role for inline DID");
 
@@ -248,7 +260,7 @@ async fn caller_does_not_see_another_dids_standing() {
         )
         .expect("create_structure");
     ctx.manager
-        .assign_role(structure.id, alice.clone(), "treasurer".to_string())
+        .assign_role(structure.id, alice.clone(), "treasurer".to_string(), vec![])
         .expect("assign_role");
 
     // Bob authenticates and queries — he is the caller, not Alice. There
@@ -345,7 +357,12 @@ async fn response_uses_regulatory_safe_vocabulary() {
         )
         .expect("create_structure");
     ctx.manager
-        .assign_role(structure.id, caller.clone(), "treasurer".to_string())
+        .assign_role(
+            structure.id,
+            caller.clone(),
+            "treasurer".to_string(),
+            vec![],
+        )
         .expect("assign_role");
 
     let app = standing_test_app!(ctx, &caller, Some("governance:read"));

--- a/icn/bins/icnctl/src/institution_bootstrap.rs
+++ b/icn/bins/icnctl/src/institution_bootstrap.rs
@@ -1232,7 +1232,7 @@ async fn apply_operation(
             structure_id,
             person_did,
             role,
-            ..
+            authority_scope,
         } => {
             let resolved_structure_id = match resolve_live_or_existing_id(
                 client,
@@ -1253,9 +1253,14 @@ async fn apply_operation(
                 Err(err) => return ApplyOutcome::Failed(err),
             };
             let path = format!("/v1/gov/structures/{resolved_structure_id}/roles");
+            // Forward the planned authority_scope so it lands on the live role
+            // assignment (#1629). Empty vector is fine — `AssignRoleRequest`
+            // defaults the field, and older planners that emit no scope still
+            // produce a clean POST body.
             let body = json!({
                 "did": person_did.to_string(),
                 "role": role,
+                "authority_scope": authority_scope,
             });
             match post_json(client, gateway, &auth.token, &path, &body).await {
                 Ok(_) => ApplyOutcome::Completed(format!(


### PR DESCRIPTION
## Summary

Closes #1629.

Plumbs `authority_scope` through the role-assignment write path end-to-end: HTTP request → manager → persisted `RoleAssignment` → response → icnctl bootstrap apply → `/me/standing` per-role row → top-level `authority_scopes` rollup.

## Why

`/me/standing` (PR #1627) structurally returns `authority_scopes: Vec<String>` — the deduplicated union of `authority_scope` across the caller's role assignments — but in production that union always rolled up empty:

- `BootstrapRoleAssignmentRecord` carried `authority_scope` from seed YAML.
- `BootstrapOperation::AssignRole` carried it through plan generation.
- The icnctl apply path POSTed only `{ did, role }`.
- `manager.assign_role` constructed `RoleAssignment` with `authority_scope: vec![]`.

NYCN organizers could see *they had a role* but not *the authority attached to it*. This PR closes that gap.

## Changes

| Layer | Change |
|---|---|
| `AssignRoleRequest` | Add `authority_scope: Vec<String>` with `#[serde(default)]` so old clients keep working unchanged. |
| `RoleAssignmentResponse` | Expose `authority_scope` so list/get endpoints return it consistently. |
| `manager.assign_role` | Take `authority_scope` and persist on the `RoleAssignment`. Uses the existing field on `RoleAssignment` — **no storage schema change**. |
| `assign_role` HTTP handler | Forward `req.authority_scope`. |
| icnctl `BootstrapOperation::AssignRole` apply arm | Include `authority_scope` in the JSON body sent to `/v1/gov/structures/{id}/roles`. |

## Backward compatibility

- `authority_scope` is `#[serde(default)]` on the request — a POST that omits it still parses and produces an empty scope.
- `RoleAssignmentResponse.authority_scope` is always serialized (no `skip_serializing_if`) so clients can rely on the field being present.
- All existing call sites of `manager.assign_role` updated to pass `vec![]` as the new fourth parameter.

## Tests

- **New** `apps/governance/tests/assign_role_authority_scope.rs`:
  - `assign_role_with_authority_scope_round_trips_to_me_standing` — POST `/structures/{id}/roles` with two scopes → response carries them → GET `/me/standing` shows them on the per-role row AND in the deduplicated top-level union.
  - `assign_role_without_authority_scope_remains_valid_and_empty` — POST without the field still 201s; `/me/standing` rolls up empty.
- **Updated** `apps/governance/tests/me_standing.rs::direct_role_assignment_surfaces_in_standing` to assert authority_scope on the row and in the rollup; removed the stale comment describing the old gap.

## Out of scope (intentional)

- No new validation of allowed scope strings. Each institution defines its own scope vocabulary; ICN treats them as opaque.
- No CCL / PolicyOracle enforcement based on scope. That belongs in the authorization-decision path, not the role-assignment write path.

## Validation

- [x] `cargo test -p icn-governance-actor --test me_standing` — 9/9 pass
- [x] `cargo test -p icn-governance-actor --test assign_role_authority_scope` — 2/2 pass
- [x] `cargo test -p icn-governance-actor` — full sweep green
- [x] `cargo test -p icnctl` — full sweep green
- [x] `cargo check -p icn-governance-actor -p icnctl -p icn-gateway` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p icn-governance-actor -p icnctl -p icn-gateway --all-targets -- -D warnings` — clean

## What this unlocks for NYCN

Once a NYCN organizer is assigned (via the bootstrap apply path) to e.g. `committee-finance` with role `treasurer` and `authority_scope: ["approve_budget_within_policy", "confirm_settlement_within_policy"]`, hitting `GET /me/standing` returns:

```json
{
  "did": "did:icn:...",
  "roles": [{
    "structure_id": "committee-finance",
    "structure_name": "Finance Committee",
    "parent_entity_id": "nycn-organizing",
    "role": "treasurer",
    "authority_scope": [
      "approve_budget_within_policy",
      "confirm_settlement_within_policy"
    ],
    ...
  }],
  "authority_scopes": [
    "approve_budget_within_policy",
    "confirm_settlement_within_policy"
  ]
}
```

The mobile/web UI can finally render "you can do X, Y" instead of just "you have a role" — the substrate Action Cards will eventually build on top of.

## Follow-ups still open

- **#1628** — forward `operating_purpose` to `/v1/entities` at apply time. Independent slice; can land in any order.
- **#1623** — persist standalone proposals/votes/delegations across gateway restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
