### PR TITLE
docs(sync): record ICN Academy repo creation

### DIFF
--- a/docs/rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md
+++ b/docs/rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md
@@ -3,7 +3,7 @@ id: "0015"
 title: "Public Surface and Learning Repo Architecture"
 status: "draft"
 created: "2026-04-27"
-updated: "2026-04-27"
+updated: "2026-04-27"  # implementation status note added — icn-learn repo created (private)
 authors: ["Matt Faherty"]
 reviewers: []
 related_adr_candidates: ["0028", "0032", "0033", "0034"]
@@ -246,6 +246,14 @@ This RFC is doctrinal. "Proof" of acceptance is structural:
   - `cd website && npm run build && npm run lint`
   - `grep -RIE 'NYCN|New York Cooperative|reference federation|Summit|first institution package' website/src/` returns clean
 - ADR-0032 / ADR-0033 enforcement remains the truth gate for the canonical site; no exception is created here.
+
+---
+
+## Implementation status
+
+The repo `InterCooperative-Network/icn-learn` was created on 2026-04-27 as a private repo seeded with the role-based learning scaffold described under "Follow-up implementation issues" item 1. No deploy target, no `learn.icn.zone` DNS, and no public link from `intercooperative.network` exist yet — those remain follow-up work consistent with this RFC's non-goals. The repo's README carries the "teaches ICN; does not define ICN" guardrail and links back to canonical truth in this repo.
+
+This is a status note, not a change to RFC status; the RFC itself remains `draft` until reviewed.
 
 ---
 

--- a/ops/coordination/rfc_candidates.yaml
+++ b/ops/coordination/rfc_candidates.yaml
@@ -803,6 +803,11 @@ candidates:
       - "docs/design/ACCESSIBILITY_BASELINE.md"
     related_future_repos:
       - "InterCooperative-Network/icn-learn"
+    repos_created:
+      - repo: "InterCooperative-Network/icn-learn"
+        created_on: "2026-04-27"
+        visibility: "private"
+        status: "scaffold-only; no deploy, no DNS, learn.icn.zone not configured"
     related_future_domains:
       - "learn.icn.zone"
       - "cooperative-systems.org"


### PR DESCRIPTION
## Summary

Records that the future ICN learning/onboarding repo now exists as `InterCooperative-Network/icn-learn` (private, scaffold-only).

This is a coordination/status update only. It does not deploy `learn.icn.zone`, does not change DNS, does not touch Cloudflare, and does not add public website links to the learning surface.

## Changes

- `docs/rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md` — adds an "Implementation status" section recording repo creation (2026-04-27, private). RFC status remains `draft`; this is a status note per the RFC's own amendment rule.
- `ops/coordination/rfc_candidates.yaml` — adds a `repos_created` field under the RFC-0015 entry recording the same.

## Boundary

- ICN remains the canonical platform truth surface.
- icn-learn / ICN Academy teaches ICN; it does not define ICN.
- `learn.icn.zone` remains future / not deployed until a separate deployment PR exists.
- NYCN/Summit operating truth remains in the NYCN repo.
- No public-website mention of NYCN, Summit, reference federation, or first institution package is introduced.

## Validation

- ``python3 docs/scripts/doc_control_check.py --strict`` — pass (36 pre-existing enforcement warnings, none introduced by this PR)
- ``git diff --check`` — clean
- ``grep -RInE 'NYCN|New York Cooperative|Summit|reference federation|first institution package' website/src`` — clean (no `website/src` files touched)