### PR TITLE
docs(architecture): add sovereign service hosting stack

### DIFF
--- a/docs/architecture/AUTH_BRIDGE_AND_DID_LOGIN.md
+++ b/docs/architecture/AUTH_BRIDGE_AND_DID_LOGIN.md
@@ -1,0 +1,296 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-05-01
+---
+
+# Auth Bridge and DID Login
+
+> **Status: design direction.** This document defines how conventional identity-provider infrastructure should bridge into ICN DID identity and authority. It is not an implementation report and it does not select a specific IdP product.
+
+## Summary
+
+ICN should support conventional web login for conventional web services, but without letting the identity-provider layer become the source of institutional authority.
+
+The rule:
+
+```text
+OIDC authenticates sessions.
+ICN authorizes institutional power.
+Receipts prove institutional transitions.
+```
+
+Keycloak, authentik, ZITADEL, Ory, Kanidm, Forgejo login sources, and similar systems may help browsers and services establish sessions. They do not replace DIDs, standing, role assignments, authority scopes, governance decisions, service identities, or receipts.
+
+## Why this exists
+
+Many useful services speak ordinary identity-provider protocols:
+
+- OIDC
+- OAuth2
+- SAML
+- LDAP / directory bridges
+- passkeys / WebAuthn
+- session cookies
+
+A sovereign forge, status page, metrics dashboard, docs service, registry, or operator console should not each invent its own login system. A shared auth bridge is the right service boundary.
+
+But ICN is not building another corporate tenant stack. The bridge exists so ordinary tools can understand ICN identity; it must not become the authority source.
+
+## Identity stack
+
+```text
+DID / ICN identity
+  = durable cryptographic identity
+
+Device keys / recovery
+  = how that identity survives device change or loss
+
+Auth bridge / IdP
+  = how web services receive login sessions
+
+ICN governance / standing / authority
+  = what the DID may do inside a domain
+
+Receipts
+  = proof that a meaningful transition was authorized and happened
+```
+
+A user may log into a web service through an IdP. The institution still knows the person or service by DID and domain-scoped authority.
+
+## Correct authority direction
+
+Correct:
+
+```text
+DID proves control
+  ↓
+ICN checks standing / role / authority scope
+  ↓
+auth bridge issues short-lived OIDC claims
+  ↓
+service grants local session
+  ↓
+important action emits receipt
+```
+
+Incorrect:
+
+```text
+IdP group membership
+  ↓
+service-local admin role
+  ↓
+institutional authority
+```
+
+The incorrect pattern lets a web admin panel silently become the constitution.
+
+## Candidate service shape
+
+The first auth bridge should likely live at:
+
+```text
+auth.intercooperative.network
+```
+
+Possible implementation choices:
+
+| Candidate | Useful for | Caution |
+|---|---|---|
+| Keycloak | Mature OIDC/OAuth2/SAML bridge, extensibility, enterprise patterns | Heavier operational surface. Must not become authority source. |
+| authentik | Friendly self-hosted SSO and proxy-provider patterns | Still an IdP projection; ICN authority remains elsewhere. |
+| ZITADEL | Organization/multitenant identity patterns | Needs evaluation against ICN domain model. |
+| Ory Hydra/Kratos | More composable identity stack | More assembly; probably not first deployment unless custom UX is desired. |
+| Kanidm | Modern identity management with Rust alignment | Needs maturity/fit review for ICN service integration. |
+
+The implementation choice is operational. The architecture rule is product-agnostic.
+
+## DID login flow
+
+A future `icn-id-bridge` or equivalent service should support a DID challenge-response login flow.
+
+```text
+1. User opens forge.intercooperative.network.
+2. Forge redirects to auth.intercooperative.network.
+3. Auth bridge offers DID login.
+4. Bridge issues a nonce.
+5. User signs nonce with an authorized DID/device key.
+6. Bridge verifies DID authentication.
+7. Bridge queries ICN standing / role / authority scope for the target domain.
+8. Bridge issues short-lived OIDC claims.
+9. Forge creates or updates a service-local session.
+10. Important service actions later map back to ICN receipts.
+```
+
+The session is temporary. The DID is durable.
+
+## Example claims
+
+An OIDC token may project ICN state into claims like:
+
+```json
+{
+  "sub": "did:icn:z...",
+  "icn_did": "did:icn:z...",
+  "icn_domain": "intercooperative-network",
+  "icn_standing": "active",
+  "icn_roles": ["maintainer", "infra-operator"],
+  "icn_scopes": ["repo:write", "release:publish"],
+  "icn_claims_version": "v1"
+}
+```
+
+Claims are projections. They must be short-lived and refreshable from ICN state.
+
+## External account bindings
+
+External identities may be useful as login conveniences:
+
+- GitHub account
+- Google account
+- email/password account
+- passkey account
+- institutional directory account
+
+But they must be bound to an ICN DID through an explicit ceremony.
+
+Correct pattern:
+
+```text
+external account login
+  ↓
+DID challenge signature
+  ↓
+binding record
+  ↓
+optional receipt / audit record
+  ↓
+external account may help enter a session
+```
+
+External account binding does not make the external provider sovereign.
+
+## Binding classes
+
+| Binding | Meaning | Authority posture |
+|---|---|---|
+| Login convenience | External account can initiate a session. | No authority by itself. |
+| Recovery aid | External account participates in recovery flow. | Must be bounded and revocable. |
+| Migration bridge | Legacy account maps to DID during transition. | Temporary; should expire or be reviewed. |
+| Service account binding | Non-human service identity maps to tool/service role. | Requires service identity and scoped capabilities. |
+
+## Service identity login
+
+Services also need to authenticate.
+
+A service identity may represent:
+
+- forge event adapter
+- CI runner
+- release builder
+- backup job
+- bridge importer
+- metrics collector
+- model runner
+- registry publisher
+
+Service login must be scoped more tightly than human login. A service should receive only the capabilities needed for its job, for the shortest useful duration.
+
+## What the auth bridge may do
+
+The auth bridge may:
+
+- verify DID challenge-response login
+- broker external IdP login
+- issue OIDC claims
+- map ICN standing/roles/scopes into service claims
+- maintain short-lived sessions
+- support passkeys or MFA as session-hardening
+- record sensitive access changes for audit
+- help ordinary tools use ICN identity without custom integrations
+
+## What the auth bridge must not do
+
+The auth bridge must not:
+
+- replace DIDs as identity roots
+- decide membership
+- decide standing
+- assign institutional authority
+- become the canonical role database
+- silently grant repository, release, or admin power
+- become the only recovery path
+- trap identity data without export
+- require all members to use a developer-oriented login flow
+
+## Access changes and receipts
+
+Not every login needs a receipt. Routine logins may be operational logs.
+
+Actions that should become receipt-bearing or at least ICN-audited include:
+
+- grant admin access
+- revoke admin access
+- bind external account to DID
+- rotate service identity credential
+- create OIDC client for a governed service
+- change claim-mapping policy
+- change MFA/passkey policy for privileged scopes
+- disable a service identity
+- recover a privileged account
+
+The receipt taxonomy is future work and should align with ADR-0026 rather than create a parallel audit store.
+
+## Browser and mobile posture
+
+The bridge must support ordinary browser flows and future mobile/member-shell flows.
+
+Member-facing participation must not require:
+
+- command line use
+- developer accounts
+- special browser extensions
+- crypto-wallet metaphors
+- long-lived bearer tokens copied by hand
+- laptop-only workflows
+
+The auth bridge is infrastructure. It exists to make member access easier, not to make technical users feel clever.
+
+## Relationship to protocol selection
+
+For browser services, the bridge should prefer:
+
+- HTTP-only secure cookies for ordinary browser sessions.
+- Short-lived tokens for service-to-service calls.
+- SSE streams authorized by cookie or short-lived stream token where appropriate.
+- WebSockets only where a service has a real bidirectional live-state requirement.
+
+See [`PROTOCOL_SELECTION_FOR_MEMBER_SERVICES.md`](PROTOCOL_SELECTION_FOR_MEMBER_SERVICES.md).
+
+## Migration posture
+
+The first deployment can be pragmatic:
+
+1. Deploy an IdP bridge for ordinary service login.
+2. Connect Forgejo via OIDC.
+3. Manually map initial maintainers/admins.
+4. Add DID claim-mapping later.
+5. Add external account binding records later.
+6. Add access-change receipts later.
+7. Move local role truth out of service-local groups and into ICN standing/authority as runtime support lands.
+
+Do not block the first service deployment on a perfect DID-native flow. Do not pretend a conventional IdP is the final authority model.
+
+## Non-goals
+
+- No product selection in this document.
+- No runtime implementation.
+- No claim that DID login exists today.
+- No replacement of ICN identity or authority with IdP groups.
+- No requirement that ordinary members interact with Keycloak-like administration surfaces.
+- No new cryptographic method definition here.
+
+## One-line rule
+
+**The auth bridge translates ICN identity into web sessions; it does not translate web sessions into ICN authority.**

--- a/docs/architecture/PROTOCOL_SELECTION_FOR_MEMBER_SERVICES.md
+++ b/docs/architecture/PROTOCOL_SELECTION_FOR_MEMBER_SERVICES.md
@@ -1,0 +1,348 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-05-01
+---
+
+# Protocol Selection for Member Services
+
+> **Status: design direction.** This document defines protocol-selection doctrine for ICN member-facing and operator-facing services. It is not an implementation report.
+
+## Summary
+
+Protocol choice is infrastructure design. Every protocol carries promises that the network, load balancers, proxies, browsers, mobile devices, and service operators must live with.
+
+ICN should use the least stateful protocol that preserves the institutional function.
+
+Default doctrine:
+
+```text
+HTTP is for institutional facts.
+SSE is for institutional awareness.
+WebSockets are for shared live activity.
+Receipts are the source of truth.
+Polling is the fallback.
+```
+
+This doctrine applies to ICN runtime surfaces, member shells, service-hosting surfaces, operator dashboards, future tool commons services, and institution packages that expose member-facing flows.
+
+## Why this matters
+
+ICN must work for people on phones, older laptops, public Wi-Fi, rural connections, cellular networks, shared devices, screen readers, and interrupted sessions. A fragile real-time stack privileges people with stable hardware and stable networks.
+
+Protocol choice is therefore an accessibility issue, not just an engineering preference.
+
+## Commands, queries, events
+
+ICN services should separate three things.
+
+### Commands
+
+Commands intentionally change state.
+
+Examples:
+
+```text
+POST /v1/gov/domains/{domain_id}/proposals
+POST /v1/gov/domains/{domain_id}/votes
+PUT  /v1/gov/domains/{domain_id}/action-items/{item_id}/status
+POST /v1/services/{service_id}/access-grants
+```
+
+Commands should use ordinary HTTP. They should be idempotent where possible and receipt-bearing where the transition matters.
+
+### Queries
+
+Queries read canonical state.
+
+Examples:
+
+```text
+GET /v1/gov/me/standing
+GET /v1/gov/me/action-cards
+GET /v1/receipts/{receipt_id}
+GET /v1/services/{service_id}/status
+```
+
+Queries should use ordinary HTTP. They should not require a live socket to answer basic membership, governance, or receipt questions.
+
+### Events
+
+Events notify clients that something changed.
+
+Examples:
+
+```text
+GET /v1/events/stream
+GET /v1/gov/domains/{domain_id}/events
+GET /v1/services/forge/builds/{build_id}/events
+```
+
+Events should usually use SSE if they are one-way server-to-client updates.
+
+## SSE default for awareness
+
+Server-Sent Events are the default for one-way update streams:
+
+- action card became available
+- receipt was created
+- proposal changed state
+- build step progressed
+- compute job completed
+- backup finished
+- mirror sync finished
+- service incident updated
+
+SSE keeps the update channel close to ordinary HTTP. It supports replay through event IDs and works well for awareness streams where the server talks and the client listens.
+
+## WebSocket justification rule
+
+A service must justify WebSockets with a real bidirectional requirement.
+
+Use WebSockets for:
+
+- collaborative editing
+- live meeting room presence where both sides send independent events
+- interactive operator shell or console sessions
+- multiplayer-style deliberation surfaces if they ever exist
+- low-latency bidirectional workflows where HTTP + SSE is insufficient
+
+Do not use WebSockets for:
+
+- action card refresh
+- ordinary notifications
+- receipt updates
+- build progress
+- governance event feeds
+- status dashboards
+- most admin dashboards
+
+Those should be HTTP + SSE until proven otherwise.
+
+## Event streams carry pointers, not secrets
+
+Event streams should usually carry pointers rather than full private payloads.
+
+Preferred shape:
+
+```json
+{
+  "event_id": "18492",
+  "type": "receipt.created",
+  "domain_id": "icn-core",
+  "receipt_id": "rec_abc",
+  "source": "action_item.complete"
+}
+```
+
+Then the client fetches:
+
+```text
+GET /v1/receipts/rec_abc
+```
+
+That lets normal authorization protect the full object. It also reduces risk from logs, proxies, browser buffers, and cross-scope leaks.
+
+## Replayability
+
+Any event stream that carries institutional awareness must be replayable.
+
+Required event fields:
+
+```text
+event_id
+sequence or cursor
+source
+domain_id or scope
+type
+timestamp
+object pointer
+```
+
+A reconnecting client should be able to resume:
+
+```text
+Last-Event-ID: 18492
+```
+
+or equivalent cursor semantics.
+
+A disconnected member must not lose institutional state because the network dropped.
+
+## Disconnection is normal
+
+ICN services must assume:
+
+- phones sleep
+- laptops close
+- Wi-Fi changes
+- tunnels kill connections
+- cellular NATs evict idle sessions
+- browsers refresh
+- deployments restart services
+- gateways fail
+
+Therefore:
+
+- writes should be idempotent where possible
+- client UX should distinguish pending / sent / confirmed
+- receipt confirmation should be explicit
+- streams should replay
+- critical functions should have polling fallback
+- reconnect should use backoff and jitter where the client controls reconnection
+
+## Polling fallback
+
+Critical member functions must not depend exclusively on live transport.
+
+If SSE or WebSockets fail, the client should fall back to ordinary HTTP polling for critical surfaces:
+
+```text
+GET /v1/gov/me/action-cards
+GET /v1/gov/me/standing
+GET /v1/receipts/{receipt_id}
+GET /v1/services/{service_id}/status
+```
+
+Polling is not elegant. It is resilient. ICN should prefer member access over architectural vanity.
+
+## Auth posture by protocol
+
+### HTTP commands and queries
+
+Use ordinary session or capability-token authorization, depending on client class.
+
+Browser path:
+
+```text
+OIDC login → secure HTTP-only session cookie → HTTP command/query
+```
+
+Native/mobile path:
+
+```text
+DID/device auth → short-lived capability token → HTTP command/query
+```
+
+### SSE streams
+
+Browser EventSource does not support arbitrary custom request headers. Therefore, choose deliberately:
+
+- secure HTTP-only cookie session for browser streams;
+- short-lived stream token if cookies are not available;
+- fetch-based SSE only when custom headers are necessary;
+- never put sensitive long-lived bearer tokens in URLs.
+
+SSE streams should send pointers, not private payloads.
+
+### WebSockets
+
+WebSockets must authenticate at connection establishment and must re-check authorization for sensitive per-message actions. A long-lived connection must not become a long-lived authority grant.
+
+WebSocket clients must implement:
+
+- heartbeat / ping-pong or equivalent liveness check
+- exponential backoff
+- jitter
+- reset-on-success
+- state resync after reconnect
+- authorization refresh or disconnect on privilege change
+
+## Service template fields
+
+Any service definition that exposes live updates should include:
+
+```yaml
+protocols:
+  commands: HTTP
+  queries: HTTP
+  events: SSE
+  realtime: none
+replay:
+  event_ids: true
+  resume_after_disconnect: true
+fallback:
+  polling: true
+payload_policy:
+  event_streams_carry: pointers
+receipt_source_of_truth: true
+auth:
+  browser: cookie-session
+  mobile: short-lived-capability-token
+```
+
+For WebSocket services:
+
+```yaml
+protocols:
+  realtime: WebSocket
+why_websocket: collaborative editing requires bidirectional low-latency presence
+heartbeat_required: true
+reconnect:
+  backoff: exponential
+  jitter: true
+  reset_on_success: true
+state_recovery: document log / CRDT / receipt replay
+fallback: read-only HTTP view
+```
+
+## Examples
+
+| Surface | Preferred protocol | Reason |
+|---|---|---|
+| `/me/standing` | HTTP | Canonical read. |
+| `/me/action-cards` | HTTP | Canonical read. |
+| action-card updates | SSE | Awareness stream. |
+| proposal vote | HTTP command | Intentional state transition. |
+| receipt retrieval | HTTP | Canonical read. |
+| receipt-created notification | SSE | Pointer to canonical record. |
+| forge build progress | SSE | One-way progress stream. |
+| forge PR discussion comments | HTTP + refresh/SSE | Not inherently bidirectional socket state. |
+| collaborative document editing | WebSocket or equivalent | Shared live activity. |
+| operator shell | WebSocket | Interactive bidirectional session. |
+| service status page | HTTP + optional SSE | Public awareness. |
+
+## Relationship to compute
+
+Compute jobs should produce records and receipts, not hidden socket state.
+
+Preferred flow:
+
+```text
+POST compute job
+  ↓
+HTTP returns job id
+  ↓
+SSE emits progress pointers
+  ↓
+GET job status / receipts for canonical state
+```
+
+A WebSocket may be justified for an interactive compute session, but batch jobs should not require one.
+
+## Relationship to service hosting
+
+Every hosted service should declare its protocol posture in its service definition. See [`SERVICE_HOSTING_MODEL.md`](SERVICE_HOSTING_MODEL.md).
+
+A service that uses WebSockets must also declare the operational tax:
+
+- connection limits
+- backend routing model
+- shared message bus if needed
+- heartbeat interval
+- reconnect behavior
+- deploy/restart behavior
+- state recovery path
+- degraded mode
+
+## Non-goals
+
+- No ban on WebSockets.
+- No runtime implementation.
+- No protocol API spec.
+- No requirement that every service expose SSE immediately.
+- No claim that polling is the ideal UX.
+
+## One-line rule
+
+**Make institutional truth boring, make awareness replayable, and make live state justify itself.**

--- a/docs/architecture/PROTOCOL_SELECTION_FOR_MEMBER_SERVICES.md
+++ b/docs/architecture/PROTOCOL_SELECTION_FOR_MEMBER_SERVICES.md
@@ -40,13 +40,13 @@ ICN services should separate three things.
 
 Commands intentionally change state.
 
-Examples:
+Examples (illustrative; consult the gateway's current routes for the canonical surface):
 
 ```text
-POST /v1/gov/domains/{domain_id}/proposals
-POST /v1/gov/domains/{domain_id}/votes
-PUT  /v1/gov/domains/{domain_id}/action-items/{item_id}/status
-POST /v1/services/{service_id}/access-grants
+POST /v1/gov/proposals                                              # current implemented route
+POST /v1/gov/proposals/{proposal_id}/vote                           # current implemented route
+PUT  /v1/gov/domains/{domain_id}/action-items/{item_id}/status      # illustrative future shape
+POST /v1/services/{service_id}/access-grants                        # illustrative future shape
 ```
 
 Commands should use ordinary HTTP. They should be idempotent where possible and receipt-bearing where the transition matters.
@@ -55,13 +55,13 @@ Commands should use ordinary HTTP. They should be idempotent where possible and 
 
 Queries read canonical state.
 
-Examples:
+Examples (illustrative; current gateway routes are the canonical surface):
 
 ```text
-GET /v1/gov/me/standing
-GET /v1/gov/me/action-cards
-GET /v1/receipts/{receipt_id}
-GET /v1/services/{service_id}/status
+GET /v1/gov/me/standing                  # current implemented route
+GET /v1/gov/me/action-cards              # current implemented route
+GET /v1/receipts/{receipt_id}            # illustrative
+GET /v1/services/{service_id}            # current implemented route
 ```
 
 Queries should use ordinary HTTP. They should not require a live socket to answer basic membership, governance, or receipt questions.
@@ -70,15 +70,15 @@ Queries should use ordinary HTTP. They should not require a live socket to answe
 
 Events notify clients that something changed.
 
-Examples:
+Examples (conceptual stream shapes; not an existing API contract — at least the governance `/events` resource is not currently exposed in the gateway):
 
 ```text
-GET /v1/events/stream
-GET /v1/gov/domains/{domain_id}/events
-GET /v1/services/forge/builds/{build_id}/events
+GET /v1/events/stream                              # conceptual global stream
+GET /v1/gov/domains/{domain_id}/events             # conceptual domain-scoped stream
+GET /v1/services/forge/builds/{build_id}/events    # conceptual build-scoped stream
 ```
 
-Events should usually use SSE if they are one-way server-to-client updates.
+Events should usually use SSE if they are one-way server-to-client updates. Implementation should use whatever streaming endpoints the gateway already exposes; the names above describe the *shape* of streams a future gateway would offer, not endpoints that exist today.
 
 ## SSE default for awareness
 
@@ -290,8 +290,8 @@ fallback: read-only HTTP view
 
 | Surface | Preferred protocol | Reason |
 |---|---|---|
-| `/me/standing` | HTTP | Canonical read. |
-| `/me/action-cards` | HTTP | Canonical read. |
+| `/v1/gov/me/standing` | HTTP | Canonical read. |
+| `/v1/gov/me/action-cards` | HTTP | Canonical read. |
 | action-card updates | SSE | Awareness stream. |
 | proposal vote | HTTP command | Intentional state transition. |
 | receipt retrieval | HTTP | Canonical read. |

--- a/docs/architecture/SERVICE_HOSTING_MODEL.md
+++ b/docs/architecture/SERVICE_HOSTING_MODEL.md
@@ -118,12 +118,12 @@ operator_scope: ICN Infrastructure
 governance_scope: ICN Core Maintainers
 identity_provider: auth.intercooperative.network
 canonical_data:
-  - repositories
-  - issues
-  - pull requests
-  - releases
+  - repositories                                  # rehearsal-stage canonical (forge holds working-tree mirrors)
+  - issues (after cutover from GitHub)            # GitHub remains canonical until explicit cutover
+  - pull requests (after cutover from GitHub)     # GitHub remains canonical until explicit cutover
+  - releases (after cutover from GitHub)          # GitHub remains canonical until explicit cutover
 external_mirrors:
-  - github.com/InterCooperative-Network/icn
+  - github.com/InterCooperative-Network/icn       # pre-cutover canonical for issues, pull requests, releases
 receipts_initial:
   - BackupReceipt
   - RepoMirrorReceipt

--- a/docs/architecture/SERVICE_HOSTING_MODEL.md
+++ b/docs/architecture/SERVICE_HOSTING_MODEL.md
@@ -1,0 +1,310 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-05-01
+---
+
+# Service Hosting Model
+
+> **Status: design direction.** This document names how ICN should treat hosted services such as a forge, identity-provider bridge, status page, registry, documentation surface, metrics surface, and future tool services. It is not an implementation report and it does not declare any service live.
+
+## Summary
+
+ICN services should not merely be deployed. They should be **governed**.
+
+A service is legitimate when its authority, custody, access, failure modes, backups, upgrades, event streams, compute jobs, and receipts are legible. Running a service is an operational fact; governing a service is an institutional fact.
+
+This document adds a service-hosting layer to the existing architecture:
+
+```text
+public / learning surfaces
+        ↓
+institution packages
+        ↓
+sovereign service hosting layer  ← this document
+        ↓
+tool / service adapter layer
+        ↓
+ICN runtime apps
+        ↓
+ICN substrate
+        ↓
+ops / infrastructure
+```
+
+The immediate forcing case is a sovereign forge, but the model is generic. The same service skeleton should eventually apply to the forge, auth bridge, status page, registry, docs, receipts, metrics, and institution-facing hosted tools.
+
+## Relationship to existing architecture
+
+This document extends, but does not replace:
+
+- [`COOPERATIVE_DOMAIN_INFRASTRUCTURE.md`](COOPERATIVE_DOMAIN_INFRASTRUCTURE.md) — institutional domains, service identities, devices, workspaces, vaults, agreements, routing, and commons resource sharing.
+- [`COOPERATIVE_TOOL_COMMONS.md`](COOPERATIVE_TOOL_COMMONS.md) — installable / forkable tools that operate on institution-owned state and emit receipts.
+- [`DOMAIN_ROUTING_AND_DNS_BINDINGS.md`](DOMAIN_ROUTING_AND_DNS_BINDINGS.md) — DNS routes are bindings to authority; DNS is not authority itself.
+- [`MODEL_WORKLOADS_AND_DELIBERATION.md`](MODEL_WORKLOADS_AND_DELIBERATION.md) — compute assists institutions; it does not govern them.
+- [RFC-0017](../rfcs/RFC-0017-tool-install-infrastructure.md) — future `ToolManifest`, `ToolBinding`, service identity audit trail, and tool install lifecycle.
+
+This document focuses on the operational bridge between those designs: how an actual service should be described before it becomes ICN-native.
+
+## Core doctrine
+
+```text
+ICN owns authority.
+Services expose functions.
+Adapters translate service events.
+Receipts prove transitions.
+Compute produces evidence.
+Governance authorizes power.
+```
+
+A service may host workflows, files, repositories, dashboards, or login screens. It does not become the source of institutional truth unless ICN explicitly records and proves the transition that made something true.
+
+## Hosted → governed → native
+
+Services should move through three stages.
+
+### 1. Hosted service
+
+The service runs on infrastructure operated by ICN or an ICN-aligned operator.
+
+Examples:
+
+- Forgejo running at `forge.intercooperative.network`.
+- An identity-provider bridge running at `auth.intercooperative.network`.
+- Grafana behind authenticated access.
+
+At this stage, the service is operationally useful but may not yet emit ICN receipts or consume ICN-native service identities.
+
+### 2. Governed service
+
+Changes to the service are bound to explicit authority.
+
+Examples:
+
+- Admin access changes require the right operator scope.
+- Backup policy is documented and tested.
+- Upgrade policy names who may apply updates.
+- Route changes produce binding records.
+- Access grants and revocations are auditable.
+
+At this stage, the service is no longer just a sysadmin artifact. It has institutional custody.
+
+### 3. ICN-native service
+
+The service participates directly in ICN primitives.
+
+Examples:
+
+- The service has a `ServiceIdentity`.
+- Its actions are capability-scoped.
+- Meaningful transitions emit receipts.
+- Event streams carry receipt pointers.
+- Compute jobs are represented as constrained workloads.
+- Installation and suspension eventually map to `ToolManifest` / `ToolBinding` lifecycle records.
+
+The first deployment of a service should not pretend to be stage 3. The path should be explicit.
+
+## Service definition
+
+Every ICN-governed service should have a service definition before it is treated as a durable dependency.
+
+```yaml
+service: forge
+status: planned
+route: forge.intercooperative.network
+service_kind: hosted_service
+runtime: Forgejo
+operator_scope: ICN Infrastructure
+governance_scope: ICN Core Maintainers
+identity_provider: auth.intercooperative.network
+canonical_data:
+  - repositories
+  - issues
+  - pull requests
+  - releases
+external_mirrors:
+  - github.com/InterCooperative-Network/icn
+receipts_initial:
+  - BackupReceipt
+  - RepoMirrorReceipt
+  - ReleaseReceipt
+receipts_future:
+  - AccessGrantReceipt
+  - AccessRevocationReceipt
+  - MergeReceipt
+  - ToolBindingReceipt
+protocols:
+  commands: HTTP
+  events: SSE
+  realtime: WebSocket only when justified
+backup_required: true
+restore_test_required: true
+exit_path_required: true
+```
+
+The service definition is not the runtime implementation. It is the institutional declaration of what the service is, who operates it, what data it touches, what authority it requires, and how the institution leaves cleanly if the service fails or is replaced.
+
+## Required questions for any service
+
+A service definition must answer:
+
+- Who operates the service?
+- Which governance scope authorizes it?
+- Which route points to it?
+- What data does it hold?
+- Which data is canonical and which is cached or mirrored?
+- Which identities may administer it?
+- Which identities may use it?
+- Which actions require receipts?
+- Which actions merely produce operational logs?
+- How is the service backed up?
+- Where are backups stored?
+- How is restore tested?
+- What happens if the operator disappears?
+- What happens if the host fails?
+- How does the institution export and leave?
+- Which protocol surfaces does it expose?
+- Which critical features degrade to polling or ordinary HTTP?
+
+## Authority model
+
+A hosted service must not become a private root of power. ICN authority remains expressed through DIDs, standing, roles, authority scopes, governance decisions, and receipts.
+
+A service may maintain local accounts as an operational projection. Those accounts are not sovereign identity.
+
+Correct pattern:
+
+```text
+member DID / service DID
+        ↓
+ICN standing + authority scope
+        ↓
+auth bridge or service adapter
+        ↓
+service-local account/session
+        ↓
+action
+        ↓
+receipt if the action changes institutional state
+```
+
+Incorrect pattern:
+
+```text
+service admin panel
+        ↓
+service-local role
+        ↓
+institutional authority
+```
+
+The second pattern rebuilds a platform tenant model and must not become ICN doctrine.
+
+## Event model
+
+Service events are not truth by themselves. They are notifications or evidence.
+
+A service event should usually become one of three things:
+
+1. **Ignored operational noise** — routine logs, health checks, view events.
+2. **Evidence** — a CI result, scan result, backup report, or audit summary.
+3. **Institutional transition** — an access grant, release, mirror update, publication, or other state change that must emit a receipt.
+
+For member-facing and operator-facing streams, events should generally carry pointers rather than private payloads:
+
+```json
+{
+  "event_id": "18492",
+  "type": "receipt.created",
+  "domain_id": "icn-core",
+  "receipt_id": "rec_abc",
+  "source": "forge.release"
+}
+```
+
+The client then fetches the receipt or state object through ordinary authorization.
+
+## Protocol rule
+
+Protocol selection is part of service design.
+
+Default posture:
+
+```text
+HTTP is for institutional facts.
+SSE is for institutional awareness.
+WebSockets are for shared live activity.
+Receipts are the source of truth.
+Polling is the fallback.
+```
+
+See [`PROTOCOL_SELECTION_FOR_MEMBER_SERVICES.md`](PROTOCOL_SELECTION_FOR_MEMBER_SERVICES.md).
+
+## Compute rule
+
+Services may ask compute to produce evidence:
+
+- run tests
+- run accessibility checks
+- scan dependencies
+- generate release artifacts
+- summarize logs
+- produce repo maps
+- generate source-linked review packets
+
+Compute does not decide. A compute result may inform a maintainer or governance body; it does not merge, release, grant access, revoke access, publish, or settle anything by itself.
+
+## Data custody
+
+A service must distinguish:
+
+| Class | Meaning |
+|---|---|
+| Canonical state | The service currently holds the authoritative working copy for the institution. Requires backup, export, restore, and future receipt path. |
+| Projection | Service-local view of ICN state. Can be regenerated from ICN. |
+| Cache | Performance copy. Disposable. |
+| Mirror | Copy pushed outward for discovery or redundancy. Not canonical. |
+| External source | Data imported from a non-ICN surface. Requires bridge markers and review boundaries. |
+
+For the forge, GitHub should become a mirror and contributor funnel, not the canonical home of ICN development.
+
+## Initial services to model
+
+The first services worth modeling are:
+
+| Service | Role | Why first |
+|---|---|---|
+| `forge` | Sovereign code forge | ICN should not depend on a corporate forge as its only workshop. |
+| `auth` | Web identity-provider bridge | Normal web services need OIDC/OAuth2-style sessions; ICN DIDs remain the authority. |
+| `status` | Public status surface | Makes outages legible without requiring service access. |
+| `metrics` | Internal observability | Existing monitoring should be behind governed access. |
+| `registry` | Future artifact / release / receipt registry | Connects releases, proofs, and artifacts. |
+| `docs` | Future documentation/publishing service | Public/civic documents with publication receipts. |
+
+## Non-goals
+
+- No runtime implementation in this document.
+- No declaration that any service is currently live.
+- No requirement to abandon GitHub immediately.
+- No treatment of Keycloak, authentik, ZITADEL, Forgejo, Grafana, or any other tool as ICN authority.
+- No claim that service hosting is already ICN-native.
+- No institution-specific nouns introduced as ICN core primitives.
+
+## Build order
+
+Recommended order:
+
+1. Land service-hosting doctrine and templates.
+2. Define the sovereign forge plan.
+3. Define the auth bridge plan.
+4. Deploy non-production services.
+5. Add backups and restore tests.
+6. Add OIDC login for the forge.
+7. Add service event adapters.
+8. Add receipt classes or map to existing receipt envelope where appropriate.
+9. Add compute jobs as evidence producers.
+10. Later, map mature services into `ToolManifest` / `ToolBinding` lifecycle once RFC-0017 lands.
+
+## One-line rule
+
+**ICN services should be operated like infrastructure, governed like institutions, and verified like receipts.**

--- a/docs/ops/FORGEJO_DEPLOYMENT_PLAN.md
+++ b/docs/ops/FORGEJO_DEPLOYMENT_PLAN.md
@@ -42,11 +42,13 @@ Recommended initial posture:
 service: forge
 route: forge.intercooperative.network
 runtime: Forgejo
-stage: hosted_service
+service_kind: hosted_service
 canonical_status: rehearsal
 github_role: canonical_for_now
 cutover_status: not_started
 ```
+
+The `service_kind` value here uses the same vocabulary the rest of this PR uses for the hosted → governed → ICN-native classification (`hosted_service` | `governed_service` | `icn_native_service`). A forge in rehearsal stage is intentionally `hosted_service`, not yet `governed_service`.
 
 Do not start by claiming the forge is canonical. Start by making it real, backed up, restorable, observable, and documented.
 

--- a/docs/ops/FORGEJO_DEPLOYMENT_PLAN.md
+++ b/docs/ops/FORGEJO_DEPLOYMENT_PLAN.md
@@ -1,0 +1,303 @@
+---
+Status: operational
+Canonical: no
+Last Reviewed: 2026-05-01
+---
+
+# Forgejo Deployment Plan
+
+> **Status: operational planning.** This document describes the proposed first deployment path for an ICN sovereign forge. It does not deploy Forgejo, change DNS, mutate infrastructure, or make the ICN forge canonical.
+
+## Summary
+
+The first sovereign forge deployment should be a conservative Forgejo MVP:
+
+```text
+forge.intercooperative.network
+  → Forgejo
+  → persistent storage
+  → SSH + HTTPS Git
+  → backups + restore test
+  → GitHub mirroring
+  → OIDC path identified
+  → monitoring
+```
+
+The first goal is governed custody, not full ICN-native integration.
+
+## Inputs from architecture
+
+This plan implements the first operational slice of:
+
+- [`SERVICE_HOSTING_MODEL.md`](../architecture/SERVICE_HOSTING_MODEL.md)
+- [`AUTH_BRIDGE_AND_DID_LOGIN.md`](../architecture/AUTH_BRIDGE_AND_DID_LOGIN.md)
+- [`PROTOCOL_SELECTION_FOR_MEMBER_SERVICES.md`](../architecture/PROTOCOL_SELECTION_FOR_MEMBER_SERVICES.md)
+- [`../strategy/SOVEREIGN_FORGE.md`](../strategy/SOVEREIGN_FORGE.md)
+
+## Deployment posture
+
+Recommended initial posture:
+
+```yaml
+service: forge
+route: forge.intercooperative.network
+runtime: Forgejo
+stage: hosted_service
+canonical_status: rehearsal
+github_role: canonical_for_now
+cutover_status: not_started
+```
+
+Do not start by claiming the forge is canonical. Start by making it real, backed up, restorable, observable, and documented.
+
+## Deployment target options
+
+| Target | Use | Caution |
+|---|---|---|
+| VPS / dedicated host | Best first public deployment if available. Stable networking and simple blast radius. | Needs backup and host custody policy. |
+| Existing K3s / homelab | Useful if consistent with current ICN deploy conventions. | Residential/network fragility must be acknowledged. |
+| Kubernetes / Helm | Good if ICN wants service parity with existing deploy patterns. | More moving parts; avoid overcomplication. |
+| Docker Compose | Good for rehearsal or single-node MVP. | Less aligned with future service hosting if production moves to K3s/Helm. |
+
+A boring VPS or a clearly managed K3s service is preferable to a fragile experimental deployment. The forge will become part of project continuity.
+
+## MVP components
+
+Required:
+
+- Forgejo web service
+- persistent repository storage
+- database storage, if not using embedded mode
+- SSH Git endpoint
+- HTTPS Git endpoint
+- TLS certificate
+- route / DNS record
+- admin bootstrap procedure
+- backup job
+- restore test procedure
+- service monitoring
+- GitHub mirror procedure
+- incident rollback notes
+
+Optional first wave:
+
+- OIDC login against `auth.intercooperative.network`
+- Prometheus metrics if available
+- object storage for attachments or artifacts
+- email notifications
+- runner integration
+
+Defer:
+
+- ICN-native service identity
+- merge receipts
+- release receipts
+- access receipts
+- compute-settled CI
+- full issue migration
+- GitHub canonical cutover
+
+## Service data classes
+
+Declare data custody explicitly:
+
+| Data | Initial class | Notes |
+|---|---|---|
+| Git repos | Mirror / rehearsal at first; canonical only after cutover | Must be backed up before cutover. |
+| Issues | GitHub canonical at first | Migrate only with explicit plan. |
+| Pull requests | GitHub canonical at first | Do not disrupt active contribution flow. |
+| Releases | GitHub canonical at first | Forge releases may be rehearsal until cutover. |
+| Users / sessions | Projection | Auth bridge should eventually project ICN identity. |
+| Attachments | Service state | Requires backup if enabled. |
+| Webhooks | Operational config | Must be documented if they trigger actions. |
+
+## Initial service definition
+
+```yaml
+service: forge
+status: planned
+route: forge.intercooperative.network
+service_kind: hosted_service
+runtime: Forgejo
+operator_scope: ICN Infrastructure
+governance_scope: ICN Core Maintainers
+identity_provider: auth.intercooperative.network # planned; may be manual at MVP
+canonical_data:
+  - repositories after cutover
+external_mirrors:
+  - github.com/InterCooperative-Network/icn
+  - github.com/InterCooperative-Network/nycn
+  - github.com/InterCooperative-Network/icn-learn
+receipts_initial: []
+receipts_future:
+  - RepoMirrorReceipt
+  - ReleaseReceipt
+  - AccessGrantReceipt
+  - AccessRevocationReceipt
+  - MergeReceipt
+protocols:
+  commands: HTTP
+  events: SSE where available
+  realtime: none for MVP
+backup_required: true
+restore_test_required: true
+exit_path_required: true
+```
+
+## Bootstrap checklist
+
+### Preflight
+
+- [ ] Confirm route choice.
+- [ ] Confirm deployment target.
+- [ ] Confirm storage location.
+- [ ] Confirm backup destination.
+- [ ] Confirm admin bootstrap identity.
+- [ ] Confirm whether OIDC is available for first pass.
+- [ ] Confirm firewall/ports: HTTPS and SSH Git.
+- [ ] Confirm monitoring target.
+- [ ] Confirm GitHub mirror direction for rehearsal.
+
+### Deploy
+
+- [ ] Deploy Forgejo.
+- [ ] Provision persistent storage.
+- [ ] Configure route and TLS.
+- [ ] Configure SSH Git.
+- [ ] Create initial admin.
+- [ ] Create organization / namespace.
+- [ ] Import or mirror `icn`.
+- [ ] Import or mirror `nycn` if appropriate.
+- [ ] Import or mirror `icn-learn` if appropriate.
+- [ ] Configure outbound mirror or inbound mirror.
+- [ ] Configure backup job.
+- [ ] Configure monitoring.
+
+### Verify
+
+- [ ] Web UI loads over HTTPS.
+- [ ] SSH clone works.
+- [ ] HTTPS clone works.
+- [ ] Push works for authorized admin.
+- [ ] Mirror sync works.
+- [ ] Backup artifact exists.
+- [ ] Restore test succeeds in isolated environment.
+- [ ] Logs are accessible to authorized operator.
+- [ ] Service status is visible.
+
+## Auth posture
+
+MVP options:
+
+1. **Temporary local admin** — acceptable only for first bootstrap; must be documented and minimized.
+2. **OIDC through auth bridge** — preferred if `auth.intercooperative.network` is ready.
+3. **External GitHub login** — acceptable only as convenience and bootstrap, not authority.
+
+Target posture:
+
+```text
+DID / ICN identity
+  ↓
+ICN standing / role / authority scope
+  ↓
+auth bridge OIDC claims
+  ↓
+Forgejo local session / team projection
+```
+
+## Mirroring posture
+
+Before cutover:
+
+```text
+GitHub canonical → Forgejo rehearsal mirror
+```
+
+After cutover:
+
+```text
+Forgejo canonical → GitHub public mirror
+```
+
+Cutover must not happen until backups, restore, auth, contributor instructions, mirror direction, and rollback are documented.
+
+## Backup requirements
+
+Minimum:
+
+- daily database backup
+- repository data backup
+- attachment/LFS backup if enabled
+- configuration backup excluding secrets or with encrypted secret handling
+- off-host copy
+- restore test before canonical cutover
+
+A forge without restore is not sovereignty. It is a login page with a hostage situation waiting inside it.
+
+## Restore test
+
+A restore test must verify:
+
+- Forgejo starts from backup.
+- Repositories are present.
+- refs/tags/branches are intact.
+- users/orgs/teams are present or documented as intentionally excluded.
+- issues/PRs/releases are present if those are in scope.
+- SSH/HTTPS clone works after restore.
+- mirror configuration is either restored or intentionally re-created.
+
+## Incident and rollback posture
+
+Before canonical cutover, rollback is simple: GitHub remains canonical.
+
+After canonical cutover, rollback requires:
+
+- recent backup
+- GitHub mirror freshness check
+- DNS rollback or status notice
+- contributor communication
+- freeze window for pushes if needed
+- receipt/audit note for the incident, once receipt support exists
+
+## Integration path
+
+### Phase 1 — hosted service
+
+- Forgejo runs.
+- GitHub remains canonical.
+- Backups and restore test exist.
+
+### Phase 2 — governed service
+
+- Service definition is ratified or accepted by maintainers.
+- Access policy exists.
+- Backup policy exists.
+- Upgrade policy exists.
+- Incident policy exists.
+
+### Phase 3 — adapted service
+
+- Forgejo webhooks feed a service adapter.
+- Adapter classifies events as noise, evidence, or institutional transition.
+- Compute jobs can be triggered for CI/evidence.
+
+### Phase 4 — ICN-native service
+
+- Forge has a `ServiceIdentity`.
+- Meaningful transitions emit receipts.
+- Merge/release/access records bind to ICN authority.
+- GitHub is public mirror only.
+
+## Non-goals
+
+- No deployment in this document.
+- No DNS mutation.
+- No secrets committed.
+- No GitHub deprecation.
+- No canonical cutover.
+- No CI runner migration.
+- No claim that Forgejo is formally selected by ADR.
+
+## One-line rule
+
+**Deploy the forge boring first; make it governed before making it canonical; make it native only after the service proves it can be trusted.**

--- a/docs/ops/SERVICE_GOVERNANCE_TEMPLATE.md
+++ b/docs/ops/SERVICE_GOVERNANCE_TEMPLATE.md
@@ -1,0 +1,282 @@
+---
+Status: operational
+Canonical: no
+Last Reviewed: 2026-05-01
+---
+
+# Service Governance Template
+
+> **Status: operational template.** Copy this template when proposing a new ICN-hosted or ICN-governed service. Filling out this template does not deploy the service or make it canonical.
+
+## Purpose
+
+This template forces every service proposal to answer the same questions:
+
+- What is the service?
+- Who operates it?
+- Who governs it?
+- What data does it hold?
+- How does identity work?
+- What protocol promises does it make?
+- What produces receipts?
+- How is it backed up?
+- How does the institution leave cleanly?
+
+A service that cannot answer these questions is not ready to become an ICN dependency.
+
+---
+
+## Service definition
+
+```yaml
+service: <short-name>
+status: planned | rehearsal | active | canonical | deprecated
+route: <host-or-route>
+service_kind: hosted_service | governed_service | icn_native_service
+runtime: <software/runtime>
+operator_scope: <who runs it>
+governance_scope: <who authorizes policy changes>
+identity_provider: <auth route or none>
+canonical_status: none | rehearsal | canonical | mirror | projection
+```
+
+## Summary
+
+Describe what the service does in one paragraph.
+
+## Why this service exists
+
+Explain the institutional need. Avoid tool-first justification. The service should reduce burden, preserve memory, improve access, create resilience, or make authority/provenance clearer.
+
+## Non-goals
+
+List what this service does not do.
+
+Examples:
+
+- Does not become ICN authority.
+- Does not replace DIDs.
+- Does not hold private data beyond stated scopes.
+- Does not make GitHub obsolete on day one.
+- Does not introduce institution-specific nouns into ICN core.
+
+## Data custody
+
+| Data class | Canonical / projection / cache / mirror / external | Notes |
+|---|---|---|
+|  |  |  |
+
+Data classes:
+
+- **Canonical** — source of truth for a bounded area.
+- **Projection** — derived view of ICN or another source.
+- **Cache** — disposable performance copy.
+- **Mirror** — copy for discovery, redundancy, or compatibility.
+- **External** — imported or linked from outside ICN.
+
+## Authority model
+
+Who may use the service?
+
+Who may administer it?
+
+Which authority scopes are required?
+
+Which actions require governance approval?
+
+Which actions are ordinary operator actions?
+
+## Identity and login
+
+```yaml
+auth:
+  browser: cookie-session | oidc | local-temporary | none
+  did_login: planned | implemented | not_applicable
+  external_idp_bindings: allowed | disallowed | transition_only
+  service_identities: planned | implemented | not_applicable
+```
+
+State clearly whether service-local users/groups are canonical or projections.
+
+Preferred doctrine:
+
+```text
+DID / ICN standing / authority_scope = authority
+IdP / OIDC / service-local account = session projection
+```
+
+## Protocol posture
+
+```yaml
+protocols:
+  commands: HTTP | other
+  queries: HTTP | other
+  events: SSE | polling | none
+  realtime: WebSocket | none
+replay:
+  event_ids: true | false | not_applicable
+  resume_after_disconnect: true | false | not_applicable
+fallback:
+  polling: true | false | not_applicable
+payload_policy:
+  event_streams_carry: pointers | payloads | none
+receipt_source_of_truth: true | false
+```
+
+If `realtime: WebSocket`, justify why HTTP + SSE is insufficient.
+
+## Receipt posture
+
+List actions that should be receipt-bearing.
+
+| Action | Receipt candidate | Implemented now? | Notes |
+|---|---|---|---|
+|  |  | no |  |
+
+Receipt candidates must eventually align with the ADR-0026 receipt envelope. Do not invent a parallel audit system.
+
+## Compute posture
+
+Can this service trigger compute jobs?
+
+Examples:
+
+- scans
+- indexing
+- summarization
+- release builds
+- docs freshness
+- accessibility tests
+- translation
+- model-assisted deliberation packets
+
+Rule:
+
+```text
+compute produces evidence; governance / authorized humans decide
+```
+
+## Backups
+
+```yaml
+backup:
+  required: true | false
+  frequency: daily | weekly | manual | other
+  includes:
+    - database
+    - files
+    - configuration
+    - repositories
+  offsite_copy: true | false
+  encryption: required | not_required | unknown
+  restore_test_required: true | false
+```
+
+Describe where backups go and who can restore them.
+
+## Restore test
+
+Describe how restore is tested.
+
+Minimum questions:
+
+- Can the service start from backup?
+- Is canonical data present?
+- Are permissions/session projections restored or intentionally recreated?
+- Are secrets handled safely?
+- Can clients reconnect or reauthenticate?
+- Is mirror direction preserved or intentionally reset?
+
+## Incident plan
+
+Describe what happens when:
+
+- service is down
+- operator loses access
+- host fails
+- database corrupts
+- credentials leak
+- route/TLS fails
+- upgrade fails
+- mirror diverges
+- unauthorized access is suspected
+
+## Exit / migration path
+
+A service that traps institutional state should not be installed.
+
+Explain:
+
+- How data exports.
+- Which formats are used.
+- How another service can import it.
+- What must be retained for audit.
+- Which data can be discarded.
+- How users are notified.
+
+## Privacy / access boundaries
+
+List the most sensitive data the service can see.
+
+List the data it must never receive.
+
+List scopes or roles that can access sensitive data.
+
+## Observability
+
+Describe:
+
+- metrics
+- logs
+- uptime checks
+- alerting
+- status-page integration
+- who can see operational logs
+- whether logs include sensitive data
+
+## Deployment target
+
+```yaml
+deploy:
+  target: vps | k3s | kubernetes | docker-compose | systemd | other
+  persistence: pvc | host-path | object-store | database | other
+  tls: acme | manual | reverse-proxy | other
+  ssh_or_special_ports: []
+```
+
+## Cutover gates
+
+For services that replace an external dependency, list cutover gates.
+
+Example gates:
+
+- backup passes
+- restore tested
+- auth works
+- route stable
+- mirror tested
+- contributor docs updated
+- incident rollback documented
+- service owners named
+- export path confirmed
+
+## Review checklist
+
+- [ ] Service definition is complete.
+- [ ] Authority model is clear.
+- [ ] Data custody is classified.
+- [ ] Backup plan exists.
+- [ ] Restore test exists.
+- [ ] Exit path exists.
+- [ ] Protocol posture is justified.
+- [ ] WebSocket use, if any, is justified.
+- [ ] Receipt candidates are named.
+- [ ] Compute use is evidence-only.
+- [ ] Auth bridge does not become authority.
+- [ ] No secrets are committed.
+- [ ] No institution-specific nouns are introduced into ICN core.
+- [ ] Accessibility / mobile implications are considered.
+
+## One-line rule
+
+**A service proposal is not ready until the institution can explain how to operate it, govern it, recover it, audit it, and leave it.**

--- a/docs/strategy/SOVEREIGN_FORGE.md
+++ b/docs/strategy/SOVEREIGN_FORGE.md
@@ -1,0 +1,350 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-05-01
+---
+
+# Sovereign Forge Strategy
+
+> **Status: strategy / design direction.** This document defines why ICN should operate its own forge and how the transition should be staged. It does not deploy a forge, change the canonical repository location, or deprecate GitHub today.
+
+## Summary
+
+ICN should operate a sovereign forge because a project building cooperative infrastructure should not depend on a corporate platform as the only canonical home of its own workshop.
+
+The strategic direction:
+
+```text
+ICN-controlled forge = canonical institutional workshop
+GitHub = public mirror, discovery surface, and contributor funnel
+```
+
+The immediate target is not purity. The immediate target is infrastructure sovereignty without breaking the workflows that currently work.
+
+## Why this matters
+
+Git hosting is not just storage. A forge holds:
+
+- source code
+- issues
+- pull requests
+- releases
+- contributor records
+- access control
+- review history
+- project memory
+- CI hooks
+- artifacts
+- governance-adjacent decision traces
+
+For ICN, that is institutional nervous tissue. Leaving it exclusively on a proprietary corporate platform contradicts the project's own premise: communities need infrastructure they can actually govern.
+
+The claim is not "GitHub is useless." GitHub remains useful for visibility, social proof, contributor discovery, issue references, and public mirroring.
+
+The claim is:
+
+> GitHub should not be the homeland.
+
+## The forge as first sovereignty service
+
+The forge should be treated as ICN's first serious sovereignty service.
+
+A sovereignty service is a hosted service that forces ICN to answer real institutional questions:
+
+- Who controls the domain?
+- Who controls the server?
+- Who controls deploy keys?
+- Who can restore from backup?
+- Who can revoke access?
+- Who pays for storage?
+- Who signs releases?
+- Who is allowed to merge?
+- What happens if a maintainer disappears?
+- What happens if the host fails?
+- What is canonical: GitHub, Forgejo, ICN state, or receipts?
+
+This is why the forge matters. It forces ICN to host itself.
+
+## Recommended first runtime
+
+Use Forgejo as the initial forge candidate unless a separate evaluation rejects it.
+
+Reasons:
+
+- open-source forge aligned with self-hosting
+- lighter than GitLab
+- supports Git repos, issues, pull requests, releases, teams, SSH, HTTP Git, webhooks
+- can integrate with OIDC
+- operationally realistic for a small infrastructure team
+
+GitLab may be evaluated later if ICN needs the larger integrated platform. Do not start with the heaviest possible system unless the need is proven.
+
+## Candidate route
+
+Preferred route:
+
+```text
+forge.intercooperative.network
+```
+
+This reads as public/cooperative infrastructure, not startup branding.
+
+Alternative routes:
+
+```text
+git.intercooperative.network
+code.intercooperative.network
+forge.icn.zone
+```
+
+The route is a DNS binding, not authority. The service's authority comes from ICN governance and service custody, not from the host name.
+
+## Staged transition
+
+### Stage 0 — GitHub canonical, forge planned
+
+Current posture.
+
+- GitHub remains canonical.
+- Service-hosting docs land.
+- Forge deployment plan lands.
+- No workflow disruption.
+
+### Stage 1 — Forge deployed as mirror / rehearsal
+
+- Deploy Forgejo.
+- Create ICN organization / project namespace.
+- Mirror `icn`, `nycn`, and `icn-learn` as appropriate.
+- Configure auth bridge or temporary local admin accounts.
+- Configure backups.
+- Verify restore.
+- Keep GitHub canonical.
+
+### Stage 2 — Dual-home development
+
+- Developers can clone from the forge.
+- GitHub still accepts contribution traffic.
+- Mirror policies are explicit.
+- CI relationship is documented.
+- Issues/PRs may remain GitHub-first until migration gates are met.
+
+### Stage 3 — Forge canonical, GitHub public mirror
+
+- Canonical remotes point to the ICN forge.
+- GitHub mirrors outward for visibility and contribution discovery.
+- Release artifacts are signed and published from the ICN-governed flow.
+- Important forge actions begin to map into receipts.
+
+### Stage 4 — ICN-native forge integration
+
+- Forge has service identity.
+- Forge events pass through an adapter.
+- Merge/release/access actions are receipt-bearing where appropriate.
+- Compute jobs produce evidence for CI, security, docs freshness, and release artifacts.
+- GitHub is clearly labeled as a mirror / public intake surface.
+
+## MVP requirements
+
+The first forge MVP should include:
+
+```text
+1. Forgejo service
+2. persistent storage
+3. SSH Git access
+4. HTTPS access
+5. route / TLS
+6. admin bootstrap
+7. OIDC path identified or temporary auth documented
+8. backups
+9. restore test
+10. GitHub mirror policy
+11. repo import procedure
+12. observability hooks
+13. incident/rollback plan
+```
+
+No ICN-native receipt integration is required for the first MVP. The first win is governed custody.
+
+## Canonical data posture
+
+The forge service definition should declare what it holds:
+
+```yaml
+canonical_data:
+  - git repositories
+  - issue tracker state once cutover happens
+  - pull request state once cutover happens
+  - release metadata once cutover happens
+mirror_data:
+  - GitHub mirrors
+projection_data:
+  - OIDC-local account/session records
+cache_data:
+  - rendered repo pages
+  - search indexes
+```
+
+Before cutover, GitHub remains canonical. After cutover, GitHub is a mirror.
+
+## Access model
+
+The forge should eventually consume ICN authority through the auth bridge:
+
+```text
+DID / ICN identity
+  ↓
+standing / role / authority_scope
+  ↓
+auth bridge OIDC claims
+  ↓
+Forgejo local session / team mapping
+  ↓
+service action
+  ↓
+receipt if institutional transition matters
+```
+
+Initial deployment may use local admin accounts or manually configured OIDC groups, but that must be marked as transitional.
+
+## Events and receipts
+
+Forge events should flow through an adapter:
+
+```text
+Forgejo webhook
+  ↓
+forge adapter validates event
+  ↓
+ICN checks authority if needed
+  ↓
+compute job may run evidence checks
+  ↓
+receipt emitted for institutional transition
+```
+
+Candidate receipt-bearing transitions:
+
+| Event | Receipt candidate |
+|---|---|
+| repo mirror updated | `RepoMirrorReceipt` |
+| release published | `ReleaseReceipt` |
+| access granted | `AccessGrantReceipt` |
+| access revoked | `AccessRevocationReceipt` |
+| backup completed | `BackupReceipt` |
+| restore test completed | `RestoreTestReceipt` |
+| PR merged under governed authority | `MergeReceipt` |
+
+These receipt names are candidates. They must align with ADR-0026 and future receipt-envelope work rather than create a parallel audit system.
+
+## Compute integration
+
+The forge is an excellent first service for compute evidence.
+
+Compute may run:
+
+- Rust CI
+- TypeScript SDK checks
+- website build checks
+- docs freshness checks
+- accessibility tests
+- compliance linter
+- license scans
+- dependency scans
+- SBOM generation
+- release artifact builds
+- repo atlas generation
+- PR summary / source-linked review packets
+
+Compute does not decide. It produces evidence. Maintainers or governance decide.
+
+Correct flow:
+
+```text
+PR opened
+  ↓
+compute runs checks
+  ↓
+ComputeReceipt / evidence artifact
+  ↓
+maintainer reviews
+  ↓
+merge action
+  ↓
+MergeReceipt if governed merge receipts are implemented
+```
+
+## Protocol posture
+
+The forge should follow the protocol-selection doctrine:
+
+- HTTP for commands and canonical reads.
+- SSE for build progress, mirror progress, receipt-created pointers, and service-awareness streams.
+- WebSockets only for genuinely interactive live development sessions, if any.
+- Polling fallback for critical views.
+
+Do not make forge usability depend on live sockets when ordinary HTTP + SSE is enough.
+
+## GitHub mirror posture
+
+GitHub should remain useful:
+
+- public discovery
+- inbound issues / discussions during transition
+- contributor familiar path
+- package ecosystem references
+- social proof
+- emergency mirror
+
+But GitHub should be labeled and treated as a mirror once cutover happens.
+
+Mirroring direction after cutover:
+
+```text
+forge.intercooperative.network/ICN/icn
+        ↓
+github.com/InterCooperative-Network/icn
+```
+
+Before cutover, direction may remain GitHub → Forgejo while the forge is being rehearsed.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Overbuilding before use | Start Forgejo MVP, not ICN-native forge from day one. |
+| Losing GitHub contributor flow | Keep GitHub as mirror and public intake. |
+| Admin capture | Document service governance, access revocation, and backup custody. |
+| Fragile self-hosting | Require backups and restore tests before canonical cutover. |
+| Confusing canonical state | Explicit cutover checklist; clear mirror labels. |
+| Auth bridge becomes authority | Keep DID/standing/authority in ICN; IdP is session bridge only. |
+| CI disruption | Stage CI migration separately; do not block cutover on perfect CI federation. |
+
+## Cutover gates
+
+Forge should not become canonical until:
+
+- backups run successfully
+- restore has been tested
+- admin access has at least two authorized custodians or an explicit break-glass policy
+- SSH and HTTPS clone/push work
+- TLS and route are stable
+- GitHub mirror direction is tested
+- contributor instructions are updated
+- release process is documented
+- incident rollback path exists
+- service definition exists
+- auth posture exists
+- export path exists
+
+## Non-goals
+
+- No immediate GitHub abandonment.
+- No runtime implementation in this document.
+- No claim that Forgejo is already selected by formal ADR.
+- No ICN-native merge/release receipt implementation in this document.
+- No replacement of RFC-0017 tool-install work.
+- No requirement that all contributors use the sovereign forge immediately.
+
+## One-line rule
+
+**GitHub can remain the billboard; ICN should own the workshop.**


### PR DESCRIPTION
## Summary

Adds a first coherent documentation slice for ICN sovereign service hosting: the layer where ICN starts governing real hosted services like a forge, auth bridge, status page, docs/registry surfaces, metrics, and future tool services.

This is **docs/architecture + docs/ops + docs/strategy only**. No runtime code, no deployment manifests, no DNS changes, no service mutation, no GitHub cutover, no Forgejo deployment, and no IdP selection.

## Why

Recent architecture work already names the pieces this needs to sit on:

- `COOPERATIVE_DOMAIN_INFRASTRUCTURE.md` names institutional domains, service identities, domain sessions, tools, workspaces, scoped vaults, DNS bindings, agreements, and hybrid commons cloud.
- `COOPERATIVE_TOOL_COMMONS.md` names governed tools, scoped capabilities, anti-capture rules, and service identities.
- RFC-0017 is active for `ToolManifest`, `ToolBinding`, install lifecycle, capability registry, and service identity audit trail.

What was missing was the operational bridge between those designs and the real services ICN will need to run: a forge, auth bridge, status page, registry, docs service, metrics, and related hosted infrastructure.

This PR names that bridge without pretending it is implemented.

## Files added

```text
docs/architecture/SERVICE_HOSTING_MODEL.md
docs/architecture/AUTH_BRIDGE_AND_DID_LOGIN.md
docs/architecture/PROTOCOL_SELECTION_FOR_MEMBER_SERVICES.md
docs/strategy/SOVEREIGN_FORGE.md
docs/ops/FORGEJO_DEPLOYMENT_PLAN.md
docs/ops/SERVICE_GOVERNANCE_TEMPLATE.md
```

## What each doc does

### `SERVICE_HOSTING_MODEL.md`

Defines the general doctrine:

> ICN services should not merely be deployed. They should be governed.

Introduces the staged path:

```text
hosted service → governed service → ICN-native service
```

Defines required service-definition fields: operator scope, governance scope, data custody, auth provider, protocols, backup/restore, exit path, event/receipt posture, and compute role.

### `AUTH_BRIDGE_AND_DID_LOGIN.md`

Defines the relationship between DID identity and conventional web SSO.

Core rule:

```text
OIDC authenticates sessions.
ICN authorizes institutional power.
Receipts prove institutional transitions.
```

Covers Keycloak/authentik/ZITADEL/Ory/Kanidm-style bridges without selecting a product. Keeps IdP groups as session projections, not institutional authority.

### `PROTOCOL_SELECTION_FOR_MEMBER_SERVICES.md`

Adds protocol doctrine for member-facing and operator-facing services.

Core rule:

```text
HTTP is for institutional facts.
SSE is for institutional awareness.
WebSockets are for shared live activity.
Receipts are the source of truth.
Polling is the fallback.
```

This turns the HTTP/SSE/WebSocket analysis into ICN architecture: command/query/event separation, replayable streams, event pointers instead of sensitive payloads, polling fallback, and WebSocket justification requirements.

### `SOVEREIGN_FORGE.md`

Frames the sovereign forge as ICN's first serious sovereignty service.

Core posture:

```text
ICN-controlled forge = canonical institutional workshop
GitHub = public mirror, discovery surface, and contributor funnel
```

Defines staged transition from GitHub-canonical → rehearsal mirror → dual home → ICN forge canonical → ICN-native forge integration.

### `FORGEJO_DEPLOYMENT_PLAN.md`

Operational planning doc for a conservative Forgejo MVP at `forge.intercooperative.network`.

Names MVP requirements: persistent storage, SSH/HTTPS Git, route/TLS, admin bootstrap, backups, restore test, monitoring, and mirror policy. Explicitly defers canonical cutover and receipt-native integration.

### `SERVICE_GOVERNANCE_TEMPLATE.md`

Reusable template for future hosted/governed services.

Forces every service proposal to answer:

- what is canonical vs projection/cache/mirror/external;
- who operates and governs it;
- how auth works;
- what protocol promises it makes;
- what requires receipts;
- how backups/restores work;
- how the institution leaves cleanly.

## Non-goals

This PR does **not**:

- deploy Forgejo;
- select Keycloak/authentik/ZITADEL/Ory/Kanidm;
- change DNS;
- mutate K3s, VPS, GitHub, or any live service;
- make the ICN forge canonical;
- deprecate GitHub;
- add runtime code, crates, SDKs, CI jobs, or manifests;
- implement DID login;
- implement service identities;
- implement receipts for forge/auth events;
- modify NYCN or icn-learn;
- start RFC-0017 implementation.

## Design posture

The docs intentionally keep service tools replaceable:

- Forgejo is the recommended first forge candidate, not a formally accepted ADR decision.
- Keycloak/authentik/ZITADEL/Ory/Kanidm are candidates for an auth bridge, not authority sources.
- GitHub remains useful as public mirror / contributor funnel.
- Compute is evidence-producing, not authority-producing.
- WebSockets are allowed only when justified by bidirectional live state.
- Receipts remain the proof layer for institutional transitions.

## Checks

Not run locally in this connector-backed edit. This PR is documentation-only. Recommended follow-up checks from repo convention:

```text
python3 docs/scripts/doc_control_check.py --strict
python3 .github/scripts/compliance_linter.py
git diff --check
```

## Review focus

Please review for:

- correct placement relative to `COOPERATIVE_DOMAIN_INFRASTRUCTURE.md`, `COOPERATIVE_TOOL_COMMONS.md`, and RFC-0017;
- whether the forge/auth/protocol doctrine should stay as architecture docs or become an RFC/ADR candidate later;
- whether any receipt names should be softened further as candidates;
- whether the protocol doctrine is strict enough for mobile/accessibility needs;
- whether the Forgejo plan is staged conservatively enough before canonical cutover.
