### PR TITLE
fix(ops-mcp): unify MCP stdio launch and harden cluster polling

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,10 +1,8 @@
 {
   "mcpServers": {
     "icn-ops": {
-      "command": "node",
-      "args": [
-        "./ops/mcp/dist/index.js"
-      ]
+      "command": "npm",
+      "args": ["--prefix", "./ops/mcp", "run", "start:stdio"]
     }
   }
 }

--- a/docs/guides/developer/cursor-mcp-setup.md
+++ b/docs/guides/developer/cursor-mcp-setup.md
@@ -2,7 +2,7 @@
 
 This repo ships a local `icn-ops` MCP server in `ops/mcp`.
 
-Both Claude Code and Cursor should launch that server from the current checkout, not from a developer-specific absolute path. The project configs therefore use repo-relative paths / commands so the same checkout works on any contributor machine.
+**Clients:** Cursor (`.cursor/mcp.json`), Claude Code and other tools that honor the repo-root `.mcp.json`, and any generic MCP host that can run a `command` + `args` from the workspace root should all launch the server the same way. Paths are repo-relative so a clone works on any machine; each host still uses **its own** `npm`/`node` from PATH, so keep Node majors aligned between “where you ran `npm ci`” and “where the MCP host spawns processes” (see Node ABI note below).
 
 ## Config Surfaces
 
@@ -15,7 +15,7 @@ Both Claude Code and Cursor should launch that server from the current checkout,
   - This file is not the place to register MCP servers.
 - `./.cursor/mcp.json`
   - Project-local Cursor MCP registration for the currently opened workspace.
-  - This is the correct place to wire Cursor to the repo-local `icn-ops` server.
+  - Uses the **same** `icn-ops` launch stanza as `./.mcp.json` (portability script enforces this).
 - `~/.mcp.json`
   - User-level Claude MCP config.
   - Use this only for personal/global servers you want in every workspace.
@@ -47,18 +47,24 @@ cd ops/mcp
 npm run build
 ```
 
-Claude's `./.mcp.json` uses `npm --prefix ./ops/mcp run start:stdio`, which runs the build before starting the server. Cursor currently points at the built runtime entrypoint directly, so Cursor users should ensure the build exists before reloading the Cursor MCP config.
+Both `./.mcp.json` and `./.cursor/mcp.json` use `npm --prefix ./ops/mcp run start:stdio`, which runs `tsc` then `node dist/index.js` under **one** `node` resolved for that `npm` invocation. After `npm ci` / `npm install`, `postinstall` runs `npm rebuild better-sqlite3` so native bindings match **that** Node.
+
+**Node ABI:** `better-sqlite3` is native. If you install dependencies with Node 22 but the MCP host starts the server with Node 20 (or the reverse), the addon fails to load until you run `npm ci` or `npm rebuild better-sqlite3` using the same Node the host will use. The unified `npm … start:stdio` entrypoint does not remove that OS-level constraint; it only ensures `tsc` and `node dist/index.js` agree within a single spawn.
+
+**DevDependency noise:** Vitest pulls Vite 7, which may print `EBADENGINE` on Node versions older than **20.19**; that warning is about the test runner stack, not the MCP runtime. Use Node **20.19+** or **22.12+** if you want a clean `npm ci` with no engine warnings.
 
 ## Validate The Runtime
 
-You can verify the server manually from the repo root:
+From the **repo root**, confirm dependencies install, TypeScript builds, and the stdio server stays up briefly without exiting (same path MCP clients use):
 
 ```bash
-printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"icn-mcp-check","version":"1.0"}}}' \
-  | node ./ops/mcp/dist/index.js
+npm --prefix ./ops/mcp ci
+npm --prefix ./ops/mcp run build
+python3 scripts/check-mcp-portability.py
+timeout 5 npm --prefix ./ops/mcp run start:stdio
 ```
 
-Expected result: a JSON-RPC response containing `"serverInfo":{"name":"icn-ops","version":"0.1.0"}`.
+Smoke test: you should **not** see a Node stack trace right after `node dist/index.js` starts. With GNU **coreutils** `timeout`, exit status **124** means the timer fired while the server was still running (expected). If the server exits immediately, investigate stderr (common causes: missing `ops/mcp` deps, Node/native ABI mismatch, or DB path issues). On macOS, use `gtimeout` from Homebrew **coreutils** if `timeout` is missing. After `npm ci`, run `npm test` inside `ops/mcp` when changing server code.
 
 ## Claude Workflow
 
@@ -76,15 +82,15 @@ Expected result: a JSON-RPC response containing `"serverInfo":{"name":"icn-ops",
 ## Cursor Workflow
 
 1. Open the repo root in Cursor. Any local checkout path works.
-2. Ensure `ops/mcp/dist/index.js` exists. If not, build it.
+2. Run `cd ops/mcp && npm ci` once per checkout (or after changing Node major versions).
 3. Reload the Cursor window so it re-reads `.cursor/mcp.json`.
 4. Confirm the `icn-ops` server appears in Cursor's MCP UI/tools list.
 
-## Claude / Cursor Coexistence
+## Claude / Cursor / other MCP hosts
 
-- Claude-side repo MCP wiring lives in `./.mcp.json`.
-- Claude lifecycle and hook configuration stays in `./.claude/settings.json`.
-- Cursor-side worktree MCP wiring is isolated in `./.cursor/mcp.json`.
-- User-global MCP files should remain for personal/global tools only.
+- Repo-local MCP wiring for Claude-compatible hosts: `./.mcp.json` (same `icn-ops` stanza as Cursor).
+- Claude lifecycle and hooks: `./.claude/settings.json` (not used for MCP server registration in this repo).
+- Cursor project MCP: `./.cursor/mcp.json` (must stay identical to `./.mcp.json` for `icn-ops`; enforced by `scripts/check-mcp-portability.py`).
+- User-global `~/.mcp.json` / `~/.cursor/mcp.json`: optional; do not duplicate `icn-ops` there unless you intentionally want a second registration.
 
 This keeps contributor setup portable and prevents one developer's machine path from becoming everyone else's broken default.

--- a/ops/mcp/package.json
+++ b/ops/mcp/package.json
@@ -4,11 +4,15 @@
   "description": "ICN orchestration plane MCP server — live state coordination for Claude Code sessions",
   "type": "module",
   "main": "dist/index.js",
+  "engines": {
+    "node": ">=20.10.0"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "start:stdio": "npm run --silent build && node dist/index.js",
+    "postinstall": "npm rebuild better-sqlite3",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"

--- a/ops/mcp/src/polling/cluster.ts
+++ b/ops/mcp/src/polling/cluster.ts
@@ -21,6 +21,25 @@ function writeCache(db: Database.Database, key: string, value: unknown): void {
   ).run(key, JSON.stringify(value));
 }
 
+function parsePodsJson(cmd: { ok: boolean; output: string }): unknown {
+  if (!cmd.ok) {
+    return { error: cmd.output };
+  }
+  const text = cmd.output;
+  if (!text) {
+    return { error: "empty kubectl/jq output (no cluster access or jq failed silently)" };
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch (e) {
+    return {
+      error: "kubectl/jq output was not valid JSON",
+      detail: e instanceof Error ? e.message : String(e),
+      preview: text.slice(0, 400),
+    };
+  }
+}
+
 const SERVICE_ENDPOINTS = [
   { name: "ICN Gateway", url: "http://10.8.30.40:30080/v1/health" },
   { name: "Pilot UI", url: "http://10.8.30.40:30030" },
@@ -30,27 +49,37 @@ const SERVICE_ENDPOINTS = [
 ];
 
 function pollOnce(db: Database.Database): void {
-  // Pod status
-  const pods = runCmd(
-    "kubectl get pods --all-namespaces -o json 2>/dev/null | " +
-    "jq '[.items[] | {name: .metadata.name, namespace: .metadata.namespace, phase: .status.phase, ready: (.status.conditions // [] | map(select(.type == \"Ready\")) | first | .status // \"Unknown\")}]'"
-  );
-  const services: Record<string, boolean> = {};
-  for (const ep of SERVICE_ENDPOINTS) {
-    services[ep.name] = runCmd(`curl -sf --max-time 3 ${ep.url}`).ok;
-  }
-  writeCache(db, "k3s:pods", {
-    pods: pods.ok ? JSON.parse(pods.output) : { error: pods.output },
-    services,
-  });
+  try {
+    // Pod status
+    const pods = runCmd(
+      "kubectl get pods --all-namespaces -o json 2>/dev/null | " +
+        "jq '[.items[] | {name: .metadata.name, namespace: .metadata.namespace, phase: .status.phase, ready: (.status.conditions // [] | map(select(.type == \"Ready\")) | first | .status // \"Unknown\")}]'"
+    );
+    const services: Record<string, boolean> = {};
+    for (const ep of SERVICE_ENDPOINTS) {
+      services[ep.name] = runCmd(`curl -sf --max-time 3 ${ep.url}`).ok;
+    }
+    writeCache(db, "k3s:pods", {
+      pods: parsePodsJson(pods),
+      services,
+    });
 
-  // Service endpoint reachability
-  const reachability = SERVICE_ENDPOINTS.map((e) => ({
-    name: e.name,
-    url: e.url,
-    reachable: runCmd(`curl -sf --max-time 3 ${e.url}`).ok,
-  }));
-  writeCache(db, "k3s:endpoints", reachability);
+    // Service endpoint reachability
+    const reachability = SERVICE_ENDPOINTS.map((e) => ({
+      name: e.name,
+      url: e.url,
+      reachable: runCmd(`curl -sf --max-time 3 ${e.url}`).ok,
+    }));
+    writeCache(db, "k3s:endpoints", reachability);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("cluster poll failed:", message);
+    try {
+      writeCache(db, "k3s:pods", { error: message, services: {} });
+    } catch {
+      // ignore secondary failures
+    }
+  }
 }
 
 export function startClusterPolling(db: Database.Database): NodeJS.Timeout {

--- a/scripts/check-mcp-portability.py
+++ b/scripts/check-mcp-portability.py
@@ -21,6 +21,11 @@ CONFIGS = [
     ROOT / ".cursor" / "mcp.json",
 ]
 
+# Every MCP-capable client must start icn-ops the same way so `tsc` + `node`
+# run under one Node, and postinstall keeps better-sqlite3 aligned with that Node.
+ICN_OPS_COMMAND = "npm"
+ICN_OPS_ARGS = ["--prefix", "./ops/mcp", "run", "start:stdio"]
+
 FORBIDDEN_PATTERNS = [
     re.compile(r"/home/[^\s\"']+"),
     re.compile(r"/Users/[^\s\"']+"),
@@ -73,17 +78,15 @@ def main() -> None:
         data = load_json(path)
         server = assert_mcp_shape(path, data)
 
-        rel = path.relative_to(ROOT).as_posix()
-        if rel == ".mcp.json":
-            expected_args = ["--prefix", "./ops/mcp", "run", "start:stdio"]
-            if server.get("command") != "npm":
-                fail(".mcp.json must launch icn-ops through npm, not an absolute node path")
-            if server.get("args") != expected_args:
-                fail(f".mcp.json args must be {expected_args!r}")
-        elif rel == ".cursor/mcp.json":
-            args = server.get("args")
-            if not isinstance(args, list) or "./ops/mcp/dist/index.js" not in args:
-                fail(".cursor/mcp.json must use the repo-relative ./ops/mcp/dist/index.js")
+        if server.get("command") != ICN_OPS_COMMAND:
+            fail(
+                f"{path.relative_to(ROOT)} must launch icn-ops with command {ICN_OPS_COMMAND!r}"
+            )
+        if server.get("args") != ICN_OPS_ARGS:
+            fail(
+                f"{path.relative_to(ROOT)} icn-ops args must be {ICN_OPS_ARGS!r} "
+                "(keep .mcp.json and .cursor/mcp.json identical for all MCP clients)"
+            )
 
     print("MCP portability check passed")
 


### PR DESCRIPTION
## Summary
- **Root cause (Cursor failure):** `better-sqlite3` in `ops/mcp/node_modules` was built for one Node major (e.g. 22 / ABI 127) while Cursor spawned MCP with another (e.g. 20 / ABI 115), so the native addon failed to load before any MCP handshake.
- **Unified launch path:** `.cursor/mcp.json` now matches `.mcp.json`: `npm --prefix ./ops/mcp run start:stdio` so `tsc` and `node dist/index.js` run under the same `npm`/`node` for that invocation.
- **Install-time alignment:** `ops/mcp/package.json` adds `engines.node` (`>=20.10.0`) and `postinstall` runs `npm rebuild better-sqlite3` after `npm ci` / `npm install` so bindings match the Node that performed the install.
- **Portability guard:** `scripts/check-mcp-portability.py` requires the **same** `icn-ops` `command` + `args` in both `.mcp.json` and `.cursor/mcp.json` so clients cannot drift again.
- **Cluster polling:** Empty or invalid kubectl/jq JSON no longer crashes the server; failures are written to `health_cache` (and outer `try/catch` logs) instead of killing stdio.

## Test plan (local)
```bash
cd /path/to/icn
npm --prefix ./ops/mcp ci
npm --prefix ./ops/mcp run build
npm --prefix ./ops/mcp test
python3 scripts/check-mcp-portability.py
timeout 5 npm --prefix ./ops/mcp run start:stdio
```
- Expect **no** Node stack trace immediately after startup.
- GNU `timeout`: exit **124** means the server was still running when the timer fired (good smoke).

## Risk
- `postinstall` adds a short `npm rebuild better-sqlite3` on every install (CI included); should stay within seconds on `ubuntu-latest` with cached toolchain.

## Docs
- `docs/guides/developer/cursor-mcp-setup.md` updated for Cursor, Claude Code, generic MCP hosts, Node ABI note, and validation commands.

Made with [Cursor](https://cursor.com)