### PR TITLE
docs(adr): lifecycle and monorepo-boundary cleanup

### DIFF
--- a/docs/adr/ADR-0001-orchestration-plane-architecture.md
+++ b/docs/adr/ADR-0001-orchestration-plane-architecture.md
@@ -1,8 +1,23 @@
 # ADR-0001: Orchestration Plane Architecture (icn-ops)
 
 **Date**: 2026-02-19
-**Status**: accepted
+**Status**: superseded
+**Superseded by**: ADR-0017
 **Tags**: orchestration, mcp, multi-agent, cross-repo, state-management
+
+> **Update (2026-04-26):** the multi-repo physical topology described in
+> this ADR (separate `icn-ops/`, `icn-website/`, `icn/`) has been
+> superseded by monorepo consolidation. Website source, MCP
+> orchestration tooling, and ops state now live in the main ICN repo
+> under `website/`, `ops/mcp/`, and `ops/state/` respectively. See
+> [ADR-0017](ADR-0017-monorepo-consolidation-with-explicit-internal-boundaries.md)
+> for the canonical roots.
+>
+> **Durable principle retained:** ICN needs an explicit orchestration /
+> state plane with hybrid state (live MCP + git-tracked durable state).
+> This ADR is the historical record of why that plane exists. The
+> *separate-repo* implementation form is what changed; the principle
+> did not. The body of this ADR is preserved as institutional memory.
 
 ## Context
 

--- a/docs/adr/ADR-0002-mcp-server-registration-via-mcp-json.md
+++ b/docs/adr/ADR-0002-mcp-server-registration-via-mcp-json.md
@@ -1,8 +1,23 @@
 # ADR-0002: MCP Server Registration via ~/.mcp.json
 
 **Date**: 2026-02-19
-**Status**: accepted
+**Status**: amended
+**Amended by**: ADR-0017
 **Tags**: mcp, claude-code, setup
+
+> **Amendment (2026-04-26):** the registration mechanism described
+> here remains correct — MCP servers are still registered in
+> `~/.mcp.json` (user scope) or `.mcp.json` (project scope), with
+> `enableAllProjectMcpServers: true` in `~/.claude/settings.json`.
+>
+> What changed is the path. MCP source is no longer in a separate
+> `icn-ops/` repo; it lives in the main ICN repo under `ops/mcp/`.
+> The `dist/` build path that `~/.mcp.json` references has moved
+> accordingly. ADRs are canonical under `docs/adr/`, not under
+> `ops/state/decisions/` (see [ADR-0018](ADR-0018-adr-lifecycle-and-canonical-decision-index.md)).
+> The decision recorded here is unchanged; its addresses are
+> updated. See [ADR-0017](ADR-0017-monorepo-consolidation-with-explicit-internal-boundaries.md)
+> for the canonical layout.
 
 ## Context
 

--- a/docs/adr/ADR-0010-app-topology.md
+++ b/docs/adr/ADR-0010-app-topology.md
@@ -1,11 +1,27 @@
 # ADR-0010: App topology and canonical app roots
 
-- Status: Proposed
+- Status: Superseded
+- Superseded by: ADR-0017
 - Date: 2026-02-09
 - Decision drivers:
   - Reduce contributor confusion
   - Preserve kernel/app separation invariant
   - Make app ownership and migration paths explicit
+
+> **Update (2026-04-26):** this ADR opened the question of canonical
+> app roots but never closed it (it was filed `Proposed` and not
+> ratified). [ADR-0017](ADR-0017-monorepo-consolidation-with-explicit-internal-boundaries.md)
+> answers the question:
+>
+> - `icn/apps/` is the **runtime-wired** location and the home for
+>   any new app crate that participates in `icnd`.
+> - `apps/` (top-level) holds **prototypes and external
+>   demonstrators** that are not part of the Rust workspace.
+> - Neither root may accumulate institution-specific vocabulary.
+>
+> The ambiguity this ADR documented is real and is now resolved by
+> ADR-0017's canonical-roots table. Body preserved as the historical
+> motivation; current rule lives in ADR-0017.
 
 ## Context
 

--- a/docs/adr/ADR-0017-monorepo-consolidation-with-explicit-internal-boundaries.md
+++ b/docs/adr/ADR-0017-monorepo-consolidation-with-explicit-internal-boundaries.md
@@ -1,0 +1,92 @@
+---
+id: "0017"
+title: "Monorepo Consolidation with Explicit Internal Boundaries"
+status: "accepted"
+date: "2026-04-26"
+deciders: ["Matt Faherty"]
+tags: ["topology", "monorepo", "orchestration", "architecture", "boundaries", "kernel-app-separation"]
+supersedes: ["ADR-0001", "ADR-0010"]
+superseded_by: []
+amends: ["ADR-0002"]
+implementation_status: "implemented (physical layout in main ICN repo)"
+references:
+  - "ADR-0001 (Orchestration Plane Architecture — superseded by this ADR)"
+  - "ADR-0002 (MCP Server Registration — amended by this ADR)"
+  - "ADR-0010 (App topology — superseded by this ADR)"
+  - "ADR-0011 (Canonical Truth Ownership)"
+  - "docs/architecture/KERNEL_APP_SEPARATION.md"
+  - "docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md"
+---
+
+# ADR 0017: Monorepo Consolidation with Explicit Internal Boundaries
+
+## Status
+
+**Accepted (2026-04-26).** This ADR records the topology that already exists in `main` and replaces the multi-repo assumptions in ADR-0001 and the dual-app-roots ambiguity in ADR-0010 with a single canonical layout.
+
+This ADR makes no behavior changes to running code. It is a topology statement: where work belongs, and what the boundary lines are.
+
+## Context
+
+Earlier ADRs assumed a multi-repo topology:
+
+- `icn/` — substrate runtime workspace.
+- `icn-website/` — public website.
+- `icn-ops/` — orchestration plane (MCP, automation, ops state).
+
+That topology was not retained. The website source, MCP/orchestration tooling, deploy assets, docs, and ADRs all moved into the main ICN repo. ADR-0001 still describes the multi-repo arrangement; ADR-0010 still describes "two app roots" without resolving which is canonical.
+
+The risk has shifted:
+
+- **Old risk** (multi-repo era): cross-repo drift. Dependencies, conventions, and decisions diverged between `icn-ops/`, `icn-website/`, and `icn/` because nothing forced them to converge.
+- **New risk** (monorepo era): semantic-layer collapse. Everything sits next to everything else; physical proximity invites the assumption that the boundaries dissolved with the directory walls. They did not.
+
+**The kernel/app boundary, the substrate/app/website boundary, the docs/state boundary, and the institution-package/runtime boundary are unchanged. Only their physical location changed.**
+
+## Decision
+
+ICN's main repo is the canonical physical home for substrate runtime, app surfaces, website/docs, MCP/orchestration tooling, operational state, deploy assets, and any in-tree institution-package scaffolding. Physical consolidation does not collapse architectural boundaries.
+
+### Canonical roots
+
+| Path | Layer | Owns | Must not |
+|---|---|---|---|
+| `icn/` | substrate / Rust workspace root | `Cargo.toml`, kernel crates (`icn-core`, `icn-kernel-api`, `icn-identity`, `icn-net`, `icn-gossip`, `icn-store`, `icn-encoding`, `icn-time`, `icn-testkit`, `icn-protocol`, `icn-services`, `icn-crypto`, `icn-obs`, `icn-security`, `icn-authz`, `icn-http-kit`, `icn-naming`), domain crates that the kernel depends on (`icn-governance`, `icn-ledger`, `icn-trust`, `icn-ccl`, `icn-federation`, `icn-compute`, `icn-privacy`, `icn-snapshot`, `icn-crypto-pq`, `icn-steward`, `icn-zkp`, `icn-coop`, `icn-community`, `icn-entity`, `icn-api`, `icn-gateway`, `icn-rpc`), bins (`icnd`, `icnctl`, `icn-console`) | hold website assets, MCP tools, deploy YAML, or institution-package fixtures |
+| `icn/apps/` | runtime-wired app crates (PolicyOracle implementations, app lifecycle wiring) | `governance`, `ledger`, `membership`, `charter` — the app crates that are part of the workspace and integrate with `icnd` | accumulate domain-only logic that should live in a kernel crate, or accumulate institution-specific vocabulary |
+| `apps/` (top-level) | external/standalone app prototypes and demonstrators | `echo`, `governance`, `ledger`, `trust` (demonstrators / standalone surfaces, not part of the Rust workspace) | be conflated with `icn/apps/`. New runtime-wired apps go in `icn/apps/`, not here. This root remains for legacy prototypes and external demonstrators only. |
+| `website/` | public/narrative/docs/discovery surface | landing pages, public docs, narrative/strategy content, public roadmap | hold proprietary or pre-publication operational state |
+| `ops/mcp/` | MCP/orchestration tooling | TypeScript MCP server, decision/sprint/repo tools, `dist/` build artifact | become a parallel decision-doc tree (see ADR-0018) |
+| `ops/state/` | operational machine state | `truth/sources.json`, `sprint/current.json`, `config/repo-map.json`, MCP SQLite (gitignored) | hold human-readable docs (those live under `docs/`) |
+| `docs/` | human-readable documentation root | `STATE.md`, `ARCHITECTURE.md`, `architecture/`, `design/`, `spec/`, `reference/`, `guides/`, `planning/`, `strategy/`, `dev/`, `dev-journal/`, etc. | duplicate state owned by `ops/state/` |
+| `docs/adr/` | canonical Architecture Decision Records | `ADR-NNNN-slug.md`, `template.md` | be parallel to any other ADR location (see ADR-0018) |
+| `deploy/` | deployment manifests and runbooks | `k8s/`, helm charts, deploy READMEs | hold runtime code |
+| `sdk/` | language SDKs | `typescript/`, `react-native/`, generated API types | hold runtime code |
+| `web/` | in-repo web UIs | `pilot-ui/` (PWA), `dashboard/` (static) | be conflated with `website/` (which is the public surface, not pilot tooling) |
+
+### Rules
+
+1. **Physical proximity is not a license to collapse layers.** A file inside `icn/` may not import a domain noun from an institution package. A file inside `ops/mcp/` may not be substituted for a doc under `docs/`. The Meaning Firewall, the kernel/app separation, and the institution-package boundary remain enforced exactly as they were across the multi-repo era.
+
+2. **Two app roots are not a bug, but they are different.** `icn/apps/` is the runtime-wired location and the home for new apps that participate in `icnd`. `apps/` (top-level) holds prototypes and external demonstrators that are not part of the Rust workspace. Neither shall accumulate institution-specific vocabulary; that belongs in an institution package (see `docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md`).
+
+3. **`ops/state/` is machine state, not documentation.** Anything a human is meant to read first goes under `docs/`. The MCP server and other tooling may *index* docs by reading them, but indexing is not authoring.
+
+4. **`website/` is the public surface; `web/` is the in-repo pilot/dashboard surface.** Do not confuse them.
+
+5. **Cross-cutting tooling lives in `tools/`, `scripts/`, or `ops/`.** Do not park it in `icn/` or `docs/`.
+
+## Consequences
+
+- The "where does this go?" question now has a single canonical answer table. Any ambiguity is a doc bug, not a topology question.
+- ADR-0001's separate-repo `icn-ops/` topology no longer matches reality. ADR-0001 stays in the record as the historical decision that motivated the orchestration plane in the first place; this ADR replaces its physical layout. The durable principle from ADR-0001 — that ICN needs an explicit orchestration/state plane — is retained. The implementation form changed; the principle did not.
+- ADR-0010's "two app roots" question is answered: both exist, with non-overlapping purposes (workspace-wired vs prototypes/external). New runtime-wired apps go in `icn/apps/`. ADR-0010 is superseded by this ADR.
+- ADR-0002's MCP-registration mechanism is unchanged in spirit; the path moved from a separate repo into `ops/mcp/`. ADR-0002 is amended, not superseded — the registration mechanism is still the right one, the address just changed.
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|---|---|
+| Re-split into `icn-ops/`, `icn-website/`, `icn/` | The merge happened for real reasons (cross-cutting work, single-PR review, atomic CI, single source of truth). Re-splitting would re-introduce the drift this ADR's predecessor existed to fight. |
+| Leave ADR-0001 / ADR-0010 in place without a successor ADR | Future contributors would read the old ADRs as current truth and re-derive the wrong topology. Recording the supersession explicitly is what makes the ADR record honest. |
+| Collapse `apps/` into `icn/apps/` | The two roots have non-overlapping purposes (prototypes vs workspace). Collapsing them now would drag legacy prototype code into the workspace surface, breaking kernel/app separation more, not less. The right move is a clear written rule, not a rename. |
+| One mega-ADR that replaces 0001, 0002, 0010, plus authority/bootstrap | Too large to review honestly. This ADR records the topology decision only. Authority/mandate (ADR-0019) and bootstrap activation (ADR-0020) get their own records.|

--- a/docs/adr/ADR-0018-adr-lifecycle-and-canonical-decision-index.md
+++ b/docs/adr/ADR-0018-adr-lifecycle-and-canonical-decision-index.md
@@ -1,0 +1,134 @@
+---
+id: "0018"
+title: "ADR Lifecycle and Canonical Decision Index"
+status: "accepted"
+date: "2026-04-26"
+deciders: ["Matt Faherty"]
+tags: ["adr", "process", "decisions", "documentation", "tooling", "lifecycle"]
+supersedes: []
+superseded_by: []
+amends: []
+implementation_status: "implemented (tooling: ops/mcp/src/tools/decisions.ts; canonical location: docs/adr/, established by PR #1637)"
+references:
+  - "ADR-0017 (Monorepo Consolidation)"
+  - "PR #1637 (ADR canonicalization under docs/adr/)"
+  - "docs/adr/template.md"
+---
+
+# ADR 0018: ADR Lifecycle and Canonical Decision Index
+
+## Status
+
+**Accepted (2026-04-26).** Establishes the lifecycle vocabulary, metadata convention, and tooling contract for ICN ADRs. PR #1637 already moved the canonical location to `docs/adr/`; this ADR records the conventions that location follows.
+
+## Context
+
+ICN's ADRs grew up across two physical locations (`docs/adr/` and the now-retired `ops/state/decisions/`) with three different metadata styles:
+
+- **Classic markdown**: `**Date**`, `**Status**`, `**Tags**` as bold labels (ADR-0001 through ADR-0009, 0011, 0015, 0016).
+- **YAML frontmatter**: `---` block at the top with `id`, `title`, `status`, `date`, etc. (ADR-0012, 0013, 0014).
+- **Bullet list**: `- Status: Proposed`, `- Date: ...` (ADR-0010).
+
+The MCP indexer in `ops/mcp/src/tools/decisions.ts` recognizes only the classic format. ADRs in the other styles fail to populate `decision_index.title`/`tags`/`date` correctly. This makes the institutional memory brittle.
+
+In addition, several decisions had implicit lifecycles that were never written down:
+
+- "Proposed" ADRs that were silently being depended on as accepted.
+- "Accepted" ADRs whose original decision had since been superseded by reality (multi-repo → monorepo) without a follow-up ADR being filed.
+- "Implementation status" being tangled up with "decision status" — they are not the same thing. An accepted decision may be unimplemented, partially implemented, or fully implemented; the decision is still accepted.
+
+## Decision
+
+### 1. Canonical location
+
+Human-readable ADRs live under `docs/adr/` only. `ops/state/decisions/` is retired and the directory holds only a redirect README (PR #1637). Operational state may *index* ADRs (the MCP `log_decision` / `search_decisions` / `get_decision` tools), but indexing is not authoring. There is one canonical decision tree, and it is `docs/adr/`.
+
+### 2. ADR lifecycle vocabulary
+
+Every ADR has a `status` from this closed list:
+
+| Status | Meaning |
+|---|---|
+| `proposed` | Documented and circulating for review. Not yet the project's decision. May still be revised in body. |
+| `accepted` | The decision is in force. Body is frozen except for amendment notes. New behavior must conform. |
+| `amended` | An accepted ADR with one or more amendment notes added after acceptance. The original decision still holds; the amendments narrow, clarify, or extend it without overturning it. |
+| `superseded` | An accepted-or-amended ADR whose decision has been replaced by a successor ADR. The body remains as institutional memory. The successor is named in `superseded_by`. |
+| `deprecated` | An accepted-or-amended ADR whose decision no longer applies, but no successor ADR replaces it (the entire concern went away). Rare. |
+
+### 3. Decision status is separate from implementation status
+
+A decision can be `accepted` without code; code can exist without a decision being recorded. The two statuses are tracked independently:
+
+- `status` (decision lifecycle, above).
+- `implementation_status` (free-form text or a closed enum: `proposed`, `partially implemented`, `implemented`, `not yet implemented`, `needs verification`, `unknown`).
+
+When code lands that proves an accepted ADR's intent, update `implementation_status` and cite the evidence (PR number, file path, test name). Do NOT silently flip `status` from `proposed` to `accepted` because code was written. The decision lifecycle moves only when the project decides; the implementation status moves when the code does.
+
+### 4. Supersession is explicit and traceable
+
+When a new ADR replaces an old one:
+
+- The new ADR's frontmatter sets `supersedes: [ADR-NNNN]`.
+- The old ADR's frontmatter sets `superseded_by: ADR-NNNN`.
+- The old ADR keeps its body. **History is preserved.** Add a short header note explaining the supersession; do not rewrite the body to match the new decision.
+- Searching for either ADR in the MCP index returns the chain.
+
+When a new ADR amends without replacing:
+
+- The new ADR's frontmatter sets `amends: [ADR-NNNN]`.
+- The old ADR's status changes from `accepted` to `amended` and gets an amendment note pointing to the new ADR.
+
+### 5. Metadata convention going forward
+
+**New ADRs use YAML frontmatter** with at minimum:
+
+```yaml
+---
+id: "NNNN"
+title: "Short Decision Title"
+status: "proposed | accepted | amended | superseded | deprecated"
+date: "YYYY-MM-DD"
+deciders: ["…"]
+tags: ["…", "…"]
+supersedes: []      # optional; list of "ADR-NNNN"
+superseded_by: []   # optional; "ADR-NNNN" or empty list
+amends: []          # optional; list of "ADR-NNNN"
+implementation_status: "…"  # optional; free-form or one of the closed values above
+references:
+  - "ADR-NNNN (relationship description)"
+  - "docs/path/to/related.md"
+---
+```
+
+**Existing ADRs keep their original metadata format.** They are not mass-rewritten. The MCP indexer is taught to parse all three formats so the index stays consistent across the historical record. When an existing ADR is touched for an amendment or supersession, the touch may include a metadata-format upgrade in the same edit, but a doc-only mass migration is out of scope for normal work.
+
+### 6. Tooling contract
+
+`ops/mcp/src/tools/decisions.ts` indexes `docs/adr/` on boot and on each ADR write:
+
+- Recognizes filenames `ADR-NNNN-slug.md` (canonical) and `NNNN-slug.md` (legacy, for safety).
+- Parses metadata in three forms: YAML frontmatter, classic `**Field**:` markdown, bullet list.
+- Extracts: `id`, `title`, `status`, `date`, `tags`, `supersedes`, `superseded_by`, `amends`, `implementation_status`.
+- Re-points stale `file_path` rows to the canonical `docs/adr/` location on every boot (`INSERT OR REPLACE`).
+- `get_decision` falls through to a filesystem scan when a stored row's `file_path` no longer exists.
+
+### 7. Template
+
+`docs/adr/template.md` is the source of truth for new-ADR shape. It uses the metadata convention above. Authors are not required to use every field, but the schema is the schema.
+
+## Consequences
+
+- ADR drift between `docs/adr/` and any other location is impossible by rule (only one canonical location exists) and indexed by tooling.
+- Old decisions remain readable as written; their relevance to today is encoded in `status` + `superseded_by` + amendment notes, not in a rewrite.
+- Searching the MCP decision index now works uniformly across all metadata formats. Brittleness from format inconsistency is gone.
+- Decision-vs-implementation status separation prevents two failure modes: (a) "code lands so I'll quietly mark the ADR accepted," (b) "ADR is still proposed so I'll act as if no decision was made."
+- Future authors have a written rule for "what do I do when the world changes after my ADR was accepted?" — file a new ADR, update the old one's `status` and frontmatter, point at the successor. No silent rewrites.
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|---|---|
+| Mass-migrate every existing ADR to YAML frontmatter | Touches every historical record without changing institutional meaning. The brittleness cost is paid by the indexer once; the rewrite cost would be paid forever in noisy commits and lost git-blame. Indexer change is the right place. |
+| Keep `ops/state/decisions/` as a parallel index | Was the source of the drift problem in the first place. PR #1637 retired it; this ADR records the principle behind that retirement. |
+| Combine "decision status" and "implementation status" into one field | Conflates two genuinely independent variables. Loses the ability to say "we decided this, code is not yet here" or "we didn't decide this, but code shipped that depends on it." Both states need to exist; they need separate fields. |
+| Skip writing this ADR | The lifecycle is real whether it is documented or not. Implicit conventions are how drift gets back in. |

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,22 +1,57 @@
-# ADR-NNNN: Title
+---
+id: "NNNN"
+title: "Short Decision Title"
+status: "proposed"
+date: "YYYY-MM-DD"
+deciders: ["Name 1", "Name 2"]
+tags: ["topic1", "topic2"]
+supersedes: []
+superseded_by: []
+amends: []
+implementation_status: "proposed"
+references:
+  - "ADR-NNNN (relationship description)"
+  - "docs/path/to/related.md"
+---
 
-**Date**: YYYY-MM-DD
-**Status**: proposed | accepted | superseded | deprecated
-**Tags**: kernel, networking, deployment, orchestration, monitoring, ci, ...
-**Supersedes**: ADR-NNNN (if applicable)
-**Superseded by**: ADR-NNNN (if applicable)
+# ADR-NNNN: Short Decision Title
+
+## Status
+
+`proposed` — until the project decides; then `accepted`. Subsequent
+amendments do not change the lifecycle status to `proposed` again;
+they add an amendment note and (if accepted on review) flip the
+status to `amended`. Supersession is recorded by adding a successor
+ADR and updating both `status` and `superseded_by` here.
+
+Decision status (`status` field) is independent from implementation
+status (`implementation_status` field). See ADR-0018 for the
+lifecycle vocabulary and rules.
 
 ## Context
 
-What's the situation? What forces are at play? What problem are we solving?
+What's the situation? What forces are at play? What problem are we
+solving?
 
 ## Decision
 
-What did we decide? Be specific — include the key choice and any important constraints that shaped it.
+What did we decide? Be specific — include the key choice and any
+important constraints that shaped it.
 
 ## Consequences
 
-What are the trade-offs? What becomes easier? What becomes harder or more risky?
+What are the trade-offs? What becomes easier? What becomes harder
+or more risky?
+
+## Implementation status
+
+If code already proves out part of this decision, list:
+
+- evidence paths (file path or PR number)
+- which sub-claims are proven and which are not
+- what would have to land to call this `implemented`
+
+If this ADR is purely doctrinal (no code change), say so.
 
 ## Alternatives Considered
 
@@ -24,5 +59,19 @@ What else did we evaluate and why did we not choose it?
 
 | Alternative | Why rejected |
 |-------------|-------------|
-| Option A    | ... |
-| Option B    | ... |
+| Option A    | … |
+| Option B    | … |
+
+---
+
+## Notes
+
+- For *amendments*, add an `## Amendments` section with dated
+  entries naming the amending ADR; do not rewrite the body.
+- For *supersession*, add a header `> Update (YYYY-MM-DD)` block
+  pointing to the successor ADR; preserve the original body
+  unchanged below it.
+- Metadata format above is YAML frontmatter. Existing ADRs may use
+  classic markdown (`**Date**:` style) or bullet metadata; the MCP
+  indexer parses all three. New ADRs SHOULD use the frontmatter
+  form.

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -2999,13 +2999,62 @@ owner = "matt"
 audiences = ["all"]
 
 [docs."docs/adr/ADR-0010-app-topology.md"]
+# DOC status is "living" — ADRs are institutional memory at their canonical
+# path even after the recorded DECISION is superseded. Decision lifecycle is
+# tracked inside the ADR frontmatter (status: superseded, superseded_by:
+# ADR-0017). See ADR-0018 for the lifecycle rules.
 category = "architecture"
 status = "living"
-title = "ADR-0010: App Topology"
-description = "Architectural decision record on app topology"
-last_updated = "2026-03-10"
+title = "ADR-0010: App Topology (decision superseded by ADR-0017)"
+description = "Architectural decision record on app topology — DECISION superseded by ADR-0017 (canonical-roots table); ADR file remains at canonical path as institutional memory."
+last_updated = "2026-04-26"
 owner = "matt"
 audiences = ["architects"]
+
+[docs."docs/adr/ADR-0017-monorepo-consolidation-with-explicit-internal-boundaries.md"]
+category = "architecture"
+status = "living"
+truth_class = "normative"
+title = "ADR-0017: Monorepo Consolidation with Explicit Internal Boundaries"
+description = "Canonical roots table for the consolidated monorepo: icn/, icn/apps/, apps/, website/, ops/mcp/, ops/state/, docs/, docs/adr/, deploy/, sdk/, web/. Decision supersedes ADR-0001 and ADR-0010; amends ADR-0002."
+last_updated = "2026-04-26"
+last_reviewed = "2026-04-26"
+owner = "matt"
+audiences = ["architects", "developers"]
+
+[docs."docs/adr/ADR-0018-adr-lifecycle-and-canonical-decision-index.md"]
+category = "architecture"
+status = "living"
+truth_class = "normative"
+title = "ADR-0018: ADR Lifecycle and Canonical Decision Index"
+description = "ADR lifecycle vocabulary (proposed/accepted/amended/superseded/deprecated), metadata convention (YAML frontmatter going forward, classic + bullet still supported), tooling contract for ops/mcp/src/tools/decisions.ts. Documents the docs/adr/ canonicalization landed in PR #1637."
+last_updated = "2026-04-26"
+last_reviewed = "2026-04-26"
+owner = "matt"
+audiences = ["architects", "developers"]
+
+[docs."docs/adr/ADR-0001-orchestration-plane-architecture.md"]
+# DOC status is "living" — ADRs stay at their canonical path even when the
+# DECISION has been superseded. Decision lifecycle is tracked in the ADR
+# frontmatter (status: superseded, superseded_by: ADR-0017).
+category = "architecture"
+status = "living"
+title = "ADR-0001: Orchestration Plane Architecture (decision superseded by ADR-0017)"
+description = "Original multi-repo orchestration-plane decision; physical layout DECISION superseded by ADR-0017, durable principle (explicit orchestration/state plane) retained. ADR remains as institutional memory at canonical path."
+last_updated = "2026-04-26"
+owner = "matt"
+audiences = ["architects"]
+
+[docs."docs/adr/ADR-0002-mcp-server-registration-via-mcp-json.md"]
+# DOC status is "living"; DECISION status is "amended" per the ADR
+# frontmatter and the amendment note in the body.
+category = "architecture"
+status = "living"
+title = "ADR-0002: MCP Server Registration via ~/.mcp.json (amended by ADR-0017)"
+description = "Registration mechanism unchanged; path moved from a separate icn-ops/ repo into ops/mcp/ in the main ICN repo (decision amended by ADR-0017)."
+last_updated = "2026-04-26"
+owner = "matt"
+audiences = ["developers"]
 
 [docs."docs/ci/GATE_RATCHET_PLAN.md"]
 category = "reference"

--- a/ops/mcp/src/tests/decisions.test.ts
+++ b/ops/mcp/src/tests/decisions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { initDb } from "../state/db.js";
+import { parseAdrMetadata } from "../tools/decisions.js";
 import type Database from "better-sqlite3";
 
 let db: Database.Database;
@@ -90,5 +91,149 @@ describe("decision_index", () => {
 
     expect(kernelResults).toHaveLength(1);
     expect(kernelResults[0].id).toBe("0001");
+  });
+});
+
+describe("parseAdrMetadata — classic markdown", () => {
+  it("extracts title, status, date, tags from `**Field**:` style", () => {
+    const content = `# ADR-0001: Orchestration Plane Architecture
+
+**Date**: 2026-02-19
+**Status**: superseded
+**Superseded by**: ADR-0017
+**Tags**: orchestration, mcp, multi-agent
+
+## Context
+…
+`;
+    const m = parseAdrMetadata(content);
+    expect(m.title).toBe("Orchestration Plane Architecture");
+    expect(m.status).toBe("superseded");
+    expect(m.date).toBe("2026-02-19");
+    expect(m.tags).toBe("orchestration, mcp, multi-agent");
+    expect(m.superseded_by).toEqual(["ADR-0017"]);
+  });
+
+  it("treats `**Tags**: —` as empty tags", () => {
+    const content = `# ADR-0099: Test
+
+**Date**: 2026-04-26
+**Status**: accepted
+**Tags**: —
+`;
+    const m = parseAdrMetadata(content);
+    expect(m.tags).toBe("");
+    expect(m.status).toBe("accepted");
+  });
+});
+
+describe("parseAdrMetadata — YAML frontmatter", () => {
+  it("extracts metadata from a frontmatter block", () => {
+    const content = `---
+id: "0014"
+title: "Constitutional Object Model"
+status: "proposed"
+date: "2026-04-19"
+tags: ["governance", "architecture", "authority"]
+supersedes: []
+superseded_by: []
+amends: []
+implementation_status: "partially implemented"
+---
+
+# ADR 0014: Constitutional Object Model
+
+## Status
+…
+`;
+    const m = parseAdrMetadata(content);
+    expect(m.title).toBe("Constitutional Object Model");
+    expect(m.status).toBe("proposed");
+    expect(m.date).toBe("2026-04-19");
+    expect(m.tags).toBe("governance, architecture, authority");
+    expect(m.implementation_status).toBe("partially implemented");
+    expect(m.supersedes).toEqual([]);
+    expect(m.superseded_by).toEqual([]);
+  });
+
+  it("handles supersedes as a populated YAML inline list", () => {
+    const content = `---
+id: "0017"
+title: "Monorepo Consolidation"
+status: "accepted"
+date: "2026-04-26"
+supersedes: ["ADR-0001", "ADR-0010"]
+amends: ["ADR-0002"]
+---
+
+# ADR 0017
+`;
+    const m = parseAdrMetadata(content);
+    expect(m.supersedes).toEqual(["ADR-0001", "ADR-0010"]);
+    expect(m.amends).toEqual(["ADR-0002"]);
+  });
+
+  it("handles supersedes as a YAML block-style list", () => {
+    const content = `---
+id: "0017"
+title: "Test"
+status: "accepted"
+date: "2026-04-26"
+supersedes:
+  - "ADR-0001"
+  - "ADR-0010"
+---
+
+# ADR
+`;
+    const m = parseAdrMetadata(content);
+    expect(m.supersedes).toEqual(["ADR-0001", "ADR-0010"]);
+  });
+});
+
+describe("parseAdrMetadata — bullet metadata", () => {
+  it("extracts status and date from `- Status:` / `- Date:` lines", () => {
+    const content = `# ADR-0010: App topology and canonical app roots
+
+- Status: Superseded
+- Superseded by: ADR-0017
+- Date: 2026-02-09
+- Decision drivers:
+  - Reduce contributor confusion
+
+## Context
+…
+`;
+    const m = parseAdrMetadata(content);
+    expect(m.title).toBe("App topology and canonical app roots");
+    expect(m.status).toBe("superseded");
+    expect(m.date).toBe("2026-02-09");
+    expect(m.superseded_by).toEqual(["ADR-0017"]);
+  });
+});
+
+describe("parseAdrMetadata — fallbacks", () => {
+  it("returns empty metadata for an empty body", () => {
+    const m = parseAdrMetadata("");
+    expect(m.title).toBe("");
+    expect(m.status).toBeNull();
+    expect(m.date).toBeNull();
+    expect(m.tags).toBe("");
+    expect(m.supersedes).toEqual([]);
+    expect(m.superseded_by).toEqual([]);
+    expect(m.amends).toEqual([]);
+    expect(m.implementation_status).toBeNull();
+  });
+
+  it("derives title from `# ADR-NNNN: …` heading when frontmatter omits it", () => {
+    const content = `---
+id: "0099"
+date: "2026-04-26"
+---
+
+# ADR-0099: Heading-Derived Title
+`;
+    const m = parseAdrMetadata(content);
+    expect(m.title).toBe("Heading-Derived Title");
   });
 });

--- a/ops/mcp/src/tools/decisions.ts
+++ b/ops/mcp/src/tools/decisions.ts
@@ -14,6 +14,225 @@ const DECISIONS_DIR = join(resolveMonorepoRoot(), "docs", "adr");
 // Match both legacy `NNNN-slug.md` and canonical `ADR-NNNN-slug.md`.
 const ADR_FILENAME_RE = /^(?:ADR-)?(\d{4})-.*\.md$/;
 
+/**
+ * Extended ADR metadata extracted from the file body.
+ *
+ * The repository carries ADRs in three metadata styles, all valid:
+ *
+ *   1. YAML frontmatter (preferred for new ADRs; ADR-0012, 0013, 0014, …):
+ *
+ *        ---
+ *        id: "0014"
+ *        title: "..."
+ *        status: "proposed"
+ *        ...
+ *        ---
+ *
+ *   2. Classic markdown bold labels (ADR-0001..0009, 0011, 0015, 0016):
+ *
+ *        # ADR-0001: Title
+ *        **Date**: 2026-02-19
+ *        **Status**: accepted
+ *        **Tags**: ...
+ *
+ *   3. Bullet metadata (ADR-0010):
+ *
+ *        # ADR-0010: Title
+ *        - Status: Proposed
+ *        - Date: 2026-02-09
+ *
+ * The indexer recognizes all three so historical ADRs index correctly
+ * without rewriting their bodies.
+ */
+export interface AdrMetadata {
+  title: string;
+  tags: string;
+  date: string | null;
+  status: string | null;
+  supersedes: string[];
+  superseded_by: string[];
+  amends: string[];
+  implementation_status: string | null;
+}
+
+function emptyMetadata(): AdrMetadata {
+  return {
+    title: "",
+    tags: "",
+    date: null,
+    status: null,
+    supersedes: [],
+    superseded_by: [],
+    amends: [],
+    implementation_status: null,
+  };
+}
+
+function splitArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .map((v) => String(v).trim())
+      .filter((v) => v.length > 0 && v !== "[]");
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "" || trimmed === "[]") return [];
+    // Allow `["ADR-0001", "ADR-0002"]` or `ADR-0001, ADR-0002`.
+    const stripped = trimmed.replace(/^\[|\]$/g, "");
+    return stripped
+      .split(",")
+      .map((s) => s.trim().replace(/^["']|["']$/g, ""))
+      .filter((s) => s.length > 0);
+  }
+  return [];
+}
+
+/**
+ * Parse a YAML-frontmatter block. Intentionally minimal: handles top-level
+ * scalar fields (`key: value`) and list fields written as either
+ *
+ *   key: ["a", "b"]
+ *   key: []
+ *
+ * or
+ *
+ *   key:
+ *     - "a"
+ *     - "b"
+ *
+ * Quoted strings have surrounding quotes stripped. Unknown fields are
+ * returned as plain strings in the `extra` map for downstream callers.
+ */
+function parseFrontmatter(block: string): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const lines = block.split(/\r?\n/);
+  let currentListKey: string | null = null;
+  for (const raw of lines) {
+    const line = raw.replace(/\s+$/, "");
+    if (line === "") {
+      currentListKey = null;
+      continue;
+    }
+    // List item under a key written in block style.
+    if (currentListKey && /^\s*-\s*/.test(line)) {
+      const item = line
+        .replace(/^\s*-\s*/, "")
+        .trim()
+        .replace(/^["']|["']$/g, "");
+      const existing = (out[currentListKey] as string[] | undefined) ?? [];
+      existing.push(item);
+      out[currentListKey] = existing;
+      continue;
+    }
+    const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.*)$/);
+    if (!m) {
+      currentListKey = null;
+      continue;
+    }
+    const key = m[1];
+    const rest = m[2].trim();
+    if (rest === "") {
+      // Possible block-list ahead.
+      currentListKey = key;
+      out[key] = [];
+      continue;
+    }
+    currentListKey = null;
+    if (rest.startsWith("[") && rest.endsWith("]")) {
+      out[key] = splitArray(rest);
+    } else {
+      out[key] = rest.replace(/^["']|["']$/g, "");
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract ADR metadata from a file body, recognizing YAML frontmatter,
+ * classic `**Field**:` markdown, and bullet `- Field:` lists. The first
+ * recognized form wins for any given field; bullet/classic forms can fill
+ * in fields that frontmatter omitted.
+ */
+export function parseAdrMetadata(content: string): AdrMetadata {
+  const out = emptyMetadata();
+
+  // 1) YAML frontmatter (highest priority, if present).
+  const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---\s*\r?\n/);
+  if (fmMatch) {
+    const fm = parseFrontmatter(fmMatch[1]);
+    if (typeof fm.title === "string") out.title = fm.title;
+    if (typeof fm.status === "string") out.status = fm.status.toLowerCase();
+    if (typeof fm.date === "string") out.date = fm.date;
+    if (typeof fm.tags !== "undefined") {
+      const tags = splitArray(fm.tags);
+      if (tags.length > 0) out.tags = tags.join(", ");
+    }
+    if (typeof fm.implementation_status === "string") {
+      out.implementation_status = fm.implementation_status;
+    }
+    out.supersedes = splitArray(fm.supersedes);
+    out.superseded_by = splitArray(fm.superseded_by);
+    out.amends = splitArray(fm.amends);
+  }
+
+  // 2) Title from first `# ADR-NNNN: Title` line if frontmatter omitted it.
+  if (!out.title) {
+    const titleMatch = content.match(/^#\s+ADR[-\s]?\d+:\s+(.+)$/m);
+    if (titleMatch) out.title = titleMatch[1].trim();
+  }
+
+  // 3) Classic `**Field**: value` markdown (multiple ADRs use this style).
+  if (!out.date) {
+    const m = content.match(/\*\*Date\*\*\s*:\s*(\S+)/);
+    if (m) out.date = m[1].trim();
+  }
+  if (!out.status) {
+    const m = content.match(/\*\*Status\*\*\s*:\s*([^\n*]+)/);
+    if (m) out.status = m[1].trim().toLowerCase();
+  }
+  if (!out.tags) {
+    const m = content.match(/\*\*Tags\*\*\s*:\s*([^\n]+)/);
+    if (m && m[1].trim() !== "—") out.tags = m[1].trim();
+  }
+  if (out.supersedes.length === 0) {
+    const m = content.match(/\*\*Supersedes\*\*\s*:\s*([^\n]+)/);
+    if (m && m[1].trim() !== "N/A" && m[1].trim() !== "—") {
+      out.supersedes = splitArray(m[1]);
+    }
+  }
+  if (out.superseded_by.length === 0) {
+    const m = content.match(/\*\*Superseded by\*\*\s*:\s*([^\n]+)/i);
+    if (m && m[1].trim() !== "N/A" && m[1].trim() !== "—") {
+      out.superseded_by = splitArray(m[1]);
+    }
+  }
+  if (out.amends.length === 0) {
+    const m = content.match(/\*\*Amend(?:ed|s) by\*\*\s*:\s*([^\n]+)/i);
+    if (m && m[1].trim() !== "N/A" && m[1].trim() !== "—") {
+      out.amends = splitArray(m[1]);
+    }
+  }
+
+  // 4) Bullet metadata (ADR-0010 style).
+  if (!out.status) {
+    const m = content.match(/^[-*]\s*Status\s*:\s*([^\n]+)/m);
+    if (m) out.status = m[1].trim().toLowerCase();
+  }
+  if (!out.date) {
+    const m = content.match(/^[-*]\s*Date\s*:\s*(\S+)/m);
+    if (m) out.date = m[1].trim();
+  }
+  if (out.superseded_by.length === 0) {
+    const m = content.match(/^[-*]\s*Superseded by\s*:\s*([^\n]+)/im);
+    if (m) out.superseded_by = splitArray(m[1]);
+  }
+
+  // Tags fallback: if still empty, leave empty string (vs. dash).
+  if (!out.tags) out.tags = "";
+
+  return out;
+}
+
 // Sync-on-boot: index any ADR files that exist on disk but aren't in SQLite.
 // Handles ADRs written manually or before the MCP server existed.
 export function syncDecisionIndex(db: Database.Database): void {
@@ -34,22 +253,14 @@ export function syncDecisionIndex(db: Database.Database): void {
     const id = m[1];
     const filePath = join(DECISIONS_DIR, file);
     const content = readFileSync(filePath, "utf-8");
+    const meta = parseAdrMetadata(content);
 
-    // Extract title from first heading: "# ADR-NNNN: Title"
-    const titleMatch = content.match(/^#\s+ADR-\d+:\s+(.+)$/m);
-    const title = titleMatch
-      ? titleMatch[1].trim()
-      : file.replace(/^(?:ADR-)?\d{4}-/, "").replace(/\.md$/, "");
+    // Title fallback: derive from filename if we still don't have one.
+    const title =
+      meta.title ||
+      file.replace(/^(?:ADR-)?\d{4}-/, "").replace(/\.md$/, "");
 
-    // Extract tags from "**Tags**: tag1, tag2"
-    const tagsMatch = content.match(/\*\*Tags\*\*:\s+(.+)$/m);
-    const tags = tagsMatch && tagsMatch[1].trim() !== "—" ? tagsMatch[1].trim() : "";
-
-    // Extract date from "**Date**: YYYY-MM-DD"
-    const dateMatch = content.match(/\*\*Date\*\*:\s+(\S+)/);
-    const date = dateMatch ? dateMatch[1] : null;
-
-    upsert.run(id, title, tags, filePath, date);
+    upsert.run(id, title, meta.tags, filePath, meta.date);
   }
 }
 
@@ -83,7 +294,7 @@ export function registerDecisionTools(
         .optional()
         .describe("Tags: kernel, networking, deployment, orchestration, etc."),
       status: z
-        .enum(["proposed", "accepted", "superseded", "deprecated"])
+        .enum(["proposed", "accepted", "amended", "superseded", "deprecated"])
         .optional()
         .default("accepted"),
     },
@@ -218,8 +429,34 @@ ${alternatives}
       }
 
       const content = readFileSync(row.file_path, "utf-8");
+      const meta = parseAdrMetadata(content);
+
+      // Surface the lifecycle metadata at the top of the response so
+      // callers see status / supersession / implementation status without
+      // having to re-parse the body.
+      const header = [
+        `# Lifecycle metadata`,
+        `- status: ${meta.status ?? "—"}`,
+        `- date: ${meta.date ?? "—"}`,
+        `- tags: ${meta.tags || "—"}`,
+        meta.supersedes.length > 0
+          ? `- supersedes: ${meta.supersedes.join(", ")}`
+          : null,
+        meta.superseded_by.length > 0
+          ? `- superseded_by: ${meta.superseded_by.join(", ")}`
+          : null,
+        meta.amends.length > 0
+          ? `- amends: ${meta.amends.join(", ")}`
+          : null,
+        meta.implementation_status
+          ? `- implementation_status: ${meta.implementation_status}`
+          : null,
+      ]
+        .filter((s): s is string => s !== null)
+        .join("\n");
+
       return {
-        content: [{ type: "text", text: content }],
+        content: [{ type: "text", text: `${header}\n\n---\n\n${content}` }],
       };
     }
   );


### PR DESCRIPTION
## Summary

Adds two new ADRs and amends three existing ones to make ICN's ADR lifecycle and monorepo topology explicit. No runtime behavior change outside the MCP parser.

- **ADR-0017** (accepted): canonical-roots table for the consolidated monorepo. Decision supersedes ADR-0001 and ADR-0010; amends ADR-0002.
- **ADR-0018** (accepted): five-state lifecycle vocabulary, decision-vs-implementation status separation, metadata convention, MCP indexer contract.

## ADRs added

| ADR | Decision |
|---|---|
| [ADR-0017](docs/adr/ADR-0017-monorepo-consolidation-with-explicit-internal-boundaries.md) | Canonical roots: `icn/`, `icn/apps/`, `apps/` (top-level prototypes), `website/`, `ops/mcp/`, `ops/state/`, `docs/`, `docs/adr/`, `deploy/`, `sdk/`, `web/`. Physical consolidation does not collapse layers. |
| [ADR-0018](docs/adr/ADR-0018-adr-lifecycle-and-canonical-decision-index.md) | Lifecycle: `proposed` / `accepted` / `amended` / `superseded` / `deprecated`. Decision status independent from `implementation_status`. Supersession explicit via frontmatter. New ADRs use YAML frontmatter; classic markdown and bullet metadata still parsed. |

## ADRs amended / superseded

| ADR | Decision lifecycle | Why |
|---|---|---|
| ADR-0001 | superseded by ADR-0017 | Multi-repo `icn-ops/` topology no longer matches reality. Body preserved as historical motivation; durable principle (explicit orchestration plane) retained. |
| ADR-0002 | amended by ADR-0017 | Registration mechanism (`~/.mcp.json` + `enableAllProjectMcpServers`) unchanged; the `ops/mcp/` path replaces the separate-repo address. |
| ADR-0010 | superseded by ADR-0017 | The "two app roots" question this ADR opened is answered by ADR-0017's canonical-roots table. Was originally filed `Proposed` and never ratified. |

**Bodies of all three ADRs are preserved unchanged.** Each gets a header note explaining the supersession or amendment and pointing to the successor. ADR-0018's policy is "history is preserved; current status changes; supersession is explicit."

## Implementation claims and code evidence

| Claim | Evidence |
|---|---|
| `website/`, `ops/mcp/`, `apps/` (top-level), `icn/apps/` all exist in main repo | `ls website ops/mcp icn/apps apps` returns all four |
| Two app roots (`icn/apps/` workspace; `apps/` prototypes) coexist | `icn/apps/` contains `governance`, `ledger`, `membership`, `charter`; top-level `apps/` contains `echo`, `governance`, `ledger`, `trust` |
| ADRs canonicalized under `docs/adr/` | PR #1637; `ops/state/decisions/README.md` is a redirect |
| MCP indexer reads three metadata formats | New tests in `ops/mcp/src/tests/decisions.test.ts`: classic, frontmatter (inline + block), bullet, fallbacks |

## Validation results

```
cd ops/mcp && npm run build                            # clean
cd ops/mcp && npm test                                 # 17/17 pass (8 new parser tests)
python3 docs/scripts/doc_control_check.py \
    --repo . --registry docs/registry.toml --strict    # PASS (32 pre-existing warnings, 0 new)
git diff --check                                       # clean
```

## Non-goals (explicit)

- **No runtime behavior changes** outside the `ops/mcp` parser/tests.
- **No authority enforcement changes.** ADR-0014 implementation status, ADR-0019 (authority grant minting), and the question of kernel dispatch gating are out of scope. They get their own follow-up PR.
- **No NYCN package changes.**
- **No mass rewrite of historical ADR bodies.** Three ADR bodies were touched only to add header supersession/amendment notes per ADR-0018's rule.
- **No bootstrap/standing-model ADR.** ADR-0020 is out of scope; planned for a follow-up alongside ADR-0019.

## Risk

Doc-only with one tooling change. The MCP parser change is exercised by 11 decisions tests (3 prior + 8 new), passes `tsc` clean, and preserves the existing `decision_index` schema. Worst case: a stale `decision_index` row keeps a path the parser reformats; the upsert path corrects it on next boot.

## Follow-ups (separate PRs)

1. Authority/mandate verification + ADR-0019 + ADR-0014 status update — pending verification of `icn-governance::authority`, `icn-governance::mandate`, `icn/apps/governance/grant_minting.rs` and whether kernel dispatch is gated. Code reading suggests grants/mandates are minted but not enforced as gates.
2. Bootstrap activation + ADR-0020 + ADR-0012/0013/0015 status amendments — `FederationProvenance` is still in-memory `RwLock<HashMap>`, `coop_a_did` is still `String::new()` in `apps/governance/src/handlers/execution.rs:642`; ADR-0013 open items remain real and should not be falsely closed.
