### PR TITLE
fix(governance): populate coop_a_did in clearing adoption

### DIFF
--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -381,7 +381,9 @@ pub fn translate_payload_to_effects(
         },
 
         // Federation proposals
-        ProposalPayload::Federation(fed_proposal) => translate_federation_proposal(fed_proposal),
+        ProposalPayload::Federation(fed_proposal) => {
+            translate_federation_proposal(fed_proposal, domain_id)
+        }
 
         // Resource access proposals
         ProposalPayload::ResourceAccess {
@@ -608,9 +610,19 @@ fn translate_membership_action(
     }
 }
 
-/// Translate federation proposals to kernel effects
+/// Translate federation proposals to kernel effects.
+///
+/// `domain_id` is the governance domain that decided the proposal — i.e. the
+/// deciding cooperative's DID. It populates the deciding-coop side of every
+/// federation effect (`coop_a_did` for clearing establishment, `coop_did` for
+/// federation membership changes, `voucher_did` / `revoker_did` for
+/// vouches, `initiating_coop_did` for clearing termination). Passing
+/// `String::new()` here was the long-standing bug that ADR-0013 listed as an
+/// open item and that fix(governance) #1644 closes for the `EstablishClearing`
+/// case; the other five sites share one plumbing fix.
 fn translate_federation_proposal(
     proposal: &icn_governance::FederationProposal,
+    domain_id: &str,
 ) -> Result<Vec<KernelEffect>, TranslationError> {
     use icn_governance::FederationProposal;
 
@@ -618,7 +630,7 @@ fn translate_federation_proposal(
         FederationProposal::JoinFederation { federation_id, .. } => {
             Ok(vec![KernelEffect::Federation(
                 FederationEffect::JoinFederation {
-                    coop_did: String::new(),
+                    coop_did: domain_id.to_string(),
                     federation_id: federation_id.clone(),
                 },
             )])
@@ -626,7 +638,7 @@ fn translate_federation_proposal(
         FederationProposal::LeaveFederation { federation_id, .. } => {
             Ok(vec![KernelEffect::Federation(
                 FederationEffect::LeaveFederation {
-                    coop_did: String::new(),
+                    coop_did: domain_id.to_string(),
                     federation_id: federation_id.clone(),
                 },
             )])
@@ -639,7 +651,7 @@ fn translate_federation_proposal(
             ..
         } => Ok(vec![KernelEffect::Federation(
             FederationEffect::EstablishClearing {
-                coop_a_did: String::new(),
+                coop_a_did: domain_id.to_string(),
                 coop_b_did: partner_coop_did.to_string(),
                 agreement_hash: String::new(),
                 settlement_interval: Some(
@@ -659,7 +671,7 @@ fn translate_federation_proposal(
             target_coop_did, ..
         } => Ok(vec![KernelEffect::Federation(
             FederationEffect::VouchForCoop {
-                voucher_did: String::new(),
+                voucher_did: domain_id.to_string(),
                 vouchee_did: target_coop_did.to_string(),
                 attestation_hash: String::new(),
             },
@@ -669,7 +681,7 @@ fn translate_federation_proposal(
             reason,
         } => Ok(vec![KernelEffect::Federation(
             FederationEffect::TerminateClearing {
-                initiating_coop_did: String::new(),
+                initiating_coop_did: domain_id.to_string(),
                 partner_coop_did: partner_coop_id.clone(),
                 reason: reason.clone(),
             },
@@ -679,7 +691,7 @@ fn translate_federation_proposal(
             reason,
         } => Ok(vec![KernelEffect::Federation(
             FederationEffect::RevokeVouch {
-                revoker_did: String::new(),
+                revoker_did: domain_id.to_string(),
                 target_coop_did: target_coop_id.clone(),
                 reason: reason.clone(),
             },
@@ -1128,11 +1140,15 @@ mod tests {
         match &effects[0] {
             KernelEffect::Federation(
                 icn_kernel_api::effects::FederationEffect::TerminateClearing {
-                    initiating_coop_did: _,
+                    initiating_coop_did,
                     partner_coop_did,
                     reason,
                 },
             ) => {
+                assert_eq!(
+                    initiating_coop_did, "coop-alpha",
+                    "initiating_coop_did must be the deciding domain, not empty"
+                );
                 assert_eq!(partner_coop_did, "coop-beta");
                 assert_eq!(reason, "persistent imbalance violations");
             }
@@ -1154,14 +1170,75 @@ mod tests {
         assert_eq!(effects.len(), 1);
         match &effects[0] {
             KernelEffect::Federation(icn_kernel_api::effects::FederationEffect::RevokeVouch {
-                revoker_did: _,
+                revoker_did,
                 target_coop_did,
                 reason,
             }) => {
+                assert_eq!(
+                    revoker_did, "coop-alpha",
+                    "revoker_did must be the deciding domain, not empty"
+                );
                 assert_eq!(target_coop_did, "coop-gamma");
                 assert_eq!(reason, "governance misconduct");
             }
             other => panic!("expected RevokeVouch effect, got {other:?}"),
+        }
+    }
+
+    /// Regression test for ADR-0013 / icn#1644.
+    ///
+    /// Before the fix, `translate_federation_proposal` did not receive the
+    /// deciding domain and produced `coop_a_did: String::new()` for every
+    /// `EstablishClearing` effect, corrupting the caller-identity invariant
+    /// for governance-adopted clearing agreements. This test pins the new
+    /// behavior: `coop_a_did` must equal the deciding governance domain.
+    #[test]
+    fn test_translate_establish_clearing_populates_coop_a_did() {
+        let partner_did = icn_identity::Did::from_anchor_id(&[0x42; 32]);
+        let expected_partner = partner_did.to_string();
+        let payload = icn_governance::ProposalPayload::Federation(
+            icn_governance::FederationProposal::EstablishClearing {
+                partner_coop_id: "coop-beta".to_string(),
+                partner_coop_did: partner_did.clone(),
+                max_imbalance: 1000,
+                settlement_interval: icn_federation::SettlementInterval::Weekly,
+                currency: "HOURS".to_string(),
+                source_agreement_id: Some("agreement-direct-1".to_string()),
+            },
+        );
+        let effects =
+            translate_payload_to_effects(&payload, "receipt-ec-1", "hash-ec-1", "coop-alpha")
+                .expect("EstablishClearing should translate");
+        assert_eq!(effects.len(), 1);
+        match &effects[0] {
+            KernelEffect::Federation(
+                icn_kernel_api::effects::FederationEffect::EstablishClearing {
+                    coop_a_did,
+                    coop_b_did,
+                    settlement_interval,
+                    max_imbalance,
+                    source_agreement_id,
+                    ..
+                },
+            ) => {
+                assert!(
+                    !coop_a_did.is_empty(),
+                    "coop_a_did must not be empty (ADR-0013 / icn#1644)"
+                );
+                assert_eq!(
+                    coop_a_did, "coop-alpha",
+                    "coop_a_did must equal the deciding governance domain"
+                );
+                assert_eq!(coop_b_did, &expected_partner);
+                assert_eq!(settlement_interval.as_deref(), Some("weekly"));
+                assert_eq!(*max_imbalance, Some(1000));
+                assert_eq!(
+                    source_agreement_id.as_deref(),
+                    Some("agreement-direct-1"),
+                    "source_agreement_id should round-trip to label adopted clearing"
+                );
+            }
+            other => panic!("expected EstablishClearing effect, got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
Closes #1644.

## Summary

Populates `coop_a_did` for governance-adopted clearing agreements by threading the deciding governance domain through `translate_federation_proposal()`. Closes the most narrowly-scoped of the three [ADR-0013](docs/adr/ADR-0013-federation-clearing-adoption-contract.md) open items.

## Root cause

`translate_federation_proposal()` in `icn/apps/governance/src/handlers/execution.rs:612` took only `&FederationProposal` and produced:

```rust
FederationEffect::EstablishClearing {
    coop_a_did: String::new(),  // ← bug
    ...
}
```

The deciding cooperative's DID *is* the governance domain. `translate_payload_to_effects` already has `domain_id: &str` (used by treasury / membership / budget translators) but it wasn't being passed into the federation helper. The same gap left five sibling fields empty:

| Effect | Field |
|---|---|
| `JoinFederation` | `coop_did` |
| `LeaveFederation` | `coop_did` |
| `EstablishClearing` | `coop_a_did` ← **issue target** |
| `VouchForCooperative` | `voucher_did` |
| `TerminateClearing` | `initiating_coop_did` |
| `RevokeVouch` | `revoker_did` |

## Fix

Thread `domain_id: &str` into `translate_federation_proposal` and populate `coop_a_did` from it. The same plumbing fixes the five sibling fields without additional cost. The kernel API (`FederationEffect::EstablishClearing` and friends) is **unchanged** — only a private helper signature gained a parameter.

## Regression test

`test_translate_establish_clearing_populates_coop_a_did` constructs a real adopted-clearing payload (full struct with `partner_coop_did`, `currency`, `source_agreement_id`), translates it under deciding domain `coop-alpha`, and asserts:

- `coop_a_did` is non-empty
- `coop_a_did` equals the deciding domain
- `source_agreement_id` round-trips (preserves the link to the direct-management origin record per ADR-0013 Step 3)
- `settlement_interval` and partner DID survive translation

The two pre-existing tests (`test_translate_terminate_clearing`, `test_translate_revoke_vouch`) previously pattern-matched the deciding-coop fields with `_` — admitting the bug. They now assert the field equals the deciding domain.

## Validation

```
cargo fmt --all --check                                            # clean
cargo test -p icn-governance-actor --lib test_translate_           # 9/9 pass
cargo test -p icn-governance-actor                                 # 220+ pass, 0 fail
cargo clippy -p icn-governance-actor --all-targets -- -D warnings  # clean
```

## ADR-0013 status

This PR closes the `coop_a_did` open item. The other [ADR-0013](docs/adr/ADR-0013-federation-clearing-adoption-contract.md) open items remain unresolved and are tracked separately:

- `FederationProvenance` Sled persistence — #1643
- store-isolation tests for clearing adoption — #1645

ADR-0013's `implementation_status` field will be updated by a follow-up docs-only PR once all three open items have closed. Updating it now would falsely close the other two.

## Non-goals

- **No FederationEffect API shape change.** The kernel API is unchanged.
- **No `FederationProvenance` persistence work** — separate issue (#1643).
- **No store-isolation test work** — separate issue (#1645).
- **No NYCN package change.**
- **Not an enforcement-gate change.** ADR-0019 records that mandates are not yet kernel-dispatch gates; this PR doesn't change that.

## Risk

Low. One private helper gains a parameter; six fields that previously held empty strings now hold the deciding domain's DID. Downstream consumers (`icn-rpc/src/handler/federation.rs`, `icn-federation/src/clearing.rs`) already expected non-empty values; the previous behavior was a silent caller-identity corruption bug, not a contract.
