### PR TITLE
ops(ideas): frame institutional rule authoring through CCL

### DIFF
--- a/ops/ideas/README.md
+++ b/ops/ideas/README.md
@@ -178,6 +178,12 @@ exists for each promotion. Thresholds:
   implemented` or `verified`, or shipped runtime.
 - The maturity band is honest (per ADR-0033).
 
+## Framing briefs
+
+Concrete framing briefs (instances of the framing-brief template) live
+under [`framing/`](framing/). Each brief is anchored to one or more
+idea cards in `ideas.yaml` and is descriptive, not normative.
+
 ## Templates
 
 - [`templates/idea-card.md`](templates/idea-card.md) — minimal capture.

--- a/ops/ideas/framing/institutional-rule-authoring.md
+++ b/ops/ideas/framing/institutional-rule-authoring.md
@@ -1,0 +1,302 @@
+# Institutional rule authoring through CCL — framing brief
+
+**Idea cards:** [idea-0017](../ideas.yaml), [idea-0018](../ideas.yaml)
+**Date:** 2026-04-28
+**Status:** pre-RFC / pre-ADR framing. Not a design doc. Not a decision.
+Not a schema commitment.
+
+## What this is
+
+ICN should allow cooperatives, communities, federations, and other
+democratic institutions to encode customized structures, processes,
+and needs through CCL. CCL composes ICN primitives into
+institution-specific bylaws, policies, workflows, constraints, and
+receipt requirements.
+
+This brief uses an anonymized bylaws specimen reviewed out-of-repo
+only as primitive-discovery input. It does not name the cooperative,
+does not commit the source document, and does not treat the specimen
+as a universal cooperative model. A later multi-source research pass
+is the right venue for generalization across cooperative types.
+
+## Why this matters
+
+Bylaws are institutional operating systems written in legal prose. If
+bylaws remain PDFs beside the system, ICN cannot prove authority,
+process, or accountability — the runtime will diverge from what the
+institution has actually agreed to. If bylaws are over-automated, the
+system pretends legal and human judgment are code, which they are not.
+
+The right path is structured encoding with explicit classes:
+enforceable, checkable, discretionary, record-only, external-law,
+private-overlay, not-encoded. Each clause is mapped to one of these,
+not coerced into all-executable.
+
+## Core thesis
+
+> ICN should ship primitives. CCL should let institutions compose
+> those primitives into their own bylaws, policies, workflows,
+> constraints, and receipts.
+
+- ICN primitives are generic.
+- CCL binds them into rules.
+- Institution packages customize them per institution.
+- Runtime emits receipts and provenance when actions occur.
+
+The intended stack:
+
+```text
+human bylaws / charter / policies
+    │
+    ▼
+institution package
+    │
+    ▼
+CCL institutional rules
+    │
+    ▼
+ICN primitives
+    │
+    ▼
+runtime state + receipts
+```
+
+A bylaws specimen feeds the top of this stack as source material; it
+does not define any layer below it.
+
+## Primitive families surfaced by the specimen
+
+The specimen surfaced recurring institutional dimensions. Categories
+only — no clauses quoted, no source named:
+
+- **Membership / standing.** Eligibility, admission, classes, lapse,
+  reinstatement, termination. ICN may need to represent membership
+  state with auditable transitions and standing predicates.
+- **Member classes / tiers.** Voting members, non-voting members,
+  affiliate or associate members, candidate / probationary members,
+  honorary members. ICN may need to represent typed member classes
+  with per-class rights and obligations.
+- **Governance rights.** Voting, nomination, recall, candidacy,
+  petition. ICN may need to represent rights as composable predicates
+  attached to membership classes, not hardcoded.
+- **Notice / quorum / proxy.** Notice periods, quorum thresholds,
+  proxy rules, virtual-meeting rules. ICN may need to represent these
+  as parameterized rules per meeting type, not as global constants.
+- **Board / council structure.** Seat counts, term lengths, election
+  cadence, vacancies, classes of seats. ICN may need to represent seat
+  inventories with election windows and succession rules.
+- **Role / officer authority.** Authority granted to officers,
+  scope-limits, signing authority, delegation. ICN may need to
+  represent authority grants as scoped, time-bounded, revocable
+  capabilities.
+- **Due process / removal / termination.** Notice, hearing, appeal,
+  remedy. ICN may need to represent process flows where
+  human-discretion steps are first-class, not approximated as if-else.
+- **Cooperative economics.** Member equity, share classes, dues,
+  fees, surplus rules, dividends. ICN may need to represent economic
+  positions distinctly from generic ledger balances.
+- **Equity lifecycle.** Issuance, holding rules, redemption,
+  transferability, forfeiture. ICN may need to represent equity-class
+  state machines with redemption windows and waterfall rules.
+- **Patronage / allocation / reserves.** Patronage measurement,
+  allocation rules, retained vs distributed shares, reserves. ICN may
+  need to represent patronage as a separate accounting class with its
+  own policy parameters.
+- **Amendment lifecycle.** Proposal, notice, deliberation, vote,
+  ratification, effective date. ICN may need to represent the
+  bylaws-amending-themselves loop with explicit version transitions.
+- **Dissolution / liquidation waterfall.** Trigger, asset
+  resolution, member-equity treatment, residual disposition. ICN may
+  need to represent dissolution paths even though they are rarely
+  exercised.
+- **Records / minutes / notices / receipts.** What must be kept,
+  who may inspect, what must be produced on demand. ICN may need to
+  represent record-only obligations distinctly from enforceable
+  rules.
+
+These are primitive families, not commitments. None of them is a
+schema yet.
+
+## Variation across institutions
+
+This is not consumer-coop-only and is not US-only. Different
+institution types bind the primitive families differently:
+
+- consumer cooperatives
+- worker cooperatives
+- housing cooperatives
+- producer cooperatives
+- platform cooperatives
+- purchasing cooperatives
+- communities / mutual aid networks
+- land trusts
+- federations
+- multi-stakeholder cooperatives
+
+Examples of variation, kept generic:
+
+- A consumer co-op may use purchase-based patronage measurement.
+- A worker co-op may use labor contribution and worker-member
+  candidacy with probationary periods.
+- A housing co-op may use occupancy rights and maintenance
+  obligations as governance-relevant standing inputs.
+- A producer co-op may use supply commitments and quality grades as
+  membership obligations.
+- A platform co-op may bind member status to platform participation
+  and revenue share rather than equity.
+- A purchasing co-op may bind voting weight to volume bands.
+- A federation may use member organizations, delegate voting, dues,
+  and inter-coop agreements rather than individual members.
+- A multi-stakeholder cooperative may use multiple member classes
+  with different rights composed into a single governance body.
+
+A useful institutional-rule layer must accommodate all of these
+without forcing one shape.
+
+## Encoding classes
+
+Not every bylaw clause becomes executable code. Each clause should be
+explicitly classed:
+
+- `machine_enforceable` — runtime can refuse the action that violates
+  the rule (example: vote outside open polling window).
+- `machine_checkable` — runtime can verify after the fact and produce
+  a finding, but does not block (example: notice given on time).
+- `human_discretion` — the rule grants a human or body the authority
+  to decide; runtime records the decision but does not make it
+  (example: termination for cause).
+- `record_only` — the rule mandates a record, not an action (example:
+  meeting minutes retained N years).
+- `external_law_reference` — the rule defers to statute, regulator,
+  or contract; runtime does not interpret it (example: state cooperative
+  statute compliance).
+- `private_overlay_required` — the rule's implementation requires
+  data that must not enter public Git (example: member contact
+  information).
+- `not_encoded` — the rule is intentionally left in prose and not
+  represented in CCL.
+
+Encoding classes are part of the rule authoring surface, not a
+post-hoc audit. Authors choose them up front.
+
+## Boundary check
+
+- Belongs in the ICN idea refinery for now.
+- Not NYCN-specific. NYCN may eventually be one of many institution
+  packages built on this surface, but the framing must remain generic.
+- Not a public website claim.
+- Not icn-learn material yet. Teaching follows canonical framing.
+- Not an RFC or ADR yet.
+- No runtime claims. Nothing here is shipping.
+- The bylaws specimen stays out of repo and unnamed.
+- A later multi-source research pass may compare public cooperative
+  bylaws across cooperative types and feed back into this brief.
+
+## Existing surface
+
+What already exists in the repo that this idea touches:
+
+- Idea refinery: `ops/ideas/`, including `idea-0017` (bylaws primitive
+  scan) and `idea-0018` (this layer). Promotion thresholds in
+  `ops/ideas/README.md`.
+- CCL direction: `docs/adr/ADR-0023-ccl-institutional-process-language.md`
+  (`proposed`); `idea-0012` is the runtime-details framing.
+- Institution package boundary: `docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md`.
+- Manifest direction: `docs/adr/ADR-0024-institution-package-manifest-schema.md`
+  (`proposed/partial`); `idea-0013` is the per-section framing.
+- Effect record direction: `docs/adr/ADR-0025-institutional-effect-record-canonical-schema.md`
+  (`proposed`); `idea-0014` is the framing.
+- Conflict object model direction: `docs/adr/ADR-0029-conflict-resolution-object-model.md`
+  (`proposed/partial`); `idea-0016` is the framing.
+- Action-card proof loop: shipping for `proposal/vote`,
+  `action_item/complete`, `meeting/attend` (per ADR-0027
+  `implementation_status`). Cited here only as an example that runtime
+  state and receipts already exist for some institutional actions, not
+  as the whole rule authoring model.
+
+This brief does not mutate any of those documents.
+
+## Open questions
+
+1. What is the minimum CCL surface needed to express institutional
+   rules across the institution types listed above?
+2. Which primitives belong in ICN runtime versus institution package
+   YAML versus CCL rule code?
+3. How does CCL distinguish `machine_enforceable` from
+   `machine_checkable` so authors do not accidentally over-promise
+   enforcement?
+4. How are `human_discretion` decisions recorded with sufficient
+   provenance without being coerced into automation?
+5. How should amendments version the institution's active rule set,
+   and how do in-flight processes inherit (or not) the new rules?
+6. How do private overlays bind sensitive member, finance, and
+   personal data without entering public Git?
+7. How should a future research pass compare bylaws across cooperative
+   types without importing private or copyrighted material wholesale?
+
+## Privacy and boundary risks
+
+- The bylaws specimen contained organization-identifying language;
+  none of it is reproduced here. The source remains anonymous and
+  out-of-repo.
+- Member, equity, and patronage clauses imply sensitive data classes
+  (PII, financial position) that must stay in private overlay.
+- The temptation to absorb one cooperative's clause shape as ICN
+  doctrine is the boundary risk this brief exists to manage.
+
+## Proposed next artifact
+
+Pick exactly one (this brief picks one):
+
+- [ ] another framing brief (decompose first)
+- [x] later multi-source research / source-review pass across public
+      cooperative bylaws, feeding back into this brief and into
+      `idea-0017`
+- [ ] dogfood slice
+- [ ] promotion review → RFC candidate
+- [ ] promotion review → ADR candidate
+- [ ] promotion review → GitHub issue
+- [ ] promotion review → NYCN package task
+- [ ] promotion review → icn-learn packet
+- [ ] promotion review → website claim
+- [ ] park
+- [ ] reject
+
+A source-review template instance covering multiple bylaws specimens
+(public and license-clean only) is acceptable as the next artifact
+shape.
+
+Do not promote to RFC yet.
+
+## Non-goals
+
+- Do not create a consumer-coop schema. Or any single-type schema.
+- Do not name or commit the bylaws specimen.
+- Do not implement CCL syntax in this brief.
+- Do not modify runtime.
+- Do not change any ADR or RFC status.
+- Do not create public-website claims.
+- Do not assume all institutions need the same primitives.
+- Do not pretend legal, accounting, or human judgment is executable
+  code.
+- Do not bundle this brief with `idea-0012`, `idea-0013`, `idea-0014`,
+  `idea-0015`, or `idea-0016` — those framings stand on their own and
+  may produce different decisions.
+
+## Receipts / evidence (if relevant)
+
+Eventually, an institutional rule authoring surface will need:
+
+- A worked example: one institution package whose CCL rules cover at
+  least one primitive family from each section above (membership,
+  authority, meeting, economics, amendment, dissolution).
+- Evidence that `machine_enforceable` rules actually refuse violating
+  actions in runtime, with receipts.
+- Evidence that `human_discretion` decisions produce auditable
+  records that name the deciding body and the legal basis without
+  pretending the decision was automated.
+- Evidence that an amendment can ratify a new rule version and that
+  the runtime correctly applies the new version going forward.
+
+None of this evidence exists today. Producing it is downstream of
+later promotion reviews, not of this framing brief.

--- a/ops/ideas/framing/institutional-rule-authoring.md
+++ b/ops/ideas/framing/institutional-rule-authoring.md
@@ -1,23 +1,38 @@
 # Institutional rule authoring through CCL — framing brief
 
-**Idea cards:** [idea-0017](../ideas.yaml), [idea-0018](../ideas.yaml)
+**Idea cards:** `ops/ideas/ideas.yaml` (`idea-0017`, `idea-0018`)
+**Author / session:** 2026-04-28 session
 **Date:** 2026-04-28
 **Status:** pre-RFC / pre-ADR framing. Not a design doc. Not a decision.
 Not a schema commitment.
+
+> **Seed-brief discipline.** This is a seed framing brief. If future
+> passes add detailed primitive inventories, cross-institution research
+> findings, or rule-language capability maps, split those into separate
+> source-review or framing artifacts rather than letting this brief
+> become a design doc.
 
 ## What this is
 
 ICN should allow cooperatives, communities, federations, and other
 democratic institutions to encode customized structures, processes,
 and needs through CCL. CCL composes ICN primitives into
-institution-specific bylaws, policies, workflows, constraints, and
-receipt requirements.
+institution-specific bylaws, charters, constitutions, policies,
+agreements, workflows, constraints, and receipt requirements.
 
-This brief uses an anonymized bylaws specimen reviewed out-of-repo
-only as primitive-discovery input. It does not name the cooperative,
-does not commit the source document, and does not treat the specimen
-as a universal cooperative model. A later multi-source research pass
-is the right venue for generalization across cooperative types.
+> **Co-ops are one specimen class. ICN is for institutions.** CCL is
+> the rule-authoring layer for whatever governing text that institution
+> actually uses: bylaws, charters, constitutions, policies, compacts,
+> rules, governance manuals, or federation agreements.
+
+This brief uses an anonymized cooperative bylaws specimen reviewed
+out-of-repo as **one early primitive-discovery input**. It does not
+imply that cooperatives are the only target institution type, and it
+does not treat bylaws as the only governing-document form. Later
+research should compare public bylaws, charters, constitutions, rules,
+policies, agreements, compacts, and governance manuals across
+cooperatives, communities, federations, land trusts, associations,
+mutual-aid networks, and other democratic institutions.
 
 ## Why this matters
 
@@ -62,60 +77,125 @@ runtime state + receipts
 ```
 
 A bylaws specimen feeds the top of this stack as source material; it
-does not define any layer below it.
+does not define any layer below it. The same is true for charters,
+constitutions, compacts, federation agreements, and any other
+governing-document form.
 
-## Primitive families surfaced by the specimen
+## Governing-document forms
 
-The specimen surfaced recurring institutional dimensions. Categories
-only — no clauses quoted, no source named:
+Different institutions express their rules through different
+documents. ICN's rule-authoring layer should not care what the human
+document is called; it should identify the institutional rules,
+boundaries, authority, evidence requirements, and state transitions
+that the document enacts.
 
-- **Membership / standing.** Eligibility, admission, classes, lapse,
-  reinstatement, termination. ICN may need to represent membership
-  state with auditable transitions and standing predicates.
-- **Member classes / tiers.** Voting members, non-voting members,
-  affiliate or associate members, candidate / probationary members,
-  honorary members. ICN may need to represent typed member classes
+Forms encountered in practice include:
+
+- bylaws
+- charters
+- constitutions
+- rules
+- policies
+- member agreements
+- operating agreements
+- community compacts / covenants
+- federation agreements
+- inter-institutional agreements
+- governance manuals
+- assembly procedures
+- stewardship rules
+- shared-resource rules
+
+Mapped to institution type:
+
+- **Cooperatives** often present this as bylaws, rules, policies, and
+  member agreements.
+- **Communities** may present this as charters, compacts, assembly
+  rules, access rules, shared-resource rules, care obligations, or
+  local governance procedures.
+- **Federations** may present this as constitution-level governance:
+  member institutions, delegates, councils or chambers, recognition
+  rules, dues, jurisdiction, amendments, exit, and dissolution.
+
+The rule-authoring layer must accept that the source text is
+heterogeneous and must avoid privileging any single form.
+
+## Primitive families surfaced by the specimen and broader institution frame
+
+The cooperative bylaws specimen surfaced recurring institutional
+dimensions. The categories below merge those with dimensions visible
+in community charters and federation constitutions, so the family list
+does not collapse to one institution type. Categories only — no
+clauses quoted, no source named:
+
+- **Membership / participation / standing.** Eligibility, admission,
+  classes, lapse, reinstatement, termination. ICN may need to
+  represent membership and participation state with auditable
+  transitions and standing predicates.
+- **Member or participant classes.** Voting / non-voting members,
+  affiliate or associate members, candidate or probationary members,
+  honorary members, member institutions (federation case), residents
+  vs guests (community case). ICN may need to represent typed classes
   with per-class rights and obligations.
 - **Governance rights.** Voting, nomination, recall, candidacy,
-  petition. ICN may need to represent rights as composable predicates
-  attached to membership classes, not hardcoded.
-- **Notice / quorum / proxy.** Notice periods, quorum thresholds,
-  proxy rules, virtual-meeting rules. ICN may need to represent these
-  as parameterized rules per meeting type, not as global constants.
-- **Board / council structure.** Seat counts, term lengths, election
-  cadence, vacancies, classes of seats. ICN may need to represent seat
-  inventories with election windows and succession rules.
-- **Role / officer authority.** Authority granted to officers,
-  scope-limits, signing authority, delegation. ICN may need to
-  represent authority grants as scoped, time-bounded, revocable
-  capabilities.
-- **Due process / removal / termination.** Notice, hearing, appeal,
-  remedy. ICN may need to represent process flows where
-  human-discretion steps are first-class, not approximated as if-else.
-- **Cooperative economics.** Member equity, share classes, dues,
-  fees, surplus rules, dividends. ICN may need to represent economic
-  positions distinctly from generic ledger balances.
-- **Equity lifecycle.** Issuance, holding rules, redemption,
-  transferability, forfeiture. ICN may need to represent equity-class
-  state machines with redemption windows and waterfall rules.
-- **Patronage / allocation / reserves.** Patronage measurement,
-  allocation rules, retained vs distributed shares, reserves. ICN may
-  need to represent patronage as a separate accounting class with its
-  own policy parameters.
-- **Amendment lifecycle.** Proposal, notice, deliberation, vote,
-  ratification, effective date. ICN may need to represent the
-  bylaws-amending-themselves loop with explicit version transitions.
-- **Dissolution / liquidation waterfall.** Trigger, asset
-  resolution, member-equity treatment, residual disposition. ICN may
-  need to represent dissolution paths even though they are rarely
-  exercised.
+  petition, delegate selection. ICN may need to represent rights as
+  composable predicates attached to classes, not hardcoded.
+- **Notice / quorum / proxy / remote participation.** Notice periods,
+  quorum thresholds, proxy rules, virtual / hybrid participation
+  rules. ICN may need to represent these as parameterized rules per
+  meeting type, not as global constants.
+- **Assemblies / meetings / councils / chambers.** Convening rules,
+  agendas, decision modes (consensus / majority / supermajority),
+  delegate vs direct chambers. ICN may need to represent multiple
+  decision-making bodies under one institution.
+- **Board / council / committee / circle structure.** Seat counts,
+  term lengths, election cadence, vacancies, classes of seats. ICN
+  may need to represent seat inventories with election windows and
+  succession rules.
+- **Role / officer / delegate authority.** Authority granted to
+  officers, delegates, or stewards; scope-limits; signing authority;
+  delegation. ICN may need to represent authority grants as scoped,
+  time-bounded, revocable capabilities.
+- **Due process / removal / termination / remedy.** Notice, hearing,
+  appeal, remedy. ICN may need to represent process flows where
+  human-discretion steps are first-class, not approximated as
+  if-else.
+- **Shared-resource rules.** Access, allocation, stewardship,
+  maintenance obligations, depletion limits. Especially relevant to
+  communities, land trusts, and commons-managing institutions.
+- **Cooperative or institutional economics.** Member equity, share
+  classes, dues, fees, surplus rules, dividends, federation dues. ICN
+  may need to represent economic positions distinctly from generic
+  ledger balances.
+- **Dues / allocations / reserves / obligations.** Recurring
+  obligations on members or member institutions, allocations of
+  surplus, mandatory reserves.
+- **Equity / patronage where applicable.** Issuance, holding rules,
+  redemption, transferability, forfeiture; patronage measurement and
+  allocation. Communities may not need this family at all; producer
+  and consumer co-ops need it strongly; federations may instead use
+  dues and capital contributions from member institutions.
+- **Amendment / ratification lifecycle.** Proposal, notice,
+  deliberation, vote, ratification, effective date. ICN may need to
+  represent the rules-amending-themselves loop with explicit version
+  transitions.
+- **Exit / withdrawal / dissolution.** Trigger, asset resolution,
+  member-equity treatment, residual disposition; member-institution
+  withdrawal in federations. ICN may need to represent these paths
+  even though they are rarely exercised.
 - **Records / minutes / notices / receipts.** What must be kept,
   who may inspect, what must be produced on demand. ICN may need to
   represent record-only obligations distinctly from enforceable
   rules.
+- **Federation / inter-institutional agreements.** Recognition,
+  membership in a federation, treaties between cooperatives or
+  federations, shared services, cost-sharing.
+- **Jurisdiction / recognition / dispute routing.** Which body decides
+  which question; which institution recognizes which other; how
+  disputes traverse institutional boundaries.
 
 These are primitive families, not commitments. None of them is a
-schema yet.
+schema yet, and not every institution needs every family.
 
 ## Variation across institutions
 
@@ -128,30 +208,43 @@ institution types bind the primitive families differently:
 - producer cooperatives
 - platform cooperatives
 - purchasing cooperatives
-- communities / mutual aid networks
-- land trusts
-- federations
 - multi-stakeholder cooperatives
+- communities / neighborhood assemblies / mutual-aid networks
+- land trusts / community land institutions
+- associations / clubs with democratic governance
+- federations / secondary cooperatives / networks of organizations
 
 Examples of variation, kept generic:
 
 - A consumer co-op may use purchase-based patronage measurement.
 - A worker co-op may use labor contribution and worker-member
   candidacy with probationary periods.
-- A housing co-op may use occupancy rights and maintenance
+- A housing co-op may care about occupancy rights and maintenance
   obligations as governance-relevant standing inputs.
 - A producer co-op may use supply commitments and quality grades as
   membership obligations.
 - A platform co-op may bind member status to platform participation
   and revenue share rather than equity.
 - A purchasing co-op may bind voting weight to volume bands.
-- A federation may use member organizations, delegate voting, dues,
-  and inter-coop agreements rather than individual members.
 - A multi-stakeholder cooperative may use multiple member classes
   with different rights composed into a single governance body.
+- A community might not need patronage or equity primitives at all;
+  it may instead need assembly rules, access rules, shared-resource
+  rules, care obligations, and local governance procedures.
+- A land trust may bind decision rights to stewardship obligations
+  rather than membership tenure.
+- An association or club with democratic governance may need only a
+  thin slice (membership, meetings, officers, dues, amendments).
+- A federation might not need individual consumer-member rules; it
+  may instead need member institutions, delegates, councils or
+  chambers, recognition, dues, jurisdiction, and inter-institutional
+  agreements at constitution-level complexity.
 
-A useful institutional-rule layer must accommodate all of these
-without forcing one shape.
+The takeaway: ICN should provide primitive families. CCL should let
+each institution compose only what it needs. A useful
+institutional-rule layer must accommodate all of these without
+forcing one shape and without requiring institutions to adopt
+primitives that do not apply to them.
 
 ## Encoding classes
 
@@ -250,8 +343,12 @@ Pick exactly one (this brief picks one):
 
 - [ ] another framing brief (decompose first)
 - [x] later multi-source research / source-review pass across public
-      cooperative bylaws, feeding back into this brief and into
-      `idea-0017`
+      institutional governing documents — bylaws, charters,
+      constitutions, rules, policies, agreements, compacts, governance
+      manuals, federation agreements — covering cooperatives,
+      communities, federations, land trusts, associations, mutual-aid
+      networks, and other democratic institutions, feeding back into
+      this brief and into `idea-0017`
 - [ ] dogfood slice
 - [ ] promotion review → RFC candidate
 - [ ] promotion review → ADR candidate
@@ -262,8 +359,9 @@ Pick exactly one (this brief picks one):
 - [ ] park
 - [ ] reject
 
-A source-review template instance covering multiple bylaws specimens
-(public and license-clean only) is acceptable as the next artifact
+A source-review template instance covering multiple public,
+license-clean institutional governing documents — including but not
+limited to cooperative bylaws — is acceptable as the next artifact
 shape.
 
 Do not promote to RFC yet.

--- a/ops/ideas/ideas.yaml
+++ b/ops/ideas/ideas.yaml
@@ -645,3 +645,114 @@ ideas:
       - "Privacy: conflict records carry the most sensitive institutional content; getting the schema wrong costs more than getting it right slowly."
     next_transform: |
       Write a framing brief that anchors on the three conflict shapes from ADR-0029 and then iterates one shape end-to-end (likely EffectChallenge against an existing EffectRecord, paired with idea-0014). Defer the other two shapes until the first has runtime.
+
+  # --------------------------------------------------------------
+  # 17. Cooperative bylaws primitive scan
+  # --------------------------------------------------------------
+  - id: idea-0017
+    title: Cooperative bylaws primitive scan
+    status: needs_source_review
+    kind: source_review
+    source: "anonymized cooperative bylaws specimen reviewed out-of-repo; source not committed"
+    one_sentence: |
+      ICN needs a reusable way to identify institutional rule
+      primitives from cooperative bylaws without treating any single
+      cooperative's bylaws as a universal schema.
+    problem: |
+      Cooperative bylaws contain recurring institutional dimensions —
+      membership, standing, authority, voting, notice, quorum, equity,
+      patronage, amendment, dissolution, and due process — but co-ops
+      vary widely in how those dimensions are bound. ICN needs
+      primitive families and encoding classes, not hardcoded co-op
+      templates.
+    belongs_to: icn
+    layer: institutional
+    current_artifact: "anonymized bylaws specimen reviewed out-of-repo (not committed); session 2026-04-28 framing"
+    proposed_next_artifact: framing_brief
+    promoted_target: null
+    proposed_objects: []
+    requires_rfc: unknown
+    likely_adr: false
+    implementation_ready: false
+    public_claim_ready: false
+    evidence_required: []
+    privacy_risk: medium
+    boundary_risk: medium
+    risks:
+      - "Naming the source cooperative or implying endorsement."
+      - "Treating one bylaws specimen as the universal cooperative model."
+      - "Promoting clause observations directly into RFC/ADR doctrine."
+      - "Pretending all legal/human-discretion clauses can be executable code."
+    next_transform: |
+      Write/maintain the framing brief in
+      ops/ideas/framing/institutional-rule-authoring.md. Defer broader
+      generalization to a later multi-source research pass across
+      public cooperative bylaws.
+
+  # --------------------------------------------------------------
+  # 18. CCL institutional rule authoring layer
+  # --------------------------------------------------------------
+  - id: idea-0018
+    title: CCL institutional rule authoring layer
+    status: framed
+    kind: architecture_concept
+    source: "session 2026-04-28; bylaws-to-CCL discussion"
+    one_sentence: |
+      CCL should become the institutional rule authoring layer that
+      lets cooperatives, communities, and federations encode their
+      customized structures, processes, economic rules, authority
+      paths, and receipt requirements using ICN primitives.
+    problem: |
+      ICN should not ship fixed cooperative templates. Democratic
+      institutions need to encode their own structure and processes:
+      membership classes, standing rules, meeting procedures, voting
+      thresholds, board or council structures, authority grants,
+      obligations, allocations, reserves, amendment paths, and
+      dissolution rules. CCL should compose ICN primitives into
+      customized institutional packages, while preserving human
+      judgment and external legal/accounting review where code should
+      not decide.
+    belongs_to: icn
+    layer: institutional
+    current_artifact: "scattered CCL/charter direction in docs/architecture and ADR-0023/0024 (proposed); no rule authoring surface shipped"
+    proposed_next_artifact: framing_brief
+    promoted_target: null
+    proposed_objects:
+      - "MembershipClass (name candidate; not committed)"
+      - "StandingRule (name candidate)"
+      - "AuthorityGrant (name candidate)"
+      - "GovernanceProcess (name candidate)"
+      - "MeetingRule (name candidate)"
+      - "NoticeRequirement (name candidate)"
+      - "QuorumRule (name candidate)"
+      - "VoteThreshold (name candidate)"
+      - "ProxyRule (name candidate)"
+      - "PetitionRule (name candidate)"
+      - "BoardSeat (name candidate)"
+      - "OfficerRole (name candidate)"
+      - "EconomicPosition (name candidate)"
+      - "PatronageAllocation (name candidate)"
+      - "ReserveRequirement (name candidate)"
+      - "RedemptionRule (name candidate)"
+      - "AmendmentProcess (name candidate)"
+      - "DissolutionWaterfall (name candidate)"
+      - "ReceiptRequirement (name candidate)"
+      - "EncodingClass (name candidate)"
+    requires_rfc: unknown
+    likely_adr: false
+    implementation_ready: false
+    public_claim_ready: false
+    evidence_required: []
+    privacy_risk: medium
+    boundary_risk: medium
+    risks:
+      - "Turning CCL into a vague 'smart contract' bucket instead of institutional rule authoring."
+      - "Freezing syntax before multiple institution types have been reviewed."
+      - "Confusing one cooperative's bylaws specimen with a universal model."
+      - "Failing to distinguish enforceable rules from human/legal judgment."
+    next_transform: |
+      Use the framing brief
+      (ops/ideas/framing/institutional-rule-authoring.md) to define the
+      variation space and encoding classes. Do not promote to RFC until
+      a later multi-source research pass compares bylaws across
+      multiple cooperative types.

--- a/ops/ideas/ideas.yaml
+++ b/ops/ideas/ideas.yaml
@@ -687,7 +687,12 @@ ideas:
       Write/maintain the framing brief in
       ops/ideas/framing/institutional-rule-authoring.md. Defer broader
       generalization to a later multi-source research pass across
-      public cooperative bylaws.
+      public institutional governing documents — including cooperative
+      bylaws, community charters, federation constitutions, rules,
+      policies, agreements, compacts, and governance manuals — not
+      cooperative bylaws alone. idea-0017 itself remains a
+      cooperative-bylaws specimen scan; the broader research pass is a
+      separate downstream artifact.
 
   # --------------------------------------------------------------
   # 18. CCL institutional rule authoring layer
@@ -703,15 +708,22 @@ ideas:
       customized structures, processes, economic rules, authority
       paths, and receipt requirements using ICN primitives.
     problem: |
-      ICN should not ship fixed cooperative templates. Democratic
-      institutions need to encode their own structure and processes:
-      membership classes, standing rules, meeting procedures, voting
-      thresholds, board or council structures, authority grants,
-      obligations, allocations, reserves, amendment paths, and
-      dissolution rules. CCL should compose ICN primitives into
-      customized institutional packages, while preserving human
-      judgment and external legal/accounting review where code should
-      not decide.
+      ICN should not ship fixed cooperative templates, and it should
+      not assume cooperatives are the only target institution type.
+      Democratic institutions of many kinds — cooperatives,
+      communities, federations, land trusts, associations, mutual-aid
+      networks — need to encode their own structure and processes:
+      membership or participation classes, standing rules, meeting and
+      assembly procedures, voting thresholds, board or council or
+      circle structures, authority grants, obligations, allocations,
+      reserves, shared-resource rules, amendment paths, withdrawal,
+      and dissolution rules. For communities and federations, the
+      relevant source text may be a charter, constitution, compact,
+      federation agreement, policy manual, governance rulebook, or
+      inter-institutional agreement rather than bylaws alone. CCL
+      should compose ICN primitives into customized institutional
+      packages, while preserving human judgment and external
+      legal/accounting review where code should not decide.
     belongs_to: icn
     layer: institutional
     current_artifact: "scattered CCL/charter direction in docs/architecture and ADR-0023/0024 (proposed); no rule authoring surface shipped"


### PR DESCRIPTION
## Summary

Adds a pre-RFC ICN idea-refinery framing brief for institutional rule
authoring. Captures the principle that cooperatives, communities,
federations, and other democratic institutions should be able to
encode customized structures, processes, and needs through CCL by
composing ICN primitives.

This is **not** an RFC, **not** an ADR, **not** implementation, **not**
a schema commitment, and **not** a universal cooperative template. It
is a controlled idea-refinery / framing pass that holds the thinking
inside the refinery with the brakes on.

## Layer classification

`ops/ideas/` (idea refinery, pre-RFC). Specifically `ops/ideas/framing/`
as a new instance directory under the existing refinery layer.

## Boundary check

- Belongs in ICN idea refinery for now.
- Not NYCN-specific.
- Not public website.
- Not icn-learn yet.
- Not an RFC/ADR yet.
- No runtime claims.
- Source bylaws specimen stays out of repo and unnamed.
- Later multi-source research pass may compare public institutional
  governing documents (bylaws, charters, constitutions, rules,
  policies, agreements, compacts, governance manuals) across
  cooperatives, communities, federations, and other democratic
  institutions.

## What changed

- `ops/ideas/ideas.yaml`: two new idea cards.
  - `idea-0017` — Cooperative bylaws primitive scan
    (`needs_source_review` / `source_review`).
  - `idea-0018` — CCL institutional rule authoring layer
    (`framed` / `architecture_concept`).
- `ops/ideas/framing/institutional-rule-authoring.md` (new): framing
  brief anchored to both idea cards. Covers the core thesis,
  governing-document forms (bylaws / charters / constitutions / rules /
  policies / agreements / compacts / governance manuals / federation
  agreements), primitive families surfaced by the specimen and the
  broader institution frame, variation across institution types
  (cooperatives, communities, federations, land trusts, associations,
  mutual-aid networks), encoding classes (`machine_enforceable`,
  `machine_checkable`, `human_discretion`, `record_only`,
  `external_law_reference`, `private_overlay_required`,
  `not_encoded`), boundary check, existing surface, open questions,
  non-goals.
- `ops/ideas/README.md`: tiny pointer that framing-brief instances live
  under `ops/ideas/framing/`.

## Review fixes applied

- Copilot traceability fix: framing brief now uses the precise
  template-shaped reference
  (`ops/ideas/ideas.yaml` `idea-0017`, `idea-0018`) and includes an
  `Author / session` line.
- Framing broadened from cooperative bylaws alone to institutional
  governing documents across cooperatives, communities, federations,
  and other democratic institutions. The cooperative bylaws specimen
  is now explicitly only one primitive-discovery input.
- Added `Governing-document forms` section.
- Broadened `Variation across institutions` to cover community and
  federation cases distinctly (e.g. communities may not need
  patronage/equity at all; federations may reach constitution-level
  complexity with member institutions, delegates, and chambers).
- Added seed-brief discipline note: future detailed primitive
  inventories, cross-institution research findings, or rule-language
  capability maps should split into separate source-review or framing
  artifacts rather than letting this brief become a design doc.
- Updated `idea-0017.next_transform` and `idea-0018.problem` to
  reflect the broader frame.

## What did **not** change

- No ADR or RFC body edited or created.
- No runtime code.
- No website content.
- No NYCN repo files.
- No icn-learn repo files.
- No `docs/architecture/` files.
- No public claims.
- The cooperative bylaws specimen used for primitive discovery is
  anonymous and remains out-of-repo.

## Why not RFC/ADR yet

The promotion thresholds in `ops/ideas/README.md` are explicit:
- RFC requires unresolved design space with enumerable options.
- ADR requires a clear decision with understood consequences.

Neither is true here. The primitive families surfaced by one
cooperative bylaws specimen are not a design decision — they are
primitive-discovery input. Multiple institution types (consumer,
worker, housing, producer, platform, purchasing, multi-stakeholder
cooperatives; communities and mutual-aid networks; land trusts;
associations; federations) bind these dimensions differently and may
use entirely different governing-document forms. Promoting now would
either freeze the wrong shape or invent objects without proof.

The framing brief explicitly picks a later multi-source research /
source-review pass across public institutional governing documents as
its next artifact.

## Privacy / source handling

- One anonymized cooperative bylaws specimen was reviewed
  out-of-repo. The cooperative is not named anywhere in this PR.
- No clauses are quoted verbatim. Primitive families are described in
  generic categories only.
- The source document is not committed.
- Member, equity, and patronage clauses imply PII and financial
  position; any future implementation work flags those for private
  overlay treatment.

## Validation

- `python3 ops/ideas/validate_ideas.py` → ok (18 ideas)
- `python3 docs/scripts/doc_control_check.py --strict` → ok (734 docs;
  36 pre-existing enforcement warnings unrelated to this PR)
- `git diff --check` → clean
- Public-website grep not applicable; `website/` is untouched.

## Cross-repo dependency status

None. This change is ICN-only and does not require coordinated NYCN or
icn-learn updates.

## Issue status

Refs InterCooperative-Network/icn#1646.

## Review-thread status

Two Copilot review threads addressed in second commit:
1. Idea-card reference + author/session traceability — fix applied.
2. Length / decomposition — seed-brief discipline note added in lieu
   of splitting in this PR; future primitive inventories / research
   findings split into separate source-review or framing artifacts.