### PR TITLE
docs(state): sync May-cycle project truth

### DIFF
--- a/docs/PHASE_PROGRESS.md
+++ b/docs/PHASE_PROGRESS.md
@@ -1,6 +1,24 @@
 # ICN Phase Progress
-**Last Updated:** 2026-04-29
-**Current Phase:** Phase 2 — Pilot Launch. NYCN is the intended first cooperative partner (active partnership track, not yet a formally committed pilot); the next concrete step is presenting the merged drive-ingest ladder + ICN proof-loop machinery to NYCN organizers to formalize the pilot. Subsequent gates: partnership formalization, then first operator pilot rehearsal. Institutional-operability infrastructure, the action-card runtime, the action-item completion-receipt retrieval endpoint, and the NYCN drive-ingest operator ladder are all in place; all currently emitted source paths are proof-bearing both locally and on K3s.
+**Last Updated:** 2026-05-02
+**Current Phase:** Phase 2 — Pilot Launch. NYCN is the intended first cooperative partner (active partnership track, not yet a formally committed pilot); the next concrete step is presenting the merged drive-ingest ladder + ICN proof-loop machinery to NYCN organizers to formalize the pilot. Subsequent gates: partnership formalization, then first operator pilot rehearsal. Institutional-operability infrastructure, the action-card runtime, the action-item completion-receipt retrieval endpoint, and the NYCN drive-ingest operator ladder are all in place; all currently emitted source paths are proof-bearing both locally and on K3s. May-cycle repo-governance, licensing, RFC, repo-record, and service-hosting docs have landed, but they do not mark Phase 2 complete or imply production readiness, live federation integration, implemented service hosting, or resolved licensing.
+
+<!-- [sync edit] 2026-05-02 (post-#1686/#1688/#1690/#1691/#1693/#1694):
+     State extended after May-cycle repo-governance and strategy docs:
+     licensing metadata/open questions (#1686); RFC-0017 active for
+     Tool Install Infrastructure (#1688, not implemented); repo-record
+     protocol/generator (#1690); generated ICN repo-record snapshot
+     (#1691, mechanical inventory, not interpretive atlas);
+     licensing/autonomy strategy matrix (#1693, planning only, no
+     relicensing); sovereign service hosting stack (#1694, design
+     direction only, no Forgejo deploy, DNS mutation, K3s mutation,
+     hosted-service rollout, or GitHub cutover). Current open PR queue
+     includes Dependabot Actions major-version bumps #1695-#1698,
+     security dependency bump #1699, and draft agent-docs PR #1700.
+     Phase 2 remains in progress. NYCN remains intended first
+     cooperative partner, not a formally committed pilot. The next
+     concrete human gate remains presenting the merged ladder + ICN
+     proof-loop machinery to NYCN organizers, then formalization, then
+     first operator rehearsal. -->
 
 <!-- [sync edit] 2026-04-29 (post-NYCN-#32, ICN PR queue clean):
      Truth-sync extension. NYCN drive-ingest work has continued
@@ -194,6 +212,12 @@
 - [x] NYCN start-here onboarding pass (NYCN #30) — short cold-reader docs (`START_HERE.md`, `ORGANIZER_QUICKSTART.md`, `STEWARD_QUICKSTART.md`, `GLOSSARY.md`) plus a no-network artifact-ladder checker.
 - [x] NYCN one-command local preflight runner (NYCN #31) — orchestrates the seven-stage chain in a single deterministic, no-network run; preserves both human-review boundaries; preflight only.
 - [x] NYCN whole-system operating-surfaces inventory + Google-Groups boundary policy + repo-safe communication-groups fixture (NYCN #32) — modeling only; no live sync, no private data.
+- [x] Licensing metadata and open questions documented (#1686) — documentation only; licensing is not resolved.
+- [x] RFC-0017 moved to active for Tool Install Infrastructure (#1688) — active RFC only; infrastructure is not implemented.
+- [x] Repo-record protocol/generator added (#1690) — documentation/control-plane generator work.
+- [x] Generated ICN repo-record snapshot added (#1691) — mechanical inventory snapshot, not an interpretive atlas.
+- [x] Licensing/autonomy strategy matrix added (#1693) — planning only; no relicensing.
+- [x] Sovereign service hosting stack documented (#1694) — design direction only; no Forgejo deployment, DNS mutation, K3s mutation, hosted-service rollout, or GitHub cutover.
 - [ ] NYCN steward-facing communication-groups directory tool (NYCN #33) — open at last sync; verify status before reading.
 - [ ] Action-card runtime — remaining gates under #1646 (RFC-gated): `signal_rule` source path (gated on #1631); `obligation_lifecycle` source path (gated on #1634)
 - [ ] One-command deployment script per cooperative
@@ -211,6 +235,7 @@
 - Subsequent gate: partnership formalization, then first operator pilot rehearsal against real (or fixture-equivalent) organizer material
 
 **Decisions Made:**
+- (2026-05-02, post-#1686/#1688/#1690/#1691/#1693/#1694) May-cycle repo-governance and strategy docs updated licensing metadata/open questions, RFC-0017 status, repo-record generation, the generated repo-record snapshot, licensing/autonomy planning, and sovereign service hosting design. These are truth/control-plane and planning landings only. They do not complete Phase 2, formally commit NYCN as a pilot, claim production readiness, claim live federation integration, deploy service hosting, mutate DNS/K3s/GitHub state, implement RFC-0017, or resolve licensing. The next concrete human gate remains presenting the merged ladder + ICN proof-loop machinery to NYCN organizers, then formalization, then first operator rehearsal. Current open PR queue: #1695-#1698 Dependabot Actions major-version bumps, #1699 wasmtime security bump, and draft #1700 agent-docs update.
 - (2026-04-29, post-#1675/#1677, post-NYCN-#28) The Phase 2 *machinery* is now in place end-to-end: (a) action-card runtime is proof-bearing for all currently emitted source paths, (b) the completion-receipt retrieval endpoint exists so a holder shell can read receipts over HTTP, (c) the local HTTP proof loop is closed and documented, (d) the K3s smoke proof loop is closed against deployed image `91a63eec` and documented, and (e) the NYCN drive-ingest operator ladder is merged end-to-end as a procedural spine. NYCN is the intended first cooperative partner (active partnership track); the next concrete step is **presenting the merged ladder + ICN proof-loop machinery to NYCN organizers** to formalize the pilot. Phase 2 remains ⏳ until that presentation, the partnership formalization that follows, and the first operator pilot rehearsal happen and are recorded. The two RFC-gated action-card source paths (`signal_rule`, `obligation_lifecycle`) remain open under #1646 and are independent of the partner gate.
 - (2026-04-27, post-#1663) Action-card runtime is now proof-bearing for **all three currently emitted source paths**: `proposal`/`vote` (#1660), `action_item`/`complete` (#1661), and `meeting`/`attend` (#1663). Issue #1646 remains open for the two RFC-gated paths: `signal_rule` (#1631) and `obligation_lifecycle` (#1634). Phase 2 status is unaffected (still partner-bound).
 - (2026-04-27) Action-card runtime is partial: `/me/action-cards` exists, `proposal`/`vote` and `action_item`/`complete` source paths have verified end-to-end receipt proof loops, and `meeting`/`attend`, `signal_rule`, `obligation_lifecycle` paths remain pending under #1646. Phase 2 status is unaffected.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,10 +1,30 @@
 ---
 Status: descriptive
 Canonical: yes
-Last Reviewed: 2026-04-29
+Last Reviewed: 2026-05-02
 ---
 
 # ICN State (living doc)
+
+<!-- [sync edit] 2026-05-02 (post-#1686/#1688/#1690/#1691/#1693/#1694):
+     May-cycle repo-governance and strategy docs landed after the
+     2026-04-29 snapshot: licensing metadata/open questions (#1686);
+     RFC-0017 moved to active for Tool Install Infrastructure (#1688,
+     active only, not implemented); repo-record protocol/generator
+     (#1690); generated ICN repo-record snapshot (#1691, mechanical
+     inventory, not an interpretive atlas); licensing/autonomy strategy
+     matrix (#1693, planning only, no relicensing); sovereign service
+     hosting stack (#1694, design direction only, no Forgejo deploy,
+     DNS mutation, K3s mutation, or GitHub cutover). Current open PR
+     queue includes Dependabot Actions major-version bumps #1695-#1698,
+     security dependency bump #1699, and draft agent-docs PR #1700.
+     Phase 2 remains in progress. NYCN remains the intended first
+     cooperative partner, not a formally committed pilot. The next
+     concrete human gate remains presenting the merged ladder + ICN
+     proof-loop machinery to NYCN organizers, then formalization, then
+     first operator rehearsal. Do not read this sync as production
+     readiness, live federation integration, implemented service
+     hosting, or resolved licensing. -->
 
 <!-- [sync edit] 2026-04-29 (post-NYCN-#32, ICN PR queue clean):
      NYCN drive-ingest work has continued past the operator
@@ -77,15 +97,21 @@ Last Reviewed: 2026-04-29
      Aligned crate list, merged PRs, and metrics to verified repo state.
      Phase model unchanged — phase classification is governance territory (PR C). -->
 
-## Current status (2026-04-29 snapshot)
+## Current status (2026-05-02 snapshot)
 
 **Current phase:** Phase 2 — Pilot Launch. NYCN is the intended first cooperative partner (active partnership track, not yet a formally committed pilot). The next concrete step is presenting the merged drive-ingest ladder + ICN proof-loop machinery to NYCN organizers to formalize the pilot. Subsequent gates: partnership formalization, then first operator pilot rehearsal against real (or fixture-equivalent) organizer material. The Phase 2 *machinery* is in place end-to-end; what remains is the human procedure — pitch, formalize, rehearse — and recording each step.
-Active execution: institutional-operability runtime (live charter activation, person-directory overlay, `/me/standing`, `authority_scope` plumbing) plus the action-card runtime (`/me/action-cards` endpoint with proof-loop linkage to `GovernanceDecisionReceipt` for proposal/vote, `ActionItemCompletionReceipt` for action_item/complete, and `MeetingAttendanceReceipt` for meeting/attend). The action-item completion-receipt retrieval endpoint shipped as #1675; the local HTTP proof loop closure is documented in #1676 and the K3s smoke proof closure is recorded in #1677. NYCN's drive-ingest operator ladder (NYCN #21–#28 in `fahertym/nycn`) is merged end-to-end, with subsequent NYCN #29–#32 also merged: organizer briefing + summit demo, start-here onboarding pass, one-command local preflight runner, and whole-NYCN operating-surfaces inventory plus Google-Groups boundary policy. NYCN #33 (steward-facing communication-groups directory tool) was open at last sync and may have merged since. Phase model classification is unchanged; see PHASE_PROGRESS.md for phase definitions.
+Active execution: institutional-operability runtime (live charter activation, person-directory overlay, `/me/standing`, `authority_scope` plumbing) plus the action-card runtime (`/me/action-cards` endpoint with proof-loop linkage to `GovernanceDecisionReceipt` for proposal/vote, `ActionItemCompletionReceipt` for action_item/complete, and `MeetingAttendanceReceipt` for meeting/attend). The action-item completion-receipt retrieval endpoint shipped as #1675; the local HTTP proof loop closure is documented in #1676 and the K3s smoke proof closure is recorded in #1677. NYCN's drive-ingest operator ladder (NYCN #21–#28 in `fahertym/nycn`) is merged end-to-end, with subsequent NYCN #29–#32 also merged: organizer briefing + summit demo, start-here onboarding pass, one-command local preflight runner, and whole-NYCN operating-surfaces inventory plus Google-Groups boundary policy. NYCN #33 (steward-facing communication-groups directory tool) was open at the prior sync and may have merged since. Since then, ICN also merged repo-governance and strategy documentation for licensing metadata, RFC-0017 activation, repo-record generation, a generated repo-record snapshot, licensing/autonomy planning, and sovereign service hosting design. Those are documentation/control-plane landings only: RFC-0017 is not implemented, service hosting is not deployed, DNS/K3s/GitHub state was not mutated, and licensing is not resolved. Phase model classification is unchanged; see PHASE_PROGRESS.md for phase definitions.
 
 ### Recently merged (since 2026-04-15)
 
 | PR | Title | Merged |
 |----|-------|--------|
+| #1694 | docs(architecture): add sovereign service hosting stack | 2026-05-02 |
+| #1693 | docs(licensing): add autonomy-focused strategy matrix | 2026-05-02 |
+| #1691 | docs(project-index): add generated repo record snapshot | 2026-05-01 |
+| #1690 | docs(project-index): add full repo record protocol | 2026-05-01 |
+| #1688 | docs(rfcs): RFC-0017 draft → active (Tool Install Infrastructure) | 2026-05-01 |
+| #1686 | docs(licensing): document current license metadata and open questions | 2026-05-01 |
 | #1678 | docs(state): sync to post-#1675/#1677 and post-NYCN-#28 reality | 2026-04-29 |
 | #1665 | deps(ts-sdk): bump the dev-dependencies group in /sdk/typescript with 2 updates | 2026-04-29 |
 | #1677 | docs(dev): record K3s NYCN action-item receipt proof path | 2026-04-29 |
@@ -140,9 +166,24 @@ Active execution: institutional-operability runtime (live charter activation, pe
 
 ### Open PRs
 
-_(none — ICN PR queue is empty as of this sync. All recent activity is on the NYCN side.)_
+| PR | Title | Status |
+|----|-------|--------|
+| #1700 | docs(agents): add Cursor Cloud specific instructions to AGENTS.md | Draft |
+| #1699 | fix(compute): bump wasmtime for RUSTSEC-2026-0114 | Open; local validation clean; benchmark gate classified as unrelated/noisy |
+| #1698 | ci: bump actions/setup-node from 4 to 6 | Open Dependabot major-version bump |
+| #1697 | ci: bump actions/checkout from 4 to 6 | Open Dependabot major-version bump |
+| #1696 | ci: bump actions/github-script from 8 to 9 | Open Dependabot major-version bump |
+| #1695 | ci: bump softprops/action-gh-release from 2 to 3 | Open Dependabot major-version bump |
 
 ### What landed since Phase 1 (Charter Engine)
+
+May-cycle repo governance and strategy documentation (added 2026-05-01 → 2026-05-02; documentation/control-plane only, not runtime deployment):
+- Licensing metadata and open questions documented — #1686.
+- RFC-0017 moved from draft to active for Tool Install Infrastructure — #1688. Active means accepted for implementation; it does not mean the tool install infrastructure is implemented.
+- Full repo-record protocol/generator added — #1690.
+- Generated ICN repo-record snapshot added — #1691. This is a mechanical inventory snapshot, not an interpretive atlas.
+- Licensing/autonomy strategy matrix added — #1693. Planning only; no relicensing happened.
+- Sovereign service hosting stack added — #1694. Design direction only; no Forgejo deployment, DNS mutation, K3s mutation, hosted-service rollout, or GitHub cutover happened.
 
 Action-card runtime (added 2026-04-27 → 2026-04-29, all currently emitted source paths now proof-bearing — issue #1646 remains open for the two RFC-gated paths):
 - `GET /v1/gov/me/action-cards` member endpoint with closed source/action enums — #1659

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -650,7 +650,7 @@ category = "status"
 status = "living"
 title = "ICN State (living doc)"
 description = "Living snapshot of repo layout, decisions, constraints, and current engineering status"
-last_updated = "2026-04-29"
+last_updated = "2026-05-02"
 owner = "matt"
 audiences = ["developers", "agents"]
 truth_class = "descriptive"
@@ -659,7 +659,7 @@ canonical = "yes"
 freshness = "current"
 domain_tags = ["status", "project"]
 recommended_action = "keep"
-last_reviewed = "2026-04-29"
+last_reviewed = "2026-05-02"
 
 [docs."docs/DOCUMENTATION_CONTROL_SYSTEM.md"]
 category = "reference"


### PR DESCRIPTION
## Summary

Truth-syncs `docs/STATE.md` and `docs/PHASE_PROGRESS.md` after the May-cycle repo-governance, licensing, repo-record, RFC, and service-hosting documentation work.

Records:
- #1686 licensing metadata/open questions
- #1688 RFC-0017 active
- #1690 repo-record protocol/generator
- #1691 generated ICN repo-record snapshot
- #1693 licensing strategy matrix
- #1694 sovereign service hosting stack
- current open PR queue / security-dependency status

## What this does not claim

- Does not mark Phase 2 complete.
- Does not claim NYCN is a formal pilot.
- Does not claim production readiness.
- Does not claim live federation integration.
- Does not deploy Forgejo, auth, DNS, K3s, or any hosted service.
- Does not resolve licensing or relicense anything.
- Does not implement RFC-0017.

## Validation

- [x] `python3 docs/scripts/doc_control_check.py --strict`
- [x] `python3 .github/scripts/compliance_linter.py`
- [x] `git diff --check`

Note: `doc_control_check.py --strict` passed with existing non-blocking registry/YAML warning debt.

Made with [Cursor](https://cursor.com)