### PR TITLE
docs(phase2): sync project truth and define NYCN pilot rehearsal gate

### DIFF
--- a/docs/INDEX.generated.md
+++ b/docs/INDEX.generated.md
@@ -30,11 +30,71 @@ Single authoritative architecture covering all 8 primitives, kernel-app separati
 
 **For:** `developers`, `architects`, `grant-reviewers` | **Updated:** 2026-03-21
 
-### 📝 **Living** [ADR-0010: App Topology](/docs/adr/ADR-0010-app-topology.md)
+### 📝 **Living** [ADR-0001: Orchestration Plane Architecture (decision superseded by ADR-0017)](/docs/adr/ADR-0001-orchestration-plane-architecture.md)
 
-Architectural decision record on app topology
+Original multi-repo orchestration-plane decision; physical layout DECISION superseded by ADR-0017, durable principle (explicit orchestration/state plane) retained. ADR remains as institutional memory at canonical path.
 
-**For:** `architects` | **Updated:** 2026-03-10
+**For:** `architects` | **Updated:** 2026-04-26
+
+### 📝 **Living** [ADR-0002: MCP Server Registration via ~/.mcp.json (amended by ADR-0017)](/docs/adr/ADR-0002-mcp-server-registration-via-mcp-json.md)
+
+Registration mechanism unchanged; path moved from a separate icn-ops/ repo into ops/mcp/ in the main ICN repo (decision amended by ADR-0017).
+
+**For:** `developers` | **Updated:** 2026-04-26
+
+### 📝 **Living** [ADR-0010: App Topology (decision superseded by ADR-0017)](/docs/adr/ADR-0010-app-topology.md)
+
+Architectural decision record on app topology — DECISION superseded by ADR-0017 (canonical-roots table); ADR file remains at canonical path as institutional memory.
+
+**For:** `architects` | **Updated:** 2026-04-26
+
+### 📝 **Living** [ADR-0012: Federation State Origin Model (decision amended by ADR-0013)](/docs/adr/ADR-0012-federation-state-origin-model.md)
+
+Model C (Explicit Parallel) for federation clearing state origins. Decision still holds; Step 3 status now owned by ADR-0013.
+
+**For:** `architects` | **Updated:** 2026-04-26
+
+### 📝 **Living** [ADR-0013: Federation Clearing Adoption Contract](/docs/adr/ADR-0013-federation-clearing-adoption-contract.md)
+
+Step 3 architecture for federation clearing adoption (3a–3d implemented). Open items remain: FederationProvenance not Sled-persisted, coop_a_did empty in execution handler, store-isolation tests not written. Verified unresolved 2026-04-26.
+
+**For:** `architects` | **Updated:** 2026-04-26
+
+### 📝 **Living** [ADR-0014: Constitutional Object Model — AuthorityClass, AuthorityGrant, TypedScope, Mandate](/docs/adr/ADR-0014-constitutional-object-model.md)
+
+Semantic freeze for the four governance constitutional types. Decision: accepted; implementation: partially landed (types + accepted-decision minting seam land at the governance app layer; kernel dispatch is not yet gated by mandates). See ADR-0019 for the minting/persistence seam decision.
+
+**For:** `architects`, `developers` | **Updated:** 2026-04-26
+
+### 📝 **Living** [ADR-0015: Service Discovery Auth Semantics — Auth-gated with Enumeration-Safe 404](/docs/adr/ADR-0015-service-discovery-auth-semantics.md)
+
+Decision: all /v1/services/* require JWT; missing/unauthorized -> 404 (enumeration-safe). Implementation status (2026-04-26): needs verification — route-level auth gating not visible in api/services.rs; follow-up audit issue suggested.
+
+**For:** `architects`, `developers` | **Updated:** 2026-04-26
+
+### 📝 **Living** [ADR-0017: Monorepo Consolidation with Explicit Internal Boundaries](/docs/adr/ADR-0017-monorepo-consolidation-with-explicit-internal-boundaries.md)
+
+Canonical roots table for the consolidated monorepo: icn/, icn/apps/, apps/, website/, ops/mcp/, ops/state/, docs/, docs/adr/, deploy/, sdk/, web/. Decision supersedes ADR-0001 and ADR-0010; amends ADR-0002.
+
+**For:** `architects`, `developers` | **Updated:** 2026-04-26
+
+### 📝 **Living** [ADR-0018: ADR Lifecycle and Canonical Decision Index](/docs/adr/ADR-0018-adr-lifecycle-and-canonical-decision-index.md)
+
+ADR lifecycle vocabulary (proposed/accepted/amended/superseded/deprecated), metadata convention (YAML frontmatter going forward, classic + bullet still supported), tooling contract for ops/mcp/src/tools/decisions.ts. Documents the docs/adr/ canonicalization landed in PR #1637.
+
+**For:** `architects`, `developers` | **Updated:** 2026-04-26
+
+### 📝 **Living** [ADR-0019: Authority Grant Minting and Mandate Persistence Seam](/docs/adr/ADR-0019-authority-grant-minting-and-mandate-persistence-seam.md)
+
+Records the deterministic seam where accepted governance decisions emit zero or more truthful AuthorityGrants plus exactly one Mandate. Conservative minting (only steward-appointment / steward-reconfirmation today); pending-grants fall-through is the truthful failure mode; kernel dispatch is NOT gated by mandates. Implementation: partially landed.
+
+**For:** `architects`, `developers` | **Updated:** 2026-04-26
+
+### 📝 **Living** [ADR-0020: Institutional Bootstrap Activation and Standing Read Model](/docs/adr/ADR-0020-institutional-bootstrap-activation-and-standing-read-model.md)
+
+Reusable activation chain: package manifest -> private overlay -> bootstrap apply -> charter activation -> entity/structure/role creation -> /me/standing -> (future) action cards. Locks the boundary between ICN runtime contract and institution-package vocabulary. Steps 1-6 implemented; action cards (icn#1608) future.
+
+**For:** `architects`, `developers` | **Updated:** 2026-04-26
 
 ### 📝 **Living** [Architectural Gaps & Remediation Plan](/docs/architecture/ARCHITECTURAL_GAPS_AND_FIXES.md)
 
@@ -60,6 +120,24 @@ Architecture of ICN client models and their relationship to kernel primitives
 
 **For:** `developers`, `architects` | **Updated:** 2026-03-15
 
+### 📋 **Draft** [Cooperative Domain Infrastructure](/docs/architecture/COOPERATIVE_DOMAIN_INFRASTRUCTURE.md)
+
+Forward-direction architecture for cooperative institutional infrastructure: institutional domains, sessions, devices, services, workspaces, artifacts, vaults, agreements, DNS bindings, hybrid commons cloud, workstations. Names what is implemented today vs what is future buildout.
+
+**For:** `developers`, `architects` | **Updated:** 2026-04-27
+
+### 📋 **Draft** [Cooperative Tool Commons](/docs/architecture/COOPERATIVE_TOOL_COMMONS.md)
+
+Forward-direction tool ecosystem: core base tools, specialized suites, third-party tools, manifests, service identities, capability grants, anti-capture rules. Companion to Cooperative Domain Infrastructure.
+
+**For:** `developers`, `architects` | **Updated:** 2026-04-27
+
+### 📋 **Draft** [Domain Routing and DNS Bindings](/docs/architecture/DOMAIN_ROUTING_AND_DNS_BINDINGS.md)
+
+Forward-direction design distinguishing institutional domains, icn.zone utility routes, custom public domains, short routes, and binding verification receipts. Companion to Cooperative Domain Infrastructure.
+
+**For:** `developers`, `architects` | **Updated:** 2026-04-27
+
 ### 📝 **Living** [Federation Actions](/docs/architecture/FEDERATION_ACTIONS.md)
 
 Design of federated action execution across network boundaries
@@ -84,17 +162,41 @@ Design of identity primitives, membership verification, and member lifecycle
 
 **For:** `architects`, `developers` | **Updated:** 2026-03-10
 
+### 📝 **Living** [Institutional Feedback and Support Primitives](/docs/architecture/INSTITUTIONAL_FEEDBACK_AND_SUPPORT_PRIMITIVES.md)
+
+Doctrine for institutional feedback, member signals, governed indicators, action cards, temporary authority, resource governance, and support programs as planned ICN primitives
+
+**For:** `developers`, `architects` | **Updated:** 2026-04-25
+
+### 📝 **Living** [Institution Package Boundary](/docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md)
+
+Normative definition of ICN platform vs institution package boundary, CCL vs host runtime split, and reusable primitive set for NYCN/Summit
+
+**For:** `developers`, `architects` | **Updated:** 2026-04-16
+
 ### 📝 **Living** [Kernel/App Separation Architecture](/docs/architecture/KERNEL_APP_SEPARATION.md)
 
 Normative specification of kernel-app boundary, infection vectors, and capability propagation rules
 
 **For:** `developers`, `architects` | **Updated:** 2026-03-17
 
+### 📋 **Draft** [Model Workloads and Deliberation](/docs/architecture/MODEL_WORKLOADS_AND_DELIBERATION.md)
+
+Forward-direction design for model-driven advisory compute workloads, deliberation packets, model registry, advisory vs deterministic classification, and the rule that compute assists but does not govern.
+
+**For:** `developers`, `architects` | **Updated:** 2026-04-27
+
 ### 📝 **Living** [Scope Bounded Trust](/docs/architecture/SCOPE_BOUNDED_TRUST.md)
 
 Trust model design limiting trust scope to organizational boundaries
 
 **For:** `architects`, `security` | **Updated:** 2026-03-10
+
+### 🔒 **Canonical** [Constitutional Genesis](/docs/genesis.md)
+
+Immutable substrate invariants, bootstrap sequence, and governance boundaries
+
+**For:** `developers`, `agents`, `stakeholders` | **Updated:** 2026-04-10
 
 ### 📋 **Draft** [ICN Kernel Contracts Specification](/docs/spec/KERNEL_CONTRACTS.md)
 
@@ -110,6 +212,18 @@ Specification of kernel contract primitives
 Design for evolving ICN commons governance and stewardship models over phases 0-3
 
 **For:** `architects`, `stakeholders` | **Updated:** 2026-03-15
+
+### 📋 **Draft** [ICN Prompt Library](/docs/design/ICN_PROMPT_LIBRARY.md)
+
+Tactical prompt library for doctrine-aligned image generation and visual exploration
+
+**For:** `architects`, `developers`, `designers` | **Updated:** 2026-04-22
+
+### 📋 **Draft** [ICN Visual System](/docs/design/ICN_VISUAL_SYSTEM.md)
+
+Stable visual doctrine for ICN across website, docs, product surfaces, onboarding, demo materials, and future institutional deployments
+
+**For:** `architects`, `developers`, `stakeholders` | **Updated:** 2026-04-22
 
 ### 📝 **Living** [Minimal Viable Coop Track](/docs/design/MINIMAL-VIABLE-COOP.md)
 
@@ -1048,7 +1162,7 @@ Master context and instructions for AI-assisted development on ICN
 
 Master navigation and directory of all documentation with cross-references
 
-**For:** `all` | **Updated:** 2026-03-15
+**For:** `all` | **Updated:** 2026-04-15
 
 ### 🔒 **Canonical** [Docs Directory README](/docs/README.md)
 
@@ -1230,6 +1344,24 @@ Approach for hosted cooperative pilot deployments
 
 **For:** `team` | **Updated:** 2026-03-10
 
+### 📝 **Living** [NYCN Boundary Brief](/docs/pilots/nycn-boundary-brief.md)
+
+Honest scope-of-now brief for NYCN organizers and ICN-side preparers: what ICN can demonstrate today, what it cannot honestly claim yet, what NYCN organizers would need to validate, and what is explicitly not being asked. Defers to STATE.md and PHASE_PROGRESS.md for current truth.
+
+**For:** `team`, `organizers` | **Updated:** 2026-04-29
+
+### 📝 **Living** [NYCN Demo Script](/docs/pilots/nycn-demo-script.md)
+
+Step-by-step organizer-facing demo flow against a localhost ICN gateway: action cards, proof loop, receipts, provenance, and explicit limit-naming. Not a pitch.
+
+**For:** `team` | **Updated:** 2026-04-29
+
+### 📝 **Living** [NYCN Organizer Asks](/docs/pilots/nycn-organizer-asks.md)
+
+Bounded set of questions to ask NYCN organizers — workflow validation, source/data validation, pilot-readiness — without assuming any partnership commitment. Includes explicit non-asks.
+
+**For:** `team`, `organizers` | **Updated:** 2026-04-29
+
 ### 📋 **Draft** [Agent Knowledge Architecture](/docs/planning/agent-knowledge-architecture.md)
 
 Design for AI agent knowledge bases and context management
@@ -1301,6 +1433,72 @@ Identity keystore backend configuration guide
 Trust score threshold configuration guide
 
 **For:** `operators` | **Updated:** 2026-03-10
+
+### 📝 **Living** [ICN Project Index](/docs/reference/project-index/README.md)
+
+Show-ready orientation layer — routes outside readers, contributors, and agents to the right canonical doc, source tree, or external URL. Defers to STATE.md and PHASE_PROGRESS.md for current truth.
+
+**For:** `all` | **Updated:** 2026-04-29
+
+### 📝 **Living** [CI / Ops / Deploy Map](/docs/reference/project-index/ci-ops-deploy-map.md)
+
+GitHub Actions workflows, deploy paths, K3s smoke runbooks, monitoring; routing layer to substantive runbooks under guides/operations/.
+
+**For:** `operators`, `contributors` | **Updated:** 2026-04-29
+
+### 📝 **Living** [Current Truth Map](/docs/reference/project-index/current-truth-map.md)
+
+One-screen routing for what is real now, what is not, what gates remain — pointing at STATE.md and PHASE_PROGRESS.md for the per-PR record.
+
+**For:** `all` | **Updated:** 2026-04-29
+
+### 📝 **Living** [Docs Control Map](/docs/reference/project-index/docs-control-map.md)
+
+How INDEX.md, registry.toml, DOCUMENT_REGISTRY.md, and doc_control_check.py relate; truth classes; how to add a doc.
+
+**For:** `contributors`, `agents` | **Updated:** 2026-04-29
+
+### 📝 **Living** [Full Repository Record Protocol](/docs/reference/project-index/full-repo-record.md)
+
+Protocol for recording every tracked file and directory across InterCooperative-Network/icn (and adjacent repos) as a mechanical record plus an interpretive atlas. Defines outputs, generator, classification vocabulary, and privacy boundary.
+
+**For:** `contributors`, `architects` | **Updated:** 2026-05-01
+
+### 📝 **Living** [Pilot and NYCN Map](/docs/reference/project-index/pilot-and-nycn-map.md)
+
+The ICN ↔ NYCN boundary — what lives in this repo, what lives in the separate InterCooperative-Network/nycn repo, the mutation boundary, and what the next gates are.
+
+**For:** `all` | **Updated:** 2026-04-29
+
+### 📋 **Draft** [ICN Repo Atlas](/docs/reference/project-index/repo-atlas.md)
+
+Draft interpretive atlas paired with the mechanical full-repo record. Names directory families, Rust-workspace families, and a classification vocabulary for stable atlas authoring across icn / nycn / icn-learn.
+
+**For:** `contributors`, `architects` | **Updated:** 2026-05-01
+
+### 📝 **Living** [Runtime Surface Map](/docs/reference/project-index/runtime-surface-map.md)
+
+Real runtime surfaces a member or app actually touches today (/me/standing, /me/action-cards, completion-receipt retrieval, governance primitives, identity/trust/ledger surfaces).
+
+**For:** `developers`, `architects` | **Updated:** 2026-04-29
+
+### 📝 **Living** [Rust Workspace Map](/docs/reference/project-index/rust-workspace-map.md)
+
+The icn/ Rust workspace grouped by rough layer (kernel, identity, networking, ledger, governance, etc.) plus app crates and binaries. Authority over kernel/app boundaries lives in KERNEL_APP_SEPARATION.md.
+
+**For:** `developers`, `contributors` | **Updated:** 2026-04-29
+
+### 📝 **Living** [Show-Readiness Map](/docs/reference/project-index/show-readiness-map.md)
+
+What can be shown now, what should not be shown as finished, suggested first-demo narrative, and red lines for outside-facing material.
+
+**For:** `all`, `team` | **Updated:** 2026-04-29
+
+### 📝 **Living** [Source Tree Map](/docs/reference/project-index/source-tree-map.md)
+
+Top-level repo surfaces and what each is for; monorepo root vs Rust workspace at icn/.
+
+**For:** `contributors`, `developers` | **Updated:** 2026-04-29
 
 ### 📝 **Living** [SDIS API Guide](/docs/sdis/SDIS_API_GUIDE.md)
 
@@ -1402,7 +1600,7 @@ Comprehensive threat model covering attack vectors, adversary capabilities, and 
 
 Living snapshot of repo layout, decisions, constraints, and current engineering status
 
-**For:** `developers`, `agents` | **Updated:** 2026-03-18
+**For:** `developers`, `agents` | **Updated:** 2026-05-02
 
 
 ## Strategy
@@ -1431,6 +1629,12 @@ Architectural Decision Record defining ICN scope, non-goals, and boundary condit
 
 **For:** `developers`, `architects`, `stakeholders` | **Updated:** 2026-02-28
 
+### 📝 **Living** [Cooperative-developer discovery brief](/docs/strategy/COOPERATIVE_DEVELOPER_DISCOVERY_BRIEF.md)
+
+Internal prep doc for discovery conversations with cooperative developers (e.g. launch.coop / comp.coop). Listening + language calibration; not a sales pitch, not a technical demo, not a partnership commitment.
+
+**For:** `internal`, `matt` | **Updated:** 2026-04-29
+
 ### 📝 **Living** [What ICN Is](/docs/strategy/ICN-Definition.md)
 
 Canonical definition: problem statement, solution approach, scope and non-goals
@@ -1457,9 +1661,9 @@ Elevator pitch, one-pagers, and public communication messaging framework
 
 ### 📝 **Living** [ICN Live Roadmap](/docs/strategy/ICN-Roadmap-Live.md)
 
-Current sprint and quarterly priorities, immediate milestones, and dependencies
+Long-arc roadmap and rationale companion that points at STATE.md / PHASE_PROGRESS.md as canonical current-state truth. Not a per-PR changelog.
 
-**For:** `team`, `stakeholders` | **Updated:** 2026-03-21
+**For:** `team`, `stakeholders` | **Updated:** 2026-04-29
 
 ### 📝 **Living** [ICN Roadmap Strategy](/docs/strategy/ICN-Roadmap-Strategy.md)
 
@@ -1484,6 +1688,18 @@ Specific sprint plan and tactical objectives for week of March 17, 2026
 Formal technical specification for grants, regulatory review, and architectural validation
 
 **For:** `grant-reviewers`, `architects`, `compliance` | **Updated:** 2026-03-15
+
+### 📋 **Draft** [Licensing strategy matrix (autonomy review)](/docs/strategy/LICENSING_STRATEGY_MATRIX.md)
+
+Planning artifact only. Component-by-component licensing/autonomy matrix and option families (permissive / AGPL / CAL / policy-layer / hybrid) for a future maintainer/legal review. Not legal advice; not a relicensing decision; no metadata changes.
+
+**For:** `maintainers`, `legal-review` | **Updated:** 2026-05-01
+
+### 📋 **Draft** [NYCN Phase 2 pilot rehearsal gate](/docs/strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md)
+
+Organizer-safe control-plane gate for moving from Phase 2 machinery exists to formal NYCN pilot rehearsal: organizer presentation, pilot formalization, first operator rehearsal. Descriptive planning only; not production readiness or Phase 2 completion.
+
+**For:** `maintainers`, `organizers`, `operators` | **Updated:** 2026-05-02
 
 ### 📋 **Draft** [ICN Compliance Architecture](/docs/strategy/grants/compliance-architecture.md)
 
@@ -1520,9 +1736,9 @@ Assessment of pilot readiness and gaps
 
 ## Summary
 
-**Total documents:** 246
+**Total documents:** 282
 
 **By status:**
-- Canonical: 38
-- Draft: 48
-- Living: 160
+- Canonical: 39
+- Draft: 57
+- Living: 186

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -424,6 +424,7 @@ Strategic direction and gap analysis (March 2026):
 - [NYCN-Repo-Architecture-Spec.md](strategy/NYCN-Repo-Architecture-Spec.md) - Repo-shaped architectural map grounded in current code: bounded domains, canonical objects, authority model, Program/cycle design (2026-04-14)
 - [NYCN-Implementation-Matrix.md](strategy/NYCN-Implementation-Matrix.md) - Execution ledger: per-object status (main/open_pr/branch_only/spec_only), touch points, bootstrap seed, ny-coop-net import crosswalk, phase-gated open questions (2026-04-14)
 - [NYCN-Execution-Tranches.md](strategy/NYCN-Execution-Tranches.md) - Merge-order + dependency plan across 7 tranches, rollback strategy, agent assignments (2026-04-14)
+- [NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md](strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md) - Organizer/operator gate before a formal NYCN Phase 2 pilot begins (2026-05-02)
 - [../institutions/nycn/README.md](../institutions/nycn/README.md) - NYCN institution package boundary, ownership rules, and package scaffold (2026-04-22)
 - [../institutions/nycn/docs/INDEX.md](../institutions/nycn/docs/INDEX.md) - NYCN package-local docs, bootstrap runbook, summit materials, and seed entrypoints (2026-04-22)
 

--- a/docs/PHASE_PROGRESS.md
+++ b/docs/PHASE_PROGRESS.md
@@ -1,24 +1,19 @@
 # ICN Phase Progress
 **Last Updated:** 2026-05-02
-**Current Phase:** Phase 2 — Pilot Launch. NYCN is the intended first cooperative partner (active partnership track, not yet a formally committed pilot); the next concrete step is presenting the merged drive-ingest ladder + ICN proof-loop machinery to NYCN organizers to formalize the pilot. Subsequent gates: partnership formalization, then first operator pilot rehearsal. Institutional-operability infrastructure, the action-card runtime, the action-item completion-receipt retrieval endpoint, and the NYCN drive-ingest operator ladder are all in place; all currently emitted source paths are proof-bearing both locally and on K3s. May-cycle repo-governance, licensing, RFC, repo-record, and service-hosting docs have landed, but they do not mark Phase 2 complete or imply production readiness, live federation integration, implemented service hosting, or resolved licensing.
+**Current Phase:** Phase 2 — Pilot Launch. NYCN is the intended first cooperative partner (active partnership track, not yet a formally committed pilot); the next concrete step is presenting the merged drive-ingest ladder + ICN proof-loop machinery to NYCN organizers. Subsequent gates: pilot formalization, then first operator rehearsal. The exact organizer/operator gate is defined in [NYCN Phase 2 Pilot Rehearsal Gate](strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md). Institutional-operability infrastructure, the action-card runtime, the action-item completion-receipt retrieval endpoint, and the NYCN drive-ingest operator ladder are all in place; all currently emitted source paths are proof-bearing both locally and on K3s. May-cycle repo-governance, licensing, RFC, repo-record, service-hosting, dependency/CI maintenance, bootstrap, and state-sync docs have landed, but they do not mark Phase 2 complete or imply production readiness, live federation integration, implemented service hosting, K3s/DNS/GitHub/Forgejo mutation, NYCN private-data handling, or resolved licensing.
 
-<!-- [sync edit] 2026-05-02 (post-#1686/#1688/#1690/#1691/#1693/#1694):
-     State extended after May-cycle repo-governance and strategy docs:
-     licensing metadata/open questions (#1686); RFC-0017 active for
-     Tool Install Infrastructure (#1688, not implemented); repo-record
-     protocol/generator (#1690); generated ICN repo-record snapshot
-     (#1691, mechanical inventory, not interpretive atlas);
-     licensing/autonomy strategy matrix (#1693, planning only, no
-     relicensing); sovereign service hosting stack (#1694, design
-     direction only, no Forgejo deploy, DNS mutation, K3s mutation,
-     hosted-service rollout, or GitHub cutover). Current open PR queue
-     includes Dependabot Actions major-version bumps #1695-#1698,
-     security dependency bump #1699, and draft agent-docs PR #1700.
-     Phase 2 remains in progress. NYCN remains intended first
-     cooperative partner, not a formally committed pilot. The next
-     concrete human gate remains presenting the merged ladder + ICN
-     proof-loop machinery to NYCN organizers, then formalization, then
-     first operator rehearsal. -->
+<!-- [sync edit] 2026-05-02 (post-#1695/#1696/#1697/#1698/#1699/#1700/#1701):
+     Follow-up May-cycle queue is now merged on main: Dependabot
+     Actions major-version bumps (#1695-#1698), wasmtime security bump
+     (#1699), unified dev-environment bootstrap (#1700), and prior state
+     sync (#1701). Open PR queue is empty at this sync. Phase 2 remains
+     in progress. NYCN remains intended first cooperative partner, not
+     a formally committed pilot. The exact next gate is defined in
+     docs/strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md: organizer
+     presentation -> pilot formalization -> first operator rehearsal.
+     This does not claim production readiness, live federation
+     integration, service hosting implementation, K3s/DNS/GitHub/Forgejo
+     mutation, NYCN private-data handling, or resolved licensing. -->
 
 <!-- [sync edit] 2026-04-29 (post-NYCN-#32, ICN PR queue clean):
      Truth-sync extension. NYCN drive-ingest work has continued
@@ -183,7 +178,7 @@
 ---
 
 ### Phase 2: Pilot Launch
-**Status:** ⏳ In progress (NYCN is the intended first cooperative partner — active partnership track, not yet a formally committed pilot; next concrete step is presenting the merged drive-ingest ladder + ICN proof-loop machinery to NYCN organizers to formalize the pilot)
+**Status:** ⏳ In progress (NYCN is the intended first cooperative partner — active partnership track, not yet a formally committed pilot; next concrete step is presenting the merged drive-ingest ladder + ICN proof-loop machinery to NYCN organizers; see [NYCN Phase 2 Pilot Rehearsal Gate](strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md))
 **Started:** —
 **Completed:** —
 **Sprint(s):** S19–S20
@@ -218,6 +213,8 @@
 - [x] Generated ICN repo-record snapshot added (#1691) — mechanical inventory snapshot, not an interpretive atlas.
 - [x] Licensing/autonomy strategy matrix added (#1693) — planning only; no relicensing.
 - [x] Sovereign service hosting stack documented (#1694) — design direction only; no Forgejo deployment, DNS mutation, K3s mutation, hosted-service rollout, or GitHub cutover.
+- [x] May-cycle follow-up queue merged (#1695–#1701) — CI action bumps, wasmtime security bump, unified bootstrap setup, and prior state sync; no Phase 2 completion claim.
+- [x] NYCN Phase 2 pilot rehearsal gate defined (`docs/strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md`) — organizer presentation -> pilot formalization -> first operator rehearsal.
 - [ ] NYCN steward-facing communication-groups directory tool (NYCN #33) — open at last sync; verify status before reading.
 - [ ] Action-card runtime — remaining gates under #1646 (RFC-gated): `signal_rule` source path (gated on #1631); `obligation_lifecycle` source path (gated on #1634)
 - [ ] One-command deployment script per cooperative
@@ -231,11 +228,11 @@
 - ~~Requires Phase 1 complete~~ ✅ Charter Engine is live
 - ~~Requires bootstrap activation runtime~~ ✅ live charter activation + person-directory + standing read model landed 2026-04-22 → 2026-04-26
 - ~~Requires cooperative partners identified~~ ✅ NYCN is the intended first cooperative partner (active partnership track)
-- Next concrete step: present the merged drive-ingest ladder + ICN proof-loop machinery to NYCN organizers to formalize the pilot
-- Subsequent gate: partnership formalization, then first operator pilot rehearsal against real (or fixture-equivalent) organizer material
+- Next concrete step: present the merged drive-ingest ladder + ICN proof-loop machinery to NYCN organizers, as defined in [NYCN Phase 2 Pilot Rehearsal Gate](strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md)
+- Subsequent gates: pilot formalization, then first operator rehearsal against real (or fixture-equivalent) organizer material
 
 **Decisions Made:**
-- (2026-05-02, post-#1686/#1688/#1690/#1691/#1693/#1694) May-cycle repo-governance and strategy docs updated licensing metadata/open questions, RFC-0017 status, repo-record generation, the generated repo-record snapshot, licensing/autonomy planning, and sovereign service hosting design. These are truth/control-plane and planning landings only. They do not complete Phase 2, formally commit NYCN as a pilot, claim production readiness, claim live federation integration, deploy service hosting, mutate DNS/K3s/GitHub state, implement RFC-0017, or resolve licensing. The next concrete human gate remains presenting the merged ladder + ICN proof-loop machinery to NYCN organizers, then formalization, then first operator rehearsal. Current open PR queue: #1695-#1698 Dependabot Actions major-version bumps, #1699 wasmtime security bump, and draft #1700 agent-docs update.
+- (2026-05-02, post-#1695/#1696/#1697/#1698/#1699/#1700/#1701) May-cycle repo-governance, strategy, dependency/CI maintenance, bootstrap, and state-sync work has merged through #1701. These are truth/control-plane, planning, or maintenance landings only. They do not complete Phase 2, formally commit NYCN as a pilot, claim production readiness, claim live federation integration, implement service hosting, mutate DNS/K3s/GitHub/Forgejo state, implement RFC-0017, handle NYCN private data, or resolve licensing. The next concrete human gate is now explicitly documented in `docs/strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md`: organizer presentation, pilot formalization, then first operator rehearsal. Open PR queue was empty at this sync.
 - (2026-04-29, post-#1675/#1677, post-NYCN-#28) The Phase 2 *machinery* is now in place end-to-end: (a) action-card runtime is proof-bearing for all currently emitted source paths, (b) the completion-receipt retrieval endpoint exists so a holder shell can read receipts over HTTP, (c) the local HTTP proof loop is closed and documented, (d) the K3s smoke proof loop is closed against deployed image `91a63eec` and documented, and (e) the NYCN drive-ingest operator ladder is merged end-to-end as a procedural spine. NYCN is the intended first cooperative partner (active partnership track); the next concrete step is **presenting the merged ladder + ICN proof-loop machinery to NYCN organizers** to formalize the pilot. Phase 2 remains ⏳ until that presentation, the partnership formalization that follows, and the first operator pilot rehearsal happen and are recorded. The two RFC-gated action-card source paths (`signal_rule`, `obligation_lifecycle`) remain open under #1646 and are independent of the partner gate.
 - (2026-04-27, post-#1663) Action-card runtime is now proof-bearing for **all three currently emitted source paths**: `proposal`/`vote` (#1660), `action_item`/`complete` (#1661), and `meeting`/`attend` (#1663). Issue #1646 remains open for the two RFC-gated paths: `signal_rule` (#1631) and `obligation_lifecycle` (#1634). Phase 2 status is unaffected (still partner-bound).
 - (2026-04-27) Action-card runtime is partial: `/me/action-cards` exists, `proposal`/`vote` and `action_item`/`complete` source paths have verified end-to-end receipt proof loops, and `meeting`/`attend`, `signal_rule`, `obligation_lifecycle` paths remain pending under #1646. Phase 2 status is unaffected.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -6,25 +6,19 @@ Last Reviewed: 2026-05-02
 
 # ICN State (living doc)
 
-<!-- [sync edit] 2026-05-02 (post-#1686/#1688/#1690/#1691/#1693/#1694):
-     May-cycle repo-governance and strategy docs landed after the
-     2026-04-29 snapshot: licensing metadata/open questions (#1686);
-     RFC-0017 moved to active for Tool Install Infrastructure (#1688,
-     active only, not implemented); repo-record protocol/generator
-     (#1690); generated ICN repo-record snapshot (#1691, mechanical
-     inventory, not an interpretive atlas); licensing/autonomy strategy
-     matrix (#1693, planning only, no relicensing); sovereign service
-     hosting stack (#1694, design direction only, no Forgejo deploy,
-     DNS mutation, K3s mutation, or GitHub cutover). Current open PR
-     queue includes Dependabot Actions major-version bumps #1695-#1698,
-     security dependency bump #1699, and draft agent-docs PR #1700.
-     Phase 2 remains in progress. NYCN remains the intended first
-     cooperative partner, not a formally committed pilot. The next
-     concrete human gate remains presenting the merged ladder + ICN
-     proof-loop machinery to NYCN organizers, then formalization, then
-     first operator rehearsal. Do not read this sync as production
-     readiness, live federation integration, implemented service
-     hosting, or resolved licensing. -->
+<!-- [sync edit] 2026-05-02 (post-#1695/#1696/#1697/#1698/#1699/#1700/#1701):
+     Follow-up May-cycle queue is now merged on main: Dependabot
+     Actions major-version bumps (#1695-#1698), wasmtime security bump
+     (#1699), unified dev-environment bootstrap (#1700), and the prior
+     state sync (#1701). Open PR queue is empty at this sync. Phase 2
+     remains in progress. NYCN remains the intended first cooperative
+     partner, not a formally committed pilot. The exact next gate is
+     defined in docs/strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md:
+     organizer presentation -> pilot formalization -> first operator
+     rehearsal. Do not read this sync as production readiness, live
+     federation integration, implemented service hosting, K3s/DNS/
+     GitHub/Forgejo mutation, NYCN private-data handling, or resolved
+     licensing. -->
 
 <!-- [sync edit] 2026-04-29 (post-NYCN-#32, ICN PR queue clean):
      NYCN drive-ingest work has continued past the operator
@@ -99,13 +93,20 @@ Last Reviewed: 2026-05-02
 
 ## Current status (2026-05-02 snapshot)
 
-**Current phase:** Phase 2 — Pilot Launch. NYCN is the intended first cooperative partner (active partnership track, not yet a formally committed pilot). The next concrete step is presenting the merged drive-ingest ladder + ICN proof-loop machinery to NYCN organizers to formalize the pilot. Subsequent gates: partnership formalization, then first operator pilot rehearsal against real (or fixture-equivalent) organizer material. The Phase 2 *machinery* is in place end-to-end; what remains is the human procedure — pitch, formalize, rehearse — and recording each step.
-Active execution: institutional-operability runtime (live charter activation, person-directory overlay, `/me/standing`, `authority_scope` plumbing) plus the action-card runtime (`/me/action-cards` endpoint with proof-loop linkage to `GovernanceDecisionReceipt` for proposal/vote, `ActionItemCompletionReceipt` for action_item/complete, and `MeetingAttendanceReceipt` for meeting/attend). The action-item completion-receipt retrieval endpoint shipped as #1675; the local HTTP proof loop closure is documented in #1676 and the K3s smoke proof closure is recorded in #1677. NYCN's drive-ingest operator ladder (NYCN #21–#28 in `fahertym/nycn`) is merged end-to-end, with subsequent NYCN #29–#32 also merged: organizer briefing + summit demo, start-here onboarding pass, one-command local preflight runner, and whole-NYCN operating-surfaces inventory plus Google-Groups boundary policy. NYCN #33 (steward-facing communication-groups directory tool) was open at the prior sync and may have merged since. Since then, ICN also merged repo-governance and strategy documentation for licensing metadata, RFC-0017 activation, repo-record generation, a generated repo-record snapshot, licensing/autonomy planning, and sovereign service hosting design. Those are documentation/control-plane landings only: RFC-0017 is not implemented, service hosting is not deployed, DNS/K3s/GitHub state was not mutated, and licensing is not resolved. Phase model classification is unchanged; see PHASE_PROGRESS.md for phase definitions.
+**Current phase:** Phase 2 — Pilot Launch. NYCN is the intended first cooperative partner (active partnership track, not yet a formally committed pilot). The next concrete step is presenting the merged drive-ingest ladder + ICN proof-loop machinery to NYCN organizers. Subsequent gates are pilot formalization, then first operator rehearsal against real (or fixture-equivalent) organizer material. The exact gate is defined in [NYCN Phase 2 Pilot Rehearsal Gate](strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md). The Phase 2 *machinery* is in place end-to-end; what remains is the human procedure — present, formalize, rehearse — and recording each step.
+Active execution: institutional-operability runtime (live charter activation, person-directory overlay, `/me/standing`, `authority_scope` plumbing) plus the action-card runtime (`/me/action-cards` endpoint with proof-loop linkage to `GovernanceDecisionReceipt` for proposal/vote, `ActionItemCompletionReceipt` for action_item/complete, and `MeetingAttendanceReceipt` for meeting/attend). The action-item completion-receipt retrieval endpoint shipped as #1675; the local HTTP proof loop closure is documented in #1676 and the K3s smoke proof closure is recorded in #1677. NYCN's drive-ingest operator ladder (NYCN #21–#28 in `fahertym/nycn`) is merged end-to-end, with subsequent NYCN #29–#32 also merged: organizer briefing + summit demo, start-here onboarding pass, one-command local preflight runner, and whole-NYCN operating-surfaces inventory plus Google-Groups boundary policy. NYCN #33 (steward-facing communication-groups directory tool) was open at the prior sync and may have merged since. Since then, ICN also merged repo-governance and strategy documentation for licensing metadata, RFC-0017 activation, repo-record generation, a generated repo-record snapshot, licensing/autonomy planning, and sovereign service hosting design, followed by CI/dependency maintenance, unified bootstrap docs, and the prior state sync. Those are documentation/control-plane or maintenance landings only: RFC-0017 is not implemented, service hosting is not deployed, DNS/K3s/GitHub/Forgejo state was not mutated, NYCN private data was not handled, and licensing is not resolved. Phase model classification is unchanged; see PHASE_PROGRESS.md for phase definitions.
 
 ### Recently merged (since 2026-04-15)
 
 | PR | Title | Merged |
 |----|-------|--------|
+| #1701 | docs(state): sync May-cycle project truth | 2026-05-02 |
+| #1700 | chore: unify dev environment setup into scripts/bootstrap.sh | 2026-05-02 |
+| #1699 | fix(compute): bump wasmtime for RUSTSEC-2026-0114 | 2026-05-02 |
+| #1698 | ci: bump actions/setup-node from 4 to 6 | 2026-05-02 |
+| #1697 | ci: bump actions/checkout from 4 to 6 | 2026-05-02 |
+| #1696 | ci: bump actions/github-script from 8 to 9 | 2026-05-02 |
+| #1695 | ci: bump softprops/action-gh-release from 2 to 3 | 2026-05-02 |
 | #1694 | docs(architecture): add sovereign service hosting stack | 2026-05-02 |
 | #1693 | docs(licensing): add autonomy-focused strategy matrix | 2026-05-02 |
 | #1691 | docs(project-index): add generated repo record snapshot | 2026-05-01 |
@@ -166,14 +167,7 @@ Active execution: institutional-operability runtime (live charter activation, pe
 
 ### Open PRs
 
-| PR | Title | Status |
-|----|-------|--------|
-| #1700 | docs(agents): add Cursor Cloud specific instructions to AGENTS.md | Draft |
-| #1699 | fix(compute): bump wasmtime for RUSTSEC-2026-0114 | Open; local validation clean; benchmark gate classified as unrelated/noisy |
-| #1698 | ci: bump actions/setup-node from 4 to 6 | Open Dependabot major-version bump |
-| #1697 | ci: bump actions/checkout from 4 to 6 | Open Dependabot major-version bump |
-| #1696 | ci: bump actions/github-script from 8 to 9 | Open Dependabot major-version bump |
-| #1695 | ci: bump softprops/action-gh-release from 2 to 3 | Open Dependabot major-version bump |
+No open PRs at this sync.
 
 ### What landed since Phase 1 (Charter Engine)
 
@@ -184,6 +178,8 @@ May-cycle repo governance and strategy documentation (added 2026-05-01 → 2026-
 - Generated ICN repo-record snapshot added — #1691. This is a mechanical inventory snapshot, not an interpretive atlas.
 - Licensing/autonomy strategy matrix added — #1693. Planning only; no relicensing happened.
 - Sovereign service hosting stack added — #1694. Design direction only; no Forgejo deployment, DNS mutation, K3s mutation, hosted-service rollout, or GitHub cutover happened.
+- Follow-up maintenance/state queue merged — #1695-#1701. This includes CI action bumps, a wasmtime security bump, unified bootstrap setup, and a prior state sync; none of these changes starts a NYCN pilot or completes Phase 2.
+- NYCN organizer/operator rehearsal gate defined — [docs/strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md](strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md). The gate remains organizer presentation -> pilot formalization -> first operator rehearsal.
 
 Action-card runtime (added 2026-04-27 → 2026-04-29, all currently emitted source paths now proof-bearing — issue #1646 remains open for the two RFC-gated paths):
 - `GET /v1/gov/me/action-cards` member endpoint with closed source/action enums — #1659
@@ -287,6 +283,7 @@ Infrastructure:
 - docs/architecture/KERNEL_APP_SEPARATION.md — kernel/app boundary
 - docs/strategy/NYCN-Repo-Architecture-Spec.md — NYCN institutional architecture
 - docs/strategy/NYCN-Execution-Tranches.md — NYCN 7-tranche execution plan
+- docs/strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md — exact Phase 2 organizer/operator gate before a formal NYCN pilot begins
 - docs/dev/handoff-2026-04-15.md — latest session handoff
 - deploy/README.md — deployment options
 

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -1315,6 +1315,22 @@ domain_tags = ["strategy", "partner-discovery"]
 recommended_action = "keep"
 last_reviewed = "2026-04-29"
 
+[docs."docs/strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md"]
+category = "strategy"
+status = "draft"
+title = "NYCN Phase 2 pilot rehearsal gate"
+description = "Organizer-safe control-plane gate for moving from Phase 2 machinery exists to formal NYCN pilot rehearsal: organizer presentation, pilot formalization, first operator rehearsal. Descriptive planning only; not production readiness or Phase 2 completion."
+last_updated = "2026-05-02"
+owner = "matt"
+audiences = ["maintainers", "organizers", "operators"]
+truth_class = "descriptive"
+role = "strategy"
+canonical = "no"
+freshness = "current"
+domain_tags = ["strategy", "nycn", "pilot", "phase-2"]
+recommended_action = "keep"
+last_reviewed = "2026-05-02"
+
 [docs."docs/strategy/LICENSING_STRATEGY_MATRIX.md"]
 category = "strategy"
 status = "draft"

--- a/docs/strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md
+++ b/docs/strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md
@@ -1,0 +1,87 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-05-02
+---
+
+# NYCN Phase 2 Pilot Rehearsal Gate
+
+This document defines the human and operational gate required to move from
+"Phase 2 machinery exists" to "NYCN pilot formally begins."
+
+It is organizer-safe control-plane guidance. It does not advance Phase 2,
+declare production readiness, or authorize live infrastructure mutation.
+
+## Current State
+
+- ICN action-card and proof-loop machinery exists for currently emitted paths.
+- The NYCN drive-ingest ladder exists as a local, file-based, reviewable workflow.
+- NYCN is the intended first cooperative partner.
+- No formal NYCN pilot has started yet.
+
+## Gate 1: Organizer Presentation
+
+Required inputs:
+
+- Drive-ingest `START_HERE`, organizer briefing, and simple summit demo.
+- Plain-language explanation of the ICN proof loop: organizer material becomes
+  reviewable action items, operator decisions produce receipts, and provenance
+  artifacts can be inspected without treating the rehearsal as live practice.
+- Privacy and mutation boundaries, including no automatic Google Drive or
+  Google Groups synchronization, no K3s mutation, and no NYCN private data in
+  the public ICN repository.
+- A clear statement of what organizers are being asked to decide.
+
+Required organizer decision:
+
+- Whether NYCN wants to proceed to a first operator rehearsal.
+- Who acts as steward/operator.
+- What real or fixture-equivalent material is safe to use.
+- What success and failure mean for the rehearsal.
+
+## Gate 2: Pilot Formalization
+
+A formalized pilot means these are recorded before rehearsal work begins:
+
+- The named body or organizers approving the rehearsal.
+- The named steward/operator.
+- The chosen rehearsal material.
+- The written privacy boundary.
+- The written success criteria.
+- An explicit statement that this remains a rehearsal unless separately approved
+  as live operating practice.
+
+## Gate 3: First Operator Rehearsal
+
+Expected outputs:
+
+- Action-item review artifact.
+- Organizer-authored decisions file.
+- Publish dry-run.
+- Assignee binding.
+- Local publish plan.
+- Local proof artifact.
+- Federation-surface summary.
+- Short rehearsal report.
+
+## Non-Claims
+
+This gate is not:
+
+- Production readiness.
+- Live federation integration.
+- Replacement of existing NYCN organizing practice.
+- Automatic Google Drive or Google Groups synchronization.
+- A general-purpose pilot for 3-5 cooperatives.
+- Phase 2 completion by itself unless `docs/STATE.md` and
+  `docs/PHASE_PROGRESS.md` record the gate as met with evidence.
+
+## Definition of Done
+
+The gate is complete only when:
+
+- Organizer presentation happened and is recorded.
+- Formal pilot/rehearsal approval is recorded.
+- Operator rehearsal ran against approved material.
+- Outputs are committed or summarized in repo-safe form.
+- `docs/STATE.md` and `docs/PHASE_PROGRESS.md` are updated with the evidence path.


### PR DESCRIPTION
## Summary

Truth-syncs Phase 2 after the latest May-cycle merges and defines the exact organizer/operator gate before any formal NYCN pilot begins.

## What changed

- Updated `docs/STATE.md` and `docs/PHASE_PROGRESS.md` to record that #1695, #1696, #1697, #1698, #1699, #1700, and #1701 are merged.
- Added `docs/strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md` defining the sequence: organizer presentation -> pilot formalization -> first operator rehearsal.
- Linked and registered the new gate doc through `docs/INDEX.md`, `docs/registry.toml`, and regenerated `docs/INDEX.generated.md`.

## What did not change

- Phase 2 remains in progress.
- NYCN remains the intended first cooperative partner, not a formally committed pilot.
- Service hosting remains documented as design direction only.
- The next concrete gate remains human/operational evidence: presentation, approval, rehearsal, and repo-safe evidence path.

## Validation

- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml --strict` passed with existing non-blocking registry/YAML warnings.
- `python3 .github/scripts/compliance_linter.py` passed.
- `python3 docs/scripts/generate-index.py --registry docs/registry.toml > /tmp/icn-index.generated.new && diff -q docs/INDEX.generated.md /tmp/icn-index.generated.new` passed.
- `git diff --check` passed.

## Explicit non-claims

- no runtime code
- no production readiness claim
- no live federation integration
- no K3s/DNS/GitHub/Forgejo mutation
- no NYCN private data
- no licensing decision

Made with [Cursor](https://cursor.com)