### PR TITLE
docs(pilots): add NYCN organizer-facing boundary package

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -350,6 +350,17 @@ Contributor onboarding materials:
 **Observability (`observability/`):**
 - Metrics, logging, and tracing
 
+### Pilot Outreach (`pilots/`)
+
+Organizer-facing pilot materials. Honest scope-of-now framing; not pitch decks. Defer to [STATE.md](STATE.md) and [PHASE_PROGRESS.md](PHASE_PROGRESS.md) for current truth.
+
+- [nycn-boundary-brief.md](pilots/nycn-boundary-brief.md) - What ICN can demonstrate now, what it cannot honestly claim yet, what NYCN organizers would need to validate, what is explicitly not being asked
+- [nycn-demo-script.md](pilots/nycn-demo-script.md) - Step-by-step organizer-facing demo flow against a localhost ICN gateway
+- [nycn-organizer-asks.md](pilots/nycn-organizer-asks.md) - Bounded set of validation questions for NYCN organizers; includes explicit non-asks
+- [pilot-proposal-template.md](pilots/pilot-proposal-template.md) - Template for approaching potential pilot communities
+- [hosted-approach.md](pilots/hosted-approach.md) - Approach for hosted cooperative pilot deployments
+- [decision_registry_treasury_vote.md](pilots/decision_registry_treasury_vote.md) - Economic receipt chain implementation in pilot
+
 ### Pilot Programs (`internal/pilots/`)
 
 Real-world pilot deployment documentation:

--- a/docs/pilots/nycn-boundary-brief.md
+++ b/docs/pilots/nycn-boundary-brief.md
@@ -1,0 +1,87 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-04-29
+---
+
+# NYCN Boundary Brief
+
+> **Audience.** NYCN organizers and stewards considering whether ICN is worth a closer look as the substrate underneath their drive-ingest operator ladder. Also any ICN-side person preparing for that conversation.
+>
+> **What this is.** An honest scope-of-now brief: what ICN can demonstrate today, what it cannot honestly claim yet, what NYCN organizers would need to validate before a pilot rehearsal, and what is **not** being asked of NYCN at this stage.
+>
+> **What this is not.** A pitch. A partnership ask. A request for commitment. A claim of capabilities that have not been built. A request to put NYCN data into a remote system.
+>
+> **Source of current truth.** [`docs/STATE.md`](../STATE.md) and [`docs/PHASE_PROGRESS.md`](../PHASE_PROGRESS.md). If anything in this brief disagrees with those, treat those as authoritative.
+
+## What ICN can demonstrate now
+
+These surfaces exist in the codebase, are exercised in tests, and have been walked end-to-end at least once:
+
+- **A decision-to-action-to-receipt loop.** A governance domain accepts a proposal, the accepted proposal materializes an action item, a member completes the action, and the system writes an append-only `ActionItemCompletionReceipt` that can be retrieved over HTTP at `GET /v1/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt`.
+- **The same loop for two adjacent paths.** Proposal/vote produces a `GovernanceDecisionReceipt`. Meeting attendance (`Present` or `Remote`) produces a `MeetingAttendanceReceipt`. Both follow the same provenance discipline.
+- **A member-facing read model.** `GET /v1/gov/me/standing` returns the caller's identity, memberships, roles, and capabilities. `GET /v1/gov/me/action-cards` returns the things waiting on them.
+- **Charter activation against a running gateway.** A charter (CCL YAML) can be ratified through governance and become live constraint that the kernel enforces — without touching the kernel's source or restarting the daemon.
+- **The local proof loop runs against a localhost gateway.** Documented in [`docs/dev/NYCN_ACTION_ITEM_RECEIPT_PATH.md`](../dev/NYCN_ACTION_ITEM_RECEIPT_PATH.md). No remote cluster is involved.
+- **The same loop has been exercised once on K3s** under operator authorization, against deployed image `91a63eec`. Documented in [`docs/dev/NYCN_K3S_PROOF_PATH.md`](../dev/NYCN_K3S_PROOF_PATH.md).
+- **The NYCN drive-ingest operator ladder, in the separate `fahertym/nycn` repo,** walks organizer drive content through parser → review → decisions → publish dry-run → assignee binding → local publisher → local proof runner → federation surface bridge → operator pilot runbook + ladder checker, and adjacent operator-facing tools. Per [`docs/STATE.md`](../STATE.md), NYCN #21–#32 are merged; NYCN #33 was open at last sync. The ladder is pure file-in / file-out or localhost-only operator-gated.
+- **A documented mutation boundary.** No NYCN-side tool ever mutates a remote ICN cluster. K3s mutation is only ever performed ICN-side, under operator authorization, and is recorded in the proof-path runbooks above.
+
+## What ICN cannot honestly claim yet
+
+These are in the repo as code or design surfaces, but they are not finished products. Anyone presenting ICN to organizers should not represent them as such:
+
+- **A live, multi-cooperative production network.** ICN runs on a homelab K3s cluster. There is no live multi-cooperative production deployment. No member currently logs in to a hosted cooperative on ICN.
+- **A formal NYCN pilot.** NYCN is the *intended* first cooperative partner; the partnership is active and in good faith but not formalized. There is no signed agreement, no committed launch date, no pilot contract.
+- **Live federation between two cooperatives.** No two cooperatives currently federate over ICN in production. The federation primitives exist as code; cross-org coordination is Phase 3 in [`docs/PHASE_PROGRESS.md`](../PHASE_PROGRESS.md), not Phase 2.
+- **A finished mobile app.** The React Native SDK and mobile member-app work exist. Treat the mobile UX spec at [`docs/mobile/icn-mobile-ux-spec-v1.md`](../mobile/icn-mobile-ux-spec-v1.md) as a build-facing spec, not a shipped product.
+- **A complete action-card runtime.** Three of the five planned source paths are proof-bearing today. Two (`signal_rule`, `obligation_lifecycle`) are RFC-gated under [#1646](https://github.com/InterCooperative-Network/icn/issues/1646).
+- **Defined K3s teardown semantics.** Smoke artifacts persist on the cluster; namespaced teardown is not yet specified ([#1679](https://github.com/InterCooperative-Network/icn/issues/1679)).
+- **A one-command, non-technical deployment per cooperative.** That is a Phase 2 deliverable that has not shipped.
+- **A polished pilot onboarding guide for non-technical members.** Same — not yet shipped.
+
+## What NYCN organizers would need to validate
+
+If a pilot rehearsal eventually happens, these are the things only NYCN organizers can answer. ICN cannot pre-answer them:
+
+- **Workflow integrity.** Does the path from "drive content shows up" → "review" → "decisions" → "action items in ICN" actually match how NYCN organizers do this work today? Is the parser seeing the right shape of organizer artifacts? Are the review boundaries the right human-review boundaries?
+- **Source-of-truth alignment.** When the ladder produces a `drive-ingest-review/v1` artifact, does it line up with what an organizer would have written by hand? Where are the silent disagreements? Are there organizer practices the ladder is silently flattening?
+- **Authority alignment.** When an `action_item` action card lands in front of a member, is the right person on the hook? Is the assignee binding capturing real responsibility, or is it inventing it?
+- **Receipt usefulness.** Once the proof loop closes for an action item, is the receipt content something an NYCN organizer would actually want — for board reports, for member legibility, for recordkeeping?
+- **Stewardship fit.** Is the operator-gated, two-flag-required local publisher acceptable as the *only* path that ever produces remote effects? Or do organizers need a different boundary?
+
+These are questions that can only be answered by NYCN people running the ladder against real (or fixture-equivalent) NYCN material, on their own machines, on their own time, on their own terms.
+
+## What this conversation is **not** asking
+
+These are explicit non-asks. If they come up in conversation, the answer is "we are not asking for that."
+
+- **No partnership commitment.** Not on the first conversation, not on the second, not on the third unless NYCN organizers explicitly initiate it.
+- **No data transfer.** No NYCN-controlled material moves into an ICN-hosted system. The mutation boundary is the load-bearing safety property.
+- **No infrastructure handover.** ICN does not propose to host or run anything for NYCN. If anything ever runs in production on NYCN's behalf, it runs on hardware NYCN controls.
+- **No re-platforming.** The drive-ingest ladder runs against the existing NYCN drive workflow; it does not propose moving NYCN off Google Drive, off Google Groups, off existing operator tooling.
+- **No agreement to be a public reference.** NYCN being the "intended first cooperative partner" is internal-language for "we are talking to NYCN organizers in good faith." It is not a marketing relationship.
+- **No request to validate ICN as an organization.** ICN is being built whether or not NYCN engages further. The conversation is about whether the substrate is useful for NYCN, not whether NYCN endorses ICN.
+
+## What an honest "next step" looks like
+
+If the conversation goes well, the next step is **another conversation**, not a deal. A reasonable second-conversation outcome looks like:
+
+- An NYCN organizer tries the local preflight runner on their own machine, against their own (or fixture-equivalent) drive content, and tells us what they see.
+- Or an organizer reads `START_HERE.md` / `ORGANIZER_QUICKSTART.md` from `fahertym/nycn` and tells us where the language lands and where it doesn't.
+- Or an organizer points at one specific NYCN workflow and asks "would the ladder make sense here?" and we work through that one workflow honestly.
+- Or an organizer says "this is not a fit for NYCN right now, but here is what would have to be true," which is also useful.
+
+A great second conversation answers one or two specific NYCN workflow questions. It does not produce a partnership announcement.
+
+## Pointers
+
+| For | See |
+|---|---|
+| Current ICN truth | [`docs/STATE.md`](../STATE.md), [`docs/PHASE_PROGRESS.md`](../PHASE_PROGRESS.md) |
+| ICN runtime surfaces | [`docs/reference/project-index/runtime-surface-map.md`](../reference/project-index/runtime-surface-map.md) |
+| ICN/NYCN boundary in detail | [`docs/reference/project-index/pilot-and-nycn-map.md`](../reference/project-index/pilot-and-nycn-map.md) |
+| What ICN is for (doctrine) | [`docs/architecture/THE_COMMONS.md`](../architecture/THE_COMMONS.md) |
+| ICN-side proof loops | [`docs/dev/NYCN_ACTION_ITEM_RECEIPT_PATH.md`](../dev/NYCN_ACTION_ITEM_RECEIPT_PATH.md), [`docs/dev/NYCN_K3S_PROOF_PATH.md`](../dev/NYCN_K3S_PROOF_PATH.md) |
+| Companion demo script | [`nycn-demo-script.md`](nycn-demo-script.md) |
+| Companion organizer asks | [`nycn-organizer-asks.md`](nycn-organizer-asks.md) |

--- a/docs/pilots/nycn-demo-script.md
+++ b/docs/pilots/nycn-demo-script.md
@@ -1,0 +1,146 @@
+---
+Status: operational
+Canonical: no
+Last Reviewed: 2026-04-29
+---
+
+# NYCN Demo Script
+
+> **Audience.** ICN-side people walking an NYCN organizer (or small group of organizers) through what ICN can demonstrate today. Not a forward-this deck.
+>
+> **What this is.** A step-by-step organizer-facing demo flow that focuses on action cards, the proof loop, receipts, and provenance — and is honest about the current limits.
+>
+> **What this is not.** A sales pitch. A technical deep-dive. A claim that any of this is finished. A presentation about ICN-the-organization. A pilot proposal.
+>
+> **Source of current truth.** [`docs/STATE.md`](../STATE.md) and [`docs/PHASE_PROGRESS.md`](../PHASE_PROGRESS.md). If anything in this script implies more than those say, the script is wrong.
+
+## Goals of the demo
+
+This demo has three goals, in priority order:
+
+1. **Build trust by being concrete.** Show a real surface, with real receipts, against a real localhost gateway. No slides, no abstractions, no roadmap-as-product.
+2. **Build trust by being honest.** Name the limits while you are showing the strengths. The limits are part of the demo.
+3. **Make space for organizer questions.** The demo should leave more time for the organizer to talk than for ICN-side to talk. If that ratio inverts, stop the demo.
+
+If a fourth goal accidentally creeps in — selling, recruiting, committing, signing — pause, name it, drop it, and resume from the last checkpoint.
+
+## Setup before the demo
+
+- Demo runs against a localhost ICN gateway. **No remote cluster.** No NYCN material is ever sent anywhere.
+- The NYCN drive-ingest ladder is pre-staged with a fixture (or, with explicit organizer consent, a fragment of real organizer material the organizer brings).
+- ICN-side person has read [`nycn-boundary-brief.md`](nycn-boundary-brief.md) within the last week.
+- ICN-side person has [`nycn-organizer-asks.md`](nycn-organizer-asks.md) open in another window.
+- A clean terminal, a clean browser tab pointed at the localhost gateway, and a small notepad for what the organizer says (not what the ICN-side person plans to say).
+
+## One-paragraph framing to open with
+
+> "What I'm going to show you is the path from a decision being recorded, to a member being asked to do something, to a tamper-evident receipt of that thing being done. That is the loop. Most of what is interesting is the receipts and where they come from. I'll also show what the ladder does to your drive content along the way, and what it does *not* do — the boundaries are deliberate."
+
+That is the whole opening. If you find yourself adding a "and ICN is also..." sentence, stop.
+
+## Step-by-step
+
+Each step has three parts: **show**, **say**, and **don't say**. The "don't say" entries are not stylistic — they are scope discipline.
+
+### Step 1 — The mutation boundary, said up front
+
+**Show:** Nothing yet. This is verbal.
+
+**Say:**
+> "Before we run anything, the rule that's load-bearing for this whole demo: nothing I run on this machine can change anything on a remote cluster. Every step is either pure (no network) or talks only to a gateway running on this laptop. If I wanted to publish to a real cluster, I'd need two operator flags I don't have. That's the boundary."
+
+**Don't say:** Anything aspirational about future federation, future cluster, future remote anything. The boundary is the trust mechanism. Don't undercut it.
+
+### Step 2 — Drive content lands as a review artifact
+
+**Show:** Run the parser against the staged fixture (or organizer-provided material). It produces a `drive-ingest-review/v1` artifact — file out, no network.
+
+**Say:**
+> "This is what the ladder sees. It's a structured view of what was in the drive content. A human — an organizer — reviews this and writes the decisions YAML by hand. That is on purpose. The ladder does not invent decisions."
+
+**Don't say:** That this replaces organizer judgment. That this is "automation." That the ladder "understands" organizer material. It does not. It surfaces structure and waits for a human.
+
+### Step 3 — Decisions YAML → publish dry-run
+
+**Show:** Run the publish dry-run against the (organizer-authored or fixture) decisions YAML. It emits `drive-ingest-action-item-publish-dry-run/v1` — file out.
+
+**Say:**
+> "Before anything is published, the ladder shows the organizer exactly what would be created if they ran it for real. Nothing has happened yet. This is the second human-review boundary. If the dry-run looks wrong, the organizer rewrites the decisions YAML and runs it again."
+
+**Don't say:** "And then the system publishes automatically." It does not. The next two steps are operator-gated.
+
+### Step 4 — Local proof loop on a localhost gateway
+
+**Show:** Start an ICN gateway on localhost. Walk the local proof runner: `GET /me/action-cards` to see the caller's pending action cards → `PUT .../status` to mark one complete → `GET .../completion-receipt` to retrieve the receipt the system just wrote.
+
+**Say:**
+> "These are real ICN endpoints. The action card came from a real proposal in a real governance domain on this gateway. When the action card is marked complete, the gateway writes an append-only receipt — keyed by domain and item, signed in a way another node could verify. That receipt is what makes the loop *evidence-bearing* instead of just *claim-bearing*. The retrieval endpoint is the read-side proof."
+
+**Don't say:** "Our distributed ledger." "Tokens." "Blockchain." "Wallet." "Currency." "Account balance." None of those describe what this is. The receipt is evidentiary, not transactional.
+
+### Step 5 — Show the receipt content honestly
+
+**Show:** Open the receipt JSON. Walk the fields: `domain_id`, `item_id`, `record_hash`, completion metadata, signing metadata.
+
+**Say:**
+> "The receipt names what was done, in which domain, by which identity. It's the kind of record an organizer could put in a board report and have someone else check it without asking us. That is the whole point. If the receipt looked impressive but couldn't be checked, it would be useless."
+
+**Don't say:** "And the receipt is then propagated through the federation." It is not. Federation propagation is Phase 3. In this demo it is local-only.
+
+### Step 6 — Member standing, briefly
+
+**Show:** `GET /v1/gov/me/standing` against the localhost gateway, as the same identity. Walk the response: identity, memberships, roles, currently selected scope.
+
+**Say:**
+> "This is the answer to 'who am I, where do I belong, what can I do' — for the same person who just completed the action item. The action card runtime and the standing read model are aimed at the same person, with the same identity, in the same domain. That alignment is the substrate under any organizer-facing UI we'd ever build."
+
+**Don't say:** "And here's our member portal." There isn't one to show today. The endpoint exists; the polished surface above it does not.
+
+### Step 7 — Stop, and name the limits
+
+**Show:** Nothing. This step is verbal and is the most important one.
+
+**Say:**
+> "Three things this demo did not show, on purpose. One: live federation between two cooperatives — that is Phase 3, not built. Two: a finished member app — there's a React Native build in progress, not shippable. Three: a one-command per-cooperative deployment — that's a Phase 2 deliverable that hasn't shipped. I'm telling you this so the demo doesn't oversell. What you saw is real; the rest is honest about not being there yet."
+
+**Don't say:** Roadmap timelines. Promised dates. "By Q3 we will have..." None of that.
+
+### Step 8 — Hand the conversation to the organizer
+
+**Show:** Close the terminal. Open the notepad.
+
+**Say:**
+> "That's the demo. The most useful thing now is for me to listen — does any of what you saw map to a real NYCN problem? Does any of it map to a workflow you'd want different? What did I show that doesn't fit, and what didn't I show that you wish I had?"
+
+Then stop talking. Read [`nycn-organizer-asks.md`](nycn-organizer-asks.md) ahead of the meeting; bring the questions in case the conversation needs prompts. Otherwise, listen.
+
+## Demo timing budget
+
+| Section | Soft budget |
+|---|---|
+| Steps 1–3 (boundary + drive ingest + dry-run) | 8–10 minutes |
+| Step 4–5 (proof loop + receipt) | 8–10 minutes |
+| Step 6 (member standing) | 3–5 minutes |
+| Step 7 (limits) | 3–5 minutes |
+| Step 8 (organizer talks, ICN-side listens) | the rest of the time, ideally 50%+ |
+
+If the demo runs long, drop step 6 first, then step 5's receipt-fields walk. Never drop step 1 or step 7.
+
+## Hard rules during the demo
+
+- **No promises.** Not about timelines, not about features, not about commitments.
+- **No proposals.** This demo is not a pilot proposal. If the conversation moves toward "so when do we start," redirect to "let's keep it as a second conversation."
+- **No NYCN data leaves the room.** Even if an organizer wants to show real material, it stays on their machine or a shared screen. Nothing is captured, copied, or sent anywhere.
+- **No vocabulary slips.** Avoid: payment, currency, wallet, balance, blockchain, token, web3. Prefer: settlement, unit, identity, position, obligation, allocation, receipt, provenance.
+- **If anything goes sideways**, stop the demo, name what went sideways, do not fake recovery. A demo that errors and is named honestly is more useful than a demo that succeeds and oversells.
+
+## Pointers
+
+| For | See |
+|---|---|
+| Honest scope-of-now | [`nycn-boundary-brief.md`](nycn-boundary-brief.md) |
+| Organizer-facing questions | [`nycn-organizer-asks.md`](nycn-organizer-asks.md) |
+| ICN-side runtime surfaces | [`docs/reference/project-index/runtime-surface-map.md`](../reference/project-index/runtime-surface-map.md) |
+| Local proof-loop runbook | [`docs/dev/NYCN_ACTION_ITEM_RECEIPT_PATH.md`](../dev/NYCN_ACTION_ITEM_RECEIPT_PATH.md) |
+| K3s proof-loop runbook | [`docs/dev/NYCN_K3S_PROOF_PATH.md`](../dev/NYCN_K3S_PROOF_PATH.md) |
+| What can / cannot be shown | [`docs/reference/project-index/show-readiness-map.md`](../reference/project-index/show-readiness-map.md) |

--- a/docs/pilots/nycn-organizer-asks.md
+++ b/docs/pilots/nycn-organizer-asks.md
@@ -1,0 +1,93 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-04-29
+---
+
+# NYCN Organizer Asks
+
+> **Audience.** ICN-side people preparing for a conversation with NYCN organizers, and the organizers themselves if they want to see what we are actually trying to learn.
+>
+> **What this is.** A bounded set of questions to ask NYCN organizers — workflow validation, source/data validation, pilot-readiness — without assuming any commitment.
+>
+> **What this is not.** A partnership ask. A vendor questionnaire. A list of features to pitch. A way to qualify NYCN as a customer. A request that could only be answered by NYCN saying yes to a pilot.
+>
+> **Frame.** Every question here is something we want to **learn** from NYCN organizers, not something we want them to **decide**. If a question reads as a sales question, it is wrong and should be rewritten.
+>
+> **Source of current truth.** [`docs/STATE.md`](../STATE.md) and [`docs/PHASE_PROGRESS.md`](../PHASE_PROGRESS.md). Use these as the authoritative reference for any specific claim about ICN's current state.
+
+## Why we are asking these
+
+NYCN is the intended first cooperative partner for ICN's Phase 2 — active partnership track, not a formal pilot. The drive-ingest operator ladder in `fahertym/nycn` is a procedural spine for walking organizer material into ICN action-item proofs. Before that spine is exercised against real organizer work, organizers need to validate that the spine matches the work.
+
+Only NYCN organizers can answer most of these questions. ICN-side cannot pre-answer them.
+
+## Workflow validation
+
+The point of these is to find out whether the ladder reflects how NYCN organizers actually do this work today — or whether it accidentally invented a workflow nobody asked for.
+
+1. **Where does drive content actually come from in your week?** Is it organizer-authored, member-submitted, summit-collected, or something else? Does the source of the content change what you do with it next?
+2. **What is the *first* human action** taken on drive content in your current workflow — review, triage, summarize, file, share, ignore-until-someone-flags-it, something else? Where does that first action happen — in the drive itself, in Google Groups, in a meeting, in someone's head?
+3. **Who has authority to turn drive content into a decision?** Is it a single steward, a committee, a quorum, an asynchronous consent process, an organizer's call followed by post-hoc ratification? Where is that authority recorded today, if anywhere?
+4. **What's the difference between a *decision* and an *action item* in NYCN practice?** Is the boundary clean (decision → action item) or fuzzy (some decisions imply work without ever generating an action item; some action items exist without a recorded decision)?
+5. **Who, by name or role, is on the hook for an action item once it is created?** How is that assignment communicated, and what makes someone *aware* they have been assigned something?
+6. **What does "complete" mean for an action item in your practice?** Is it "the work was done," "someone confirmed the work was done," "the next meeting noted the work was done," or "nobody complained for two weeks"?
+7. **What's the failure mode you most want a system to prevent?** Lost decisions, lost responsibilities, lost paper trail, double-counted work, decisions that quietly never happened, something else?
+
+## Data and source validation
+
+These are about the *shape* of what the ladder sees vs the shape of what NYCN organizers actually have. The risk we are trying to surface is silent flattening: where the parser produces a clean structure and the organizer thinks "that's not actually how we work, but it looks plausible."
+
+8. **When the parser produces a `drive-ingest-review/v1` artifact, does it line up with what you would have written by hand from the same source?** Where is the ladder simplifying? Where is it inventing?
+9. **Are there organizer practices encoded in your drive content that the ladder cannot see?** (Examples: tacit conventions about file naming, meeting-notes formatting, decision shorthand, who is allowed to edit what.) If so, is each invisible practice load-bearing or incidental?
+10. **Is Google Drive the only place this content lives, or does it also live in Google Groups, in meeting minutes, in a Slack/Discord, in a wiki, in someone's head?** When the ladder takes drive content as the source, what is it missing?
+11. **When the ladder binds an action item to an assignee** (the `drive-ingest-action-item-publish-dry-run-bound/v1` step), does the assignee match who you would have named yourself? Where would the binding go wrong?
+12. **What kind of receipt would actually be useful to you for board reporting, member legibility, or grant reporting?** What fields, what format, what level of detail? What would be useless overkill?
+
+## Pilot-readiness
+
+These are about what would have to be true for an operator pilot rehearsal to even make sense — not about whether NYCN wants one.
+
+13. **What organizer time is currently *not* available, and at what cost?** If a pilot rehearsal needed two hours of organizer attention in a given week, what would it cost NYCN — in displaced work, in volunteer attention, in trust capital?
+14. **What infrastructure is NYCN willing to run on its own machines?** Is there an organizer comfortable with a localhost gateway? With a long-running process? With reading a terminal? Or is the bar "everything must be in a browser tab on a phone"?
+15. **What infrastructure is NYCN explicitly *not* willing to run, ever?** What would crossing that line cost NYCN's relationship with members?
+16. **What would have to be true for a first rehearsal to feel safe?** (Examples: fixture-equivalent material, not real organizer content; no other cooperative aware of the rehearsal; the rehearsal recorded only by NYCN; the rehearsal stopped on first surprise.)
+17. **What are the conditions under which NYCN would *not* want to be the intended first cooperative partner?** (We need to be able to hear this without it being awkward. The answer "it would be awkward to say so" is itself useful.)
+18. **Who else needs to be in the room before any pilot rehearsal happens?** Stewards, members, board, advisors, legal? Whose absence would later turn into "we should have asked them first"?
+19. **What is the smallest thing the ladder could do, on real NYCN material, that would tell you whether the spine is correct?** That is the actual first rehearsal — smaller than a pilot, smaller than a partnership, just one honest test.
+
+## Things we are explicitly not asking
+
+These are the questions ICN-side people should *not* be asking NYCN organizers in this phase. Listed here so the asks above stay clean by contrast.
+
+- **"Will NYCN commit to a pilot?"** No. Commitment is downstream of validation, not a prerequisite for it.
+- **"Can ICN announce NYCN as a partner?"** No. NYCN being the intended first cooperative partner is internal language, not a marketing claim.
+- **"Will NYCN host an ICN node?"** No. The mutation boundary stays in place: NYCN-side tooling never mutates a remote cluster, and ICN does not propose to host anything for NYCN.
+- **"Can ICN have your member list, your governance content, or your historical drive content?"** No. None of that material moves into ICN-side systems as part of validation.
+- **"Will NYCN endorse ICN publicly?"** No. ICN is being built whether or not NYCN endorses it.
+- **"Will NYCN sign a memorandum?"** No. There is no memorandum.
+
+If any of those questions creep into a real conversation with organizers, the ICN-side person should pause, name the slip, and return to the validation questions above.
+
+## How to use this in conversation
+
+- **Read 1–7 before the conversation; pick three or four.** Asking all of them would feel like a survey. Pick the three or four most relevant to what NYCN actually does, and let the conversation pull others out.
+- **Read 8–12 to know what to listen for during the demo.** These are not interview questions; they are awareness primers. If an organizer's reaction during the demo lands on one of these, follow it.
+- **Save 13–19 for after the demo.** Pilot-readiness questions only make sense once the organizer has seen what the demo shows and not shows.
+- **Take notes on what the organizer says, not on what we plan to say next.** The output of the conversation is "what NYCN organizers actually told us," not "how the conversation went."
+
+## After the conversation
+
+- **Update [`nycn-boundary-brief.md`](nycn-boundary-brief.md) if the conversation revealed a "what ICN cannot honestly claim" item we missed.**
+- **Update [`docs/STATE.md`](../STATE.md) only with what is now demonstrably true.** A conversation alone does not change Phase 2 status. Phase 2 status changes when partnership formalizes and a rehearsal happens.
+- **Do not write a press post, summary blog, or external announcement about the conversation.** A conversation is not a milestone.
+
+## Pointers
+
+| For | See |
+|---|---|
+| Honest scope-of-now | [`nycn-boundary-brief.md`](nycn-boundary-brief.md) |
+| Demo flow with limits called out | [`nycn-demo-script.md`](nycn-demo-script.md) |
+| ICN/NYCN boundary in detail | [`docs/reference/project-index/pilot-and-nycn-map.md`](../reference/project-index/pilot-and-nycn-map.md) |
+| ICN doctrine | [`docs/architecture/THE_COMMONS.md`](../architecture/THE_COMMONS.md) |
+| Cooperative-developer discovery brief (analog tone) | [`docs/strategy/COOPERATIVE_DEVELOPER_DISCOVERY_BRIEF.md`](../strategy/COOPERATIVE_DEVELOPER_DISCOVERY_BRIEF.md) |

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -3032,6 +3032,54 @@ last_updated = "2026-03-10"
 owner = "matt"
 audiences = ["team"]
 
+[docs."docs/pilots/nycn-boundary-brief.md"]
+category = "reference"
+status = "living"
+title = "NYCN Boundary Brief"
+description = "Honest scope-of-now brief for NYCN organizers and ICN-side preparers: what ICN can demonstrate today, what it cannot honestly claim yet, what NYCN organizers would need to validate, and what is explicitly not being asked. Defers to STATE.md and PHASE_PROGRESS.md for current truth."
+last_updated = "2026-04-29"
+owner = "matt"
+audiences = ["team", "organizers"]
+truth_class = "descriptive"
+role = "reference"
+canonical = "no"
+freshness = "current"
+domain_tags = ["pilot", "nycn", "boundary", "communications"]
+recommended_action = "keep"
+last_reviewed = "2026-04-29"
+
+[docs."docs/pilots/nycn-demo-script.md"]
+category = "reference"
+status = "living"
+title = "NYCN Demo Script"
+description = "Step-by-step organizer-facing demo flow against a localhost ICN gateway: action cards, proof loop, receipts, provenance, and explicit limit-naming. Not a pitch."
+last_updated = "2026-04-29"
+owner = "matt"
+audiences = ["team"]
+truth_class = "operational"
+role = "reference"
+canonical = "no"
+freshness = "current"
+domain_tags = ["pilot", "nycn", "demo", "communications"]
+recommended_action = "keep"
+last_reviewed = "2026-04-29"
+
+[docs."docs/pilots/nycn-organizer-asks.md"]
+category = "reference"
+status = "living"
+title = "NYCN Organizer Asks"
+description = "Bounded set of questions to ask NYCN organizers — workflow validation, source/data validation, pilot-readiness — without assuming any partnership commitment. Includes explicit non-asks."
+last_updated = "2026-04-29"
+owner = "matt"
+audiences = ["team", "organizers"]
+truth_class = "descriptive"
+role = "reference"
+canonical = "no"
+freshness = "current"
+domain_tags = ["pilot", "nycn", "discovery", "communications"]
+recommended_action = "keep"
+last_reviewed = "2026-04-29"
+
 # ============================================================================
 # PLANNING AND STRATEGY (Additional)
 # ============================================================================


### PR DESCRIPTION
## Summary

Adds three organizer-facing boundary docs under `docs/pilots/` to support the next concrete Phase 2 step: presenting the merged drive-ingest ladder + ICN proof-loop machinery to NYCN organizers without overclaiming.

This builds on the project-index layer that landed in #1682. Defers to `docs/STATE.md` and `docs/PHASE_PROGRESS.md` for current truth.

## What changed

- Added `docs/pilots/nycn-boundary-brief.md` — honest scope-of-now: what ICN can demonstrate today, what it cannot honestly claim yet, what NYCN organizers would need to validate, what is explicitly **not** being asked.
- Added `docs/pilots/nycn-demo-script.md` — step-by-step organizer-facing demo flow against a localhost ICN gateway. Action cards, proof loop, receipts, provenance, and explicit limit-naming. Each step has explicit "Don't say" entries to keep scope.
- Added `docs/pilots/nycn-organizer-asks.md` — bounded set of validation questions (workflow validation, source/data validation, pilot-readiness) plus an explicit "things we are not asking" list.
- Registered all three in `docs/registry.toml`.
- Linked all three from `docs/INDEX.md` under a new "Pilot Outreach (`pilots/`)" subsection (plus surfaced the existing `docs/pilots/*` entries that were not previously linked from INDEX).

## Path note

The original prompt requested `docs/pilot/` (singular). Used `docs/pilots/` (plural) to match the existing project convention — `pilots` is in `[control].allowlisted_docs_subdirs` in `docs/registry.toml`, and `docs/pilots/` already houses pilot-related materials (`pilot-proposal-template.md`, `hosted-approach.md`, `decision_registry_treasury_vote.md`). Singular `pilot` would have required an allowlist change.

## What this is not

- Not a runtime change.
- Not a redesign of the website.
- Not a touch of the `fahertym/nycn` repo.
- Not a Phase 2 completion claim — explicitly deferred throughout.
- Not a formal NYCN commitment claim — explicitly named as "intended first cooperative partner, not formally committed."
- Not a production-federation claim — explicitly named as Phase 3, not Phase 2.
- Not a new source of truth — every doc points at `STATE.md` / `PHASE_PROGRESS.md` as authoritative.
- Not a partnership ask of NYCN — `nycn-organizer-asks.md` includes explicit "things we are not asking" enumerated.

## Validation

- [x] `python3 docs/scripts/doc_control_check.py --strict` (passed; 36 enforcement warnings, all pre-existing — none reference the new docs)
- [x] `git diff --check`
- [x] Changed-doc vocabulary scan for unsafe ICN-native terms (only hits inside explicit "Don't say" / "Avoid:" tables in nycn-demo-script.md, which is the allowed context)
- [x] `python3 .github/scripts/compliance_linter.py` (passed; no violations)

## Notes

Current truth remains in `docs/STATE.md` and `docs/PHASE_PROGRESS.md`. The boundary brief, demo script, and organizer asks are intentionally bounded — they do not invent capability claims, do not propose specific partnership timelines, and do not stand in for actual conversations with NYCN organizers.