### PR TITLE
docs(rfc): add RFC process and candidate registry

### DIFF
--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -13,7 +13,7 @@ allowlisted_docs_subdirs = [
   "adr", "ai", "api", "architecture", "archive", "ci", "crate-manifests", "demo", "deployment",
   "design", "design-language", "dev", "development", "examples", "features", "guides", "internal",
   "maintenance", "manual", "migration-guides", "mobile", "observability", "onboarding", "operations",
-  "ops", "performance", "phases", "pilots", "planning", "plans", "reference", "scripts", "sdis",
+  "ops", "performance", "phases", "pilots", "planning", "plans", "reference", "rfcs", "scripts", "sdis",
   "security", "spec", "sprints", "state", "status", "strategy", "summit", "superpowers",
   "templates", "testing", "vision",
 ]
@@ -370,6 +370,16 @@ freshness = "unknown"
 domain_tags = ["adr"]
 recommended_action = "keep"
 last_reviewed = "unknown"
+
+[[doc_path_defaults]]
+prefix = "docs/rfcs/"
+truth_class = "draft"
+role = "design"
+canonical = "no"
+freshness = "current"
+domain_tags = ["rfc"]
+recommended_action = "keep"
+last_reviewed = "2026-04-26"
 
 [[doc_path_defaults]]
 prefix = "docs/api/"

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,0 +1,80 @@
+# docs/rfcs/
+
+Request-for-Comment design documents for ICN.
+
+> **RFCs explore. ADRs decide. Issues build. Tests prove. The website claims only what the proof supports.**
+
+## What an RFC is
+
+An RFC explores a design space. It is the document where tradeoffs get named, options get compared, and consequences get traced — *before* a decision is made. RFCs are the "we are not yet sure how to do this; here is a structured way to think about it" layer of the project.
+
+An RFC is **not** a decision. It is **not** an implementation commitment. It is **not** authority for runtime change.
+
+## Why RFCs are separate from ADRs
+
+| Layer | What it is | Where it lives |
+|---|---|---|
+| RFC candidate | Unresolved design space worth exploring | [ops/coordination/rfc_candidates.yaml](../../ops/coordination/rfc_candidates.yaml) |
+| RFC | Design exploration and tradeoff analysis | `docs/rfcs/RFC-NNNN-*.md` |
+| ADR candidate | Likely future decision the project intends to record | [ops/coordination/adr_candidates.yaml](../../ops/coordination/adr_candidates.yaml) |
+| ADR | Architectural decision receipt | [docs/adr/ADR-NNNN-*.md](../adr/) |
+| Issue | Implementation commitment | GitHub issues |
+| Test | Evidence that implementation matches the decision | `crates/*/tests/` |
+| Website | Public truth boundary; only claims what evidence supports | [website/src/](../../website/src/) |
+
+ADRs in `docs/adr/` are *decision receipts* — they record what was decided and why, with explicit lifecycle governed by [ADR-0018](../adr/ADR-0018-adr-lifecycle-and-canonical-decision-index.md). RFCs are upstream of decisions: they exist so the project can hold a design conversation in writing without prematurely committing to an outcome.
+
+Drafting an ADR before the design space is explored produces shallow ADRs. Drafting an RFC and then an ADR produces decisions whose tradeoffs are documented and whose alternatives are auditable.
+
+## RFC lifecycle
+
+| Status | Meaning |
+|---|---|
+| `draft` | Author is still composing; not ready for broad review. |
+| `active` | Open for review, comments, alternative proposals. |
+| `accepted` | Project has converged on a direction. The follow-up ADR(s) record the decision. **Accepted RFC does NOT mean implemented.** |
+| `rejected` | Project decided against the proposal. Body preserved for future reference. |
+| `superseded` | A later RFC replaces this one. Both bodies preserved; cross-linked. |
+| `withdrawn` | Author or project removed the RFC before reaching a decision. |
+
+See [RFC-0000](RFC-0000-rfc-process.md) for the process detail (when to write an RFC, how to move it forward, how to supersede or withdraw).
+
+## File naming
+
+`RFC-NNNN-short-kebab-title.md` — four-digit zero-padded number, hyphen, kebab-case title. The number is allocated when the RFC moves from `candidate` (in `rfc_candidates.yaml`) to `draft`. Numbers are sequential and never reused.
+
+## Frontmatter contract
+
+Every RFC carries YAML frontmatter conforming to [`template.md`](template.md). The required fields are:
+
+- `id` — string, four-digit zero-padded
+- `title` — short title
+- `status` — one of `draft | active | accepted | rejected | superseded | withdrawn`
+- `created` — ISO date the RFC was first written
+- `updated` — ISO date of the last meaningful change
+- `authors` — list of names or DIDs
+- `reviewers` — list of names or DIDs (may be empty during `draft`)
+- `related_adr_candidates` — list of ADR ids the RFC may inform
+- `related_issues` — list of GitHub issue references
+- `supersedes` — list of RFC ids this RFC replaces (empty unless replacing one)
+- `superseded_by` — list of RFC ids that replace this one (empty unless replaced)
+
+Implementation status is **not** an RFC field. Implementation status lives on ADRs and only changes with code/test evidence.
+
+## What RFCs are NOT
+
+- Not decisions. ADRs decide.
+- Not implementation commitments. Issues commit.
+- Not evidence. Tests prove.
+- Not public claims. The website claims.
+
+A future contributor reading "RFC-0042 says X" should understand that as "the project explored X in RFC-0042" — not as "X is the law of the project," and not as "X is implemented."
+
+## See also
+
+- [RFC-0000](RFC-0000-rfc-process.md) — the RFC process itself.
+- [docs/adr/ADR-0018](../adr/ADR-0018-adr-lifecycle-and-canonical-decision-index.md) — ADR lifecycle vocabulary.
+- [docs/adr/ADR-0034](../adr/ADR-0034-adr-candidate-registry-as-architectural-memory.md) — ADR candidate registry as architectural memory.
+- [docs/strategy/ICN_CONSTITUTIONAL_ROADMAP.md](../strategy/ICN_CONSTITUTIONAL_ROADMAP.md) — long-arc architectural roadmap.
+- [ops/coordination/rfc_candidates.yaml](../../ops/coordination/rfc_candidates.yaml) — unresolved design spaces awaiting RFCs.
+- [ops/coordination/adr_candidates.yaml](../../ops/coordination/adr_candidates.yaml) — likely future decisions awaiting ADRs.

--- a/docs/rfcs/RFC-0000-rfc-process.md
+++ b/docs/rfcs/RFC-0000-rfc-process.md
@@ -1,0 +1,185 @@
+---
+id: "0000"
+title: "RFC Process"
+status: "accepted"
+created: "2026-04-26"
+updated: "2026-04-26"
+authors: ["Matt Faherty"]
+reviewers: []
+related_adr_candidates: []
+related_issues: []
+supersedes: []
+superseded_by: []
+---
+
+# RFC 0000: RFC Process
+
+## Status
+
+`accepted` — this RFC defines its own process and is the seed RFC for the system. Future amendments are made by drafting a successor RFC.
+
+## The one-line model
+
+> **RFCs explore. ADRs decide. Issues build. Tests prove. The website claims only what the proof supports.**
+
+## Pipeline
+
+```text
+                 ┌─────────────────┐
+   design        │ rfc_candidates  │  ops/coordination/rfc_candidates.yaml
+   space         │     .yaml       │  unresolved design spaces, no decision yet
+                 └────────┬────────┘
+                          │  promote
+                          ▼
+                 ┌─────────────────┐
+   exploration   │      RFC        │  docs/rfcs/RFC-NNNN-*.md
+                 │ draft → active  │  options, tradeoffs, alternatives
+                 └────────┬────────┘
+                          │  accept (project converges)
+                          ▼
+                 ┌─────────────────┐
+   decision      │ adr_candidates  │  ops/coordination/adr_candidates.yaml
+   queued        │     .yaml       │  rows updated to point at the accepted RFC
+                 └────────┬────────┘
+                          │  draft ADR
+                          ▼
+                 ┌─────────────────┐
+   decision      │      ADR        │  docs/adr/ADR-NNNN-*.md
+                 │ proposed →      │  records the decision and rationale
+                 │ accepted        │
+                 └────────┬────────┘
+                          │  open issue(s)
+                          ▼
+                 ┌─────────────────┐
+   commitment    │   GitHub issue  │  links back to ADR + RFC
+                 └────────┬────────┘
+                          │  implement
+                          ▼
+                 ┌─────────────────┐
+   evidence      │   tests / proof │  crates/*/tests/, docs, observability
+                 └────────┬────────┘
+                          │  proof passes
+                          ▼
+                 ┌─────────────────┐
+   status update │ ADR.implementation_status →
+                 │   not_started → partial → implemented → verified
+                 └────────┬────────┘
+                          │  evidence is public
+                          ▼
+                 ┌─────────────────┐
+   public claim  │     website     │  website/src/
+                 │  claims only    │  evidence-linked maturity band
+                 │  what's proven  │
+                 └─────────────────┘
+```
+
+The pipeline is one-way in spirit. Anyone can write an RFC; not every RFC reaches `accepted`; not every accepted RFC produces an ADR; not every ADR is implemented; not every implementation is publicly claimed. Each arrow above filters out designs that should not advance.
+
+## When to write an RFC
+
+Write an RFC when:
+
+- The design space is **non-obvious**. Multiple viable approaches exist; tradeoffs are real; picking one without writing them down would lose information.
+- The change crosses **multiple subsystems** or **kernel/app boundaries**. Anything that touches the meaning firewall benefits from explicit exploration.
+- The change has **accessibility, conflict-resolution, or compute-authority** consequences. These are first-class concerns; an RFC forces them to be addressed in writing.
+- The project is **forming a north star**. Forward-direction architecture (e.g., CCL as institutional process language; cross-institution mandate recognition) needs design exploration before decisions are made.
+- A **public claim is at stake**. If the website would describe a capability differently after the change, an RFC keeps the truth boundary honest.
+- A **reviewer can't make sense of an ADR** because the alternatives are missing. The fix is to write the RFC the ADR was implicitly depending on.
+
+## When NOT to write an RFC
+
+Do not write an RFC when:
+
+- The change is a **bug fix** with a single correct answer.
+- The change is a **straightforward implementation** of an already-accepted ADR.
+- The design is **constrained by existing invariants** to a single path. (Write a short ADR instead, citing the invariant.)
+- The change is **scoped to one file**, has no cross-cutting effects, and would be reviewable in a normal PR.
+- The decision is **already made** elsewhere and the work is to record it. (Write an ADR back-fill instead.)
+- The design space is **so unsettled** that a candidate row in [`rfc_candidates.yaml`](../../ops/coordination/rfc_candidates.yaml) is the right artifact and the RFC itself can wait.
+
+If in doubt, prefer a candidate row first; promote to an RFC when the design space is concrete enough to compare options.
+
+## How RFCs move to ADRs
+
+1. RFC drafted → `status: draft`. Author writes alone.
+2. RFC opened for review → `status: active`. Reviewers comment, propose alternatives, surface invariants.
+3. Project converges on an option (or rejects all). RFC moves to `status: accepted` (or `rejected`). The `Outcome` section names the choice and the rationale.
+4. The follow-up ADR(s) are drafted. They reference the accepted RFC. ADR `status` lifecycle then takes over per [ADR-0018](../adr/ADR-0018-adr-lifecycle-and-canonical-decision-index.md).
+5. [`adr_candidates.yaml`](../../ops/coordination/adr_candidates.yaml) rows are updated to point at the accepted RFC and the new ADR file paths.
+
+An RFC may produce **zero, one, or multiple** ADRs. A complex RFC (e.g., obligation/allocation/settlement) routinely produces three or four. A narrow RFC may produce one. A rejected RFC produces zero.
+
+## How RFCs relate to issues
+
+- An RFC may **cite** existing issues as evidence of the design problem. RFCs do not own implementation; issues do.
+- An accepted RFC's `Follow-up implementation issues` section names the issues that should exist (or be opened) to drive implementation. Those issues link back to the RFC and the resulting ADR(s).
+- Issues do not change RFC status. Issues track work; RFCs track design.
+
+## How implementation evidence updates ADRs
+
+ADR `implementation_status` is a separate field with the closed taxonomy `not_started | partial | implemented | verified`. It moves only when:
+
+- `partial` requires landed code that exercises the decision in production paths.
+- `implemented` requires landed code **and** integration tests proving the decision's invariants.
+- `verified` requires implementation **and** evidence the invariant holds under the production deployment (telemetry, fault injection, replay audit, etc.).
+
+**Accepted RFC does not move ADR implementation status.** Accepted ADR does not move implementation status. Only code and tests do. This separation is what keeps the website honest.
+
+## How public website claims depend on evidence
+
+The public website ([website/src/](../../website/src/)) claims only what implementation evidence supports. The maturity bands (`strong | advancing | maturing | behind | not-yet`) are documented in [ADR-0032](../adr/ADR-0032-website-truth-boundary.md). The chain is:
+
+- `not-yet` claim: the RFC may exist; no ADR or no implementation. Public framing must be aspirational.
+- `behind` claim: ADR exists; implementation is partial; member-facing surface is missing.
+- `maturing` claim: implementation exists; integration paths and public surfaces are still being completed.
+- `advancing` claim: implementation exists; gaps are visible; the system can stand behind it for some uses but not all.
+- `strong` claim: implementation is complete and hardened; ADR `implementation_status: verified`; the project is willing to stand behind it in production.
+
+[ADR-0033](../adr/ADR-0033-public-maturity-claims-and-evidence-links.md) proposes a build-time linter that verifies every banded claim cites an ADR, issue, code path, or phase reference. Until that linter ships, evidence-linking is editorial discipline.
+
+## How to supersede or withdraw RFCs
+
+**Supersede** when the design space changes meaningfully or a better proposal emerges:
+
+1. Draft the successor RFC.
+2. In the successor's frontmatter, set `supersedes: ["NNNN"]`.
+3. In the original RFC's frontmatter, set `status: superseded` and `superseded_by: ["MMMM"]`.
+4. Add a `> Update (YYYY-MM-DD)` block at the top of the original pointing to the successor.
+5. **Do not delete the original body.** Superseded RFCs preserve institutional memory of why the project changed direction.
+
+**Withdraw** when the author or project removes the proposal before a decision:
+
+1. Set `status: withdrawn` in frontmatter.
+2. Add a short note at the top explaining why.
+3. Preserve the body. A withdrawn RFC is part of the design history.
+
+## How RFCs interact with `ops/coordination/adr_candidates.yaml`
+
+The two registries are complementary, not redundant.
+
+- [`rfc_candidates.yaml`](../../ops/coordination/rfc_candidates.yaml) lists **unresolved design spaces**. A row here means "the project knows this is a place where decisions will eventually need to be made; we have not yet explored the space enough to draft an RFC."
+- [`adr_candidates.yaml`](../../ops/coordination/adr_candidates.yaml) lists **likely future decisions**. A row here means "the project knows this decision will need to be recorded; the decision may follow from an RFC, may follow from an obvious-direction back-fill, or may be a forward-state proposal that can be modified later."
+
+Some ADR candidates **should be preceded by an RFC** because the design space is unsettled. Examples in the current registry:
+
+- ADR-0029 (Conflict Resolution Object Model) — broad design space, multiple plausible models. → RFC-0002.
+- ADR-0023 (CCL Institutional Process Language) — forward direction with non-trivial language design. → RFC-0004.
+- ADR-0027 (Action Card Contract) — multi-stakeholder UX surface. → RFC-0005.
+- ADR-0028 (Accessibility Baseline) — five-layer model with explicit floor commitments. → RFC-0003.
+
+Other ADR candidates can proceed without an RFC because they back-fill existing implementation reality (e.g., ADR-0021 CCL determinism, ADR-0030 compute workload manifest). The signal is whether the design is *settled by code* or *unsettled in writing*.
+
+When an RFC moves to `accepted`, update the relevant ADR candidate row(s) to add `related_rfc: NNNN` and the candidate's `priority` may shift. This keeps the two registries in sync without forcing either to become authoritative over the other.
+
+## Numbering
+
+- RFC numbers are sequential, four-digit zero-padded (`RFC-0001`, `RFC-0002`, …).
+- Numbers are allocated when an RFC moves from `candidate` to `draft`. The author picks the next unused number; collisions are resolved by bumping.
+- Withdrawn or rejected numbers are **not** reused. The number reflects the chronology of the conversation, not the chronology of accepted decisions.
+- This RFC is `RFC-0000` because it is the seed for the system. No future RFC takes that number.
+
+## What this RFC is not
+
+- Not a project-governance ADR. ICN's broader project governance is the territory of [ADR-0063 candidate](../../ops/coordination/adr_candidates.yaml) and a future RFC-0009.
+- Not a license to bypass ADR review. Accepting an RFC does not skip the ADR step; it just makes the ADR step easier.
+- Not a documentation treadmill. RFCs are written when the design space justifies them. Most ICN work does not need an RFC. The pipeline filters at every step for a reason.

--- a/docs/rfcs/template.md
+++ b/docs/rfcs/template.md
@@ -1,0 +1,170 @@
+---
+id: "NNNN"
+title: "Short RFC Title"
+status: "draft"
+created: "YYYY-MM-DD"
+updated: "YYYY-MM-DD"
+authors: ["Name or DID"]
+reviewers: []
+related_adr_candidates: []
+related_issues: []
+supersedes: []
+superseded_by: []
+---
+
+# RFC NNNN: Short RFC Title
+
+## Status
+
+`draft` — being written, not yet ready for review.
+`active` — open for review and comments.
+`accepted` — project has converged. The follow-up ADR(s) record the decision.
+`rejected` — project decided against. Body preserved for reference.
+`superseded` — a later RFC replaces this one.
+`withdrawn` — author or project removed before a decision.
+
+**Accepted RFC does not mean implemented.** Implementation status lives on ADRs and changes only with code/test evidence. See [RFC-0000](RFC-0000-rfc-process.md) for the lifecycle in detail.
+
+## Summary
+
+One paragraph. What problem does this RFC explore, and what is the recommended direction? A reader should be able to stop here and know whether the rest of the document is relevant.
+
+## Problem statement
+
+What is the situation that motivates this RFC? What is missing, broken, ambiguous, or contested? Be specific — name files, ADRs, issues, observed behavior. An RFC that cannot articulate a concrete problem usually should not be an RFC yet.
+
+## Goals
+
+What outcomes would make this RFC "succeed"? List the specific, falsifiable properties the chosen design should achieve.
+
+## Non-goals
+
+What is *not* in scope? RFCs that drift into adjacent territory produce incoherent decisions. Name the territory you are deliberately leaving alone.
+
+## Background / current state
+
+What does the project already know? Summarize the relevant ADRs, prior RFCs, code surfaces, and issues. Cite specific files (`crate/path/file.rs:LINE`) where they ground a claim. Quote sparingly.
+
+## Design options
+
+At least two options. Three is healthy. One option is not an exploration.
+
+### Option A — short name
+
+What is the design? How does it work concretely? What does it look like at the runtime, package, and member-facing layers?
+
+### Option B — short name
+
+Same shape.
+
+### Option C — short name
+
+Same shape. (Optional.)
+
+## Tradeoffs
+
+For each option above, list:
+
+- What it makes easier.
+- What it makes harder.
+- What invariants it preserves.
+- What invariants it stresses.
+- What new failure modes it introduces.
+- What it costs (engineering, complexity, migration burden).
+
+A table is often the right form here. The point is to make the comparison legible.
+
+## Core/package boundary
+
+How does this design respect the kernel/app separation and the institution-package boundary?
+- What lives in ICN core (generic substrate, primitive types, constraint enforcement)?
+- What lives in institution packages (local vocabulary, charter content, fixtures)?
+- What stays opaque to the kernel?
+- Does any option erode the meaning firewall? If so, name the erosion.
+
+See [docs/architecture/KERNEL_APP_SEPARATION.md](../architecture/KERNEL_APP_SEPARATION.md) and [docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md](../architecture/INSTITUTION_PACKAGE_BOUNDARY.md).
+
+## Accessibility implications
+
+How does this design land for low-bandwidth, low-device, non-English, disabled, caregiving, or shift-working members? If the answer is "it doesn't change anything," say so explicitly and explain why. Accessibility is a participation floor; an RFC that ignores it is incomplete.
+
+See ADR-0028 (Accessibility Baseline for Member Interfaces).
+
+## Conflict / dispute path
+
+How are conflicts about this design's outcomes handled?
+- Conflicts about effects (post-decision)?
+- Conflicts about decisions (process appeal)?
+- Relational conflicts between members?
+
+If this RFC is upstream of conflict resolution itself, name the dependency.
+
+See ADR-0029 (Conflict Resolution Object Model).
+
+## Security / privacy implications
+
+What new attack surface does this design introduce or remove? What sensitive data does it touch? What re-disclosure risks does it create? What capability boundaries does it stress?
+
+If the design has no security or privacy implications, say so explicitly and justify the claim.
+
+## Compute / automation boundary
+
+What may compute do under this design? What may compute *not* do?
+- Is compute carrying out what authority asked, or making decisions?
+- What is governance-grade output vs advisory output?
+- Are determinism and fuel bounds preserved?
+
+See ADR-0030 (Compute Workload Manifest and Authority Boundary).
+
+## Website / public truth implications
+
+What can the public website honestly say once this RFC is accepted? What can it *not* say?
+- What maturity band would the relevant subsystem occupy?
+- What evidence would the website link to?
+- What overclaim risk does the design create?
+
+See ADR-0032 (Website Truth Boundary).
+
+## Migration / compatibility
+
+If accepted, what changes for:
+- Existing deployments?
+- Existing institution packages?
+- Existing CCL contracts?
+- Existing API consumers?
+- Existing test surfaces?
+
+If the design is greenfield with no migration cost, say so.
+
+## Open questions
+
+Specific, unresolved questions that block a decision. Each question should be answerable; vague concerns belong in Tradeoffs.
+
+## Decision criteria
+
+What would tip the project toward one option over another? Be concrete. "We pick A if we observe X; we pick B if we observe Y." A vague decision criterion produces a vague decision.
+
+## Outcome
+
+Filled in when the RFC moves to `accepted` or `rejected`. Names the chosen option (or the rejection rationale) and links to the follow-up ADR(s) that record the decision.
+
+## Follow-up ADRs
+
+If accepted, which ADRs (or ADR candidates) does this RFC produce? Cite by id. Update [ops/coordination/adr_candidates.yaml](../../ops/coordination/adr_candidates.yaml) accordingly.
+
+## Follow-up implementation issues
+
+If accepted, what issues should be opened to drive implementation? Cite existing issues where applicable; name new issues that should be opened.
+
+## Validation / proof plan
+
+How will the project know the implementation matches the decision? List the test surfaces, integration paths, and observability signals that will demonstrate correctness. Implementation status moves only when this proof plan is satisfied.
+
+---
+
+## Notes
+
+- For *amendments* during `draft` or `active`, edit in place and bump `updated`. RFCs in those statuses are living documents.
+- For *amendments* after `accepted`, prefer a successor RFC. Editing accepted text rewrites history.
+- For *supersession*, add `> Update (YYYY-MM-DD)` block at the top pointing to the successor RFC; preserve the original body unchanged. Update both `status` and `superseded_by` in frontmatter.
+- For *withdrawal*, set `status: withdrawn` and add a short note explaining why.

--- a/ops/coordination/README.md
+++ b/ops/coordination/README.md
@@ -1,25 +1,101 @@
 # ops/coordination/
 
-Coordination artifacts that span ADRs, issues, and doc surfaces. These files are **planning indices**, not authoritative decisions.
+Coordination artifacts that span RFCs, ADRs, issues, and doc surfaces. These files are **planning indices**, not authoritative decisions.
+
+## The pipeline
+
+> **RFCs explore. ADRs decide. Issues build. Tests prove. The website claims only what the proof supports.**
+
+```text
+   rfc_candidates.yaml      unresolved design spaces, no decision yet
+              │
+              │  promote
+              ▼
+   docs/rfcs/RFC-NNNN-*.md  design exploration: options, tradeoffs, alternatives
+              │
+              │  accept (project converges)
+              ▼
+   adr_candidates.yaml      likely future decisions; rows updated to point at the accepted RFC
+              │
+              │  draft ADR
+              ▼
+   docs/adr/ADR-NNNN-*.md   architectural decision receipt
+              │
+              │  open issue(s)
+              ▼
+   GitHub issue             implementation commitment
+              │
+              │  implement
+              ▼
+   tests / proof            evidence that implementation matches the decision
+              │
+              │  proof passes
+              ▼
+   ADR.implementation_status   not_started → partial → implemented → verified
+              │
+              │  evidence is public
+              ▼
+   website/src/             public truth boundary; only claims what evidence supports
+```
+
+The pipeline is one-way in spirit. Each arrow filters out designs that should not advance.
 
 ## Files
 
-- `adr_candidates.yaml` — Index of every ADR ICN intends to write, including rows that have been drafted (Tranche 1) and rows still queued (Tranches 2–4). Decisions live in [docs/adr/](../../docs/adr/); this file just tracks what should exist there over time so that long-arc architecture is not accidentally designed out.
+- **`rfc_candidates.yaml`** — Index of unresolved design spaces that need an RFC before an ADR or implementation. Each row describes a design space with enough detail that a future contributor or agent can draft the RFC without re-doing scope discovery.
+- **`adr_candidates.yaml`** — Index of likely future decisions ICN intends to record, including rows that have been drafted (Tranche 1) and rows still queued (Tranches 2–4). Some ADR candidates should be preceded by an RFC; others (back-fills of existing implementation reality) can proceed directly. Decisions live in [`docs/adr/`](../../docs/adr/).
 
 ## Conventions
 
-- Every row in `adr_candidates.yaml` has an `id` matching the eventual ADR number, a `registry_state` (`candidate | drafted | merged`), and a `tranche` (`1 | 2 | 3 | 4`).
+### `rfc_candidates.yaml`
+
+- Every row has an `id` (zero-padded, four digits) matching the eventual RFC number, and a `status` of `candidate` until the RFC is drafted.
+- Rows describe the design space: why it matters, related ADR candidates, related issues, design questions to address, and proposed outputs.
+- Rows flip from `candidate` → drafted (an RFC file appears under `docs/rfcs/`) → resolved (RFC accepted, rejected, superseded, or withdrawn).
+
+### `adr_candidates.yaml`
+
+- Every row has an `id` matching the eventual ADR number, a `registry_state` (`candidate | drafted | merged`), and a `tranche` (`1 | 2 | 3 | 4`).
 - `proposed_status` is the status the ADR will carry once written; it is `proposed` for forward-state direction and `accepted` for back-fills of existing implementation reality.
-- Drafted rows must reference the file path of the ADR (`adr_path`).
-- Candidate rows describe the ADR with enough detail that a future agent can draft it without re-doing scope discovery.
-- The registry is updated when a tranche lands; rows flip from `candidate` → `drafted` → `merged` over time.
+- Drafted rows reference the file path of the ADR (`adr_path`).
+- Some candidates should be preceded by an RFC (those whose design space is unsettled). Examples:
+  - ADR-0023 (CCL Institutional Process Language) → RFC-0004
+  - ADR-0027 (Action Card Contract) → RFC-0005
+  - ADR-0028 (Accessibility Baseline) → RFC-0003
+  - ADR-0029 (Conflict Resolution Object Model) → RFC-0002
+  - ADR-0044/0045/0046/0047/0048 (Economics tranche) → RFC-0001
+- Other candidates (e.g., ADR-0021 CCL determinism, ADR-0030 compute manifest) back-fill existing reality and do not need an RFC first.
+
+### Lifecycle distinctions
+
+| Layer | Statuses |
+|---|---|
+| RFC | `draft` / `active` / `accepted` / `rejected` / `superseded` / `withdrawn` |
+| ADR | `proposed` / `accepted` / `amended` / `superseded` / `deprecated` |
+| Implementation | `not_started` / `partial` / `implemented` / `verified` |
+
+**Hard rule.** Accepted RFC does NOT mean implemented. Accepted ADR does NOT mean implemented. Implementation status is a separate field on the ADR and changes only with code/test evidence.
 
 ## Why this exists
 
-ADR-0034 records the decision to maintain this registry as architectural memory. Without it, the long arc of design (CCL as institutional process language, accessibility baseline, conflict resolution object model, federation depth, etc.) tends to fade between sessions and gets re-discovered ad hoc.
+ADR-0034 records the decision to maintain `adr_candidates.yaml` as architectural memory. RFC-0000 records the corresponding decision for `rfc_candidates.yaml`. Without these registries, the long arc of design (CCL as institutional process language, accessibility baseline, conflict resolution object model, federation depth, etc.) tends to fade between sessions and gets re-discovered ad hoc.
+
+The two registries serve different purposes:
+
+- `rfc_candidates.yaml` answers "what design conversations are still pending?"
+- `adr_candidates.yaml` answers "what decisions does the project intend to record?"
+
+A single concern often appears in both — first as an RFC candidate (design space unsettled), then as an ADR candidate (after the RFC is accepted), then as an ADR (decision recorded), then as code (issue closed), then on the website (public claim). The two files keep the long arc legible at every step.
 
 ## Not authoritative
 
-- This is a coordination artifact. It does not bind project decisions.
-- ADR-0018 governs ADR lifecycle. Status changes happen in the ADR file itself.
+- These are coordination artifacts. They do not bind project decisions.
+- [RFC-0000](../../docs/rfcs/RFC-0000-rfc-process.md) governs RFC lifecycle.
+- [ADR-0018](../../docs/adr/ADR-0018-adr-lifecycle-and-canonical-decision-index.md) governs ADR lifecycle.
 - Issue numbers in registry rows are pointers, not promises. Issues may be closed without the ADR landing, and ADRs may land without an issue.
+
+## See also
+
+- [docs/rfcs/](../../docs/rfcs/) — RFC documents (RFC-0000 is the seed)
+- [docs/adr/](../../docs/adr/) — ADR decision receipts
+- [docs/strategy/ICN_CONSTITUTIONAL_ROADMAP.md](../../docs/strategy/ICN_CONSTITUTIONAL_ROADMAP.md) — long-arc architectural roadmap

--- a/ops/coordination/adr_candidates.yaml
+++ b/ops/coordination/adr_candidates.yaml
@@ -7,6 +7,18 @@
 # Rows here exist so the long arc of architecture does not get designed
 # out by accident between sessions.
 #
+# RFCs precede some ADR candidates. Where an ADR candidate's design space is
+# unsettled, the project should draft an RFC first (see
+# ops/coordination/rfc_candidates.yaml and docs/rfcs/RFC-0000-rfc-process.md).
+# Examples currently in this registry:
+#   ADR-0023 (CCL Institutional Process Language)         → RFC-0004
+#   ADR-0027 (Action Card Contract)                       → RFC-0005
+#   ADR-0028 (Accessibility Baseline)                     → RFC-0003
+#   ADR-0029 (Conflict Resolution Object Model)           → RFC-0002
+#   ADR-0044/0045/0046/0047/0048 (Economics tranche)      → RFC-0001
+# Back-fill candidates (e.g., 0021, 0022, 0030, 0031) do not need an RFC
+# because they record decisions already settled by code.
+#
 # Conventions: see ops/coordination/README.md
 # ADR lifecycle: see docs/adr/ADR-0018-adr-lifecycle-and-canonical-decision-index.md
 # Numbering: continues from the highest existing ADR (0020 at registry-creation time)

--- a/ops/coordination/rfc_candidates.yaml
+++ b/ops/coordination/rfc_candidates.yaml
@@ -1,0 +1,515 @@
+# ICN RFC Candidate Registry
+#
+# A planning index of unresolved design spaces that need an RFC before an ADR
+# or implementation. This file is NOT a decision record. It exists so the
+# project knows what design conversations are pending and does not lose them
+# between sessions.
+#
+# RFCs themselves live in docs/rfcs/. ADRs live in docs/adr/. ADR candidates
+# live in ops/coordination/adr_candidates.yaml.
+#
+# RFCs explore. ADRs decide. Issues build. Tests prove. The website claims
+# only what the proof supports. See docs/rfcs/RFC-0000-rfc-process.md.
+#
+# Updated: 2026-04-26
+#
+# Field reference:
+#   id: RFC number (zero-padded, 4 digits)
+#   title: Short RFC title
+#   status: candidate (until promoted to draft, when an RFC file is created)
+#   domain: economics | conflict | accessibility | ccl | member-shell |
+#           governance | federation | provenance | project-governance |
+#           website | compute | package
+#   why_it_matters: 1-2 sentence rationale
+#   related_adr_candidates: ADR ids the RFC may inform (from adr_candidates.yaml)
+#   related_issues: GitHub issue references
+#   design_questions: open questions the RFC must address
+#   icn_runtime_surface: what kernel/runtime surface this affects, or "doctrinal"
+#   package_or_institution_expression: how institution packages express this
+#   accessibility_implications: how this lands for low-bandwidth/low-device/
+#                               non-English/disabled members
+#   conflict_or_dispute_path: how disputes about this surface are handled
+#   compute_or_automation_boundary: what compute can and cannot do here
+#   website_truth_implication: what the public site can claim once accepted
+#                              and implemented
+#   proposed_outputs: what ADRs or implementation issues the RFC should produce
+#   priority: now | soon | later
+#
+# Note: some ADR candidates in adr_candidates.yaml should be preceded by an RFC
+# in this file. The pipeline is one-way in spirit: RFC explores → ADR decides
+# → issue commits → tests prove → ADR.implementation_status updates → website
+# claims. See RFC-0000 for the full process.
+
+candidates:
+
+  - id: "0001"
+    title: "Obligation / Allocation / Settlement Primitives"
+    status: candidate
+    domain: economics
+    why_it_matters: |
+      ADR-0004 distinguishes obligations from payments. ICN ships a commons
+      compute settlement engine (ADR-0005, ADR-0031) that produces balanced
+      journal entries, and #1634 proposes formal obligation/allocation/
+      settlement primitives. The design space — what shape these primitives
+      take, what their lifecycles are, how challenges and reversals work — is
+      not yet fully written. Without an RFC, the resulting ADRs will be
+      shallow and the regulatory-safe vocabulary will be at risk.
+    related_adr_candidates: ["0044", "0045", "0046", "0047", "0048", "0041"]
+    related_issues: ["#1634", "#1635"]
+    design_questions:
+      - "What are the canonical types: Obligation, Allocation, Settlement, Position, SettlementAsset?"
+      - "What is the lifecycle of an obligation? When does it form, when does it close, when does it convert to a settlement?"
+      - "What authority is required to create an allocation? What authority is required to settle?"
+      - "What is the challenge/reversal path when an obligation is disputed?"
+      - "How do positions accumulate; how are they zeroed by settlement; how do mutual-credit ceilings interact with allocations?"
+      - "What does cross-coop clearing look like at the settlement primitive level (extends ADR-0013)?"
+      - "What is the boundary between treasury authority, patronage accounts, and commons pool settlement (ADR-0031)?"
+    icn_runtime_surface: "icn-ledger; icn-federation clearing path; future obligation/allocation actor; potential new icn-economics crate"
+    package_or_institution_expression: "Packages declare allocation templates and obligation kinds; ICN owns the lifecycle and settlement primitives."
+    accessibility_implications: |
+      Obligation and allocation surfaces must render in plain language and not
+      look like a bank statement. Members must be able to see what they owe,
+      what they are owed, and what is pending — without payment-rail metaphors
+      that obscure the cooperative accounting model.
+    conflict_or_dispute_path: |
+      Settlement disputes route through the conflict resolution object model
+      (ADR-0029 / RFC-0002). The RFC must specify whether challenges produce
+      counter-effects, reversals, or repair agreements, and how authority
+      grants for these flow.
+    compute_or_automation_boundary: |
+      Compute may compute proposed allocations under a covering mandate;
+      compute may not finalize settlement without authority. Settlement is
+      governance-grade; advisory output is allowed but cannot move positions.
+    website_truth_implication: |
+      Once the RFC is accepted and the primitives ship, the website may say
+      "ICN models obligations and allocations with explicit lifecycles" and
+      cite the ADRs. Until then, public claims must remain at "obligations,
+      not payments" framing without claiming a complete primitive surface.
+    proposed_outputs:
+      - "ADR(s) for obligation lifecycle, allocation authorization, settlement/position semantics, challenge/reversal path"
+      - "Issues for primitive type definitions, lifecycle handlers, settlement integration, ledger journal extensions"
+      - "Validation: integration tests proving lifecycle invariants and challenge paths"
+    priority: now
+
+  - id: "0002"
+    title: "Conflict Resolution and Institutional Care"
+    status: candidate
+    domain: conflict
+    why_it_matters: |
+      ADR-0029 names three conflict shapes (effect challenges, process
+      appeals, relational conflicts) and notes that compute disputes are
+      implemented while institutional resolution is at the type-sketch level
+      only. The design space — object model detail, evidence handling,
+      mediation roles, remedy taxonomy, repair-first defaults — is unsettled
+      and consequential. Conflict is the human reality layer; getting it
+      wrong erodes institutional trust faster than any other surface.
+    related_adr_candidates: ["0029", "0060", "0061", "0062", "0042"]
+    related_issues: []
+    design_questions:
+      - "What is the canonical ConflictCase type? What lifecycle does it carry?"
+      - "What is the EvidenceBundle shape? How does selective disclosure work?"
+      - "What process roles exist (mediator, facilitator, arbiter, observer)? Who can hold them?"
+      - "What is the MediationProcess vs Appeal vs structured agreement distinction?"
+      - "What remedies are first-class (counter-effect, reversal, repair agreement, sanction)?"
+      - "How does retaliation protection work? What enforcement mechanism guards process integrity?"
+      - "How do CCL-defined resolution processes (ADR-0060) plug into this?"
+      - "What is private vs public in a resolution? What gets redacted, what gets archived?"
+    icn_runtime_surface: "Future: icn-conflict crate or extension of icn-governance; CCL process runner integration"
+    package_or_institution_expression: "Packages declare resolution processes as CCL workflows; ICN owns conflict object identity and lifecycle."
+    accessibility_implications: |
+      Resolution flows must accommodate language, time, technology, and
+      caregiving constraints. Testimony submission must support assistive
+      technology. Deadlines for response must be just rather than
+      pre-empting members who cannot respond on a fixed schedule.
+    conflict_or_dispute_path: "This RFC IS the path."
+    compute_or_automation_boundary: |
+      Compute mediates evidence and timing; compute does not decide outcomes.
+      Decisions are human or governance acts. Compute may compile evidence
+      summaries, surface deadlines, and route notifications under a covering
+      mandate.
+    website_truth_implication: |
+      Once accepted, the website may describe conflict resolution as a
+      first-class architectural goal with a written object model. It may NOT
+      claim a complete runtime surface until ADRs land and integration tests
+      prove the path end-to-end.
+    proposed_outputs:
+      - "ADRs for object model detail, evidence bundle, remedy taxonomy, appeals lifecycle, retaliation protection"
+      - "Follow-up RFCs on cross-institution conflict resolution (extends RFC-0007 territory)"
+      - "Issues for runtime support across icn-governance and a future conflict actor"
+    priority: now
+
+  - id: "0003"
+    title: "Accessibility Baseline and Member Participation"
+    status: candidate
+    domain: accessibility
+    why_it_matters: |
+      ADR-0028 names accessibility as a participation floor with five layers
+      (sensory, cognitive, linguistic, economic, temporal) and proposes the
+      floor; it does not prescribe the runtime contract that ties every
+      member-facing surface to a measurable target. Action cards (ADR-0027 /
+      RFC-0005) are about to ship and need this floor to be concrete; the
+      glossary endpoint (#1610) and mobile SDK (#1366) likewise.
+    related_adr_candidates: ["0028", "0054", "0055", "0056", "0057", "0058", "0059"]
+    related_issues: ["#1610", "#1611", "#1366"]
+    design_questions:
+      - "What is the WCAG 2.2 AA floor checklist concretely for each ICN surface?"
+      - "What is the language justice workflow? Who translates; how is the canonical-vs-translated boundary maintained?"
+      - "What is the deadline-justice profile on action cards? What metadata travels with deadlines?"
+      - "How does the glossary endpoint resolve institutional vocabulary? What is the canonical definition source?"
+      - "What is the offline tolerance contract for mobile read paths? For mobile write paths?"
+      - "What is the assistive-tech contract (ARIA roles, semantic HTML, focus order) for action cards specifically?"
+      - "What hardware floor does ICN target (low-end Android, screen reader on iOS, low-resolution displays)?"
+      - "What is the caregiving / shift-work / wage barrier accommodation model? Is this CCL territory or runtime configuration?"
+    icn_runtime_surface: "Future: GET /me/glossary endpoint; locale fields on standing schema; offline queue in mobile SDK; build-time accessibility linter"
+    package_or_institution_expression: "Packages declare locale and assistive metadata; package fixtures must pass baseline checks before bootstrap."
+    accessibility_implications: "This RFC IS the implication."
+    conflict_or_dispute_path: |
+      Accessibility violations are graded as institutional defects, not bugs.
+      Remediation routes through the conflict resolution model (RFC-0002).
+      The RFC must specify the escalation path for violations that block
+      participation.
+    compute_or_automation_boundary: |
+      Compute does not decide accessibility outcomes. Compute may render
+      assistive content under explicit member opt-in (e.g., simplified
+      summaries, reading-level adjustments) but the canonical content is
+      authority's, not compute's.
+    website_truth_implication: |
+      Once accepted, the website may describe accessibility as a
+      first-class architectural goal with a measurable floor and
+      evidence-linked claims. The site itself must conform to the floor.
+    proposed_outputs:
+      - "ADR amendments / successors to 0028 detailing the WCAG checklist, glossary contract, language justice flow, deadline-justice profile"
+      - "ADRs for plain-language and glossary contract (0055), assistive-tech semantics for action cards (0056), caregiving/time/wage accommodation (0057), offline participation (0058), non-CLI workflows (0059)"
+      - "Issues for /me/glossary endpoint, locale-aware standing, offline queue, build-time accessibility linter"
+    priority: now
+
+  - id: "0004"
+    title: "CCL Institutional Process Language"
+    status: candidate
+    domain: ccl
+    why_it_matters: |
+      ADR-0023 names CCL-as-process-language as a forward direction. CCL
+      today encodes thresholds and formulas via the schema bridge
+      (ADR-0022). The design space for processes — step grammar, deadlines,
+      escalation, human-judgment pauses, conflict workflows, accessibility
+      rules, federation agreements — is non-trivial. Drafting an ADR
+      without an RFC would lock in language design choices without
+      tradeoff analysis.
+    related_adr_candidates: ["0023", "0036", "0060"]
+    related_issues: ["#863"]
+    design_questions:
+      - "What is the Process step grammar? AutoStep, MemberStep, RoleStep, SignalStep — closed taxonomy or extensible?"
+      - "What are deadline semantics? How do escalation rules compose? Are deadlines preemptive or declarative?"
+      - "How does process amendment affect in-flight processes? Is migration explicit or transparent?"
+      - "What is the process runner's relationship to the supervisor and the actor system?"
+      - "How do processes interact with mandates and effect records (ADR-0019, ADR-0025)?"
+      - "How do CCL processes express conflict resolution flows (RFC-0002 dependency)?"
+      - "How do CCL processes express accessibility requirements (RFC-0003 dependency)?"
+      - "How are processes ratified through governance? Is activation the same as charter activation?"
+    icn_runtime_surface: "Future: process-runner actor; new icn-process crate or extension of icn-governance; schema additions to icn-ccl"
+    package_or_institution_expression: "Packages ship process definitions (onboarding, grievance, allocation review, etc.) as CCL alongside charter rules."
+    accessibility_implications: |
+      Process steps with deadlines must respect the temporal-justice floor
+      (RFC-0003). Member-facing steps must be plain-language, accessible,
+      and assistive-tech-friendly. Caregiving and shift-work accommodation
+      must be expressible as deadline metadata.
+    conflict_or_dispute_path: |
+      CCL processes express conflict resolution workflows (ADR-0060). The
+      RFC must specify how a dispute about the process itself is handled
+      (process appeal vs effect challenge per ADR-0029).
+    compute_or_automation_boundary: |
+      Process steps that are deterministic and bounded are executed by
+      compute; human-judgment steps pause for member input. The RFC must
+      specify what counts as deterministic in a process context and how
+      pauses interact with deadlines.
+    website_truth_implication: |
+      Once accepted and a process runner ships, the site may describe CCL
+      as the institutional process language. Until then, public framing
+      is at "rule/process language direction; charter constraints prove
+      the pattern" only.
+    proposed_outputs:
+      - "ADR(s) for process step grammar, deadline semantics, escalation rules, amendment migration"
+      - "Follow-up RFC for cross-process composition (deferred per ADR-0023)"
+      - "Issues for process runner actor, schema additions, integration tests"
+    priority: soon
+
+  - id: "0005"
+    title: "Action Card Contract and Prioritization"
+    status: candidate
+    domain: member-shell
+    why_it_matters: |
+      ADR-0027 defines action cards as derived views over standing,
+      pending governance objects, and signals. The design space —
+      kind taxonomy, prioritization policy, accessibility metadata,
+      active-scope binding, member-attention model — is not yet fully
+      written. #1608 is the implementation issue; without an RFC, the
+      first /me/action-cards version risks shipping a shape that later
+      needs costly migration.
+    related_adr_candidates: ["0027", "0049", "0050", "0052", "0056"]
+    related_issues: ["#1608", "#1646", "#1605", "#1537"]
+    design_questions:
+      - "What is the closed kind taxonomy at v1? What can grow by ADR amendment?"
+      - "What is the priority policy? Static rules, PolicyOracle, or hybrid? What inputs go in?"
+      - "How does active scope (#1605) affect card derivation?"
+      - "What accessibility metadata travels on a card (locale, deadline-justice profile, plain-language summary, assistive notes)?"
+      - "What is the receipt expectation — does opening a card produce a receipt? Does dismissing one?"
+      - "How does the attention model differ from notifications (RFC dependency on ADR-0052)?"
+      - "How does derivation interact with caching at the gateway? Is determinism preserved request-to-request?"
+    icn_runtime_surface: "Future: GET /v1/gov/me/action-cards in icn-gateway; derivation logic in icn-governance; card-priority PolicyOracle"
+    package_or_institution_expression: "Packages contribute card templates and rendering hints; ICN owns the envelope, kind taxonomy, and prioritization."
+    accessibility_implications: |
+      Cards are the primary member surface. Per RFC-0003, every card must
+      carry plain-language summary, locale metadata, deadline-justice
+      profile, and assistive-tech semantics. The RFC must make these
+      mandatory at the schema level.
+    conflict_or_dispute_path: |
+      Cards reference underlying objects (proposals, action items,
+      allocations). Disputes proceed against those, not the card. The RFC
+      must specify how a dispute about the priority policy itself is
+      handled.
+    compute_or_automation_boundary: |
+      Cards are derived views; compute is involved in priority scoring
+      under a covering policy oracle but not in card content. The RFC
+      must specify whether priority is governance-grade (deterministic)
+      or advisory (allowed to use non-deterministic ranking).
+    website_truth_implication: |
+      Once accepted and shipped, the site may describe action cards as
+      the member-facing nervous system with a documented contract. Until
+      shipped, public framing remains at "named, not yet implemented."
+    proposed_outputs:
+      - "ADR amending or successing 0027 with finalized kind taxonomy, priority contract, accessibility schema"
+      - "Issues for endpoint implementation, derivation logic, priority oracle"
+      - "Validation: integration tests proving determinism, priority correctness, accessibility metadata presence"
+    priority: now
+
+  - id: "0006"
+    title: "Governance Payload Execution Dispatch"
+    status: candidate
+    domain: governance
+    why_it_matters: |
+      ADR-0019 records the authority grant minting seam at proposal
+      acceptance. The next gap is dispatch: what happens when the
+      governance actor closes a proposal whose payload should produce an
+      institutional effect? Today, only a few proposal kinds dispatch;
+      most are accepted-but-non-executable. The pattern needs an RFC
+      before more kinds are added piecemeal.
+    related_adr_candidates: ["0069", "0070", "0071", "0074", "0075"]
+    related_issues: ["#1588", "#1607"]
+    design_questions:
+      - "What is the dispatch map shape? Per-kind handlers, or a payload-driven trait dispatch?"
+      - "What is the accepted-but-non-executable status semantically? Does it produce an effect record (ADR-0025)?"
+      - "How does mandate-gated mutation work in dispatch — when is the mandate consulted?"
+      - "What atomicity guarantees does dispatch provide? (See ADR-0075 candidate, #1588.)"
+      - "What is the proposal type taxonomy at v1? What can grow?"
+      - "How does cross-institution dispatch interact (RFC-0007 dependency)?"
+      - "What is the rollback path when dispatch partially fails?"
+    icn_runtime_surface: "icn-governance dispatch layer; integration with icn-kernel-api effect record schema; supervisor actor handlers"
+    package_or_institution_expression: "Packages declare which proposal kinds are accepted at their domain; dispatch is shared infrastructure."
+    accessibility_implications: |
+      Dispatch outcomes feed action cards (RFC-0005). The RFC must
+      specify what plain-language summary travels on the resulting effect
+      record so member-facing surfaces can render it without
+      re-interpretation.
+    conflict_or_dispute_path: |
+      Effect challenges (ADR-0029 Shape 1) are the dispute path against
+      dispatched outcomes. The RFC must specify how challenges produce
+      counter-effects through the same dispatch surface.
+    compute_or_automation_boundary: |
+      Dispatch is governance-grade; compute may execute the work under a
+      mandate but cannot decide whether to dispatch. The RFC must specify
+      what is governance-only vs what compute may perform under
+      authority.
+    website_truth_implication: |
+      Once accepted and the dispatch path lands for major proposal kinds,
+      the site can describe execution coverage as "advancing to strong"
+      with evidence-linked claims for each kind. Currently the band is
+      "advancing" because coverage is partial; this RFC is the precondition
+      for moving the band.
+    proposed_outputs:
+      - "ADRs for dispatch architecture, proposal type taxonomy, accepted-but-non-executable semantics, atomicity, mandate-gated kernel dispatch (0069)"
+      - "Issues for dispatch implementation per kind, integration tests, replay validation"
+    priority: soon
+
+  - id: "0007"
+    title: "Cross-Institution Mandate Recognition"
+    status: candidate
+    domain: federation
+    why_it_matters: |
+      ADR-0011/0012/0013 govern federation state origin, two-store
+      isolation, and clearing adoption. The next layer is mandate
+      recognition: when coop A grants authority for a cross-coop action,
+      coop B must have a written rule for whether and how to honor it.
+      Today the answer is implicit. The RFC must make it explicit before
+      more federation primitives are added.
+    related_adr_candidates: ["0035", "0036", "0037", "0038", "0039", "0040"]
+    related_issues: ["#1607", "#1609", "#863"]
+    design_questions:
+      - "What is the recognition policy schema? Per-treaty, per-mandate-class, per-issuer-DID?"
+      - "What is the difference between Representation and Delegation across institutions?"
+      - "What is the federation membership lifecycle (ADR-0035) and how does it gate recognition?"
+      - "How does entity-level voting eligibility (#1609) interact with cross-coop representation receipts (#1607)?"
+      - "What happens when coop A revokes a mandate that coop B has already acted on?"
+      - "How does federation agreement support (ADR-0036, #863) express recognition rules in CCL?"
+      - "What audit trail does cross-coop dispatch produce?"
+    icn_runtime_surface: "icn-federation; icn-governance representation/delegation logic; potential new icn-recognition crate"
+    package_or_institution_expression: "Packages declare which external authorities they recognize and under what conditions; ICN owns the recognition primitive."
+    accessibility_implications: |
+      Cross-institution actions surface in a holder's standing across
+      multiple entities. The RFC must specify how the assistive-tech
+      contract (RFC-0003) extends to multi-entity standing reads.
+    conflict_or_dispute_path: |
+      Recognition disputes route through federation dispute resolution
+      (ADR-0042 / RFC-0002 cross-link). The RFC must specify the
+      escalation path when coops disagree on whether a mandate is valid.
+    compute_or_automation_boundary: |
+      Compute may compute recognition decisions under a covering policy
+      oracle (deterministic, fuel-bounded); compute does not have
+      authority to recognize on its own. The RFC must specify the
+      PolicyOracle contract.
+    website_truth_implication: |
+      Once accepted and recognition primitives ship, the site may
+      describe federation depth in concrete terms (membership lifecycle,
+      recognition policy, audit trail). Until then, federation framing
+      stays at "real implementation, public surfaces still maturing."
+    proposed_outputs:
+      - "ADRs for federation membership lifecycle, recognition policy, representation/delegation distinction, entity-level voting eligibility, RepresentativeVote receipts"
+      - "Issues for federation primitive implementations, integration tests across multi-coop scenarios"
+      - "Reference Tranche 2 in adr_candidates.yaml"
+    priority: soon
+
+  - id: "0008"
+    title: "Publicly Verifiable Provenance"
+    status: candidate
+    domain: provenance
+    why_it_matters: |
+      ADR-0026 records the receipt and provenance proof envelope spanning
+      ADR-0008/0011/0012/0014/0019/0020 and PR #1648. Layer 4 of that
+      envelope — the publicly verifiable query surface — is not yet
+      designed. Three open issues (#1435, #1436, #1438) target pieces of
+      this design: per-entry signing instead of HMAC, signature semantics
+      disambiguation, and the auditor-accessible query endpoint.
+    related_adr_candidates: ["0072", "0073"]
+    related_issues: ["#1435", "#1436", "#1438"]
+    design_questions:
+      - "What is the proof envelope shape at the public-query boundary? What is included; what is omitted for privacy?"
+      - "What is the per-entry signing scheme that replaces JWT-secret-bound HMAC fingerprinting (#1435)?"
+      - "What does ProvenanceRef::DirectMember.signature actually attest to (#1436)?"
+      - "What is the auditor-facing query endpoint shape (#1438)? Pagination, filtering, redaction?"
+      - "What is the federation peer's verification path? Same as auditor's, or separate?"
+      - "What is the canonical event log and replay semantics (ADR-0073 candidate)?"
+      - "How does publicly verifiable provenance interact with privacy-class-bounded compute (ADR-0082 candidate)?"
+    icn_runtime_surface: "icn-governance proof layer; icn-federation provenance store; new query endpoint in icn-gateway; potential icn-audit crate"
+    package_or_institution_expression: "Packages do not author provenance; they consume it via the public query surface and audit endpoints."
+    accessibility_implications: |
+      Auditors and federated peers may not be the primary consumers, but
+      members may also want to verify their own provenance. The query
+      surface must support plain-language receipt rendering (per ADR-0028
+      / RFC-0003).
+    conflict_or_dispute_path: |
+      Provenance disputes ARE conflicts about effects (ADR-0029 Shape 1).
+      The RFC must specify what evidence the query surface produces to
+      support a challenge and what re-verification looks like.
+    compute_or_automation_boundary: |
+      Compute may produce provenance entries under mandate; compute may
+      not mint provenance without a covering authority grant. The RFC
+      must specify how compute-produced entries are signed and verified
+      independently of the producing actor.
+    website_truth_implication: |
+      Once accepted and the public query surface ships, the site may say
+      provenance is "publicly verifiable" with evidence-linked claims.
+      Currently the strongest public claim is "provenance is the strongest
+      part of the system" — true at the gateway/supervisor layer; the
+      cross-coop and auditor verifiability layer is future work.
+    proposed_outputs:
+      - "ADRs for cross-node verifiable provenance (0072), canonical event log and replay semantics (0073)"
+      - "Issues for per-entry signing migration, query endpoint, replay validation"
+    priority: soon
+
+  - id: "0009"
+    title: "Project Governance and ADR/RFC Acceptance"
+    status: candidate
+    domain: project-governance
+    why_it_matters: |
+      ICN's own governance — who can accept an RFC, who can merge an
+      ADR, who controls release authority, who issues emergency patches —
+      is currently informal. The forward direction is to use ICN's own
+      governance primitives to govern ICN. The RFC is the place to design
+      that transition.
+    related_adr_candidates: ["0063", "0064", "0065", "0066", "0067", "0068"]
+    related_issues: []
+    design_questions:
+      - "What is the maintainer authority model at v1? Who has merge rights, who has accept rights?"
+      - "What is the contributor role model beyond code (docs, design, research, testing, partnership)?"
+      - "What is the RFC acceptance process? Quorum, lazy consensus, maintainer call?"
+      - "What is the ADR acceptance process? How does it differ from RFC acceptance?"
+      - "What is the release authority and cadence model?"
+      - "What is the security authority and emergency patch path?"
+      - "What is the transition path toward ICN-hosted governance — when is the substrate stable enough?"
+      - "How does ICN dogfood its own governance primitives (charters, mandates, effect records, conflict resolution)?"
+    icn_runtime_surface: "doctrinal initially; later ICN's own institutional package"
+    package_or_institution_expression: "ICN itself becomes an institution package once primitives stabilize."
+    accessibility_implications: |
+      Project governance must itself be accessible — non-CLI workflows
+      (RFC-0003), plain-language process docs, deadline justice for
+      contributors with caregiving or wage constraints. The RFC must
+      specify how ICN's own governance honors the floor it asks
+      institutions to honor.
+    conflict_or_dispute_path: |
+      Project disputes (e.g., contested RFC outcomes, contributor
+      conflicts) need a path. Initially this is informal; the RFC must
+      design the transition to a formalized path that uses the same
+      conflict resolution model (RFC-0002).
+    compute_or_automation_boundary: |
+      Project governance may use compute under mandate (e.g., automated
+      checks, build-time linters per ADR-0033) but compute does not
+      decide RFC outcomes or emergency patches.
+    website_truth_implication: |
+      Once accepted and the transition path is documented, the site can
+      describe ICN's own governance with the same maturity-band
+      discipline applied to other subsystems. Until then, project
+      governance is informal and the public framing should reflect that.
+    proposed_outputs:
+      - "ADRs for project governance, maintainer authority, contributor roles, security authority, release authority, transition path"
+      - "Issues for governance-as-code dogfooding"
+    priority: later
+
+  - id: "0010"
+    title: "Website Maturity Evidence and Public Claim Linting"
+    status: candidate
+    domain: website
+    why_it_matters: |
+      ADR-0032 records the website truth boundary (maturity bands,
+      evidence chain). ADR-0033 proposes a build-time linter that
+      verifies every banded claim cites an ADR, issue, code path, or
+      phase reference. The design space — what counts as evidence, how
+      the linter resolves references, how editorial discipline interacts
+      with mechanical checks — is not yet fully written.
+    related_adr_candidates: ["0032", "0033"]
+    related_issues: ["#1369"]
+    design_questions:
+      - "What is the evidence-reference schema? ADR-NNNN, #NNNN, repo path, phase reference — same field or separate?"
+      - "How does the linter resolve references at build time? GitHub API for issues, file existence for paths?"
+      - "How does the linter handle superseded ADRs or closed issues? Stale references — fail build, warn, or auto-update?"
+      - "What is the threshold for prose claims that imply a band but don't use a MaturityBadge component?"
+      - "How does the live roadmap page (#1369) interact with the evidence schema?"
+      - "What caching strategy keeps build time reasonable when GitHub API is involved?"
+    icn_runtime_surface: "doctrinal — applies to website/ build pipeline only"
+    package_or_institution_expression: "n/a"
+    accessibility_implications: |
+      Evidence-linked claims are themselves an accessibility property —
+      members and partners can audit any claim by following its
+      reference. The RFC must specify how linked references are
+      rendered (visible vs hover, plain vs URL).
+    conflict_or_dispute_path: |
+      Disputes about a claim resolve against the cited ADR/issue. The
+      RFC must specify what happens when an evidence reference becomes
+      stale (e.g., ADR superseded, issue closed without resolution).
+    compute_or_automation_boundary: |
+      The linter is a build-time check; no runtime. Compute does not
+      decide what bands to apply.
+    website_truth_implication: |
+      This RFC IS the public-claim implication.
+    proposed_outputs:
+      - "ADR amendments / successors to 0032 and 0033 with finalized evidence schema, linter contract"
+      - "Issues for linter implementation, MaturityBadge component schema update, existing usage backfill, live roadmap rendering (#1369)"
+    priority: soon


### PR DESCRIPTION
## Summary

Adds the RFC layer of ICN's design pipeline. RFCs sit upstream of ADRs as the place where the project explores design spaces, compares options, and traces tradeoffs — *before* a decision is recorded.

> **RFCs explore. ADRs decide. Issues build. Tests prove. The website claims only what the proof supports.**

## Why RFCs are separate from ADRs

| Layer | What it is | Where it lives |
|---|---|---|
| RFC candidate | Unresolved design space worth exploring | [ops/coordination/rfc_candidates.yaml](ops/coordination/rfc_candidates.yaml) |
| RFC | Design exploration and tradeoff analysis | `docs/rfcs/RFC-NNNN-*.md` |
| ADR candidate | Likely future decision the project intends to record | [ops/coordination/adr_candidates.yaml](ops/coordination/adr_candidates.yaml) |
| ADR | Architectural decision receipt | `docs/adr/ADR-NNNN-*.md` |
| Issue | Implementation commitment | GitHub issues |
| Test | Evidence that implementation matches the decision | `crates/*/tests/` |
| Website | Public truth boundary; only claims what evidence supports | `website/src/` |

ADRs are decision receipts. RFCs are upstream of decisions: they exist so the project can hold a design conversation in writing without prematurely committing. Drafting an ADR before the design space is explored produces shallow ADRs. Drafting an RFC and then an ADR produces decisions whose tradeoffs are documented and whose alternatives are auditable.

## Files added

- **[`docs/rfcs/README.md`](docs/rfcs/README.md)** — layer overview, lifecycle vocab, frontmatter contract, file naming.
- **[`docs/rfcs/template.md`](docs/rfcs/template.md)** — YAML frontmatter + 21 sections covering Summary through Validation/proof plan: problem statement, goals, non-goals, design options (A/B/C minimum), tradeoffs, core/package boundary, accessibility implications, conflict path, security/privacy, compute/automation boundary, website truth implications, migration, open questions, decision criteria, outcome, follow-up ADRs/issues, validation plan.
- **[`docs/rfcs/RFC-0000-rfc-process.md`](docs/rfcs/RFC-0000-rfc-process.md)** — seed RFC. Defines when to write an RFC, when not to, how RFCs move to ADRs, how RFCs relate to issues, how implementation evidence updates ADRs, how website claims depend on evidence, supersession/withdrawal rules, and how RFCs interact with the ADR candidate registry. Status: `accepted`.
- **[`ops/coordination/rfc_candidates.yaml`](ops/coordination/rfc_candidates.yaml)** — 10 seed RFC candidates (see below).

## Files updated

- **[`ops/coordination/README.md`](ops/coordination/README.md)** — explains the pipeline. Distinguishes `rfc_candidates.yaml` from `adr_candidates.yaml`. Notes which ADR candidates should be preceded by an RFC and which back-fill candidates can proceed directly.
- **[`ops/coordination/adr_candidates.yaml`](ops/coordination/adr_candidates.yaml)** — header note added pointing at the RFCs that should precede the relevant ADR candidates. **No row rewrites.** Minimal mechanical change.
- **[`docs/registry.toml`](docs/registry.toml)** — adds `rfcs` to `allowlisted_docs_subdirs` and a `doc_path_defaults` block for `docs/rfcs/` (`truth_class: draft`, `role: design`, `domain_tags: rfc`).

## RFC statuses

| Status | Meaning |
|---|---|
| `draft` | Author is composing; not ready for review. |
| `active` | Open for review, comments, alternative proposals. |
| `accepted` | Project converged. Follow-up ADR(s) record the decision. |
| `rejected` | Project decided against. Body preserved for reference. |
| `superseded` | Later RFC replaces this one. Both bodies preserved. |
| `withdrawn` | Author or project removed before a decision. |

## Relationship to ADRs / issues / tests / website

The three lifecycles are independent:

- **RFC**: `draft / active / accepted / rejected / superseded / withdrawn`
- **ADR**: `proposed / accepted / amended / superseded / deprecated`
- **Implementation**: `not_started / partial / implemented / verified`

**Hard rules**:

- Accepted RFC does NOT mean implemented.
- Accepted ADR does NOT mean implemented.
- Implementation status moves only with code/test evidence.

The public website (per [ADR-0032](docs/adr/ADR-0032-website-truth-boundary.md), [ADR-0033](docs/adr/ADR-0033-public-maturity-claims-and-evidence-links.md)) claims only what implementation evidence supports — never what the RFC proposes.

## Seed RFC candidates

| # | Title | Related ADR candidates | Related issues |
|---|---|---|---|
| RFC-0001 | Obligation / Allocation / Settlement Primitives | 0044, 0045, 0046, 0047, 0048, 0041 | [#1634](https://github.com/InterCooperative-Network/icn/issues/1634), [#1635](https://github.com/InterCooperative-Network/icn/issues/1635) |
| RFC-0002 | Conflict Resolution and Institutional Care | 0029, 0060, 0061, 0062, 0042 | — |
| RFC-0003 | Accessibility Baseline and Member Participation | 0028, 0054, 0055, 0056, 0057, 0058, 0059 | [#1610](https://github.com/InterCooperative-Network/icn/issues/1610), [#1611](https://github.com/InterCooperative-Network/icn/issues/1611), [#1366](https://github.com/InterCooperative-Network/icn/issues/1366) |
| RFC-0004 | CCL Institutional Process Language | 0023, 0036, 0060 | [#863](https://github.com/InterCooperative-Network/icn/issues/863) |
| RFC-0005 | Action Card Contract and Prioritization | 0027, 0049, 0050, 0052, 0056 | [#1608](https://github.com/InterCooperative-Network/icn/issues/1608), [#1646](https://github.com/InterCooperative-Network/icn/issues/1646), [#1605](https://github.com/InterCooperative-Network/icn/issues/1605), [#1537](https://github.com/InterCooperative-Network/icn/issues/1537) |
| RFC-0006 | Governance Payload Execution Dispatch | 0069, 0070, 0071, 0074, 0075 | [#1588](https://github.com/InterCooperative-Network/icn/issues/1588), [#1607](https://github.com/InterCooperative-Network/icn/issues/1607) |
| RFC-0007 | Cross-Institution Mandate Recognition | 0035–0040 | [#1607](https://github.com/InterCooperative-Network/icn/issues/1607), [#1609](https://github.com/InterCooperative-Network/icn/issues/1609), [#863](https://github.com/InterCooperative-Network/icn/issues/863) |
| RFC-0008 | Publicly Verifiable Provenance | 0072, 0073 | [#1435](https://github.com/InterCooperative-Network/icn/issues/1435), [#1436](https://github.com/InterCooperative-Network/icn/issues/1436), [#1438](https://github.com/InterCooperative-Network/icn/issues/1438) |
| RFC-0009 | Project Governance and ADR/RFC Acceptance | 0063–0068 | — |
| RFC-0010 | Website Maturity Evidence and Public Claim Linting | 0032, 0033 | [#1369](https://github.com/InterCooperative-Network/icn/issues/1369) |

RFC-0001 explicitly preserves regulatory-safe vocabulary (use: settlement, unit, position, settlement asset, obligation, allocation; avoid: payment, currency, balance, wallet) per [ADR-0004](docs/adr/ADR-0004-icn-base-layer-models-obligations-and-attestations.md), [ADR-0031](docs/adr/ADR-0031-commons-compute-admission-and-settlement-policy.md).

## Validation

```text
python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml --strict
  -> OK: doc control check passed (724 docs markdown files); 32 enforcement warnings
     (all 32 pre-existing; none from new files)

git diff --check
  -> clean

git diff --stat
  -> 7 files changed, 1058 insertions(+), 10 deletions(-)
     Scope: docs/rfcs/ (3 new files), docs/registry.toml, ops/coordination/
```

## Risk

- **Low.** Documentation and planning artifacts only. No runtime changes. No public website changes. No SDK regen. No lockfile churn. No Rust changes.
- The RFC system is itself an RFC (RFC-0000) and self-contained: it defines its own process and seeds its own candidate registry without claiming any other architectural decisions.

## Test plan

- [x] `python3 docs/scripts/doc_control_check.py --strict` exits 0
- [x] `docs/rfcs/` added to `allowlisted_docs_subdirs`
- [x] `docs/rfcs/` prefix has explicit `doc_path_defaults` row
- [x] `git diff --check` clean
- [x] Diff scope confined to `docs/rfcs/`, `docs/registry.toml`, `ops/coordination/`
- [x] No NYCN/Summit/website changes
- [x] No runtime/Rust changes

## Non-goals

- No runtime changes.
- No architecture changes other than the RFC process itself.
- No drafting of all 10 RFCs — this PR builds the system, not the documents.
- No Tranche 2 ADRs.
- No website edits.
- No NYCN changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
