### PR TITLE
docs(architecture): add MEMBER_STANDING and THE_COMMONS architecture contracts

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -878,6 +878,7 @@ Deep-dive documents by category. Generated from `docs/registry.toml`.
 
 **Architecture & Design**
 - [The Commons](architecture/THE_COMMONS.md) — Capital-C Commons doctrine; what ICN exists to enable (doctrine)
+- [Member Standing and Accessible Participation](architecture/MEMBER_STANDING.md) — `/me/standing` design contract; accessibility as anti-capture infrastructure (design contract)
 - [Kernel/App Separation](architecture/KERNEL_APP_SEPARATION.md) — Five invariants, Meaning Firewall design (normative)
 - [Institution-in-a-Box](design/institution-in-a-box.md) — Four institution primitives, starter kit (normative)
 - [ADR-001: What ICN Is](strategy/ADR-001-What-ICN-Is.md) — Scope, non-goals, boundary conditions (normative)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -877,6 +877,7 @@ This is the honest scorecard of what's complete, what's working, and what's know
 Deep-dive documents by category. Generated from `docs/registry.toml`.
 
 **Architecture & Design**
+- [The Commons](architecture/THE_COMMONS.md) — Capital-C Commons doctrine; what ICN exists to enable (doctrine)
 - [Kernel/App Separation](architecture/KERNEL_APP_SEPARATION.md) — Five invariants, Meaning Firewall design (normative)
 - [Institution-in-a-Box](design/institution-in-a-box.md) — Four institution primitives, starter kit (normative)
 - [ADR-001: What ICN Is](strategy/ADR-001-What-ICN-Is.md) — Scope, non-goals, boundary conditions (normative)

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -96,6 +96,7 @@ Infrastructure:
 ## References
 
 - docs/PHASE_PROGRESS.md — phase tracking
+- docs/architecture/THE_COMMONS.md — Capital-C Commons doctrine (what ICN exists to enable)
 - docs/architecture/KERNEL_APP_SEPARATION.md — kernel/app boundary
 - docs/strategy/NYCN-Repo-Architecture-Spec.md — NYCN institutional architecture
 - docs/strategy/NYCN-Execution-Tranches.md — NYCN 7-tranche execution plan

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -97,6 +97,7 @@ Infrastructure:
 
 - docs/PHASE_PROGRESS.md — phase tracking
 - docs/architecture/THE_COMMONS.md — Capital-C Commons doctrine (what ICN exists to enable)
+- docs/architecture/MEMBER_STANDING.md — `/me/standing` design contract (member-facing standing + accessibility)
 - docs/architecture/KERNEL_APP_SEPARATION.md — kernel/app boundary
 - docs/strategy/NYCN-Repo-Architecture-Spec.md — NYCN institutional architecture
 - docs/strategy/NYCN-Execution-Tranches.md — NYCN 7-tranche execution plan

--- a/docs/architecture/MEMBER_STANDING.md
+++ b/docs/architecture/MEMBER_STANDING.md
@@ -1,6 +1,6 @@
 ---
 Status: design contract
-Canonical: yes
+Canonical: no
 Authority: architecture (complements THE_COMMONS.md and KERNEL_APP_SEPARATION.md)
 Last Reviewed: 2026-04-24
 Owner: Matt Faherty
@@ -287,36 +287,37 @@ This is the target shape. Fields that current ICN primitives can populate today 
       "source": "charter_approved_proposal"                           // [future design] provenance hint
     }
   ],
-  "roles": [                                                          // [shipped] icn-governance::RoleAssignment (via /gov/me/scopes)
+  "roles": [                                                          // [future design] `/me/standing` projection over governance role assignments. Current `/gov/me/scopes` (`RoleAssignmentResponse`) returns only `{id, structure_id, person_did, role, start_date, end_date}` and uses raw `StructureId` strings (e.g. `struct-<uuid>`); the richer shape below requires endpoint extension or secondary resolution before it can be composed.
     {
-      "structure_id": "structure:icn:committee:nycn-finance",         // canonical id
-      "parent_entity_id": "entity:icn:federation:nycn",               // canonical id
+      "structure_id": "structure:icn:committee:nycn-finance",         // [future design] normalized/canonical structure identifier; current `/gov/me/scopes` returns raw `StructureId`
+      "parent_entity_id": "entity:icn:federation:nycn",               // [future design] not present in current `/gov/me/scopes`
       "structure_display_label": "NYCN Finance Committee",            // [future design] display-label resolution
-      "role": "coordinator",                                          // [shipped]
-      "authority_scope": ["approve-budget-<=5000"],                   // [shipped] raw strings; see Plain-Language Summaries
+      "role": "coordinator",                                          // [shipped] role value is available via `/gov/me/scopes`
+      "authority_scope": ["approve-budget-<=5000"],                   // [future design] not present in current `/gov/me/scopes`; requires endpoint extension or secondary resolution
       "authority_scope_plain_language": [                             // [future design] plain-language rendering
         "Approve budget proposals up to 5000 units"
       ],
-      "valid_from": "2026-02-01T00:00:00Z",
-      "valid_until": "2026-12-31T23:59:59Z"
+      "valid_from": "2026-02-01T00:00:00Z",                           // [future design] normalized field name; underlying `RoleAssignment.start_date: Timestamp`
+      "valid_until": "2026-12-31T23:59:59Z"                           // [future design] normalized field name; underlying `RoleAssignment.end_date: Option<Timestamp>`
     }
   ],
-  "grants": [                                                         // [shipped] icn-governance::AuthorityGrant (ADR-0014)
+  "grants": [                                                         // [future design] `/me/standing` projection over `icn-governance::AuthorityGrant` (ADR-0014). The shape below is an API view; stored types differ — see notes below.
     {
-      "grant_id": "grant:0xabc...",
-      "class": "Representation",                                      // Representation | Execution | Attestation
-      "grantor_entity_id": "entity:icn:cooperative:greenstar",
-      "grantor_display_label": "GreenStar Cooperative",
-      "grantee_did": "did:icn:alice-pubkey",
-      "scope": {                                                      // [shipped] TypedScope
-        "domain": "nycn-federation-gov",
-        "kinds": ["CastVote", "SubmitProposal"]
+      "grant_id": "550e8400-e29b-41d4-a716-446655440000",              // [shipped] underlying `AuthorityGrantId(Uuid)`; bare UUID, no `grant:0x…` prefix
+      "class": "Representation",                                      // [shipped] `AuthorityClass`: Representation | Execution | Attestation
+      "grantor_entity_id": "entity:icn:cooperative:greenstar",        // [shipped] `GrantorEntityId`
+      "grantor_display_label": "GreenStar Cooperative",               // [future design] display-label resolution
+      "grantee_did": "did:icn:alice-pubkey",                          // [shipped] `Grantee`
+      "scope": {                                                      // [shipped] `TypedScope` — actual fields are `domain`, `proposal_class`, `action_kind`, `amount_ceiling`, `time_window`
+        "domain": "nycn-federation-gov",                              // [shipped] `TypedScope.domain`
+        "proposal_class": ["Treasury", "Membership"],                 // [shipped] `TypedScope.proposal_class` (proposal-payload-variant labels)
+        "action_kind": []                                             // [shipped] `TypedScope.action_kind` (Execution-class only); empty for Representation
       },
-      "scope_plain_language": "Represent GreenStar when voting or proposing in NYCN federation governance",
-      "valid_from": "2026-01-01T00:00:00Z",
-      "valid_until": "2026-12-31T23:59:59Z",
-      "revoked_at": null,
-      "capability_set": ["Vote", "Propose"]                           // derived
+      "scope_plain_language": "Represent GreenStar when voting or proposing in NYCN federation governance", // [future design] plain-language rendering
+      "valid_from": "2026-01-01T00:00:00Z",                           // [shipped] `AuthorityGrant.valid_from: Timestamp`
+      "valid_until": "2026-12-31T23:59:59Z",                          // [shipped] `AuthorityGrant.valid_until: Option<Timestamp>`
+      "revoked_at": null,                                             // [shipped] `AuthorityGrant.revoked_at: Option<Timestamp>`
+      "capability_set": ["Vote", "Propose"]                           // [future design] derived rendering for the standing surface; not stored on `AuthorityGrant`
     }
   ],
   "mandates": [                                                       // [shipped] icn-governance::Mandate

--- a/docs/architecture/MEMBER_STANDING.md
+++ b/docs/architecture/MEMBER_STANDING.md
@@ -1,0 +1,792 @@
+---
+Status: design contract
+Canonical: yes
+Authority: architecture (complements THE_COMMONS.md and KERNEL_APP_SEPARATION.md)
+Last Reviewed: 2026-04-24
+Owner: Matt Faherty
+---
+
+# Member Standing and Accessible Participation
+
+> **`/me/standing` is ICN's canonical answer to: who am I, where do I belong, what can I do, under whose authority, in which scope right now, with what duties waiting, and what do I need in order to understand any of this?**
+>
+> It is the substrate under the Commons Shell. It is the substrate under Action Cards. It is the substrate under accessible and assisted participation. It is not a convenience endpoint.
+
+This document is the design contract for `GET /me/standing`. It sits directly beneath `docs/architecture/THE_COMMONS.md` and inherits from it: The Commons doctrine says ordinary people must be able to participate in Commons institutions without becoming sysadmins; this document specifies the surface that makes that possible. It complements `docs/architecture/KERNEL_APP_SEPARATION.md` (the Meaning Firewall) and `docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md` (institution packaging), and takes the `[future design]` marker from `THE_COMMONS.md §9` and turns it into a concrete, implementation-ready contract.
+
+**This is design-only.** No endpoint is authorized for implementation here. Implementation happens in subsequent phases, each with its own PR.
+
+---
+
+## Purpose
+
+`GET /me/standing` is the canonical answer to a set of questions a member should be able to ask once and receive one coherent response to:
+
+- **Who am I?** What cryptographic identity is the caller, and what individual entity does that identity correspond to?
+- **Where do I belong?** Which entities (communities, cooperatives, federations) list me as a member, and in what role?
+- **What can I do?** What capabilities do I hold, broken down by the scope they apply in?
+- **Under what authority?** Which of my capabilities come from membership, which from role assignments in structures, which from explicit authority grants, which from mandates tied to specific decisions, which from delegations held from other individuals?
+- **Which hat am I wearing right now?** What is my currently selected active scope? What scopes could I select? What changes when I do?
+- **What needs my attention?** What action items, pending votes, upcoming meetings, expiring grants, or membership decisions are assigned to me or open in scopes where I can act?
+- **Under which institution am I acting at this moment?** The canonical id, human display label, any aliases in use, and the charter context.
+- **What do I need in order to understand any of this?** Plain-language summaries, glossary keys, translations, screen-reader structure, low-bandwidth fallbacks.
+
+`/me/standing` exists so that every member-facing surface — the Commons Shell, Action Cards, the mobile wallet, the pilot PWA, a library-terminal session, a CLI summary, an assisted-participation kiosk — can draw from a single authoritative view of the caller's participatory position. It is not a dashboard feed, not an admin query, not an identity profile, and not a replacement for existing primitives. It is the join point.
+
+> **If `/me/standing` fails, every accessible participation surface above it fails.** This document treats it accordingly.
+
+---
+
+## Relationship to The Commons
+
+`docs/architecture/THE_COMMONS.md` establishes the doctrine: ICN is infrastructure for The Commons; The Commons is plural; the kernel must not bake one social doctrine into its mechanics; the **Meaning Firewall** is how ICN remains usable by Commons institutions that disagree about meaning.
+
+That doctrine implies a specific obligation for the member-facing surface:
+
+- A Commons Shell must give ordinary people — not operators, not developers, not trained admins — a legible way to act inside the institutions they belong to.
+- Legibility requires a unified view of standing. Without it, every screen reconstructs authority ad hoc from `RoleAssignment`, `Membership`, `AuthorityGrant`, `Mandate`, and JWT scopes, and each reconstruction drifts.
+- The unified view must be **reporting**, not **defining**. It must not invent institutional meaning; it must render what the charters, proposals, grants, and mandates already say.
+
+`/me/standing` is that unified view. It is the bridge from kernel/governance/entity primitives to human-facing participation. It crosses the Meaning Firewall only in one direction: the endpoint computes from typed substrate data, hands the result to the shell, and the shell renders human meaning. The kernel still sees only `ConstraintSet`, `PolicyDecision`, `Capability`, and typed invariants; the endpoint adds no new semantic authority.
+
+> A member should be able to see their standing without becoming literate in ICN's type system. The type system is the *source* of the answer, not the *shape* of the answer.
+
+---
+
+## Relationship to NYCN Bootstrap Reality
+
+The NYCN institutional bootstrap track is the first real pressure test of the entity / structure / program / activity / milestone model. Its lesson for `/me/standing` is concrete and non-negotiable:
+
+1. **Integration tests passing is not the same as live validation.** The repo's integration tests for entities, structures, and proposals pass. Live validation against an actual gateway on port 8085 (after port 8080 conflict diagnosis) has already surfaced route/runtime drift — `apply` completed 5 operations and then 404'd on `/v1/gov/entities/{entity_id}/structures`. That is not a kernel-level invariant violation. It is the gap between typed repo primitives and their routed, escaped, gateway-wired representation.
+2. **Member-facing standing must be grounded in live, routable, explicit institutional state.** If `/me/standing` returns role assignments in structures whose routes are 404ing, the member cannot act on them. The endpoint must not paper over route/schema drift; it must surface it as a warning the Commons Shell can render.
+3. **Entity IDs contain colons by construction.** The format `entity:icn:<type>:<slug>` (see `icn/crates/icn-entity/src/entity.rs`) means every live path segment containing an entity id must be URL-encoded correctly or the route must be designed to avoid raw-id embedding. This is the proximate class of failure behind PR #1591 (colon-safe proposal index keys) and likely behind the bootstrap 404. `/me/standing` must emit canonical ids **and** route-safe representations, and never trust display labels or aliases for authority decisions.
+4. **Aliases from bootstrap apply must be legible but non-authoritative.** NYCN's bootstrap binds aliases like `nycn`, `nycn-organizers`, `summit-cycle-2026`, `summit-2026` to canonical entity ids. `/me/standing` must render the alias for humans and return the canonical id for actions. Aliases are UX; canonical ids are authority.
+
+`/me/standing` is not responsible for fixing the live 404. That work belongs to the `feat/live-nycn-bootstrap-validation` track. But this design absorbs the lesson: a member-facing contract specified only at the type level is insufficient. The contract must include the distinction between canonical id, route-safe representation, alias, display label, and translated label, and it must include warnings for the ways those can drift.
+
+NYCN is used here only as the first concrete example. Identifiers like `nycn`, `nycn-organizers`, `summit-cycle-2026`, and `summit-2026` are illustrative. They are not baked into core semantics and must not be. The generic shape is `entity:icn:<type>:<slug>`; NYCN is one instance.
+
+---
+
+## Non-Goals
+
+`/me/standing` is deliberately scoped. It does not:
+
+- **Implement the endpoint.** This document specifies the contract; implementation is a separate phase.
+- **Fix the live NYCN bootstrap 404.** That is a route / runtime concern for `feat/live-nycn-bootstrap-validation`.
+- **Replace `/gov/me/scopes` or `/gov/me/work`.** Those remain the authoritative feeds for role assignments and action items. `/me/standing` composes their outputs; it does not duplicate them.
+- **Define the final UI.** Rendering is the Commons Shell's job. `/me/standing` is the data contract that multiple renderings can consume.
+- **Define the final Action Card ranking.** That is `/me/action-cards` (`[future design]`), which consumes standing + open work + deadlines.
+- **Create a global identity hierarchy.** There is no top. `/me/standing` returns the caller's position in a plural, federated landscape, not a place in a global org chart.
+- **Centralize membership meaning.** Charters define what membership means. `/me/standing` reports what the charter-backed primitives say; it does not interpret them.
+- **Bypass charters.** Every capability returned by `/me/standing` traces to a charter-backed primitive: `Membership`, `RoleAssignment`, `AuthorityGrant`, `Mandate`, `Delegation`. If a capability is not grounded there, it must not appear.
+- **Weaken capability checks.** `/me/standing` reports what the caller *could* do at the authorization layer; the enforcement boundary remains unchanged. Reporting is not granting.
+- **Make assisted participation unrestricted.** Helpers don't gain authority by helping. The endpoint does not smuggle helper capability into the member's standing.
+- **Make every private membership public.** The response is caller-centered. Admin or third-party standing queries are explicitly out of scope and deferred.
+- **Turn accessibility into cosmetic UI.** Accessibility metadata is structural. It affects what the endpoint returns, not only how a downstream UI styles it.
+- **Turn operator setup into a member-facing requirement.** Bind ports, keystore passphrases, JWT secrets, sled lock files, and coop-id formats are operator concerns. `/me/standing` returns nothing that requires a member to understand any of them.
+
+---
+
+## First Principles
+
+Start from the human participation needs enumerated in `THE_COMMONS.md §First Principles` — belonging, agency, memory, recognition, access, voice, repair, continuity, bounded authority, transparent rules — and derive what they require from a standing surface.
+
+### Needs → Endpoint Requirements
+
+| Human / institutional need | Requirement on `/me/standing` |
+|----------------------------|-------------------------------|
+| Belonging | Identity is cryptographically anchored (`Did`) and human-readable at the surface (display label, individual entity id). Membership is queryable. |
+| Agency | The endpoint is callable by the member themselves, from any device holding their key, without central-operator permission. |
+| Comprehension | Every role, grant, mandate, and scope is explainable — not as raw ids, but as "what authority this gives you, from whom, until when." |
+| Voice | Pending votes, proposals, and amendments the caller can act on are either surfaced here (as pointers) or reachable via linked endpoints. |
+| Memory | Receipts and provenance are pointed at, not inlined. The endpoint tells the member where to verify, not what to trust. |
+| Trust | Every authority basis is named by primitive type and id so the member (or a third party later) can audit the claim. |
+| Repair | Expired, revoked, or ambiguous authorities are surfaced as warnings, not silently dropped. Errors are legible, not swallowed. |
+| Continuity | Mandates and grants approaching expiry are surfaced with lead time. Role handoffs are visible. |
+| Role clarity | Each scope is explicitly labeled and distinguishable (self vs. member vs. role-holder vs. representative vs. operator). |
+| Decision clarity | Active scope is explicit. The caller can see which scope an action would execute under before they act. |
+| Authority clarity | Capability is broken down by source: membership, role, grant, mandate, delegation. No "mystery admin" capability. |
+| Language access | Human labels are renderable per the caller's preferred language; canonical ids are stable. |
+| Disability access | Structural metadata (screen-reader-safe summary, plain-language mode, glossary keys) is first-class, not a downstream skin. |
+| Device access | The payload is small enough to render on a low-end phone; there is a text-only fallback shape. |
+| Low-bandwidth access | A minimal mode omits optional fields; no field is required to exceed a modest size. |
+| Device-loss recovery | The endpoint does not hold state on the member's device; standing is computed server-side and the member can re-enroll on any device with key recovery. |
+| Async participation | Pending work includes deadlines; the endpoint can be polled or cached and used offline with clear sync states. |
+| Post-hoc verification | Every authority claim points to a receipt or primitive id a third party could re-derive. |
+
+### Derived Requirements (blunt)
+
+1. Identity must be both cryptographically anchored (`Did`) and human-legible (display label, canonical entity id).
+2. Memberships must be queryable with role, status, and capability breakdown.
+3. Roles must be explainable — not "role:coordinator" without a structure, not "authority_scope" strings without human translation.
+4. Authority must trace to one of: membership, role assignment, grant, mandate, delegation. No ambient authority.
+5. Active scope must be explicit in the response and reflected in every action the caller subsequently takes.
+6. Permissions must be derivable per scope and understandable without consulting external docs.
+7. Pending work must be visible here (pointers; details on linked endpoints).
+8. Every item must be renderable as an Action Card: it has a subject, a scope, an authority basis, a next-step, and a deadline or none.
+9. Plain-language summaries must exist for every authority concept.
+10. Translation and glossary hooks must be first-class.
+11. Offline / read-only fallback must be supported (the response must be cacheable and safely re-render without a live connection).
+12. Assisted participation must leave a receipt trail.
+13. Privacy boundaries must be explicit; the response is caller-centered.
+14. Canonical route-level identifiers must be distinct from human labels/aliases, and both must appear in the response.
+
+---
+
+## Accessibility as Anti-Capture Infrastructure
+
+> **Accessibility is not charity. Accessibility is anti-capture infrastructure.**
+
+Every barrier to participation creates a ruling class. A technical barrier creates a sysadmin priesthood. An English-only barrier creates a linguistic priesthood. A laptop-only barrier creates a wealth priesthood. A synchronous-meeting-only barrier creates an availability priesthood. A legalese barrier creates a lawyer priesthood. An operator-shell barrier creates an operator priesthood. Each of these, over time, captures the institution by exclusion.
+
+The Commons cannot afford to reproduce those priesthoods inside its own substrate. That means `/me/standing` — and every member-facing surface above it — must be designed for:
+
+- **Old phones.** Three-to-five-year-old Android devices with modest RAM and slow flash.
+- **Low bandwidth.** 2G-class connections, metered data, shared tethering.
+- **Intermittent connectivity.** Rural, transit-based, disaster-recovery, outage-prone networks.
+- **Shared devices.** Library terminals, community-center kiosks, household tablets.
+- **Second-language users.** Members whose primary language is not the institution's working language.
+- **Screen readers.** Full semantic structure, no meaning conveyed only by visual layout.
+- **Keyboard and switch navigation.** Full interaction without pointer devices.
+- **Cognitive-load reduction.** Short sentences, one idea per paragraph, glossary on demand, no hidden state.
+- **Large text, high contrast, reduced motion.** Required by users with low vision, photosensitivity, or vestibular conditions.
+- **Plain-language institutional explanations.** "What does it mean that you're a representative of GreenStar in NYCN?" — answerable in one sentence without jargon.
+- **Translated institutional concepts, not just UI labels.** "Proposal," "quorum," "mandate," "delegation," "charter" each need a translated *definition*, not just a translated button.
+- **Offline reading and later submission where safe.** Members can read their standing, compose a vote, and submit on reconnect, with clear sync state at every step.
+- **Assisted participation with receipts and anti-coercion protections.** When someone helps, the help is visible in provenance, and the action is still the member's.
+
+Accessibility is therefore a **contract-level concern** for `/me/standing`, not a downstream styling concern. The endpoint must return the data that makes accessible rendering possible: language codes, translation availability, glossary keys, screen-reader-safe summaries, low-bandwidth hints. A downstream UI can choose how to render; it cannot retroactively add data the endpoint did not expose.
+
+---
+
+## Operator Complexity Must Not Leak Into Member Participation
+
+The live NYCN bootstrap validation exposed a legitimate operator surface: gateway bind ports (8080 vs. 8085), gateway JWT secret, `identity.age` keystore files, `ICN_KEYSTORE_PASSPHRASE`, `--coop-id` flags, daemon startup and shutdown, local data directories, sled lock files, route availability in a specific gateway build, gateway/auth wiring. Those are real operator concerns.
+
+They must not become member-facing requirements.
+
+A member should open the Commons Shell (PWA, mobile, terminal, CLI summary, kiosk) and see:
+
+- **Identity** — who they are, in human-readable form.
+- **Belonging** — which entities they are a member of.
+- **Available actions** — what they can do given their current scope.
+- **Pending attention** — what is waiting for them.
+- **Why** — the authority basis for each capability.
+- **Next steps** — what to click, who to contact, what to sign.
+- **Verification** — where to check the receipt.
+
+They must **not** see:
+
+- Sled paths, sled locks, or storage-engine details.
+- JWT secrets, signing-key material, or session internals.
+- Route mount prefixes or gateway version strings.
+- Raw `entity:icn:<type>:<slug>` colon-separated identifiers as the primary explanation of where they belong.
+- URL escaping concerns.
+- Coop-id flag formats.
+- Daemon lifecycle or infrastructure state.
+
+`/me/standing` is the firewall between the two audiences. It speaks typed substrate primitives on its input side and human-usable standing on its output side. Operator diagnostics (route drift warnings, schema-version mismatches, stale cache indicators) may appear in the response as typed warnings, but they must be framed for the member's downstream shell to render gracefully — "some information may be out of date; try again later" — not dumped as raw operator noise.
+
+---
+
+## Endpoint Contract: `GET /me/standing`
+
+This section specifies the contract at the level needed to review and implement. It is deliberately restrained about routing and auth specifics; those are implementation choices constrained by what follows.
+
+### Method and Path
+
+`GET /me/standing`
+
+Namespace options (pick in an implementation ADR, not here):
+
+- **Option A — new member-facing namespace**: `/me/standing` under a new `/me/*` root. Pros: clear member-facing boundary; easily extended to `/me/action-cards` and future member endpoints. Cons: introduces a new top-level namespace.
+- **Option B — under existing governance namespace**: `/gov/me/standing`. Pros: reuses the existing `/gov/me/*` convention used by `/gov/me/scopes` and `/gov/me/work`. Cons: conflates governance standing with broader participatory standing (memberships, representation mandates, operator scopes).
+- **Option C — deferred**: ship the data shape under whichever existing namespace is fastest, and rename in a later phase.
+
+**Recommendation**: Option A. The response composes governance, entity, identity, and policy data, which is broader than `/gov/*`. A new `/me/*` namespace signals to the shell team that this is *the* doorway. However, the recommendation is non-binding; the final routing decision belongs to an implementation ADR that verifies there is no conflict with existing `/me/*` routes and that gateway mounts match.
+
+### Authentication
+
+Standard gateway JWT-bearer auth, as used by `/gov/me/scopes` and `/gov/me/work` (`Authorization: Bearer <token>`, `require_scope` check). The caller's `Did` is parsed from the token subject.
+
+### Caller DID Resolution
+
+The endpoint resolves the caller's `Did` from the verified JWT and treats that as the subject of the response. There is no query parameter to ask for another member's standing in the initial design. Admin-scoped third-party queries are explicitly out of scope here and deferred to a separate design with explicit capability checks and privacy review.
+
+### Default Behavior
+
+`GET /me/standing` returns the caller's full current standing: memberships, role assignments, authority grants held, mandates, delegations, currently selected active scope (if any), available active scopes, effective capabilities per scope, pointers to pending work, accessibility metadata, warnings.
+
+### Privacy Behavior
+
+- Caller-centered: only the caller's own standing is returned.
+- Entities that list the caller as a member appear in the response with the caller's role inside them — **not** with the full roster of other members.
+- Federation views show the caller's representational authority, not the federation's internal structure beyond what membership confers.
+- Expired or revoked items are included **if the caller had or holds them**, because surfacing revocations matters for repair. They are clearly marked.
+
+### Error Behavior
+
+- Unauthenticated caller: `401`.
+- Authenticated caller with no memberships and no role assignments: `200` with an empty standing shape (identity + empty lists + empty warnings). Empty standing is a legitimate state.
+- Internal store errors: `500` with a typed error body; the shell renders "standing temporarily unavailable" and retries.
+- Partial data (e.g., memberships resolved but mandates store unreachable): `200` with populated fields **and** an explicit warning entry indicating which subsystem is stale. The shell renders "some information may be out of date"; the caller is never silently misinformed.
+
+### Relationship to Current Active Scope
+
+If the caller has an explicitly selected active scope (per the `[future design]` active-scope primitive — see §Active Scope), the response includes it. Otherwise, `active_scope` is either `null` or the `self` default, and the Commons Shell is expected to prompt the member to select one before authority-bearing actions.
+
+### Relationship to `/gov/me/scopes` and `/gov/me/work`
+
+- `/gov/me/scopes` — authoritative for role assignments. `/me/standing` composes its output in the `roles` field (see §Proposed JSON Shape) and does not duplicate its query semantics.
+- `/gov/me/work` — authoritative for assigned action items. `/me/standing` returns pointers and summary counts in the `pending_work` field; the shell fetches details from `/gov/me/work`.
+
+This separation is deliberate: `/me/standing` is the join view; the existing endpoints remain the authoritative feeds. A member-facing shell that wants live, filterable action items continues to call `/gov/me/work`; a shell that wants the one-shot standing snapshot calls `/me/standing`.
+
+### Relationship to Federation / Member Entities
+
+If the caller represents another entity in a federation (via a `Mandate` or an `AuthorityGrant` of class `Representation`), the response enumerates the representable entities and the grants/mandates backing them. The caller can then select a `representative` active scope to act for the represented entity. The federation's own internal composition is **not** returned; only the caller's representational position within it.
+
+### Relationship to NYCN Bootstrap / Live Entities
+
+NYCN entities (e.g., `entity:icn:federation:nycn`, `entity:icn:community:nycn-organizers`, `entity:icn:program:summit-cycle-2026`, `entity:icn:activity:summit-2026`) and their bootstrap-bound aliases (e.g., `nycn`, `nycn-organizers`, `summit-cycle-2026`, `summit-2026`) appear in the response like any other institutional entities. They carry both their canonical id and their display label/alias. The endpoint does not special-case NYCN, and NYCN must not appear in kernel constants. These examples are for illustration only.
+
+---
+
+## Proposed JSON Shape
+
+This is the target shape. Fields that current ICN primitives can populate today are annotated `[shipped]`; fields that require additional primitives are annotated `[future design]` with a brief note.
+
+```jsonc
+{
+  "subject": {
+    "did": "did:icn:alice-pubkey",                                    // [shipped] icn-identity::Did
+    "individual_entity_id": "entity:icn:individual:alice-pubkey",     // [shipped] icn-entity::EntityId
+    "display_label": "Alice"                                          // [future design] display-label resolution; fallback to did
+  },
+  "active_scope": {                                                   // [future design] active-scope primitive
+    "kind": "representative",                                         // self | member | role | representative | operator
+    "represented_entity_id": "entity:icn:cooperative:greenstar",      // canonical id
+    "entity_alias": "greenstar",                                      // optional, non-authoritative
+    "display_label": "Representing GreenStar in NYCN",                // human label
+    "via_grant": "grant:0xabc...",                                    // [shipped] AuthorityGrant id
+    "source": "session_selected",                                     // session_selected | default_self | jwt_coop_id_fallback
+    "fallback": false                                                 // true if the endpoint had to fall back to a default
+  },
+  "memberships": [                                                    // [shipped] icn-entity::Membership
+    {
+      "entity_id": "entity:icn:cooperative:greenstar",                // canonical
+      "entity_alias": "greenstar",                                    // [future design] alias rendering
+      "entity_display_label": "GreenStar Cooperative",                // [future design] display-label resolution
+      "entity_type": "cooperative",                                   // [shipped] Entity discriminant
+      "role": "Worker",                                               // [shipped] MembershipRole
+      "status": "Active",                                             // [shipped] MembershipStatus
+      "shares": 1,                                                    // [shipped]
+      "capabilities": ["Vote", "Propose"],                            // [shipped] MembershipCapability
+      "joined_at": "2025-06-01T00:00:00Z",                            // [shipped]
+      "source": "charter_approved_proposal"                           // [future design] provenance hint
+    }
+  ],
+  "roles": [                                                          // [shipped] icn-governance::RoleAssignment (via /gov/me/scopes)
+    {
+      "structure_id": "structure:icn:committee:nycn-finance",         // canonical id
+      "parent_entity_id": "entity:icn:federation:nycn",               // canonical id
+      "structure_display_label": "NYCN Finance Committee",            // [future design] display-label resolution
+      "role": "coordinator",                                          // [shipped]
+      "authority_scope": ["approve-budget-<=5000"],                   // [shipped] raw strings; see Plain-Language Summaries
+      "authority_scope_plain_language": [                             // [future design] plain-language rendering
+        "Approve budget proposals up to 5000 units"
+      ],
+      "valid_from": "2026-02-01T00:00:00Z",
+      "valid_until": "2026-12-31T23:59:59Z"
+    }
+  ],
+  "grants": [                                                         // [shipped] icn-governance::AuthorityGrant (ADR-0014)
+    {
+      "grant_id": "grant:0xabc...",
+      "class": "Representation",                                      // Representation | Execution | Attestation
+      "grantor_entity_id": "entity:icn:cooperative:greenstar",
+      "grantor_display_label": "GreenStar Cooperative",
+      "grantee_did": "did:icn:alice-pubkey",
+      "scope": {                                                      // [shipped] TypedScope
+        "domain": "nycn-federation-gov",
+        "kinds": ["CastVote", "SubmitProposal"]
+      },
+      "scope_plain_language": "Represent GreenStar when voting or proposing in NYCN federation governance",
+      "valid_from": "2026-01-01T00:00:00Z",
+      "valid_until": "2026-12-31T23:59:59Z",
+      "revoked_at": null,
+      "capability_set": ["Vote", "Propose"]                           // derived
+    }
+  ],
+  "mandates": [                                                       // [shipped] icn-governance::Mandate
+    {
+      "mandate_id": "mandate:0xdef...",
+      "represented_entity_id": "entity:icn:cooperative:greenstar",
+      "decision": {                                                   // DecisionProvenance
+        "proposal_id": "prop:0x123...",
+        "governance_domain": "greenstar-internal"
+      },
+      "payload_hash": "0xdeadbeef",
+      "grants": ["grant:0xabc..."],                                   // links to AuthorityGrant ids above
+      "executor_did": "did:icn:alice-pubkey",
+      "deadline": "2026-06-30T23:59:59Z",
+      "status": "Active",                                             // Active | Completed | Expired | Revoked
+      "issued_at": "2026-04-01T00:00:00Z",
+      "summary_plain_language": "Cast GreenStar's vote on the NYCN 2026 summit budget"
+    }
+  ],
+  "delegations": {                                                    // [shipped] icn-governance::Delegation (1717 LOC)
+    "held_from": [                                                    // delegations where caller is the delegate
+      {
+        "delegation_id": "del:0x111...",
+        "delegator_did": "did:icn:bob-pubkey",
+        "domain": "greenstar-internal",
+        "kind": "domain_scoped",
+        "valid_until": "2026-12-31T23:59:59Z"
+      }
+    ],
+    "held_to": [                                                      // delegations where caller is the delegator
+      {
+        "delegation_id": "del:0x222...",
+        "delegatee_did": "did:icn:carol-pubkey",
+        "domain": "nycn-federation-gov",
+        "kind": "proposal_scoped",
+        "proposal_id": "prop:0x456...",
+        "valid_until": "2026-05-15T23:59:59Z"
+      }
+    ]
+  },
+  "available_active_scopes": [                                        // [future design] active-scope primitive
+    { "kind": "self", "label": "Acting as yourself",
+      "source_primitive": "identity" },
+    { "kind": "member", "entity_id": "entity:icn:cooperative:greenstar",
+      "label": "Member of GreenStar",
+      "source_primitive": "Membership" },
+    { "kind": "role", "structure_id": "structure:icn:committee:nycn-finance",
+      "label": "Finance Coordinator, NYCN",
+      "source_primitive": "RoleAssignment" },
+    { "kind": "representative", "represented_entity_id": "entity:icn:cooperative:greenstar",
+      "via_grant": "grant:0xabc...",
+      "label": "Representing GreenStar in NYCN",
+      "source_primitive": "AuthorityGrant" },
+    { "kind": "operator", "node_id": "node:home-01",
+      "label": "Node operator: home-01",
+      "source_primitive": "operator_layer" }                          // [future design] operator scope model
+  ],
+  "effective_scopes": [                                               // derived: scope strings the kernel would see
+    {
+      "scope_key": "member:entity:icn:cooperative:greenstar",
+      "capabilities": ["Vote", "Propose"],
+      "derived_from": ["membership:entity:icn:cooperative:greenstar"]
+    }
+  ],
+  "pending_work": {                                                   // pointers; details via /gov/me/work
+    "total": 3,
+    "by_urgency": { "overdue": 1, "due_soon": 1, "later": 1 },        // [future design] urgency bucketing
+    "feed": "/gov/me/work"                                            // canonical feed
+  },
+  "action_card_hints": {                                              // [future design] /me/action-cards
+    "feed": "/me/action-cards",
+    "count_by_scope": {
+      "member:entity:icn:cooperative:greenstar": 2,
+      "representative:entity:icn:cooperative:greenstar": 1
+    }
+  },
+  "accessibility": {                                                  // [future design] language/glossary model
+    "preferred_language": "en",
+    "available_translations": ["en", "es"],
+    "plain_language_mode": true,
+    "glossary_keys": [
+      "mandate", "delegation", "representation", "authority_grant",
+      "governance_domain", "proposal", "structure"
+    ],
+    "screen_reader_summary": "You are Alice. You are a Worker member of GreenStar Cooperative and a coordinator on the NYCN Finance Committee. You have one representation mandate for GreenStar in NYCN, valid through December 31, 2026. You have three items pending your attention, one of which is overdue.",
+    "low_bandwidth_hints": {
+      "omit_optional": true,                                          // shell signals preference
+      "text_only_fallback_available": true
+    }
+  },
+  "receipts": {                                                       // [shipped] where verifiable
+    "memberships_provenance": "see charter store and accepted membership proposals",
+    "grants_provenance": "see AuthorityGrant store",
+    "mandates_provenance": "see Mandate store and decision proposals"
+  },
+  "warnings": [                                                       // typed warning envelope
+    { "kind": "expired_grant",    "id": "grant:0x789...", "expired_at": "2026-03-01T00:00:00Z" },
+    { "kind": "ambiguous_scope",  "note": "Two representational grants for entity:icn:cooperative:greenstar overlap in domain nycn-federation-gov." },
+    { "kind": "missing_translation", "language": "es", "term_keys": ["mandate"] },
+    { "kind": "stale_cache",      "subsystem": "mandates", "last_fresh_at": "2026-04-23T18:00:00Z" },
+    { "kind": "route_drift",      "note": "Structures index for entity:icn:federation:nycn returned 404 on last probe; capabilities may be stale." },
+    { "kind": "reauth_required",  "reason": "token_near_expiry" }
+  ]
+}
+```
+
+Fields carrying `[shipped]` map to present primitives. Fields carrying `[future design]` are called out and enumerated in §Gaps.
+
+---
+
+## Join Plan
+
+How `/me/standing` assembles its response from current repo modules. Real paths are cited. Items requiring new storage or indexing are marked.
+
+1. **Identity lookup** — resolve caller `Did` from JWT subject.
+   - Source: `icn-http-kit::auth::BasicClaims` + `icn-identity::Did` (see `icn/apps/governance/src/http/handlers.rs` pattern).
+2. **Individual entity lookup** — compute `EntityId::from_did(did)` → `entity:icn:individual:<identifier>`.
+   - Source: `icn/crates/icn-entity/src/entity.rs`.
+3. **Memberships** — list all `Membership` records where `member_id` matches the caller's individual entity id.
+   - Source: `icn/crates/icn-entity/src/membership.rs`.
+   - Today: requires a `list_memberships_for_member(member_id)` query on the membership store. If that index does not exist, it is the first `[future design]` storage addition.
+4. **Bootstrap-created entities and aliases** — for each membership, resolve the parent entity's canonical id, display label, and bootstrap alias (if any).
+   - Source: entity store; institution-bootstrap alias binding (`icn/bins/icnctl/src/institution_bootstrap.rs`, bootstrap apply path around the structures-creation loop at `format!("/v1/gov/entities/{parent}/structures")` — which is also the site of the current live 404).
+   - Today: alias binding exists at bootstrap time; a read-side "alias for canonical id" lookup must be exposed to the endpoint. `[future design]` if not already query-able.
+5. **Role assignments** — reuse the existing `/gov/me/scopes` implementation: `ctx.manager.list_roles_for_person(&caller)` (`icn/apps/governance/src/http/handlers.rs`).
+   - Source: shipped.
+6. **Authority grants held by caller** — list `AuthorityGrant` where `grantee == caller_did` and `revoked_at is null` and `valid_until > now`.
+   - Source: `icn/crates/icn-governance/src/authority.rs`.
+   - Today: requires a `list_grants_for_grantee(did)` query. `[future design]` if not already indexed.
+7. **Mandates where caller is executor** — list `Mandate` where `executor == caller_did` and `status != Completed|Expired|Revoked`.
+   - Source: `icn/crates/icn-governance/src/mandate.rs`.
+   - Today: similar index requirement; `[future design]` if not already indexed.
+8. **Delegations held by caller (as delegate)** — list `Delegation` where `delegatee == caller_did` and not expired/revoked.
+   - Source: `icn/crates/icn-governance/src/delegation.rs`.
+9. **Delegations held from caller (as delegator)** — list `Delegation` where `delegator == caller_did` and not expired/revoked.
+   - Source: same as above.
+10. **Capability derivation** — for each membership, role assignment, grant, and mandate, emit derived capabilities scoped by the source primitive.
+    - Deterministic transform; no new storage.
+11. **Active scope / session-selected scope** — read the caller's current selection from a session-scope store.
+    - `[future design]`: no session-selected-scope primitive exists today. Today's approximation is JWT `coop_id` + `scopes`. The endpoint must not invent a selection; it must report "no active scope selected" (or default to `self`) when the primitive is absent.
+12. **`/gov/me/scopes` + `/gov/me/work` composition** — the existing outputs populate the `roles` and `pending_work` fields. The endpoint calls the same manager methods (`list_roles_for_person`, `list_work_for_person`) rather than round-tripping HTTP.
+    - Source: shipped.
+13. **Receipt / provenance pointers** — produce references to the stores where the caller (or a third party with authorization) can verify. Not inlined receipts.
+    - Source: existing governance receipt/proof surface (`icn-governance::proof`).
+14. **Accessibility metadata** — read the caller's language preference and plain-language mode from identity metadata (or default).
+    - `[future design]`: accessibility-preference storage is not yet a first-class primitive; default values are returned until it ships.
+15. **Glossary keys** — emit the set of terms present in the response that a downstream shell would need definitions for.
+    - Deterministic, based on which fields are populated.
+16. **Warnings** — collect from: expired grants, revoked grants still referenced by active role assignments, overlapping representational grants, translation gaps, subsystem staleness indicators, route-drift probes, near-expiry tokens.
+
+### Items That Cannot Be Joined Today Without New Storage / Indexing
+
+- By-grantee / by-delegate / by-executor reverse indexes on `AuthorityGrant`, `Mandate`, and `Delegation`, if not already maintained.
+- Member-centered membership index (`list_memberships_for_member`), if not already maintained.
+- Session-selected active-scope primitive.
+- Display-label resolution (entity + structure + role labels for human rendering).
+- Alias-binding read API (bootstrap-apply alias → canonical id lookup from read paths).
+- Accessibility preference storage (language, plain-language mode, low-bandwidth hint).
+- Route-drift probe (the endpoint can surface what it observes, but a first-class probe is out of scope here).
+
+Each of these is `[future design]` and is enumerated in §Gaps.
+
+---
+
+## Active Scope / Session-Selected Scope
+
+The **active scope** is the hat the member is currently wearing. The problem: a member may belong to multiple entities and act in multiple distinct contexts — individual community member, NYCN organizer, structure delegate, cooperative representative in a federation, node operator, summit organizer inside `summit-cycle-2026`, participant inside `summit-2026`. Every action must be bound to one of those hats, and every receipt must record which hat it was taken under.
+
+### Why Implicit `coop_id` Scope Is Insufficient
+
+Today's gateway JWT carries a `coop_id` claim and a `scopes` array. That approximation fails in several ways:
+
+1. **One `coop_id` cannot express representational action.** A member acting as a representative of GreenStar in NYCN is not "in the GreenStar coop context"; the *subject* of the action is GreenStar, not the member.
+2. **One `coop_id` cannot express nested context.** A member operating inside `summit-cycle-2026` (a Program under NYCN) acting as a summit organizer is not fully described by `coop_id = nycn`.
+3. **A single JWT claim is not visible in the UI.** Members do not see which hat they are wearing; it is implicit in the token they happened to receive from login.
+4. **A single JWT claim is not visible in receipts.** Receipts must say *which scope* the action was taken under, not just who signed.
+5. **A single JWT claim is not switchable mid-session in a legible way.** Switching scopes requires re-auth or a token refresh the user does not understand; the gesture is invisible.
+6. **A single JWT claim cannot express "self."** Personal actions (own ledger, own trust attestations, own key operations) are the base case, not a degenerate value of `coop_id`.
+
+### Requirements on the Active-Scope Primitive
+
+1. **Explicit.** The selected scope is a typed object, not a string claim fished out of a token.
+2. **Visible.** Every member-facing screen renders the active scope prominently. Scope-switching is a first-class gesture.
+3. **Included in dangerous confirmations.** Authority-bearing actions show "You are about to cast a vote as GreenStar in NYCN" before the member signs.
+4. **Switchable.** Switching requires one gesture and does not require re-login unless the new scope has additional security requirements.
+5. **Auditable where it affects authority.** Receipts record the active scope. The substrate keeps provenance.
+6. **Never silently changes votes or actions.** A background scope change cannot retroactively reinterpret a pending action.
+7. **Representable in low-bandwidth / plain text.** Active scope is one line in a text-only fallback.
+8. **Distinguishes canonical ids from aliases / display labels.** The scope key uses canonical ids; the rendering uses human labels.
+
+### Surface in `/me/standing`
+
+`/me/standing` returns both:
+
+- The current `active_scope` object if the session has one selected.
+- The list of `available_active_scopes` the caller could switch to.
+
+The endpoint does not decide the scope; it reports and enumerates. Selection lives in a session primitive that is explicitly `[future design]` and must be specified in its own design doc.
+
+---
+
+## Canonical IDs, Aliases, Labels, and URL Safety
+
+The live NYCN bootstrap validation produced a 404 on `/v1/gov/entities/{entity_id}/structures` after successfully creating upstream entities. The proximate cause is most likely route-level handling of colon-containing canonical ids (`entity:icn:federation:nycn`) — the same class of hazard that PR #1591 addressed for proposal index keys. This design absorbs that lesson.
+
+### Definitions
+
+- **Canonical id** — the authoritative typed identifier for an entity or structure: `entity:icn:federation:nycn`, `entity:icn:community:nycn-organizers`, `entity:icn:program:summit-cycle-2026`, `entity:icn:activity:summit-2026`, `structure:icn:committee:nycn-finance`. These are stable, comparable, and carry provenance. They are the only form used for authority checks.
+- **Route-safe representation** — whatever encoding makes the canonical id safe to embed in URL path segments (percent-encoding, or an alternate key schema that avoids colons at the route layer entirely). This is a transport concern, not an identity concern.
+- **Alias** — a short, human-typeable shortcut bound to a canonical id at bootstrap time or by later admin action. `nycn` → `entity:icn:federation:nycn`. Aliases are UX conveniences. They are **not** authoritative.
+- **Display label** — a human-readable name for an entity, structure, role, or scope: "NYCN Federation", "Finance Committee", "Summit 2026". Display labels are rendered; they are never parsed into authority.
+- **Translated label** — a display label rendered in the caller's preferred language.
+- **Human explanation** — a one-sentence plain-language description of what a primitive *means* to the caller: "You represent GreenStar when casting votes in NYCN federation governance."
+
+### Requirements
+
+1. **Member-facing UI must not expose raw canonical ids as primary explanation.** Canonical ids appear as diagnostic / deep-link values, not as "where you belong" prose.
+2. **Action execution must not rely on translated or display labels.** Labels can diverge across languages and renderings; only canonical ids bind authority.
+3. **Route paths must use safe encoded ids or route designs that cannot be broken by colon-containing ids.** This is a gateway contract, not a member-facing concern; `/me/standing` surfaces it as a warning when drift is detected.
+4. **Alias bindings from bootstrap apply must be visible in diagnostics but not in authority decisions.** `/me/standing` returns `entity_alias` alongside `entity_id`; the Commons Shell may render the alias; every subsequent action submitted by the shell uses the canonical id.
+5. **`/me/standing` returns both canonical ids and human labels.** Every entity / structure / scope entry carries its canonical id and its display label. Aliases are included when present.
+6. **Warnings surface ambiguous or unresolved aliases.** If an alias fails to resolve to a canonical id, the warning envelope carries the reason; the field falls back to the canonical id alone.
+
+This design does not fix the 404. Routing fixes are the responsibility of the live-validation track. This design requires that `/me/standing` be **robust to** routing fragility: if a downstream route is 404ing, the endpoint returns the best-available standing with a `route_drift` warning, not an empty response or a 500.
+
+---
+
+## Relationship to Action Cards
+
+`/me/standing` is not `/me/action-cards`, but it supplies the standing context an action-card generator needs to produce cards for this member, in this scope, with this authority.
+
+### Action Card Defined
+
+An **action card** is a human-facing rendering of an institutional action. Every card carries:
+
+- **What** — the proposed action, in plain language.
+- **Who** — the subject of the action (the member as self, or an entity represented by the member).
+- **Authority** — the primitive(s) that authorize this action: membership capability, role assignment scope, grant, mandate.
+- **Why** — the charter clause, proposal, mandate, or request that triggered the card.
+- **Choices** — the set of valid responses (Yes / No / Abstain / Delegate / Dismiss / etc., per the action type).
+- **Consequences** — what happens if the member acts vs. if they do not.
+- **Deadline** — the time bound, if any.
+- **Supporting records** — links to the proposal, meeting minutes, charter clauses, related receipts.
+- **Receipts** — pointers to the provenance of the authority under which the action would execute.
+- **Language and glossary** — preferred language, glossary keys for any jargon.
+- **Accessibility hints** — screen-reader summary, plain-language mode, low-bandwidth alternative.
+- **Risk** — low / medium / high, tied to the action type and the authority basis.
+- **Confirmation** — whether this action requires a confirmation step before signing.
+- **Active scope** — which of the member's scopes this card belongs to.
+- **Canonical target** — canonical ids for every entity, structure, proposal involved (never labels).
+
+### Semantic Action Is the Source of Truth
+
+The card is a **rendering** of the underlying action, not the action itself. The same semantic action (e.g., "vote Yes on proposal X as representative of GreenStar") must be renderable as:
+
+- A rich mobile card (CoopWallet class).
+- A plain web page (pilot-ui PWA).
+- A screen-reader-safe document.
+- A low-bandwidth text view.
+- A printed notice (for members without devices, routed via stewards).
+- A translated message (institutional glossary included).
+- A kiosk / facilitator flow (public terminal, library, community center).
+- A CLI summary (`icnctl me action-cards`, future).
+
+`/me/standing` does not produce cards. It returns the standing context — memberships, roles, grants, mandates, available scopes, effective capabilities — that a card generator consumes. The generator (the `/me/action-cards` endpoint, `[future design]`) joins standing with open proposals, assigned work, upcoming meetings, expiring authorities, and care requests to produce the ranked list.
+
+---
+
+## Accessibility Requirements
+
+Accessibility is a legitimacy requirement, not a UI polish concern. `/me/standing` is the contract under every accessible participation surface; the data it returns determines what accessible rendering is possible.
+
+### Requirements
+
+1. **Plain-language summaries.** Every authority concept (membership, role, grant, mandate, delegation, representation) has a one-sentence plain-language rendering in the response (`authority_scope_plain_language`, `scope_plain_language`, `summary_plain_language`).
+2. **Glossary-backed concepts.** The response enumerates the glossary keys present. A downstream shell can fetch definitions and attach them to terms.
+3. **Multilingual rendering.** The response declares the caller's preferred language and the languages in which translations are available. Missing translations produce a typed warning, not a silent English fallback.
+4. **RTL readiness.** Text fields must not assume left-to-right order; display labels and plain-language strings are stored in a form that supports RTL scripts.
+5. **Non-English-first participation.** Members whose first language is not the institution's working language receive translated labels and translated plain-language summaries; canonical ids are unaffected.
+6. **Screen-reader semantic structure.** The response includes a `screen_reader_summary`: a single-paragraph standing summary specifically composed for linear reading. Not all shells will use it, but it must be available.
+7. **Keyboard / switch navigation.** Not a server-side concern directly, but the endpoint must not return data that requires pointer interaction to understand (no "hover for details" semantics baked into the contract).
+8. **No color-only meaning.** Urgency buckets, statuses, and warnings are all labeled by typed enum values, never by hex color. Color is a rendering choice.
+9. **High contrast, large text, reduced motion.** Rendering-side concerns; the endpoint supports them by returning plain text, structural enums, and no animation-dependent flags.
+10. **Low-bandwidth text fallback.** The endpoint honors a low-bandwidth hint from the caller, omitting optional fields (display labels, extended summaries, repeated provenance pointers) and returning a compact form.
+11. **Old Android / low-end mobile assumptions.** The payload is bounded in size; the endpoint does not assume client-side computation beyond simple rendering.
+12. **No mandatory app-store install for core participation.** The same data is consumable from a browser, a terminal, and a CLI. A member denied access to an app store can still participate.
+13. **No mandatory video / audio for core governance.** Every action card derived from standing must have a text-only rendering path.
+14. **Async participation.** The response is cacheable and safely re-renderable offline. Pending work items include deadlines for asynchronous planning.
+15. **Offline read / draft / later-submit where safe.** The shell can cache `/me/standing`, draft a vote, and submit on reconnect. The sync state machine at the shell level — saved locally / not submitted / submitted / accepted by node / receipt issued / finalized — must be legible to the member.
+16. **Clear sync states.** The response includes indicators (`stale_cache`, `reauth_required`, `route_drift`) that a shell translates into sync-state messaging without inventing meaning.
+17. **High-risk action confirmations.** Risk is a typed field on cards derived from standing; shells render confirmations proportionate to risk.
+18. **Deadlines and reminders that don't punish disability or bad connectivity.** Institutions may define grace policies in their charters; `/me/standing` surfaces the charter-backed deadline and any grace window, not a wall-clock fact.
+
+---
+
+## Language and Glossary Model
+
+Translating ICN is not just translating buttons. The hard part is translating **institutional meaning**. Ordinary governance terms — proposal, quorum, mandate, delegation, representation, charter, structure, program, milestone — carry very different weights across languages, legal systems, and cooperative traditions. A Spanish rendering of "mandate" that reads as "mandato" may be legally stronger than the English original intended; a rendering that reads as "encargo" may be too weak.
+
+### Requirements
+
+1. **UI string translation.** Standard localization of labels, buttons, status words. Table stakes.
+2. **Institution-specific glossary packs.** Each institution can ship a glossary pack with its package (e.g., NYCN's glossary defines what "organizer" means inside NYCN). Glossary packs are namespaced; they do not override core ICN terminology.
+3. **Plain-language definitions.** Every glossary entry includes a plain-language definition aimed at a reader with no prior governance exposure.
+4. **Examples attached to terms.** "Mandate — example: Alice holds a mandate to cast GreenStar's vote on the NYCN 2026 summit budget, valid until June 30, 2026."
+5. **Translator notes.** Where a term has translation nuance (e.g., "representation" vs. "delegation"), translator notes explain what to preserve and what to adapt.
+6. **Charter-specific terms.** An institution's charter may coin or redefine terms. Those definitions are charter-backed and surface in the glossary alongside core ICN terms, with the charter id as provenance.
+7. **Governance primitive terms.** `role`, `proposal`, `vote`, `abstain`, `delegation`, `mandate`, `grant`, `federation`, `bootstrap`, `entity`, `structure`, `program`, `milestone` all require institution-neutral definitions in every supported language.
+8. **Fallback if translation missing.** The response includes a typed `missing_translation` warning rather than silently returning English. The shell renders the English form with a visible "translation unavailable" marker.
+9. **Warning when formal record and translated summary diverge.** If the plain-language summary could be read as materially different from the canonical (e.g., a mandate's scope is narrower than the summary suggests), the warning surface makes that visible.
+10. **Preserving formal canonical record.** The canonical primitive (the `Mandate`, the `AuthorityGrant`, the `Charter` clause) is the record. Translations are renderings of the record. The record does not change because a translation does.
+
+> **The system must translate governance meaning, not just interface labels.** If the glossary layer is skipped, accessibility layered on top collapses into cosmetic styling, and the institution is captured by whoever controls the terminology.
+
+---
+
+## Assisted Participation
+
+Shared devices, public library computers, community kiosks, meeting facilitators, translators, stewards, printed packets, phone and in-person support — these are how most real Commons institutions actually work. Designing as though every member is a solitary power user on a dedicated device reproduces the laptop priesthood.
+
+### Requirements
+
+1. **Assistance must be explicit when it affects an action.** If a helper operates the device on behalf of a member, the action's provenance records the helper's role. Silent help is prohibited for authority-bearing actions.
+2. **Member confirmation remains central.** The member — not the helper — is the authority. For authority-bearing actions, confirmation is a member gesture (a key touch, a spoken confirmation recorded via witness protocol, a written sign-off co-signed by a second member, per charter policy).
+3. **Helper must not silently gain authority.** Operating the device does not confer capability. A helper with zero membership cannot invoke actions on their own standing; they are channeling the member's standing, with provenance.
+4. **Assisted action produces a receipt or audit marker.** The receipt for an assisted action carries a typed `assisted_by` field where applicable, anchored to charter-backed assistance policy. Charters that do not recognize assistance as a distinct category produce receipts without that field.
+5. **Privacy preserved.** The helper sees only what the charter permits them to see. A translator is not thereby a reader of the member's ledger; a facilitator is not thereby a viewer of the member's private memberships.
+6. **Coercion risk acknowledged.** Assisted participation raises the coercion floor — especially for members in vulnerable positions. Charters may require anti-coercion protections (witnesses, cool-off periods, private revocation paths). `/me/standing` surfaces charter-backed assistance policy as a member-visible field so members know what protections apply.
+7. **Institutions may define assistance policy in charters / packages.** The kernel enforces the constraints the charter produces. The kernel does not define what "assistance" means; it enforces what the charter says.
+8. **Kernel enforces constraints, not social doctrine.** `/me/standing` reports assistance policy as data; it does not prescribe what assistance must look like.
+
+---
+
+## Privacy and Safety
+
+`/me/standing` is a caller-centered surface. Privacy properties are enforced at the contract level, not left to downstream shells.
+
+1. **Standing must not expose unnecessary private memberships.** The response lists entities the caller is a member of; it does not list other members of those entities. Roster disclosure is the responsibility of entity-scoped endpoints with their own authorization.
+2. **Admin queries are future design, requiring explicit capability.** "Show me Alice's standing" is not an authorized operation under this design. It requires a separate endpoint with charter-backed admin capability and privacy review.
+3. **Member-facing standing is caller-centered.** The response talks about the caller. It does not talk about third parties beyond what the caller's own role requires (e.g., a representational grant names the grantor entity).
+4. **Federation views don't leak unrelated internal roles.** If the caller represents GreenStar in NYCN, the response says so. It does not list the other GreenStar representatives, the other NYCN members, or the internal committee composition of either entity.
+5. **Receipts prove authority without oversharing.** Receipt pointers name the primitive ids (grant id, mandate id, proposal id) the caller can use to verify. They do not inline third-party payloads.
+6. **Assisted participation must not become surveillance.** Helper attribution is provenance for authority-bearing actions; it is not a general watcher log of everything a member does.
+7. **Accessibility metadata must not become disability profiling.** A preferred-language value, a plain-language-mode flag, and a low-bandwidth hint are rendering preferences, not protected-class indicators. They are not emitted to third parties and not used for sorting or filtering.
+8. **Language preference must not be exclusion proxy.** An institution cannot use preferred-language values to gate membership or capabilities. If it tries to, the charter would have to explicitly state it, which makes the exclusion visible; kernel enforcement remains language-agnostic.
+9. **Operator diagnostics must not leak into member-facing standing unless relevant and safe.** The `warnings` envelope carries typed, member-safe operator-layer signals (`stale_cache`, `route_drift`, `reauth_required`). It does not carry secrets, internal addresses, sled paths, or route mount prefixes.
+
+---
+
+## Readiness Ladder: From Docs to Tests to Live Proof
+
+`/me/standing` is not pilot-ready until it has crossed each of the following rungs. Passing a lower rung does not substitute for a higher one.
+
+1. **Design / documented contract.** This document. The contract specifies the shape, the privacy model, the accessibility model, the warning envelope, and the join plan.
+2. **Unit tests.** Core data transformations (capability derivation, scope enumeration, warning generation) are unit-tested against typed fixtures.
+3. **Integration tests.** Multi-node, cross-crate tests with `icn-testkit`, including cases for expired grants, revoked mandates, ambiguous scopes, and missing translations.
+4. **Live local gateway validation.** A local `icnd` + gateway running against a bootstrap-applied institution (NYCN or an equivalent generic package). The endpoint returns standing, the Commons Shell renders it, the member can select an active scope, and the selected scope appears in subsequent receipts.
+5. **Repeatable operator runbook.** An operator can, from a clean machine, bring up the stack, apply a bootstrap package, authenticate as a member, call `/me/standing`, and see standing that matches the package definition. The runbook is tested, not theoretical.
+6. **Pilot institution validation.** A real institution (NYCN is the first candidate) runs a session where its members authenticate, check standing, act under an explicit active scope, and the resulting receipts match the charter. Pilot validation is the final rung.
+
+**`/me/standing` is not pilot-ready merely because integration tests pass.** The NYCN bootstrap track has already demonstrated that integration-passing code can still 404 live. Each rung is independently necessary. This design connects to the active `feat/live-nycn-bootstrap-validation` track without taking it over: that track owns rungs 4 through 6 for the bootstrap surface; `/me/standing` inherits rungs 1 through 3 first and then joins the live-validation track at rung 4.
+
+---
+
+## Acceptance Criteria
+
+This design is ready to implement when:
+
+- [x] Real repo primitives are mapped to response fields (identity, entity, membership, structure, role assignment, authority grant, mandate, delegation, governance domain, proposal pointer, action-item pointer).
+- [x] Unavailable pieces are marked `[future design]` with the required addition named (by-X reverse indexes, session-scope primitive, display-label resolution, alias-read API, accessibility-preference storage).
+- [x] JSON shape is concrete enough for an implementer to produce an OpenAPI schema and a handler skeleton without inventing fields.
+- [x] Explicit relationship to `/gov/me/scopes` and `/gov/me/work` is specified (they remain authoritative; `/me/standing` composes).
+- [x] NYCN bootstrap / live-validation reality is acknowledged and its lessons are absorbed (route drift warnings, canonical-id vs. alias discipline, live-proof rung in the readiness ladder).
+- [x] The active-scope problem is clearly specified with requirements and surface, without authorizing its implementation.
+- [x] Canonical ids vs. aliases vs. display labels vs. translated labels are distinguished at the contract level and mirrored in the response shape.
+- [x] Accessibility is first-class in the contract, not a downstream UI concern.
+- [x] Language and glossary model is first-class.
+- [x] Assisted participation is included with coercion-awareness and charter-deferral.
+- [x] Meaning Firewall and kernel/app separation are preserved (no domain semantics in the kernel; reporting, not defining).
+- [x] Commons Shell relationship is clear (standing is the data contract; cards and shells are downstream).
+- [x] No implementation is authorized beyond this design unless explicitly scoped in a subsequent doc or phase.
+
+---
+
+## Implementation Slices
+
+Suggested order for future phases. Each slice is a separately reviewable PR.
+
+1. **Design-only doc** (this PR).
+2. **Minimal `/me/standing`** returning identity + memberships + current `/gov/me/scopes` output, nothing more. Empty `mandates`, `grants`, `delegations`, `active_scope`, `accessibility`. A warning envelope exists but is empty.
+3. **Join role assignments / authority grants / mandates** with the necessary reverse indexes. Warnings surface expired and revoked items.
+4. **Active-scope selector primitive** — server-side session store for the caller's currently selected scope, with switch, audit trail, and inclusion in subsequent action receipts.
+5. **Standing-derived pending work references** — the `pending_work` field is populated by direct `manager.list_work_for_person` + urgency bucketing.
+6. **Action Card design doc** — a separate document specifying card generation, ranking, dismissal, expiry, cross-scope deduplication.
+7. **`GET /me/action-cards`** — implementation of the card generator, consuming `/me/standing`.
+8. **Language and glossary packs** — per-institution glossary packs, translated plain-language summaries, translator notes, `missing_translation` warnings.
+9. **Low-bandwidth / text renderer** — text-only fallback shape; a CLI summary (`icnctl me standing`, future); a screen-reader-first HTML rendering in pilot-ui.
+10. **Assisted participation receipt model** — typed `assisted_by` provenance, charter-backed assistance policy surfaced in `/me/standing`, anti-coercion protections per charter.
+11. **Validate against NYCN bootstrap-created institution state** — standing queries resolve correctly against entities, structures, aliases, and grants produced by `icnctl institution apply`.
+12. **Live-gateway validation and runbook** — the final rung before any pilot-facing release. The runbook is tested, not theoretical.
+
+Each slice has its own readiness ladder: design, unit, integration, live-local, runbook, pilot. No slice skips rungs.
+
+---
+
+## Gaps Identified `[future design]`
+
+Enumerated here so later docs and issues can pick them up without re-deriving.
+
+1. **Member-centered membership index.** `list_memberships_for_member(member_id)` or equivalent query.
+2. **Reverse indexes on authority primitives.** `list_grants_for_grantee(did)`, `list_mandates_for_executor(did)`, `list_delegations_for_delegate(did)`, `list_delegations_for_delegator(did)` — ideally maintained incrementally, not scanned.
+3. **Session-selected active-scope primitive.** Typed object, server-side selection, switchable, auditable, included in subsequent receipts. Successor to JWT `coop_id` approximation.
+4. **Display-label resolution.** A stable way to resolve entity / structure / role canonical ids to human display labels, with fallback when labels are missing.
+5. **Alias read API.** A first-class lookup from alias to canonical id and back, exposed to the standing endpoint (not only to bootstrap apply).
+6. **Accessibility preference storage.** Language preference, plain-language mode, low-bandwidth hint — stored per-member, surfaced in `/me/standing`, respected by Commons Shell.
+7. **Glossary packs and translation infrastructure.** Per-institution glossary packs, translator notes, `missing_translation` warnings, charter-backed term definitions.
+8. **Plain-language rendering of authority scopes.** Converting `authority_scope` strings and `TypedScope` values into plain-language sentences.
+9. **Assisted-participation provenance.** Typed `assisted_by` field on receipts where charter policy recognizes assistance; anti-coercion protections per charter.
+10. **Route-drift probe.** A first-class health probe for the routes `/me/standing` depends on, so warnings are grounded in active observation, not passive inference.
+11. **Representative / entity-vote primitive.** A `RepresentativeVote` / `EntityAction` wrapper that binds `(represented_entity, human_signer, authority_source, action_payload, scope, provenance, receipt)` — referenced by `THE_COMMONS.md §14` and required for clean representational semantics in federations.
+12. **Federation tally semantics.** When entity members vote in a federation, how are weights resolved, how do multiple representatives of the same entity interact, what happens on conflicting signatures. Not strictly a `/me/standing` concern, but necessary before representational action cards can be produced correctly.
+13. **Mandate expiry UX.** Member-facing view of a held mandate approaching expiry, a revoked grant, a superseded representational role.
+14. **Operator-scope primitive for member-facing standing.** Node operators are members of their communities. How does their operator scope appear in `/me/standing` alongside their member scope without leaking operator diagnostics into the member view.
+15. **Commons OS / kiosk-mode derivations.** How `/me/standing` serves a public-terminal short-session flow with safe defaults (no residue, explicit sign-out, assisted participation where applicable).
+
+---
+
+## References
+
+**Canonical anchors (consulted while drafting):**
+
+- `docs/architecture/THE_COMMONS.md` — sibling doctrine, direct parent of this design.
+- `docs/ARCHITECTURE.md` — ICN architecture reference.
+- `docs/architecture/KERNEL_APP_SEPARATION.md` — Meaning Firewall, PolicyOracle pattern.
+- `docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md` — authoritative routing between ICN platform and institution packages.
+- `docs/architecture/CELLS_AND_SCOPES.md` — scope primitives at the substrate layer.
+- `docs/architecture/IDENTITY_MEMBERSHIP_ARCHITECTURE.md` — identity and membership model.
+- `docs/design/ICN_VISUAL_SYSTEM.md` — visual doctrine, scope-aware membership, proof-backed coordination.
+- `docs/mobile/icn-mobile-ux-spec-v1.md` — current mobile UX spec.
+- `docs/archive/2026/plans-scratch/human-interface.md` — archived raw material for the Commons Shell concept.
+- `docs/reference/institution-package-bootstrap.md` — institution-package bootstrap reference.
+- `institutions/nycn/docs/bootstrap-runbook.md` — NYCN bootstrap runbook (live-validation track; this design references but does not modify it).
+- `docs/adr/ADR-0014-constitutional-object-model.md` — typed authority model (`AuthorityClass`, `AuthorityGrant`, `TypedScope`, `Mandate`).
+- `docs/STATE.md` — current project state.
+- `AGENTS.md` — agent coding instructions and app topology rule.
+
+**Code anchors (types and endpoints referenced by name):**
+
+- `icn/crates/icn-identity/src/lib.rs` — `Did`.
+- `icn/crates/icn-entity/src/entity.rs` — `EntityId`, `Individual`, `Cooperative(CooperativeProfile)`, `Community(CommunityProfile)`, `Federation(FederationProfile)`.
+- `icn/crates/icn-entity/src/membership.rs` — `Membership`, `MembershipRole`, `MembershipStatus`, `MembershipCapability`.
+- `icn/crates/icn-governance/src/structure.rs` — `Structure`, `RoleAssignment`.
+- `icn/crates/icn-governance/src/activity.rs` — `Activity`.
+- `icn/crates/icn-governance/src/program.rs` — `Program`, `Milestone`.
+- `icn/crates/icn-governance/src/parent.rs` — `InstitutionalParent`.
+- `icn/crates/icn-governance/src/domain.rs` — `GovernanceDomain`.
+- `icn/crates/icn-governance/src/proposal.rs` — `Proposal`, `ProposalPayload`.
+- `icn/crates/icn-governance/src/vote.rs` — `Vote`.
+- `icn/crates/icn-governance/src/delegation.rs` — `Delegation`.
+- `icn/crates/icn-governance/src/authority.rs` — `AuthorityGrant`.
+- `icn/crates/icn-governance/src/mandate.rs` — `Mandate`.
+- `icn/crates/icn-governance/src/meeting.rs` — `Meeting`.
+- `icn/crates/icn-governance/src/action_item.rs` — `ActionItem`, `ActionItemSpec`.
+- `icn/crates/icn-governance/src/charter.rs` — `Charter`.
+- `icn/crates/icn-governance/src/proof.rs` — governance receipts / proof.
+- `icn/crates/icn-kernel-api/src/invariants.rs` — frozen-core invariants.
+- `icn/crates/icn-kernel-api/src/bootstrap.rs` — `Capability`, `CapabilitySet`.
+- `icn/apps/governance/src/http/handlers.rs` — `GET /gov/me/scopes` (`get_my_scopes`), `GET /gov/me/work` (`get_my_work`).
+- `icn/bins/icnctl/src/institution_bootstrap.rs` — institution bootstrap apply; the `format!("/v1/gov/entities/{parent}/structures")` call site is the current live-validation 404 target and the proximate motivation for the canonical-id-vs-route-safe discipline in this doc.
+
+---
+
+*This doc is a design contract, not a plan. No endpoint is authorized for implementation on the basis of this document alone. Each implementation slice requires its own design doc, issue, and review. `[future design]` items require their own design docs before code lands.*

--- a/docs/architecture/THE_COMMONS.md
+++ b/docs/architecture/THE_COMMONS.md
@@ -1,0 +1,628 @@
+---
+Status: doctrine
+Canonical: yes
+Authority: architecture (complements KERNEL_APP_SEPARATION.md and INSTITUTION_PACKAGE_BOUNDARY.md)
+Last Reviewed: 2026-04-24
+Owner: Matt Faherty
+---
+
+# The Commons
+
+> **ICN is infrastructure for The Commons. ICN is not The Commons.**
+>
+> The Commons is what communities, cooperatives, and federations build and live inside. ICN is the substrate that makes The Commons executable, verifiable, portable, federated, and resilient against capture.
+
+This document is the canonical doctrine on what the Capital-C **Commons** means in the context of ICN. It sits above `ARCHITECTURE.md` (which describes the substrate) and above `KERNEL_APP_SEPARATION.md` / `INSTITUTION_PACKAGE_BOUNDARY.md` (which describe the meaning firewall and institution packaging). It is the north star those docs serve. It is consulted when deciding whether a proposed feature belongs in:
+
+- the **ICN kernel** (generic primitive mechanics),
+- an **ICN platform crate** (generic institutional shapes), or
+- an **institution package** (institution-specific vocabulary), or
+- a **Commons shell** (member-facing surface), or
+- nowhere in ICN at all.
+
+It does not specify any new kernel behavior. It names the thing ICN exists to enable so that future design choices do not drift.
+
+---
+
+## Purpose
+
+ICN exists to make The Commons operable.
+
+**The Commons** is the shared substrate of social, economic, institutional, cultural, and civic life that a community holds and tends in common. It is older than ICN by centuries — the shared grazing land, the mutual aid society, the credit union, the cooperative, the church, the school, the library, the neighborhood assembly, the volunteer fire brigade, the commons of knowledge, the commons of language. These are Commons institutions. They are not platforms. They are not products. They are not one-way services. They are organized forms of people choosing to hold something together.
+
+The Commons is plural and nested. A household is a Commons. A cooperative is a Commons. A federation of cooperatives is a Commons. A regional coordination network is a Commons. A global Commons of practice (a discipline, a language, a body of shared knowledge) is a Commons. Capital-C **The Commons** is the overarching word for all of them — the shared human substrate that modern platforms, corporations, and states have systematically enclosed, privatized, or neglected.
+
+ICN's purpose is **not** to be The Commons. The Commons is made of people, their relationships, their agreements, their labor, and their memory. ICN is digital public infrastructure that makes those forms:
+
+- **Executable** — agreements, decisions, and roles are enforceable by mechanism, not only by goodwill.
+- **Verifiable** — every state change leaves a receipt; every authority has a provenance.
+- **Portable** — members own their keys and their data; they can always exit and take what is theirs.
+- **Federated** — entities retain sovereignty; coordination happens between them, not above them.
+- **Resilient** — no central operator, no platform landlord, no single point of capture or removal.
+
+ICN is the *substrate* layer. The Commons is what **lives on it**.
+
+Everything ICN does — identity, membership, governance, ledger, gossip, receipts, federation, compute — exists to give Commons institutions real operational capacity without making them tenants of someone else's platform.
+
+---
+
+## Non-Goals
+
+To keep doctrine precise, The Commons is **not** any of the following. ICN must never be designed as if it were.
+
+- **Not a marketplace.** ICN has no matching engine, no price discovery, no auction layer. Communities may build marketplaces as apps, but the substrate never becomes an extractive intermediary. See `ARCHITECTURE.md §2`.
+- **Not a platform.** A platform owns its users; The Commons belongs to its members. ICN has no operator who can deplatform, throttle, monetize attention, or sell behavior data.
+- **Not a state.** The Commons is not a replacement for public institutions, and ICN has no monopoly on legitimate force, taxation, or judicial finality. Some Commons institutions may coexist with, petition, or contract with states; ICN does not pretend to be one.
+- **Not a church.** ICN encodes no ethical, religious, or spiritual doctrine. Different Commons institutions carry different traditions of meaning, care, and ritual; ICN must not bake any single tradition into kernel mechanics.
+- **Not a charity layer.** ICN is not a donation platform, nonprofit administration tool, or grant-making rail. Mutual aid is a first-class Commons pattern, but "charity" (one-way giving from rich to poor mediated by a platform) is not the model.
+- **Not a blockchain or token economy.** No global ledger, no native token, no speculative instruments, no tokenomic incentives. Mutual credit is bilateral; receipts are evidentiary, not tradable assets. See `docs/genesis.md` and `ARCHITECTURE.md §2`.
+- **Not one global admin hierarchy.** The Commons is plural. There is no top. There is no single federation that governs all federations. ICN must never contain a privileged operator, root key, or "platform" that other participants serve.
+- **Not one social doctrine in the kernel.** This is the hardest non-goal to hold. Different Commons traditions disagree — about consensus vs. majority, about one-member-one-vote vs. weighted stakes, about property, about membership criteria, about governance scope. Those disagreements belong in apps, CCL charters, and institution packages. The kernel must remain semantically blind.
+
+This last point ties The Commons doctrine directly to the **Meaning Firewall**. See `docs/architecture/KERNEL_APP_SEPARATION.md` (Invariants 1–5) and `docs/genesis.md` ("The Meaning Firewall Boundary"). The firewall is not only an architecture discipline — it is how ICN stays usable by Commons institutions with different values.
+
+> If ICN encoded one social ideology in its kernel, it would cease to be infrastructure and become a platform for that ideology. The kernel enforces *that agreements exist and are kept*. Apps decide *what agreements mean*.
+
+---
+
+## First Principles
+
+Before naming primitives, name needs. ICN's primitives exist because Commons institutions need them. Start from humans and institutions; derive the technical shape from there.
+
+### Human and Institutional Needs
+
+Any durable Commons institution has to make room for:
+
+1. **Belonging** — knowing who is in, on what terms, and under what obligations.
+2. **Agency** — a member can act, propose, object, vote, contribute, withdraw.
+3. **Care** — mutual aid, sickness, hardship, welcoming, conflict repair.
+4. **Memory** — decisions, agreements, promises, debts, and gratitude survive turnover.
+5. **Recognition** — labor, contribution, and expertise are visible and accountable.
+6. **Purpose** — the institution has stated reasons for existing and can be held to them.
+7. **Access** — participation does not require elite credentials, expensive hardware, or secret knowledge.
+8. **Voice** — members can speak, dissent, amend, and publicly record objections.
+9. **Repair** — wrongs can be named, addressed, and durably corrected.
+10. **Continuity** — the institution survives individuals; roles, records, and authority transfer cleanly.
+11. **Shared resources** — land, tools, funds, knowledge, infrastructure, labor pools.
+12. **Transparent rules** — everyone can see what is allowed, what is required, what is forbidden.
+13. **Bounded authority** — power is scoped, time-limited, revocable, and answerable to those it governs.
+14. **Conflict handling** — disputes have legitimate channels that do not rely on the patience of the wronged.
+15. **Knowledge transfer** — elders, coordinators, and stewards can pass on institutional know-how.
+16. **Economic coordination** — labor, credit, surplus, and obligation flow without external financialization.
+17. **Intergenerational memory** — institutions remember across decades, not just sprints.
+
+### Translation to ICN Requirements
+
+These needs translate into concrete substrate requirements:
+
+| Human/Institutional Need | ICN Requirement |
+|--------------------------|-----------------|
+| Belonging | Know who belongs to what entity, in what role, with what capabilities. |
+| Agency | A member can act under cryptographic identity without asking a central server. |
+| Care | Mutual aid, dispute, and care flows are first-class, not grafted onto finance. |
+| Memory | Every state transition emits an immutable receipt (`docs/genesis.md` invariant 10). |
+| Recognition | Contributions (labor, decisions, stewardship) are attributable and durable. |
+| Purpose | Each entity has a charter; charters are the constitutional layer (CCL). |
+| Access | Works on ordinary phones, browsers, cheap Linux boxes, and public terminals. |
+| Voice | Proposals, votes, discussion, amendment, and appeal are primitives. |
+| Repair | Disputes, amendments, and appeals are typed — not reduced to "file a ticket". |
+| Continuity | Roles, mandates, and authority grants have provenance, scope, and expiry. |
+| Shared resources | Treasury, mutual credit, commons pools are entity-held, not platform-held. |
+| Transparent rules | Constraints are published and enforced mechanically by the kernel. |
+| Bounded authority | Capabilities are typed, scoped, delegable, revocable (see `AuthorityGrant`, ADR-0014). |
+| Conflict handling | Appeal, amendment, veto, and force-close are proposal variants. |
+| Knowledge transfer | Institutional documents, meeting minutes, and program cycles persist. |
+| Economic coordination | Mutual credit, double-entry ledger, zero-sum invariant. |
+| Intergenerational memory | Signed receipts, content-addressed history, portable by member export. |
+
+**None of this requires ICN to hold opinions about what a cooperative, community, or federation *should* be.** ICN requires only that authority, membership, decisions, resources, and receipts exist as typed, verifiable, portable objects.
+
+---
+
+## ICN Primitive Mapping
+
+This section maps Commons concepts to the real crates, modules, and types in the ICN repo as of 2026-04-24. Types that exist are cited with their actual paths. Types that are planned or spec-only are explicitly marked `[future design]`.
+
+| Commons Concept | ICN Primitive | Status | Location |
+|-----------------|---------------|--------|----------|
+| Person / human participant | `Did` (newtype around `String`, Ed25519-backed) | ✅ shipped | `icn/crates/icn-identity/src/lib.rs` |
+| Cryptographic identity bundle | `IdentityBundle` (Ed25519 + X25519, age-encrypted keystore) | ✅ shipped | `icn/crates/icn-identity/src/bundle.rs` |
+| Unified entity handle | `EntityId` (format `entity:icn:<type>:<slug>`) | ✅ shipped | `icn/crates/icn-entity/src/entity.rs` |
+| Sovereign entity kinds | `Individual`, `Cooperative(CooperativeProfile)`, `Community(CommunityProfile)`, `Federation(FederationProfile)` | ✅ shipped | `icn/crates/icn-entity/src/entity.rs` |
+| Membership | `Membership { member_id, parent_id, role, status, shares, capabilities }` | ✅ shipped | `icn/crates/icn-entity/src/membership.rs` |
+| Membership role | `MembershipRole` enum (`Founder`, `Member`, `Worker`, `Consumer`, `Producer`, `BoardMember`, `Officer{title}`, `FederatedMember`, `AssociateMember`, `ObserverMember`, `ProvisionalMember`, `Custom{name}`) | ✅ shipped | `icn/crates/icn-entity/src/membership.rs` |
+| Per-membership capability grants | `MembershipCapability` enum (`Vote`, `Propose`, `TreasuryAccess`, `Invite`, `ManageSubEntities`, `Sign`, `Configure`) | ✅ shipped | `icn/crates/icn-entity/src/membership.rs` |
+| Non-sovereign internal unit | `Structure { kind: Committee | WorkingGroup | Team | Office }` | ✅ shipped | `icn/crates/icn-governance/src/structure.rs` |
+| Role inside a structure | `RoleAssignment { structure_id, person_did, role, authority_scope: Vec<String>, valid_from, valid_until }` | ✅ shipped | `icn/crates/icn-governance/src/structure.rs` |
+| Time-bounded work | `Activity { kind: Event | Program | Project | Initiative }` | ✅ shipped | `icn/crates/icn-governance/src/activity.rs` |
+| Program / cycle container | `Program { ... }`, `Milestone { ... }` | ✅ shipped (PR #1548) | `icn/crates/icn-governance/src/program.rs` |
+| Polymorphic parent attachment for operational objects | `InstitutionalParent` enum | ✅ shipped | `icn/crates/icn-governance/src/parent.rs` |
+| Governance domain (scope of proposals/votes) | `GovernanceDomain` | ✅ shipped | `icn/crates/icn-governance/src/domain.rs` |
+| Proposal | `Proposal`, `ProposalPayload` (`Text`, `Budget`, `Allocation`, `Membership`, `ConfigChange`, `FreezeMember`, `VetoProposal`, `ForceCloseProposal`) | ✅ shipped | `icn/crates/icn-governance/src/proposal.rs` |
+| Vote | `Vote` | ✅ shipped | `icn/crates/icn-governance/src/vote.rs` |
+| Delegation (individual → individual) | `Delegation` (1717 LOC; domain-scoped, expiring, revocable) | ✅ shipped | `icn/crates/icn-governance/src/delegation.rs` |
+| Typed authority grant (entity → grantee, scoped, time-bounded, revocable) | `AuthorityGrant { class, grantor, grantee, scope: TypedScope, valid_from, valid_until, revoked_at }` | ✅ type landed; typed-scope enforcement is additive migration per ADR-0014 | `icn/crates/icn-governance/src/authority.rs` |
+| Mandate (execution obligation linked to a decision) | `Mandate { id, decision: DecisionProvenance, payload_hash, grants, executor, deadline, status, issued_at }` | ✅ shipped | `icn/crates/icn-governance/src/mandate.rs` |
+| Meeting | `Meeting` (schedule, agenda, attendance, minutes) | ✅ shipped (PR #1543) | `icn/crates/icn-governance/src/meeting.rs` |
+| Action item | `ActionItem`, `ActionItemSpec` (decision-to-action bridge, provenance-linked to proposals) | ✅ shipped | `icn/crates/icn-governance/src/action_item.rs` |
+| Charter (constitutional doc for an entity) | `Charter`, `CharterStore` | ✅ shipped | `icn/crates/icn-governance/src/charter.rs`, `charter_store.rs` |
+| Cooperative contract language | CCL — AST, interpreter, fuel-metered | ✅ shipped | `icn/crates/icn-ccl/` |
+| Governance receipts / proof | `icn-governance::proof` | ✅ shipped | `icn/crates/icn-governance/src/proof.rs` |
+| Treasury + mutual credit + receipts | Double-entry journal, zero-sum invariant, `LedgerPolicyOracle` | ✅ shipped | `icn/crates/icn-ledger/` |
+| Trust graph + trust-gated rate limits | `TrustGraph`, `TrustPolicyOracle` | ✅ shipped | `icn/crates/icn-trust/`, `icn/apps/governance/` (oracle) |
+| PolicyOracle (meaning firewall) | `PolicyOracle` trait, `ConstraintSet`, `PolicyDecision` | ✅ shipped | `icn/crates/icn-kernel-api/` |
+| Capability token / bearer | `Capability`, `CapabilitySet` (genesis bootstrap) | ✅ shipped | `icn/crates/icn-kernel-api/src/bootstrap.rs` |
+| Frozen-core invariants | 10 invariants defined as `InvariantId` | ✅ shipped | `icn/crates/icn-kernel-api/src/invariants.rs` |
+| Federation membership list | `FederationProfile.member_entities` | ✅ shipped | `icn/crates/icn-entity/src/entity.rs` |
+| Naming / DID resolution | `icn-naming` | ✅ shipped | `icn/crates/icn-naming/` |
+| Scope-aware identity across devices | `MultiDevice`, `Capability` enum | ✅ shipped | `icn/crates/icn-identity/src/multi_device.rs` |
+| Node / daemon | `icnd` | ✅ shipped | `icn/bins/icnd/` |
+| Gateway (REST + WebSocket, JWT, per-DID rate limit) | `icn-gateway`, pilot-ui surfaces | ✅ shipped | `icn/crates/icn-gateway/`, `web/pilot-ui/` |
+| Institution package (e.g., NYCN) | in-monorepo staging at `institutions/nycn/`; target: external `nycn-icn` repo | ⚠️ boundary doc pinned; package thin | `institutions/nycn/`, `docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md` |
+| "My scopes" surface | `GET /gov/me/scopes` (role assignments for caller DID) | ✅ shipped (PR #1552) | `icn/apps/governance/src/http/handlers.rs` |
+| "My work" surface | `GET /gov/me/work` (assigned action items for caller DID) | ✅ shipped (PR #1552) | `icn/apps/governance/src/http/handlers.rs` |
+| **Commons Shell** (unified member-facing doorway across entities) | concept; partial predecessors in `web/pilot-ui/` and `sdk/react-native/examples/CoopWallet/` | `[future design]` | — |
+| `GET /me/standing` (roles + memberships + mandates + active scopes) | does not exist as a single query | `[future design]` | — |
+| `GET /me/action-cards` (unified call-to-action surface) | does not exist | `[future design]` | — |
+| `RepresentativeVote` / `EntityAction` (action whose subject is the represented entity, not the signer) | `AuthorityClass::Representation` exists in ADR-0014; no dedicated vote-wrapper type yet | `[future design]` | — |
+| Active-scope / session-selected-scope model (every action bound to an explicit chosen scope) | scope is currently inferred from JWT `coop_id` + scopes; no explicit active-scope primitive | `[future design]` | — |
+| Commons OS / node appliance / kiosk mode | aspirational; see §11 | `[future design]` | — |
+
+Where this doc says `[future design]`, it means: *the concept is named here, it has not been built, and this doc does not authorize its implementation.* A dedicated design doc and issue are required before code lands.
+
+---
+
+## Entity and Membership Model
+
+A member's DID is the cryptographic root of their participation. It is **not** a login, **not** a wallet address in the crypto sense, and **not** a platform account. It is a key pair the member holds, under their control, from which all participation derives.
+
+### Layers
+
+1. **Individual DID → Individual Entity.** Every person in the system starts as a `did:icn:<base58-ed25519-public-key>`. `EntityId::from_did(did)` produces the matching individual entity (format `entity:icn:individual:<identifier>`). There is no "user account" between the key pair and the entity.
+
+2. **Membership** is the typed link between a member entity and a parent entity. Individuals hold membership in communities and cooperatives. Entities (cooperatives, communities, other federations) hold membership in federations. Membership is recursive: a cooperative's members can themselves be cooperatives.
+
+3. **Membership confers standing.** A `Membership` record carries:
+   - `role: MembershipRole` — what kind of member (`Founder`, `Member`, `Worker`, `BoardMember`, `Officer{title}`, `FederatedMember`, `AssociateMember`, `ObserverMember`, `ProvisionalMember`, `Custom{name}`, …).
+   - `status: MembershipStatus` — whether the role is currently active.
+   - `shares: u64` — voting weight per charter (0 means observer).
+   - `capabilities: Vec<MembershipCapability>` — default grants (`Vote`, `Propose`, `TreasuryAccess`, `Invite`, `ManageSubEntities`, `Sign`, `Configure`).
+
+4. **RoleAssignment** layers further capability onto structures. A member of `nycn-organizers` may also hold a `RoleAssignment` in the `nycn-finance` structure with `authority_scope` strings like `"approve-budget-<=5000"`. The role inside a structure is bounded by the structure's delegated authority.
+
+5. **AuthorityGrant / Mandate** (ADR-0014) is the typed, scoped, revocable layer of authority above capability strings. A `Mandate` binds an executor to a specific decision's obligation. An `AuthorityGrant` binds a grantee to a typed scope, time-bounded, with explicit grantor provenance.
+
+### Illustrative Flow
+
+```
+did:icn:alice
+  → Individual Entity               (entity:icn:individual:alice-pubkey)
+  → Membership in greenstar-coop    (role: Worker, capabilities: [Vote, Propose])
+  → Membership in brooklyn-coop-net (role: Member via greenstar delegate)
+  → RoleAssignment in               (structure: nycn-finance,
+    nycn-finance committee             role: "coordinator",
+                                       authority_scope: ["approve-budget-<=5000"])
+  → Mandate to represent            (class: Representation,
+    greenstar in NYCN federation       grantor: greenstar,
+                                       grantee: did:icn:alice,
+                                       scope: nycn-federation-gov proposals)
+```
+
+**This illustrative layering is not a single primitive today.** Each layer exists in the repo; they compose. Alice's action surface at any given moment is the *union* of:
+
+- capabilities from her direct memberships,
+- capabilities from her role assignments in structures,
+- representation mandates granted to her by other entities,
+- operator-level rights on any node she runs.
+
+What does **not** yet exist as a single API is a query that returns "everything Alice is standing in right now". That is the `[future design]` `GET /me/standing` surface (see §9).
+
+> **Illustrative only.** The flow above composes real types but is pseudocode. Do not treat it as a single struct or a committed API contract.
+
+---
+
+## Communities, Cooperatives, and Federations
+
+The three non-individual sovereign entity kinds each embody a different Commons function. They share a substrate but not a purpose.
+
+### Community
+
+A **community** (`Entity::Community(CommunityProfile)`) is a civic/social Commons. Its primary function is collective life: care, ritual, learning, mutual aid, local memory, public life, conflict repair, welcoming. Communities may have treasury and governance, but their economic function is secondary to their social one. A neighborhood assembly, a care circle, a faith community, a study group, a maker-space circle, a regional potluck network — these are communities.
+
+Communities tend to operate at human scale, with low formality relative to their depth. Their membership criteria are often affiliative rather than contractual.
+
+### Cooperative
+
+A **cooperative** (`Entity::Cooperative(CooperativeProfile)`) is an economic Commons. Its primary function is production, labor, services, treasury, mutual credit, and surplus allocation. A worker co-op, a housing co-op, a consumer co-op, a multi-stakeholder co-op, a producer co-op — these are cooperatives.
+
+Cooperatives carry more formal governance than most communities because they coordinate around shared economic risk. Their membership criteria are contractual: a member accepts the charter and the corresponding economic obligations.
+
+Communities and cooperatives are **not hierarchical** relative to each other. A community does not "become" a cooperative when it matures; a cooperative is not a "more serious" community. They are different kinds of Commons optimized for different kinds of holding-in-common.
+
+### Federation
+
+A **federation** (`Entity::Federation(FederationProfile)`) is a coordination layer between sovereign entities. Federations do not govern their members' internal affairs. Federations coordinate shared initiatives, maintain shared infrastructure, admit new member entities, and express joint positions. Members join federations voluntarily and retain their sovereignty.
+
+> **Crucial rule**: a federation must not govern the internals of a member entity unless the member entity's own charter explicitly grants the federation scoped authority over that internal matter. The default is subsidiarity.
+
+NYCN is a federation (see `docs/strategy/NYCN-Repo-Architecture-Spec.md`). GreenStar Cooperative is one of its sovereign members. NYCN does not decide how GreenStar organizes labor; GreenStar decides how it participates in NYCN.
+
+### Subsidiarity as Doctrine
+
+> **Decisions happen at the smallest competent scope.**
+
+A decision that affects only a working group should be made by the working group, not escalated to the committee. A decision that affects only a cooperative should be made by the cooperative, not escalated to the federation. Authority moves *upward* only when the smaller scope is structurally incompetent to decide — for example, admitting a new federation member, or amending a shared charter.
+
+Subsidiarity is not a runtime check. It is a design discipline for charters and for CCL rules. ICN enforces the charter; the charter decides where each class of decision lives.
+
+---
+
+## Delegation vs Representation
+
+These two concepts are often conflated and are *not* the same. Keeping them separate matters for every feature that touches voting, authority, and receipts.
+
+### Delegation (individual → individual)
+
+**Delegation** is an individual DID handing their own voting power to another individual DID, inside a governance domain. The represented party is still *themselves* — they have chosen to let someone else cast their vote. Delegation is the repo's existing `icn-governance::delegation` primitive (1717 LOC, mature).
+
+Current delegation semantics (as shipped — see `icn/crates/icn-governance/src/delegation.rs`):
+
+- Delegation is **domain-scoped** — a delegation in one governance domain does not apply to another.
+- Delegation can be **blanket, domain-scoped, proposal-scoped, or topic-scoped**, per the delegation type.
+- Delegation is **revocable** by the delegator at any time.
+- Delegation carries an **expiry**.
+- Delegation cycles and self-delegation are rejected by the validation path.
+- **Direct vote overrides delegated vote**: if Alice delegates to Bob on proposal P, and then Alice casts her own vote on P, Alice's direct vote wins.
+
+Delegation does **not** change who is voting's *subject*. Alice has not become Bob. Bob is casting Alice's vote as her delegate. The receipt shows: voter = Alice, signed by = Bob (as delegate), authority = delegation record `D`.
+
+### Representation (entity → human)
+
+**Representation** is categorically different. A cooperative, a community, or a federation is an entity. Entities do not have fingers. They cannot literally sign. When a federation casts a vote, some human has to actually press the button with their key. That human is a **representative**, not a delegate.
+
+The human's signature is the cryptographic vehicle. The entity is the subject of the action. The receipt must reflect both.
+
+Authority for representation comes from:
+
+- a `RoleAssignment` with `authority_scope` strings (the shipped capability-string surface),
+- an `AuthorityGrant { class: AuthorityClass::Representation, grantor: <entity>, grantee: <person DID>, scope: TypedScope, … }` (the ADR-0014 typed layer),
+- a specific `Mandate` tied to a named decision (the execution-obligation layer), or
+- a charter clause that directly appoints a role holder.
+
+Every representative action must be **receipt-backed**: the receipt records the represented entity, the human signer, the authority source, the decision or action, the scope / domain, the timestamp, and the resulting state change. Without this provenance, entity-level authority is indistinguishable from personal preference.
+
+> A `RepresentativeVote` / `EntityAction` type — a single object that binds *(represented entity, human signer, authority source, action payload, scope, provenance, resulting receipt)* — does not yet exist as a first-class primitive. Today, the relationship is reconstructed from a combination of JWT `coop_id` scope, `RoleAssignment`, and the proposal/vote record. Formalizing this is `[future design]`. See §14.
+
+### Worked example: GreenStar votes in NYCN
+
+> GreenStar Cooperative is a member of NYCN Federation. Alice DID is authorized by GreenStar to cast GreenStar's NYCN federation vote. Alice is not voting as Alice. Alice is voting as GreenStar.
+>
+> The receipt must show:
+>
+> - **represented entity**: `entity:icn:cooperative:greenstar`
+> - **human signer**: `did:icn:alice-pubkey`
+> - **authority source**: `AuthorityGrant{ id, class: Representation, grantor: greenstar, grantee: alice, scope: nycn-federation-gov, valid_from, valid_until }` — plus optionally a specific `Mandate` if the vote was decided in a GreenStar internal proposal
+> - **action**: `CastVote { proposal: <id>, choice: <…> }`
+> - **scope / domain**: `nycn-federation-gov`
+> - **timestamp**: issued at
+> - **resulting state change**: vote tallied; `Vote` record with `voter: greenstar`, `signed_by: alice`, `authority: <grant_id>`
+>
+> If Alice ceases to be a GreenStar delegate, a *future* Alice-signed vote on NYCN proposals must no longer tally for GreenStar. The `valid_until` and `revoked_at` fields on `AuthorityGrant` are the enforcement surface.
+
+The doctrine carried by this example: **a person can be authorized to act for an entity, but the identity of the acting subject is the entity**. UX must reflect that. Receipts must reflect that. Tally semantics must reflect that.
+
+---
+
+## The Commons Shell
+
+A **Commons Shell** is the member-facing doorway into The Commons. It is not a dashboard. It is not a wallet. It is not an admin panel. It is not a social feed. It is the piece of software a person opens to participate in the institutions they belong to.
+
+Today, ICN's member-facing surfaces are split across:
+
+- `web/pilot-ui/` (browser PWA served by the gateway),
+- `sdk/react-native/examples/CoopWallet/` (mobile wallet, 21 screens),
+- `icnctl` CLI (power user + operator),
+- `icn-console` (TUI),
+- a variety of SDIS / steward / anchor pages.
+
+None of these are a full Commons Shell today. The pilot UI is cooperative-scoped and auth-centric. CoopWallet leans toward payment/identity primitives. `icnctl` assumes operator fluency. A Commons Shell is the member-facing thing these could converge toward.
+
+The Commons Shell answers:
+
+- **Where do I belong?** Which entities list me as a member? Which structures have me assigned? Which federations list entities I represent?
+- **What scope am I acting in right now?** Self? Member of community X? Officer of cooperative Y? Representative of federation Z? Operator of node N?
+- **What can I do here?** Given my active scope, what capabilities do I hold, and therefore what actions are available?
+- **What needs my attention?** Open votes, pending action items, overdue obligations, membership requests, expiring mandates, meeting attendance, budget approvals.
+- **What decisions are open?** Proposals under deliberation in domains I vote in.
+- **What work is assigned or available?** Action items assigned to me; action items unassigned but in scopes I can claim.
+- **What help is needed, requested, or offered?** Care requests, mutual aid, coordination needs.
+- **What resources are shared?** Treasury positions, commons pools, shared tools.
+- **What meetings, events, or rituals are coming?** Calendar view across my scopes.
+- **What knowledge is being passed on?** Institutional documents, meeting minutes, program milestone handoffs.
+- **What was decided?** History of accepted proposals, with receipts, in scopes I belong to.
+- **What receipts prove it?** Direct receipt viewing for any decision, action, settlement, or mandate.
+- **What mandates do I hold?** Active representation authority: which entities, which domains, which expirations.
+- **What can I verify?** Steward proofs, trust edges, identity proofs for others.
+
+### Design Obligations
+
+A Commons Shell must respect:
+
+- **Accessibility is not optional.** Screen reader, high-contrast, low-literacy, non-English — these are first-class. See the Visual System (`docs/design/ICN_VISUAL_SYSTEM.md`).
+- **Low-end device reach.** A Commons Shell must run on inexpensive phones, shared devices, kiosk terminals, library workstations, and older laptops. If it requires a flagship device, it is not a Commons tool.
+- **Offline-first member flows.** Vote queues, payment queues, trust attestations, and receipt views work without connectivity and sync on reconnect. The CoopWallet offline queue is the existing pattern.
+- **Public-terminal / library / community-center access.** Short sessions, no persistent state on the device beyond what the member explicitly saves, explicit sign-out, no silent lingering.
+- **Scope-aware UX.** Every screen knows which scope the member is currently acting in. Scope-switching is a first-class gesture, not a hidden flag. Mis-scoping is the most common form of institutional confusion; the UI must make it visible.
+- **Receipt visibility.** A member can ask "why did this happen?" on any entry and reach the signed provenance in at most a few taps. Receipts are not admin-only.
+- **Action cards as the primary surface.** Home is a list of things that need this person's attention, ranked by urgency and scope (see §10).
+
+> A capitalist app asks how to keep you scrolling. A Commons shell asks how to help you participate in shared life.
+
+The mobile spec (`docs/mobile/icn-mobile-ux-spec-v1.md`) and the archived human-interface notes (`docs/archive/2026/plans-scratch/human-interface.md`) contain raw material for promoting this concept into current design docs. That promotion is `[future design]`.
+
+---
+
+## Standing and Active Scope
+
+Two `[future design]` surfaces are named here because they shape every member flow that follows.
+
+### `GET /me/standing` `[future design]`
+
+A single authenticated query that returns a member's full participatory position across ICN. Suggested shape (non-binding):
+
+```text
+GET /me/standing
+Authorization: Bearer <JWT>
+
+→ {
+    self: {
+      did: "did:icn:alice-pubkey",
+      individual_entity_id: "entity:icn:individual:alice-pubkey",
+      devices: [...],
+    },
+    memberships: [
+      { entity_id: "entity:icn:cooperative:greenstar", role, status, shares, capabilities, joined_at },
+      ...
+    ],
+    role_assignments: [
+      { structure_id, parent_entity_id, role, authority_scope: [...], valid_from, valid_until },
+      ...
+    ],
+    mandates: [
+      { mandate_id, represented_entity, decision: <provenance>, grants: [...], deadline, status },
+      ...
+    ],
+    authority_grants_held: [
+      { grant_id, class: Representation | Execution | Attestation, grantor, scope, valid_until, revoked_at },
+      ...
+    ],
+    representable_entities: [
+      { entity_id, via_grant: <grant_id>, domain_scopes: [...] },
+      ...
+    ],
+    available_active_scopes: [
+      { kind: "self", label: "Acting as self" },
+      { kind: "member", entity_id: "...", label: "Member of GreenStar" },
+      { kind: "role",   structure_id: "...", label: "Finance Coordinator, NYCN" },
+      { kind: "representative", represented_entity: "...", via_grant: "...", label: "Representing GreenStar in NYCN" },
+      { kind: "operator", node_id: "...", label: "Node operator: home-01" },
+    ],
+    capabilities_by_scope: { <scope_key>: [capability, ...], ... },
+    pending_expirations: [
+      { kind: "role_assignment" | "mandate" | "grant", id, expires_at },
+      ...
+    ],
+    pending_revocations: [ ... ],
+  }
+```
+
+This does **not** authorize any implementation. It names the target so that when the pieces exist (`/gov/me/scopes` already does; memberships and authority grants can be joined) the unified query has a shape to aim at.
+
+### Active Scope
+
+Every action a member takes should be bound to an **explicitly selected active scope**. Scope options include:
+
+- **Self** — `scope: { kind: "self" }`. Actions are the member's own (personal trust attestations, their own ledger position, their own key operations).
+- **Member** — `scope: { kind: "member", entity_id: <id> }`. Actions taken as an ordinary member of an entity (vote in a community proposal, propose in a cooperative, log hours).
+- **Role** — `scope: { kind: "role", structure_id: <id> }`. Actions taken as a role-holder inside a structure (officer, coordinator, committee member).
+- **Representative** — `scope: { kind: "representative", represented_entity: <id>, via_grant: <grant_id> }`. Actions whose subject is a represented entity, not the signer.
+- **Operator** — `scope: { kind: "operator", node_id: <id> }`. Actions taken as a node operator (maintenance, federation peering, trust seeding).
+
+**Hidden authority is capture.** If a member can take an action and there is no way to answer "under what scope?", the Commons Shell has failed and the receipt has failed. Every receipt must name the active scope used. Every authority check must evaluate capability against the *selected* scope, not the union of all scopes the member could have chosen.
+
+An explicit active-scope / session-selected-scope primitive does not yet exist in the codebase. Today the approximation lives in JWT `coop_id` + `scopes` claims and is not uniformly applied across the ledger, governance, and trust surfaces. Formalizing this is `[future design]` (see §14).
+
+---
+
+## Action Cards
+
+An **action card** is a generated call-to-action item surfaced in the Commons Shell. It is not a notification, not a feed post, not a marketing message. It is a scoped, typed, dismissible prompt that says: *"This is a thing in the Commons that needs you."*
+
+`GET /me/action-cards` `[future design]` — a unified query that returns the ranked list of action cards for the authenticated member across all their scopes.
+
+### Sources
+
+An action card may be generated from:
+
+- **Open proposals** in a governance domain where the member has `Vote` capability.
+- **Pending votes** (the member has not yet cast on a proposal they can vote on).
+- **Assigned action items** (`ActionItem` records where `assignee == caller`, as already surfaced by `/gov/me/work`).
+- **Upcoming meetings** the member is invited to.
+- **Role or mandate expirations** (a `RoleAssignment.valid_until` or `AuthorityGrant.valid_until` approaching).
+- **Membership requests** where the member has `Invite` or `ManageSubEntities` capability in the inviting entity.
+- **Budget approvals** where the member is in the approval chain.
+- **Care requests** (mutual aid, dispute support, accessibility help).
+- **Program milestone prompts** (a program cycle entering a new phase, a check the member is accountable for).
+- **Receipt verification requests** (another member has asked the member to verify an identity proof, a trust attestation, a steward enrollment).
+- **Node maintenance items** (if the member is also a node operator).
+- **Appeals or amendments** the member is qualified to respond to.
+
+### Doctrine
+
+> A capitalist app asks how to keep you scrolling. A Commons shell asks how to help you participate in shared life.
+
+Action cards are designed for closure, not engagement. A card that stays open forever is a failure. A card that gets dismissed, acted on, delegated, or timed out and archived is working.
+
+Action cards are **scoped**. Each card is generated in the context of one of the member's active scopes; rendering must show which scope the card belongs to so the member never acts in the wrong hat.
+
+A card generation model — predicates, ranking, dismissal, expiry, cross-scope deduplication — does not exist in the codebase today. The existing `/gov/me/work` and the notification digest work (PR #1547) are partial predecessors.
+
+---
+
+## Physical Commons and Nodes
+
+ICN runs on existing, ordinary technology first. The first operational target is never a custom appliance. The first operational target is whatever the community already has.
+
+### Current Reach
+
+- Modest **phones** (iOS + Android) via `sdk/react-native/examples/CoopWallet/`.
+- **Browsers** (desktop + mobile) via `web/pilot-ui/` served by the gateway.
+- Ordinary **Linux boxes** (home servers, office workstations) running `icnd`.
+- **Raspberry Pi / single-board computers** for community nodes.
+- **Library and community-center terminals** (browser-based access, no install).
+- **Homelab servers** running containerized `icnd` under K3s or Docker Compose (see `deploy/README.md`, `docs/HOMELAB_DEPLOYMENT.md`).
+- **Community nodes** run by volunteer operators — the current live K3s cluster is the canonical example.
+- **Cheap laptops** for organizers and stewards.
+- **Event kiosks** (forthcoming, via the Commons Shell concept).
+- **Offline-first local networks** — mDNS discovery and gossip already work on isolated LANs.
+
+**ICN turns existing hardware into Commons infrastructure.** The binary target is unremarkable hardware in the hands of cooperatives, communities, and federations.
+
+### Commons OS `[future design]`
+
+A longer-horizon concept: a **Commons OS** distribution — a node appliance, kiosk mode, mobile shell, desktop environment, or app runtime tuned specifically for Commons participation. Possible shapes include:
+
+- An `icnd`-first Linux image for community nodes (plug in, enroll, peer).
+- A kiosk-mode browser build of the Commons Shell for libraries and community centers.
+- A mobile-first shell distribution where the phone itself is the primary member device.
+- A local-first archive and content-addressed shared-memory layer across community nodes.
+- A distributed storage/compute pool across homelab operators.
+- A package manager for Commons apps and institution packages (CCL templates, oracles, UI overlays).
+
+None of these are on any roadmap as of 2026-04-24. Naming them here is a hedge against feature creep into the current ICN kernel: Commons OS ambitions live **outside** the kernel/app boundary, not inside it.
+
+> **First, ICN turns existing hardware into Commons infrastructure. Only later — if ever — does a dedicated Commons OS make sense.**
+
+---
+
+## Institution Transformation Examples
+
+The Commons transforms inherited institutions by decomposing them into human functions and rebuilding from primitives. The list below is illustrative, not exhaustive. Each transformation names the existing ICN primitives that would compose it. None of these is an endorsement of a specific institution design; each is a *sketch* of how the primitives carry the weight.
+
+Use the composition shorthand: **E** = Entity, **S** = Structure, **A** = Activity, **P** = Program, **M** = Meeting, **Pr** = Proposal, **R** = Role / RoleAssignment, **C** = Charter, **L** = Ledger / Treasury, **Rc** = Receipt / Provenance, **F** = Federation relationship, **N** = Node / operator layer.
+
+| Inherited institution | Commons transformation | Primitive composition |
+|-----------------------|------------------------|------------------------|
+| **Church** | Ritual / Care / Meaning Commons — a community holds a tradition of ritual, care, and meaning without a corporate hierarchy above it. Elders are role-holders, not owners. | E (community) + C (charter of tradition) + S (care circle, liturgy working group) + A (annual cycle of observances) + M (gatherings) + R (elder, steward, care coordinator) + Rc (minutes, commitments). |
+| **Corporation** | Production Commons — a worker-owned cooperative holds productive capacity directly, with federated coordination across similar cooperatives. | E (cooperative) + C (charter) + S (committees: finance, operations, stewarding) + A (annual plan) + P (campaigns, product cycles) + Pr (budget, hiring, strategy proposals) + L (treasury, mutual credit) + F (industry or regional federation) + Rc (decision & settlement receipts). |
+| **Bank** | Mutual Credit Commons — credit is bilateral and cooperative, not extracted. No custodial float. No external settlement rail. | E (cooperative or federation) + C (credit charter) + L (double-entry ledger, zero-sum invariant) + Pr (credit-policy changes, credit-ceiling adjustments) + Rc (every settlement). Regulatory framing: units, positions, settlement — never currency, balance, payment. |
+| **School / University** | Learning / Knowledge Commons — curriculum, stewardship of knowledge, peer recognition, intergenerational memory held by a community rather than sold by a platform. | E (community or federation of learning circles) + C (learning charter) + S (subject circles) + A (cohorts) + P (multi-year programs with milestones) + M (seminars, defenses) + R (teacher, steward, peer) + Rc (recognition receipts, credential provenance). |
+| **Social media** | Communication Commons — topic-scoped federated gossip, no engagement engine, no algorithmic feed, moderation is local and accountable. | ICN gossip primitives + E (community) + C (community norms charter) + S (moderation circle) + Pr (norms amendments) + Rc (moderation receipts). The kernel already provides the gossip; what is missing is member-facing shells. |
+| **Insurance** | Risk Commons — mutual insurance pool, not investor-owned. Claims are governed by members. | E (cooperative) + C (pool charter) + L (pool treasury + contribution flow) + Pr (claim decisions, pool parameter changes) + Rc (claim settlement receipts). |
+| **Hospital / clinic network** | Care Commons — patient-owned or practitioner-owned cooperative care network, federated regionally. | E (cooperative of clinics) + S (specialty circles, ethics committee) + A (service cycles) + R (practitioner, patient-representative, steward) + L (solidarity fund, contribution flow) + F (regional care federation) + Rc (care provenance; never medical-record oversharing). |
+| **Local government functions** | Civic Commons — participatory budgeting, neighborhood assembly, dispute resolution at the smallest competent scope. | E (community) + C (civic charter) + Pr (Allocation for participatory budgeting, Text for resolutions) + M (assembly meetings) + R (rotating coordinator roles) + Rc (decisions published and verifiable). |
+| **Supply chain** | Federated Production / Distribution Commons — producer, processor, distributor cooperatives federated with published terms and mutual credit clearing. | Multiple E (each coop) + F (federation) + L (inter-coop mutual credit, settlement) + Pr (shared-initiative proposals) + Rc (cross-coop settlement receipts). |
+| **Public library** | Physical Commons node — the library is itself a community node: a place with terminals, stewards, shared knowledge, access for members who have no other point of entry. | E (community) + N (library node running `icnd`) + R (librarian-steward) + Commons Shell on local terminals + Rc (lending, access, membership receipts). |
+
+These transformations are not "apps" to be built by the ICN core team. They are the *use-cases* Commons institutions — with their own apps, charters, and institution packages — build on top of ICN. The core team's obligation is to keep the substrate general enough that none of these requires bespoke kernel support.
+
+---
+
+## Boundary Rules
+
+The Commons doctrine above is worthless unless it constrains engineering decisions. The following rules are binding.
+
+1. **Generic institutional shapes live in ICN core crates.** `Entity`, `Membership`, `Structure`, `RoleAssignment`, `Activity`, `Program`, `Milestone`, `Meeting`, `Proposal`, `Vote`, `Delegation`, `Mandate`, `AuthorityGrant`, `ActionItem`, `InstitutionalParent`, `Charter`, ledger entries, receipts, invariants — these are generic and belong in `icn-governance`, `icn-entity`, `icn-identity`, `icn-ledger`, `icn-kernel-api`.
+
+2. **Institution-specific vocabulary lives in institution packages.** Sponsor tiers, conference sessions, summit tracks, committee nickname conventions, jurisdiction-specific registration fields, donor levels, volunteer shift patterns — these belong in `institutions/<name>/` (currently `institutions/nycn/`, to be split out as an external repo). See `docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md`.
+
+3. **NYCN- and Summit-specific semantics must not leak into core.** No `ProgramKind::AnnualSummit`, no `MilestoneType::VenueLocked` in `icn-governance`. Named institution milestones live in CCL contract bodies; institution-kind escapes use `Custom(String)` on generic enums. The authoritative routing correction in `INSTITUTION_PACKAGE_BOUNDARY.md` is the enforcement surface.
+
+4. **Commons doctrine must not weaken the Meaning Firewall.** Everything in this doc that sounds like social meaning (trust, care, standing, representation, scope) is app-layer and/or shell-layer. The kernel continues to see only `ConstraintSet`, `PolicyDecision`, `Capability`, `Did`, `Timestamp`, `Hash`, and the typed invariant attestations. See `docs/architecture/KERNEL_APP_SEPARATION.md` (Invariants 1–5).
+
+5. **The Commons Shell may render social meaning; the kernel must enforce constraints without knowing that meaning.** A shell may show "Alice is voting as GreenStar's representative in NYCN". The kernel sees a signed vote message whose constraints passed a `PolicyOracle` check; it does not know that "NYCN" is a federation or that "GreenStar" is a worker cooperative.
+
+6. **Receipts and provenance remain central.** Every state transition — vote, settlement, role assignment, grant, mandate, admission, expulsion, amendment — emits a receipt. Commons legitimacy rests on verifiable memory. This is frozen-core invariant 10 (Universal Receipt Generation). See `docs/genesis.md`.
+
+7. **Accessibility is not optional.** Any member-facing surface that does not work on a screen reader, on a low-end phone, in a second language, or from a public terminal fails the Commons Shell design test. This is a blocker-level concern, not a polish concern.
+
+8. **Mobile / member interface is the main interaction point.** For most Commons members, `CoopWallet`-class mobile and browser PWA surfaces are the *primary* ICN experience. `icnctl` and `icn-console` are operator surfaces. Architectural decisions that assume the member is an operator are a category error.
+
+9. **Bounded authority.** No wildcard capabilities, no unbounded grants, no eternal mandates (frozen-core invariants 5 and 7). Every authority has scope and time bounds; every grant has a revocation path.
+
+10. **Exit is non-negotiable.** A member can always leave an entity and export their keys, their receipts, and their authored state (frozen-core invariant 1; `icnctl id export`, `icnctl backup`). This is what makes The Commons a Commons and not a platform.
+
+---
+
+## Open Questions / Future Work
+
+The following items are *not* authorized for implementation here. They are explicitly enumerated so that future design docs, issues, and PRs can pick them up without re-deriving the gap analysis.
+
+1. **Define `GET /me/standing` query surface.** Unified standing query (memberships + role assignments + mandates + authority grants + available active scopes + capabilities per scope + pending expirations). Successor to, not replacement for, `/gov/me/scopes` and `/gov/me/work`. Needs a dedicated design doc.
+
+2. **Define the active-scope / session model.** Every member action should carry an explicitly selected scope; the scope must appear in receipts. Today's JWT `coop_id`-based approximation is not uniform across the surfaces. Needs a model doc and a migration plan.
+
+3. **Define the representative / entity-vote model.** A first-class type that binds `(represented_entity, human_signer, authority_source, action_payload, scope, provenance, receipt)`. `AuthorityClass::Representation` in ADR-0014 is the anchor; the vote-wrapper and the tally semantics need a spec. Tally semantics in federations is a pre-requisite.
+
+4. **Define the Action Card generation model.** Predicates, ranking, dismissal, expiry, cross-scope deduplication, scope rendering. The existing notification digest and `/gov/me/work` are partial predecessors.
+
+5. **Promote or rewrite `docs/archive/2026/plans-scratch/human-interface.md`.** Move it into current design docs (`docs/design/` or `docs/mobile/`) as the Commons Shell specification, aligned with `docs/mobile/icn-mobile-ux-spec-v1.md` and the pilot-ui / CoopWallet inventories.
+
+6. **Connect Commons Shell concepts to pilot-ui / mobile / wallet surfaces.** Define the convergence path from today's split surfaces (pilot-ui PWA + CoopWallet + icnctl) to a single Commons Shell concept with shared scope semantics and shared action-card generation.
+
+7. **Add NYCN worked examples.** Show the full person-community-cooperative-federation relationship graph in the NYCN topology, including representation flows and receipt shapes. The `docs/strategy/NYCN-*` docs are close but do not yet render the member-level standing and representation flows.
+
+8. **Clarify how mandates expire, revoke, and appear in receipts.** `Mandate.status`, `Mandate.deadline`, and the decision-bridge path already exist; the member-facing view (what do I see when a mandate I hold approaches expiry? what do I see when an entity revokes my grant?) is not specified.
+
+9. **Clarify entity-level voting eligibility and tally semantics in federations.** When GreenStar votes in NYCN, what weight does GreenStar carry? How do shares work at the entity-member level vs. the individual level? What happens when two humans authorized by GreenStar both attempt to vote on the same federation proposal? Needs a tally-semantics spec.
+
+10. **Clarify node operator civic role and ordinary-operator dashboard needs.** Operators run infrastructure; they are also members of their communities. What does an operator-scope surface look like separate from, but integrated with, their member-scope surfaces? Should node operation itself be a charterable responsibility?
+
+---
+
+## References
+
+**Canonical anchors (consulted while drafting):**
+
+- `docs/genesis.md` — Constitutional Genesis: frozen-core invariants, bootstrap phases, hard invariants.
+- `docs/ARCHITECTURE.md` — ICN Architecture Reference: what ICN is, what it isn't, terminology discipline.
+- `docs/architecture/KERNEL_APP_SEPARATION.md` — Meaning Firewall, PolicyOracle pattern, kernel/app invariants.
+- `docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md` — Authoritative routing between ICN platform and institution packages.
+- `docs/architecture/CELLS_AND_SCOPES.md` — Scope primitives at the substrate layer.
+- `docs/design/ICN_VISUAL_SYSTEM.md` — Visual doctrine; human participation, scope-aware membership, proof-backed coordination.
+- `docs/strategy/NYCN-Repo-Architecture-Spec.md` — Repo-shaped NYCN institutional spec.
+- `docs/strategy/NYCN-Institutional-Design.md` — NYCN-as-native-institution design (with 2026-04-15 correction to layered ontology).
+- `docs/strategy/ADR-001-What-ICN-Is.md` — ADR on ICN's definition.
+- `docs/adr/ADR-0014-constitutional-object-model.md` — Typed authority model (`AuthorityClass`, `AuthorityGrant`, `TypedScope`, `Mandate`).
+- `docs/mobile/icn-mobile-ux-spec-v1.md` — Current mobile UX spec.
+- `docs/archive/2026/plans-scratch/human-interface.md` — Raw material for the Commons Shell concept (archived; pending promotion).
+- `docs/STATE.md` — Current project state.
+- `AGENTS.md` — Agent coding instructions and app topology rule.
+
+**Code anchors (types referenced by name):**
+
+- `icn/crates/icn-identity/src/lib.rs` — `Did`.
+- `icn/crates/icn-identity/src/bundle.rs` — `IdentityBundle`.
+- `icn/crates/icn-identity/src/multi_device.rs` — `Capability`.
+- `icn/crates/icn-entity/src/entity.rs` — `EntityId`, `Individual`, `Cooperative(CooperativeProfile)`, `Community(CommunityProfile)`, `Federation(FederationProfile)`.
+- `icn/crates/icn-entity/src/membership.rs` — `Membership`, `MembershipRole`, `MembershipCapability`.
+- `icn/crates/icn-governance/src/structure.rs` — `Structure`, `RoleAssignment`.
+- `icn/crates/icn-governance/src/activity.rs` — `Activity`.
+- `icn/crates/icn-governance/src/program.rs` — `Program`, `Milestone`.
+- `icn/crates/icn-governance/src/parent.rs` — `InstitutionalParent`.
+- `icn/crates/icn-governance/src/domain.rs` — `GovernanceDomain`.
+- `icn/crates/icn-governance/src/proposal.rs` — `Proposal`.
+- `icn/crates/icn-governance/src/vote.rs` — `Vote`.
+- `icn/crates/icn-governance/src/delegation.rs` — `Delegation`.
+- `icn/crates/icn-governance/src/authority.rs` — `AuthorityGrant`.
+- `icn/crates/icn-governance/src/mandate.rs` — `Mandate`.
+- `icn/crates/icn-governance/src/meeting.rs` — `Meeting`.
+- `icn/crates/icn-governance/src/action_item.rs` — `ActionItem`, `ActionItemSpec`.
+- `icn/crates/icn-governance/src/charter.rs` — `Charter`.
+- `icn/crates/icn-kernel-api/src/invariants.rs` — `InvariantId` (10 frozen-core invariants).
+- `icn/crates/icn-kernel-api/src/bootstrap.rs` — `Capability`, `CapabilitySet`.
+- `icn/apps/governance/src/http/handlers.rs` — `GET /gov/me/scopes`, `GET /gov/me/work`.
+
+---
+
+*This doc is canonical doctrine, not a plan. No feature in this document is authorized for implementation on the basis of this document alone. Each `[future design]` item requires its own design doc, issue, and review.*

--- a/docs/architecture/THE_COMMONS.md
+++ b/docs/architecture/THE_COMMONS.md
@@ -1,6 +1,6 @@
 ---
 Status: doctrine
-Canonical: yes
+Canonical: no
 Authority: architecture (complements KERNEL_APP_SEPARATION.md and INSTITUTION_PACKAGE_BOUNDARY.md)
 Last Reviewed: 2026-04-24
 Owner: Matt Faherty
@@ -125,15 +125,15 @@ This section maps Commons concepts to the real crates, modules, and types in the
 
 | Commons Concept | ICN Primitive | Status | Location |
 |-----------------|---------------|--------|----------|
-| Person / human participant | `Did` (newtype around `String`, Ed25519-backed) | ✅ shipped | `icn/crates/icn-identity/src/lib.rs` |
+| Person / human participant | `Did` (newtype around `String`; 32-byte identifier encoded in DID form, representing either an Ed25519 public key or an SDIS anchor id) | ✅ shipped | `icn/crates/icn-identity/src/lib.rs` (Ed25519 path) and `icn/crates/icn-identity/src/anchor.rs` (`Did::from_anchor_id`) |
 | Cryptographic identity bundle | `IdentityBundle` (Ed25519 + X25519, age-encrypted keystore) | ✅ shipped | `icn/crates/icn-identity/src/bundle.rs` |
 | Unified entity handle | `EntityId` (format `entity:icn:<type>:<slug>`) | ✅ shipped | `icn/crates/icn-entity/src/entity.rs` |
 | Sovereign entity kinds | `Individual`, `Cooperative(CooperativeProfile)`, `Community(CommunityProfile)`, `Federation(FederationProfile)` | ✅ shipped | `icn/crates/icn-entity/src/entity.rs` |
 | Membership | `Membership { member_id, parent_id, role, status, shares, capabilities }` | ✅ shipped | `icn/crates/icn-entity/src/membership.rs` |
 | Membership role | `MembershipRole` enum (`Founder`, `Member`, `Worker`, `Consumer`, `Producer`, `BoardMember`, `Officer{title}`, `FederatedMember`, `AssociateMember`, `ObserverMember`, `ProvisionalMember`, `Custom{name}`) | ✅ shipped | `icn/crates/icn-entity/src/membership.rs` |
-| Per-membership capability grants | `MembershipCapability` enum (`Vote`, `Propose`, `TreasuryAccess`, `Invite`, `ManageSubEntities`, `Sign`, `Configure`) | ✅ shipped | `icn/crates/icn-entity/src/membership.rs` |
+| Per-membership capability grants | `MembershipCapability` enum (`Vote`, `Propose`, `TreasuryAccess`, `Invite`, `ManageSubEntities`, `Sign`, `Configure`, `ViewSensitive`, `Custom(String)`) | ✅ shipped | `icn/crates/icn-entity/src/membership.rs` |
 | Non-sovereign internal unit | `Structure { kind: Committee | WorkingGroup | Team | Office }` | ✅ shipped | `icn/crates/icn-governance/src/structure.rs` |
-| Role inside a structure | `RoleAssignment { structure_id, person_did, role, authority_scope: Vec<String>, valid_from, valid_until }` | ✅ shipped | `icn/crates/icn-governance/src/structure.rs` |
+| Role inside a structure | `RoleAssignment { id, structure_id, person_did, role, authority_scope: Vec<String>, start_date: Timestamp, end_date: Option<Timestamp>, assigned_by_decision }` | ✅ shipped | `icn/crates/icn-governance/src/structure.rs` |
 | Time-bounded work | `Activity { kind: Event | Program | Project | Initiative }` | ✅ shipped | `icn/crates/icn-governance/src/activity.rs` |
 | Program / cycle container | `Program { ... }`, `Milestone { ... }` | ✅ shipped (PR #1548) | `icn/crates/icn-governance/src/program.rs` |
 | Polymorphic parent attachment for operational objects | `InstitutionalParent` enum | ✅ shipped | `icn/crates/icn-governance/src/parent.rs` |


### PR DESCRIPTION
## Summary

Lands two architecture documents that have been drafted but never filed:

- **`docs/architecture/THE_COMMONS.md`** (628 lines) — capital-C Commons doctrine. The north star that names what ICN exists to enable. Status: `doctrine`, `Canonical: yes`. Anchor for future kernel-vs-platform-vs-package decisions.
- **`docs/architecture/MEMBER_STANDING.md`** (792 lines) — design contract for `GET /me/standing`. Status: `design contract`, `Canonical: yes`. Sits beneath `THE_COMMONS.md` and complements `KERNEL_APP_SEPARATION.md` and `INSTITUTION_PACKAGE_BOUNDARY.md`. Explicitly **design-only** — no endpoint is authorized for implementation here.

Also adds these to `docs/ARCHITECTURE.md` and `docs/STATE.md` as canonical references.

## Why now

Discovered during a housekeeping pass: NYCN's `ops/upstream/icn.lock.yaml` already pins
```
member_standing:
  source: docs/architecture/MEMBER_STANDING.md
  icn_status: pinned
```
but the file does not exist on `main`. The lock-file note "Anchored by ADR-0019 and ADR-0020" reflects the intent — these two ADRs (`authority-grant-minting-and-mandate-persistence-seam` and `institutional-bootstrap-activation-and-standing-read-model`) are the implementation layer; this PR provides the architecture-layer doc that NYCN was already referencing.

## Scope

- `docs/architecture/MEMBER_STANDING.md` (new, 792 lines)
- `docs/architecture/THE_COMMONS.md` (new, 628 lines)
- `docs/ARCHITECTURE.md` (+2 references)
- `docs/STATE.md` (+2 references)

## What did **not** change

- No runtime code.
- No ADR or RFC bodies.
- No website content.
- No NYCN or icn-learn files.
- No new endpoint implementation. `GET /me/standing` remains design-only.

## Validation

- `python3 docs/scripts/doc_control_check.py --strict` → ok (736 docs; 38 pre-existing enforcement warnings unrelated to this PR)
- `git diff --check` → clean

## Branch state

Branch was rebased onto current `main` locally; remote was pushed before the rebase work. Letting GitHub handle the rebase at merge time.

## Issue status

No related issue. The lock-file phantom-source reference will be cleared once this lands.