### PR TITLE
docs(state): sync to post-#1675/#1677 and post-NYCN-#28 reality

### DIFF
--- a/docs/PHASE_PROGRESS.md
+++ b/docs/PHASE_PROGRESS.md
@@ -1,6 +1,28 @@
 # ICN Phase Progress
-**Last Updated:** 2026-04-27
-**Current Phase:** Phase 2 — Pilot Launch (still blocked on cooperative partners; institutional-operability infrastructure and the action-card runtime are now in place — all currently emitted source paths are proof-bearing)
+**Last Updated:** 2026-04-29
+**Current Phase:** Phase 2 — Pilot Launch. NYCN is the intended first cooperative partner (active partnership track, not yet a formally committed pilot); the next concrete step is presenting the merged drive-ingest ladder + ICN proof-loop machinery to NYCN organizers to formalize the pilot. Subsequent gates: partnership formalization, then first operator pilot rehearsal. Institutional-operability infrastructure, the action-card runtime, the action-item completion-receipt retrieval endpoint, and the NYCN drive-ingest operator ladder are all in place; all currently emitted source paths are proof-bearing both locally and on K3s.
+
+<!-- [sync edit] 2026-04-29 (post-#1675/#1677, post-NYCN-#28):
+     Phase 2 framing change. NYCN is the intended first
+     cooperative partner; not yet a formally committed pilot.
+     We are no longer blocked on partner identification — the
+     active partnership track is NYCN — but the next concrete
+     step is presenting the merged drive-ingest ladder + ICN
+     proof-loop machinery to NYCN organizers to formalize the
+     pilot. Subsequent gates: partnership formalization, then
+     first operator pilot rehearsal against real (or fixture-
+     equivalent) organizer material. Phase 2 deliverables list
+     extended to record: completion-receipt retrieval endpoint
+     (GET /v1/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt)
+     shipped as #1675; local HTTP proof loop closure documented
+     in #1676; K3s smoke proof closure against deployed image
+     91a63eec recorded in #1677; NYCN drive-ingest operator
+     ladder merged end-to-end (NYCN #21–#28 in fahertym/nycn):
+     parser → review → decisions → publish dry-run → assignee
+     binding → local publisher → local proof runner → federation
+     surface bridge → operator pilot runbook + ladder checker.
+     These landings do not flip Phase 2 to ✅ on their own. -->
+
 
 <!-- [sync edit] 2026-04-27 (post-#1663): Phase 2 status unchanged (still
      blocked on cooperative partners). Action-card runtime now has
@@ -126,12 +148,12 @@
 ---
 
 ### Phase 2: Pilot Launch
-**Status:** ⏳ Blocked (awaiting cooperative partners)
+**Status:** ⏳ In progress (NYCN is the intended first cooperative partner — active partnership track, not yet a formally committed pilot; next concrete step is presenting the merged drive-ingest ladder + ICN proof-loop machinery to NYCN organizers to formalize the pilot)
 **Started:** —
 **Completed:** —
 **Sprint(s):** S19–S20
 
-**Objective:** 3–5 real cooperatives operating on ICN for governance and/or time-credit tracking.
+**Objective:** 3–5 real cooperatives operating on ICN for governance and/or time-credit tracking. NYCN is the intended first; additional cooperatives are downstream of a successful first-partner rehearsal.
 
 **Deliverables:**
 - [x] Pilot runbook (#1222 ✅ closed)
@@ -147,6 +169,10 @@
 - [x] Action card → `GovernanceDecisionReceipt` proof linkage for proposal/vote (#1660) — proof loop verified
 - [x] `action_item`/`complete` source path emits append-only `ActionItemCompletionReceipt` (#1661) — proof loop verified
 - [x] `meeting`/`attend` source path emits append-only `MeetingAttendanceReceipt` (#1663) — proof loop verified; `Present`/`Remote` are receipt-bearing transitions; `Absent` is not; steward-recorded attendance distinguished by `recorded_by` vs `attendee_did`
+- [x] `GET /v1/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt` retrieval endpoint (#1675) — closes the proof loop on the read side so a holder shell can fetch the persisted receipt over HTTP; `governance:read` scope + domain membership; cross-domain probes rejected
+- [x] Local HTTP proof loop closure documented in `docs/dev/NYCN_ACTION_ITEM_RECEIPT_PATH.md` (#1676)
+- [x] K3s smoke proof closure (operator-authorized, deployed image 91a63eec) recorded in `docs/dev/NYCN_K3S_PROOF_PATH.md` (#1677)
+- [x] NYCN drive-ingest operator ladder merged end-to-end in `fahertym/nycn` (NYCN #21–#28): parser → review → decisions → publish dry-run → assignee binding → local publisher → local proof runner → federation surface bridge → operator pilot runbook + ladder checker. Procedural spine for walking organizer material into ICN action-item proofs without an agent in the loop. **Note:** the ladder runs against a localhost ICN gateway only; K3s exercise lives ICN-side under #1677, not in the NYCN repo.
 - [ ] Action-card runtime — remaining gates under #1646 (RFC-gated): `signal_rule` source path (gated on #1631); `obligation_lifecycle` source path (gated on #1634)
 - [ ] One-command deployment script per cooperative
 - [ ] Charter customization workflow documented (charter activation endpoint exists; non-technical workflow doc still missing)
@@ -158,9 +184,12 @@
 **Blockers:**
 - ~~Requires Phase 1 complete~~ ✅ Charter Engine is live
 - ~~Requires bootstrap activation runtime~~ ✅ live charter activation + person-directory + standing read model landed 2026-04-22 → 2026-04-26
-- Requires cooperative partners identified and committed (primary blocker)
+- ~~Requires cooperative partners identified~~ ✅ NYCN is the intended first cooperative partner (active partnership track)
+- Next concrete step: present the merged drive-ingest ladder + ICN proof-loop machinery to NYCN organizers to formalize the pilot
+- Subsequent gate: partnership formalization, then first operator pilot rehearsal against real (or fixture-equivalent) organizer material
 
 **Decisions Made:**
+- (2026-04-29, post-#1675/#1677, post-NYCN-#28) The Phase 2 *machinery* is now in place end-to-end: (a) action-card runtime is proof-bearing for all currently emitted source paths, (b) the completion-receipt retrieval endpoint exists so a holder shell can read receipts over HTTP, (c) the local HTTP proof loop is closed and documented, (d) the K3s smoke proof loop is closed against deployed image `91a63eec` and documented, and (e) the NYCN drive-ingest operator ladder is merged end-to-end as a procedural spine. NYCN is the intended first cooperative partner (active partnership track); the next concrete step is **presenting the merged ladder + ICN proof-loop machinery to NYCN organizers** to formalize the pilot. Phase 2 remains ⏳ until that presentation, the partnership formalization that follows, and the first operator pilot rehearsal happen and are recorded. The two RFC-gated action-card source paths (`signal_rule`, `obligation_lifecycle`) remain open under #1646 and are independent of the partner gate.
 - (2026-04-27, post-#1663) Action-card runtime is now proof-bearing for **all three currently emitted source paths**: `proposal`/`vote` (#1660), `action_item`/`complete` (#1661), and `meeting`/`attend` (#1663). Issue #1646 remains open for the two RFC-gated paths: `signal_rule` (#1631) and `obligation_lifecycle` (#1634). Phase 2 status is unaffected (still partner-bound).
 - (2026-04-27) Action-card runtime is partial: `/me/action-cards` exists, `proposal`/`vote` and `action_item`/`complete` source paths have verified end-to-end receipt proof loops, and `meeting`/`attend`, `signal_rule`, `obligation_lifecycle` paths remain pending under #1646. Phase 2 status is unaffected.
 - (2026-04-26) Pilot enablement infrastructure (bootstrap, charter activation, role binding, standing) is in place; Phase 2 remains ⏳ until partners run it for real.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,10 +1,33 @@
 ---
 Status: descriptive
 Canonical: yes
-Last Reviewed: 2026-04-27
+Last Reviewed: 2026-04-29
 ---
 
 # ICN State (living doc)
+
+<!-- [sync edit] 2026-04-29 (post-#1675/#1677, post-NYCN-#28):
+     Action-item completion-receipt retrieval endpoint is now live
+     (`GET /v1/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt`,
+     #1675). Local HTTP proof loop closure for the action-item path
+     is recorded in #1676; the operator-authorized K3s NYCN smoke
+     proof closure against deployed image 91a63eec is recorded in
+     #1677. NYCN's drive-ingest operator ladder (#21–#28 in
+     fahertym/nycn) is now merged: parser → review → decisions →
+     publish dry-run → assignee binding → local publisher → local
+     proof runner → federation surface bridge → operator pilot
+     runbook + ladder checker. The procedural spine that walks
+     organizer material into ICN action-item proofs is real.
+     Phase 2 framing change: NYCN is the intended first
+     cooperative partner; not yet a formally committed pilot.
+     The next concrete step is **presenting the merged ladder
+     + ICN proof-loop machinery to NYCN organizers** to
+     formalize the pilot partnership. Subsequent gates are
+     partnership formalization and the first operator pilot
+     rehearsal against real (or fixture-equivalent) organizer
+     material. Phase 2 remains ⏳ until those happen and are
+     recorded. Issue #1646 still open; signal_rule and
+     obligation_lifecycle source paths remain RFC-gated. -->
 
 <!-- [sync edit] 2026-04-27 (post-#1663): Action-card runtime now has
      proof-bearing receipt loops for all three currently emitted source
@@ -30,15 +53,18 @@ Last Reviewed: 2026-04-27
      Aligned crate list, merged PRs, and metrics to verified repo state.
      Phase model unchanged — phase classification is governance territory (PR C). -->
 
-## Current status (2026-04-27 snapshot)
+## Current status (2026-04-29 snapshot)
 
-**Current phase:** Phase 2 — Pilot Launch (blocked on cooperative partners).
-Active execution: institutional-operability runtime (live charter activation, person-directory overlay, `/me/standing`, `authority_scope` plumbing) plus the action-card runtime (`/me/action-cards` endpoint with proof-loop linkage to `GovernanceDecisionReceipt` for proposal/vote, `ActionItemCompletionReceipt` for action_item/complete, and `MeetingAttendanceReceipt` for meeting/attend). NYCN package side dogfoods these via the institution-package boundary. Phase model classification is unchanged; see PHASE_PROGRESS.md for phase definitions.
+**Current phase:** Phase 2 — Pilot Launch. NYCN is the intended first cooperative partner (active partnership track, not yet a formally committed pilot). The next concrete step is presenting the merged drive-ingest ladder + ICN proof-loop machinery to NYCN organizers to formalize the pilot. Subsequent gates: partnership formalization, then first operator pilot rehearsal against real (or fixture-equivalent) organizer material. The Phase 2 *machinery* is in place end-to-end; what remains is the human procedure — pitch, formalize, rehearse — and recording each step.
+Active execution: institutional-operability runtime (live charter activation, person-directory overlay, `/me/standing`, `authority_scope` plumbing) plus the action-card runtime (`/me/action-cards` endpoint with proof-loop linkage to `GovernanceDecisionReceipt` for proposal/vote, `ActionItemCompletionReceipt` for action_item/complete, and `MeetingAttendanceReceipt` for meeting/attend). The action-item completion-receipt retrieval endpoint shipped as #1675; the local HTTP proof loop closure is documented in #1676 and the K3s smoke proof closure is recorded in #1677. NYCN's drive-ingest operator ladder (#21–#28 in `fahertym/nycn`) is now merged end-to-end, providing the procedural spine that walks organizer material into ICN action-item proofs. Phase model classification is unchanged; see PHASE_PROGRESS.md for phase definitions.
 
 ### Recently merged (since 2026-04-15)
 
 | PR | Title | Merged |
 |----|-------|--------|
+| #1677 | docs(dev): record K3s NYCN action-item receipt proof path | 2026-04-29 |
+| #1676 | docs(dev): record action-item completion receipt endpoint | 2026-04-29 |
+| #1675 | feat(governance): add completion-receipt endpoint for action items | 2026-04-29 |
 | #1663 | feat(governance): add meeting attendance receipts | 2026-04-27 |
 | #1662 | docs(state): record action-card runtime landing (#1659/#1660/#1661) | 2026-04-27 |
 | #1661 | feat(governance): add action item completion receipts | 2026-04-27 |
@@ -90,18 +116,32 @@ Active execution: institutional-operability runtime (live charter activation, pe
 
 | PR | Title | Branch | Status |
 |----|-------|--------|--------|
-| #1636 | chore(toolchain): upgrade Rust 1.88.0 → 1.95.0 | copilot/upgrade-rust-1-88-to-1-95 | Open — fmt fix pushed; tests running |
+| #1665 | deps(ts-sdk): bump the dev-dependencies group in /sdk/typescript with 2 updates | dependabot/npm_and_yarn/sdk/typescript/dev-dependencies-ea513a49e7 | Open — required CI green; `claude-review` 15-min timeout (never blocks merge); `mergeStateStatus: BEHIND` (sync against main before merge) |
 
 ### What landed since Phase 1 (Charter Engine)
 
-Action-card runtime (added 2026-04-27, all currently emitted source paths now proof-bearing — issue #1646 remains open for the two RFC-gated paths):
+Action-card runtime (added 2026-04-27 → 2026-04-29, all currently emitted source paths now proof-bearing — issue #1646 remains open for the two RFC-gated paths):
 - `GET /v1/gov/me/action-cards` member endpoint with closed source/action enums — #1659
 - Proposal/vote action card → `GovernanceDecisionReceipt` proof linkage, end-to-end test — #1660
 - `action_item`/`complete` source path emits append-only `ActionItemCompletionReceipt` (ADR-0026 Layer 2); persist-before-commit semantics; full-update handler routes status changes through receipt-bearing path — #1661
 - `meeting`/`attend` source path emits append-only `MeetingAttendanceReceipt` (ADR-0026 Layer 2) keyed by `(meeting_id, attendee_did)`; `Present` and `Remote` are receipt-bearing transitions, `Absent` is not; `recorded_by` is the authenticated caller (distinct from `attendee_did` for steward-recorded attendance); persist-before-commit semantics — #1663
+- `GET /v1/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt` retrieval endpoint — #1675; closes the proof loop on the read side so a holder shell that completed an `action_item`/`complete` action card can fetch the persisted `ActionItemCompletionReceipt` over HTTP instead of relying on in-process tests or on-disk Sled inspection. Authorization mirrors the rest of the action-item read surface (`governance:read` scope plus domain membership; the receipt's bound `domain_id` is asserted to match the path parameter so cross-domain probes are rejected).
+- Local HTTP proof loop closure recorded in `docs/dev/NYCN_ACTION_ITEM_RECEIPT_PATH.md` — #1676.
+- K3s smoke proof closure (operator-authorized, against deployed image `91a63eec`) recorded in `docs/dev/NYCN_K3S_PROOF_PATH.md` — #1677. K3s smoke records remain durable devnet proof artifacts; full namespaced teardown semantics are not yet specified (tracking issue planned).
 - Source paths currently emitted by `/me/action-cards`: `proposal`/`vote`, `meeting`/`attend`, `action_item`/`complete`
-- **Proof loop verified end-to-end for all three currently emitted source paths.**
+- **Proof loop verified end-to-end for all three currently emitted source paths, both locally and on K3s.**
 - Pending under #1646 (RFC-gated): `signal_rule` source path (gated on #1631); `obligation_lifecycle` source path (gated on #1634)
+
+NYCN drive-ingest operator ladder (added 2026-04-29; lives in `fahertym/nycn`):
+- Parser → review artifact (`drive-ingest-review/v1`) — NYCN #21, #22
+- Review decisions YAML (organizer-authored)
+- Publish dry-run (`drive-ingest-action-item-publish-dry-run/v1`) — NYCN #23
+- Assignee binding (`drive-ingest-action-item-publish-dry-run-bound/v1`) — NYCN #24
+- Local publisher (`drive-ingest-local-publish-plan/v1`; preflight default, execute fenced behind two operator flags + localhost-only `--gateway`) — NYCN #25
+- Local proof runner (`drive-ingest-local-proof/v1`; walks `/me/action-cards` → `PUT .../status` → `GET .../completion-receipt`) — NYCN #26
+- Federation surface bridge (`drive-ingest-federation-surface/v1`; pure file-in/file-out summary records keyed on the cross-node deterministic blake3 `record_hash` from `ActionItemCompletionReceipt`) — NYCN #27
+- Operator pilot runbook + no-network ladder checker — NYCN #28
+- The ladder defends a hard mutation boundary: every layer is either pure (no network) or localhost-only operator-gated. K3s mutation is never allowed by NYCN-side tools. ICN-side K3s exercise lives in `docs/dev/NYCN_K3S_PROOF_PATH.md` (#1677), not in the NYCN repo.
 
 Institutional-operability runtime (added 2026-04-22 → 2026-04-26):
 - Generic institution bootstrap package path — #1586

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -650,7 +650,7 @@ category = "status"
 status = "living"
 title = "ICN State (living doc)"
 description = "Living snapshot of repo layout, decisions, constraints, and current engineering status"
-last_updated = "2026-04-27"
+last_updated = "2026-04-29"
 owner = "matt"
 audiences = ["developers", "agents"]
 truth_class = "descriptive"
@@ -659,7 +659,7 @@ canonical = "yes"
 freshness = "current"
 domain_tags = ["status", "project"]
 recommended_action = "keep"
-last_reviewed = "2026-04-27"
+last_reviewed = "2026-04-29"
 
 [docs."docs/DOCUMENTATION_CONTROL_SYSTEM.md"]
 category = "reference"


### PR DESCRIPTION
## Summary

Truth-sync pass on `docs/STATE.md`, `docs/PHASE_PROGRESS.md`, and the matching `docs/registry.toml` entry, after the Phase 2 machinery landed end-to-end. Pure docs PR.

## What this records

- **#1675** shipped the action-item completion-receipt retrieval endpoint (`GET /v1/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt`). Closes the proof loop on the read side: a holder shell that completed an `action_item`/`complete` action card can now fetch the persisted `ActionItemCompletionReceipt` over HTTP. Same authorization as the rest of the action-item read surface (`governance:read` scope + domain membership; cross-domain probes rejected via `domain_id` binding check).
- **#1676** records the local HTTP proof loop closure for the action-item path in `docs/dev/NYCN_ACTION_ITEM_RECEIPT_PATH.md`.
- **#1677** records the operator-authorized K3s NYCN smoke proof closure against deployed image `91a63eec` in `docs/dev/NYCN_K3S_PROOF_PATH.md`. K3s smoke records remain durable devnet proof artifacts; full namespaced teardown semantics are not yet specified (tracking issue to follow).
- **NYCN #21–#28** in `fahertym/nycn` are now merged end-to-end. The procedural spine that walks organizer material into ICN action-item proofs is real: parser → review → decisions → publish dry-run → assignee binding → local publisher → local proof runner → federation surface bridge → operator pilot runbook + ladder checker. Hard mutation boundary defended by every layer: each is either pure (no network) or localhost-only operator-gated. K3s mutation is never allowed by NYCN-side tools.

## Phase 2 framing change

The substantive shift in this PR (and the part most likely to need careful read):

> NYCN is the **intended** first cooperative partner — active partnership track, not yet a formally committed pilot. We are no longer "blocked on partner identification". The next concrete step is **presenting the merged drive-ingest ladder + ICN proof-loop machinery to NYCN organizers** to formalize the pilot. Subsequent gates are partnership formalization, then first operator pilot rehearsal against real (or fixture-equivalent) organizer material.

Phase 2 remains ⏳. None of the recent landings flip it to ✅ on their own; the gates above are not engineering gates.

## What did NOT change

- No runtime change. No code touched.
- No website change. No `docs/website` tree touched.
- No NYCN package change.
- No K3s mutation.
- **No Phase 2 completion claim.** Phase 2 remains ⏳.
- **No claim of "live federation integration".** That is the next Fork A bridge, deliberately not bundled here.
- The two RFC-gated action-card source paths (`signal_rule`, `obligation_lifecycle`) remain open under #1646 and are independent of the partner gate.

## Validation

- [x] `python3 docs/scripts/doc_control_check.py --strict` → passed (36 pre-existing warnings, none introduced by this PR).
- [x] `git diff --check` → clean.
- [x] `docs/registry.toml`: `docs/STATE.md` `last_updated` and `last_reviewed` bumped to `2026-04-29`. `PHASE_PROGRESS.md` is not registered in `registry.toml` so requires no entry change.