### PR TITLE
docs(licensing): document current license metadata and open questions

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,54 +1,67 @@
 # Licensing
 
-This project uses two distinct license postures by design. This document clarifies the structure so contributors and downstream consumers can answer "which terms apply to this part of the repo?" without guessing.
+This document summarizes current repository license metadata and open licensing questions. **It is a maintainer-facing project note, not legal advice.** It does not relicense any code, modify any license declaration, define legal obligations for downstream consumers, or settle a licensing architecture by itself.
 
-## Repository-level license: AGPL-3.0
+If repository metadata appears inconsistent with this document, the metadata in [`LICENSE`](LICENSE) and per-crate `Cargo.toml` files governs over any prose here. When inconsistencies surface, resolve them in a dedicated licensing decision (PR or RFC), not by treating this document as doctrine.
 
-The ICN project — the source distribution as a whole, the deliverable, the running daemon, and any artifact built from this repository where no narrower crate license applies — is licensed under the **GNU Affero General Public License, version 3** (AGPL-3.0).
+## What the repository currently declares
 
-The full license text lives at [`LICENSE`](LICENSE). The README license badge points to the same file.
+The metadata signals below are **observations of the present state**, not claims about how the signals should ultimately interact. Their relationship is an [open question](#open-questions) for a dedicated licensing decision.
 
-This is the governing license for the project as a whole. Anything in this repository that is not covered by a more specific crate-level declaration falls under AGPL-3.0.
+### Root license file
 
-## Per-crate license metadata: MIT OR Apache-2.0 (where explicitly declared)
+[`LICENSE`](LICENSE) at the repository root contains the GNU Affero General Public License, Version 3 (AGPL-3.0).
 
-Selected Rust crates in `icn/crates/` and `icn/apps/` declare their own license in their `Cargo.toml`:
+### Rust workspace license metadata
+
+[`icn/Cargo.toml`](icn/Cargo.toml) declares a workspace-level package license:
 
 ```toml
-[package]
+[workspace.package]
 license = "MIT OR Apache-2.0"
 ```
 
-This is intentional. These crates are reusable technical primitives — not deliverable application code — and the dual MIT/Apache-2.0 posture lets downstream Rust projects pick them up under permissive terms, in the same idiom Rust itself uses.
+Every crate in the canonical Rust workspace either declares this license explicitly or inherits it via `license.workspace = true`. As of this writing, of the 49 canonical `Cargo.toml` files (excluding `target/` and `.claude/worktrees/`):
 
-Where a crate's `Cargo.toml` explicitly declares a license, **that declaration governs that crate's published metadata and any third-party reuse of that crate as a library**. Where a crate inherits from `workspace.package.license` in `icn/Cargo.toml`, that workspace declaration governs.
+- 13 declare `license = "MIT OR Apache-2.0"` explicitly. These are: `icn/Cargo.toml` (workspace root), the four `apps/*` crates (`apps/governance`, `apps/trust`, `apps/ledger`, `apps/echo`), the four `icn/apps/*` crates (`membership`, `charter`, `governance`, `ledger`), and four `icn/crates/*` crates (`icn-kernel-api`, `icn-http-kit`, `icn-zkp`, `icn-crypto-pq`).
+- 34 inherit via `license.workspace = true`. These are the rest of `icn/crates/*` and all three `icn/bins/*` binaries (`icnd`, `icnctl`, `icn-console`).
+- 2 declare no `license` field at all (`examples/wasm-compute/Cargo.toml`, `icn/crates/icn-ccl/fuzz/Cargo.toml`).
 
-## Which terms apply to what
+**No `Cargo.toml` in the canonical set declares AGPL-3.0.** The AGPL-3.0 declaration lives only in the root `LICENSE` file.
 
-| What you are looking at | Which license applies |
-|---|---|
-| The ICN project as a whole — source tree, deliverable, daemon binaries built from this repo | [`LICENSE`](LICENSE) (AGPL-3.0) |
-| A Rust crate with `license = "..."` in its `Cargo.toml` | The crate's declared license |
-| A Rust crate inheriting `license.workspace = true` | The workspace declaration in `icn/Cargo.toml` |
-| A documentation file, deployment manifest, or other non-code artifact under no narrower declaration | [`LICENSE`](LICENSE) (AGPL-3.0) |
+### Cargo `license` field caveat
 
-## For contributors
+The Cargo `license` field is **intent metadata**. It is not a license document and does not by itself capture every notice, exception, or accompanying file that may apply to a crate. Downstream consumers should consult the `license` field together with any `LICENSE` or `NOTICE` file in the relevant directory before relying on it.
 
-When you add or substantially rework a Rust crate, do not silently change its `license` field. License changes are a deliberate decision and should land in a dedicated PR clearly titled and reviewed for the licensing implication, not bundled with feature work.
+### Other directly relevant artifacts
 
-When you add a non-code artifact (docs, scripts, examples, ops manifests) without a narrower declaration, it falls under the repository-level AGPL-3.0 by default — no per-file header is required for that to hold.
+- [`docs/internal/legal-considerations.md`](docs/internal/legal-considerations.md) — maintainer-facing notes on regulatory questions communities deploying ICN may face. Like this document, it disclaims being legal advice.
+- `docs/api/`, `docs/reference/api/`, `web/api-docs/`, `deploy/README.md`, and per-SDK READMEs reference `MIT OR Apache-2.0` as the API/SDK metadata. These reflect Cargo workspace metadata, not a separate decision.
 
-## For downstream consumers
+## Open questions
 
-If you are reusing one of this project's Rust crates as a library dependency, look at that crate's `Cargo.toml` `license` field. The license you see there governs your reuse of that crate.
+The following questions are **not resolved by this document**. They are recorded here so a future licensing decision (PR, RFC, or maintainer/legal review) can address them explicitly:
 
-If you are forking, redistributing, or running the ICN project as a whole — including the daemon, the gateway, the deployment, or any composed artifact built from this repository — AGPL-3.0 governs your obligations.
+- **Relationship between root `LICENSE` and the Rust workspace license.** The root file declares AGPL-3.0; the workspace metadata declares `MIT OR Apache-2.0`. The intended relationship between these two signals — whether the AGPL-3.0 governs the source distribution or specific deliverables, whether the Rust workspace metadata reflects an intentional permissive posture for reusable libraries, or whether one of the two signals is stale — is not currently captured by a canonical maintainer decision.
+- **Scope of AGPL-3.0 if it is intended to govern the project as a whole.** Which artifacts (source distribution, daemon binaries, deployment manifests, documentation, generated artifacts) the AGPL-3.0 obligations are intended to cover.
+- **Per-component license posture.** Whether reusable Rust crates should remain `MIT OR Apache-2.0` (as the workspace currently declares) or move to a different license; whether runtime / tool layers should adopt a network copyleft license (AGPL, CAL, or another) deliberately rather than by default.
+- **Network copyleft scope.** If AGPL-style obligations are intended for any component, which components and which deployment shapes trigger them.
+- **Data and autonomy protections.** Whether any component requires data-rights or autonomy-rights protections beyond what `MIT OR Apache-2.0` or AGPL-3.0 provide on their own.
+- **Trademark and certification policy.** Whether the project intends to maintain a separate trademark or certification policy distinct from its source license, and where such a policy would live in the repository.
+- **SPDX header policy.** Whether per-file SPDX identifiers should be added across the source tree, and to what scope.
 
-If you are uncertain whether your use case falls under a crate-level declaration or the repository-level license, the safe default is to assume AGPL-3.0 and ask before redistributing.
+These questions are deliberately phrased as questions, not tentative answers. Answering any of them is a maintainer/legal decision and should land as an explicit, dedicated PR or RFC clearly titled and reviewed for the licensing implication.
+
+## Hard rules for changes
+
+- **License metadata changes must be explicit.** Do not silently change a crate's `license` field, the workspace `license` declaration, or the root `LICENSE` file as a side effect of feature work. License changes land in a dedicated PR clearly titled and reviewed for the licensing implication.
+- **License text is authoritative over prose.** When a downstream question arises about a specific file or crate, the relevant `LICENSE`, `NOTICE`, and `Cargo.toml` `license` fields are the source of truth; this document and any other prose are summaries that may lag behind.
+- **Not legal advice.** This document is a maintainer-facing inventory. It does not give legal advice, define obligations for downstream consumers, or authorize any change to the present licensing posture.
 
 ## What this document does not do
 
 - It does not relicense any existing code.
-- It does not modify `LICENSE`, `icn/Cargo.toml`, or any per-crate `Cargo.toml` license field.
-- It does not add SPDX headers to source files (that is a separate decision tracked elsewhere).
-- It does not authorize a future change to either license posture. Any such change must come from a dedicated, explicit decision and PR.
+- It does not modify [`LICENSE`](LICENSE), [`icn/Cargo.toml`](icn/Cargo.toml), or any per-crate `Cargo.toml` license field.
+- It does not add SPDX headers to any source file.
+- It does not authorize, justify, or settle a multi-license architecture. Any such decision must come from a dedicated maintainer/legal review and a separate PR or RFC.
+- It does not assert that the present metadata signals are intentional, harmonized, or final. They are observations of the current state, recorded so a future licensing decision has a starting point.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -21,11 +21,11 @@ The metadata signals below are **observations of the present state**, not claims
 license = "MIT OR Apache-2.0"
 ```
 
-Every crate in the canonical Rust workspace either declares this license explicitly or inherits it via `license.workspace = true`. As of this writing, of the 49 canonical `Cargo.toml` files (excluding `target/` and `.claude/worktrees/`):
+Most crates in the canonical Rust workspace declare this license explicitly or inherit it via `license.workspace = true`; a small number declare no `license` field at all. As of this writing, of the 49 canonical `Cargo.toml` files (excluding `target/` and `.claude/worktrees/`):
 
 - 13 declare `license = "MIT OR Apache-2.0"` explicitly. These are: `icn/Cargo.toml` (workspace root), the four `apps/*` crates (`apps/governance`, `apps/trust`, `apps/ledger`, `apps/echo`), the four `icn/apps/*` crates (`membership`, `charter`, `governance`, `ledger`), and four `icn/crates/*` crates (`icn-kernel-api`, `icn-http-kit`, `icn-zkp`, `icn-crypto-pq`).
 - 34 inherit via `license.workspace = true`. These are the rest of `icn/crates/*` and all three `icn/bins/*` binaries (`icnd`, `icnctl`, `icn-console`).
-- 2 declare no `license` field at all (`examples/wasm-compute/Cargo.toml`, `icn/crates/icn-ccl/fuzz/Cargo.toml`).
+- 2 declare no `license` field at all and do not opt into the workspace inheritance: `examples/wasm-compute/Cargo.toml` (an example crate) and `icn/crates/icn-ccl/fuzz/Cargo.toml` (a fuzz test harness). What license applies to these two `Cargo.toml`s on their own is one of the [Open Questions](#open-questions) below.
 
 **No `Cargo.toml` in the canonical set declares AGPL-3.0.** The AGPL-3.0 declaration lives only in the root `LICENSE` file.
 
@@ -49,6 +49,7 @@ The following questions are **not resolved by this document**. They are recorded
 - **Data and autonomy protections.** Whether any component requires data-rights or autonomy-rights protections beyond what `MIT OR Apache-2.0` or AGPL-3.0 provide on their own.
 - **Trademark and certification policy.** Whether the project intends to maintain a separate trademark or certification policy distinct from its source license, and where such a policy would live in the repository.
 - **SPDX header policy.** Whether per-file SPDX identifiers should be added across the source tree, and to what scope.
+- **Crates with no `license` field.** What license applies on its own to `examples/wasm-compute/Cargo.toml` and `icn/crates/icn-ccl/fuzz/Cargo.toml`, both of which omit the `license` field entirely and do not opt into workspace inheritance. The repository-level `LICENSE` file applies to the source tree as a whole; whether each of these two crates should also declare `license.workspace = true` (or an explicit license) is a separate decision.
 
 These questions are deliberately phrased as questions, not tentative answers. Answering any of them is a maintainer/legal decision and should land as an explicit, dedicated PR or RFC clearly titled and reviewed for the licensing implication.
 

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,54 @@
+# Licensing
+
+This project uses two distinct license postures by design. This document clarifies the structure so contributors and downstream consumers can answer "which terms apply to this part of the repo?" without guessing.
+
+## Repository-level license: AGPL-3.0
+
+The ICN project — the source distribution as a whole, the deliverable, the running daemon, and any artifact built from this repository where no narrower crate license applies — is licensed under the **GNU Affero General Public License, version 3** (AGPL-3.0).
+
+The full license text lives at [`LICENSE`](LICENSE). The README license badge points to the same file.
+
+This is the governing license for the project as a whole. Anything in this repository that is not covered by a more specific crate-level declaration falls under AGPL-3.0.
+
+## Per-crate license metadata: MIT OR Apache-2.0 (where explicitly declared)
+
+Selected Rust crates in `icn/crates/` and `icn/apps/` declare their own license in their `Cargo.toml`:
+
+```toml
+[package]
+license = "MIT OR Apache-2.0"
+```
+
+This is intentional. These crates are reusable technical primitives — not deliverable application code — and the dual MIT/Apache-2.0 posture lets downstream Rust projects pick them up under permissive terms, in the same idiom Rust itself uses.
+
+Where a crate's `Cargo.toml` explicitly declares a license, **that declaration governs that crate's published metadata and any third-party reuse of that crate as a library**. Where a crate inherits from `workspace.package.license` in `icn/Cargo.toml`, that workspace declaration governs.
+
+## Which terms apply to what
+
+| What you are looking at | Which license applies |
+|---|---|
+| The ICN project as a whole — source tree, deliverable, daemon binaries built from this repo | [`LICENSE`](LICENSE) (AGPL-3.0) |
+| A Rust crate with `license = "..."` in its `Cargo.toml` | The crate's declared license |
+| A Rust crate inheriting `license.workspace = true` | The workspace declaration in `icn/Cargo.toml` |
+| A documentation file, deployment manifest, or other non-code artifact under no narrower declaration | [`LICENSE`](LICENSE) (AGPL-3.0) |
+
+## For contributors
+
+When you add or substantially rework a Rust crate, do not silently change its `license` field. License changes are a deliberate decision and should land in a dedicated PR clearly titled and reviewed for the licensing implication, not bundled with feature work.
+
+When you add a non-code artifact (docs, scripts, examples, ops manifests) without a narrower declaration, it falls under the repository-level AGPL-3.0 by default — no per-file header is required for that to hold.
+
+## For downstream consumers
+
+If you are reusing one of this project's Rust crates as a library dependency, look at that crate's `Cargo.toml` `license` field. The license you see there governs your reuse of that crate.
+
+If you are forking, redistributing, or running the ICN project as a whole — including the daemon, the gateway, the deployment, or any composed artifact built from this repository — AGPL-3.0 governs your obligations.
+
+If you are uncertain whether your use case falls under a crate-level declaration or the repository-level license, the safe default is to assume AGPL-3.0 and ask before redistributing.
+
+## What this document does not do
+
+- It does not relicense any existing code.
+- It does not modify `LICENSE`, `icn/Cargo.toml`, or any per-crate `Cargo.toml` license field.
+- It does not add SPDX headers to source files (that is a separate decision tracked elsewhere).
+- It does not authorize a future change to either license posture. Any such change must come from a dedicated, explicit decision and PR.

--- a/README.md
+++ b/README.md
@@ -125,4 +125,4 @@ ICN is real, active, and uneven in maturity. The strongest parts today are prove
 
 ## License
 
-[AGPL-3.0](LICENSE)
+[AGPL-3.0](LICENSE) governs the project as a whole. Selected Rust crates declare `MIT OR Apache-2.0` in their own `Cargo.toml` for reusable technical primitives. See [LICENSING.md](LICENSING.md) for the relationship between the repository-level license and per-crate metadata.

--- a/README.md
+++ b/README.md
@@ -125,4 +125,4 @@ ICN is real, active, and uneven in maturity. The strongest parts today are prove
 
 ## License
 
-[AGPL-3.0](LICENSE) governs the project as a whole. Selected Rust crates declare `MIT OR Apache-2.0` in their own `Cargo.toml` for reusable technical primitives. See [LICENSING.md](LICENSING.md) for the relationship between the repository-level license and per-crate metadata.
+The root [`LICENSE`](LICENSE) file contains [AGPL-3.0](LICENSE). The Rust workspace metadata in [`icn/Cargo.toml`](icn/Cargo.toml) declares `MIT OR Apache-2.0`, and most crates in the workspace either declare it explicitly or inherit it via `license.workspace = true`. See [`LICENSING.md`](LICENSING.md) for current repository license metadata and open licensing questions; that document is not legal advice and does not relicense any code.


### PR DESCRIPTION
## Summary

Documents current repository license metadata and lists open licensing questions, **without** asserting an "intentional two-tier" architecture, defining downstream legal obligations, or relicensing any code.

The original commit (`29eef7ae`, rebased to `6376175f`) framed the repository as having an intentional AGPL-project / per-crate-permissive design and stated that "the running daemon" is governed by AGPL-3.0 by default. Both Codex (P1) and Copilot (×4) flagged that the Cargo metadata directly contradicts that prose: the daemon binaries (`icnd`, `icnctl`, `icn-console`) inherit `license.workspace = true` from `icn/Cargo.toml`'s `MIT OR Apache-2.0` declaration, and no `Cargo.toml` in the canonical set declares AGPL-3.0.

Commit `5bf87ba9` rewrites both `LICENSING.md` and the README license section to be conservative and factual, leaving the architecture question to a future maintainer/legal decision.

## What changed

- **`LICENSING.md`** — rewritten as "current repository license metadata and open licensing questions." Removes the "intentional two-tier posture" framing, the AGPL-by-default-for-deliverables claim, the daemon-is-AGPL claim, and the "license field governs third-party reuse" overclaim. Adds an Open Questions section listing the relationship between the root `LICENSE` and the workspace metadata, the scope of AGPL-3.0 if it is intended to govern the project as a whole, per-component license posture, network-copyleft scope, data/autonomy protections, trademark/certification policy, and SPDX header policy — all explicitly framed as questions, not tentative answers.
- **`README.md`** — the License section is rewritten symmetrically. Instead of "AGPL-3.0 governs the project as a whole; selected Rust crates declare MIT OR Apache-2.0 ... for reusable technical primitives," the new wording describes the metadata as it stands (root `LICENSE` contains AGPL-3.0; workspace metadata declares `MIT OR Apache-2.0`; most crates declare it explicitly or inherit it) and points at `LICENSING.md` with the explicit caveat that the document is not legal advice and does not relicense any code.

The branch was rebased onto current `main` (which now contains PR #1690 + PR #1691). The original commit `29eef7ae` is replaced by `6376175f` (rebase) + `5bf87ba9` (corrective rewrite).

## What the document does and does not claim

**Does claim** (factual observations of present metadata):

- The root `LICENSE` file contains AGPL-3.0.
- `icn/Cargo.toml` declares `[workspace.package] license = "MIT OR Apache-2.0"`.
- Of 49 canonical `Cargo.toml` files (excluding `target/` and `.claude/worktrees/`): 13 declare `MIT OR Apache-2.0` explicitly, 34 inherit via `license.workspace = true`, 2 declare no `license` field at all.
- No `Cargo.toml` in the canonical set declares AGPL-3.0.
- The Cargo `license` field is intent metadata, not a license document.

**Does NOT claim**:

- That a two-tier license architecture is intentional or settled.
- That the running daemon, `icnd`, or any other binary is governed by AGPL-3.0 by default. (The metadata says otherwise; the relationship is an open question.)
- That MIT OR Apache-2.0 only applies to "reusable technical primitives" — the workspace metadata applies broadly, including to binaries and apps.
- That the Cargo `license` field "governs" any third-party reuse — that overclaim is removed.
- That this document gives legal advice or defines downstream obligations.
- That this document authorizes, justifies, or settles any change to the present licensing posture.

## Factual license metadata found

| Path | Declared license | Source |
|---|---|---|
| `LICENSE` (root) | AGPL-3.0 | full license text |
| `icn/Cargo.toml` | `MIT OR Apache-2.0` | `[workspace.package]` line 49 |
| 13 explicit `Cargo.toml`s | `MIT OR Apache-2.0` | per-crate `license = "..."` |
| 34 inherited `Cargo.toml`s (incl. `icnd`/`icnctl`/`icn-console`) | `MIT OR Apache-2.0` (via workspace) | `license.workspace = true` |
| 2 unset `Cargo.toml`s (`examples/wasm-compute`, `icn/crates/icn-ccl/fuzz`) | no `license` field | (none) |
| `docs/internal/legal-considerations.md` | (no license declaration; covered by `LICENSE`) | maintainer-facing notes; "not legal advice" |

No `Cargo.toml` in the canonical set declares AGPL-3.0.

## Explicit no-relicensing statement

This PR does **not** modify `LICENSE`, `icn/Cargo.toml`, any per-crate `Cargo.toml` license field, or any other license-bearing file. No SPDX headers are added. Both files in the diff (`LICENSING.md`, `README.md`) are documentation only.

## Open questions / legal review caveat

`LICENSING.md` records seven open questions explicitly, including the relationship between the root `LICENSE` and the Rust workspace license declaration, scope of AGPL-3.0, per-component license posture, network-copyleft scope, data/autonomy protections, trademark/certification policy, and SPDX header policy. None are resolved by this PR. Resolving any of them is a maintainer/legal decision and should land as a dedicated, explicit PR or RFC clearly titled and reviewed for the licensing implication.

## Checks run (at HEAD `5bf87ba9`)

```text
python3 docs/scripts/doc_control_check.py --strict
  → OK (756 docs; 36 pre-existing enforcement warnings, none new from this PR)

python3 .github/scripts/compliance_linter.py
  → No compliance violations detected (107 files scanned)

git diff --check
  → clean
```

Overclaim audit on the new prose: the keywords `intentional` / `governs` / `deliberate` appear five times in the rewritten `LICENSING.md`; all five are in safe contexts (one disclaimer that license metadata governs over prose, three in Open Questions framed as questions, one meta-statement explicitly disclaiming any "intentional / harmonized / final" assertion). Disclaimers present: "not legal advice" (×1), "does not relicense" (×2), "open question" / "Open Questions" (×4), "observations" (×2).

## Review thread status

All 5 inline review threads (Codex P1 + Copilot ×4) addressed in commit `5bf87ba9` and resolved.

| Thread | Concern | Addressed |
|---|---|---|
| Codex P1 (`LICENSING.md:30`) | daemon AGPL claim contradicts Cargo metadata | ✓ AGPL-by-default claim removed; metadata facts recorded; relationship moved to Open Questions |
| Copilot (`README.md:128`) | "selected technical primitives" understates MIT/Apache scope | ✓ README rewritten to describe metadata as-it-stands |
| Copilot (`LICENSING.md:11`) | "running daemon" AGPL implication | ✓ removed; daemon binaries described as inheriting workspace license |
| Copilot (`LICENSING.md:24`) | Cargo license field "governs" overclaim | ✓ replaced with explicit "intent metadata, not a license document" caveat |
| Copilot (`LICENSING.md:43`) | "license you see there governs your reuse" reads as legal advice | ✓ entire downstream-consumers section removed; doc disclaims defining obligations |

## Relationship to recent merges

- PR #1690 (merge SHA `9af1d6c6`): added the repo-record protocol/generator/scaffold. Not affected by this PR.
- PR #1691 (merge SHA `763d8367`): added the first generated mechanical repo-record snapshot. Not affected by this PR.
- This PR was the only ICN PR open before the rewrite. The branch has been rebased onto current main; mergeable=BLOCKED reflects CI re-running on the rebased + corrected commits.

## Hard scope statement

This PR is **legal-facing documentation hygiene only**. It does not:

- start runtime implementation, create crates, or modify code;
- start RFC-0016, RFC-0017, or any PR B/C/D/E work;
- modify NYCN, icn-learn, or any non-ICN-repo source;
- change LICENSE, any Cargo.toml license field, or add SPDX headers;
- relicense any code;
- make legal conclusions beyond what repo metadata supports.
