### PR TITLE
docs(design): add ICN design system foundation

### DIFF
--- a/docs/design/ACCESSIBILITY_BASELINE.md
+++ b/docs/design/ACCESSIBILITY_BASELINE.md
@@ -1,0 +1,109 @@
+---
+Status: draft
+Canonical: no
+Owner: Matt Faherty
+Last Reviewed: 2026-04-26
+Last Updated: 2026-04-26
+Purpose: The accessibility floor every ICN member-facing surface must meet. Anchors ADR-0028 (proposed) at the design layer; pairs with docs/design-language/accessibility.md for component-level patterns.
+---
+
+# ICN Accessibility Baseline
+
+> **One sentence.** Accessibility is not a polish phase. It is a precondition for democratic legitimacy.
+
+This document is the floor. A surface that does not meet this floor is not shippable, regardless of how complete its functionality is.
+
+For component-level patterns, copy, and detailed guidance, see [docs/design-language/accessibility.md](../design-language/accessibility.md). For the binding decision, see [ADR-0028 — Accessibility Baseline for Member Interfaces](../adr/ADR-0028-accessibility-baseline-for-member-interfaces.md).
+
+## Standards anchor
+
+- **WCAG 2.2 Level AA** is the minimum for every member-facing surface.
+- ICN-specific requirements (receipts, provenance, scope, dangerous actions) extend WCAG; they do not replace it.
+
+## Per-surface obligations
+
+| Surface | Hard requirements |
+|---------|-------------------|
+| Public website | WCAG 2.2 AA. No motion that auto-starts. Skip-to-content link. Keyboard-navigable. Glossary linked from any unfamiliar term. |
+| Documentation | Same as website. Plain-language summary at the top of every doc. Code blocks have language tags. Headings are properly nested. |
+| Member shell | Above plus: identity-aware focus order; never trap keyboard focus inside a modal without an Escape; never require fine motor precision for a routine action. |
+| Standing view | Above plus: full content readable without color cues; non-color status indicators; "challenge" path always reachable from this view. |
+| Action cards | Above plus: confirm step requires explicit input (no default-yes); mandate and receipt named in plain language before confirm. |
+| Receipts/provenance | Above plus: progressive disclosure (summary → explanation → raw); export and share are first-class buttons. |
+| Governance flows | Above plus: vote actions are reversible up until threshold; deliberation thread is keyboard-navigable; quorum and threshold are stated in plain language. |
+| Federation/operator | Above plus: operators see no more provenance than members on records that affect members; admin actions confirm with named scope. |
+
+## Cross-cutting requirements
+
+### Color and contrast
+- Text and meaningful graphics meet WCAG AA contrast (4.5:1 for body text, 3:1 for large text and UI components).
+- Status is never color-only — paired with text, icon, or position.
+- The system does not assume light or dark theme; both must pass contrast independently.
+
+### Keyboard
+- Every interactive element reachable by keyboard.
+- Visible focus indicator on every focusable element. The indicator is not "thin gray underline"; it is unambiguous.
+- No keyboard trap. Escape always exits a modal or popover.
+- Tab order matches reading order.
+
+### Screen reader semantics
+- Real HTML elements over generic `<div>` with role attributes.
+- Form fields have programmatically associated labels.
+- Live regions announce state changes (e.g., "Vote recorded", "Receipt issued").
+- Receipts and provenance carry a description that screen readers can read coherently — no walls of opaque hashes without a label.
+
+### Tap targets
+- Minimum 44×44 CSS pixels for any interactive element on touch surfaces.
+- Adjacent tap targets do not crowd; minimum 8px between actionable hit areas.
+
+### Motion
+- Reduced-motion preference (`prefers-reduced-motion`) is honored.
+- No motion that auto-plays without a user action on first load.
+- No parallax that affects readability.
+
+### Bandwidth and device
+- Public pages render usefully on a 2 Mbps connection on a five-year-old phone.
+- Critical paths do not require JavaScript to convey content; JS adds, never gates.
+- Assets are sized for member devices, not designer monitors.
+
+### Plain language
+- The first paragraph of any complex page is plain language.
+- Glossary entries are linked inline, not buried at the bottom.
+- A member can read what they are about to do without expert help.
+
+### Multilingual
+- The member chooses language; the surface does not auto-detect from IP.
+- Translation covers the summary layer; the formal record layer remains in its canonical form with a link.
+
+### Dangerous-action confirmation
+See [CONTENT_STYLE_GUIDE.md](CONTENT_STYLE_GUIDE.md). Summary: every dangerous action must declare what it does, the mandate that backs it, reversibility, and the receipt to be produced — before confirm. Confirm is explicit input, not a default-yes button.
+
+### Receipts and provenance
+- Member can export a receipt as a downloadable file.
+- Member can share a receipt without exposing private fields by default.
+- Receipts have human-readable summaries; the canonical record is reachable but not the only view.
+
+## What this baseline is not
+
+- Not a substitute for testing with real members on real devices.
+- Not a waiver. "Accessibility blocked by upstream component" is a bug to fix, not a permanent state.
+- Not exhaustive. Component-level guidance lives in [docs/design-language/accessibility.md](../design-language/accessibility.md).
+
+## Verification
+
+A surface is considered to have met the baseline when:
+
+1. Automated checks (axe / Pa11y / equivalent) report zero AA violations on the surface.
+2. Keyboard-only walkthrough completes the primary task.
+3. Screen-reader walkthrough (NVDA, VoiceOver) completes the primary task.
+4. Reduced-motion and high-contrast modes do not break the layout.
+5. The surface renders usefully on a 2 Mbps link on a low-end device.
+
+ADR-0028 will define the binding verification protocol once accepted.
+
+## See also
+
+- [ADR-0028 — Accessibility Baseline for Member Interfaces](../adr/ADR-0028-accessibility-baseline-for-member-interfaces.md)
+- [docs/design-language/accessibility.md](../design-language/accessibility.md)
+- [docs/design/CONTENT_STYLE_GUIDE.md](CONTENT_STYLE_GUIDE.md)
+- [docs/design/ICN_DESIGN_SYSTEM.md](ICN_DESIGN_SYSTEM.md)

--- a/docs/design/CLAUDE_DESIGN_CONTEXT.md
+++ b/docs/design/CLAUDE_DESIGN_CONTEXT.md
@@ -1,0 +1,52 @@
+---
+Status: draft
+Canonical: no
+Owner: Matt Faherty
+Last Reviewed: 2026-04-26
+Last Updated: 2026-04-26
+Purpose: Ready-to-paste context for Claude Design or any external collaborator generating ICN-side design work. Keep brief; this file is meant to be copied into a tool's context window verbatim.
+---
+
+# Claude Design — ICN Context
+
+This file exists to be pasted into Claude Design (or a similar tool) whenever someone produces ICN-side design work. Keep it short. Link to richer docs only after the paste.
+
+---
+
+## Company / design system name
+
+**InterCooperative Network / ICN Commons Design System**
+
+## Blurb
+
+ICN is infrastructure for democratic institutions: governance, membership, federation, resource coordination, receipts, provenance, CCL-defined institutional rules, and member-facing participation surfaces. The visual system should feel trustworthy, civic, legible, cooperative, technical without being cold, and accessible on low-end devices.
+
+## Primary surfaces
+
+Public website, documentation, member shell, action cards, standing views, receipt and provenance views, governance flows, federation and operator views, compute and commons views.
+
+## Design priorities
+
+Accessibility, clarity, institutional seriousness, mobile-first participation, low-bandwidth use, plain-language explanation, visible provenance. Avoid: crypto-bro aesthetics, corporate SaaS sludge, fintech dashboard styling, gamified social patterns, neon futurism, or "AI sheen" without meaning.
+
+## Hard constraints
+
+- **WCAG 2.2 AA is the floor** — color contrast, keyboard navigation, screen reader semantics, large tap targets, reduced motion, low-bandwidth mode, plain language. Detail in [ACCESSIBILITY_BASELINE.md](ACCESSIBILITY_BASELINE.md).
+- **No payment/wallet/balance/currency vocabulary for ICN-native primitives.** Use: obligation, allocation, settlement, unit, position, settlement asset, external settlement instruction, bridge receipt. See [CONTENT_STYLE_GUIDE.md](CONTENT_STYLE_GUIDE.md).
+- **No NYCN, "New York Cooperative Network", "Summit", or "reference federation" language on the public ICN website.** ICN is generic substrate; NYCN is a separate institution package in a separate private repo.
+- **Maturity-band honesty.** Public claims must match implementation reality. See [ADR-0032 — Website Truth Boundary](../adr/ADR-0032-website-truth-boundary.md).
+- **Receipts are first-class UI.** Any action shown must have a path to its provenance. See [ADR-0026 — Receipt and Provenance Proof Envelope](../adr/ADR-0026-receipt-and-provenance-proof-envelope.md).
+
+## Brand position (compact)
+
+- **Yes**: civic, trustworthy, cooperative, calm, durable, technical.
+- **No**: crypto, SaaS dashboard, fintech, govtech-portal, hacker-terminal, glassmorphism, neon.
+
+## When in doubt
+
+Read the canonical files in this order:
+
+1. [docs/design-language/brief-v0.md](../design-language/brief-v0.md) — design language
+2. [docs/design/ICN_VISUAL_SYSTEM.md](ICN_VISUAL_SYSTEM.md) — visual doctrine
+3. [docs/design/ACCESSIBILITY_BASELINE.md](ACCESSIBILITY_BASELINE.md) — accessibility floor
+4. [docs/design/CONTENT_STYLE_GUIDE.md](CONTENT_STYLE_GUIDE.md) — voice, vocabulary, dangerous-action copy

--- a/docs/design/CONTENT_STYLE_GUIDE.md
+++ b/docs/design/CONTENT_STYLE_GUIDE.md
@@ -1,0 +1,107 @@
+---
+Status: draft
+Canonical: no
+Owner: Matt Faherty
+Last Reviewed: 2026-04-26
+Last Updated: 2026-04-26
+Purpose: Voice, vocabulary, and copy patterns for ICN member-facing surfaces. Pairs with the design language brief and accessibility baseline.
+---
+
+# ICN Content Style Guide
+
+## Voice
+
+- **Plain.** Grade-9 reading level on first pass. Jargon only when it earns its keep, and always linked to a glossary entry.
+- **Direct.** Short sentences. Active voice. No corporate-tone hedging ("we strive to ensure...").
+- **Calm.** No urgency theater. No exclamation marks for routine state.
+- **Honest about uncertainty.** Say "this is proposed", "this has not been verified", "you can challenge this" when those things are true.
+- **Receipts-aware.** When something is final, say so. When something is provisional, say so.
+
+## Regulatory-safe vocabulary
+
+ICN-native primitives use this vocabulary. Do not substitute money/wallet/balance/currency vocabulary into ICN-native UI.
+
+| Use | Avoid for ICN primitives | Notes |
+|-----|--------------------------|-------|
+| obligation | debt, IOU, balance owed | Authorized commitment to deliver |
+| allocation | budget line, payment plan | Authorized assignment of capacity |
+| settlement | payment, transfer, payout | Closing an obligation per its terms |
+| unit | currency, token, coin | Generic accounting unit |
+| position | balance, wallet, account | A holder's standing in a unit |
+| settlement asset | money, fiat, stablecoin | The asset used to settle externally |
+| external settlement instruction | bank transfer, payout request | Instruction to a bridge partner |
+| bridge receipt | confirmation of payment | Returned record from external partner |
+| mandate | permission, authorization, role | Authorized scope to act |
+| receipt | confirmation, transaction | Provenance-bearing record of an act |
+| standing | member status, account level | A member's recognized authority and history |
+
+External-system language (bank transfer, ACH, currency) is allowed when describing the external system itself. The boundary is: ICN-native primitives use ICN-native vocabulary; external systems can be named for what they are.
+
+## Concept words to use carefully
+
+- **"verified"** — only when there is code/test/runtime evidence linked. See [ADR-0033](../adr/ADR-0033-public-maturity-claims-and-evidence-links.md).
+- **"accepted"** — for ADRs and RFCs that have reached accepted status. Not interchangeable with "implemented".
+- **"governance"** — refers to authority and process, not to "admin tools".
+- **"federation"** — a relation between sovereign coops, never a centralized hub.
+- **"institution"** — a governed entity. Not a metaphor.
+
+## Dangerous-action copy
+
+Any action that creates an obligation, casts a vote, dispatches a mandate, settles a position, or rotates a key needs:
+
+1. A short summary of what is about to happen, in plain language.
+2. The mandate or authority that backs it (named, linked).
+3. A reversibility statement: reversible / appealable / final.
+4. The receipt that will be produced, named in advance.
+5. A confirm step that requires explicit user input (not a default-yes button).
+
+Example pattern:
+
+> **You are about to:** record the obligation **"Buy 200 print flyers from co-op press"** under mandate **"Summit print budget Q2"**.
+>
+> **What this does:** creates an `Obligation` record visible to your federation council.
+> **Reversibility:** can be challenged through the dispute path within 14 days.
+> **Receipt:** an `ArtifactReceipt` will be issued and added to your standing view.
+>
+> [ Confirm ]   [ Cancel ]
+
+## Formal record vs summary
+
+A surface that shows ICN data in two layers should label them.
+
+- **Summary** — plain-language, member-readable. Not legally formal.
+- **Formal record** — the canonical record (receipt, ledger entry, governance proof). Always reachable from the summary.
+
+Never show a summary alone for a contested or appealable action — the formal record link must be present.
+
+## Numbers and units
+
+- Always show the unit. Never a bare number for a quantity.
+- Currency-style numbers use locale-appropriate formatting; never strip the unit symbol or code.
+- Time is shown in the member's locale; the formal record carries UTC alongside.
+
+## Translations and language justice
+
+- Plain-language English first pass.
+- Spanish second pass for any surface used by NYC-based or community-org members.
+- The member chooses; never auto-detect from IP.
+- Never machine-translate a formal record. Translate the summary; link to the canonical original.
+
+## Errors
+
+- Tell the member what they can do next. "Try again", "contact support", "wait and retry" are all worse than a specific recoverable action.
+- Never blame the member.
+- Never expose stack traces, internal IDs without context, or unredacted error data on member-facing surfaces.
+
+## What this guide is not
+
+- Not a marketing voice doc.
+- Not a vocabulary lock for institution packages — packages bring their own copy and brand voice on top of the ICN substrate.
+- Not legal review — legal-binding copy goes through a separate review path.
+
+## See also
+
+- [docs/design-language/brief-v0.md](../design-language/brief-v0.md)
+- [docs/design/ACCESSIBILITY_BASELINE.md](ACCESSIBILITY_BASELINE.md)
+- [docs/rfcs/RFC-0001-obligation-allocation-settlement-primitives.md](../rfcs/RFC-0001-obligation-allocation-settlement-primitives.md)
+- [docs/glossary.md](../glossary.md)

--- a/docs/design/ICN_DESIGN_SYSTEM.md
+++ b/docs/design/ICN_DESIGN_SYSTEM.md
@@ -1,0 +1,106 @@
+---
+Status: draft
+Canonical: no
+Owner: Matt Faherty
+Last Reviewed: 2026-04-26
+Last Updated: 2026-04-26
+Purpose: Top-level entry point for the ICN Commons Design System. Anchors visual doctrine, design language, accessibility baseline, content style, and per-surface guidance under one named system.
+---
+
+# ICN Commons Design System
+
+> **One sentence.** ICN looks like democratic infrastructure that ordinary people can actually use — civic, legible, cooperative, technical without being cold.
+
+This document is the entry point. Substance lives in subdocuments. Treat this file as the table of contents; do not duplicate content here.
+
+## What this system covers
+
+ICN is institutional infrastructure for cooperatives, communities, and federations. The design system spans every surface where ICN meets a person:
+
+- public website
+- documentation
+- member shell (the surface a member sees when participating in their institutions)
+- standing view (who the member is, where they have authority, what receipts they hold)
+- action cards (member-facing mandates and authorizations)
+- receipts and provenance views
+- governance flows (proposals, deliberation, mandates, dispute paths)
+- federation, operator, and admin surfaces
+- compute and commons surfaces
+
+It does **not** cover NYCN, Summit, or any specific institution package. Institution packages bring their own brand, their own copy, and their own surfaces; they consume ICN primitives and design tokens, not the other way around.
+
+## Brand position (one paragraph)
+
+ICN is institutional infrastructure, not a crypto product, not project-management SaaS, not a social network. It should feel civic, trustworthy, cooperative, technical, legible, and durable. It should work on a five-year-old phone, in a public library, in three languages the member chose, and in conditions where the member is tired and skeptical.
+
+What ICN must not look like: a venture-backed dashboard, a speculative finance product, a cyberpunk terminal, a gamified social platform, a dead government portal, or AI-vapor futurism.
+
+## Constituent documents
+
+Living docs that make up the system. Read in order on first pass:
+
+| # | Document | Role |
+|---|----------|------|
+| 1 | [docs/design-language/brief-v0.md](../design-language/brief-v0.md) | Canonical design language brief — symbols, scope, member-first framing |
+| 2 | [docs/design/ICN_VISUAL_SYSTEM.md](ICN_VISUAL_SYSTEM.md) | Stable visual doctrine across web, docs, product, demos |
+| 3 | [docs/design-language/concept-map.md](../design-language/concept-map.md) | Shared vocabulary for institutional concepts shown in UI |
+| 4 | [docs/design/ACCESSIBILITY_BASELINE.md](ACCESSIBILITY_BASELINE.md) | Floor for every member-facing surface (WCAG 2.2 AA, plus ICN-specific obligations) |
+| 5 | [docs/design-language/accessibility.md](../design-language/accessibility.md) | Detailed accessibility patterns, copy, and component-level guidance |
+| 6 | [docs/design/CONTENT_STYLE_GUIDE.md](CONTENT_STYLE_GUIDE.md) | Plain language, vocabulary, dangerous-action copy, formal-record markers |
+| 7 | [docs/design/CLAUDE_DESIGN_CONTEXT.md](CLAUDE_DESIGN_CONTEXT.md) | Ready-to-paste design context for Claude Design / external collaborators |
+
+ADRs that bind this work:
+
+- [ADR-0028 — Accessibility Baseline for Member Interfaces](../adr/ADR-0028-accessibility-baseline-for-member-interfaces.md) (`proposed`)
+- [ADR-0027 — Action Card Contract](../adr/ADR-0027-action-card-contract.md) (`proposed`)
+- [ADR-0032 — Website Truth Boundary](../adr/ADR-0032-website-truth-boundary.md) (`accepted`)
+- [ADR-0033 — Public Maturity Claims and Evidence Links](../adr/ADR-0033-public-maturity-claims-and-evidence-links.md) (`proposed`)
+
+## Design principles (compact)
+
+These are the load-bearing rules. The full statement of each lives in the visual system and language brief; this list exists so a reviewer can hold the system in their head.
+
+1. **Make the invisible visible.** Authority, scope, mandates, and receipts must be legible without expert knowledge.
+2. **Member-first.** The person persists across institutional contexts; the institution is the changing context, not the anchor.
+3. **Scope coequality.** Cooperatives, communities, and federations are co-equal forms with different jobs — never depicted as a hierarchy or a ladder.
+4. **Proof must be understandable.** Provenance reveals through progressive disclosure: a one-line answer, then explanation, then raw material.
+5. **Civic seriousness without bureaucratic deadness.** Calm, capable, trustworthy. Never sterile, authoritarian, or theatrical.
+6. **Mobile-first and low-bandwidth.** A five-year-old phone on a slow link is the design target, not the edge case.
+7. **No fake futurism.** No glassmorphism, neon, or "AI sheen" unless it serves clarity. Decoration that doesn't carry meaning is removed.
+8. **Plain language is required, not a courtesy.** If a term needs jargon, it gets a glossary entry; the UI links to the entry.
+9. **Receipts are first-class UI.** A member must be able to read, share, and export a receipt. Receipts are not buried in a settings menu.
+10. **Reduced motion and large tap targets are defaults, not options.** Accessibility is the floor.
+
+## Product-surface obligations (compact)
+
+Each surface has a non-negotiable floor. Detail lives in the accessibility baseline; this is the index.
+
+- **Public website**: WCAG 2.2 AA, no member personal data, maturity-band honesty (see ADR-0032), no NYCN/Summit references.
+- **Documentation**: scannable, link-rich, plain-language summary at the top, formal definitions linked.
+- **Member shell**: identity-aware, scope-aware, never displays an action button without showing the authority that backs it.
+- **Standing view**: a member can read their own standing without help. Includes who attests it and where to challenge it.
+- **Action cards**: every card declares the mandate that authorized it and the receipt produced when it acts.
+- **Receipts and provenance**: progressive disclosure (summary → explanation → raw record), always exportable.
+- **Governance flows**: proposal, deliberation, threshold, decision, receipt — every step legible to a non-expert member.
+- **Federation/operator surfaces**: power asymmetry is shown plainly; operators see the same provenance the member sees, never more.
+- **Compute/commons surfaces**: workload manifest is the member-readable contract, not a hidden config blob.
+
+## Non-goals
+
+- Not a brand kit for a specific institution.
+- Not a token system or a CSS framework. Tokens may follow; this document does not invent them.
+- Not a doctrine that locks navigation models or component APIs.
+- Not a substitute for accessibility testing on real devices with real members.
+
+## How to use this system
+
+- Building a new ICN-native UI? Start with the visual system, then the language brief, then the accessibility baseline.
+- Building an institution package (NYCN, Summit, future federations)? Inherit the design system, add your own brand layer, do not modify ICN-side primitives.
+- Bringing in an external collaborator (Claude Design, agency, contributor)? Hand them [CLAUDE_DESIGN_CONTEXT.md](CLAUDE_DESIGN_CONTEXT.md) verbatim.
+- Adding a new public claim to the website? It is bound by ADR-0032 and ADR-0033 — claim only what proof supports.
+
+## See also
+
+- [docs/strategy/ICN_CONSTITUTIONAL_ROADMAP.md](../strategy/ICN_CONSTITUTIONAL_ROADMAP.md)
+- [docs/architecture/KERNEL_APP_SEPARATION.md](../architecture/KERNEL_APP_SEPARATION.md)
+- [docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md](../architecture/INSTITUTION_PACKAGE_BOUNDARY.md)

--- a/website/src/design/README.md
+++ b/website/src/design/README.md
@@ -1,0 +1,30 @@
+# website/src/design/
+
+Pointer from the website source tree to the ICN Commons Design System.
+
+The design system itself does not live in the website. It lives in the repo's `docs/design/` and `docs/design-language/` directories so that institution packages, member shell, documentation, and demo materials can all share one source.
+
+## Where to read
+
+- [docs/design/ICN_DESIGN_SYSTEM.md](../../../docs/design/ICN_DESIGN_SYSTEM.md) — top-level entry point
+- [docs/design/ICN_VISUAL_SYSTEM.md](../../../docs/design/ICN_VISUAL_SYSTEM.md) — visual doctrine
+- [docs/design-language/brief-v0.md](../../../docs/design-language/brief-v0.md) — design language
+- [docs/design/ACCESSIBILITY_BASELINE.md](../../../docs/design/ACCESSIBILITY_BASELINE.md) — accessibility floor
+- [docs/design/CONTENT_STYLE_GUIDE.md](../../../docs/design/CONTENT_STYLE_GUIDE.md) — voice and vocabulary
+- [docs/design/CLAUDE_DESIGN_CONTEXT.md](../../../docs/design/CLAUDE_DESIGN_CONTEXT.md) — paste-ready collaborator context
+
+## What goes in this directory
+
+Currently nothing. This directory exists as a documented anchor for future work:
+
+- design tokens, if extracted to a shared module
+- per-surface component contracts, if formalized
+- per-surface design notes that are too website-specific for the cross-repo design docs
+
+When something lands here, it must defer to `docs/design/*` for principles, not redefine them.
+
+## What does not go in this directory
+
+- Brand kits for any specific institution package. Institution packages live in their own repos.
+- References to specific institution packages or events. ICN is generic substrate; package-specific design lives in the package's own repo.
+- Member personal data, even as fixtures.


### PR DESCRIPTION
## Summary

Adds the ICN Commons Design System foundation: a top-level entry point, paste-ready Claude Design context, content style guide, and accessibility baseline. Does not duplicate the existing visual doctrine and design-language briefs.

## Files added

- New file at docs/design/ICN_DESIGN_SYSTEM.md - top-level entry point. References existing ICN visual system and design-language docs rather than restating them.
- New file at docs/design/CLAUDE_DESIGN_CONTEXT.md - short paste-ready context for Claude Design or any external collaborator.
- New file at docs/design/CONTENT_STYLE_GUIDE.md - voice, vocabulary table for obligation/allocation/settlement primitives, dangerous-action confirmation copy.
- New file at docs/design/ACCESSIBILITY_BASELINE.md - design-layer floor anchored on ADR-0028 and WCAG 2.2 AA.
- New file at website/src/design/README.md - pointer from the website source tree to the cross-repo design docs.

## Why

ICN already has substantial visual and design-language docs. What was missing:

- a named entry point that knits them together
- a paste-ready Claude Design or external-collaborator brief
- an explicit content style guide locking the regulatory-safe vocabulary across UI copy
- a design-layer accessibility baseline, separate from component-level patterns

## Design principles (compact)

1. Make the invisible visible
2. Member-first
3. Scope coequality
4. Proof must be understandable
5. Civic seriousness without bureaucratic deadness
6. Mobile-first and low-bandwidth
7. No fake futurism
8. Plain language is required
9. Receipts are first-class UI
10. Reduced motion and large tap targets are defaults

## Accessibility baseline

WCAG 2.2 AA is the floor. Per-surface obligations defined for: public website, documentation, member shell, standing view, action cards, receipts and provenance, governance flows, federation and operator, compute and commons. Anchors on ADR-0028.

## Validation

- doc_control_check.py --strict: PASS, 729 docs. 4 new yaml-mismatch warnings on new files (Status draft vs registry default truth_class descriptive); non-blocking.
- npm run build for the website: PASS (749 pages built)
- npm run lint for the website: PASS (0 errors, 0 warnings, 0 hints)
- grep NYCN/Summit/reference-federation in website/src: CLEAN
- git diff --check: clean

## Non-goals

- No runtime changes
- No changes to existing visual system or design-language docs
- No public website content changes (no .astro files modified)
- No NYCN, Summit, or reference-federation references in website/src
- Not a token system or CSS framework
- Not a brand kit for any specific institution package

## Refs

- ADR-0028 (Accessibility Baseline for Member Interfaces)
- ADR-0032 (Website Truth Boundary)
- ADR-0033 (Public Maturity Claims and Evidence Links)
- RFC-0001 (Obligation/Allocation/Settlement Primitives and External Settlement Bridges)