### PR TITLE
ops(coordination): add idea refinery and pre-RFC intake pipeline

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,9 +3,44 @@
 ## Summary
 What changed and why?
 
+## Layer classification
+Mark one (see [`ops/coordination/PR_STACK_PROTOCOL.md`](../ops/coordination/PR_STACK_PROTOCOL.md)):
+- [ ] ICN core (generic primitive, kernel, runtime)
+- [ ] ICN app (PolicyOracle / state model)
+- [ ] NYCN package (institution-specific application)
+- [ ] icn-learn (teaching)
+- [ ] Public website (claim)
+- [ ] ops/coordination (process, refinery, hygiene)
+
+## Boundary check
+What this PR intentionally avoids — explicit non-goals:
+- Institution-specific meaning out of ICN core.
+- Private operational data out of any repo.
+- Public website claim without evidence (per ADR-0033).
+- New ICN primitives invented by an institution package.
+
+## What changed
+Files touched and one-line reason per file (or per cluster of files).
+
+## What did not change
+Adjacent surfaces a reader might expect to change but should not.
+
 ## Related
-- Issues: <!-- Fixes # / Closes # -->
+- Issues: <!-- USE `Refs #NNNN`. NEVER use Fixes/Closes/Resolves near issue numbers unless intentionally closing. See PR_STACK_PROTOCOL.md. -->
 - Specs / ADRs / RFCs: <!-- paths under docs/ -->
+- Idea card (if from refinery): <!-- ops/ideas/ideas.yaml#idea-NNNN -->
+
+## Cross-repo dependency status
+If this PR is part of a multi-repo stack, name the upstream/downstream PRs and their state. Cross-repo merge order is **ICN canonical first → NYCN application → ICN Academy teaching** (per [`PR_STACK_PROTOCOL.md`](../ops/coordination/PR_STACK_PROTOCOL.md)).
+
+- Upstream PR(s): <!-- e.g. InterCooperative-Network/icn#NNNN — merged / open / blocked -->
+- Downstream PR(s): <!-- e.g. InterCooperative-Network/nycn#NN — open / queued -->
+- This PR depends on upstream merging first: yes / no
+
+## Review-thread status
+Before requesting merge:
+- [ ] Prior review threads resolved or marked outdated, with reason.
+- [ ] PR body matches the current diff (no stale "in flight" wording).
 
 ## Work mode
 - [ ] Discovery output

--- a/ops/coordination/PR_STACK_PROTOCOL.md
+++ b/ops/coordination/PR_STACK_PROTOCOL.md
@@ -1,0 +1,120 @@
+# Cross-Repo PR Stack Protocol
+
+Coordinates pull requests across ICN, NYCN, and ICN Academy when a
+single idea, concept, or feature touches more than one repo.
+
+> **Order matters.** Stacks merged out of order produce stale PR
+> bodies, broken cross-references, and review-thread confusion. This
+> protocol prevents that by fixing the merge order.
+
+## Cross-repo merge order
+
+For any change that spans more than one repo:
+
+1. **ICN canonical first.** Generic primitives, design direction
+   docs, ADRs, RFCs, runtime, and shared types land in
+   [`InterCooperative-Network/icn`](https://github.com/InterCooperative-Network/icn).
+2. **NYCN application second.** Institution-specific application,
+   package shapes, and operating material land in
+   [`InterCooperative-Network/nycn`](https://github.com/InterCooperative-Network/nycn).
+3. **ICN Academy teaching third.** Cross-role orientation packets,
+   role packets, tracks, and teaching surfaces land in
+   [`InterCooperative-Network/icn-learn`](https://github.com/InterCooperative-Network/icn-learn).
+
+Reasons:
+
+- ICN canonical wording is what the other repos cite. Citing a
+  not-yet-merged ICN PR produces broken or stale links.
+- Teaching surfaces are downstream of canonical truth. A packet that
+  cites a canonical doc that has not landed will go stale on the
+  first edit.
+- Public website changes are downstream of all three (per
+  ADR-0032/-0033) and are gated separately on evidence, not on the
+  stack.
+
+## When to deviate
+
+Almost never. Two cases:
+
+- **Hot fix in NYCN that does not depend on an ICN change.** Fine
+  to merge alone.
+- **Pure repo-hygiene change in icn-learn.** Fine to merge alone.
+
+If the deviation requires a citation back to the canonical ICN doc,
+the deviation does not apply — wait for the ICN PR.
+
+## PR body discipline
+
+Every PR body must include:
+
+1. **Summary.** What this PR does in one or two sentences.
+2. **Layer classification.** ICN core / ICN app / NYCN package /
+   icn-learn / website / private overlay.
+3. **Boundary check.** What stays out of this PR (the explicit
+   non-goals — institution-specific meaning out of ICN core; private
+   data out of any repo; etc.).
+4. **What changed.** Files touched and why.
+5. **What did not change.** Especially adjacent surfaces that a
+   reader might expect to change but should not.
+6. **Evidence / validation.** Commands run, gates that passed.
+7. **Issue status.** Use `Refs #NNNN`. **Never** use `Fixes #NNNN`,
+   `Closes #NNNN`, or `Resolves #NNNN` near issue numbers unless you
+   are intentionally closing the issue. GitHub auto-close on those
+   keywords is a recurring source of accidental issue closes.
+8. **Review-thread status.** Whether prior review threads are
+   resolved or marked outdated, with reason.
+9. **Cross-repo dependency status.** Names the upstream/downstream
+   PRs in the stack and whether this PR depends on them merging
+   first.
+
+## The "Refs vs close-keyword" warning
+
+GitHub treats the following keywords (case-insensitive) followed by
+a `#NNNN` reference as auto-close instructions when the PR merges:
+
+- `close`, `closes`, `closed`
+- `fix`, `fixes`, `fixed`
+- `resolve`, `resolves`, `resolved`
+
+If you do not intend to close the issue, **always** use `Refs #NNNN`
+or write the relationship in plain prose ("relates to issue #NNNN",
+"part of #NNNN").
+
+This is enforced by convention, not by tooling. Reviewers should
+flag any PR body that uses an auto-close keyword unless the closure
+is intentional and noted in the summary.
+
+## Stale PR body detection
+
+PR bodies decay during long review cycles. Before merge:
+
+- Re-read the PR body against the actual diff.
+- Confirm every "Files added" / "Files changed" entry still matches
+  the current commits.
+- Update wording for any in-flight reference (e.g. "PR #1663 in
+  flight") to the current state ("PR #1663 merged 2026-04-27").
+- If the PR body claims a non-goal that the diff has since violated,
+  fix one or the other before merge.
+
+## Mid-stack drift
+
+If you discover that the canonical ICN wording shifts during the
+stack (for example, ADR alignment changes the term used in a
+companion repo), update the dependent PRs **before** merging the
+canonical PR. Otherwise the dependent PRs land citing stale wording.
+
+## Idea refinery interaction
+
+Ideas in `ops/ideas/ideas.yaml` are pre-RFC. They may promote into a
+PR stack via promotion review. When a single idea promotes to
+multiple repos (e.g. a generic ICN primitive plus a NYCN dogfood
+slice plus an icn-learn packet), the stack follows this protocol.
+
+## Reference
+
+- [`ops/coordination/README.md`](README.md) — the post-promotion
+  pipeline (RFC → ADR → issue → tests → website).
+- [`ops/ideas/README.md`](../ideas/README.md) — the pre-RFC
+  refinery.
+- [ADR-0032 — Website Truth Boundary](../../docs/adr/ADR-0032-website-truth-boundary.md)
+- [ADR-0033 — Public Maturity Claims and Evidence Links](../../docs/adr/ADR-0033-public-maturity-claims-and-evidence-links.md)

--- a/ops/coordination/README.md
+++ b/ops/coordination/README.md
@@ -4,9 +4,19 @@ Coordination artifacts that span RFCs, ADRs, issues, and doc surfaces. These fil
 
 ## The pipeline
 
+> **Ideas enter. The refinery decides what they must become next.**
 > **RFCs explore. ADRs decide. Issues build. Tests prove. The website claims only what the proof supports.**
 
+The refinery layer (pre-RFC intake) lives in [`ops/ideas/`](../ideas/README.md). Most ideas should not become RFCs; they become NYCN package tasks, icn-learn packets, GitHub issues, source reviews, dogfood slices, or get parked. Promotion has thresholds — see [`ops/ideas/templates/promotion-review.md`](../ideas/templates/promotion-review.md).
+
+Cross-repo merge order is fixed by [`PR_STACK_PROTOCOL.md`](PR_STACK_PROTOCOL.md): ICN canonical first, NYCN application second, ICN Academy teaching third.
+
 ```text
+   ops/ideas/ideas.yaml     raw ideas, framing briefs, source reviews,
+                            dogfood slices — pre-RFC intake
+              │
+              │  promotion review (per ops/ideas/templates/)
+              ▼
    rfc_candidates.yaml      unresolved design spaces, no decision yet
               │
               │  promote

--- a/ops/ideas/README.md
+++ b/ops/ideas/README.md
@@ -1,0 +1,214 @@
+# ops/ideas/ — Idea Refinery
+
+The pre-RFC intake layer. Where raw ideas, product frames, operating
+insights, source reviews, dogfood opportunities, institutional patterns,
+seed backlog clusters, framing briefs, design sketches, teaching
+candidates, and package-only examples enter the project before being
+promoted into RFCs, ADRs, issues, package tasks, learning material, or
+public claims.
+
+> **Ideas enter. The refinery decides what they must become next.**
+
+This layer exists because the prior pipeline assumed every new concept
+deserved a full RFC or ADR. That produces architecture sprawl,
+premature doctrine, and stale design docs that outpace runtime.
+
+## What this is not
+
+- Not the RFC layer. RFCs explore unresolved design spaces with enough
+  shape to enumerate options. Most ideas do not have that shape.
+- Not the ADR layer. ADRs record decisions. Ideas are upstream of
+  decisions.
+- Not a backlog. Ideas are not implementation commitments.
+- Not a future-map. Naming a future object in a doc is not an idea
+  promotion.
+
+## The pipeline
+
+```text
+   raw idea
+      │  capture
+      ▼
+   idea card                       ops/ideas/templates/idea-card.md
+      │  triage
+      ▼
+   framed / classified             ops/ideas/ideas.yaml row
+      │
+      │  one or more of:
+      ▼
+   framing brief                   ops/ideas/templates/framing-brief.md
+   source review                   ops/ideas/templates/source-review.md
+   dogfood slice                   ops/ideas/templates/dogfood-slice.md
+      │
+      │  promotion review
+      ▼
+   promotion review                ops/ideas/templates/promotion-review.md
+      │
+      │  promote (one of)
+      ▼
+   ┌─────────────┬─────────────┬─────────────┬──────────────┬──────────────┬─────────────┐
+   │ RFC         │ ADR         │ GitHub      │ NYCN package │ icn-learn    │ website     │
+   │ candidate   │ candidate   │ issue       │ task         │ packet       │ claim       │
+   └─────────────┴─────────────┴─────────────┴──────────────┴──────────────┴─────────────┘
+      │
+      │  (or)
+      ▼
+   parked / rejected / superseded
+```
+
+After promotion, the existing pipeline resumes:
+
+> **RFCs explore. ADRs decide. Issues build. Tests prove. The website claims only what the proof supports.**
+
+(See [`ops/coordination/README.md`](../coordination/README.md).)
+
+## Hard rules
+
+1. **No idea enters the build backlog until it has a scope, a boundary,
+   and a proof path.** Capture is cheap; promotion has thresholds.
+2. **Accepted RFC does not mean implemented.**
+3. **Accepted ADR does not mean implemented.**
+4. **Future map does not mean backlog commitment.** Naming an object in
+   `docs/architecture/*.md` does not promote it to an issue.
+5. **Public claim requires evidence.** Website touches gate on shipped
+   runtime, ADR `implementation_status`, or test/proof receipts.
+6. **NYCN/Summit-specific meaning does not go into ICN core.** It lives
+   in the NYCN repo as institution package material.
+7. **Private operational data does not go into Git.** Drive sources are
+   bootstrap material; promotion requires a privacy review.
+8. **Drive/Sheets are bootstrap source material, not canonical
+   architecture.** They are imported into typed records via
+   `BridgeImportReceipt`, never pinned as truth.
+
+## Statuses
+
+| Status | Meaning |
+|---|---|
+| `raw` | Captured but not framed. |
+| `captured` | Has a one-sentence problem and a source. |
+| `framed` | Has a framing brief or equivalent shape. |
+| `classified` | `kind`, `belongs_to`, and `layer` are set. |
+| `decomposed` | Broken into smaller ideas where appropriate. |
+| `needs_source_review` | Requires a Drive/external-system review before promotion. |
+| `needs_dogfood` | Requires a NYCN dogfood slice before generic promotion. |
+| `promotion_review` | A promotion review is in progress. |
+| `promoted_rfc_candidate` | Added as a row in `rfc_candidates.yaml`. |
+| `promoted_adr_candidate` | Added as a row in `adr_candidates.yaml`. |
+| `promoted_issue` | Filed as a GitHub issue. |
+| `promoted_package_task` | Captured as a NYCN repo task. |
+| `promoted_learning_task` | Captured as an icn-learn repo task. |
+| `promoted_website_claim` | Eligible for a public-site change with evidence. |
+| `parked` | Real but not actionable now. |
+| `rejected` | Will not be pursued. |
+| `superseded` | Replaced by another idea (cite the replacement). |
+
+## Destinations (`belongs_to`)
+
+| Destination | Example |
+|---|---|
+| `icn` | Generic ICN substrate, kernel, or app. |
+| `nycn` | Institution-specific application or operating material. |
+| `icn-learn` | Teaching, onboarding, packet, or course material. |
+| `website` | Public claim on `intercooperative.network`. |
+| `private_overlay` | Private operational data; not in Git. |
+| `google_drive` | Lives in Drive as bootstrap/source material. |
+| `external` | Outside the ICN ecosystem entirely. |
+| `unknown` | Triage incomplete. |
+
+## Idea kinds
+
+| Kind | Use for |
+|---|---|
+| `product_frame` | High-level product framing or naming (e.g. "ICN as cooperative relationship infrastructure"). |
+| `institutional_need` | An institution's operating need (e.g. "consent-based outreach"). |
+| `architecture_concept` | A design concept that may eventually need an RFC. |
+| `runtime_gap` | A gap between current runtime and a stated direction. |
+| `package_pattern` | Pattern that belongs in NYCN, not ICN core. |
+| `learning_material` | Teaching/onboarding candidate for icn-learn. |
+| `public_claim` | Candidate website claim. |
+| `source_review` | Drive / Sheets / external-source mapping work. |
+| `dogfood_slice` | A real NYCN slice to validate a generic ICN primitive. |
+| `process_rule` | Coordination/governance/ops rule for the project itself. |
+| `privacy_boundary` | Boundary or carve-out for private/PII data. |
+| `evidence_gap` | A claim that lacks evidence/proof. |
+| `repo_hygiene` | Tooling, templates, hooks, or CI hygiene. |
+| `future_research` | Long-horizon question; not actionable now. |
+
+## Promotion thresholds
+
+Promotion is not automatic and is not scheduled. A promotion review
+exists for each promotion. Thresholds:
+
+### Promote to RFC candidate only if
+
+- The design space is unresolved.
+- Multiple viable options exist with real tradeoffs.
+- The decision would affect generic ICN architecture (not just NYCN).
+- The idea has enough shape to enumerate options, not just a name.
+
+### Promote to ADR candidate only if
+
+- The decision is clear enough to record.
+- Scope is generic, or back-fills actual implementation.
+- Consequences are understood.
+- Implementation status can be tracked separately from the ADR itself.
+
+### Promote to GitHub issue only if
+
+- The build slice is clear.
+- Acceptance criteria are clear.
+- Affected files / crates / docs are identifiable.
+- A validation / proof path is known.
+
+### Promote to NYCN package task only if
+
+- The institution-specific meaning belongs in NYCN.
+- The generic ICN substrate already exists or is explicitly marked
+  planned in an ICN doc.
+- No private data is committed.
+
+### Promote to icn-learn only if
+
+- The canonical source already exists or is explicitly linked.
+- The teaching material does not define doctrine.
+
+### Promote to website only if
+
+- The claim is backed by state docs, tests, ADR `implementation_status:
+  implemented` or `verified`, or shipped runtime.
+- The maturity band is honest (per ADR-0033).
+
+## Templates
+
+- [`templates/idea-card.md`](templates/idea-card.md) — minimal capture.
+- [`templates/framing-brief.md`](templates/framing-brief.md) — refine
+  scope and boundary before promotion.
+- [`templates/source-review.md`](templates/source-review.md) — map
+  Drive / external sources to typed records and privacy classes.
+- [`templates/dogfood-slice.md`](templates/dogfood-slice.md) — design
+  a NYCN-real slice that exercises a generic ICN primitive.
+- [`templates/promotion-review.md`](templates/promotion-review.md) —
+  promotion gate before any RFC / ADR / issue / package / learning /
+  website target.
+
+## Validator
+
+```sh
+python3 ops/ideas/validate_ideas.py
+```
+
+Stdlib-only. Checks unique IDs, required fields, valid statuses, valid
+destinations, valid kinds, that promoted statuses include a
+`promoted_target`, that `public_claim_ready: true` has an
+`evidence_required` entry that is satisfied, and that
+`implementation_ready: true` has a proof path. Exits non-zero on
+failure.
+
+## Cross-repo coordination
+
+Idea destinations span repos. The cross-repo merge order rule is in
+[`ops/coordination/PR_STACK_PROTOCOL.md`](../coordination/PR_STACK_PROTOCOL.md):
+
+1. ICN canonical first.
+2. NYCN application second.
+3. ICN Academy teaching third.

--- a/ops/ideas/ideas.yaml
+++ b/ops/ideas/ideas.yaml
@@ -1,0 +1,491 @@
+# Idea Refinery — pre-RFC intake.
+#
+# Schema and discipline live in ops/ideas/README.md. Each row is a
+# captured idea, NOT a decision and NOT a backlog commitment.
+#
+# Promotion has thresholds (see ops/ideas/templates/promotion-review.md).
+# Most ideas should NOT promote to RFC.
+#
+# Hard rules (see ops/ideas/README.md):
+#   1. No idea enters the build backlog without scope, boundary, and
+#      proof path.
+#   2. Accepted RFC does not mean implemented.
+#   3. Accepted ADR does not mean implemented.
+#   4. Future map does not mean backlog commitment.
+#   5. Public claim requires evidence.
+#   6. NYCN/Summit-specific meaning does not go into ICN core.
+#   7. Private operational data does not go into Git.
+#   8. Drive is bootstrap source material; promotion requires review.
+
+version: 0.1.0-draft
+
+ideas:
+
+  # --------------------------------------------------------------
+  # 1. Cooperative Relationship Infrastructure / MRM
+  # --------------------------------------------------------------
+  - id: idea-0001
+    title: Cooperative Relationship Infrastructure (MRM frame)
+    status: framed
+    kind: product_frame
+    source: "session 2026-04-28; conversation about whether ICN should be 'Salesforce for co-ops'"
+    one_sentence: |
+      ICN should be framed as Cooperative Relationship Infrastructure
+      (or Federated MRM) where the relationship belongs to the
+      person/member, not to the platform or organization.
+    problem: |
+      Treating ICN as a SaaS-CRM clone (Salesforce-for-co-ops) imports
+      the wrong ownership model: the platform owns the relationship,
+      the institution rents it, the member is the product. The
+      cooperative version is the inverse — the member owns identity,
+      memberships, standing, consent, participation history,
+      obligations, receipts, and the relationship graph; institutions
+      authorize and verify; ICN is the substrate that makes that
+      legible across institutions.
+    belongs_to: icn
+    layer: substrate
+    current_artifact: "session conversation only"
+    proposed_next_artifact: framing_brief
+    promoted_target: null
+    proposed_objects:
+      - "MemberRelationship (name candidate; not committed)"
+      - "ParticipationHistory (name candidate)"
+      - "ConsentRecord (name candidate)"
+    requires_rfc: unknown
+    likely_adr: false
+    implementation_ready: false
+    public_claim_ready: false
+    evidence_required: []
+    privacy_risk: high
+    boundary_risk: medium
+    risks:
+      - "Premature naming as 'MRM' invites SaaS-clone framing."
+      - "Premature RFC creates objects before the boundary is clear."
+      - "Confusion with NYCN-specific outreach work (idea-0002)."
+    next_transform: |
+      Write a framing brief that distinguishes (a) the substrate-level
+      identity/standing/consent primitives ICN already has from (b)
+      the cooperative-relationship layer this idea proposes, before
+      any RFC.
+
+  # --------------------------------------------------------------
+  # 2. Consent-based outreach / anti-spam relationship commons
+  # --------------------------------------------------------------
+  - id: idea-0002
+    title: Consent-based outreach / relationship commons
+    status: framed
+    kind: institutional_need
+    source: "session 2026-04-28; NYCN outreach surface"
+    one_sentence: |
+      Outreach (marketing, organizing, partner contact) becomes
+      consented relationship management with verifiable sender,
+      topic-scoped consent, duration, revocation, abuse reporting,
+      and consent receipts.
+    problem: |
+      External SaaS treats outreach as bulk send with opt-out.
+      Cooperatives need the inverse: opt-in, scoped, verifiable,
+      revocable, and receipted. Without this, cooperatives either
+      tolerate spam-style tooling or build ad-hoc consent in
+      spreadsheets that leak and drift.
+    belongs_to: icn
+    layer: institutional
+    current_artifact: "ad-hoc Drive-based outreach plans in NYCN"
+    proposed_next_artifact: framing_brief
+    promoted_target: null
+    proposed_objects:
+      - "OutreachConsent (name candidate)"
+      - "ConsentReceipt (name candidate)"
+    requires_rfc: unknown
+    likely_adr: false
+    implementation_ready: false
+    public_claim_ready: false
+    evidence_required: []
+    privacy_risk: high
+    boundary_risk: medium
+    risks:
+      - "Easy to accidentally absorb NYCN-specific outreach flows into ICN core."
+      - "Privacy-sensitive: contact data must stay in private overlay."
+    next_transform: |
+      Write a framing brief that bounds ICN's role to the consent
+      object + receipt class only; outreach campaigns themselves
+      remain institution-package work. Pair with a NYCN source
+      review of current outreach data.
+
+  # --------------------------------------------------------------
+  # 3. Regional cooperative ecosystem / economic cognition
+  # --------------------------------------------------------------
+  - id: idea-0003
+    title: Regional cooperative ecosystem (economic cognition frame)
+    status: framed
+    kind: product_frame
+    source: "session 2026-04-28; macro framing conversation"
+    one_sentence: |
+      ICN should make a region legible to itself, not to capital —
+      scaling from member → group → institution → community/place →
+      federation → inter-federation network.
+    problem: |
+      Most platforms make regions legible to capital (markets,
+      investors, regulators). Cooperatives need the inverse: a
+      region that can see its own members, institutions, agreements,
+      flows, and obligations without surrendering that view to a
+      vendor. This is a long-horizon framing, not an
+      implementation issue.
+    belongs_to: icn
+    layer: institutional
+    current_artifact: "scattered language in pitch / strategy docs"
+    proposed_next_artifact: framing_brief
+    promoted_target: null
+    proposed_objects: []
+    requires_rfc: false
+    likely_adr: false
+    implementation_ready: false
+    public_claim_ready: false
+    evidence_required: []
+    privacy_risk: low
+    boundary_risk: low
+    risks:
+      - "If promoted to RFC prematurely, becomes vaporware with many named-but-empty objects."
+      - "Scope is large; must decompose before any concrete work."
+    next_transform: |
+      Write a framing brief that names the scale path explicitly and
+      distinguishes long-horizon framing from any near-term build.
+      Do not promote to RFC unless a specific bounded sub-question
+      emerges with enumerated options.
+
+  # --------------------------------------------------------------
+  # 4. Cooperative directory / resource map (NYCN dogfood candidate)
+  # --------------------------------------------------------------
+  - id: idea-0004
+    title: Cooperative directory / resource map
+    status: needs_dogfood
+    kind: institutional_need
+    source: "Summit feedback (2024/2025) — attendees wanted to know who's who"
+    one_sentence: |
+      A directory / resource map of cooperatives, organizers, and
+      services — surfaced first as a NYCN dogfood slice, before any
+      generic ICN primitive.
+    problem: |
+      Attendees and organizers repeatedly ask for a way to see the
+      cooperative ecosystem they are part of. Building this as a
+      generic ICN primitive first risks inventing objects that don't
+      match real use; running it as a NYCN slice first surfaces what
+      the generic primitive actually needs to be.
+    belongs_to: nycn
+    layer: package
+    current_artifact: "Summit feedback notes; informal directory in Drive"
+    proposed_next_artifact: dogfood_slice
+    promoted_target: null
+    proposed_objects:
+      - "DirectoryEntry (name candidate, NYCN-scoped)"
+      - "ResourceMap (name candidate, NYCN-scoped)"
+    requires_rfc: false
+    likely_adr: false
+    implementation_ready: false
+    public_claim_ready: false
+    evidence_required:
+      - "NYCN directory dogfood slice with at least one action_item / complete + receipt cycle"
+    privacy_risk: medium
+    boundary_risk: medium
+    risks:
+      - "Easy to invent ICN core primitives prematurely; keep in NYCN until the slice produces real signal."
+      - "Privacy: real organizer/sponsor identities stay in private overlay."
+    next_transform: |
+      Write a dogfood slice scoped to NYCN. Decide whether the
+      directory record is public-archive or *-internal. Do not
+      promote to ICN core until the slice has run end-to-end with
+      receipts.
+
+  # --------------------------------------------------------------
+  # 5. Drive import map / source review
+  # --------------------------------------------------------------
+  - id: idea-0005
+    title: Drive import map for NYCN bootstrap material
+    status: needs_source_review
+    kind: source_review
+    source: "session 2026-04-28; review of NYCN Drive folders"
+    one_sentence: |
+      Drive material (planning, budget, fundraising, attendees,
+      evaluations, marketing, secrets) needs an explicit source
+      review that maps each folder to a typed record, privacy
+      class, and action — not a blind import.
+    problem: |
+      Drive is bootstrap source material. Bridge-importing it
+      without classification leaks PII and pins stale Drive shape
+      as architecture. The fix is an explicit source review that
+      categorizes each item into keep-public, summarize-only,
+      private-overlay, or never-Git.
+    belongs_to: nycn
+    layer: package
+    current_artifact: "Drive folders + ad-hoc notes"
+    proposed_next_artifact: source_review
+    promoted_target: null
+    proposed_objects: []
+    requires_rfc: false
+    likely_adr: false
+    implementation_ready: false
+    public_claim_ready: false
+    evidence_required:
+      - "source-review document landed in NYCN repo with per-item action and privacy class"
+    privacy_risk: high
+    boundary_risk: medium
+    risks:
+      - "PII leak if an attendee list or evaluation row is committed."
+      - "Premature pinning: Drive shape != target ICN typed records."
+      - "Sponsor contact data must split from public commitment data."
+    next_transform: |
+      Open `ops/ideas/templates/source-review.md` against the
+      NYCN Drive root. Promote the resulting NYCN repo file as a
+      `promoted_package_task` row.
+
+  # --------------------------------------------------------------
+  # 6. Summit 2026 canonical facts
+  # --------------------------------------------------------------
+  - id: idea-0006
+    title: Summit 2026 canonical facts (Schenectady, 2026-10-17)
+    status: classified
+    kind: package_pattern
+    source: "session 2026-04-28; correction of stale spreadsheet sync language"
+    one_sentence: |
+      Add a small repo-safe NYCN doc pinning Summit 2026 canonical
+      facts (October 17, 2026, Schenectady, NY); deprecate stale
+      spreadsheet-sync language that was experimental, not
+      architectural.
+    problem: |
+      Earlier docs/conversations described a "spreadsheet sync"
+      pattern that was a test artifact, not a settled architecture.
+      Without a canonical-facts doc, downstream contributors
+      (and agents) re-derive the wrong shape from stale notes.
+    belongs_to: nycn
+    layer: package
+    current_artifact: "scattered references; stale spreadsheet-sync wording"
+    proposed_next_artifact: promotion_review
+    promoted_target: null
+    proposed_objects: []
+    requires_rfc: false
+    likely_adr: false
+    implementation_ready: true
+    public_claim_ready: false
+    evidence_required:
+      - "summit/2026/CANONICAL_FACTS.md committed to NYCN repo"
+    privacy_risk: low
+    boundary_risk: low
+    risks:
+      - "Do not expose private venue/contract details."
+    next_transform: |
+      Promotion review → NYCN package task. Target file:
+      `summit/2026/CANONICAL_FACTS.md`. Body: date + city + repo
+      role; explicit note that Drive/Sheets are bootstrap material
+      and the prior spreadsheet-sync wording is stale.
+
+  # --------------------------------------------------------------
+  # 7. Feedback-to-2026 design response
+  # --------------------------------------------------------------
+  - id: idea-0007
+    title: Feedback-to-2026 design response (no PII)
+    status: framed
+    kind: package_pattern
+    source: "Summit 2024 / 2025 evaluation themes"
+    one_sentence: |
+      Convert 2024/2025 evaluation feedback into a repo-safe NYCN
+      design response covering venue/accessibility, networking,
+      closing, session load, cross-sector representation, language
+      justice, resource map, organizer burnout, art/music/movement,
+      childcare/wayfinding/mics — without raw rows or PII.
+    problem: |
+      Evaluation rows include PII and free-text identifying
+      attendees. They cannot enter the public repo. But the
+      themes can: a design response document captures what the
+      organization heard and what it commits to in 2026.
+    belongs_to: nycn
+    layer: package
+    current_artifact: "raw evaluation rows in Drive (private)"
+    proposed_next_artifact: promotion_review
+    promoted_target: null
+    proposed_objects: []
+    requires_rfc: false
+    likely_adr: false
+    implementation_ready: true
+    public_claim_ready: false
+    evidence_required:
+      - "summit/2026/FEEDBACK_DESIGN_RESPONSE.md (or equivalent) in NYCN repo with no raw rows and no PII"
+    privacy_risk: high
+    boundary_risk: low
+    risks:
+      - "PII leak from raw rows."
+      - "Re-identification via small-N quotes."
+    next_transform: |
+      Promotion review → NYCN package task. Source review feeds
+      this; raw rows stay private.
+
+  # --------------------------------------------------------------
+  # 8. Content / RFP dogfood slice
+  # --------------------------------------------------------------
+  - id: idea-0008
+    title: Content/RFP dogfood slice (NYCN, action-card path)
+    status: needs_dogfood
+    kind: dogfood_slice
+    source: "session 2026-04-28; first NYCN dogfood candidate"
+    one_sentence: |
+      Use a Content/RFP workflow (RFP draft → publish → review →
+      schedule fill → speaker bios → finalize) as the first real
+      NYCN dogfood path on the existing action-card proof loop.
+    problem: |
+      ICN's action-card runtime is real for proposal/vote,
+      action_item/complete, meeting/attend. NYCN needs a real
+      institutional flow to exercise these paths end-to-end without
+      inventing new ICN primitives. Content/RFP is the right
+      candidate: low private-data risk, multiple action-card steps,
+      receipt-bearing throughout.
+    belongs_to: nycn
+    layer: package
+    current_artifact: "informal RFP process; no package fixture"
+    proposed_next_artifact: dogfood_slice
+    promoted_target: null
+    proposed_objects:
+      - "summit/2026/content-rfp.example.yaml (NYCN repo)"
+      - "action-card templates: draft RFP, publish RFP, review proposals, fill program gaps, collect speaker bios, finalize schedule"
+    requires_rfc: false
+    likely_adr: false
+    implementation_ready: false
+    public_claim_ready: false
+    evidence_required:
+      - "Dogfood slice runs against existing ICN action-card runtime and emits at least one ActionItemCompletionReceipt."
+    privacy_risk: low
+    boundary_risk: low
+    risks:
+      - "Real speaker contact info must NOT enter the package fixture."
+    next_transform: |
+      Write a dogfood slice using the dogfood-slice template.
+      Outputs: NYCN repo example yaml + playbook section + action-card
+      templates. No ICN core change required.
+
+  # --------------------------------------------------------------
+  # 9. First live ICN smoke against NYCN package
+  # --------------------------------------------------------------
+  - id: idea-0009
+    title: First live ICN smoke against NYCN package
+    status: framed
+    kind: runtime_gap
+    source: "session 2026-04-28; proof-path hardening priority"
+    one_sentence: |
+      Run the NYCN package against a live ICN node end-to-end:
+      bootstrap → /me/standing → /me/action-cards → complete one
+      action item → verify receipt → document exact commands.
+    problem: |
+      The action-card proof loop landed at the doc/code level, but
+      no published end-to-end run against a real package fixture
+      exists. Without that, the public claim "the proof loop works"
+      is unevidenced.
+    belongs_to: icn
+    layer: runtime
+    current_artifact: "action-card runtime exists; receipt classes
+      exist; no end-to-end smoke against NYCN package documented"
+    proposed_next_artifact: promotion_review
+    promoted_target: null
+    proposed_objects: []
+    requires_rfc: false
+    likely_adr: false
+    implementation_ready: true
+    public_claim_ready: false
+    evidence_required:
+      - "Documented command sequence: bootstrap, GET /me/standing, GET /me/action-cards, action completion, GET /me/receipts."
+      - "Recorded receipts (transcript or fixture)."
+    privacy_risk: low
+    boundary_risk: low
+    risks:
+      - "Runtime gap discovered mid-smoke (non-blocking; promotes to a focused issue)."
+    next_transform: |
+      Promotion review → GitHub issue. Acceptance criteria:
+      command sequence + recorded receipts + audit export. Outranks
+      speculative expansion of the design-direction docs.
+
+  # --------------------------------------------------------------
+  # 10. Cooperative Domain Infrastructure cluster
+  # --------------------------------------------------------------
+  - id: idea-0010
+    title: Cooperative Domain Infrastructure (parent cluster)
+    status: framed
+    kind: architecture_concept
+    source: "merged ICN PR #1664 (design-direction docs)"
+    one_sentence: |
+      The parent cluster of future objects (InstitutionalDomain,
+      DomainPolicy, DomainSession, DeviceIdentity, DeviceEnrollment,
+      ServiceIdentity, Workspace, ArtifactRegistry, ScopedVault,
+      ToolManifest, ToolBinding, AgreementGrant, DnsBinding,
+      PublicationReceipt, ResourceOffer, LocalReservePolicy,
+      WorkloadPlacementPolicy, UsageReceipt, CommonsSettlementReceipt,
+      ChallengePath) — a design direction, not a backlog
+      commitment.
+    problem: |
+      The design-direction docs name many future objects. Promoting
+      each one to an RFC now would produce architecture sprawl
+      and premature doctrine. The right pattern is per-cluster
+      promotion review when there is real signal (a NYCN dogfood
+      slice, a pilot need, or a substrate gap).
+    belongs_to: icn
+    layer: substrate
+    current_artifact: |
+      docs/architecture/COOPERATIVE_DOMAIN_INFRASTRUCTURE.md and
+      companions (merged via #1664).
+    proposed_next_artifact: framing_brief
+    promoted_target: null
+    proposed_objects:
+      - "see one_sentence — names only, not commitments"
+    requires_rfc: false
+    likely_adr: false
+    implementation_ready: false
+    public_claim_ready: false
+    evidence_required: []
+    privacy_risk: low
+    boundary_risk: medium
+    risks:
+      - "Auto-promotion of every named object into RFC candidates — the exact sprawl this refinery exists to prevent."
+    next_transform: |
+      Decompose the cluster: each sub-cluster (identity/sessions,
+      devices/services, workspaces/vaults, tools, agreements,
+      routing/publication, hybrid commons) becomes its own idea
+      card, framed independently. RFC promotion happens per
+      sub-cluster only when a dogfood slice or substrate gap
+      surfaces real design questions.
+
+  # --------------------------------------------------------------
+  # 11. PR / issue hygiene
+  # --------------------------------------------------------------
+  - id: idea-0011
+    title: PR / issue hygiene (auto-close avoidance + cross-repo stack)
+    status: classified
+    kind: repo_hygiene
+    source: "session 2026-04-28; recurring PR-body drift across the cooperative-domain-infrastructure stack"
+    one_sentence: |
+      Add a PR template with hygiene sections (boundary check,
+      review-thread status, cross-repo dependency status, explicit
+      Refs vs close-keyword warning) and codify the cross-repo
+      stack merge order in PR_STACK_PROTOCOL.md.
+    problem: |
+      The cooperative-domain-infrastructure stack drifted across
+      three repos: stale PR bodies, accidental close keywords, and
+      missing review-thread status. The fix is process: a PR
+      template that asks the right questions and a protocol doc
+      that codifies the merge order.
+    belongs_to: icn
+    layer: package
+    current_artifact: |
+      .github/pull_request_template.md (existing) — does not yet
+      include cross-repo dep status or close-keyword warning.
+      No ops/coordination/PR_STACK_PROTOCOL.md.
+    proposed_next_artifact: promotion_review
+    promoted_target: null
+    proposed_objects: []
+    requires_rfc: false
+    likely_adr: false
+    implementation_ready: true
+    public_claim_ready: false
+    evidence_required:
+      - "Updated .github/pull_request_template.md and ops/coordination/PR_STACK_PROTOCOL.md committed in this PR."
+    privacy_risk: low
+    boundary_risk: low
+    risks:
+      - "Template bloat — keep sections short and skippable."
+    next_transform: |
+      Land in this PR alongside the refinery scaffold, since the
+      hygiene rules are part of how the refinery actually works.

--- a/ops/ideas/templates/dogfood-slice.md
+++ b/ops/ideas/templates/dogfood-slice.md
@@ -1,0 +1,106 @@
+# Dogfood Slice — design a NYCN-real proof slice
+
+A dogfood slice is a NYCN-real path that exercises a generic ICN
+primitive end-to-end: bootstrap → standing → action card → action →
+receipt → audit/export. It is the artifact that promotes generic ICN
+substrate from "named" to "proven."
+
+> **A dogfood slice is the cheapest honest test of a generic ICN
+> primitive.** It runs against real-shaped (but fictional or redacted)
+> NYCN package data and produces real receipts, not slideware.
+
+## When to write one
+
+- An idea names a future ICN object and the project needs to know
+  whether the existing substrate already supports it.
+- An institution-side need (NYCN) has matured enough to test a
+  generic ICN primitive, but the primitive should **not** absorb
+  institution-specific meaning to satisfy the test.
+- A public claim is being considered and the proof path needs to be
+  named explicitly.
+
+## Outline
+
+```markdown
+# {slice name} — dogfood slice
+
+**Idea card(s):** ops/ideas/ideas.yaml#idea-NNNN
+**Owner / session:** ...
+**Date:** YYYY-MM-DD
+
+## What this slice proves
+
+One sentence. The generic ICN primitive being exercised.
+
+Examples:
+- "The action-card proof loop works end-to-end for a NYCN
+  Content/RFP workflow without any ICN core change."
+- "Bridge imports from a Drive folder produce a `BridgeImportReceipt`
+  that NYCN typed records can refer to."
+
+## What this slice does NOT prove
+
+Be explicit. A dogfood slice is bounded.
+
+- Not a full Summit run.
+- Not a full institution package activation.
+- Not a federation-scale test.
+
+## Slice steps
+
+Each step is concrete and named. Each step's authority comes from a
+charter / role / standing source. Each step's evidence is a receipt
+or a recorded view.
+
+1. Bootstrap: NYCN package files used (paths in the NYCN repo).
+2. Standing: which holders the slice runs against (`/me/standing`).
+3. Action cards: which `(source, action)` pairs the slice exercises.
+4. Authorized actions: what runs against the gateway / governance app.
+5. Receipts: which receipt classes are emitted; expected counts.
+6. Audit / export: how the slice's receipts are surfaced
+   (`icnctl audit`, `/me/receipts`, etc.).
+
+## Boundary check
+
+- Generic ICN substrate is not modified to fit the slice.
+- NYCN-specific meaning stays in NYCN package files.
+- No private data committed (real partner names → fictional; real
+  contacts → private overlay).
+- No public website change unless the slice is promoting a
+  `public_claim` and an ADR `implementation_status` allows it.
+
+## Validation commands
+
+Exact commands the slice needs to run, in order. Future-state-only
+commands are listed but marked `(planned)`.
+
+## Acceptance criteria
+
+- Each receipt class is emitted with the expected `(source, action)`
+  pair and resolves through `/me/receipts`.
+- All actions trace back to a charter / role / standing source.
+- Audit export contains every emitted receipt and excludes private
+  vault scopes.
+
+## What promotes after this slice succeeds
+
+A successful dogfood slice can promote:
+
+- `promoted_issue` for any small generic ICN gap surfaced.
+- `promoted_package_task` for institution-side follow-up in NYCN.
+- `promoted_website_claim` only if the slice's evidence matches the
+  claim's maturity band (per ADR-0033).
+- `promoted_rfc_candidate` only if the slice surfaced an unresolved
+  generic design space — most do not.
+```
+
+## Discipline
+
+- Dogfood slices are bounded. A slice that grows past 6 steps should
+  decompose into multiple slices.
+- A dogfood slice that requires an ICN core change is a **failure
+  signal**, not a deliverable. The framing brief should be re-opened.
+- A dogfood slice that requires private data is a **boundary
+  violation**. Use fictional or redacted values.
+- Receipts are the unit of evidence. A slice without receipts proves
+  nothing reusable.

--- a/ops/ideas/templates/framing-brief.md
+++ b/ops/ideas/templates/framing-brief.md
@@ -1,0 +1,113 @@
+# Framing Brief — refine scope and boundary
+
+A framing brief is the artifact between an idea card and any promotion
+to RFC / ADR / issue / package task / learning task / website claim.
+
+> **A framing brief shapes an idea enough that someone can decide what
+> it should become next. It is not a design doc and not a decision.**
+
+Use this template when an idea card is ready to be sharpened. Keep it
+short. If a framing brief grows beyond two pages, decompose the idea
+into multiple cards.
+
+## Outline
+
+```markdown
+# {title} — framing brief
+
+**Idea card:** ops/ideas/ideas.yaml#idea-NNNN
+**Author / session:** ...
+**Date:** YYYY-MM-DD
+
+## What this is
+
+One paragraph. State the idea in plain language. No jargon, no naming
+of imagined objects yet.
+
+## Why this is interesting
+
+Two or three sentences. What problem does this address? What pattern
+does it want to break? Who feels the problem today?
+
+## Scope
+
+What is in scope and what is not. Be ruthless. The most common framing
+mistake is bundling three ideas into one brief.
+
+- In scope:
+- Out of scope:
+- Adjacent (named, not pursued):
+
+## Boundary check
+
+Where does this belong?
+
+- ICN core (generic primitive)
+- ICN app (PolicyOracle / state model)
+- NYCN package (institution-specific)
+- ICN Academy (teaching)
+- Public website (claim)
+- Private overlay (operational, not Git)
+- Google Drive (source material, not architecture)
+- External (outside ICN)
+
+If the answer crosses boundaries, the idea probably needs to decompose.
+
+## Existing surface
+
+What already exists in the repo that this idea touches?
+
+- Crates / apps:
+- Docs:
+- ADRs / RFCs (cite by id):
+- Issues / PRs:
+- NYCN / icn-learn material:
+
+## Open questions
+
+The questions a future RFC, ADR, or implementation would have to
+answer. If there are no open questions, this might already be an ADR
+candidate, not an RFC candidate.
+
+1.
+2.
+3.
+
+## Privacy and boundary risks
+
+- Does this idea touch private operational data?
+- Does it risk leaking institution-specific meaning into ICN core?
+- Does it require a Drive / external source review before promotion?
+
+## Proposed next artifact
+
+Pick exactly one:
+
+- [ ] another framing brief (decompose first)
+- [ ] source review
+- [ ] dogfood slice
+- [ ] promotion review → RFC candidate
+- [ ] promotion review → ADR candidate
+- [ ] promotion review → GitHub issue
+- [ ] promotion review → NYCN package task
+- [ ] promotion review → icn-learn packet
+- [ ] promotion review → website claim
+- [ ] park
+- [ ] reject
+
+## Receipts / evidence (if relevant)
+
+What evidence would have to exist for this idea to be implemented or
+claimed publicly? Cite specific receipt types, ADR
+`implementation_status` transitions, test names, or runtime endpoints.
+```
+
+## Discipline
+
+- A framing brief is **descriptive**, not normative. It does not
+  decide; it makes the idea legible enough for someone else to decide.
+- A framing brief that turns into doctrine should be promoted to RFC
+  or ADR. Briefs that linger as quasi-architecture are exactly the
+  drift this layer exists to prevent.
+- A framing brief that names invented objects without a proof path
+  should be challenged at promotion review.

--- a/ops/ideas/templates/idea-card.md
+++ b/ops/ideas/templates/idea-card.md
@@ -1,0 +1,110 @@
+# Idea Card — minimal capture
+
+Use this template when capturing a new idea into `ops/ideas/ideas.yaml`.
+Capture is cheap; promotion has thresholds (see
+[`ops/ideas/README.md`](../README.md)).
+
+> **An idea card is not a decision and not a backlog commitment.** It
+> is a captured observation that we will then triage, frame, classify,
+> decompose, park, promote, or reject.
+
+## Required fields
+
+```yaml
+- id: idea-NNNN                    # zero-padded, four digits
+  title: short-noun-phrase
+  status: raw                      # raw, captured, framed, classified,
+                                   # decomposed, needs_source_review,
+                                   # needs_dogfood, promotion_review,
+                                   # promoted_*, parked, rejected,
+                                   # superseded
+  kind: architecture_concept       # see ops/ideas/README.md
+  source: "session 2026-04-28; conversation with X; Drive folder Y"
+  one_sentence: "Single sentence stating the idea."
+  problem: |
+    Two or three sentences. What is the actual problem this idea is
+    trying to address? What is wrong today? What patterns does it want
+    to break?
+
+  belongs_to: icn                  # icn, nycn, icn-learn, website,
+                                   # private_overlay, google_drive,
+                                   # external, unknown
+  layer: substrate                 # informal: substrate / runtime /
+                                   # institutional / package / learning /
+                                   # public
+
+  current_artifact: "(none)"       # what exists today: a sentence in
+                                   # CLAUDE.md, a Drive doc, a
+                                   # conversation note, an ADR sketch,
+                                   # a stale comment, etc.
+  proposed_next_artifact: framing_brief   # idea_card / framing_brief /
+                                          # source_review / dogfood_slice /
+                                          # promotion_review / rfc_candidate /
+                                          # adr_candidate / issue / package_task /
+                                          # learning_packet / website_claim
+  promoted_target: null            # filled at promotion: e.g.
+                                   # "rfc_candidates.yaml#NNNN" or
+                                   # "issues#NNNN" or "nycn:summit/2026/..."
+
+  proposed_objects:
+    - "(strings only — names, not commitments)"
+  requires_rfc: false              # true / false / unknown
+  likely_adr: false                # true / false / unknown
+  implementation_ready: false      # true requires a proof path field
+  public_claim_ready: false        # true requires evidence_required + evidence
+
+  evidence_required: []            # list of evidence types needed
+                                   # before public claim or
+                                   # implementation_ready: true
+  privacy_risk: low                # low / medium / high
+  boundary_risk: low               # low / medium / high — risk of
+                                   # leaking institution-specific
+                                   # meaning into ICN core or
+                                   # private data into the public repo
+  risks:
+    - "list of concrete risks"
+
+  next_transform: |
+    What needs to happen to move this idea to its next artifact.
+    Be concrete. Name a person/role only if a human owner is required.
+    Otherwise name the artifact and the question it must answer.
+```
+
+## Field discipline
+
+- `id` is unique across all idea-cards. The validator enforces this.
+- `title` is a short noun phrase. Imperative phrasing ("Implement X",
+  "Add Y") belongs on issues, not idea cards.
+- `source` is human-readable and citation-style. It is not a typed
+  reference.
+- `proposed_objects` is a list of name candidates only. Naming an
+  object here does not commit to building it.
+- `requires_rfc` and `likely_adr` are best-guess at capture time and
+  may change at framing or promotion review.
+- `implementation_ready: true` requires the idea to have a proof path
+  (a `dogfood_slice` template, an existing test fixture, or a
+  receipt-bearing flow).
+- `public_claim_ready: true` requires `evidence_required` to be
+  populated and have at least one entry satisfied.
+
+## Status transitions
+
+- `raw` → `captured`: a one-sentence problem and a source are
+  recorded.
+- `captured` → `framed`: a framing brief is written.
+- `framed` → `classified`: `kind`, `belongs_to`, and `layer` are
+  finalized.
+- `classified` → `decomposed`: the idea is broken into smaller ideas
+  if needed (each gets its own card).
+- Any state → `needs_source_review`: a Drive/external source must be
+  reviewed before promotion.
+- Any state → `needs_dogfood`: a NYCN dogfood slice is required.
+- Any state → `promotion_review`: a promotion review is opened.
+- `promotion_review` → `promoted_*` or `parked` or `rejected`.
+
+## What an idea card is not
+
+- Not an RFC. RFCs require enumerated options and tradeoffs.
+- Not an ADR. ADRs record decisions.
+- Not an issue. Issues require buildable acceptance criteria.
+- Not a backlog item. Capture does not commit to delivery.

--- a/ops/ideas/templates/promotion-review.md
+++ b/ops/ideas/templates/promotion-review.md
@@ -1,0 +1,148 @@
+# Promotion Review — gate before any RFC / ADR / issue / package / learning / website target
+
+A promotion review is the artifact that decides whether an idea moves
+from the refinery into another pipeline (RFC candidates, ADR
+candidates, GitHub issues, NYCN package tasks, icn-learn packets, or
+website claims) — or is parked or rejected.
+
+> **Capture is cheap; promotion has thresholds.** A promotion review
+> is the explicit gate where those thresholds are checked.
+
+## When to open one
+
+- An idea is `framed` or `classified` and someone wants to act on it.
+- A framing brief, source review, or dogfood slice has produced
+  enough shape to decide on a destination.
+- An idea has been `parked` and a new signal makes it actionable.
+
+## Outline
+
+```markdown
+# {idea title} — promotion review
+
+**Idea card:** ops/ideas/ideas.yaml#idea-NNNN
+**Reviewer / session:** ...
+**Date:** YYYY-MM-DD
+
+## Idea summary
+
+One sentence (copy from the idea card's `one_sentence`).
+
+## Current artifacts
+
+- Framing brief: path or none
+- Source review: path or none
+- Dogfood slice: path or none
+- Other: prior PRs, ADRs, RFCs, related issues
+
+## Proposed promotion target
+
+Pick exactly one:
+
+- [ ] RFC candidate (`rfc_candidates.yaml`)
+- [ ] ADR candidate (`adr_candidates.yaml`)
+- [ ] GitHub issue
+- [ ] NYCN package task
+- [ ] icn-learn packet
+- [ ] Website claim
+- [ ] Park (real but not actionable)
+- [ ] Reject (will not be pursued)
+- [ ] Supersede (cite replacing idea)
+
+## Threshold check
+
+Mark the row that applies. All boxes must be checked for the
+selected target.
+
+### → RFC candidate
+
+- [ ] Design space is unresolved.
+- [ ] Multiple viable options exist with real tradeoffs.
+- [ ] Decision would affect generic ICN architecture (not just NYCN).
+- [ ] The framing brief enumerates options, not just a name.
+
+### → ADR candidate
+
+- [ ] Decision is clear enough to record.
+- [ ] Scope is generic, or back-fills actual implementation.
+- [ ] Consequences are understood.
+- [ ] Implementation status will be tracked separately on the ADR.
+
+### → GitHub issue
+
+- [ ] Build slice is clear.
+- [ ] Acceptance criteria are clear.
+- [ ] Affected files / crates / docs are identifiable.
+- [ ] Validation / proof path is known.
+
+### → NYCN package task
+
+- [ ] Institution-specific meaning belongs in NYCN.
+- [ ] Generic ICN substrate exists or is explicitly marked planned.
+- [ ] No private data in the proposed change.
+- [ ] Boundary check: ICN does not absorb the institution-specific
+      meaning.
+
+### → icn-learn packet
+
+- [ ] Canonical source exists or is explicitly linked.
+- [ ] Teaching material does not define doctrine.
+- [ ] Cross-role vs role packet is decided (per icn-learn README).
+
+### → Website claim
+
+- [ ] Backed by state docs, tests, ADR `implementation_status:
+      implemented` or `verified`, or shipped runtime.
+- [ ] Maturity band is honest (per ADR-0033).
+- [ ] Evidence link is specific (test, receipt, ADR — not a generic
+      doc reference).
+
+## Cross-repo effect
+
+What other repos does this promotion touch?
+
+- ICN: ...
+- NYCN: ...
+- icn-learn: ...
+- public website: ...
+
+If multiple repos are affected, the merge order is fixed (per
+[`PR_STACK_PROTOCOL.md`](../../coordination/PR_STACK_PROTOCOL.md)):
+ICN canonical first, NYCN application second, ICN Academy teaching
+third.
+
+## Decision
+
+- Outcome: promote / park / reject / supersede.
+- Target artifact reference (filled at promotion):
+  - `rfc_candidates.yaml#NNNN`
+  - `adr_candidates.yaml#NNNN`
+  - `issues#NNNN`
+  - NYCN repo path
+  - icn-learn repo path
+  - website path
+
+## Idea card update
+
+After the decision, update `ops/ideas/ideas.yaml`:
+
+- `status` → one of `promoted_*`, `parked`, `rejected`, `superseded`.
+- `promoted_target` → reference to the target artifact.
+- `next_transform` → a short description of the next step in the
+  target's own pipeline (not in the refinery).
+```
+
+## Discipline
+
+- A promotion review is a **gate**, not a celebration. Most ideas
+  should land in `parked`, `rejected`, or one of the lighter
+  destinations (NYCN package task / icn-learn packet) — not RFCs.
+- An RFC candidate that is just a renamed idea card should be
+  rejected at this gate. RFCs require enumerated options and
+  tradeoffs.
+- A website claim that is not backed by ADR
+  `implementation_status: implemented | verified` or a receipt-bearing
+  test should be rejected at this gate.
+- The promotion decision is recorded in `ops/ideas/ideas.yaml`. The
+  refinery is the audit trail of what the project considered and
+  what it decided to do with it.

--- a/ops/ideas/templates/source-review.md
+++ b/ops/ideas/templates/source-review.md
@@ -1,0 +1,98 @@
+# Source Review — map external sources to typed records
+
+A source review captures what exists today in Drive / Sheets / external
+SaaS / private notes — and what should happen with each item.
+
+> **Drive and Sheets are bootstrap source material, not canonical ICN
+> architecture.** A source review is the artifact that maps that
+> material to typed records, privacy classes, and promotion decisions.
+
+Use this template when an idea is `needs_source_review`, or when a
+package import (NYCN bootstrap, Drive folder, external SaaS export)
+needs to be planned without committing private data to Git.
+
+## Outline
+
+```markdown
+# {source} — source review
+
+**Idea card:** ops/ideas/ideas.yaml#idea-NNNN
+**Source:** Drive folder / Sheet name / SaaS export / etc.
+**Reviewer / session:** ...
+**Date:** YYYY-MM-DD
+
+## What this source is
+
+One paragraph. What lives at this source today? Who maintains it? Why
+does it exist?
+
+## Items
+
+| Item | Keep as | Future ICN object | Privacy level | Action |
+|---|---|---|---|---|
+
+Examples:
+
+| 2026 Planning | NYCN bootstrap source | SummitCycle / Activity (planned) | public structure / private contact | promote to NYCN package as `summit/2026/...` |
+| Budget | private allocation plan | governed allocation (planned) | private | summarize publicly only via approved governance act |
+| Fundraising | sponsor agreements | obligation + relationship records (planned) | public commitments only; contacts private | split: public sponsor commitments → repo; contacts → private overlay |
+| Attendee list | private registration import | attendee record (planned) | private | never expose; bridge import via `BridgeImportReceipt` |
+| Evaluation summary | redacted cycle learning | feedback aggregate (planned) | aggregate only, no PII | summarize as design response (no raw rows) |
+| Marketing plan | consent campaign / outreach plan | outreach plan + consent receipts (planned) | public framing; per-contact data private | promote framing to NYCN; contacts to private overlay |
+| Passwords / secrets | private scoped vault | (none — secrets never enter ICN typed records) | private | move to private overlay; never commit |
+
+## Privacy classes (vault scopes)
+
+Each row above must classify into one of:
+
+- `public-archive` — safe to publish.
+- `*-internal` — visible to specific role-holders.
+- `*-restricted` — visible to a small named scope; aggregate
+  publication forbidden.
+- `private-overlay` — never enters Git.
+
+## Boundary check
+
+- ICN-side action: is anything here a generic ICN primitive that
+  should land in ICN docs? If yes, open a separate framing brief.
+- NYCN-side action: which items become NYCN package material? Cite
+  the target file (e.g. `summit/2026/...`).
+- Private-overlay-side action: which items must never be in any repo?
+
+## Promotion proposals
+
+For each item, a proposed promotion:
+
+- `promoted_package_task` for NYCN repo content.
+- `promoted_learning_task` for icn-learn material.
+- `promoted_issue` for ICN runtime work (rare; usually framed first).
+- `parked` for items not actionable.
+- `private_overlay` for never-Git items.
+
+## Risks
+
+- Private data leak (PII, contacts, secrets).
+- Premature pinning of stale Drive structure as architecture.
+- Inventing ICN primitives to match Drive shape (anti-pattern — Drive
+  shape is bootstrap, not target).
+
+## Forbidden
+
+A source review must not:
+
+- Commit private data to Git.
+- Promote raw spreadsheet rows into the public website.
+- Treat Drive structure as canonical ICN architecture.
+- Introduce new ICN primitives without a framing brief and promotion
+  review.
+```
+
+## Discipline
+
+- Drive shape is **bootstrap**. The target ICN typed records are
+  designed in ICN, not back-derived from a Drive folder.
+- Where Drive holds private data, the review's job is to **prevent**
+  it from entering the repo, not to find a clever way to import it.
+- A source review can promote multiple items in one pass — but each
+  promotion target should be tracked as its own row in
+  `ops/ideas/ideas.yaml` so promotion review and validation work.

--- a/ops/ideas/validate_ideas.py
+++ b/ops/ideas/validate_ideas.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Validate ops/ideas/ideas.yaml against the refinery schema.
+
+Stdlib-only. Hand-rolled minimal YAML reader (line-oriented,
+2-space indent, ":" separators, "- " list items) tuned to the
+small, stable shape used by ideas.yaml. If ideas.yaml grows beyond
+this shape, replace this reader with a proper YAML library.
+
+Usage:
+    python3 ops/ideas/validate_ideas.py [--path PATH]
+
+Exit code 0 on pass, 1 on validation failure, 2 on parse failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+ALLOWED_STATUS = {
+    "raw",
+    "captured",
+    "framed",
+    "classified",
+    "decomposed",
+    "needs_source_review",
+    "needs_dogfood",
+    "promotion_review",
+    "promoted_rfc_candidate",
+    "promoted_adr_candidate",
+    "promoted_issue",
+    "promoted_package_task",
+    "promoted_learning_task",
+    "promoted_website_claim",
+    "parked",
+    "rejected",
+    "superseded",
+}
+
+ALLOWED_DESTINATIONS = {
+    "icn",
+    "nycn",
+    "icn-learn",
+    "website",
+    "private_overlay",
+    "google_drive",
+    "external",
+    "unknown",
+}
+
+ALLOWED_KINDS = {
+    "product_frame",
+    "institutional_need",
+    "architecture_concept",
+    "runtime_gap",
+    "package_pattern",
+    "learning_material",
+    "public_claim",
+    "source_review",
+    "dogfood_slice",
+    "process_rule",
+    "privacy_boundary",
+    "evidence_gap",
+    "repo_hygiene",
+    "future_research",
+}
+
+PROMOTED_STATUSES = {s for s in ALLOWED_STATUS if s.startswith("promoted_")}
+
+REQUIRED_FIELDS = (
+    "id",
+    "title",
+    "status",
+    "kind",
+    "source",
+    "one_sentence",
+    "problem",
+    "belongs_to",
+    "layer",
+    "current_artifact",
+    "proposed_next_artifact",
+    "promoted_target",
+    "proposed_objects",
+    "requires_rfc",
+    "likely_adr",
+    "implementation_ready",
+    "public_claim_ready",
+    "evidence_required",
+    "privacy_risk",
+    "boundary_risk",
+    "risks",
+    "next_transform",
+)
+
+
+# --- minimal YAML reader -----------------------------------------------------
+
+
+def _strip_comment(line: str) -> str:
+    """Strip a trailing '# comment' that is not inside quotes."""
+    in_single = False
+    in_double = False
+    for i, ch in enumerate(line):
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        elif ch == "#" and not in_single and not in_double:
+            return line[:i].rstrip()
+    return line.rstrip()
+
+
+def _coerce_scalar(raw: str) -> Any:
+    s = raw.strip()
+    if s == "" or s == "null" or s == "~":
+        return None
+    if s in ("true", "True"):
+        return True
+    if s in ("false", "False"):
+        return False
+    if s.startswith("[") and s.endswith("]"):
+        body = s[1:-1].strip()
+        if body == "":
+            return []
+        # naive split: ideas.yaml inline lists are short and never
+        # contain commas inside values
+        return [_coerce_scalar(p) for p in _split_top_level(body, ",")]
+    if (s.startswith('"') and s.endswith('"')) or (s.startswith("'") and s.endswith("'")):
+        return s[1:-1]
+    if s.startswith("|") or s.startswith(">"):
+        return ""  # block scalars handled separately
+    try:
+        return int(s)
+    except ValueError:
+        pass
+    try:
+        return float(s)
+    except ValueError:
+        pass
+    return s
+
+
+def _split_top_level(body: str, sep: str) -> list[str]:
+    out: list[str] = []
+    cur = ""
+    in_single = False
+    in_double = False
+    depth = 0
+    for ch in body:
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        elif ch in "[{(" and not in_single and not in_double:
+            depth += 1
+        elif ch in "]})" and not in_single and not in_double:
+            depth -= 1
+        if ch == sep and depth == 0 and not in_single and not in_double:
+            out.append(cur)
+            cur = ""
+        else:
+            cur += ch
+    if cur != "":
+        out.append(cur)
+    return out
+
+
+def _indent_of(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def parse_ideas_yaml(text: str) -> dict[str, Any]:
+    """Parse the small subset of YAML used by ideas.yaml.
+
+    Supports:
+      - top-level scalar `key: value`
+      - top-level list `ideas:` followed by `- key: value` blocks
+      - per-item nested scalars, block scalars (`|` and `>`), and
+        inline `[]` lists
+    """
+    lines = text.splitlines()
+    # strip pure-comment lines and trailing comments
+    clean = []
+    for ln in lines:
+        if ln.strip().startswith("#"):
+            continue
+        clean.append(_strip_comment(ln))
+    # drop trailing blank lines
+    while clean and clean[-1].strip() == "":
+        clean.pop()
+
+    out: dict[str, Any] = {}
+    i = 0
+    n = len(clean)
+
+    while i < n:
+        ln = clean[i]
+        if ln.strip() == "":
+            i += 1
+            continue
+        if _indent_of(ln) != 0:
+            raise ValueError(f"line {i + 1}: expected top-level key, got indented line")
+        key, _, rest = ln.partition(":")
+        key = key.strip()
+        rest = rest.strip()
+        if rest != "":
+            out[key] = _coerce_scalar(rest)
+            i += 1
+            continue
+        # block under this key
+        i += 1
+        # skip blank lines before block detection
+        while i < n and clean[i].strip() == "":
+            i += 1
+        # detect list of mappings (ideas:)
+        if i < n and clean[i].lstrip().startswith("- "):
+            items: list[dict[str, Any]] = []
+            list_indent = _indent_of(clean[i])
+            while i < n and (
+                clean[i].strip() == ""
+                or (clean[i].lstrip().startswith("- ") and _indent_of(clean[i]) == list_indent)
+                or _indent_of(clean[i]) > list_indent
+            ):
+                if clean[i].strip() == "":
+                    i += 1
+                    continue
+                if clean[i].lstrip().startswith("- ") and _indent_of(clean[i]) == list_indent:
+                    base_indent = _indent_of(clean[i])
+                    item: dict[str, Any] = {}
+                    first_line = clean[i][base_indent + 2 :]
+                    if first_line.strip() != "":
+                        # `- key: value` form
+                        ik, _, iv = first_line.partition(":")
+                        ik = ik.strip()
+                        iv = iv.strip()
+                        if iv != "":
+                            item[ik] = _coerce_scalar(iv)
+                        else:
+                            item[ik] = None  # placeholder, may be re-set
+                    i += 1
+                    while i < n and clean[i].strip() != "" and _indent_of(clean[i]) > base_indent and not clean[i].lstrip().startswith("- "):
+                        sub_line = clean[i]
+                        sub_indent = _indent_of(sub_line)
+                        sub_key, _, sub_rest = sub_line.partition(":")
+                        sub_key = sub_key.strip()
+                        sub_rest = sub_rest.strip()
+                        if sub_rest == "":
+                            # nested list or block scalar
+                            i += 1
+                            if i < n and clean[i].lstrip().startswith("- ") and _indent_of(clean[i]) > sub_indent:
+                                lst: list[Any] = []
+                                while i < n and clean[i].lstrip().startswith("- ") and _indent_of(clean[i]) > sub_indent:
+                                    val_line = clean[i].lstrip()[2:].strip()
+                                    lst.append(_coerce_scalar(val_line))
+                                    i += 1
+                                item[sub_key] = lst
+                            else:
+                                # empty list (e.g. proposed_objects: with nothing under)
+                                item[sub_key] = []
+                            continue
+                        if sub_rest in ("|", ">", "|-", ">-"):
+                            # block scalar — gather indented lines
+                            i += 1
+                            block_lines: list[str] = []
+                            block_indent = None
+                            while i < n and (clean[i].strip() == "" or _indent_of(clean[i]) > sub_indent):
+                                if clean[i].strip() == "":
+                                    block_lines.append("")
+                                    i += 1
+                                    continue
+                                if block_indent is None:
+                                    block_indent = _indent_of(clean[i])
+                                block_lines.append(clean[i][block_indent:])
+                                i += 1
+                            if sub_rest.startswith(">"):
+                                joined = " ".join(b.strip() for b in block_lines if b.strip() != "")
+                            else:
+                                joined = "\n".join(block_lines).rstrip()
+                            item[sub_key] = joined
+                            continue
+                        item[sub_key] = _coerce_scalar(sub_rest)
+                        i += 1
+                    items.append(item)
+                else:
+                    i += 1
+            out[key] = items
+            continue
+        # otherwise: nested mapping at this key (not used by ideas.yaml top level)
+        i += 1
+
+    return out
+
+
+# --- validation --------------------------------------------------------------
+
+
+def validate(doc: dict[str, Any]) -> list[str]:
+    errs: list[str] = []
+    ideas = doc.get("ideas")
+    if not isinstance(ideas, list):
+        errs.append("ideas: missing or not a list")
+        return errs
+
+    seen_ids: set[str] = set()
+    for n, idea in enumerate(ideas, start=1):
+        if not isinstance(idea, dict):
+            errs.append(f"idea #{n}: not a mapping")
+            continue
+        ctx = idea.get("id") or f"#{n}"
+
+        for fld in REQUIRED_FIELDS:
+            if fld not in idea:
+                errs.append(f"{ctx}: missing required field '{fld}'")
+
+        idea_id = idea.get("id")
+        if idea_id:
+            if idea_id in seen_ids:
+                errs.append(f"{ctx}: duplicate id '{idea_id}'")
+            seen_ids.add(idea_id)
+
+        status = idea.get("status")
+        if status is not None and status not in ALLOWED_STATUS:
+            errs.append(f"{ctx}: invalid status '{status}'")
+
+        belongs_to = idea.get("belongs_to")
+        if belongs_to is not None and belongs_to not in ALLOWED_DESTINATIONS:
+            errs.append(f"{ctx}: invalid belongs_to '{belongs_to}'")
+
+        kind = idea.get("kind")
+        if kind is not None and kind not in ALLOWED_KINDS:
+            errs.append(f"{ctx}: invalid kind '{kind}'")
+
+        if status in PROMOTED_STATUSES:
+            target = idea.get("promoted_target")
+            if not target:
+                errs.append(f"{ctx}: status '{status}' requires promoted_target")
+
+        if idea.get("public_claim_ready") is True:
+            ev = idea.get("evidence_required")
+            if not ev or (isinstance(ev, list) and len(ev) == 0):
+                errs.append(f"{ctx}: public_claim_ready=true requires non-empty evidence_required")
+
+        if idea.get("implementation_ready") is True:
+            ev = idea.get("evidence_required")
+            if not ev or (isinstance(ev, list) and len(ev) == 0):
+                errs.append(f"{ctx}: implementation_ready=true requires a proof path in evidence_required")
+
+        for risk_field in ("privacy_risk", "boundary_risk"):
+            v = idea.get(risk_field)
+            if v is not None and v not in ("low", "medium", "high"):
+                errs.append(f"{ctx}: invalid {risk_field} '{v}' (expected low/medium/high)")
+
+    return errs
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--path", default="ops/ideas/ideas.yaml")
+    args = ap.parse_args()
+
+    path = Path(args.path)
+    if not path.exists():
+        print(f"validate_ideas: file not found: {path}", file=sys.stderr)
+        return 2
+
+    try:
+        doc = parse_ideas_yaml(path.read_text(encoding="utf-8"))
+    except Exception as e:  # noqa: BLE001
+        print(f"validate_ideas: parse error: {e}", file=sys.stderr)
+        return 2
+
+    errs = validate(doc)
+    if errs:
+        for e in errs:
+            print(f"FAIL: {e}", file=sys.stderr)
+        print(f"validate_ideas: {len(errs)} error(s)", file=sys.stderr)
+        return 1
+
+    n = len(doc.get("ideas", []))
+    print(f"validate_ideas: ok ({n} idea(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a structured layer before RFC candidates so raw ideas, product frames, operating insights, source reviews, dogfood opportunities, institutional patterns, framing briefs, design sketches, teaching candidates, and package-only examples can be captured, classified, decomposed, parked, promoted, or rejected — **without** pretending they are already decisions.

Process / docs only. No runtime claim. No public-site change.

## Layer classification

- [x] ops/coordination (process, refinery, hygiene)

## Boundary check

This PR intentionally:

- Does **not** auto-promote any idea to an RFC. The refinery is pre-RFC; promotion has thresholds.
- Does **not** introduce any new ICN runtime, primitive, or shipped surface.
- Does **not** change the public website or any maturity claim.
- Does **not** commit private operational data.

## Why this exists

The cooperative-domain-infrastructure stack (ICN #1664 / NYCN #14 / icn-learn #2) showed that the project was treating every new concept as a candidate RFC. That produces architecture sprawl, premature doctrine, and stale design docs that outpace runtime.

The refinery is the explicit upstream layer that prevents that pattern. Most ideas should **not** promote to RFC; they become NYCN package tasks, icn-learn packets, GitHub issues, source reviews, dogfood slices, or get parked.

> **Hard rule:** No idea enters the build backlog until it has a scope, a boundary, and a proof path.

## Pipeline

```text
raw idea
 → idea card
 → triage / classify
 → framing brief / source review / dogfood slice
 → promotion review
 → RFC candidate / ADR candidate / GitHub issue / NYCN package task
   / icn-learn packet / website claim / parked / rejected
 → (then the existing post-promotion pipeline:
    RFCs explore, ADRs decide, issues build, tests prove,
    website claims only what proof supports)
```

## What changed

| Path | Role |
|---|---|
| `ops/ideas/README.md` | Pipeline, statuses, kinds, destinations, promotion thresholds. |
| `ops/ideas/ideas.yaml` | Seeded with 11 captured ideas (none promoted to RFC). |
| `ops/ideas/templates/idea-card.md` | Minimal capture template. |
| `ops/ideas/templates/framing-brief.md` | Refine scope and boundary. |
| `ops/ideas/templates/source-review.md` | Map Drive / external sources to typed records and privacy classes. |
| `ops/ideas/templates/dogfood-slice.md` | Design a NYCN-real proof slice. |
| `ops/ideas/templates/promotion-review.md` | Gate before any RFC / ADR / issue / package / learning / website target. |
| `ops/ideas/validate_ideas.py` | Stdlib-only validator. |
| `ops/coordination/README.md` | Updated to reference the refinery as the upstream layer. |
| `ops/coordination/PR_STACK_PROTOCOL.md` | Cross-repo merge order rule (ICN canonical → NYCN → ICN Academy), PR-body discipline, "Refs vs close keyword" warning, stale-PR detection rule. |
| `.github/pull_request_template.md` | Adds layer classification, boundary check, what changed / did not change, cross-repo dependency status, review-thread status, explicit Refs-not-Closes warning. |

## Seeded ideas

All 11 are pre-RFC captures. Specifically **none** are auto-promoted to RFC candidates; the parent cluster (`idea-0010` Cooperative Domain Infrastructure) is explicitly tagged "decompose, do not auto-promote sub-objects to RFCs."

| Id | Title | Status | Belongs to |
|---|---|---|---|
| `idea-0001` | Cooperative Relationship Infrastructure (MRM frame) | framed | icn |
| `idea-0002` | Consent-based outreach / relationship commons | framed | icn |
| `idea-0003` | Regional cooperative ecosystem (economic cognition) | framed | icn |
| `idea-0004` | Cooperative directory / resource map | needs_dogfood | nycn |
| `idea-0005` | Drive import map / source review | needs_source_review | nycn |
| `idea-0006` | Summit 2026 canonical facts | classified | nycn |
| `idea-0007` | Feedback-to-2026 design response (no PII) | framed | nycn |
| `idea-0008` | Content/RFP dogfood slice | needs_dogfood | nycn |
| `idea-0009` | First live ICN smoke against NYCN package | framed | icn |
| `idea-0010` | Cooperative Domain Infrastructure (parent cluster) | framed | icn |
| `idea-0011` | PR / issue hygiene | classified | icn |

## What did not change

- No public website edits.
- No ADRs or RFCs added.
- No GitHub issues filed by this PR (issue creation happens at promotion review time, not capture time).
- No NYCN or icn-learn changes (those are downstream PRs per `PR_STACK_PROTOCOL.md`).

## Cross-repo dependency status

- Upstream PR(s): none. This PR sits on top of the merged cooperative-domain-infrastructure stack (ICN #1664, NYCN #14, icn-learn #2).
- Downstream PR(s): expected sequence (per the prompt that produced this work):
  - NYCN truth sync after #1663/#1666
  - NYCN 2026 canonical facts and source-review correction
  - NYCN feedback-to-2026 design response
  - NYCN Content/RFP dogfood slice
  - First live ICN smoke against NYCN package
- This PR depends on upstream merging first: no.

## Review-thread status

- This is a new PR; no prior review threads.

## Validation

- `python3 ops/ideas/validate_ideas.py` — ok (11 ideas)
- `python3 docs/scripts/doc_control_check.py --strict` — ok (only pre-existing enforcement warnings)
- `git diff --check` — clean
- forbidden-term grep on `website/src` — zero hits

## Issue status

Refs InterCooperative-Network/icn#1664. This PR does not affect any specific ICN issue. It establishes the upstream layer for future idea capture.