### PR TITLE
docs(site): add cooperative economy framing

### DIFF
--- a/website/src/pages/cooperative-economy.astro
+++ b/website/src/pages/cooperative-economy.astro
@@ -1,0 +1,230 @@
+---
+import Layout from '../layouts/Layout.astro';
+import MaturityBadge from '../components/MaturityBadge.astro';
+---
+
+<Layout
+  title="The Cooperative Economy Needs Its Own Machinery"
+  activeNav="what-is-icn"
+  description="Credit unions, fiscal sponsors, and CDFIs help cooperatives interface with the existing economy. ICN is the machinery a cooperative economy needs on its own side of the bridge."
+>
+
+  <section class="section" style="padding-top: calc(64px + var(--space-3xl));">
+    <div class="container narrow">
+      <div class="page-hero">
+        <span class="badge badge-teal">A framing</span>
+        <h1>The cooperative economy needs its own machinery.</h1>
+        <p class="lead">
+          Credit unions, fiscal sponsors, CDFIs, and cooperative lenders show one half of the pattern.
+          They help cooperative institutions and their members interface with the existing economy
+          without becoming ordinary commercial banks. They are bridges.
+        </p>
+        <p class="lead">
+          A bridge is not a city. A bridge lets you cross into someone else's system. It does not build
+          the machinery of your own. ICN is about the other half: the shared machinery a cooperative
+          economy needs on its own side of the bridge.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section-alt">
+    <div class="container narrow prose">
+      <h2>Bridges help cooperatives survive the existing economy</h2>
+      <p>
+        Cooperatives operate inside a financial and legal world they did not build. Money has to move
+        across regulated rails. Taxes have to be filed. Loans have to clear underwriting. Grants
+        have to be received by an entity the funder recognizes. Insurance has to attach to a real
+        policy on file with a real insurer.
+      </p>
+      <p>
+        A handful of institutions exist specifically to help cooperatives meet those requirements
+        without abandoning cooperative principles:
+      </p>
+      <ul>
+        <li><strong>Credit unions</strong> hold deposits and clear obligations between members and the wider economy.</li>
+        <li><strong>Community development financial institutions</strong> route capital toward cooperative and community-owned work.</li>
+        <li><strong>Cooperative lenders</strong> underwrite cooperative conversions, expansions, and operating capacity.</li>
+        <li><strong>Fiscal sponsors</strong> let new or unincorporated cooperative work receive grants and contributions through an established legal entity.</li>
+        <li><strong>Public and community banks</strong>, where they exist, provide a public-mission alternative to private banking.</li>
+        <li><strong>Accountants, bookkeepers, and legal / co-op developers</strong> translate cooperative practice into the books, filings, and contracts the wider economy expects.</li>
+        <li><strong>Technical assistance organizations</strong> teach, mentor, and help cooperatives form, scale, convert, and weather crises.</li>
+      </ul>
+      <p>
+        These are bridge institutions. They do indispensable work. The cooperative economy survives in
+        large part because they exist.
+      </p>
+
+      <h2>Bridges are necessary but not sufficient</h2>
+      <p>
+        A bridge handles the crossing. It does not handle what happens on either side of it.
+      </p>
+      <p>
+        Once a cooperative is on its own ground, it still has to do the work of being a cooperative:
+        recognize who is a member; carry the rules the membership agreed to; make decisions and have
+        them count; authorize action; carry obligations between members and between cooperatives;
+        allocate shared resources; settle positions inside the cooperative economy; produce receipts
+        the institution can stand behind; preserve institutional memory across years and across
+        people; and coordinate credibly with other cooperatives without being absorbed into them.
+      </p>
+      <p>
+        That work is not bridge work. It is everyday cooperative work. And there is no bridge
+        institution whose job is to provide the digital infrastructure for it.
+      </p>
+
+      <h2>The cooperative economy still runs on borrowed machinery</h2>
+      <p>
+        Right now, most cooperatives carry that everyday work on tools that were built for firms,
+        platforms, or administrative convenience. Documents and email run on Google Workspace or
+        Microsoft 365. Voting runs on Loomio. Books run on QuickBooks. Coordination runs on Slack
+        or Teams. Membership often lives in a CRM built for a sales team. Each tool is fine in
+        isolation. None of them models the cooperative as an institution.
+      </p>
+      <p>
+        A cooperative can own its workplace and still rent its nervous system from companies that
+        do not answer to it. A federation can hold formal agreements between member cooperatives and
+        still depend on a chat platform whose owner can change the terms of service tomorrow.
+        That is not a tooling complaint. It is a structural dependency on systems that do not share
+        the cooperative's purpose.
+      </p>
+      <p>
+        The cooperative economy cannot scale on spreadsheets, heroic memory, and software built for
+        bosses. It needs shared machinery designed for the kind of institution it actually is.
+      </p>
+
+      <h2>What machinery cooperatives need</h2>
+      <p>
+        Cooperative machinery is not a single product. It is a connected set of capabilities that
+        together let cooperatives, communities, and federations operate as themselves rather than as
+        approximations of firms. The list below is what ICN is building, with current maturity called
+        out honestly. The full account lives at <a href="/whats-real-now">What's Real Now</a>.
+      </p>
+      <ul>
+        <li>
+          <strong>Standing</strong> — provable membership inside an institution, carried by cryptographic
+          identity rather than a row in a CRM. <MaturityBadge band="strong" />
+        </li>
+        <li>
+          <strong>Authority and mandate</strong> — the chain that turns standing into the right to
+          participate in decisions and the right to act under them. <MaturityBadge band="strong" />
+        </li>
+        <li>
+          <strong>Receipts and provenance</strong> — durable records that trace every outcome back through
+          the rule that shaped it, the decision that authorized it, and the members who held standing.
+          <MaturityBadge band="strong" />
+        </li>
+        <li>
+          <strong>Decisions that carry into action</strong> — execution coverage that turns accepted
+          decisions into operational effect, on infrastructure the institution can govern.
+          <MaturityBadge band="advancing" />
+        </li>
+        <li>
+          <strong>Obligations and allocations between cooperatives</strong> — relational accounting where
+          a cooperative's commitments are first-class institutional facts, not entries in a private
+          spreadsheet. <MaturityBadge band="advancing" />
+        </li>
+        <li>
+          <strong>Federation</strong> — formal agreements, attestations, and cross-institutional clearing
+          between distinct cooperatives without dissolving them into one organization.
+          <MaturityBadge band="maturing" />
+        </li>
+        <li>
+          <strong>Commons and coordinated work</strong> — shared resources and compute capacity governed
+          collectively, with placement, clearing, and dispute paths in the same loop as governance.
+          <MaturityBadge band="maturing" />
+        </li>
+        <li>
+          <strong>Member-facing experience</strong> — the surface where standing, decisions, action,
+          and receipts converge into something a member can actually use.
+          <MaturityBadge band="behind" />
+        </li>
+      </ul>
+      <p>
+        ICN is not another app for cooperatives. It is the layer underneath them — the missing
+        coordination machinery for a cooperative economy.
+      </p>
+
+      <h2>How ICN handles external bridge institutions</h2>
+      <p>
+        ICN does not try to become a credit union, a CDFI, a fiscal sponsor, or a payment processor.
+        Those institutions exist for good reasons. They are regulated, they are accountable to specific
+        legal frameworks, and they carry the risk and responsibility of moving real money in the wider
+        economy. ICN should not duplicate them and cannot replace them.
+      </p>
+      <p>
+        What ICN does instead is record what cooperatives need to record around those bridges so the
+        cooperative side stays coherent:
+      </p>
+      <ul>
+        <li>The <strong>governance authorization</strong> for an action that touches an external bridge.</li>
+        <li>An <strong>external settlement instruction</strong> when the cooperative side has to ask a bridge institution to act.</li>
+        <li>The <strong>bridge receipt</strong> when the external institution executes — the cooperative side records what came back.</li>
+        <li>The <strong>provenance chain</strong> tying the authorization, the instruction, and the receipt together so a member can read what actually happened.</li>
+      </ul>
+      <p>
+        The bridge institution executes; ICN records. That separation is deliberate and load-bearing.
+        The detailed framing for obligation, allocation, settlement, and bridge institutions lives in
+        <a href="/docs">RFC-0001</a> in the project's documentation. It is a draft, not an accepted
+        decision; the public site does not claim it as built reality.
+      </p>
+
+      <h2>What exists now</h2>
+      <p>
+        ICN is not finished. The strongest parts today are the ones that carry the institution's
+        memory: cryptographic identity, provable standing, decision-to-outcome chains, and the
+        provenance records the rest of the system depends on. Federation, commons, and the substrate
+        for relational accounting are real and advancing. Member-facing surfaces are explicitly behind.
+        The honest account, with maturity bands and dates, lives at
+        <a href="/whats-real-now">What's Real Now</a>.
+      </p>
+      <p>
+        ICN does not process payments. ICN is not a bank, a credit union, a currency issuer, an
+        exchange, a wallet, or a payment rail. It is not a blockchain product. It is shared
+        infrastructure that cooperatives, communities, and federations can govern and improve
+        together.
+      </p>
+
+      <h2>What is still being built</h2>
+      <p>
+        Several capabilities described above are anticipated rather than complete. Action cards as
+        a member-facing pattern, a runtime path for conflict resolution and institutional care, and
+        the full obligation / allocation / settlement primitive set for cross-cooperative economic
+        coordination are being designed and discussed in the project's RFC and ADR records.
+        Where those documents are public, the <a href="/docs">documentation index</a> links to them
+        directly. Until a capability moves into one of the upper maturity bands at
+        <a href="/whats-real-now">What's Real Now</a>, the public site treats it as a direction,
+        not a delivery.
+      </p>
+      <p>
+        Bridges help cooperatives survive the old economy. Machinery lets cooperatives build more
+        of the new one. Both have to exist.
+      </p>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="container narrow">
+      <div class="cta-row">
+        <a href="/what-is-icn" class="btn btn-primary">What ICN is</a>
+        <a href="/whats-real-now" class="btn btn-secondary">What's Real Now</a>
+        <a href="/for-cooperatives" class="btn btn-ghost">For Cooperatives</a>
+      </div>
+    </div>
+  </section>
+
+</Layout>
+
+<style>
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  justify-content: center;
+}
+.cta-row .btn {
+  min-width: 12rem;
+}
+@media (max-width: 480px) {
+  .cta-row .btn { width: 100%; min-width: 0; }
+}
+</style>

--- a/website/src/pages/for-cooperatives.astro
+++ b/website/src/pages/for-cooperatives.astro
@@ -40,6 +40,26 @@ import ReadingLadder from '../components/ReadingLadder.astro';
 
   <section class="section-alt section-pre-ladder">
     <div class="container narrow prose">
+      <h2>Bridges, and what the bridge does not cover</h2>
+      <p>
+        Cooperatives already have institutions that help them survive the existing economy.
+        Credit unions hold deposits and clear obligations across regulated rails. Fiscal sponsors
+        let new cooperative work receive grants through an established legal entity. CDFIs and
+        cooperative lenders move capital toward cooperative formation, conversion, and operating
+        capacity. Accountants, bookkeepers, and legal / co-op developers translate cooperative
+        practice into the books, filings, and contracts the wider economy expects. Together with
+        technical assistance organizations, these are the bridge institutions the cooperative
+        economy depends on.
+      </p>
+      <p>
+        Bridges are necessary. They are not sufficient. A bridge handles the crossing into someone
+        else's system; it does not provide the machinery a cooperative needs <em>on its own side
+        of the bridge</em> — the digital substrate for membership, decisions, action, obligations,
+        receipts, and federation between cooperatives. ICN is being built to be that machinery.
+        The framing is laid out in
+        <a href="/cooperative-economy">The cooperative economy needs its own machinery</a>.
+      </p>
+
       <h2>The institutional problem you actually face</h2>
       <p>
         Most cooperatives operate across a stack of tools that were built for firms, platforms,

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -145,6 +145,16 @@ import MaturityCard from '../components/MaturityCard.astro';
           expected to rely on digital systems controlled by outside owners, outside incentives, and outside priorities.
         </p>
       </div>
+
+      <div class="bridge-block">
+        <p class="bridge-lede">
+          Credit unions, fiscal sponsors, and CDFIs help cooperatives interface with the existing economy.
+          ICN is the machinery a cooperative economy needs on its own side of the bridge.
+        </p>
+        <p class="bridge-link-row">
+          <a href="/cooperative-economy" class="link-arrow">The cooperative economy needs its own machinery →</a>
+        </p>
+      </div>
     </div>
   </section>
 
@@ -610,6 +620,23 @@ import MaturityCard from '../components/MaturityCard.astro';
 .closure-footnote a:hover { border-bottom-color: var(--accent-teal); }
 
 /* Status grid styles moved to MaturityGrid/MaturityCard components. */
+
+/* Bridge / machinery framing block under "The Problem" */
+.bridge-block {
+  margin-top: var(--space-xl);
+  padding-top: var(--space-lg);
+  border-top: 1px solid var(--border-subtle);
+}
+.bridge-lede {
+  font-size: 1.0625rem;
+  line-height: 1.6;
+  color: var(--text-body);
+  margin: 0 0 var(--space-sm);
+  max-width: 42rem;
+}
+.bridge-link-row {
+  margin: 0;
+}
 
 /* Link-arrow style for card CTAs */
 .link-arrow {

--- a/website/src/pages/what-is-icn.astro
+++ b/website/src/pages/what-is-icn.astro
@@ -52,7 +52,14 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         should not have to live in separate products owned by somebody else.
       </p>
       <p>
-        Today that layer is improvised. It lives in spreadsheets, chat threads, documents,
+        Bridge institutions like credit unions, fiscal sponsors, and CDFIs already help cooperatives
+        interface with the wider economy. ICN is the machinery a cooperative economy needs
+        <em>on its own side of the bridge</em> — for standing, decisions, action, and the records a
+        cooperative can stand behind. The framing is laid out in
+        <a href="/cooperative-economy">The cooperative economy needs its own machinery</a>.
+      </p>
+      <p>
+        Today that machinery is improvised. It lives in spreadsheets, chat threads, documents,
         staff memory, and disconnected tools that were never designed to carry institutional weight.
         ICN is an attempt to provide a durable alternative.
       </p>

--- a/website/src/pages/why-icn.astro
+++ b/website/src/pages/why-icn.astro
@@ -56,12 +56,21 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         and the software stack democratic organizations have been forced to use.
       </p>
 
-      <h2>Most of the tools we depend on do not answer to us</h2>
+      <h2>A cooperative can own its workplace and still rent its nervous system</h2>
       <p>
-        The deeper problem is that most of the systems we depend on —
+        The deeper problem is that most of the systems cooperatives depend on —
         platforms, employers, infrastructure providers, administrative backends —
         do not answer to the people who live inside them. They answer to ownership, to management,
         to capital, or to centralized administration.
+      </p>
+      <p>
+        A cooperative can own its workplace and still rent its nervous system from companies that
+        do not answer to it. A federation can hold formal agreements between member cooperatives and
+        still depend on a chat platform whose owner can change the terms tomorrow. The diagnosis is
+        not "the tools are bad." The diagnosis is that <em>cooperative institutions are forced to borrow
+        the nervous system of capital</em> in order to operate at all. The complementary framing —
+        bridges versus machinery — lives at
+        <a href="/cooperative-economy">The cooperative economy needs its own machinery</a>.
       </p>
       <p>
         Name the stack plainly and the problem becomes clearer: Google Workspace or Microsoft 365


### PR DESCRIPTION
## Summary

Adds a new public page at `/cooperative-economy` that introduces the bridge / machinery framing, and lightly tunes four existing pages to route to it without bloating them. No runtime changes; no ICN maturity promotion; no NYCN/Summit references on the public site.

## Why this belongs on the public site

The existing public pages share one diagnosis (the fragmented-tool stack) across four surfaces: index, why-icn, what-is-icn, for-cooperatives. The bridge / machinery framing is a complementary, positive proposition that the site has been missing: credit unions, fiscal sponsors, CDFIs, cooperative lenders, and technical assistance organizations are bridges to the existing economy; ICN is the machinery a cooperative economy needs on its own side of the bridge. A dedicated page lets readers move from "what is broken" to "what is missing" without re-reading the same diagnosis four times.

## What changed

**New: `website/src/pages/cooperative-economy.astro`** — full treatment of the framing. Sections per the brief:

- Bridges help cooperatives survive the existing economy
- Bridges are necessary but not sufficient
- The cooperative economy still runs on borrowed machinery
- What machinery cooperatives need (with maturity bands)
- How ICN handles external bridge institutions
- What exists now
- What is still being built

**Edited: `website/src/pages/index.astro`** — adds a small bridge-block under "The Problem" with a one-line lede ("Credit unions, fiscal sponsors, and CDFIs help cooperatives interface with the existing economy. ICN is the machinery a cooperative economy needs on its own side of the bridge.") and a link to the new page. Adds matching CSS.

**Edited: `website/src/pages/why-icn.astro`** — sharpens the diagnosis section heading from "Most of the tools we depend on do not answer to us" to "A cooperative can own its workplace and still rent its nervous system". Adds one paragraph reframing the diagnosis ("cooperative institutions are forced to borrow the nervous system of capital") and links to the new page. No content removed.

**Edited: `website/src/pages/what-is-icn.astro`** — adds a short "machinery on our side of the bridge" paragraph in the "A different kind of system" section. Existing content preserved.

**Edited: `website/src/pages/for-cooperatives.astro`** — adds a "Bridges, and what the bridge does not cover" section near the top naming credit unions / CDFIs / fiscal sponsors / cooperative lenders / accountants / co-op developers / technical assistance organizations explicitly, with the bridge-vs-machinery framing and a link to the new page. Existing institutional-problem section preserved.

## Truth-boundary / maturity discipline

The new page mirrors the [whats-real-now](https://intercooperative.network/whats-real-now/) maturity bands using the existing `MaturityBadge` component:

- **strong** — standing, authority / mandate, receipts / provenance
- **advancing** — decisions that carry into action, obligations and allocations between cooperatives
- **maturing** — federation, commons and coordinated work
- **behind** — member-facing experience

The "What is still being built" section explicitly names action cards as a member-facing pattern, conflict resolution runtime, and full obligation / allocation / settlement primitives as anticipated rather than complete; readers are routed to the docs / RFC index for the canonical record. No claim that those subsystems are runtime-complete.

## Regulatory-safe vocabulary check

**Used (ICN-native primitives):** standing, authority, mandate, obligation, allocation, settlement, receipt, provenance, position, external settlement instruction, bridge receipt.

**Avoided for ICN-native primitives:** payment, currency, balance, wallet.

**Used only when describing external systems or stating what ICN is NOT:** payment processor, payment rails, currency issuer, exchange, wallet, blockchain.

The new page contains an explicit rejection paragraph: *"ICN does not process payments. ICN is not a bank, a credit union, a currency issuer, an exchange, a wallet, or a payment rail. It is not a blockchain product."*

## No-NYCN / no-Summit public-site check

`grep -RInE 'NYCN|New York Cooperative|Summit|reference federation|first institution package' website/src` → **CLEAN**. No new references introduced.

## Validation results

- `npm run build` (Astro): PASS — 751 pages built (was 749; +1 new page + sitemap entry)
- `npm run lint` (astro check): PASS — 0 errors / 0 warnings / 0 hints across 42 Astro files
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml --strict`: PASS — 730 docs; 36 pre-existing warnings, none new (no doc/ files modified)
- Forbidden-term grep on `website/src`: CLEAN
- Risky-term grep on `website/src`: only pre-existing rejection-of-framing matches plus the two new explicit rejection lines in `cooperative-economy.astro`
- `git diff --check`: clean

## Non-goals

- No runtime changes
- No ICN maturity promotion — every claim about a subsystem either links to whats-real-now bands or appears in the explicit "still being built" section
- No NYCN package changes
- No `icn-learn` changes (parallel session is scaffolding that repo)
- No DNS or Cloudflare changes
- No public claim that ICN replaces credit unions or processes payments
- No new dependencies, no full redesign
- No docs-navigation tune-up (kept out of scope to keep this PR reviewable)

## Refs

- [ADR-0032 — Website Truth Boundary](docs/adr/ADR-0032-website-truth-boundary.md)
- [ADR-0033 — Public Maturity Claims and Evidence Links](docs/adr/ADR-0033-public-maturity-claims-and-evidence-links.md)
- [RFC-0001 — Obligation/Allocation/Settlement Primitives and External Settlement Bridges](docs/rfcs/RFC-0001-obligation-allocation-settlement-primitives.md)
- [RFC-0015 — Public Surface and Learning Repo Architecture](docs/rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md)
