### PR TITLE
feat(gateway): add member action cards endpoint

### DIFF
--- a/docs/adr/ADR-0020-institutional-bootstrap-activation-and-standing-read-model.md
+++ b/docs/adr/ADR-0020-institutional-bootstrap-activation-and-standing-read-model.md
@@ -8,7 +8,7 @@ tags: ["bootstrap", "activation", "standing", "institution-package", "charter", 
 supersedes: []
 superseded_by: []
 amends: []
-implementation_status: "partially implemented (bootstrap → charter activation → standing path landed; action cards not yet)"
+implementation_status: "partially implemented (bootstrap → charter activation → standing → action cards vertical slice landed; signal-rule and obligation-lifecycle source paths still pending)"
 references:
   - "ADR-0011 (Canonical Truth Ownership)"
   - "ADR-0014 (Constitutional Object Model)"
@@ -75,7 +75,7 @@ Institution package activation follows a single reusable path. Each step has a w
 | 4 | Live charter activation endpoint | `POST /v1/charters/...` taking ratified charter content and binding it to a governance domain (`PR #1624`) | The charter document content (CCL YAML or equivalent) | implemented |
 | 5 | Entity / structure / role creation | `BootstrapEntityRecord` parsing, person-directory overlay for DID binding (`PR #1626`), `authority_scope` plumbed end-to-end through `assign_role` (`PR #1630`) | Per-package ids, per-package authority scope strings | implemented |
 | 6 | `/me/standing` read model | The endpoint shape, the standing schema, the smoke contract (`PR #1627`) | Smoke verifier on the package side that asserts each holder's expected standing matches the live response | implemented; NYCN ships `tools/verify-standing.py` against the contract |
-| 7 | Action cards | `GET /me/action-cards` (icn#1608, future) | Action-card template catalog, holder-side rendering | NOT YET IMPLEMENTED — icn#1608 is open. NYCN ships planned fixtures (`institution/action-card-templates.example.yaml`) marked `icn_target_status: planned`. |
+| 7 | Action cards | `GET /v1/gov/me/action-cards` returning a generic `ActionCard` shape (id, source_kind, action_kind, scope, title, summary, authority_basis, required_authority_scope, deadline, risk_level, accessibility_hint, receipt_expected, source_id, domain_id) | Action-card template catalog, holder-side rendering | partially implemented (icn#1646 vertical slice). `proposal`/`vote`, `meeting`/`attend`, and `action_item`/`complete` source paths emit cards. `signal_rule` and `obligation_lifecycle` are reserved enum variants (gating issues icn#1631 and icn#1634). NYCN's `institution/action-card-templates.example.yaml` remains the package-side template catalog. |
 
 ### Boundary rules
 
@@ -111,7 +111,7 @@ The schema is the runtime contract. NYCN's smoke verifier (`tools/verify-standin
 | 4. Live charter activation endpoint | implemented | `POST /v1/charters/...` (PR #1624) |
 | 5. Entity / structure / role creation, persistent | implemented | PR #1621 (persist domains across restart), PR #1626 (person-directory overlay), PR #1630 (authority_scope plumbing) |
 | 6. `/me/standing` read model | implemented | PR #1627; NYCN `tools/verify-standing.py` |
-| 7. Action cards | NOT YET IMPLEMENTED | icn#1608 open; NYCN ships planned fixtures only |
+| 7. Action cards | partially implemented (vertical slice) | `GET /v1/gov/me/action-cards` handler at `icn/apps/governance/src/http/handlers.rs::get_my_action_cards`; runtime types in `icn/apps/governance/src/http/models.rs::ActionCard*`; JSON schema at `docs/contracts/institution-package/action-card.schema.json` (`x-icn-status: rfc`); integration coverage at `icn/apps/governance/tests/me_action_cards.rs`. icn#1646 closes once the reserved `signal_rule` (icn#1631) and `obligation_lifecycle` (icn#1634) source paths land. |
 
 ## Consequences
 

--- a/docs/contracts/institution-package/action-card.schema.json
+++ b/docs/contracts/institution-package/action-card.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://intercooperative.network/contracts/institution-package/action-card.schema.json",
+  "title": "ActionCard",
+  "description": "A single pending action card for a member, returned by GET /v1/gov/me/action-cards. Cards are derived views — computed at request time from the holder's standing plus open governance state — and are never stored entities. See ADR-0027.",
+  "x-icn-status": "rfc",
+  "x-icn-references": [
+    "ADR-0020",
+    "ADR-0027",
+    "ADR-0028",
+    "GitHub icn#1646",
+    "GitHub icn#1608"
+  ],
+  "type": "object",
+  "required": [
+    "id",
+    "source_kind",
+    "action_kind",
+    "scope",
+    "title",
+    "summary",
+    "authority_basis",
+    "required_authority_scope",
+    "risk_level",
+    "accessibility_hint",
+    "receipt_expected",
+    "source_id"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Stable, deterministic id of the card. Format: card-<source_kind>-<source_id>(-<action_kind>). Two requests at the same moment from the same DID return identical card ids.",
+      "minLength": 1
+    },
+    "source_kind": {
+      "description": "Where this card was derived from. Closed taxonomy. Variants 'signal_rule' and 'obligation_lifecycle' are reserved by issue icn#1646 and not emitted by the runtime today; they will land alongside their source-path implementation.",
+      "type": "string",
+      "enum": [
+        "proposal",
+        "meeting",
+        "action_item",
+        "signal_rule",
+        "obligation_lifecycle"
+      ]
+    },
+    "action_kind": {
+      "description": "What the holder is being asked to do. Closed taxonomy. New variants land when their source path implementation lands.",
+      "type": "string",
+      "enum": [
+        "vote",
+        "attend",
+        "complete"
+      ]
+    },
+    "scope": {
+      "description": "What the card targets, mapped to ICN's constitutional axes. Institution packages bind their local taxonomy to these.",
+      "type": "string",
+      "enum": [
+        "entity",
+        "structure",
+        "individual"
+      ]
+    },
+    "title": {
+      "type": "string",
+      "description": "Short, plain-language title suitable for a list row.",
+      "minLength": 1
+    },
+    "summary": {
+      "type": "string",
+      "description": "One-line plain-language summary of what this card is asking the holder to do.",
+      "minLength": 1
+    },
+    "authority_basis": {
+      "type": "string",
+      "description": "Why the caller has the right to act here, in plain language. Examples: 'domain_membership', 'meeting_attendee', 'assigned_action_item'.",
+      "minLength": 1
+    },
+    "required_authority_scope": {
+      "type": "array",
+      "description": "Authority-scope strings the kernel would expect for this action. Generic; institution packages may use richer strings.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "deadline": {
+      "description": "Optional Unix-seconds deadline. Absent means no time pressure encoded by this card.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "risk_level": {
+      "description": "Coarse risk indicator surfaced to the holder. UI may sort or annotate but must not hide cards. Exact semantics are a policy concern.",
+      "type": "string",
+      "enum": [
+        "low",
+        "normal",
+        "elevated"
+      ]
+    },
+    "accessibility_hint": {
+      "type": "string",
+      "description": "Plain-language accessibility note for the rendering shell. Per ADR-0028, every card must carry one. Generic across institutions.",
+      "minLength": 1
+    },
+    "receipt_expected": {
+      "type": "boolean",
+      "description": "Whether successful completion of this action is expected to produce a receipt (governance receipt, attendance receipt, action-item completion receipt)."
+    },
+    "source_id": {
+      "type": "string",
+      "description": "Underlying object id (proposal id, meeting id, action item id). The holder acts on this object via its native endpoint; the card carries no mutation API.",
+      "minLength": 1
+    },
+    "domain_id": {
+      "description": "Governance domain this card lives under, when known.",
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -536,5 +536,9 @@ where
         // ── Me (caller-scoped views) ─────────────────────────────────────
         .service(web::resource("/me/scopes").route(web::get().to(handlers::get_my_scopes::<E>)))
         .service(web::resource("/me/standing").route(web::get().to(handlers::get_my_standing::<E>)))
-        .service(web::resource("/me/work").route(web::get().to(handlers::get_my_work::<E>)));
+        .service(web::resource("/me/work").route(web::get().to(handlers::get_my_work::<E>)))
+        .service(
+            web::resource("/me/action-cards")
+                .route(web::get().to(handlers::get_my_action_cards::<E>)),
+        );
 }

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -5042,6 +5042,152 @@ pub async fn get_my_work<E: GovernanceEventEmitter + Clone + 'static>(
     Ok(HttpResponse::Ok().json(responses))
 }
 
+/// GET /gov/me/action-cards — Return pending action cards for the caller.
+///
+/// Action cards are derived views — computed at request time from the caller's
+/// `/me/standing` inputs plus open governance state. There is no mutation API;
+/// the card carries a `source_id` and the holder acts on the underlying
+/// object. See ADR-0027.
+///
+/// ## Sources currently emitted
+///
+/// - `proposal` / `vote` — Open proposals in domains where the caller has
+///   voting standing and has not yet voted.
+/// - `meeting` / `attend` — Meetings scheduled in the next 48 h where the
+///   caller is on the attendee list.
+/// - `action_item` / `complete` — Open action items assigned to the caller.
+///
+/// ## Sources reserved (not emitted today)
+///
+/// - `signal_rule` — pending icn#1631
+/// - `obligation_lifecycle` — pending icn#1634
+///
+/// Per ADR-0027 the taxonomy is closed; new variants land alongside their
+/// source-path implementation.
+///
+/// ## Self-only
+///
+/// There is no `did` query parameter. The caller's DID is always derived from
+/// the authenticated claims; no card-set for a third party is reachable here.
+pub async fn get_my_action_cards<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+) -> Result<HttpResponse, ApiError> {
+    let claims = require_scope::<BasicClaims>(&http_req, "governance:read")?;
+    let caller = parse_did(&claims.sub, "Invalid DID in token")?;
+    let now = current_time_secs();
+
+    let mut cards: Vec<ActionCard> = Vec::new();
+
+    // 1. Pending votes + upcoming meetings come from the existing digest
+    //    pipeline. That pipeline already enforces "open proposal the caller
+    //    has not yet voted on" and "meeting in the next 48 h where caller is
+    //    on the attendee list" — exactly the membership/authority checks this
+    //    surface needs.
+    let digest = ctx.manager.generate_digest(&caller, now).await;
+
+    for v in digest.pending_votes {
+        cards.push(ActionCard {
+            id: format!("card-proposal-{}-vote", v.proposal_id),
+            source_kind: ActionCardSourceKind::Proposal,
+            action_kind: ActionCardActionKind::Vote,
+            scope: ActionCardScope::Entity,
+            title: format!("Vote on proposal: {}", v.title),
+            summary:
+                "An open proposal awaits your vote in a domain where you have voting standing."
+                    .to_string(),
+            authority_basis: "domain_membership".to_string(),
+            required_authority_scope: vec![format!("vote_in:{}", v.domain_id)],
+            deadline: v.closes_at,
+            risk_level: ActionCardRiskLevel::Normal,
+            accessibility_hint:
+                "Plain-language proposal summary available; alternate formats on request."
+                    .to_string(),
+            receipt_expected: true,
+            source_id: v.proposal_id,
+            domain_id: Some(v.domain_id),
+        });
+    }
+
+    for m in digest.upcoming_meetings {
+        cards.push(ActionCard {
+            id: format!("card-meeting-{}-attend", m.meeting_id),
+            source_kind: ActionCardSourceKind::Meeting,
+            action_kind: ActionCardActionKind::Attend,
+            scope: ActionCardScope::Structure,
+            title: format!("Attend meeting: {}", m.title),
+            summary: "A scheduled meeting includes you on the attendee list.".to_string(),
+            authority_basis: "meeting_attendee".to_string(),
+            required_authority_scope: Vec::new(),
+            deadline: Some(m.scheduled_at),
+            risk_level: ActionCardRiskLevel::Low,
+            accessibility_hint:
+                "Meeting accessibility provisions available on request from the host structure."
+                    .to_string(),
+            receipt_expected: false,
+            source_id: m.meeting_id,
+            domain_id: Some(m.domain_id),
+        });
+    }
+
+    // 2. Open assigned action items. `list_work_for_person` with the
+    //    `assigned_to` filter (which sets `open_only: true`) covers the
+    //    broader "any open assigned work" set — strictly larger than the
+    //    digest's `overdue_items` subset.
+    let work_filter = ActionItemFilter::assigned_to(caller.clone());
+    let items = ctx
+        .manager
+        .list_work_for_person(&caller, &work_filter)
+        .map_err(anyhow_to_api)?;
+
+    for item in items {
+        let item_id_str = item.id.to_string();
+        cards.push(ActionCard {
+            id: format!("card-action_item-{}-complete", item_id_str),
+            source_kind: ActionCardSourceKind::ActionItem,
+            action_kind: ActionCardActionKind::Complete,
+            scope: ActionCardScope::Individual,
+            title: format!("Complete: {}", item.title),
+            summary: item
+                .description
+                .clone()
+                .unwrap_or_else(|| "An assigned action item is awaiting your work.".to_string()),
+            authority_basis: "assigned_action_item".to_string(),
+            required_authority_scope: vec![format!("complete:{}", item_id_str)],
+            deadline: item.due_date,
+            risk_level: match item.priority {
+                ActionItemPriority::Critical | ActionItemPriority::High => {
+                    ActionCardRiskLevel::Elevated
+                }
+                ActionItemPriority::Medium => ActionCardRiskLevel::Normal,
+                ActionItemPriority::Low => ActionCardRiskLevel::Low,
+            },
+            accessibility_hint:
+                "Action items may be reassigned or accommodated; ask the owning structure."
+                    .to_string(),
+            receipt_expected: true,
+            source_id: item_id_str,
+            domain_id: Some(item.domain_id.0),
+        });
+    }
+
+    // Stable order: deadline ascending (cards without a deadline last), then
+    // id ascending. Deterministic so two identical requests return identical
+    // payloads — required for the derived-view contract in ADR-0027.
+    cards.sort_by(|a, b| match (a.deadline, b.deadline) {
+        (Some(da), Some(db)) => da.cmp(&db).then_with(|| a.id.cmp(&b.id)),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => a.id.cmp(&b.id),
+    });
+
+    Ok(HttpResponse::Ok().json(ActionCardsResponse {
+        did: caller.to_string(),
+        cards,
+        generated_at: now,
+    }))
+}
+
 // ============================================================================
 // Tests — governance → execution bridge
 // ============================================================================

--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -168,6 +168,122 @@ pub struct StandingRoleAssignment {
 }
 
 // ============================================================================
+// Action cards (read model for `GET /me/action-cards`)
+// ============================================================================
+
+/// Where a card is derived from. Closed taxonomy. Variants `SignalRule` and
+/// `ObligationLifecycle` are reserved by issue #1646 for future implementation;
+/// the runtime does not emit them today.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionCardSourceKind {
+    Proposal,
+    Meeting,
+    ActionItem,
+    SignalRule,
+    ObligationLifecycle,
+}
+
+/// What the holder is being asked to do. Closed taxonomy. New variants land
+/// when their source path implementation lands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionCardActionKind {
+    /// Cast a vote on a proposal.
+    Vote,
+    /// Attend a scheduled meeting.
+    Attend,
+    /// Complete an assigned action item.
+    Complete,
+}
+
+/// What the card targets. Maps to ICN's `entity / structure / individual`
+/// constitutional axes; institution packages bind their local taxonomy to
+/// these.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionCardScope {
+    Entity,
+    Structure,
+    Individual,
+}
+
+/// Coarse risk indicator surfaced to the holder. UI may sort or annotate but
+/// must not hide cards. Exact semantics are policy concerns; this enum carries
+/// a conservative three-level vocabulary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionCardRiskLevel {
+    Low,
+    Normal,
+    Elevated,
+}
+
+/// One pending action card for the authenticated caller.
+///
+/// Returned by `GET /v1/gov/me/action-cards`. Cards are **derived views** —
+/// computed at request time from the caller's standing plus open governance
+/// state — never stored entities. Two requests at the same moment from the
+/// same DID return identical cards. See ADR-0027.
+///
+/// ## Boundary
+///
+/// All fields are generic. No institution-specific vocabulary. Institution
+/// packages translate their local templates into these generic kinds; ICN
+/// does not learn package-specific nouns from this surface.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ActionCard {
+    /// Stable, deterministic id of the card. Format:
+    /// `card-<source_kind>-<source_id>` so the same underlying object yields
+    /// the same card id across requests.
+    pub id: String,
+    pub source_kind: ActionCardSourceKind,
+    pub action_kind: ActionCardActionKind,
+    pub scope: ActionCardScope,
+    /// Short, plain-language title. Suitable for a list row.
+    pub title: String,
+    /// One-line plain-language summary of what this card is asking the
+    /// holder to do.
+    pub summary: String,
+    /// Why the caller has the right to act here, in plain language. Examples:
+    /// `"role_assignment_in_domain"`, `"assigned_action_item"`,
+    /// `"meeting_attendee"`.
+    pub authority_basis: String,
+    /// Authority-scope strings the kernel would expect for this action.
+    /// Generic; institution packages may use richer strings.
+    pub required_authority_scope: Vec<String>,
+    /// Optional Unix-seconds deadline. `None` means no time pressure encoded
+    /// by this card.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deadline: Option<u64>,
+    pub risk_level: ActionCardRiskLevel,
+    /// Accessibility note for the rendering shell. Generic across institutions;
+    /// today the runtime emits the same baseline note for all cards.
+    pub accessibility_hint: String,
+    /// Whether successful completion of this action is expected to produce a
+    /// receipt (governance receipt, attendance receipt, action-item completion
+    /// receipt).
+    pub receipt_expected: bool,
+    /// Underlying object id (proposal id, meeting id, action item id).
+    pub source_id: String,
+    /// Governance domain this card lives under, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub domain_id: Option<String>,
+}
+
+/// Wrapper response for `GET /me/action-cards`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ActionCardsResponse {
+    /// The authenticated caller's DID.
+    pub did: String,
+    /// Pending cards for the caller, derived at request time. May be empty.
+    pub cards: Vec<ActionCard>,
+    /// Unix-seconds when this card set was computed. Snapshot only — nothing
+    /// is cached server-side.
+    pub generated_at: u64,
+}
+
+// ============================================================================
 // Proposals
 // ============================================================================
 

--- a/icn/apps/governance/tests/me_action_cards.rs
+++ b/icn/apps/governance/tests/me_action_cards.rs
@@ -1,0 +1,344 @@
+//! `GET /v1/gov/me/action-cards` integration tests (issue icn#1646).
+//!
+//! Proves the first runtime slice of the action-cards surface defined by
+//! ADR-0027 and seated on top of the `/me/standing` activation chain
+//! recorded in ADR-0020 (step 7).
+//!
+//! 1. A holder with mixed standing inputs — one open proposal in their
+//!    domain, one scheduled meeting where they are an attendee, one
+//!    assigned action item — receives three cards with the expected
+//!    `source_kind` and `action_kind` values, the underlying `source_id`,
+//!    and a deterministic id.
+//! 2. The response payload uses regulatory-safe vocabulary (no payment /
+//!    currency / balance / wallet terms).
+//! 3. A different DID does not see the first DID's cards.
+//! 4. The reserved `signal_rule` and `obligation_lifecycle` source kinds
+//!    are not emitted today.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use actix_web::{body::to_bytes, dev::Service as _, http::StatusCode, test, App, HttpMessage};
+use icn_governance::{
+    ActionItemPriority, AttendanceStatus, GovernanceDomainId, GovernanceParams, MeetingAttendee,
+    MeetingRole, MembershipConfig, MembershipSource, ProposalId, ProposalPayload, ProposalScope,
+};
+use icn_governance_actor::{
+    http::{self, GovernanceContext},
+    manager::GovernanceManager,
+    NoopEventEmitter,
+};
+use icn_http_kit::auth::BasicClaims;
+use icn_identity::{Did, IdentityBundle};
+use serde_json::Value;
+
+fn fresh_did() -> Did {
+    IdentityBundle::generate()
+        .expect("IdentityBundle::generate")
+        .did()
+        .clone()
+}
+
+fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
+    GovernanceContext {
+        manager: Arc::new(GovernanceManager::new()),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: None,
+        on_proposal_accepted_with_evidence: None,
+        member_checker: None,
+        steward_checker: None,
+        suspension_checker: None,
+        membership_resolver: None,
+        sdis_service: None,
+    }
+}
+
+/// Stand up a domain with `caller` in the static member list. Returns the
+/// domain id so callers can pin proposals/action items into it.
+async fn seed_domain_with_member(
+    mgr: &GovernanceManager,
+    caller: &Did,
+    domain_id: &str,
+) -> GovernanceDomainId {
+    let domain = GovernanceDomainId::new(domain_id);
+    mgr.create_domain(
+        domain.clone(),
+        "Test Coop".to_string(),
+        "default".to_string(),
+        GovernanceParams {
+            quorum_percentage: 1,
+            approval_threshold_percentage: 51,
+            voting_period_seconds: 86_400,
+            require_deliberation: false,
+            ..GovernanceParams::default()
+        },
+        MembershipConfig {
+            source: MembershipSource::StaticList(vec![caller.clone()]),
+        },
+    )
+    .await
+    .expect("create_domain");
+    domain
+}
+
+macro_rules! action_cards_test_app {
+    ($ctx:expr, $caller_did:expr, $scope:expr) => {{
+        let scope: Option<&'static str> = $scope;
+        let caller = $caller_did.to_string();
+        test::init_service(
+            App::new()
+                .wrap_fn(move |req, srv| {
+                    if let Some(scope_str) = scope {
+                        req.extensions_mut().insert(BasicClaims {
+                            sub: caller.clone(),
+                            scope: Some(scope_str.to_string()),
+                        });
+                    }
+                    srv.call(req)
+                })
+                .configure(|cfg| http::configure(cfg, $ctx)),
+        )
+        .await
+    }};
+}
+
+macro_rules! fetch_action_cards {
+    ($app:expr, $uri:expr) => {{
+        let req = test::TestRequest::get().uri($uri).to_request();
+        let resp = test::call_service(&$app, req).await;
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body()).await.unwrap();
+        let parsed: Value = serde_json::from_slice(&bytes).expect("response is valid JSON");
+        (status, parsed)
+    }};
+}
+
+#[actix_web::test]
+async fn caller_with_no_inputs_returns_well_formed_empty_card_set() {
+    let ctx = make_ctx();
+    let caller = fresh_did();
+    let app = action_cards_test_app!(ctx, &caller, Some("governance:read"));
+
+    let (status, body) = fetch_action_cards!(app, "/me/action-cards");
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["did"], caller.to_string());
+    assert!(
+        body["cards"].as_array().unwrap().is_empty(),
+        "no inputs should produce no cards, not an error"
+    );
+    assert!(body["generated_at"].as_u64().is_some());
+}
+
+#[actix_web::test]
+async fn mixed_inputs_produce_one_card_per_source() {
+    let ctx = make_ctx();
+    let caller = fresh_did();
+    let domain = seed_domain_with_member(&ctx.manager, &caller, "test-coop").await;
+
+    // ── Source 1: open proposal in caller's domain ────────────────────────
+    let proposal_id = ProposalId(format!("prop-{}", uuid::Uuid::new_v4()));
+    ctx.manager
+        .create_proposal(
+            proposal_id.clone(),
+            domain.clone(),
+            caller.clone(),
+            "Adopt fictional statement".to_string(),
+            "A test proposal awaiting the holder's vote.".to_string(),
+            ProposalPayload::Text {
+                body: "We endorse this fictional statement.".to_string(),
+            },
+            ProposalScope::Local,
+        )
+        .await
+        .expect("create_proposal");
+    ctx.manager
+        .open_proposal(proposal_id.clone(), 86_400)
+        .await
+        .expect("open_proposal");
+
+    // ── Source 2: meeting in next 48h with caller on attendee list ───────
+    // The digest helper looks at the meeting store's `list_upcoming` window
+    // measured against the wall clock; scheduling at +1h covers any test
+    // jitter without overshooting the 48h bound.
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_secs();
+    let meeting = ctx
+        .manager
+        .create_meeting(
+            domain.0.clone(),
+            "Quarterly review (fictional)".to_string(),
+            None,
+            Some(now_secs + 3_600),
+            "did:icn:organizer".to_string(),
+        )
+        .expect("create_meeting");
+    let mut updated = meeting.clone();
+    updated.attendees = vec![MeetingAttendee {
+        did: caller.as_str().to_owned(),
+        status: AttendanceStatus::Invited,
+        meeting_role: MeetingRole::Participant,
+    }];
+    ctx.manager
+        .update_meeting(&updated)
+        .expect("update_meeting");
+
+    // ── Source 3: action item assigned to caller ─────────────────────────
+    let item = ctx
+        .manager
+        .create_action_item(
+            domain.clone(),
+            "Draft fictional onboarding note".to_string(),
+            Some("Background: a fictional onboarding example.".to_string()),
+            caller.clone(),
+            Some(caller.clone()),
+            None,
+            ActionItemPriority::Medium,
+            None,
+            None,
+            vec!["fictional".to_string()],
+        )
+        .expect("create_action_item");
+
+    // ── Exercise the endpoint ────────────────────────────────────────────
+    let app = action_cards_test_app!(ctx, &caller, Some("governance:read"));
+    let (status, body) = fetch_action_cards!(app, "/me/action-cards");
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["did"], caller.to_string());
+
+    let cards = body["cards"].as_array().expect("cards is an array");
+    assert_eq!(
+        cards.len(),
+        3,
+        "expected one card per source (proposal + meeting + action_item); got {cards:?}"
+    );
+
+    // Index by source_kind so order-independence is explicit.
+    let by_source: std::collections::HashMap<&str, &Value> = cards
+        .iter()
+        .map(|c| (c["source_kind"].as_str().unwrap(), c))
+        .collect();
+
+    let proposal_card = by_source
+        .get("proposal")
+        .expect("expected a proposal-source card");
+    assert_eq!(proposal_card["action_kind"], "vote");
+    assert_eq!(proposal_card["scope"], "entity");
+    assert_eq!(proposal_card["source_id"], proposal_id.0);
+    assert_eq!(proposal_card["domain_id"], domain.0);
+    assert_eq!(proposal_card["receipt_expected"], true);
+    assert_eq!(proposal_card["risk_level"], "normal");
+    assert_eq!(
+        proposal_card["id"],
+        format!("card-proposal-{}-vote", proposal_id.0),
+        "proposal-card id must be deterministic per ADR-0027"
+    );
+
+    let meeting_card = by_source
+        .get("meeting")
+        .expect("expected a meeting-source card");
+    assert_eq!(meeting_card["action_kind"], "attend");
+    assert_eq!(meeting_card["scope"], "structure");
+    assert_eq!(meeting_card["source_id"], meeting.id.0);
+    assert!(
+        meeting_card["deadline"].as_u64().unwrap() >= now_secs,
+        "scheduled meeting deadline must be in the future"
+    );
+    assert_eq!(meeting_card["receipt_expected"], false);
+
+    let item_card = by_source
+        .get("action_item")
+        .expect("expected an action_item-source card");
+    assert_eq!(item_card["action_kind"], "complete");
+    assert_eq!(item_card["scope"], "individual");
+    assert_eq!(item_card["source_id"], item.id.to_string());
+    assert_eq!(item_card["receipt_expected"], true);
+
+    // Reserved variants must NOT appear in this slice (icn#1646 leaves them
+    // unimplemented; icn#1631 and icn#1634 are the gating issues).
+    for source in ["signal_rule", "obligation_lifecycle"] {
+        assert!(
+            !by_source.contains_key(source),
+            "source_kind '{source}' is reserved by icn#1646 and must not be emitted today"
+        );
+    }
+}
+
+#[actix_web::test]
+async fn response_uses_regulatory_safe_vocabulary() {
+    let ctx = make_ctx();
+    let caller = fresh_did();
+    let domain = seed_domain_with_member(&ctx.manager, &caller, "test-coop").await;
+
+    // One proposal is enough to populate the response with prose fields
+    // (title, summary, authority_basis, accessibility_hint).
+    let proposal_id = ProposalId(format!("prop-{}", uuid::Uuid::new_v4()));
+    ctx.manager
+        .create_proposal(
+            proposal_id.clone(),
+            domain.clone(),
+            caller.clone(),
+            "Vocabulary check (fictional)".to_string(),
+            "Make sure the action-cards surface stays away from regulated-finance vocabulary."
+                .to_string(),
+            ProposalPayload::Text {
+                body: "endorse".to_string(),
+            },
+            ProposalScope::Local,
+        )
+        .await
+        .expect("create_proposal");
+    ctx.manager
+        .open_proposal(proposal_id, 86_400)
+        .await
+        .expect("open_proposal");
+
+    let app = action_cards_test_app!(ctx, &caller, Some("governance:read"));
+    let (status, body) = fetch_action_cards!(app, "/me/action-cards");
+    assert_eq!(status, StatusCode::OK);
+    let raw_lower = body.to_string().to_lowercase();
+    for forbidden in ["payment", "wallet", "balance", "currency"] {
+        assert!(
+            !raw_lower.contains(forbidden),
+            "/me/action-cards response must not contain forbidden term '{forbidden}': {raw_lower}"
+        );
+    }
+}
+
+#[actix_web::test]
+async fn caller_does_not_see_another_dids_cards() {
+    let ctx = make_ctx();
+    let alice = fresh_did();
+    let bob = fresh_did();
+    assert_ne!(alice, bob);
+
+    let domain = seed_domain_with_member(&ctx.manager, &alice, "test-coop").await;
+    let _ = ctx
+        .manager
+        .create_action_item(
+            domain.clone(),
+            "Alice's private fictional task".to_string(),
+            None,
+            alice.clone(),
+            Some(alice.clone()),
+            None,
+            ActionItemPriority::Medium,
+            None,
+            None,
+            vec!["fictional".to_string()],
+        )
+        .expect("create_action_item");
+
+    // Bob hits the endpoint; he gets *his* (empty) card set, not Alice's.
+    let app = action_cards_test_app!(ctx, &bob, Some("governance:read"));
+    let (status, body) = fetch_action_cards!(app, "/me/action-cards");
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["did"], bob.to_string());
+    assert!(
+        body["cards"].as_array().unwrap().is_empty(),
+        "bob must not inherit alice's assigned cards"
+    );
+}


### PR DESCRIPTION
## Summary

Implements the first runtime slice of `GET /v1/gov/me/action-cards` on top of `/me/standing`. Moves the member-facing loop from "standing is visible" toward the proof loop:

> **standing → action card → authorized action → receipt**

## Sources currently producing cards

Closed enum (per ADR-0027 + icn#1646 spec):

| `source_kind` | `action_kind` | Derivation |
|---|---|---|
| `proposal` | `vote` | Open proposals where the caller has voting standing and has not yet voted (reuses `digest_pending_votes`) |
| `meeting` | `attend` | Meetings scheduled in the next 48 h where the caller is on the attendee list (reuses `digest_upcoming_meetings`) |
| `action_item` | `complete` | Open action items assigned to the caller (`list_work_for_person` with `assigned_to` filter — broader than the digest's `overdue_items` subset) |

## Sources reserved (not implemented in this PR)

- `signal_rule` — gated on icn#1631
- `obligation_lifecycle` — gated on icn#1634

Per ADR-0027 the taxonomy is closed; new variants land alongside their source-path implementation.

## Changes

- Adds the generic `ActionCard` runtime contract (id, source_kind, action_kind, scope, title, summary, authority_basis, required_authority_scope, deadline, risk_level, accessibility_hint, receipt_expected, source_id, domain_id) in `icn/apps/governance/src/http/models.rs`.
- Adds `GET /v1/gov/me/action-cards` handler `get_my_action_cards` in `icn/apps/governance/src/http/handlers.rs`, composing existing `manager.generate_digest` + `manager.list_work_for_person` (no new manager APIs, no duplicated auth logic).
- Wires the route alongside `/me/standing` in `icn/apps/governance/src/http/configure.rs`.
- Adds JSON schema `docs/contracts/institution-package/action-card.schema.json` with `x-icn-status: rfc`, usable by NYCN later to validate `institution/action-card-templates.example.yaml`.
- Adds integration tests `icn/apps/governance/tests/me_action_cards.rs`:
  - Empty card set for a holder with no inputs.
  - **Mixed inputs (one proposal + one meeting + one action item) yield three cards with the expected `source_kind`/`action_kind` and deterministic ids** — the icn#1646 acceptance test.
  - Regulatory-safe vocabulary check (no wallet/balance/currency/payment).
  - Cross-DID isolation (Bob does not see Alice's cards).
- Updates ADR-0020 row 7 + `implementation_status` to record the vertical slice with evidence paths. Notes the reserved variants are still pending.

## Boundary

- ✅ No NYCN/Summit-specific nouns in ICN core. `ActionCard` shape is generic; institution packages bind their templates onto these kinds.
- ✅ No public website changes.
- ✅ No DNS / Cloudflare / deployment changes.
- ✅ No `learn.icn.zone` link added.
- ✅ No payment/wallet/balance/currency vocabulary in the new surface.
- ✅ Additive only. `/me/standing` shape and behavior unchanged; `me_standing` integration tests still pass.

## Validation

Local gates (run from `icn/icn`):

- `cargo fmt --all --check` — clean
- `cargo clippy -p icn-governance-actor --all-targets -- -D warnings` — clean
- `cargo test -p icn-governance-actor --test me_action_cards` — 4/4 pass
- `cargo test -p icn-governance-actor --test me_standing` — 9/9 pass (no regression)

Repo-level gates:

- `python3 docs/scripts/doc_control_check.py --strict` — pass (36 pre-existing enforcement warnings, none introduced)
- `git diff --check` — clean
- `grep -RInE 'NYCN|New York Cooperative|Summit|reference federation|first institution package' website/src` — clean (no website changes)
- `grep -RInE 'wallet|balance|currency|payment'` against new files — only matches in the explicit "forbidden" list inside the regulatory-safe-vocabulary test assertion

## Closes

Refs icn#1646. Leaves icn#1646 open: the reserved `signal_rule` and `obligation_lifecycle` source paths are not implemented in this slice and the issue should close only after icn#1631 and icn#1634 land their source paths.