### PR TITLE
docs(rfc): draft public surface and learning repo architecture

### DIFF
--- a/docs/rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md
+++ b/docs/rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md
@@ -1,0 +1,256 @@
+---
+id: "0015"
+title: "Public Surface and Learning Repo Architecture"
+status: "draft"
+created: "2026-04-27"
+updated: "2026-04-27"
+authors: ["Matt Faherty"]
+reviewers: []
+related_adr_candidates: ["0028", "0032", "0033", "0034"]
+related_issues: []
+supersedes: []
+superseded_by: []
+---
+
+# RFC 0015: Public Surface and Learning Repo Architecture
+
+## Status
+
+`draft` — being written, not yet ready for review.
+
+This RFC clarifies how ICN's public-facing identity is split across multiple domains and across multiple repos, and defines a future learning/onboarding repo (deploying to `learn.icn.zone`) without creating it in this RFC.
+
+**Accepted RFC does not mean implemented.** This RFC is doctrinal coordination; the follow-up work is repo creation and content authoring, both of which happen outside this RFC.
+
+## Summary
+
+ICN currently confuses three things into one surface: the canonical public truth about ICN (intercooperative.network), utility routing for cluster endpoints and short links (icn.zone and its subdomains), and the future role-based learning/onboarding material that should not pollute the canonical site (a future `learn.icn.zone`). This RFC names six domains, assigns each a single role, and defines a future learning repo that teaches ICN without claiming the authority to define ICN. It explicitly does **not** create that repo, build that site, or change DNS — those are follow-up tasks.
+
+## Problem statement
+
+The project currently has more domains than well-defined surfaces. Several distinct concerns are conflated, which produces drift over time:
+
+- **Canonical truth** is mixed with **marketing**, **onboarding pedagogy**, and **operational endpoints**. Without naming each surface separately, contributors land doc and content changes in whichever repo or branch is closest to hand, and the public site slowly accumulates onboarding content that should live elsewhere.
+- **Onboarding and curriculum** ("how to join", "how to contribute as a developer / designer / organizer / operator / cooperative partner") have no home. Putting them on intercooperative.network risks (a) overclaiming program maturity per ADR-0032 and ADR-0033, and (b) burying the canonical truth surface under teaching material.
+- **Adjacent surfaces** (a future Cooperative Systems Institute, a future Summit/event/convergence surface, Matt's personal hub) need to exist as named possibilities with assigned roles so they do not later silently take over the ICN identity.
+- **`icn.zone` is already documented** ([docs/deployment/ICN_ZONE_ROUTING.md](../deployment/ICN_ZONE_ROUTING.md)) as utility routing with a redirect at root. That decision is correct and should be preserved here.
+
+The cost of leaving this implicit: the public truth surface keeps drifting, contributors don't know where to put new content, and the project ships either an overclaiming front page or an underexplained one.
+
+## Goals
+
+- Name every public-facing domain ICN currently controls or anticipates, with one role each.
+- Make explicit the rule that a learning/onboarding surface lives in a separate repo and a separate domain.
+- Preserve the canonical truth boundary at intercooperative.network (ADR-0032, ADR-0033).
+- Preserve the `icn.zone` utility routing model documented in [docs/deployment/ICN_ZONE_ROUTING.md](../deployment/ICN_ZONE_ROUTING.md).
+- Define the future `learn.icn.zone` learning repo's purpose, guardrails, and content areas — without committing to its content here.
+- Keep the regulatory-safe vocabulary discipline (RFC-0001, [docs/design/CONTENT_STYLE_GUIDE.md](../design/CONTENT_STYLE_GUIDE.md)) intact across surfaces.
+- Keep the public website free of NYCN, "New York Cooperative Network", "Summit", "reference federation", or "first institution package" references.
+
+## Non-goals
+
+This RFC explicitly does **not**:
+
+- Create a third repo (`InterCooperative-Network/icn-learn` or any other).
+- Build the `learn.icn.zone` site.
+- Draft the curriculum.
+- Change DNS records.
+- Change Cloudflare configuration.
+- Move existing developer or contributor docs out of the main ICN repo.
+- Make the public ICN website mention NYCN, Summit, reference federation, or any institution package.
+- Create content for `cooperative-systems.org` or `thesync.net`.
+- Decide what `faherty.network` contains — only its role.
+- Mass-rename archived wallet or mobile docs (those are a separate scoped change).
+
+## Background / current state
+
+- **Canonical site**: `intercooperative.network`. Live, GitHub-Pages-deployed, sourced from `website/src/` in this repo. Bound by [ADR-0032 — Website Truth Boundary](../adr/ADR-0032-website-truth-boundary.md) and [ADR-0033 — Public Maturity Claims and Evidence Links](../adr/ADR-0033-public-maturity-claims-and-evidence-links.md).
+- **Utility routing**: `icn.zone` plus `api.icn.zone`, `pilot.icn.zone`, `metrics.icn.zone`. Documented in [docs/deployment/ICN_ZONE_ROUTING.md](../deployment/ICN_ZONE_ROUTING.md). Root redirect to `intercooperative.network` is the entire root behavior; subdomains serve K3s endpoints.
+- **No onboarding home**: ICN has rich docs in this repo (`docs/onboarding/`, `docs/getting-started`, `docs/development/`), but no single learner-facing site. Material that wants to be progressive ("welcome → orientation → deep dive") has no home.
+- **Adjacent ideas have surfaced**: a future Cooperative Systems Institute (broader theory/research/field-building) and a future Summit/event surface (`thesync.net`) have been mentioned in planning conversations but never assigned a doctrinal role.
+- **NYCN / Summit content is already segregated**: the NYCN repo (private) holds NYCN- and Summit-specific docs and assets per the boundary established in PR #9 and the [ICN_DESIGN_SYSTEM.md](../design/ICN_DESIGN_SYSTEM.md) "no NYCN/Summit on the public ICN website" rule.
+- **The project has an RFC process**: see [RFC-0000](RFC-0000-rfc-process.md). This RFC follows that lifecycle.
+
+## Design options
+
+### Option A — Single canonical site, ad-hoc onboarding
+
+Keep onboarding and curriculum inside this repo. Add a `learn/` section under `intercooperative.network`. Treat any future `learn.icn.zone` as a CNAME to a path on the canonical site. Adjacent surfaces (`cooperative-systems.org`, `thesync.net`) are deferred until they have content.
+
+### Option B — Separate learning repo + named domain roles (recommended)
+
+Define one role per domain:
+
+| Domain | Role |
+|--------|------|
+| intercooperative.network | Canonical ICN public truth surface |
+| icn.zone | Utility routing — short links, QR, redirects, cluster subdomains |
+| learn.icn.zone | Future role-based learning/onboarding site, separate repo |
+| cooperative-systems.org | Future Cooperative Systems Institute; broader field-building |
+| thesync.net | Future Summit/event/demo/convergence surface |
+| faherty.network | Matt's personal/professional hub; points at the work, doesn't define it |
+
+Create a future repo `InterCooperative-Network/icn-learn` for `learn.icn.zone` content. That repo teaches ICN; it does not define ICN. Architecture, ADRs, RFCs, state, and code remain in this repo. The learning repo references canonical truth via deep links rather than rewriting it.
+
+### Option C — Single super-repo / monorepo
+
+Pull all content into this repo: canonical site, learning, future Cooperative Systems Institute, future Summit/event surface. Use path-based routing or build pipelines to deploy to multiple domains from one source.
+
+## Tradeoffs
+
+| Option | Easier | Harder | Invariants preserved | Invariants stressed | New failure modes | Cost |
+|--------|--------|--------|----------------------|---------------------|--------------------|------|
+| A | Adding onboarding content fast | Keeping ADR-0032/0033 truth boundary; preventing curriculum from overclaiming program maturity; finding canonical truth amid teaching | Single source of build artifacts | Canonical truth boundary; member-first information design | Curriculum gradually rewrites canonical claims; public site becomes an explainer instead of a truth surface | Low up-front; high later (cleanup) |
+| **B** (recommended) | Keeping canonical truth surface clean; letting curriculum evolve at its own cadence; keeping NYCN/Summit boundaries intact; future repos start with explicit guardrails | Maintaining cross-repo links; coordinating two release cadences | Truth boundary; meaning firewall; institution-package boundary; vocabulary discipline | Cross-repo navigation requires deliberate UX | Stale cross-repo links; duplicated explanations if the learning repo is not disciplined | Modest — new repo + deploy target |
+| C | Single deploy pipeline | Every constraint above (truth boundary, institution boundary, surface separation) routed through path-based hacks | None — actively erodes most of them | All of them | Single repo becomes the everything-bucket; new contributors can't tell what the canonical truth is | High in coupling; rework cost when surfaces diverge |
+
+Option B is recommended. The canonical site stays small, evidence-bound, and stable. The learning repo can iterate fast without touching the truth surface. Adjacent surfaces (`cooperative-systems.org`, `thesync.net`) have named roles waiting for them when content exists.
+
+## Core/package boundary
+
+This RFC is doctrinal: it defines surface separation, not a runtime contract. It nonetheless interacts with the kernel/app and institution-package boundaries:
+
+- The canonical public site sources content from this repo. Public claims are bound by ADR-0032 and ADR-0033; they may not silently encode institution-package vocabulary.
+- The future learning repo consumes ICN substrate documentation. It does not define ICN primitives, ADRs, or RFCs. Its README must declare this guardrail explicitly.
+- The institution-package boundary stays at the NYCN/ICN seam. The learning repo can teach how to use ICN with an institution package conceptually; it must not encode any specific institution package as canonical.
+- The vocabulary discipline ([docs/design/CONTENT_STYLE_GUIDE.md](../design/CONTENT_STYLE_GUIDE.md)) applies to every surface: obligation/allocation/settlement/unit/position/settlement asset/external settlement instruction/bridge receipt for ICN-native primitives; payment/wallet/balance/currency only when describing external systems on their own terms.
+
+## Accessibility implications
+
+The learning repo is the highest-leverage accessibility surface in the ecosystem because it is where new contributors meet ICN.
+
+- The future `learn.icn.zone` site must inherit [docs/design/ACCESSIBILITY_BASELINE.md](../design/ACCESSIBILITY_BASELINE.md) (WCAG 2.2 AA floor; plain language; mobile-first; low-bandwidth; reduced motion; multilingual support paths).
+- Curriculum content must use plain language, with glossary linkage rather than expert-only phrasing.
+- Role-based paths (developer / designer / organizer / cooperative partner / node operator / tester / researcher / communications / educator / maintainer / trusted collaborator) must each have a phone-readable, low-bandwidth-readable entry point.
+- The canonical public site keeps its current accessibility commitments; this RFC neither raises nor lowers that floor.
+
+## Conflict / dispute path
+
+This RFC defines a doctrinal split, not a runtime mechanism. If a downstream change attempts to put learning material on the canonical site or canonical truth on the learning site, the resolution path is:
+
+- Reviewer flags the surface violation in PR review.
+- Author moves content to the correct surface.
+- If the question is whether content belongs on the canonical site at all, ADR-0032 governs.
+- If the question is whether content overclaims program maturity, ADR-0033 governs.
+- This RFC is not the venue for relational conflicts (those route through ADR-0029 once accepted).
+
+## Security / privacy implications
+
+- Splitting surfaces reduces leak risk: curriculum and onboarding flows that expect input from learners (forms, contact, accounts) live on a separate domain from the canonical truth surface, so a future contact form on `learn.icn.zone` does not put PII on the canonical site.
+- The canonical site remains static, member-data-free, and low-attack-surface.
+- DNS posture is unchanged by this RFC; that is a Non-goal.
+- Cross-domain analytics, if ever introduced, must be opt-in and must respect [docs/design/CONTENT_STYLE_GUIDE.md](../design/CONTENT_STYLE_GUIDE.md) and accessibility baseline.
+
+## Compute / automation boundary
+
+Compute is not directly involved. Build pipelines deploying multiple sites must remain deterministic and reproducible. No runtime authority flows through these surfaces; they are static and informational.
+
+## Website / public truth implications
+
+- `intercooperative.network` remains the only surface bound by ADR-0032 and ADR-0033.
+- `learn.icn.zone` is **not** a truth surface. It teaches; it does not claim. Maturity-band statements about ICN primitives must defer to the canonical site or to ADRs cited by deep link.
+- `icn.zone` has no truth content; it is utility routing.
+- `cooperative-systems.org` and `thesync.net` are not yet content-bearing; their truth posture is to be defined when they have content.
+- `faherty.network` is personal; it does not carry ICN truth claims.
+
+The canonical site continues to enforce: no NYCN, no "New York Cooperative Network", no "Summit", no "reference federation", no "first institution package".
+
+## Migration / compatibility
+
+- No existing content moves in this RFC. The current `intercooperative.network` source under `website/src/` is unchanged.
+- The existing `icn.zone` redirect at root (per [docs/deployment/ICN_ZONE_ROUTING.md](../deployment/ICN_ZONE_ROUTING.md)) is preserved.
+- Existing onboarding docs in `docs/onboarding/`, `docs/getting-started`, and `docs/development/` remain in place. They may eventually be referenced from the future learning repo via deep link, but no migration is forced.
+- No archived wallet or mobile docs are renamed by this RFC.
+
+## Open questions
+
+- Should the learning repo and the canonical site share design tokens once those exist, or should each keep an independent visual layer?
+- Should `learn.icn.zone` present an "I am a [developer / designer / organizer / cooperative partner / node operator / tester / researcher]" picker on first visit, or should role paths be discoverable through navigation?
+- What is the canonical-truth deep-link convention from the learning repo to ICN ADRs and RFCs? Permalink anchors? Versioned references?
+- Does Cooperative Systems Institute (`cooperative-systems.org`) deserve its own RFC when it has content, or is it a reuse of this surface model?
+- Does `thesync.net` need its own RFC, or is the surface model from this RFC sufficient when content is ready?
+
+## Decision criteria
+
+Pick **Option B** if:
+
+- The project intends to keep ADR-0032's truth-boundary discipline.
+- The project intends to grow role-based onboarding without overclaiming program maturity.
+- The project values cross-repo navigation cost less than monorepo coupling cost.
+
+Pick **Option A** only if:
+
+- The project is willing to absorb learning content under the canonical site and accepts the truth-boundary stress that creates.
+
+Pick **Option C** only if:
+
+- The project commits to building a single deployment pipeline that can route per-domain content correctly *and* enforce per-surface truth posture inside one repo.
+
+## Outcome
+
+To be filled in when this RFC moves to `accepted` or `rejected`. If accepted, the follow-up work is enumerated under "Follow-up implementation issues" below; this RFC does not produce ADRs by itself, but a small ADR may follow if cross-surface deployment policy needs to be recorded.
+
+## Follow-up ADRs
+
+If accepted, this RFC may produce:
+
+- An ADR recording the canonical-site / learning-site truth-boundary policy (the rule that learning material may not encode canonical truth claims and must defer via deep link).
+- A small ADR describing the cross-domain deployment guardrail (per-domain build, no shared analytics without opt-in, vocabulary discipline carried across surfaces).
+
+ADRs are not pre-allocated in this RFC; they will be enumerated when this RFC moves toward `accepted`.
+
+## Follow-up implementation issues
+
+If accepted, the project should open issues to:
+
+1. Create `InterCooperative-Network/icn-learn` repo with explicit README guardrail: "This repo teaches ICN. It does not define ICN. Canonical architecture, implementation status, ADRs, RFCs, contribution rules, and runtime documentation live in the main ICN repo."
+2. Scaffold the static site for `learn.icn.zone` (build target chosen by the new repo's contributors; not constrained here).
+3. Add the README guardrail in #1 with explicit links back to the main ICN repo's `README.md`, `docs/INDEX.md`, `docs/STATE.md`, and `docs/rfcs/RFC-0000-rfc-process.md`.
+4. Add a first curriculum structure in icn-learn organized by role:
+   - universal ICN orientation
+   - developer path
+   - docs/writer path
+   - designer / member-experience path
+   - accessibility path
+   - organizer path
+   - cooperative partner path
+   - node operator path
+   - tester / QA path
+   - researcher path
+   - communications / outreach path
+   - educator / facilitator path
+   - maintainer / steward path
+   - trusted collaborator path
+   - generic institution-package onboarding hooks (no specific package named)
+   - glossary and language drills
+   - exercises, workshops, templates
+   - "where truth lives" reference page
+5. Add canonical-doc references back to this repo using a stable deep-link convention.
+6. Add a domain-map reference page in icn-learn naming the six domains and their roles.
+7. Add vocabulary and public-claims discipline to icn-learn's contribution guide (carry [CONTENT_STYLE_GUIDE.md](../design/CONTENT_STYLE_GUIDE.md) discipline across).
+8. Configure the deployment target for `learn.icn.zone` (specific provider chosen at repo-creation time).
+9. Configure DNS for `learn.icn.zone` only after the repo and site exist and pass an internal review.
+10. Later: update the canonical site's "Get involved" content (currently in [website/src/pages/get-involved.astro](../../website/src/pages/get-involved.astro)) to link into `learn.icn.zone` once that site is live, replacing or augmenting in-repo onboarding pointers as appropriate.
+
+These are pointers, not commitments. The follow-up work happens after this RFC reaches `accepted` (or its substance is rolled into a smaller, faster decision).
+
+## Validation / proof plan
+
+This RFC is doctrinal. "Proof" of acceptance is structural:
+
+- A future PR creates `InterCooperative-Network/icn-learn` with the README guardrail.
+- A future PR adds the canonical-truth deep-link convention.
+- A future deployment connects the new repo's build artifact to `learn.icn.zone`.
+- The canonical `intercooperative.network` build remains green and continues to pass:
+  - `python3 docs/scripts/doc_control_check.py --strict`
+  - `cd website && npm run build && npm run lint`
+  - `grep -RIE 'NYCN|New York Cooperative|reference federation|Summit|first institution package' website/src/` returns clean
+- ADR-0032 / ADR-0033 enforcement remains the truth gate for the canonical site; no exception is created here.
+
+---
+
+## Notes
+
+- This RFC is a small, deliberate piece. It does not draft curriculum, create repos, or change DNS. Its job is to make those follow-ups possible without re-opening the surface debate later.
+- For *amendments* during `draft`, edit in place and bump `updated`.
+- This RFC's relationship to ADR-0032 and ADR-0033 is downstream: it extends the truth-boundary doctrine across multiple domains rather than concentrating it on one site.

--- a/docs/rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md
+++ b/docs/rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md
@@ -66,7 +66,7 @@ This RFC explicitly does **not**:
 
 - **Canonical site**: `intercooperative.network`. Live, GitHub-Pages-deployed, sourced from `website/src/` in this repo. Bound by [ADR-0032 — Website Truth Boundary](../adr/ADR-0032-website-truth-boundary.md) and [ADR-0033 — Public Maturity Claims and Evidence Links](../adr/ADR-0033-public-maturity-claims-and-evidence-links.md).
 - **Utility routing**: `icn.zone` plus `api.icn.zone`, `pilot.icn.zone`, `metrics.icn.zone`. Documented in [docs/deployment/ICN_ZONE_ROUTING.md](../deployment/ICN_ZONE_ROUTING.md). Root redirect to `intercooperative.network` is the entire root behavior; subdomains serve K3s endpoints.
-- **No onboarding home**: ICN has rich docs in this repo (`docs/onboarding/`, `docs/getting-started`, `docs/development/`), but no single learner-facing site. Material that wants to be progressive ("welcome → orientation → deep dive") has no home.
+- **No onboarding home**: ICN has rich docs in this repo (`docs/onboarding/`, `docs/GETTING_STARTED.md`, `docs/development/`), but no single learner-facing site. Material that wants to be progressive ("welcome → orientation → deep dive") has no home.
 - **Adjacent ideas have surfaced**: a future Cooperative Systems Institute (broader theory/research/field-building) and a future Summit/event surface (`thesync.net`) have been mentioned in planning conversations but never assigned a doctrinal role.
 - **NYCN / Summit content is already segregated**: the NYCN repo (private) holds NYCN- and Summit-specific docs and assets per the boundary established in PR #9 and the [ICN_DESIGN_SYSTEM.md](../design/ICN_DESIGN_SYSTEM.md) "no NYCN/Summit on the public ICN website" rule.
 - **The project has an RFC process**: see [RFC-0000](RFC-0000-rfc-process.md). This RFC follows that lifecycle.
@@ -159,7 +159,7 @@ The canonical site continues to enforce: no NYCN, no "New York Cooperative Netwo
 
 - No existing content moves in this RFC. The current `intercooperative.network` source under `website/src/` is unchanged.
 - The existing `icn.zone` redirect at root (per [docs/deployment/ICN_ZONE_ROUTING.md](../deployment/ICN_ZONE_ROUTING.md)) is preserved.
-- Existing onboarding docs in `docs/onboarding/`, `docs/getting-started`, and `docs/development/` remain in place. They may eventually be referenced from the future learning repo via deep link, but no migration is forced.
+- Existing onboarding docs in `docs/onboarding/`, `docs/GETTING_STARTED.md`, and `docs/development/` remain in place. They may eventually be referenced from the future learning repo via deep link, but no migration is forced.
 - No archived wallet or mobile docs are renamed by this RFC.
 
 ## Open questions

--- a/ops/coordination/README.md
+++ b/ops/coordination/README.md
@@ -94,8 +94,13 @@ A single concern often appears in both — first as an RFC candidate (design spa
 - [ADR-0018](../../docs/adr/ADR-0018-adr-lifecycle-and-canonical-decision-index.md) governs ADR lifecycle.
 - Issue numbers in registry rows are pointers, not promises. Issues may be closed without the ADR landing, and ADRs may land without an issue.
 
+## Cross-surface architecture
+
+Public-surface and learning-repo architecture (the role split across `intercooperative.network`, `icn.zone`, future `learn.icn.zone`, and adjacent domains) is tracked by [RFC-0015](../../docs/rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md).
+
 ## See also
 
 - [docs/rfcs/](../../docs/rfcs/) — RFC documents (RFC-0000 is the seed)
 - [docs/adr/](../../docs/adr/) — ADR decision receipts
 - [docs/strategy/ICN_CONSTITUTIONAL_ROADMAP.md](../../docs/strategy/ICN_CONSTITUTIONAL_ROADMAP.md) — long-arc architectural roadmap
+- [docs/deployment/ICN_ZONE_ROUTING.md](../../docs/deployment/ICN_ZONE_ROUTING.md) — `icn.zone` utility routing plan

--- a/ops/coordination/rfc_candidates.yaml
+++ b/ops/coordination/rfc_candidates.yaml
@@ -776,3 +776,74 @@ candidates:
       - "ADR for cooperative conversion support multi-stage flow"
       - "Issues for support-institution type definitions, service-agreement schema, receipt extension"
     priority: soon
+
+  - id: "0015"
+    title: "Public Surface and Learning Repo Architecture"
+    status: drafted
+    rfc_path: "docs/rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md"
+    domain: website
+    why_it_matters: |
+      ICN's public-facing identity is currently split across multiple
+      domains with overlapping or undefined roles
+      (intercooperative.network as canonical truth, icn.zone as utility
+      routing, plus future learn.icn.zone, cooperative-systems.org,
+      thesync.net, faherty.network). Without an explicit role
+      assignment, onboarding/curriculum content drifts onto the
+      canonical site and erodes ADR-0032's truth boundary; learning
+      material has no separate home; adjacent surfaces silently
+      compete for the ICN identity. The RFC names six domains, assigns
+      each a single role, and defines a future learning/onboarding
+      repo (deploying to learn.icn.zone) without creating it.
+    related_adr_candidates: ["0028", "0032", "0033", "0034"]
+    related_issues: []
+    related_docs:
+      - "docs/deployment/ICN_ZONE_ROUTING.md"
+      - "docs/design/ICN_DESIGN_SYSTEM.md"
+      - "docs/design/CONTENT_STYLE_GUIDE.md"
+      - "docs/design/ACCESSIBILITY_BASELINE.md"
+    related_future_repos:
+      - "InterCooperative-Network/icn-learn"
+    related_future_domains:
+      - "learn.icn.zone"
+      - "cooperative-systems.org"
+      - "thesync.net"
+      - "faherty.network"
+    design_questions:
+      - "Should the future learning repo and the canonical site share design tokens, or each keep an independent visual layer?"
+      - "Should learn.icn.zone present a role picker on first visit, or surface role paths through navigation?"
+      - "What is the canonical-truth deep-link convention from learning material to ICN ADRs and RFCs?"
+      - "Does cooperative-systems.org deserve its own RFC when it has content, or is it a reuse of this surface model?"
+      - "Does thesync.net need its own RFC, or is the surface model from this RFC sufficient when content is ready?"
+    icn_runtime_surface: "doctrinal — no kernel/runtime surface; downstream affects website source and deployment configuration"
+    package_or_institution_expression: |
+      Institution packages remain in their own repos. Public-facing
+      institution-package mentions stay off the canonical ICN site;
+      learning material may explain how packages work without naming
+      specific packages as canonical.
+    accessibility_implications: |
+      The future learn.icn.zone is the highest-leverage accessibility
+      surface in the ecosystem because it is where new contributors
+      meet ICN. It must inherit the accessibility baseline (ADR-0028,
+      docs/design/ACCESSIBILITY_BASELINE.md): WCAG 2.2 AA, plain
+      language, mobile-first, low-bandwidth, reduced motion,
+      multilingual support paths.
+    conflict_or_dispute_path: |
+      Surface-violation conflicts (curriculum on canonical site or
+      canonical truth on learning site) resolve through ADR-0032 /
+      ADR-0033 enforcement during PR review.
+    compute_or_automation_boundary: |
+      No runtime compute. Build pipelines must remain deterministic
+      and reproducible across surfaces.
+    website_truth_implication: |
+      intercooperative.network remains the only ADR-0032/ADR-0033 truth
+      surface. learn.icn.zone is not a truth surface; it teaches via
+      deep links to canonical material. icn.zone has no truth content.
+      Adjacent domains' truth posture is defined when they have content.
+    proposed_outputs:
+      - "Future PR creating InterCooperative-Network/icn-learn with README guardrail"
+      - "Future PR scaffolding learn.icn.zone static site"
+      - "Future PR adding role-based curriculum structure"
+      - "Future PR adding canonical-truth deep-link convention"
+      - "Future PR linking canonical site Get-Involved into learn.icn.zone once the site is live"
+      - "Possible small ADR recording cross-surface deployment / truth-boundary policy"
+    priority: soon


### PR DESCRIPTION
## Summary

Drafts RFC-0015, a doctrinal RFC that names every public-facing domain ICN currently controls or anticipates and assigns each a single role. Recommends Option B (separate learning repo with named domain roles). Does not create the learning repo, build any site, or change DNS — those are explicit non-goals.

## Domain model

| Domain | Role |
|--------|------|
| intercooperative.network | Canonical ICN public truth surface (bound by ADR-0032 and ADR-0033) |
| icn.zone | Utility routing — short links, QR, redirects, cluster subdomains; root redirects to intercooperative.network per docs/deployment/ICN_ZONE_ROUTING.md |
| learn.icn.zone | Future role-based learning/onboarding site; separate repo; not a truth surface; teaches via deep links to canonical material |
| cooperative-systems.org | Future Cooperative Systems Institute / broader public field-building surface |
| thesync.net | Future Summit/event/demo/convergence surface |
| faherty.network | Personal/professional hub; points at the work, does not define the project |

## Repo boundary

- **Main ICN repo (this repo)** — code, ADRs, RFCs, architecture docs, state docs, implementation docs, contribution rules, deployment docs, public website source, design-system source. Anything that must move with implementation truth.
- **NYCN repo (private)** — NYCN institution package, Summit-specific docs/assets/config, public/private asset policy, ICN dependency lock, package proof/status docs.
- **Future learning repo** — proposed name `InterCooperative-Network/icn-learn`, deploys to `learn.icn.zone`. Teaches ICN; does not define ICN. Must include README guardrail referring to the main ICN repo for canonical truth.

## learn.icn.zone future repo

The RFC enumerates intended content areas for the future learning site (universal orientation; developer / docs / designer / accessibility / organizer / cooperative partner / node operator / tester / researcher / communications / educator / maintainer / trusted collaborator paths; glossary and language drills; exercises, workshops, templates; reference page for "where truth lives"). It does **not** draft any of that content here.

## Non-goals (explicit)

- Does not create `InterCooperative-Network/icn-learn` repo
- Does not build the learn.icn.zone site
- Does not change DNS or Cloudflare configuration
- Does not move existing developer or contributor docs
- Does not make the public ICN website mention NYCN, Summit, reference federation, or first institution package
- Does not create content for cooperative-systems.org or thesync.net
- Does not draft the curriculum
- Does not mass-rename archived wallet/mobile docs

## Files added / changed

- New: `docs/rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md` — full RFC body following the template (status: draft).
- Updated: `ops/coordination/rfc_candidates.yaml` — adds RFC-0015 row (status: drafted, priority: soon) with related_adr_candidates [0028, 0032, 0033, 0034], related_docs (ICN_ZONE_ROUTING, ICN_DESIGN_SYSTEM, CONTENT_STYLE_GUIDE, ACCESSIBILITY_BASELINE), related_future_repos (InterCooperative-Network/icn-learn), related_future_domains (learn.icn.zone, cooperative-systems.org, thesync.net, faherty.network).
- Updated: `ops/coordination/README.md` — one-line cross-surface architecture pointer to RFC-0015 plus See-also entry for ICN_ZONE_ROUTING.md.

## Validation

- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml --strict` — PASS, 730 docs, 36 pre-existing warnings (no new warnings introduced).
- `grep -RIE 'NYCN|New York Cooperative|reference federation|Summit|first institution package' website/src/` — CLEAN
- `git diff --check` — clean
- No website/src changes; no website build needed.

## Follow-ups (deferred to future PRs)

1. Create `InterCooperative-Network/icn-learn` repo with explicit README guardrail.
2. Scaffold the static site for `learn.icn.zone`.
3. Add the README guardrail with canonical-doc references back to this repo.
4. Add a first role-based curriculum structure.
5. Add canonical-truth deep-link convention.
6. Add domain-map reference page in icn-learn.
7. Carry vocabulary/public-claims discipline (CONTENT_STYLE_GUIDE.md) across surfaces.
8. Configure deployment target for `learn.icn.zone`.
9. Configure DNS only after the repo and site exist.
10. Later: update the canonical site Get-Involved links into `learn.icn.zone` once that site is live.

## Refs

- ADR-0028 (Accessibility Baseline for Member Interfaces)
- ADR-0032 (Website Truth Boundary)
- ADR-0033 (Public Maturity Claims and Evidence Links)
- ADR-0034 (ADR Candidate Registry as Architectural Memory)
- docs/deployment/ICN_ZONE_ROUTING.md (existing icn.zone routing plan)
