### PR TITLE
docs(dev): record K3s NYCN action-item receipt proof path

### DIFF
--- a/docs/dev/NYCN_K3S_PROOF_PATH.md
+++ b/docs/dev/NYCN_K3S_PROOF_PATH.md
@@ -16,9 +16,19 @@ It is a **discovery runbook**: the steps it documents have been
 executed against a real local gateway (Path A) and against the
 deployed K3s gateway under explicit operator authorization
 (Path B, exercised end-to-end on 2026-04-29 against deployed image
-`91a63eec` = ICN #1675). Both paths produce the same observed
-behaviour; the divergence is in persistence and cleanup posture
-(see §B.5).
+`91a63eec` = ICN #1675).
+
+Path A in this document covers `start-gateway-test.sh` startup,
+the smoke-fixture apply, and the
+`/v1/gov/me/{standing,action-cards}` reads. The action-item
+HTTP loop (POST → derived card → PUT → completion-receipt) is
+documented in the sibling
+[`NYCN_ACTION_ITEM_RECEIPT_PATH.md`](./NYCN_ACTION_ITEM_RECEIPT_PATH.md);
+Path B (§B.4) inlines that loop against K3s rather than pointing
+at the sibling, so an operator running Path B end-to-end has a
+single document to follow. The two paths produce the same
+observed behaviour for the steps each documents; persistence and
+cleanup posture differ between them (§B.5).
 
 ## Scope
 
@@ -236,15 +246,18 @@ action items"). The image therefore carries:
   by `nycn_bootstrap_apply_idempotent` and the per-create-op stub
   tests in `bins/icnctl/src/institution_bootstrap.rs`.
 
-Confirm the new route is wired by hitting it without auth — a
-bare `401` indicates the route is mounted (vs `404` if the image
-predated #1675):
-
-```sh
-curl -sS -w "\n[%{http_code}]\n" \
-  http://10.8.30.40:30080/v1/gov/domains/nycn-icnctl-smoke-federation-gov/action-items/00000000-0000-0000-0000-000000000000/completion-receipt
-# [401]
-```
+A bare-no-auth probe on this route is **not** a route-existence
+check: the entire `/v1/gov` scope is wrapped in auth middleware
+(see `crates/icn-gateway/src/server.rs` around the `/gov` scope
+configuration), so any path under it returns `401` to a
+no-auth call regardless of whether the specific route is
+mounted. The honest route-existence probe is authenticated and
+relies on the handler's specific 404 message — see §B.4.4 below,
+where a `GET .../completion-receipt` with a valid JWT and a
+random UUID returns `HTTP 404 — No completion receipt found for
+action item: ...` (handler-emitted) rather than a generic
+actix not-found. That distinguishes a mounted route from a
+missing one on a hypothetical pre-#1675 image.
 
 ### B.3 Confirm endpoints exist and accept auth (read-only)
 
@@ -465,7 +478,7 @@ or generic delete-entity command. The `icnctl institution` surface
 exposes only `bootstrap {validate,plan,apply}` (verify with
 `target/debug/icnctl institution bootstrap --help`); no top-level
 `entity` subcommand exists in `icnctl --help`. The action-item
-HTTP surface does include `DELETE /v1/gov/domains/{id}/action-items/{id}`
+HTTP surface does include `DELETE /v1/gov/domains/{domain_id}/action-items/{item_id}`
 (creator-only), but no equivalent for the federation entity or
 governance domain seeded by bootstrap apply.
 

--- a/docs/dev/NYCN_K3S_PROOF_PATH.md
+++ b/docs/dev/NYCN_K3S_PROOF_PATH.md
@@ -13,10 +13,12 @@ action-card queue, and the remaining gap to the full
 package-driven action-item completion receipt path.
 
 It is a **discovery runbook**: the steps it documents have been
-executed against a real local gateway and read-only against the K3s
-deployment. The K3s `apply` step is documented but deliberately left
-for an explicit operator decision — this runbook does not perform
-cluster mutation.
+executed against a real local gateway (Path A) and against the
+deployed K3s gateway under explicit operator authorization
+(Path B, exercised end-to-end on 2026-04-29 against deployed image
+`91a63eec` = ICN #1675). Both paths produce the same observed
+behaviour; the divergence is in persistence and cleanup posture
+(see §B.5).
 
 ## Scope
 
@@ -185,11 +187,14 @@ verifier accepts the long forms only. The full set is:
 `constitutional:{read,write,admin}`, `entity:{read,write,audit}`,
 `treasury:{read,write}`, `admin`.
 
-## Path B — K3s deployment (read-only verified; apply pending)
+## Path B — K3s deployment (operator-confirmed proof loop)
 
 Use this when the cluster image is current enough and the operator
-has accepted that smoke entities will persist in cluster state until
-manually cleared.
+has accepted that smoke entities will persist in cluster state
+until manually cleared. Path B has been **exercised end-to-end**
+against the deployed K3s gateway as of 2026-04-29; the transcripts
+below are verbatim. K3s mutation occurred under explicit operator
+authorization recorded in this session.
 
 ### B.1 Confirm cluster reachability and image freshness
 
@@ -205,29 +210,41 @@ ssh ubuntu@10.8.30.40 \
    -o jsonpath='{.spec.template.spec.containers[0].image}'"
 ```
 
-**Observed (this session, 2026-04-28):**
+**Observed (preflight for the operator-authorized proof pass,
+2026-04-29):**
 
-- Pod `icn-daemon-7544dc7bfc-lkrkt` Running 23h on `k3s-worker-2`.
+- Pod `icn-daemon-7fb8dd89fb-957bt` Running on `k3s-worker-2`,
+  16 minutes since rollout at probe time.
 - Service `icn-nodeport` exposes 8080 → 30080 and 7777 → 30777.
-- Deployed image: `10.8.30.40:30500/icn:44fc2043409a6437ae74a35e823b74446c2789c8`.
+- Deployed image:
+  `10.8.30.40:30500/icn:91a63eec9e86beb06e8bf2aa0251bc38708ac2c0`.
+- PVCs `icn-data` (10Gi, `atlas-nfs`), `icn-backups` (20Gi),
+  `etcd-snapshot-backups` (5Gi) all `Bound`.
 
 ### B.2 Verify the deployed image carries the API surface
 
-The deployed image is built from ICN commit `44fc2043` (PR #1663,
-"feat(governance): add meeting attendance receipts"). NYCN main was
-8 commits ahead at the time of writing; none of those commits
-touched runtime code:
+The deployed image is built from ICN commit `91a63eec`, exactly
+PR #1675 ("feat(governance): add completion-receipt endpoint for
+action items"). The image therefore carries:
+
+- the `icnctl institution bootstrap` surface (apply / validate /
+  plan, since pre-#1675),
+- `/v1/gov/me/{standing,action-cards}` (since #1659),
+- `/v1/gov/domains/{domain_id}/action-items[/{item_id}[/status|/notes|/completion-receipt]]`
+  (the new completion-receipt route landed in #1675), and
+- the per-handler 409→`Completed` idempotency coercion verified
+  by `nycn_bootstrap_apply_idempotent` and the per-create-op stub
+  tests in `bins/icnctl/src/institution_bootstrap.rs`.
+
+Confirm the new route is wired by hitting it without auth — a
+bare `401` indicates the route is mounted (vs `404` if the image
+predated #1675):
 
 ```sh
-git log --oneline 44fc20434..2438a362 \
-  -- icn/bins/icnctl icn/apps/governance \
-     icn/crates/icn-governance icn/crates/icn-gateway
-# (empty)
+curl -sS -w "\n[%{http_code}]\n" \
+  http://10.8.30.40:30080/v1/gov/domains/nycn-icnctl-smoke-federation-gov/action-items/00000000-0000-0000-0000-000000000000/completion-receipt
+# [401]
 ```
-
-All eight commits between are docs/ops/RFC. The deployed image
-therefore exposes the full `icnctl institution bootstrap` surface
-plus the `/v1/gov/me/{standing,action-cards}` routes used below.
 
 ### B.3 Confirm endpoints exist and accept auth (read-only)
 
@@ -254,10 +271,16 @@ Both responses are well-formed empty projections — the expected
 output for a DID with no standing or assigned cards on the cluster.
 This proves the routes are live and JWT-bound on K3s.
 
-### B.4 Apply against K3s (operator decision required)
+### B.4 Apply, drive, and retrieve against K3s
 
-The apply command for K3s mirrors the local one with a different
-gateway:
+Operator authorization recorded for the 2026-04-29 pass. The
+sequence below mirrors Path A §§A.2–A.3 and the local action-item
+loop in [`NYCN_ACTION_ITEM_RECEIPT_PATH.md`](./NYCN_ACTION_ITEM_RECEIPT_PATH.md),
+with `--gateway http://10.8.30.40:30080` instead of localhost.
+Smoke ids stay namespaced (`nycn-icnctl-smoke-*`) so the
+persistent records are identifiable.
+
+**B.4.1 Apply.**
 
 ```sh
 ICN_KEYSTORE_PASSPHRASE='smoke-test-passphrase' \
@@ -269,10 +292,165 @@ ICN_KEYSTORE_PASSPHRASE='smoke-test-passphrase' \
   --coop-id smoke-test-coop
 ```
 
-Before running this command, the operator must accept the
-constraints in §B.5 below. This runbook does not execute it; the
-local apply at §A.2 produces equivalent code-path coverage with no
-cluster persistence.
+Verbatim:
+
+```
+Charter status:  valid
+Completed:       3
+Deferred:        0
+Unsupported:     1
+Failed:          no
+
+Completed steps:
+  - validate charter ...
+  - create Federation entity nycn-icnctl-smoke-federation:
+    created entity as
+    entity:icn:federation:nycn-icnctl-smoke-federation;
+    governance domain alias nycn-icnctl-smoke-federation-gov
+    recorded for subsequent provisioning
+  - provision governance domain nycn-icnctl-smoke-federation-gov:
+    provisioned governance domain as
+    nycn-icnctl-smoke-federation-gov
+
+Unsupported steps:
+  - store charter: ...
+
+Alias bindings:
+  - nycn-icnctl-smoke-federation ->
+    entity:icn:federation:nycn-icnctl-smoke-federation
+```
+
+**B.4.2 JWT + standing + cards-before.**
+
+```sh
+TOKEN=$(ICN_KEYSTORE_PASSPHRASE='smoke-test-passphrase' \
+  <icn-repo-root>/icn/target/debug/icnctl \
+  --data-dir /tmp/icnctl-bootstrap-test \
+  auth token \
+  --gateway http://10.8.30.40:30080 \
+  --coop-id smoke-test-coop \
+  --scopes "governance:read,governance:write,entity:read" \
+  | grep -E "^eyJ" | head -1)
+
+curl -sS http://10.8.30.40:30080/v1/gov/me/standing \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Verbatim:
+
+```json
+{
+  "did": "did:icn:zFLjfYPgF2BEg7NMFcxsM498Zd4VPUTvKh7K3XQrD93Tk",
+  "domains": [
+    {
+      "domain_id": "nycn-icnctl-smoke-federation-gov",
+      "domain_name": "NYCN icnctl Smoke Federation Governance",
+      "membership_source": "static_list",
+      "status": "member"
+    }
+  ],
+  "roles": [],
+  "authority_scopes": [],
+  "generated_at": 1777424370
+}
+```
+
+`/me/action-cards` before any action-item creation returns the
+expected empty projection (`{"did": "...", "cards": [], ...}`).
+
+**B.4.3 Create + complete + retrieve.**
+
+```sh
+DID="did:icn:zFLjfYPgF2BEg7NMFcxsM498Zd4VPUTvKh7K3XQrD93Tk"
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+
+# Create
+curl -sS -X POST \
+  http://10.8.30.40:30080/v1/gov/domains/nycn-icnctl-smoke-federation-gov/action-items \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"title\":\"k3s-smoke proof item $TS\",
+       \"description\":\"Repo-safe placeholder action item driving the K3s proof loop.\",
+       \"assignee\":\"$DID\",
+       \"priority\":\"medium\",
+       \"tags\":[\"k3s-smoke\",\"icnctl-smoke\"]}"
+```
+
+Returned `id`: `6aa137e4-004c-4902-b011-583e123336f8`. The
+post-create `/me/action-cards` query returns one
+`source_kind: action_item, action_kind: complete,
+authority_basis: assigned_action_item, receipt_expected: true`
+card with `source_id` matching the new item.
+
+```sh
+ITEM_ID="6aa137e4-004c-4902-b011-583e123336f8"
+
+# Complete
+curl -sS -X PUT \
+  "http://10.8.30.40:30080/v1/gov/domains/nycn-icnctl-smoke-federation-gov/action-items/$ITEM_ID/status" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"status":"completed"}'
+# 200 + status:completed in the body
+
+# /me/action-cards now empty (card derivation drops completed items)
+
+# Retrieve receipt
+curl -sS \
+  "http://10.8.30.40:30080/v1/gov/domains/nycn-icnctl-smoke-federation-gov/action-items/$ITEM_ID/completion-receipt" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Verbatim:
+
+```json
+{
+  "item_id": "6aa137e4-004c-4902-b011-583e123336f8",
+  "domain_id": "nycn-icnctl-smoke-federation-gov",
+  "actor_did": "did:icn:zFLjfYPgF2BEg7NMFcxsM498Zd4VPUTvKh7K3XQrD93Tk",
+  "transition": "completed",
+  "completed_at": 1777424395,
+  "record_hash": [93,71,129,141,33,247,155,144,241,70,254,206,98,90,118,170,220,75,44,4,230,138,233,197,194,162,255,188,197,26,246,183]
+}
+```
+
+Every persisted field round-trips on the wire.
+
+**B.4.4 Negative-path spot checks (each verified live against
+this same K3s deployment).**
+
+- No auth → `HTTP 401` (route present, JWT required).
+- Random UUID with no completed transition →
+  `HTTP 404 — No completion receipt found for action item:
+  00000000-0000-0000-0000-000000000000`.
+- Malformed UUID in path →
+  `HTTP 400 — Invalid action item ID: ...` (parse error from
+  `parse_action_item_id`, before any DB lookup).
+- Same item id under a non-existent domain →
+  `HTTP 404 — Domain not found: some-other-domain` (precondition
+  branch; cross-domain existence is not leaked).
+
+**B.4.5 Idempotent re-apply.**
+
+A second `icnctl institution bootstrap apply` against the same
+gateway with the same data-dir / coop-id returns the same
+`Completed: 3, Failed: 0` shape, with the create steps reporting
+"already exists":
+
+```
+Completed steps:
+  - validate charter ...
+  - create Federation entity nycn-icnctl-smoke-federation:
+    entity entity:icn:federation:nycn-icnctl-smoke-federation
+    already exists
+  - provision governance domain nycn-icnctl-smoke-federation-gov:
+    governance domain nycn-icnctl-smoke-federation-gov already
+    exists
+```
+
+This matches the local Path A §A.2 idempotency confirmation and
+the unit-test guarantees in
+`bins/icnctl/src/institution_bootstrap.rs`.
 
 ### B.5 Idempotency, cleanup, persistence
 
@@ -286,15 +464,27 @@ so a repeated apply is safe.
 or generic delete-entity command. The `icnctl institution` surface
 exposes only `bootstrap {validate,plan,apply}` (verify with
 `target/debug/icnctl institution bootstrap --help`); no top-level
-`entity` subcommand exists in `icnctl --help`. Smoke records
-therefore persist in the daemon's Sled store until that store is
-cleared manually:
+`entity` subcommand exists in `icnctl --help`. The action-item
+HTTP surface does include `DELETE /v1/gov/domains/{id}/action-items/{id}`
+(creator-only), but no equivalent for the federation entity or
+governance domain seeded by bootstrap apply.
+
+Smoke records therefore persist in the daemon's Sled store until
+that store is cleared manually:
 
 - For local: `rm -rf /tmp/icn-bootstrap-test` after stopping `icnd`.
-- For K3s: a record is written into the persistent volume backing
-  `icn-daemon`. Removing it requires either a targeted entity-delete
-  endpoint (does not currently exist as part of the public surface)
-  or PV reset.
+- **For K3s (after the 2026-04-29 pass)**: one federation entity
+  (`entity:icn:federation:nycn-icnctl-smoke-federation`), one
+  governance domain (`nycn-icnctl-smoke-federation-gov`), and one
+  completed action item (`6aa137e4-004c-4902-b011-583e123336f8`,
+  with its persisted `ActionItemCompletionReceipt` under the
+  `receipt:action_item_completion:rec:` / `:by_item:` Sled
+  prefixes) live in the cluster's persistent gateway store
+  (PVC `icn-data`, `atlas-nfs`-backed). Removing them requires
+  either a targeted entity-delete endpoint (does not currently
+  exist as part of the public surface) or a PV reset. These
+  records are devnet proof artifacts; the namespaced ids make
+  them identifiable when reviewing cluster state.
 
 **Naming hygiene** — the smoke fixture's `package_id`
 (`nycn-icnctl-smoke`), entity id


### PR DESCRIPTION
## Summary

Records the operator-authorized K3s proof pass executed 2026-04-29 against the deployed image `91a63eec` (= ICN [#1675](https://github.com/InterCooperative-Network/icn/pull/1675)). The local HTTP proof loop documented in [#1673](https://github.com/InterCooperative-Network/icn/pull/1673), [#1674](https://github.com/InterCooperative-Network/icn/pull/1674), and [#1676](https://github.com/InterCooperative-Network/icn/pull/1676) is now also exercised end-to-end against the deployed K3s gateway. Updates `docs/dev/NYCN_K3S_PROOF_PATH.md` only — one file, +226 / −36.

## Layer classification

- Layer: ICN dev runbook (`docs/dev/`).
- Not an RFC, not an ADR.
- Not a runtime change.
- Not a deploy / manifest / DNS / cluster-state change in *this PR* (cluster state was changed live by the operator-authorized proof pass; this PR documents the result).
- Not a public-website change.
- Not a NYCN change.

## Boundary check

- Touches only `docs/dev/NYCN_K3S_PROOF_PATH.md`.
- ICN runtime: unchanged.
- Cluster state: this PR does not mutate the cluster. The cluster mutation occurred during the documented proof pass; the namespaced smoke records (`nycn-icnctl-smoke-*`) and the completed action item / persisted receipt are now durable in PVC `icn-data` until manually cleared (no teardown command exists).
- Vocabulary: regulatory-safe; no `payment | currency | wallet | balance` introduced.

## What changed

- Head-of-doc summary: removed "K3s apply step is deliberately left for an explicit operator decision"; replaced with current posture (Path B exercised end-to-end on 2026-04-29 under explicit operator authorization).
- §B.1 (preflight): refreshed observed cluster state — pod `icn-daemon-7fb8dd89fb-957bt` Running on `k3s-worker-2`, deployed image `10.8.30.40:30500/icn:91a63eec9e86beb06e8bf2aa0251bc38708ac2c0`, PVCs all `Bound`.
- §B.2 (API surface): replaced the previous `44fc2043`-vs-main delta narrative with a direct statement that the deployed image IS the `91a63eec` commit, so the completion-receipt route is present; documented the bare-no-auth 401 probe as the cheapest way to confirm route mounting.
- §B.4 (was: "Apply against K3s (operator decision required)" → now: "Apply, drive, and retrieve against K3s"): five new sub-sections with verbatim transcripts:
  - **B.4.1 Apply**: `Completed: 3, Deferred: 0, Unsupported: 1, Failed: no`; federation + governance-domain alias bindings recorded.
  - **B.4.2 JWT + standing**: smoke DID surfaces as `static_list` member of `nycn-icnctl-smoke-federation-gov`; `/me/action-cards` pre-create returns expected empty projection.
  - **B.4.3 Create + complete + retrieve**: action item `6aa137e4-004c-4902-b011-583e123336f8` created → `action_item / complete` card derives with `receipt_expected:true` → `PUT .../status: completed` transitions → `/me/action-cards` empties → `GET .../completion-receipt` returns the persisted `ActionItemCompletionReceipt` with full 32-byte `record_hash`.
  - **B.4.4 Negative-path spot checks** (each verified live against the same deployment): 401 (no auth), 404 (random UUID), 400 (malformed UUID), 404 (wrong/non-existent domain — no cross-domain leak).
  - **B.4.5 Idempotent re-apply**: second `bootstrap apply` returns same `Completed: 3, Failed: 0` shape with create steps reporting "already exists" — empirical confirmation of the 409→`Completed` coercion against K3s.
- §B.5 (persistence/cleanup): updated to record the durable state the proof pass left in PVC `icn-data` — one federation entity, one governance domain, one completed action item, one `ActionItemCompletionReceipt` under `receipt:action_item_completion:rec:` / `:by_item:` Sled prefixes. Notes the action-item-level `DELETE` endpoint exists (creator-only); no equivalent at federation/domain level, and no `bootstrap teardown` command. Smoke records are devnet proof artifacts; namespaced ids make them identifiable.

## What did not change

- ICN runtime, schema, or migration.
- Cluster manifests, deploy/k8s scripts, kustomization, configmap, services.
- NYCN repo (smoke fixture and sync docs already at `91a63eec` pin).
- icn-learn repo.
- Public website, DNS, Cloudflare.
- `.mcp.json` / hook permissions / unrelated local state.

## K3s status before mutation

| Gate | Result |
|---|---|
| SSH `ubuntu@10.8.30.40` | OK |
| Namespace `icn` | present |
| `icn-daemon` pod | Running on `k3s-worker-2`, post-redeploy by operator |
| Deployed image | `10.8.30.40:30500/icn:91a63eec9e86beb06e8bf2aa0251bc38708ac2c0` (= #1675) |
| Gateway `/v1/health` | `200` `{"status":"ok","version":"0.1.0",...}` |
| `/v1/gov/me/standing` route | `401` no-auth (mounted) |
| `/v1/gov/.../completion-receipt` route | `401` no-auth (mounted; predates this proof pass would have been 404) |
| Metrics `:30090` | serving |
| PVCs `icn-data`, `icn-backups`, `etcd-snapshot-backups` | all `Bound`, `atlas-nfs` |

## Deploy/redeploy status

No redeploy was performed in this session. The cluster was already running image `91a63eec` (operator-redeployed prior to the session). The proof pass therefore exercised the existing deployment without manifest or image change.

## Proof result

Full path closed against K3s:

```
NYCN smoke fixture
  → icnctl institution bootstrap apply  (3/0/1/0)
  → /v1/gov/me/standing                  (DID = static_list member of smoke domain)
  → POST /v1/gov/domains/.../action-items
  → /v1/gov/me/action-cards              (one action_item / complete card derives)
  → PUT /v1/gov/domains/.../action-items/{id}/status: completed
  → /v1/gov/me/action-cards              (empty again)
  → GET /v1/gov/domains/.../action-items/{id}/completion-receipt
       ↳ persisted ActionItemCompletionReceipt JSON returned
```

Re-apply is idempotent against K3s (verified via §B.4.5 transcripts).

## Cleanup / idempotency posture

- **Idempotency**: confirmed empirically; second apply returns "already exists" details with the same `Completed: 3, Failed: 0` shape.
- **Cleanup**: no full teardown. Action item can be deleted via `DELETE /v1/gov/domains/{id}/action-items/{id}` (creator-only; would also leave its receipt in the by-item index). Federation entity and governance domain have no public delete endpoint — they remain in PVC `icn-data` until manually cleared. Smoke ids are namespaced (`nycn-icnctl-smoke-*`) so operators can identify them when reviewing cluster state. Acceptable as devnet proof artifacts.

## Validation

- `python3 docs/scripts/doc_control_check.py --strict`: passed (738 docs; 36 pre-existing warnings on unrelated files).
- `git diff --check`: clean.

## Risk

- Low. One existing runbook updated to record an already-completed proof pass. No code, no manifests, no NYCN changes.

## Cross-repo dependency status

- ICN runtime endpoint shipped in [#1675](https://github.com/InterCooperative-Network/icn/pull/1675).
- ICN-side runbook updates in [#1673](https://github.com/InterCooperative-Network/icn/pull/1673), [#1674](https://github.com/InterCooperative-Network/icn/pull/1674), [#1676](https://github.com/InterCooperative-Network/icn/pull/1676).
- NYCN sync at [nycn#19](https://github.com/InterCooperative-Network/nycn/pull/19) recorded local closure; this PR records K3s closure. A follow-up NYCN sync PR can update `docs/sync/PACKAGE_PROOF_MATRIX.md` to flip the K3s row from "K3s exercise pending operator decision" to "K3s exercised on 2026-04-29 against deployed image `91a63eec`."
- Refs InterCooperative-Network/icn#1608 (action-card source-path expansion umbrella).

## Test plan

- [x] All gateway/cluster pre-checks passed (table above).
- [x] `bootstrap apply` returned `Completed: 3, Failed: 0`.
- [x] `/v1/gov/me/standing` returned smoke DID as static_list member.
- [x] `POST .../action-items` returned 201 with item id.
- [x] `/me/action-cards` derived `action_item / complete` card with `receipt_expected: true`.
- [x] `PUT .../status: completed` returned 200, item status `completed`.
- [x] `/me/action-cards` returned empty after completion.
- [x] `GET .../completion-receipt` returned 200 with full receipt JSON, including 32-byte `record_hash`.
- [x] Negative paths verified: 401, 400, 404 (random UUID), 404 (wrong domain).
- [x] Re-apply returned same `Completed: 3, Failed: 0` shape.
- [x] `python3 docs/scripts/doc_control_check.py --strict` passed.
- [x] No real DIDs (smoke DID), no private data, no secrets in PR body.