### PR TITLE
docs(adr): authority grant minting seam (ADR-0019) and ADR-0014 status

### DIFF
--- a/docs/adr/ADR-0014-constitutional-object-model.md
+++ b/docs/adr/ADR-0014-constitutional-object-model.md
@@ -1,17 +1,22 @@
 ---
 id: "0014"
 title: "Constitutional Object Model — AuthorityClass, AuthorityGrant, TypedScope, Mandate"
-status: "proposed"
+status: "accepted"
 date: "2026-04-19"
 context: "post-SDIS-evidence arc (#1571); post-institution-package-boundary (#1560); pre-executor-gating; pre-federation-authority-narrowing"
 deciders: ["Matt Faherty"]
 tags: ["governance", "architecture", "authority", "charter", "federation", "mandate", "meaning-firewall", "semantic-freeze"]
 supersedes: []
 superseded_by: []
+amends: []
+implementation_status: "partially implemented (types + minting seam landed; kernel dispatch not gated)"
 references:
   - "ADR-0010 (App topology)"
   - "ADR-0012 (Federation state origin model)"
   - "ADR-0013 (Federation clearing adoption contract)"
+  - "ADR-0017 (Monorepo Consolidation)"
+  - "ADR-0018 (ADR Lifecycle)"
+  - "ADR-0019 (Authority Grant Minting and Mandate Persistence Seam)"
   - "docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md"
   - "docs/architecture/KERNEL_APP_SEPARATION.md"
 ---
@@ -20,13 +25,59 @@ references:
 
 ## Status
 
-**Proposed (docs-only semantic freeze).** This ADR introduces no behavior changes, no
-new code paths, no new crate public surface. It freezes the meaning of four constitutional
-objects — `AuthorityClass`, `AuthorityGrant`, `TypedScope`, `Mandate` — so that a later
-implementation tranche can land them without reopening what they are.
+**Accepted; implementation partially landed (status updated 2026-04-26).** The
+ADR was originally filed as `proposed` (docs-only semantic freeze); the
+semantic content was never revised. Code has since landed that proves the
+type model out at the governance app layer. See the **Implementation Update**
+section below for evidence and what remains. Per ADR-0018, the decision
+lifecycle (`accepted`) is independent from the `implementation_status`
+(`partially implemented`).
 
-Implementation follows this ADR in a separate PR. Nothing in this ADR promotes any phase
-status or claims completion.
+The original Status note is preserved verbatim below as the historical
+record of what this ADR claimed at filing time.
+
+### Original status note (2026-04-19)
+
+> **Proposed (docs-only semantic freeze).** This ADR introduces no behavior changes, no
+> new code paths, no new crate public surface. It freezes the meaning of four constitutional
+> objects — `AuthorityClass`, `AuthorityGrant`, `TypedScope`, `Mandate` — so that a later
+> implementation tranche can land them without reopening what they are.
+>
+> Implementation follows this ADR in a separate PR. Nothing in this ADR promotes any phase
+> status or claims completion.
+
+## Implementation Update (2026-04-26)
+
+The four constitutional types frozen by this ADR are now implemented at the
+governance app layer. The accepted-decision seam mints `AuthorityGrant`s
+and persists `Mandate`s. The minting/persistence behavior is recorded
+separately as a decision in [ADR-0019](ADR-0019-authority-grant-minting-and-mandate-persistence-seam.md);
+this section records what is verifiable in code as of this date.
+
+### What is implemented
+
+| Claim | Evidence |
+|---|---|
+| `AuthorityClass` is a closed three-variant enum (Representation / Execution / Attestation) | `icn/crates/icn-governance/src/authority.rs` (`pub enum AuthorityClass` ~line 61, with serde tests at line 439) |
+| `AuthorityGrant` is a typed record with `class: AuthorityClass`, grantor, grantee, scope | `icn/crates/icn-governance/src/authority.rs` (`pub struct AuthorityGrant` ~line 273) |
+| `TypedScope` is the typed replacement for `RoleAssignment.authority_scope: Vec<String>` | `icn/crates/icn-governance/src/authority.rs` (TypedScope type), referenced by `icn/crates/icn-governance/src/structure.rs:230` |
+| `Mandate` is a first-class institutional-memory record with two constructors (`new`, `new_pending_grants`) | `icn/crates/icn-governance/src/mandate.rs` (full module documents the distinction from delegation, role assignment, structure, etc.) |
+| Accepted-decision seam mints grants narrowly and falls through to pending-grants mandates otherwise | `icn/apps/governance/src/grant_minting.rs` (module doc + steward-appointment / steward-reconfirmation classes) |
+| Mandate parity through the close-proposal actor flow | `icn/apps/governance/tests/actor_close_proposal_mandate_parity.rs:311` |
+| Layer placement: types live at governance app layer, never imported by kernel crates | `icn/crates/icn-governance/src/authority.rs` module doc lines 1-30 explicitly states this rule |
+
+### What is NOT implemented
+
+- **Kernel dispatch is not gated by mandates or authority grants.** A grep of `icn/crates/icn-kernel-api/` and `icn/crates/icn-core/src/dispatch*` for `Mandate` / `mandate` returns no matches as of 2026-04-26. Mandates exist as institutional memory; they are not yet a precondition for `KernelEffect` execution.
+- **Kernel `Capability` tokens are not minted from `AuthorityGrant`s.** ADR-0014 explicitly leaves this for a future implementation tranche, and that tranche has not landed.
+- **Authority revocation end-to-end is partial.** Revocation writes are referenced in `grant_minting.rs:343`; the full revocation lifecycle has not been verified by this update.
+- **Federation-side mandate recognition is not specified or implemented.** Federation peers do not yet read or honor mandates from another entity.
+
+### What this update does NOT change
+
+- The semantic content of this ADR (Context, Decision, Consequences, Alternatives) is unchanged from the original filing.
+- The decision recorded here is the same decision; only its lifecycle marker (`status: accepted`) and `implementation_status` (`partially implemented`) are updated, per ADR-0018's rule that historical content is preserved while current status can change.
+- This update does not authorize kernel-side enforcement. That requires a separate decision.
 
 ---
 

--- a/docs/adr/ADR-0019-authority-grant-minting-and-mandate-persistence-seam.md
+++ b/docs/adr/ADR-0019-authority-grant-minting-and-mandate-persistence-seam.md
@@ -1,0 +1,110 @@
+---
+id: "0019"
+title: "Authority Grant Minting and Mandate Persistence Seam"
+status: "accepted"
+date: "2026-04-26"
+deciders: ["Matt Faherty"]
+tags: ["governance", "authority", "mandate", "grant-minting", "decision-seam", "constitutional-memory"]
+supersedes: []
+superseded_by: []
+amends: []
+implementation_status: "partially implemented (minting + persistence landed; enforcement gating not yet)"
+references:
+  - "ADR-0014 (Constitutional Object Model — semantic source)"
+  - "ADR-0018 (ADR Lifecycle — for the decision-vs-implementation status separation)"
+  - "icn/crates/icn-governance/src/authority.rs"
+  - "icn/crates/icn-governance/src/mandate.rs"
+  - "icn/apps/governance/src/grant_minting.rs"
+---
+
+# ADR 0019: Authority Grant Minting and Mandate Persistence Seam
+
+## Status
+
+**Accepted (2026-04-26).** This ADR records the *seam* — the deterministic translation from accepted decisions into persisted constitutional-memory records — that already exists in code. ADR-0014 froze the *semantic model* (`AuthorityClass`, `AuthorityGrant`, `TypedScope`, `Mandate`); this ADR records what code does with those types at the accepted-decision boundary.
+
+**This is not an enforcement-gate decision.** The seam mints and persists records. Whether kernel dispatch consults those records to gate execution is a separate, future decision (see "Non-decisions" below).
+
+## Context
+
+ADR-0014 introduced four types — `AuthorityClass`, `AuthorityGrant`, `TypedScope`, `Mandate` — as the constitutional-memory primitives. It explicitly deferred behavior to a later tranche:
+
+> "This ADR introduces no behavior changes, no new code paths, no new crate public surface."  
+> — ADR-0014, Status section
+
+The behavior tranche has since landed. Code now sits at the accepted-decision boundary and emits constitutional-memory records when a proposal passes. The shape of that emission — what gets minted, who is the grantor, what falls back to a pending-grants mandate, and what *never* happens — is not currently recorded as a decision. This ADR records it.
+
+The need is acute because **silent broadening of grant minting is the canonical institutional-capture failure mode.** "We accept the proposal, therefore we mint the grants its sponsor would like to have minted" is exactly the move ADR-0014's distinct-by-construction `AuthorityClass` enum exists to prevent. The seam recorded here is deliberately conservative; this ADR makes the conservatism load-bearing.
+
+## Decision
+
+When the governance app processes an accepted proposal, the seam in `icn/apps/governance/src/grant_minting.rs` produces:
+
+1. **Zero or more `AuthorityGrant`s, minted only when the accepted payload truthfully carries the data.** The grantor is always the sovereign entity behind the accepted decision (the governance domain). The platform, the runtime, the gateway, and any shared service are *never* grantors. Scope is populated only with categories the payload unambiguously supplies — no invented action kinds, ceilings, or durations.
+
+2. **Exactly one `Mandate`, persisted as durable institutional memory.** A mandate binds a decision to a bounded authorization. If the seam can derive a coherent grant set from the payload, the mandate composes those grants. If it cannot — because the proposal class is not yet in the supported set, or because the payload is malformed in a way that would force fabrication — the mandate is recorded via the bootstrap-phase `Mandate::new_pending_grants` constructor instead. The mandate exists; the grants are explicitly pending.
+
+3. **Zero kernel-dispatch behavior change.** This seam produces records. It does not authorize executors, does not gate dispatch, and does not change effect semantics. `KernelEffect` dispatch continues to run under the constraints already enforced by the kernel.
+
+### Conservative-broadening invariants
+
+- **No fabricated grants.** A grant is minted only when the accepted payload directly names the grantee, the class, and a truthful time bound. If any of those is absent, the mint returns the empty set for that proposal.
+- **`new_pending_grants` is the truthful fall-through, not the easy way out.** Recording a pending-grants mandate is *more* honest than recording a "synthetic grant for everything" mandate. The institutional-memory record reads "we decided this; the authority shape is not yet expressible," which is what is actually true.
+- **The grantor is never the platform.** The grantor field is bound to the governance domain that decided the proposal. There is no provision for "ICN granted X to Y." Authority flows from sovereign entities, not from runtime.
+- **The supported proposal-class set is small on purpose.** Today only steward-appointment and steward-reconfirmation proposals mint grants (Attestation class). Expanding this set is explicit future work via additional ADRs; silently broadening it is forbidden.
+
+### Implementation-status separation
+
+Per ADR-0018, decision lifecycle is independent from implementation status. The decision recorded here is `accepted`. The implementation status is `partially implemented`:
+
+| Layer | Status |
+|---|---|
+| `AuthorityClass` / `AuthorityGrant` / `TypedScope` / `Mandate` types | implemented (`icn/crates/icn-governance/src/authority.rs`, `mandate.rs`) |
+| Mint at accepted-decision seam | implemented (`icn/apps/governance/src/grant_minting.rs`) |
+| `Mandate::new_pending_grants` truthful fall-through | implemented (referenced from `grant_minting.rs:241`) |
+| Mandate persistence in receipt store | implemented (`icn/crates/icn-gateway/src/receipt_store.rs` mints test fixtures using these types) |
+| Kernel dispatch gated by mandates | **NOT IMPLEMENTED.** Mandates are institutional memory only at present. |
+| Kernel capability minting from `AuthorityGrant` | **NOT IMPLEMENTED.** ADR-0014 explicitly leaves this for a future implementation. |
+| Authority-revocation flow | partially implemented (revocation writes referenced in `grant_minting.rs:343`); end-to-end not verified by this ADR |
+
+## Code evidence
+
+- `icn/crates/icn-governance/src/authority.rs` declares `AuthorityClass` (closed enum: `Representation`, `Execution`, `Attestation`), `AuthorityGrant`, `TypedScope`. Module doc: "These types live at the **governance app layer** and must never be imported by kernel crates."
+- `icn/crates/icn-governance/src/mandate.rs` declares `Mandate` with `Mandate::new_pending_grants(...)` and `Mandate::new(...)` constructors. Module doc explicitly distinguishes mandate from delegation, role assignment, structure, institutional effect record, governance decision receipt, federation agreement, and charter.
+- `icn/apps/governance/src/grant_minting.rs` is the seam. Module doc:
+  > "It mints a grant **only** for proposal classes whose payload already names the grantee, the class of authority, and a truthful time bound. If a payload does not carry that information, we return an empty `Vec` — no grant is better than a fabricated one."
+  > "Today the only classes that mint grants are steward-appointment and steward-reconfirmation proposals … Every other accepted proposal currently produces zero grants, and its mandate is recorded via [`crate::manager`] using the bootstrap-phase `new_pending_grants` constructor."
+  > "This module does not gate dispatch, authorize executors, or change effect semantics. It only produces records."
+- `icn/apps/governance/tests/actor_close_proposal_mandate_parity.rs` exercises `AuthorityClass::Attestation` parity through the close-proposal flow.
+- Kernel-dispatch enforcement search (`grep -rn "Mandate" icn/crates/icn-kernel-api/ icn/crates/icn-core/src/dispatch*`) returns no matches: the kernel does not consult mandates.
+- `icn/crates/icn-gateway/tests/authority_enforcement_integration.rs` enforces *cross-domain authority rejection* in handler-layer code (capability + jurisdiction checks). This is a separate enforcement axis from mandate-based dispatch gating; it predates ADR-0014's typed authority model and operates on `Did`/`Capability`/`Domain` directly.
+
+## Consequences
+
+- The accepted-decision seam has a written contract that future authors can read instead of reverse-engineering from `grant_minting.rs`.
+- Reviewers proposing to broaden the supported-class set of grant minting must do so via a follow-up ADR; silent broadening is a process violation.
+- Institutional-memory readers (auditors, federation peers, governance researchers) can rely on the rule that a `Mandate` exists for every accepted decision, even if no grants do.
+- The kernel/app boundary remains intact: mandates and grants live at the governance app layer; the kernel never imports them.
+- The "next ADR" frontier on this axis is *enforcement* — when (if ever) kernel dispatch starts consulting mandates as an authorization check. That is a non-trivial decision that imposes a hard correctness bar on the seam this ADR records, and it deserves its own ADR.
+
+## Non-decisions (out of scope)
+
+This ADR does **not**:
+
+- Authorize the kernel dispatcher to consult mandates as a gate.
+- Change the supported-proposal-class set for grant minting.
+- Mint kernel `Capability` tokens from `AuthorityGrant`s.
+- Define a revocation/conflict-resolution protocol for grants.
+- Specify a federation-side mandate-recognition contract.
+- Govern how non-governance app code (e.g., gateway handlers) consults grants.
+
+Each of those is a separate decision and gets its own ADR if and when it is taken.
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|---|---|
+| Mint default grants for unsupported proposal classes | Would fabricate authority. ADR-0014 is explicit: "These classes are distinct and must not be silently conflated. A grant of one class does not confer the powers of another. Conflating them is the usual mechanism of institutional capture; typing prevents it." A "default Attestation grant" for any proposal would re-introduce exactly that conflation. |
+| Skip mandate persistence for unsupported classes | Mandates are the constitutional-memory anchor between decision and action. Skipping persistence breaks the chain `Charter → Decision → Mandate → Action → Receipt → Evidence` (ADR-0014 §What a Mandate is). The pending-grants record is a truthful answer to "we decided this, but the authority shape is not yet expressible," and that answer is more useful than a missing record. |
+| Make this ADR an enforcement-gate decision | Two distinct decisions, two distinct review surfaces. Bundling them obscures whether the project signed off on (a) "we mint these records," (b) "the kernel enforces these records," or both. ADR-0019 is (a) only. |
+| Wait for an enforcement decision before recording the seam | The seam already exists in code. Leaving it un-recorded means the next reviewer has to re-derive it from `grant_minting.rs`. Recording the seam is a precondition, not a successor, for a future enforcement decision. |

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -3033,6 +3033,31 @@ last_reviewed = "2026-04-26"
 owner = "matt"
 audiences = ["architects", "developers"]
 
+[docs."docs/adr/ADR-0014-constitutional-object-model.md"]
+# DOC status is "living"; DECISION status is "accepted" with
+# implementation_status "partially implemented" (see ADR-0019 and the
+# Implementation Update section in the ADR body).
+category = "architecture"
+status = "living"
+truth_class = "normative"
+title = "ADR-0014: Constitutional Object Model — AuthorityClass, AuthorityGrant, TypedScope, Mandate"
+description = "Semantic freeze for the four governance constitutional types. Decision: accepted; implementation: partially landed (types + accepted-decision minting seam land at the governance app layer; kernel dispatch is not yet gated by mandates). See ADR-0019 for the minting/persistence seam decision."
+last_updated = "2026-04-26"
+last_reviewed = "2026-04-26"
+owner = "matt"
+audiences = ["architects", "developers"]
+
+[docs."docs/adr/ADR-0019-authority-grant-minting-and-mandate-persistence-seam.md"]
+category = "architecture"
+status = "living"
+truth_class = "normative"
+title = "ADR-0019: Authority Grant Minting and Mandate Persistence Seam"
+description = "Records the deterministic seam where accepted governance decisions emit zero or more truthful AuthorityGrants plus exactly one Mandate. Conservative minting (only steward-appointment / steward-reconfirmation today); pending-grants fall-through is the truthful failure mode; kernel dispatch is NOT gated by mandates. Implementation: partially landed."
+last_updated = "2026-04-26"
+last_reviewed = "2026-04-26"
+owner = "matt"
+audiences = ["architects", "developers"]
+
 [docs."docs/adr/ADR-0001-orchestration-plane-architecture.md"]
 # DOC status is "living" — ADRs stay at their canonical path even when the
 # DECISION has been superseded. Decision lifecycle is tracked in the ADR


### PR DESCRIPTION
## Summary

Records the accepted-decision seam that already exists in code as ADR-0019, and updates ADR-0014's lifecycle marker to reflect that its types now have a working implementation. Per [ADR-0018](docs/adr/ADR-0018-adr-lifecycle-and-canonical-decision-index.md), decision lifecycle is independent from implementation status; historical content is preserved.

This PR makes **no runtime behavior change** and **no authority enforcement change.** It records what is real and explicitly names what is not.

## ADR added

- **[ADR-0019](docs/adr/ADR-0019-authority-grant-minting-and-mandate-persistence-seam.md)** (accepted) — Authority Grant Minting and Mandate Persistence Seam. Records the deterministic translation from accepted decisions into constitutional-memory records. Conservative-broadening invariants made load-bearing: no fabricated grants, pending-grants fall-through is the truthful failure mode, the grantor is never the platform, supported proposal-class set is small on purpose.

## ADR amended

- **[ADR-0014](docs/adr/ADR-0014-constitutional-object-model.md)** — status `proposed` → `accepted`, `implementation_status: partially implemented`. Original Status note preserved verbatim. New "Implementation Update (2026-04-26)" section lists what is in code and what is not. Body (Context / Decision / Consequences / Alternatives) is unchanged.

## Implementation claims and code evidence

| Claim | Evidence |
|---|---|
| `AuthorityClass` is a closed three-variant enum | `icn/crates/icn-governance/src/authority.rs:61` (`pub enum AuthorityClass { Representation, Execution, Attestation }`); serde tests at line 439 |
| `AuthorityGrant` is a typed record | `icn/crates/icn-governance/src/authority.rs:273` (`pub struct AuthorityGrant { class: AuthorityClass, ... }`) |
| `TypedScope` is implemented and used | `icn/crates/icn-governance/src/authority.rs` (TypedScope), referenced from `icn/crates/icn-governance/src/structure.rs:230` |
| `Mandate` exists with `new` and `new_pending_grants` constructors | `icn/crates/icn-governance/src/mandate.rs` (full module) |
| Accepted-decision seam mints grants narrowly | `icn/apps/governance/src/grant_minting.rs` — module doc: "It mints a grant only for proposal classes whose payload already names the grantee … no grant is better than a fabricated one." |
| Pending-grants fall-through path | `icn/apps/governance/src/grant_minting.rs:241` (`Mandate::new_pending_grants(...)`) |
| Mandate parity through close-proposal | `icn/apps/governance/tests/actor_close_proposal_mandate_parity.rs:311` |
| Layer placement preserved | `icn/crates/icn-governance/src/authority.rs` lines 1-30 ("These types live at the **governance app layer** and must never be imported by kernel crates.") |

### Explicitly NOT implemented (verified by code search)

- **Kernel dispatch gated by mandates**: `grep -rn "Mandate" icn/crates/icn-kernel-api/ icn/crates/icn-core/src/dispatch*` returns no matches.
- **Kernel `Capability` minting from `AuthorityGrant`**: not found in code.
- **End-to-end authority revocation**: revocation writes referenced at `grant_minting.rs:343`; full lifecycle not verified by this PR.
- **Federation-side mandate recognition**: not found in `icn/crates/icn-federation/`.

These are explicitly named as out-of-scope. ADR-0019 forbids fabricating any of them.

## Validation results

```
python3 docs/scripts/doc_control_check.py \
  --repo . --registry docs/registry.toml --strict     # PASS (32 pre-existing warnings, 0 new)
git diff --check                                      # clean
```

No tests were added in this PR (it is doc-only). The existing parser tests landed in PR #1639 already cover YAML frontmatter parsing of the kind ADR-0019 uses.

## Non-goals (explicit)

- **No runtime behavior change.** Zero Rust files touched.
- **No authority enforcement / dispatch gating change.** ADR-0019 is the *minting/persistence* decision. Whether the kernel ever consults mandates as a gate is a separate future ADR.
- **No new public types, no new tests, no new crate surface.**
- **No NYCN package change.**
- **No mass rewrite of historical ADR bodies.** ADR-0014's body is preserved unchanged; only the YAML frontmatter and a new Implementation Update section were added.

## Risk

Doc-only. Worst case: a future reader reads the ADR-0014 amendment and misreads "partially implemented" as authorizing kernel-level mandate enforcement; the Implementation Update's "What is NOT implemented" section explicitly forecloses that.

## Companion PR

[#1639 (merged)](https://github.com/InterCooperative-Network/icn/pull/1639) — ADR lifecycle + monorepo boundaries (ADR-0017, ADR-0018, ADR-0001/0002/0010 amendments, MCP parser extension). This PR builds on ADR-0018's decision-vs-implementation status separation rule.

## Follow-up (not in this PR)

- ADR-0020 (institutional bootstrap activation + standing read model) and amendments to ADR-0012 / ADR-0013 / ADR-0015 — separate PR. Federation provenance is still in-memory and `coop_a_did` is still empty in execution handlers; ADR-0013's open items remain real.
