### PR TITLE
docs(state): record meeting/attend proof loop landed (#1663)

### DIFF
--- a/docs/PHASE_PROGRESS.md
+++ b/docs/PHASE_PROGRESS.md
@@ -1,6 +1,15 @@
 # ICN Phase Progress
 **Last Updated:** 2026-04-27
-**Current Phase:** Phase 2 — Pilot Launch (still blocked on cooperative partners; institutional-operability infrastructure and partial action-card runtime are now in place)
+**Current Phase:** Phase 2 — Pilot Launch (still blocked on cooperative partners; institutional-operability infrastructure and the action-card runtime are now in place — all currently emitted source paths are proof-bearing)
+
+<!-- [sync edit] 2026-04-27 (post-#1663): Phase 2 status unchanged (still
+     blocked on cooperative partners). Action-card runtime now has
+     proof-bearing receipt loops for all three currently emitted source
+     paths: proposal/vote (#1660), action_item/complete (#1661), and
+     meeting/attend (#1663). Issue #1646 remains open with two RFC-
+     gated paths still pending: signal_rule (gated on #1631) and
+     obligation_lifecycle (gated on #1634). These landings do not flip
+     Phase 2 to ✅ on their own — that gate is partner-bound. -->
 
 <!-- [sync edit] 2026-04-27: Phase 2 status unchanged (still blocked on
      cooperative partners). Phase 2 deliverables list extended to record
@@ -137,7 +146,8 @@
 - [x] `GET /v1/gov/me/action-cards` member endpoint with closed source/action enums (#1659)
 - [x] Action card → `GovernanceDecisionReceipt` proof linkage for proposal/vote (#1660) — proof loop verified
 - [x] `action_item`/`complete` source path emits append-only `ActionItemCompletionReceipt` (#1661) — proof loop verified
-- [ ] Action-card runtime — remaining gates under #1646: `meeting`/`attend` receipt seam; `signal_rule` source path (gated on #1631); `obligation_lifecycle` source path (gated on #1634)
+- [x] `meeting`/`attend` source path emits append-only `MeetingAttendanceReceipt` (#1663) — proof loop verified; `Present`/`Remote` are receipt-bearing transitions; `Absent` is not; steward-recorded attendance distinguished by `recorded_by` vs `attendee_did`
+- [ ] Action-card runtime — remaining gates under #1646 (RFC-gated): `signal_rule` source path (gated on #1631); `obligation_lifecycle` source path (gated on #1634)
 - [ ] One-command deployment script per cooperative
 - [ ] Charter customization workflow documented (charter activation endpoint exists; non-technical workflow doc still missing)
 - [ ] Pilot onboarding guide (non-technical audience)
@@ -151,6 +161,7 @@
 - Requires cooperative partners identified and committed (primary blocker)
 
 **Decisions Made:**
+- (2026-04-27, post-#1663) Action-card runtime is now proof-bearing for **all three currently emitted source paths**: `proposal`/`vote` (#1660), `action_item`/`complete` (#1661), and `meeting`/`attend` (#1663). Issue #1646 remains open for the two RFC-gated paths: `signal_rule` (#1631) and `obligation_lifecycle` (#1634). Phase 2 status is unaffected (still partner-bound).
 - (2026-04-27) Action-card runtime is partial: `/me/action-cards` exists, `proposal`/`vote` and `action_item`/`complete` source paths have verified end-to-end receipt proof loops, and `meeting`/`attend`, `signal_rule`, `obligation_lifecycle` paths remain pending under #1646. Phase 2 status is unaffected.
 - (2026-04-26) Pilot enablement infrastructure (bootstrap, charter activation, role binding, standing) is in place; Phase 2 remains ⏳ until partners run it for real.
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -6,6 +6,13 @@ Last Reviewed: 2026-04-27
 
 # ICN State (living doc)
 
+<!-- [sync edit] 2026-04-27 (post-#1663): Action-card runtime now has
+     proof-bearing receipt loops for all three currently emitted source
+     paths: proposal/vote (#1660), action_item/complete (#1661), and
+     meeting/attend (#1663). Issue #1646 remains open with two RFC-
+     gated paths still pending: signal_rule (gated on #1631) and
+     obligation_lifecycle (gated on #1634). Phase model unchanged. -->
+
 <!-- [sync edit] 2026-04-27: Append the action-card runtime sequence
      (/me/action-cards endpoint, proposal/vote receipt linkage,
      action_item completion receipt seam) landed via #1659/#1660/#1661.
@@ -26,12 +33,14 @@ Last Reviewed: 2026-04-27
 ## Current status (2026-04-27 snapshot)
 
 **Current phase:** Phase 2 — Pilot Launch (blocked on cooperative partners).
-Active execution: institutional-operability runtime (live charter activation, person-directory overlay, `/me/standing`, `authority_scope` plumbing) plus the action-card runtime (`/me/action-cards` endpoint with proof-loop linkage to `GovernanceDecisionReceipt` for proposal/vote and `ActionItemCompletionReceipt` for action_item/complete). NYCN package side dogfoods these via the institution-package boundary. Phase model classification is unchanged; see PHASE_PROGRESS.md for phase definitions.
+Active execution: institutional-operability runtime (live charter activation, person-directory overlay, `/me/standing`, `authority_scope` plumbing) plus the action-card runtime (`/me/action-cards` endpoint with proof-loop linkage to `GovernanceDecisionReceipt` for proposal/vote, `ActionItemCompletionReceipt` for action_item/complete, and `MeetingAttendanceReceipt` for meeting/attend). NYCN package side dogfoods these via the institution-package boundary. Phase model classification is unchanged; see PHASE_PROGRESS.md for phase definitions.
 
 ### Recently merged (since 2026-04-15)
 
 | PR | Title | Merged |
 |----|-------|--------|
+| #1663 | feat(governance): add meeting attendance receipts | 2026-04-27 |
+| #1662 | docs(state): record action-card runtime landing (#1659/#1660/#1661) | 2026-04-27 |
 | #1661 | feat(governance): add action item completion receipts | 2026-04-27 |
 | #1660 | feat(governance): connect action cards to receipts | 2026-04-27 |
 | #1659 | feat(gateway): add member action cards endpoint | 2026-04-27 |
@@ -85,13 +94,14 @@ Active execution: institutional-operability runtime (live charter activation, pe
 
 ### What landed since Phase 1 (Charter Engine)
 
-Action-card runtime (added 2026-04-27, partial — issue #1646 remains open):
+Action-card runtime (added 2026-04-27, all currently emitted source paths now proof-bearing — issue #1646 remains open for the two RFC-gated paths):
 - `GET /v1/gov/me/action-cards` member endpoint with closed source/action enums — #1659
 - Proposal/vote action card → `GovernanceDecisionReceipt` proof linkage, end-to-end test — #1660
 - `action_item`/`complete` source path emits append-only `ActionItemCompletionReceipt` (ADR-0026 Layer 2); persist-before-commit semantics; full-update handler routes status changes through receipt-bearing path — #1661
+- `meeting`/`attend` source path emits append-only `MeetingAttendanceReceipt` (ADR-0026 Layer 2) keyed by `(meeting_id, attendee_did)`; `Present` and `Remote` are receipt-bearing transitions, `Absent` is not; `recorded_by` is the authenticated caller (distinct from `attendee_did` for steward-recorded attendance); persist-before-commit semantics — #1663
 - Source paths currently emitted by `/me/action-cards`: `proposal`/`vote`, `meeting`/`attend`, `action_item`/`complete`
-- Proof loop verified end-to-end for `proposal`/`vote` and `action_item`/`complete`
-- Pending under #1646: `meeting`/`attend` receipt seam; `signal_rule` source path (gated on #1631); `obligation_lifecycle` source path (gated on #1634)
+- **Proof loop verified end-to-end for all three currently emitted source paths.**
+- Pending under #1646 (RFC-gated): `signal_rule` source path (gated on #1631); `obligation_lifecycle` source path (gated on #1634)
 
 Institutional-operability runtime (added 2026-04-22 → 2026-04-26):
 - Generic institution bootstrap package path — #1586


### PR DESCRIPTION
## Summary

Truth-sync to canonical state docs after #1663 merged at `44fc2043` (`feat(governance): add meeting attendance receipts`).

The action-card runtime now has **proof-bearing receipt loops for all three currently emitted source paths**. Issue #1646 remains open with two RFC-gated paths still pending.

## What changed

`docs/STATE.md`:

- New sync-edit comment for the post-#1663 state, kept above the prior 2026-04-27 comment for archeological continuity.
- Current-status one-liner now references all three receipt classes (`GovernanceDecisionReceipt`, `ActionItemCompletionReceipt`, `MeetingAttendanceReceipt`).
- Recently-merged table includes #1662 (the prior truth-sync) and #1663.
- Action-card-runtime section flips from "partial" framing to "all currently emitted source paths now proof-bearing", with the meeting/attend bullet expanded (`Present`/`Remote` are receipt-bearing transitions, `Absent` is not, steward-recorded attendance distinguished by `recorded_by` vs `attendee_did`).
- "Pending under #1646" line is now scoped to RFC-gated paths only.

`docs/PHASE_PROGRESS.md`:

- Header status sentence flips to "all currently emitted source paths are proof-bearing".
- New post-#1663 sync-edit comment.
- Phase 2 deliverables list:
  - Adds the `meeting`/`attend` checkbox as completed via #1663 with the same expanded note.
  - Existing "remaining gates under #1646" line is now scoped to RFC-gated only.
- New decision entry for 2026-04-27 (post-#1663) recording the all-three-paths-proof-bearing state.

## What this PR does NOT do

- Does **not** modify ADR-0026 / ADR-0027. Those were already updated by #1663 itself.
- Does **not** flip Phase 2 to ✅. Still partner-bound.
- Does **not** introduce NYCN/Summit-specific nouns into ICN core.
- Does **not** touch the public website.
- Does **not** add `learn.icn.zone` links.

## Validation

- `python3 docs/scripts/doc_control_check.py --strict` — 730 docs, 36 pre-existing warnings, none introduced
- `git diff --check` — clean
- public website forbidden-term grep — N/A (only `docs/STATE.md` and `docs/PHASE_PROGRESS.md` touched)

## Issue status

Refs #1646. Two RFC-gated paths remain: `signal_rule` (#1631), `obligation_lifecycle` (#1634).
