### PR TITLE
docs(architecture): name cooperative domain infrastructure direction

### DIFF
--- a/docs/architecture/COOPERATIVE_DOMAIN_INFRASTRUCTURE.md
+++ b/docs/architecture/COOPERATIVE_DOMAIN_INFRASTRUCTURE.md
@@ -285,7 +285,7 @@ What is already in the codebase as substrate this design will sit on (citations 
 | `/me/action-cards` member endpoint | PR #1659 (closed source/action enums per [ADR-0027](../adr/ADR-0027-action-card-contract.md)) |
 | Proposal/vote action card → `GovernanceDecisionReceipt` proof linkage | PR #1660 |
 | Action-item / complete → `ActionItemCompletionReceipt` (ADR-0026 Layer 2) | PR #1661 |
-| Meeting / attend → `MeetingAttendanceReceipt` (ADR-0026 Layer 2) | PR #1663 (in flight at time of writing) |
+| Meeting / attend → `MeetingAttendanceReceipt` (ADR-0026 Layer 2) | PR #1663 |
 | Meeting management (schedule, agenda, attendance, minutes) | PR #1543 |
 | Action items + decision-to-action bridge | PRs #1532, #1547 |
 | Receipts and provenance proof envelope | [ADR-0026](../adr/ADR-0026-receipt-and-provenance-proof-envelope.md) |

--- a/docs/architecture/COOPERATIVE_DOMAIN_INFRASTRUCTURE.md
+++ b/docs/architecture/COOPERATIVE_DOMAIN_INFRASTRUCTURE.md
@@ -1,0 +1,382 @@
+---
+Status: design-direction
+Authority: architecture (forward-direction; not yet normative)
+Canonical: no
+Last Reviewed: 2026-04-27
+---
+
+# Cooperative Domain Infrastructure
+
+> **Status: draft / design direction / roadmap.** This document names a future architecture direction for ICN. It is **not** an implementation report. Where the text describes objects, flows, or tools that do not yet exist in the repository, those are explicitly marked as future / planned. Existing implementation is cited against current source.
+
+## Summary
+
+ICN should provide **cooperative institutional infrastructure**: domains, tools, storage, compute, agreements, routing, and commons resource sharing — governed by ICN primitives (charters, roles, standing, agreements, receipts) and proven by an immutable receipt envelope.
+
+The forward frame for ICN as a whole:
+
+> ICN should become the open cooperative infrastructure layer where institutions run their own domains, install and fork their own tools, store and govern their own data, coordinate with other institutions through explicit agreements, contribute spare infrastructure to the commons, and prove institutional action through receipts.
+
+Cooperative Domain Infrastructure is the **missing middle layer** between ICN's primitives/runtime (already shipping) and the future user-facing tool ecosystem. It is similar in *purpose* to "IAM + a domain controller + office infrastructure", but governed by **charters, roles, standing, agreements, and receipts** rather than corporate tenant administration.
+
+## Repository boundaries
+
+This document lives in the canonical ICN repo (`InterCooperative-Network/icn`). Cross-repo placement of follow-on material:
+
+| Repo | What lives there |
+|---|---|
+| `icn` (this repo) | Generic primitives, runtime, ADRs, RFCs, public website source, and architectural direction documents like this one. **No** institution-specific nouns. |
+| `nycn` | NYCN-specific application of these designs: institution package, domain bindings example, partner workspace examples, Summit operating playbook, Drive/Sheets bridge usage. NYCN-specific operating truth. |
+| `icn-learn` | Teaching surface only. Links back to canonical truth here and operating truth in `nycn`. **Does not define ICN.** |
+
+Boundary rule (per [`INSTITUTION_PACKAGE_BOUNDARY.md`](INSTITUTION_PACKAGE_BOUNDARY.md)): generic shapes go in ICN; institution-specific nouns stay in packages.
+
+## Why this exists
+
+Cooperative institutions today rely on fragmented external tools and private memory: Google Drive folders, ad-hoc spreadsheets, an event ticketing platform, a separate CRM, a CMS no one owns, a Slack with no archive policy. The failure modes are familiar: state captured by vendors, drift between what was decided and what was published, no auditable trail when authority is contested, and no clean migration path when a tool changes terms.
+
+ICN should let cooperative institutions **govern, coordinate, remember, publish, compute, and federate on their own infrastructure**. Not as a SaaS product running for them, but as a substrate they run on hardware they control or hardware they share with peers under explicit agreements.
+
+## Layer model
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│  Learning layer (icn-learn)                                        │
+│   teaches the system; does not define it                           │
+├────────────────────────────────────────────────────────────────────┤
+│  Workstations / endpoints                                          │
+│   member shells, kiosks, event devices, node operator consoles     │
+├────────────────────────────────────────────────────────────────────┤
+│  Hybrid commons cloud                                              │
+│   resource offers, local reserve policy, commons settlement        │
+├────────────────────────────────────────────────────────────────────┤
+│  Live nodes                                                        │
+│   per-institution daemons holding live operational state           │
+├────────────────────────────────────────────────────────────────────┤
+│  Institution packages (e.g. nycn)                                  │
+│   concrete institutional meaning, templates, fixtures, bindings    │
+├────────────────────────────────────────────────────────────────────┤
+│  Specialized tool suites                                           │
+│   cooperative / community / federation / municipal / NYCN-Summit   │
+├────────────────────────────────────────────────────────────────────┤
+│  Tool commons                                                      │
+│   icn-domain-admin, icn-meetings, icn-action-cards, icn-drive, …   │
+├────────────────────────────────────────────────────────────────────┤
+│  Cooperative Domain Infrastructure  ← this document                │
+│   institutional domains, sessions, devices, services, vaults,      │
+│   workspaces, artifact registry, agreements, DNS bindings          │
+├────────────────────────────────────────────────────────────────────┤
+│  Institutional runtime                                             │
+│   charters, governance, meetings, action items, receipts, standing │
+├────────────────────────────────────────────────────────────────────┤
+│  Kernel / substrate                                                │
+│   identity, gossip, ledger journal, compute substrate, gateway     │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+The layers below "Cooperative Domain Infrastructure" exist today (see [Existing repo support](#existing-repo-support)). The layers at and above are mostly future / planned.
+
+## Institutional domains
+
+An **InstitutionalDomain** is the ICN authority/security/governance boundary for an institution. Examples (illustrative): `nycn`, `electric-city-food-coop`, `summit-2026`. An institutional domain owns members, roles, standing, data, tools, agreements, and receipts.
+
+> An institutional domain is **not** a DNS domain. The institutional domain is the ICN object/scope; the DNS domain is a routable address. See [Routing and DNS bindings](#routing-and-dns-bindings).
+
+### Future objects (not yet in the repo)
+
+| Object | Purpose |
+|---|---|
+| `InstitutionalDomain` | Top-level authority/scope object owning the institution's members, devices, services, vaults, workspaces, agreements, and receipts. |
+| `DomainPolicy` | Rules for the domain: who may join, what devices may enroll, what tools may run, what privacy classes exist, how data is shared, when access expires, what requires receipts, what authority is needed for tool/service actions. |
+| `DomainSession` | A member or service's active authenticated/authorized session inside an institutional domain. |
+| `DeviceIdentity` | A DID (or equivalent) identity for a workstation, phone, kiosk, server, node, or event check-in device. |
+| `DeviceEnrollment` | The process and record by which an institution approves a device to participate in its domain. Required for future ICN workstations, kiosks, event devices, office computers, and node operator machines. |
+| `ServiceIdentity` | An identity for a tool, bridge, model runner, compute service, or import adapter. A service identity gets *scoped capabilities*; it never gets blanket access. |
+
+These objects are **planned**. The `Charter` / `RoleAssignment` / `authority_scope` plumbing already in the codebase is the substrate they will sit on.
+
+## Routing and DNS bindings
+
+See the focused doc: [`DOMAIN_ROUTING_AND_DNS_BINDINGS.md`](DOMAIN_ROUTING_AND_DNS_BINDINGS.md).
+
+Quick frame:
+
+| Concept | Example | Notes |
+|---|---|---|
+| Institutional domain | `nycn` | ICN authority boundary |
+| ICN utility route | `nycn.icn.zone` | ICN-managed default; **utility, not canonical truth** |
+| Short route | `icn.zone/n/nycn` | Human-friendly redirect |
+| Custom public domain | An institution's own DNS, e.g. NYCN's public site | Institution-owned; bound to the institutional domain via receipt |
+
+**`icn.zone` is utility routing, not canonical truth.** Canonical public ICN truth lives at `intercooperative.network`. Learning material at `learn.icn.zone` is teaching, not authority.
+
+Verification flow (planned):
+
+```
+request custom domain → add TXT challenge → verify control →
+  approve binding → provision route/cert → emit binding receipt
+```
+
+The verification record (`DnsBinding` + a future receipt envelope entry) is what makes the binding auditable.
+
+## Domain authority
+
+A domain controls authority over **what** can be done by **whom** with **which device or service**. The future surface combines the existing charter/role/standing primitives (already in `icn-governance`) with new device and service identity primitives:
+
+```
+DomainPolicy
+   ↓ authorizes
+DomainSession  ←— authenticates ←— member DID + DeviceIdentity
+   ↓                                                  
+   └─► action attempt
+        ↓
+   DomainPolicy.evaluate(session, action) → allow/deny + scoped capability
+        ↓ if allowed
+   action runs → receipt emitted
+```
+
+Action cards (`/me/action-cards`, ADR-0027) are how the holder *discovers* what they have authority to do; the proof loop `standing → action card → authorized action → receipt` is what makes the surface honest. Receipt-bearing source paths today: `proposal`/`vote`, `action_item`/`complete`, `meeting`/`attend` (the latter as of 2026-04-27). Reserved-but-pending: `signal_rule` (gated on icn#1631), `obligation_lifecycle` (gated on icn#1634).
+
+## Workspaces
+
+A `Workspace` is a **bounded collaboration space** under a domain or agreement. Future use cases (illustrative, fictional):
+
+- a planning workspace for a multi-day convening, scoped to its organizing committee
+- a finance committee workspace, scoped to finance role-holders
+- an accessibility / care workspace, scoped to the care committee and care-requesting members only
+- a shared local-logistics workspace co-owned by two cooperatives under a `SharedWorkspaceAgreement`
+
+Workspaces are not chat channels and not file folders — they are scoped contexts inside which **tools, artifacts, vaults, and agreements compose**.
+
+## Artifact registry and scoped vaults
+
+Two distinct layers:
+
+### `ArtifactRegistry` (planned)
+
+Content-addressed registry for files and documents: docs, PDFs, images, receipts, meeting recordings, attachments, sponsor logos, venue maps, public reports, transcripts, exports. Stores metadata, hashes, versions, ownership, access policy, retention, and provenance.
+
+### `ScopedVault` (planned)
+
+Encrypted storage scoped to a domain, committee, role, member, or agreement. Examples (fictional):
+
+| Vault | Scope |
+|---|---|
+| Finance vault | Finance committee role-holders only |
+| Accessibility / care vault | Care committee + care-requesting member |
+| Public archive | Domain-public, post-publication-receipt |
+| Internal organizer vault | Operating-body role-holders |
+| Personal / member-controlled vault | Single member, recoverable per domain policy |
+
+Rule: **the smallest competent scope owns the data.** Larger scopes get proofs, summaries, indexes, or explicit shared access — not automatic possession.
+
+## Tool commons
+
+See the focused doc: [`COOPERATIVE_TOOL_COMMONS.md`](COOPERATIVE_TOOL_COMMONS.md).
+
+Brief frame: ICN should support a **tool commons** — installable / forkable tools that run on institution-controlled nodes (or governed service nodes) and operate on **institution-owned state**. A tool can render, edit, summarize, import, publish, or assist. A tool **never owns institutional truth**; the domain/node does.
+
+Core base tools (planned identifiers, illustrative):
+
+```
+icn-domain-admin       icn-meetings        icn-drive (artifact vault)
+icn-member-directory   icn-action-cards    icn-docs
+icn-governance         icn-tables          icn-forms
+icn-calendar           icn-publish (CMS)   icn-search
+icn-agreements         icn-budget          icn-signals
+icn-compute-jobs       icn-directory
+```
+
+Specialized suites (cooperative / community / federation / municipal / NYCN-Summit) compose these base tools plus package-specific schemas, templates, and workflows. They are **not** isolated apps.
+
+## Agreements
+
+Federation does **not** mean dumping all data into one shared tenant. Inter-org collaboration happens through explicit, scoped, receipted agreements.
+
+### Future agreement types
+
+| Type | Purpose |
+|---|---|
+| `MembershipAgreement` | An entity's membership in another (cooperative joins federation, etc.) |
+| `ServiceAgreement` | One institution provides a service to another |
+| `SharedWorkspaceAgreement` | A bounded shared workspace with explicit scope |
+| `DataSharingAgreement` | Specific records / vaults / artifact classes shared, with privacy class and expiry |
+| `ComputeAgreement` | One node runs a compute workload for another under defined limits |
+| `FiscalBridgeAgreement` | One institution acts as fiscal bridge for another (see ADR-0001 candidate, RFC-0013) |
+| `ResourceSharingAgreement` | Spare-capacity sharing into a commons pool |
+| `TemporaryAuthorityAgreement` | Time-bounded delegated authority for an event or task |
+
+**Phrase to keep:** *Domain-local by default. Shared by explicit agreement. Receipted always.*
+
+Today, `Charter`, `RoleAssignment`, and `authority_scope` provide the underlying authority plumbing. The agreement object itself is future buildout.
+
+## Compute and model workloads
+
+See the focused doc: [`MODEL_WORKLOADS_AND_DELIBERATION.md`](MODEL_WORKLOADS_AND_DELIBERATION.md).
+
+Core rule: **models can assist institutions; they cannot govern institutions.**
+
+Compute already exists in the substrate as constrained execution with workload manifest, fuel/resource limits, privacy/determinism classes, scope, resource profile, and optional mandate reference (see [ADR-0030](../adr/ADR-0030-compute-workload-manifest-and-authority-boundary.md), [ADR-0031](../adr/ADR-0031-commons-compute-admission-and-settlement-policy.md)). What is future:
+
+- `ModelArtifact` registry with hashing and versioning
+- explicit advisory-vs-deterministic classification on workloads
+- a deliberation-packet pattern (model produces source-linked draft → governance authorizes → it becomes institutional state)
+
+## Hybrid commons cloud
+
+ICN can eventually become a **cooperative hybrid cloud**: each org node runs local services for its institution **and** contributes safe unused resources to a commons pool.
+
+Future objects:
+
+```
+ResourceOffer              CommonsSettlementReceipt
+ResourceContributionPolicy NodeCapabilityRegistry
+LocalReservePolicy         StorageReplicationOffer
+WorkloadPlacementPolicy    MediaRelayOffer
+UsageReceipt               ChallengePath
+```
+
+**Rule: local sovereignty first; commons contribution second.** An office node must reserve capacity for its own domain (docs, vaults, meetings, identity, backups) **before** offering surplus to the commons.
+
+## Workstations
+
+Long-term endpoint direction (do not start here):
+
+```
+desktop / member shell  →  Linux install profile  →  managed workstation
+   enrollment  →  live USB / event kiosk  →  immutable workstation image
+   →  possible ICN distro
+```
+
+Workstation modes (future): member workstation, organizer workstation, finance workstation, public kiosk, event check-in station, node operator console, classroom / training station, offline field kit.
+
+**Warning:** do not start by building "ICN Linux." Start by making ICN work well on ordinary devices. Then package. Then image. Then maybe distro.
+
+## NYCN / Summit proof path
+
+NYCN is the first institution ecosystem package and the first proof body. The 2026 New York Cooperative Summit (Schenectady, NY, 2026-10-17) is the first pressure test.
+
+NYCN-correct facts (preserve these — they replace prior placeholder text):
+
+| Surface | Value |
+|---|---|
+| Public website | The NYCN repo's documented public domain (NYCN-owned) |
+| Future / default ICN utility route | `nycn.icn.zone` |
+| Possible short route | `icn.zone/n/nycn` |
+| Summit | 2026-10-17, Schenectady, NY |
+| Current Drive / Sheets | Bootstrap / operational source material — **not** the final architecture |
+
+NYCN will need: committees, sponsor pipeline, speaker / session planning, registration / intake, accessibility / care intake, logistics / food / tech planning, public website publishing, meeting / action loop, evaluation / debrief loop, partner workspaces, bridge imports from external sources, action cards, receipts.
+
+**The goal is not to sync Google Drive into a better database.** The goal is for NYCN to eventually run its institutional life on ICN — meetings, decisions, action items, records, docs, tools, agreements, receipts, publishing, and federation relationships.
+
+NYCN-specific application of this architecture lives in the NYCN repo, not here. Follow-up docs are tracked under [Follow-up TODOs](#follow-up-todos).
+
+## Existing repo support
+
+What is already in the codebase as substrate this design will sit on (citations are to the `icn/` workspace at the time of this doc's last review):
+
+| Capability | Where |
+|---|---|
+| Live charter activation | `icn-governance` charter primitives + activation endpoint (PR #1624) |
+| Person-directory overlay (DID binding) | PR #1626 |
+| `/me/standing` read model | PR #1627 |
+| `authority_scope` plumbed through `assign_role` | PR #1630 |
+| `/me/action-cards` member endpoint | PR #1659 (closed source/action enums per [ADR-0027](../adr/ADR-0027-action-card-contract.md)) |
+| Proposal/vote action card → `GovernanceDecisionReceipt` proof linkage | PR #1660 |
+| Action-item / complete → `ActionItemCompletionReceipt` (ADR-0026 Layer 2) | PR #1661 |
+| Meeting / attend → `MeetingAttendanceReceipt` (ADR-0026 Layer 2) | PR #1663 (in flight at time of writing) |
+| Meeting management (schedule, agenda, attendance, minutes) | PR #1543 |
+| Action items + decision-to-action bridge | PRs #1532, #1547 |
+| Receipts and provenance proof envelope | [ADR-0026](../adr/ADR-0026-receipt-and-provenance-proof-envelope.md) |
+| Compute substrate (workload manifest, fuel/resource limits) | [ADR-0030](../adr/ADR-0030-compute-workload-manifest-and-authority-boundary.md) |
+| Commons compute (admission and settlement policy) | [ADR-0031](../adr/ADR-0031-commons-compute-admission-and-settlement-policy.md) |
+| Institution package boundary | [`INSTITUTION_PACKAGE_BOUNDARY.md`](INSTITUTION_PACKAGE_BOUNDARY.md) |
+| Public surface and learning repo architecture | [RFC-0015](../rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md) |
+| NYCN package + smoke flow | NYCN repo (`institution/`, `tools/`) |
+| icn-learn teaching boundary | `icn-learn` repo (`README.md`, `docs/WHERE_TRUTH_LIVES.md`) |
+
+For the canonical implementation snapshot at any point in time, see [`docs/STATE.md`](../STATE.md).
+
+## Missing buildout
+
+Future / planned, not in the repo today:
+
+- Domain identity & sessions: `InstitutionalDomain`, `DomainPolicy`, `DomainSession`
+- Devices & services: `DeviceIdentity`, `DeviceEnrollment`, `ServiceIdentity`
+- Spaces: `Workspace`, `ArtifactRegistry`, `ScopedVault`
+- Tools: `ToolManifest`, `ToolBinding`, third-party tool ecosystem, tool install/upgrade/fork/suspend lifecycle
+- Agreements: `AgreementGrant`, the eight `*Agreement` types listed above
+- Routing: `DnsBinding`, verification receipts
+- Publication & bridges: `PublicationReceipt`, `BridgeImportReceipt`
+- Commons cloud: `ResourceOffer`, `LocalReservePolicy`, `WorkloadPlacementPolicy`, `UsageReceipt`, `CommonsSettlementReceipt`, `ChallengePath`
+- Endpoint path: enrollment, kiosks, workstations, eventual ICN distro
+- Action-card source paths still pending under #1646: `signal_rule` (gated on icn#1631), `obligation_lifecycle` (gated on icn#1634)
+
+Each item should land via its own ADR or RFC. This document does not pre-commit shapes; it names the gaps.
+
+## Non-goals
+
+- **No** runtime implementation in this PR. This is documentation only.
+- **No** public website changes from this PR.
+- **No** institution-specific nouns (NYCN / Summit / partner names) introduced into ICN core.
+- **No** model governance authority. Models assist; governance authorizes.
+- **No** external tool as source of truth. Tools operate on institution-owned state.
+- **No** ICN-as-platform-landlord. `icn.zone` is utility routing, not authority.
+
+## Build phases
+
+Sequential and additive — none of these phases are committed merge orders, but each implies the previous.
+
+| Phase | What | Why |
+|---|---|---|
+| A | Design docs (this PR + companions) | Name the architecture before coding |
+| B | Artifact / workspace proof | Smallest end-to-end slice: artifact upload → scoped access → publication receipt |
+| C | Meeting / action / document loop | Existing meeting+action runtime + a docs surface above it |
+| D | NYCN Summit tool slice | First specialized suite proving the package boundary holds in production |
+| E | Inter-org workspace agreement | First `SharedWorkspaceAgreement` + scoped capability proof |
+| F | Advisory compute / model workload | Source-linked deliberation packets + advisory class |
+| G | Commons resource offer | First `ResourceOffer` + `LocalReservePolicy` enforcement |
+| H | Tool package ecosystem | `ToolManifest` + install/fork/suspend lifecycle |
+| I | Workstation path | Member shell, kiosk image, eventually ICN distro |
+
+## Non-negotiable rules
+
+- **ICN is infrastructure, not platform.** Institutions run on it; they are not tenants of it.
+- **Tools do not own truth.** The domain/node does. Every tool must support clean export and migration.
+- **Compute assists; governance authorizes.** Models can produce drafts, summaries, classifications, suggestions. Only an authorized institution can turn that output into institutional state.
+- **Agreements scope sharing.** Cross-institution access is never automatic.
+- **Local sovereignty first; commons contribution second.** A node's local domain comes before its commons offer.
+- **Receipts prove institutional transitions.** If a transition matters, it produces a receipt.
+- **Accessibility is first-class.** Every member-facing surface respects [ADR-0028](../adr/ADR-0028-accessibility-baseline-for-member-interfaces.md).
+- **Regulatory-safe vocabulary for ICN-native primitives.** Use obligation / allocation / settlement / unit / position / settlement asset / external settlement instruction / bridge receipt. Avoid payment / wallet / balance / currency for ICN-native primitives.
+
+## Follow-up TODOs
+
+This PR creates the four ICN-side architectural docs as a coherent first slice. The cross-repo follow-ups intentionally live in their own PRs to keep the boundary clean:
+
+- **`nycn` repo**:
+  - `docs/architecture/COOPERATIVE_OFFICE_TOOLS.md` — NYCN application of the tool commons.
+  - `docs/architecture/DOMAIN_AND_AGREEMENT_MODEL.md` — NYCN domain, Summit 2026 workspace, committees, partner agreements, public/private boundaries.
+  - `docs/architecture/HYBRID_COMMONS_INFRA.md` — how NYCN/org nodes could run local services and contribute surplus.
+  - `institution/tool-bindings.example.yaml` — example tool bindings (fictional only).
+  - `institution/shared-workspaces.example.yaml` — example partner workspaces (fictional only).
+  - `institution/domain-bindings.example.yaml` — `nycn.icn.zone`, `icn.zone/n/nycn`, NYCN public domain, possible Summit path. Marked planned/example, not live proof.
+- **`icn-learn` repo**:
+  - `packets/cooperative-domain-infrastructure.md` — teaching summary linking back here.
+  - `packets/tool-commons.md` — teaching summary linking back to [`COOPERATIVE_TOOL_COMMONS.md`](COOPERATIVE_TOOL_COMMONS.md).
+  - `packets/model-assisted-deliberation.md` — teaching summary linking back to [`MODEL_WORKLOADS_AND_DELIBERATION.md`](MODEL_WORKLOADS_AND_DELIBERATION.md).
+  - Each must say it teaches ICN and links to canonical docs; it does not define ICN.
+
+These follow-up PRs MUST NOT introduce NYCN/Summit nouns into the ICN public website, and MUST NOT add `learn.icn.zone` links to the public ICN site.
+
+## References
+
+- Companion architectural docs in this PR:
+  - [`COOPERATIVE_TOOL_COMMONS.md`](COOPERATIVE_TOOL_COMMONS.md)
+  - [`MODEL_WORKLOADS_AND_DELIBERATION.md`](MODEL_WORKLOADS_AND_DELIBERATION.md)
+  - [`DOMAIN_ROUTING_AND_DNS_BINDINGS.md`](DOMAIN_ROUTING_AND_DNS_BINDINGS.md)
+- Existing architecture: [`INSTITUTION_PACKAGE_BOUNDARY.md`](INSTITUTION_PACKAGE_BOUNDARY.md), [`KERNEL_APP_SEPARATION.md`](KERNEL_APP_SEPARATION.md), [`IDENTITY_MEMBERSHIP_ARCHITECTURE.md`](IDENTITY_MEMBERSHIP_ARCHITECTURE.md), [`INSTITUTIONAL_FEEDBACK_AND_SUPPORT_PRIMITIVES.md`](INSTITUTIONAL_FEEDBACK_AND_SUPPORT_PRIMITIVES.md)
+- ADRs: [ADR-0026](../adr/ADR-0026-receipt-and-provenance-proof-envelope.md), [ADR-0027](../adr/ADR-0027-action-card-contract.md), [ADR-0030](../adr/ADR-0030-compute-workload-manifest-and-authority-boundary.md), [ADR-0031](../adr/ADR-0031-commons-compute-admission-and-settlement-policy.md)
+- RFCs: [RFC-0015](../rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md)
+- Implementation snapshot: [`docs/STATE.md`](../STATE.md)

--- a/docs/architecture/COOPERATIVE_DOMAIN_INFRASTRUCTURE.md
+++ b/docs/architecture/COOPERATIVE_DOMAIN_INFRASTRUCTURE.md
@@ -108,7 +108,7 @@ Quick frame:
 | Short route | `icn.zone/n/nycn` | Human-friendly redirect |
 | Custom public domain | An institution's own DNS, e.g. NYCN's public site | Institution-owned; bound to the institutional domain via receipt |
 
-**`icn.zone` is utility routing, not canonical truth.** Canonical public ICN truth lives at `intercooperative.network`. Learning material at `learn.icn.zone` is teaching, not authority.
+**`icn.zone` is the primary public ICN surface** for routing, identity, and short-link authority over ICN's own surface. Institutional domains rooted under it (e.g. `nycn.icn.zone`) are utility routes — not authority over the institution itself. Learning material at `learn.icn.zone` is teaching, not authority.
 
 Verification flow (planned):
 

--- a/docs/architecture/COOPERATIVE_DOMAIN_INFRASTRUCTURE.md
+++ b/docs/architecture/COOPERATIVE_DOMAIN_INFRASTRUCTURE.md
@@ -252,9 +252,9 @@ Workstation modes (future): member workstation, organizer workstation, finance w
 
 **Warning:** do not start by building "ICN Linux." Start by making ICN work well on ordinary devices. Then package. Then image. Then maybe distro.
 
-## NYCN / Summit proof path
+## NYCN / Summit proof path (illustrative example)
 
-NYCN is the first institution ecosystem package and the first proof body. The 2026 New York Cooperative Summit (Schenectady, NY, 2026-10-17) is the first pressure test.
+NYCN is the first institution ecosystem package planned as a proof body for this architecture. The 2026 New York Cooperative Summit (Schenectady, NY, 2026-10-17) is the first pressure test. Per the Non-goals below, NYCN / Summit names appear in this section as an illustrative example of how the generic shapes will be used by a real institution package — not as a normative ICN core concept.
 
 NYCN-correct facts (preserve these — they replace prior placeholder text):
 
@@ -319,7 +319,7 @@ Each item should land via its own ADR or RFC. This document does not pre-commit 
 
 - **No** runtime implementation in this PR. This is documentation only.
 - **No** public website changes from this PR.
-- **No** institution-specific nouns (NYCN / Summit / partner names) introduced into ICN core.
+- **No** institution-specific operating details or branded nouns introduced as normative ICN core concepts. Institution-specific names (for example, NYCN / Summit / partner names) may appear in this document only as illustrative examples of how generic shapes will be used, not as core protocol or governance dependencies.
 - **No** model governance authority. Models assist; governance authorizes.
 - **No** external tool as source of truth. Tools operate on institution-owned state.
 - **No** ICN-as-platform-landlord. `icn.zone` is utility routing, not authority.

--- a/docs/architecture/COOPERATIVE_TOOL_COMMONS.md
+++ b/docs/architecture/COOPERATIVE_TOOL_COMMONS.md
@@ -110,9 +110,9 @@ A specialized **community suite at local scale** plus a **federation suite at re
 - local / regional resource maps
 - inter-municipal agreements
 
-### NYCN / Summit suite
+### NYCN / Summit suite (illustrative example)
 
-The first specialized suite that ICN will run end-to-end as a proof body. NYCN-specific application docs live in the NYCN repo; this is a forward summary only.
+The first specialized suite that ICN will run end-to-end as a proof body. NYCN-specific application docs live in the NYCN repo; this is a forward summary only, illustrating how a specialized suite would be composed from base tools. Per the Non-goals below, NYCN / Summit names appear here as an illustrative example, not as a core ICN tool ecosystem dependency.
 
 - event CMS
 - registration / intake forms
@@ -237,7 +237,7 @@ Each of these will land via its own ADR or RFC. This document does not pre-commi
 - **No** runtime implementation in this PR.
 - **No** specific tool implementation.
 - **No** public website changes.
-- **No** institution-specific tool nouns in ICN core.
+- **No** institution-specific tool nouns introduced as normative ICN core concepts. Institution-specific names (for example, NYCN / Summit / partner names) may appear in this document only as illustrative examples of how a specialized suite would be composed, not as core tool ecosystem dependencies.
 - **No** "ICN App Store" framing — tool installation is a governance act, not a marketplace transaction.
 
 ## References

--- a/docs/architecture/COOPERATIVE_TOOL_COMMONS.md
+++ b/docs/architecture/COOPERATIVE_TOOL_COMMONS.md
@@ -1,0 +1,249 @@
+---
+Status: design-direction
+Authority: architecture (forward-direction; not yet normative)
+Canonical: no
+Last Reviewed: 2026-04-27
+---
+
+# Cooperative Tool Commons
+
+> **Status: draft / design direction / roadmap.** Names a future tool ecosystem for ICN. Items marked _planned_ are not in the repo today. Companion to [`COOPERATIVE_DOMAIN_INFRASTRUCTURE.md`](COOPERATIVE_DOMAIN_INFRASTRUCTURE.md).
+
+## Summary
+
+ICN should support a **tool commons**: a set of installable / forkable tools that run on institution-controlled nodes (or governed service nodes) and operate on **institution-owned state**. Tools render, edit, summarize, import, publish, or assist. They never own institutional truth.
+
+> **Core principle:** tools do not own institutional truth. The domain/node does.
+
+A tool acts through **scoped capabilities** granted by the domain, and emits **receipts** for meaningful institutional transitions. Tools are replaceable, forkable, and suspendable without trapping the data they operated on.
+
+## Core base tools
+
+The base tools below are **planned identifiers**. They are framed in terms that match the existing ICN runtime (charters, governance, meetings, action items, receipts) and the future domain infrastructure (workspaces, scoped vaults, agreements, DNS bindings).
+
+| Tool | What it does |
+|---|---|
+| `icn-domain-admin` | Manage domain policy, members, roles, devices, service identities, installed tools, DNS bindings, and security posture. The administrative surface for an `InstitutionalDomain`. |
+| `icn-member-directory` | People, member organizations, roles, standing, delegates, contact visibility, member profiles. Reads from the existing person-directory overlay (PR #1626) and `/me/standing` (PR #1627). |
+| `icn-governance` | Proposals, votes, consent, charters, decisions, receipts. Sits on top of `icn-governance` runtime (existing). |
+| `icn-meetings` | Agendas, attendance, minutes, decisions, action items, meeting artifacts, meeting receipts. Sits on top of meeting management (PR #1543) and the meeting/attend receipt seam (PR #1663). |
+| `icn-action-cards` | Member-facing "what needs me?" derived queue. Action cards are not stored tasks; they are views over proposals, meetings, action items, signals, obligations (per [ADR-0027](../adr/ADR-0027-action-card-contract.md)). |
+| `icn-drive` (artifact vault) | Files, folders, versioning, access policy, public/private vaults, external source references. Front-end to the future `ArtifactRegistry` + `ScopedVault`. |
+| `icn-docs` | Collaborative institutional documents tied to meetings, proposals, policies, public pages, playbooks, drafts, reports, and receipts. |
+| `icn-tables` | Human-editable views over typed institutional records. **Not** random spreadsheets as source of truth — typed records first, table view second. |
+| `icn-forms` | Intake, applications, surveys, accessibility/care requests, evaluations, registration, member onboarding. |
+| `icn-calendar` | Meetings, milestones, event schedules, deadlines, public event calendars. |
+| `icn-publish` (CMS) | Public web pages generated from approved records and artifacts. Emits a `PublicationReceipt` per publish. |
+| `icn-search` | Permission-aware search across docs, records, meetings, receipts, artifacts, archives. |
+| `icn-agreements` | Inter-org agreements, shared workspaces, service relationships, data-sharing agreements. UI for the eight `*Agreement` types named in the parent doc. |
+| `icn-budget` (resources) | Obligations, allocations, settlements, positions, resource commitments, public/internal reports. Uses regulatory-safe vocabulary throughout. |
+| `icn-signals` | Feedback, concerns, institutional reflexes, escalation, indicators, challenge paths. |
+| `icn-compute-jobs` | Imports, summaries, translation, transcription, indexing, report generation, model workloads. Sits on the existing compute substrate ([ADR-0030](../adr/ADR-0030-compute-workload-manifest-and-authority-boundary.md), [ADR-0031](../adr/ADR-0031-commons-compute-admission-and-settlement-policy.md)). |
+| `icn-directory` (public directory) | The institution's public-facing organizational directory. |
+
+These compose. A "Summit operating dashboard" is not a new app — it is `icn-meetings` + `icn-tables` + `icn-action-cards` + `icn-publish` + `icn-forms` bound to a package's templates.
+
+## Specialized tool suites
+
+A specialized suite is **mostly a bundle of base tools plus package schemas, templates, and workflows.** Not a fork. Not an isolated app. The package boundary in [`INSTITUTION_PACKAGE_BOUNDARY.md`](INSTITUTION_PACKAGE_BOUNDARY.md) applies: generic shapes in ICN; institution-specific nouns in the package.
+
+### Cooperative suite
+
+For worker co-ops, food co-ops, housing co-ops, service co-ops, platform co-ops:
+
+- member CRM
+- customer / client CRM
+- service desk
+- work scheduling
+- contribution tracking
+- inventory
+- orders / service fulfillment
+- patronage / surplus tools
+- board portal
+- compliance binder
+- training / onboarding
+
+### Community suite
+
+For civic communities, mutual aid networks, neighborhood assemblies, public associations:
+
+- community CMS
+- public forum / deliberation
+- participatory budgeting
+- issue reporting
+- resource map
+- mutual aid coordination
+- events / assemblies
+- surveys / feedback
+- emergency response
+- accessibility / care desk
+- public archive
+
+### Federation suite
+
+For networks of co-ops, communities, institutions:
+
+- member-organization registry
+- inter-org agreements
+- service catalog
+- support programs
+- shared procurement
+- commons resource pool
+- clearing / settlement views (regulatory-safe vocabulary)
+- grants / sponsorship pipeline
+- convening suite (events at federation scale)
+- standards review
+- mediation / dispute resolution
+- federation directory
+
+### Municipal suite
+
+A specialized **community suite at local scale** plus a **federation suite at regional scale**:
+
+- public issue reporting
+- public records
+- forms / permits
+- service requests
+- public meetings
+- participatory budgeting
+- public works dashboard
+- local / regional resource maps
+- inter-municipal agreements
+
+### NYCN / Summit suite
+
+The first specialized suite that ICN will run end-to-end as a proof body. NYCN-specific application docs live in the NYCN repo; this is a forward summary only.
+
+- event CMS
+- registration / intake forms
+- sponsor pipeline
+- speaker / session planning
+- schedule builder
+- food / logistics / tech tables
+- accessibility / care intake
+- meeting / action loop
+- public publishing
+- evaluation forms
+- post-event report generation
+- external bridge imports (Drive / Sheets)
+- partner workspaces by agreement
+
+## Third-party tools
+
+The architecture supports developers and cooperatives writing their own tools.
+
+### Tool install flow (planned)
+
+```
+tool package submitted
+  ↓
+manifest declares capabilities
+  ↓
+institution reviews authority request
+  ↓
+governance / admin approves install
+  ↓
+tool receives ServiceIdentity
+  ↓
+tool accesses only granted scopes
+  ↓
+tool actions produce receipts
+  ↓
+tool can be suspended, upgraded, forked, removed
+```
+
+A `ToolManifest` declares what the tool needs; a `ToolBinding` records how a specific institution has chosen to use it. Both are future objects.
+
+### Tool runtime modes
+
+- **Local node service** — runs on the institution's own ICN node
+- **Frontend-only view** — no service identity, just a client over signed APIs
+- **Compute workload** — runs as an `icn-compute-jobs` workload with workload-manifest constraints
+- **Bridge adapter** — moves data between ICN and an external system; emits `BridgeImportReceipt`
+- **Shared service run by another co-op / federation** — under an explicit `ServiceAgreement`
+- **Workstation app** — runs on an enrolled `DeviceIdentity`
+- **Mobile app** — same enrollment story, smaller form factor
+- **Package template** — not a runtime, just shapes other tools instantiate
+
+### Anti-capture rule
+
+A tool **must never trap institutional state**. The institution owns:
+
+- records (typed institutional data)
+- artifacts (files, media, exports)
+- receipts (the proof envelope)
+- vaults (encrypted scoped storage)
+- permissions (charter / role / `authority_scope` data)
+- export and migration path
+
+A tool that cannot answer "how does the institution leave you cleanly?" should not be installable.
+
+## Capability grants and service identities
+
+Every tool runs as a **service identity**. Tools never receive blanket access. The granted capability set is bound to:
+
+- a `DomainPolicy` (what kinds of actions the domain allows tools to take at all)
+- a `ToolBinding` (what *this institution* allows *this tool* to do)
+- per-action authority checks (existing `authority_scope` plumbing extended to service identities)
+
+This is the same authority discipline that members operate under, applied to non-human actors.
+
+## Receipts emitted by tools
+
+A tool emits a receipt when it produces an institutional transition. Examples (planned):
+
+| Tool action | Receipt class |
+|---|---|
+| Publish a public page | `PublicationReceipt` |
+| Import from Google Drive | `BridgeImportReceipt` |
+| Settle an obligation against a position | existing settlement-receipt path (regulatory-safe vocabulary) |
+| Mark a member as enrolled | governance/onboarding receipt |
+| Run a deliberation summary model job | `icn-compute-jobs` workload receipt + advisory-class flag |
+
+Receipts are how tools prove they did what they claimed; the receipt envelope ([ADR-0026](../adr/ADR-0026-receipt-and-provenance-proof-envelope.md)) is the contract.
+
+## Boundary discipline
+
+- Tools running outside ICN (e.g. an external CMS) **may import** but never **export** institutional truth back as canonical state. Imported data carries an explicit external-source marker on the bridge receipt.
+- Tools never write to a vault scope they were not explicitly granted.
+- Tools that fail or are suspended must leave the institution's records in a recoverable state. The institution's data is never in the tool's database — it is in domain-owned storage that the tool happens to operate on.
+- Specialized suites do **not** fork ICN primitives. They bind generic tools.
+
+## Existing repo support
+
+What is in the codebase today that this design builds on:
+
+- `/me/standing` (PR #1627) and `/me/action-cards` (PR #1659) — the member-facing surfaces a future Action Cards tool will render
+- Charter / role / `authority_scope` plumbing — the policy substrate a `DomainPolicy` will sit on
+- Meeting management (PR #1543), action items (PR #1532), notification digest (PR #1547) — the runtime an `icn-meetings` tool will render
+- Receipt envelope (ADR-0026) — what tool-emitted transitions plug into
+- Compute substrate (ADR-0030 / ADR-0031) — what `icn-compute-jobs` and model workloads run on
+- Institution package boundary ([`INSTITUTION_PACKAGE_BOUNDARY.md`](INSTITUTION_PACKAGE_BOUNDARY.md)) — the rule specialized suites obey
+
+## Missing buildout
+
+| Object | Role |
+|---|---|
+| `ToolManifest` | Declares capabilities, data touched, storage needs, privacy classes, UI surfaces, compute jobs, schemas, receipts emitted |
+| `ToolBinding` | Per-institution configuration; "how `nycn` uses generic `icn-tables` for sponsor pipeline" lives in the NYCN package, not in ICN |
+| `ToolInstall` lifecycle | submit → review → approve → bind → run → suspend → upgrade → fork → remove |
+| Tool capability registry per `InstitutionalDomain` | What tools exist, what scopes they hold, what receipts they emit |
+| Service identity audit trail | Per-tool history visible in the existing receipt query path |
+
+Each of these will land via its own ADR or RFC. This document does not pre-commit shapes.
+
+## Non-goals
+
+- **No** runtime implementation in this PR.
+- **No** specific tool implementation.
+- **No** public website changes.
+- **No** institution-specific tool nouns in ICN core.
+- **No** "ICN App Store" framing — tool installation is a governance act, not a marketplace transaction.
+
+## References
+
+- [`COOPERATIVE_DOMAIN_INFRASTRUCTURE.md`](COOPERATIVE_DOMAIN_INFRASTRUCTURE.md) — parent design
+- [`MODEL_WORKLOADS_AND_DELIBERATION.md`](MODEL_WORKLOADS_AND_DELIBERATION.md) — companion: model workloads as compute jobs
+- [`DOMAIN_ROUTING_AND_DNS_BINDINGS.md`](DOMAIN_ROUTING_AND_DNS_BINDINGS.md) — companion: routing
+- [`INSTITUTION_PACKAGE_BOUNDARY.md`](INSTITUTION_PACKAGE_BOUNDARY.md) — what stays in ICN vs in a package
+- [ADR-0026](../adr/ADR-0026-receipt-and-provenance-proof-envelope.md), [ADR-0027](../adr/ADR-0027-action-card-contract.md), [ADR-0030](../adr/ADR-0030-compute-workload-manifest-and-authority-boundary.md), [ADR-0031](../adr/ADR-0031-commons-compute-admission-and-settlement-policy.md)

--- a/docs/architecture/DOMAIN_ROUTING_AND_DNS_BINDINGS.md
+++ b/docs/architecture/DOMAIN_ROUTING_AND_DNS_BINDINGS.md
@@ -16,7 +16,7 @@ Three concepts, often conflated, must stay distinct:
 | Concept | Example | Authority |
 |---|---|---|
 | **Institutional domain** | `nycn` | ICN authority/security/governance boundary. Owns members, roles, standing, data, tools, agreements, receipts. |
-| **ICN utility route** | `nycn.icn.zone` | ICN-managed default; bootstrap namespace; **utility, not canonical truth**. |
+| **ICN utility route** | `nycn.icn.zone` | ICN-managed sub-route under the `icn.zone` namespace. **Utility route for finding the institution, not the institution's authority.** Authority lives in the `InstitutionalDomain`. |
 | **Custom public domain** | A cooperative's own DNS, e.g. NYCN's public site | Institution-owned. The public face of the institution on the open web. |
 
 Plus a fourth, optional surface:
@@ -144,14 +144,14 @@ For a custom public domain, the same flow applies — the difference is only the
 
 - The routing layer **never** owns institutional truth. It is a router, not a database.
 - A `DnsBinding` does not grant authority over the institutional domain. Authority is governed by charter / role / standing; the binding only routes.
-- `icn.zone` is **utility, not authority**. ICN as a project must not become a landlord of institutional names.
+- `icn.zone` is the ICN-owned public namespace and surface. Institutional sub-routes under it (e.g. `nycn.icn.zone`, `icn.zone/n/nycn`) are **utility routes, not institutional authority**. The institution's authority lives in its `InstitutionalDomain`; DNS never equals institutional authority. ICN as a project must not become a landlord of institutional names.
 - Custom domains never override the primary ICN public surface (`icn.zone`). A cooperative's site can describe ICN; only canonical surfaces under `icn.zone` define ICN.
 
 ## Existing repo support
 
 What exists today that this design will sit on:
 
-- [RFC-0015](../rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md) — public surface and learning repo architecture (governs `icn.zone`, `learn.icn.zone`, and any other ICN-managed surfaces; this design refers to it for canonical-surface roles)
+- [RFC-0015](../rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md) — public surface and learning repo architecture (governs `icn.zone`, `learn.icn.zone`, and any other ICN-managed surfaces; this design refers to it for canonical-surface roles). RFC-0015 frames `icn.zone` as utility routing only; this design's framing of `icn.zone` as the primary ICN-owned public namespace will require a follow-up RFC-0015 amendment to keep the two docs aligned. This PR does not rewrite RFC-0015.
 - Receipt envelope for binding receipts and publication receipts ([ADR-0026](../adr/ADR-0026-receipt-and-provenance-proof-envelope.md))
 - Charter/role/`authority_scope` plumbing for governance acts that approve bindings (existing)
 - Public ICN website source under `website/src` — **does not** carry NYCN/Summit nouns
@@ -171,7 +171,7 @@ What exists today that this design will sit on:
 - **No** public website changes.
 - **No** new NYCN-specific text in `website/src`.
 - **No** `learn.icn.zone` link on the public ICN website (RFC-0015 governs the public surface; this doc does not change it).
-- **No** treatment of `icn.zone` as canonical truth.
+- **No** treatment of an institutional sub-route (e.g. `nycn.icn.zone`) as the institution's authority — authority lives in the `InstitutionalDomain`, not in DNS.
 - **No** vendor lock-in to a specific DNS provider, certificate authority, or routing stack — the design is provider-agnostic.
 
 ## References

--- a/docs/architecture/DOMAIN_ROUTING_AND_DNS_BINDINGS.md
+++ b/docs/architecture/DOMAIN_ROUTING_AND_DNS_BINDINGS.md
@@ -1,0 +1,184 @@
+---
+Status: design-direction
+Authority: architecture (forward-direction; not yet normative)
+Canonical: no
+Last Reviewed: 2026-04-27
+---
+
+# Domain Routing and DNS Bindings
+
+> **Status: draft / design direction / roadmap.** Names a future routing model for ICN. Items marked _planned_ are not in the repo today. Companion to [`COOPERATIVE_DOMAIN_INFRASTRUCTURE.md`](COOPERATIVE_DOMAIN_INFRASTRUCTURE.md).
+
+## Summary
+
+Three concepts, often conflated, must stay distinct:
+
+| Concept | Example | Authority |
+|---|---|---|
+| **Institutional domain** | `nycn` | ICN authority/security/governance boundary. Owns members, roles, standing, data, tools, agreements, receipts. |
+| **ICN utility route** | `nycn.icn.zone` | ICN-managed default; bootstrap namespace; **utility, not canonical truth**. |
+| **Custom public domain** | A cooperative's own DNS, e.g. NYCN's public site | Institution-owned. The public face of the institution on the open web. |
+
+Plus a fourth, optional surface:
+
+| Concept | Example |
+|---|---|
+| **Short route** | `icn.zone/n/nycn` — human-friendly redirect to whichever route the institution wants to expose |
+
+### Why this distinction matters
+
+Cooperative institutions need an authority boundary that does **not** depend on a vendor's DNS. Treating "ICN domain" and "DNS domain" as the same thing rebuilds the platform-landlord pattern: institutions become tenants of whoever owns the DNS namespace.
+
+The institutional domain is the ICN object (`InstitutionalDomain`, planned). The DNS layer is just how packets find an HTTP surface. They bind to each other through an explicit, receipted process; they do not collapse into one thing.
+
+## Routing analogy (not a precedent)
+
+Microsoft gives tenants an `example.onmicrosoft.com` domain and lets them verify `example.org`. ICN can use `icn.zone` similarly as a default utility namespace — but ICN must not become a landlord platform. The institution's real authority is the ICN `InstitutionalDomain`, and the institution may use its own custom public DNS.
+
+The analogy stops at "utility namespace." ICN is not a tenancy.
+
+## Surfaces
+
+| Surface | Use |
+|---|---|
+| `intercooperative.network` | Canonical public ICN truth. Authority over what ICN is. |
+| `icn.zone` | Utility routing. Default institutional bootstrap routes. **Not** canonical truth. |
+| `learn.icn.zone` | Teaching surface (the icn-learn repo's eventual public face). Teaches ICN; does not define it. |
+| Custom institution domain | Each institution's own DNS, owned by the institution. |
+
+> `icn.zone` is utility routing, not canonical truth. Public canonical ICN truth lives at `intercooperative.network`. Learning surfaces live at `learn.icn.zone`.
+
+## Future objects
+
+### `DnsBinding`
+
+A binding between an `InstitutionalDomain` and a routable DNS name.
+
+Future fields (illustrative shape — not yet committed):
+
+- `binding_id`
+- `institutional_domain` (the ICN scope, e.g. `nycn`)
+- `host` (e.g. `nycn.icn.zone` or a custom public domain)
+- `purpose` (`default_icn_zone` / `short_route` / `custom_public_domain` / `event_route` / etc.)
+- `verification` (TXT challenge value, verification method, verification time)
+- `status` (`pending` / `verified` / `revoked`)
+- `binding_receipt_hash` (link into the receipt envelope)
+- `valid_from` / `valid_until` (optional)
+
+A binding is approved by domain governance and emits a receipt. Reversal is a counter-record, not a mutation (consistent with [ADR-0026](../adr/ADR-0026-receipt-and-provenance-proof-envelope.md)).
+
+### Verification flow (planned)
+
+```
+request custom domain                ──► proposal / charter act
+   ↓
+add TXT challenge                    ──► institution adds DNS record
+   ↓
+verify control                       ──► ICN node confirms TXT match
+   ↓
+approve binding                      ──► governance / domain admin act
+   ↓
+provision route / cert               ──► routing layer + ACME or equivalent
+   ↓
+emit binding receipt                 ──► receipt envelope (ADR-0026 Layer 2)
+```
+
+Each step is auditable. The binding's existence is provable from the receipt envelope alone, without trusting the routing layer.
+
+### `PublicationReceipt` (planned)
+
+When content is published to a routed surface (custom domain or `icn.zone` route), the publish action emits a `PublicationReceipt` carrying:
+
+- domain
+- binding the publication used
+- content artifact hash
+- approving governance reference (proposal id or charter id, as applicable)
+- timestamp
+- runner DID
+
+Public surfaces become **provably approved** — the published content can be verified back to a governance act.
+
+## NYCN example (illustrative)
+
+NYCN-correct facts (preserve these — they replace prior placeholder text):
+
+```yaml
+institutional_domain:
+  id: nycn
+  canonical_name: "New York Cooperative Network"
+
+dns_bindings:
+  default_icn_zone:
+    host: nycn.icn.zone
+    purpose: "ICN utility route / bootstrap namespace"
+
+  short_route:
+    host: icn.zone/n/nycn
+    purpose: "Human-friendly ICN short link"
+
+  custom_public_domain:
+    # NYCN's own public domain (held by NYCN, not ICN). Documented in the
+    # NYCN repo, not duplicated into ICN core.
+    purpose: "NYCN public website / public identity"
+
+  possible_summit_route:
+    # Public route for the 2026 Summit (Schenectady, NY, 2026-10-17),
+    # if NYCN chooses to expose one under their custom domain.
+    purpose: "Public route for 2026 Summit (planned/example)"
+```
+
+NYCN-specific binding files (the `institution/domain-bindings.example.yaml` referenced in the parent doc) live in the NYCN repo. ICN core does **not** carry NYCN's specific public domain — that stays where it belongs, in the package.
+
+> **Important:** the prior placeholder `newyorkcooperative.network` is stale and incorrect. NYCN's actual public domain is documented in the NYCN repo (`README.md`, `institution/package.yaml`). Do not introduce NYCN-specific public-domain text into the ICN public website.
+
+## Routing semantics
+
+A request to `nycn.icn.zone/...` should resolve to the routing layer for the `nycn` institutional domain. The routing layer:
+
+1. Checks the requested path against the domain's installed tools (each tool exposes UI surfaces declared in its `ToolManifest`).
+2. Checks the request's authentication against the domain's `DomainPolicy` (a `DomainSession` is established for member traffic; service-identity traffic uses scoped capabilities).
+3. Forwards to the appropriate tool service, or returns the public-facing surface for unauthenticated requests.
+
+For a custom public domain, the same flow applies — the difference is only the host header that arrived. The institution's authority is the same in either case.
+
+## Boundary discipline
+
+- The routing layer **never** owns institutional truth. It is a router, not a database.
+- A `DnsBinding` does not grant authority over the institutional domain. Authority is governed by charter / role / standing; the binding only routes.
+- `icn.zone` is **utility, not authority**. ICN as a project must not become a landlord of institutional names.
+- Custom domains never override the canonical truth surface (`intercooperative.network`). A cooperative's site can describe ICN; only canonical surfaces define ICN.
+
+## Existing repo support
+
+What exists today that this design will sit on:
+
+- [RFC-0015](../rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md) — public surface and learning repo architecture (defines `intercooperative.network`, `icn.zone`, `learn.icn.zone` roles)
+- Receipt envelope for binding receipts and publication receipts ([ADR-0026](../adr/ADR-0026-receipt-and-provenance-proof-envelope.md))
+- Charter/role/`authority_scope` plumbing for governance acts that approve bindings (existing)
+- Public ICN website source under `website/src` — **does not** carry NYCN/Summit nouns
+
+## Missing buildout
+
+- `DnsBinding` object + verification record
+- `PublicationReceipt` class
+- Routing layer for `*.icn.zone` and custom institutional domains
+- Per-tool UI-surface declarations in `ToolManifest`
+- Provisioning automation (ACME or equivalent) gated on a verified binding
+- Per-domain admin UI for managing bindings (future tool: `icn-domain-admin`)
+
+## Non-goals
+
+- **No** runtime implementation in this PR.
+- **No** public website changes.
+- **No** new NYCN-specific text in `website/src`.
+- **No** `learn.icn.zone` link on the public ICN website (RFC-0015 governs the public surface; this doc does not change it).
+- **No** treatment of `icn.zone` as canonical truth.
+- **No** vendor lock-in to a specific DNS provider, certificate authority, or routing stack — the design is provider-agnostic.
+
+## References
+
+- [`COOPERATIVE_DOMAIN_INFRASTRUCTURE.md`](COOPERATIVE_DOMAIN_INFRASTRUCTURE.md) — parent design (institutional domains, agreements, receipts)
+- [`COOPERATIVE_TOOL_COMMONS.md`](COOPERATIVE_TOOL_COMMONS.md) — companion: tools that publish to routed surfaces
+- [`MODEL_WORKLOADS_AND_DELIBERATION.md`](MODEL_WORKLOADS_AND_DELIBERATION.md) — companion: advisory compute
+- [RFC-0015](../rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md)
+- [ADR-0026](../adr/ADR-0026-receipt-and-provenance-proof-envelope.md), [ADR-0027](../adr/ADR-0027-action-card-contract.md)

--- a/docs/architecture/DOMAIN_ROUTING_AND_DNS_BINDINGS.md
+++ b/docs/architecture/DOMAIN_ROUTING_AND_DNS_BINDINGS.md
@@ -39,13 +39,16 @@ The analogy stops at "utility namespace." ICN is not a tenancy.
 
 ## Surfaces
 
-| Surface | Use |
+Per accepted [ADR-0032 — Website Truth Boundary](../adr/ADR-0032-website-truth-boundary.md), public ICN surfaces split into three roles. None of these is institutional authority — institutional authority lives in the `InstitutionalDomain` object, not in DNS.
+
+| Surface | Role |
 |---|---|
-| `icn.zone` | **Primary public ICN surface.** Authority over what ICN is, plus the namespace under which institutional utility routes (e.g. `nycn.icn.zone`) and short-links (e.g. `icn.zone/n/nycn`) live. |
-| `learn.icn.zone` | Teaching surface (the icn-learn repo's eventual public face). Teaches ICN; does not define it. |
+| `intercooperative.network` | **Canonical ICN public truth surface** (ADR-0032). Source of truth for what ICN is, what is real now, and what is planned. |
+| `icn.zone` | **Utility routing namespace.** Short links, QR links, cluster subdomains (`api.icn.zone`, `pilot.icn.zone`, etc.), and institutional utility sub-routes (e.g. `nycn.icn.zone`, `icn.zone/n/nycn`). Root redirects to `intercooperative.network`. Not a truth surface. |
+| `learn.icn.zone` | Future teaching surface (the icn-learn repo's eventual public face). Teaches ICN; does not define it. |
 | Custom institution domain | Each institution's own DNS, owned by the institution. Bound to the institutional domain via a verified `DnsBinding`. |
 
-> `icn.zone` is the primary public ICN surface. Institutional sub-routes under it (`nycn.icn.zone`, `icn.zone/n/nycn`, etc.) are utility routes for finding institutions; they are not the institution's own authority. Learning surfaces live at `learn.icn.zone`.
+> Institutional sub-routes under `icn.zone` (`nycn.icn.zone`, `icn.zone/n/nycn`, etc.) are utility routes for finding/entering institutions. They are not the institution's authority and they are not the canonical public ICN surface. Authority lives in `InstitutionalDomain`; canonical ICN truth lives at `intercooperative.network`.
 
 ## Future objects
 
@@ -144,14 +147,15 @@ For a custom public domain, the same flow applies — the difference is only the
 
 - The routing layer **never** owns institutional truth. It is a router, not a database.
 - A `DnsBinding` does not grant authority over the institutional domain. Authority is governed by charter / role / standing; the binding only routes.
-- `icn.zone` is the ICN-owned public namespace and surface. Institutional sub-routes under it (e.g. `nycn.icn.zone`, `icn.zone/n/nycn`) are **utility routes, not institutional authority**. The institution's authority lives in its `InstitutionalDomain`; DNS never equals institutional authority. ICN as a project must not become a landlord of institutional names.
-- Custom domains never override the primary ICN public surface (`icn.zone`). A cooperative's site can describe ICN; only canonical surfaces under `icn.zone` define ICN.
+- `icn.zone` is an ICN-owned utility-routing namespace. Institutional sub-routes under it (e.g. `nycn.icn.zone`, `icn.zone/n/nycn`) are **utility routes, not institutional authority**. The institution's authority lives in its `InstitutionalDomain`; DNS never equals institutional authority. ICN as a project must not become a landlord of institutional names.
+- Canonical public truth about ICN lives at `intercooperative.network`, per ADR-0032. Custom institution domains and ICN utility routes can describe or link to ICN, but they do not define ICN.
 
 ## Existing repo support
 
 What exists today that this design will sit on:
 
-- [RFC-0015](../rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md) — public surface and learning repo architecture (governs `icn.zone`, `learn.icn.zone`, and any other ICN-managed surfaces; this design refers to it for canonical-surface roles). RFC-0015 frames `icn.zone` as utility routing only; this design's framing of `icn.zone` as the primary ICN-owned public namespace will require a follow-up RFC-0015 amendment to keep the two docs aligned. This PR does not rewrite RFC-0015.
+- [ADR-0032 — Website Truth Boundary](../adr/ADR-0032-website-truth-boundary.md) — accepted; `intercooperative.network` is the canonical public truth surface.
+- [RFC-0015 — Public Surface and Learning Repo Architecture](../rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md) — draft; explores how `intercooperative.network`, `icn.zone`, `learn.icn.zone`, and adjacent surfaces split roles. Cited here as exploratory framing only; the accepted policy is ADR-0032.
 - Receipt envelope for binding receipts and publication receipts ([ADR-0026](../adr/ADR-0026-receipt-and-provenance-proof-envelope.md))
 - Charter/role/`authority_scope` plumbing for governance acts that approve bindings (existing)
 - Public ICN website source under `website/src` — **does not** carry NYCN/Summit nouns
@@ -170,9 +174,10 @@ What exists today that this design will sit on:
 - **No** runtime implementation in this PR.
 - **No** public website changes.
 - **No** new NYCN-specific text in `website/src`.
-- **No** `learn.icn.zone` link on the public ICN website (RFC-0015 governs the public surface; this doc does not change it).
+- **No** `learn.icn.zone` link on the public ICN website. ADR-0032 governs the canonical public surface; RFC-0015 explores the future split. This doc does not change either.
 - **No** treatment of an institutional sub-route (e.g. `nycn.icn.zone`) as the institution's authority — authority lives in the `InstitutionalDomain`, not in DNS.
 - **No** vendor lock-in to a specific DNS provider, certificate authority, or routing stack — the design is provider-agnostic.
+- **No** treatment of `icn.zone` as the canonical public truth surface. ADR-0032 makes `intercooperative.network` the truth boundary; `icn.zone` is utility routing.
 
 ## References
 

--- a/docs/architecture/DOMAIN_ROUTING_AND_DNS_BINDINGS.md
+++ b/docs/architecture/DOMAIN_ROUTING_AND_DNS_BINDINGS.md
@@ -41,12 +41,11 @@ The analogy stops at "utility namespace." ICN is not a tenancy.
 
 | Surface | Use |
 |---|---|
-| `intercooperative.network` | Canonical public ICN truth. Authority over what ICN is. |
-| `icn.zone` | Utility routing. Default institutional bootstrap routes. **Not** canonical truth. |
+| `icn.zone` | **Primary public ICN surface.** Authority over what ICN is, plus the namespace under which institutional utility routes (e.g. `nycn.icn.zone`) and short-links (e.g. `icn.zone/n/nycn`) live. |
 | `learn.icn.zone` | Teaching surface (the icn-learn repo's eventual public face). Teaches ICN; does not define it. |
-| Custom institution domain | Each institution's own DNS, owned by the institution. |
+| Custom institution domain | Each institution's own DNS, owned by the institution. Bound to the institutional domain via a verified `DnsBinding`. |
 
-> `icn.zone` is utility routing, not canonical truth. Public canonical ICN truth lives at `intercooperative.network`. Learning surfaces live at `learn.icn.zone`.
+> `icn.zone` is the primary public ICN surface. Institutional sub-routes under it (`nycn.icn.zone`, `icn.zone/n/nycn`, etc.) are utility routes for finding institutions; they are not the institution's own authority. Learning surfaces live at `learn.icn.zone`.
 
 ## Future objects
 
@@ -146,13 +145,13 @@ For a custom public domain, the same flow applies — the difference is only the
 - The routing layer **never** owns institutional truth. It is a router, not a database.
 - A `DnsBinding` does not grant authority over the institutional domain. Authority is governed by charter / role / standing; the binding only routes.
 - `icn.zone` is **utility, not authority**. ICN as a project must not become a landlord of institutional names.
-- Custom domains never override the canonical truth surface (`intercooperative.network`). A cooperative's site can describe ICN; only canonical surfaces define ICN.
+- Custom domains never override the primary ICN public surface (`icn.zone`). A cooperative's site can describe ICN; only canonical surfaces under `icn.zone` define ICN.
 
 ## Existing repo support
 
 What exists today that this design will sit on:
 
-- [RFC-0015](../rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md) — public surface and learning repo architecture (defines `intercooperative.network`, `icn.zone`, `learn.icn.zone` roles)
+- [RFC-0015](../rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md) — public surface and learning repo architecture (governs `icn.zone`, `learn.icn.zone`, and any other ICN-managed surfaces; this design refers to it for canonical-surface roles)
 - Receipt envelope for binding receipts and publication receipts ([ADR-0026](../adr/ADR-0026-receipt-and-provenance-proof-envelope.md))
 - Charter/role/`authority_scope` plumbing for governance acts that approve bindings (existing)
 - Public ICN website source under `website/src` — **does not** carry NYCN/Summit nouns

--- a/docs/architecture/MODEL_WORKLOADS_AND_DELIBERATION.md
+++ b/docs/architecture/MODEL_WORKLOADS_AND_DELIBERATION.md
@@ -1,0 +1,202 @@
+---
+Status: design-direction
+Authority: architecture (forward-direction; not yet normative)
+Canonical: no
+Last Reviewed: 2026-04-27
+---
+
+# Model Workloads and Deliberation
+
+> **Status: draft / design direction / roadmap.** Names a future class of compute workloads inside ICN — model-driven advisory work that supports deliberation. Items marked _planned_ are not in the repo today. Companion to [`COOPERATIVE_DOMAIN_INFRASTRUCTURE.md`](COOPERATIVE_DOMAIN_INFRASTRUCTURE.md) and [`COOPERATIVE_TOOL_COMMONS.md`](COOPERATIVE_TOOL_COMMONS.md).
+
+## Summary
+
+ICN treats compute as **constrained execution with workload manifests, fuel/resource limits, privacy/determinism classes, scope, resource profile, and optional mandate reference** ([ADR-0030](../adr/ADR-0030-compute-workload-manifest-and-authority-boundary.md), [ADR-0031](../adr/ADR-0031-commons-compute-admission-and-settlement-policy.md)). Models are one kind of compute workload.
+
+> **Compute executes. Compute does not decide.**
+
+> **Models can assist institutions. They cannot govern institutions.**
+
+This document records what models are *for* in ICN, what they are explicitly *not for*, and how their outputs become institutional state — through governance review, never automatically.
+
+## What models are for
+
+Allowed model uses (advisory, source-linked, receipted):
+
+- summarize meeting notes
+- transcribe meetings
+- translate materials
+- create source-linked proposal briefs
+- map arguments in deliberation
+- summarize prior decisions and receipts
+- extract proposed action items
+- classify survey or evaluation themes
+- draft reports and public copy
+- prepare grant or sponsor drafts
+- search archives (permission-aware embeddings)
+- create embeddings for permission-aware search
+- detect missing context or unresolved questions
+
+In every case the model produces a **draft, suggestion, summary, classification, or artifact** — and that artifact remains advisory until an authorized human or governance act takes it up.
+
+## What models are not for
+
+Forbidden model uses:
+
+- **decide votes** — a vote is a member act
+- **approve budgets** — allocation is a governance act
+- **admit or reject members** — a membership decision is a governance act
+- **assign authority** — `authority_scope` is constitutional, not advisory
+- **resolve disputes** — disputes go through institutional process, not model output
+- **rank member worth** — the institution does not have a worth ranking
+- **profile political reliability** — out of scope; not a thing ICN supports
+- **auto-publish restricted data** — publication requires authorization and a publication receipt
+- **auto-settle obligations** — settlement is a governance act with a settlement receipt
+- **auto-sanction people** — sanctions are governance acts with appeal paths
+- **make binding governance decisions** of any kind
+
+Phrasing rule: a model **may** produce a draft; an **authorized institution** turns that output into institutional state.
+
+## Model-assisted deliberation
+
+The most valuable model use in cooperative infrastructure is **getting everyone on the same page**. A model can produce a neutral, source-linked deliberation packet:
+
+- what are we deciding?
+- why are we deciding it?
+- what has already been said?
+- what prior decisions and receipts matter?
+- what are the options?
+- what are the tradeoffs?
+- what objections exist?
+- what questions are unresolved?
+- who is affected?
+- what needs to happen next?
+
+The packet is a **draft / advisory artifact**. It enters institutional state only after an authorized review.
+
+This is not a robot deliberator. It is closer to a research librarian: it cites, it organizes, it does not vote.
+
+## Workload shape
+
+A model workload is a compute workload (per ADR-0030/0031) with a few extra pieces:
+
+| Field | Purpose |
+|---|---|
+| `model_artifact_hash` | Content-addressed reference to the model artifact in a future model registry |
+| `model_version` | Version metadata |
+| `prompt_template_hash` | Hash of the prompt or generation template, so the workload is reproducible |
+| `input_artifact_hashes` | Content-addressed references to inputs (meeting notes, prior receipts, source documents) |
+| `output_artifact_hashes` | Content-addressed references to outputs (draft summary, packet, transcript, classification) |
+| `privacy_class` | Inherits from compute substrate; bounds where the workload may run |
+| `determinism_class` | `advisory` (model output) vs `deterministic` (e.g. canonical hashing). Advisory is the default for model workloads. |
+| `runner_did` | The service identity that executed the workload |
+| `scope` | Scopes the workload to a domain / structure / activity |
+| `output_receipt` | Receipt produced by the workload, advisory-classed |
+| `external_model_bridge_policy` | Whether and how the workload may call out to an external model service |
+
+These are **planned**. Today the substrate has the workload manifest, fuel/resource limits, privacy/determinism classes, scope, resource profile, and optional mandate reference (ADR-0030). The model-specific fields are future additions.
+
+## Model registry (planned)
+
+A `ModelRegistry` records:
+
+- model artifact hash
+- model version
+- provenance (where it came from, who packaged it)
+- license / use restrictions
+- privacy class compatibility
+- known evaluation results
+- federation visibility (per-institution, federation-shared, public-commons)
+
+Without a registry, advisory workloads cannot pin a reproducible model — and a workload that cannot be re-run is not auditable.
+
+## External model bridges
+
+Some institutions will want to call external model services. The bridge is a **service identity** with explicit policy:
+
+- which institutional domain may use it
+- what privacy classes may flow to it
+- what request hashes are recorded
+- what response hashes are recorded
+- whether and how outputs return as artifacts
+- a `BridgeImportReceipt`-style record per call
+
+External model bridges follow the **anti-capture rule**: institutional state never lives at the external service. Inputs and outputs flow back as artifacts under the institution's own `ArtifactRegistry`.
+
+## Receipts and audit
+
+Every advisory workload produces an `output_receipt` carrying:
+
+- workload identity (manifest hash + runner DID)
+- input artifact hashes
+- output artifact hashes
+- prompt / template hash
+- determinism class (advisory)
+- timestamp
+- scope
+
+This is the audit trail that lets an institution later answer "what model produced this draft, against what inputs, on what date?" — without that answer, the draft cannot meaningfully be reviewed or trusted.
+
+## Deliberation pattern (end-to-end, planned)
+
+```
+member opens action card             ──► /me/action-cards (existing)
+"deliberate proposal X"
+       ↓
+governance tool requests deliberation packet
+       ↓
+icn-compute-jobs runs a model workload
+   inputs: proposal text, prior decisions/receipts, comments
+   determinism class: advisory
+       ↓
+output artifact: source-linked deliberation packet
+       ↓
+output receipt persisted in receipt envelope
+       ↓
+members read packet, comment, propose amendments
+       ↓
+governance vote (existing: GovernanceDecisionReceipt path)
+       ↓
+decision becomes institutional state
+       ↓
+action items emitted (existing: decision-to-action bridge, PR #1532)
+```
+
+Model output never short-circuits this loop. Every transition that becomes institutional state is a governance act with a receipt.
+
+## Boundary discipline
+
+- An advisory artifact becomes institutional state **only** after an authorized human or governance act takes it up. The act is what transitions; the artifact is what informed the act.
+- Models do not see vault data they were not explicitly scoped to. Permission-aware embeddings honor scope.
+- Model output never bypasses the receipt envelope. A model-produced public draft becomes a public artifact only after a `PublicationReceipt`.
+- A model that cannot be reproduced (missing artifact hash, missing prompt hash) cannot be cited as a source for institutional state.
+
+## Existing repo support
+
+- Compute substrate: workload manifest, fuel/resource limits, privacy/determinism classes, scope, resource profile, optional mandate reference ([ADR-0030](../adr/ADR-0030-compute-workload-manifest-and-authority-boundary.md))
+- Commons compute admission and settlement policy ([ADR-0031](../adr/ADR-0031-commons-compute-admission-and-settlement-policy.md))
+- Receipt envelope including the artifact-receipt layer ([ADR-0026](../adr/ADR-0026-receipt-and-provenance-proof-envelope.md))
+
+## Missing buildout
+
+- `ModelArtifact` registry with content-addressed hashing
+- explicit `advisory` vs `deterministic` workload classification surface
+- prompt-template hashing convention
+- output-receipt class extension carrying model-specific fields
+- external model bridge service-identity pattern + per-call receipt
+- deliberation-packet template (the source-linked summary shape)
+
+## Non-goals
+
+- **No** automated decision-making on member, governance, allocation, or sanction questions.
+- **No** model-as-arbiter framing.
+- **No** runtime implementation in this PR.
+- **No** specific model vendor or hosting choice — design is bridge-friendly to multiple model runtimes.
+- **No** institution-specific deliberation rules in ICN core. Institution packages can constrain *which* model classes their domain allows, not the substrate's shape.
+
+## References
+
+- [`COOPERATIVE_DOMAIN_INFRASTRUCTURE.md`](COOPERATIVE_DOMAIN_INFRASTRUCTURE.md) — parent design
+- [`COOPERATIVE_TOOL_COMMONS.md`](COOPERATIVE_TOOL_COMMONS.md) — companion: tools
+- [`DOMAIN_ROUTING_AND_DNS_BINDINGS.md`](DOMAIN_ROUTING_AND_DNS_BINDINGS.md) — companion: routing
+- [ADR-0026](../adr/ADR-0026-receipt-and-provenance-proof-envelope.md), [ADR-0030](../adr/ADR-0030-compute-workload-manifest-and-authority-boundary.md), [ADR-0031](../adr/ADR-0031-commons-compute-admission-and-settlement-policy.md)

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -801,6 +801,62 @@ depends_on = ["docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md", "docs/archite
 recommended_action = "keep"
 freshness = "current"
 
+[docs."docs/architecture/COOPERATIVE_DOMAIN_INFRASTRUCTURE.md"]
+category = "architecture"
+status = "draft"
+truth_class = "descriptive"
+title = "Cooperative Domain Infrastructure"
+description = "Forward-direction architecture for cooperative institutional infrastructure: institutional domains, sessions, devices, services, workspaces, artifacts, vaults, agreements, DNS bindings, hybrid commons cloud, workstations. Names what is implemented today vs what is future buildout."
+last_updated = "2026-04-27"
+last_reviewed = "2026-04-27"
+owner = "matt"
+audiences = ["developers", "architects"]
+depends_on = ["docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md", "docs/architecture/KERNEL_APP_SEPARATION.md", "docs/adr/ADR-0026-receipt-and-provenance-proof-envelope.md", "docs/adr/ADR-0027-action-card-contract.md", "docs/adr/ADR-0030-compute-workload-manifest-and-authority-boundary.md", "docs/adr/ADR-0031-commons-compute-admission-and-settlement-policy.md", "docs/rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md"]
+recommended_action = "keep"
+freshness = "current"
+
+[docs."docs/architecture/COOPERATIVE_TOOL_COMMONS.md"]
+category = "architecture"
+status = "draft"
+truth_class = "descriptive"
+title = "Cooperative Tool Commons"
+description = "Forward-direction tool ecosystem: core base tools, specialized suites, third-party tools, manifests, service identities, capability grants, anti-capture rules. Companion to Cooperative Domain Infrastructure."
+last_updated = "2026-04-27"
+last_reviewed = "2026-04-27"
+owner = "matt"
+audiences = ["developers", "architects"]
+depends_on = ["docs/architecture/COOPERATIVE_DOMAIN_INFRASTRUCTURE.md", "docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md", "docs/adr/ADR-0026-receipt-and-provenance-proof-envelope.md", "docs/adr/ADR-0027-action-card-contract.md", "docs/adr/ADR-0030-compute-workload-manifest-and-authority-boundary.md"]
+recommended_action = "keep"
+freshness = "current"
+
+[docs."docs/architecture/MODEL_WORKLOADS_AND_DELIBERATION.md"]
+category = "architecture"
+status = "draft"
+truth_class = "descriptive"
+title = "Model Workloads and Deliberation"
+description = "Forward-direction design for model-driven advisory compute workloads, deliberation packets, model registry, advisory vs deterministic classification, and the rule that compute assists but does not govern."
+last_updated = "2026-04-27"
+last_reviewed = "2026-04-27"
+owner = "matt"
+audiences = ["developers", "architects"]
+depends_on = ["docs/architecture/COOPERATIVE_DOMAIN_INFRASTRUCTURE.md", "docs/adr/ADR-0026-receipt-and-provenance-proof-envelope.md", "docs/adr/ADR-0030-compute-workload-manifest-and-authority-boundary.md", "docs/adr/ADR-0031-commons-compute-admission-and-settlement-policy.md"]
+recommended_action = "keep"
+freshness = "current"
+
+[docs."docs/architecture/DOMAIN_ROUTING_AND_DNS_BINDINGS.md"]
+category = "architecture"
+status = "draft"
+truth_class = "descriptive"
+title = "Domain Routing and DNS Bindings"
+description = "Forward-direction design distinguishing institutional domains, icn.zone utility routes, custom public domains, short routes, and binding verification receipts. Companion to Cooperative Domain Infrastructure."
+last_updated = "2026-04-27"
+last_reviewed = "2026-04-27"
+owner = "matt"
+audiences = ["developers", "architects"]
+depends_on = ["docs/architecture/COOPERATIVE_DOMAIN_INFRASTRUCTURE.md", "docs/rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md", "docs/adr/ADR-0026-receipt-and-provenance-proof-envelope.md"]
+recommended_action = "keep"
+freshness = "current"
+
 [docs."docs/architecture/KERNEL_APP_SEPARATION.md"]
 category = "architecture"
 status = "living"


### PR DESCRIPTION
## Summary

Names a future ICN architectural direction: **cooperative institutional infrastructure** governed by charters, roles, standing, agreements, and receipts â€” not by SaaS tenancy.

This PR is **docs only**. Every object and flow that does not yet exist in the repo is explicitly marked as future / planned. Existing implementation is cited against current source.

The forward frame this set of docs codifies:

> ICN should become the open cooperative infrastructure layer where institutions run their own domains, install and fork their own tools, store and govern their own data, coordinate with other institutions through explicit agreements, contribute spare infrastructure to the commons, and prove institutional action through receipts.

## Public surface roles (aligned with ADR-0032)

`DOMAIN_ROUTING_AND_DNS_BINDINGS.md` aligns to the accepted [ADR-0032 â€” Website Truth Boundary](docs/adr/ADR-0032-website-truth-boundary.md):

| Surface | Role |
|---|---|
| `intercooperative.network` | Canonical ICN public truth surface (ADR-0032). |
| `icn.zone` | Utility routing namespace â€” short links, QR, redirects, cluster subdomains, institutional utility sub-routes (`nycn.icn.zone`, `icn.zone/n/nycn`). Root redirects to `intercooperative.network`. **Not** a truth surface. |
| `learn.icn.zone` | Future teaching surface (the icn-learn repo's eventual public face). |
| Custom institution domain | Institution-owned DNS, bound to the `InstitutionalDomain` via a verified `DnsBinding`. |

Institutional sub-routes under `icn.zone` are utility routes for finding/entering institutions; they are not the institution's authority. Institutional authority lives in the `InstitutionalDomain` object, not in DNS.

[RFC-0015](docs/rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md) is cited as draft/exploratory framing only; the accepted policy is ADR-0032.

## Documents

| Path | Role |
|---|---|
| `docs/architecture/COOPERATIVE_DOMAIN_INFRASTRUCTURE.md` | Main synthesis â€” layer model, institutional domains, sessions, devices, services, workspaces, artifact registry, scoped vaults, agreements, hybrid commons cloud, workstations, illustrative NYCN/Summit proof path, build phases, non-negotiable rules. |
| `docs/architecture/COOPERATIVE_TOOL_COMMONS.md` | Tool ecosystem â€” core base tools, specialized suites (with NYCN/Summit suite as illustrative example), third-party tool flow, `ToolManifest`/`ToolBinding`, service identities, anti-capture rule. |
| `docs/architecture/MODEL_WORKLOADS_AND_DELIBERATION.md` | Models as advisory compute. Allowed/forbidden uses. Deliberation packet pattern. Compute assists; governance authorizes. |
| `docs/architecture/DOMAIN_ROUTING_AND_DNS_BINDINGS.md` | Institutional domain vs DNS domain. Surface roles aligned with ADR-0032. Verification flow with binding receipts. |

All four registered in `docs/registry.toml`.

## Institution-specific examples are illustrative, not normative

Per the Non-goals in `COOPERATIVE_DOMAIN_INFRASTRUCTURE.md` and `COOPERATIVE_TOOL_COMMONS.md`, institution-specific names (NYCN / Summit / partner names) appear in this set of docs only as **illustrative examples** of how the generic shapes will be used by a real institution package. They are not core ICN protocol or governance dependencies. The illustrative sections are tagged `(illustrative example)` to remove ambiguity.

## What is EXISTING (cited in the docs)

The action-card proof loop `standing â†’ action card â†’ authorized action â†’ receipt` is real for the currently-emitted source paths:

- `proposal` / `vote` â†’ `GovernanceDecisionReceipt` (PRs #1627, #1660)
- `action_item` / `complete` â†’ `ActionItemCompletionReceipt` (PR #1661)
- `meeting` / `attend` â†’ `MeetingAttendanceReceipt` (PR #1663, merged 2026-04-27 via #1666)

Reserved-but-pending source paths: `signal_rule` (gated on #1631), `obligation_lifecycle` (gated on #1634).

Other cited substrate:

- Charter / role / `authority_scope` plumbing (PRs #1624 / #1626 / #1630)
- Receipt envelope ([ADR-0026](docs/adr/ADR-0026-receipt-and-provenance-proof-envelope.md))
- Action card contract ([ADR-0027](docs/adr/ADR-0027-action-card-contract.md))
- Compute substrate ([ADR-0030](docs/adr/ADR-0030-compute-workload-manifest-and-authority-boundary.md))
- Commons compute admission and settlement policy ([ADR-0031](docs/adr/ADR-0031-commons-compute-admission-and-settlement-policy.md))
- Website truth boundary ([ADR-0032](docs/adr/ADR-0032-website-truth-boundary.md))
- Public maturity claims and evidence links ([ADR-0033](docs/adr/ADR-0033-public-maturity-claims-and-evidence-links.md))
- Institution package boundary ([`docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md`](docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md))

## What is NEW (future / planned)

Named explicitly as future / planned objects (not implemented today):

- Domain identity & sessions: `InstitutionalDomain`, `DomainPolicy`, `DomainSession`
- Devices & services: `DeviceIdentity`, `DeviceEnrollment`, `ServiceIdentity`
- Spaces: `Workspace`, `ArtifactRegistry`, `ScopedVault`
- Tools: `ToolManifest`, `ToolBinding`, third-party tool ecosystem
- Agreements: `AgreementGrant` and the eight `*Agreement` types
- Routing: `DnsBinding`, `PublicationReceipt`, verification flow
- Bridges: `BridgeImportReceipt`
- Commons cloud: `ResourceOffer`, `LocalReservePolicy`, `WorkloadPlacementPolicy`, `UsageReceipt`, `CommonsSettlementReceipt`, `ChallengePath`
- Endpoints: enrollment, kiosks, workstations, eventual ICN distro

Each will require its own ADR or RFC. This set of docs does not pre-commit shapes; it names the gaps.

## Cross-repo follow-up TODOs (NOT in this PR)

The follow-up docs intentionally live in their own PRs to keep the boundary clean:

- **`nycn` repo (PR #14):** architecture docs and `institution/*.example.yaml` shapes for NYCN's planned application.
- **`icn-learn` repo (PR #2):** teaching packets summarizing this design as cross-role orientation material.

These follow-up PRs MUST NOT introduce NYCN/Summit nouns into the ICN public website, and MUST NOT add `learn.icn.zone` links to the public ICN site.

## Boundary confirmations

- **Docs only.** No runtime implementation.
- **No public website changes.** `website/src` forbidden-term grep clean (no NYCN / Summit / reference-federation / first-institution-package / learn.icn.zone / nycn.icn.zone hits).
- **Institution-specific names appear as illustrative examples only**, never as normative ICN core concepts (per the carved-out Non-goals).
- **No DNS, Cloudflare, deploy, or public-infrastructure changes.**
- **Regulatory-safe vocabulary** used for all ICN-native primitives. No payment/wallet/balance/currency for ICN-native primitives.
- **No closing keywords near issue numbers.** Body uses `Refs #1646` only.

## Validation

- `python3 docs/scripts/doc_control_check.py --strict` â€” 734 docs markdown files; 36 pre-existing enforcement warnings, none introduced by this PR
- `git diff --check` â€” clean
- forbidden-term grep on `website/src` â€” clean

## Issue status

Refs #1646. This PR does not affect the action-card runtime gate set on that issue.
