### PR TITLE
docs(strategy): truth-sync ICN-Roadmap-Live to post-#1680 reality

### DIFF
--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -1355,10 +1355,11 @@ audiences = ["architects", "stakeholders", "grant-reviewers"]
 category = "strategy"
 status = "living"
 title = "ICN Live Roadmap"
-description = "Current sprint and quarterly priorities, immediate milestones, and dependencies"
-last_updated = "2026-03-21"
+description = "Long-arc roadmap and rationale companion that points at STATE.md / PHASE_PROGRESS.md as canonical current-state truth. Not a per-PR changelog."
+last_updated = "2026-04-29"
 owner = "matt"
 audiences = ["team", "stakeholders"]
+last_reviewed = "2026-04-29"
 
 [docs."docs/strategy/ICN-Sprint-March17.md"]
 category = "strategy"

--- a/docs/strategy/ICN-Roadmap-Live.md
+++ b/docs/strategy/ICN-Roadmap-Live.md
@@ -48,24 +48,25 @@ recorded.
 
 The cadence formerly tracked here as "Governance Dispatch
 Tranches" continues to advance through executor-wiring work;
-its per-tranche status now lives in
-`docs/architecture/agent-handoff-current.md` and is no longer
+its per-tranche status is reflected in `docs/STATE.md`,
+`docs/PHASE_PROGRESS.md`, and the git log, and is no longer
 re-published in this file. The 2026-04-08 tranche table that
 was here previously is preserved below in the "Historical"
 section for continuity.
 
 > **Rule:** Do not treat the per-sprint sections below as
 > current status. They are historical only. For current state,
-> read `docs/STATE.md`, `docs/PHASE_PROGRESS.md`, git log, and
-> `docs/architecture/agent-handoff-current.md`.
+> read `docs/STATE.md`, `docs/PHASE_PROGRESS.md`, and the git
+> log.
 
 ---
 
 ## Historical: 2026-04-08 tranche snapshot
 
 The Governance Dispatch Tranche table as it stood at the prior
-2026-04-08 sync, retained for continuity. Current tranche status
-lives in `docs/architecture/agent-handoff-current.md`.
+2026-04-08 sync, retained for continuity. Current tranche
+status is reflected in `docs/STATE.md`, `docs/PHASE_PROGRESS.md`,
+and the git log.
 
 | Tranche | Scope | Status (as of 2026-04-08) |
 |---|---|---|

--- a/docs/strategy/ICN-Roadmap-Live.md
+++ b/docs/strategy/ICN-Roadmap-Live.md
@@ -1,29 +1,73 @@
 # ICN Roadmap — Live
 
-*Last updated: 2026-04-08 (Post-Sprint 28 — Governance Dispatch Tranches)*
+*Last updated: 2026-04-29 (post-#1680, post-NYCN-#34)*
 
-> This document tracks sprint-level progress against the ICN development roadmap.
-> For architecture and phase history, see `docs/ARCHITECTURE.md` and `docs/PHASE_HISTORY.md`.
+> This document tracks long-arc planning context for ICN development.
+> For **canonical current state and recently-merged work**, read
+> `docs/STATE.md` and `docs/PHASE_PROGRESS.md` — those are
+> truth-synced and re-bumped with every state-changing PR.
+> This file is a roadmap-and-rationale companion that points at
+> them; it is not a per-PR changelog.
+> For architecture and phase history, see `docs/ARCHITECTURE.md`
+> and `docs/PHASE_HISTORY.md`.
 
 ---
 
-## Current state (2026-04-08)
+## Current state (2026-04-29 snapshot)
 
-**Active workstream:** Post-Sprint-28 governance dispatch tranches. The sprint-numbered planning cadence ended with Sprint 28; active work is now organized as sequential "Tranches" against the executor-wiring and ADR-0016 closure epics.
+**Active workstream:** Phase 2 — Pilot Launch. NYCN is the
+intended first cooperative partner (active partnership track,
+not yet a formally committed pilot). The Phase 2 *machinery* is
+in place end-to-end; what remains is the human procedure —
+present the merged ladder + ICN proof-loop machinery to NYCN
+organizers, formalize, rehearse — and recording each step.
 
-**What landed between Sprint 23 and the current work (summarized; see git log for detail):**
+**Canonical source of truth:** `docs/STATE.md` and
+`docs/PHASE_PROGRESS.md`. Those docs name every recently-merged
+PR with its date and effect. This file does not duplicate
+their tables.
 
-- **Sprint 24** — Commons-compute spine. Two-tier trust threshold for pool admission, stale participant expiry, V1 scheduling-time credit enforcement floor. Closed 2026-03-23. See `docs/strategy/sprint-24-close.md`.
-- **Sprint 25** — ADR-0016 Phase 2 work. Closed via `chore(ops): close sprint 25, open sprint 26` (commit `92de849e`).
-- **Sprint 26** — Interim tranche; see commits between `92de849e` and Sprint 27 opening.
-- **Sprint 27** — Demo-Ready + Compute Story. Flow 5 commons compute trust-gated admission, demo polish, website five-flow update, summit proposal. Key commits: `1600a1fb`, `b1ba40c7`, `cb22e1e5`, `8ab59cff`.
-- **Sprint 28** — Gossip fan-out fix (compute task delivery restored). Commit `4ae8401f` (PR #1419).
+**What changed between this doc's prior 2026-04-08 sync and the
+current 2026-04-29 sync** (high-level only; see `STATE.md` for
+the per-PR record):
 
-**Governance Dispatch Tranches (post-Sprint 28, active):**
+- **Institutional-operability runtime** landed across 2026-04-22 → 2026-04-26: live charter activation endpoint (#1624), person-directory overlay for bootstrap role assignment (#1626), `GET /me/standing` read model (#1627), `authority_scope` plumbed end-to-end through `assign_role` (#1630), generic institution bootstrap package path (#1586), bootstrap-apply 409 idempotency (#1617), persistent governance domains across gateway restart (#1621), feedback/support doctrine + ADR canonicalization (#1637).
+- **Action-card runtime** landed 2026-04-27 with proof-bearing receipt loops for all currently emitted source paths: `GET /v1/gov/me/action-cards` (#1659), proposal/vote → `GovernanceDecisionReceipt` (#1660), `action_item`/`complete` → `ActionItemCompletionReceipt` (#1661), `meeting`/`attend` → `MeetingAttendanceReceipt` (#1663). Issue #1646 remains open for the two RFC-gated paths (`signal_rule`, `obligation_lifecycle`).
+- **Action-item completion-receipt retrieval** shipped 2026-04-29: `GET /v1/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt` (#1675). Local HTTP proof loop closure documented in #1676. Operator-authorized K3s NYCN smoke proof closure against deployed image `91a63eec` recorded in #1677.
+- **Truth-sync docs** updated in #1678 and #1680 to reflect every landing above plus the new cooperator-developer prep doc at `docs/strategy/COOPERATIVE_DEVELOPER_DISCOVERY_BRIEF.md`.
+- **NYCN side**: the drive-ingest operator ladder shipped end-to-end in `fahertym/nycn` PRs #21–#34 (parser → review → decisions YAML → publish dry-run → assignee binding → local publisher → local proof runner → federation surface bridge → operator pilot runbook + ladder checker → organizer briefing + simple summit demo → start-here onboarding pass → one-command local preflight runner → whole-NYCN operating-surfaces inventory + Google-Groups boundary policy → communication-groups directory tool → operating-surfaces directory tool). The ladder defends a hard mutation boundary: every layer is either pure (no network) or localhost-only operator-gated. K3s mutation is never allowed by NYCN-side tools; ICN-side K3s exercise lives under `docs/dev/NYCN_K3S_PROOF_PATH.md` (#1677).
+- **Issue #1679** filed 2026-04-29 for K3s/devnet smoke artifact cleanup / teardown semantics. Inventory-only as the suggested first concrete step.
 
-The canonical source of truth for tranche status is `docs/architecture/agent-handoff-current.md` and git commit messages tagged `Tranche N`. At time of writing:
+**Phase 2 framing:** NYCN is the intended first cooperative
+partner. The next concrete step is presenting the merged ladder
++ ICN proof-loop machinery to NYCN organizers to formalize the
+pilot. Subsequent gates: partnership formalization, then first
+operator pilot rehearsal against real (or fixture-equivalent)
+organizer material. Phase 2 stays ⏳ until those happen and are
+recorded.
 
-| Tranche | Scope | Status |
+The cadence formerly tracked here as "Governance Dispatch
+Tranches" continues to advance through executor-wiring work;
+its per-tranche status now lives in
+`docs/architecture/agent-handoff-current.md` and is no longer
+re-published in this file. The 2026-04-08 tranche table that
+was here previously is preserved below in the "Historical"
+section for continuity.
+
+> **Rule:** Do not treat the per-sprint sections below as
+> current status. They are historical only. For current state,
+> read `docs/STATE.md`, `docs/PHASE_PROGRESS.md`, git log, and
+> `docs/architecture/agent-handoff-current.md`.
+
+---
+
+## Historical: 2026-04-08 tranche snapshot
+
+The Governance Dispatch Tranche table as it stood at the prior
+2026-04-08 sync, retained for continuity. Current tranche status
+lives in `docs/architecture/agent-handoff-current.md`.
+
+| Tranche | Scope | Status (as of 2026-04-08) |
 |---|---|---|
 | 9 | TrustThreshold suspension enforcement | ✅ Merged |
 | 10 | BondIssuance treasury mutation | ✅ Merged |
@@ -36,9 +80,26 @@ The canonical source of truth for tranche status is `docs/architecture/agent-han
 | 17 | UpdateJurisdictionTier executor | 🚧 Local on `fix/steward-bond-semantics` (icn-dev) |
 | 18 | TerminateClearing + RevokeVouch executors | ⏳ Next |
 
-An overlaid "Agent Handoff Tranche" track (`I`, `II`, `III`, ...) in `docs/architecture/agent-handoff-current.md` covers ADR-0016 closures (surplus reserves consumption, charter view persistence, etc.) and advances on its own cadence. Tranches I, II, and III all closed 2026-04-08.
+The overlaid "Agent Handoff Tranche" track (`I`, `II`, `III`,
+...) covers ADR-0016 closures (surplus reserves consumption,
+charter view persistence, etc.) and advances on its own
+cadence. Tranches I, II, and III closed 2026-04-08.
 
-> **Rule:** Do not treat the per-sprint sections below as current status. They are historical only. For current state, read this block, git log, and `docs/architecture/agent-handoff-current.md`.
+---
+
+## Pre-2026-04-08: completed sprints
+
+The per-sprint summary that historically lived in this file
+covers sprints 22 through 28 (Meaning Firewall completion
+through Gossip fan-out fix). Retained below for continuity but
+**not authoritative** — the canonical record of completed work
+is `docs/PHASE_HISTORY.md` plus git log.
+
+- **Sprint 24** — Commons-compute spine. Two-tier trust threshold for pool admission, stale participant expiry, V1 scheduling-time credit enforcement floor. Closed 2026-03-23. See `docs/strategy/sprint-24-close.md`.
+- **Sprint 25** — ADR-0016 Phase 2 work. Closed via `chore(ops): close sprint 25, open sprint 26` (commit `92de849e`).
+- **Sprint 26** — Interim tranche; see commits between `92de849e` and Sprint 27 opening.
+- **Sprint 27** — Demo-Ready + Compute Story. Flow 5 commons compute trust-gated admission, demo polish, website five-flow update, summit proposal. Key commits: `1600a1fb`, `b1ba40c7`, `cb22e1e5`, `8ab59cff`.
+- **Sprint 28** — Gossip fan-out fix (compute task delivery restored). Commit `4ae8401f` (PR #1419).
 
 ---
 


### PR DESCRIPTION
## Summary

The Live roadmap was last touched 2026-04-08 and its tranche table stops at Tranche 11. `STATE.md` and `PHASE_PROGRESS.md` have been truth-synced multiple times since (most recently #1680 on 2026-04-29), and the Live roadmap has fallen out of step. A careful external reader landing on this file would read it as a stale signal.

This PR repositions `ICN-Roadmap-Live.md` as a **long-arc roadmap and rationale companion** that points at `STATE.md` + `PHASE_PROGRESS.md` as canonical current-state truth, rather than trying to be its own per-PR record.

## What changed

- `docs/strategy/ICN-Roadmap-Live.md`:
  - Header date 2026-04-08 → 2026-04-29
  - New "Current state (2026-04-29 snapshot)" section with a high-level summary of what shipped between the prior sync and now (institutional-operability runtime, action-card runtime, completion-receipt endpoint, K3s smoke proof closure, state truth-sync, NYCN drive-ingest ladder #21–#34, K3s teardown issue #1679 filed).
  - Phase 2 framing restated consistently with `STATE.md` and the cooperator-discovery brief in #1680: NYCN is the intended first cooperative partner; not yet a formally committed pilot; next concrete step is presenting the merged ladder to NYCN organizers.
  - 2026-04-08 tranche table preserved verbatim under a new "Historical" subsection.
  - Per-sprint detail blocks (sprints 22–28) preserved unchanged below; existing "do not treat as current status" rule still in force.
- `docs/registry.toml`: entry's `last_updated` bumped 2026-03-21 → 2026-04-29; description rewritten to reflect the file's new positioning; `last_reviewed` added.

## Validation

- [x] `python3 docs/scripts/doc_control_check.py --strict` → passed (739 markdown files; 36 pre-existing yaml-mismatch warnings, **none** introduced).
- [x] `git diff --check` → clean.
- [x] Vocabulary scan (`\b(payment|currency|wallet|balance|paid)\b`) on the changed files excluding the `Concurrency` false-positive: zero matches.

## What did NOT change

- No runtime change. No code touched.
- No website tree touched.
- No claim of live federation integration.
- No production-readiness or Phase 2 completion claim.
- No re-publication of the per-tranche status table that lives in `docs/architecture/agent-handoff-current.md`.
- The cooperator-discovery brief (`docs/strategy/COOPERATIVE_DEVELOPER_DISCOVERY_BRIEF.md`) is unchanged; this PR points at it from the truth-sync narrative.