### PR TITLE
docs(adr): refresh action-card implementation status

### DIFF
--- a/docs/adr/ADR-0027-action-card-contract.md
+++ b/docs/adr/ADR-0027-action-card-contract.md
@@ -8,7 +8,7 @@ tags: ["action-cards", "member-shell", "standing", "derived-views", "forward-dir
 supersedes: []
 superseded_by: []
 amends: []
-implementation_status: "partially implemented (vertical slice; proof-loop verified for proposal/vote source path)"
+implementation_status: "partially implemented (vertical slice; proof-loop verified for all three currently-emitted source paths: proposal/vote, action_item/complete, meeting/attend; signal_rule and obligation_lifecycle remain RFC-gated on icn#1631 and icn#1634)"
 references:
   - "ADR-0020 (Bootstrap Activation and Standing Read Model)"
   - "ADR-0025 (Institutional Effect Record Canonical Schema)"


### PR DESCRIPTION
## Summary

One-line refresh of ADR-0027's YAML frontmatter `implementation_status`. Recorded that all three currently-emitted action-card source paths now have verified proof loops, and that the remaining two source paths (`signal_rule`, `obligation_lifecycle`) remain RFC-gated.

The body of ADR-0027 (`## Status` section, line ~101) already documents all three proof-bearing paths correctly. Only the YAML header was stale, written when only `proposal/vote` had a verified loop.

## Layer classification

- [x] docs / ADR status sync (no decision change)

## Boundary check

- No decision change to ADR-0027.
- No action-card schema change.
- No new source paths added.
- No runtime code touched.
- No website touched.
- No new RFCs or ADRs.

## What changed

`docs/adr/ADR-0027-action-card-contract.md` — single line in YAML frontmatter:

- Before: `implementation_status: "partially implemented (vertical slice; proof-loop verified for proposal/vote source path)"`
- After: lists all three currently-emitted paths and notes the two RFC-gated paths.

## What did not change

- ADR-0027 body. The `## Status` section already names all three paths and cites the test files (`me_action_card_receipt_chain.rs`, `me_action_item_receipt_chain.rs`, `me_meeting_attendance_receipt_chain.rs`).
- ADR-0027 status (`proposed`).
- ADR-0027 references list.
- `ops/coordination/RFC_ADR_READINESS_AUDIT.md` (still accurate; the audit already noted this refresh as recommended).
- `ops/coordination/adr_candidates.yaml` row 0027.
- Any other ADR or RFC.
- Runtime code, tests, website.

## Currently proof-bearing paths

| Source path | Receipt class | Test |
|---|---|---|
| `proposal` / `vote` | `GovernanceDecisionReceipt` | `icn/apps/governance/tests/me_action_card_receipt_chain.rs` |
| `action_item` / `complete` | `ActionItemCompletionReceipt` | `icn/apps/governance/tests/me_action_item_receipt_chain.rs` |
| `meeting` / `attend` | `MeetingAttendanceReceipt` | `icn/apps/governance/tests/me_meeting_attendance_receipt_chain.rs` |

## Still pending / RFC-gated

- `signal_rule` → gated on icn#1631
- `obligation_lifecycle` → gated on icn#1634

## Validation

- `python3 docs/scripts/doc_control_check.py --strict` — ok (only pre-existing warnings)
- `git diff --check` — clean

## Issue status

Refs #1646.