### PR TITLE
ops(coordination): audit RFC and ADR readiness after idea refinery

### DIFF
--- a/ops/coordination/RFC_ADR_READINESS_AUDIT.md
+++ b/ops/coordination/RFC_ADR_READINESS_AUDIT.md
@@ -1,0 +1,128 @@
+# RFC / ADR Readiness Audit (post-refinery)
+
+> **Purpose.** The idea refinery now exists ([`ops/ideas/`](../ideas/README.md), merged via #1667). Some recent RFCs and ADRs were drafted *before* the refinery layer, when every new concept tended to be promoted directly to RFC or ADR. This audit reclassifies each artifact against the refinery's promotion thresholds. No artifact is deleted. The thinking is preserved; the institutional gravity is adjusted to match the actual evidence.
+
+**Date:** 2026-04-28
+**Scope:** ADR-0021 through ADR-0034; RFC-0000, RFC-0001, RFC-0015; `ops/coordination/rfc_candidates.yaml`; `ops/coordination/adr_candidates.yaml`.
+**Hard rules** (from `ops/ideas/README.md`):
+
+1. Accepted RFC does not mean implemented.
+2. Accepted ADR does not mean implemented.
+3. Future map does not mean backlog commitment.
+4. Public claim requires evidence.
+5. Backfill ADRs are acceptable only when tied to code, tests, merged PRs, or accepted process.
+6. Forward-looking ADRs must not decide details still speculative.
+7. Do not delete the thinking. Lower the gravity until the idea earns promotion.
+
+This audit changes **no runtime behavior**, **no public website claims**, and **does not add or remove any ADR or RFC document**. It adds a `readiness` annotation to specific rows of `adr_candidates.yaml` where the gravity is wrong, adds a small number of idea cards in `ops/ideas/ideas.yaml` for the framing work needed before forward-looking ADRs should advance to accepted, and produces this audit document for institutional memory.
+
+---
+
+## Audit table
+
+| Artifact | Current status | Recommended classification | Action | Reason | Evidence | Next artifact |
+|---|---|---|---|---|---|---|
+| ADR-0021 CCL Determinism, Fuel, Capability Safety | accepted / implemented | **keep_accepted_backfill** | leave as-is | Records shipped behavior of `icn-ccl` and executors. | `icn/crates/icn-ccl`, executor tests | none |
+| ADR-0022 CCL Schema Bridge | accepted / implemented | **keep_accepted_backfill** | leave as-is | Records shipped schema-bridge in `icn-ccl/src/schema/bridge.rs`. | code path | none |
+| ADR-0023 CCL Institutional Process Language | proposed / proposed | **split_principle_from_runtime** | add `readiness: needs_framing_brief`; demote runtime details to idea card | Principle ("CCL grows process surface") is reasonable; runtime details (Process DAG, step-kind taxonomy, deadline-as-data, escalation-as-step) are speculative with no shipping evidence. ADR is too detailed for the evidence it has. | none — type sketches only | idea card `idea-0012` (CCL process layer — framing brief) |
+| ADR-0024 Institution Package Manifest Schema | proposed / partial | **split_principle_from_runtime** | add `readiness: needs_framing_brief` | Principle (packages declare a manifest) is settled; `BootstrapSeedManifest` ships seed primitives. Proposed sections (indicators, signal rules, allocation templates, locale metadata, package-level operating intent) are speculative and bundle several different design spaces. | partial: `icn/crates/icn-governance/src/bootstrap.rs` for seed primitives only | idea card `idea-0013` (manifest schema extensions — split into per-section briefs) |
+| ADR-0025 Institutional Effect Record Canonical Schema | proposed / proposed | **demote_to_idea_or_framing** | add `readiness: needs_framing_brief`; add idea card | No `EffectRecord` ships today — only mandates. Proposed schema (closed taxonomy, plain-language summary, persistence model, reversal pointer) is forward design without enough shape to decide as an ADR. | none | idea card `idea-0014` (EffectRecord canonical schema — framing) |
+| ADR-0026 Receipt & Provenance Proof Envelope | accepted / partial | **keep_accepted_backfill** | leave as-is | Honest backfill of shipped pieces (ADR-0008 receipts, ADR-0011 truth ownership, ADR-0019 mandate persistence, PR #1648 federation provenance). `partial` is honest; the envelope is real where shipped. | merged PRs cited; receipt tests | none |
+| ADR-0027 Action Card Contract | proposed / partially implemented | **keep_proposed_adr** with status update | leave decision; refresh `implementation_status` text to reflect 3 shipped paths | The contract (member-facing derived view, no mutation API, prioritization in policy) is settled and partially shipped. The doc honestly scopes "vertical slice; proof-loop verified for proposal/vote". As of #1663/#1666, two more paths shipped: `action_item/complete` and `meeting/attend`. RFC-gated paths (`signal_rule`, `obligation_lifecycle`) remain pending. The status string is now stale. | shipping: PRs #1627 / #1660 / #1661 / #1663 / #1666 | optional small status-update PR (out of scope here) |
+| ADR-0028 Accessibility Baseline | proposed / proposed | **split_principle_from_runtime** | add `readiness: needs_split` | Principle ("accessibility is a participation floor") is non-negotiable and well-founded. The five-layer floor (sensory / cognitive / linguistic / economic / temporal) is right framing. Runtime details (per-layer implementation contracts, glossary endpoint plumbing, mobile bandwidth model) are speculative. | partial: `docs/design-language/accessibility.md` (design doctrine), open #1610, #1611, #1366 | idea card `idea-0015` (accessibility runtime details — per-layer briefs) |
+| ADR-0029 Conflict Resolution Object Model | proposed / partial | **split_principle_from_runtime** | add `readiness: needs_split` | Principle ("institutional care is first-class; three conflict shapes") is solid and useful as a reference. Compute-dispute path ships. Institutional-conflict object model (EffectChallenge, etc.) is type sketches in `icn-governance/src/appeal.rs` only. | shipping: `icn-ccl/src/disputes.rs`. Type sketch only: `icn-governance/src/appeal.rs` | idea card `idea-0016` (institutional conflict object model — framing) |
+| ADR-0030 Compute Workload Manifest | accepted / implemented | **keep_accepted_backfill** | leave as-is | Backfills shipped `icn-compute` workload manifest and authority boundary. | code | none |
+| ADR-0031 Commons Compute Admission & Settlement | accepted / implemented | **keep_accepted_backfill** | leave as-is | Backfills the settlement engine producing balanced journal entries. | code + tests | none |
+| ADR-0032 Website Truth Boundary | accepted / implemented | **keep_accepted_backfill** | leave as-is | Records the canonical-truth-surface decision. Already cited by the cooperative-domain-infrastructure stack and the PR-stack protocol. | `website/src/`, ADR-0032 itself, PR_STACK_PROTOCOL.md | none |
+| ADR-0033 Public Maturity Claims & Evidence Links | proposed / proposed | **keep_proposed_adr** with readiness note | add `readiness: needs_implementation_evidence` | Decision direction is clear (every banded claim cites evidence). Linter is unbuilt. Lower the gravity until the linter exists; do not pretend the convention is enforced. | partial: existing badge components carry some evidence by hand | optional follow-up issue to scope the linter |
+| ADR-0034 ADR Candidate Registry as Architectural Memory | accepted / implemented | **keep_accepted_backfill** | leave as-is | Backfills the registry pattern itself. The registries exist and are exercised. | `ops/coordination/*.yaml` | none |
+| RFC-0000 RFC Process | accepted | **keep_accepted_backfill** | leave as-is | The process is in use. | `ops/coordination/README.md` cites it | none |
+| RFC-0001 Obligation / Allocation / Settlement Primitives | draft | **keep_draft_rfc** | leave as-is | Real unresolved design space with multiple options, real tradeoffs, recommended direction (Option B: external bridge receipts), bounded scope. Exactly the kind of design space RFCs exist for. | RFC structure, ADR-0004/0005/0013/0026/0031 cross-refs | proceed via the RFC's own process |
+| RFC-0015 Public Surface and Learning Repo Architecture | draft | **supersede_or_amend** for canonical-surface section; **keep_draft_rfc** for learning-repo direction | add a status note in the RFC that ADR-0032 is the accepted policy for the canonical-truth-surface decision; the learning-repo / `learn.icn.zone` direction remains exploratory | The canonical-truth-surface decision (intercooperative.network) was settled by ADR-0032 (accepted). The RFC was written *before* that ADR landed and so reads as if it is governing on that point. The learning-repo direction (`learn.icn.zone` as a separate repo) was realized by `icn-learn` and is now exploratory framing for the future site. | ADR-0032 (accepted); merged icn-learn repo | optional small RFC amendment PR (out of scope here) |
+
+---
+
+## Findings by category
+
+### Accepted / backfill — okay
+
+These ADRs record shipped reality. They are tied to code, tests, or accepted process. They stay as-is.
+
+- ADR-0021 CCL Determinism, Fuel, Capability Safety
+- ADR-0022 CCL Schema Bridge
+- ADR-0026 Receipt & Provenance Proof Envelope
+- ADR-0030 Compute Workload Manifest
+- ADR-0031 Commons Compute Admission & Settlement
+- ADR-0032 Website Truth Boundary
+- ADR-0034 ADR Candidate Registry
+- RFC-0000 RFC Process
+
+### Draft RFC — okay
+
+RFC-0001 is exactly the kind of design space the RFC layer exists for: real tradeoffs, multiple viable options, a recommended direction, follow-up ADRs scoped explicitly, regulatory-safe vocabulary preserved. Leave alone. Continue via RFC process.
+
+### Proposed ADR — okay with readiness annotation
+
+- **ADR-0027 Action Card Contract.** Decision is settled; vertical slice is shipping. Refresh the `implementation_status` text in a small follow-up; do not change the decision.
+- **ADR-0033 Public Maturity Claims & Evidence Links.** Decision is clear, linter is unbuilt — `readiness: needs_implementation_evidence` annotation in the candidate registry, no doc change.
+
+### Demote to idea / framing
+
+- **ADR-0025 Institutional Effect Record Canonical Schema.** No shipping evidence; schema details speculative. Add idea card `idea-0014` for the framing-brief work needed; lower the registry's gravity with `readiness: needs_framing_brief`.
+
+### Split principle from runtime
+
+- **ADR-0023 CCL Institutional Process Language.** Principle (CCL grows process surface) reasonable; runtime details (DAG semantics, step kinds, deadline-as-data, escalation-as-step) speculative.
+- **ADR-0024 Institution Package Manifest Schema.** Principle settled; speculative sections (indicators, signal rules, allocation templates, locale metadata) bundle several distinct design spaces.
+- **ADR-0028 Accessibility Baseline.** Principle (participation floor; five layers) non-negotiable; per-layer runtime contracts speculative.
+- **ADR-0029 Conflict Resolution Object Model.** Principle (institutional care first-class; three conflict shapes) solid; institutional-conflict object model details speculative.
+
+### Amend / supersede
+
+- **RFC-0015 Public Surface and Learning Repo Architecture.** Canonical-surface section is superseded by ADR-0032 (accepted); learning-repo direction remains exploratory framing. Recommended: small future PR adds a status note in the RFC pointing to ADR-0032. Out of scope for this audit PR.
+
+---
+
+## Concrete recommendations (per artifact)
+
+For each artifact whose gravity is wrong, this audit recommends one of the following — not direct edits to the ADR/RFC bodies:
+
+| Artifact | Action this PR | Action future PR |
+|---|---|---|
+| ADR-0023 | `readiness: needs_framing_brief` in `adr_candidates.yaml`; idea-0012 added | optional: amend ADR with explicit "principle vs runtime" demarcation |
+| ADR-0024 | `readiness: needs_framing_brief` in `adr_candidates.yaml`; idea-0013 added | per-section follow-up briefs |
+| ADR-0025 | `readiness: needs_framing_brief` in `adr_candidates.yaml`; idea-0014 added | none until framing brief lands |
+| ADR-0027 | none (decision is fine) | optional small status-text update reflecting #1663/#1666 |
+| ADR-0028 | `readiness: needs_split` in `adr_candidates.yaml`; idea-0015 added | per-layer runtime briefs |
+| ADR-0029 | `readiness: needs_split` in `adr_candidates.yaml`; idea-0016 added | object model framing brief |
+| ADR-0033 | `readiness: needs_implementation_evidence` in `adr_candidates.yaml` | scope the build-time linter as a separate issue |
+| RFC-0015 | none (registry already lists it as drafted) | small RFC amendment PR adding ADR-0032 supersession note |
+
+---
+
+## What this PR does NOT change
+
+- **No ADR or RFC body is edited.** Every existing ADR and RFC retains its current status, content, and `implementation_status`. The thinking is preserved.
+- **No runtime change.**
+- **No public website change.** ADR-0032 is unaffected; the website truth boundary stands.
+- **No new ADR or RFC is added.**
+- **No GitHub issue is filed by this PR.** Future framing-brief work is captured in `ideas.yaml` only.
+- **No existing idea card is rewritten.** New cards (idea-0012 through idea-0016) are added.
+- **No private NYCN/Summit data is referenced.** This audit operates on ICN canonical material only.
+
+---
+
+## Hygiene notes for future audits
+
+- Run this audit after any tranche of new ADRs lands. The pattern that produced the gravity mismatch (drafting an ADR before a framing brief exists) is recurring; this audit pattern is the corrective.
+- When `readiness: needs_framing_brief` or `needs_split` is set on a row, the corresponding idea card carries the actual next-transform work.
+- A `readiness` annotation is a *gravity dampener*. It does not invalidate the ADR; it tells the reader the doc is downstream of work that has not happened yet.
+
+---
+
+## References
+
+- [`ops/ideas/README.md`](../ideas/README.md) — refinery doctrine, statuses, kinds, promotion thresholds.
+- [`ops/coordination/README.md`](README.md) — pipeline (ideas → RFC → ADR → issues → tests → website).
+- [`ops/coordination/PR_STACK_PROTOCOL.md`](PR_STACK_PROTOCOL.md) — cross-repo merge order.
+- [ADR-0032](../../docs/adr/ADR-0032-website-truth-boundary.md), [ADR-0033](../../docs/adr/ADR-0033-public-maturity-claims-and-evidence-links.md), [ADR-0034](../../docs/adr/ADR-0034-adr-candidate-registry-as-architectural-memory.md).

--- a/ops/coordination/adr_candidates.yaml
+++ b/ops/coordination/adr_candidates.yaml
@@ -43,6 +43,14 @@
 #   depends_on: ADR ids that must land first
 #   priority: now | soon | later
 #   tranche: 1 | 2 | 3 | 4
+#   readiness: ready | needs_framing_brief | needs_split | needs_source_review |
+#              needs_dogfood | needs_implementation_evidence | blocked
+#     (optional; set per ops/coordination/RFC_ADR_READINESS_AUDIT.md when an ADR's
+#      institutional gravity exceeds its evidence — the ADR is preserved, but the
+#      registry signals that further framing/splitting/evidence is required before
+#      the decision should advance from `proposed` to `accepted`.)
+#   readiness_notes: free-form sentence explaining the readiness annotation
+#     (cite the audit doc and the linked idea card)
 
 candidates:
 
@@ -109,6 +117,8 @@ candidates:
     depends_on: ["0021", "0022"]
     priority: soon
     tranche: 1
+    readiness: needs_framing_brief
+    readiness_notes: "ADR is `proposed / proposed`. Principle is reasonable; runtime details (Process DAG, step kinds, deadline-as-data, escalation-as-step) are speculative without shipping evidence. Framing work tracked at ops/ideas/ideas.yaml#idea-0012. See ops/coordination/RFC_ADR_READINESS_AUDIT.md."
 
   - id: "0024"
     title: "Institution Package Manifest Schema"
@@ -128,6 +138,8 @@ candidates:
     depends_on: []
     priority: now
     tranche: 1
+    readiness: needs_framing_brief
+    readiness_notes: "Seed-primitive part is settled (BootstrapSeedManifest ships). Proposed sections (indicators, signal rules, allocation templates, locale metadata, package operating intent) bundle distinct design spaces and need separate framing briefs. Tracked at ops/ideas/ideas.yaml#idea-0013. See ops/coordination/RFC_ADR_READINESS_AUDIT.md."
 
   - id: "0025"
     title: "Institutional Effect Record Canonical Schema"
@@ -147,6 +159,8 @@ candidates:
     depends_on: ["0024"]
     priority: soon
     tranche: 1
+    readiness: needs_framing_brief
+    readiness_notes: "ADR is `proposed / proposed`. No EffectRecord ships today — the dispatch seam from mandate to effect does not yet exist in code. Schema details (closed kind taxonomy, persistence model, reversal pointer) are speculative. Tracked at ops/ideas/ideas.yaml#idea-0014. See ops/coordination/RFC_ADR_READINESS_AUDIT.md."
 
   - id: "0026"
     title: "Receipt and Provenance Proof Envelope"
@@ -204,6 +218,8 @@ candidates:
     depends_on: []
     priority: now
     tranche: 1
+    readiness: needs_split
+    readiness_notes: "Principle (accessibility is a participation floor; five layers) is foundational and stays. Per-layer runtime contracts (sensory/cognitive/linguistic/economic/temporal) are speculative and span very different surfaces; each needs a separate framing brief. Tracked at ops/ideas/ideas.yaml#idea-0015. See ops/coordination/RFC_ADR_READINESS_AUDIT.md."
 
   - id: "0029"
     title: "Conflict Resolution Object Model"
@@ -223,6 +239,8 @@ candidates:
     depends_on: ["0023", "0025"]
     priority: soon
     tranche: 1
+    readiness: needs_split
+    readiness_notes: "Principle (institutional care first-class; three conflict shapes) is solid. Compute-disputes path ships. Institutional-conflict object model details (EffectChallenge type, evidence model, remedy taxonomy, mediation roles) are speculative and depend on idea-0014 (EffectRecord). Tracked at ops/ideas/ideas.yaml#idea-0016. See ops/coordination/RFC_ADR_READINESS_AUDIT.md."
 
   - id: "0030"
     title: "Compute Workload Manifest and Authority Boundary"
@@ -299,6 +317,8 @@ candidates:
     depends_on: ["0032"]
     priority: soon
     tranche: 1
+    readiness: needs_implementation_evidence
+    readiness_notes: "Decision direction is clear (every banded claim cites evidence). Linter is unbuilt. Lower the gravity until the linter exists; do not pretend the convention is enforced. See ops/coordination/RFC_ADR_READINESS_AUDIT.md."
 
   - id: "0034"
     title: "ADR Candidate Registry as Architectural Memory"

--- a/ops/ideas/ideas.yaml
+++ b/ops/ideas/ideas.yaml
@@ -489,3 +489,159 @@ ideas:
     next_transform: |
       Land in this PR alongside the refinery scaffold, since the
       hygiene rules are part of how the refinery actually works.
+
+  # --------------------------------------------------------------
+  # 12. CCL institutional process language — runtime details
+  # --------------------------------------------------------------
+  - id: idea-0012
+    title: CCL institutional process language — runtime framing
+    status: framed
+    kind: architecture_concept
+    source: "RFC/ADR readiness audit 2026-04-28; downgrade of ADR-0023 runtime details"
+    one_sentence: |
+      The runtime details proposed in ADR-0023 (Process DAG, step-kind taxonomy, deadline-as-data, escalation-as-step) need a framing brief before they should advance to accepted.
+    problem: |
+      ADR-0023 is `proposed / proposed` and names a CCL process layer with a specific runtime model. The principle (CCL grows a process surface) is reasonable, but the runtime model is speculative with no shipping evidence. Promoting the runtime details to accepted before a framing brief risks foreclosing alternatives prematurely.
+    belongs_to: icn
+    layer: substrate
+    current_artifact: "docs/adr/ADR-0023-ccl-institutional-process-language.md (proposed); ops/coordination/adr_candidates.yaml row 0023"
+    proposed_next_artifact: framing_brief
+    promoted_target: null
+    proposed_objects: []
+    requires_rfc: unknown
+    likely_adr: false
+    implementation_ready: false
+    public_claim_ready: false
+    evidence_required: []
+    privacy_risk: low
+    boundary_risk: low
+    risks:
+      - "Premature foreclosure of alternative process-execution models."
+      - "ADR appearing accepted before runtime is shippable."
+    next_transform: |
+      Write a framing brief that distinguishes the principle (CCL gains a process surface) from the runtime details. Identify the smallest plausible first step (e.g. AutoStep-only, no member input) and what evidence that first step would produce.
+
+  # --------------------------------------------------------------
+  # 13. Institution package manifest extensions
+  # --------------------------------------------------------------
+  - id: idea-0013
+    title: Institution package manifest extensions (per section)
+    status: framed
+    kind: architecture_concept
+    source: "RFC/ADR readiness audit 2026-04-28; downgrade of ADR-0024 speculative sections"
+    one_sentence: |
+      The proposed manifest sections in ADR-0024 (indicators, signal rules, allocation templates, locale and accessibility metadata, package operating intent) bundle several distinct design spaces and need separate framing briefs before any of them advances.
+    problem: |
+      ADR-0024 ships the seed-primitive part of the manifest (BootstrapSeedManifest) and proposes five additional sections. Each proposed section is its own design space. Treating them as one ADR-shaped decision over-bundles unrelated work and risks each section landing under-framed.
+    belongs_to: icn
+    layer: substrate
+    current_artifact: "docs/adr/ADR-0024-institution-package-manifest-schema.md (proposed/partial); ops/coordination/adr_candidates.yaml row 0024"
+    proposed_next_artifact: framing_brief
+    promoted_target: null
+    proposed_objects: []
+    requires_rfc: unknown
+    likely_adr: false
+    implementation_ready: false
+    public_claim_ready: false
+    evidence_required: []
+    privacy_risk: medium
+    boundary_risk: medium
+    risks:
+      - "Bundled ADR forecloses alternative shapes for sections that should be decided independently."
+      - "Locale/accessibility metadata is an accessibility-runtime concern (idea-0015), not a manifest-schema concern alone."
+    next_transform: |
+      Write per-section framing briefs (indicators, signal rules, allocation templates, locale metadata, package operating intent). Each may eventually become its own ADR or get parked. The seed-primitive part of ADR-0024 is settled and stays.
+
+  # --------------------------------------------------------------
+  # 14. Institutional EffectRecord canonical schema
+  # --------------------------------------------------------------
+  - id: idea-0014
+    title: Institutional EffectRecord canonical schema (framing)
+    status: framed
+    kind: architecture_concept
+    source: "RFC/ADR readiness audit 2026-04-28; downgrade of ADR-0025"
+    one_sentence: |
+      The EffectRecord schema proposed in ADR-0025 (closed kind taxonomy, plain-language summary, persistence model, reversal pointer, /me/standing visibility) needs a framing brief before it should advance — no EffectRecord ships today.
+    problem: |
+      ADR-0025 is `proposed / proposed`. The decision spine (proposal → mandate → grant) is in place, but the EffectRecord type is forward design without shipping evidence. Specifying the closed taxonomy and persistence model now risks foreclosing alternatives the kernel/dispatch work has not yet surfaced.
+    belongs_to: icn
+    layer: substrate
+    current_artifact: "docs/adr/ADR-0025-institutional-effect-record-canonical-schema.md (proposed); ops/coordination/adr_candidates.yaml row 0025"
+    proposed_next_artifact: framing_brief
+    promoted_target: null
+    proposed_objects:
+      - "EffectRecord (name candidate; under framing)"
+    requires_rfc: unknown
+    likely_adr: false
+    implementation_ready: false
+    public_claim_ready: false
+    evidence_required: []
+    privacy_risk: low
+    boundary_risk: low
+    risks:
+      - "Closed kind taxonomy locked in before kernel dispatch is built."
+      - "Persistence model decided before mandate-dispatch seam exists in code."
+    next_transform: |
+      Write a framing brief paired with the smallest concrete EffectRecord case (likely RoleAssigned). Build that case end-to-end (mandate dispatch → effect produced → /me/standing visible) before promoting the schema to an accepted ADR.
+
+  # --------------------------------------------------------------
+  # 15. Accessibility runtime details (per layer)
+  # --------------------------------------------------------------
+  - id: idea-0015
+    title: Accessibility runtime contracts (per layer)
+    status: framed
+    kind: architecture_concept
+    source: "RFC/ADR readiness audit 2026-04-28; split of ADR-0028 principle from runtime"
+    one_sentence: |
+      ADR-0028's accessibility principle is non-negotiable; the per-layer runtime contracts (sensory / cognitive / linguistic / economic / temporal) need separate framing briefs before they should advance to accepted.
+    problem: |
+      ADR-0028 is `proposed / proposed`. The principle (accessibility is a participation floor; five layers) is foundational and should stay. The per-layer runtime contracts (WCAG 2.2 AA bindings, glossary endpoint contract, mobile bandwidth model, plain-language rendering, reduced-motion semantics) are speculative and span very different surfaces.
+    belongs_to: icn
+    layer: institutional
+    current_artifact: "docs/adr/ADR-0028-accessibility-baseline-for-member-interfaces.md (proposed); docs/design-language/accessibility.md (descriptive); open #1610 / #1611 / #1366"
+    proposed_next_artifact: framing_brief
+    promoted_target: null
+    proposed_objects: []
+    requires_rfc: unknown
+    likely_adr: false
+    implementation_ready: false
+    public_claim_ready: false
+    evidence_required: []
+    privacy_risk: low
+    boundary_risk: low
+    risks:
+      - "Premature freezing of per-layer contracts before each layer has a real implementation surface."
+      - "Glossary / mobile / cards work could each surface a layer-specific tradeoff that the bundled ADR forecloses."
+    next_transform: |
+      Write per-layer framing briefs. Keep the principle paragraph from ADR-0028 as the load-bearing reference; treat each layer as its own framing/decision.
+
+  # --------------------------------------------------------------
+  # 16. Institutional conflict object model
+  # --------------------------------------------------------------
+  - id: idea-0016
+    title: Institutional conflict object model (framing)
+    status: framed
+    kind: architecture_concept
+    source: "RFC/ADR readiness audit 2026-04-28; split of ADR-0029 principle from runtime"
+    one_sentence: |
+      ADR-0029's principle (institutional care is first-class; three conflict shapes) is solid; the institutional-conflict object model details (EffectChallenge type, evidence model, remedy taxonomy, mediation roles) need a framing brief before they should advance.
+    problem: |
+      ADR-0029 is `proposed / partial`. The compute-disputes path ships in `icn-ccl/src/disputes.rs`. The institutional-conflict path is type sketches in `icn-governance/src/appeal.rs` only. Locking the object model before any institutional-conflict runtime exists risks foreclosing the actual remediation flows real institutions need.
+    belongs_to: icn
+    layer: institutional
+    current_artifact: "docs/adr/ADR-0029-conflict-resolution-object-model.md (proposed/partial); icn-ccl/src/disputes.rs (shipping for compute); icn-governance/src/appeal.rs (sketch only)"
+    proposed_next_artifact: framing_brief
+    promoted_target: null
+    proposed_objects: []
+    requires_rfc: unknown
+    likely_adr: false
+    implementation_ready: false
+    public_claim_ready: false
+    evidence_required: []
+    privacy_risk: high
+    boundary_risk: medium
+    risks:
+      - "Lock-in of object shapes before real grievance flows have run."
+      - "Privacy: conflict records carry the most sensitive institutional content; getting the schema wrong costs more than getting it right slowly."
+    next_transform: |
+      Write a framing brief that anchors on the three conflict shapes from ADR-0029 and then iterates one shape end-to-end (likely EffectChallenge against an existing EffectRecord, paired with idea-0014). Defer the other two shapes until the first has runtime.


### PR DESCRIPTION
## Summary

Reclassifies recent ADRs (and the two open RFCs) against the promotion thresholds defined by the idea refinery (`ops/ideas/`, merged via #1667). Some ADRs sit at higher institutional gravity than their evidence supports. This audit lowers the gravity to match the evidence — without deleting the thinking, without editing any ADR or RFC body, and without changing runtime or public-site behavior.

## Layer classification

- [x] ops/coordination (process, refinery, hygiene)

## Boundary check

- No ADR or RFC body is edited.
- No new ADR or RFC is added.
- No runtime change.
- No public website change.
- No private NYCN/Summit data referenced.
- No GitHub issue is filed by this PR.

## What changed

| Path | Role |
|---|---|
| `ops/coordination/RFC_ADR_READINESS_AUDIT.md` (new) | Full classification table for ADR-0021..0034 and RFC-0000/-0001/-0015; per-artifact recommendations; what this PR does not change. |
| `ops/coordination/adr_candidates.yaml` | Adds `readiness` and `readiness_notes` to rows **0023, 0024, 0025, 0028, 0029, 0033**. All other rows untouched. Header updated to document the new optional fields. |
| `ops/ideas/ideas.yaml` | Adds 5 idea cards (`idea-0012`..`idea-0016`) for the framing-brief work that should precede advancing the affected ADRs from `proposed` to `accepted`. |

## What did not change

- Every ADR file under `docs/adr/` is byte-identical.
- Every RFC file under `docs/rfcs/` is byte-identical.
- `ops/coordination/rfc_candidates.yaml` is unchanged (the only RFC change recommended is a future amendment PR for RFC-0015 to cite ADR-0032 as accepted policy for the canonical-surface section; not in scope here).
- `ops/coordination/README.md` is unchanged.
- No code, tests, or website assets are touched.

## Audit findings summary

| Bucket | Artifacts | Action |
|---|---|---|
| `keep_accepted_backfill` | ADR-0021, 0022, 0026, 0030, 0031, 0032, 0034; RFC-0000 | leave as-is |
| `keep_draft_rfc` | RFC-0001 | leave as-is |
| `keep_proposed_adr` | ADR-0027 | leave decision; refresh `implementation_status` text in a future PR |
| `needs_implementation_evidence` | ADR-0033 | `readiness` annotation only |
| `needs_framing_brief` | ADR-0023, 0024, 0025 | `readiness` annotation + idea cards (0012/0013/0014) |
| `needs_split` | ADR-0028, 0029 | `readiness` annotation + idea cards (0015/0016) |
| `amend_or_supersede` | RFC-0015 (canonical-surface section only) | future amendment PR (out of scope) |

## Hard rules carried forward

From `ops/ideas/README.md`:

1. Accepted RFC does not mean implemented.
2. Accepted ADR does not mean implemented.
3. Future map does not mean backlog commitment.
4. Public claim requires evidence.
5. Backfill ADRs are acceptable only when tied to code, tests, or accepted process.
6. Forward-looking ADRs must not decide details still speculative.
7. **Do not delete the thinking.** Lower the institutional gravity until the idea earns promotion.

## Cross-repo dependency status

- Upstream PR(s): #1667 (idea refinery) — merged.
- Downstream PR(s): none required by this PR. Optional follow-ups described in the audit doc (small status-text refresh for ADR-0027; small RFC-0015 amendment to cite ADR-0032).
- This PR depends on upstream merging first: no (it depends on #1667 merged, which it is).

## Review-thread status

- New PR; no prior review threads.

## Validation

- `python3 ops/ideas/validate_ideas.py` — ok (16 ideas)
- `python3 docs/scripts/doc_control_check.py --strict` — ok (only pre-existing enforcement warnings, none introduced by this PR)
- `git diff --check` — clean
- forbidden-term grep on `website/src` — zero hits

## Issue status

Refs InterCooperative-Network/icn#1664 (the cooperative-domain-infrastructure stack that surfaced the readiness gap).
Refs InterCooperative-Network/icn#1667 (the refinery that defines the promotion thresholds this audit applies).

This PR does not affect any specific ICN issue.