### PR TITLE
docs(rfcs): open stubs for RelationshipRecord (#0016) and tool install infrastructure (#0017)

### DIFF
--- a/docs/rfcs/RFC-0016-relationship-surface.md
+++ b/docs/rfcs/RFC-0016-relationship-surface.md
@@ -24,7 +24,7 @@ superseded_by: []
 
 ICN today models *authority* relationships through `RoleAssignment` (DID + structure + capability strings) and *entity participation* through `Federation.member_entities`. It does not model the much larger surface of **non-authority relationships**: who is the relationship owner for a partner co-op, when was an organization last contacted, who is the next follow-up due from, what consent boundaries apply to a contact.
 
-This RFC explores a single generic substrate primitive, `RelationshipRecord`, that captures non-authority relationships between any two DIDs (subject and counterparty), with an opaque `relationship_kind: String` so institutions can carry their own taxonomy without leaking institution-specific vocabulary into ICN core. The recommended direction is to add `RelationshipRecord` to the *Reusable Primitive Set* table in [`INSTITUTION_PACKAGE_BOUNDARY.md`](../architecture/INSTITUTION_PACKAGE_BOUNDARY.md) and implement it with the same anti-ontology-laundering discipline already used by `Program::ProgramKind::Custom(String)` and `Milestone::completion_criteria: Vec<String>`.
+This RFC explores a single generic substrate primitive, `RelationshipRecord`, that captures non-authority relationships between any two DIDs (subject and counterparty), with an opaque `relationship_kind: String` so institutions can carry their own taxonomy without leaking institution-specific vocabulary into ICN core. The recommended direction is to add `RelationshipRecord` to the *Reusable Primitive Set* table in [`INSTITUTION_PACKAGE_BOUNDARY.md`](../architecture/INSTITUTION_PACKAGE_BOUNDARY.md) and implement it with the same anti-ontology-laundering discipline already used by `ProgramKind::Custom(String)` and `Milestone::completion_criteria: Vec<String>`.
 
 ## Problem statement
 
@@ -86,7 +86,7 @@ Per [`INSTITUTION_PACKAGE_BOUNDARY.md`](../architecture/INSTITUTION_PACKAGE_BOUN
 
 - **What lives in ICN core** under this RFC: the generic `RelationshipRecord` type with opaque-string `relationship_kind`. Storage. Receipt emission on lifecycle-state-change. Service trait for app consumption.
 - **What stays in institution packages**: the actual taxonomy (which `relationship_kind` values exist for *this* institution), the lifecycle rules (when does a sponsor relationship close), the rendering vocabulary (do we call them sponsors, funders, partners, member co-ops), the consent enforcement specifics.
-- **What stays opaque to the kernel**: every value of `relationship_kind`. Kernel must not pattern-match on it. The pattern follows `Program::ProgramKind::Custom(String)` and `Milestone::completion_criteria: Vec<String>`, both of which the program module already demonstrates.
+- **What stays opaque to the kernel**: every value of `relationship_kind`. Kernel must not pattern-match on it. The pattern follows `ProgramKind::Custom(String)` and `Milestone::completion_criteria: Vec<String>`, both of which the program module already demonstrates.
 
 ## Accessibility implications
 

--- a/docs/rfcs/RFC-0016-relationship-surface.md
+++ b/docs/rfcs/RFC-0016-relationship-surface.md
@@ -1,0 +1,164 @@
+---
+id: "0016"
+title: "Generic Relationship Surface (RelationshipRecord primitive)"
+status: "draft"
+created: "2026-04-30"
+updated: "2026-04-30"
+authors: ["Matt Faherty"]
+reviewers: []
+related_adr_candidates: []
+related_issues: []
+supersedes: []
+superseded_by: []
+---
+
+# RFC 0016: Generic Relationship Surface (RelationshipRecord primitive)
+
+## Status
+
+`draft` — being written, not yet ready for review. This RFC explores adding a generic relationship/contact substrate primitive (`RelationshipRecord`) to the ICN reusable primitive set, and is a stated prerequisite of the `icn-member-directory` base tool named in [`docs/architecture/COOPERATIVE_TOOL_COMMONS.md`](../architecture/COOPERATIVE_TOOL_COMMONS.md).
+
+**Accepted RFC does not mean implemented.** Implementation lands under follow-up ADR(s) and issues with code/test evidence.
+
+## Summary
+
+ICN today models *authority* relationships through `RoleAssignment` (DID + structure + capability strings) and *entity participation* through `Federation.member_entities`. It does not model the much larger surface of **non-authority relationships**: who is the relationship owner for a partner co-op, when was an organization last contacted, who is the next follow-up due from, what consent boundaries apply to a contact.
+
+This RFC explores a single generic substrate primitive, `RelationshipRecord`, that captures non-authority relationships between any two DIDs (subject and counterparty), with an opaque `relationship_kind: String` so institutions can carry their own taxonomy without leaking institution-specific vocabulary into ICN core. The recommended direction is to add `RelationshipRecord` to the *Reusable Primitive Set* table in [`INSTITUTION_PACKAGE_BOUNDARY.md`](../architecture/INSTITUTION_PACKAGE_BOUNDARY.md) and implement it with the same anti-ontology-laundering discipline already used by `Program::ProgramKind::Custom(String)` and `Milestone::completion_criteria: Vec<String>`.
+
+## Problem statement
+
+Multiple cooperative-tool surfaces currently in the design pipeline need to point at a non-authority relationship between DIDs:
+
+- The `icn-member-directory` base tool (planned per `COOPERATIVE_TOOL_COMMONS.md`) renders contact directories, relationship pipeline views, and follow-up queues for organizers. None of these surfaces are pure authority assertions; they are relational state.
+- Specialized suites composed at L2/L3 (sponsor / fundraising, organizer recruitment, partner workspace) all need to track *who owns the relationship*, *when did we last touch it*, and *when is the next action due*. These are not `RoleAssignment` data — they are observation/intention records.
+- `INSTITUTION_PACKAGE_BOUNDARY.md` § *Stays Out of ICN Core* explicitly puts CRM out of bounds: "CRM shape and field semantics vary too much across institutions." That is correct as a boundary on **CRM**. But the underlying primitive (a generic relationship record between DIDs) is institution-agnostic if it carries no institution-specific enum variants.
+
+Without a generic primitive, every consumer (every base tool, every specialized suite) reinvents a relationship surface in its own crate, drifting toward institution-specific shapes. With a generic primitive, the L2 tools point at one type and the L3 institution-specific vocabulary stays in package fields and CCL semantics.
+
+## Goals
+
+- Define a `RelationshipRecord` primitive that lives in ICN core and is consumable by base tools without leaking institution semantics.
+- Preserve the firewall: no institution-specific enum variants. `relationship_kind` is `String` (or equivalent free-form opaque tag).
+- Carry only the fields that are universal across institutions: subject DID, counterparty DID, owner DID, lifecycle state, last-contact timestamp, next-followup timestamp, consent scopes.
+- Emit receipts on lifecycle-state-change events through the existing receipt envelope (ADR-0026).
+- Be consumable by `icn-member-directory` and by future base tools (`icn-tables`, `icn-action-cards`) without each tool re-deriving relationship state.
+
+## Non-goals
+
+- **No CRM logic in ICN.** Pipeline stages, contact-history rendering, follow-up cadence rules, and any field whose meaning is institution-specific belong at L3 in the institution package.
+- **No participation taxonomy in ICN core.** `kind: Speaker | Sponsor | Attendee` would import institution vocabulary into the kernel; that is forbidden per `INSTITUTION_PACKAGE_BOUNDARY.md`.
+- **No private contact data in core records.** Real contact info lives in the institution's private overlay or future ScopedVault. The primitive carries DIDs and references, not phone numbers, emails, or notes.
+- **No replacement for `RoleAssignment`.** Authority grants stay in the existing `RoleAssignment` shape; this primitive does not overlap.
+
+## Background / current state
+
+- **Relevant existing primitives:** `RoleAssignment` (`icn-governance::structure`); `BootstrapEntityRecord` and `EntityKind` (`icn-governance::bootstrap`, `icn-entity`); person-directory overlay (PR #1626); `/me/standing` (PR #1627).
+- **Relevant boundary docs:** [`INSTITUTION_PACKAGE_BOUNDARY.md`](../architecture/INSTITUTION_PACKAGE_BOUNDARY.md) § Reusable Primitive Set (lists existing primitives) and § Stays Out (explicitly excludes CRM).
+- **Relevant tool catalog:** [`COOPERATIVE_TOOL_COMMONS.md`](../architecture/COOPERATIVE_TOOL_COMMONS.md) names `icn-member-directory` as a planned base tool that reads from the person-directory overlay and `/me/standing` and renders member profiles.
+- **Relevant kernel discipline:** [`KERNEL_APP_SEPARATION.md`](../architecture/KERNEL_APP_SEPARATION.md) — kernel reads pure data types; semantic interpretation is confined to apps. `RelationshipRecord` must not require kernel pattern-matching on `relationship_kind`.
+
+## Design options
+
+### Option A — New substrate crate `icn-relationships`
+
+Create a new substrate crate that defines `RelationshipRecord`, persistence, and receipt emission. Apps consume it through a service trait analogous to `TrustService`. Stays out of `icn-governance` to avoid coupling relationship state to governance state.
+
+### Option B — New module under `icn-governance`
+
+Add `icn-governance::relationship` alongside `::structure`, `::activity`, `::program`. Reuses existing storage, governance receipt machinery, and HTTP plumbing in `apps/governance`. Risk: blurs the line between governance state and relational state; could invite future drift.
+
+### Option C — Defer; keep relationship state at L3 only
+
+Do nothing in core; require each L3 institution package to carry its own relationship records. Tools at L2 receive relationship data through package config rather than a typed primitive. Lower architectural cost; higher per-tool reinvention cost.
+
+## Tradeoffs
+
+| Option | Easier | Harder | Invariants preserved | Invariants stressed | New failure modes |
+|---|---|---|---|---|---|
+| A — new crate | clean isolation, easier to evolve, easier kernel-discipline review | new crate to maintain, new receipt path to wire, more places to look for "where does relationship state live" | meaning firewall, kernel/app separation | none new | crate proliferation; service-injection complexity |
+| B — module under `icn-governance` | reuses governance machinery, no new crate | governance state and relationship state co-located; review burden on every governance change | reuses existing patterns | meaning firewall (relationship semantics are not governance semantics) | governance receipts and relationship receipts could be confused; cleanup later is costly |
+| C — defer | zero substrate work | every L2 tool reinvents relationship records; second-adopter story breaks ("you have to write a relationship type yourself") | none new | reusable-primitive principle (ICN has the generic shape institutions need) | per-tool drift; relationship state never receipt-bearing |
+
+## Core/package boundary
+
+Per [`INSTITUTION_PACKAGE_BOUNDARY.md`](../architecture/INSTITUTION_PACKAGE_BOUNDARY.md):
+
+- **What lives in ICN core** under this RFC: the generic `RelationshipRecord` type with opaque-string `relationship_kind`. Storage. Receipt emission on lifecycle-state-change. Service trait for app consumption.
+- **What stays in institution packages**: the actual taxonomy (which `relationship_kind` values exist for *this* institution), the lifecycle rules (when does a sponsor relationship close), the rendering vocabulary (do we call them sponsors, funders, partners, member co-ops), the consent enforcement specifics.
+- **What stays opaque to the kernel**: every value of `relationship_kind`. Kernel must not pattern-match on it. The pattern follows `Program::ProgramKind::Custom(String)` and `Milestone::completion_criteria: Vec<String>`, both of which the program module already demonstrates.
+
+## Accessibility implications
+
+`RelationshipRecord` is a substrate primitive with no member-facing surface of its own. Accessibility lands in the consumer tool surfaces (`icn-member-directory`, future suite UIs). The primitive must not block low-bandwidth operation: lifecycle-state-change receipts should be small enough that a member shell can render the relationship history without paginating large auxiliary data.
+
+## Conflict / dispute path
+
+Disputes about a `RelationshipRecord`:
+
+- **Wrong owner_did asserted.** Same path as governance disputes — challenge the record through the institution's existing dispute surface (ADR-0029 candidate).
+- **Disputed lifecycle-state-change.** The receipt envelope (ADR-0026) is the authoritative log; reverting requires a new state-change receipt referencing the prior one.
+- **Consent scope dispute.** The institution's privacy/redaction policy governs (ADR candidate for ScopedVault).
+
+## Security / privacy implications
+
+- DIDs are public; `RelationshipRecord` linking two DIDs is itself public unless scoped under a vault.
+- Real contact info never appears in the primitive. Phone, email, and free-text notes live in the institution's private overlay or future ScopedVault.
+- `consent_scopes: Vec<String>` lets institutions tag a relationship with consent boundaries (e.g. `public_listing`, `action_card_delivery`, `photography`); the kernel does not interpret these strings, but tools can refuse to act outside declared scopes.
+
+## Compute / automation boundary
+
+Tools may compute over `RelationshipRecord` (rendering pipelines, follow-up queue derivations, search). Compute may not mutate a record without producing a lifecycle-state-change receipt. Determinism and fuel bounds apply where compute jobs are invoked (per ADR-0030).
+
+## Website / public truth implications
+
+Once accepted and implemented, the maturity band for the relationship surface goes from "missing" to "early"; the canonical site can claim that ICN supports a generic relationship primitive that institutional packages compose specialized contact / partner / sponsor surfaces from. The site does **not** claim ICN provides a CRM.
+
+## Migration / compatibility
+
+Greenfield primitive. No migration cost for existing deployments, governance proposals, CCL contracts, API consumers, or test surfaces. The first consumer (`icn-member-directory`) is itself unbuilt at the time of this RFC.
+
+## Open questions
+
+1. **Crate placement** — Option A (new `icn-relationships` crate) vs Option B (module under `icn-governance`). Architecture review per `INSTITUTION_PACKAGE_BOUNDARY.md` *Reusable Primitive Set* discipline should decide.
+2. **Service trait shape** — Should `RelationshipService` mirror `TrustService` (per `KERNEL_APP_SEPARATION.md`)? Or is direct consumption from a store handle sufficient at the tool layer?
+3. **Lifecycle states** — Is the lifecycle a fixed enum (`active | dormant | closed`) or an opaque string per the anti-ontology-laundering rule? Recommended: opaque string with a documented set of common states, but the kernel does not branch on them.
+4. **Consent scope vocabulary** — Should ICN ship a starter set of consent scopes (`public_listing`, `photography`, etc.) as documentation only, or leave the field entirely free?
+5. **Subject vs counterparty asymmetry** — Are relationships directional (subject → counterparty) or symmetric? Implications for query patterns and receipt routing.
+6. **Receipt class** — Does `RelationshipReceipt` need to be a new receipt class in the ADR-0026 envelope, or does an existing class suffice with a new `kind` discriminator?
+
+## Decision criteria
+
+- Pick **A (new crate)** if the architecture review concludes that relationship state and governance state should evolve independently (likely outcome — relationship surface will grow features that have nothing to do with governance).
+- Pick **B (under `icn-governance`)** if the architecture review concludes that the maintenance cost of a new crate outweighs the conceptual cleanup of separating concerns.
+- Pick **C (defer)** if the build plan slows enough that no L2 tool consumer materializes within the next implementation window. (Unlikely given the build plan.)
+
+## Outcome
+
+To be filled when the RFC moves to `accepted` or `rejected`.
+
+## Follow-up ADRs
+
+If accepted: at least one new ADR recording the crate-placement decision and the type contract. Possibly a second ADR for the service trait if Option A wins.
+
+## Follow-up implementation issues
+
+If accepted:
+
+- New issue: implement `RelationshipRecord` per chosen option.
+- New issue: integrate with ADR-0026 receipt envelope for lifecycle-state-change receipts.
+- New issue: add to `INSTITUTION_PACKAGE_BOUNDARY.md` *Reusable Primitive Set* table.
+- New issue: prerequisite for `icn-member-directory` tool implementation.
+
+## Validation / proof plan
+
+- Unit tests in the new crate (or new module) covering: record creation, lifecycle-state-change emit, receipt formation, opaque `relationship_kind` round-trip, opaque `consent_scopes` round-trip.
+- Integration test: a fictional relationship goes from `created` → `active` → `dormant` → `closed`, each transition produces a receipt, the receipt envelope can replay the history.
+- CI check: kernel crates do not import the relationship crate (firewall preserved).
+- Documentation update: `INSTITUTION_PACKAGE_BOUNDARY.md` *Reusable Primitive Set* table extended.
+
+---
+
+## Notes
+
+This RFC is a stub. The design space is sketched; the recommended option is named (Option A — new substrate crate) but not committed. Drafting will deepen Options A and B in particular, and may add a sketch of the type contract in Rust pseudocode once architecture review converges.

--- a/docs/rfcs/RFC-0017-tool-install-infrastructure.md
+++ b/docs/rfcs/RFC-0017-tool-install-infrastructure.md
@@ -94,7 +94,7 @@ Single RFC for coherent design; implementation split across two or three crates 
 ## Core/package boundary
 
 - **What lives in ICN core** under this RFC: the five infrastructure objects (manifest, binding, lifecycle, registry, audit trail). All five are generic shapes, not institution-specific.
-- **What lives in institution packages**: the binding *content* — NYCN's specific schemas for the bound tools, the institution's specific capability requests, the institution's specific approval-flow values per its charter. NYCN's `tool_bindings` block in `institution/package.yaml` is exactly this.
+- **What lives in institution packages**: the binding *content* — NYCN's specific schemas for the bound tools, the institution's specific capability requests, the institution's specific approval-flow values per its charter. The eventual `tool_bindings` block in NYCN's `institution/package.yaml` (planned follow-up work; see *Follow-up implementation issues* below) will be the first concrete example of this pattern.
 - **What stays opaque to the kernel**: the contents of capability declarations beyond their type-safe shape. Tools may declare `custom_capability: "review-sponsor-recognition"` and the kernel must not branch on the string.
 
 ## Accessibility implications

--- a/docs/rfcs/RFC-0017-tool-install-infrastructure.md
+++ b/docs/rfcs/RFC-0017-tool-install-infrastructure.md
@@ -1,0 +1,176 @@
+---
+id: "0017"
+title: "Tool Install Infrastructure (ToolManifest, ToolBinding, ToolInstall lifecycle)"
+status: "draft"
+created: "2026-04-30"
+updated: "2026-04-30"
+authors: ["Matt Faherty"]
+reviewers: []
+related_adr_candidates: []
+related_issues: []
+supersedes: []
+superseded_by: []
+---
+
+# RFC 0017: Tool Install Infrastructure (ToolManifest, ToolBinding, ToolInstall lifecycle)
+
+## Status
+
+`draft` — being written, not yet ready for review. This RFC explores the L2 install infrastructure already named in [`docs/architecture/COOPERATIVE_TOOL_COMMONS.md`](../architecture/COOPERATIVE_TOOL_COMMONS.md) § *Missing buildout*: `ToolManifest`, `ToolBinding`, `ToolInstall` lifecycle, tool capability registry per `InstitutionalDomain`, and service identity audit trail.
+
+**Accepted RFC does not mean implemented.** Implementation lands under follow-up ADR(s) and issues with code/test evidence.
+
+## Summary
+
+`COOPERATIVE_TOOL_COMMONS.md` (status: design-direction, last reviewed 2026-04-27) names a base-tool catalog (`icn-domain-admin`, `icn-member-directory`, `icn-governance`, `icn-meetings`, `icn-action-cards`, `icn-drive`, `icn-docs`, `icn-tables`, `icn-forms`, `icn-calendar`, `icn-publish`, `icn-search`, `icn-agreements`, `icn-budget`, `icn-signals`, `icn-compute-jobs`, `icn-directory`) and a *Missing buildout* section listing five infrastructure objects that need to land before any tool can be installed by a coop on its own ICN node:
+
+- `ToolManifest` — declares capabilities, data touched, storage needs, privacy classes, UI surfaces, compute jobs, schemas, receipts emitted.
+- `ToolBinding` — per-institution configuration record. Carries the institution's specific values that fill a generic tool's slots.
+- `ToolInstall` lifecycle — submit → review → approve → bind → run → suspend → upgrade → fork → remove.
+- Tool capability registry per `InstitutionalDomain` — what tools exist in this domain, what scopes they hold, what receipts they emit.
+- Service identity audit trail — per-tool history visible through the existing receipt query path.
+
+This RFC explores how to land those five infrastructure objects coherently, integrated with the existing receipt envelope (ADR-0026), action card contract (ADR-0027), authority scope plumbing (PRs #1626/#1627/#1630), and the meaning firewall (`KERNEL_APP_SEPARATION.md`). The recommended direction is to land all five as a single substrate package (one new crate or extension of an existing crate, decided by architecture review), with the lifecycle integrated as governance-driven `Activity` records — install is a governance act, not a marketplace transaction.
+
+## Problem statement
+
+ICN today has no mechanism for an institution to declare which cooperative tools it has installed, what scopes those tools hold, or how those tools' actions are audited. Every base tool named in `COOPERATIVE_TOOL_COMMONS.md` (none of which exist as deployed code today) will need this infrastructure to exist *before* it can ship.
+
+The downstream consequence is that the second-adopter narrative — "RegionalCoopNet spins up an ICN node and installs `icn-member-directory` + `icn-tables`" — has no install verb today. Without `ToolManifest`/`ToolBinding`/`ToolInstall`, the only adoption path is "fork the entire NYCN repo and run it," which is exactly the failure mode the cooperative-tool architecture is meant to avoid.
+
+The five infrastructure objects above were named in the parent doc explicitly: *"Each of these will land via its own ADR or RFC. This document does not pre-commit shapes."* This RFC takes that pre-commitment.
+
+## Goals
+
+- Define `ToolManifest` such that a tool author can declare what their tool needs (capabilities, data scopes, storage, privacy classes, UI surfaces, schemas, receipts) without the kernel pattern-matching on tool-specific keys.
+- Define `ToolBinding` such that an institution can record how *their* domain has chosen to use a generic tool (e.g. "NYCN binds `icn-tables` to its sponsor pipeline schema with these field overrides"). Per `INSTITUTION_PACKAGE_BOUNDARY.md`: institution-specific values stay in the binding, never in the tool.
+- Define the `ToolInstall` lifecycle states and the governance-act mapping for each transition.
+- Define the tool capability registry: a per-`InstitutionalDomain` view of installed tools, granted scopes, and emitted receipts.
+- Define service identity audit trail integration with the ADR-0026 receipt envelope so that every tool action is provenance-bearing.
+- Preserve the anti-capture rule (per `COOPERATIVE_TOOL_COMMONS.md`): a tool that cannot answer "how does the institution leave you cleanly?" is not installable.
+- Preserve the no-marketplace stance: tool install is a governance act, not a transaction.
+
+## Non-goals
+
+- **No tool runtime sandboxing details.** WASM, OS-level isolation, capability-based security mechanics belong in adjacent RFCs/ADRs and reference the existing `icn-compute-jobs` substrate (ADR-0030).
+- **No specific tool implementation.** This RFC is about the install/binding mechanism; `icn-member-directory`, `icn-tables`, etc. land under their own implementation work.
+- **No marketplace, app store, ranking, or recommendation logic.** Install is governance.
+- **No third-party tool registry beyond the per-domain `InstitutionalDomain` capability list.** A federation-wide tool catalog may emerge later but is not in this RFC's scope.
+
+## Background / current state
+
+- [`COOPERATIVE_TOOL_COMMONS.md`](../architecture/COOPERATIVE_TOOL_COMMONS.md) — names the buildout. Defines the install flow conceptually (`tool package submitted → manifest declares capabilities → institution reviews authority request → governance / admin approves install → tool receives ServiceIdentity → tool accesses only granted scopes → tool actions produce receipts → tool can be suspended, upgraded, forked, removed`). Defines tool runtime modes (local node service, frontend-only view, compute workload, bridge adapter, shared service, workstation app, mobile app, package template).
+- [`COOPERATIVE_DOMAIN_INFRASTRUCTURE.md`](../architecture/COOPERATIVE_DOMAIN_INFRASTRUCTURE.md) — parent doc; `InstitutionalDomain` is the per-coop runtime container that tools install into.
+- [`INSTITUTION_PACKAGE_BOUNDARY.md`](../architecture/INSTITUTION_PACKAGE_BOUNDARY.md) — pins the rule: generic shapes in ICN, institution-specific values in packages. `ToolManifest` is generic; `ToolBinding` is the institution's binding.
+- [`KERNEL_APP_SEPARATION.md`](../architecture/KERNEL_APP_SEPARATION.md) — kernel never branches on tool-specific keys; capabilities and scopes are typed; meaning firewall preserved.
+- ADR-0026 (Receipt and Provenance Proof Envelope) — the receipt path tools emit into.
+- ADR-0027 (Action Card Contract) — action cards are derived views over institutional state; tools may compose action cards; this RFC must not contradict the contract.
+- ADR-0030 (Compute Workload Manifest and Authority Boundary) — bridge adapter and compute-job tool runtime modes plug into existing compute manifest constraints.
+- ADR-0031 (Commons Compute Admission and Settlement Policy) — shared-service tool runtime mode references this.
+- PR #1626 (person-directory overlay), PR #1627 (`/me/standing`), PR #1630 (authority scope plumbing) — substrate that `ToolBinding` capability grants extend.
+
+## Design options
+
+### Option A — Single combined RFC, single substrate crate
+
+Land all five infrastructure objects (`ToolManifest`, `ToolBinding`, `ToolInstall` lifecycle, capability registry, service identity audit trail) as one substrate package. New crate `icn-tools` (location TBD; may be `icn/crates/icn-tools/` or a new module under existing crate per architecture review). Single PR per phase; one mental model for adopters.
+
+### Option B — Split into separate RFCs and crates
+
+Each of the five objects gets its own RFC and its own crate. Slower but lower per-PR review surface. Risk: bindings depend on manifests, lifecycle depends on bindings, registry depends on lifecycle — sequencing dependencies make the split painful.
+
+### Option C — Hybrid: one RFC, multiple crates
+
+Single RFC for coherent design; implementation split across two or three crates (e.g. `icn-tool-manifest`, `icn-tool-runtime`, `icn-tool-registry`) if the crate review concludes a single crate is too large.
+
+## Tradeoffs
+
+| Option | Easier | Harder | Invariants preserved | Invariants stressed | New failure modes |
+|---|---|---|---|---|---|
+| A — single crate | one mental model; one review thread; coherent type contract | larger initial PR; one place that holds all five concepts | meaning firewall (single-crate discipline easy to enforce) | none new beyond crate-size norms | a single point of failure in the crate's evolution |
+| B — split RFCs/crates | smaller per-PR surface; independent evolution | sequencing pain (manifest → binding → lifecycle → registry → audit); five separate review threads; risk of inconsistent shape | none new | meaning firewall (more places to enforce) | divergence across the five surfaces; "where is `ToolManifest` defined" question |
+| C — hybrid | single design coherence; smaller crate granularity | crate boundaries must be carefully drawn; slightly more wiring | same as A | same as A | crate-boundary drift over time |
+
+## Core/package boundary
+
+- **What lives in ICN core** under this RFC: the five infrastructure objects (manifest, binding, lifecycle, registry, audit trail). All five are generic shapes, not institution-specific.
+- **What lives in institution packages**: the binding *content* — NYCN's specific schemas for the bound tools, the institution's specific capability requests, the institution's specific approval-flow values per its charter. NYCN's `tool_bindings` block in `institution/package.yaml` is exactly this.
+- **What stays opaque to the kernel**: the contents of capability declarations beyond their type-safe shape. Tools may declare `custom_capability: "review-sponsor-recognition"` and the kernel must not branch on the string.
+
+## Accessibility implications
+
+The install flow is governance-mediated — it surfaces in `icn-domain-admin` and the institution's governance process. Per ADR-0028 (accessibility baseline): the install flow's UI must be plain-language, mobile-first, and operable on low-bandwidth devices for organizers reviewing tool authority requests.
+
+## Conflict / dispute path
+
+- **Disputed install approval.** Reverse the install through a new governance act (lifecycle: `installed` → `suspended` → `removed`). The audit trail preserves the original install.
+- **Disputed tool action.** Tools emit receipts; the receipt envelope (ADR-0026) is the authoritative log. Disputes resolve through the existing dispute surface (ADR-0029 candidate).
+- **Tool fork after disagreement.** The lifecycle includes `fork`; an institution may fork a tool's binding without removing the canonical tool. The fork has its own `ToolBinding`.
+
+## Security / privacy implications
+
+- **Capability over-grant risk.** A `ToolManifest` declaring excessive scopes could be approved by inattentive governance. Mitigation: standardized scope declarations, plain-language summaries surfaced at approval time, and a default deny-by-default posture that requires explicit grant per scope.
+- **Service identity capture.** A compromised tool with a service identity could act on the institution's behalf. Mitigation: receipts on every action, suspension lifecycle state, and a capability registry that lets the domain answer "what does this tool currently hold?" at any time.
+- **Bridge adapter exfiltration risk.** Tool runtime mode "bridge adapter" moves data between ICN and external systems. Mitigation: every bridge action emits a `BridgeImportReceipt` (per `COOPERATIVE_TOOL_COMMONS.md`); no tool can move data silently.
+
+## Compute / automation boundary
+
+- Tools may compute over institution-owned state with declared capabilities. Tools may not mutate state without producing a receipt.
+- Compute workloads (per ADR-0030) used by tools follow the existing compute manifest constraints; this RFC does not introduce a parallel compute path.
+- Determinism and fuel bounds apply where compute is invoked (per ADR-0030 / ADR-0031).
+
+## Website / public truth implications
+
+Once accepted and implemented, the canonical site can claim that ICN supports cooperative-tool install and binding as a substrate primitive. The site does **not** claim a marketplace, an app store, a tool ranking, or any tool catalog beyond the per-domain capability list. Maturity band moves from "design-direction only" to "early" once the install lifecycle has at least one shipped tool flowing through it (probably PR C1 in the build plan: `icn-member-directory`).
+
+## Migration / compatibility
+
+Greenfield substrate. No migration cost for existing deployments, governance proposals, CCL contracts, API consumers, or test surfaces. The first tools to consume this infrastructure (`icn-member-directory`, `icn-tables`) are themselves unbuilt at the time of this RFC.
+
+## Open questions
+
+1. **Crate placement** — Option A (single new crate) vs Option B (split) vs Option C (hybrid). Architecture review per `INSTITUTION_PACKAGE_BOUNDARY.md` *Reusable Primitive Set* discipline should decide. Default recommendation: Option A.
+2. **Manifest format** — YAML, JSON, CCL, or a Rust-typed declaration that compiles into a manifest? Tradeoffs across authoring ergonomics, kernel-discipline review surface, and CI validation cost.
+3. **Lifecycle as `Activity`?** Should the install lifecycle reuse the existing `Activity + Milestone` substrate, or is it a new lifecycle type? Existing primitive likely suffices; verify.
+4. **Capability declaration vocabulary** — Should ICN ship a starter set of capability strings (`read-relationships`, `emit-action-cards`, `bridge-import-from-external`, etc.) as documentation only, or leave declarations entirely free?
+5. **Service identity rotation and revocation** — When a tool is suspended or removed, how is its service identity invalidated across the network? Reuses existing key rotation patterns, or needs new mechanism?
+6. **Cross-domain tool installation** — A federation may want to share a tool install across member entities. Out of scope for this RFC; flag as future work.
+7. **Manifest signing** — Who signs a `ToolManifest` (tool author? distributor? institution at install time)? Implications for trust graph and supply-chain security.
+
+## Decision criteria
+
+- Pick **A (single crate)** if the architecture review concludes the five concepts evolve coherently and the crate is small enough to maintain. Default expectation.
+- Pick **B (split)** if architecture review identifies distinct lifecycles for the five objects (e.g. `ToolManifest` is mostly static while audit trail evolves continuously). Unlikely.
+- Pick **C (hybrid)** if architecture review concludes a single crate would exceed reasonable size after first-cycle implementation; split along natural seams (manifest+binding vs lifecycle vs registry+audit).
+
+## Outcome
+
+To be filled when the RFC moves to `accepted` or `rejected`.
+
+## Follow-up ADRs
+
+If accepted: at least one new ADR recording the crate-placement decision and the type contract. Possibly additional ADRs for capability vocabulary and service identity audit trail integration with ADR-0026.
+
+## Follow-up implementation issues
+
+If accepted:
+
+- New issue: implement `ToolManifest` per chosen option.
+- New issue: implement `ToolBinding` and the per-domain capability registry.
+- New issue: implement `ToolInstall` lifecycle with governance-act integration.
+- New issue: integrate service identity audit trail with ADR-0026 receipt envelope.
+- New issue: add `tool_bindings` block to NYCN's `institution/package.yaml` once binding format is concrete (this is NYCN-side work that depends on PR B landing).
+
+## Validation / proof plan
+
+- Unit tests in the new crate(s) covering: manifest parse, binding validation, lifecycle state transitions, capability registry queries, audit trail receipt formation.
+- Integration test: an end-to-end install of a fictional tool (smallest possible scope) goes through the lifecycle, emits receipts at each transition, appears in the capability registry, and can be cleanly suspended and removed.
+- CI check: kernel crates do not import the tools crate (firewall preserved).
+- CI check: forbidden module paths (`icn-governance::sponsor`, etc., per `INSTITUTION_PACKAGE_BOUNDARY.md`) are not introduced via tool-binding back-doors.
+- Documentation update: `COOPERATIVE_TOOL_COMMONS.md` § *Missing buildout* table marked as landed (or partially landed per option chosen).
+
+---
+
+## Notes
+
+This RFC is a stub. The design space is sketched; the recommended option is named (Option A — single combined RFC and crate, default; Option C as fallback if size demands) but not committed. Drafting will deepen the type contract sketches, the install-flow sequence diagram, and the integration with ADR-0026 / ADR-0027 in particular.

--- a/docs/rfcs/RFC-0017-tool-install-infrastructure.md
+++ b/docs/rfcs/RFC-0017-tool-install-infrastructure.md
@@ -34,11 +34,11 @@ This RFC explores how to land those five infrastructure objects coherently, inte
 
 ## Problem statement
 
-ICN today has no mechanism for an institution to declare which cooperative tools it has installed, what scopes those tools hold, or how those tools' actions are audited. Every base tool named in `COOPERATIVE_TOOL_COMMONS.md` (none of which exist as deployed code today) will need this infrastructure to exist *before* it can ship.
+ICN today has no mechanism for an institution to declare which cooperative tools it has installed, what scopes those tools hold, or how those tools' actions are audited. Every base tool named in `COOPERATIVE_TOOL_COMMONS.md` will need this infrastructure to exist *before* it can ship as an installable tool package with institution-specific bindings for downstream deployment. (Some of the named surfaces — e.g. the governance runtime under `icn-governance` and the HTTP app under `apps/governance` — already exist as in-repo runtime capability; what does not yet exist is the install / binding / audit packaging that lets a coop *declare and govern* their use as installable tools.)
 
 The downstream consequence is that the second-adopter narrative — "RegionalCoopNet spins up an ICN node and installs `icn-member-directory` + `icn-tables`" — has no install verb today. Without `ToolManifest`/`ToolBinding`/`ToolInstall`, the only adoption path is "fork the entire NYCN repo and run it," which is exactly the failure mode the cooperative-tool architecture is meant to avoid.
 
-The five infrastructure objects above were named in the parent doc explicitly: *"Each of these will land via its own ADR or RFC. This document does not pre-commit shapes."* This RFC takes that pre-commitment.
+The five infrastructure objects above were named in the parent doc explicitly: *"Each of these will land via its own ADR or RFC. This document does not pre-commit shapes."* This RFC takes up that work by advancing the missing-buildout list into a structured design exploration.
 
 ## Goals
 

--- a/ops/coordination/rfc_candidates.yaml
+++ b/ops/coordination/rfc_candidates.yaml
@@ -852,3 +852,132 @@ candidates:
       - "Future PR linking canonical site Get-Involved into learn.icn.zone once the site is live"
       - "Possible small ADR recording cross-surface deployment / truth-boundary policy"
     priority: soon
+
+  - id: "0016"
+    title: "Generic Relationship Surface (RelationshipRecord primitive)"
+    status: drafted
+    rfc_path: "docs/rfcs/RFC-0016-relationship-surface.md"
+    domain: governance
+    why_it_matters: |
+      Multiple cooperative-tool surfaces in the design pipeline
+      (icn-member-directory, sponsor / fundraising specialized suite,
+      organizer recruitment, partner workspaces) need to point at a
+      generic non-authority relationship between DIDs (subject,
+      counterparty, owner, lifecycle state, last contact, next
+      followup, consent scopes). INSTITUTION_PACKAGE_BOUNDARY.md
+      correctly excludes CRM from ICN core; the underlying generic
+      relationship primitive is institution-agnostic if it carries no
+      institution-specific enum variants. Without a generic primitive
+      every consumer reinvents one and the second-adopter story
+      breaks.
+    related_adr_candidates: []
+    related_issues: []
+    design_questions:
+      - "Crate placement: new icn-relationships crate vs new module under icn-governance?"
+      - "Service trait shape: mirror TrustService, or direct store consumption sufficient?"
+      - "Lifecycle states: fixed enum or opaque string per anti-ontology-laundering rule?"
+      - "Consent scope vocabulary: ship a starter set as documentation only, or leave entirely free?"
+      - "Subject/counterparty asymmetry: directional or symmetric?"
+      - "Receipt class: new RelationshipReceipt or kind-discriminated extension of existing class?"
+    icn_runtime_surface: "substrate primitive — type, store, receipt emission on lifecycle-state-change"
+    package_or_institution_expression: |
+      Institution packages declare their own relationship_kind values
+      (sponsor, funder, partner, member-coop, vendor, speaker) as
+      opaque strings. The kernel does not branch on these. Consent
+      scope enforcement is per-institution policy.
+    accessibility_implications: |
+      Substrate primitive with no member-facing surface of its own.
+      Accessibility lands in consumer tools; receipts must be small
+      enough that a member shell can render relationship history on
+      low-bandwidth devices.
+    conflict_or_dispute_path: |
+      Disputed records resolve through the institution's dispute
+      surface (ADR-0029 candidate); lifecycle-state-change receipts
+      under ADR-0026 are the authoritative log; consent-scope
+      disputes follow ScopedVault policy.
+    compute_or_automation_boundary: |
+      Compute may render and derive over relationship records; mutations
+      must produce a lifecycle-state-change receipt. Determinism and
+      fuel bounds apply per ADR-0030 where compute jobs are invoked.
+    website_truth_implication: |
+      Once accepted and implemented, the canonical site can claim
+      ICN supports a generic relationship primitive that institutional
+      packages compose specialized contact / partner / sponsor
+      surfaces from. Site does NOT claim ICN provides a CRM.
+    proposed_outputs:
+      - "ADR recording crate-placement decision and type contract"
+      - "Implementation issue for RelationshipRecord primitive"
+      - "Implementation issue for receipt envelope integration"
+      - "Update to INSTITUTION_PACKAGE_BOUNDARY.md Reusable Primitive Set table"
+      - "Prerequisite for icn-member-directory tool implementation"
+    priority: now
+
+  - id: "0017"
+    title: "Tool Install Infrastructure (ToolManifest, ToolBinding, ToolInstall lifecycle)"
+    status: drafted
+    rfc_path: "docs/rfcs/RFC-0017-tool-install-infrastructure.md"
+    domain: package
+    why_it_matters: |
+      COOPERATIVE_TOOL_COMMONS.md Missing-buildout section names five
+      infrastructure objects (ToolManifest, ToolBinding, ToolInstall
+      lifecycle, tool capability registry, service identity audit
+      trail) that need to land before any of the named base tools
+      (icn-member-directory, icn-meetings, icn-tables, icn-docs, etc.)
+      can be installed by a coop on its own ICN node. Without this
+      infrastructure the second-adopter narrative collapses ("fork
+      the entire NYCN repo" is the only adoption path), which is
+      exactly what the cooperative-tool architecture is meant to
+      avoid. Install must be a governance act, not a marketplace
+      transaction (per the parent doc's no-app-store stance).
+    related_adr_candidates: []
+    related_issues: []
+    design_questions:
+      - "Crate placement: single icn-tools crate (Option A), split (Option B), or hybrid (Option C)?"
+      - "Manifest format: YAML, JSON, CCL, or Rust-typed declaration compiled to manifest?"
+      - "Lifecycle as Activity: reuse existing Activity+Milestone substrate or new lifecycle type?"
+      - "Capability declaration vocabulary: ship a starter set as documentation only, or leave free?"
+      - "Service identity rotation/revocation: reuse existing key rotation patterns?"
+      - "Cross-domain tool installation: in scope here or future RFC?"
+      - "Manifest signing: who signs (author / distributor / institution at install time)?"
+    icn_runtime_surface: |
+      substrate types (ToolManifest, ToolBinding), lifecycle records
+      (ToolInstall states), per-domain capability registry, service
+      identity audit trail integrated with the receipt envelope.
+    package_or_institution_expression: |
+      Institutions express tool installs through tool_bindings blocks
+      in their package manifest. NYCN's institution/package.yaml is
+      the first concrete example. Each binding carries the
+      institution's specific schemas, capability requests, and
+      approval-flow values per its charter — not in ICN core.
+    accessibility_implications: |
+      Install flow surfaces in icn-domain-admin and the institution's
+      governance process. Per ADR-0028, the approval UI must be
+      plain-language, mobile-first, low-bandwidth.
+    conflict_or_dispute_path: |
+      Disputed install: reverse through new governance act
+      (lifecycle: installed → suspended → removed); audit trail
+      preserves original install. Disputed tool action: receipts under
+      ADR-0026 are the authoritative log; resolves through the existing
+      dispute surface. Tool fork: the lifecycle includes fork; an
+      institution may fork a tool's binding without removing the
+      canonical tool.
+    compute_or_automation_boundary: |
+      Tools compute over institution-owned state with declared
+      capabilities; mutations produce receipts. Compute workloads used
+      by tools follow ADR-0030 manifest constraints.
+    website_truth_implication: |
+      Once accepted and implemented (with at least one shipped tool
+      flowing through the lifecycle), the canonical site can claim
+      ICN supports cooperative-tool install and binding as a substrate
+      primitive. Site does NOT claim a marketplace, app store, tool
+      ranking, or any tool catalog beyond the per-domain capability
+      list.
+    proposed_outputs:
+      - "ADR recording crate-placement decision and type contract"
+      - "Implementation issue for ToolManifest"
+      - "Implementation issue for ToolBinding and per-domain capability registry"
+      - "Implementation issue for ToolInstall lifecycle with governance-act integration"
+      - "Implementation issue for service identity audit trail integration with ADR-0026"
+      - "NYCN-side issue: add tool_bindings block to institution/package.yaml once binding format is concrete"
+      - "Update to COOPERATIVE_TOOL_COMMONS.md Missing-buildout section marking objects landed"
+    priority: now

--- a/ops/coordination/rfc_candidates.yaml
+++ b/ops/coordination/rfc_candidates.yaml
@@ -864,7 +864,7 @@ candidates:
       organizer recruitment, partner workspaces) need to point at a
       generic non-authority relationship between DIDs (subject,
       counterparty, owner, lifecycle state, last contact, next
-      followup, consent scopes). INSTITUTION_PACKAGE_BOUNDARY.md
+      follow-up, consent scopes). INSTITUTION_PACKAGE_BOUNDARY.md
       correctly excludes CRM from ICN core; the underlying generic
       relationship primitive is institution-agnostic if it carries no
       institution-specific enum variants. Without a generic primitive


### PR DESCRIPTION
## What

Stage 1 / PR A of the cooperative tooling build plan. Two RFC stubs plus matching candidate-registry entries.

- **`docs/rfcs/RFC-0016-relationship-surface.md`** — generic `RelationshipRecord` substrate primitive. Foundational for the planned `icn-member-directory` base tool and any specialized suite (sponsor pipeline, organizer recruitment, partner workspaces) that needs to point at non-authority relationships between DIDs. Stub explores Option A (new `icn-relationships` crate, default recommendation) vs Option B (module under `icn-governance`) vs Option C (defer); architecture review per `INSTITUTION_PACKAGE_BOUNDARY.md` *Reusable Primitive Set* will decide.
- **`docs/rfcs/RFC-0017-tool-install-infrastructure.md`** — single combined RFC covering `ToolManifest`, `ToolBinding`, `ToolInstall` lifecycle, tool capability registry per `InstitutionalDomain`, and service identity audit trail. These are the five infrastructure objects already named as missing buildout in `docs/architecture/COOPERATIVE_TOOL_COMMONS.md`. Without them, no base tool from the published catalog can be installed by a coop on its own ICN node, and the second-adopter narrative collapses.
- **`ops/coordination/rfc_candidates.yaml`** — entries 0016 and 0017 added with `status: drafted`, `priority: now`, full design-question lists, and `rfc_path` pointers.

## Why

`COOPERATIVE_TOOL_COMMONS.md` (status: design-direction, last reviewed 2026-04-27) names the L2 base-tool catalog and an explicit *Missing buildout* list of infrastructure objects that need to land before any tool ships. `INSTITUTION_PACKAGE_BOUNDARY.md` excludes CRM and sponsor/funder/donor from ICN core and pins the placement rule for new primitives. These two RFCs take the next step: turn the named buildout into structured design conversations under the existing RFC process (`RFC-0000`).

Both are draft stubs — motivation, design constraints, options, open questions, decision criteria. No type contracts committed; no implementation. Recommended options are named but defer to architecture review.

## Risk

Low. Doc-only.

- No new crates, types, runtime code, or app-layer implementation.
- No CCL, gateway, or kernel changes.
- No NYCN-side changes (those land in NYCN PRs A1/A2/A3 separately per the build plan).
- The two RFCs use the existing `RFC-NNNN-kebab-title.md` convention and `template.md` structure; new IDs (0016, 0017) follow the next free numbers in `rfc_candidates.yaml`.

## Test plan

- [x] `python3 docs/scripts/doc_control_check.py --strict` — 753 docs scanned, OK; 36 enforcement warnings are pre-existing classification debt for unrelated `docs/plans/`, `docs/onboarding/`, and `docs/ai/` paths, not introduced by this PR.
- [x] `python3 .github/scripts/compliance_linter.py` — no compliance violations across 107 scanned files. RFCs use regulatory-safe vocabulary throughout (settlement / unit / position / obligation / allocation / receipt / provenance).
- [x] `git diff --check` — clean.

## What this PR is not

- Not implementation. No new crates, no new types, no runtime code.
- Not a binding decision. Both RFCs name a recommended option but defer to architecture review per `INSTITUTION_PACKAGE_BOUNDARY.md` *Reusable Primitive Set*.
- Not NYCN-side work. NYCN cleanup PRs (sponsor obligation schema, operating-surfaces ↔ communication-groups dedup, accessibility consolidation) land separately.
- Not Stage 2 work. PRs B (tool install substrate), C0/C1 (`icn-member-directory`), D (`icn-tables`), E (NYCN sponsor specialized-suite binding) are downstream of these RFCs landing.