### PR TITLE
feat(governance): add completion-receipt endpoint for action items

### DIFF
--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -389,6 +389,10 @@ where
             web::resource("/domains/{domain_id}/action-items/{item_id}/notes")
                 .route(web::post().to(handlers::add_action_item_note::<E>)),
         )
+        .service(
+            web::resource("/domains/{domain_id}/action-items/{item_id}/completion-receipt")
+                .route(web::get().to(handlers::get_action_item_completion_receipt::<E>)),
+        )
         // ── Structure endpoints ──────────────────────────────────────────
         .service(
             web::resource("/entities/{entity_id}/structures")

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -2859,18 +2859,26 @@ pub async fn get_action_item_completion_receipt<E: GovernanceEventEmitter + Clon
     let (domain_id, item_id) = path.into_inner();
     let domain = GovernanceDomainId(domain_id);
     // Validate the item id format before any DB lookup so a malformed
-    // path returns 400, not a missing-record 404.
-    let _ = parse_action_item_id(&item_id)?;
+    // path returns 400, not a missing-record 404. The receipt store
+    // indexes by the canonical lowercase-hyphenated UUID string that
+    // the manager wrote at receipt-emission time
+    // (`ActionItemCompletionReceipt::new(item.id.to_string(), ...)`),
+    // so we canonicalize the parsed id back to a string here. Without
+    // this normalization, a caller passing the same UUID in
+    // alternative-but-valid forms (uppercase hex, URN form,
+    // braces-wrapped) would parse OK but miss the index entry and
+    // receive a spurious 404.
+    let canonical_item_id = parse_action_item_id(&item_id)?.to_string();
 
     check_domain_membership(&ctx.manager, &domain, &caller_did).await?;
 
     let receipt = ctx
         .manager
-        .get_action_item_completion_by_item(&item_id)
+        .get_action_item_completion_by_item(&canonical_item_id)
         .map_err(anyhow_to_api)?
         .ok_or_else(|| {
             err_not_found(format!(
-                "No completion receipt found for action item: {item_id}"
+                "No completion receipt found for action item: {canonical_item_id}"
             ))
         })?;
 
@@ -2879,7 +2887,7 @@ pub async fn get_action_item_completion_receipt<E: GovernanceEventEmitter + Clon
         // governance domain. From this caller's perspective the receipt
         // does not exist; do not leak cross-domain existence.
         return Err(err_not_found(format!(
-            "No completion receipt found for action item: {item_id}"
+            "No completion receipt found for action item: {canonical_item_id}"
         )));
     }
 

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -2826,6 +2826,66 @@ pub async fn add_action_item_note<E: GovernanceEventEmitter + Clone + 'static>(
     Ok(HttpResponse::Ok().json(action_item_to_response(&item)))
 }
 
+/// GET /gov/domains/{domain_id}/action-items/{item_id}/completion-receipt
+/// — Retrieve the latest [`ActionItemCompletionReceipt`] persisted for an
+/// action item, if any.
+///
+/// Closes the proof loop documented in `docs/dev/NYCN_K3S_PROOF_PATH.md`
+/// and `docs/dev/NYCN_ACTION_ITEM_RECEIPT_PATH.md`: a holder shell that
+/// completed an `action_item / complete` action card can read the
+/// `ActionItemCompletionReceipt` back via HTTP, instead of relying on
+/// in-process tests or on-disk Sled inspection.
+///
+/// Authorization mirrors the rest of the action-item read surface:
+/// `governance:read` scope plus domain membership for the caller. The
+/// receipt's bound `domain_id` is also asserted to match the path
+/// parameter so a holder cannot probe across domain boundaries.
+///
+/// Returns:
+/// - 200 with the receipt JSON when a completion receipt has been
+///   persisted for the item under this domain.
+/// - 404 when no receipt exists, when the item id does not match the
+///   stored receipt's `domain_id`, or when the manager has no receipt
+///   store wired (the receipt simply does not exist from the caller's
+///   point of view).
+pub async fn get_action_item_completion_receipt<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    path: web::Path<(String, String)>,
+) -> Result<HttpResponse, ApiError> {
+    let claims = require_scope::<BasicClaims>(&http_req, "governance:read")?;
+    let caller_did = parse_did(&claims.sub, "Invalid DID in token")?;
+
+    let (domain_id, item_id) = path.into_inner();
+    let domain = GovernanceDomainId(domain_id);
+    // Validate the item id format before any DB lookup so a malformed
+    // path returns 400, not a missing-record 404.
+    let _ = parse_action_item_id(&item_id)?;
+
+    check_domain_membership(&ctx.manager, &domain, &caller_did).await?;
+
+    let receipt = ctx
+        .manager
+        .get_action_item_completion_by_item(&item_id)
+        .map_err(anyhow_to_api)?
+        .ok_or_else(|| {
+            err_not_found(format!(
+                "No completion receipt found for action item: {item_id}"
+            ))
+        })?;
+
+    if receipt.domain_id != domain.0 {
+        // Receipt exists for the item id, but under a different
+        // governance domain. From this caller's perspective the receipt
+        // does not exist; do not leak cross-domain existence.
+        return Err(err_not_found(format!(
+            "No completion receipt found for action item: {item_id}"
+        )));
+    }
+
+    Ok(HttpResponse::Ok().json(receipt))
+}
+
 // ============================================================================
 // Notification digest handler
 // ============================================================================

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -4287,6 +4287,56 @@ impl GovernanceManager {
         Ok(None)
     }
 
+    /// Get the latest [`ActionItemCompletionReceipt`] for an action item id.
+    ///
+    /// Reads from the wired receipt store backend. Returns `Ok(None)`
+    /// when no receipt has been emitted for the item, when the manager
+    /// has no receipt store configured, or when the backend's query
+    /// fails (failures are logged so the caller does not have to
+    /// distinguish absence from query error).
+    pub fn get_action_item_completion_by_item(
+        &self,
+        item_id: &str,
+    ) -> Result<Option<icn_governance::ActionItemCompletionReceipt>> {
+        if let Some(ref store) = self.receipt_store {
+            match store.get_action_item_completion_by_item(item_id) {
+                Ok(receipt) => return Ok(receipt),
+                Err(e) => {
+                    tracing::warn!(
+                        item_id = %item_id,
+                        error = %e,
+                        "Failed to query receipt store for action item completion"
+                    );
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    /// List all [`ActionItemCompletionReceipt`]s ever persisted for an
+    /// action item id, oldest-first by `completed_at`.
+    ///
+    /// Useful for surfaces that need the full reopen/re-complete chain
+    /// rather than just the latest receipt.
+    pub fn list_action_item_completions_by_item(
+        &self,
+        item_id: &str,
+    ) -> Result<Vec<icn_governance::ActionItemCompletionReceipt>> {
+        if let Some(ref store) = self.receipt_store {
+            match store.list_action_item_completions_by_item(item_id) {
+                Ok(receipts) => return Ok(receipts),
+                Err(e) => {
+                    tracing::warn!(
+                        item_id = %item_id,
+                        error = %e,
+                        "Failed to list receipt-store action item completions"
+                    );
+                }
+            }
+        }
+        Ok(Vec::new())
+    }
+
     /// Cast a vote on a proposal
     pub async fn cast_vote(
         &self,

--- a/icn/apps/governance/tests/me_action_item_receipt_chain.rs
+++ b/icn/apps/governance/tests/me_action_item_receipt_chain.rs
@@ -736,3 +736,238 @@ async fn reopen_and_recomplete_preserves_completion_history() {
         .expect("latest receipt");
     assert_eq!(latest.record_hash, chain[1].record_hash);
 }
+
+// ============================================================================
+// HTTP endpoint: GET .../action-items/{item_id}/completion-receipt
+// ============================================================================
+
+/// Builds an actix-web app with the full governance routing surface and a
+/// fixed `BasicClaims` injected for the supplied DID + scope. Used by the
+/// completion-receipt HTTP tests below so they exercise the same handler
+/// path a real gateway would route to.
+macro_rules! gov_app_with_scope {
+    ($ctx:expr, $caller_did:expr, $scope:expr) => {{
+        let caller = $caller_did.to_string();
+        let scope = $scope.to_string();
+        test::init_service(
+            App::new()
+                .wrap_fn(move |req, srv| {
+                    req.extensions_mut().insert(BasicClaims {
+                        sub: caller.clone(),
+                        scope: Some(scope.clone()),
+                    });
+                    srv.call(req)
+                })
+                .configure(|cfg| http::configure(cfg, $ctx)),
+        )
+        .await
+    }};
+}
+
+#[actix_web::test]
+async fn completion_receipt_endpoint_returns_persisted_receipt() {
+    let h = make_harness();
+    let caller = fresh_did();
+    let domain = seed_domain_with_member(&h.ctx.manager, &caller, "test-coop").await;
+
+    // Create + complete the item via the manager (same code path the
+    // status-update HTTP handler exercises).
+    let item = h
+        .ctx
+        .manager
+        .create_action_item(
+            domain.clone(),
+            "Endpoint smoke item".to_string(),
+            Some("Repo-safe placeholder for the completion-receipt endpoint.".to_string()),
+            caller.clone(),
+            Some(caller.clone()),
+            None,
+            ActionItemPriority::Medium,
+            None,
+            None,
+            vec![],
+        )
+        .expect("create_action_item");
+    let item_id = item.id.to_string();
+
+    let updated = h
+        .ctx
+        .manager
+        .update_action_item_status(&domain, &item.id, ActionItemStatus::Completed, &caller)
+        .expect("update_action_item_status -> Completed");
+
+    // GET the new endpoint as the same caller (governance:read). The
+    // receipt body must round-trip the persisted `ActionItemCompletionReceipt`.
+    let app = gov_app_with_scope!(h.ctx.clone(), &caller, "governance:read");
+    let req = test::TestRequest::get()
+        .uri(&format!(
+            "/domains/{}/action-items/{}/completion-receipt",
+            domain.0, item_id
+        ))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = to_bytes(resp.into_body()).await.unwrap();
+    let body: Value = serde_json::from_slice(&bytes).expect("response is valid JSON");
+
+    // Field-level assertions: every field that survives the manager →
+    // backend → handler → wire roundtrip must match the persisted record.
+    assert_eq!(body["item_id"], item_id);
+    assert_eq!(body["domain_id"], domain.0);
+    assert_eq!(body["actor_did"], caller.to_string());
+    assert_eq!(body["transition"], "completed");
+    assert_eq!(body["completed_at"], updated.updated_at);
+    let record_hash_hex = body["record_hash"]
+        .as_str()
+        .or_else(|| body["record_hash"].as_array().map(|_| "array"))
+        .unwrap_or("");
+    assert!(
+        !record_hash_hex.is_empty() || body["record_hash"].is_array(),
+        "record_hash must serialize as a non-empty hex string or byte array, not omitted"
+    );
+}
+
+#[actix_web::test]
+async fn completion_receipt_endpoint_404_when_no_receipt_yet() {
+    let h = make_harness();
+    let caller = fresh_did();
+    let domain = seed_domain_with_member(&h.ctx.manager, &caller, "test-coop").await;
+
+    // Create but do NOT complete: no receipt should exist.
+    let item = h
+        .ctx
+        .manager
+        .create_action_item(
+            domain.clone(),
+            "Endpoint 404 item".to_string(),
+            None,
+            caller.clone(),
+            Some(caller.clone()),
+            None,
+            ActionItemPriority::Low,
+            None,
+            None,
+            vec![],
+        )
+        .expect("create_action_item");
+
+    let app = gov_app_with_scope!(h.ctx.clone(), &caller, "governance:read");
+    let req = test::TestRequest::get()
+        .uri(&format!(
+            "/domains/{}/action-items/{}/completion-receipt",
+            domain.0, item.id
+        ))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "an item without a completed transition has no receipt; endpoint must 404"
+    );
+}
+
+#[actix_web::test]
+async fn completion_receipt_endpoint_does_not_leak_across_domains() {
+    let h = make_harness();
+    let caller = fresh_did();
+    let dom_a = seed_domain_with_member(&h.ctx.manager, &caller, "domain-a").await;
+    let dom_b = seed_domain_with_member(&h.ctx.manager, &caller, "domain-b").await;
+
+    // Create + complete in domain A only.
+    let item = h
+        .ctx
+        .manager
+        .create_action_item(
+            dom_a.clone(),
+            "Domain-A item".to_string(),
+            None,
+            caller.clone(),
+            Some(caller.clone()),
+            None,
+            ActionItemPriority::Medium,
+            None,
+            None,
+            vec![],
+        )
+        .expect("create_action_item");
+    h.ctx
+        .manager
+        .update_action_item_status(&dom_a, &item.id, ActionItemStatus::Completed, &caller)
+        .expect("complete in dom_a");
+    let item_id = item.id.to_string();
+
+    // GET via dom_b's path — must not surface dom_a's receipt.
+    let app = gov_app_with_scope!(h.ctx.clone(), &caller, "governance:read");
+    let req_wrong_domain = test::TestRequest::get()
+        .uri(&format!(
+            "/domains/{}/action-items/{}/completion-receipt",
+            dom_b.0, item_id
+        ))
+        .to_request();
+    let resp_wrong = test::call_service(&app, req_wrong_domain).await;
+    assert_eq!(
+        resp_wrong.status(),
+        StatusCode::NOT_FOUND,
+        "completion receipts must not be visible across governance domains"
+    );
+
+    // Sanity: same item id under the correct domain still resolves.
+    let req_right_domain = test::TestRequest::get()
+        .uri(&format!(
+            "/domains/{}/action-items/{}/completion-receipt",
+            dom_a.0, item_id
+        ))
+        .to_request();
+    let resp_right = test::call_service(&app, req_right_domain).await;
+    assert_eq!(resp_right.status(), StatusCode::OK);
+}
+
+#[actix_web::test]
+async fn completion_receipt_endpoint_response_uses_regulatory_safe_vocabulary() {
+    let h = make_harness();
+    let caller = fresh_did();
+    let domain = seed_domain_with_member(&h.ctx.manager, &caller, "test-coop").await;
+
+    let item = h
+        .ctx
+        .manager
+        .create_action_item(
+            domain.clone(),
+            "Vocabulary smoke item".to_string(),
+            None,
+            caller.clone(),
+            Some(caller.clone()),
+            None,
+            ActionItemPriority::Medium,
+            None,
+            None,
+            vec![],
+        )
+        .expect("create_action_item");
+    h.ctx
+        .manager
+        .update_action_item_status(&domain, &item.id, ActionItemStatus::Completed, &caller)
+        .expect("complete");
+
+    let app = gov_app_with_scope!(h.ctx.clone(), &caller, "governance:read");
+    let req = test::TestRequest::get()
+        .uri(&format!(
+            "/domains/{}/action-items/{}/completion-receipt",
+            domain.0, item.id
+        ))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = to_bytes(resp.into_body()).await.unwrap();
+    let raw = std::str::from_utf8(&bytes)
+        .expect("response bytes are valid UTF-8")
+        .to_lowercase();
+    for forbidden in [
+        "payment", "currency", "wallet", "balance", "deposit", "withdraw",
+    ] {
+        assert!(
+            !raw.contains(forbidden),
+            "completion receipt response must not contain forbidden term '{forbidden}': {raw}"
+        );
+    }
+}

--- a/icn/apps/governance/tests/me_action_item_receipt_chain.rs
+++ b/icn/apps/governance/tests/me_action_item_receipt_chain.rs
@@ -971,3 +971,69 @@ async fn completion_receipt_endpoint_response_uses_regulatory_safe_vocabulary() 
         );
     }
 }
+
+#[actix_web::test]
+async fn completion_receipt_endpoint_canonicalizes_non_canonical_uuids() {
+    // Pins the fix for the reviewer-flagged issue on #1675: the receipt
+    // store indexes by the canonical lowercase-hyphenated UUID string
+    // the manager wrote at emission time, so the handler must canonicalize
+    // the parsed id back to a string before looking it up. Without this,
+    // a caller passing uppercase hex or URN-form UUIDs would parse OK
+    // and then miss the index entry and receive a spurious 404.
+    let h = make_harness();
+    let caller = fresh_did();
+    let domain = seed_domain_with_member(&h.ctx.manager, &caller, "test-coop").await;
+
+    let item = h
+        .ctx
+        .manager
+        .create_action_item(
+            domain.clone(),
+            "Canonical UUID smoke item".to_string(),
+            None,
+            caller.clone(),
+            Some(caller.clone()),
+            None,
+            ActionItemPriority::Medium,
+            None,
+            None,
+            vec![],
+        )
+        .expect("create_action_item");
+    h.ctx
+        .manager
+        .update_action_item_status(&domain, &item.id, ActionItemStatus::Completed, &caller)
+        .expect("complete");
+
+    let item_id_lower = item.id.to_string();
+    let item_id_upper = item_id_lower.to_uppercase();
+    let item_id_urn = format!("urn:uuid:{item_id_lower}");
+
+    assert_ne!(
+        item_id_upper, item_id_lower,
+        "uppercase form must differ byte-wise from canonical form for this test to be meaningful"
+    );
+
+    let app = gov_app_with_scope!(h.ctx.clone(), &caller, "governance:read");
+
+    for variant in [&item_id_lower, &item_id_upper, &item_id_urn] {
+        let req = test::TestRequest::get()
+            .uri(&format!(
+                "/domains/{}/action-items/{}/completion-receipt",
+                domain.0, variant
+            ))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "non-canonical UUID variant {variant} must resolve to the same persisted receipt"
+        );
+        let bytes = to_bytes(resp.into_body()).await.unwrap();
+        let body: Value = serde_json::from_slice(&bytes).expect("response is valid JSON");
+        assert_eq!(
+            body["item_id"], item_id_lower,
+            "response item_id must be the canonical lowercase form regardless of input casing"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds `GET /v1/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt`, the smallest unit of HTTP that closes the proof loop opened by `docs/dev/NYCN_ACTION_ITEM_RECEIPT_PATH.md` ([#1674](https://github.com/InterCooperative-Network/icn/pull/1674)). After today, a holder shell that completed an `action_item / complete` action card can read the persisted `ActionItemCompletionReceipt` back over HTTP instead of relying on on-disk Sled inspection or in-process integration tests.

This is the default-recommended next step from #1674's "Three narrow next steps" section: one route, one handler, one new test file section, no new primitives, no schema change, no RFC, no ADR.

## Layer classification

- Layer: `apps/governance` HTTP surface (read-side).
- Crate-level scope: `icn-governance-actor` only. No changes to `icn-governance` types, `icn-gateway`, `icn-kernel-api`, or any kernel crate.
- Wraps existing `receipt_backend::GovernanceReceiptBackend::get_action_item_completion_by_item`; no schema migration, no new persistence shape.

## Boundary check

- Adds `pub fn get_action_item_completion_by_item` / `pub fn list_action_item_completions_by_item` to `GovernanceManager`. Both delegate to the existing receipt-store backend trait method (mirroring the existing `get_proof` pattern).
- Adds `pub async fn get_action_item_completion_receipt::<E>` HTTP handler.
- Adds one route in `apps/governance/src/http/configure.rs`.
- Adds four targeted handler tests in `apps/governance/tests/me_action_item_receipt_chain.rs`.
- No domain-type imports leak into kernel crates. No public CCL or kernel surface changed.

## What changed

```
 icn/apps/governance/src/http/configure.rs           |   4 +
 icn/apps/governance/src/http/handlers.rs            |  60 ++++++
 icn/apps/governance/src/manager.rs                  |  50 +++++
 icn/apps/governance/tests/me_action_item_receipt_chain.rs |  235 +++++++++++++++
 4 files changed, 349 insertions(+)
```

### Behavior

**Endpoint**: `GET /v1/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt`

**Auth**: `governance:read` scope (matching the rest of the action-item read surface) plus domain membership check.

**Validation order**:
1. Scope check (401 on missing/invalid token).
2. Item-id format parse (400 on malformed UUID).
3. Domain membership (consistent with existing read paths; non-members get the same projected error path).
4. Receipt lookup. If absent → 404.
5. Cross-domain check: even if a receipt with the same `item_id` exists under a different domain, return 404 — do not leak cross-domain existence.

**Response shape**: serializes the persisted `ActionItemCompletionReceipt` (`item_id`, `domain_id`, `actor_did`, `transition`, `completed_at`, `record_hash`).

## What did not change

- `icn-governance` crate (no type changes).
- `icn-gateway`, `icn-core`, `icn-kernel-api`, any kernel crate.
- Existing action-item handlers, the bootstrap loader, or the manager's emission seam at `manager.rs:4870-4890`.
- NYCN repo (smoke fixture continues to drive the loop unchanged).
- K3s (no deploy, no manifest change).
- Public website, DNS, or any external surface.
- `.mcp.json` / hook permissions (untouched).

## Discovery results

- Receipt persistence (`receipt:action_item_completion:rec:` and `:by_item:` Sled prefixes) was already wired in `crates/icn-gateway/src/receipt_store.rs:1587–1660`. The receipt was being emitted by `manager.rs:4870–4890` and persisted, but no HTTP handler read it back. Confirmed by:

  ```
  grep -RIn "get_action_item_completion\|list_action_item_completion" \
    apps/governance/src/http
  # (empty before this PR)
  ```

- `apps/governance/src/receipt_backend.rs` already defined `get_action_item_completion_by_item` and `list_action_item_completions_by_item` on `GovernanceReceiptBackend`. The PR's manager methods are thin wrappers; no trait change needed.
- `icnctl receipts` is the economic-chain receipt surface only and intentionally remains so. Wrapping this new endpoint into `icnctl` is a follow-on, not in scope here.

## Exact commands run

Build + lint + test (from `icn/`):

```sh
cargo check -p icn-governance-actor                 # passed (after manager + handler additions)
cargo fmt -p icn-governance-actor                   # clean
cargo fmt --check                                   # clean
cargo clippy -p icn-governance-actor --tests --all-features  # clean (no -D warnings hits)
cargo test -p icn-governance-actor --test me_action_item_receipt_chain
# 10 passed; 0 failed (4 new + 6 pre-existing)
```

End-to-end local-gateway verification (separate ephemeral data dirs to avoid clobbering prior session state):

```sh
# data dir prepared with a JWT secret; daemon started with the rebuilt icnd
/home/matt/.../icn/target/debug/icnd \
  --data-dir /tmp/icn-completion-receipt-test \
  --gateway-enable \
  --gateway-bind 127.0.0.1:8086 \
  --gateway-jwt-secret "$JWT_SECRET" \
  --log-level warn

# apply NYCN smoke fixture
ICN_KEYSTORE_PASSPHRASE='smoke-test-passphrase' \
  icnctl --data-dir /tmp/icnctl-bootstrap-test \
  institution bootstrap apply \
  --package /home/<user>/projects/nycn/institution/smoke/icnctl \
  --gateway http://127.0.0.1:8086 \
  --coop-id smoke-test-coop
# Completed: 3, Deferred: 0, Unsupported: 1, Failed: no

# create + complete one action item
TOKEN=$(icnctl ... auth token --scopes "governance:read,governance:write,entity:read" ...)
curl -X POST .../v1/gov/domains/nycn-icnctl-smoke-federation-gov/action-items ...
# 201 + ActionItemResponse with id

curl -X PUT .../action-items/$ITEM_ID/status -d '{"status":"completed"}'
# 200 + status:completed

# THE NEW ENDPOINT
curl .../action-items/$ITEM_ID/completion-receipt
# {
#   "item_id":"6ef7a6b8-1752-42cc-8a1a-1d9cc0f27d7f",
#   "domain_id":"nycn-icnctl-smoke-federation-gov",
#   "actor_did":"did:icn:zFLjfYPgF2BEg7NMFcxsM498Zd4VPUTvKh7K3XQrD93Tk",
#   "transition":"completed",
#   "completed_at":1777420018,
#   "record_hash":[250,211,103,51,11,119,225,7,...]
# }
# HTTP 200
```

Negative-path verification (same gateway, same DID):

- Random UUID with no completed transition: `HTTP 404 — No completion receipt found for action item: 00000000-0000-0000-0000-000000000000`.
- Same item id under a different (non-existent) domain: `HTTP 404 — Domain not found: some-other-domain` (existing membership-check path; correctly does not leak cross-domain).
- No `Authorization` header: `HTTP 401`.

## Whether `ActionItemCompletionReceipt` was produced/retrieved

Yes — both ends of the contract:
- **Produced**: by the existing manager seam at `manager.rs:4870–4890` (unchanged), now confirmed end-to-end against a real daemon.
- **Retrieved**: by the new endpoint, returning every field that `ActionItemCompletionReceipt` carries with no field omission. Cross-domain leak protection asserted by `completion_receipt_endpoint_does_not_leak_across_domains`.

## Validation

- `cargo fmt --check`: clean (whole workspace).
- `cargo clippy -p icn-governance-actor --tests --all-features`: clean.
- `cargo test -p icn-governance-actor --test me_action_item_receipt_chain`: 10/10 pass.
- Live local end-to-end: full proof loop completes including HTTP receipt retrieval (transcripts above).
- Vocabulary check (handler text, test text, response): no `payment | currency | wallet | balance | deposit | withdraw`.

## Risk

- Low. One additive read endpoint. No schema change, no migration, no new persistence shape, no kernel-boundary change. Failure modes (no receipt store, backend error, cross-domain probe, malformed id) are all explicitly handled.

## Cross-repo dependency status

- ICN pin in NYCN: `2438a36223b171ca247946b42581aae729471322` (unchanged).
- NYCN smoke fixture remains unchanged on NYCN main as of [nycn#18](https://github.com/InterCooperative-Network/nycn/pull/18).
- After this PR merges, the runbook in [#1674](https://github.com/InterCooperative-Network/icn/pull/1674) and the K3s posture in [#1673](https://github.com/InterCooperative-Network/icn/pull/1673) become end-to-end self-checking over HTTP — no follow-up doc PR required from this one, though a small note appended to `NYCN_ACTION_ITEM_RECEIPT_PATH.md` after merge would be appropriate if the operator wants to record the new step inline.

## Test plan

- [x] `cargo fmt --check` clean.
- [x] `cargo clippy -p icn-governance-actor --tests --all-features` clean.
- [x] `cargo test -p icn-governance-actor --test me_action_item_receipt_chain` 10/10 pass.
- [x] Live local gateway: apply → create item → /me/action-cards card derived → complete → GET completion-receipt returns persisted JSON.
- [x] Negative paths verified live: 404 (missing receipt), 404 (wrong domain), 401 (no auth).
- [x] No real DIDs, no private data, no secrets in code, tests, or PR body.