### PR TITLE
docs(state): canon-sync — institutional-operability work through #1637

### DIFF
--- a/docs/PHASE_PROGRESS.md
+++ b/docs/PHASE_PROGRESS.md
@@ -1,6 +1,15 @@
 # ICN Phase Progress
-**Last Updated:** 2026-04-15
-**Current Phase:** Phase 2 — Pilot Launch (blocked on cooperative partners)
+**Last Updated:** 2026-04-26
+**Current Phase:** Phase 2 — Pilot Launch (still blocked on cooperative partners; institutional-operability infrastructure for pilot enablement is now in place)
+
+<!-- [sync edit] 2026-04-26: Phase 2 status unchanged (still blocked on
+     cooperative partners). Phase 2 deliverables list extended to record
+     that institutional-operability infrastructure to support pilot
+     deployment landed 2026-04-22 → 2026-04-26 (live charter activation,
+     person-directory overlay, /me/standing, authority_scope plumbing,
+     bootstrap-apply idempotency, persistent governance domains, NYCN
+     bootstrap apply integration tests + live-validate runbook). These
+     do not flip Phase 2 to ✅ on their own — that gate is partner-bound. -->
 
 <!-- [sync edit] 2026-04-15: Updated metrics tables with current measurements.
      Phase model, phase definitions, and completion criteria unchanged.
@@ -108,8 +117,16 @@
 
 **Deliverables:**
 - [x] Pilot runbook (#1222 ✅ closed)
+- [x] Live charter activation endpoint (#1624) — pilots can activate a charter against a running gateway
+- [x] Persistent governance domains across gateway restart (#1621)
+- [x] Person-directory overlay for bootstrap role assignment (#1626) — DID binding from package-side person ids
+- [x] `GET /me/standing` read model (#1627) — member-facing standing surface
+- [x] `authority_scope` plumbed end-to-end through `assign_role` (#1630)
+- [x] Generic institution bootstrap package path (#1586)
+- [x] Bootstrap-apply 409 idempotency (#1617) — re-running bootstrap is safe
+- [x] NYCN bootstrap apply integration tests + live-validate runbook (#1592, #1593)
 - [ ] One-command deployment script per cooperative
-- [ ] Charter customization workflow documented
+- [ ] Charter customization workflow documented (charter activation endpoint exists; non-technical workflow doc still missing)
 - [ ] Pilot onboarding guide (non-technical audience)
 - [ ] Deploy nodes for 3–5 pilot cooperatives
 - [ ] Weekly check-in process established
@@ -117,10 +134,11 @@
 
 **Blockers:**
 - ~~Requires Phase 1 complete~~ ✅ Charter Engine is live
+- ~~Requires bootstrap activation runtime~~ ✅ live charter activation + person-directory + standing read model landed 2026-04-22 → 2026-04-26
 - Requires cooperative partners identified and committed (primary blocker)
 
 **Decisions Made:**
-- (none yet)
+- (2026-04-26) Pilot enablement infrastructure (bootstrap, charter activation, role binding, standing) is in place; Phase 2 remains ⏳ until partners run it for real.
 
 ---
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,21 +1,51 @@
 ---
 Status: descriptive
 Canonical: yes
-Last Reviewed: 2026-04-15
+Last Reviewed: 2026-04-26
 ---
 
 # ICN State (living doc)
+
+<!-- [sync edit] 2026-04-26: Append the institutional-operability sequence
+     (live charter activation, person-directory overlay, /me/standing,
+     authority_scope plumbing) and the doctrine/ADR canonicalization that
+     landed since 2026-04-15. Open-PR table updated; 4-15 entries kept
+     intact below for continuity. Phase model unchanged. -->
 
 <!-- [sync edit] 2026-04-15: Consolidated stacked changelog into single current snapshot.
      Aligned crate list, merged PRs, and metrics to verified repo state.
      Phase model unchanged — phase classification is governance territory (PR C). -->
 
-## Current status (2026-04-15 snapshot)
+## Current status (2026-04-26 snapshot)
 
 **Current phase:** Phase 2 — Pilot Launch (blocked on cooperative partners).
-Active execution: NYCN institutional integration work (meetings, structures, activities, notification digest, Program/Milestone in review). Phase model classification is unchanged; see PHASE_PROGRESS.md for phase definitions and PR C for any future reclassification.
+Active execution: institutional-operability runtime (live charter activation, person-directory overlay, `/me/standing`, `authority_scope` plumbing all landed) plus the feedback/support doctrine rename and ADR canonicalization under `docs/adr/`. NYCN package side dogfoods these via the institution-package boundary. Phase model classification is unchanged; see PHASE_PROGRESS.md for phase definitions.
 
-### Recently merged (since last STATE.md update 2026-04-11)
+### Recently merged (since 2026-04-15)
+
+| PR | Title | Merged |
+|----|-------|--------|
+| #1637 | docs: reframe feedback doctrine and canonicalize ADR location | 2026-04-26 |
+| #1630 | feat(governance): plumb authority_scope through assign_role end-to-end | 2026-04-25 |
+| #1627 | feat(governance): add GET /me/standing read model | 2026-04-25 |
+| #1626 | feat(governance): person-directory overlay for bootstrap role assignment | 2026-04-25 |
+| #1625 | fix(coop): release sled db lock before reopen test | 2026-04-25 |
+| #1624 | feat(governance): live charter activation endpoint | 2026-04-25 |
+| #1622 | docs(strategy): institutional ecosystem arc — NYCN as first ecosystem seed | 2026-04-24 |
+| #1621 | fix(governance): persist domains across gateway restart in standalone mode | 2026-04-24 |
+| #1620 | fix(web): derive steward dashboard gateway URL from request context | 2026-04-24 |
+| #1619 | feat(infra): add soft pod anti-affinity for ICN daemons | 2026-04-23 |
+| #1618 | feat(ci): add Atlas-backed sccache setup for ci-runner | 2026-04-23 |
+| #1617 | fix(bootstrap): treat remaining create conflicts as idempotent | 2026-04-22 |
+| #1616 | docs(monitoring): document Helm access path for kube-prometheus-stack upgrade | 2026-04-22 |
+| #1614 | fix(monitoring): move Prometheus to Atlas-backed persistent storage | 2026-04-22 |
+| #1593 | docs(nycn): live-validate bootstrap apply and rewrite runbook | 2026-04-19 |
+| #1592 | test(icnctl): NYCN bootstrap apply integration tests | 2026-04-19 |
+| #1591 | fix(gateway): colon-safe proposal index keys with one-shot migration | 2026-04-19 |
+| #1590 | fix(governance): close residual acceptance-closure atomicity hazards | 2026-04-18 |
+| #1586 | feat(governance): add generic institution bootstrap package path | 2026-04-18 |
+
+### Recently merged (2026-04-15 snapshot, retained)
 
 | PR | Title | Merged |
 |----|-------|--------|
@@ -39,11 +69,20 @@ Active execution: NYCN institutional integration work (meetings, structures, act
 
 | PR | Title | Branch | Status |
 |----|-------|--------|--------|
-| #1550 | docs(state): canon-sync — align canonical docs to verified merged reality | docs/canon-sync-2026-04 | Open |
-| #1549 | docs(ai): constitutional core + workflow architecture migration | docs/workflow-migration | Open |
-| #1548 | feat(governance): Program + Milestone primitives (Tranche 1a) | feat/program-milestone | Open |
+| #1636 | chore(toolchain): upgrade Rust 1.88.0 → 1.95.0 | copilot/upgrade-rust-1-88-to-1-95 | Open — fmt fix pushed; tests running |
 
 ### What landed since Phase 1 (Charter Engine)
+
+Institutional-operability runtime (added 2026-04-22 → 2026-04-26):
+- Generic institution bootstrap package path — #1586
+- Bootstrap-apply 409 idempotency for repeated bootstrap runs — #1617
+- Persistent governance domains across gateway restart in standalone mode — #1621
+- Live charter activation endpoint — #1624
+- Person-directory overlay for bootstrap role assignment (DID binding) — #1626
+- `GET /me/standing` read model — #1627
+- `authority_scope` plumbed end-to-end through `assign_role` — #1630
+- Feedback/support doctrine rename + ADR canonicalization under `docs/adr/` — #1637
+- NYCN bootstrap apply integration tests + live-validate runbook — #1592, #1593
 
 Governance institutional primitives:
 - Governance domains, structures, activities, parent (scope container) — #1540
@@ -53,8 +92,15 @@ Governance institutional primitives:
 - Notification digest (pending votes, overdue items, upcoming meetings) — #1547
 - NYCN architecture docs (repo-shaped spec, implementation matrix, execution tranches) — #1544
 - NYCN institutional design correction (layered ontology) — #1545
+- Residual acceptance-closure atomicity hazards closed — #1590
+- Colon-safe proposal index keys with one-shot migration — #1591
 
 Infrastructure:
+- Atlas-backed Prometheus persistent storage — #1614
+- Atlas-backed sccache for ci-runner — #1618
+- Soft pod anti-affinity for ICN daemons — #1619
+- Helm path documented for kube-prometheus-stack — #1616
+- Steward dashboard derives gateway URL from request context — #1620
 - Security Audit CI fix (wasmtime bump) — #1522, #1542
 - CI dual-signal guard — #1524
 - Docker-build-deploy timeout fix — #1527

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -640,7 +640,7 @@ category = "status"
 status = "living"
 title = "ICN State (living doc)"
 description = "Living snapshot of repo layout, decisions, constraints, and current engineering status"
-last_updated = "2026-04-15"
+last_updated = "2026-04-26"
 owner = "matt"
 audiences = ["developers", "agents"]
 truth_class = "descriptive"
@@ -649,7 +649,7 @@ canonical = "yes"
 freshness = "current"
 domain_tags = ["status", "project"]
 recommended_action = "keep"
-last_reviewed = "2026-04-15"
+last_reviewed = "2026-04-26"
 
 [docs."docs/DOCUMENTATION_CONTROL_SYSTEM.md"]
 category = "reference"


### PR DESCRIPTION
## Summary

Narrow refresh of state docs after the institutional-operability sequence and ADR canonicalization that landed since 2026-04-15.

This is a docs-only PR. No code, no schema, no API surface change.

## Changes

### `docs/STATE.md`

- `Last Reviewed`: 2026-04-15 → 2026-04-26.
- Current status snapshot reframed around the institutional-operability runtime: live charter activation (#1624), person-directory overlay (#1626), `/me/standing` (#1627), `authority_scope` plumbing (#1630), feedback/support doctrine rename + ADR canonicalization (#1637).
- "Recently merged" table extended with #1586, #1590–#1593, #1614–#1622, #1624–#1627, #1630, #1637. The 2026-04-15 table is retained verbatim for continuity.
- Open PRs table truncated to the actually-open #1636 (toolchain) — the previously listed #1548/#1549/#1550 are merged or closed.
- "What landed since Phase 1": added an Institutional-operability runtime block; small additions to Governance institutional primitives and Infrastructure.

### `docs/PHASE_PROGRESS.md`

- `Last Updated`: 2026-04-15 → 2026-04-26 with an explicit sync-edit note.
- **Phase 2 status retained as ⏳ blocked on cooperative partners.** The pilot enablement deliverables that landed are checked off in place; the partner gate is unchanged. Phase 2 does not flip ✅ on infrastructure alone.

### `docs/registry.toml`

- Bump `STATE.md` `last_updated`/`last_reviewed` to 2026-04-26 to match the YAML front-matter (otherwise `doc_control_check --strict` fails).

## Risk

Documentation only. Worst case: a reader sees a slightly different recently-merged table than git log on a given day. Phase model unchanged. No "supported" claim added that isn't already in code.

## Test plan

- [x] `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml --strict` — passes (32 pre-existing warnings, 0 new)
- [x] `git diff --check` — clean
- [x] No new "supported" claim — every new line cites a merged PR number from `git log origin/main`