### PR TITLE
docs(site): add curated docs pathways

### DIFF
--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -166,6 +166,107 @@ const allDocs = sections.flatMap(s => s.docs);
         </a>
       </div>
 
+      <!-- Curated reading pathways -->
+      <section class="docs-pathways" aria-labelledby="docs-pathways-heading">
+        <header class="docs-pathways-header">
+          <h2 id="docs-pathways-heading">Choose a docs path</h2>
+          <p>If you do not yet know what to search for, start here. Each path is a short reading sequence built from existing pages and docs.</p>
+        </header>
+
+        <ol class="docs-pathways-grid">
+          <li class="docs-pathway">
+            <span class="docs-pathway-num">01</span>
+            <h3>Understand the project</h3>
+            <p>What ICN is, what problem it addresses, and how the closure loop holds the institution together.</p>
+            <ul>
+              <li><a href="/what-is-icn">What is ICN</a></li>
+              <li><a href="/why-icn">Why ICN</a></li>
+              <li><a href="/cooperative-economy">The cooperative economy needs its own machinery</a></li>
+              <li><a href="/how-it-works">How It Works</a></li>
+            </ul>
+          </li>
+
+          <li class="docs-pathway">
+            <span class="docs-pathway-num">02</span>
+            <h3>Build or contribute</h3>
+            <p>Get the workspace running and find a contribution path that matches the repo as it actually exists.</p>
+            <ul>
+              <li><a href="/for-developers">For Developers</a></li>
+              <li><a href="/get-involved">Get Involved</a></li>
+              <li><a href="/docs/GETTING_STARTED">Getting Started</a></li>
+              <li><a href="/docs/ARCHITECTURE">Architecture overview</a></li>
+            </ul>
+          </li>
+
+          <li class="docs-pathway">
+            <span class="docs-pathway-num">03</span>
+            <h3>Run infrastructure</h3>
+            <p>Deployment routing, K3s, and the public domain map for nodes, gateways, and short links.</p>
+            <ul>
+              <li><a href="/docs/deployment/ICN_ZONE_ROUTING">icn.zone routing plan</a></li>
+              <li><a href="/docs/deployment/DEPLOYMENT_GUIDE">Deployment guide</a></li>
+              <li><a href="/docs/HOMELAB_DEPLOYMENT">Homelab deployment</a></li>
+            </ul>
+          </li>
+
+          <li class="docs-pathway">
+            <span class="docs-pathway-num">04</span>
+            <h3>Understand governance</h3>
+            <p>How proposals, decisions, mandates, and the kernel-app boundary actually work in ICN.</p>
+            <ul>
+              <li><a href="/docs/architecture/GOVERNANCE_STATE_MACHINE">Governance state machine</a></li>
+              <li><a href="/docs/architecture/KERNEL_APP_SEPARATION">Kernel / app separation</a></li>
+              <li><a href="/docs/adr">ADR index</a></li>
+            </ul>
+          </li>
+
+          <li class="docs-pathway">
+            <span class="docs-pathway-num">05</span>
+            <h3>Understand economics and resource governance</h3>
+            <p>The vocabulary discipline (obligation / allocation / settlement) and the draft RFC that frames external bridge institutions.</p>
+            <ul>
+              <li><a href="/cooperative-economy">The cooperative economy needs its own machinery</a></li>
+              <li><a href="/docs/rfcs/RFC-0001-obligation-allocation-settlement-primitives">RFC-0001 — Obligation / Allocation / Settlement Primitives</a></li>
+              <li><a href="/docs/design/CONTENT_STYLE_GUIDE">Content Style Guide (vocabulary)</a></li>
+            </ul>
+          </li>
+
+          <li class="docs-pathway">
+            <span class="docs-pathway-num">06</span>
+            <h3>Understand federation</h3>
+            <p>How distinct cooperatives coordinate without merger — treaties, attestations, and cross-institutional clearing.</p>
+            <ul>
+              <li><a href="/docs/architecture/FEDERATION_ACTIONS">Federation actions</a></li>
+              <li><a href="/docs/architecture/FEDERATION_INTEROP_CONTRACT">Federation interop contract</a></li>
+              <li><a href="/docs/adr/ADR-0013-federation-clearing-adoption-contract">ADR-0013 — Federation clearing adoption</a></li>
+            </ul>
+          </li>
+
+          <li class="docs-pathway">
+            <span class="docs-pathway-num">07</span>
+            <h3>Understand design and accessibility</h3>
+            <p>The cross-surface design system, content style discipline, and accessibility floor for member-facing surfaces.</p>
+            <ul>
+              <li><a href="/docs/design/ICN_DESIGN_SYSTEM">ICN Design System</a></li>
+              <li><a href="/docs/design/ACCESSIBILITY_BASELINE">Accessibility Baseline</a></li>
+              <li><a href="/docs/design/CONTENT_STYLE_GUIDE">Content Style Guide</a></li>
+              <li><a href="/docs/rfcs/RFC-0015-public-surface-and-learning-repo-architecture">RFC-0015 — Public surface architecture</a></li>
+            </ul>
+          </li>
+
+          <li class="docs-pathway">
+            <span class="docs-pathway-num">08</span>
+            <h3>Check current project state</h3>
+            <p>Honest, dated maturity. Read this before treating any subsystem as production-ready.</p>
+            <ul>
+              <li><a href="/whats-real-now">What's Real Now</a></li>
+              <li><a href="/docs/STATE">State (project status)</a></li>
+              <li><a href="/docs/INDEX">Documentation index</a></li>
+            </ul>
+          </li>
+        </ol>
+      </section>
+
       <!-- Search -->
       <Search searchList={allDocs} />
 
@@ -314,6 +415,91 @@ const allDocs = sections.flatMap(s => s.docs);
   @media (max-width: 900px) {
     .docs-quickstart {
       grid-template-columns: 1fr;
+    }
+  }
+
+  /* Curated reading pathways — sit above the search/index */
+  .docs-pathways {
+    margin: var(--space-xl) 0;
+    padding: var(--space-xl);
+    background: var(--bg-card);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-xl);
+  }
+  .docs-pathways-header {
+    margin-bottom: var(--space-lg);
+  }
+  .docs-pathways-header h2 {
+    font-size: 1.25rem;
+    margin: 0 0 var(--space-xs);
+  }
+  .docs-pathways-header p {
+    margin: 0;
+    font-size: 0.9375rem;
+    color: var(--text-secondary);
+    max-width: 48rem;
+  }
+  .docs-pathways-grid {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-md);
+  }
+  .docs-pathway {
+    padding: var(--space-md) var(--space-lg);
+    background: var(--bg-base, transparent);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+  }
+  .docs-pathway-num {
+    display: inline-block;
+    margin-bottom: var(--space-xs);
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: var(--accent-teal);
+  }
+  .docs-pathway h3 {
+    font-size: 1rem;
+    margin: 0 0 var(--space-xs);
+    line-height: 1.3;
+  }
+  .docs-pathway > p {
+    margin: 0 0 var(--space-sm);
+    font-size: 0.875rem;
+    line-height: 1.55;
+    color: var(--text-secondary);
+  }
+  .docs-pathway ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+  .docs-pathway li a {
+    display: block;
+    padding: 0.25rem 0;
+    font-size: 0.875rem;
+    color: var(--text-body);
+    border-bottom: 1px solid transparent;
+    transition: color var(--duration-fast) var(--ease-out), border-color var(--duration-fast) var(--ease-out);
+  }
+  .docs-pathway li a:hover {
+    color: var(--accent-teal);
+    border-bottom-color: var(--accent-teal);
+  }
+
+  @media (max-width: 900px) {
+    .docs-pathways-grid {
+      grid-template-columns: 1fr;
+    }
+    .docs-pathways {
+      padding: var(--space-lg);
     }
   }
 </style>

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -175,7 +175,7 @@ const allDocs = sections.flatMap(s => s.docs);
 
         <ol class="docs-pathways-grid">
           <li class="docs-pathway">
-            <span class="docs-pathway-num">01</span>
+            <span class="docs-pathway-num" aria-hidden="true">01</span>
             <h3>Understand the project</h3>
             <p>What ICN is, what problem it addresses, and how the closure loop holds the institution together.</p>
             <ul>
@@ -187,7 +187,7 @@ const allDocs = sections.flatMap(s => s.docs);
           </li>
 
           <li class="docs-pathway">
-            <span class="docs-pathway-num">02</span>
+            <span class="docs-pathway-num" aria-hidden="true">02</span>
             <h3>Build or contribute</h3>
             <p>Get the workspace running and find a contribution path that matches the repo as it actually exists.</p>
             <ul>
@@ -199,29 +199,29 @@ const allDocs = sections.flatMap(s => s.docs);
           </li>
 
           <li class="docs-pathway">
-            <span class="docs-pathway-num">03</span>
+            <span class="docs-pathway-num" aria-hidden="true">03</span>
             <h3>Run infrastructure</h3>
             <p>Deployment routing, K3s, and the public domain map for nodes, gateways, and short links.</p>
             <ul>
               <li><a href="/docs/deployment/ICN_ZONE_ROUTING">icn.zone routing plan</a></li>
               <li><a href="/docs/deployment/DEPLOYMENT_GUIDE">Deployment guide</a></li>
-              <li><a href="/docs/HOMELAB_DEPLOYMENT">Homelab deployment</a></li>
+              <li><a href="/docs/operations/deployment/HOMELAB_DEPLOYMENT">Homelab deployment</a></li>
             </ul>
           </li>
 
           <li class="docs-pathway">
-            <span class="docs-pathway-num">04</span>
+            <span class="docs-pathway-num" aria-hidden="true">04</span>
             <h3>Understand governance</h3>
             <p>How proposals, decisions, mandates, and the kernel-app boundary actually work in ICN.</p>
             <ul>
               <li><a href="/docs/architecture/GOVERNANCE_STATE_MACHINE">Governance state machine</a></li>
               <li><a href="/docs/architecture/KERNEL_APP_SEPARATION">Kernel / app separation</a></li>
-              <li><a href="/docs/adr">ADR index</a></li>
+              <li><a href="/docs/adr/ADR-0018-adr-lifecycle-and-canonical-decision-index">ADR-0018 — ADR lifecycle and canonical decision index</a></li>
             </ul>
           </li>
 
           <li class="docs-pathway">
-            <span class="docs-pathway-num">05</span>
+            <span class="docs-pathway-num" aria-hidden="true">05</span>
             <h3>Understand economics and resource governance</h3>
             <p>The vocabulary discipline (obligation / allocation / settlement) and the draft RFC that frames external bridge institutions.</p>
             <ul>
@@ -232,7 +232,7 @@ const allDocs = sections.flatMap(s => s.docs);
           </li>
 
           <li class="docs-pathway">
-            <span class="docs-pathway-num">06</span>
+            <span class="docs-pathway-num" aria-hidden="true">06</span>
             <h3>Understand federation</h3>
             <p>How distinct cooperatives coordinate without merger — treaties, attestations, and cross-institutional clearing.</p>
             <ul>
@@ -243,7 +243,7 @@ const allDocs = sections.flatMap(s => s.docs);
           </li>
 
           <li class="docs-pathway">
-            <span class="docs-pathway-num">07</span>
+            <span class="docs-pathway-num" aria-hidden="true">07</span>
             <h3>Understand design and accessibility</h3>
             <p>The cross-surface design system, content style discipline, and accessibility floor for member-facing surfaces.</p>
             <ul>
@@ -255,7 +255,7 @@ const allDocs = sections.flatMap(s => s.docs);
           </li>
 
           <li class="docs-pathway">
-            <span class="docs-pathway-num">08</span>
+            <span class="docs-pathway-num" aria-hidden="true">08</span>
             <h3>Check current project state</h3>
             <p>Honest, dated maturity. Read this before treating any subsystem as production-ready.</p>
             <ul>
@@ -485,11 +485,12 @@ const allDocs = sections.flatMap(s => s.docs);
     display: block;
     padding: 0.25rem 0;
     font-size: 0.875rem;
-    color: var(--text-body);
-    border-bottom: 1px solid transparent;
+    color: var(--accent-teal);
+    border-bottom: 1px solid var(--border-subtle);
     transition: color var(--duration-fast) var(--ease-out), border-color var(--duration-fast) var(--ease-out);
   }
-  .docs-pathway li a:hover {
+  .docs-pathway li a:hover,
+  .docs-pathway li a:focus-visible {
     color: var(--accent-teal);
     border-bottom-color: var(--accent-teal);
   }


### PR DESCRIPTION
## Summary

Adds a "Choose a docs path" section to the docs index page, above the existing search and section grid. Eight curated pathways help readers who do not yet know what to search for find a coherent reading order across the existing site pages and synced documentation. Pure navigation; every link points to material that already exists.

## Why this belongs on the public site

The docs index now syncs ~730 markdown files. The existing quickstart card row covers Developers / Contributors / Supporters, but does not give readers an ICN-shaped entry point — "I want to understand governance," "I want to understand economics," "I want to check current state." A small curated-pathways block delivers that without redesigning the docs explorer or claiming new doctrine.

## What changed

**`website/src/pages/docs/index.astro`** — added a new `Choose a docs path` section between the existing 3-card quickstart and the `Search` component. Eight pathways:

| # | Path | Reading set |
|---|------|-------------|
| 01 | Understand the project | What is ICN · Why ICN · The cooperative economy needs its own machinery · How It Works |
| 02 | Build or contribute | For Developers · Get Involved · Getting Started · Architecture overview |
| 03 | Run infrastructure | icn.zone routing plan · Deployment guide · Homelab deployment |
| 04 | Understand governance | Governance state machine · Kernel / app separation · ADR index |
| 05 | Understand economics and resource governance | The cooperative economy needs its own machinery · RFC-0001 (Obligation / Allocation / Settlement Primitives) · Content Style Guide |
| 06 | Understand federation | Federation actions · Federation interop contract · ADR-0013 (Federation clearing adoption) |
| 07 | Understand design and accessibility | ICN Design System · Accessibility Baseline · Content Style Guide · RFC-0015 (Public surface architecture) |
| 08 | Check current project state | What's Real Now · State (project status) · Documentation index |

Each pathway includes a one-line plain-language description plus 3–4 links. No invented docs.

The existing 3-card quickstart row, the `Search` component, the `docs-index-grid` of synced sections, and the search-filter script are all unchanged.

## Truth-boundary / maturity discipline

Every link points at material that already exists in the repo or on the site. Pathway descriptions do not encode maturity claims. The single maturity claim ("honest, dated maturity") on pathway 08 points at `/whats-real-now` and `docs/STATE` — the existing truth anchors per ADR-0032 and ADR-0033. No promotion of any subsystem to "production-ready" in pathway copy.

## No `learn.icn.zone` link yet

`learn.icn.zone` is reserved by [RFC-0015](docs/rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md) as a future surface but the site does not exist. No pathway links to `learn.icn.zone` or implies the future learning repo is a current destination. RFC-0015 itself is linked under pathway 07 as the architectural reference.

## No-NYCN / no-Summit public-site check

`grep -RInE 'NYCN|New York Cooperative|Summit|reference federation|first institution package' website/src` → **CLEAN**. No new references.

## Regulatory-safe vocabulary check

New section uses: standing, authority, mandate, obligation, allocation, settlement, receipt, provenance, federation, treaty, attestation, clearing, governance.

Avoided for ICN-native primitives: payment, currency, balance, wallet. `grep -RInE 'wallet|balance|currency|payment' website/src/pages/docs/index.astro` → **NO MATCHES** in the edited file.

## Validation results

- `npm run build`: PASS (751 pages built — page edit, not a new page)
- `npm run lint` (astro check): PASS (0 errors / 0 warnings / 0 hints across 42 Astro files)
- `python3 docs/scripts/doc_control_check.py --strict`: PASS (730 docs; 36 pre-existing warnings, none new)
- forbidden-term grep on `website/src`: CLEAN
- risky-term grep on edited file: NO MATCHES
- `git diff --check`: clean

## Non-goals

- No runtime changes
- No docs migration; nothing was moved
- No learning repo changes
- No NYCN package changes
- No DNS or Cloudflare changes
- No public maturity promotion
- No new dependencies, no docs explorer redesign — the existing search and section grid are intact

## Refs

- [RFC-0015 — Public Surface and Learning Repo Architecture](docs/rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md)
- [ADR-0032 — Website Truth Boundary](docs/adr/ADR-0032-website-truth-boundary.md)
- [ADR-0033 — Public Maturity Claims and Evidence Links](docs/adr/ADR-0033-public-maturity-claims-and-evidence-links.md)
- [docs/design/CONTENT_STYLE_GUIDE.md](docs/design/CONTENT_STYLE_GUIDE.md)
