### PR TITLE
docs(state): record action-card runtime landing (#1659/#1660/#1661)

### DIFF
--- a/docs/PHASE_PROGRESS.md
+++ b/docs/PHASE_PROGRESS.md
@@ -1,6 +1,15 @@
 # ICN Phase Progress
-**Last Updated:** 2026-04-26
-**Current Phase:** Phase 2 — Pilot Launch (still blocked on cooperative partners; institutional-operability infrastructure for pilot enablement is now in place)
+**Last Updated:** 2026-04-27
+**Current Phase:** Phase 2 — Pilot Launch (still blocked on cooperative partners; institutional-operability infrastructure and partial action-card runtime are now in place)
+
+<!-- [sync edit] 2026-04-27: Phase 2 status unchanged (still blocked on
+     cooperative partners). Phase 2 deliverables list extended to record
+     the action-card runtime that landed 2026-04-27 (#1659/#1660/#1661):
+     /me/action-cards endpoint, proposal/vote receipt proof loop verified,
+     action_item/complete receipt proof loop verified. Issue #1646 remains
+     open; meeting/attend, signal_rule, and obligation_lifecycle source
+     paths remain pending. These do not flip Phase 2 to ✅ on their own —
+     that gate is partner-bound. -->
 
 <!-- [sync edit] 2026-04-26: Phase 2 status unchanged (still blocked on
      cooperative partners). Phase 2 deliverables list extended to record
@@ -125,6 +134,10 @@
 - [x] Generic institution bootstrap package path (#1586)
 - [x] Bootstrap-apply 409 idempotency (#1617) — re-running bootstrap is safe
 - [x] NYCN bootstrap apply integration tests + live-validate runbook (#1592, #1593)
+- [x] `GET /v1/gov/me/action-cards` member endpoint with closed source/action enums (#1659)
+- [x] Action card → `GovernanceDecisionReceipt` proof linkage for proposal/vote (#1660) — proof loop verified
+- [x] `action_item`/`complete` source path emits append-only `ActionItemCompletionReceipt` (#1661) — proof loop verified
+- [ ] Action-card runtime — remaining gates under #1646: `meeting`/`attend` receipt seam; `signal_rule` source path (gated on #1631); `obligation_lifecycle` source path (gated on #1634)
 - [ ] One-command deployment script per cooperative
 - [ ] Charter customization workflow documented (charter activation endpoint exists; non-technical workflow doc still missing)
 - [ ] Pilot onboarding guide (non-technical audience)
@@ -138,6 +151,7 @@
 - Requires cooperative partners identified and committed (primary blocker)
 
 **Decisions Made:**
+- (2026-04-27) Action-card runtime is partial: `/me/action-cards` exists, `proposal`/`vote` and `action_item`/`complete` source paths have verified end-to-end receipt proof loops, and `meeting`/`attend`, `signal_rule`, `obligation_lifecycle` paths remain pending under #1646. Phase 2 status is unaffected.
 - (2026-04-26) Pilot enablement infrastructure (bootstrap, charter activation, role binding, standing) is in place; Phase 2 remains ⏳ until partners run it for real.
 
 ---

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,10 +1,17 @@
 ---
 Status: descriptive
 Canonical: yes
-Last Reviewed: 2026-04-26
+Last Reviewed: 2026-04-27
 ---
 
 # ICN State (living doc)
+
+<!-- [sync edit] 2026-04-27: Append the action-card runtime sequence
+     (/me/action-cards endpoint, proposal/vote receipt linkage,
+     action_item completion receipt seam) landed via #1659/#1660/#1661.
+     Issue #1646 remains open; meeting/attend, signal_rule, and
+     obligation_lifecycle source paths remain pending. Phase model
+     unchanged. -->
 
 <!-- [sync edit] 2026-04-26: Append the institutional-operability sequence
      (live charter activation, person-directory overlay, /me/standing,
@@ -16,15 +23,20 @@ Last Reviewed: 2026-04-26
      Aligned crate list, merged PRs, and metrics to verified repo state.
      Phase model unchanged — phase classification is governance territory (PR C). -->
 
-## Current status (2026-04-26 snapshot)
+## Current status (2026-04-27 snapshot)
 
 **Current phase:** Phase 2 — Pilot Launch (blocked on cooperative partners).
-Active execution: institutional-operability runtime (live charter activation, person-directory overlay, `/me/standing`, `authority_scope` plumbing all landed) plus the feedback/support doctrine rename and ADR canonicalization under `docs/adr/`. NYCN package side dogfoods these via the institution-package boundary. Phase model classification is unchanged; see PHASE_PROGRESS.md for phase definitions.
+Active execution: institutional-operability runtime (live charter activation, person-directory overlay, `/me/standing`, `authority_scope` plumbing) plus the action-card runtime (`/me/action-cards` endpoint with proof-loop linkage to `GovernanceDecisionReceipt` for proposal/vote and `ActionItemCompletionReceipt` for action_item/complete). NYCN package side dogfoods these via the institution-package boundary. Phase model classification is unchanged; see PHASE_PROGRESS.md for phase definitions.
 
 ### Recently merged (since 2026-04-15)
 
 | PR | Title | Merged |
 |----|-------|--------|
+| #1661 | feat(governance): add action item completion receipts | 2026-04-27 |
+| #1660 | feat(governance): connect action cards to receipts | 2026-04-27 |
+| #1659 | feat(gateway): add member action cards endpoint | 2026-04-27 |
+| #1658 | docs(sync): record ICN Academy repo creation | 2026-04-27 |
+| #1656 | docs(site): add curated docs pathways | 2026-04-27 |
 | #1637 | docs: reframe feedback doctrine and canonicalize ADR location | 2026-04-26 |
 | #1630 | feat(governance): plumb authority_scope through assign_role end-to-end | 2026-04-25 |
 | #1627 | feat(governance): add GET /me/standing read model | 2026-04-25 |
@@ -72,6 +84,14 @@ Active execution: institutional-operability runtime (live charter activation, pe
 | #1636 | chore(toolchain): upgrade Rust 1.88.0 → 1.95.0 | copilot/upgrade-rust-1-88-to-1-95 | Open — fmt fix pushed; tests running |
 
 ### What landed since Phase 1 (Charter Engine)
+
+Action-card runtime (added 2026-04-27, partial — issue #1646 remains open):
+- `GET /v1/gov/me/action-cards` member endpoint with closed source/action enums — #1659
+- Proposal/vote action card → `GovernanceDecisionReceipt` proof linkage, end-to-end test — #1660
+- `action_item`/`complete` source path emits append-only `ActionItemCompletionReceipt` (ADR-0026 Layer 2); persist-before-commit semantics; full-update handler routes status changes through receipt-bearing path — #1661
+- Source paths currently emitted by `/me/action-cards`: `proposal`/`vote`, `meeting`/`attend`, `action_item`/`complete`
+- Proof loop verified end-to-end for `proposal`/`vote` and `action_item`/`complete`
+- Pending under #1646: `meeting`/`attend` receipt seam; `signal_rule` source path (gated on #1631); `obligation_lifecycle` source path (gated on #1634)
 
 Institutional-operability runtime (added 2026-04-22 → 2026-04-26):
 - Generic institution bootstrap package path — #1586

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -650,7 +650,7 @@ category = "status"
 status = "living"
 title = "ICN State (living doc)"
 description = "Living snapshot of repo layout, decisions, constraints, and current engineering status"
-last_updated = "2026-04-26"
+last_updated = "2026-04-27"
 owner = "matt"
 audiences = ["developers", "agents"]
 truth_class = "descriptive"
@@ -659,7 +659,7 @@ canonical = "yes"
 freshness = "current"
 domain_tags = ["status", "project"]
 recommended_action = "keep"
-last_reviewed = "2026-04-26"
+last_reviewed = "2026-04-27"
 
 [docs."docs/DOCUMENTATION_CONTROL_SYSTEM.md"]
 category = "reference"


### PR DESCRIPTION
## Summary

Truth-sync update to canonical state docs after the action-card runtime sequence merged 2026-04-27.

## What changed

`docs/STATE.md`:

- Last-reviewed bump to 2026-04-27
- Recently-merged table now includes #1656, #1658, #1659, #1660, #1661
- New "Action-card runtime" section under "What landed since Phase 1" with explicit current-vs-pending breakdown:
  - Currently emitted source paths: `proposal`/`vote`, `meeting`/`attend`, `action_item`/`complete`
  - Proof loop **verified** end-to-end for `proposal`/`vote` and `action_item`/`complete`
  - **Pending** under #1646: `meeting`/`attend` receipt seam; `signal_rule` source path (gated on #1631); `obligation_lifecycle` source path (gated on #1634)

`docs/PHASE_PROGRESS.md`:

- Last-updated bump to 2026-04-27
- Phase 2 deliverables list extended with the three action-card PRs (with appropriate ✅/⏳ markers)
- New decision entry for 2026-04-27 noting partial action-card runtime
- Phase 2 status unchanged — still partner-bound

`docs/registry.toml`:

- `last_updated` and `last_reviewed` for `docs/STATE.md` advanced to 2026-04-27 to keep doc-control aligned

## What this PR does NOT do

- Does **not** close #1646
- Does **not** claim action-card runtime is complete
- Does **not** flip Phase 2 to ✅
- Does **not** introduce NYCN/Summit-specific nouns into ICN core
- Does **not** touch the public website
- Does **not** add `learn.icn.zone` links
- Does **not** touch DNS, Cloudflare, or deployments

## Validation

- `python3 docs/scripts/doc_control_check.py --strict` — 730 docs, 36 pre-existing enforcement warnings (none introduced by this PR)
- `git diff --check` — clean
- public website forbidden-term grep — clean (no NYCN/Summit/reference-federation/learn.icn.zone hits in `website/src`)

## Issue status

Refs #1646.
